### PR TITLE
fix: roborev backlog — gitignore scope, HDT streaming sniff, SHACL README, resolve_iri test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,13 @@ STATUS.md
 /.claude/worktrees/
 
 # Beads / Dolt files (added by bd init)
+# [OPUS-4.8] Scope the Dolt/SQLite ignore to .beads/ so legitimate *.db
+# fixtures elsewhere in the tree are NOT silently hidden from `git add`.
+# (The generated DBs live under .beads/, which also ships its own .gitignore.)
 .dolt/
-*.db
+.beads/*.db
+.beads/*.db-journal
+.beads/*.db-wal
+.beads/*.db-shm
 .beads-credential-key
 .beads/proxieddb/

--- a/crates/sparq-hdt/src/lib.rs
+++ b/crates/sparq-hdt/src/lib.rs
@@ -119,20 +119,46 @@ enum Container {
     None,
 }
 
-/// Sniffs the container from the head of the stream WITHOUT consuming it (peeks
-/// the [`BufRead`] buffer). `.hdt` magic itself is `$HDT` (`24 48 44 54`); any
-/// non-compression head is returned as [`Container::None`] and passed through.
-fn sniff_container<R: BufRead>(reader: &mut R) -> std::io::Result<Container> {
-    let buf = reader.fill_buf()?;
-    Ok(if buf.len() >= 2 && buf[0] == 0x1f && buf[1] == 0x8b {
+/// The longest magic prefix we need to classify a container (zstd's `28 b5 2f
+/// fd`). gzip is 2, bzip2 3, zstd 4 — reading 4 covers all of them.
+const MAGIC_PREFIX_LEN: usize = 4;
+
+/// Reads up to [`MAGIC_PREFIX_LEN`] bytes off the front of `reader` into an owned
+/// buffer and classifies the container by its magic bytes.
+///
+/// [OPUS-4.8] roborev 2272: a streaming [`BufRead`] may legally return fewer
+/// bytes than requested per `fill_buf()` — even a single byte — so peeking the
+/// buffer once (`buf.len() >= N`) can misclassify a real gzip/zstd/bzip2 stream
+/// as bare HDT and fail the load. We instead drain a fixed-size prefix robustly
+/// (looping `read` until EOF or the buffer is full, the same contract as
+/// `read_exact` but tolerant of a short stream), and the caller chains that
+/// owned prefix back onto the remaining reader for EVERY path — so detection
+/// never depends on how the underlying reader chunks its data.
+fn sniff_prefix<R: BufRead>(reader: &mut R) -> std::io::Result<(Vec<u8>, Container)> {
+    // `BufRead: Read`, so `read` is available without an extra import.
+    let mut prefix = [0u8; MAGIC_PREFIX_LEN];
+    let mut filled = 0;
+    // Loop because a single `read` may return fewer bytes than requested even
+    // when more data is available (it is not an error). Stop on a 0-length read
+    // (genuine EOF) so an HDT shorter than the prefix still classifies correctly.
+    while filled < MAGIC_PREFIX_LEN {
+        let n = reader.read(&mut prefix[filled..])?;
+        if n == 0 {
+            break;
+        }
+        filled += n;
+    }
+    let prefix = prefix[..filled].to_vec();
+    let container = if filled >= 2 && prefix[0] == 0x1f && prefix[1] == 0x8b {
         Container::Gzip
-    } else if buf.len() >= 4 && buf[..4] == [0x28, 0xb5, 0x2f, 0xfd] {
+    } else if filled >= 4 && prefix[..4] == [0x28, 0xb5, 0x2f, 0xfd] {
         Container::Zstd
-    } else if buf.len() >= 3 && buf[..3] == [0x42, 0x5a, 0x68] {
+    } else if filled >= 3 && prefix[..3] == [0x42, 0x5a, 0x68] {
         Container::Bzip2
     } else {
         Container::None
-    })
+    };
+    Ok((prefix, container))
 }
 
 /// Runs `f` over the (transparently decompressed) HDT byte stream. A stream
@@ -141,31 +167,43 @@ fn sniff_container<R: BufRead>(reader: &mut R) -> std::io::Result<Container> {
 /// fully materialized, it is decoded on demand as `f` reads it; anything else is
 /// passed through unchanged. Detection is by CONTENT, not file name.
 fn with_hdt_stream<T>(
-    mut reader: impl BufRead,
+    reader: impl BufRead,
     f: impl FnOnce(&mut dyn BufRead) -> Result<T, Error>,
 ) -> Result<T, Error> {
-    match sniff_container(&mut reader)? {
+    // [OPUS-4.8] roborev 2272: consume a fixed magic-byte prefix robustly, then
+    // chain it back so the decoder/HDT reader sees the full, unmodified stream —
+    // both the compressed and the bare-HDT path. `Read::chain` re-prepends the
+    // owned prefix; we wrap the chain in a `BufReader` to satisfy the `BufRead`
+    // bound the decoders need (the prefix is at most 4 bytes, so this adds no
+    // meaningful buffering cost on the bare-HDT path).
+    let mut reader = reader;
+    let (prefix, container) = sniff_prefix(&mut reader)?;
+    let stream = std::io::Read::chain(std::io::Cursor::new(prefix), reader);
+    let stream = std::io::BufReader::new(stream);
+    match container {
         // `MultiGzDecoder` / `MultiBzDecoder` already buffer per the `bufread`
         // input, but their `Read` output needs a `BufRead` for the HDT reader;
-        // zstd's `Decoder` likewise. One wrapping `BufReader` each — no double
-        // buffering on the bare-HDT path (it is already a `BufRead`).
+        // zstd's `Decoder` likewise. One wrapping `BufReader` each.
         Container::Gzip => {
-            let mut d = std::io::BufReader::new(flate2::bufread::MultiGzDecoder::new(reader));
+            let mut d = std::io::BufReader::new(flate2::bufread::MultiGzDecoder::new(stream));
             f(&mut d)
         }
         Container::Zstd => {
             // `zstd::stream::read::Decoder::with_buffer` takes a `BufRead` source
             // directly (no inner re-buffer); its output is wrapped once.
-            let dec = zstd::stream::read::Decoder::with_buffer(reader)
+            let dec = zstd::stream::read::Decoder::with_buffer(stream)
                 .map_err(Error::Io)?;
             let mut d = std::io::BufReader::new(dec);
             f(&mut d)
         }
         Container::Bzip2 => {
-            let mut d = std::io::BufReader::new(bzip2::bufread::MultiBzDecoder::new(reader));
+            let mut d = std::io::BufReader::new(bzip2::bufread::MultiBzDecoder::new(stream));
             f(&mut d)
         }
-        Container::None => f(&mut reader),
+        Container::None => {
+            let mut d = stream;
+            f(&mut d)
+        }
     }
 }
 
@@ -379,5 +417,81 @@ mod tests {
         assert!(intern_hdt_term(&mut dict, "\"x\"^^<>").is_err());
         assert!(intern_hdt_term(&mut dict, "\"x\"!!").is_err());
         assert!(intern_hdt_term(&mut dict, "").is_err());
+    }
+
+    // [OPUS-4.8] roborev 2272 regression: a `BufRead` that hands back exactly
+    // ONE byte per `fill_buf()`/`read()` (a legal streaming reader) must not
+    // defeat magic-byte container detection, and the consumed prefix must be
+    // chained back so the downstream reader sees the full, unmodified stream.
+    struct OneByteAtATime<'a> {
+        data: &'a [u8],
+        pos: usize,
+    }
+
+    impl std::io::Read for OneByteAtATime<'_> {
+        fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+            if self.pos >= self.data.len() || out.is_empty() {
+                return Ok(0);
+            }
+            out[0] = self.data[self.pos];
+            self.pos += 1;
+            Ok(1) // never more than one byte, even when more is available
+        }
+    }
+
+    impl BufRead for OneByteAtATime<'_> {
+        fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+            // Expose at most ONE byte of the available buffer — the worst case a
+            // streaming reader may legally present.
+            let end = (self.pos + 1).min(self.data.len());
+            Ok(&self.data[self.pos..end])
+        }
+        fn consume(&mut self, amt: usize) {
+            self.pos = (self.pos + amt).min(self.data.len());
+        }
+    }
+
+    #[test]
+    fn one_byte_at_a_time_detects_containers() {
+        // gzip / zstd / bzip2 magic + a bare-HDT head must all classify the same
+        // way they would if delivered in one chunk, even at 1 byte per read.
+        for (bytes, want) in [
+            (vec![0x1f, 0x8b, 0x00, 0x00], Container::Gzip),
+            (vec![0x28, 0xb5, 0x2f, 0xfd], Container::Zstd),
+            (vec![0x42, 0x5a, 0x68, 0x39], Container::Bzip2),
+            (b"$HDT".to_vec(), Container::None),
+        ] {
+            let mut r = OneByteAtATime { data: &bytes, pos: 0 };
+            let (prefix, got) = sniff_prefix(&mut r).unwrap();
+            assert_eq!(got, want, "classification for {bytes:02x?}");
+            // The whole 4-byte prefix is preserved (none dropped or duplicated).
+            assert_eq!(prefix, &bytes[..MAGIC_PREFIX_LEN.min(bytes.len())]);
+        }
+    }
+
+    #[test]
+    fn prefix_is_chained_back_for_passthrough() {
+        // A bare-HDT stream delivered 1 byte at a time must round-trip BYTE-FOR-BYTE
+        // through `with_hdt_stream` (the prefix is re-prepended, not lost).
+        let payload = b"$HDT then some more dictionary/triples bytes here".to_vec();
+        let r = OneByteAtATime { data: &payload, pos: 0 };
+        let round_tripped = with_hdt_stream(r, |reader| {
+            let mut v = Vec::new();
+            std::io::Read::read_to_end(reader, &mut v).map_err(Error::Io)?;
+            Ok(v)
+        })
+        .unwrap();
+        assert_eq!(round_tripped, payload);
+    }
+
+    #[test]
+    fn short_stream_below_prefix_len_classifies_as_none() {
+        // A stream shorter than the magic prefix must not hang or misclassify.
+        for bytes in [vec![], vec![0x24], vec![0x24, 0x48], vec![0x24, 0x48, 0x44]] {
+            let mut r = OneByteAtATime { data: &bytes, pos: 0 };
+            let (prefix, got) = sniff_prefix(&mut r).unwrap();
+            assert_eq!(got, Container::None);
+            assert_eq!(prefix, bytes);
+        }
     }
 }

--- a/crates/sparq-reason/src/n3/parser.rs
+++ b/crates/sparq-reason/src/n3/parser.rs
@@ -1238,3 +1238,63 @@ fn utf8_len(b: u8) -> usize {
         4
     }
 }
+
+#[cfg(test)]
+mod resolve_iri_tests {
+    use super::resolve_iri;
+
+    // [OPUS-4.8] roborev 2318 regression: excess `..` segments must NOT ascend
+    // above the path root and swallow the authority (RFC 3986 §5.2.4 step 2C:
+    // a leading `..` against an empty/root output buffer is discarded, never
+    // popping past root). The finding claimed `../../../x` against
+    // `http://example.org/a/b/c.n3` would yield `http://example.orgx`.
+    #[test]
+    fn excess_dotdot_does_not_pop_root() {
+        assert_eq!(
+            resolve_iri("http://example.org/a/b/c.n3", "../../../x"),
+            "http://example.org/x"
+        );
+        // Exactly enough `..` to reach root, plus more, all clamp at root.
+        assert_eq!(
+            resolve_iri("http://example.org/a/b/c.n3", "../../x"),
+            "http://example.org/x"
+        );
+        assert_eq!(
+            resolve_iri("http://example.org/a/b/c.n3", "../x"),
+            "http://example.org/a/x"
+        );
+        // Authority is preserved even with a single excess `..` from a shallow base.
+        assert_eq!(
+            resolve_iri("http://example.org/a", "../../x"),
+            "http://example.org/x"
+        );
+    }
+
+    // RFC 3986 §5.4 normal + abnormal reference-resolution examples (the ones
+    // exercising dot-segment removal), against base `http://a/b/c/d;p?q`.
+    #[test]
+    fn rfc3986_dot_segment_examples() {
+        let base = "http://a/b/c/d;p?q";
+        for (rel, want) in [
+            ("g", "http://a/b/c/g"),
+            ("./g", "http://a/b/c/g"),
+            ("g/", "http://a/b/c/g/"),
+            ("/g", "http://a/g"),
+            ("..", "http://a/b/"),
+            ("../", "http://a/b/"),
+            ("../g", "http://a/b/g"),
+            ("../..", "http://a/"),
+            ("../../", "http://a/"),
+            ("../../g", "http://a/g"),
+            // Abnormal: extra `..` must not climb past root.
+            ("../../../g", "http://a/g"),
+            ("../../../../g", "http://a/g"),
+            ("/./g", "http://a/g"),
+            ("/../g", "http://a/g"),
+            (".", "http://a/b/c/"),
+            ("./", "http://a/b/c/"),
+        ] {
+            assert_eq!(resolve_iri(base, rel), want, "rel={rel}");
+        }
+    }
+}

--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -56,8 +56,21 @@ property shapes), each solution a violation; honours `sh:prefixes`
 `sh:message` (`{?var}` templating). Maps `?value`→`sh:value` (defaulting to the
 focus node when unprojected), `?path`→`sh:resultPath`, `?message`→
 `sh:resultMessage`. Pinned by the W3C `sparql/node` + `sparql/property`
-sub-suites. SPARQL-based constraint *components* (custom `sh:ConstraintComponent`
-with `sh:parameter`/`sh:validator`) are deferred — see the open beads for this crate (`bd list -l area:sparq-shacl`).
+sub-suites.
+
+**SPARQL-based constraint *components* (custom `sh:ConstraintComponent`, §6):**
+implemented. A component node — typed `sh:ConstraintComponent` or any
+`rdfs:subClassOf*` descendant — declaring `sh:parameter`s and a validator
+(`sh:validator`, or the kind-specific `sh:nodeValidator`/`sh:propertyValidator`,
+chosen per shape kind, §6.2.2) activates on any shape that carries the
+parameter predicates. The validator runs with `$this`, `$value`, each parameter
+VALUE (`$paramName`) and (on a property shape) `$PATH` pre-bound; `sh:ask`
+validators run per value node (`false` ⇒ violation), `sh:select` validators run
+per focus node (each solution a violation, §6.3). `sh:optional true` parameters
+need not be present. The component's IRI is the
+`sh:sourceConstraintComponent`. The remaining §6 limit is the full
+`sparql/pre-binding` semantics (rejecting variable re-binding, `$shapesGraph`) —
+see the open beads for this crate (`bd list -l area:sparq-shacl`).
 
 Targets: `sh:targetNode`, `sh:targetClass` (with `rdfs:subClassOf*` closure),
 implicit class targets (a shape that is itself an `rdfs:Class`),
@@ -128,10 +141,13 @@ for data in data_graphs {
 
 ## Scope and non-goals
 
-- **SHACL Core + `sh:sparql`.** The SPARQL-based constraint *component*
-  declaration machinery (custom `sh:ConstraintComponent` with `sh:parameter` /
-  `sh:validator`) and the full `sparql/pre-binding` semantics (rejecting
-  variable re-binding, `$shapesGraph`) are out of scope; see the open beads for this crate (`bd list -l area:sparq-shacl`).
+- **SHACL Core + `sh:sparql` + custom §6 components.** SHACL Core, `sh:sparql`
+  (§5.2) and the SPARQL-based constraint *component* declaration machinery
+  (custom `sh:ConstraintComponent` with `sh:parameter` / `sh:validator`, §6) are
+  all implemented (see "Supported constraint components" above). What remains out
+  of scope is the full `sparql/pre-binding` semantics (rejecting variable
+  re-binding, `$shapesGraph`); see the open beads for this crate
+  (`bd list -l area:sparq-shacl`).
 - Validation results are **not deduplicated** across traversal routes /
   component occurrences — matching the test suite's expectations (a nested
   shape reached through two parents reports twice).

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -227,9 +227,9 @@ let g = sparq_shacl::load_turtle_with_base(&text, &format!("file://{path}")).unw
 - **W3C conformance:** 98/98 of the core `sht:Validate` suite passes. Reproduce with
   `crates/sparq-shacl/fetch-shacl-tests.sh` then
   `cargo test -p sparq-shacl --test w3c_core` (self-skips if the gitignored suite is absent).
-- Note: the crate README still lists §6 SPARQL-based constraint *components* as
-  "deferred" — that line is stale; they are implemented and tested
-  (`tests/sparql_components.rs`).
+- §6 SPARQL-based constraint *components* are implemented and tested
+  (`tests/sparql_components.rs`); the crate README documents them under
+  "Supported constraint components".
 
 ## See also
 


### PR DESCRIPTION
Addresses 4 roborev (codex) findings filed against landed main commits, each verified vs HEAD:
- **2257** `.gitignore` `*.db` was too broad → scoped to `.beads/` (legit SQLite fixtures no longer hidden).
- **2272** `sparq-hdt` `is_gzip`/container-sniff assumed `fill_buf()` returns ≥2 bytes → robust looped magic-byte sniff that chains the consumed prefix back; +3 tests with a 1-byte-at-a-time `BufRead`.
- **2387** `sparq-shacl` README claimed custom §6 SPARQL `sh:ConstraintComponent` is 'deferred' while the code implements + tests it → README/SKILL corrected.
- **2318 (Medium)** `sparq-reason` `resolve_iri` upward-traversal: verified **false-positive** (already correct) and locked it with a regression test (the exact case + 16 RFC3986 §5.4 examples).

11 other open findings were verified false-positive/already-resolved and closed directly with reasons. Gated in-worktree: clippy + tests green on the 4 touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)