### PR TITLE
fix(release): boot the Docker image on `docker run` + run/curl smoke test (sq-n6rv)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,4 +458,33 @@ jobs:
         # set already covers the unsafe of interest (sparq-core). sparq-py is skipped
         # (pyo3 extension module — not a plain cargo-geiger target, like the other jobs).
         run: cargo geiger --workspace --exclude sparq-py >> "$GITHUB_STEP_SUMMARY"
+
+  docker-smoke:
+    # [OPUS-4.8] sq-n6rv: build the release container EXACTLY as release.yml ships it, then
+    # `docker run` it and prove over the network that it serves. This is the gate that makes
+    # a container which exits immediately on `docker run` un-shippable: sq-n6rv was precisely
+    # that (the fail-closed bind posture refused the ENTRYPOINT's 0.0.0.0 bind, so every
+    # released image died on boot) and NO test caught it because nothing ever ran the image.
+    # PR-triggered, so `ci-summary` auto-discovers and gates it; release.yml re-runs the same
+    # script against the tag's image before push. Builds with the SAME Dockerfile + buildx the
+    # release job uses, so the artifact under test matches the one that ships.
+    name: docker image smoke (run + curl /health + query)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Build image (load into the local daemon)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          # Single-arch, loaded into the runner's docker daemon so `docker run` can use it.
+          load: true
+          push: false
+          tags: sparq-server:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Smoke test (docker run + /health + ASK query)
+        run: scripts/docker-smoke.sh sparq-server:smoke 3030
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,4 +487,3 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Smoke test (docker run + /health + ASK query)
         run: scripts/docker-smoke.sh sparq-server:smoke 3030
-        continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,21 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
+      # [OPUS-4.8] sq-n6rv: SMOKE BEFORE PUSH. Build the image locally first, `docker run`
+      # it, and prove it serves /health + a query — so a container that exits immediately on
+      # boot (the sq-n6rv regression) can never reach ghcr.io. The build is cached to GHA, so
+      # the subsequent push step is a cache hit (it does not rebuild from scratch).
+      - name: Build image for smoke test (load locally)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          load: true
+          push: false
+          tags: sparq-server:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Smoke test the image (docker run + /health + ASK query)
+        run: scripts/docker-smoke.sh sparq-server:smoke 3030
       - name: Build and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,31 @@
 # Run:      docker run --rm -p 3030:3030 -v "$PWD/data:/data:ro" sparq-server \
 #             --format turtle /data/dataset.ttl
 #           (no data file => starts with an empty default graph)
-# Endpoint: http://localhost:3030/sparql
+# Endpoint: http://localhost:3030/sparql   Health: http://localhost:3030/health
+#
+# [OPUS-4.8] sq-n6rv — SECURITY POSTURE OF THIS IMAGE (read before exposing the port):
+#   This image sets ENV SPARQ_ALLOW_REMOTE=1 so it BOOTS on `docker run` out of the box:
+#   without a published port the server is useless, and inside the container the only
+#   reachable bind is the non-loopback 0.0.0.0 the ENTRYPOINT requests. Running the
+#   container is itself the operator's explicit choice to expose a network surface, so
+#   the bind is permitted — but the server has NO built-in auth in this default posture,
+#   i.e. anyone who can reach the published port can READ AND WRITE the whole dataset.
+#   The binary logs a loud no-auth WARNING at startup; do not ignore it.
+#
+#   For any non-trivial deployment, gate the surface with the Bearer token (#71) — the
+#   server reads SPARQ_AUTH_TOKEN / SPARQ_AUTH_TOKEN_READ from the ENVIRONMENT (see
+#   ServerConfig::from_env), so pass them straight through with `-e`, no flag wiring:
+#     # writes gated, reads open (QLever-style):
+#     docker run --rm -p 3030:3030 -e SPARQ_AUTH_TOKEN=$TOK sparq-server
+#     # whole surface gated (writes AND reads require the token):
+#     docker run --rm -p 3030:3030 -e SPARQ_AUTH_TOKEN=$TOK -e SPARQ_AUTH_TOKEN_READ=1 sparq-server
+#   Deliver the token over TLS (terminate at a reverse proxy); a bare Bearer token on
+#   plaintext HTTP is sniffable. For per-user authz, front it with a gateway / sparq-solid.
+#   See crates/sparq-server/README.md -> "Running the container image (ghcr.io)".
+#
+# A CI smoke test (docker run + curl /health + a basic query) gates this image on every
+# PR and before each release push, so a container that exits immediately can never ship —
+# see .github/workflows/ci.yml (docker-smoke) and release.yml.
 #
 # CI builds + pushes this to ghcr.io on version tags — see .github/workflows/release.yml.
 
@@ -47,6 +71,17 @@ COPY --from=builder /build/target/release/sparq-server /usr/local/bin/sparq-serv
 # Conventional mount point for read-only datasets.
 VOLUME ["/data"]
 EXPOSE 3030
+
+# [OPUS-4.8] sq-n6rv: permit the non-loopback bind the ENTRYPOINT requests.
+# After the fail-closed bind posture (sq-o4qf) landed, the server REFUSES a non-loopback
+# `--addr` (and exits non-zero) unless --allow-remote / SPARQ_ALLOW_REMOTE=1 is set. Inside
+# a container the ONLY useful bind is 0.0.0.0 (loopback is unreachable through Docker's port
+# mapping), and running the container is itself the operator's explicit choice to publish a
+# network surface — so we set it here so the image BOOTS out of the box. This does NOT add
+# auth: see the security note in the header and crates/sparq-server/README.md. Gate the
+# surface in production with `-e SPARQ_AUTH_TOKEN=...` (and `-e SPARQ_AUTH_TOKEN_READ=1` for
+# a fully-gated surface) — the server reads those from the environment.
+ENV SPARQ_ALLOW_REMOTE=1
 
 # Bind 0.0.0.0 inside the container (the binary's default 127.0.0.1 is unreachable through
 # Docker's port mapping). Flags repeat-override in sparq-server's arg parser, so callers can

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,13 +40,15 @@
 # CI builds + pushes this to ghcr.io on version tags — see .github/workflows/release.yml.
 
 # -------- builder --------
-# Pin a toolchain >= the workspace's rust-version (1.85). Bump deliberately.
+# Pin a toolchain >= the workspace's rust-version (1.88, the declared MSRV floor in the
+# root Cargo.toml [workspace.package] — `cargo build --locked` REFUSES an older toolchain).
+# Bump deliberately, in lock-step with that floor.
 # [OPUS-4.8] SHA-pinned for supply-chain integrity (Scorecard PinnedDependencies). The
 # human-readable tag is kept on its OWN comment line above the FROM, NOT as a trailing
 # inline comment: Docker only treats `#` as a comment at the start of a line, so an inline
 # `# tag` on a FROM is parsed as extra arguments and fails with "FROM requires either one
-# or three arguments". Tag: rust:1.87-slim-bookworm
-FROM rust:1.87-slim-bookworm@sha256:437507c3e719e4f968033b88d851ffa9f5aceeb2dcc2482cc6cb7647811a55eb AS builder
+# or three arguments". Tag: rust:1.88-slim-bookworm
+FROM rust:1.88-slim-bookworm@sha256:38bc5a86d998772d4aec2348656ed21438d20fcdce2795b56ca434cf21430d89 AS builder
 
 ARG CARGO_FLAGS=""
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,12 @@
 
 # -------- builder --------
 # Pin a toolchain >= the workspace's rust-version (1.85). Bump deliberately.
-# [OPUS-4.8] SHA-pinned for supply-chain integrity (Scorecard PinnedDependencies); the
-# trailing comment keeps the human-readable tag legible for future bumps.
-FROM rust:1.87-slim-bookworm@sha256:437507c3e719e4f968033b88d851ffa9f5aceeb2dcc2482cc6cb7647811a55eb AS builder # rust:1.87-slim-bookworm
+# [OPUS-4.8] SHA-pinned for supply-chain integrity (Scorecard PinnedDependencies). The
+# human-readable tag is kept on its OWN comment line above the FROM, NOT as a trailing
+# inline comment: Docker only treats `#` as a comment at the start of a line, so an inline
+# `# tag` on a FROM is parsed as extra arguments and fails with "FROM requires either one
+# or three arguments". Tag: rust:1.87-slim-bookworm
+FROM rust:1.87-slim-bookworm@sha256:437507c3e719e4f968033b88d851ffa9f5aceeb2dcc2482cc6cb7647811a55eb AS builder
 
 ARG CARGO_FLAGS=""
 WORKDIR /build
@@ -57,8 +60,10 @@ COPY . .
 RUN cargo build --release --locked -p sparq-server ${CARGO_FLAGS}
 
 # -------- runtime --------
-# [OPUS-4.8] SHA-pinned (Scorecard PinnedDependencies); tag kept as a trailing comment.
-FROM gcr.io/distroless/cc-debian12:nonroot@sha256:b0ae8e989418b458e0f25489bc3be523718938a2b70864cc0f6a00af1ddbd985 # gcr.io/distroless/cc-debian12:nonroot
+# [OPUS-4.8] SHA-pinned (Scorecard PinnedDependencies). Tag kept on its own comment line
+# above the FROM (an inline trailing `# tag` breaks FROM's arg parser — see builder above).
+# Tag: gcr.io/distroless/cc-debian12:nonroot
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:b0ae8e989418b458e0f25489bc3be523718938a2b70864cc0f6a00af1ddbd985
 
 LABEL org.opencontainers.image.title="sparq-server" \
       org.opencontainers.image.description="W3C SPARQL 1.1 Protocol server for the sparq RDF triplestore (dictionary-encoded, six permutation indexes, parallel execution)" \

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -90,6 +90,46 @@ cargo run -p sparq-server -- --format turtle data.ttl
 curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=SELECT * WHERE { ?s ?p ?o } LIMIT 5'
 ```
 
+## 🐳 Running the container image (ghcr.io)
+
+A container image is published to `ghcr.io/jeswr/sparq-server` on every release tag (built
+from the repo `Dockerfile`; a CI smoke test runs the built image and curls `/health` + a
+query before it ships). The runtime stage is distroless (no shell, no package manager).
+
+```sh
+# boots out of the box, empty default graph, no auth (see the warning it prints):
+docker run --rm -p 3030:3030 ghcr.io/jeswr/sparq-server
+
+# serve a dataset (mount it read-only):
+docker run --rm -p 3030:3030 -v "$PWD/data:/data:ro" \
+  ghcr.io/jeswr/sparq-server --format turtle /data/dataset.ttl
+
+curl http://127.0.0.1:3030/health   # -> ok
+curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=ASK {}'
+```
+
+**Why it binds `0.0.0.0`.** Inside a container the only useful bind is the non-loopback
+`0.0.0.0` (loopback is unreachable through Docker's port mapping). The fail-closed bind
+posture above refuses a non-loopback bind unless opted in, so the image sets
+`SPARQ_ALLOW_REMOTE=1` to boot — running the container is itself the operator's explicit
+choice to publish a network surface. **This default posture has no auth**: anyone who can
+reach the published port can READ AND WRITE the dataset (the server logs a loud no-auth
+WARNING on startup — heed it).
+
+**Securing it (recommended for anything beyond local use).** Every `SPARQ_*` var is read
+from the *environment*, so turn on the Bearer gate with `-e` — no flag wiring needed:
+
+```sh
+# fully gated — writes AND reads require the token (drop the second -e for QLever-style
+# writes-gated/reads-open). Deliver $TOK over TLS — terminate at a reverse proxy:
+docker run --rm -p 3030:3030 \
+  -e SPARQ_AUTH_TOKEN="$TOK" -e SPARQ_AUTH_TOKEN_READ=1 ghcr.io/jeswr/sparq-server
+```
+
+For per-user authz, front it with a gateway or `sparq-solid`. The other `SPARQ_*` hardening
+vars (timeout, body cap, concurrency, …) work the same way through `-e`. See the auth × bind
+matrix under "Security posture".
+
 ## ✨ Features
 
 - **SPARQL 1.1 Protocol** — `query` (GET / POST direct / POST url-encoded / HEAD) and

--- a/scripts/docker-smoke.sh
+++ b/scripts/docker-smoke.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] sq-n6rv — sparq-server container smoke test.
+#
+# WHY: the released ghcr.io image is the only surface where a `docker run` that exits
+# immediately ships silently. sq-n6rv was exactly that: after the fail-closed bind posture
+# (sq-o4qf) landed, the ENTRYPOINT's non-loopback `--addr 0.0.0.0:3030` was REFUSED at
+# startup, so every `docker run ghcr.io/jeswr/sparq-server` from a release tag died on
+# boot — and nothing caught it because no test ever actually RAN the built image. This
+# script does: it runs an already-built image, then proves over the network that it serves.
+#
+# It deliberately does NOT build — the caller (ci.yml / release.yml) builds (or pulls) the
+# image and passes its ref, so the same artifact that ships is the one tested. The runtime
+# stage is distroless (no shell, no curl), so every probe is done from the HOST against the
+# published port, never via `docker exec`.
+#
+# Usage:   scripts/docker-smoke.sh <IMAGE_REF> [HOST_PORT]
+# Example: scripts/docker-smoke.sh sparq-server:smoke 3030
+#
+# Exit 0 iff the container boots, /health returns "ok", and a trivial SPARQL query returns
+# a well-formed SPARQL-JSON result. Any failure prints the container logs and exits non-zero.
+set -euo pipefail
+
+IMAGE="${1:?usage: docker-smoke.sh <IMAGE_REF> [HOST_PORT]}"
+PORT="${2:-3030}"
+NAME="sparq-smoke-$$"
+BASE="http://127.0.0.1:${PORT}"
+
+cleanup() {
+  # Surface logs on ANY exit path before tearing the container down — a boot failure
+  # (the sq-n6rv regression) is only legible in the logs the no-shell image emits.
+  echo "::group::container logs (${NAME})"
+  docker logs "${NAME}" 2>&1 || true
+  echo "::endgroup::"
+  docker rm -f "${NAME}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo ">> running ${IMAGE} (publishing :${PORT}, no auth — default boot posture)"
+# No -e SPARQ_AUTH_TOKEN: this asserts the OUT-OF-THE-BOX boot path (the bug's blast radius).
+# The image's ENV SPARQ_ALLOW_REMOTE=1 is what lets the 0.0.0.0 bind proceed; if that env or
+# the entrypoint regresses, the container exits and the health poll below fails fast.
+docker run -d --name "${NAME}" -p "127.0.0.1:${PORT}:3030" "${IMAGE}" >/dev/null
+
+echo ">> waiting for /health"
+ok=""
+for i in $(seq 1 30); do
+  # If the container has already exited (the sq-n6rv failure mode), stop polling and report.
+  if [ "$(docker inspect -f '{{.State.Running}}' "${NAME}" 2>/dev/null || echo false)" != "true" ]; then
+    echo "!! container is not running (exited on boot) after ${i} attempt(s)" >&2
+    exit 1
+  fi
+  body="$(curl -fsS "${BASE}/health" 2>/dev/null || true)"
+  if [ "${body}" = "ok" ]; then ok=1; echo ">> /health -> ok (attempt ${i})"; break; fi
+  sleep 1
+done
+if [ -z "${ok}" ]; then
+  echo "!! /health did not return \"ok\" within 30s" >&2
+  exit 1
+fi
+
+echo ">> issuing a trivial SPARQL query"
+# ASK {} is the cheapest well-formed query; an empty default graph still answers it.
+resp="$(curl -fsS -G "${BASE}/sparql" \
+  -H 'Accept: application/sparql-results+json' \
+  --data-urlencode 'query=ASK {}')"
+echo "   response: ${resp}"
+# The empty default graph yields a valid SPARQL-JSON ASK result; "boolean" must be present.
+case "${resp}" in
+  *'"boolean"'*) echo ">> query path OK" ;;
+  *) echo "!! SPARQL query did not return a SPARQL-JSON boolean result" >&2; exit 1 ;;
+esac
+
+echo ">> SMOKE PASS: ${IMAGE} boots and serves /health + /sparql"

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -243,6 +243,24 @@ feature), AND its **auth gate** (a GSP write is as powerful as an UPDATE, so `PU
 `DELETE` are gated by `--auth-token` exactly like an UPDATE; `GET`/`HEAD` are reads). A
 malformed body → `400`; an unsupported body Content-Type → `415`.
 
+**5b. Container (ghcr.io).** Published on every release tag (`ghcr.io/jeswr/sparq-server`,
+distroless). The image sets `SPARQ_ALLOW_REMOTE=1` so the `0.0.0.0` bind it needs (loopback
+is unreachable through Docker's port map) boots out of the box — running the container is the
+operator's explicit choice to publish a surface. **This default has NO auth.** Because every
+`SPARQ_*` var is read from the environment, secure it with `-e` (no flag wiring):
+
+```sh
+docker run --rm -p 3030:3030 ghcr.io/jeswr/sparq-server                       # empty graph, no auth
+docker run --rm -p 3030:3030 -v "$PWD/data:/data:ro" \
+  ghcr.io/jeswr/sparq-server --format turtle /data/dataset.ttl                # serve a dataset
+docker run --rm -p 3030:3030 \
+  -e SPARQ_AUTH_TOKEN="$TOK" -e SPARQ_AUTH_TOKEN_READ=1 \
+  ghcr.io/jeswr/sparq-server                                                  # fully Bearer-gated
+```
+
+Deliver the token over TLS (terminate at a proxy). See `crates/sparq-server/README.md` →
+"Running the container image".
+
 **6. Hardening — flags / env / library.** Each flag overrides its `SPARQ_*` env var; the
 env overrides the default.
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

## The defect (sq-n6rv, confirmed P1)

The released `ghcr.io/jeswr/sparq-server` image **exited immediately on `docker run`**. After the fail-closed bind posture (`sq-o4qf`) landed, the server refuses a non-loopback `--addr` unless `--allow-remote` / `SPARQ_ALLOW_REMOTE=1` is set. The `Dockerfile` ENTRYPOINT is `["/usr/local/bin/sparq-server","--addr","0.0.0.0:3030"]` with neither — so `bind_posture(non-loopback, allow_remote=false) => RemoteRefused` and `main.rs` returned `Err` **before binding**. Every container from a release tag died on boot, and nothing caught it because **no test ever ran the built image**.

## The fix (Dockerfile + CI + docs only — no `crates/sparq-server/src/*.rs` change)

1. **Boot out of the box, safely.** `Dockerfile` sets `ENV SPARQ_ALLOW_REMOTE=1`. Inside a container the only useful bind is `0.0.0.0` (loopback is unreachable through Docker's port map), and running the container is itself the operator's explicit choice to publish a network surface — so the bind is permitted. The startup **no-auth WARNING is preserved**. No server code changed (sparq-server is reserved for the in-flight branch).
2. **Easy + documented secure path.** The server reads `SPARQ_AUTH_TOKEN` / `SPARQ_AUTH_TOKEN_READ` from the **environment** (`ServerConfig::from_env`, #71), so the token is passed straight through with `-e` — no entrypoint flag wiring needed. The Dockerfile header, README and SKILL all document `-e SPARQ_AUTH_TOKEN=… [-e SPARQ_AUTH_TOKEN_READ=1]` for a write-gated / fully-gated surface.
3. **Smoke test so a broken image can never ship again.** `scripts/docker-smoke.sh` runs an already-built image, polls `/health`, and issues a trivial `ASK {}` query — surfacing container logs and failing fast if the container exits on boot (the no-shell distroless image is probed from the host, not via `docker exec`). Wired into:
   - a new **`docker-smoke`** job in `ci.yml` (PR-triggered → `ci-summary` auto-discovers and gates it), and
   - `release.yml` as a **smoke-before-push** step (cached build → the push step is a cache hit), so a container that exits immediately can never reach ghcr.io.
4. **Docs.** `crates/sparq-server/README.md` gains a "Running the container image (ghcr.io)" section (correct `docker run` invocation + security guidance: no-auth default vs `-e` Bearer-gated); a matching container recipe added to `skills/http-server/SKILL.md`.

## Security posture chosen (and why)

`ENV SPARQ_ALLOW_REMOTE=1` (boot) **+** documented `-e SPARQ_AUTH_TOKEN` (secure). Rationale: a container with no published port is useless, and the only reachable bind inside it is the non-loopback `0.0.0.0` the entrypoint requests — so `docker run` *is* the explicit remote-exposure opt-in. Baking `SPARQ_ALLOW_REMOTE=1` matches that intent without weakening the fail-closed default for the bare binary. The no-auth WARNING stays loud, and the prominent, low-friction `-e` token path makes the gated surface (#71) the obvious production choice.

## Verification

- **Could not `docker build` / `docker run` locally — Docker is not installed on the dev box** (`docker: command not found`), exactly as the brief anticipated. The **CI `docker-smoke` job is the real test** (it builds with the same Dockerfile + buildx the release job uses).
- Both workflows parse (`yaml.safe_load`); `scripts/docker-smoke.sh` is **shellcheck-clean** and `bash -n`-valid; the changed docs pass the repo's no-perf-numbers check.

## Follow-ups (beaded)

- **`sq-a3ey`** — add a Trivy image scan to the container CI (nice-to-have per the bead; deferred because Docker is unavailable locally to validate it and to keep this PR focused on the boot fix + smoke test).

Refs sq-n6rv. No GitHub issue exists for this, so there is no `Closes #N`.
