### PR TITLE
fix(sparq-cli): hdt_cli output-wording test drift (sq-w6ri)

### DIFF
--- a/crates/sparq-cli/tests/hdt_cli.rs
+++ b/crates/sparq-cli/tests/hdt_cli.rs
@@ -16,9 +16,12 @@ const COUNT_ALL: &str = "SELECT ?s ?p ?o WHERE { ?s ?p ?o }";
 /// [OPUS-4.8] (sq-w6ri) The default `query` SELECT path (no `--count`) renders a readable
 /// ASCII table footed by `(<N> row(s))` — the canonical wording documented in
 /// `cli_contract.rs` (sq-l4ki). The snikmeta fixture has 328 triples, so a `SELECT ?s ?p ?o`
-/// yields 328 rows. (`solutions` is reserved for the `--count` count-only output, which these
-/// tests do not exercise.)
-const EXPECTED_FOOTER: &str = "328 row(s)";
+/// yields 328 rows. The constant asserts the *full parenthesized* footer `(328 row(s))` —
+/// exactly the substring `select_to_table` emits via `writeln!(out, "({} row(s))", ..)` —
+/// rather than the bare `328 row(s)`, so the test is pinned to the precise contract.
+/// (`solutions` is reserved for the `--count` count-only output, which these tests do not
+/// exercise.)
+const EXPECTED_FOOTER: &str = "(328 row(s))";
 
 /// Runs `sparq-cli query <path> <format> <sparql>` and returns (status-ok, stdout, stderr).
 fn run_query(path: &Path, format: &str) -> (bool, String, String) {

--- a/crates/sparq-cli/tests/hdt_cli.rs
+++ b/crates/sparq-cli/tests/hdt_cli.rs
@@ -13,6 +13,13 @@ fn fixture() -> PathBuf {
 
 const COUNT_ALL: &str = "SELECT ?s ?p ?o WHERE { ?s ?p ?o }";
 
+/// [OPUS-4.8] (sq-w6ri) The default `query` SELECT path (no `--count`) renders a readable
+/// ASCII table footed by `(<N> row(s))` — the canonical wording documented in
+/// `cli_contract.rs` (sq-l4ki). The snikmeta fixture has 328 triples, so a `SELECT ?s ?p ?o`
+/// yields 328 rows. (`solutions` is reserved for the `--count` count-only output, which these
+/// tests do not exercise.)
+const EXPECTED_FOOTER: &str = "328 row(s)";
+
 /// Runs `sparq-cli query <path> <format> <sparql>` and returns (status-ok, stdout, stderr).
 fn run_query(path: &Path, format: &str) -> (bool, String, String) {
     let out = Command::new(env!("CARGO_BIN_EXE_sparq-cli"))
@@ -29,17 +36,24 @@ fn run_query(path: &Path, format: &str) -> (bool, String, String) {
 #[test]
 fn query_loads_hdt_via_explicit_format_and_extension() {
     let hdt = fixture();
-    assert!(hdt.exists(), "snikmeta fixture missing at {}", hdt.display());
+    assert!(
+        hdt.exists(),
+        "snikmeta fixture missing at {}",
+        hdt.display()
+    );
 
     // Explicit `hdt` format argument.
     let (ok, stdout, stderr) = run_query(&hdt, "hdt");
     assert!(ok, "stderr: {stderr}");
-    assert!(stdout.contains("328 solutions"), "stdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        stdout.contains(EXPECTED_FOOTER),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
 
     // Extension-driven detection: a bogus format argument is overridden by `.hdt`.
     let (ok, stdout, _) = run_query(&hdt, "ntriples");
     assert!(ok);
-    assert!(stdout.contains("328 solutions"), "stdout: {stdout}");
+    assert!(stdout.contains(EXPECTED_FOOTER), "stdout: {stdout}");
 }
 
 #[test]
@@ -59,5 +73,5 @@ fn query_loads_gzipped_hdt() {
 
     let (ok, stdout, stderr) = run_query(&gz_path, "hdt");
     assert!(ok, "stderr: {stderr}");
-    assert!(stdout.contains("328 solutions"), "stdout: {stdout}");
+    assert!(stdout.contains(EXPECTED_FOOTER), "stdout: {stdout}");
 }


### PR DESCRIPTION
> 🤖 _SPARQ agent_

Fixes the `--features hdt` test failures in `hdt_cli.rs` where the tests asserted the stale "NNN solutions" wording after the CLI standardized on "<N> row(s)".

**What drifted:** the `query` subcommand was reworked (sq-l4ki) into a real query CLI: a default SELECT (no `--count`) now renders a readable ASCII table footed by `(<N> row(s))` (`select_to_table` in `main.rs`), and the `<n> solutions` wording is reserved exclusively for the `--count` count-only path. The `cli_contract.rs` header documents this output contract, and its own tests already assert `3 row(s)` for default SELECT — so the CLI is canonical and `hdt_cli.rs` simply hadn't caught up.

**Side corrected:** the tests. `hdt_cli.rs` runs `query <path> <format> <sparql>` with no `--count`, so it hits the table path; the three assertions now check `328 row(s)` (extracted to an `EXPECTED_FOOTER` const with a doc comment). The 328 count is preserved (snikmeta fixture = 328 triples).

Refs bead sq-w6ri.

Gate: `cargo test -p sparq-cli --features hdt` green (40 tests); `cargo test -p sparq-cli` green (38, hdt_cli feature-gated out); `cargo clippy -p sparq-cli --all-targets --features hdt -- -D warnings` clean.