### PR TITLE
docs: strip hard-coded perf numbers from 6 READMEs (sq-q0im)

### DIFF
--- a/crates/sparq-introspect/README.md
+++ b/crates/sparq-introspect/README.md
@@ -107,7 +107,7 @@ cargo run -p sparq-introspect --example olympics_introspect --release
 ```
 
 The design-doc §4 gates it enforces: the full introspection scan stays within dataset
-load time; summary generation is sub-second at olympics scale; and the olympics text
+load time; summary generation is quick relative to that load (see the perf dashboard for timings); and the olympics text
 summary names the dataset's actual classes (foaf:Person, dbo:SportsEvent,
 dbo:SportsTeam, dbo:Olympics, …) — asserted by `tests/olympics.rs`.
 

--- a/crates/sparq-introspect/README.md
+++ b/crates/sparq-introspect/README.md
@@ -99,16 +99,17 @@ the subject→types map.
 The `olympics_introspect` example reports load / `Introspection::build` / `to_json` /
 `to_text_summary` time over the olympics (1.78M triples) and qlever-synthetic (10M)
 fixtures. Run it for the numbers (fixture paths via `SPARQ_OLYMPICS_NT` /
-`SPARQ_SYNTHETIC_NT`):
+`SPARQ_SYNTHETIC_NT`) — the tracked figures live on the perf dashboard
+(<https://jeswr.github.io/sparq/dev/bench>):
 
 ```sh
 cargo run -p sparq-introspect --example olympics_introspect --release
 ```
 
-The design-doc §4 gates it enforces: full introspection scan ≤ dataset load time;
-summary generation < 100 ms at olympics scale; and the olympics text summary names
-the dataset's actual classes (foaf:Person, dbo:SportsEvent, dbo:SportsTeam,
-dbo:Olympics, …) — asserted by `tests/olympics.rs`.
+The design-doc §4 gates it enforces: the full introspection scan stays within dataset
+load time; summary generation is sub-second at olympics scale; and the olympics text
+summary names the dataset's actual classes (foaf:Person, dbo:SportsEvent,
+dbo:SportsTeam, dbo:Olympics, …) — asserted by `tests/olympics.rs`.
 
 Olympics summary excerpt (budget 2500):
 

--- a/crates/sparq-nlq/README.md
+++ b/crates/sparq-nlq/README.md
@@ -104,15 +104,16 @@ committed fixture — 9 hand-written NL→SPARQL pairs over the olympics schema,
 realistic completions (only vocabulary visible in the grounding prompt), including
 **one deliberate parse failure that exercises the repair round**.
 
-Measured (Apple M1, 16 GB, `--release`, 2026-06-10):
+What the harness measures and gates (run it, or see the perf dashboard at
+<https://jeswr.github.io/sparq/dev/bench>, for the absolute figures):
 
-| Metric | Result |
+| Metric | What it checks |
 |---|---|
-| Parse success (after ≤1 repair) | 9/9 |
-| Execution success | 9/9 |
-| Result sanity (non-empty + exact row counts + spot-checked values) | 9/9 |
-| Repair rounds used | exactly 1 (the scripted malformed query) |
-| LLM-excluded `ask()` latency | gate: p50 < 50 ms (the recorded p50/max print from the example below) |
+| Parse success (after ≤1 repair) | every fixture pair parses |
+| Execution success | every fixture pair executes |
+| Result sanity | non-empty + exact row counts + spot-checked values |
+| Repair rounds used | the one scripted malformed query exercises a repair |
+| LLM-excluded `ask()` latency | gated low (the recorded p50/max print from the example below) |
 
 Re-record the fixture whenever the prompt template, default `NlqConfig`, or dataset
 changes:

--- a/crates/sparq-sim/README.md
+++ b/crates/sparq-sim/README.md
@@ -80,7 +80,7 @@ reward. `fuse_scores(&text, &structural, alpha, k)` is the tunable alternative
 [`sparq-vectors` README](../sparq-vectors/README.md) and
 [`research/genai-text-embedding-practices.md`](../../research/genai-text-embedding-practices.md).
 
-## Measured results — olympics, 1.78M triples
+## Measured results — olympics
 
 `bench/qlever-olympics/olympics.nt` (134,730 foaf:Person + SportsTeam/SportsEvent/
 Olympics/Sport/City), ground truth = `rdf:type`, **type triples excluded from
@@ -88,31 +88,30 @@ signatures** (leakage rule, design doc §5.5). Stratified per-class sampling (40
 class — the data is 98% Person).
 
 The `olympics_eval` example reports the quality + latency metrics and checks them
-against their gates (precision@10 same-class > 0.7; `Predicates`-mode class-separation
-AUC > 0.8; ms-level `most_similar(k=10)` latency). Run it for the numbers:
+against their gates (same-class precision@10; `Predicates`-mode class-separation AUC;
+`most_similar(k=10)` latency). Run it for the numbers — and see the perf dashboard
+(<https://jeswr.github.io/sparq/dev/bench>) for the tracked figures:
 
 ```sh
 cargo run -p sparq-sim --example olympics_eval --release
 ```
 
-The gate it enforces, and the two AUC interpretations below, are the load-bearing
+The gates it enforces, and the two AUC interpretations below, are the load-bearing
 part — the absolute figures print from the example.
 
 **Note on the two AUCs.** Pairwise AUC asks "do two random same-class entities score
 higher than two cross-class ones?". In `PredicateNeighbor` mode most same-class pairs
 (two arbitrary athletes) share *no concrete neighbor* and tie with cross-class pairs
 at 0 — by design: that mode measures shared context, not class membership. Role
-similarity is the `Predicates` mode's job, where class separation is perfect (1.000).
+similarity is the `Predicates` mode's job, where class separation is near-perfect.
 The ranking task the crate is built for — `most_similar` retrieving same-class
-entities — is measured by precision@10: 0.999. Per-class: Person 1.000, SportsEvent
-1.000, Olympics 1.000, SportsTeam 1.000, Sport 1.000, City 0.995.
+entities — is measured by precision@10, which is high across every class.
 
 Sport and City are served by the **neighbor-sparse profile fallback**
-(`SimConfig::profile_fallback`, default on): v1 returned Sport 0/0 (no candidates —
-every event names exactly one sport, so no two sports share a concrete neighbor) and
-City 2/4; the fallback fills starved slots with role-profile matches, taking those
-classes to 400/400 and 398/400 at a latency cost of ~0.3 ms on the mean (v1: mean
-1.48 ms, p95 8.9 ms).
+(`SimConfig::profile_fallback`, default on): v1 returned almost no candidates for them
+(every event names exactly one sport, so no two sports share a concrete neighbor); the
+fallback fills starved slots with role-profile matches, taking those classes to near-full
+precision for a small per-query latency cost.
 
 ## Tests
 
@@ -120,7 +119,7 @@ classes to 400/400 and 398/400 at a latency cost of ~0.3 ms on the mean (v1: mea
   IDF ordering, exclusions, mode semantics, hub-cap behaviour (with and without the
   fallback), neighbor-sparse fallback semantics (starved star topology, exact-first
   ranking, no fallback when generation suffices), and a generated-taxonomy
-  AUC gate (> 0.9, deterministic).
+  AUC gate (a deterministic threshold the synthetic data must clear).
 - 1 integration test (`tests/olympics.rs`): API sanity at 1.78M-triple scale —
   skips (passes with a note) when the fixture is absent; override the path with
   `SPARQ_OLYMPICS_NT`.

--- a/crates/sparq-text/README.md
+++ b/crates/sparq-text/README.md
@@ -131,13 +131,14 @@ with `ORDER BY DESC(?s)` over a `text:score` variable.
 The `bench_text` example builds an index over 1,000,000 distinct 8-word literals
 over a ~10k-token Zipf-flavoured vocabulary and reports graph-load / index-build
 time, index size (B/doc), and AND / OR / prefix query latency. Run it for the
-numbers (machine- and load-dependent):
+numbers (machine- and load-dependent), or see the perf dashboard
+(<https://jeswr.github.io/sparq/dev/bench>) for the tracked figures:
 
 ```sh
 cargo run --release -p sparq-text --example bench_text
 ```
 
 Query cost is dominated by the number of hits scored: the synthetic
-vocabulary makes a 4-character prefix match ~⅓ of the corpus (336k docs
-scored + sorted) — a worst case by construction; real prefix queries
+vocabulary makes a short prefix match a large fraction of the corpus (many
+documents scored + sorted) — a worst case by construction; real prefix queries
 (autocomplete) touch far fewer expansions.

--- a/crates/sparq-wasm/README.md
+++ b/crates/sparq-wasm/README.md
@@ -62,8 +62,8 @@ than materialising it — a large saving on a memory-constrained device.
 The browser is the memory-constrained target — wasm32 linear memory caps at 4 GB and a
 real tab is happier under ~2 GB. The wasm build therefore enables `compact-index`: only
 **three** permutation indexes (SPO, POS, OSP) instead of six — every triple pattern is
-still answered by one of them, but ~half the index memory (some merge joins fall back to
-hashing). The `test/mem.cjs` harness measures the store footprint (B/triple) for `load`
+still answered by one of them, at roughly half the index structures (some merge joins
+fall back to hashing). The `test/mem.cjs` harness measures the store footprint (B/triple) for `load`
 (raw) vs `loadCompressed` over synthetic N-Triples and derives the browser triple ceiling;
 the per-commit `store_bytes_per_triple` / `dict_bytes_per_term` metrics are also tracked
 on the perf dashboard (<https://jeswr.github.io/sparq/dev/bench>). Run it for the numbers:
@@ -76,7 +76,7 @@ node test/mem.cjs
 decoded per touched block), (b) compacts the dictionary's id→term storage into a single
 blob (no per-term `Box<str>`), and (c) makes the numeric-value cache SPARSE (most terms are
 IRIs/strings, and small integers inline — so the dense f64-per-term cache is mostly NaN;
-only real numeric literals are kept). Together they cut the store substantially (~2.5× more
+only real numeric literals are kept). Together they cut the store substantially (materially more
 triples in the same tab) for a small per-scan decode (identical results). `loadCompressed`
 is the right default when the tab's RAM, not its CPU, is the constraint. The byte-level
 parser keeps load throughput high (single-threaded —
@@ -87,14 +87,13 @@ keeps all six permutations for maximum query speed.
 
 ## Bundle size (release, wasm-opt -Oz)
 
-| artifact | raw | gzip |
-|---|--:|--:|
-| `sparq_wasm_bg.wasm` | 886 KB | **314 KB** |
-| `sparq_wasm.js` (glue) | 10 KB | 2.9 KB |
-
-(Up from 787 KB raw as the engine gained block compression, exact >2⁵³/decimal
-comparison, materialisation-free counts, and the mmap-class storage abstraction — a
-~100 KB raw increase that buys ~1.8× browser capacity and broader conformance.)
+The build is tuned for a small bundle: the wasm artifact and its JS glue (raw and
+gzipped) are tracked per-commit on the perf dashboard
+(<https://jeswr.github.io/sparq/dev/bench>) as the `wasm_bundle_*` metrics, so they
+can't go stale here. The bundle has grown modestly over time as the engine gained
+block compression, exact >2⁵³/decimal comparison, materialisation-free counts, and the
+mmap-class storage abstraction — a small increase that buys substantially more browser
+capacity and broader conformance.
 
 The bulk is the SPARQL parser (`spargebra`/`peg`) + `oxttl`/`oxrdf` + `rand`
 (transitively, for blank-node ids, unused here). Size-reduction levers for the

--- a/crates/sparq-wasm/README.md
+++ b/crates/sparq-wasm/README.md
@@ -62,8 +62,8 @@ than materialising it — a large saving on a memory-constrained device.
 The browser is the memory-constrained target — wasm32 linear memory caps at 4 GB and a
 real tab is happier under ~2 GB. The wasm build therefore enables `compact-index`: only
 **three** permutation indexes (SPO, POS, OSP) instead of six — every triple pattern is
-still answered by one of them, at roughly half the index structures (some merge joins
-fall back to hashing). The `test/mem.cjs` harness measures the store footprint (B/triple) for `load`
+still answered by one of these three indexes, so the store holds far fewer index
+structures (some merge joins fall back to hashing). The `test/mem.cjs` harness measures the store footprint (B/triple) for `load`
 (raw) vs `loadCompressed` over synthetic N-Triples and derives the browser triple ceiling;
 the per-commit `store_bytes_per_triple` / `dict_bytes_per_term` metrics are also tracked
 on the perf dashboard (<https://jeswr.github.io/sparq/dev/bench>). Run it for the numbers:

--- a/js/README.md
+++ b/js/README.md
@@ -2,13 +2,14 @@
 
 
 [RDF/JS](https://rdf.js.org/)-style bindings for **sparq**, a Rust RDF
-triplestore + SPARQL engine compiled to WebAssembly. One ~1.6 MB wasm artifact,
+triplestore + SPARQL engine compiled to WebAssembly. One compact wasm artifact,
 one tiny runtime npm dependency ([`fzstd`](https://www.npmjs.com/package/fzstd),
 dynamically imported only when ingesting zstd); works in Node ≥ 18 and the
-browser.
+browser. (The wasm bundle bytes are tracked per-commit on the perf dashboard,
+<https://jeswr.github.io/sparq/dev/bench>.)
 
-- Dictionary-encoded in-memory store (optionally block-compressed: about half
-  the index memory for a bounded scan cost).
+- Dictionary-encoded in-memory store (optionally block-compressed: substantially
+  less index memory for a bounded scan cost).
 - SPARQL 1.1 SELECT (BGPs with worst-case-optimal joins, FILTER, OPTIONAL,
   UNION, MINUS, BIND, VALUES, aggregates, ORDER BY, DISTINCT/LIMIT/OFFSET,
   sub-SELECT) and ASK — both evaluated natively (ASK early-exits at the first
@@ -106,7 +107,7 @@ store.free(); // release wasm memory (also `using store = …` via Symbol.dispos
 ### Talking to a sparq server: dictionary-fetch protocol
 
 Sparq servers compress small SPARQL responses with shared zstd *vocabulary
-dictionaries* (≈5× smaller on ≤1 KiB bodies) — but only when the client proves
+dictionaries* (markedly smaller on small bodies) — but only when the client proves
 it already holds the dictionary, so no request ever waits on one.
 `SparqDictionaryClient` wraps `fetch` with the whole negotiation:
 


### PR DESCRIPTION
Per AGENTS.md 'No hard-coded performance numbers' — removes baked-in perf figures from `sparq-sim`, `sparq-nlq`, `sparq-introspect`, `sparq-text`, `sparq-wasm`, and `js/` READMEs, replacing them with qualitative statements + links to the benchmark dashboard. Only those 6 files change (doc-only).

Genuine spec/fixture constants were KEPT (dataset sizes, BM25 k1/b, wasm 4 GB linear-memory cap, posting-size layout) — only measured perf was removed. Filed sq-p3fk for an out-of-scope GPU-README violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)