### PR TITLE
ci(lint): clippy hard-gate (-D warnings) + zero existing warnings; pin rustfmt.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
 name: CI
 
 # Correctness gate (roadmap G1). Build + test the whole workspace on every push to main and every
-# PR — the regression safety net the "no regressions in functionality" constraint requires. fmt +
-# clippy run informationally for now (the codebase predates a rustfmt.toml; tightened in a later
-# pass). Heavy benchmarks live in bench.yml / bench-ec2.yml, NOT here.
+# PR — the regression safety net the "no regressions in functionality" constraint requires.
+# clippy now GATES with -D warnings (the workspace is warning-clean). rustfmt runs informationally
+# until the one-time `cargo fmt --all` reformat lands (deferred behind the in-flight branches —
+# see rustfmt.toml); flip it to a hard gate once that reformat merges. Heavy benchmarks live in
+# bench.yml / bench-ec2.yml, NOT here.
 on:
   push:
     branches: [main]
@@ -48,7 +50,7 @@ jobs:
         run: cargo build -p sparq-wasm --target wasm32-unknown-unknown
 
   lint:
-    name: fmt + clippy (informational)
+    name: clippy (gate) + fmt (informational)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,11 +58,13 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      - name: rustfmt
+      # GATES: the whole workspace (sparq-py included) is clippy-clean under -D warnings.
+      # A new warning — from new code or a Rust-stable bump that adds a lint — fails CI.
+      - name: clippy (deny warnings)
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      # Informational until the deferred `cargo fmt --all` reformat lands (see rustfmt.toml).
+      - name: rustfmt (informational)
         run: cargo fmt --all --check
-        continue-on-error: true
-      - name: clippy
-        run: cargo clippy --workspace --all-targets
         continue-on-error: true
 
   conformance:

--- a/crates/sparq-bench/src/fuzz.rs
+++ b/crates/sparq-bench/src/fuzz.rs
@@ -69,7 +69,7 @@ fn gen_graph(rng: &mut Rng) -> String {
                 3 => format!("\"-{}\"^^xsd:integer", rng.below(60)),   // negative integer (not inline)
                 4 => format!("\"0{}\"^^xsd:integer", 1 + rng.below(9)), // non-canonical (leading zero)
                 5 => format!("\"{}.0\"^^xsd:double", rng.below(120)),   // double
-                6 => format!("\"{}\"^^xsd:integer", 9007199254740990u64 + rng.below(6) as u64), // near 2^53 — f64-inexact
+                6 => format!("\"{}\"^^xsd:integer", 9007199254740990u64 + rng.below(6)), // near 2^53 — f64-inexact
                 7 => format!("\"{}\"^^xsd:decimal", hp_dec[rng.below(4) as usize]), // high-precision decimal
                 _ => format!("\"s{}\"", rng.below(5)),                  // plain string (non-numeric)
             };
@@ -101,7 +101,7 @@ fn gen_filter(rng: &mut Rng, var: &str) -> String {
     // non-numeric operand must turn into a type error, not a string comparison.
     // 1-in-6: a threshold near 2^53, where an f64 numeric model loses integer precision.
     if rng.chance(1, 6) {
-        let t = 9007199254740990u64 + rng.below(6) as u64;
+        let t = 9007199254740990u64 + rng.below(6);
         return format!("FILTER({var} {op} {t})");
     }
     let t = rng.below(160) as i64 - 40; // -40..119
@@ -145,7 +145,7 @@ fn gen_query(rng: &mut Rng, category: &str) -> String {
                 2 => "ex:n0".to_string(),                          // IRI
                 3 => "\"true\"^^xsd:boolean".to_string(),          // boolean
                 4 => format!("\"{}\"^^xsd:int", rng.below(120)),   // xsd:int
-                5 => format!("\"{}\"^^xsd:integer", 9007199254740990u64 + rng.below(6) as u64), // near 2^53
+                5 => format!("\"{}\"^^xsd:integer", 9007199254740990u64 + rng.below(6)), // near 2^53
                 6 => format!("\"{}\"^^xsd:decimal", ["0.123456789012345678", "0.123456789012345679", "0.299999999999999999"][rng.below(3) as usize]), // high-precision decimal
                 _ => format!("\"{}.5\"^^xsd:decimal", rng.below(120)), // decimal
             };

--- a/crates/sparq-bench/src/fuzz.rs
+++ b/crates/sparq-bench/src/fuzz.rs
@@ -174,6 +174,8 @@ fn gen_query(rng: &mut Rng, category: &str) -> String {
     format!("{pfx}SELECT * WHERE {{ {body} }}")
 }
 
+// clippy: differential oracle pins oxigraph's legacy Store::query semantics
+#[allow(deprecated)]
 fn oxi_count(store: &Store, q: &str) -> Result<usize, String> {
     match store.query(q).map_err(|e| e.to_string())? {
         oxigraph::sparql::QueryResults::Solutions(s) => Ok(s.count()),
@@ -183,6 +185,8 @@ fn oxi_count(store: &Store, q: &str) -> Result<usize, String> {
 }
 
 /// Oxigraph's ordered sequence of a single projected variable, as term strings.
+// clippy: differential oracle pins oxigraph's legacy Store::query semantics
+#[allow(deprecated)]
 fn oxi_seq(store: &Store, q: &str, var: &str) -> Option<Vec<String>> {
     match store.query(q).ok()? {
         oxigraph::sparql::QueryResults::Solutions(s) => Some(

--- a/crates/sparq-bench/src/main.rs
+++ b/crates/sparq-bench/src/main.rs
@@ -196,6 +196,8 @@ fn time_min(iters: usize, mut f: impl FnMut() -> usize) -> (Duration, usize) {
     (best, rows)
 }
 
+// clippy: differential oracle pins oxigraph's legacy Store::query semantics
+#[allow(deprecated)]
 fn oxi_count(store: &oxigraph::store::Store, q: &str) -> usize {
     match store.query(q).expect("oxi query") {
         oxigraph::sparql::QueryResults::Solutions(s) => s.count(),

--- a/crates/sparq-conformance/src/inference/entail.rs
+++ b/crates/sparq-conformance/src/inference/entail.rs
@@ -554,11 +554,10 @@ fn solve(
         }
         let mut bound: Vec<String> = Vec::new();
         let ok = (0..3).all(|k| pat_match(&pat[k], &row[k], map, &mut bound, d));
-        if ok {
-            if solve(i + 1, conclusion, closure, map, d, steps) {
+        if ok
+            && solve(i + 1, conclusion, closure, map, d, steps) {
                 return true;
             }
-        }
         for b in bound {
             map.remove(&b);
         }
@@ -690,15 +689,14 @@ pub fn inconsistency(closure: &[Row], d: &Recognized) -> Option<String> {
                 }
             } else if pn.as_str() == rdfs::SUB_CLASS_OF.as_str() {
                 if let (Term::NamedNode(sub), Term::NamedNode(sup)) = (s, o) {
-                    if d.contains(sub.as_str()) && d.contains(sup.as_str()) {
-                        if dt_subset(sub.as_str(), sup.as_str()) == Some(false) {
+                    if d.contains(sub.as_str()) && d.contains(sup.as_str())
+                        && dt_subset(sub.as_str(), sup.as_str()) == Some(false) {
                             return Some(format!(
                                 "datatype subclass clash: <{}> ⊄ <{}> (value spaces)",
                                 sub.as_str(),
                                 sup.as_str()
                             ));
                         }
-                    }
                 }
             }
         }

--- a/crates/sparq-conformance/src/inference/report.rs
+++ b/crates/sparq-conformance/src/inference/report.rs
@@ -170,7 +170,7 @@ pub fn render(sections: &[Section], roots: &[(&str, &Path)]) -> String {
         if !oos_hist.is_empty() {
             let _ = writeln!(md, "### Out-of-scope reasons\n");
             let mut hist: Vec<_> = oos_hist.into_iter().collect();
-            hist.sort_by(|a, b| b.1.cmp(&a.1));
+            hist.sort_by_key(|e| std::cmp::Reverse(e.1));
             let _ = writeln!(md, "| reason | tests |");
             let _ = writeln!(md, "|---|---:|");
             for (reason, n) in hist {

--- a/crates/sparq-conformance/src/main.rs
+++ b/crates/sparq-conformance/src/main.rs
@@ -460,7 +460,7 @@ fn render_report(
     if !skip_hist.is_empty() {
         let _ = writeln!(md, "## Skip reasons\n");
         let mut hist: Vec<_> = skip_hist.into_iter().collect();
-        hist.sort_by(|a, b| b.1.cmp(&a.1));
+        hist.sort_by_key(|e| std::cmp::Reverse(e.1));
         let _ = writeln!(md, "| reason | tests |");
         let _ = writeln!(md, "|---|---:|");
         for (reason, n) in hist {
@@ -487,7 +487,7 @@ fn render_report(
     if !fail_hist.is_empty() {
         let _ = writeln!(md, "## Failure categories\n");
         let mut hist: Vec<_> = fail_hist.into_iter().collect();
-        hist.sort_by(|a, b| b.1.cmp(&a.1));
+        hist.sort_by_key(|e| std::cmp::Reverse(e.1));
         let _ = writeln!(md, "| category | tests |");
         let _ = writeln!(md, "|---|---:|");
         for (reason, n) in hist {

--- a/crates/sparq-conformance/src/main.rs
+++ b/crates/sparq-conformance/src/main.rs
@@ -165,6 +165,11 @@ struct SuiteStats {
     divergences: Vec<(String, String, String)>, // (test name, rationale, observed mismatch)
 }
 
+/// The grouped conformance report shape: group -> section -> suite -> stats.
+type SuiteMap = BTreeMap<String, SuiteStats>;
+type SectionGroups = Vec<(String, SuiteMap)>;
+type ReportGroups = Vec<(String, SectionGroups)>;
+
 fn main() {
     // Quiet expected engine panics (they are reported as FAILs by the watchdog).
     std::panic::set_hook(Box::new(|_| {}));
@@ -203,12 +208,12 @@ fn main() {
         .expect("canonicalize suites root");
 
     // Group -> section -> suite -> stats, preserving GROUPS order.
-    let mut groups: Vec<(String, Vec<(String, BTreeMap<String, SuiteStats>)>)> = Vec::new();
+    let mut groups: ReportGroups = Vec::new();
     let mut other_entries = 0usize;
     let mut total_run = 0usize;
 
     for (group_label, section_specs) in GROUPS {
-        let mut sections: Vec<(String, BTreeMap<String, SuiteStats>)> = Vec::new();
+        let mut sections: SectionGroups = Vec::new();
         for (label, tops, scope) in *section_specs {
             let mut entries: Vec<TestEntry> = Vec::new();
             for top in *tops {
@@ -217,7 +222,7 @@ fn main() {
                     eprintln!("failed to load {}: {e}", manifest_path.display());
                 }
             }
-            let mut suites: BTreeMap<String, SuiteStats> = BTreeMap::new();
+            let mut suites: SuiteMap = BTreeMap::new();
             for entry in &entries {
                 if let Some(f) = &filter {
                     if !entry.id.contains(f.as_str())
@@ -336,7 +341,7 @@ fn git_head(dir: &Path) -> String {
 }
 
 fn render_report(
-    groups: &[(String, Vec<(String, BTreeMap<String, SuiteStats>)>)],
+    groups: &[(String, SectionGroups)],
     root: &Path,
     other_entries: usize,
     total_run: usize,

--- a/crates/sparq-core/src/dict.rs
+++ b/crates/sparq-core/src/dict.rs
@@ -1719,7 +1719,7 @@ impl ShardedDict {
         struct SlotPtr(*mut Id, usize);
         unsafe impl Send for SlotPtr {}
         unsafe impl Sync for SlotPtr {}
-        let scatter: Vec<SlotPtr> = remaps.iter_mut().map(|v| (SlotPtr(v.as_mut_ptr(), v.len()))).collect();
+        let scatter: Vec<SlotPtr> = remaps.iter_mut().map(|v| SlotPtr(v.as_mut_ptr(), v.len())).collect();
 
         // Intern each shard's terms in parallel (single-writer per shard → no contention),
         // walking partials in order so per-shard id assignment matches the serial routing.
@@ -2065,7 +2065,7 @@ mod tests {
         let mut d = Dict::new();
         let tt = triple("http://ex/alice", "http://ex/age", int("30"));
         let id = d.intern(&tt);
-        assert!(id >= 1 && id < INLINE_BASE);
+        assert!((1..INLINE_BASE).contains(&id));
         // Children were interned (subject + predicate; the object is inline).
         assert_eq!(d.len(), 3, "subject + predicate + the triple itself (inline object not stored)");
         // term() rebuilds a structural Term::Triple, not a literal.
@@ -2217,7 +2217,7 @@ mod tests {
         let mut d = Dict::new();
         let iri = Term::NamedNode(oxrdf::NamedNode::new("http://ex/x").unwrap());
         let id = d.intern(&iri);
-        assert!(id >= 1 && id < INLINE_BASE);
+        assert!((1..INLINE_BASE).contains(&id));
         assert!(!is_inline(id));
         assert_eq!(d.term(id), iri);
     }

--- a/crates/sparq-core/src/dict.rs
+++ b/crates/sparq-core/src/dict.rs
@@ -47,8 +47,12 @@ const INLINE_MAX: u32 = (1 << 30) - 1;
 /// `dict-meta.bin` previously began with `prefixes.len() as u32` (a small count). This magic
 /// is chosen to be distinguishable from any plausible legacy prefix count, so the reader can
 /// detect header-less legacy files. ("DMV1" — Dict Meta, V1; little-endian.)
+// clippy/dead_code: the on-disk meta header is read/written only by the `mmap`/`dict-spill`
+// persistence paths, which are cfg'd out of the default feature set.
+#[allow(dead_code)]
 pub(crate) const DICT_META_MAGIC: u32 = 0x31_56_4D_44; // b"DMV1" little-endian
 /// Bump when the on-disk meta layout changes incompatibly.
+#[allow(dead_code)]
 pub(crate) const DICT_META_VERSION: u32 = 1;
 
 /// If a literal `value`/`datatype` is a canonical non-negative `xsd:integer` in

--- a/crates/sparq-core/src/dictspill.rs
+++ b/crates/sparq-core/src/dictspill.rs
@@ -11,34 +11,39 @@
 //!
 //! Pipeline (all IO is sequential — no random disk access anywhere):
 //!   1. ingest    — route each parsed partial's terms to `hash % n` shards (the same
-//!     routing as `ShardedDict::intern_partials`); per shard, a BOUNDED
-//!     dedup cache maps serialized term -> seq (the per-shard occurrence
-//!     counter). Cache misses append the term to the shard's record file
-//!     (seq = record index, implicit). Triples are staged to disk as
-//!     `[u64;3]` (`(shard+1)<<32 | seq`; inline ids pass through).
-//!     Over-budget caches are CLEARED at batch boundaries (an "epoch") —
-//!     re-spilled duplicates collapse at dedup time, so correctness never
-//!     depends on the cache policy, only IO volume does.
+//!      routing as `ShardedDict::intern_partials`); per shard, a BOUNDED
+//!      dedup cache maps serialized term -> seq (the per-shard occurrence
+//!      counter). Cache misses append the term to the shard's record file
+//!      (seq = record index, implicit). Triples are staged to disk as
+//!      `[u64;3]` (`(shard+1)<<32 | seq`; inline ids pass through).
+//!      Over-budget caches are CLEARED at batch boundaries (an "epoch") —
+//!      re-spilled duplicates collapse at dedup time, so correctness never
+//!      depends on the cache policy, only IO volume does.
 //!   2. dedup     — per shard: external sort of the records by (term bytes, seq);
-//!     groups of equal terms yield the distinct term with its MIN seq
-//!     (= first occurrence) plus a (min_seq, seq) pair per occurrence.
+//!      groups of equal terms yield the distinct term with its MIN seq
+//!      (= first occurrence) plus a (min_seq, seq) pair per occurrence.
 //!   3. assign    — per shard in order: external sort of the distinct terms by
-//!     min_seq; final id = base[shard] + rank (the sharded path's
-//!     assignment). The dictionary files (`dict-terms/offs/hash/hid/
-//!     meta.bin`) plus `numerics.bin`/`temporals.bin` are STREAM-written
-//!     in final-id order — never resident.
+//!      min_seq; final id = base[shard] + rank (the sharded path's
+//!      assignment). The dictionary files (`dict-terms/offs/hash/hid/
+//!      meta.bin`) plus `numerics.bin`/`temporals.bin` are STREAM-written
+//!      in final-id order — never resident.
 //!   4. join      — (seq -> min_seq) ⋈ (min_seq -> final id) -> dense per-shard
-//!     `seq -> final id` remap files (two more small external sorts).
+//!      `seq -> final id` remap files (two more small external sorts).
 //!   5. remap     — stream the staged triples through per-shard sliding windows over
-//!     the remap files (advanced at the recorded epoch boundaries), and
-//!     feed final-id `[u32;3]` triples into the existing
-//!     `extsort::spill_run` / `kway_merge` machinery. Ids are already
-//!     final and dense, so no `remap_perm_file` pass is needed.
+//!      the remap files (advanced at the recorded epoch boundaries), and
+//!      feed final-id `[u32;3]` triples into the existing
+//!      `extsort::spill_run` / `kway_merge` machinery. Ids are already
+//!      final and dense, so no `remap_perm_file` pass is needed.
 
 use crate::dict::{self, Dict, Id, TermParts};
 use rustc_hash::FxHashMap;
 use std::io::{self, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
+
+/// One shard's routed `(seq, serialized-term)` entries for a single ingest batch.
+type ShardEntries = Vec<(Id, Box<[u8]>)>;
+/// A finalized per-shard record: `(record-file path, final seq count, epoch boundaries)`.
+type ShardFile = (PathBuf, u32, Vec<(u64, u32)>);
 
 // ---- Configuration + resource detection -------------------------------------------
 
@@ -673,10 +678,10 @@ impl SpillInterner {
         let n = self.shards.len();
 
         // Route + serialize (parallel over partials; same hash routing as the sharded path).
-        let routed: Vec<Vec<Vec<(Id, Box<[u8]>)>>> = partials
+        let routed: Vec<Vec<ShardEntries>> = partials
             .par_iter()
             .map(|(pd, _)| {
-                let mut b: Vec<Vec<(Id, Box<[u8]>)>> = (0..n).map(|_| Vec::with_capacity(pd.len() / n + 1)).collect();
+                let mut b: Vec<ShardEntries> = (0..n).map(|_| Vec::with_capacity(pd.len() / n + 1)).collect();
                 let mut scratch: Vec<u8> = Vec::new();
                 for i in 1..=pd.len() as Id {
                     let tp = pd.term_parts(i);
@@ -798,7 +803,7 @@ pub(crate) fn consolidate(mut st: SpillInterner, dir: &Path, tmp: &Path, cfg: &S
     st.staged.flush().map_err(io_err)?;
     let staged_path = st.staged_path.clone();
     let staged_count = st.staged_count;
-    let mut shard_files: Vec<(PathBuf, u32, Vec<(u64, u32)>)> = Vec::with_capacity(n);
+    let mut shard_files: Vec<ShardFile> = Vec::with_capacity(n);
     for mut s in std::mem::take(&mut st.shards) {
         s.rec.flush().map_err(io_err)?;
         s.cache = FxHashMap::default();

--- a/crates/sparq-core/src/dictspill.rs
+++ b/crates/sparq-core/src/dictspill.rs
@@ -11,29 +11,29 @@
 //!
 //! Pipeline (all IO is sequential — no random disk access anywhere):
 //!   1. ingest    — route each parsed partial's terms to `hash % n` shards (the same
-//!                  routing as `ShardedDict::intern_partials`); per shard, a BOUNDED
-//!                  dedup cache maps serialized term -> seq (the per-shard occurrence
-//!                  counter). Cache misses append the term to the shard's record file
-//!                  (seq = record index, implicit). Triples are staged to disk as
-//!                  `[u64;3]` (`(shard+1)<<32 | seq`; inline ids pass through).
-//!                  Over-budget caches are CLEARED at batch boundaries (an "epoch") —
-//!                  re-spilled duplicates collapse at dedup time, so correctness never
-//!                  depends on the cache policy, only IO volume does.
+//!     routing as `ShardedDict::intern_partials`); per shard, a BOUNDED
+//!     dedup cache maps serialized term -> seq (the per-shard occurrence
+//!     counter). Cache misses append the term to the shard's record file
+//!     (seq = record index, implicit). Triples are staged to disk as
+//!     `[u64;3]` (`(shard+1)<<32 | seq`; inline ids pass through).
+//!     Over-budget caches are CLEARED at batch boundaries (an "epoch") —
+//!     re-spilled duplicates collapse at dedup time, so correctness never
+//!     depends on the cache policy, only IO volume does.
 //!   2. dedup     — per shard: external sort of the records by (term bytes, seq);
-//!                  groups of equal terms yield the distinct term with its MIN seq
-//!                  (= first occurrence) plus a (min_seq, seq) pair per occurrence.
+//!     groups of equal terms yield the distinct term with its MIN seq
+//!     (= first occurrence) plus a (min_seq, seq) pair per occurrence.
 //!   3. assign    — per shard in order: external sort of the distinct terms by
-//!                  min_seq; final id = base[shard] + rank (the sharded path's
-//!                  assignment). The dictionary files (`dict-terms/offs/hash/hid/
-//!                  meta.bin`) plus `numerics.bin`/`temporals.bin` are STREAM-written
-//!                  in final-id order — never resident.
+//!     min_seq; final id = base[shard] + rank (the sharded path's
+//!     assignment). The dictionary files (`dict-terms/offs/hash/hid/
+//!     meta.bin`) plus `numerics.bin`/`temporals.bin` are STREAM-written
+//!     in final-id order — never resident.
 //!   4. join      — (seq -> min_seq) ⋈ (min_seq -> final id) -> dense per-shard
-//!                  `seq -> final id` remap files (two more small external sorts).
+//!     `seq -> final id` remap files (two more small external sorts).
 //!   5. remap     — stream the staged triples through per-shard sliding windows over
-//!                  the remap files (advanced at the recorded epoch boundaries), and
-//!                  feed final-id `[u32;3]` triples into the existing
-//!                  `extsort::spill_run` / `kway_merge` machinery. Ids are already
-//!                  final and dense, so no `remap_perm_file` pass is needed.
+//!     the remap files (advanced at the recorded epoch boundaries), and
+//!     feed final-id `[u32;3]` triples into the existing
+//!     `extsort::spill_run` / `kway_merge` machinery. Ids are already
+//!     final and dense, so no `remap_perm_file` pass is needed.
 
 use crate::dict::{self, Dict, Id, TermParts};
 use rustc_hash::FxHashMap;

--- a/crates/sparq-core/src/dictspill.rs
+++ b/crates/sparq-core/src/dictspill.rs
@@ -610,7 +610,7 @@ impl ShardState {
         }
         let seq = self.seq;
         self.seq = self.seq.checked_add(1).ok_or_else(|| {
-            io::Error::new(io::ErrorKind::Other, "dict-spill: shard exceeded 2^32 spilled occurrences")
+            io::Error::other("dict-spill: shard exceeded 2^32 spilled occurrences")
         })?;
         self.rec.write_all(&(bytes.len() as u32).to_le_bytes())?;
         self.rec.write_all(bytes)?;
@@ -711,7 +711,7 @@ impl SpillInterner {
                         // SAFETY: i < len and this (pidx, i) slot is hash-routed to
                         // exactly this shard — disjoint writes, no reads until the
                         // parallel scope ends.
-                        unsafe { ptr.add(*i as usize).write(STAGED_DICT_BASE * (s as u64 + 1) | seq as u64) };
+                        unsafe { ptr.add(*i as usize).write((STAGED_DICT_BASE * (s as u64 + 1)) | seq as u64) };
                     }
                 }
                 Ok(())
@@ -1022,7 +1022,7 @@ pub(crate) fn consolidate(mut st: SpillInterner, dir: &Path, tmp: &Path, cfg: &S
                 }))
             };
             while let Some(p) = merge.next().map_err(io_err)? {
-                while cur.map_or(true, |(m, _)| m < p.min_seq) {
+                while cur.is_none_or(|(m, _)| m < p.min_seq) {
                     cur = next_m2f(&mut m2f).map_err(io_err)?;
                     if cur.is_none() {
                         return Err("dict-spill: remap join exhausted the assignment stream".into());

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -16,6 +16,10 @@ pub mod temporal;
 
 use dict::{Dict, Id};
 use temporal::Temporal;
+
+/// Per-chunk parse output: a partial dictionary + that chunk's local-id triples, one
+/// element per parallel chunk (the parallelizable half of ingest, merged downstream).
+type ChunkPartials = Vec<(Dict, Vec<[Id; 3]>)>;
 use oxrdf::vocab::xsd;
 use oxrdf::{Literal, NamedNode, Term};
 use oxttl::{NQuadsParser, NTriplesParser, TriGParser, TurtleParser};
@@ -1653,6 +1657,8 @@ impl Graph {
     pub fn apply_delta_nquads(&mut self, inserts: &str, deletes: &str) -> Result<(), String> {
         use oxrdf::GraphName;
         type Slot = Option<Term>;
+        // Per-graph delta: `(slot, inserts, deletes)` — one entry per distinct graph.
+        type SlotDelta = (Slot, Vec<[Term; 3]>, Vec<[Term; 3]>);
         fn parse(text: &str) -> Result<Vec<(Slot, [Term; 3])>, String> {
             let mut out = Vec::new();
             for q in NQuadsParser::new().for_slice(text.as_bytes()) {
@@ -1669,7 +1675,7 @@ impl Graph {
         // Group per slot preserving first-seen order (datasets hold few graphs, so a
         // linear scan beats hashing Terms), keeping each slot's deletes and inserts
         // together so they go through ONE apply_delta call (deletes applied first).
-        let mut slots: Vec<(Slot, Vec<[Term; 3]>, Vec<[Term; 3]>)> = Vec::new();
+        let mut slots: Vec<SlotDelta> = Vec::new();
         for (is_insert, items) in [(false, parse(deletes)?), (true, parse(inserts)?)] {
             for (slot, t) in items {
                 let entry = match slots.iter_mut().find(|(s, _, _)| *s == slot) {
@@ -2526,8 +2532,10 @@ fn turtle_chunks(bytes: &[u8], target: usize) -> Option<Vec<Vec<u8>>> {
         let group_start = stmts[idx].start;
         let mut end_i = (idx + per).min(stmts.len());
         // Shrink the group so every statement in it shares the same directive snapshot.
-        for k in idx + 1..end_i {
-            if stmts[k].dirs_before != dirs_before {
+        // (Range bounds are snapshotted at loop entry, so the in-loop `end_i` write only
+        // takes effect via the immediate `break`.)
+        for (k, stmt) in stmts.iter().enumerate().take(end_i).skip(idx + 1) {
+            if stmt.dirs_before != dirs_before {
                 end_i = k;
                 break;
             }
@@ -2572,7 +2580,8 @@ fn parse_turtle_chunked(bytes: &[u8], target: usize) -> Result<(Dict, Vec<[Id; 3
         Some(c) if c.len() > 1 => c,
         _ => return serial(),
     };
-    let partials: Result<Vec<(Dict, Vec<[Id; 3]>)>, String> = chunks
+    type Partials = Vec<(Dict, Vec<[Id; 3]>)>;
+    let partials: Result<Partials, String> = chunks
         .par_iter()
         .map(|chunk| {
             let mut dict = Dict::new();
@@ -2941,7 +2950,7 @@ fn build_external_ntriples_dictspill<R: std::io::Read + Send>(
 /// Parses one (complete-line) N-Triples byte block in parallel into per-chunk partial
 /// dictionaries + local-id triples (no shared state) — the parallelizable half of ingest.
 #[cfg(feature = "parallel")]
-fn parse_block(bytes: &[u8]) -> Result<Vec<(Dict, Vec<[Id; 3]>)>, String> {
+fn parse_block(bytes: &[u8]) -> Result<ChunkPartials, String> {
     use rayon::prelude::*;
     let target = (rayon::current_num_threads().max(1) * 4).min(bytes.len() / 4096 + 1);
     let bounds = newline_chunk_bounds(bytes, target);
@@ -2964,6 +2973,10 @@ fn parse_block(bytes: &[u8]) -> Result<Vec<(Dict, Vec<[Id; 3]>)>, String> {
 /// to attribute wall-time across parallel-parse vs dict-merge vs triple-remap.
 #[cfg(feature = "parallel")]
 mod build_timing {
+    // clippy/dead_code: this build-phase timing helper is consumed only by the
+    // `mmap`/`dict-spill` external-build paths; in the default feature set those callers
+    // are cfg'd out, leaving some members unused. They are not dead under those features.
+    #![allow(dead_code)]
     use std::sync::atomic::AtomicU64;
     pub static PARSE_NS: AtomicU64 = AtomicU64::new(0);
     pub static MERGE_NS: AtomicU64 = AtomicU64::new(0);

--- a/crates/sparq-core/src/temporal.rs
+++ b/crates/sparq-core/src/temporal.rs
@@ -82,9 +82,9 @@ impl Timeline {
 /// outside the ±14h window (inside it: indeterminate -> `None`).
 #[inline]
 fn cmp_instants(ai: f64, a_tz: bool, bi: f64, b_tz: bool) -> Option<Ordering> {
-    if a_tz == b_tz {
-        ai.partial_cmp(&bi)
-    } else if (ai - bi).abs() > 14.0 * 3600.0 {
+    // Same (or no) timezone: a direct compare. With MIXED presence the order is
+    // only decidable outside the ±14h window; inside it the result is indeterminate.
+    if a_tz == b_tz || (ai - bi).abs() > 14.0 * 3600.0 {
         ai.partial_cmp(&bi)
     } else {
         None

--- a/crates/sparq-engine/src/construct.rs
+++ b/crates/sparq-engine/src/construct.rs
@@ -242,11 +242,10 @@ fn cbd(graph: &Graph, solutions: &QueryResult) -> Result<Vec<Triple>, String> {
     for row in &solutions.rows {
         for cell in row.iter().flatten() {
             match cell {
-                Term::NamedNode(_) | Term::BlankNode(_) => {
-                    if visited.insert(cell.clone()) {
+                Term::NamedNode(_) | Term::BlankNode(_)
+                    if visited.insert(cell.clone()) => {
                         queue.push(cell.clone());
                     }
-                }
                 _ => {} // a literal has no description
             }
         }

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -3115,7 +3115,7 @@ pub(crate) fn goo_pick(
             Some(star) => star * sel,
             None => cur_card * prepared[i].est as f64 * sel,
         };
-        if best.map_or(true, |(_, bc)| out < bc) {
+        if best.is_none_or(|(_, bc)| out < bc) {
             best = Some((i, out));
         }
     }
@@ -4121,7 +4121,7 @@ fn left_outer_join(graph: &Graph, local: &mut LocalVocab, left: Bindings, right:
         }
         if !matched {
             let mut combined = lrow.clone();
-            combined.extend(std::iter::repeat(NO_ID).take(n_right_only));
+            combined.extend(std::iter::repeat_n(NO_ID, n_right_only));
             rows.push(combined);
         }
     }
@@ -4186,7 +4186,7 @@ fn left_outer_merge(
             }
             if !matched {
                 let mut combined = l[li].clone();
-                combined.extend(std::iter::repeat(NO_ID).take(n_right_only));
+                combined.extend(std::iter::repeat_n(NO_ID, n_right_only));
                 rows.push(combined);
             }
         }
@@ -5580,7 +5580,7 @@ fn eval_exact_lexical(graph: &Graph, local: &LocalVocab, b: &Bindings, row: &[Id
             if id == NO_ID {
                 None
             } else if is_local(id) {
-                exact_lexical_of_term(&local.term(id))
+                exact_lexical_of_term(local.term(id))
             } else {
                 graph.exact_numeric_lexical(id)
             }
@@ -5800,7 +5800,7 @@ impl Dec {
             }
             None => match mode {
                 // |value| < 1: floor of a tiny positive is 0, of a tiny negative is -1.
-                RoundMode::Floor => i128::from(self.mant < 0) * -1,
+                RoundMode::Floor => -i128::from(self.mant < 0),
                 // ceil of a tiny positive is 1, of a tiny negative is 0.
                 RoundMode::Ceil => i128::from(self.mant > 0),
                 // |value| < 0.5 always at this scale, so half-up rounds to 0.
@@ -5869,7 +5869,7 @@ fn eval_dec(graph: &Graph, local: &LocalVocab, b: &Bindings, row: &[Id], e: &Exp
             if id == NO_ID {
                 None
             } else if is_local(id) {
-                exact_lexical_of_term(&local.term(id)).and_then(|s| Dec::parse(&s))
+                exact_lexical_of_term(local.term(id)).and_then(|s| Dec::parse(&s))
             } else {
                 Dec::parse(&graph.exact_numeric_lexical(id)?)
             }
@@ -6092,14 +6092,14 @@ fn value_compare_strict(x: &Value, y: &Value) -> Option<Ordering> {
     use LitKind::*;
     match (lit_kind(x), lit_kind(y)) {
         (Num(Some(a)), Num(Some(b))) => num_compare(a, b),
-        (Str(a), Str(b)) => Some(a.cmp(&b)),
+        (Str(a), Str(b)) => Some(a.cmp(b)),
         (Bool(Some(a)), Bool(Some(b))) => Some(a.cmp(&b)),
         (DateTime(Some(a)), DateTime(Some(b))) => Timeline::cmp_tl(a, b),
         (Date(Some(a)), Date(Some(b))) => Timeline::cmp_tl(a, b),
         // Same language tag: compare values (the suites' lenient extension).
-        (Lang(t1, v1), Lang(t2, v2)) if t1 == t2 => Some(v1.cmp(&v2)),
+        (Lang(t1, v1), Lang(t2, v2)) if t1 == t2 => Some(v1.cmp(v2)),
         // Same other-XSD datatype: lexical order (correct for time, gYear, …).
-        (OtherXsd(d1, l1), OtherXsd(d2, l2)) if d1 == d2 => Some(l1.cmp(&l2)),
+        (OtherXsd(d1, l1), OtherXsd(d2, l2)) if d1 == d2 => Some(l1.cmp(l2)),
         _ => None,
     }
 }

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -2105,7 +2105,7 @@ fn eval_path(
     // DefaultGraphMode::Empty (L1 dataset view): no data pairs at top-level graph
     // scope — exactly the empty-graph evaluation. The zero-length constant
     // solutions below still apply (`<s> p* <s>` holds even on an empty graph).
-    if !view::default_is_empty() && !(matches!(s_end, End::Missing(_)) || matches!(o_end, End::Missing(_))) {
+    if !(view::default_is_empty() || matches!(s_end, End::Missing(_)) || matches!(o_end, End::Missing(_))) {
         let ends = PathEnds { s: s_bound, o: o_bound };
         // `?x p ?x` (same variable at both ends — necessarily both unbound): only
         // diagonal pairs survive the filter, and for the recursive operators the

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -3736,12 +3736,12 @@ fn merge_join(left: Bindings, right: Bindings, jv: &Variable) -> Bindings {
                 while j2 < r.len() && r[j2][rk] == rv {
                     j2 += 1;
                 }
-                for li in i..i2 {
-                    for rj in j..j2 {
-                        if extra_shared.iter().all(|&(lc, rc)| l[li][lc] == r[rj][rc]) {
-                            let mut row = l[li].clone();
+                for lrow in l.iter().take(i2).skip(i) {
+                    for rrow in r.iter().take(j2).skip(j) {
+                        if extra_shared.iter().all(|&(lc, rc)| lrow[lc] == rrow[rc]) {
+                            let mut row = lrow.clone();
                             for &rc in &right_only {
-                                row.push(r[rj][rc]);
+                                row.push(rrow[rc]);
                             }
                             rows.push(row);
                         }
@@ -4168,10 +4168,10 @@ fn left_outer_merge(
         while j2 < r.len() && r[j2][rk] == key {
             j2 += 1;
         }
-        for li in i..i2 {
+        for lrow in l.iter().take(i2).skip(i) {
             let mut matched = false;
-            for rj in j..j2 {
-                let combined = merge_rows(&l[li], &r[rj], shared, right_only);
+            for rrow in r.iter().take(j2).skip(j) {
+                let combined = merge_rows(lrow, rrow, shared, right_only);
                 let keep = match expr {
                     None => true,
                     Some(e) => {
@@ -4185,7 +4185,7 @@ fn left_outer_merge(
                 }
             }
             if !matched {
-                let mut combined = l[li].clone();
+                let mut combined = lrow.clone();
                 combined.extend(std::iter::repeat_n(NO_ID, n_right_only));
                 rows.push(combined);
             }

--- a/crates/sparq-engine/src/update.rs
+++ b/crates/sparq-engine/src/update.rs
@@ -80,11 +80,7 @@ fn freshen_term(t: &Term, fresh: &mut FreshBnodes) -> Term {
 }
 
 fn quad_to_triple_fresh(q: &Quad, fresh: &mut FreshBnodes) -> (GraphSlot, TripleTerms) {
-    let subject = match freshen_term(&nob_to_term(&q.subject), fresh) {
-        Term::NamedNode(n) => Term::NamedNode(n),
-        Term::BlankNode(b) => Term::BlankNode(b),
-        s => s,
-    };
+    let subject = freshen_term(&nob_to_term(&q.subject), fresh);
     (
         graph_name_slot(&q.graph_name),
         [subject, Term::NamedNode(q.predicate.clone()), freshen_term(&q.object, fresh)],

--- a/crates/sparq-engine/src/update.rs
+++ b/crates/sparq-engine/src/update.rs
@@ -28,6 +28,9 @@ use spargebra::SparqlParser;
 /// A graph slot: `None` = the default graph, `Some(term)` = that named graph.
 type GraphSlot = Option<Term>;
 
+/// An instantiated update triple plus the graph slot it targets.
+type SlotTriple = (GraphSlot, TripleTerms);
+
 fn nob_to_term(s: &NamedOrBlankNode) -> Term {
     match s {
         NamedOrBlankNode::NamedNode(n) => Term::NamedNode(n.clone()),
@@ -79,7 +82,7 @@ fn freshen_term(t: &Term, fresh: &mut FreshBnodes) -> Term {
     }
 }
 
-fn quad_to_triple_fresh(q: &Quad, fresh: &mut FreshBnodes) -> (GraphSlot, TripleTerms) {
+fn quad_to_triple_fresh(q: &Quad, fresh: &mut FreshBnodes) -> SlotTriple {
     let subject = freshen_term(&nob_to_term(&q.subject), fresh);
     (
         graph_name_slot(&q.graph_name),
@@ -87,7 +90,7 @@ fn quad_to_triple_fresh(q: &Quad, fresh: &mut FreshBnodes) -> (GraphSlot, Triple
     )
 }
 
-fn ground_quad_to_triple(q: &GroundQuad) -> (GraphSlot, TripleTerms) {
+fn ground_quad_to_triple(q: &GroundQuad) -> SlotTriple {
     (
         graph_name_slot(&q.graph_name),
         [Term::NamedNode(q.subject.clone()), Term::NamedNode(q.predicate.clone()), ground_to_term(&q.object)],
@@ -287,12 +290,12 @@ fn instantiate_templates(
     delete: &[GroundQuadPattern],
     insert: &[QuadPattern],
     pattern: &spargebra::algebra::GraphPattern,
-) -> Result<(Vec<(GraphSlot, TripleTerms)>, Vec<(GraphSlot, TripleTerms)>), String> {
+) -> Result<(Vec<SlotTriple>, Vec<SlotTriple>), String> {
     let result = crate::exec::eval_select(active, pattern)?;
     let cols: FxHashMap<Variable, usize> =
         result.vars.iter().enumerate().map(|(i, v)| (v.clone(), i)).collect();
-    let mut dels: Vec<(GraphSlot, TripleTerms)> = Vec::new();
-    let mut inss: Vec<(GraphSlot, TripleTerms)> = Vec::new();
+    let mut dels: Vec<SlotTriple> = Vec::new();
+    let mut inss: Vec<SlotTriple> = Vec::new();
     for row in &result.rows {
         let get = |v: &Variable| -> Option<Term> { cols.get(v).and_then(|&i| row[i].clone()) };
         for dp in delete {
@@ -504,7 +507,7 @@ pub fn update(graph: &Graph, sparql: &str) -> Result<Graph, String> {
 // --- the delta-overlay path ------------------------------------------------------------------
 
 /// Groups (graph-slot, triple) pairs per graph slot, preserving first-seen slot order.
-fn group_by_slot(items: Vec<(GraphSlot, TripleTerms)>) -> Vec<(GraphSlot, Vec<TripleTerms>)> {
+fn group_by_slot(items: Vec<SlotTriple>) -> Vec<(GraphSlot, Vec<TripleTerms>)> {
     let mut out: Vec<(GraphSlot, Vec<TripleTerms>)> = Vec::new();
     for (slot, t) in items {
         match out.iter_mut().find(|(s, _)| *s == slot) {

--- a/crates/sparq-hdt/tests/roundtrip.rs
+++ b/crates/sparq-hdt/tests/roundtrip.rs
@@ -208,6 +208,7 @@ fn direct_decoder_matches_upstream_snikmeta() {
 ///  * MULTI-BLOCK PFC: > 16 distinct strings per section (block_size 16) so the
 ///    block-sequential decode (H3) crosses block boundaries with running prefixes;
 ///  * a term zoo across blocks: langtag/datatyped/plain literals, blank nodes.
+///
 /// Then asserts the direct decoder == upstream oracle on those exact bytes.
 #[test]
 fn direct_decoder_matches_upstream_generated_multiblock() {

--- a/crates/sparq-mpc/src/join.rs
+++ b/crates/sparq-mpc/src/join.rs
@@ -575,7 +575,7 @@ mod tests {
             .evaluate_local("PREFIX ex: <http://ex/> SELECT ?p ?x WHERE { ?p ex:knows ?x }")
             .unwrap();
         let plan = JoinPlan { join_var: var("x"), key_disclosed: true };
-        let joined = DisclosedKeyJoin.join(&[pa.clone()], &plan).unwrap();
+        let joined = DisclosedKeyJoin.join(std::slice::from_ref(&pa), &plan).unwrap();
         assert_eq!(joined.rows.len(), pa.rows.len());
         assert_eq!(
             canonical_multiset(&joined.vars, &joined.rows),

--- a/crates/sparq-parse/src/lib.rs
+++ b/crates/sparq-parse/src/lib.rs
@@ -346,8 +346,11 @@ pub struct SingleMemberGzipSink {
     header_sent: bool,
 }
 
+/// One decompressed-and-CRCed gzip member, keyed by member index in `GzShared::ready`.
+type GzMember = io::Result<(Vec<u8>, flate2::Crc)>;
+
 struct GzShared {
-    ready: Mutex<BTreeMap<usize, io::Result<(Vec<u8>, flate2::Crc)>>>,
+    ready: Mutex<BTreeMap<usize, GzMember>>,
     cv: Condvar,
 }
 

--- a/crates/sparq-parse/src/lib.rs
+++ b/crates/sparq-parse/src/lib.rs
@@ -818,7 +818,7 @@ mod tests {
             .ready
             .lock()
             .unwrap()
-            .insert(next_out_before, Err(io::Error::new(io::ErrorKind::Other, "boom")));
+            .insert(next_out_before, Err(io::Error::other("boom")));
         let err = sink.try_drain().unwrap_err();
         assert_eq!(err.to_string(), "boom");
         // Cursor advanced past the failed (and already-removed) index; the entry

--- a/crates/sparq-reason/src/n3/mod.rs
+++ b/crates/sparq-reason/src/n3/mod.rs
@@ -78,6 +78,10 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use sparq_core::dict::{Dict, Id};
 use std::collections::HashMap;
 
+/// One forward-chaining derivation step: `(derived ground fact, rule index, premise facts
+/// that justified it)`. Collected during closure so a proof can be reconstructed.
+type DerivationStep = ([Term; 3], usize, Vec<[Term; 3]>);
+
 /// Facts + access indexes, so a rule-body join atom is an O(1)/O(matches) lookup instead of a
 /// full scan. Indexed by (predicate, subject)→objects, (predicate, object)→subjects, and
 /// predicate→facts — the patterns that arise when a rule atom's predicate (and often one
@@ -101,9 +105,6 @@ impl FactIndex {
     }
     fn contains(&self, t: &[Term; 3]) -> bool {
         self.all.contains(t)
-    }
-    fn len(&self) -> usize {
-        self.all.len()
     }
     fn insert(&mut self, t: [Term; 3]) -> bool {
         if !self.all.insert(t.clone()) {
@@ -203,7 +204,7 @@ pub fn reason_n3_proof(dict: &mut Dict, src: &str) -> Result<(Vec<[Id; 3]>, Vec<
 #[allow(clippy::type_complexity)]
 pub(crate) fn reason_n3_terms_proof(
     src: &str,
-) -> Result<(FxHashSet<[Term; 3]>, Vec<([Term; 3], usize, Vec<[Term; 3]>)>), String> {
+) -> Result<(FxHashSet<[Term; 3]>, Vec<DerivationStep>), String> {
     let parsed = parser::parse(src)?;
     let (facts, steps) = run_closure(parsed, None, StepMode::Full);
     Ok((facts.all, steps))
@@ -277,7 +278,7 @@ fn run_closure(
     parsed: parser::Parsed,
     resolver: Option<&Resolver>,
     mode: StepMode,
-) -> (FactIndex, Vec<([Term; 3], usize, Vec<[Term; 3]>)>) {
+) -> (FactIndex, Vec<DerivationStep>) {
     let parser::Parsed { facts: facts0, mut rules, mut backward_rules, base } = parsed;
     // Premises evaluate left-to-right with no coroutining — reorder each
     // premise so a builtin runs only after the atoms that produce its inputs
@@ -291,7 +292,7 @@ fn run_closure(
     bw.base = base;
     bw.resolver = resolver;
     // Derivation steps at the term level (interned to ids once at the end).
-    let mut steps: Vec<([Term; 3], usize, Vec<[Term; 3]>)> = Vec::new();
+    let mut steps: Vec<DerivationStep> = Vec::new();
 
     // Which predicates can a backward rule conclude? A forward rule with a premise atom on
     // such a predicate cannot use the semi-naive delta restriction (a backward proof is not
@@ -444,7 +445,7 @@ fn run_closure(
     let mut delta: FxHashSet<[Term; 3]> = facts.all.clone(); // round 0: every fact is "new"
     let mut first_round = true;
     loop {
-        let mut produced: Vec<([Term; 3], usize, Vec<[Term; 3]>)> = Vec::new();
+        let mut produced: Vec<DerivationStep> = Vec::new();
         for (ri, rule) in rules.iter().enumerate() {
             if let Some(&si) = trans_rules.get(&ri) {
                 // Transitivity fast path (linearized; see `TransState` above). Bypasses the
@@ -606,7 +607,7 @@ fn run_closure(
 fn intern_closure(
     dict: &mut Dict,
     facts: &FactIndex,
-    steps: &[([Term; 3], usize, Vec<[Term; 3]>)],
+    steps: &[DerivationStep],
 ) -> Result<(Vec<[Id; 3]>, Vec<ProofStep>), String> {
     // First-class list values have no dictionary representation — expand them
     // into rdf:first/rest blank-node chains (one chain per list VALUE, shared

--- a/crates/sparq-reason/src/owl.rs
+++ b/crates/sparq-reason/src/owl.rs
@@ -839,7 +839,7 @@ fn post_equivalences(dict: &mut Dict, triples: &mut Vec<[Id; 3]>) -> usize {
         }
     }
     let mut added = 0;
-    let mut emit = |pairs: &FxHashSet<(Id, Id)>,
+    let emit = |pairs: &FxHashSet<(Id, Id)>,
                     eq: Id,
                     set: &mut FxHashSet<[Id; 3]>,
                     triples: &mut Vec<[Id; 3]>,

--- a/crates/sparq-reason/src/owl.rs
+++ b/crates/sparq-reason/src/owl.rs
@@ -555,6 +555,7 @@ impl ClassFeatureIdx {
 ///     predicate appears only after RDFS subproperty propagation.
 ///   - rdfs9:  `(:C rdfs:subClassOf owl:SymmetricProperty), (:p a :C)` ⊢ `(:p a owl:SymmetricProperty)`
 ///     — a feature class appears only after RDFS subclass propagation.
+///
 /// In both cases the single-pass fast path would emit the derived `owl:sameAs`/feature-type triple
 /// as an *ordinary* triple WITHOUT running the equality/property reasoning it implies.
 ///

--- a/crates/sparq-reason/tests/incremental_n3_prop.rs
+++ b/crates/sparq-reason/tests/incremental_n3_prop.rs
@@ -179,10 +179,10 @@ fn counting_with_layer_guard_and_builtins_matches_from_scratch() {
             let t = [x, ex("hidden"), b_true()];
             let before = g.full_rebuilds();
             if base.contains(&t) {
-                g.delete(&[t.clone()]);
+                g.delete(std::slice::from_ref(&t));
                 base.remove(&t);
             } else {
-                g.insert(&[t.clone()]);
+                g.insert(std::slice::from_ref(&t));
                 base.insert(t);
             }
             assert_eq!(
@@ -245,10 +245,10 @@ fn unsupported_builtin_rules_run_in_fallback_and_stay_correct() {
         ];
         let before = g.full_rebuilds();
         if base.contains(&t) {
-            g.delete(&[t.clone()]);
+            g.delete(std::slice::from_ref(&t));
             base.remove(&t);
         } else {
-            g.insert(&[t.clone()]);
+            g.insert(std::slice::from_ref(&t));
             base.insert(t);
         }
         assert!(g.full_rebuilds() > before, "fallback mutations re-materialize");
@@ -274,7 +274,7 @@ fn decimal_data_reaching_concatenation_falls_back_sticky_and_stays_correct() {
     // A decimal literal flowing into string:concatenation is outside the parity whitelist:
     // the graph must drop to (sticky) engine fallback and stay correct.
     let t = [ex("b"), ex("val"), Term::Lit("1.50".into(), dec.into(), None)];
-    g.insert(&[t.clone()]);
+    g.insert(std::slice::from_ref(&t));
     base.insert(t);
     assert_eq!(g.mode(), N3Mode::Fallback);
     assert!(g.fallback_reason().is_some());
@@ -353,14 +353,14 @@ fn wac_small_pod_differential() {
     // ACL edit: grant Write too (incremental, no rebuild).
     let before = g.full_rebuilds();
     let t = [iri("https://pod.ex/.acl#owner"), acl("mode"), acl("Write")];
-    g.insert(&[t.clone()]);
+    g.insert(std::slice::from_ref(&t));
     base.insert(t);
     assert_eq!(g.full_rebuilds(), before, "plain ACL edit must stay incremental");
     assert_equal(&g, &rules, &base, "after mode insert");
 
     // Revoke Read (incremental delete).
     let t = [iri("https://pod.ex/.acl#owner"), acl("mode"), acl("Read")];
-    g.delete(&[t.clone()]);
+    g.delete(std::slice::from_ref(&t));
     base.remove(&t);
     assert_equal(&g, &rules, &base, "after mode delete");
     assert!(!g.contains(&[iri("https://alice.ex/#me"), auth_read, res("docs/a")]));
@@ -368,7 +368,7 @@ fn wac_small_pod_differential() {
     // ownAcl is a guard predicate: adding a closer ACL rebuilds (documented fallback).
     let before = g.full_rebuilds();
     let t = [res("docs/"), solidx("ownAcl"), res("docs/.acl")];
-    g.insert(&[t.clone()]);
+    g.insert(std::slice::from_ref(&t));
     base.insert(t);
     assert_eq!(g.full_rebuilds(), before + 1, "ownAcl delta must rebuild");
     assert_equal(&g, &rules, &base, "after ownAcl insert");

--- a/crates/sparq-reason/tests/incremental_n3_prop.rs
+++ b/crates/sparq-reason/tests/incremental_n3_prop.rs
@@ -281,7 +281,7 @@ fn decimal_data_reaching_concatenation_falls_back_sticky_and_stays_correct() {
     assert_equal(&g, CONCAT_RULES, &base, "after decimal");
 
     let t2 = [ex("c"), ex("val"), s_lit("world")];
-    g.insert(&[t2.clone()]);
+    g.insert(std::slice::from_ref(&t2));
     base.insert(t2);
     assert_equal(&g, CONCAT_RULES, &base, "sticky fallback insert");
 }

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -520,6 +520,9 @@ fn resolve_pin(
 /// is just an ignored unknown parameter (like any other).
 #[cfg(not(feature = "time-travel"))]
 #[inline(always)]
+// clippy: Err is axum's `Response` (the idiomatic handler error); boxing it would
+// only desync this signature from the `time-travel` variant and every call-site match.
+#[allow(clippy::result_large_err)]
 fn resolve_pin(
     state: &AppState,
     _url_params: &HashMap<String, String>,

--- a/crates/sparq-solid/src/authindex.rs
+++ b/crates/sparq-solid/src/authindex.rs
@@ -287,7 +287,7 @@ impl AuthIndex {
 
     /// Does a conditional grant's (agent, client) head apply to this session?
     fn cond_applies(&self, g: &ConditionalGrant, s: &Session) -> bool {
-        let agent_ok = Self::agent_principals(s).iter().any(|p| *p == g.agent);
+        let agent_ok = Self::agent_principals(s).contains(&g.agent);
         let client_ok = g.client == ANY_CLIENT || s.client == Some(g.client.as_str());
         agent_ok && client_ok && !g.except.iter().any(|m| self.matcher_accepts(m, s))
     }

--- a/crates/sparq-vectors/src/verbalize.rs
+++ b/crates/sparq-vectors/src/verbalize.rs
@@ -302,7 +302,7 @@ fn group_value(graph: &Graph, id: Id, group: &PropertyGroup, cfg: &EntityTextCon
         if cands.is_empty() {
             continue;
         }
-        cands.sort_by(|a, b| (a.0, a.1).cmp(&(b.0, b.1)));
+        cands.sort_by_key(|a| (a.0, a.1));
         let mut values: Vec<String> = Vec::new();
         for (_, _, text) in cands {
             if values.len() >= group.max_values.max(1) {

--- a/crates/sparq-vectors/tests/verbalize.rs
+++ b/crates/sparq-vectors/tests/verbalize.rs
@@ -63,8 +63,10 @@ fn language_preference_and_fallback() {
     let g = Graph::load_str(TTL, "turtle").unwrap();
 
     // French-first chain flips both the entity label and the type's label.
-    let mut fr = EntityTextConfig::default();
-    fr.languages = vec!["fr".into(), "en".into(), String::new()];
+    let fr = EntityTextConfig {
+        languages: vec!["fr".into(), "en".into(), String::new()],
+        ..Default::default()
+    };
     assert_eq!(
         verbalize(&g, &ex("bolt"), &fr).unwrap(),
         "Usain Bolt (fr). a athlète. Jamaican sprinter, eight-time Olympic champion.",
@@ -128,10 +130,12 @@ fn extra_prefixed_literal_group_with_value_cap() {
 #[test]
 fn char_budget_truncates_but_keeps_the_label() {
     let g = Graph::load_str(TTL, "turtle").unwrap();
-    let mut cfg = EntityTextConfig::default();
 
     // Whole-piece fit: label + type fit, description does not start.
-    cfg.max_chars = "Usain Bolt. a athlete".chars().count();
+    let mut cfg = EntityTextConfig {
+        max_chars: "Usain Bolt. a athlete".chars().count(),
+        ..Default::default()
+    };
     assert_eq!(verbalize(&g, &ex("bolt"), &cfg).unwrap(), "Usain Bolt. a athlete");
 
     // Mid-piece overflow: the overflowing piece is truncated at a char boundary.
@@ -144,12 +148,14 @@ fn entity_label_groups_only_enrich() {
     // A config whose ONLY group is the type (EntityLabel) must verbalize nothing:
     // Some requires at least one Literal-group contribution.
     let g = Graph::load_str(TTL, "turtle").unwrap();
-    let mut cfg = EntityTextConfig::default();
-    cfg.groups = vec![PropertyGroup::entity_label(vec![NamedNode::new(
-        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
-    )
-    .unwrap()])
-    .with_prefix("a ")];
+    let cfg = EntityTextConfig {
+        groups: vec![PropertyGroup::entity_label(vec![NamedNode::new(
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        )
+        .unwrap()])
+        .with_prefix("a ")],
+        ..Default::default()
+    };
     assert_eq!(cfg.groups[0].kind, ObjectKind::EntityLabel);
     assert_eq!(verbalize(&g, &ex("bolt"), &cfg), None);
 }

--- a/crates/sparq-wasm/src/lib.rs
+++ b/crates/sparq-wasm/src/lib.rs
@@ -31,6 +31,9 @@ pub struct QueryChunks {
 #[wasm_bindgen]
 impl QueryChunks {
     /// The next chunk, or `undefined` when the sequence is exhausted.
+    // clippy: a #[wasm_bindgen]-exported inherent method (JS calls `.next()`); it cannot
+    // be `Iterator::next`, and renaming would break the published JS binding contract.
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Option<String> {
         self.chunks.next()
     }

--- a/crates/sparq-zk-compose/src/manifest.rs
+++ b/crates/sparq-zk-compose/src/manifest.rs
@@ -194,10 +194,10 @@ pub struct AttestedStatusRef {
 /// # Privacy (interim, documented deferral)
 /// `index` is disclosed in the CLEAR here — a linkability channel (a relying
 /// party can correlate two presentations of the same credential by its index).
-/// The full-privacy upgrade is an IN-CIRCUIT hidden-index status-list inclusion
-/// + bit-unset proof bound to a disclosed list version, revealing only "the
-/// (hidden) index is in-range and unset in version V". See the verifier module
-/// docs (audit #12 remaining-step note).
+/// The full-privacy upgrade is an IN-CIRCUIT hidden-index status-list inclusion +
+/// bit-unset proof bound to a disclosed list version, revealing only "the (hidden)
+/// index is in-range and unset in version V". See the verifier module docs
+/// (audit #12 remaining-step note).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RevocationStatus {
     /// IRI of the status-list credential (bound under the issuer signature via

--- a/crates/sparq-zk-compose/src/verifier.rs
+++ b/crates/sparq-zk-compose/src/verifier.rs
@@ -10,6 +10,7 @@
 //! 2. **Binding-consistency edges**: each declared edge's scan-proof row/slot
 //!    encoding must equal the consuming filter proof's `operand_enc` (a plain
 //!    field equality over public inputs — the modular composition seam).
+//!
 //! 2d. **Issuer-signature / key-set binding (audit #3, codex #1).** Every scan
 //!    sub-proof's `commitments[g]` must carry an issuer attestation
 //!    ([`crate::manifest::CommitmentAttestation`]) whose Schnorr signature
@@ -28,19 +29,19 @@
 //!    `sparq_zk::sig`) removes that.
 //! 3. **bb verification (the cryptographic gate)**, for each sub-proof, all of:
 //!    a. **Public-input reconstruction (audit #1).** Independently rebuild the
-//!       public-input field vector from the DECLARED [`ProofInputs`] (in `main`
-//!       declaration order) using the verifier's own challenge, serialize to
-//!       bb's byte layout (32-byte BE field elements, no header — see
-//!       [`reconstruct_public_inputs`]), and assert byte-equality with the
-//!       prover's `public_inputs` blob. This binds the JSON statement to the
-//!       proof; without it stages 1-2 (JSON) and the proof (a detached crypto
-//!       object) describe potentially different statements.
+//!   public-input field vector from the DECLARED [`ProofInputs`] (in `main`
+//!   declaration order) using the verifier's own challenge, serialize to
+//!   bb's byte layout (32-byte BE field elements, no header — see
+//!   [`reconstruct_public_inputs`]), and assert byte-equality with the
+//!   prover's `public_inputs` blob. This binds the JSON statement to the
+//!   proof; without it stages 1-2 (JSON) and the proof (a detached crypto
+//!   object) describe potentially different statements.
 //!    b. **Canonical vk (audit #2).** Recompute the vk verifier-side from the
-//!       compiled member named by the re-derived [`CircuitId`] (never the
-//!       prover's `art.vk`), pinning the vk to the FULL CircuitId (subsumes the
-//!       #11 n/d/r relabel).
+//!   compiled member named by the re-derived [`CircuitId`] (never the
+//!   prover's `art.vk`), pinning the vk to the FULL CircuitId (subsumes the
+//!   #11 n/d/r relabel).
 //!    c. `bb verify` over (prover proof, reconstructed public inputs, canonical
-//!       vk).
+//!   vk).
 //!
 //! 2f. **Revocation / freshness (audit #12, + re-audit Option B).** Leverages #3:
 //!    the issuer signature ALSO binds the credential's STATUS-LIST REFERENCE

--- a/crates/sparq-zk/src/registry.rs
+++ b/crates/sparq-zk/src/registry.rs
@@ -194,6 +194,9 @@ impl RegistryEntry {
     /// verify path. Same deterministic `(sk, m)` nonce discipline as
     /// [`Self::issued`].
     // [OPUS-4.8] audit #12: status-bound issuance.
+    // clippy: each arg is a distinct cryptographic input to a signing constructor;
+    // bundling into a params struct would only obscure the call sites.
+    #[allow(clippy::too_many_arguments)]
     pub fn issued_with_status(
         document: NamedNode,
         commitment: Fr,

--- a/crates/sparq-zk/src/registry.rs
+++ b/crates/sparq-zk/src/registry.rs
@@ -559,7 +559,7 @@ mod tests {
         assert!(e.verify_commitment_signature(), "fresh issued entry verifies");
         // Round-trips through the store unchanged (key + sig survive).
         let mut g = Graph::load_str("", "turtle").unwrap();
-        install_registry(&mut g, &[e.clone()]).unwrap();
+        install_registry(&mut g, std::slice::from_ref(&e)).unwrap();
         let back = read_registry(&g);
         assert_eq!(back, vec![e]);
         assert!(back[0].verify_commitment_signature(), "read-back entry verifies");
@@ -589,7 +589,7 @@ mod tests {
         assert!(e.verify_commitment_signature_with_status(), "fresh status-bound entry verifies");
         // Round-trips through the store.
         let mut g = Graph::load_str("", "turtle").unwrap();
-        install_registry(&mut g, &[e.clone()]).unwrap();
+        install_registry(&mut g, std::slice::from_ref(&e)).unwrap();
         let back = read_registry(&g);
         assert_eq!(back, vec![e.clone()]);
         assert!(back[0].verify_commitment_signature_with_status(), "read-back verifies");

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,14 @@
+# rustfmt configuration for the sparq workspace.
+#
+# The codebase predates this file, so a one-time `cargo fmt --all` reformat is still
+# pending — it is deferred until the in-flight branches (serve-wave-b, MPC M3,
+# neon-intersect) land, to avoid a workspace-wide reformat conflicting with them.
+# Until then the CI `lint` job runs `cargo fmt --all --check` *informationally*
+# (continue-on-error); clippy is the hard gate. Pinning the config now means that
+# deferred reformat — and the eventual flip of fmt to a hard gate — is deterministic.
+#
+# STABLE options only: `cargo fmt` on the stable toolchain rejects unstable keys
+# (imports_granularity, group_imports, etc.), which would turn the informational
+# check into a confusing hard error. Keep everything here stable.
+edition = "2021"
+max_width = 100


### PR DESCRIPTION
## What

Stands up **enforcing lint CI**. The CI `lint` job previously ran `cargo fmt`/`cargo clippy` with `continue-on-error: true` (purely informational), so build warnings accumulated. This PR:

1. **Drives the whole workspace to zero clippy warnings** (`cargo clippy --workspace --all-targets -- -D warnings` → exit 0, sparq-py included).
2. **Makes clippy a hard gate** in `.github/workflows/ci.yml` (removes `continue-on-error`). Any new warning — from new code or a Rust-stable bump that adds a lint — now fails CI.
3. **Pins `rustfmt.toml`** (`edition=2021`, `max_width=100`, stable keys only).

## Warning disposition (106 distinct)

- **Auto-fixed** (`cargo clippy --fix`, ~30): `needless_borrow`, `unnecessary_cast`, `redundant_closure`, `manual_*`, `field_reassign_with_default`, `io_other_error`, `collapsible_if/match`, `unused_parens/mut`, …
- **Hand-fixed, semantics-preserving** (remainder): 13× `cloned_ref_to_slice_refs` → `slice::from_ref`; 3× descending `sort_by` → `sort_by_key(Reverse)`; De Morgan on one `nonminimal_bool`; merged identical `if_same_then_else` arms; ~50 doc-comment indentation/continuation fixes; 5× `needless_range_loop`; 3× `field_reassign` → struct-update; **11× `type_complexity` → named type aliases**; one dead `FactIndex::len` removed.
- **`#[allow]` with rationale (7 sites)** — each a deliberate, documented exception:
  - `sparq-bench/src/fuzz.rs` (×2), `main.rs`: `#[allow(deprecated)]` — differential oracle intentionally pins oxigraph's legacy `Store::query` semantics.
  - `sparq-wasm/src/lib.rs`: `#[allow(clippy::should_implement_trait)]` — `#[wasm_bindgen]`-exported JS `.next()`, can't be `Iterator::next`.
  - `sparq-zk/src/registry.rs`: `#[allow(clippy::too_many_arguments)]` — distinct cryptographic signing inputs.
  - `sparq-server/src/http.rs`: `#[allow(clippy::result_large_err)]` — `Err` is axum's `Response`; boxing desyncs the time-travel cfg variant.
  - `sparq-core` `build_timing` / `dict.rs` `DICT_META_*`: `#[allow(dead_code)]` — used only by `mmap`/`dict-spill` cfg paths that are off by default.

## fmt is deferred (intentional)

The repo was never run through `cargo fmt`, so a one-time `cargo fmt --all` reformat (~34K lines, mechanical) is still pending. It's deferred behind the in-flight branches (serve-wave-b, MPC M3, neon-intersect) to avoid a workspace-wide reformat conflicting with them. Until then the `rustfmt` step stays informational; flip it to a hard gate once that reformat merges. `rustfmt.toml` is pinned now so both are deterministic.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` → **exit 0**.
- `cargo test --workspace --exclude sparq-py --release --no-fail-fast` → **901 passed / 0 failed** (11 ignored). No behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)