### PR TITLE
feat(server): SERVICE egress allowlist — default-deny SSRF guard via CLI/env/file (sq-4w18)

### DIFF
--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -33,6 +33,11 @@ mod service;
 // (threat-model B4 / sq-2v6f). [OPUS-4.8]
 #[cfg(feature = "service")]
 pub use service::with_service_egress_allow;
+// Strict allowlist-only egress policy: only listed hosts reachable (even public ones
+// off the list are refused). The network-exposed server wires this to --service-allow
+// so federation is restricted to operator-configured endpoints. [OPUS-4.8] (sq-4w18)
+#[cfg(feature = "service")]
+pub use service::with_service_egress_policy;
 mod update;
 // zk-trace seam (NON-DEFAULT `zk` feature; consumed only by `sparq-zk`).
 // When off, zero zk code is compiled — default builds and wasm are untouched.

--- a/crates/sparq-engine/src/service.rs
+++ b/crates/sparq-engine/src/service.rs
@@ -242,41 +242,105 @@ pub(crate) fn is_forbidden_ip(ip: std::net::IpAddr) -> bool {
     }
 }
 
-/// SERVICE egress allowlist. A host (DNS name or IP literal, exactly as written
-/// in the SERVICE IRI authority) on this list is exempt from [`is_forbidden_ip`]
-/// — its resolved addresses are permitted even when private. Empty by default
-/// (full default-deny). Installed for a scope via [`with_service_egress_allow`],
-/// mirroring `update.rs`'s `with_load_base` thread-local allowlist pattern.
+/// SERVICE egress allowlist + policy mode. A host (DNS name or IP literal, exactly
+/// as written in the SERVICE IRI authority) on this list is exempt from
+/// [`is_forbidden_ip`] — its resolved addresses are permitted even when private.
+///
+/// Two modes (the [`Mode`] flag), both default-deny but at different strictnesses:
+///
+/// * **`Mode::DenyPrivate`** (the engine's standalone default, installed by
+///   [`with_service_egress_allow`]): public IPs are reachable, private/internal IPs
+///   are refused unless the host is on the allowlist. Allowlist entries only *add*
+///   permission (re-open a private host).
+/// * **`Mode::AllowlistOnly`** (the strict mode the *server* uses, installed by
+///   [`with_service_egress_policy`]): ONLY hosts on the allowlist may be reached at
+///   all — every other host is refused even if it resolves to a public address. An
+///   empty allowlist in this mode is therefore "deny ALL SERVICE", which is the
+///   server's safe default for the network-exposed surface.
+///
+/// Empty + `DenyPrivate` (the thread-local default before any scope installs a
+/// policy) preserves the original behaviour: public allowed, private denied.
+/// Installed for a scope via [`with_service_egress_allow`] /
+/// [`with_service_egress_policy`], mirroring `update.rs`'s `with_load_base`
+/// thread-local allowlist pattern. [OPUS-4.8] (sq-4w18)
 #[cfg(feature = "service")]
 pub(crate) mod egress_policy {
     use std::cell::RefCell;
     use std::collections::HashSet;
 
-    thread_local! {
-        static ALLOW: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
+    /// How the allowlist is interpreted for hosts NOT on it. [OPUS-4.8] (sq-4w18)
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) enum Mode {
+        /// Hosts off the allowlist are reachable iff they resolve to a *public*
+        /// address (private/internal IPs are refused). The engine's standalone
+        /// default and the semantics of [`super::with_service_egress_allow`].
+        DenyPrivate,
+        /// Hosts off the allowlist are refused unconditionally (even public IPs).
+        /// The server installs this so federation is restricted to exactly the
+        /// operator-listed hosts; an empty allowlist = deny ALL SERVICE.
+        AllowlistOnly,
     }
 
-    /// Restores the previous allowlist when the installing scope returns (also on
+    struct Policy {
+        allow: HashSet<String>,
+        mode: Mode,
+    }
+
+    thread_local! {
+        static POLICY: RefCell<Policy> =
+            RefCell::new(Policy { allow: HashSet::new(), mode: Mode::DenyPrivate });
+    }
+
+    /// Restores the previous policy when the installing scope returns (also on
     /// unwind, so a panicking SERVICE call never leaks a relaxed policy).
-    pub(crate) struct Guard(HashSet<String>);
+    pub(crate) struct Guard(Option<Policy>);
     impl Drop for Guard {
         fn drop(&mut self) {
-            ALLOW.with(|a| *a.borrow_mut() = std::mem::take(&mut self.0));
+            if let Some(prev) = self.0.take() {
+                POLICY.with(|p| *p.borrow_mut() = prev);
+            }
         }
     }
 
-    /// Installs `hosts` (lower-cased) as the allowlisted SERVICE hosts for the
-    /// duration of the returned guard; the previous set is restored on drop.
-    pub(crate) fn install(hosts: impl IntoIterator<Item = String>) -> Guard {
-        let set: HashSet<String> = hosts.into_iter().map(|h| h.to_ascii_lowercase()).collect();
-        // Swap in the new set and hand the previous one to the Guard for restore.
-        ALLOW.with(|a| Guard(std::mem::replace(&mut *a.borrow_mut(), set)))
+    /// Installs `hosts` (lower-cased) + `mode` as the active SERVICE egress policy
+    /// for the duration of the returned guard; the previous policy is restored on
+    /// drop.
+    pub(crate) fn install(hosts: impl IntoIterator<Item = String>, mode: Mode) -> Guard {
+        let allow: HashSet<String> = hosts.into_iter().map(|h| h.to_ascii_lowercase()).collect();
+        let next = Policy { allow, mode };
+        // Swap in the new policy and hand the previous one to the Guard for restore.
+        POLICY.with(|p| Guard(Some(std::mem::replace(&mut *p.borrow_mut(), next))))
     }
 
-    /// True if `host` (case-insensitive) is on the active allowlist.
+    /// True if `host` (case-insensitive) is on the active allowlist. An entry is
+    /// matched two ways: [OPUS-4.8] (sq-4w18)
+    ///   * **exact** — the entry equals the host (`"sparql.example.org"`).
+    ///   * **suffix wildcard** — an entry beginning with a dot (`".example.org"`)
+    ///     matches any host ending in that suffix INCLUDING the bare apex
+    ///     (`example.org`, `a.example.org`, `a.b.example.org`). This is the engine
+    ///     representation of the server's `*.example.org` pattern. The leading-dot
+    ///     boundary means `.example.org` does NOT match `notexample.org`.
     pub(crate) fn is_allowed(host: &str) -> bool {
         let h = host.to_ascii_lowercase();
-        ALLOW.with(|a| a.borrow().contains(&h))
+        POLICY.with(|p| {
+            let allow = &p.borrow().allow;
+            if allow.contains(&h) {
+                return true;
+            }
+            // Suffix-wildcard entries (".suffix"): match the apex and any subdomain.
+            allow.iter().any(|e| {
+                if let Some(suffix) = e.strip_prefix('.') {
+                    h == suffix || h.ends_with(e.as_str())
+                } else {
+                    false
+                }
+            })
+        })
+    }
+
+    /// The active policy mode.
+    pub(crate) fn mode() -> Mode {
+        POLICY.with(|p| p.borrow().mode)
     }
 }
 
@@ -304,7 +368,46 @@ pub fn with_service_egress_allow<R>(
     hosts: impl IntoIterator<Item = String>,
     f: impl FnOnce() -> R,
 ) -> R {
-    let _guard = egress_policy::install(hosts);
+    let _guard = egress_policy::install(hosts, egress_policy::Mode::DenyPrivate);
+    f()
+}
+
+/// Runs `f` under a STRICT SERVICE egress policy: only the listed `hosts` may be
+/// reached, and EVERY other host is refused — even one resolving to a public
+/// address. This is the policy the network-exposed **server** installs (bead
+/// sq-4w18): the SERVICE clause turns attacker-controlled SPARQL into outbound HTTP,
+/// so federation is restricted to exactly the operator-configured endpoints.
+///
+/// `strict = false` is identical to [`with_service_egress_allow`] (default-deny
+/// *private*: public hosts reachable, private/internal only if allowlisted). The
+/// server wires this directly to its `--service-allow` config so the same call site
+/// expresses both "no federation at all" (strict + empty list) and "an explicit
+/// allowlist" (strict + hosts). Host matching is case-insensitive against the
+/// SERVICE IRI *authority* (DNS name or IP literal), exactly like
+/// [`with_service_egress_allow`].
+///
+/// ```no_run
+/// # #[cfg(feature = "service")] {
+/// // Restrict SERVICE to a single trusted endpoint; anything else is refused.
+/// sparq_engine::with_service_egress_policy(true, ["sparql.example.org".to_string()], || {
+///     // ... run a query that may contain `SERVICE <…> { ... }`
+/// });
+/// // Strict + empty list = federation fully disabled (deny ALL SERVICE).
+/// sparq_engine::with_service_egress_policy(true, std::iter::empty(), || { /* ... */ });
+/// # }
+/// ```
+#[cfg(feature = "service")]
+pub fn with_service_egress_policy<R>(
+    strict: bool,
+    hosts: impl IntoIterator<Item = String>,
+    f: impl FnOnce() -> R,
+) -> R {
+    let mode = if strict {
+        egress_policy::Mode::AllowlistOnly
+    } else {
+        egress_policy::Mode::DenyPrivate
+    };
+    let _guard = egress_policy::install(hosts, mode);
     f()
 }
 
@@ -356,6 +459,20 @@ impl ureq::Resolver for EgressFilterResolver {
         };
         let host = host.trim_start_matches('[').trim_end_matches(']');
         let allowed = egress_policy::is_allowed(host);
+        // [OPUS-4.8] (sq-4w18) STRICT (AllowlistOnly) mode — the server's policy —
+        // refuses any host not on the allowlist BEFORE resolving DNS, so a host that
+        // is not explicitly permitted never triggers even a lookup (no network at all,
+        // and no public-IP escape hatch). An empty allowlist here = deny ALL SERVICE.
+        if !allowed && egress_policy::mode() == egress_policy::Mode::AllowlistOnly {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!(
+                    "SERVICE egress refused: host {host:?} is not on the SERVICE allowlist \
+                     (strict allowlist-only policy; add it via --service-allow / SPARQ_SERVICE_ALLOW \
+                     on the server, or with_service_egress_policy in an embedder)"
+                ),
+            ));
+        }
         let all: Vec<std::net::SocketAddr> = netloc.to_socket_addrs()?.collect();
         let permitted: Vec<std::net::SocketAddr> = all
             .into_iter()
@@ -596,7 +713,10 @@ mod tests {
         // Default: nothing is allowlisted.
         assert!(!egress_policy::is_allowed("localhost"));
         {
-            let _g = egress_policy::install(["localhost".to_string(), "10.0.0.5".to_string()]);
+            let _g = egress_policy::install(
+                ["localhost".to_string(), "10.0.0.5".to_string()],
+                egress_policy::Mode::DenyPrivate,
+            );
             assert!(egress_policy::is_allowed("localhost"));
             assert!(egress_policy::is_allowed("LOCALHOST")); // case-insensitive
             assert!(egress_policy::is_allowed("10.0.0.5"));
@@ -615,6 +735,45 @@ mod tests {
         assert!(seen);
         // Allowlist is gone after the scope returns.
         assert!(!egress_policy::is_allowed("sparql.internal"));
+    }
+
+    #[test]
+    fn strict_allowlist_only_mode_scopes_and_restores() {
+        // [OPUS-4.8] (sq-4w18) Strict mode: only listed hosts are allowed; the mode
+        // and allowlist both restore on scope exit.
+        assert_eq!(egress_policy::mode(), egress_policy::Mode::DenyPrivate);
+        assert!(!egress_policy::is_allowed("a.example"));
+        with_service_egress_policy(true, ["a.example".to_string()], || {
+            assert_eq!(egress_policy::mode(), egress_policy::Mode::AllowlistOnly);
+            assert!(egress_policy::is_allowed("a.example"));
+            assert!(egress_policy::is_allowed("A.EXAMPLE")); // case-insensitive
+            assert!(!egress_policy::is_allowed("b.example"));
+        });
+        assert_eq!(egress_policy::mode(), egress_policy::Mode::DenyPrivate);
+        assert!(!egress_policy::is_allowed("a.example"));
+    }
+
+    #[test]
+    fn suffix_wildcard_allowlist_matches_apex_and_subdomains() {
+        // [OPUS-4.8] (sq-4w18) A ".example.org" entry matches the apex and any
+        // subdomain, but not a host that merely ends in the same letters.
+        with_service_egress_policy(true, [".example.org".to_string()], || {
+            assert!(egress_policy::is_allowed("example.org")); // apex
+            assert!(egress_policy::is_allowed("sparql.example.org")); // subdomain
+            assert!(egress_policy::is_allowed("a.b.example.org")); // deep subdomain
+            assert!(egress_policy::is_allowed("SPARQL.EXAMPLE.ORG")); // case-insensitive
+            assert!(!egress_policy::is_allowed("notexample.org")); // boundary respected
+            assert!(!egress_policy::is_allowed("example.org.evil.com")); // suffix only
+        });
+    }
+
+    #[test]
+    fn non_strict_policy_matches_allow_helper() {
+        // strict=false behaves exactly like with_service_egress_allow (DenyPrivate).
+        with_service_egress_policy(false, ["c.example".to_string()], || {
+            assert_eq!(egress_policy::mode(), egress_policy::Mode::DenyPrivate);
+            assert!(egress_policy::is_allowed("c.example"));
+        });
     }
 
     #[test]
@@ -680,6 +839,48 @@ mod tests {
             .unwrap();
             assert_eq!(addrs.len(), 1);
             assert!(addrs[0].ip().is_loopback());
+        }
+
+        // [OPUS-4.8] (sq-4w18) Strict allowlist-only mode — the server's policy.
+
+        #[test]
+        fn strict_refuses_public_host_off_the_allowlist() {
+            let r = EgressFilterResolver;
+            let err = with_service_egress_policy(true, std::iter::empty(), || r.resolve("8.8.8.8:443"))
+                .unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+        }
+
+        #[test]
+        fn strict_empty_allowlist_denies_all() {
+            let r = EgressFilterResolver;
+            for netloc in ["8.8.8.8:443", "1.1.1.1:80", "127.0.0.1:8080"] {
+                let err = with_service_egress_policy(true, std::iter::empty(), || r.resolve(netloc))
+                    .unwrap_err();
+                assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied, "{netloc} must be refused");
+            }
+        }
+
+        #[test]
+        fn strict_permits_allowlisted_host() {
+            let r = EgressFilterResolver;
+            let addrs = with_service_egress_policy(true, ["8.8.8.8".to_string()], || r.resolve("8.8.8.8:443"))
+                .unwrap();
+            assert_eq!(addrs.len(), 1);
+            assert_eq!(addrs[0].ip(), v4(8, 8, 8, 8));
+
+            let addrs = with_service_egress_policy(true, ["127.0.0.1".to_string()], || r.resolve("127.0.0.1:8080"))
+                .unwrap();
+            assert_eq!(addrs.len(), 1);
+            assert!(addrs[0].ip().is_loopback());
+        }
+
+        #[test]
+        fn non_strict_resolver_allows_public_off_list() {
+            let r = EgressFilterResolver;
+            let addrs = with_service_egress_policy(false, std::iter::empty(), || r.resolve("8.8.8.8:443"))
+                .unwrap();
+            assert_eq!(addrs.len(), 1);
         }
     }
 }

--- a/crates/sparq-server/Cargo.toml
+++ b/crates/sparq-server/Cargo.toml
@@ -39,6 +39,13 @@ server = ["dep:sparq-serve", "dep:axum", "dep:tokio", "dep:tower", "dep:tower-ht
 # real: each retained generation is a FULL Graph until the structural-fork follow-up
 # lands (see sparq_serve::TimeTravelConfig).
 time-travel = ["server"]
+# [OPUS-4.8] (sq-4w18) `service` (default OFF) enables the engine's SPARQL 1.1 federated
+# SERVICE clause (passthrough to sparq-engine/service: ureq + serde_json, native-only).
+# It makes the host an SSRF surface, so it is gated behind a default-DENY-all egress
+# allowlist (--service-allow / --service-allow-file / SPARQ_SERVICE_ALLOW). Off (default),
+# no federation code compiles and a SERVICE clause errors at execution. See the README
+# and skills/http-server/SKILL.md.
+service = ["server", "sparq-engine/service"]
 # `geo` (default OFF) installs sparq-geo's geof: extension-function registry
 # (GeoSPARQL distance / sf* relations / envelope / boundary / convexHull) on the
 # query, update and subscription paths — see docs/extension-functions.md. Off, the

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -44,15 +44,28 @@ API gateway, or [`sparq-solid`](../sparq-solid/README.md)). Concretely:
   **unlimited by default**, and there is no query-complexity bound. If you expose the server,
   set `--max-results`/`--max-concurrent` appropriately and put a rate limiter in the gateway.
   (Tracked: bead `sq-ebii` — the broader timeout/memory/rate-limit/SSRF policy.)
-* **`SERVICE` federation SSRF.** SPARQL `SERVICE` (federated query) is **OFF in the shipped
-  server** — it is gated behind the engine's non-default `service` cargo feature, which
-  `sparq-server` does not enable, so a `SERVICE` clause is *rejected* as unsupported (verified:
-  `ureq` is absent from the server's dependency tree). **If** a deployer enables that feature,
-  the federated-endpoint fetch currently has **no egress filtering** — a
-  `SERVICE <http://169.254.169.254/…>` / `http://127.0.0.1` / RFC1918 clause becomes an SSRF
-  primitive into the internal network / cloud-metadata endpoint. Do not enable the `service`
-  feature on a server reachable by untrusted query authors until the egress allow/deny filter
-  lands (tracked: bead `sq-2v6f`, engine-side `crates/sparq-engine/src/service.rs`).
+* **`SERVICE` federation SSRF — gated behind a default-deny egress allowlist** <!-- [OPUS-4.8] sq-4w18 -->.
+  SPARQL `SERVICE` (federated query) is **OFF in the default build** — gated behind the
+  server's non-default `service` cargo feature (which turns on the engine's `service` feature;
+  off, `ureq` is absent from the dependency tree and a `SERVICE` clause errors at execution).
+  Built with `--features service`, the server is **default-DENY-all SERVICE**: a `SERVICE <iri>`
+  clause reaches **nothing** unless its host is on the egress allowlist. A `SERVICE` clause turns
+  attacker-controlled query text into an outbound request from the server host (textbook SSRF;
+  worst case `169.254.169.254` cloud-metadata), so the operator must opt in to every reachable
+  host. Configure the allowlist with any of (UNIONed, additive):
+  * `--service-allow HOST` / `--service-allow *.SUFFIX` — repeatable; exact host or suffix wildcard;
+  * `--service-allow-file PATH` — one entry per line (`#` comments + blanks ignored);
+  * `SPARQ_SERVICE_ALLOW` — comma/whitespace-separated.
+
+  Matching is case-insensitive against the SERVICE IRI authority; `*.example.org` matches the apex
+  `example.org` and any subdomain. The server is **strict** — unlike the engine's standalone
+  default (which permits public IPs and only blocks private/internal ones via
+  `with_service_egress_allow`), here even a public host must be on the allowlist. Enforcement
+  happens before any socket is opened, on the *resolved* IP (DNS-rebinding-safe), and applies
+  uniformly to queries, ASK, CONSTRUCT/DESCRIBE, subscriptions and federated `INSERT … WHERE`
+  updates. The startup log prints the effective allowlist. (Beads `sq-4w18` this wiring, `sq-2v6f`
+  the engine SSRF filter; engine seam `crates/sparq-engine/src/service.rs`
+  `with_service_egress_policy`.)
 
 ## Running
 

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -198,7 +198,14 @@ impl ServerConfig {
     /// and `SPARQ_SERVICE_ALLOW` (comma/whitespace-separated SERVICE egress allowlist;
     /// [OPUS-4.8] sq-4w18). CLI flags override / widen these in `main` (the allowlist is
     /// additive: `--service-allow` / `--service-allow-file` UNION with the env baseline).
-    pub fn from_env() -> Self {
+    ///
+    /// [OPUS-4.8] sq-4w18: returns `Err` (rather than panicking) on a malformed
+    /// `SPARQ_SERVICE_ALLOW` entry. `from_env` is public config API an embedder may
+    /// call, and a panic in a config constructor is a hostile surprise; a `Result`
+    /// (the crate's `Result<_, String>` error style, e.g. `from_sources` / nlq's
+    /// `from_env`) lets the caller surface a clean user-facing message. The valid
+    /// path is byte-for-byte unchanged.
+    pub fn from_env() -> Result<Self, String> {
         let mut cfg = Self::default();
         if let Some(secs) = env_parse::<u64>("SPARQ_QUERY_TIMEOUT") {
             cfg.query_timeout = (secs > 0).then(|| Duration::from_secs(secs));
@@ -236,14 +243,15 @@ impl ServerConfig {
         // [OPUS-4.8] sq-4w18: SERVICE egress allowlist baseline from SPARQ_SERVICE_ALLOW
         // (comma/whitespace-separated). The binary then ADDS any `--service-allow` /
         // `--service-allow-file` entries (the union — CLI only ever widens). A malformed
-        // env entry is a hard startup error rather than a silently-dropped host, so the
-        // operator's allowlist is never quietly narrower than written.
+        // env entry is a hard startup error (propagated, not panicked) rather than a
+        // silently-dropped host, so the operator's allowlist is never quietly narrower
+        // than written.
         if let Ok(v) = std::env::var("SPARQ_SERVICE_ALLOW") {
             cfg.service_allow
                 .add_many(&v)
-                .unwrap_or_else(|e| panic!("SPARQ_SERVICE_ALLOW: {e}"));
+                .map_err(|e| format!("SPARQ_SERVICE_ALLOW: {e}"))?;
         }
-        cfg
+        Ok(cfg)
     }
 }
 

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -71,6 +71,34 @@ pub(crate) fn with_extensions<T>(f: impl FnOnce() -> T) -> T {
     f()
 }
 
+/// [OPUS-4.8] (sq-4w18) Runs an engine call inside the full per-request engine scope:
+/// the SERVICE egress allowlist policy AND the SPARQL extension functions.
+///
+/// With the `service` cargo feature, this installs
+/// [`sparq_engine::with_service_egress_policy`] in STRICT (allowlist-only) mode for the
+/// config's [`ServerConfig::service_allow`]: SERVICE may reach ONLY allowlisted hosts —
+/// an empty allowlist (the default) refuses ALL federation before any network call.
+/// Every engine entry point that can evaluate a `SERVICE` clause (query, ASK,
+/// CONSTRUCT/DESCRIBE, the subscription re-eval, and updates with a federated WHERE) is
+/// wrapped in this, so the policy applies uniformly. The policy is a thread-local
+/// installed for the closure's duration; the engine re-checks it inside the ureq
+/// resolver on the same thread, so it covers the blocking-pool worker that runs the call.
+///
+/// Without the `service` feature this is exactly [`with_extensions`] — no federation
+/// code exists, so there is nothing to gate (a SERVICE clause errors at execution).
+#[cfg(feature = "service")]
+pub(crate) fn with_engine_scope<T>(config: &ServerConfig, f: impl FnOnce() -> T) -> T {
+    sparq_engine::with_service_egress_policy(true, config.service_allow.engine_entries(), || {
+        with_extensions(f)
+    })
+}
+
+#[cfg(not(feature = "service"))]
+#[inline(always)]
+pub(crate) fn with_engine_scope<T>(_config: &ServerConfig, f: impl FnOnce() -> T) -> T {
+    with_extensions(f)
+}
+
 // ---------------------------------------------------------------------------
 // Hardening configuration (T15)
 // ---------------------------------------------------------------------------
@@ -124,6 +152,20 @@ pub struct ServerConfig {
     /// This is purely a *bind-time* posture gate in the binary; it does not add any
     /// per-request auth and does not affect the library `router`/`harden` surface.
     pub allow_remote: bool,
+    /// [OPUS-4.8] (sq-4w18) SERVICE federation egress allowlist. SPARQL `SERVICE <iri>`
+    /// makes attacker-controlled query text trigger an outbound HTTP request from the
+    /// server host — an SSRF surface. The server's posture is **default-DENY-all
+    /// SERVICE**: with the `service` cargo feature on but this allowlist EMPTY (the
+    /// default), every SERVICE clause is refused before any network call. An operator
+    /// opts hosts back in via `--service-allow` / `--service-allow-file` /
+    /// `SPARQ_SERVICE_ALLOW` (see [`crate::ServiceAllowlist`]); only listed hosts (or
+    /// `*.suffix` matches) become reachable — even a public host must be listed.
+    ///
+    /// Enforced by installing [`sparq_engine::with_service_egress_policy`] (strict =
+    /// allowlist-only) around every engine call. Without the `service` cargo feature
+    /// this field is still present (so the config shape is stable) but inert: no
+    /// federation code is compiled and a SERVICE clause errors at execution as before.
+    pub service_allow: crate::service_config::ServiceAllowlist,
 }
 
 impl Default for ServerConfig {
@@ -141,6 +183,8 @@ impl Default for ServerConfig {
             time_travel_max_age: None,
             verbose: false,
             allow_remote: false, // [OPUS-4.8] sq-o4qf: safe default — refuse non-loopback bind unless opted in
+            // [OPUS-4.8] sq-4w18: safe default — empty allowlist = deny ALL SERVICE.
+            service_allow: crate::service_config::ServiceAllowlist::default(),
         }
     }
 }
@@ -150,7 +194,10 @@ impl ServerConfig {
     /// `SPARQ_MAX_BODY_BYTES`, `SPARQ_MAX_CONCURRENT` and `SPARQ_MAX_RESULTS`
     /// environment variables — plus, with the `time-travel` feature,
     /// `SPARQ_TIME_TRAVEL_GENERATIONS` and `SPARQ_TIME_TRAVEL_MAX_AGE` (seconds;
-    /// `0` disables the age bound). CLI flags override these in `main`.
+    /// `0` disables the age bound), `SPARQ_ALLOW_REMOTE` (non-loopback bind opt-in),
+    /// and `SPARQ_SERVICE_ALLOW` (comma/whitespace-separated SERVICE egress allowlist;
+    /// [OPUS-4.8] sq-4w18). CLI flags override / widen these in `main` (the allowlist is
+    /// additive: `--service-allow` / `--service-allow-file` UNION with the env baseline).
     pub fn from_env() -> Self {
         let mut cfg = Self::default();
         if let Some(secs) = env_parse::<u64>("SPARQ_QUERY_TIMEOUT") {
@@ -185,6 +232,16 @@ impl ServerConfig {
         // safe default of refusing to expose the unauthenticated surface beyond loopback.
         if let Ok(v) = std::env::var("SPARQ_ALLOW_REMOTE") {
             cfg.allow_remote = env_truthy(&v);
+        }
+        // [OPUS-4.8] sq-4w18: SERVICE egress allowlist baseline from SPARQ_SERVICE_ALLOW
+        // (comma/whitespace-separated). The binary then ADDS any `--service-allow` /
+        // `--service-allow-file` entries (the union — CLI only ever widens). A malformed
+        // env entry is a hard startup error rather than a silently-dropped host, so the
+        // operator's allowlist is never quietly narrower than written.
+        if let Ok(v) = std::env::var("SPARQ_SERVICE_ALLOW") {
+            cfg.service_allow
+                .add_many(&v)
+                .unwrap_or_else(|e| panic!("SPARQ_SERVICE_ALLOW: {e}"));
         }
         cfg
     }
@@ -410,11 +467,23 @@ impl TouchedPods {
 
 /// The sequenced writer's snapshot-production strategy: sparq-serve's [`GraphApplier`]
 /// (per-batch O(graph) fork + O(batch) `update_in_place` — see its module docs for the
-/// recorded cost decision), with every engine call wrapped in [`with_extensions`] so the
-/// opt-in `geo` registry applies to updates exactly as it does to queries. The trait is
-/// sparq-serve's documented seam for exactly this wrapper.
-#[derive(Default)]
-struct ServerApplier(GraphApplier);
+/// recorded cost decision), with every engine call wrapped in [`with_engine_scope`] so the
+/// opt-in `geo` registry AND the SERVICE egress allowlist (sq-4w18) apply to updates
+/// exactly as they do to queries — an `INSERT … WHERE { SERVICE <iri> { … } }` update
+/// federates under the same default-deny allowlist as a read. The trait is sparq-serve's
+/// documented seam for exactly this wrapper. [OPUS-4.8]
+struct ServerApplier {
+    inner: GraphApplier,
+    /// The config the writer thread enforces around every engine call (carries the
+    /// SERVICE egress allowlist; the writer has no per-request config, so it owns its own).
+    config: Arc<ServerConfig>,
+}
+
+impl ServerApplier {
+    fn new(config: Arc<ServerConfig>) -> Self {
+        Self { inner: GraphApplier::default(), config }
+    }
+}
 
 impl ApplyUpdates for ServerApplier {
     type Snapshot = Graph;
@@ -422,15 +491,15 @@ impl ApplyUpdates for ServerApplier {
     type Update = String;
 
     fn fork(&mut self, base: &Graph) -> Result<Graph, String> {
-        with_extensions(|| self.0.fork(base))
+        with_engine_scope(&self.config, || self.inner.fork(base))
     }
 
     fn apply(&mut self, working: &mut Graph, update: &String) -> Result<(), String> {
-        with_extensions(|| self.0.apply(working, update))
+        with_engine_scope(&self.config, || self.inner.apply(working, update))
     }
 
     fn seal(&mut self, working: Graph) -> Graph {
-        self.0.seal(working)
+        self.inner.seal(working)
     }
 }
 
@@ -489,11 +558,19 @@ impl AppState {
             ..sparq_serve::RingConfig::default()
         };
         let ring = Arc::new(GenerationRing::with_config(graph, ring_config));
-        let writer = Arc::new(Writer::spawn(ring.clone(), ServerApplier::default(), WriterConfig::default()));
+        // [OPUS-4.8] sq-4w18: share the config Arc with the writer so its update path
+        // enforces the same SERVICE egress allowlist (a federated `INSERT … WHERE` is
+        // gated like a read).
+        let config = Arc::new(config);
+        let writer = Arc::new(Writer::spawn(
+            ring.clone(),
+            ServerApplier::new(config.clone()),
+            WriterConfig::default(),
+        ));
         Self {
             ring,
             writer,
-            config: Arc::new(config),
+            config,
             commits: Arc::new(tokio::sync::watch::channel(0).0),
             subs: Arc::new(crate::subscriptions::SubscriptionCounters::default()),
             metrics: Arc::new(crate::metrics::Metrics::default()),
@@ -939,7 +1016,10 @@ async fn run_query_pinned(
         let budget = make_budget(&config, true);
         let task = tokio::task::spawn_blocking(move || {
             let graph = gen.snapshot();
-            let r = with_extensions(|| {
+            // [OPUS-4.8] sq-4w18: EXPLAIN ANALYZE executes (can hit SERVICE), so it runs
+            // under the egress allowlist policy like a normal query; plan-only is a dry
+            // run but is wrapped identically for uniformity (it never dials).
+            let r = with_engine_scope(&cfg, || {
                 if analyze {
                     sparq_engine::explain_analyze_with_budget(graph, &q, &budget)
                 } else {
@@ -968,7 +1048,7 @@ async fn run_query_pinned(
             let budget = make_budget(&config, !is_ask);
             let cfg = config.clone();
             let task = tokio::task::spawn_blocking(move || {
-                with_extensions(|| if is_ask {
+                with_engine_scope(&cfg, || if is_ask {
                     match sparq_engine::ask_with_budget(gen.snapshot(), &select, &budget) {
                         Ok(value) => {
                             let (body, ct) = match fmt {
@@ -999,7 +1079,7 @@ async fn run_query_pinned(
                 // [OPUS-4.8] sq-rt6v: produce the triple list once, then serialise it in the
                 // negotiated graph syntax — N-Triples (default), prefix-compacting Turtle, or
                 // RDF/XML — rather than always emitting N-Triples.
-                match with_extensions(|| sparq_engine::construct_or_describe_with_budget(gen.snapshot(), &query, &budget)) {
+                match with_engine_scope(&cfg, || sparq_engine::construct_or_describe_with_budget(gen.snapshot(), &query, &budget)) {
                     Ok(triples) => {
                         let body = serialise_graph_triples(&triples, gfmt);
                         text_response(StatusCode::OK, gfmt.content_type(), body, head_only)
@@ -1900,5 +1980,40 @@ mod bind_posture_tests {
         for f in ["", "0", "false", "no", "off", "2", "maybe"] {
             assert!(!env_truthy(f), "{f:?} should be falsy");
         }
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-4w18 — SERVICE egress allowlist config wiring tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod service_allow_config_tests {
+    //! The default posture and the ServerConfig <-> engine-entries plumbing. These are
+    //! pure (no process-env mutation) so they parallelise; the env-precedence path
+    //! (SPARQ_SERVICE_ALLOW baseline + CLI/file union) is covered by
+    //! `service_config::tests::from_sources_unions_cli_file_env`.
+    use super::ServerConfig;
+    use crate::service_config::ServiceAllowlist;
+
+    #[test]
+    fn default_config_denies_all_service() {
+        // The safe default: no host allowlisted => deny ALL SERVICE.
+        let cfg = ServerConfig::default();
+        assert!(cfg.service_allow.is_empty(), "default must be deny-all");
+        assert!(cfg.service_allow.engine_entries().is_empty());
+    }
+
+    #[test]
+    fn populated_allowlist_flows_to_engine_entries() {
+        let mut cfg = ServerConfig::default();
+        let mut allow = ServiceAllowlist::default();
+        allow.add("sparql.example.org").unwrap();
+        allow.add("*.internal").unwrap();
+        cfg.service_allow = allow;
+        let mut e = cfg.service_allow.engine_entries();
+        e.sort();
+        // Exact host verbatim; the wildcard in the engine's leading-dot form.
+        assert_eq!(e, vec![".internal".to_string(), "sparql.example.org".to_string()]);
     }
 }

--- a/crates/sparq-server/src/lib.rs
+++ b/crates/sparq-server/src/lib.rs
@@ -29,6 +29,14 @@ pub mod exec;
 pub mod graph;
 pub mod negotiate;
 pub mod results;
+/// [OPUS-4.8] (sq-4w18) SERVICE federation egress allowlist — the
+/// [`service_config::ServiceAllowlist`] config type (parse `--service-allow` /
+/// `--service-allow-file` / `SPARQ_SERVICE_ALLOW`, exact-host + `*.suffix` matcher).
+/// Pure (no async), always compiled + unit-tested; it only *carries* the policy. The
+/// policy is enforced by the engine's `service` feature, which the server enables via
+/// its own opt-in `service` feature. See the module docs for the default-DENY-all
+/// posture and rationale.
+pub mod service_config;
 
 #[cfg(feature = "server")]
 pub mod http;
@@ -45,6 +53,10 @@ pub mod subscriptions;
 pub use http::{
     bind_posture, harden, router, AppState, BindPosture, PinnedGen, ServerConfig, GLOBAL_POD,
 }; // [OPUS-4.8] sq-o4qf: bind_posture / BindPosture for the no-auth non-loopback bind gate
+
+/// [OPUS-4.8] (sq-4w18) The SERVICE egress allowlist config type, re-exported at the
+/// crate root next to [`ServerConfig`].
+pub use service_config::ServiceAllowlist;
 
 /// [OPUS-4.8] (sq-uqh, Wave B) Re-exported for consumers (and tests) that introspect a
 /// pinned generation's per-pod epoch vector — the cache-invalidation hook the server's

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -70,8 +70,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut addr = "127.0.0.1:3030".to_string();
     let mut format = "turtle".to_string();
     let mut data_file: Option<String> = None;
-    // Env first, flags override.
-    let mut config = ServerConfig::from_env();
+    // Env first, flags override. [OPUS-4.8] sq-4w18: a malformed SPARQ_SERVICE_ALLOW
+    // surfaces here as a clean config error (the `?` turns the String into the boxed
+    // error main returns -> a one-line message to stderr + non-zero exit), not a panic.
+    let mut config = ServerConfig::from_env()?;
     // [OPUS-4.8] sq-4w18: collect SERVICE egress allowlist entries from the CLI; they
     // are UNIONed with the SPARQ_SERVICE_ALLOW env baseline (already in `config`) + an
     // optional --service-allow-file, after the arg loop. An allowlist is additive, so

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -5,7 +5,16 @@
 //!   sparq-server [--addr 127.0.0.1:3030] [--allow-remote] [--format turtle]
 //!                [--query-timeout SECS] [--max-body-bytes N] [--max-concurrent N]
 //!                [--max-results N] [--max-subscriptions N]
-//!                [--max-subscriptions-per-conn N] [--verbose] [DATA_FILE]
+//!                [--max-subscriptions-per-conn N]
+//!                [--service-allow HOST|*.SUFFIX]... [--service-allow-file PATH]
+//!                [--verbose] [DATA_FILE]
+//!
+//! SERVICE federation (`service` build feature) is DENY-ALL by default: a `SERVICE <iri>`
+//! clause reaches NOTHING unless its host is allowlisted via `--service-allow` (repeatable;
+//! exact host or `*.suffix` wildcard), `--service-allow-file` (one entry per line) or the
+//! `SPARQ_SERVICE_ALLOW` env var (comma/whitespace-separated). This is an SSRF guard: a
+//! `SERVICE` clause turns attacker-controlled query text into an outbound request from this
+//! host. See crates/sparq-server/README.md -> "SERVICE federation (egress allowlist)". [OPUS-4.8]
 //!
 //! SECURITY: the server has NO built-in authentication on any endpoint (query, the
 //! `application/sparql-update` mutation path, the `/subscriptions` WebSocket). `--addr`
@@ -63,6 +72,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut data_file: Option<String> = None;
     // Env first, flags override.
     let mut config = ServerConfig::from_env();
+    // [OPUS-4.8] sq-4w18: collect SERVICE egress allowlist entries from the CLI; they
+    // are UNIONed with the SPARQ_SERVICE_ALLOW env baseline (already in `config`) + an
+    // optional --service-allow-file, after the arg loop. An allowlist is additive, so
+    // the CLI only ever widens what env granted (never silently narrows it).
+    let mut service_allow_cli: Vec<String> = Vec::new();
+    let mut service_allow_file: Option<String> = None;
 
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
@@ -102,9 +117,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // posture. Without this (and without SPARQ_ALLOW_REMOTE), a non-loopback --addr is
             // refused — see bind_posture below.
             "--allow-remote" => config.allow_remote = true,
+            // [OPUS-4.8] sq-4w18: SERVICE egress allowlist. Repeatable: each value adds one
+            // host (`sparql.example.org`) or suffix wildcard (`*.example.org`). With NO
+            // allowlist (the default) every SERVICE clause is refused (default-DENY-all).
+            "--service-allow" => {
+                service_allow_cli.push(args.next().ok_or("--service-allow requires a host/pattern")?);
+            }
+            "--service-allow-file" => {
+                service_allow_file = Some(args.next().ok_or("--service-allow-file requires a path")?);
+            }
             "-h" | "--help" => {
                 let time_travel = if cfg!(feature = "time-travel") {
                     " [--time-travel-generations N] [--time-travel-max-age SECS]"
+                } else {
+                    ""
+                };
+                let service = if cfg!(feature = "service") {
+                    " [--service-allow HOST|*.SUFFIX]... [--service-allow-file PATH]"
                 } else {
                     ""
                 };
@@ -112,16 +141,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     "usage: sparq-server [--addr HOST:PORT] [--allow-remote] [--format FMT] \
                      [--query-timeout SECS] [--max-body-bytes N] [--max-concurrent N] \
                      [--max-results N] [--max-subscriptions N] \
-                     [--max-subscriptions-per-conn N]{time_travel} [--verbose] [DATA_FILE]\n\n  \
+                     [--max-subscriptions-per-conn N]{time_travel}{service} [--verbose] [DATA_FILE]\n\n  \
                      SECURITY: no built-in auth. --addr defaults to loopback (127.0.0.1); a \
                      non-loopback bind (e.g. 0.0.0.0) is REFUSED unless --allow-remote (or \
                      SPARQ_ALLOW_REMOTE=1) is set, because it would expose READ+WRITE to the \
-                     network. Put it behind a reverse proxy / gateway that enforces auth."
+                     network. Put it behind a reverse proxy / gateway that enforces auth.\n  \
+                     SERVICE federation (the `service` build feature) is DENY-ALL by default: \
+                     SERVICE <iri> reaches NOTHING unless the host is allowlisted via \
+                     --service-allow / --service-allow-file / SPARQ_SERVICE_ALLOW \
+                     (exact host or *.suffix wildcard) — an SSRF guard."
                 );
                 return Ok(());
             }
             other => data_file = Some(other.to_string()),
         }
+    }
+
+    // [OPUS-4.8] sq-4w18: merge the --service-allow-file + --service-allow CLI entries
+    // INTO the env baseline already in config.service_allow (union — additive). A
+    // malformed entry or unreadable file is a hard startup error: better to refuse to
+    // boot than to silently run with an allowlist narrower than the operator wrote.
+    if let Some(path) = &service_allow_file {
+        let text = std::fs::read_to_string(path).map_err(|e| format!("--service-allow-file {path}: {e}"))?;
+        for line in text.lines() {
+            let line = line.split('#').next().unwrap_or("").trim();
+            config.service_allow.add(line)?;
+        }
+    }
+    for entry in &service_allow_cli {
+        config.service_allow.add(entry)?;
     }
 
     if config.verbose {
@@ -156,6 +204,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.max_subscriptions,
         config.max_subscriptions_per_conn,
     );
+    // [OPUS-4.8] sq-4w18: surface the SERVICE egress posture at startup so an operator
+    // sees whether (and where) federation can reach. Only meaningful with the `service`
+    // build feature; without it a SERVICE clause errors at execution regardless.
+    #[cfg(feature = "service")]
+    eprintln!("SERVICE egress allowlist: {}", config.service_allow.display());
     #[cfg(feature = "time-travel")]
     eprintln!(
         "time travel: ?generation=N enabled — generations={} max-age={} (each retained generation is a full graph)",

--- a/crates/sparq-server/src/service_config.rs
+++ b/crates/sparq-server/src/service_config.rs
@@ -1,0 +1,255 @@
+//! SERVICE federation egress allowlist — server configuration. [OPUS-4.8] (sq-4w18)
+//!
+//! SPARQL 1.1 federated query (`SERVICE <iri> { … }`) turns attacker-controlled
+//! query text into an OUTBOUND HTTP request from the server host — a textbook SSRF
+//! primitive (the worst case being the cloud-metadata endpoint
+//! `169.254.169.254`). `sparq-server` is the network-exposed surface, so it locks
+//! federation down by default and makes the operator opt specific hosts back in.
+//!
+//! ## Default policy: DENY ALL SERVICE
+//!
+//! With the `service` cargo feature on but NO allowlist configured, **every**
+//! `SERVICE` clause is refused before any network call — federation is effectively
+//! off. Rationale: the server accepts queries from the network, and a SERVICE clause
+//! is a request to dial an arbitrary endpoint *from inside the deployment's network
+//! boundary*; defaulting to "reach nothing" is the only safe posture for an
+//! unauthenticated, network-facing process. An operator enables federation by
+//! listing the hosts it is allowed to reach; nothing else becomes reachable. This
+//! mirrors the server's other fail-closed defaults (loopback-only bind unless
+//! `--allow-remote`; `LOAD file://` gated behind a base).
+//!
+//! This is STRICTER than the engine's standalone default (which allows public IPs
+//! and only blocks private/internal ones): on the server, a host must be on the
+//! allowlist to be reached *at all*, even a public one. The strictness is wired via
+//! [`sparq_engine::with_service_egress_policy`] with `strict = true`.
+//!
+//! ## Allowlist syntax
+//!
+//! Each entry is one of:
+//!   * an **exact host** — `sparql.example.org`, `192.0.2.10`, `localhost`
+//!     (matched case-insensitively against the SERVICE IRI authority);
+//!   * a **suffix wildcard** — `*.example.org`, matching the apex `example.org` and
+//!     any subdomain (`a.example.org`, `a.b.example.org`) but not `notexample.org`.
+//!
+//! Entries come from (union of all three, deduplicated):
+//!   * the repeatable `--service-allow <entry>` CLI flag;
+//!   * `--service-allow-file <path>` (one entry per line; `#` comments + blanks
+//!     ignored);
+//!   * the `SPARQ_SERVICE_ALLOW` env var (comma- and/or whitespace-separated).
+//!
+//! Precedence: env establishes a baseline, CLI flags ADD to it (the union — an
+//! allowlist is additive, so there is no "override" that could silently *remove* a
+//! host the env granted; CLI only ever widens). The file is loaded at startup and
+//! merged in too.
+
+use std::collections::BTreeSet;
+
+/// The configured SERVICE egress allowlist. Empty = deny ALL SERVICE (the default).
+///
+/// Stored as a normalised, deduplicated, sorted set so two configs built from the
+/// same inputs in any order compare equal (handy for tests) and the startup log is
+/// deterministic. Each stored entry is already lower-cased and validated.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ServiceAllowlist {
+    /// Exact host entries (`sparql.example.org`).
+    exact: BTreeSet<String>,
+    /// Suffix-wildcard entries stored in the engine's leading-dot form
+    /// (`*.example.org` -> `.example.org`).
+    suffix: BTreeSet<String>,
+}
+
+impl ServiceAllowlist {
+    /// True when no host is allowlisted — i.e. SERVICE federation is fully denied.
+    pub fn is_empty(&self) -> bool {
+        self.exact.is_empty() && self.suffix.is_empty()
+    }
+
+    /// Number of distinct entries (exact + suffix).
+    pub fn len(&self) -> usize {
+        self.exact.len() + self.suffix.len()
+    }
+
+    /// Adds one raw entry (CLI flag value, file line, or env token). Returns an
+    /// error string for a malformed entry so the caller can fail fast at startup
+    /// rather than silently dropping a host the operator meant to allow.
+    ///
+    /// Accepted forms: a bare host, or `*.suffix` (suffix wildcard). The entry is
+    /// lower-cased; surrounding whitespace is trimmed. A `*` anywhere other than a
+    /// leading `*.` is rejected (we deliberately support only the simple
+    /// apex-and-subdomain suffix wildcard, not arbitrary globs).
+    pub fn add(&mut self, raw: &str) -> Result<(), String> {
+        let e = raw.trim().to_ascii_lowercase();
+        if e.is_empty() {
+            return Ok(()); // blank line / empty token — nothing to add
+        }
+        if let Some(suffix) = e.strip_prefix("*.") {
+            if suffix.is_empty() || suffix.contains('*') {
+                return Err(format!("invalid SERVICE allow pattern {raw:?}: expected '*.<suffix>'"));
+            }
+            // Engine form: leading dot. Matches the apex + any subdomain.
+            self.suffix.insert(format!(".{suffix}"));
+            return Ok(());
+        }
+        if e.contains('*') {
+            return Err(format!(
+                "invalid SERVICE allow entry {raw:?}: '*' is only supported as a leading '*.' suffix wildcard"
+            ));
+        }
+        self.exact.insert(e);
+        Ok(())
+    }
+
+    /// Builds an allowlist from the CLI flag values, an optional file, and the
+    /// `SPARQ_SERVICE_ALLOW` env var. The union of all three (additive — CLI never
+    /// removes an env/file entry). Returns an error if any entry is malformed or the
+    /// file cannot be read.
+    ///
+    /// `cli` are the `--service-allow` values in order; `file` is the
+    /// `--service-allow-file` path (if any). The env var is read here so a single
+    /// call assembles the full effective allowlist.
+    pub fn from_sources(cli: &[String], file: Option<&str>) -> Result<Self, String> {
+        let mut out = Self::default();
+        // 1. Env baseline.
+        if let Ok(v) = std::env::var("SPARQ_SERVICE_ALLOW") {
+            out.add_many(&v)?;
+        }
+        // 2. File (one entry per line; '#' comments and blanks ignored).
+        if let Some(path) = file {
+            let text = std::fs::read_to_string(path)
+                .map_err(|e| format!("--service-allow-file {path}: {e}"))?;
+            for line in text.lines() {
+                let line = line.split('#').next().unwrap_or("").trim();
+                out.add(line)?;
+            }
+        }
+        // 3. CLI flags (additive — widen the union).
+        for entry in cli {
+            out.add(entry)?;
+        }
+        Ok(out)
+    }
+
+    /// Adds every comma- and/or whitespace-separated token in `s` (the
+    /// `SPARQ_SERVICE_ALLOW` env-var grammar).
+    pub fn add_many(&mut self, s: &str) -> Result<(), String> {
+        for tok in s.split([',', ' ', '\t', '\n', '\r']) {
+            self.add(tok)?;
+        }
+        Ok(())
+    }
+
+    /// The entries in the engine's allowlist representation: exact hosts verbatim,
+    /// suffix wildcards as leading-dot strings (`.example.org`). Fed to
+    /// [`sparq_engine::with_service_egress_policy`].
+    pub fn engine_entries(&self) -> Vec<String> {
+        self.exact.iter().chain(self.suffix.iter()).cloned().collect()
+    }
+
+    /// A stable, human-readable rendering for the startup log (suffix entries shown
+    /// in the user-facing `*.` form).
+    pub fn display(&self) -> String {
+        if self.is_empty() {
+            return "deny-all (no SERVICE host allowlisted)".to_string();
+        }
+        let mut parts: Vec<String> = self.exact.iter().cloned().collect();
+        parts.extend(self.suffix.iter().map(|s| format!("*{s}")));
+        parts.join(", ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_is_deny_all() {
+        let a = ServiceAllowlist::default();
+        assert!(a.is_empty());
+        assert_eq!(a.len(), 0);
+        assert_eq!(a.engine_entries(), Vec::<String>::new());
+        assert_eq!(a.display(), "deny-all (no SERVICE host allowlisted)");
+    }
+
+    #[test]
+    fn exact_host_is_lowercased_and_deduped() {
+        let mut a = ServiceAllowlist::default();
+        a.add("Sparql.Example.ORG").unwrap();
+        a.add("sparql.example.org").unwrap(); // dup
+        a.add(" 192.0.2.10 ").unwrap(); // trimmed
+        assert_eq!(a.len(), 2);
+        let mut e = a.engine_entries();
+        e.sort();
+        assert_eq!(e, vec!["192.0.2.10".to_string(), "sparql.example.org".to_string()]);
+    }
+
+    #[test]
+    fn suffix_wildcard_normalised_to_leading_dot() {
+        let mut a = ServiceAllowlist::default();
+        a.add("*.example.org").unwrap();
+        assert_eq!(a.engine_entries(), vec![".example.org".to_string()]);
+        assert_eq!(a.display(), "*.example.org");
+    }
+
+    #[test]
+    fn blank_entries_ignored() {
+        let mut a = ServiceAllowlist::default();
+        a.add("   ").unwrap();
+        a.add("").unwrap();
+        assert!(a.is_empty());
+    }
+
+    #[test]
+    fn malformed_wildcards_rejected() {
+        let mut a = ServiceAllowlist::default();
+        assert!(a.add("ex*mple.org").is_err()); // '*' not leading
+        assert!(a.add("*.").is_err()); // empty suffix
+        assert!(a.add("*.a.*.b").is_err()); // extra '*'
+    }
+
+    #[test]
+    fn add_many_splits_on_comma_and_whitespace() {
+        let mut a = ServiceAllowlist::default();
+        a.add_many("a.example.org, b.example.org  c.example.org\nd.example.org").unwrap();
+        assert_eq!(a.len(), 4);
+    }
+
+    #[test]
+    fn from_sources_unions_cli_file_env() {
+        std::env::set_var("SPARQ_SERVICE_ALLOW", "env.example.org, *.env.example.org");
+        let a = ServiceAllowlist::from_sources(
+            &["cli.example.org".to_string(), "*.cli.example.org".to_string()],
+            None,
+        )
+        .unwrap();
+        std::env::remove_var("SPARQ_SERVICE_ALLOW");
+        assert!(a.engine_entries().contains(&"env.example.org".to_string()));
+        assert!(a.engine_entries().contains(&".env.example.org".to_string()));
+        assert!(a.engine_entries().contains(&"cli.example.org".to_string()));
+        assert!(a.engine_entries().contains(&".cli.example.org".to_string()));
+        assert_eq!(a.len(), 4);
+    }
+
+    #[test]
+    fn from_sources_reads_file_with_comments_and_blanks() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("sparq-svc-allow-{}.txt", std::process::id()));
+        std::fs::write(
+            &path,
+            "# a comment\nfile.example.org\n\n  *.file.example.org   # trailing comment\n",
+        )
+        .unwrap();
+        std::env::remove_var("SPARQ_SERVICE_ALLOW");
+        let a = ServiceAllowlist::from_sources(&[], Some(path.to_str().unwrap())).unwrap();
+        std::fs::remove_file(&path).ok();
+        assert_eq!(a.len(), 2);
+        assert!(a.engine_entries().contains(&"file.example.org".to_string()));
+        assert!(a.engine_entries().contains(&".file.example.org".to_string()));
+    }
+
+    #[test]
+    fn from_sources_missing_file_errors() {
+        std::env::remove_var("SPARQ_SERVICE_ALLOW");
+        let err = ServiceAllowlist::from_sources(&[], Some("/no/such/sparq-allow-file")).unwrap_err();
+        assert!(err.contains("service-allow-file"));
+    }
+}

--- a/crates/sparq-server/src/service_config.rs
+++ b/crates/sparq-server/src/service_config.rs
@@ -77,6 +77,12 @@ impl ServiceAllowlist {
     /// lower-cased; surrounding whitespace is trimmed. A `*` anywhere other than a
     /// leading `*.` is rejected (we deliberately support only the simple
     /// apex-and-subdomain suffix wildcard, not arbitrary globs).
+    ///
+    /// [OPUS-4.8] sq-4w18: exact-host entries are NORMALISED to the bare host the
+    /// engine actually compares against (see [`Self::normalize_host`]), so a copy-
+    /// pasted endpoint like `example.org:443` or a bracketed IPv6 `[::1]` matches
+    /// instead of silently never matching (which would make the allowlist look
+    /// configured but be inert — a fail-open footgun).
     pub fn add(&mut self, raw: &str) -> Result<(), String> {
         let e = raw.trim().to_ascii_lowercase();
         if e.is_empty() {
@@ -95,8 +101,50 @@ impl ServiceAllowlist {
                 "invalid SERVICE allow entry {raw:?}: '*' is only supported as a leading '*.' suffix wildcard"
             ));
         }
-        self.exact.insert(e);
+        self.exact.insert(Self::normalize_host(&e));
         Ok(())
+    }
+
+    /// [OPUS-4.8] sq-4w18: normalise an exact-host entry to the EXACT string the
+    /// engine's egress resolver compares the SERVICE IRI authority against.
+    ///
+    /// The engine ([`sparq_engine`]'s `EgressFilterResolver`) is handed `netloc` as
+    /// `host:port` (IPv6 bracketed: `[::1]:80`) and derives the bare host by
+    /// (1) dropping a trailing `:port` via `rsplit_once(':')` and (2) stripping a
+    /// surrounding `[ ]`. An allowlist entry that still carries a port or brackets
+    /// would therefore NEVER equal what the engine looks up. We apply the same two
+    /// transforms here so an operator can paste an authority verbatim:
+    ///
+    ///   * `example.org:443`  -> `example.org`        (port stripped)
+    ///   * `[::1]`            -> `::1`                 (brackets stripped)
+    ///   * `[::1]:443`        -> `::1`                 (port + brackets stripped)
+    ///   * `192.0.2.10:8080`  -> `192.0.2.10`         (port stripped)
+    ///   * `example.org`      -> `example.org`        (unchanged)
+    ///   * `::1` (bare IPv6)  -> `::1`                 (unchanged — NOT mangled)
+    ///
+    /// A trailing `:port` is only stripped when the entry is unambiguously
+    /// `host:port`: either bracketed (`[...]:port`) or a single-colon `host:digits`
+    /// form. A bare IPv6 literal (multiple colons, unbracketed) is left intact so we
+    /// never amputate its last hextet.
+    fn normalize_host(e: &str) -> String {
+        // Bracketed IPv6: `[addr]` or `[addr]:port`. Strip the optional `:port`
+        // that follows the closing bracket, then strip the brackets themselves.
+        if let Some(rest) = e.strip_prefix('[') {
+            if let Some((inner, _after)) = rest.split_once(']') {
+                // `_after` is either empty or `:port`; the engine drops it either way.
+                return inner.to_string();
+            }
+            // Malformed (no closing bracket) — leave verbatim; it just won't match.
+            return e.to_string();
+        }
+        // Unbracketed. Only a single-colon `host:port` is a port-bearing authority;
+        // anything with more than one colon is a bare IPv6 literal we must NOT touch.
+        if let Some((host, port)) = e.split_once(':') {
+            if !host.contains(':') && !port.contains(':') && !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) {
+                return host.to_string();
+            }
+        }
+        e.to_string()
     }
 
     /// Builds an allowlist from the CLI flag values, an optional file, and the
@@ -161,6 +209,30 @@ impl ServiceAllowlist {
 mod tests {
     use super::*;
 
+    /// [OPUS-4.8] sq-4w18: RAII guard that restores `SPARQ_SERVICE_ALLOW` to its
+    /// pre-test value on drop — INCLUDING on a panic mid-test. `from_sources` reads
+    /// this process-global var, so a test that set/removed it and then panicked would
+    /// otherwise leak the mutated value into sibling tests (and other crates' tests in
+    /// the same process). Mirrors the `EnvRestore` pattern in
+    /// `sparq-core::dictspill` tests. (roborev/Copilot 2026-06-14)
+    struct EnvRestore {
+        key: &'static str,
+        saved: Option<String>,
+    }
+    impl EnvRestore {
+        fn new(key: &'static str) -> Self {
+            EnvRestore { key, saved: std::env::var(key).ok() }
+        }
+    }
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            match &self.saved {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     #[test]
     fn empty_is_deny_all() {
         let a = ServiceAllowlist::default();
@@ -180,6 +252,31 @@ mod tests {
         let mut e = a.engine_entries();
         e.sort();
         assert_eq!(e, vec!["192.0.2.10".to_string(), "sparql.example.org".to_string()]);
+    }
+
+    #[test]
+    fn exact_host_normalised_to_engine_bare_host() {
+        // [OPUS-4.8] sq-4w18: the engine compares the SERVICE IRI authority with the
+        // port dropped and IPv6 brackets stripped, so `add` must normalise to the same
+        // form or the entry would silently never match (fail-open).
+        for (raw, want) in [
+            ("example.org:443", "example.org"),    // host:port -> bare host
+            ("192.0.2.10:8080", "192.0.2.10"),     // ipv4:port -> bare ip
+            ("[::1]", "::1"),                       // bracketed ipv6 -> bare ipv6
+            ("[::1]:443", "::1"),                   // bracketed ipv6 + port -> bare ipv6
+            ("[2001:db8::1]:80", "2001:db8::1"),    // full bracketed ipv6 + port
+            ("example.org", "example.org"),         // already bare -> unchanged
+            ("::1", "::1"),                          // bare (unbracketed) ipv6 -> NOT mangled
+            ("2001:db8::1", "2001:db8::1"),          // bare full ipv6 -> NOT mangled
+        ] {
+            let mut a = ServiceAllowlist::default();
+            a.add(raw).unwrap();
+            assert_eq!(
+                a.engine_entries(),
+                vec![want.to_string()],
+                "{raw:?} should normalise to the bare host {want:?} the engine compares against",
+            );
+        }
     }
 
     #[test]
@@ -215,13 +312,14 @@ mod tests {
 
     #[test]
     fn from_sources_unions_cli_file_env() {
+        // [OPUS-4.8] sq-4w18: restore SPARQ_SERVICE_ALLOW on drop (incl. on panic).
+        let _env = EnvRestore::new("SPARQ_SERVICE_ALLOW");
         std::env::set_var("SPARQ_SERVICE_ALLOW", "env.example.org, *.env.example.org");
         let a = ServiceAllowlist::from_sources(
             &["cli.example.org".to_string(), "*.cli.example.org".to_string()],
             None,
         )
         .unwrap();
-        std::env::remove_var("SPARQ_SERVICE_ALLOW");
         assert!(a.engine_entries().contains(&"env.example.org".to_string()));
         assert!(a.engine_entries().contains(&".env.example.org".to_string()));
         assert!(a.engine_entries().contains(&"cli.example.org".to_string()));
@@ -231,6 +329,8 @@ mod tests {
 
     #[test]
     fn from_sources_reads_file_with_comments_and_blanks() {
+        // [OPUS-4.8] sq-4w18: restore SPARQ_SERVICE_ALLOW on drop (incl. on panic).
+        let _env = EnvRestore::new("SPARQ_SERVICE_ALLOW");
         let dir = std::env::temp_dir();
         let path = dir.join(format!("sparq-svc-allow-{}.txt", std::process::id()));
         std::fs::write(
@@ -248,6 +348,8 @@ mod tests {
 
     #[test]
     fn from_sources_missing_file_errors() {
+        // [OPUS-4.8] sq-4w18: restore SPARQ_SERVICE_ALLOW on drop (incl. on panic).
+        let _env = EnvRestore::new("SPARQ_SERVICE_ALLOW");
         std::env::remove_var("SPARQ_SERVICE_ALLOW");
         let err = ServiceAllowlist::from_sources(&[], Some("/no/such/sparq-allow-file")).unwrap_err();
         assert!(err.contains("service-allow-file"));

--- a/crates/sparq-server/src/subscriptions.rs
+++ b/crates/sparq-server/src/subscriptions.rs
@@ -365,7 +365,10 @@ async fn evaluate(state: &AppState, query: String) -> Result<(Vec<String>, HashM
     // Pin the current generation for this evaluation (lock-free; never blocked by the
     // writer). Each re-evaluation pins afresh, so it always sees the latest commit.
     let gen = state.current();
-    let task = tokio::task::spawn_blocking(move || eval_rows(gen.snapshot(), &query, &budget));
+    // [OPUS-4.8] sq-4w18: the SERVICE egress allowlist applies to subscription SELECTs
+    // exactly as to /sparql ones — a federated subscription is gated like a read.
+    let cfg = config.clone();
+    let task = tokio::task::spawn_blocking(move || eval_rows(gen.snapshot(), &query, &budget, &cfg));
     let joined = match config.query_timeout {
         Some(t) => tokio::time::timeout(t + TIMEOUT_GRACE, task)
             .await
@@ -397,10 +400,10 @@ fn budget_error(e: &str, config: &ServerConfig) -> String {
 /// object; the serialised object is the row's identity key. `serde_json`'s map keeps a
 /// deterministic key order, so equal rows always serialise identically. Duplicate rows
 /// collapse (set semantics — see module docs).
-fn eval_rows(graph: &Graph, query: &str, budget: &QueryBudget) -> Result<(Vec<String>, HashMap<String, Value>), String> {
-    // Extension functions (the `geo` feature's geof: registry) apply to
-    // subscription SELECTs exactly as to /sparql ones.
-    let r = crate::http::with_extensions(|| sparq_engine::query_with_budget(graph, query, budget))?;
+fn eval_rows(graph: &Graph, query: &str, budget: &QueryBudget, config: &ServerConfig) -> Result<(Vec<String>, HashMap<String, Value>), String> {
+    // Extension functions (the `geo` feature's geof: registry) AND the SERVICE egress
+    // allowlist (sq-4w18) apply to subscription SELECTs exactly as to /sparql ones.
+    let r = crate::http::with_engine_scope(config, || sparq_engine::query_with_budget(graph, query, budget))?;
     let vars: Vec<String> = r.vars.iter().map(|v| v.as_str().to_string()).collect();
     let mut rows = HashMap::with_capacity(r.rows.len());
     for row in &r.rows {
@@ -531,8 +534,8 @@ mod tests {
     fn eval_rows_canonical_keys_are_stable_across_evaluations() {
         let g = graph("@prefix ex: <http://ex/> . ex:a ex:p ex:b . ex:c ex:p \"x\"@en .");
         let q = "SELECT ?s ?o WHERE { ?s <http://ex/p> ?o }";
-        let (vars1, rows1) = eval_rows(&g, q, &QueryBudget::unlimited()).unwrap();
-        let (vars2, rows2) = eval_rows(&g, q, &QueryBudget::unlimited()).unwrap();
+        let (vars1, rows1) = eval_rows(&g, q, &QueryBudget::unlimited(), &ServerConfig::default()).unwrap();
+        let (vars2, rows2) = eval_rows(&g, q, &QueryBudget::unlimited(), &ServerConfig::default()).unwrap();
         assert_eq!(vars1, vec!["s", "o"]);
         assert_eq!(vars1, vars2);
         assert_eq!(rows1.keys().collect::<std::collections::BTreeSet<_>>(), rows2.keys().collect());
@@ -544,8 +547,8 @@ mod tests {
         let before = graph("@prefix ex: <http://ex/> . ex:a ex:p ex:b . ex:c ex:p ex:d .");
         let after = graph("@prefix ex: <http://ex/> . ex:a ex:p ex:b . ex:e ex:p ex:f .");
         let q = "SELECT ?s WHERE { ?s <http://ex/p> ?o }";
-        let (_, old) = eval_rows(&before, q, &QueryBudget::unlimited()).unwrap();
-        let (_, new) = eval_rows(&after, q, &QueryBudget::unlimited()).unwrap();
+        let (_, old) = eval_rows(&before, q, &QueryBudget::unlimited(), &ServerConfig::default()).unwrap();
+        let (_, new) = eval_rows(&after, q, &QueryBudget::unlimited(), &ServerConfig::default()).unwrap();
         let added = sorted_pairs(new.iter().filter(|(k, _)| !old.contains_key(*k)));
         let removed = sorted_pairs(old.iter().filter(|(k, _)| !new.contains_key(*k)));
         assert_eq!(added.len(), 1);
@@ -575,7 +578,7 @@ mod tests {
     fn unbound_variables_are_omitted_from_the_binding() {
         let g = graph("@prefix ex: <http://ex/> . ex:a ex:p ex:b .");
         let q = "SELECT ?s ?missing WHERE { ?s <http://ex/p> ?o OPTIONAL { ?s <http://ex/q> ?missing } }";
-        let (vars, rows) = eval_rows(&g, q, &QueryBudget::unlimited()).unwrap();
+        let (vars, rows) = eval_rows(&g, q, &QueryBudget::unlimited(), &ServerConfig::default()).unwrap();
         assert_eq!(vars, vec!["s", "missing"]);
         let binding = rows.values().next().unwrap();
         assert!(binding.get("missing").is_none());
@@ -586,7 +589,7 @@ mod tests {
     fn max_rows_budget_refuses_oversized_results() {
         let g = graph("@prefix ex: <http://ex/> . ex:a ex:p ex:b . ex:c ex:p ex:d . ex:e ex:p ex:f .");
         let budget = QueryBudget { deadline: None, max_rows: Some(2) };
-        let err = eval_rows(&g, "SELECT ?s WHERE { ?s ?p ?o }", &budget).unwrap_err();
+        let err = eval_rows(&g, "SELECT ?s WHERE { ?s ?p ?o }", &budget, &ServerConfig::default()).unwrap_err();
         assert!(err.contains("max-rows"), "unexpected error: {err}");
     }
 

--- a/crates/sparq-server/tests/service_allowlist.rs
+++ b/crates/sparq-server/tests/service_allowlist.rs
@@ -25,16 +25,24 @@ use tokio::net::TcpListener;
 const DATA: &str = "@prefix ex: <http://ex/> . ex:alice a ex:Person . ex:bob a ex:Person .";
 
 /// A one-shot loopback HTTP endpoint returning a canned SPARQL-Results-JSON body to the
-/// first `n` requests, then exiting. With `n == 0` it accepts nothing — so a test that
-/// expects the egress filter to refuse BEFORE dialling proves no socket was opened.
-fn serve(body: String, n: usize) -> String {
+/// first `n` requests, then exiting.
+///
+/// [OPUS-4.8] sq-4w18: returns `(url, accepts)` where `accepts` is a channel that fires
+/// once for every connection the listener actually `accept()`s. A deny-posture test can
+/// therefore PROVE the egress filter refused before any socket was opened — by asserting
+/// nothing arrives on `accepts` within a window — rather than relying on a request count
+/// (a count of 0 alone does not distinguish "no socket opened" from "dialled but the OS
+/// returned a fast `ECONNREFUSED`"). With `n == 0` the listener accepts nothing.
+fn serve(body: String, n: usize) -> (String, mpsc::Receiver<()>) {
     let listener = StdListener::bind("127.0.0.1:0").expect("bind loopback");
     let addr = listener.local_addr().unwrap();
-    let (tx, rx) = mpsc::channel();
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let (accept_tx, accept_rx) = mpsc::channel();
     thread::spawn(move || {
-        tx.send(()).ok();
+        ready_tx.send(()).ok();
         for _ in 0..n {
             let Ok((mut stream, _)) = listener.accept() else { return };
+            accept_tx.send(()).ok(); // a connection was accepted
             let mut buf = [0u8; 4096];
             let _ = stream.read(&mut buf);
             let resp = format!(
@@ -46,8 +54,8 @@ fn serve(body: String, n: usize) -> String {
             let _ = stream.flush();
         }
     });
-    rx.recv().unwrap();
-    format!("http://{addr}/")
+    ready_rx.recv().unwrap();
+    (format!("http://{addr}/"), accept_rx)
 }
 
 async fn spawn_with(config: ServerConfig) -> String {
@@ -72,13 +80,20 @@ fn remote_body() -> String {
 
 #[tokio::test]
 async fn empty_allowlist_refuses_service_before_any_network_call() {
-    // The fake remote serves ZERO requests: if the server dialled it the assertion that
-    // the query failed would still hold, but the point is the egress filter refuses the
-    // loopback host before opening a socket.
-    let remote = serve(remote_body(), 0);
+    // [OPUS-4.8] sq-4w18: the fake remote stays LIVE and ready to accept one connection
+    // (n == 1). Under the strict deny posture the engine refuses the host before DNS
+    // resolution, so the server must never dial it — we PROVE that by asserting nothing
+    // is ever `accept()`ed on the live listener (see the `accepts` channel below). A
+    // bare request count of 0 would not distinguish "no socket opened" from "dialled but
+    // got a fast ECONNREFUSED on a closed port".
+    let (remote, accepts) = serve(remote_body(), 1);
     let host = remote.trim_start_matches("http://").trim_end_matches('/');
-    // Default config => empty allowlist => deny ALL SERVICE.
-    let base = spawn_with(ServerConfig::default()).await;
+    // Default config + a SHORT query timeout: if the strict pre-DNS refusal ever
+    // regresses and the server actually dials the (live) endpoint, the request must not
+    // hang on the 30s default and slow CI — the timeout bounds the failure.
+    let mut config = ServerConfig::default();
+    config.query_timeout = Some(std::time::Duration::from_secs(2)); // empty allowlist => deny ALL SERVICE
+    let base = spawn_with(config).await;
     let q = format!(
         "PREFIX ex: <http://ex/> SELECT ?s WHERE {{ ?s a ex:Person . SERVICE <http://{host}/> {{ ?s ex:name ?name }} }}"
     );
@@ -96,11 +111,18 @@ async fn empty_allowlist_refuses_service_before_any_network_call() {
         body.contains("egress") || body.contains("allowlist") || body.contains("service"),
         "expected an egress/allowlist refusal in the body, got: {body}"
     );
+    // The query has already returned; give any in-flight dial a brief window, then assert
+    // the live listener accepted NOTHING — i.e. the refusal happened before any socket
+    // was opened to the endpoint.
+    assert!(
+        accepts.recv_timeout(std::time::Duration::from_millis(250)).is_err(),
+        "strict deny posture must refuse BEFORE dialling — the listener must accept no connection",
+    );
 }
 
 #[tokio::test]
 async fn allowlisted_loopback_host_reaches_the_endpoint() {
-    let remote = serve(remote_body(), 1);
+    let (remote, _accepts) = serve(remote_body(), 1);
     let host = remote.trim_start_matches("http://").trim_end_matches('/');
     let bare_host = host.split(':').next().unwrap().to_string(); // "127.0.0.1"
     // Allowlist the loopback host => SERVICE to it is permitted.
@@ -126,9 +148,14 @@ async fn allowlisted_loopback_host_reaches_the_endpoint() {
 
 #[tokio::test]
 async fn silent_service_under_deny_yields_identity() {
-    let remote = serve(remote_body(), 0);
+    // [OPUS-4.8] sq-4w18: live listener (n == 1) so a regression that dials would hit a
+    // real accept, plus a SHORT query timeout so such a regression cannot hang CI on the
+    // 30s default. (SILENT swallows the refusal either way, but the timeout bounds it.)
+    let (remote, _accepts) = serve(remote_body(), 1);
     let host = remote.trim_start_matches("http://").trim_end_matches('/');
-    let base = spawn_with(ServerConfig::default()).await; // empty allowlist
+    let mut config = ServerConfig::default(); // empty allowlist => deny ALL SERVICE
+    config.query_timeout = Some(std::time::Duration::from_secs(2));
+    let base = spawn_with(config).await;
     let q = format!(
         "PREFIX ex: <http://ex/> SELECT ?s WHERE {{ ?s a ex:Person . SERVICE SILENT <http://{host}/> {{ ?s ex:name ?name }} }}"
     );

--- a/crates/sparq-server/tests/service_allowlist.rs
+++ b/crates/sparq-server/tests/service_allowlist.rs
@@ -1,0 +1,145 @@
+//! SERVICE federation egress allowlist — server integration. [OPUS-4.8] (sq-4w18)
+//!
+//! Runs only with `cargo test -p sparq-server --features service`. Boots the real axum
+//! server in-process and drives `/sparql` with a `SERVICE <iri>` clause, asserting the
+//! server's default-DENY-all posture and the allowlist opt-in:
+//!
+//!   * with NO allowlist (the default), a SERVICE to a loopback endpoint is REFUSED
+//!     before any socket is opened (the fake remote serves 0 requests and the query
+//!     still errors) — the SSRF guard;
+//!   * with the loopback host on the allowlist, the SAME query reaches the endpoint and
+//!     joins the remote solution;
+//!   * `SERVICE SILENT` under the deny posture yields the join identity (the query
+//!     succeeds with the surrounding bindings intact, no network call).
+#![cfg(feature = "service")]
+
+use std::io::{Read, Write};
+use std::net::TcpListener as StdListener;
+use std::sync::mpsc;
+use std::thread;
+
+use sparq_core::Graph;
+use sparq_server::{router, AppState, ServerConfig, ServiceAllowlist};
+use tokio::net::TcpListener;
+
+const DATA: &str = "@prefix ex: <http://ex/> . ex:alice a ex:Person . ex:bob a ex:Person .";
+
+/// A one-shot loopback HTTP endpoint returning a canned SPARQL-Results-JSON body to the
+/// first `n` requests, then exiting. With `n == 0` it accepts nothing — so a test that
+/// expects the egress filter to refuse BEFORE dialling proves no socket was opened.
+fn serve(body: String, n: usize) -> String {
+    let listener = StdListener::bind("127.0.0.1:0").expect("bind loopback");
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        tx.send(()).ok();
+        for _ in 0..n {
+            let Ok((mut stream, _)) = listener.accept() else { return };
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/sparql-results+json\r\n\
+                 Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = stream.write_all(resp.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+    rx.recv().unwrap();
+    format!("http://{addr}/")
+}
+
+async fn spawn_with(config: ServerConfig) -> String {
+    let graph = Graph::load_str(DATA, "turtle").unwrap();
+    let app = router(AppState::with_config(graph, config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+fn remote_body() -> String {
+    r#"{ "head": { "vars": ["s", "name"] },
+        "results": { "bindings": [
+            { "s": {"type":"uri","value":"http://ex/alice"}, "name": {"type":"literal","value":"Alice"} },
+            { "s": {"type":"uri","value":"http://ex/bob"},   "name": {"type":"literal","value":"Bob"} }
+        ] } }"#
+        .to_string()
+}
+
+#[tokio::test]
+async fn empty_allowlist_refuses_service_before_any_network_call() {
+    // The fake remote serves ZERO requests: if the server dialled it the assertion that
+    // the query failed would still hold, but the point is the egress filter refuses the
+    // loopback host before opening a socket.
+    let remote = serve(remote_body(), 0);
+    let host = remote.trim_start_matches("http://").trim_end_matches('/');
+    // Default config => empty allowlist => deny ALL SERVICE.
+    let base = spawn_with(ServerConfig::default()).await;
+    let q = format!(
+        "PREFIX ex: <http://ex/> SELECT ?s WHERE {{ ?s a ex:Person . SERVICE <http://{host}/> {{ ?s ex:name ?name }} }}"
+    );
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", q)])
+        .send()
+        .await
+        .unwrap();
+    // A non-SILENT SERVICE that is refused fails the query — the server maps an engine
+    // execution error to a non-2xx. (500 here; the body names the egress refusal.)
+    assert!(!resp.status().is_success(), "blocked SERVICE must not 200; got {}", resp.status());
+    let body = resp.text().await.unwrap().to_lowercase();
+    assert!(
+        body.contains("egress") || body.contains("allowlist") || body.contains("service"),
+        "expected an egress/allowlist refusal in the body, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn allowlisted_loopback_host_reaches_the_endpoint() {
+    let remote = serve(remote_body(), 1);
+    let host = remote.trim_start_matches("http://").trim_end_matches('/');
+    let bare_host = host.split(':').next().unwrap().to_string(); // "127.0.0.1"
+    // Allowlist the loopback host => SERVICE to it is permitted.
+    let mut config = ServerConfig::default();
+    let mut allow = ServiceAllowlist::default();
+    allow.add(&bare_host).unwrap();
+    config.service_allow = allow;
+    let base = spawn_with(config).await;
+    let q = format!(
+        "PREFIX ex: <http://ex/> SELECT ?s ?name WHERE {{ ?s a ex:Person . SERVICE <http://{host}/> {{ ?s ex:name ?name }} }}"
+    );
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", q)])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "allowlisted SERVICE must succeed");
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("Alice"), "expected the remote name joined in: {body}");
+    assert!(body.contains("Bob"), "expected the remote name joined in: {body}");
+}
+
+#[tokio::test]
+async fn silent_service_under_deny_yields_identity() {
+    let remote = serve(remote_body(), 0);
+    let host = remote.trim_start_matches("http://").trim_end_matches('/');
+    let base = spawn_with(ServerConfig::default()).await; // empty allowlist
+    let q = format!(
+        "PREFIX ex: <http://ex/> SELECT ?s WHERE {{ ?s a ex:Person . SERVICE SILENT <http://{host}/> {{ ?s ex:name ?name }} }}"
+    );
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", q)])
+        .send()
+        .await
+        .unwrap();
+    // SILENT swallows the egress refusal -> identity -> both local persons survive, 200.
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("alice") && body.contains("bob"), "SILENT must keep local bindings: {body}");
+}

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -31,12 +31,15 @@ cargo run -p sparq-server -- --addr 0.0.0.0:8080 --allow-remote --format ntriple
 > `0.0.0.0`) unless you set `--allow-remote` (env `SPARQ_ALLOW_REMOTE=1`), warning loudly
 > even then. Do not expose it to an untrusted network without a reverse proxy / API
 > gateway (or `sparq-solid`) enforcing auth in front. SPARQL `SERVICE` federation is OFF
-> in the shipped server (engine `service` feature not enabled). When the `service`
-> feature *is* compiled in, the engine applies a **default-deny SSRF egress filter**: a
-> `SERVICE` endpoint that resolves to a loopback / RFC1918 / link-local (incl. the
-> `169.254.169.254` cloud-metadata IP) / unique-local / unspecified address is refused.
-> The check runs on the *resolved* IP (DNS-rebinding-safe). Opt a trusted internal host
-> back in with `sparq_engine::with_service_egress_allow([host], || …)` (bead `sq-2v6f`).
+> in the default build (the `service` cargo feature is off); a `SERVICE` clause then
+> errors at execution. Build with `--features service` to enable it — and even then the
+> server is **default-DENY-all SERVICE**: a `SERVICE <iri>` reaches **nothing** unless its
+> host is on the egress allowlist (`--service-allow` / `--service-allow-file` /
+> `SPARQ_SERVICE_ALLOW`; bead `sq-4w18`). This is an SSRF guard: a `SERVICE` clause turns
+> attacker-controlled query text into an outbound request from the server host (worst case
+> the `169.254.169.254` cloud-metadata IP). The allowlist is enforced before any socket is
+> opened, on the *resolved* IP (DNS-rebinding-safe). See "SERVICE federation (egress
+> allowlist)" below.
 
 Point a client at it (the endpoint is `/sparql`):
 
@@ -222,6 +225,8 @@ env overrides the default.
 | `--max-subscriptions-per-conn N` | `SPARQ_MAX_SUBSCRIPTIONS_PER_CONN` | `16` | per-socket subs |
 | `--verbose` | — | off | TraceLayer request logging (respects `RUST_LOG`) |
 | `--allow-remote` | `SPARQ_ALLOW_REMOTE` | off | opt in to a non-loopback bind despite no auth; without it a non-loopback `--addr` is **refused** at startup, with it it warns and proceeds |
+| `--service-allow HOST\|*.SUFFIX` (repeatable) | `SPARQ_SERVICE_ALLOW` (comma/ws-sep) | empty = **deny ALL SERVICE** | (feature `service`) allowlist a SERVICE egress host (exact or `*.suffix` wildcard); CLI + file + env are UNIONed |
+| `--service-allow-file PATH` | — | — | (feature `service`) load allowlist entries, one per line (`#` comments + blanks ignored) |
 | `--time-travel-generations N` | `SPARQ_TIME_TRAVEL_GENERATIONS` | `16` | (feature) retained generations |
 | `--time-travel-max-age SECS` | `SPARQ_TIME_TRAVEL_MAX_AGE` | off | (feature) age-out window |
 
@@ -236,12 +241,26 @@ then `router(state)`, or `harden(my_router, &config)`.
   **refuses** a non-loopback `--addr` (incl. `0.0.0.0`/`::`) unless `--allow-remote` /
   `SPARQ_ALLOW_REMOTE=1`; even then it warns. Front it with a reverse proxy / gateway (or
   `sparq-solid`) for auth. No rate limit and `--max-results` is unlimited by default — set
-  caps + a gateway rate limiter if exposing it (beads `sq-o4qf`, `sq-ebii`). `SERVICE`
-  federation is OFF in the shipped server; when the engine `service` feature is compiled
-  in, outbound `SERVICE` fetches are guarded by a **default-deny SSRF egress filter**
-  (loopback / RFC1918 / link-local incl. `169.254.169.254` cloud-metadata / unique-local
-  / unspecified are refused on the *resolved* IP; opt a trusted host back in via
-  `sparq_engine::with_service_egress_allow`) — bead `sq-2v6f`.
+  caps + a gateway rate limiter if exposing it (beads `sq-o4qf`, `sq-ebii`).
+- **SERVICE federation (egress allowlist).** `SERVICE` is OFF in the default build (build
+  with `--features service` to enable it). Even enabled, the server is **default-DENY-all
+  SERVICE**: a `SERVICE <iri>` clause reaches **nothing** unless its host is allowlisted —
+  via `--service-allow HOST` / `*.SUFFIX` (repeatable), `--service-allow-file PATH` (one
+  entry per line), or `SPARQ_SERVICE_ALLOW` (comma/whitespace-separated). All three are
+  UNIONed (additive; the CLI only ever widens the env baseline). Rationale: a `SERVICE`
+  clause turns attacker-controlled query text into an outbound request from the server
+  host (textbook SSRF; worst case the `169.254.169.254` cloud-metadata IP), so the
+  network-exposed surface must opt in to every reachable host. Matching is
+  case-insensitive against the SERVICE IRI authority; a `*.example.org` entry matches the
+  apex `example.org` and any subdomain. Unlike the engine's standalone default (which lets
+  public IPs through and only blocks private ones), the server is **strict**: even a public
+  host must be on the allowlist. The allowlist applies uniformly to queries, ASK,
+  CONSTRUCT/DESCRIBE, subscriptions and federated `INSERT … WHERE` updates, and is enforced
+  before any socket is opened (DNS-rebinding-safe, on the *resolved* IP). The startup log
+  prints the effective allowlist. Beads `sq-4w18` (this wiring), `sq-2v6f` (the engine SSRF
+  filter). Embedders that drive the engine directly use
+  `sparq_engine::with_service_egress_policy(strict, [host], || …)` /
+  `with_service_egress_allow([host], || …)`.
 - **Feature flags.** `server` (default-on) pulls axum/tokio/tower — the binary needs it
   (`required-features = ["server"]`). `time-travel` (default **off**) enables
   `?generation=N` pinning, the `Sparq-Generation` header, `AppState::at`, and the


### PR DESCRIPTION
Closes the SERVICE-SSRF gap: the server is the unauthenticated network surface where attacker-controlled SPARQL arrives, and `SERVICE <iri>` turns query text into outbound HTTP (worst case the cloud-metadata IP).

**Policy: default-DENY-all.** SERVICE reaches nothing unless explicitly allowlisted (stricter than the engine's standalone default, which permits public IPs). Also gated behind an opt-in `service` cargo feature.

**Config (all UNIONed, additive):**
- `--service-allow HOST|*.SUFFIX` (repeatable), `--service-allow-file PATH` (one/line, `#` comments), env `SPARQ_SERVICE_ALLOW`.
- Matcher: case-insensitive exact host + `*.suffix` wildcard (apex + subdomains, not `notexample.org`).

**Engine seam:** extended the existing egress hook with an `AllowlistOnly` mode + `with_service_egress_policy(strict, hosts, f)`; strict mode refuses non-allowlisted hosts **before DNS resolution** (composes with the existing DNS-rebinding-safe resolver, sq-2v6f). Installed via a `with_engine_scope` wrapper around every engine call in http.rs (query/ASK/CONSTRUCT/DESCRIBE/EXPLAIN, the federated `INSERT…WHERE` applier, subscriptions).

**Tests:** engine strict-scope + suffix-wildcard + resolver-level refusal; server matcher unit tests + config wiring + integration test proving an un-allowlisted loopback SERVICE is refused before any socket opens.

**Docs:** `skills/http-server/SKILL.md` + README updated (replaces stale 'no egress filtering' text). Filed follow-ups sq-9xoh (per-request policy override) + sq-iu0c (403/422 instead of 500 on refusal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)