### PR TITLE
docs: no-internals / spec-link convention for user-facing crate READMEs (sq-avp7)

### DIFF
--- a/crates/sparq-cli/README.md
+++ b/crates/sparq-cli/README.md
@@ -32,8 +32,8 @@ cargo run --release -p sparq-cli -- query data.ttl turtle 'SELECT * WHERE { ?s ?
 
 - **`query`** — load a file and run one query; SELECT/ASK output as table / tsv / csv / xml /
   json (`--format`), CONSTRUCT/DESCRIBE as N-Triples.
-- **`build` / `query-mmap`** — persist the six permutation indexes to disk, then query them
-  memory-mapped without loading the dataset into RAM.
+- **`build` / `query-mmap`** — build an on-disk index once, then query it memory-mapped
+  without loading the dataset into RAM.
 - **`bench`** — run a directory of `*.rq` queries N times each, one TSV timing line per query.
 - **`--reason <rdfs|owl-rl|n3>`** — opt-in forward-chaining materialization before query.
 - **Transparent decompression** — `.gz` / `.bz2` / `.zst` inputs detected by content.

--- a/crates/sparq-core/README.md
+++ b/crates/sparq-core/README.md
@@ -30,7 +30,8 @@ assert_eq!(count, 1);
 ## ✨ Features
 
 - **RDF parsing & ingest** — load Turtle, N-Triples, N-Quads, and TriG from a `&str` or any
-  `Read`, with transparent `.gz` / `.bz2` / `.zst` decompression
+  `Read`. `load_reader*` accepts any `Read`, so you can wrap a `gzip` / `bzip2` / `zstd`
+  decoder around your file and stream it in — sparq does not content-sniff or auto-decompress
   ([guide](../../skills/data-formats/SKILL.md)).
 - **Triple-pattern scans** — look up any triple pattern over the loaded graph.
 - **Incremental updates** — insert and delete triples in place, with an optional

--- a/crates/sparq-core/README.md
+++ b/crates/sparq-core/README.md
@@ -6,15 +6,12 @@
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
 </p>
 
-The **dictionary-encoded RDF triplestore** at the heart of [sparq](../../README.md): a
-`Graph` is a term dictionary plus six sorted permutation indexes.
+The **[RDF](https://www.w3.org/TR/rdf12-concepts/) triplestore** at the heart of
+[sparq](../../README.md) — the storage substrate every other sparq crate builds on.
 
-It is the storage substrate every other sparq crate builds on. Terms are interned to
-integer ids once; the six permutations (SPO/SOP/PSO/POS/OSP/OPS) make every triple-pattern
-shape an index range scan. Loaders are parallel and streaming, read the RDF text formats from
-a `&str` or any `Read` (wrap a `.gz` / `.bz2` / `.zst` decompressor to stream compressed input
-straight into the parse), and an out-of-core, memory-mapped store with optional
-block-compressed permutations queries datasets larger than RAM.
+Load [RDF 1.2](https://www.w3.org/TR/rdf12-concepts/) (named graphs and quoted triple terms
+included) from the text formats, in memory or out-of-core for datasets larger than RAM, and
+scan triple patterns. How the store is laid out and why is in the design docs linked below.
 
 ## 🚀 Quickstart
 
@@ -25,7 +22,6 @@ use sparq_core::Graph;
 let turtle = r#"<http://example.org/alice> a <http://schema.org/Person> ."#;
 let g = Graph::load_str(turtle, "turtle")?;
 
-// Range-scan a triple pattern over the permutation indexes.
 let count = g.len();
 assert_eq!(count, 1);
 # Ok(()) }
@@ -33,16 +29,16 @@ assert_eq!(count, 1);
 
 ## ✨ Features
 
-- **Dictionary encoding** — every term interned to a `u32` id once; storage and joins
-  operate on fixed-width integers, not strings.
-- **Six permutation indexes** — every BGP triple pattern is an index range scan; no
-  full-graph filtering.
-- **Parallel + streaming loaders** — Turtle / N-Triples / N-Quads / TriG from a `&str` or any
-  `Read`; a caller-supplied `.gz` / `.bz2` / `.zst` decompressor streams straight into the parse.
-- **Incremental updates** — delta-overlay inserts/deletes with an optional write-ahead log.
-- **Out-of-core store** — memory-mapped permutations (optional block compression) for
-  datasets larger than RAM, with near-zero resident heap.
-- **Named graphs & RDF 1.2** — full quad storage and structurally stored quoted triple terms.
+- **RDF parsing & ingest** — load Turtle, N-Triples, N-Quads, and TriG from a `&str` or any
+  `Read`, with transparent `.gz` / `.bz2` / `.zst` decompression
+  ([guide](../../skills/data-formats/SKILL.md)).
+- **Triple-pattern scans** — look up any triple pattern over the loaded graph.
+- **Incremental updates** — insert and delete triples in place, with an optional
+  write-ahead log.
+- **Out-of-core store** — query datasets larger than RAM from a memory-mapped on-disk store,
+  with optional block compression and near-zero resident heap.
+- **Named graphs & RDF 1.2** — full quad storage and
+  [quoted triple terms](https://www.w3.org/TR/rdf12-concepts/).
 
 ## 📚 Learn more
 

--- a/crates/sparq-engine/README.md
+++ b/crates/sparq-engine/README.md
@@ -6,14 +6,12 @@
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
 </p>
 
-The **SPARQL 1.1/1.2 query engine** over [`sparq-core`](../sparq-core) `Graph`s.
+The [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/) / [1.2](https://www.w3.org/TR/sparql12-query/)
+query engine over [`sparq-core`](../sparq-core) `Graph`s.
 
-It parses SPARQL to algebra (via `spargebra`), compiles the algebra to a physical plan with
-cardinality-based join ordering, and executes it in parallel over the permutation indexes —
-sort-merge, hash and worst-case-optimal joins. It runs SELECT / ASK / CONSTRUCT / DESCRIBE,
-the full FILTER built-in set, OPTIONAL / UNION / MINUS / VALUES / BIND, aggregation, all
-property-path operators, and named-graph dataset clauses, with EXPLAIN / EXPLAIN ANALYZE for
-plan introspection.
+Run conformant SPARQL over an in-memory or out-of-core graph, with `EXPLAIN` / `EXPLAIN ANALYZE`
+for plan introspection and a hook for registering your own functions. How it plans and executes
+queries is described in the design docs linked below.
 
 ## 🚀 Quickstart
 
@@ -32,15 +30,16 @@ let json = sparq_engine::query_json(&g, "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?
 
 ## ✨ Features
 
-- **SPARQL 1.1/1.2 query** — SELECT / ASK / CONSTRUCT / DESCRIBE, OPTIONAL / UNION / MINUS /
-  VALUES / BIND, sub-SELECT, aggregation + GROUP BY / HAVING, ORDER BY, DISTINCT, LIMIT/OFFSET.
-- **All 8 property-path operators** and full FILTER built-ins with XSD-aware comparisons.
-- **Cardinality-based planning** — greedy join ordering with sort-merge / hash / bind /
-  worst-case-optimal join selection; `EXPLAIN` and `EXPLAIN ANALYZE`.
-- **Named graphs** — `GRAPH`, FROM / FROM NAMED active-dataset scoping; zero-copy dataset views.
-- **RDF 1.2 / RDF-star** — quoted triple-term patterns (including variables inside them).
-- **Custom functions** — register Rust closures under function IRIs (SPARQL 17.6 extension
-  mechanism); see [`docs/extension-functions.md`](../../docs/extension-functions.md).
+- **SPARQL query** — run [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/) and
+  [1.2](https://www.w3.org/TR/sparql12-query/) over your data; conformance is tracked by the
+  CI ratchets (see the root [`README.md`](../../README.md)).
+- **Named graphs** — query across an active dataset with `GRAPH` and `FROM` / `FROM NAMED`.
+- **RDF 1.2 / RDF-star** — match [quoted triple terms](https://www.w3.org/TR/rdf12-concepts/),
+  including variables inside them.
+- **Query plan introspection** — `EXPLAIN` and `EXPLAIN ANALYZE`.
+- **Custom functions** — register Rust closures under function IRIs (the
+  [SPARQL extension mechanism](https://www.w3.org/TR/sparql11-query/#extensionFunctions));
+  see [`docs/extension-functions.md`](../../docs/extension-functions.md).
 - **`forbid(unsafe_code)`** — the crate contains zero `unsafe`.
 
 ## 📚 Learn more

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -14,8 +14,8 @@ on restart) or, with **`--persist <DIR>`**, **durable** (write-ahead-logged + fs
 on-disk index that survives a restart with no rebuild — see "Durable persistence"). Adds
 `Accept`-driven content negotiation (SELECT/ASK JSON/XML/CSV/TSV; CONSTRUCT/DESCRIBE + Graph
 Store N-Triples/Turtle/RDF-XML), EXPLAIN, Prometheus `/metrics`, WebSocket subscriptions, and
-an opt-in time-travel feature. Reads and writes never share a lock (a generation-ring snapshot
-chain + a single sequenced group-commit writer), so queries never wait on the writer.
+an opt-in time-travel feature. Reads and writes never share a lock, so queries never wait on
+the writer (the concurrency model is in the design doc linked below).
 
 ## Security posture (read before exposing)
 
@@ -123,9 +123,8 @@ Semantics:
   index. If `DIR` is empty/absent, the `DATA_FILE` seed (or an empty graph) is written there
   and opened.
 - **Back-compat.** Without `--persist` the behaviour is unchanged: in-memory, lost on restart.
-- **Atomicity.** Persistence rides on the existing generation-ring + sequenced-writer model —
-  a rejected update is never persisted (it is never published either), and the durable store
-  stays in lockstep with the published snapshot chain. The durable graph is written from the
+- **Atomicity.** A rejected update is never persisted (it is never published either), and the
+  durable store stays in lockstep with the published in-memory state. The durable graph is written from the
   **resolved delta** captured during the in-memory commit (not by re-executing the update text),
   so a non-deterministic or side-effecting update (`NOW()`/`RAND()`/`UUID()`/`BNODE()`,
   `LOAD <remote>`) persists the EXACT value that was acked — never a re-rolled one — so a restart


### PR DESCRIPTION
> 🤖 **SPARQ agent** — audit of human-facing docs for engine-internals leakage + SPARQL-spec-content enumeration, applying the convention the root README already follows (bead **sq-avp7**, P3 docs).

## Convention applied

Per AGENTS.md *"Documents must stay current"* and CONTRIBUTING *"Crate README conventions"*: user-facing docs state **capabilities** and **link** the standard + the in-repo design doc; they do **not** explain engine internals (dictionary encoding, permutation indexes, join/planning algorithms, delta overlays, mmap, concurrency model) and do **not** enumerate the contents of a linked spec (no `SELECT/ASK/CONSTRUCT/…` after a SPARQL link). Internals live in `research/` + are linked, not inlined.

## Per-doc disposition

**Cleaned (published crate READMEs):**

- **`crates/sparq-engine/README.md`** — removed the SPARQL-spec enumeration (`SELECT / ASK / CONSTRUCT / DESCRIBE`, `OPTIONAL / UNION / MINUS / VALUES / BIND`, property-paths, FILTER built-ins) after the standard link, and the planner/join-algorithm internals (algebra compilation via `spargebra`, cardinality-based join ordering, sort-merge / hash / worst-case-optimal joins). Now states the capability + hyperlinks SPARQL 1.1/1.2 and RDF 1.2; design deferred to `research/` (already linked from *Learn more*).
- **`crates/sparq-core/README.md`** — removed the storage internals (dictionary-encoding mechanics, the six SPO/SOP/PSO/POS/OSP/OPS permutation indexes, range-scan/BGP framing, delta-overlay inserts/deletes, memory-mapped permutations). Now states the capability + hyperlinks RDF 1.2; layout deferred to `research/` (already linked). Also dropped a stale/internals Quickstart code comment.
- **`crates/sparq-cli/README.md`** — `"persist the six permutation indexes to disk"` → `"build an on-disk index once"` (single internals term → capability).
- **`crates/sparq-server/README.md`** — trimmed the inline concurrency mechanism (`generation-ring snapshot chain + sequenced group-commit writer`) from the pitch and the *Atomicity* bullet, keeping the user-facing guarantee ("reads and writes never share a lock; queries never wait on the writer"). The mechanism is already linked at `research/concurrent-serving.md` from *Learn more*.

**Already clean (left as-is):**

- **All `skills/*/SKILL.md`** — the keyword hits (`permutation index`, `delta overlay`, `closure maintenance`) describe **user-observable API/CLI behaviour contracts** (e.g. `update_in_place` mutation semantics, `query-mmap` out-of-core behaviour, the JS `applyDelta` tombstone/by-label contract, the `MaterializedGraph` incremental-closure API). Per the bead's conservative rule, usage/behaviour docs are **not** internals leakage. No standalone internals/architecture sections exist in any SKILL.md.
- **Other published crate READMEs** not edited above either had no leakage in scope or are out of scope.

**Out of scope (not touched):** `AGENTS.md`/`CLAUDE.md`, `research/`, `.claude/skills/`, and the `publish = false` internal-crate READMEs (`sparq-py`, `sparq-wasm`, `sparq-gpu`).

## Follow-up (not in this bead)

The three GenAI capability READMEs (`sparq-introspect`, `sparq-nlq`, `sparq-sim`) predate the concise-README template and read as algorithm manuals (`## How it works`, `## Cost model`, signature math, characteristic-set scan mechanics). Bringing them to the concise-template shape is a structural rewrite beyond this leak-audit (and the `readme-template` advisory CI check already flags them, alongside `geo`/`rsp`/`shacl`/`server`, as over the 120-line cap). Worth a dedicated bead — flagged here, not opened, to avoid editing `.beads/` from a worktree.

## Verification (doc-only change)

- `markdownlint` (HARD config) — **0 errors** across the 54-file scoped surface.
- `typos` (HARD) — clean over the edited files.
- `internal-links` (lychee `--offline`, HARD) — all new relative links resolve.
- `cargo test --doc -p sparq-core -p sparq-engine` — **pass** (both READMEs are `include_str!`'d doctests).
- `readme-template` advisory check — the four edited crates stay within cap; no regression.

Refs bead **sq-avp7**. `[OPUS-4.8]`