### PR TITLE
feat(sparq-core): persist NAMED graphs across save/open + per-graph WAL (sq-3ui0, gh-45)

### DIFF
--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -1106,7 +1106,6 @@ impl Graph {
             std::fs::remove_file(&manifest).ok();
             return Ok(());
         }
-        let _ = &manifest;
         // Rewrite the subtree from scratch so removed/renamed graphs cannot survive a re-save.
         std::fs::remove_dir_all(&named_dir).ok();
         std::fs::create_dir_all(&named_dir)?;
@@ -4138,10 +4137,12 @@ mod tests {
     #[cfg(feature = "mmap")]
     #[test]
     fn save_open_named_graphs_roundtrip_lossless() {
+        type Triple = (String, String, String);
+        type Dataset = Vec<(String, Vec<Triple>)>;
         // Dump a single graph's triples as a sorted N-Triples-ish vector.
-        fn dump_one(gg: &Graph) -> Vec<(String, String, String)> {
+        fn dump_one(gg: &Graph) -> Vec<Triple> {
             let scan = gg.store.scan(&[None, None, None]);
-            let mut v: Vec<(String, String, String)> = scan
+            let mut v: Vec<Triple> = scan
                 .rows
                 .iter()
                 .map(|r| {
@@ -4153,8 +4154,8 @@ mod tests {
             v
         }
         // Dump the WHOLE dataset: default graph under key "", each named graph under its name.
-        fn dump_dataset(gg: &Graph) -> Vec<(String, Vec<(String, String, String)>)> {
-            let mut out: Vec<(String, Vec<(String, String, String)>)> = vec![(String::new(), dump_one(gg))];
+        fn dump_dataset(gg: &Graph) -> Dataset {
+            let mut out: Dataset = vec![(String::new(), dump_one(gg))];
             for (name, sub) in &gg.named {
                 out.push((name.to_string(), dump_one(sub)));
             }

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -1154,8 +1154,20 @@ impl Graph {
             return Err(bad(&format!("unsupported format version {version} (this build writes/reads {NAMED_FORMAT_VERSION})")));
         }
         let count = u32::from_le_bytes(bytes[8..12].try_into().expect("4 bytes")) as usize;
+        // [OPUS-4.8] (Copilot review #69, finding 3) `count` is attacker-controlled: a corrupt
+        // or hostile manifest can declare a huge count behind a tiny file, and the old
+        // `Vec::with_capacity(count)` would attempt a multi-GB reservation (OOM/abort) BEFORE
+        // any per-entry bounds check ran. Each entry costs >= MIN_MANIFEST_ENTRY_BYTES on disk
+        // (kind byte + u32 length prefix, zero-length value), so the post-header byte count is
+        // a hard upper bound on how many entries can possibly follow — clamp the reservation to
+        // it. The decode loop below still errors cleanly via `decode_graph_name`'s bounds checks
+        // if the file actually ends early, so a count the file can't back is a clean
+        // `InvalidData` (truncated manifest), never an OOM. Same defensive idiom as
+        // `Dict::open_mmap` (dict.rs) and the rest of the corruption-hardened `open` path.
+        let remaining = bytes.len() - 12;
+        let cap = count.min(remaining / MIN_MANIFEST_ENTRY_BYTES);
         let named_dir = dir.join(NAMED_SUBDIR);
-        let mut out = Vec::with_capacity(count);
+        let mut out = Vec::with_capacity(cap);
         let mut pos = 12usize;
         for i in 0..count {
             let (name, next) = decode_graph_name(&bytes, pos).map_err(|m| bad(&m))?;
@@ -1948,11 +1960,19 @@ impl Graph {
         // Persist an empty sub-graph, then open it so it carries its own WAL.
         let empty = Graph::from_parts(Dict::new(), Vec::new());
         empty.save(&sub_dir).map_err(|e| e.to_string())?;
+        // fsync `dir/named/` so the new sub-graph DIRECTORY's existence is durable before the
+        // manifest names it (otherwise a crash could leave the manifest pointing at a dir whose
+        // creation never reached disk).
+        fsync_dir(&named_dir).map_err(|e| e.to_string())?;
         // Rewrite the manifest with the new entry appended (index order == named order).
+        // [OPUS-4.8] (Copilot review #69, finding 2) `named.bin` lives in the PARENT `dir`, not
+        // in `dir/named/`. The old code only fsync'd `dir/named/`, so a crash could lose the
+        // manifest entry even though the sub-graph was on disk. `write_named_manifest` now does
+        // an atomic temp+rename AND fsyncs the parent `dir` (the dir that holds `named.bin`), so
+        // the manifest entry — the recovery commit point — is itself durable.
         let mut names: Vec<Term> = self.named.iter().map(|(n, _)| n.clone()).collect();
         names.push(name.clone());
         write_named_manifest(dir, &names).map_err(|e| e.to_string())?;
-        fsync_dir(&named_dir).map_err(|e| e.to_string())?;
         Graph::open(&sub_dir).map_err(|e| e.to_string())
     }
 
@@ -2104,6 +2124,11 @@ fn recover_compaction(dir: &std::path::Path) -> std::io::Result<()> {
 const NAMED_SUBDIR: &str = "named";
 #[cfg(feature = "mmap")]
 const NAMED_MANIFEST: &str = "named.bin";
+/// [OPUS-4.8] (Copilot review #69, finding 1) Temp filename for the ATOMIC manifest write: the
+/// full image is written here, fsync'd, then renamed over [`NAMED_MANIFEST`] so a crash
+/// mid-write never leaves a partial/corrupt `named.bin`. See [`write_named_manifest`].
+#[cfg(feature = "mmap")]
+const NAMED_MANIFEST_TMP: &str = "named.bin.tmp";
 /// Manifest magic ("NMG1" little-endian) — identifies a named-graph manifest and lets a
 /// stray/legacy file be rejected rather than misread.
 #[cfg(feature = "mmap")]
@@ -2112,13 +2137,30 @@ const NAMED_MANIFEST_MAGIC: u32 = 0x31_47_4D_4E;
 /// incompatibly; `open_named` refuses an unknown version rather than silently misreading.
 #[cfg(feature = "mmap")]
 const NAMED_FORMAT_VERSION: u32 = 1;
+/// [OPUS-4.8] (Copilot review #69, finding 3) Smallest possible on-disk size of one manifest
+/// entry: `[kind u8][len u32]` (1 + 4) with a zero-length value. The post-header byte count
+/// divided by this is a hard upper bound on the entry count, so `open_named` clamps its
+/// pre-allocation to it — a hostile `count` field can never drive an unbounded reservation.
+#[cfg(feature = "mmap")]
+const MIN_MANIFEST_ENTRY_BYTES: usize = 5;
 
 /// [OPUS-4.8] (sq-3ui0) Writes the named-graph manifest `dir/named.bin`: the magic +
 /// format version + count, then each graph name in order (see [`encode_graph_name`]). The
 /// sub-graph directories `dir/named/<i>/` must already be durable before this is called —
 /// the manifest's presence is the commit point for the named-graph set.
+///
+/// [OPUS-4.8] (Copilot review #69, findings 1+2) The write is ATOMIC and DURABLE: a plain
+/// `std::fs::write` truncates `named.bin` IN PLACE, so a crash mid-write leaves a partial
+/// (corrupt) manifest that `open_named` then rejects as `InvalidData` — bricking the dataset.
+/// Instead we write the full image to a sibling `named.bin.tmp`, fsync IT (its bytes are
+/// durable), `rename` it over `named.bin` (the rename is atomic — a reader sees either the old
+/// complete manifest or the new complete manifest, never a torn one), then fsync the PARENT
+/// `dir` (which is what actually contains `named.bin`) so the rename — i.e. the commit point of
+/// the whole named-graph set — survives a crash. This is the same temp-file + fsync + rename +
+/// dir-fsync discipline the compaction directory-swap uses (`Graph::compact`).
 #[cfg(feature = "mmap")]
 fn write_named_manifest(dir: &std::path::Path, names: &[Term]) -> std::io::Result<()> {
+    use std::io::Write;
     let mut buf = Vec::with_capacity(12 + names.len() * 32);
     buf.extend_from_slice(&NAMED_MANIFEST_MAGIC.to_le_bytes());
     buf.extend_from_slice(&NAMED_FORMAT_VERSION.to_le_bytes());
@@ -2126,7 +2168,20 @@ fn write_named_manifest(dir: &std::path::Path, names: &[Term]) -> std::io::Resul
     for name in names {
         encode_graph_name(&mut buf, name);
     }
-    std::fs::write(dir.join(NAMED_MANIFEST), &buf)
+    let final_path = dir.join(NAMED_MANIFEST);
+    let tmp_path = dir.join(NAMED_MANIFEST_TMP);
+    // Write the full image to a sibling temp file and fsync its CONTENTS before the rename, so
+    // the bytes the rename publishes are already durable (a crash can't surface a
+    // zero-length/partial file under the canonical name).
+    {
+        let mut f = std::fs::File::create(&tmp_path)?;
+        f.write_all(&buf)?;
+        f.sync_all()?;
+    }
+    // Atomically publish: rename can't tear, so `named.bin` is always a COMPLETE manifest.
+    std::fs::rename(&tmp_path, &final_path)?;
+    // fsync the dir holding `named.bin` so the rename (the commit) is itself durable.
+    fsync_dir(dir)
 }
 
 /// [OPUS-4.8] (sq-3ui0) Serialise a graph-name term into the manifest buffer as
@@ -4258,6 +4313,75 @@ mod tests {
             Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::InvalidData, "unknown version must be a hard InvalidData error"),
         }
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (Copilot review #69, finding 3) A hostile/corrupt manifest that declares a
+    /// HUGE entry `count` behind a tiny file must fail as a clean `InvalidData` (truncated)
+    /// error — NEVER an unbounded `Vec::with_capacity` allocation (OOM/abort). The reservation
+    /// is clamped to the file's remaining length, and the decode loop then errors on the
+    /// missing entry bytes.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn named_manifest_hostile_count_is_bounded_not_oom() {
+        let nq = "<http://res/x> <http://ex/p> <http://ex/o> <http://res/x> .\n";
+        let g = Graph::load_dataset(nq, "nquads").unwrap();
+        let dir = std::env::temp_dir().join(format!("sparq_named_hostile_{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        g.save(&dir).unwrap();
+        // Set the count field (bytes 8..12) to ~4 billion — a real `with_capacity(count)` would
+        // try to reserve tens of GB (an uncatchable abort) before any bounds check ran.
+        let mut bytes = std::fs::read(dir.join("named.bin")).unwrap();
+        bytes[8..12].copy_from_slice(&u32::MAX.to_le_bytes());
+        std::fs::write(dir.join("named.bin"), &bytes).unwrap();
+        // Must return cleanly (the clamp + the bounded decode loop), not OOM/panic.
+        match Graph::open(&dir) {
+            Ok(_) => panic!("a manifest whose count exceeds the file must NOT open"),
+            Err(e) => assert_eq!(
+                e.kind(),
+                std::io::ErrorKind::InvalidData,
+                "a hostile count must be a clean InvalidData error (truncated manifest), not an OOM"
+            ),
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (Copilot review #69, findings 1+2) The manifest write is ATOMIC: it goes
+    /// through a temp file + rename, so the canonical `named.bin` is always a COMPLETE image,
+    /// never a torn one. This asserts the temp file is cleaned up (renamed away, not left
+    /// behind) and that a simulated CRASH that leaves a stale `named.bin.tmp` behind does NOT
+    /// affect a subsequent open (the canonical manifest is the only commit point).
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn named_manifest_write_is_atomic_temp_then_rename() {
+        let nq = concat!(
+            "<http://ex/d> <http://ex/p> <http://ex/o> .\n",
+            "<http://res/x> <http://ex/p> <http://ex/ox> <http://res/x> .\n",
+            "<http://res/y> <http://ex/p> <http://ex/oy> <http://res/y> .\n",
+        );
+        let g = Graph::load_dataset(nq, "nquads").unwrap();
+        let dir = std::env::temp_dir().join(format!("sparq_named_atomic_{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        g.save(&dir).unwrap();
+        // The atomic write must leave the canonical manifest and NO leftover temp file.
+        assert!(dir.join("named.bin").exists(), "canonical manifest missing after atomic write");
+        assert!(!dir.join("named.bin.tmp").exists(), "temp manifest must be renamed away, not left behind");
+        // Simulate a crash mid-write of a *previous* attempt: a stale, GARBAGE temp file is on
+        // disk. It must be IGNORED on open (only `named.bin` is the commit point) — `open_named`
+        // reads `named.bin`, never `named.bin.tmp`, so the torn temp can never be misread.
+        std::fs::write(dir.join("named.bin.tmp"), b"torn-garbage-not-a-manifest").unwrap();
+        let g2 = Graph::open(&dir).unwrap();
+        assert_eq!(g2.named.len(), 2, "stale temp file must not affect the open");
+        // A fresh atomic write (into a clean dir) must leave NO leftover temp file: the rename
+        // consumed it. (We save the in-memory copy to a SEPARATE dir — re-saving an mmap'd
+        // graph back over its own source files is unsupported on every save path here.)
+        let dir2 = std::env::temp_dir().join(format!("sparq_named_atomic2_{}", std::process::id()));
+        std::fs::remove_dir_all(&dir2).ok();
+        g.save(&dir2).unwrap();
+        assert!(!dir2.join("named.bin.tmp").exists(), "atomic write must rename the temp file away");
+        let g3 = Graph::open(&dir2).unwrap();
+        assert_eq!(g3.named.len(), 2, "named graphs lost after atomic write");
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::remove_dir_all(&dir2).ok();
     }
 
     /// [OPUS-4.8] (sq-3ui0, gh-45) PER-GRAPH WAL durability: a NEW named graph created via

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -1050,6 +1050,13 @@ impl Graph {
     /// Persists the graph to `dir` (the permutation indexes + the dictionary) so it can
     /// later be QUERIED with the indexes MEMORY-MAPPED via [`open`](Self::open) — the
     /// out-of-core path for datasets larger than RAM.
+    ///
+    /// [OPUS-4.8] (sq-3ui0, gh-45) NAMED GRAPHS are persisted too: each named graph is
+    /// saved (recursively, identical format) under `dir/named/<i>/`, and a manifest
+    /// `dir/named.bin` records every graph's name term in index order. `open` replays the
+    /// manifest so a save→open round-trip is LOSSLESS for the whole dataset (every named
+    /// graph's triples + its IRI). A default-graph-only graph writes NO `named/` subtree
+    /// and NO `named.bin`, so its on-disk layout is byte-identical to before this change.
     #[cfg(feature = "mmap")]
     pub fn save(&self, dir: &std::path::Path) -> std::io::Result<()> {
         std::fs::create_dir_all(dir)?;
@@ -1057,7 +1064,8 @@ impl Graph {
         self.dict.save_mmap(dir)?; // includes appended (delta-overlay) terms
         write_numerics(&dir.join("numerics.bin"), &self.dense_numerics())?;
         let (tf, ti) = self.dense_temporals();
-        write_temporals(&dir.join("temporals.bin"), &tf, &ti)
+        write_temporals(&dir.join("temporals.bin"), &tf, &ti)?;
+        self.save_named(dir, false)
     }
 
     /// Like [`save`](Self::save) but persists the permutation indexes BLOCK-COMPRESSED
@@ -1072,7 +1080,91 @@ impl Graph {
         self.dict.save_mmap(dir)?;
         write_numerics(&dir.join("numerics.bin"), &self.dense_numerics())?;
         let (tf, ti) = self.dense_temporals();
-        write_temporals(&dir.join("temporals.bin"), &tf, &ti)
+        write_temporals(&dir.join("temporals.bin"), &tf, &ti)?;
+        // [OPUS-4.8] (sq-3ui0) Named graphs are persisted block-compressed too.
+        self.save_named(dir, true)
+    }
+
+    /// [OPUS-4.8] (sq-3ui0, gh-45) Persists every named graph under `dir/named/<i>/` and
+    /// writes the manifest `dir/named.bin` (the ordered list of graph-name terms). Each
+    /// sub-graph goes through the SAME [`save`](Self::save) / [`save_compressed`] machinery
+    /// (so it round-trips losslessly, recursively, and carries its own per-graph WAL on
+    /// `open`). No `named/` subtree and no `named.bin` are written when there are no named
+    /// graphs, so the default-graph-only directory layout is unchanged (byte-identical).
+    ///
+    /// STALE-STATE HYGIENE: when there ARE named graphs we first remove any pre-existing
+    /// `named/` subtree so a re-save into the same directory cannot leave orphaned old
+    /// sub-graphs behind; when there are none we remove both the subtree and the manifest
+    /// so a graph that lost all its named graphs persists as a clean default-only directory.
+    #[cfg(feature = "mmap")]
+    fn save_named(&self, dir: &std::path::Path, compressed: bool) -> std::io::Result<()> {
+        let named_dir = dir.join(NAMED_SUBDIR);
+        let manifest = dir.join(NAMED_MANIFEST);
+        if self.named.is_empty() {
+            // Default-graph-only: ensure no stale named state lingers, then write nothing.
+            std::fs::remove_dir_all(&named_dir).ok();
+            std::fs::remove_file(&manifest).ok();
+            return Ok(());
+        }
+        let _ = &manifest;
+        // Rewrite the subtree from scratch so removed/renamed graphs cannot survive a re-save.
+        std::fs::remove_dir_all(&named_dir).ok();
+        std::fs::create_dir_all(&named_dir)?;
+        for (i, (_, sub)) in self.named.iter().enumerate() {
+            let sub_dir = named_dir.join(i.to_string());
+            if compressed {
+                sub.save_compressed(&sub_dir)?;
+            } else {
+                sub.save(&sub_dir)?;
+            }
+        }
+        // Write the manifest LAST (after every sub-graph is durable) so a crash mid-save
+        // never leaves a manifest pointing at a missing/partial sub-graph. The presence of
+        // a complete `named.bin` is the commit point for the named-graph set.
+        let names: Vec<Term> = self.named.iter().map(|(n, _)| n.clone()).collect();
+        write_named_manifest(dir, &names)
+    }
+
+    /// [OPUS-4.8] (sq-3ui0, gh-45) Loads the named graphs persisted by
+    /// [`save_named`](Self::save_named) back into [`named`](Self::named), each opened via
+    /// [`open`](Self::open) (so every sub-graph is memory-mapped and carries its OWN
+    /// per-graph WAL). Returns an empty vec — backward compatible — when `dir` carries no
+    /// `named.bin` (a default-graph-only directory, or one saved before this format). A
+    /// present-but-malformed manifest (wrong magic / unknown version) is a hard error
+    /// rather than a silent misread, so an incompatible on-disk format is never opened as
+    /// if it were valid.
+    #[cfg(feature = "mmap")]
+    fn open_named(dir: &std::path::Path) -> std::io::Result<Vec<(Term, Graph)>> {
+        let manifest = dir.join(NAMED_MANIFEST);
+        let bytes = match std::fs::read(&manifest) {
+            Ok(b) => b,
+            // No manifest: default-graph-only or a pre-named-graph directory.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e),
+        };
+        let bad = |msg: &str| std::io::Error::new(std::io::ErrorKind::InvalidData, format!("named.bin: {msg}"));
+        if bytes.len() < 12 {
+            return Err(bad("manifest too short for header"));
+        }
+        let magic = u32::from_le_bytes(bytes[0..4].try_into().expect("4 bytes"));
+        if magic != NAMED_MANIFEST_MAGIC {
+            return Err(bad("bad magic (not a named-graph manifest)"));
+        }
+        let version = u32::from_le_bytes(bytes[4..8].try_into().expect("4 bytes"));
+        if version != NAMED_FORMAT_VERSION {
+            return Err(bad(&format!("unsupported format version {version} (this build writes/reads {NAMED_FORMAT_VERSION})")));
+        }
+        let count = u32::from_le_bytes(bytes[8..12].try_into().expect("4 bytes")) as usize;
+        let named_dir = dir.join(NAMED_SUBDIR);
+        let mut out = Vec::with_capacity(count);
+        let mut pos = 12usize;
+        for i in 0..count {
+            let (name, next) = decode_graph_name(&bytes, pos).map_err(|m| bad(&m))?;
+            pos = next;
+            let sub = Graph::open(&named_dir.join(i.to_string()))?;
+            out.push((name, sub));
+        }
+        Ok(out)
     }
 
     /// Decodes any block-compressed permutation indexes into raw RAM (the load-time
@@ -1181,7 +1273,11 @@ impl Graph {
             // backward compatible, like the numerics cache.
             _ => TempData::Owned(temporals_of(&dict)),
         };
-        let mut g = Graph { dict, store, numerics, temporals, named: Vec::new(), wal: None };
+        // [OPUS-4.8] (sq-3ui0, gh-45) Restore the named graphs (each opened memory-mapped
+        // with its own per-graph WAL) so a save→open round-trip is lossless for the whole
+        // dataset. Empty for a default-graph-only / pre-named-graph directory.
+        let named = Self::open_named(dir)?;
+        let mut g = Graph { dict, store, numerics, temporals, named, wal: None };
         // Replay any write-ahead log into the delta-overlay (recovery after a crash or a
         // plain not-yet-compacted close), stopping cleanly at the first torn record and
         // truncating the log there — then keep the log open for further appends.
@@ -1806,6 +1902,13 @@ impl Graph {
                 }
             }
         }
+        // [OPUS-4.8] (sq-3ui0, gh-45) For a DIRECTORY-BACKED parent, a NEW named graph is
+        // created with its own on-disk directory + per-graph WAL under `dir/named/<i>/` so
+        // its very first mutation is WAL-logged + fsync'd (durable before this call
+        // returns) and the manifest is kept in sync — not deferred to the next save. An
+        // in-memory parent keeps the overlay-only path (no directory, no WAL).
+        #[cfg(feature = "mmap")]
+        let parent_dir = self.wal.as_ref().map(|w| w.dir.clone());
         for (slot, ins, del) in slots {
             match slot {
                 None => self.apply_delta(&ins, &del)?,
@@ -1813,6 +1916,13 @@ impl Graph {
                     if let Some(i) = self.named.iter().position(|(n, _)| *n == name) {
                         self.named[i].1.apply_delta(&ins, &del)?;
                     } else if !ins.is_empty() {
+                        #[cfg(feature = "mmap")]
+                        if let Some(dir) = &parent_dir {
+                            let mut g = self.create_durable_named(dir, &name)?;
+                            g.apply_delta(&ins, &[])?;
+                            self.named.push((name, g));
+                            continue;
+                        }
                         let mut g = Graph::from_parts(Dict::new(), Vec::new());
                         g.apply_delta(&ins, &[])?;
                         self.named.push((name, g));
@@ -1821,6 +1931,30 @@ impl Graph {
             }
         }
         Ok(())
+    }
+
+    /// [OPUS-4.8] (sq-3ui0, gh-45) Creates a fresh, EMPTY named sub-graph that is
+    /// directory-backed (its own `dir/named/<i>/` + per-graph WAL) and appends/updates the
+    /// parent's `named.bin` manifest so the new graph is recoverable on the next
+    /// [`open`](Self::open) even before a full [`save`](Self::save)/[`compact`]. The index
+    /// `i` is the parent's current `named.len()` (the slot this graph will occupy). Saving
+    /// an empty graph then re-opening it yields a graph with its own WAL, so the caller can
+    /// immediately [`apply_delta`](Self::apply_delta) durably.
+    #[cfg(feature = "mmap")]
+    fn create_durable_named(&self, dir: &std::path::Path, name: &Term) -> Result<Graph, String> {
+        let i = self.named.len();
+        let named_dir = dir.join(NAMED_SUBDIR);
+        let sub_dir = named_dir.join(i.to_string());
+        std::fs::create_dir_all(&named_dir).map_err(|e| e.to_string())?;
+        // Persist an empty sub-graph, then open it so it carries its own WAL.
+        let empty = Graph::from_parts(Dict::new(), Vec::new());
+        empty.save(&sub_dir).map_err(|e| e.to_string())?;
+        // Rewrite the manifest with the new entry appended (index order == named order).
+        let mut names: Vec<Term> = self.named.iter().map(|(n, _)| n.clone()).collect();
+        names.push(name.clone());
+        write_named_manifest(dir, &names).map_err(|e| e.to_string())?;
+        fsync_dir(&named_dir).map_err(|e| e.to_string())?;
+        Graph::open(&sub_dir).map_err(|e| e.to_string())
     }
 
     /// The in-memory half of [`apply_delta`](Self::apply_delta) (no WAL append) — also
@@ -1963,6 +2097,81 @@ fn recover_compaction(dir: &std::path::Path) -> std::io::Result<()> {
         fsync_dir(parent)?;
     }
     Ok(())
+}
+
+/// [OPUS-4.8] (sq-3ui0, gh-45) The subdirectory holding the persisted named graphs (one
+/// numbered sub-directory per named graph), and the manifest file naming them in order.
+#[cfg(feature = "mmap")]
+const NAMED_SUBDIR: &str = "named";
+#[cfg(feature = "mmap")]
+const NAMED_MANIFEST: &str = "named.bin";
+/// Manifest magic ("NMG1" little-endian) — identifies a named-graph manifest and lets a
+/// stray/legacy file be rejected rather than misread.
+#[cfg(feature = "mmap")]
+const NAMED_MANIFEST_MAGIC: u32 = 0x31_47_4D_4E;
+/// On-disk named-graph format version. Bumped if the named-graph LAYOUT changes
+/// incompatibly; `open_named` refuses an unknown version rather than silently misreading.
+#[cfg(feature = "mmap")]
+const NAMED_FORMAT_VERSION: u32 = 1;
+
+/// [OPUS-4.8] (sq-3ui0) Writes the named-graph manifest `dir/named.bin`: the magic +
+/// format version + count, then each graph name in order (see [`encode_graph_name`]). The
+/// sub-graph directories `dir/named/<i>/` must already be durable before this is called —
+/// the manifest's presence is the commit point for the named-graph set.
+#[cfg(feature = "mmap")]
+fn write_named_manifest(dir: &std::path::Path, names: &[Term]) -> std::io::Result<()> {
+    let mut buf = Vec::with_capacity(12 + names.len() * 32);
+    buf.extend_from_slice(&NAMED_MANIFEST_MAGIC.to_le_bytes());
+    buf.extend_from_slice(&NAMED_FORMAT_VERSION.to_le_bytes());
+    buf.extend_from_slice(&(names.len() as u32).to_le_bytes());
+    for name in names {
+        encode_graph_name(&mut buf, name);
+    }
+    std::fs::write(dir.join(NAMED_MANIFEST), &buf)
+}
+
+/// [OPUS-4.8] (sq-3ui0) Serialise a graph-name term into the manifest buffer as
+/// `[kind u8][len u32][raw value bytes]`, where kind is 0 for a NamedNode (value = the
+/// raw IRI) and 1 for a BlankNode (value = the raw label). Storing the RAW string with a
+/// length prefix avoids any N-Triples escaping ambiguity on the round-trip. Graph names
+/// are only ever NamedNode or BlankNode (never a literal/triple — see
+/// [`load_dataset`](Graph::load_dataset) / [`apply_delta_nquads`](Graph::apply_delta_nquads)).
+#[cfg(feature = "mmap")]
+fn encode_graph_name(buf: &mut Vec<u8>, name: &Term) {
+    // Graph names are constrained to NamedNode | BlankNode by every public loader; encode
+    // each with its raw value. A literal/triple graph name cannot occur, so map it to its
+    // lexical form as a NamedNode rather than panicking (keeps the encoding total).
+    let (kind, val): (u8, String) = match name {
+        Term::NamedNode(n) => (0, n.as_str().to_string()),
+        Term::BlankNode(b) => (1, b.as_str().to_string()),
+        other => (0, other.to_string()),
+    };
+    buf.push(kind);
+    let bytes = val.as_bytes();
+    buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+    buf.extend_from_slice(bytes);
+}
+
+/// [OPUS-4.8] (sq-3ui0) Inverse of [`encode_graph_name`]: decode the term starting at
+/// `pos`, returning it plus the offset just past it. Bounds-checked — a truncated or
+/// non-UTF-8 record is a clean `Err`, never a panic / OOB read (the manifest is a trusted
+/// asset, but the loader stays memory-safe under corruption like the rest of `open`).
+#[cfg(feature = "mmap")]
+fn decode_graph_name(bytes: &[u8], pos: usize) -> Result<(Term, usize), String> {
+    let kind = *bytes.get(pos).ok_or("truncated manifest (missing kind byte)")?;
+    let lo = pos + 1;
+    let len_end = lo + 4;
+    let len_bytes = bytes.get(lo..len_end).ok_or("truncated manifest (missing length)")?;
+    let len = u32::from_le_bytes(len_bytes.try_into().expect("4 bytes")) as usize;
+    let val_end = len_end + len;
+    let val_bytes = bytes.get(len_end..val_end).ok_or("truncated manifest (length exceeds buffer)")?;
+    let val = std::str::from_utf8(val_bytes).map_err(|_| "non-UTF-8 graph name in manifest".to_string())?;
+    let term = match kind {
+        0 => Term::NamedNode(oxrdf::NamedNode::new(val).map_err(|e| format!("invalid IRI graph name: {e}"))?),
+        1 => Term::BlankNode(oxrdf::BlankNode::new(val).map_err(|e| format!("invalid blank-node graph name: {e}"))?),
+        k => return Err(format!("unknown graph-name kind byte {k}")),
+    };
+    Ok((term, val_end))
 }
 
 /// The append-only write-ahead log of update operations for a directory-backed graph.
@@ -3918,6 +4127,168 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// [OPUS-4.8] (sq-3ui0, gh-45) A dataset with MULTIPLE named graphs must survive a
+    /// save→open round-trip LOSSLESSLY: every named graph's IRI + triples reopen exactly,
+    /// including a graph the default graph does not name. Sorted-dump equality of the whole
+    /// dataset (default + every named graph) on both sides is the data-loss guard — before
+    /// this fix `open` dropped `named` entirely (total data loss for PSS's per-resource
+    /// named graphs).
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn save_open_named_graphs_roundtrip_lossless() {
+        // Dump a single graph's triples as a sorted N-Triples-ish vector.
+        fn dump_one(gg: &Graph) -> Vec<(String, String, String)> {
+            let scan = gg.store.scan(&[None, None, None]);
+            let mut v: Vec<(String, String, String)> = scan
+                .rows
+                .iter()
+                .map(|r| {
+                    let spo = scan.to_spo(r);
+                    (gg.dict.term(spo[0]).to_string(), gg.dict.term(spo[1]).to_string(), gg.dict.term(spo[2]).to_string())
+                })
+                .collect();
+            v.sort();
+            v
+        }
+        // Dump the WHOLE dataset: default graph under key "", each named graph under its name.
+        fn dump_dataset(gg: &Graph) -> Vec<(String, Vec<(String, String, String)>)> {
+            let mut out: Vec<(String, Vec<(String, String, String)>)> = vec![(String::new(), dump_one(gg))];
+            for (name, sub) in &gg.named {
+                out.push((name.to_string(), dump_one(sub)));
+            }
+            out.sort();
+            out
+        }
+
+        // A dataset shaped like PSS: a default graph plus several named graphs whose IRI ==
+        // the "resource" IRI (one of them with a literal + lang-tag, one a single triple).
+        let nq = concat!(
+            "<http://ex/default-s> <http://ex/p> <http://ex/default-o> .\n",
+            "<http://res/a> <http://ex/p> \"value a\" <http://res/a> .\n",
+            "<http://res/a> <http://ex/label> \"caf\\u00e9\"@fr <http://res/a> .\n",
+            "<http://res/b> <http://ex/p> <http://ex/o-b> <http://res/b> .\n",
+            "<http://res/b/.acl> <http://acl#mode> <http://acl#Read> <http://res/b/.acl> .\n",
+        );
+        let g = Graph::load_dataset(nq, "nquads").unwrap();
+        assert_eq!(g.named.len(), 3, "fixture should have 3 named graphs");
+        let before = dump_dataset(&g);
+
+        let dir = std::env::temp_dir().join(format!("sparq_named_rt_{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        g.save(&dir).unwrap();
+        // The manifest + one sub-directory per named graph must exist.
+        assert!(dir.join("named.bin").exists(), "named-graph manifest not persisted");
+        for i in 0..3 {
+            assert!(dir.join("named").join(i.to_string()).join("perm0.bin").exists(), "named sub-graph {i} not persisted");
+        }
+
+        let g2 = Graph::open(&dir).unwrap();
+        assert_eq!(g2.named.len(), 3, "named graphs dropped on reopen");
+        let after = dump_dataset(&g2);
+        assert_eq!(before, after, "named-graph dataset not losslessly round-tripped");
+
+        // Every reopened named graph must carry its OWN per-graph WAL (durable updates).
+        for (_, sub) in &g2.named {
+            assert!(sub.wal.is_some(), "reopened named graph lacks its own WAL");
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (sq-3ui0) The block-COMPRESSED save path must round-trip named graphs too.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn save_compressed_named_graphs_roundtrip_lossless() {
+        let nq = concat!(
+            "<http://ex/d> <http://ex/p> <http://ex/o> .\n",
+            "<http://res/x> <http://ex/p> <http://ex/ox> <http://res/x> .\n",
+            "<http://res/y> <http://ex/p> <http://ex/oy> <http://res/y> .\n",
+        );
+        let g = Graph::load_dataset(nq, "nquads").unwrap();
+        let dir = std::env::temp_dir().join(format!("sparq_named_zrt_{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        g.save_compressed(&dir).unwrap();
+        let g2 = Graph::open(&dir).unwrap();
+        assert_eq!(g2.named.len(), 2);
+        let named_of = |gg: &Graph, name: &str| {
+            gg.named.iter().find(|(n, _)| n.to_string() == format!("<{name}>")).map(|(_, s)| s.len())
+        };
+        assert_eq!(named_of(&g2, "http://res/x"), Some(1));
+        assert_eq!(named_of(&g2, "http://res/y"), Some(1));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (sq-3ui0) A DEFAULT-GRAPH-ONLY save writes NO `named/` subtree and NO
+    /// `named.bin`, so its on-disk layout is unchanged from before this feature
+    /// (byte-identity preserved for the common single-graph case).
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn default_only_save_has_no_named_artifacts() {
+        let g = Graph::load_str("<http://ex/s> <http://ex/p> <http://ex/o> .\n", "ntriples").unwrap();
+        assert!(g.named.is_empty());
+        let dir = std::env::temp_dir().join(format!("sparq_default_only_{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        g.save(&dir).unwrap();
+        assert!(!dir.join("named.bin").exists(), "default-only save must not write a named manifest");
+        assert!(!dir.join("named").exists(), "default-only save must not write a named subtree");
+        let g2 = Graph::open(&dir).unwrap();
+        assert!(g2.named.is_empty());
+        assert_eq!(g2.len(), 1);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (sq-3ui0) A named-graph manifest with an UNKNOWN format version (or bad
+    /// magic) is a hard error on open — never silently misread as the current format.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn named_manifest_unknown_version_is_rejected() {
+        let nq = "<http://res/x> <http://ex/p> <http://ex/o> <http://res/x> .\n";
+        let g = Graph::load_dataset(nq, "nquads").unwrap();
+        let dir = std::env::temp_dir().join(format!("sparq_named_badver_{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        g.save(&dir).unwrap();
+        // Corrupt the manifest's version field (bytes 4..8) to a future version.
+        let mut bytes = std::fs::read(dir.join("named.bin")).unwrap();
+        bytes[4..8].copy_from_slice(&999u32.to_le_bytes());
+        std::fs::write(dir.join("named.bin"), &bytes).unwrap();
+        match Graph::open(&dir) {
+            Ok(_) => panic!("unknown manifest version must NOT open silently"),
+            Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::InvalidData, "unknown version must be a hard InvalidData error"),
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (sq-3ui0, gh-45) PER-GRAPH WAL durability: a NEW named graph created via
+    /// `apply_delta_nquads` against a DIRECTORY-BACKED graph is WAL-logged + manifested at
+    /// once, so a crash-style reopen (no `save`/`compact` in between) still recovers both
+    /// the new graph AND a subsequent named-graph update — the named-graph analogue of the
+    /// default-graph WAL recovery.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn named_graph_updates_are_wal_durable() {
+        let dir = std::env::temp_dir().join(format!("sparq_named_wal_{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        // Persist an empty (default-only) directory-backed graph, then open it for updates.
+        Graph::load_str("", "ntriples").unwrap().save(&dir).unwrap();
+        {
+            let mut g = Graph::open(&dir).unwrap();
+            // Create a brand-new named graph (auto-created) and add a triple to it.
+            g.apply_delta_nquads("<http://res/a> <http://ex/p> <http://ex/o1> <http://res/a> .\n", "").unwrap();
+            // A second batch into the SAME named graph (exercises the per-graph WAL append).
+            g.apply_delta_nquads("<http://res/a> <http://ex/p> <http://ex/o2> <http://res/a> .\n", "").unwrap();
+            // A second named graph too.
+            g.apply_delta_nquads("<http://res/b> <http://ex/p> <http://ex/o3> <http://res/b> .\n", "").unwrap();
+            // Deliberately DROP `g` WITHOUT save()/compact() — only the WALs are on disk.
+        }
+        // Reopen: the named graphs + every WAL-logged triple must recover.
+        let g2 = Graph::open(&dir).unwrap();
+        let named_of = |gg: &Graph, name: &str| {
+            gg.named.iter().find(|(n, _)| n.to_string() == format!("<{name}>")).map(|(_, s)| s.len())
+        };
+        assert_eq!(named_of(&g2, "http://res/a"), Some(2), "named graph a lost a WAL-logged triple");
+        assert_eq!(named_of(&g2, "http://res/b"), Some(1), "named graph b not recovered from WAL");
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[cfg(feature = "mmap")]

--- a/crates/sparq-engine/tests/named_graph_persistence.rs
+++ b/crates/sparq-engine/tests/named_graph_persistence.rs
@@ -1,0 +1,65 @@
+//! [OPUS-4.8] (sq-3ui0, gh-45) End-to-end persistence test for NAMED graphs: a dataset
+//! with several named graphs is queried with `GRAPH ?g { ... }`, then SAVED and REOPENED
+//! (memory-mapped, the out-of-core path), and the SAME query must return byte-identical
+//! rows. Before the fix, `Graph::open` dropped `named` entirely, so every `GRAPH`-scoped
+//! query returned ZERO rows after a reopen — total data loss for the PSS shape (every
+//! resource / `.acl` stored as a named graph whose IRI == the resource IRI).
+//!
+//! Pinned at the engine layer (not just core's structural round-trip) so the guarantee is
+//! the one PSS actually relies on: a quad-level query over a reopened store.
+
+#![cfg(feature = "parallel")] // engine default; mmap comes from sparq-core dev-dep
+
+use sparq_core::Graph;
+use sparq_engine::{query, QueryResult};
+
+/// PSS-shaped dataset: a default graph plus named graphs whose IRI == the resource IRI,
+/// including a `.acl` graph and a graph carrying a language-tagged literal.
+const DATA: &str = "\
+<http://ex/d1> <http://ex/p> <http://ex/d2> .
+<http://res/a> <http://ex/p> <http://ex/b> <http://res/a> .
+<http://res/a> <http://ex/label> \"caf\\u00e9\"@fr <http://res/a> .
+<http://res/b> <http://ex/p> <http://ex/c> <http://res/b> .
+<http://res/b/.acl> <http://acl#mode> <http://acl#Read> <http://res/b/.acl> .
+";
+
+/// Sort a result's rows into a stable string form for set-equality comparison.
+fn rows_sorted(r: &QueryResult) -> Vec<Vec<String>> {
+    let mut v: Vec<Vec<String>> = r
+        .rows
+        .iter()
+        .map(|row| row.iter().map(|c| c.as_ref().map(|t| t.to_string()).unwrap_or_default()).collect())
+        .collect();
+    v.sort();
+    v
+}
+
+#[test]
+fn graph_query_survives_save_open_roundtrip() {
+    let g = Graph::load_dataset(DATA, "nquads").unwrap();
+    assert_eq!(g.named.len(), 3, "fixture should hold 3 named graphs");
+
+    // Quad-level queries to pin down: enumerate (?g, ?s, ?p, ?o), and a graph-scoped one.
+    let q_all = "SELECT ?g ?s ?p ?o WHERE { GRAPH ?g { ?s ?p ?o } }";
+    let q_one = "SELECT ?s ?p ?o WHERE { GRAPH <http://res/b/.acl> { ?s ?p ?o } }";
+    let q_default = "SELECT ?s ?p ?o WHERE { ?s ?p ?o }";
+
+    let before_all = rows_sorted(&query(&g, q_all).unwrap());
+    let before_one = rows_sorted(&query(&g, q_one).unwrap());
+    let before_default = rows_sorted(&query(&g, q_default).unwrap());
+    assert_eq!(before_all.len(), 4, "4 named-graph triples expected");
+    assert_eq!(before_one.len(), 1, "the .acl graph has one triple");
+    assert_eq!(before_default.len(), 1, "default graph has one triple");
+
+    let dir = std::env::temp_dir().join(format!("sparq_ng_persist_{}", std::process::id()));
+    std::fs::remove_dir_all(&dir).ok();
+    g.save(&dir).unwrap();
+    let g2 = Graph::open(&dir).unwrap();
+
+    // The SAME queries over the reopened (mmap) store must return the SAME rows.
+    assert_eq!(rows_sorted(&query(&g2, q_all).unwrap()), before_all, "GRAPH ?g rows changed after reopen");
+    assert_eq!(rows_sorted(&query(&g2, q_one).unwrap()), before_one, "graph-scoped rows changed after reopen");
+    assert_eq!(rows_sorted(&query(&g2, q_default).unwrap()), before_default, "default-graph rows changed after reopen");
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the `jeswr/sparq` RDF/SPARQL engine (Claude Opus 4.8). @jeswr runs multiple agents; this was written by the **SPARQ** agent. The **PSS** agent (`prod-solid-server`) is a separate party in these discussions.

Fixes the **deepest PSS showstopper** (gh-45 / sq-3ui0): `Graph::save` serialized only the default graph and `Graph::open` hard-coded `named: Vec::new()`, so **every save→open round-trip silently dropped all named-graph data** — total data loss for the PSS shape where every resource/.acl is a named graph.

## What changed
- **Versioned on-disk format**: named graphs persist as one full sub-directory per graph under `dir/named/<i>/` (recursively the same save/open machinery) plus a `dir/named.bin` manifest (`[magic "NMG1"][version u32=1][count u32]` + each graph-name term). Manifest written **last** (commit point). Unknown version / bad magic → hard `InvalidData` (never a silent misread).
- **Backward compatible**: a default-graph-only graph writes **no** `named/` subtree and **no** `named.bin`, so its on-disk layout is **byte-identical** to before; absent manifest opens as default-only. Covers both `save()` and `save_compressed()`; compaction's dir-swap preserves named graphs.
- **Per-graph WAL**: each named graph reopened from disk carries its own `wal.log`; a new named graph created via `apply_delta_nquads` against a directory-backed parent is created durable + manifested immediately, so its first mutation is WAL-logged + fsync'd and recoverable on reopen without an intervening save/compact.

## Tests
`save_open_named_graphs_roundtrip_lossless`, `save_compressed_named_graphs_roundtrip_lossless`, `default_only_save_has_no_named_artifacts` (byte-identity), `named_manifest_unknown_version_is_rejected`, `named_graph_updates_are_wal_durable`, and `sparq-engine/tests/named_graph_persistence.rs` (`GRAPH ?g {…}` returns identical rows over the reopened mmap store).

## Gate
clippy `--workspace --exclude sparq-py --all-targets -D warnings` clean; sparq-core 81 (mmap) / 96 (mmap,dict-spill) incl. `mmap_corruption_oracle`; sparq-engine 192; sparq-server 140.

Closes sq-3ui0 (gh-45). Follow-up: **sq-5atq** (out-of-core N-Quads/TriG build for named graphs — `build_external` is still N-Triples/default-only).

[OPUS-4.8]