### PR TITLE
fix(sparq-engine): SERVICE result parser preserves rdf:dirLangString its:dir (sq-s955)

### DIFF
--- a/crates/sparq-core/src/dict.rs
+++ b/crates/sparq-core/src/dict.rs
@@ -278,14 +278,21 @@ pub fn split_lang_dir(slot: &str) -> (&str, Option<&str>) {
     }
 }
 
-/// [OPUS-4.8] sq-bj7o: the single source of truth for "is this `lang--<suffix>` suffix a
-/// valid RDF 1.2 base direction?". The two possible directions are `ltr` / `rtl`, lowercase
-/// and case-sensitive (matching oxrdf `BaseDirection::Display` and the W3C RDF 1.2 / SPARQL
-/// 1.2 grammar — `LTR` / `Ltr` are NOT directions). Returns the typed enum so the
-/// materialised path ([`reconstruct_ref`]) and the validating split ([`split_lang_dir`]) can
-/// share exactly one definition and never drift apart.
+/// [OPUS-4.8] sq-bj7o: the single source of truth for "is this RDF 1.2 base direction string
+/// valid?". The two possible directions are `ltr` / `rtl`, lowercase and case-sensitive
+/// (matching oxrdf `BaseDirection::Display` and the W3C RDF 1.2 / SPARQL 1.2 grammar — `LTR`
+/// / `Ltr` are NOT directions). Returns the typed enum so the materialised path
+/// ([`reconstruct_ref`]) and the validating split ([`split_lang_dir`]) can share exactly one
+/// definition and never drift apart.
+///
+/// [OPUS-4.8] sq-s955: also the validator for the *inbound* SERVICE results parser, where
+/// `its:dir` arrives as its own JSON/XML field (not a `lang--dir` slot suffix). Routing that
+/// field through this one function makes the inbound path agree with the stored-slot
+/// (`split_lang_dir`), materialised (`reconstruct_ref`) and outbound (`json.rs`) paths on
+/// what a valid direction is — and, with the caller's fallback, on what an *invalid* one
+/// degrades to (a plain language-tagged literal).
 #[inline]
-fn parse_lang_dir_suffix(suffix: &str) -> Option<oxrdf::BaseDirection> {
+pub fn parse_lang_dir_suffix(suffix: &str) -> Option<oxrdf::BaseDirection> {
     match suffix {
         "ltr" => Some(oxrdf::BaseDirection::Ltr),
         "rtl" => Some(oxrdf::BaseDirection::Rtl),

--- a/crates/sparq-core/src/dict.rs
+++ b/crates/sparq-core/src/dict.rs
@@ -266,11 +266,11 @@ pub(crate) fn lang_with_dir(l: &Literal) -> Option<std::borrow::Cow<'_, str>> {
 /// materialised `oxrdf::Term` path. So a suffix that is not exactly `ltr`/`rtl` is NOT a
 /// direction: the whole slot is returned as the language tag and no direction is reported —
 /// the same decision the materialised `reconstruct_ref` path makes (both call
-/// [`parse_lang_dir_suffix`]), so the fast path and the materialised path AGREE.
+/// [`parse_base_direction`]), so the fast path and the materialised path AGREE.
 #[inline]
 pub fn split_lang_dir(slot: &str) -> (&str, Option<&str>) {
     match slot.split_once("--") {
-        Some((tag, dir)) if parse_lang_dir_suffix(dir).is_some() => (tag, Some(dir)),
+        Some((tag, dir)) if parse_base_direction(dir).is_some() => (tag, Some(dir)),
         // No `--`, or a `--suffix` that is not a valid base direction: the entire slot is the
         // language tag and there is no direction. Keeping the full slot intact (rather than
         // dropping the bogus suffix) matches `reconstruct_ref`'s plain-language-tag fallback.
@@ -278,22 +278,30 @@ pub fn split_lang_dir(slot: &str) -> (&str, Option<&str>) {
     }
 }
 
-/// [OPUS-4.8] sq-bj7o: the single source of truth for "is this RDF 1.2 base direction string
-/// valid?". The two possible directions are `ltr` / `rtl`, lowercase and case-sensitive
+/// [OPUS-4.8] sq-bj7o / sq-s955: the single source of truth for "is this RDF 1.2 base
+/// direction string valid?" — the base-direction validator for the whole stack. Takes a
+/// candidate direction string (NOT a `lang--dir` slot; just the direction component) and
+/// returns the typed [`oxrdf::BaseDirection`] when it is one of the two valid values, else
+/// `None`. The two possible directions are `ltr` / `rtl`, lowercase and case-sensitive
 /// (matching oxrdf `BaseDirection::Display` and the W3C RDF 1.2 / SPARQL 1.2 grammar — `LTR`
-/// / `Ltr` are NOT directions). Returns the typed enum so the materialised path
-/// ([`reconstruct_ref`]) and the validating split ([`split_lang_dir`]) can share exactly one
-/// definition and never drift apart.
+/// / `Ltr` are NOT directions).
 ///
-/// [OPUS-4.8] sq-s955: also the validator for the *inbound* SERVICE results parser, where
-/// `its:dir` arrives as its own JSON/XML field (not a `lang--dir` slot suffix). Routing that
-/// field through this one function makes the inbound path agree with the stored-slot
-/// (`split_lang_dir`), materialised (`reconstruct_ref`) and outbound (`json.rs`) paths on
-/// what a valid direction is — and, with the caller's fallback, on what an *invalid* one
-/// degrades to (a plain language-tagged literal).
+/// Returning the typed enum lets every direction-bearing path share exactly one definition
+/// and never drift apart:
+/// - stored-slot fast path — [`split_lang_dir`] (splits off the `--dir` suffix, then validates
+///   it here);
+/// - materialised path — [`reconstruct_ref`] (same split-then-validate of a stored slot);
+/// - outbound SPARQL 1.2 results — `sparq-engine`'s `json.rs` (emits the validated direction
+///   as a separate `its:dir` field);
+/// - inbound SERVICE results parser — `sparq-engine`'s `service.rs` (sq-s955), where `its:dir`
+///   arrives as its own JSON/XML field rather than a slot suffix and is validated directly
+///   through this function.
+///
+/// With each caller's fallback, all paths also agree on what an *invalid* direction degrades
+/// to (a plain language-tagged literal).
 #[inline]
-pub fn parse_lang_dir_suffix(suffix: &str) -> Option<oxrdf::BaseDirection> {
-    match suffix {
+pub fn parse_base_direction(dir: &str) -> Option<oxrdf::BaseDirection> {
+    match dir {
         "ltr" => Some(oxrdf::BaseDirection::Ltr),
         "rtl" => Some(oxrdf::BaseDirection::Rtl),
         _ => None,
@@ -572,12 +580,12 @@ fn reconstruct_ref(d: &Dict, s: &StoredRef) -> Term {
             // A stored `lang--dir` slot is an RDF 1.2 directional language-tagged string
             // (see `lang_with_dir`); a plain tag is an ordinary one. [OPUS-4.8] sq-bj7o: the
             // suffix is only a base direction when it is exactly `ltr`/`rtl`
-            // (`parse_lang_dir_suffix`) — the SAME validation `split_lang_dir` (the JSON fast
+            // (`parse_base_direction`) — the SAME validation `split_lang_dir` (the JSON fast
             // path) applies, so a malformed slot like `en--bogus` from an untrusted/mmap'd
             // index decodes to a PLAIN language-tagged literal with tag `en--bogus` here AND
             // to `("en--bogus", None)` there. Previously any non-`rtl` suffix was silently
             // coerced to `ltr`, which both fabricated a direction and diverged from the split.
-            Some(l) => match l.split_once("--").and_then(|(tag, dir)| parse_lang_dir_suffix(dir).map(|d| (tag, d))) {
+            Some(l) => match l.split_once("--").and_then(|(tag, dir)| parse_base_direction(dir).map(|d| (tag, d))) {
                 Some((tag, dir)) => Literal::new_directional_language_tagged_literal_unchecked(
                     value.to_string(),
                     tag.to_string(),

--- a/crates/sparq-engine/src/service.rs
+++ b/crates/sparq-engine/src/service.rs
@@ -143,10 +143,29 @@ fn srj_term(val: &serde_json::Value) -> Result<Term, String> {
                 .ok_or_else(|| "SERVICE: literal binding without value".to_string())?
                 .to_string();
             if let Some(lang) = get("xml:lang") {
-                Ok(Term::Literal(
-                    Literal::new_language_tagged_literal(value, lang)
-                        .map_err(|e| format!("SERVICE: bad language tag {lang:?}: {e}"))?,
-                ))
+                // [OPUS-4.8] sq-s955: the INBOUND counterpart to the outbound `its:dir`
+                // emission (sq-bj7o, `json.rs::term_to_json`). A remote endpoint's SPARQL 1.2
+                // results carry the RDF 1.2 base direction as a SEPARATE `its:dir` field
+                // alongside the bare `xml:lang` tag; reading only `xml:lang` dropped the
+                // direction, so a `dirLangString` arrived as a plain language-tagged literal
+                // and silently lost its direction on the way in. We now reconstruct the
+                // directional literal, validating the direction through the single source of
+                // truth (`dict::parse_lang_dir_suffix`, also used by the stored-slot,
+                // materialised and outbound paths). An ABSENT or INVALID `its:dir` degrades
+                // to a plain language-tagged literal — the SAME decision `split_lang_dir` /
+                // `reconstruct_ref` make for a malformed stored slot — so all four paths AGREE
+                // on `(lang, dir)`.
+                match get("its:dir").and_then(sparq_core::dict::parse_lang_dir_suffix) {
+                    Some(dir) => Ok(Term::Literal(
+                        Literal::new_directional_language_tagged_literal(value, lang, dir).map_err(
+                            |e| format!("SERVICE: bad language tag {lang:?}: {e}"),
+                        )?,
+                    )),
+                    None => Ok(Term::Literal(
+                        Literal::new_language_tagged_literal(value, lang)
+                            .map_err(|e| format!("SERVICE: bad language tag {lang:?}: {e}"))?,
+                    )),
+                }
             } else if let Some(dt) = get("datatype") {
                 let dt = NamedNode::new(dt).map_err(|e| format!("SERVICE: bad datatype {dt:?}: {e}"))?;
                 Ok(Term::Literal(Literal::new_typed_literal(value, dt)))
@@ -584,6 +603,62 @@ mod tests {
             NamedNode::new("http://www.w3.org/2001/XMLSchema#integer").unwrap(),
         );
         assert_eq!(rel.rows[0][0], Some(Term::Literal(want)));
+    }
+
+    /// [OPUS-4.8] sq-s955: inbound parity for the outbound `its:dir` emission. A SERVICE
+    /// endpoint's results carry the RDF 1.2 base direction as a SEPARATE `its:dir` field
+    /// next to the bare `xml:lang` tag; the parser must reconstruct the `dirLangString` so
+    /// the direction survives INTO the local join (it was previously dropped). This mirrors
+    /// the outbound `json.rs` parity test — direction round-trips both ways.
+    #[test]
+    fn dir_lang_string_direction_roundtrips_inbound() {
+        for (dir, want) in [
+            ("ltr", oxrdf::BaseDirection::Ltr),
+            ("rtl", oxrdf::BaseDirection::Rtl),
+        ] {
+            let body = format!(
+                r#"{{
+                "head": {{ "vars": ["g"] }},
+                "results": {{ "bindings": [
+                    {{ "g": {{"type":"literal","value":"مرحبا","xml:lang":"ar","its:dir":"{dir}"}} }}
+                ] }}
+            }}"#
+            );
+            let rel = parse_srj(&body).unwrap();
+            match &rel.rows[0][0] {
+                Some(Term::Literal(l)) => {
+                    assert_eq!(l.value(), "مرحبا");
+                    assert_eq!(l.language(), Some("ar"));
+                    // The direction round-trips inbound (the bug: it was None).
+                    assert_eq!(l.direction(), Some(want), "its:dir={dir} must survive inbound");
+                }
+                other => panic!("expected a directional literal, got {other:?}"),
+            }
+        }
+    }
+
+    /// [OPUS-4.8] sq-s955: an ABSENT or INVALID `its:dir` degrades to a PLAIN language-tagged
+    /// literal — the same decision `dict::split_lang_dir` / `reconstruct_ref` make for a
+    /// malformed stored slot — so the inbound, stored-slot, materialised and outbound paths
+    /// all AGREE on `(lang, dir)`. (An uppercase `LTR` or any other value is not a direction.)
+    #[test]
+    fn invalid_or_absent_its_dir_is_plain_language_literal() {
+        let plain = Literal::new_language_tagged_literal("hi", "en").unwrap();
+        for cell in [
+            r#"{"type":"literal","value":"hi","xml:lang":"en"}"#, // absent its:dir
+            r#"{"type":"literal","value":"hi","xml:lang":"en","its:dir":"LTR"}"#, // wrong case
+            r#"{"type":"literal","value":"hi","xml:lang":"en","its:dir":"sideways"}"#, // bogus
+            r#"{"type":"literal","value":"hi","xml:lang":"en","its:dir":""}"#, // empty
+        ] {
+            let body =
+                format!(r#"{{"head":{{"vars":["g"]}},"results":{{"bindings":[{{"g":{cell}}}]}}}}"#);
+            let rel = parse_srj(&body).unwrap();
+            assert_eq!(
+                rel.rows[0][0],
+                Some(Term::Literal(plain.clone())),
+                "invalid/absent its:dir in {cell} must degrade to a plain language-tagged literal"
+            );
+        }
     }
 
     #[test]

--- a/crates/sparq-engine/src/service.rs
+++ b/crates/sparq-engine/src/service.rs
@@ -150,12 +150,12 @@ fn srj_term(val: &serde_json::Value) -> Result<Term, String> {
                 // direction, so a `dirLangString` arrived as a plain language-tagged literal
                 // and silently lost its direction on the way in. We now reconstruct the
                 // directional literal, validating the direction through the single source of
-                // truth (`dict::parse_lang_dir_suffix`, also used by the stored-slot,
+                // truth (`dict::parse_base_direction`, also used by the stored-slot,
                 // materialised and outbound paths). An ABSENT or INVALID `its:dir` degrades
                 // to a plain language-tagged literal — the SAME decision `split_lang_dir` /
                 // `reconstruct_ref` make for a malformed stored slot — so all four paths AGREE
                 // on `(lang, dir)`.
-                match get("its:dir").and_then(sparq_core::dict::parse_lang_dir_suffix) {
+                match get("its:dir").and_then(sparq_core::dict::parse_base_direction) {
                     Some(dir) => Ok(Term::Literal(
                         Literal::new_directional_language_tagged_literal(value, lang, dir).map_err(
                             |e| format!("SERVICE: bad language tag {lang:?}: {e}"),


### PR DESCRIPTION
Inbound counterpart to the merged outbound dirLangString fix. `service.rs:145` (`srj_term`) read only `xml:lang` from the SPARQL-Results-**JSON** a federated `SERVICE` endpoint returns, dropping the RDF 1.2 base direction (`its:dir`). Now reads both and reconstructs the directional literal via `Literal::new_directional_language_tagged_literal`, validating through `dict::parse_lang_dir_suffix` (promoted to `pub` so inbound reuses the SAME source of truth as the stored-slot / materialised / outbound-JSON paths). Absent/invalid `its:dir` → plain language-tagged literal, identical degradation across all 4 paths.

(Bead said results-XML; the actual + only inbound SERVICE surface is results-JSON — there is no SERVICE results-XML parser.) +2 tests (rtl/ltr round-trip inbound; invalid/absent degradation). Gates: clippy + test green on sparq-engine/sparq-core (default + `--features service`: engine 194 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)