### PR TITLE
feat(sparq-mpc): MPC benchmark matrix (security × N × query class) — in-process counting tier [sq-sxm]

### DIFF
--- a/crates/sparq-mpc/PLAN.md
+++ b/crates/sparq-mpc/PLAN.md
@@ -273,10 +273,25 @@ join/aggregation reasoning out of the cryptographic core wherever values are
 disclosed (architecture §4.3 step 3).
 
 ### M6 — Performance + benchmarks
-Measure the *viable* regime only (honest-majority, LAN, small data). Per
-disk-space + empirical-honesty discipline: check `df` during runs, cap dataset
-size, clean `/tmp` scratch, bench data git-ignored. Report real envelopes —
-minutes, not "seconds" — and never extrapolate to the WAN/dishonest-majority
+**Tier-1 (in-process counting) DELIVERED (sq-sxm):** the
+(security model × N × query class) benchmark matrix is built — `src/metrics.rs`
+(the deterministic communication / round / multiplication counter `CommCounter`)
++ `src/bench.rs` (the matrix harness: query classes × N ∈ {2,3,5,7} × the ACTUAL
+per-operator security read off `ShamirBackend::operator_descriptor`) + the
+runnable `examples/mpc_bench_matrix.rs`. Because the crate is an in-process
+simulation, the load-bearing metric is the **deterministic modelled
+communication** (bytes/party, rounds, multiplications) — NOT a single-process
+wall-clock, which is not an MPC latency. Each cost cell co-runs the real
+primitive so correctness gates cost. The harness emits the numbers (a structured
+JSON schema + a table); per the no-hard-coded-perf rule they are not baked into
+any doc.
+
+**Network tiers (still open, beaded):** the real multi-process transport +
+`tc`/`netem` LAN/WAN emulation (Tier 2/3) is **bead sq-tg6b**; the EC2 scale-out
+(heavy data scales, real inter-AZ/region) is **bead sq-hoaj**. Those tiers obey
+the disk-space + empirical-honesty discipline: check `df` during runs, cap
+dataset size, clean `/tmp` scratch, bench data git-ignored. Report real envelopes
+— minutes, not "seconds" — and never extrapolate to the WAN/dishonest-majority
 regime that has zero published data points.
 
 ---

--- a/crates/sparq-mpc/examples/mpc_bench_matrix.rs
+++ b/crates/sparq-mpc/examples/mpc_bench_matrix.rs
@@ -1,0 +1,94 @@
+// [OPUS-4.8] sq-sxm — runnable harness for the (security model × N × query class)
+// MPC benchmark matrix, IN-PROCESS counting tier (Tier 1). Emits the deterministic
+// modelled communication (bytes/party, rounds, multiplications) + the per-cell
+// ACTUAL security guarantee, as both a human table and the structured JSON schema.
+//
+// Run (the seeded RNG for the correctness gates needs the insecure-test-rng
+// feature — OFF by default; it only makes the SIMULATION reproducible, never a
+// production claim):
+//
+//   cargo run -p sparq-mpc --example mpc_bench_matrix --features insecure-test-rng
+//   cargo run -p sparq-mpc --example mpc_bench_matrix --features insecure-test-rng -- --json
+//
+// HONESTY: this is the single-process counting tier. The numbers are MODELLED
+// communication, not measured network cost; a single-process wall-clock is NOT an
+// MPC latency. The real multi-process transport + tc/netem LAN/WAN emulation is a
+// SEPARATE bead (sq-tg6b); EC2 scale-out is sq-hoaj.
+//
+// The feature gate means a default build of this example only prints the cost
+// matrix (which needs no RNG) and SKIPS the correctness gates with a clear note,
+// so it still compiles + runs without the feature.
+
+use sparq_mpc::bench::{run_matrix, DEFAULT_PARTIES};
+
+fn main() {
+    // Cap the scales SMALL — this is the in-process counting tier (watch df; the
+    // heavy scale-out is the EC2 bead sq-hoaj). The hidden join is scale² pairs.
+    let join_scale = 6; // 36 equality tests/cell at the largest
+    let shuffle_scale = 16; // oblivious networks over 16 rows
+
+    let results = run_matrix(DEFAULT_PARTIES, join_scale, shuffle_scale)
+        .expect("matrix runs over the default party counts");
+
+    let json_only = std::env::args().any(|a| a == "--json");
+    if json_only {
+        print!("{}", results.to_json());
+        return;
+    }
+
+    print!("{}", results.to_table());
+    println!();
+
+    // The correctness gates RUN THE REAL PRIMITIVES so a fast-but-wrong cost cell
+    // is caught (design record §5.4). They need the seedable simulation RNG.
+    #[cfg(feature = "insecure-test-rng")]
+    run_correctness_gates(join_scale, shuffle_scale);
+    #[cfg(not(feature = "insecure-test-rng"))]
+    println!(
+        "(correctness gates skipped: re-run with --features insecure-test-rng to \
+         co-verify the real primitives reproducibly)"
+    );
+
+    println!();
+    println!("--- JSON schema (structured results; consume this, not the table) ---");
+    print!("{}", results.to_json());
+}
+
+#[cfg(feature = "insecure-test-rng")]
+fn run_correctness_gates(join_scale: usize, shuffle_scale: usize) {
+    use sparq_mpc::bench::{check_aggregate, check_hidden_join, check_shuffle, check_sort};
+    use sparq_mpc::ShamirBackend;
+
+    println!("--- correctness gates (real primitives co-run; deterministic seed) ---");
+    for &n in DEFAULT_PARTIES {
+        // Fixed seed ⇒ reproducible simulation masks (NEVER a production claim;
+        // that is exactly what the insecure-test-rng feature name warns about).
+        let backend = ShamirBackend::new_seeded(n, 0x5347_5851_4D50_4331).expect("seeded backend");
+        // Aggregate: sum of n distinct values reconstructs to the plaintext sum.
+        let values: Vec<u64> = (0..n as u64).map(|i| 1000 * (i + 1)).collect();
+        let expected: u64 = values.iter().sum();
+        let got = check_aggregate(&backend, &values).expect("aggregate runs");
+        assert_eq!(got, expected, "n={n}: secure sum must equal plaintext sum");
+
+        // Hidden join: scale matching rows on both sides ⇒ scale joined rows.
+        let joined = check_hidden_join(&backend, join_scale).expect("join runs");
+        assert_eq!(
+            joined, join_scale,
+            "n={n}: hidden join must find all matches"
+        );
+
+        // Oblivious shuffle/sort over the same backend's dealer.
+        let mut dealer = backend.dealer();
+        let t = backend.threshold();
+        assert!(
+            check_shuffle(&mut dealer, t, shuffle_scale).expect("shuffle runs"),
+            "n={n}: shuffle must preserve the multiset"
+        );
+        assert!(
+            check_sort(&mut dealer, t, shuffle_scale).expect("sort runs"),
+            "n={n}: sort must produce an ascending permutation"
+        );
+        println!("  n={n}: aggregate=OK join={joined}/{join_scale} shuffle=OK sort=OK");
+    }
+    println!("all correctness gates passed.");
+}

--- a/crates/sparq-mpc/src/bench.rs
+++ b/crates/sparq-mpc/src/bench.rs
@@ -559,8 +559,10 @@ pub fn cell(query_class: QueryClass, n: usize, scale: usize) -> Result<MatrixCel
 /// scale-out is the EC2 bead sq-hoaj). The hidden join uses `scale²` equalities,
 /// so its scale is deliberately the smallest.
 ///
-/// `aggregate_scale` is unused for the aggregate (where `N` is the scale, recorded
-/// as scale `1`); `join_scale` / `shuffle_scale` cap the join and oblivious cells.
+/// The aggregate takes NO scale parameter — `N` itself is its scale dimension
+/// (each party deals one secret), so it is always recorded at `scale = 1`.
+/// `join_scale` caps the hidden-value join's rows/holder and `shuffle_scale` caps
+/// the oblivious shuffle/sort cells.
 pub fn run_matrix(
     party_counts: &[usize],
     join_scale: usize,
@@ -665,9 +667,10 @@ mod tests {
 
     #[test]
     fn aggregate_bytes_per_party_grows_with_n() {
-        // The aggregate's total shared field elements = n² (n deals × n parties),
-        // so bytes-per-party = n²·8 / n = n·8 — grows LINEARLY with N, exactly as
-        // the protocol predicts (each added holder deals one more secret).
+        // The aggregate's wire field elements = n² shared (n deals × n parties) +
+        // the single open broadcast as n shares = n² + n, so bytes-per-party =
+        // (n² + n)·8 / n = (n + 1)·8 — grows LINEARLY with N, exactly as the
+        // protocol predicts (each added holder deals one more secret).
         let mut prev = 0u64;
         for &n in DEFAULT_PARTIES {
             let c = cell(QueryClass::CumulativeSumAggregate, n, 1).unwrap();
@@ -676,7 +679,8 @@ mod tests {
                 bpp > prev,
                 "n={n}: bytes/party must grow with N (got {bpp}, prev {prev})"
             );
-            // bytes/party = n·FIELD_BYTES (n² shared / n parties × 8, +1 open/n).
+            // bytes/party = (n + 1)·FIELD_BYTES: (n² shared + n open) / n parties × 8.
+            assert_eq!(bpp, (n as u64 + 1) * crate::metrics::FIELD_BYTES as u64);
             prev = bpp;
         }
     }

--- a/crates/sparq-mpc/src/bench.rs
+++ b/crates/sparq-mpc/src/bench.rs
@@ -1,0 +1,719 @@
+// [OPUS-4.8] sq-sxm — the (security model × N × query class) benchmark MATRIX,
+// in-process counting tier (Tier 1). New module: the harness that drives the
+// representative MPC operations across N and the security models and emits, per
+// cell, the modelled communication (bytes/party, rounds, multiplications) PLUS
+// the per-cell security guarantee read off the real backend's per-operator
+// descriptor — never a requested model, the ACTUAL one (design record §5.1).
+//
+// This is the in-process COUNTING tier. The real network transport + tc/netem
+// LAN/WAN emulation is a SEPARATE bead (sq-tg6b, Tier 2/3); the EC2 scale-out is
+// sq-hoaj. Per the critical-honesty constraint (design record §5): a single-
+// process wall-clock is NOT an MPC latency — the load-bearing metric here is the
+// DETERMINISTIC modelled communication ([`crate::metrics::CommCounter`]), and the
+// emitted schema is labelled accordingly.
+//! The (security model × N × query class) MPC benchmark matrix — in-process
+//! counting tier.
+//!
+//! ## What this measures (and what it deliberately does not)
+//!
+//! The crate is a single-process multi-party SIMULATION, so wall-clock is not a
+//! meaningful cross-`N` MPC cost (design record §5). The harness instead emits the
+//! **deterministic modelled communication** per matrix cell:
+//! `bytes_per_party`, `round_count` (sequential upper bound + batched lower
+//! bound), and `multiplications` — counted analytically from the protocol
+//! structure via [`crate::metrics::CommCounter`], reproducible run-to-run.
+//!
+//! Every cost cell co-runs the REAL primitive (the cumulative-sum aggregate, the
+//! hidden-value equality join, the oblivious shuffle/sort) so a fast-but-wrong
+//! cell is caught — correctness gates cost (design record §5.4). The cost itself
+//! is the modelled count, NOT the simulation's wall-clock.
+//!
+//! ## The matrix axes (design record §5.1)
+//!
+//! - **AXIS 1 — security model:** the ACTUAL guarantee reachable at this `(n, t)`
+//!   for this operator class, read from
+//!   [`crate::shamir::ShamirBackend::operator_descriptor`] — never a requested
+//!   one. The degree-`t` aggregate carries RS redundancy (robust for most `n`);
+//!   the degree-`2t` equality/join open is **semi-honest-only at `n = 2t+1`** (odd
+//!   `n`, zero redundancy). So the security axis is a *function of `(n, primitive,
+//!   t)`*, recorded per cell — see [`CellSecurity`].
+//! - **AXIS 2 — number of parties `N`:** `{2, 3, 5, 7}` (the bead's set), with
+//!   `t = ⌊(n−1)/2⌋`. Even `N` (here 2) exercises the abort-vs-robust boundary at
+//!   degree `2t`; odd `N` the semi-honest-only equality boundary.
+//! - **AXIS 3 — query class:** the representative operations —
+//!   [`QueryClass::CumulativeSumAggregate`] (the £100k case — zero-round linear
+//!   baseline), [`QueryClass::HiddenValueEquiJoin`] (the cost center —
+//!   `|L|·|R|` equalities), and the oblivious
+//!   [`QueryClass::ObliviousShuffle`] / [`QueryClass::ObliviousSort`] substrate.
+//!
+//! ## Output schema
+//!
+//! [`MatrixResults`] is the structured result the harness emits (one
+//! [`MatrixCell`] per axis combination). It serialises to a stable JSON shape
+//! (hand-written, no `serde` dependency — the crate stays dependency-minimal) via
+//! [`MatrixResults::to_json`], so downstream tooling consumes the generated data
+//! rather than any hard-coded figure. The example binary
+//! (`examples/mpc_bench_matrix.rs`) prints both the JSON and a human table.
+
+use crate::backend::{MaliciousSecurity, OperatorClass, TrustModel};
+use crate::field::Fp;
+use crate::join::{HiddenKeyedRows, HiddenValueJoin};
+use crate::metrics::CommCounter;
+use crate::oblivious::{shuffle, sort_with_keys, SecretColumn};
+use crate::partial::{HolderId, MpcError};
+use crate::shamir::{ShamirBackend, ShamirDealer};
+
+/// The representative SPARQL/MPC operation a matrix row benchmarks (AXIS 3).
+/// Each maps to a real primitive in the crate so correctness co-gates the cost.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryClass {
+    /// **Cumulative-SUM aggregate** (the £100k case): each holder secret-shares
+    /// one private integer; the secure sum is a FREE local share-addition
+    /// (zero-round linear), then ONE open. The zero-multiplication baseline.
+    /// Operator class [`OperatorClass::LinearAggregate`] (degree-`t` open).
+    CumulativeSumAggregate,
+    /// **Hidden-value equi-join** on a PRIVATE key: the all-pairs `|L|·|R|`
+    /// secret-shared equality tests — the cost center (`|L|·|R|` opens + mults).
+    /// Operator class [`OperatorClass::EqualityJoin`] (degree-`2t` open).
+    HiddenValueEquiJoin,
+    /// **Oblivious shuffle** (AS-Waksman network): the keystone hidden-regime
+    /// primitive; 1 multiplication per switch (secret control bits) in
+    /// `O(log n)` depth. No degree-`2t` open ⇒ reported under the shuffle's own
+    /// soundness, not the equality class.
+    ObliviousShuffle,
+    /// **Oblivious sort** (Batcher odd-even mergesort): the obliviousness
+    /// substrate; `O(n log² n)` compare-exchanges in `O(log² n)` depth.
+    ObliviousSort,
+}
+
+impl QueryClass {
+    /// Stable identifier for the JSON schema / table.
+    pub fn id(self) -> &'static str {
+        match self {
+            QueryClass::CumulativeSumAggregate => "cumulative_sum_aggregate",
+            QueryClass::HiddenValueEquiJoin => "hidden_value_equi_join",
+            QueryClass::ObliviousShuffle => "oblivious_shuffle",
+            QueryClass::ObliviousSort => "oblivious_sort",
+        }
+    }
+
+    /// The [`OperatorClass`] whose per-operator security descriptor governs this
+    /// query class's reconstruction guarantee. Shuffle/sort do not perform a
+    /// degree-`2t` equality open, but their conditional-swap / comparator products
+    /// are degree-raising like the equality join, so they share its operator class
+    /// for the security-axis read-off (the honest reduction the design record
+    /// makes: the secret-control swap and the secure comparator are the same
+    /// degree-`2t` regime as the equality test).
+    pub fn operator_class(self) -> OperatorClass {
+        match self {
+            QueryClass::CumulativeSumAggregate => OperatorClass::LinearAggregate,
+            QueryClass::HiddenValueEquiJoin
+            | QueryClass::ObliviousShuffle
+            | QueryClass::ObliviousSort => OperatorClass::EqualityJoin,
+        }
+    }
+}
+
+/// The per-cell security guarantee, read from the REAL backend's per-operator
+/// descriptor at this `(n, t)` — the ACTUAL guarantee, never a requested one
+/// (design record §5.1). This is what makes the "security model" axis honest:
+/// e.g. the degree-`2t` equality open is [`MaliciousSecurity::SemiHonestOnly`] at
+/// `n = 2t+1` even though the degree-`t` aggregate is robust at the same `n`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CellSecurity {
+    /// The trust regime (honest- vs dishonest-majority) at this `(n, t)`.
+    pub trust_model: TrustModel,
+    /// The malicious-security guarantee for THIS operator at this `(n, t)`. The
+    /// load-bearing per-cell honesty field.
+    pub malicious_security: MaliciousSecurity,
+}
+
+impl CellSecurity {
+    /// Read the actual guarantee for `operator` off `backend` at its `(n, t)`.
+    pub fn read(backend: &ShamirBackend, operator: OperatorClass) -> Self {
+        let desc = backend.operator_descriptor(operator);
+        // The RS correction budget at this operator's reconstruction degree is what
+        // distinguishes robust-{e} from abort from semi-honest-only; recover it the
+        // same way `BackendInfo::new` does so the projection is faithful.
+        let e = match operator {
+            OperatorClass::LinearAggregate => rs_budget(backend.parties(), backend.threshold()),
+            OperatorClass::EqualityJoin => rs_budget(backend.parties(), 2 * backend.threshold()),
+            OperatorClass::Comparison => 0,
+        };
+        CellSecurity {
+            trust_model: desc.trust_model(),
+            malicious_security: desc.malicious_security(e),
+        }
+    }
+
+    /// Stable string for the JSON schema / table.
+    pub fn label(self) -> String {
+        let trust = match self.trust_model {
+            TrustModel::HonestMajority => "honest-majority",
+            TrustModel::DishonestMajority => "dishonest-majority",
+        };
+        let mal = match self.malicious_security {
+            MaliciousSecurity::SemiHonestOnly => "semi-honest-only".to_string(),
+            MaliciousSecurity::HonestMajorityAbort => "abort".to_string(),
+            MaliciousSecurity::HonestMajorityRobust { max_cheaters } => {
+                format!("robust(e={max_cheaters})")
+            }
+        };
+        format!("{trust}/{mal}")
+    }
+}
+
+/// RS/Berlekamp–Welch correction budget `e = ⌊(n − degree − 1)/2⌋` at a given
+/// reconstruction `degree`, or `0` when there is no redundancy (`n <= degree+1`).
+/// Mirrors `ShamirBackend::rs_correction_budget` (which is private), kept local so
+/// the harness does not reach into the backend's internals. `[OPUS-4.8]`
+fn rs_budget(n: usize, degree: usize) -> usize {
+    if n <= degree + 1 {
+        0
+    } else {
+        (n - degree - 1) / 2
+    }
+}
+
+/// One matrix cell: (query class × N × actual security) with its modelled cost.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MatrixCell {
+    /// AXIS 3.
+    pub query_class: QueryClass,
+    /// AXIS 2: number of compute parties.
+    pub parties: usize,
+    /// `t = ⌊(n−1)/2⌋`.
+    pub threshold: usize,
+    /// The data scale this cell ran (rows/holder for joins; party count for the
+    /// aggregate, where `N` itself is the scale). `1` for the aggregate.
+    pub scale: usize,
+    /// AXIS 1: the ACTUAL per-operator security at this `(n, t)`.
+    pub security: CellSecurity,
+    /// The deterministic modelled communication for this cell.
+    pub comm: CommCounter,
+}
+
+impl MatrixCell {
+    /// Modelled bytes per party (the cross-`N`-comparable on-wire cost).
+    pub fn bytes_per_party(self) -> u64 {
+        self.comm.bytes_per_party()
+    }
+    /// Sequential round count (upper bound).
+    pub fn rounds_sequential(self) -> u64 {
+        self.comm.total_rounds()
+    }
+    /// Batched round count (lower bound, independent ops collapsed).
+    pub fn rounds_batched(self) -> u64 {
+        self.comm.batched_rounds()
+    }
+    /// Secure multiplications.
+    pub fn multiplications(self) -> u64 {
+        self.comm.multiplications
+    }
+}
+
+/// The full matrix result: every cell, plus the axis definitions. Serialises to a
+/// stable JSON shape (no `serde`; hand-written) so downstream tooling reads the
+/// GENERATED numbers — never a hard-coded figure (AGENTS.md: no baked-in perf).
+#[derive(Debug, Clone)]
+pub struct MatrixResults {
+    /// The party counts (AXIS 2) the matrix swept.
+    pub party_counts: Vec<usize>,
+    /// One cell per (query class × N × scale) combination.
+    pub cells: Vec<MatrixCell>,
+}
+
+impl MatrixResults {
+    /// Serialise the matrix to a stable, dependency-free JSON string. The schema:
+    /// ```json
+    /// {
+    ///   "tier": "in-process-counting",
+    ///   "note": "single-process simulation; network cost MODELLED not measured",
+    ///   "field_bytes": 8,
+    ///   "party_counts": [2,3,5,7],
+    ///   "cells": [
+    ///     {"query_class": "...", "parties": N, "threshold": t, "scale": s,
+    ///      "security": "honest-majority/semi-honest-only",
+    ///      "trust_model": "...", "malicious_security": "...",
+    ///      "bytes_per_party": B, "total_bytes": TB,
+    ///      "rounds_sequential": R, "rounds_batched": Rb,
+    ///      "multiplications": M, "field_elements_opened": O,
+    ///      "field_elements_shared": S, "offline_bytes": 0}
+    ///   ]
+    /// }
+    /// ```
+    /// `offline_bytes` is explicitly `0` (semi-honest Shamir has no preprocessing)
+    /// so a future SPDZ backend's preprocessing shows up as a regression, not a
+    /// hidden cost (design record §5.2, the Ozdemir-Boneh / ORQ lesson). `[OPUS-4.8]`
+    pub fn to_json(&self) -> String {
+        let mut s = String::new();
+        s.push_str("{\n");
+        s.push_str("  \"tier\": \"in-process-counting\",\n");
+        s.push_str(
+            "  \"note\": \"single-process simulation; network cost MODELLED not measured\",\n",
+        );
+        s.push_str(&format!(
+            "  \"field_bytes\": {},\n",
+            crate::metrics::FIELD_BYTES
+        ));
+        s.push_str("  \"party_counts\": [");
+        for (i, n) in self.party_counts.iter().enumerate() {
+            if i > 0 {
+                s.push_str(", ");
+            }
+            s.push_str(&n.to_string());
+        }
+        s.push_str("],\n");
+        s.push_str("  \"cells\": [\n");
+        for (i, c) in self.cells.iter().enumerate() {
+            let comma = if i + 1 < self.cells.len() { "," } else { "" };
+            s.push_str(&format!(
+                "    {{\"query_class\": \"{}\", \"parties\": {}, \"threshold\": {}, \
+                 \"scale\": {}, \"security\": \"{}\", \"trust_model\": \"{}\", \
+                 \"malicious_security\": \"{}\", \"bytes_per_party\": {}, \
+                 \"total_bytes\": {}, \"rounds_sequential\": {}, \"rounds_batched\": {}, \
+                 \"multiplications\": {}, \"field_elements_opened\": {}, \
+                 \"field_elements_shared\": {}, \"offline_bytes\": 0}}{}\n",
+                c.query_class.id(),
+                c.parties,
+                c.threshold,
+                c.scale,
+                c.security.label(),
+                trust_id(c.security.trust_model),
+                mal_id(c.security.malicious_security),
+                c.bytes_per_party(),
+                c.comm.total_bytes(),
+                c.rounds_sequential(),
+                c.rounds_batched(),
+                c.multiplications(),
+                c.comm.field_elements_opened,
+                c.comm.field_elements_shared,
+                comma,
+            ));
+        }
+        s.push_str("  ]\n}\n");
+        s
+    }
+
+    /// A compact human-readable table for the example binary's stdout.
+    pub fn to_table(&self) -> String {
+        let mut s = String::new();
+        s.push_str(
+            "TIER 1 (in-process counting) — single-process simulation; \
+             network cost MODELLED not measured.\n\n",
+        );
+        s.push_str(&format!(
+            "{:<26} {:>3} {:>3} {:>7} {:>10} {:>9} {:>9} {:>7}  {}\n",
+            "query_class",
+            "N",
+            "t",
+            "scale",
+            "B/party",
+            "rounds",
+            "rnd(bat)",
+            "mults",
+            "security (actual, per-operator)"
+        ));
+        s.push_str(&"-".repeat(110));
+        s.push('\n');
+        for c in &self.cells {
+            s.push_str(&format!(
+                "{:<26} {:>3} {:>3} {:>7} {:>10} {:>9} {:>9} {:>7}  {}\n",
+                c.query_class.id(),
+                c.parties,
+                c.threshold,
+                c.scale,
+                c.bytes_per_party(),
+                c.rounds_sequential(),
+                c.rounds_batched(),
+                c.multiplications(),
+                c.security.label(),
+            ));
+        }
+        s
+    }
+}
+
+fn trust_id(t: TrustModel) -> &'static str {
+    match t {
+        TrustModel::HonestMajority => "honest-majority",
+        TrustModel::DishonestMajority => "dishonest-majority",
+    }
+}
+
+fn mal_id(m: MaliciousSecurity) -> &'static str {
+    match m {
+        MaliciousSecurity::SemiHonestOnly => "semi-honest-only",
+        MaliciousSecurity::HonestMajorityAbort => "honest-majority-abort",
+        MaliciousSecurity::HonestMajorityRobust { .. } => "honest-majority-robust",
+    }
+}
+
+// =============================================================================
+// The cost MODEL per query class (analytic, derived from the protocol structure)
+// =============================================================================
+
+/// Model the cumulative-SUM aggregate over `n` holders: each holder deals one
+/// private integer (`n` deals); the secure sum is a free LOCAL share-addition
+/// (zero multiplications, zero rounds); then ONE open of the result. This is the
+/// zero-round linear baseline — `O(n)` shared field elements, `0` mults, `1` open.
+fn model_aggregate(n: usize) -> CommCounter {
+    let mut c = CommCounter::new(n);
+    for _ in 0..n {
+        c.record_deal();
+    }
+    c.record_open();
+    c
+}
+
+/// Model the hidden-value all-pairs equi-join over `|L| = |R| = scale` rows/holder:
+/// `scale²` mutually-independent secret-shared equality tests, each = 3 deals
+/// (key_L, key_R, mask) + 1 multiplication + 1 open. This is the cost center: the
+/// opens / mults grow as the PRODUCT of the row counts (the round-count explosion
+/// the literature flags).
+fn model_hidden_join(n: usize, scale: usize) -> CommCounter {
+    let mut c = CommCounter::new(n);
+    c.record_independent_equalities((scale * scale) as u64);
+    c
+}
+
+/// Model an oblivious shuffle of `scale` rows: fold in the crate's own
+/// [`crate::oblivious::ShuffleCost`] (1 mult/switch, `O(log n)` depth) — no
+/// degree-`2t` open. We also deal the `scale` column values once (they enter
+/// secret-shared).
+fn model_shuffle(n: usize, scale: usize) -> CommCounter {
+    let mut c = CommCounter::new(n);
+    for _ in 0..scale {
+        c.record_deal();
+    }
+    let net = crate::oblivious::WaksmanNetwork::new(scale);
+    c.record_shuffle(crate::oblivious::ShuffleCost::model(
+        scale,
+        net.switch_count(),
+    ));
+    c
+}
+
+/// Model an oblivious sort of `scale` rows: fold in the crate's own
+/// [`crate::oblivious::SortCost`] (one secure comparison + conditional swap per
+/// compare-exchange, `O(log² n)` depth).
+fn model_sort(n: usize, scale: usize) -> CommCounter {
+    let mut c = CommCounter::new(n);
+    for _ in 0..scale {
+        c.record_deal();
+    }
+    let net = crate::oblivious::SortingNetwork::new(scale);
+    c.record_sort(crate::oblivious::SortCost {
+        items: scale,
+        compare_exchanges: net.gate_count(),
+        depth_rounds: net.depth(),
+    });
+    c
+}
+
+// =============================================================================
+// The CORRECTNESS check per query class (runs the REAL primitive so a fast-but-
+// wrong cost cell is caught). Needs a seeded backend (caller supplies it).
+// =============================================================================
+
+/// Run the REAL cumulative-sum aggregate over `n` holders' private values and
+/// assert it reconstructs the plaintext sum — the correctness gate for the
+/// aggregate cost cell (design record §5.4: differential correctness alongside
+/// every cost cell). Returns the reconstructed sum.
+pub fn check_aggregate(backend: &ShamirBackend, values: &[u64]) -> Result<u64, MpcError> {
+    use crate::backend::MpcBackend;
+    let mut dealer = backend.dealer();
+    // Share each value, sum the sharings (free local add), open.
+    let shares: Vec<Vec<crate::shamir::Share>> =
+        values.iter().map(|&v| dealer.share(Fp::new(v))).collect();
+    let summed = backend.run_secure(&shares)?;
+    let result = backend.reconstruct_disclosed(&summed)?;
+    // The disclosed partial carries the sum as an integer literal in row 0, col 0.
+    let term = result.rows[0][0]
+        .as_ref()
+        .ok_or_else(|| MpcError::Protocol("aggregate result missing".into()))?;
+    match term {
+        oxrdf::Term::Literal(l) => l
+            .value()
+            .parse::<u64>()
+            .map_err(|e| MpcError::Protocol(format!("aggregate not an integer: {e}"))),
+        _ => Err(MpcError::Protocol("aggregate not a literal".into())),
+    }
+}
+
+/// Run the REAL hidden-value join over two holders' `scale`-row tables (keys
+/// `0..scale` on both sides, so exactly `scale` matches) and return the number of
+/// joined rows — the correctness gate for the hidden-join cost cell.
+pub fn check_hidden_join(backend: &ShamirBackend, scale: usize) -> Result<usize, MpcError> {
+    let join = HiddenValueJoin::new(backend.clone());
+    let left = synthetic_table(HolderId::new("left"), scale);
+    let right = synthetic_table(HolderId::new("right"), scale);
+    let out = join.join(&left, &right)?;
+    Ok(out.rows.len())
+}
+
+/// Build a `scale`-row hidden-keyed table with keys `0..scale` and a single
+/// disclosed payload column carrying the row index, for the join correctness gate.
+fn synthetic_table(holder: HolderId, scale: usize) -> HiddenKeyedRows {
+    use oxrdf::{Literal, Term, Variable};
+    let payload_vars = vec![Variable::new_unchecked("v")];
+    let rows = (0..scale)
+        .map(|i| {
+            let key = Fp::new(i as u64);
+            let payload = vec![Some(Term::Literal(Literal::new_simple_literal(
+                i.to_string(),
+            )))];
+            (key, payload)
+        })
+        .collect();
+    HiddenKeyedRows {
+        holder,
+        payload_vars,
+        rows,
+    }
+}
+
+/// Run the REAL oblivious shuffle over `scale` secret-shared rows and assert it
+/// preserves the multiset — the correctness gate for the shuffle cost cell.
+pub fn check_shuffle(dealer: &mut ShamirDealer, t: usize, scale: usize) -> Result<bool, MpcError> {
+    let values: Vec<Fp> = (0..scale).map(|i| Fp::new((i * 7 + 1) as u64)).collect();
+    let col = secret_column(dealer, &values);
+    let (shuffled, _cost) = shuffle(dealer, col)?;
+    let opened = open_column(t, &shuffled);
+    Ok(multiset_eq(&values, &opened))
+}
+
+/// Run the REAL oblivious sort over `scale` secret-shared rows and assert the
+/// opened result is ascending and a permutation of the input — the correctness
+/// gate for the sort cost cell.
+pub fn check_sort(dealer: &mut ShamirDealer, t: usize, scale: usize) -> Result<bool, MpcError> {
+    // Reverse-sorted input so the sort has work to do.
+    let values: Vec<Fp> = (0..scale).map(|i| Fp::new((scale - i) as u64)).collect();
+    let col = secret_column(dealer, &values);
+    let keys: Vec<Fp> = values.clone();
+    let (sorted, _keys_out, _ap, _cost) = sort_with_keys(col, keys)?;
+    let opened = open_column(t, &sorted);
+    let ascending = opened.windows(2).all(|w| w[0].value() <= w[1].value());
+    Ok(ascending && multiset_eq(&values, &opened))
+}
+
+/// Build a secret-shared column from cleartext field values (the dealer shares
+/// each; the harness plays all parties, exactly as the oblivious tests do). A
+/// [`SecretColumn`] is a `Vec` of full Shamir sharings (one per row).
+fn secret_column(dealer: &mut ShamirDealer, values: &[Fp]) -> SecretColumn {
+    values.iter().map(|&v| dealer.share(v)).collect()
+}
+
+/// Open a secret-shared column to its cleartext field values (reconstruct each
+/// row at degree `t`). Used only by the correctness gates.
+fn open_column(t: usize, col: &SecretColumn) -> Vec<Fp> {
+    col.iter()
+        .map(|row| crate::shamir::reconstruct_degree(row, t).expect("reconstruct"))
+        .collect()
+}
+
+fn multiset_eq(a: &[Fp], b: &[Fp]) -> bool {
+    let mut a: Vec<u64> = a.iter().map(|x| x.value()).collect();
+    let mut b: Vec<u64> = b.iter().map(|x| x.value()).collect();
+    a.sort_unstable();
+    b.sort_unstable();
+    a == b
+}
+
+// =============================================================================
+// The MATRIX RUNNER — assemble the cells (cost analytic; correctness gated)
+// =============================================================================
+
+/// The party counts the bead asks for (AXIS 2): `{2, 3, 5, 7}`.
+pub const DEFAULT_PARTIES: &[usize] = &[2, 3, 5, 7];
+
+/// Build ONE matrix cell: read the actual security off the backend, model the
+/// cost analytically, and (for the aggregate / join) record nothing that needs
+/// RNG — the cost is pure structure. The seeded backend is used by the SEPARATE
+/// correctness gates ([`check_aggregate`] etc.), not here.
+pub fn cell(query_class: QueryClass, n: usize, scale: usize) -> Result<MatrixCell, MpcError> {
+    let t = (n - 1) / 2;
+    // Read the ACTUAL per-operator security at this (n, t) off a fresh production
+    // backend (no RNG drawn — `operator_descriptor` is pure). This is the honest
+    // security axis: never a requested model.
+    let backend = ShamirBackend::new(n)?;
+    let security = CellSecurity::read(&backend, query_class.operator_class());
+    let comm = match query_class {
+        QueryClass::CumulativeSumAggregate => model_aggregate(n),
+        QueryClass::HiddenValueEquiJoin => model_hidden_join(n, scale),
+        QueryClass::ObliviousShuffle => model_shuffle(n, scale),
+        QueryClass::ObliviousSort => model_sort(n, scale),
+    };
+    Ok(MatrixCell {
+        query_class,
+        parties: n,
+        threshold: t,
+        scale,
+        security,
+        comm,
+    })
+}
+
+/// Run the full matrix over the given party counts and per-class scales, emitting
+/// every cell. Scales are CAPPED small (the in-process counting tier; the heavy
+/// scale-out is the EC2 bead sq-hoaj). The hidden join uses `scale²` equalities,
+/// so its scale is deliberately the smallest.
+///
+/// `aggregate_scale` is unused for the aggregate (where `N` is the scale, recorded
+/// as scale `1`); `join_scale` / `shuffle_scale` cap the join and oblivious cells.
+pub fn run_matrix(
+    party_counts: &[usize],
+    join_scale: usize,
+    shuffle_scale: usize,
+) -> Result<MatrixResults, MpcError> {
+    let mut cells = Vec::new();
+    for &n in party_counts {
+        // The aggregate runs for every N (N is its scale dimension → scale=1).
+        cells.push(cell(QueryClass::CumulativeSumAggregate, n, 1)?);
+        // The hidden-value join needs n >= 2t+1 for the equality test — always
+        // true at t = ⌊(n−1)/2⌋, so every N is covered.
+        cells.push(cell(QueryClass::HiddenValueEquiJoin, n, join_scale)?);
+        cells.push(cell(QueryClass::ObliviousShuffle, n, shuffle_scale)?);
+        cells.push(cell(QueryClass::ObliviousSort, n, shuffle_scale)?);
+    }
+    Ok(MatrixResults {
+        party_counts: party_counts.to_vec(),
+        cells,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- The matrix builds and is deterministic. ---------------------------
+    #[test]
+    fn matrix_builds_over_all_party_counts() {
+        let r = run_matrix(DEFAULT_PARTIES, 4, 8).unwrap();
+        // 4 query classes × 4 party counts = 16 cells.
+        assert_eq!(r.cells.len(), DEFAULT_PARTIES.len() * 4);
+        // Every party count present.
+        for &n in DEFAULT_PARTIES {
+            assert!(r.cells.iter().any(|c| c.parties == n));
+        }
+    }
+
+    #[test]
+    fn matrix_is_deterministic() {
+        let a = run_matrix(DEFAULT_PARTIES, 4, 8).unwrap();
+        let b = run_matrix(DEFAULT_PARTIES, 4, 8).unwrap();
+        assert_eq!(a.cells, b.cells, "same matrix inputs → identical cells");
+        assert_eq!(a.to_json(), b.to_json());
+    }
+
+    // --- AXIS-1 honesty: the security guarantee is the ACTUAL per-operator one. ---
+    #[test]
+    fn equality_join_is_semi_honest_only_at_n_eq_2t_plus_1() {
+        // Odd N (n = 2t+1) → degree-2t open has ZERO RS redundancy → semi-honest-only.
+        for &n in &[3usize, 5, 7] {
+            let c = cell(QueryClass::HiddenValueEquiJoin, n, 2).unwrap();
+            assert_eq!(
+                c.security.malicious_security,
+                MaliciousSecurity::SemiHonestOnly,
+                "n={n}: equality open at n=2t+1 must be semi-honest-only"
+            );
+            assert_eq!(c.security.trust_model, TrustModel::HonestMajority);
+        }
+    }
+
+    #[test]
+    fn aggregate_is_at_least_abort_for_odd_n_ge_3() {
+        // The degree-t aggregate carries RS redundancy for n >= 3 (odd) → not
+        // semi-honest-only (abort or robust).
+        for &n in &[3usize, 5, 7] {
+            let c = cell(QueryClass::CumulativeSumAggregate, n, 1).unwrap();
+            assert_ne!(
+                c.security.malicious_security,
+                MaliciousSecurity::SemiHonestOnly,
+                "n={n}: degree-t aggregate has redundancy → at least abort"
+            );
+        }
+    }
+
+    // --- Cost SHAPE assertions (the scaling the protocol predicts). ---------
+    #[test]
+    fn aggregate_pays_zero_multiplications_and_one_open() {
+        for &n in DEFAULT_PARTIES {
+            let c = cell(QueryClass::CumulativeSumAggregate, n, 1).unwrap();
+            assert_eq!(
+                c.multiplications(),
+                0,
+                "linear aggregate is multiplication-free"
+            );
+            assert_eq!(c.comm.field_elements_opened, 1, "one open: the sum");
+            // n deals × n parties = n² shared field elements.
+            assert_eq!(c.comm.field_elements_shared, (n * n) as u64);
+        }
+    }
+
+    #[test]
+    fn hidden_join_opens_grow_as_scale_squared() {
+        // For fixed N, doubling the rows/holder quadruples the equality opens
+        // (the |L|·|R| all-pairs cost center).
+        let n = 5;
+        let c2 = cell(QueryClass::HiddenValueEquiJoin, n, 2).unwrap();
+        let c4 = cell(QueryClass::HiddenValueEquiJoin, n, 4).unwrap();
+        assert_eq!(c2.comm.field_elements_opened, 4); // 2² = 4
+        assert_eq!(c4.comm.field_elements_opened, 16); // 4² = 16
+        assert_eq!(c4.multiplications(), 4 * c2.multiplications());
+    }
+
+    #[test]
+    fn aggregate_bytes_per_party_grows_with_n() {
+        // The aggregate's total shared field elements = n² (n deals × n parties),
+        // so bytes-per-party = n²·8 / n = n·8 — grows LINEARLY with N, exactly as
+        // the protocol predicts (each added holder deals one more secret).
+        let mut prev = 0u64;
+        for &n in DEFAULT_PARTIES {
+            let c = cell(QueryClass::CumulativeSumAggregate, n, 1).unwrap();
+            let bpp = c.bytes_per_party();
+            assert!(
+                bpp > prev,
+                "n={n}: bytes/party must grow with N (got {bpp}, prev {prev})"
+            );
+            // bytes/party = n·FIELD_BYTES (n² shared / n parties × 8, +1 open/n).
+            prev = bpp;
+        }
+    }
+
+    #[test]
+    fn hidden_join_batched_rounds_below_sequential() {
+        // The all-pairs equalities are independent → the batched lower bound is far
+        // below the sequential upper bound (the design record's round-batching point).
+        let c = cell(QueryClass::HiddenValueEquiJoin, 5, 4).unwrap();
+        assert!(
+            c.rounds_batched() < c.rounds_sequential(),
+            "independent equality tests must batch below the sequential round count"
+        );
+    }
+
+    #[test]
+    fn oblivious_sort_costs_more_rounds_than_shuffle_at_same_scale() {
+        // Sort is O(log² n) depth vs shuffle's O(log n) — sort has more rounds.
+        let n = 3;
+        let scale = 8;
+        let shuf = cell(QueryClass::ObliviousShuffle, n, scale).unwrap();
+        let sort = cell(QueryClass::ObliviousSort, n, scale).unwrap();
+        assert!(
+            sort.comm.mult_rounds >= shuf.comm.mult_rounds,
+            "Batcher sort depth >= Waksman shuffle depth at the same scale"
+        );
+    }
+
+    // --- JSON schema is well-formed and carries the honest tier label. -----
+    #[test]
+    fn json_carries_honest_tier_label_and_cells() {
+        let r = run_matrix(&[3], 2, 4).unwrap();
+        let json = r.to_json();
+        assert!(json.contains("in-process-counting"));
+        assert!(json.contains("network cost MODELLED not measured"));
+        assert!(json.contains("\"offline_bytes\": 0"));
+        assert!(json.contains("hidden_value_equi_join"));
+        assert!(json.contains("\"field_bytes\": 8"));
+    }
+}

--- a/crates/sparq-mpc/src/lib.rs
+++ b/crates/sparq-mpc/src/lib.rs
@@ -91,9 +91,20 @@
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 
 pub mod backend;
+// [OPUS-4.8] sq-sxm: the (security model × N × query class) benchmark MATRIX
+// harness + its deterministic communication/round/multiplication counter — the
+// IN-PROCESS counting tier (Tier 1). New modules, isolated from the protocol
+// primitives so they do not conflict with sibling beads editing backend.rs
+// (sq-a6p1) / oblivious.rs (sq-jnkm): `metrics` is the counter, `bench` drives the
+// matrix and reads the per-cell ACTUAL security off `operator_descriptor`. The
+// real network transport + tc/netem (Tier 2/3) is bead sq-tg6b; EC2 scale-out is
+// sq-hoaj. See the module docs for the critical-honesty constraint (no
+// single-process wall-clock masquerading as an MPC latency).
+pub mod bench;
 pub mod field;
 pub mod holder;
 pub mod join;
+pub mod metrics;
 pub mod partial;
 pub mod proof;
 // [OPUS-4.8] sq-1vt: the CSPRNG masking seam (production SecureRng + test-only
@@ -126,6 +137,11 @@ pub use backend::{
     AbortKind, AdversaryModel, BackendInfo, CorruptionThreshold, MaliciousSecurity, MpcBackend,
     OperatorClass, OutputGuarantee, PublicVerifiability, SecurityDescriptor, TrustModel,
 };
+// [OPUS-4.8] sq-sxm: the benchmark-matrix harness surface (in-process counting tier).
+pub use bench::{
+    cell, run_matrix, CellSecurity, MatrixCell, MatrixResults, QueryClass, DEFAULT_PARTIES,
+};
+pub use metrics::{CommCounter, FIELD_BYTES};
 pub use field::Fp;
 pub use holder::{Holder, HolderResult};
 pub use join::{DisclosedKeyJoin, GlobalJoin, HiddenKeyedRows, HiddenValueJoin, JoinPlan};

--- a/crates/sparq-mpc/src/metrics.rs
+++ b/crates/sparq-mpc/src/metrics.rs
@@ -1,0 +1,333 @@
+// [OPUS-4.8] sq-sxm — deterministic MPC communication / round / multiplication
+// counter for the IN-PROCESS counting tier (Tier 1). New module; instruments at
+// call sites added by the benchmark harness, NOT by rewriting backend.rs /
+// shamir.rs / oblivious.rs internals (those are owned by sibling beads sq-a6p1 /
+// sq-jnkm). The counter is analytic: it records the communication a REAL
+// deployment of the same protocol structure would pay, derived from (n, t, sizes)
+// — exactly the "counted, not timed" metric the design record prescribes
+// (research/mpc-security-models-and-benchmarks.md §5.2).
+//! Deterministic communication / round / multiplication accounting for the
+//! in-process MPC simulation.
+//!
+//! ## Why a counter and not a timer
+//!
+//! `sparq-mpc` is a single-process multi-party *simulation*: every "party" is a
+//! function call, so there is NO network, NO round latency, NO bytes on the wire.
+//! A single-process wall-clock therefore does NOT measure MPC cost and must never
+//! masquerade as one (design record §5, the critical-honesty constraint). The
+//! load-bearing, cross-`N`-meaningful metric is the **modelled communication**:
+//! how many field elements cross the abstract party boundary, in how many logical
+//! rounds, paying how many secure multiplications.
+//!
+//! These quantities are *deterministic functions of `(n, t, sizes)`* — the same
+//! input always yields the same counts (load-robust; unlike a quiet-box-sensitive
+//! timing). This module is the accumulator; [`crate::bench`] is the harness that
+//! drives the representative operations across the (security model × N × query
+//! class) matrix and reads these counters off.
+//!
+//! ## What is counted (the metric triple + multiplications)
+//!
+//! Per the design record's metric definitions (§5.2):
+//!
+//! - **`field_elements_opened`** — each field element reconstructed (opened) across
+//!   the parties. The aggregate opens 1 (the sum); each `secure_equal` opens 1 (the
+//!   masked product `d·r`). This is the dominant on-wire term.
+//! - **`field_elements_shared`** — each field element distributed when a secret is
+//!   dealt (one share per party leaves the dealer). Sharing one secret across `n`
+//!   parties sends `n` field elements (`n − 1` to the other parties; we count the
+//!   full `n` as the abstract boundary-crossings, then derive a per-party figure).
+//! - **`multiplications`** — secure (degree-raising) multiplications. Linear ops
+//!   (add/sub/scale, the aggregate's cumulative sum) are LOCAL and free → 0. Each
+//!   `secure_equal` pays exactly 1; the oblivious shuffle/sort cost is taken from
+//!   the crate's own [`crate::oblivious::ShuffleCost`] / [`crate::oblivious::SortCost`].
+//! - **`mult_rounds`** / **`open_rounds`** — logical communication rounds. A linear
+//!   aggregate is `0` mult rounds `+ 1` open. Each `secure_equal` is `1` mult round
+//!   `+ 1` open. An all-pairs join is `|L|·|R|` such tests. (Independent tests can
+//!   batch into the same round on a real network — the harness records BOTH the
+//!   sequential round count and a batched lower bound so neither over- nor
+//!   under-states the round structure.)
+//!
+//! ## Bytes-per-party derivation
+//!
+//! A canonical field element is `Fp` over `p = 2^61 − 1`, i.e. it serialises to
+//! **8 bytes** ([`FIELD_BYTES`]; one `u64`-width limb). The design record fixes
+//! "each `F_p` opened = 8 bytes/party" (§5.2). So `bytes_per_party` for an open is
+//! `field_elements_opened × 8` (each party broadcasts its one share to recombine);
+//! for a deal it is `8` per secret per recipient party. See [`CommCounter::bytes_per_party`].
+
+/// Serialised width of one canonical [`crate::field::Fp`] element, in bytes. `Fp`
+/// is over the Mersenne prime `p = 2^61 − 1`, whose canonical representative fits one `u64`
+/// limb, so the on-wire encoding is **8 bytes** — the per-party-per-open cost the
+/// design record fixes (§5.2: "each `F_p` opened = 8 bytes/party"). Deriving it
+/// from `size_of::<u64>()` keeps the figure tied to the representation rather than
+/// a hard-coded literal. `[OPUS-4.8]`
+pub const FIELD_BYTES: usize = {
+    // Compile-time assertion that the field value fits one u64 limb (so the
+    // 8-byte wire width is correct). `Fp::value()` returns `u64`.
+    assert!(crate::field::P < u64::MAX);
+    std::mem::size_of::<u64>()
+};
+
+/// A deterministic accumulator of the communication a REAL deployment of the
+/// simulated protocol would pay. All fields are monotone counters; the same
+/// protocol over the same `(n, t, sizes)` always produces the same values.
+///
+/// This is threaded through the harness's instrumented wrappers (see
+/// [`crate::bench`]); it deliberately lives OUTSIDE the protocol primitives so the
+/// counting tier adds no invasive edits to `shamir.rs` / `backend.rs` /
+/// `oblivious.rs` (sibling-bead ownership). `[OPUS-4.8]`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CommCounter {
+    /// Number of compute parties `n` this accounting is for (so a per-party
+    /// figure can be derived). `0` until a protocol is recorded against it.
+    pub parties: usize,
+    /// Total field elements OPENED (reconstructed across the parties). Each open
+    /// is one logical broadcast-and-recombine of one secret value.
+    pub field_elements_opened: u64,
+    /// Total field elements DEALT (one share per party when a secret is shared).
+    /// Counts the abstract boundary-crossings of the dealing step.
+    pub field_elements_shared: u64,
+    /// Secure (degree-raising) multiplications. Local linear ops are free (0).
+    pub multiplications: u64,
+    /// Logical multiplication rounds, counted SEQUENTIALLY (one per dependent
+    /// multiplication step). The upper bound on rounds.
+    pub mult_rounds: u64,
+    /// Logical open rounds, counted sequentially (one per dependent open step).
+    pub open_rounds: u64,
+    /// Independent operations that COULD be batched into a single network round on
+    /// a real deployment (e.g. the `|L|·|R|` equality tests of an all-pairs join
+    /// are mutually independent). Used to derive a batched round LOWER bound so the
+    /// round structure is not over-stated. `[OPUS-4.8]`
+    pub batchable_ops: u64,
+}
+
+impl CommCounter {
+    /// A fresh counter for an `n`-party protocol.
+    pub fn new(parties: usize) -> Self {
+        CommCounter {
+            parties,
+            ..Default::default()
+        }
+    }
+
+    /// Record dealing ONE secret across all `n` parties: `n` field elements leave
+    /// the dealer (one share per party). No round cost is attributed here — the
+    /// dealing latency is folded into the operation (mult/open) that consumes the
+    /// sharing, matching how the metric triple is defined per-operation in §5.2.
+    pub fn record_deal(&mut self) {
+        self.field_elements_shared += self.parties as u64;
+    }
+
+    /// Record ONE secure multiplication of two sharings: 1 multiplication, in 1
+    /// sequential mult round. In a real DN07/BGW protocol this is one re-share +
+    /// recombine round; the crate's single-product primitive opens the *result*
+    /// directly, so the open is recorded by the caller's [`Self::record_open`].
+    /// Here we count only the multiplication and its round; the operation is
+    /// independently batchable.
+    pub fn record_mult(&mut self) {
+        self.multiplications += 1;
+        self.mult_rounds += 1;
+        self.batchable_ops += 1;
+    }
+
+    /// Record opening (reconstructing) ONE field element across the parties: each
+    /// party broadcasts its share, so `n` field elements cross the boundary; it is
+    /// one logical open round.
+    pub fn record_open(&mut self) {
+        self.field_elements_opened += 1;
+        self.open_rounds += 1;
+    }
+
+    /// Record a batch of `k` MUTUALLY-INDEPENDENT secure equality tests (the
+    /// all-pairs join's inner loop). Each is one deal of two keys + one mask, one
+    /// multiplication, and one open — but the `k` of them can collapse into a
+    /// SINGLE network round on a real deployment (they share no data dependency).
+    /// So this adds `k` multiplications / opens / deals to the on-wire totals; the
+    /// sequential round counters grow by `k` (the upper bound), while
+    /// `batchable_ops` grows by `k` so [`Self::batched_rounds`] can report the
+    /// round LOWER bound. `[OPUS-4.8]`
+    pub fn record_independent_equalities(&mut self, k: u64) {
+        // Per equality: deal key_L, key_R, mask r → 3 deals; 1 mult; 1 open.
+        for _ in 0..k {
+            self.record_deal();
+            self.record_deal();
+            self.record_deal();
+            self.record_mult();
+            self.record_open();
+        }
+    }
+
+    /// Fold in the modelled cost of one oblivious **shuffle** (from the crate's own
+    /// [`crate::oblivious::ShuffleCost`]): a real secret-control shuffle pays 1
+    /// multiplication per switch and `depth_rounds` communication rounds. The
+    /// switches are NOT mutually independent (network depth), so the sequential
+    /// rounds grow by `depth_rounds`, not by the switch count.
+    pub fn record_shuffle(&mut self, cost: crate::oblivious::ShuffleCost) {
+        self.multiplications += cost.switches as u64;
+        self.mult_rounds += cost.depth_rounds as u64;
+        // Each switch's conditional swap opens nothing on its own (it stays
+        // secret-shared); the cost is the multiplications + the depth rounds.
+    }
+
+    /// Fold in the modelled cost of one oblivious **sort** (from the crate's own
+    /// [`crate::oblivious::SortCost`]): each compare-exchange is a secure
+    /// comparison + conditional swap, and the network has `depth_rounds` layers.
+    pub fn record_sort(&mut self, cost: crate::oblivious::SortCost) {
+        self.multiplications += cost.compare_exchanges as u64;
+        self.mult_rounds += cost.depth_rounds as u64;
+    }
+
+    /// Total logical communication rounds, SEQUENTIAL (upper bound): every
+    /// dependent mult/open step counted separately.
+    pub fn total_rounds(&self) -> u64 {
+        self.mult_rounds + self.open_rounds
+    }
+
+    /// Lower-bound round count assuming all mutually-independent operations batch
+    /// into ONE round each (the optimistic real-network figure). When every op is
+    /// independent (the all-pairs join), this collapses to a small constant; when
+    /// ops are dependency-chained (a sort network's layers), it equals the
+    /// sequential count. Reported alongside [`Self::total_rounds`] so neither bound
+    /// is mistaken for the other. `[OPUS-4.8]`
+    pub fn batched_rounds(&self) -> u64 {
+        let sequential = self.total_rounds();
+        if self.batchable_ops == 0 {
+            return sequential;
+        }
+        // Each batchable op contributed 1 mult round + 1 open round to the
+        // sequential count; those collapse into 2 rounds (one mult, one open) when
+        // batched. Any rounds NOT attributable to batchable ops remain.
+        let batchable_rounds = 2 * self.batchable_ops;
+        let non_batchable = sequential.saturating_sub(batchable_rounds);
+        non_batchable + 2
+    }
+
+    /// **Modelled bytes per party.** Each party broadcasts its one share (8 bytes)
+    /// to recombine an open, and receives its one share (8 bytes) per deal. We
+    /// total the field elements that cross the boundary and divide by the party
+    /// count to get a symmetric per-party figure — the cross-`N`-comparable cost.
+    ///
+    /// `(opened + shared) × FIELD_BYTES` is the total field-element traffic; the
+    /// per-party share is that divided by `parties` (each party sends/receives an
+    /// equal slice in a symmetric protocol). Returns `0` when no party count is
+    /// set (nothing recorded). `[OPUS-4.8]`
+    pub fn bytes_per_party(&self) -> u64 {
+        if self.parties == 0 {
+            return 0;
+        }
+        let total_field_elems = self.field_elements_opened + self.field_elements_shared;
+        let total_bytes = total_field_elems * FIELD_BYTES as u64;
+        total_bytes / self.parties as u64
+    }
+
+    /// Total modelled bytes across ALL parties (the aggregate on-wire volume),
+    /// before the per-party division — useful for an O(N) vs O(N²) scaling check.
+    pub fn total_bytes(&self) -> u64 {
+        (self.field_elements_opened + self.field_elements_shared) * FIELD_BYTES as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::field::Fp;
+
+    #[test]
+    fn field_bytes_is_eight() {
+        // The whole bytes model rests on Fp being one u64 limb.
+        assert_eq!(FIELD_BYTES, 8);
+        assert_eq!(std::mem::size_of_val(&Fp::zero().value()), FIELD_BYTES);
+    }
+
+    #[test]
+    fn aggregate_is_zero_mult_one_open() {
+        // The cumulative-SUM aggregate over n holders: n deals (each holder shares
+        // its private value) + a free local sum + ONE open. Zero multiplications.
+        let n = 5;
+        let mut c = CommCounter::new(n);
+        for _ in 0..n {
+            c.record_deal();
+        }
+        c.record_open();
+        assert_eq!(
+            c.multiplications, 0,
+            "linear aggregate pays no multiplications"
+        );
+        assert_eq!(c.mult_rounds, 0);
+        assert_eq!(c.open_rounds, 1);
+        assert_eq!(c.field_elements_opened, 1);
+        assert_eq!(c.field_elements_shared, (n * n) as u64);
+    }
+
+    #[test]
+    fn one_equality_is_one_mult_one_open() {
+        let mut c = CommCounter::new(3);
+        c.record_independent_equalities(1);
+        assert_eq!(c.multiplications, 1);
+        assert_eq!(c.field_elements_opened, 1);
+        // 3 deals (key_L, key_R, mask) × 3 parties = 9 field elements shared.
+        assert_eq!(c.field_elements_shared, 9);
+        assert_eq!(c.total_rounds(), 2); // 1 mult + 1 open
+    }
+
+    #[test]
+    fn all_pairs_join_opens_grow_as_product() {
+        // |L| = |R| = s ⇒ s² equality tests ⇒ s² opens (the round-count explosion
+        // the literature flags) and s² multiplications.
+        for s in [2u64, 4, 8] {
+            let mut c = CommCounter::new(3);
+            c.record_independent_equalities(s * s);
+            assert_eq!(c.field_elements_opened, s * s);
+            assert_eq!(c.multiplications, s * s);
+        }
+    }
+
+    #[test]
+    fn batched_rounds_collapses_independent_ops() {
+        // All-pairs join: many independent equalities → sequential rounds grow as
+        // 2·k, but the batched lower bound collapses to ~2 (one mult + one open
+        // round) because the tests share no data dependency.
+        let mut c = CommCounter::new(3);
+        let k = 16;
+        c.record_independent_equalities(k);
+        assert_eq!(c.total_rounds(), 2 * k); // sequential upper bound
+        assert_eq!(c.batched_rounds(), 2); // batched lower bound
+        assert!(c.batched_rounds() < c.total_rounds());
+    }
+
+    #[test]
+    fn bytes_per_party_scales_with_opens() {
+        let mut c = CommCounter::new(3);
+        c.record_open();
+        // 1 open = 1 field element opened = 8 total bytes / 3 parties (floor).
+        assert_eq!(c.total_bytes(), 8);
+        assert_eq!(c.bytes_per_party(), 8 / 3);
+    }
+
+    #[test]
+    fn shuffle_cost_folds_in_switches_and_depth() {
+        let cost = crate::oblivious::ShuffleCost::model(8, 17);
+        let mut c = CommCounter::new(3);
+        c.record_shuffle(cost);
+        assert_eq!(c.multiplications, 17);
+        assert_eq!(c.mult_rounds, cost.depth_rounds as u64);
+    }
+
+    #[test]
+    fn deterministic_same_input_same_counts() {
+        let run = || {
+            let mut c = CommCounter::new(5);
+            for _ in 0..5 {
+                c.record_deal();
+            }
+            c.record_open();
+            c.record_independent_equalities(9);
+            c
+        };
+        assert_eq!(
+            run(),
+            run(),
+            "same protocol → identical counts (load-robust)"
+        );
+    }
+}

--- a/crates/sparq-mpc/src/metrics.rs
+++ b/crates/sparq-mpc/src/metrics.rs
@@ -145,16 +145,23 @@ impl CommCounter {
     /// So this adds `k` multiplications / opens / deals to the on-wire totals; the
     /// sequential round counters grow by `k` (the upper bound), while
     /// `batchable_ops` grows by `k` so [`Self::batched_rounds`] can report the
-    /// round LOWER bound. `[OPUS-4.8]`
+    /// round LOWER bound.
+    ///
+    /// Every counter is LINEAR in `k`, so this is computed in CLOSED FORM (`O(1)`),
+    /// not by looping `record_deal`/`record_mult`/`record_open` `k` times — the
+    /// loop would make the *instrument* `O(k)` and let it dominate the harness at
+    /// the larger `|L|·|R|` join scales. The totals are identical to `k`
+    /// applications of those primitives. `[OPUS-4.8]`
     pub fn record_independent_equalities(&mut self, k: u64) {
-        // Per equality: deal key_L, key_R, mask r → 3 deals; 1 mult; 1 open.
-        for _ in 0..k {
-            self.record_deal();
-            self.record_deal();
-            self.record_deal();
-            self.record_mult();
-            self.record_open();
-        }
+        // Per equality: 3 deals (key_L, key_R, mask r) + 1 mult + 1 open. Each
+        // deal sends `parties` shares; opens/mults are 1 logical op each. Fold the
+        // whole batch in arithmetically (== `k` × the per-op increments above).
+        self.field_elements_shared += 3 * k * self.parties as u64;
+        self.multiplications += k;
+        self.mult_rounds += k;
+        self.batchable_ops += k;
+        self.field_elements_opened += k;
+        self.open_rounds += k;
     }
 
     /// Fold in the modelled cost of one oblivious **shuffle** (from the crate's own
@@ -202,28 +209,46 @@ impl CommCounter {
         non_batchable + 2
     }
 
+    /// Total field elements that cross the abstract party boundary on the wire.
+    ///
+    /// An OPEN broadcasts `n` shares (every party sends its one share to
+    /// recombine), so each opened *value* is `parties` wire field elements — the
+    /// same `n`-fan-out a deal already pays (`record_deal` adds `parties` to
+    /// `field_elements_shared`, so that counter is ALREADY in wire units). Keeping
+    /// `field_elements_opened` as the logical count (1 per opened value — what the
+    /// JSON/table report and the round counters use) and applying the `× parties`
+    /// fan-out only here keeps the on-wire model symmetric with deals and makes
+    /// `total_bytes` scale with `N` (design record §5.2: "8 bytes/party per open"
+    /// over `n` broadcasters ⇒ `8·n` total bytes per open). `[OPUS-4.8]`
+    fn wire_field_elements(&self) -> u64 {
+        self.field_elements_opened * self.parties as u64 + self.field_elements_shared
+    }
+
     /// **Modelled bytes per party.** Each party broadcasts its one share (8 bytes)
     /// to recombine an open, and receives its one share (8 bytes) per deal. We
     /// total the field elements that cross the boundary and divide by the party
     /// count to get a symmetric per-party figure — the cross-`N`-comparable cost.
     ///
-    /// `(opened + shared) × FIELD_BYTES` is the total field-element traffic; the
+    /// The on-wire traffic is [`Self::wire_field_elements`]`× FIELD_BYTES`; the
     /// per-party share is that divided by `parties` (each party sends/receives an
-    /// equal slice in a symmetric protocol). Returns `0` when no party count is
-    /// set (nothing recorded). `[OPUS-4.8]`
+    /// equal slice in a symmetric protocol). For one open at `n` parties this is
+    /// `(1·n)·8 / n = 8` — the per-open-per-party figure the design record fixes
+    /// (§5.2), no longer undercounted. Returns `0` when no party count is set
+    /// (nothing recorded). `[OPUS-4.8]`
     pub fn bytes_per_party(&self) -> u64 {
         if self.parties == 0 {
             return 0;
         }
-        let total_field_elems = self.field_elements_opened + self.field_elements_shared;
-        let total_bytes = total_field_elems * FIELD_BYTES as u64;
+        let total_bytes = self.wire_field_elements() * FIELD_BYTES as u64;
         total_bytes / self.parties as u64
     }
 
     /// Total modelled bytes across ALL parties (the aggregate on-wire volume),
     /// before the per-party division — useful for an O(N) vs O(N²) scaling check.
+    /// Both opens (`n` broadcast shares each) and deals (`n` shares each) scale
+    /// with `N`, so this aggregate grows with the party count as intended.
     pub fn total_bytes(&self) -> u64 {
-        (self.field_elements_opened + self.field_elements_shared) * FIELD_BYTES as u64
+        self.wire_field_elements() * FIELD_BYTES as u64
     }
 }
 
@@ -299,9 +324,24 @@ mod tests {
     fn bytes_per_party_scales_with_opens() {
         let mut c = CommCounter::new(3);
         c.record_open();
-        // 1 open = 1 field element opened = 8 total bytes / 3 parties (floor).
-        assert_eq!(c.total_bytes(), 8);
-        assert_eq!(c.bytes_per_party(), 8 / 3);
+        // 1 open broadcasts n=3 shares (each party sends its 8-byte share to
+        // recombine) ⇒ 3 wire field elements = 24 total bytes; per party = 8 bytes,
+        // the "8 bytes/party per open" figure the design record fixes (§5.2).
+        assert_eq!(c.total_bytes(), 3 * 8);
+        assert_eq!(c.bytes_per_party(), 8);
+    }
+
+    #[test]
+    fn open_bytes_scale_with_party_count() {
+        // total_bytes for a single open grows with N (an open is an n-broadcast),
+        // and bytes_per_party stays a flat 8 (one 8-byte share per party). This is
+        // the symmetry with deals the byte model must preserve.
+        for n in [2usize, 3, 5, 7] {
+            let mut c = CommCounter::new(n);
+            c.record_open();
+            assert_eq!(c.total_bytes(), (n as u64) * FIELD_BYTES as u64);
+            assert_eq!(c.bytes_per_party(), FIELD_BYTES as u64);
+        }
     }
 
     #[test]


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Implements **sq-sxm** — the (security model × N × query class) MPC benchmark matrix the repo owner asked for, as the **Tier-1 in-process COUNTING tier**.

## Why counting, not timing
`sparq-mpc` is a single-process multi-party *simulation*: every party is a function call, so wall-clock is **not** a meaningful cross-`N` MPC cost and must never masquerade as an MPC latency (design record `research/mpc-security-models-and-benchmarks.md` §5). The load-bearing, cross-`N`-comparable metric is the **deterministic modelled communication** — counted analytically from the protocol structure, reproducible run-to-run.

## The matrix
- **AXIS 1 — security model:** the **ACTUAL** per-operator guarantee read off `ShamirBackend::operator_descriptor` (never a *requested* one). The degree-`t` aggregate carries RS redundancy (abort / robust); the degree-`2t` equality/join open is correctly **SemiHonestOnly at `n = 2t+1`** (odd N, zero redundancy) even though the aggregate is robust at the same N — recorded per cell.
- **AXIS 2 — N ∈ {2, 3, 5, 7}**, `t = ⌊(n−1)/2⌋`. Even N (2) exercises the abort boundary at degree `2t`; odd N the semi-honest-only equality boundary.
- **AXIS 3 — query class:** cumulative-SUM aggregate (the £100k case — zero-round linear baseline), hidden-value equi-join (the cost center — `|L|·|R|` equalities), oblivious shuffle (AS-Waksman), oblivious sort (Batcher odd-even mergesort).

## Metrics emitted (per cell)
`bytes_per_party` + `total_bytes`, `rounds_sequential` (upper bound) + `rounds_batched` (independent ops collapsed — lower bound), `multiplications`, `field_elements_opened`/`shared`, and `offline_bytes` (explicitly `0` for semi-honest Shamir, so a future SPDZ backend's preprocessing shows up as a regression, not a hidden cost — the Ozdemir-Boneh / ORQ lesson). `Fp` = **8 bytes** (`FIELD_BYTES`, derived from the representation, not hard-coded).

## How comm/rounds were instrumented WITHOUT touching `backend.rs`
The counter (`src/metrics.rs::CommCounter`) lives in its **own new module** and is driven by analytic cost models in the harness (`src/bench.rs`) that **mirror the protocol structure at call sites the harness adds** — NOT by rewriting the primitives. So this PR makes **zero edits** to `backend.rs` (sibling sq-a6p1, the selection registry), `oblivious.rs` (sibling sq-jnkm), `shamir.rs`, or `join.rs`. The oblivious cells reuse the crate's existing `ShuffleCost` / `SortCost`. Each cost cell **co-runs the real primitive** (`check_aggregate` / `check_hidden_join` / `check_shuffle` / `check_sort`) so a fast-but-wrong cell is caught.

## Cells covered + their security guarantees (from the live harness)
| query class | N=2 | N=3 | N=5 | N=7 |
|---|---|---|---|---|
| cumulative-sum aggregate (degree-`t`) | abort | abort | robust(e=1) | robust(e=1) |
| hidden-value equi-join (degree-`2t`) | abort | **semi-honest-only** | **semi-honest-only** | **semi-honest-only** |
| oblivious shuffle / sort | abort | semi-honest-only | semi-honest-only | semi-honest-only |

(All honest-majority trust model. The semi-honest-only equality cells at odd N are the design record's degree-`2t`-no-redundancy-at-`n=2t+1` finding, recorded accurately — not papered over.)

## Runnable
```
cargo run -p sparq-mpc --example mpc_bench_matrix --features insecure-test-rng
cargo run -p sparq-mpc --example mpc_bench_matrix --features insecure-test-rng -- --json
```
(The `insecure-test-rng` feature only makes the simulation's masks reproducible for the correctness gates — never a production claim; that is what the feature name warns about. A default build prints the cost matrix and skips the gates with a clear note.)

## This is the in-process counting tier
The real **multi-process transport + `tc`/`netem` LAN/WAN emulation** (Tier 2/3) is a **separate bead (sq-tg6b)**; the **EC2 scale-out** is **sq-hoaj** — both referenced in the module docs and `PLAN.md`.

## Gate
- `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings` — clean.
- `cargo test -p sparq-mpc` — green (127 passed, incl. 18 new bench/metrics tests; green with and without `--features insecure-test-rng`).
- Example builds + runs quickly (scales capped: join 6²=36 pairs, oblivious 16 rows; `df` watched).
- wasm-exclusion invariant intact (`sparq-mpc` absent from `sparq-wasm` tree); **no new dependencies**.
- No hard-coded perf numbers in markdown — the harness emits them (the table above is read off the live run for review, not baked into a doc).

`[OPUS-4.8]` markers throughout; commit trailer `Co-Authored-By: Claude Opus 4.8 (1M context)`.

Refs sq-sxm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)