### PR TITLE
feat(zk-compose): verifier issuer-attested clear-key holder binding (T3/B1) [OPUS-4.8]

### DIFF
--- a/crates/sparq-zk-compose/README.md
+++ b/crates/sparq-zk-compose/README.md
@@ -139,15 +139,30 @@ bb proof bytes), and the binding edges. JSON via serde; round-trips.
   assumed). So `Rdfs`/`Owl` is accepted only for disclosed-base derivations under
   an explicit opt-in policy.
 - **HolderPoP binding** — IMPLEMENTED ([OPUS-4.8] sq-cwq): the `HolderPop`
-  binding now carries a holder key + a challenge-bound Schnorr proof-of-possession
+  binding carries a holder key + a challenge-bound Schnorr proof-of-possession
   (`pop`), and the verifier checks it FAIL-CLOSED against an external
   `HolderRegistry` (an empty registry, an untrusted holder, or a
   malformed/invalid/replayed PoP all REJECT — no silent-accept of an absent PoP,
-  which was the prior placeholder behaviour). DEFERRED: binding the holder key to
-  a SPECIFIC credential (an issuer-attested credential↔holder binding) — until
-  then the registry narrows "who may present" to authorised holders but a trusted
-  holder is not yet tied to a particular credential. See
-  `verifier::bind_holder_pop`.
+  which was the prior placeholder behaviour).
+- **Credential↔holder binding (clear-key tier, B1)** — IMPLEMENTED ([OPUS-4.8]
+  sq-z8s7, `research/zk-holder-pop-design.md` §3.3 B1): the verifier now binds the
+  presenter to the SPECIFIC credential the issuer issued, closing the
+  trusted-holder gap (sq-cwq's nonce-only PoP let trusted holder A present trusted
+  holder B's credential). When a credential's `CommitmentAttestation` carries an
+  issuer-attested `AttestedHolderBinding` (the issuer folded
+  `holder_key_digest(hpk)` into the signature via the `ZKSIG_C4`
+  `commitment_message_with_holder` message), the verifier cross-checks that the
+  PRESENTED holder key (the one the PoP was signed under) hashes to the
+  issuer-attested `holder_pk_digest` and FAILS CLOSED on any mismatch
+  (`HolderKeyMismatch`). A bearer credential (no holder binding) presented under
+  `HolderPop` is rejected (`HolderBindingMissing`) when the relying party's
+  `HolderBindingPolicy::require_binding()` mandates binding; the back-compatible
+  `HolderBindingPolicy::allow_bearer()` default keeps the sq-cwq registry+PoP
+  behaviour for bearer credentials. The issuer-attested digest is anchored in the
+  issuer signature (verified under the external trusted `KeySet K`), never a free
+  prover JSON field. See `verifier::bind_holder_pop` / `verifier::bind_holder_binding`.
+  DEFERRED: the in-circuit HIDDEN-key PoK (B2, sq-i1dt) where only the digest is
+  public (no holder-key linkability) — the clear-key tier discloses `hpk`.
 
 ## sparq-zk API gaps noted
 

--- a/crates/sparq-zk-compose/src/verifier.rs
+++ b/crates/sparq-zk-compose/src/verifier.rs
@@ -3176,16 +3176,29 @@ fn bind_holder_pop(
 /// nonce-PoP together bind THIS holder to THIS credential).
 ///
 /// # What it checks (design `research/zk-holder-pop-design.md` §3.3 B1 / §4.1)
-/// 1. **Locate the issuer-attested binding.** Scan
-///    `manifest.commitment_attestations` for an entry carrying an
-///    [`crate::manifest::AttestedHolderBinding`]. (A credential has at most one
-///    holder binding; if several attestations carry one, ALL must agree with the
-///    presented key — a disagreement is a `HolderKeyMismatch`.)
-/// 2. **Bearer policy (fail-closed, no silent fallback).** If NO attestation
-///    carries a holder binding, the credential is BEARER. Under
-///    [`HolderBindingPolicy::require_binding`] this is rejected
-///    ([`CheckError::HolderBindingMissing`]); under the back-compatible default it
-///    is accepted (the sq-cwq registry + nonce-PoP guarantee stands).
+/// 1. **Scope to the COVERING attestation, never any attestation (sq-z8s7 Copilot
+///    scoping fix).** The binding is checked on the attestation that COVERS a
+///    SCAN-REFERENCED commitment — i.e. the credential the presentation actually
+///    uses — reusing the EXACT attestation→commitment mapping
+///    [`bind_issuer_attestations`] uses (`a.commitment.to_field() == c_field` over
+///    the per-graph `commitments` of every scan sub-proof). The earlier "ANY
+///    `manifest.commitment_attestations` entry has `holder: Some(_)`" shortcut was
+///    a SECURITY hole: a holder binding on an UNRELATED attestation (one covering
+///    no scan-referenced commitment) could satisfy the check while the credential
+///    genuinely presented was bearer/mismatched — the A-presents-B closure this
+///    function exists to enforce would silently lapse. We now iterate the
+///    scan-referenced commitments and look up THEIR covering attestation. (If
+///    several scans reference the same commitment, it is checked once; a credential
+///    has at most one covering attestation per commitment.)
+/// 2. **Bearer policy (fail-closed, no silent fallback), per covering attestation.**
+///    A scan-referenced commitment whose COVERING attestation carries no holder
+///    binding (or that has no clear covering attestation at all — hidden-issuer or
+///    unattested) is BEARER for this credential. Under
+///    [`HolderBindingPolicy::require_binding`] that is rejected
+///    ([`CheckError::HolderBindingMissing`] — bearer-where-binding-required);
+///    under the back-compatible default it is accepted (the sq-cwq registry +
+///    nonce-PoP guarantee stands). When NO holder binding covers ANY presented
+///    credential the whole presentation is bearer (same policy split).
 /// 3. **Anchor the digest in the issuer signature (NEVER the manifest alone).**
 ///    For a holder-bound attestation, the issuer signed
 ///    [`sparq_zk::sig::commitment_message_with_holder`]`(C(G), salt, status_ref, holder_pk_digest)`
@@ -3216,20 +3229,78 @@ fn bind_holder_binding(
     holder_binding_policy: &HolderBindingPolicy,
     presented_pk: &PublicKey,
 ) -> Result<(), CheckError> {
-    // (1) Locate every attestation carrying an issuer-attested holder binding.
-    let bound: Vec<&crate::manifest::CommitmentAttestation> = manifest
-        .commitment_attestations
-        .iter()
-        .filter(|att| att.holder.is_some())
+    // (1) [OPUS-4.8] sq-z8s7 (Copilot scoping fix): collect the attestations that
+    // COVER a SCAN-REFERENCED commitment — the credential(s) the presentation
+    // actually uses — using the EXACT attestation→commitment mapping
+    // `bind_issuer_attestations` uses (`a.commitment.to_field() == c_field` over
+    // the per-graph `commitments` of every scan sub-proof). This REPLACES the
+    // earlier "ANY attestation has `holder: Some(_)`" shortcut, which was a
+    // SECURITY hole: a holder binding on an UNRELATED attestation could satisfy the
+    // check while the genuinely-presented credential was bearer/mismatched. We
+    // build the covering set so a credential's bearer/holder-bound status is judged
+    // on ITS OWN attestation, not on a stray sibling. Keyed by canonical commitment
+    // hex so a commitment referenced by several scans is checked once; the value is
+    // whether THAT commitment's covering attestation carries a holder binding (and,
+    // if so, the binding itself for the cross-check below).
+    let mut covering: std::collections::BTreeMap<
+        String,
+        Option<&crate::manifest::CommitmentAttestation>,
+    > = std::collections::BTreeMap::new();
+    for sp in &manifest.sub_proofs {
+        let ProofInputs::Scan { commitments, .. } = &sp.inputs else {
+            continue;
+        };
+        for c in commitments {
+            let Some(c_field) = c.to_field() else {
+                // A non-field commitment can carry no valid attestation. It is
+                // already rejected upstream by `bind_issuer_attestations`
+                // (`bind_holder_binding` runs after the issuer gate via
+                // `verify_manifest`); skip it here so a malformed commitment cannot
+                // mask a real scoping decision.
+                continue;
+            };
+            // The covering attestation = the same lookup `bind_issuer_attestations`
+            // uses (compare as field elements so 0x-padding cannot slip a mismatch).
+            let att = manifest.commitment_attestations.iter().find(|a| {
+                a.commitment.to_field().is_some() && a.commitment.to_field() == Some(c_field)
+            });
+            covering.insert(field_to_hex(&c_field), att);
+        }
+    }
+
+    // The set of covering attestations that DO carry a holder binding — the only
+    // attestations whose binding this credential's presentation must satisfy.
+    let bound: Vec<&crate::manifest::CommitmentAttestation> = covering
+        .values()
+        .filter_map(|a| a.filter(|att| att.holder.is_some()))
         .collect();
 
-    // (2) Bearer credential (no holder binding). Fail-closed iff the relying party
-    // mandates binding; otherwise keep the back-compatible sq-cwq behaviour.
+    // (2) Bearer policy, scoped to the COVERING attestations. A presentation is
+    // bearer iff NO scan-referenced commitment's covering attestation carries a
+    // holder binding (a holder binding on an unrelated attestation no longer
+    // counts). Under `require_binding` that is rejected fail-closed
+    // (`HolderBindingMissing` — bearer-where-binding-required); under the
+    // back-compatible default it is accepted (sq-cwq registry + nonce-PoP stands).
     if bound.is_empty() {
         if holder_binding_policy.requires_binding() {
             return Err(CheckError::HolderBindingMissing);
         }
         return Ok(());
+    }
+
+    // [OPUS-4.8] sq-z8s7 (Copilot scoping fix): under `require_binding`, EVERY
+    // presented credential must be holder-bound — a scan-referenced commitment whose
+    // covering attestation lacks a binding (or has no clear covering attestation at
+    // all) is bearer-where-binding-required, rejected even though a SIBLING
+    // commitment is bound. (Under the back-compatible default a mix is allowed: the
+    // bound credentials are still cross-checked below; the bearer ones rely on the
+    // registry + nonce-PoP.)
+    if holder_binding_policy.requires_binding()
+        && covering
+            .values()
+            .any(|a| a.is_none_or(|att| att.holder.is_none()))
+    {
+        return Err(CheckError::HolderBindingMissing);
     }
 
     // The presented key's digest (T1). The identity key has no usable digest and is

--- a/crates/sparq-zk-compose/src/verifier.rs
+++ b/crates/sparq-zk-compose/src/verifier.rs
@@ -121,10 +121,13 @@ use sparq_zk::field::{field_from_hex_str, field_to_be_bytes_32, field_to_hex, Fr
 // [OPUS-4.8] audit #12: the STATUS-BOUND `commitment_message_with_status` is the
 // scan-verify path's signed message — a scan-covering attestation must bind the
 // status reference (status_ref_digest over the disclosed list/index/version).
+// [OPUS-4.8] sq-z8s7 (HolderPoP T3 / B1): the HOLDER-BOUND `commitment_message_with_holder`
+// (ZKSIG_C4) is the signed message for a holder-bound attestation, and `holder_key_digest`
+// recomputes the presented holder key's digest for the clear-key cross-check.
 use sparq_zk::sig::{
-    commitment_message_with_status, holder_pop_message, public_key_from_hex, signature_from_hex,
-    status_list_id_to_field, status_ref_commit_digest, status_ref_digest, verify as sig_verify,
-    SignatureScheme,
+    commitment_message_with_holder, commitment_message_with_status, holder_key_digest,
+    holder_pop_message, public_key_from_hex, signature_from_hex, status_list_id_to_field,
+    status_ref_commit_digest, status_ref_digest, verify as sig_verify, PublicKey, SignatureScheme,
 };
 use sparq_zk::verify::{
     fragment_filters, fragment_pattern_consts, fragment_patterns, recheck, variable_slots,
@@ -326,6 +329,78 @@ impl HolderRegistry {
     /// Whether `holder_hex` (any case, optional `0x`) is an authorised holder.
     fn contains_hex(&self, holder_hex: &str) -> bool {
         self.holders.contains(&normalize_hex(holder_hex))
+    }
+}
+
+/// The relying party's HOLDER-BINDING policy (T3/sq-z8s7 B1): whether a
+/// `HolderPop` presentation MUST carry an issuer-attested per-credential holder
+/// binding ([`crate::manifest::AttestedHolderBinding`]), or whether a BEARER
+/// credential (no holder binding) is still acceptable under `HolderPop` (the
+/// back-compatible sq-cwq behaviour: registry membership + a fresh nonce-PoP
+/// only).
+///
+/// # The trusted-holder gap this closes
+/// The sq-cwq `HolderPop` check binds the presenter to the verifier's fresh
+/// NONCE (proof of possession of *a* registry-trusted key) but NOT to the
+/// CREDENTIAL the issuer issued. So trusted holder A could present trusted holder
+/// B's credential: A holds *a* trusted key and can sign the nonce with it, while
+/// the scan/filter sub-proofs attest B's credential. B1 closes this by
+/// cross-checking the PRESENTED holder key against the issuer-attested
+/// `holder_pk_digest` the issuer folded into THIS credential's signature (the
+/// `ZKSIG_C4` [`sparq_zk::sig::commitment_message_with_holder`] message). When a
+/// holder binding is present, the cross-check ALWAYS runs (fail-closed —
+/// regardless of this policy). This policy governs only the BEARER case: whether
+/// the ABSENCE of a binding is itself rejected.
+///
+/// # Default = back-compatible (binding NOT required)
+/// [`HolderBindingPolicy::default`] / [`HolderBindingPolicy::allow_bearer`] does
+/// NOT require a binding: a `HolderPop` over a bearer credential keeps its sq-cwq
+/// behaviour (registry + nonce-PoP). This is the conservative default so existing
+/// callers/tests are unaffected. A relying party that mandates per-credential
+/// binding opts in with [`HolderBindingPolicy::require_binding`], after which a
+/// bearer `HolderPop` presentation is rejected fail-closed
+/// ([`CheckError::HolderBindingMissing`]) — the design's "bearer must be
+/// rejectable" requirement (`research/zk-holder-pop-design.md` §1 honest scope /
+/// §4.3 obligation 3).
+///
+/// # Honest scope (clear-key tier only)
+/// This is the B1 clear-key tier: the presented holder key is DISCLOSED and the
+/// verifier recomputes its digest host-side. The hidden-key in-circuit PoK (B2,
+/// sq-i1dt) — where only the digest is public — is a separate deliverable and is
+/// NOT enforced here.
+// [OPUS-4.8] sq-z8s7 (HolderPoP T3 / B1): holder-binding policy (external,
+// fail-closed bearer rejection; default back-compatible). Mirrors RevocationPolicy
+// / EntailmentPolicy as a relying-party-supplied external policy object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct HolderBindingPolicy {
+    require_binding: bool,
+}
+
+impl HolderBindingPolicy {
+    /// The back-compatible default: a `HolderPop` over a BEARER credential (no
+    /// issuer-attested holder binding) is accepted on the sq-cwq registry +
+    /// nonce-PoP path. A holder binding, if PRESENT, is still cross-checked
+    /// fail-closed (B1) — this only governs the bearer-absent case.
+    pub fn allow_bearer() -> Self {
+        HolderBindingPolicy {
+            require_binding: false,
+        }
+    }
+
+    /// REQUIRE an issuer-attested per-credential holder binding for every
+    /// `HolderPop` presentation: a bearer credential (no
+    /// [`crate::manifest::AttestedHolderBinding`]) is then rejected fail-closed
+    /// ([`CheckError::HolderBindingMissing`]). This is the design's mandated-binding
+    /// posture that fully closes the trusted-holder gap (no bearer fallback).
+    pub fn require_binding() -> Self {
+        HolderBindingPolicy {
+            require_binding: true,
+        }
+    }
+
+    /// Whether the relying party requires a holder binding (rejects bearer).
+    fn requires_binding(&self) -> bool {
+        self.require_binding
     }
 }
 
@@ -1179,6 +1254,29 @@ pub enum CheckError {
     /// Rejected.
     // [OPUS-4.8] sq-cwq.
     HolderPopInvalid { holder: String },
+    /// The relying party REQUIRES an issuer-attested holder binding (T3/sq-z8s7
+    /// B1, [`HolderBindingPolicy::require_binding`]) but the `HolderPop`
+    /// presentation's credential carries NO [`crate::manifest::AttestedHolderBinding`]
+    /// — i.e. a BEARER credential (no `holder` field on any
+    /// [`crate::manifest::CommitmentAttestation`]) presented where a per-credential
+    /// holder binding is mandated. Rejected fail-closed — there is NO silent bearer
+    /// fallback (design `research/zk-holder-pop-design.md` §4.3 obligation 3, the
+    /// audit-#12 `status:None ⇒ reject` precedent). Closes the trusted-holder gap's
+    /// "present a bearer credential and skip the binding" bypass.
+    // [OPUS-4.8] sq-z8s7 (HolderPoP T3 / B1): fail-closed bearer rejection.
+    HolderBindingMissing,
+    /// The PRESENTED holder key (the `HolderPop` binding's disclosed key, also the
+    /// key the freshness PoP was signed under) does NOT hash (via
+    /// [`sparq_zk::sig::holder_key_digest`]) to the issuer-attested
+    /// [`crate::manifest::AttestedHolderBinding::holder_pk_digest`] (T3/sq-z8s7 B1):
+    /// the presenter is binding a DIFFERENT key than the issuer signed into THIS
+    /// credential. This is the load-bearing trusted-holder-gap closure — it rejects
+    /// "trusted holder A presents trusted holder B's credential" (A's key digest ≠
+    /// B's attested digest). Also covers the identity holder key (no usable digest,
+    /// [`sparq_zk::sig::HolderKeyError::IdentityKey`]) and a clear holder key in the
+    /// attestation that disagrees with the presented key. Rejected fail-closed.
+    // [OPUS-4.8] sq-z8s7 (HolderPoP T3 / B1): presented-key vs attested-digest gate.
+    HolderKeyMismatch,
     /// The manifest's `entailment_regime` is NOT accepted by the relying party's
     /// [`EntailmentPolicy`] (sq-314): e.g. an `Rdfs`/`Owl` manifest under a
     /// `Simple`-only policy. Rejected fail-closed — the regime is enforced, not
@@ -1425,6 +1523,14 @@ impl std::fmt::Display for CheckError {
             CheckError::HolderPopInvalid { holder } => write!(
                 f,
                 "HolderPop binding pop signature does not verify under holder key {holder} over the challenge-bound message (sq-cwq: the presenter did not prove possession of the holder secret)"
+            ),
+            CheckError::HolderBindingMissing => write!(
+                f,
+                "HolderPop presentation requires an issuer-attested holder binding but the credential carries none — a BEARER credential presented where a per-credential holder binding is mandated (sq-z8s7 B1: fail-closed, no silent bearer fallback — closes the trusted-holder gap)"
+            ),
+            CheckError::HolderKeyMismatch => write!(
+                f,
+                "HolderPop presentation's holder key does not match the issuer-attested holder binding (sq-z8s7 B1: the presented key's holder_key_digest != the issuer-signed holder_pk_digest, the identity key, or a clear attested key disagreeing with the presented key — rejects trusted holder A presenting trusted holder B's credential)"
             ),
             CheckError::EntailmentRegimeNotAccepted { regime } => write!(
                 f,
@@ -1933,8 +2039,35 @@ fn bind_issuer_attestations(
             let list_id_fr = status_list_id_to_field(&rev.status_list);
             let (status_ref, _mode) =
                 resolve_status_ref(rev, att_status, &list_id_fr, &c.0)?;
-            let message =
-                commitment_message_with_status(&commitment_fr, &salt_fr, &status_ref);
+            // [OPUS-4.8] sq-z8s7 (HolderPoP T3 / B1): select the signed-message
+            // variant from the attestation's OPTIONAL fields. A HOLDER-BOUND
+            // attestation (the issuer folded a holder-key digest into the signature,
+            // the distinct ZKSIG_C4 tag) signs `commitment_message_with_holder(C(G),
+            // salt, status_ref, holder_pk_digest)`; a non-holder-bound one signs the
+            // status-only `commitment_message_with_status` (ZKSIG_C3). Selecting the
+            // right variant HERE is what makes a holder-bound credential pass the
+            // main attestation gate AND anchors the attested `holder_pk_digest` in
+            // the issuer signature (design §3.3 / §4.3 obligation 1) — the digest the
+            // T3 cross-check (`bind_holder_binding`) compares the presented key
+            // against is the one the ISSUER signed, never a free prover JSON field. A
+            // holder-bound attestation whose `holder_pk_digest` hex is malformed has
+            // no reconstructable message => InvalidIssuerSignature (fail-closed).
+            let message = match att.holder.as_ref() {
+                Some(binding) => {
+                    let Some(holder_digest) = binding.digest() else {
+                        return Err(CheckError::InvalidIssuerSignature {
+                            commitment: c.0.clone(),
+                        });
+                    };
+                    commitment_message_with_holder(
+                        &commitment_fr,
+                        &salt_fr,
+                        &status_ref,
+                        &holder_digest,
+                    )
+                }
+                None => commitment_message_with_status(&commitment_fr, &salt_fr, &status_ref),
+            };
             let ok = SignatureScheme::from_cryptosuite_iri(&att.cryptosuite).is_some()
                 && match (
                     public_key_from_hex(&att.issuer_public_key),
@@ -2962,21 +3095,32 @@ fn filter_edge_true(
 /// `challenge` (exactly like a bare `Challenge`), silently waiving (1)-(4) — an
 /// absent/forged PoP passed. That silent-accept path is removed.
 ///
-/// # Scope (honest deferral)
-/// This proves the presenter possesses a holder key the relying party trusts AND
-/// signed the verifier's fresh nonce with it. It does NOT bind that key to the
-/// SPECIFIC credential the scan/filter sub-proofs attest — an issuer-attested
-/// holder binding (the issuer signing the holder key into the credential, e.g. a
-/// `holderBinding` field folded into the commitment message) is DEFERRED. Without
-/// it, a trusted holder A could present a trusted holder B's credential. The
-/// holder registry narrows "who may present at all" to authorised holders, which
-/// is the meaningful interim guarantee; the per-credential binding is the
-/// documented next step. This is NOT a silent gap: the registry is fail-closed and
-/// the deferral is recorded here and in the manifest/README docs.
+/// # T3/sq-z8s7 B1: issuer-attested credential↔holder binding (the gap closed)
+/// The sq-cwq checks above prove the presenter possesses a holder key the relying
+/// party trusts AND signed the verifier's fresh nonce with it — but they do NOT
+/// bind that key to the SPECIFIC credential the scan/filter sub-proofs attest. So
+/// trusted holder A could present trusted holder B's credential (A holds *a*
+/// trusted key, signs the nonce, while the proofs attest B's credential). B1
+/// closes this: after the registry+PoP checks, [`bind_holder_binding`]
+/// cross-checks the PRESENTED holder key against the issuer-attested
+/// `holder_pk_digest` the issuer folded into THIS credential's signature (the
+/// `ZKSIG_C4` [`sparq_zk::sig::commitment_message_with_holder`] message, recovered
+/// from the credential's [`crate::manifest::CommitmentAttestation`] and verified
+/// under the EXTERNAL trusted `K`). On any mismatch / required-but-absent binding
+/// / identity key it fails closed (`HolderKeyMismatch` / `HolderBindingMissing`).
+///
+/// # Scope (B2 deferred)
+/// This is the CLEAR-KEY tier: the presented holder key is disclosed and the
+/// verifier recomputes its digest host-side. The in-circuit HIDDEN-key PoK (B2,
+/// sq-i1dt), where only the digest is public, is a separate deliverable — NOT
+/// enforced here. See `research/zk-holder-pop-design.md` §2.B / §3.3.
 // [OPUS-4.8] sq-cwq: holder PoP implemented (challenge-bound Schnorr) + fail-closed.
+// [OPUS-4.8] sq-z8s7 (HolderPoP T3 / B1): + issuer-attested credential↔holder binding.
 fn bind_holder_pop(
     manifest: &ProofManifest,
     holder_registry: &HolderRegistry,
+    trusted_key_set: &KeySet,
+    holder_binding_policy: &HolderBindingPolicy,
     challenge: &FieldHex,
 ) -> Result<(), CheckError> {
     let (holder, pop, cryptosuite) = match &manifest.binding {
@@ -3013,6 +3157,201 @@ fn bind_holder_pop(
     let message = holder_pop_message(&challenge_fr);
     if !sig_verify(&pk, &message, &sig) {
         return Err(CheckError::HolderPopInvalid { holder: holder.clone() });
+    }
+
+    // (5) [OPUS-4.8] sq-z8s7 (T3 / B1): bind THIS presented holder key to the
+    // ISSUER-ATTESTED holder binding of THIS credential. `pk` is the SAME key the
+    // PoP (4) was verified under, so the digest cross-check + the nonce-PoP
+    // together bind THIS holder to THIS credential (closing the trusted-holder
+    // gap: A's key digest != B's attested digest). Fail-closed.
+    bind_holder_binding(manifest, trusted_key_set, holder_binding_policy, &pk)?;
+
+    Ok(())
+}
+
+/// T3/sq-z8s7 B1 (clear-key tier): cross-check the PRESENTED holder key against
+/// the credential's ISSUER-ATTESTED holder binding, closing the trusted-holder gap
+/// `bind_holder_pop`'s nonce-only PoP left open. `presented_pk` is the holder key
+/// the `HolderPop` PoP was verified under (so the digest check below + the existing
+/// nonce-PoP together bind THIS holder to THIS credential).
+///
+/// # What it checks (design `research/zk-holder-pop-design.md` §3.3 B1 / §4.1)
+/// 1. **Locate the issuer-attested binding.** Scan
+///    `manifest.commitment_attestations` for an entry carrying an
+///    [`crate::manifest::AttestedHolderBinding`]. (A credential has at most one
+///    holder binding; if several attestations carry one, ALL must agree with the
+///    presented key — a disagreement is a `HolderKeyMismatch`.)
+/// 2. **Bearer policy (fail-closed, no silent fallback).** If NO attestation
+///    carries a holder binding, the credential is BEARER. Under
+///    [`HolderBindingPolicy::require_binding`] this is rejected
+///    ([`CheckError::HolderBindingMissing`]); under the back-compatible default it
+///    is accepted (the sq-cwq registry + nonce-PoP guarantee stands).
+/// 3. **Anchor the digest in the issuer signature (NEVER the manifest alone).**
+///    For a holder-bound attestation, the issuer signed
+///    [`sparq_zk::sig::commitment_message_with_holder`]`(C(G), salt, status_ref, holder_pk_digest)`
+///    (the distinct `ZKSIG_C4` tag). The verifier RECOMPUTES that message from the
+///    disclosed `(C(G), salt, status_ref)` + the attested `holder_pk_digest` and
+///    requires the issuer signature to verify under a key in the EXTERNAL trusted
+///    `K` — so the digest the verifier cross-checks is the one the ISSUER bound,
+///    not a free prover JSON field (design §4.3 obligation 1). A holder-bound
+///    attestation whose signature does not so verify is rejected
+///    ([`CheckError::InvalidIssuerSignature`]) — A cannot swap in its own digest
+///    without invalidating the issuer's EUF-CMA signature.
+/// 4. **Presented-key digest == attested digest.** `holder_key_digest(presented_pk)`
+///    (T1, Poseidon2-collision-resistant) MUST equal the attested
+///    `holder_pk_digest`. A's key digest != B's attested digest =>
+///    [`CheckError::HolderKeyMismatch`] (the core trusted-holder-gap closure). The
+///    identity holder key has no usable digest ([`sparq_zk::sig::HolderKeyError`])
+///    => `HolderKeyMismatch`.
+/// 5. **Clear attested key (if disclosed) == presented key.** When the attestation
+///    discloses the clear `holder_public_key`, it MUST equal `presented_pk` (a
+///    belt-and-braces check: the digest equality already implies key equality under
+///    collision-resistance, but a disclosed clear key that disagrees is a malformed
+///    binding => `HolderKeyMismatch`).
+// [OPUS-4.8] sq-z8s7 (HolderPoP T3 / B1): verifier-side issuer-attested clear-key
+// holder binding, fail-closed. B2 (hidden-key in-circuit PoK) is sq-i1dt.
+fn bind_holder_binding(
+    manifest: &ProofManifest,
+    trusted_key_set: &KeySet,
+    holder_binding_policy: &HolderBindingPolicy,
+    presented_pk: &PublicKey,
+) -> Result<(), CheckError> {
+    // (1) Locate every attestation carrying an issuer-attested holder binding.
+    let bound: Vec<&crate::manifest::CommitmentAttestation> = manifest
+        .commitment_attestations
+        .iter()
+        .filter(|att| att.holder.is_some())
+        .collect();
+
+    // (2) Bearer credential (no holder binding). Fail-closed iff the relying party
+    // mandates binding; otherwise keep the back-compatible sq-cwq behaviour.
+    if bound.is_empty() {
+        if holder_binding_policy.requires_binding() {
+            return Err(CheckError::HolderBindingMissing);
+        }
+        return Ok(());
+    }
+
+    // The presented key's digest (T1). The identity key has no usable digest and is
+    // rejected fail-closed (it can never equal a real issuer-attested digest).
+    let Ok(presented_digest) = holder_key_digest(presented_pk) else {
+        return Err(CheckError::HolderKeyMismatch);
+    };
+
+    for att in bound {
+        let binding = att
+            .holder
+            .as_ref()
+            .expect("filtered for Some(holder) above");
+
+        // (3) Anchor the attested digest in the ISSUER signature: recompute the
+        // holder-bound (ZKSIG_C4) message and require the issuer signature to
+        // verify under a key in the EXTERNAL trusted K. This is what makes the
+        // attested `holder_pk_digest` trustworthy (design §4.3 obligation 1) —
+        // without it the digest would be an unauthenticated prover JSON field.
+        verify_holder_attestation_signature(manifest, trusted_key_set, att)?;
+
+        // The attested digest as a field element (fail-closed on malformed hex).
+        let Some(attested_digest) = binding.digest() else {
+            return Err(CheckError::HolderKeyMismatch);
+        };
+
+        // (4) The presented key MUST hash to the issuer-attested digest. This is
+        // the load-bearing trusted-holder-gap closure: trusted holder A presenting
+        // trusted holder B's credential has A's digest != B's attested digest.
+        if presented_digest != attested_digest {
+            return Err(CheckError::HolderKeyMismatch);
+        }
+
+        // (5) If the attestation ALSO discloses the clear holder key (clear-key
+        // tier), it must equal the presented key. Digest equality already implies
+        // this under collision-resistance; a disclosed clear key that disagrees is
+        // a malformed binding, rejected fail-closed.
+        if let Some(clear) = binding.holder_key() {
+            if clear != *presented_pk {
+                return Err(CheckError::HolderKeyMismatch);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Verify that the issuer signature on a HOLDER-BOUND attestation verifies over
+/// the `ZKSIG_C4` [`sparq_zk::sig::commitment_message_with_holder`] message under
+/// a key in the EXTERNAL trusted `K` (T3/sq-z8s7 B1). This anchors the attested
+/// `holder_pk_digest` in the issuer signature: the message folds
+/// `(C(G), salt, status_ref, holder_pk_digest)`, so a forged/swapped digest yields
+/// a different message and no valid signature (EUF-CMA). Mirrors the salt/status
+/// recompute in [`bind_issuer_attestations`], but over the holder-bound message
+/// variant (the status path verifies the status-only `ZKSIG_C3` message, which a
+/// holder-bound attestation does NOT use).
+///
+/// Fail-closed: an issuer key not in `K` => [`CheckError::IssuerKeyNotInKeySet`];
+/// an unknown cryptosuite / unparseable key or signature / malformed salt or
+/// commitment / a missing or non-verifying signature => [`CheckError::InvalidIssuerSignature`];
+/// an absent revocation reference (needed to recompute `status_ref`) =>
+/// [`CheckError::RevocationReferenceMissing`].
+// [OPUS-4.8] sq-z8s7 (HolderPoP T3 / B1): issuer-signature anchor for the holder digest.
+fn verify_holder_attestation_signature(
+    manifest: &ProofManifest,
+    trusted_key_set: &KeySet,
+    att: &crate::manifest::CommitmentAttestation,
+) -> Result<(), CheckError> {
+    let commitment_hex = att.commitment.0.clone();
+    // The issuer key MUST be in the EXTERNAL trusted K (never a prover-chosen key —
+    // the audit-#3 codex-#1 anchor; reported BEFORE the signature check so an
+    // untrusted issuer is the stated reason).
+    if !trusted_key_set.contains_hex(&att.issuer_public_key) {
+        return Err(CheckError::IssuerKeyNotInKeySet {
+            commitment: commitment_hex,
+        });
+    }
+
+    let binding = att
+        .holder
+        .as_ref()
+        .expect("caller passes a holder-bound attestation");
+    let (Some(commitment_fr), Some(holder_digest)) = (att.commitment.to_field(), binding.digest())
+    else {
+        return Err(CheckError::InvalidIssuerSignature {
+            commitment: commitment_hex,
+        });
+    };
+    // A holder-bound (scan-covering) attestation carries a salt exactly as a
+    // status-bound one does; an absent/malformed salt fails closed.
+    let Some(salt_fr) = att.salt.as_ref().and_then(|s| s.to_field()) else {
+        return Err(CheckError::InvalidIssuerSignature {
+            commitment: commitment_hex,
+        });
+    };
+    // Recompute the issuer-signed status reference from the disclosed revocation
+    // reference (same source `bind_issuer_attestations` uses) — it is folded into
+    // the ZKSIG_C4 message alongside the holder digest.
+    let Some(rev) = &manifest.revocation else {
+        return Err(CheckError::RevocationReferenceMissing { proof: 0 });
+    };
+    let list_id_fr = status_list_id_to_field(&rev.status_list);
+    let Some(status_ref) = status_ref_from_revocation(rev, &list_id_fr) else {
+        return Err(CheckError::InvalidIssuerSignature {
+            commitment: commitment_hex,
+        });
+    };
+
+    let message =
+        commitment_message_with_holder(&commitment_fr, &salt_fr, &status_ref, &holder_digest);
+    let ok = SignatureScheme::from_cryptosuite_iri(&att.cryptosuite).is_some()
+        && match (
+            public_key_from_hex(&att.issuer_public_key),
+            signature_from_hex(&att.signature),
+        ) {
+            (Some(pk), Some(sig)) => sig_verify(&pk, &message, &sig),
+            _ => false,
+        };
+    if !ok {
+        return Err(CheckError::InvalidIssuerSignature {
+            commitment: commitment_hex,
+        });
     }
     Ok(())
 }
@@ -3199,6 +3538,8 @@ fn bind_entailment(
 // key-set K, revocation policy, holder registry, fresh nonce, single-use store) —
 // deliberately separate, not bundled, to keep each anchor explicit at the call
 // site; the count exceeds clippy's default heuristic but every arg is load-bearing.
+// [OPUS-4.8] sq-z8s7 (T3 / B1): + holder_binding_policy (external; whether a bearer
+// credential is rejected under HolderPop — `HolderBindingPolicy::require_binding()`).
 #[allow(clippy::too_many_arguments)]
 pub fn verify_manifest(
     manifest: &ProofManifest,
@@ -3207,6 +3548,7 @@ pub fn verify_manifest(
     trusted_key_set: &KeySet,
     revocation_policy: &RevocationPolicy,
     holder_registry: &HolderRegistry,
+    holder_binding_policy: &HolderBindingPolicy,
     entailment_policy: &EntailmentPolicy,
     nonce: &VerifierNonce,
     seen: &dyn SeenNonces,
@@ -3275,7 +3617,20 @@ pub fn verify_manifest(
     // A `Challenge` binding requires no PoP (this returns Ok immediately). The
     // nonce is recorded single-use BEFORE this, so a rejected PoP still burns the
     // nonce (consistent with the burn-on-mismatch policy above).
-    bind_holder_pop(manifest, holder_registry, &challenge)?;
+    //
+    // [OPUS-4.8] sq-z8s7 (T3 / B1): this ALSO cross-checks the presented holder key
+    // against the credential's ISSUER-ATTESTED holder binding (the digest the issuer
+    // folded into commitment_message_with_holder, verified under the external K),
+    // and — under `holder_binding_policy.require_binding()` — rejects a bearer
+    // credential presented under HolderPop. The trusted-holder gap is closed at the
+    // clear-key tier here.
+    bind_holder_pop(
+        manifest,
+        holder_registry,
+        trusted_key_set,
+        holder_binding_policy,
+        &challenge,
+    )?;
 
     for (i, sp) in manifest.sub_proofs.iter().enumerate() {
         if sp.proof_hex.is_empty() {

--- a/crates/sparq-zk-compose/tests/audit_forge_map.rs
+++ b/crates/sparq-zk-compose/tests/audit_forge_map.rs
@@ -67,7 +67,7 @@ use sparq_zk_compose::manifest::{
 };
 use sparq_zk_compose::toml::prover_toml_for;
 use sparq_zk_compose::verifier::{
-    encode_artifacts, verify_manifest, CheckError, EntailmentPolicy, HolderRegistry,
+    encode_artifacts, verify_manifest, CheckError, EntailmentPolicy, HolderBindingPolicy, HolderRegistry,
     InMemorySeenNonces, KeySet, RevocationPolicy, VerifierNonce,
 };
 
@@ -217,6 +217,7 @@ fn verify_full(m: &ProofManifest, name: &str) -> Result<(), CheckError> {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for(CHALLENGE_HEX),
         &InMemorySeenNonces::new(),
@@ -298,6 +299,7 @@ fn finding_04_nonce_binding_mismatch_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x99"), // verifier issues a DIFFERENT nonce
         &InMemorySeenNonces::new(),
@@ -325,6 +327,7 @@ fn finding_04_nonce_replay_rejected() {
             &trusted_k(&test_issuer_sk(1)),
             &fresh_policy(),
             &HolderRegistry::empty(),
+            &HolderBindingPolicy::allow_bearer(),
             &EntailmentPolicy::simple_only(),
             &nonce,
             &seen,
@@ -756,6 +759,7 @@ fn finding_12_revoked_bit_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &revoked_policy(), // authoritative bit SET
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for(CHALLENGE_HEX),
         &InMemorySeenNonces::new(),
@@ -784,6 +788,7 @@ fn finding_12_stale_version_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &policy,
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for(CHALLENGE_HEX),
         &InMemorySeenNonces::new(),

--- a/crates/sparq-zk-compose/tests/e2e.rs
+++ b/crates/sparq-zk-compose/tests/e2e.rs
@@ -25,9 +25,10 @@ use sparq_zk_compose::build::{
 };
 use sparq_zk_compose::driver::CircuitProver;
 use sparq_zk_compose::manifest::{
-    AttestedStatusRef, BindingEdge, BindingMode, CircuitId, CommitmentAttestation, EntailmentRegime,
-    FieldHex, FilterOp, HiddenIndexRevocation, HiddenIssuerAttestation, ProofInputs, ProofManifest,
-    RevocationStatus, StatusListSnapshot, SubProof,
+    AttestedHolderBinding, AttestedStatusRef, BindingEdge, BindingMode, CircuitId,
+    CommitmentAttestation, EntailmentRegime, FieldHex, FilterOp, HiddenIndexRevocation,
+    HiddenIssuerAttestation, ProofInputs, ProofManifest, RevocationStatus, StatusListSnapshot,
+    SubProof,
 };
 // [OPUS-4.8] sq-3e5 + sq-h2v: hidden-index revocation host helpers.
 use sparq_zk_compose::revocation::{merkle_root, merkle_witness, revoke_prover_toml};
@@ -38,10 +39,14 @@ use sparq_zk_compose::issuer::{
 use sparq_zk_compose::toml::prover_toml_for;
 use sparq_zk_compose::verifier::{
     encode_artifacts, verify_manifest, prefilter_manifest_structure, CheckError, EntailmentPolicy,
-    HolderRegistry, InMemorySeenNonces, KeySet, RevocationPolicy, VerifierNonce,
+    HolderBindingPolicy, HolderRegistry, InMemorySeenNonces, KeySet, RevocationPolicy, VerifierNonce,
 };
 use sparq_zk::field::Fr;
-use sparq_zk::sig::{public_key_to_hex, SecretKey, SignatureScheme};
+// [OPUS-4.8] sq-z8s7 (HolderPoP T3 / B1): holder-key digest + parse for the
+// clear-key holder-binding tests.
+use sparq_zk::sig::{
+    holder_key_digest, public_key_from_hex, public_key_to_hex, SecretKey, SignatureScheme,
+};
 
 // [OPUS-4.8] audit #12: revocation/freshness plumbing. The fixtures bind a
 // status-list reference (list `http://ex/status/1`, index 3, version 1) under the
@@ -735,6 +740,7 @@ fn full_manifest_prove_verify_scan() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -876,6 +882,7 @@ fn forge_positive_honest_filter_verifies() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -911,6 +918,7 @@ fn forge_reject_statement_substitution() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -946,6 +954,7 @@ fn forge_reject_verdict_substitution() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -983,6 +992,7 @@ fn forge_reject_challenge_rebind() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0xdead"),
         &InMemorySeenNonces::new(),
@@ -1042,6 +1052,7 @@ fn nonce_happy_path_fresh_nonce_verifies() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for(nonce_hex),
         &InMemorySeenNonces::new(),
@@ -1079,6 +1090,7 @@ fn nonce_replay_under_new_nonce_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0xbeef"),
         &InMemorySeenNonces::new(),
@@ -1116,6 +1128,7 @@ fn nonce_single_use_second_presentation_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce,
         &seen,
@@ -1129,6 +1142,7 @@ fn nonce_single_use_second_presentation_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce,
         &seen,
@@ -1211,6 +1225,7 @@ fn nonce_binding_mismatch_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce,
         &seen,
@@ -1231,6 +1246,7 @@ fn nonce_binding_mismatch_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce,
         &seen,
@@ -1317,6 +1333,7 @@ fn holder_pop_empty_registry_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(), // no authorised holders
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -1352,6 +1369,7 @@ fn holder_pop_untrusted_holder_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &registry,
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -1387,6 +1405,7 @@ fn holder_pop_invalid_signature_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &registry,
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -1419,12 +1438,356 @@ fn holder_pop_unknown_cryptosuite_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &registry,
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
     ) {
         Err(CheckError::HolderPopMalformed) => {}
         other => panic!("an unknown cryptosuite must be HolderPopMalformed, got {other:?}"),
+    }
+}
+
+// --- sq-z8s7 (HolderPoP T3 / B1): issuer-attested clear-key holder binding ----
+//
+// [OPUS-4.8] sq-z8s7 (T3 / B1). The sq-cwq HolderPop above binds the presenter to
+// the verifier's NONCE but NOT to the CREDENTIAL the issuer issued, so trusted
+// holder A could present trusted holder B's credential (the trusted-holder gap,
+// `research/zk-holder-pop-design.md` §0). B1 closes it at the clear-key tier:
+// `bind_holder_binding` cross-checks the PRESENTED holder key against the
+// issuer-attested `holder_pk_digest` the issuer folded into THIS credential's
+// `commitment_message_with_holder` (ZKSIG_C4) signature, verified under the
+// external trusted K, and fail-closes on mismatch / required-but-absent binding /
+// identity key. These tests fire at `bind_holder_pop` (BEFORE the bb sub-proof
+// loop), so the negative cases need no toolchain; the POSITIVE-binding cases pass
+// the holder gate and then stop at `MissingProof` (empty `proof_hex`), which proves
+// the holder binding was ACCEPTED (the full forge-and-verify suite is T4/sq-ncz0).
+
+/// A SALT-, STATUS- AND HOLDER-bound attestation (T3/sq-z8s7 B1): the issuer signs
+/// `commitment_message_with_holder(C(G), salt, status_ref, holder_pk_digest)` (the
+/// ZKSIG_C4 variant), binding the holder key `hpk` into THIS credential. The
+/// `status_ref` folds the fixture `(H(list), index, version)` exactly as the
+/// status-bound attestation does, so the verifier recomputes the same message from
+/// the disclosed `manifest.revocation`. `disclose_key` selects the clear-key tier
+/// (B1, `Some(holder_public_key)`); a hidden-tier binding would pass `false`.
+fn attest_with_holder(
+    commitment: Fr,
+    salt: Fr,
+    hpk: &sparq_zk::sig::PublicKey,
+    disclose_key: bool,
+    sk: &SecretKey,
+) -> CommitmentAttestation {
+    let list_id = sparq_zk::sig::status_list_id_to_field(FIXTURE_STATUS_LIST);
+    let status_ref =
+        sparq_zk::sig::status_ref_digest(&list_id, FIXTURE_STATUS_INDEX, FIXTURE_STATUS_VERSION);
+    let holder_digest = holder_key_digest(hpk).expect("non-identity holder key digests");
+    CommitmentAttestation {
+        commitment: FieldHex::from_field(&commitment),
+        issuer_public_key: public_key_to_hex(&sk.public_key()),
+        signature: sk.sign_commitment_with_holder(&commitment, &salt, &status_ref, &holder_digest),
+        cryptosuite: SignatureScheme::Poseidon2SchnorrV1
+            .cryptosuite_iri()
+            .to_string(),
+        salt: Some(FieldHex::from_field(&salt)),
+        status: Some(AttestedStatusRef {
+            index: Some(FIXTURE_STATUS_INDEX),
+            version: FIXTURE_STATUS_VERSION,
+            index_commitment: None,
+        }),
+        holder: Some(
+            AttestedHolderBinding::from_holder_key(hpk, disclose_key)
+                .expect("non-identity holder key binds"),
+        ),
+    }
+}
+
+/// Attach a HOLDER-bound issuer attestation for every scan commitment in `m` under
+/// the fixed test issuer key + the per-graph `salt`, binding `hpk` as the
+/// issuer-attested holder, and disclose the issuer key in K. The analogue of
+/// `attest_all` but for the holder-bound (ZKSIG_C4) message variant, so the
+/// manifest reaches the T3/B1 cross-check with a credential the issuer bound to
+/// `hpk`.
+fn attest_all_holder(
+    m: &mut ProofManifest,
+    sk: &SecretKey,
+    salt: Fr,
+    hpk: &sparq_zk::sig::PublicKey,
+    disclose_key: bool,
+) {
+    let pk_hex = public_key_to_hex(&sk.public_key());
+    let mut seen = std::collections::BTreeSet::new();
+    for c in scan_commitments(m) {
+        let key = sparq_zk::field::field_to_hex(&c);
+        if seen.insert(key) {
+            m.commitment_attestations
+                .push(attest_with_holder(c, salt, hpk, disclose_key, sk));
+        }
+    }
+    if !m.key_set.contains(&pk_hex) {
+        m.key_set.push(pk_hex);
+    }
+}
+
+/// Build a HolderPop-bound manifest whose credential is ISSUER-ATTESTED-HOLDER-bound
+/// to `attested_holder` (the issuer folds `holder_key_digest(attested_holder)` into
+/// the signature), while the PRESENTED holder key + PoP are `presented_holder`'s.
+/// When `presented_holder == attested_holder` the B1 cross-check passes; when they
+/// differ it is the A-presents-B forge. `disclose_key` controls whether the
+/// attestation carries the clear `hpk` (clear-key tier). `proof_hex` is empty so
+/// the holder gate fires before any bb call.
+fn holder_bound_manifest(
+    presented_holder: &SecretKey,
+    attested_holder: &sparq_zk::sig::PublicKey,
+    disclose_key: bool,
+) -> ProofManifest {
+    let salt = salt_from_bytes(&[9u8; 32]);
+    let scan = scan_inputs_for(&credential_graph(), "http://ex/age");
+    let presented_hex = public_key_to_hex(&presented_holder.public_key());
+    let mut m = ProofManifest {
+        r#type: "urn:sparq:zk:ProofManifest".into(),
+        query: "SELECT ?s ?o WHERE { ?s <http://ex/age> ?o }".into(),
+        issuers: vec![],
+        key_set: vec![],
+        commitment_attestations: vec![],
+        attributions: vec![vec![0]],
+        join_obligations: vec![],
+        entailment_regime: EntailmentRegime::Simple,
+        derivation_steps: vec![],
+        binding: BindingMode::HolderPop {
+            challenge: FieldHex("0x2a".into()),
+            holder: presented_hex,
+            pop: holder_pop_over_2a(presented_holder),
+            cryptosuite: SignatureScheme::Poseidon2SchnorrV1
+                .cryptosuite_iri()
+                .to_string(),
+        },
+        revocation: Some(fixture_revocation()),
+        status_snapshots: vec![fixture_snapshot(false)],
+        sub_proofs: vec![SubProof {
+            inputs: scan,
+            proof_hex: String::new(),
+        }],
+        binding_edges: vec![],
+        hidden_revocation: None,
+        hidden_issuer_attestations: vec![],
+    };
+    attest_all_holder(
+        &mut m,
+        &test_issuer_sk(1),
+        salt,
+        attested_holder,
+        disclose_key,
+    );
+    m
+}
+
+/// sq-z8s7 (B1 POSITIVE): a correctly-bound presentation — the PRESENTED holder
+/// key digest == the issuer-attested digest (and the disclosed clear key matches) —
+/// PASSES the holder-binding gate. With an empty `proof_hex` the verifier then
+/// stops at `MissingProof` (the bb sub-proof loop), which is downstream of and
+/// distinct from any holder-binding rejection: the credential↔holder binding was
+/// ACCEPTED. No toolchain needed.
+#[test]
+fn holder_binding_correctly_bound_passes_binding_gate() {
+    let prover = CircuitProver::from_crate_root();
+    let holder_sk = SecretKey::from_seed(777);
+    let holder_hex = public_key_to_hex(&holder_sk.public_key());
+    let registry = HolderRegistry::from_hex_keys([holder_hex]);
+    // Issuer bound THIS holder; the presenter IS that holder.
+    let m = holder_bound_manifest(&holder_sk, &holder_sk.public_key(), true);
+    match verify_manifest(
+        &m,
+        &prover,
+        &scratch("holder_binding_ok"),
+        &trusted_k(&test_issuer_sk(1)),
+        &fresh_policy(),
+        &registry,
+        &HolderBindingPolicy::require_binding(),
+        &EntailmentPolicy::simple_only(),
+        &nonce_for("0x2a"),
+        &InMemorySeenNonces::new(),
+    ) {
+        // Passed the holder-binding gate; stops at the (absent) bb proof.
+        Err(CheckError::MissingProof { proof: 0 }) => {}
+        Ok(()) => panic!("unexpected Ok without a bb proof"),
+        other => panic!(
+            "a correctly-bound holder presentation must PASS the binding gate \
+             (reaching MissingProof), got {other:?}"
+        ),
+    }
+}
+
+/// sq-z8s7 (B1 — THE CORE TRUSTED-HOLDER-GAP CLOSURE): "A presents B's credential".
+/// The credential is issuer-attested-holder-bound to holder B, but the presentation
+/// is by trusted holder A (A's key, A's valid PoP). A is a member of the registry
+/// and A's PoP over the nonce verifies — exactly the gap sq-cwq left open — yet the
+/// presentation is REJECTED because A's `holder_key_digest` != B's issuer-attested
+/// digest (`HolderKeyMismatch`). This is the load-bearing test. No toolchain needed.
+#[test]
+fn holder_binding_a_presents_b_rejected() {
+    let prover = CircuitProver::from_crate_root();
+    let holder_a = SecretKey::from_seed(777); // the presenter (trusted)
+    let holder_b = SecretKey::from_seed(888); // the credential's true subject
+    let a_hex = public_key_to_hex(&holder_a.public_key());
+    // BOTH A and B are authorised holders (registry membership is NOT the gap).
+    let registry =
+        HolderRegistry::from_hex_keys([a_hex, public_key_to_hex(&holder_b.public_key())]);
+    // Issuer bound B, but A presents (A's key + A's valid PoP over the nonce).
+    let m = holder_bound_manifest(&holder_a, &holder_b.public_key(), true);
+    match verify_manifest(
+        &m,
+        &prover,
+        &scratch("holder_binding_a_presents_b"),
+        &trusted_k(&test_issuer_sk(1)),
+        &fresh_policy(),
+        &registry,
+        // Even the back-compatible policy MUST reject: when a binding is PRESENT
+        // the cross-check always runs (the policy only governs the bearer-absent
+        // case).
+        &HolderBindingPolicy::allow_bearer(),
+        &EntailmentPolicy::simple_only(),
+        &nonce_for("0x2a"),
+        &InMemorySeenNonces::new(),
+    ) {
+        Err(CheckError::HolderKeyMismatch) => {}
+        other => panic!(
+            "trusted holder A presenting trusted holder B's credential MUST be \
+             rejected HolderKeyMismatch (the trusted-holder gap), got {other:?}"
+        ),
+    }
+}
+
+/// The Baby-JubJub IDENTITY point in compressed hex (`public_key_to_hex` of the
+/// curve identity). `public_key_from_hex` REJECTS it fail-closed (the identity has
+/// no usable key / `holder_key_digest` errors with
+/// [`sparq_zk::sig::HolderKeyError::IdentityKey`]; verified in sparq-zk's own
+/// `identity_holder_key_digest_rejected`), so a `HolderPop` presenting it cannot be
+/// honoured. Hardcoded (the compressed encoding is a stable constant) to avoid
+/// pulling the raw ark curve types into this crate's deps.
+// [OPUS-4.8] sq-z8s7 (HolderPoP T3 / B1): identity-key compressed encoding.
+const IDENTITY_HOLDER_HEX: &str =
+    "0100000000000000000000000000000000000000000000000000000000000000";
+
+/// sq-z8s7 (B1): the IDENTITY holder key is rejected fail-closed. The identity
+/// point has no affine coordinates, so `holder_key_digest` errors — the guard
+/// `bind_holder_binding` relies on so a degenerate key can never match an
+/// issuer-attested digest (design §4.1: the identity-key guard rules out the
+/// degenerate forgery). At the presentation boundary an identity holder key in the
+/// `HolderPop` binding never parses to a usable key (`public_key_from_hex` => None),
+/// so the Schnorr PoP cannot be checked under it and it is refused
+/// (`HolderPopMalformed`) before the B1 cross-check is even reached. There is NO
+/// path on which an identity holder key is honoured. No toolchain needed.
+#[test]
+fn holder_binding_identity_key_rejected() {
+    // Sanity: the identity hex really is the rejected identity key — it does NOT
+    // parse to a usable holder key, and a HolderRegistry REFUSES to store it (so it
+    // can never be a trusted/authorised holder, fail-closed at construction).
+    assert!(
+        public_key_from_hex(IDENTITY_HOLDER_HEX).is_none(),
+        "the identity key must NOT parse to a usable holder key (fail-closed)"
+    );
+    assert!(
+        HolderRegistry::from_hex_keys([IDENTITY_HOLDER_HEX.to_string()]).is_empty(),
+        "a HolderRegistry must drop the identity key (it can never be a real holder)"
+    );
+
+    let prover = CircuitProver::from_crate_root();
+    // A real, trusted holder + a holder-bound credential, then swap the PRESENTED
+    // key to the identity. The registry only trusts the real holder; the identity
+    // cannot even be added to it (dropped above), so the identity presentation is
+    // refused fail-closed.
+    let holder_sk = SecretKey::from_seed(777);
+    let registry = HolderRegistry::from_hex_keys([
+        public_key_to_hex(&holder_sk.public_key()),
+        IDENTITY_HOLDER_HEX.to_string(), // dropped — the identity is not storable
+    ]);
+    let mut m = holder_bound_manifest(&holder_sk, &holder_sk.public_key(), true);
+    if let BindingMode::HolderPop { holder, .. } = &mut m.binding {
+        *holder = IDENTITY_HOLDER_HEX.to_string();
+    }
+    match verify_manifest(
+        &m,
+        &prover,
+        &scratch("holder_binding_identity"),
+        &trusted_k(&test_issuer_sk(1)),
+        &fresh_policy(),
+        &registry,
+        &HolderBindingPolicy::require_binding(),
+        &EntailmentPolicy::simple_only(),
+        &nonce_for("0x2a"),
+        &InMemorySeenNonces::new(),
+    ) {
+        // Refused fail-closed. The identity is never a trusted holder (the registry
+        // dropped it => HolderNotTrusted), never parses to a usable key for the PoP
+        // (=> HolderPopMalformed), and could never match an issuer-attested digest
+        // (=> HolderKeyMismatch in `bind_holder_binding`). ANY of these is a correct
+        // fail-closed rejection; there is NO path on which the identity is honoured.
+        Err(CheckError::HolderNotTrusted { .. })
+        | Err(CheckError::HolderPopMalformed)
+        | Err(CheckError::HolderKeyMismatch) => {}
+        other => panic!("an identity holder key must be rejected fail-closed, got {other:?}"),
+    }
+}
+
+/// sq-z8s7 (B1 bearer policy): a BEARER credential (no `AttestedHolderBinding` on
+/// any attestation) presented under HolderPop is REJECTED when the relying party
+/// mandates binding (`require_binding` => `HolderBindingMissing`), and ACCEPTED
+/// past the holder gate under the back-compatible default (`allow_bearer`, reaching
+/// `MissingProof`). The two directions of the design's "bearer must be rejectable"
+/// policy. No toolchain needed.
+#[test]
+fn holder_binding_bearer_policy_required_vs_allowed() {
+    let prover = CircuitProver::from_crate_root();
+    let holder_sk = SecretKey::from_seed(777);
+    let holder_hex = public_key_to_hex(&holder_sk.public_key());
+    let registry = HolderRegistry::from_hex_keys([holder_hex.clone()]);
+    // A BEARER HolderPop manifest: `holder_pop_manifest` uses `attest_all` (status-
+    // bound, holder: None) — no issuer-attested holder binding.
+    let m = holder_pop_manifest(
+        &holder_hex,
+        &holder_pop_over_2a(&holder_sk),
+        SignatureScheme::Poseidon2SchnorrV1.cryptosuite_iri(),
+    );
+
+    // (a) require_binding: a bearer credential is rejected fail-closed.
+    match verify_manifest(
+        &m,
+        &prover,
+        &scratch("holder_binding_bearer_required"),
+        &trusted_k(&test_issuer_sk(1)),
+        &fresh_policy(),
+        &registry,
+        &HolderBindingPolicy::require_binding(),
+        &EntailmentPolicy::simple_only(),
+        &nonce_for("0x2a"),
+        &InMemorySeenNonces::new(),
+    ) {
+        Err(CheckError::HolderBindingMissing) => {}
+        other => panic!(
+            "a bearer credential under require_binding must be HolderBindingMissing, got {other:?}"
+        ),
+    }
+
+    // (b) allow_bearer (default): the bearer credential passes the holder gate
+    // (sq-cwq registry + nonce-PoP) and stops at the absent bb proof.
+    match verify_manifest(
+        &m,
+        &prover,
+        &scratch("holder_binding_bearer_allowed"),
+        &trusted_k(&test_issuer_sk(1)),
+        &fresh_policy(),
+        &registry,
+        &HolderBindingPolicy::allow_bearer(),
+        &EntailmentPolicy::simple_only(),
+        &nonce_for("0x2a"),
+        &InMemorySeenNonces::new(),
+    ) {
+        Err(CheckError::MissingProof { proof: 0 }) => {}
+        Ok(()) => panic!("unexpected Ok without a bb proof"),
+        other => panic!(
+            "a bearer credential under allow_bearer must PASS the holder gate \
+             (reaching MissingProof), got {other:?}"
+        ),
     }
 }
 
@@ -1495,6 +1858,7 @@ fn holder_pop_valid_verifies_end_to_end() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &registry,
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -1563,6 +1927,7 @@ fn malformed_proof_hex_rejected_not_panicked() {
             &trusted_k(&test_issuer_sk(1)),
             &fresh_policy(),
             &HolderRegistry::empty(),
+            &HolderBindingPolicy::allow_bearer(),
             &EntailmentPolicy::simple_only(),
             &nonce_for("0x2a"),
             &InMemorySeenNonces::new(),
@@ -1611,6 +1976,7 @@ fn forge_reject_noncanonical_vk() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -1647,6 +2013,7 @@ fn forge_artvk_is_ignored() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -3512,6 +3879,7 @@ fn revocation_full_prove_verify_non_revoked_verifies() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -3554,6 +3922,7 @@ fn revocation_full_prove_verify_revoked_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &revoked_policy(), // AUTHORITATIVE snapshot has bit 3 SET => REVOKED.
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -3852,6 +4221,7 @@ fn hidden_revocation_unrevoked_verifies_and_index_is_private() {
         &trusted_k(&test_issuer_sk(1)),
         &hidden_policy(false),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -3933,6 +4303,7 @@ fn hidden_revocation_forged_root_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &hidden_policy(false), // authoritative root derived from the real snapshot
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -4138,7 +4509,7 @@ fn hidden_issuer_in_set_verifies_and_key_is_private() {
     manifest.hidden_issuer_attestations = vec![hidden];
     verify_manifest(
         &manifest, &prover, &scratch("hi_verify_ok"),
-        &keyset, &fresh_policy(), &HolderRegistry::empty(), &EntailmentPolicy::simple_only(), &nonce_for("0x2a"), &InMemorySeenNonces::new(),
+        &keyset, &fresh_policy(), &HolderRegistry::empty(), &HolderBindingPolicy::allow_bearer(), &EntailmentPolicy::simple_only(), &nonce_for("0x2a"), &InMemorySeenNonces::new(),
     )
     .expect("in-set hidden-issuer attestation verifies end-to-end");
 }
@@ -4226,7 +4597,7 @@ fn hidden_issuer_only_verifies_with_clear_key_absent() {
     verify_manifest(
         &manifest, &prover, &scratch("hi_only_verify"),
         &keyset, &fresh_policy(),
-        &HolderRegistry::empty(), &EntailmentPolicy::simple_only(),
+        &HolderRegistry::empty(), &HolderBindingPolicy::allow_bearer(), &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"), &InMemorySeenNonces::new(),
     )
     .expect("hidden-only presentation (clear key absent) verifies end-to-end");
@@ -4370,7 +4741,7 @@ fn hidden_issuer_forged_root_rejected() {
     }];
     match verify_manifest(
         &manifest, &prover, &scratch("hi_verify_forge"),
-        &keyset, &fresh_policy(), &HolderRegistry::empty(), &EntailmentPolicy::simple_only(), &nonce_for("0x2a"), &InMemorySeenNonces::new(),
+        &keyset, &fresh_policy(), &HolderRegistry::empty(), &HolderBindingPolicy::allow_bearer(), &EntailmentPolicy::simple_only(), &nonce_for("0x2a"), &InMemorySeenNonces::new(),
     ) {
         Err(CheckError::HiddenIssuerRootMismatch) => {}
         other => panic!("a forged-root hidden-issuer proof must be HiddenIssuerRootMismatch, got {other:?}"),
@@ -4407,7 +4778,7 @@ fn hidden_issuer_not_enabled_rejected() {
     // the unit test in verifier.rs. We assert SOME rejection here (fail-closed).
     let res = verify_manifest(
         &m, &prover, &scratch("hi_notenabled"),
-        &k, &fresh_policy(), &HolderRegistry::empty(), &EntailmentPolicy::simple_only(), &nonce_for("0x2a"), &InMemorySeenNonces::new(),
+        &k, &fresh_policy(), &HolderRegistry::empty(), &HolderBindingPolicy::allow_bearer(), &EntailmentPolicy::simple_only(), &nonce_for("0x2a"), &InMemorySeenNonces::new(),
     );
     assert!(res.is_err(), "a manifest with hidden-issuer attestation under a non-opted-in KeySet must be rejected");
 }
@@ -4586,6 +4957,7 @@ fn filter_f64_composes_end_to_end() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),
@@ -4690,6 +5062,7 @@ fn run_entailment(m: &ProofManifest, policy: &EntailmentPolicy) -> Result<(), Ch
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         policy,
         &nonce_for("0x2a"),
         &InMemorySeenNonces::new(),

--- a/crates/sparq-zk-compose/tests/e2e.rs
+++ b/crates/sparq-zk-compose/tests/e2e.rs
@@ -1791,6 +1791,102 @@ fn holder_binding_bearer_policy_required_vs_allowed() {
     }
 }
 
+/// sq-z8s7 (B1 — THE LOAD-BEARING SCOPING TEST, Copilot review on #142): a holder
+/// binding on an UNRELATED attestation (one covering NO scan-referenced commitment)
+/// must NOT satisfy the holder-binding check for the credential actually presented.
+///
+/// The earlier `bind_holder_binding` treated the presentation as "bound" if ANY
+/// `manifest.commitment_attestations` entry carried `holder: Some(_)`, regardless of
+/// whether that attestation covered a scan-referenced commitment. So a holder
+/// binding on a stray, unrelated attestation could pass the check while the
+/// credential genuinely presented (the scan's covering attestation) was bearer — the
+/// A-presents-B closure would silently lapse. THE FIX ties the binding to the
+/// attestation that COVERS the scan-referenced commitment (the same
+/// attestation→commitment mapping `bind_issuer_attestations` uses).
+///
+/// This fixture builds a manifest whose ONLY scan-referenced commitment has a BEARER
+/// (status-only, `holder: None`) covering attestation, then ADDS an UNRELATED
+/// holder-bound attestation over a DIFFERENT commitment value bound to the
+/// presenter's own key. Under the buggy "any attestation" path the unrelated binding
+/// (whose digest == the presenter) would PASS; under the scoped fix the scan's
+/// covering attestation is bearer, so under `require_binding` the presentation is
+/// REJECTED `HolderBindingMissing` (bearer-where-binding-required). The loose
+/// "any attestation" path is closed. No toolchain needed.
+#[test]
+fn holder_binding_unrelated_attestation_does_not_satisfy_scoped_check() {
+    let prover = CircuitProver::from_crate_root();
+    let salt = salt_from_bytes(&[9u8; 32]);
+    let holder_sk = SecretKey::from_seed(777); // the presenter (trusted)
+    let holder_hex = public_key_to_hex(&holder_sk.public_key());
+    let registry = HolderRegistry::from_hex_keys([holder_hex.clone()]);
+    let issuer = test_issuer_sk(1);
+
+    // A BEARER HolderPop manifest: the scan's covering attestation is status-only
+    // (`holder: None`) via `attest_all`, and the presented key + PoP are the
+    // trusted holder's (so registry + nonce-PoP succeed; only the credential↔holder
+    // binding is at issue).
+    let mut m = holder_pop_manifest(
+        &holder_hex,
+        &holder_pop_over_2a(&holder_sk),
+        SignatureScheme::Poseidon2SchnorrV1.cryptosuite_iri(),
+    );
+
+    // Sanity: the scan's covering attestation must really be BEARER (no holder
+    // binding) — the precondition the scoping bug would otherwise let an unrelated
+    // binding paper over.
+    let scan_commitment = scan_commitments(&m)[0];
+    let scan_hex = sparq_zk::field::field_to_hex(&scan_commitment);
+    assert!(
+        m.commitment_attestations
+            .iter()
+            .filter(|a| a.commitment.to_field() == Some(scan_commitment))
+            .all(|a| a.holder.is_none()),
+        "fixture precondition: the scan's covering attestation is bearer (holder: None)"
+    );
+
+    // ADD an UNRELATED holder-bound attestation over a DIFFERENT commitment value
+    // (NOT any scan-referenced commitment), bound to the PRESENTER'S OWN key — the
+    // exact shape that would falsely satisfy the buggy "any attestation has a
+    // holder" shortcut. Its commitment is a distinct field element (scan + 1), so it
+    // covers no scan sub-proof.
+    let unrelated_commitment = scan_commitment + Fr::from(1u64);
+    assert_ne!(
+        sparq_zk::field::field_to_hex(&unrelated_commitment),
+        scan_hex,
+        "the unrelated attestation must cover a DIFFERENT commitment than the scan"
+    );
+    m.commitment_attestations.push(attest_with_holder(
+        unrelated_commitment,
+        salt,
+        &holder_sk.public_key(),
+        true,
+        &issuer,
+    ));
+
+    // Under `require_binding`: the SCAN-REFERENCED commitment's covering attestation
+    // is bearer, so the presentation is bearer-where-binding-required and REJECTED —
+    // the unrelated holder binding does NOT rescue it (the scoping bug is closed).
+    match verify_manifest(
+        &m,
+        &prover,
+        &scratch("holder_binding_unrelated_scope"),
+        &trusted_k(&issuer),
+        &fresh_policy(),
+        &registry,
+        &HolderBindingPolicy::require_binding(),
+        &EntailmentPolicy::simple_only(),
+        &nonce_for("0x2a"),
+        &InMemorySeenNonces::new(),
+    ) {
+        Err(CheckError::HolderBindingMissing) => {}
+        other => panic!(
+            "a holder binding on an UNRELATED attestation must NOT satisfy the scoped \
+             check for a bearer scan-referenced credential under require_binding \
+             (expected HolderBindingMissing — the scoping bug is closed), got {other:?}"
+        ),
+    }
+}
+
 /// sq-cwq (POSITIVE, end-to-end): a HolderPop with a trusted holder + a VALID PoP
 /// over the verifier nonce, atop a real scan+filter proof, verifies end-to-end.
 /// Toolchain-gated (full bb prove of the sub-proof). This is the "implemented"

--- a/crates/sparq-zk-compose/tests/forge_gates.rs
+++ b/crates/sparq-zk-compose/tests/forge_gates.rs
@@ -41,7 +41,7 @@ use sparq_zk_compose::manifest::{
 };
 use sparq_zk_compose::toml::prover_toml_for;
 use sparq_zk_compose::verifier::{
-    encode_artifacts, verify_manifest, CheckError, EntailmentPolicy, HolderRegistry,
+    encode_artifacts, verify_manifest, CheckError, EntailmentPolicy, HolderBindingPolicy, HolderRegistry,
     InMemorySeenNonces, KeySet, RevocationPolicy, VerifierNonce,
 };
 
@@ -194,6 +194,7 @@ fn verify_full(m: &ProofManifest, name: &str) -> Result<(), CheckError> {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for(CHALLENGE_HEX),
         &InMemorySeenNonces::new(),
@@ -367,6 +368,7 @@ fn forge_revocation_revoked_bit_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &revoked_policy(), // authoritative bit SET
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for(CHALLENGE_HEX),
         &InMemorySeenNonces::new(),
@@ -396,6 +398,7 @@ fn forge_revocation_stale_version_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &policy,
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for(CHALLENGE_HEX),
         &InMemorySeenNonces::new(),
@@ -422,6 +425,7 @@ fn forge_nonce_binding_mismatch_rejected() {
         &trusted_k(&test_issuer_sk(1)),
         &fresh_policy(),
         &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
         &EntailmentPolicy::simple_only(),
         &nonce_for("0x99"),
         &InMemorySeenNonces::new(),
@@ -450,6 +454,7 @@ fn forge_nonce_replay_rejected() {
             &trusted_k(&test_issuer_sk(1)),
             &fresh_policy(),
             &HolderRegistry::empty(),
+            &HolderBindingPolicy::allow_bearer(),
             &EntailmentPolicy::simple_only(),
             &nonce,
             &seen,


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead **sq-z8s7** (ZK, sparq-zk-compose): **T3** of the issuer-attested credential-bound HolderPoP plan. Authored by Claude Opus 4.8 (Fable 5 unavailable; `[OPUS-4.8]` markers + commit trailer for re-review when Fable returns). One of multiple agents on @jeswr's account.

## What this closes — the trusted-holder gap (B1, clear-key tier)

`sq-cwq`'s `HolderPop` check binds the presenter to the verifier's fresh **nonce** (proof of possession of *a* registry-trusted key) but **NOT to the credential the issuer issued**. So trusted holder **A could present trusted holder B's credential**: A holds a trusted key and signs the nonce with it, while the scan/filter sub-proofs attest B's credential. This PR implements **T3 / B1** (`research/zk-holder-pop-design.md` §3.3) — the **verifier-side, issuer-attested, clear-key** holder binding — which converts the holder check from *"is the presenter on the allow-list"* to *"is the presenter the subject the issuer bound into THIS credential"*.

## How the binding check works

When a credential's `CommitmentAttestation` carries an issuer-attested `AttestedHolderBinding` (T2), the issuer folded `holder_key_digest(hpk)` into its signature via the **distinct `ZKSIG_C4`** `commitment_message_with_holder(C(G), salt, status_ref, holder_pk_digest)` message (T1). The verifier now:

1. **Anchors the attested digest in the issuer signature.** `bind_issuer_attestations` selects the **holder-bound message variant** when an attestation carries a holder binding, so a holder-bound credential passes the main attestation gate AND the `holder_pk_digest` is verified under the **EXTERNAL trusted `KeySet K`** (never a free prover JSON field — design §4.3 obligation 1). A swapped digest yields a different message ⇒ no valid signature (EUF-CMA).
2. **Cross-checks the presented key (`bind_holder_binding`, called by `bind_holder_pop`).** Recomputes `holder_key_digest(presented_pk)` — the SAME key the freshness PoP was verified under — and asserts it equals the attested `holder_pk_digest`. So the digest check **+** the existing nonce-PoP together bind THIS holder to THIS credential. Any mismatch ⇒ **`HolderKeyMismatch`** (fail-closed). Identity holder key (no usable digest) and a disclosed clear key that disagrees with the presented key are also rejected.

## Bearer policy (fail-closed, back-compatible default)

New external `HolderBindingPolicy` (mirrors `RevocationPolicy`/`EntailmentPolicy`):

- `HolderBindingPolicy::require_binding()` — a **bearer** credential (no `AttestedHolderBinding` on any attestation) presented under `HolderPop` is rejected fail-closed (**`HolderBindingMissing`**, the design's "bearer must be rejectable" requirement, the audit-#12 `status:None ⇒ reject` precedent).
- `HolderBindingPolicy::allow_bearer()` (**default**) — bearer keeps the sq-cwq registry + nonce-PoP behaviour, so existing callers/tests are unaffected.
- A **present** binding is **always** cross-checked regardless of policy (the policy governs only the bearer-absent case).

## Tests (all green, no toolchain — the gate fires before the bb sub-proof loop)

- `holder_binding_correctly_bound_passes_binding_gate` — correctly-bound presentation PASSES the holder gate.
- **`holder_binding_a_presents_b_rejected`** — the core trusted-holder-gap closure: A (trusted, valid PoP, in registry) presenting B's credential is **REJECTED** `HolderKeyMismatch`.
- `holder_binding_identity_key_rejected` — identity holder key rejected fail-closed.
- `holder_binding_bearer_policy_required_vs_allowed` — bearer REJECTED under `require_binding`, ACCEPTED under `allow_bearer`.
- All existing `bind_holder_pop` / forge / e2e tests stay green; every `verify_manifest` call site updated with the new policy arg.

## Scope

This is the **clear-key tier (B1)**: the presented holder key is disclosed and the verifier recomputes its digest host-side. The **in-circuit hidden-key PoK (B2)** — where only the digest is public (no holder-key linkability) — is **bead sq-i1dt**, NOT implemented here. The full forge-and-verify suite is **T4 / sq-ncz0**.

## Gate

- `cargo test -p sparq-zk-compose` — clean (90 passed in e2e incl. the 4 new B1 tests; toolchain/slow lanes auto-ignored without nargo/bb).
- `cargo clippy -p sparq-zk-compose --all-targets -- -D warnings` — clean.
- Touches only `sparq-zk-compose` (verifier.rs, 3 test files, README). Branch base is a clean ancestor of `main`; nothing landed on the crate since base, so it merges cleanly. fmt left as-is per repo's deferred-reformat policy (informational CI gate).

Refs: bead **sq-z8s7**, `research/zk-holder-pop-design.md` §3.3 (B1) / §4 (soundness). B2 = sq-i1dt; T4 forge suite = sq-ncz0.