### PR TITLE
feat(zk): enforce distinct-graph strict ordering in scan_check — close duplicate-inclusion / COUNT forgery (sq-vxq8)

### DIFF
--- a/bench/zk-compose/gate_counts_latest.json
+++ b/bench/zk-compose/gate_counts_latest.json
@@ -1,12 +1,12 @@
 {
-  "timestamp": "2026-06-13T08:58:37Z",
+  "timestamp": "2026-06-15T03:02:27Z",
   "tool": "bb gates -s ultra_honk",
   "bb_version": "5.0.0-nightly.20260324",
   "nargo_version": "nargo version = 1.0.0-beta.21",
   "benchmarks": {
-    "scan_k1_n16_r4": { "circuit_size": 5958 },
-    "scan_k2_n16_r8": { "circuit_size": 11011 },
-    "scan_k2_n64_r8": { "circuit_size": 34379 },
+    "scan_k1_n16_r4": { "circuit_size": 5991 },
+    "scan_k2_n16_r8": { "circuit_size": 11261 },
+    "scan_k2_n64_r8": { "circuit_size": 34821 },
     "filter_int_d1": { "circuit_size": 17416 },
     "filter_int_d2": { "circuit_size": 17416 },
     "filter_int_d4": { "circuit_size": 17416 },

--- a/crates/sparq-zk-compose/src/build.rs
+++ b/crates/sparq-zk-compose/src/build.rs
@@ -10,7 +10,7 @@
 use crate::manifest::{CircuitId, FieldHex, FilterOp, ProofInputs};
 use sparq_zk::commit::GraphCommitment;
 use sparq_zk::encode::encode_term;
-use sparq_zk::field::{field_to_hex, Fr};
+use sparq_zk::field::{field_to_be_bytes_32, field_to_hex, Fr};
 use oxrdf::{NamedNode, Term};
 
 /// Compiled slot buckets (`n`) of the scan family, ascending.
@@ -149,16 +149,40 @@ fn encode_slot(slot: &Slot, salt: &Fr) -> (bool, FieldHex, Option<Fr>) {
 /// terms. We re-encode each canonical triple's terms (the circuit checks
 /// `h3(enc) == leaf`), so this re-derivation is sound by construction: a wrong
 /// encoding would fail the in-circuit commitment recompute.
+///
+/// # Strict-ordering canonicalisation (plan S2.5, [OPUS-4.8])
+/// `scan_check` enforces `commitments[0] < commitments[1] < ...` (strict, on the
+/// canonical field representative) to force the committed graphs pairwise
+/// distinct and close the duplicate-inclusion / COUNT-forgery class. So this
+/// builder emits the commitments -- and, in lock-step, every per-graph witness
+/// (`counts`, `enc`) and the public `attribution` vector -- sorted ASCENDING by
+/// the canonical big-endian commitment bytes (the exact order the in-circuit
+/// `Field::lt` / the bb public-input word use). Sorting here (rather than
+/// trusting caller order) means an honest k>=2 scan always satisfies the gate
+/// regardless of the order the caller supplied its graphs in. If the caller
+/// supplies two graphs with the SAME commitment (a genuine duplicate), the sort
+/// places them adjacent and the in-circuit `<` then rejects -- the gate's intent.
 pub fn build_scan(
     commitments: &[GraphCommitment],
     pattern: &Pattern,
 ) -> Option<BuiltScan> {
     let k = commitments.len() as u32;
+    // S2.5: canonicalise graph order ascending by the commitment's field
+    // representative so the strict-ordering gate (`scan_check` step 1b) is
+    // satisfied for any honest input order. Sort the SAME canonical big-endian
+    // bytes the circuit compares (`field_to_be_bytes_32`), so the host order
+    // and the in-circuit `Field::lt` order agree exactly.
+    let mut order: Vec<usize> = (0..commitments.len()).collect();
+    order.sort_by(|&a, &b| {
+        field_to_be_bytes_32(&commitments[a].commitment)
+            .cmp(&field_to_be_bytes_32(&commitments[b].commitment))
+    });
+    let commitments: Vec<&GraphCommitment> = order.iter().map(|&i| &commitments[i]).collect();
     // Per-graph term encodings of every canonical triple.
     let mut enc: Vec<Vec<[FieldHex; 3]>> = Vec::with_capacity(commitments.len());
     let mut enc_fr: Vec<Vec<[Fr; 3]>> = Vec::with_capacity(commitments.len());
     let mut counts = Vec::with_capacity(commitments.len());
-    for c in commitments {
+    for c in &commitments {
         let salt = c.salt;
         let mut graph_hex = Vec::new();
         let mut graph_fr = Vec::new();

--- a/crates/sparq-zk-compose/src/verifier.rs
+++ b/crates/sparq-zk-compose/src/verifier.rs
@@ -6,7 +6,15 @@
 //!    `sparq_zk::verify::recheck` — the bnode cross-graph join guard (Q6) plus
 //!    attribution arity. Re-derive each sub-proof's circuit id from its public
 //!    inputs and confirm it equals the declared id (a proof cannot be replayed
-//!    against a different family member).
+//!    against a different family member). For each scan sub-proof, also require
+//!    the per-graph `attribution` to be exactly `CircuitId.k` bits AND the
+//!    per-graph `commitments` to be STRICTLY INCREASING on the field
+//!    representative ([OPUS-4.8] sq-vxq8 / plan S2.5): the latter is the host-side
+//!    mirror of `scan_check` step 1b, rejecting a duplicate/out-of-order
+//!    commitment (the duplicate-inclusion / COUNT-forgery class) before any bb
+//!    proof. The in-circuit `<` is the authoritative gate; this structural check
+//!    is defence in depth so a witness-only manifest cannot smuggle a duplicate
+//!    past the fast stage.
 //! 2. **Binding-consistency edges**: each declared edge's scan-proof row/slot
 //!    encoding must equal the consuming filter proof's `operand_enc` (a plain
 //!    field equality over public inputs — the modular composition seam).
@@ -959,6 +967,20 @@ pub enum CheckError {
     /// `CircuitId.k` bits (no default/pad-to-false). `expected` = k.
     // [OPUS-4.8] codex 2221 MEDIUM: attribution must be present + exactly k bits.
     AttributionMalformed { proof: usize, expected: usize, got: usize },
+    /// A scan sub-proof's per-graph `commitments` are NOT strictly increasing on
+    /// the field representative (plan S2.5, [OPUS-4.8]): two adjacent commitments
+    /// are equal or out of order. `scan_check` step 1b enforces
+    /// `commitments[0] < commitments[1] < ...` in-circuit to force the committed
+    /// graphs pairwise DISTINCT — closing the duplicate-inclusion / COUNT-forgery
+    /// class (the same credential committed twice repeats a commitment). This is
+    /// the host-side, structural mirror of that gate: it rejects a non-increasing
+    /// commitment vector BEFORE any bb proof (defence in depth), so a witness-only
+    /// manifest cannot smuggle a duplicate past the structural stage either. The
+    /// honest builder ([`crate::build::build_scan`]) emits commitments ascending,
+    /// so a consistent honest manifest never trips this. `at` is the index `g`
+    /// whose `commitments[g] <= commitments[g-1]`.
+    // [OPUS-4.8] sq-vxq8: distinct-graph strict-ordering (duplicate-inclusion closure).
+    ScanCommitmentsNotStrictlyIncreasing { proof: usize, at: usize },
     /// The verifier-issued nonce has already been seen by the single-use store
     /// (audit #4): a captured (nonce, manifest) pair re-presented to the SAME
     /// verifier session. Rejected before the cryptographic gate so a bearer proof
@@ -1275,6 +1297,11 @@ impl std::fmt::Display for CheckError {
                 f,
                 "scan sub-proof {proof}: attribution must be present and exactly {expected} bits (CircuitId.k), got {got} (audit #8 / codex 2221 MEDIUM: an omitted/short attribution makes the cross-graph under-declaration check vacuous)"
             ),
+            CheckError::ScanCommitmentsNotStrictlyIncreasing { proof, at } => write!(
+                f,
+                "scan sub-proof {proof}: per-graph commitments are not strictly increasing at index {at} (commitments[{at}] <= commitments[{at_prev}]) (plan S2.5 / sq-vxq8: distinct-graph strict ordering — a duplicate or out-of-order commitment is the duplicate-inclusion / COUNT forgery, e.g. the same credential included twice to claim 'I hold >=2 tickets')",
+                at_prev = at - 1
+            ),
             CheckError::NonceReplay => write!(
                 f,
                 "verifier nonce already seen (audit #4: single-use — a captured (nonce, manifest) pair may not be replayed)"
@@ -1558,7 +1585,7 @@ pub fn prefilter_manifest_structure(
         // reconstruction byte-binds — with NO default and NO pad-to-false. A
         // missing/empty/short/long attribution is rejected here, before any gate
         // can silently skip the omitted graphs.
-        if let ProofInputs::Scan { attribution, .. } = &sp.inputs {
+        if let ProofInputs::Scan { attribution, commitments, .. } = &sp.inputs {
             let k = match &declared {
                 CircuitId::Scan { k, .. } => *k as usize,
                 _ => unreachable!("Scan inputs always carry a Scan circuit id"),
@@ -1569,6 +1596,29 @@ pub fn prefilter_manifest_structure(
                     expected: k,
                     got: attribution.len(),
                 });
+            }
+            // [OPUS-4.8] sq-vxq8 / plan S2.5: distinct-graph strict ordering.
+            // `scan_check` step 1b enforces `commitments[0] < commitments[1] < ...`
+            // in-circuit to force the K committed graphs pairwise distinct (closing
+            // the duplicate-inclusion / COUNT-forgery class). Mirror it structurally
+            // here so a witness-only manifest with a duplicate/out-of-order
+            // commitment is rejected BEFORE any bb proof (defence in depth). Compare
+            // on the SAME canonical big-endian bytes the circuit's `Field::lt` and
+            // the audit-#1 public-input reconstruction use, so the host and circuit
+            // orders agree exactly. A malformed commitment hex is left to the
+            // reconstruction stage (`MalformedField`); skip it here.
+            for g in 1..commitments.len() {
+                let (Some(prev), Some(cur)) =
+                    (commitments[g - 1].to_field(), commitments[g].to_field())
+                else {
+                    continue;
+                };
+                if field_to_be_bytes_32(&cur) <= field_to_be_bytes_32(&prev) {
+                    return Err(CheckError::ScanCommitmentsNotStrictlyIncreasing {
+                        proof: i,
+                        at: g,
+                    });
+                }
             }
         }
     }

--- a/crates/sparq-zk-compose/src/verifier.rs
+++ b/crates/sparq-zk-compose/src/verifier.rs
@@ -1300,7 +1300,11 @@ impl std::fmt::Display for CheckError {
             CheckError::ScanCommitmentsNotStrictlyIncreasing { proof, at } => write!(
                 f,
                 "scan sub-proof {proof}: per-graph commitments are not strictly increasing at index {at} (commitments[{at}] <= commitments[{at_prev}]) (plan S2.5 / sq-vxq8: distinct-graph strict ordering — a duplicate or out-of-order commitment is the duplicate-inclusion / COUNT forgery, e.g. the same credential included twice to claim 'I hold >=2 tickets')",
-                at_prev = at - 1
+                // [OPUS-4.8] `Display` must be panic-free for every constructible value
+                // (Copilot PR #95): the sole constructor sets `at` from `1..len()`, so
+                // `at >= 1` in practice, but `saturating_sub` avoids an `at - 1` underflow
+                // (debug panic / release wrap) should `at == 0` ever reach here.
+                at_prev = at.saturating_sub(1)
             ),
             CheckError::NonceReplay => write!(
                 f,

--- a/crates/sparq-zk-compose/tests/forge_gates.rs
+++ b/crates/sparq-zk-compose/tests/forge_gates.rs
@@ -617,3 +617,273 @@ fn forge_pubinput_verdict_substitution_rejected() {
         other => panic!("verdict substitution must be PublicInputMismatch, got {other:?}"),
     }
 }
+
+// === BINDING 7: distinct-graph strict ordering (duplicate-inclusion / COUNT) ===
+//
+// [OPUS-4.8] sq-vxq8 / plan S2.5. `scan_check` step 1b enforces
+// `commitments[0] < commitments[1] < ...` (strict, on the field representative) so
+// the K committed graphs are pairwise DISTINCT. This closes the
+// duplicate-inclusion / COUNT-forgery class: including the SAME credential twice
+// (its commitment repeated at two block indices) to forge a COUNT-style "I hold
+// >=2 tickets" claim. Aggregates are out of the v1 fragment so the class is latent
+// today, but the guard lands before any aggregate/COUNT support. Two layers gate
+// it: (a) the host-side STRUCTURAL mirror in `prefilter_manifest_structure`
+// (rejects a non-increasing commitment vector before any bb proof — runs without
+// the toolchain), and (b) the in-circuit `<` itself (the authoritative gate — a
+// duplicate-commitment witness is UNSATISFIABLE, so no proof can exist; gated
+// behind the toolchain + `#[ignore]`).
+
+/// Two DISTINCT named-graph credentials over a shared predicate `<ex/p>`, each
+/// issuer-attested salt+status-bound, so a k=2 scan over `<ex/p>` builds and
+/// (with honest distinct graphs) verifies. Each graph carries THREE `<ex/p>`
+/// triples (distinct subjects => distinct commitments), so the k=2 scan discloses
+/// 6 matched rows => derives the COMPILED `scan_k2_n16_r8` member (n=16, r=8).
+/// Returns the two `GraphCommitment`s + their salts.
+fn two_distinct_p_graphs(
+) -> (sparq_zk::commit::GraphCommitment, Fr, sparq_zk::commit::GraphCommitment, Fr) {
+    let g0 = vec![
+        Triple::new(NamedOrBlankNode::NamedNode(iri("http://ex/a0")), iri("http://ex/p"), int_lit(1)),
+        Triple::new(NamedOrBlankNode::NamedNode(iri("http://ex/a1")), iri("http://ex/p"), int_lit(2)),
+        Triple::new(NamedOrBlankNode::NamedNode(iri("http://ex/a2")), iri("http://ex/p"), int_lit(3)),
+    ];
+    let g1 = vec![
+        Triple::new(NamedOrBlankNode::NamedNode(iri("http://ex/b0")), iri("http://ex/p"), int_lit(4)),
+        Triple::new(NamedOrBlankNode::NamedNode(iri("http://ex/b1")), iri("http://ex/p"), int_lit(5)),
+        Triple::new(NamedOrBlankNode::NamedNode(iri("http://ex/b2")), iri("http://ex/p"), int_lit(6)),
+    ];
+    let salt0 = salt_from_bytes(&[21u8; 32]);
+    let salt1 = salt_from_bytes(&[22u8; 32]);
+    let c0 = commit_triples(&g0, salt0).unwrap();
+    let c1 = commit_triples(&g1, salt1).unwrap();
+    (c0, salt0, c1, salt1)
+}
+
+/// Build a k=2 scan-only manifest over `{ ?s <ex/p> ?o }` from scan inputs + their
+/// attestations. Passes every structural gate except whatever the caller forged
+/// (or, when honest, reaches MissingProof with no bb proof). `attributions` is
+/// `[[0,1]]` (both graphs contribute — the honest truth the in-circuit attribution
+/// proves).
+fn k2_scan_only_manifest(
+    scan_inputs: ProofInputs,
+    attests: Vec<CommitmentAttestation>,
+) -> ProofManifest {
+    let sk = test_issuer_sk(1);
+    ProofManifest {
+        r#type: "urn:sparq:zk:ProofManifest".into(),
+        query: "SELECT ?s ?o WHERE { ?s <http://ex/p> ?o }".into(),
+        issuers: vec![],
+        key_set: vec![public_key_to_hex(&sk.public_key())],
+        commitment_attestations: attests,
+        attributions: vec![vec![0, 1]],
+        join_obligations: vec![],
+        entailment_regime: EntailmentRegime::Simple,
+        derivation_steps: vec![],
+        binding: BindingMode::Challenge { challenge: FieldHex(CHALLENGE_HEX.into()) },
+        revocation: Some(fixture_revocation()),
+        status_snapshots: vec![fixture_snapshot(false)],
+        sub_proofs: vec![SubProof { inputs: scan_inputs, proof_hex: String::new() }],
+        binding_edges: vec![],
+        hidden_revocation: None,
+        hidden_issuer_attestations: vec![],
+    }
+}
+
+/// Structural forge (NO bb): a k=2 scan whose two per-graph commitments are EQUAL
+/// (the same credential's commitment included twice — the duplicate-inclusion
+/// forge). The strict-ordering structural mirror must REJECT
+/// (`ScanCommitmentsNotStrictlyIncreasing`) BEFORE any bb proof. Reaches the gate
+/// through the SOUND `verify_manifest` entry point.
+#[test]
+fn forge_scan_duplicate_commitment_structural_rejected() {
+    let (c0, salt0, c1b, salt1b) = two_distinct_p_graphs();
+    let sk = test_issuer_sk(1);
+    let pattern = Pattern {
+        s: Slot::Var,
+        p: Slot::Const(Term::NamedNode(iri("http://ex/p"))),
+        o: Slot::Var,
+    };
+    let mut scan = build_scan(&[c0.clone(), c1b.clone()], &pattern).expect("k=2 scan builds");
+    if let ProofInputs::Scan { commitments, .. } = &mut scan.inputs {
+        // FORGE: both slots carry c0's commitment (equal => not strictly increasing).
+        let dup = FieldHex::from_field(&c0.commitment);
+        commitments[0] = dup.clone();
+        commitments[1] = dup;
+    } else {
+        unreachable!("scan inputs");
+    }
+    // Attest the (single distinct) commitment value so the forge reaches the
+    // ordering gate, not the attestation gate.
+    let attests = vec![attest_full(c0.commitment, salt0, &sk)];
+    let _ = (salt1b, c1b);
+    let m = k2_scan_only_manifest(scan.inputs, attests);
+    match verify_full(&m, "forge_dup_commit_struct") {
+        Err(CheckError::ScanCommitmentsNotStrictlyIncreasing { proof: 0, at: 1 }) => {}
+        other => panic!(
+            "duplicate (equal) commitments must be ScanCommitmentsNotStrictlyIncreasing, got {other:?}"
+        ),
+    }
+}
+
+/// Structural forge (NO bb): a k=2 scan whose commitments are DESCENDING
+/// (out-of-order, distinct values). Strict ordering must REJECT
+/// (`ScanCommitmentsNotStrictlyIncreasing`) — only the canonical ascending order
+/// is accepted, so a prover cannot reorder graphs to dodge the gate.
+#[test]
+fn forge_scan_out_of_order_commitment_structural_rejected() {
+    let (c0, salt0, c1, salt1) = two_distinct_p_graphs();
+    let sk = test_issuer_sk(1);
+    let pattern = Pattern {
+        s: Slot::Var,
+        p: Slot::Const(Term::NamedNode(iri("http://ex/p"))),
+        o: Slot::Var,
+    };
+    let mut scan = build_scan(&[c0.clone(), c1.clone()], &pattern).expect("k=2 scan builds");
+    // build_scan emits ASCENDING; FORGE by swapping to descending order.
+    if let ProofInputs::Scan { commitments, attribution, .. } = &mut scan.inputs {
+        commitments.reverse();
+        attribution.reverse();
+    } else {
+        unreachable!("scan inputs");
+    }
+    let attests = vec![
+        attest_full(c0.commitment, salt0, &sk),
+        attest_full(c1.commitment, salt1, &sk),
+    ];
+    let m = k2_scan_only_manifest(scan.inputs, attests);
+    match verify_full(&m, "forge_ooo_commit_struct") {
+        Err(CheckError::ScanCommitmentsNotStrictlyIncreasing { proof: 0, at: 1 }) => {}
+        other => panic!(
+            "descending commitments must be ScanCommitmentsNotStrictlyIncreasing, got {other:?}"
+        ),
+    }
+}
+
+/// Positive control (sanity): the honest builder canonicalises graph order
+/// ascending, so an honest k=2 scan-only manifest passes the strict-ordering
+/// structural gate (and every other structural gate), reaching MissingProof
+/// (witness-only). Proves the gate does not reject honest distinct graphs.
+#[test]
+fn honest_k2_scan_passes_strict_ordering_structural() {
+    let (c0, salt0, c1, salt1) = two_distinct_p_graphs();
+    let sk = test_issuer_sk(1);
+    let pattern = Pattern {
+        s: Slot::Var,
+        p: Slot::Const(Term::NamedNode(iri("http://ex/p"))),
+        o: Slot::Var,
+    };
+    let scan = build_scan(&[c0.clone(), c1.clone()], &pattern).expect("k=2 scan builds");
+    // build_scan emits commitments ascending; confirm that here so the test
+    // documents the canonicalisation contract the gate depends on.
+    if let ProofInputs::Scan { commitments, .. } = &scan.inputs {
+        let a = commitments[0].to_field().unwrap();
+        let b = commitments[1].to_field().unwrap();
+        assert!(
+            sparq_zk::field::field_to_be_bytes_32(&a) < sparq_zk::field::field_to_be_bytes_32(&b),
+            "build_scan must emit strictly-increasing commitments"
+        );
+    } else {
+        unreachable!("scan inputs");
+    }
+    let attests = vec![
+        attest_full(c0.commitment, salt0, &sk),
+        attest_full(c1.commitment, salt1, &sk),
+    ];
+    let m = k2_scan_only_manifest(scan.inputs, attests);
+    match verify_full(&m, "honest_k2_strict_struct") {
+        // Structural stage (incl. strict ordering) passed; only the bb proof is absent.
+        Err(CheckError::MissingProof { proof: 0 }) => {}
+        other => panic!(
+            "honest k=2 scan should pass strict-ordering then hit MissingProof, got {other:?}"
+        ),
+    }
+}
+
+/// CIRCUIT-LEVEL forge (FULL toolchain): a k=2 scan witness whose two per-graph
+/// commitments are EQUAL is UNSATISFIABLE under the in-circuit strict-ordering
+/// `<` — `nargo execute` produces NO witness, so no proof can exist. This is the
+/// AUTHORITATIVE gate (the structural mirror above is defence in depth). Uses the
+/// fast witness-generation path (`gen_witness_tagged`); no `bb prove` needed to
+/// demonstrate unsatisfiability.
+#[test]
+#[ignore = "slow/toolchain: real nargo witness-gen of a k=2 scan (sq-vxq8 strict-ordering circuit forge)"]
+fn forge_scan_duplicate_commitment_circuit_rejected() {
+    if !toolchain_available() {
+        eprintln!("nargo/bb absent; skipping");
+        return;
+    }
+    let challenge = FieldHex(CHALLENGE_HEX.into());
+    let prover = CircuitProver::from_crate_root();
+    let (c0, _s0, _c1, _s1) = two_distinct_p_graphs();
+    let pattern = Pattern {
+        s: Slot::Var,
+        p: Slot::Const(Term::NamedNode(iri("http://ex/p"))),
+        o: Slot::Var,
+    };
+    // Build a k=2 scan over the SAME graph twice — the duplicate-inclusion forge.
+    // Both graphs' encodings derive c0, so the commitment-recompute (step 1) holds
+    // for both, and the ONLY violated constraint is the strict ordering
+    // `commitments[0] < commitments[1]` (= `c0 < c0`, false). This isolates step
+    // 1b: the witness is well-formed except for the duplicate the gate forbids.
+    let scan = build_scan(&[c0.clone(), c0.clone()], &pattern).expect("k=2 dup scan builds");
+    if let ProofInputs::Scan { commitments, .. } = &scan.inputs {
+        assert_eq!(commitments[0], commitments[1], "forged duplicate commitments");
+    } else {
+        unreachable!("scan inputs");
+    }
+    let (id, toml) = prover_toml_for(
+        &scan.inputs,
+        &challenge,
+        &scan.witness.counts,
+        &scan.witness.enc,
+        &[],
+    );
+    // The in-circuit `commitments[0] < commitments[1]` (= `c0 < c0`) is FALSE, so
+    // the relation is unsatisfiable: nargo writes no witness => Err.
+    let res = prover.gen_witness_tagged(&id, &toml, "fg_dup_commit");
+    assert!(
+        res.is_err(),
+        "a duplicate-commitment k=2 scan witness must be UNSATISFIABLE (strict-ordering gate), but nargo produced a witness"
+    );
+}
+
+/// CIRCUIT-LEVEL positive control (FULL toolchain): an HONEST k=2 scan over two
+/// DISTINCT graphs (ascending commitments, as build_scan emits) is SATISFIABLE
+/// and PROVES + VERIFIES through the full `verify_manifest` path. Proves the
+/// strict-ordering gate did NOT break honest k=2 proofs (the gate's completeness).
+#[test]
+#[ignore = "slow/toolchain: real bb prove+verify of an honest k=2 scan (sq-vxq8 strict-ordering positive control)"]
+fn honest_k2_distinct_scan_proves_and_verifies() {
+    if !toolchain_available() {
+        eprintln!("nargo/bb absent; skipping");
+        return;
+    }
+    let challenge = FieldHex(CHALLENGE_HEX.into());
+    let prover = CircuitProver::from_crate_root();
+    let (c0, salt0, c1, salt1) = two_distinct_p_graphs();
+    let sk = test_issuer_sk(1);
+    let pattern = Pattern {
+        s: Slot::Var,
+        p: Slot::Const(Term::NamedNode(iri("http://ex/p"))),
+        o: Slot::Var,
+    };
+    let scan = build_scan(&[c0.clone(), c1.clone()], &pattern).expect("k=2 scan builds");
+    let (id, toml) = prover_toml_for(
+        &scan.inputs,
+        &challenge,
+        &scan.witness.counts,
+        &scan.witness.enc,
+        &[],
+    );
+    let out = scratch("honest_k2_distinct_prove");
+    let art = prover
+        .prove_in(&id, &toml, &out, "honest_k2_distinct")
+        .expect("honest distinct k=2 scan PROVES (strict ordering holds)");
+    let attests = vec![
+        attest_full(c0.commitment, salt0, &sk),
+        attest_full(c1.commitment, salt1, &sk),
+    ];
+    let mut m = k2_scan_only_manifest(scan.inputs, attests);
+    m.sub_proofs[0].proof_hex = encode_artifacts(&art);
+    verify_full(&m, "honest_k2_distinct_verify")
+        .expect("honest distinct k=2 scan VERIFIES through verify_manifest");
+}

--- a/crates/sparq-zk-compose/tests/gate_count_snapshot.json
+++ b/crates/sparq-zk-compose/tests/gate_count_snapshot.json
@@ -5,9 +5,9 @@
   "nargo_version_baselined": "1.0.0-beta.21",
   "tolerance_pct": 3.0,
   "members": {
-    "scan_k1_n16_r4": 5958,
-    "scan_k2_n16_r8": 11011,
-    "scan_k2_n64_r8": 34379,
+    "scan_k1_n16_r4": 5991,
+    "scan_k2_n16_r8": 11261,
+    "scan_k2_n64_r8": 34821,
     "filter_int_d1": 17416,
     "filter_int_d2": 17416,
     "filter_int_d3": 17416,

--- a/crates/sparq-zk-compose/tests/verifier_errors.rs
+++ b/crates/sparq-zk-compose/tests/verifier_errors.rs
@@ -69,6 +69,11 @@ fn check_error_display_covers_structural_reject_reasons() {
         &CheckError::PublicInputMismatch { proof: 9 },
         &["9", "public inputs"],
     );
+    // [OPUS-4.8] sq-vxq8: distinct-graph strict-ordering reject (duplicate-inclusion).
+    assert_display_carries(
+        &CheckError::ScanCommitmentsNotStrictlyIncreasing { proof: 0, at: 1 },
+        &["strictly increasing", "S2.5"],
+    );
 }
 
 #[test]

--- a/crates/sparq-zk-compose/tests/verifier_errors.rs
+++ b/crates/sparq-zk-compose/tests/verifier_errors.rs
@@ -74,6 +74,15 @@ fn check_error_display_covers_structural_reject_reasons() {
         &CheckError::ScanCommitmentsNotStrictlyIncreasing { proof: 0, at: 1 },
         &["strictly increasing", "S2.5"],
     );
+    // [OPUS-4.8] Copilot PR #95: Display must be panic-free for EVERY constructible
+    // value, including the `at == 0` boundary (the prior `at - 1` would underflow:
+    // debug panic / release wrap). `saturating_sub(1)` keeps it total. The current
+    // constructor never emits `at == 0`, but Display correctness is independent of
+    // that and the assertion documents the contract.
+    assert_display_carries(
+        &CheckError::ScanCommitmentsNotStrictlyIncreasing { proof: 0, at: 0 },
+        &["strictly increasing", "S2.5"],
+    );
 }
 
 #[test]

--- a/zk/compose/compose_core/src/scan.nr
+++ b/zk/compose/compose_core/src/scan.nr
@@ -8,6 +8,22 @@
 //! 1. **Commitment recompute**: for every graph `g`, the witnessed per-slot
 //!    term encodings `enc[g]` re-hash (leaf `h3`, then `commit_fold` over the
 //!    first `counts[g]` leaves) to the PUBLIC commitment `commitments[g]`.
+//! 1b. **Distinct-graph strict ordering** (plan S2.5, [OPUS-4.8]): the public
+//!    per-graph commitment representatives are constrained STRICTLY INCREASING,
+//!    `C(G_0) < C(G_1) < ... < C(G_{K-1})` (numeric `<` on the field
+//!    representative). This forces the `K` committed graphs to be pairwise
+//!    distinct and closes the DUPLICATE-INCLUSION / COUNT-forgery class: without
+//!    it a prover could pass the SAME commitment twice (`[C(G), C(G)]`, or any
+//!    out-of-order/equal pair) to forge a COUNT-style "I hold >=2 tickets" claim
+//!    by including one credential twice at two block indices. The aggregate
+//!    fragment that would consume such a claim is out of v1 scope, so the class
+//!    is latent today, but the guard is ~free (one full-width `Field` comparison
+//!    per adjacent pair -- zero for K=1) and lands BEFORE any aggregate/COUNT
+//!    support so the class is never reachable. The host builder canonicalises the
+//!    commitment order (and the matching per-graph witnesses) ascending; the
+//!    verifier additionally rejects non-increasing commitments structurally
+//!    (defence in depth, before any bb proof) so a witness-only manifest cannot
+//!    smuggle a duplicate past this gate either.
 //! 2. **Row soundness**: each of the `row_count` disclosed rows (term-encoding
 //!    triples) matches the pattern's constant slots and occurs in some active
 //!    slot of some graph.
@@ -60,6 +76,12 @@ pub struct PatternSpec {
 /// it MUST equal "graph `g` holds an active slot matching the pattern", which
 /// the relation enforces (step 4). The verifier byte-binds it (audit #1) and
 /// checks `manifest.attributions[pattern]` is consistent with it.
+///
+/// `commitments` (PUBLIC) MUST be strictly increasing on the field
+/// representative (`commitments[0] < commitments[1] < ...`, plan S2.5 step 1b):
+/// the relation enforces it, forcing the `K` committed graphs pairwise distinct
+/// and closing the duplicate-inclusion / COUNT-forgery class. The host builder
+/// emits commitments (and the matching per-graph witnesses) in ascending order.
 pub fn scan_check<let K: u32, let N: u32, let R: u32>(
     commitments: [Field; K],
     pattern: PatternSpec,
@@ -82,6 +104,22 @@ pub fn scan_check<let K: u32, let N: u32, let R: u32>(
             commit_fold(leaves, counts[g]),
             commitments[g],
             "graph commitment mismatch",
+        );
+    }
+
+    // 1b. Distinct-graph strict ordering (plan S2.5, [OPUS-4.8]): each successive
+    // per-graph commitment representative must be STRICTLY GREATER than the
+    // previous, `C(G_{g-1}) < C(G_g)`. Strictness (not `<=`) makes the K graphs
+    // pairwise DISTINCT, closing the duplicate-inclusion / COUNT-forgery class
+    // (the same credential committed twice would repeat a commitment, which the
+    // `<` rejects). `Field::lt` is the full-width BN254 comparison (commitments
+    // are full field elements, not small typed values), so this is a real
+    // ordering over the whole representative; ~one comparison per adjacent pair
+    // (none for K=1 -- the loop body is empty).
+    for g in 1..K {
+        assert(
+            commitments[g - 1].lt(commitments[g]),
+            "per-graph commitments not strictly increasing (duplicate-inclusion / COUNT forgery)",
         );
     }
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Closes the **duplicate-inclusion / COUNT-forgery** soundness class (plan **§2.5**, bead **sq-vxq8**).

## The forgery class closed
Plan §2.5 specifies a numeric **strict-ordering** constraint on the per-graph commitment field representatives — `C(G_0) < C(G_1) < … < C(G_{K-1})` — to force the committed graphs pairwise distinct. `scan_check` did **not** enforce it. Without it a prover could pass the **same** commitment twice (`[C(G), C(G)]`, or any out-of-order/equal pair) to forge a COUNT-style **"I hold ≥2 tickets"** claim by including one credential twice at two block indices. Latent today only because aggregates are out of the v1 fragment — the guard is a handful of gates and lands **before** any aggregate/COUNT support so the class is never reachable.

## The gate added (and where)
- **Circuit — `zk/compose/compose_core/src/scan.nr` (new step 1b):** for each adjacent pair, `commitments[g-1].lt(commitments[g])` (full-width BN254 `Field::lt`; **strict** ⇒ pairwise-distinct). Zero comparisons for `K=1` (empty loop); one per adjacent pair for `K≥2`. This is the **authoritative** gate.
- **Host builder — `crates/sparq-zk-compose/src/build.rs`:** `build_scan` now canonicalises graph order **ascending** by the canonical big-endian commitment bytes (the exact order the in-circuit `<` and the bb public-input word use), reordering `counts`/`enc`/`attribution` in lock-step — so any honest `k≥2` input order satisfies the gate.
- **Host verifier — `crates/sparq-zk-compose/src/verifier.rs`:** a **structural mirror** in prefilter stage 1b (`ScanCommitmentsNotStrictlyIncreasing`) rejects a duplicate/out-of-order commitment vector **before any bb proof** (defence in depth; runs without the toolchain).
- **Public-input layout is UNCHANGED** — this is a constraint over the *existing* `commitments` public inputs, not a new input — so `reconstruct_public_inputs` / the audit-#1 byte-binding are untouched.

## Gate-count delta
Only the three scan members change (they share `scan_check`); every other compiled member is **byte-identical**. `bb gates -s ultra_honk`, nargo beta.21 / bb 5.0.0-nightly.20260324:

| member | before | after | Δ |
|---|---|---|---|
| `scan_k1_n16_r4` | 5958 | 5991 | +33 (loop scaffolding; K=1 ⇒ no comparison) |
| `scan_k2_n16_r8` | 11011 | 11261 | +250 (one full-width comparison) |
| `scan_k2_n64_r8` | 34379 | 34821 | +442 |

Snapshot ratchet (`tests/gate_count_snapshot.json`) + bench JSON (`bench/zk-compose/gate_counts_latest.json`) re-baselined to the new counts. No vk fixtures are pinned (the verifier recomputes the canonical vk per audit #2), so none to regenerate. No unrelated ratchet loosened.

## Honest proofs still verify; the forge rejects (real bb)
Forge suite added under `tests/forge_gates.rs` **BINDING 7** (audit-forge style; PR #89's `audit_forge_map.rs` is not on main yet, so this lands in the existing forge file):
- **Structural (no toolchain):** duplicate (equal) + descending (out-of-order) commitments REJECT with `ScanCommitmentsNotStrictlyIncreasing`; an honest k=2 scan passes strict-ordering → `MissingProof`.
- **Real-bb (`#[ignore]`, local toolchain):** a duplicate-commitment k=2 witness is **UNSATISFIABLE** (the in-circuit `<` rejects — no proof can exist); an **honest distinct k=2 scan PROVES + VERIFIES** through the full `verify_manifest` path. Both confirmed locally with the installed nargo + bb.

## Gate results (local)
- `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings` — **clean**.
- `cargo test -p sparq-zk-compose -p sparq-zk` — **green** (incl. `gate_count_regression`, which recompiles every member and checks the snapshot).
- k=1 scan full prove/verify e2e + the differential-fuzz full-prove (scan pipeline) re-run green (circuit changed).

This change is authored under the **Opus 4.8** fallback model (Fable unavailable): `[OPUS-4.8]` inline markers + the commit trailer mark it for re-review when Fable returns.
