### PR TITLE
MPC: finalise tampered-share detection (guarantee (D)) — PLAN refresh + deferred seams + e2e test (closes sq-uu0u)

### DIFF
--- a/crates/sparq-mpc/PLAN.md
+++ b/crates/sparq-mpc/PLAN.md
@@ -94,11 +94,16 @@ First concrete secret-sharing impl behind the trait + the hidden-value join,
 detect-and-abort / robust-correct on every reconstruction path, surfaced via the
 `MaliciousSecurity` enum. See the "Security model" bullet below and the
 "Deferred malicious-security seams" subsection for what remains beyond v1.
-- **Q2 RESOLVED for v1: honest-majority, semi-honest** (Jesse's decision:
+- **Q2 RESOLVED for v1: honest-majority trust model** (Jesse's decision:
   honest-majority now, configurable long-term). The four flatmates *cooperate*
-  among themselves (honest-but-curious) to prove an aggregate to an external
-  landlord — the regime Shamir serves. LAN secret-sharing chosen (the aggregate
-  is linear → zero-round under Shamir; WAN garbled-circuit unneeded for v1).
+  among themselves to prove an aggregate to an external landlord — the regime
+  Shamir serves. LAN secret-sharing chosen (the aggregate is linear → zero-round
+  under Shamir; WAN garbled-circuit unneeded for v1). The *adversary model* is no
+  longer purely semi-honest on integrity: tamper-detection / robust-correction
+  (guarantee (D)) is now wired through the reconstruction layer (see the "Security
+  model" bullet), so the exact integrity guarantee a given `(n, t)` delivers is
+  reported by the `MaliciousSecurity` enum rather than asserted as a blanket
+  "semi-honest" label here.
 - **Scheme: Shamir `t`-of-`n` over `F_p`** (`p = 2^61-1` Mersenne, dependency-
   free `u128` reduction). Chosen over **replicated 3PC** because the use case is
   "any N cooperating flatmates" (replicated is n=3-only) and the secured
@@ -107,8 +112,11 @@ detect-and-abort / robust-correct on every reconstruction path, surfaced via the
 - **Implemented (REAL, in-process multi-party simulation):**
   - `MpcBackend` for `ShamirBackend`: `share_private_input` (Shamir-share a
     holder's private salary), `run_secure` (cumulative sum — zero rounds),
-    `reconstruct_disclosed` (Lagrange at 0 → the disclosed integer; the verifier
-    recomputes `> £100k` OUTSIDE the crypto, M5).
+    `reconstruct_disclosed` (checked/robust reconstruction at x=0 when redundancy
+    is present — RS / Berlekamp–Welch via `robust.rs`, detect-and-abort or
+    correct, see the "Security model" bullet; reduces to Lagrange at 0 only at the
+    no-redundancy `t+1` boundary → the disclosed integer; the verifier recomputes
+    `> £100k` OUTSIDE the crypto, M5).
   - Secret-shared **equality test** (`secure_equal`): `d=a-b`, mask by fresh
     nonzero `r`, one Shamir multiplication (`mul_shares_raw`, degree 2t), open
     `m=d·r`; `m==0 ⇔ a==b`, leaking ONLY the match bit. Keys never reconstructed.

--- a/crates/sparq-mpc/PLAN.md
+++ b/crates/sparq-mpc/PLAN.md
@@ -89,7 +89,11 @@ Join holders' partials on GLOBAL IRIs (architecture §2 #6, §4.3 step 4).
   the dedicated type, not faked into the disclosed-key one.
 
 ### M3 — `MpcBackend` (honest-majority Shamir) + hidden-value join  ✅ DONE [OPUS-4.8]
-First concrete secret-sharing impl behind the trait + the hidden-value join.
+First concrete secret-sharing impl behind the trait + the hidden-value join,
+**plus the RS tampered-share-detection hardening (guarantee (D), sq-uu0u)** —
+detect-and-abort / robust-correct on every reconstruction path, surfaced via the
+`MaliciousSecurity` enum. See the "Security model" bullet below and the
+"Deferred malicious-security seams" subsection for what remains beyond v1.
 - **Q2 RESOLVED for v1: honest-majority, semi-honest** (Jesse's decision:
   honest-majority now, configurable long-term). The four flatmates *cooperate*
   among themselves (honest-but-curious) to prove an aggregate to an external
@@ -110,26 +114,53 @@ First concrete secret-sharing impl behind the trait + the hidden-value join.
     `m=d·r`; `m==0 ⇔ a==b`, leaking ONLY the match bit. Keys never reconstructed.
   - `HiddenValueJoin`: all-pairs oblivious join on a PRIVATE key driven by the
     equality test, disclosing only the matching payload columns.
-- **Tested (`cargo test -p sparq-mpc --release`, 32 pass):** DIFFERENTIAL —
+- **Tested (`cargo test -p sparq-mpc`):** DIFFERENTIAL —
   (a) secure cumulative sum == plaintext sum; (b) hidden-value join == plaintext
   inner join over the union (overlap, no-overlap, multi-match fan-out, empty
   side). Plus: field arithmetic vs reference modulo; share/reconstruct round-
   trip; the threshold actually hides (a <=t-share set is consistent with a
   DIFFERENT secret — information-theoretic hiding witness); reconstruction below
-  t+1 errors; the equality primitive in isolation (n=5,t=2). Native-only
-  invariant re-verified: `cargo tree -p sparq-wasm` excludes `sparq-mpc`.
-- **Security model (stated, not papered over):** honest-majority **semi-honest**.
-  Privacy holds while `< t+1` parties pool shares; each party learns only its
-  shares + the disclosed output. **NOT malicious-secure** (guarantee D) — a
-  malicious party feeding inconsistent shares is out of scope for v1. Malicious
-  honest-majority (VSS / IT-MACs, ≈2×) is future hardening behind the SAME trait.
+  t+1 errors; the equality primitive in isolation (n=5,t=2). The adversarial
+  suite (`adversarial_tests.rs`) pins guarantee (D): tampered-share detection /
+  RS correction across the `(n, t, e)` regimes and at the end-to-end
+  `reconstruct_disclosed` API boundary, the non-detection boundaries (exact `t+1`
+  and the degree-`2t` `n=2t+1` equality open), and the "no fake crypto" stub
+  table. Native-only invariant re-verified: `cargo tree -p sparq-wasm` excludes
+  `sparq-mpc`.
+- **Security model (stated, not papered over):** honest-majority. Privacy holds
+  while `< t+1` parties pool shares; each party learns only its shares + the
+  disclosed output (confidentiality, guarantee (A)). **Tampered-share detection
+  (guarantee (D)) IS now provided at the Shamir reconstruction layer** (sq-uu0u
+  WI-1/WI-2/WI-3, merged) — *not* the old semi-honest-only stance:
+  - Shamir shares are an `[n, t+1]` Reed–Solomon codeword over the same `F_p`, so
+    `robust.rs::reconstruct_robust` (Berlekamp–Welch via Gaussian elimination,
+    **zero new deps** — no DLOG group, no SPDZ preprocessing) DETECTS any
+    tampering and CORRECTS up to `e = ⌊(n−t−1)/2⌋` cheaters, else ABORTS with the
+    typed `MpcError::Tampered`. Every production reconstruction routes through it
+    (`ShamirBackend::reconstruct` / `reconstruct_disclosed`, and the degree-`2t`
+    equality open via `reconstruct_degree`). The guarantee a given `(n, t)`
+    delivers is surfaced through `BackendInfo` as the `MaliciousSecurity` enum
+    (`SemiHonestOnly` / `HonestMajorityAbort` / `HonestMajorityRobust{max_cheaters}`).
+  - **Honest boundaries where RS cannot help (pinned by tests, not papered over):**
+    at exactly `t+1` shares (no redundancy) tampering is information-theoretically
+    undetectable; and the degree-`2t` equality/mult open has zero redundancy at
+    the honest-majority minimum `n = 2t+1` (odd `n`), so a forged product share is
+    undetectable there. A true fix at those no-redundancy points needs an
+    information-theoretic MAC (the deferred SPDZ-style seam below, bead sq-6d6g),
+    not RS redundancy. **Cheater *attribution* in the abort message is best-effort
+    (heuristic) when correction is impossible — detection is sound; sharpening
+    blame is bead sq-6u6b.**
+  - Robust *with guaranteed output* still assumes an honest majority; a
+    dishonest-majority malicious backend (SPDZ/MASCOT IT-MACs, ≈2×) remains future
+    hardening behind the SAME trait (deferred seam below).
 - **Honest scope / what is scaffolded (not faked):** the join is `O(|L|·|R|)`
   all-pairs (real circuit-PSI uses cuckoo bins — that ~linear optimisation is
   **Q3 / RQ2b, NOT done**); the key→`Fp` encoding is the holder's responsibility
   and needs a collision-resistant hash whose correctness is proven in-circuit in
-  production (here controlled so the differential is exact); the simulation RNG
-  is a deterministic SplitMix64 — **production needs a CSPRNG** for the dealer's
-  masking coefficients (flagged in `shamir.rs`, not hidden).
+  production (here controlled so the differential is exact). The dealer's masking
+  randomness is a **CSPRNG** (OS-seeded ChaCha20, `rng.rs`, sq-1vt) — a
+  deterministic SplitMix64 is reachable only behind a test-only feature gate, so
+  the real protocol's masks are unpredictable.
 - **Configurability (Jesse's requirement):** the trust model is a property of
   the chosen `MpcBackend` value (`BackendInfo::trust_model`), never hardcoded in
   the join/proof layer. A dishonest-majority (SPDZ/MASCOT) backend slots in
@@ -144,6 +175,48 @@ First concrete secret-sharing impl behind the trait + the hidden-value join.
   obliviousness forces worst-case padding"). Viable regime only: honest-majority,
   LAN, ≤10³–10⁴ rows/holder. Do NOT extrapolate to WAN / dishonest-majority
   (zero published data points).
+
+#### Deferred malicious-security seams (sq-uu0u WI-4, bead sq-6d6g) [OPUS-4.8]
+The RS detect-and-abort / robust path (WI-1/2/3) closes guarantee (D) **in the
+honest-majority, redundancy-present regime** (`reconstruct` at degree `t`; the
+degree-`2t` equality open when `n > 2t+1`). Two gaps are explicitly NOT covered
+by RS redundancy and are deferred to dedicated future backends behind the SAME
+`MpcBackend` trait — recorded here so the boundary is a documented design seam,
+not a silent hole (architecture §4.2 guarantee (D), §5.2 Q2; sq-uu0u DESIGN
+"REJECTED for now"):
+
+1. **SPDZ-style information-theoretic-MAC backend (dishonest-majority + the
+   no-redundancy points).** An additive-share + per-share MAC scheme
+   (SPDZ/MASCOT/Overdrive) is the only family that gives malicious security
+   *without* reconstruction redundancy, and the only one that extends to a
+   **dishonest majority** (up to `n−1` corrupt). It is the principled fix for the
+   two RS blind spots: (a) reconstruction at exactly `t+1` shares, and (b) the
+   degree-`2t` equality/mult open at the honest-majority minimum `n = 2t+1`
+   (`join::secure_equal` / `shamir::reconstruct_degree`) — both have zero RS
+   redundancy, so a MAC-check before opening (abort on a failed tag) is required,
+   not Berlekamp–Welch. Cost: input-independent preprocessing (Beaver triples +
+   MACs) and ≈`2^-61` soundness over `F_p = 2^61−1`. It slots in as a new backend
+   reporting `TrustModel::DishonestMajority` + a non-`SemiHonestOnly`
+   `MaliciousSecurity`, changing only `type Share` (value + MAC tag) and adding a
+   MAC-check in `reconstruct_disclosed` — the `share_private_input` / `run_secure`
+   / `reconstruct_disclosed` SIGNATURES and all callers stay put (`backend.rs`).
+   REJECTED for *this* increment: it needs preprocessing + a fresh soundness
+   argument and is a whole backend, not a Shamir-layer change.
+
+2. **Poseidon2 / Schnorr share-commitments for the M4 attestation layer.**
+   Binding a *reconstructed* (or shared) value to an issuer-signed commitment
+   inside the collaborative proof (guarantees (B) correctness end-to-end and (C)
+   attested-source) needs a commitment in a circuit-friendly group — Poseidon2
+   over a SNARK field (BN254 `Fr`), with Schnorr/EdDSA opening — NOT the lean
+   `F_p = 2^61−1` arithmetic this crate carries. That deliberately keeps arkworks
+   /DLOG out of `sparq-mpc`; it lives in the M4 proof/attestation seam (`proof.rs`,
+   gated on Q1 + the ZK-foundation remediation), which is a separate milestone.
+   REJECTED for this increment: wrong field, would drag a heavy dependency into a
+   crate that is intentionally dependency-light and wasm-excluded.
+
+Neither seam is on the v1 critical path: v1 is honest-majority, and the RS path
+already delivers (D) there. Both are tracked as beads (sq-6d6g) and named at
+their call sites so the deferral is auditable.
 
 ### M4 — Collaborative proof + distributed attestation  ⚠️ THE HARD PROBLEM (SPIKE)
 The contribution AND the principal research risk (architecture §5.2 Q1, §3.4).
@@ -188,6 +261,13 @@ regime that has zero published data points.
   **the principal thing that remains.** Unsolved in the literature; SPIKE.
 - **Q2** ✅ DECIDED at **M3**: honest-majority Shamir for v1 (configurable behind
   the trait long-term). Done.
+- **Guarantee (D), malicious security** ✅ DELIVERED at **M3** for the honest-
+  majority, redundancy-present regime (sq-uu0u WI-1/2/3): RS / Berlekamp–Welch
+  detect-and-abort / robust-correct on every reconstruction path, surfaced via
+  the `MaliciousSecurity` enum. Remaining seams (no-redundancy points + dishonest
+  majority via an IT-MAC backend; M4 attestation commitments) are deferred and
+  documented under M3 "Deferred malicious-security seams" (bead sq-6d6g);
+  attribution sharpening is bead sq-6u6b.
 - **Q3** (BGP-join obliviousness cost / RQ2b) — surfaced concretely at **M3**:
   the hidden-value join is `O(|L|·|R|)` all-pairs; the ~linear cuckoo-bin /
   oblivious-hashing optimisation and the fragment it applies to is **still open**

--- a/crates/sparq-mpc/src/adversarial_tests.rs
+++ b/crates/sparq-mpc/src/adversarial_tests.rs
@@ -366,6 +366,71 @@ mod tamper {
              (MpcError::Tampered), not silently change the total; got {err:?}"
         );
     }
+
+    /// [OPUS-4.8] **END-TO-END guarantee (D) at the production API boundary
+    /// (sq-uu0u).** The tests above exercise the RS checker via `reconstruct` /
+    /// `reconstruct_degree`. This one drives the WHOLE public [`MpcBackend`]
+    /// pipeline a federation actually calls — `run_secure` then
+    /// `reconstruct_disclosed` (the disclosed-output trait method, NOT the helper)
+    /// — and proves guarantee (D) is wired all the way THROUGH that surface: a
+    /// tampered share in the result sharing is (a) RS-corrected back to the true
+    /// disclosed integer within the budget, and (b) detect-and-aborts with
+    /// [`MpcError::Tampered`] beyond it — never a silently wrong disclosed answer.
+    /// Honest runs still disclose the correct total (no behaviour change clean).
+    #[test]
+    fn tampered_share_at_reconstruct_disclosed_boundary_is_corrected_or_aborts() {
+        // n = 4, t = 1 → e_max = ⌊(4−1−1)/2⌋ = 1: one error is CORRECTABLE, two abort.
+        let backend = ShamirBackend::new_seeded(4, 0xD15C).unwrap();
+        let mut dealer = backend.dealer();
+        let inputs: Vec<Vec<Share>> = [30_000u64, 45_000, 28_000]
+            .iter()
+            .map(|&v| dealer.share(fp(v)))
+            .collect();
+        let plaintext_sum = 30_000u64 + 45_000 + 28_000;
+        let summed = backend.run_secure(&inputs).unwrap();
+
+        // Helper: pull the single disclosed integer out of the disclosed partial.
+        let disclosed_int = |p: &PartialResult| -> u64 {
+            assert_eq!(p.rows.len(), 1, "disclosed partial is exactly one row");
+            match &p.rows[0][0] {
+                Some(Term::Literal(l)) => l.value().parse::<u64>().unwrap(),
+                other => panic!("expected integer literal, got {other:?}"),
+            }
+        };
+
+        // HONEST: the disclosed-output method returns the true total.
+        let honest = backend.reconstruct_disclosed(&summed).unwrap();
+        assert_eq!(
+            disclosed_int(&honest),
+            plaintext_sum,
+            "sanity: honest disclosed output is the true sum"
+        );
+
+        // ONE tampered result share (within e_max=1) → disclosed output is
+        // RS-CORRECTED back to the true total at the public boundary.
+        let mut one_bad = summed.clone();
+        one_bad[0][1].y = one_bad[0][1].y.add(fp(13));
+        let corrected = backend.reconstruct_disclosed(&one_bad).unwrap();
+        assert_eq!(
+            disclosed_int(&corrected),
+            plaintext_sum,
+            "sq-uu0u: a single tampered result share is RS-corrected through \
+             reconstruct_disclosed — the relying party sees the TRUE total"
+        );
+
+        // TWO tampered result shares (> e_max=1) → reconstruct_disclosed ABORTS;
+        // the relying party gets a typed error, never a fabricated disclosed value.
+        let mut two_bad = summed;
+        two_bad[0][1].y = two_bad[0][1].y.add(fp(13));
+        two_bad[0][3].y = two_bad[0][3].y.add(fp(17));
+        let err = backend.reconstruct_disclosed(&two_bad).unwrap_err();
+        assert!(
+            matches!(err, MpcError::Tampered { .. }),
+            "sq-uu0u: tampering beyond the correctable budget must ABORT at the \
+             reconstruct_disclosed boundary (MpcError::Tampered), never disclose a \
+             silently-wrong total; got {err:?}"
+        );
+    }
 }
 
 // =====================================================================


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the `jeswr/sparq` RDF/SPARQL engine (Claude Opus 4.8). @jeswr runs multiple agents; this was written by the **SPARQ** agent. The **PSS** agent (`prod-solid-server`) is a separate party in these discussions.

## What & why

Closes **sq-uu0u** — the semi-honest Shamir path had NO tampered-share detection (malicious-security gap, guarantee (D)): a corrupted/tampered share would silently corrupt the reconstructed result rather than abort.

The **substantive detection mechanism already landed** on `main` across this bead's child work items, all merged:
- **WI-1 (sq-m34i, #38):** Reed–Solomon / Berlekamp–Welch consistency-checked + robust reconstruction over the existing `F_p = 2^61−1` (zero new deps — no DLOG group, no SPDZ preprocessing). `robust.rs::reconstruct_robust` DETECTS any tampering, CORRECTS up to `e = ⌊(n−t−1)/2⌋` cheaters, else ABORTS with the typed `MpcError::Tampered`. Wired into `ShamirBackend::reconstruct` / `reconstruct_disclosed`.
- **WI-2 (sq-7q9i, #43):** the degree-`2t` equality/mult open (`join::secure_equal`) routes through the same checker via `reconstruct_degree`.
- **WI-3 (sq-sz1h, #60):** the guarantee is surfaced in `BackendInfo` via the `MaliciousSecurity` enum (`SemiHonestOnly` / `HonestMajorityAbort` / `HonestMajorityRobust{max_cheaters}`).

This PR completes the **remaining WI-4 (doc-only, sq-6d6g)** and adds an **end-to-end adversarial test**, which is what was left to close the parent bead.

## How it maps to guarantee (D)

Shamir shares are an `[n, t+1]` Reed–Solomon codeword over `F_p`. With redundancy present (`n > t+1` at degree `t`; `n > 2t+1` at the degree-`2t` equality open), Berlekamp–Welch turns a tampered share into a **detect-and-abort** (or robust-correct) event instead of silent corruption — guarantee (D) in the honest-majority, redundancy-present regime. The honest boundaries where RS cannot help (exactly `t+1` shares; the degree-`2t` open at the honest-majority minimum `n = 2t+1`) are pinned by tests and documented as needing an information-theoretic MAC, not RS.

## Changes in this PR

- **`crates/sparq-mpc/PLAN.md`** — refresh the **stale** M3 "Security model" bullet (it still claimed "**NOT malicious-secure** (guarantee D)" — now false) to state the delivered RS detect-and-abort / robust guarantee + its honest boundaries; fix the stale "production needs a CSPRNG" note (the CSPRNG was wired, sq-1vt); add a **"Deferred malicious-security seams" subsection (WI-4)** documenting the two seams the design names — the SPDZ IT-MAC dishonest-majority backend (closes the no-redundancy points) and the Poseidon2/Schnorr share-commitments for the M4 attestation layer — both behind the same `MpcBackend` trait; add a guarantee-(D) line to the decision summary.
- **`crates/sparq-mpc/src/adversarial_tests.rs`** — add an **end-to-end** test (`tampered_share_at_reconstruct_disclosed_boundary_is_corrected_or_aborts`) that drives the whole public `MpcBackend` pipeline (`run_secure` → `reconstruct_disclosed`, the trait method a federation actually calls) and proves (D) is wired through that production surface: a tampered result share is RS-corrected within budget and **aborts** (`MpcError::Tampered`) beyond it — never a silently-wrong disclosed total — with the honest run still disclosing the true sum. This complements the existing `tamper` + `robust_props` suites (which exercise the internal `reconstruct` / `reconstruct_degree` helpers).

## Gate

- `cargo test -p sparq-mpc` — **green, 76 passed** (+1, the new e2e test).
- `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings` — **clean**.
- `cargo tree -p sparq-wasm` — still **EXCLUDES** `sparq-mpc` (native-only invariant holds).
- `cargo fmt`: the new test is fmt-clean; pre-existing rustfmt-1.9.0-vs-committed-format diffs in untouched files (`backend.rs`/`holder.rs`/etc.) were left alone (CI's pinned toolchain matches the committed format).

## Deferred (separate beads — NOT blocking (D))

- **sq-6u6b** — sharpen cheater *attribution* in the abort message. Detection is already **sound**; blame is best-effort (heuristic) when correction is impossible. Quality follow-up only.
- **sq-6d6g** — the IT-MAC dishonest-majority backend + Poseidon2 share-commitments are now **documented** here as design seams; their implementation is a future backend / the M4 attestation milestone.

[OPUS-4.8] authored under fallback model (Fable unavailable) — tagged for re-review on return.