### PR TITLE
feat(sparq-server): SSE subscriptions transport (sq-bxog)

### DIFF
--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -1119,6 +1119,9 @@ pub fn router(state: AppState) -> Router {
         .route("/graphs/{*path}", any(graph_store_direct))
         // SEPA-style SPARQL subscriptions over WebSocket (T23).
         .route("/subscriptions", get(crate::subscriptions::subscriptions_endpoint))
+        // [OPUS-4.8] sq-bxog: the same subscription engine over Server-Sent Events
+        // (text/event-stream) — one subscription per stream, query in the query string.
+        .route("/subscriptions/sse", get(crate::subscriptions::sse::sse_endpoint))
         // Liveness.
         .route("/health", get(|| async { "ok" }))
         // Prometheus metrics (T22).
@@ -2498,7 +2501,10 @@ fn chunked_response(status: StatusCode, content_type: &str, chunks: Vec<String>,
 
 /// Structured error body: every error the server emits is `{"error": "..."}` JSON, so
 /// programmatic clients never have to scrape prose out of plain text.
-fn json_error(status: StatusCode, msg: &str) -> Response {
+///
+/// [OPUS-4.8] sq-bxog: `pub(crate)` so the SSE subscription handler returns the SAME error
+/// envelope as the rest of the HTTP surface for a pre-stream registration refusal.
+pub(crate) fn json_error(status: StatusCode, msg: &str) -> Response {
     let mut body = String::with_capacity(msg.len() + 16);
     body.push_str("{\"error\":\"");
     for c in msg.chars() {

--- a/crates/sparq-server/src/subscriptions.rs
+++ b/crates/sparq-server/src/subscriptions.rs
@@ -85,18 +85,22 @@ impl SubscriptionCounters {
 /// `subscribe` and released on `unsubscribe`/termination; `Drop` releases whatever is
 /// still held, so a socket that disconnects (or a handler that panics) can never leak
 /// global capacity.
-struct ConnSlots {
+///
+/// [OPUS-4.8] sq-bxog: `pub(crate)` so the SSE transport ([`crate::subscriptions::sse`])
+/// reuses the SAME global-cap accounting as the WebSocket path — one stream holds one slot,
+/// released on disconnect by `Drop` exactly like a WS connection's slots.
+pub(crate) struct ConnSlots {
     counters: Arc<SubscriptionCounters>,
     held: usize,
 }
 
 impl ConnSlots {
-    fn new(counters: Arc<SubscriptionCounters>) -> Self {
+    pub(crate) fn new(counters: Arc<SubscriptionCounters>) -> Self {
         Self { counters, held: 0 }
     }
 
     /// Tries to take one global slot (CAS loop so concurrent connections never overshoot).
-    fn try_acquire(&mut self, max_global: usize) -> bool {
+    pub(crate) fn try_acquire(&mut self, max_global: usize) -> bool {
         let ok = self
             .counters
             .active
@@ -108,7 +112,7 @@ impl ConnSlots {
         ok
     }
 
-    fn release_one(&mut self) {
+    pub(crate) fn release_one(&mut self) {
         debug_assert!(self.held > 0);
         self.held -= 1;
         self.counters.active.fetch_sub(1, Ordering::AcqRel);
@@ -136,7 +140,11 @@ pub async fn subscriptions_endpoint(State(state): State<AppState>, ws: WebSocket
 
 /// One active subscription: the query, its identity, and the last seen result keyed by
 /// canonical row encoding (the diff baseline).
-struct Subscription {
+///
+/// [OPUS-4.8] sq-bxog: `pub(crate)` (with [`Subscription::reevaluate_step`]) so the SSE
+/// transport drives the SAME re-evaluate + diff state machine as the WebSocket path — only
+/// the wire framing differs.
+pub(crate) struct Subscription {
     alias: Option<String>,
     query: String,
     /// Per-subscription notification sequence; 0 is the initial full result.
@@ -144,6 +152,49 @@ struct Subscription {
     vars: Vec<String>,
     /// canonical row key (serialised binding object) → binding object.
     rows: HashMap<String, Value>,
+}
+
+/// [OPUS-4.8] sq-bxog: the outcome of one [`Subscription::reevaluate_step`] — the
+/// transport-agnostic core that both `/subscriptions` (WS) and `/subscriptions/sse` reuse.
+pub(crate) enum ReevalStep {
+    /// The result is unchanged (or only coalesced no-ops): emit nothing.
+    Unchanged,
+    /// The result changed: emit this `notification` JSON (added/removed diff).
+    Notify(Value),
+    /// Re-evaluation failed (timeout / max-rows overflow): the caller must drop the
+    /// subscription and emit this terminating `error` JSON.
+    Terminate(Value),
+}
+
+impl Subscription {
+    /// Re-evaluates this subscription against the latest snapshot and advances its diff
+    /// baseline, returning the JSON to emit (or [`ReevalStep::Unchanged`]). This is the
+    /// single source of truth for the re-evaluate + diff semantics shared by both
+    /// transports — see the module docs. On a [`ReevalStep::Terminate`] the baseline is NOT
+    /// advanced (the caller drops the subscription).
+    pub(crate) async fn reevaluate_step(&mut self, id: u64, state: &AppState) -> ReevalStep {
+        match evaluate(state, self.query.clone()).await {
+            Ok((vars, new_rows)) => {
+                let added: Vec<&Value> =
+                    sorted_pairs(new_rows.iter().filter(|(k, _)| !self.rows.contains_key(*k)));
+                let removed: Vec<&Value> =
+                    sorted_pairs(self.rows.iter().filter(|(k, _)| !new_rows.contains_key(*k)));
+                if added.is_empty() && removed.is_empty() {
+                    return ReevalStep::Unchanged; // result unchanged — coalesced no-ops included
+                }
+                self.sequence += 1;
+                let msg = notification(id, self.alias.as_deref(), self.sequence, &vars, &added, &removed);
+                self.vars = vars;
+                self.rows = new_rows;
+                ReevalStep::Notify(msg)
+            }
+            Err(e) => ReevalStep::Terminate(error_msg(
+                &format!("re-evaluation failed, subscription terminated: {e}"),
+                Some(id),
+                self.alias.as_deref(),
+            )),
+        }
+    }
 }
 
 /// The per-connection driver: a single task owns the socket and its subscription table,
@@ -221,39 +272,49 @@ async fn handle_client_message(
     .is_ok()
 }
 
-async fn handle_subscribe(
-    socket: &mut WebSocket,
+/// [OPUS-4.8] sq-bxog: a successfully-registered subscription, ready to stream. The
+/// transport-agnostic product of [`subscribe_init`]: the live [`Subscription`] (its diff
+/// baseline holds the initial full result), its server-wide `id`, and the two opening
+/// frames a client expects — the `subscribed` ack and the sequence-0 notification (the full
+/// result as `addedResults`). A global slot is held on `slots` for it.
+pub(crate) struct NewSubscription {
+    pub(crate) id: u64,
+    pub(crate) subscription: Subscription,
+    pub(crate) subscribed: Value,
+    pub(crate) initial: Value,
+}
+
+/// [OPUS-4.8] sq-bxog: the transport-agnostic "register a subscription" core, shared by the
+/// WebSocket `subscribe` frame and the SSE `GET /subscriptions/sse` handler. Validates the
+/// query (SELECT-only), enforces the per-connection then the global cap (acquiring one slot
+/// on `slots`), runs the initial evaluation (refusing on timeout / max-rows overflow,
+/// mirroring the HTTP 503/413 semantics), allocates the server-wide id, and builds the two
+/// opening frames. On refusal it returns the `error` JSON to emit and holds NO slot.
+pub(crate) async fn subscribe_init(
     state: &AppState,
-    subs: &mut HashMap<u64, Subscription>,
     slots: &mut ConnSlots,
-    req: &Value,
-) -> bool {
-    let alias = req.get("alias").and_then(Value::as_str).map(str::to_string);
+    current_conn_subs: usize,
+    query: &str,
+    alias: Option<String>,
+) -> Result<NewSubscription, Value> {
     let refuse = |msg: String| error_msg(&msg, None, alias.as_deref());
 
-    let Some(query) = req.get("query").and_then(Value::as_str) else {
-        return send(socket, &refuse("subscribe requires a string 'query' field".into())).await.is_ok();
-    };
     // Only SELECT is subscribable: the diff is defined over solution bindings.
     match prepare(query) {
         Ok(p) if p.form == QueryForm::Select => {}
-        Ok(_) => {
-            return send(socket, &refuse("only SELECT queries can be subscribed".into())).await.is_ok();
-        }
-        Err(PrepareError::Malformed(e)) => {
-            return send(socket, &refuse(format!("malformed query: {e}"))).await.is_ok();
-        }
+        Ok(_) => return Err(refuse("only SELECT queries can be subscribed".into())),
+        Err(PrepareError::Malformed(e)) => return Err(refuse(format!("malformed query: {e}"))),
     }
 
     // Limits: per-connection first (cheap), then the global slot.
     let config = state.config();
-    if subs.len() >= config.max_subscriptions_per_conn {
+    if current_conn_subs >= config.max_subscriptions_per_conn {
         let max = config.max_subscriptions_per_conn;
-        return send(socket, &refuse(format!("subscription limit reached for this connection ({max}); unsubscribe first or raise --max-subscriptions-per-conn"))).await.is_ok();
+        return Err(refuse(format!("subscription limit reached for this connection ({max}); unsubscribe first or raise --max-subscriptions-per-conn")));
     }
     if !slots.try_acquire(config.max_subscriptions) {
         let max = config.max_subscriptions;
-        return send(socket, &refuse(format!("server-wide subscription limit reached ({max}); retry later or raise --max-subscriptions"))).await.is_ok();
+        return Err(refuse(format!("server-wide subscription limit reached ({max}); retry later or raise --max-subscriptions")));
     }
 
     // Initial evaluation. Failure (parse-at-engine, timeout, max-rows overflow) refuses
@@ -262,24 +323,45 @@ async fn handle_subscribe(
         Ok(r) => r,
         Err(e) => {
             slots.release_one();
-            return send(socket, &refuse(format!("initial evaluation failed: {e}"))).await.is_ok();
+            return Err(refuse(format!("initial evaluation failed: {e}")));
         }
     };
 
     let id = state.subs.next_id.fetch_add(1, Ordering::Relaxed) + 1;
-    let sub = Subscription { alias, query: query.to_string(), sequence: 0, vars, rows };
+    let subscription = Subscription { alias, query: query.to_string(), sequence: 0, vars, rows };
 
     // {"subscribed": ...} then the sequence-0 notification: full result as added, empty removed.
-    let subscribed = with_alias(json!({ "subscribed": { "id": id } }), "subscribed", sub.alias.as_deref());
-    if send(socket, &subscribed).await.is_err() {
+    let subscribed = with_alias(json!({ "subscribed": { "id": id } }), "subscribed", subscription.alias.as_deref());
+    let added: Vec<&Value> = sorted_bindings(&subscription.rows);
+    let initial = notification(id, subscription.alias.as_deref(), 0, &subscription.vars, &added, &[]);
+    Ok(NewSubscription { id, subscription, subscribed, initial })
+}
+
+async fn handle_subscribe(
+    socket: &mut WebSocket,
+    state: &AppState,
+    subs: &mut HashMap<u64, Subscription>,
+    slots: &mut ConnSlots,
+    req: &Value,
+) -> bool {
+    let alias = req.get("alias").and_then(Value::as_str).map(str::to_string);
+
+    let Some(query) = req.get("query").and_then(Value::as_str) else {
+        return send(socket, &error_msg("subscribe requires a string 'query' field", None, alias.as_deref())).await.is_ok();
+    };
+
+    let new = match subscribe_init(state, slots, subs.len(), query, alias).await {
+        Ok(n) => n,
+        Err(refusal) => return send(socket, &refusal).await.is_ok(),
+    };
+
+    if send(socket, &new.subscribed).await.is_err() {
         return false;
     }
-    let added: Vec<&Value> = sorted_bindings(&sub.rows);
-    let initial = notification(id, sub.alias.as_deref(), 0, &sub.vars, &added, &[]);
-    if send(socket, &initial).await.is_err() {
+    if send(socket, &new.initial).await.is_err() {
         return false;
     }
-    subs.insert(id, sub);
+    subs.insert(new.id, new.subscription);
     true
 }
 
@@ -315,34 +397,19 @@ async fn reevaluate_all(
     let mut ids: Vec<u64> = subs.keys().copied().collect();
     ids.sort_unstable();
     for id in ids {
-        let query = subs[&id].query.clone();
-        match evaluate(state, query).await {
-            Ok((vars, new_rows)) => {
-                let sub = subs.get_mut(&id).expect("subscription vanished mid-batch");
-                let added: Vec<&Value> =
-                    sorted_pairs(new_rows.iter().filter(|(k, _)| !sub.rows.contains_key(*k)));
-                let removed: Vec<&Value> =
-                    sorted_pairs(sub.rows.iter().filter(|(k, _)| !new_rows.contains_key(*k)));
-                if added.is_empty() && removed.is_empty() {
-                    continue; // result unchanged — no notification (coalesced no-ops included)
-                }
-                sub.sequence += 1;
-                let msg = notification(id, sub.alias.as_deref(), sub.sequence, &vars, &added, &removed);
+        // [OPUS-4.8] sq-bxog: the re-evaluate + diff core is `Subscription::reevaluate_step`,
+        // shared verbatim with the SSE transport; the WS path only handles the framing.
+        let sub = subs.get_mut(&id).expect("subscription vanished mid-batch");
+        match sub.reevaluate_step(id, state).await {
+            ReevalStep::Unchanged => {}
+            ReevalStep::Notify(msg) => {
                 if send(socket, &msg).await.is_err() {
                     return false;
                 }
-                sub.vars = vars;
-                sub.rows = new_rows;
             }
-            Err(e) => {
-                let alias = subs[&id].alias.clone();
+            ReevalStep::Terminate(msg) => {
                 subs.remove(&id);
                 slots.release_one();
-                let msg = error_msg(
-                    &format!("re-evaluation failed, subscription terminated: {e}"),
-                    Some(id),
-                    alias.as_deref(),
-                );
                 if send(socket, &msg).await.is_err() {
                     return false;
                 }
@@ -516,6 +583,175 @@ fn error_msg(message: &str, id: Option<u64>, alias: Option<&str>) -> Value {
 async fn send(socket: &mut WebSocket, msg: &Value) -> Result<(), axum::Error> {
     // [OPUS-4.8] axum 0.8: ws Message::Text wraps Utf8Bytes; String converts via Into.
     socket.send(Message::Text(msg.to_string().into())).await
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-bxog: SSE (Server-Sent Events) transport
+// ---------------------------------------------------------------------------
+
+/// SSE (`text/event-stream`) transport for SPARQL update subscriptions, ALONGSIDE the
+/// WebSocket `/subscriptions` endpoint. Both transports share ONE notification source —
+/// [`subscribe_init`] (register + initial result) and [`Subscription::reevaluate_step`]
+/// (re-evaluate + diff), driven by the same commit-generation `watch` channel
+/// ([`AppState::subscribe_commits`]) and the same global/per-connection slot accounting
+/// ([`ConnSlots`]). Only the wire framing differs: SSE emits `event:`/`data:`/`id:` frames
+/// instead of WebSocket JSON text frames.
+///
+/// Because SSE is a one-way GET stream (no client→server channel after the request),
+/// each connection carries exactly ONE subscription, identified by the `query` (and
+/// optional `alias`) query-string parameters — the natural REST shape, versus the WS
+/// path's multiplexed many-subscriptions-per-socket protocol. There is no `unsubscribe`
+/// frame: a client unsubscribes by closing the stream, which drops the per-stream state
+/// (releasing its global slot via [`ConnSlots`]'s `Drop`) with no leak.
+pub mod sse {
+    use std::collections::HashMap;
+
+    use axum::extract::{Query, State};
+    use axum::response::sse::{Event, KeepAlive, Sse};
+    use axum::response::{IntoResponse, Response};
+    use futures_util::Stream;
+    use serde_json::Value;
+
+    use super::{subscribe_init, ConnSlots, ReevalStep, Subscription};
+    use crate::http::AppState;
+
+    /// SSE keep-alive comment interval (`: ping\n\n` every 15 s) — holds idle connections
+    /// open across proxies/load balancers that would otherwise reap a silent stream.
+    const KEEP_ALIVE_SECS: u64 = 15;
+
+    /// The per-stream state threaded through the [`futures_util::stream::unfold`] generator.
+    /// Dropping it (on client disconnect, when axum stops polling the body) drops `_slots`,
+    /// releasing the global subscription slot — the leak-free disconnect path, mirroring the
+    /// WebSocket connection task's `ConnSlots` drop.
+    struct StreamState {
+        id: u64,
+        subscription: Subscription,
+        commits: tokio::sync::watch::Receiver<u64>,
+        state: AppState,
+        /// Opening frames (subscribed ack, then the sequence-0 notification) and any
+        /// terminating error, queued FIFO so each `unfold` step yields exactly one event.
+        pending: std::collections::VecDeque<Event>,
+        /// Once a `Terminate` (re-evaluation failure) has been queued, the stream ends after
+        /// draining `pending`.
+        finished: bool,
+        /// Held for the stream's lifetime; `Drop` releases the global slot on disconnect.
+        _slots: ConnSlots,
+    }
+
+    /// `GET /subscriptions/sse?query=<SELECT>[&alias=<x>]` — registers ONE SPARQL update
+    /// subscription and streams notifications as Server-Sent Events.
+    ///
+    /// Auth: this mirrors the WebSocket `/subscriptions` path, which is itself NOT
+    /// auth-gated today — gating the subscription transports behind the read token is
+    /// tracked under bead `sq-cxk5`. When that lands, both transports must gate together.
+    ///
+    /// A registration refusal (missing/non-SELECT/malformed query → 400; initial
+    /// evaluation over the row cap / past the timeout → 503/413-style) is returned as a
+    /// normal JSON HTTP error BEFORE the event-stream opens — SSE cannot set a status once
+    /// the stream is flowing, so refusals surface with a real status code. On success the
+    /// response is `text/event-stream` and the first two frames are the `subscribed` ack
+    /// and the full initial result.
+    pub async fn sse_endpoint(State(state): State<AppState>, Query(params): Query<HashMap<String, String>>) -> Response {
+        let Some(query) = params.get("query") else {
+            return crate::http::json_error(
+                axum::http::StatusCode::BAD_REQUEST,
+                "the 'query' query-string parameter is required (the SELECT to subscribe)",
+            );
+        };
+        let alias = params.get("alias").cloned();
+
+        let mut slots = ConnSlots::new(state.subs.clone());
+        // One subscription per SSE stream, so the per-connection count starts at 0.
+        let new = match subscribe_init(&state, &mut slots, 0, query, alias).await {
+            Ok(n) => n,
+            Err(refusal) => {
+                // Map the refusal onto an HTTP status: a malformed/non-SELECT query is a
+                // 400; a limit/eval refusal is a 503 (server-side capacity / budget).
+                let msg = refusal["error"]["message"].as_str().unwrap_or("subscription refused").to_string();
+                let status = if msg.starts_with("malformed query") || msg.starts_with("only SELECT") {
+                    axum::http::StatusCode::BAD_REQUEST
+                } else {
+                    axum::http::StatusCode::SERVICE_UNAVAILABLE
+                };
+                return crate::http::json_error(status, &msg);
+            }
+        };
+
+        // Drop generations committed before this stream existed: the initial frame already
+        // reflects the current graph (same `mark_unchanged` discipline as the WS task).
+        let mut commits = state.subscribe_commits();
+        commits.mark_unchanged();
+
+        let mut pending = std::collections::VecDeque::with_capacity(2);
+        pending.push_back(json_event("subscribed", &new.subscribed));
+        pending.push_back(notification_event(&new.initial));
+
+        let init = StreamState {
+            id: new.id,
+            subscription: new.subscription,
+            commits,
+            state,
+            pending,
+            finished: false,
+            _slots: slots,
+        };
+
+        Sse::new(into_event_stream(init))
+            .keep_alive(KeepAlive::new().interval(std::time::Duration::from_secs(KEEP_ALIVE_SECS)).text("ping"))
+            .into_response()
+    }
+
+    /// Builds the infallible `Stream<Item = Result<Event, Infallible>>` axum's [`Sse`]
+    /// wants. Each `unfold` step first drains any queued frame (the opening pair, or a
+    /// terminating error); when empty, it awaits the next commit and re-evaluates,
+    /// emitting one diff `notification` (or terminating on failure). Returning `None`
+    /// ends the stream; the watch channel closing (server shutdown) ends it too.
+    fn into_event_stream(init: StreamState) -> impl Stream<Item = Result<Event, std::convert::Infallible>> {
+        futures_util::stream::unfold(init, |mut st| async move {
+            loop {
+                if let Some(ev) = st.pending.pop_front() {
+                    return Some((Ok(ev), st));
+                }
+                if st.finished {
+                    return None; // terminating error already drained — close the stream
+                }
+                // Block until a commit advances the published generation (the watch
+                // channel coalesces bursts — see the module docs), then re-evaluate.
+                if st.commits.changed().await.is_err() {
+                    return None; // server shutting down
+                }
+                let id = st.id;
+                match st.subscription.reevaluate_step(id, &st.state).await {
+                    ReevalStep::Unchanged => continue, // no diff — keep waiting (no frame)
+                    ReevalStep::Notify(msg) => return Some((Ok(notification_event(&msg)), st)),
+                    ReevalStep::Terminate(msg) => {
+                        st.finished = true;
+                        return Some((Ok(json_event("error", &msg)), st));
+                    }
+                }
+            }
+        })
+    }
+
+    /// A `notification` SSE frame: `event: notification`, the JSON as `data:`, and the
+    /// per-subscription `sequence` as the SSE `id:` (so a client can track ordering /
+    /// `Last-Event-ID` resumption semantics at the application layer).
+    fn notification_event(msg: &Value) -> Event {
+        let ev = json_event("notification", msg);
+        match msg["notification"]["sequence"].as_u64() {
+            Some(seq) => ev.id(seq.to_string()),
+            None => ev,
+        }
+    }
+
+    /// A typed SSE frame: `event: <name>` with the JSON value serialised as the `data:`
+    /// payload (single line — `serde_json` never emits a bare newline, so SSE framing is
+    /// preserved without escaping). The on-the-wire framing (`event:`/`data:`/`id:`/`\n\n`)
+    /// is asserted end-to-end in `tests/subscriptions_sse.rs`, which reads the raw bytes
+    /// (axum's [`Event`] finalises to bytes internally and exposes no inspection API).
+    fn json_event(name: &str, value: &Value) -> Event {
+        Event::default().event(name).data(value.to_string())
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sparq-server/src/subscriptions.rs
+++ b/crates/sparq-server/src/subscriptions.rs
@@ -51,6 +51,7 @@ use std::sync::Arc;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
+use axum::http::StatusCode;
 use axum::response::Response;
 use serde_json::{json, Value};
 
@@ -189,7 +190,7 @@ impl Subscription {
                 ReevalStep::Notify(msg)
             }
             Err(e) => ReevalStep::Terminate(error_msg(
-                &format!("re-evaluation failed, subscription terminated: {e}"),
+                &format!("re-evaluation failed, subscription terminated: {}", e.message),
                 Some(id),
                 self.alias.as_deref(),
             )),
@@ -284,6 +285,28 @@ pub(crate) struct NewSubscription {
     pub(crate) initial: Value,
 }
 
+/// [OPUS-4.8] sq-bxog (Copilot #120): a subscription-registration refusal, carrying BOTH the
+/// `error` JSON to emit AND the HTTP status the SSE transport must surface — classified at the
+/// point of refusal so the SSE path is consistent with the `/sparql` endpoint's status
+/// semantics ([`crate::http::engine_error_response`]):
+///
+///   * malformed / non-SELECT query → **400** (the client's request is wrong);
+///   * the initial evaluation overflowing `--max-results` / `--max-query-rows` (the row cap)
+///     → **413** PAYLOAD_TOO_LARGE — EXACTLY as `/sparql` maps `query budget exceeded
+///     (max-rows)`, instead of the previous blanket 503;
+///   * the initial evaluation timing out, OR subscription-slot exhaustion (per-connection /
+///     server-wide cap) → **503** SERVICE_UNAVAILABLE — genuine capacity / overload, mirroring
+///     `/sparql`'s timeout 503;
+///   * any other engine error (e.g. a denied SERVICE) → **500**, mirroring `/sparql`'s
+///     `execution_error`.
+///
+/// The WebSocket transport ignores `status` (it has no HTTP response, only the `error` frame);
+/// only the SSE GET, which must set a real status BEFORE the stream opens, consults it.
+pub(crate) struct Refusal {
+    pub(crate) error: Value,
+    pub(crate) status: StatusCode,
+}
+
 /// [OPUS-4.8] sq-bxog: the transport-agnostic "register a subscription" core, shared by the
 /// WebSocket `subscribe` frame and the SSE `GET /subscriptions/sse` handler. Validates the
 /// query (SELECT-only), enforces the per-connection then the global cap (acquiring one slot
@@ -296,34 +319,40 @@ pub(crate) async fn subscribe_init(
     current_conn_subs: usize,
     query: &str,
     alias: Option<String>,
-) -> Result<NewSubscription, Value> {
-    let refuse = |msg: String| error_msg(&msg, None, alias.as_deref());
+) -> Result<NewSubscription, Refusal> {
+    // [OPUS-4.8] sq-bxog (Copilot #120): carry the HTTP status alongside the `error` JSON so the
+    // SSE transport surfaces the SAME status `/sparql` would (400 client / 413 row-cap / 503
+    // capacity-or-timeout / 500 other) — see [`Refusal`].
+    let refuse = |msg: String, status: StatusCode| Refusal { error: error_msg(&msg, None, alias.as_deref()), status };
 
-    // Only SELECT is subscribable: the diff is defined over solution bindings.
+    // Only SELECT is subscribable: the diff is defined over solution bindings. A wrong-form or
+    // malformed query is the client's error → 400, exactly like a `/sparql` parse error.
     match prepare(query) {
         Ok(p) if p.form == QueryForm::Select => {}
-        Ok(_) => return Err(refuse("only SELECT queries can be subscribed".into())),
-        Err(PrepareError::Malformed(e)) => return Err(refuse(format!("malformed query: {e}"))),
+        Ok(_) => return Err(refuse("only SELECT queries can be subscribed".into(), StatusCode::BAD_REQUEST)),
+        Err(PrepareError::Malformed(e)) => return Err(refuse(format!("malformed query: {e}"), StatusCode::BAD_REQUEST)),
     }
 
-    // Limits: per-connection first (cheap), then the global slot.
+    // Limits: per-connection first (cheap), then the global slot. Both are genuine
+    // capacity/overload (subscription-slot exhaustion) → 503, NOT a payload refusal.
     let config = state.config();
     if current_conn_subs >= config.max_subscriptions_per_conn {
         let max = config.max_subscriptions_per_conn;
-        return Err(refuse(format!("subscription limit reached for this connection ({max}); unsubscribe first or raise --max-subscriptions-per-conn")));
+        return Err(refuse(format!("subscription limit reached for this connection ({max}); unsubscribe first or raise --max-subscriptions-per-conn"), StatusCode::SERVICE_UNAVAILABLE));
     }
     if !slots.try_acquire(config.max_subscriptions) {
         let max = config.max_subscriptions;
-        return Err(refuse(format!("server-wide subscription limit reached ({max}); retry later or raise --max-subscriptions")));
+        return Err(refuse(format!("server-wide subscription limit reached ({max}); retry later or raise --max-subscriptions"), StatusCode::SERVICE_UNAVAILABLE));
     }
 
-    // Initial evaluation. Failure (parse-at-engine, timeout, max-rows overflow) refuses
-    // the subscription — mirroring the HTTP endpoint's 400/503/413 semantics.
+    // Initial evaluation. Failure refuses the subscription with the SAME status `/sparql` would
+    // give the equivalent engine error: a row-cap overflow (`--max-results` / `--max-query-rows`)
+    // is a 413 (mirroring `crate::http::engine_error_response`), a timeout is a 503, else a 500.
     let (vars, rows) = match evaluate(state, query.to_string()).await {
         Ok(r) => r,
         Err(e) => {
             slots.release_one();
-            return Err(refuse(format!("initial evaluation failed: {e}")));
+            return Err(refuse(format!("initial evaluation failed: {}", e.message), e.status()));
         }
     };
 
@@ -352,7 +381,9 @@ async fn handle_subscribe(
 
     let new = match subscribe_init(state, slots, subs.len(), query, alias).await {
         Ok(n) => n,
-        Err(refusal) => return send(socket, &refusal).await.is_ok(),
+        // [OPUS-4.8] sq-bxog (Copilot #120): the WS transport has no HTTP status — it just emits
+        // the `error` frame (the refusal's `status` is for the SSE GET only).
+        Err(refusal) => return send(socket, &refusal.error).await.is_ok(),
     };
 
     if send(socket, &new.subscribed).await.is_err() {
@@ -423,10 +454,43 @@ async fn reevaluate_all(
 // Evaluation + diff primitives
 // ---------------------------------------------------------------------------
 
+/// [OPUS-4.8] sq-bxog (Copilot #120): a categorised initial-evaluation failure — the
+/// human-readable `message` (named after the same limits a `/sparql` 413/503 would name) plus a
+/// [`RefuseKind`] so the refusal status mirrors the HTTP surface
+/// ([`crate::http::engine_error_response`]) instead of collapsing everything into 503.
+struct EvalError {
+    message: String,
+    kind: RefuseKind,
+}
+
+/// [OPUS-4.8] sq-bxog (Copilot #120): the cause of an initial-evaluation failure, classified from
+/// the engine's budget-violation string EXACTLY as [`crate::http::engine_error_response`] does, so
+/// the SSE status is consistent with `/sparql`.
+enum RefuseKind {
+    /// `query budget exceeded (timeout)` → 503 (genuine overload), matching `/sparql`'s timeout.
+    Timeout,
+    /// `query budget exceeded (max-rows)` → 413 (the result is too large, NOT a capacity problem).
+    RowCap,
+    /// Any other engine error (a denied SERVICE, a worker panic) → 500, like `execution_error`.
+    Other,
+}
+
+impl EvalError {
+    /// The HTTP status the SSE transport surfaces for this failure — the SAME mapping
+    /// [`crate::http::engine_error_response`] applies on `/sparql`.
+    fn status(&self) -> StatusCode {
+        match self.kind {
+            RefuseKind::Timeout => StatusCode::SERVICE_UNAVAILABLE,
+            RefuseKind::RowCap => StatusCode::PAYLOAD_TOO_LARGE,
+            RefuseKind::Other => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
 /// Runs the SELECT on the blocking pool under the server budget (deadline + row cap),
 /// with the same hard await-cap as the HTTP path. Returns the head vars and the result
 /// keyed by canonical row encoding.
-async fn evaluate(state: &AppState, query: String) -> Result<(Vec<String>, HashMap<String, Value>), String> {
+async fn evaluate(state: &AppState, query: String) -> Result<(Vec<String>, HashMap<String, Value>), EvalError> {
     let config = state.config().clone();
     let budget = make_budget(&config, true);
     // Pin the current generation for this evaluation (lock-free; never blocked by the
@@ -445,22 +509,24 @@ async fn evaluate(state: &AppState, query: String) -> Result<(Vec<String>, HashM
     match joined {
         Ok(Ok(r)) => Ok(r),
         Ok(Err(e)) => Err(budget_error(&e, &config)),
-        Err(_) => Err("query worker panicked".into()),
+        Err(_) => Err(EvalError { message: "query worker panicked".into(), kind: RefuseKind::Other }),
     }
 }
 
-/// Maps the engine's budget-violation strings onto the messages the HTTP layer uses
-/// (so a refused subscription names the same limits as a 503/413 would).
-fn budget_error(e: &str, config: &ServerConfig) -> String {
+/// Maps the engine's budget-violation strings onto the messages the HTTP layer uses (so a refused
+/// subscription names the same limits as a 503/413 would) AND classifies the cause ([`RefuseKind`])
+/// so the SSE status matches `/sparql` ([`crate::http::engine_error_response`]): timeout → 503,
+/// row cap → 413, else → 500.
+fn budget_error(e: &str, config: &ServerConfig) -> EvalError {
     if e.contains("query budget exceeded (timeout)") {
         let secs = config.query_timeout.map(|t| t.as_secs()).unwrap_or(0);
-        return format!("query timed out (server limit: {secs}s)");
+        return EvalError { message: format!("query timed out (server limit: {secs}s)"), kind: RefuseKind::Timeout };
     }
     if e.contains("query budget exceeded (max-rows)") {
         let max = config.max_results.unwrap_or(0);
-        return format!("result exceeds the server's max-results limit ({max} rows)");
+        return EvalError { message: format!("result exceeds the server's max-results limit ({max} rows)"), kind: RefuseKind::RowCap };
     }
-    e.to_string()
+    EvalError { message: e.to_string(), kind: RefuseKind::Other }
 }
 
 /// Evaluates the SELECT and canonicalises each solution row to its SPARQL-JSON binding
@@ -645,12 +711,14 @@ pub mod sse {
     /// auth-gated today — gating the subscription transports behind the read token is
     /// tracked under bead `sq-cxk5`. When that lands, both transports must gate together.
     ///
-    /// A registration refusal (missing/non-SELECT/malformed query → 400; initial
-    /// evaluation over the row cap / past the timeout → 503/413-style) is returned as a
-    /// normal JSON HTTP error BEFORE the event-stream opens — SSE cannot set a status once
-    /// the stream is flowing, so refusals surface with a real status code. On success the
-    /// response is `text/event-stream` and the first two frames are the `subscribed` ack
-    /// and the full initial result.
+    /// A registration refusal is returned as a normal JSON HTTP error BEFORE the event-stream
+    /// opens — SSE cannot set a status once the stream is flowing — classified to match the
+    /// `/sparql` endpoint ([`crate::http::engine_error_response`]): missing/non-SELECT/malformed
+    /// query → **400**; the initial evaluation over the row cap (`--max-results` /
+    /// `--max-query-rows`) → **413**; the initial evaluation timing out, or subscription-slot
+    /// exhaustion → **503**; any other engine error → **500**. The status is carried on the
+    /// [`super::Refusal`]. On success the response is `text/event-stream` and the first two
+    /// frames are the `subscribed` ack and the full initial result.
     pub async fn sse_endpoint(State(state): State<AppState>, Query(params): Query<HashMap<String, String>>) -> Response {
         let Some(query) = params.get("query") else {
             return crate::http::json_error(
@@ -665,15 +733,11 @@ pub mod sse {
         let new = match subscribe_init(&state, &mut slots, 0, query, alias).await {
             Ok(n) => n,
             Err(refusal) => {
-                // Map the refusal onto an HTTP status: a malformed/non-SELECT query is a
-                // 400; a limit/eval refusal is a 503 (server-side capacity / budget).
-                let msg = refusal["error"]["message"].as_str().unwrap_or("subscription refused").to_string();
-                let status = if msg.starts_with("malformed query") || msg.starts_with("only SELECT") {
-                    axum::http::StatusCode::BAD_REQUEST
-                } else {
-                    axum::http::StatusCode::SERVICE_UNAVAILABLE
-                };
-                return crate::http::json_error(status, &msg);
+                // [OPUS-4.8] sq-bxog (Copilot #120): the refusal already carries the HTTP status,
+                // classified at the point of refusal to match the `/sparql` endpoint (400 client /
+                // 413 row-cap / 503 capacity-or-timeout / 500 other) — see [`super::Refusal`].
+                let msg = refusal.error["error"]["message"].as_str().unwrap_or("subscription refused").to_string();
+                return crate::http::json_error(refusal.status, &msg);
             }
         };
 

--- a/crates/sparq-server/tests/subscriptions_sse.rs
+++ b/crates/sparq-server/tests/subscriptions_sse.rs
@@ -1,0 +1,379 @@
+//! [OPUS-4.8] sq-bxog: integration tests for the SSE (Server-Sent Events) transport for
+//! SPARQL update subscriptions — `GET /subscriptions/sse`.
+//!
+//! These boot the real axum server on an ephemeral port and speak raw HTTP/SSE with
+//! `reqwest` (reading the `text/event-stream` body chunk by chunk), asserting the same
+//! logical events the WebSocket `/subscriptions` path delivers — only the wire framing
+//! differs. The SSE transport reuses the SAME subscription engine (register + initial
+//! result via `subscribe_init`, re-evaluate + diff via `Subscription::reevaluate_step`,
+//! global/per-connection slot accounting via `ConnSlots`).
+//!
+//! Coverage: (1) register → `subscribed` + initial-result frames; (2) a committed UPDATE
+//! triggers a `notification` diff frame; (3) a non-matching UPDATE produces no frame;
+//! (4) dropping the stream releases the global slot (no leak); (5) bad-query refusals
+//! surface as real HTTP error statuses BEFORE the stream opens.
+
+use std::time::Duration;
+
+use reqwest::Response;
+use serde_json::Value;
+use sparq_core::Graph;
+use sparq_server::{router, AppState, ServerConfig};
+use tokio::net::TcpListener;
+
+const DATA: &str = r#"
+    @prefix ex: <http://ex/> .
+    ex:alice ex:age 30 .
+    ex:bob   ex:age 25 .
+"#;
+
+const AGES: &str = "SELECT ?s ?age WHERE { ?s <http://ex/age> ?age }";
+
+/// Boots the server and returns its `host:port`.
+async fn spawn_with(config: ServerConfig) -> String {
+    let graph = Graph::load_str(DATA, "turtle").unwrap();
+    let app = router(AppState::with_config(graph, config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    addr.to_string()
+}
+
+async fn spawn() -> String {
+    spawn_with(ServerConfig::default()).await
+}
+
+/// Opens the SSE stream for `query` (and optional `alias`); asserts the `text/event-stream`
+/// content type and returns the streaming response.
+async fn open_sse(addr: &str, query: &str, alias: Option<&str>) -> Response {
+    let mut url = reqwest::Url::parse(&format!("http://{addr}/subscriptions/sse")).unwrap();
+    url.query_pairs_mut().append_pair("query", query);
+    if let Some(a) = alias {
+        url.query_pairs_mut().append_pair("alias", a);
+    }
+    let resp = reqwest::Client::new().get(url).send().await.unwrap();
+    assert_eq!(resp.status(), 200, "SSE stream should open with 200");
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(
+        ct.starts_with("text/event-stream"),
+        "unexpected content-type: {ct}"
+    );
+    resp
+}
+
+/// An accumulating SSE frame reader over a streaming reqwest body.
+struct SseReader {
+    resp: Response,
+    buf: String,
+}
+
+/// One parsed SSE event: its `event:` name, concatenated `data:` payload, and `id:`.
+#[derive(Debug, Default, Clone)]
+struct SseEvent {
+    event: Option<String>,
+    data: String,
+    id: Option<String>,
+    /// Raw comment lines (e.g. the keep-alive `: ping`).
+    comment: Option<String>,
+}
+
+impl SseEvent {
+    /// Parses the (single) `data:` line as JSON.
+    fn json(&self) -> Value {
+        serde_json::from_str(&self.data)
+            .unwrap_or_else(|e| panic!("data not JSON ({e}): {:?}", self.data))
+    }
+}
+
+impl SseReader {
+    fn new(resp: Response) -> Self {
+        Self {
+            resp,
+            buf: String::new(),
+        }
+    }
+
+    /// Reads the next complete SSE event (a record terminated by a blank line). Keep-alive
+    /// `: ping` comments are returned as their own events (with `comment` set) so callers can
+    /// skip them. Times out after 5 s so a missing event fails fast.
+    async fn next_event(&mut self) -> SseEvent {
+        loop {
+            if let Some(idx) = self.buf.find("\n\n") {
+                let raw: String = self.buf.drain(..idx + 2).collect();
+                return parse_event(&raw);
+            }
+            let chunk = tokio::time::timeout(Duration::from_secs(5), self.resp.chunk())
+                .await
+                .expect("timed out waiting for an SSE frame")
+                .expect("stream error")
+                .expect("stream closed");
+            self.buf.push_str(std::str::from_utf8(&chunk).unwrap());
+        }
+    }
+
+    /// Reads the next non-keep-alive event (skips `: ping` comment frames).
+    async fn next_data_event(&mut self) -> SseEvent {
+        loop {
+            let ev = self.next_event().await;
+            if ev.comment.is_some() && ev.data.is_empty() && ev.event.is_none() {
+                continue; // keep-alive ping — skip
+            }
+            return ev;
+        }
+    }
+
+    /// Asserts no DATA event arrives within `window` (keep-alive pings are tolerated).
+    async fn assert_silent(&mut self, window: Duration) {
+        match tokio::time::timeout(window, self.next_data_event()).await {
+            Err(_elapsed) => {}
+            Ok(ev) => panic!("expected silence, got: {ev:?}"),
+        }
+    }
+}
+
+/// Parses one SSE record (the text up to and including its blank-line terminator).
+fn parse_event(raw: &str) -> SseEvent {
+    let mut ev = SseEvent::default();
+    for line in raw.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(c) = line.strip_prefix(':') {
+            ev.comment = Some(c.trim().to_string());
+        } else if let Some(v) = line.strip_prefix("event:") {
+            ev.event = Some(v.trim().to_string());
+        } else if let Some(v) = line.strip_prefix("data:") {
+            if !ev.data.is_empty() {
+                ev.data.push('\n');
+            }
+            // SSE strips a single leading space after the colon.
+            ev.data.push_str(v.strip_prefix(' ').unwrap_or(v));
+        } else if let Some(v) = line.strip_prefix("id:") {
+            ev.id = Some(v.trim().to_string());
+        }
+    }
+    ev
+}
+
+/// Commits a SPARQL Update through the HTTP endpoint (the protocol's only write path).
+async fn update(addr: &str, sparql: &str) {
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .body(sparql.to_string())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 204, "update failed");
+}
+
+fn bindings<'a>(notification: &'a Value, which: &str) -> &'a Vec<Value> {
+    notification["notification"][which]["results"]["bindings"]
+        .as_array()
+        .unwrap_or_else(|| panic!("missing {which} bindings"))
+}
+
+/// Reads and asserts the opening `subscribed` + sequence-0 `notification` frames, returning
+/// `(id, initial_notification_event)`.
+async fn read_open(reader: &mut SseReader) -> (u64, SseEvent) {
+    let subscribed = reader.next_data_event().await;
+    assert_eq!(
+        subscribed.event.as_deref(),
+        Some("subscribed"),
+        "first frame: {subscribed:?}"
+    );
+    let id = subscribed.json()["subscribed"]["id"]
+        .as_u64()
+        .expect("subscribed.id");
+
+    let initial = reader.next_data_event().await;
+    assert_eq!(
+        initial.event.as_deref(),
+        Some("notification"),
+        "second frame: {initial:?}"
+    );
+    let body = initial.json();
+    assert_eq!(body["notification"]["id"].as_u64(), Some(id));
+    assert_eq!(body["notification"]["sequence"], 0);
+    // The sequence-0 notification is carried with `id: 0` (SSE event id).
+    assert_eq!(initial.id.as_deref(), Some("0"));
+    (id, initial)
+}
+
+// ---------------------------------------------------------------------------
+// (1) register → initial result frames
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sse_register_streams_subscribed_and_initial_result() {
+    let addr = spawn().await;
+    let resp = open_sse(&addr, AGES, None).await;
+    let mut reader = SseReader::new(resp);
+    let (_id, initial) = read_open(&mut reader).await;
+    let body = initial.json();
+    let added = bindings(&body, "addedResults");
+    assert_eq!(added.len(), 2, "initial result = both ages");
+    let removed = bindings(&body, "removedResults");
+    assert!(removed.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// (2) UPDATE triggers a notification diff frame on the SSE stream
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sse_update_delivers_added_diff_frame() {
+    let addr = spawn().await;
+    let resp = open_sse(&addr, AGES, Some("watch")).await;
+    let mut reader = SseReader::new(resp);
+    let (id, _initial) = read_open(&mut reader).await;
+
+    // Insert a new matching triple — the subscription must observe it as an `addedResults`.
+    update(
+        &addr,
+        "INSERT DATA { <http://ex/carol> <http://ex/age> 40 }",
+    )
+    .await;
+
+    let note = reader.next_data_event().await;
+    assert_eq!(note.event.as_deref(), Some("notification"));
+    let body = note.json();
+    assert_eq!(body["notification"]["id"].as_u64(), Some(id));
+    assert_eq!(body["notification"]["sequence"], 1);
+    assert_eq!(
+        body["notification"]["alias"], "watch",
+        "alias echoed (SEPA)"
+    );
+    // SSE event id mirrors the per-subscription sequence.
+    assert_eq!(note.id.as_deref(), Some("1"));
+
+    let added = bindings(&body, "addedResults");
+    assert_eq!(added.len(), 1, "exactly the new row");
+    assert_eq!(added[0]["s"]["value"], "http://ex/carol");
+    assert_eq!(added[0]["age"]["value"], "40");
+    assert!(bindings(&body, "removedResults").is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// (3) a non-matching UPDATE produces no frame
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sse_non_matching_update_is_silent() {
+    let addr = spawn().await;
+    // Subscribe to alice's age only — an unrelated insert must not notify.
+    let resp = open_sse(
+        &addr,
+        "SELECT ?age WHERE { <http://ex/alice> <http://ex/age> ?age }",
+        None,
+    )
+    .await;
+    let mut reader = SseReader::new(resp);
+    read_open(&mut reader).await;
+
+    update(&addr, "INSERT DATA { <http://ex/dave> <http://ex/age> 99 }").await;
+    reader.assert_silent(Duration::from_millis(500)).await;
+}
+
+// ---------------------------------------------------------------------------
+// (4) dropping the stream releases the global slot (no leak)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sse_dropped_stream_releases_its_global_slot() {
+    let addr = spawn_with(ServerConfig {
+        max_subscriptions: 1,
+        ..ServerConfig::default()
+    })
+    .await;
+
+    {
+        let resp = open_sse(&addr, AGES, None).await;
+        let mut reader = SseReader::new(resp);
+        read_open(&mut reader).await;
+        // `reader` (and the underlying response/stream) drops here — a vanished client.
+    }
+
+    // The server notices the closed stream and releases the slot; poll a fresh stream.
+    let mut ok = false;
+    for _ in 0..50 {
+        let mut url = reqwest::Url::parse(&format!("http://{addr}/subscriptions/sse")).unwrap();
+        url.query_pairs_mut().append_pair("query", AGES);
+        let resp = reqwest::Client::new().get(url).send().await.unwrap();
+        if resp.status() == 200 {
+            // Confirm it really registered (read the opening frames).
+            let mut reader = SseReader::new(resp);
+            read_open(&mut reader).await;
+            ok = true;
+            break;
+        }
+        assert_eq!(
+            resp.status(),
+            503,
+            "expected a capacity refusal while the slot is held"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        ok,
+        "global slot was never released after the SSE stream dropped"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (5) registration refusals surface as real HTTP statuses before the stream opens
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sse_missing_query_is_400() {
+    let addr = spawn().await;
+    let resp = reqwest::Client::new()
+        .get(format!("http://{addr}/subscriptions/sse"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["error"].as_str().unwrap().contains("query"), "{body}");
+}
+
+#[tokio::test]
+async fn sse_non_select_query_is_400() {
+    let addr = spawn().await;
+    let resp = reqwest::Client::new()
+        .get(format!("http://{addr}/subscriptions/sse"))
+        .query(&[("query", "ASK { ?s ?p ?o }")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: Value = resp.json().await.unwrap();
+    assert!(
+        body["error"].as_str().unwrap().contains("only SELECT"),
+        "{body}"
+    );
+}
+
+#[tokio::test]
+async fn sse_malformed_query_is_400() {
+    let addr = spawn().await;
+    let resp = reqwest::Client::new()
+        .get(format!("http://{addr}/subscriptions/sse"))
+        .query(&[("query", "SELECT ?s WHERE { this is not sparql")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: Value = resp.json().await.unwrap();
+    assert!(
+        body["error"].as_str().unwrap().contains("malformed"),
+        "{body}"
+    );
+}

--- a/crates/sparq-server/tests/subscriptions_sse.rs
+++ b/crates/sparq-server/tests/subscriptions_sse.rs
@@ -11,7 +11,8 @@
 //! Coverage: (1) register → `subscribed` + initial-result frames; (2) a committed UPDATE
 //! triggers a `notification` diff frame; (3) a non-matching UPDATE produces no frame;
 //! (4) dropping the stream releases the global slot (no leak); (5) bad-query refusals
-//! surface as real HTTP error statuses BEFORE the stream opens.
+//! surface as real HTTP error statuses BEFORE the stream opens; (6) [OPUS-4.8] sq-bxog
+//! (Copilot #120) an initial result over the row cap is a 413 (matching `/sparql`), NOT a 503.
 
 use std::time::Duration;
 
@@ -376,4 +377,66 @@ async fn sse_malformed_query_is_400() {
         body["error"].as_str().unwrap().contains("malformed"),
         "{body}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// (6) [OPUS-4.8] sq-bxog (Copilot #120): an initial result over the max-results / row cap is
+//     refused with 413 PAYLOAD_TOO_LARGE — the SAME status `/sparql` gives a row-cap overflow
+//     (`engine_error_response`), NOT the blanket 503 the SSE path used before. 503 is reserved
+//     for genuine capacity/overload (subscription-slot exhaustion — see test (4)).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sse_initial_result_over_max_results_is_413() {
+    // `AGES` selects BOTH ages (2 rows) from `DATA`; cap the result at 1 row so the INITIAL
+    // evaluation overflows the budget and the registration is refused before the stream opens.
+    let addr = spawn_with(ServerConfig {
+        max_results: Some(1),
+        ..ServerConfig::default()
+    })
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("http://{addr}/subscriptions/sse"))
+        .query(&[("query", AGES)])
+        .send()
+        .await
+        .unwrap();
+
+    // 413 PAYLOAD_TOO_LARGE — consistent with the `/sparql` endpoint's row-cap refusal, not 503.
+    assert_eq!(
+        resp.status(),
+        413,
+        "an initial result over the row cap must be a 413, not a 503"
+    );
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        ct.starts_with("application/json"),
+        "refusal is a JSON error, not an event-stream: {ct}"
+    );
+    let body: Value = resp.json().await.unwrap();
+    let msg = body["error"].as_str().unwrap_or("");
+    assert!(
+        msg.contains("max-results") && msg.contains("initial evaluation"),
+        "413 body names the cap that was exceeded: {body}"
+    );
+}
+
+#[tokio::test]
+async fn sse_initial_result_within_max_results_still_opens() {
+    // Sanity counterpart to the 413 test: a cap the initial result does NOT exceed (2 rows,
+    // cap 2) must still open the stream normally — the 413 is for a genuine overflow only.
+    let addr = spawn_with(ServerConfig {
+        max_results: Some(2),
+        ..ServerConfig::default()
+    })
+    .await;
+    let resp = open_sse(&addr, AGES, None).await;
+    let mut reader = SseReader::new(resp);
+    let (_id, initial) = read_open(&mut reader).await;
+    assert_eq!(bindings(&initial.json(), "addedResults").len(), 2);
 }

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: http-server
-description: Run or point an agent at a sparq SPARQL 1.1 Protocol HTTP endpoint (sparq-server) — /sparql query+update over GET/POST, content negotiation (SELECT/ASK JSON/XML/CSV/TSV; CONSTRUCT/DESCRIBE + Graph Store N-Triples/prefix-Turtle/RDF-XML), Graph Store read AND write (PUT/POST/DELETE on graph resources, RDF/XML bodies accepted), EXPLAIN, Prometheus /metrics, WebSocket subscriptions, and opt-in time-travel ?generation pinning. Use when starting the server, querying/updating a running endpoint, choosing Accept/Content-Type, or embedding the axum router.
+description: Run or point an agent at a sparq SPARQL 1.1 Protocol HTTP endpoint (sparq-server) — /sparql query+update over GET/POST, content negotiation (SELECT/ASK JSON/XML/CSV/TSV; CONSTRUCT/DESCRIBE + Graph Store N-Triples/prefix-Turtle/RDF-XML), Graph Store read AND write (PUT/POST/DELETE on graph resources, RDF/XML bodies accepted), EXPLAIN, Prometheus /metrics, WebSocket + SSE subscriptions, and opt-in time-travel ?generation pinning. Use when starting the server, querying/updating a running endpoint, choosing Accept/Content-Type, or embedding the axum router.
 ---
 
 # sparq-http-server
@@ -10,7 +10,7 @@ query engine over a `sparq_core::Graph` — in-memory by default, or **durable o
 with `--persist DIR` (updates WAL-fsync'd, survive a restart with no rebuild; see the
 "Durability" gotcha). It implements the **SPARQL 1.1 Protocol** (`query` + `update` at
 `/sparql`) and the **Graph Store HTTP Protocol** (read + write), with `Accept`-driven
-content negotiation, hardening guards, Prometheus `/metrics`, WebSocket subscriptions,
+content negotiation, hardening guards, Prometheus `/metrics`, WebSocket + SSE subscriptions,
 and opt-in time-travel + GeoSPARQL.
 
 ## Quickstart
@@ -34,8 +34,9 @@ cargo run -p sparq-server -- --addr 0.0.0.0:8080 --allow-remote --format ntriple
 > `query`/`update` body that parses as an update — and the GSP `PUT`/`POST`/`DELETE`
 > methods); otherwise `401` with `WWW-Authenticate: Bearer` (constant-time compared; mirrors
 > QLever's `-a <token>`). Add `--auth-token-read` (env `SPARQ_AUTH_TOKEN_READ=1`) to ALSO
-> gate reads. The `/subscriptions` WebSocket is a read surface and is NOT gated by this token
-> (bead `sq-cxk5`). The server binds **loopback by default** and **refuses a non-loopback
+> gate reads. The subscription transports (`/subscriptions` WebSocket and `/subscriptions/sse`
+> SSE) are a read surface and are NOT gated by this token (bead `sq-cxk5` — both transports
+> must gate together when it lands). The server binds **loopback by default** and **refuses a non-loopback
 > bind** (e.g. `0.0.0.0`) unless you set `--allow-remote` (env `SPARQ_ALLOW_REMOTE=1`) OR the
 > whole surface is authenticated (`--auth-token` AND `--auth-token-read`) — a write-token
 > alone still leaves reads open. Deliver the token over TLS (terminate it at a proxy). For
@@ -91,7 +92,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 Library surface re-exported from `sparq_server` (behind the default `server` feature):
 
 - `fn router(state: AppState) -> axum::Router` — builds the hardened endpoint router
-  (`/sparql`, `/sparql/graph`, `/graphs/*path`, `/subscriptions`, `/health`, `/metrics`).
+  (`/sparql`, `/sparql/graph`, `/graphs/*path`, `/subscriptions`, `/subscriptions/sse`,
+  `/health`, `/metrics`). [OPUS-4.8] sq-bxog: `/subscriptions/sse` is the SSE transport.
 - `AppState::new(graph: Graph) -> AppState` — default `ServerConfig`.
 - `AppState::with_config(graph: Graph, config: ServerConfig) -> AppState`.
 - `AppState::current(&self) -> PinnedGen` — lock-free pin of the current immutable
@@ -199,6 +201,38 @@ server:  {"unsubscribed": {"id": 1}}
 ```
 `addedResults`/`removedResults` are each full SPARQL-JSON results objects. Refusals and
 failed re-evaluations come back as `{"error": {"message": …, "id"?: n}}`.
+
+**4b. SSE subscriptions (`text/event-stream`).** [OPUS-4.8] sq-bxog: the SAME subscription
+engine over Server-Sent Events, for clients that prefer a plain HTTP GET stream to a
+WebSocket. `GET /subscriptions/sse?query=<SELECT>[&alias=<x>]` opens one subscription per
+stream (the query is in the query string — SSE is one-way, so there is no `subscribe`/
+`unsubscribe` frame; close the stream to unsubscribe). The events carry the SAME JSON as
+the WS path — only the framing differs (`event:` / `data:` / `id:` lines, blank-line
+terminated, `: ping` keep-alive comments hold idle connections open). The SSE `id:` mirrors
+the per-subscription `sequence`.
+
+```sh
+curl -N 'http://127.0.0.1:3030/subscriptions/sse?query=SELECT%20?s%20WHERE%20{%20?s%20%3Chttp://ex/age%3E%20?o%20}&alias=ages'
+```
+```text
+event: subscribed
+data: {"subscribed":{"id":1,"alias":"ages"}}
+
+event: notification
+id: 0
+data: {"notification":{"id":1,"sequence":0,"alias":"ages","addedResults":{…full result…},"removedResults":{…empty…}}}
+
+  …POST /sparql update commits…
+event: notification
+id: 1
+data: {"notification":{"id":1,"sequence":1,"alias":"ages","addedResults":{…},"removedResults":{…}}}
+```
+A registration refusal (missing/non-SELECT/malformed `query` → `400`; capacity/budget →
+`503`) is returned as a normal `{"error":"…"}` JSON HTTP response BEFORE the stream opens —
+SSE cannot set a status once the stream is flowing. A later re-evaluation failure ends the
+stream with a final `event: error` frame. Both transports share one registry + change
+source, so the per-conn / server-wide subscription caps and the `sparq_active_subscriptions`
+gauge count SSE streams and WS subscriptions together.
 
 **5. Graph Store read + write + operational endpoints.**
 
@@ -359,8 +393,9 @@ and `update_in_place_with_budget`, and wrap calls in
   compared; QLever's `-a <token>`; missing-vs-wrong are indistinguishable). The classification
   keys on whether the request **mutates**, not the route — an Update smuggled through the
   query path is gated too. Add `--auth-token-read` (env `SPARQ_AUTH_TOKEN_READ=1`) to ALSO
-  gate reads. The `/subscriptions` WS is a read surface and is NOT gated by this token (bead
-  `sq-cxk5`). The binary binds `127.0.0.1:3030` by default and **refuses** a non-loopback
+  gate reads. The subscription transports (`/subscriptions` WS + `/subscriptions/sse` SSE)
+  are a read surface and are NOT gated by this token (bead `sq-cxk5`). The binary binds
+  `127.0.0.1:3030` by default and **refuses** a non-loopback
   `--addr` (incl. `0.0.0.0`/`::`) unless `--allow-remote` / `SPARQ_ALLOW_REMOTE=1` OR the
   whole surface is authenticated (`--auth-token` AND `--auth-token-read`); even then it warns.
   A write-token alone still leaves reads open, so it does NOT by itself make a remote bind


### PR DESCRIPTION
> 🤖 _SPARQ agent_

Adds a Server-Sent Events (`text/event-stream`) transport for SPARQL update subscriptions
(SEPA-style), alongside the existing WebSocket `/subscriptions`. Both transports share one
subscription registry + change-detection source — SSE is just an alternate wire format.

### Endpoint shape

`GET /subscriptions/sse?query=<SELECT>[&alias=<x>]` — one subscription per stream (SSE is a
one-way GET, so the query rides the query string; there is no `subscribe`/`unsubscribe`
frame — close the stream to unsubscribe). The response is `text/event-stream` and the first
two frames are the `subscribed` ack and the sequence-0 `notification` (full result as
`addedResults`); each later committed UPDATE that changes the result yields a
`notification` diff frame (`event:` / `data:` / `id:` lines, blank-line terminated). The
SSE `id:` mirrors the per-subscription `sequence`. The JSON carried is byte-for-byte the
same as the WS path.

```text
event: subscribed
data: {"subscribed":{"id":1,"alias":"ages"}}

event: notification
id: 0
data: {"notification":{"id":1,"sequence":0,"alias":"ages","addedResults":{…},"removedResults":{…}}}
```

### How it reuses the WS subscription engine

The re-evaluate + diff core and the register-a-subscription core were extracted from the WS
path into two transport-agnostic pieces — `Subscription::reevaluate_step` and
`subscribe_init` — and the WS handler was rewritten to call them (behaviour preserved; all
13 existing WS subscription tests pass unchanged). SSE drives the SAME pieces:

- same commit-generation `watch` channel (`AppState::subscribe_commits`) as the change source;
- same `ConnSlots` global + per-connection cap accounting (one stream = one slot);
- same `sparq_active_subscriptions` metric counts WS + SSE together;
- same initial-eval refusal semantics (timeout / max-rows).

Only the wire framing differs (axum `Sse`/`Event` instead of WS `Message::Text`).

### Operational details

- Keep-alive `: ping` comment every 15 s holds idle connections open across proxies.
- Clean per-client disconnect: the stream's state (holding the `ConnSlots`) drops when the
  client goes away, releasing the global slot via `Drop` — no leak (integration-tested).
- Registration refusals (missing/non-SELECT/malformed query → 400; capacity/budget → 503)
  surface as a real HTTP status + `{"error":"…"}` body BEFORE the stream opens; a later
  re-evaluation failure ends the stream with a final `event: error` frame.

### Auth parity

Mirrors the WS `/subscriptions` path, which is itself NOT auth-gated today. Gating both
subscription transports behind the read token is tracked under bead `sq-cxk5` — when it
lands, both must gate together (noted in code + `skills/http-server/SKILL.md`).

### Tests

`crates/sparq-server/tests/subscriptions_sse.rs` (7 tests): register → `subscribed` +
initial-result frames; UPDATE → asserted `addedResults` diff frame; non-matching UPDATE →
silence; dropped stream releases its global slot (no leak); and 400/503 refusal statuses.

Gate: `cargo test -p sparq-server` (all pass) + `cargo clippy -p sparq-server --all-targets
-- -D warnings` (clean). Diff kept focused (no repo-wide rustfmt reflow, per the deferred
`cargo fmt --all` in-flight branches).

Refs bead sq-bxog. (Auth-gating parity with the WS path tracked under sq-cxk5.)

Public-API surface: new `subscriptions::sse` module (`sse_endpoint`) + `/subscriptions/sse`
route — documented in `skills/http-server/SKILL.md` per the public-API → SKILL rule.