### PR TITLE
chore(pages): redirect bare Pages root to the benchmark dashboard [OPUS-4.8]

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -317,16 +317,25 @@ jobs:
               changed=1
             fi
           done
+          # [OPUS-4.8] root redirect (sq-pages-root): the bare Pages root would 404 because the
+          # dashboard lives under dev/bench/. Seed bench/dashboard/root-redirect.html to the
+          # benchmark-data branch ROOT as index.html so https://jeswr.github.io/sparq/ bounces to
+          # dev/bench/. github-action-benchmark only writes data.js + dev/bench/index.html (never a
+          # root index.html), so this coexists with its data and is preserved across runs.
+          if [ ! -f "$tmp/index.html" ] || ! cmp -s "$src/root-redirect.html" "$tmp/index.html"; then
+            cp "$src/root-redirect.html" "$tmp/index.html"
+            changed=1
+          fi
           if [ "$changed" = "0" ]; then
             echo "dev/bench dashboard already up to date — nothing to seed."
             exit 0
           fi
           git -C "$tmp" -c user.name='github-actions[bot]' \
                         -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-                        add dev/bench/index.html dev/bench/dashboard.js dev/bench/dashboard.css \
+                        add index.html dev/bench/index.html dev/bench/dashboard.js dev/bench/dashboard.css \
                             dev/bench/metric-labels.json dev/bench/vendor/Chart.min.js
           git -C "$tmp" -c user.name='github-actions[bot]' \
                         -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-                        commit -q -m "chore(bench): seed/update Pages dashboard under dev/bench [skip ci]"
+                        commit -q -m "chore(bench): seed/update Pages dashboard (dev/bench + root redirect) [skip ci]"
           git -C "$tmp" push -q origin benchmark-data:benchmark-data
           echo "Seeded/updated the custom Pages dashboard on benchmark-data."

--- a/bench/dashboard/root-redirect.html
+++ b/bench/dashboard/root-redirect.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<!-- [OPUS-4.8] sparq Pages root redirect. The benchmark dashboard is served from the
+     benchmark-data branch under dev/bench/, so the bare Pages root (https://jeswr.github.io/sparq/)
+     would otherwise 404 and read as "the dashboard is dark". bench.yml's seed step copies this file
+     to the benchmark-data branch ROOT as index.html so the bare URL bounces to dev/bench/.
+     Kept tiny + dependency-free: a meta refresh does the redirect, a canonical link points search
+     engines at the dashboard, and a manual <a> is the no-JS/no-meta fallback. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="refresh" content="0; url=dev/bench/" />
+  <link rel="canonical" href="dev/bench/" />
+  <title>sparq · benchmark dashboard</title>
+</head>
+<body>
+  <p>Redirecting to the sparq benchmark dashboard… If you are not redirected, <a href="dev/bench/">open the dashboard</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. @jeswr runs multiple agents on this account; ping if this needs a human.

## Problem

The bare GitHub Pages URL **https://jeswr.github.io/sparq/** returns HTTP **404**, which reads as *"the dashboard is dark"*. It is not — Pages is in deploy-from-branch mode (source = `benchmark-data` / `/root`), and the live dashboard works at **https://jeswr.github.io/sparq/dev/bench/**. The dashboard files are seeded there under `dev/bench/` by the **"Seed Pages dashboard onto benchmark-data"** step in `.github/workflows/bench.yml`. There is simply **nothing at the branch root**, so Pages serves a 404 for the bare URL.

## Fix

- Add a minimal, dependency-free **`bench/dashboard/root-redirect.html`** — a `<meta http-equiv="refresh" content="0; url=dev/bench/">` plus a `<link rel="canonical" href="dev/bench/">` and a one-line *"Redirecting to the sparq benchmark dashboard…"* with a manual `<a href="dev/bench/">` fallback for no-JS / no-meta clients.
- Extend the bench.yml **seed step** to ALSO copy that file to the **benchmark-data branch ROOT as `index.html`**, mirroring exactly the `vendor/Chart.min.js` copy + `git add` style introduced in #137 (copy-if-missing-or-differing → bump `changed` → add to the final `git add`).

So the bare URL bounces straight to the dashboard.

## Safety

Inspected the `benchmark-data` branch root first: it contains **only** the `dev/` tree (the dashboard + `data.js` live under `dev/bench/`). github-action-benchmark writes `data.js` and `dev/bench/index.html`, but **never a root `index.html`** — so a root `index.html` redirect coexists with its data and is preserved across runs (same "seed-if-absent / overwrite-if-differs" semantics as the rest of the step). The existing `dev/bench/` seeding is untouched.

## Activation

I cannot trigger a Pages rebuild. **The redirect goes live the next time `bench.yml`'s seed step runs on `main`** (the orchestrator may trigger a run). This fixes the *"dashboard appears dark at the root URL"* confusion.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/bench.yml'))"` → **YAML valid**
- Seed-step `run:` block extracted and `bash -n` checked → **syntax OK**
- Redirect HTML: balanced tags + meta-refresh + canonical + fallback link all present (well-formed)
- `dashboard labels (lint + drift)` gate (`metric-labels.json` JSON validity + `gen-metric-labels.py --check`) → **still green** (untouched)

Touches only `bench/dashboard/` (new file) and the seed step of `.github/workflows/bench.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
