### PR TITLE
fix(sparq-core): RDF 1.2 triple terms in the sharded external builder (sq-t3rt)

### DIFF
--- a/crates/sparq-core/src/dict.rs
+++ b/crates/sparq-core/src/dict.rs
@@ -1194,15 +1194,14 @@ impl Dict {
     }
 
     /// Interns a borrowed term (already-split components) without building a `Term` or
-    /// concatenating the IRI — the fast path used by the sharded parallel merge.
+    /// concatenating the IRI — the fast path used by the sharded parallel merge for LEAF
+    /// terms.
     ///
-    /// Triple terms are NOT supported here: `TermParts::Triple` carries ids of the
-    /// SOURCE dict, which are meaningless in another dict. [OPUS-4.8] (sq-hxgb) The
-    /// byte-level N-Triples parser now ACCEPTS `<<( … )>>` triple-term objects, so a
-    /// partial dict CAN contain one — but the loader detects that (`has_triple_terms`)
-    /// and routes such documents to the SERIAL `merge_remap` (which interns triple terms
-    /// structurally), so the sharded parts-based path is never reached for them. This
-    /// remains a loud guard, not a path.
+    /// Triple terms are NOT handled here: `TermParts::Triple` carries ids of the SOURCE
+    /// dict, meaningless in another dict. [OPUS-4.8] (sq-t3rt) The sharded merge no longer
+    /// reaches this with a triple term — `ShardedDict::intern_partials` SKIPS triple terms
+    /// in the (hash-routed) leaf pass and interns them structurally into a dedicated triple
+    /// shard via `intern_triple_ids` instead. This stays a loud guard, not a path.
     #[inline]
     fn intern_parts(&mut self, tp: &TermParts) -> Id {
         match tp {
@@ -1210,7 +1209,7 @@ impl Dict {
             TermParts::Lit { value, datatype, lang } => self.intern_lit(value, datatype, *lang),
             TermParts::Blank(b) => self.intern_blank(b),
             TermParts::Triple(_) => {
-                panic!("RDF-star triple terms are not supported by the sharded (parts-based) bulk interner; use the serial loader")
+                panic!("RDF-star triple terms must be interned structurally (intern_triple_ids), not via the parts-based leaf path")
             }
         }
     }
@@ -2016,19 +2015,43 @@ fn stored_owned_bytes(s: &Stored) -> usize {
 // integer ids (≥ INLINE_BASE) are global and never enter a shard.
 
 /// A hash-sharded interner — see the module comment above.
+///
+/// [OPUS-4.8] (sq-t3rt) RDF 1.2 triple terms `<<( s p o )>>` cannot be hash-routed like leaf
+/// terms: a triple term's content IS its components' ids, and those final ids are only known
+/// after every leaf consolidates (a component may live in any shard). So `shards` holds
+/// `n_leaf` LEAF shards (`shards[0..n_leaf]`, routed by `hash % n_leaf`, unchanged) PLUS one
+/// extra TRIPLE-TERM shard (`shards[n_leaf]`) interned in a serial second pass: its entries
+/// are `Stored::Triple([temp_s, temp_p, temp_o])` content-addressed by their components' TEMP
+/// ids, resolved to final ids in `into_merged`. The triple shard sorts LAST (highest `base`),
+/// so every triple term's final id exceeds every leaf's — a triple term can only reference
+/// already-finalised leaf / earlier-triple ids, exactly the children-first ordering serial
+/// `merge_remap` relies on. `stride` is sized for `n_leaf + 1` shards so the triple shard's
+/// temp ids stay below `INLINE_BASE`; FINAL ids are `base[shard] + local`, which is
+/// stride-INDEPENDENT, so leaf-only output stays byte-identical to before.
 pub struct ShardedDict {
+    /// `n_leaf` leaf shards followed by one triple-term shard (`shards[n_leaf]`).
     shards: Vec<Dict>,
+    /// Number of LEAF shards (`shards.len() - 1`); leaves route to `hash % n_leaf`.
+    n_leaf: usize,
     stride: u32,
 }
 
 impl ShardedDict {
     pub fn new(n: usize) -> ShardedDict {
-        let n = n.max(1);
-        ShardedDict { shards: (0..n).map(|_| Dict::new()).collect(), stride: INLINE_BASE / n as u32 }
+        let n_leaf = n.max(1);
+        // `n_leaf` leaf shards + 1 triple-term shard. `stride = INLINE_BASE / (n_leaf + 1)`
+        // reserves the top stride-band for the triple shard so its temp ids stay below
+        // INLINE_BASE; leaf shards' FINAL ids are unaffected (final = base + local).
+        ShardedDict {
+            shards: (0..n_leaf + 1).map(|_| Dict::new()).collect(),
+            n_leaf,
+            stride: INLINE_BASE / (n_leaf as u32 + 1),
+        }
     }
 
+    /// The number of LEAF shards (the historical shard count; the triple shard is internal).
     pub fn n(&self) -> usize {
-        self.shards.len()
+        self.n_leaf
     }
 
     /// Route + intern a batch of `(tag, idx, term)` items (the terms must be NON-inline —
@@ -2040,7 +2063,9 @@ impl ShardedDict {
     /// the triple, breaking the term↔id bijection on merge); the N-Triples bulk loaders
     /// that feed it reject RDF-star syntax before it could reach here.
     pub fn intern_terms(&mut self, items: Vec<(u32, Id, Term)>) -> Vec<(u32, Id, Id)> {
-        let n = self.shards.len();
+        // Leaves route across the `n_leaf` LEAF shards only; the trailing triple shard is
+        // reserved for `intern_partials`'s structural second pass (see the type doc).
+        let n = self.n_leaf;
         let stride = self.stride;
         let mut buckets: Vec<Vec<(u32, Id, Term)>> = (0..n).map(|_| Vec::new()).collect();
         for (tag, idx, t) in items {
@@ -2101,18 +2126,28 @@ impl ShardedDict {
     /// to the old serial-routed version), and each shard scatters its temp ids straight
     /// into the shared remap table (disjoint writes: a term instance `(partial, local-id)`
     /// is hash-routed to exactly one shard).
+    ///
+    /// [OPUS-4.8] (sq-t3rt) RDF 1.2 triple terms (`Stored::Triple`) are handled in a SERIAL
+    /// second pass into the dedicated triple shard (`shards[n_leaf]`): they cannot be
+    /// hash-routed (their content is their components' ids, only resolvable once the leaves
+    /// are interned), so each is content-addressed by its components' already-known TEMP ids
+    /// (children precede the triple in a partial's arena — `intern` pushes them first — so
+    /// the per-partial remap entry of each component, leaf or nested triple, is already
+    /// filled when the triple is reached). Triple terms are reification metadata (rare), so
+    /// the serial pass is not on the hot path.
     pub fn intern_partials(&mut self, partials: &[(Dict, Vec<[Id; 3]>)]) -> Vec<Vec<Id>> {
-        let n = self.shards.len();
+        let n = self.n_leaf;
         let stride = self.stride;
-        // Route each partial's terms to per-shard sub-buckets (parallel over partials).
+        // Route each partial's LEAF terms to per-leaf-shard sub-buckets (parallel over
+        // partials). Triple terms (`TermParts::Triple`) are skipped here — they take the
+        // serial second pass below.
         fn route<'a>(pd: &'a Dict, n: usize) -> Vec<Vec<(Id, TermParts<'a>)>> {
             let mut b: Vec<Vec<(Id, TermParts<'a>)>> = (0..n).map(|_| Vec::with_capacity(pd.len() / n + 1)).collect();
             for i in 1..=pd.len() as Id {
                 let tp = pd.term_parts(i);
-                debug_assert!(
-                    !matches!(tp, TermParts::Triple(_)),
-                    "RDF-star triple terms are not supported by the sharded bulk interner"
-                );
+                if matches!(tp, TermParts::Triple(_)) {
+                    continue; // a triple term — interned structurally in the serial pass
+                }
                 let s = (hash_termparts(&tp) % n as u64) as usize;
                 b[s].push((i, tp));
             }
@@ -2130,16 +2165,18 @@ impl ShardedDict {
         let mut remaps: Vec<Vec<Id>> = partials.iter().map(|(pd, _)| vec![0 as Id; pd.len() + 1]).collect();
         // Raw view of `remaps` so each shard can write its own (partial, local-id) slots
         // from a parallel context. SAFETY (disjointness): the hash routing above assigns
-        // every (pidx, i) slot to exactly ONE shard, so no two shards write the same slot,
-        // and nobody reads until the parallel scope ends.
+        // every (pidx, i) leaf slot to exactly ONE leaf shard, so no two shards write the
+        // same slot, and nobody reads until the parallel scope ends. (Triple-term slots are
+        // written afterwards by the serial pass, never concurrently.)
         #[derive(Clone, Copy)]
         struct SlotPtr(*mut Id, usize);
         unsafe impl Send for SlotPtr {}
         unsafe impl Sync for SlotPtr {}
         let scatter: Vec<SlotPtr> = remaps.iter_mut().map(|v| SlotPtr(v.as_mut_ptr(), v.len())).collect();
 
-        // Intern each shard's terms in parallel (single-writer per shard → no contention),
-        // walking partials in order so per-shard id assignment matches the serial routing.
+        // Intern each LEAF shard's terms in parallel (single-writer per shard → no
+        // contention), walking partials in order so per-shard id assignment matches the
+        // serial routing.
         let intern_shard = |s: usize, shard: &mut Dict| {
             for (pidx, per_partial) in routed.iter().enumerate() {
                 let SlotPtr(ptr, len) = scatter[pidx];
@@ -2151,19 +2188,54 @@ impl ShardedDict {
                     assert!(lid < stride, "shard {s} exceeded STRIDE ({stride}) — raise shard count / widen Id");
                     debug_assert!((*i as usize) < len);
                     // SAFETY: i < len (local ids are 1..=pd.len() < pd.len()+1) and this
-                    // (pidx, i) slot is written by exactly this shard — see RemapScatter.
+                    // (pidx, i) slot is written by exactly this shard — see SlotPtr.
                     unsafe { ptr.add(*i as usize).write((s as u32) * stride + lid) };
                 }
             }
         };
+        // Only the `n_leaf` leaf shards take the parallel pass; the triple shard (index
+        // `n_leaf`) is filled serially below.
         #[cfg(feature = "parallel")]
         {
             use rayon::prelude::*;
-            self.shards.par_iter_mut().enumerate().for_each(|(s, shard)| intern_shard(s, shard));
+            self.shards[..n].par_iter_mut().enumerate().for_each(|(s, shard)| intern_shard(s, shard));
         }
         #[cfg(not(feature = "parallel"))]
-        self.shards.iter_mut().enumerate().for_each(|(s, shard)| intern_shard(s, shard));
+        self.shards[..n].iter_mut().enumerate().for_each(|(s, shard)| intern_shard(s, shard));
+
+        // [OPUS-4.8] (sq-t3rt) Serial second pass — triple terms into the triple shard.
+        self.intern_triple_terms(partials, &mut remaps);
         remaps
+    }
+
+    /// [OPUS-4.8] (sq-t3rt) Intern every partial's RDF 1.2 triple terms into the dedicated
+    /// triple shard (`shards[n_leaf]`), filling their slots in `remaps`. Runs AFTER the leaf
+    /// pass, so every component's temp id is already in `remaps` (children precede their
+    /// triple in a partial's arena). Each triple is content-addressed by its components'
+    /// TEMP ids, so identical triple terms across partials share one triple-shard id (the
+    /// term↔id bijection the hash-routed path could not preserve). Serial: triple-shard id
+    /// assignment must follow first-occurrence (partial, then arena) order deterministically,
+    /// and triple terms are rare metadata.
+    fn intern_triple_terms(&mut self, partials: &[(Dict, Vec<[Id; 3]>)], remaps: &mut [Vec<Id>]) {
+        let tshard_idx = self.n_leaf; // the triple shard
+        let stride = self.stride;
+        // Resolve a component LOCAL id to its TEMP id via this partial's remap. Inline
+        // integers (≥ INLINE_BASE) are global and pass through unchanged. A component is a
+        // leaf (filled by the parallel pass) or a NESTED triple term (filled earlier in this
+        // same ordered walk — children always precede their parent in arena order).
+        for (pidx, (pd, _)) in partials.iter().enumerate() {
+            for i in 1..=pd.len() as Id {
+                if let TermParts::Triple(local_ids) = pd.term_parts(i) {
+                    let rm = &remaps[pidx];
+                    let resolve = |id: Id| if is_inline(id) { id } else { rm[id as usize] };
+                    let temp_ids = [resolve(local_ids[0]), resolve(local_ids[1]), resolve(local_ids[2])];
+                    let lid = self.shards[tshard_idx].intern_triple_ids(temp_ids);
+                    // The triple shard, like every shard, must not overflow its STRIDE band.
+                    assert!(lid < stride, "triple shard exceeded STRIDE ({stride}) — raise shard count / widen Id");
+                    remaps[pidx][i as usize] = (tshard_idx as u32) * stride + lid;
+                }
+            }
+        }
     }
 
     /// `base[s]` = number of terms in shards `< s` (the final id of shard `s`'s local 1 is
@@ -2244,9 +2316,19 @@ impl ShardedDict {
                     Stored::Iri { prefix, suffix } => Stored::Iri { prefix: pr[prefix as usize], suffix },
                     Stored::Lit { value, datatype, lang } => Stored::Lit { value, datatype: dr[datatype as usize], lang },
                     Stored::Blank(b) => Stored::Blank(b),
-                    // Guarded out at `intern_terms` / `intern_parts` — a shard can never
-                    // hold a triple term (see the `intern_terms` doc comment).
-                    Stored::Triple(_) => unreachable!("triple terms cannot enter the sharded interner"),
+                    // [OPUS-4.8] (sq-t3rt) A triple term lives only in the triple shard
+                    // (`shards[n_leaf]`); its component ids are TEMP ids (leaf or earlier
+                    // nested-triple temps) — resolve each to its FINAL dense id with the same
+                    // order-preserving `remap_sharded` the perm files use. Children sort
+                    // before parents (lower base / earlier triple-shard local), so every
+                    // component's final id is already well-defined.
+                    Stored::Triple(ids) => {
+                        Stored::Triple([
+                            remap_sharded(ids[0], &base, stride),
+                            remap_sharded(ids[1], &base, stride),
+                            remap_sharded(ids[2], &base, stride),
+                        ])
+                    }
                 }
             };
             #[cfg(feature = "parallel")]

--- a/crates/sparq-core/src/dict.rs
+++ b/crates/sparq-core/src/dict.rs
@@ -2043,7 +2043,9 @@ impl ShardedDict {
         // reserves the top stride-band for the triple shard so its temp ids stay below
         // INLINE_BASE; leaf shards' FINAL ids are unaffected (final = base + local).
         ShardedDict {
-            shards: (0..n_leaf + 1).map(|_| Dict::new()).collect(),
+            // [OPUS-4.8] `0..(n_leaf + 1)` (== `0..=n_leaf`) — `n_leaf` leaf shards plus the
+            // one trailing triple-term shard. Parenthesised so the bound reads unambiguously.
+            shards: (0..(n_leaf + 1)).map(|_| Dict::new()).collect(),
             n_leaf,
             stride: INLINE_BASE / (n_leaf as u32 + 1),
         }
@@ -2135,7 +2137,13 @@ impl ShardedDict {
     /// the per-partial remap entry of each component, leaf or nested triple, is already
     /// filled when the triple is reached). Triple terms are reification metadata (rare), so
     /// the serial pass is not on the hot path.
-    pub fn intern_partials(&mut self, partials: &[(Dict, Vec<[Id; 3]>)]) -> Vec<Vec<Id>> {
+    ///
+    /// # Errors
+    /// [OPUS-4.8] Returns `Err` if a partial is malformed — a triple term whose component
+    /// local id is out of the partial's range, or references a slot that was never
+    /// routed/interned (e.g. children-first arena ordering was violated). Such input is
+    /// rejected with a descriptive message rather than silently mis-indexing the remap.
+    pub fn intern_partials(&mut self, partials: &[(Dict, Vec<[Id; 3]>)]) -> Result<Vec<Vec<Id>>, String> {
         let n = self.n_leaf;
         let stride = self.stride;
         // Route each partial's LEAF terms to per-leaf-shard sub-buckets (parallel over
@@ -2204,8 +2212,8 @@ impl ShardedDict {
         self.shards[..n].iter_mut().enumerate().for_each(|(s, shard)| intern_shard(s, shard));
 
         // [OPUS-4.8] (sq-t3rt) Serial second pass — triple terms into the triple shard.
-        self.intern_triple_terms(partials, &mut remaps);
-        remaps
+        self.intern_triple_terms(partials, &mut remaps)?;
+        Ok(remaps)
     }
 
     /// [OPUS-4.8] (sq-t3rt) Intern every partial's RDF 1.2 triple terms into the dedicated
@@ -2216,19 +2224,44 @@ impl ShardedDict {
     /// term↔id bijection the hash-routed path could not preserve). Serial: triple-shard id
     /// assignment must follow first-occurrence (partial, then arena) order deterministically,
     /// and triple terms are rare metadata.
-    fn intern_triple_terms(&mut self, partials: &[(Dict, Vec<[Id; 3]>)], remaps: &mut [Vec<Id>]) {
+    fn intern_triple_terms(&mut self, partials: &[(Dict, Vec<[Id; 3]>)], remaps: &mut [Vec<Id>]) -> Result<(), String> {
         let tshard_idx = self.n_leaf; // the triple shard
         let stride = self.stride;
         // Resolve a component LOCAL id to its TEMP id via this partial's remap. Inline
         // integers (≥ INLINE_BASE) are global and pass through unchanged. A component is a
         // leaf (filled by the parallel pass) or a NESTED triple term (filled earlier in this
         // same ordered walk — children always precede their parent in arena order).
+        //
+        // [OPUS-4.8] (sq-t3rt review) A component id is VALIDATED before it indexes the remap:
+        // a malformed partial that violated children-first arena ordering, or that carried a
+        // component id which was never routed/interned, would otherwise index a wrong/empty
+        // slot silently. Both failures are recoverable bad input, not invariant breaches, so
+        // we return a descriptive `Err` rather than panicking or producing a garbage id. The
+        // leaf pass fills every routed slot with `base + local ≥ stride > 0`, so a remaining
+        // `0` marks an unpopulated (hence un-resolvable) component slot.
         for (pidx, (pd, _)) in partials.iter().enumerate() {
             for i in 1..=pd.len() as Id {
                 if let TermParts::Triple(local_ids) = pd.term_parts(i) {
                     let rm = &remaps[pidx];
-                    let resolve = |id: Id| if is_inline(id) { id } else { rm[id as usize] };
-                    let temp_ids = [resolve(local_ids[0]), resolve(local_ids[1]), resolve(local_ids[2])];
+                    let resolve = |id: Id| -> Result<Id, String> {
+                        if is_inline(id) {
+                            return Ok(id);
+                        }
+                        let slot = *rm.get(id as usize).ok_or_else(|| {
+                            format!(
+                                "malformed triple term in partial {pidx}: component local id {id} out of range (remap len {})",
+                                rm.len()
+                            )
+                        })?;
+                        if slot == 0 {
+                            return Err(format!(
+                                "malformed triple term in partial {pidx}: component local id {id} references an unpopulated slot \
+                                 (not routed/interned, or violates children-first ordering)"
+                            ));
+                        }
+                        Ok(slot)
+                    };
+                    let temp_ids = [resolve(local_ids[0])?, resolve(local_ids[1])?, resolve(local_ids[2])?];
                     let lid = self.shards[tshard_idx].intern_triple_ids(temp_ids);
                     // The triple shard, like every shard, must not overflow its STRIDE band.
                     assert!(lid < stride, "triple shard exceeded STRIDE ({stride}) — raise shard count / widen Id");
@@ -2236,6 +2269,7 @@ impl ShardedDict {
                 }
             }
         }
+        Ok(())
     }
 
     /// `base[s]` = number of terms in shards `< s` (the final id of shard `s`'s local 1 is
@@ -2741,6 +2775,55 @@ mod tests {
         assert_eq!(d2.term(iid), inner);
         assert_eq!(d2.lookup(&outer), oid);
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (sq-t3rt review) `intern_triple_terms` must REJECT a malformed partial whose
+    /// triple-term component id is out of range or references an unpopulated remap slot, rather
+    /// than silently mis-indexing the per-partial remap (returning garbage / panicking).
+    #[test]
+    fn intern_partials_rejects_malformed_triple_component() {
+        // Build a partial Dict with two real leaf terms (local ids 1, 2) followed by a triple
+        // term whose components reference an OUT-OF-RANGE local id (> pd.len()). The valid
+        // path always interns components first (children-first), so we use the low-level
+        // `intern_triple_ids` to forge the malformed arena a tampered/buggy producer might.
+        let mut pd = Dict::new();
+        let s = pd.intern(&Term::NamedNode(NamedNode::new_unchecked("http://ex/s"))); // local 1
+        let p = pd.intern(&Term::NamedNode(NamedNode::new_unchecked("http://ex/p"))); // local 2
+        let bogus = pd.len() as Id + 5; // out of range: no such local id exists
+        let _tt = pd.intern_triple_ids([s, p, bogus]);
+        let partials = vec![(pd, Vec::<[Id; 3]>::new())];
+
+        let mut sd = ShardedDict::new(4);
+        let err = sd
+            .intern_partials(&partials)
+            .expect_err("an out-of-range triple component id must be a descriptive Err, not garbage/panic");
+        assert!(err.contains("out of range"), "error should name the out-of-range cause: {err:?}");
+
+        // Second case: an IN-RANGE but UNPOPULATED component slot. The triple references a
+        // non-inline local id whose remap slot the leaf pass never fills (here the triple's
+        // own not-yet-written slot — a children-first ordering violation), so `rm[id]` is the
+        // `0` sentinel rather than a routed `base + local` temp id.
+        let mut pd2 = Dict::new();
+        let a = pd2.intern(&Term::NamedNode(NamedNode::new_unchecked("http://ex/a"))); // local 1
+        let phantom = pd2.len() as Id + 1; // == 2: the triple term's OWN slot, unwritten when resolved
+        let _tt2 = pd2.intern_triple_ids([a, a, phantom]);
+        let partials2 = vec![(pd2, Vec::<[Id; 3]>::new())];
+
+        let mut sd2 = ShardedDict::new(4);
+        let err2 = sd2
+            .intern_partials(&partials2)
+            .expect_err("an unpopulated triple component slot must be a descriptive Err, not garbage/panic");
+        assert!(
+            err2.contains("out of range") || err2.contains("unpopulated"),
+            "error should name the out-of-range / unpopulated cause: {err2:?}"
+        );
+
+        // Sanity: a WELL-FORMED triple-term partial still succeeds (no false rejection).
+        let mut pdok = Dict::new();
+        let _ok = pdok.intern(&triple("http://ex/x", "http://ex/y", int("7")));
+        let mut sdok = ShardedDict::new(4);
+        sdok.intern_partials(&[(pdok, Vec::<[Id; 3]>::new())])
+            .expect("a well-formed triple-term partial must intern without error");
     }
 
     #[cfg(feature = "mmap")]

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -3326,15 +3326,16 @@ fn build_external_ntriples_sharded<R: std::io::Read + Send>(
             }
         });
         // Stage 2 — parse (identical).
+        // [OPUS-4.8] (sq-t3rt) The sharded consolidation now handles RDF 1.2 triple terms
+        // (`ShardedDict::intern_partials` interns them structurally into a dedicated triple
+        // shard), so no rejection here — unlike the dict-spill path (sq-jvbr), which still
+        // cannot and keeps `reject_triple_terms_in_external_build`.
         let parser = scope.spawn(move || -> Result<(), String> {
             for block in rx {
                 if block.is_empty() {
                     continue;
                 }
                 let partials = parse_block(&block)?;
-                // [OPUS-4.8] (sq-hxgb) The sharded/spill consolidation cannot represent
-                // triple terms; fail clearly rather than panic / corrupt (see helper).
-                reject_triple_terms_in_external_build(&partials)?;
                 if ptx.send(partials).is_err() {
                     return Ok(());
                 }
@@ -3523,20 +3524,23 @@ fn parse_block(bytes: &[u8]) -> Result<ChunkPartials, String> {
     Ok(partials)
 }
 
-/// [OPUS-4.8] (sq-hxgb) The disk-spilling external N-Triples builders (sharded /
-/// dict-spill) consolidate partial dicts through a HASH-SHARDED interner that cannot
-/// represent RDF 1.2 triple terms (`<<( … )>>`) — a triple term's components are both
-/// hash-routed to a shard AND referenced structurally by the triple, which breaks the
-/// term↔id bijection across shards (the in-shard interners assert/panic on `Term::Triple`).
-/// The in-MEMORY loader handles triple terms by falling back to the serial `merge_remap`,
-/// but that fallback does not exist for the streaming external build. Until it does
-/// (bead sq-t3rt), surface a CLEAR error here instead of a panic / silent corruption.
-#[cfg(all(feature = "parallel", any(feature = "mmap", feature = "dict-spill")))]
+/// [OPUS-4.8] (sq-jvbr) The DICT-SPILL external N-Triples builder consolidates partial
+/// dicts through a HASH-SHARDED, disk-staged interner whose on-disk term records are
+/// content-only (`serialize_termparts`) — it has no representation for an RDF 1.2 triple
+/// term `<<( … )>>`, whose content IS its components' ids (resolvable only after the whole
+/// external dedup). So it surfaces a CLEAR error rather than panicking / corrupting.
+///
+/// The SHARDED in-RAM external builder (`build_external_ntriples_sharded`) NO LONGER needs
+/// this: as of sq-t3rt `ShardedDict::intern_partials` interns triple terms structurally into
+/// a dedicated triple shard. Giving the dict-spill staging the same is tracked as sq-jvbr;
+/// until then this guard keeps that path honest.
+#[cfg(feature = "dict-spill")]
 fn reject_triple_terms_in_external_build(partials: &[(Dict, Vec<[Id; 3]>)]) -> Result<(), String> {
     if partials.iter().any(|(d, _)| d.has_triple_terms()) {
         return Err("N-Triples: RDF 1.2 triple terms `<<( … )>>` are not yet supported by the \
-                    external disk-spilling builder (Graph::build_external); load this document \
-                    in memory (Graph::load_str/load_reader) instead (sq-hxgb / sq-t3rt)"
+                    dict-spill external builder; build with the default sharded path \
+                    (SPARQ_DICT_SPILL unset) or load this document in memory \
+                    (Graph::load_str/load_reader) instead (sq-jvbr)"
             .to_string());
     }
     Ok(())
@@ -5012,6 +5016,9 @@ mod tests {
 
     /// [OPUS-4.8] The spilled external build still supports its mmap'd read-back path, and
     /// it rejects non-N-Triples formats with a clear error (the documented restriction).
+    /// [OPUS-4.8] (sq-jvbr) It also still rejects RDF 1.2 triple terms with a clear error
+    /// (unlike the sharded path, which now handles them — sq-t3rt): the dict-spill staging
+    /// has no representation for a triple term, so the guard must stay live and tested.
     #[cfg(feature = "dict-spill")]
     #[test]
     fn dict_spill_rejects_non_ntriples_and_opens_mmap() {
@@ -5020,6 +5027,15 @@ mod tests {
         let err = Graph::build_external_spill(b"@prefix : <x> .".as_slice(), "turtle", &dir, 256, &cfg)
             .expect_err("spill build must reject non-ntriples");
         assert!(err.contains("N-Triples"), "error must name the restriction: {err}");
+
+        // RDF 1.2 triple terms are rejected by the dict-spill path (sq-jvbr) with an
+        // actionable error that points at the working alternatives.
+        let tt = "<http://ex/r1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> \
+                  <<( <http://ex/a> <http://ex/b> <http://ex/c> )>> .\n";
+        let tt_err = Graph::build_external_spill(tt.as_bytes(), "ntriples", &dir.join("tt"), 64, &cfg)
+            .expect_err("dict-spill build must reject triple terms (sq-jvbr)");
+        assert!(tt_err.contains("triple term"), "error must name triple terms: {tt_err}");
+        assert!(tt_err.contains("sharded") || tt_err.contains("memory"), "error must point at a working path: {tt_err}");
 
         let nt = "<http://ex/a> <http://ex/p> <http://ex/b> .\n\
                   <http://ex/a> <http://ex/p> \"42\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n";
@@ -5031,37 +5047,164 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    /// [OPUS-4.8] (sq-hxgb) Triple-term support across the external (disk-spilling) build
-    /// paths: the SERIAL-merge path handles `<<( … )>>` correctly (it interns triple terms
-    /// structurally via `merge_remap`, like the in-memory serial fallback), but the
-    /// hash-SHARDED consolidation cannot represent them — so the sharded path must surface a
-    /// CLEAR error (naming `build_external` + the in-memory alternative) rather than panic in
-    /// a shard worker or silently corrupt the dictionary. (Full sharded/spill triple-term
-    /// support is bead sq-t3rt.)
+    /// [OPUS-4.8] (sq-t3rt) The SHARDED external builder now handles RDF 1.2 triple terms
+    /// `<<( … )>>`: it interns them structurally into a dedicated triple shard
+    /// (`ShardedDict::intern_partials`), preserving the triple-term↔id bijection ACROSS
+    /// shards (a triple term's components are hash-routed to leaf shards, while the triple
+    /// itself is content-addressed by its components' resolved ids and appended after every
+    /// leaf). The result must round-trip identically to the SERIAL external path and the
+    /// in-memory loader — both of which already intern triple terms structurally via
+    /// `merge_remap`. The differential test below mirrors the N-Quads loader's style:
+    /// compare every path's round-tripped triples (term-level, order-independent).
+    ///
+    /// Coverage of the cross-shard sharing the bead calls out:
+    /// - a triple term whose three components hash-route to DIFFERENT leaf shards;
+    /// - the SAME triple term referenced by two statements (must dedup to ONE triple id);
+    /// - a leaf SHARED between a plain triple and a triple-term component;
+    /// - NESTED triple terms (a triple term inside a triple term's object);
+    /// - a blank-node component;
+    /// - enough bulk rows that the input spans multiple parse blocks/chunks (cross-chunk
+    ///   partial merge), with the reification metadata interleaved among them.
+    ///
+    /// (The dict-spill path still rejects triple terms — that is bead sq-jvbr, deliberately
+    /// not fixed here to avoid a conflicting edit.)
     #[cfg(all(feature = "mmap", feature = "parallel"))]
     #[test]
-    fn external_build_triple_terms_serial_ok_sharded_errors() {
-        let nt = "<http://ex/r1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> \
-                  <<( <http://ex/alice> <http://ex/age> \"30\"^^<http://www.w3.org/2001/XMLSchema#integer> )>> .\n";
-        // The in-memory loader handles it (reference).
-        let mem = Graph::load_str(nt, "ntriples").expect("in-memory loader must accept triple terms");
+    fn external_build_triple_terms_sharded_matches_serial_and_memory() {
+        // Bulk rows so the document spans multiple parse blocks/chunks; the reification
+        // metadata (triple terms) is interleaved so triple terms occur in several partials.
+        let mut nt = String::new();
+        for i in 0..3000u32 {
+            nt.push_str(&format!(
+                "<http://ex/n{}> <http://ex/p{}> \"{}\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
+                i % 211,
+                i % 11,
+                i % 500
+            ));
+            // Sprinkle reification metadata through the stream.
+            if i % 500 == 0 {
+                // A triple term shared by TWO statements (must dedup to one triple id), with
+                // components in distinct namespaces (so they hash to different leaf shards).
+                nt.push_str("<http://ex/r1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( <http://alpha.example/alice> <http://beta.example/age> \"30\"^^<http://www.w3.org/2001/XMLSchema#integer> )>> .\n");
+                nt.push_str("<http://ex/r1b> <http://ex/sameAs> <<( <http://alpha.example/alice> <http://beta.example/age> \"30\"^^<http://www.w3.org/2001/XMLSchema#integer> )>> .\n");
+            }
+        }
+        // A leaf SHARED between a plain triple and a triple-term component (the object
+        // `<http://alpha.example/alice>` is both a plain object below and a TT subject above).
+        nt.push_str("<http://ex/knows> <http://ex/about> <http://alpha.example/alice> .\n");
+        // A blank-node component inside a triple term.
+        nt.push_str("<http://ex/r2> <http://ex/about> <<( _:b0 <http://ex/p> \"v\" )>> .\n");
+        // NESTED triple terms (a TT in the object slot of a TT), distinct shards per leaf.
+        nt.push_str("<http://ex/r3> <http://ex/nested> <<( <http://gamma.example/x> <http://delta.example/q> <<( <http://eps.example/a> <http://zeta.example/b> <http://eta.example/c> )>> )>> .\n");
 
-        // SERIAL external path (sharded = false) builds it and matches the in-memory load.
+        // Reference paths: in-memory load (serial `merge_remap` fallback for triple terms)
+        // and the SERIAL external build (sharded = false) — both intern triple terms
+        // structurally and are byte-compatible with each other.
+        let mem = Graph::load_str(&nt, "ntriples").expect("in-memory loader must accept triple terms");
+
         let base = std::env::temp_dir().join(format!("sparq_ext_tt_{}", std::process::id()));
         let ser_dir = base.join("serial");
+        let sh_dir = base.join("sharded");
         Graph::build_external_opts(nt.as_bytes(), "ntriples", &ser_dir, 256, false)
             .expect("serial external build must accept triple terms");
-        let ser = Graph::open(&ser_dir).unwrap();
-        assert_eq!(ser.len(), mem.len(), "serial external triple count differs");
-        assert_eq!(ser.dict.len(), mem.dict.len(), "serial external dict size differs");
+        // The PATH UNDER TEST: the sharded external builder must now ACCEPT triple terms.
+        Graph::build_external_opts(nt.as_bytes(), "ntriples", &sh_dir, 256, true)
+            .expect("sharded external build must now accept triple terms (sq-t3rt)");
 
-        // SHARDED external path (sharded = true) rejects it with a clear, actionable error.
-        let sh_dir = base.join("sharded");
-        let err = Graph::build_external_opts(nt.as_bytes(), "ntriples", &sh_dir, 256, true)
-            .expect_err("sharded external build must reject triple terms");
-        assert!(err.contains("triple term"), "error must name triple terms: {err}");
-        assert!(err.contains("build_external"), "error must point at the external builder: {err}");
+        let ser = Graph::open(&ser_dir).unwrap();
+        let sh = Graph::open(&sh_dir).unwrap();
+        assert_eq!(sh.len(), mem.len(), "sharded external triple count differs from in-memory");
+        assert_eq!(sh.len(), ser.len(), "sharded external triple count differs from serial");
+        assert_eq!(sh.dict.len(), mem.dict.len(), "sharded external dict size differs from in-memory");
+        assert_eq!(sh.dict.len(), ser.dict.len(), "sharded external dict size differs from serial");
+
+        // Round-trip every stored triple back to its terms (recursively expanding triple
+        // terms via `Dict::term`), sort, and compare — id-assignment-order independent. This
+        // proves the cross-shard triple-term bijection: the same triple term shared by two
+        // statements resolves to ONE term, and nested/blank/cross-namespace components all
+        // reconstruct correctly.
+        let dump = |g: &Graph| {
+            let scan = g.store.scan(&[None, None, None]);
+            let mut v: Vec<(String, String, String)> = scan
+                .rows
+                .iter()
+                .map(|r| {
+                    let spo = scan.to_spo(r);
+                    (g.dict.term(spo[0]).to_string(), g.dict.term(spo[1]).to_string(), g.dict.term(spo[2]).to_string())
+                })
+                .collect();
+            v.sort();
+            v
+        };
+        let d_mem = dump(&mem);
+        let d_ser = dump(&ser);
+        let d_sh = dump(&sh);
+        assert_eq!(d_sh, d_mem, "sharded external build differs from in-memory load (triple terms)");
+        assert_eq!(d_sh, d_ser, "sharded external build differs from serial external (triple terms)");
+
+        // Cross-shard dedup is OBSERVABLE: the triple term shared by <r1>/<r1b> must be ONE
+        // dictionary entry referenced by both statements, i.e. their objects share an id.
+        let tt = Term::Triple(Box::new(oxrdf::Triple::new(
+            oxrdf::NamedNode::new("http://alpha.example/alice").unwrap(),
+            oxrdf::NamedNode::new("http://beta.example/age").unwrap(),
+            Term::Literal(Literal::new_typed_literal("30", xsd::INTEGER)),
+        )));
+        let tt_id = sh.id_of(&tt).expect("the shared triple term must be in the sharded dict");
+        let r1 = sh.id_of(&Term::NamedNode(oxrdf::NamedNode::new("http://ex/r1").unwrap())).unwrap();
+        let r1b = sh.id_of(&Term::NamedNode(oxrdf::NamedNode::new("http://ex/r1b").unwrap())).unwrap();
+        let n_r1 = sh.store.scan(&[Some(r1), None, None]).rows.len();
+        let n_r1b = sh.store.scan(&[Some(r1b), None, None]).rows.len();
+        assert_eq!(n_r1, 1, "<r1> must have exactly one statement");
+        assert_eq!(n_r1b, 1, "<r1b> must have exactly one statement");
+        // Both reifier statements point at the SAME triple-term id (the bijection held).
+        let obj_of = |s: Id| {
+            let scan = sh.store.scan(&[Some(s), None, None]);
+            scan.to_spo(&scan.rows[0])[2]
+        };
+        assert_eq!(obj_of(r1), tt_id, "<r1>'s object is the shared triple term");
+        assert_eq!(obj_of(r1b), tt_id, "<r1b>'s object is the SAME shared triple term id");
+
         std::fs::remove_dir_all(&base).ok();
+    }
+
+    /// [OPUS-4.8] (sq-t3rt) The PIPELINED sharded IN-RAM loader (`load_reader_parallel` →
+    /// `load_ntriples_pipelined` → `sharded_extend` → `ShardedDict::intern_partials`) shares
+    /// the same consolidation as the sharded external builder, so the same fix lets it
+    /// handle triple terms too (it would previously have PANICKED in a shard worker via
+    /// `intern_parts`). Verify it round-trips identically to the serial `load_reader`.
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn load_reader_parallel_handles_triple_terms() {
+        let mut nt = String::new();
+        for i in 0..1500u32 {
+            nt.push_str(&format!(
+                "<http://ex/n{}> <http://ex/p{}> \"{}\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
+                i % 97,
+                i % 7,
+                i % 300
+            ));
+            if i % 300 == 0 {
+                nt.push_str("<http://ex/r1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( <http://alpha.example/s> <http://beta.example/p> <<( <http://gamma.example/a> <http://delta.example/b> \"x\" )>> )>> .\n");
+            }
+        }
+        let par = Graph::load_reader_parallel(nt.as_bytes(), "ntriples").unwrap();
+        let seq = Graph::load_reader(nt.as_bytes(), "ntriples").unwrap();
+        assert_eq!(par.len(), seq.len());
+        assert_eq!(par.dict.len(), seq.dict.len());
+        let dump = |g: &Graph| {
+            let scan = g.store.scan(&[None, None, None]);
+            let mut v: Vec<(String, String, String)> = scan
+                .rows
+                .iter()
+                .map(|r| {
+                    let spo = scan.to_spo(r);
+                    (g.dict.term(spo[0]).to_string(), g.dict.term(spo[1]).to_string(), g.dict.term(spo[2]).to_string())
+                })
+                .collect();
+            v.sort();
+            v
+        };
+        assert_eq!(dump(&par), dump(&seq));
     }
 
     #[test]

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -1023,7 +1023,9 @@ impl Graph {
             // assignment matches the non-pipelined load (deterministic).
             for partials in prx {
                 if sharded {
-                    sharded_extend(&mut sd, &partials, &mut all);
+                    // [OPUS-4.8] Propagate a malformed-triple-term error (the streaming sharded
+                    // path is not triple-term-guarded) instead of panicking.
+                    sharded_extend(&mut sd, &partials, &mut all)?;
                 } else {
                     for (pd, pt) in partials {
                         let remap = global.merge_remap(&pd);
@@ -2689,7 +2691,10 @@ fn merge_partials(partials: ChunkPartials) -> (Dict, Vec<[Id; 3]>) {
     // ceiling — load plateaued at ~1.8× on 4 identical cores — was exactly this stage).
     let mut sd = dict::ShardedDict::new(default_shards());
     let mut all: Vec<[Id; 3]> = Vec::with_capacity(total);
-    sharded_extend(&mut sd, &partials, &mut all);
+    // [OPUS-4.8] `sharded_extend` can only `Err` on a malformed triple term, but the guard
+    // above (`has_triple_terms` ⇒ serial path) means this branch is triple-term-free — so an
+    // error here is an internal invariant breach, not recoverable input. Surface it loudly.
+    sharded_extend(&mut sd, &partials, &mut all).expect("sharded merge: triple-term-free path must not error");
     finish_sharded(sd, all)
 }
 
@@ -2704,15 +2709,22 @@ fn default_shards() -> usize {
 /// triples (remapped to TEMPORARY sharded ids, inline ids passing through) to `all` — the
 /// parallel-merge step shared by the in-memory N-Triples loaders. The remap gather runs
 /// in parallel (indexed `par_extend`, deterministic order).
+// [OPUS-4.8] Returns `Err` (propagated, not panicking) when a partial carries a malformed
+// triple term — see `ShardedDict::intern_partials`.
 #[cfg(feature = "parallel")]
-fn sharded_extend(sd: &mut dict::ShardedDict, partials: &[(Dict, Vec<[Id; 3]>)], all: &mut Vec<[Id; 3]>) {
+fn sharded_extend(
+    sd: &mut dict::ShardedDict,
+    partials: &[(Dict, Vec<[Id; 3]>)],
+    all: &mut Vec<[Id; 3]>,
+) -> Result<(), String> {
     use rayon::prelude::*;
-    let remaps = sd.intern_partials(partials);
+    let remaps = sd.intern_partials(partials)?;
     for (pidx, (_, ptriples)) in partials.iter().enumerate() {
         let rm = &remaps[pidx];
         let map = |id: Id| if id >= dict::INLINE_BASE { id } else { rm[id as usize] };
         all.par_extend(ptriples.par_iter().map(|&[s, p, o]| [map(s), map(p), map(o)]));
     }
+    Ok(())
 }
 
 /// Consolidates the sharded dict into one `Dict` (parallel arena move + parallel-hash
@@ -3381,7 +3393,8 @@ fn build_external_ntriples_sharded<R: std::io::Read + Send>(
         let feed = || -> Result<(), String> {
             for partials in prx {
                 let t_merge = build_timing::start(timing);
-                let remaps = sharded.intern_partials(&partials);
+                // [OPUS-4.8] Propagate a malformed-triple-term error instead of panicking.
+                let remaps = sharded.intern_partials(&partials)?;
                 build_timing::record(t_merge, &build_timing::MERGE_NS);
                 if rtx.send((partials, remaps)).is_err() {
                     return Ok(()); // the remap stage errored and dropped the receiver


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Fixes bead **sq-t3rt**.

## Problem
The disk-spilling **SHARDED** external N-Triples builder (`Graph::build_external` → `build_external_ntriples_sharded`) rejected RDF 1.2 triple terms `<<( s p o )>>`. A triple term's *content* is its components' ids, which cannot be content-hash-routed to a shard like a leaf term — so the cross-shard consolidation could not preserve the triple-term↔id bijection (it returned a clear error via `reject_triple_terms_in_external_build`). The SERIAL external path and the in-memory loader already handled triple terms structurally via `merge_remap`.

## Fix — a dedicated triple-term shard
`ShardedDict` now holds `n_leaf` leaf shards **plus one triple-term shard** (`shards[n_leaf]`):

- Leaf terms route to the `n_leaf` leaf shards by content hash, **unchanged**.
- Triple terms are interned in a **serial second pass**, content-addressed by their components' already-resolved **temp** ids (children precede their triple in a partial's arena, so each component's remap entry — leaf *or* nested triple — is filled when the triple is reached).
- The triple shard sorts **last** (highest `base`), so every triple term's final id exceeds every leaf's; `into_merged` resolves each `Stored::Triple`'s component temp ids to final ids with the same order-preserving `remap_sharded` the perm files already use.
- `stride` is sized for `n_leaf + 1` shards so the triple shard's temp ids stay below `INLINE_BASE`. **Final ids are `base[shard] + local` (stride-independent), so leaf-only output stays byte-identical to before** — the `dict_spill_build_byte_identical_to_sharded` contract is preserved.

This also lets the pipelined sharded **in-RAM** loader (`load_reader_parallel`) handle triple terms instead of panicking in a shard worker (it shares `ShardedDict::intern_partials`).

### Cross-shard bijection
A triple term shared by two statements dedups to **one** triple-shard id (its components resolve to the same stable temp ids in both partials → same `hash_triple_ids` → one entry). Nested triple terms and cross-namespace components (routed to different leaf shards) all reconstruct correctly. Triple-shard id assignment follows global first-occurrence order and is chunking-invariant, like the leaf path.

## Out of scope — sibling bead sq-jvbr
The **dict-spill** external builder is *not* changed here: its disk-staged interner serializes terms by content only and has no triple-term representation. That is sibling bead **sq-jvbr** (deliberately untouched to avoid a conflicting edit). Its rejection guard is retained, retargeted to sq-jvbr, and now covered by a test.

## Tests (differential, mirroring the N-Quads style)
- `external_build_triple_terms_sharded_matches_serial_and_memory` — builds reified N-Triples (cross-namespace components → different shards; a triple term shared by two statements; a leaf shared between a plain triple and a TT component; nested triple terms; a blank-node component; multi-chunk input) through the **sharded external** builder and round-trips identically to the serial external path **and** the in-memory loader; asserts the shared triple term dedups to **one** id referenced by both reifiers.
- `load_reader_parallel_handles_triple_terms` — the pipelined sharded in-RAM loader round-trips triple terms identically to serial `load_reader`.
- `dict_spill_rejects_non_ntriples_and_opens_mmap` — extended to assert the dict-spill path still rejects triple terms with an actionable error (sq-jvbr).

## Gate
- `cargo test -p sparq-core` green on **default**, **`--features mmap`**, and **`--features mmap,dict-spill`**.
- `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings` clean.
- No ratchet regressions (storage/encoding change covered by the byte-identity differentials + dict-spill coverage).

Authored under the Opus 4.8 fallback (`[OPUS-4.8]` markers + commit trailer) for re-review when the stronger model returns.