### PR TITLE
feat(sparq-mpc): consistency-checked degree-2t equality/mult open (sq-7q9i / sq-uu0u WI-2)

### DIFF
--- a/crates/sparq-mpc/src/adversarial_tests.rs
+++ b/crates/sparq-mpc/src/adversarial_tests.rs
@@ -186,19 +186,27 @@ mod tamper {
         }
     }
 
-    /// The secure-equality primitive (`HiddenValueJoin::secure_equal`) opens
-    /// `m = d·r` at degree `2t` and reports `m == 0` as the match bit. We
-    /// reproduce that EXACT primitive from the public `shamir` ops and show that
-    /// tampering one share of the opened product FLIPS the verdict undetected:
-    /// a forged share can turn a true match into a false non-match (and a
-    /// non-match into a spurious match). This is the join-layer face of the same
-    /// missing guarantee — pinned, not implied.
+    /// **POSITIVE detection test (sq-7q9i, WI-2; was the `…_flips_secure_
+    /// equality_verdict_undetected` pin).** The secure-equality primitive
+    /// (`HiddenValueJoin::secure_equal`) opens `m = d·r` at degree `2t` and
+    /// reports `m == 0` as the match bit. We reproduce that EXACT primitive from
+    /// the public `shamir` ops. WI-2 routes the degree-`2t` open through the WI-1
+    /// Reed–Solomon checker, so when redundancy is present at degree `2t`
+    /// (`n > 2t+1`) tampering one product share is now DETECTED rather than
+    /// silently flipping the verdict.
+    ///
+    /// Redundancy at degree `2t` needs `n > 2t+1`. The honest-majority
+    /// constructor fixes `t = ⌊(n−1)/2⌋`, so EVEN `n` gives `2t+1 = n−1 < n`
+    /// (exactly one redundant share at degree `2t`, `e_max = 0` ⇒ detect-only).
+    /// We use `n = 4, t = 1` (`2t = 2`, opened with all 4 shares ⇒ `4 > 3`).
     #[test]
-    fn tampered_share_flips_secure_equality_verdict_undetected() {
-        // n = 5, t = 2 → one multiplication opens at degree 2t = 4 (needs 5 pts).
-        let backend = ShamirBackend::new_seeded(5, 0xEEEE).unwrap();
+    fn tampered_share_in_secure_equality_open_is_detected_when_redundant() {
+        // n = 4, t = 1 → equality opens at degree 2t = 2 with all n=4 shares:
+        // 4 > 2t+1 = 3 ⇒ one redundant share ⇒ detect-and-abort (e_max = 0).
+        let backend = ShamirBackend::new_seeded(4, 0xEEEE).unwrap();
         let mut dealer = backend.dealer();
         let t = dealer.threshold();
+        assert_eq!(t, 1);
 
         // Two EQUAL keys → honest verdict is "match" (m == 0).
         let key = fp(42);
@@ -208,8 +216,67 @@ mod tamper {
         let r = dealer.share(mask);
         let d = shamir::sub_shares(&sa, &sb).unwrap();
         let m_shares = mul_shares_raw(&d, &r).unwrap();
+        assert_eq!(
+            m_shares.len(),
+            4,
+            "all n=4 product shares opened (redundant)"
+        );
 
-        // Honest open: equal keys ⇒ m == 0 ⇒ match.
+        // Honest open: equal keys ⇒ m == 0 ⇒ match (no behaviour change clean).
+        let m_honest = reconstruct_degree(&m_shares, 2 * t).unwrap();
+        assert_eq!(
+            m_honest,
+            Fp::zero(),
+            "sanity: equal keys open to m = 0 (match) on the checked path"
+        );
+
+        // Tamper ONE product share: with n > 2t+1 the RS check now DETECTS the
+        // off-curve share and ABORTS instead of silently flipping the verdict.
+        let mut tampered = m_shares.clone();
+        tampered[0].y = tampered[0].y.add(fp(1));
+        let err = reconstruct_degree(&tampered, 2 * t).unwrap_err();
+        assert!(
+            matches!(err, MpcError::Tampered { .. }),
+            "sq-7q9i: a tampered degree-2t product share with redundancy (n > 2t+1) \
+             must be DETECTED (MpcError::Tampered), not silently flip the match bit; got {err:?}"
+        );
+    }
+
+    /// **NON-detection BOUNDARY pin (sq-7q9i, WI-2).** At EXACTLY the honest-
+    /// majority minimum `n = 2t+1`, the degree-`2t` product open has ZERO RS
+    /// redundancy (it is the minimal `2t+1` points that pin a unique degree-`2t`
+    /// polynomial — analogous to the degree-`t` `t+1`-share no-redundancy case).
+    /// So tampering one product share is information-theoretically UNDETECTABLE:
+    /// it simply selects a different (wrong) degree-`2t` polynomial whose value at
+    /// 0 flips the match verdict, with NO inconsistency to detect. WI-2 must NOT
+    /// fake a guarantee here — the open must return the (flipped, wrong) value,
+    /// never a false-positive [`MpcError::Tampered`]. This mirrors WI-1's exact-
+    /// `t+1` non-detection pin. A true fix at `n = 2t+1` needs a MAC (deferred
+    /// WI-4 / bead sq-6d6g).
+    #[test]
+    fn tampered_share_in_secure_equality_open_is_undetectable_at_n_eq_2t_plus_1() {
+        // n = 5, t = 2 → equality opens at degree 2t = 4 with all n=5 shares:
+        // n = 2t+1 = 5 ⇒ NO redundancy at degree 2t ⇒ tampering is undetectable.
+        let backend = ShamirBackend::new_seeded(5, 0xEEEE).unwrap();
+        let mut dealer = backend.dealer();
+        let t = dealer.threshold();
+        assert_eq!(t, 2);
+        assert_eq!(dealer.parties(), 2 * t + 1, "exact honest-majority minimum");
+
+        // Two EQUAL keys → honest verdict is "match" (m == 0).
+        let key = fp(42);
+        let sa = dealer.share(key);
+        let sb = dealer.share(key);
+        let mask = dealer.draw_nonzero_fp();
+        let r = dealer.share(mask);
+        let d = shamir::sub_shares(&sa, &sb).unwrap();
+        let m_shares = mul_shares_raw(&d, &r).unwrap();
+        assert_eq!(
+            m_shares.len(),
+            2 * t + 1,
+            "exactly 2t+1 product shares (no redundancy)"
+        );
+
         let m_honest = reconstruct_degree(&m_shares, 2 * t).unwrap();
         assert_eq!(
             m_honest,
@@ -217,17 +284,25 @@ mod tamper {
             "sanity: equal keys open to m = 0 (match)"
         );
 
-        // Tamper ONE product share: the opened m is now nonzero ⇒ verdict flips to
-        // "no match", with NO signal that a share was corrupted.
+        // Tamper ONE product share at n = 2t+1: NO redundancy ⇒ the open must NOT
+        // report Tampered (no false positive) and the verdict silently flips. This
+        // is the honest boundary — RS cannot help; a MAC is required (WI-4).
         let mut tampered = m_shares.clone();
         tampered[0].y = tampered[0].y.add(fp(1));
-        let m_tampered = reconstruct_degree(&tampered, 2 * t).unwrap();
-        assert_ne!(
-            m_tampered,
-            Fp::zero(),
-            "FINDING (sq-nuok pin → bead sq-uu0u): tampering one product share flips a true secure- \
-             equality MATCH into a non-match undetected (semi-honest; no integrity)"
-        );
+        match reconstruct_degree(&tampered, 2 * t) {
+            Ok(m_tampered) => assert_ne!(
+                m_tampered,
+                Fp::zero(),
+                "sq-7q9i boundary: at n = 2t+1 a tampered product share flips the verdict \
+                 (different valid degree-2t poly), so m must be nonzero — but NO detection"
+            ),
+            Err(MpcError::Tampered { .. }) => panic!(
+                "sq-7q9i boundary FALSE POSITIVE: degree-2t open at n = 2t+1 has no RS \
+                 redundancy, so tampering is undetectable and must NOT report Tampered \
+                 (a MAC is the deferred WI-4 fix, not RS)"
+            ),
+            Err(other) => panic!("unexpected error at the n=2t+1 boundary: {other:?}"),
+        }
     }
 
     /// Mismatched evaluation points (a party submitting a share on the WRONG `x`)
@@ -481,6 +556,172 @@ mod robust_props {
                         "n={n} take={take}: robust must equal honest Lagrange on clean input"
                     );
                     assert_eq!(robust, secret, "and equal the true secret");
+                }
+            }
+        }
+    }
+
+    // =================================================================
+    // [OPUS-4.8] sq-7q9i (WI-2): degree-2t open property tests. The
+    // equality/mult path opens m = d·r at degree 2t; these pin the
+    // n>2t+1 (detect/correct) vs n=2t+1 (no detection) boundary at the
+    // ACTUAL product degree, mirroring the degree-t props above.
+    // =================================================================
+
+    /// Build a degree-`degree` Shamir-style sharing of `secret` at points
+    /// `x = 1..=n` directly (the production dealer only deals degree `t`). Free
+    /// coefficients are drawn from the deterministic test RNG so the resulting
+    /// codeword genuinely has the requested degree.
+    fn share_degree(rng: &mut Lcg, secret: Fp, degree: usize, n: usize) -> Vec<Share> {
+        let mut coeffs = Vec::with_capacity(degree + 1);
+        coeffs.push(secret);
+        for _ in 0..degree {
+            coeffs.push(fp(rng.next_fp()));
+        }
+        (1..=n as u64)
+            .map(|x| {
+                // Horner eval of the degree-`degree` polynomial at x.
+                let xf = fp(x);
+                let mut acc = Fp::zero();
+                for &c in coeffs.iter().rev() {
+                    acc = acc.mul(xf).add(c);
+                }
+                Share { x, y: acc }
+            })
+            .collect()
+    }
+
+    /// Reproduce the EXACT secure-equality open (`m = d·r` at degree `2t`) for
+    /// honest-majority party counts and assert the WI-2 boundary as a PROPERTY:
+    /// whenever `n > 2t+1` (redundancy at degree `2t`) a single tampered product
+    /// share is DETECTED (abort) — never a silently flipped verdict. Even `n`
+    /// gives `2t+1 = n−1 < n` (one redundant share), which is the regime the
+    /// honest-majority constructor actually reaches.
+    #[test]
+    fn equality_open_detects_tamper_whenever_redundant() {
+        let mut rng = Lcg(0x2E0F_7A11);
+        for &n in &[4usize, 6, 8] {
+            let backend = ShamirBackend::new_seeded(n, 0x9E5 + n as u64).unwrap();
+            let t = backend.threshold();
+            // Honest-majority even-n invariant: redundancy at degree 2t is n - (2t+1).
+            assert!(n > 2 * t + 1, "n={n} t={t}: expected degree-2t redundancy");
+            for _ in 0..150 {
+                let mut dealer = backend.dealer();
+                // EQUAL keys ⇒ honest m = 0 (match). (Unequal keys would open to a
+                // random nonzero m; either way one tampered share is off-curve.)
+                let key = fp(rng.next_fp());
+                let sa = dealer.share(key);
+                let sb = dealer.share(key);
+                let mask = dealer.draw_nonzero_fp();
+                let r = dealer.share(mask);
+                let d = shamir::sub_shares(&sa, &sb).unwrap();
+                let m_shares = mul_shares_raw(&d, &r).unwrap();
+                // Honest open is the match (no behaviour change on clean input).
+                assert_eq!(
+                    reconstruct_degree(&m_shares, 2 * t).unwrap(),
+                    Fp::zero(),
+                    "n={n}: honest equal-key open must be m = 0"
+                );
+                // Tamper one product share ⇒ detected (redundancy present).
+                let mut tampered = m_shares.clone();
+                let i = rng.next_in(n);
+                let mut delta = rng.next_fp();
+                if delta == 0 {
+                    delta = 1;
+                }
+                tampered[i].y = tampered[i].y.add(fp(delta));
+                match reconstruct_degree(&tampered, 2 * t) {
+                    Err(MpcError::Tampered { .. }) => { /* detected — correct */ }
+                    Ok(v) => panic!(
+                        "n={n} t={t}: tampered degree-2t product share with redundancy must \
+                         ABORT, got {v:?} (would silently flip the match verdict)"
+                    ),
+                    Err(other) => panic!("n={n}: must be Tampered, got {other:?}"),
+                }
+            }
+        }
+    }
+
+    /// PROPERTY: the degree-`2t` open CORRECTS up to `e` tampered shares when the
+    /// codeword carries enough redundancy (`n ≥ 2t + 2e + 1`). The honest-
+    /// majority constructor (`t = ⌊(n−1)/2⌋`) never provisions this headroom for a
+    /// degree-`2t` product, so we build the degree-`2t` sharing DIRECTLY at a
+    /// chosen `n` to exercise the checker's correction arm at the product degree
+    /// (the equality primitive itself only ever DETECTS, never corrects — that is
+    /// the honest envelope, documented on `reconstruct_degree`).
+    #[test]
+    fn degree_2t_open_corrects_up_to_budget_when_overprovisioned() {
+        let mut rng = Lcg(0x4C0F_FEE2);
+        // (t, n) with n >= 2t + 3 so e_max = floor((n - 2t - 1)/2) >= 1 at deg 2t.
+        for &(t, n) in &[(1usize, 5usize), (1, 7), (2, 7), (2, 9), (3, 11)] {
+            let degree = 2 * t;
+            let e_max = (n - degree - 1) / 2;
+            assert!(e_max >= 1, "t={t} n={n}: expected a correction budget");
+            for _ in 0..150 {
+                let secret = fp(rng.next_fp());
+                let clean = share_degree(&mut rng, secret, degree, n);
+                // Honest open recovers the secret.
+                assert_eq!(
+                    reconstruct_degree(&clean, degree).unwrap(),
+                    secret,
+                    "t={t} n={n}: honest degree-2t open must recover the secret"
+                );
+                // Tamper up to e_max shares ⇒ corrected back to the truth.
+                let num_err = rng.next_in(e_max + 1); // 0..=e_max
+                let mut shares = clean.clone();
+                let idxs = distinct_indices(&mut rng, n, num_err);
+                tamper(&mut rng, &mut shares, &idxs);
+                let got = reconstruct_degree(&shares, degree).unwrap_or_else(|e| {
+                    panic!("t={t} n={n} e_max={e_max} num_err={num_err}: must correct, got {e:?}")
+                });
+                assert_eq!(
+                    got, secret,
+                    "t={t} n={n} num_err={num_err}: degree-2t open must correct to the truth"
+                );
+            }
+        }
+    }
+
+    /// PROPERTY (documented non-detection at the boundary): at EXACTLY
+    /// `n = 2t + 1` the degree-`2t` open has NO redundancy, so a single tampered
+    /// product share is undetectable — the open must NOT report `Tampered` (no
+    /// false positive) and simply interpolates to a different (wrong) value. This
+    /// is the degree-`2t` analogue of `exact_threshold_set_never_reports_tampered`
+    /// and pins the honest WI-2 boundary across the honest-majority odd-`n` counts
+    /// (where `2t+1 = n`). A MAC is the deferred WI-4 fix here, not RS.
+    #[test]
+    fn degree_2t_open_never_reports_tampered_at_n_eq_2t_plus_1() {
+        let mut rng = Lcg(0x2717_B0DE);
+        for &n in &[3usize, 5, 7, 9] {
+            let backend = ShamirBackend::new_seeded(n, 0xB0 + n as u64).unwrap();
+            let t = backend.threshold();
+            assert_eq!(
+                n,
+                2 * t + 1,
+                "odd honest-majority n: degree-2t has no redundancy"
+            );
+            let degree = 2 * t;
+            for _ in 0..150 {
+                let secret = fp(rng.next_fp());
+                // Exactly n = 2t+1 points of a degree-2t sharing (no redundancy).
+                let mut shares = share_degree(&mut rng, secret, degree, n);
+                let i = rng.next_in(n);
+                let mut delta = rng.next_fp();
+                if delta == 0 {
+                    delta = 1;
+                }
+                shares[i].y = shares[i].y.add(fp(delta));
+                match reconstruct_degree(&shares, degree) {
+                    Ok(v) => assert_ne!(
+                        v, secret,
+                        "n={n} t={t}: degree-2t tamper at n=2t+1 must change the value \
+                         (no magic correction)"
+                    ),
+                    Err(MpcError::Tampered { .. }) => panic!(
+                        "n={n} t={t}: FALSE POSITIVE — degree-2t open at n=2t+1 has no \
+                         redundancy; tampering is undetectable, must not report Tampered"
+                    ),
+                    Err(other) => panic!("n={n}: unexpected error {other:?}"),
                 }
             }
         }

--- a/crates/sparq-mpc/src/adversarial_tests.rs
+++ b/crates/sparq-mpc/src/adversarial_tests.rs
@@ -572,11 +572,29 @@ mod robust_props {
     /// `x = 1..=n` directly (the production dealer only deals degree `t`). Free
     /// coefficients are drawn from the deterministic test RNG so the resulting
     /// codeword genuinely has the requested degree.
+    ///
+    /// [OPUS-4.8] sq-7q9i (WI-2): the LEADING (highest-index) coefficient is
+    /// forced non-zero by rejection sampling. If it were left as a raw RNG draw
+    /// it could be 0 with probability ~1/P, silently dropping the polynomial
+    /// below the requested `degree`; that would hand the degree-`2t` boundary /
+    /// correction-budget tests MORE RS redundancy than intended and weaken them.
+    /// Resampling stays deterministic (it only consumes extra draws from the
+    /// seeded test RNG). `degree >= 1` at every call site (always `2t`, `t >= 1`).
     fn share_degree(rng: &mut Lcg, secret: Fp, degree: usize, n: usize) -> Vec<Share> {
         let mut coeffs = Vec::with_capacity(degree + 1);
         coeffs.push(secret);
-        for _ in 0..degree {
+        // Free (middle) coefficients: zero is harmless for the degree.
+        for _ in 0..degree.saturating_sub(1) {
             coeffs.push(fp(rng.next_fp()));
+        }
+        // Leading coefficient must be non-zero so the codeword is genuinely
+        // degree `degree` (only relevant when `degree >= 1`).
+        if degree >= 1 {
+            let mut lead = rng.next_fp();
+            while lead == 0 {
+                lead = rng.next_fp();
+            }
+            coeffs.push(fp(lead));
         }
         (1..=n as u64)
             .map(|x| {

--- a/crates/sparq-mpc/src/join.rs
+++ b/crates/sparq-mpc/src/join.rs
@@ -396,6 +396,18 @@ impl HiddenValueJoin {
     /// one process; it secret-shares them internally and never uses the
     /// cleartext after sharing except to deal the shares — exactly what a dealer
     /// does. It returns the boolean match WITHOUT reconstructing `a` or `b`.
+    ///
+    /// **Consistency-checked open (sq-7q9i, WI-2).** The product `m = d·r` is a
+    /// degree-`2t` Reed–Solomon codeword over the `n` party points; the open
+    /// routes through [`shamir::reconstruct_degree`] → the WI-1 RS checker at
+    /// degree `2t`. When `n > 2t + 1` a tampered product share is detected (abort
+    /// with [`MpcError::Tampered`]) or corrected, so a forged share can no longer
+    /// silently flip the match verdict. HONESTY: the honest-majority instantiation
+    /// `t = ⌊(n−1)/2⌋` gives `n = 2t + 1` for odd `n`, where degree-`2t` has ZERO
+    /// RS redundancy — tampering is information-theoretically undetectable and is
+    /// NOT claimed otherwise (pinned by a boundary test; a true fix needs a MAC,
+    /// deferred WI-4 / bead sq-6d6g). Detection at `n > 2t + 1` thus requires
+    /// running the equality test on MORE than the minimal party count.
     fn secure_equal(&self, dealer: &mut ShamirDealer, a: Fp, b: Fp) -> Result<bool, MpcError> {
         let t = dealer.threshold();
         // Honest-majority headroom: one multiplication needs 2t+1 <= n parties.

--- a/crates/sparq-mpc/src/rng.rs
+++ b/crates/sparq-mpc/src/rng.rs
@@ -21,10 +21,12 @@
 //!
 //! - [`SecureRng`] — the **production / default** masking RNG. A
 //!   [`rand_chacha::ChaCha20Rng`] CSPRNG seeded from OS entropy
-//!   ([`rand_core::SeedableRng::from_os_rng`] → `getrandom`). This is what the
+//!   (`rand_core::SeedableRng::from_os_rng` → `getrandom`). This is what the
 //!   real protocol uses and the only RNG reachable from the default
 //!   [`crate::shamir::ShamirBackend::new`] constructor.
-//! - [`InsecureTestRng`] — a **deterministic, seedable SplitMix64** PRNG for
+//! - `InsecureTestRng` (`#[cfg(any(test, feature = "insecure-test-rng"))]`,
+//!   so not an intra-doc link in default builds) — a **deterministic, seedable
+//!   SplitMix64** PRNG for
 //!   reproducible tests/benchmarks ONLY. It is gated behind
 //!   `#[cfg(any(test, feature = "insecure-test-rng"))]` so it cannot be
 //!   constructed from a normal (non-test, default-feature) build. Its name
@@ -52,7 +54,8 @@ use rand::RngCore;
 ///
 /// Implementors yield uniform field elements over `F_p`. The trait exists so the
 /// security-critical [`SecureRng`] (CSPRNG) is the production default while a
-/// deterministic [`InsecureTestRng`] stays available for reproducible tests —
+/// deterministic `InsecureTestRng` (test-gated, so not an intra-doc link) stays
+/// available for reproducible tests —
 /// without the two being silently swappable in the real protocol (the insecure
 /// impl is `cfg`-gated out of normal builds).
 pub trait MpcRng {

--- a/crates/sparq-mpc/src/robust.rs
+++ b/crates/sparq-mpc/src/robust.rs
@@ -43,9 +43,13 @@
 //!   second valid codeword within distance `e` — needs `> e` coordinated errors
 //!   and is the standard RS limitation, not a regression over plain Lagrange,
 //!   which silently miscorrects on a SINGLE error.)
-//! - **The degree-`2t` equality/mult open** (`join::secure_equal`, opened at
-//!   `n = 2t+1` with NO RS redundancy). That is WI-2 (bead sq-7q9i), deliberately
-//!   out of scope here; this module does not touch it.
+//! - **The degree-`2t` equality/mult open at `n = 2t+1`** (`join::secure_equal`).
+//!   WI-2 (bead sq-7q9i) routes that open through THIS primitive at degree `2t`
+//!   ([`crate::shamir::reconstruct_degree`]): it detects/corrects when
+//!   `n > 2t+1`, but at exactly `n = 2t+1` degree `2t` has NO RS redundancy, so
+//!   the same no-redundancy non-detection above applies — a forged product share
+//!   is undetectable there. A true fix at `n = 2t+1` needs an information-
+//!   theoretic MAC (deferred WI-4, bead sq-6d6g), not RS redundancy.
 //!
 //! ## Algorithm — Berlekamp–Welch via Gaussian elimination over `F_p`
 //!

--- a/crates/sparq-mpc/src/robust.rs
+++ b/crates/sparq-mpc/src/robust.rs
@@ -11,7 +11,8 @@
 //! codeword over the existing field `F_p` ([`crate::field`]). The message is the
 //! `t+1` low coefficients of `Q` (the secret is `Q(0)`); the codeword is the `n`
 //! evaluations `y_i = Q(x_i)`. Plain Lagrange interpolation
-//! ([`crate::shamir::reconstruct_at_zero`]) is RS *decoding under the assumption
+//! (`shamir::reconstruct_at_zero`, now `#[cfg(test)]` — no production caller after
+//! WI-2, so not an intra-doc link) is RS *decoding under the assumption
 //! that every symbol is correct* — it has no consistency check, so one tampered
 //! `y_i` silently yields the wrong `Q(0)` even when redundancy is present
 //! (pinned by `adversarial_tests::tamper`; bead sq-uu0u).

--- a/crates/sparq-mpc/src/shamir.rs
+++ b/crates/sparq-mpc/src/shamir.rs
@@ -285,11 +285,14 @@ fn eval_poly(coeffs: &[Fp], x: Fp) -> Fp {
 /// secret). Requires `>= t+1` distinct points.
 ///
 /// This is the unchecked RS-decode-under-no-errors primitive — it does NOT
-/// detect tampering. The consistency-checked / robust entry point that callers
-/// use is [`crate::robust::reconstruct_robust`] (wired into
-/// [`ShamirBackend::reconstruct`]); this stays the underlying building block
-/// (e.g. for the degree-`2t` [`reconstruct_degree`] open). `pub(crate)` so the
-/// adversarial differential suite can compare the robust path against it.
+/// detect tampering. Every PRODUCTION reconstruction path now routes through the
+/// consistency-checked / robust entry point [`crate::robust::reconstruct_robust`]
+/// (wired into [`ShamirBackend::reconstruct`] AND, since WI-2 / sq-7q9i, into the
+/// degree-`2t` [`reconstruct_degree`] open). This unchecked Lagrange-at-0 helper
+/// therefore has NO production caller left; it is kept `#[cfg(test)]` purely as
+/// the differential REFERENCE the adversarial suite compares the robust path
+/// against (robust-vs-robust would be vacuous — see `robust.rs` tests).
+#[cfg(test)]
 pub(crate) fn reconstruct_at_zero(shares: &[Share], t: usize) -> Result<Fp, MpcError> {
     if shares.len() < t + 1 {
         return Err(MpcError::Protocol(format!(
@@ -405,9 +408,35 @@ pub fn mul_shares_raw(a: &[Share], b: &[Share]) -> Result<Vec<Share>, MpcError> 
 /// Reconstruct the secret of a sharing of a known polynomial `degree`, requiring
 /// `degree + 1` points. Used to open the degree-`2t` product of the equality
 /// test (`degree = 2t`).
+///
+/// **Consistency-checked / robust at degree `degree` (sq-7q9i, WI-2).** This
+/// routes the open through [`crate::robust::reconstruct_robust`] at the GIVEN
+/// `degree` — the SAME Reed–Solomon checker WI-1 wired into the degree-`t`
+/// reconstruction, just instantiated at the product's degree. The codeword view
+/// is identical: a sharing of a degree-`degree` polynomial at `n` distinct points
+/// is an `[n, degree+1]` RS codeword, so the checker:
+///
+/// - `n == degree + 1` (**NO redundancy**) → plain Lagrange; tampering is
+///   information-theoretically undetectable and is NOT claimed otherwise.
+/// - `n > degree + 1` (**redundancy**) → Berlekamp–Welch: detect any tampering
+///   and abort with [`MpcError::Tampered`], correcting up to
+///   `e = ⌊(n − degree − 1)/2⌋` tampered shares first.
+///
+/// HONESTY (the degree-`2t` boundary; bead sq-7q9i / parent sq-uu0u): for the
+/// equality/mult open `degree = 2t`, redundancy exists ONLY when `n > 2t + 1`.
+/// The honest-majority constructor fixes `t = ⌊(n−1)/2⌋`, so `n = 2t + 1` for odd
+/// `n` (e.g. n=3,5,7,9): there is **zero** RS redundancy at degree `2t` and
+/// tampering one product share is undetectable — pinned by a boundary test. A
+/// true fix at `n = 2t + 1` needs an information-theoretic MAC (the deferred WI-4
+/// seam, bead sq-6d6g), not RS redundancy. Even `n` (n=4,6,8) yields exactly one
+/// redundant share at degree `2t` (`e_max = 0`), so tampering is DETECT-only
+/// there; correction (`e_max ≥ 1`) at degree `2t` needs `n ≥ 2t + 3`.
 pub fn reconstruct_degree(shares: &[Share], degree: usize) -> Result<Fp, MpcError> {
-    // reconstruct_at_zero needs `t+1` points where here the "t" is `degree`.
-    reconstruct_at_zero(shares, degree)
+    // Same RS-consistency-checked entry point as ShamirBackend::reconstruct,
+    // instantiated at the product's `degree` (here `2t`) rather than `t`. At
+    // `n == degree+1` it falls back to plain Lagrange (no detection claim); with
+    // redundancy it detects/corrects. See the doc above for the degree-2t bound.
+    crate::robust::reconstruct_robust(shares, degree)
 }
 
 /// The Shamir `Share` representation surfaced through the trait. A holder's

--- a/crates/sparq-mpc/src/shamir.rs
+++ b/crates/sparq-mpc/src/shamir.rs
@@ -65,8 +65,9 @@
 //!   [`ShamirBackend::dealer`]) mints a fresh [`crate::rng::SecureRng`] — a
 //!   ChaCha20 CSPRNG seeded from OS entropy — for each dealing session. Field
 //!   elements are drawn uniformly via rejection sampling (no modulo bias).
-//! - A **deterministic, seedable** path ([`ShamirBackend::new_seeded`], gated
-//!   behind `#[cfg(any(test, feature = "insecure-test-rng"))]`) drives the
+//! - A **deterministic, seedable** path (`ShamirBackend::new_seeded`, gated
+//!   behind `#[cfg(any(test, feature = "insecure-test-rng"))]` — so not an
+//!   intra-doc link in default builds) drives the
 //!   in-process multi-party SIMULATION and its differential/stress tests
 //!   reproducibly. It is feature-gated out of normal builds: the real masking
 //!   path cannot reach the deterministic RNG. No security is claimed for it.
@@ -115,7 +116,7 @@ enum RngSource {
 ///
 /// `n` = number of compute parties (= holders in the flatmate model); the
 /// privacy threshold is `t = ⌊(n-1)/2⌋` (honest majority). The backend holds NO
-/// live RNG state — only `n`, `t`, and the [`RngSource`] descriptor — so it is
+/// live RNG state — only `n`, `t`, and the `RngSource` descriptor (private) — so it is
 /// freely `Clone`-able without ever cloning a CSPRNG keystream. The masking
 /// randomness lives on the short-lived [`ShamirDealer`] minted by [`Self::dealer`].
 ///
@@ -138,7 +139,8 @@ impl ShamirBackend {
     /// Masking randomness comes from a fresh OS-seeded ChaCha20 CSPRNG per
     /// dealing session — the only RNG this constructor wires in (sq-1vt). There
     /// is no seed parameter: a real masking RNG must not be predictable. For a
-    /// reproducible test simulation use [`Self::new_seeded`] (test-gated).
+    /// reproducible test simulation use `Self::new_seeded` (test-gated, so not an
+    /// intra-doc link in default builds).
     pub fn new(n: usize) -> Result<Self, MpcError> {
         Self::with_source(n, RngSource::Os)
     }


### PR DESCRIPTION
Extends WI-1's RS tamper-detection to the **degree-2t** open used by the secure-equality / multiplication path (`HiddenValueJoin::secure_equal`). Builds on the merged `reconstruct_robust`.

**Seam (one entry point):** `shamir::reconstruct_degree` now routes through `robust::reconstruct_robust` at the product's degree, so `secure_equal`'s `m = d·r` open is checked with no other change.

**Honest boundary (per the design — not over-claimed):**
- `n = 2t+1` (odd n, the honest-majority party count): NO RS redundancy at degree 2t → tampering is information-theoretically undetectable; **pinned** by `..._undetectable_at_n_eq_2t_plus_1` (mirrors WI-1's exact-t+1 pin). NOT faked.
- `n > 2t+1` (even n → 1 redundant share): Berlekamp–Welch detect-and-abort (`MpcError::Tampered`), correcting up to `e=⌊(n-2t-1)/2⌋`.

The old `tampered_share_flips_secure_equality_verdict_undetected` pin is now a POSITIVE detection test; + property tests over n. Filed **sq-ji5f**: robust *correction* at degree 2t needs `n≥2t+3` which the honest-majority constructor never provisions (records the 3 options); the n=2t+1 MAC fix stays WI-4 (sq-6d6g).

Gates: `cargo test -p sparq-mpc` 75 passed (debug+release); clippy -D warnings clean; fmt zero new diffs; wasm excludes mpc; no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)