### PR TITLE
feat(bench): shared external-engine adapter kinds (sq-eifd)

### DIFF
--- a/bench/competitors.json
+++ b/bench/competitors.json
@@ -103,6 +103,45 @@
       "version_env_metadata": "gather records `eye --version`, the SWI-Prolog version, and the host env block; the cited third-party EYE measurements + machine spec live in bench/inference/eye-comparison.md.",
       "quiet_box_sensitive": true,
       "dashboard_engine_id": "eye"
+    },
+    {
+      "id": "pyshacl",
+      "name": "pySHACL",
+      "kind": "report-cli",
+      "role": "[OPUS-4.8 sq-eifd] W3C SHACL reference implementation; the 'correct-but-slow' SHACL anchor. Adapter kind `report-cli` (file-in / validation-report-out), reusing scripts/bench-adapters/shacl_report_count.py (count sh:result, read sh:conforms) so #violations is directly comparable to sparq's report.results.len().",
+      "pinned_version": "pyshacl (pin the exact version at gather time; `pyshacl --version` is the authoritative reported version)",
+      "version_source": "`pyshacl --version` at run time, recorded in the gather results file.",
+      "install_recipe": "pip install pyshacl rdflib  (gather-only — NOT a committed dependency of the repo; engines stay out of git per AGENTS.md). The adapter also needs rdflib for the shared report->count parser.",
+      "run_recipe": "scripts/gather-competitors.sh --run --only pyshacl  with SHACL_DATA=<data.ttl> SHACL_SHAPES=<shapes.ttl> set; the dispatch calls scripts/bench-adapters/report_cli_adapter.py with the `adapter` recipe below.",
+      "adapter": {
+        "cmd": ["pyshacl", "-s", "{shapes}", "-f", "turtle", "-o", "{report}", "{data}"],
+        "report_format": "turtle",
+        "report_to": "file",
+        "version_cmd": ["pyshacl", "--version"]
+      },
+      "comparable_suites": [
+        { "sparq_suite": "shacl-validate-bench", "note": "same data x shapes; cross-check #violations/conforms (per-engine expected counts — engines that dedup results differ from sparq, which does not) before trusting any timing" }
+      ],
+      "version_env_metadata": "gather records `pyshacl --version`, rdflib version, and the host env block.",
+      "quiet_box_sensitive": true,
+      "dashboard_engine_id": "pyshacl"
+    },
+    {
+      "id": "rdf-validate-shacl",
+      "name": "Zazuko rdf-validate-shacl",
+      "kind": "js-lib",
+      "role": "[OPUS-4.8 sq-eifd] JS-ecosystem SHACL validator (MIT); the WASM-peer datapoint for sparq's browser SHACL story. Adapter kind `js-lib` (in-process Node/RDF-JS), run in the SAME Node runtime that can also bench sparq's own @jeswr/sparq WASM SHACL. Counts `report.results` / reads `report.conforms` — the identical reduction the shared report->count parser performs over the report graph.",
+      "pinned_version": "rdf-validate-shacl (pin the exact npm version at gather time)",
+      "version_source": "the resolved npm version in the gather box's node_modules, recorded in the results file.",
+      "install_recipe": "npm i rdf-validate-shacl @rdfjs/data-model @rdfjs/dataset @rdfjs/term-map @rdfjs/namespace @rdfjs/parser-n3 @rdfjs/environment clownface  (gather-only — NOT committed; set JS_MODULES_DIR to the node_modules parent). Optionally `npm i shacl-engine` for the shacl-engine variant (set adapter.js_engine).",
+      "run_recipe": "scripts/gather-competitors.sh --run --only rdf-validate-shacl  with SHACL_DATA + SHACL_SHAPES (+ JS_MODULES_DIR) set; the dispatch calls scripts/bench-adapters/js_shacl_adapter.mjs.",
+      "adapter": { "js_engine": "rdf-validate-shacl" },
+      "comparable_suites": [
+        { "sparq_suite": "shacl-validate-bench", "note": "same data x shapes; cross-check #violations/conforms (per-engine expected counts) before trusting timing; also the harness for sparq's own WASM SHACL in-runtime comparison" }
+      ],
+      "version_env_metadata": "gather records the resolved npm version + node --version + the host env block.",
+      "quiet_box_sensitive": true,
+      "dashboard_engine_id": "rdf-validate-shacl"
     }
   ],
 

--- a/scripts/bench-adapters/cross_check_shacl.sh
+++ b/scripts/bench-adapters/cross_check_shacl.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] sq-eifd: cross-engine SHACL COUNT-AGREEMENT check. Authored by Opus
+# 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# The headline verification for the report-cli + js-lib adapters: validate the SAME
+# (data.ttl, shapes.ttl) fixture with sparq-shacl, pySHACL (report-cli) and
+# rdf-validate-shacl (js-lib), reduce all three to (conforms, #violations) through
+# the SHARED shacl_report_count semantics, and ASSERT they agree. Skips any engine
+# that is not installed (these are gather-only deps, not committed) and only
+# asserts agreement across the engines that DID run — but requires >= 2 to make a
+# real cross-check.
+#
+# Env knobs (all optional; point at wherever you installed the gather-only engines):
+#   SPARQ_VALIDATE   path to the sparq-shacl `validate` example binary
+#                    (default: target/release/examples/validate)
+#   PYSHACL          pyshacl CLI (default: pyshacl on PATH)
+#   RDFLIB_PYTHON    a python with rdflib (for the shared parser; default python3)
+#   JS_MODULES_DIR   node_modules parent for rdf-validate-shacl (default: cwd)
+#   FIXTURE_DIR      data.ttl+shapes.ttl dir (default: this script's fixtures/)
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+FIXTURE_DIR="${FIXTURE_DIR:-$HERE/fixtures}"
+DATA="$FIXTURE_DIR/data.ttl"
+SHAPES="$FIXTURE_DIR/shapes.ttl"
+SPARQ_VALIDATE="${SPARQ_VALIDATE:-$ROOT/target/release/examples/validate}"
+PYSHACL="${PYSHACL:-pyshacl}"
+RDFLIB_PYTHON="${RDFLIB_PYTHON:-python3}"
+JS_MODULES_DIR="${JS_MODULES_DIR:-$PWD}"
+
+COUNTER="$HERE/shacl_report_count.py"
+log() { printf '%s\n' "$*" >&2; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+rdflib_ok() { "$RDFLIB_PYTHON" -c 'import rdflib' >/dev/null 2>&1; }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+declare -A VIOL CONF
+ran=0
+
+# --- sparq-shacl (its OWN --turtle report -> shared parser) ------------------
+if [ -x "$SPARQ_VALIDATE" ] && rdflib_ok; then
+  "$SPARQ_VALIDATE" "$DATA" "$SHAPES" --turtle > "$tmp/sparq.ttl" || true
+  out="$("$RDFLIB_PYTHON" "$COUNTER" --format turtle "$tmp/sparq.ttl")"
+  VIOL[sparq]="$(printf '%s' "$out" | "$RDFLIB_PYTHON" -c 'import json,sys;print(json.load(sys.stdin)["violations"])')"
+  CONF[sparq]="$(printf '%s' "$out" | "$RDFLIB_PYTHON" -c 'import json,sys;print(json.load(sys.stdin)["conforms"])')"
+  ran=$((ran+1)); log "sparq-shacl : violations=${VIOL[sparq]} conforms=${CONF[sparq]}"
+else
+  log "sparq-shacl : SKIP (build target/release/examples/validate + need rdflib)"
+fi
+
+# --- pySHACL via the report-cli adapter --------------------------------------
+if have "$PYSHACL" && rdflib_ok; then
+  recipe="{\"cmd\":[\"$PYSHACL\",\"-s\",\"{shapes}\",\"-f\",\"turtle\",\"-o\",\"{report}\",\"{data}\"],\"report_format\":\"turtle\",\"report_to\":\"file\",\"version_cmd\":[\"$PYSHACL\",\"--version\"]}"
+  "$RDFLIB_PYTHON" "$HERE/report_cli_adapter.py" --recipe "$recipe" \
+    --data "$DATA" --shapes "$SHAPES" --engine pyshacl --json > "$tmp/py.tsv" 2>"$tmp/py.json" || true
+  if [ -s "$tmp/py.tsv" ]; then
+    VIOL[pyshacl]="$(cut -f2 "$tmp/py.tsv")"
+    CONF[pyshacl]="$("$RDFLIB_PYTHON" -c 'import json,sys;print(json.load(open(sys.argv[1]))["conforms"])' "$tmp/py.json")"
+    ran=$((ran+1)); log "pyshacl     : violations=${VIOL[pyshacl]} conforms=${CONF[pyshacl]}"
+  else log "pyshacl     : SKIP (ran but produced no row — see stderr)"; fi
+else
+  log "pyshacl     : SKIP (pip install pyshacl + need rdflib)"
+fi
+
+# --- rdf-validate-shacl via the js-lib adapter -------------------------------
+if have node && [ -d "$JS_MODULES_DIR/node_modules/rdf-validate-shacl" ]; then
+  node "$HERE/js_shacl_adapter.mjs" --data "$DATA" --shapes "$SHAPES" \
+    --engine rdf-validate-shacl --modules-dir "$JS_MODULES_DIR" --json \
+    > "$tmp/js.tsv" 2>"$tmp/js.json" || true
+  if [ -s "$tmp/js.tsv" ]; then
+    VIOL[rvs]="$(cut -f2 "$tmp/js.tsv")"
+    CONF[rvs]="$(node -e 'const fs=require("fs");process.stdout.write(String(JSON.parse(fs.readFileSync(process.argv[1],"utf8")).conforms))' "$tmp/js.json")"
+    ran=$((ran+1)); log "rdf-validate-shacl: violations=${VIOL[rvs]} conforms=${CONF[rvs]}"
+  else log "rdf-validate-shacl: SKIP (ran but produced no row — see stderr)"; fi
+else
+  log "rdf-validate-shacl: SKIP (npm i rdf-validate-shacl + set JS_MODULES_DIR)"
+fi
+
+# --- assert agreement across the engines that ran ----------------------------
+if [ "$ran" -lt 2 ]; then
+  log "NOTE: only $ran engine(s) available — install >=2 for a real cross-check."
+  exit 0
+fi
+first_v=""; first_c=""
+for e in "${!VIOL[@]}"; do
+  v="${VIOL[$e]}"; c="$(printf '%s' "${CONF[$e]}" | tr '[:upper:]' '[:lower:]')"
+  if [ -z "$first_v" ]; then first_v="$v"; first_c="$c"; continue; fi
+  [ "$v" = "$first_v" ] || { log "DISAGREE: $e violations=$v != $first_v"; exit 1; }
+  [ "$c" = "$first_c" ] || { log "DISAGREE: $e conforms=$c != $first_c"; exit 1; }
+done
+log "AGREE: $ran engines all report violations=$first_v conforms=$first_c"

--- a/scripts/bench-adapters/fixtures/data.ttl
+++ b/scripts/bench-adapters/fixtures/data.ttl
@@ -1,0 +1,27 @@
+# [OPUS-4.8] sq-eifd cross-engine SHACL fixture — DATA graph.
+# Four ex:Person focus nodes, hand-authored so the violation set is unambiguous:
+#   ex:alice   — VALID    (name string, age integer, knows an IRI)            0 viol
+#   ex:bob     — missing ex:name                                  -> minCount  1 viol
+#   ex:carol   — ex:age is a string not integer                   -> datatype  1 viol
+#   ex:dave    — ex:knows points at a literal not an IRI          -> nodeKind  1 viol
+# Total: 3 violations, does NOT conform. No constraint can fire twice on one node
+# here, so engines that dedup vs not agree on the count (3).
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:  <http://example.org/> .
+
+ex:alice a ex:Person ;
+    ex:name "Alice" ;
+    ex:age 30 ;
+    ex:knows ex:bob .
+
+ex:bob a ex:Person ;
+    ex:age 25 ;
+    ex:knows ex:carol .
+
+ex:carol a ex:Person ;
+    ex:name "Carol" ;
+    ex:age "twenty-six" .
+
+ex:dave a ex:Person ;
+    ex:name "Dave" ;
+    ex:knows "not-an-iri" .

--- a/scripts/bench-adapters/fixtures/knn_approx.tsv
+++ b/scripts/bench-adapters/fixtures/knn_approx.tsv
@@ -1,0 +1,6 @@
+# sq-eifd vector fixture: an ANN engine's APPROX neighbours. <qid>\t<csv ids>
+# q0,q1 perfect; q2 has one wrong neighbour (99 instead of 33) -> recall@4 = 3/4.
+# Mean recall@4 = (4 + 4 + 3) / 12 = 11/12 = 0.91666...  -> deficit_milli = 83.
+q0	10,11,12,13
+q1	20,21,22,23
+q2	30,31,32,99

--- a/scripts/bench-adapters/fixtures/knn_exact.tsv
+++ b/scripts/bench-adapters/fixtures/knn_exact.tsv
@@ -1,0 +1,5 @@
+# sq-eifd vector fixture: EXACT-kNN ground truth. <qid>\t<ranked neighbour ids, csv>
+# 3 queries, k=4. Pairs with knn_approx.tsv to give a KNOWN recall@4 = 11/12.
+q0	10,11,12,13
+q1	20,21,22,23
+q2	30,31,32,33

--- a/scripts/bench-adapters/fixtures/shapes.ttl
+++ b/scripts/bench-adapters/fixtures/shapes.ttl
@@ -1,0 +1,28 @@
+# [OPUS-4.8] sq-eifd cross-engine SHACL fixture — SHAPES graph.
+# A minimal shapes graph designed to produce a KNOWN, engine-stable violation
+# count over fixtures/data.ttl, used by the adapter unit tests to prove that
+# sparq-shacl, pySHACL and rdf-validate-shacl all agree on (conforms, #violations).
+# Deliberately uses only CORE constraints (sh:minCount, sh:datatype, sh:nodeKind)
+# whose semantics are unambiguous and NOT subject to per-engine result dedup.
+@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:   <http://example.org/> .
+
+ex:PersonShape a sh:NodeShape ;
+    sh:targetClass ex:Person ;
+    # exactly one ex:name, a string
+    sh:property [
+        sh:path ex:name ;
+        sh:minCount 1 ;
+        sh:datatype xsd:string ;
+    ] ;
+    # age must be an integer if present
+    sh:property [
+        sh:path ex:age ;
+        sh:datatype xsd:integer ;
+    ] ;
+    # knows must point at an IRI (not a literal/bnode)
+    sh:property [
+        sh:path ex:knows ;
+        sh:nodeKind sh:IRI ;
+    ] .

--- a/scripts/bench-adapters/fixtures/sparql_ask.json
+++ b/scripts/bench-adapters/fixtures/sparql_ask.json
@@ -1,0 +1,1 @@
+{ "head": {}, "boolean": true }

--- a/scripts/bench-adapters/fixtures/sparql_count.json
+++ b/scripts/bench-adapters/fixtures/sparql_count.json
@@ -1,0 +1,10 @@
+{
+  "head": { "vars": [ "c" ] },
+  "results": {
+    "bindings": [
+      { "c": { "type": "literal",
+               "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+               "value": "3" } }
+    ]
+  }
+}

--- a/scripts/bench-adapters/fixtures/sparql_select.json
+++ b/scripts/bench-adapters/fixtures/sparql_select.json
@@ -1,0 +1,13 @@
+{
+  "head": { "vars": [ "person", "name" ] },
+  "results": {
+    "bindings": [
+      { "person": { "type": "uri", "value": "http://example.org/alice" },
+        "name": { "type": "literal", "value": "Alice" } },
+      { "person": { "type": "uri", "value": "http://example.org/carol" },
+        "name": { "type": "literal", "value": "Carol" } },
+      { "person": { "type": "uri", "value": "http://example.org/dave" },
+        "name": { "type": "literal", "value": "Dave" } }
+    ]
+  }
+}

--- a/scripts/bench-adapters/http_sparql_adapter.py
+++ b/scripts/bench-adapters/http_sparql_adapter.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] sq-eifd: HTTP-SPARQL adapter KIND. Authored by Opus 4.8 (Fable
+# unavailable; flag for re-review when Fable returns).
+#
+# POST a SPARQL query to an HTTP endpoint -> parse the SPARQL 1.1 Query Results
+# JSON -> count solutions / read the ASK boolean / extract a COUNT(*) value.
+# Shared across Fuseki, Virtuoso (the core-SPARQL reference engines from
+# research/BENCHMARKS.md) AND the existing QLever HTTP path (this is the reusable
+# unit the per-dir bench/qlever-*/compare.py hand-rolls today; G3 in
+# research/capability-benchmark-program.md §2).
+#
+# The PARSER (parse_sparql_json) is the value here and is unit-tested against a
+# captured sample response WITHOUT a live server. The transport (do_query) is a
+# thin urllib POST; standing up Fuseki/Virtuoso is gather-only on a Docker box.
+#
+# SPARQL-JSON shapes handled (per the W3C rec):
+#   - SELECT : {"head":{"vars":[...]}, "results":{"bindings":[ {var:{...}}, ...]}}
+#              -> solution count = len(bindings); a single-binding single-var row
+#                 is treated as a COUNT(*) and its value extracted (the
+#                 correctness cross-check QLever's compare.py does today).
+#   - ASK    : {"head":{}, "boolean": true|false} -> count = 1 if true else 0,
+#              boolean carried through.
+#
+# Output: `<engine>\t<count>\t<query_us>` TSV on stdout (the same 3-col contract
+# the rest of the adapters + the ci-bench hook use). Non-zero exit only on a
+# transport/parse ERROR.
+import json
+import sys
+import time
+import urllib.parse
+import urllib.request
+
+
+def parse_sparql_json(text):
+    """Reduce a SPARQL-results-JSON document to a comparable count.
+
+    Returns {"count": int, "boolean": bool|None, "count_value": str|None}:
+      count       : len(bindings) for SELECT, or 1/0 for ASK true/false.
+      boolean     : the ASK boolean (None for SELECT).
+      count_value : the scalar of a single-row single-var SELECT (a COUNT(*) wrap),
+                    else None — the value to cross-check against sparq's count.
+    Raises ValueError on a document that is neither a SELECT nor an ASK result."""
+    obj = text if isinstance(text, dict) else json.loads(text)
+    if "boolean" in obj:
+        b = bool(obj["boolean"])
+        return {"count": 1 if b else 0, "boolean": b, "count_value": None}
+    results = obj.get("results")
+    if results is None or "bindings" not in results:
+        raise ValueError("not a SPARQL SELECT/ASK results document")
+    bindings = results["bindings"]
+    count_value = None
+    if len(bindings) == 1 and len(bindings[0]) == 1:
+        only = next(iter(bindings[0].values()))
+        count_value = only.get("value")
+    return {"count": len(bindings), "boolean": None, "count_value": count_value}
+
+
+def do_query(endpoint, query, accept="application/sparql-results+json", timeout=300):
+    """POST a SPARQL query (application/x-www-form-urlencoded) -> response bytes."""
+    data = urllib.parse.urlencode({"query": query}).encode()
+    req = urllib.request.Request(
+        endpoint, data=data, headers={"Accept": accept}
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return r.read().decode("utf-8")
+
+
+def run_http_sparql(endpoint, query, engine="engine", iters=1, timeout=300):
+    """Run a query `iters` times (min wall-clock), parse the JSON result.
+
+    Returns {"engine","count","boolean","count_value","query_us"}.
+    Raises on transport/parse error."""
+    best_us = None
+    parsed = None
+    for _ in range(max(1, iters)):
+        t0 = time.perf_counter()
+        body = do_query(endpoint, query, timeout=timeout)
+        dt_us = (time.perf_counter() - t0) * 1e6
+        parsed = parse_sparql_json(body)
+        if best_us is None or dt_us < best_us:
+            best_us = dt_us
+    return {
+        "engine": engine,
+        "count": parsed["count"],
+        "boolean": parsed["boolean"],
+        "count_value": parsed["count_value"],
+        "query_us": int(round(best_us)),
+    }
+
+
+def main(argv):
+    """CLI: http_sparql_adapter.py --endpoint URL (--query Q | --query-file F)
+            [--engine NAME] [--iters N] [--json]
+       OR : --parse-only <json-file>   (offline: just run the parser, for tests)"""
+    endpoint = query = None
+    engine = "engine"
+    iters = 1
+    want_json = False
+    parse_only = None
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--endpoint":
+            i += 1
+            endpoint = argv[i]
+        elif a == "--query":
+            i += 1
+            query = argv[i]
+        elif a == "--query-file":
+            i += 1
+            with open(argv[i], "r", encoding="utf-8") as fh:
+                query = fh.read()
+        elif a == "--engine":
+            i += 1
+            engine = argv[i]
+        elif a == "--iters":
+            i += 1
+            iters = int(argv[i])
+        elif a == "--parse-only":
+            i += 1
+            parse_only = argv[i]
+        elif a == "--json":
+            want_json = True
+        else:
+            sys.stderr.write("http_sparql_adapter: unknown arg %s\n" % a)
+            return 2
+        i += 1
+
+    if parse_only is not None:
+        with open(parse_only, "r", encoding="utf-8") as fh:
+            res = parse_sparql_json(fh.read())
+        json.dump(res, sys.stdout)
+        sys.stdout.write("\n")
+        return 0
+
+    if not (endpoint and query):
+        sys.stderr.write(
+            "usage: http_sparql_adapter.py --endpoint URL (--query Q|--query-file F) "
+            "[--engine NAME] [--iters N] [--json]   |   --parse-only <json-file>\n"
+        )
+        return 2
+    try:
+        res = run_http_sparql(endpoint, query, engine=engine, iters=iters)
+    except Exception as e:  # noqa: BLE001 — adapter boundary
+        sys.stderr.write("http_sparql_adapter: %s\n" % e)
+        return 1
+    sys.stdout.write("%s\t%d\t%d\n" % (res["engine"], res["count"], res["query_us"]))
+    if want_json:
+        sys.stderr.write(json.dumps(res) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/bench-adapters/http_sparql_adapter.py
+++ b/scripts/bench-adapters/http_sparql_adapter.py
@@ -42,8 +42,16 @@ def parse_sparql_json(text):
     Raises ValueError on a document that is neither a SELECT nor an ASK result."""
     obj = text if isinstance(text, dict) else json.loads(text)
     if "boolean" in obj:
-        b = bool(obj["boolean"])
-        return {"count": 1 if b else 0, "boolean": b, "count_value": None}
+        # [OPUS-4.8] Per the SPARQL 1.1 Query Results JSON rec the ASK "boolean"
+        # member is a JSON boolean. Reject anything else (e.g. the string "false",
+        # which bool() would wrongly coerce to True) as an invalid document rather
+        # than silently mis-counting it.
+        raw = obj["boolean"]
+        if not isinstance(raw, bool):
+            raise ValueError(
+                "SPARQL-JSON 'boolean' is not a JSON boolean: %r" % (raw,)
+            )
+        return {"count": 1 if raw else 0, "boolean": raw, "count_value": None}
     results = obj.get("results")
     if results is None or "bindings" not in results:
         raise ValueError("not a SPARQL SELECT/ASK results document")

--- a/scripts/bench-adapters/js_shacl_adapter.mjs
+++ b/scripts/bench-adapters/js_shacl_adapter.mjs
@@ -212,4 +212,10 @@ async function main() {
   if (args.json) process.stderr.write(JSON.stringify(res) + '\n');
 }
 
-main();
+// [OPUS-4.8] Attach a rejection handler so an uncaught error inside the async
+// main() reliably exits non-zero with a clear message, rather than relying on
+// Node's version-dependent unhandled-rejection exit behaviour.
+main().catch((e) => {
+  process.stderr.write(`js_shacl_adapter: fatal: ${e && e.stack ? e.stack : e}\n`);
+  process.exit(1);
+});

--- a/scripts/bench-adapters/js_shacl_adapter.mjs
+++ b/scripts/bench-adapters/js_shacl_adapter.mjs
@@ -1,0 +1,215 @@
+// [OPUS-4.8] sq-eifd: JS-LIB (node-rdfjs) adapter KIND. Authored by Opus 4.8
+// (Fable unavailable; flag for re-review when Fable returns).
+//
+// In-process Node / RDF-JS SHACL harness. Covers the JS-ecosystem SHACL engines
+// (research/capability-benchmark-program.md §3.1c Tier-2 / WASM-peer):
+//   - Zazuko `rdf-validate-shacl`   (engine=rdf-validate-shacl)  [default]
+//   - Zazuko `shacl-engine`         (engine=shacl-engine)        [if installed]
+//   - sparq's OWN @jeswr/sparq WASM/JS SHACL (engine=sparq-js)   [if installed]
+// run in the SAME Node runtime as the others — the natural way to bench sparq's
+// browser SHACL story against its JS peers.
+//
+// CONTRACT (mirrors report_cli_adapter.py so counts are cross-engine comparable):
+//   parse data.ttl + shapes.ttl into an RDF/JS dataset -> run validator ->
+//   reduce to (conforms, violations) with the SAME semantics as the shared
+//   shacl_report_count parser (count sh:ValidationResult / read sh:conforms):
+//   we count `report.results` and read `report.conforms`, which the W3C SHACL
+//   report model defines as exactly the sh:result set + sh:conforms — i.e. the
+//   identical reduction the Python side performs over the report GRAPH.
+//
+//   stdout : `<engine>\t<violations>\t<validate_us>`  (the 3-col name\tcount\tus
+//            contract the ci-bench hook + bench/lubm/run.sh consume).
+//   --report-out <path> : ALSO serialise the report graph to N-Triples there, so
+//            the gather harness can re-parse it through shacl_report_count.py and
+//            prove count agreement across the JS and Python reductions.
+//   exit   : non-zero only on an engine/adapter ERROR.
+//
+// Usage:
+//   node js_shacl_adapter.mjs --data d.ttl --shapes s.ttl \
+//        [--engine rdf-validate-shacl|shacl-engine|sparq-js] \
+//        [--iters N] [--modules-dir <node_modules parent>] [--report-out r.nt] [--json]
+//
+// --modules-dir lets the gather box point at wherever the JS engines were
+// `npm i`-installed (they are gather-only deps, NOT a committed dependency of the
+// repo — AGENTS.md: engines stay out of git).
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { performance } from 'node:perf_hooks';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+function parseArgs(argv) {
+  const a = { engine: 'rdf-validate-shacl', iters: 1, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === '--data') a.data = argv[++i];
+    else if (k === '--shapes') a.shapes = argv[++i];
+    else if (k === '--engine') a.engine = argv[++i];
+    else if (k === '--iters') a.iters = parseInt(argv[++i], 10);
+    else if (k === '--modules-dir') a.modulesDir = argv[++i];
+    else if (k === '--report-out') a.reportOut = argv[++i];
+    else if (k === '--json') a.json = true;
+    else { process.stderr.write(`js_shacl_adapter: unknown arg ${k}\n`); process.exit(2); }
+  }
+  if (!a.data || !a.shapes) {
+    process.stderr.write('usage: node js_shacl_adapter.mjs --data d.ttl --shapes s.ttl [--engine E] [--iters N] [--modules-dir DIR] [--report-out r.nt] [--json]\n');
+    process.exit(2);
+  }
+  return a;
+}
+
+// Resolve the gather-only JS engines from --modules-dir (or NODE_PATH / cwd).
+function makeImporter(modulesDir) {
+  const base = modulesDir
+    ? pathToFileURL(modulesDir.replace(/\/?$/, '/') + 'package.json')
+    : pathToFileURL(process.cwd() + '/package.json');
+  const req = createRequire(base);
+  return {
+    require: (id) => req(id),
+    resolve: (id) => req.resolve(id),
+  };
+}
+
+// Build the RDF/JS factory rdf-validate-shacl uses (blankNode, clownface,
+// dataset, literal, quad, termMap + the term constructors the parser/serialiser
+// need) by composing the installed @rdfjs/* Factory classes through
+// @rdfjs/environment — exactly how @zazuko/env builds its env, but without taking
+// that heavier bundle as a gather dependency. The `.default` unwraps are because
+// these packages publish transpiled-ESM whose CJS entry is on `.default`.
+function makeFactory(imp) {
+  const Environment = imp.require('@rdfjs/environment').default || imp.require('@rdfjs/environment');
+  const def = (id, sub) => {
+    const m = imp.require(sub ? `${id}/${sub}` : id);
+    return m.default || m;
+  };
+  const DataFactory = def('@rdfjs/data-model', 'Factory.js');
+  const DatasetFactory = def('@rdfjs/dataset', 'Factory.js');
+  const TermMapFactory = def('@rdfjs/term-map', 'Factory.js');
+  const NamespaceFactory = def('@rdfjs/namespace', 'Factory.js');
+  const ClownfaceFactory = def('clownface', 'Factory.js');
+  return new Environment([
+    DataFactory, DatasetFactory, TermMapFactory, NamespaceFactory, ClownfaceFactory,
+  ]);
+}
+
+async function parseTurtleToDataset(imp, factory, text, baseIRI) {
+  const ParserN3mod = imp.require('@rdfjs/parser-n3');
+  const ParserN3 = ParserN3mod.default || ParserN3mod;
+  const parser = new ParserN3({ factory, baseIRI });
+  const { Readable } = await import('node:stream');
+  const stream = parser.import(Readable.from([text]));
+  const ds = factory.dataset();
+  for await (const quad of stream) ds.add(quad);
+  return ds;
+}
+
+function serialiseNT(dataset) {
+  // Minimal N-Triples writer (default graph only) — enough for the Python
+  // cross-check parser to re-count the report graph.
+  const lines = [];
+  for (const q of dataset) {
+    const t = (term) => {
+      if (term.termType === 'NamedNode') return `<${term.value}>`;
+      if (term.termType === 'BlankNode') return `_:${term.value}`;
+      if (term.termType === 'Literal') {
+        const v = term.value
+          .replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+          .replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t');
+        if (term.language) return `"${v}"@${term.language}`;
+        if (term.datatype && term.datatype.value !== 'http://www.w3.org/2001/XMLSchema#string')
+          return `"${v}"^^<${term.datatype.value}>`;
+        return `"${v}"`;
+      }
+      return `<${term.value}>`;
+    };
+    lines.push(`${t(q.subject)} ${t(q.predicate)} ${t(q.object)} .`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+// Engine adapters: each returns { conforms, violations, reportDataset|null }.
+async function runRdfValidateShacl(imp, factory, dataDs, shapesDs) {
+  const SHACLValidator = imp.require('rdf-validate-shacl').default || imp.require('rdf-validate-shacl');
+  const validator = new SHACLValidator(shapesDs, { factory });
+  const report = await validator.validate(dataDs);
+  return {
+    conforms: report.conforms,
+    violations: report.results.length,
+    reportDataset: report.dataset,
+  };
+}
+
+async function runShaclEngine(imp, factory, dataDs, shapesDs) {
+  const mod = imp.require('shacl-engine');
+  const Validator = mod.Validator || mod.default;
+  const validator = new Validator(shapesDs, { factory });
+  const report = await validator.validate({ dataset: dataDs });
+  return {
+    conforms: report.conforms,
+    violations: report.results.length,
+    reportDataset: report.dataset || null,
+  };
+}
+
+const ENGINES = {
+  'rdf-validate-shacl': runRdfValidateShacl,
+  'shacl-engine': runShaclEngine,
+};
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const imp = makeImporter(args.modulesDir);
+  let factory;
+  try {
+    factory = makeFactory(imp);
+  } catch (e) {
+    process.stderr.write(`js_shacl_adapter: cannot load RDF/JS factory (npm i in --modules-dir?): ${e}\n`);
+    process.exit(1);
+  }
+  const runner = ENGINES[args.engine];
+  if (!runner) {
+    process.stderr.write(`js_shacl_adapter: unknown engine '${args.engine}' (have: ${Object.keys(ENGINES).join(', ')})\n`);
+    process.exit(2);
+  }
+
+  let dataDs, shapesDs;
+  try {
+    const dataText = readFileSync(args.data, 'utf-8');
+    const shapesText = readFileSync(args.shapes, 'utf-8');
+    dataDs = await parseTurtleToDataset(imp, factory, dataText, pathToFileURL(args.data).href);
+    shapesDs = await parseTurtleToDataset(imp, factory, shapesText, pathToFileURL(args.shapes).href);
+  } catch (e) {
+    process.stderr.write(`js_shacl_adapter: parse error: ${e}\n`);
+    process.exit(1);
+  }
+
+  let bestUs = Infinity;
+  let last = null;
+  try {
+    for (let i = 0; i < Math.max(1, args.iters); i++) {
+      const t0 = performance.now();
+      last = await runner(imp, factory, dataDs, shapesDs);
+      const dt = (performance.now() - t0) * 1000;
+      if (dt < bestUs) bestUs = dt;
+    }
+  } catch (e) {
+    process.stderr.write(`js_shacl_adapter: engine error (${args.engine}): ${e}\n`);
+    process.exit(1);
+  }
+
+  if (args.reportOut && last.reportDataset) {
+    try { writeFileSync(args.reportOut, serialiseNT(last.reportDataset)); }
+    catch (e) { process.stderr.write(`js_shacl_adapter: report-out write failed: ${e}\n`); }
+  }
+
+  const res = {
+    engine: args.engine,
+    conforms: last.conforms,
+    violations: last.violations,
+    validate_us: Math.round(bestUs),
+  };
+  process.stdout.write(`${res.engine}\t${res.violations}\t${res.validate_us}\n`);
+  if (args.json) process.stderr.write(JSON.stringify(res) + '\n');
+}
+
+main();

--- a/scripts/bench-adapters/report_cli_adapter.py
+++ b/scripts/bench-adapters/report_cli_adapter.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] sq-eifd: REPORT-CLI adapter KIND. Authored by Opus 4.8 (Fable
+# unavailable; flag for re-review when Fable returns).
+#
+# Covers any external SHACL engine exposed as a file-in / validation-report-out
+# CLI — structurally identical to the existing EYE adapter (binary, file->file).
+# Tier-1 targets (research/capability-benchmark-program.md §3.1c): Apache Jena
+# `shacl validate`, pySHACL, TopBraid.
+#
+#   build_argv(recipe, data, shapes, report)  : substitute {data}/{shapes}/{report}
+#                                               into the engine's templated argv.
+#   run_report_cli(...)                        : run it, time it, parse the report
+#                                               via the SHARED shacl_report_count
+#                                               so the count is comparable to
+#                                               sparq's report.results.len().
+#
+# The validation-report -> count reduction is NOT duplicated here: it delegates to
+# shacl_report_count.count_report (the single source of truth for "count sh:result,
+# read sh:conforms").
+#
+# Output: a one-row TSV line `<engine>\t<violations>\t<validate_us>` on stdout (the
+# same 3-column name\tcount\tus contract bench/lubm/run.sh + the ci-bench hook
+# consume), plus a JSON sidecar to stderr/`--json` with conforms + the resolved
+# version. Non-zero exit ONLY on an adapter/engine error (so a benchmark can tell
+# "engine says X" from "engine could not run").
+#
+# RECIPE shape (from competitors.json, the `report_cli` block of a competitor):
+#   {
+#     "cmd": ["pyshacl", "-s", "{shapes}", "-f", "turtle", "-o", "{report}", "{data}"],
+#     "report_format": "turtle",      # rdflib format of the produced report
+#     "report_to": "file",            # "file" (engine writes {report}) | "stdout"
+#     "version_cmd": ["pyshacl", "--version"]
+#   }
+# {data}/{shapes} are the input paths; {report} is a temp path the adapter creates
+# when report_to == "file" (omit {report} from cmd for report_to == "stdout").
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import shacl_report_count  # noqa: E402  (local sibling module)
+
+
+def build_argv(template, mapping):
+    """Substitute {data}/{shapes}/{report} tokens in each argv element."""
+    out = []
+    for tok in template:
+        for k, v in mapping.items():
+            tok = tok.replace("{%s}" % k, v)
+        out.append(tok)
+    return out
+
+
+def _resolve_version(version_cmd):
+    if not version_cmd:
+        return "unknown"
+    try:
+        p = subprocess.run(version_cmd, capture_output=True, text=True, timeout=60)
+        line = (p.stdout or p.stderr).strip().splitlines()
+        return line[0] if line else "unknown"
+    except Exception:  # noqa: BLE001
+        return "not-installed"
+
+
+def run_report_cli(recipe, data_path, shapes_path, engine="engine", iters=1):
+    """Run a report-cli engine `iters` times (min wall-clock), parse its report.
+
+    Returns {"engine","version","conforms","violations","validate_us"}.
+    Raises RuntimeError on engine/adapter failure."""
+    report_format = recipe.get("report_format", "turtle")
+    report_to = recipe.get("report_to", "file")
+    cmd_template = recipe["cmd"]
+    version = _resolve_version(recipe.get("version_cmd"))
+
+    best_us = None
+    last_report_text = None
+    with tempfile.TemporaryDirectory(prefix="report-cli-") as td:
+        report_path = os.path.join(td, "report.out")
+        mapping = {"data": data_path, "shapes": shapes_path, "report": report_path}
+        argv = build_argv(cmd_template, mapping)
+        for _ in range(max(1, iters)):
+            if report_to == "file" and os.path.exists(report_path):
+                os.remove(report_path)
+            t0 = time.perf_counter()
+            proc = subprocess.run(argv, capture_output=True, text=True)
+            dt_us = (time.perf_counter() - t0) * 1e6
+            # pySHACL exits non-zero (1) when the data does NOT conform — that is a
+            # VALID report, not an engine error. So we do not treat a non-zero exit
+            # as failure by itself; we require a parseable report instead.
+            if report_to == "stdout":
+                last_report_text = proc.stdout
+            else:
+                if not os.path.exists(report_path):
+                    raise RuntimeError(
+                        "%s produced no report file (exit %d):\n%s"
+                        % (engine, proc.returncode, proc.stderr)
+                    )
+                with open(report_path, "r", encoding="utf-8") as fh:
+                    last_report_text = fh.read()
+            if best_us is None or dt_us < best_us:
+                best_us = dt_us
+
+    counts = shacl_report_count.count_report(last_report_text, fmt=report_format)
+    return {
+        "engine": engine,
+        "version": version,
+        "conforms": counts["conforms"],
+        "violations": counts["violations"],
+        "validate_us": int(round(best_us)),
+    }
+
+
+def main(argv):
+    """CLI: report_cli_adapter.py --recipe <json> --data <ttl> --shapes <ttl>
+            [--engine NAME] [--iters N] [--json]
+
+    Emits `<engine>\\t<violations>\\t<validate_us>` on stdout; with --json also
+    dumps the full result dict to stderr for the gather envelope."""
+    recipe_json = None
+    data = shapes = None
+    engine = "engine"
+    iters = 1
+    want_json = False
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--recipe":
+            i += 1
+            recipe_json = argv[i]
+        elif a == "--recipe-file":
+            i += 1
+            with open(argv[i], "r", encoding="utf-8") as fh:
+                recipe_json = fh.read()
+        elif a == "--data":
+            i += 1
+            data = argv[i]
+        elif a == "--shapes":
+            i += 1
+            shapes = argv[i]
+        elif a == "--engine":
+            i += 1
+            engine = argv[i]
+        elif a == "--iters":
+            i += 1
+            iters = int(argv[i])
+        elif a == "--json":
+            want_json = True
+        else:
+            sys.stderr.write("report_cli_adapter: unknown arg %s\n" % a)
+            return 2
+        i += 1
+    if not (recipe_json and data and shapes):
+        sys.stderr.write(
+            "usage: report_cli_adapter.py --recipe <json> --data <ttl> "
+            "--shapes <ttl> [--engine NAME] [--iters N] [--json]\n"
+        )
+        return 2
+    recipe = json.loads(recipe_json)
+    try:
+        res = run_report_cli(recipe, data, shapes, engine=engine, iters=iters)
+    except Exception as e:  # noqa: BLE001 — adapter boundary
+        sys.stderr.write("report_cli_adapter: %s\n" % e)
+        return 1
+    sys.stdout.write("%s\t%d\t%d\n" % (res["engine"], res["violations"], res["validate_us"]))
+    if want_json:
+        sys.stderr.write(json.dumps(res) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/bench-adapters/report_cli_adapter.py
+++ b/scripts/bench-adapters/report_cli_adapter.py
@@ -29,7 +29,8 @@
 #     "cmd": ["pyshacl", "-s", "{shapes}", "-f", "turtle", "-o", "{report}", "{data}"],
 #     "report_format": "turtle",      # rdflib format of the produced report
 #     "report_to": "file",            # "file" (engine writes {report}) | "stdout"
-#     "version_cmd": ["pyshacl", "--version"]
+#     "version_cmd": ["pyshacl", "--version"],
+#     "timeout_s": 600                # per-invocation wall-clock cap (default 600)
 #   }
 # {data}/{shapes} are the input paths; {report} is a temp path the adapter creates
 # when report_to == "file" (omit {report} from cmd for report_to == "stdout").
@@ -39,6 +40,11 @@ import subprocess
 import sys
 import tempfile
 import time
+
+# [OPUS-4.8] Default per-invocation wall-clock cap so a hung/interactive external
+# CLI cannot hang the whole long-running gather indefinitely. Overridable per
+# engine via the recipe's "timeout_s".
+DEFAULT_TIMEOUT_S = 600
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)
@@ -74,6 +80,7 @@ def run_report_cli(recipe, data_path, shapes_path, engine="engine", iters=1):
     report_format = recipe.get("report_format", "turtle")
     report_to = recipe.get("report_to", "file")
     cmd_template = recipe["cmd"]
+    timeout_s = recipe.get("timeout_s", DEFAULT_TIMEOUT_S)
     version = _resolve_version(recipe.get("version_cmd"))
 
     best_us = None
@@ -86,7 +93,15 @@ def run_report_cli(recipe, data_path, shapes_path, engine="engine", iters=1):
             if report_to == "file" and os.path.exists(report_path):
                 os.remove(report_path)
             t0 = time.perf_counter()
-            proc = subprocess.run(argv, capture_output=True, text=True)
+            try:
+                proc = subprocess.run(
+                    argv, capture_output=True, text=True, timeout=timeout_s
+                )
+            except subprocess.TimeoutExpired as e:
+                raise RuntimeError(
+                    "%s timed out after %ss (override via recipe \"timeout_s\")"
+                    % (engine, timeout_s)
+                ) from e
             dt_us = (time.perf_counter() - t0) * 1e6
             # pySHACL exits non-zero (1) when the data does NOT conform — that is a
             # VALID report, not an engine error. So we do not treat a non-zero exit

--- a/scripts/bench-adapters/shacl_report_count.py
+++ b/scripts/bench-adapters/shacl_report_count.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] sq-eifd: SHARED SHACL-validation-report -> (conforms, violation-count)
+# parser. Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable
+# returns).
+#
+# This is THE contract that makes cross-engine SHACL counts comparable. Every
+# report-cli adapter (pySHACL, Jena `shacl validate`, TopBraid) emits a SHACL
+# ValidationReport graph (Turtle / N-Triples); this module reduces it to the SAME
+# two numbers sparq-shacl exposes via `report.conforms` + `report.results.len()`:
+#
+#   conforms   : the value of `sh:conforms` (bool) on the sh:ValidationReport node;
+#                falls back to (violations == 0) when no sh:conforms triple exists.
+#   violations : the number of sh:ValidationResult nodes (the `sh:result` set).
+#
+# These are EXACTLY sparq-shacl's semantics:
+#   - sparq's `report.conforms` == `results.is_empty()` (report.rs), and its
+#     `to_turtle()` emits `sh:conforms <bool>` + one `sh:result [ a
+#     sh:ValidationResult ... ]` per result. So sparq's OWN --turtle report parses
+#     through this same function and yields the same (conforms, violations) pair —
+#     the basis of the cross-engine count-agreement check (sparq vs pySHACL vs
+#     rdf-validate-shacl on one fixture).
+#   - It REUSES the count semantics of the diff-fuzz pyshacl_adapter
+#     (crates/sparq-shacl/tests/diff_fuzz/pyshacl_adapter.py): count
+#     sh:ValidationResult, read sh:conforms. That adapter additionally captures the
+#     per-violation (focus, component, path) set for differential FUZZING; here we
+#     only need the COUNT (the benchmark cross-check), so we keep it minimal.
+#
+# HONEST CAVEAT (carried from research/capability-benchmark-program.md §3.1c):
+# engines that DEDUP results across traversal routes report a different #violations
+# for the same data than sparq (which does not dedup). The count this returns is the
+# RAW sh:result count of whatever the engine emitted; the per-engine expected count
+# (not one shared constant) is what a suite's expected.tsv must record.
+import sys
+
+
+SH = "http://www.w3.org/ns/shacl#"
+
+
+def count_report(report_ttl, fmt="turtle"):
+    """Parse a SHACL ValidationReport graph -> {"conforms": bool, "violations": int}.
+
+    `report_ttl` is the serialised report graph; `fmt` is an rdflib format string
+    ("turtle" | "nt" | "n3" | "xml" ...). Raises on a parse error (the caller's
+    adapter boundary turns that into a non-zero exit so a benchmark can tell
+    "engine could not run" from "engine says conforms")."""
+    import rdflib
+
+    g = rdflib.Graph()
+    g.parse(data=report_ttl, format=fmt)
+    return count_graph(g)
+
+
+def count_graph(g):
+    """Count over an already-parsed rdflib.Graph (lets the js/oracle paths share
+    the exact same reduction without re-serialising)."""
+    import rdflib
+
+    result_t = rdflib.URIRef(SH + "ValidationResult")
+    rdf_type = rdflib.RDF.type
+    p_conforms = rdflib.URIRef(SH + "conforms")
+    report_t = rdflib.URIRef(SH + "ValidationReport")
+
+    violations = sum(1 for _ in g.subjects(rdf_type, result_t))
+
+    conforms = None
+    # Prefer the sh:conforms on a sh:ValidationReport node; else any sh:conforms.
+    for report in g.subjects(rdf_type, report_t):
+        v = g.value(report, p_conforms)
+        if v is not None:
+            conforms = bool(v.toPython())
+            break
+    if conforms is None:
+        for _s, _p, v in g.triples((None, p_conforms, None)):
+            conforms = bool(v.toPython())
+            break
+    if conforms is None:
+        # No explicit sh:conforms triple: derive it the way sparq does
+        # (conforms iff there are no results).
+        conforms = violations == 0
+    return {"conforms": conforms, "violations": violations}
+
+
+def main(argv):
+    """CLI: shacl_report_count.py [--format FMT] [report-file | -]  -> JSON on stdout.
+
+    Reads a validation-report graph from a file (or stdin with `-`), prints
+    {"conforms":bool,"violations":int}."""
+    fmt = "turtle"
+    args = []
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--format":
+            i += 1
+            fmt = argv[i]
+        elif a.startswith("--format="):
+            fmt = a.split("=", 1)[1]
+        else:
+            args.append(a)
+        i += 1
+    src = args[0] if args else "-"
+    if src == "-":
+        text = sys.stdin.read()
+    else:
+        with open(src, "r", encoding="utf-8") as fh:
+            text = fh.read()
+    import json
+
+    try:
+        out = count_report(text, fmt=fmt)
+    except Exception as e:  # noqa: BLE001 — adapter boundary: report + non-zero exit
+        sys.stderr.write("shacl_report_count: parse error: %s\n" % e)
+        return 1
+    json.dump(out, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/bench-adapters/test_adapters.py
+++ b/scripts/bench-adapters/test_adapters.py
@@ -63,6 +63,14 @@ def test_http():
     except ValueError:
         check("http.bad-doc-raises", True, True)
 
+    # [OPUS-4.8] A non-boolean "boolean" member (e.g. the string "false") is an
+    # invalid SPARQL-JSON ASK result and must be rejected, not coerced via bool().
+    try:
+        http.parse_sparql_json('{"head":{},"boolean":"false"}')
+        check("http.non-bool-boolean-raises", False, True)
+    except ValueError:
+        check("http.non-bool-boolean-raises", True, True)
+
 
 # --- vector recall scoring ---------------------------------------------------
 def test_vector():

--- a/scripts/bench-adapters/test_adapters.py
+++ b/scripts/bench-adapters/test_adapters.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] sq-eifd: unit tests for the bench-adapter parsers. Authored by Opus
+# 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# FIXTURE-based parser tests that DO NOT need a live engine:
+#   - shacl_report_count : parse a SHACL ValidationReport graph -> (conforms, viol)
+#   - http_sparql_adapter.parse_sparql_json : SELECT / ASK / COUNT(*) reductions
+#   - vector_lib_adapter.recall_at_k + parse_neighbour_tsv : recall scoring + deficit
+# shacl_report_count's test needs rdflib (the SHACL report parser's only dep); if
+# rdflib is absent that one test SKIPS (the http + vector tests are stdlib-only and
+# always run). Run with the venv that has rdflib for full coverage:
+#   /tmp/sq-eifd-venv/bin/python scripts/bench-adapters/test_adapters.py
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+FIX = os.path.join(HERE, "fixtures")
+
+import http_sparql_adapter as http  # noqa: E402
+import vector_lib_adapter as vec  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, got, want):
+    global PASS, FAIL
+    if got == want:
+        PASS += 1
+        print("ok   %-46s = %r" % (name, got))
+    else:
+        FAIL += 1
+        print("FAIL %-46s got %r want %r" % (name, got, want))
+
+
+def approx(name, got, want, tol=1e-6):
+    check(name, abs(got - want) < tol, True)
+
+
+# --- http-sparql SPARQL-JSON parser -----------------------------------------
+def test_http():
+    with open(os.path.join(FIX, "sparql_select.json")) as f:
+        sel = http.parse_sparql_json(f.read())
+    check("http.select.count", sel["count"], 3)
+    check("http.select.boolean", sel["boolean"], None)
+    # 2-var rows are not a COUNT(*) wrap -> no scalar extracted
+    check("http.select.count_value", sel["count_value"], None)
+
+    with open(os.path.join(FIX, "sparql_count.json")) as f:
+        cnt = http.parse_sparql_json(f.read())
+    check("http.count.count", cnt["count"], 1)
+    check("http.count.count_value", cnt["count_value"], "3")
+
+    with open(os.path.join(FIX, "sparql_ask.json")) as f:
+        ask = http.parse_sparql_json(f.read())
+    check("http.ask.count", ask["count"], 1)
+    check("http.ask.boolean", ask["boolean"], True)
+
+    try:
+        http.parse_sparql_json('{"head":{}}')
+        check("http.bad-doc-raises", False, True)
+    except ValueError:
+        check("http.bad-doc-raises", True, True)
+
+
+# --- vector recall scoring ---------------------------------------------------
+def test_vector():
+    with open(os.path.join(FIX, "knn_approx.tsv")) as f:
+        approx_map = vec.parse_neighbour_tsv(f.read())
+    with open(os.path.join(FIX, "knn_exact.tsv")) as f:
+        exact_map = vec.parse_neighbour_tsv(f.read())
+    check("vec.parse.nqueries", len(approx_map), 3)
+    recall, n = vec.recall_at_k(approx_map, exact_map, 4)
+    check("vec.recall.nqueries", n, 3)
+    approx("vec.recall@4", recall, 11.0 / 12.0)
+    check("vec.recall_deficit_milli", vec.recall_deficit_milli(recall), 83)
+    # perfect recall -> deficit 0
+    perfect, _ = vec.recall_at_k(exact_map, exact_map, 4)
+    check("vec.recall@4.perfect", vec.recall_deficit_milli(perfect), 0)
+    # disjoint query ids must raise (catch a mis-aligned fixture loudly)
+    try:
+        vec.recall_at_k({"zz": ["1"]}, {"yy": ["1"]}, 4)
+        check("vec.disjoint-raises", False, True)
+    except ValueError:
+        check("vec.disjoint-raises", True, True)
+
+
+# --- shacl report-count parser (needs rdflib) --------------------------------
+def test_shacl():
+    try:
+        import rdflib  # noqa: F401
+    except ImportError:
+        print("skip shacl_report_count tests (rdflib not installed in this python)")
+        return
+    import shacl_report_count as src
+
+    # A minimal non-conforming report: 2 results + sh:conforms false.
+    report = """
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    [] a sh:ValidationReport ;
+       sh:conforms false ;
+       sh:result [ a sh:ValidationResult ;
+                   sh:sourceConstraintComponent sh:MinCountConstraintComponent ] ;
+       sh:result [ a sh:ValidationResult ;
+                   sh:sourceConstraintComponent sh:DatatypeConstraintComponent ] .
+    """
+    r = src.count_report(report, fmt="turtle")
+    check("shacl.report.violations", r["violations"], 2)
+    check("shacl.report.conforms", r["conforms"], False)
+
+    conforming = """
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    [] a sh:ValidationReport ; sh:conforms true .
+    """
+    rc = src.count_report(conforming, fmt="turtle")
+    check("shacl.report.conforming.violations", rc["violations"], 0)
+    check("shacl.report.conforming.conforms", rc["conforms"], True)
+
+
+def main():
+    test_http()
+    test_vector()
+    test_shacl()
+    print("\n%d passed, %d failed" % (PASS, FAIL))
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench-adapters/vector_lib_adapter.py
+++ b/scripts/bench-adapters/vector_lib_adapter.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] sq-eifd: PYTHON-LIB (vector-lib) adapter KIND. Authored by Opus 4.8
+# (Fable unavailable; flag for re-review when Fable returns).
+#
+# In-process, cross-language ANN harness — the vector analogue of the embedded-Rust
+# Oxigraph model, but Python. Covers FAISS / hnswlib / Lucene-via-Anserini
+# (research/capability-benchmark-program.md §3.3 + G3 `python-lib`). The deliverable
+# shape: build index -> query -> emit recall@k + latency TSV + an EXACT-kNN
+# correctness oracle (G4 — ANN is approximate, so the gate is recall vs exact-kNN,
+# not a row-count diff).
+#
+# TWO pieces, separable so the gather box can run the heavy half and CI can unit-
+# test the light half:
+#   1. recall_at_k(approx_ids, exact_ids, k)  — the SCORING/ORACLE. Pure function:
+#      mean over queries of |approx_topk ∩ exact_topk| / k. This is fixture-unit-
+#      tested (a captured neighbour TSV) WITHOUT FAISS/hnswlib installed.
+#   2. exact_knn / run_hnswlib — the heavy harness: build the index, query, compute
+#      the exact-kNN ground truth with numpy (the oracle), emit recall@k + latency.
+#      Requires numpy (+ hnswlib for the ANN engine); gather-only.
+#
+# Output: `<engine>\t<recall_deficit_milli>\t<query_us>` TSV on stdout, where
+# recall_deficit_milli = round((1 - recall@k) * 1000) — emitted as a DEFICIT so it
+# slots into the smaller-is-better mode:"auto" ratchet with zero perf-gate change
+# (the G4 trick). --json carries the raw recall + k for the dashboard.
+#
+# NEIGHBOUR-TSV format (what an external ANN tool dumps, and the fixture format):
+#   one line per query: `<query_id>\t<id1>,<id2>,...,<idk>`  (ranked neighbour ids).
+# recall_at_k consumes two such maps (approx + exact) and scores them.
+import json
+import sys
+import time
+
+
+def parse_neighbour_tsv(text):
+    """`<qid>\\t<csv of ranked neighbour ids>` per line -> {qid: [ids...]}.
+
+    Blank lines and `#`-comments are skipped. Ids are kept as strings (ids may be
+    dict-encoded entity ids in sparq's case)."""
+    out = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) != 2:
+            raise ValueError("bad neighbour-tsv line: %r" % line)
+        qid, ids = parts
+        out[qid] = [t for t in ids.split(",") if t != ""]
+    return out
+
+
+def recall_at_k(approx, exact, k):
+    """Mean recall@k of `approx` vs the `exact` ground truth (both {qid:[ids]}).
+
+    recall@k for a query = |approx[:k] ∩ exact[:k]| / k, averaged over the queries
+    present in BOTH maps. Returns (recall: float, n_queries: int). Raises if there
+    is no overlapping query (so a mis-aligned fixture fails loudly, not silently
+    as recall 0)."""
+    qids = [q for q in exact if q in approx]
+    if not qids:
+        raise ValueError("no query ids common to approx and exact neighbour sets")
+    total = 0.0
+    for q in qids:
+        a = set(approx[q][:k])
+        e = set(exact[q][:k])
+        denom = min(k, len(e)) or 1
+        total += len(a & e) / denom
+    return total / len(qids), len(qids)
+
+
+def recall_deficit_milli(recall):
+    """(1 - recall) scaled to integer milli-units — the smaller-is-better metric
+    the mode:"auto" ratchet wants (G4)."""
+    return int(round((1.0 - recall) * 1000))
+
+
+# --- heavy harness (gather-only; needs numpy [+ hnswlib]) --------------------
+def exact_knn(data, queries, k):
+    """numpy exact L2 kNN ground truth -> {qid:[ids]} with qid/ids as str(index)."""
+    import numpy as np  # local import: oracle is gather-only
+
+    data = np.asarray(data, dtype="float32")
+    queries = np.asarray(queries, dtype="float32")
+    out = {}
+    for qi, q in enumerate(queries):
+        d = ((data - q) ** 2).sum(axis=1)
+        idx = np.argsort(d)[:k]
+        out[str(qi)] = [str(int(i)) for i in idx]
+    return out
+
+
+def run_hnswlib(data, queries, k, ef=64, m=16, ef_construction=200):
+    """Build an hnswlib index, query top-k, time it -> ({qid:[ids]}, query_us)."""
+    import hnswlib  # local import: gather-only
+    import numpy as np
+
+    data = np.asarray(data, dtype="float32")
+    queries = np.asarray(queries, dtype="float32")
+    dim = data.shape[1]
+    index = hnswlib.Index(space="l2", dim=dim)
+    index.init_index(max_elements=len(data), ef_construction=ef_construction, M=m)
+    index.add_items(data, list(range(len(data))))
+    index.set_ef(ef)
+    t0 = time.perf_counter()
+    labels, _ = index.knn_query(queries, k=k)
+    query_us = (time.perf_counter() - t0) * 1e6 / max(1, len(queries))
+    approx = {str(qi): [str(int(i)) for i in row] for qi, row in enumerate(labels)}
+    return approx, int(round(query_us))
+
+
+def main(argv):
+    """CLI:
+      vector_lib_adapter.py --score --approx <tsv> --exact <tsv> --k K [--engine N]
+            offline: score two neighbour TSVs (fixture-testable, no numpy/hnswlib).
+      vector_lib_adapter.py --hnswlib --npz <file.npz> --k K [--engine N]
+            heavy: build hnswlib index over npz {data,queries}, score vs exact-kNN.
+    Emits `<engine>\\t<recall_deficit_milli>\\t<query_us>`; --json adds raw recall."""
+    mode = None
+    approx_f = exact_f = npz_f = None
+    k = 10
+    engine = "engine"
+    want_json = False
+    query_us = 0
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--score":
+            mode = "score"
+        elif a == "--hnswlib":
+            mode = "hnswlib"
+        elif a == "--approx":
+            i += 1
+            approx_f = argv[i]
+        elif a == "--exact":
+            i += 1
+            exact_f = argv[i]
+        elif a == "--npz":
+            i += 1
+            npz_f = argv[i]
+        elif a == "--k":
+            i += 1
+            k = int(argv[i])
+        elif a == "--engine":
+            i += 1
+            engine = argv[i]
+        elif a == "--json":
+            want_json = True
+        else:
+            sys.stderr.write("vector_lib_adapter: unknown arg %s\n" % a)
+            return 2
+        i += 1
+
+    try:
+        if mode == "score":
+            if not (approx_f and exact_f):
+                raise ValueError("--score needs --approx <tsv> --exact <tsv>")
+            with open(approx_f, encoding="utf-8") as fh:
+                approx = parse_neighbour_tsv(fh.read())
+            with open(exact_f, encoding="utf-8") as fh:
+                exact = parse_neighbour_tsv(fh.read())
+            recall, _n = recall_at_k(approx, exact, k)
+        elif mode == "hnswlib":
+            import numpy as np
+
+            if not npz_f:
+                raise ValueError("--hnswlib needs --npz <file.npz {data,queries}>")
+            npz = np.load(npz_f)
+            approx, query_us = run_hnswlib(npz["data"], npz["queries"], k)
+            exact = exact_knn(npz["data"], npz["queries"], k)
+            recall, _n = recall_at_k(approx, exact, k)
+        else:
+            sys.stderr.write("vector_lib_adapter: pick --score or --hnswlib\n")
+            return 2
+    except Exception as e:  # noqa: BLE001 — adapter boundary
+        sys.stderr.write("vector_lib_adapter: %s\n" % e)
+        return 1
+
+    sys.stdout.write("%s\t%d\t%d\n" % (engine, recall_deficit_milli(recall), query_us))
+    if want_json:
+        sys.stderr.write(
+            json.dumps({"engine": engine, "recall_at_k": recall, "k": k, "query_us": query_us})
+            + "\n"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/gather-competitors.sh
+++ b/scripts/gather-competitors.sh
@@ -15,7 +15,13 @@
 #                          Heavy. Caps dataset size, watches `df`, cleans /tmp.
 #
 # Engines: oxigraph (embedded Rust dep) | qlever (Docker) | eye (N3 binary).
-# Select with --only <id[,id...]>; default is all THREE in dry-run, but --run
+# Plus four SHARED reusable adapter KINDS (sq-eifd), dispatched off competitors.json
+# `kind` and backed by scripts/bench-adapters/:
+#   report-cli  : file-in/SHACL-report-out CLI (pySHACL, Jena `shacl validate`)
+#   js-lib      : in-process Node/RDF-JS SHACL (rdf-validate-shacl, sparq's own WASM)
+#   http-sparql : POST query -> parse SPARQL-JSON -> count (Fuseki, Virtuoso, QLever)
+#   vector-lib  : in-process Python ANN -> recall@k vs exact-kNN (FAISS, hnswlib)
+# Select with --only <id[,id...]>; default is all engines in dry-run, but --run
 # requires you to NAME the engines (no accidental "run everything heavy").
 #
 # Usage:
@@ -64,6 +70,10 @@ cd "$REPO_ROOT"
 
 REGISTRY="bench/competitors.json"
 RESULTS_DIR="bench/competitor-results"
+# [OPUS-4.8] sq-eifd: shared external-engine adapter KINDS live here. Each kind is
+# a small parser/harness reused across engines; dispatch is off competitors.json's
+# `kind` field (see the "adapter-kind dispatch" section below).
+ADAPTERS_DIR="scripts/bench-adapters"
 
 # --- defaults / knobs --------------------------------------------------------
 DO_RUN=0                 # 0 = dry-run (safe default); 1 = actually run
@@ -343,6 +353,131 @@ if want qlever; then
     write_result qlever "qlever-${SUITE}-${PASS}" "$Q_DIGEST" "$PAYLOAD"
     check_df
   fi
+fi
+
+# =============================================================================
+# adapter-kind dispatch (sq-eifd) — the SHARED reusable kinds, dispatched off the
+# competitors.json `kind` field instead of one bespoke recipe per engine.
+#
+#   report-cli   : file-in / SHACL-validation-report-out CLI (pySHACL, Jena
+#                  `shacl validate`, TopBraid). Shared report->count parser
+#                  (count sh:result, read sh:conforms) so #violations is directly
+#                  comparable to sparq's report.results.len().  [REQUIRED by sq-7iai]
+#   js-lib       : in-process Node/RDF-JS harness (rdf-validate-shacl, shacl-engine,
+#                  sparq's own @jeswr/sparq WASM SHACL) — same count semantics.
+#   http-sparql  : POST query -> parse SPARQL-JSON -> count (Fuseki/Virtuoso + the
+#                  QLever HTTP path). End-to-end gather-only (needs a live server);
+#                  parser fixture-verified here.
+#   vector-lib   : in-process Python ANN harness (FAISS/hnswlib) — recall@k vs an
+#                  exact-kNN oracle, recall-deficit TSV. End-to-end gather-only
+#                  (needs numpy/hnswlib); recall scorer fixture-verified here.
+#
+# Each new-kind registry entry carries an `adapter` object (the recipe). The gather
+# box installs the (gather-only, NOT committed) engine and supplies the data/shapes
+# (or endpoint/dataset) via the flags below. Per AGENTS.md the engines + the
+# resulting numbers stay OUT of git — this dispatch just runs the shared harness and
+# writes a git-ignored results file like the other kinds.
+#
+# Env inputs (per-kind; only consulted under --run):
+#   report-cli / js-lib : SHACL_DATA + SHACL_SHAPES (paths to the data+shapes graphs)
+#   http-sparql         : SPARQL_ENDPOINT + SPARQL_QUERY_FILE
+#   vector-lib          : VECTOR_NPZ (npz with {data,queries}) [hnswlib mode]
+# =============================================================================
+adapter_kind_of() { # adapter_kind_of <id> -> the engine's `kind` from the registry
+  have jq || { echo ""; return; }
+  # `first(...)` so we emit EXACTLY one line (the matching engine's kind), not one
+  # empty line per non-matching competitor.
+  jq -r --arg id "$1" 'first(.competitors[]|select(.id==$id)).kind // ""' "$REGISTRY"
+}
+adapter_recipe_of() { # the engine's `.adapter` recipe object as compact JSON
+  have jq || { echo "{}"; return; }
+  jq -c --arg id "$1" 'first(.competitors[]|select(.id==$id)).adapter // {}' "$REGISTRY"
+}
+
+run_report_cli_engine() { # <id>
+  local id="$1" recipe; recipe="$(adapter_recipe_of "$id")"
+  hdr "$id (report-cli)"
+  log "  shared report->count parser: $ADAPTERS_DIR/shacl_report_count.py (count sh:result, read sh:conforms)"
+  log "  recipe: $recipe"
+  if [ "$DO_RUN" -eq 1 ]; then
+    have python3 || die "python3 needed for the report-cli adapter"
+    python3 -c 'import rdflib' 2>/dev/null || die "report-cli adapter needs rdflib (pip install rdflib)"
+    { [ -n "${SHACL_DATA:-}" ] && [ -n "${SHACL_SHAPES:-}" ]; } || die "report-cli --run needs SHACL_DATA + SHACL_SHAPES"
+    OUT="$(python3 "$ADAPTERS_DIR/report_cli_adapter.py" --recipe "$recipe" \
+            --data "$SHACL_DATA" --shapes "$SHACL_SHAPES" --engine "$id" --iters "$ITERS" --json 2>/dev/null)" \
+      || die "report-cli adapter failed for $id"
+    PAYLOAD="$(printf '%s' "$OUT" | python3 -c 'import json,sys; e,v,u=sys.stdin.read().split(); print(json.dumps({"engine":e,"violations":int(v),"validate_us":int(u)}))')"
+    write_result "$id" "shacl-validate-bench" "$(jq -r --arg id "$id" 'first(.competitors[]|select(.id==$id)).pinned_version//"unknown"' "$REGISTRY")" "$PAYLOAD"
+    check_df
+  fi
+}
+
+run_js_lib_engine() { # <id>
+  local id="$1" recipe; recipe="$(adapter_recipe_of "$id")"
+  local jsengine; jsengine="$(printf '%s' "$recipe" | jq -r '.js_engine // "rdf-validate-shacl"')"
+  hdr "$id (js-lib node-rdfjs)"
+  log "  node harness: $ADAPTERS_DIR/js_shacl_adapter.mjs (engine=$jsengine; same count semantics as report-cli)"
+  if [ "$DO_RUN" -eq 1 ]; then
+    have node || die "node needed for the js-lib adapter"
+    { [ -n "${SHACL_DATA:-}" ] && [ -n "${SHACL_SHAPES:-}" ]; } || die "js-lib --run needs SHACL_DATA + SHACL_SHAPES"
+    local mdir; mdir="${JS_MODULES_DIR:-$PWD}"
+    OUT="$(node "$ADAPTERS_DIR/js_shacl_adapter.mjs" --data "$SHACL_DATA" --shapes "$SHACL_SHAPES" \
+            --engine "$jsengine" --modules-dir "$mdir" --iters "$ITERS" --json 2>/dev/null)" \
+      || die "js-lib adapter failed for $id (npm i $jsengine in $mdir?)"
+    PAYLOAD="$(printf '%s' "$OUT" | python3 -c 'import json,sys; e,v,u=sys.stdin.read().split(); print(json.dumps({"engine":e,"violations":int(v),"validate_us":int(u)}))' 2>/dev/null || printf '{"raw":"%s"}' "$OUT")"
+    write_result "$id" "shacl-validate-bench" "$jsengine" "$PAYLOAD"
+    check_df
+  fi
+}
+
+run_http_sparql_engine() { # <id>
+  local id="$1"
+  hdr "$id (http-sparql)"
+  log "  adapter: $ADAPTERS_DIR/http_sparql_adapter.py (POST query -> parse SPARQL-JSON -> count)"
+  log "  PREP (gather box): start the engine's HTTP endpoint, then set SPARQL_ENDPOINT + SPARQL_QUERY_FILE"
+  if [ "$DO_RUN" -eq 1 ]; then
+    have python3 || die "python3 needed for the http-sparql adapter"
+    { [ -n "${SPARQL_ENDPOINT:-}" ] && [ -n "${SPARQL_QUERY_FILE:-}" ]; } || die "http-sparql --run needs SPARQL_ENDPOINT + SPARQL_QUERY_FILE"
+    OUT="$(python3 "$ADAPTERS_DIR/http_sparql_adapter.py" --endpoint "$SPARQL_ENDPOINT" \
+            --query-file "$SPARQL_QUERY_FILE" --engine "$id" --iters "$ITERS" --json 2>/dev/null)" \
+      || die "http-sparql adapter failed for $id (endpoint up?)"
+    PAYLOAD="$(printf '%s' "$OUT" | python3 -c 'import json,sys; e,c,u=sys.stdin.read().split(); print(json.dumps({"engine":e,"count":int(c),"query_us":int(u)}))')"
+    write_result "$id" "http-sparql" "$(jq -r --arg id "$id" 'first(.competitors[]|select(.id==$id)).pinned_version//"unknown"' "$REGISTRY")" "$PAYLOAD"
+    check_df
+  fi
+}
+
+run_vector_lib_engine() { # <id>
+  local id="$1"
+  hdr "$id (vector-lib)"
+  log "  adapter: $ADAPTERS_DIR/vector_lib_adapter.py (build index -> query -> recall@k vs exact-kNN oracle)"
+  log "  PREP (gather box): pip install numpy hnswlib; set VECTOR_NPZ to an npz with {data,queries}"
+  if [ "$DO_RUN" -eq 1 ]; then
+    have python3 || die "python3 needed for the vector-lib adapter"
+    python3 -c 'import numpy, hnswlib' 2>/dev/null || die "vector-lib adapter needs numpy + hnswlib (pip install numpy hnswlib)"
+    [ -n "${VECTOR_NPZ:-}" ] || die "vector-lib --run needs VECTOR_NPZ (npz with {data,queries})"
+    OUT="$(python3 "$ADAPTERS_DIR/vector_lib_adapter.py" --hnswlib --npz "$VECTOR_NPZ" --k "${VECTOR_K:-10}" --engine "$id" --json 2>/dev/null)" \
+      || die "vector-lib adapter failed for $id"
+    PAYLOAD="$(printf '%s' "$OUT" | python3 -c 'import json,sys; e,d,u=sys.stdin.read().split(); print(json.dumps({"engine":e,"recall_deficit_milli":int(d),"query_us":int(u)}))')"
+    write_result "$id" "vectors-recall" "$(jq -r --arg id "$id" 'first(.competitors[]|select(.id==$id)).pinned_version//"unknown"' "$REGISTRY")" "$PAYLOAD"
+    check_df
+  fi
+}
+
+# Walk every registry engine of a SHARED-ADAPTER kind (skipping the three bespoke
+# kinds handled above) and dispatch. Engines stay empty in git, so this is a no-op
+# until a maintainer adds report-cli/js-lib/http-sparql/vector-lib entries.
+if have jq; then
+  while IFS= read -r aid; do
+    [ -n "$aid" ] || continue
+    want "$aid" || continue
+    case "$(adapter_kind_of "$aid")" in
+      report-cli)  run_report_cli_engine  "$aid" ;;
+      js-lib)      run_js_lib_engine      "$aid" ;;
+      http-sparql) run_http_sparql_engine "$aid" ;;
+      vector-lib)  run_vector_lib_engine  "$aid" ;;
+    esac
+  done < <(jq -r '.competitors[] | select(.kind=="report-cli" or .kind=="js-lib" or .kind=="http-sparql" or .kind=="vector-lib") | .id' "$REGISTRY")
 fi
 
 hdr "done"

--- a/scripts/gather-competitors.sh
+++ b/scripts/gather-competitors.sh
@@ -403,11 +403,20 @@ run_report_cli_engine() { # <id>
     have python3 || die "python3 needed for the report-cli adapter"
     python3 -c 'import rdflib' 2>/dev/null || die "report-cli adapter needs rdflib (pip install rdflib)"
     { [ -n "${SHACL_DATA:-}" ] && [ -n "${SHACL_SHAPES:-}" ]; } || die "report-cli --run needs SHACL_DATA + SHACL_SHAPES"
+    # [OPUS-4.8] The adapter's --json sidecar (stderr) carries the RESOLVED engine
+    # version + the conforms bit; capture it (not /dev/null) so the results
+    # envelope records what the engine actually reported, per the script header
+    # and the adapter design — rather than the pinned_version placeholder.
+    local errf; errf="$(mktemp)"
     OUT="$(python3 "$ADAPTERS_DIR/report_cli_adapter.py" --recipe "$recipe" \
-            --data "$SHACL_DATA" --shapes "$SHACL_SHAPES" --engine "$id" --iters "$ITERS" --json 2>/dev/null)" \
-      || die "report-cli adapter failed for $id"
-    PAYLOAD="$(printf '%s' "$OUT" | python3 -c 'import json,sys; e,v,u=sys.stdin.read().split(); print(json.dumps({"engine":e,"violations":int(v),"validate_us":int(u)}))')"
-    write_result "$id" "shacl-validate-bench" "$(jq -r --arg id "$id" 'first(.competitors[]|select(.id==$id)).pinned_version//"unknown"' "$REGISTRY")" "$PAYLOAD"
+            --data "$SHACL_DATA" --shapes "$SHACL_SHAPES" --engine "$id" --iters "$ITERS" --json 2>"$errf")" \
+      || { rm -f "$errf"; die "report-cli adapter failed for $id"; }
+    PAYLOAD="$(tail -n1 "$errf" | jq -c '{engine,version,conforms,violations,validate_us}' 2>/dev/null)"
+    rm -f "$errf"
+    [ -n "$PAYLOAD" ] || PAYLOAD="$(printf '%s' "$OUT" | python3 -c 'import json,sys; e,v,u=sys.stdin.read().split(); print(json.dumps({"engine":e,"violations":int(v),"validate_us":int(u)}))')"
+    local rcver; rcver="$(printf '%s' "$PAYLOAD" | jq -r '.version // empty' 2>/dev/null)"
+    [ -n "$rcver" ] || rcver="$(jq -r --arg id "$id" 'first(.competitors[]|select(.id==$id)).pinned_version//"unknown"' "$REGISTRY")"
+    write_result "$id" "shacl-validate-bench" "$rcver" "$PAYLOAD"
     check_df
   fi
 }
@@ -419,12 +428,21 @@ run_js_lib_engine() { # <id>
   log "  node harness: $ADAPTERS_DIR/js_shacl_adapter.mjs (engine=$jsengine; same count semantics as report-cli)"
   if [ "$DO_RUN" -eq 1 ]; then
     have node || die "node needed for the js-lib adapter"
+    have jq || die "jq needed for the js-lib adapter (to build the result payload)"
     { [ -n "${SHACL_DATA:-}" ] && [ -n "${SHACL_SHAPES:-}" ]; } || die "js-lib --run needs SHACL_DATA + SHACL_SHAPES"
     local mdir; mdir="${JS_MODULES_DIR:-$PWD}"
+    # [OPUS-4.8] Build the payload from the adapter's --json sidecar (stderr,
+    # well-formed JSON) via jq — not a python3 TSV reparse (python3 was never
+    # required for js-lib) and not a printf %s of raw $OUT (whose unescaped
+    # trailing newline/tab would emit invalid JSON and fail write_result's
+    # validation under set -euo pipefail).
+    local errf; errf="$(mktemp)"
     OUT="$(node "$ADAPTERS_DIR/js_shacl_adapter.mjs" --data "$SHACL_DATA" --shapes "$SHACL_SHAPES" \
-            --engine "$jsengine" --modules-dir "$mdir" --iters "$ITERS" --json 2>/dev/null)" \
-      || die "js-lib adapter failed for $id (npm i $jsengine in $mdir?)"
-    PAYLOAD="$(printf '%s' "$OUT" | python3 -c 'import json,sys; e,v,u=sys.stdin.read().split(); print(json.dumps({"engine":e,"violations":int(v),"validate_us":int(u)}))' 2>/dev/null || printf '{"raw":"%s"}' "$OUT")"
+            --engine "$jsengine" --modules-dir "$mdir" --iters "$ITERS" --json 2>"$errf")" \
+      || { rm -f "$errf"; die "js-lib adapter failed for $id (npm i $jsengine in $mdir?)"; }
+    PAYLOAD="$(tail -n1 "$errf" | jq -c '{engine,conforms,violations,validate_us}' 2>/dev/null)"
+    rm -f "$errf"
+    [ -n "$PAYLOAD" ] || die "js-lib adapter produced no parseable --json sidecar for $id"
     write_result "$id" "shacl-validate-bench" "$jsengine" "$PAYLOAD"
     check_df
   fi


### PR DESCRIPTION
> 🤖 SPARQ agent

Foundational bench infra (bead **sq-eifd**, P1): grows `scripts/gather-competitors.sh` from three bespoke per-engine recipes (Oxigraph / QLever / EYE) to **four reusable adapter KINDS**, dispatched off the existing `competitors.json` `kind` field. Unblocks the competitor-gather step of the SHACL (**sq-7iai**), geo (sq-tf8n), FTS (sq-ustq), and vector (sq-v02y) suites.

All new harness code lives in `scripts/bench-adapters/`. `engines`/`values` in `bench/competitors.json` stay **EMPTY** in git (AGENTS.md). The gather-only engines (pyshacl, rdf-validate-shacl, FAISS, …) are NOT committed dependencies.

## The four adapter kinds

| Kind | What it does | Engines | Verification |
|---|---|---|---|
| **`report-cli`** | file-in / SHACL-validation-report-out CLI | pySHACL, Jena `shacl validate`, TopBraid | **end-to-end** ✅ |
| **`js-lib`** (node-rdfjs) | in-process Node/RDF-JS SHACL | rdf-validate-shacl, shacl-engine, sparq's own WASM SHACL | **end-to-end** ✅ |
| **`http-sparql`** | POST query → parse SPARQL-JSON → count | Fuseki, Virtuoso, QLever | parser-only (fixtures) ⚠️ |
| **`vector-lib`** (python-lib) | build index → query → recall@k vs exact-kNN | FAISS, hnswlib | parser-only (fixtures) ⚠️ |

## Shared validation-report → count parser
`scripts/bench-adapters/shacl_report_count.py` is the contract that makes SHACL counts cross-engine comparable: **count `sh:ValidationResult`, read `sh:conforms`** — the exact semantics of sparq-shacl's `report.conforms` + `report.results.len()`. So sparq's own `--turtle` report reduces through the same function. Reuses the count contract of the diff-fuzz `pyshacl_adapter.py` (#166) rather than duplicating it. The report-cli adapter and the js-lib adapter both reduce to the same numbers via this contract.

## Cross-engine count-agreement check (the headline)
`scripts/bench-adapters/cross_check_shacl.sh` validates the committed `fixtures/{data,shapes}.ttl` with all three engines and asserts agreement. Result on this box:

```
sparq-shacl       : violations=3 conforms=False
pyshacl           : violations=3 conforms=False
rdf-validate-shacl: violations=3 conforms=false
AGREE: 3 engines all report violations=3 conforms=false
```

The JS-emitted report (N-Triples) and sparq's own (Turtle) report both re-parse through `shacl_report_count.py` to the same `(3, false)`.

## Verified vs parser-only (being honest)
- **report-cli + js-lib — END-TO-END**: run through `gather-competitors.sh --run --only pyshacl|rdf-validate-shacl` (pyshacl 0.31.0, rdf-validate-shacl via npm), each wrote a proper git-ignored results envelope with `violations:3`. Plus the cross-engine agreement above.
- **http-sparql + vector-lib — PARSER-ONLY**: standing up Fuseki/Virtuoso/FAISS needs a Docker gather box (this is an EC2 *work* box, AWS SSO expired — sq-j0wy). The SPARQL-JSON parser (SELECT/ASK/COUNT) and the recall@k scorer + recall-deficit (G4) reduction are unit-tested against committed fixtures (`fixtures/sparql_*.json`, `fixtures/knn_*.tsv`). **End-to-end follow-ups filed: sq-pjhc (http-sparql), sq-6te5 (vector-lib).**

`scripts/bench-adapters/test_adapters.py`: **18 parser unit tests pass**. `shellcheck` clean on both shell scripts.

## Landed vs beaded
- Landed: all 4 adapter kinds + dispatch wiring, shared report-count parser, fixtures + unit tests, cross-engine agreement check, pyshacl + rdf-validate-shacl registry entries.
- Beaded: sq-pjhc (http-sparql e2e Fuseki/Virtuoso), sq-6te5 (vector-lib e2e FAISS/hnswlib) — both gather-only on a Docker box.

Does not close sq-eifd. NON-CANONICAL timing (this box) — no numbers baked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)