### PR TITLE
feat(sparq-server): gate WS + SSE subscriptions with the read token (sq-cxk5)

### DIFF
--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -34,12 +34,31 @@ surface** (PSS gh-46), with an **optional read gate**:
   The token is compared in **constant time**. Scheme casing is tolerated (`Bearer`/`bearer`).
   When unset, there is **no write auth** (today's behaviour preserved exactly).
 - **`--auth-token-read`** (env `SPARQ_AUTH_TOKEN_READ=1`) — ALSO gate **reads** (SPARQL query,
-  GSP `GET`/`HEAD`) with the same token. Off by default (QLever-style: writes gated, reads
-  open). Has no effect unless a token is also configured.
+  GSP `GET`/`HEAD`, AND the subscription read surfaces — see below) with the same token. Off by
+  default (QLever-style: writes gated, reads open). Has no effect unless a token is also configured.
 - The 401 is **identical for a missing vs a wrong token**, so an attacker cannot learn whether
   a token was presented.
-- The `/subscriptions` WebSocket (live SELECT diffs, a read surface) is **not** gated by this
-  token — keep it behind a proxy if it must be restricted (bead `sq-cxk5` tracks gating it).
+- The subscription transports — the **`/subscriptions` WebSocket** and the
+  **`/subscriptions/sse`** Server-Sent-Events stream (both stream live SELECT diffs, a *read*
+  surface) — are gated by `--auth-token-read` exactly like the other reads (bead `sq-cxk5`,
+  closing the prior read-auth bypass). The **SSE** GET takes the `Authorization: Bearer <TOKEN>`
+  header like any GET. The **WebSocket** upgrade accepts the token from either channel — see
+  the next paragraph. With no read gate configured, both are open (back-compatible).
+
+#### Authenticating a WebSocket subscription from a browser
+
+A browser's `WebSocket` API **cannot set arbitrary headers** on the handshake, so it cannot send
+`Authorization: Bearer`. The `/subscriptions` upgrade therefore accepts the read token from
+**either** channel and validates it against `--auth-token` (constant-time) when `--auth-token-read`
+is on:
+
+- **`Authorization: Bearer <TOKEN>`** header — for non-browser clients (a CLI WS client, a proxy).
+- **`Sec-WebSocket-Protocol: bearer.<TOKEN>`** subprotocol — the browser channel:
+  `new WebSocket("ws://host/subscriptions", ["bearer." + token])`. The server picks the
+  *first* offered subprotocol whose value starts with `bearer.`, takes the substring after the
+  `bearer.` prefix as the token, and (per RFC 6455) echoes that exact subprotocol back as the
+  selected one so the handshake completes. The token is **validated, not merely echoed** — a
+  wrong/absent token is refused with the same `401` the HTTP surface uses, *before* the upgrade.
 
 This is a complement to, not a replacement for, a real authorization layer (a reverse proxy /
 gateway, or [`sparq-solid`](../sparq-solid)) — the gate is a single shared secret with no

--- a/crates/sparq-server/SUBSCRIPTIONS.md
+++ b/crates/sparq-server/SUBSCRIPTIONS.md
@@ -26,7 +26,7 @@ Divergences (deliberate, for v1 simplicity):
 | --- | --- |
 | Dedicated `sparql-se:` URI scheme + a separate subscribe HTTP endpoint | A plain WebSocket at `ws://host:port/subscriptions`; updates arrive through the ordinary `POST /sparql` (`application/sparql-update`) endpoint |
 | `spuid` string subscription ids | Numeric `id`s, unique for the server's lifetime |
-| Secure variant (OAuth, `wss`-only profile) | None — deploy behind your own TLS/auth layer |
+| Secure variant (OAuth, `wss`-only profile) | An optional shared-secret **Bearer read gate** (`--auth-token` + `--auth-token-read`, bead `sq-cxk5`) — see "Authentication" below; deploy behind your own TLS for per-user authz |
 | Subscriptions to any query form | **SELECT only** (the diff is defined over solution bindings) |
 | Bag (multiset) result semantics | Diffs are over **distinct** bindings (set semantics; duplicate rows collapse) |
 
@@ -37,6 +37,25 @@ Divergences (deliberate, for v1 simplicity):
   answered with an `error` message. Pings are answered automatically.
 * Incoming frames are capped at the server's `--max-body-bytes` (default 1 MiB), the same
   guard as HTTP request bodies.
+
+## Authentication (bead `sq-cxk5`)
+
+Subscriptions are a **read** surface (live SELECT diffs). When the server is started with
+`--auth-token <TOKEN>` AND `--auth-token-read` (env `SPARQ_AUTH_TOKEN` + `SPARQ_AUTH_TOKEN_READ=1`),
+both subscription transports are gated behind that read token exactly like a `/sparql` GET —
+refused with `401` + `WWW-Authenticate: Bearer` before the stream/socket opens. With no read
+token configured, both are open (back-compatible — the historical behaviour).
+
+* **WebSocket** (`GET /subscriptions` upgrade): the token is accepted from **either**
+  * the `Authorization: Bearer <TOKEN>` header (non-browser clients), OR
+  * a `Sec-WebSocket-Protocol: bearer.<TOKEN>` subprotocol — the browser channel, since a
+    browser cannot set arbitrary headers on a WS handshake:
+    `new WebSocket("ws://host/subscriptions", ["bearer." + token])`. The server takes the
+    substring after the `bearer.` prefix as the token, validates it (constant-time), and echoes
+    that subprotocol back as the selected one (RFC 6455) so the handshake completes. The token
+    is **validated, not merely echoed**.
+* **SSE** (`GET /subscriptions/sse`): a plain GET, so the `Authorization: Bearer <TOKEN>`
+  header is the only auth channel; the `401` is returned before the `text/event-stream` opens.
 * One socket can hold **multiple subscriptions** (up to `--max-subscriptions-per-conn`).
 
 ## Client → server messages

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -207,6 +207,14 @@ pub struct ServerConfig {
     /// open). Has no effect unless `auth_token` is also set. When on, the whole surface is
     /// authenticated, which the bind posture ([`AuthPosture`]) treats as "auth present" for
     /// allowing a non-loopback bind without `--allow-remote`.
+    ///
+    /// [OPUS-4.8] sq-cxk5: the subscription READ surfaces — the `/subscriptions` WebSocket and
+    /// the `/subscriptions/sse` Server-Sent-Events stream (both stream live SELECT diffs) — are
+    /// gated by this flag too, closing the read-auth bypass that existed when they were always
+    /// open. The SSE GET reads the `Authorization: Bearer` header like any other GET; the WS
+    /// UPGRADE accepts the token from that header OR (for browsers, which cannot set headers on a
+    /// WS handshake) a `Sec-WebSocket-Protocol: bearer.<token>` subprotocol — see
+    /// [`crate::subscriptions::subscriptions_endpoint`] and [`ws_auth_gate`].
     pub auth_token_read: bool,
     /// [OPUS-4.8] (sq-4w18) SERVICE federation egress allowlist. SPARQL `SERVICE <iri>`
     /// makes attacker-controlled query text trigger an outbound HTTP request from the
@@ -421,8 +429,10 @@ pub fn bind_posture(addr: &SocketAddr, allow_remote: bool, auth: AuthPosture) ->
                  is not open to anonymous access. NOTE: the token is a single shared secret \
                  (not per-user authz) — deliver it over TLS (terminate at a proxy), and front \
                  it with a real authorization layer (a reverse proxy / gateway or sparq-solid) \
-                 for per-user access control. The /subscriptions WebSocket is a read surface \
-                 NOT gated by this token."
+                 for per-user access control. [OPUS-4.8] sq-cxk5: the /subscriptions WebSocket \
+                 AND /subscriptions/sse stream (read surfaces) are gated by --auth-token-read \
+                 too — browser WS clients pass the token as a 'Sec-WebSocket-Protocol: \
+                 bearer.<token>' subprotocol."
             ),
         };
     }
@@ -560,13 +570,39 @@ fn bearer_token(headers: &HeaderMap) -> Option<&str> {
     }
 }
 
-/// [OPUS-4.8] sq-zcby: the per-request auth gate. Returns `None` to proceed, or `Some(401)` to
-/// refuse. A request is gated when its [`Operation`] is covered by the configured posture:
-/// a `Write` whenever a token is set; a `Read` only additionally when `--auth-token-read` is on.
-/// An ungated operation (or no token at all) always proceeds. A gated request must present the
-/// exact token (constant-time compared, scheme casing tolerant); the 401 is byte-identical for a
-/// missing vs a wrong token, so it never leaks which.
-fn auth_gate(config: &ServerConfig, headers: &HeaderMap, op: Operation) -> Option<Response> {
+/// [OPUS-4.8] sq-cxk5: the WebSocket subprotocol-token prefix. A browser cannot set an
+/// `Authorization` header on a WebSocket handshake, so it carries the Bearer token as a
+/// `Sec-WebSocket-Protocol: bearer.<token>` subprotocol instead. See [`subprotocol_bearer_token`]
+/// and `crates/sparq-server/README.md` → "Authenticating a WebSocket subscription from a browser".
+pub(crate) const WS_BEARER_SUBPROTOCOL_PREFIX: &str = "bearer.";
+
+/// [OPUS-4.8] sq-cxk5: extracts a Bearer token offered as a `Sec-WebSocket-Protocol`
+/// subprotocol of the form `bearer.<token>` (the browser-compatible channel — browsers CANNOT
+/// set an `Authorization` header on a WS handshake, but `new WebSocket(url, [proto])` sets
+/// `Sec-WebSocket-Protocol`). The header may list several comma-separated subprotocols; the FIRST
+/// entry whose value starts with `bearer.` wins, and the substring AFTER the prefix is the token
+/// (no trimming of the token body — a subprotocol token is exact). Returns the FULL matched
+/// subprotocol string too (caller echoes it back per RFC 6455). `None` when no offered subprotocol
+/// carries the prefix.
+pub(crate) fn subprotocol_bearer_token(headers: &HeaderMap) -> Option<(&str, &str)> {
+    // A client may send multiple `Sec-WebSocket-Protocol` header lines, each itself a
+    // comma-separated list; scan every entry across all lines.
+    headers.get_all(header::SEC_WEBSOCKET_PROTOCOL).iter().find_map(|v| {
+        let raw = v.to_str().ok()?;
+        raw.split(',').map(str::trim).find_map(|proto| proto.strip_prefix(WS_BEARER_SUBPROTOCOL_PREFIX).map(|tok| (proto, tok)))
+    })
+}
+
+/// [OPUS-4.8] sq-zcby / sq-cxk5: the per-request auth decision core. Returns `None` to proceed,
+/// or `Some(401)` to refuse. A request is gated when its [`Operation`] is covered by the
+/// configured posture: a `Write` whenever a token is set; a `Read` only additionally when
+/// `--auth-token-read` is on. An ungated operation (or no token configured at all) always
+/// proceeds. A gated request must present the exact token (constant-time compared); `presented`
+/// is the candidate token already extracted from whichever channel the transport allows (the
+/// `Authorization: Bearer` header on plain HTTP, or ALSO the `bearer.<token>` WebSocket
+/// subprotocol — sq-cxk5). The 401 is byte-identical for a missing vs a wrong token, so it never
+/// leaks which.
+pub(crate) fn auth_check(config: &ServerConfig, op: Operation, presented: Option<&str>) -> Option<Response> {
     let token = config.auth_token.as_deref()?; // no token configured => never gated
     let gated = match op {
         Operation::Write => true,
@@ -575,7 +611,7 @@ fn auth_gate(config: &ServerConfig, headers: &HeaderMap, op: Operation) -> Optio
     if !gated {
         return None;
     }
-    let ok = bearer_token(headers).is_some_and(|presented| constant_time_eq(token.as_bytes(), presented.as_bytes()));
+    let ok = presented.is_some_and(|p| constant_time_eq(token.as_bytes(), p.as_bytes()));
     if ok {
         None
     } else {
@@ -583,10 +619,32 @@ fn auth_gate(config: &ServerConfig, headers: &HeaderMap, op: Operation) -> Optio
     }
 }
 
+/// [OPUS-4.8] sq-zcby: the per-request auth gate for the plain-HTTP surface — validates the
+/// `Authorization: Bearer <token>` header against the configured posture. See [`auth_check`].
+/// The SSE subscription GET (`/subscriptions/sse`) uses this exactly like the other GET routes
+/// (sq-cxk5): it is a plain GET, so the Bearer header is the only channel.
+pub(crate) fn auth_gate(config: &ServerConfig, headers: &HeaderMap, op: Operation) -> Option<Response> {
+    auth_check(config, op, bearer_token(headers))
+}
+
+/// [OPUS-4.8] sq-cxk5: the auth gate for the `/subscriptions` WebSocket UPGRADE. A browser cannot
+/// set an `Authorization` header on a WS handshake, so this accepts the token from EITHER channel:
+/// the `Authorization: Bearer <token>` header (non-browser clients) OR a `Sec-WebSocket-Protocol:
+/// bearer.<token>` subprotocol (browsers). The token is validated against the read token
+/// (constant-time, [`auth_check`] with [`Operation::Read`]) — a subprotocol token is VALIDATED,
+/// never merely echoed. When `--auth-token-read` is not set (or no token is configured) the
+/// upgrade is unchanged (open) — back-compatible. The `Authorization` header is preferred when
+/// present; the subprotocol is the fallback so a browser is not penalised for offering an
+/// unrelated subprotocol alongside `bearer.<token>`.
+pub(crate) fn ws_auth_gate(config: &ServerConfig, headers: &HeaderMap, op: Operation) -> Option<Response> {
+    let presented = bearer_token(headers).or_else(|| subprotocol_bearer_token(headers).map(|(_, tok)| tok));
+    auth_check(config, op, presented)
+}
+
 /// [OPUS-4.8] sq-zcby: the 401 a gated request without a valid token gets — `WWW-Authenticate:
 /// Bearer` plus the server's standard JSON error body. Identical for a missing vs a wrong
 /// token (the body carries no hint either way), so it never leaks which.
-fn unauthorized() -> Response {
+pub(crate) fn unauthorized() -> Response {
     let mut resp = json_error(StatusCode::UNAUTHORIZED, "authentication required: present a valid Bearer token");
     resp.headers_mut().insert(header::WWW_AUTHENTICATE, header::HeaderValue::from_static("Bearer"));
     resp
@@ -2786,8 +2844,9 @@ mod bind_posture_tests {
     }
 
     /// A FULLY authenticated surface (token gates reads AND writes) is allowed to bind a
-    /// non-loopback address WITHOUT --allow-remote — there is no open endpoint left. It still
-    /// warns (single shared secret, deliver over TLS, /subscriptions not gated).
+    /// non-loopback address WITHOUT --allow-remote — there is no open endpoint left (sq-cxk5:
+    /// the /subscriptions WS + SSE read surfaces are gated by --auth-token-read too). It still
+    /// warns (single shared secret, deliver over TLS).
     #[test]
     fn full_auth_allows_remote_bind_without_optin() {
         match bind_posture(&addr("0.0.0.0:3030"), false, AuthPosture::ReadAndWrite) {
@@ -2946,6 +3005,63 @@ mod auth_tests {
             resp.headers().get(header::WWW_AUTHENTICATE).and_then(|v| v.to_str().ok()),
             Some("Bearer")
         );
+    }
+
+    // [OPUS-4.8] sq-cxk5: the WebSocket subprotocol-token channel + the WS auth gate.
+
+    fn headers_with_subprotocol(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(header::SEC_WEBSOCKET_PROTOCOL, HeaderValue::from_str(value).unwrap());
+        h
+    }
+
+    #[test]
+    fn subprotocol_bearer_token_extracts_the_bearer_subprotocol() {
+        // The matched subprotocol AND the token after the `bearer.` prefix are returned.
+        assert_eq!(subprotocol_bearer_token(&headers_with_subprotocol("bearer.t0k")), Some(("bearer.t0k", "t0k")));
+        // First bearer.* entry wins, even alongside other offered subprotocols.
+        assert_eq!(
+            subprotocol_bearer_token(&headers_with_subprotocol("graphql-ws, bearer.t0k, other")),
+            Some(("bearer.t0k", "t0k"))
+        );
+        // The token body is exact (no trimming) — a subprotocol value carries no spaces anyway.
+        assert_eq!(subprotocol_bearer_token(&headers_with_subprotocol("bearer.")), Some(("bearer.", "")));
+    }
+
+    #[test]
+    fn subprotocol_bearer_token_absent_without_the_prefix() {
+        assert_eq!(subprotocol_bearer_token(&headers_with_subprotocol("graphql-ws, chat")), None);
+        assert_eq!(subprotocol_bearer_token(&HeaderMap::new()), None);
+        // A scheme other than the `bearer.` subprotocol prefix is not a match.
+        assert_eq!(subprotocol_bearer_token(&headers_with_subprotocol("token.t0k")), None);
+    }
+
+    #[test]
+    fn ws_auth_gate_no_token_never_gates() {
+        let cfg = ServerConfig::default();
+        assert!(ws_auth_gate(&cfg, &HeaderMap::new(), Operation::Read).is_none());
+        // Even an offered bearer subprotocol proceeds when nothing is configured.
+        assert!(ws_auth_gate(&cfg, &headers_with_subprotocol("bearer.anything"), Operation::Read).is_none());
+    }
+
+    #[test]
+    fn ws_auth_gate_read_gate_accepts_header_or_subprotocol() {
+        let cfg = ServerConfig { auth_token: Some("secret".into()), auth_token_read: true, ..ServerConfig::default() };
+        // Neither channel => 401.
+        assert!(ws_auth_gate(&cfg, &HeaderMap::new(), Operation::Read).is_some(), "no credentials => 401");
+        // The Authorization: Bearer header is accepted (non-browser clients).
+        assert!(ws_auth_gate(&cfg, &headers_with_auth("Bearer secret"), Operation::Read).is_none(), "header token => proceed");
+        // The Sec-WebSocket-Protocol bearer.<token> subprotocol is accepted (browsers).
+        assert!(ws_auth_gate(&cfg, &headers_with_subprotocol("bearer.secret"), Operation::Read).is_none(), "subprotocol token => proceed");
+        // A WRONG subprotocol token is VALIDATED, not echoed — 401.
+        assert!(ws_auth_gate(&cfg, &headers_with_subprotocol("bearer.wrong"), Operation::Read).is_some(), "wrong subprotocol token => 401");
+    }
+
+    #[test]
+    fn ws_auth_gate_write_only_leaves_ws_read_open() {
+        // A write-only token (no --auth-token-read) does not gate the WS read upgrade.
+        let cfg = ServerConfig { auth_token: Some("secret".into()), ..ServerConfig::default() };
+        assert!(ws_auth_gate(&cfg, &HeaderMap::new(), Operation::Read).is_none(), "WS read open in write-only mode");
     }
 }
 

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -36,8 +36,13 @@
 //! update; classification keys on whether the request MUTATES, not the route — plus the GSP
 //! `PUT`/`POST`/`DELETE` methods); otherwise `401` with `WWW-Authenticate: Bearer`
 //! (constant-time compared, scheme-casing tolerant; mirrors QLever's `-a <token>`). Add
-//! `--auth-token-read` (env `SPARQ_AUTH_TOKEN_READ=1`) to ALSO gate reads. The
-//! `/subscriptions` WebSocket (a read surface) is NOT gated by this token.
+//! `--auth-token-read` (env `SPARQ_AUTH_TOKEN_READ=1`) to ALSO gate reads. [OPUS-4.8] sq-cxk5:
+//! the subscription read surfaces — the `/subscriptions` WebSocket AND the
+//! `/subscriptions/sse` Server-Sent-Events stream — are gated by `--auth-token-read` too. The
+//! SSE GET takes the `Authorization: Bearer` header like any GET; the WS upgrade accepts the
+//! token from that header OR (for browsers, which cannot set headers on a WS handshake) a
+//! `Sec-WebSocket-Protocol: bearer.<token>` subprotocol. With no read token configured both
+//! are open (back-compatible).
 //!
 //! SECURITY (bind): `--addr` defaults to loopback (127.0.0.1:3030), reachable only from this
 //! host. A NON-loopback bind (e.g. `0.0.0.0`) is REFUSED unless `--allow-remote` (env
@@ -332,12 +337,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         AuthPosture::WriteOnly => eprintln!(
             "auth: --auth-token set — WRITES require 'Authorization: Bearer <token>'; READS \
              remain OPEN (add --auth-token-read to gate reads too). The /subscriptions \
-             WebSocket is a read surface and is NOT gated by this token."
+             WebSocket and /subscriptions/sse stream are read surfaces and are NOT gated \
+             without --auth-token-read."
         ),
+        // [OPUS-4.8] sq-cxk5: with --auth-token-read the subscription read surfaces (the
+        // /subscriptions WebSocket and the /subscriptions/sse stream) are gated by the read
+        // token too — no longer an open read bypass.
         AuthPosture::ReadAndWrite => eprintln!(
-            "auth: --auth-token + --auth-token-read set — the whole surface (reads AND writes) \
-             requires 'Authorization: Bearer <token>'. Note: the /subscriptions WebSocket is \
-             NOT gated by this token; deliver the token over TLS."
+            "auth: --auth-token + --auth-token-read set — the whole surface (reads AND writes), \
+             including the /subscriptions WebSocket and /subscriptions/sse stream, requires the \
+             Bearer token. WS browser clients pass it as a 'Sec-WebSocket-Protocol: bearer.<token>' \
+             subprotocol (no 'Authorization' header on a WS handshake); deliver the token over TLS."
         ),
     }
 

--- a/crates/sparq-server/src/subscriptions.rs
+++ b/crates/sparq-server/src/subscriptions.rs
@@ -51,7 +51,7 @@ use std::sync::Arc;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::Response;
 use serde_json::{json, Value};
 
@@ -134,7 +134,32 @@ impl Drop for ConnSlots {
 
 /// `GET /subscriptions` — upgrades to the subscription WebSocket. Incoming text frames
 /// are capped at the server's `--max-body-bytes` (same guard as HTTP request bodies).
-pub async fn subscriptions_endpoint(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
+///
+/// [OPUS-4.8] sq-cxk5: this is a READ surface (live SELECT diffs), so when `--auth-token-read`
+/// is configured the UPGRADE is gated behind the read token EXACTLY like a `/sparql` GET —
+/// rejected with the same 401 BEFORE the socket is upgraded. Because a browser cannot set an
+/// `Authorization` header on a WS handshake, the token is accepted from EITHER the
+/// `Authorization: Bearer <token>` header (non-browser clients) OR a
+/// `Sec-WebSocket-Protocol: bearer.<token>` subprotocol (browsers) — see
+/// [`crate::http::ws_auth_gate`]. When a `bearer.<token>` subprotocol is present and accepted, it
+/// is echoed back as the selected subprotocol (RFC 6455 requires the server to confirm one of the
+/// client's offered subprotocols, or a browser rejects the handshake). When no read token is
+/// configured the upgrade is unchanged (open access) — back-compatible.
+pub async fn subscriptions_endpoint(State(state): State<AppState>, headers: HeaderMap, mut ws: WebSocketUpgrade) -> Response {
+    // Gate the upgrade behind the read token (fail-closed when required + absent/wrong).
+    if let Some(resp) = crate::http::ws_auth_gate(state.config(), &headers, crate::http::Operation::Read) {
+        return resp;
+    }
+    // RFC 6455: if the client offered a `bearer.<token>` subprotocol (the browser auth channel),
+    // the server MUST confirm exactly one offered subprotocol or the browser rejects the
+    // handshake. We confirm the matched `bearer.<token>` value (its token was already validated
+    // above — confirming it is NOT a second auth check). Non-`bearer.` subprotocols are not part
+    // of this protocol, so none is selected for them.
+    if let Some((proto, _tok)) = crate::http::subprotocol_bearer_token(&headers) {
+        if let Ok(value) = axum::http::HeaderValue::from_str(proto) {
+            ws.set_selected_protocol(value);
+        }
+    }
     let max_msg = state.config().max_body_bytes;
     ws.max_message_size(max_msg).on_upgrade(move |socket| handle_socket(socket, state))
 }
@@ -707,9 +732,13 @@ pub mod sse {
     /// `GET /subscriptions/sse?query=<SELECT>[&alias=<x>]` — registers ONE SPARQL update
     /// subscription and streams notifications as Server-Sent Events.
     ///
-    /// Auth: this mirrors the WebSocket `/subscriptions` path, which is itself NOT
-    /// auth-gated today — gating the subscription transports behind the read token is
-    /// tracked under bead `sq-cxk5`. When that lands, both transports must gate together.
+    /// Auth ([OPUS-4.8] sq-cxk5): this is a READ surface (live SELECT diffs), so it mirrors the
+    /// WebSocket `/subscriptions` path AND the other `/sparql` GET routes — when
+    /// `--auth-token-read` is configured the GET is gated behind the read token via
+    /// [`crate::http::auth_gate`] ([`crate::http::Operation::Read`]) and refused with the SAME
+    /// 401 BEFORE the event-stream opens. As a plain GET, the `Authorization: Bearer <token>`
+    /// header is the only auth channel here (no WS subprotocol). When no read token is configured
+    /// the GET is unchanged (open access) — back-compatible.
     ///
     /// A registration refusal is returned as a normal JSON HTTP error BEFORE the event-stream
     /// opens — SSE cannot set a status once the stream is flowing — classified to match the
@@ -719,7 +748,12 @@ pub mod sse {
     /// exhaustion → **503**; any other engine error → **500**. The status is carried on the
     /// [`super::Refusal`]. On success the response is `text/event-stream` and the first two
     /// frames are the `subscribed` ack and the full initial result.
-    pub async fn sse_endpoint(State(state): State<AppState>, Query(params): Query<HashMap<String, String>>) -> Response {
+    pub async fn sse_endpoint(State(state): State<AppState>, headers: axum::http::HeaderMap, Query(params): Query<HashMap<String, String>>) -> Response {
+        // [OPUS-4.8] sq-cxk5: gate the read surface behind the read token (fail-closed when
+        // required + absent/wrong), BEFORE opening the stream — exactly like a `/sparql` GET.
+        if let Some(resp) = crate::http::auth_gate(state.config(), &headers, crate::http::Operation::Read) {
+            return resp;
+        }
         let Some(query) = params.get("query") else {
             return crate::http::json_error(
                 axum::http::StatusCode::BAD_REQUEST,

--- a/crates/sparq-server/tests/subscriptions_auth.rs
+++ b/crates/sparq-server/tests/subscriptions_auth.rs
@@ -1,0 +1,183 @@
+//! [OPUS-4.8] sq-cxk5 — integration tests for the Bearer **read**-token gate on the
+//! subscription READ surfaces: the `/subscriptions` WebSocket AND the `/subscriptions/sse`
+//! Server-Sent-Events stream.
+//!
+//! `sq-zcby` gated the HTTP write/read surface; the subscription transports were left open,
+//! a read-auth bypass. These tests boot the real axum server on an ephemeral port and assert:
+//!
+//!   * **SSE** (`GET /subscriptions/sse`, a plain GET): with `--auth-token-read` set, no token
+//!     and a WRONG token are `401`; the CORRECT `Authorization: Bearer` token opens the stream.
+//!   * **WebSocket** (`/subscriptions` upgrade): with `--auth-token-read` set, no token is
+//!     rejected; the `Authorization: Bearer` header is accepted (non-browser clients); the
+//!     `Sec-WebSocket-Protocol: bearer.<token>` subprotocol is accepted (the browser channel)
+//!     and the matched subprotocol is echoed back per RFC 6455.
+//!   * **back-compat**: with NO read token configured, both transports still open.
+//!
+//! Reuses the WS harness shape from `subscriptions.rs` (tokio-tungstenite) and the SSE shape
+//! from `subscriptions_sse.rs` (reqwest reads the `text/event-stream` body).
+
+use sparq_core::Graph;
+use sparq_server::{router, AppState, ServerConfig};
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::client::ClientRequestBuilder;
+use tokio_tungstenite::tungstenite::http::Uri;
+
+const DATA: &str = r#"
+    @prefix ex: <http://ex/> .
+    ex:alice ex:age 30 .
+    ex:bob   ex:age 25 .
+"#;
+
+const AGES: &str = "SELECT ?s ?age WHERE { ?s <http://ex/age> ?age }";
+const TOKEN: &str = "s3cr3t-read-token";
+
+/// Boots the server with `config`; returns its `host:port` (no scheme — callers add `http`/`ws`).
+async fn spawn_with(config: ServerConfig) -> String {
+    let graph = Graph::load_str(DATA, "turtle").unwrap();
+    let app = router(AppState::with_config(graph, config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    addr.to_string()
+}
+
+/// A config whose read surface is gated by `TOKEN` (`--auth-token` + `--auth-token-read`).
+fn read_gated_config() -> ServerConfig {
+    ServerConfig { auth_token: Some(TOKEN.to_string()), auth_token_read: true, ..ServerConfig::default() }
+}
+
+// ---------------------------------------------------------------------------
+// SSE (plain GET): Authorization: Bearer header only
+// ---------------------------------------------------------------------------
+
+/// Sends `GET /subscriptions/sse?query=<AGES>`, optionally with a Bearer token, and returns the
+/// HTTP status (without consuming the stream body).
+async fn sse_status(addr: &str, bearer: Option<&str>) -> reqwest::StatusCode {
+    let mut url = reqwest::Url::parse(&format!("http://{addr}/subscriptions/sse")).unwrap();
+    url.query_pairs_mut().append_pair("query", AGES);
+    let mut req = reqwest::Client::new().get(url);
+    if let Some(tok) = bearer {
+        req = req.header("authorization", format!("Bearer {tok}"));
+    }
+    req.send().await.unwrap().status()
+}
+
+#[tokio::test]
+async fn sse_without_token_is_401_when_read_gated() {
+    let addr = spawn_with(read_gated_config()).await;
+    assert_eq!(sse_status(&addr, None).await, reqwest::StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn sse_with_wrong_token_is_401_when_read_gated() {
+    let addr = spawn_with(read_gated_config()).await;
+    assert_eq!(sse_status(&addr, Some("not-the-token")).await, reqwest::StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn sse_with_correct_token_opens_stream() {
+    let addr = spawn_with(read_gated_config()).await;
+    let mut url = reqwest::Url::parse(&format!("http://{addr}/subscriptions/sse")).unwrap();
+    url.query_pairs_mut().append_pair("query", AGES);
+    let resp = reqwest::Client::new().get(url).header("authorization", format!("Bearer {TOKEN}")).send().await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK, "correct token must open the stream");
+    let ct = resp.headers().get("content-type").unwrap().to_str().unwrap();
+    assert!(ct.starts_with("text/event-stream"), "unexpected content-type: {ct}");
+}
+
+#[tokio::test]
+async fn sse_open_when_no_read_token_configured() {
+    // Back-compat: no token at all → the stream opens with no auth header.
+    let addr = spawn_with(ServerConfig::default()).await;
+    assert_eq!(sse_status(&addr, None).await, reqwest::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn sse_open_when_only_write_gated() {
+    // A write-only token (no --auth-token-read) leaves the read surface open (back-compat).
+    let cfg = ServerConfig { auth_token: Some(TOKEN.to_string()), auth_token_read: false, ..ServerConfig::default() };
+    let addr = spawn_with(cfg).await;
+    assert_eq!(sse_status(&addr, None).await, reqwest::StatusCode::OK);
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket upgrade: Authorization header OR Sec-WebSocket-Protocol subprotocol
+// ---------------------------------------------------------------------------
+
+fn ws_uri(addr: &str) -> Uri {
+    format!("ws://{addr}/subscriptions").parse().unwrap()
+}
+
+/// Attempts the WS upgrade with the given builder; returns `Ok(selected_subprotocol)` on a
+/// successful handshake (the echoed `Sec-WebSocket-Protocol`, if any), or `Err(status)` with
+/// the HTTP status the server refused the upgrade with.
+async fn try_ws_upgrade(builder: ClientRequestBuilder) -> Result<Option<String>, u16> {
+    match tokio_tungstenite::connect_async(builder).await {
+        Ok((_stream, resp)) => {
+            let proto = resp.headers().get("sec-websocket-protocol").and_then(|v| v.to_str().ok()).map(str::to_string);
+            Ok(proto)
+        }
+        Err(tokio_tungstenite::tungstenite::Error::Http(resp)) => Err(resp.status().as_u16()),
+        Err(other) => panic!("unexpected WS connect error: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn ws_upgrade_without_token_is_rejected_when_read_gated() {
+    let addr = spawn_with(read_gated_config()).await;
+    let status = try_ws_upgrade(ClientRequestBuilder::new(ws_uri(&addr))).await.expect_err("upgrade must be refused without a token");
+    assert_eq!(status, 401, "unauthenticated WS upgrade must be 401");
+}
+
+#[tokio::test]
+async fn ws_upgrade_with_wrong_token_is_rejected_when_read_gated() {
+    let addr = spawn_with(read_gated_config()).await;
+    let builder = ClientRequestBuilder::new(ws_uri(&addr)).with_header("Authorization", "Bearer nope");
+    let status = try_ws_upgrade(builder).await.expect_err("wrong token must be refused");
+    assert_eq!(status, 401);
+}
+
+#[tokio::test]
+async fn ws_upgrade_with_authorization_header_is_accepted() {
+    let addr = spawn_with(read_gated_config()).await;
+    let builder = ClientRequestBuilder::new(ws_uri(&addr)).with_header("Authorization", format!("Bearer {TOKEN}"));
+    let proto = try_ws_upgrade(builder).await.expect("Bearer header must be accepted");
+    // No subprotocol was offered, so none is echoed back.
+    assert_eq!(proto, None);
+}
+
+#[tokio::test]
+async fn ws_upgrade_with_bearer_subprotocol_is_accepted_and_echoed() {
+    let addr = spawn_with(read_gated_config()).await;
+    let sub = format!("bearer.{TOKEN}");
+    let builder = ClientRequestBuilder::new(ws_uri(&addr)).with_sub_protocol(sub.clone());
+    let proto = try_ws_upgrade(builder).await.expect("bearer subprotocol must be accepted");
+    // RFC 6455: the server confirms the matched subprotocol so the browser handshake completes.
+    assert_eq!(proto.as_deref(), Some(sub.as_str()), "server must echo the accepted bearer subprotocol");
+}
+
+#[tokio::test]
+async fn ws_upgrade_with_wrong_bearer_subprotocol_is_rejected() {
+    let addr = spawn_with(read_gated_config()).await;
+    let builder = ClientRequestBuilder::new(ws_uri(&addr)).with_sub_protocol("bearer.nope");
+    let status = try_ws_upgrade(builder).await.expect_err("a wrong subprotocol token must be refused");
+    assert_eq!(status, 401, "the subprotocol token is VALIDATED, not merely echoed");
+}
+
+#[tokio::test]
+async fn ws_upgrade_open_when_no_read_token_configured() {
+    // Back-compat: no token at all → the upgrade succeeds with no credentials.
+    let addr = spawn_with(ServerConfig::default()).await;
+    let proto = try_ws_upgrade(ClientRequestBuilder::new(ws_uri(&addr))).await.expect("upgrade must succeed with no token configured");
+    assert_eq!(proto, None);
+}
+
+#[tokio::test]
+async fn ws_upgrade_open_when_only_write_gated() {
+    // A write-only token leaves the WS read surface open (back-compat).
+    let cfg = ServerConfig { auth_token: Some(TOKEN.to_string()), auth_token_read: false, ..ServerConfig::default() };
+    let addr = spawn_with(cfg).await;
+    try_ws_upgrade(ClientRequestBuilder::new(ws_uri(&addr))).await.expect("write-only gate must leave the WS upgrade open");
+}

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -34,9 +34,12 @@ cargo run -p sparq-server -- --addr 0.0.0.0:8080 --allow-remote --format ntriple
 > `query`/`update` body that parses as an update — and the GSP `PUT`/`POST`/`DELETE`
 > methods); otherwise `401` with `WWW-Authenticate: Bearer` (constant-time compared; mirrors
 > QLever's `-a <token>`). Add `--auth-token-read` (env `SPARQ_AUTH_TOKEN_READ=1`) to ALSO
-> gate reads. The subscription transports (`/subscriptions` WebSocket and `/subscriptions/sse`
-> SSE) are a read surface and are NOT gated by this token (bead `sq-cxk5` — both transports
-> must gate together when it lands). The server binds **loopback by default** and **refuses a non-loopback
+> gate reads. The subscription transports — the `/subscriptions` WebSocket and the
+> `/subscriptions/sse` SSE stream (both a *read* surface) — are gated by `--auth-token-read`
+> too (bead `sq-cxk5`, closing the prior read-auth bypass): the SSE GET takes the
+> `Authorization: Bearer` header; the WS upgrade accepts that header OR (for browsers, which
+> cannot set headers on a WS handshake) a `Sec-WebSocket-Protocol: bearer.<token>` subprotocol.
+> With no read gate, both are open (back-compatible). The server binds **loopback by default** and **refuses a non-loopback
 > bind** (e.g. `0.0.0.0`) unless you set `--allow-remote` (env `SPARQ_ALLOW_REMOTE=1`) OR the
 > whole surface is authenticated (`--auth-token` AND `--auth-token-read`) — a write-token
 > alone still leaves reads open. Deliver the token over TLS (terminate it at a proxy). For
@@ -202,6 +205,14 @@ server:  {"unsubscribed": {"id": 1}}
 `addedResults`/`removedResults` are each full SPARQL-JSON results objects. Refusals and
 failed re-evaluations come back as `{"error": {"message": …, "id"?: n}}`.
 
+[OPUS-4.8] sq-cxk5: when `--auth-token-read` is set, the upgrade is gated behind the read
+token (`401` before upgrade otherwise). A non-browser client sends `Authorization: Bearer
+<TOKEN>` on the handshake; a **browser** (which cannot set WS handshake headers) passes it as
+a subprotocol: `new WebSocket("ws://host/subscriptions", ["bearer." + token])`. The server
+takes the substring after the `bearer.` prefix as the token, validates it (constant-time),
+and echoes the subprotocol back per RFC 6455. With no read token configured, the upgrade is
+open (back-compatible).
+
 **4b. SSE subscriptions (`text/event-stream`).** [OPUS-4.8] sq-bxog: the SAME subscription
 engine over Server-Sent Events, for clients that prefer a plain HTTP GET stream to a
 WebSocket. `GET /subscriptions/sse?query=<SELECT>[&alias=<x>]` opens one subscription per
@@ -227,7 +238,10 @@ event: notification
 id: 1
 data: {"notification":{"id":1,"sequence":1,"alias":"ages","addedResults":{…},"removedResults":{…}}}
 ```
-A registration refusal (missing/non-SELECT/malformed `query` → `400`; capacity/budget →
+[OPUS-4.8] sq-cxk5: like the WS path, when `--auth-token-read` is set this GET is gated
+behind the read token via the `Authorization: Bearer <TOKEN>` header (it is a plain GET, so
+the header is the only auth channel — no WS subprotocol) — `401` before the stream opens
+otherwise. A registration refusal (missing/non-SELECT/malformed `query` → `400`; capacity/budget →
 `503`) is returned as a normal `{"error":"…"}` JSON HTTP response BEFORE the stream opens —
 SSE cannot set a status once the stream is flowing. A later re-evaluation failure ends the
 stream with a final `event: error` frame. Both transports share one registry + change
@@ -393,8 +407,10 @@ and `update_in_place_with_budget`, and wrap calls in
   compared; QLever's `-a <token>`; missing-vs-wrong are indistinguishable). The classification
   keys on whether the request **mutates**, not the route — an Update smuggled through the
   query path is gated too. Add `--auth-token-read` (env `SPARQ_AUTH_TOKEN_READ=1`) to ALSO
-  gate reads. The subscription transports (`/subscriptions` WS + `/subscriptions/sse` SSE)
-  are a read surface and are NOT gated by this token (bead `sq-cxk5`). The binary binds
+  gate reads — INCLUDING the subscription transports (`/subscriptions` WS + `/subscriptions/sse`
+  SSE, both a read surface), closing the prior read-auth bypass (bead `sq-cxk5`): the SSE GET
+  takes the `Authorization: Bearer` header; the WS upgrade accepts that header OR (for browsers)
+  a `Sec-WebSocket-Protocol: bearer.<token>` subprotocol. The binary binds
   `127.0.0.1:3030` by default and **refuses** a non-loopback
   `--addr` (incl. `0.0.0.0`/`::`) unless `--allow-remote` / `SPARQ_ALLOW_REMOTE=1` OR the
   whole surface is authenticated (`--auth-token` AND `--auth-token-read`); even then it warns.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead **sq-cxk5**: gate the `/subscriptions` WebSocket AND the `/subscriptions/sse` SSE endpoints with the Bearer **read** token, closing a read-auth bypass.

## The gap

`sq-zcby` added a Bearer write gate (`--auth-token`) + optional read gate (`--auth-token-read`) on the HTTP surface, but the subscription endpoints — live SELECT diffs, a **read** surface — were NOT gated. With `--auth-token-read` set, an unauthenticated client could still open a WS or SSE subscription and observe results, bypassing the read gate. The SSE endpoint from #120 / sq-bxog explicitly mirrored the WS path's no-auth posture. This gates them **together** and closes the bypass on both #120 surfaces.

## What changed

- **SSE** (`GET /subscriptions/sse`) — a plain GET, so it applies `auth_gate(Operation::Read)` on the `Authorization: Bearer` header *exactly* like the other GET routes, refused with the same `401` (`WWW-Authenticate: Bearer`) **before** the event-stream opens.
- **WebSocket** (`/subscriptions` upgrade) — gated at the upgrade via a new `ws_auth_gate`. Browsers **cannot** set arbitrary headers on a WS handshake, so the token is accepted from **either** channel:
  - **`Authorization: Bearer <token>`** header — non-browser clients.
  - **`Sec-WebSocket-Protocol: bearer.<token>`** subprotocol — browsers (`new WebSocket(url, ["bearer." + token])`). The server takes the substring after the `bearer.` prefix as the token, **validates** it (constant-time — it is validated, *not* merely echoed), and confirms that exact subprotocol back per RFC 6455 so the browser handshake completes.
- **Fail-closed**: when the read gate is required, a missing/wrong token on either channel is refused with the standard `401`.
- **Back-compatible**: with **no** read token configured, both transports are open (unchanged). A write-only token (no `--auth-token-read`) also leaves both open.

The token validation reuses the existing constant-time `auth_check` core, so the WS and SSE gates are byte-for-byte the same comparison the rest of the surface uses.

## Docs

Dropped the "subscriptions NOT gated" statements and documented the header + `Sec-WebSocket-Protocol` subprotocol scheme in: `crates/sparq-server/README.md` (incl. a new "Authenticating a WebSocket subscription from a browser" subsection), `skills/http-server/SKILL.md`, `crates/sparq-server/SUBSCRIPTIONS.md` (new "Authentication" section), the `main.rs` `//!` doc + the startup auth-posture warning, and the bind-posture warning text + `auth_token_read` field doc in `http.rs`.

## Tests

`tests/subscriptions_auth.rs` (integration, reusing the WS tokio-tungstenite + SSE reqwest harness shapes):
1. **SSE**: without token → 401, wrong token → 401, correct token → stream opens (`text/event-stream`).
2. **WS**: no token → upgrade rejected (401), `Authorization: Bearer` → accepted, `bearer.<token>` subprotocol → accepted **and echoed back**, wrong subprotocol token → 401.
3. **Back-compat**: no read token → both still open; write-only token → both still open.

Plus unit tests for `subprotocol_bearer_token` (extraction / multi-subprotocol / absent) and `ws_auth_gate` (header-or-subprotocol acceptance, wrong subprotocol rejection, write-only leaves WS read open).

## Gate

- `cargo test -p sparq-server` — all green.
- `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings` — clean.

Constraints honoured: touched only sparq-server (+ its README / SUBSCRIPTIONS / SKILL / main.rs docs per the public-API rule); did not edit `.beads/` or close the bead. `[OPUS-4.8]` markers on new code/notes. Only edited files were hand-formatted (no crate-wide rustfmt).

Closes the read-auth bypass tracked by bead **sq-cxk5** on the #120 SSE + WS subscription surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)