### PR TITLE
ci: add merge_group triggers so the merge queue's gate checks run [OPUS-4.8]

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -27,6 +27,12 @@ on:
     paths-ignore:
       - 'bench/perf-baseline.json'
   pull_request:
+  # [OPUS-4.8] Merge queue: the perf gate must run on the queue's merge_group ref so
+  # the required ci-summary aggregates the benchmark check. The auto-push / baseline-
+  # commit / benchmark-data steps are all gated `if: github.ref == 'refs/heads/main'`
+  # — on merge_group github.ref is refs/heads/gh-readonly-queue/main/…, so (exactly as
+  # on a PR) they SKIP and only the perf gate computes + enforces the floor.
+  merge_group:
   workflow_dispatch:
 
 # [OPUS-4.8] Least-privilege default (Scorecard TokenPermissions): top-level is read-only

--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -42,6 +42,13 @@ name: ci-summary
 
 on:
   pull_request:
+  # [OPUS-4.8] Merge queue: GitHub runs the required check(s) on a temporary
+  # `merge_group` ref before merging. ci-summary is the SINGLE required check, so it
+  # MUST run here to produce the `ci-summary / gate` check on that ref — and every
+  # sibling workflow it aggregates (ci/bench/codeql/docs-quality/supply-chain) also
+  # triggers on merge_group, so the discovery below finds the identical check-set it
+  # finds on a PR. Without this the queue would hang forever waiting for the check.
+  merge_group:
   push:
     branches: [main]
 
@@ -70,7 +77,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          # On pull_request the head commit is the PR head; on push it's github.sha.
+          # On pull_request the head commit is the PR head; on push AND on merge_group
+          # it's github.sha (the merge_group ref's commit) — github.event.pull_request
+          # is undefined there, so the fallback selects the right SHA automatically and
+          # the check-run discovery reads the merge_group commit's siblings. [OPUS-4.8]
           SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           # This workflow RUN's id — unique to THIS gate run. Every check-run's
           # details_url embeds the run id of the workflow run that produced it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
   push:
     branches: [main]
   pull_request:
+  # [OPUS-4.8] Merge queue: re-run the identical PR check-set on the queue's
+  # merge_group ref so the required ci-summary gate finds the same siblings it finds
+  # on a PR. The per-commit `coverage` job (if: event_name != 'schedule') runs here;
+  # the nightly tier (if: event_name == 'schedule' || 'workflow_dispatch') stays off.
+  merge_group:
   workflow_dispatch: # [OPUS-4.8] manual trigger forces the nightly tier regardless of the freshness gate
   # [OPUS-4.8] Nightly schedule drives the heavy coverage tier (sq-hbg7): the
   # `coverage-nightly` job runs the sparq-vectors 50k recall/diskann accuracy

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # [OPUS-4.8] Merge queue: CodeQL surfaces a check on PRs, so it must also run on the
+  # queue's merge_group ref or the required ci-summary would wait for a sibling that
+  # never appears on that ref and time out. (Bare `merge_group` — it fires on every
+  # enqueue against the base branch.)
+  merge_group:
   # Weekly cadence so the latest CodeQL query packs are re-run against an otherwise
   # quiet default branch (catches newly-published queries on unchanged code).
   schedule:

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -41,6 +41,13 @@ name: docs-quality
 
 on:
   pull_request:
+  # [OPUS-4.8] Merge queue: docs-quality surfaces checks on PRs (some gating, some
+  # advisory/informational which ci-summary excludes), so it must also run on the
+  # queue's merge_group ref or the required ci-summary would wait for siblings that
+  # never appear there. The concurrency group below uses
+  # `github.event.pull_request.number || github.ref`, which falls back to the unique
+  # merge_group ref — no cross-event collision.
+  merge_group:
   push:
     branches: [main]
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -28,6 +28,12 @@ on:
   push:
     branches: [main]
   pull_request:
+  # [OPUS-4.8] Merge queue: fuzz surfaces a check on PRs, so it must also run on the
+  # queue's merge_group ref or the required ci-summary would wait for a sibling that
+  # never appears there. The budget step below maps merge_group to the fast SMOKE
+  # budget (same as pull_request) — a pre-merge gate wants quick coverage, not the
+  # nightly soak. github.ref in the concurrency group is the unique merge_group ref.
+  merge_group:
   workflow_dispatch:
   # Daily heavy tier. 04:23 UTC (offset from ci.yml's 03:17 coverage cron so the two
   # heavy nightly lanes do not contend for the same runner window).
@@ -98,9 +104,11 @@ jobs:
         run: |
           set -euo pipefail
           case "${{ github.event_name }}" in
-            schedule)          secs="$NIGHTLY_SECS" ;;
-            pull_request)      secs="$SMOKE_SECS" ;;
-            push|workflow_dispatch|*) secs="$MAIN_SECS" ;;
+            schedule)                     secs="$NIGHTLY_SECS" ;;
+            # [OPUS-4.8] merge_group (the merge queue) takes the same fast SMOKE budget
+            # as a PR — a pre-merge gate wants quick coverage, not the nightly soak.
+            pull_request|merge_group)     secs="$SMOKE_SECS" ;;
+            push|workflow_dispatch|*)     secs="$MAIN_SECS" ;;
           esac
           echo "secs=$secs" >> "$GITHUB_OUTPUT"
           echo "Per-target fuzz budget for '${{ github.event_name }}': ${secs}s"

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -13,6 +13,10 @@ on:
   push:
     branches: [main]
   pull_request:
+  # [OPUS-4.8] Merge queue: supply-chain (cargo-deny etc.) surfaces a check on PRs, so
+  # it must also run on the queue's merge_group ref or the required ci-summary would
+  # wait for a sibling that never appears there and time out.
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/zk-toolchain.yml
+++ b/.github/workflows/zk-toolchain.yml
@@ -49,13 +49,23 @@ on:
   # [OPUS-4.8] Merge queue: zk-toolchain surfaces a check on zk-touching PRs, so it
   # must also run on the queue's merge_group ref or the required ci-summary would wait
   # for a sibling that never appears there. NOTE: the `merge_group` event does NOT
-  # honour `paths` filters (GitHub ignores paths/paths-ignore for merge_group), so this
-  # bare trigger runs the forge suite on EVERY enqueue, not only zk-touching ones — a
-  # deliberate cost trade-off: the merge queue is a serialized, low-frequency lane and
-  # running the full zk gate on the exact to-be-merged tree is the safest pre-merge
-  # posture. ci-summary discovers the present check-set per-ref, so this never hangs.
-  # If queue runtime becomes a concern, gate `forge-suite` with a changed-files step
-  # keyed on github.event.merge_group.base_sha (tracked as a bead).
+  # honour `paths` filters (GitHub ignores paths/paths-ignore for merge_group), so a
+  # BARE trigger would run the full ~60min forge suite on EVERY enqueue, not only
+  # zk-touching ones — making the serialized queue unusably slow.
+  #
+  # [OPUS-4.8] sq-9jnj — CHANGED-FILES GATE (in `forge-suite` below): on merge_group the
+  # job ALWAYS runs (so the `zk forge + anchor suite (nargo/bb)` check-run always appears
+  # on the merge_group ref and ci-summary never hangs waiting for an absent sibling), but
+  # a cheap leading `detect zk changes` step diffs the queued batch's
+  # github.event.merge_group.base_sha..head_sha and decides whether any ZK-relevant path
+  # (the SAME set the pull_request paths filter uses) changed. The heavy toolchain-install
+  # + real-bb-proving steps are gated `if: steps.changes.outputs.zk == 'true'`, so:
+  #   • zk paths changed in the batch  → full forge suite runs and GATES (soundness kept),
+  #   • no zk paths changed            → heavy steps skip; the job completes a FAST GREEN
+  #     check-run with the identical name, matching the paths-gated PR posture.
+  # For every NON-merge_group event the detect step short-circuits to zk=true, so the
+  # paths-filtered pull_request / push / schedule / dispatch behaviour is UNCHANGED (the
+  # workflow only triggers on those events when zk paths changed in the first place).
   merge_group:
   push:
     branches: [main]
@@ -114,10 +124,80 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # [OPUS-4.8] sq-9jnj — changed-files gate for the merge queue. The `merge_group`
+      # event ignores `paths` filters, so without this the ~60min forge suite would run
+      # on EVERY queue enqueue. This cheap step decides whether the queued batch touched
+      # any ZK-relevant path; the heavy steps below are gated on its `zk` output.
+      #
+      # The path set MUST stay in lock-step with the `pull_request`/`push` paths filter
+      # above (crates/sparq-zk/**, crates/sparq-zk-compose/**, zk/**, this workflow file).
+      #
+      # SAFE-BY-DEFAULT: zk defaults to "true". Only the `merge_group` branch can flip it
+      # to "false", and only after a SUCCESSFUL diff that found no ZK paths. So:
+      #   • every non-merge_group event (pull_request / push / schedule / dispatch) →
+      #     zk=true → full suite, behaviour UNCHANGED (those events are already
+      #     paths-gated, so the workflow only triggers when zk paths changed anyway);
+      #   • merge_group + zk paths changed → zk=true → full suite GATES (soundness kept);
+      #   • merge_group + no zk paths     → zk=false → heavy steps skip → fast green check;
+      #   • merge_group + any diff failure → falls through to zk=true → full suite (fail
+      #     SAFE: we never silently skip the gate because the diff couldn't be computed).
+      #
+      # NOTE: this step ALWAYS runs and the job ALWAYS runs, so the
+      # `zk forge + anchor suite (nargo/bb)` check-run ALWAYS appears on the merge_group
+      # ref and goes green quickly on the skip path — ci-summary (which waits for the
+      # discovered, named check-set to stabilise + complete) sees it complete fast and
+      # never hangs on an absent sibling.
+      - name: Detect zk changes (merge_group changed-files gate)
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+        run: |
+          set -euo pipefail
+          # Default: run the full suite (fail-safe — see step comment).
+          zk=true
+          if [ "${EVENT_NAME}" = "merge_group" ]; then
+            zk=false
+            # Fetch both ends of the queued batch (the default checkout is shallow, so
+            # the base may be absent). Best-effort: on any fetch/diff error we leave
+            # zk=true via the `||` fallbacks below so the gate fails SAFE.
+            ok=true
+            git fetch --no-tags --quiet origin "${MG_BASE_SHA}" "${MG_HEAD_SHA}" 2>/dev/null \
+              || git fetch --no-tags --quiet origin "${MG_BASE_SHA}" 2>/dev/null \
+              || ok=false
+            git cat-file -e "${MG_BASE_SHA}^{commit}" 2>/dev/null || ok=false
+            git cat-file -e "${MG_HEAD_SHA}^{commit}" 2>/dev/null || ok=false
+            if [ "${ok}" = "true" ]; then
+              changed="$(git diff --name-only "${MG_BASE_SHA}" "${MG_HEAD_SHA}")"
+              echo "Changed files in queued batch (${MG_BASE_SHA}..${MG_HEAD_SHA}):"
+              printf '%s\n' "${changed}"
+              # ZK-relevant paths — SAME set as the pull_request/push paths filter.
+              if printf '%s\n' "${changed}" | grep -Eq \
+                '^(crates/sparq-zk/|crates/sparq-zk-compose/|zk/|\.github/workflows/zk-toolchain\.yml$)'; then
+                zk=true
+              else
+                zk=false
+              fi
+            else
+              echo "::warning::could not resolve merge_group base/head SHAs for the diff — running the full forge suite (fail-safe)."
+              zk=true
+            fi
+          fi
+          echo "zk=${zk}" >> "$GITHUB_OUTPUT"
+          if [ "${zk}" = "true" ]; then
+            echo "ZK-relevant paths changed (or non-merge_group / fail-safe) — running the full forge suite."
+          else
+            echo "No ZK-relevant paths in this merge_group batch — fast-passing (forge suite skipped, check stays green)." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Install Rust (stable)
+        if: steps.changes.outputs.zk == 'true'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo + target
+        if: steps.changes.outputs.zk == 'true'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           # Distinct cache key: this lane builds sparq-zk* with the toolchain present.
@@ -129,6 +209,7 @@ jobs:
       # target that defeats the pin — Copilot review, sq-f9tl). `noirup --version` then
       # installs the EXACT nargo. Two-level pinning: pinned noirup release + pinned nargo.
       - name: Install nargo (Noir) — pinned
+        if: steps.changes.outputs.zk == 'true'
         run: |
           set -euo pipefail
           mkdir -p "$HOME/.nargo/bin"
@@ -150,6 +231,7 @@ jobs:
       # pinned bb version. (The bbup script accepts `-v|--version <ver>`; `--version <ver>`
       # binds `<ver>` as its argument.)
       - name: Install bb (Barretenberg) — pinned
+        if: steps.changes.outputs.zk == 'true'
         run: |
           set -euo pipefail
           mkdir -p "$HOME/.bb"
@@ -163,6 +245,7 @@ jobs:
           bb --version
 
       - name: Toolchain versions (record for the run log)
+        if: steps.changes.outputs.zk == 'true'
         run: |
           echo "nargo: $(nargo --version | head -1)"
           echo "bb:    $(bb --version)"
@@ -170,6 +253,7 @@ jobs:
       # Build the ZK crates' test targets first so a compile failure is distinct from a
       # proving failure in the logs.
       - name: Build sparq-zk* test targets
+        if: steps.changes.outputs.zk == 'true'
         run: cargo build -p sparq-zk -p sparq-zk-compose --all-targets
 
       # The load-bearing step: run EVERY `#[ignore]`d test in the ZK crates. With the
@@ -180,5 +264,6 @@ jobs:
       # serialized, toolchain-bound cases (the retry/process-isolation nextest buys us on
       # the fast lane is not what this lane needs).
       - name: Run the ignored ZK forge + anchor + e2e suite (real bb)
+        if: steps.changes.outputs.zk == 'true'
         run: |
           cargo test -p sparq-zk-compose -p sparq-zk -- --ignored --test-threads=1

--- a/.github/workflows/zk-toolchain.yml
+++ b/.github/workflows/zk-toolchain.yml
@@ -46,6 +46,17 @@ on:
       - "crates/sparq-zk-compose/**"
       - "zk/**"
       - ".github/workflows/zk-toolchain.yml"
+  # [OPUS-4.8] Merge queue: zk-toolchain surfaces a check on zk-touching PRs, so it
+  # must also run on the queue's merge_group ref or the required ci-summary would wait
+  # for a sibling that never appears there. NOTE: the `merge_group` event does NOT
+  # honour `paths` filters (GitHub ignores paths/paths-ignore for merge_group), so this
+  # bare trigger runs the forge suite on EVERY enqueue, not only zk-touching ones — a
+  # deliberate cost trade-off: the merge queue is a serialized, low-frequency lane and
+  # running the full zk gate on the exact to-be-merged tree is the safest pre-merge
+  # posture. ci-summary discovers the present check-set per-ref, so this never hangs.
+  # If queue runtime becomes a concern, gate `forge-suite` with a changed-files step
+  # keyed on github.event.merge_group.base_sha (tracked as a bead).
+  merge_group:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
> 🤖 **SPARQ agent** — prerequisite for enabling GitHub's **merge queue** on `main`.

## Why

The merge queue runs the required status check(s) on a temporary **`merge_group`** ref before merging. Today **no workflow triggers on `merge_group`**, so once the queue is enabled every queued PR would **hang forever**.

`ci-summary` (`.github/workflows/ci-summary.yml`) is the **single required check**: it discovers + waits for the full set of sibling check-runs on the head commit, then aggregates them (pass iff no gating sibling failed). On the queue that head commit is the `merge_group` ref's commit — so **ci-summary AND every workflow whose checks it aggregates must also trigger on `merge_group`**. Otherwise ci-summary discovers a sibling set that never runs on the queue ref and dies with its own error: *"timed out waiting for the sibling check-run set to stabilise and complete."*

## What changed

Added `merge_group:` (bare — fires on every enqueue) to the **8 gate-feeding, `pull_request`-triggered** workflows:

| Workflow | Note |
|---|---|
| `ci-summary.yml` | the required check itself |
| `ci.yml` | build/test/clippy/conformance/SHACL/inference/coverage/wasm/MSRV/docker-smoke |
| `bench.yml` | perf gate runs; auto-push/baseline-commit/benchmark-data steps stay `if: github.ref == 'refs/heads/main'` (skip on the queue ref, exactly as on a PR) |
| `codeql.yml` | |
| `docs-quality.yml` | concurrency group `pull_request.number \|\| github.ref` falls back to the merge_group ref |
| `supply-chain.yml` | cargo-deny etc. |
| `fuzz.yml` | budget step maps `merge_group` → **SMOKE** budget (same as a PR) |
| `zk-toolchain.yml` | **bare** `merge_group` + a **changed-files gate** (sq-9jnj, folded in — see below) so the ~60-min forge suite runs on the queue **only** when zk paths changed, and fast-passes (green check) otherwise. |

### Deliberately EXCLUDED

Push-only / tag-only / schedule-only — they **never emit a check on a PR**, so ci-summary never waits on them; adding `merge_group` would only run pointless work (and tag/release ones make no sense on the queue):

`js.yml` (push-only), `python.yml` (push + dispatch), `dist.yml` (tag `v*` + dispatch), `release.yml` (tag `v*`), `scorecard.yml` (push + schedule + dispatch), `bench-ec2.yml` (schedule + dispatch), `dependency-monitoring.yml` (schedule + dispatch).

## ci-summary discovery is merge_group-safe (confirmed)

- **Head SHA**: `${{ github.event.pull_request.head.sha || github.sha }}` — `pull_request` is undefined on `merge_group`, so it falls back to `github.sha` = the merge_group commit. The check-run discovery reads that commit's siblings. ✅
- **Self-exclusion** is by `github.run_id` embedded in `details_url`, **not** by PR — works identically. ✅
- **Concurrency** group `ci-summary-${{ github.event.pull_request.number || github.ref }}` falls back to the **unique** merge_group ref — no cross-event collision/deadlock. ✅
- **No `pull_request`-only `if:` gating** exists in any included workflow that would skip a required check on `merge_group` (ci.yml's `event_name` conditions correctly run the per-commit `coverage` job and keep the nightly tier off). So the **identical gating check-set runs on the queue ref**. ✅

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` passes for **all 15** workflows; `merge_group` + `pull_request` both present in each of the 8 edited files; excluded files confirmed to have neither.

## sq-9jnj folded in — zk-toolchain merge_group changed-files gate [OPUS-4.8]

The first cut gave `zk-toolchain.yml` a **bare** `merge_group:` trigger. Because `merge_group` **ignores `paths:` filters**, that would run the ~60-min nargo/bb forge suite on **every** merge-queue enqueue — making the serialized queue unusably slow. We can't simply drop the trigger: zk-toolchain isn't a *named* required check, so removing it from `merge_group` would stop the queue from gating ZK regressions (a soundness gap). **This commit folds in bead sq-9jnj's fix** so the gate is preserved *and* the queue stays fast:

- The `forge-suite` job **always runs** on `merge_group` (so the `zk forge + anchor suite (nargo/bb)` **check-run always appears** on the queue ref and ci-summary never hangs on an absent sibling).
- A cheap leading **`Detect zk changes`** step (`id: changes`) computes `git diff --name-only <merge_group.base_sha> <merge_group.head_sha>` (fetching both ends, since the checkout is shallow) and sets output `zk` iff any **ZK-relevant path** changed — the **same set** as the `pull_request` paths filter (`crates/sparq-zk/**`, `crates/sparq-zk-compose/**`, `zk/**`, `.github/workflows/zk-toolchain.yml`).
- Every heavy step (toolchain install → real `bb prove`/`verify` suite) is gated `if: steps.changes.outputs.zk == 'true'`:
  - **zk paths changed** → full forge suite runs and **GATES** (soundness preserved);
  - **no zk paths** → heavy steps skip → the job completes a **fast green check** with the identical name (matches the paths-gated PR posture);
  - **diff couldn't be computed** → falls through to `zk=true` → full suite runs (**fail-safe**: never silently skips the gate).
- **`pull_request` / `push` paths behaviour is unchanged**; for every non-`merge_group` event the detect step short-circuits to `zk=true`. YAML re-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
