### PR TITLE
deps: migrate quick-xml 0.37 → 0.40 (sq-8bhq, supersedes Dependabot #19)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,7 +2029,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf 0.3.3",
- "quick-xml",
+ "quick-xml 0.37.5",
  "thiserror 2.0.18",
 ]
 
@@ -2287,6 +2287,15 @@ name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
 ]
@@ -3124,7 +3133,7 @@ dependencies = [
  "json-event-parser",
  "memchr",
  "oxrdf 0.3.3",
- "quick-xml",
+ "quick-xml 0.37.5",
  "thiserror 2.0.18",
 ]
 
@@ -3212,7 +3221,7 @@ dependencies = [
  "oxrdf 0.3.3",
  "oxrdfxml",
  "oxttl 0.2.3",
- "quick-xml",
+ "quick-xml 0.40.1",
  "rustc-hash 2.1.2",
  "serde_json",
  "spargebra",
@@ -3265,7 +3274,7 @@ dependencies = [
  "i_overlay",
  "oxrdf 0.3.3",
  "proj4rs",
- "quick-xml",
+ "quick-xml 0.40.1",
  "rand 0.9.4",
  "rstar 0.13.0",
  "rustc-hash 2.1.2",

--- a/crates/sparq-conformance/Cargo.toml
+++ b/crates/sparq-conformance/Cargo.toml
@@ -31,5 +31,5 @@ spargebra.workspace = true
 rustc-hash.workspace = true
 # Expected-result parsing only: RDF/XML result sets (.rdf) and SPARQL XML results (.srx).
 oxrdfxml = { version = "0.2", features = ["rdf-12"] }
-quick-xml = "0.37"
+quick-xml = "0.40"
 serde_json = "1"

--- a/crates/sparq-conformance/src/results.rs
+++ b/crates/sparq-conformance/src/results.rs
@@ -6,9 +6,27 @@ use crate::rdf::{as_node, MiniGraph};
 use oxrdf::{Literal, NamedNode, Term};
 use quick_xml::events::Event;
 use quick_xml::Reader;
+use std::borrow::Cow;
 use std::path::Path;
 
 const RS: &str = "http://www.w3.org/2001/sw/DataAccess/tests/result-set#";
+
+// [OPUS-4.8] quick-xml 0.40 removed `BytesText::unescape()` / deprecated
+// `Attribute::unescape_value()`. Both used to decode + resolve the XML
+// predefined entities (`&amp;`/`&lt;`/`&gt;`/`&apos;`/`&quot;` and numeric
+// char-refs) without applying attribute-value whitespace folding. We replicate
+// that EXACT semantics here — `quick_xml::escape::unescape` is
+// `unescape_with(resolve_predefined_entity)`, the same resolver the old
+// methods called — so the SPARQL-XML-results parse path is byte-for-byte
+// unchanged (CONFORMANCE-CRITICAL: this file feeds the W3C ratchet). We
+// deliberately do NOT switch to 0.40's `normalized_value`/`xml_content`, which
+// would add AVN whitespace folding / EOL normalization the old path never did.
+fn unescape_utf8(raw: &[u8]) -> Result<String, String> {
+    let s = std::str::from_utf8(raw).map_err(|e| e.to_string())?;
+    quick_xml::escape::unescape(s)
+        .map(Cow::into_owned)
+        .map_err(|e| e.to_string())
+}
 
 /// One solution: `(variable name, bound term)` pairs.
 pub type Binding = Vec<(String, Term)>;
@@ -232,7 +250,7 @@ fn parse_srx(path: &Path) -> Result<Expected, String> {
                         let k = std::str::from_utf8(a.key.as_ref()).ok()?;
                         // Matches both `datatype` and `xml:lang`-style keys.
                         if k == key || k.ends_with(&format!(":{key}")) {
-                            Some(a.unescape_value().ok()?.into_owned())
+                            Some(unescape_utf8(&a.value).ok()?)
                         } else {
                             None
                         }
@@ -277,7 +295,12 @@ fn parse_srx(path: &Path) -> Result<Expected, String> {
                 }
             }
             Event::Text(t) => {
-                let s = t.unescape().map_err(|e| e.to_string())?.into_owned();
+                // [OPUS-4.8] 0.40: `decode()` (no EOL normalization, matching the
+                // old `unescape`) then resolve predefined entities — see `unescape_utf8`.
+                let decoded = t.decode().map_err(|e| e.to_string())?;
+                let s = quick_xml::escape::unescape(&decoded)
+                    .map_err(|e| e.to_string())?
+                    .into_owned();
                 if in_boolean {
                     boolean = Some(s.trim() == "true");
                 } else if let Some(v) = cur_val.as_mut() {

--- a/crates/sparq-geo/Cargo.toml
+++ b/crates/sparq-geo/Cargo.toml
@@ -61,10 +61,11 @@ i_overlay = { version = "4.5.1, < 4.6.0", default-features = false }
 rstar = "0.13"
 # GML-SF geometry parsing (geo:gmlLiteral). A streaming XML reader, NOT a full
 # GML processor — we walk the OGC GML Simple-Features geometry subset GeoSPARQL
-# uses (Point/LineString/Polygon/Multi*). `quick-xml` is ALREADY in the lockfile
-# (transitive via oxrdf/spargebra), so this adds no new transitive crates;
-# `default-features = false` keeps it to the pull-parser with no serde. [OPUS-4.8]
-quick-xml = { version = "0.37", default-features = false }
+# uses (Point/LineString/Polygon/Multi*). `default-features = false` keeps it to
+# the pull-parser with no serde. The transitive oxigraph stack (oxrdfxml /
+# sparesults) still pins quick-xml 0.37, so this 0.40 requirement currently
+# resolves as a second copy in the lockfile until those upstreams bump. [OPUS-4.8]
+quick-xml = { version = "0.40", default-features = false }
 # Behind the `reproject` feature: pure-Rust proj4 (NOT the C `proj` binding —
 # the workspace's pure-Rust constraint holds). One transitive dep (thiserror).
 proj4rs = { version = "0.1", optional = true }

--- a/crates/sparq-geo/README.md
+++ b/crates/sparq-geo/README.md
@@ -46,8 +46,9 @@ fragment in the OGC *GML Simple-Features* profile. No maintained pure-Rust GML
 *geometry* parser crate exists (the georust stack covers WKT/WKB/GeoJSON but
 not GML), so per AGENTS.md "Upstream blockers" this crate ships a focused
 GML-SF geometry parser in [`src/gml.rs`](src/gml.rs) built on
-[`quick-xml`](https://crates.io/crates/quick-xml) (already in the lockfile —
-no new transitive crates). It walks only the geometry subset GeoSPARQL uses
+[`quick-xml`](https://crates.io/crates/quick-xml) (the same pull-parser the
+oxigraph stack already pulls transitively, here pinned to a newer major — see
+the `Cargo.toml` note). It walks only the geometry subset GeoSPARQL uses
 (Point/LineString/Polygon/Multi\*) and maps it onto the SAME
 `geo_types::Geometry<f64>` + `Crs` the WKT path produces, so every downstream
 `geof:` function and the `GeoIndex` work unchanged. The parser is namespace-

--- a/crates/sparq-geo/README.md
+++ b/crates/sparq-geo/README.md
@@ -47,8 +47,8 @@ fragment in the OGC *GML Simple-Features* profile. No maintained pure-Rust GML
 not GML), so per AGENTS.md "Upstream blockers" this crate ships a focused
 GML-SF geometry parser in [`src/gml.rs`](src/gml.rs) built on
 [`quick-xml`](https://crates.io/crates/quick-xml) (the same pull-parser the
-oxigraph stack already pulls transitively, here pinned to a newer major — see
-the `Cargo.toml` note). It walks only the geometry subset GeoSPARQL uses
+oxigraph stack already pulls transitively, here on a newer breaking 0.x — 0.40,
+quick-xml is pre-1.0 — see the `Cargo.toml` note). It walks only the geometry subset GeoSPARQL uses
 (Point/LineString/Polygon/Multi\*) and maps it onto the SAME
 `geo_types::Geometry<f64>` + `Crs` the WKT path produces, so every downstream
 `geof:` function and the `GeoIndex` work unchanged. The parser is namespace-

--- a/crates/sparq-geo/src/gml.rs
+++ b/crates/sparq-geo/src/gml.rs
@@ -53,6 +53,21 @@ use geo_types::{
 use quick_xml::events::Event;
 use quick_xml::reader::Reader;
 
+// [OPUS-4.8] quick-xml 0.40 removed `BytesText::unescape()` and deprecated
+// `Attribute::unescape_value()`. Both used to decode + resolve the XML
+// predefined entities without attribute-value whitespace folding. We replicate
+// that exact behaviour with `quick_xml::escape::unescape`
+// (= `unescape_with(resolve_predefined_entity)`, the resolver the old methods
+// used), rather than 0.40's `normalized_value`/`xml_content` which would add
+// AVN whitespace folding / EOL normalization the old GML path never applied.
+fn unescape_attr_value(raw: &[u8]) -> Result<String, GeoError> {
+    let s =
+        std::str::from_utf8(raw).map_err(|e| GeoError::Parse(format!("GML attr error: {e}")))?;
+    quick_xml::escape::unescape(s)
+        .map(|c| c.into_owned())
+        .map_err(|e| GeoError::Parse(format!("GML attr error: {e}")))
+}
+
 /// Parses a `geo:gmlLiteral` LEXICAL FORM (the literal's string value, without
 /// the `^^geo:gmlLiteral` datatype): a GML-SF geometry element.
 ///
@@ -140,9 +155,7 @@ fn parse_root(lex: &str) -> Result<Node, GeoError> {
                 let mut crs = inherited_crs.clone();
                 for attr in e.attributes().flatten() {
                     if local_name(attr.key.as_ref()) == "srsname" {
-                        let val = attr
-                            .unescape_value()
-                            .map_err(|err| GeoError::Parse(format!("GML attr error: {err}")))?;
+                        let val = unescape_attr_value(&attr.value)?;
                         crs = crs_from_srs_name(&val);
                         inherited_crs = crs.clone();
                     }
@@ -151,8 +164,12 @@ fn parse_root(lex: &str) -> Result<Node, GeoError> {
             }
             Ok(Event::Text(t)) => {
                 if let Some(top) = stack.last_mut() {
-                    let txt = t
-                        .unescape()
+                    // [OPUS-4.8] 0.40: decode (no EOL normalization, matching the old
+                    // `unescape`) then resolve predefined entities.
+                    let decoded = t
+                        .decode()
+                        .map_err(|err| GeoError::Parse(format!("GML text error: {err}")))?;
+                    let txt = quick_xml::escape::unescape(&decoded)
                         .map_err(|err| GeoError::Parse(format!("GML text error: {err}")))?;
                     if !top.text.is_empty() {
                         top.text.push(' ');
@@ -175,9 +192,7 @@ fn parse_root(lex: &str) -> Result<Node, GeoError> {
                 let mut crs = inherited_crs.clone();
                 for attr in e.attributes().flatten() {
                     if local_name(attr.key.as_ref()) == "srsname" {
-                        let val = attr
-                            .unescape_value()
-                            .map_err(|err| GeoError::Parse(format!("GML attr error: {err}")))?;
+                        let val = unescape_attr_value(&attr.value)?;
                         crs = crs_from_srs_name(&val);
                         inherited_crs = crs.clone();
                     }


### PR DESCRIPTION
Migrates quick-xml to 0.40.1 (the breaking change: `BytesText::unescape()` removed). Usages in `sparq-geo/src/gml.rs` + `sparq-conformance/src/results.rs` updated to the 0.40 unescape API. **W3C SPARQL conformance 1229/1229 before AND after** (no regression — results.rs parses the SPARQL XML results format); geo green; full-workspace clippy + test green. Supersedes Dependabot #19 (auto-closes on merge).

(sha2 0.11 / sq-jkcj is NOT in this PR — it's blocked upstream: a dev-dep, rdf-canon 0.15.3, pins digest 0.10. #17 closed, bead labelled blocked-upstream.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)