### PR TITLE
ci(zk): toolchain-gated lane for the forge/anchor suite + f64/k2 bb anchors (sq-f9tl)

### DIFF
--- a/.github/workflows/zk-toolchain.yml
+++ b/.github/workflows/zk-toolchain.yml
@@ -23,12 +23,15 @@
 #     wait on it; it stays a nightly safety net, not a per-PR tax).
 #
 # TOOLCHAIN PINNING (supply-chain): the Noir/Barretenberg toolchain is version-managed
-# by `noirup` / `bbup` (there is no published GitHub Action for it). The installer
-# scripts are fetched from a SHA-PINNED ref of the noir-lang/barretenberg repos, and the
-# tool versions themselves are pinned to the exact versions this repo's circuits were
-# authored + anchored against (NARGO_VERSION / BB_VERSION below) — matching the box that
-# captured the empirical bb anchors in verifier.rs. A toolchain bump is therefore an
-# explicit edit here (and re-captures the anchors), never a silent floating "latest".
+# by `noirup` / `bbup` (there is no published GitHub Action for it). The bootstrappers
+# themselves are fetched from a pinned source — the `noirup` binary from a TAGGED release
+# and the `bbup` script from a SHA-PINNED ref — NOT via the upstream `install` helpers,
+# which re-fetch the actual tool from a floating "latest"/`next` (see the env: block for
+# why that silently defeats a pin). The tool versions are then pinned to the exact versions
+# this repo's circuits were authored + anchored against (NARGO_VERSION / BB_VERSION below)
+# — matching the box that captured the empirical bb anchors in verifier.rs. A toolchain
+# bump is therefore an explicit edit here (and re-captures the anchors), never a silent
+# floating "latest".
 name: zk-toolchain
 
 on:
@@ -68,14 +71,28 @@ env:
   # the anchors) — never float to "latest".
   NARGO_VERSION: "1.0.0-beta.21"
   BB_VERSION: "5.0.0-nightly.20260324"
-  # SHA-pinned installer-script refs (supply-chain: avoid an unpinned `curl | bash` of a
-  # moving branch). The noirup / bbup *installers* are version-managers, not the tools —
-  # they bootstrap the `noirup` / `bbup` binaries, which then install the EXACT pinned
-  # NARGO_VERSION / BB_VERSION below. We pin the installer fetch to a specific commit so
-  # the bootstrap script itself can't change under us; the trailing comment records the
-  # repo + branch the SHA was taken from, for legible Dependabot-style bumps.
-  NOIRUP_REF: "324a51fca2c410d2477400316efc5ce0d743a5b3" # noir-lang/noirup @ main
-  BBUP_REF: "e80a3ada0bdc5501ff74fb2df7c9c99a19167049"   # AztecProtocol/aztec-packages @ next
+  # Pinned bootstrap sources (supply-chain: avoid an unpinned `curl | bash` of a moving
+  # branch). The noirup / bbup *bootstrappers* are version-managers, not the tools — they
+  # then install the EXACT pinned NARGO_VERSION / BB_VERSION below.
+  #
+  # [OPUS-4.8] sq-f9tl (Copilot review): we deliberately do NOT run the upstream `install`
+  # *helper* scripts, because each re-fetches the actual tool from a FLOATING source even
+  # when the helper itself is pinned by SHA — silently defeating the pin:
+  #   • noirup's `install` curls the `noirup` binary from `releases/latest/download/noirup`
+  #     (a moving "latest"), and
+  #   • bbup's `barretenberg/bbup/install` hard-codes
+  #     `BBUP_URL=…/AztecProtocol/aztec-packages/next/barretenberg/bbup/bbup`, re-downloading
+  #     the `bbup` script from the moving `next` branch.
+  # Instead we fetch the *actual* tool from a pinned source directly:
+  #   • the `noirup` binary from a TAGGED release (NOIRUP_BIN_URL @ NOIRUP_RELEASE), and
+  #   • the `bbup` script from the SHA-pinned ref (BBUP_REF) — the real tool, not the helper
+  #     that re-fetches it from `next`.
+  # The two-level pin is now genuine end-to-end: pinned bootstrapper + pinned tool version.
+  # (bbup then downloads the bb binary tarball from a release URL keyed by the exact
+  # BB_VERSION, so the backend binary is version-pinned too.)
+  NOIRUP_RELEASE: "v0.1.4" # noir-lang/noirup release tag (pins the noirup binary itself)
+  NOIRUP_BIN_URL: "https://github.com/noir-lang/noirup/releases/download/v0.1.4/noirup"
+  BBUP_REF: "e80a3ada0bdc5501ff74fb2df7c9c99a19167049" # AztecProtocol/aztec-packages @ next (the bbup script is pinned to this SHA)
 
 jobs:
   forge-suite:
@@ -95,32 +112,40 @@ jobs:
           # Distinct cache key: this lane builds sparq-zk* with the toolchain present.
           key: zk-toolchain
 
-      # Install nargo via noirup, pinned to NARGO_VERSION. Step 1 fetches the noirup
-      # bootstrap script from a SHA-pinned raw ref (NOIRUP_REF) and runs it to drop the
-      # `noirup` binary into ~/.nargo/bin; step 2 runs `noirup --version` to install the
-      # EXACT nargo. Two-level pinning: installer ref + installed-tool version.
+      # Install nargo via noirup, pinned to NARGO_VERSION. We fetch the `noirup` binary
+      # DIRECTLY from a tagged release (NOIRUP_BIN_URL) rather than running upstream's
+      # `install` helper, because that helper curls noirup from `releases/latest` (a moving
+      # target that defeats the pin — Copilot review, sq-f9tl). `noirup --version` then
+      # installs the EXACT nargo. Two-level pinning: pinned noirup release + pinned nargo.
       - name: Install nargo (Noir) — pinned
         run: |
           set -euo pipefail
+          mkdir -p "$HOME/.nargo/bin"
           curl -fsSL --proto '=https' --tlsv1.2 \
-            "https://raw.githubusercontent.com/noir-lang/noirup/${NOIRUP_REF}/install" \
-            -o /tmp/noirup-install.sh
-          bash /tmp/noirup-install.sh
+            "${NOIRUP_BIN_URL}" \
+            -o "$HOME/.nargo/bin/noirup"
+          chmod +x "$HOME/.nargo/bin/noirup"
           echo "$HOME/.nargo/bin" >> "$GITHUB_PATH"
           export PATH="$HOME/.nargo/bin:$PATH"
           noirup --version "${NARGO_VERSION}"
           nargo --version
 
-      # Install Barretenberg (bb) via bbup, pinned to BB_VERSION. Same two-level pinning:
-      # SHA-pinned bbup installer ref + exact bb --version. The bbup installer lives in the
-      # AztecProtocol/aztec-packages monorepo (barretenberg/bbup/install).
+      # Install Barretenberg (bb) via bbup, pinned to BB_VERSION. We fetch the `bbup` SCRIPT
+      # DIRECTLY from the SHA-pinned ref (BBUP_REF) rather than running upstream's `install`
+      # helper, because that helper re-downloads bbup from the moving `next` branch and so
+      # defeats the SHA pin (Copilot review, sq-f9tl). `bbup --version "${BB_VERSION}"` then
+      # downloads the bb binary tarball from a release URL keyed by that exact version, so
+      # the backend binary is version-pinned. Two-level pinning: pinned bbup @ BBUP_REF +
+      # pinned bb version. (The bbup script accepts `-v|--version <ver>`; `--version <ver>`
+      # binds `<ver>` as its argument.)
       - name: Install bb (Barretenberg) — pinned
         run: |
           set -euo pipefail
+          mkdir -p "$HOME/.bb"
           curl -fsSL --proto '=https' --tlsv1.2 \
-            "https://raw.githubusercontent.com/AztecProtocol/aztec-packages/${BBUP_REF}/barretenberg/bbup/install" \
-            -o /tmp/bbup-install.sh
-          bash /tmp/bbup-install.sh
+            "https://raw.githubusercontent.com/AztecProtocol/aztec-packages/${BBUP_REF}/barretenberg/bbup/bbup" \
+            -o "$HOME/.bb/bbup"
+          chmod +x "$HOME/.bb/bbup"
           echo "$HOME/.bb" >> "$GITHUB_PATH"
           export PATH="$HOME/.bb:$PATH"
           bbup --version "${BB_VERSION}"

--- a/.github/workflows/zk-toolchain.yml
+++ b/.github/workflows/zk-toolchain.yml
@@ -1,0 +1,148 @@
+# zk-toolchain — toolchain-gated lane for the ZK forge/anchor suite (sq-f9tl, re-audit NEW-1).
+# [OPUS-4.8] authored while Fable 5 unavailable — re-review when Fable returns.
+#
+# WHY: the repo's STRONGEST correctness claim is ZK *verifier soundness* — the
+# forge-and-verify negative suite (forge_pubinput_* in forge_gates.rs, the real
+# bb prove/verify e2e cases) that proves a forged proof/manifest is REJECTED. Those
+# tests need a real `nargo execute` + `bb prove`/`verify`, so they are `#[ignore]`d
+# and DO NOT run in the default `cargo test` lane (ci.yml). That left the soundness
+# claim with NO standing CI coverage: a regression in the hand-serialized public-input
+# reconstruction (`verifier.rs::reconstruct_public_inputs`) — a field-order / endianness
+# / arity slip — could re-open the whole estate without a single red check. This lane
+# installs the PINNED Noir toolchain and runs those `#[ignore]`d tests, so a forge that
+# verifies (or a serialization drift that breaks an empirical bb anchor) fails visibly.
+#
+# TRIGGER (deliberately OFF the fast per-PR critical path — the toolchain install +
+# real proving is slow):
+#   • schedule (nightly 04:23 UTC)  — the standing safety net.
+#   • workflow_dispatch             — on demand.
+#   • pull_request / push to main RESTRICTED by a path filter to ZK-touching paths
+#     (crates/sparq-zk*/**, zk/**, this workflow) — so a ZK change DOES get the forge
+#     suite run (and gates that PR via ci-summary, which is correct), while a non-ZK PR
+#     never triggers this workflow at all (no check-run created => ci-summary doesn't
+#     wait on it; it stays a nightly safety net, not a per-PR tax).
+#
+# TOOLCHAIN PINNING (supply-chain): the Noir/Barretenberg toolchain is version-managed
+# by `noirup` / `bbup` (there is no published GitHub Action for it). The installer
+# scripts are fetched from a SHA-PINNED ref of the noir-lang/barretenberg repos, and the
+# tool versions themselves are pinned to the exact versions this repo's circuits were
+# authored + anchored against (NARGO_VERSION / BB_VERSION below) — matching the box that
+# captured the empirical bb anchors in verifier.rs. A toolchain bump is therefore an
+# explicit edit here (and re-captures the anchors), never a silent floating "latest".
+name: zk-toolchain
+
+on:
+  schedule:
+    # Nightly safety net at 04:23 UTC (offset from ci.yml's 03:17 coverage tier so
+    # the two heavy nightly lanes don't contend for the same runner window).
+    - cron: "23 4 * * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "crates/sparq-zk/**"
+      - "crates/sparq-zk-compose/**"
+      - "zk/**"
+      - ".github/workflows/zk-toolchain.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/sparq-zk/**"
+      - "crates/sparq-zk-compose/**"
+      - "zk/**"
+      - ".github/workflows/zk-toolchain.yml"
+
+# Least-privilege: this lane only reads the repo + runs tests.
+permissions:
+  contents: read
+
+concurrency:
+  group: zk-toolchain-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  # Pinned Noir toolchain — the versions the circuits were authored against and the
+  # empirical bb public-input anchors in verifier.rs were captured from. Bump these
+  # deliberately (and re-run the e2e `probe_*_public_inputs_hex` tests to re-capture
+  # the anchors) — never float to "latest".
+  NARGO_VERSION: "1.0.0-beta.21"
+  BB_VERSION: "5.0.0-nightly.20260324"
+  # SHA-pinned installer-script refs (supply-chain: avoid an unpinned `curl | bash` of a
+  # moving branch). The noirup / bbup *installers* are version-managers, not the tools —
+  # they bootstrap the `noirup` / `bbup` binaries, which then install the EXACT pinned
+  # NARGO_VERSION / BB_VERSION below. We pin the installer fetch to a specific commit so
+  # the bootstrap script itself can't change under us; the trailing comment records the
+  # repo + branch the SHA was taken from, for legible Dependabot-style bumps.
+  NOIRUP_REF: "324a51fca2c410d2477400316efc5ce0d743a5b3" # noir-lang/noirup @ main
+  BBUP_REF: "e80a3ada0bdc5501ff74fb2df7c9c99a19167049"   # AztecProtocol/aztec-packages @ next
+
+jobs:
+  forge-suite:
+    name: zk forge + anchor suite (nargo/bb)
+    runs-on: ubuntu-latest
+    # Toolchain install + real bb proving is the long pole; generous headroom.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo + target
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Distinct cache key: this lane builds sparq-zk* with the toolchain present.
+          key: zk-toolchain
+
+      # Install nargo via noirup, pinned to NARGO_VERSION. Step 1 fetches the noirup
+      # bootstrap script from a SHA-pinned raw ref (NOIRUP_REF) and runs it to drop the
+      # `noirup` binary into ~/.nargo/bin; step 2 runs `noirup --version` to install the
+      # EXACT nargo. Two-level pinning: installer ref + installed-tool version.
+      - name: Install nargo (Noir) — pinned
+        run: |
+          set -euo pipefail
+          curl -fsSL --proto '=https' --tlsv1.2 \
+            "https://raw.githubusercontent.com/noir-lang/noirup/${NOIRUP_REF}/install" \
+            -o /tmp/noirup-install.sh
+          bash /tmp/noirup-install.sh
+          echo "$HOME/.nargo/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.nargo/bin:$PATH"
+          noirup --version "${NARGO_VERSION}"
+          nargo --version
+
+      # Install Barretenberg (bb) via bbup, pinned to BB_VERSION. Same two-level pinning:
+      # SHA-pinned bbup installer ref + exact bb --version. The bbup installer lives in the
+      # AztecProtocol/aztec-packages monorepo (barretenberg/bbup/install).
+      - name: Install bb (Barretenberg) — pinned
+        run: |
+          set -euo pipefail
+          curl -fsSL --proto '=https' --tlsv1.2 \
+            "https://raw.githubusercontent.com/AztecProtocol/aztec-packages/${BBUP_REF}/barretenberg/bbup/install" \
+            -o /tmp/bbup-install.sh
+          bash /tmp/bbup-install.sh
+          echo "$HOME/.bb" >> "$GITHUB_PATH"
+          export PATH="$HOME/.bb:$PATH"
+          bbup --version "${BB_VERSION}"
+          bb --version
+
+      - name: Toolchain versions (record for the run log)
+        run: |
+          echo "nargo: $(nargo --version | head -1)"
+          echo "bb:    $(bb --version)"
+
+      # Build the ZK crates' test targets first so a compile failure is distinct from a
+      # proving failure in the logs.
+      - name: Build sparq-zk* test targets
+        run: cargo build -p sparq-zk -p sparq-zk-compose --all-targets
+
+      # The load-bearing step: run EVERY `#[ignore]`d test in the ZK crates. With the
+      # toolchain on PATH the forge tests do a REAL bb prove and assert every forgery is
+      # REJECTED (and the positive controls verify); the empirical bb anchors re-validate
+      # the public-input serialization. --test-threads=1 keeps concurrent bb subprocesses
+      # from contending for the runner; nextest is NOT used here because these are slow,
+      # serialized, toolchain-bound cases (the retry/process-isolation nextest buys us on
+      # the fast lane is not what this lane needs).
+      - name: Run the ignored ZK forge + anchor + e2e suite (real bb)
+        run: |
+          cargo test -p sparq-zk-compose -p sparq-zk -- --ignored --test-threads=1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ After a batch of changes, re-run only the evaluations whose inputs changed — o
 | a public API (`pub` item / CLI flag / HTTP route / Py/JS binding) | update the matching `skills/<surface>/SKILL.md` (REQUIRED, same change); the surface's tests |
 | `sparq-wasm` / the wasm graph | `scripts/wasm-deps-guard.sh`; `wasm-pack test --node`; the `wasm_bundle_bytes` size gate |
 | Cargo dependencies (`Cargo.toml`/`Cargo.lock`) | `cargo audit` + `cargo deny check` + regenerate the SBOM (supply-chain gate) |
-| the ZK verifier / circuits (`sparq-zk`, `sparq-zk-compose`) | `forge_gates` + `differential_fuzz`; the gate-count snapshot; re-open the soundness audit |
+| the ZK verifier / circuits (`sparq-zk`, `sparq-zk-compose`) | `forge_gates` + `differential_fuzz`; the gate-count snapshot; re-open the soundness audit; the **`zk-toolchain` lane** (`.github/workflows/zk-toolchain.yml`) — runs the `#[ignore]`d real-`bb` forge/anchor suite under the pinned Noir toolchain (nightly + `workflow_dispatch` + on ZK-path PRs). If you change the public-input serialization (`verifier.rs::reconstruct_public_inputs`) re-capture the empirical bb anchors via the `probe_*_public_inputs_hex` e2e probes |
 | SHACL (`sparq-shacl`) | the W3C SHACL conformance ratchet (core ≥98, sparql ≥5) |
 | storage/encoding (`sparq-core` store/dict/compress, mmap, dict-spill) | the deterministic perf-gate metrics; byte-identity differentials; coverage with `--features dict-spill` |
 | anything merged | the per-crate coverage ratchet + test-presence gate (`scripts/coverage*.py`) |

--- a/crates/sparq-zk-compose/src/verifier.rs
+++ b/crates/sparq-zk-compose/src/verifier.rs
@@ -3712,8 +3712,11 @@ mod tests {
             "0000000000000000000000000000000000000000000000000000000000000001",
         ))
         .unwrap();
+        // [OPUS-4.8] sq-f9tl (Copilot review): each closure is named for the (s,p,o)
+        // COLUMN it fills, so the anchor rows read in triple order — `subj` is the
+        // subject (ex:alice), `age` the predicate (ex:age), `z` a zero field.
         let z = || fh("0x0");
-        let p = || fh("0x067d8d75b405117a4cce58d59db1cbe420dabf0ff8d4c0fa50d80ccf0ed4a713");
+        let subj = || fh("0x067d8d75b405117a4cce58d59db1cbe420dabf0ff8d4c0fa50d80ccf0ed4a713");
         let age = || fh("0x057914fc592ade7b970f92e4992958ea8a6a265caeb012b5b63903257eef5b61");
         let inputs = ProofInputs::Scan {
             id: CircuitId::Scan { k: 2, n: 16, r: 8 },
@@ -3724,12 +3727,12 @@ mod tests {
             pattern_is_const: [false, true, false],
             pattern_const_enc: [z(), age(), z()],
             rows: vec![
-                [p(), age(), fh("0x08a387a1d4e98da1fcf28c25bc413f88d5ff771682c18f432f0f03971fad9602")],
-                [p(), age(), fh("0x1aff50a8f430c8288c8a386adefff02a20c75db111a6ef0dcb71e3d63c36e39e")],
-                [p(), age(), fh("0x1e76b7d5b462137832e8c482bf0e84cd27acff5af29ab19f584b7e4e5279c3c6")],
-                [p(), age(), fh("0x132fa587351bf3f12fd3cbed64d5526f28791099d1d40870f94595873c78fa72")],
-                [p(), age(), fh("0x30202cbdd89765b9370d4790b6f7f073a95ef2ffbd731b53ce49cd2eb86614f0")],
-                [p(), age(), fh("0x16cd94467389dbde075372360eadb589f417d9e8c79507a34293ef3478b2d68b")],
+                [subj(), age(), fh("0x08a387a1d4e98da1fcf28c25bc413f88d5ff771682c18f432f0f03971fad9602")],
+                [subj(), age(), fh("0x1aff50a8f430c8288c8a386adefff02a20c75db111a6ef0dcb71e3d63c36e39e")],
+                [subj(), age(), fh("0x1e76b7d5b462137832e8c482bf0e84cd27acff5af29ab19f584b7e4e5279c3c6")],
+                [subj(), age(), fh("0x132fa587351bf3f12fd3cbed64d5526f28791099d1d40870f94595873c78fa72")],
+                [subj(), age(), fh("0x30202cbdd89765b9370d4790b6f7f073a95ef2ffbd731b53ce49cd2eb86614f0")],
+                [subj(), age(), fh("0x16cd94467389dbde075372360eadb589f417d9e8c79507a34293ef3478b2d68b")],
             ],
             row_count: 6,
             attribution: vec![true, true],

--- a/crates/sparq-zk-compose/src/verifier.rs
+++ b/crates/sparq-zk-compose/src/verifier.rs
@@ -3620,6 +3620,125 @@ mod tests {
         assert_eq!(got, bb, "scan reconstruction must byte-match bb");
     }
 
+    /// [OPUS-4.8] sq-f9tl (re-audit NEW-1): EMPIRICAL anchor for the
+    /// `filter_f64_d{d}` family — the re-audit flagged it as relying on layout
+    /// reasoning with NO captured golden vector. `filter_f64_d2` over:
+    /// challenge=0x2a, operand_enc=0x1a9c…c990 ("25"^^xsd:double), op=Ge(3),
+    /// b_bits=0x4032000000000000 (18.0 IEEE-754), expected=true. 5 fields * 32 =
+    /// 160 bytes. Captured verbatim by `probe_filter_f64_public_inputs_hex`
+    /// (e2e.rs, ignored) from a real `bb prove`; a toolchain bump that changes
+    /// the f64 serialization breaks this test loudly.
+    #[test]
+    fn reconstruct_filter_f64_matches_real_bb_public_inputs() {
+        let bb = hex_decode(concat!(
+            // challenge
+            "000000000000000000000000000000000000000000000000000000000000002a",
+            // operand_enc ("25"^^xsd:double)
+            "1a9cfccd1a2354f0e79fefda14e00216260fce60b75bd34cace5606856c3c990",
+            // op = Ge (3)
+            "0000000000000000000000000000000000000000000000000000000000000003",
+            // b_bits = 18.0_f64 = 0x4032000000000000
+            "0000000000000000000000000000000000000000000000004032000000000000",
+            // expected = true
+            "0000000000000000000000000000000000000000000000000000000000000001",
+        ))
+        .unwrap();
+        let inputs = ProofInputs::FilterF64 {
+            id: CircuitId::FilterF64 { d: 2 },
+            operand_enc: fh("0x1a9cfccd1a2354f0e79fefda14e00216260fce60b75bd34cace5606856c3c990"),
+            op: FilterOp::Ge,
+            b_bits: 18.0_f64.to_bits(),
+            expected: true,
+        };
+        let got = reconstruct_public_inputs(&inputs, &fh("0x2a"), 0).unwrap();
+        assert_eq!(got.len(), 160);
+        assert_eq!(got, bb, "filter_f64 reconstruction must byte-match bb");
+    }
+
+    /// [OPUS-4.8] sq-f9tl (re-audit NEW-1): EMPIRICAL anchor for the k=2 scan
+    /// family (`scan_k2_n16_r8`) — the other un-anchored member the re-audit
+    /// flagged. Two named-graph credentials, each with 3 matching `ex:age`
+    /// triples (6 active rows, padded to r=8) and BOTH contributing (audit #8
+    /// attribution = [true, true]). 36 fields * 32 = 1152 bytes; this exercises
+    /// the k=2 commitment array, the trailing two-bit attribution word group, and
+    /// the r=8 pad path that the k=1 anchor cannot. Captured verbatim by
+    /// `probe_scan_k2_public_inputs_hex` (e2e.rs, ignored) from a real `bb prove`.
+    #[test]
+    fn reconstruct_scan_k2_matches_real_bb_public_inputs() {
+        let bb = hex_decode(concat!(
+            // challenge
+            "000000000000000000000000000000000000000000000000000000000000002a",
+            // commitments[0], commitments[1]
+            "3009ad0a7a02313686bfb8e9224a7a9a5d2f90653b3905243ffc826f8b1c4baf",
+            "1e182eccb67380e0a29dfbdd337b27daee9b2bc0c6d35e9dbc55be67b2acfa90",
+            // pattern_is_const [false,true,false]
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000001",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            // pattern_const_enc [0, ex:age, 0]
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "057914fc592ade7b970f92e4992958ea8a6a265caeb012b5b63903257eef5b61",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            // rows[0..6] = the 6 active matched rows (row-major s,p,o)
+            "067d8d75b405117a4cce58d59db1cbe420dabf0ff8d4c0fa50d80ccf0ed4a713",
+            "057914fc592ade7b970f92e4992958ea8a6a265caeb012b5b63903257eef5b61",
+            "08a387a1d4e98da1fcf28c25bc413f88d5ff771682c18f432f0f03971fad9602",
+            "067d8d75b405117a4cce58d59db1cbe420dabf0ff8d4c0fa50d80ccf0ed4a713",
+            "057914fc592ade7b970f92e4992958ea8a6a265caeb012b5b63903257eef5b61",
+            "1aff50a8f430c8288c8a386adefff02a20c75db111a6ef0dcb71e3d63c36e39e",
+            "067d8d75b405117a4cce58d59db1cbe420dabf0ff8d4c0fa50d80ccf0ed4a713",
+            "057914fc592ade7b970f92e4992958ea8a6a265caeb012b5b63903257eef5b61",
+            "1e76b7d5b462137832e8c482bf0e84cd27acff5af29ab19f584b7e4e5279c3c6",
+            "067d8d75b405117a4cce58d59db1cbe420dabf0ff8d4c0fa50d80ccf0ed4a713",
+            "057914fc592ade7b970f92e4992958ea8a6a265caeb012b5b63903257eef5b61",
+            "132fa587351bf3f12fd3cbed64d5526f28791099d1d40870f94595873c78fa72",
+            "067d8d75b405117a4cce58d59db1cbe420dabf0ff8d4c0fa50d80ccf0ed4a713",
+            "057914fc592ade7b970f92e4992958ea8a6a265caeb012b5b63903257eef5b61",
+            "30202cbdd89765b9370d4790b6f7f073a95ef2ffbd731b53ce49cd2eb86614f0",
+            "067d8d75b405117a4cce58d59db1cbe420dabf0ff8d4c0fa50d80ccf0ed4a713",
+            "057914fc592ade7b970f92e4992958ea8a6a265caeb012b5b63903257eef5b61",
+            "16cd94467389dbde075372360eadb589f417d9e8c79507a34293ef3478b2d68b",
+            // rows[6..8] = 2 zero rows (6 zero words) padding to r=8
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            // row_count = 6
+            "0000000000000000000000000000000000000000000000000000000000000006",
+            // attribution[0], attribution[1] = both true (audit #8)
+            "0000000000000000000000000000000000000000000000000000000000000001",
+            "0000000000000000000000000000000000000000000000000000000000000001",
+        ))
+        .unwrap();
+        let z = || fh("0x0");
+        let p = || fh("0x067d8d75b405117a4cce58d59db1cbe420dabf0ff8d4c0fa50d80ccf0ed4a713");
+        let age = || fh("0x057914fc592ade7b970f92e4992958ea8a6a265caeb012b5b63903257eef5b61");
+        let inputs = ProofInputs::Scan {
+            id: CircuitId::Scan { k: 2, n: 16, r: 8 },
+            commitments: vec![
+                fh("0x3009ad0a7a02313686bfb8e9224a7a9a5d2f90653b3905243ffc826f8b1c4baf"),
+                fh("0x1e182eccb67380e0a29dfbdd337b27daee9b2bc0c6d35e9dbc55be67b2acfa90"),
+            ],
+            pattern_is_const: [false, true, false],
+            pattern_const_enc: [z(), age(), z()],
+            rows: vec![
+                [p(), age(), fh("0x08a387a1d4e98da1fcf28c25bc413f88d5ff771682c18f432f0f03971fad9602")],
+                [p(), age(), fh("0x1aff50a8f430c8288c8a386adefff02a20c75db111a6ef0dcb71e3d63c36e39e")],
+                [p(), age(), fh("0x1e76b7d5b462137832e8c482bf0e84cd27acff5af29ab19f584b7e4e5279c3c6")],
+                [p(), age(), fh("0x132fa587351bf3f12fd3cbed64d5526f28791099d1d40870f94595873c78fa72")],
+                [p(), age(), fh("0x30202cbdd89765b9370d4790b6f7f073a95ef2ffbd731b53ce49cd2eb86614f0")],
+                [p(), age(), fh("0x16cd94467389dbde075372360eadb589f417d9e8c79507a34293ef3478b2d68b")],
+            ],
+            row_count: 6,
+            attribution: vec![true, true],
+        };
+        let got = reconstruct_public_inputs(&inputs, &fh("0x2a"), 0).unwrap();
+        assert_eq!(got.len(), 1152);
+        assert_eq!(got, bb, "scan_k2 reconstruction must byte-match bb");
+    }
+
     /// A different declared statement (a single mutated field) must produce a
     /// different vector — the property the byte-compare relies on (audit #1).
     #[test]

--- a/crates/sparq-zk-compose/tests/e2e.rs
+++ b/crates/sparq-zk-compose/tests/e2e.rs
@@ -3041,9 +3041,12 @@ fn probe_filter_f64_public_inputs_hex() {
 
 /// [OPUS-4.8] sq-f9tl (NEW-1): PROBE (ignored) that dumps the real bb
 /// `public_inputs` for a k=2 scan member (`scan_k2_n16_r8`), the other family the
-/// re-audit (NEW-1) flagged as un-anchored. Two single-triple credential graphs
-/// matching the same pattern => k=2, two true attribution bits, r padded to 8.
-/// Run with `--ignored` when the toolchain is present; paste into the unit test.
+/// re-audit (NEW-1) flagged as un-anchored. Two named-graph credentials (k=2), each
+/// carrying 3 matching `ex:age` triples (see `multi_age` / `0..3` below) => 6 active
+/// rows, which overflows the r=4 bucket and so reaches the only compiled k=2 member
+/// (r=8), with both credentials contributing (two true attribution bits) and the 6
+/// rows padded out to r=8. Run with `--ignored` when the toolchain is present; paste
+/// into the unit test.
 #[test]
 #[ignore = "probe: prints real bb public_inputs hex for the scan_k2 reconstruct unit test"]
 fn probe_scan_k2_public_inputs_hex() {

--- a/crates/sparq-zk-compose/tests/e2e.rs
+++ b/crates/sparq-zk-compose/tests/e2e.rs
@@ -3007,6 +3007,88 @@ fn probe_scan_public_inputs_hex() {
     eprintln!("SCAN_INPUTS_JSON={}", serde_json::to_string(&scan.inputs).unwrap());
 }
 
+/// [OPUS-4.8] sq-f9tl (NEW-1): PROBE (ignored) that dumps the real bb
+/// `public_inputs` for a `filter_f64_d{d}` member, so the
+/// `reconstruct_filter_f64_matches_real_bb_public_inputs` unit-test constant in
+/// `verifier.rs` is an EMPIRICAL anchor (not self-referential layout reasoning).
+/// The re-audit (NEW-1) flagged that only `filter_int_d1` + `scan_k1_n16_r4` had
+/// captured golden vectors; this closes the f64 family. Run with `--ignored`
+/// when the toolchain is present; paste the printed hex into the unit test.
+#[test]
+#[ignore = "probe: prints real bb public_inputs hex for the filter_f64 reconstruct unit test"]
+fn probe_filter_f64_public_inputs_hex() {
+    if !toolchain_available() {
+        eprintln!("nargo/bb absent; skipping probe");
+        return;
+    }
+    // operand = 25.0 (xsd:double), FILTER(?o >= 18.0) -> true. value has 2
+    // digits => filter_f64_d2 member.
+    let value: u64 = 25;
+    let operand_enc = encode_double_literal(value);
+    let (inputs, digits) =
+        build_filter_f64(operand_enc, value, FilterOp::Ge, 18.0_f64, true).expect("d2 builds");
+    assert_eq!(*inputs.circuit_id(), CircuitId::FilterF64 { d: 2 });
+    let challenge = FieldHex("0x2a".into());
+    let (id, toml) = prover_toml_for(&inputs, &challenge, &[], &[], &digits);
+    let prover = CircuitProver::from_crate_root();
+    let out = scratch("probe_filter_f64_pi");
+    let art = prover.prove_in(&id, &toml, &out, "probe_filter_f64_pi").unwrap();
+    let hex: String = art.public_inputs.iter().map(|b| format!("{b:02x}")).collect();
+    eprintln!("FILTER_F64_PUBLIC_INPUTS_LEN={}", art.public_inputs.len());
+    eprintln!("FILTER_F64_PUBLIC_INPUTS_HEX={hex}");
+    eprintln!("FILTER_F64_INPUTS_JSON={}", serde_json::to_string(&inputs).unwrap());
+}
+
+/// [OPUS-4.8] sq-f9tl (NEW-1): PROBE (ignored) that dumps the real bb
+/// `public_inputs` for a k=2 scan member (`scan_k2_n16_r8`), the other family the
+/// re-audit (NEW-1) flagged as un-anchored. Two single-triple credential graphs
+/// matching the same pattern => k=2, two true attribution bits, r padded to 8.
+/// Run with `--ignored` when the toolchain is present; paste into the unit test.
+#[test]
+#[ignore = "probe: prints real bb public_inputs hex for the scan_k2 reconstruct unit test"]
+fn probe_scan_k2_public_inputs_hex() {
+    if !toolchain_available() {
+        eprintln!("nargo/bb absent; skipping probe");
+        return;
+    }
+    // Two distinct named-graph credentials, each committed under its OWN salt
+    // (mirrors real ingest), each carrying SEVERAL `ex:age` triples so the union
+    // of matched rows exceeds the r=4 bucket and the build derives the r=8 member
+    // (`scan_k2_n16_r8` is the only compiled k=2 member: r buckets are {4,8} but
+    // no k2_r4 member is compiled — a >4-row match is what reaches a real member).
+    let multi_age = |base: u64| -> Vec<Triple> {
+        let subj = NamedOrBlankNode::NamedNode(iri("http://ex/alice"));
+        (0..3)
+            .map(|i| Triple::new(subj.clone(), iri("http://ex/age"), int_lit(base + i)))
+            .collect()
+    };
+    let salt_a = salt_from_bytes(&[7u8; 32]);
+    let salt_b = salt_from_bytes(&[9u8; 32]);
+    let commit_a = commit_triples(&multi_age(20), salt_a).unwrap();
+    let commit_b = commit_triples(&multi_age(30), salt_b).unwrap();
+    let pattern = Pattern {
+        s: Slot::Var,
+        p: Slot::Const(Term::NamedNode(iri("http://ex/age"))),
+        o: Slot::Var,
+    };
+    let scan = build_scan(&[commit_a, commit_b], &pattern).unwrap();
+    assert!(
+        matches!(scan.inputs.circuit_id(), CircuitId::Scan { k: 2, r: 8, .. }),
+        "two multi-age commitments must derive the compiled k=2, r=8 scan member"
+    );
+    let challenge = FieldHex("0x2a".into());
+    let (id, toml) =
+        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]);
+    let prover = CircuitProver::from_crate_root();
+    let out = scratch("probe_scan_k2_pi");
+    let art = prover.prove_in(&id, &toml, &out, "probe_scan_k2_pi").unwrap();
+    let hex: String = art.public_inputs.iter().map(|b| format!("{b:02x}")).collect();
+    eprintln!("SCAN_K2_ID={:?}", scan.inputs.circuit_id());
+    eprintln!("SCAN_K2_PUBLIC_INPUTS_LEN={}", art.public_inputs.len());
+    eprintln!("SCAN_K2_PUBLIC_INPUTS_HEX={hex}");
+    eprintln!("SCAN_K2_INPUTS_JSON={}", serde_json::to_string(&scan.inputs).unwrap());
+}
+
 // ===========================================================================
 // [OPUS-4.8] audit #12: revocation / freshness (forge-and-verify).
 // ===========================================================================


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Implements bead **sq-f9tl** (ZK re-audit NEW-1).

## Problem
The repo's strongest correctness claim is ZK **verifier soundness** — the forge-and-verify negative suite (`forge_pubinput_*` in `forge_gates.rs`, the real `bb prove`/`verify` e2e cases) proving a forged proof/manifest is REJECTED. Those tests need a real `nargo`/`bb`, so they are `#[ignore]`d and DON'T run in the default `cargo test` lane (`ci.yml`). That left soundness with **no standing CI coverage**: a regression in the hand-serialized public-input reconstruction (`verifier.rs::reconstruct_public_inputs`) could re-open the whole estate without a single red check.

## The lane — `.github/workflows/zk-toolchain.yml`
- **Installs the pinned Noir toolchain**: `nargo 1.0.0-beta.21` (via `noirup`), `bb 5.0.0-nightly.20260324` (via `bbup`). Two-level supply-chain pin — the installer scripts are fetched from **SHA-pinned** refs (`noir-lang/noirup`, `AztecProtocol/aztec-packages`), and the tool versions are pinned **exactly** (these match the box that captured the empirical bb anchors). A bump is an explicit edit, never a floating "latest".
- **Runs the ignored suite**: `cargo test -p sparq-zk-compose -p sparq-zk -- --ignored --test-threads=1` — the real-bb `forge_pubinput_*`, the e2e prove/verify + revoked-rejected cases, the `differential_fuzz` heavy variant, and the empirical bb anchors. Fails visibly on a forge that verifies or a serialization drift that breaks an anchor.
- **Trigger (OFF the per-PR critical path)**: nightly schedule (`04:23 UTC`) + `workflow_dispatch` + a **path-filtered** `pull_request`/`push` on `crates/sparq-zk*/**`, `zk/**`, and this workflow. A ZK PR DOES get the forge run (and gates via `ci-summary`, which is correct); a non-ZK PR never triggers it (no check-run ⇒ `ci-summary` doesn't wait on it ⇒ it stays a nightly safety net, not a per-PR tax).

## Empirical anchors (NEW-1 residual — generated, not beaded)
NEW-1 flagged that only `filter_int_d1` + `scan_k1_n16_r4` had captured golden vectors. This PR captures real `bb prove` `public_inputs` for the two un-anchored families and adds them as anchor unit tests in `verifier.rs`, plus the `probe_*_public_inputs_hex` e2e probes that regenerate them:
- `filter_f64_d2` — 160 B (`reconstruct_filter_f64_matches_real_bb_public_inputs`)
- `scan_k2_n16_r8` — 1152 B, k=2 commitments + two-bit attribution + r=8 pad (`reconstruct_scan_k2_matches_real_bb_public_inputs`)

So a toolchain bump that changes f64/k2 serialization now breaks an anchor loudly, same as the existing `filter_int`/`scan_k1` anchors.

## Validation (local, with the dev box's nargo/bb)
- All `#[ignore]`d ZK tests pass: **forgeries REJECT** (`forge_pubinput_statement_substitution_rejected`, `forge_pubinput_verdict_substitution_rejected`), positive control verifies; e2e 19/19, differential_fuzz heavy 1/1.
- New anchor unit tests pass (pure reconstruction byte-compare, no toolchain).
- `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings` clean.
- `actionlint` clean; YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).

Refs sq-f9tl; companion to sq-1gir (the forge regression map). Authored under the Opus 4.8 fallback (`[OPUS-4.8]` markers) — re-review when Fable returns.