### PR TITLE
fix(sparq-py + engine): preserve rdf:dirLangString base direction; SPARQL-1.2-conformant its:dir JSON (sq-bj7o)

### DIFF
--- a/crates/sparq-core/src/dict.rs
+++ b/crates/sparq-core/src/dict.rs
@@ -253,17 +253,43 @@ pub(crate) fn lang_with_dir(l: &Literal) -> Option<std::borrow::Cow<'_, str>> {
 
 /// Inverse of [`lang_with_dir`]: split a STORED language slot back into its BCP47 tag and
 /// (optional) RDF 1.2 base direction. A stored slot of `en--ltr` is `("en", Some("ltr"))`;
-/// a plain `en` is `("en", None)`. `--` can never occur inside a valid language tag, so the
-/// split is unambiguous. The returned tag/direction are the spec-distinct components the
-/// SPARQL 1.2 results formats keep apart (`xml:lang` vs `its:dir`) — see the engine's
-/// `json.rs` and the conformance results reader.
-// [OPUS-4.8] sq-bj7o: the JSON fast path serialises straight from this stored slot, so it
-// needs the same split the `oxrdf::Term` path gets for free via `Literal::direction()`.
+/// a plain `en` is `("en", None)`. The returned tag/direction are the spec-distinct
+/// components the SPARQL 1.2 results formats keep apart (`xml:lang` vs `its:dir`) — see the
+/// engine's `json.rs` and the conformance results reader.
+///
+/// [OPUS-4.8] sq-bj7o: VALIDATION. The base direction in RDF 1.2 / SPARQL 1.2 is exactly
+/// `ltr` or `rtl`, lowercase (oxrdf's `BaseDirection` enum, whose `Display` emits those two
+/// strings — the only suffixes `lang_with_dir` ever writes). A trusted store therefore only
+/// ever holds `lang--ltr` / `lang--rtl`. But a STORED slot can come from an untrusted/mmap'd
+/// index, where the suffix after `--` is attacker-controlled; treating *any* suffix as a
+/// direction would (a) emit an arbitrary `its:dir` value and (b) diverge from the
+/// materialised `oxrdf::Term` path. So a suffix that is not exactly `ltr`/`rtl` is NOT a
+/// direction: the whole slot is returned as the language tag and no direction is reported —
+/// the same decision the materialised `reconstruct_ref` path makes (both call
+/// [`parse_lang_dir_suffix`]), so the fast path and the materialised path AGREE.
 #[inline]
 pub fn split_lang_dir(slot: &str) -> (&str, Option<&str>) {
     match slot.split_once("--") {
-        Some((tag, dir)) => (tag, Some(dir)),
-        None => (slot, None),
+        Some((tag, dir)) if parse_lang_dir_suffix(dir).is_some() => (tag, Some(dir)),
+        // No `--`, or a `--suffix` that is not a valid base direction: the entire slot is the
+        // language tag and there is no direction. Keeping the full slot intact (rather than
+        // dropping the bogus suffix) matches `reconstruct_ref`'s plain-language-tag fallback.
+        _ => (slot, None),
+    }
+}
+
+/// [OPUS-4.8] sq-bj7o: the single source of truth for "is this `lang--<suffix>` suffix a
+/// valid RDF 1.2 base direction?". The two possible directions are `ltr` / `rtl`, lowercase
+/// and case-sensitive (matching oxrdf `BaseDirection::Display` and the W3C RDF 1.2 / SPARQL
+/// 1.2 grammar — `LTR` / `Ltr` are NOT directions). Returns the typed enum so the
+/// materialised path ([`reconstruct_ref`]) and the validating split ([`split_lang_dir`]) can
+/// share exactly one definition and never drift apart.
+#[inline]
+fn parse_lang_dir_suffix(suffix: &str) -> Option<oxrdf::BaseDirection> {
+    match suffix {
+        "ltr" => Some(oxrdf::BaseDirection::Ltr),
+        "rtl" => Some(oxrdf::BaseDirection::Rtl),
+        _ => None,
     }
 }
 
@@ -537,12 +563,18 @@ fn reconstruct_ref(d: &Dict, s: &StoredRef) -> Term {
         }
         StoredRef::Lit { value, datatype, lang } => Term::Literal(match lang {
             // A stored `lang--dir` slot is an RDF 1.2 directional language-tagged string
-            // (see `lang_with_dir`); a plain tag is an ordinary one.
-            Some(l) => match l.split_once("--") {
+            // (see `lang_with_dir`); a plain tag is an ordinary one. [OPUS-4.8] sq-bj7o: the
+            // suffix is only a base direction when it is exactly `ltr`/`rtl`
+            // (`parse_lang_dir_suffix`) — the SAME validation `split_lang_dir` (the JSON fast
+            // path) applies, so a malformed slot like `en--bogus` from an untrusted/mmap'd
+            // index decodes to a PLAIN language-tagged literal with tag `en--bogus` here AND
+            // to `("en--bogus", None)` there. Previously any non-`rtl` suffix was silently
+            // coerced to `ltr`, which both fabricated a direction and diverged from the split.
+            Some(l) => match l.split_once("--").and_then(|(tag, dir)| parse_lang_dir_suffix(dir).map(|d| (tag, d))) {
                 Some((tag, dir)) => Literal::new_directional_language_tagged_literal_unchecked(
                     value.to_string(),
                     tag.to_string(),
-                    if dir == "rtl" { oxrdf::BaseDirection::Rtl } else { oxrdf::BaseDirection::Ltr },
+                    dir,
                 ),
                 None => Literal::new_language_tagged_literal_unchecked(value.to_string(), l.to_string()),
             },
@@ -2296,6 +2328,64 @@ mod tests {
         let d = d.into_blob();
         let Term::Triple(t) = d.term(bad_subj) else { panic!("expected a triple term") };
         assert_eq!(t.subject, oxrdf::BlankNode::new_unchecked(OOR_TRIPLE_SUBJECT).into());
+    }
+
+    /// [OPUS-4.8] sq-bj7o — base-direction VALIDATION + cross-path PARITY. The stored
+    /// language slot can come from an untrusted/mmap'd index whose `--<suffix>` is
+    /// attacker-controlled. The split used by the JSON fast path (`split_lang_dir`) and the
+    /// materialised-`Term` path (`reconstruct_ref`, reached via `Dict::term`) must AGREE on
+    /// every slot — and an invalid suffix must NOT fabricate an `its:dir`. This test feeds
+    /// raw slots directly through `intern_lit` (the same entry an mmap record takes) and
+    /// asserts both paths agree.
+    #[test]
+    fn lang_dir_suffix_validated_and_paths_agree() {
+        // A valid base direction must be lowercase `ltr`/`rtl` (case-sensitive, per
+        // BaseDirection::Display / RDF 1.2). A trusted store only ever writes those two; the
+        // others model a tampered/untrusted slot.
+        // (slot, expected (tag, dir) from split_lang_dir)
+        let cases: &[(&str, (&str, Option<&str>))] = &[
+            // Valid directions: split out, direction reported.
+            ("en--ltr", ("en", Some("ltr"))),
+            ("ar--rtl", ("ar", Some("rtl"))),
+            // Plain language tag: no `--`, no direction.
+            ("en", ("en", None)),
+            // Malformed / hostile suffixes: NOT a direction → whole slot is the tag, no dir.
+            ("en--bogus", ("en--bogus", None)),
+            ("en--LTR", ("en--LTR", None)), // case-sensitive: uppercase is NOT a direction
+            ("en--", ("en--", None)),       // empty suffix
+            ("en--ltr--rtl", ("en--ltr--rtl", None)), // suffix `ltr--rtl` is not a direction
+        ];
+
+        for &(slot, (want_tag, want_dir)) in cases {
+            // (1) The fast-path split validates the suffix.
+            assert_eq!(
+                split_lang_dir(slot),
+                (want_tag, want_dir),
+                "split_lang_dir disagreed for slot {slot:?}"
+            );
+
+            // (2) Round-trip the SAME raw slot through the dictionary and materialise it
+            //     (the `oxrdf::Term` path). Both the in-arena and compacted-blob records must
+            //     agree with the split.
+            let mut d = Dict::new();
+            let id = d.intern_lit("v", xsd::STRING.as_str(), Some(slot));
+            for d in [d.clone(), d.clone().into_blob()] {
+                // The stored slot is preserved verbatim (the fast path reads exactly this).
+                let TermParts::Lit { lang: Some(stored), .. } = d.term_parts(id) else {
+                    panic!("expected a lang literal for slot {slot:?}");
+                };
+                assert_eq!(stored, slot, "stored slot mutated for {slot:?}");
+
+                // The materialised Term: direction() and language() MUST match the split.
+                let Term::Literal(l) = d.term(id) else { panic!("expected a literal for {slot:?}") };
+                let mat_dir = l.direction().map(|x| match x {
+                    oxrdf::BaseDirection::Ltr => "ltr",
+                    oxrdf::BaseDirection::Rtl => "rtl",
+                });
+                assert_eq!(mat_dir, want_dir, "materialised direction != split for {slot:?}");
+                assert_eq!(l.language(), Some(want_tag), "materialised lang != split tag for {slot:?}");
+            }
+        }
     }
 
     #[test]

--- a/crates/sparq-core/src/dict.rs
+++ b/crates/sparq-core/src/dict.rs
@@ -251,6 +251,22 @@ pub(crate) fn lang_with_dir(l: &Literal) -> Option<std::borrow::Cow<'_, str>> {
     }
 }
 
+/// Inverse of [`lang_with_dir`]: split a STORED language slot back into its BCP47 tag and
+/// (optional) RDF 1.2 base direction. A stored slot of `en--ltr` is `("en", Some("ltr"))`;
+/// a plain `en` is `("en", None)`. `--` can never occur inside a valid language tag, so the
+/// split is unambiguous. The returned tag/direction are the spec-distinct components the
+/// SPARQL 1.2 results formats keep apart (`xml:lang` vs `its:dir`) — see the engine's
+/// `json.rs` and the conformance results reader.
+// [OPUS-4.8] sq-bj7o: the JSON fast path serialises straight from this stored slot, so it
+// needs the same split the `oxrdf::Term` path gets for free via `Literal::direction()`.
+#[inline]
+pub fn split_lang_dir(slot: &str) -> (&str, Option<&str>) {
+    match slot.split_once("--") {
+        Some((tag, dir)) => (tag, Some(dir)),
+        None => (slot, None),
+    }
+}
+
 #[inline]
 fn hash_term(t: &Term) -> u64 {
     match t {

--- a/crates/sparq-engine/src/json.rs
+++ b/crates/sparq-engine/src/json.rs
@@ -33,9 +33,21 @@ pub(crate) fn parts_to_json(s: &mut String, parts: TermParts<'_>) {
             escape_into(s, value);
             s.push('"');
             if let Some(lang) = lang {
+                // [OPUS-4.8] sq-bj7o: the stored slot folds an RDF 1.2 base direction into
+                // the tag as `lang--dir` (see `dict::lang_with_dir`). The SPARQL 1.2 JSON
+                // results format keeps them apart: `xml:lang` is the bare tag and `its:dir`
+                // the direction. Splitting here (instead of emitting `xml:lang:"en--ltr"`)
+                // makes this path spec-conformant AND match the materialised `oxrdf::Term`
+                // path (`term_to_json`) — the two were diverging for directional literals.
+                let (tag, dir) = sparq_core::dict::split_lang_dir(lang);
                 s.push_str(",\"xml:lang\":\"");
-                escape_into(s, lang);
+                escape_into(s, tag);
                 s.push('"');
+                if let Some(dir) = dir {
+                    s.push_str(",\"its:dir\":\"");
+                    escape_into(s, dir);
+                    s.push('"');
+                }
             } else if datatype != XSD_STRING {
                 s.push_str(",\"datatype\":\"");
                 escape_into(s, datatype);
@@ -134,6 +146,13 @@ pub(crate) fn term_to_json(s: &mut String, t: &Term) {
                 s.push_str(",\"xml:lang\":\"");
                 escape_into(s, lang);
                 s.push('"');
+                // [OPUS-4.8] sq-bj7o: RDF 1.2 base direction → SPARQL 1.2 `its:dir` (kept
+                // separate from `xml:lang`, matching the stored-slot fast path above).
+                if let Some(dir) = l.direction() {
+                    s.push_str(",\"its:dir\":\"");
+                    escape_into(s, &dir.to_string());
+                    s.push('"');
+                }
             } else {
                 let dt = l.datatype();
                 if dt.as_str() != "http://www.w3.org/2001/XMLSchema#string" {

--- a/crates/sparq-engine/src/json.rs
+++ b/crates/sparq-engine/src/json.rs
@@ -147,10 +147,17 @@ pub(crate) fn term_to_json(s: &mut String, t: &Term) {
                 escape_into(s, lang);
                 s.push('"');
                 // [OPUS-4.8] sq-bj7o: RDF 1.2 base direction → SPARQL 1.2 `its:dir` (kept
-                // separate from `xml:lang`, matching the stored-slot fast path above).
+                // separate from `xml:lang`, matching the stored-slot fast path above). Map the
+                // two-variant `BaseDirection` enum to a `&'static str` rather than
+                // `dir.to_string()` — the latter heap-allocated a fresh `String` per
+                // directional literal (a Display call) for no reason.
                 if let Some(dir) = l.direction() {
+                    let dir = match dir {
+                        oxrdf::BaseDirection::Ltr => "ltr",
+                        oxrdf::BaseDirection::Rtl => "rtl",
+                    };
                     s.push_str(",\"its:dir\":\"");
-                    escape_into(s, &dir.to_string());
+                    escape_into(s, dir);
                     s.push('"');
                 }
             } else {

--- a/crates/sparq-py/src/lib.rs
+++ b/crates/sparq-py/src/lib.rs
@@ -55,7 +55,13 @@ fn engine_err(e: String) -> PyErr {
 /// `value` is the IRI / lexical form / blank-node label. For literals,
 /// `language` is the language tag (if any) and `datatype` the datatype IRI
 /// (always set — plain literals carry `xsd:string`, language-tagged ones
-/// `rdf:langString`). Non-literals have `language = datatype = None`.
+/// `rdf:langString`, directional ones `rdf:dirLangString`). `direction` is the
+/// RDF 1.2 base direction (`"ltr"` / `"rtl"`) of a directional language string,
+/// else `None` — it is the SPARQL 1.2 `its:dir` value `Graph.query_json` emits.
+/// Non-literals have `language = datatype = direction = None`.
+// [OPUS-4.8] sq-bj7o: `direction` added so a directional language string
+// (`"hi"@en--ltr`) keeps its base direction through `query` — previously the
+// Term path dropped it while `query_json` kept it, so the two diverged.
 // `skip_from_py_object`: pyo3 0.29 makes the auto `FromPyObject` for Clone
 // pyclasses opt-in; nothing here extracts a `Term` from Python, so skip it.
 #[pyclass(frozen, eq, hash, skip_from_py_object, module = "sparq")]
@@ -69,6 +75,10 @@ struct Term {
     language: Option<String>,
     #[pyo3(get)]
     datatype: Option<String>,
+    /// RDF 1.2 base direction (`"ltr"` / `"rtl"`) of a directional language
+    /// string; `None` for every other term. [OPUS-4.8] sq-bj7o
+    #[pyo3(get)]
+    direction: Option<String>,
 }
 
 impl Term {
@@ -79,18 +89,24 @@ impl Term {
                 value: n.as_str().to_string(),
                 language: None,
                 datatype: None,
+                direction: None,
             },
             oxrdf::Term::BlankNode(b) => Term {
                 kind: "bnode".into(),
                 value: b.as_str().to_string(),
                 language: None,
                 datatype: None,
+                direction: None,
             },
             oxrdf::Term::Literal(l) => Term {
                 kind: "literal".into(),
                 value: l.value().to_string(),
                 language: l.language().map(str::to_string),
                 datatype: Some(l.datatype().as_str().to_string()),
+                // [OPUS-4.8] sq-bj7o: preserve the RDF 1.2 base direction (the
+                // SPARQL 1.2 `its:dir` value) so a directional language string
+                // round-trips through `query` at parity with `query_json`.
+                direction: l.direction().map(|d| d.to_string()),
             },
             // RDF-star quoted triple: keep the N-Triples rendering as the value.
             oxrdf::Term::Triple(t) => Term {
@@ -98,6 +114,7 @@ impl Term {
                 value: t.to_string(),
                 language: None,
                 datatype: None,
+                direction: None,
             },
         }
     }
@@ -112,7 +129,12 @@ impl Term {
             _ => {
                 let v = self.value.replace('\\', "\\\\").replace('"', "\\\"").replace('\n', "\\n");
                 if let Some(lang) = &self.language {
-                    format!("\"{v}\"@{lang}")
+                    // [OPUS-4.8] sq-bj7o: a directional language string renders as
+                    // `"v"@lang--dir` (the RDF 1.2 / Turtle surface form).
+                    match &self.direction {
+                        Some(dir) => format!("\"{v}\"@{lang}--{dir}"),
+                        None => format!("\"{v}\"@{lang}"),
+                    }
                 } else {
                     match self.datatype.as_deref() {
                         None | Some(XSD_STRING) => format!("\"{v}\""),

--- a/crates/sparq-py/tests/test_parity.py
+++ b/crates/sparq-py/tests/test_parity.py
@@ -52,7 +52,15 @@ RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 
 def _term_dict(t):
     """A `Term` as a plain dict — what we compare against hand-computed truth."""
-    return {"kind": t.kind, "value": t.value, "language": t.language, "datatype": t.datatype}
+    return {
+        "kind": t.kind,
+        "value": t.value,
+        "language": t.language,
+        "datatype": t.datatype,
+        # [OPUS-4.8] sq-bj7o: RDF 1.2 base direction (its:dir) — None for all but
+        # directional language strings.
+        "direction": t.direction,
+    }
 
 
 def _rows_via_json(graph, sparql):
@@ -69,21 +77,30 @@ def _rows_via_json(graph, sparql):
             if kind == "literal":
                 # SPARQL JSON: language-tagged literals carry "xml:lang" and no
                 # explicit datatype (it is implicitly rdf:langString); plain ones
-                # carry "datatype" only when it is not xsd:string.
+                # carry "datatype" only when it is not xsd:string. RDF 1.2
+                # directional language strings additionally carry "its:dir" (the
+                # base direction) and are implicitly rdf:dirLangString.
                 lang = cell.get("xml:lang")
                 dt = cell.get("datatype")
+                direction = cell.get("its:dir")  # [OPUS-4.8] sq-bj7o
                 if lang is not None:
-                    dt = RDF + "langString"
+                    dt = RDF + ("dirLangString" if direction is not None else "langString")
                 elif dt is None:
                     dt = XSD + "string"
-                row[var] = {"kind": "literal", "value": cell["value"], "language": lang, "datatype": dt}
+                row[var] = {
+                    "kind": "literal",
+                    "value": cell["value"],
+                    "language": lang,
+                    "datatype": dt,
+                    "direction": direction,
+                }
             elif kind == "triple":
                 # The JSON writer nests the quoted triple; `Term` renders it as an
                 # N-Triples string. Compare only kind here (value rendering differs
                 # by design) — the dedicated triple-term test covers the value.
                 row[var] = {"kind": "triple"}
             else:  # uri / bnode
-                row[var] = {"kind": kind, "value": cell["value"], "language": None, "datatype": None}
+                row[var] = {"kind": kind, "value": cell["value"], "language": None, "datatype": None, "direction": None}
         out.append(row)
     return out
 
@@ -124,18 +141,20 @@ def _object_of(graph, pred):
 @pytest.mark.parametrize(
     "pred,expected",
     [
-        ("iri", {"kind": "uri", "value": "http://ex/object", "language": None, "datatype": None}),
-        ("plain", {"kind": "literal", "value": "plain text", "language": None, "datatype": XSD + "string"}),
+        ("iri", {"kind": "uri", "value": "http://ex/object", "language": None, "datatype": None, "direction": None}),
+        ("plain", {"kind": "literal", "value": "plain text", "language": None, "datatype": XSD + "string", "direction": None}),
         # An explicit ^^xsd:string is indistinguishable from a plain literal (RDF 1.1).
-        ("typedStr", {"kind": "literal", "value": "typed", "language": None, "datatype": XSD + "string"}),
-        ("int", {"kind": "literal", "value": "42", "language": None, "datatype": XSD + "integer"}),
-        ("dec", {"kind": "literal", "value": "3.14", "language": None, "datatype": XSD + "decimal"}),
-        ("dbl", {"kind": "literal", "value": "1.0e3", "language": None, "datatype": XSD + "double"}),
-        ("bool", {"kind": "literal", "value": "true", "language": None, "datatype": XSD + "boolean"}),
-        ("date", {"kind": "literal", "value": "2020-01-01", "language": None, "datatype": XSD + "date"}),
-        ("custom", {"kind": "literal", "value": "abc", "language": None, "datatype": "http://ex/myType"}),
+        ("typedStr", {"kind": "literal", "value": "typed", "language": None, "datatype": XSD + "string", "direction": None}),
+        ("int", {"kind": "literal", "value": "42", "language": None, "datatype": XSD + "integer", "direction": None}),
+        ("dec", {"kind": "literal", "value": "3.14", "language": None, "datatype": XSD + "decimal", "direction": None}),
+        ("dbl", {"kind": "literal", "value": "1.0e3", "language": None, "datatype": XSD + "double", "direction": None}),
+        ("bool", {"kind": "literal", "value": "true", "language": None, "datatype": XSD + "boolean", "direction": None}),
+        ("date", {"kind": "literal", "value": "2020-01-01", "language": None, "datatype": XSD + "date", "direction": None}),
+        ("custom", {"kind": "literal", "value": "abc", "language": None, "datatype": "http://ex/myType", "direction": None}),
         # Language tag is preserved and lower-cased per the parser; datatype is rdf:langString.
-        ("lang", {"kind": "literal", "value": "bonjour", "language": "fr", "datatype": RDF + "langString"}),
+        ("lang", {"kind": "literal", "value": "bonjour", "language": "fr", "datatype": RDF + "langString", "direction": None}),
+        # [OPUS-4.8] sq-bj7o: directional language string keeps its base direction.
+        ("dir", {"kind": "literal", "value": "hello", "language": "en", "datatype": RDF + "dirLangString", "direction": "ltr"}),
     ],
 )
 def test_term_kind_roundtrip(pred, expected):
@@ -163,46 +182,49 @@ def test_term_kind_blank_node_roundtrip():
 
 def test_term_kind_directional_language_string():
     """RDF 1.2 directional language string: `"hello"@en--ltr` round-trips with
-    language 'en' and datatype rdf:dirLangString. The Term type currently
-    surfaces only kind/value/language/datatype (no separate base-direction
-    field) — this test PINS that observed contract so a future change is caught."""
+    language 'en', datatype rdf:dirLangString, AND base direction 'ltr' exposed
+    on the dedicated `Term.direction` field.
+
+    [OPUS-4.8] sq-bj7o: before the fix the Term path dropped the base direction
+    (only kind/value/language/datatype surfaced); now `direction` carries the
+    RDF 1.2 base direction (the SPARQL 1.2 `its:dir` value)."""
     g = sparq.Graph.load(TERMS_DATA)
     o = _object_of(g, "dir")
     assert o.kind == "literal"
     assert o.value == "hello"
     assert o.language == "en"
     assert o.datatype == RDF + "dirLangString"
+    assert o.direction == "ltr"
 
 
-# [OPUS-4.8] sq-f9tu DISCOVERED PARITY GAP (filed as bead sq-bj7o): the base DIRECTION
-# of an RDF-1.2 directional language string is LOST by the Term path but PRESERVED
-# by the JSON path — so `Graph.query` and `Graph.query_json` DIVERGE for these
-# literals. Through `Term`, `@en--ltr` and `@en--rtl` are indistinguishable (both
-# language="en", datatype=rdf:dirLangString); through `query_json` they correctly
-# carry `xml:lang="en--ltr"` vs `"en--rtl"`. Documented as xfail (not a hard fail)
-# so the suite stays green while the gap is tracked; flip to a hard assert when the
-# bead lands a fix (extend Term with a base-direction field / fold it into language).
-@pytest.mark.xfail(
-    reason="bead sq-bj7o: Term loses base-direction of rdf:dirLangString; "
-    "query vs query_json diverge (query_json keeps en--ltr/en--rtl, Term does not)",
-    strict=True,
-)
+# [OPUS-4.8] sq-bj7o REGRESSION TEST. The base DIRECTION of an RDF-1.2 directional
+# language string used to be LOST by the Term path but smuggled (into `xml:lang` as
+# `en--ltr`) by the JSON path — so `Graph.query` and `Graph.query_json` DIVERGED.
+# The fix gives the Term a dedicated `direction` field and makes `query_json` emit
+# the spec-correct SPARQL 1.2 `its:dir` (with `xml:lang` now the bare tag). This
+# test asserts the two paths now AGREE on the direction for both ltr and rtl.
 def test_directional_literal_direction_parity_query_vs_json():
     ltr = sparq.Graph.load('@prefix ex: <http://ex/> . ex:s ex:p "x"@en--ltr .')
     rtl = sparq.Graph.load('@prefix ex: <http://ex/> . ex:s ex:p "x"@en--rtl .')
 
-    def term_lang(g):
-        return g.query("SELECT ?o WHERE { ?s ?p ?o }").rows[0]["o"].language
+    def term_dir(g):
+        o = g.query("SELECT ?o WHERE { ?s ?p ?o }").rows[0]["o"]
+        # The Term keeps the bare tag in `language` and the direction separately.
+        assert o.language == "en"
+        return o.direction
 
-    def json_lang(g):
-        doc = json.loads(g.query_json("SELECT ?o WHERE { ?s ?p ?o }"))
-        return doc["results"]["bindings"][0]["o"].get("xml:lang")
+    def json_dir(g):
+        cell = json.loads(g.query_json("SELECT ?o WHERE { ?s ?p ?o }"))["results"]["bindings"][0]["o"]
+        # SPARQL 1.2 JSON: `xml:lang` is the bare tag, `its:dir` the direction.
+        assert cell.get("xml:lang") == "en"
+        return cell.get("its:dir")
 
-    # The JSON path keeps the direction (en--ltr vs en--rtl); the Term path must
-    # ALSO distinguish them for the two result paths to be at parity. Today it
-    # does not, so this fails (xfail) until the bead's fix lands.
-    assert json_lang(ltr) != json_lang(rtl)  # holds today
-    assert term_lang(ltr) != term_lang(rtl)  # the parity claim — currently FALSE
+    # Both paths distinguish ltr from rtl ...
+    assert term_dir(ltr) != term_dir(rtl)
+    assert json_dir(ltr) != json_dir(rtl)
+    # ... and the two paths AGREE term-by-term (the parity claim the bead is about).
+    assert term_dir(ltr) == json_dir(ltr) == "ltr"
+    assert term_dir(rtl) == json_dir(rtl) == "rtl"
 
 
 # ===========================================================================
@@ -306,6 +328,7 @@ def test_construct_literal_object_parity():
         "value": "Bob",
         "language": "en",
         "datatype": RDF + "langString",
+        "direction": None,
     }
 
 

--- a/skills/python/SKILL.md
+++ b/skills/python/SKILL.md
@@ -65,7 +65,7 @@ All on the `sparq.Graph` class (the only entry point). Constructors are static m
 
 `QueryResult`: `.vars: list[str]`, `.rows: list[dict[str, Term]]`, plus `len(res)`, `res[i]` (negative indices/slices ok), and iteration.
 
-`Term` (frozen, value-based `==`/`hash`): `.kind` ∈ `"uri"` | `"literal"` | `"bnode"` | `"triple"` (RDF-star); `.value` (IRI / lexical form / bnode label); `.language` (literals only, else `None`); `.datatype` (literals only — always set: plain → `xsd:string`, lang-tagged → `rdf:langString`; else `None`). `str(term)` → bare `.value`; `repr(term)` → N-Triples-ish (e.g. `Term("Bob"@en)`).
+`Term` (frozen, value-based `==`/`hash`): `.kind` ∈ `"uri"` | `"literal"` | `"bnode"` | `"triple"` (RDF-star); `.value` (IRI / lexical form / bnode label); `.language` (literals only — the bare BCP-47 tag, else `None`); `.datatype` (literals only — always set: plain → `xsd:string`, lang-tagged → `rdf:langString`, directional → `rdf:dirLangString`; else `None`); `.direction` (RDF 1.2 base direction `"ltr"` / `"rtl"` of a directional language string — the SPARQL 1.2 `its:dir`; `None` otherwise). `str(term)` → bare `.value`; `repr(term)` → N-Triples-ish (e.g. `Term("Bob"@en)`, `Term("hi"@en--ltr)`).
 
 `sparq.__version__` is the package version string.
 


### PR DESCRIPTION
Fixes sq-bj7o: a directional language string (`"hi"@en--rtl`) lost its base **direction** through the Python bindings, so `query()` and `query_json()` diverged.

**Root cause (two-sided):** direction is stored folded into the lang slot as `lang--dir`.
- `query`: `Term::from_oxrdf` read only `language()`+`datatype()`, dropping `direction()`.
- `query_json`: the serializer was itself **non-conformant** — the fast path emitted `"xml:lang":"en--ltr"` while the materialized path dropped direction. SPARQL 1.2 keeps `xml:lang` (bare tag) and `its:dir` separate (the conformance reader already expects this split).

**Fix:** added `sparq-core::dict::split_lang_dir`; both `json.rs` paths now emit `xml:lang`=bare + `its:dir`=direction (identical, spec-conformant); `sparq-py Term` gained a `direction` field. Verified `Term("hi"@en--rtl)` → `lang=en, dir=rtl`, JSON `{"xml:lang":"en","its:dir":"rtl"}`.

**Tests:** the previously-xfail parity test is now a real passing regression (query vs query_json agree on direction, ltr+rtl); pytest 80 passed / 0 failed; engine 158 + rdfstar_write 15 green; clippy clean. Documented `Term.direction` in skills/python.

Filed sq-s955 (inbound counterpart: SERVICE remote-result parser ignores `its:dir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)