### PR TITLE
fix(skills): quote colon-bearing SKILL.md descriptions + gate frontmatter YAML (sq-56im)

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -127,6 +127,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+  skill-frontmatter:
+    # [OPUS-4.8] HARD gate (bead sq-56im): every skills/**/SKILL.md must have YAML
+    # frontmatter that actually parses (yaml.safe_load) and carries non-empty string
+    # `name` + `description`. Catches the GitHub "mapping values are not allowed in
+    # this context" render error caused by an UNQUOTED colon in a description value
+    # (reported on full-text-search/SKILL.md). Deterministic, no network → gates.
+    name: skill-frontmatter (Agent-Skills YAML)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install PyYAML
+        run: pip install pyyaml
+      - name: Validate SKILL.md frontmatter
+        run: python3 scripts/check-skill-frontmatter.py
+
   # ----------------------------- ADVISORY -----------------------------
   markdownlint-advisory:
     name: markdownlint-advisory (whole repo)

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -132,7 +132,9 @@ jobs:
     # frontmatter that actually parses (yaml.safe_load) and carries non-empty string
     # `name` + `description`. Catches the GitHub "mapping values are not allowed in
     # this context" render error caused by an UNQUOTED colon in a description value
-    # (reported on full-text-search/SKILL.md). Deterministic, no network → gates.
+    # (reported on full-text-search/SKILL.md). The validation itself is deterministic
+    # (no network); the one network touch is the version-pinned `pip install` of PyYAML
+    # below. Still a HARD gate. [OPUS-4.8]
     name: skill-frontmatter (Agent-Skills YAML)
     runs-on: ubuntu-latest
     steps:
@@ -143,7 +145,10 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install PyYAML
-        run: pip install pyyaml
+        # [OPUS-4.8] Version-pinned (Scorecard PinnedDependencies), matching the `==`
+        # style used for the Python build tools in python.yml (maturin/pytest). A single
+        # fixed dep, so `==` pinning is non-brittle; bump deliberately.
+        run: pip install pyyaml==6.0.2
       - name: Validate SKILL.md frontmatter
         run: python3 scripts/check-skill-frontmatter.py
 

--- a/scripts/check-skill-frontmatter.py
+++ b/scripts/check-skill-frontmatter.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] HARD gate: validate the YAML frontmatter of every Agent-Skills
+# SKILL.md (bead sq-56im).
+#
+# WHY: GitHub renders these skills/<surface>/SKILL.md files and parses their
+# YAML frontmatter. An UNQUOTED colon inside a `description:` value (e.g.
+# "...the sparq-text crate: build..." or "text:matches") makes the YAML parser
+# read the second colon as a nested mapping key, producing the render error
+#   "mapping values are not allowed in this context".
+# That error was reported on skills/full-text-search/SKILL.md (and was present
+# on geosparql / python / vector-search). This check catches the class of bug
+# before it ships: it actually `yaml.safe_load`s each frontmatter block.
+#
+# WHAT it asserts for every skills/**/SKILL.md:
+#   1. The file begins with a `---` line and has a closing `---` (a frontmatter
+#      block exists).
+#   2. The block parses as YAML (yaml.safe_load) without error.
+#   3. The parsed value is a mapping (dict).
+#   4. It has non-empty STRING `name` and `description` keys (the two fields the
+#      agentskills.io format requires).
+#
+# It also WARNS (never fails) when `name` does not match the lowercase,
+# hyphen-separated Agent-Skills convention or does not equal the parent
+# directory name — these are nice-to-haves, kept advisory so the gate only
+# fails on the real render-breaking defect.
+#
+# Exit 0 when every file is valid; exit 1 listing each offending file and its
+# precise parse/validation error otherwise.
+#
+# Usage:
+#   python3 scripts/check-skill-frontmatter.py            # glob skills/**/SKILL.md
+#   python3 scripts/check-skill-frontmatter.py path/to/SKILL.md ...
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+import sys
+
+try:
+    import yaml  # PyYAML
+except ImportError:  # pragma: no cover - exercised only without PyYAML
+    sys.stderr.write(
+        "error: PyYAML is required (pip install pyyaml). "
+        "The frontmatter must be parsed with a real YAML loader.\n"
+    )
+    sys.exit(2)
+
+# Agent-Skills `name` convention: lowercase letters/digits, hyphen-separated.
+NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def extract_frontmatter(text: str) -> tuple[str | None, str | None]:
+    """Return (frontmatter_block, error). Exactly one is non-None.
+
+    The frontmatter is the text between the first two lines that are exactly
+    `---`. The opening `---` must be the very first line of the file.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None, "no YAML frontmatter: file does not start with a '---' line"
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return "\n".join(lines[1:i]), None
+    return None, "unterminated frontmatter: no closing '---' line found"
+
+
+def check_file(path: str) -> tuple[list[str], list[str]]:
+    """Return (errors, warnings) for a single SKILL.md."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    try:
+        text = open(path, encoding="utf-8").read()
+    except OSError as e:
+        return [f"could not read: {e}"], []
+
+    block, fm_err = extract_frontmatter(text)
+    if fm_err is not None:
+        return [fm_err], []
+
+    try:
+        data = yaml.safe_load(block)
+    except yaml.YAMLError as e:
+        # Flatten the (often multi-line) YAML error to a single readable line.
+        msg = " ".join(str(e).split())
+        return [f"YAML parse error: {msg}"], []
+
+    if not isinstance(data, dict):
+        return [f"frontmatter is not a mapping (parsed as {type(data).__name__})"], []
+
+    for field in ("name", "description"):
+        val = data.get(field)
+        if val is None:
+            errors.append(f"missing required '{field}' field")
+        elif not isinstance(val, str):
+            errors.append(f"'{field}' is not a string (got {type(val).__name__})")
+        elif not val.strip():
+            errors.append(f"'{field}' is empty")
+
+    # ---- advisory: name convention + directory match ----
+    name = data.get("name")
+    if isinstance(name, str) and name.strip():
+        if not NAME_RE.match(name):
+            warnings.append(
+                f"name '{name}' is not lowercase-hyphen (Agent-Skills convention)"
+            )
+        # The repo root skills/SKILL.md is an index, not a surface skill, so its
+        # directory is `skills` rather than the skill name — only check nested ones.
+        parent = os.path.basename(os.path.dirname(os.path.abspath(path)))
+        if parent != "skills" and name != parent:
+            warnings.append(f"name '{name}' != directory '{parent}'")
+
+    return errors, warnings
+
+
+def main() -> int:
+    paths = sys.argv[1:] or sorted(glob.glob("skills/**/SKILL.md", recursive=True))
+    if not paths:
+        print("check-skill-frontmatter: no SKILL.md files found under skills/.")
+        return 0
+
+    n_bad = 0
+    n_warn = 0
+    for path in paths:
+        errors, warnings = check_file(path)
+        for w in warnings:
+            n_warn += 1
+            print(f"WARN  {path}: {w}")
+        if errors:
+            n_bad += 1
+            for e in errors:
+                print(f"FAIL  {path}: {e}")
+
+    n_ok = len(paths) - n_bad
+    print(
+        f"\ncheck-skill-frontmatter: {n_ok}/{len(paths)} SKILL.md valid"
+        f" ({n_bad} broken, {n_warn} warning(s))."
+    )
+    if n_bad:
+        print(
+            "::error::SKILL.md frontmatter is invalid YAML — GitHub will fail to "
+            "render it. Quote any 'description'/'name' value containing a colon."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-skill-frontmatter.py
+++ b/scripts/check-skill-frontmatter.py
@@ -71,7 +71,12 @@ def check_file(path: str) -> tuple[list[str], list[str]]:
     errors: list[str] = []
     warnings: list[str] = []
     try:
-        text = open(path, encoding="utf-8").read()
+        # [OPUS-4.8] Context manager (no leaked fd). A non-UTF-8 SKILL.md must be a
+        # per-file failure, not a script-wide crash, so catch UnicodeDecodeError too.
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+    except UnicodeDecodeError as e:
+        return [f"not valid UTF-8 (cannot decode): {e}"], []
     except OSError as e:
         return [f"could not read: {e}"], []
 

--- a/skills/full-text-search/SKILL.md
+++ b/skills/full-text-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: full-text-search
-description: Full-text search over RDF string literals in sparq via the sparq-text crate: build a BM25 inverted index (TextIndex) and run text: magic predicates (text:matches / text:matchesAny / text:phrase / text:near / text:slop / text:score) inside plain SPARQL. Use when an agent needs keyword/prefix/phrase/proximity search, BM25 or proximity relevance ranking, or autocomplete over literals in a sparq Graph.
+description: "Full-text search over RDF string literals in sparq via the sparq-text crate: build a BM25 inverted index (TextIndex) and run text: magic predicates (text:matches / text:matchesAny / text:phrase / text:near / text:slop / text:score) inside plain SPARQL. Use when an agent needs keyword/prefix/phrase/proximity search, BM25 or proximity relevance ranking, or autocomplete over literals in a sparq Graph."
 ---
 
 # sparq full-text search (sparq-text)

--- a/skills/geosparql/SKILL.md
+++ b/skills/geosparql/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: geosparql
-description: Use when adding GeoSPARQL spatial support to the sparq RDF/SPARQL engine — parsing geo:wktLiteral and geo:gmlLiteral (GML Simple-Features) geometries, calling geof: functions (distance, sf*/eh*/rcc8* DE-9IM relations, envelope/boundary/convexHull/buffer, intersection/union/difference/symDifference, getSRID) inside SPARQL FILTER/BIND/SELECT via the sparq-engine extension-function registry, or building an R-tree GeoIndex over a Graph for within_distance / nearest / intersects queries. Crate: sparq-geo.
+description: "Use when adding GeoSPARQL spatial support to the sparq RDF/SPARQL engine — parsing geo:wktLiteral and geo:gmlLiteral (GML Simple-Features) geometries, calling geof: functions (distance, sf*/eh*/rcc8* DE-9IM relations, envelope/boundary/convexHull/buffer, intersection/union/difference/symDifference, getSRID) inside SPARQL FILTER/BIND/SELECT via the sparq-engine extension-function registry, or building an R-tree GeoIndex over a Graph for within_distance / nearest / intersects queries. Crate: sparq-geo."
 ---
 
 # sparq-geosparql

--- a/skills/python/SKILL.md
+++ b/skills/python/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: python
-description: Use the sparq RDF + SPARQL engine from Python (PyPI distribution `sparq-rdf`; `import sparq`). Reach for this when an agent or developer needs to load RDF (Turtle/N-Triples/N-Quads/TriG), run SPARQL 1.1 SELECT/ASK/CONSTRUCT/DESCRIBE, apply SPARQL Update, do opt-in RDFS/OWL-RL/Notation3 reasoning + OWL inconsistency checks, run BM25 full-text search (text: magic predicates), or persist/memory-map a triplestore — all via the pyo3 sparq.Graph class.
+description: "Use the sparq RDF + SPARQL engine from Python (PyPI distribution `sparq-rdf`; `import sparq`). Reach for this when an agent or developer needs to load RDF (Turtle/N-Triples/N-Quads/TriG), run SPARQL 1.1 SELECT/ASK/CONSTRUCT/DESCRIBE, apply SPARQL Update, do opt-in RDFS/OWL-RL/Notation3 reasoning + OWL inconsistency checks, run BM25 full-text search (text: magic predicates), or persist/memory-map a triplestore — all via the pyo3 sparq.Graph class."
 ---
 
 # sparq (Python)

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vector-search
-description: Semantic / ANN vector search over a sparq RDF graph: build a memory-mapped per-term-id embedding store (.spqv), then run cosine top-k with an in-RAM HNSW, a persistent on-disk DiskANN/Vamana graph (.spqg), or an exact brute-force baseline; verbalize entities (label+type+description) for embedding, scalar/product quantize (SQ/PQ) for large stores, and fuse with another ranked signal (RRF / score blend) for hybrid retrieval. Use when adding embedding/semantic-search/nearest-neighbour over a sparq Graph in the sparq-vectors crate.
+description: "Semantic / ANN vector search over a sparq RDF graph: build a memory-mapped per-term-id embedding store (.spqv), then run cosine top-k with an in-RAM HNSW, a persistent on-disk DiskANN/Vamana graph (.spqg), or an exact brute-force baseline; verbalize entities (label+type+description) for embedding, scalar/product quantize (SQ/PQ) for large stores, and fuse with another ranked signal (RRF / score blend) for hybrid retrieval. Use when adding embedding/semantic-search/nearest-neighbour over a sparq Graph in the sparq-vectors crate."
 ---
 
 # sparq-vector-search


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes the GitHub render error reported on `skills/full-text-search/SKILL.md`:
**"Error in user YAML: (<unknown>): mapping values are not allowed in this context"**. Bead **sq-56im**.

## Root cause
Agent-Skills `SKILL.md` files carry YAML frontmatter between the first two `---` lines. Four files had an **unquoted colon** inside their `description:` value (e.g. `...the sparq-text crate: build...`, `text:matches`, `PyPI ... import sparq`, `RDF graph: build...`). YAML then treats the second colon as a nested mapping key → parse failure → GitHub refuses to render the frontmatter.

## Files fixed (4)
All fixed by wrapping the `description` value in double quotes. No embedded double quotes, so no escaping; the parsed description text is **byte-identical** to the original (verified) — no rewording.

| File | Original parse error |
|------|----------------------|
| `skills/full-text-search/SKILL.md` | `mapping values are not allowed here … line 2` (`sparq-text crate:`) |
| `skills/geosparql/SKILL.md` | `mapping values are not allowed here … line 2` (`geof: functions`) |
| `skills/python/SKILL.md` | `mapping values are not allowed here … line 2` (`text: magic predicates`) |
| `skills/vector-search/SKILL.md` | `mapping values are not allowed here … line 2` (`RDF graph:`) |

I validated **all 16** `skills/**/SKILL.md`, not just the 4 — the other 12 already parse cleanly with non-empty `name`/`description` (0 warnings: `name` is lowercase-hyphen and matches the directory in every case).

## New validator + CI gate
- **`scripts/check-skill-frontmatter.py`** (Python 3 stdlib + PyYAML): globs `skills/**/SKILL.md`, extracts the frontmatter, `yaml.safe_load`s it, and asserts a mapping with non-empty **string** `name` + `description`. WARNs (never fails) on the advisory nice-to-haves (name convention / directory mismatch). Exits non-zero listing every offending file + its precise parse error; exit 0 on success.
- **CI wiring**: a new **HARD-gate** job `skill-frontmatter` in `.github/workflows/docs-quality.yml` (the docs-quality lane), alongside the existing `markdownlint` / `typos` / `internal-links` gates. It reuses the SHA-pinned `actions/checkout@df4cb1c…` + `actions/setup-python@a309ff8b…` already used in that workflow, plus an explicit `pip install pyyaml`. Picked up by the `ci-summary` aggregator gate.

## Verification (local)
- **Fail-before** (original frontmatter from `main` HEAD): `0/4 valid (4 broken)`, exit 1 — each with `mapping values are not allowed here`.
- **Pass-after** (this branch): `16/16 SKILL.md valid (0 broken, 0 warning(s))`, exit 0.
- `docs-quality.yml` is valid YAML; each fixed file's frontmatter `yaml.safe_load`s to a dict whose `description` equals the original text exactly.

(Timing/measurements not relevant; this is a deterministic doc/CI fix.)