### PR TITLE
feat(bench): Deep Taxonomy first-class CI reasoning suite + guarded ci-bench hook [OPUS-4.8]

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -63,7 +63,7 @@ conventions first, then a per-category map that points at the registry, then a
 | **ingest** | load + dict + external-memory build throughput | `cli-ingest`, `cli-save-build`, `cli-bench-remap`, `hdt-load-bench`, `wikidata-8b` |
 | **compression** | index / result-serialization footprint tradeoffs | `cli-probe-compress`, `cli-compare-compress`, `compress-bench` |
 | **scaling** | parallel thread sweep + cross-commit/hardware tracking | `cli-scaling`, `ci-bench`, `ci-bench-ec2`, `hw-bench` |
-| **inference** | N3 / RDFS / OWL closure + incremental maintenance | `inference-eye-comparison`, `inference-owl-bench`, `inference-incremental`, `solid-wac-bench` |
+| **inference** | N3 / RDFS / OWL closure + incremental maintenance | `inference-eye-comparison`, `inference-owl-bench`, `inference-incremental`, `deep-taxonomy`, `solid-wac-bench` |
 | **zk** | commitment pipeline, trace seam, circuit gates, prove/verify | `zk-commit-throughput`, `zk-trace-overhead`, `zk-compose-gates`, `zk-compose-prove-verify` |
 | **serve** | concurrent-serving + memory-tiering research spikes | `serve-spikes`, `memtier-spikes` |
 | **conformance** | W3C SPARQL + reasoning suites (correctness, not perf) | `sparql-conformance`, `inference-conformance` |
@@ -113,6 +113,18 @@ Notes on a few that need care:
   asserting BOTH tiers' counts vs `expected-rows.tsv`. CI emits `lubm_<query>_count_us`
   (trend-only) and fails on any count mismatch (reasoner OR engine regression). Full-scale
   **LUBM(1000)** (~133M triples) is the EC2/nightly tier (`bench/lubm/gen.sh 1000 0`).
+- **`deep-taxonomy` (DeepTaxonomy) is the rule-heavy N3 REASONING suite** — see
+  [`bench/deep-taxonomy/README.md`](./deep-taxonomy/README.md). `run.sh` is self-asserting and
+  REUSES the existing generator `bench/inference/gen_deeptaxonomy.py` (1 instance + a depth-deep
+  `:sc` chain + 1 transitivity meta-rule): per depth tier it materializes the **N3 forward
+  closure** (`sparq-cli reason … n3`), runs a class-membership `query.rq` over it, and asserts
+  BOTH the closure triple-count (`= 2·depth+1`) AND the query rows (`= depth+1`) vs `expected.tsv`
+  — a deterministic, load-robust gate that fails LOUDLY on a reasoner regression. Needs only
+  `python3` (no g++/javac), so it runs on the per-commit tier at a SMALL depth pair (dt1k+dt10k);
+  dt100k is opt-in via `DEEPTAX_DEPTHS` for EC2/nightly. CI emits
+  `deeptax_d<DEPTH>_{closure_s,query_us,closure_triples}` (trend-only). The dashboard features it
+  as a scaling suite (depth axis) with EYE external-reference baselines (cited from
+  `bench/inference/eye-comparison.md`; dt100k = n/a, EYE not run).
 - **`wikidata-8b` is external-cost and gated.** It builds the full Wikidata
   truthy dump (~8-9.4B triples) on a 16 GB EC2 box (~$5-17). It is **blocked
   until dict-spill merges to public main** — see
@@ -139,7 +151,7 @@ Notes on a few that need care:
   Comparable-suite map (registry-driven): **Oxigraph** ↔ `sparq-bench-compare`,
   `sp2b`, `watdiv`, `bsbm`, `dbpsb`, `lubm` (extensional only); **QLever** ↔
   `qlever-olympics`, `qlever-synthetic-10m/100m`, `watdiv`, `bsbm`, `lubm`
-  (extensional); **eye** ↔ `inference-eye-comparison` (DeepTaxonomy/anc500/grid30).
+  (extensional); **eye** ↔ `inference-eye-comparison` + `deep-taxonomy` (DeepTaxonomy/anc500/grid30).
   HONESTY NOTE (per parent `sq-i0nm`): a gh-runner gather is noisy and not
   comparable to the EC2/quiet-box reference band — the recorded `env.quiet_box`
   flag lets the dashboard label it distinctly (see the QUIET-BOX convention above).
@@ -161,6 +173,7 @@ CUT=$(bench/dbpsb/fetch.sh 750000)   && ./target/release/sparq-cli bench "$CUT" 
 bench/watdiv/run.sh 1                 # WatDiv SF=1 (g++ + Boost): gen + count/materialize/json + row diff
 bench/bsbm/run.sh                     # BSBM Explore -pc 300 (JRE + unzip): gen + materialize + row diff
 bench/lubm/run.sh                     # LUBM(1) (javac + rapper): gen + OWL-RL closure + both tiers + row diff
+bench/deep-taxonomy/run.sh            # DeepTaxonomy (python3 only): N3 closure per depth tier + closure-size + query-row gate
 
 # --- selective bind-join + u64 value-id probes ---
 python3 bench/selective/gen.py 500000 > bench/selective/selective.nt

--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -177,6 +177,19 @@ records_to  = "stdout (TSV); CI emits lubm_<query>_count_us into benchmark-data 
 status      = "ok"
 
 [[benchmark]]
+id          = "deep-taxonomy"
+name        = "Deep Taxonomy (DeepTaxonomy) — rule-heavy N3 forward-closure reasoning"
+category    = "inference"
+measures    = "per depth tier (default dt1k+dt10k per-commit; dt100k EC2/nightly): N3 forward-closure time (deeptax_d<DEPTH>_closure_s), a class-membership query over the closure (deeptax_d<DEPTH>_query_us), and the materialized closure triple-count (deeptax_d<DEPTH>_closure_triples). run.sh carries a SELF-ASSERTING closure-size gate: closure_triples (= 2·depth+1) AND query rows (= depth+1) are asserted vs expected.tsv (deterministic) so a sparq-reason regression fails LOUDLY. This is the canonical workload where naive forward chaining blows up O(N^2) and semi-naive + indexing is linear"
+invoke      = "cargo build --release -p sparq-cli && bench/deep-taxonomy/run.sh   # self-contained: reuse gen_deeptaxonomy.py, materialize the N3 closure per depth tier, query.rq over it, assert expected.tsv; CI runs it via scripts/ci-bench.sh -> deeptax_d<DEPTH>_{closure_s,query_us,closure_triples}. Tiers via DEEPTAX_DEPTHS"
+source      = "bench/deep-taxonomy/{gen.sh,run.sh,query.rq,expected.tsv,README.md} (gen.sh REUSES bench/inference/gen_deeptaxonomy.py — generator NOT rewritten); scripts/ci-bench.sh (deeptax hook); crates/sparq-cli/src/main.rs (cmd_reason n3)"
+dataset     = "DeepTaxonomy from the existing bench/inference/gen_deeptaxonomy.py: 1 instance fact + a DEPTH-deep :sc chain + 1 transitivity meta-rule; pure-Python stdlib, NO network/toolchain, byte-deterministic. Per-commit depths 1000 + 10000 (N3 closures 2,001 / 20,001 triples, ~0.1 s total); depth 100000 (closure 200,001) is opt-in via DEEPTAX_DEPTHS for EC2/nightly. Closure sizes cross-checked with bench/inference/eye-comparison.md. gitignored + regenerable (/tmp/deep-taxonomy)"
+quiet_box_sensitive = true  # closure_s/query_us wall-clock trend-only, NOT in scripts/perf-gate.py; the closure-triple-count + query-row assertions ARE a hard correctness gate (deterministic, load-robust; catches reasoner regressions). EYE head-to-head wall numbers live in bench/inference/eye-comparison.md (cited, NOT re-run per commit)
+pinning     = "gen_deeptaxonomy.py is a deterministic pure function of depth (no RNG, byte-identical); expected.tsv pins the structural closure sizes (2·depth+1) + query rows (depth+1) per tier; metric `d<DEPTH>` token is numeric so the dashboard derives the depth-scaling axis"
+records_to  = "stdout (TSV); CI emits deeptax_d<DEPTH>_{closure_s,query_us,closure_triples} into benchmark-data (dev/bench) via scripts/ci-bench.sh; expected sizes in bench/deep-taxonomy/expected.tsv; EYE comparison numbers in bench/inference/eye-comparison.md + the dashboard external-reference baselines (bench/dashboard/competitors.json)"
+status      = "ok"
+
+[[benchmark]]
 id          = "selective-bindjoin"
 name        = "Selective (index-nested-loop / bind) join"
 category    = "query"

--- a/bench/dashboard/metric-labels.json
+++ b/bench/dashboard/metric-labels.json
@@ -677,6 +677,78 @@
       "mode": "materialize",
       "unit": "µs"
     },
+    "deeptax_d100000_closure_s": {
+      "label": "Deep Taxonomy dt100k — N3 forward-closure time",
+      "suite": "Deep Taxonomy",
+      "dataset": "DeepTaxonomy dt100k — 1 instance, 100000-deep :sc chain, 1 transitivity meta-rule (reuses bench/inference/gen_deeptaxonomy.py); N3 forward closure = 200001 triples",
+      "query": "materialize the N3 forward closure (transitivity meta-rule)",
+      "mode": "closure",
+      "unit": "s"
+    },
+    "deeptax_d100000_closure_triples": {
+      "label": "Deep Taxonomy dt100k — materialized closure size",
+      "suite": "Deep Taxonomy",
+      "dataset": "DeepTaxonomy dt100k — 1 instance, 100000-deep :sc chain, 1 transitivity meta-rule (reuses bench/inference/gen_deeptaxonomy.py); N3 forward closure = 200001 triples",
+      "query": "deterministic closure triple-count (self-asserting gate; = 2·depth+1 = 200001)",
+      "mode": "closure",
+      "unit": "triples"
+    },
+    "deeptax_d100000_query": {
+      "label": "Deep Taxonomy dt100k — class-membership query over the closure",
+      "suite": "Deep Taxonomy",
+      "dataset": "DeepTaxonomy dt100k — 1 instance, 100000-deep :sc chain, 1 transitivity meta-rule (reuses bench/inference/gen_deeptaxonomy.py); N3 forward closure = 200001 triples",
+      "query": "SELECT ?c WHERE { :i a ?c } (returns depth+1 = 100001 rows)",
+      "mode": "count",
+      "unit": "µs"
+    },
+    "deeptax_d10000_closure_s": {
+      "label": "Deep Taxonomy dt10k — N3 forward-closure time",
+      "suite": "Deep Taxonomy",
+      "dataset": "DeepTaxonomy dt10k — 1 instance, 10000-deep :sc chain, 1 transitivity meta-rule (reuses bench/inference/gen_deeptaxonomy.py); N3 forward closure = 20001 triples",
+      "query": "materialize the N3 forward closure (transitivity meta-rule)",
+      "mode": "closure",
+      "unit": "s"
+    },
+    "deeptax_d10000_closure_triples": {
+      "label": "Deep Taxonomy dt10k — materialized closure size",
+      "suite": "Deep Taxonomy",
+      "dataset": "DeepTaxonomy dt10k — 1 instance, 10000-deep :sc chain, 1 transitivity meta-rule (reuses bench/inference/gen_deeptaxonomy.py); N3 forward closure = 20001 triples",
+      "query": "deterministic closure triple-count (self-asserting gate; = 2·depth+1 = 20001)",
+      "mode": "closure",
+      "unit": "triples"
+    },
+    "deeptax_d10000_query": {
+      "label": "Deep Taxonomy dt10k — class-membership query over the closure",
+      "suite": "Deep Taxonomy",
+      "dataset": "DeepTaxonomy dt10k — 1 instance, 10000-deep :sc chain, 1 transitivity meta-rule (reuses bench/inference/gen_deeptaxonomy.py); N3 forward closure = 20001 triples",
+      "query": "SELECT ?c WHERE { :i a ?c } (returns depth+1 = 10001 rows)",
+      "mode": "count",
+      "unit": "µs"
+    },
+    "deeptax_d1000_closure_s": {
+      "label": "Deep Taxonomy dt1k — N3 forward-closure time",
+      "suite": "Deep Taxonomy",
+      "dataset": "DeepTaxonomy dt1k — 1 instance, 1000-deep :sc chain, 1 transitivity meta-rule (reuses bench/inference/gen_deeptaxonomy.py); N3 forward closure = 2001 triples",
+      "query": "materialize the N3 forward closure (transitivity meta-rule)",
+      "mode": "closure",
+      "unit": "s"
+    },
+    "deeptax_d1000_closure_triples": {
+      "label": "Deep Taxonomy dt1k — materialized closure size",
+      "suite": "Deep Taxonomy",
+      "dataset": "DeepTaxonomy dt1k — 1 instance, 1000-deep :sc chain, 1 transitivity meta-rule (reuses bench/inference/gen_deeptaxonomy.py); N3 forward closure = 2001 triples",
+      "query": "deterministic closure triple-count (self-asserting gate; = 2·depth+1 = 2001)",
+      "mode": "closure",
+      "unit": "triples"
+    },
+    "deeptax_d1000_query": {
+      "label": "Deep Taxonomy dt1k — class-membership query over the closure",
+      "suite": "Deep Taxonomy",
+      "dataset": "DeepTaxonomy dt1k — 1 instance, 1000-deep :sc chain, 1 transitivity meta-rule (reuses bench/inference/gen_deeptaxonomy.py); N3 forward closure = 2001 triples",
+      "query": "SELECT ?c WHERE { :i a ?c } (returns depth+1 = 1001 rows)",
+      "mode": "count",
+      "unit": "µs"
+    },
     "dict_bytes_per_term": {
       "label": "Dictionary size — bytes per term",
       "suite": "Memory / Size",

--- a/bench/deep-taxonomy/README.md
+++ b/bench/deep-taxonomy/README.md
@@ -1,0 +1,107 @@
+<!-- [OPUS-4.8] Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns). -->
+# Deep Taxonomy (DeepTaxonomy) — rule-heavy N3 forward-closure reasoning
+
+The canonical rule-heavy inference micro-benchmark: a **single** instance fact, a **deep**
+`rdfs`-style `:sc` (subclass) chain, and **one** transitivity meta-rule. It is the workload where
+NAIVE forward chaining blows up (O(N²) — each new derived type re-joins the whole relation) while
+a semi-naive, delta-indexed fixpoint is effectively linear. The reasoner under test is
+`sparq-reason` (the closure under RDFS/OWL-RL/N3); here it runs the **N3** profile
+(`sparq-cli reason … n3`). Registry entry: `deep-taxonomy` in
+[`bench/benchmarks.toml`](../benchmarks.toml).
+
+> **Attribution.** DeepTaxonomy is a community N3-reasoner benchmark used by the EYE reasoner and
+> the RR-2023 literature. We **reuse** the existing in-repo generator
+> [`bench/inference/gen_deeptaxonomy.py`](../inference/gen_deeptaxonomy.py) — this suite does NOT
+> rewrite it; `gen.sh` is a thin, cache-backed wrapper around it (same generator the EYE
+> head-to-head in [`bench/inference/eye-comparison.md`](../inference/eye-comparison.md) uses, so
+> the closure sizes match).
+
+## Layout
+
+```
+bench/deep-taxonomy/
+├── gen.sh           thin wrapper REUSING bench/inference/gen_deeptaxonomy.py; emits a DT N3 corpus per depth
+├── run.sh           self-asserting runner: materialize the N3 closure per tier, query it, assert expected.tsv
+├── query.rq         class-membership probe: SELECT ?c WHERE { :i a ?c }  (returns depth+1 rows)
+└── expected.tsv     DETERMINISTIC per-depth closure_triples (= 2·depth+1) + query_rows (= depth+1)
+```
+
+## The workload (per depth N)
+
+`gen_deeptaxonomy.py N` emits:
+
+```
+:i a :n0 .                                 # one instance fact
+{ ?x a ?c . ?c :sc ?d } => { ?x a ?d } .   # one transitivity meta-rule
+:n0 :sc :n1 . :n1 :sc :n2 . … :n{N-1} :sc :nN .   # a depth-N :sc chain
+```
+
+After the N3 forward closure, `:i` is a member of **every** class `:n0 … :nN`. The closure is
+therefore fully determined by the depth:
+
+- **closure triple-count** `= 2·N + 1` — the `N` chain edges + the `N` derived `:i a :nK` + the
+  seed `:i a :n0`. (dt1k → 2,001; dt10k → 20,001; dt100k → 200,001 — these match the closure
+  cross-check table in [`bench/inference/eye-comparison.md`](../inference/eye-comparison.md), where
+  sparq and EYE agree.)
+- **`query.rq` rows** `= N + 1` — `:i` is now a member of `:n0 … :nN`.
+
+## Self-asserting closure-size gate
+
+`run.sh` is the point of the suite. For each depth tier it materializes the closure with
+`sparq-cli reason <corpus> n3 n3 <out.nt>`, runs `query.rq` over the closure, and asserts BOTH the
+materialized closure triple-count AND the query row-count against the deterministic values in
+`expected.tsv`. Any divergence is a `sparq-reason` correctness regression (a missing/extra
+entailment, a broken fixpoint) and **exits non-zero** — the metric latencies are trend-only, but
+this structural gate is a hard correctness check (deterministic + load-robust, so it never flakes
+on a noisy runner). The closure-size cross-check matches EYE's (cited above), so a regression that
+keeps the timings green but changes the closure is still caught.
+
+## Run it
+
+```sh
+cargo build --release -p sparq-cli
+bench/deep-taxonomy/run.sh                       # default per-commit tiers: dt1k + dt10k
+DEEPTAX_DEPTHS="1000 10000 100000" bench/deep-taxonomy/run.sh   # add dt100k (EC2/nightly)
+```
+
+`run.sh` prints one metric TSV line per tier-metric on stdout
+(`<metric>\t<value>\t<unit>`) and the assertion diagnostics on stderr.
+
+CI wires the per-commit subset through [`scripts/ci-bench.sh`](../../scripts/ci-bench.sh) (the
+`deeptax` hook, mirroring the LUBM hook: it invokes the self-asserting `run.sh` and harvests its
+TSV) as metrics:
+
+- `deeptax_d<DEPTH>_closure_s` — N3 forward-closure wall seconds (engine-internal timer)
+- `deeptax_d<DEPTH>_query_us` — `query.rq` min-of-iters latency (µs), count mode
+- `deeptax_d<DEPTH>_closure_triples` — materialized closure triple-count (deterministic structural)
+
+All three are **trend-only** (NOT in the deterministic hard perf-gate
+`scripts/perf-gate.py`); the closure-size + query-row assertions inside `run.sh` are the hard
+correctness gate. `run.sh` failing fails the whole `ci-bench` run.
+
+## Tiering — per-commit vs EC2/nightly
+
+Unlike `watdiv`/`bsbm`/`lubm`, this suite needs **no** heavyweight toolchain — only `python3`
+(stdlib) plus the built `sparq-cli` — so it runs on the per-commit tier by default at a SMALL depth
+pair (**dt1k + dt10k**; closures 2,001 / 20,001 triples — sub-second). The numeric `d<DEPTH>`
+metric token lets the dashboard derive a **depth-scaling axis** (two points → a scaling curve).
+**dt100k** (depth 100,000; closure 200,001) is opt-in via `DEEPTAX_DEPTHS` for the EC2/nightly
+tier (its EYE reference was extrapolated, never run — see below).
+
+## Dashboard + EYE competitor
+
+The dashboard ([`bench/dashboard/dashboard.js`](../dashboard/dashboard.js)) features Deep Taxonomy
+as a recognised public suite (`featuredSuiteOf` routes the `deeptax_…` metrics; `sizeAxisOf` reads
+the `_d<DEPTH>` depth axis for the scaling chart), with readable labels generated into
+[`bench/dashboard/metric-labels.json`](../dashboard/metric-labels.json) by
+[`scripts/gen-metric-labels.py`](../../scripts/gen-metric-labels.py) (derived from this suite's
+`expected.tsv` tiers — re-run the generator, or `--check` gates drift, if you add a tier).
+
+EYE (the N3 reasoner reference) numbers are surfaced as **external-reference baselines** — real,
+cited measurements at EYE's OWN scale/machine, shown SEPARATELY from sparq's same-scale metrics so
+a mismatched figure is never aligned into a same-row comparison. They live in the dashboard's
+competitor data ([`bench/dashboard/competitors.json`](../dashboard/competitors.json) + its
+byte-mirror `COMPETITORS_DATA` in `dashboard.js`), cited from
+[`bench/inference/eye-comparison.md`](../inference/eye-comparison.md): **dt1k** and **dt10k** EYE
+forward-closure wall-clock numbers exist (idle-machine M1); **dt100k is `n/a` — EYE was not run at
+that depth** (extrapolated only; NOT fabricated). See the honesty note in `competitors.json`.

--- a/bench/deep-taxonomy/expected.tsv
+++ b/bench/deep-taxonomy/expected.tsv
@@ -1,0 +1,10 @@
+# [OPUS-4.8] Deep Taxonomy DETERMINISTIC expected sizes per depth tier (sq-1hgz). run.sh asserts
+# BOTH columns; any mismatch is a sparq-reason regression and fails the run loudly. These are
+# STRUCTURAL facts of the DT closure, not perf measurements:
+#   closure_triples = 2*depth + 1   (depth :sc edges + depth derived `:i a :nK` + the seed `:i a :n0`)
+#   query_rows      =   depth + 1   (:i is a member of every class :n0 .. :n{depth} after closure)
+# Cross-checked against bench/inference/eye-comparison.md (dt1k 2,001; dt10k 20,001; dt100k 200,001
+# — engines agree). Columns: depth<TAB>closure_triples<TAB>query_rows
+1000	2001	1001
+10000	20001	10001
+100000	200001	100001

--- a/bench/deep-taxonomy/gen.sh
+++ b/bench/deep-taxonomy/gen.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] Deep Taxonomy (DT) corpus generator (sq-1hgz; parent sq-i0nm "design D"). A thin,
+# DETERMINISTIC wrapper around the EXISTING generator bench/inference/gen_deeptaxonomy.py — this
+# suite REUSES that generator (it is NOT rewritten here), it just promotes it to a first-class,
+# cache-backed bench/<suite>/gen.sh entry point mirroring bench/sp2b/gen.sh + bench/lubm/gen.sh.
+#
+#   bench/deep-taxonomy/gen.sh [depth=1000] [out=/tmp/deep-taxonomy/dt-<depth>.n3]
+#
+# Emits ONE path on stdout: the generated Notation3 document for the requested DEPTH tier:
+#   :i a :n0 .                                       (one instance fact)
+#   { ?x a ?c . ?c :sc ?d } => { ?x a ?d } .         (one transitivity meta-rule)
+#   :n0 :sc :n1 . :n1 :sc :n2 . ... :n{depth-1} :sc :n{depth} .   (a depth-deep :sc chain)
+#
+# run.sh consumes it: materialize the N3 forward closure with `sparq-cli reason … n3`, then run
+# query.rq over the closure and ASSERT both the closure triple-count and the query row-count
+# against expected.tsv (deterministic — see run.sh + README.md).
+#
+# WHY REUSE gen_deeptaxonomy.py (no rewrite): it is the canonical DT generator already cited by
+# bench/inference/eye-comparison.md (the EYE head-to-head), so the closure sizes it produces are
+# the SAME ones the EYE comparison + the published RR-2023 DeepTaxonomy literature use. The output
+# is FULLY DETERMINISTIC (pure function of `depth`, no RNG, byte-identical every run), so the
+# corpus — and thus the closure size — is reproducible per-commit.
+#
+# HERMETICITY / CI NOTES:
+#  - Network: NONE. The generator is in-repo pure Python (stdlib only); nothing is fetched.
+#  - Toolchain: python3 ONLY (already required by the bench harness). No g++/javac/rapper/java,
+#    so unlike lubm/watdiv/bsbm this suite has NO heavyweight toolchain guard — it runs on the
+#    per-commit tier by default (see scripts/ci-bench.sh deeptax hook).
+#  - Output is cached under $DEEPTAX_CACHE (default /tmp/deep-taxonomy), gitignored + regenerable
+#    (see bench/CATALOG.md disk discipline). Caller cleans up.
+#
+# Output is Notation3; load into sparq with format `n3` (it carries the `{…}=>{…}` rule). Caller
+# cleans up the corpus.
+set -euo pipefail
+
+DEPTH="${1:-1000}"
+CACHE="${DEEPTAX_CACHE:-/tmp/deep-taxonomy}"
+OUT="${2:-$CACHE/dt-${DEPTH}.n3}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GEN="$ROOT/bench/inference/gen_deeptaxonomy.py"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[deeptax] ERROR: 'python3' not found (needed to run gen_deeptaxonomy.py)." >&2
+  exit 1
+fi
+if [ ! -f "$GEN" ]; then
+  echo "[deeptax] ERROR: generator missing at $GEN" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUT")"
+# Deterministic: same bytes every run for a given depth. Regenerate only if absent so the cache
+# (like lubm/sp2b) makes steady-state per-commit runs skip the (cheap) generation step too.
+if [ ! -s "$OUT" ]; then
+  python3 "$GEN" "$DEPTH" > "$OUT.tmp"
+  mv "$OUT.tmp" "$OUT"
+fi
+
+echo "$OUT"

--- a/bench/deep-taxonomy/query.rq
+++ b/bench/deep-taxonomy/query.rq
@@ -1,0 +1,9 @@
+# [OPUS-4.8] Deep Taxonomy probe query (sq-1hgz). Counts every class the single instance :i is a
+# member of in the MATERIALIZED N3 closure. On the raw data :i is only `a :n0`; after the
+# transitivity meta-rule closes the depth-deep :sc chain, :i is a member of EVERY class :n0..:nN,
+# so this returns exactly DEPTH+1 rows (deterministic — see expected.tsv). It both exercises the
+# closure (a full type scan over the entailed triples) AND yields a deterministic row count the
+# self-asserting gate checks alongside the closure triple-count.
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX : <http://ex/>
+SELECT ?c WHERE { :i a ?c }

--- a/bench/deep-taxonomy/run.sh
+++ b/bench/deep-taxonomy/run.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] Deep Taxonomy per-commit runner (sq-1hgz; parent sq-i0nm "design D") — the
+# self-contained, self-asserting entry point CI calls (mirrors bench/lubm/run.sh). For EACH
+# requested DEPTH tier it:
+#   1. ensures the DT N3 corpus exists (gen.sh, which reuses bench/inference/gen_deeptaxonomy.py).
+#   2. materializes the N3 forward closure with `sparq-cli reason <f> n3 n3 <out.nt>` (sparq-reason)
+#      and records the engine-internal closure time + the materialized closure triple-count.
+#   3. runs query.rq over the closure (count mode, $ITERS iters) and records the query latency.
+#   4. ASSERTS the closure triple-count AND the query row-count against expected.tsv (exit 1 on
+#      any mismatch — a sparq-reason / engine correctness regression fails the run LOUDLY).
+#
+# The self-asserting closure-size gate is the point of the suite: DeepTaxonomy is the canonical
+# rule-heavy inference workload where a reasoner regression (missing/extra entailments, a broken
+# fixpoint) changes the closure size, and that is caught deterministically here.
+#
+# Usage: bench/deep-taxonomy/run.sh   (run from anywhere; honours these env knobs)
+#   DEEPTAX_DEPTHS="1000 10000"   space-separated depth tiers (default: the per-commit pair)
+#   CLI=<path>                    sparq-cli binary (default: target/release/sparq-cli)
+#   ITERS=<n>                     query bench iterations (default 3)
+# stdout: one TSV line per metric:  <metric_name>\t<value>\t<unit>  — harvested by the
+#         scripts/ci-bench.sh deeptax hook into github-action-benchmark JSON. Metric names:
+#   deeptax_d<DEPTH>_closure_s        N3 forward-closure wall seconds (engine-internal "in Xs")
+#   deeptax_d<DEPTH>_query_us         query.rq min-of-ITERS latency (µs), count mode
+#   deeptax_d<DEPTH>_closure_triples  materialized closure triple-count (DETERMINISTIC structural)
+# The `d<DEPTH>` token is numeric so the dashboard derives the DEPTH axis for its scaling chart
+# (bench/dashboard/dashboard.js sizeAxisOf `_d<digits>`); the `deeptax` prefix routes it to the
+# featured "Deep Taxonomy" suite (featuredSuiteOf). See README.md.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+CLI="${CLI:-$ROOT/target/release/sparq-cli}"
+ITERS="${ITERS:-3}"
+GEN="$ROOT/bench/deep-taxonomy/gen.sh"
+QUERY="$ROOT/bench/deep-taxonomy/query.rq"
+EXP="$ROOT/bench/deep-taxonomy/expected.tsv"
+CACHE="${DEEPTAX_CACHE:-/tmp/deep-taxonomy}"
+# Default per-commit tiers: dt1k + dt10k (cheap — closures 2,001 / 20,001 triples, ~0.1 s total).
+# dt100k (depth 100000) is available via DEEPTAX_DEPTHS for the EC2/nightly tier.
+DEPTHS="${DEEPTAX_DEPTHS:-1000 10000}"
+
+if [ ! -x "$CLI" ]; then
+  echo "[deeptax] ERROR: sparq-cli not found at $CLI (build: cargo build --release -p sparq-cli)" >&2
+  exit 1
+fi
+
+# query.rq lives in a file but `sparq-cli bench` takes a queries DIRECTORY; stage a dir with just
+# the probe query so the bench runner's TSV reports it under a stable `q` name.
+QDIR="$CACHE/qdir"
+mkdir -p "$QDIR"
+cp "$QUERY" "$QDIR/q_membership.rq"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+expected_for() {  # $1 = depth, $2 = column index (2=closure_triples, 3=query_rows)
+  awk -F'\t' -v d="$1" -v c="$2" '$1==d{print $c}' "$EXP"
+}
+
+for DEPTH in $DEPTHS; do
+  echo "[deeptax] === depth $DEPTH ===" >&2
+  # ---- 1. ensure corpus -----------------------------------------------------------------
+  CORPUS="$("$GEN" "$DEPTH")"
+  CLOSURE="$CACHE/dt-${DEPTH}-closure.nt"
+
+  # ---- 2. materialize the N3 forward closure; capture engine time + triple-count --------
+  # `reason <f> n3 n3 <out.nt>`: stderr carries `reasoned [N3]: <N> ground triples in closure in
+  # <X>s` (engine-internal timer, robust to machine load); stdout carries `<N> triples after n3
+  # reasoning`. We read the triple-count from stdout and the closure seconds from the stderr timer.
+  "$CLI" reason "$CORPUS" n3 n3 "$CLOSURE" >"$TMP/r.out" 2>"$TMP/r.err"
+  triples="$(grep -oE '[0-9]+ triples after n3 reasoning' "$TMP/r.out" | grep -oE '^[0-9]+' | head -1)"
+  closure_s="$(grep -oE 'in [0-9.]+s' "$TMP/r.err" | head -1 | grep -oE '[0-9.]+' | head -1)"
+
+  # ---- 3. run query.rq over the closure (count mode, min-of-ITERS) ----------------------
+  "$CLI" bench "$CLOSURE" ntriples "$QDIR" "$ITERS" count 2>/dev/null > "$TMP/q.tsv" || true
+  IFS=$'\t' read -r _qname qrows qus < "$TMP/q.tsv"
+
+  # ---- emit metric TSV lines (harvested by the ci-bench deeptax hook) -------------------
+  [ -n "${closure_s:-}" ] && printf 'deeptax_d%s_closure_s\t%s\ts\n'        "$DEPTH" "$closure_s"
+  [ -n "${qus:-}" ]       && printf 'deeptax_d%s_query_us\t%s\tus\n'         "$DEPTH" "$qus"
+  [ -n "${triples:-}" ]   && printf 'deeptax_d%s_closure_triples\t%s\ttriples\n' "$DEPTH" "$triples"
+
+  # ---- 4. SELF-ASSERTING closure-size + query-row gate (deterministic) ------------------
+  exp_tri="$(expected_for "$DEPTH" 2)"
+  exp_rows="$(expected_for "$DEPTH" 3)"
+  if [ -z "$exp_tri" ] || [ -z "$exp_rows" ]; then
+    echo "[deeptax] ERROR: depth $DEPTH has no expected.tsv entry (add closure_triples + query_rows)" >&2
+    fail=1; continue
+  fi
+  if [ "${triples:-MISSING}" != "$exp_tri" ]; then
+    echo "[deeptax] ERROR: depth $DEPTH closure=${triples:-MISSING} expected=$exp_tri (reasoner regression)" >&2
+    fail=1
+  fi
+  if [ "${qrows:-MISSING}" != "$exp_rows" ]; then
+    echo "[deeptax] ERROR: depth $DEPTH query rows=${qrows:-MISSING} expected=$exp_rows (reasoner regression)" >&2
+    fail=1
+  fi
+done
+
+if [ "$fail" = 0 ]; then
+  echo "[deeptax] OK: all closure sizes + query rows match expected.tsv ($DEPTHS)" >&2
+else
+  echo "[deeptax] FAILED: closure size or query rows diverged from expected.tsv" >&2
+fi
+exit "$fail"

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -84,6 +84,16 @@ BSBM_PC="${BSBM_PC:-300}"
 # below just invokes run.sh (the self-asserting path) and harvests its count-mode TSV lines into
 # `lubm_<query>_count_us`. Registry: bench/benchmarks.toml (lubm); details: bench/lubm/README.md.
 LUBM_RUN=bench/lubm/run.sh
+# [OPUS-4.8] Deep Taxonomy (DeepTaxonomy, sq-1hgz; parent sq-i0nm "design D") — the rule-heavy N3
+# REASONING suite. Like LUBM, its run.sh is the self-asserting entry point: it reuses the existing
+# generator (bench/inference/gen_deeptaxonomy.py via bench/deep-taxonomy/gen.sh), materializes the
+# N3 forward closure per depth tier with `sparq-cli reason … n3`, runs query.rq over the closure,
+# and asserts BOTH the closure triple-count AND the query row-count vs expected.tsv internally
+# (exit 1 on any mismatch). So the hook below just invokes run.sh and harvests its metric TSV into
+# `deeptax_d<DEPTH>_{closure_s,query_us,closure_triples}`. Registry: bench/benchmarks.toml
+# (deep-taxonomy); details: bench/deep-taxonomy/README.md. (sq-1hgz)
+DEEPTAX_RUN=bench/deep-taxonomy/run.sh
+DEEPTAX_DEPTHS="${DEEPTAX_DEPTHS:-1000 10000}"
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 RES="$TMP/res.tsv"; : > "$RES"
 add() { printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$RES"; }
@@ -368,6 +378,36 @@ if command -v javac >/dev/null 2>&1 && command -v rapper >/dev/null 2>&1 && [ -x
   fi
 else
   echo "note: lubm skipped (javac/rapper not on PATH)" >&2
+fi
+
+# [OPUS-4.8] Deep Taxonomy reasoning suite per-commit (sq-1hgz). Like the LUBM hook above, this
+# suite's run.sh is the self-asserting entry point: it reuses bench/inference/gen_deeptaxonomy.py
+# (via gen.sh) to build the DT N3 corpus at each depth tier, materializes the N3 forward closure
+# with `sparq-cli reason … n3`, runs query.rq over the closure, and asserts EVERY closure
+# triple-count + query row-count vs expected.tsv internally (exit 1 on any mismatch). So we invoke
+# run.sh and harvest its metric TSV (it prints `<metric>\t<value>\t<unit>` lines on stdout) into
+# `deeptax_d<DEPTH>_{closure_s,query_us,closure_triples}` (trend-only, NOT in scripts/perf-gate.py;
+# closure_triples is a deterministic structural metric, never an alert source). UNLIKE
+# watdiv/bsbm/lubm this suite needs NO heavyweight toolchain — only python3 (always present) + the
+# built sparq-cli — so it runs on the per-commit tier by default at a SMALL depth pair (dt1k+dt10k;
+# closures 2,001 / 20,001 triples, ~0.1 s total). dt100k is opt-in via DEEPTAX_DEPTHS for the
+# EC2/nightly tier. Guarded on python3 + run.sh present, mirroring the LUBM guard shape: if python3
+# is somehow absent it is skipped gracefully so ci-bench still emits valid JSON. run.sh failing (a
+# reasoner OR engine correctness regression) fails the whole ci-bench run.
+if command -v python3 >/dev/null 2>&1 && [ -x "$DEEPTAX_RUN" ]; then
+  if CLI="$CLI" ITERS=3 DEEPTAX_DEPTHS="$DEEPTAX_DEPTHS" bash "$DEEPTAX_RUN" > "$TMP/deeptax.tsv" 2>"$TMP/deeptax.err"; then
+    while IFS=$'\t' read -r name value unit; do
+      [ -n "${name:-}" ] && [ -n "${value:-}" ] && add "$name" "${unit:-}" "$value"
+    done < "$TMP/deeptax.tsv"
+  else
+    # run.sh exits non-zero ONLY on a hard correctness mismatch (the python3 guard above ensures
+    # the toolchain is present), so surface its diagnostics and fail the run.
+    echo "ERROR: deep-taxonomy run.sh failed (closure-size regression or reasoner/engine error)" >&2
+    cat "$TMP/deeptax.err" >&2 || true
+    exit 1
+  fi
+else
+  echo "note: deep-taxonomy skipped (python3 not on PATH)" >&2
 fi
 
 # RDFS inference (seconds) — instance-heavy: SCALE individuals under a depth-20 class hierarchy.

--- a/scripts/gen-metric-labels.py
+++ b/scripts/gen-metric-labels.py
@@ -226,6 +226,34 @@ def stems(subdir):
     return sorted(f[:-3] for f in os.listdir(d) if f.endswith(".rq"))
 
 
+def deeptax_depths():
+    """The Deep Taxonomy depth tiers, read from bench/deep-taxonomy/expected.tsv (the ground
+    truth the suite asserts against). Each line is `depth<TAB>closure_triples<TAB>query_rows`;
+    `#`/blank lines are skipped. Sorted ascending. So adding a tier to expected.tsv + the run
+    set automatically labels its metrics here (and `--check` flags the resulting drift)."""
+    path = os.path.join(BENCH, "deep-taxonomy", "expected.tsv")
+    if not os.path.isfile(path):
+        return []
+    out = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("\t")
+            if parts and parts[0].isdigit():
+                out.append(int(parts[0]))
+    return sorted(out)
+
+
+def deeptax_tier_name(depth):
+    """Human "dtNk"/"dtN" tier label for a depth (matches bench/inference/eye-comparison.md +
+    the EYE reference scales: 1000->dt1k, 10000->dt10k, 100000->dt100k)."""
+    if depth and depth % 1000 == 0:
+        return "dt%dk" % (depth // 1000)
+    return "dt%d" % depth
+
+
 def mode_records(stem_key, base_label, suite, dataset, query_desc, modes=MODES):
     """Emit one {label,...} record per mode for a query stem, keyed `<stem>_<mode>`.
 
@@ -324,6 +352,37 @@ def build():
                     "raw ABox" if regime == "extensional" else "OWL-RL closure"),
                 "query": desc, "mode": "count", "regime": regime, "unit": "µs",
             }
+
+    # 9) Deep Taxonomy reasoning suite (sq-1hgz) -> three metrics per depth tier. The metric
+    # NAMES carry a numeric `d<DEPTH>` token (so the dashboard derives the depth axis for its
+    # scaling chart, and `deeptax` routes it to the featured "Deep Taxonomy" suite). One depth
+    # tier per row of bench/deep-taxonomy/expected.tsv. Keys match the dashboard's lookup (stem =
+    # name minus `_us`, else the raw name), so the `_s`/`_triples` metrics are keyed by raw name
+    # and the `_us` latency by its `_query` stem. (See bench/deep-taxonomy/README.md.)
+    for depth in deeptax_depths():
+        tier = deeptax_tier_name(depth)
+        dataset = ("DeepTaxonomy %s — 1 instance, %d-deep :sc chain, 1 transitivity meta-rule "
+                   "(reuses bench/inference/gen_deeptaxonomy.py); N3 forward closure = %d triples"
+                   % (tier, depth, 2 * depth + 1))
+        labels["deeptax_d%d_closure_s" % depth] = {
+            "label": "Deep Taxonomy %s — N3 forward-closure time" % tier,
+            "suite": "Deep Taxonomy", "dataset": dataset,
+            "query": "materialize the N3 forward closure (transitivity meta-rule)",
+            "mode": "closure", "unit": "s",
+        }
+        labels["deeptax_d%d_query" % depth] = {
+            "label": "Deep Taxonomy %s — class-membership query over the closure" % tier,
+            "suite": "Deep Taxonomy", "dataset": dataset,
+            "query": "SELECT ?c WHERE { :i a ?c } (returns depth+1 = %d rows)" % (depth + 1),
+            "mode": "count", "unit": "µs",
+        }
+        labels["deeptax_d%d_closure_triples" % depth] = {
+            "label": "Deep Taxonomy %s — materialized closure size" % tier,
+            "suite": "Deep Taxonomy", "dataset": dataset,
+            "query": "deterministic closure triple-count (self-asserting gate; = 2·depth+1 = %d)"
+                     % (2 * depth + 1),
+            "mode": "closure", "unit": "triples",
+        }
 
     return labels
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — promoting the DeepTaxonomy inference benchmark into a first-class, self-asserting CI suite. Implements bead **sq-1hgz** (parent **sq-i0nm**, the dashboard featured-suites + competitor seam merged in #145).

## What this does

Promotes `bench/inference/gen_deeptaxonomy.py` into a first-class `bench/deep-taxonomy/` suite **reusing the existing generator** (it is NOT rewritten — `gen.sh` is a thin, cache-backed wrapper around it).

### Suite layout (`bench/deep-taxonomy/`)
- **`gen.sh`** — thin wrapper around `bench/inference/gen_deeptaxonomy.py`; emits a DT N3 corpus per depth (python3-only, no network/toolchain, byte-deterministic, cached under `/tmp/deep-taxonomy`).
- **`run.sh`** — the **self-asserting** entry point (mirrors `bench/lubm/run.sh`): per depth tier it materializes the N3 forward closure with `sparq-cli reason … n3`, runs `query.rq` over the closure, emits metrics on stdout, and asserts the gate (below).
- **`query.rq`** — `SELECT ?c WHERE { :i a ?c }`: counts every class `:i` is a member of in the closure (= `depth+1` rows).
- **`expected.tsv`** — deterministic per-depth `closure_triples` (= `2·depth+1`) + `query_rows` (= `depth+1`).
- **`README.md`** — full rationale + the structural-facts / EYE-reference wiring.

### Guarded ci-bench hook (`scripts/ci-bench.sh`)
A `deeptax` hook **mirroring the LUBM hook exactly**: it invokes the self-asserting `run.sh` and harvests its TSV into metrics `deeptax_d<DEPTH>_{closure_s, query_us, closure_triples}`. Unlike watdiv/bsbm/lubm it needs **only `python3`** (no g++/javac/rapper), so it runs on the **per-commit tier** at a SMALL depth pair (**dt1k + dt10k**; closures 2,001 / 20,001 triples, ~0.1 s total). **dt100k** (depth 100,000; closure 200,001) is opt-in via `DEEPTAX_DEPTHS` for the EC2/nightly tier — guarded + skips gracefully, and `run.sh` failing (a reasoner/engine regression) fails the whole ci-bench run.

### Self-asserting closure-size gate
`run.sh` asserts **both** the materialized closure triple-count (`= 2·depth+1`) **and** the query row-count (`= depth+1`) against `expected.tsv` — deterministic + load-robust, so it never flakes on a noisy runner but fails **loudly** on any sparq-reason regression (missing/extra entailment, broken fixpoint). The latency metrics are trend-only; this structural gate is the hard correctness check. Closure sizes are cross-checked against `bench/inference/eye-comparison.md` (sparq + EYE agree: dt1k 2,001; dt10k 20,001; dt100k 200,001) — **verified locally on all three tiers**.

### Featured dashboard row + EYE competitor
The featured **"Deep Taxonomy"** suite and the **EYE** external-reference baselines were already wired into `bench/dashboard/{competitors.json, dashboard.js COMPETITORS_DATA}` by #145 (sq-i0nm). This suite's **real** metric names plug straight in — verified: `featuredSuiteOf("deeptax_d1000_closure_s")` → Deep Taxonomy, `sizeAxisOf` → depth axis (1000/10000/100000), scaling families group cleanly by base. The EYE baselines are cited from `eye-comparison.md` with **honest n/a**: **dt1k = 4.19 s**, **dt10k = 377.9 s**, **dt100k = n/a (EYE not run — extrapolated only, NOT fabricated)**. Added readable labels via `scripts/gen-metric-labels.py` (generated from this suite's `expected.tsv` tiers, not hand-edited) so the dashboard renders "Deep Taxonomy dt1k — N3 forward-closure time" etc.

## Verification (all green locally)
- `bash bench/deep-taxonomy/gen.sh` + `run.sh` at dt1k/dt10k/dt100k — closures 2001/20001/200001, query rows 1001/10001/100001, gate exit 0; verified the gate **fails loudly** on a simulated mismatch.
- Full `scripts/ci-bench.sh` run emits valid JSON including the 6 deeptax metrics, exit 0.
- `node --check bench/dashboard/dashboard.js` — OK; `node scripts/dashboard-smoke.js` — all 79 checks pass.
- `python3 scripts/gen-metric-labels.py --check` (dashboard labels drift gate) — up to date.
- `python3 scripts/check-no-perf-numbers.py --advisory` — 0 findings in the changed files (README cites structural closure facts + references, no hard-coded perf).
- `bench/dashboard/competitors.json` ↔ `COMPETITORS_DATA` confirmed byte-for-meaning consistent (4 engines, 7 references, `values` empty in both); the registry `bench/competitors.json` intentionally left untouched (its `engines:[]`/`values:{}` is the gather recipe seam).

## Scope
Touches only `bench/` (the new `deep-taxonomy/` suite, the `ci-bench.sh` deeptax-hook, the label generator + generated labels, registry, catalog). No `sparq-reason` source change. `.beads/` untouched; bead **sq-1hgz** left open for review.

## Follow-ups
- Wiring **per-metric** competitor cells (`values`) requires a same-scale quiet-box gather of EYE — out of scope here (the honest default keeps cells "n/a"); tracked by the gather flow in `bench/competitors.json`.

References: bead **sq-1hgz**; parent **sq-i0nm** (#145).

🤖 Generated with [Claude Code](https://claude.com/claude-code)