### PR TITLE
feat(sparq-mpc): RS consistency-checked + robust (Berlekamp–Welch) reconstruction — closes tamper-detection gap (sq-m34i / sq-uu0u WI-1)

### DIFF
--- a/crates/sparq-mpc/src/adversarial_tests.rs
+++ b/crates/sparq-mpc/src/adversarial_tests.rs
@@ -107,33 +107,83 @@ mod tamper {
         );
     }
 
-    /// Even with MAXIMAL redundancy (all `n` shares present, of which any `t+1`
-    /// suffice), a single tampered share STILL silently corrupts the result. This
-    /// sharpens the finding: the impl does NOT exploit the available redundancy to
-    /// detect (let alone correct) the error — it just Lagrange-interpolates the
-    /// whole over-determined set, which an inconsistent point poisons. A
-    /// malicious-secure scheme (VSS / IT-MACs) WOULD catch this; v1 does not.
+    /// **POSITIVE detection/correction test (sq-m34i, was the `…_is_still_
+    /// undetected` pin).** With MAXIMAL redundancy (all `n` shares present), the
+    /// consistency-checked / robust reconstruction now EXPLOITS the redundancy
+    /// via Reed–Solomon (Berlekamp–Welch): it corrects up to
+    /// `e = ⌊(n−t−1)/2⌋` tampered shares and returns the TRUE secret, and aborts
+    /// with `MpcError::Tampered` when the tampering exceeds that budget. This was
+    /// the gap pinned by bead sq-uu0u and is now CLOSED at the Shamir layer.
     #[test]
-    fn tampered_share_with_full_redundancy_is_still_undetected() {
+    fn tampered_share_with_full_redundancy_is_corrected_or_aborts() {
+        // n = 7, t = 3 → e_max = ⌊(7−3−1)/2⌋ = 1: one error is CORRECTABLE.
         let backend = ShamirBackend::new_seeded(7, 0x5EED).unwrap();
+        let t = backend.threshold();
+        assert_eq!(t, 3);
         let secret = fp(2_024);
-        let mut shares = backend.dealer().share(secret); // n = 7 shares
+        let shares = backend.dealer().share(secret); // n = 7 shares
 
         assert_eq!(
             backend.reconstruct(&shares).unwrap(),
             secret,
-            "honest full set ok"
+            "honest full set ok (no behaviour change on clean input)"
         );
 
-        corrupt_one(&mut shares, 3, 1); // flip a single share by +1
-
-        let got = backend.reconstruct(&shares).unwrap();
-        assert_ne!(
-            got, secret,
-            "FINDING (sq-nuok pin → bead sq-uu0u): a single tampered share corrupts reconstruction \
-             even with full n-share redundancy — the impl does no consistency / \
-             error-detection across subsets (no malicious security)"
+        // ONE tampered share (within budget e_max=1) → robustly CORRECTED to the
+        // true secret. The redundancy that v1 wasted is now used.
+        let mut one_bad = shares.clone();
+        corrupt_one(&mut one_bad, 3, 1); // flip a single share by +1
+        assert_eq!(
+            backend.reconstruct(&one_bad).unwrap(),
+            secret,
+            "sq-m34i: a single tampered share is RS-corrected back to the true secret \
+             (Berlekamp–Welch, n≥t+2e+1)"
         );
+
+        // TWO tampered shares (> e_max=1) → cannot be corrected → detect-and-abort.
+        let mut two_bad = shares.clone();
+        corrupt_one(&mut two_bad, 3, 1);
+        corrupt_one(&mut two_bad, 5, 2);
+        let err = backend.reconstruct(&two_bad).unwrap_err();
+        assert!(
+            matches!(err, MpcError::Tampered { .. }),
+            "sq-m34i: tampering beyond the correctable budget must ABORT with \
+             MpcError::Tampered, never silently corrupt; got {err:?}"
+        );
+    }
+
+    /// **POSITIVE detection test (sq-m34i).** At the minimal redundancy where no
+    /// correction is possible but detection IS (`e_max = 0`, i.e. `n = t+2`), a
+    /// single tampered share is DETECTED and the reconstruction aborts. This is
+    /// the pure detect-and-abort regime (no correction budget).
+    #[test]
+    fn tampered_share_with_minimal_redundancy_is_detected_and_aborts() {
+        // n = 3, t = 1 → e_max = ⌊(3−1−1)/2⌋ = 0: a single error is DETECTABLE
+        // (abort) but not correctable.
+        let backend = ShamirBackend::new_seeded(3, 0xD00D).unwrap();
+        assert_eq!(backend.threshold(), 1);
+        let secret = fp(777);
+        let mut shares = backend.dealer().share(secret); // n = 3 > t+1 = 2
+
+        assert_eq!(backend.reconstruct(&shares).unwrap(), secret, "honest ok");
+
+        corrupt_one(&mut shares, 1, 9); // single tampered share
+        let err = backend.reconstruct(&shares).unwrap_err();
+        match err {
+            MpcError::Tampered { cheaters, .. } => {
+                // Detection is SOUND (we aborted). Attribution is best-effort:
+                // with e_max=0 the honest set is unknown, so the reported off-
+                // curve point(s) — relative to an arbitrary reference subset —
+                // need not be the true cheater. We assert only that SOME suspect
+                // is named (the message is actionable), per the documented
+                // best-effort attribution contract.
+                assert!(
+                    !cheaters.is_empty(),
+                    "sq-m34i: detect-and-abort should name at least one suspect point; got {cheaters:?}"
+                );
+            }
+            other => panic!("sq-m34i: a tampered share with redundancy must abort, got {other:?}"),
+        }
     }
 
     /// The secure-equality primitive (`HiddenValueJoin::secure_equal`) opens
@@ -199,11 +249,15 @@ mod tamper {
         );
     }
 
-    /// A tampered share inside a SECURE SUM (`run_secure`) likewise propagates to
-    /// a wrong reconstructed total — the aggregate is just as unprotected as a
-    /// single reconstruction. We pin it to cover the `run_secure` path too.
+    /// **POSITIVE detection/correction test (sq-m34i, was the `…_corrupts_secure_
+    /// sum_silently` pin).** A tampered share inside the SECURE SUM output
+    /// (`run_secure`) is now caught by the same consistency-checked / robust
+    /// reconstruction: with the available redundancy it is RS-corrected back to
+    /// the true total (within `e_max`), and aborts when the tampering exceeds the
+    /// correctable budget. The aggregate path is no longer silently corruptible.
     #[test]
-    fn tampered_share_corrupts_secure_sum_silently() {
+    fn tampered_share_in_secure_sum_is_corrected_or_aborts() {
+        // n = 4, t = 1 → e_max = ⌊(4−1−1)/2⌋ = 1: one error is CORRECTABLE.
         let backend = ShamirBackend::new_seeded(4, 0x5151).unwrap();
         let mut dealer = backend.dealer();
         let inputs: Vec<Vec<Share>> = [10u64, 20, 30]
@@ -217,16 +271,219 @@ mod tamper {
             "honest sum"
         );
 
-        // Corrupt one share of the summed sharing.
-        let mut bad = summed.clone();
-        bad[0][0].y = bad[0][0].y.add(fp(7));
-        let got = backend.reconstruct(&bad[0]).unwrap();
-        assert_ne!(
-            got,
+        // ONE corrupted share of the summed sharing → RS-corrected to the truth.
+        let mut one_bad = summed.clone();
+        one_bad[0][0].y = one_bad[0][0].y.add(fp(7));
+        assert_eq!(
+            backend.reconstruct(&one_bad[0]).unwrap(),
             fp(60),
-            "FINDING (sq-nuok pin → bead sq-uu0u): a tampered share in run_secure's output corrupts \
-             the reconstructed aggregate undetected"
+            "sq-m34i: a single tampered share in the aggregate is RS-corrected to the true sum"
         );
+
+        // TWO corrupted shares (> e_max=1) → detect-and-abort, never a wrong total.
+        let mut two_bad = summed.clone();
+        two_bad[0][0].y = two_bad[0][0].y.add(fp(7));
+        two_bad[0][2].y = two_bad[0][2].y.add(fp(11));
+        let err = backend.reconstruct(&two_bad[0]).unwrap_err();
+        assert!(
+            matches!(err, MpcError::Tampered { .. }),
+            "sq-m34i: tampering the aggregate beyond the correctable budget must ABORT \
+             (MpcError::Tampered), not silently change the total; got {err:?}"
+        );
+    }
+}
+
+// =====================================================================
+// PART 1b — RS robust/checked reconstruction PROPERTY tests (sq-m34i).
+// Random secret + random tamper patterns across the (n, t, e) regimes,
+// plus a differential against honest Lagrange on untampered inputs.
+// =====================================================================
+mod robust_props {
+    use super::*;
+    use crate::robust::reconstruct_robust;
+    use crate::shamir::reconstruct_at_zero;
+
+    /// Deterministic SplitMix64 (reproducible; same shape as `field_fuzz::Lcg`).
+    struct Lcg(u64);
+    impl Lcg {
+        fn next(&mut self) -> u64 {
+            self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut z = self.0;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^ (z >> 31)
+        }
+        /// A canonical field element in [0, P) via rejection (no modulo bias).
+        fn next_fp(&mut self) -> u64 {
+            loop {
+                let c = self.next() & ((1u64 << 61) - 1);
+                if c < P {
+                    return c;
+                }
+            }
+        }
+        fn next_in(&mut self, hi: usize) -> usize {
+            (self.next() % hi as u64) as usize
+        }
+    }
+
+    /// Choose `k` distinct indices in `[0, n)`.
+    fn distinct_indices(rng: &mut Lcg, n: usize, k: usize) -> Vec<usize> {
+        let mut chosen: Vec<usize> = Vec::with_capacity(k);
+        while chosen.len() < k {
+            let i = rng.next_in(n);
+            if !chosen.contains(&i) {
+                chosen.push(i);
+            }
+        }
+        chosen
+    }
+
+    /// Tamper exactly the chosen indices by a nonzero field delta.
+    fn tamper(rng: &mut Lcg, shares: &mut [Share], idxs: &[usize]) {
+        for &i in idxs {
+            let mut d = rng.next_fp();
+            if d == 0 {
+                d = 1;
+            }
+            shares[i].y = shares[i].y.add(fp(d));
+        }
+    }
+
+    /// PROPERTY: with `n ≥ t + 2e + 1` and up to `e` random tampered shares, the
+    /// robust reconstruction returns the TRUE secret (Berlekamp–Welch corrects).
+    #[test]
+    fn robust_corrects_up_to_e_errors_returns_truth() {
+        let mut rng = Lcg(0x00C0_DE15_F00D);
+        // Use n with comfortable redundancy so e_max >= 1 for several t.
+        for &n in &[4usize, 5, 7, 9] {
+            let backend = ShamirBackend::new_seeded(n, 0x5A5A + n as u64).unwrap();
+            let t = backend.threshold();
+            let e_max = (n - t - 1) / 2;
+            if e_max == 0 {
+                continue; // no correction budget at this (n, t)
+            }
+            for _ in 0..200 {
+                let secret = fp(rng.next_fp());
+                let clean = backend.dealer().share(secret);
+                // Tamper a random number of shares in 0..=e_max.
+                let num_err = rng.next_in(e_max + 1); // 0..=e_max
+                let mut shares = clean.clone();
+                let idxs = distinct_indices(&mut rng, n, num_err);
+                tamper(&mut rng, &mut shares, &idxs);
+                let got = reconstruct_robust(&shares, t).unwrap_or_else(|e| {
+                    panic!("n={n} t={t} e_max={e_max} num_err={num_err}: must correct, got {e:?}")
+                });
+                assert_eq!(
+                    got, secret,
+                    "n={n} t={t} e_max={e_max} num_err={num_err}: robust must return the truth"
+                );
+            }
+        }
+    }
+
+    /// PROPERTY: when the number of tampered shares is in `(e_max, n−t−1]` — i.e.
+    /// MORE than correctable but redundancy still present — the reconstruction
+    /// ABORTS with `MpcError::Tampered` rather than returning a wrong secret.
+    /// (`n−t−1` is the count of redundant shares; beyond it the codeword can be
+    /// underdetermined, so we cap at the detectable band.)
+    #[test]
+    fn robust_aborts_when_errors_exceed_budget() {
+        let mut rng = Lcg(0xDEAD_BEEF_F00D);
+        for &n in &[3usize, 4, 5, 7, 9] {
+            let backend = ShamirBackend::new_seeded(n, 0x1234 + n as u64).unwrap();
+            let t = backend.threshold();
+            let e_max = (n - t - 1) / 2;
+            // # excess shares over the threshold; the detectable-but-not-
+            // correctable band is (e_max, redundancy].
+            let redundancy = n - t - 1;
+            if redundancy <= e_max {
+                continue; // no such band (e.g. nothing beyond correctable to test)
+            }
+            for _ in 0..200 {
+                let secret = fp(rng.next_fp());
+                let clean = backend.dealer().share(secret);
+                // num_err strictly above e_max, up to `redundancy`.
+                let span = redundancy - e_max; // >= 1
+                let num_err = e_max + 1 + rng.next_in(span); // (e_max, redundancy]
+                let mut shares = clean.clone();
+                let idxs = distinct_indices(&mut rng, n, num_err);
+                tamper(&mut rng, &mut shares, &idxs);
+                match reconstruct_robust(&shares, t) {
+                    Err(MpcError::Tampered { .. }) => { /* detected — correct */ }
+                    Ok(v) => panic!(
+                        "n={n} t={t} e_max={e_max} num_err={num_err}: must ABORT, \
+                         but returned {v:?} (true secret was {secret:?})"
+                    ),
+                    Err(other) => {
+                        panic!("n={n} num_err={num_err}: must be Tampered, got {other:?}")
+                    }
+                }
+            }
+        }
+    }
+
+    /// PROPERTY (documented non-detection): at EXACTLY `t+1` shares (no
+    /// redundancy) a single tampered share is information-theoretically
+    /// undetectable — robust reconstruction must NOT return `Tampered` and must
+    /// simply interpolate (to a different, wrong secret). No false positives.
+    #[test]
+    fn exact_threshold_set_never_reports_tampered() {
+        let mut rng = Lcg(0xFEED_FACE);
+        for &n in &[2usize, 3, 5, 7, 9] {
+            let backend = ShamirBackend::new_seeded(n, 0xABCD + n as u64).unwrap();
+            let t = backend.threshold();
+            for _ in 0..200 {
+                let secret = fp(rng.next_fp());
+                let clean = backend.dealer().share(secret);
+                // Take exactly t+1 shares, then tamper one of them.
+                let mut min_set = clean[..t + 1].to_vec();
+                let i = rng.next_in(t + 1);
+                let mut d = rng.next_fp();
+                if d == 0 {
+                    d = 1;
+                }
+                min_set[i].y = min_set[i].y.add(fp(d));
+                match reconstruct_robust(&min_set, t) {
+                    Ok(v) => assert_ne!(
+                        v, secret,
+                        "n={n} t={t}: t+1-share tamper must change the secret (no magic correction)"
+                    ),
+                    Err(MpcError::Tampered { .. }) => panic!(
+                        "n={n} t={t}: FALSE POSITIVE — no redundancy means tampering is \
+                         undetectable; must not report Tampered"
+                    ),
+                    Err(other) => panic!("n={n}: unexpected error {other:?}"),
+                }
+            }
+        }
+    }
+
+    /// DIFFERENTIAL: on UNTAMPERED inputs the robust path returns EXACTLY the
+    /// same value as the honest primitive `reconstruct_at_zero` (plain Lagrange)
+    /// — no regression for the common, honest case, at every redundancy level.
+    #[test]
+    fn robust_matches_honest_lagrange_on_clean_inputs() {
+        let mut rng = Lcg(0x000F_F1CE);
+        for &n in &[2usize, 3, 4, 5, 7, 9] {
+            let backend = ShamirBackend::new_seeded(n, 0x7E57 + n as u64).unwrap();
+            let t = backend.threshold();
+            for _ in 0..300 {
+                let secret = fp(rng.next_fp());
+                let shares = backend.dealer().share(secret);
+                // Compare on every subset size from t+1 up to n.
+                for take in (t + 1)..=n {
+                    let subset = &shares[..take];
+                    let honest = reconstruct_at_zero(subset, t).unwrap();
+                    let robust = reconstruct_robust(subset, t).unwrap();
+                    assert_eq!(
+                        robust, honest,
+                        "n={n} take={take}: robust must equal honest Lagrange on clean input"
+                    );
+                    assert_eq!(robust, secret, "and equal the true secret");
+                }
+            }
+        }
     }
 }
 

--- a/crates/sparq-mpc/src/lib.rs
+++ b/crates/sparq-mpc/src/lib.rs
@@ -84,6 +84,11 @@ pub mod proof;
 // [OPUS-4.8] sq-1vt: the CSPRNG masking seam (production SecureRng + test-only
 // InsecureTestRng). The real protocol's secret-sharing randomness lives here.
 pub mod rng;
+// [OPUS-4.8] sq-m34i (MPC WI-1): Reed-Solomon consistency-checked + robust
+// (Berlekamp-Welch) reconstruction over Fp — detect-and-abort / correct tampered
+// shares when redundancy is present. Closes malicious-security gap (D) at the
+// Shamir layer (parent bead sq-uu0u). See the module docs for the threat model.
+pub mod robust;
 pub mod shamir;
 
 // [OPUS-4.8] sq-nuok: adversarial-share negative suite + 'no fake crypto' stub
@@ -101,4 +106,5 @@ pub use join::{DisclosedKeyJoin, GlobalJoin, HiddenKeyedRows, HiddenValueJoin, J
 pub use partial::{HolderId, MpcError, PartialResult};
 pub use proof::{Attestation, CollaborativeProof, ProofStatement};
 pub use rng::{MpcRng, SecureRng};
+pub use robust::reconstruct_robust;
 pub use shamir::{Share, ShamirBackend};

--- a/crates/sparq-mpc/src/partial.rs
+++ b/crates/sparq-mpc/src/partial.rs
@@ -89,6 +89,20 @@ pub enum MpcError {
     /// land first. Carrying the gate in the value (not just a doc-comment) keeps
     /// the deferral auditable at the call site.
     NotYetImplemented { what: String, gated_on: String },
+    /// **Active tampering detected** during a consistency-checked / robust
+    /// reconstruction (guarantee (D), malicious-honest-majority abort — sq-m34i).
+    /// Returned when redundant Shamir shares (`n > t+1`) do NOT all lie on one
+    /// degree-`t` polynomial and the inconsistency exceeds the correctable error
+    /// budget `e = ⌊(n−t−1)/2⌋`. This is **not** a precondition bug
+    /// ([`MpcError::Protocol`]) nor a deferred stub ([`MpcError::NotYetImplemented`]):
+    /// it means a party fed an inconsistent share value, so the result is
+    /// REFUSED rather than silently corrupted. `cheaters` lists the evaluation
+    /// points (`Share::x`) identified as off-curve where attribution is possible
+    /// (best-effort when correction itself is impossible — detection is sound,
+    /// attribution is heuristic). NOTE: at exactly `t+1` shares (no redundancy)
+    /// tampering is information-theoretically undetectable and this is NEVER
+    /// returned there — see [`crate::robust::reconstruct_robust`].
+    Tampered { detail: String, cheaters: Vec<u64> },
 }
 
 impl MpcError {
@@ -109,6 +123,12 @@ impl std::fmt::Display for MpcError {
             MpcError::Protocol(m) => write!(f, "MPC protocol precondition violated: {m}"),
             MpcError::NotYetImplemented { what, gated_on } => {
                 write!(f, "not yet implemented: {what} (gated on {gated_on})")
+            }
+            MpcError::Tampered { detail, cheaters } => {
+                write!(
+                    f,
+                    "tampered share(s) detected: {detail} (suspect evaluation points: {cheaters:?})"
+                )
             }
         }
     }

--- a/crates/sparq-mpc/src/robust.rs
+++ b/crates/sparq-mpc/src/robust.rs
@@ -1,0 +1,501 @@
+// [OPUS-4.8] sq-m34i (MPC WI-1): Reed-Solomon consistency-checked + robust
+// (Berlekamp-Welch) reconstruction over Fp. Closes malicious-security gap (D)
+// at the Shamir layer for the honest-majority abort/robust regime. Written while
+// Fable unavailable — re-review on return.
+//! Reed–Solomon error-detection / error-correction for Shamir reconstruction.
+//!
+//! ## The codeword view (why this works with NO new dependency)
+//!
+//! A Shamir sharing of a degree-`t` secret polynomial `Q` evaluated at `n`
+//! distinct nonzero points `x_1..x_n` is **exactly** an `[n, t+1]` Reed–Solomon
+//! codeword over the existing field `F_p` ([`crate::field`]). The message is the
+//! `t+1` low coefficients of `Q` (the secret is `Q(0)`); the codeword is the `n`
+//! evaluations `y_i = Q(x_i)`. Plain Lagrange interpolation
+//! ([`crate::shamir::reconstruct_at_zero`]) is RS *decoding under the assumption
+//! that every symbol is correct* — it has no consistency check, so one tampered
+//! `y_i` silently yields the wrong `Q(0)` even when redundancy is present
+//! (pinned by `adversarial_tests::tamper`; bead sq-uu0u).
+//!
+//! With redundancy (`n > t+1`) the same codeword view gives us, for FREE over the
+//! same `F_p` (no Feldman/Pedersen DLOG group, no SPDZ MAC preprocessing, no
+//! bigint — see sq-uu0u "REJECTED for now"):
+//!
+//! - **Detect** any tampering, for any number of errors, by checking all `n`
+//!   points lie on a single degree-`t` polynomial.
+//! - **Correct** up to `e = ⌊(n − t − 1)/2⌋` tampered shares (the RS / BW bound
+//!   `n ≥ t + 2e + 1`) and return the TRUE secret — *robust* reconstruction.
+//!
+//! ## Threat model (honest-majority, information-theoretic)
+//!
+//! This adds detect-and-abort (and, where the bound allows, robust correction)
+//! against ACTIVE tampering of share *values* — guarantee (D) at the Shamir
+//! layer. It needs no PKI, broadcast, or preprocessing. It does NOT defend:
+//!
+//! - **Exactly `t+1` shares (no redundancy).** Any `t+1` arbitrary points define
+//!   *some* degree-`t` polynomial, so a single forged share just selects a
+//!   different (wrong) secret with no inconsistency to detect. No scheme can
+//!   detect this; we preserve the existing behaviour and say so explicitly
+//!   ([`reconstruct_robust`] returns the interpolation, never a false
+//!   `Tampered`). This is pinned by a test.
+//! - **More than the correctable budget with sub-detectable structure.** When
+//!   `#errors > e` the BW system can fail to yield a consistent codeword; we
+//!   ABORT ([`MpcError::Tampered`]) rather than guess. (RS *miscorrection* — a
+//!   second valid codeword within distance `e` — needs `> e` coordinated errors
+//!   and is the standard RS limitation, not a regression over plain Lagrange,
+//!   which silently miscorrects on a SINGLE error.)
+//! - **The degree-`2t` equality/mult open** (`join::secure_equal`, opened at
+//!   `n = 2t+1` with NO RS redundancy). That is WI-2 (bead sq-7q9i), deliberately
+//!   out of scope here; this module does not touch it.
+//!
+//! ## Algorithm — Berlekamp–Welch via Gaussian elimination over `F_p`
+//!
+//! For target error budget `e`, find an **error-locator** `E(x)` of degree `e`
+//! (monic: leading coeff 1) and `N(x)` of degree `t + e` such that
+//! `N(x_i) = y_i · E(x_i)` for every share `i`, where (by construction)
+//! `N(x) = E(x)·Q(x)`. Writing the unknown coefficients of `E` (the `e` below the
+//! monic top) and of `N` (`t+e+1` of them) gives a linear system in `t + 2e + 1`
+//! unknowns over `n ≥ t + 2e + 1` equations:
+//!
+//! ```text
+//!   N(x_i) − y_i·E(x_i) = 0
+//!   ⟺  Σ_{k≤t+e} N_k x_i^k  −  y_i·(Σ_{k<e} E_k x_i^k + x_i^e) = 0
+//!   ⟺  Σ_{k≤t+e} N_k x_i^k  −  Σ_{k<e} (y_i x_i^k) E_k  =  y_i x_i^e
+//! ```
+//!
+//! We solve it by Gaussian elimination over `F_p` (uses [`Fp::inv`]/`mul`),
+//! recover `Q = N / E` by exact polynomial division (the remainder MUST be zero
+//! — if it is not, the candidate is rejected), and return `Q(0)`. Finally we
+//! re-verify that *all* `n` original points satisfy the recovered `Q`; only then
+//! is the result trusted. `O(n^3)` Gaussian elimination is fine at the intended
+//! party counts (`n` = 3..9).
+
+use crate::field::Fp;
+use crate::partial::MpcError;
+use crate::shamir::Share;
+
+/// Robust / consistency-checked reconstruction of a degree-`degree` sharing's
+/// value at `x = 0`, using the Reed–Solomon structure of the shares.
+///
+/// `degree` is the polynomial degree (`t` for a normal sharing). Let `n` be the
+/// number of (distinct-`x`) shares supplied. Behaviour by redundancy:
+///
+/// - `n < degree + 1` → [`MpcError::Protocol`] (below threshold — cannot
+///   reconstruct at all; same precondition as plain Lagrange).
+/// - `n == degree + 1` (NO redundancy) → plain Lagrange interpolation. Tampering
+///   is **undetectable** here and we do NOT claim otherwise (see module docs):
+///   never returns [`MpcError::Tampered`].
+/// - `n > degree + 1` (redundancy) → Berlekamp–Welch with the maximal
+///   correctable budget `e = ⌊(n − degree − 1)/2⌋`:
+///   - `≤ e` tampered shares → corrects them, returns the TRUE secret.
+///   - `> e` tampered shares but still inconsistent → [`MpcError::Tampered`].
+///   - all consistent → the secret (no behaviour change on honest input).
+///
+/// The returned secret is `Q(0)` of the recovered/agreed degree-`degree`
+/// polynomial. On any inconsistency that cannot be corrected, returns
+/// [`MpcError::Tampered`] with the identified cheater points where possible.
+pub fn reconstruct_robust(shares: &[Share], degree: usize) -> Result<Fp, MpcError> {
+    let n = shares.len();
+    if n < degree + 1 {
+        return Err(MpcError::Protocol(format!(
+            "robust reconstruction needs >= {} shares, got {}",
+            degree + 1,
+            n
+        )));
+    }
+    // Distinct evaluation points are required for RS decoding (a repeated x is a
+    // structural protocol violation, not a value tamper).
+    check_distinct_points(shares)?;
+
+    // No redundancy: t+1 points always define SOME degree-t polynomial. There is
+    // nothing to cross-check, so we preserve plain-Lagrange behaviour and make NO
+    // detection claim (returning Tampered here would be a false positive).
+    if n == degree + 1 {
+        return lagrange_at_zero(shares);
+    }
+
+    // Redundant: maximal Berlekamp–Welch error budget for this (n, degree).
+    // n >= degree + 2e + 1  ⟺  e <= (n - degree - 1)/2.
+    let e_max = (n - degree - 1) / 2;
+
+    // Try increasing error budgets 0..=e_max. e = 0 is the pure consistency
+    // check (interpolate degree+1 points, verify the rest); larger e attempts
+    // correction. The first budget that yields a polynomial consistent with all
+    // points within that error budget wins.
+    for e in 0..=e_max {
+        if let Some(q) = berlekamp_welch(shares, degree, e) {
+            // Re-verify against ALL points: the recovered Q must disagree with at
+            // most e of them; the agreeing majority pins the true codeword.
+            let bad = disagreeing_points(shares, &q);
+            if bad.len() <= e {
+                return Ok(eval_poly(&q, Fp::zero()));
+            }
+        }
+    }
+
+    // No degree-`degree` polynomial fits within the correctable budget: the
+    // shares are mutually inconsistent beyond what redundancy can repair. Abort
+    // (detect-and-abort), naming the cheaters we can pin against the best fit.
+    Err(tampered_error(shares, degree, e_max))
+}
+
+/// Identify, against the best-effort interpolation of the first `degree+1`
+/// points, which point indices are off-curve — a best-effort cheater list for
+/// the abort message. (When correction is impossible this is heuristic: the
+/// honest set is unknown, so we report the minority relative to one reference
+/// subset. Detection itself is sound; the *attribution* is best-effort.)
+fn tampered_error(shares: &[Share], degree: usize, e_max: usize) -> MpcError {
+    let n = shares.len();
+    // Reference polynomial from the first degree+1 points (an arbitrary subset).
+    let suspects = match lagrange_at_zero_poly(&shares[..degree + 1]) {
+        Ok(q) => disagreeing_points(shares, &q)
+            .into_iter()
+            .map(|i| shares[i].x)
+            .collect::<Vec<_>>(),
+        Err(_) => Vec::new(),
+    };
+    MpcError::Tampered {
+        detail: format!(
+            "RS consistency check failed: {n} shares of a degree-{degree} secret are not all on \
+             one polynomial and the inconsistency exceeds the correctable budget e={e_max} \
+             (need n >= degree + 2e + 1 to correct e errors)"
+        ),
+        cheaters: suspects,
+    }
+}
+
+/// Indices of shares whose `y` does NOT equal `Q(x)` for the candidate poly `q`.
+fn disagreeing_points(shares: &[Share], q: &[Fp]) -> Vec<usize> {
+    shares
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| eval_poly(q, Fp::new(s.x)) != s.y)
+        .map(|(i, _)| i)
+        .collect()
+}
+
+/// Reject repeated evaluation points (RS decoding assumes distinct `x_i`).
+fn check_distinct_points(shares: &[Share]) -> Result<(), MpcError> {
+    for i in 0..shares.len() {
+        for j in (i + 1)..shares.len() {
+            if shares[i].x == shares[j].x {
+                return Err(MpcError::Protocol(format!(
+                    "robust reconstruction: repeated evaluation point x={}",
+                    shares[i].x
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Berlekamp–Welch decode for `n` shares of a degree-`degree` polynomial,
+/// targeting exactly `e` correctable errors. Returns the recovered polynomial
+/// `Q` (coeffs low→high, length `degree+1`) if the key-equation system is
+/// solvable and `E | N` exactly; otherwise `None`.
+///
+/// Unknowns: `E_0..E_{e-1}` (the `e` non-leading error-locator coeffs; `E_e = 1`
+/// is fixed monic) and `N_0..N_{degree+e}` (`degree+e+1` numerator coeffs). The
+/// equation per share `i` is `N(x_i) − y_i·E(x_i) = 0`, rearranged so the known
+/// `y_i·x_i^e` (from the fixed monic top of `E`) is the RHS.
+fn berlekamp_welch(shares: &[Share], degree: usize, e: usize) -> Option<Vec<Fp>> {
+    let n = shares.len();
+    let num_n = degree + e + 1; // coeffs of N: N_0..N_{degree+e}
+    let num_e = e; // unknown coeffs of E: E_0..E_{e-1}
+    let cols = num_n + num_e;
+
+    // We need at least as many equations as unknowns. With n >= degree+2e+1,
+    // n >= num_n + num_e holds; use exactly the available n rows.
+    if n < cols {
+        return None;
+    }
+
+    // Build the augmented matrix [A | b] with n rows, `cols` unknown columns.
+    // Column layout: [N_0..N_{degree+e}, E_0..E_{e-1}].
+    let mut aug: Vec<Vec<Fp>> = Vec::with_capacity(n);
+    for s in shares {
+        let x = Fp::new(s.x);
+        let y = s.y;
+        let mut row = vec![Fp::zero(); cols + 1];
+        // N coefficients: + x^k.
+        let mut xpow = Fp::one();
+        for col in row.iter_mut().take(num_n) {
+            *col = xpow;
+            xpow = xpow.mul(x);
+        }
+        // E coefficients (unknown, k = 0..e-1): − y·x^k.
+        let mut xpow = Fp::one();
+        for k in 0..num_e {
+            row[num_n + k] = y.mul(xpow).neg();
+            xpow = xpow.mul(x);
+        }
+        // RHS: the fixed monic top E_e = 1 contributes y·x^e to N(x_i)=y·E(x_i),
+        // i.e. moves to the RHS as + y·x^e.
+        row[cols] = y.mul(x.pow(e as u64));
+        aug.push(row);
+    }
+
+    let sol = solve_linear_system(aug, cols)?;
+    let n_coeffs = &sol[..num_n]; // N_0..N_{degree+e}
+                                  // Rebuild E with the fixed monic leading coefficient.
+    let mut e_coeffs: Vec<Fp> = sol[num_n..].to_vec(); // E_0..E_{e-1}
+    e_coeffs.push(Fp::one()); // E_e = 1
+
+    // Q = N / E exactly (remainder must vanish, else this (E,N) is spurious).
+    let (q, rem) = poly_divmod(n_coeffs, &e_coeffs)?;
+    if !rem.iter().all(|c| *c == Fp::zero()) {
+        return None;
+    }
+    // Q must have degree <= `degree`. Trim and length-check.
+    let q = trim_trailing_zeros(q);
+    if q.len() > degree + 1 {
+        return None;
+    }
+    let mut q = q;
+    q.resize(degree + 1, Fp::zero());
+    Some(q)
+}
+
+/// Solve a (possibly over-determined) linear system `A·z = b` over `F_p` for
+/// exactly `cols` unknowns, given an augmented matrix with `>= cols` rows
+/// (last entry of each row is the RHS). Returns the unique solution, or `None`
+/// if the system is inconsistent or rank-deficient (no unique solution). Plain
+/// Gaussian elimination with partial (nonzero) pivoting; `O(rows · cols^2)`.
+fn solve_linear_system(mut aug: Vec<Vec<Fp>>, cols: usize) -> Option<Vec<Fp>> {
+    let rows = aug.len();
+    let mut pivot_row = 0usize;
+    let mut where_pivot = vec![usize::MAX; cols]; // pivot row for each column
+
+    for col in 0..cols {
+        if pivot_row >= rows {
+            break;
+        }
+        // Find a row at/below pivot_row with a nonzero entry in this column.
+        let sel = (pivot_row..rows).find(|&r| aug[r][col] != Fp::zero());
+        let Some(sel) = sel else { continue };
+        aug.swap(pivot_row, sel);
+
+        // Normalize the pivot row so the pivot is 1.
+        let inv = aug[pivot_row][col].inv();
+        for entry in aug[pivot_row].iter_mut().skip(col) {
+            *entry = entry.mul(inv);
+        }
+        // Eliminate this column from every other row. Snapshot the (now-borrowed-
+        // immutably) pivot row so we can mutate the other rows in place.
+        let pivot_snapshot = aug[pivot_row].clone();
+        for (r, row) in aug.iter_mut().enumerate() {
+            if r != pivot_row && row[col] != Fp::zero() {
+                let factor = row[col];
+                for (entry, &p) in row.iter_mut().zip(pivot_snapshot.iter()).skip(col) {
+                    *entry = entry.sub(factor.mul(p));
+                }
+            }
+        }
+        where_pivot[col] = pivot_row;
+        pivot_row += 1;
+    }
+
+    // Every unknown must be pivoted (unique solution), else underdetermined.
+    if where_pivot.contains(&usize::MAX) {
+        return None;
+    }
+    // Consistency: any all-zero coefficient row must have zero RHS.
+    for row in aug.iter() {
+        if row[..cols].iter().all(|c| *c == Fp::zero()) && row[cols] != Fp::zero() {
+            return None;
+        }
+    }
+    let mut sol = vec![Fp::zero(); cols];
+    for (col, &pr) in where_pivot.iter().enumerate() {
+        sol[col] = aug[pr][cols];
+    }
+    Some(sol)
+}
+
+/// Polynomial division `num / den` over `F_p` (coeffs low→high). Returns
+/// `(quotient, remainder)`. `None` if `den` is the zero polynomial.
+fn poly_divmod(num: &[Fp], den: &[Fp]) -> Option<(Vec<Fp>, Vec<Fp>)> {
+    let den = trim_trailing_zeros(den.to_vec());
+    if den.is_empty() {
+        return None; // division by zero polynomial
+    }
+    let mut rem = trim_trailing_zeros(num.to_vec());
+    let den_deg = den.len() - 1;
+    let den_lead_inv = den[den_deg].inv();
+
+    if rem.len() < den.len() {
+        return Some((vec![Fp::zero()], rem));
+    }
+    let mut quot = vec![Fp::zero(); rem.len() - den_deg];
+    while rem.len() >= den.len() && !rem.is_empty() {
+        let rem_deg = rem.len() - 1;
+        let shift = rem_deg - den_deg;
+        let coeff = rem[rem_deg].mul(den_lead_inv);
+        quot[shift] = coeff;
+        // rem -= coeff · x^shift · den.
+        for (k, &d) in den.iter().enumerate() {
+            let idx = shift + k;
+            rem[idx] = rem[idx].sub(coeff.mul(d));
+        }
+        rem = trim_trailing_zeros(rem);
+    }
+    Some((trim_trailing_zeros(quot), rem))
+}
+
+/// Drop trailing zero (high-degree) coefficients; an all-zero poly becomes `[]`.
+fn trim_trailing_zeros(mut v: Vec<Fp>) -> Vec<Fp> {
+    while v.last() == Some(&Fp::zero()) {
+        v.pop();
+    }
+    v
+}
+
+/// Evaluate a polynomial (coeffs low→high) at `x` by Horner's method.
+fn eval_poly(coeffs: &[Fp], x: Fp) -> Fp {
+    let mut acc = Fp::zero();
+    for &c in coeffs.iter().rev() {
+        acc = acc.mul(x).add(c);
+    }
+    acc
+}
+
+/// Plain Lagrange interpolation at `x = 0` (the secret), no consistency check.
+/// Used on the no-redundancy path where detection is impossible.
+fn lagrange_at_zero(shares: &[Share]) -> Result<Fp, MpcError> {
+    Ok(eval_poly(&lagrange_at_zero_poly(shares)?, Fp::zero()))
+}
+
+/// Full Lagrange interpolation: recover the polynomial (coeffs low→high) through
+/// the given points. Used both to evaluate at 0 and to verify other points.
+fn lagrange_at_zero_poly(shares: &[Share]) -> Result<Vec<Fp>, MpcError> {
+    if shares.is_empty() {
+        return Err(MpcError::Protocol("interpolation needs >= 1 point".into()));
+    }
+    // Build P(x) = Σ_i y_i · Π_{j≠i} (x − x_j)/(x_i − x_j) by accumulating the
+    // weighted basis polynomials. O(n^2) over small n.
+    let n = shares.len();
+    let mut result = vec![Fp::zero(); n];
+    for (i, si) in shares.iter().enumerate() {
+        let xi = Fp::new(si.x);
+        // Numerator polynomial Π_{j≠i} (x − x_j) and the scalar denominator.
+        let mut basis = vec![Fp::one()]; // start with the constant poly 1
+        let mut den = Fp::one();
+        for (j, sj) in shares.iter().enumerate() {
+            if i == j {
+                continue;
+            }
+            let xj = Fp::new(sj.x);
+            basis = poly_mul_linear(&basis, xj.neg()); // multiply by (x − x_j)
+            den = den.mul(xi.sub(xj));
+        }
+        let scale = si.y.mul(den.inv());
+        for (k, b) in basis.iter().enumerate() {
+            result[k] = result[k].add(b.mul(scale));
+        }
+    }
+    Ok(result)
+}
+
+/// Multiply a polynomial (coeffs low→high) by the linear factor `(x + c)`.
+fn poly_mul_linear(poly: &[Fp], c: Fp) -> Vec<Fp> {
+    let mut out = vec![Fp::zero(); poly.len() + 1];
+    for (k, &p) in poly.iter().enumerate() {
+        out[k] = out[k].add(p.mul(c)); // p · c  → x^k term
+        out[k + 1] = out[k + 1].add(p); // p · x  → x^{k+1} term
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shamir::ShamirBackend;
+
+    fn fp(v: u64) -> Fp {
+        Fp::new(v)
+    }
+
+    fn corrupt(shares: &mut [Share], idx: usize, delta: u64) {
+        shares[idx].y = shares[idx].y.add(fp(delta));
+    }
+
+    #[test]
+    fn untampered_full_set_reconstructs() {
+        // Differential vs honest Lagrange on clean inputs: no regression.
+        let b = ShamirBackend::new_seeded(7, 0xC0FFEE).unwrap();
+        let t = b.threshold();
+        for secret in [0u64, 1, 42, 100_000, crate::field::P - 1] {
+            let shares = b.dealer().share(fp(secret));
+            let robust = reconstruct_robust(&shares, t).unwrap();
+            let honest = b.reconstruct(&shares).unwrap();
+            assert_eq!(robust, honest, "robust must match honest on clean input");
+            assert_eq!(robust, fp(secret));
+        }
+    }
+
+    #[test]
+    fn detects_single_tamper_with_full_redundancy_when_e_zero_not_enough() {
+        // n=4, t=1 → e_max = floor((4-1-1)/2) = 1: a single error is CORRECTABLE.
+        // n=3, t=1 → e_max = 0: a single error is only DETECTABLE (abort).
+        let b = ShamirBackend::new_seeded(3, 1).unwrap(); // n=3, t=1
+        let t = b.threshold();
+        let mut shares = b.dealer().share(fp(2024));
+        // Honest robust reconstruct is fine.
+        assert_eq!(reconstruct_robust(&shares, t).unwrap(), fp(2024));
+        // Tamper one share: redundancy present (n=3 > t+1=2) but e_max=0 ⇒ abort.
+        corrupt(&mut shares, 1, 5);
+        let err = reconstruct_robust(&shares, t).unwrap_err();
+        assert!(matches!(err, MpcError::Tampered { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn corrects_single_tamper_when_budget_allows() {
+        // n=4, t=1 → e_max = floor((4-1-1)/2) = 1: correct ONE error, return truth.
+        let b = ShamirBackend::new_seeded(4, 7).unwrap();
+        let t = b.threshold();
+        assert_eq!(t, 1);
+        let secret = fp(98_765);
+        let mut shares = b.dealer().share(secret);
+        corrupt(&mut shares, 2, 42); // one tampered share, within budget
+        let got = reconstruct_robust(&shares, t).unwrap();
+        assert_eq!(
+            got, secret,
+            "BW must correct one error and return the truth"
+        );
+    }
+
+    #[test]
+    fn corrects_two_tampers_at_n9() {
+        // n=9, t=2 → e_max = floor((9-2-1)/2) = 3: correct up to THREE errors.
+        let b = ShamirBackend::new_seeded(9, 0x9999).unwrap();
+        let t = b.threshold();
+        assert_eq!(t, 4); // (9-1)/2
+                          // t=4 ⇒ e_max = floor((9-4-1)/2) = 2: correct up to TWO errors.
+        let secret = fp(555_555);
+        let mut shares = b.dealer().share(secret);
+        corrupt(&mut shares, 0, 11);
+        corrupt(&mut shares, 5, 22);
+        let got = reconstruct_robust(&shares, t).unwrap();
+        assert_eq!(got, secret, "BW must correct two errors at n=9,t=4");
+        // A THIRD error exceeds e_max=2 ⇒ abort.
+        let mut three = b.dealer().share(secret);
+        corrupt(&mut three, 0, 11);
+        corrupt(&mut three, 4, 22);
+        corrupt(&mut three, 7, 33);
+        let err = reconstruct_robust(&three, t).unwrap_err();
+        assert!(matches!(err, MpcError::Tampered { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn no_redundancy_does_not_claim_detection() {
+        // Exactly t+1 shares: tampering selects a different valid secret, NOT a
+        // detectable inconsistency. Must NOT return Tampered (no false positive).
+        let b = ShamirBackend::new_seeded(5, 0xABCD).unwrap();
+        let t = b.threshold(); // 2
+        let secret = fp(123_456);
+        let shares = b.dealer().share(secret);
+        let mut min_set = shares[..t + 1].to_vec();
+        corrupt(&mut min_set, 0, 9_999);
+        let got = reconstruct_robust(&min_set, t).expect("t+1 points always interpolate");
+        assert_ne!(got, secret, "t+1: tamper changes the secret (no detection)");
+    }
+}

--- a/crates/sparq-mpc/src/robust.rs
+++ b/crates/sparq-mpc/src/robust.rs
@@ -420,14 +420,23 @@ mod tests {
 
     #[test]
     fn untampered_full_set_reconstructs() {
-        // Differential vs honest Lagrange on clean inputs: no regression.
+        // [OPUS-4.8] Genuine differential vs the UNCHECKED Lagrange primitive on
+        // clean inputs: no regression. We must NOT compare against
+        // `ShamirBackend::reconstruct`, which now routes through
+        // `reconstruct_robust` itself (robust-vs-robust is vacuous). Compare the
+        // robust path against `reconstruct_at_zero` (the plain Lagrange-at-0
+        // building block, `pub(crate)` for exactly this suite) so the assertion
+        // genuinely pins robust == honest-Lagrange with no errors present.
         let b = ShamirBackend::new_seeded(7, 0xC0FFEE).unwrap();
         let t = b.threshold();
         for secret in [0u64, 1, 42, 100_000, crate::field::P - 1] {
             let shares = b.dealer().share(fp(secret));
             let robust = reconstruct_robust(&shares, t).unwrap();
-            let honest = b.reconstruct(&shares).unwrap();
-            assert_eq!(robust, honest, "robust must match honest on clean input");
+            let honest = crate::shamir::reconstruct_at_zero(&shares, t).unwrap();
+            assert_eq!(
+                robust, honest,
+                "robust must match unchecked Lagrange on clean input"
+            );
             assert_eq!(robust, fp(secret));
         }
     }
@@ -465,10 +474,13 @@ mod tests {
 
     #[test]
     fn corrects_two_tampers_at_n9() {
-        // n=9, t=2 → e_max = floor((9-2-1)/2) = 3: correct up to THREE errors.
+        // [OPUS-4.8] The backend fixes t = floor((n-1)/2), so for n=9, t=4 (NOT
+        // t=2). With t=4 the BW correction budget is e_max = floor((n-t-1)/2) =
+        // floor((9-4-1)/2) = 2: this test corrects exactly e_max = 2 errors and
+        // then asserts that a 3rd error (over budget) aborts.
         let b = ShamirBackend::new_seeded(9, 0x9999).unwrap();
         let t = b.threshold();
-        assert_eq!(t, 4); // (9-1)/2
+        assert_eq!(t, 4); // floor((9-1)/2) = 4
                           // t=4 ⇒ e_max = floor((9-4-1)/2) = 2: correct up to TWO errors.
         let secret = fp(555_555);
         let mut shares = b.dealer().share(secret);

--- a/crates/sparq-mpc/src/shamir.rs
+++ b/crates/sparq-mpc/src/shamir.rs
@@ -187,11 +187,22 @@ impl ShamirBackend {
         ShamirDealer { n: self.n, t: self.t, rng }
     }
 
-    /// Reconstruct the secret `f(0)` from `>= t+1` shares via Lagrange
-    /// interpolation. Fewer than `t+1` shares is a protocol error (the whole
-    /// point of the threshold). Shares must have distinct `x`. RNG-free.
+    /// Reconstruct the secret `f(0)` from `>= t+1` shares. Fewer than `t+1`
+    /// shares is a protocol error (the whole point of the threshold). Shares must
+    /// have distinct `x`. RNG-free.
+    ///
+    /// **Consistency-checked / robust (sq-m34i, WI-1).** When redundancy is
+    /// present (`n > t+1`) this routes through [`crate::robust::reconstruct_robust`]:
+    /// it verifies all points lie on one degree-`t` polynomial, CORRECTS up to
+    /// `e = ⌊(n−t−1)/2⌋` tampered shares (returning the true secret), and aborts
+    /// with [`MpcError::Tampered`] on any inconsistency it cannot repair —
+    /// closing the malicious-security gap (D) at the Shamir layer (parent bead
+    /// sq-uu0u). On clean input it returns exactly the same value as plain
+    /// Lagrange (no behaviour change). At exactly `t+1` shares (no redundancy)
+    /// tampering is information-theoretically undetectable, so it falls back to
+    /// plain Lagrange and makes NO detection claim.
     pub fn reconstruct(&self, shares: &[Share]) -> Result<Fp, MpcError> {
-        reconstruct_at_zero(shares, self.t)
+        crate::robust::reconstruct_robust(shares, self.t)
     }
 }
 
@@ -254,9 +265,10 @@ impl ShamirDealer {
             .collect()
     }
 
-    /// Reconstruct (RNG-free; delegates to the backend's Lagrange interpolation).
+    /// Reconstruct (RNG-free). Like [`ShamirBackend::reconstruct`], this uses the
+    /// consistency-checked / robust path (sq-m34i) when redundancy is present.
     pub fn reconstruct(&self, shares: &[Share]) -> Result<Fp, MpcError> {
-        reconstruct_at_zero(shares, self.t)
+        crate::robust::reconstruct_robust(shares, self.t)
     }
 }
 
@@ -271,7 +283,14 @@ fn eval_poly(coeffs: &[Fp], x: Fp) -> Fp {
 
 /// Lagrange-interpolate the shares' polynomial and evaluate it at `x = 0` (the
 /// secret). Requires `>= t+1` distinct points.
-fn reconstruct_at_zero(shares: &[Share], t: usize) -> Result<Fp, MpcError> {
+///
+/// This is the unchecked RS-decode-under-no-errors primitive — it does NOT
+/// detect tampering. The consistency-checked / robust entry point that callers
+/// use is [`crate::robust::reconstruct_robust`] (wired into
+/// [`ShamirBackend::reconstruct`]); this stays the underlying building block
+/// (e.g. for the degree-`2t` [`reconstruct_degree`] open). `pub(crate)` so the
+/// adversarial differential suite can compare the robust path against it.
+pub(crate) fn reconstruct_at_zero(shares: &[Share], t: usize) -> Result<Fp, MpcError> {
     if shares.len() < t + 1 {
         return Err(MpcError::Protocol(format!(
             "Shamir reconstruction needs >= {} shares, got {}",


### PR DESCRIPTION
Closes the malicious-security tamper-detection gap (guarantee D) at the Shamir layer, honest-majority. Shamir shares ARE a Reed–Solomon [n,t+1] codeword; the old unchecked Lagrange open silently accepted a tampered share even with full redundancy. New `reconstruct_robust` (Berlekamp–Welch over the existing `Fp=2^61-1`, **zero new deps**, wasm-exclusion preserved):
- n<t+1 → Protocol error; n==t+1 → plain Lagrange, never claims detection (info-theoretically impossible — preserved + tested); n>t+1 → correct up to `e=(n-t-1)/2` errors (robust, returns the TRUE secret) else `MpcError::Tampered` (detect-and-abort).
- The three silently-corrupts adversarial pins are now **positive detection/correction** tests; new property suite (n=2..9) proves: corrects ≤e ⇒ truth; >e ⇒ abort; exact-t+1 ⇒ documented non-detection (no false positives); differential vs honest Lagrange on clean inputs.
- Scope: WI-1 only. The degree-2t equality path (join::secure_equal) is **WI-2** (sq-7q9i) and untouched; surfacing the guarantee via a MaliciousSecurity enum is **WI-3** (sq-sz1h) — `malicious_secure` stays false here.

Design on sq-uu0u. Filed sq-6u6b (sharpen cheater attribution). Gates: 71 tests (debug+release), clippy -D warnings clean, wasm excludes mpc, no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)