### PR TITLE
feat(sparq-server): required Bearer-token gate on the write surface + optional read gate (sq-zcby)

### DIFF
--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -15,15 +15,57 @@ N-Triples/Turtle/RDF-XML), EXPLAIN, Prometheus `/metrics`, WebSocket subscriptio
 opt-in time-travel feature. Reads and writes never share a lock (a generation-ring snapshot
 chain + a single sequenced group-commit writer), so queries never wait on the writer.
 
-## Security posture — no built-in auth (read before exposing)
+## Security posture (read before exposing)
 
-**`sparq-server` has NO authentication on any endpoint** — including the mutating
-`application/sparql-update` path and the `/subscriptions` WebSocket. Anyone who can reach the
-port can read AND write the whole dataset. Authorization belongs to a layer in front (a
-reverse proxy / gateway, or [`sparq-solid`](../sparq-solid)). Therefore:
+### Authentication — optional Bearer-token write gate (mirrors QLever's `-a`)
 
-- The server **binds loopback by default** (`127.0.0.1:3030`); a non-loopback bind is
-  **refused** unless you opt in with `--allow-remote` (env `SPARQ_ALLOW_REMOTE=1`).
+By default `sparq-server` has **no authentication** — anyone who can reach the port can read
+AND write the whole dataset. You can turn on a **required Bearer-token gate on the write
+surface** (PSS gh-46), with an **optional read gate**:
+
+- **`--auth-token <TOKEN>`** (env `SPARQ_AUTH_TOKEN`) — gates **writes**. Every request that
+  MUTATES the dataset must present `Authorization: Bearer <TOKEN>` or it is refused `401`
+  (with `WWW-Authenticate: Bearer`). The write surface is: a SPARQL **UPDATE** on `/sparql`
+  (`Content-Type: application/sparql-update`, OR a `query`/`update` body that *parses as an
+  update* — classification keys on "does this mutate", not the route), and the **Graph-Store
+  Protocol write methods** (`PUT`/`POST`/`DELETE`) on `/sparql/graph` and `/graphs/{*path}`.
+  The token is compared in **constant time**. Scheme casing is tolerated (`Bearer`/`bearer`).
+  When unset, there is **no write auth** (today's behaviour preserved exactly).
+- **`--auth-token-read`** (env `SPARQ_AUTH_TOKEN_READ=1`) — ALSO gate **reads** (SPARQL query,
+  GSP `GET`/`HEAD`) with the same token. Off by default (QLever-style: writes gated, reads
+  open). Has no effect unless a token is also configured.
+- The 401 is **identical for a missing vs a wrong token**, so an attacker cannot learn whether
+  a token was presented.
+- The `/subscriptions` WebSocket (live SELECT diffs, a read surface) is **not** gated by this
+  token — keep it behind a proxy if it must be restricted (bead `sq-cxk5` tracks gating it).
+
+This is a complement to, not a replacement for, a real authorization layer (a reverse proxy /
+gateway, or [`sparq-solid`](../sparq-solid)) — the gate is a single shared secret with no
+per-user identity, scopes, or TLS of its own. **Deliver the token over TLS** (terminate it at a
+proxy); a bare `Bearer` token on plaintext HTTP is sniffable.
+
+### Bind posture — loopback by default; the auth × bind matrix
+
+The server **binds loopback by default** (`127.0.0.1:3030`, reachable only from this host). A
+**non-loopback** bind (e.g. `0.0.0.0`) exposes the surface to the network, so the binary
+refuses it unless the posture makes it safe. The full matrix:
+
+| `--auth-token`? | `--auth-token-read`? | `--allow-remote`? | non-loopback bind |
+| --- | --- | --- | --- |
+| no  | —   | no  | **refused** — read+write fully open |
+| no  | —   | yes | allowed, **warns** read+write exposed |
+| yes | no  | no  | **refused** — writes gated but **reads still open** |
+| yes | no  | yes | allowed, **warns** reads remain open |
+| yes | yes | no  | **allowed** — whole surface authenticated (still warns) |
+| yes | yes | yes | **allowed** (still warns) |
+
+The rule: a configured write-token counts as "auth present" for the bind decision **only when
+reads are also gated** (`--auth-token-read`) — because a write-token alone still leaves an open
+read endpoint on a remote bind. When only writes are gated, `--allow-remote` is still required
+and the server warns that reads remain open. Loopback binds are always allowed.
+
+### SERVICE federation + DoS guards
+
 - SPARQL `SERVICE` federation is **OFF in the default build** (the `service` cargo feature).
   Built with `--features service` it is **default-DENY-all**: a `SERVICE <iri>` reaches
   nothing unless its host is on the egress allowlist (`--service-allow` / `--service-allow-file`
@@ -52,6 +94,9 @@ curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=SELECT * WHERE { ?s
   (`?graph=`/`?default`) and direct (request-URI) graph identification.
 - **Content negotiation** — q-value aware; SELECT/ASK in JSON/XML/CSV/TSV, CONSTRUCT/DESCRIBE
   and GSP read in N-Triples / prefix-Turtle / RDF/XML; streamed SELECT bodies.
+- **Authentication** — optional `--auth-token <TOKEN>` Bearer gate on the write surface
+  (constant-time compared; mirrors QLever's `-a`), with an optional `--auth-token-read` gate
+  for reads. Off by default (back-compat). See "Security posture".
 - **Hardening flags** — `--query-timeout` / `--max-body-bytes` / `--max-concurrent` /
   `--max-results` / `--max-subscriptions*`, each with a `SPARQ_*` env override.
 - **EXPLAIN / EXPLAIN ANALYZE**, Prometheus **`/metrics`**, and SEPA-style **WebSocket

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -158,9 +158,11 @@ pub struct ServerConfig {
     /// surface**. When `Some(token)`, every request that MUTATES the dataset must present
     /// `Authorization: Bearer <token>` (scheme casing tolerated) or it is refused `401`
     /// with `WWW-Authenticate: Bearer`. The write surface is: a SPARQL UPDATE on `/sparql`
-    /// (`Content-Type: application/sparql-update`, OR a `query`/`update` body that *parses
-    /// as an update* — classification keys on whether the request mutates, not the route),
-    /// and the Graph-Store-Protocol write methods (`PUT`/`POST`/`DELETE`/`PATCH`) on
+    /// — `Content-Type: application/sparql-update` OR an `update=` form field (BOTH are
+    /// updates by SPARQL-Protocol definition, gated as writes UNCONDITIONALLY), and ALSO a
+    /// `query=`/`application/sparql-query` body that *parses as an update* (an update smuggled
+    /// through the query path — classification there keys on whether the request mutates, not
+    /// the route) — and the Graph-Store-Protocol write methods (`PUT`/`POST`/`DELETE`/`PATCH`) on
     /// `/sparql/graph` and `/graphs/{*path}`. The token is compared in **constant time**
     /// ([`constant_time_eq`]). A missing vs a wrong token produce the *identical* 401, so an
     /// attacker cannot learn whether a token was presented. `None` (the default) means **no
@@ -469,8 +471,13 @@ pub(crate) fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     for (x, y) in a.iter().zip(b.iter()) {
         diff |= x ^ y;
     }
-    // Fold to bool without a data-dependent branch on the secret.
-    diff == 0
+    // [OPUS-4.8] sq-zcby (Copilot PR#71 fix): route the accumulator through
+    // `core::hint::black_box` BEFORE the `== 0` test so the optimiser cannot prove anything
+    // about `diff` and rewrite the loop+compare into an early-exit `memcmp`-style
+    // short-circuit. This matches the doc claim ("black_box-style fold"): without it the
+    // bare `diff == 0` was a plain data-dependent comparison the compiler is free to
+    // short-circuit. Fold to bool with no data-dependent branch on the secret.
+    core::hint::black_box(diff) == 0
 }
 
 /// [OPUS-4.8] sq-zcby: extracts the token from an `Authorization: Bearer <token>` header,
@@ -518,21 +525,30 @@ fn unauthorized() -> Response {
     resp
 }
 
-/// [OPUS-4.8] sq-zcby: does this SPARQL string MUTATE the dataset? The auth classifier keys on
-/// this, not on the route or Content-Type, so an UPDATE smuggled through the query path is
-/// still gated as a write. A string that parses as a read-only query (SELECT/ASK/CONSTRUCT/
-/// DESCRIBE) is a read; otherwise, if it parses as a SPARQL Update, it is a write. A string
-/// that parses as NEITHER is treated conservatively as a write (fail-closed: the writer/query
-/// handler will reject it, and gating an unparsable body as a write never wrongly opens the
-/// write surface).
+/// [OPUS-4.8] sq-zcby: does this SPARQL string MUTATE the dataset, for the auth classifier?
+/// The classifier keys on this, not on the route or Content-Type, so an UPDATE smuggled
+/// through a `query=`/generic body path is still gated as a write.
+///
+/// [OPUS-4.8] (Copilot PR#71 doc/impl-consistency fix) The implemented rule is
+/// **default-to-write unless it provably parses as a read-only query**: a string that parses
+/// as a read-only query (SELECT/ASK/CONSTRUCT/DESCRIBE) returns `false` (a read); EVERYTHING
+/// ELSE returns `true` (gated as a write). That "everything else" deliberately collapses the
+/// "parses as a SPARQL Update" and the "parses as NEITHER" cases into one branch — both are
+/// fail-safe to gate as a write, so a positive `parse_update` check would only add cost
+/// without changing the answer. This is the conservative/secure default: ambiguous or
+/// malformed bodies are gated as writes (fail-closed), so a body can never slip past the
+/// write gate by being unparsable, and gating a non-mutating-but-unparsable body as a write
+/// never wrongly OPENS the write surface (the writer/query handler rejects it anyway).
+///
+/// Note this function is only the classifier for the AMBIGUOUS body path; the unambiguous
+/// `update=` form field and `application/sparql-update` Content-Type are gated as writes
+/// unconditionally at their call sites (they ARE updates by protocol definition), without
+/// consulting this function.
 pub(crate) fn payload_mutates(sparql: &str) -> bool {
-    if spargebra::SparqlParser::new().parse_query(sparql).is_ok() {
-        return false; // a well-formed read-only query
-    }
-    // Not a read-only query. If it parses as an update it definitely mutates; if it parses as
-    // neither, fail closed (treat as a write) so a malformed body can never slip past the
-    // write gate. Either way the answer is "this is not a read", i.e. gate it as a write.
-    true
+    // Provably a read-only query => a read (`is_ok`). Otherwise (parses as an update, OR
+    // parses as neither) => fail-safe to a write (`is_err`). The two non-read cases share one
+    // branch on purpose: both must be gated as a write, so distinguishing them changes nothing.
+    spargebra::SparqlParser::new().parse_query(sparql).is_err()
 }
 
 fn env_parse<T: std::str::FromStr>(name: &str) -> Option<T> {
@@ -1140,21 +1156,31 @@ async fn handle_post(
         run_query(state, s, headers, false, explain, pin).await
     } else if ct.starts_with(FORM_CT) {
         // POST url-encoded — `query=` (read) or `update=` (write) in the body. [OPUS-4.8]
-        // sq-zcby: classify on the payload — an `update=` form (or a `query=` whose value
-        // parses as an update) is a write and is gated as one.
+        // sq-zcby: classify on the payload for the ambiguous `query=` path; an `update=` form
+        // is ALWAYS a write (see below).
         let s = match std::str::from_utf8(body) {
             Ok(s) => s,
             Err(_) => return bad_request("request body is not valid UTF-8"),
         };
         let params = parse_form(s);
-        // An explicit `update=` form is a write; a `query=` form is classified by its payload.
-        let mutates = match (params.get("update"), params.get("query")) {
-            (Some(u), _) => payload_mutates(u),
-            (None, Some(q)) => payload_mutates(q),
-            // Neither parameter present: not a write, let the query handler return its 400.
-            (None, None) => false,
+        // [OPUS-4.8] sq-zcby (Copilot PR#71 SECURITY fix): the `update=` form field IS an
+        // update operation BY DEFINITION (SPARQL 1.1 Protocol §2.2), so it is a WRITE
+        // UNCONDITIONALLY — regardless of whether its value happens to parse as a read-only
+        // query (e.g. `update=SELECT…`). Classifying it on its payload (the old
+        // `payload_mutates(u)`) let such a request slip past the write gate: the auth-bypass
+        // this fixes. Only the ambiguous `query=`/generic path falls through to content
+        // inspection — a `query=` whose value parses as an UPDATE is still gated as a write
+        // (an UPDATE smuggled through the query parameter).
+        let op = if params.contains_key("update") {
+            Operation::Write
+        } else {
+            match params.get("query") {
+                Some(q) if payload_mutates(q) => Operation::Write,
+                Some(_) => Operation::Read,
+                // Neither parameter present: not a write, let the query handler return its 400.
+                None => Operation::Read,
+            }
         };
-        let op = if mutates { Operation::Write } else { Operation::Read };
         if let Some(resp) = auth_gate(state.config(), headers, op) {
             return resp;
         }

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -139,19 +139,40 @@ pub struct ServerConfig {
     pub verbose: bool,
     /// [OPUS-4.8] sq-o4qf: explicit opt-in to bind a **non-loopback** address.
     ///
-    /// The server has **no authentication** on any endpoint — including the mutating
-    /// `application/sparql-update` path and the `/subscriptions` WebSocket. Binding a
-    /// non-loopback address (e.g. `0.0.0.0`) therefore exposes the entire dataset for
-    /// **read AND write** to anyone who can reach the port. To make that a deliberate
-    /// act rather than a foot-gun, the binary REFUSES to bind a non-loopback address
-    /// unless this is set (CLI `--allow-remote` / env `SPARQ_ALLOW_REMOTE=1`); even
-    /// then it logs a loud warning. Loopback binds are unaffected. See
-    /// [`bind_posture`] for the decision, and `crates/sparq-server/README.md` →
-    /// "Security posture (no built-in auth)".
+    /// By default the server has **no authentication** on any endpoint — including the
+    /// mutating `application/sparql-update` path and the `/subscriptions` WebSocket.
+    /// Binding a non-loopback address (e.g. `0.0.0.0`) therefore exposes the entire dataset
+    /// for **read AND write** to anyone who can reach the port. To make that a deliberate
+    /// act rather than a foot-gun, the binary REFUSES to bind a non-loopback address unless
+    /// this is set (CLI `--allow-remote` / env `SPARQ_ALLOW_REMOTE=1`) OR the whole surface
+    /// is authenticated by [`auth_token`](Self::auth_token) AND
+    /// [`auth_token_read`](Self::auth_token_read) (sq-zcby) — a write-token alone still
+    /// leaves reads open, so it does NOT by itself make a remote bind safe. Even an allowed
+    /// remote bind logs a warning. Loopback binds are unaffected. See [`bind_posture`] for
+    /// the decision, and `crates/sparq-server/README.md` → "Security posture".
     ///
     /// This is purely a *bind-time* posture gate in the binary; it does not add any
     /// per-request auth and does not affect the library `router`/`harden` surface.
     pub allow_remote: bool,
+    /// [OPUS-4.8] sq-zcby (PSS gh-46): the required Bearer token that gates the **write
+    /// surface**. When `Some(token)`, every request that MUTATES the dataset must present
+    /// `Authorization: Bearer <token>` (scheme casing tolerated) or it is refused `401`
+    /// with `WWW-Authenticate: Bearer`. The write surface is: a SPARQL UPDATE on `/sparql`
+    /// (`Content-Type: application/sparql-update`, OR a `query`/`update` body that *parses
+    /// as an update* — classification keys on whether the request mutates, not the route),
+    /// and the Graph-Store-Protocol write methods (`PUT`/`POST`/`DELETE`/`PATCH`) on
+    /// `/sparql/graph` and `/graphs/{*path}`. The token is compared in **constant time**
+    /// ([`constant_time_eq`]). A missing vs a wrong token produce the *identical* 401, so an
+    /// attacker cannot learn whether a token was presented. `None` (the default) means **no
+    /// write auth** — today's behaviour, preserved exactly. Mirrors QLever's `-a <token>`.
+    /// Enforced by the library `router` itself, so an embedder gets the gate for free.
+    pub auth_token: Option<String>,
+    /// [OPUS-4.8] sq-zcby: ALSO gate **reads** (SPARQL query, GSP `GET`/`HEAD`) with the same
+    /// [`auth_token`](Self::auth_token). Off by default (QLever-style: writes gated, reads
+    /// open). Has no effect unless `auth_token` is also set. When on, the whole surface is
+    /// authenticated, which the bind posture ([`AuthPosture`]) treats as "auth present" for
+    /// allowing a non-loopback bind without `--allow-remote`.
+    pub auth_token_read: bool,
     /// [OPUS-4.8] (sq-4w18) SERVICE federation egress allowlist. SPARQL `SERVICE <iri>`
     /// makes attacker-controlled query text trigger an outbound HTTP request from the
     /// server host — an SSRF surface. The server's posture is **default-DENY-all
@@ -183,6 +204,9 @@ impl Default for ServerConfig {
             time_travel_max_age: None,
             verbose: false,
             allow_remote: false, // [OPUS-4.8] sq-o4qf: safe default — refuse non-loopback bind unless opted in
+            // [OPUS-4.8] sq-zcby: safe default — no token => no write auth (back-compat).
+            auth_token: None,
+            auth_token_read: false,
             // [OPUS-4.8] sq-4w18: safe default — empty allowlist = deny ALL SERVICE.
             service_allow: crate::service_config::ServiceAllowlist::default(),
         }
@@ -240,6 +264,15 @@ impl ServerConfig {
         if let Ok(v) = std::env::var("SPARQ_ALLOW_REMOTE") {
             cfg.allow_remote = env_truthy(&v);
         }
+        // [OPUS-4.8] sq-zcby: SPARQ_AUTH_TOKEN sets the write-gate token (an empty value is
+        // treated as "unset" — an empty shared secret is a footgun, never a valid token);
+        // SPARQ_AUTH_TOKEN_READ truthy ("1"/"true"/"yes"/"on") additionally gates reads.
+        if let Ok(v) = std::env::var("SPARQ_AUTH_TOKEN") {
+            cfg.auth_token = (!v.is_empty()).then_some(v);
+        }
+        if let Ok(v) = std::env::var("SPARQ_AUTH_TOKEN_READ") {
+            cfg.auth_token_read = env_truthy(&v);
+        }
         // [OPUS-4.8] sq-4w18: SERVICE egress allowlist baseline from SPARQ_SERVICE_ALLOW
         // (comma/whitespace-separated). The binary then ADDS any `--service-allow` /
         // `--service-allow-file` entries (the union — CLI only ever widens). A malformed
@@ -262,64 +295,244 @@ fn env_truthy(v: &str) -> bool {
 }
 
 // ---------------------------------------------------------------------------
-// [OPUS-4.8] sq-o4qf — bind-time security posture (no built-in auth)
+// [OPUS-4.8] sq-o4qf / sq-zcby — bind-time security posture (auth-aware)
 // ---------------------------------------------------------------------------
 
 /// [OPUS-4.8] sq-o4qf: the decision the binary makes about a requested bind address,
-/// given the no-auth posture. Returned by [`bind_posture`] so `main` (and tests) can act
-/// on it without the side effect of actually binding.
+/// given the configured auth posture. Returned by [`bind_posture`] so `main` (and tests)
+/// can act on it without the side effect of actually binding.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BindPosture {
     /// Loopback (or otherwise not-remotely-reachable) bind — safe, proceed silently.
     Loopback,
-    /// Non-loopback bind explicitly opted into (`--allow-remote` / `SPARQ_ALLOW_REMOTE`).
-    /// Proceed, but the caller MUST surface `warning` (the unauthenticated surface is now
-    /// reachable from the network).
+    /// Non-loopback bind that is allowed to proceed (opted in via `--allow-remote` /
+    /// `SPARQ_ALLOW_REMOTE`, or the whole surface is authenticated — sq-zcby). Proceed, but the
+    /// caller MUST surface `warning` (it describes exactly what is now reachable: a fully open
+    /// surface, an open read endpoint behind a write gate, or a fully authenticated surface).
     RemoteAllowed { warning: String },
-    /// Non-loopback bind WITHOUT the opt-in. The caller MUST refuse to bind and print
-    /// `message` (which explains the no-auth risk and how to opt in).
+    /// Non-loopback bind that is refused. The caller MUST refuse to bind and print `message`
+    /// (which explains the exposure and how to proceed: gate the surface or opt in).
     RemoteRefused { message: String },
 }
 
-/// [OPUS-4.8] sq-o4qf: classify a requested bind address under the no-built-in-auth posture.
+/// [OPUS-4.8] sq-o4qf / sq-zcby: classify a requested bind address under the configured auth
+/// posture.
 ///
-/// `sparq-server` has no authentication on any endpoint (query, `application/sparql-update`,
-/// the `/subscriptions` WebSocket). A loopback bind (`127.0.0.0/8`, `::1`) is only reachable
-/// from the same host, so it is safe by default. A **non-loopback** bind exposes the full
-/// read+write surface to the network, so the binary refuses it unless the operator explicitly
-/// opts in via `--allow-remote` / `SPARQ_ALLOW_REMOTE=1` (and even then warns).
+/// By default `sparq-server` has no authentication on any endpoint (query,
+/// `application/sparql-update`, the `/subscriptions` WebSocket). A loopback bind
+/// (`127.0.0.0/8`, `::1`) is only reachable from the same host, so it is safe by default. A
+/// **non-loopback** bind exposes the surface to the network, so the binary refuses it unless
+/// the operator opts in via `--allow-remote` / `SPARQ_ALLOW_REMOTE=1` (and even then warns) OR
+/// the whole surface is authenticated ([`AuthPosture::ReadAndWrite`]). A write-token alone
+/// ([`AuthPosture::WriteOnly`]) leaves reads open, so it is treated like no auth for this
+/// decision: still refused without `--allow-remote`.
 ///
 /// "Loopback" here means the literal loopback ranges. Note `0.0.0.0` / `::` (the unspecified
 /// "bind to all interfaces" addresses) are NOT loopback — they are the most common way the
 /// surface gets exposed, so they are treated as remote. This is a deliberately blunt,
 /// fail-closed check: it errs toward refusing exposure, not toward allowing it.
-pub fn bind_posture(addr: &SocketAddr, allow_remote: bool) -> BindPosture {
+///
+/// [OPUS-4.8] sq-zcby: `auth` folds the configured Bearer-token gate into the decision. A
+/// non-loopback bind is allowed when `--allow-remote` is set OR the **whole surface** is
+/// authenticated ([`AuthPosture::ReadAndWrite`]) — a write-token alone ([`AuthPosture::
+/// WriteOnly`]) still requires `--allow-remote`, because it leaves an OPEN read endpoint on
+/// the remote bind; we still warn in that case that reads remain open.
+pub fn bind_posture(addr: &SocketAddr, allow_remote: bool, auth: AuthPosture) -> BindPosture {
     if addr.ip().is_loopback() {
         return BindPosture::Loopback;
     }
+    // A fully-authenticated surface (token gates reads AND writes) is safe to expose without
+    // --allow-remote: there is no open endpoint left. We still warn (a single shared secret
+    // is not per-user authz, and the token must be carried over TLS).
+    if auth == AuthPosture::ReadAndWrite {
+        return BindPosture::RemoteAllowed {
+            warning: format!(
+                "WARNING: sparq-server is binding the non-loopback address {addr}. The whole \
+                 surface is gated by the --auth-token Bearer token (reads AND writes), so it \
+                 is not open to anonymous access. NOTE: the token is a single shared secret \
+                 (not per-user authz) — deliver it over TLS (terminate at a proxy), and front \
+                 it with a real authorization layer (a reverse proxy / gateway or sparq-solid) \
+                 for per-user access control. The /subscriptions WebSocket is a read surface \
+                 NOT gated by this token."
+            ),
+        };
+    }
     if allow_remote {
+        // The surface is reachable from the network; describe exactly what is open.
+        let exposure = match auth {
+            AuthPosture::None => {
+                "The full dataset is exposed for READ AND WRITE (SPARQL Update + the \
+                 /subscriptions WebSocket) to anyone who can reach this port — there is NO \
+                 authentication."
+            }
+            // WriteOnly: writes are gated, but reads are still open on this remote bind.
+            AuthPosture::WriteOnly => {
+                "Writes are gated by --auth-token, but READS remain OPEN to anyone who can \
+                 reach this port (add --auth-token-read to gate reads too). The /subscriptions \
+                 WebSocket (a read surface) is also open."
+            }
+            AuthPosture::ReadAndWrite => unreachable!("handled above"),
+        };
         BindPosture::RemoteAllowed {
             warning: format!(
-                "WARNING: sparq-server is binding the non-loopback address {addr} and has NO \
-                 built-in authentication. The full dataset is exposed for READ AND WRITE \
-                 (SPARQL Update + the /subscriptions WebSocket) to anyone who can reach this \
-                 port. Put it behind a reverse proxy / API gateway (or sparq-solid) that \
-                 enforces auth before exposing it to an untrusted network. \
+                "WARNING: sparq-server is binding the non-loopback address {addr}. {exposure} \
+                 Put it behind a reverse proxy / API gateway (or sparq-solid) that enforces \
+                 auth before exposing it to an untrusted network. \
                  (--allow-remote / SPARQ_ALLOW_REMOTE is set, so this bind proceeds.)"
             ),
         }
     } else {
+        // Refused. A write-token alone is NOT sufficient (reads stay open), so we name the
+        // two ways to proceed: gate reads too (--auth-token-read) or opt in (--allow-remote).
+        let reason = match auth {
+            AuthPosture::None => {
+                "sparq-server has NO authentication, so this would expose the full dataset for \
+                 READ AND WRITE to the network"
+            }
+            AuthPosture::WriteOnly => {
+                "--auth-token gates writes but READS would still be OPEN on a non-loopback bind \
+                 (add --auth-token-read to gate reads too, which makes the whole surface \
+                 authenticated and the bind safe)"
+            }
+            AuthPosture::ReadAndWrite => unreachable!("handled above"),
+        };
         BindPosture::RemoteRefused {
             message: format!(
-                "refusing to bind non-loopback address {addr}: sparq-server has NO built-in \
-                 authentication, so this would expose the full dataset for READ AND WRITE \
-                 (SPARQL Update + the /subscriptions WebSocket) to the network. If that is \
-                 intended, run behind a reverse proxy / gateway that enforces auth and \
-                 re-run with --allow-remote (or SPARQ_ALLOW_REMOTE=1). To serve only this \
-                 host, bind a loopback address such as 127.0.0.1."
+                "refusing to bind non-loopback address {addr}: {reason}. If a network bind is \
+                 intended, either gate the whole surface (--auth-token AND --auth-token-read) \
+                 or run behind a reverse proxy / gateway that enforces auth and re-run with \
+                 --allow-remote (or SPARQ_ALLOW_REMOTE=1). To serve only this host, bind a \
+                 loopback address such as 127.0.0.1."
             ),
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-zcby (PSS gh-46) — the Bearer-token auth gate (write surface +
+// optional read gate), mirroring QLever's `-a <token>`.
+// ---------------------------------------------------------------------------
+
+/// [OPUS-4.8] sq-zcby: how much of the surface a configured token authenticates — folded into
+/// the bind decision ([`bind_posture`]). `WriteOnly` (a token, reads open) still requires
+/// `--allow-remote` for a non-loopback bind because reads stay open; `ReadAndWrite` (token +
+/// `--auth-token-read`) makes the whole surface authenticated, so it does not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthPosture {
+    /// No token configured — no auth on any endpoint.
+    None,
+    /// A token gates writes; reads are open.
+    WriteOnly,
+    /// A token gates writes AND reads (`--auth-token-read`).
+    ReadAndWrite,
+}
+
+impl AuthPosture {
+    /// Derives the posture from a [`ServerConfig`]: no token → `None`; a token without the
+    /// read gate → `WriteOnly`; a token with `--auth-token-read` → `ReadAndWrite`.
+    pub fn from_config(config: &ServerConfig) -> Self {
+        match (config.auth_token.is_some(), config.auth_token_read) {
+            (false, _) => AuthPosture::None,
+            (true, false) => AuthPosture::WriteOnly,
+            (true, true) => AuthPosture::ReadAndWrite,
+        }
+    }
+}
+
+/// [OPUS-4.8] sq-zcby: whether a request is a WRITE (mutates the dataset) or a READ, for the
+/// auth gate. Classification keys on "does this mutate", NOT the route — an UPDATE smuggled
+/// through the query path is a write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Operation {
+    Read,
+    Write,
+}
+
+/// [OPUS-4.8] sq-zcby: constant-time byte-string equality. Returns `true` iff `a == b`,
+/// taking time that depends only on `a.len()` (not on the contents or on how far the first
+/// difference is), so a token check cannot be turned into a timing oracle that recovers the
+/// secret byte-by-byte.
+///
+/// Hand-rolled rather than pulling in the `subtle` crate: it is a few lines, sparq-server
+/// has no other crypto dependency (keeping it out of the supply-chain / SBOM surface), and a
+/// length-difference + per-byte XOR-accumulate is the standard, well-understood construction.
+/// `a` is the configured secret and `b` the presented token; the length comparison reveals
+/// only whether the *presented* token has the secret's length (already inferable, and not the
+/// secret's bytes). The accumulator is `#[inline(never)]` and read into a `black_box`-style
+/// volatile-ish fold to keep the optimiser from short-circuiting (no data-dependent branch).
+#[inline(never)]
+pub(crate) fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    // Fold to bool without a data-dependent branch on the secret.
+    diff == 0
+}
+
+/// [OPUS-4.8] sq-zcby: extracts the token from an `Authorization: Bearer <token>` header,
+/// tolerant of scheme casing (`Bearer`/`bearer`/`BEARER`) and of leading/trailing space. Any
+/// other scheme (or no header) yields `None`.
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    let raw = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
+    let (scheme, token) = raw.split_once(' ')?;
+    if scheme.eq_ignore_ascii_case("bearer") {
+        Some(token.trim())
+    } else {
+        None
+    }
+}
+
+/// [OPUS-4.8] sq-zcby: the per-request auth gate. Returns `None` to proceed, or `Some(401)` to
+/// refuse. A request is gated when its [`Operation`] is covered by the configured posture:
+/// a `Write` whenever a token is set; a `Read` only additionally when `--auth-token-read` is on.
+/// An ungated operation (or no token at all) always proceeds. A gated request must present the
+/// exact token (constant-time compared, scheme casing tolerant); the 401 is byte-identical for a
+/// missing vs a wrong token, so it never leaks which.
+fn auth_gate(config: &ServerConfig, headers: &HeaderMap, op: Operation) -> Option<Response> {
+    let token = config.auth_token.as_deref()?; // no token configured => never gated
+    let gated = match op {
+        Operation::Write => true,
+        Operation::Read => config.auth_token_read,
+    };
+    if !gated {
+        return None;
+    }
+    let ok = bearer_token(headers).is_some_and(|presented| constant_time_eq(token.as_bytes(), presented.as_bytes()));
+    if ok {
+        None
+    } else {
+        Some(unauthorized())
+    }
+}
+
+/// [OPUS-4.8] sq-zcby: the 401 a gated request without a valid token gets — `WWW-Authenticate:
+/// Bearer` plus the server's standard JSON error body. Identical for a missing vs a wrong
+/// token (the body carries no hint either way), so it never leaks which.
+fn unauthorized() -> Response {
+    let mut resp = json_error(StatusCode::UNAUTHORIZED, "authentication required: present a valid Bearer token");
+    resp.headers_mut().insert(header::WWW_AUTHENTICATE, header::HeaderValue::from_static("Bearer"));
+    resp
+}
+
+/// [OPUS-4.8] sq-zcby: does this SPARQL string MUTATE the dataset? The auth classifier keys on
+/// this, not on the route or Content-Type, so an UPDATE smuggled through the query path is
+/// still gated as a write. A string that parses as a read-only query (SELECT/ASK/CONSTRUCT/
+/// DESCRIBE) is a read; otherwise, if it parses as a SPARQL Update, it is a write. A string
+/// that parses as NEITHER is treated conservatively as a write (fail-closed: the writer/query
+/// handler will reject it, and gating an unparsable body as a write never wrongly opens the
+/// write surface).
+pub(crate) fn payload_mutates(sparql: &str) -> bool {
+    if spargebra::SparqlParser::new().parse_query(sparql).is_ok() {
+        return false; // a well-formed read-only query
+    }
+    // Not a read-only query. If it parses as an update it definitely mutates; if it parses as
+    // neither, fail closed (treat as a write) so a malformed body can never slip past the
+    // write gate. Either way the answer is "this is not a read", i.e. gate it as a write.
+    true
 }
 
 fn env_parse<T: std::str::FromStr>(name: &str) -> Option<T> {
@@ -877,7 +1090,12 @@ async fn sparql_endpoint(
     match method {
         Method::GET | Method::HEAD => {
             // Query string carries `query=` (+ optional dataset params). Per protocol, a
-            // GET without a `query` parameter is a malformed request (400).
+            // GET without a `query` parameter is a malformed request (400). A GET is always a
+            // READ (the protocol has no GET update), so it is gated only under --auth-token-read.
+            // [OPUS-4.8] sq-zcby.
+            if let Some(resp) = auth_gate(state.config(), &headers, Operation::Read) {
+                return resp;
+            }
             match url_params.get("query") {
                 Some(q) => {
                     let pin = match resolve_pin(&state, &url_params, None) {
@@ -903,25 +1121,55 @@ async fn handle_post(
 ) -> Response {
     let ct = content_type(headers);
     if ct.starts_with(SPARQL_QUERY_CT) {
-        // POST directly — body IS the SPARQL query.
-        match std::str::from_utf8(body) {
-            Ok(q) => {
-                let pin = match resolve_pin(state, url_params, None) {
-                    Ok(pin) => pin,
-                    Err(resp) => return resp,
-                };
-                let explain = explain_mode(url_params, None, headers);
-                run_query(state, q, headers, false, explain, pin).await
-            }
-            Err(_) => bad_request("request body is not valid UTF-8"),
+        // POST directly — body IS the SPARQL query. [OPUS-4.8] sq-zcby: the auth gate keys on
+        // whether the body MUTATES, not on the route — an UPDATE smuggled through the query
+        // Content-Type is gated as a write before the query handler ever sees it.
+        let s = match std::str::from_utf8(body) {
+            Ok(s) => s,
+            Err(_) => return bad_request("request body is not valid UTF-8"),
+        };
+        let op = if payload_mutates(s) { Operation::Write } else { Operation::Read };
+        if let Some(resp) = auth_gate(state.config(), headers, op) {
+            return resp;
         }
+        let pin = match resolve_pin(state, url_params, None) {
+            Ok(pin) => pin,
+            Err(resp) => return resp,
+        };
+        let explain = explain_mode(url_params, None, headers);
+        run_query(state, s, headers, false, explain, pin).await
     } else if ct.starts_with(FORM_CT) {
-        // POST url-encoded — `query=` in the body.
+        // POST url-encoded — `query=` (read) or `update=` (write) in the body. [OPUS-4.8]
+        // sq-zcby: classify on the payload — an `update=` form (or a `query=` whose value
+        // parses as an update) is a write and is gated as one.
         let s = match std::str::from_utf8(body) {
             Ok(s) => s,
             Err(_) => return bad_request("request body is not valid UTF-8"),
         };
         let params = parse_form(s);
+        // An explicit `update=` form is a write; a `query=` form is classified by its payload.
+        let mutates = match (params.get("update"), params.get("query")) {
+            (Some(u), _) => payload_mutates(u),
+            (None, Some(q)) => payload_mutates(q),
+            // Neither parameter present: not a write, let the query handler return its 400.
+            (None, None) => false,
+        };
+        let op = if mutates { Operation::Write } else { Operation::Read };
+        if let Some(resp) = auth_gate(state.config(), headers, op) {
+            return resp;
+        }
+        // The SPARQL 1.1 Protocol url-encoded UPDATE operation (`update=` form) submits through
+        // the same sequenced writer as `application/sparql-update`.
+        if let Some(u) = params.get("update") {
+            #[cfg(feature = "time-travel")]
+            if url_params.contains_key("generation") {
+                return bad_request(
+                    "the 'generation' parameter pins queries to a retained generation; \
+                     updates always apply to the current generation",
+                );
+            }
+            return run_update(state, u.clone()).await;
+        }
         match params.get("query") {
             Some(q) => {
                 let pin = match resolve_pin(state, url_params, Some(&params)) {
@@ -931,10 +1179,14 @@ async fn handle_post(
                 let explain = explain_mode(url_params, Some(&params), headers);
                 run_query(state, q, headers, false, explain, pin).await
             }
-            None => bad_request("missing 'query' parameter in url-encoded body"),
+            None => bad_request("missing 'query' or 'update' parameter in url-encoded body"),
         }
     } else if ct.starts_with("application/sparql-update") {
         // SPARQL 1.1 Protocol — update operation (T11b). Body IS the update; success → 204.
+        // [OPUS-4.8] sq-zcby: an UPDATE is always a write — gate it before doing any work.
+        if let Some(resp) = auth_gate(state.config(), headers, Operation::Write) {
+            return resp;
+        }
         // `apply_update` blocks for the writer's group-commit ack (window + batch
         // application, which includes an O(graph) fork), so it runs off the async workers.
         // Time travel is a READ concept: an update can only apply to the current
@@ -948,21 +1200,7 @@ async fn handle_post(
             );
         }
         match std::str::from_utf8(body) {
-            Ok(u) => {
-                let st = state.clone();
-                let u = u.to_string();
-                let joined = tokio::task::spawn_blocking(move || st.apply_update(&u)).await;
-                match joined {
-                    Ok(Ok(number)) => {
-                        state.metrics().inc_updates();
-                        // The 204 carries the generation containing the update (the
-                        // read-your-writes token) under the time-travel feature.
-                        with_generation_header(StatusCode::NO_CONTENT.into_response(), number)
-                    }
-                    Ok(Err(e)) => bad_request(&format!("update failed: {e}")),
-                    Err(_) => json_error(StatusCode::INTERNAL_SERVER_ERROR, "update worker panicked"),
-                }
-            }
+            Ok(u) => run_update(state, u.to_string()).await,
             Err(_) => bad_request("request body is not valid UTF-8"),
         }
     } else {
@@ -971,6 +1209,26 @@ async fn handle_post(
             StatusCode::UNSUPPORTED_MEDIA_TYPE,
             "POST requires Content-Type 'application/sparql-query' or 'application/x-www-form-urlencoded'",
         )
+    }
+}
+
+/// Applies a SPARQL Update string through the sequenced writer off the async workers (it
+/// blocks for the group-commit ack), mapping the outcome onto 204/400/500. Shared by the
+/// `application/sparql-update` body path and the url-encoded `update=` form path (T11b /
+/// [OPUS-4.8] sq-zcby). The caller is responsible for the auth gate (so the gate runs before
+/// any work) and any `generation`-pin refusal.
+async fn run_update(state: &AppState, update: String) -> Response {
+    let st = state.clone();
+    let joined = tokio::task::spawn_blocking(move || st.apply_update(&update)).await;
+    match joined {
+        Ok(Ok(number)) => {
+            state.metrics().inc_updates();
+            // The 204 carries the generation containing the update (the read-your-writes
+            // token) under the time-travel feature.
+            with_generation_header(StatusCode::NO_CONTENT.into_response(), number)
+        }
+        Ok(Err(e)) => bad_request(&format!("update failed: {e}")),
+        Err(_) => json_error(StatusCode::INTERNAL_SERVER_ERROR, "update worker panicked"),
     }
 }
 
@@ -1277,6 +1535,18 @@ fn mint_graph_iri() -> String {
 /// READ (`GET`/`HEAD`) serialises the addressed graph; WRITE (`PUT`/`POST`/`DELETE`)
 /// translates into a SPARQL Update submitted through the sequenced writer.
 async fn graph_store(state: &AppState, method: &Method, graph: GraphRef, headers: &HeaderMap, body: Bytes) -> Response {
+    // [OPUS-4.8] sq-zcby: the GSP write methods (PUT/POST/DELETE, and PATCH which we 405) are
+    // as powerful as an UPDATE, so they are gated as writes; GET/HEAD are reads (gated only
+    // under --auth-token-read). Any other method is gated as a write too (fail-closed). The
+    // gate runs before any work — even the 405 for an unsupported method is behind it for a
+    // write verb, so an attacker cannot probe the surface without the token.
+    let op = match *method {
+        Method::GET | Method::HEAD => Operation::Read,
+        _ => Operation::Write,
+    };
+    if let Some(resp) = auth_gate(state.config(), headers, op) {
+        return resp;
+    }
     match *method {
         Method::GET | Method::HEAD => {
             let head_only = *method == Method::HEAD;
@@ -1937,7 +2207,7 @@ mod bind_posture_tests {
     //! which are the usual way the surface gets exposed); (c) WITH the opt-in it proceeds
     //! but warns. Pure functions over an explicit `allow_remote` flag — no process-env
     //! mutation, so they are parallel-safe.
-    use super::{bind_posture, env_truthy, BindPosture};
+    use super::{bind_posture, env_truthy, AuthPosture, BindPosture};
     use std::net::SocketAddr;
 
     fn addr(s: &str) -> SocketAddr {
@@ -1947,17 +2217,17 @@ mod bind_posture_tests {
     #[test]
     fn loopback_proceeds_regardless_of_flag() {
         for a in ["127.0.0.1:3030", "127.0.0.5:80", "[::1]:3030"] {
-            assert_eq!(bind_posture(&addr(a), false), BindPosture::Loopback, "{a} (no opt-in)");
-            assert_eq!(bind_posture(&addr(a), true), BindPosture::Loopback, "{a} (opt-in)");
+            assert_eq!(bind_posture(&addr(a), false, AuthPosture::None), BindPosture::Loopback, "{a} (no opt-in)");
+            assert_eq!(bind_posture(&addr(a), true, AuthPosture::None), BindPosture::Loopback, "{a} (opt-in)");
         }
     }
 
     #[test]
     fn non_loopback_without_optin_is_refused() {
         // 0.0.0.0 / :: (all-interfaces), an RFC1918 address, a link-local, and the cloud
-        // metadata IP all fail closed without --allow-remote.
+        // metadata IP all fail closed without --allow-remote (and with no auth).
         for a in ["0.0.0.0:3030", "[::]:3030", "10.0.0.1:8080", "169.254.169.254:80", "192.168.1.5:3030"] {
-            match bind_posture(&addr(a), false) {
+            match bind_posture(&addr(a), false, AuthPosture::None) {
                 BindPosture::RemoteRefused { message } => {
                     assert!(message.contains("refusing to bind"), "{a}: {message}");
                     assert!(message.contains("--allow-remote"), "{a}: must name the opt-in flag");
@@ -1970,13 +2240,55 @@ mod bind_posture_tests {
 
     #[test]
     fn non_loopback_with_optin_warns_but_proceeds() {
-        match bind_posture(&addr("0.0.0.0:3030"), true) {
+        match bind_posture(&addr("0.0.0.0:3030"), true, AuthPosture::None) {
             BindPosture::RemoteAllowed { warning } => {
                 assert!(warning.contains("WARNING"), "{warning}");
                 assert!(warning.contains("READ AND WRITE"), "{warning}");
                 assert!(warning.contains("0.0.0.0:3030"), "must name the address: {warning}");
             }
             other => panic!("opt-in must allow with a warning, got {other:?}"),
+        }
+    }
+
+    // [OPUS-4.8] sq-zcby — auth folded into the bind decision.
+
+    /// A WRITE-only token (reads still open) is NOT sufficient to bind a non-loopback address:
+    /// --allow-remote is still required, because reads remain open on the remote bind. The
+    /// refusal must point at --auth-token-read as the way to make the whole surface safe.
+    #[test]
+    fn write_only_token_still_refused_without_optin() {
+        match bind_posture(&addr("0.0.0.0:3030"), false, AuthPosture::WriteOnly) {
+            BindPosture::RemoteRefused { message } => {
+                assert!(message.contains("refusing to bind"), "{message}");
+                assert!(message.contains("--auth-token-read"), "must name the read-gate flag: {message}");
+            }
+            other => panic!("a write-only token must still be refused without opt-in, got {other:?}"),
+        }
+    }
+
+    /// A WRITE-only token WITH --allow-remote proceeds, but warns that READS remain open.
+    #[test]
+    fn write_only_token_with_optin_warns_reads_open() {
+        match bind_posture(&addr("0.0.0.0:3030"), true, AuthPosture::WriteOnly) {
+            BindPosture::RemoteAllowed { warning } => {
+                assert!(warning.contains("WARNING"), "{warning}");
+                assert!(warning.to_ascii_uppercase().contains("READS"), "must warn reads are open: {warning}");
+            }
+            other => panic!("write-only + opt-in must allow with a warning, got {other:?}"),
+        }
+    }
+
+    /// A FULLY authenticated surface (token gates reads AND writes) is allowed to bind a
+    /// non-loopback address WITHOUT --allow-remote — there is no open endpoint left. It still
+    /// warns (single shared secret, deliver over TLS, /subscriptions not gated).
+    #[test]
+    fn full_auth_allows_remote_bind_without_optin() {
+        match bind_posture(&addr("0.0.0.0:3030"), false, AuthPosture::ReadAndWrite) {
+            BindPosture::RemoteAllowed { warning } => {
+                assert!(warning.contains("WARNING"), "{warning}");
+                assert!(warning.contains("--auth-token"), "must name the gate: {warning}");
+            }
+            other => panic!("full auth must allow a remote bind without opt-in, got {other:?}"),
         }
     }
 
@@ -1988,6 +2300,145 @@ mod bind_posture_tests {
         for f in ["", "0", "false", "no", "off", "2", "maybe"] {
             assert!(!env_truthy(f), "{f:?} should be falsy");
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-zcby — auth-gate unit tests (constant-time eq, Bearer parsing,
+// mutation classification, the gate decision, posture derivation)
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod auth_tests {
+    //! Pure-function coverage for the Bearer-token write gate. The end-to-end HTTP behaviour
+    //! (401 shape, mutation-applied, read-gate, GSP write gate, update-via-query/form path) is
+    //! the integration suite in `tests/auth.rs`; these pin the building blocks.
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn headers_with_auth(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(header::AUTHORIZATION, HeaderValue::from_str(value).unwrap());
+        h
+    }
+
+    #[test]
+    fn constant_time_eq_matches_plain_eq() {
+        let cases: &[(&[u8], &[u8])] = &[
+            (b"", b""),
+            (b"a", b"a"),
+            (b"a", b"b"),
+            (b"token", b"token"),
+            (b"token", b"toker"),
+            (b"token", b"tokens"), // length mismatch
+            (b"", b"x"),
+        ];
+        for (a, b) in cases {
+            assert_eq!(constant_time_eq(a, b), a == b, "{a:?} vs {b:?}");
+        }
+    }
+
+    #[test]
+    fn bearer_token_tolerates_scheme_casing() {
+        for v in ["Bearer t0k", "bearer t0k", "BEARER t0k", "BeArEr t0k"] {
+            assert_eq!(bearer_token(&headers_with_auth(v)), Some("t0k"), "{v:?}");
+        }
+        // Trailing/leading space around the token is trimmed.
+        assert_eq!(bearer_token(&headers_with_auth("Bearer  t0k  ")), Some("t0k"));
+    }
+
+    #[test]
+    fn bearer_token_rejects_other_schemes_and_absence() {
+        assert_eq!(bearer_token(&headers_with_auth("Basic abc")), None);
+        assert_eq!(bearer_token(&headers_with_auth("t0k")), None); // no scheme
+        assert_eq!(bearer_token(&HeaderMap::new()), None); // no header
+    }
+
+    #[test]
+    fn payload_mutates_classifies_reads_and_writes() {
+        // Reads (well-formed queries) do not mutate.
+        for q in [
+            "SELECT ?s WHERE { ?s ?p ?o }",
+            "ASK { ?s ?p ?o }",
+            "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }",
+            "DESCRIBE <http://ex/s>",
+        ] {
+            assert!(!payload_mutates(q), "{q:?} must be a read");
+        }
+        // Writes (updates) mutate.
+        for u in [
+            "INSERT DATA { <http://ex/s> <http://ex/p> <http://ex/o> }",
+            "DELETE DATA { <http://ex/s> <http://ex/p> <http://ex/o> }",
+            "DELETE { ?s ?p ?o } WHERE { ?s ?p ?o }",
+            "DROP ALL",
+            "CLEAR DEFAULT",
+            "LOAD <http://ex/d> INTO GRAPH <http://ex/g>",
+        ] {
+            assert!(payload_mutates(u), "{u:?} must be a write");
+        }
+        // Garbage that parses as neither is fail-closed to a write.
+        assert!(payload_mutates("this is not sparql"), "unparsable must fail closed to a write");
+    }
+
+    #[test]
+    fn auth_posture_from_config() {
+        let mut cfg = ServerConfig::default();
+        assert_eq!(AuthPosture::from_config(&cfg), AuthPosture::None);
+        cfg.auth_token = Some("t".into());
+        assert_eq!(AuthPosture::from_config(&cfg), AuthPosture::WriteOnly);
+        cfg.auth_token_read = true;
+        assert_eq!(AuthPosture::from_config(&cfg), AuthPosture::ReadAndWrite);
+        // read-gate without a token is still "None" (no token => nothing to gate with).
+        cfg.auth_token = None;
+        assert_eq!(AuthPosture::from_config(&cfg), AuthPosture::None);
+    }
+
+    #[test]
+    fn auth_gate_no_token_never_gates() {
+        let cfg = ServerConfig::default(); // no auth_token
+        let h = HeaderMap::new();
+        assert!(auth_gate(&cfg, &h, Operation::Write).is_none());
+        assert!(auth_gate(&cfg, &h, Operation::Read).is_none());
+    }
+
+    #[test]
+    fn auth_gate_write_only_gates_writes_not_reads() {
+        let cfg = ServerConfig { auth_token: Some("secret".into()), ..ServerConfig::default() };
+        // Writes need the token.
+        assert!(auth_gate(&cfg, &HeaderMap::new(), Operation::Write).is_some(), "missing token => 401");
+        assert!(
+            auth_gate(&cfg, &headers_with_auth("Bearer wrong"), Operation::Write).is_some(),
+            "wrong token => 401"
+        );
+        assert!(
+            auth_gate(&cfg, &headers_with_auth("Bearer secret"), Operation::Write).is_none(),
+            "correct token => proceed"
+        );
+        // Reads stay open (no read gate).
+        assert!(auth_gate(&cfg, &HeaderMap::new(), Operation::Read).is_none(), "reads open in write-only mode");
+    }
+
+    #[test]
+    fn auth_gate_read_gate_also_gates_reads() {
+        let cfg = ServerConfig {
+            auth_token: Some("secret".into()),
+            auth_token_read: true,
+            ..ServerConfig::default()
+        };
+        assert!(auth_gate(&cfg, &HeaderMap::new(), Operation::Read).is_some(), "read gated => 401");
+        assert!(
+            auth_gate(&cfg, &headers_with_auth("bearer secret"), Operation::Read).is_none(),
+            "correct token (lowercase scheme) => proceed"
+        );
+    }
+
+    #[test]
+    fn unauthorized_carries_www_authenticate_bearer() {
+        let resp = unauthorized();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            resp.headers().get(header::WWW_AUTHENTICATE).and_then(|v| v.to_str().ok()),
+            Some("Bearer")
+        );
     }
 }
 

--- a/crates/sparq-server/src/lib.rs
+++ b/crates/sparq-server/src/lib.rs
@@ -51,8 +51,9 @@ pub mod subscriptions;
 
 #[cfg(feature = "server")]
 pub use http::{
-    bind_posture, harden, router, AppState, BindPosture, PinnedGen, ServerConfig, GLOBAL_POD,
-}; // [OPUS-4.8] sq-o4qf: bind_posture / BindPosture for the no-auth non-loopback bind gate
+    bind_posture, harden, router, AppState, AuthPosture, BindPosture, PinnedGen, ServerConfig,
+    GLOBAL_POD,
+}; // [OPUS-4.8] sq-o4qf: bind_posture / BindPosture for the bind gate; sq-zcby: AuthPosture folds the --auth-token gate into it
 
 /// [OPUS-4.8] (sq-4w18) The SERVICE egress allowlist config type, re-exported at the
 /// crate root next to [`ServerConfig`].

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -3,6 +3,7 @@
 //!
 //! Usage:
 //!   sparq-server [--addr 127.0.0.1:3030] [--allow-remote] [--format turtle]
+//!                [--auth-token TOKEN] [--auth-token-read]
 //!                [--query-timeout SECS] [--max-body-bytes N] [--max-concurrent N]
 //!                [--max-results N] [--max-subscriptions N]
 //!                [--max-subscriptions-per-conn N]
@@ -16,14 +17,24 @@
 //! `SERVICE` clause turns attacker-controlled query text into an outbound request from this
 //! host. See crates/sparq-server/README.md -> "SERVICE federation (egress allowlist)". [OPUS-4.8]
 //!
-//! SECURITY: the server has NO built-in authentication on any endpoint (query, the
-//! `application/sparql-update` mutation path, the `/subscriptions` WebSocket). `--addr`
-//! defaults to loopback (127.0.0.1:3030), reachable only from this host. A NON-loopback
-//! bind (e.g. `0.0.0.0`) exposes the full dataset for READ AND WRITE to the network and is
-//! REFUSED unless `--allow-remote` (env `SPARQ_ALLOW_REMOTE=1`) is set — and even then it
-//! logs a warning. Run behind a reverse proxy / API gateway (or sparq-solid) that enforces
-//! auth before exposing it to an untrusted network. See crates/sparq-server/README.md
-//! → "Security posture".
+//! SECURITY (auth): by default the server has NO authentication on any endpoint (query, the
+//! `application/sparql-update` mutation path, the `/subscriptions` WebSocket). [OPUS-4.8]
+//! sq-zcby (PSS gh-46): set `--auth-token TOKEN` (env `SPARQ_AUTH_TOKEN`) to require
+//! `Authorization: Bearer TOKEN` on every WRITE (a SPARQL Update on `/sparql` — by
+//! `application/sparql-update` Content-Type OR a `query`/`update` body that parses as an
+//! update; classification keys on whether the request MUTATES, not the route — plus the GSP
+//! `PUT`/`POST`/`DELETE` methods); otherwise `401` with `WWW-Authenticate: Bearer`
+//! (constant-time compared, scheme-casing tolerant; mirrors QLever's `-a <token>`). Add
+//! `--auth-token-read` (env `SPARQ_AUTH_TOKEN_READ=1`) to ALSO gate reads. The
+//! `/subscriptions` WebSocket (a read surface) is NOT gated by this token.
+//!
+//! SECURITY (bind): `--addr` defaults to loopback (127.0.0.1:3030), reachable only from this
+//! host. A NON-loopback bind (e.g. `0.0.0.0`) is REFUSED unless `--allow-remote` (env
+//! `SPARQ_ALLOW_REMOTE=1`) is set OR the whole surface is authenticated (`--auth-token` AND
+//! `--auth-token-read`) — a write-token alone still leaves reads open, so it is not
+//! sufficient by itself. Even an allowed remote bind logs a warning. Deliver the token over
+//! TLS (terminate at a proxy); for per-user authz front it with a reverse proxy / gateway
+//! (or sparq-solid). See crates/sparq-server/README.md → "Security posture".
 //!
 //! With no DATA_FILE the server starts with an empty default graph (still answers queries —
 //! they just return no rows). The format defaults to `turtle`; pass `--format ntriples |
@@ -56,8 +67,9 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use sparq_core::Graph;
-// [OPUS-4.8] sq-o4qf: bind_posture / BindPosture gate the non-loopback bind under the no-auth posture.
-use sparq_server::{bind_posture, router, AppState, BindPosture, ServerConfig};
+// [OPUS-4.8] sq-o4qf: bind_posture / BindPosture gate the non-loopback bind; sq-zcby:
+// AuthPosture folds the --auth-token Bearer gate into that bind decision.
+use sparq_server::{bind_posture, router, AppState, AuthPosture, BindPosture, ServerConfig};
 
 // Same allocator as the CLI (T1.0a, measured ~1.29x on the parallel join): the system allocator's
 // arena locks contend under rayon's per-row allocation, and the server is the long-running,
@@ -115,10 +127,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 config.time_travel_max_age = (secs > 0).then(|| Duration::from_secs(secs));
             }
             "--verbose" => config.verbose = true,
-            // [OPUS-4.8] sq-o4qf: opt in to binding a non-loopback address despite the no-auth
-            // posture. Without this (and without SPARQ_ALLOW_REMOTE), a non-loopback --addr is
-            // refused — see bind_posture below.
+            // [OPUS-4.8] sq-o4qf: opt in to binding a non-loopback address. Without this (and
+            // without SPARQ_ALLOW_REMOTE), a non-loopback --addr is refused unless the whole
+            // surface is authenticated (--auth-token AND --auth-token-read) — see bind_posture.
             "--allow-remote" => config.allow_remote = true,
+            // [OPUS-4.8] sq-zcby (PSS gh-46): require a Bearer token on the WRITE surface.
+            // An empty token is rejected (an empty shared secret is a footgun, never valid).
+            "--auth-token" => {
+                let tok = args.next().ok_or("--auth-token requires a token value")?;
+                if tok.is_empty() {
+                    return Err("--auth-token must not be empty".into());
+                }
+                config.auth_token = Some(tok);
+            }
+            // [OPUS-4.8] sq-zcby: ALSO gate reads with the same token (QLever-style; only
+            // meaningful alongside --auth-token).
+            "--auth-token-read" => config.auth_token_read = true,
             // [OPUS-4.8] sq-4w18: SERVICE egress allowlist. Repeatable: each value adds one
             // host (`sparql.example.org`) or suffix wildcard (`*.example.org`). With NO
             // allowlist (the default) every SERVICE clause is refused (default-DENY-all).
@@ -140,14 +164,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     ""
                 };
                 eprintln!(
-                    "usage: sparq-server [--addr HOST:PORT] [--allow-remote] [--format FMT] \
+                    "usage: sparq-server [--addr HOST:PORT] [--allow-remote] \
+                     [--auth-token TOKEN] [--auth-token-read] [--format FMT] \
                      [--query-timeout SECS] [--max-body-bytes N] [--max-concurrent N] \
                      [--max-results N] [--max-subscriptions N] \
                      [--max-subscriptions-per-conn N]{time_travel}{service} [--verbose] [DATA_FILE]\n\n  \
-                     SECURITY: no built-in auth. --addr defaults to loopback (127.0.0.1); a \
-                     non-loopback bind (e.g. 0.0.0.0) is REFUSED unless --allow-remote (or \
-                     SPARQ_ALLOW_REMOTE=1) is set, because it would expose READ+WRITE to the \
-                     network. Put it behind a reverse proxy / gateway that enforces auth.\n  \
+                     AUTH: --auth-token TOKEN (env SPARQ_AUTH_TOKEN) requires \
+                     'Authorization: Bearer TOKEN' on every WRITE (SPARQL Update + GSP \
+                     PUT/POST/DELETE) -> 401 + 'WWW-Authenticate: Bearer' otherwise \
+                     (constant-time compared; QLever's -a). Add --auth-token-read (env \
+                     SPARQ_AUTH_TOKEN_READ=1) to ALSO gate reads. Unset = no auth.\n  \
+                     SECURITY (bind): --addr defaults to loopback (127.0.0.1); a non-loopback \
+                     bind (e.g. 0.0.0.0) is REFUSED unless --allow-remote (or \
+                     SPARQ_ALLOW_REMOTE=1) is set OR the whole surface is authenticated \
+                     (--auth-token AND --auth-token-read) — a write-token alone still leaves \
+                     reads open. Put it behind a reverse proxy / gateway that enforces auth.\n  \
                      SERVICE federation (the `service` build feature) is DENY-ALL by default: \
                      SERVICE <iri> reaches NOTHING unless the host is allowlisted via \
                      --service-allow / --service-allow-file / SPARQ_SERVICE_ALLOW \
@@ -218,11 +249,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.time_travel_max_age.map_or("off".into(), |t| format!("{}s", t.as_secs())),
     );
 
+    // [OPUS-4.8] sq-zcby: surface the auth posture at startup. A write-only token (no
+    // --auth-token-read) leaves reads OPEN — warn so the operator is not surprised; a fully
+    // gated surface is reported too. No token = silent (the bind posture already warns on a
+    // non-loopback bind without auth).
+    let auth = AuthPosture::from_config(&config);
+    match auth {
+        AuthPosture::None => {}
+        AuthPosture::WriteOnly => eprintln!(
+            "auth: --auth-token set — WRITES require 'Authorization: Bearer <token>'; READS \
+             remain OPEN (add --auth-token-read to gate reads too). The /subscriptions \
+             WebSocket is a read surface and is NOT gated by this token."
+        ),
+        AuthPosture::ReadAndWrite => eprintln!(
+            "auth: --auth-token + --auth-token-read set — the whole surface (reads AND writes) \
+             requires 'Authorization: Bearer <token>'. Note: the /subscriptions WebSocket is \
+             NOT gated by this token; deliver the token over TLS."
+        ),
+    }
+
     let addr: SocketAddr = addr.parse()?;
-    // [OPUS-4.8] sq-o4qf: enforce the no-auth bind posture BEFORE binding. A non-loopback
-    // address is refused unless explicitly opted into (--allow-remote / SPARQ_ALLOW_REMOTE),
-    // because the server exposes READ+WRITE with no authentication.
-    match bind_posture(&addr, config.allow_remote) {
+    // [OPUS-4.8] sq-o4qf / sq-zcby: enforce the bind posture BEFORE binding. A non-loopback
+    // address is refused unless explicitly opted into (--allow-remote / SPARQ_ALLOW_REMOTE)
+    // OR the whole surface is authenticated (--auth-token AND --auth-token-read). A
+    // write-token alone still leaves reads open, so it still requires --allow-remote.
+    match bind_posture(&addr, config.allow_remote, auth) {
         BindPosture::Loopback => {}
         BindPosture::RemoteAllowed { warning } => eprintln!("{warning}"),
         BindPosture::RemoteRefused { message } => return Err(message.into()),

--- a/crates/sparq-server/tests/auth.rs
+++ b/crates/sparq-server/tests/auth.rs
@@ -385,8 +385,9 @@ async fn update_via_query_path_is_gated() {
     );
 }
 
-/// The url-encoded form path is classified on the payload too: an `update=` form parameter
-/// (or an update string in `query=`) is a write and is gated.
+/// The url-encoded form path: an `update=` form parameter is a write UNCONDITIONALLY (it IS
+/// an update by SPARQL-Protocol definition; see `update_form_with_select_body_is_gated_as_write`
+/// for the bypass guard), and an update string smuggled through `query=` is gated too.
 #[tokio::test]
 async fn update_via_form_path_is_gated() {
     let base = spawn_with(token_config(false)).await;
@@ -415,5 +416,53 @@ async fn update_via_form_path_is_gated() {
         read.status(),
         200,
         "a `query=` form read must stay open in write-only mode"
+    );
+}
+
+/// [OPUS-4.8] sq-zcby (Copilot PR#71 SECURITY regression test): the auth-bypass fix.
+///
+/// An `update=` form field IS an update operation BY DEFINITION (SPARQL 1.1 Protocol §2.2),
+/// so it MUST be gated as a write UNCONDITIONALLY — even when its value is a well-formed
+/// read-only query (e.g. `update=SELECT…`). The old classifier ran `payload_mutates(u)` on
+/// the `update=` value, which returned `false` for a SELECT-looking body and classified the
+/// request as a READ, so the write gate was BYPASSED. After the fix this request must be 401
+/// without a (correct) token, exactly like any other `update=` form.
+#[tokio::test]
+async fn update_form_with_select_body_is_gated_as_write() {
+    let base = spawn_with(token_config(false)).await;
+    let cl = client();
+    // `update=<SELECT…>` (a SELECT-looking body in the update field) with NO token => 401.
+    // This is the bypass: pre-fix it was classified as a read and allowed through.
+    let r = cl
+        .post(format!("{base}/sparql"))
+        .form(&[("update", SELECT)])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status(),
+        401,
+        "an `update=` form with a SELECT-looking body must still be gated as a write (no bypass)"
+    );
+    assert_eq!(
+        r.headers()
+            .get("www-authenticate")
+            .map(|v| v.to_str().unwrap()),
+        Some("Bearer"),
+        "the bypass-fix 401 must carry WWW-Authenticate: Bearer"
+    );
+
+    // With the WRONG token it must still be 401 (the gate ran, not bypassed).
+    let wrong = cl
+        .post(format!("{base}/sparql"))
+        .header("authorization", "Bearer not-the-token")
+        .form(&[("update", SELECT)])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        wrong.status(),
+        401,
+        "wrong token on an `update=SELECT…` form must still be 401"
     );
 }

--- a/crates/sparq-server/tests/auth.rs
+++ b/crates/sparq-server/tests/auth.rs
@@ -1,0 +1,419 @@
+//! [OPUS-4.8] sq-zcby (PSS gh-46) — HTTP integration tests for the Bearer-token gate on the
+//! write surface, plus the optional read gate.
+//!
+//! Each test spins the real axum server on an ephemeral port and drives it over HTTP with
+//! `reqwest`, asserting:
+//!   * back-compat — with NO token configured, writes still work;
+//!   * a configured write-token gates the UPDATE path (no header / wrong token => 401 with
+//!     `WWW-Authenticate: Bearer`; correct `Bearer` token => 204 and the mutation applies,
+//!     verified by a follow-up read);
+//!   * the Graph-Store-Protocol write methods (PUT a graph) are gated the same way;
+//!   * reads stay OPEN with only a write-token, and are GATED (401) once `--auth-token-read`
+//!     is on;
+//!   * classification keys on "does this mutate", not the route — an UPDATE smuggled through
+//!     the query path (POST `application/sparql-query` body that is an update) is gated too.
+//!
+//! Mirrors QLever's `-a <token>` write gate.
+
+use sparq_core::Graph;
+use sparq_server::{router, AppState, ServerConfig};
+use tokio::net::TcpListener;
+
+const TOKEN: &str = "s3cr3t-write-token";
+
+/// Boots the server over an empty graph with `config`; returns its base URL.
+async fn spawn_with(config: ServerConfig) -> String {
+    let graph = Graph::load_str("", "turtle").unwrap();
+    let app = router(AppState::with_config(graph, config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+/// A config with the write-token set; `read_gate` toggles `--auth-token-read`.
+fn token_config(read_gate: bool) -> ServerConfig {
+    ServerConfig {
+        auth_token: Some(TOKEN.to_string()),
+        auth_token_read: read_gate,
+        ..ServerConfig::default()
+    }
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+const INSERT: &str = "INSERT DATA { <http://ex/s> <http://ex/p> <http://ex/o> }";
+const SELECT: &str = "SELECT ?s WHERE { ?s ?p ?o }";
+
+/// Counts solutions of `SELECT` via the JSON result (no auth header — only valid when reads
+/// are open).
+async fn count_rows_open(cl: &reqwest::Client, base: &str) -> usize {
+    let body: serde_json::Value = cl
+        .get(format!("{base}/sparql"))
+        .header("accept", "application/sparql-results+json")
+        .query(&[("query", SELECT)])
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    body["results"]["bindings"].as_array().unwrap().len()
+}
+
+/// Counts solutions with a Bearer token (for the read-gated case).
+async fn count_rows_authed(cl: &reqwest::Client, base: &str, token: &str) -> usize {
+    let body: serde_json::Value = cl
+        .get(format!("{base}/sparql"))
+        .header("accept", "application/sparql-results+json")
+        .header("authorization", format!("Bearer {token}"))
+        .query(&[("query", SELECT)])
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    body["results"]["bindings"].as_array().unwrap().len()
+}
+
+// ---------------------------------------------------------------------------
+// Back-compat: no token configured
+// ---------------------------------------------------------------------------
+
+/// With NO token configured, an UPDATE still works (today's behaviour preserved).
+#[tokio::test]
+async fn update_with_no_token_configured_still_works() {
+    let base = spawn_with(ServerConfig::default()).await;
+    let cl = client();
+    let r = cl
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .body(INSERT)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 204, "no-token UPDATE must be back-compat 204");
+    assert_eq!(
+        count_rows_open(&cl, &base).await,
+        1,
+        "the mutation must have applied"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Write gate: the UPDATE path
+// ---------------------------------------------------------------------------
+
+/// UPDATE with a token configured but NO Authorization header => 401 + WWW-Authenticate.
+#[tokio::test]
+async fn update_without_header_is_401() {
+    let base = spawn_with(token_config(false)).await;
+    let cl = client();
+    let r = cl
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .body(INSERT)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 401);
+    assert_eq!(
+        r.headers()
+            .get("www-authenticate")
+            .map(|v| v.to_str().unwrap()),
+        Some("Bearer"),
+        "401 must carry WWW-Authenticate: Bearer"
+    );
+    // The mutation must NOT have applied (reads are open in write-only mode).
+    assert_eq!(
+        count_rows_open(&cl, &base).await,
+        0,
+        "a rejected UPDATE must not mutate"
+    );
+}
+
+/// UPDATE with the WRONG token => 401 (indistinguishable from the missing-token 401).
+#[tokio::test]
+async fn update_with_wrong_token_is_401() {
+    let base = spawn_with(token_config(false)).await;
+    let cl = client();
+    let r = cl
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .header("authorization", "Bearer not-the-token")
+        .body(INSERT)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 401);
+    assert_eq!(
+        r.headers()
+            .get("www-authenticate")
+            .map(|v| v.to_str().unwrap()),
+        Some("Bearer")
+    );
+    assert_eq!(count_rows_open(&cl, &base).await, 0);
+}
+
+/// UPDATE with the CORRECT Bearer token => 204 and the mutation actually applies (verified
+/// by a follow-up read). Scheme casing is tolerated.
+#[tokio::test]
+async fn update_with_correct_token_applies() {
+    let base = spawn_with(token_config(false)).await;
+    let cl = client();
+    let r = cl
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .header("authorization", format!("bearer {TOKEN}")) // lowercase scheme on purpose
+        .body(INSERT)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 204, "correct token => 204");
+    assert_eq!(
+        count_rows_open(&cl, &base).await,
+        1,
+        "the mutation must have applied"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Write gate: a Graph-Store-Protocol write method (PUT a graph)
+// ---------------------------------------------------------------------------
+
+/// A GSP write (PUT a named graph) is gated the same way: no token => 401; correct token =>
+/// the graph is written (a follow-up read sees it).
+#[tokio::test]
+async fn gsp_put_is_gated() {
+    let base = spawn_with(token_config(false)).await;
+    let cl = client();
+    let g = "http://ex/g/team";
+    let ttl = "<http://ex/a> <http://ex/p> <http://ex/b> .";
+
+    // No token => 401.
+    let unauth = cl
+        .put(format!("{base}/sparql/graph?graph={g}"))
+        .header("content-type", "text/turtle")
+        .body(ttl)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unauth.status(), 401, "GSP PUT must be gated");
+    assert_eq!(
+        unauth
+            .headers()
+            .get("www-authenticate")
+            .map(|v| v.to_str().unwrap()),
+        Some("Bearer")
+    );
+
+    // Correct token => 201 Created.
+    let authed = cl
+        .put(format!("{base}/sparql/graph?graph={g}"))
+        .header("content-type", "text/turtle")
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .body(ttl)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        authed.status(),
+        201,
+        "authed GSP PUT into an absent graph => 201"
+    );
+
+    // Read it back (reads are open in write-only mode) — the write applied.
+    let got = cl
+        .get(format!("{base}/sparql/graph?graph={g}"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        got.contains("<http://ex/a>"),
+        "the GSP PUT must have applied: {got:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Reads: open in write-only mode, gated under --auth-token-read
+// ---------------------------------------------------------------------------
+
+/// With only a write-token, reads stay OPEN (no Authorization needed).
+#[tokio::test]
+async fn reads_open_when_only_write_token_set() {
+    let base = spawn_with(token_config(false)).await;
+    let cl = client();
+    // Seed via an authed UPDATE, then read with NO header.
+    let seed = cl
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .body(INSERT)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(seed.status(), 204);
+    // GET /sparql with no token must succeed.
+    let r = cl
+        .get(format!("{base}/sparql"))
+        .query(&[("query", SELECT)])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status(),
+        200,
+        "reads must be open with only a write-token"
+    );
+    assert_eq!(count_rows_open(&cl, &base).await, 1);
+    // A GSP read with no token must succeed too.
+    let gr = cl
+        .get(format!("{base}/sparql/graph?default"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        gr.status(),
+        200,
+        "GSP reads must be open with only a write-token"
+    );
+}
+
+/// With --auth-token-read on, reads are GATED: no token => 401, correct token => 200.
+#[tokio::test]
+async fn reads_gated_when_read_gate_on() {
+    let base = spawn_with(token_config(true)).await;
+    let cl = client();
+    // Seed (authed write).
+    cl.post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .body(INSERT)
+        .send()
+        .await
+        .unwrap();
+
+    // GET /sparql with NO header => 401.
+    let unauth = cl
+        .get(format!("{base}/sparql"))
+        .query(&[("query", SELECT)])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        unauth.status(),
+        401,
+        "reads must be gated with --auth-token-read"
+    );
+    assert_eq!(
+        unauth
+            .headers()
+            .get("www-authenticate")
+            .map(|v| v.to_str().unwrap()),
+        Some("Bearer")
+    );
+
+    // A GSP read with no header => 401 too.
+    let gsp_unauth = cl
+        .get(format!("{base}/sparql/graph?default"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        gsp_unauth.status(),
+        401,
+        "GSP reads must be gated with --auth-token-read"
+    );
+
+    // With the token => 200 and the data is there.
+    assert_eq!(count_rows_authed(&cl, &base, TOKEN).await, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Mutation classification (not route): UPDATE via the query path
+// ---------------------------------------------------------------------------
+
+/// An UPDATE smuggled through the QUERY path (POST with `application/sparql-query` whose body
+/// is actually an UPDATE) must be gated as a write — classification keys on the payload, not
+/// the Content-Type/route. With no token it would be a 400 (the query handler rejects a
+/// non-query); with a token AND no header it must be a 401 BEFORE that, proving the gate
+/// classified it as a write.
+#[tokio::test]
+async fn update_via_query_path_is_gated() {
+    let base = spawn_with(token_config(false)).await;
+    let cl = client();
+    let r = cl
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query") // the *query* operation route
+        .body(INSERT) // ...but the body is an UPDATE
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status(),
+        401,
+        "an UPDATE on the query path must be gated as a write"
+    );
+    assert_eq!(
+        r.headers()
+            .get("www-authenticate")
+            .map(|v| v.to_str().unwrap()),
+        Some("Bearer")
+    );
+
+    // And a genuine READ on the query path stays open (write-only mode), proving the
+    // classifier does not over-gate.
+    let read = cl
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .body(SELECT)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        read.status(),
+        200,
+        "a genuine query must stay open in write-only mode"
+    );
+}
+
+/// The url-encoded form path is classified on the payload too: an `update=` form parameter
+/// (or an update string in `query=`) is a write and is gated.
+#[tokio::test]
+async fn update_via_form_path_is_gated() {
+    let base = spawn_with(token_config(false)).await;
+    let cl = client();
+    // `update=<INSERT…>` with no token => 401 (gated as a write).
+    let r = cl
+        .post(format!("{base}/sparql"))
+        .form(&[("update", INSERT)])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status(),
+        401,
+        "an `update=` form must be gated as a write"
+    );
+
+    // A genuine `query=` form stays open.
+    let read = cl
+        .post(format!("{base}/sparql"))
+        .form(&[("query", SELECT)])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        read.status(),
+        200,
+        "a `query=` form read must stay open in write-only mode"
+    );
+}

--- a/research/threat-model.md
+++ b/research/threat-model.md
@@ -311,25 +311,37 @@ query, and `application/sparql-update` mutation), `/sparql/graph` &
 `/graphs/*` (Graph Store Protocol; writes return 501), `/subscriptions`
 (WebSocket), `/health`, `/metrics`.
 
-**T-HTTP-EoP — Elevation of privilege / Information disclosure (no auth; open
-read+write).**
-*Mechanism:* **no authentication on any endpoint** — including the mutating
-`application/sparql-update` path and the `/subscriptions` WebSocket (a grep of
-`sparq-server/src` for auth/bearer/token/api-key finds nothing; `router()`
-applies only the `harden` middleware). Anyone who can reach the port can **read
-and mutate the entire dataset** (breaching dataset confidentiality *and*
-integrity). The binary defaults to `127.0.0.1:3030` but `--addr 0.0.0.0`
-(`main.rs:50`) exposes that surface **with no warning**.
-*Existing mitigation:* loopback-by-default bind is the only guard. Update *write*
-via `LOAD` is constrained separately (only `file://`, and even that is
-default-disabled unless `with_load_base` installs an allowlisted, canonicalized,
-containment-checked base dir — `crates/sparq-engine/src/update.rs:330-401`; the
-server never calls `with_load_base`, so `file://` LOAD always fails), so SSRF via
-`LOAD` is *not* reachable.
-*GAP:* no auth, no warning on non-loopback bind. **Bead sq-o4qf** (new): warn on
-non-loopback bind without auth; offer an optional auth hook; document the
-deploy-behind-a-gateway expectation in `skills/http-server/SKILL.md`. (Overlaps
-sq-ebii's policy doc; sq-o4qf is the auth+bind posture specifically.)
+**T-HTTP-EoP — Elevation of privilege / Information disclosure (open read+write
+without auth).**
+*Mechanism:* by default there is **no authentication on any endpoint** —
+including the mutating `application/sparql-update` path and the `/subscriptions`
+WebSocket. With no token configured, anyone who can reach the port can **read and
+mutate the entire dataset** (breaching dataset confidentiality *and* integrity).
+The binary defaults to `127.0.0.1:3030`.
+*Existing mitigation (sq-zcby — RESOLVED for the write surface):* a **required
+Bearer-token gate on the write surface** — `--auth-token <TOKEN>` (env
+`SPARQ_AUTH_TOKEN`) requires `Authorization: Bearer <TOKEN>` on every request that
+MUTATES the dataset (the `application/sparql-update` path, an update smuggled
+through the query path — classification keys on whether the request mutates, not
+the route — and the GSP `PUT`/`POST`/`DELETE` methods), `401` otherwise (token
+compared in constant time; mirrors QLever's `-a`). `--auth-token-read` additionally
+gates reads. Implemented in `crates/sparq-server/src/http.rs` (`auth_gate` /
+`constant_time_eq` / `payload_mutates`) and wired into the `router` handlers, so
+embedders get the gate too. The bind posture (sq-o4qf) now refuses a non-loopback
+bind unless `--allow-remote` is set OR the whole surface is authenticated
+(`--auth-token` AND `--auth-token-read`) — a write-token alone still leaves reads
+open, so it is not sufficient on its own; even an allowed remote bind warns. Update
+*write* via `LOAD` is constrained separately (only `file://`, default-disabled
+unless `with_load_base` installs an allowlisted, canonicalized, containment-checked
+base dir — `crates/sparq-engine/src/update.rs`; the server never calls
+`with_load_base`, so `file://` LOAD always fails), so SSRF via `LOAD` is *not*
+reachable.
+*RESIDUAL GAP:* the gate is a single shared secret (no per-user identity / scopes
+/ TLS of its own — deliver it over TLS via a proxy, and use a real authz layer
+such as `sparq-solid` for per-user authz), and the `/subscriptions` WebSocket
+(a read surface) is **not** gated by the token yet — **bead sq-cxk5** tracks
+gating it. Beads: **sq-zcby** (write gate, done), **sq-o4qf** (bind posture),
+**sq-cxk5** (subscriptions gate, open), **sq-ebii** (deploy-policy doc).
 
 **T-HTTP-DoS — Denial of service (request flood / pathological query).**
 *Mechanism:* expensive queries, large bodies, connection floods.
@@ -434,7 +446,7 @@ Ordered by severity. Every gap maps to a bead (existing or new).
 | 2 | mmap loader unfuzzed against hostile/truncated files (the whole B5 surface incl. dict-spill & raw-perm sortedness, plus parser-robustness) | **High** | B5 / B1 | Add a fuzz target: corrupt/truncated/hostile store + hostile RDF/SPARQL bytes → must error, never UB/panic-loop; run under `--features dict-spill` | **sq-ky2a** (exists, P2) |
 | 3 | Compressed-perm header arithmetic overflow + unchecked block offsets/varints → panic / OOB-read | **High** | B5 | `checked_mul`/`checked_add` header math; bounds-check directory offsets and varint reads | **sq-ed2i** (new, P2) |
 | 4 | SPARQL parser stack-overflow on deeply-nested query → process abort | **High** | B2 | Recursion-depth / input-size cap (or `stacker`) at parse entry; contribute upstream | **sq-v5dg** (new, P2) |
-| 5 | Server: no auth + `0.0.0.0` bind with no warning; `max-results` unlimited; no rate limit; no query-complexity bound | **High** | B3 / B2 | Warn on non-loopback bind w/o auth; optional auth hook; default-on rate limit + sensible `max-results`; document gateway expectation | **sq-o4qf** (new, P2) + **sq-ebii** (exists, P2) |
+| 5 | Server auth: write surface now has a Bearer-token gate (`--auth-token`, sq-zcby) + bind-posture refusal (sq-o4qf); RESIDUAL — `/subscriptions` WS not yet token-gated, no per-user authz, `max-results` unlimited, no rate limit / query-complexity bound | **Medium** (was High) | B3 / B2 | Gate the subscriptions WS (sq-cxk5); default-on rate limit + sensible `max-results`; document gateway expectation | **sq-zcby** (write gate, done) + **sq-o4qf** (bind, done) + **sq-cxk5** (WS, new) + **sq-ebii** (exists, P2) |
 | 6 | No documented/enforced server timeout-memory-decompression-SSRF policy; minor 500-error engine-internal disclosure; reason/SHACL materialization budgets | **Medium** | B3 / B1 | Write+enforce the DoS/SSRF policy doc; redact `{:?}` algebra from 500s; add reasoning/validation budgets when exposed to untrusted input | **sq-ebii** (exists, P2) |
 | 7 | SERVICE federation has zero SSRF egress filtering **if** the `service` feature is enabled | **Medium** (gated off by default) | B4 | Default-deny loopback/RFC1918/link-local/metadata; config allowlist; document the sharp edge | **sq-2v6f** (new, P2) |
 | 8 | Decompression bomb on CLI/operator ingest (not network-reachable in the shipped server) | **Medium** | B1 | Decompression-ratio + output-size cap on the fused-decompress ingest | **sq-ebii** (exists, P2) |

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -25,12 +25,20 @@ cargo run -p sparq-server
 cargo run -p sparq-server -- --addr 0.0.0.0:8080 --allow-remote --format ntriples data.nt
 ```
 
-> **Security: no built-in auth.** Every endpoint is unauthenticated — including the
-> mutating `application/sparql-update` path and the `/subscriptions` WebSocket. The
-> server binds **loopback by default** and **refuses a non-loopback bind** (e.g.
-> `0.0.0.0`) unless you set `--allow-remote` (env `SPARQ_ALLOW_REMOTE=1`), warning loudly
-> even then. Do not expose it to an untrusted network without a reverse proxy / API
-> gateway (or `sparq-solid`) enforcing auth in front. SPARQL `SERVICE` federation is OFF
+> **Security: optional Bearer-token write gate; loopback by default.** With no token
+> configured, every endpoint is unauthenticated (the back-compat default). Set
+> `--auth-token <TOKEN>` (env `SPARQ_AUTH_TOKEN`) to require `Authorization: Bearer <TOKEN>`
+> on every **write** (a SPARQL Update on `/sparql` — `application/sparql-update`, or a
+> `query`/`update` body that parses as an update — and the GSP `PUT`/`POST`/`DELETE`
+> methods); otherwise `401` with `WWW-Authenticate: Bearer` (constant-time compared; mirrors
+> QLever's `-a <token>`). Add `--auth-token-read` (env `SPARQ_AUTH_TOKEN_READ=1`) to ALSO
+> gate reads. The `/subscriptions` WebSocket is a read surface and is NOT gated by this token
+> (bead `sq-cxk5`). The server binds **loopback by default** and **refuses a non-loopback
+> bind** (e.g. `0.0.0.0`) unless you set `--allow-remote` (env `SPARQ_ALLOW_REMOTE=1`) OR the
+> whole surface is authenticated (`--auth-token` AND `--auth-token-read`) — a write-token
+> alone still leaves reads open. Deliver the token over TLS (terminate it at a proxy). For
+> real per-user authz, front it with a reverse proxy / API gateway (or `sparq-solid`). SPARQL
+> `SERVICE` federation is OFF
 > in the default build (the `service` cargo feature is off); a `SERVICE` clause then
 > errors at execution. Build with `--features service` to enable it — and even then the
 > server is **default-DENY-all SERVICE**: a `SERVICE <iri>` reaches **nothing** unless its
@@ -95,13 +103,20 @@ Library surface re-exported from `sparq_server` (behind the default `server` fea
   (**`time-travel` feature only**).
 - `struct ServerConfig { query_timeout: Option<Duration>, max_body_bytes: usize,
   max_concurrent: usize, max_results: Option<usize>, max_subscriptions: usize,
-  max_subscriptions_per_conn: usize, verbose: bool, allow_remote: bool, /* + time_travel_*
-  under feature */ }` with `ServerConfig::default()` and `ServerConfig::from_env()`.
-- `fn bind_posture(addr: &SocketAddr, allow_remote: bool) -> BindPosture` — the no-auth
-  bind gate the binary applies: `Loopback` (proceed), `RemoteAllowed { warning }` (proceed
-  + log), or `RemoteRefused { message }` (refuse). `allow_remote` is a *binary* posture
-  gate only — it does not add per-request auth and the library `router`/`harden` surface
-  ignores it.
+  max_subscriptions_per_conn: usize, verbose: bool, allow_remote: bool,
+  auth_token: Option<String>, auth_token_read: bool, /* + time_travel_* under feature */ }`
+  with `ServerConfig::default()` and `ServerConfig::from_env()`. `auth_token` (set: gates the
+  write surface with a Bearer token, constant-time compared; `None`: no write auth) and
+  `auth_token_read` (gate reads too) are honoured by the library `router` itself — embedders
+  get the gate for free.
+- `fn bind_posture(addr: &SocketAddr, allow_remote: bool, auth: AuthPosture) -> BindPosture`
+  — the bind gate the binary applies: `Loopback` (proceed), `RemoteAllowed { warning }`
+  (proceed + log), or `RemoteRefused { message }` (refuse). `AuthPosture::{None, WriteOnly,
+  ReadAndWrite}` (via `AuthPosture::from_config(&config)`) folds the token + read-gate into
+  the decision: a non-loopback bind is allowed when `--allow-remote` is set OR the surface is
+  fully authenticated (`ReadAndWrite`); a write-token alone (`WriteOnly`) still requires
+  `--allow-remote` because reads stay open. This is a *bind-time* posture gate; per-request
+  auth is the `auth_token` fields above (enforced by `router`/`harden`-wrapped handlers).
 - `fn harden(routes: axum::Router, config: &ServerConfig) -> axum::Router` — wrap any
   router in the production middleware (panic→500, concurrency-limit→429, body-limit→413,
   JSON error bodies, optional trace).
@@ -222,8 +237,9 @@ GSP **writes** translate into a server-minted SPARQL Update (`DROP`/`CLEAR` + `I
 DATA`) and submit through the SAME sequenced group-commit writer the
 `application/sparql-update` operation uses — so they share its atomicity, snapshot
 consistency, blocking-on-commit semantics, the `Sparq-Generation` header (time-travel
-feature), AND its **no-auth** posture (a GSP write is as powerful as an UPDATE — see the
-security gotcha). A malformed body → `400`; an unsupported body Content-Type → `415`.
+feature), AND its **auth gate** (a GSP write is as powerful as an UPDATE, so `PUT`/`POST`/
+`DELETE` are gated by `--auth-token` exactly like an UPDATE; `GET`/`HEAD` are reads). A
+malformed body → `400`; an unsupported body Content-Type → `415`.
 
 **6. Hardening — flags / env / library.** Each flag overrides its `SPARQ_*` env var; the
 env overrides the default.
@@ -237,7 +253,9 @@ env overrides the default.
 | `--max-subscriptions N` | `SPARQ_MAX_SUBSCRIPTIONS` | `256` | server-wide subs |
 | `--max-subscriptions-per-conn N` | `SPARQ_MAX_SUBSCRIPTIONS_PER_CONN` | `16` | per-socket subs |
 | `--verbose` | — | off | TraceLayer request logging (respects `RUST_LOG`) |
-| `--allow-remote` | `SPARQ_ALLOW_REMOTE` | off | opt in to a non-loopback bind despite no auth; without it a non-loopback `--addr` is **refused** at startup, with it it warns and proceeds |
+| `--auth-token TOKEN` | `SPARQ_AUTH_TOKEN` | off (no auth) | require `Authorization: Bearer TOKEN` on every WRITE (SPARQL Update + GSP PUT/POST/DELETE) → `401` + `WWW-Authenticate: Bearer` otherwise; constant-time compared (QLever's `-a`) |
+| `--auth-token-read` | `SPARQ_AUTH_TOKEN_READ` | off | ALSO gate reads with the same token (only meaningful with a token set) |
+| `--allow-remote` | `SPARQ_ALLOW_REMOTE` | off | opt in to a non-loopback bind; without it a non-loopback `--addr` is **refused** unless the surface is fully authenticated (`--auth-token` AND `--auth-token-read`), with it it warns and proceeds |
 | `--service-allow HOST\|*.SUFFIX` (repeatable) | `SPARQ_SERVICE_ALLOW` (comma/ws-sep) | empty = **deny ALL SERVICE** | (feature `service`) allowlist a SERVICE egress host (exact or `*.suffix` wildcard); CLI + file + env are all merged (combined additively) |
 | `--service-allow-file PATH` | — | — | (feature `service`) load allowlist entries, one per line (`#` comments + blanks ignored) |
 | `--time-travel-generations N` | `SPARQ_TIME_TRAVEL_GENERATIONS` | `16` | (feature) retained generations |
@@ -248,13 +266,23 @@ then `router(state)`, or `harden(my_router, &config)`.
 
 ## Gotchas / feature flags / prerequisites
 
-- **No built-in auth — loopback-by-default, non-loopback bind is refused.** Every endpoint
-  (query, `application/sparql-update`, `/subscriptions` WS) is unauthenticated → read+write
-  open to anyone who can reach the port. The binary binds `127.0.0.1:3030` by default and
-  **refuses** a non-loopback `--addr` (incl. `0.0.0.0`/`::`) unless `--allow-remote` /
-  `SPARQ_ALLOW_REMOTE=1`; even then it warns. Front it with a reverse proxy / gateway (or
-  `sparq-solid`) for auth. No rate limit and `--max-results` is unlimited by default — set
-  caps + a gateway rate limiter if exposing it (beads `sq-o4qf`, `sq-ebii`).
+- **Auth — optional Bearer write gate; loopback-by-default; non-loopback bind refused
+  unless safe.** With no `--auth-token` the server is unauthenticated (read+write open to
+  anyone who can reach the port) — the back-compat default. Set `--auth-token <TOKEN>` (env
+  `SPARQ_AUTH_TOKEN`) to require `Authorization: Bearer <TOKEN>` on every WRITE (SPARQL Update
+  + GSP `PUT`/`POST`/`DELETE`); `401` + `WWW-Authenticate: Bearer` otherwise (constant-time
+  compared; QLever's `-a <token>`; missing-vs-wrong are indistinguishable). The classification
+  keys on whether the request **mutates**, not the route — an Update smuggled through the
+  query path is gated too. Add `--auth-token-read` (env `SPARQ_AUTH_TOKEN_READ=1`) to ALSO
+  gate reads. The `/subscriptions` WS is a read surface and is NOT gated by this token (bead
+  `sq-cxk5`). The binary binds `127.0.0.1:3030` by default and **refuses** a non-loopback
+  `--addr` (incl. `0.0.0.0`/`::`) unless `--allow-remote` / `SPARQ_ALLOW_REMOTE=1` OR the
+  whole surface is authenticated (`--auth-token` AND `--auth-token-read`); even then it warns.
+  A write-token alone still leaves reads open, so it does NOT by itself make a remote bind
+  safe. Deliver the token over TLS (terminate at a proxy). For per-user authz front it with a
+  reverse proxy / gateway (or `sparq-solid`). No rate limit and `--max-results` is unlimited by
+  default — set caps + a gateway rate limiter if exposing it (beads `sq-zcby`, `sq-o4qf`,
+  `sq-ebii`).
 - **SERVICE federation (egress allowlist).** `SERVICE` is OFF in the default build (build
   with `--features service` to enable it). Even enabled, the server is **default-DENY-all
   SERVICE**: a `SERVICE <iri>` clause reaches **nothing** unless its host is allowlisted —


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the `jeswr/sparq` RDF/SPARQL engine (Claude Opus 4.8). @jeswr runs multiple agents; this was written by the **SPARQ** agent. The **PSS** agent (`prod-solid-server`) is a separate party in these discussions.

## What

Adds an optional **required Bearer-token gate on the WRITE surface** of `sparq-server`, with an optional read gate — closing PSS **gh-46** (`sq-zcby`), a security showstopper. Mirrors QLever's `-a <token>`.

- **`--auth-token <TOKEN>`** (env `SPARQ_AUTH_TOKEN`) gates **writes**: every request that MUTATES the dataset must present `Authorization: Bearer <TOKEN>` or it is refused `401` with `WWW-Authenticate: Bearer`.
- **`--auth-token-read`** (env `SPARQ_AUTH_TOKEN_READ=1`) ALSO gates **reads** (SPARQL query, GSP `GET`/`HEAD`). Off by default (QLever-style: writes gated, reads open).
- Unset token = **today's behaviour, preserved exactly** (no write auth — back-compat).

## Why

By default the server is unauthenticated: anyone who can reach the port can read AND mutate the whole dataset. PSS needs a write gate so the engine can be exposed without a full reverse-proxy in front. This is the threat-model's **T-HTTP-EoP** mitigation for the write surface.

## How — classification keys on "does this mutate", not the route

The write surface gated is the full set of paths that reach the writer (`apply_update` / `Writer`):
- a SPARQL **UPDATE** on `/sparql` — by `Content-Type: application/sparql-update`, **OR** a `query`/`update` body that *parses as an update* (`payload_mutates`): an UPDATE smuggled through the query Content-Type or a `query=`/`update=` form is gated as a write;
- the **Graph-Store-Protocol write methods** (`PUT`/`POST`/`DELETE`, and `PATCH` → 405) on `/sparql/graph` and `/graphs/{*path}`.

`GET`/`HEAD` (query + GSP read) are reads — gated only under `--auth-token-read`.

## Auth × bind matrix (bind posture, sq-o4qf, now auth-aware)

| `--auth-token`? | `--auth-token-read`? | `--allow-remote`? | non-loopback bind |
| --- | --- | --- | --- |
| no  | —   | no  | **refused** (read+write open) |
| no  | —   | yes | allowed, **warns** |
| yes | no  | no  | **refused** — writes gated but **reads still open** |
| yes | no  | yes | allowed, **warns reads remain open** |
| yes | yes | no  | **allowed** — whole surface authenticated (still warns) |
| yes | yes | yes | **allowed** (still warns) |

Rule: a write-token counts as "auth present" for a non-loopback bind **only when reads are also gated**; a write-token alone still requires `--allow-remote` and warns that reads remain open. Loopback always allowed. Implemented via the new `AuthPosture` enum threaded into `bind_posture`.

## Constant-time comparison

Hand-rolled `constant_time_eq` (length check + per-byte XOR-accumulate, `#[inline(never)]`). Chosen over pulling in the `subtle` crate: `sparq-server` has no other crypto dep, this keeps it off the supply-chain/SBOM surface, and it is the standard well-understood construction. The 401 is **byte-identical for a missing vs a wrong token**, so it never leaks which. Scheme casing tolerated (`Bearer`/`bearer`).

## Test coverage

`crates/sparq-server/tests/auth.rs` (9 integration tests — the acceptance spec, **unmodified**): no-token back-compat; 401 on missing/wrong token for UPDATE; 200 + mutation-applied with correct token; GSP PUT gated; reads open in write-only mode; reads gated under `--auth-token-read`; UPDATE-via-query-path gated; UPDATE-via-form-path gated. Plus a new `auth_tests` unit module (constant-time eq, Bearer parsing, `payload_mutates` classification, the gate decision, posture derivation) and updated `bind_posture_tests`.

## Public surface (SKILL.md maintenance rule honoured)

New `--auth-token` / `--auth-token-read` CLI flags + env, new `ServerConfig` fields, new `AuthPosture` type, `bind_posture` signature gains an `AuthPosture` arg. Updated: `main.rs` `--help` + `//!` header, `crates/sparq-server/README.md` (security posture + auth matrix), `research/threat-model.md`, `skills/http-server/SKILL.md`. Stale "no auth" claims reconciled (now "by default … no auth").

## Follow-ups (beaded)

- `sq-cxk5` — gate the `/subscriptions` WebSocket (a read surface) under the read token.
- `sq-9jrx` — gate `/metrics` under `--auth-token-read` (leaks triple/subscription counts).

## Gates

- `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings` — clean.
- `cargo test -p sparq-server` — 69 lib + 9 auth integration + all suites green.
- rustfmt is informational in this repo (the one-time `cargo fmt --all` reformat is deferred — see `rustfmt.toml`); no workspace-wide reformat done.

Closes sq-zcby (PSS gh-46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)