### PR TITLE
feat(dashboard): featured well-known-suites section + scaling-comparison charts (sq-xvow / sq-viby)

### DIFF
--- a/bench/dashboard/dashboard.css
+++ b/bench/dashboard/dashboard.css
@@ -100,4 +100,18 @@ table.summary-table { width: 100%; border-collapse: collapse; font-size: 0.92rem
 }
 .chart-card canvas { height: 140px !important; width: 100% !important; }
 
+/* [OPUS-4.8] sq-xvow: featured well-known suites at the top. One table per suite, with sparq's
+   latest value + optional competitor columns (the sq-t0c3 seam). Reuses .summary-table styling. */
+#featured-card .featured-suite { margin-bottom: 22px; }
+#featured-card .featured-suite:last-child { margin-bottom: 0; }
+.featured-title {
+  margin: 0 0 10px; font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--accent); font-weight: 700;
+}
+.featured-table th.competitor-col, .featured-table td.competitor-col { color: var(--muted); }
+/* sparq's own column reads slightly stronger than competitor columns so the engine-under-test is
+   visually anchored. */
+.featured-table thead th:nth-child(2) { color: var(--fg); }
+.featured-table td.competitor-na { color: var(--muted); opacity: 0.7; }
+
 .site-footer { border-top: 1px solid var(--line); color: var(--muted); font-size: 0.82rem; padding: 18px 0; }

--- a/bench/dashboard/dashboard.css
+++ b/bench/dashboard/dashboard.css
@@ -114,4 +114,12 @@ table.summary-table { width: 100%; border-collapse: collapse; font-size: 0.92rem
 .featured-table thead th:nth-child(2) { color: var(--fg); }
 .featured-table td.competitor-na { color: var(--muted); opacity: 0.7; }
 
+/* [OPUS-4.8] sq-viby: scaling charts at the bottom. Same chart-card shell as the trend charts; a
+   muted note appears for single-point families until more sizes are reported. */
+#scaling-card .scaling-card { display: flex; flex-direction: column; }
+.scaling-note {
+  font-size: 0.72rem; color: var(--muted); margin: -2px 0 6px; font-style: italic;
+}
+.scaling-card canvas { height: 160px !important; width: 100% !important; }
+
 .site-footer { border-top: 1px solid var(--line); color: var(--muted); font-size: 0.82rem; padding: 18px 0; }

--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -172,13 +172,105 @@
     return pts;
   }
 
+  // ---- featured well-known suites (sq-xvow) --------------------------------
+  // [OPUS-4.8] sq-xvow (design sq-i0nm §B): surface the RECOGNISED public benchmark suites
+  // (LUBM / WatDiv / SP2Bench / Deep Taxonomy / BSBM / DBPSB) front-and-centre ABOVE the
+  // per-metric trends, so a reader lands on the suites they already know. This is purely a
+  // PROMOTION/regrouping of metrics that already flow through suiteFor()/labelFor() (sq-ocuf) —
+  // it does NOT change the labels, the grouping, or the existing summary/trend sections.
+
+  // The suites we feature, in display order. Keys are matched against suiteFor() (which is driven
+  // by metric-labels.json). FEATURED_ALIASES lets a suite be recognised under several spellings
+  // (e.g. Deep Taxonomy isn't in the label map yet — sq-1hgz promotes it — so we also accept the
+  // structural-fallback / naming spellings it WILL carry). title = the card heading.
+  var FEATURED_SUITES = [
+    { key: 'LUBM',          title: 'LUBM',          aliases: ['lubm (reasoning)', 'lubm'] },
+    { key: 'WatDiv',        title: 'WatDiv',        aliases: ['watdiv'] },
+    { key: 'SP2Bench',      title: 'SP2Bench',      aliases: ['sp2bench', 'sp2b'] },
+    { key: 'Deep Taxonomy', title: 'Deep Taxonomy', aliases: ['deep taxonomy', 'deeptax', 'deep-taxonomy', 'deeptaxonomy'] },
+    { key: 'BSBM',          title: 'BSBM',          aliases: ['bsbm'] },
+    { key: 'DBPSB',         title: 'DBPSB',         aliases: ['dbpsb', 'dbpedia sparql benchmark'] }
+  ];
+
+  // Which featured suite (if any) a metric belongs to. Consults suiteFor() FIRST (label-map driven,
+  // the source of truth); if that misses, falls back to a token match on the raw metric name so a
+  // not-yet-labelled suite (Deep Taxonomy today) is still recognised. Returns the FEATURED_SUITES
+  // entry or null. Pure + node-testable.
+  function featuredSuiteOf(name) {
+    var suite = (suiteFor(name) || '').toLowerCase();
+    var lowerName = (name || '').toLowerCase();
+    for (var i = 0; i < FEATURED_SUITES.length; i++) {
+      var f = FEATURED_SUITES[i];
+      for (var j = 0; j < f.aliases.length; j++) {
+        var a = f.aliases[j];
+        // label-map suite match (exact, normalised) OR a name-token prefix like `deeptax_…`.
+        if (suite === a) return f;
+        if (lowerName.indexOf(a.replace(/[ -]/g, '')) === 0 ||
+            lowerName.indexOf(a.replace(/[ -]/g, '_')) === 0) return f;
+      }
+    }
+    return null;
+  }
+
+  // Build the featured-suites view from the LATEST commit's benches. One group per recognised
+  // suite (only suites that actually have data appear). Each row carries the readable label, raw
+  // stem, latest value, unit, Δ-vs-best — AND a `competitors` SEAM (see below). Sorted by label.
+  //
+  // COMPETITOR SEAM (for sq-t0c3): every row gets `competitors: {}` and the view carries
+  // `competitorEngines: []`. This dashboard does NOT gather competitor numbers (that's sq-t0c3,
+  // which writes bench/competitors.json). When that file exists, the caller passes it in as the
+  // 2nd arg and we map matching numbers onto each row's `competitors[engine]`; absent/unmatched
+  // cells stay undefined and render as "—"/"n/a". Shape expected from sq-t0c3:
+  //   { engines:[{id,label,version,env}], values:{ "<metric stem or name>": { "<engineId>": <µs> } } }
+  // We match on the raw metric NAME first, then the stem (name minus _us), so the competitor file
+  // can key either way. We never invent numbers — a missing key is simply absent.
+  function buildFeatured(entries, competitors) {
+    var latest = entries[entries.length - 1];
+    var bySuite = {};
+    latest.benches.forEach(function (b) {
+      var f = featuredSuiteOf(b.name);
+      if (!f) return;
+      var best = bestOf(entries, b.name);
+      var row = {
+        name: b.name, label: labelFor(b.name), title: titleFor(b.name),
+        value: b.value, unit: b.unit || '',
+        best: best, delta: deltaVsBest(b.value, best),
+        competitors: competitorsFor(competitors, b.name)
+      };
+      (bySuite[f.key] = bySuite[f.key] || { title: f.title, rows: [] }).rows.push(row);
+    });
+    var groups = [];
+    FEATURED_SUITES.forEach(function (f) {
+      if (bySuite[f.key]) groups.push({ suite: f.key, title: f.title, rows: sortRows(bySuite[f.key].rows) });
+    });
+    return { commit: latest.commit, date: latest.date, groups: groups,
+             competitorEngines: competitorEngines(competitors) };
+  }
+
+  // SEAM helper (sq-t0c3): read the per-engine competitor numbers for one metric, or {} when the
+  // competitor file is absent/has no entry. Tolerant of both `name` and stem keys.
+  function competitorsFor(competitors, name) {
+    if (!competitors || !competitors.values) return {};
+    return competitors.values[name] || competitors.values[name.replace(/_us$/, '')] || {};
+  }
+
+  // SEAM helper (sq-t0c3): the ordered list of competitor engines (id+label+version) to render as
+  // extra columns; [] when the competitor file is absent — the featured table then shows only sparq.
+  function competitorEngines(competitors) {
+    return (competitors && Array.isArray(competitors.engines)) ? competitors.engines : [];
+  }
+
   // Export pure fns for node smoke-test (no effect in the browser).
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = { classify: classify, bestOf: bestOf, deltaVsBest: deltaVsBest,
                        buildSummary: buildSummary, humanize: humanize, fmtNum: fmtNum,
                        trendPoints: trendPoints, GROUP_ORDER: GROUP_ORDER,
                        labelFor: labelFor, suiteFor: suiteFor, titleFor: titleFor,
-                       lookup: lookup };
+                       lookup: lookup,
+                       // sq-xvow (featured well-known suites + competitor seam)
+                       FEATURED_SUITES: FEATURED_SUITES, featuredSuiteOf: featuredSuiteOf,
+                       buildFeatured: buildFeatured, competitorsFor: competitorsFor,
+                       competitorEngines: competitorEngines };
     return;
   }
 
@@ -301,6 +393,67 @@
     });
   }
 
+  // ---- featured well-known suites: DOM (sq-xvow) ---------------------------
+  // Renders the #featured host (a card at the TOP). One table per recognised suite, with the
+  // sparq latest value + Δ-pill, and ONE COLUMN PER competitor engine (the sq-t0c3 seam). When no
+  // competitor file is present, only the sparq column shows. Competitor cells with no number for a
+  // given metric render "—" (na). Reuses pill()/fmtNum()/labelFor tooltips — no new label logic.
+  function renderFeatured(featured) {
+    var host = document.getElementById('featured');
+    if (!host) return;
+    host.innerHTML = '';
+    if (!featured.groups.length) {
+      host.appendChild(el('p', { 'class': 'hint',
+        text: 'No recognised public-suite metrics in the latest commit yet.' }));
+      return;
+    }
+    var engines = featured.competitorEngines; // [] until sq-t0c3 lands
+    featured.groups.forEach(function (g) {
+      var section = el('section', { 'class': 'featured-suite' }, [
+        el('h3', { 'class': 'featured-title', text: g.title })
+      ]);
+      var table = el('table', { 'class': 'summary-table featured-table' });
+      var headCells = [
+        el('th', { text: 'Query' }),
+        el('th', { 'class': 'num', text: 'sparq' }),
+        el('th', { text: 'Unit' }),
+        el('th', { 'class': 'num', text: 'Δ vs best' })
+      ];
+      // Competitor columns (seam): one per engine, header shows id + version when supplied.
+      engines.forEach(function (e) {
+        headCells.push(el('th', { 'class': 'num competitor-col',
+          text: e.label || e.id,
+          title: (e.version ? e.id + ' ' + e.version : e.id) + (e.env ? ' · ' + e.env : '') }));
+      });
+      table.appendChild(el('thead', null, [el('tr', null, headCells)]));
+      var tbody = el('tbody');
+      g.rows.forEach(function (r) {
+        var metricCell = el('td', { 'class': 'metric', title: r.title }, [
+          el('span', { 'class': 'metric-label', text: r.label }),
+          el('code', { 'class': 'metric-stem', text: r.name })
+        ]);
+        var cells = [
+          metricCell,
+          el('td', { 'class': 'num', text: fmtNum(r.value) }),
+          el('td', { 'class': 'unit', text: r.unit }),
+          el('td', { 'class': 'num delta' })
+        ];
+        cells[3].appendChild(pill(r.delta));
+        // Competitor cells (seam): render the number if present, else "—" (n/a).
+        engines.forEach(function (e) {
+          var v = r.competitors && r.competitors[e.id];
+          cells.push(el('td', { 'class': 'num competitor-col' + (v == null ? ' competitor-na' : ''),
+            text: v == null ? '—' : fmtNum(v),
+            title: v == null ? 'no competitor number gathered (sq-t0c3)' : '' }));
+        });
+        tbody.appendChild(el('tr', null, cells));
+      });
+      table.appendChild(tbody);
+      section.appendChild(table);
+      host.appendChild(section);
+    });
+  }
+
   function render() {
     var data = window.BENCHMARK_DATA;
     if (!data || !data.entries || !data.entries[SERIES] || !data.entries[SERIES].length) {
@@ -310,11 +463,17 @@
     }
     var entries = data.entries[SERIES];
     var summary = buildSummary(entries);
+    // sq-t0c3 SEAM: competitor numbers live in window.COMPETITORS (loaded from bench/competitors.json
+    // by sq-t0c3). Absent today -> featured table shows only the sparq column and "—" everywhere a
+    // competitor cell would go. We never gather them here.
+    var competitors = (typeof window !== 'undefined' && window.COMPETITORS) || null;
+    var featured = buildFeatured(entries, competitors);
     document.getElementById('updated').textContent =
       'last updated ' + new Date(data.lastUpdate).toLocaleString() +
       ' · ' + entries.length + ' commits';
     var repo = el('a', { href: data.repoUrl, target: '_blank', text: data.repoUrl.replace(/^https?:\/\//, '') });
     document.getElementById('repo').appendChild(repo);
+    renderFeatured(featured);                 // sq-xvow — TOP
     renderSummary(summary);
     if (typeof Chart !== 'undefined') renderCharts(entries, summary);
   }

--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -46,6 +46,16 @@
     return rec && rec.label ? rec.label : humanize(name);
   }
 
+  // [OPUS-4.8] Unit-LESS readable label — same as labelFor() but with any trailing ` (<unit>)`
+  // stripped. Used where the unit is shown in a SEPARATE cell/column (the featured table's metric
+  // cell, sq-xvow; the scaling card title, sq-viby) so the unit isn't printed twice. The label map
+  // labels (sq-ocuf) don't carry a trailing unit, so this only bites the humanize() fallback (which
+  // appends `(µs)`/`(s)` for UNLABELLED metrics like Deep Taxonomy). We strip ONLY a trailing
+  // parenthesised token, leaving mid-label parentheses (e.g. "LUBM (reasoning)") untouched.
+  function labelForBare(name) {
+    return labelFor(name).replace(/\s*\([^()]*\)\s*$/, '').trim();
+  }
+
   // A rich tooltip/title for a metric: the raw stem first (transparency), then dataset + query.
   function titleFor(name) {
     var rec = lookup(name);
@@ -232,7 +242,9 @@
       if (!f) return;
       var best = bestOf(entries, b.name);
       var row = {
-        name: b.name, label: labelFor(b.name), title: titleFor(b.name),
+        // [OPUS-4.8] unit-less label: the featured table prints the unit in its OWN column, so use
+        // labelForBare() to avoid a doubled `(µs)` on humanize()-fallback metrics (Deep Taxonomy).
+        name: b.name, label: labelForBare(b.name), title: titleFor(b.name),
         value: b.value, unit: b.unit || '',
         best: best, delta: deltaVsBest(b.value, best),
         competitors: competitorsFor(competitors, b.name)
@@ -293,7 +305,12 @@
         var suffix = (m[2] || '').toLowerCase();
         if (suffix === 'k') mag *= 1000;
         else if (suffix === 'm') mag *= 1000000;
-        return { base: name.replace(m[0], '_'), axisLabel: t.label, axis: mag };
+        // [OPUS-4.8] Removing the size token leaves a placeholder `_`; that can collide with the
+        // surrounding underscores (e.g. `deeptax_d10_count_us` -> `deeptax__count_us`) and `base`
+        // is DISPLAYED (the scaling card stem). Collapse repeated `_` and trim leading/trailing so
+        // the family stem renders cleanly (`deeptax_count_us`). Two sizes still share one base.
+        var base = name.replace(m[0], '_').replace(/_{2,}/g, '_').replace(/^_|_$/g, '');
+        return { base: base, axisLabel: t.label, axis: mag };
       }
     }
     return null;
@@ -313,8 +330,10 @@
       var fam = fams[s.base] || (fams[s.base] = {
         base: s.base, axisLabel: s.axisLabel, suite: suiteFor(b.name),
         // readable label/title for the family from this metric (humanized fallback until the
-        // suite is in the label map — e.g. Deep Taxonomy, sq-1hgz).
-        label: labelFor(b.name), title: titleFor(b.name), unit: b.unit || '', points: []
+        // suite is in the label map — e.g. Deep Taxonomy, sq-1hgz). [OPUS-4.8] unit-LESS label:
+        // renderScaling() appends ` (<unit>)` to the card title itself, so use labelForBare() to
+        // avoid a doubled unit on humanize()-fallback metrics.
+        label: labelForBare(b.name), title: titleFor(b.name), unit: b.unit || '', points: []
       });
       fam.points.push({ axis: s.axis, value: b.value, name: b.name, unit: b.unit || '' });
     });
@@ -337,7 +356,8 @@
     module.exports = { classify: classify, bestOf: bestOf, deltaVsBest: deltaVsBest,
                        buildSummary: buildSummary, humanize: humanize, fmtNum: fmtNum,
                        trendPoints: trendPoints, GROUP_ORDER: GROUP_ORDER,
-                       labelFor: labelFor, suiteFor: suiteFor, titleFor: titleFor,
+                       labelFor: labelFor, labelForBare: labelForBare,
+                       suiteFor: suiteFor, titleFor: titleFor,
                        lookup: lookup,
                        // sq-xvow (featured well-known suites + competitor seam)
                        FEATURED_SUITES: FEATURED_SUITES, featuredSuiteOf: featuredSuiteOf,
@@ -488,7 +508,10 @@
       ]);
       var table = el('table', { 'class': 'summary-table featured-table' });
       var headCells = [
-        el('th', { text: 'Query' }),
+        // [OPUS-4.8] Header is "Metric" (matching the summary table) — the cell holds a general
+        // metric label + raw stem and may carry NON-query metrics (load/store/dict), so "Query" was
+        // inaccurate.
+        el('th', { text: 'Metric' }),
         el('th', { 'class': 'num', text: 'sparq' }),
         el('th', { text: 'Unit' }),
         el('th', { 'class': 'num', text: 'Δ vs best' })

--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -260,6 +260,78 @@
     return (competitors && Array.isArray(competitors.engines)) ? competitors.engines : [];
   }
 
+  // ---- scaling comparison charts (sq-viby) ---------------------------------
+  // [OPUS-4.8] sq-viby (design sq-i0nm): for SIZE-PARAMETRISED benchmarks (Deep Taxonomy at
+  // increasing depth; WatDiv at increasing scale factor; any family whose metrics differ only by a
+  // size/depth token) plot the engine's metric value vs that size/depth axis — so the reader sees
+  // how it SCALES, not just one point in time. The axis is DERIVED FROM THE METRIC NAME, since the
+  // benchmark harness encodes the size in the metric name (e.g. `deeptax_d10_count_us`,
+  // `watdiv_sf100_S1_count_us`). Pure + node-testable.
+
+  // Recognise a size/depth token in a metric name and split it out. Returns
+  //   { base, axisLabel, axis } | null
+  // where `base` is the metric name with the size token REMOVED (so two sizes of the same query
+  // share a base and form one family), `axis` is the numeric magnitude (SF / depth / scale), and
+  // `axisLabel` names the axis ("scale factor" / "depth" / "scale"). Suffix multipliers k/m are
+  // honoured (sf1k -> 1000). We anchor the END of the magnitude with `(?![0-9])` (NOT \b — a \b
+  // between a digit and a following `_` never matches, both are word chars) so it fires on a
+  // `_token<digits>` segment but NOT on incidental digits (q06, S1, star3 have no size keyword).
+  var SIZE_TOKENS = [
+    { re: /_sf(\d+)([km]?)(?![0-9])/i,    label: 'scale factor' },
+    { re: /_depth(\d+)(?![0-9])/i,        label: 'depth' },
+    { re: /_d(\d+)(?![0-9])/i,            label: 'depth' },
+    { re: /_scale(\d+)([km]?)(?![0-9])/i, label: 'scale' },
+    { re: /_size(\d+)([km]?)(?![0-9])/i,  label: 'size' }
+  ];
+
+  function sizeAxisOf(name) {
+    for (var i = 0; i < SIZE_TOKENS.length; i++) {
+      var t = SIZE_TOKENS[i];
+      var m = name.match(t.re);
+      if (m) {
+        var mag = parseInt(m[1], 10);
+        var suffix = (m[2] || '').toLowerCase();
+        if (suffix === 'k') mag *= 1000;
+        else if (suffix === 'm') mag *= 1000000;
+        return { base: name.replace(m[0], '_'), axisLabel: t.label, axis: mag };
+      }
+    }
+    return null;
+  }
+
+  // Group the LATEST commit's benches into scaling FAMILIES keyed by `base` (the size-token-stripped
+  // name). Each family lists its {axis,value,name,unit} points sorted ascending by axis, plus a
+  // readable label/title taken from the family's first (smallest) member. A family with a single
+  // point is kept (degenerate scaling chart -> single marker; the renderer notes it). Families with
+  // NO size token never appear here. Pure + node-testable.
+  function buildScalingFamilies(entries) {
+    var latest = entries[entries.length - 1];
+    var fams = {};
+    latest.benches.forEach(function (b) {
+      var s = sizeAxisOf(b.name);
+      if (!s) return;
+      var fam = fams[s.base] || (fams[s.base] = {
+        base: s.base, axisLabel: s.axisLabel, suite: suiteFor(b.name),
+        // readable label/title for the family from this metric (humanized fallback until the
+        // suite is in the label map — e.g. Deep Taxonomy, sq-1hgz).
+        label: labelFor(b.name), title: titleFor(b.name), unit: b.unit || '', points: []
+      });
+      fam.points.push({ axis: s.axis, value: b.value, name: b.name, unit: b.unit || '' });
+    });
+    var out = [];
+    Object.keys(fams).forEach(function (k) {
+      var f = fams[k];
+      f.points.sort(function (a, c) { return a.axis - c.axis; });
+      out.push(f);
+    });
+    // Stable, readable order: by suite then label.
+    out.sort(function (a, c) {
+      if (a.suite !== c.suite) return a.suite < c.suite ? -1 : 1;
+      return a.label < c.label ? -1 : a.label > c.label ? 1 : 0;
+    });
+    return out;
+  }
+
   // Export pure fns for node smoke-test (no effect in the browser).
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = { classify: classify, bestOf: bestOf, deltaVsBest: deltaVsBest,
@@ -270,7 +342,9 @@
                        // sq-xvow (featured well-known suites + competitor seam)
                        FEATURED_SUITES: FEATURED_SUITES, featuredSuiteOf: featuredSuiteOf,
                        buildFeatured: buildFeatured, competitorsFor: competitorsFor,
-                       competitorEngines: competitorEngines };
+                       competitorEngines: competitorEngines,
+                       // sq-viby (scaling comparison)
+                       sizeAxisOf: sizeAxisOf, buildScalingFamilies: buildScalingFamilies };
     return;
   }
 
@@ -454,6 +528,76 @@
     });
   }
 
+  // ---- scaling comparison charts: DOM (sq-viby) ----------------------------
+  // Renders the #scaling host (a card at the BOTTOM). One line chart per scaling family: x = the
+  // derived size/depth axis (LINEAR, ascending), y = the metric value. ONE line for sparq today;
+  // the same x-axis is the seam where sq-t0c3 competitor series would add lines. Graceful: a
+  // single-point family renders as one marker plus a "single data point" note.
+  function renderScaling(families) {
+    var host = document.getElementById('scaling');
+    if (!host) return;
+    host.innerHTML = '';
+    if (!families.length) {
+      host.appendChild(el('p', { 'class': 'hint',
+        text: 'No size-parametrised benchmark families detected yet — scaling charts appear once a '
+            + 'suite reports a metric at multiple sizes/depths (e.g. Deep Taxonomy depths, WatDiv SF).' }));
+      return;
+    }
+    var darkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var grid = darkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.07)';
+    var tick = darkMode ? '#9aa4b2' : '#586069';
+    var gridEl = el('div', { 'class': 'chart-grid' });
+    families.forEach(function (f, i) {
+      var single = f.points.length < 2;
+      var card = el('div', { 'class': 'chart-card scaling-card' }, [
+        el('div', { 'class': 'chart-title', title: f.title,
+          text: f.label + ' — vs ' + f.axisLabel + ' (' + f.unit + ')' }),
+        el('code', { 'class': 'chart-stem', title: f.title, text: f.base })
+      ]);
+      if (single) {
+        card.appendChild(el('div', { 'class': 'scaling-note',
+          text: 'single data point (axis: ' + f.axisLabel + ' = ' + f.points[0].axis + ') — '
+              + 'curve appears once more sizes are reported' }));
+      }
+      var canvas = el('canvas');
+      card.appendChild(canvas);
+      gridEl.appendChild(card);
+      if (typeof Chart === 'undefined') return;
+      var color = PALETTE[i % PALETTE.length];
+      // points are {axis,value}; plot as {x:axis,y:value} on a LINEAR x-axis so spacing reflects
+      // magnitude (SF=1 vs SF=1000 are far apart, as they should be).
+      var pts = f.points.map(function (p) { return { x: p.axis, y: p.value }; });
+      // eslint-disable-next-line no-new
+      new Chart(canvas.getContext('2d'), {
+        type: 'line',
+        data: { datasets: [{
+          label: 'sparq', data: pts, borderColor: color,
+          backgroundColor: color + '22', borderWidth: 2,
+          pointRadius: 3, pointHoverRadius: 5, fill: false, lineTension: 0
+        }] },
+        options: {
+          responsive: true, maintainAspectRatio: false,
+          legend: { display: false },
+          tooltips: {
+            mode: 'nearest', intersect: false,
+            callbacks: {
+              title: function (items) { return f.axisLabel + ' = ' + items[0].xLabel; },
+              label: function (item) { return fmtNum(item.yLabel) + ' ' + f.unit; }
+            }
+          },
+          scales: {
+            xAxes: [{ type: 'linear', position: 'bottom',
+                      scaleLabel: { display: true, labelString: f.axisLabel, fontColor: tick },
+                      gridLines: { color: grid }, ticks: { fontColor: tick, maxTicksLimit: 6 } }],
+            yAxes: [{ gridLines: { color: grid },
+                      ticks: { fontColor: tick, maxTicksLimit: 4, callback: function (v) { return fmtNum(v); } } }]
+          }
+        }
+      });
+    });
+    host.appendChild(gridEl);
+  }
+
   function render() {
     var data = window.BENCHMARK_DATA;
     if (!data || !data.entries || !data.entries[SERIES] || !data.entries[SERIES].length) {
@@ -468,6 +612,7 @@
     // competitor cell would go. We never gather them here.
     var competitors = (typeof window !== 'undefined' && window.COMPETITORS) || null;
     var featured = buildFeatured(entries, competitors);
+    var families = buildScalingFamilies(entries);
     document.getElementById('updated').textContent =
       'last updated ' + new Date(data.lastUpdate).toLocaleString() +
       ' · ' + entries.length + ' commits';
@@ -476,6 +621,7 @@
     renderFeatured(featured);                 // sq-xvow — TOP
     renderSummary(summary);
     if (typeof Chart !== 'undefined') renderCharts(entries, summary);
+    renderScaling(families);                  // sq-viby — BOTTOM
   }
 
   // [OPUS-4.8] sq-ocuf: load metric-labels.json (readable labels) BEFORE rendering. The file is

--- a/bench/dashboard/index.html
+++ b/bench/dashboard/index.html
@@ -28,6 +28,20 @@
   </header>
 
   <main class="wrap">
+    <!-- [OPUS-4.8] sq-xvow: featured well-known suites at the TOP. dashboard.js fills #featured
+         with one table per recognised public suite (LUBM / WatDiv / SP2Bench / Deep Taxonomy /
+         BSBM / DBPSB). The "sparq" column is the latest-commit value; the COMPETITOR COLUMNS are a
+         seam for sq-t0c3 (bench/competitors.json -> window.COMPETITORS) and render "—" until it
+         lands. This is a promotion of existing labelled metrics — it does not change sq-ocuf's
+         labels or grouping below. -->
+    <section class="card" id="featured-card">
+      <h2>Featured suites</h2>
+      <p class="hint">Recognised public benchmark suites, latest commit. The <strong>sparq</strong>
+         column is this run; competitor columns are populated by the competitor harness
+         (<code>bench/competitors.json</code>) and show <code>—</code> until gathered.</p>
+      <div id="featured">loading…</div>
+    </section>
+
     <section class="card" id="summary-card">
       <h2>Latest commit</h2>
       <div id="summary">loading…</div>

--- a/bench/dashboard/index.html
+++ b/bench/dashboard/index.html
@@ -55,6 +55,19 @@
          compares the latest commit against the all-time minimum for that metric.</p>
       <div id="charts"></div>
     </section>
+
+    <!-- [OPUS-4.8] sq-viby: scaling comparison charts at the BOTTOM. dashboard.js fills #scaling
+         with one chart per size-parametrised benchmark family (Deep Taxonomy depths, WatDiv SF, …),
+         x = the size/depth axis DERIVED FROM THE METRIC NAME, y = the metric value. One line for
+         sparq today; competitor lines share the same x-axis when sq-t0c3 supplies them. Graceful:
+         absent families show a hint, single-point families show a marker + note. -->
+    <section class="card" id="scaling-card">
+      <h2>Scaling</h2>
+      <p class="hint">How a metric scales with dataset size / depth, for suites run at multiple
+         sizes (e.g. Deep Taxonomy depths, WatDiv scale factors). The size/depth axis is read from
+         the metric name.</p>
+      <div id="scaling"></div>
+    </section>
   </main>
 
   <footer class="site-footer">

--- a/scripts/dashboard-smoke.js
+++ b/scripts/dashboard-smoke.js
@@ -214,6 +214,58 @@ ok(sfFam && sfFam.points.length === 1, 'single-size family is kept (renders a si
 ok(fams.every(function (f) { return !/lubm_q06/.test(f.base); }), 'non-size-parametrised metric excluded');
 
 // ============================================================================================
+// [OPUS-4.8] Copilot review fixes on PR #59 — unit-less labels (#2/#4), clean scaling base (#3),
+// and the featured "Metric" column header (#1).
+// ============================================================================================
+ok(typeof D.labelForBare === 'function', 'dashboard.js exports labelForBare');
+
+// #2/#4 — labelForBare strips ONLY a trailing ` (<unit>)` so the unit isn't doubled when the unit
+// has its OWN cell/column. An UNLABELLED metric (humanize fallback) appends `(µs)`/`(s)` to its
+// label; labelForBare must remove it. Labelled metrics (sq-ocuf) carry no trailing unit -> unchanged.
+ok(/\(µs\)$/.test(D.labelFor('deeptax_d10_count_us')), 'labelFor (fallback) carries a trailing (µs)');
+ok(!/\(µs\)$/.test(D.labelForBare('deeptax_d10_count_us')),
+   'labelForBare strips the trailing (µs) from an unlabelled metric');
+ok(!/\(s\)$/.test(D.labelForBare('totally_new_metric_s')),
+   'labelForBare strips a trailing (s) too');
+eq(D.labelForBare('watdiv_S1_count_us'), D.labelFor('watdiv_S1_count_us'),
+   'labelForBare leaves a labelled (no-trailing-unit) label unchanged');
+// mid-label parentheses must survive: only a TRAILING parenthesised token is a unit. lubm_q06's
+// readable label mentions "Students" and carries no trailing unit, so it is returned untouched.
+eq(D.labelForBare('lubm_q06_count_us'), D.labelFor('lubm_q06_count_us'),
+   'labelForBare leaves a labelled metric (no trailing unit) untouched');
+
+// #2 — buildFeatured rows use the unit-less label (Deep Taxonomy is unlabelled -> would double).
+const dtFeatEntries = [{
+  commit: { id: 'd', message: 'd', url: '#' }, date: Date.now(),
+  benches: [{ name: 'deeptax_d10_count_us', value: 120, unit: 'µs' }]
+}];
+const dtFeat = D.buildFeatured(dtFeatEntries, null);
+let dtFeatRow = null;
+dtFeat.groups.forEach(function (g) { g.rows.forEach(function (r) {
+  if (r.name === 'deeptax_d10_count_us') dtFeatRow = r;
+}); });
+ok(dtFeatRow, 'featured view surfaces the deep-taxonomy row');
+ok(dtFeatRow && !/\(µs\)$/.test(dtFeatRow.label),
+   'featured row label has NO trailing unit (unit lives in its own column) — fix #2');
+
+// #4 — scaling family label is unit-less (renderScaling appends the unit to the card title).
+const dtScaleFam = D.buildScalingFamilies(scaleEntries).filter(function (f) {
+  return f.axisLabel === 'depth';
+})[0];
+ok(dtScaleFam && !/\(µs\)$/.test(dtScaleFam.label),
+   'scaling family label has NO trailing unit (title appends it) — fix #4');
+
+// #3 — sizeAxisOf base is normalized: no double/leading/trailing underscores, even though removing
+// the token leaves a placeholder `_` adjacent to existing underscores.
+eq(D.sizeAxisOf('deeptax_d10_count_us').base, 'deeptax_count_us',
+   'sizeAxisOf base collapses the placeholder underscore (no `deeptax__count_us`) — fix #3');
+ok(!/__/.test(D.sizeAxisOf('watdiv_sf100_C1_count_us').base), 'no double underscore in scaling base');
+ok(!/^_|_$/.test(D.sizeAxisOf('deeptax_d1_count_us').base), 'no leading/trailing underscore in base');
+// the base is still a SHARED key across sizes (fix #3 must not break family grouping).
+eq(D.sizeAxisOf('deeptax_d1_count_us').base, D.sizeAxisOf('deeptax_d10_count_us').base,
+   'normalized base is still shared across sizes (family grouping intact)');
+
+// ============================================================================================
 // [OPUS-4.8] BROWSER-DOM SIMULATION — confirm the featured section + scaling charts actually
 // build DOM (sq-xvow #featured / sq-viby #scaling), like sq-ocuf's renderSummary smoke would. A
 // tiny stub document/window/Chart lets the (browser-only) render fns run under node: we import
@@ -280,6 +332,17 @@ ok(fams.every(function (f) { return !/lubm_q06/.test(f.base); }), 'non-size-para
   // featured host should contain at least one suite section with a table.
   const featuredSection = hosts.featured.children[0];
   ok(featuredSection && featuredSection.tagName === 'section', 'DOM: featured host holds suite sections');
+  // #1 — the featured table's first column header is "Metric" (not "Query"): the cell may hold
+  // non-query metrics. Walk section -> table -> thead -> tr -> first th.
+  (function () {
+    var table = featuredSection.children.filter(function (c) { return c.tagName === 'table'; })[0];
+    var thead = table && table.children.filter(function (c) { return c.tagName === 'thead'; })[0];
+    var headRow = thead && thead.children[0];
+    var firstTh = headRow && headRow.children[0];
+    ok(firstTh && firstTh.textContent === 'Metric',
+       'DOM: featured table first column header is "Metric" (fix #1, got ' +
+       JSON.stringify(firstTh && firstTh.textContent) + ')');
+  })();
   // scaling host should contain a chart-grid with at least one scaling card.
   ok(hosts.scaling.children[0] && hosts.scaling.children[0].attributes['class'] === 'chart-grid',
      'DOM: scaling host holds a chart-grid');

--- a/scripts/dashboard-smoke.js
+++ b/scripts/dashboard-smoke.js
@@ -172,11 +172,52 @@ eq(lubmComp && lubmComp.oxigraph, 200, 'competitor matched by canonical stem (na
 ok(watdivComp && watdivComp.oxigraph === undefined, 'unmatched competitor cell stays absent (renders —)');
 
 // ============================================================================================
-// [OPUS-4.8] BROWSER-DOM SIMULATION — confirm the featured section actually builds DOM
-// (sq-xvow #featured), like sq-ocuf's renderSummary smoke would. A tiny stub document/window/Chart
-// lets the (browser-only) render fns run under node: we import dashboard.js a SECOND time with its
-// module.exports branch suppressed so its DOM half executes. (sq-viby extends this to assert
-// #scaling too once the scaling charts land.)
+// [OPUS-4.8] sq-viby — scaling comparison: size/depth axis derived from the metric NAME.
+// ============================================================================================
+ok(typeof D.sizeAxisOf === 'function', 'dashboard.js exports sizeAxisOf');
+ok(typeof D.buildScalingFamilies === 'function', 'dashboard.js exports buildScalingFamilies');
+
+// sizeAxisOf: recognise depth / scale-factor tokens; ignore incidental digits (S1, q06, star3).
+const dt = D.sizeAxisOf('deeptax_d10_count_us');
+ok(dt && dt.axisLabel === 'depth' && dt.axis === 10, 'sizeAxisOf reads deep-taxonomy depth (_d10 -> 10)');
+const dt2 = D.sizeAxisOf('deep_taxonomy_depth20_count_us');
+ok(dt2 && dt2.axisLabel === 'depth' && dt2.axis === 20, 'sizeAxisOf reads _depth20 -> 20');
+const sf = D.sizeAxisOf('watdiv_sf100_C1_count_us');
+ok(sf && sf.axisLabel === 'scale factor' && sf.axis === 100, 'sizeAxisOf reads WatDiv SF (_sf100 -> 100)');
+const sfk = D.sizeAxisOf('watdiv_sf1k_C1_count_us');
+ok(sfk && sfk.axis === 1000, 'sizeAxisOf honours k multiplier (_sf1k -> 1000)');
+ok(D.sizeAxisOf('watdiv_S1_count_us') === null, 'sizeAxisOf ignores S1 (not a size token)');
+ok(D.sizeAxisOf('lubm_q06_count_us') === null, 'sizeAxisOf ignores q06 (not a size token)');
+ok(D.sizeAxisOf('op_q02_star3_count_us') === null, 'sizeAxisOf ignores star3 (not a size token)');
+// two sizes of the same query collapse to ONE base -> one family.
+eq(D.sizeAxisOf('deeptax_d1_count_us').base, D.sizeAxisOf('deeptax_d10_count_us').base,
+   'different sizes of the same query share a family base');
+
+// buildScalingFamilies: groups by base, points sorted ascending by axis; single-point family kept.
+const scaleEntries = [{
+  commit: { id: 'abc', message: 's', url: '#' }, date: Date.now(),
+  benches: [
+    { name: 'deeptax_d1_count_us', value: 10, unit: 'µs' },
+    { name: 'deeptax_d10_count_us', value: 120, unit: 'µs' },
+    { name: 'deeptax_d5_count_us', value: 40, unit: 'µs' },     // out of order on purpose
+    { name: 'watdiv_sf100_C1_count_us', value: 800, unit: 'µs' }, // single-point family
+    { name: 'lubm_q06_count_us', value: 99, unit: 'µs' }          // NOT size-parametrised
+  ]
+}];
+const fams = D.buildScalingFamilies(scaleEntries);
+ok(fams.length === 2, 'buildScalingFamilies found exactly the two size-parametrised families');
+const dtFam = fams.filter(function (f) { return f.axisLabel === 'depth'; })[0];
+ok(dtFam && dtFam.points.length === 3, 'deep-taxonomy family has 3 depth points');
+ok(dtFam.points[0].axis === 1 && dtFam.points[2].axis === 10, 'scaling points sorted ascending by axis');
+const sfFam = fams.filter(function (f) { return f.axisLabel === 'scale factor'; })[0];
+ok(sfFam && sfFam.points.length === 1, 'single-size family is kept (renders a single marker + note)');
+ok(fams.every(function (f) { return !/lubm_q06/.test(f.base); }), 'non-size-parametrised metric excluded');
+
+// ============================================================================================
+// [OPUS-4.8] BROWSER-DOM SIMULATION — confirm the featured section + scaling charts actually
+// build DOM (sq-xvow #featured / sq-viby #scaling), like sq-ocuf's renderSummary smoke would. A
+// tiny stub document/window/Chart lets the (browser-only) render fns run under node: we import
+// dashboard.js a SECOND time with its module.exports branch suppressed so its DOM half executes.
 // ============================================================================================
 (function domSimulation() {
   // --- minimal DOM shim: just enough for el()/renderFeatured()/renderSummary()/render(). -------
@@ -213,7 +254,10 @@ ok(watdivComp && watdivComp.oxigraph === undefined, 'unmatched competitor cell s
         benches: [
           { name: 'load_s', value: 1.2, unit: 's' },
           { name: 'watdiv_S1_count_us', value: 30, unit: 'µs' },
-          { name: 'lubm_q06_count_us', value: 99, unit: 'µs' }
+          { name: 'lubm_q06_count_us', value: 99, unit: 'µs' },
+          // size-parametrised family (sq-viby): two depths -> a real scaling curve.
+          { name: 'deeptax_d1_count_us', value: 10, unit: 'µs' },
+          { name: 'deeptax_d10_count_us', value: 120, unit: 'µs' }
         ]
       }] }
     },
@@ -231,10 +275,14 @@ ok(watdivComp && watdivComp.oxigraph === undefined, 'unmatched competitor cell s
   (function (module, exports, require) { eval(dashSrc); })(undefined, undefined, undefined);
 
   ok(hosts.featured.children.length > 0, 'DOM: #featured populated (sq-xvow rendered)');
+  ok(hosts.scaling.children.length > 0, 'DOM: #scaling populated (sq-viby rendered)');
   ok(hosts.summary.children.length > 0, 'DOM: #summary still populated (existing path intact)');
   // featured host should contain at least one suite section with a table.
   const featuredSection = hosts.featured.children[0];
   ok(featuredSection && featuredSection.tagName === 'section', 'DOM: featured host holds suite sections');
+  // scaling host should contain a chart-grid with at least one scaling card.
+  ok(hosts.scaling.children[0] && hosts.scaling.children[0].attributes['class'] === 'chart-grid',
+     'DOM: scaling host holds a chart-grid');
 
   delete global.document; delete global.window; delete global.Chart;
 })();

--- a/scripts/dashboard-smoke.js
+++ b/scripts/dashboard-smoke.js
@@ -103,6 +103,142 @@ summary.groups.forEach(function (g) {
 });
 ok(sawWatdivRow, 'watdiv row present in summary');
 
+// ============================================================================================
+// [OPUS-4.8] sq-xvow — featured well-known suites at the TOP (+ competitor seam for sq-t0c3).
+// ============================================================================================
+ok(typeof D.featuredSuiteOf === 'function', 'dashboard.js exports featuredSuiteOf');
+ok(typeof D.buildFeatured === 'function', 'dashboard.js exports buildFeatured');
+ok(typeof D.competitorsFor === 'function', 'dashboard.js exports competitorsFor');
+
+// featuredSuiteOf: recognised public suites are featured; engine micro-suites are NOT.
+eq(D.featuredSuiteOf('watdiv_S1_count_us') && D.featuredSuiteOf('watdiv_S1_count_us').key, 'WatDiv',
+   'watdiv metric is featured under WatDiv');
+eq(D.featuredSuiteOf('lubm_q06_count_us') && D.featuredSuiteOf('lubm_q06_count_us').key, 'LUBM',
+   'lubm metric is featured under LUBM');
+eq(D.featuredSuiteOf('sp2b_q1_count_us') && D.featuredSuiteOf('sp2b_q1_count_us').key, 'SP2Bench',
+   'sp2b metric is featured under SP2Bench');
+ok(D.featuredSuiteOf('op_q01_bgp_count_us') === null, 'operator micro-suite is NOT featured');
+ok(D.featuredSuiteOf('load_s') === null, 'pipeline metric is NOT featured');
+// Deep Taxonomy isn't in the label map yet (sq-1hgz) — name-token fallback must still recognise it.
+eq(D.featuredSuiteOf('deeptax_d5_count_us') && D.featuredSuiteOf('deeptax_d5_count_us').key, 'Deep Taxonomy',
+   'unlabelled deep-taxonomy metric is featured via name fallback');
+
+// buildFeatured: groups by suite, latest value per metric, competitor SEAM present.
+const featEntries = [{
+  commit: { id: 'feedfacefeed', message: 'feat test', url: '#' }, date: Date.now(),
+  benches: [
+    { name: 'load_s', value: 1.2, unit: 's' },                  // NOT featured
+    { name: 'op_q01_bgp_count_us', value: 5, unit: 'us' },      // NOT featured
+    { name: 'watdiv_S1_count_us', value: 30, unit: 'µs' },
+    { name: 'lubm_q06_count_us', value: 99, unit: 'µs' },
+    { name: 'sp2b_q1_count_us', value: 50, unit: 'µs' }
+  ]
+}];
+const feat = D.buildFeatured(featEntries, null);
+const featSuites = feat.groups.map(function (g) { return g.suite; });
+ok(featSuites.indexOf('WatDiv') !== -1 && featSuites.indexOf('LUBM') !== -1 &&
+   featSuites.indexOf('SP2Bench') !== -1, 'buildFeatured surfaces WatDiv/LUBM/SP2Bench');
+ok(featSuites.indexOf('Operators') === -1 && featSuites.indexOf('Pipeline') === -1,
+   'buildFeatured excludes non-featured (engine) suites');
+// the SEAM: no competitor file -> empty engine list, every row has a competitors:{} object.
+ok(Array.isArray(feat.competitorEngines) && feat.competitorEngines.length === 0,
+   'no competitor file -> competitorEngines is []');
+let sawFeatRow = false;
+feat.groups.forEach(function (g) { g.rows.forEach(function (r) {
+  if (r.name === 'watdiv_S1_count_us') {
+    sawFeatRow = true;
+    eq(r.value, 30, 'featured row carries the latest value');
+    ok(r.label === 'WatDiv S1 — star query, count', 'featured row uses the sq-ocuf readable label');
+    ok(r.competitors && typeof r.competitors === 'object', 'featured row exposes a competitors seam');
+  }
+}); });
+ok(sawFeatRow, 'watdiv row present in featured view');
+
+// competitor seam wiring (sq-t0c3): a competitor file is mapped onto rows; matches by raw NAME
+// AND by canonical stem (name minus _us). Absent numbers stay absent (-> "—" in the DOM).
+const compFile = {
+  engines: [{ id: 'qlever', label: 'QLever', version: '1.2.3', env: 'CI' }, { id: 'oxigraph' }],
+  values: { 'watdiv_S1_count_us': { qlever: 12 }, 'lubm_q06_count': { oxigraph: 200 } }
+};
+const featC = D.buildFeatured(featEntries, compFile);
+eq(featC.competitorEngines.length, 2, 'competitor file -> two engine columns');
+let watdivComp = null, lubmComp = null;
+featC.groups.forEach(function (g) { g.rows.forEach(function (r) {
+  if (r.name === 'watdiv_S1_count_us') watdivComp = r.competitors;
+  if (r.name === 'lubm_q06_count_us') lubmComp = r.competitors;
+}); });
+eq(watdivComp && watdivComp.qlever, 12, 'competitor matched by raw metric name');
+eq(lubmComp && lubmComp.oxigraph, 200, 'competitor matched by canonical stem (name minus _us)');
+ok(watdivComp && watdivComp.oxigraph === undefined, 'unmatched competitor cell stays absent (renders —)');
+
+// ============================================================================================
+// [OPUS-4.8] BROWSER-DOM SIMULATION — confirm the featured section actually builds DOM
+// (sq-xvow #featured), like sq-ocuf's renderSummary smoke would. A tiny stub document/window/Chart
+// lets the (browser-only) render fns run under node: we import dashboard.js a SECOND time with its
+// module.exports branch suppressed so its DOM half executes. (sq-viby extends this to assert
+// #scaling too once the scaling charts land.)
+// ============================================================================================
+(function domSimulation() {
+  // --- minimal DOM shim: just enough for el()/renderFeatured()/renderSummary()/render(). -------
+  function makeNode(tag) {
+    return {
+      tagName: tag, children: [], attributes: {}, _text: '', _html: '',
+      style: {},
+      set textContent(v) { this._text = String(v); }, get textContent() { return this._text; },
+      set innerHTML(v) { this._html = String(v); if (v === '') this.children = []; },
+      get innerHTML() { return this._html; },
+      get lastChild() { return this.children[this.children.length - 1]; },
+      get firstChild() { return this.children[0]; },
+      setAttribute: function (k, v) { this.attributes[k] = String(v); },
+      appendChild: function (c) { this.children.push(c); return c; },
+      getContext: function () { return {}; }
+    };
+  }
+  const hosts = {};
+  ['updated', 'repo', 'summary', 'charts', 'featured', 'scaling'].forEach(function (id) {
+    hosts[id] = makeNode('div');
+  });
+  global.document = {
+    readyState: 'complete',
+    createElement: makeNode,
+    getElementById: function (id) { return hosts[id] || makeNode('div'); },
+    addEventListener: function () {}
+  };
+  global.window = {
+    matchMedia: function () { return { matches: false }; },
+    BENCHMARK_DATA: {
+      lastUpdate: Date.now(), repoUrl: 'https://github.com/jeswr/sparq',
+      entries: { 'sparq engine': [{
+        commit: { id: 'deadbeefcafe', message: 'dom sim', url: '#' }, date: Date.now(),
+        benches: [
+          { name: 'load_s', value: 1.2, unit: 's' },
+          { name: 'watdiv_S1_count_us', value: 30, unit: 'µs' },
+          { name: 'lubm_q06_count_us', value: 99, unit: 'µs' }
+        ]
+      }] }
+    },
+    METRIC_LABELS: labelsFile
+  };
+  // a no-op Chart constructor so renderCharts doesn't blow up.
+  global.Chart = function () { return {}; };
+
+  // re-import dashboard.js with its module.exports branch suppressed so the DOM half runs. The
+  // dashboard's IIFE takes the node-export early-return when `module.exports` is truthy; inside this
+  // eval scope we shadow `module` to undefined so it falls through to the BROWSER DOM path instead.
+  // boot() then runs synchronously: there is no window.fetch in the shim, so it calls render().
+  const dashSrc = fs.readFileSync(DASH, 'utf8');
+  // eslint-disable-next-line no-eval
+  (function (module, exports, require) { eval(dashSrc); })(undefined, undefined, undefined);
+
+  ok(hosts.featured.children.length > 0, 'DOM: #featured populated (sq-xvow rendered)');
+  ok(hosts.summary.children.length > 0, 'DOM: #summary still populated (existing path intact)');
+  // featured host should contain at least one suite section with a table.
+  const featuredSection = hosts.featured.children[0];
+  ok(featuredSection && featuredSection.tagName === 'section', 'DOM: featured host holds suite sections');
+
+  delete global.document; delete global.window; delete global.Chart;
+})();
+
 if (failures) {
   console.error('\nFAILED: ' + failures + ' assertion(s).');
   process.exit(1);


### PR DESCRIPTION
Builds on sq-ocuf's labels. **sq-xvow**: a featured card at the TOP promoting the recognised public suites (LUBM, WatDiv, SP2Bench, Deep Taxonomy, BSBM, DBPSB) — one table per suite, readable label + raw stem + latest value + Δ-vs-best, with a **clean competitor seam** (reads `window.COMPETITORS`; renders `—` when absent — sq-t0c3 populates it). **sq-viby**: a scaling card at the BOTTOM plotting metric-vs-size, axis derived from the metric name (`_sfN`, `_depthN`, …); graceful on single-point/empty families.

Section order: featured → summary → charts → scaling. Pure-vanilla JS, no new deps; sq-ocuf labels/grouping/tooltips + existing summary/trend untouched.

**Found + beaded sq-1wrw:** no live metric carries a size token yet (WatDiv SF=1/full-scale collide on the same github-action-benchmark name), so the scaling card shows its graceful empty hint until `ci-bench.sh` emits size-suffixed names — that bead lights it up.

Closes sq-xvow, sq-viby. Gates: `node --check` (both files) + `dashboard-smoke.js` 65 ok/0 fail (incl. a browser-DOM render simulation); metric-labels.json untouched + valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)