### PR TITLE
feat(beads): SessionStart hook for bd context recovery + AGENTS.md note

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "hooks": {
     "SessionStart": [
       {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/bd-session-context.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ This repo tracks work in **beads** (`bd`, a git-native dependency-graph issue tr
   This writes the shared Dolt DB (exclusive-lock-serialized — safe across parallel agents). For the rationale behind a *deferred* task, put it in the bead's `-d` description or `--design` field so the bead is self-contained. **Never edit `.beads/issues.jsonl` (or any `.beads/` file) by hand** — it causes merge conflicts; `bd export` regenerates it.
 - Run `bd ready` to see unblocked work; close with `bd close <id>`.
 
+**Beads session-context hook.** `.claude/settings.json` registers a `SessionStart` hook (`scripts/bd-session-context.sh`) that injects a concise bead snapshot — the `bd ready` list + open count — at the start of every Claude Code session, so a new or post-compaction session recovers the task state automatically. It's a graceful no-op when `bd` isn't installed or `.beads/` is absent. We deliberately do **not** use beads' own `bd setup claude` / `bd prime` injection: that path ships generic rules ("do not use TaskCreate / MEMORY.md") that conflict with this harness's task tracker and auto-memory, and it duplicates the beads guidance already in this file. The hook ships only the useful, non-conflicting part. (A committed `.claude/settings.json` hook takes effect on the *next* session start / `/hooks` reload, not the current session.)
+
 ## Orchestration — delegate to sub-agents + run a continuous bead loop
 
 If you are an ORCHESTRATING agent (driving multi-step work on this repo), two standing rules:

--- a/scripts/bd-session-context.sh
+++ b/scripts/bd-session-context.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SessionStart hook — inject a concise beads (bd) task snapshot so a NEW or
+# post-compaction Claude Code session recovers this repo's task state automatically.
+#
+# Deliberately does NOT run `bd prime` / `bd setup claude`: that path injects generic
+# rules ("do NOT use TaskCreate", "do NOT use MEMORY.md files") that conflict with this
+# harness's own task tracker and MEMORY.md auto-memory, and it duplicates the beads
+# guidance already in AGENTS.md. This hook ships only the useful, non-conflicting bit:
+# the unblocked-work list + an open count. See AGENTS.md "Beads session-context hook".
+# [OPUS-4.8]
+set -uo pipefail
+
+# Graceful no-op when bd isn't installed or this isn't a beads workspace.
+command -v bd >/dev/null 2>&1 || exit 0
+[ -d .beads ] || exit 0
+
+ready="$(bd ready 2>/dev/null | head -25)"
+[ -n "$ready" ] || ready="(no unblocked beads right now — run 'bd ready')"
+open_count="$(bd count --status open 2>/dev/null | tr -dc '0-9')"
+[ -n "$open_count" ] || open_count="?"
+
+ctx="Beads (bd) is the task tracker for this repo (source of truth: .beads/issues.jsonl — never edit it directly; use bd commands). Unblocked work right now:
+${ready}
+
+(${open_count} open beads total. Use 'bd ready', 'bd show <id>', 'bd create \"title\" -t task -p 2'. Title is POSITIONAL; valid --type: bug|feature|task|epic|chore. Full workflow: AGENTS.md 'Task tracking — beads'.)"
+
+# Emit as SessionStart additionalContext (injected into the model's context at session start).
+python3 -c 'import json,sys; print(json.dumps({"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":sys.argv[1]}}))' "$ctx"

--- a/scripts/bd-session-context.sh
+++ b/scripts/bd-session-context.sh
@@ -10,6 +10,12 @@
 # [OPUS-4.8]
 set -uo pipefail
 
+# Always operate from the repo root, regardless of the CWD the hook is invoked from
+# (the script lives in <root>/scripts/). Otherwise the relative `.beads/` check below
+# would wrongly no-op when Claude runs hooks from a subdirectory. (Copilot review, PR #30)
+script_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 0
+cd "$script_dir/.." 2>/dev/null || exit 0
+
 # Graceful no-op when bd isn't installed or this isn't a beads workspace.
 command -v bd >/dev/null 2>&1 || exit 0
 [ -d .beads ] || exit 0
@@ -22,7 +28,7 @@ open_count="$(bd count --status open 2>/dev/null | tr -dc '0-9')"
 ctx="Beads (bd) is the task tracker for this repo (source of truth: .beads/issues.jsonl — never edit it directly; use bd commands). Unblocked work right now:
 ${ready}
 
-(${open_count} open beads total. Use 'bd ready', 'bd show <id>', 'bd create \"title\" -t task -p 2'. Title is POSITIONAL; valid --type: bug|feature|task|epic|chore. Full workflow: AGENTS.md 'Task tracking — beads'.)"
+(${open_count} open beads total. Use 'bd ready', 'bd show <id>', 'bd create \"title\" -t task -p 2'. Title is POSITIONAL; --type is one of bug|feature|task|epic|chore|spike (run 'bd types' for the full list). Full workflow: AGENTS.md 'Task tracking — beads'.)"
 
 # Emit as SessionStart additionalContext (injected into the model's context at session start).
 python3 -c 'import json,sys; print(json.dumps({"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":sys.argv[1]}}))' "$ctx"


### PR DESCRIPTION
## What
Wires a thin `.claude/settings.json` **SessionStart hook** (`scripts/bd-session-context.sh`) that injects the `bd ready` list + open-bead count at the start of every Claude Code session — so a new or **post-compaction** session recovers this repo's task state automatically (the exact pain that hit at the start of the last session).

## Why not `bd setup claude` / `bd prime`
`bd prime`'s injected content includes generic rules (*"do NOT use TaskCreate"*, *"do NOT use MEMORY.md files"*) that **conflict** with this harness's task tracker + auto-memory, and the doc block it writes **duplicates** the "Task tracking — beads" section already in AGENTS.md (violates our no-duplication hygiene). This hook ships only the useful, non-conflicting part.

## Details
- Graceful no-op when `bd` isn't installed or `.beads/` is absent.
- Emits `SessionStart` `additionalContext` JSON (verified locally: valid JSON, ~3.1k chars).
- Documented in AGENTS.md "Beads session-context hook". Takes effect on next session start / `/hooks` reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)