### PR TITLE
fix(sparq-engine): WAL-durable named-graph CLEAR/DROP (sq-glw2)

### DIFF
--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -1982,24 +1982,72 @@ impl Graph {
     /// stays free of `mmap`-only fields.
     #[cfg(feature = "mmap")]
     fn drop_named_durable_dir(&mut self, idx: usize, dir: &std::path::Path) -> Result<bool, String> {
-        // Drop the entry in memory first; `self.named` is now the SURVIVING set in final order.
+        // [OPUS-4.8] (Copilot #123, Issue 1) Drop the entry in memory first; `self.named` is now
+        // the SURVIVING set in final order. RELEASE the removed sub-graph's mmap/WAL handles
+        // IMMEDIATELY (it is gone) so no live map points into `named/<idx>/` before the directory
+        // is removed/renamed below — required on Windows (a mapped file blocks dir removal), cheap
+        // and correct everywhere else.
         let removed = self.named.remove(idx);
+        drop(removed);
+        // Re-persist the renumbered survivor set in ONE staging swap (or tear the whole sub-tree
+        // down when none survive). Shared with the batch drop-all path.
+        self.persist_named_after_drop(dir)?;
+        Ok(true)
+    }
+
+    /// [OPUS-4.8] (sq-glw2, Copilot #123) DURABLY removes EVERY named graph in ONE manifest
+    /// rewrite + one staging swap — the batch DROP NAMED / named-part-of DROP ALL. Replaces the
+    /// engine's old loop that called [`drop_named_durable`](Self::drop_named_durable) once per
+    /// graph: each of those rebuilt the ENTIRE surviving named set (renumber + manifest rewrite),
+    /// making DROP ALL O(n²) in the number of named graphs. Clearing the whole set is O(n) — one
+    /// pass to release every sub-graph's handles, one manifest removal, one sub-tree removal — so
+    /// this routes straight through the no-survivors arm of [`persist_named_after_drop`].
+    ///
+    /// In-memory parent (or a non-`mmap` build): just clears the entries, matching the old
+    /// `self.named.clear()`. Idempotent — a no-op when there are no named graphs.
+    pub fn drop_all_named_durable(&mut self) -> Result<(), String> {
+        if self.named.is_empty() {
+            return Ok(());
+        }
+        // Release every sub-graph's mmap/WAL handles before any directory is touched (Issue 1/2:
+        // no live map may point into `named/<i>/` across the removal — correct on every platform,
+        // required on Windows where a mapped file blocks `remove_dir_all`/`rename`).
+        self.named.clear();
+        #[cfg(feature = "mmap")]
+        if let Some(dir) = self.wal.as_ref().map(|w| w.dir.clone()) {
+            return self.persist_named_after_drop(&dir);
+        }
+        Ok(())
+    }
+
+    /// [OPUS-4.8] (sq-glw2, Copilot #123) Crash-safe persistence of `self.named` AFTER a drop has
+    /// shrunk it (one entry, or all of them). `self.named` is already the SURVIVING set in final
+    /// order; the dropped sub-graphs' handles must already be released by the caller so no live
+    /// mmap/WAL points into the `named/` sub-tree being removed/renamed (cross-platform-safe;
+    /// required on Windows). Two cases:
+    ///
+    /// - NO survivors: the whole sub-tree + manifest go away (a default-only dir). The manifest is
+    ///   removed FIRST as the commit point, then the sub-tree — a crash after it leaves an orphan
+    ///   `named/` that `open_named` ignores (no manifest ⇒ no named graphs); `recover_named_drop`
+    ///   cleans up any staging siblings on the next open.
+    /// - SOME survivors: the renumbered survivors are written into a staging `named.drop-new/`,
+    ///   fsync'd, then swapped in (`named` → `drop-old`, `drop-new` → `named`) and the shrunk
+    ///   manifest rewritten — the same rollback-safe protocol as [`compact`](Self::compact),
+    ///   recovered by [`recover_named_drop`]. The survivors' OWN handles are released before the
+    ///   rename and re-acquired by re-`open`ing each from its new directory afterwards, so a live
+    ///   map never points into the directory being renamed (Issue 2; Windows-safe).
+    #[cfg(feature = "mmap")]
+    fn persist_named_after_drop(&mut self, dir: &std::path::Path) -> Result<(), String> {
         let named_dir = dir.join(NAMED_SUBDIR);
         let new_dir = named_dir.with_extension("drop-new");
         let old_dir = named_dir.with_extension("drop-old");
 
         if self.named.is_empty() {
-            // No survivors: the whole named sub-tree and manifest go away (a default-only dir).
-            // REMOVE the manifest as the commit point, then drop the sub-tree. Removing the
-            // manifest first means a crash after it leaves an orphan `named/` sub-tree that
-            // `open_named` ignores (no manifest ⇒ no named graphs); `recover_named_drop` cleans
-            // up any leftover staging siblings on the next open.
             remove_named_manifest(dir).map_err(|e| e.to_string())?;
             std::fs::remove_dir_all(&named_dir).ok();
             std::fs::remove_dir_all(&new_dir).ok();
             std::fs::remove_dir_all(&old_dir).ok();
-            drop(removed);
-            return Ok(true);
+            return Ok(());
         }
 
         // Build the renumbered survivor sub-tree in a fresh staging dir, fsync it, then swap.
@@ -2007,13 +2055,22 @@ impl Graph {
         std::fs::remove_dir_all(&old_dir).ok();
         std::fs::create_dir_all(&new_dir).map_err(|e| e.to_string())?;
         // Close every survivor's WAL before copying its directory so no open append handle is
-        // mid-flight across the swap (the re-open below re-acquires a fresh, correctly-indexed
-        // WAL). Then persist each survivor — folding any overlay — into its NEW positional slot.
-        for (i, (_, sub)) in self.named.iter_mut().enumerate() {
+        // mid-flight across the swap. Then persist each survivor — folding any overlay — into its
+        // NEW positional slot, capturing its name for the rebuilt manifest.
+        let mut names: Vec<Term> = Vec::with_capacity(self.named.len());
+        for (i, (name, sub)) in self.named.iter_mut().enumerate() {
             sub.wal = None;
             sub.save(&new_dir.join(i.to_string())).map_err(|e| e.to_string())?;
+            names.push(name.clone());
         }
         fsync_dir(&new_dir).map_err(|e| e.to_string())?;
+        // [OPUS-4.8] (Copilot #123, Issue 2) RELEASE every survivor's live mmap/WAL handles
+        // BEFORE the rename: each is now fully persisted under `new_dir`, so drop the in-memory
+        // `Graph`s (mmaps into the OLD `named/<i>/` included) and re-open from the new directories
+        // after the swap. Renaming/removing a directory with mapped files into it fails on
+        // Windows; releasing first makes the swap safe on every platform (mirrors `compact`, which
+        // likewise drops its handles via `*self = Graph::open(..)` after its swap).
+        self.named.clear();
         // Rollback-safe swap (mirrors `compact`): old aside, new in, parent fsync each rename.
         std::fs::rename(&named_dir, &old_dir).map_err(|e| e.to_string())?;
         fsync_dir(dir).map_err(|e| e.to_string())?;
@@ -2021,15 +2078,15 @@ impl Graph {
         fsync_dir(dir).map_err(|e| e.to_string())?;
         // The sub-tree is now the renumbered survivors. Commit the new set by rewriting the
         // manifest (atomic temp+rename, fsyncs the parent dir) — the commit point for the set.
-        let names: Vec<Term> = self.named.iter().map(|(n, _)| n.clone()).collect();
         write_named_manifest(dir, &names).map_err(|e| e.to_string())?;
         std::fs::remove_dir_all(&old_dir).ok();
-        // Re-open survivors from their NEW directories so each carries a correctly-indexed WAL.
-        for (i, (_, sub)) in self.named.iter_mut().enumerate() {
-            *sub = Graph::open(&named_dir.join(i.to_string())).map_err(|e| e.to_string())?;
+        // Re-open survivors from their NEW directories so each carries a correctly-indexed WAL
+        // (and a fresh, correctly-targeted mmap into the swapped-in `named/`).
+        for (i, name) in names.into_iter().enumerate() {
+            let sub = Graph::open(&named_dir.join(i.to_string())).map_err(|e| e.to_string())?;
+            self.named.push((name, sub));
         }
-        drop(removed);
-        Ok(true)
+        Ok(())
     }
 
     /// [`apply_delta`](Self::apply_delta) over the whole DATASET, parsing the batch
@@ -5934,6 +5991,55 @@ mod tests {
         let g2 = Graph::open(&dir).unwrap();
         assert_eq!(g2.named.len(), 0, "no named graphs resurrected; default graph intact");
         assert_eq!(g2.len(), 1, "the default-graph triple survives");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (sq-glw2, Copilot #123) The BATCH `drop_all_named_durable` (DROP NAMED / the
+    /// named part of DROP ALL) removes EVERY named sub-graph and the manifest durably in ONE
+    /// pass — no survivor renumbering — and leaves the directory as a clean default-only store
+    /// across a reopen. Exercises the O(n) batch path on a directory-backed dataset with several
+    /// named graphs: all gone after restart, default graph intact. (The old engine loop dropped
+    /// them one at a time, O(n²); this asserts the single-rewrite batch path produces the same
+    /// durable end-state.)
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn drop_all_named_durable_batch_survives_restart() {
+        let dir = std::env::temp_dir().join(format!("sparq_drop_all_named_batch_{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        Graph::load_dataset(
+            "<http://ex/d> <http://ex/p> <http://ex/e> .\n\
+             <http://ex/a1> <http://ex/p> <http://ex/o> <http://ex/g1> .\n\
+             <http://ex/a2> <http://ex/p> <http://ex/o> <http://ex/g2> .\n\
+             <http://ex/a3> <http://ex/p> <http://ex/o> <http://ex/g3> .\n\
+             <http://ex/a4> <http://ex/p> <http://ex/o> <http://ex/g4> .",
+            "nquads",
+        )
+        .unwrap()
+        .save(&dir)
+        .unwrap();
+        // Four positional sub-dirs + manifest before the batch drop.
+        assert!(dir.join("named.bin").exists());
+        for i in 0..4 {
+            assert!(dir.join("named").join(i.to_string()).exists(), "sub-dir {i} present before DROP ALL");
+        }
+        {
+            let mut g = Graph::open(&dir).unwrap();
+            assert_eq!(g.named.len(), 4);
+            // ONE batch call drops all four (no per-graph renumber/manifest-rewrite loop).
+            g.drop_all_named_durable().unwrap();
+            assert_eq!(g.named.len(), 0, "every named graph gone in memory after the batch drop");
+            // A second batch drop is an idempotent no-op (nothing left to remove).
+            g.drop_all_named_durable().unwrap();
+            assert_eq!(g.named.len(), 0);
+        }
+        // The whole named sub-tree + manifest are gone on disk (no staging siblings left behind).
+        assert!(!dir.join("named.bin").exists(), "manifest removed by the batch drop");
+        assert!(!dir.join("named").exists(), "named/ sub-tree removed by the batch drop");
+        assert!(!dir.join("named.drop-new").exists() && !dir.join("named.drop-old").exists());
+        // Restart: all named graphs stay gone; the default graph survives.
+        let g2 = Graph::open(&dir).unwrap();
+        assert_eq!(g2.named.len(), 0, "no named graph resurrected after restart");
+        assert_eq!(g2.len(), 1, "the default-graph triple survives the batch DROP ALL");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -1297,6 +1297,9 @@ impl Graph {
         // [OPUS-4.8] (review 1593) Finish or roll back any compaction directory swap that a
         // crash interrupted, so `dir` is always present (never lost in the rename window).
         recover_compaction(dir)?;
+        // [OPUS-4.8] (sq-glw2) Finish or roll back any named-graph DROP sub-tree swap a crash
+        // interrupted, so `named/` is always consistent with the manifest before `open_named`.
+        recover_named_drop(dir)?;
         let store = TripleStore::open(dir)?;
         // [OPUS-4.8] (review 1325, sub-finding 2) Prefer the mmap dictionary format
         // (`dict-meta.bin`, written by `save_mmap`); fall back to the LEGACY single-file
@@ -1915,6 +1918,120 @@ impl Graph {
         Ok(())
     }
 
+    /// [OPUS-4.8] (sq-glw2) DURABLY empties an EXISTING named sub-graph (CLEAR GRAPH `<g>` /
+    /// CLEAR NAMED of `name`) while PRESERVING the sub-graph's slot, directory and per-graph
+    /// WAL association — the durable replacement for `self.named[i].1 = empty_graph()`, which
+    /// (on a directory-backed parent) dropped the sub-graph's WAL/dir so the clear only became
+    /// durable at the next compaction. The retraction routes through the sub-graph's own
+    /// [`clear_default_durable`](Self::clear_default_durable), so for a directory-backed
+    /// sub-graph the deletions are WAL-logged + fsync'd (durable before this returns) and
+    /// survive a crash/reopen; the manifest is untouched (the slot stays). Returns `true` if a
+    /// matching named graph existed (and was emptied), `false` if it was absent — the caller
+    /// keeps the SPARQL CLEAR no-op-on-absent semantics. An in-memory parent's sub-graph just
+    /// clears its store in place (no WAL to keep), identical to the old behaviour. Available in
+    /// every build — the durability only kicks in for a directory-backed sub-graph (the in-memory
+    /// path of [`clear_default_durable`](Self::clear_default_durable) is a plain store clear).
+    pub fn clear_named_durable(&mut self, name: &Term) -> Result<bool, String> {
+        match self.named.iter().position(|(n, _)| n == name) {
+            Some(i) => {
+                self.named[i].1.clear_default_durable()?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    /// [OPUS-4.8] (sq-glw2) DURABLY removes an EXISTING named sub-graph (DROP GRAPH `<g>`): the
+    /// sub-graph ceases to exist — its on-disk directory AND its manifest entry are removed so
+    /// the removal survives a reopen IMMEDIATELY, not just at the next compaction. The old
+    /// `self.named.retain(...)` dropped the entry in memory only, leaving the on-disk
+    /// `named/<i>/` + manifest entry behind, so a reopen RESTORED the dropped graph.
+    ///
+    /// The named sub-tree is positional (`named/<i>/` ↔ `self.named[i]`) and the manifest's
+    /// presence is the commit point, so a drop must RENUMBER the surviving sub-graphs to stay
+    /// contiguous. To make that crash-safe we mirror [`compact`](Self::compact)'s rollback-safe
+    /// directory swap, scoped to the `named/` sub-tree: the renumbered survivors are built in a
+    /// staging `named.drop-new/`, fsync'd, then swapped in (`named` → `named.drop-old`,
+    /// `named.drop-new` → `named`), and only THEN is the shrunk manifest written (the manifest
+    /// rewrite is itself atomic+dir-fsync'd via [`write_named_manifest`]). An interrupted swap
+    /// is completed/rolled back deterministically by [`recover_named_drop`] on the next
+    /// [`open`](Self::open). Surviving sub-graphs are re-opened from their new directories so
+    /// each re-acquires a correctly-indexed per-graph WAL.
+    ///
+    /// Returns `true` if a matching named graph existed (and was removed), `false` if absent —
+    /// the caller keeps the SPARQL DROP no-op-on-absent semantics. An in-memory parent (or any
+    /// build without the `mmap` feature) simply drops the entry — there is no directory/manifest
+    /// to update, matching the old `self.named.retain(...)` behaviour.
+    pub fn drop_named_durable(&mut self, name: &Term) -> Result<bool, String> {
+        let Some(idx) = self.named.iter().position(|(n, _)| n == name) else {
+            return Ok(false);
+        };
+        // Directory-backed parent: durably remove the sub-dir + manifest entry. For an in-memory
+        // parent (or a non-mmap build) fall through to the plain in-memory entry removal below.
+        #[cfg(feature = "mmap")]
+        if let Some(dir) = self.wal.as_ref().map(|w| w.dir.clone()) {
+            return self.drop_named_durable_dir(idx, &dir);
+        }
+        self.named.remove(idx);
+        Ok(true)
+    }
+
+    /// [OPUS-4.8] (sq-glw2) The directory-backed half of [`drop_named_durable`](Self::drop_named_durable):
+    /// remove the in-memory entry then durably renumber/persist the surviving named sub-tree
+    /// (see that method's docs for the crash-safe swap protocol). Split out so the public method
+    /// stays free of `mmap`-only fields.
+    #[cfg(feature = "mmap")]
+    fn drop_named_durable_dir(&mut self, idx: usize, dir: &std::path::Path) -> Result<bool, String> {
+        // Drop the entry in memory first; `self.named` is now the SURVIVING set in final order.
+        let removed = self.named.remove(idx);
+        let named_dir = dir.join(NAMED_SUBDIR);
+        let new_dir = named_dir.with_extension("drop-new");
+        let old_dir = named_dir.with_extension("drop-old");
+
+        if self.named.is_empty() {
+            // No survivors: the whole named sub-tree and manifest go away (a default-only dir).
+            // REMOVE the manifest as the commit point, then drop the sub-tree. Removing the
+            // manifest first means a crash after it leaves an orphan `named/` sub-tree that
+            // `open_named` ignores (no manifest ⇒ no named graphs); `recover_named_drop` cleans
+            // up any leftover staging siblings on the next open.
+            remove_named_manifest(dir).map_err(|e| e.to_string())?;
+            std::fs::remove_dir_all(&named_dir).ok();
+            std::fs::remove_dir_all(&new_dir).ok();
+            std::fs::remove_dir_all(&old_dir).ok();
+            drop(removed);
+            return Ok(true);
+        }
+
+        // Build the renumbered survivor sub-tree in a fresh staging dir, fsync it, then swap.
+        std::fs::remove_dir_all(&new_dir).ok();
+        std::fs::remove_dir_all(&old_dir).ok();
+        std::fs::create_dir_all(&new_dir).map_err(|e| e.to_string())?;
+        // Close every survivor's WAL before copying its directory so no open append handle is
+        // mid-flight across the swap (the re-open below re-acquires a fresh, correctly-indexed
+        // WAL). Then persist each survivor — folding any overlay — into its NEW positional slot.
+        for (i, (_, sub)) in self.named.iter_mut().enumerate() {
+            sub.wal = None;
+            sub.save(&new_dir.join(i.to_string())).map_err(|e| e.to_string())?;
+        }
+        fsync_dir(&new_dir).map_err(|e| e.to_string())?;
+        // Rollback-safe swap (mirrors `compact`): old aside, new in, parent fsync each rename.
+        std::fs::rename(&named_dir, &old_dir).map_err(|e| e.to_string())?;
+        fsync_dir(dir).map_err(|e| e.to_string())?;
+        std::fs::rename(&new_dir, &named_dir).map_err(|e| e.to_string())?;
+        fsync_dir(dir).map_err(|e| e.to_string())?;
+        // The sub-tree is now the renumbered survivors. Commit the new set by rewriting the
+        // manifest (atomic temp+rename, fsyncs the parent dir) — the commit point for the set.
+        let names: Vec<Term> = self.named.iter().map(|(n, _)| n.clone()).collect();
+        write_named_manifest(dir, &names).map_err(|e| e.to_string())?;
+        std::fs::remove_dir_all(&old_dir).ok();
+        // Re-open survivors from their NEW directories so each carries a correctly-indexed WAL.
+        for (i, (_, sub)) in self.named.iter_mut().enumerate() {
+            *sub = Graph::open(&named_dir.join(i.to_string())).map_err(|e| e.to_string())?;
+        }
+        drop(removed);
+        Ok(true)
+    }
+
     /// [`apply_delta`](Self::apply_delta) over the whole DATASET, parsing the batch
     /// from two N-Quads documents (N-Triples is the default-graph subset): `deletes`
     /// first, then `inserts`, grouped and applied PER GRAPH — default-graph statements
@@ -2193,6 +2310,45 @@ fn recover_compaction(dir: &std::path::Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// [OPUS-4.8] (sq-glw2) Recover an INTERRUPTED [`drop_named_durable`](Graph::drop_named_durable)
+/// named-sub-tree swap so `named/` always ends up consistent with the manifest after any crash.
+/// Mirrors [`recover_compaction`] but scoped to the `named/` sub-tree (`named.drop-old` /
+/// `named.drop-new` siblings):
+///
+/// - `named/` present: the swap completed (or never started) — drop any stale siblings. The
+///   manifest is then reconciled by [`open_named`](Graph::open_named) (it trusts the manifest's
+///   count; extra leftover sub-dirs beyond it are ignored, a missing one surfaces as a clean
+///   error).
+/// - `named/` MISSING, `named.drop-new` present: a crash between the two renames — the new
+///   (renumbered survivor) sub-tree was fully written + fsync'd, so COMPLETE the swap by
+///   promoting it.
+/// - `named/` MISSING, only `named.drop-old` present: a crash before the new sub-tree was
+///   durable — ROLL BACK by restoring the old sub-tree (the manifest still matches it).
+///
+/// Run BEFORE [`open_named`](Graph::open_named) on every open. Best-effort and idempotent.
+#[cfg(feature = "mmap")]
+fn recover_named_drop(dir: &std::path::Path) -> std::io::Result<()> {
+    let named_dir = dir.join(NAMED_SUBDIR);
+    let new_dir = named_dir.with_extension("drop-new");
+    let old_dir = named_dir.with_extension("drop-old");
+    if named_dir.exists() {
+        std::fs::remove_dir_all(&new_dir).ok();
+        std::fs::remove_dir_all(&old_dir).ok();
+        return Ok(());
+    }
+    if new_dir.exists() {
+        // The new survivor sub-tree was fully written + fsync'd before the swap began.
+        std::fs::rename(&new_dir, &named_dir)?;
+        fsync_dir(dir)?;
+        std::fs::remove_dir_all(&old_dir).ok();
+    } else if old_dir.exists() {
+        // The new sub-tree never reached durability: restore the previous one.
+        std::fs::rename(&old_dir, &named_dir)?;
+        fsync_dir(dir)?;
+    }
+    Ok(())
+}
+
 /// [OPUS-4.8] (sq-3ui0, gh-45) The subdirectory holding the persisted named graphs (one
 /// numbered sub-directory per named graph), and the manifest file naming them in order.
 #[cfg(feature = "mmap")]
@@ -2257,6 +2413,21 @@ fn write_named_manifest(dir: &std::path::Path, names: &[Term]) -> std::io::Resul
     std::fs::rename(&tmp_path, &final_path)?;
     // fsync the dir holding `named.bin` so the rename (the commit) is itself durable.
     fsync_dir(dir)
+}
+
+/// [OPUS-4.8] (sq-glw2) Durably REMOVES the named-graph manifest `dir/named.bin` (the commit
+/// point when a [`drop_named_durable`](Graph::drop_named_durable) leaves NO named graphs): once
+/// the manifest is gone, [`open_named`](Graph::open_named) reports zero named graphs regardless
+/// of any leftover `named/` sub-tree (a crash after this leaves only an orphan sub-tree, cleaned
+/// up by [`recover_named_drop`]). The parent `dir` is fsync'd so the removal survives a crash.
+/// A no-op (success) when there is no manifest.
+#[cfg(feature = "mmap")]
+fn remove_named_manifest(dir: &std::path::Path) -> std::io::Result<()> {
+    match std::fs::remove_file(dir.join(NAMED_MANIFEST)) {
+        Ok(()) => fsync_dir(dir),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
 }
 
 /// [OPUS-4.8] (sq-3ui0) Serialise a graph-name term into the manifest buffer as
@@ -5646,6 +5817,123 @@ mod tests {
         // Reopen: the WAL-logged retractions replay, so the graph stays empty.
         let g2 = Graph::open(&dir).unwrap();
         assert_eq!(dump_terms(&g2).len(), 0, "durable CLEAR must survive the reopen");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (sq-glw2) `clear_named_durable` empties an EXISTING named sub-graph durably
+    /// (WAL-logged retraction) while PRESERVING its slot/dir/WAL — the named-graph twin of
+    /// `clear_default_durable_survives_reopen`. The pre-fix engine path did `entry.1 =
+    /// empty_graph()`, dropping the sub-graph's WAL so the clear survived only a compaction.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn clear_named_durable_survives_reopen() {
+        let dir = std::env::temp_dir().join(format!("sparq_clear_named_durable_{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        Graph::load_dataset(
+            "<http://ex/x> <http://ex/q> <http://ex/y> <http://ex/g1> .\n\
+             <http://ex/z> <http://ex/q> <http://ex/w> <http://ex/g1> .",
+            "nquads",
+        )
+        .unwrap()
+        .save(&dir)
+        .unwrap();
+        let g1 = |g: &Graph| g.named.iter().find(|(n, _)| n.to_string().contains("g1")).map(|(_, s)| s.len());
+
+        {
+            let mut g = Graph::open(&dir).unwrap();
+            assert_eq!(g1(&g), Some(2));
+            let cleared =
+                g.clear_named_durable(&Term::NamedNode(NamedNode::new_unchecked("http://ex/g1"))).unwrap();
+            assert!(cleared, "an existing graph reports cleared = true");
+            assert_eq!(g1(&g), Some(0), "cleared in memory, slot kept");
+            // A clear of an ABSENT graph is a no-op reporting false (CLEAR no-op-on-absent).
+            assert!(!g
+                .clear_named_durable(&Term::NamedNode(NamedNode::new_unchecked("http://ex/absent")))
+                .unwrap());
+        }
+        let g2 = Graph::open(&dir).unwrap();
+        assert_eq!(g1(&g2), Some(0), "durable CLEAR of a named graph survives the reopen (slot present, empty)");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (sq-glw2) `drop_named_durable` removes a named sub-graph's directory AND its
+    /// manifest entry durably (so a reopen does NOT resurrect it), renumbers the surviving
+    /// sub-tree to stay positional, and re-opens survivors with correctly-indexed WALs (a
+    /// post-drop mutation of a survivor persists). The pre-fix engine path did
+    /// `graph.named.retain(...)`, leaving `named/<i>/` + the manifest entry so a reopen brought
+    /// the dropped graph back.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn drop_named_durable_removes_subdir_and_manifest_and_renumbers() {
+        let dir = std::env::temp_dir().join(format!("sparq_drop_named_durable_{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        Graph::load_dataset(
+            "<http://ex/a1> <http://ex/p> <http://ex/o> <http://ex/g1> .\n\
+             <http://ex/a2> <http://ex/p> <http://ex/o> <http://ex/g2> .\n\
+             <http://ex/a3> <http://ex/p> <http://ex/o> <http://ex/g3> .",
+            "nquads",
+        )
+        .unwrap()
+        .save(&dir)
+        .unwrap();
+        let nn = |s: &str| Term::NamedNode(NamedNode::new_unchecked(s));
+        let count =
+            |g: &Graph, frag: &str| g.named.iter().find(|(n, _)| n.to_string().contains(frag)).map(|(_, s)| s.len());
+
+        {
+            let mut g = Graph::open(&dir).unwrap();
+            assert_eq!(g.named.len(), 3);
+            // The on-disk sub-tree has 3 positional sub-dirs before the drop.
+            assert!(dir.join("named").join("0").exists() && dir.join("named").join("2").exists());
+            // Drop the MIDDLE graph; g3 must renumber down a slot.
+            assert!(g.drop_named_durable(&nn("http://ex/g2")).unwrap(), "existing graph reports dropped = true");
+            assert_eq!(g.named.len(), 2);
+            assert_eq!(count(&g, "g2"), None);
+            // The highest old sub-dir is gone (3 -> 2 sub-dirs after renumber).
+            assert!(!dir.join("named").join("2").exists(), "drop renumbered the sub-tree to 2 contiguous slots");
+            // A post-drop mutation of a survivor proves its WAL was re-indexed correctly.
+            g.apply_delta_nquads("<http://ex/extra> <http://ex/p> <http://ex/o> <http://ex/g3> .", "").unwrap();
+            assert_eq!(count(&g, "g3"), Some(2));
+            // Dropping an ABSENT graph is a no-op reporting false (DROP no-op-on-absent).
+            assert!(!g.drop_named_durable(&nn("http://ex/absent")).unwrap());
+        }
+        // Reopen: dropped graph stays gone; survivors keep their (renumbered) contents.
+        let g2 = Graph::open(&dir).unwrap();
+        assert_eq!(g2.named.len(), 2, "exactly the two survivors after reopen");
+        assert_eq!(count(&g2, "g2"), None, "dropped graph is NOT resurrected on reopen");
+        assert_eq!(count(&g2, "g1"), Some(1));
+        assert_eq!(count(&g2, "g3"), Some(2), "renumbered survivor keeps its original + post-drop triple");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (sq-glw2) Dropping the LAST named graph removes the whole `named/` sub-tree
+    /// and the `named.bin` manifest, so the directory persists as a clean default-graph-only
+    /// store across a reopen.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn drop_last_named_graph_clears_manifest_and_subtree() {
+        let dir = std::env::temp_dir().join(format!("sparq_drop_last_named_{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        Graph::load_dataset(
+            "<http://ex/d> <http://ex/p> <http://ex/e> .\n\
+             <http://ex/x> <http://ex/q> <http://ex/y> <http://ex/only> .",
+            "nquads",
+        )
+        .unwrap()
+        .save(&dir)
+        .unwrap();
+        assert!(dir.join("named.bin").exists() && dir.join("named").exists());
+        {
+            let mut g = Graph::open(&dir).unwrap();
+            assert!(g
+                .drop_named_durable(&Term::NamedNode(NamedNode::new_unchecked("http://ex/only")))
+                .unwrap());
+            assert_eq!(g.named.len(), 0);
+        }
+        assert!(!dir.join("named.bin").exists(), "manifest removed when the last named graph is dropped");
+        let g2 = Graph::open(&dir).unwrap();
+        assert_eq!(g2.named.len(), 0, "no named graphs resurrected; default graph intact");
+        assert_eq!(g2.len(), 1, "the default-graph triple survives");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/sparq-engine/src/update.rs
+++ b/crates/sparq-engine/src/update.rs
@@ -13,7 +13,10 @@
 //! graph, CREATE of an existing one) are no-ops here — a graph store that auto-creates graphs
 //! is explicitly allowed to succeed on them — so `SILENT` only matters for LOAD.
 
-use crate::dataset::{build, decode_triples, empty_graph, TripleSet, TripleTerms};
+// [OPUS-4.8] (sq-glw2) `empty_graph` is now only needed by the tests — the named-graph
+// CLEAR/DROP arms route through the durable `Graph` methods instead of swapping in a fresh
+// in-memory graph — so it is imported locally in the test module rather than crate-wide.
+use crate::dataset::{build, decode_triples, TripleSet, TripleTerms};
 use oxrdf::{BlankNode, NamedOrBlankNode, Term, Variable};
 use rustc_hash::FxHashMap;
 use sparq_core::Graph;
@@ -598,11 +601,13 @@ fn record_delta(sink: &mut EffectSink, slot: &GraphSlot, inserts: &[TripleTerms]
 /// Applies a SPARQL Update IN PLACE through the store's DELTA-OVERLAY (roadmap T17): the data
 /// operations route to [`Graph::apply_delta`] per target graph — O(batch) per operation instead
 /// of the O(n) decode-everything-and-rebuild that [`update`] performs — and, for a
-/// directory-backed graph, each default-graph batch is WAL-logged (fsync'd) before it is
-/// applied, so updates are durable across a crash. `CLEAR`/`DROP` of the default graph still
-/// REPLACE it with an empty rebuild (this drops a directory-backed graph's WAL/directory
-/// association); named graphs are preserved across every operation. Fold the accumulated
-/// overlay back into the base periodically with [`Graph::compact`].
+/// directory-backed graph, each batch is WAL-logged (fsync'd) before it is applied, so updates
+/// are durable across a crash. [OPUS-4.8] (sq-glw2) `CLEAR`/`DROP` are durable BEFORE the ack on
+/// a directory-backed graph too: default-graph CLEAR/DROP retract via [`Graph::clear_default_durable`];
+/// named-graph CLEAR empties the slot via [`Graph::clear_named_durable`] (WAL-logged retraction,
+/// slot preserved) and named-graph DROP removes the sub-dir + manifest entry via
+/// [`Graph::drop_named_durable`]. Fold the accumulated overlay back into the base periodically
+/// with [`Graph::compact`].
 pub fn update_in_place(graph: &mut Graph, sparql: &str) -> Result<(), String> {
     update_in_place_with_budget(graph, sparql, &crate::QueryBudget::unlimited())
 }
@@ -672,42 +677,44 @@ fn update_in_place_core(
                     record_delta(&mut sink, &slot, &[], &del);
                 }
             }
+            // [OPUS-4.8] (sq-glw2) CLEAR keeps the named-graph SLOT but empties it. On a
+            // directory-backed parent, retract the existing graph's contents through its own WAL
+            // (`Graph::clear_named_durable`) so the emptied state is fsync'd BEFORE the ack — the
+            // old `entry.1 = empty_graph()` dropped the sub-graph's WAL/dir association, so the
+            // clear was durable only at the next compaction. Absent graph: a no-op; in-memory
+            // parent: a plain store clear (unchanged).
             GraphUpdateOperation::Clear { graph: target, .. } => {
                 match target {
                     GraphTarget::DefaultGraph => replace_default(graph)?,
                     GraphTarget::NamedNode(n) => {
-                        let name = Term::NamedNode(n.clone());
-                        if let Some(i) = graph.named.iter().position(|(g, _)| *g == name) {
-                            graph.named[i].1 = empty_graph();
-                        }
+                        graph.clear_named_durable(&Term::NamedNode(n.clone()))?;
                     }
-                    GraphTarget::NamedGraphs => {
-                        for entry in &mut graph.named {
-                            entry.1 = empty_graph();
-                        }
-                    }
+                    GraphTarget::NamedGraphs => clear_all_named_durable(graph)?,
                     GraphTarget::AllGraphs => {
                         replace_default(graph)?;
-                        for entry in &mut graph.named {
-                            entry.1 = empty_graph();
-                        }
+                        clear_all_named_durable(graph)?;
                     }
                 }
                 if let Some(s) = &mut sink {
                     s.push(UpdateEffect::Clear(target.clone()));
                 }
             }
+            // [OPUS-4.8] (sq-glw2) DROP makes the named graph cease to exist. On a directory-
+            // backed parent, `Graph::drop_named_durable` removes the sub-dir + manifest entry
+            // durably (fsync'd) so the removal survives a reopen immediately — the old
+            // `graph.named.retain(...)` dropped only the in-memory entry, leaving the on-disk
+            // sub-dir + manifest entry so a reopen RESTORED the dropped graph. Absent graph: a
+            // no-op; in-memory parent: a plain entry removal (unchanged).
             GraphUpdateOperation::Drop { graph: target, .. } => {
                 match target {
                     GraphTarget::DefaultGraph => replace_default(graph)?,
                     GraphTarget::NamedNode(n) => {
-                        let name = Term::NamedNode(n.clone());
-                        graph.named.retain(|(g, _)| *g != name);
+                        graph.drop_named_durable(&Term::NamedNode(n.clone()))?;
                     }
-                    GraphTarget::NamedGraphs => graph.named.clear(),
+                    GraphTarget::NamedGraphs => drop_all_named_durable(graph)?,
                     GraphTarget::AllGraphs => {
                         replace_default(graph)?;
-                        graph.named.clear();
+                        drop_all_named_durable(graph)?;
                     }
                 }
                 if let Some(s) = &mut sink {
@@ -788,36 +795,31 @@ pub fn apply_effects(graph: &mut Graph, effects: &[UpdateEffect]) -> Result<(), 
                 apply_slot_delta(graph, slot, &[], deletes)?;
                 apply_slot_delta(graph, slot, inserts, &[])?;
             }
+            // [OPUS-4.8] (sq-glw2) The durable mirror replays CLEAR/DROP through the SAME durable
+            // helpers the live path uses (`clear_named_durable` / `drop_named_durable`), so the
+            // mirror's named-graph clear/drop is WAL/manifest-durable before its ack too — not
+            // just at the next compaction (the old `empty_graph()`/`retain` swap dropped the
+            // sub-graph WAL / left the on-disk sub-dir, so the mirror would resurrect the data).
             UpdateEffect::Clear(target) => match target {
                 GraphTarget::DefaultGraph => replace_default(graph)?,
                 GraphTarget::NamedNode(n) => {
-                    let name = Term::NamedNode(n.clone());
-                    if let Some(i) = graph.named.iter().position(|(g, _)| *g == name) {
-                        graph.named[i].1 = empty_graph();
-                    }
+                    graph.clear_named_durable(&Term::NamedNode(n.clone()))?;
                 }
-                GraphTarget::NamedGraphs => {
-                    for entry in &mut graph.named {
-                        entry.1 = empty_graph();
-                    }
-                }
+                GraphTarget::NamedGraphs => clear_all_named_durable(graph)?,
                 GraphTarget::AllGraphs => {
                     replace_default(graph)?;
-                    for entry in &mut graph.named {
-                        entry.1 = empty_graph();
-                    }
+                    clear_all_named_durable(graph)?;
                 }
             },
             UpdateEffect::Drop(target) => match target {
                 GraphTarget::DefaultGraph => replace_default(graph)?,
                 GraphTarget::NamedNode(n) => {
-                    let name = Term::NamedNode(n.clone());
-                    graph.named.retain(|(g, _)| *g != name);
+                    graph.drop_named_durable(&Term::NamedNode(n.clone()))?;
                 }
-                GraphTarget::NamedGraphs => graph.named.clear(),
+                GraphTarget::NamedGraphs => drop_all_named_durable(graph)?,
                 GraphTarget::AllGraphs => {
                     replace_default(graph)?;
-                    graph.named.clear();
+                    drop_all_named_durable(graph)?;
                 }
             },
             UpdateEffect::Create(name) => {
@@ -837,9 +839,33 @@ fn replace_default(graph: &mut Graph) -> Result<(), String> {
     graph.clear_default_durable()
 }
 
+/// [OPUS-4.8] (sq-glw2) DURABLY empties EVERY named graph (CLEAR NAMED / the named part of
+/// CLEAR ALL), preserving each slot — mirrors a per-graph CLEAR GRAPH across the whole set. On a
+/// directory-backed parent each sub-graph's contents are WAL-logged + fsync'd before the ack.
+fn clear_all_named_durable(graph: &mut Graph) -> Result<(), String> {
+    let names: Vec<Term> = graph.named.iter().map(|(n, _)| n.clone()).collect();
+    for name in &names {
+        graph.clear_named_durable(name)?;
+    }
+    Ok(())
+}
+
+/// [OPUS-4.8] (sq-glw2) DURABLY removes EVERY named graph (DROP NAMED / the named part of DROP
+/// ALL). Each [`Graph::drop_named_durable`] renumbers the surviving sub-tree, so dropping by
+/// the head name each iteration is robust to the index shifts; on a directory-backed parent
+/// every removal's manifest update is fsync'd before the ack.
+fn drop_all_named_durable(graph: &mut Graph) -> Result<(), String> {
+    while let Some((name, _)) = graph.named.first() {
+        let name = name.clone();
+        graph.drop_named_durable(&name)?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dataset::empty_graph; // [OPUS-4.8] (sq-glw2) test-only now (see top-of-file note)
     use sparq_core::store::Pattern as IdPattern;
 
     fn count(g: &Graph) -> usize {

--- a/crates/sparq-engine/src/update.rs
+++ b/crates/sparq-engine/src/update.rs
@@ -850,16 +850,15 @@ fn clear_all_named_durable(graph: &mut Graph) -> Result<(), String> {
     Ok(())
 }
 
-/// [OPUS-4.8] (sq-glw2) DURABLY removes EVERY named graph (DROP NAMED / the named part of DROP
-/// ALL). Each [`Graph::drop_named_durable`] renumbers the surviving sub-tree, so dropping by
-/// the head name each iteration is robust to the index shifts; on a directory-backed parent
-/// every removal's manifest update is fsync'd before the ack.
+/// [OPUS-4.8] (sq-glw2, Copilot #123) DURABLY removes EVERY named graph (DROP NAMED / the named
+/// part of DROP ALL) in ONE batch. The old implementation looped, calling
+/// [`Graph::drop_named_durable`] once per graph — but EACH such call rebuilds the entire surviving
+/// named set (renumber + manifest rewrite + per-survivor save/re-open), making DROP ALL O(n²) in
+/// the number of named graphs. [`Graph::drop_all_named_durable`] tears the whole sub-tree down in
+/// a single manifest removal + single sub-tree removal (no survivors to renumber), which is O(n)
+/// — one pass to release every sub-graph's handles, then two unlinks.
 fn drop_all_named_durable(graph: &mut Graph) -> Result<(), String> {
-    while let Some((name, _)) = graph.named.first() {
-        let name = name.clone();
-        graph.drop_named_durable(&name)?;
-    }
-    Ok(())
+    graph.drop_all_named_durable()
 }
 
 #[cfg(test)]

--- a/crates/sparq-engine/tests/named_graph_durable_clear_drop.rs
+++ b/crates/sparq-engine/tests/named_graph_durable_clear_drop.rs
@@ -1,0 +1,294 @@
+//! [OPUS-4.8] (sq-glw2) End-to-end DURABILITY test for named-graph CLEAR / DROP through
+//! `update_in_place` on a DIRECTORY-BACKED store: the "204 ⇒ durable across restart" guarantee.
+//!
+//! The pre-fix in-place path emptied a named graph with `entry.1 = empty_graph()` — which on a
+//! directory-backed parent DROPPED the sub-graph's WAL/dir association, so the clear became
+//! durable only at the next compaction — and dropped one with `graph.named.retain(...)`, which
+//! left the on-disk `named/<i>/` sub-dir + manifest entry behind, so a reopen RESURRECTED the
+//! dropped graph. Both broke the durability contract that default-graph CLEAR
+//! (`clear_default_durable`) and named-graph INSERT/DELETE (`ensure_named` + WAL) already met.
+//!
+//! These tests build a real directory-backed graph (`save` then `open`, the out-of-core path,
+//! mmap from the sparq-core dev-dep), run the update, then SIMULATE A PROCESS RESTART by dropping
+//! the in-memory graph and re-`open`ing the directory, and assert the post-restart state. Mirrors
+//! `named_graph_persistence.rs` (the sq-7cxr/gh-45 persistence test) and is the engine-layer twin
+//! of sparq-core's `clear_named_durable_survives_reopen` / `drop_named_durable_*` unit tests.
+
+#![cfg(feature = "parallel")] // engine default; mmap comes from the sparq-core dev-dep
+
+use sparq_core::Graph;
+use sparq_engine::update_in_place;
+
+/// Triple count in a (sub-)graph via a full overlay-merged scan.
+fn rows(g: &Graph) -> usize {
+    g.store.scan(&[None, None, None]).rows.len()
+}
+
+/// The sub-graph whose name contains `frag`, if present.
+fn named<'a>(g: &'a Graph, frag: &str) -> Option<&'a Graph> {
+    g.named
+        .iter()
+        .find(|(n, _)| n.to_string().contains(frag))
+        .map(|(_, sub)| sub)
+}
+
+/// A unique temp dir per test, cleaned on entry.
+fn tmp(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("sparq_glw2_{tag}_{}", std::process::id()));
+    std::fs::remove_dir_all(&dir).ok();
+    dir
+}
+
+/// (1) CLEAR GRAPH <g>: INSERT into a named graph, CLEAR it, simulate restart (reload from the
+/// dir) — the named graph must be PRESENT-but-EMPTY (slot preserved, contents durably gone).
+#[test]
+fn clear_named_graph_survives_restart_present_but_empty() {
+    let dir = tmp("clear");
+    Graph::load_dataset(
+        "<http://ex/x> <http://ex/q> <http://ex/y> <http://ex/g1> .",
+        "nquads",
+    )
+    .unwrap()
+    .save(&dir)
+    .unwrap();
+
+    {
+        let mut g = Graph::open(&dir).unwrap();
+        update_in_place(
+            &mut g,
+            "PREFIX : <http://ex/> INSERT DATA { GRAPH :g1 { :a :b :c . :d :e :f } }",
+        )
+        .unwrap();
+        assert_eq!(
+            rows(named(&g, "g1").expect("g1 present")),
+            3,
+            "3 triples before CLEAR"
+        );
+        update_in_place(&mut g, "PREFIX : <http://ex/> CLEAR GRAPH :g1").unwrap();
+        assert_eq!(
+            rows(named(&g, "g1").expect("slot kept")),
+            0,
+            "CLEAR empties in memory"
+        );
+    } // drop closes the WAL/mmaps — on-disk state is the durability boundary.
+
+    // Restart: reopen from the directory. The cleared state must persist.
+    let g2 = Graph::open(&dir).unwrap();
+    let g1 = named(&g2, "g1").expect("CLEAR GRAPH must PRESERVE the (now empty) slot");
+    assert_eq!(
+        rows(g1),
+        0,
+        "CLEAR GRAPH must be durable: empty after restart, not resurrected"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// (2) DROP GRAPH <g>: INSERT into a named graph, DROP it, reload — the graph must be GONE
+/// (sub-dir + manifest entry removed durably), while a sibling named graph is preserved.
+#[test]
+fn drop_named_graph_survives_restart_gone() {
+    let dir = tmp("drop");
+    Graph::load_dataset(
+        "<http://ex/x> <http://ex/q> <http://ex/y> <http://ex/g1> .\n\
+         <http://ex/m> <http://ex/n> <http://ex/o> <http://ex/keep> .",
+        "nquads",
+    )
+    .unwrap()
+    .save(&dir)
+    .unwrap();
+
+    {
+        let mut g = Graph::open(&dir).unwrap();
+        update_in_place(
+            &mut g,
+            "PREFIX : <http://ex/> INSERT DATA { GRAPH :g1 { :a :b :c } }",
+        )
+        .unwrap();
+        assert!(named(&g, "g1").is_some() && named(&g, "keep").is_some());
+        update_in_place(&mut g, "PREFIX : <http://ex/> DROP GRAPH :g1").unwrap();
+        assert!(
+            named(&g, "g1").is_none(),
+            "DROP removes the entry in memory"
+        );
+        assert!(named(&g, "keep").is_some(), "sibling preserved");
+    }
+
+    // Restart: the dropped graph must NOT come back; the sibling must still be intact.
+    let g2 = Graph::open(&dir).unwrap();
+    assert!(
+        named(&g2, "g1").is_none(),
+        "DROP GRAPH must be durable: gone after restart, not resurrected"
+    );
+    let keep = named(&g2, "keep").expect("the un-dropped sibling must survive the restart");
+    assert_eq!(
+        rows(keep),
+        1,
+        "sibling's triple intact after the drop+restart"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// DROP of a MIDDLE graph among several must renumber the surviving positional sub-tree and
+/// survive a restart with the survivors' contents intact — exercises the `named/<i>/` ↔ manifest
+/// renumbering the durable drop performs, plus the survivors' WAL re-indexing.
+#[test]
+fn drop_middle_named_graph_renumbers_and_survives_restart() {
+    let dir = tmp("renumber");
+    Graph::load_dataset(
+        "<http://ex/a1> <http://ex/p> <http://ex/o> <http://ex/g1> .\n\
+         <http://ex/a2> <http://ex/p> <http://ex/o> <http://ex/g2> .\n\
+         <http://ex/a3> <http://ex/p> <http://ex/o> <http://ex/g3> .",
+        "nquads",
+    )
+    .unwrap()
+    .save(&dir)
+    .unwrap();
+
+    {
+        let mut g = Graph::open(&dir).unwrap();
+        assert_eq!(g.named.len(), 3);
+        update_in_place(&mut g, "PREFIX : <http://ex/> DROP GRAPH :g2").unwrap();
+        assert_eq!(g.named.len(), 2);
+        assert!(named(&g, "g2").is_none());
+        // Mutate a survivor AFTER the renumber to prove its WAL is correctly re-indexed.
+        update_in_place(
+            &mut g,
+            "PREFIX : <http://ex/> INSERT DATA { GRAPH :g3 { :extra :p :o } }",
+        )
+        .unwrap();
+        assert_eq!(rows(named(&g, "g3").expect("g3 present")), 2);
+    }
+
+    let g2 = Graph::open(&dir).unwrap();
+    assert_eq!(g2.named.len(), 2, "exactly the two survivors after restart");
+    assert!(
+        named(&g2, "g2").is_none(),
+        "dropped middle graph stays gone"
+    );
+    assert_eq!(rows(named(&g2, "g1").expect("g1 survives")), 1);
+    assert_eq!(
+        rows(named(&g2, "g3").expect("g3 survives")),
+        2,
+        "g3 (renumbered) keeps its original + post-drop triple across the restart"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// (3) SILENT vs non-SILENT CLEAR/DROP of a MISSING named graph keeps the existing
+/// auto-create-store semantics: a no-op SUCCESS either way, and the directory-backed store
+/// survives the no-op + restart unchanged. (SILENT is a no-op distinction for CLEAR/DROP here —
+/// see `update::update_contract`.)
+#[test]
+fn clear_drop_missing_named_graph_is_noop_success_with_and_without_silent() {
+    let dir = tmp("missing");
+    Graph::load_dataset(
+        "<http://ex/x> <http://ex/q> <http://ex/y> <http://ex/g1> .",
+        "nquads",
+    )
+    .unwrap()
+    .save(&dir)
+    .unwrap();
+
+    {
+        let mut g = Graph::open(&dir).unwrap();
+        for op in [
+            "CLEAR GRAPH <http://ex/absent>",
+            "CLEAR SILENT GRAPH <http://ex/absent>",
+            "DROP GRAPH <http://ex/absent>",
+            "DROP SILENT GRAPH <http://ex/absent>",
+        ] {
+            update_in_place(&mut g, op)
+                .unwrap_or_else(|e| panic!("{op} must be a no-op success, got: {e}"));
+        }
+        assert_eq!(rows(named(&g, "g1").expect("g1 untouched")), 1);
+    }
+    let g2 = Graph::open(&dir).unwrap();
+    assert_eq!(
+        rows(named(&g2, "g1").expect("g1 survives")),
+        1,
+        "no-op clear/drop of an absent graph leaves the store intact"
+    );
+    assert_eq!(g2.named.len(), 1);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// (4) The IN-MEMORY parent path is unchanged: named-graph CLEAR keeps the (empty) slot, DROP
+/// removes the entry, with no directory/WAL involved — byte-for-byte the previous behaviour.
+#[test]
+fn in_memory_parent_clear_keeps_slot_drop_removes_entry() {
+    let mut g = Graph::load_dataset(
+        "<http://ex/a> <http://ex/p> <http://ex/b> <http://ex/g1> .\n\
+         <http://ex/c> <http://ex/p> <http://ex/d> <http://ex/g2> .",
+        "nquads",
+    )
+    .unwrap();
+    assert_eq!(g.named.len(), 2);
+
+    update_in_place(&mut g, "PREFIX : <http://ex/> CLEAR GRAPH :g1").unwrap();
+    assert_eq!(g.named.len(), 2, "in-memory CLEAR keeps the slot");
+    assert_eq!(
+        rows(named(&g, "g1").expect("g1 slot kept")),
+        0,
+        "in-memory CLEAR empties it"
+    );
+
+    update_in_place(&mut g, "PREFIX : <http://ex/> DROP GRAPH :g2").unwrap();
+    assert!(
+        named(&g, "g2").is_none(),
+        "in-memory DROP removes the entry"
+    );
+    assert_eq!(g.named.len(), 1);
+
+    // CLEAR/DROP of a missing graph is a no-op success in memory too.
+    update_in_place(&mut g, "PREFIX : <http://ex/> CLEAR GRAPH :nope").unwrap();
+    update_in_place(&mut g, "PREFIX : <http://ex/> DROP GRAPH :nope").unwrap();
+    assert_eq!(g.named.len(), 1);
+}
+
+/// CLEAR ALL / DROP ALL on a directory-backed store: every named graph is durably emptied
+/// (CLEAR) or removed (DROP), surviving a restart.
+#[test]
+fn clear_all_then_drop_all_named_are_durable() {
+    let dir = tmp("all");
+    Graph::load_dataset(
+        "<http://ex/d> <http://ex/p> <http://ex/e> .\n\
+         <http://ex/a> <http://ex/p> <http://ex/o> <http://ex/g1> .\n\
+         <http://ex/b> <http://ex/p> <http://ex/o> <http://ex/g2> .",
+        "nquads",
+    )
+    .unwrap()
+    .save(&dir)
+    .unwrap();
+
+    {
+        let mut g = Graph::open(&dir).unwrap();
+        // CLEAR ALL empties the default graph AND every named graph (slots kept).
+        update_in_place(&mut g, "CLEAR ALL").unwrap();
+        assert_eq!(rows(&g), 0);
+        assert_eq!(
+            g.named.len(),
+            2,
+            "CLEAR ALL keeps the (now empty) named slots"
+        );
+        assert!(g.named.iter().all(|(_, s)| rows(s) == 0));
+    }
+    {
+        // Reopen: the cleared state is durable.
+        let mut g = Graph::open(&dir).unwrap();
+        assert_eq!(g.named.len(), 2);
+        assert!(
+            g.named.iter().all(|(_, s)| rows(s) == 0),
+            "CLEAR ALL durable across restart"
+        );
+        // Now DROP ALL: removes the default-graph content AND every named graph entry.
+        update_in_place(&mut g, "DROP ALL").unwrap();
+        assert_eq!(g.named.len(), 0);
+    }
+    let g3 = Graph::open(&dir).unwrap();
+    assert_eq!(
+        g3.named.len(),
+        0,
+        "DROP ALL removes every named graph durably"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
> 🤖 _SPARQ agent_

## The durability gap (sq-glw2, from-pss; follow-up to gh-44 / #80)

`update_in_place`'s named-graph CLEAR/DROP arms broke the **"204 ⇒ durable across restart"** guarantee on a directory-backed (`--persist`) store:

- **CLEAR GRAPH `<g>`** replaced the subgraph with `empty_graph()`. On a directory-backed parent this DROPPED the subgraph's WAL/dir association, so the clear was durable only at the **next compaction** — not WAL-fsync'd before the ack.
- **DROP GRAPH `<g>`** dropped only the in-memory entry (`Vec::retain`), leaving the on-disk `named/<i>/` subdir **and its manifest entry** behind — so a reopen **RESURRECTED** the dropped graph.

By contrast, default-graph CLEAR (`clear_default_durable`) and named-graph INSERT/DELETE (`ensure_named` + per-graph WAL) were already durable before ack. This PR closes the gap for named CLEAR/DROP, mirroring those existing patterns exactly — no new persistence mechanism.

## Mirroring `clear_default_durable`

- **CLEAR** (slot preserved): the existing subgraph is retracted via WAL-logged deletes through its own `clear_default_durable` (`Graph::clear_named_durable`). For a directory-backed subgraph the deletions are fsync'd before return; the manifest is untouched, so the slot stays present-but-empty.
- **DROP** (graph ceases to exist): `Graph::drop_named_durable` durably removes the subdir + manifest entry. Because the named subtree is **positional** (`named/<i>/` ↔ `named[i]`) and the manifest is the commit point, surviving subgraphs are **renumbered** via a crash-safe staging swap (`named.drop-new` → `named`, recovered by `recover_named_drop` on `open`, mirroring `compact`/`recover_compaction`), then the shrunk manifest is rewritten atomically (`write_named_manifest`), and survivors re-open with correctly-indexed WALs. Dropping the **last** named graph removes the manifest + subtree (clean default-only dir).

## Why a small sparq-core API was needed

The WAL dir, the manifest writer, the `named/<i>/` layout and the fsync helpers are all **private to sparq-core** — there is no existing public surface through which the engine could fsync the manifest/WAL. So this adds a minimal, focused public API that mirrors the established `create_durable_named` / `clear_default_durable` / `compact` idioms: `Graph::clear_named_durable`, `Graph::drop_named_durable` (+ private `recover_named_drop`, `remove_named_manifest`). Shipping CLEAR-durable-but-DROP-only-at-compaction would have been the partial guarantee the bead forbids.

## Preserved semantics

- SPARQL CLEAR/DROP `[SILENT]` on an absent graph stays a **no-op success** (auto-create store; the SHOULD-error precondition is unmet) — with and without SILENT, unchanged.
- The **in-memory** (non-directory-backed) parent path is byte-for-byte the old behaviour.
- The durable-mirror replay (`apply_effects`, the sq-7cxr/#80 path) routes named CLEAR/DROP through the same durable helpers, so the mirror is durable too.

## Restart tests

- **`tests/named_graph_durable_clear_drop.rs`** (engine integration, mirrors `named_graph_persistence.rs`): CLEAR survives restart present-but-empty; DROP survives restart gone (sibling preserved); **middle-graph DROP renumbers** + survives restart with a post-drop survivor mutation; CLEAR/DROP `[SILENT]` no-op on missing; in-memory parent unchanged; CLEAR ALL then DROP ALL durable.
- **sparq-core unit tests**: `clear_named_durable_survives_reopen`, `drop_named_durable_removes_subdir_and_manifest_and_renumbers`, `drop_last_named_graph_clears_manifest_and_subtree`.

## Gate

- `cargo test -p sparq-engine` — all pass (incl. the 6 new integration tests).
- `cargo clippy -p sparq-engine --all-targets -- -D warnings` — clean.
- `cargo test -p sparq-core --features mmap` + `cargo clippy -p sparq-core --features mmap --all-targets -- -D warnings` — all pass / clean.

Bead **sq-glw2**.