### PR TITLE
feat(dashboard): versioned static competitor data + external-reference baselines (sq-i0nm) [OPUS-4.8]

### DIFF
--- a/bench/dashboard/competitors.json
+++ b/bench/dashboard/competitors.json
@@ -1,0 +1,71 @@
+{
+  "_comment": [
+    "[OPUS-4.8] Versioned STATIC competitor-comparison data for the perf dashboard (bead sq-i0nm;",
+    "the featured-suites section sq-xvow + scaling charts sq-viby are its DONE children sq-ocuf/sq-viby).",
+    "Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).",
+    "",
+    "WHAT THIS FILE IS. The dashboard (bench/dashboard/dashboard.js) reads competitor numbers from",
+    "window.COMPETITORS to draw external-engine reference COLUMNS next to sparq in the featured-suites",
+    "table, and per-suite external-reference baseline rows. The numbers are GATHERED ONCE / STATIC —",
+    "NOT measured per-CI — and pinned to an explicit tool VERSION + machine + source for transparency.",
+    "This is the human-reviewable source-of-record; dashboard.js embeds a BYTE-IDENTICAL copy of the",
+    "`engines`/`values`/`references` keys below as COMPETITORS_DATA so the page renders on GitHub",
+    "Pages (the bench.yml seed step copies only index.html/dashboard.js/dashboard.css/metric-labels.json,",
+    "so a separate JSON is NOT served — the embedded copy is what the live page uses; THIS file is the",
+    "canonical mirror reviewers diff). Keep the two in sync: the `engines`/`values`/`references` data",
+    "rows here must equal COMPETITORS_DATA in dashboard.js (only this `_comment` is file-only).",
+    "",
+    "HONESTY (per parent sq-i0nm design + the empirical-honesty rule). Competitor numbers are shown",
+    "ONLY where a real, cited measurement exists ON A COMPARABLE BENCHMARK. The per-commit dashboard",
+    "metrics run at CI scale (~200k-entity synthetic, real-DBpedia 750k cut, SP2Bench 250k, WatDiv",
+    "SF=1, LUBM(1)) on a GitHub-hosted runner. NO in-repo competitor number was measured on that exact",
+    "same dataset-scale + machine + regime, so EVERY per-metric competitor cell is \"n/a (not gathered)\"",
+    "rather than a fabricated apples-to-oranges figure (a 10M-scale QLever ms placed next to a 200k µs",
+    "would mislead). The numbers we DO have (QLever 0.5.47 on a 2020 MacBook Air M1 16GB native at the",
+    "10M/100M synthetic scale, bench/qlever-baselines.md; EYE v11.24.4 DeepTaxonomy forward closures on",
+    "the same M1, bench/inference/eye-comparison.md) are surfaced as clearly-captioned EXTERNAL-REFERENCE",
+    "baselines that state their own scale/machine/source — NEVER aligned into a same-row comparison with",
+    "a mismatched sparq metric. Oxigraph 0.5.8 is an embedded Rust dev-dep (Cargo.lock-resolved) with NO",
+    "committed dashboard-scale numbers; RDFox has only vendor/paper figures (research/inference-sota.md",
+    "§1.1), no in-repo head-to-head — both are listed with their version but every cell is n/a. To FILL",
+    "the per-metric `values` cells, gather competitors on a quiet box at the SAME scale as the dashboard",
+    "run (scripts/gather-competitors.sh --run --only <id>; see the bench/competitors.json registry +",
+    "bench/CATALOG.md) and commit the snapshot here + into COMPETITORS_DATA. Follow-up tracked as a bead",
+    "(see the PR body for sq-i0nm).",
+    "",
+    "SHAPE (verified against dashboard.js buildFeatured/competitorsFor/competitorEngines):",
+    "  engines: [{ id, label, version, env, source }]    -> one competitor COLUMN each (header shows",
+    "                                                        label + version inline; env+source on hover).",
+    "  values:  { \"<metric name or stem>\": { \"<engineId>\": <number-in-the-metric's-unit> } }",
+    "           -> a per-metric competitor cell; matched by raw metric NAME first then stem (name minus",
+    "              _us). A MISSING key renders \"n/a\". EMPTY here BY DESIGN (see HONESTY).",
+    "  references: [{ suite, engine, version, env, scale, metric, value, unit, regime, source, caveat }]",
+    "           -> the dashboard's per-suite \"external reference baselines\" note: real cited numbers",
+    "              with their OWN scale/machine, shown SEPARATELY from the same-scale comparison cells.",
+    "              `suite` matches a featured-suite key in dashboard.js (e.g. \"Synthetic (qlever-style)\",",
+    "              \"Deep Taxonomy\"). A null `value` renders \"n/a (not gathered)\"."
+  ],
+
+  "schema_version": 1,
+  "gathered_at_utc": "2026-06-15",
+  "gathered_by": "static curation from in-repo sources (no live gather); see `source` on each engine/reference",
+
+  "engines": [
+    { "id": "qlever", "label": "QLever", "version": "0.5.47", "env": "2020 MacBook Air M1, 16GB, native", "source": "bench/qlever-baselines.md" },
+    { "id": "oxigraph", "label": "Oxigraph", "version": "0.5.8", "env": "embedded Rust dev-dep (Cargo.lock); no committed dashboard-scale numbers", "source": "crates/sparq-bench Cargo.toml + Cargo.lock" },
+    { "id": "eye", "label": "EYE", "version": "v11.24.4 (2026-05-12), SWI-Prolog 10.0.2", "env": "Apple M1 (fanless), macOS 25.4.0", "source": "bench/inference/eye-comparison.md" },
+    { "id": "rdfox", "label": "RDFox", "version": "not gathered (vendor/paper figures only — Oxford Semantic; AAAI-2014/ISWC-2015)", "env": "n/a — no head-to-head run in-repo", "source": "research/inference-sota.md §1.1" }
+  ],
+
+  "values": {},
+
+  "references": [
+    { "suite": "Synthetic (qlever-style)", "engine": "qlever", "version": "0.5.47", "env": "2020 MacBook Air M1, 16GB, native", "scale": "10M synthetic (1.25M entities × 8)", "metric": "q03_star3 (3-pattern star join), count", "value": 73, "unit": "ms", "regime": "min-of-N cold, COUNT(*)-wrapped, compute-only", "source": "bench/qlever-baselines.md", "caveat": "10M-scale on an M1 — NOT the dashboard CI scale; reference only." },
+    { "suite": "Synthetic (qlever-style)", "engine": "qlever", "version": "0.5.47", "env": "2020 MacBook Air M1, 16GB, native", "scale": "10M synthetic (1.25M entities × 8)", "metric": "q04_follows_name (2-pattern chain), count", "value": 56, "unit": "ms", "regime": "min-of-N cold, COUNT(*)-wrapped, compute-only", "source": "bench/qlever-baselines.md", "caveat": "10M-scale on an M1, not the dashboard CI scale — reference only." },
+    { "suite": "Synthetic (qlever-style)", "engine": "qlever", "version": "0.5.47", "env": "2020 MacBook Air M1, 16GB, native", "scale": "10M synthetic (1.25M entities × 8)", "metric": "q10_optional_age (OPTIONAL left-join), count", "value": 60, "unit": "ms", "regime": "min-of-N cold, COUNT(*)-wrapped, compute-only", "source": "bench/qlever-baselines.md", "caveat": "10M-scale on an M1, not the dashboard CI scale — reference only." },
+    { "suite": "Synthetic (qlever-style)", "engine": "qlever", "version": "0.5.47", "env": "2020 MacBook Air M1, 16GB, native", "scale": "100M synthetic (12.5M entities × 8)", "metric": "q03_star3 (3-pattern star join), count", "value": 900, "unit": "ms", "regime": "min-of-N cold, COUNT(*)-wrapped, compute-only (observed 829–1195)", "source": "bench/qlever-baselines.md", "caveat": "100M-scale on an M1, not the dashboard CI scale — reference only." },
+    { "suite": "Deep Taxonomy", "engine": "eye", "version": "v11.24.4 (2026-05-12), SWI-Prolog 10.0.2", "env": "Apple M1 (fanless), macOS 25.4.0, idle", "scale": "dt1k — 1000-deep :sc chain", "metric": "forward closure (parse → fixpoint → serialize), wall-clock", "value": 4.19, "unit": "s", "regime": "least-contended run; same pipeline as `sparq-cli reason … n3`", "source": "bench/inference/eye-comparison.md (idle-machine table)", "caveat": "REASONING-CLOSURE task on an M1 — different task/machine/unit from any dashboard metric. Reference only." },
+    { "suite": "Deep Taxonomy", "engine": "eye", "version": "v11.24.4 (2026-05-12), SWI-Prolog 10.0.2", "env": "Apple M1 (fanless), macOS 25.4.0, idle", "scale": "dt10k — 10000-deep :sc chain", "metric": "forward closure, wall-clock", "value": 377.9, "unit": "s", "regime": "single run", "source": "bench/inference/eye-comparison.md (idle-machine table)", "caveat": "Reasoning closure on an M1; different task/machine/unit. Reference only." },
+    { "suite": "Deep Taxonomy", "engine": "eye", "version": "v11.24.4 (2026-05-12), SWI-Prolog 10.0.2", "env": "Apple M1 (fanless), macOS 25.4.0, idle", "scale": "dt100k — 100000-deep :sc chain", "metric": "forward closure, wall-clock", "value": null, "unit": "s", "regime": "not run (extrapolated ≈9h at EYE’s observed ≈N^1.95 DT scaling)", "source": "bench/inference/eye-comparison.md", "caveat": "n/a (not gathered) — EYE was not run at dt100k. NOT fabricated." }
+  ]
+}

--- a/bench/dashboard/dashboard.css
+++ b/bench/dashboard/dashboard.css
@@ -113,6 +113,21 @@ table.summary-table { width: 100%; border-collapse: collapse; font-size: 0.92rem
    visually anchored. */
 .featured-table thead th:nth-child(2) { color: var(--fg); }
 .featured-table td.competitor-na { color: var(--muted); opacity: 0.7; }
+/* [OPUS-4.8] sq-i0nm: competitor column header shows the engine name + the pinned VERSION inline
+   (muted, smaller) so versions are visible for transparency, not just on hover. */
+.featured-table th.competitor-col .competitor-name { display: block; }
+.featured-table th.competitor-col .competitor-version {
+  display: block; font-size: 0.66rem; font-weight: 400; color: var(--muted); opacity: 0.8;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+/* [OPUS-4.8] sq-i0nm: per-suite EXTERNAL-REFERENCE baselines — real cited competitor numbers at
+   their own scale/machine, shown beneath the comparison table (NOT a same-scale comparison). */
+.featured-refs { margin: 8px 0 4px; }
+.featured-refs-head {
+  font-size: 0.72rem; color: var(--muted); font-style: italic; margin-bottom: 4px;
+}
+.featured-refs-list { margin: 0; padding-left: 16px; }
+.featured-ref { font-size: 0.74rem; color: var(--muted); line-height: 1.5; cursor: help; }
 
 /* [OPUS-4.8] sq-viby: scaling charts at the bottom. Same chart-card shell as the trend charts; a
    muted note appears for single-point families until more sizes are reported. */

--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -40,6 +40,7 @@
   var COMPETITORS_DATA = {
     schema_version: 1,
     gathered_at_utc: '2026-06-15',
+    gathered_by: 'static curation from in-repo sources (no live gather); see `source` on each engine/reference',
     engines: [
       { id: 'qlever', label: 'QLever', version: '0.5.47',
         env: '2020 MacBook Air M1, 16GB, native', source: 'bench/qlever-baselines.md' },

--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -22,6 +22,79 @@
 
   var SERIES = 'sparq engine';
 
+  // ---- competitor reference data (sq-i0nm parent) --------------------------
+  // [OPUS-4.8] Versioned STATIC competitor data, EMBEDDED so the live GitHub Pages page renders it
+  // (bench.yml's seed step copies only index.html/dashboard.js/dashboard.css/metric-labels.json — a
+  // separate JSON is NOT served, so the seam cannot rely on a fetch in production). This object is a
+  // byte-for-meaning MIRROR of the canonical, reviewable bench/dashboard/competitors.json; keep the
+  // two in sync (the file carries the full rationale + HONESTY note). render() loads it into
+  // window.COMPETITORS unless one was already injected externally (a future competitors.js/fetch can
+  // still override). The featured table reads `engines`/`values` (the sq-xvow seam); `references`
+  // drives a per-suite external-reference baseline note. NO fabricated numbers: `values` is EMPTY by
+  // design (no in-repo competitor was measured at the dashboard's CI scale+machine+regime, so every
+  // per-metric cell shows "n/a (not gathered)"); `references` carries the real cited numbers that DO
+  // exist (QLever synthetic on a 2020 M1; EYE DeepTaxonomy closures on an M1) with their OWN
+  // scale/machine/source, shown SEPARATELY so a mismatched figure is never aligned into a same-row
+  // comparison. Sources: bench/qlever-baselines.md, bench/inference/eye-comparison.md, Cargo.lock
+  // (oxigraph 0.5.8), research/inference-sota.md (RDFox citations only). Gathered: 2026-06-15.
+  var COMPETITORS_DATA = {
+    schema_version: 1,
+    gathered_at_utc: '2026-06-15',
+    engines: [
+      { id: 'qlever', label: 'QLever', version: '0.5.47',
+        env: '2020 MacBook Air M1, 16GB, native', source: 'bench/qlever-baselines.md' },
+      { id: 'oxigraph', label: 'Oxigraph', version: '0.5.8',
+        env: 'embedded Rust dev-dep (Cargo.lock); no committed dashboard-scale numbers',
+        source: 'crates/sparq-bench Cargo.toml + Cargo.lock' },
+      { id: 'eye', label: 'EYE', version: 'v11.24.4 (2026-05-12), SWI-Prolog 10.0.2',
+        env: 'Apple M1 (fanless), macOS 25.4.0', source: 'bench/inference/eye-comparison.md' },
+      { id: 'rdfox', label: 'RDFox',
+        version: 'not gathered (vendor/paper figures only — Oxford Semantic; AAAI-2014/ISWC-2015)',
+        env: 'n/a — no head-to-head run in-repo', source: 'research/inference-sota.md §1.1' }
+    ],
+    // EMPTY BY DESIGN — see the comment above + competitors.json HONESTY note. Every per-metric
+    // competitor cell renders "n/a (not gathered)" until a same-scale quiet-box gather fills it.
+    values: {},
+    references: [
+      { suite: 'Synthetic (qlever-style)', engine: 'qlever', version: '0.5.47',
+        env: '2020 MacBook Air M1, 16GB, native', scale: '10M synthetic (1.25M entities × 8)',
+        metric: 'q03_star3 (3-pattern star join), count', value: 73, unit: 'ms',
+        regime: 'min-of-N cold, COUNT(*)-wrapped, compute-only', source: 'bench/qlever-baselines.md',
+        caveat: '10M-scale on an M1 — NOT the dashboard CI scale; reference only.' },
+      { suite: 'Synthetic (qlever-style)', engine: 'qlever', version: '0.5.47',
+        env: '2020 MacBook Air M1, 16GB, native', scale: '10M synthetic (1.25M entities × 8)',
+        metric: 'q04_follows_name (2-pattern chain), count', value: 56, unit: 'ms',
+        regime: 'min-of-N cold, COUNT(*)-wrapped, compute-only', source: 'bench/qlever-baselines.md',
+        caveat: '10M-scale on an M1, not the dashboard CI scale — reference only.' },
+      { suite: 'Synthetic (qlever-style)', engine: 'qlever', version: '0.5.47',
+        env: '2020 MacBook Air M1, 16GB, native', scale: '10M synthetic (1.25M entities × 8)',
+        metric: 'q10_optional_age (OPTIONAL left-join), count', value: 60, unit: 'ms',
+        regime: 'min-of-N cold, COUNT(*)-wrapped, compute-only', source: 'bench/qlever-baselines.md',
+        caveat: '10M-scale on an M1, not the dashboard CI scale — reference only.' },
+      { suite: 'Synthetic (qlever-style)', engine: 'qlever', version: '0.5.47',
+        env: '2020 MacBook Air M1, 16GB, native', scale: '100M synthetic (12.5M entities × 8)',
+        metric: 'q03_star3 (3-pattern star join), count', value: 900, unit: 'ms',
+        regime: 'min-of-N cold, COUNT(*)-wrapped, compute-only (observed 829–1195)',
+        source: 'bench/qlever-baselines.md', caveat: '100M-scale on an M1, not the dashboard CI scale — reference only.' },
+      { suite: 'Deep Taxonomy', engine: 'eye', version: 'v11.24.4 (2026-05-12), SWI-Prolog 10.0.2',
+        env: 'Apple M1 (fanless), macOS 25.4.0, idle', scale: 'dt1k — 1000-deep :sc chain',
+        metric: 'forward closure (parse → fixpoint → serialize), wall-clock', value: 4.19, unit: 's',
+        regime: 'least-contended run; same pipeline as `sparq-cli reason … n3`',
+        source: 'bench/inference/eye-comparison.md (idle-machine table)',
+        caveat: 'REASONING-CLOSURE task on an M1 — different task/machine/unit from any dashboard metric. Reference only.' },
+      { suite: 'Deep Taxonomy', engine: 'eye', version: 'v11.24.4 (2026-05-12), SWI-Prolog 10.0.2',
+        env: 'Apple M1 (fanless), macOS 25.4.0, idle', scale: 'dt10k — 10000-deep :sc chain',
+        metric: 'forward closure, wall-clock', value: 377.9, unit: 's', regime: 'single run',
+        source: 'bench/inference/eye-comparison.md (idle-machine table)',
+        caveat: 'Reasoning closure on an M1; different task/machine/unit. Reference only.' },
+      { suite: 'Deep Taxonomy', engine: 'eye', version: 'v11.24.4 (2026-05-12), SWI-Prolog 10.0.2',
+        env: 'Apple M1 (fanless), macOS 25.4.0, idle', scale: 'dt100k — 100000-deep :sc chain',
+        metric: 'forward closure, wall-clock', value: null, unit: 's',
+        regime: 'not run (extrapolated ≈9h at EYE’s observed ≈N^1.95 DT scaling)',
+        source: 'bench/inference/eye-comparison.md', caveat: 'n/a (not gathered) — EYE was not run at dt100k. NOT fabricated.' }
+    ]
+  };
+
   // ---- metric-label registry (sq-ocuf) -------------------------------------
 
   // metric-labels.json is { labels: { "<stem>": {label,suite,...} }, ... }; boot() fetches it into
@@ -199,7 +272,12 @@
     { key: 'SP2Bench',      title: 'SP2Bench',      aliases: ['sp2bench', 'sp2b'] },
     { key: 'Deep Taxonomy', title: 'Deep Taxonomy', aliases: ['deep taxonomy', 'deeptax', 'deep-taxonomy', 'deeptaxonomy'] },
     { key: 'BSBM',          title: 'BSBM',          aliases: ['bsbm'] },
-    { key: 'DBPSB',         title: 'DBPSB',         aliases: ['dbpsb', 'dbpedia sparql benchmark'] }
+    { key: 'DBPSB',         title: 'DBPSB',         aliases: ['dbpsb', 'dbpedia sparql benchmark'] },
+    // [OPUS-4.8] sq-i0nm: the synthetic qlever-style suite carries the one in-repo competitor
+    // REFERENCE (QLever 0.5.47 on a 2020 M1, bench/qlever-baselines.md), so feature it too — its
+    // external-reference baselines render under the table. The suiteFor() label is the canonical key.
+    { key: 'Synthetic (qlever-style)', title: 'Synthetic (qlever-style)',
+      aliases: ['synthetic (qlever-style)', 'synthetic'] }
   ];
 
   // Which featured suite (if any) a metric belongs to. Consults suiteFor() FIRST (label-map driven,
@@ -253,7 +331,12 @@
     });
     var groups = [];
     FEATURED_SUITES.forEach(function (f) {
-      if (bySuite[f.key]) groups.push({ suite: f.key, title: f.title, rows: sortRows(bySuite[f.key].rows) });
+      // [OPUS-4.8] sq-i0nm: attach this suite's EXTERNAL-REFERENCE baselines (cited competitor
+      // numbers at their OWN scale/machine) so the renderer can show them as a captioned note BELOW
+      // the comparison table — never aligned into a same-row competitor cell (those stay n/a unless a
+      // same-scale gather fills `values`). A suite with rows but no references just omits the note.
+      if (bySuite[f.key]) groups.push({ suite: f.key, title: f.title,
+        rows: sortRows(bySuite[f.key].rows), references: referencesForSuite(competitors, f.key) });
     });
     return { commit: latest.commit, date: latest.date, groups: groups,
              competitorEngines: competitorEngines(competitors) };
@@ -270,6 +353,15 @@
   // extra columns; [] when the competitor file is absent — the featured table then shows only sparq.
   function competitorEngines(competitors) {
     return (competitors && Array.isArray(competitors.engines)) ? competitors.engines : [];
+  }
+
+  // [OPUS-4.8] sq-i0nm: the external-reference baselines that belong to one featured suite — the
+  // cited competitor numbers (`references` array on the competitor data) whose `suite` matches. Pure
+  // + node-testable; returns [] when none. These carry their OWN scale/machine/source so the reader
+  // sees a real number WITHOUT a misleading same-scale comparison.
+  function referencesForSuite(competitors, suiteKey) {
+    if (!competitors || !Array.isArray(competitors.references)) return [];
+    return competitors.references.filter(function (r) { return r.suite === suiteKey; });
   }
 
   // ---- scaling comparison charts (sq-viby) ---------------------------------
@@ -363,6 +455,8 @@
                        FEATURED_SUITES: FEATURED_SUITES, featuredSuiteOf: featuredSuiteOf,
                        buildFeatured: buildFeatured, competitorsFor: competitorsFor,
                        competitorEngines: competitorEngines,
+                       // sq-i0nm (embedded versioned competitor data + per-suite references)
+                       COMPETITORS_DATA: COMPETITORS_DATA, referencesForSuite: referencesForSuite,
                        // sq-viby (scaling comparison)
                        sizeAxisOf: sizeAxisOf, buildScalingFamilies: buildScalingFamilies };
     return;
@@ -487,11 +581,14 @@
     });
   }
 
-  // ---- featured well-known suites: DOM (sq-xvow) ---------------------------
+  // ---- featured well-known suites: DOM (sq-xvow / sq-i0nm) -----------------
   // Renders the #featured host (a card at the TOP). One table per recognised suite, with the
-  // sparq latest value + Δ-pill, and ONE COLUMN PER competitor engine (the sq-t0c3 seam). When no
-  // competitor file is present, only the sparq column shows. Competitor cells with no number for a
-  // given metric render "—" (na). Reuses pill()/fmtNum()/labelFor tooltips — no new label logic.
+  // sparq latest value + Δ-pill, and ONE COLUMN PER competitor engine. The engine header shows the
+  // pinned VERSION inline (transparency, sq-i0nm) with the env on hover. Per-metric competitor cells
+  // render "n/a" when no number was gathered at the dashboard's scale (the honest default — see
+  // competitors.json). Below each suite, any EXTERNAL-REFERENCE baselines (cited competitor numbers
+  // at their OWN scale/machine) render as a captioned note — real numbers, never a misleading
+  // same-row comparison. Reuses pill()/fmtNum()/labelFor tooltips — no new label logic.
   function renderFeatured(featured) {
     var host = document.getElementById('featured');
     if (!host) return;
@@ -516,11 +613,16 @@
         el('th', { text: 'Unit' }),
         el('th', { 'class': 'num', text: 'Δ vs best' })
       ];
-      // Competitor columns (seam): one per engine, header shows id + version when supplied.
+      // Competitor columns (seam): one per engine. [OPUS-4.8] sq-i0nm — the VERSION shows inline
+      // (a second muted line) for transparency, not just on hover; the env + source stay on hover.
       engines.forEach(function (e) {
-        headCells.push(el('th', { 'class': 'num competitor-col',
-          text: e.label || e.id,
-          title: (e.version ? e.id + ' ' + e.version : e.id) + (e.env ? ' · ' + e.env : '') }));
+        var th = el('th', { 'class': 'num competitor-col',
+          title: (e.version ? (e.label || e.id) + ' ' + e.version : (e.label || e.id)) +
+                 (e.env ? ' · ' + e.env : '') + (e.source ? ' · src: ' + e.source : '') }, [
+          el('span', { 'class': 'competitor-name', text: e.label || e.id })
+        ]);
+        if (e.version) th.appendChild(el('code', { 'class': 'competitor-version', text: e.version }));
+        headCells.push(th);
       });
       table.appendChild(el('thead', null, [el('tr', null, headCells)]));
       var tbody = el('tbody');
@@ -536,17 +638,47 @@
           el('td', { 'class': 'num delta' })
         ];
         cells[3].appendChild(pill(r.delta));
-        // Competitor cells (seam): render the number if present, else "—" (n/a).
+        // Competitor cells: render the number if present, else "n/a" (not gathered). [OPUS-4.8]
+        // sq-i0nm — honest default: no in-repo competitor was measured at the dashboard's scale, so
+        // these are n/a, not fabricated. A same-scale quiet-box gather fills competitors.values.
         engines.forEach(function (e) {
           var v = r.competitors && r.competitors[e.id];
           cells.push(el('td', { 'class': 'num competitor-col' + (v == null ? ' competitor-na' : ''),
-            text: v == null ? '—' : fmtNum(v),
-            title: v == null ? 'no competitor number gathered (sq-t0c3)' : '' }));
+            text: v == null ? 'n/a' : fmtNum(v),
+            title: v == null
+              ? 'n/a — not gathered at the dashboard’s CI scale (no fabricated number); '
+                + 'gather on a quiet box to fill (see bench/dashboard/competitors.json)'
+              : '' }));
         });
         tbody.appendChild(el('tr', null, cells));
       });
       table.appendChild(tbody);
       section.appendChild(table);
+      // [OPUS-4.8] sq-i0nm: per-suite EXTERNAL-REFERENCE baselines — real cited competitor numbers at
+      // their OWN scale/machine, shown SEPARATELY from the comparison table so a mismatched figure is
+      // never aligned into a same-row cell. Each line states engine+version, scale, value+unit, and
+      // links its source on hover. A null value renders "n/a (not gathered)".
+      if (g.references && g.references.length) {
+        var refBox = el('div', { 'class': 'featured-refs' }, [
+          el('div', { 'class': 'featured-refs-head',
+            text: 'External reference baselines (gathered once; different scale/machine — not a same-scale comparison)' })
+        ]);
+        var refList = el('ul', { 'class': 'featured-refs-list' });
+        g.references.forEach(function (ref) {
+          var eng = (engines.filter(function (e) { return e.id === ref.engine; })[0]) || { label: ref.engine };
+          var val = ref.value == null ? 'n/a (not gathered)' : fmtNum(ref.value) + ' ' + (ref.unit || '');
+          var label = (eng.label || ref.engine) + (ref.version ? ' ' + ref.version : '') +
+                      ' — ' + ref.metric + ' @ ' + ref.scale + ': ' + val;
+          var li = el('li', { 'class': 'featured-ref',
+            title: [ref.regime ? 'regime: ' + ref.regime : '', ref.env ? 'env: ' + ref.env : '',
+                     ref.caveat ? 'caveat: ' + ref.caveat : '', ref.source ? 'source: ' + ref.source : '']
+                    .filter(Boolean).join('\n'),
+            text: label });
+          refList.appendChild(li);
+        });
+        refBox.appendChild(refList);
+        section.appendChild(refBox);
+      }
       host.appendChild(section);
     });
   }
@@ -630,10 +762,14 @@
     }
     var entries = data.entries[SERIES];
     var summary = buildSummary(entries);
-    // sq-t0c3 SEAM: competitor numbers live in window.COMPETITORS (loaded from bench/competitors.json
-    // by sq-t0c3). Absent today -> featured table shows only the sparq column and "—" everywhere a
-    // competitor cell would go. We never gather them here.
-    var competitors = (typeof window !== 'undefined' && window.COMPETITORS) || null;
+    // [OPUS-4.8] sq-i0nm: competitor data comes from window.COMPETITORS. Prefer an EXTERNALLY
+    // injected object (a future competitors.js/fetch can override), else fall back to the EMBEDDED
+    // versioned COMPETITORS_DATA (the byte-for-meaning mirror of bench/dashboard/competitors.json) —
+    // embedded because the Pages seed step doesn't serve a separate JSON. This populates the
+    // competitor reference COLUMNS (with explicit versions) + per-suite external-reference baselines;
+    // per-metric cells stay "n/a (not gathered)" until a same-scale gather fills `values`.
+    var competitors = (typeof window !== 'undefined' && window.COMPETITORS) || COMPETITORS_DATA;
+    if (typeof window !== 'undefined' && !window.COMPETITORS) window.COMPETITORS = competitors;
     var featured = buildFeatured(entries, competitors);
     var families = buildScalingFamilies(entries);
     document.getElementById('updated').textContent =

--- a/bench/dashboard/index.html
+++ b/bench/dashboard/index.html
@@ -28,17 +28,25 @@
   </header>
 
   <main class="wrap">
-    <!-- [OPUS-4.8] sq-xvow: featured well-known suites at the TOP. dashboard.js fills #featured
-         with one table per recognised public suite (LUBM / WatDiv / SP2Bench / Deep Taxonomy /
-         BSBM / DBPSB). The "sparq" column is the latest-commit value; the COMPETITOR COLUMNS are a
-         seam for sq-t0c3 (bench/competitors.json -> window.COMPETITORS) and render "—" until it
-         lands. This is a promotion of existing labelled metrics — it does not change sq-ocuf's
+    <!-- [OPUS-4.8] sq-xvow + sq-i0nm: featured well-known suites at the TOP. dashboard.js fills
+         #featured with one table per recognised public suite (LUBM / WatDiv / SP2Bench / Deep
+         Taxonomy / BSBM / DBPSB / Synthetic-qlever-style). The "sparq" column is the latest-commit
+         value; COMPETITOR COLUMNS (QLever / Oxigraph / EYE / RDFox) show the pinned VERSION inline
+         and read from versioned STATIC data — embedded in dashboard.js (COMPETITORS_DATA), mirrored
+         in bench/dashboard/competitors.json — gathered ONCE, NOT per-CI. Per-metric cells show
+         "n/a" where no number was gathered at this scale (never a fabricated figure); real cited
+         numbers at their own scale/machine appear as per-suite EXTERNAL-REFERENCE baselines below
+         each table. This is a promotion of existing labelled metrics — it does not change sq-ocuf's
          labels or grouping below. -->
     <section class="card" id="featured-card">
       <h2>Featured suites</h2>
       <p class="hint">Recognised public benchmark suites, latest commit. The <strong>sparq</strong>
-         column is this run; competitor columns are populated by the competitor harness
-         (<code>bench/competitors.json</code>) and show <code>—</code> until gathered.</p>
+         column is this run; competitor columns (<strong>QLever / Oxigraph / EYE / RDFox</strong>,
+         with pinned versions) are <em>versioned static</em> data gathered once — not measured per
+         commit — from <code>bench/dashboard/competitors.json</code>. A cell shows <code>n/a</code>
+         where no competitor number was gathered at this scale (no fabricated numbers); real cited
+         numbers at their own scale/machine appear as <em>external reference baselines</em> beneath
+         each suite.</p>
       <div id="featured">loading…</div>
     </section>
 

--- a/bench/dashboard/index.html
+++ b/bench/dashboard/index.html
@@ -30,7 +30,7 @@
   <main class="wrap">
     <!-- [OPUS-4.8] sq-xvow + sq-i0nm: featured well-known suites at the TOP. dashboard.js fills
          #featured with one table per recognised public suite (LUBM / WatDiv / SP2Bench / Deep
-         Taxonomy / BSBM / DBPSB / Synthetic-qlever-style). The "sparq" column is the latest-commit
+         Taxonomy / BSBM / DBPSB / Synthetic (qlever-style)). The "sparq" column is the latest-commit
          value; COMPETITOR COLUMNS (QLever / Oxigraph / EYE / RDFox) show the pinned VERSION inline
          and read from versioned STATIC data — embedded in dashboard.js (COMPETITORS_DATA), mirrored
          in bench/dashboard/competitors.json — gathered ONCE, NOT per-CI. Per-metric cells show


### PR DESCRIPTION
> 🤖 **SPARQ agent** — advancing bead **sq-i0nm** (P2, bench/dashboard, from-user). Its two children are DONE: **sq-ocuf** (readable metric labels + tooltips) and **sq-viby** (scaling comparison charts). Sibling **sq-xvow** already built the featured-suites *section* + the competitor *seam*. This PR completes the **remaining parent scope**: real, versioned, **static** competitor-comparison data that the dashboard actually renders.

## What this does

**1. Featured well-known suites at the TOP — now with live competitor columns.**
The featured-suites section (sq-xvow) already sits above the rest (LUBM / WatDiv / SP2Bench / Deep Taxonomy / BSBM / DBPSB). This PR adds **Synthetic (qlever-style)** to the featured set (it carries the one in-repo competitor reference) and wires the previously-**dead** competitor seam to real data, so each featured suite now shows **competitor columns for QLever / Oxigraph / EYE / RDFox with their pinned versions shown inline** (env + source on hover).

**2. Versioned static competitor data — gathered once, NOT per-CI.**
New `bench/dashboard/competitors.json` is the human-reviewable source-of-record; `dashboard.js` embeds a **byte-identical** mirror (`COMPETITORS_DATA`) so the GitHub Pages page renders it. *(The `bench.yml` seed step serves only `index.html`/`dashboard.js`/`dashboard.css`/`metric-labels.json` — editing the workflow is out of scope — so a standalone JSON would not be served; the embedded copy is what the live page uses, the file is the canonical mirror reviewers diff.)* Each engine carries an **explicit version**: QLever **0.5.47**, Oxigraph **0.5.8** (Cargo.lock-resolved), EYE **v11.24.4** (SWI-Prolog 10.0.2), RDFox (vendor/paper figures only).

**3. No fabricated competitor numbers (empirical honesty).**
The per-commit dashboard metrics run at **CI scale on a gh-runner**. **No** in-repo competitor number was measured at that exact scale + machine + regime, so every per-metric competitor **cell renders `n/a`** (with a tooltip explaining why) rather than an apples-to-oranges figure. The real numbers that *do* exist are surfaced as captioned **external-reference baselines** beneath each suite, stating their **own** scale/machine/source + a caveat — never aligned into a same-row comparison:
- **QLever 0.5.47** on a 2020 MacBook Air M1 — synthetic q03/q04/q10 @ 10M (73/56/60 ms) and q03 @ 100M (900 ms). Source: `bench/qlever-baselines.md`.
- **EYE v11.24.4** on an M1 — DeepTaxonomy forward closures dt1k (4.19 s), dt10k (377.9 s); **dt100k = n/a (not run / extrapolated ≈9h)**. Source: `bench/inference/eye-comparison.md`.
- **Oxigraph / RDFox**: listed with versions, every cell `n/a` (no in-repo head-to-head numbers).

## Sources used
`bench/qlever-baselines.md` (QLever), `bench/inference/eye-comparison.md` (EYE), `Cargo.lock` (oxigraph 0.5.8), `research/inference-sota.md §1.1` (RDFox citations only). All cited per-datapoint; `n/a` where not gathered.

## Gate (all green)
`node --check bench/dashboard/dashboard.js` ✓ · `scripts/dashboard-smoke.js` ✓ (incl. the DOM-sim, which now exercises the embedded competitor data) · `competitors.json` valid JSON (node + python) ✓ · `gen-metric-labels.py --check` clean ✓ — the `dashboard labels (lint + drift)` CI job stays green. Embedded `COMPETITORS_DATA` verified byte-identical to `competitors.json`'s `engines`/`values`/`references`.

## Scope
Touches **only** `bench/dashboard/**` (dashboard.js / dashboard.css / index.html / new competitors.json). Does **not** edit `bench/ci-bench.sh`, `benchmarks.toml`, any workflow, or `.beads/`; does not close the bead.

## Follow-up
To fill the per-metric competitor cells with real same-scale numbers, gather competitors on a quiet box at the dashboard's CI scale (`scripts/gather-competitors.sh --run --only <id>`; registry `bench/competitors.json` + `bench/CATALOG.md`) and commit the snapshot into `competitors.json` + `COMPETITORS_DATA`. I will file a bead for this same-scale gather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)