### PR TITLE
test(sparq-hdt): isolate roundtrip scratch dirs to fix flaky rejection oracle (sq-117n)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +1699,12 @@ dependencies = [
  "cmake",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2720,6 +2732,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3349,6 +3374,7 @@ dependencies = [
  "hdt",
  "rayon",
  "sparq-core",
+ "tempfile",
  "zstd",
 ]
 
@@ -3662,6 +3688,19 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "termcolor"

--- a/crates/sparq-hdt/Cargo.toml
+++ b/crates/sparq-hdt/Cargo.toml
@@ -80,3 +80,11 @@ rayon = { workspace = true }
 # (`Hdt::read_nt`), used ONLY to build .hdt round-trip fixtures / benchmark inputs
 # from N-Triples ground truth in-process.
 hdt = { version = "0.4", features = ["sophia"] }
+# [OPUS-4.8] sq-117n: per-test unique, auto-cleaned scratch dirs. The roundtrip
+# tests build `.hdt` archives by writing an N-Triples file to disk and reading it
+# back with `Hdt::read_nt`; using FIXED `CARGO_TARGET_TMPDIR` subdir names let
+# sibling tests race on the same `src.nt` (three rejection-oracle tests shared one
+# `valid_corruptible_hdt()` helper -> one fixed scratch dir), flaking the suite
+# under `cargo test` parallelism. `tempfile::tempdir()` hands each invocation a
+# unique directory (auto-removed on drop), so no two tests can ever collide.
+tempfile = "3"

--- a/crates/sparq-hdt/tests/roundtrip.rs
+++ b/crates/sparq-hdt/tests/roundtrip.rs
@@ -4,9 +4,29 @@
 use sparq_core::Graph;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use tempfile::TempDir;
 
 fn fixture(name: &str) -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures").join(name)
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+/// [OPUS-4.8] sq-117n: a UNIQUE, auto-cleaned scratch directory, one per call.
+///
+/// The tests here materialize `.hdt` archives by writing an N-Triples file to disk
+/// (`src.nt` / `zoo.nt` / …) and reading it back with `hdt::Hdt::read_nt`. Previously
+/// each test (and the shared `valid_corruptible_hdt()` / `nt_to_hdt_bytes` helpers)
+/// joined `CARGO_TARGET_TMPDIR` with a FIXED subdir name, so sibling tests running
+/// concurrently under `cargo test` raced on the same file — one test writing/replacing
+/// `src.nt` while another read it back, which intermittently flaked the rejection-oracle
+/// tests (`rejection_oracle_*` all funneled through one `sparq-hdt-corrupt` dir).
+/// `tempfile::tempdir()` returns a fresh, uniquely-named directory under the OS temp
+/// dir that is removed when the returned `TempDir` is dropped, so no two test
+/// invocations can ever collide. Callers must keep the `TempDir` alive for as long as
+/// they use the path (binding it to a local does this).
+fn scratch_dir() -> TempDir {
+    tempfile::tempdir().expect("creating a unique scratch directory")
 }
 
 /// Dumps a graph as a canonical, comparable triple set (N-Triples term rendering).
@@ -16,7 +36,11 @@ fn triple_set(g: &Graph) -> BTreeSet<[String; 3]> {
         .iter()
         .map(|r| {
             let [s, p, o] = scan.to_spo(r);
-            [g.dict.term(s).to_string(), g.dict.term(p).to_string(), g.dict.term(o).to_string()]
+            [
+                g.dict.term(s).to_string(),
+                g.dict.term(p).to_string(),
+                g.dict.term(o).to_string(),
+            ]
         })
         .collect()
 }
@@ -64,10 +88,9 @@ fn generated_hdt_round_trips() {
         "_:b1 <http://xmlns.com/foaf/0.1/name> \"anon\" .\n",
     );
 
-    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("sparq-hdt-roundtrip");
-    std::fs::create_dir_all(&dir).unwrap();
-    let nt_path = dir.join("zoo.nt");
-    let hdt_path = dir.join("zoo.hdt");
+    let dir = scratch_dir();
+    let nt_path = dir.path().join("zoo.nt");
+    let hdt_path = dir.path().join("zoo.hdt");
     std::fs::write(&nt_path, nt).unwrap();
 
     // N-Triples -> HDT archive on disk (FourSectDict PFC + BitmapTriples).
@@ -126,11 +149,13 @@ fn gzipped_hdt_loads_transparently() {
     // Through a reader…
     let g = sparq_hdt::load_reader(std::io::Cursor::new(gz.clone())).unwrap();
     assert_eq!(g.store.len(), 328);
-    assert_eq!(triple_set(&g), triple_set(&sparq_hdt::load(fixture("snikmeta.hdt")).unwrap()));
+    assert_eq!(
+        triple_set(&g),
+        triple_set(&sparq_hdt::load(fixture("snikmeta.hdt")).unwrap())
+    );
     // …and through a path with NO .gz extension (content sniffing, not names).
-    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("sparq-hdt-gz");
-    std::fs::create_dir_all(&dir).unwrap();
-    let path = dir.join("disguised.hdt");
+    let dir = scratch_dir();
+    let path = dir.path().join("disguised.hdt");
     std::fs::write(&path, &gz).unwrap();
     assert_eq!(sparq_hdt::load(&path).unwrap().store.len(), 328);
 }
@@ -173,9 +198,8 @@ fn zstd_hdt_loads_transparently() {
     let g = sparq_hdt::load_reader(std::io::Cursor::new(zst.clone())).unwrap();
     assert_eq!(g.store.len(), 328);
     assert_eq!(triple_set(&g), triple_set(&plain));
-    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("sparq-hdt-zst");
-    std::fs::create_dir_all(&dir).unwrap();
-    let path = dir.join("disguised.hdt"); // sniffed by content, not name
+    let dir = scratch_dir();
+    let path = dir.path().join("disguised.hdt"); // sniffed by content, not name
     std::fs::write(&path, &zst).unwrap();
     assert_eq!(sparq_hdt::load(&path).unwrap().store.len(), 328);
 }
@@ -189,9 +213,8 @@ fn bzip2_hdt_loads_transparently() {
     let g = sparq_hdt::load_reader(std::io::Cursor::new(bz.clone())).unwrap();
     assert_eq!(g.store.len(), 328);
     assert_eq!(triple_set(&g), triple_set(&plain));
-    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("sparq-hdt-bz2");
-    std::fs::create_dir_all(&dir).unwrap();
-    let path = dir.join("disguised.hdt"); // sniffed by content, not name
+    let dir = scratch_dir();
+    let path = dir.path().join("disguised.hdt"); // sniffed by content, not name
     std::fs::write(&path, &bz).unwrap();
     assert_eq!(sparq_hdt::load(&path).unwrap().store.len(), 328);
 }
@@ -232,21 +255,36 @@ fn header_exposes_dataset_metadata() {
 /// Loads `bytes` both ways (direct decoder vs upstream oracle) and asserts the two
 /// graphs are triple-for-triple identical and have the same distinct-term count.
 fn assert_direct_matches_upstream(bytes: &[u8], min_triples: usize) {
-    let direct = sparq_hdt::load_reader(std::io::Cursor::new(bytes.to_vec()))
-        .expect("direct decoder load");
+    let direct =
+        sparq_hdt::load_reader(std::io::Cursor::new(bytes.to_vec())).expect("direct decoder load");
     let upstream = sparq_hdt::load_reader_via_upstream(std::io::Cursor::new(bytes.to_vec()))
         .expect("upstream-oracle load");
 
     let d = triple_set(&direct);
     let u = triple_set(&upstream);
-    assert!(d.len() >= min_triples, "expected >= {min_triples} triples, got {}", d.len());
-    assert_eq!(d, u, "direct decoder and upstream oracle must agree triple-for-triple");
-    assert_eq!(direct.store.len(), upstream.store.len(), "same stored triple count");
+    assert!(
+        d.len() >= min_triples,
+        "expected >= {min_triples} triples, got {}",
+        d.len()
+    );
+    assert_eq!(
+        d, u,
+        "direct decoder and upstream oracle must agree triple-for-triple"
+    );
+    assert_eq!(
+        direct.store.len(),
+        upstream.store.len(),
+        "same stored triple count"
+    );
     // The id-translation must intern the same set of distinct terms. The exact
     // sparq ids depend only on first-appearance order, which is identical because
     // both walk SPO order; comparing distinct-term counts plus the triple-set
     // equality above pins the dictionary translation.
-    assert_eq!(direct.dict.len(), upstream.dict.len(), "same number of distinct interned terms");
+    assert_eq!(
+        direct.dict.len(),
+        upstream.dict.len(),
+        "same number of distinct interned terms"
+    );
 }
 
 /// snikmeta.hdt: a real archive (NOT produced by our writer), 328 triples, whose
@@ -282,19 +320,27 @@ fn direct_decoder_matches_upstream_generated_multiblock() {
     let height = "<http://example.org/height>";
     for i in 0..N {
         // chain: e{i} knows e{i+1} -> e{i} appears as both subject and object (shared)
-        writeln!(nt, "<http://example.org/e{i}> {knows} <http://example.org/e{}> .", i + 1).unwrap();
+        writeln!(
+            nt,
+            "<http://example.org/e{i}> {knows} <http://example.org/e{}> .",
+            i + 1
+        )
+        .unwrap();
         // language-tagged + datatyped + plain literals, object-only section, many blocks
         writeln!(nt, "<http://example.org/e{i}> {label} \"name {i}\"@en .").unwrap();
-        writeln!(nt, "<http://example.org/e{i}> {age} \"{i}\"^^<http://www.w3.org/2001/XMLSchema#integer> .").unwrap();
+        writeln!(
+            nt,
+            "<http://example.org/e{i}> {age} \"{i}\"^^<http://www.w3.org/2001/XMLSchema#integer> ."
+        )
+        .unwrap();
         writeln!(nt, "<http://example.org/e{i}> {height} \"{i}.5\"^^<http://www.w3.org/2001/XMLSchema#decimal> .").unwrap();
     }
     // A couple of blank nodes (subject + object positions).
     writeln!(nt, "_:anon0 {knows} <http://example.org/e0> .").unwrap();
     writeln!(nt, "<http://example.org/e0> {knows} _:anon1 .").unwrap();
 
-    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("sparq-hdt-multiblock");
-    std::fs::create_dir_all(&dir).unwrap();
-    let nt_path = dir.join("multiblock.nt");
+    let dir = scratch_dir();
+    let nt_path = dir.path().join("multiblock.nt");
     std::fs::write(&nt_path, &nt).unwrap();
 
     let written = hdt::Hdt::read_nt(&nt_path).expect("building multi-block HDT");
@@ -302,8 +348,14 @@ fn direct_decoder_matches_upstream_generated_multiblock() {
     written.write(&mut buf).expect("serializing HDT");
 
     // Sanity: confirm the fixture really is multi-block + shared-heavy.
-    assert!(written.dict.objects.num_strings > written.dict.objects.block_size, "objects must span >1 block");
-    assert!(written.dict.shared.num_strings > written.dict.shared.block_size, "shared must span >1 block");
+    assert!(
+        written.dict.objects.num_strings > written.dict.objects.block_size,
+        "objects must span >1 block"
+    );
+    assert!(
+        written.dict.shared.num_strings > written.dict.shared.block_size,
+        "shared must span >1 block"
+    );
 
     assert_direct_matches_upstream(&buf, 4 * N);
 
@@ -340,19 +392,24 @@ fn all_codecs_decode_to_identical_triple_set() {
     let knows = "<http://xmlns.com/foaf/0.1/knows>";
     let label = "<http://www.w3.org/2000/01/rdf-schema#label>";
     for i in 0..N {
-        writeln!(nt, "<http://example.org/e{i}> {knows} <http://example.org/e{}> .", i + 1).unwrap();
+        writeln!(
+            nt,
+            "<http://example.org/e{i}> {knows} <http://example.org/e{}> .",
+            i + 1
+        )
+        .unwrap();
         writeln!(nt, "<http://example.org/e{i}> {label} \"name {i}\"@en .").unwrap();
     }
 
-    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("sparq-hdt-codecs");
-    std::fs::create_dir_all(&dir).unwrap();
-    let nt_path = dir.join("codecs.nt");
+    let dir = scratch_dir();
+    let nt_path = dir.path().join("codecs.nt");
     std::fs::write(&nt_path, &nt).unwrap();
     let written = hdt::Hdt::read_nt(&nt_path).expect("building HDT");
     let mut plain: Vec<u8> = Vec::new();
     written.write(&mut plain).expect("serializing HDT");
 
-    let reference = triple_set(&sparq_hdt::load_reader(std::io::Cursor::new(plain.clone())).unwrap());
+    let reference =
+        triple_set(&sparq_hdt::load_reader(std::io::Cursor::new(plain.clone())).unwrap());
     assert!(reference.len() >= 2 * N);
 
     // gzip
@@ -369,7 +426,11 @@ fn all_codecs_decode_to_identical_triple_set() {
     for (codec, bytes) in [("gzip", gz), ("zstd", zst), ("bzip2", bz)] {
         let g = sparq_hdt::load_reader(std::io::Cursor::new(bytes))
             .unwrap_or_else(|e| panic!("{codec} decode failed: {e}"));
-        assert_eq!(triple_set(&g), reference, "{codec} must decode to the identical triple set as plain .hdt");
+        assert_eq!(
+            triple_set(&g),
+            reference,
+            "{codec} must decode to the identical triple set as plain .hdt"
+        );
     }
 }
 
@@ -381,9 +442,8 @@ fn direct_decoder_matches_upstream_tiny() {
         "", // empty graph: zero strings in every section, zero triples
         "<http://example.org/s> <http://example.org/p> <http://example.org/o> .\n",
     ] {
-        let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("sparq-hdt-tiny");
-        std::fs::create_dir_all(&dir).unwrap();
-        let nt_path = dir.join("tiny.nt");
+        let dir = scratch_dir();
+        let nt_path = dir.path().join("tiny.nt");
         std::fs::write(&nt_path, nt).unwrap();
         let written = hdt::Hdt::read_nt(&nt_path).expect("building tiny HDT");
         let mut buf: Vec<u8> = Vec::new();
@@ -413,10 +473,14 @@ fn direct_decoder_matches_upstream_tiny() {
 /// Materializes `nt` as an in-process `.hdt` archive (the crate's existing
 /// fixture-write path: N-Triples -> FourSectDict PFC + BitmapTriples via the `hdt`
 /// crate's `read_nt` + `write`) and returns the archive bytes.
-fn nt_to_hdt_bytes(nt: &str, scratch: &str) -> Vec<u8> {
-    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join(scratch);
-    std::fs::create_dir_all(&dir).unwrap();
-    let nt_path = dir.join("src.nt");
+///
+/// [OPUS-4.8] sq-117n: each call gets its OWN unique, auto-cleaned scratch dir
+/// (`scratch_dir()`), so concurrent callers can never race on the same `src.nt`.
+/// The `TempDir` lives only for this call: `read_nt` reads the whole file and the
+/// archive is returned in memory, so the directory is safely removed on return.
+fn nt_to_hdt_bytes(nt: &str) -> Vec<u8> {
+    let dir = scratch_dir();
+    let nt_path = dir.path().join("src.nt");
     std::fs::write(&nt_path, nt).unwrap();
     let written = hdt::Hdt::read_nt(&nt_path).expect("building HDT from N-Triples");
     let mut buf: Vec<u8> = Vec::new();
@@ -477,7 +541,7 @@ fn hdt_load_matches_ntriples_load() {
     ];
 
     for (name, nt) in graphs {
-        let hdt_bytes = nt_to_hdt_bytes(nt, &format!("sparq-hdt-diff-{name}"));
+        let hdt_bytes = nt_to_hdt_bytes(nt);
         let from_hdt = sparq_hdt::load_reader(std::io::Cursor::new(hdt_bytes))
             .unwrap_or_else(|e| panic!("[{name}] loading generated HDT: {e}"));
         let from_nt = Graph::load_str(nt, "ntriples")
@@ -501,7 +565,7 @@ fn hdt_load_matches_ntriples_load() {
         // (2) The SAME archive gzipped must term-equal the plain archive (the
         // streaming `.hdt.gz` path feeds the identical decoder), exercised on each
         // differential graph rather than only the snikmeta fixture.
-        let plain = nt_to_hdt_bytes(nt, &format!("sparq-hdt-diff-{name}"));
+        let plain = nt_to_hdt_bytes(nt);
         use std::io::Write as _;
         let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
         gz.write_all(&plain).unwrap();
@@ -537,7 +601,7 @@ fn pfc_dictionary_edges_translate_identically() {
               <http://example.org/path/to/resource/aaab> <http://example.org/p> <http://example.org/path/to/resource/aaac> .\n\
               <http://example.org/path/to/resource/a> <http://example.org/empty> \"\" .\n";
 
-    let hdt_bytes = nt_to_hdt_bytes(nt, "sparq-hdt-pfc-edges");
+    let hdt_bytes = nt_to_hdt_bytes(nt);
     let from_hdt = sparq_hdt::load_reader(std::io::Cursor::new(hdt_bytes.clone())).unwrap();
     let from_nt = Graph::load_str(nt, "ntriples").unwrap();
     assert_eq!(
@@ -604,7 +668,7 @@ fn valid_corruptible_hdt() -> Vec<u8> {
               _:b0 <http://xmlns.com/foaf/0.1/knows> <http://example.org/alice> .\n\
               _:b0 <http://example.org/link> _:b1 .\n\
               _:b1 <http://xmlns.com/foaf/0.1/name> \"anon\" .\n";
-    nt_to_hdt_bytes(nt, "sparq-hdt-corrupt")
+    nt_to_hdt_bytes(nt)
 }
 
 /// Named, targeted corruptions: bad magic and a truncation landing in each of the

--- a/crates/sparq-hdt/tests/write_roundtrip.rs
+++ b/crates/sparq-hdt/tests/write_roundtrip.rs
@@ -11,7 +11,7 @@
 
 use sparq_core::Graph;
 use std::collections::BTreeSet;
-use std::path::Path;
+use tempfile::TempDir;
 
 /// Canonical comparable triple set (N-Triples term rendering) — same helper as
 /// `tests/roundtrip.rs`.
@@ -48,10 +48,15 @@ const ZOO: &str = concat!(
     "_:b1 <http://xmlns.com/foaf/0.1/name> \"anon\" .\n",
 );
 
-fn scratch(name: &str) -> std::path::PathBuf {
-    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("sparq-hdt-write");
-    std::fs::create_dir_all(&dir).unwrap();
-    dir.join(name)
+/// [OPUS-4.8] sq-117n: a UNIQUE, auto-cleaned scratch directory, one per call.
+///
+/// These tests `save` archives to disk and read them back. Previously every test
+/// shared one fixed `CARGO_TARGET_TMPDIR/sparq-hdt-write` directory (distinguished
+/// only by per-call FILE names); a unique `tempfile::tempdir()` per test removes any
+/// chance of cross-test contention on the shared directory and auto-cleans on drop.
+/// Bind the returned `TempDir` to a local and join names off `dir.path()`.
+fn scratch_dir() -> TempDir {
+    tempfile::tempdir().expect("creating a unique scratch directory")
 }
 
 /// Core contract: Graph -> `save` .hdt -> `load` .hdt == the original Graph,
@@ -59,7 +64,8 @@ fn scratch(name: &str) -> std::path::PathBuf {
 #[test]
 fn save_then_load_round_trips_the_term_zoo() {
     let original = Graph::load_str(ZOO, "ntriples").unwrap();
-    let path = scratch("zoo.hdt");
+    let dir = scratch_dir();
+    let path = dir.path().join("zoo.hdt");
     sparq_hdt::save(&original, &path).expect("saving Graph to .hdt");
 
     let reloaded = sparq_hdt::load(&path).expect("loading the saved .hdt");
@@ -87,7 +93,8 @@ fn save_then_load_round_trips_the_term_zoo() {
 #[test]
 fn saved_archive_loads_via_upstream_oracle_too() {
     let original = Graph::load_str(ZOO, "ntriples").unwrap();
-    let path = scratch("zoo-oracle.hdt");
+    let dir = scratch_dir();
+    let path = dir.path().join("zoo-oracle.hdt");
     sparq_hdt::save(&original, &path).unwrap();
 
     let bytes = std::fs::read(&path).unwrap();
@@ -104,6 +111,7 @@ fn saved_archive_loads_via_upstream_oracle_too() {
 fn save_honours_compression_containers() {
     let original = Graph::load_str(ZOO, "ntriples").unwrap();
     let reference = triple_set(&original);
+    let dir = scratch_dir();
 
     // Magic bytes the reader sniffs: gzip 1f 8b, zstd 28 b5 2f fd, bzip2 "BZh".
     for (name, magic) in [
@@ -111,7 +119,7 @@ fn save_honours_compression_containers() {
         ("zoo.hdt.zst", &[0x28, 0xb5, 0x2f, 0xfd][..]),
         ("zoo.hdt.bz2", &[0x42, 0x5a, 0x68][..]),
     ] {
-        let path = scratch(name);
+        let path = dir.path().join(name);
         sparq_hdt::save(&original, &path).unwrap_or_else(|e| panic!("[{name}] save: {e}"));
 
         // The file really is wrapped in the requested container.
@@ -127,7 +135,7 @@ fn save_honours_compression_containers() {
     }
 
     // A bare `.hdt` writes the uncompressed `$HDT` cookie.
-    let bare = scratch("zoo-bare.hdt");
+    let bare = dir.path().join("zoo-bare.hdt");
     sparq_hdt::save(&original, &bare).unwrap();
     let head = std::fs::read(&bare).unwrap();
     assert_eq!(
@@ -157,7 +165,8 @@ fn save_round_trips_multiblock_graph() {
         writeln!(nt, "<http://example.org/e{i}> {label} \"name {i}\"@en .").unwrap();
     }
     let original = Graph::load_str(&nt, "ntriples").unwrap();
-    let path = scratch("multiblock.hdt");
+    let dir = scratch_dir();
+    let path = dir.path().join("multiblock.hdt");
     sparq_hdt::save(&original, &path).unwrap();
 
     let reloaded = sparq_hdt::load(&path).unwrap();
@@ -170,7 +179,8 @@ fn save_round_trips_multiblock_graph() {
 #[test]
 fn save_empty_graph() {
     let empty = Graph::load_str("", "ntriples").unwrap();
-    let path = scratch("empty.hdt");
+    let dir = scratch_dir();
+    let path = dir.path().join("empty.hdt");
     sparq_hdt::save(&empty, &path).unwrap();
     let reloaded = sparq_hdt::load(&path).unwrap();
     assert_eq!(reloaded.store.len(), 0);
@@ -182,10 +192,11 @@ fn save_empty_graph() {
 #[test]
 fn save_is_idempotent_on_content() {
     let original = Graph::load_str(ZOO, "ntriples").unwrap();
-    let p1 = scratch("idem-1.hdt");
+    let dir = scratch_dir();
+    let p1 = dir.path().join("idem-1.hdt");
     sparq_hdt::save(&original, &p1).unwrap();
     let g1 = sparq_hdt::load(&p1).unwrap();
-    let p2 = scratch("idem-2.hdt");
+    let p2 = dir.path().join("idem-2.hdt");
     sparq_hdt::save(&g1, &p2).unwrap();
     let g2 = sparq_hdt::load(&p2).unwrap();
     assert_eq!(triple_set(&g1), triple_set(&g2));
@@ -200,9 +211,10 @@ fn save_is_idempotent_on_content() {
 fn direct_encoder_writes_no_temp_files() {
     const SAVES: usize = 30;
     let original = Graph::load_str(ZOO, "ntriples").unwrap();
+    let dir = scratch_dir();
     let before = count_scratch_nt();
     for i in 0..SAVES {
-        sparq_hdt::save(&original, scratch(&format!("cleanup-{i}.hdt"))).unwrap();
+        sparq_hdt::save(&original, dir.path().join(format!("cleanup-{i}.hdt"))).unwrap();
     }
     let after = count_scratch_nt();
     // The direct encoder creates none, so the count cannot grow with `SAVES`.
@@ -243,15 +255,16 @@ fn count_scratch_nt() -> usize {
 #[test]
 fn direct_encode_matches_upstream_builder() {
     let original = Graph::load_str(ZOO, "ntriples").unwrap();
+    let dir = scratch_dir();
 
     // Ours: the direct in-memory encoder.
-    let direct_path = scratch("equiv-direct.hdt");
+    let direct_path = dir.path().join("equiv-direct.hdt");
     sparq_hdt::save(&original, &direct_path).unwrap();
     let direct_bytes = std::fs::read(&direct_path).unwrap();
 
     // Oracle: render the SAME graph to N-Triples, build via the upstream crate's
     // `read_nt`, write via `Hdt::write` (the retired round-trip path's machinery).
-    let nt_path = scratch("equiv-oracle.nt");
+    let nt_path = dir.path().join("equiv-oracle.nt");
     {
         use std::io::Write as _;
         let mut f = std::io::BufWriter::new(std::fs::File::create(&nt_path).unwrap());


### PR DESCRIPTION
> 🤖 **SPARQ agent** — fixing bead **sq-117n**: the sparq-hdt test `roundtrip.rs::rejection_oracle_no_truncation_panics_or_partial_decodes` was FLAKY under the parallel full suite (passed isolated/single-threaded, flaked ~2/N under `cargo test` parallelism) due to **scratch-directory contention**.

## Root cause

The roundtrip tests materialize `.hdt` archives by writing an N-Triples file to disk and reading it back with `hdt::Hdt::read_nt`. They joined `CARGO_TARGET_TMPDIR` with a **fixed** subdirectory name, so sibling tests running concurrently shared a path. The three `rejection_oracle_*` tests all funnel through one `valid_corruptible_hdt()` helper, which wrote `src.nt` into one shared `sparq-hdt-corrupt` directory — one test rewriting/replacing that file while another read it back is the race that intermittently broke the truncation oracle.

## Fix — per-invocation isolated scratch dirs

- Added `tempfile` as a **dev-dependency** (dev-only; confirmed NOT in sparq-hdt's normal graph and never in the `sparq-wasm` bundle via `cargo tree -e normal`).
- Introduced a `scratch_dir()` helper that returns a fresh `tempfile::tempdir()` — a uniquely-named directory under the OS temp dir, auto-removed on `TempDir` drop — so **no two test invocations can ever collide on a path**.
- `tests/roundtrip.rs`: every `CARGO_TARGET_TMPDIR`/fixed-name scratch site now uses `scratch_dir()`; dropped the now-redundant per-call `scratch: &str` argument on `nt_to_hdt_bytes` (every call is unique by construction).
- `tests/write_roundtrip.rs`: audited for the same pattern — it shared one fixed `sparq-hdt-write` dir across all save tests. Converted its `scratch(name)` helper to a per-test `TempDir` (`dir.path().join(name)`), removing the shared directory entirely.

No production code changed; only sparq-hdt tests + the dev-dependency. `[OPUS-4.8]` markers on the new helpers/notes.

## Flake-gone evidence

- The contention is deterministic by inspection (three tests racing on one `src.nt`). After the fix, ran the **full** `cargo test -p sparq-hdt --features write` suite **13×** under parallelism (including explicit `--test-threads=8`); the target test `rejection_oracle_no_truncation_panics_or_partial_decodes` was executed and reported `... ok` on **every** run — 0 failures.

## Gate (all clean)

- `cargo test -p sparq-hdt` (default features): 9 unit + 18 roundtrip pass.
- `cargo test -p sparq-hdt --features write`: 9 unit + 18 roundtrip + 8 write_roundtrip pass.
- `cargo clippy -p sparq-hdt --all-targets --features write -- -D warnings`: clean.
- Only the edited test files formatted.

Refs: bead **sq-117n**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)