### PR TITLE
Pin SPARQL 1.1 aggregate-over-empty semantics (sq-53ti)

### DIFF
--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -9311,3 +9311,171 @@ mod service_exec_tests {
         assert!(eval_select(&g, &p2).is_ok());
     }
 }
+
+/// [OPUS-4.8] sq-53ti (gh-49) — SPARQL 1.1 aggregate-over-EMPTY-multiset semantics.
+///
+/// Pins the §18.5.1 "Set Functions over an empty group" contract that downstream
+/// consumers (notably PSS `usage()`, which sums resource sizes over a possibly-empty
+/// graph match and reads a single all-but-COUNT-bound row) depend on. The rule, split
+/// by the one axis that matters — whether a `GROUP BY` is present:
+///
+/// * **No `GROUP BY`, the WHERE clause matches nothing** → the whole solution set is a
+///   SINGLE implicit group, so the result is exactly ONE row (NOT zero). In that row:
+///   - `COUNT(*)` and `COUNT(?x)` → `"0"^^xsd:integer` (§18.5.1.1: Count({}) = 0)
+///   - `SUM(?x)` → `"0"^^xsd:integer` (§18.5.1.4: Sum({}) = 0)
+///   - `AVG(?x)` → `"0"^^xsd:integer` (§18.5.1.5: Avg({}) = 0)
+///   - `MIN(?x)` / `MAX(?x)` → UNBOUND (§18.5.1.6/7: an error over {} ⇒ the variable is left unbound for that row)
+///   - `SAMPLE(?x)` → UNBOUND (§18.5.1.8: no element to sample)
+///   - `GROUP_CONCAT(?x)` → `""` (empty string) (§18.5.1.9: concat of zero strings)
+///
+///   The SUM/AVG-vs-MIN/MAX split is the subtle part: SUM and AVG over the empty
+///   multiset are DEFINED to be the integer `0` (so `COALESCE(SUM(?x), 0)` and a bare
+///   `SUM(?x)` both yield `0`, and a single bound `0` cell — not an unbound one), whereas
+///   MIN/MAX/SAMPLE raise an error that surfaces as an UNBOUND cell in the one result row.
+///
+/// * **With `GROUP BY`, the input is empty** → there are ZERO groups, hence ZERO result
+///   rows (the implicit-single-group rule applies ONLY when no GROUP BY is written).
+///
+/// Ground truth: this matches the engine's behaviour today AND the W3C SPARQL 1.1
+/// `aggregates` conformance suite — `agg-empty-group-count-2` (COUNT, no GROUP BY → one
+/// `0` row), `agg-empty-group-max-2` (MAX, no GROUP BY → one all-unbound row),
+/// `agg-empty-group-count-1` / `agg-empty-group-max-1` (with GROUP BY → zero rows). These
+/// tests are the GUARANTEE that pins the contract against regressions.
+#[cfg(test)]
+mod aggregate_empty_semantics {
+    use super::*;
+
+    /// A non-empty graph whose triples never match the test queries' predicate, so the
+    /// WHERE clause produces an EMPTY multiset while the store itself is non-trivial
+    /// (rules out "0 rows because the store is empty" as the cause).
+    fn g() -> Graph {
+        Graph::load_str("@prefix ex: <http://ex/> . ex:keep ex:other 1 .", "turtle").unwrap()
+    }
+
+    fn run(q: &str) -> QueryResult {
+        crate::query(&g(), &format!("PREFIX ex: <http://ex/> {q}")).unwrap()
+    }
+
+    /// The single cell of a one-row, one-projected-variable result.
+    fn one_cell(q: &str) -> Option<Term> {
+        let r = run(q);
+        assert_eq!(r.rows.len(), 1, "expected exactly one solution row for: {q}");
+        assert_eq!(r.rows[0].len(), 1, "expected exactly one projected cell for: {q}");
+        r.rows[0][0].clone()
+    }
+
+    fn int_lit(n: i64) -> Term {
+        Term::Literal(oxrdf::Literal::new_typed_literal(n.to_string(), oxrdf::vocab::xsd::INTEGER))
+    }
+
+    // ---- No GROUP BY over an empty match: ONE row, COUNT=0, others per the split above ----
+
+    #[test]
+    fn count_star_over_empty_is_zero_one_row() {
+        assert_eq!(one_cell("SELECT (COUNT(*) AS ?v) WHERE { ?s ex:nomatch ?o }"), Some(int_lit(0)));
+    }
+
+    #[test]
+    fn count_var_over_empty_is_zero_one_row() {
+        // COUNT(?x) and COUNT(*) coincide over an empty multiset: both 0.
+        assert_eq!(one_cell("SELECT (COUNT(?o) AS ?v) WHERE { ?s ex:nomatch ?o }"), Some(int_lit(0)));
+    }
+
+    #[test]
+    fn count_star_vs_count_var_agree_over_empty() {
+        let star = one_cell("SELECT (COUNT(*) AS ?v) WHERE { ?s ex:nomatch ?o }");
+        let var = one_cell("SELECT (COUNT(?o) AS ?v) WHERE { ?s ex:nomatch ?o }");
+        assert_eq!(star, var);
+        assert_eq!(star, Some(int_lit(0)));
+    }
+
+    #[test]
+    fn sum_over_empty_is_integer_zero_one_row() {
+        // §18.5.1.4: Sum({}) = "0"^^xsd:integer — a BOUND 0, NOT unbound. This is the cell
+        // PSS usage() reads (directly, or via COALESCE(SUM(?size), 0) which still sees 0).
+        assert_eq!(one_cell("SELECT (SUM(?o) AS ?v) WHERE { ?s ex:nomatch ?o }"), Some(int_lit(0)));
+    }
+
+    #[test]
+    fn avg_over_empty_is_integer_zero_one_row() {
+        // §18.5.1.5: Avg({}) = "0"^^xsd:integer.
+        assert_eq!(one_cell("SELECT (AVG(?o) AS ?v) WHERE { ?s ex:nomatch ?o }"), Some(int_lit(0)));
+    }
+
+    #[test]
+    fn min_over_empty_is_unbound_one_row() {
+        // §18.5.1.6: Min over {} errors ⇒ unbound cell, but still ONE row.
+        assert_eq!(one_cell("SELECT (MIN(?o) AS ?v) WHERE { ?s ex:nomatch ?o }"), None);
+    }
+
+    #[test]
+    fn max_over_empty_is_unbound_one_row() {
+        // §18.5.1.7. Mirrors the W3C `agg-empty-group-max-2` conformance test.
+        assert_eq!(one_cell("SELECT (MAX(?o) AS ?v) WHERE { ?s ex:nomatch ?o }"), None);
+    }
+
+    #[test]
+    fn sample_over_empty_is_unbound_one_row() {
+        // §18.5.1.8: no element to sample ⇒ unbound cell, ONE row.
+        assert_eq!(one_cell("SELECT (SAMPLE(?o) AS ?v) WHERE { ?s ex:nomatch ?o }"), None);
+    }
+
+    #[test]
+    fn group_concat_over_empty_is_empty_string_one_row() {
+        // §18.5.1.9: concatenation of zero strings is the empty simple literal "".
+        assert_eq!(
+            one_cell("SELECT (GROUP_CONCAT(?o) AS ?v) WHERE { ?s ex:nomatch ?o }"),
+            Some(Term::Literal(oxrdf::Literal::new_simple_literal("")))
+        );
+    }
+
+    #[test]
+    fn group_concat_with_separator_over_empty_is_empty_string() {
+        // A custom separator does not change the empty-input result: still "".
+        assert_eq!(
+            one_cell("SELECT (GROUP_CONCAT(?o; SEPARATOR=\",\") AS ?v) WHERE { ?s ex:nomatch ?o }"),
+            Some(Term::Literal(oxrdf::Literal::new_simple_literal("")))
+        );
+    }
+
+    /// The PSS `usage()` shape end-to-end: several aggregates in one SELECT over an empty
+    /// match must yield a SINGLE row whose COUNT is 0 and SUM is 0 (so `{resourceCount:0,
+    /// bytes:0}` falls out of that one row), with no extra/zero rows.
+    #[test]
+    fn mixed_aggregates_no_group_by_yield_one_row() {
+        let r = run("SELECT (COUNT(?o) AS ?n) (SUM(?o) AS ?total) WHERE { ?s ex:nomatch ?o }");
+        assert_eq!(r.vars.iter().map(|v| v.as_str()).collect::<Vec<_>>(), ["n", "total"]);
+        assert_eq!(r.rows.len(), 1, "aggregates with no GROUP BY over empty must be ONE row");
+        assert_eq!(r.rows[0], vec![Some(int_lit(0)), Some(int_lit(0))]);
+    }
+
+    // ---- WITH GROUP BY over empty input: ZERO groups ⇒ ZERO rows ----
+
+    #[test]
+    fn count_star_with_group_by_over_empty_is_zero_rows() {
+        // Mirrors W3C `agg-empty-group-count-1`.
+        let r = run("SELECT ?s (COUNT(*) AS ?v) WHERE { ?s ex:nomatch ?o } GROUP BY ?s");
+        assert!(r.rows.is_empty(), "GROUP BY over empty input must yield zero groups (zero rows)");
+    }
+
+    #[test]
+    fn sum_with_group_by_over_empty_is_zero_rows() {
+        let r = run("SELECT ?s (SUM(?o) AS ?v) WHERE { ?s ex:nomatch ?o } GROUP BY ?s");
+        assert!(r.rows.is_empty());
+    }
+
+    #[test]
+    fn max_with_group_by_over_empty_is_zero_rows() {
+        // Mirrors W3C `agg-empty-group-max-1`.
+        let r = run("SELECT ?s (MAX(?o) AS ?v) WHERE { ?s ex:nomatch ?o } GROUP BY ?s");
+        assert!(r.rows.is_empty());
+    }
+
+    /// The single-implicit-group rule must NOT fire when a GROUP BY is written, even if the
+    /// grouping key is a constant expression — empty input still means zero groups.
+    #[test]
+    fn group_by_constant_over_empty_is_zero_rows() {
+        let r = run("SELECT ?k (COUNT(*) AS ?v) WHERE { ?s ex:nomatch ?o } GROUP BY (1 AS ?k)");
+        assert!(r.rows.is_empty());
+    }
+}

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -112,6 +112,18 @@ sparq_engine::query(&g,
     "SELECT ?s WHERE { { SELECT ?s WHERE { ?s <http://ex/age> ?a } ORDER BY DESC(?a) LIMIT 1 } }").unwrap();
 ```
 
+*Aggregates over an EMPTY result* (SPARQL 1.1 §18.5.1, pinned by the engine's
+`aggregate_empty_semantics` tests and the W3C `agg-empty-group-*` conformance cases):
+
+- **No `GROUP BY`** ⇒ the whole result is ONE implicit group, so you get exactly **one** row
+  even when nothing matched. In it: `COUNT(*)`/`COUNT(?x)`/`SUM(?x)`/`AVG(?x)` are
+  **`"0"^^xsd:integer`** (a *bound* `0`), `GROUP_CONCAT(?x)` is the empty string `""`, and
+  `MIN`/`MAX`/`SAMPLE` are **unbound** (an empty-set error surfaces as an unbound cell).
+  Mind the split: `SUM`/`AVG` over empty are `0`, not unbound — so `COALESCE(SUM(?x), 0)`
+  returns `0` because `SUM` already returned a bound `0`.
+- **With `GROUP BY`** ⇒ an empty input has **zero groups**, so you get **zero** rows (the
+  single-implicit-group rule applies only when no `GROUP BY` is written).
+
 **Property paths** (all 8 operators: `/  | ^  *  +  ?` and `!(…)` negated sets) — write them inline:
 
 ```rust


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Closes #49

## What

Defines and **guarantees** SPARQL 1.1 §18.5.1 aggregate-over-EMPTY-multiset semantics in `sparq-engine`, pinned with tests. PSS `usage()` sums resource sizes over a possibly-empty graph match and reads a single mostly-bound row; this locks the contract it depends on.

## Finding: the engine already matches the spec

I verified the current `group_aggregate` / `eval_aggregate` behaviour empirically against the SPARQL 1.1 rec **and** the W3C `agg-empty-group-*` conformance cases. It is conformant on every case, so this PR lands the **guarantee** (pinning tests + a doc note), not a behaviour change.

| Aggregate (no GROUP BY, empty match) | Result | Spec |
|---|---|---|
| `COUNT(*)` / `COUNT(?x)` | `"0"^^xsd:integer` | §18.5.1.1 Count({}) = 0 |
| `SUM(?x)` | `"0"^^xsd:integer` (bound 0) | §18.5.1.4 Sum({}) = 0 |
| `AVG(?x)` | `"0"^^xsd:integer` (bound 0) | §18.5.1.5 Avg({}) = 0 |
| `MIN(?x)` / `MAX(?x)` | UNBOUND | §18.5.1.6/7 error ⇒ unbound cell |
| `SAMPLE(?x)` | UNBOUND | §18.5.1.8 |
| `GROUP_CONCAT(?x)` | `""` | §18.5.1.9 |

- **No GROUP BY** ⇒ one implicit group ⇒ exactly **one** row even when nothing matched.
- **With GROUP BY** ⇒ empty input ⇒ **zero** groups ⇒ **zero** rows.

The subtle point (documented inline + in the skill): `SUM`/`AVG` over `{}` are a **bound `0`**, *not* unbound — so `COALESCE(SUM(?x), 0)` returns `0` because `SUM` already returned a bound `0`; only `MIN`/`MAX`/`SAMPLE` are unbound. This is fully spec-conformant; the literal wording of the originating need ("SUM over empty yields UNBOUND") is non-conformant, but PSS's observed `{bytes:0}` result holds either way.

## Changes

- `crates/sparq-engine/src/exec.rs` — new `aggregate_empty_semantics` test module (15 cases): COUNT(\*) vs COUNT(?x), SUM, AVG, MIN, MAX, SAMPLE, GROUP_CONCAT (±separator) over empty → one row with exact bound/unbound cells; a mixed-aggregate usage()-shaped query → one row; the GROUP-BY-over-empty → zero-rows cases (incl. GROUP BY on a constant). Asserts exact `Term`s and `None` (unbound) cells, not just row counts.
- `skills/sparql-query/SKILL.md` — documents the empty-aggregate contract next to the aggregates recipe.

Test-only + doc; no execution-path change. Mirrors the W3C `agg-empty-group-count-1/2` and `agg-empty-group-max-1/2` conformance tests already in the green ratchet.

## Gate

- `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings` — clean.
- `cargo test -p sparq-engine` — green (173 passed + 2 ignored; the 15 new tests pass).