### PR TITLE
feat(sparq-engine): atomic multi-op SPARQL UPDATE — one durable commit (sq-ycle, #48)

### DIFF
--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -50,6 +50,15 @@ pub struct Graph {
     /// incremental updates. `None` for in-memory graphs (updates are overlay-only).
     #[cfg(feature = "mmap")]
     wal: Option<Wal>,
+    /// [OPUS-4.8] (sq-ycle) The parent-level REDO JOURNAL (`dir/txn.log`) for a DIRECTORY-BACKED
+    /// graph — the SINGLE atomic commit point for a whole multi-operation SPARQL UPDATE body. The
+    /// resolved per-slot quad-delta of one `apply_effects` call is recorded here as ONE fsync'd
+    /// frame BEFORE it is materialised across the per-graph WALs, so a crash mid-body can never
+    /// leave a PARTIAL durable write (e.g. parent containment without the child graph). On the next
+    /// `open` a committed frame is redone idempotently and the journal truncated. `None` for
+    /// in-memory graphs (the per-`apply_effects` commit/clear are then no-ops). See [`TxnJournal`].
+    #[cfg(feature = "mmap")]
+    txn: Option<TxnJournal>,
 }
 
 /// [OPUS-4.8] (sq-5lf) An IMMUTABLE, logically-independent point-in-time view of a
@@ -1062,6 +1071,9 @@ impl Graph {
             named: Vec::new(),
             #[cfg(feature = "mmap")]
             wal: None,
+            // [OPUS-4.8] (sq-ycle) In-memory graph: no parent-level redo journal.
+            #[cfg(feature = "mmap")]
+            txn: None,
         }
     }
 
@@ -1093,6 +1105,10 @@ impl Graph {
             named: self.named,
             #[cfg(feature = "mmap")]
             wal: self.wal,
+            // [OPUS-4.8] (sq-ycle) Re-encoding keeps the directory association — carry the redo
+            // journal handle with the WAL, so a compressed graph stays atomically durable.
+            #[cfg(feature = "mmap")]
+            txn: self.txn,
         }
     }
 
@@ -1340,7 +1356,7 @@ impl Graph {
         // with its own per-graph WAL) so a save→open round-trip is lossless for the whole
         // dataset. Empty for a default-graph-only / pre-named-graph directory.
         let named = Self::open_named(dir)?;
-        let mut g = Graph { dict, store, numerics, temporals, named, wal: None };
+        let mut g = Graph { dict, store, numerics, temporals, named, wal: None, txn: None };
         // Replay any write-ahead log into the delta-overlay (recovery after a crash or a
         // plain not-yet-compacted close), stopping cleanly at the first torn record and
         // truncating the log there — then keep the log open for further appends.
@@ -1352,7 +1368,58 @@ impl Graph {
             }
         }
         g.wal = Some(Wal::open(dir)?);
+        // [OPUS-4.8] (sq-ycle) AFTER the per-graph WALs are replayed (above + per named graph in
+        // `open_named`), redo any committed parent-level transaction frame, idempotently. A
+        // multi-op UPDATE body's resolved per-slot quad-delta is one atomic `txn.log` frame; if a
+        // crash interrupted materialisation after that single fsync, the per-graph WALs hold only a
+        // PREFIX of the body — replaying the frame heals the desync. Re-applying records the WALs
+        // already materialised is a no-op: `apply_delta_mem` is set-semantic (re-inserting a present
+        // triple / deleting an absent one changes nothing) and `ensure_named` is find-or-create.
+        // ORDER: read the frame, apply it in memory, THEN truncate the on-disk journal — so a crash
+        // before truncation simply redoes the (idempotent) frame again on the next open.
+        let txn_records = TxnJournal::replay(dir)?;
+        for (insert, slot, t) in txn_records {
+            g.redo_txn_record(insert, slot, t).map_err(std::io::Error::other)?;
+        }
+        let mut journal = TxnJournal::open(dir)?;
+        journal.truncate()?;
+        g.txn = Some(journal);
         Ok(g)
+    }
+
+    /// [OPUS-4.8] (sq-ycle) Idempotently re-apply one redo-journal record on `open`. A default-slot
+    /// record goes to this graph's default store; a named-slot record is routed to the matching
+    /// named sub-graph (find-or-create via [`ensure_named`](Self::ensure_named), so a frame whose
+    /// child-graph creation crashed before materialisation still rebuilds the graph). Set-semantic:
+    /// re-applying a change the per-graph WAL already materialised is a no-op.
+    #[cfg(feature = "mmap")]
+    fn redo_txn_record(&mut self, insert: bool, slot: Option<Term>, t: [Term; 3]) -> Result<(), String> {
+        match slot {
+            None => {
+                if insert {
+                    self.apply_delta_mem(&[t], &[]);
+                } else {
+                    self.apply_delta_mem(&[], &[t]);
+                }
+            }
+            Some(name) => {
+                // An insert into an absent named graph must materialise the graph (find-or-create);
+                // a delete from an absent one is a no-op (nothing to retract).
+                let idx = if insert {
+                    Some(self.ensure_named(&name)?)
+                } else {
+                    self.named.iter().position(|(n, _)| *n == name)
+                };
+                if let Some(i) = idx {
+                    if insert {
+                        self.named[i].1.apply_delta_mem(&[t], &[]);
+                    } else {
+                        self.named[i].1.apply_delta_mem(&[], &[t]);
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 
     /// EXTERNAL-MEMORY build: streams an RDF document and writes the on-disk permutation
@@ -1829,6 +1896,10 @@ impl Graph {
             named: self.named.iter().map(|(name, g)| (name.clone(), g.fork())).collect(),
             #[cfg(feature = "mmap")]
             wal: None,
+            // [OPUS-4.8] (sq-ycle) A fork/snapshot is a logically-independent in-memory copy with
+            // NO directory association — no WAL and no redo journal (like `wal: None`).
+            #[cfg(feature = "mmap")]
+            txn: None,
         }
     }
 
@@ -1883,6 +1954,37 @@ impl Graph {
             w.append_batch(inserts, deletes).map_err(|e| format!("WAL append failed: {e}"))?;
         }
         self.apply_delta_mem(inserts, deletes);
+        Ok(())
+    }
+
+    /// [OPUS-4.8] (sq-ycle) Commit a whole multi-operation UPDATE body's resolved per-slot
+    /// quad-delta as ONE atomic, all-or-nothing durable frame — the SINGLE commit point for
+    /// `sparq_engine::apply_effects`. `records` is `(is_insert, slot, triple)` quads computed
+    /// against the CURRENT graph state (so CLEAR/DROP have already been expanded to concrete
+    /// retraction records by the caller). One `write_all` + one `sync_data()` makes the body
+    /// durable as a unit BEFORE it is materialised across the per-graph WALs; if a crash interrupts
+    /// materialisation, [`open`](Self::open) redoes this frame idempotently. A NO-OP (returns `Ok`)
+    /// for an IN-MEMORY graph (no journal) and for an empty record set, so the in-memory live
+    /// update path is byte-for-byte unchanged.
+    pub fn commit_txn(&mut self, records: &[(bool, Option<Term>, [Term; 3])]) -> Result<(), String> {
+        #[cfg(feature = "mmap")]
+        if let Some(j) = &mut self.txn {
+            return j.append(records).map_err(|e| format!("txn journal commit failed: {e}"));
+        }
+        #[cfg(not(feature = "mmap"))]
+        let _ = records;
+        Ok(())
+    }
+
+    /// [OPUS-4.8] (sq-ycle) Clear the redo journal after its frame has been fully materialised into
+    /// the per-graph state (the second half of `sparq_engine::apply_effects`'s journal-first
+    /// protocol), so the next body starts from an empty journal and a clean reopen is a no-op. A
+    /// NO-OP for an in-memory graph (no journal).
+    pub fn clear_txn(&mut self) -> Result<(), String> {
+        #[cfg(feature = "mmap")]
+        if let Some(j) = &mut self.txn {
+            return j.truncate().map_err(|e| format!("txn journal clear failed: {e}"));
+        }
         Ok(())
     }
 
@@ -2689,6 +2791,218 @@ impl Wal {
                 break; // body record count disagreed with the header — corrupt
             }
             ops.extend(batch_ops);
+            good = trailer_end;
+        }
+        if good < bytes.len() {
+            let f = std::fs::OpenOptions::new().write(true).open(&path)?;
+            f.set_len(good as u64)?;
+            f.sync_data()?;
+        }
+        Ok(ops)
+    }
+}
+
+/// [OPUS-4.8] (sq-ycle) One resolved redo-journal record: `(is_insert, slot, triple)` — an
+/// insert/delete flag, the graph slot (`None` = default graph, `Some` = that named graph) and the
+/// term-triple. The unit the parent-level [`TxnJournal`] commits and [`Graph::commit_txn`] takes.
+#[cfg(feature = "mmap")]
+type TxnRecord = (bool, Option<Term>, [Term; 3]);
+
+/// [OPUS-4.8] (sq-ycle) Serialise a journal SLOT — the graph a record targets — into `buf`.
+/// A named slot reuses the manifest's [`encode_graph_name`] (kind 0 NamedNode / 1 BlankNode);
+/// the DEFAULT graph (`None`) gets a distinct marker byte (kind 2, no payload) so [`decode_slot`]
+/// can tell "default graph" apart from "named graph" unambiguously on replay.
+#[cfg(feature = "mmap")]
+fn encode_slot(buf: &mut Vec<u8>, slot: &Option<Term>) {
+    match slot {
+        Some(name) => encode_graph_name(buf, name),
+        // Default-graph marker: kind 2, no length/value (kinds 0/1 are NamedNode/BlankNode).
+        None => buf.push(2),
+    }
+}
+
+/// [OPUS-4.8] (sq-ycle) Inverse of [`encode_slot`]: decode a slot at `pos`, returning it plus the
+/// offset just past it. Kind 2 (no payload) is the default graph; 0/1 defer to [`decode_graph_name`]
+/// for a NamedNode/BlankNode. Bounds-checked — a truncated record is a clean `Err`, never a panic.
+#[cfg(feature = "mmap")]
+fn decode_slot(bytes: &[u8], pos: usize) -> Result<(Option<Term>, usize), String> {
+    match bytes.get(pos) {
+        Some(2) => Ok((None, pos + 1)),
+        Some(0) | Some(1) => {
+            let (term, end) = decode_graph_name(bytes, pos)?;
+            Ok((Some(term), end))
+        }
+        Some(k) => Err(format!("unknown txn slot kind byte {k}")),
+        None => Err("truncated txn record (missing slot kind byte)".to_string()),
+    }
+}
+
+/// [OPUS-4.8] (sq-ycle) A parent-level REDO JOURNAL — the single durable COMMIT POINT for a
+/// whole multi-operation SPARQL UPDATE body — at `dir/txn.log`, a sibling of the per-graph [`Wal`].
+///
+/// The problem it fixes: a multi-op body like `DROP SILENT GRAPH <r> ; INSERT DATA { GRAPH <r> ... ;
+/// GRAPH <parent> ldp:contains <r> }` materialises through [`apply_effects`] as N independent
+/// `apply_delta` calls across DIFFERENT files (the `<r>` per-graph `wal.log`, the `<parent>`
+/// per-graph `wal.log`, the `named.bin` manifest), each fsync'd on its own. A crash between them
+/// leaves a PARTIAL durable write (parent containment present but child graph missing, or vice
+/// versa). This journal records the WHOLE resolved per-slot quad-delta of one `apply_effects` call
+/// as ONE framed, checksummed, single-`sync_data()` frame. That single fsync is THE commit point;
+/// the per-graph WAL appends still happen but are now materialisation, not the commit point.
+///
+/// On [`open`](Graph::open), AFTER the per-graph WALs are replayed, any committed `txn.log` frame
+/// is replayed idempotently and then the journal is truncated. Idempotency holds because
+/// [`apply_delta_mem`](Graph::apply_delta_mem) is set-semantic (re-inserting a present triple /
+/// deleting an absent one is a no-op) and [`ensure_named`](Graph::ensure_named) is find-or-create —
+/// so re-applying records the per-graph WALs already materialised changes nothing.
+///
+/// Frame layout (byte-identical write+fsync discipline to [`Wal::append_batch`]):
+///
+/// ```text
+/// [TXN_MAGIC u32][n_records u32][body_len u32]   <- header
+/// <body_len bytes of records>                     <- each: [op u8][slot ...][nt_len u32][N-Triples]
+/// [checksum u64][COMMIT_MARKER u32]               <- commit trailer (written last)
+/// ```
+///
+/// where a record's SLOT is [`encode_slot`]'s `[kind u8]( [len u32][value] )?` and the triple is
+/// the N-Triples line + `u32` length, exactly as [`Wal::push_record`] frames it (so the same
+/// [`parse_nt_record`] decodes it). The FNV-1a [`Wal::checksum`] over header+body plus the trailing
+/// [`Wal::COMMIT_MARKER`] form the commit point: [`replay`](TxnJournal::replay) applies only frames
+/// whose trailer is present AND whose checksum matches, and truncates at the first torn/corrupt
+/// frame — so a torn frame is discarded WHOLE, never partially applied.
+#[cfg(feature = "mmap")]
+struct TxnJournal {
+    file: std::fs::File,
+}
+
+#[cfg(feature = "mmap")]
+impl TxnJournal {
+    const INSERT: u8 = 0;
+    const DELETE: u8 = 1;
+    /// Frame magic ("WTX1" little-endian) — distinct from `Wal::BATCH_MAGIC` so a `txn.log` frame
+    /// can never be mistaken for a `wal.log` batch (and vice versa) on a misdirected read.
+    const TXN_MAGIC: u32 = 0x31_58_54_57;
+
+    fn path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("txn.log")
+    }
+
+    fn open(dir: &std::path::Path) -> std::io::Result<TxnJournal> {
+        let file = std::fs::OpenOptions::new().create(true).append(true).open(Self::path(dir))?;
+        Ok(TxnJournal { file })
+    }
+
+    /// Frames `records` (each `(is_insert, slot, triple)`) into ONE checksummed frame and fsyncs —
+    /// THE single commit point for one `apply_effects` body. A crash mid-append leaves an
+    /// uncommitted tail that [`replay`](Self::replay) discards entirely. An empty record set is a
+    /// no-op (an UPDATE that resolves to no data change carries no atomicity obligation).
+    fn append(&mut self, records: &[TxnRecord]) -> std::io::Result<()> {
+        use std::io::Write;
+        if records.is_empty() {
+            return Ok(());
+        }
+        let mut body = Vec::new();
+        for (insert, slot, t) in records {
+            let op = if *insert { Self::INSERT } else { Self::DELETE };
+            body.push(op);
+            encode_slot(&mut body, slot);
+            // The triple as N-Triples + u32 length — byte-identical to `Wal::push_record`'s line
+            // form (minus the op byte, which we wrote before the slot above), so the same
+            // `parse_nt_record` decodes it on replay.
+            let line = format!("{} {} {} .\n", t[0], t[1], t[2]);
+            body.extend_from_slice(&(line.len() as u32).to_le_bytes());
+            body.extend_from_slice(line.as_bytes());
+        }
+        let mut buf = Vec::with_capacity(body.len() + 24);
+        buf.extend_from_slice(&Self::TXN_MAGIC.to_le_bytes());
+        buf.extend_from_slice(&(records.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&body);
+        // Checksum covers header + body; the commit marker is appended AFTER it so a torn write
+        // can't produce a valid-looking trailer (identical discipline to `Wal::append_batch`).
+        let crc = Wal::checksum(&buf);
+        buf.extend_from_slice(&crc.to_le_bytes());
+        buf.extend_from_slice(&Wal::COMMIT_MARKER.to_le_bytes());
+        self.file.write_all(&buf)?;
+        self.file.sync_data()
+    }
+
+    /// Empties the journal (after its frame has been materialised into the per-graph state).
+    fn truncate(&mut self) -> std::io::Result<()> {
+        self.file.set_len(0)?;
+        self.file.sync_data()
+    }
+
+    /// Reads `dir`'s journal into `(is_insert, slot, triple)` records in append order, frame by
+    /// frame. Only fully-COMMITTED frames (intact header + body + matching checksum + commit
+    /// marker) are returned; the file is TRUNCATED at the start of the first incomplete/corrupt
+    /// frame — the torn tail of an interrupted append — so a partial frame is NEVER partially
+    /// applied. EXACT clone of [`Wal::replay`]'s torn-tail logic, extended with the per-record slot.
+    fn replay(dir: &std::path::Path) -> std::io::Result<Vec<TxnRecord>> {
+        let path = Self::path(dir);
+        let bytes = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e),
+        };
+        let mut ops = Vec::new();
+        let mut good = 0usize; // end of the last fully-committed frame
+        'frames: while good < bytes.len() {
+            let bstart = good;
+            // Header: magic + n_records + body_len (12 bytes).
+            if bstart + 12 > bytes.len() {
+                break; // torn header
+            }
+            let rd = |o: usize| u32::from_le_bytes([bytes[o], bytes[o + 1], bytes[o + 2], bytes[o + 3]]);
+            if rd(bstart) != Self::TXN_MAGIC {
+                break; // not a txn frame (corruption / torn tail)
+            }
+            let n_records = rd(bstart + 4) as usize;
+            let body_len = rd(bstart + 8) as usize;
+            let body_start = bstart + 12;
+            let Some(body_end) = body_start.checked_add(body_len).filter(|&e| e <= bytes.len()) else {
+                break; // torn body
+            };
+            // Commit trailer: checksum (8) + marker (4).
+            let Some(trailer_end) = body_end.checked_add(12).filter(|&e| e <= bytes.len()) else {
+                break; // trailer not yet written — uncommitted frame
+            };
+            let stored_crc = u64::from_le_bytes(bytes[body_end..body_end + 8].try_into().expect("8 bytes"));
+            let marker = rd(body_end + 8);
+            if marker != Wal::COMMIT_MARKER || Wal::checksum(&bytes[bstart..body_end]) != stored_crc {
+                break; // uncommitted / corrupt frame — discard the tail
+            }
+            // The frame is committed: parse its records. A parse failure here means a
+            // committed-but-corrupt body — treat it as a torn tail and stop, conservatively.
+            let mut pos = body_start;
+            let mut frame_ops = Vec::with_capacity(n_records);
+            for _ in 0..n_records {
+                if pos >= body_end {
+                    break 'frames;
+                }
+                let op = bytes[pos];
+                pos += 1;
+                let Ok((slot, after_slot)) = decode_slot(&bytes[..body_end], pos) else {
+                    break 'frames;
+                };
+                pos = after_slot;
+                if pos + 4 > body_end {
+                    break 'frames;
+                }
+                let len = rd(pos) as usize;
+                let start = pos + 4;
+                let Some(end) = start.checked_add(len).filter(|&e| e <= body_end) else {
+                    break 'frames;
+                };
+                let Some(t) = parse_nt_record(&bytes[start..end]) else {
+                    break 'frames;
+                };
+                frame_ops.push((op == Self::INSERT, slot, t));
+                pos = end;
+            }
+            if frame_ops.len() != n_records {
+                break; // body record count disagreed with the header — corrupt
+            }
+            ops.extend(frame_ops);
             good = trailer_end;
         }
         if good < bytes.len() {
@@ -5806,6 +6120,209 @@ mod tests {
         // NONE of the three records may have applied — only the base triple remains.
         assert_eq!(dump_terms(&g).len(), 1, "uncommitted multi-record batch must apply nothing");
         assert_eq!(std::fs::read(&wal_path).unwrap().len(), 0, "the torn batch is the whole log → truncated empty");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // [OPUS-4.8] (sq-ycle) ---- atomic multi-op UPDATE redo journal (`txn.log`) -----------------
+
+    /// A unique temp dir per test (pid + a process-local counter) so the journal tests never
+    /// collide when run in parallel; cleaned with `remove_dir_all` at the end of each test.
+    #[cfg(feature = "mmap")]
+    fn txn_tmp_dir(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static CTR: AtomicU64 = AtomicU64::new(0);
+        let n = CTR.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("sparq_txn_{tag}_{}_{n}", std::process::id()))
+    }
+
+    /// [OPUS-4.8] (sq-ycle) The named-graph term used by the journal tests.
+    #[cfg(feature = "mmap")]
+    fn named(n: &str) -> Term {
+        Term::NamedNode(NamedNode::new_unchecked(format!("http://ex/{n}")))
+    }
+
+    /// [OPUS-4.8] (sq-ycle) The single named-graph triple the torn-tail test starts with.
+    #[cfg(feature = "mmap")]
+    fn base_named() -> Vec<(String, String, String)> {
+        vec![("<http://ex/n0>".into(), "<http://ex/p>".into(), "<http://ex/o0>".into())]
+    }
+
+    /// [OPUS-4.8] (sq-ycle) TORN-TAIL guarantee: a multi-slot redo frame (a default-graph record
+    /// PLUS a named-graph record) whose commit trailer + part of the last record were severed by a
+    /// crash must apply NOTHING on `open`, and the torn `txn.log` must be truncated to empty.
+    /// Mirrors `wal_torn_multi_record_batch_is_all_or_nothing` for the parent-level journal.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn txn_journal_torn_tail_is_all_or_nothing() {
+        let dir = txn_tmp_dir("torn");
+        std::fs::remove_dir_all(&dir).ok();
+        // Base graph with one default triple + one named graph holding one triple — so a torn
+        // frame redo would, if it leaked, change BOTH slots (and the assert below would fire).
+        Graph::load_dataset(
+            "<http://ex/base> <http://ex/p> <http://ex/o> .\n\
+             <http://ex/n0> <http://ex/p> <http://ex/o0> <http://ex/g> .",
+            "nquads",
+        )
+        .unwrap()
+        .save(&dir)
+        .unwrap();
+        let base = dump_terms(&Graph::open(&dir).unwrap());
+
+        // Write ONE valid frame with a default-slot insert AND a named-slot insert.
+        let records: Vec<(bool, Option<Term>, [Term; 3])> = vec![
+            (true, None, [term_iri(1, "s"), term_iri(1, "p"), term_iri(1, "o")]),
+            (true, Some(named("g")), [term_iri(2, "s"), term_iri(2, "p"), term_iri(2, "o")]),
+        ];
+        {
+            let mut j = TxnJournal::open(&dir).unwrap();
+            j.append(&records).unwrap();
+        }
+        let path = TxnJournal::path(&dir);
+        let full = std::fs::read(&path).unwrap();
+        assert!(full.len() > 24, "frame must have a header + body + trailer");
+        // Sever the commit trailer (last 12 bytes) AND part of the last record (a torn append).
+        let torn = &full[..full.len() - 12 - 5];
+        std::fs::write(&path, torn).unwrap();
+
+        let g = Graph::open(&dir).unwrap();
+        // NONE of the journaled records applied: the state equals the pre-frame base, and neither
+        // the default `s1` triple nor the named `s2` triple is present.
+        assert_eq!(dump_terms(&g), base, "torn frame must apply nothing to the default graph");
+        let gnamed = g.named.iter().find(|(n, _)| n == &named("g")).map(|(_, sub)| dump_terms(sub));
+        assert_eq!(gnamed, Some(base_named()), "torn frame must apply nothing to the named graph");
+        assert_eq!(std::fs::read(&path).unwrap().len(), 0, "torn journal is truncated to empty on open");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (sq-ycle) The PURE journal guarantee that underwrites atomicity: a committed
+    /// `txn.log` frame ALONE — with NO per-graph WAL materialisation at all — reconstructs the
+    /// FULL all-or-nothing record set on `open`, across BOTH the default graph and a named graph
+    /// (the PSS `INSERT DATA { GRAPH <r> ... ; GRAPH <parent> contains <r> }` shape). This is the
+    /// reliable simulation of "a crash after the single commit fsync but before materialisation":
+    /// the journal redo heals the desync. The journal is truncated afterwards.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn apply_effects_multi_slot_is_atomic_via_journal() {
+        let dir = txn_tmp_dir("multislot");
+        std::fs::remove_dir_all(&dir).ok();
+        // Empty base default graph; no named graphs yet (the frame must CREATE the named graph).
+        Graph::load_str("", "ntriples").unwrap().save(&dir).unwrap();
+
+        // The PSS body resolved to records: a child-graph triple under <r>, and a containment
+        // triple under <parent>. Commit them to the journal with NO materialisation, then close.
+        let r = named("r");
+        let parent = named("parent");
+        let child = [
+            term_iri(1, "x"),
+            Term::NamedNode(NamedNode::new_unchecked("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")),
+            named("Resource"),
+        ];
+        let contains = [
+            parent.clone(),
+            Term::NamedNode(NamedNode::new_unchecked("http://www.w3.org/ns/ldp#contains")),
+            r.clone(),
+        ];
+        let records: Vec<(bool, Option<Term>, [Term; 3])> = vec![
+            (true, Some(r.clone()), child.clone()),
+            (true, Some(parent.clone()), contains.clone()),
+        ];
+        {
+            let mut g = Graph::open(&dir).unwrap();
+            g.commit_txn(&records).unwrap(); // THE commit point — NO materialisation follows.
+            assert!(TxnJournal::path(&dir).metadata().unwrap().len() > 0, "frame must be on disk");
+            // Drop without materialising: simulates a crash right after the commit fsync.
+        }
+        // Reopen: the journal redo must reconstruct BOTH slots (child + containment), all-or-nothing.
+        let g = Graph::open(&dir).unwrap();
+        let r_sub = g.named.iter().find(|(n, _)| n == &r).map(|(_, s)| dump_terms(s));
+        let p_sub = g.named.iter().find(|(n, _)| n == &parent).map(|(_, s)| dump_terms(s));
+        assert_eq!(
+            r_sub,
+            Some(vec![(child[0].to_string(), child[1].to_string(), child[2].to_string())]),
+            "journal redo must materialise the child graph <r>"
+        );
+        assert_eq!(
+            p_sub,
+            Some(vec![(contains[0].to_string(), contains[1].to_string(), contains[2].to_string())]),
+            "journal redo must materialise the containment under <parent>"
+        );
+        assert_eq!(std::fs::read(TxnJournal::path(&dir)).unwrap().len(), 0, "journal truncated after redo");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (sq-ycle) An UNCOMMITTED frame (no commit trailer written — the crash landed
+    /// before the single fsync completed the trailer) must apply NOTHING and leave the pre-body
+    /// state intact; the torn tail is truncated.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn txn_uncommitted_frame_applies_nothing() {
+        let dir = txn_tmp_dir("uncommitted");
+        std::fs::remove_dir_all(&dir).ok();
+        Graph::load_str("<http://ex/base> <http://ex/p> <http://ex/o> .", "ntriples").unwrap().save(&dir).unwrap();
+        let base = dump_terms(&Graph::open(&dir).unwrap());
+
+        // A valid frame, then strip JUST the commit trailer (the last 12 bytes) — header + body
+        // present, no commit marker → an uncommitted frame.
+        let records: Vec<(bool, Option<Term>, [Term; 3])> =
+            vec![(true, None, [term_iri(9, "s"), term_iri(9, "p"), term_iri(9, "o")])];
+        {
+            let mut j = TxnJournal::open(&dir).unwrap();
+            j.append(&records).unwrap();
+        }
+        let path = TxnJournal::path(&dir);
+        let full = std::fs::read(&path).unwrap();
+        std::fs::write(&path, &full[..full.len() - 12]).unwrap(); // drop the commit trailer
+
+        let g = Graph::open(&dir).unwrap();
+        assert_eq!(dump_terms(&g), base, "uncommitted frame must apply nothing");
+        assert_eq!(std::fs::read(&path).unwrap().len(), 0, "uncommitted tail truncated to empty");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (sq-ycle) IDEMPOTENCY: a committed `txn.log` frame whose records were ALSO
+    /// already materialised into the per-graph WALs (the normal, crash-free case) must, on `open`,
+    /// yield EXACTLY the committed set — no duplicate triples (set semantics) — and truncate the
+    /// journal. This is what guarantees the redundant-on-crash redo is harmless in the happy path.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn txn_idempotent_when_already_materialized() {
+        let dir = txn_tmp_dir("idempotent");
+        std::fs::remove_dir_all(&dir).ok();
+        Graph::load_dataset(
+            "<http://ex/base> <http://ex/p> <http://ex/o> .\n\
+             <http://ex/n0> <http://ex/p> <http://ex/o0> <http://ex/g> .",
+            "nquads",
+        )
+        .unwrap()
+        .save(&dir)
+        .unwrap();
+
+        let g_default = [term_iri(1, "s"), term_iri(1, "p"), term_iri(1, "o")];
+        let g_named = [term_iri(2, "s"), term_iri(2, "p"), term_iri(2, "o")];
+        let records: Vec<(bool, Option<Term>, [Term; 3])> =
+            vec![(true, None, g_default.clone()), (true, Some(named("g")), g_named.clone())];
+        {
+            let mut g = Graph::open(&dir).unwrap();
+            // Commit the frame AND materialise the SAME records into the per-graph WALs (the
+            // crash-free path: both the journal and the per-graph WALs hold the change).
+            g.commit_txn(&records).unwrap();
+            g.apply_delta(std::slice::from_ref(&g_default), &[]).unwrap();
+            let i = g.ensure_named(&named("g")).unwrap();
+            g.named[i].1.apply_delta(std::slice::from_ref(&g_named), &[]).unwrap();
+        }
+        // Reopen: the per-graph WALs replay the records, THEN the journal redoes the SAME records —
+        // set semantics means no duplicates; the committed set is present exactly once.
+        let g = Graph::open(&dir).unwrap();
+        let mut def = dump_terms(&g);
+        def.retain(|(s, _, _)| s.contains("/s1"));
+        assert_eq!(def.len(), 1, "the default record is present exactly once (no duplicate)");
+        let nsub = g.named.iter().find(|(n, _)| n == &named("g")).map(|(_, s)| {
+            let mut v = dump_terms(s);
+            v.retain(|(x, _, _)| x.contains("/s2"));
+            v
+        });
+        assert_eq!(nsub.map(|v| v.len()), Some(1), "the named record is present exactly once");
+        assert_eq!(std::fs::read(TxnJournal::path(&dir)).unwrap().len(), 0, "journal truncated after idempotent redo");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -1373,14 +1373,25 @@ impl Graph {
         // multi-op UPDATE body's resolved per-slot quad-delta is one atomic `txn.log` frame; if a
         // crash interrupted materialisation after that single fsync, the per-graph WALs hold only a
         // PREFIX of the body — replaying the frame heals the desync. Re-applying records the WALs
-        // already materialised is a no-op: `apply_delta_mem` is set-semantic (re-inserting a present
-        // triple / deleting an absent one changes nothing) and `ensure_named` is find-or-create.
-        // ORDER: read the frame, apply it in memory, THEN truncate the on-disk journal — so a crash
-        // before truncation simply redoes the (idempotent) frame again on the next open.
+        // already materialised is a no-op: `apply_delta` replays with set semantics (re-inserting a
+        // present triple / deleting an absent one changes nothing) and `ensure_named` is
+        // find-or-create.
+        //
+        // [OPUS-4.8] (Copilot #135) DURABILITY ORDER (load-bearing): the records MUST be
+        // MATERIALISED INTO THE DURABLE PER-GRAPH WAL (`redo_txn_record` -> `apply_delta`, which
+        // appends + fsyncs) BEFORE the `txn.log` is truncated. The earlier code applied them with
+        // `apply_delta_mem` (IN-MEMORY only) and then truncated the journal, so a record that lived
+        // ONLY in `txn.log` — the precise crash window the journal exists for — was applied to this
+        // process's memory but written nowhere durable, then ERASED by the truncation, so it did NOT
+        // survive the NEXT restart. Re-logging into the WAL first (then truncate) makes the recovered
+        // state durable across any number of restarts; a re-crash between WAL-redo and truncation
+        // simply redoes the (idempotent) frame again on the next open.
         let txn_records = TxnJournal::replay(dir)?;
         for (insert, slot, t) in txn_records {
             g.redo_txn_record(insert, slot, t).map_err(std::io::Error::other)?;
         }
+        // Every committed record is now durably in a per-graph WAL (fsync'd by `apply_delta`); only
+        // NOW is it safe to truncate the journal that was the sole durable home of those records.
         let mut journal = TxnJournal::open(dir)?;
         journal.truncate()?;
         g.txn = Some(journal);
@@ -1392,14 +1403,24 @@ impl Graph {
     /// named sub-graph (find-or-create via [`ensure_named`](Self::ensure_named), so a frame whose
     /// child-graph creation crashed before materialisation still rebuilds the graph). Set-semantic:
     /// re-applying a change the per-graph WAL already materialised is a no-op.
+    ///
+    /// [OPUS-4.8] (Copilot #135) DURABILITY: the redo goes through the WAL-logged + fsync'd
+    /// [`apply_delta`](Self::apply_delta) (NOT the in-memory-only `apply_delta_mem`), so a record
+    /// that lived ONLY in `txn.log` — the exact crash window the journal exists for (crash AFTER
+    /// `commit_txn` fsync, BEFORE per-graph WAL materialisation) — is MATERIALISED into the durable
+    /// per-graph WAL on recovery. The caller truncates `txn.log` only AFTER every record has been
+    /// re-logged this way (see [`open`](Self::open)), so the recovered state survives ANY number of
+    /// subsequent restarts. Re-logging a record the per-graph WAL already holds is harmless: the WAL
+    /// replays with set semantics (re-inserting a present triple / deleting an absent one is a
+    /// no-op), so a re-crash mid-redo simply redoes the (idempotent) frame again.
     #[cfg(feature = "mmap")]
     fn redo_txn_record(&mut self, insert: bool, slot: Option<Term>, t: [Term; 3]) -> Result<(), String> {
         match slot {
             None => {
                 if insert {
-                    self.apply_delta_mem(&[t], &[]);
+                    self.apply_delta(&[t], &[])?;
                 } else {
-                    self.apply_delta_mem(&[], &[t]);
+                    self.apply_delta(&[], &[t])?;
                 }
             }
             Some(name) => {
@@ -1412,9 +1433,9 @@ impl Graph {
                 };
                 if let Some(i) = idx {
                     if insert {
-                        self.named[i].1.apply_delta_mem(&[t], &[]);
+                        self.named[i].1.apply_delta(&[t], &[])?;
                     } else {
-                        self.named[i].1.apply_delta_mem(&[], &[t]);
+                        self.named[i].1.apply_delta(&[], &[t])?;
                     }
                 }
             }
@@ -2850,10 +2871,15 @@ fn decode_slot(bytes: &[u8], pos: usize) -> Result<(Option<Term>, usize), String
 /// the per-graph WAL appends still happen but are now materialisation, not the commit point.
 ///
 /// On [`open`](Graph::open), AFTER the per-graph WALs are replayed, any committed `txn.log` frame
-/// is replayed idempotently and then the journal is truncated. Idempotency holds because
-/// [`apply_delta_mem`](Graph::apply_delta_mem) is set-semantic (re-inserting a present triple /
-/// deleting an absent one is a no-op) and [`ensure_named`](Graph::ensure_named) is find-or-create —
-/// so re-applying records the per-graph WALs already materialised changes nothing.
+/// is replayed idempotently and then the journal is truncated. [OPUS-4.8] (Copilot #135) The redo
+/// goes through the DURABLE [`apply_delta`](Graph::apply_delta) (WAL-logged + fsync'd), NOT the
+/// in-memory-only `apply_delta_mem`, and the truncation happens only AFTER every record is durably
+/// in a per-graph WAL — so a record that lived ONLY in `txn.log` (the crash-after-commit /
+/// before-materialisation window) is moved into durable storage on recovery and survives the NEXT
+/// restart, instead of being applied in-memory once and then erased by the truncation. Idempotency
+/// holds because [`apply_delta`](Graph::apply_delta) replays with set semantics (re-inserting a
+/// present triple / deleting an absent one is a no-op) and [`ensure_named`](Graph::ensure_named) is
+/// find-or-create — so re-applying records the per-graph WALs already materialised changes nothing.
 ///
 /// Frame layout (byte-identical write+fsync discipline to [`Wal::append_batch`]):
 ///
@@ -6247,6 +6273,119 @@ mod tests {
             "journal redo must materialise the containment under <parent>"
         );
         assert_eq!(std::fs::read(TxnJournal::path(&dir)).unwrap().len(), 0, "journal truncated after redo");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (Copilot #135) DOUBLE-RESTART DURABILITY (default graph): the load-bearing
+    /// regression test for the recovery-durability fix. A committed `txn.log` frame with NO
+    /// per-graph WAL materialisation (the crash-after-commit-fsync / before-materialisation window)
+    /// must be REDONE INTO THE DURABLE WAL on the first reopen and then SURVIVE a SECOND reopen.
+    ///
+    /// Under the OLD behaviour (`apply_delta_mem` then truncate) the first reopen applied the record
+    /// only IN MEMORY and erased `txn.log`, so the data was present after the first open but GONE
+    /// after the second — exactly the durability defect this asserts against. The second reopen is
+    /// what distinguishes "durable" from "in-memory-on-first-open".
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn txn_default_redo_survives_double_restart() {
+        let dir = txn_tmp_dir("double_default");
+        std::fs::remove_dir_all(&dir).ok();
+        Graph::load_str("<http://ex/base> <http://ex/p> <http://ex/o> .", "ntriples").unwrap().save(&dir).unwrap();
+
+        // Two default-graph inserts committed to the journal with NO materialisation, then dropped
+        // — simulating a crash right after the single commit fsync, before any per-graph WAL write.
+        let a = [term_iri(1, "s"), term_iri(1, "p"), term_iri(1, "o")];
+        let b = [term_iri(2, "s"), term_iri(2, "p"), term_iri(2, "o")];
+        let records: Vec<(bool, Option<Term>, [Term; 3])> = vec![(true, None, a.clone()), (true, None, b.clone())];
+        {
+            let mut g = Graph::open(&dir).unwrap();
+            g.commit_txn(&records).unwrap(); // THE commit point — NO materialisation follows.
+            assert!(TxnJournal::path(&dir).metadata().unwrap().len() > 0, "frame must be on disk");
+        }
+
+        let want = |g: &Graph| {
+            let d = dump_terms(g);
+            assert!(d.iter().any(|(s, _, _)| s.contains("/s1")), "record a must be present");
+            assert!(d.iter().any(|(s, _, _)| s.contains("/s2")), "record b must be present");
+            assert!(d.iter().any(|(s, _, _)| s.contains("/base")), "base must be present");
+        };
+
+        // First reopen: recovery REDOES the frame INTO THE DURABLE WAL, then truncates `txn.log`.
+        {
+            let g = Graph::open(&dir).unwrap();
+            want(&g);
+            assert_eq!(std::fs::read(TxnJournal::path(&dir)).unwrap().len(), 0, "journal truncated after redo");
+            // The WAL — not the (now empty) journal — must now hold the recovered records.
+            assert!(Wal::path(&dir).metadata().unwrap().len() > 0, "records must be durably in the per-graph WAL");
+        }
+        // SECOND reopen: `txn.log` is empty, so the data can ONLY come from the durable WAL. This is
+        // the assertion the OLD in-memory-only redo failed.
+        {
+            let g = Graph::open(&dir).unwrap();
+            want(&g);
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (Copilot #135) DOUBLE-RESTART DURABILITY (named graphs): the named-graph twin of
+    /// `txn_default_redo_survives_double_restart` — the PSS `INSERT DATA { GRAPH <r> ... ; GRAPH
+    /// <parent> contains <r> }` shape. A committed frame that CREATES a named graph and writes a
+    /// containment triple under another, with NO materialisation, must be redone into the durable
+    /// per-graph WALs on the first reopen and STILL be present after a SECOND reopen (`txn.log`
+    /// empty → the data must come from each sub-graph's own WAL).
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn txn_named_redo_survives_double_restart() {
+        let dir = txn_tmp_dir("double_named");
+        std::fs::remove_dir_all(&dir).ok();
+        Graph::load_str("", "ntriples").unwrap().save(&dir).unwrap();
+
+        let r = named("r");
+        let parent = named("parent");
+        let child = [
+            term_iri(1, "x"),
+            Term::NamedNode(NamedNode::new_unchecked("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")),
+            named("Resource"),
+        ];
+        let contains = [
+            parent.clone(),
+            Term::NamedNode(NamedNode::new_unchecked("http://www.w3.org/ns/ldp#contains")),
+            r.clone(),
+        ];
+        let records: Vec<(bool, Option<Term>, [Term; 3])> =
+            vec![(true, Some(r.clone()), child.clone()), (true, Some(parent.clone()), contains.clone())];
+        {
+            let mut g = Graph::open(&dir).unwrap();
+            g.commit_txn(&records).unwrap(); // THE commit point — NO materialisation follows.
+            assert!(TxnJournal::path(&dir).metadata().unwrap().len() > 0, "frame must be on disk");
+        }
+
+        let want = |g: &Graph| {
+            let r_sub = g.named.iter().find(|(n, _)| n == &r).map(|(_, s)| dump_terms(s));
+            let p_sub = g.named.iter().find(|(n, _)| n == &parent).map(|(_, s)| dump_terms(s));
+            assert_eq!(
+                r_sub,
+                Some(vec![(child[0].to_string(), child[1].to_string(), child[2].to_string())]),
+                "child graph <r> must be present"
+            );
+            assert_eq!(
+                p_sub,
+                Some(vec![(contains[0].to_string(), contains[1].to_string(), contains[2].to_string())]),
+                "containment under <parent> must be present"
+            );
+        };
+
+        // First reopen: recovery redoes the frame into each sub-graph's DURABLE WAL, then truncates.
+        {
+            let g = Graph::open(&dir).unwrap();
+            want(&g);
+            assert_eq!(std::fs::read(TxnJournal::path(&dir)).unwrap().len(), 0, "journal truncated after redo");
+        }
+        // SECOND reopen: `txn.log` empty → both records must come from the per-graph WALs (durable).
+        {
+            let g = Graph::open(&dir).unwrap();
+            want(&g);
+        }
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/sparq-engine/src/update.rs
+++ b/crates/sparq-engine/src/update.rs
@@ -787,7 +787,29 @@ fn update_in_place_core(
 /// Effects are applied in capture order, which is the order the in-memory side committed them
 /// (deletes before inserts within a DELETE/INSERT … WHERE), so order-sensitive sequences
 /// reproduce faithfully.
+///
+/// [OPUS-4.8] (sq-ycle) ATOMICITY: a multi-op body materialises through MANY independent
+/// `apply_delta` fsyncs across DIFFERENT files (the per-slot `wal.log`s + the `named.bin`
+/// manifest), so a crash between them used to leave a PARTIAL durable write (e.g. a `<parent>
+/// ldp:contains <r>` containment present without the `<r>` graph it points at). To make the WHOLE
+/// body ONE all-or-nothing durable commit we are now JOURNAL-FIRST, in four steps.
+///
+/// 1. RESOLVE every effect into a flat ordered quad-delta against the CURRENT graph state, so
+///    CLEAR/DROP expand to the concrete retractions of the triples present NOW.
+/// 2. [`Graph::commit_txn`] writes that delta as ONE fsync'd `txn.log` frame — THE commit point
+///    (a no-op for an in-memory graph and for an empty delta).
+/// 3. MATERIALISE via the existing per-effect loop; the per-graph WAL fsyncs here are now
+///    redundant-on-crash, not the commit point — correct, since `open` redoes the journal frame.
+/// 4. [`Graph::clear_txn`] empties the journal so the next body starts fresh.
+///
+/// For an IN-MEMORY graph (no journal/WAL) steps 2 & 4 are no-ops, so its behaviour is byte-for-byte
+/// unchanged. `DROP`'s manifest/sub-dir removal stays a materialisation concern (already crash-safe
+/// via `recover_named_drop`); the journal only carries the DATA retraction needed for atomicity.
 pub fn apply_effects(graph: &mut Graph, effects: &[UpdateEffect]) -> Result<(), String> {
+    // [OPUS-4.8] (sq-ycle) (1) RESOLVE + (2) COMMIT: the single durable commit point for the body.
+    let records = resolve_effect_records(graph, effects);
+    graph.commit_txn(&records)?;
+    // (3) MATERIALISE: the per-effect loop (unchanged from the pre-journal `apply_effects`).
     for effect in effects {
         match effect {
             UpdateEffect::Delta { slot, inserts, deletes } => {
@@ -827,7 +849,76 @@ pub fn apply_effects(graph: &mut Graph, effects: &[UpdateEffect]) -> Result<(), 
             }
         }
     }
+    // [OPUS-4.8] (sq-ycle) (4) The body is fully materialised into the per-graph state — clear the
+    // redo journal so the next body starts fresh and a clean reopen is a no-op (no-op in-memory).
+    graph.clear_txn()?;
     Ok(())
+}
+
+/// [OPUS-4.8] (sq-ycle) RESOLVE a captured `&[UpdateEffect]` into the flat, ORDERED quad-delta
+/// that the atomic redo journal commits in ONE fsync — computed against the CURRENT `graph` state
+/// so structural ops are concrete:
+///   * `Delta { slot, inserts, deletes }` -> the deletes (false) then the inserts (true), the same
+///     per-slot order [`apply_effects`] materialises them in.
+///   * `Clear`/`Drop` -> scan the affected slot(s) NOW and emit a delete record (false) for every
+///     triple PRESENT (default graph: scan `graph`; a NamedNode: scan that named sub-graph if it
+///     exists; NamedGraphs: every named slot; AllGraphs: every named slot PLUS the default). The
+///     data retraction is all the journal needs for atomicity — `Drop`'s manifest/sub-dir removal
+///     stays a materialisation concern (already crash-safe via `recover_named_drop`).
+///   * `Create(_)` -> nothing (an empty graph carries no triples).
+///
+/// The result is the per-slot quad-delta whose single-frame commit makes the WHOLE body atomic.
+fn resolve_effect_records(graph: &Graph, effects: &[UpdateEffect]) -> Vec<(bool, GraphSlot, TripleTerms)> {
+    let mut records: Vec<(bool, GraphSlot, TripleTerms)> = Vec::new();
+    // Retract every triple currently present in the named sub-graph called `name` (if any).
+    let push_named_clear = |records: &mut Vec<(bool, GraphSlot, TripleTerms)>, name: &Term| {
+        if let Some((_, sub)) = graph.named.iter().find(|(n, _)| n == name) {
+            for t in decode_triples(sub) {
+                records.push((false, Some(name.clone()), t));
+            }
+        }
+    };
+    // Retract every triple currently present in the DEFAULT graph.
+    let push_default_clear = |records: &mut Vec<(bool, GraphSlot, TripleTerms)>| {
+        for t in decode_triples(graph) {
+            records.push((false, None, t));
+        }
+    };
+    for effect in effects {
+        match effect {
+            UpdateEffect::Delta { slot, inserts, deletes } => {
+                for t in deletes {
+                    records.push((false, slot.clone(), t.clone()));
+                }
+                for t in inserts {
+                    records.push((true, slot.clone(), t.clone()));
+                }
+            }
+            // CLEAR and DROP retract the SAME data set (every present triple of the target); they
+            // differ only in DROP also removing the slot, which is a manifest/sub-dir concern, not
+            // a journalled DATA change. So both resolve to the present-triple retractions.
+            UpdateEffect::Clear(target) | UpdateEffect::Drop(target) => match target {
+                GraphTarget::DefaultGraph => push_default_clear(&mut records),
+                GraphTarget::NamedNode(n) => push_named_clear(&mut records, &Term::NamedNode(n.clone())),
+                GraphTarget::NamedGraphs => {
+                    let names: Vec<Term> = graph.named.iter().map(|(n, _)| n.clone()).collect();
+                    for name in &names {
+                        push_named_clear(&mut records, name);
+                    }
+                }
+                GraphTarget::AllGraphs => {
+                    push_default_clear(&mut records);
+                    let names: Vec<Term> = graph.named.iter().map(|(n, _)| n.clone()).collect();
+                    for name in &names {
+                        push_named_clear(&mut records, name);
+                    }
+                }
+            },
+            // CREATE adds an empty graph — no triples to journal.
+            UpdateEffect::Create(_) => {}
+        }
+    }
+    records
 }
 
 /// [OPUS-4.8] (review 1593) DURABLY empties the default graph, preserving the named graphs

--- a/crates/sparq-server/tests/persist.rs
+++ b/crates/sparq-server/tests/persist.rs
@@ -360,7 +360,7 @@ async fn pss_combined_multiop_body_accepted_and_atomic() {
 /// gh-48 all-or-nothing. A multi-op request whose LATER operation is invalid must leave NO
 /// partial write — the request fails (non-2xx) and the valid prefix is NOT committed (not in
 /// memory, and — on `--persist` — not on disk after a restart). This is the engine's
-/// request-level atomicity: the serve writer applies the body to a private fork and seals
+/// request-level atomicity: the server writer applies the body to a private fork and seals
 /// (and durably commits) ONLY on full success, so a rejected body never publishes or persists
 /// a prefix. (A non-SILENT `LOAD` of an unfetchable source is the reliable mid-body failure.)
 #[tokio::test]

--- a/crates/sparq-server/tests/persist.rs
+++ b/crates/sparq-server/tests/persist.rs
@@ -123,6 +123,21 @@ async fn count_rows(cl: &reqwest::Client, base: &str, query: &str) -> usize {
     body["results"]["bindings"].as_array().unwrap().len()
 }
 
+/// [OPUS-4.8] (sq-ycle) The boolean answer to an `ASK` query (the SPARQL JSON `boolean` field).
+async fn ask(cl: &reqwest::Client, base: &str, query: &str) -> bool {
+    let body: serde_json::Value = cl
+        .get(format!("{base}/sparql"))
+        .header("accept", "application/sparql-results+json")
+        .query(&[("query", query)])
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    body["boolean"].as_bool().unwrap()
+}
+
 /// The `value` field of the single binding of variable `var` for a one-row `query` (asserts
 /// exactly one row). Used to read back a non-deterministically-generated literal.
 async fn single_value(cl: &reqwest::Client, base: &str, query: &str, var: &str) -> String {
@@ -269,6 +284,110 @@ async fn nondeterministic_update_persists_committed_value_not_a_reroll() {
         persisted, live,
         "the persisted STRUUID() value must equal the value the live server acked — \
          the durable mirror must NOT re-execute (and thus re-roll) the update"
+    );
+    s2.stop().await;
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-ycle, gh-48) PSS combined multi-op update body: accepted as ONE request
+// AND committed ATOMICALLY (all-or-nothing) on the durable `--persist` path.
+// ---------------------------------------------------------------------------
+
+/// gh-48 (a)+(b). PSS's `putDocument`/`deleteResource` send ONE request body of `;`-separated
+/// operations — `DROP SILENT GRAPH <r> ; INSERT DATA { GRAPH <r> … ; GRAPH <parent> ldp:contains
+/// <r> }` — that rewrites the resource graph AND the parent's `ldp:contains` containment in a
+/// single shot. PSS's reconciler does NOT repair index-internal containment desync, so this body
+/// MUST be (a) accepted as one update request and (b) applied atomically: a single 204, with the
+/// child graph AND the parent containment triple BOTH present afterwards (never one without the
+/// other). This test sends PSS's exact shape, asserts the single 204 + the fully-applied post-state,
+/// then RESTARTS the `--persist` server to prove the WHOLE body is durable as one atomic commit
+/// (the [`sparq_engine`] txn-journal commit point, sq-ycle) — a crash mid-body can never leave the
+/// parent containment pointing at a child graph that did not survive (or vice versa).
+#[tokio::test]
+async fn pss_combined_multiop_body_accepted_and_atomic() {
+    const LDP_CONTAINS: &str = "http://www.w3.org/ns/ldp#contains";
+    const R: &str = "http://ex/pod/resource1";
+    const PARENT: &str = "http://ex/pod/";
+
+    let scratch = ScratchDir::new();
+    let cl = reqwest::Client::new();
+    let s1 = Server::start(persist_config(scratch.path())).await;
+
+    // The EXACT PSS combined body: DROP the resource graph, then in ONE INSERT DATA write the new
+    // resource content into GRAPH <r> AND the parent containment triple into GRAPH <parent>.
+    let body = format!(
+        "DROP SILENT GRAPH <{R}> ; \
+         INSERT DATA {{ \
+           GRAPH <{R}> {{ <{R}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#Resource> . \
+                          <{R}> <http://ex/title> \"hello\" }} \
+           GRAPH <{PARENT}> {{ <{PARENT}> <{LDP_CONTAINS}> <{R}> }} \
+         }}"
+    );
+
+    // (a) ACCEPTED: the `;`-separated multi-op body is one update request → a SINGLE 204.
+    assert_eq!(post_update(&cl, &s1.base, &body).await, 204, "the combined multi-op body must be accepted as ONE update (single 204)");
+
+    // (b) FULLY APPLIED: both halves of the body are present — the child graph content AND the
+    // parent containment triple. (No partial write: containment without the resource, or vice versa.)
+    let child = format!("SELECT * WHERE {{ GRAPH <{R}> {{ ?s ?p ?o }} }}");
+    let containment = format!("ASK WHERE {{ GRAPH <{PARENT}> {{ <{PARENT}> <{LDP_CONTAINS}> <{R}> }} }}");
+    assert_eq!(count_rows(&cl, &s1.base, &child).await, 2, "the child resource graph must be fully written");
+    assert!(ask(&cl, &s1.base, &containment).await, "the parent ldp:contains triple must be present");
+
+    // The whole body is ONE atomic durable commit: a restart re-opens both halves together.
+    s1.stop().await;
+    let s2 = Server::start(persist_config(scratch.path())).await;
+    assert_eq!(count_rows(&cl, &s2.base, &child).await, 2, "the child graph must survive the restart (durable)");
+    assert!(ask(&cl, &s2.base, &containment).await, "the parent containment must survive the restart, in lockstep with the child graph");
+
+    // A second putDocument-shaped body REPLACES the resource graph atomically and is durable too.
+    let body2 = format!(
+        "DROP SILENT GRAPH <{R}> ; \
+         INSERT DATA {{ \
+           GRAPH <{R}> {{ <{R}> <http://ex/title> \"updated\" }} \
+           GRAPH <{PARENT}> {{ <{PARENT}> <{LDP_CONTAINS}> <{R}> }} \
+         }}"
+    );
+    assert_eq!(post_update(&cl, &s2.base, &body2).await, 204);
+    assert_eq!(count_rows(&cl, &s2.base, &child).await, 1, "the DROP+re-INSERT replaced the resource graph atomically (old content gone)");
+    s2.stop().await;
+    let s3 = Server::start(persist_config(scratch.path())).await;
+    assert_eq!(count_rows(&cl, &s3.base, &child).await, 1, "the replacement survives a second restart");
+    assert!(ask(&cl, &s3.base, &containment).await);
+    s3.stop().await;
+}
+
+/// gh-48 all-or-nothing. A multi-op request whose LATER operation is invalid must leave NO
+/// partial write — the request fails (non-2xx) and the valid prefix is NOT committed (not in
+/// memory, and — on `--persist` — not on disk after a restart). This is the engine's
+/// request-level atomicity: the serve writer applies the body to a private fork and seals
+/// (and durably commits) ONLY on full success, so a rejected body never publishes or persists
+/// a prefix. (A non-SILENT `LOAD` of an unfetchable source is the reliable mid-body failure.)
+#[tokio::test]
+async fn invalid_second_op_leaves_no_partial_write() {
+    let scratch = ScratchDir::new();
+    let cl = reqwest::Client::new();
+    let s1 = Server::start(persist_config(scratch.path())).await;
+
+    // op 1 (valid INSERT DATA) ; op 2 (a non-SILENT LOAD that the engine refuses → request error).
+    let failing = "INSERT DATA { <http://ex/a> <http://ex/p> <http://ex/b> } ; LOAD <http://ex/nope.ttl>";
+    let status = post_update(&cl, &s1.base, failing).await;
+    assert!(!status.is_success(), "a multi-op body with an invalid op must be rejected (non-2xx), got {status}");
+
+    // The valid prefix must NOT have committed in memory (all-or-nothing).
+    assert_eq!(
+        count_rows(&cl, &s1.base, "SELECT * WHERE { <http://ex/a> ?p ?o }").await,
+        0,
+        "the valid INSERT DATA prefix must NOT be visible after a rejected multi-op request"
+    );
+
+    // …and nothing of it reached the durable store either: a restart shows an empty store.
+    s1.stop().await;
+    let s2 = Server::start(persist_config(scratch.path())).await;
+    assert_eq!(
+        count_rows(&cl, &s2.base, "SELECT * WHERE { ?s ?p ?o }").await,
+        0,
+        "a rejected multi-op request must persist NOTHING (no partial durable write)"
     );
     s2.stop().await;
 }

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -443,6 +443,19 @@ and `update_in_place_with_budget`, and wrap calls in
   published). `apply_update` **blocks** (group-commit + O(graph) fork) — never call it on the
   async runtime directly; the HTTP handler (and the GSP write verbs) already use
   `spawn_blocking`.
+- **Multi-operation update bodies are accepted and applied ATOMICALLY (one request, one
+  commit).** A SPARQL 1.1 Update request is a sequence of `;`-separated operations, and the
+  endpoint takes the WHOLE body as ONE update (it is never split on `;`): e.g. a Solid PSS
+  `putDocument` body — `DROP SILENT GRAPH <r> ; INSERT DATA { GRAPH <r> … ; GRAPH <parent>
+  ldp:contains <r> }` — is one request → a single `204`, with the resource graph AND the parent
+  containment triple either BOTH applied or (on any operation failing) NEITHER. The sequenced
+  writer applies the body to a private fork and publishes only on full success, so a partial
+  body is never visible (in-memory all-or-nothing). On `--persist` the whole body's resolved
+  delta is committed as ONE fsync'd transaction-journal frame BEFORE the `204`, so a crash
+  mid-body can never leave the parent `ldp:contains` desynced from the child graph it points at
+  (the journal redoes the whole frame, or none of it, on `Graph::open`). (sq-ycle / gh-48; see
+  `crates/sparq-server/tests/persist.rs::pss_combined_multiop_body_accepted_and_atomic` and
+  `::invalid_second_op_leaves_no_partial_write`.)
 - **GSP write created-vs-replaced status is advisory.** PUT/POST sample graph existence from
   the current generation to choose `201` vs `204`/`200`; the write itself is atomic on the
   sequenced writer regardless. An existing-but-empty named graph reads as absent (the engine


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead **sq-ycle** = issue #48 (filed by the PSS agent). I am the reserved single-server-branch agent.

PSS's `putDocument`/`deleteResource` send ONE combined update body of `;`-separated operations:
`DROP SILENT GRAPH <r> ; INSERT DATA { GRAPH <r> … ; GRAPH <parent> ldp:contains <r> }`.
Issue #48 asks two questions; both are now answered with a guarantee **and** a test.

## What I FOUND (empirical)

**(a) Is the multi-op `;`-separated body ACCEPTED as one request? — YES.**
The `application/sparql-update` body (and the `update=` form field) is passed through `Writer::submit` as ONE update (`http.rs::apply_update`); it is **never split on `;`**. spargebra parses the sequence into `upd.operations` and the engine (`update_in_place_core`) applies all of them in one pass.

**(b) Is it applied ATOMICALLY (all-or-nothing, single 2xx, no partial write)?**
- **In-memory (default server): already YES.** The sequenced writer applies the whole body to a private `fork`, then `seal`s → an atomic `ArcSwap` publish. On any operation error it discards the working copy and re-forks, so a partial body is **never** published. A failing body → `400`, nothing applied.
- **Durable `--persist` path (sq-7cxr): it was NOT atomic — this was a real PSS-correctness bug.** The durable mirror's `apply_effects` replayed the captured resolved-effect log via `Graph::apply_delta` → **one WAL `sync_data()` PER (operation, graph-slot), across DIFFERENT files** (the per-graph `wal.log`s for `<r>` and `<parent>`, plus the `named.bin` manifest for the DROP). So PSS's body became **3+ independent fsync'd commits**. A crash between them left a **partial durable write** — the parent `ldp:contains` present without the child graph it points at (or vice versa). PSS's reconciler does not repair index-internal containment desync, so per the bead this had to be fixed **at the engine**.

## What I CHANGED (`sparq-core` + `sparq-engine` only; + server test + SKILL.md)

A parent-level **redo journal** `TxnJournal` (`dir/txn.log`) — a sibling of the existing `Wal`, reusing its frame layout / FNV-1a checksum / `COMMIT_MARKER` + torn-tail recovery, with a per-record graph-slot column. `apply_effects` is now **journal-first**:
1. **Resolve** the WHOLE body to a flat, ordered per-slot quad-delta against current state (CLEAR/DROP expand to concrete retractions of present triples).
2. `Graph::commit_txn` writes it as **ONE fsync'd frame — THE single commit point** (no-op for in-memory / empty delta).
3. **Materialise** via the existing per-effect loop (the per-graph WAL fsyncs are now redundant-on-crash, not the commit point).
4. `Graph::clear_txn` empties the journal.

`Graph::open` redoes any committed journal frame **idempotently** (set-semantic `apply_delta_mem` + find-or-create `ensure_named`) after the per-graph WAL replay, then truncates it — so a crash either has the **full** frame (replays everything) or a **torn** one (replays nothing). For an in-memory durable graph, `commit_txn`/`clear_txn` are no-ops → behaviour is **byte-for-byte unchanged**.

## Tests added (all green)

- **sparq-core (mmap):** `txn_journal_torn_tail_is_all_or_nothing`, `apply_effects_multi_slot_is_atomic_via_journal` (PSS's `GRAPH <r>` + `GRAPH <parent> contains <r>` shape reconstructed from the journal alone), `txn_uncommitted_frame_applies_nothing`, `txn_idempotent_when_already_materialized`.
- **sparq-server (`tests/persist.rs`):** `pss_combined_multiop_body_accepted_and_atomic` — sends PSS's **exact** body, asserts a single **204**, asserts the child graph **and** the parent containment triple are **both** present, then **restarts** the `--persist` server and asserts both survive **together** (the atomic durable commit). `invalid_second_op_leaves_no_partial_write` — an invalid second op → non-2xx, valid prefix not visible and **nothing persists** across a restart.
- **Doc:** `skills/http-server/SKILL.md` now states multi-op bodies are accepted and applied atomically (one request, one commit) — in-memory and durable.

## Gate (run in the worktree)
- `cargo test -p sparq-server` ✅ (incl. the 2 new persist tests)
- `cargo test -p sparq-engine` ✅ (184 unit + integration)
- `cargo test -p sparq-core --features mmap` ✅ (82 unit incl. 4 new txn tests + integration)
- `cargo clippy -p sparq-server | -p sparq-engine | -p sparq-core --features mmap --all-targets -- -D warnings` ✅ clean
- `cargo fmt` deliberately **not** run repo-wide (the repo's `fmt --all` reformat is explicitly deferred / CI `fmt --check` is informational); new code hand-formatted to surrounding style.

## Known narrow edge (will file a follow-up bead)
CLEAR/DROP resolve against **pre-body** state, so an intra-body `INSERT into X ; CLEAR X` would not journal the just-inserted triple's retraction. This does **not** affect PSS (DROP precedes INSERT) nor the in-memory result.

`Closes #48`. Bead **sq-ycle**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)