### PR TITLE
feat(vectors): opt-in `embeddings` feature — reqwest-backed RemoteEmbedder from env (sq-fg9y)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3478,6 +3478,7 @@ dependencies = [
  "instant-distance",
  "memmap2",
  "oxrdf 0.3.3",
+ "reqwest",
  "rustc-hash 2.1.2",
  "serde_json",
  "sparq-core",

--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -31,6 +31,13 @@ default = []
 # is supplied by the CALLER (a `Transport` impl over their HTTP client of choice);
 # this crate never opens a socket. Pulls in serde_json for request/response bodies.
 provider = ["dep:serde_json"]
+# [OPUS-4.8] `embeddings` ships a CONCRETE reqwest blocking `Transport` + an
+# env-driven constructor so the crate works against a real /v1/embeddings endpoint
+# WITHOUT caller glue (sq-fg9y). Mirrors sparq-nlq's `live` feature: blocking reqwest,
+# rustls-tls, key/base-url/model from env, a hard request timeout. OFF by default — the
+# default build stays socket-free (no reqwest) and wasm-safe (nothing depends on this
+# crate, and reqwest is not in the default feature set so it never enters a wasm bundle).
+embeddings = ["provider", "dep:reqwest"]
 
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io
@@ -44,3 +51,8 @@ memmap2.workspace = true
 # cleaner fit for an in-RAM index rebuilt from the mmap'd store on open.
 instant-distance.workspace = true
 serde_json = { version = "1", optional = true }
+# [OPUS-4.8] Concrete HTTP transport for the non-default `embeddings` feature only.
+# Blocking by design (the embed call is synchronous and this crate must not drag an
+# async runtime into the tree) — mirrors sparq-nlq's `live` reqwest dependency exactly.
+# rustls-tls so there is no system-OpenSSL build dependency.
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"], optional = true }

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -57,9 +57,45 @@ let _neighbours = index.nearest_term(&some_term, &graph, &store, 10);
 - **Verbalization** — `verbalize` / `embed_entities` render `<label>. a <type>. <description>`
   per entity (multilingual, char-budgeted); `embed_labels` is the label-only special case.
 - **Quantization** — `ScalarQuantizer` (4×) and `ProductQuantizer` (asymmetric distance) for
-  large stores; `Embedder` is provider-agnostic (the crate never opens a socket).
+  large stores; `Embedder` is provider-agnostic.
+- **Live embeddings (opt-in)** — the default build is **socket-free** (no HTTP client). The
+  non-default `provider` feature carries the OpenAI-compatible `/v1/embeddings` API shape with
+  a caller-supplied `Transport`; the non-default **`embeddings`** feature additionally ships a
+  concrete reqwest blocking `Transport` and `RemoteEmbedder::from_env(dim)`, so `embed_entities`
+  works against a real endpoint with **no caller glue** (see below). Mirrors `sparq-nlq`'s
+  `live` feature; never enters the wasm bundle.
 - **Hybrid fusion** — `fuse_rrf` / `fuse_rrf_weighted` / `fuse_scores` combine text vectors
   with another ranked signal (e.g. [`sparq-sim`](../sparq-sim) structural similarity).
+
+## 🔌 Live embeddings (opt-in `embeddings` feature)
+
+The default build opens no sockets. To embed against a real OpenAI-compatible
+`/v1/embeddings` endpoint without writing any HTTP glue, enable the **non-default**
+`embeddings` feature (it pulls in a blocking [`reqwest`] client; the default build does not):
+
+```toml
+sparq-vectors = { path = "../sparq-vectors", features = ["embeddings"] }
+```
+
+```rust,ignore
+use sparq_core::Graph;
+use sparq_vectors::{embed_entities, EntityTextConfig, VectorStore};
+use sparq_vectors::embed::provider::RemoteEmbedder;
+
+// SPARQ_EMBEDDINGS_API_KEY (required) → Authorization: Bearer …
+// SPARQ_EMBEDDINGS_BASE_URL (optional) → endpoint, default https://api.openai.com/v1/embeddings
+// SPARQ_EMBEDDINGS_MODEL    (optional) → model,    default text-embedding-3-small
+let embedder = RemoteEmbedder::from_env(1536)?;     // dim must match the store
+let mut store = VectorStore::create("graph.spqv", 1536)?;
+embed_entities(&graph, &mut store, &embedder, &EntityTextConfig::default())?;
+store.finalize()?;
+```
+
+`from_env` reads the key/base-url/model from the environment (mirroring `sparq-nlq`'s live
+client); requests carry a hard timeout. Point `SPARQ_EMBEDDINGS_BASE_URL` at any
+OpenAI-compatible server (a self-hosted model, a proxy). The crate still **never opens a
+socket in the default build** — only with `--features embeddings`, and it is excluded from the
+wasm build (nothing in the workspace depends on this crate).
 
 ## 📚 Learn more
 

--- a/crates/sparq-vectors/src/embed.rs
+++ b/crates/sparq-vectors/src/embed.rs
@@ -145,6 +145,210 @@ pub mod provider {
         }
     }
 
+    // [OPUS-4.8] Concrete reqwest blocking transport + env-driven constructor
+    // (non-default `embeddings` feature, sq-fg9y). This is the piece that makes the
+    // crate usable for real retrieval WITHOUT caller glue: with the feature on, a
+    // `RemoteEmbedder` can be built straight from environment variables and embeds
+    // against a live OpenAI-compatible `/v1/embeddings` endpoint. Mirrors
+    // `sparq-nlq`'s `live` feature (`AnthropicLlm::from_env`): blocking reqwest, key
+    // from env, a hard per-request timeout, status->error mapping. The DEFAULT build
+    // pulls none of this (no reqwest), so it stays socket-free and wasm-safe.
+    #[cfg(feature = "embeddings")]
+    pub use live::{ReqwestTransport, DEFAULT_ENDPOINT, DEFAULT_MODEL};
+
+    #[cfg(feature = "embeddings")]
+    mod live {
+        use super::{ProviderConfig, RemoteEmbedder, Transport};
+
+        /// Default endpoint when `SPARQ_EMBEDDINGS_BASE_URL` is unset — OpenAI's
+        /// `/v1/embeddings`. Any OpenAI-compatible server works (point the base URL
+        /// at it).
+        pub const DEFAULT_ENDPOINT: &str = "https://api.openai.com/v1/embeddings";
+        /// Default model when `SPARQ_EMBEDDINGS_MODEL` is unset.
+        pub const DEFAULT_MODEL: &str = "text-embedding-3-small";
+
+        /// Hard wall-clock cap on one `/v1/embeddings` round trip — `Embedder::embed`
+        /// must never hang on a stalled connection. Matches `sparq-nlq`'s live client.
+        const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
+        /// A blocking [`reqwest`] [`Transport`]: one `POST` with the JSON body the
+        /// caller built, returning the response body on 2xx and an error string
+        /// (status + provider message when JSON) otherwise. Blocking by design — the
+        /// embed loop is synchronous and this crate must not drag in an async runtime.
+        pub struct ReqwestTransport {
+            client: reqwest::blocking::Client,
+        }
+
+        impl ReqwestTransport {
+            /// Builds the blocking client with the standard request timeout.
+            pub fn new() -> Result<ReqwestTransport, String> {
+                let client = reqwest::blocking::Client::builder()
+                    .timeout(REQUEST_TIMEOUT)
+                    .build()
+                    .map_err(|e| format!("cannot build HTTP client: {e}"))?;
+                Ok(ReqwestTransport { client })
+            }
+        }
+
+        impl Transport for ReqwestTransport {
+            fn post_json(
+                &self,
+                url: &str,
+                headers: &[(String, String)],
+                body: &str,
+            ) -> Result<String, String> {
+                let mut req = self.client.post(url).body(body.to_owned());
+                for (k, v) in headers {
+                    req = req.header(k, v);
+                }
+                let resp = req
+                    .send()
+                    .map_err(|e| format!("embeddings request failed: {e}"))?;
+                let status = resp.status();
+                let text = resp
+                    .text()
+                    .map_err(|e| format!("cannot read embeddings response body: {e}"))?;
+                if !status.is_success() {
+                    // Surface the provider's `error.message` when the body is JSON,
+                    // else a truncated raw body — same shape as the nlq live client.
+                    let message = serde_json::from_str::<serde_json::Value>(&text)
+                        .ok()
+                        .and_then(|v| v["error"]["message"].as_str().map(str::to_owned))
+                        .unwrap_or_else(|| text.chars().take(200).collect());
+                    return Err(format!("embeddings API error ({status}): {message}"));
+                }
+                Ok(text)
+            }
+        }
+
+        impl RemoteEmbedder<ReqwestTransport> {
+            /// Build a live embedder entirely from the environment, mirroring
+            /// `sparq-nlq`'s `AnthropicLlm::from_env`:
+            ///
+            /// - `SPARQ_EMBEDDINGS_API_KEY` (**required**) → `Authorization: Bearer …`;
+            /// - `SPARQ_EMBEDDINGS_BASE_URL` (optional) → endpoint, default
+            ///   [`DEFAULT_ENDPOINT`];
+            /// - `SPARQ_EMBEDDINGS_MODEL` (optional) → model, default [`DEFAULT_MODEL`].
+            ///
+            /// `dim` is passed explicitly because it must match the
+            /// [`VectorStore`](crate::VectorStore) it will write into — every response
+            /// vector is checked against it (a mismatch is an error, never silently
+            /// truncated). Returns `Err` if the key is unset or the HTTP client cannot
+            /// be built.
+            pub fn from_env(dim: usize) -> Result<RemoteEmbedder<ReqwestTransport>, String> {
+                let api_key = std::env::var("SPARQ_EMBEDDINGS_API_KEY")
+                    .map_err(|_| "SPARQ_EMBEDDINGS_API_KEY is not set".to_string())?;
+                let endpoint = std::env::var("SPARQ_EMBEDDINGS_BASE_URL")
+                    .unwrap_or_else(|_| DEFAULT_ENDPOINT.to_string());
+                let model = std::env::var("SPARQ_EMBEDDINGS_MODEL")
+                    .unwrap_or_else(|_| DEFAULT_MODEL.to_string());
+                let cfg = ProviderConfig {
+                    endpoint,
+                    model,
+                    api_key: Some(api_key),
+                    dim,
+                };
+                Ok(RemoteEmbedder::new(cfg, ReqwestTransport::new()?))
+            }
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use super::super::Embedder; // RemoteEmbedder::dim is from the Embedder trait
+            use super::*;
+
+            // Env vars are process-global; serialize the tests that mutate them so
+            // they don't race when the binary runs them in parallel.
+            static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+            fn clear_env() {
+                for k in [
+                    "SPARQ_EMBEDDINGS_API_KEY",
+                    "SPARQ_EMBEDDINGS_BASE_URL",
+                    "SPARQ_EMBEDDINGS_MODEL",
+                ] {
+                    std::env::remove_var(k);
+                }
+            }
+
+            /// No key set → a clear error, and crucially NO network/socket touched
+            /// (the client is never even built). This is the default-CI path.
+            #[test]
+            fn from_env_errors_without_key() {
+                let _g = ENV_LOCK.lock().unwrap();
+                clear_env();
+                // RemoteEmbedder isn't Debug, so unwrap the Result by hand rather than
+                // `expect_err`.
+                let err = match RemoteEmbedder::from_env(8) {
+                    Ok(_) => panic!("missing key must be an error"),
+                    Err(e) => e,
+                };
+                assert!(
+                    err.contains("SPARQ_EMBEDDINGS_API_KEY"),
+                    "error names the missing var, got: {err}"
+                );
+            }
+
+            /// Key only → defaults for endpoint + model; `dim` is honored.
+            #[test]
+            fn from_env_uses_defaults_for_base_url_and_model() {
+                let _g = ENV_LOCK.lock().unwrap();
+                clear_env();
+                std::env::set_var("SPARQ_EMBEDDINGS_API_KEY", "sk-test");
+                let e = RemoteEmbedder::from_env(1536).expect("builds with just a key");
+                assert_eq!(e.dim(), 1536);
+                assert_eq!(e.cfg.endpoint, DEFAULT_ENDPOINT);
+                assert_eq!(e.cfg.model, DEFAULT_MODEL);
+                assert_eq!(e.cfg.api_key.as_deref(), Some("sk-test"));
+                clear_env();
+            }
+
+            /// All three env vars set → all three are read (point at a self-hosted
+            /// OpenAI-compatible server).
+            #[test]
+            fn from_env_reads_base_url_and_model_overrides() {
+                let _g = ENV_LOCK.lock().unwrap();
+                clear_env();
+                std::env::set_var("SPARQ_EMBEDDINGS_API_KEY", "sk-x");
+                std::env::set_var("SPARQ_EMBEDDINGS_BASE_URL", "http://localhost:8080/v1/embeddings");
+                std::env::set_var("SPARQ_EMBEDDINGS_MODEL", "bge-small");
+                let e = RemoteEmbedder::from_env(384).expect("builds with overrides");
+                assert_eq!(e.cfg.endpoint, "http://localhost:8080/v1/embeddings");
+                assert_eq!(e.cfg.model, "bge-small");
+                assert_eq!(e.dim(), 384);
+                clear_env();
+            }
+
+            /// LIVE network test — opt-in only. `#[ignore]` by default (mirrors
+            /// `sparq-nlq`'s live-model test), and additionally a no-op unless
+            /// `SPARQ_EMBEDDINGS_API_KEY` is set, so it never hits the network in CI
+            /// even if explicitly un-ignored. Run with:
+            ///   `SPARQ_EMBEDDINGS_API_KEY=… cargo test -p sparq-vectors \
+            ///       --features embeddings -- --ignored embeddings_live`
+            #[test]
+            #[ignore = "hits a live /v1/embeddings endpoint; needs SPARQ_EMBEDDINGS_API_KEY"]
+            fn embeddings_live_round_trip() {
+                if std::env::var("SPARQ_EMBEDDINGS_API_KEY").is_err() {
+                    eprintln!("skipping: SPARQ_EMBEDDINGS_API_KEY not set");
+                    return;
+                }
+                // Dimension of OpenAI text-embedding-3-small; override the model/dim
+                // via env if you point at a different server.
+                let dim = std::env::var("SPARQ_EMBEDDINGS_DIM")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(1536usize);
+                let e = RemoteEmbedder::from_env(dim).expect("from_env");
+                let vecs = e
+                    .embed(&["the quick brown fox", "a slow green turtle"])
+                    .expect("live embed call");
+                assert_eq!(vecs.len(), 2);
+                assert!(vecs.iter().all(|v| v.len() == dim));
+                assert!(vecs.iter().all(|v| v.iter().any(|x| *x != 0.0)));
+            }
+        }
+    }
+
     impl<T: Transport> Embedder for RemoteEmbedder<T> {
         fn dim(&self) -> usize {
             self.cfg.dim

--- a/crates/sparq-vectors/src/embed.rs
+++ b/crates/sparq-vectors/src/embed.rs
@@ -257,17 +257,64 @@ pub mod provider {
             use super::super::Embedder; // RemoteEmbedder::dim is from the Embedder trait
             use super::*;
 
-            // Env vars are process-global; serialize the tests that mutate them so
-            // they don't race when the binary runs them in parallel.
+            // Env vars are process-global; serialize every test that reads OR mutates
+            // them so they don't race when the binary runs them in parallel.
             static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-            fn clear_env() {
-                for k in [
-                    "SPARQ_EMBEDDINGS_API_KEY",
-                    "SPARQ_EMBEDDINGS_BASE_URL",
-                    "SPARQ_EMBEDDINGS_MODEL",
-                ] {
-                    std::env::remove_var(k);
+            // [OPUS-4.8] The full set of SPARQ_EMBEDDINGS_* vars any test in this
+            // module reads or writes — the guard snapshots/restores exactly these.
+            const ENV_VARS: [&str; 4] = [
+                "SPARQ_EMBEDDINGS_API_KEY",
+                "SPARQ_EMBEDDINGS_BASE_URL",
+                "SPARQ_EMBEDDINGS_MODEL",
+                "SPARQ_EMBEDDINGS_DIM",
+            ];
+
+            /// [OPUS-4.8] RAII env guard: on construction it takes [`ENV_LOCK`] (so all
+            /// env-touching tests are serialized — including the live round-trip, which
+            /// only *reads* the vars) and snapshots the current value of every
+            /// [`ENV_VARS`] entry; on drop it restores each to exactly what it was —
+            /// re-`set_var` if it had a value, `remove_var` if it was unset. Restore
+            /// runs on the unwinding path too, so a panicking test never leaks mutated
+            /// (or removed) `SPARQ_EMBEDDINGS_*` state into the rest of the process or a
+            /// developer's shell. Replaces the old destructive `clear_env()` helper that
+            /// wiped pre-existing values without restoring them.
+            struct EnvGuard {
+                _lock: std::sync::MutexGuard<'static, ()>,
+                saved: Vec<(&'static str, Option<String>)>,
+            }
+
+            impl EnvGuard {
+                /// Acquire the lock + snapshot. Does NOT mutate the environment — call
+                /// [`EnvGuard::clear`] for the cleared-state unit tests; the live test
+                /// keeps the user-set opt-in vars and just relies on the lock + restore.
+                fn acquire() -> EnvGuard {
+                    // `.unwrap_or_else(|e| e.into_inner())` so a panic in a prior test
+                    // (which poisons the mutex) doesn't cascade-fail every other one;
+                    // we still serialize and the restore-on-drop keeps state clean.
+                    let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+                    let saved =
+                        ENV_VARS.iter().map(|&k| (k, std::env::var(k).ok())).collect();
+                    EnvGuard { _lock: lock, saved }
+                }
+
+                /// Remove every `SPARQ_EMBEDDINGS_*` var, for tests that need a known
+                /// empty starting point. The originals are still restored on drop.
+                fn clear(&self) {
+                    for &k in &ENV_VARS {
+                        std::env::remove_var(k);
+                    }
+                }
+            }
+
+            impl Drop for EnvGuard {
+                fn drop(&mut self) {
+                    for (k, v) in &self.saved {
+                        match v {
+                            Some(val) => std::env::set_var(k, val),
+                            None => std::env::remove_var(k),
+                        }
+                    }
                 }
             }
 
@@ -275,8 +322,8 @@ pub mod provider {
             /// (the client is never even built). This is the default-CI path.
             #[test]
             fn from_env_errors_without_key() {
-                let _g = ENV_LOCK.lock().unwrap();
-                clear_env();
+                let g = EnvGuard::acquire();
+                g.clear();
                 // RemoteEmbedder isn't Debug, so unwrap the Result by hand rather than
                 // `expect_err`.
                 let err = match RemoteEmbedder::from_env(8) {
@@ -292,23 +339,22 @@ pub mod provider {
             /// Key only → defaults for endpoint + model; `dim` is honored.
             #[test]
             fn from_env_uses_defaults_for_base_url_and_model() {
-                let _g = ENV_LOCK.lock().unwrap();
-                clear_env();
+                let g = EnvGuard::acquire();
+                g.clear();
                 std::env::set_var("SPARQ_EMBEDDINGS_API_KEY", "sk-test");
                 let e = RemoteEmbedder::from_env(1536).expect("builds with just a key");
                 assert_eq!(e.dim(), 1536);
                 assert_eq!(e.cfg.endpoint, DEFAULT_ENDPOINT);
                 assert_eq!(e.cfg.model, DEFAULT_MODEL);
                 assert_eq!(e.cfg.api_key.as_deref(), Some("sk-test"));
-                clear_env();
             }
 
             /// All three env vars set → all three are read (point at a self-hosted
             /// OpenAI-compatible server).
             #[test]
             fn from_env_reads_base_url_and_model_overrides() {
-                let _g = ENV_LOCK.lock().unwrap();
-                clear_env();
+                let g = EnvGuard::acquire();
+                g.clear();
                 std::env::set_var("SPARQ_EMBEDDINGS_API_KEY", "sk-x");
                 std::env::set_var("SPARQ_EMBEDDINGS_BASE_URL", "http://localhost:8080/v1/embeddings");
                 std::env::set_var("SPARQ_EMBEDDINGS_MODEL", "bge-small");
@@ -316,7 +362,6 @@ pub mod provider {
                 assert_eq!(e.cfg.endpoint, "http://localhost:8080/v1/embeddings");
                 assert_eq!(e.cfg.model, "bge-small");
                 assert_eq!(e.dim(), 384);
-                clear_env();
             }
 
             /// LIVE network test — opt-in only. `#[ignore]` by default (mirrors
@@ -328,6 +373,10 @@ pub mod provider {
             #[test]
             #[ignore = "hits a live /v1/embeddings endpoint; needs SPARQ_EMBEDDINGS_API_KEY"]
             fn embeddings_live_round_trip() {
+                // [OPUS-4.8] Take ENV_LOCK (via the guard) so this serializes against
+                // the env-parsing unit tests when run together under `--ignored`; do NOT
+                // `clear()`, the user-set SPARQ_EMBEDDINGS_* opt-in vars are the input.
+                let _g = EnvGuard::acquire();
                 if std::env::var("SPARQ_EMBEDDINGS_API_KEY").is_err() {
                     eprintln!("skipping: SPARQ_EMBEDDINGS_API_KEY not set");
                     return;

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -243,10 +243,19 @@ let store2 = VectorStore::open_from_bytes(bytes)?;           // identical valida
 - **`HashEmbedder` is TEST-ONLY.** It is lexical n-gram hashing with **no semantics**
   ("car" and "automobile" are unrelated). Use it to exercise the store/ANN/pipeline; bring
   a real `Embedder` for actual retrieval.
-- **`provider` feature** for a live OpenAI-compatible `/v1/embeddings` endpoint: it builds
-  the request body and parses the response but **never opens a socket** — you supply a
-  `Transport` impl over your HTTP client (reqwest/ureq/recorded cassette). `cargo build -p
-  sparq-vectors --features provider`.
+- **Live embeddings — two opt-in tiers, default build is socket-free.** For a real
+  OpenAI-compatible `/v1/embeddings` endpoint:
+  - **`provider`** (non-default) carries the API shape only — it builds the request body and
+    parses the response but **never opens a socket**; you supply a `Transport` impl over your
+    HTTP client (reqwest/ureq/recorded cassette). `cargo build -p sparq-vectors --features provider`.
+  - **`embeddings`** (non-default; enables `provider` + a blocking reqwest `Transport`) needs
+    **no caller glue**: `RemoteEmbedder::from_env(dim)` reads `SPARQ_EMBEDDINGS_API_KEY`
+    (required), `SPARQ_EMBEDDINGS_BASE_URL` (default `https://api.openai.com/v1/embeddings`),
+    and `SPARQ_EMBEDDINGS_MODEL` (default `text-embedding-3-small`), then `embed_entities`
+    works against the live endpoint. Mirrors `sparq-nlq`'s `live` feature; requests carry a
+    hard timeout. `cargo build -p sparq-vectors --features embeddings`.
+  The **default build pulls no HTTP client** (no reqwest) and the crate never enters the wasm
+  bundle, so neither tier affects the default or wasm builds.
 - **Keys are dictionary term ids** (`sparq_core::dict::Id`, a `u32`). Resolve a `Term` with
   `graph.id_of(&term) -> Option<Id>` and an `Id` back with `graph.dict.term(id)`. Coverage
   is **sparse by design** — only entities get vectors, not every literal.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Closes **sq-fg9y**.

## Problem
The only shipped `Embedder` in `sparq-vectors` is the test-only `HashEmbedder`. The existing `provider` feature has the OpenAI-compatible `RemoteEmbedder` API shape but forces every caller to implement `Transport` themselves — so the crate is **unusable for real retrieval out of the box**.

## What this ships
A non-default **`embeddings`** cargo feature (`= ["provider", "dep:reqwest"]`) that provides, behind the feature gate:

- **`ReqwestTransport`** — a concrete blocking [`reqwest`] `Transport` impl: rustls-tls, a hard 120s per-request timeout, and status→error mapping that surfaces the provider's `error.message`.
- **`RemoteEmbedder::<ReqwestTransport>::from_env(dim)`** — builds a live embedder entirely from the environment:
  - `SPARQ_EMBEDDINGS_API_KEY` (**required**) → `Authorization: Bearer …`
  - `SPARQ_EMBEDDINGS_BASE_URL` (optional) → endpoint, default `https://api.openai.com/v1/embeddings`
  - `SPARQ_EMBEDDINGS_MODEL` (optional) → model, default `text-embedding-3-small`

  so `embed_entities` / `embed_labels` work against a real `/v1/embeddings` endpoint with **no caller glue**. Point `SPARQ_EMBEDDINGS_BASE_URL` at any OpenAI-compatible server.

## Design — mirrors `sparq-nlq`'s `live` feature
Same pattern as `crates/sparq-nlq/src/live.rs` (`AnthropicLlm`): blocking `reqwest` (no async runtime dragged into the tree), `default-features = false` + `["blocking","json","rustls-tls"]`, key/base-url/model from env, a hard request timeout, and error mapping. It reuses the crate's existing `provider` request-building / response-ordering logic (out-of-order `index` handling, dim + finiteness checks) — `ReqwestTransport` only does the HTTP.

## Socket-free default + wasm-clean guarantee
- The **default build pulls no HTTP client** — `reqwest` is only in the `embeddings` feature. `cargo tree -p sparq-vectors` (default) shows no `reqwest`/`hyper`/`tokio`; it appears only under `--features embeddings`.
- `sparq-wasm` does **not** depend on `sparq-vectors` at all, and `reqwest` is not in any default feature set, so it **cannot enter the wasm bundle**. `cargo tree -p sparq-wasm` shows neither `sparq-vectors` nor `reqwest`.

## Tests
- **Offline (run in CI):** env-parsing unit tests — missing key → error naming the var; key-only → endpoint/model defaults; all three vars → overrides honored. No network.
- **Live (opt-in):** a `/v1/embeddings` round-trip test, `#[ignore]` by default (like nlq's live-model test) **and** a no-op unless `SPARQ_EMBEDDINGS_API_KEY` is set, so it never touches the network in CI.

## Gate
- `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings` clean — built **with and without** `embeddings`.
- `cargo test -p sparq-vectors` green (incl. `--features embeddings --lib`/`--doc`); live test ignored.
- Default build socket-free; wasm unaffected. No ratchet regressions.

## Docs
- `crates/sparq-vectors/README.md` — new "Live embeddings (opt-in)" section + feature bullet.
- `skills/vector-search/SKILL.md` — `provider` vs `embeddings` two-tier gotcha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)