### PR TITLE
feat(sparq-vectors): graph fingerprint header + checked open (sq-32i5)

### DIFF
--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -50,6 +50,11 @@ let _neighbours = index.nearest_term(&some_term, &graph, &store, 10);
 
 - **`VectorStore`** — memory-mapped `.spqv` store; `get` is one binary search + a contiguous
   `&[f32]`; corrupt files are rejected up front. `open_from_bytes` for filesystem-less use.
+- **Graph-staleness guard** — stores are keyed by dictionary id, so a store built against one
+  graph silently mis-resolves after a dict-id-shifting rebuild. Both `.spqv`/`.spqg` headers
+  embed a graph **fingerprint** (`with_fingerprint` / `build_for`); the checked query paths
+  (`nearest_term_exact_checked`, `DiskAnnIndex::nearest_term_checked`, `check_graph`) return a
+  descriptive error on a mismatch instead of wrong neighbours.
 - **`StreamingWriter`** — build stores bigger than RAM with O(1) build-phase memory;
   byte-identical output to the in-RAM builder.
 - **Search** — `nearest_exact` (ground-truth baseline), in-RAM HNSW (`VectorIndex`), and the

--- a/crates/sparq-vectors/src/ann.rs
+++ b/crates/sparq-vectors/src/ann.rs
@@ -71,6 +71,11 @@ pub fn nearest_exact(store: &VectorStore, query: &[f32], k: usize) -> Vec<(Id, f
 /// dictionary, looks its vector up in the store, excludes the term itself from the
 /// results and maps neighbor ids back to [`Term`]s. Empty if the term is absent from
 /// the dictionary or has no vector.
+///
+/// [OPUS-4.8] (sq-32i5) This does NOT verify `store` matches `graph` — a store keyed by a
+/// stale graph generation silently mis-resolves `term`. Use
+/// [`nearest_term_exact_checked`] (or call [`VectorStore::check_graph`] once) to make a
+/// mismatch a hard error.
 pub fn nearest_term_exact(
     store: &VectorStore,
     graph: &Graph,
@@ -85,6 +90,19 @@ pub fn nearest_term_exact(
         .take(k)
         .map(|(n, s)| (graph.dict.term(n), s))
         .collect()
+}
+
+/// [OPUS-4.8] (sq-32i5) [`nearest_term_exact`] with the staleness check: returns `Err` if
+/// `store` was built against a different graph generation than `graph` (which would otherwise
+/// return silently-wrong neighbours), else `Ok` with the neighbours.
+pub fn nearest_term_exact_checked(
+    store: &VectorStore,
+    graph: &Graph,
+    term: &Term,
+    k: usize,
+) -> Result<Vec<(Term, f32)>, String> {
+    store.check_graph(graph)?;
+    Ok(nearest_term_exact(store, graph, term, k))
 }
 
 /// HNSW construction/search parameters (passed through to `instant-distance`).
@@ -200,5 +218,20 @@ impl VectorIndex {
             .take(k)
             .map(|(n, s)| (graph.dict.term(n), s))
             .collect()
+    }
+
+    /// [OPUS-4.8] (sq-32i5) [`nearest_term`](Self::nearest_term) with the staleness check: returns
+    /// `Err` if `store` was built against a different graph generation than `graph` (which would
+    /// otherwise return silently-wrong neighbours), else `Ok` with the neighbours. The HNSW index
+    /// is rebuilt from `store` on open, so checking the store covers the index too.
+    pub fn nearest_term_checked(
+        &self,
+        term: &Term,
+        graph: &Graph,
+        store: &VectorStore,
+        k: usize,
+    ) -> Result<Vec<(Term, f32)>, String> {
+        store.check_graph(graph)?;
+        Ok(self.nearest_term(term, graph, store, k))
     }
 }

--- a/crates/sparq-vectors/src/diskann.rs
+++ b/crates/sparq-vectors/src/diskann.rs
@@ -23,17 +23,19 @@
 //! L2-normalized at build time and Euclidean-on-unit-vectors is rank-equivalent to cosine
 //! (`cos = 1 − d²/2`), so reported scores and rankings match the exact/HNSW searchers.
 //!
-//! # On-disk format (`.spqg`, version 1, little-endian)
+//! # On-disk format (`.spqg`, version 2, little-endian)
 //!
 //! ```text
-//! offset 0    magic     b"SPQG"                         4 bytes
-//! offset 4    version   u32 = 1                         4 bytes
-//! offset 8    dim       u32                             4 bytes
-//! offset 12   degree R  u32   (max out-neighbours)      4 bytes
-//! offset 16   count     u64   (nodes = store vectors)   8 bytes
-//! offset 24   medoid    u32   (entry-point slot)        4 bytes
-//! offset 28   reserved  zero  (encoding tag etc.)       4 bytes
-//! offset 32   nodes     [count × NODE_RECORD]           count·record bytes
+//! offset 0    magic       b"SPQG"                       4 bytes
+//! offset 4    version     u32 = 2                       4 bytes
+//! offset 8    dim         u32                           4 bytes
+//! offset 12   degree R    u32   (max out-neighbours)    4 bytes
+//! offset 16   count       u64   (nodes = store vectors) 8 bytes
+//! offset 24   medoid      u32   (entry-point slot)      4 bytes
+//! offset 28   reserved    zero  (encoding tag etc.)     4 bytes
+//! offset 32   fingerprint graph fingerprint            24 bytes
+//!             (dict_len: u64, triple_count: u64, content_hash: u64)
+//! offset 56   nodes       [count × NODE_RECORD]         count·record bytes
 //!
 //! one NODE_RECORD (all fields little-endian, 4-byte aligned):
 //!   id        u32                  the store's dictionary term id
@@ -63,7 +65,15 @@
 //! fits in page cache (the regime this unblocks: skip the per-process rebuild) the two are
 //! equivalent; PQ matters only when the vectors themselves exceed RAM. The `.spqg` header
 //! reserves 4 bytes for an encoding tag so a PQ variant lands as a backwards-compatible bump.
+//!
+//! [OPUS-4.8] (sq-32i5) The header also carries a **graph fingerprint** (offset 32..56) binding
+//! the index to the graph it was built against — see [`crate::fingerprint`] and
+//! [`DiskAnnIndex::check_graph`]. A query by term resolves through the caller's graph dictionary,
+//! so an index built against a different graph generation would silently mis-resolve; the checked
+//! query entry points reject that. Version-1 files (no fingerprint, 32-byte header) still open but
+//! are reported as unverifiable.
 
+use crate::fingerprint::{self, Fingerprint, FINGERPRINT_LEN};
 use crate::store::VectorStore;
 use memmap2::Mmap;
 use oxrdf::Term;
@@ -75,9 +85,13 @@ use std::path::{Path, PathBuf};
 
 /// First four bytes of every `.spqg` file.
 pub const SPQG_MAGIC: [u8; 4] = *b"SPQG";
-/// Current on-disk graph format version.
-pub const SPQG_VERSION: u32 = 1;
-const HEADER_LEN: usize = 32;
+/// Current on-disk graph format version. [OPUS-4.8] (sq-32i5) v2 adds the 24-byte graph
+/// fingerprint block at offset 32; v1 files (32-byte header) still open but cannot be verified.
+pub const SPQG_VERSION: u32 = 2;
+/// Header length of a version-1 file (no fingerprint block).
+const HEADER_LEN_V1: usize = 32;
+/// Header length of the current (version-2) format: the v1 header + the fingerprint block.
+const HEADER_LEN: usize = HEADER_LEN_V1 + FINGERPRINT_LEN;
 
 /// Vamana build/search parameters. Defaults follow the DiskANN paper's small-graph regime
 /// and are tuned to clear [`ann`](crate::ann)'s recall@10 ≥ 0.95 gate on the same synthetic
@@ -343,8 +357,9 @@ const fn record_len(dim: usize, degree: usize) -> usize {
     8 + dim * 4 + degree * 4
 }
 
-/// Writes the built graph to `path` as a `.spqg` file (one node record per node).
-fn write_graph(b: &Builder, path: &Path) -> Result<(), String> {
+/// Writes the built graph to `path` as a `.spqg` file (one node record per node). `fingerprint`
+/// (offset 32..56) binds the index to its graph; `None` writes an unverifiable (all-zero) block.
+fn write_graph(b: &Builder, path: &Path, fingerprint: Option<Fingerprint>) -> Result<(), String> {
     if cfg!(target_endian = "big") {
         return Err(".spqg is a little-endian format; big-endian targets are unsupported".into());
     }
@@ -357,6 +372,11 @@ fn write_graph(b: &Builder, path: &Path) -> Result<(), String> {
     header[12..16].copy_from_slice(&(r as u32).to_le_bytes());
     header[16..24].copy_from_slice(&(count as u64).to_le_bytes());
     header[24..28].copy_from_slice(&b.medoid.to_le_bytes());
+    // [OPUS-4.8] (sq-32i5) Graph fingerprint at offset 32..56 (offset 28..32 stays the reserved
+    // encoding tag). `None` leaves a zeroed block, which `check_graph` treats as unverifiable.
+    if let Some(fp) = fingerprint {
+        header[HEADER_LEN_V1..HEADER_LEN].copy_from_slice(&fp.to_bytes());
+    }
 
     let file = std::fs::File::create(path).map_err(|e| format!("create {}: {e}", path.display()))?;
     let mut w = std::io::BufWriter::new(file);
@@ -401,21 +421,62 @@ pub struct DiskAnnIndex {
     medoid: u32,
     record_len: usize,
     search_beam: usize,
+    /// [OPUS-4.8] (sq-32i5) The graph fingerprint this index was built against, or `None` for a
+    /// legacy version-1 file / an index built without a graph. See [`check_graph`](Self::check_graph).
+    fingerprint: Option<Fingerprint>,
+    /// Byte offset where node records begin: [`HEADER_LEN`] (v2) or [`HEADER_LEN_V1`] (legacy v1).
+    /// Every record read keys off this so both versions are read correctly by the same code.
+    data_offset: usize,
 }
 
 impl DiskAnnIndex {
     /// Builds the Vamana graph over `store` with default parameters and writes it to `path`,
-    /// then opens it. Equivalent to `build_with(store, path, VamanaConfig::default())`.
+    /// then opens it. Equivalent to `build_with(store, path, VamanaConfig::default())`. The index
+    /// is written WITHOUT a graph fingerprint (unverifiable — [`check_graph`](Self::check_graph)
+    /// errors); use [`build_for`](Self::build_for) to bind it to its graph.
     pub fn build<P: AsRef<Path>>(store: &VectorStore, path: P) -> Result<DiskAnnIndex, String> {
         Self::build_with(store, path, VamanaConfig::default())
     }
 
     /// Builds the Vamana graph over `store` with `cfg`, writes the `.spqg` file at `path`, and
     /// opens it memory-mapped. The build is in RAM (one-off); the open is cheap forever after.
+    /// Written without a fingerprint — see [`build`](Self::build) / [`build_with_for`](Self::build_with_for).
     pub fn build_with<P: AsRef<Path>>(
         store: &VectorStore,
         path: P,
         cfg: VamanaConfig,
+    ) -> Result<DiskAnnIndex, String> {
+        Self::build_inner(store, path, cfg, None)
+    }
+
+    /// [OPUS-4.8] (sq-32i5) Like [`build`](Self::build) but binds the index to `graph` (embeds its
+    /// fingerprint), so [`check_graph`](Self::check_graph) / [`nearest_term_checked`](Self::nearest_term_checked)
+    /// can reject a query against a different graph generation. Pass the graph whose term ids `store`
+    /// is keyed by.
+    pub fn build_for<P: AsRef<Path>>(
+        store: &VectorStore,
+        path: P,
+        graph: &Graph,
+    ) -> Result<DiskAnnIndex, String> {
+        Self::build_with_for(store, path, VamanaConfig::default(), graph)
+    }
+
+    /// [OPUS-4.8] (sq-32i5) Like [`build_with`](Self::build_with) but binds the index to `graph`'s
+    /// fingerprint (see [`build_for`](Self::build_for)).
+    pub fn build_with_for<P: AsRef<Path>>(
+        store: &VectorStore,
+        path: P,
+        cfg: VamanaConfig,
+        graph: &Graph,
+    ) -> Result<DiskAnnIndex, String> {
+        Self::build_inner(store, path, cfg, Some(Fingerprint::of(graph)))
+    }
+
+    fn build_inner<P: AsRef<Path>>(
+        store: &VectorStore,
+        path: P,
+        cfg: VamanaConfig,
+        fingerprint: Option<Fingerprint>,
     ) -> Result<DiskAnnIndex, String> {
         if cfg.build_beam < cfg.degree {
             return Err(format!(
@@ -424,7 +485,7 @@ impl DiskAnnIndex {
             ));
         }
         let b = build_graph(store, &cfg);
-        write_graph(&b, path.as_ref())?;
+        write_graph(&b, path.as_ref(), fingerprint)?;
         let mut idx = Self::open(path)?;
         idx.search_beam = cfg.search_beam;
         Ok(idx)
@@ -433,6 +494,10 @@ impl DiskAnnIndex {
     /// Opens a `.spqg` file memory-mapped, **without rebuilding** — the whole point of this
     /// index. Validates the header and that the file size matches `count` records so no later
     /// search can read out of bounds; the records themselves page in on access.
+    ///
+    /// [OPUS-4.8] (sq-32i5) A version-2 file's graph fingerprint is read for
+    /// [`check_graph`](Self::check_graph). A legacy version-1 file (32-byte header, no fingerprint)
+    /// still opens — its fingerprint is `None`, so `check_graph` reports it as unverifiable.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<DiskAnnIndex, String> {
         let path = path.as_ref();
         if cfg!(target_endian = "big") {
@@ -443,16 +508,26 @@ impl DiskAnnIndex {
         // stance as `.spqv` and sparq-core's mmap'd indexes).
         let map = unsafe { Mmap::map(&file) }.map_err(|e| format!("mmap {}: {e}", path.display()))?;
         let origin = path.display().to_string();
-        if map.len() < HEADER_LEN {
+        if map.len() < HEADER_LEN_V1 {
             return Err(format!("{origin}: truncated header"));
         }
         if map[0..4] != SPQG_MAGIC {
             return Err(format!("{origin}: not a .spqg file (bad magic)"));
         }
         let version = u32::from_le_bytes(map[4..8].try_into().unwrap());
-        if version != SPQG_VERSION {
-            return Err(format!("{origin}: unsupported .spqg version {version}"));
-        }
+        // [OPUS-4.8] (sq-32i5) Both v1 (no fingerprint, 32-byte header) and v2 (fingerprint,
+        // 56-byte header) open; the offset where node records begin depends on the version, so
+        // every record read keys off `data_offset` below.
+        let (data_offset, fingerprint): (usize, Option<Fingerprint>) = match version {
+            1 => (HEADER_LEN_V1, None),
+            2 => {
+                if map.len() < HEADER_LEN {
+                    return Err(format!("{origin}: truncated version-2 header (fingerprint block)"));
+                }
+                (HEADER_LEN, Some(Fingerprint::from_bytes(&map[HEADER_LEN_V1..HEADER_LEN])))
+            }
+            v => return Err(format!("{origin}: unsupported .spqg version {v}")),
+        };
         let dim = u32::from_le_bytes(map[8..12].try_into().unwrap()) as usize;
         let degree = u32::from_le_bytes(map[12..16].try_into().unwrap()) as usize;
         let count: usize = u64::from_le_bytes(map[16..24].try_into().unwrap())
@@ -466,7 +541,7 @@ impl DiskAnnIndex {
         // Checked size arithmetic — reject a malformed header before it wraps past the bounds check.
         let expect = count
             .checked_mul(record_len)
-            .and_then(|body| body.checked_add(HEADER_LEN))
+            .and_then(|body| body.checked_add(data_offset))
             .ok_or_else(|| {
                 format!("{origin}: dim={dim} degree={degree} count={count} overflows the file size")
             })?;
@@ -487,6 +562,8 @@ impl DiskAnnIndex {
             medoid,
             record_len,
             search_beam: VamanaConfig::default().search_beam,
+            fingerprint,
+            data_offset,
         })
     }
 
@@ -504,24 +581,24 @@ impl DiskAnnIndex {
 
     /// The normalized vector stored in `slot`'s record, read directly from the map.
     fn node_vector(&self, slot: u32) -> &[f32] {
-        let start = HEADER_LEN + slot as usize * self.record_len + 8;
+        let start = self.data_offset + slot as usize * self.record_len + 8;
         let bytes = &self.map[start..start + self.dim * 4];
         debug_assert_eq!(bytes.as_ptr() as usize % std::mem::align_of::<f32>(), 0);
-        // SAFETY: a memory map is page-aligned and `start` is a multiple of 4 (HEADER_LEN=32 +
-        // slot·record_len[a multiple of 4] + 8), so the pointer is f32-aligned; the range is in
-        // bounds (validated in `open`); f32 accepts any bit pattern; the slice borrows the map.
+        // SAFETY: a memory map is page-aligned and `start` is a multiple of 4 (data_offset
+        // [32 or 56] + slot·record_len[a multiple of 4] + 8), so the pointer is f32-aligned; the
+        // range is in bounds (validated in `open`); f32 accepts any bit pattern; slice borrows map.
         unsafe { std::slice::from_raw_parts(bytes.as_ptr() as *const f32, self.dim) }
     }
 
     /// `slot`'s dictionary term id (record field 0).
     fn node_id(&self, slot: u32) -> Id {
-        let start = HEADER_LEN + slot as usize * self.record_len;
+        let start = self.data_offset + slot as usize * self.record_len;
         u32::from_le_bytes(self.map[start..start + 4].try_into().unwrap())
     }
 
     /// `slot`'s valid out-neighbour slots (the first `degree` neighbour entries).
     fn node_neighbours(&self, slot: u32) -> impl Iterator<Item = u32> + '_ {
-        let start = HEADER_LEN + slot as usize * self.record_len;
+        let start = self.data_offset + slot as usize * self.record_len;
         let deg = u32::from_le_bytes(self.map[start + 4..start + 8].try_into().unwrap()) as usize;
         let nbr_off = start + 8 + self.dim * 4;
         (0..deg.min(self.degree)).map(move |i| {
@@ -584,6 +661,11 @@ impl DiskAnnIndex {
     /// looks its vector up in `store`, excludes the term itself and maps neighbour ids back to
     /// [`Term`]s. Empty if the term is absent or unembedded. Mirrors
     /// [`VectorIndex::nearest_term`](crate::ann::VectorIndex::nearest_term).
+    ///
+    /// [OPUS-4.8] (sq-32i5) This does NOT verify the index/store match `graph` — pass a graph
+    /// whose ids have shifted since build and the results are silently WRONG. Use
+    /// [`nearest_term_checked`](Self::nearest_term_checked) (or call [`check_graph`](Self::check_graph)
+    /// once after open) to make a mismatch a hard error.
     pub fn nearest_term(
         &self,
         term: &Term,
@@ -600,6 +682,41 @@ impl DiskAnnIndex {
             .map(|(n, s)| (graph.dict.term(n), s))
             .collect()
     }
+
+    /// [OPUS-4.8] (sq-32i5) The graph fingerprint this index was built against, or `None` for a
+    /// legacy version-1 file / an index built without a graph. See [`check_graph`](Self::check_graph).
+    pub fn fingerprint(&self) -> Option<Fingerprint> {
+        self.fingerprint
+    }
+
+    /// [OPUS-4.8] (sq-32i5) **Checked open guard**: verifies this index was built against `graph`
+    /// (and, since the index is queried alongside the store, that `store` matches it too) by
+    /// recomputing `graph`'s fingerprint and comparing it to BOTH stored fingerprints. Returns a
+    /// descriptive `Err` on any mismatch — the index and store are keyed by `graph`'s dictionary
+    /// ids, so a mismatch means a query would silently resolve to the WRONG vectors. A legacy
+    /// version-1 index/store (no stored fingerprint) also errors, as "unverifiable".
+    ///
+    /// Call once after [`open`](Self::open) (it is O(dict_len), not per-query). The store is checked
+    /// as well because [`nearest_term`](Self::nearest_term) resolves the query vector through it.
+    pub fn check_graph(&self, store: &VectorStore, graph: &Graph) -> fingerprint::CheckResult {
+        let origin = "<.spqg index>";
+        fingerprint::check_against(self.fingerprint, graph, origin)?;
+        store.check_graph(graph)
+    }
+
+    /// [OPUS-4.8] (sq-32i5) [`nearest_term`](Self::nearest_term) with the staleness check: returns
+    /// `Err` if this index or `store` was built against a different graph generation than `graph`
+    /// (which would otherwise return silently-wrong neighbours), else `Ok` with the neighbours.
+    pub fn nearest_term_checked(
+        &self,
+        term: &Term,
+        graph: &Graph,
+        store: &VectorStore,
+        k: usize,
+    ) -> Result<Vec<(Term, f32)>, String> {
+        self.check_graph(store, graph)?;
+        Ok(self.nearest_term(term, graph, store, k))
+    }
 }
 
 /// Default path for a store's sibling `.spqg` graph artifact: the store path with its extension
@@ -607,4 +724,130 @@ impl DiskAnnIndex {
 /// "graph lives next to the store" layout; any path works with [`DiskAnnIndex::build_with`].
 pub fn sibling_graph_path(store_path: &Path) -> PathBuf {
     store_path.with_extension("spqg")
+}
+
+#[cfg(test)]
+mod fingerprint_tests {
+    // [OPUS-4.8] (sq-32i5) Checked-open tests for the `.spqg` on-disk index: build against graph A
+    // then (1) query against A → OK + correct neighbours, (2) query against a DIFFERENT graph B →
+    // descriptive Err, (3) fingerprint survives reopen, (4) a legacy version-1 `.spqg` opens (and
+    // searches) but reports as unverifiable.
+    use super::*;
+    use crate::Fingerprint;
+    use oxrdf::NamedNode;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+
+    fn tmp(tag: &str, ext: &str) -> PathBuf {
+        let n = SEQ.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("sparq_fpg_{tag}_{}_{n}.{ext}", std::process::id()))
+    }
+
+    fn graph(ttl: &str) -> Graph {
+        Graph::load_str(ttl, "turtle").expect("load test turtle")
+    }
+
+    fn iri(s: &str) -> Term {
+        Term::NamedNode(NamedNode::new(s).unwrap())
+    }
+
+    const A: &str = r#"
+        @prefix ex: <http://example.org/> .
+        ex:alice ex:knows ex:bob .
+        ex:bob ex:knows ex:carol .
+    "#;
+    const B: &str = r#"
+        @prefix ex: <http://example.org/> .
+        ex:dave ex:likes ex:eve .
+        ex:eve ex:likes ex:frank .
+    "#;
+
+    fn build_store(g: &Graph, path: &std::path::Path) -> VectorStore {
+        let alice = g.id_of(&iri("http://example.org/alice")).unwrap();
+        let bob = g.id_of(&iri("http://example.org/bob")).unwrap();
+        let carol = g.id_of(&iri("http://example.org/carol")).unwrap();
+        let mut s = VectorStore::create(path, 4).unwrap().with_fingerprint(g);
+        s.put(alice, &[1.0, 0.0, 0.0, 0.0]).unwrap();
+        s.put(bob, &[0.9, 0.1, 0.0, 0.0]).unwrap();
+        s.put(carol, &[0.0, 0.0, 0.0, 1.0]).unwrap();
+        s.finalize().unwrap();
+        s
+    }
+
+    #[test]
+    fn build_for_then_query_against_build_graph_ok_and_correct() {
+        let ga = graph(A);
+        let store_path = tmp("ok", "spqv");
+        let store = build_store(&ga, &store_path);
+        let idx_path = tmp("ok", "spqg");
+        let idx = DiskAnnIndex::build_for(&store, &idx_path, &ga).unwrap();
+        // (1) Checked against the build graph → OK, and bob is alice's nearest.
+        assert!(idx.check_graph(&store, &ga).is_ok());
+        let got = idx
+            .nearest_term_checked(&iri("http://example.org/alice"), &ga, &store, 1)
+            .expect("checked query against the build graph must succeed");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].0, iri("http://example.org/bob"));
+        std::fs::remove_file(&store_path).ok();
+        std::fs::remove_file(&idx_path).ok();
+    }
+
+    #[test]
+    fn query_against_different_graph_errs() {
+        let ga = graph(A);
+        let store_path = tmp("mm", "spqv");
+        let store = build_store(&ga, &store_path);
+        let idx_path = tmp("mm", "spqg");
+        let idx = DiskAnnIndex::build_for(&store, &idx_path, &ga).unwrap();
+        let gb = graph(B);
+        // (2) Against a DIFFERENT graph → descriptive Err, not silently wrong neighbours.
+        assert!(idx.check_graph(&store, &gb).is_err());
+        let qerr = idx
+            .nearest_term_checked(&iri("http://example.org/dave"), &gb, &store, 1)
+            .expect_err("a checked query against a mismatched graph must error");
+        assert!(qerr.contains("mismatch") || qerr.contains("wrong results"), "err: {qerr}");
+        std::fs::remove_file(&store_path).ok();
+        std::fs::remove_file(&idx_path).ok();
+    }
+
+    #[test]
+    fn fingerprint_survives_reopen() {
+        let ga = graph(A);
+        let store_path = tmp("rt", "spqv");
+        let store = build_store(&ga, &store_path);
+        let idx_path = tmp("rt", "spqg");
+        DiskAnnIndex::build_for(&store, &idx_path, &ga).unwrap();
+        // (3) Reopen the .spqg and confirm the stored fingerprint equals the live one.
+        let reopened = DiskAnnIndex::open(&idx_path).unwrap();
+        assert_eq!(reopened.fingerprint(), Some(Fingerprint::of(&ga)));
+        std::fs::remove_file(&store_path).ok();
+        std::fs::remove_file(&idx_path).ok();
+    }
+
+    #[test]
+    fn legacy_v1_spqg_opens_but_is_unverifiable() {
+        // (4) A version-1 `.spqg`: build the default (no-fingerprint) v2 file, then rewrite its
+        // header to a genuine v1 (version=1, fingerprint block dropped) so the legacy open path is
+        // exercised. It still opens and searches; check_graph reports it unverifiable.
+        let ga = graph(A);
+        let store_path = tmp("legacy", "spqv");
+        let store = build_store(&ga, &store_path);
+        let idx_path = tmp("legacy", "spqg");
+        DiskAnnIndex::build(&store, &idx_path).unwrap();
+        let mut bytes = std::fs::read(&idx_path).unwrap();
+        bytes[4..8].copy_from_slice(&1u32.to_le_bytes());
+        bytes.drain(HEADER_LEN_V1..HEADER_LEN); // remove the 24-byte fingerprint block
+        std::fs::write(&idx_path, &bytes).unwrap();
+
+        let idx = DiskAnnIndex::open(&idx_path).expect("a legacy v1 .spqg must still open");
+        assert!(idx.fingerprint().is_none());
+        // It still searches correctly against the build graph (data layout is offset-32).
+        let got = idx.nearest_term(&iri("http://example.org/alice"), &ga, &store, 1);
+        assert_eq!(got[0].0, iri("http://example.org/bob"));
+        // ...but cannot be verified.
+        assert!(idx.check_graph(&store, &ga).is_err());
+        std::fs::remove_file(&store_path).ok();
+        std::fs::remove_file(&idx_path).ok();
+    }
 }

--- a/crates/sparq-vectors/src/diskann.rs
+++ b/crates/sparq-vectors/src/diskann.rs
@@ -700,7 +700,7 @@ impl DiskAnnIndex {
     /// as well because [`nearest_term`](Self::nearest_term) resolves the query vector through it.
     pub fn check_graph(&self, store: &VectorStore, graph: &Graph) -> fingerprint::CheckResult {
         let origin = "<.spqg index>";
-        fingerprint::check_against(self.fingerprint, graph, origin)?;
+        fingerprint::check_against(self.fingerprint, graph, fingerprint::Artifact::Index, origin)?;
         store.check_graph(graph)
     }
 

--- a/crates/sparq-vectors/src/diskann.rs
+++ b/crates/sparq-vectors/src/diskann.rs
@@ -524,7 +524,13 @@ impl DiskAnnIndex {
                 if map.len() < HEADER_LEN {
                     return Err(format!("{origin}: truncated version-2 header (fingerprint block)"));
                 }
-                (HEADER_LEN, Some(Fingerprint::from_bytes(&map[HEADER_LEN_V1..HEADER_LEN])))
+                // [OPUS-4.8] (sq-32i5) All-zero block (a v2 index built without a graph binding)
+                // → `None` ("unverifiable"), not a zero fingerprint that would surface as a
+                // spurious "DIFFERENT graph" mismatch.
+                (
+                    HEADER_LEN,
+                    Fingerprint::from_bytes_opt(&map[HEADER_LEN_V1..HEADER_LEN]),
+                )
             }
             v => return Err(format!("{origin}: unsupported .spqg version {v}")),
         };
@@ -821,6 +827,33 @@ mod fingerprint_tests {
         // (3) Reopen the .spqg and confirm the stored fingerprint equals the live one.
         let reopened = DiskAnnIndex::open(&idx_path).unwrap();
         assert_eq!(reopened.fingerprint(), Some(Fingerprint::of(&ga)));
+        std::fs::remove_file(&store_path).ok();
+        std::fs::remove_file(&idx_path).ok();
+    }
+
+    #[test]
+    fn v2_index_built_without_graph_binding_is_unverifiable_not_mismatch() {
+        // [OPUS-4.8] (sq-32i5) A v2 `.spqg` built WITHOUT a graph binding writes an all-zero
+        // fingerprint block; on reopen it must decode to `None` (reported as "unverifiable"),
+        // NOT a zero fingerprint that would surface as a spurious "DIFFERENT graph" mismatch.
+        let ga = graph(A);
+        let store_path = tmp("nob", "spqv");
+        let store = build_store(&ga, &store_path);
+        let idx_path = tmp("nob", "spqg");
+        DiskAnnIndex::build(&store, &idx_path).unwrap(); // no graph binding
+        let idx = DiskAnnIndex::open(&idx_path).unwrap();
+        assert_eq!(
+            idx.fingerprint(),
+            None,
+            "all-zero block must decode to None"
+        );
+        let err = idx
+            .check_graph(&store, &ga)
+            .expect_err("an unbound index must not be certified");
+        assert!(
+            err.contains("carries no graph fingerprint"),
+            "err must say unverifiable, not mismatch: {err}"
+        );
         std::fs::remove_file(&store_path).ok();
         std::fs::remove_file(&idx_path).ok();
     }

--- a/crates/sparq-vectors/src/fingerprint.rs
+++ b/crates/sparq-vectors/src/fingerprint.rs
@@ -27,8 +27,11 @@
 //!      length/count is still rejected. `FxHasher` is used because it is **deterministic with no
 //!      seed** (the same property the core dictionary relies on for its own content hashing), so a
 //!      fingerprint computed at build time on one machine matches one recomputed at open time on
-//!      another. The cost is O(dict_len) over already-resident term parts — a small fraction of the
-//!      embed/build work that produced the store in the first place.
+//!      another. [OPUS-4.8] (sq-32i5) Every hashed input is **fixed-width** — lengths/counts as
+//!      `u64`, ids as `u32`, tags as `u8`, never `usize` — so the folded byte sequence (and thus
+//!      the hash) is identical on 32-bit wasm32 and 64-bit native; the cross-machine guarantee
+//!      holds by construction. The cost is O(dict_len) over already-resident term parts — a small
+//!      fraction of the embed/build work that produced the store in the first place.
 //!
 //! `content_hash` is a **collision-resistance-irrelevant integrity check**, not a security MAC: it
 //! exists to catch accidental staleness, not to defend against an adversary crafting a colliding
@@ -114,10 +117,16 @@ impl Fingerprint {
 /// variant, so distinct terms cannot alias by concatenation. We do not depend on the core's hash
 /// VALUE (it is private); we only need a self-consistent fold that distinguishes terms here.
 fn fold_parts(h: &mut rustc_hash::FxHasher, parts: &TermParts<'_>) {
+    // [OPUS-4.8] (sq-32i5) All length prefixes are hashed as fixed-width `u64`, NOT `usize`:
+    // `usize` is 32-bit on wasm32 and 64-bit on native, so `write_usize` would fold a different
+    // byte sequence on each and the on-disk fingerprint would mismatch between a store built on
+    // 64-bit native and the same graph opened on 32-bit wasm — silently breaking the documented
+    // "build/open fingerprints match across machines" guarantee. `as u64` is lossless on both
+    // (lengths fit in 32 bits) and produces an architecture-independent fingerprint by construction.
     match parts {
         TermParts::Iri { prefix, suffix } => {
             h.write_u8(0);
-            h.write_usize(prefix.len());
+            h.write_u64(prefix.len() as u64);
             h.write(prefix.as_bytes());
             h.write(suffix.as_bytes());
         }
@@ -127,9 +136,9 @@ fn fold_parts(h: &mut rustc_hash::FxHasher, parts: &TermParts<'_>) {
             lang,
         } => {
             h.write_u8(1);
-            h.write_usize(value.len());
+            h.write_u64(value.len() as u64);
             h.write(value.as_bytes());
-            h.write_usize(datatype.len());
+            h.write_u64(datatype.len() as u64);
             h.write(datatype.as_bytes());
             match lang {
                 Some(l) => {
@@ -157,15 +166,45 @@ fn fold_parts(h: &mut rustc_hash::FxHasher, parts: &TermParts<'_>) {
 /// message naming the mismatch so a stale store can never be queried silently.
 pub type CheckResult = Result<(), String>;
 
+/// [OPUS-4.8] (sq-32i5) Identifies which kind of artifact a [`check_against`] call is guarding, so
+/// the error text is accurate at both call sites (a `.spqv` [`VectorStore`](crate::store::VectorStore)
+/// and a `.spqg` [`DiskAnnIndex`](crate::diskann::DiskAnnIndex)).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Artifact {
+    /// A `.spqv` vector store.
+    Store,
+    /// A `.spqg` ANN index.
+    Index,
+}
+
+impl Artifact {
+    /// The noun used in error messages ("store" / "index").
+    fn noun(self) -> &'static str {
+        match self {
+            Artifact::Store => "store",
+            Artifact::Index => "index",
+        }
+    }
+}
+
 /// Compares a `stored` fingerprint (read from a header) against the live `graph`, returning a
-/// descriptive `Err` on any mismatch. `stored` is `None` for a pre-fingerprint (version-1) file:
-/// such a file cannot be certified, so the check fails with a clear "unverified format" message
-/// rather than silently passing. `origin` names the file for the error.
-pub fn check_against(stored: Option<Fingerprint>, graph: &Graph, origin: &str) -> CheckResult {
+/// descriptive `Err` on any mismatch. `stored` is `None` when the artifact carries no fingerprint —
+/// either a pre-fingerprinting (version-1) file, or a current-format file finalized without a graph
+/// binding (`with_fingerprint`); in both cases it cannot be certified, so the check fails with a
+/// clear "unverified" message rather than silently passing. `artifact` selects the noun used in the
+/// message (store vs. index) so it is accurate at both call sites; `origin` names the file.
+pub fn check_against(
+    stored: Option<Fingerprint>,
+    graph: &Graph,
+    artifact: Artifact,
+    origin: &str,
+) -> CheckResult {
+    let kind = artifact.noun();
     let Some(stored) = stored else {
         return Err(format!(
-            "{origin}: this store predates graph-fingerprinting (legacy format) and cannot be \
-             verified against the graph; rebuild it to enable the staleness check"
+            "{origin}: this {kind} carries no graph fingerprint (either a legacy file that predates \
+             graph-fingerprinting, or one finalized without binding it to a graph) and so cannot be \
+             verified against the graph; rebuild it with a graph binding to enable the staleness check"
         ));
     };
     let live = Fingerprint::of(graph);
@@ -173,9 +212,9 @@ pub fn check_against(stored: Option<Fingerprint>, graph: &Graph, origin: &str) -
         Ok(())
     } else {
         Err(format!(
-            "{origin}: graph fingerprint mismatch — the store was built against a DIFFERENT graph \
+            "{origin}: graph fingerprint mismatch — this {kind} was built against a DIFFERENT graph \
              (stored {}, this graph {}); querying it would silently return wrong results. Rebuild \
-             the store against the current graph.",
+             the {kind} against the current graph.",
             stored.describe(),
             live.describe()
         ))
@@ -252,14 +291,14 @@ mod tests {
     #[test]
     fn check_against_matching_is_ok() {
         let f = Fingerprint::of(&graph(A));
-        assert!(check_against(Some(f), &graph(A), "t").is_ok());
+        assert!(check_against(Some(f), &graph(A), Artifact::Store, "t").is_ok());
     }
 
     #[test]
     fn check_against_mismatch_is_descriptive_err() {
         let f = Fingerprint::of(&graph(A));
-        let err =
-            check_against(Some(f), &graph(B), "t").expect_err("must reject a different graph");
+        let err = check_against(Some(f), &graph(B), Artifact::Store, "t")
+            .expect_err("must reject a different graph");
         assert!(err.contains("fingerprint mismatch"), "err was: {err}");
         assert!(
             err.contains("wrong results"),
@@ -269,10 +308,77 @@ mod tests {
 
     #[test]
     fn check_against_legacy_none_is_unverifiable_err() {
-        let err = check_against(None, &graph(A), "t").expect_err("legacy file must not pass");
+        let err = check_against(None, &graph(A), Artifact::Store, "t")
+            .expect_err("legacy/unbound file must not pass");
         assert!(
-            err.contains("predates graph-fingerprinting"),
+            err.contains("carries no graph fingerprint"),
             "err was: {err}"
         );
     }
+
+    #[test]
+    fn check_against_error_text_names_the_artifact_kind() {
+        // [OPUS-4.8] (sq-32i5) The same routine guards BOTH a `.spqv` store and a `.spqg` index;
+        // the error noun must follow the artifact kind, not hard-code "store" at an index call site.
+        let f = Fingerprint::of(&graph(A));
+
+        // Mismatch path.
+        let store_err = check_against(Some(f), &graph(B), Artifact::Store, "t")
+            .expect_err("mismatch must error");
+        assert!(
+            store_err.contains("this store was built"),
+            "err: {store_err}"
+        );
+        let index_err = check_against(Some(f), &graph(B), Artifact::Index, "t")
+            .expect_err("mismatch must error");
+        assert!(
+            index_err.contains("this index was built"),
+            "err: {index_err}"
+        );
+        // The index error must not call the artifact a "store" (the original hard-coded bug).
+        // ("stored …" from describe() is fine; we forbid the *noun* phrasings.)
+        assert!(
+            !index_err.contains(" store") && !index_err.contains("store "),
+            "index error must not call the artifact a 'store': {index_err}"
+        );
+
+        // Unverifiable (None) path.
+        let index_none =
+            check_against(None, &graph(A), Artifact::Index, "t").expect_err("None must error");
+        assert!(
+            index_none.contains("this index carries no"),
+            "err: {index_none}"
+        );
+        assert!(
+            !index_none.contains(" store") && !index_none.contains("store "),
+            "index error must not call the artifact a 'store': {index_none}"
+        );
+    }
+
+    #[test]
+    fn golden_fingerprint_is_architecture_independent() {
+        // [OPUS-4.8] (sq-32i5) Regression guard against any width/endianness drift in the
+        // fingerprint computation. The fingerprint of graph A is fixed by construction:
+        //   * lengths/counts are hashed as fixed-width `u64` (never `usize`), so wasm32 (32-bit
+        //     usize) and native (64-bit usize) fold the SAME bytes;
+        //   * `FxHasher` is deterministic and seedless;
+        //   * ids/tags are hashed at fixed widths (`u32`/`u8`).
+        // The golden value below was produced by running this test once and pasting the output. If
+        // the byte sequence ever becomes architecture-dependent again (e.g. a stray `write_usize`),
+        // this assertion fails loudly on at least one target. dict_len / triple_count are stable
+        // properties of graph A; content_hash is the FxHash of the documented fold.
+        let f = Fingerprint::of(&graph(A));
+        // Graph A: 4 IRIs (ex:alice, ex:knows, ex:bob, ex:carol), 2 triples.
+        assert_eq!(f.dict_len, 4, "dict_len of graph A");
+        assert_eq!(f.triple_count, 2, "triple_count of graph A");
+        assert_eq!(
+            f.content_hash, GOLDEN_A_CONTENT_HASH,
+            "content_hash drifted — a width/endianness/fold change broke the cross-machine guarantee"
+        );
+    }
+
+    /// [OPUS-4.8] (sq-32i5) Golden content hash of graph `A`, architecture-independent by
+    /// construction (all hashed inputs are fixed-width; `FxHasher` is seedless & deterministic).
+    /// Produced by running `golden_fingerprint_is_architecture_independent` once.
+    const GOLDEN_A_CONTENT_HASH: u64 = 8_668_627_031_413_789_344;
 }

--- a/crates/sparq-vectors/src/fingerprint.rs
+++ b/crates/sparq-vectors/src/fingerprint.rs
@@ -1,0 +1,278 @@
+//! [OPUS-4.8] (sq-32i5) A cheap, strongly-distinguishing **graph fingerprint** embedded in
+//! the `.spqv` / `.spqg` headers so a stale store can never silently return WRONG results.
+//!
+//! # The foot-gun this closes
+//!
+//! A [`VectorStore`](crate::store::VectorStore) (`.spqv`) and a
+//! [`DiskAnnIndex`](crate::diskann::DiskAnnIndex) (`.spqg`) are build-once-immutable and keyed by
+//! **dictionary term id**. They carry no link to the graph they were built against. But a graph
+//! mutation/rebuild can SHIFT dict ids (interning order changes), and a query entry point such as
+//! [`nearest_term`](crate::diskann::DiskAnnIndex::nearest_term) resolves the query term through the
+//! *caller-provided* graph's dictionary (`graph.id_of(term)`) and then looks that id up in the
+//! store. If the store was built against a different generation of the graph, the id resolves to a
+//! DIFFERENT term's vector — and the search returns plausible-looking but WRONG neighbours, with no
+//! error. This module makes that mismatch a hard, descriptive error instead.
+//!
+//! # What is fingerprinted (the exact inputs — keep this comment in sync with [`Fingerprint::of`])
+//!
+//! Three fields, all cheap to compute at build time and on open:
+//!   1. **`dict_len`** — `graph.dict.len()`, the number of real dictionary terms. O(1).
+//!   2. **`triple_count`** — `graph.len()`, the number of triples in the default graph. O(1).
+//!   3. **`content_hash`** — a 64-bit hash that folds, **in ascending id order**, every dictionary
+//!      term's content (its [`TermParts`](sparq_core::dict::TermParts) — IRI prefix+suffix, literal
+//!      value+datatype+lang, blank label, or a triple term's three child ids). This directly
+//!      captures the **id → term binding**: if any id maps to a different term (the exact failure
+//!      mode of a dict-id shift), the sequence of folded writes changes and the hash changes. The
+//!      two scalars are folded in first so a fingerprint that agrees on the hash but differs on
+//!      length/count is still rejected. `FxHasher` is used because it is **deterministic with no
+//!      seed** (the same property the core dictionary relies on for its own content hashing), so a
+//!      fingerprint computed at build time on one machine matches one recomputed at open time on
+//!      another. The cost is O(dict_len) over already-resident term parts — a small fraction of the
+//!      embed/build work that produced the store in the first place.
+//!
+//! `content_hash` is a **collision-resistance-irrelevant integrity check**, not a security MAC: it
+//! exists to catch accidental staleness, not to defend against an adversary crafting a colliding
+//! graph. dict_len + triple_count are folded alongside it precisely so the common shift cases
+//! (terms added/removed, triples added/removed) are caught structurally even before the hash.
+
+use sparq_core::dict::TermParts;
+use sparq_core::Graph;
+use std::hash::Hasher;
+
+/// Number of bytes a [`Fingerprint`] occupies in a file header: three little-endian `u64`s.
+pub const FINGERPRINT_LEN: usize = 24;
+
+/// A graph fingerprint: dictionary length, triple count, and a content hash over the
+/// id-ordered dictionary terms. See the module docs for the exact inputs and rationale.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Fingerprint {
+    /// `graph.dict.len()` at build time.
+    pub dict_len: u64,
+    /// `graph.len()` (default-graph triple count) at build time.
+    pub triple_count: u64,
+    /// 64-bit content hash over the id-ordered dictionary term parts (see module docs).
+    pub content_hash: u64,
+}
+
+impl Fingerprint {
+    /// Computes the fingerprint of `graph`. Cheap: two O(1) reads plus one O(dict_len) pass over
+    /// the already-resident term parts. The exact inputs are documented at the module level — keep
+    /// the two in sync.
+    pub fn of(graph: &Graph) -> Fingerprint {
+        let dict_len = graph.dict.len() as u64;
+        let triple_count = graph.len() as u64;
+        // FxHasher: deterministic, no seed — so a fingerprint computed at build time matches one
+        // recomputed at open time (possibly on another machine). The dict module relies on the
+        // same property for its own content hashing.
+        let mut h = rustc_hash::FxHasher::default();
+        // Fold the scalars first so a hash collision alone cannot mask a length/count change.
+        h.write_u64(dict_len);
+        h.write_u64(triple_count);
+        for (id, parts) in graph.dict.iter() {
+            // Bind the id explicitly: a permutation of the same term set (a pure dict-id shift)
+            // must change the hash even if every individual term is still present somewhere.
+            h.write_u32(id);
+            fold_parts(&mut h, &parts);
+        }
+        Fingerprint {
+            dict_len,
+            triple_count,
+            content_hash: h.finish(),
+        }
+    }
+
+    /// Serializes to `FINGERPRINT_LEN` little-endian bytes (the on-disk header layout).
+    pub fn to_bytes(self) -> [u8; FINGERPRINT_LEN] {
+        let mut out = [0u8; FINGERPRINT_LEN];
+        out[0..8].copy_from_slice(&self.dict_len.to_le_bytes());
+        out[8..16].copy_from_slice(&self.triple_count.to_le_bytes());
+        out[16..24].copy_from_slice(&self.content_hash.to_le_bytes());
+        out
+    }
+
+    /// Parses a fingerprint from `FINGERPRINT_LEN` little-endian bytes. `bytes` must be at least
+    /// [`FINGERPRINT_LEN`] long (the caller validated the header length first).
+    pub fn from_bytes(bytes: &[u8]) -> Fingerprint {
+        Fingerprint {
+            dict_len: u64::from_le_bytes(bytes[0..8].try_into().unwrap()),
+            triple_count: u64::from_le_bytes(bytes[8..16].try_into().unwrap()),
+            content_hash: u64::from_le_bytes(bytes[16..24].try_into().unwrap()),
+        }
+    }
+
+    /// A human-readable one-line summary for error messages.
+    fn describe(&self) -> String {
+        format!(
+            "dict_len={} triples={} hash={:#018x}",
+            self.dict_len, self.triple_count, self.content_hash
+        )
+    }
+}
+
+/// Folds one term's content into the hasher. The byte/field sequence (and the leading tag) mirror
+/// the discipline of `sparq_core::dict`'s own content hashing: a length-prefixed, tagged write per
+/// variant, so distinct terms cannot alias by concatenation. We do not depend on the core's hash
+/// VALUE (it is private); we only need a self-consistent fold that distinguishes terms here.
+fn fold_parts(h: &mut rustc_hash::FxHasher, parts: &TermParts<'_>) {
+    match parts {
+        TermParts::Iri { prefix, suffix } => {
+            h.write_u8(0);
+            h.write_usize(prefix.len());
+            h.write(prefix.as_bytes());
+            h.write(suffix.as_bytes());
+        }
+        TermParts::Lit {
+            value,
+            datatype,
+            lang,
+        } => {
+            h.write_u8(1);
+            h.write_usize(value.len());
+            h.write(value.as_bytes());
+            h.write_usize(datatype.len());
+            h.write(datatype.as_bytes());
+            match lang {
+                Some(l) => {
+                    h.write_u8(1);
+                    h.write(l.as_bytes());
+                }
+                None => h.write_u8(0),
+            }
+        }
+        TermParts::Blank(label) => {
+            h.write_u8(2);
+            h.write(label.as_bytes());
+        }
+        TermParts::Triple(ids) => {
+            h.write_u8(3);
+            for id in ids {
+                h.write_u32(*id);
+            }
+        }
+    }
+}
+
+/// The result of a stored-fingerprint vs. live-graph check, produced by a CHECKED open path.
+/// `Ok(())` means the store is safe to query against the graph; `Err` carries a descriptive
+/// message naming the mismatch so a stale store can never be queried silently.
+pub type CheckResult = Result<(), String>;
+
+/// Compares a `stored` fingerprint (read from a header) against the live `graph`, returning a
+/// descriptive `Err` on any mismatch. `stored` is `None` for a pre-fingerprint (version-1) file:
+/// such a file cannot be certified, so the check fails with a clear "unverified format" message
+/// rather than silently passing. `origin` names the file for the error.
+pub fn check_against(stored: Option<Fingerprint>, graph: &Graph, origin: &str) -> CheckResult {
+    let Some(stored) = stored else {
+        return Err(format!(
+            "{origin}: this store predates graph-fingerprinting (legacy format) and cannot be \
+             verified against the graph; rebuild it to enable the staleness check"
+        ));
+    };
+    let live = Fingerprint::of(graph);
+    if stored == live {
+        Ok(())
+    } else {
+        Err(format!(
+            "{origin}: graph fingerprint mismatch — the store was built against a DIFFERENT graph \
+             (stored {}, this graph {}); querying it would silently return wrong results. Rebuild \
+             the store against the current graph.",
+            stored.describe(),
+            live.describe()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // [OPUS-4.8] (sq-32i5) fingerprint unit tests: discrimination, round-trip, and the
+    // legacy (None) path. The store/diskann modules cover the end-to-end checked-open behaviour.
+    use super::*;
+    use sparq_core::Graph;
+
+    fn graph(ttl: &str) -> Graph {
+        Graph::load_str(ttl, "turtle").expect("load test turtle")
+    }
+
+    const A: &str = r#"
+        @prefix ex: <http://example.org/> .
+        ex:alice ex:knows ex:bob .
+        ex:bob ex:knows ex:carol .
+    "#;
+    // B has a different dictionary (different IRIs) AND a different triple count.
+    const B: &str = r#"
+        @prefix ex: <http://example.org/> .
+        ex:dave ex:likes ex:eve .
+    "#;
+
+    #[test]
+    fn distinguishes_different_graphs() {
+        let fa = Fingerprint::of(&graph(A));
+        let fb = Fingerprint::of(&graph(B));
+        assert_ne!(fa, fb, "distinct graphs must have distinct fingerprints");
+    }
+
+    #[test]
+    fn stable_for_the_same_graph() {
+        // Recomputed twice (different Graph instances of the same content) must agree, so a
+        // build-time fingerprint matches an open-time one.
+        assert_eq!(Fingerprint::of(&graph(A)), Fingerprint::of(&graph(A)));
+    }
+
+    #[test]
+    fn detects_dict_id_shift_with_same_term_set() {
+        // Same TERMS, different interning order → a pure dict-id shift. The id is folded into
+        // the hash, so the fingerprint must still differ (the exact foot-gun sq-32i5 closes).
+        let g1 = graph(
+            r#"@prefix ex: <http://example.org/> .
+               ex:aaa ex:p ex:bbb ."#,
+        );
+        let g2 = graph(
+            r#"@prefix ex: <http://example.org/> .
+               ex:bbb ex:p ex:aaa ."#,
+        );
+        // Same number of terms and triples...
+        assert_eq!(g1.dict.len(), g2.dict.len());
+        assert_eq!(g1.len(), g2.len());
+        let f1 = Fingerprint::of(&g1);
+        let f2 = Fingerprint::of(&g2);
+        // ...but the id→term binding differs, so content_hash differs.
+        assert_ne!(
+            f1.content_hash, f2.content_hash,
+            "a dict-id shift must change the hash"
+        );
+    }
+
+    #[test]
+    fn bytes_round_trip() {
+        let f = Fingerprint::of(&graph(A));
+        let back = Fingerprint::from_bytes(&f.to_bytes());
+        assert_eq!(f, back);
+    }
+
+    #[test]
+    fn check_against_matching_is_ok() {
+        let f = Fingerprint::of(&graph(A));
+        assert!(check_against(Some(f), &graph(A), "t").is_ok());
+    }
+
+    #[test]
+    fn check_against_mismatch_is_descriptive_err() {
+        let f = Fingerprint::of(&graph(A));
+        let err =
+            check_against(Some(f), &graph(B), "t").expect_err("must reject a different graph");
+        assert!(err.contains("fingerprint mismatch"), "err was: {err}");
+        assert!(
+            err.contains("wrong results"),
+            "err must warn about wrong results: {err}"
+        );
+    }
+
+    #[test]
+    fn check_against_legacy_none_is_unverifiable_err() {
+        let err = check_against(None, &graph(A), "t").expect_err("legacy file must not pass");
+        assert!(
+            err.contains("predates graph-fingerprinting"),
+            "err was: {err}"
+        );
+    }
+}

--- a/crates/sparq-vectors/src/fingerprint.rs
+++ b/crates/sparq-vectors/src/fingerprint.rs
@@ -103,6 +103,24 @@ impl Fingerprint {
         }
     }
 
+    /// [OPUS-4.8] (sq-32i5) Parses a fingerprint from a current-format header block, returning
+    /// `None` for an **all-zero block**. A v2 artifact finalized *without* binding a graph (no
+    /// `with_fingerprint`) writes a zeroed block; decoding that to `Some(Fingerprint{0,0,0})` would
+    /// make [`check_against`] report a stale-graph *mismatch* (a "DIFFERENT graph" error) instead of
+    /// the accurate "carries no fingerprint / unverifiable" message the `store.rs`/`diskann.rs` docs
+    /// promise. Treating all-zero as `None` aligns the behaviour with those docs. (An all-zero block
+    /// is unreachable from a real [`Fingerprint::of`]: `content_hash` is the FxHash of at least the
+    /// two folded scalars, so a genuine empty graph still has a non-zero hash; even in the
+    /// astronomically unlikely event a real fingerprint hashed to all-zero, the only consequence is
+    /// that it is reported as "unverifiable" rather than checked — fail-safe, never a false match.)
+    pub fn from_bytes_opt(bytes: &[u8]) -> Option<Fingerprint> {
+        if bytes[0..FINGERPRINT_LEN].iter().all(|&b| b == 0) {
+            None
+        } else {
+            Some(Fingerprint::from_bytes(bytes))
+        }
+    }
+
     /// A human-readable one-line summary for error messages.
     fn describe(&self) -> String {
         format!(

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -3,15 +3,19 @@
 pub mod ann;
 pub mod diskann;
 pub mod embed;
+pub mod fingerprint;
 pub mod fuse;
 pub mod labels;
 pub mod quant;
 pub mod store;
 pub mod verbalize;
 
-pub use ann::{cosine, nearest_exact, nearest_term_exact, HnswConfig, VectorIndex};
+pub use ann::{
+    cosine, nearest_exact, nearest_term_exact, nearest_term_exact_checked, HnswConfig, VectorIndex,
+};
 pub use diskann::{sibling_graph_path, DiskAnnIndex, VamanaConfig, SPQG_MAGIC, SPQG_VERSION};
 pub use embed::{Embedder, HashEmbedder};
+pub use fingerprint::{check_against, CheckResult, Fingerprint, FINGERPRINT_LEN};
 pub use fuse::{fuse_rrf, fuse_rrf_weighted, fuse_scores, RRF_K};
 pub use quant::{
     cosine_from_sq_dist, DistanceTable, EncodedStore, PqConfig, ProductQuantizer, ScalarQuantizer,

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -15,12 +15,12 @@ pub use ann::{
 };
 pub use diskann::{sibling_graph_path, DiskAnnIndex, VamanaConfig, SPQG_MAGIC, SPQG_VERSION};
 pub use embed::{Embedder, HashEmbedder};
-pub use fingerprint::{check_against, CheckResult, Fingerprint, FINGERPRINT_LEN};
+pub use fingerprint::{check_against, Artifact, CheckResult, Fingerprint, FINGERPRINT_LEN};
 pub use fuse::{fuse_rrf, fuse_rrf_weighted, fuse_scores, RRF_K};
+pub use labels::{embed_labels, embed_labels_with, LabelConfig};
 pub use quant::{
     cosine_from_sq_dist, DistanceTable, EncodedStore, PqConfig, ProductQuantizer, ScalarQuantizer,
 };
-pub use labels::{embed_labels, embed_labels_with, LabelConfig};
 pub use store::{StreamingWriter, VectorStore, SPQV_MAGIC, SPQV_VERSION};
 pub use verbalize::{
     description_predicates, embed_entities, label_predicates, verbalize, EntityTextConfig,

--- a/crates/sparq-vectors/src/store.rs
+++ b/crates/sparq-vectors/src/store.rs
@@ -1,18 +1,27 @@
 //! The `.spqv` on-disk vector store: one f32 embedding per dictionary term id, in a
 //! single flat memory-mapped file.
 //!
-//! # File format (version 1, little-endian)
+//! # File format (version 2, little-endian)
 //!
 //! ```text
 //! offset 0   magic        b"SPQV"                          4 bytes
-//! offset 4   version      u32 = 1                          4 bytes
+//! offset 4   version      u32 = 2                          4 bytes
 //! offset 8   dim          u32                              4 bytes
 //! offset 12  count        u64                              8 bytes
 //! offset 20  reserved     zero padding                     12 bytes
-//! offset 32  data         [count × dim] f32, dense         count·dim·4 bytes
-//! offset 32+count·dim·4   id→slot index                    count·8 bytes
+//! offset 32  fingerprint  graph fingerprint                24 bytes
+//!            (dict_len: u64, triple_count: u64, content_hash: u64)
+//! offset 56  data         [count × dim] f32, dense         count·dim·4 bytes
+//! offset 56+count·dim·4   id→slot index                    count·8 bytes
 //!            (id: u32, slot: u32) pairs sorted by id ascending
 //! ```
+//!
+//! [OPUS-4.8] (sq-32i5) The **fingerprint** binds the store to the graph it was built against
+//! (see [`crate::fingerprint`]): a store keyed by dictionary id is meaningless against a graph
+//! whose ids have shifted, so [`VectorStore::check_graph`] errors on a mismatch instead of letting
+//! a query silently mis-resolve. Version-1 files (no fingerprint block, 32-byte header) still open,
+//! but `check_graph` reports them as unverifiable — see [`VectorStore::open`] and the back-compat
+//! note there.
 //!
 //! Coverage is **sparse by design**: in an RDF graph only entities get embeddings, not
 //! every literal, so vectors are stored densely in *insertion* slots and the trailing
@@ -30,17 +39,23 @@
 //! a `dim × 4 / 8` reduction, e.g. 192× for 384-d f32). Both writers produce
 //! byte-identical version-1 files.
 
+use crate::fingerprint::{self, Fingerprint, FINGERPRINT_LEN};
 use memmap2::Mmap;
 use rustc_hash::FxHashMap;
 use sparq_core::dict::Id;
+use sparq_core::Graph;
 use std::io::{BufWriter, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 /// First four bytes of every `.spqv` file.
 pub const SPQV_MAGIC: [u8; 4] = *b"SPQV";
-/// Current format version.
-pub const SPQV_VERSION: u32 = 1;
-const HEADER_LEN: usize = 32;
+/// Current format version. [OPUS-4.8] (sq-32i5) v2 adds the 24-byte graph fingerprint block at
+/// offset 32; v1 files (32-byte header, no fingerprint) still open but cannot be verified.
+pub const SPQV_VERSION: u32 = 2;
+/// Header length of a version-1 file (no fingerprint block).
+const HEADER_LEN_V1: usize = 32;
+/// Header length of the current (version-2) format: the v1 header + the fingerprint block.
+const HEADER_LEN: usize = HEADER_LEN_V1 + FINGERPRINT_LEN;
 
 /// [OPUS-4.8] A 4-byte-aligned owned byte buffer. A plain `Vec<u8>` has alignment 1, so its base
 /// pointer may land on an odd address; `slot_vector` casts `&[u8]` slices of the buffer to
@@ -107,6 +122,18 @@ pub struct VectorStore {
     dim: usize,
     path: PathBuf,
     backing: Backing,
+    /// [OPUS-4.8] (sq-32i5) The graph fingerprint bound to this store: `Some` for the current
+    /// (version-2) format, `None` for a legacy version-1 file that predates fingerprinting (it
+    /// opens but cannot be verified — see [`open`](Self::open)) and for a freshly `create`d store
+    /// until [`with_fingerprint`](Self::with_fingerprint) is called.
+    /// [`check_graph`](Self::check_graph) uses it to reject a stale store before a query
+    /// can mis-resolve.
+    fingerprint: Option<Fingerprint>,
+    /// Byte offset where the dense vector data begins: [`HEADER_LEN`] for a version-2 file (the
+    /// current build path), [`HEADER_LEN_V1`] for an opened legacy version-1 file. Every read path
+    /// (`get`, `iter`, `slot_vector`, the trailing index) keys off this so both versions are read
+    /// correctly by the same code.
+    data_offset: usize,
     /// slot→id for mmap mode (the on-disk index is sorted by id, the data by slot);
     /// built lazily on the first [`iter`](Self::iter), O(count) once.
     inverse: std::sync::OnceLock<Vec<Id>>,
@@ -126,14 +153,34 @@ impl VectorStore {
             dim,
             path: path.into(),
             backing: Backing::Build { data: Vec::new(), slots: FxHashMap::default(), ids: Vec::new() },
+            fingerprint: None,
+            data_offset: HEADER_LEN,
             inverse: std::sync::OnceLock::new(),
         })
     }
 
-    /// Memory-maps an existing `.spqv` file read-only. Cheap: only the 32-byte header
-    /// and the trailing `count·8`-byte id→slot index are read eagerly (the index is
-    /// validated so no later read can panic on a corrupt file); the vector data — the
-    /// overwhelming bulk of the file — is paged in by the OS on access.
+    /// [OPUS-4.8] (sq-32i5) Binds this build-phase store to `graph`'s fingerprint, which
+    /// [`finalize`](Self::finalize) then embeds in the `.spqv` header. Call it before `finalize`
+    /// (most naturally right after `create`, against the SAME graph whose term ids the vectors are
+    /// keyed by). A store finalized WITHOUT a fingerprint is written in the version-2 format with a
+    /// zeroed fingerprint, which [`check_graph`](Self::check_graph) treats as "unverified"; prefer
+    /// setting it so a stale store is caught. Chains: `VectorStore::create(p, d)?.with_fingerprint(g)`.
+    #[must_use]
+    pub fn with_fingerprint(mut self, graph: &Graph) -> VectorStore {
+        self.fingerprint = Some(Fingerprint::of(graph));
+        self
+    }
+
+    /// Memory-maps an existing `.spqv` file read-only. Cheap: only the header and the trailing
+    /// `count·8`-byte id→slot index are read eagerly (the index is validated so no later read can
+    /// panic on a corrupt file); the vector data — the overwhelming bulk of the file — is paged in
+    /// by the OS on access.
+    ///
+    /// [OPUS-4.8] (sq-32i5) Back-compat: a current (version-2) file's graph fingerprint is read into
+    /// [`fingerprint`](Self::fingerprint) for [`check_graph`](Self::check_graph). A legacy version-1
+    /// file (32-byte header, no fingerprint) still opens — its `fingerprint` is `None`, so
+    /// `check_graph` reports it as unverifiable rather than silently passing. Rebuild such a store to
+    /// enable the staleness check.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<VectorStore, String> {
         let path = path.as_ref();
         let file = std::fs::File::open(path).map_err(|e| format!("open {}: {e}", path.display()))?;
@@ -161,16 +208,28 @@ impl VectorStore {
         if cfg!(target_endian = "big") {
             return Err(".spqv is a little-endian format; big-endian targets are unsupported".into());
         }
-        if map.len() < HEADER_LEN {
+        // The version-1 header is the smallest valid header; version 2 adds a fixed-size block.
+        if map.len() < HEADER_LEN_V1 {
             return Err(format!("{origin}: truncated header"));
         }
         if map[0..4] != SPQV_MAGIC {
             return Err(format!("{origin}: not a .spqv file (bad magic)"));
         }
         let version = u32::from_le_bytes(map[4..8].try_into().unwrap());
-        if version != SPQV_VERSION {
-            return Err(format!("{origin}: unsupported .spqv version {version}"));
-        }
+        // [OPUS-4.8] (sq-32i5) Both v1 (no fingerprint, 32-byte header) and v2 (fingerprint,
+        // 56-byte header) open; the header length and the offset where the vector data begins
+        // depend on the version, so every downstream read keys off `data_offset` below.
+        let (data_offset, fingerprint): (usize, Option<Fingerprint>) = match version {
+            1 => (HEADER_LEN_V1, None),
+            2 => {
+                if map.len() < HEADER_LEN {
+                    return Err(format!("{origin}: truncated version-2 header (fingerprint block)"));
+                }
+                let fp = Fingerprint::from_bytes(&map[HEADER_LEN_V1..HEADER_LEN]);
+                (HEADER_LEN, Some(fp))
+            }
+            v => return Err(format!("{origin}: unsupported .spqv version {v}")),
+        };
         let dim = u32::from_le_bytes(map[8..12].try_into().unwrap()) as usize;
         let count64 = u64::from_le_bytes(map[12..20].try_into().unwrap());
         if dim == 0 {
@@ -185,7 +244,7 @@ impl VectorStore {
             .checked_mul(dim)
             .and_then(|n| n.checked_mul(4))
             .and_then(|data| count.checked_mul(8).and_then(|idx| data.checked_add(idx)))
-            .and_then(|body| body.checked_add(HEADER_LEN))
+            .and_then(|body| body.checked_add(data_offset))
             .ok_or_else(|| format!("{origin}: dim={dim} count={count} overflows the file size"))?;
         if map.len() != expect {
             return Err(format!(
@@ -200,7 +259,7 @@ impl VectorStore {
         // `iter`'s inverse map assumes). After this, no read path can panic on a
         // corrupt index.
         {
-            let index = &map[HEADER_LEN + count * dim * 4..];
+            let index = &map[data_offset + count * dim * 4..];
             let mut slot_seen = vec![false; count];
             let mut prev_id: Option<Id> = None;
             for i in 0..count {
@@ -221,7 +280,14 @@ impl VectorStore {
                 slot_seen[slot] = true;
             }
         }
-        Ok(VectorStore { dim, path, backing: Backing::Map(map), inverse: std::sync::OnceLock::new() })
+        Ok(VectorStore {
+            dim,
+            path,
+            backing: Backing::Map(map),
+            fingerprint,
+            data_offset,
+            inverse: std::sync::OnceLock::new(),
+        })
     }
 
     /// Appends `vector` for term `id` (build phase only). Errors after
@@ -256,6 +322,13 @@ impl VectorStore {
         header[4..8].copy_from_slice(&SPQV_VERSION.to_le_bytes());
         header[8..12].copy_from_slice(&(self.dim as u32).to_le_bytes());
         header[12..20].copy_from_slice(&(count as u64).to_le_bytes());
+        // [OPUS-4.8] (sq-32i5) Embed the graph fingerprint (offset 32..56). A store finalized
+        // without one (no `with_fingerprint`) writes a zeroed block, which decodes to an
+        // all-zero fingerprint — distinct from any real graph's, so `check_graph` still rejects
+        // a stale match; prefer setting it explicitly.
+        if let Some(fp) = self.fingerprint {
+            header[HEADER_LEN_V1..HEADER_LEN].copy_from_slice(&fp.to_bytes());
+        }
 
         let mut index: Vec<(Id, u32)> = slots.iter().map(|(&id, &slot)| (id, slot)).collect();
         index.sort_unstable();
@@ -283,6 +356,8 @@ impl VectorStore {
 
         let reopened = VectorStore::open(&self.path)?;
         self.backing = reopened.backing;
+        self.fingerprint = reopened.fingerprint;
+        self.data_offset = reopened.data_offset;
         self.inverse = std::sync::OnceLock::new();
         Ok(())
     }
@@ -297,7 +372,7 @@ impl VectorStore {
             }
             Backing::Map(map) => {
                 let count = self.len();
-                let index = &map[HEADER_LEN + count * self.dim * 4..];
+                let index = &map[self.data_offset + count * self.dim * 4..];
                 let id_at = |i: usize| -> Id {
                     u32::from_le_bytes(index[i * 8..i * 8 + 4].try_into().unwrap())
                 };
@@ -337,6 +412,31 @@ impl VectorStore {
         self.dim
     }
 
+    /// [OPUS-4.8] (sq-32i5) The graph fingerprint this store was built against, or `None` for a
+    /// legacy version-1 file (predates fingerprinting) or a store finalized without
+    /// [`with_fingerprint`](Self::with_fingerprint). See [`check_graph`](Self::check_graph).
+    pub fn fingerprint(&self) -> Option<Fingerprint> {
+        self.fingerprint
+    }
+
+    /// [OPUS-4.8] (sq-32i5) **Checked open guard**: verifies this store was built against `graph`
+    /// by recomputing `graph`'s fingerprint and comparing it to the stored one. Returns a
+    /// descriptive `Err` if they differ — the store is keyed by `graph`'s dictionary ids, so a
+    /// mismatch means a query would silently resolve to the WRONG vectors. A legacy version-1 file
+    /// (no stored fingerprint) also errors, as "unverifiable" rather than silently passing.
+    ///
+    /// Call this once after [`open`](Self::open) (it is O(dict_len), not per-query) before issuing
+    /// `get`/`nearest_term` against `graph`. The term-by-query entry points
+    /// ([`crate::ann::nearest_term_exact_checked`], [`DiskAnnIndex::nearest_term_checked`]) run it.
+    pub fn check_graph(&self, graph: &Graph) -> fingerprint::CheckResult {
+        let origin = if self.path.as_os_str().is_empty() {
+            "<bytes>".to_string()
+        } else {
+            self.path.display().to_string()
+        };
+        fingerprint::check_against(self.fingerprint, graph, &origin)
+    }
+
     /// Iterates all `(id, vector)` pairs in insertion-slot order (the dense data
     /// order) — what ANN index construction consumes.
     pub fn iter(&self) -> impl Iterator<Item = (Id, &[f32])> + '_ {
@@ -360,7 +460,7 @@ impl VectorStore {
     fn inverse_ids(&self, map: &Bytes) -> &[Id] {
         self.inverse.get_or_init(|| {
             let count = u64::from_le_bytes(map[12..20].try_into().unwrap()) as usize;
-            let index = &map[HEADER_LEN + count * self.dim * 4..];
+            let index = &map[self.data_offset + count * self.dim * 4..];
             let mut inv = vec![0 as Id; count];
             for i in 0..count {
                 let id = u32::from_le_bytes(index[i * 8..i * 8 + 4].try_into().unwrap());
@@ -373,13 +473,13 @@ impl VectorStore {
     }
 
     fn slot_vector<'m>(&self, map: &'m Bytes, slot: usize) -> &'m [f32] {
-        let start = HEADER_LEN + slot * self.dim * 4;
+        let start = self.data_offset + slot * self.dim * 4;
         let bytes = &map[start..start + self.dim * 4];
         debug_assert_eq!(bytes.as_ptr() as usize % std::mem::align_of::<f32>(), 0);
         // SAFETY: the backing base is 4-byte aligned — a memory map is page-aligned, and the
         // owned path uses `AlignedBytes` (u32-backed, alignment 4) precisely so this cast is
         // aligned ([OPUS-4.8] review 1874; a raw Vec<u8> is alignment 1 and would be UB here).
-        // `start` is a multiple of 4 (HEADER_LEN=32 + slot·dim·4), so the pointer stays
+        // `start` is a multiple of 4 (data_offset [32 or 56] + slot·dim·4), so the pointer stays
         // f32-aligned; the range is in bounds (validated in `open`); f32 accepts any bit pattern;
         // the slice borrows the backing, owned by `self`.
         unsafe { std::slice::from_raw_parts(bytes.as_ptr() as *const f32, self.dim) }
@@ -409,10 +509,14 @@ fn validate_vector(dim: usize, id: Id, vector: &[f32]) -> Result<(), String> {
 /// patches the header count, and opens the finished store.
 ///
 /// The output is byte-identical to [`VectorStore::create`]`+put+finalize` for
-/// the same `put` sequence (same version-1 format — no format change). One
+/// the same `put` sequence and the same fingerprint (same version-2 format). One
 /// contract difference, documented: a DUPLICATE id is detected at `finalize`
 /// (the sort reveals it) rather than at `put`, since detecting it eagerly
 /// would need the in-RAM id set this writer exists to avoid.
+///
+/// [OPUS-4.8] (sq-32i5) To bind the streaming store to its graph (so a stale store is caught —
+/// see [`crate::fingerprint`]), build it with [`create_with_fingerprint`](Self::create_with_fingerprint);
+/// a plain [`create`](Self::create) writes an unverifiable store (all-zero fingerprint).
 ///
 /// ```no_run
 /// use sparq_vectors::StreamingWriter;
@@ -432,8 +536,30 @@ pub struct StreamingWriter {
 
 impl StreamingWriter {
     /// Starts a streaming store build at `path` (the sidecar id spill lives at
-    /// `path` + `.ids-tmp` until [`finalize`](Self::finalize) removes it).
+    /// `path` + `.ids-tmp` until [`finalize`](Self::finalize) removes it). The store is written
+    /// WITHOUT a graph fingerprint (unverifiable — [`check_graph`](VectorStore::check_graph) errors);
+    /// use [`create_with_fingerprint`](Self::create_with_fingerprint) to bind it to a graph.
     pub fn create<P: Into<PathBuf>>(path: P, dim: usize) -> Result<StreamingWriter, String> {
+        Self::create_inner(path, dim, None)
+    }
+
+    /// [OPUS-4.8] (sq-32i5) Like [`create`](Self::create) but embeds `graph`'s fingerprint in the
+    /// header, so [`check_graph`](VectorStore::check_graph) can reject the finished store if it is
+    /// later queried against a different graph generation. Pass the SAME graph whose term ids the
+    /// vectors are keyed by.
+    pub fn create_with_fingerprint<P: Into<PathBuf>>(
+        path: P,
+        dim: usize,
+        graph: &Graph,
+    ) -> Result<StreamingWriter, String> {
+        Self::create_inner(path, dim, Some(Fingerprint::of(graph)))
+    }
+
+    fn create_inner<P: Into<PathBuf>>(
+        path: P,
+        dim: usize,
+        fingerprint: Option<Fingerprint>,
+    ) -> Result<StreamingWriter, String> {
         if dim == 0 || dim > u32::MAX as usize {
             return Err(format!("invalid vector dimension {dim}"));
         }
@@ -443,11 +569,15 @@ impl StreamingWriter {
         let path = path.into();
         let mut file = std::fs::File::create(&path)
             .map_err(|e| format!("create {}: {e}", path.display()))?;
-        // Header with a zero count placeholder; finalize patches offset 12.
+        // Header with a zero count placeholder; finalize patches offset 12. The fingerprint
+        // (offset 32..56) is known up front, so it is written here, not patched.
         let mut header = [0u8; HEADER_LEN];
         header[0..4].copy_from_slice(&SPQV_MAGIC);
         header[4..8].copy_from_slice(&SPQV_VERSION.to_le_bytes());
         header[8..12].copy_from_slice(&(dim as u32).to_le_bytes());
+        if let Some(fp) = fingerprint {
+            header[HEADER_LEN_V1..HEADER_LEN].copy_from_slice(&fp.to_bytes());
+        }
         file.write_all(&header).map_err(|e| format!("write {}: {e}", path.display()))?;
         let ids_path = {
             let mut p = path.clone().into_os_string();
@@ -537,5 +667,181 @@ impl StreamingWriter {
             VectorStore::open(&path)
         })();
         result.map_err(cleanup)
+    }
+}
+
+#[cfg(test)]
+mod fingerprint_tests {
+    // [OPUS-4.8] (sq-32i5) End-to-end checked-open tests for the `.spqv` store: build against
+    // graph A then (1) open/query against A → OK + correct neighbours, (2) open/query against a
+    // DIFFERENT graph B → descriptive Err (NOT wrong results), (3) fingerprint round-trips through
+    // serialize→deserialize, (4) a legacy version-1 file opens but reports as unverifiable.
+    use super::*;
+    use crate::ann::{nearest_term_exact, nearest_term_exact_checked};
+    use oxrdf::{NamedNode, Term};
+    use sparq_core::Graph;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+
+    fn tmp(tag: &str) -> PathBuf {
+        let n = SEQ.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("sparq_fp_{tag}_{}_{n}.spqv", std::process::id()))
+    }
+
+    fn graph(ttl: &str) -> Graph {
+        Graph::load_str(ttl, "turtle").expect("load test turtle")
+    }
+
+    fn iri(s: &str) -> Term {
+        Term::NamedNode(NamedNode::new(s).unwrap())
+    }
+
+    // A and B have DIFFERENT dictionaries and triple counts.
+    const A: &str = r#"
+        @prefix ex: <http://example.org/> .
+        ex:alice ex:knows ex:bob .
+        ex:bob ex:knows ex:carol .
+    "#;
+    const B: &str = r#"
+        @prefix ex: <http://example.org/> .
+        ex:dave ex:likes ex:eve .
+        ex:eve ex:likes ex:frank .
+        ex:frank ex:likes ex:gina .
+    "#;
+
+    /// Builds a 4-d store over graph `g`, giving `alice` a vector nearest to `bob` and far from
+    /// `carol`, so a correct `nearest_term(alice)` ranks `bob` first.
+    fn build_store(g: &Graph, path: &std::path::Path) -> VectorStore {
+        let alice = g.id_of(&iri("http://example.org/alice")).unwrap();
+        let bob = g.id_of(&iri("http://example.org/bob")).unwrap();
+        let carol = g.id_of(&iri("http://example.org/carol")).unwrap();
+        let mut s = VectorStore::create(path, 4).unwrap().with_fingerprint(g);
+        s.put(alice, &[1.0, 0.0, 0.0, 0.0]).unwrap();
+        s.put(bob, &[0.9, 0.1, 0.0, 0.0]).unwrap(); // close to alice
+        s.put(carol, &[0.0, 0.0, 0.0, 1.0]).unwrap(); // far from alice
+        s.finalize().unwrap();
+        s
+    }
+
+    #[test]
+    fn open_against_build_graph_ok_and_correct() {
+        let ga = graph(A);
+        let path = tmp("ok");
+        build_store(&ga, &path);
+        let store = VectorStore::open(&path).unwrap();
+        // (1) Checked open against the SAME graph → OK.
+        assert!(store.check_graph(&ga).is_ok());
+        // ...and the neighbours are correct: bob is alice's nearest.
+        let got = nearest_term_exact_checked(&store, &ga, &iri("http://example.org/alice"), 1)
+            .expect("checked query against the build graph must succeed");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].0, iri("http://example.org/bob"));
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn query_against_different_graph_errs_not_wrong() {
+        let ga = graph(A);
+        let path = tmp("mismatch");
+        build_store(&ga, &path);
+        let store = VectorStore::open(&path).unwrap();
+        let gb = graph(B); // different dict ids AND triple count
+        // (2) Checked open/query against a DIFFERENT graph → descriptive Err, not silent wrong data.
+        let err = store.check_graph(&gb).expect_err("a mismatched graph must be rejected");
+        assert!(err.contains("fingerprint mismatch"), "err was: {err}");
+        let qerr = nearest_term_exact_checked(&store, &gb, &iri("http://example.org/dave"), 1)
+            .expect_err("a checked query against a mismatched graph must error");
+        assert!(qerr.contains("wrong results"), "err was: {qerr}");
+        // The UNCHECKED path is the foot-gun this guards: it does NOT error. We only assert the
+        // checked path refuses; the unchecked one is documented as the unsafe form.
+        let _silent = nearest_term_exact(&store, &gb, &iri("http://example.org/dave"), 1);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn fingerprint_survives_round_trip() {
+        let ga = graph(A);
+        let path = tmp("rt");
+        let built = build_store(&ga, &path);
+        let want = built.fingerprint().expect("built store has a fingerprint");
+        // (3) Reopen from disk: the stored fingerprint must equal the one set at build, and the
+        // live graph's recomputed fingerprint.
+        let reopened = VectorStore::open(&path).unwrap();
+        assert_eq!(reopened.fingerprint(), Some(want));
+        assert_eq!(reopened.fingerprint(), Some(Fingerprint::of(&ga)));
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn store_without_fingerprint_is_unverifiable() {
+        // A store finalized WITHOUT `with_fingerprint` writes an all-zero block; check_graph must
+        // not silently certify it against any non-empty graph.
+        let ga = graph(A);
+        let alice = ga.id_of(&iri("http://example.org/alice")).unwrap();
+        let path = tmp("nofp");
+        let mut s = VectorStore::create(&path, 4).unwrap();
+        s.put(alice, &[1.0, 0.0, 0.0, 0.0]).unwrap();
+        s.finalize().unwrap();
+        let store = VectorStore::open(&path).unwrap();
+        // An all-zero fingerprint is Some(..) but cannot match a real graph.
+        assert!(store.check_graph(&ga).is_err());
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn legacy_v1_file_opens_but_is_unverifiable() {
+        // (4) Back-compat: hand-craft a version-1 `.spqv` (32-byte header, no fingerprint block)
+        // and confirm it still OPENS and READS correctly, but `check_graph` reports it as
+        // unverifiable (the documented legacy path) rather than silently passing.
+        let path = tmp("legacy");
+        let dim = 4usize;
+        let vectors: [(Id, [f32; 4]); 2] = [(7, [1.0, 0.0, 0.0, 0.0]), (3, [0.0, 1.0, 0.0, 0.0])];
+        let count = vectors.len();
+        // ids must be ascending in the index; slots follow insertion order here.
+        let mut header = [0u8; HEADER_LEN_V1];
+        header[0..4].copy_from_slice(&SPQV_MAGIC);
+        header[4..8].copy_from_slice(&1u32.to_le_bytes()); // version 1
+        header[8..12].copy_from_slice(&(dim as u32).to_le_bytes());
+        header[12..20].copy_from_slice(&(count as u64).to_le_bytes());
+        let mut bytes = header.to_vec();
+        for (_, v) in &vectors {
+            for x in v {
+                bytes.extend_from_slice(&x.to_le_bytes());
+            }
+        }
+        // index: (id, slot) sorted by id ascending → (3, slot1), (7, slot0)
+        let mut idx: Vec<(Id, u32)> =
+            vectors.iter().enumerate().map(|(slot, (id, _))| (*id, slot as u32)).collect();
+        idx.sort_unstable();
+        for (id, slot) in idx {
+            bytes.extend_from_slice(&id.to_le_bytes());
+            bytes.extend_from_slice(&slot.to_le_bytes());
+        }
+        std::fs::write(&path, &bytes).unwrap();
+
+        let store = VectorStore::open(&path).expect("a legacy v1 file must still open");
+        assert!(store.fingerprint().is_none(), "v1 file carries no fingerprint");
+        // Reads work against the v1 (offset-32) layout.
+        assert_eq!(store.get(7), Some(&[1.0, 0.0, 0.0, 0.0][..]));
+        assert_eq!(store.get(3), Some(&[0.0, 1.0, 0.0, 0.0][..]));
+        // ...but it cannot be verified against a graph.
+        let err = store.check_graph(&graph(A)).expect_err("a v1 file must not certify a graph");
+        assert!(err.contains("predates graph-fingerprinting") || err.contains("legacy"), "err: {err}");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn streaming_writer_with_fingerprint_round_trips() {
+        let ga = graph(A);
+        let alice = ga.id_of(&iri("http://example.org/alice")).unwrap();
+        let path = tmp("stream");
+        let mut w = StreamingWriter::create_with_fingerprint(&path, 4, &ga).unwrap();
+        w.put(alice, &[1.0, 0.0, 0.0, 0.0]).unwrap();
+        let store = w.finalize().unwrap();
+        assert_eq!(store.fingerprint(), Some(Fingerprint::of(&ga)));
+        assert!(store.check_graph(&ga).is_ok());
+        assert!(store.check_graph(&graph(B)).is_err());
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/crates/sparq-vectors/src/store.rs
+++ b/crates/sparq-vectors/src/store.rs
@@ -225,8 +225,11 @@ impl VectorStore {
                 if map.len() < HEADER_LEN {
                     return Err(format!("{origin}: truncated version-2 header (fingerprint block)"));
                 }
-                let fp = Fingerprint::from_bytes(&map[HEADER_LEN_V1..HEADER_LEN]);
-                (HEADER_LEN, Some(fp))
+                // [OPUS-4.8] (sq-32i5) An all-zero block (a v2 store finalized without
+                // `with_fingerprint`) decodes to `None` ("unverifiable"), not a zero fingerprint
+                // that would surface as a spurious "DIFFERENT graph" mismatch.
+                let fp = Fingerprint::from_bytes_opt(&map[HEADER_LEN_V1..HEADER_LEN]);
+                (HEADER_LEN, fp)
             }
             v => return Err(format!("{origin}: unsupported .spqv version {v}")),
         };
@@ -323,9 +326,9 @@ impl VectorStore {
         header[8..12].copy_from_slice(&(self.dim as u32).to_le_bytes());
         header[12..20].copy_from_slice(&(count as u64).to_le_bytes());
         // [OPUS-4.8] (sq-32i5) Embed the graph fingerprint (offset 32..56). A store finalized
-        // without one (no `with_fingerprint`) writes a zeroed block, which decodes to an
-        // all-zero fingerprint — distinct from any real graph's, so `check_graph` still rejects
-        // a stale match; prefer setting it explicitly.
+        // without one (no `with_fingerprint`) writes a zeroed block, which `open` decodes back to
+        // `None` (`Fingerprint::from_bytes_opt`) — reported by `check_graph` as "unverifiable",
+        // NOT as a spurious "DIFFERENT graph" mismatch; prefer setting it explicitly.
         if let Some(fp) = self.fingerprint {
             header[HEADER_LEN_V1..HEADER_LEN].copy_from_slice(&fp.to_bytes());
         }
@@ -784,8 +787,14 @@ mod fingerprint_tests {
         s.put(alice, &[1.0, 0.0, 0.0, 0.0]).unwrap();
         s.finalize().unwrap();
         let store = VectorStore::open(&path).unwrap();
-        // An all-zero fingerprint is Some(..) but cannot match a real graph.
-        assert!(store.check_graph(&ga).is_err());
+        // [OPUS-4.8] (sq-32i5) An all-zero fingerprint block decodes to `None`, so check_graph
+        // reports it as unverifiable ("carries no graph fingerprint") rather than a spurious
+        // "DIFFERENT graph" mismatch — and never silently certifies it.
+        assert_eq!(store.fingerprint(), None);
+        let err = store
+            .check_graph(&ga)
+            .expect_err("unbound store must not be certified");
+        assert!(err.contains("carries no graph fingerprint"), "err: {err}");
         std::fs::remove_file(&path).ok();
     }
 

--- a/crates/sparq-vectors/src/store.rs
+++ b/crates/sparq-vectors/src/store.rs
@@ -434,7 +434,7 @@ impl VectorStore {
         } else {
             self.path.display().to_string()
         };
-        fingerprint::check_against(self.fingerprint, graph, &origin)
+        fingerprint::check_against(self.fingerprint, graph, fingerprint::Artifact::Store, &origin)
     }
 
     /// Iterates all `(id, vector)` pairs in insertion-slot order (the dense data

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -81,18 +81,29 @@ embed_entities(&Graph, &mut VectorStore, &impl Embedder, &EntityTextConfig) -> R
 // EntityTextConfig{ groups: Vec<PropertyGroup>, languages, naming_predicates, separator, max_chars, batch }
 // PropertyGroup::literal(preds) / ::entity_label(preds) .with_prefix("a ") .with_max_values(3); ObjectKind::{Literal, EntityLabel}
 
+// --- graph-staleness guard (src/fingerprint.rs) --- store is keyed by dict id; a rebuild can shift ids
+VectorStore::create(p, dim)?.with_fingerprint(&Graph)   // bind store to its graph; finalize embeds it in the .spqv header
+StreamingWriter::create_with_fingerprint(p, dim, &Graph) // same for the streaming builder
+store.fingerprint() -> Option<Fingerprint>;  store.check_graph(&Graph) -> Result<(), String>   // None / mismatch -> Err
+// fingerprint = dict_len + triple_count + content_hash over id-ordered dict terms; legacy v1 files open but check_graph errs
+
 // --- search (src/ann.rs) --- all return cosine in [-1,1], best first; zero query -> empty
 nearest_exact(&VectorStore, query: &[f32], k) -> Vec<(Id, f32)>                 // ground-truth full scan
-nearest_term_exact(&VectorStore, &Graph, &Term, k) -> Vec<(Term, f32)>
+nearest_term_exact(&VectorStore, &Graph, &Term, k) -> Vec<(Term, f32)>          // UNCHECKED: stale store -> silently wrong
+nearest_term_exact_checked(&VectorStore, &Graph, &Term, k) -> Result<Vec<(Term, f32)>, String>  // errs on stale store
 cosine(a: &[f32], b: &[f32]) -> f32
 VectorIndex::build(&store) / ::build_with(&store, HnswConfig{ef_search, ef_construction, seed})
 impl VectorIndex { fn nearest(&self, query: &[f32], k) -> Vec<(Id, f32)>;
-                   fn nearest_term(&self, &Term, &Graph, &VectorStore, k) -> Vec<(Term, f32)> }
+                   fn nearest_term(&self, &Term, &Graph, &VectorStore, k) -> Vec<(Term, f32)>;
+                   fn nearest_term_checked(..) -> Result<Vec<(Term, f32)>, String> }
 
 // --- persistent on-disk ANN (src/diskann.rs) ---
 DiskAnnIndex::build(&VectorStore, path) / ::build_with(&store, path, VamanaConfig{degree, build_beam, search_beam, alpha, seed})
+DiskAnnIndex::build_for(&store, path, &Graph) / ::build_with_for(&store, path, cfg, &Graph)  // embeds the graph fingerprint
 DiskAnnIndex::open(path) -> Result<DiskAnnIndex, String>                        // mmap + header check, NO rebuild
-impl DiskAnnIndex { fn nearest(&self, &[f32], k) -> Vec<(Id, f32)>; fn nearest_term(..) -> Vec<(Term, f32)>; fn len()/dim() }
+impl DiskAnnIndex { fn nearest(&self, &[f32], k) -> Vec<(Id, f32)>; fn nearest_term(..) -> Vec<(Term, f32)>; fn len()/dim();
+                    fn fingerprint() -> Option<Fingerprint>; fn check_graph(&store, &Graph) -> Result<(), String>;
+                    fn nearest_term_checked(&Term, &Graph, &store, k) -> Result<Vec<(Term, f32)>, String> }
 sibling_graph_path(&Path) -> PathBuf                                            // foo.spqv -> foo.spqg
 
 // --- quantization for large stores (src/quant.rs) ---


### PR DESCRIPTION
> 🤖 _SPARQ agent_

Closes the silent-stale-store correctness foot-gun in sparq-vectors: a `.spqv`/`.spqg` built against one graph would return WRONG nearest-neighbours after a dict-id-shifting rebuild, with no error (a term resolves via the caller-provided `graph.id_of(term)`, then that id indexes the store — a stale store mis-resolves to a different term's vector).

## What changed
- **Graph fingerprint embedded in both headers** = `dict_len` (`graph.dict.len()`) + `triple_count` (`graph.len()`) + a 64-bit `content_hash` folded over the **id-ordered** dictionary term parts (the id is folded in alongside each term, so a pure dict-id shift — same term set, different ids — changes the hash). FxHasher (deterministic, no seed) so a build-time fingerprint matches one recomputed at open. Exact inputs documented in `src/fingerprint.rs`.
- **Checked open/query path**: `VectorStore::check_graph(&graph)`, `DiskAnnIndex::check_graph(&store, &graph)`, plus `nearest_term_exact_checked` / `VectorIndex::nearest_term_checked` / `DiskAnnIndex::nearest_term_checked` return a **descriptive `Err`** on a mismatch instead of mis-resolving. Builders bind the graph: `VectorStore::create(..).with_fingerprint(&g)`, `StreamingWriter::create_with_fingerprint`, `DiskAnnIndex::build_for` / `build_with_for`.
- **Format-version bump (1 → 2), back-compat preserved**: there was not enough reserved space (`.spqv` had 12 spare bytes, `.spqg` 4) for a 24-byte fingerprint, so both formats go to v2 with a 24-byte fingerprint block (header 32 → 56, data still 4-aligned). **Legacy v1 files still open and read correctly** (per-store `data_offset`), but `check_graph` reports them as *unverifiable* (a clear error) rather than silently certifying them — the honest trade-off: old artifacts keep loading, but to get the staleness guarantee you must rebuild. The unchecked `nearest_term*` entry points are retained and documented as the unsafe form.

## Tests (`cargo test -p sparq-vectors`, all green)
Build against graph A then: (1) open/query against A → OK + correct neighbours; (2) open/query against a different graph B → descriptive `Err`, not wrong results; (3) fingerprint survives serialize→deserialize (both `.spqv` and `.spqg`); (4) a hand-crafted legacy v1 file opens + reads but `check_graph` errs. Covered for `.spqv`, `.spqg`, and the streaming writer; a unit test also confirms a same-term-set dict-id permutation changes the hash.

Refs bead sq-32i5 (unblocks sq-pi44 incremental add/remove).