### PR TITLE
test(sparq-geo): OGC GeoSPARQL compliance ratchet + DE-9IM differential vs geo crate (sq-9h1r)

### DIFF
--- a/crates/sparq-geo/tests/de9im_differential.rs
+++ b/crates/sparq-geo/tests/de9im_differential.rs
@@ -13,10 +13,16 @@
 //!   * `geof::sf_within(a,b)` against `geo::Contains` with operands swapped
 //!     (`geo` has no `Within` trait; `within(a,b) ≡ contains(b,a)`),
 //!
-//! and asserts agreement. A disagreement is therefore a real signal: either a
-//! bug in sparq-geo's wrapper or a genuine, documented semantic divergence
-//! between `Relate`-DE-9IM and the standalone predicate (see the
-//! [`KNOWN_DIVERGENCES`] handling below).
+//! and asserts agreement in the load-bearing direction. A disagreement there is
+//! a real signal: either a bug in sparq-geo's wrapper or a genuine semantic
+//! divergence between `Relate`-DE-9IM and the standalone predicate. The one
+//! known, deliberate divergence is on `sfContains`: OGC `contains` (via `Relate`,
+//! pattern `T*****FF*`) requires the operands' INTERIORS to intersect, so it is
+//! `false` for a sub-geometry lying entirely on the boundary, whereas
+//! `geo::Contains` can answer `true` for such boundary-only containment. The
+//! `sfContains` check below therefore only asserts the direction that catches an
+//! over-permissive bug (sparq-true must imply geo-true); the OGC
+//! interior-vs-boundary asymmetric case is not asserted on.
 //!
 //! It additionally checks the **DE-9IM matrix laws** that any correct relation
 //! set must obey (`sfDisjoint ≡ ¬sfIntersects`, `sfWithin(a,b) ≡
@@ -150,15 +156,16 @@ fn de9im_differential_vs_geo_predicates() {
         }
 
         // ---- sfContains vs geo::Contains ----------------------------------
-        // DOCUMENTED DIVERGENCE: the OGC simple-features `contains` (which
-        // sparq-geo implements via Relate, pattern `T*****FF*`) requires the
-        // operands' INTERIORS to intersect, so a geometry does NOT contain a
-        // sub-geometry that lies entirely on its boundary. `geo::Contains`
-        // uses a point-set ⊇ test on some type pairs and can answer `true`
-        // for a boundary-only containment. We therefore only assert agreement
-        // when geo::Contains is true AND interiors plausibly intersect; the
-        // asymmetric case is recorded but not failed (see report). The reverse
-        // (sparq true => geo true) is always required.
+        // [OPUS-4.8] DOCUMENTED DIVERGENCE: the OGC simple-features `contains`
+        // (which sparq-geo implements via Relate, pattern `T*****FF*`) requires
+        // the operands' INTERIORS to intersect, so a geometry does NOT contain a
+        // sub-geometry that lies entirely on its boundary. `geo::Contains` uses a
+        // point-set ⊇ test on some type pairs and can answer `true` for a
+        // boundary-only containment. So we assert ONLY the load-bearing
+        // direction: sparq-true must imply geo-true (an over-permissive
+        // sfContains is a bug). The reverse asymmetric case — geo-true while
+        // sparq-false (OGC interior-vs-boundary) — is the known divergence and is
+        // simply NOT asserted on here.
         let sparq_contains = geof::sf_contains(&a, &b).unwrap();
         let geo_contains = ga.contains(&gb);
         stats.contains_checked += 1;

--- a/crates/sparq-geo/tests/de9im_differential.rs
+++ b/crates/sparq-geo/tests/de9im_differential.rs
@@ -1,0 +1,385 @@
+//! [OPUS-4.8] sq-9h1r — DE-9IM differential vs the upstream `geo` crate.
+//!
+//! sparq-geo computes the eight simple-features relations via `geo`'s `Relate`
+//! (the DE-9IM IntersectionMatrix) and the Egenhofer / RCC8 families via
+//! hand-written DE-9IM *pattern strings* matched against that same matrix. `geo`
+//! ALSO ships standalone predicate traits — `Contains` and `Intersects` — whose
+//! implementations are SEPARATE from `Relate` (different algorithms, not a
+//! re-derivation of the matrix). This test is a **differential**: over a corpus
+//! of randomly-generated geometry pairs it cross-checks
+//!
+//!   * `geof::sf_intersects` against `geo::Intersects`,
+//!   * `geof::sf_contains`   against `geo::Contains`,
+//!   * `geof::sf_within(a,b)` against `geo::Contains` with operands swapped
+//!     (`geo` has no `Within` trait; `within(a,b) ≡ contains(b,a)`),
+//!
+//! and asserts agreement. A disagreement is therefore a real signal: either a
+//! bug in sparq-geo's wrapper or a genuine, documented semantic divergence
+//! between `Relate`-DE-9IM and the standalone predicate (see the
+//! [`KNOWN_DIVERGENCES`] handling below).
+//!
+//! It additionally checks the **DE-9IM matrix laws** that any correct relation
+//! set must obey (`sfDisjoint ≡ ¬sfIntersects`, `sfWithin(a,b) ≡
+//! sfContains(b,a)`, the eh/rcc8 families partition region space, eh/rcc8 vs the
+//! generic `geof::relate` pattern), exercising the hand-written eh/rcc8 patterns
+//! against the matrix `geo` computes — the part of sparq-geo that is NOT a thin
+//! pass-through and where a wrong pattern string would hide.
+//!
+//! Corpus: deterministically seeded (reproducible). Size is reported in the test
+//! output and asserted to exceed [`MIN_CORPUS_PAIRS`].
+
+use geo::{Contains, Intersects};
+use geo_types::{Coord, Geometry, LineString, Point, Polygon};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use sparq_geo::geof;
+use sparq_geo::{GeoGeometry, Crs};
+
+/// The differential must run over at least this many generated pairs, so the
+/// corpus can't silently shrink to nothing.
+const MIN_CORPUS_PAIRS: usize = 400;
+
+/// Build a CRS84 [`GeoGeometry`] around an existing geo-types geometry.
+fn g(geometry: Geometry<f64>) -> GeoGeometry {
+    GeoGeometry { crs: Crs::Crs84, geometry }
+}
+
+/// A small axis-aligned square of side `s` with lower-left corner `(x, y)`.
+fn square(x: f64, y: f64, s: f64) -> Geometry<f64> {
+    Geometry::Polygon(Polygon::new(
+        LineString(vec![
+            Coord { x, y },
+            Coord { x: x + s, y },
+            Coord { x: x + s, y: y + s },
+            Coord { x, y: y + s },
+            Coord { x, y },
+        ]),
+        vec![],
+    ))
+}
+
+/// A random geometry drawn from points, segments, and squares on an integer-ish
+/// lattice (so pairs frequently share vertices / edges — the topologically
+/// interesting cases, not just disjoint blobs).
+fn random_geometry(rng: &mut StdRng) -> Geometry<f64> {
+    // Snap to a coarse lattice so touches / equals / collinear-overlap occur
+    // with meaningful frequency.
+    let coord = |rng: &mut StdRng| -> f64 { rng.random_range(0..6) as f64 };
+    match rng.random_range(0..4) {
+        0 => Geometry::Point(Point::new(coord(rng), coord(rng))),
+        1 => {
+            let (x0, y0, x1, y1) = (coord(rng), coord(rng), coord(rng), coord(rng));
+            Geometry::LineString(LineString(vec![
+                Coord { x: x0, y: y0 },
+                Coord { x: x1, y: y1 },
+            ]))
+        }
+        2 => {
+            // A two-segment polyline.
+            Geometry::LineString(LineString(vec![
+                Coord { x: coord(rng), y: coord(rng) },
+                Coord { x: coord(rng), y: coord(rng) },
+                Coord { x: coord(rng), y: coord(rng) },
+            ]))
+        }
+        _ => {
+            let s = rng.random_range(1..3) as f64;
+            square(coord(rng), coord(rng), s)
+        }
+    }
+}
+
+/// Skip degenerate inputs the relation algebra treats as empty (a zero-length
+/// segment, a zero-area "square"). They are not interesting for the differential
+/// and `geo`'s predicates and `Relate` can legitimately differ on empties.
+fn is_degenerate(geom: &Geometry<f64>) -> bool {
+    match geom {
+        Geometry::LineString(ls) => {
+            ls.0.windows(2).all(|w| w[0] == w[1])
+        }
+        Geometry::Polygon(p) => {
+            use geo::Area;
+            p.unsigned_area() == 0.0
+        }
+        _ => false,
+    }
+}
+
+struct Stats {
+    pairs: usize,
+    intersects_checked: usize,
+    contains_checked: usize,
+    within_checked: usize,
+    disagreements: Vec<String>,
+}
+
+#[test]
+fn de9im_differential_vs_geo_predicates() {
+    let mut rng = StdRng::seed_from_u64(0x9417_2026_u64);
+    let mut stats = Stats {
+        pairs: 0,
+        intersects_checked: 0,
+        contains_checked: 0,
+        within_checked: 0,
+        disagreements: Vec::new(),
+    };
+
+    // Generate pairs; keep only non-degenerate ones.
+    let mut generated = 0usize;
+    while stats.pairs < 500 && generated < 20_000 {
+        generated += 1;
+        let ga = random_geometry(&mut rng);
+        let gb = random_geometry(&mut rng);
+        if is_degenerate(&ga) || is_degenerate(&gb) {
+            continue;
+        }
+        stats.pairs += 1;
+        let a = g(ga.clone());
+        let b = g(gb.clone());
+
+        // ---- sfIntersects vs geo::Intersects (separate impl) --------------
+        let sparq_inter = geof::sf_intersects(&a, &b).unwrap();
+        let geo_inter = ga.intersects(&gb);
+        stats.intersects_checked += 1;
+        if sparq_inter != geo_inter {
+            stats.disagreements.push(format!(
+                "INTERSECTS sparq={sparq_inter} geo={geo_inter} | a={} b={}",
+                a.to_wkt_literal(),
+                b.to_wkt_literal()
+            ));
+        }
+
+        // ---- sfContains vs geo::Contains ----------------------------------
+        // DOCUMENTED DIVERGENCE: the OGC simple-features `contains` (which
+        // sparq-geo implements via Relate, pattern `T*****FF*`) requires the
+        // operands' INTERIORS to intersect, so a geometry does NOT contain a
+        // sub-geometry that lies entirely on its boundary. `geo::Contains`
+        // uses a point-set ⊇ test on some type pairs and can answer `true`
+        // for a boundary-only containment. We therefore only assert agreement
+        // when geo::Contains is true AND interiors plausibly intersect; the
+        // asymmetric case is recorded but not failed (see report). The reverse
+        // (sparq true => geo true) is always required.
+        let sparq_contains = geof::sf_contains(&a, &b).unwrap();
+        let geo_contains = ga.contains(&gb);
+        stats.contains_checked += 1;
+        if sparq_contains && !geo_contains {
+            stats.disagreements.push(format!(
+                "CONTAINS sparq=true geo=false (sparq stronger — bug) | a={} b={}",
+                a.to_wkt_literal(),
+                b.to_wkt_literal()
+            ));
+        }
+
+        // ---- sfWithin(a,b) vs geo::Contains(b,a) --------------------------
+        let sparq_within = geof::sf_within(&a, &b).unwrap();
+        let geo_b_contains_a = gb.contains(&ga);
+        stats.within_checked += 1;
+        if sparq_within && !geo_b_contains_a {
+            stats.disagreements.push(format!(
+                "WITHIN sparq=true (b.contains(a))=false (sparq stronger — bug) | a={} b={}",
+                a.to_wkt_literal(),
+                b.to_wkt_literal()
+            ));
+        }
+    }
+
+    println!("\nDE-9IM differential vs geo crate predicates");
+    println!(
+        "corpus pairs {} (generated {generated}); checks: intersects {}, contains {}, within {}",
+        stats.pairs, stats.intersects_checked, stats.contains_checked, stats.within_checked
+    );
+    for d in &stats.disagreements {
+        println!("  DISAGREE {d}");
+    }
+
+    assert!(
+        stats.pairs >= MIN_CORPUS_PAIRS,
+        "corpus too small: {} < {MIN_CORPUS_PAIRS}",
+        stats.pairs
+    );
+    assert!(
+        stats.disagreements.is_empty(),
+        "{} differential disagreement(s) vs the geo crate:\n{}",
+        stats.disagreements.len(),
+        stats.disagreements.join("\n")
+    );
+}
+
+/// The DE-9IM relation algebra laws, checked over the same generated corpus.
+/// These exercise the hand-written eh/rcc8 DE-9IM patterns against the matrix
+/// `geo` computes (the non-pass-through part of sparq-geo), plus the structural
+/// invariants every correct relation set obeys.
+#[test]
+fn de9im_relation_laws_hold_over_corpus() {
+    let mut rng = StdRng::seed_from_u64(0xC0FFEE_u64);
+    let mut pairs = 0usize;
+    let mut region_pairs = 0usize;
+    let mut violations: Vec<String> = Vec::new();
+
+    let mut generated = 0usize;
+    while pairs < 500 && generated < 20_000 {
+        generated += 1;
+        let ga = random_geometry(&mut rng);
+        let gb = random_geometry(&mut rng);
+        if is_degenerate(&ga) || is_degenerate(&gb) {
+            continue;
+        }
+        pairs += 1;
+        let a = g(ga.clone());
+        let b = g(gb.clone());
+
+        // Law 1: disjoint == not intersects (a DE-9IM tautology).
+        let disjoint = geof::sf_disjoint(&a, &b).unwrap();
+        let intersects = geof::sf_intersects(&a, &b).unwrap();
+        if disjoint == intersects {
+            violations.push(format!(
+                "disjoint({disjoint}) should be ¬intersects({intersects}) | a={} b={}",
+                a.to_wkt_literal(),
+                b.to_wkt_literal()
+            ));
+        }
+
+        // Law 2: within(a,b) == contains(b,a).
+        let within = geof::sf_within(&a, &b).unwrap();
+        let contains_ba = geof::sf_contains(&b, &a).unwrap();
+        if within != contains_ba {
+            violations.push(format!(
+                "within(a,b)={within} != contains(b,a)={contains_ba} | a={} b={}",
+                a.to_wkt_literal(),
+                b.to_wkt_literal()
+            ));
+        }
+
+        // Law 3: equals is symmetric.
+        if geof::sf_equals(&a, &b).unwrap() != geof::sf_equals(&b, &a).unwrap() {
+            violations.push(format!(
+                "equals not symmetric | a={} b={}",
+                a.to_wkt_literal(),
+                b.to_wkt_literal()
+            ));
+        }
+
+        // Law 4: touches is symmetric.
+        if geof::sf_touches(&a, &b).unwrap() != geof::sf_touches(&b, &a).unwrap() {
+            violations.push(format!(
+                "touches not symmetric | a={} b={}",
+                a.to_wkt_literal(),
+                b.to_wkt_literal()
+            ));
+        }
+
+        // Region-only laws: the eh/rcc8 families PARTITION region-region space —
+        // exactly one relation per family is true for any pair of regions
+        // (polygons with non-empty interior).
+        if matches!(ga, Geometry::Polygon(_)) && matches!(gb, Geometry::Polygon(_)) {
+            region_pairs += 1;
+            // Egenhofer family (8 relations, mutually exclusive + exhaustive).
+            let eh = [
+                geof::eh_equals(&a, &b).unwrap(),
+                geof::eh_disjoint(&a, &b).unwrap(),
+                geof::eh_meet(&a, &b).unwrap(),
+                geof::eh_overlap(&a, &b).unwrap(),
+                geof::eh_covers(&a, &b).unwrap(),
+                geof::eh_covered_by(&a, &b).unwrap(),
+                geof::eh_inside(&a, &b).unwrap(),
+                geof::eh_contains(&a, &b).unwrap(),
+            ];
+            let eh_true = eh.iter().filter(|x| **x).count();
+            if eh_true != 1 {
+                violations.push(format!(
+                    "Egenhofer family non-partition: {eh_true} true (expected 1) | a={} b={}",
+                    a.to_wkt_literal(),
+                    b.to_wkt_literal()
+                ));
+            }
+            // RCC8 family (8 relations, mutually exclusive + exhaustive).
+            let rcc8 = [
+                geof::rcc8_eq(&a, &b).unwrap(),
+                geof::rcc8_dc(&a, &b).unwrap(),
+                geof::rcc8_ec(&a, &b).unwrap(),
+                geof::rcc8_po(&a, &b).unwrap(),
+                geof::rcc8_tpp(&a, &b).unwrap(),
+                geof::rcc8_tppi(&a, &b).unwrap(),
+                geof::rcc8_ntpp(&a, &b).unwrap(),
+                geof::rcc8_ntppi(&a, &b).unwrap(),
+            ];
+            let rcc8_true = rcc8.iter().filter(|x| **x).count();
+            if rcc8_true != 1 {
+                violations.push(format!(
+                    "RCC8 family non-partition: {rcc8_true} true (expected 1) | a={} b={}",
+                    a.to_wkt_literal(),
+                    b.to_wkt_literal()
+                ));
+            }
+        }
+    }
+
+    println!("\nDE-9IM relation laws over corpus");
+    println!("pairs {pairs} ({region_pairs} region-region pairs)");
+    for v in &violations {
+        println!("  VIOLATION {v}");
+    }
+    assert!(pairs >= MIN_CORPUS_PAIRS, "corpus too small: {pairs} < {MIN_CORPUS_PAIRS}");
+    assert!(region_pairs > 0, "no region-region pairs generated — partition laws untested");
+    assert!(
+        violations.is_empty(),
+        "{} DE-9IM relation-law violation(s):\n{}",
+        violations.len(),
+        violations.join("\n")
+    );
+}
+
+/// The eh/rcc8 families are derived from hand-written DE-9IM pattern strings;
+/// cross-check each against the GENERIC `geof::relate(a, b, pattern)` (which
+/// matches the SAME pattern against `geo`'s matrix) for a representative region
+/// pair set — guarding the literal pattern strings in the macros against a typo.
+#[test]
+fn eh_rcc8_patterns_match_generic_relate() {
+    // (relation fn, its single canonical DE-9IM pattern). The multi-pattern
+    // relations (ehMeet) are excluded — they are a disjunction, not one matrix.
+    const SMALL: &str = "POLYGON((1 1, 2 1, 2 2, 1 2, 1 1))";
+    const BIG: &str = "POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))";
+    const TANGENT: &str = "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))";
+    const FAR: &str = "POLYGON((9 9, 10 9, 10 10, 9 10, 9 9))";
+    const ADJ: &str = "POLYGON((4 0, 6 0, 6 2, 4 2, 4 0))";
+    const OVL: &str = "POLYGON((3 3, 6 3, 6 6, 3 6, 3 3))";
+    let regions = [SMALL, BIG, TANGENT, FAR, ADJ, OVL];
+
+    type Rel = fn(&str, &str) -> Result<bool, GeoError>;
+    use sparq_geo::geof::lex;
+    use sparq_geo::GeoError;
+    // Single-matrix relations and the DE-9IM pattern the spec assigns them.
+    let single_pattern: &[(Rel, &str)] = &[
+        (lex::eh_equals, "TFFFTFFFT"),
+        (lex::eh_overlap, "T*T***T**"),
+        (lex::eh_covers, "T*TFT*FF*"),
+        (lex::eh_covered_by, "TFF*TFT**"),
+        (lex::eh_inside, "TFF*FFT**"),
+        (lex::eh_contains, "T*TFF*FF*"),
+        (lex::rcc8_eq, "TFFFTFFFT"),
+        (lex::rcc8_dc, "FFTFFTTTT"),
+        (lex::rcc8_ec, "FFTFTTTTT"),
+        (lex::rcc8_po, "TTTTTTTTT"),
+        (lex::rcc8_tppi, "TTTFTTFFT"),
+        (lex::rcc8_tpp, "TFFTTFTTT"),
+        (lex::rcc8_ntpp, "TFFTFFTTT"),
+        (lex::rcc8_ntppi, "TTTFFTFFT"),
+    ];
+
+    let mut checks = 0usize;
+    for a in &regions {
+        for b in &regions {
+            for (rel, pattern) in single_pattern {
+                let via_named = rel(a, b).unwrap();
+                let via_generic = lex::relate(a, b, pattern).unwrap();
+                assert_eq!(
+                    via_named, via_generic,
+                    "pattern {pattern:?} mismatch on ({a}, {b}): named={via_named} generic={via_generic}"
+                );
+                checks += 1;
+            }
+        }
+    }
+    println!("\neh/rcc8 pattern cross-check: {checks} assertions");
+    assert!(checks > 0);
+}

--- a/crates/sparq-geo/tests/ogc_compliance_ratchet.rs
+++ b/crates/sparq-geo/tests/ogc_compliance_ratchet.rs
@@ -1,0 +1,415 @@
+//! [OPUS-4.8] sq-9h1r — OGC GeoSPARQL compliance ratchet.
+//!
+//! A fixture-gated, pass-count **ratchet** over a corpus of OGC GeoSPARQL
+//! conformance-style assertions: each fixture is a geometry pair, a `geof:`
+//! topology relation, and the expected boolean per the OGC GeoSPARQL
+//! specification (1.0 Req 22/25/26, 1.1 §9–10). The harness runs every
+//! assertion, counts passes, and enforces TWO invariants:
+//!
+//! 1. zero regressions — every fixture currently asserted MUST pass
+//!    (`assert_eq!(fail, 0)`), so a relation that starts disagreeing with the
+//!    hand-checked OGC truth value is a hard failure; and
+//! 2. a pass-count FLOOR ([`OGC_RATCHET_FLOOR`]) that may only RISE — mirrors
+//!    the SHACL W3C ratchet (`crates/sparq-shacl/tests/w3c_sparql.rs`) and the
+//!    conformance-suite ratchets, so deleting coverage below the recorded floor
+//!    fails the build.
+//!
+//! This is a HAND-CURATED conformance set, NOT the official OGC TEAM Engine /
+//! CITE test suite (that suite is a Java/HTTP harness over a live endpoint and
+//! is not vendored here). The fixtures are modelled on the relation semantics
+//! the OGC Simple Features / GeoSPARQL DE-9IM patterns define; the expected
+//! booleans are derived by hand from those matrices.
+//!
+//! ## OGC sub-conformance classes EXERCISED here
+//!
+//! * **Topology vocabulary extension — Simple Features (`geof:sf*`)**: all eight
+//!   relations (`sfEquals` `sfDisjoint` `sfIntersects` `sfTouches` `sfCrosses`
+//!   `sfWithin` `sfContains` `sfOverlaps`) over point / line / polygon operands,
+//!   in BOTH operand orders where the relation is order-sensitive.
+//! * **Topology vocabulary extension — Egenhofer (`geof:eh*`)**: all eight
+//!   (`ehEquals` `ehDisjoint` `ehMeet` `ehOverlap` `ehCovers` `ehCoveredBy`
+//!   `ehInside` `ehContains`) over REGION (polygon) pairs.
+//! * **Topology vocabulary extension — RCC8 (`geof:rcc8*`)**: all eight
+//!   (`rcc8eq` `rcc8dc` `rcc8ec` `rcc8po` `rcc8tpp` `rcc8tppi` `rcc8ntpp`
+//!   `rcc8ntppi`) over region pairs.
+//! * **Geometry serialization equivalence (GeoSPARQL §8.5)**: a subset of the
+//!   sf fixtures is ALSO run with one operand supplied as a `geo:gmlLiteral`
+//!   (GML-SF), asserting the WKT and GML serializations yield identical
+//!   topology results (the `gml_equivalence` test).
+//!
+//! ## OGC sub-conformance classes NOT exercised here (tracked as beads)
+//!
+//! * The official OGC CITE / TEAM-Engine conformance suite itself (live-endpoint
+//!   HTTP harness) — not vendored.
+//! * The RDFS/OWL **Geometry / Feature class** entailment requirements
+//!   (`geo:Feature`, `geo:Geometry`, the `geo:hasGeometry` reasoning rules).
+//! * The **query rewrite extension** (the `geo:sfWithin`-style triple-pattern
+//!   property forms, as opposed to the `geof:` filter functions tested here).
+//! * Non-topological `geof:` functions (`distance`, `buffer`, set operations,
+//!   `boundary`/`envelope`/`convexHull`) — covered by `tests/relations.rs`, not
+//!   this topology ratchet.
+
+use sparq_geo::geof::lex;
+use sparq_geo::GeoError;
+
+/// [OPUS-4.8] Pass-count FLOOR for the OGC topology compliance fixtures
+/// (sq-9h1r). A ratchet: it may only RISE. Set to the number of assertions in
+/// [`FIXTURES`] (expanded across both operand orders) at commit time; raising it
+/// is a deliberate act when fixtures are added.
+const OGC_RATCHET_FLOOR: usize = 119;
+
+/// One topology relation under test, named by its `geof:` local name and bound
+/// to its lexical-level implementation.
+type Rel = fn(&str, &str) -> Result<bool, GeoError>;
+
+/// The full set of topology relations the ratchet drives, grouped by family.
+fn all_relations() -> Vec<(&'static str, Rel)> {
+    vec![
+        // Simple Features (GeoSPARQL Req 22 / OGC SFA DE-9IM).
+        ("sfEquals", lex::sf_equals as Rel),
+        ("sfDisjoint", lex::sf_disjoint),
+        ("sfIntersects", lex::sf_intersects),
+        ("sfTouches", lex::sf_touches),
+        ("sfCrosses", lex::sf_crosses),
+        ("sfWithin", lex::sf_within),
+        ("sfContains", lex::sf_contains),
+        ("sfOverlaps", lex::sf_overlaps),
+        // Egenhofer (GeoSPARQL Req 25).
+        ("ehEquals", lex::eh_equals),
+        ("ehDisjoint", lex::eh_disjoint),
+        ("ehMeet", lex::eh_meet),
+        ("ehOverlap", lex::eh_overlap),
+        ("ehCovers", lex::eh_covers),
+        ("ehCoveredBy", lex::eh_covered_by),
+        ("ehInside", lex::eh_inside),
+        ("ehContains", lex::eh_contains),
+        // RCC8 (GeoSPARQL Req 26).
+        ("rcc8eq", lex::rcc8_eq),
+        ("rcc8dc", lex::rcc8_dc),
+        ("rcc8ec", lex::rcc8_ec),
+        ("rcc8po", lex::rcc8_po),
+        ("rcc8tpp", lex::rcc8_tpp),
+        ("rcc8tppi", lex::rcc8_tppi),
+        ("rcc8ntpp", lex::rcc8_ntpp),
+        ("rcc8ntppi", lex::rcc8_ntppi),
+    ]
+}
+
+/// A single OGC conformance assertion: `relation(a, b) == expected`.
+struct Fixture {
+    a: &'static str,
+    b: &'static str,
+    relation: &'static str,
+    expected: bool,
+}
+
+const fn fx(a: &'static str, b: &'static str, relation: &'static str, expected: bool) -> Fixture {
+    Fixture { a, b, relation, expected }
+}
+
+// Reusable geometries (named so the assertion list reads like the OGC matrices).
+const BIG: &str = "POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))";
+const BIG_REORDERED: &str = "POLYGON((4 0, 4 4, 0 4, 0 0, 4 0))";
+const SMALL_INSIDE: &str = "POLYGON((1 1, 2 1, 2 2, 1 2, 1 1))";
+const CORNER_TANGENT: &str = "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))";
+const EDGE_ADJACENT: &str = "POLYGON((4 0, 6 0, 6 2, 4 2, 4 0))";
+const FAR: &str = "POLYGON((9 9, 10 9, 10 10, 9 10, 9 9))";
+const OVERLAP: &str = "POLYGON((3 3, 6 3, 6 6, 3 6, 3 3))";
+
+/// The OGC conformance corpus. Each entry's expected boolean is hand-derived
+/// from the relation's DE-9IM matrix per the OGC GeoSPARQL specification.
+const FIXTURES: &[Fixture] = &[
+    // ---- Simple Features: polygon vs polygon -------------------------------
+    // Identical regions: equal, intersect, within, contains; not disjoint /
+    // touches / crosses / overlaps.
+    fx(BIG, BIG, "sfEquals", true),
+    fx(BIG, BIG, "sfDisjoint", false),
+    fx(BIG, BIG, "sfIntersects", true),
+    fx(BIG, BIG, "sfTouches", false),
+    fx(BIG, BIG, "sfCrosses", false),
+    fx(BIG, BIG, "sfWithin", true),
+    fx(BIG, BIG, "sfContains", true),
+    fx(BIG, BIG, "sfOverlaps", false),
+    // Same point set, different ring start vertex: still topologically equal.
+    fx(BIG, BIG_REORDERED, "sfEquals", true),
+    fx(BIG, BIG_REORDERED, "sfWithin", true),
+    fx(BIG, BIG_REORDERED, "sfContains", true),
+    // Small region strictly inside the big one.
+    fx(SMALL_INSIDE, BIG, "sfWithin", true),
+    fx(SMALL_INSIDE, BIG, "sfContains", false),
+    fx(SMALL_INSIDE, BIG, "sfIntersects", true),
+    fx(SMALL_INSIDE, BIG, "sfDisjoint", false),
+    fx(SMALL_INSIDE, BIG, "sfTouches", false),
+    fx(SMALL_INSIDE, BIG, "sfEquals", false),
+    fx(SMALL_INSIDE, BIG, "sfOverlaps", false),
+    // …and the reverse direction is contains.
+    fx(BIG, SMALL_INSIDE, "sfContains", true),
+    fx(BIG, SMALL_INSIDE, "sfWithin", false),
+    // Far-apart regions: disjoint.
+    fx(BIG, FAR, "sfDisjoint", true),
+    fx(BIG, FAR, "sfIntersects", false),
+    fx(BIG, FAR, "sfTouches", false),
+    fx(BIG, FAR, "sfEquals", false),
+    fx(BIG, FAR, "sfWithin", false),
+    fx(BIG, FAR, "sfContains", false),
+    // Edge-adjacent regions: touch (boundaries meet, interiors do not).
+    fx(BIG, EDGE_ADJACENT, "sfTouches", true),
+    fx(BIG, EDGE_ADJACENT, "sfIntersects", true),
+    fx(BIG, EDGE_ADJACENT, "sfDisjoint", false),
+    fx(BIG, EDGE_ADJACENT, "sfOverlaps", false),
+    fx(BIG, EDGE_ADJACENT, "sfContains", false),
+    fx(BIG, EDGE_ADJACENT, "sfWithin", false),
+    // Partially overlapping regions: overlap.
+    fx(BIG, OVERLAP, "sfOverlaps", true),
+    fx(BIG, OVERLAP, "sfIntersects", true),
+    fx(BIG, OVERLAP, "sfDisjoint", false),
+    fx(BIG, OVERLAP, "sfTouches", false),
+    fx(BIG, OVERLAP, "sfContains", false),
+    fx(BIG, OVERLAP, "sfWithin", false),
+    fx(BIG, OVERLAP, "sfEquals", false),
+    // ---- Simple Features: line / point operands ----------------------------
+    // Line crossing a polygon interior (dim-1 vs dim-2): crosses.
+    fx("LINESTRING(-1 1, 3 1)", "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "sfCrosses", true),
+    fx("LINESTRING(-1 1, 3 1)", "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "sfIntersects", true),
+    fx("LINESTRING(-1 1, 3 1)", "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "sfWithin", false),
+    fx("LINESTRING(-1 1, 3 1)", "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "sfTouches", false),
+    // Two lines crossing at one interior point: crosses.
+    fx("LINESTRING(0 0, 2 2)", "LINESTRING(0 2, 2 0)", "sfCrosses", true),
+    fx("LINESTRING(0 0, 2 2)", "LINESTRING(0 2, 2 0)", "sfIntersects", true),
+    fx("LINESTRING(0 0, 2 2)", "LINESTRING(0 2, 2 0)", "sfTouches", false),
+    fx("LINESTRING(0 0, 2 2)", "LINESTRING(0 2, 2 0)", "sfOverlaps", false),
+    // Two lines sharing only an endpoint: touch.
+    fx("LINESTRING(0 0, 1 1)", "LINESTRING(1 1, 2 0)", "sfTouches", true),
+    fx("LINESTRING(0 0, 1 1)", "LINESTRING(1 1, 2 0)", "sfCrosses", false),
+    fx("LINESTRING(0 0, 1 1)", "LINESTRING(1 1, 2 0)", "sfIntersects", true),
+    // Collinear partially-overlapping lines: overlap (same dim, partial share).
+    fx("LINESTRING(0 0, 2 0)", "LINESTRING(1 0, 3 0)", "sfOverlaps", true),
+    fx("LINESTRING(0 0, 2 0)", "LINESTRING(1 0, 3 0)", "sfCrosses", false),
+    fx("LINESTRING(0 0, 2 0)", "LINESTRING(1 0, 3 0)", "sfIntersects", true),
+    // Line strictly within a polygon.
+    fx("LINESTRING(0.5 0.5, 1.5 1.5)", "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "sfWithin", true),
+    fx("LINESTRING(0.5 0.5, 1.5 1.5)", "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "sfCrosses", false),
+    // Point inside a polygon: within (interior).
+    fx("POINT(1 1)", "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "sfWithin", true),
+    fx("POINT(1 1)", "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "sfIntersects", true),
+    fx("POINT(1 1)", "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "sfTouches", false),
+    fx("POINT(1 1)", "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "sfDisjoint", false),
+    // Point ON a polygon boundary: touches, NOT within (interior rule).
+    fx("POINT(0 1)", "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "sfTouches", true),
+    fx("POINT(0 1)", "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "sfWithin", false),
+    fx("POINT(0 1)", "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "sfIntersects", true),
+    // Point vs same / different point.
+    fx("POINT(3 4)", "POINT(3 4)", "sfEquals", true),
+    fx("POINT(3 4)", "POINT(3 4)", "sfIntersects", true),
+    fx("POINT(3 4)", "POINT(3 4)", "sfDisjoint", false),
+    fx("POINT(3 4)", "POINT(3 5)", "sfDisjoint", true),
+    fx("POINT(3 4)", "POINT(3 5)", "sfIntersects", false),
+    fx("POINT(3 4)", "POINT(3 5)", "sfEquals", false),
+    // ---- Egenhofer: region pairs (Req 25 — exactly one holds per pair) ------
+    fx(BIG, BIG, "ehEquals", true),
+    fx(BIG, BIG, "ehDisjoint", false),
+    fx(BIG, BIG, "ehMeet", false),
+    fx(BIG, BIG, "ehOverlap", false),
+    fx(BIG, BIG, "ehCovers", false),
+    fx(BIG, BIG, "ehCoveredBy", false),
+    fx(BIG, BIG, "ehInside", false),
+    fx(BIG, BIG, "ehContains", false),
+    fx(BIG, FAR, "ehDisjoint", true),
+    fx(BIG, FAR, "ehEquals", false),
+    fx(BIG, FAR, "ehMeet", false),
+    fx(BIG, EDGE_ADJACENT, "ehMeet", true),
+    fx(BIG, EDGE_ADJACENT, "ehDisjoint", false),
+    fx(BIG, EDGE_ADJACENT, "ehOverlap", false),
+    fx(BIG, OVERLAP, "ehOverlap", true),
+    fx(BIG, OVERLAP, "ehMeet", false),
+    fx(BIG, OVERLAP, "ehEquals", false),
+    fx(SMALL_INSIDE, BIG, "ehInside", true),
+    fx(SMALL_INSIDE, BIG, "ehContains", false),
+    fx(SMALL_INSIDE, BIG, "ehCoveredBy", false),
+    fx(BIG, SMALL_INSIDE, "ehContains", true),
+    fx(BIG, SMALL_INSIDE, "ehInside", false),
+    fx(CORNER_TANGENT, BIG, "ehCoveredBy", true),
+    fx(CORNER_TANGENT, BIG, "ehInside", false),
+    fx(CORNER_TANGENT, BIG, "ehCovers", false),
+    fx(BIG, CORNER_TANGENT, "ehCovers", true),
+    fx(BIG, CORNER_TANGENT, "ehContains", false),
+    fx(BIG, CORNER_TANGENT, "ehCoveredBy", false),
+    // ---- RCC8: region pairs (Req 26 — exactly one holds per pair) -----------
+    fx(BIG, BIG, "rcc8eq", true),
+    fx(BIG, BIG, "rcc8dc", false),
+    fx(BIG, BIG, "rcc8ec", false),
+    fx(BIG, BIG, "rcc8po", false),
+    fx(BIG, FAR, "rcc8dc", true),
+    fx(BIG, FAR, "rcc8ec", false),
+    fx(BIG, FAR, "rcc8eq", false),
+    fx(BIG, EDGE_ADJACENT, "rcc8ec", true),
+    fx(BIG, EDGE_ADJACENT, "rcc8dc", false),
+    fx(BIG, EDGE_ADJACENT, "rcc8po", false),
+    fx(BIG, OVERLAP, "rcc8po", true),
+    fx(BIG, OVERLAP, "rcc8ec", false),
+    fx(BIG, OVERLAP, "rcc8eq", false),
+    fx(SMALL_INSIDE, BIG, "rcc8ntpp", true),
+    fx(SMALL_INSIDE, BIG, "rcc8tpp", false),
+    fx(SMALL_INSIDE, BIG, "rcc8ntppi", false),
+    fx(BIG, SMALL_INSIDE, "rcc8ntppi", true),
+    fx(BIG, SMALL_INSIDE, "rcc8ntpp", false),
+    fx(CORNER_TANGENT, BIG, "rcc8tpp", true),
+    fx(CORNER_TANGENT, BIG, "rcc8ntpp", false),
+    fx(CORNER_TANGENT, BIG, "rcc8tppi", false),
+    fx(BIG, CORNER_TANGENT, "rcc8tppi", true),
+    fx(BIG, CORNER_TANGENT, "rcc8tpp", false),
+];
+
+fn run_fixtures(fixtures: &[Fixture]) -> (usize, usize, Vec<String>) {
+    let relations = all_relations();
+    let lookup = |name: &str| -> Rel {
+        relations
+            .iter()
+            .find(|(n, _)| *n == name)
+            .map(|(_, f)| *f)
+            .unwrap_or_else(|| panic!("fixture names unknown relation {name:?}"))
+    };
+    let mut pass = 0usize;
+    let mut fail = 0usize;
+    let mut failures = Vec::new();
+    for f in fixtures {
+        let rel = lookup(f.relation);
+        match rel(f.a, f.b) {
+            Ok(got) if got == f.expected => pass += 1,
+            Ok(got) => {
+                fail += 1;
+                failures.push(format!(
+                    "geof:{}({}, {}) = {got}, expected {}",
+                    f.relation, f.a, f.b, f.expected
+                ));
+            }
+            Err(e) => {
+                fail += 1;
+                failures.push(format!("geof:{}({}, {}) errored: {e}", f.relation, f.a, f.b));
+            }
+        }
+    }
+    (pass, fail, failures)
+}
+
+#[test]
+fn ogc_topology_compliance_ratchet() {
+    let (pass, fail, failures) = run_fixtures(FIXTURES);
+
+    println!("\nOGC GeoSPARQL topology compliance scoreboard");
+    for why in &failures {
+        println!("  FAIL {why}");
+    }
+    println!("pass {pass} / fail {fail} (floor {OGC_RATCHET_FLOOR})");
+
+    assert_eq!(fail, 0, "OGC topology compliance regressions:\n{}", failures.join("\n"));
+    assert!(
+        pass >= OGC_RATCHET_FLOOR,
+        "OGC compliance pass count regressed: {pass} < floor {OGC_RATCHET_FLOOR} — \
+         if fixtures were removed deliberately, lower the floor in the same commit"
+    );
+}
+
+/// GeoSPARQL §8.5: the WKT and GML serializations of the same geometry are
+/// equivalent. A subset of the sf fixtures is re-run with operand `b` supplied
+/// as a `geo:gmlLiteral` (GML-SF); the topology result MUST be identical to the
+/// all-WKT run. This exercises the geometry-serialization-equivalence
+/// sub-conformance class against the GML parser.
+#[test]
+fn gml_equivalence_for_topology() {
+    // (a-WKT, b-WKT, b-as-GML, relation, expected) — b is the GML-supplied side.
+    struct GmlFixture {
+        a: &'static str,
+        b_gml: &'static str,
+        relation: &'static str,
+        expected: bool,
+    }
+    // A 2x2 square at the origin, in GML-SF.
+    const SQUARE_GML: &str = "<gml:Polygon><gml:exterior><gml:LinearRing>\
+<gml:posList>0 0 2 0 2 2 0 2 0 0</gml:posList>\
+</gml:LinearRing></gml:exterior></gml:Polygon>";
+    // A point, in GML-SF.
+    const POINT_GML: &str = "<gml:Point><gml:pos>1 1</gml:pos></gml:Point>";
+
+    let fixtures = [
+        // Point inside the GML square: within / intersects.
+        GmlFixture { a: "POINT(1 1)", b_gml: SQUARE_GML, relation: "sfWithin", expected: true },
+        GmlFixture { a: "POINT(1 1)", b_gml: SQUARE_GML, relation: "sfIntersects", expected: true },
+        GmlFixture {
+            a: "POINT(9 9)",
+            b_gml: SQUARE_GML,
+            relation: "sfDisjoint",
+            expected: true,
+        },
+        // The GML point sits inside the WKT square.
+        GmlFixture {
+            a: "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))",
+            b_gml: POINT_GML,
+            relation: "sfContains",
+            expected: true,
+        },
+    ];
+
+    let relations = all_relations();
+    let lookup = |name: &str| -> Rel {
+        relations.iter().find(|(n, _)| *n == name).map(|(_, f)| *f).unwrap()
+    };
+
+    for f in &fixtures {
+        let rel = lookup(f.relation);
+        // GML literals carry their datatype via parse_geometry_literal, but the
+        // lex:: relations parse WKT; so cross-check the GML path through the
+        // crate's combined parser and the relation through the geometry API.
+        let a = sparq_geo::parse_wkt_literal(f.a).expect("WKT a parses");
+        let b = sparq_geo::parse_gml_literal(f.b_gml).expect("GML b parses");
+        let got_gml = relate_via_name(f.relation, &a, &b);
+        // The same pair, with b re-expressed as WKT, must agree.
+        let b_wkt = b.to_wkt_literal();
+        let got_wkt = rel(f.a, &b_wkt).expect("WKT relation evaluates");
+        assert_eq!(
+            got_gml, f.expected,
+            "GML path geof:{}({}, <gml>) = {got_gml}, expected {}",
+            f.relation, f.a, f.expected
+        );
+        assert_eq!(
+            got_gml, got_wkt,
+            "WKT/GML serialization disagreement for geof:{} on {} vs {b_wkt}",
+            f.relation, f.a
+        );
+    }
+}
+
+/// Dispatch a relation by `geof:` local name over already-parsed geometries
+/// (used by the GML-equivalence test, whose `b` operand is parsed from GML).
+fn relate_via_name(
+    name: &str,
+    a: &sparq_geo::GeoGeometry,
+    b: &sparq_geo::GeoGeometry,
+) -> bool {
+    use sparq_geo::geof;
+    match name {
+        "sfEquals" => geof::sf_equals(a, b),
+        "sfDisjoint" => geof::sf_disjoint(a, b),
+        "sfIntersects" => geof::sf_intersects(a, b),
+        "sfTouches" => geof::sf_touches(a, b),
+        "sfCrosses" => geof::sf_crosses(a, b),
+        "sfWithin" => geof::sf_within(a, b),
+        "sfContains" => geof::sf_contains(a, b),
+        "sfOverlaps" => geof::sf_overlaps(a, b),
+        other => panic!("relate_via_name: unsupported relation {other:?}"),
+    }
+    .expect("relation evaluates")
+}
+
+/// The recorded floor must never exceed what the corpus can actually deliver —
+/// catches a stale floor left above the fixture count after a deletion.
+#[test]
+fn floor_is_consistent_with_corpus() {
+    let (pass, fail, _) = run_fixtures(FIXTURES);
+    assert_eq!(fail, 0);
+    assert!(
+        OGC_RATCHET_FLOOR <= pass,
+        "OGC_RATCHET_FLOOR ({OGC_RATCHET_FLOOR}) exceeds achievable passes ({pass}) — \
+         the floor is unreachable; lower it or add fixtures"
+    );
+}

--- a/crates/sparq-geo/tests/ogc_compliance_ratchet.rs
+++ b/crates/sparq-geo/tests/ogc_compliance_ratchet.rs
@@ -267,7 +267,7 @@ fn run_fixtures(fixtures: &[Fixture]) -> (usize, usize, Vec<String>) {
             .iter()
             .find(|(n, _)| *n == name)
             .map(|(_, f)| *f)
-            .unwrap_or_else(|| panic!("fixture names unknown relation {name:?}"))
+            .unwrap_or_else(|| panic!("fixture references an unknown relation: {name:?}"))
     };
     let mut pass = 0usize;
     let mut fail = 0usize;
@@ -324,12 +324,15 @@ fn gml_equivalence_for_topology() {
         relation: &'static str,
         expected: bool,
     }
-    // A 2x2 square at the origin, in GML-SF.
-    const SQUARE_GML: &str = "<gml:Polygon><gml:exterior><gml:LinearRing>\
+    // A 2x2 square at the origin, in GML-SF. The gml: prefix is declared on the
+    // root element so the fixture is well-formed XML. [OPUS-4.8]
+    const SQUARE_GML: &str = "<gml:Polygon xmlns:gml=\"http://www.opengis.net/gml\">\
+<gml:exterior><gml:LinearRing>\
 <gml:posList>0 0 2 0 2 2 0 2 0 0</gml:posList>\
 </gml:LinearRing></gml:exterior></gml:Polygon>";
-    // A point, in GML-SF.
-    const POINT_GML: &str = "<gml:Point><gml:pos>1 1</gml:pos></gml:Point>";
+    // A point, in GML-SF (gml: prefix declared on the root element). [OPUS-4.8]
+    const POINT_GML: &str =
+        "<gml:Point xmlns:gml=\"http://www.opengis.net/gml\"><gml:pos>1 1</gml:pos></gml:Point>";
 
     let fixtures = [
         // Point inside the GML square: within / intersects.


### PR DESCRIPTION
Raises confidence in `sparq-geo` with two test suites (no production code changed):
- **OGC compliance ratchet** (`tests/ogc_compliance_ratchet.rs`): SF(8)+Egenhofer(8)+RCC8(8) relations over point/line/polygon, both operand orders, + WKT↔GML serialization-equivalence. Floor `OGC_RATCHET_FLOOR=119`, enforced as `fail==0 && pass>=floor` (floor only rises, mirrors the W3C ratchets).
- **DE-9IM differential** (`tests/de9im_differential.rs`): seeded 500-pair corpus cross-checked against the `geo` crate's standalone `Intersects`/`Contains` traits (separate impls from `Relate`) + relation-law checks + a 504-assertion guard validating all 14 eh/rcc8 pattern literals against the generic matcher. **Zero disagreements found — no bugs.**

Honestly NOT covered (filed as beads sq-i2a0, sq-5ts8): the official OGC CITE/TEAM-Engine suite + RDFS/OWL Feature/Geometry entailment. 117 sparq-geo tests green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)