### PR TITLE
ci: documentation-quality gate — markdownlint/typos/internal-links HARD + vale/external/no-perf ADVISORY (sq-5fd1)

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -26,9 +26,14 @@
 # (sq-9jw5), so they advise until their scope is clean, then flip to HARD.
 #
 # ci-summary aggregation: it polls every check-run on the head commit and fails iff one
-# concluded failure. A job with `continue-on-error: true` reports conclusion=success to
-# the Checks API even when its steps fail, so the ADVISORY jobs below are invisible to
-# the gate by construction — no extra wiring needed.
+# concluded failure. So every ADVISORY job must CONCLUDE SUCCESS or it would block the
+# gate. JOB-level `continue-on-error: true` is NOT sufficient — it stops the run from
+# failing but the job's check-run still concludes `failure` (verified: vale showed as a
+# failing check on PR #42). Therefore advisory jobs make their findings non-fatal AT THE
+# STEP: script steps end with `|| true` (markdownlint-advisory, custom-checks); action
+# steps that exit non-zero on findings (vale/reviewdog) carry step-level
+# `continue-on-error: true`. (lychee uses `fail: false`.) Job-level continue-on-error is
+# kept as defence-in-depth. [OPUS-4.8]
 #
 # Third-party actions are pinned by full commit SHA with a trailing `# vX.Y.Z`
 # (repo hard rule, #34) so the supply chain + Scorecard/CodeQL stay green.
@@ -157,6 +162,12 @@ jobs:
         with:
           persist-credentials: false
       - name: Vale prose lint (vendored styles, no network)
+        # [OPUS-4.8] STEP-level continue-on-error: reviewdog exits 1 on findings, and
+        # JOB-level continue-on-error does NOT make the job's check-run conclude success
+        # (it only stops the run from failing) — so ci-summary, which fails iff any
+        # check-run concluded failure, would wrongly block on this advisory job. Swallowing
+        # at the step makes the job conclude success while the findings still print.
+        continue-on-error: true
         uses: errata-ai/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a # v2.1.2
         with:
           version: 3.9.1

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -1,0 +1,207 @@
+# docs-quality — documentation-quality CI (bead sq-5fd1). [OPUS-4.8]
+#
+# WHAT: lints the repo's markdown for spelling, link integrity, style, and the
+# house rules (no baked-in perf numbers; concise crate-README template). Two tiers:
+#
+#   HARD gates (FAIL the build; picked up by the ci-summary aggregator):
+#     • markdownlint  — structural markdown defects over the user-facing + governance
+#                       doc surface (root docs, skills/, docs/, crates/). Tuned to the
+#                       repo's house style via .markdownlint-cli2.jsonc.
+#     • typos         — high-confidence spelling errors in those same docs (markdown
+#                       only), with a domain allowlist in _typos.toml.
+#     • internal-links — lychee --offline over those docs: every relative link AND
+#                       heading-anchor (#fragment) must resolve. Deterministic (no net).
+#
+#   ADVISORY (continue-on-error → reported in the job summary, never block a merge):
+#     • markdownlint-advisory — same rules over the WHOLE repo (research/, zk/, bench/)
+#                       so the staged-rollout backlog stays visible (tracked: sq-<TBD>).
+#     • vale          — prose hygiene: weasel words, wordy phrases, adjective puffery.
+#     • external-links — lychee online: dead http(s) links (network-flaky → advisory).
+#     • no-perf-numbers — greps docs for baked-in benchmark figures (AGENTS.md rule).
+#     • readme-template — crate-README length cap + required sections (pairs w/ sq-9jw5).
+#
+# WHY this split: markdownlint/typos/internal-links are deterministic and already pass
+# on the scoped doc surface, so they gate. Vale/external-links/the custom checks either
+# carry a large pre-existing backlog or depend on network/another in-flight bead
+# (sq-9jw5), so they advise until their scope is clean, then flip to HARD.
+#
+# ci-summary aggregation: it polls every check-run on the head commit and fails iff one
+# concluded failure. A job with `continue-on-error: true` reports conclusion=success to
+# the Checks API even when its steps fail, so the ADVISORY jobs below are invisible to
+# the gate by construction — no extra wiring needed.
+#
+# Third-party actions are pinned by full commit SHA with a trailing `# vX.Y.Z`
+# (repo hard rule, #34) so the supply chain + Scorecard/CodeQL stay green.
+name: docs-quality
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Read-only: every job only reads the checked-out tree.
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-quality-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ----------------------------- HARD GATES -----------------------------
+  markdownlint:
+    name: markdownlint (docs)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: markdownlint-cli2 (scoped HARD config)
+        # npx pins the exact cli2 version; the config (.markdownlint-cli2.jsonc) carries
+        # the tuned ruleset AND the HARD-scope globs (root docs + skills/ + docs/ + crates/).
+        run: npx --yes markdownlint-cli2@0.18.1
+
+  typos:
+    name: typos (docs)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install typos
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: typos@1.47.2
+      - name: typos (markdown doc surface only)
+        # Scope to the SAME doc surface as markdownlint: root *.md + skills + docs +
+        # crates, markdown only (typos over the full tree would flag code-side tokens
+        # out of this gate's scope). _typos.toml holds the domain-term allowlist.
+        run: |
+          set -euo pipefail
+          # HARD scope = root *.md + skills/ + docs/ + crates/ (markdown only).
+          # `git ls-files '*.md'` matches at any depth, so EXCLUDE the out-of-scope
+          # dirs to land exactly on the same set markdownlint's config globs (49 files).
+          git ls-files '*.md' \
+            ':!:research/**' ':!:zk/**' ':!:bench/**' ':!:js/**' \
+            ':!:.beads/**' ':!:.claude/**' ':!:.github/**' \
+            ':!:vendor/**' ':!:**/vendor/**' | sort -u > /tmp/doc-md.txt
+          echo "Scanning $(wc -l < /tmp/doc-md.txt) markdown file(s) for typos:"
+          typos --file-list /tmp/doc-md.txt
+
+  internal-links:
+    name: internal-links (lychee --offline)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: "lychee (offline: relative links + anchors)"
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          # --offline → no network (deterministic); --include-fragments validates
+          # #heading anchors. fail=true makes broken internal links a HARD failure.
+          args: >-
+            --offline
+            --include-fragments
+            --no-progress
+            README.md AGENTS.md CONTRIBUTING.md SECURITY.md CHANGELOG.md CLAUDE.md
+            './skills/**/*.md' './docs/**/*.md' './crates/**/*.md'
+          fail: true
+          # Don't post a tracking issue (read-only token; gating is enough).
+          jobSummary: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  # ----------------------------- ADVISORY -----------------------------
+  markdownlint-advisory:
+    name: markdownlint-advisory (whole repo)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: markdownlint over the FULL corpus (visibility for the staged rollout)
+        run: |
+          set -uo pipefail
+          # The advisory config (same tuned rules) must be named with a supported
+          # prefix so it's accepted by --config. Pass whole-repo globs explicitly.
+          npx --yes markdownlint-cli2@0.18.1 \
+            --config advisory.markdownlint-cli2.jsonc \
+            "**/*.md" "#node_modules" "#**/node_modules" "#target" "#**/target" \
+            "#vendor" "#**/vendor" "#zk/xpath/vendor" \
+            > md-advisory.txt 2>&1 || true
+          n=$(grep -cE ' MD[0-9]+/' md-advisory.txt || true)
+          {
+            echo "### markdownlint-advisory (whole repo): ${n} finding(s)"
+            echo ""
+            echo "Out-of-HARD-scope dirs (research/, zk/, bench/, .claude/) — staged rollout."
+            echo ""
+            echo '```'
+            grep -oE ' (MD[0-9]+/[a-z0-9-]+)' md-advisory.txt | sort | uniq -c | sort -rn || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  vale:
+    name: vale (prose, advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Vale prose lint (vendored styles, no network)
+        uses: errata-ai/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a # v2.1.2
+        with:
+          version: 3.9.1
+          files: README.md AGENTS.md CONTRIBUTING.md SECURITY.md skills docs crates
+          fail_on_error: false
+          # `local` reporter prints to the job log — no PR-annotation write scope
+          # needed (top-level permissions stay read-only). Advisory anyway.
+          reporter: local
+          token: ${{ github.token }}
+
+  external-links:
+    name: external-links (lychee online, advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: lychee (online; dead http(s) links — network-flaky → advisory)
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: >-
+            --no-progress
+            --cache
+            --max-cache-age 1d
+            --accept 200..=206,429
+            README.md AGENTS.md CONTRIBUTING.md SECURITY.md CHANGELOG.md
+            './skills/**/*.md' './docs/**/*.md' './crates/**/*.md'
+          fail: false
+          jobSummary: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  custom-checks:
+    name: custom-checks (perf-numbers + readme-template, advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: No hard-coded performance numbers in user-facing docs
+        run: python3 scripts/check-no-perf-numbers.py --advisory
+      - name: Crate-README length cap + required sections (template, sq-9jw5)
+        run: python3 scripts/check-readme-template.py --advisory

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,58 @@
+// markdownlint-cli2 config — HARD documentation-quality gate (bead sq-5fd1). [OPUS-4.8]
+//
+// SCOPE (staged rollout): this HARD gate covers the user-facing + governance doc
+// surface that is already clean — the top-level governance docs, the `skills/` usage
+// tree (the source of truth for using sparq), `docs/`, and every crate README/doc.
+// `research/` and `zk/` (design records + research scaffolds) carry a large backlog
+// of cosmetic violations (mostly missing code-fence languages); bringing them under
+// the HARD gate is tracked as a follow-up bead. They are still checked in the
+// ADVISORY job (whole-repo, continue-on-error) so the backlog stays visible.
+//
+// RULESET: markdownlint defaults, MINUS the rules that fight this repo's deliberate
+// house style (long unwrapped lines, bare/autolink URLs, inline HTML for the logo +
+// metadata comments, CHANGELOG-style repeated/duplicate headings) and MINUS the
+// purely-cosmetic "blank line around X" rules that are render-irrelevant here. What
+// remains catches REAL defects: broken link fragments, mismatched table columns,
+// missing space after `#`, stray spaces in code/emphasis, trailing whitespace, and
+// missing/duplicate trailing newlines.
+{
+  "config": {
+    "default": true,
+
+    // --- disabled: deliberate house style (see README/AGENTS prose) ---
+    "MD013": false, // line-length: docs are intentionally not hard-wrapped at 80
+    "MD033": false, // inline HTML: logo SVG, <details>, metadata comments
+    "MD034": false, // bare URLs: <https://…> autolinks used throughout
+    "MD041": false, // first-line-heading: CHANGELOG / front-matter docs
+    "MD025": false, // single H1: CHANGELOG-style multi-section docs
+    "MD024": { "siblings_only": true }, // dup headings OK across sections (changelog)
+    "MD036": false, // emphasis-as-heading: used as soft sub-labels
+    "MD026": false, // trailing punctuation in headings ("… exposing it")
+    "MD029": false, // ordered-list numbering style varies by doc
+    "MD004": false, // unordered-list bullet style varies by doc
+    "MD049": false, // emphasis style (_ vs *) mixed deliberately
+    "MD007": false, // list indent width varies
+    "MD046": false, // code-block style (indented vs fenced) mixed
+
+    // --- disabled: purely cosmetic blank-line spacing (render-irrelevant here) ---
+    "MD022": false, // blanks around headings
+    "MD031": false, // blanks around fenced code
+    "MD032": false  // blanks around lists
+  },
+  // HARD-gate scope: governance docs + skills/ + docs/ + crates/.
+  "globs": [
+    "*.md",
+    "skills/**/*.md",
+    "docs/**/*.md",
+    "crates/**/*.md"
+  ],
+  "ignores": [
+    "node_modules",
+    "**/node_modules",
+    "target",
+    "**/target",
+    "vendor",
+    "**/vendor",
+    "zk/xpath/vendor"
+  ]
+}

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,27 @@
+# Vale config — ADVISORY prose linting for sparq docs (bead sq-5fd1). [OPUS-4.8]
+#
+# Vale is ADVISORY: the workflow runs it continue-on-error and surfaces results in
+# the job summary; it never gates a merge. The goal is gentle prose hygiene on the
+# user-facing docs — flag weasel words, superfluous filler, and unsubstantiated
+# adjective puffery ("blazingly fast") that the empirical-honesty house style avoids.
+#
+# Styles are vendored under .vale/styles/sparq (no network fetch in CI → deterministic).
+# MinAlertLevel = suggestion so everything shows; severities live in each rule.
+
+StylesPath = .vale/styles
+
+# Be quiet about external packages we don't vendor.
+Packages =
+
+MinAlertLevel = suggestion
+
+# Only lint prose; ignore fenced code, inline code, and URLs.
+[formats]
+md = md
+
+[*.md]
+BasedOnStyles = sparq
+
+# Code spans / fences / raw HTML comments aren't prose — don't lint them.
+TokenIgnores = (\x60[^\x60]+\x60)
+BlockIgnores = (?s) *(\x60{3}.*?\x60{3}), (?s)<!--.*?-->

--- a/.vale/styles/sparq/Puffery.yml
+++ b/.vale/styles/sparq/Puffery.yml
@@ -1,0 +1,23 @@
+# [OPUS-4.8] ADVISORY: unsubstantiated marketing adjectives (bead sq-5fd1).
+# The empirical-honesty house style avoids puffery — back claims with measurements
+# (link the perf dashboard) instead of "blazingly fast".
+extends: existence
+message: "'%s' is unsubstantiated puffery — make a measured, concrete claim instead."
+level: warning
+ignorecase: true
+tokens:
+  - blazing(ly)?
+  - lightning[- ]fast
+  - blistering(ly)?
+  - seamless(ly)?
+  - effortless(ly)?
+  - cutting[- ]edge
+  - bleeding[- ]edge
+  - world[- ]class
+  - best[- ]in[- ]class
+  - next[- ]generation
+  - revolutionary
+  - game[- ]changing
+  - unparalleled
+  - unmatched
+  - turbocharged

--- a/.vale/styles/sparq/Superfluous.yml
+++ b/.vale/styles/sparq/Superfluous.yml
@@ -1,0 +1,23 @@
+# [OPUS-4.8] ADVISORY: superfluous / wordy phrases — tighten them (bead sq-5fd1).
+extends: substitution
+message: "'%s' is wordy — consider '%s'."
+level: suggestion
+ignorecase: true
+action:
+  name: replace
+swap:
+  "in order to": to
+  "due to the fact that": because
+  "in spite of the fact that": although
+  "for the purpose of": for
+  "in the event that": if
+  "a number of": several
+  "the vast majority of": most
+  "at this point in time": now
+  "in the process of": currently
+  "is able to": can
+  "are able to": can
+  "has the ability to": can
+  "with regard to": about
+  "in terms of": for
+  "a large number of": many

--- a/.vale/styles/sparq/Weasel.yml
+++ b/.vale/styles/sparq/Weasel.yml
@@ -1,0 +1,27 @@
+# [OPUS-4.8] ADVISORY: weasel words that weaken technical prose (bead sq-5fd1).
+# Vague intensifiers/hedges add no information. Prefer a concrete claim or cut it.
+extends: existence
+message: "'%s' is a weasel word — cut it or replace with a concrete claim."
+level: suggestion
+ignorecase: true
+tokens:
+  - very
+  - really
+  - quite
+  - extremely
+  - simply
+  - just
+  - basically
+  - actually
+  - essentially
+  - fairly
+  - somewhat
+  - relatively
+  - obviously
+  - clearly
+  - of course
+  - arguably
+  - virtually
+  - largely
+  - mostly
+  - generally

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,6 @@ Then edit the corresponding `skills/<surface>/SKILL.md` (sparql-query / data-for
 
 If you add a brand-new public surface, add a new `skills/<surface>/` (dir name == the skill's `name` frontmatter) and link it from the list above and from the README.
 
-
 ## Task tracking — beads, not markdown TODOs
 
 This repo tracks work in **beads** (`bd`, a git-native dependency-graph issue tracker; the committed source-of-record is `.beads/issues.jsonl`). Rules for any agent working here:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,7 +190,6 @@ publish set). The API is unstable; SERVICE federation remains unimplemented — 
   unchanged (no extra maintenance state). Design lever if that ever matters: build the
   indexes lazily on first `why()`.
 
-
 - **Opt-in full-text search over literals (`sparq-text`, new crate)** — a small,
   owned BM25 inverted index over a graph's string literals (UAX #29 tokenizer +
   Unicode lowercasing via `unicode-segmentation`; deliberately no tantivy) where
@@ -387,7 +386,6 @@ publish set). The API is unstable; SERVICE federation remains unimplemented — 
   Inference conformance unchanged (1637 pass / 0 fail / 17 documented divergences);
   wasm artifact size unchanged; refreshed EYE head-to-head in
   `bench/inference/eye-comparison.md`.
-
 
 - **`sparq-geo` depends on geo 0.33** (was 0.30; clean API compatibility): brings
   the `Buffer` trait that makes `geof:buffer` implementable.

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,66 @@
+# typos (crate-ci/typos) config — HARD spell-check gate (bead sq-5fd1). [OPUS-4.8]
+#
+# `typos` is conservative by design (it only flags high-confidence misspellings),
+# which makes it a sound HARD gate. The allowlist below pins the FALSE POSITIVES it
+# raises on this codebase: SPARQL/RDF keyword fragments that appear split across
+# table cells or wrapped lines, domain identifiers, author surnames, and short
+# code-token abbreviations. Each entry is "as-typed = corrected-to-itself", which is
+# typos' idiom for "this token is intentional, leave it".
+#
+# Genuine misspellings are fixed in the prose, NOT allowlisted — keep this list to
+# real domain vocabulary so the gate keeps catching actual typos.
+
+[files]
+# Don't scan generated, vendored, or build output.
+extend-exclude = [
+  "target",
+  "vendor",
+  "**/vendor",
+  "node_modules",
+  "**/node_modules",
+  "Cargo.lock",
+  "zk/xpath/vendor",
+  "*.svg",
+]
+
+[default]
+# Keep typos' default checks; we only extend the dictionaries below.
+
+[default.extend-identifiers]
+# Author surnames + tool/library identifiers flagged as typos.
+Hendler = "Hendler"      # Jim Hendler (BitMat paper author)
+
+[default.extend-words]
+# --- SPARQL / SQL keyword fragments split across table cells or wrapped lines ---
+flate = "flate"          # flate2 crate name fragment (typos splits on the digit)
+SELEC = "SELEC"          # "SELECT" wrapped mid-token in prose
+UPDAT = "UPDAT"          # "UPDATE" wrapped
+SER = "SER"              # SPARQL "SERVICE"/"SET" fragment in a plan table
+ser = "ser"              # lowercase variant (serde-style token)
+Buil = "Buil"            # "Build/Built" wrapped in a table cell
+# --- short identifiers / abbreviations in code, tables, and bench labels ---
+anc = "anc"              # "anc500" benchmark label (ancestor chain)
+mis = "mis"              # "mis-framed" / hyphenated prefix
+Mis = "Mis"              # capitalised "Mis-" prefix
+oly = "oly"              # "oly q07" (olympics benchmark) shorthand
+wrk = "wrk"              # the `wrk` HTTP benchmarking tool
+ede = "ede"             # "ede" node label in a graph diagram
+thr = "thr"              # "thr" (thread / throughput) abbreviation in a table
+pn = "pn"                # SPARQL grammar PN_* production fragment / table cell
+PN = "PN"                # uppercase grammar-production fragment
+iz = "iz"                # token in a diagram / pseudo-code
+ot = "ot"               # wrapped fragment in a table
+Fo = "Fo"               # wrapped "For/Of" fragment in a table
+Thm = "Thm"             # "Theorem" abbreviation
+IST = "IST"             # acronym in a table
+Rotat = "Rotat"         # "RotatE" KG-embedding model name (wraps to "Rotat")
+criticals = "criticals"  # audit jargon: "the audit's criticals"
+unparseable = "unparseable" # accepted variant spelling used in skills docs
+unstalled = "unstalled"  # "proceeding unstalled" (= not stalled) — intentional
+# --- domain acronyms / dataset + crypto names ---
+ANE = "ANE"              # Apple Neural Engine
+FPR = "FPR"              # false-positive rate
+LOV = "LOV"              # Linked Open Vocabularies (dataset)
+lov = "lov"              # lowercase var name in a SIMD code block
+LOD = "LOD"              # Linked Open Data
+Groth = "Groth"          # Groth16 zk-SNARK proving system

--- a/advisory.markdownlint-cli2.jsonc
+++ b/advisory.markdownlint-cli2.jsonc
@@ -1,0 +1,38 @@
+// markdownlint-cli2 ADVISORY config — whole-repo visibility (bead sq-5fd1). [OPUS-4.8]
+//
+// Same tuned ruleset as the HARD config (.markdownlint-cli2.jsonc) but globbed over
+// the ENTIRE corpus (research/, zk/, bench/, .claude/ included). Run ONLY by the
+// `markdownlint-advisory` job (continue-on-error) so the staged-rollout backlog in
+// the not-yet-clean dirs stays visible without blocking merges. As those dirs are
+// cleaned, fold them into the HARD config's `globs` and shrink this one.
+{
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD033": false,
+    "MD034": false,
+    "MD041": false,
+    "MD025": false,
+    "MD024": { "siblings_only": true },
+    "MD036": false,
+    "MD026": false,
+    "MD029": false,
+    "MD004": false,
+    "MD049": false,
+    "MD007": false,
+    "MD046": false,
+    "MD022": false,
+    "MD031": false,
+    "MD032": false
+  },
+  "globs": ["**/*.md"],
+  "ignores": [
+    "node_modules",
+    "**/node_modules",
+    "target",
+    "**/target",
+    "vendor",
+    "**/vendor",
+    "zk/xpath/vendor"
+  ]
+}

--- a/crates/sparq-conformance/FINDINGS.md
+++ b/crates/sparq-conformance/FINDINGS.md
@@ -279,7 +279,6 @@ point). Fixed in `crates/sparq-engine` (commits on `conformance-round2`):
    *SUM with GROUP BY* expects `"3.21E4"^^xsd:double` (canonical scientific)
    for the same construct; the engine follows the canonical convention.
 
-
 First full run of `sparq-conformance` against w3c/rdf-tests @ `f25dbc092c654d792974848e81bb519d7328f0e8`
 (sparq @ `d555096`). Headline: **344 pass / 110 fail / 148 skip over 602 evaluation
 tests — 75.8% of executed tests pass** (data-r2 query 85.3%, data-sparql11 query 62.4%,
@@ -344,7 +343,7 @@ The engine computes arithmetic/aggregates in f64 and stamps the result `xsd:doub
 ### F5. Expression type errors not propagated — ~6 tests
 SPARQL type errors must make the expression error (binding left unbound / row
 filtered), not produce a value:
-- *IF() error propogation*: expected `{}` (unbound), got `?error="false"^^xsd:boolean`.
+- *IF() error propagation*: expected `{}` (unbound), got `?error="false"^^xsd:boolean`.
 - *Error in AVG* / *Protect from error in AVG*: AVG over a group containing a
   non-numeric must error → group row with unbound aggregate.
 - Integer division by zero must be an error, not NaN (see COALESCE above).

--- a/crates/sparq-geo/README.md
+++ b/crates/sparq-geo/README.md
@@ -223,7 +223,7 @@ node). `GeoIndex::apply_delta(graph, inserts, deletes)` mirrors a
 points over an 8°×8° window (country-sized), 1 000 query points, Apple M-class
 laptop (2026-06-10):
 
-```
+```text
 graph load     : 100000 asWKT triples in 81.05ms
 index build    : 100000 entries in 96.15ms (1.04 Mentries/s)
 within     1km :      1.1 µs/query (0.7 avg hits)

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -53,7 +53,7 @@ API gateway, or [`sparq-solid`](../sparq-solid/README.md)). Concretely:
   clause reaches **nothing** unless its host is on the egress allowlist. A `SERVICE` clause turns
   attacker-controlled query text into an outbound request from the server host (textbook SSRF;
   worst case `169.254.169.254` cloud-metadata), so the operator must opt in to every reachable
-  host. Configure the allowlist with any of (UNIONed, additive):
+  host. Configure the allowlist with any of the following (combined additively):
   * `--service-allow HOST` / `--service-allow *.SUFFIX` — repeatable; exact host or suffix wildcard;
   * `--service-allow-file PATH` — one entry per line (`#` comments + blanks ignored);
   * `SPARQ_SERVICE_ALLOW` — comma/whitespace-separated.

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -16,7 +16,8 @@ Implements the **read** side of two W3C specifications over an in-memory
   share its atomicity and the **no-auth posture below** — a GSP write is as powerful as an
   UPDATE). Implemented in bead `sq-gxsj`. <!-- [OPUS-4.8] -->
 
-## Security posture (no built-in auth) — read before exposing it <!-- [OPUS-4.8] sq-o4qf / sq-2v6f -->
+<!-- [OPUS-4.8] sq-o4qf / sq-2v6f -->
+## Security posture (no built-in auth) — read before exposing it
 
 **`sparq-server` has NO authentication on any endpoint.** This is by design: the engine is
 not an auth boundary — authorization belongs to a layer in front of it (a reverse proxy /

--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -305,4 +305,3 @@ for any custom authorization storage.
   pending follow-ups: a *precise* per-solution check for variable `GRAPH ?var` template
   slots (today: deny unless the actor can write every graph) and `acl:Append`-only
   insert-into-absent-graph nuances. <!-- [OPUS-4.8] sq-xor3 -->
-

--- a/crates/sparq-zk-compose/README.md
+++ b/crates/sparq-zk-compose/README.md
@@ -11,7 +11,7 @@ full query-result proof and verifies one.
 
 ## Architecture
 
-```
+```text
 sparq-zk (stage 1)                 sparq-zk-compose (stage 2, this crate)
 ─────────────────────              ──────────────────────────────────────
 canonicalize + commit  ──leaves──▶ build::build_scan      ──┐

--- a/docs/release.md
+++ b/docs/release.md
@@ -72,7 +72,7 @@ in sync until they're unified. (The retired `macos-13` runner label has been rep
 **16 crates publish.** The publish order follows the dependency DAG, leaf-first (a crate's
 deps must exist on crates.io before it can be verified):
 
-```
+```text
 sparq-core                      # no internal deps — first
   ├── sparq-introspect          # core only                ┐
   ├── sparq-reason              # core only                │ order among these

--- a/docs/upstream-proposals.md
+++ b/docs/upstream-proposals.md
@@ -12,8 +12,8 @@ release ships; re-run the conformance suite against that release, then retire
 **Section B (rdf-tests issues): not yet filed, awaiting go-ahead (tracked in beads).**
 Tracker search 2026-06-11: Issues 3+4 fall under the already-open w3c/rdf-tests#58
 "How to format decimals?" — file them as an evidence comment there (approved-vs-
-unapproved contradictory pairs), not new issues. Issues 1+2 are unreported (closed
-#81 was an author-retracted misreading, different specifics) — file as new issues.
+unapproved contradictory pairs), not new issues. Issues 1+2 are unreported
+(closed #81 was an author-retracted misreading, different specifics) — file as new issues.
 
 The final-eleven conformance work surfaced six parser bugs in spargebra 0.4.6
 (fixed in our vendored copy, `vendor/spargebra/SPARQ-PATCHES.md`) and four

--- a/scripts/check-no-perf-numbers.py
+++ b/scripts/check-no-perf-numbers.py
@@ -97,6 +97,14 @@ def is_exempt_path(path: str) -> bool:
     return any(path == p or path.startswith(p) for p in ALLOW_PATH_PREFIXES)
 
 
+class FileReadError(Exception):
+    """[OPUS-4.8] Raised when a scanned file cannot be read/decoded.
+
+    Surfaced rather than swallowed: silently skipping an unreadable file would hide
+    any perf-number violations inside it and make --enforce non-deterministic.
+    """
+
+
 def scan_file(path: str) -> list[tuple[int, str, str]]:
     findings: list[tuple[int, str, str]] = []
     in_code_fence = False
@@ -104,7 +112,11 @@ def scan_file(path: str) -> list[tuple[int, str, str]]:
         with open(path, encoding="utf-8") as fh:
             for lineno, raw in enumerate(fh, 1):
                 line = raw.rstrip("\n")
-                stripped = line.lstrip()
+                # [OPUS-4.8] Strip leading blockquote markers (`>` + spaces, possibly
+                # nested e.g. `> > `) BEFORE the fence test, so blockquoted code fences
+                # (`> ```lang`, as in docs/upstream-proposals.md) are recognised — else
+                # perf-number lines inside them would be mis-scanned as prose.
+                stripped = re.sub(r"^(?:\s*>)+\s*", "", line).lstrip()
                 # Track fenced code blocks; perf numbers inside example output /
                 # console transcripts are illustrative, not doc claims — skip them.
                 if stripped.startswith("```") or stripped.startswith("~~~"):
@@ -119,8 +131,10 @@ def scan_file(path: str) -> list[tuple[int, str, str]]:
                     if m:
                         findings.append((lineno, label, m.group(0).strip()))
                         break  # one finding per line is enough to flag it
-    except (OSError, UnicodeDecodeError):
-        return findings
+    except (OSError, UnicodeDecodeError) as e:
+        # [OPUS-4.8] Don't swallow the error: surface it so the caller can warn and,
+        # in --enforce mode, fail (a skipped file could hide real violations).
+        raise FileReadError(f"{path}: could not read: {e}") from e
     return findings
 
 
@@ -144,11 +158,21 @@ def main() -> int:
     files = args.paths or [p for p in tracked_markdown() if not is_exempt_path(p)]
 
     total = 0
+    read_errors = 0  # [OPUS-4.8] unreadable files — never silently skipped
     summary_lines: list[str] = []
     for path in sorted(files):
         if not args.paths and is_exempt_path(path):
             continue
-        for lineno, label, snippet in scan_file(path):
+        try:
+            file_findings = scan_file(path)
+        except FileReadError as e:
+            # [OPUS-4.8] Warn on stderr always; in --enforce/non-advisory mode this
+            # also counts as a failure below so a hidden file can't pass silently.
+            read_errors += 1
+            print(f"::warning::{e}", file=sys.stderr)
+            summary_lines.append(f"- `{path}` — UNREADABLE (counted as a failure under --enforce)")
+            continue
+        for lineno, label, snippet in file_findings:
             total += 1
             print(f"{path}:{lineno}: perf-number [{label}]: {snippet!r}")
             summary_lines.append(f"- `{path}:{lineno}` — {label}: `{snippet}`")
@@ -157,11 +181,12 @@ def main() -> int:
     step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if step_summary:
         with open(step_summary, "a", encoding="utf-8") as fh:
-            if total == 0:
+            if total == 0 and read_errors == 0:
                 fh.write("### no-perf-numbers: clean ✅\n\n"
                          "No hard-coded performance figures found in the scanned docs.\n")
             else:
-                fh.write(f"### no-perf-numbers (ADVISORY): {total} finding(s) ⚠️\n\n")
+                fh.write(f"### no-perf-numbers (ADVISORY): {total} finding(s)"
+                         f"{f', {read_errors} unreadable file(s)' if read_errors else ''} ⚠️\n\n")
                 fh.write("Benchmark figures drift — relocate these to `bench/`/`research/` "
                          "and link the perf dashboard (AGENTS.md house rule). "
                          "Allowlist a justified line with `<!-- perf-ok -->`.\n\n")
@@ -171,9 +196,16 @@ def main() -> int:
                 if len(summary_lines) > 60:
                     fh.write(f"\n…and {len(summary_lines) - 60} more (see the job log).\n")
 
-    print(f"\nno-perf-numbers: {total} finding(s) across {len(files)} scanned file(s).")
-    if total and args.enforce and not args.advisory:
-        print("::error::hard-coded performance numbers found (see above) — relocate to bench/research.")
+    print(f"\nno-perf-numbers: {total} finding(s) across {len(files)} scanned file(s)"
+          f"{f'; {read_errors} unreadable file(s)' if read_errors else ''}.")
+    # [OPUS-4.8] --advisory always exits 0 (reports only). In --enforce/non-advisory
+    # mode, BOTH perf-number findings AND unreadable files are failures — a file we
+    # couldn't scan might be hiding a violation, so it must not pass silently.
+    if args.enforce and not args.advisory and (total or read_errors):
+        if total:
+            print("::error::hard-coded performance numbers found (see above) — relocate to bench/research.")
+        if read_errors:
+            print(f"::error::{read_errors} file(s) could not be read (see warnings) — cannot certify clean.")
         return 1
     return 0
 

--- a/scripts/check-no-perf-numbers.py
+++ b/scripts/check-no-perf-numbers.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] No-hard-coded-performance-numbers check for markdown (bead sq-5fd1).
+#
+# AGENTS.md house rule: benchmark figures MUST NOT be baked into markdown — they
+# drift, and the single source of truth is the generated perf dashboard + the bench
+# registry (`bench/benchmarks.toml` / `bench/CATALOG.md`). This script greps tracked
+# markdown for measured-throughput / latency / ratio / size-per-triple patterns and
+# reports them so reviewers can relocate the figure to bench/research and link it.
+#
+# STATUS: ADVISORY (run with --advisory in CI — never fails the build) because the
+# violation backlog is still widespread (tracked beads: sq-h1s7 / sq-q2em / sq-rt1t /
+# sq-puyy / sq-kuqa / sq-p3fk + the research/bench corpus). As crates are de-perf'd
+# their READMEs can be moved into --enforce scope. With --enforce it exits non-zero
+# on any finding outside the allowlist, so a clean directory can be ratcheted to HARD.
+#
+# It is deliberately conservative: it allowlists legit, NON-perf numeric facts
+# (algorithm constants, platform/spec limits, dataset/fixture sizes, layout
+# constants, dates/versions/hashes) so it flags *measured performance*, not "any
+# number". False positives are tuned out via ALLOW_LINE_SUBSTRINGS / ALLOW_PATHS.
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+# --- perf-figure patterns (case-insensitive). A NUMBER immediately followed by a
+#     throughput / latency / ratio / size-per-record unit is treated as a measured
+#     performance figure. Spec/algorithm constants are excluded by ALLOW_* below. ---
+NUM = r"[0-9][0-9_.,]*"
+PERF_PATTERNS = [
+    # throughput
+    (re.compile(rf"{NUM}\s*(?:[GMK]?B/s|[GMK]B/sec)\b", re.I), "throughput (bytes/s)"),
+    (re.compile(rf"{NUM}\s*(?:M|K|G)?(?:triples?|rows?|entries|ops|queries|req)/s(?:ec)?\b", re.I), "throughput (records/s)"),
+    (re.compile(rf"{NUM}\s*M/s\b"), "throughput (M/s)"),
+    (re.compile(rf"{NUM}\s*ns/op\b", re.I), "latency (ns/op)"),
+    # latency (a bare number + time unit, often with /query or /op)
+    (re.compile(rf"{NUM}\s*(?:ns|µs|us|ms)\s*/\s*(?:op|query|row|call|item)\b", re.I), "latency (/op)"),
+    (re.compile(rf"{NUM}\s*(?:ns|µs|us)\b(?!\w)", re.I), "latency (ns/µs)"),
+    # speed-up ratios: "12× faster", "1.27x faster", "3× speedup"
+    (re.compile(rf"{NUM}\s*(?:×|x)\s*(?:faster|slower|speed-?up)", re.I), "speed-up ratio"),
+    (re.compile(rf"{NUM}\s*(?:×|x)\b(?=.{{0,30}}(?:faster|slower|speedup|throughput|latency))", re.I), "ratio (perf context)"),
+    # bytes-per-record layout *measurements* (vs. fixed layout constants, see allow)
+    (re.compile(rf"{NUM}\s*B/(?:triple|term|posting|row|node)\b", re.I), "size per record (B/record)"),
+    (re.compile(rf"{NUM}\s*bytes?/(?:triple|term|posting|row|node)\b", re.I), "size per record (bytes/record)"),
+]
+
+# --- ALLOWLIST: lines containing any of these substrings are skipped entirely.
+#     These mark legit non-perf numeric facts or already-relocated references. ---
+ALLOW_LINE_SUBSTRINGS = [
+    # algorithm / spec constants (not measurements)
+    "k1=1.2", "b=0.75", "BM25",
+    # platform / spec limits
+    "wasm32", "4 GB", "2 GB", "4 GiB",
+    # the canonical perf homes — a line that POINTS to them is fine
+    "jeswr.github.io/sparq/dev/bench", "benchmarks.toml", "bench/CATALOG.md",
+    "perf-baseline.json", "perf dashboard",
+    # explicit opt-out marker a reviewer can add on a justified line
+    "<!-- perf-ok -->", "perf-ok:",
+]
+
+# --- ALLOWLIST: whole paths/prefixes that are EXEMPT from the check.
+#     bench/ and research/ are the SANCTIONED homes for measured numbers (AGENTS.md:
+#     "Durable knowledge → … a research/ design record"; bench/ holds methodology +
+#     baselines). The rule is about not baking numbers into USER-FACING docs. ---
+ALLOW_PATH_PREFIXES = [
+    "bench/",            # the benchmark corpus — numbers belong here
+    "research/",         # design records + measured verdicts — numbers belong here
+    "CHANGELOG.md",      # historical record of measured deltas at release time
+    "conformance-report.md",
+    "inference-conformance-report.md",
+    "crates/sparq-conformance/FINDINGS.md",
+    "zk/",               # research scaffolds (separate workspaces)
+    "vendor/",
+    "node_modules/",
+    "target/",
+    ".claude/",
+    ".github/",
+]
+
+# Globs of files to scan (markdown only).
+SCAN_GLOBS = ["*.md"]
+
+
+def tracked_markdown() -> list[str]:
+    """All git-tracked markdown files (deterministic, no untracked scratch)."""
+    out = subprocess.run(
+        ["git", "ls-files", *SCAN_GLOBS],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    return [p for p in out.splitlines() if p]
+
+
+def is_exempt_path(path: str) -> bool:
+    return any(path == p or path.startswith(p) for p in ALLOW_PATH_PREFIXES)
+
+
+def scan_file(path: str) -> list[tuple[int, str, str]]:
+    findings: list[tuple[int, str, str]] = []
+    in_code_fence = False
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for lineno, raw in enumerate(fh, 1):
+                line = raw.rstrip("\n")
+                stripped = line.lstrip()
+                # Track fenced code blocks; perf numbers inside example output /
+                # console transcripts are illustrative, not doc claims — skip them.
+                if stripped.startswith("```") or stripped.startswith("~~~"):
+                    in_code_fence = not in_code_fence
+                    continue
+                if in_code_fence:
+                    continue
+                if any(sub in line for sub in ALLOW_LINE_SUBSTRINGS):
+                    continue
+                for pat, label in PERF_PATTERNS:
+                    m = pat.search(line)
+                    if m:
+                        findings.append((lineno, label, m.group(0).strip()))
+                        break  # one finding per line is enough to flag it
+    except (OSError, UnicodeDecodeError):
+        return findings
+    return findings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--advisory", action="store_true",
+        help="report findings but always exit 0 (default CI mode while the backlog clears)",
+    )
+    ap.add_argument(
+        "--enforce", action="store_true",
+        help="exit non-zero if any finding remains (use once a scope is clean to ratchet it HARD)",
+    )
+    ap.add_argument(
+        "paths", nargs="*",
+        help="optional explicit paths to scan (default: all git-tracked markdown, "
+             "minus the bench/research/changelog allowlisted homes)",
+    )
+    args = ap.parse_args()
+
+    files = args.paths or [p for p in tracked_markdown() if not is_exempt_path(p)]
+
+    total = 0
+    summary_lines: list[str] = []
+    for path in sorted(files):
+        if not args.paths and is_exempt_path(path):
+            continue
+        for lineno, label, snippet in scan_file(path):
+            total += 1
+            print(f"{path}:{lineno}: perf-number [{label}]: {snippet!r}")
+            summary_lines.append(f"- `{path}:{lineno}` — {label}: `{snippet}`")
+
+    # Feed the GitHub step summary when available.
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a", encoding="utf-8") as fh:
+            if total == 0:
+                fh.write("### no-perf-numbers: clean ✅\n\n"
+                         "No hard-coded performance figures found in the scanned docs.\n")
+            else:
+                fh.write(f"### no-perf-numbers (ADVISORY): {total} finding(s) ⚠️\n\n")
+                fh.write("Benchmark figures drift — relocate these to `bench/`/`research/` "
+                         "and link the perf dashboard (AGENTS.md house rule). "
+                         "Allowlist a justified line with `<!-- perf-ok -->`.\n\n")
+                # Cap the inline list so the summary stays readable.
+                for ln in summary_lines[:60]:
+                    fh.write(ln + "\n")
+                if len(summary_lines) > 60:
+                    fh.write(f"\n…and {len(summary_lines) - 60} more (see the job log).\n")
+
+    print(f"\nno-perf-numbers: {total} finding(s) across {len(files)} scanned file(s).")
+    if total and args.enforce and not args.advisory:
+        print("::error::hard-coded performance numbers found (see above) — relocate to bench/research.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-readme-template.py
+++ b/scripts/check-readme-template.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] ADVISORY README length-cap + required-sections check (bead sq-5fd1).
+#
+# Pairs with the crate-README template from the doc-overhaul design (bead sq-9jw5):
+# a concise (<=120-line) per-crate README with three emoji section markers —
+# "## 🚀 Quickstart", "## ✨ Features", "## 📚 Learn more" — plus a License line.
+# `publish=false` crates get a short stub instead (no section requirement).
+#
+# STATUS: ADVISORY (run with --advisory). Today most crate READMEs predate the
+# template and exceed the cap; the overhaul (sq-9jw5) brings them into line per-crate.
+# Until then this check only REPORTS (into the job summary) so the gap stays visible
+# without blocking. Once a README adopts the template it passes; once ALL do, flip the
+# workflow step to --enforce to ratchet it HARD.
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+MAX_LINES = 120
+REQUIRED_SECTIONS = [
+    ("🚀", re.compile(r"^##\s*🚀", re.M)),   # Quickstart
+    ("✨", re.compile(r"^##\s*✨", re.M)),    # Features
+    ("📚", re.compile(r"^##\s*📚", re.M)),    # Learn more
+]
+LICENSE_RE = re.compile(r"^#+\s*License|\bLicense\b", re.M | re.I)
+# A README that openly declares itself an internal/unpublished stub is exempt from the
+# section requirement (the template allows a 15-line stub for publish=false crates).
+STUB_MARKERS = ("not published", "internal, not published", "internal crate", "not on crates.io")
+
+
+def check_readme(path: str) -> list[str]:
+    issues: list[str] = []
+    try:
+        text = open(path, encoding="utf-8").read()
+    except OSError as e:
+        return [f"could not read: {e}"]
+    n_lines = text.count("\n") + (0 if text.endswith("\n") else 1)
+
+    is_stub = any(m in text.lower() for m in STUB_MARKERS)
+
+    if is_stub:
+        if n_lines > 30:
+            issues.append(f"declared a stub but {n_lines} lines (stub target: <=30)")
+        return issues
+
+    if n_lines > MAX_LINES:
+        issues.append(f"{n_lines} lines (template cap: <={MAX_LINES})")
+    for emoji, rx in REQUIRED_SECTIONS:
+        if not rx.search(text):
+            issues.append(f"missing '## {emoji} …' section")
+    if not LICENSE_RE.search(text):
+        issues.append("no License section/line")
+    return issues
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--advisory", action="store_true",
+                    help="report only, always exit 0 (default while sq-9jw5 lands)")
+    ap.add_argument("--enforce", action="store_true",
+                    help="exit non-zero on any template deviation (ratchet to HARD)")
+    ap.add_argument("paths", nargs="*",
+                    help="explicit README paths (default: crates/*/README.md)")
+    args = ap.parse_args()
+
+    paths = args.paths or sorted(glob.glob("crates/*/README.md"))
+    total = 0
+    summary: list[str] = []
+    for path in paths:
+        issues = check_readme(path)
+        if issues:
+            total += len(issues)
+            for it in issues:
+                print(f"{path}: {it}")
+                summary.append(f"- `{path}` — {it}")
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a", encoding="utf-8") as fh:
+            if total == 0:
+                fh.write("### readme-template: all conform ✅\n")
+            else:
+                fh.write(f"### readme-template (ADVISORY): {total} deviation(s) ⚠️\n\n")
+                fh.write("Crate READMEs should follow the concise template from sq-9jw5 "
+                         f"(<= {MAX_LINES} lines; 🚀 Quickstart / ✨ Features / 📚 Learn more; "
+                         "License). The overhaul (sq-9jw5) brings them into line.\n\n")
+                for ln in summary[:60]:
+                    fh.write(ln + "\n")
+
+    print(f"\nreadme-template: {total} deviation(s) across {len(paths)} README(s).")
+    if total and args.enforce and not args.advisory:
+        print("::error::crate READMEs deviate from the template (see above).")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-readme-template.py
+++ b/scripts/check-readme-template.py
@@ -26,7 +26,17 @@ REQUIRED_SECTIONS = [
     ("✨", re.compile(r"^##\s*✨", re.M)),    # Features
     ("📚", re.compile(r"^##\s*📚", re.M)),    # Learn more
 ]
-LICENSE_RE = re.compile(r"^#+\s*License|\bLicense\b", re.M | re.I)
+# [OPUS-4.8] Require a real License *section*, not any inline mention of the word
+# "License" (e.g. "licensed under", a "license" badge). The template's License is a
+# heading or a one-line section label at line-start: a markdown heading (`## License`),
+# a bold label (`**License**`), or a leading `License` followed by `:`/`—`/`-`. Each
+# alternative is anchored to the start of a line (re.M) so prose mentions don't count.
+LICENSE_RE = re.compile(
+    r"^\s{0,3}(?:#{1,6}\s*License\b"          # markdown heading: ## License
+    r"|\*\*License\*\*"                         # bold label: **License**
+    r"|License\s*(?:[:—-]|$))",                # one-line section: "License:" / "License —"
+    re.M | re.I,
+)
 # A README that openly declares itself an internal/unpublished stub is exempt from the
 # section requirement (the template allows a 15-line stub for publish=false crates).
 STUB_MARKERS = ("not published", "internal, not published", "internal crate", "not on crates.io")

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -225,7 +225,7 @@ env overrides the default.
 | `--max-subscriptions-per-conn N` | `SPARQ_MAX_SUBSCRIPTIONS_PER_CONN` | `16` | per-socket subs |
 | `--verbose` | — | off | TraceLayer request logging (respects `RUST_LOG`) |
 | `--allow-remote` | `SPARQ_ALLOW_REMOTE` | off | opt in to a non-loopback bind despite no auth; without it a non-loopback `--addr` is **refused** at startup, with it it warns and proceeds |
-| `--service-allow HOST\|*.SUFFIX` (repeatable) | `SPARQ_SERVICE_ALLOW` (comma/ws-sep) | empty = **deny ALL SERVICE** | (feature `service`) allowlist a SERVICE egress host (exact or `*.suffix` wildcard); CLI + file + env are UNIONed |
+| `--service-allow HOST\|*.SUFFIX` (repeatable) | `SPARQ_SERVICE_ALLOW` (comma/ws-sep) | empty = **deny ALL SERVICE** | (feature `service`) allowlist a SERVICE egress host (exact or `*.suffix` wildcard); CLI + file + env are all merged (combined additively) |
 | `--service-allow-file PATH` | — | — | (feature `service`) load allowlist entries, one per line (`#` comments + blanks ignored) |
 | `--time-travel-generations N` | `SPARQ_TIME_TRAVEL_GENERATIONS` | `16` | (feature) retained generations |
 | `--time-travel-max-age SECS` | `SPARQ_TIME_TRAVEL_MAX_AGE` | off | (feature) age-out window |
@@ -247,7 +247,7 @@ then `router(state)`, or `harden(my_router, &config)`.
   SERVICE**: a `SERVICE <iri>` clause reaches **nothing** unless its host is allowlisted —
   via `--service-allow HOST` / `*.SUFFIX` (repeatable), `--service-allow-file PATH` (one
   entry per line), or `SPARQ_SERVICE_ALLOW` (comma/whitespace-separated). All three are
-  UNIONed (additive; the CLI only ever widens the env baseline). Rationale: a `SERVICE`
+  combined additively (the CLI only ever widens the env baseline). Rationale: a `SERVICE`
   clause turns attacker-controlled query text into an outbound request from the server
   host (textbook SSRF; worst case the `169.254.169.254` cloud-metadata IP), so the
   network-exposed surface must opt in to every reachable host. Matching is


### PR DESCRIPTION
Implements sq-5fd1. Staged rollout (per its design): HARD where already-clean, ADVISORY where a pre-existing backlog or the in-flight doc overhaul (sq-9jw5) means it can't gate yet.

**HARD (gate the build, deterministic, currently PASSING):** markdownlint + typos + internal-link check (lychee `--offline`), scoped to the already-clean user-facing + governance surface — root `*.md` + `skills/` + `docs/` + `crates/` = **49 files, 0 violations** (verified on current main incl. the new kuqa README). Cleared 11 trivial real violations (1 typo, 2 stale anchors, 3 missing code-fence langs, 1 PR-ref heading, 5 double-blanks).

**ADVISORY (`continue-on-error` → step summary, never block):** whole-repo markdownlint, Vale prose (weasel/superfluous/puffery), external-link check (network-flaky), and custom checks — a **no-hard-coded-perf-numbers** grep (`scripts/check-no-perf-numbers.py`, found 9 real violations → existing de-perf beads) + a README-template conformance check (`scripts/check-readme-template.py`, 72 deviations → sq-9jw5).

All `uses:` SHA-pinned (`# vX.Y.Z`); permissions `contents: read` (Vale local reporter). Filed sq-rqyo (bring research/+zk/ under HARD markdownlint) + sq-8ic6 (ratchet advisory→HARD once the backlog clears, blocked-by sq-9jw5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)