### PR TITLE
feat(sparq-zk): scale + harden committed-index revocation privacy (sq-hwe + sq-6qe)

### DIFF
--- a/crates/sparq-zk-compose/src/revocation.rs
+++ b/crates/sparq-zk-compose/src/revocation.rs
@@ -24,14 +24,35 @@
 //! - Indices past the snapshot's `bits` length read as SET (revoked) via
 //!   [`StatusListSnapshot::bit`] — fail-closed, mirroring the verifier.
 //!
-//! # Scope (honest)
-//! This is a DENSE tree of `2^D` leaves: `merkle_root` hashes all `2^D` leaves,
-//! so it is `O(2^D)` host work and the depth-10 member covers 1024 indices. A
-//! production status list (StatusList2021 lists are commonly 2^17+) needs a
-//! SPARSE / compressed-inclusion commitment (most leaves are 0) — see the crate
-//! verifier docs (`bind_hidden_revocation`) for the deferred-work note. The
-//! circuit relation itself is depth-generic; only this dense host builder and the
-//! single compiled `d10` member bound the representative size.
+//! # Scaling (sq-hwe): sparse builder, dense-identical roots
+//! [OPUS-4.8] sq-hwe: [`merkle_root`] / [`merkle_witness`] are SPARSE — they do
+//! NOT materialise `2^depth` leaves. A StatusList2021 list is overwhelmingly
+//! uniform (a credential is live = bit unset; the revoked set `S` is tiny), so
+//! the tree is dominated by all-ZERO subtrees in the covered region and all-ONE
+//! subtrees in the fail-closed padding region past the bitstring. We cache the
+//! "all-zeros subtree root" and "all-ones subtree root" at every height
+//! ([`SubtreeDefaults`]) and recurse only into the `O(S)` subtrees that actually
+//! contain a set bit or straddle the covered/padding boundary. Cost is
+//! `O(S * depth + depth)` host work and `O(S * depth)` memory — INDEPENDENT of
+//! `2^depth` — so production depths (StatusList2021 lists are commonly 2^17+) are
+//! supported WITHOUT the old dense `O(2^depth)` full-size builder ([`dense_merkle_root`],
+//! retained only as the cross-check oracle).
+//!
+//! The root is BIT-IDENTICAL to the dense fold (same Poseidon2 `h2`, same leaf
+//! layout, same fail-closed padding — indices past `bits` read as SET/1 via
+//! [`StatusListSnapshot::bit`]), so the circuit relation (`revoke.nr`,
+//! `revoke_unset_check_committed`) and the verifier's root-equality binding are
+//! unchanged — only the host-side construction is cheaper. Cross-checked against
+//! the dense oracle in the unit tests.
+//!
+//! # Residual scope (honest)
+//! Only the `revoke_unset_d10` circuit member is currently COMPILED, so although
+//! the host builder now scales, an end-to-end hidden-revocation PROOF is still
+//! bounded by the compiled member's depth (compiling a larger member —
+//! `revoke_unset_d17` etc. — is mechanical: the relation is depth-generic; tracked
+//! as follow-up). And the status-list IRI + version are still disclosed in the
+//! clear on the committed-index path (sq-6qe). See the crate verifier docs
+//! (`bind_hidden_revocation`).
 
 use crate::manifest::StatusListSnapshot;
 use sparq_zk::field::{field_to_hex, Fr};
@@ -51,6 +72,116 @@ fn leaf(snapshot: &StatusListSnapshot, index: u64) -> Fr {
     Fr::from(u64::from(snapshot.bit(index)))
 }
 
+/// [OPUS-4.8] sq-hwe: precomputed roots of UNIFORM subtrees, one per height. The
+/// sparse builder folds only the subtrees that contain a non-default leaf; every
+/// other subtree's root is read from here in `O(1)`.
+///
+/// `zeros[h]` is the root of a height-`h` subtree whose `2^h` leaves are ALL the
+/// leaf value `0` (active); `ones[h]` is the root of a height-`h` subtree of ALL
+/// `1` (revoked / fail-closed padding). Height 0 is a single leaf, so
+/// `zeros[0] = Fr(0)` and `ones[0] = Fr(1)` (the circuit's `leaf = bit`); each
+/// higher level is `h2(child, child)` of the level below. Computed once in
+/// `O(depth)` — exactly the two "merkle-path-of-a-constant-subtree" defaults a
+/// sparse Merkle tree caches.
+struct SubtreeDefaults {
+    /// `zeros[h]` = root of an all-zero (all-active) height-`h` subtree.
+    zeros: Vec<Fr>,
+    /// `ones[h]` = root of an all-one (all-revoked / padding) height-`h` subtree.
+    ones: Vec<Fr>,
+}
+
+impl SubtreeDefaults {
+    /// Precompute the uniform-subtree roots for heights `0..=depth` in `O(depth)`.
+    fn new(depth: u32) -> Self {
+        let mut zeros = Vec::with_capacity(depth as usize + 1);
+        let mut ones = Vec::with_capacity(depth as usize + 1);
+        zeros.push(Fr::from(0u64)); // a single 0 leaf
+        ones.push(Fr::from(1u64)); // a single 1 leaf
+        for h in 1..=depth as usize {
+            zeros.push(h2(zeros[h - 1], zeros[h - 1]));
+            ones.push(h2(ones[h - 1], ones[h - 1]));
+        }
+        SubtreeDefaults { zeros, ones }
+    }
+}
+
+/// [OPUS-4.8] sq-hwe: sparse root of the height-`h` subtree covering leaf indices
+/// `[lo, lo + 2^h)`, given the snapshot and the precomputed uniform-subtree roots.
+///
+/// `set_after` is the first leaf index past the snapshot's covered bits
+/// (`8 * bits.len()`): every leaf at `idx >= set_after` reads as `1` (the
+/// fail-closed padding), and every leaf below it reads the snapshot bit. The three
+/// fast paths that avoid recursion (the whole point of the sparse builder):
+///   1. the subtree lies ENTIRELY in the padding (`lo >= set_after`) → all `1` →
+///      `defaults.ones[h]`;
+///   2. the subtree lies entirely in the covered region AND holds NO set bit →
+///      all `0` → `defaults.zeros[h]`;
+///   3. otherwise recurse into the two half-subtrees and combine with `h2`.
+///
+/// A height-0 subtree is a single leaf and just reads its bit. Recursion depth is
+/// `depth`, and a branch only splits when it contains a set bit or straddles the
+/// covered/padding boundary, so the work is `O(S * depth + depth)`.
+fn sparse_subtree_root(
+    snapshot: &StatusListSnapshot,
+    defaults: &SubtreeDefaults,
+    set_after: u64,
+    lo: u64,
+    h: u32,
+) -> Fr {
+    // Fast path 1: the whole subtree is in the fail-closed padding (all ones).
+    if lo >= set_after {
+        return defaults.ones[h as usize];
+    }
+    let span = 1u64 << h;
+    // Fast path 2: the whole subtree is in the covered region and contains no set
+    // bit. `hi` is exclusive; `lo < set_after` already, so if `hi <= set_after`
+    // the subtree is fully covered. `any_bit_set` short-circuits on the first set
+    // bit, so a genuinely all-zero subtree costs only the byte-range scan.
+    let hi = lo + span;
+    if hi <= set_after && !any_bit_set(snapshot, lo, hi) {
+        return defaults.zeros[h as usize];
+    }
+    if h == 0 {
+        // Single leaf: read the (boundary-straddling or set) bit directly.
+        return leaf(snapshot, lo);
+    }
+    // Recurse into the two halves; one of them is frequently a cached uniform
+    // subtree (fast path 1 or 2 above), so the recursion fans out only along the
+    // O(S) branches that hold a set bit or the covered/padding boundary.
+    let left = sparse_subtree_root(snapshot, defaults, set_after, lo, h - 1);
+    let right = sparse_subtree_root(snapshot, defaults, set_after, lo + (span >> 1), h - 1);
+    h2(left, right)
+}
+
+/// [OPUS-4.8] sq-hwe: whether ANY status bit in `[lo, hi)` is set, scanning the
+/// snapshot's bytes (not `bit()`-per-index) and short-circuiting on the first set
+/// bit. Caller guarantees `hi <= 8 * bits.len()` (the covered region), so every
+/// byte touched exists. Used by the sparse builder's all-zero fast path.
+fn any_bit_set(snapshot: &StatusListSnapshot, lo: u64, hi: u64) -> bool {
+    debug_assert!(lo <= hi);
+    let mut idx = lo;
+    while idx < hi {
+        let byte = (idx / 8) as usize;
+        let off = (idx % 8) as u32;
+        // How many bits remain in this byte from `off`, capped by `hi`.
+        let bits_left_in_byte = 8 - off;
+        let bits_to_hi = (hi - idx) as u32;
+        let take = bits_left_in_byte.min(bits_to_hi);
+        // Mask the `take` bits starting at `off` and test them in one shot.
+        let mask: u8 = (((1u16 << take) - 1) as u8) << off;
+        // The covered-region guarantee means the byte exists; treat a missing byte
+        // as all-zero defensively (it cannot make a false negative — a missing byte
+        // would read as `1` via `bit()`, but the caller only invokes this for the
+        // covered region where bytes are present).
+        let b = snapshot.bits.get(byte).copied().unwrap_or(0);
+        if b & mask != 0 {
+            return true;
+        }
+        idx += u64::from(take);
+    }
+    false
+}
+
 /// Commit `snapshot` as a depth-`depth` Poseidon2 Merkle tree and return the
 /// root. Leaves are the `2^depth` status bits (indices `0..2^depth`, padded with
 /// SET/revoked bits past the snapshot length — fail-closed). Internal nodes are
@@ -58,10 +189,34 @@ fn leaf(snapshot: &StatusListSnapshot, index: u64) -> Fr {
 /// (the trust anchor the proof's public root is checked against) and what the
 /// PROVER computes over the list it holds.
 ///
+/// [OPUS-4.8] sq-hwe: computed by the SPARSE builder ([`sparse_subtree_root`]) —
+/// `O(S * depth + depth)` host work / `O(S * depth)` memory for `S` set bits,
+/// INDEPENDENT of `2^depth`, so production depths (2^17+) are supported without a
+/// dense full-size builder. The result is BIT-IDENTICAL to the dense fold (same
+/// `h2`, same leaf layout, same fail-closed padding); cross-checked against
+/// [`dense_merkle_root`] in the unit tests.
+///
 /// Returns `None` if `depth` is implausibly large (`> 31`, i.e. more than ~2^31
 /// leaves) — a guard so a hostile/buggy `depth` cannot trigger an astronomical
-/// allocation. (The compiled member is `d10`; real callers pass small depths.)
+/// recursion. (The compiled member is `d10`; real callers pass small depths.)
 pub fn merkle_root(snapshot: &StatusListSnapshot, depth: u32) -> Option<Fr> {
+    if depth > 31 {
+        return None;
+    }
+    let defaults = SubtreeDefaults::new(depth);
+    // The first leaf index that reads as SET (padding past the covered bits).
+    let set_after = (snapshot.bits.len() as u64).saturating_mul(8);
+    Some(sparse_subtree_root(snapshot, &defaults, set_after, 0, depth))
+}
+
+/// [OPUS-4.8] sq-hwe: the ORIGINAL dense `O(2^depth)` Merkle-root builder, retained
+/// ONLY as the cross-check ORACLE for [`merkle_root`]'s sparse output in tests. It
+/// materialises all `2^depth` leaves and folds them pairwise, so it is unusable at
+/// production depths — never call it on the hot path. `merkle_root` MUST return a
+/// byte-identical root for the same `(snapshot, depth)`; the unit tests assert this
+/// across uniform, sparse, and boundary-straddling snapshots.
+#[cfg(test)]
+fn dense_merkle_root(snapshot: &StatusListSnapshot, depth: u32) -> Option<Fr> {
     if depth > 31 {
         return None;
     }
@@ -96,6 +251,15 @@ pub struct MerkleWitness {
 /// Build the [`MerkleWitness`] for `index` in `snapshot`'s depth-`depth` tree.
 /// `None` if `index >= 2^depth` (out of range for the tree — the circuit also
 /// range-bounds the index) or `depth > 31`.
+///
+/// [OPUS-4.8] sq-hwe: SPARSE. The sibling at level `k` is the root of the
+/// height-`k` subtree hanging off the OTHER side of the path node at that level;
+/// each is computed by [`sparse_subtree_root`] (which short-circuits uniform
+/// subtrees against the precomputed defaults), so the whole authentication path is
+/// `O(depth^2)` worst case but `O(depth)` for the common case where the siblings
+/// are uniform subtrees — and, crucially, NEVER materialises `2^depth` leaves. The
+/// path is byte-identical to the one the old dense builder produced (cross-checked
+/// in the unit tests by re-folding to the dense root).
 pub fn merkle_witness(snapshot: &StatusListSnapshot, depth: u32, index: u64) -> Option<MerkleWitness> {
     if depth > 31 {
         return None;
@@ -105,16 +269,19 @@ pub fn merkle_witness(snapshot: &StatusListSnapshot, depth: u32, index: u64) -> 
         return None;
     }
     let bit = leaf(snapshot, index);
-    // Recompute each level, recording the sibling on the path to `index`.
-    let mut level: Vec<Fr> = (0..n_leaves).map(|i| leaf(snapshot, i)).collect();
-    let mut pos = index as usize;
+    let defaults = SubtreeDefaults::new(depth);
+    let set_after = (snapshot.bits.len() as u64).saturating_mul(8);
+    // At level `k` the path node spans 2^k leaves; its sibling is the height-`k`
+    // subtree sharing the same parent. `pos` tracks the path node's index AMONG the
+    // 2^(depth-k) nodes at level k (i.e. index >> k); the sibling's node index is
+    // `pos ^ 1`, whose leaf range begins at `(pos ^ 1) << k`.
     let mut siblings = Vec::with_capacity(depth as usize);
-    for _ in 0..depth {
-        // Sibling is the partner in this node's pair: flip the low bit of pos.
-        let sib = pos ^ 1;
-        siblings.push(level[sib]);
-        level = level.chunks(2).map(|pair| h2(pair[0], pair[1])).collect();
-        pos /= 2;
+    let mut pos = index;
+    for k in 0..depth {
+        let sib_node = pos ^ 1;
+        let sib_lo = sib_node << k;
+        siblings.push(sparse_subtree_root(snapshot, &defaults, set_after, sib_lo, k));
+        pos >>= 1;
     }
     Some(MerkleWitness { bit, siblings })
 }
@@ -180,6 +347,108 @@ mod tests {
         let s = snap(vec![0b0000_0010]); // bit 1 set, rest unset
         let expected = h2(h2(Fr::from(0u64), Fr::from(1u64)), h2(Fr::from(0u64), Fr::from(0u64)));
         assert_eq!(merkle_root(&s, 2), Some(expected));
+    }
+
+    // [OPUS-4.8] sq-hwe: the SPARSE builder must return a BYTE-IDENTICAL root to
+    // the dense oracle across every snapshot shape — uniform-zero, sparse 1s, a
+    // snapshot SHORTER than the tree (so the tail leaves read as fail-closed 1s),
+    // and a boundary that straddles the covered/padding line mid-byte. This is the
+    // load-bearing correctness invariant: the circuit + verifier binding are
+    // unchanged precisely BECAUSE the root is identical to the old dense fold.
+    #[test]
+    fn sparse_root_equals_dense_root_for_every_shape() {
+        let cases = vec![
+            // (bits, depths to test)
+            (vec![0u8], vec![0u32, 1, 2, 3, 6]),                 // tiny + tail padding
+            (vec![0b0000_0010u8], vec![2, 3, 6]),                // one set bit
+            (vec![0xFFu8], vec![3, 6]),                          // a fully-revoked byte + padding
+            (vec![0u8, 0, 0, 0, 0, 0, 0, 0], vec![6]),          // 64 covered, all zero
+            (vec![0b1000_0001u8, 0, 0b0100_0000, 0], vec![5, 6]),// scattered set bits
+            (vec![], vec![0, 2, 4]),                             // EMPTY: every leaf is fail-closed 1
+            (vec![0u8; 3], vec![6]),                             // 24 covered (boundary mid-tree)
+        ];
+        for (bits, depths) in cases {
+            let s = snap(bits.clone());
+            for d in depths {
+                assert_eq!(
+                    merkle_root(&s, d),
+                    dense_merkle_root(&s, d),
+                    "sparse != dense for bits={bits:?} depth={d}"
+                );
+            }
+        }
+    }
+
+    // [OPUS-4.8] sq-hwe: the sparse builder handles a PRODUCTION-scale depth
+    // (2^17 leaves) without materialising them — the whole point of the bead. The
+    // dense oracle would allocate 131072 field elements; the sparse builder folds
+    // only the cached uniform-subtree defaults plus the single set bit. We assert
+    // the witness for an unset index re-folds to this same large-depth root.
+    #[test]
+    fn sparse_root_and_witness_scale_to_production_depth() {
+        // One revoked credential at index 5; the list nominally covers 2^17 slots
+        // but the snapshot byte vector is tiny (the rest read as fail-closed 1s
+        // past the covered region — exactly the StatusList2021 shape).
+        let s = snap(vec![0b0010_0000u8]); // index 5 set; 0..4,6,7 active
+        let depth = 17;
+        let root = merkle_root(&s, depth).expect("sparse root at depth 17");
+        // An ACTIVE index inside the covered region re-folds to the root via the
+        // sparse witness.
+        let w = merkle_witness(&s, depth, 0).expect("witness");
+        assert_eq!(w.bit, Fr::from(0u64), "index 0 is active");
+        assert_eq!(w.siblings.len(), depth as usize);
+        let mut node = w.bit;
+        let mut pos = 0u64;
+        for sib in &w.siblings {
+            let is_right = pos & 1 == 1;
+            node = if is_right { h2(*sib, node) } else { h2(node, *sib) };
+            pos >>= 1;
+        }
+        assert_eq!(node, root, "sparse witness must re-fold to the sparse root");
+        // The revoked index 5 carries bit 1 (the circuit's bit-unset assert fails).
+        assert_eq!(merkle_witness(&s, depth, 5).unwrap().bit, Fr::from(1u64));
+    }
+
+    // [OPUS-4.8] sq-hwe: at a production depth, the sparse witness for an index in
+    // the FAIL-CLOSED PADDING region (past the covered bits) still re-folds to the
+    // root and carries bit 1 — the padding leaves are genuinely SET, so a holder
+    // cannot prove bit-unset for an uncovered slot. Cross-checks the all-ones
+    // subtree default path.
+    #[test]
+    fn sparse_witness_in_padding_region_is_revoked_and_consistent() {
+        let s = snap(vec![0u8]); // 8 covered active bits; everything >= 8 is padding
+        let depth = 12;
+        let root = merkle_root(&s, depth).unwrap();
+        let padding_index = 100u64; // >= 8, in the fail-closed region, < 2^12
+        let w = merkle_witness(&s, depth, padding_index).unwrap();
+        assert_eq!(w.bit, Fr::from(1u64), "padding leaf reads as revoked");
+        let mut node = w.bit;
+        let mut pos = padding_index;
+        for sib in &w.siblings {
+            let is_right = pos & 1 == 1;
+            node = if is_right { h2(*sib, node) } else { h2(node, *sib) };
+            pos >>= 1;
+        }
+        assert_eq!(node, root, "padding-index witness must still re-fold to the root");
+    }
+
+    // [OPUS-4.8] sq-hwe: any_bit_set scans byte ranges and short-circuits; verify
+    // it agrees with the per-index `bit()` oracle on awkward sub-byte ranges within
+    // the covered region.
+    #[test]
+    fn any_bit_set_matches_per_index_oracle() {
+        let s = snap(vec![0b1010_0101u8, 0b0000_0000, 0b1000_0000]);
+        let covered = 24u64;
+        for lo in 0..covered {
+            for hi in lo..=covered {
+                let expected = (lo..hi).any(|i| s.bit(i));
+                assert_eq!(
+                    any_bit_set(&s, lo, hi),
+                    expected,
+                    "any_bit_set disagreed on [{lo}, {hi})"
+                );
+            }
+        }
     }
 
     // A witness for an unset index recomputes the root via the same fold the

--- a/crates/sparq-zk-compose/src/revocation.rs
+++ b/crates/sparq-zk-compose/src/revocation.rs
@@ -169,11 +169,14 @@ fn any_bit_set(snapshot: &StatusListSnapshot, lo: u64, hi: u64) -> bool {
         let take = bits_left_in_byte.min(bits_to_hi);
         // Mask the `take` bits starting at `off` and test them in one shot.
         let mask: u8 = (((1u16 << take) - 1) as u8) << off;
-        // The covered-region guarantee means the byte exists; treat a missing byte
-        // as all-zero defensively (it cannot make a false negative — a missing byte
-        // would read as `1` via `bit()`, but the caller only invokes this for the
-        // covered region where bytes are present).
-        let b = snapshot.bits.get(byte).copied().unwrap_or(0);
+        // The covered-region guarantee means the byte exists, so this fallback is
+        // unreachable on the real call site. It is FAIL-CLOSED nonetheless: a
+        // missing byte reads as all-ones (`0xFF`), matching `StatusListSnapshot::bit`
+        // / `leaf`, which define out-of-range bits as `1` (revoked). So if this
+        // helper is ever called on a range that touches a missing byte, it reports
+        // the region as set (returns `true`) rather than letting `sparse_subtree_root`
+        // misclassify an unknown/padding region as an all-zero subtree.
+        let b = snapshot.bits.get(byte).copied().unwrap_or(0xFF);
         if b & mask != 0 {
             return true;
         }
@@ -448,6 +451,26 @@ mod tests {
                     "any_bit_set disagreed on [{lo}, {hi})"
                 );
             }
+        }
+    }
+
+    // [OPUS-4.8] sq-6qe: the real caller never invokes any_bit_set past the covered
+    // region, but the missing-byte fallback must be FAIL-CLOSED: a range touching a
+    // byte beyond `bits` reads as revoked (`1`), matching `bit()`, so the helper
+    // reports the region as set (`true`) and never lets the sparse builder
+    // misclassify an unknown/padding region as an all-zero subtree.
+    #[test]
+    fn any_bit_set_is_fail_closed_on_missing_bytes() {
+        let s = snap(vec![0b0000_0000u8]); // one covered byte, all active
+        // Range entirely in the missing/padding region (bytes 1..) must read as set.
+        assert!(any_bit_set(&s, 8, 24), "padding region must be fail-closed (set)");
+        // Range straddling covered (active) + missing also reports set via the tail.
+        assert!(any_bit_set(&s, 0, 16), "straddling range must be fail-closed (set)");
+        // Sanity: a fully-covered all-active range is correctly NOT set.
+        assert!(!any_bit_set(&s, 0, 8), "covered all-active range is not set");
+        // And the missing-byte reads agree with the per-index `bit()` oracle.
+        for i in 8u64..24 {
+            assert!(s.bit(i), "out-of-range bit {i} must be revoked");
         }
     }
 

--- a/crates/sparq-zk-compose/src/verifier.rs
+++ b/crates/sparq-zk-compose/src/verifier.rs
@@ -2149,9 +2149,13 @@ fn resolve_status_ref(
 ///
 /// HONEST REMAINING DISCLOSURE: the status-list IRI and the `version` are still
 /// disclosed in the clear (both issuer-bound); only the index + liveness bit are
-/// hidden on the committed path. The dense depth-10 host Merkle builder still
-/// bounds the representative list size (the sparse-commitment scope note is
-/// unchanged — see [`crate::revocation`]).
+/// hidden on the committed path. Closing the IRI/version leak is sq-6qe (a new
+/// committed-reference circuit + sig path; see `research/zk-statuslist-hide-iri-version.md`).
+/// [OPUS-4.8] sq-hwe: the host Merkle builder is now SPARSE
+/// ([`crate::revocation::merkle_root`]) — `O(set-bits * depth)`, independent of
+/// `2^depth` — so it no longer bounds the list size; the remaining size bound is
+/// the single COMPILED `revoke_unset_d10` circuit member (compiling a deeper member
+/// is mechanical, the relation is depth-generic — tracked as follow-up).
 // [OPUS-4.8] audit #12: verifier-side revocation / freshness check.
 // [OPUS-4.8] audit #12 re-audit (Option B): the bit decision reads the
 // AUTHORITATIVE (relying-party-resolved) snapshot, never the prover's bytes.
@@ -2294,14 +2298,15 @@ fn bind_revocation(
 /// to resolve the authoritative snapshot here is the issuer's, not a prover claim.
 ///
 /// # Scope (honest, see [`crate::revocation`])
-/// The authoritative root is derived with the DENSE [`merkle_root`] builder (it
-/// hashes all `2^depth` leaves), and only the `revoke_unset_d10` member (depth 10,
-/// up to 1024 indices) is compiled. A production status list (2^17+ slots) needs a
-/// sparse / compressed-inclusion commitment — the circuit relation is
-/// depth-generic, but the dense host builder + single member bound the
-/// representative size. This is a representative implementation; the soundness of
-/// the binding (root equality + bb verify + in-circuit bit-unset) holds at any
-/// supported depth.
+/// [OPUS-4.8] sq-hwe: the authoritative root is now derived with the SPARSE
+/// [`merkle_root`] builder (`O(set-bits * depth)`, independent of `2^depth`, with
+/// roots BIT-IDENTICAL to the old dense fold), so the host side scales to
+/// production list sizes (2^17+ slots) WITHOUT materialising `2^depth` leaves. The
+/// remaining size bound is that only the `revoke_unset_d10` member (depth 10, up to
+/// 1024 indices) is COMPILED — the circuit relation is depth-generic, so compiling
+/// a deeper member is mechanical (tracked as follow-up). The soundness of the
+/// binding (root equality + bb verify + in-circuit bit-unset) holds at any supported
+/// depth. The status-list IRI + version are still disclosed in the clear (sq-6qe).
 // [OPUS-4.8] sq-3e5 + sq-h2v: hidden-index revocation cryptographic gate.
 fn bind_hidden_revocation(
     manifest: &ProofManifest,

--- a/crates/sparq-zk/src/sig.rs
+++ b/crates/sparq-zk/src/sig.rs
@@ -366,6 +366,101 @@ pub fn status_ref_commit_digest(list_id: &Fr, index_commitment: &Fr, version: u6
     ])
 }
 
+/// [OPUS-4.8] sq-6qe: a hiding COMMITMENT to a credential's status-list
+/// `(list_id, version)` reference — the IRI/version-hiding analogue of the clear
+/// `list_id` + `version` that [`status_ref_commit_digest`] still folds in the
+/// clear. The fully-hidden committed-index revocation path (sq-6qe) signs over
+/// THIS commitment instead of the clear list/version, so a hidden-revocation
+/// presentation discloses neither the list IRI nor the publication epoch.
+///
+/// `ref_blinding` is a per-credential random field element (the holder's secret)
+/// that makes the commitment hiding: two credentials on the same list+version
+/// commit to different values, closing the linkability channel the clear IRI +
+/// version open. Domain-separated and binding under the Poseidon2
+/// collision/hiding assumption.
+///
+/// # Future in-circuit use (sq-6qe, see `research/zk-statuslist-hide-iri-version.md`)
+/// The deferred fully-hidden circuit recomputes this commitment IN-CIRCUIT from
+/// the SAME private `(list_id, version)` it (a) proves member of the relying
+/// party's accepted `(list, version, status_list_root)` set and (b) freshness-checks
+/// (`version >= public min_version`), exposing it so the verifier byte-matches it
+/// against the ISSUER-SIGNED value — exactly the cross-binding discipline
+/// [`status_index_commitment`] uses for the index. So `list_id` and `version` are
+/// disclosed in NEITHER the signed object NOR any clear field, yet the proof is
+/// bound to a list/version the issuer attested and the relying party accepts.
+///
+/// Maps to a Noir `Poseidon2::hash([DOMAIN, list_id, version, ref_blinding], 4)`.
+// [OPUS-4.8] sq-6qe: hiding (list, version) reference commitment.
+pub fn status_ref_commitment(list_id: &Fr, version: u64, ref_blinding: &Fr) -> Fr {
+    const SIG_DOMAIN_STATUS_REF_COMMITMENT: u64 = 0x5a4b_5349_475f_5243; // "ZKSIG_RC"
+    poseidon2::hash(&[
+        Fr::from(SIG_DOMAIN_STATUS_REF_COMMITMENT),
+        *list_id,
+        Fr::from(version),
+        *ref_blinding,
+    ])
+}
+
+/// [OPUS-4.8] sq-6qe: a domain-separated digest of a credential's status-list
+/// reference that binds a COMMITMENT to BOTH the `(list, version)` reference AND
+/// the index — the fully-hidden analogue of [`status_ref_commit_digest`] (which
+/// still folds the clear `list_id` + `version`). The issuer folds
+/// `(ref_commitment, index_commitment)`, so NEITHER the list IRI, the version, NOR
+/// the index ever enters the signed object. A DISTINCT domain tag from both
+/// [`status_ref_digest`] (clear index) and [`status_ref_commit_digest`]
+/// (committed index, clear list/version), so no cross-substitution between the
+/// three disclosure modes is possible.
+///
+/// `ref_commitment` is [`status_ref_commitment`]`(list_id, version, ref_blinding)`
+/// and `index_commitment` is [`status_index_commitment`]`(index, blinding)`. The
+/// verifier (in the deferred sq-6qe path) recomputes this digest from the disclosed
+/// commitments to check the issuer signature; the fully-hidden revocation proof
+/// then cross-binds BOTH commitments in-circuit (the proven-unset index to
+/// `index_commitment`, and the membership-resolved `(list, version)` to
+/// `ref_commitment`), so the disclosure floor is "some accepted (list, version) in
+/// the RP's committed set, version >= public min_version, my hidden index unset".
+///
+/// Maps to a Noir `Poseidon2::hash([DOMAIN, ref_commitment, index_commitment], 3)`.
+// [OPUS-4.8] sq-6qe: fully-committed (list+version+index hidden) status-reference digest.
+pub fn status_ref_fully_committed_digest(ref_commitment: &Fr, index_commitment: &Fr) -> Fr {
+    const SIG_DOMAIN_STATUS_REF_FULL_COMMIT: u64 = 0x5a4b_5349_475f_4643; // "ZKSIG_FC"
+    poseidon2::hash(&[
+        Fr::from(SIG_DOMAIN_STATUS_REF_FULL_COMMIT),
+        *ref_commitment,
+        *index_commitment,
+    ])
+}
+
+/// [OPUS-4.8] sq-6qe: the relying party's ACCEPTED-SET Merkle LEAF for a
+/// `(list_id, version, status_list_root)` triple (sub-option A of the sq-6qe
+/// design — see `research/zk-statuslist-hide-iri-version.md`). The fully-hidden
+/// revocation circuit proves membership of the credential's hidden `(list_id,
+/// version)` in the relying party's accepted set committed as a Poseidon2 Merkle
+/// root over these leaves — which ALSO privately binds the corresponding
+/// `status_list_root` the bit-unset fold then runs against, so the verifier
+/// publishes only the accepted-SET root and never learns which list/version/root.
+///
+/// Binding all three in ONE leaf is load-bearing: a prover cannot pair list₁'s
+/// identity with list₂'s root, because the leaf hash commits the triple atomically
+/// and the membership fold must recompute the public accepted-set root (the same
+/// atomic-binding discipline [`crate::sig::status_index_commitment`] +
+/// `revoke_unset_check_committed` use). The relying party builds this set from its
+/// OWN authoritative, freshness-curated snapshots (the audit-#12 trust anchor,
+/// moved behind a commitment — no new trust assumption).
+///
+/// Maps to the in-circuit leaf `Poseidon2::hash([DOMAIN, list_id, version,
+/// status_list_root], 4)` (the accepted-set analogue of `issuer.nr`'s `key_leaf`).
+// [OPUS-4.8] sq-6qe: accepted (list, version, root)-set Merkle leaf.
+pub fn accepted_status_leaf(list_id: &Fr, version: u64, status_list_root: &Fr) -> Fr {
+    const SIG_DOMAIN_ACCEPTED_STATUS_LEAF: u64 = 0x5a4b_5349_475f_414c; // "ZKSIG_AL"
+    poseidon2::hash(&[
+        Fr::from(SIG_DOMAIN_ACCEPTED_STATUS_LEAF),
+        *list_id,
+        Fr::from(version),
+        *status_list_root,
+    ])
+}
+
 /// Hash a status-list IRI string to a field element (domain-separated), so the
 /// in-the-clear `manifest.revocation.status_list` IRI can be bound under the
 /// issuer signature. Issuer and verifier both call this, so a drift cannot make
@@ -954,6 +1049,95 @@ mod tests {
         let clear = status_ref_digest(&list_id, 94, 7);
         let committed = status_ref_commit_digest(&list_id, &idx_commit, 7);
         assert_ne!(clear, committed, "clear-index and committed-index digests are domain-separated");
+    }
+
+    /// [OPUS-4.8] sq-6qe: the `(list, version)` reference commitment is HIDING
+    /// (a different blinding => a different commitment for the same list+version,
+    /// so two presentations are unlinkable on the reference) and BINDING (a
+    /// different list OR a different version => a different commitment).
+    #[test]
+    fn status_ref_commitment_is_hiding_and_binding() {
+        let list_a = status_list_id_to_field("https://dmv.example/status/3");
+        let list_b = status_list_id_to_field("https://dmv.example/status/4");
+        let rc = status_ref_commitment(&list_a, 7, &Fr::from(0xb11du64));
+
+        // Hiding: same (list, version) under different blinding commits differently.
+        let rc_other_blinding = status_ref_commitment(&list_a, 7, &Fr::from(0x1234u64));
+        assert_ne!(rc, rc_other_blinding, "different blinding => different commitment");
+
+        // Binding: a different version OR a different list changes the commitment.
+        let rc_other_version = status_ref_commitment(&list_a, 8, &Fr::from(0xb11du64));
+        assert_ne!(rc, rc_other_version, "different version => different commitment");
+        let rc_other_list = status_ref_commitment(&list_b, 7, &Fr::from(0xb11du64));
+        assert_ne!(rc, rc_other_list, "different list => different commitment");
+    }
+
+    /// [OPUS-4.8] sq-6qe: a FULLY-HIDDEN status-bound signature binds BOTH the
+    /// reference commitment and the index commitment (neither list, version, nor
+    /// index in the clear), and its digest domain is distinct from BOTH the
+    /// clear-index (audit #12) and committed-index-clear-list (sq-ayv) digests, so
+    /// no disclosure-mode substitution is possible.
+    #[test]
+    fn fully_committed_status_signature_binds_both_commitments() {
+        let sk = SecretKey::from_seed(41);
+        let pk = sk.public_key();
+        let c = Fr::from(0xc0ffeeu64);
+        let salt = Fr::from(0x5a17u64);
+        let list_id = status_list_id_to_field("https://dmv.example/status/3");
+        let ref_commit = status_ref_commitment(&list_id, 7, &Fr::from(0x5efb10u64));
+        let idx_commit = status_index_commitment(94, &Fr::from(0xbeefu64));
+        let sref = status_ref_fully_committed_digest(&ref_commit, &idx_commit);
+        let hex = sk.sign_commitment_with_status(&c, &salt, &sref);
+        let sig = signature_from_hex(&hex).expect("round-trips");
+        let msg = commitment_message_with_status(&c, &salt, &sref);
+        assert!(verify(&pk, &msg, &sig), "honest fully-hidden signature verifies");
+
+        // A different reference commitment (e.g. a different list/version/blinding)
+        // => different digest => signature fails.
+        let ref_commit2 = status_ref_commitment(&list_id, 8, &Fr::from(0x5efb10u64));
+        let sref2 = status_ref_fully_committed_digest(&ref_commit2, &idx_commit);
+        let msg2 = commitment_message_with_status(&c, &salt, &sref2);
+        assert!(!verify(&pk, &msg2, &sig), "a different reference commitment must not verify");
+
+        // A different index commitment => different digest => signature fails.
+        let idx_commit2 = status_index_commitment(95, &Fr::from(0xbeefu64));
+        let sref3 = status_ref_fully_committed_digest(&ref_commit, &idx_commit2);
+        let msg3 = commitment_message_with_status(&c, &salt, &sref3);
+        assert!(!verify(&pk, &msg3, &sig), "a different index commitment must not verify");
+
+        // Domain separation from the two other disclosure modes: even with
+        // numerically-equal inputs the three digests differ (distinct domain tags).
+        let clear = status_ref_digest(&list_id, 94, 7);
+        let committed_clear_list = status_ref_commit_digest(&list_id, &idx_commit, 7);
+        assert_ne!(sref, clear, "fully-hidden vs clear-index digests are domain-separated");
+        assert_ne!(
+            sref, committed_clear_list,
+            "fully-hidden vs committed-index-clear-list digests are domain-separated"
+        );
+    }
+
+    /// [OPUS-4.8] sq-6qe: the accepted `(list, version, status_list_root)`-set leaf
+    /// binds all three atomically — any one differing changes the leaf, so a prover
+    /// cannot pair one list's identity with another list's root (the sub-option-A
+    /// soundness property). Also distinct from the reference commitment's domain.
+    #[test]
+    fn accepted_status_leaf_binds_triple_atomically() {
+        let list_id = status_list_id_to_field("https://dmv.example/status/3");
+        let root = Fr::from(0x12345678u64);
+        let leaf = accepted_status_leaf(&list_id, 7, &root);
+
+        let other_list = status_list_id_to_field("https://dmv.example/status/4");
+        assert_ne!(leaf, accepted_status_leaf(&other_list, 7, &root), "list binds");
+        assert_ne!(leaf, accepted_status_leaf(&list_id, 8, &root), "version binds");
+        assert_ne!(
+            leaf,
+            accepted_status_leaf(&list_id, 7, &Fr::from(0x87654321u64)),
+            "root binds"
+        );
+
+        // Distinct domain from the reference commitment (no leaf/commitment confusion).
+        let rc = status_ref_commitment(&list_id, 7, &root); // same inputs, different role
+        assert_ne!(leaf, rc, "accepted-set leaf and ref commitment are domain-separated");
     }
 
     /// [OPUS-4.8] audit #12: the list-id hash is collision-resistant on distinct

--- a/research/zk-statuslist-hide-iri-version.md
+++ b/research/zk-statuslist-hide-iri-version.md
@@ -1,0 +1,200 @@
+# Hiding the status-list IRI + version on the committed-index revocation path (sq-6qe)
+
+Status: **design for review — the cryptographic PRIMITIVES are implemented in
+`sparq-zk::sig` (see §6); the circuit + verifier + manifest path is DEFERRED to a
+follow-up bead.** Author: SPARQ agent (Claude Opus 4.8 — Fable unavailable, tag
+for re-review). Inputs: the existing committed-index revocation estate
+(`zk/compose/compose_core/src/revoke.nr`, `…/issuer.nr`,
+`crates/sparq-zk-compose/src/{revocation.rs,verifier.rs,manifest.rs}`,
+`crates/sparq-zk/src/sig.rs`), the internal skills `noir-optimisation` /
+`noir-circuit-patterns`, and a grounded cost/feasibility review (June 2026).
+Companion: `research/zk-soundness-audit.md`, `research/zkp-query-proofs-plan.md`.
+
+[OPUS-4.8] This record describes work that is PROVISIONAL — graduate it into an
+architecture note (or fold into the crate README / SKILL) once the circuit lands,
+per the AGENTS.md "research records become architecture docs" rule. It must not be
+read as describing shipped code: only §6's `sparq-zk::sig` primitives exist today.
+
+## 1. The gap
+
+sq-ayv closed the index + liveness-bit leak on the committed-index revocation
+path: the issuer signs `status_ref_commit_digest(H(list), index_commitment,
+version)` — a HIDING commitment to the index, not the clear index — and the
+hidden-index proof (`revoke_unset_check_committed`) cross-binds the proven-unset
+index to that commitment. A hidden-revocation presentation therefore discloses
+neither the index nor the liveness bit.
+
+But the **status-list IRI** (`H(list)`) and the **version** are still folded into
+the signed digest IN THE CLEAR, and `RevocationStatus.{status_list, version}` are
+disclosed in the manifest. This leaves a coarser linkability / correlation
+channel: a relying party learns WHICH status list and WHICH publication epoch a
+presentation pertains to. Two presentations of credentials from the same issuer's
+list (or two presentations citing the same epoch) are correlatable on that axis.
+sq-6qe closes it: bind/commit the list IRI + version too, and prove freshness
+in-zk against a committed version, so a hidden-revocation presentation discloses
+**neither index, bit, IRI, nor version**.
+
+This is the verifier-side note flagged in `verifier::bind_revocation`'s "HONEST
+REMAINING DISCLOSURE" doc.
+
+## 2. The design tension
+
+The verifier, to run the bit-unset Merkle inclusion check, needs the
+**status-list root** for the credential's `(list, version)`. Today it resolves
+that root by looking the snapshot up by the CLEAR `(list, version)` in
+`RevocationPolicy.authoritative` and folding it (`merkle_root`). If `(list,
+version)` is hidden, the verifier can no longer name the snapshot — so the root
+must be resolved WITHOUT the verifier learning which list/version.
+
+## 3. Chosen design — sub-option A: bind the root inside an accepted-set leaf
+
+The issuer signs over a HIDING reference commitment instead of clear
+`(list, version)`:
+
+```
+ref_commitment = Poseidon2([DOMAIN_RC, list_id, version, ref_blinding], 4)
+signed digest  = Poseidon2([DOMAIN_FC, ref_commitment, index_commitment], 3)
+```
+
+(`DOMAIN_RC` / `DOMAIN_FC` are distinct tags from the clear-index and
+committed-index-clear-list digests, so no disclosure-mode substitution is
+possible.) The holder withholds `list_id`, `version`, `ref_blinding`; the manifest
+carries only `ref_commitment` (and `index_commitment`, as today).
+
+The relying party publishes a single **accepted-set Merkle root** over leaves
+
+```
+accepted_leaf = Poseidon2([DOMAIN_AL, list_id, version, status_list_root], 4)
+```
+
+for every `(list, version)` it currently trusts (built from its own authoritative,
+freshness-curated snapshots — the audit-#12 trust anchor, moved behind a
+commitment; no new trust assumption). A NEW circuit member
+(`revoke_hidden_ref_d{D}_a{A}`, depth `D` for the status-list tree, depth `A` for
+the accepted set) proves, in zero knowledge:
+
+- **(a) ref open**: `ref_commitment` recomputes from the private `(list_id,
+  version, ref_blinding)` — ties the proof to the issuer-signed reference.
+- **(b) accepted-set membership**: `accepted_leaf(list_id, version,
+  status_list_root)` is a member of the PUBLIC accepted-set root, at a private
+  index/path. This is `issuer.nr::key_set_membership` generalised from a 2-input
+  `key_leaf` to a 4-input leaf — and, crucially, it PRIVATELY BINDS the
+  `status_list_root` for the hidden `(list, version)`.
+- **(c) freshness**: `version >= min_version` for a PUBLIC `min_version` floor —
+  a typed `u64` comparison (cheap; see §5). `version` has no witness freedom (it
+  is bound through both (a) and (b)), so a holder cannot prove an OLD version is
+  fresh.
+- **(d) bit-unset inclusion**: the existing `revoke_unset_check_committed` body,
+  but folding against the PRIVATE `status_list_root` from (b) instead of a public
+  `root`, and cross-binding `index_commitment` to the proven-unset index as today.
+
+Public inputs: `challenge`, `index_commitment`, `accepted_set_root`,
+`min_version`. Everything else is private.
+
+### Why sub-option A over a public candidate-root set (B)
+
+(B) — the verifier publishes a SET of candidate roots and the proof shows the fold
+holds against one (an OR / disjunction) — leaks strictly more (the candidate-root
+list and its cardinality) and costs N folds. **A** leaks only the accepted-set
+root, costs ONE membership fold, and binds the root atomically inside the leaf so
+a prover cannot pair list₁'s identity with list₂'s root. Sub-option A is the
+clear choice.
+
+## 4. Disclosure floor after sq-6qe (honest)
+
+A hidden-revocation presentation then discloses **no holder-identifying
+attribute**: not the index, bit, list IRI, nor version. The statement reduces to
+"some accepted `(list, version)` in the relying party's committed set, with
+`version >= min_version`, has my hidden index unset."
+
+Residual disclosures — all policy-side / structural, NOT holder-identifying:
+
+- **accepted-set root** = the RP's policy fingerprint (stable across presentations
+  to that RP; same character as the hidden-issuer `key_set_root` already accepted).
+- **public `min_version`** = the coarse epoch FLOOR of the RP's policy, not the
+  credential's epoch.
+- **circuit member depth(s)** `D` / `A` (via the vk / member name) = a cardinality
+  bound (≤ 2^D leaves, ≤ 2^A accepted entries). Inherent to fixed-depth Merkle.
+
+**Conditional dependency — call out loudly:** the whole privacy guarantee is
+undone if `index_commitment` (or `ref_commitment`) is REUSED across presentations
+— a static commitment is itself a cross-presentation linkage handle. The
+holder/issuer flow MUST re-blind per presentation (fresh `blinding` and
+`ref_blinding`), or use a re-randomisable commitment. This is the single most
+important operational requirement of the design.
+
+## 5. Cost (PRIORS — must be measured with `bb gates`)
+
+This box runs `nargo 1.0.0-beta.21` / `bb 5.0.0-nightly.20260324`, NEWER than the
+toolchain the `noir-optimisation` skill's gate figures were calibrated on, so the
+numbers below are PRIORS and **must be re-measured with `bb gates -s ultra_honk -b
+target/<member>.json` before any number is committed** (the skill's first rule:
+"Always run `bb gates` before claiming a saving").
+
+- **(c) freshness `version >= min_version`**: keep `version` a typed `u64` and use
+  `>=` — the cheapest comparison primitive (plookup absorbs the range check; the
+  skill puts `u64 <` at ~13 gates/call vs `Field::lt` ~14× more). Likely reuses an
+  existing range table the circuit already pays for. Essentially free. Do NOT cast
+  `version` to `Field` for the compare.
+- **(a) ref open**: one extra Poseidon2 permutation (~74 gates by the carried
+  estimate), a 4-input `Poseidon2::hash([...], 4)`.
+- **(b) accepted-set fold**: `A` `h2` permutations (~74 each) + one `to_le_bits`
+  decomposition — structurally identical to `key_set_membership`. Roughly DOUBLES
+  the revocation circuit's Merkle work (two folds), but the fold is the cheap part.
+
+Crucially this member has **no scalar mul** (unlike the Schnorr / hidden-issuer
+members, whose two ~251-bit double-and-adds dominate the estate), so even with two
+folds + a permutation + a `u64` compare it stays in the "tiny next to the scan /
+Schnorr family" regime. Feasible and cheap — but **measure before claiming**.
+
+Gate-counting mechanism (already in the repo): add the member under `zk/compose/`,
+`nargo compile --package <member>`, `bb gates -s ultra_honk -b
+target/<member>.json` → `functions[0].circuit_size`; the snapshot gate is
+`crates/sparq-zk-compose/tests/gate_count_snapshot.json` (3% tolerance), re-baselined
+by `bench/zk-compose/scripts/gate_counts.sh`. A new member MUST get a baseline or
+`snapshot_covers_every_member` fails. Beware the per-circuit padding floor
+(`noir-optimisation` §2.4): measure deltas against the existing revocation member,
+not the raw floor of an isolated small circuit.
+
+## 6. What is implemented now (the tractable increment)
+
+The cryptographic PRIMITIVES the deferred circuit + verifier will consume are
+landed in `crates/sparq-zk/src/sig.rs`, domain-separated and unit-tested
+(hiding / binding / domain-separation / atomic-triple-binding), mirroring how the
+sq-ayv `status_index_commitment` + `status_ref_commit_digest` primitives landed
+before that path's circuit:
+
+- `sig::status_ref_commitment(list_id, version, ref_blinding) -> Fr` — the hiding
+  `(list, version)` commitment of §3, `Poseidon2([DOMAIN_RC, list_id, version,
+  ref_blinding], 4)`.
+- `sig::status_ref_fully_committed_digest(ref_commitment, index_commitment) -> Fr`
+  — the issuer-signed digest of §3, `Poseidon2([DOMAIN_FC, ref_commitment,
+  index_commitment], 3)`, distinct-domain from both other modes.
+- `sig::accepted_status_leaf(list_id, version, status_list_root) -> Fr` — the
+  accepted-set Merkle leaf of §3 (sub-option A), `Poseidon2([DOMAIN_AL, list_id,
+  version, status_list_root], 4)`.
+
+These are off-circuit Rust whose field outputs are exactly what the future Noir
+member will recompute in-circuit (single source of truth), so the in-circuit
+opening/membership will byte-match the host without drift — the same discipline
+the existing `status_index_commitment` cross-vector test pins.
+
+## 7. Deferred (the follow-up bead)
+
+1. The Noir member `revoke_hidden_ref_d{D}_a{A}` (relations (a)–(d) of §3),
+   cross-vector-tested against the §6 host primitives (poseidon2_noir_cross style).
+2. A new `CircuitId` variant + `derive_*` id, `Prover.toml` renderer, and host
+   witness builder (the accepted-set membership witness — reuse the sparse-Merkle
+   `merkle_witness` machinery for both trees).
+3. Manifest: a fully-hidden `RevocationStatus` mode (`status_list` / `version` /
+   `index` all `None`, carrying `ref_commitment` + `index_commitment`) and a
+   `HiddenIndexRevocation` carrying `accepted_set_root` + `min_version`.
+4. Verifier: a `bind_fully_hidden_revocation` gate that derives the accepted-set
+   root from `RevocationPolicy`'s curated snapshots, supplies it + `min_version` as
+   public inputs, and `bb verify`s — never trusting the prover's declared root.
+   Plus the issuer-side `status_ref_fully_committed_digest` attestation path in
+   `bind_issuer_attestations` / `resolve_status_ref`.
+5. `RevocationPolicy::accepted_set(...)` + a `with_min_version` builder, and the
+   re-blinding requirement (§4) enforced/documented in the holder flow.
+6. SKILL.md (`skills/zk-query-proofs`): document the fully-hidden mode once it is
+   end-to-end usable.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the `jeswr/sparq` RDF/SPARQL engine (Claude Opus 4.8). @jeswr runs multiple agents; this was written by the **SPARQ** agent. The **PSS** agent (`prod-solid-server`) is a separate party in these discussions.

Resolves two related beads in the committed-index revocation ZK estate. `sparq-zk` / `sparq-zk-compose` are `publish=false` and depend on nothing else in the workspace — independent of the merge train; `sparq-server` is untouched.

## sq-hwe — sparse status-list Merkle builder (FULLY IMPLEMENTED ✅)

The committed-index hidden-revocation path inherited a **dense `O(2^depth)`** host Merkle-root/witness builder (`crates/sparq-zk-compose/src/revocation.rs`), which bounded the representative list size — production StatusList2021 lists are commonly 2^17+.

This replaces it with a **sparse** builder: it caches the all-zeros and all-ones uniform-subtree root at each height and recurses only into the `O(set-bits)` subtrees that actually hold a revoked bit or straddle the covered / fail-closed-padding boundary. Cost is `O(S·depth + depth)` host work / `O(S·depth)` memory, **independent of `2^depth`**, so production depths are supported without a dense full-size builder.

Crucially, roots and authentication paths are **bit-identical** to the old dense fold (same Poseidon2 `h2`, same leaf layout, same fail-closed padding), so the circuit relation (`revoke.nr`) and the verifier's root-equality binding are **unchanged** — only the host construction is cheaper. The original dense builder is retained as `dense_merkle_root` (a `#[cfg(test)]` oracle); new tests cross-check sparse == dense across uniform / sparse / boundary-straddling shapes, exercise a 2^17-depth root+witness, and the existing **end-to-end bb prove+verify** hidden-revocation tests pass against the sparse roots.

## sq-6qe — hide status-list IRI + version (FOUNDATION implemented; full path DEFERRED)

sq-ayv closed the index + liveness-bit leak, but the **list IRI** and **version** are still disclosed in the clear (both issuer-bound) on the committed-index path — a coarser linkability channel.

Fully closing this needs a **new Noir circuit member + verifier + manifest path** (a hiding `(list,version)` commitment, in-zk accepted-set membership that privately binds the status-list root, in-zk `version >= public min_version` freshness, and bit-unset against the bound root). That is too large for one clean PR, so per the scope-honestly guidance this PR lands the **highest-value tractable increment** and records the rest:

- **Implemented:** the domain-separated cryptographic primitives in `sparq-zk::sig` — `status_ref_commitment`, `status_ref_fully_committed_digest`, `accepted_status_leaf` — unit-tested for hiding / binding / atomic-triple-binding / domain-separation from the other two disclosure modes. These are off-circuit Rust whose field outputs the deferred circuit will recompute in-circuit (single source of truth), mirroring how the sq-ayv index-commitment primitives landed before that path's circuit.
- **Design record:** `research/zk-statuslist-hide-iri-version.md` — the full sub-option-A design (bind the root inside an accepted `(list,version,root)`-set leaf), the disclosure-floor analysis (closes all holder-identifying leaks; residual is the RP policy fingerprint + public min_version floor + circuit depth; the privacy guarantee **depends on per-presentation re-blinding**), and a grounded cost estimate (no scalar mul; ~2 Merkle folds + 1 permutation + a `u64` compare — **must be measured with `bb gates` before any number is claimed**).
- **Follow-up bead:** `sq-kndw` (the deferred circuit + verifier + manifest path).

Docs updated: `verifier::bind_revocation` "HONEST REMAINING DISCLOSURE" and `bind_hidden_revocation` "Scope" notes now reflect that the host builder no longer bounds list size (the residual bound is the single compiled `revoke_unset_d10` member — depth-generic, deeper member mechanical) and point sq-6qe at the design record.

## Gate

- `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings` — **clean**.
- `cargo test -p sparq-zk` — **green** (82 tests across lib + integration).
- `cargo test -p sparq-zk-compose` — **green** (lib 29 + host 24 + verifier_errors 13 + e2e 86 + forge_gates 10 + gate_count 2), and the `--ignored` end-to-end **bb prove+verify** hidden-revocation tests (3) pass against the sparse roots.
- No Noir circuits added/changed → the gate-count snapshot is untouched.

Closes sq-hwe. Advances sq-6qe (foundation + design + follow-up sq-kndw); does **not** close sq-6qe.

[OPUS-4.8] Authored under the Opus 4.8 fallback (Fable unavailable) — inline `[OPUS-4.8]` markers on new code/notes for re-review.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)