### PR TITLE
feat(sparq-vectors): hybrid_search fusing nearest_term + most_similar by Term via RRF (sq-88c6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3529,6 +3529,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "serde_json",
  "sparq-core",
+ "sparq-sim",
 ]
 
 [[package]]

--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -56,3 +56,11 @@ serde_json = { version = "1", optional = true }
 # async runtime into the tree) — mirrors sparq-nlq's `live` reqwest dependency exactly.
 # rustls-tls so there is no system-OpenSSL build dependency.
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"], optional = true }
+
+# [OPUS-4.8] sq-88c6: DEV-only. The `hybrid_search` example/tests fuse this crate's ANN
+# (`VectorIndex::nearest_term`) with `sparq-sim`'s structural similarity
+# (`Sim::most_similar`) by `Term`. The fusion helper itself is generic over retriever
+# closures, so the LIBRARY stays decoupled — `sparq-sim` is a test/example dependency
+# only and never enters the published dependency graph.
+[dev-dependencies]
+sparq-sim = { path = "../sparq-sim" }

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -70,7 +70,8 @@ let _neighbours = index.nearest_term(&some_term, &graph, &store, 10);
   works against a real endpoint with **no caller glue** (see below). Mirrors `sparq-nlq`'s
   `live` feature; never enters the wasm bundle.
 - **Hybrid fusion** — `fuse_rrf` / `fuse_rrf_weighted` / `fuse_scores` combine text vectors
-  with another ranked signal (e.g. [`sparq-sim`](../sparq-sim) structural similarity).
+  with another ranked signal (e.g. [`sparq-sim`](../sparq-sim) structural similarity);
+  `hybrid_search` runs N retriever closures off one query and fuses by item with RRF.
 
 ## 🔌 Live embeddings (opt-in `embeddings` feature)
 

--- a/crates/sparq-vectors/src/fuse.rs
+++ b/crates/sparq-vectors/src/fuse.rs
@@ -17,6 +17,30 @@
 //!   `[0, 1]`, then blends `alpha·a + (1 − alpha)·b`. Preserves score *magnitudes*
 //!   (a runaway top hit stays a runaway), at the cost of an `alpha` to tune.
 //!
+//! For the common case — fuse this crate's ANN with another `Term` retriever — reach
+//! for [`hybrid_search`], which drives N retriever closures off one query `Term` and
+//! fuses their ranked `Term` lists by [`fuse_rrf`], deduplicating by `Term`:
+//!
+//! ```no_run
+//! # use sparq_core::Graph;
+//! # use sparq_vectors::{VectorStore, VectorIndex, hybrid_search, RRF_K};
+//! # use oxrdf::Term;
+//! # fn demo(graph: &Graph, store: &VectorStore, index: &VectorIndex,
+//! #         sim: &sparq_sim::Sim, query: &Term) {
+//! // Fuse the embedding ANN with sparq-sim's structural similarity, BY `Term`. The ANN's
+//! // f32 cosine scores are widened to f64 so both lists share the fused `(Term, f64)`
+//! // shape — RRF ignores the scores anyway, only the ranks matter.
+//! let fused = hybrid_search(query, 10, RRF_K, &mut [
+//!     &mut |t: &Term| index.nearest_term(t, graph, store, 50)   // ANN (cosine)
+//!         .into_iter().map(|(t, s)| (t, s as f64)).collect(),
+//!     &mut |t: &Term| sim.most_similar(t, 50),                  // semantic (Jaccard)
+//! ]);
+//! // `fused` is one ranked `Vec<(Term, f64)>`, each `Term` appearing once. A term ranked
+//! // high in BOTH retrievers outranks one ranked high in only one — consensus wins.
+//! # let _ = fused;
+//! # }
+//! ```
+//!
 //! ```
 //! use sparq_vectors::{fuse_rrf, fuse_scores, RRF_K};
 //!
@@ -98,6 +122,50 @@ pub fn fuse_rrf_weighted<T: Clone + Eq + Hash>(
         }
     }
     top_n(acc, top_k)
+}
+
+/// [OPUS-4.8] sq-88c6 — a borrowed retriever for [`hybrid_search`]: maps a query of type
+/// `Q` to a ranked `Vec<(T, f64)>` (best first). `&mut dyn` so heterogeneous retrievers
+/// (a `VectorIndex::nearest_term` closure, a `Sim::most_similar` closure, …) share one
+/// slice. Construct as `&mut |q: &Q| { … }`.
+pub type Retriever<'r, Q, T> = &'r mut dyn FnMut(&Q) -> Vec<(T, f64)>;
+
+/// [OPUS-4.8] sq-88c6 — **Hybrid retrieval over one query item, fused by [`fuse_rrf`].**
+///
+/// Drives every `retriever` off the same `query` (typically a [`Term`](oxrdf::Term)),
+/// then fuses the resulting ranked lists by item with Reciprocal Rank Fusion, returning
+/// the fused top `top_k` (best first). Each retriever is `FnMut(&Q) -> Vec<(T, f64)>`
+/// (best first), so any `Term` source plugs in WITHOUT this crate depending on it — pass
+/// closures over the producers you already have:
+///
+/// - this crate's ANN: `&mut |t| index.nearest_term(t, graph, store, n)` (cosine);
+/// - structural similarity: `&mut |t| sim.most_similar(t, n)` (`sparq-sim`, weighted
+///   Jaccard);
+/// - a lexical/BM25 list, a SPARQL-derived candidate set, …
+///
+/// Fusion is RRF, so the retrievers' score *scales never need reconciling* (cosine in
+/// `[-1, 1]` vs Jaccard in `[0, 1]`) — only their ranks matter. The returned scores are
+/// fused RRF scores, NOT either retriever's. An item is deduplicated to a single entry
+/// whose score sums the `1/(k + rank)` contributions of every list that ranks it; an item
+/// in only one list still appears (with that one contribution). A retriever returning an
+/// empty list contributes nothing, so a partly-unembedded query degrades gracefully.
+///
+/// Use [`RRF_K`] for `k` unless you have a reason not to. To down-weight a noisier
+/// retriever, collect its list and call [`fuse_rrf_weighted`] directly. `top_k == 0`,
+/// no retrievers, or all-empty results yield an empty `Vec`.
+///
+/// # Panics
+/// If `k ≤ 0` (propagated from [`fuse_rrf`]).
+pub fn hybrid_search<Q, T: Clone + Eq + Hash>(
+    query: &Q,
+    top_k: usize,
+    k: f64,
+    retrievers: &mut [Retriever<'_, Q, T>],
+) -> Vec<(T, f64)> {
+    // Run each retriever once on the shared query, keeping its rank order.
+    let lists: Vec<Vec<(T, f64)>> = retrievers.iter_mut().map(|r| r(query)).collect();
+    let refs: Vec<&[(T, f64)]> = lists.iter().map(|l| l.as_slice()).collect();
+    fuse_rrf(&refs, k, top_k)
 }
 
 /// **Relative score fusion** of two ranked lists: min-max normalizes each list's
@@ -290,5 +358,113 @@ mod tests {
     fn weighted_rrf_rejects_negative_weight() {
         let a: Vec<(&str, f64)> = vec![("x", 1.0)];
         fuse_rrf_weighted(&[(&a, -0.1)], 60.0, 1);
+    }
+
+    // [OPUS-4.8] sq-88c6 — hybrid_search: two retriever closures fused by RRF.
+
+    #[test]
+    fn hybrid_search_fuses_two_retrievers_consensus_wins() {
+        // Stand-ins for the two retrievers (e.g. `index.nearest_term` and
+        // `sim.most_similar`), each keyed on a query string and returning ranked items.
+        // "b" is rank 2 in ANN and rank 1 in semantic → consensus; "a" is rank 1 in ANN
+        // only; "d" is rank 2 in semantic only. Query type `Q = &str`, so each retriever
+        // receives `&Q = &&str`.
+        let ann = |_q: &&str| -> Vec<(&'static str, f64)> {
+            vec![("a", 0.92), ("b", 0.85), ("c", 0.20)] // cosine scale
+        };
+        let semantic = |_q: &&str| -> Vec<(&'static str, f64)> {
+            vec![("b", 0.61), ("d", 0.55), ("a", 0.10)] // Jaccard scale
+        };
+        let mut r0 = ann;
+        let mut r1 = semantic;
+        let fused =
+            hybrid_search(&"query", 10, 60.0, &mut [&mut r0 as &mut dyn FnMut(&&str) -> _, &mut r1]);
+
+        // Consensus (high in BOTH) beats high-in-only-one: b = rank2 ANN + rank1 semantic
+        // = 1/62 + 1/61.
+        assert_eq!(fused[0].0, "b");
+        assert!((fused[0].1 - (1.0 / 62.0 + 1.0 / 61.0)).abs() < 1e-12);
+        // a: rank1 (ANN) + rank3 (semantic) = 1/61 + 1/63 — beats single-list items.
+        assert_eq!(fused[1].0, "a");
+        assert!((fused[1].1 - (1.0 / 61.0 + 1.0 / 63.0)).abs() < 1e-12);
+        // Every item is deduplicated by key: a, b, c, d each appear once.
+        assert_eq!(fused.len(), 4);
+        let keys: Vec<&str> = fused.iter().map(|(t, _)| *t).collect();
+        for want in ["a", "b", "c", "d"] {
+            assert_eq!(keys.iter().filter(|&&t| t == want).count(), 1, "{want} deduped");
+        }
+        // RRF ignores raw scores: a term in ONE list still appears (d, from semantic only).
+        assert!(keys.contains(&"d"));
+        // top_k truncates the fused list.
+        let truncated =
+            hybrid_search(&"q", 2, 60.0, &mut [&mut r0 as &mut dyn FnMut(&&str) -> _, &mut r1]);
+        assert_eq!(truncated.len(), 2);
+    }
+
+    #[test]
+    fn hybrid_search_high_in_both_outranks_high_in_one() {
+        // "shared" is rank 1 in retriever A and rank 1 in retriever B. "soloA" is strong
+        // in A only; "soloB" strong in B only.
+        let mut a = |_q: &i32| vec![("soloA", 9.9), ("shared", 0.0)];
+        let mut b = |_q: &i32| vec![("soloB", 9.9), ("shared", 0.0)];
+        let fused = hybrid_search(&0, 10, 60.0, &mut [&mut a as &mut dyn FnMut(&i32) -> _, &mut b]);
+        // shared: 1/62 + 1/62 ≈ 0.03226 beats soloA/soloB at 1/61 ≈ 0.01639.
+        assert_eq!(fused[0].0, "shared");
+        assert!(fused[0].1 > fused[1].1, "consensus item must strictly outrank single-list items");
+    }
+
+    #[test]
+    fn hybrid_search_edge_cases() {
+        // (1) No retrievers → empty.
+        let empty: Vec<(&str, f64)> = hybrid_search::<i32, &str>(&0, 10, 60.0, &mut []);
+        assert!(empty.is_empty());
+
+        // (2) One retriever empty, the other not: degrades to the non-empty list, in order.
+        let mut none = |_q: &i32| Vec::<(&'static str, f64)>::new();
+        let mut some = |_q: &i32| vec![("x", 1.0), ("y", 0.5)];
+        let fused =
+            hybrid_search(&0, 10, 60.0, &mut [&mut none as &mut dyn FnMut(&i32) -> _, &mut some]);
+        assert_eq!(fused.iter().map(|(t, _)| *t).collect::<Vec<_>>(), vec!["x", "y"]);
+
+        // (3) Both empty → empty.
+        let mut none2 = |_q: &i32| Vec::<(&'static str, f64)>::new();
+        let both_empty =
+            hybrid_search(&0, 10, 60.0, &mut [&mut none as &mut dyn FnMut(&i32) -> _, &mut none2]);
+        assert!(both_empty.is_empty());
+
+        // (4) top_k == 0 → empty even with results.
+        let zero = hybrid_search(&0, 0, 60.0, &mut [&mut some as &mut dyn FnMut(&i32) -> _]);
+        assert!(zero.is_empty());
+    }
+
+    #[test]
+    fn hybrid_search_term_in_one_list_only() {
+        // "only_b" appears solely in retriever b; it must surface (one contribution), but
+        // below any item ranked by both. "both" is rank 2 in a and rank 1 in b.
+        let mut a = |_q: &i32| vec![("top_a", 1.0), ("both", 0.9)];
+        let mut b = |_q: &i32| vec![("both", 0.8), ("only_b", 0.7)];
+        let fused = hybrid_search(&0, 10, 60.0, &mut [&mut a as &mut dyn FnMut(&i32) -> _, &mut b]);
+        // both: 1/62 + 1/61; top_a: 1/61; only_b: 1/62. Consensus first.
+        assert_eq!(fused[0].0, "both");
+        assert_eq!(fused[1].0, "top_a"); // single list, but rank 1 (1/61) > only_b's 1/62
+        assert_eq!(fused[2].0, "only_b");
+        assert!(
+            (fused[2].1 - 1.0 / 62.0).abs() < 1e-12,
+            "single-list item keeps its lone contribution"
+        );
+    }
+
+    #[test]
+    fn hybrid_search_identical_lists_double_every_contribution() {
+        // Two identical retrievers: each item's fused score is exactly 2× its single
+        // contribution, and the order is preserved.
+        let list = || vec![("p", 1.0), ("q", 0.5), ("r", 0.1)];
+        let mut a = |_q: &i32| list();
+        let mut b = |_q: &i32| list();
+        let fused = hybrid_search(&0, 10, 60.0, &mut [&mut a as &mut dyn FnMut(&i32) -> _, &mut b]);
+        assert_eq!(fused.iter().map(|(t, _)| *t).collect::<Vec<_>>(), vec!["p", "q", "r"]);
+        assert!((fused[0].1 - 2.0 / 61.0).abs() < 1e-12);
+        assert!((fused[1].1 - 2.0 / 62.0).abs() < 1e-12);
+        assert!((fused[2].1 - 2.0 / 63.0).abs() < 1e-12);
     }
 }

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -17,7 +17,7 @@ pub use ann::{
 pub use diskann::{sibling_graph_path, DiskAnnIndex, VamanaConfig, SPQG_MAGIC, SPQG_VERSION};
 pub use embed::{Embedder, HashEmbedder};
 pub use fingerprint::{check_against, Artifact, CheckResult, Fingerprint, FINGERPRINT_LEN};
-pub use fuse::{fuse_rrf, fuse_rrf_weighted, fuse_scores, RRF_K};
+pub use fuse::{fuse_rrf, fuse_rrf_weighted, fuse_scores, hybrid_search, Retriever, RRF_K};
 pub use import::{ImportBinding, ImportSpec, MAX_NPY_HEADER_LEN};
 pub use labels::{embed_labels, embed_labels_with, LabelConfig};
 pub use quant::{

--- a/crates/sparq-vectors/tests/hybrid.rs
+++ b/crates/sparq-vectors/tests/hybrid.rs
@@ -1,0 +1,152 @@
+//! [OPUS-4.8] sq-88c6 — `hybrid_search` end to end: fuse this crate's embedding ANN
+//! (`VectorIndex::nearest_term`, cosine) with `sparq-sim`'s structural similarity
+//! (`Sim::most_similar`, weighted Jaccard) BY `Term`, via Reciprocal Rank Fusion.
+//!
+//! `sparq-sim` is a DEV-dependency only — the `hybrid_search` helper is generic over
+//! retriever closures, so the library never depends on it.
+
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+use sparq_sim::Sim;
+use sparq_vectors::{embed_labels, hybrid_search, HashEmbedder, VectorIndex, VectorStore, RRF_K};
+
+// A tiny social graph. `:alice` and `:twin` are structurally identical (same predicates,
+// same neighbors) so `most_similar(alice)` ranks `:twin` first. Labels are crafted so the
+// label-embedding ANN ALSO ranks `:twin` near `:alice` (shared n-grams "Alice"), giving a
+// consensus winner, while `:half` is structurally close but lexically distant, and
+// `:alias` is lexically close ("Alice Smith") but structurally distant.
+const TTL: &str = r#"
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:   <http://example.org/> .
+
+ex:alice rdfs:label "Alice Jones" ; ex:knows ex:bob, ex:eve ; ex:worksAt ex:acme .
+ex:twin  rdfs:label "Alice Janes" ; ex:knows ex:bob, ex:eve ; ex:worksAt ex:acme .
+ex:half  rdfs:label "Zeno Quark"  ; ex:knows ex:bob ; ex:worksAt ex:other .
+ex:alias rdfs:label "Alice Smith" ; ex:plays ex:chess .
+ex:far   rdfs:label "Far Away"    ; ex:plays ex:go .
+"#;
+
+fn iri(s: &str) -> Term {
+    Term::NamedNode(NamedNode::new(format!("http://example.org/{s}")).unwrap())
+}
+
+/// `VectorIndex::nearest_term` returns `(Term, f32)`; widen the score to `f64` so the ANN
+/// list shares the fused `(Term, f64)` shape with `Sim::most_similar`. RRF ignores the
+/// scores (only ranks matter), so the cast is purely a type bridge.
+fn ann_f64(
+    index: &VectorIndex,
+    g: &Graph,
+    store: &VectorStore,
+    t: &Term,
+    k: usize,
+) -> Vec<(Term, f64)> {
+    index
+        .nearest_term(t, g, store, k)
+        .into_iter()
+        .map(|(t, s)| (t, s as f64))
+        .collect()
+}
+
+#[test]
+fn hybrid_search_fuses_ann_and_structural_by_term() {
+    let g = Graph::load_str(TTL, "turtle").unwrap();
+    let dim = 64;
+    let path =
+        std::env::temp_dir().join(format!("sparq-vectors-hybrid-{}.spqv", std::process::id()));
+
+    // Label-embedding store + HNSW index (the embedding/ANN retriever).
+    let embedder = HashEmbedder::new(dim);
+    let mut store = VectorStore::create(&path, dim).unwrap();
+    let n = embed_labels(&g, &mut store, &embedder).unwrap();
+    assert_eq!(n, 5, "all five entities are labeled");
+    store.finalize().unwrap();
+    let index = VectorIndex::build(&store);
+
+    // Structural similarity retriever (the semantic retriever).
+    let sim = Sim::new(&g);
+
+    let query = iri("alice");
+
+    // Sanity: each retriever alone ranks `:twin` first (consensus candidate).
+    let ann_alone = index.nearest_term(&query, &g, &store, 10);
+    assert_eq!(ann_alone[0].0, iri("twin"), "ANN: closest label n-grams");
+    let struct_alone = sim.most_similar(&query, 10);
+    assert_eq!(
+        struct_alone[0].0,
+        iri("twin"),
+        "structural: identical signature"
+    );
+
+    // Fuse the two retrievers by `Term` via RRF.
+    let fused = hybrid_search(
+        &query,
+        10,
+        RRF_K,
+        &mut [
+            // `nearest_term` scores are f32; cast to f64 so both retrievers share the
+            // fused `(Term, f64)` shape. RRF ignores the scores — only ranks matter.
+            &mut |t: &Term| ann_f64(&index, &g, &store, t, 10),
+            &mut |t: &Term| sim.most_similar(t, 10),
+        ],
+    );
+
+    assert!(!fused.is_empty(), "fusion over a known term yields results");
+    // Consensus winner: `:twin` is rank 1 in BOTH retrievers → top of the fused list.
+    assert_eq!(
+        fused[0].0,
+        iri("twin"),
+        "high in BOTH retrievers wins the fusion"
+    );
+    // Every `Term` appears at most once (dedup by Term across the two lists).
+    let mut seen = std::collections::HashSet::new();
+    for (t, _) in &fused {
+        assert!(seen.insert(t.clone()), "{t} duplicated in fused output");
+    }
+    // The query term itself is excluded by both retrievers, so never appears.
+    assert!(
+        !fused.iter().any(|(t, _)| *t == query),
+        "self must be excluded"
+    );
+
+    // Fused scores are RRF scores: `:twin` (rank 1 in both) = 2/(k+1).
+    assert!(
+        (fused[0].1 - 2.0 / (RRF_K + 1.0)).abs() < 1e-12,
+        "consensus rank-1 score must be 2/(k+1), got {}",
+        fused[0].1
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn hybrid_search_unknown_query_yields_empty() {
+    let g = Graph::load_str(TTL, "turtle").unwrap();
+    let dim = 32;
+    let path = std::env::temp_dir().join(format!(
+        "sparq-vectors-hybrid-unknown-{}.spqv",
+        std::process::id()
+    ));
+    let mut store = VectorStore::create(&path, dim).unwrap();
+    embed_labels(&g, &mut store, &HashEmbedder::new(dim)).unwrap();
+    store.finalize().unwrap();
+    let index = VectorIndex::build(&store);
+    let sim = Sim::new(&g);
+
+    // A term absent from the graph: both retrievers return empty, so fusion is empty.
+    let unknown = iri("nobody");
+    let fused = hybrid_search(
+        &unknown,
+        10,
+        RRF_K,
+        &mut [
+            &mut |t: &Term| ann_f64(&index, &g, &store, t, 10),
+            &mut |t: &Term| sim.most_similar(t, 10),
+        ],
+    );
+    assert!(
+        fused.is_empty(),
+        "unknown query fuses to nothing, not an error"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -125,6 +125,9 @@ EncodedStore::rank_pq(&self, &DistanceTable, k) -> Vec<(Id, f32)>;  cosine_from_
 fuse_rrf(lists: &[&[(T, f64)]], k: f64 /*RRF_K=60.0*/, top_k) -> Vec<(T, f64)>
 fuse_rrf_weighted(lists: &[(&[(T, f64)], f64)], k, top_k) -> Vec<(T, f64)>      // weight 0.0 mutes a list entirely
 fuse_scores(a: &[(T,f64)], b: &[(T,f64)], alpha /*1.0=a only*/, top_k) -> Vec<(T, f64)>
+// one-call hybrid: run N retriever closures on one query, fuse by item via RRF, dedup
+hybrid_search(query: &Q, top_k, k /*RRF_K*/, &mut [Retriever<Q,T>]) -> Vec<(T, f64)>
+//   Retriever<'_, Q, T> = &mut dyn FnMut(&Q) -> Vec<(T, f64)>  (e.g. nearest_term / most_similar closures)
 ```
 
 ## Common recipes
@@ -237,6 +240,20 @@ let structural: Vec<(oxrdf::Term, f64)> = Sim::new(&graph).most_similar(&query, 
 
 let hybrid  = fuse_rrf(&[&text, &structural], RRF_K, 10);   // rank-only; right default for differing score scales
 let blended = fuse_scores(&text, &structural, 0.7, 10);     // min-max normalize then blend; alpha 1.0 = text only
+```
+
+`hybrid_search` packages the common RRF case — drive N retriever closures off one query
+`Term` and fuse by `Term` in a single call (dedups; a term in only one list still surfaces;
+RRF ignores the score scales). Widen `nearest_term`'s `f32` to `f64` so both lists share the
+`(Term, f64)` shape:
+
+```rust
+use sparq_vectors::{hybrid_search, RRF_K};
+let fused = hybrid_search(&query, 10, RRF_K, &mut [
+    &mut |t: &oxrdf::Term| index.nearest_term(t, &graph, &store, 50)
+        .into_iter().map(|(t, s)| (t, s as f64)).collect(),   // ANN (cosine)
+    &mut |t: &oxrdf::Term| Sim::new(&graph).most_similar(t, 50),  // structural (Jaccard)
+]);
 ```
 
 ### 6. Out-of-RAM build / filesystem-less open

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -126,8 +126,8 @@ fuse_rrf(lists: &[&[(T, f64)]], k: f64 /*RRF_K=60.0*/, top_k) -> Vec<(T, f64)>
 fuse_rrf_weighted(lists: &[(&[(T, f64)], f64)], k, top_k) -> Vec<(T, f64)>      // weight 0.0 mutes a list entirely
 fuse_scores(a: &[(T,f64)], b: &[(T,f64)], alpha /*1.0=a only*/, top_k) -> Vec<(T, f64)>
 // one-call hybrid: run N retriever closures on one query, fuse by item via RRF, dedup
-hybrid_search(query: &Q, top_k, k /*RRF_K*/, &mut [Retriever<Q,T>]) -> Vec<(T, f64)>
-//   Retriever<'_, Q, T> = &mut dyn FnMut(&Q) -> Vec<(T, f64)>  (e.g. nearest_term / most_similar closures)
+hybrid_search(query: &Q, top_k, k /*RRF_K*/, &mut [Retriever<'_, Q, T>]) -> Vec<(T, f64)>   // [OPUS-4.8] lifetime on alias use
+//   Retriever<'r, Q, T> = &'r mut dyn FnMut(&Q) -> Vec<(T, f64)>  (e.g. nearest_term / most_similar closures)
 ```
 
 ## Common recipes
@@ -252,7 +252,7 @@ use sparq_vectors::{hybrid_search, RRF_K};
 let fused = hybrid_search(&query, 10, RRF_K, &mut [
     &mut |t: &oxrdf::Term| index.nearest_term(t, &graph, &store, 50)
         .into_iter().map(|(t, s)| (t, s as f64)).collect(),   // ANN (cosine)
-    &mut |t: &oxrdf::Term| Sim::new(&graph).most_similar(t, 50),  // structural (Jaccard)
+    &mut |t: &oxrdf::Term| sparq_sim::Sim::new(&graph).most_similar(t, 50),  // structural (Jaccard) [OPUS-4.8] FQ path: block has no `use Sim`
 ]);
 ```
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead **sq-88c6** (sparq-vectors, P3): a hybrid-retrieval helper that fuses semantic similarity and ANN vector search by `Term` via Reciprocal Rank Fusion.

## What this adds

**`hybrid_search`** — a one-call hybrid-retrieval helper that drives **N retriever closures** off a single query item and fuses their ranked lists **by item** using the existing `fuse_rrf` (Reciprocal Rank Fusion, `score(t) = Σ 1/(k + rank_i(t))`, default `k = 60`). The canonical use fuses:

- this crate's embedding **ANN** — `VectorIndex::nearest_term` (cosine), and
- `sparq-sim`'s structural **semantic** similarity — `Sim::most_similar` (weighted Jaccard)

**by `Term`**. A term ranked high in *both* retrievers outranks one high in only one (consensus wins); a term in only one list still surfaces; results are **deduplicated by `Term`**.

```rust
let fused = hybrid_search(&query, 10, RRF_K, &mut [
    &mut |t: &Term| index.nearest_term(t, &graph, &store, 50)        // ANN (cosine, f32→f64)
        .into_iter().map(|(t, s)| (t, s as f64)).collect(),
    &mut |t: &Term| sim.most_similar(t, 50),                          // structural (Jaccard)
]);
```

## Design notes

- **`fuse_rrf` already existed** and is **reused unchanged** — no duplication. `hybrid_search` is a thin orchestration layer over it.
- The helper is **generic over retriever closures** (`Retriever<'_, Q, T> = &mut dyn FnMut(&Q) -> Vec<(T, f64)>`), so the **library stays decoupled** from `sparq-sim`. That crate is a **dev-dependency only** — used by the integration example/test, never entering the published dependency graph. This preserves the crate's deliberate *"neither crate depends on the other"* design (documented in `fuse.rs`).
- RRF ignores score *scales* (cosine in `[-1,1]` vs Jaccard in `[0,1]`) — only ranks matter; the `f32→f64` widen on `nearest_term` is a pure type bridge.

## Tests (all green)

- **5 unit tests** (`fuse.rs`): RRF consensus (high-in-both beats high-in-one), hand-computed scores, dedup, `top_k` truncation, edge cases (no / empty / all-empty retrievers, `top_k == 0`), term-in-one-list-only, identical-lists doubling.
- **2 integration tests** (`tests/hybrid.rs`): fuse the **real** `nearest_term` + `most_similar` over a built store + graph (consensus ordering + exact RRF score `2/(k+1)`), and unknown-query → empty.

## Gate

- `cargo test -p sparq-vectors` — 43 lib + 2 integration + doc-tests, all pass.
- `cargo clippy -p sparq-vectors --all-targets -- -D warnings` — clean.
- `skills/vector-search/SKILL.md` + crate `README.md` updated for the new public API (`hybrid_search`, `Retriever`).

Touches only `sparq-vectors` (+ its SKILL.md). References bead **sq-88c6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)