### PR TITLE
fix(zk): canonicalise scan test fixtures to satisfy #95 strict-ordering (sq-7p9c)

### DIFF
--- a/zk/compose/compose_core/src/tests.nr
+++ b/zk/compose/compose_core/src/tests.nr
@@ -135,8 +135,9 @@ global ATTR_BOTH: [bool; 2] = [true, true];
 fn scan_accepts_complete_match_set() {
     let (enc, counts, commitments) = test_graphs();
     // Pattern ?s P ?o matches (S2,P,O2) in graph 0 and (S1,P,O1) in graph 1
-    // (canonical ascending-commitment order, see test_graphs).
-    let rows: [[Field; 3]; 2] = [[S1, P, O1], [S2, P, O2]];
+    // (canonical ascending-commitment order, see test_graphs). Disclosed rows are
+    // listed in that same graph order: graph-0 row first, then graph-1.
+    let rows: [[Field; 3]; 2] = [[S2, P, O2], [S1, P, O1]];
     scan_check::<2, 4, 2>(commitments, p_pattern(), rows, 2, ATTR_BOTH, counts, enc);
 }
 

--- a/zk/compose/compose_core/src/tests.nr
+++ b/zk/compose/compose_core/src/tests.nr
@@ -82,13 +82,29 @@ global O2: Field = 202;
 global P_OTHER: Field = 8;
 
 fn test_graphs() -> ([[[Field; 3]; 4]; 2], [u32; 2], [Field; 2]) {
-    // Graph 0: { (S1, P, O1), (S1, P_OTHER, O2) } -- 2 active slots.
-    // Graph 1: { (S2, P, O2) }                    -- 1 active slot.
+    // [OPUS-4.8] sq-7p9c: the fixture's per-graph witnesses are laid out in
+    // CANONICAL ascending-commitment order, the same canonicalisation a real host
+    // builder performs (scan.nr step 1b / plan S2.5): `scan_check` now requires the
+    // PUBLIC `commitments` array STRICTLY INCREASING (`commitments[0] < ...`, the
+    // distinct-graph guard added by #95 that closes the duplicate-inclusion / COUNT
+    // forgery class). `commit_fold` is hash-like, so a graph's commitment value is
+    // unrelated to its content "size" -- the single-triple graph { (S2,P,O2) }
+    // happens to commit to the SMALLER field element than the two-triple graph
+    // { (S1,P,O1), (S1,P_OTHER,O2) }, so the single-triple graph is graph 0 and the
+    // two-triple graph is graph 1. Graphs are an unordered set keyed by commitment,
+    // so reordering them (with the matching `counts` and disclosed `rows`) does NOT
+    // change the proved statement -- only the now-canonical index assignment, which
+    // every per-test attribution array below tracks. The trailing assert pins the
+    // ordering invariant so this fixture fails LOUDLY (not the circuit's strict-order
+    // assert silently) if an encoding edit ever flips the natural order again.
+    //
+    // Graph 0: { (S2, P, O2) }                    -- 1 active slot.
+    // Graph 1: { (S1, P, O1), (S1, P_OTHER, O2) } -- 2 active slots.
     let enc: [[[Field; 3]; 4]; 2] = [
-        [[S1, P, O1], [S1, P_OTHER, O2], [0, 0, 0], [0, 0, 0]],
         [[S2, P, O2], [0, 0, 0], [0, 0, 0], [0, 0, 0]],
+        [[S1, P, O1], [S1, P_OTHER, O2], [0, 0, 0], [0, 0, 0]],
     ];
-    let counts: [u32; 2] = [2, 1];
+    let counts: [u32; 2] = [1, 2];
     let mut commitments: [Field; 2] = [0, 0];
     for g in 0..2 {
         let mut leaves: [Field; 4] = [0; 4];
@@ -97,6 +113,12 @@ fn test_graphs() -> ([[[Field; 3]; 4]; 2], [u32; 2], [Field; 2]) {
         }
         commitments[g] = commit_fold(leaves, counts[g]);
     }
+    // [OPUS-4.8] Canonical-order invariant: the public commitments this fixture
+    // hands to `scan_check` MUST already be strictly increasing (the circuit's
+    // step-1b contract). If a future encoding change flips the natural order, this
+    // asserts HERE -- a clear fixture bug -- rather than tripping the circuit's
+    // "per-graph commitments not strictly increasing" guard inside an unrelated test.
+    assert(commitments[0].lt(commitments[1]), "test_graphs fixture not in canonical ascending-commitment order");
     (enc, counts, commitments)
 }
 
@@ -112,7 +134,8 @@ global ATTR_BOTH: [bool; 2] = [true, true];
 #[test]
 fn scan_accepts_complete_match_set() {
     let (enc, counts, commitments) = test_graphs();
-    // Pattern ?s P ?o matches (S1,P,O1) in graph 0 and (S2,P,O2) in graph 1.
+    // Pattern ?s P ?o matches (S2,P,O2) in graph 0 and (S1,P,O1) in graph 1
+    // (canonical ascending-commitment order, see test_graphs).
     let rows: [[Field; 3]; 2] = [[S1, P, O1], [S2, P, O2]];
     scan_check::<2, 4, 2>(commitments, p_pattern(), rows, 2, ATTR_BOTH, counts, enc);
 }
@@ -121,11 +144,12 @@ fn scan_accepts_complete_match_set() {
 fn scan_accepts_constant_only_pattern_with_padding_rows() {
     let (enc, counts, commitments) = test_graphs();
     // Fully-constant pattern (an ASK-shaped membership): one matching row,
-    // second row slot padded. (S2,P,O2) lives only in graph 1, so the bound
-    // attribution is [false, true].
+    // second row slot padded. (S2,P,O2) lives only in graph 0 (canonical
+    // ascending-commitment order, see test_graphs), so the bound attribution is
+    // [true, false].
     let pattern = PatternSpec { is_const: [true, true, true], const_enc: [S2, P, O2] };
     let rows: [[Field; 3]; 2] = [[S2, P, O2], [0, 0, 0]];
-    scan_check::<2, 4, 2>(commitments, pattern, rows, 1, [false, true], counts, enc);
+    scan_check::<2, 4, 2>(commitments, pattern, rows, 1, [true, false], counts, enc);
 }
 
 // [OPUS-4.8] audit #8: the per-graph attribution is constrained to the true
@@ -133,8 +157,9 @@ fn scan_accepts_constant_only_pattern_with_padding_rows() {
 #[test(should_fail_with = "attribution does not match the proved source graphs")]
 fn scan_rejects_attribution_understated() {
     // The [[0],[0]] collapse-two-graphs lie at the circuit level: the pattern
-    // matches in graph 1 too, but the prover claims attribution[1] = false to
-    // hide the cross-graph source.
+    // matches in graph 1 too (it holds (S1,P,O1)), but the prover claims
+    // attribution[1] = false to hide the cross-graph source. The true attribution
+    // is [true, true]; [true, false] understates the genuinely-matching graph 1.
     let (enc, counts, commitments) = test_graphs();
     let rows: [[Field; 3]; 2] = [[S1, P, O1], [S2, P, O2]];
     scan_check::<2, 4, 2>(commitments, p_pattern(), rows, 2, [true, false], counts, enc);
@@ -143,7 +168,9 @@ fn scan_rejects_attribution_understated() {
 #[test(should_fail_with = "attribution does not match the proved source graphs")]
 fn scan_rejects_attribution_overstated() {
     // Claiming a graph contributes when it does not is also rejected (exact
-    // matched set, not a superset).
+    // matched set, not a superset). (S2,P,O2) lives only in graph 0, so the true
+    // attribution is [true, false]; [true, true] overstates the non-matching
+    // graph 1.
     let (enc, counts, commitments) = test_graphs();
     let pattern = PatternSpec { is_const: [true, true, true], const_enc: [S2, P, O2] };
     let rows: [[Field; 3]; 2] = [[S2, P, O2], [0, 0, 0]];
@@ -162,16 +189,19 @@ fn scan_rejects_tampered_commitment() {
 fn scan_rejects_tampered_graph_content() {
     let (mut enc, counts, commitments) = test_graphs();
     // Suppress a committed triple by overwriting an active slot ("license:
-    // suspended" hiding, plan S1.1) -- the fold no longer reproduces C.
-    enc[0][0] = [S1, P_OTHER, O1];
+    // suspended" hiding, plan S1.1) -- the fold no longer reproduces C. Here we
+    // overwrite graph 1's first active slot (S1,P,O1); the step-1 recompute of
+    // graph 1's commitment then mismatches BEFORE any row/attribution check.
+    enc[1][0] = [S1, P_OTHER, O1];
     let rows: [[Field; 3]; 2] = [[S2, P, O2], [0, 0, 0]];
-    scan_check::<2, 4, 2>(commitments, p_pattern(), rows, 1, [false, true], counts, enc);
+    scan_check::<2, 4, 2>(commitments, p_pattern(), rows, 1, [true, false], counts, enc);
 }
 
 #[test(should_fail_with = "matching triple missing from disclosed rows")]
 fn scan_rejects_suppressed_row() {
     let (enc, counts, commitments) = test_graphs();
-    // Graph 1's match is suppressed: completeness sweep must catch it.
+    // Graph 0's match (S2,P,O2) is suppressed (only (S1,P,O1) disclosed):
+    // completeness sweep must catch the undisclosed matching slot.
     let rows: [[Field; 3]; 2] = [[S1, P, O1], [0, 0, 0]];
     scan_check::<2, 4, 2>(commitments, p_pattern(), rows, 1, ATTR_BOTH, counts, enc);
 }


### PR DESCRIPTION
> 🤖 SPARQ agent

Fixes bead **sq-7p9c** (BUG): the `scan_*` Noir tests in `zk/compose/compose_core/src/tests.nr` fail on `main`.

## Root cause
PR #95 (sq-vxq8) added a **distinct-graph strict-ordering** requirement to `scan_check` (`zk/compose/compose_core/src/scan.nr`, step 1b, lines ~110-124): the PUBLIC `commitments` array MUST be **strictly increasing** on the field representative — `commitments[0] < commitments[1] < ...` — which forces the K committed graphs pairwise distinct and closes the duplicate-inclusion / COUNT-forgery class. This is a correct hardening and **stays**.

The `compose_core` scan fixtures were never updated for it. `test_graphs()` built its two graphs (`{(S1,P,O1),(S1,P_OTHER,O2)}` then `{(S2,P,O2)}`) and computed each commitment with `commit_fold`. `commit_fold` is hash-like, so the resulting commitments are NOT guaranteed strictly increasing — and in fact `commitments[0] >= commitments[1]` for this fixture. Every `scan_*` test therefore tripped the new ordering assert: the `scan_accepts_*` paths failed outright, and the `scan_rejects_*` paths failed on the **wrong** clause (`per-graph commitments not strictly increasing`) instead of their named attribution / completeness / soundness clause — so they no longer proved what they claimed. 8 of 12 scan tests were red.

## Fix approach (tests.nr only — scan.nr untouched)
Lay out `test_graphs()` in **canonical ascending-commitment order** — exactly the canonicalisation a real host builder performs (scan.nr step 1b / plan S2.5: "the host builder canonicalises the commitment order ascending"). Since `commit_fold` output is unrelated to a graph's triple-count, the single-triple graph `{(S2,P,O2)}` commits to the **smaller** field element and becomes **graph 0**; the two-triple graph `{(S1,P,O1),(S1,P_OTHER,O2)}` becomes **graph 1**.

Graphs are an **unordered set keyed by commitment**, so reordering them (together with the matching `counts` and the disclosed `rows`, which reference term encodings directly — not graph indices) does **not** change the proved statement; only the now-canonical index assignment changes. Every per-test positional `attribution` array (and the affected comments) was updated to track the new index assignment:
- `scan_accepts_constant_only_pattern_with_padding_rows`: `(S2,P,O2)` now lives in graph 0 → attribution `[true,false]` (was `[false,true]`).
- `scan_rejects_attribution_overstated`: true attribution now `[true,false]`; the lie `[true,true]` still overstates graph 1.
- `scan_rejects_attribution_understated`: still `[true,false]` understating the genuinely-matching graph 1.
- `scan_rejects_tampered_graph_content`: now overwrites graph 1's first active slot.
- `scan_rejects_suppressed_row` / `scan_accepts_complete_match_set`: comments re-pointed; ATTR_BOTH `[true,true]` is symmetric and unchanged.

A trailing `assert(commitments[0].lt(commitments[1]), ...)` inside `test_graphs()` pins the ascending invariant, so a future encoding edit that flips the natural order fails **loudly in the fixture** rather than silently re-tripping the circuit's strict-order guard inside an unrelated test.

**Why this does not weaken the adversarial tests:** with the fixture now strictly increasing, the ordering assert (step 1b) passes for every test, so each `scan_rejects_*` reaches and fails on its **intended named clause** again — verified by `should_fail_with` message matching (attribution / completeness / soundness / bucket-bound). The `#95` strict-ordering contract in `scan.nr` is **not modified**.

## Verification — `nargo test` (nargo 1.0.0-beta.21, the pinned zk-toolchain version)
```
[sparq_zk_compose_core] Running 50 test functions
...
[sparq_zk_compose_core] Testing tests::scan_accepts_complete_match_set ... ok
[sparq_zk_compose_core] Testing tests::scan_accepts_constant_only_pattern_with_padding_rows ... ok
[sparq_zk_compose_core] Testing tests::scan_rejects_attribution_overstated ... ok
[sparq_zk_compose_core] Testing tests::scan_rejects_attribution_understated ... ok
[sparq_zk_compose_core] Testing tests::scan_rejects_fabricated_row ... ok
[sparq_zk_compose_core] Testing tests::scan_rejects_inactive_row_padding_as_disclosure ... ok
[sparq_zk_compose_core] Testing tests::scan_rejects_off_pattern_row ... ok
[sparq_zk_compose_core] Testing tests::scan_rejects_oversized_count ... ok
[sparq_zk_compose_core] Testing tests::scan_rejects_oversized_row_count ... ok
[sparq_zk_compose_core] Testing tests::scan_rejects_suppressed_row ... ok
[sparq_zk_compose_core] Testing tests::scan_rejects_tampered_commitment ... ok
[sparq_zk_compose_core] Testing tests::scan_rejects_tampered_graph_content ... ok
[sparq_zk_compose_core] Testing tests::commit_fold_matches_sparq_zk_cross_vectors ... ok
[sparq_zk_compose_core] Testing tests::commit_fold_padding_slots_do_not_enter_the_commitment ... ok
[sparq_zk_compose_core] 50 tests passed
```
All 12 `scan_*` tests + both `commit_fold` cross-vector tests pass; the full 50-test `compose_core` suite is green.

[OPUS-4.8] authored while Fable unavailable — re-review when Fable returns.