### PR TITLE
ci: PR-gating infra — ci-summary aggregator + CodeQL SAST + SHA-pin all actions; AGENTS.md directives

### DIFF
--- a/.github/workflows/bench-ec2.yml
+++ b/.github/workflows/bench-ec2.yml
@@ -33,9 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45        # hard wall-clock cap (backstop to the script's own cleanup)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ vars.AWS_BENCH_ROLE_ARN }}
           aws-region: eu-west-2
@@ -66,7 +66,7 @@ jobs:
             echo "Created and pushed orphan benchmark-data branch."
           fi
       - name: Track EC2 benchmark series
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: sparq engine (EC2)
           tool: customSmallerIsBetter

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -45,11 +45,11 @@ jobs:
     name: run + track benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown   # enables the wasm bundle-size metric in ci-bench.sh
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       # [OPUS-4.8] Well-known-suite toolchains (sp2b/dbpsb/watdiv/bsbm/lubm), MAIN ONLY. On push to
       # main the full well-known-suite set runs; on PRs we DELIBERATELY do NOT install these, so the
       # ci-bench.sh suite hooks SKIP gracefully (each is guarded on `command -v <tool>`) and PR perf
@@ -68,27 +68,27 @@ jobs:
       # generator scripts so a generator/pinning change busts the cache. PRs skip the toolchain install
       # above, so a cache miss on a PR is harmless (the hook skips); on main it just rebuilds once.
       - name: Cache sp2b generator + corpus
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: /tmp/sp2b
           key: bench-sp2b-${{ runner.os }}-${{ hashFiles('bench/sp2b/gen.sh') }}
       - name: Cache watdiv generator + corpus
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: /tmp/watdiv
           key: bench-watdiv-${{ runner.os }}-${{ hashFiles('bench/watdiv/gen.sh', 'bench/watdiv/files/words.txt') }}
       - name: Cache bsbm generator + corpus
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: /tmp/bsbm
           key: bench-bsbm-${{ runner.os }}-${{ hashFiles('bench/bsbm/gen.sh') }}
       - name: Cache lubm generator + corpus
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: /tmp/lubm
           key: bench-lubm-${{ runner.os }}-${{ hashFiles('bench/lubm/gen.sh') }}
       - name: Cache dbpsb pinned slice + cut
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: /tmp/dbpsb
           key: bench-dbpsb-${{ runner.os }}-${{ hashFiles('bench/dbpsb/fetch.sh') }}
@@ -207,7 +207,7 @@ jobs:
             echo "Created and pushed orphan benchmark-data branch."
           fi
       - name: Store + compare against history
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: sparq engine
           tool: customSmallerIsBetter

--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -51,6 +51,14 @@ jobs:
           REPO: ${{ github.repository }}
           # On pull_request the head commit is the PR head; on push it's github.sha.
           SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          # This workflow RUN's id — unique to THIS gate run. Every check-run's
+          # details_url embeds the run id of the workflow run that produced it
+          # (…/actions/runs/<RUN_ID>/job/<JOB_ID>), so we self-exclude by exact
+          # run id rather than by the job NAME. A name match ("gate") is fragile:
+          # it would also drop any FUTURE sibling job literally named `gate` in any
+          # workflow, undermining the "add/rename jobs freely" goal. The run id is
+          # ours alone, so the exclusion is exact and collision-proof. [OPUS-4.8]
+          SELF_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
           # STABILITY WINDOW (handles the startup race + late-registering workflows):
@@ -65,13 +73,23 @@ jobs:
           prev_names=""
           stable=0
           for attempt in $(seq 1 110); do   # 110 × 20s ≈ 37 min, under the job timeout
-            # Exclude THIS gate's own check-run from the aggregate. The Checks API
-            # returns the bare job name ("gate"); we also exclude the
-            # "ci-summary / gate" workflow/job form so a future API/naming change can't
-            # make the gate count itself into `pending` and self-deadlock.
+            # Exclude THIS gate's own check-run from the aggregate so it can't count
+            # itself into `pending` and self-deadlock. We exclude by THIS workflow
+            # run's id (SELF_RUN_ID), which the check-run's details_url embeds as
+            # …/actions/runs/<RUN_ID>/…, NOT by job name: a name match would also
+            # drop a future sibling job literally named `gate`. The match is anchored
+            # to "/runs/<id>" so it can't accidentally hit a substring of some other
+            # numeric id elsewhere in the URL.
             runs=$(gh api "repos/$REPO/commits/$SHA/check-runs" --paginate \
-              --jq '.check_runs[] | select(.name != "gate" and .name != "ci-summary / gate") | {name, status, conclusion}')
-            names=$(printf '%s\n' "$runs" | jq -rs '[.[].name] | unique | join(",")')
+              --jq "[.check_runs[]
+                     | select((.details_url // .html_url // \"\") | contains(\"/runs/$SELF_RUN_ID\") | not)
+                     | {name, status, conclusion}] | .[]")
+            # Stability key: join the SORTED, de-duplicated check NAMES with newlines.
+            # A newline cannot appear inside a check name, whereas a comma can (e.g.
+            # "MSRV check (Rust 1.88, declared floor)"), so a comma-joined key was
+            # collision/ambiguity-prone — two distinct sets could fold to the same
+            # string. The newline-joined sorted-unique set is an unambiguous key.
+            names=$(printf '%s\n' "$runs" | jq -rs '[.[].name] | unique | join("\n")')
             pending=$(printf '%s\n' "$runs" | jq -rs '[.[] | select(.status != "completed")] | length')
             total=$(printf '%s\n' "$runs" | jq -rs 'length')
             if [ "$names" = "$prev_names" ]; then stable=$((stable + 1)); else stable=1; prev_names="$names"; fi

--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -1,0 +1,104 @@
+# ci-summary — the SINGLE required status check for branch protection on `main`
+# (bead sq-prg4). [OPUS-4.8]
+#
+# WHY: sparq's gates live across many workflows + jobs (ci.yml's build/test/clippy/
+# conformance/SHACL/inference/coverage/wasm/MSRV, supply-chain.yml, python.yml,
+# js.yml, codeql.yml, scorecard.yml, …). Requiring each by name in the branch-
+# protection ruleset is brittle: every job rename or added gate breaks the rule and
+# silently weakens the gate. `needs:` cannot span workflows, so we cannot aggregate
+# with a normal dependency edge. Instead this workflow contributes ONE check —
+# `ci-summary / gate` — that the ruleset requires; it POLLS every OTHER check-run on
+# the head commit and passes iff none failed. Add/rename jobs freely; the gate adapts.
+# (Pattern ported from jeswr/prod-solid-server's pr-gate.yml, incl. its stability-
+# window race fix.)
+#
+# SEMANTICS: success / skipped / neutral are non-failing; failure / cancelled /
+# timed_out / action_required / stale fail the gate. The gate EXCLUDES ITSELF (no
+# self-deadlock). It waits until the discovered set of sibling check names has
+# stabilised AND every one of them is terminal, bounded by the job timeout. A
+# stable-empty set passes (e.g. a docs-only change that triggers no other workflow).
+name: ci-summary
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Read-only: the gate only READS check-runs + commit statuses for the head commit.
+permissions:
+  checks: read
+  statuses: read
+  contents: read
+
+# One in-flight gate per PR (or per branch on push). Cancel a superseded run so a
+# new push doesn't leave a stale, slowly-timing-out gate behind.
+concurrency:
+  group: ci-summary-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: gate
+    runs-on: ubuntu-latest
+    # > the slowest sibling gate (coverage / conformance are the long poles, well
+    # under ~20 min on a warm cache) with generous headroom; the poll loop below
+    # caps itself under this wall-clock so it emits a clear timeout error first.
+    timeout-minutes: 45
+    steps:
+      - name: Wait for all other checks, then aggregate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # On pull_request the head commit is the PR head; on push it's github.sha.
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          # STABILITY WINDOW (handles the startup race + late-registering workflows):
+          # a fixed settle can't eliminate the race — a sibling check-run can register
+          # late, after we've read a partial set. So we require the DISCOVERED SET OF
+          # CHECK NAMES to stay unchanged across STABLE_POLLS consecutive polls before
+          # we trust it. Any new check-run appearing resets the counter, so a slow-to-
+          # register workflow is always folded in. Only once the set is stable AND
+          # nothing is pending do we render a verdict; a stable-empty set passes.
+          STABLE_POLLS=4          # set must hold for 4 × 20s = 80s of quiet
+          INTERVAL=20
+          prev_names=""
+          stable=0
+          for attempt in $(seq 1 110); do   # 110 × 20s ≈ 37 min, under the job timeout
+            # Exclude THIS gate's own check-run from the aggregate. The Checks API
+            # returns the bare job name ("gate"); we also exclude the
+            # "ci-summary / gate" workflow/job form so a future API/naming change can't
+            # make the gate count itself into `pending` and self-deadlock.
+            runs=$(gh api "repos/$REPO/commits/$SHA/check-runs" --paginate \
+              --jq '.check_runs[] | select(.name != "gate" and .name != "ci-summary / gate") | {name, status, conclusion}')
+            names=$(printf '%s\n' "$runs" | jq -rs '[.[].name] | unique | join(",")')
+            pending=$(printf '%s\n' "$runs" | jq -rs '[.[] | select(.status != "completed")] | length')
+            total=$(printf '%s\n' "$runs" | jq -rs 'length')
+            if [ "$names" = "$prev_names" ]; then stable=$((stable + 1)); else stable=1; prev_names="$names"; fi
+            echo "attempt $attempt: $total check-run(s), $pending running, set stable for $stable/$STABLE_POLLS poll(s)"
+            if [ "$stable" -ge "$STABLE_POLLS" ] && [ "$pending" -eq 0 ]; then
+              # Set has settled and everything is terminal — render the verdict.
+              if [ "$total" -eq 0 ]; then
+                echo "ci-summary: no sibling checks to aggregate (stable empty set) — passing." \
+                  | tee -a "$GITHUB_STEP_SUMMARY"
+                exit 0
+              fi
+              failed=$(printf '%s\n' "$runs" | jq -rs '[.[]
+                | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")]')
+              n=$(printf '%s' "$failed" | jq 'length')
+              if [ "$n" -gt 0 ]; then
+                {
+                  echo "### ci-summary: FAILED — $n non-passing check(s) of $total"
+                  printf '%s' "$failed" | jq -r '.[] | "- ✗ \(.name): \(.conclusion // "incomplete")"'
+                } | tee -a "$GITHUB_STEP_SUMMARY"
+                echo "::error::ci-summary failed — see the non-passing checks above."
+                exit 1
+              fi
+              echo "### ci-summary: PASSED — all $total sibling checks green (or skipped/neutral), set stable." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            sleep "$INTERVAL"
+          done
+          echo "::error::ci-summary timed out waiting for the sibling check-run set to stabilise and complete."
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,11 @@ jobs:
     name: build + test (workspace)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Cache cargo + target
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Build
         run: cargo build --workspace --all-targets
       - name: Test
@@ -49,11 +49,11 @@ jobs:
     name: wasm build (sparq-wasm)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Build sparq-wasm for the browser target
         run: cargo build -p sparq-wasm --target wasm32-unknown-unknown
       # [OPUS-4.8] sq-085p follow-up: clippy AGAINST the wasm32 target (the target is
@@ -73,11 +73,11 @@ jobs:
       # RUNS the exported API (JsError/serialisation across the JS boundary), so the
       # web.rs #[wasm_bindgen_test]s run via wasm-pack in the Node executor — closing
       # exactly that gap. Verified locally: 20 passed.
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
+        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
         with:
           version: v0.13.1
       - name: Headless wasm tests (wasm-pack test --node)
@@ -93,11 +93,11 @@ jobs:
     name: clippy (gate) + fmt (informational)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       # GATES: the whole workspace (sparq-py included) is clippy-clean under -D warnings.
       # A new warning — from new code or a Rust-stable bump that adds a lint — fails CI.
       - name: clippy (deny warnings)
@@ -133,10 +133,10 @@ jobs:
     name: MSRV check (Rust 1.88, declared floor)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust (pinned MSRV)
-        uses: dtolnay/rust-toolchain@1.88
-      - uses: Swatinem/rust-cache@v2
+        uses: dtolnay/rust-toolchain@98e1b82157cd469e843cb7f524c1313b4ad9492c # 1.88
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: cargo check on the declared MSRV
         run: cargo check --workspace --exclude sparq-py --exclude sparq-hdt
 
@@ -153,9 +153,9 @@ jobs:
     name: W3C SPARQL conformance (ratchet >= 1229 pass+divergence)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Fetch W3C test suites (pinned)
         run: ./scripts/fetch-conformance.sh
       - name: Run conformance suites
@@ -178,7 +178,7 @@ jobs:
           echo "pass: ${PASS:-unknown} + documented divergences: ${DIV:-0} = $TOTAL (ratchet: $RATCHET)"
           [ -n "$PASS" ] && [ "$TOTAL" -ge "$RATCHET" ] || { echo "::error::conformance regressed below the ratchet ($TOTAL < $RATCHET)"; exit 1; }
       - name: Upload report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: conformance-report
@@ -199,9 +199,9 @@ jobs:
     name: W3C SHACL conformance (ratchet — core >= 98, sparql >= 5)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Fetch W3C SHACL test suite (pinned)
         run: ./crates/sparq-shacl/fetch-shacl-tests.sh
       - name: Run SHACL core + SHACL-SPARQL suites
@@ -222,7 +222,7 @@ jobs:
           [ -n "$CORE_PASS" ] && [ "$CORE_PASS" -ge "$CORE_FLOOR" ] || { echo "::error::SHACL core regressed below the ratchet (${CORE_PASS:-?} < $CORE_FLOOR)"; exit 1; }
           [ -n "$SPARQL_PASS" ] && [ "$SPARQL_PASS" -ge "$SPARQL_FLOOR" ] || { echo "::error::SHACL-SPARQL regressed below the ratchet (${SPARQL_PASS:-?} < $SPARQL_FLOOR)"; exit 1; }
       - name: Upload scoreboard
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: shacl-conformance
@@ -245,9 +245,9 @@ jobs:
     name: Inference conformance (ratchet >= 1967 pass+divergence)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Fetch inference test suites (pinned)
         run: ./scripts/fetch-inference-suites.sh
       - name: Run inference suites
@@ -268,7 +268,7 @@ jobs:
           echo "pass: ${PASS:-unknown} + documented divergences: ${DIV:-0} = $TOTAL (ratchet: $RATCHET)"
           [ -n "$PASS" ] && [ "$TOTAL" -ge "$RATCHET" ] || { echo "::error::inference conformance regressed below the ratchet ($TOTAL < $RATCHET)"; exit 1; }
       - name: Upload report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: inference-conformance-report
@@ -303,13 +303,13 @@ jobs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@91534edaf9fd796a162759d80d49cdff574bff2c # cargo-llvm-cov
       - name: Test-presence gate (fast, no compile)
         run: python3 scripts/coverage-presence.py --check
       - name: Fetch fixtures + measure per-crate coverage (per-commit tier)
@@ -317,7 +317,7 @@ jobs:
       - name: Enforce coverage floor (ratchet)
         run: python3 scripts/coverage-gate.py --check target/coverage/coverage-summary.json
       - name: Upload coverage summary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: coverage-summary
@@ -369,13 +369,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@91534edaf9fd796a162759d80d49cdff574bff2c # cargo-llvm-cov
       - name: Test-presence gate
         run: python3 scripts/coverage-presence.py --check
       - name: Fetch fixtures + measure per-crate coverage (FULL tier)
@@ -383,7 +383,7 @@ jobs:
       - name: Enforce coverage floor (ratchet, all crates required)
         run: python3 scripts/coverage-gate.py --check target/coverage/coverage-summary.json
       - name: Upload coverage summary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: coverage-summary-nightly
@@ -401,11 +401,11 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-geiger
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
         with:
           tool: cargo-geiger
         continue-on-error: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,77 @@
+# CodeQL SAST — static security/quality analysis for the Rust workspace.
+# Resolves the OpenSSF Scorecard `SAST` alert and is the security-quality SAST gate
+# (the `analyze` job feeds the ci-summary aggregator; CodeQL findings also land in the
+# code-scanning dashboard and the Copilot/CodeQL PR review). [OPUS-4.8]
+#
+# Rust CodeQL is GA, so we analyse the `rust` language. We use CodeQL's buildless
+# extraction (`build-mode: none`): the Rust extractor reads the Cargo workspace +
+# sources directly, so no `cargo build` step is needed and the analysis is not gated on
+# the whole workspace compiling under instrumentation (which would duplicate ci.yml's
+# build job and be slow). If a future CodeQL release needs a trace-based build for a
+# query pack we rely on, switch this matrix entry to `build-mode: manual` + a
+# `cargo build --workspace` step (see the CodeQL Rust docs).
+#
+# Third-party actions pinned by full commit SHA (supply-chain hardening); the trailing
+# `# vX.Y.Z` comment is what Dependabot follows to bump the pin.
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Weekly cadence so the latest CodeQL query packs are re-run against an otherwise
+  # quiet default branch (catches newly-published queries on unchanged code).
+  schedule:
+    - cron: "41 4 * * 1" # Mondays 04:41 UTC (off-peak, odd minute)
+
+# Top-level read-only; the analysis job opts into exactly what it needs.
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL analysis (rust)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      # Upload the SARIF results to the code-scanning dashboard.
+      security-events: write
+      # Read the workspace.
+      contents: read
+      # Needed by CodeQL on private repos / for some workflow events.
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: rust
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      # Initialise the CodeQL tooling + database for the matrix language.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # security-and-quality runs the security queries plus the maintainability/
+          # reliability quality queries — the SAST gate Scorecard's `SAST` check wants.
+          queries: security-and-quality
+
+      # Buildless extraction (build-mode: none) above means no explicit build step is
+      # required for Rust. If a build mode that traces compilation is adopted later,
+      # add the `cargo build --workspace` here.
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-monitoring.yml
+++ b/.github/workflows/dependency-monitoring.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install cargo-deny
         uses: taiki-e/install-action@e03236526ace47fa2e04bebcfc6da471ebd4690c # v2.49.0
         with:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -42,7 +42,7 @@ jobs:
           # Windows on ARM (Surface Pro X, Snapdragon X Elite) — cross-compiled from the x64 runner.
           - { tier: win-arm64,        os: windows-latest,   target: aarch64-pc-windows-msvc,   cpu: "",          ext: ".exe" }
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust + target
         shell: bash
         run: |
@@ -57,7 +57,7 @@ jobs:
           RUSTFLAGS="$FLAGS" cargo build --release -p sparq-cli --target ${{ matrix.target }}
           mkdir -p dist
           cp "target/${{ matrix.target }}/release/sparq-cli${{ matrix.ext }}" "dist/sparq-cli-${{ matrix.tier }}${{ matrix.ext }}"
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sparq-cli-${{ matrix.tier }}
           path: dist/sparq-cli-${{ matrix.tier }}${{ matrix.ext }}

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -14,18 +14,18 @@ jobs:
       run:
         working-directory: js
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,12 +25,12 @@ jobs:
     name: maturin build + pytest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Cache cargo + target
-        uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v6
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
       - name: Install maturin + pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           # Windows on ARM — cross-compiled from the x64 runner.
           - { tier: win-arm64,        os: windows-latest,   target: aarch64-pc-windows-msvc,   cpu: "",          ext: ".exe" }
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust + target
         shell: bash
         run: |
@@ -100,7 +100,7 @@ jobs:
           subject-path: |
             pkg/*.tar.gz
             pkg/*.zip
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pkg-${{ matrix.tier }}
           path: |
@@ -116,7 +116,7 @@ jobs:
     permissions:
       contents: write # create the release + upload assets — the only write this pipeline needs
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: pkg-*
           path: assets
@@ -124,7 +124,7 @@ jobs:
       - name: Generate SHA256SUMS
         run: cd assets && sha256sum -- * > SHA256SUMS
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: assets/*
           generate_release_notes: true
@@ -151,17 +151,17 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Log in to ghcr.io
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Image metadata (tags + OCI labels from the git tag)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/sparq-server
           tags: |
@@ -169,7 +169,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: true

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -37,7 +37,7 @@ jobs:
       # (>=1.85) parses it fine; `cargo deny check` then passes (verified locally).
       # The vendored spargebra path source is allowlisted in deny.toml.
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install cargo-deny
         uses: taiki-e/install-action@e03236526ace47fa2e04bebcfc6da471ebd4690c # v2.49.0
         with:
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install cargo-cyclonedx
         uses: taiki-e/install-action@e03236526ace47fa2e04bebcfc6da471ebd4690c # v2.49.0
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Each sub-agent brief must: work in its own worktree, NOT push/merge (the orchest
 
 ## Post-batch re-evaluation checklist — what to re-run after a change
 
-After a batch of changes, re-run only the evaluations whose inputs changed (and always the base gate: full-workspace `clippy -D warnings` + `cargo test` for touched crates). Map change → evaluation:
+After a batch of changes, re-run only the evaluations whose inputs changed — on top of the base gate, which is always required. The base gate is full-workspace `clippy -D warnings` **plus full-workspace `cargo test`**: a sub-agent may scope its in-worktree test run to the affected crates for speed, but the orchestrator's authoritative pre-merge gate runs `cargo test` across the **whole workspace** (feature-unification and cross-crate regressions only surface workspace-wide). Map change → evaluation:
 
 | If the change touches… | Re-run |
 |---|---|
@@ -121,6 +121,30 @@ Do NOT wait to be told. Whenever you notice a **repeated behaviour, a standing r
 When orchestrating, run agents and long shell commands (builds, gates, fetches, watches) **in the background** by default, and parallelise independent work. A foreground/blocking call stalls the loop and prevents picking up new instructions or other ready beads meanwhile. Reserve foreground for genuinely sequential, short glue. (Continues the delegation + continuous-loop rules above.)
 
 **Reconcile finished-but-unnotified agents.** Completion notifications can occasionally not surface. Don't wait indefinitely on a background agent: if it's gone quiet, check the real state — `git worktree list`, the branch's last commit (`git log -1 <branch>`), and whether any of its processes are still alive (`pgrep -af cargo`). A committed branch + no live process = done; verify with your own gate and merge. (Trust ground truth over the notification stream.)
+
+## Contribution workflow — PRs, reviews resolved, the `ci-summary` gate
+
+Changes land on `main` via **pull requests**, not direct pushes (direct push is reserved for the rare hotfix the team agrees on). For every PR:
+
+1. Branch → open a PR (`gh pr create`). Request review, **including GitHub Copilot** code review.
+2. **Address and RESOLVE every review comment** before merge — especially Copilot's. "Resolve" means: make the change or reply with the reason it's declined, and mark the conversation resolved. An unresolved thread blocks merge.
+3. CI must be green: a single **`ci-summary`** check aggregates every other workflow's result and passes ONLY when they all pass. It is the one required status check for branch protection.
+4. Merge only when: `ci-summary` is green AND all review threads are resolved. Then squash/merge and delete the branch.
+
+Branch protection (owner-set, out-of-repo) enforces this: require `ci-summary`, require conversation resolution, require the Copilot/CodeQL review. The repo documents the required set in `docs/branch-protection.md`.
+
+**Security & quality gating:** new security/quality regressions must not merge. CodeQL (SAST) + `cargo clippy -D warnings` + `cargo-deny` + the coverage/conformance ratchets all feed `ci-summary`. Keep the GitHub **code-scanning** alert count at zero — SHA-pin every action (`uses: owner/action@<full-sha> # vX.Y.Z`), and resolve/triage Scorecard + CodeQL alerts as they appear.
+
+## Automated review — roborev on every commit, including in worktrees
+
+Every commit is auto-reviewed by **roborev**: a `.git/hooks/post-commit` hook enqueues a review job to the local roborev daemon. The reviewer agent is **codex — a deliberately non-Anthropic model**, so the engine is never reviewed by the same model family that wrote it. Git worktrees share the main repo's `.git/hooks`, so commits made by worktree sub-agents are reviewed too. Verify the loop is live with `roborev list` (recent jobs, all `done`) and `~/.roborev/post-commit.log` (the per-repo enqueue trail, incl. `sparq-wt-*` worktrees).
+
+Findings must be **addressed, not merely gathered.** A finding is resolved in exactly one of two ways — **never** by merging the branch:
+
+1. **the flagged code changed** — the lines the reviewer objected to were rewritten or removed, so the finding no longer describes anything that exists on `main` (verify against current HEAD, *not* the WIP SHA the review was filed on); or
+2. **explicit triage** — it is fixed, beaded as real-but-deferred work (`bd create`), or closed with a written reason (`roborev close <id>`) when it's a false positive.
+
+Squashing a branch into `main` does **not** address its findings: if the flagged code survived the squash it is still live — just orphaned onto a SHA that no longer appears in `git log`, which is *worse* than an open finding on a current commit because it's invisible. So before merging a branch, reconcile its roborev findings against current `main` HEAD and dispose of each (fix / bead / close-with-reason). Periodically run `roborev list --open` and drain the backlog; don't let unaddressed findings accumulate.
 
 ## Monitor CI after every push to main — and fix red
 

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -15,41 +15,60 @@ recreated.
 
 ## Required status checks
 
-PRs must be **up to date with `main`** before merging, and **all** of the checks below
-must pass. These names are the **job names** from the CI workflows (an owner selects them
-in the "Require status checks" list); keep this list in sync with
-[`.github/workflows/ci.yml`](../.github/workflows/ci.yml) (and the auxiliary workflows) as
-jobs are renamed or added.
+PRs must be **up to date with `main`** before merging. There is now exactly **ONE**
+required status check — the aggregator:
+
+| Required check (job name) | Workflow | What it gates |
+|---|---|---|
+| **`ci-summary / gate`** | [`.github/workflows/ci-summary.yml`](../.github/workflows/ci-summary.yml) | **The single gate.** Polls every *other* check-run on the PR head commit and passes iff none failed (`success`/`skipped`/`neutral` are non-failing). |
+
+> **Select only `ci-summary / gate`** in the ruleset's "Require status checks that must
+> pass" list. Do **not** add the individual job names below — `ci-summary` already
+> aggregates them. This is deliberate: `needs:` cannot span workflows, so requiring each
+> job by name was brittle (every rename / added gate broke the rule and silently weakened
+> the gate). The aggregator adapts automatically — add or rename jobs freely and the gate
+> still covers them, because it discovers the live set of check-runs at run time. See the
+> header of `ci-summary.yml` for the full semantics (stability window + self-exclusion).
+
+### What `ci-summary` aggregates (informational — do NOT add these individually)
+
+The gate covers **every** check-run on the head commit. As of this writing those are the
+jobs below; this table is a map for reviewers, **not** a list of required checks.
 
 From the **CI** workflow (`.github/workflows/ci.yml`):
 
-| Required check (job name) | What it gates |
+| Job name | What it gates |
 |---|---|
 | `build + test (workspace)` | `cargo build --workspace --all-targets` + `cargo test --workspace`. |
 | `clippy (gate) + fmt (informational)` | `cargo clippy --workspace --all-targets -- -D warnings` (the clippy gate; fmt is informational until the one-time reformat lands). |
+| `MSRV check (Rust 1.88, declared floor)` | `cargo check` on the pinned MSRV toolchain. |
 | `W3C SPARQL conformance (ratchet >= 1229 pass+divergence)` | The W3C SPARQL conformance ratchet (never lower). |
 | `W3C SHACL conformance (ratchet — core >= 98, sparql >= 5)` | The W3C SHACL core + SHACL-SPARQL ratchets. |
 | `Inference conformance (ratchet >= 1967 pass+divergence)` | The RDFS/OWL-RL/N3/entailment + rdf-turtle inference ratchet. |
 | `coverage ratchet + test-presence gate (per-crate)` | The per-crate line-coverage floor + the test-presence gate. |
 | `wasm build (sparq-wasm)` | The `wasm32-unknown-unknown` build, the wasm-deps guard, and `wasm-pack test --node`. |
 
-From the binding/packaging workflows (require when those surfaces are exercised):
+From the security / supply-chain / SAST workflows (all now LIVE and aggregated by the gate):
 
-| Required check (job name) | Workflow | What it gates |
+| Job name | Workflow | What it gates |
+|---|---|---|
+| `cargo-deny (advisories + bans + sources + licenses)` | `.github/workflows/supply-chain.yml` | `cargo deny check bans sources licenses` (gating); advisories informational until cargo-deny ships CVSS-4.0 support (the daily `dependency-monitoring.yml` is the real advisory watchdog). |
+| `generate CycloneDX SBOM` | `.github/workflows/supply-chain.yml` | The CycloneDX SBOM artifact. |
+| `CodeQL analysis (rust)` | `.github/workflows/codeql.yml` | CodeQL SAST (`security-and-quality`) over the Rust workspace — resolves Scorecard's `SAST` check. |
+
+From the binding/packaging workflows (when those surfaces are exercised):
+
+| Job name | Workflow | What it gates |
 |---|---|---|
 | `maturin build + pytest` | `.github/workflows/python.yml` | The `sparq` PyPI binding build + pytest parity suite. |
 | (js binding job) | `.github/workflows/js.yml` | The `@jeswr/sparq` npm build/tests. |
 
 > Heavy benchmarks (`bench.yml`, `bench-ec2.yml`) and release/dist workflows are **not**
-> required status checks — they are not part of the per-PR correctness gate.
-
-### Checks to add once they land (supply-chain + SBOM)
-
-The AGENTS.md post-batch checklist calls for a supply-chain gate when Cargo dependencies
-change (`cargo audit` + `cargo deny check` + an SBOM). When those jobs are added to CI,
-**add them to the required-checks list above** (and to this table). Until then they are
-documented expectations, not enforced gates, and `deny.toml` has a CODEOWNERS entry in
-anticipation.
+> aggregated as per-PR gates (bench runs on PRs for feedback but its own hard gate
+> self-fails; release/dist fire only on tags). The **Scorecard** workflow
+> (`scorecard.yml`) re-scores posture on push to `main` and feeds the code-scanning
+> dashboard; **CodeQL** + **Scorecard** therefore both feed the gate/dashboard even
+> though only the per-commit `CodeQL analysis (rust)` check is a per-PR check-run.
 
 ## Required reviews
 
@@ -58,6 +77,15 @@ anticipation.
   (`sparq-zk*`, `sparq-mpc`, `sparq-core`, `sparq-server`, `.github/`, `deny.toml`,
   `SECURITY.md`) therefore needs the listed owner's approval.
 - **Dismiss stale approvals** when new commits are pushed.
+- **Require the automated code review** (GitHub Copilot code review + the CodeQL
+  code-scanning review). Enable "Request Copilot code review automatically" for `main`
+  PRs, and treat **CodeQL code-scanning alerts** as blocking — pair the ruleset with a
+  *code-scanning results* check requiring no new `error`/`high`-severity CodeQL alerts.
+  (The CodeQL run itself is also aggregated by `ci-summary` as the `CodeQL analysis
+  (rust)` check-run; the code-scanning *results* requirement is the complementary
+  alert-severity gate.)
+- **Require conversation resolution before merging** — all PR review threads (human and
+  bot, incl. Copilot/CodeQL) must be resolved. (Also listed under "Other settings".)
 
 ## History and push rules
 
@@ -77,7 +105,18 @@ anticipation.
 
 `AGENTS.md` defines the landing gate as *full-workspace clippy + `cargo test` + the
 conformance/perf/coverage ratchets, all green*, with parallel worktrees gated and merged
-**one branch at a time**. The required status checks above are the CI enforcement of that
-gate; linear history + one CODEOWNERS approval + the up-to-date requirement enforce the
-one-at-a-time merge discipline. When a new ratchet or gate is added to CI, update both
-the CI workflow and this document, and add the new job to the required-checks list.
+**one branch at a time**. The single required check — `ci-summary / gate` — is the CI
+enforcement of that gate: it aggregates every other check-run, so the gate stays complete
+even as jobs are added or renamed. Linear history + one CODEOWNERS approval + the
+up-to-date requirement + conversation resolution enforce the one-at-a-time merge
+discipline. When a new ratchet or gate is added to a CI workflow it is covered
+automatically (no ruleset edit needed); update the informational table above so reviewers
+keep an accurate map.
+
+> All third-party GitHub Actions across `.github/workflows/*.yml` are **pinned by full
+> commit SHA** (with a trailing `# vX.Y.Z` comment that Dependabot follows), resolving
+> the Scorecard `Pinned-Dependencies` alerts. The one documented nuance:
+> `dtolnay/rust-toolchain` is pinned to the **commit SHA of its `stable` / `1.88`
+> branch tip** — that action selects the toolchain from the `action.yml` content at the
+> ref (input default `stable`, or a hard-wired `1.88.0`), not from the ref *name*, so
+> the SHA pin preserves toolchain selection (verified against the action source).


### PR DESCRIPTION
Establishes the PR-based gating you asked for (sq-prg4 / sq-yjoh / sq-clu0).

**CI infra**
- `ci-summary.yml` — a single aggregator check that polls the commit's check-runs across all workflows and passes ONLY when every other job passes (cross-workflow, like prod-solid-server pr-gate). The one required branch-protection check.
- `codeql.yml` — CodeQL SAST (Rust, build-mode none).
- **SHA-pin every third-party action** across all workflows (resolves Scorecard PinnedDependencies; trailing `# vX.Y.Z` drives Dependabot).

**Docs (AGENTS.md)**
- Contribution workflow (PRs, reviews resolved, ci-summary gate).
- Automated review — roborev on every commit incl. worktrees (codex/non-Anthropic; findings resolved by code-change-verified-on-HEAD or explicit triage, never by merging).
- Base gate clarified to full-workspace `cargo test` (roborev 2422); `docs/branch-protection.md` updated.

**needs:user follow-up (beaded sq-cw4n/sq-nzmf):** enabling branch protection + the code-scanning gate + auto-Copilot-review in the ruleset are owner actions; this PR lands the CI they require.

🤖 Generated with [Claude Code](https://claude.com/claude-code)