### PR TITLE
ci(security): hash-pin CI pip installs → Scorecard PinnedDependencies zero (sq-rbps)

### DIFF
--- a/.github/requirements/docs-quality.txt
+++ b/.github/requirements/docs-quality.txt
@@ -1,0 +1,68 @@
+# Hash-pinned dependencies for the docs-quality `skill-frontmatter` job. [OPUS-4.8]
+#
+# Scorecard PinnedDependenciesID requires CI pip installs be pinned by HASH, not
+# just by `==` version (a `==` pin still trusts whatever PyPI serves for that
+# version). Installed with `pip install --require-hashes -r` so every artifact's
+# sha256 is verified before use.
+#
+# PyYAML is self-contained (no runtime dependencies), so this file needs only the
+# PyYAML distributions. ALL published 6.0.2 distribution hashes are listed so the
+# install matches whichever wheel the runner resolves (and the sdist as a fallback).
+#
+# To bump: pick the new version, then regenerate the hash block from PyPI:
+#   curl -s https://pypi.org/pypi/pyyaml/<VERSION>/json | \
+#     python3 -c "import json,sys; [print(f\"    --hash=sha256:{f['digests']['sha256']}\") for f in json.load(sys.stdin)['urls']]"
+pyyaml==6.0.2 \
+    --hash=sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086 \
+    --hash=sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf \
+    --hash=sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237 \
+    --hash=sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b \
+    --hash=sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed \
+    --hash=sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180 \
+    --hash=sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68 \
+    --hash=sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99 \
+    --hash=sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e \
+    --hash=sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774 \
+    --hash=sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee \
+    --hash=sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c \
+    --hash=sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317 \
+    --hash=sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85 \
+    --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4 \
+    --hash=sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e \
+    --hash=sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5 \
+    --hash=sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44 \
+    --hash=sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab \
+    --hash=sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725 \
+    --hash=sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5 \
+    --hash=sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425 \
+    --hash=sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476 \
+    --hash=sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48 \
+    --hash=sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b \
+    --hash=sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4 \
+    --hash=sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8 \
+    --hash=sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba \
+    --hash=sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1 \
+    --hash=sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133 \
+    --hash=sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484 \
+    --hash=sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5 \
+    --hash=sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc \
+    --hash=sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652 \
+    --hash=sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183 \
+    --hash=sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563 \
+    --hash=sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a \
+    --hash=sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5 \
+    --hash=sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d \
+    --hash=sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083 \
+    --hash=sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706 \
+    --hash=sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a \
+    --hash=sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff \
+    --hash=sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d \
+    --hash=sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f \
+    --hash=sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290 \
+    --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
+    --hash=sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19 \
+    --hash=sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e \
+    --hash=sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725 \
+    --hash=sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631 \
+    --hash=sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8 \
+    --hash=sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e

--- a/.github/requirements/python-build.txt
+++ b/.github/requirements/python-build.txt
@@ -1,0 +1,50 @@
+# Hash-pinned build/test tools for the Python-bindings CI (python.yml). [OPUS-4.8]
+#
+# Scorecard PinnedDependenciesID requires CI pip installs be pinned by HASH, not
+# just `==` version. Installed with `pip install --require-hashes -r`, which
+# verifies the sha256 of EVERY artifact — including transitive deps — before use.
+#
+# maturin and pytest DO pull transitive deps, so the full closure (iniconfig,
+# packaging, pluggy, pygments) is hash-pinned here too; --require-hashes rejects
+# any unlisted dependency.
+#
+# Generated (do not hand-edit the body below) — regenerate after a version bump:
+#   printf 'maturin==1.14.0\npytest==9.1.0\n' > python-build.in
+#   pip-compile --generate-hashes --allow-unsafe --no-header \
+#       --output-file=.github/requirements/python-build.txt python-build.in
+iniconfig==2.3.0 \
+    --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \
+    --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
+    # via pytest
+maturin==1.14.0 \
+    --hash=sha256:019ea3ec7e71f4c9759a367d4d21022ed5a3a621a2ce123abf3fb114ab3711ca \
+    --hash=sha256:095714b2a904927e3c868a1c5d078257ff0443c5049f7623777352966768306e \
+    --hash=sha256:107f84110d890090a01bb1ecd01761fdfae925c23c659ba492c9b83dd179eab4 \
+    --hash=sha256:1506e86b1e273a98074a62e281b13f27ac96f8cdef85f7f98d3e3589a9387a23 \
+    --hash=sha256:20229d332f87166b930e4ca07cdbee8a1726f2eea87a337610aa25bba3ddf4b4 \
+    --hash=sha256:2d123337e817f8dfe23755d6760139c01104137bb63e9e20c289c547e25ec857 \
+    --hash=sha256:4ba1e3c3f33609f461d587b7549104c81a15fd6d42ba63a73cea9376a1e9876e \
+    --hash=sha256:6948a10f5f3470b791f79319be51debdd8bfd1778b36f2409f98e1314bc3859b \
+    --hash=sha256:75bcd4468a7fe597652cc2980c6bb16ce4bb8c411e3eb85dac2c4418cef0e95a \
+    --hash=sha256:8c1a8188195f5b6ce1aab99ae2d92e342900298f901456b43ca028947fd3b288 \
+    --hash=sha256:9a84277aa907961cd47ad26fef1539e79efa30611972eaf7499606e773e991b2 \
+    --hash=sha256:cb09a313f097adeb4dda0082277871a28d1bd26615dbadab42e6234b6df6fe69 \
+    --hash=sha256:df10ce4f7ba97fd3423f624f39b94c888ae3e5b470642a91918e1ccec81282fd \
+    --hash=sha256:f7f82a6aca4a6c402bf00b99200be199d4874d04b9b9e74e825726a3478bba7f
+    # via -r python-build.in
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
+    # via pytest
+pluggy==1.6.0 \
+    --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
+    --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+    # via pytest
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+    # via pytest
+pytest==9.1.0 \
+    --hash=sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c \
+    --hash=sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32
+    # via -r python-build.in

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -145,10 +145,11 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install PyYAML
-        # [OPUS-4.8] Version-pinned (Scorecard PinnedDependencies), matching the `==`
-        # style used for the Python build tools in python.yml (maturin/pytest). A single
-        # fixed dep, so `==` pinning is non-brittle; bump deliberately.
-        run: pip install pyyaml==6.0.2
+        # [OPUS-4.8] HASH-pinned (Scorecard PinnedDependenciesID): a `==` version pin
+        # still trusts whatever PyPI serves, so --require-hashes verifies every artifact's
+        # sha256 against .github/requirements/docs-quality.txt before use. PyYAML has no
+        # runtime deps, so that file is the full closure. See its header to bump/regenerate.
+        run: pip install --require-hashes -r .github/requirements/docs-quality.txt
       - name: Validate SKILL.md frontmatter
         run: python3 scripts/check-skill-frontmatter.py
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,9 +34,11 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install maturin + pytest
-        # [OPUS-4.8] Version-pinned (Scorecard PinnedDependencies): a small, fixed build-tool
-        # set, so `==` pinning is non-brittle. Bump deliberately when adopting a newer maturin.
-        run: pip install maturin==1.14.0 pytest==9.1.0
+        # [OPUS-4.8] HASH-pinned (Scorecard PinnedDependenciesID): a `==` version pin still
+        # trusts whatever PyPI serves, so --require-hashes verifies every artifact's sha256
+        # — including the full transitive closure — against .github/requirements/python-build.txt
+        # before use. See that file's header to bump versions / regenerate the hash set.
+        run: pip install --require-hashes -r .github/requirements/python-build.txt
       - name: Build wheel (abi3, python-release profile — unwinding panics)
         run: maturin build --manifest-path crates/sparq-py/Cargo.toml --profile python-release --out dist
       - name: Install wheel


### PR DESCRIPTION
> 🤖 SPARQ agent

## What & why

Drives `jeswr/sparq` code-scanning back toward **zero** open alerts by fixing the two open **Scorecard `PinnedDependenciesID`** findings. Scorecard flags `pip install <pkg>==<ver>` even though it is version-pinned, because a `==` pin still trusts whatever PyPI serves for that version — the documented remediation is **hash pinning** verified with `pip install --require-hashes`.

| Alert | Location | Offending command |
|------|----------|-------------------|
| **#149** | `.github/workflows/docs-quality.yml` | `pip install pyyaml==6.0.2` (introduced by PR #164) |
| **#84** | `.github/workflows/python.yml:40` | `pip install maturin==1.14.0 pytest==9.1.0` (pre-existing) |

## The fix

Each install now reads a **hash-pinned requirements file** consumed with `--require-hashes`:

- **`.github/requirements/docs-quality.txt`** — `pyyaml==6.0.2` with **every** published 6.0.2 distribution hash (all platform wheels + the sdist), so whichever wheel the ubuntu runner resolves matches a listed hash. PyYAML has no runtime deps, so this file is the full install closure.
- **`.github/requirements/python-build.txt`** — `maturin==1.14.0` + `pytest==9.1.0` **and their full transitive closure** (iniconfig, packaging, pluggy, pygments), generated by `pip-compile --generate-hashes` (regen recipe is in the file header). With `--require-hashes`, pip rejects any unlisted/transitive dependency, so the closure had to be complete.

Hashes sourced from PyPI (PyYAML via the JSON API; the maturin/pytest closure via `pip-compile --generate-hashes`).

## Local verification

In fresh venvs (Python 3.12, matching the runner), `pip install --require-hashes -r <file>` **succeeds for both files** — hashes match and the tools import / report versions:

```
docs-quality.txt → Successfully installed pyyaml-6.0.2   (import yaml OK, 6.0.2)
python-build.txt → Successfully installed iniconfig-2.3.0 maturin-1.14.0 packaging-26.2 pluggy-1.6.0 pygments-2.20.0 pytest-9.1.0
                   maturin 1.14.0 / pytest 9.1.0
```

`actionlint` is **clean** on both workflows and both parse as valid YAML. (Scorecard itself can't be run locally, but a complete `--require-hashes` install is its documented remediation.)

## Stale / out-of-scope alerts

The other open code-scanning alerts are **not** `PinnedDependenciesID` and have **no file location** — they are repo-level Scorecard policy findings, out of scope for this hash-pinning bead and not fixable by a code change here:

- **#1** BranchProtectionID, **#91** CIIBestPracticesID, **#92** CodeReviewID — governance / branch-protection / OpenSSF-badge settings.
- **#94** MaintainedID — "project created within the last 90 days"; auto-resolves with time.
- **#96** VulnerabilitiesID — dependency-vuln triage, a separate concern.

## Bead

Closes work tracked by **sq-rbps** (P1). Bead closure is left to the orchestrator on merge once Scorecard re-scans #149/#84 to resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)