### PR TITLE
feat(mpc): bounded property-path over disclosed-key regime (sq-py8h.1)

### DIFF
--- a/crates/sparq-mpc/src/bounded_path.rs
+++ b/crates/sparq-mpc/src/bounded_path.rs
@@ -218,6 +218,39 @@ impl DisclosedEdges {
                     part.vars.len()
                 )));
             }
+            // Soundness: the disclosed-key regime joins on GLOBAL IRIs. Both
+            // endpoints of every disclosed edge MUST be NamedNodes. A blank node
+            // would be unsound — blank-node labels are only document-scoped, so two
+            // holders emitting the same label do NOT denote the same term, yet the
+            // disclosed-key equi-join would treat equal labels as equal terms
+            // (a false cross-holder join). A literal endpoint is outside the
+            // global-IRI key regime entirely. Reject either at ingest (fail fast)
+            // rather than silently producing unsound joins (design §2.1 DISCLOSED
+            // regime boundary).
+            for row in &part.rows {
+                if row.len() != 2 {
+                    return Err(MpcError::Protocol(format!(
+                        "disclosed edge row for <{}> must have width 2; got {}",
+                        pred.as_str(),
+                        row.len()
+                    )));
+                }
+                for (col, slot) in row.iter().enumerate() {
+                    match slot {
+                        Some(Term::NamedNode(_)) => {}
+                        other => {
+                            return Err(MpcError::Protocol(format!(
+                                "disclosed edge for <{}> has a non-IRI endpoint in \
+                                 column {col} ({other:?}); the disclosed-key regime \
+                                 requires global-IRI (NamedNode) endpoints — blank \
+                                 nodes are document-scoped (unsound to join across \
+                                 holders) and literals are out of regime",
+                                pred.as_str()
+                            )));
+                        }
+                    }
+                }
+            }
             // Re-key onto the canonical (?__pp_edge_s, ?__pp_edge_o) schema so the
             // holder's chosen variable names cannot influence the join.
             let rekeyed = PartialResult {
@@ -376,8 +409,13 @@ fn eval_repetition(
 fn alternation_chains(step: &PathStep, length: usize) -> Vec<Vec<NamedNode>> {
     let mut chains: Vec<Vec<NamedNode>> = vec![Vec::new()];
     for _ in 0..length {
-        let mut next: Vec<Vec<NamedNode>> =
-            Vec::with_capacity(chains.len() * step.alternatives.len());
+        // Grow the chain set WITHOUT a `chains.len() * alternatives.len()`
+        // `with_capacity`: that product is `alternatives^length`, which can
+        // overflow `usize` or request an enormous allocation for large unrolls,
+        // turning a should-be-controlled protocol error into a panic/abort on a
+        // public API surface. Let the `Vec` grow amortised instead; any genuine
+        // unroll-size limit belongs to a higher-level guard, not here.
+        let mut next: Vec<Vec<NamedNode>> = Vec::new();
         for prefix in &chains {
             for alt in &step.alternatives {
                 let mut extended = prefix.clone();
@@ -434,7 +472,7 @@ fn eval_fixed_chain(
     }
 
     // Project onto (subject, object), dropping the intermediate columns.
-    Ok(project_endpoints(&acc, subject, object))
+    project_endpoints(&acc, subject, object)
 }
 
 /// `f1 / f2 / ... / fn` → relational composition of the sub-forms' pair
@@ -481,33 +519,51 @@ fn eval_sequence(
             key_disclosed: true,
         };
         acc = join.join(&[acc_dedup, part_rel], &plan)?;
-        acc = project_endpoints(&acc, subject, &this_end);
+        acc = project_endpoints(&acc, subject, &this_end)?;
         prev_end = this_end;
     }
 
-    Ok(project_endpoints(&acc, subject, object))
+    project_endpoints(&acc, subject, object)
 }
 
 /// Project a partial onto exactly `[subject, object]`, dropping every other
-/// (intermediate) column. The endpoint vars must be present.
-fn project_endpoints(part: &PartialResult, subject: &Variable, object: &Variable) -> PartialResult {
+/// (intermediate) column. Both endpoint vars MUST be present: this is an
+/// internal-invariant projection (the unroller always constructs relations that
+/// carry the endpoint columns it asks to project), so a missing endpoint var
+/// indicates a logic/protocol violation inside this module — NOT a "no results"
+/// situation. We FAIL FAST with a Protocol error rather than silently returning
+/// an empty relation, which would mask the bug by turning it into "no path
+/// found" and undermine soundness reasoning.
+fn project_endpoints(
+    part: &PartialResult,
+    subject: &Variable,
+    object: &Variable,
+) -> Result<PartialResult, MpcError> {
     let s_idx = part.vars.iter().position(|v| v == subject);
     let o_idx = part.vars.iter().position(|v| v == object);
-    let rows = match (s_idx, o_idx) {
-        (Some(si), Some(oi)) => part
-            .rows
-            .iter()
-            .map(|r| vec![r[si].clone(), r[oi].clone()])
-            .collect(),
-        // A degenerate single-endpoint relation (not expected on the disclosed
-        // endpoint-pair path) — keep nothing rather than guess a schema.
-        _ => Vec::new(),
+    let (si, oi) = match (s_idx, o_idx) {
+        (Some(si), Some(oi)) => (si, oi),
+        _ => {
+            return Err(MpcError::Protocol(format!(
+                "project_endpoints: endpoint var(s) missing from relation schema \
+                 (subject {subject:?} present: {}, object {object:?} present: {}; \
+                 actual vars: {:?}) — internal unroll invariant violated",
+                s_idx.is_some(),
+                o_idx.is_some(),
+                part.vars
+            )));
+        }
     };
-    PartialResult {
+    let rows = part
+        .rows
+        .iter()
+        .map(|r| vec![r[si].clone(), r[oi].clone()])
+        .collect();
+    Ok(PartialResult {
         holder: HolderId::new("federation"),
         vars: vec![subject.clone(), object.clone()],
         rows,
-    }
+    })
 }
 
 /// DEDUP the endpoint pairs to a SET (design §2.2/§2.5): each distinct `(a,b)`
@@ -520,15 +576,20 @@ fn dedup_endpoint_pairs(
     subject: &Variable,
     object: &Variable,
 ) -> PartialResult {
+    // Compute each row's canonical key ONCE (one allocation per row), then use it
+    // for both dedup and ordering. The previous `sort_by` re-`format!`-ed both
+    // operands on every comparison — O(n log n) string allocations — which gets
+    // expensive on large result sets; keying first is O(n) allocations.
     let mut seen: BTreeSet<String> = BTreeSet::new();
-    let mut rows: Vec<Vec<Option<Term>>> = Vec::new();
+    let mut keyed: Vec<(String, Vec<Option<Term>>)> = Vec::new();
     for row in part.rows {
         let key = format!("{row:?}");
-        if seen.insert(key) {
-            rows.push(row);
+        if seen.insert(key.clone()) {
+            keyed.push((key, row));
         }
     }
-    rows.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
+    keyed.sort_by(|a, b| a.0.cmp(&b.0));
+    let rows: Vec<Vec<Option<Term>>> = keyed.into_iter().map(|(_, row)| row).collect();
     PartialResult {
         holder: HolderId::new("federation"),
         vars: vec![subject.clone(), object.clone()],

--- a/crates/sparq-mpc/src/bounded_path.rs
+++ b/crates/sparq-mpc/src/bounded_path.rs
@@ -52,7 +52,11 @@
 //!   exactly once after dedup.
 //! - **alternation** `(p1|p2|...)` per hop — each hop position expands over its
 //!   alternatives; a length-`ℓ` chain of an `a`-way alternation unrolls to `a^ℓ`
-//!   fixed chains (design §2.4), all unioned and deduped.
+//!   fixed chains (design §2.4), all unioned and deduped. Because that count is
+//!   exponential in the PUBLIC bound, the unroller refuses any repetition whose
+//!   projected chain count exceeds [`MAX_UNROLL_CHAINS`] (a controlled
+//!   `MpcError::Protocol`, checked BEFORE any allocation), so a large public
+//!   `{m,k}`/alternation cannot become a CPU/memory denial-of-service.
 //!
 //! Composition: a [`BoundedRepetition`] is a repetition `{m,k}` of a single
 //! [`PathStep`] (a named predicate or an alternation of named predicates); a
@@ -162,6 +166,51 @@ impl PathForm {
     pub fn sequence(preds: impl IntoIterator<Item = NamedNode>) -> Self {
         PathForm::Sequence(preds.into_iter().map(|p| PathForm::exact(p, 1)).collect())
     }
+}
+
+/// Maximum number of fixed-length BGP chains a single bounded repetition may
+/// unroll to before we refuse the path with [`MpcError::Protocol`]. `[OPUS-4.8]`
+///
+/// A repetition `(step){m,k}` over an `a`-way alternation unrolls to
+/// `Σ_{ℓ=m..=k} a^ℓ` fixed chains (design §2.4). That sum is **exponential in `k`**
+/// and **polynomial-of-degree-`k` in `a`**, so a modest-looking public bound — e.g.
+/// a 4-way alternation with `k = 16` — already projects to billions of chains.
+/// Each chain is then evaluated as a multi-hop join fold, so an unchecked unroll is
+/// a CPU/memory denial-of-service on this **public** API surface (the reviewer's
+/// `alternatives^length` blowup). Because the bound `k` and the alternation arity
+/// are PUBLIC plan parameters (design §1.2/§4.1), the projected chain count is
+/// computable in closed form WITHOUT touching any holder data — so we can reject an
+/// over-cap path *before* allocating or evaluating anything.
+///
+/// The cap is a deliberately generous-but-finite ceiling: large enough that every
+/// realistic disclosed-key bounded path (small `k`, small alternations) passes, far
+/// below the point where the chain set would exhaust memory. It is a protocol
+/// guard, not a tuning knob; a query that exceeds it is malformed/abusive for this
+/// regime, not merely slow.
+pub const MAX_UNROLL_CHAINS: u64 = 1 << 20; // 1_048_576
+
+/// Closed-form count of fixed-length chains a single `(step){m,k}` repetition
+/// unrolls to: `Σ_{ℓ=m..=k} a^ℓ` where `a = alternatives.len()` (length-0 adds the
+/// reflexive identity arm, which is NOT a chain — it is handled separately — so it
+/// contributes nothing here). Returns `None` on `u64` overflow so the caller can
+/// reject the path with a controlled error instead of risking a wrapping/huge
+/// allocation. `[OPUS-4.8]`
+fn projected_chain_count(alternatives: usize, min: usize, max: usize) -> Option<u64> {
+    let a = alternatives as u64;
+    let mut total: u64 = 0;
+    for length in min..=max {
+        if length == 0 {
+            // The reflexive identity arm is not an unrolled chain.
+            continue;
+        }
+        // a^length, checked.
+        let mut term: u64 = 1;
+        for _ in 0..length {
+            term = term.checked_mul(a)?;
+        }
+        total = total.checked_add(term)?;
+    }
+    Some(total)
 }
 
 /// Reserved subject-end variable name the unroller projects onto (`?__pp_a`).
@@ -375,6 +424,33 @@ fn eval_repetition(
         ));
     }
 
+    // UNROLL-SIZE GUARD (sq-py8h.1, reviewer thread): `(step){m,k}` over an
+    // `a`-way alternation unrolls to `Σ_{ℓ=m..=k} a^ℓ` fixed chains, which is
+    // exponential in the PUBLIC bound `k`. Compute that projected chain count in
+    // closed form FIRST (no holder data touched, no allocation) and reject an
+    // over-cap path with a controlled `MpcError::Protocol` *before* generating or
+    // evaluating any chain — otherwise a large public `{m,k}`/alternation is a
+    // CPU/memory DoS (huge `Vec` growth, or a `usize` overflow in a `with_capacity`)
+    // on this public API surface. `[OPUS-4.8]`
+    let projected = projected_chain_count(rep.step.alternatives.len(), rep.min, rep.max);
+    match projected {
+        Some(count) if count <= MAX_UNROLL_CHAINS => {}
+        _ => {
+            return Err(MpcError::Protocol(format!(
+                "bounded path {{{},{}}} over a {}-way alternation would unroll to {} \
+                 fixed chains, exceeding the MAX_UNROLL_CHAINS cap of {} — refusing \
+                 to evaluate (would be a CPU/memory denial-of-service)",
+                rep.min,
+                rep.max,
+                rep.step.alternatives.len(),
+                projected
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "an amount that overflows u64".to_string()),
+                MAX_UNROLL_CHAINS,
+            )));
+        }
+    }
+
     // Accumulate the union of all chain lengths as raw (a,b) rows; dedup happens
     // once at the top.
     let mut union_rows: Vec<Vec<Option<Term>>> = Vec::new();
@@ -413,8 +489,10 @@ fn alternation_chains(step: &PathStep, length: usize) -> Vec<Vec<NamedNode>> {
         // `with_capacity`: that product is `alternatives^length`, which can
         // overflow `usize` or request an enormous allocation for large unrolls,
         // turning a should-be-controlled protocol error into a panic/abort on a
-        // public API surface. Let the `Vec` grow amortised instead; any genuine
-        // unroll-size limit belongs to a higher-level guard, not here.
+        // public API surface. Let the `Vec` grow amortised instead. The genuine
+        // unroll-size limit is enforced upstream by `eval_repetition`'s
+        // `MAX_UNROLL_CHAINS` guard (which runs BEFORE this function is reached),
+        // so by the time we get here the total chain count is provably bounded.
         let mut next: Vec<Vec<NamedNode>> = Vec::new();
         for prefix in &chains {
             for alt in &step.alternatives {

--- a/crates/sparq-mpc/src/bounded_path.rs
+++ b/crates/sparq-mpc/src/bounded_path.rs
@@ -1,0 +1,540 @@
+// [OPUS-4.8] sq-py8h.1 — bounded property-path over DISCLOSED global-IRI keys.
+//! Bounded-length SPARQL property paths over **disclosed global-IRI keys**
+//! (the crypto-free, "headline federation" regime).
+//!
+//! ## What this is — and the regime boundary (read first)
+//!
+//! This module resolves **increment #1** of the bounded property-path design
+//! (`research/mpc-bounded-property-path-design.md` §6 step 1, §2.1 DISCLOSED
+//! regime). It evaluates a **bounded** path `?a (p){m,k} ?b` whose endpoints AND
+//! intermediate join keys are **disclosed global IRIs** by *unrolling* the
+//! bounded path — statically, on the PUBLIC bound `k` — into a finite set of
+//! fixed-length BGP chains, evaluating each chain as a left-to-right fold of the
+//! existing [`crate::join::DisclosedKeyJoin`], then UNION-ing and DEDUP-ing the
+//! endpoint pairs.
+//!
+//! Because the join key on every hop is a disclosed global IRI, the whole
+//! computation runs **OUTSIDE the cryptographic core** (architecture convention
+//! #4; design §2.1 DISCLOSED regime): it is a plaintext fold of equi-joins, the
+//! *exact* construction the `differential_three_holder_chain_equals_union` test
+//! in [`crate::join`] already exercises for a single 3-pattern chain — here
+//! generalised to a *bounded path* (a union of chains, one per length in
+//! `m..=k`). **NO MPC primitive runs; NO secret sharing; NO MPC round occurs.**
+//! It is crypto-free, and the differential tests assert that explicitly.
+//!
+//! ### Regime boundary (stated, not hidden) — disclosed-key ONLY
+//!
+//! This is the **DISCLOSED-KEY** regime: every endpoint and every intermediate
+//! node `?z_i` on the chain is a disclosed global IRI, so nothing enters an MPC.
+//! It does **NOT** support the HIDDEN-intermediate regime (where the `?z_i` are
+//! secret and the per-hop match must stay secret-shared via `secure_equal` /
+//! `degree_reduce` / `oblivious_set_output`). That is the separate, cryptographic
+//! deliverable **sq-py8h.2** (design §2.1 HIDDEN regime, §6 step 2), which THIS
+//! bead blocks. Do not read disclosed-key bounded-path support as hidden-path
+//! support.
+//!
+//! ### Semantic boundary (the bound is a real SPARQL construct, not an approx)
+//!
+//! The operator implements the *bounded* path `{m,k}` exactly — a well-defined
+//! SPARQL 1.1 construct. It is NOT the unbounded `(p)+`/`(p)*` closure; a pair
+//! connected only by a chain of length `> k` is (correctly, by definition of the
+//! bounded form) absent. The differential oracle is the clear-text engine's
+//! `eval_path` over the *union* store evaluating the **same bounded form**
+//! (`p{m,k}`), so the equality is exact, not an approximation (design §1.2).
+//!
+//! ## Supported path forms (the acceptance matrix)
+//!
+//! - **sequence** `p1/p2/.../pk` — one fixed BGP chain ([`PathForm::Sequence`]).
+//! - **exact** `(p){k}` — one fixed `k`-hop chain ([`BoundedRepetition`] `m==k`).
+//! - **range** `(p){m,k}` — UNION of the exactly-`ℓ` chains for `ℓ in m..=k`.
+//! - **reflexive** `(p){0,k}` — the `{1,k}` union PLUS the length-0 identity pairs
+//!   `(x,x)` over the node set in scope (design §2.3); the identity pairs appear
+//!   exactly once after dedup.
+//! - **alternation** `(p1|p2|...)` per hop — each hop position expands over its
+//!   alternatives; a length-`ℓ` chain of an `a`-way alternation unrolls to `a^ℓ`
+//!   fixed chains (design §2.4), all unioned and deduped.
+//!
+//! Composition: a [`BoundedRepetition`] is a repetition `{m,k}` of a single
+//! [`PathStep`] (a named predicate or an alternation of named predicates); a
+//! [`PathForm::Sequence`] is a fixed sequence of such forms each with its own
+//! bound, distributed into the chain set. Endpoint-pair DEDUP is by the
+//! `(a,b)` term pair (set semantics for path endpoints, design §2.2/§2.5) — the
+//! realized length is NEVER part of the output (design §1.2 length-revealing
+//! prohibition), so a pair reached by two different lengths appears once.
+
+use crate::join::{DisclosedKeyJoin, GlobalJoin, JoinPlan};
+use crate::partial::{HolderId, MpcError, PartialResult};
+use oxrdf::{NamedNode, Term, Variable};
+use std::collections::BTreeSet;
+
+/// One hop of a bounded path: a single predicate, or an ALTERNATION of
+/// predicates (`p1 | p2 | ...`). Each alternative is a disclosed global-IRI
+/// predicate. A bare predicate is `alternatives.len() == 1`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathStep {
+    /// The predicate IRIs this hop may traverse (one = a plain `p`, many = an
+    /// alternation `p1|p2|...`). Must be non-empty.
+    pub alternatives: Vec<NamedNode>,
+}
+
+impl PathStep {
+    /// A single-predicate hop `p`.
+    pub fn predicate(p: NamedNode) -> Self {
+        PathStep {
+            alternatives: vec![p],
+        }
+    }
+
+    /// An alternation hop `p1 | p2 | ...`.
+    pub fn alternation(alts: impl IntoIterator<Item = NamedNode>) -> Self {
+        PathStep {
+            alternatives: alts.into_iter().collect(),
+        }
+    }
+}
+
+/// A bounded repetition of one [`PathStep`]: `(step){m,k}` with PUBLIC, finite
+/// `m <= k`. This is the core repetition unit; [`PathForm`] composes it.
+///
+/// - `(p){k}` is `m == k` (exactly-`k`).
+/// - `(p){m,k}` is the range.
+/// - `(p){0,k}` (`m == 0`) adds the length-0 reflexive identity pairs (design
+///   §2.3). `(p?)` is the special case `{0,1}`.
+///
+/// The bound is PUBLIC and part of the query plan; it is a stated parameter, not
+/// a secret (design §1.2/§4.1). An OPEN upper bound (`{m,}`, `+`, `*`) is NOT
+/// representable here by construction — `max` is a concrete `usize` — which is
+/// the point: only the bounded, tractable slice lives in this module.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundedRepetition {
+    /// The repeated step.
+    pub step: PathStep,
+    /// Minimum hop count `m` (`0` enables the reflexive identity pairs).
+    pub min: usize,
+    /// Maximum hop count `k` (PUBLIC, finite, `>= min`).
+    pub max: usize,
+}
+
+/// A bounded property-path FORM the unroller understands. Either a single
+/// bounded repetition, or a fixed sequence of bounded repetitions (`/`).
+///
+/// A pure sequence of single-predicate steps `p1/p2/.../pk` is
+/// `Sequence(vec![{p1}{1,1}, {p2}{1,1}, ...])`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PathForm {
+    /// `(step){m,k}` — a bounded repetition of one (possibly alternation) step.
+    Repetition(BoundedRepetition),
+    /// `f1 / f2 / ...` — a fixed sequence of bounded forms, joined head-to-tail.
+    /// The endpoint pairs are the relational composition of the sub-forms'
+    /// pair relations.
+    Sequence(Vec<PathForm>),
+}
+
+impl PathForm {
+    /// Exactly-`k` repetition `(p){k}` of a single predicate.
+    pub fn exact(p: NamedNode, k: usize) -> Self {
+        PathForm::Repetition(BoundedRepetition {
+            step: PathStep::predicate(p),
+            min: k,
+            max: k,
+        })
+    }
+
+    /// Range repetition `(p){m,k}` of a single predicate.
+    pub fn range(p: NamedNode, m: usize, k: usize) -> Self {
+        PathForm::Repetition(BoundedRepetition {
+            step: PathStep::predicate(p),
+            min: m,
+            max: k,
+        })
+    }
+
+    /// Range repetition `(step){m,k}` of an arbitrary (possibly alternation) step.
+    pub fn repeat_step(step: PathStep, m: usize, k: usize) -> Self {
+        PathForm::Repetition(BoundedRepetition {
+            step,
+            min: m,
+            max: k,
+        })
+    }
+
+    /// A plain sequence of single predicates `p1/p2/.../pn` (each exactly one hop).
+    pub fn sequence(preds: impl IntoIterator<Item = NamedNode>) -> Self {
+        PathForm::Sequence(preds.into_iter().map(|p| PathForm::exact(p, 1)).collect())
+    }
+}
+
+/// Reserved subject-end variable name the unroller projects onto (`?__pp_a`).
+const SUBJECT_VAR: &str = "__pp_a";
+/// Reserved object-end variable name the unroller projects onto (`?__pp_b`).
+const OBJECT_VAR: &str = "__pp_b";
+/// Prefix for the fresh intermediate join variables `?__pp_z{i}` between hops.
+const INTERMEDIATE_PREFIX: &str = "__pp_z";
+
+/// The disclosed edge-relations the unroller joins over. ONE entry per
+/// **predicate IRI** that appears anywhere in the path: the set of `(subject,
+/// object)` global-IRI pairs each holder disclosed for that predicate, already
+/// merged into a single disclosed `(?__pp_edge_s, ?__pp_edge_o)` partial per
+/// predicate (the union over holders — the federated edge set for that
+/// predicate). Because the keys are disclosed global IRIs, building this set is a
+/// plaintext union; NO MPC is involved.
+///
+/// This is the disclosed-key analogue of "the graph": the unroller never sees
+/// raw holder graphs, only these per-predicate disclosed edge relations
+/// (minimise data sharing, architecture §4.2). The `(a,b)` pairs are the headline
+/// federation case: endpoints are disclosed global IRIs.
+#[derive(Debug, Clone)]
+pub struct DisclosedEdges {
+    /// `(predicate IRI string, disclosed (?__pp_edge_s, ?__pp_edge_o) edge partial)`.
+    by_predicate: Vec<(String, PartialResult)>,
+}
+
+impl DisclosedEdges {
+    /// Build the per-predicate disclosed edge relations from each holder's
+    /// disclosed edge partials.
+    ///
+    /// `holder_edges` is one `(predicate, partial)` per holder-disclosed edge
+    /// set, where `partial.vars == [?subject_var, ?object_var]` (in that order) —
+    /// i.e. exactly what a holder gets from
+    /// `evaluate_local("SELECT ?s ?o WHERE { ?s <p> ?o }")`. Rows for the same
+    /// predicate from different holders are UNIONED (the federated edge set).
+    ///
+    /// Soundness: the subject/object variable names of each partial may differ
+    /// per holder; only the COLUMN ORDER (subject, object) is contractual, so we
+    /// re-key every edge partial onto the reserved `(?__pp_edge_s, ?__pp_edge_o)`
+    /// schema.
+    pub fn from_holder_edges(
+        holder_edges: impl IntoIterator<Item = (NamedNode, PartialResult)>,
+    ) -> Result<Self, MpcError> {
+        let edge_s = Variable::new_unchecked("__pp_edge_s");
+        let edge_o = Variable::new_unchecked("__pp_edge_o");
+        let mut by_predicate: Vec<(String, PartialResult)> = Vec::new();
+        for (pred, part) in holder_edges {
+            if part.vars.len() != 2 {
+                return Err(MpcError::Protocol(format!(
+                    "disclosed edge partial for <{}> must have exactly 2 columns \
+                     (subject, object); got {} columns",
+                    pred.as_str(),
+                    part.vars.len()
+                )));
+            }
+            // Re-key onto the canonical (?__pp_edge_s, ?__pp_edge_o) schema so the
+            // holder's chosen variable names cannot influence the join.
+            let rekeyed = PartialResult {
+                holder: part.holder.clone(),
+                vars: vec![edge_s.clone(), edge_o.clone()],
+                rows: part.rows.clone(),
+            };
+            let key = pred.as_str().to_string();
+            match by_predicate.iter_mut().find(|(k, _)| *k == key) {
+                Some((_, acc)) => acc.rows.extend(rekeyed.rows),
+                None => by_predicate.push((key, rekeyed)),
+            }
+        }
+        Ok(DisclosedEdges { by_predicate })
+    }
+
+    /// The disclosed edge relation for one predicate, projected onto a chosen
+    /// `(subject_var, object_var)` schema (so a hop can be slotted into a chain
+    /// at any position). Returns an EMPTY relation (no rows) for a predicate with
+    /// no disclosed edges — an absent predicate simply contributes nothing, which
+    /// is exactly how the clear-text engine treats it.
+    fn relation_for(
+        &self,
+        pred: &NamedNode,
+        subject: &Variable,
+        object: &Variable,
+    ) -> PartialResult {
+        let rows = self
+            .by_predicate
+            .iter()
+            .find(|(k, _)| k == pred.as_str())
+            .map(|(_, p)| p.rows.clone())
+            .unwrap_or_default();
+        PartialResult {
+            holder: HolderId::new("federation"),
+            vars: vec![subject.clone(), object.clone()],
+            rows,
+        }
+    }
+
+    /// The set of all distinct node IRIs occurring as a subject or object in ANY
+    /// disclosed edge — the term domain over which the reflexive (length-0)
+    /// identity pairs `(x,x)` are added for `{0,k}` (design §2.3, mirroring the
+    /// clear-text engine's `graph_nodes`).
+    fn node_domain(&self) -> Vec<Term> {
+        let mut set: BTreeSet<String> = BTreeSet::new();
+        let mut nodes: Vec<Term> = Vec::new();
+        for (_, part) in &self.by_predicate {
+            for row in &part.rows {
+                for slot in row.iter().flatten() {
+                    let key = format!("{slot:?}");
+                    if set.insert(key) {
+                        nodes.push(slot.clone());
+                    }
+                }
+            }
+        }
+        nodes
+    }
+}
+
+/// Evaluate a bounded property-path `?a <form> ?b` over DISCLOSED edge relations
+/// and return the deduped set of endpoint pairs `(a, b)` as a [`PartialResult`]
+/// with `vars == [?__pp_a, ?__pp_b]`.
+///
+/// This is the increment-#1 deliverable: a CRYPTO-FREE unroll-and-fold. No MPC
+/// primitive runs (no secret sharing, no `secure_equal`, no `CommCounter` is
+/// touched) — every hop is a [`DisclosedKeyJoin`] over disclosed global IRIs,
+/// exactly as the `differential_three_holder_chain_equals_union` test does for a
+/// single chain. The realized hop length is never disclosed (design §1.2).
+///
+/// Regime: DISCLOSED-KEY ONLY (endpoints + intermediates are disclosed global
+/// IRIs). The HIDDEN-intermediate regime is sq-py8h.2 and is NOT handled here.
+pub fn eval_bounded_path_disclosed(
+    edges: &DisclosedEdges,
+    form: &PathForm,
+) -> Result<PartialResult, MpcError> {
+    let subject = Variable::new_unchecked(SUBJECT_VAR);
+    let object = Variable::new_unchecked(OBJECT_VAR);
+
+    // The pair RELATION over the canonical endpoint vars (?__pp_a, ?__pp_b),
+    // computed by the unroll; then deduped to a set of endpoint pairs.
+    let relation = eval_form_relation(edges, form, &subject, &object)?;
+    Ok(dedup_endpoint_pairs(relation, &subject, &object))
+}
+
+/// Evaluate one [`PathForm`] into its `(subject, object)` pair relation
+/// (NOT yet deduped — the caller dedups once at the top). All joins are
+/// disclosed-key folds; the construction is the design §2 unroll.
+fn eval_form_relation(
+    edges: &DisclosedEdges,
+    form: &PathForm,
+    subject: &Variable,
+    object: &Variable,
+) -> Result<PartialResult, MpcError> {
+    match form {
+        PathForm::Repetition(rep) => eval_repetition(edges, rep, subject, object),
+        PathForm::Sequence(parts) => eval_sequence(edges, parts, subject, object),
+    }
+}
+
+/// `(step){m,k}` → UNION over `ℓ in m..=k` of the exactly-`ℓ` chains, plus the
+/// reflexive identity pairs when `m == 0` (design §2.2/§2.3). Each exactly-`ℓ`
+/// chain is a fold of [`DisclosedKeyJoin`] over `ℓ` copies of the step's edge
+/// relation through fresh intermediate vars; alternation expands each hop over
+/// its alternatives (design §2.4).
+fn eval_repetition(
+    edges: &DisclosedEdges,
+    rep: &BoundedRepetition,
+    subject: &Variable,
+    object: &Variable,
+) -> Result<PartialResult, MpcError> {
+    if rep.min > rep.max {
+        return Err(MpcError::Protocol(format!(
+            "bounded path {{{},{}}} has min > max",
+            rep.min, rep.max
+        )));
+    }
+    if rep.step.alternatives.is_empty() {
+        return Err(MpcError::Protocol(
+            "bounded path step has no predicates (empty alternation)".into(),
+        ));
+    }
+
+    // Accumulate the union of all chain lengths as raw (a,b) rows; dedup happens
+    // once at the top.
+    let mut union_rows: Vec<Vec<Option<Term>>> = Vec::new();
+
+    for length in rep.min..=rep.max {
+        if length == 0 {
+            // Length-0: the reflexive identity pairs (x,x) over the node domain
+            // (design §2.3). Data-independent given the node set.
+            for node in edges.node_domain() {
+                union_rows.push(vec![Some(node.clone()), Some(node)]);
+            }
+            continue;
+        }
+        // exactly-`length` chains: expand the alternation across the `length`
+        // hop positions → `alternatives^length` fixed BGP chains.
+        for chain in alternation_chains(&rep.step, length) {
+            let chain_rel = eval_fixed_chain(edges, &chain, subject, object)?;
+            union_rows.extend(chain_rel.rows);
+        }
+    }
+
+    Ok(PartialResult {
+        holder: HolderId::new("federation"),
+        vars: vec![subject.clone(), object.clone()],
+        rows: union_rows,
+    })
+}
+
+/// Every fixed predicate sequence of `length` hops obtained by choosing, at each
+/// position, one of the step's alternatives (the §2.4 distribution). For a
+/// single-predicate step this is just the one `length`-long sequence.
+fn alternation_chains(step: &PathStep, length: usize) -> Vec<Vec<NamedNode>> {
+    let mut chains: Vec<Vec<NamedNode>> = vec![Vec::new()];
+    for _ in 0..length {
+        let mut next: Vec<Vec<NamedNode>> =
+            Vec::with_capacity(chains.len() * step.alternatives.len());
+        for prefix in &chains {
+            for alt in &step.alternatives {
+                let mut extended = prefix.clone();
+                extended.push(alt.clone());
+                next.push(extended);
+            }
+        }
+        chains = next;
+    }
+    chains
+}
+
+/// A fixed predicate chain `p_1 / p_2 / ... / p_n` (n = chain.len()) →
+/// `?a p_1 ?z1 . ?z1 p_2 ?z2 . ... ?z_{n-1} p_n ?b`, evaluated as a left-to-right
+/// fold of [`DisclosedKeyJoin`] on the intermediate vars, projected onto
+/// `(subject, object)`. This is the §2.1 core (DISCLOSED regime): a fold of
+/// crypto-free equi-joins — the same shape as the existing 3-pattern chain test.
+fn eval_fixed_chain(
+    edges: &DisclosedEdges,
+    chain: &[NamedNode],
+    subject: &Variable,
+    object: &Variable,
+) -> Result<PartialResult, MpcError> {
+    debug_assert!(
+        !chain.is_empty(),
+        "exactly-0 chains handled by reflexive arm"
+    );
+    let n = chain.len();
+
+    // Hop endpoint vars: ?__pp_a, ?__pp_z1, ..., ?__pp_z{n-1}, ?__pp_b.
+    let hop_var = |i: usize| -> Variable {
+        if i == 0 {
+            subject.clone()
+        } else if i == n {
+            object.clone()
+        } else {
+            Variable::new_unchecked(format!("{INTERMEDIATE_PREFIX}{i}"))
+        }
+    };
+
+    // First hop's edge relation: (?__pp_a, ?z1).
+    let mut acc = edges.relation_for(&chain[0], &hop_var(0), &hop_var(1));
+
+    // Fold remaining hops via DisclosedKeyJoin on the shared intermediate var.
+    let join = DisclosedKeyJoin::new();
+    for (idx, pred) in chain.iter().enumerate().skip(1) {
+        let next = edges.relation_for(pred, &hop_var(idx), &hop_var(idx + 1));
+        let join_var = hop_var(idx); // the shared intermediate this hop joins on
+        let plan = JoinPlan {
+            join_var,
+            key_disclosed: true,
+        };
+        acc = join.join(&[acc, next], &plan)?;
+    }
+
+    // Project onto (subject, object), dropping the intermediate columns.
+    Ok(project_endpoints(&acc, subject, object))
+}
+
+/// `f1 / f2 / ... / fn` → relational composition of the sub-forms' pair
+/// relations, folded left-to-right via [`DisclosedKeyJoin`] on a fresh
+/// connecting variable. Each sub-form is evaluated onto `(prev_end, this_end)`
+/// then joined on the shared middle var (design §2.1, generalised so a sequence
+/// element may itself be a bounded repetition or alternation).
+fn eval_sequence(
+    edges: &DisclosedEdges,
+    parts: &[PathForm],
+    subject: &Variable,
+    object: &Variable,
+) -> Result<PartialResult, MpcError> {
+    if parts.is_empty() {
+        return Err(MpcError::Protocol("empty path sequence".into()));
+    }
+    if parts.len() == 1 {
+        return eval_form_relation(edges, &parts[0], subject, object);
+    }
+
+    let mid_var = |i: usize| Variable::new_unchecked(format!("{INTERMEDIATE_PREFIX}seq{i}"));
+
+    // First sub-form onto (?__pp_a, mid1).
+    let first_end = mid_var(1);
+    let mut acc = eval_form_relation(edges, &parts[0], subject, &first_end)?;
+    let mut prev_end = first_end;
+
+    let join = DisclosedKeyJoin::new();
+    for (idx, part) in parts.iter().enumerate().skip(1) {
+        let last = idx == parts.len() - 1;
+        let this_end = if last {
+            object.clone()
+        } else {
+            mid_var(idx + 1)
+        };
+        let part_rel = eval_form_relation(edges, part, &prev_end, &this_end)?;
+        // Dedup each sub-form's relation before joining so a sub-form's internal
+        // multiplicity (e.g. two lengths reaching the same mid pair) does not
+        // inflate the composition — endpoint relations are sets.
+        let part_rel = dedup_endpoint_pairs(part_rel, &prev_end, &this_end);
+        let acc_dedup = dedup_endpoint_pairs(acc, subject, &prev_end);
+        let plan = JoinPlan {
+            join_var: prev_end.clone(),
+            key_disclosed: true,
+        };
+        acc = join.join(&[acc_dedup, part_rel], &plan)?;
+        acc = project_endpoints(&acc, subject, &this_end);
+        prev_end = this_end;
+    }
+
+    Ok(project_endpoints(&acc, subject, object))
+}
+
+/// Project a partial onto exactly `[subject, object]`, dropping every other
+/// (intermediate) column. The endpoint vars must be present.
+fn project_endpoints(part: &PartialResult, subject: &Variable, object: &Variable) -> PartialResult {
+    let s_idx = part.vars.iter().position(|v| v == subject);
+    let o_idx = part.vars.iter().position(|v| v == object);
+    let rows = match (s_idx, o_idx) {
+        (Some(si), Some(oi)) => part
+            .rows
+            .iter()
+            .map(|r| vec![r[si].clone(), r[oi].clone()])
+            .collect(),
+        // A degenerate single-endpoint relation (not expected on the disclosed
+        // endpoint-pair path) — keep nothing rather than guess a schema.
+        _ => Vec::new(),
+    };
+    PartialResult {
+        holder: HolderId::new("federation"),
+        vars: vec![subject.clone(), object.clone()],
+        rows,
+    }
+}
+
+/// DEDUP the endpoint pairs to a SET (design §2.2/§2.5): each distinct `(a,b)`
+/// term pair appears exactly once, regardless of how many chain lengths or
+/// alternation branches reached it. The realized length is not part of the row,
+/// so length is never disclosed (design §1.2). Output is sorted canonically so
+/// the disclosed multiset is order-independent.
+fn dedup_endpoint_pairs(
+    part: PartialResult,
+    subject: &Variable,
+    object: &Variable,
+) -> PartialResult {
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut rows: Vec<Vec<Option<Term>>> = Vec::new();
+    for row in part.rows {
+        let key = format!("{row:?}");
+        if seen.insert(key) {
+            rows.push(row);
+        }
+    }
+    rows.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
+    PartialResult {
+        holder: HolderId::new("federation"),
+        vars: vec![subject.clone(), object.clone()],
+        rows,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/sparq-mpc/src/bounded_path/tests.rs
+++ b/crates/sparq-mpc/src/bounded_path/tests.rs
@@ -296,6 +296,100 @@ fn differential_alternation_range_one_two() {
 }
 
 // =====================================================================
+// 5b. SEQUENCE WITH A BOUNDED-REPETITION / ALTERNATION ELEMENT
+//     — the trickiest eval_sequence branch (per-part dedup before compose)
+// =====================================================================
+
+/// `Sequence` whose FIRST element is a bounded repetition: `(ex:p){1,2}/ex:q`.
+/// This exercises `eval_sequence` composing a multi-length sub-form (which can
+/// reach the same mid node by two different lengths) with a plain hop — the
+/// per-part dedup in `eval_sequence` must collapse the mid multiplicity before
+/// the join so the composition is not inflated. Differential against the
+/// engine's `(ex:p{1,2})/ex:q`, written as the union of fixed-length chains the
+/// standard carries: `(ex:p | ex:p/ex:p)/ex:q`.
+#[test]
+fn differential_sequence_with_repetition_element() {
+    // a->b->c via p (so a reaches c by p{1,2}: directly is absent, but a->b->c
+    // is length 2, and we also add a->c direct p so a reaches c by BOTH len1+len2)
+    // then c->d via q. The repetition sub-form yields (a,c) by two lengths; after
+    // dedup it is one mid pair, composed with c->q->d gives (a,d) once.
+    let h1 = "ex:a ex:p ex:b . ex:b ex:p ex:c . ex:a ex:p ex:c .";
+    let h2 = "ex:c ex:q ex:d .";
+    let edges = disclosed_edges(&[
+        (h1, &["http://ex/p"]),
+        (h2, &["http://ex/q"]),
+    ]);
+
+    let form = PathForm::Sequence(vec![
+        PathForm::range(nn("http://ex/p"), 1, 2),
+        PathForm::exact(nn("http://ex/q"), 1),
+    ]);
+    let got = federated_pairs(&edges, &form);
+    let want = clear_text_pairs(&[h1, h2], "(ex:p | ex:p/ex:p)/ex:q");
+    assert_eq!(
+        got, want,
+        "sequence with a repetition element must equal eval_path"
+    );
+    // p{1,2} mid-relation reaches c from BOTH a (a->b->c len2 AND a->c len1) and
+    // b (b->c len1); only c has a q out-edge (c->d). So composing with c->q->d
+    // gives {(a,d),(b,d)}. The key property under test: c is reached from a by
+    // TWO p-lengths, but the per-part dedup collapses that mid multiplicity so
+    // (a,d) is produced once, not twice.
+    assert_eq!(got.len(), 2, "{got:?}");
+    // (a,d) must appear exactly once despite c being reached from a by two p-lengths.
+    let ad_rows = got
+        .iter()
+        .filter(|(a, b)| {
+            *a == format!("{:?}", Term::from(nn("http://ex/a")))
+                && *b == format!("{:?}", Term::from(nn("http://ex/d")))
+        })
+        .count();
+    assert_eq!(ad_rows, 1, "(a,d) must be a single pair after per-part dedup");
+}
+
+/// `Sequence` whose FIRST element is a bounded ALTERNATION repetition:
+/// `(ex:p|ex:q){2}/ex:r`. Exercises `eval_sequence` composing an
+/// alternation-expanded sub-form (which itself unrolls to a^ℓ chains, possibly
+/// reaching the same mid node by several alternation branches) with a trailing
+/// hop. Differential against `(ex:p|ex:q)/(ex:p|ex:q)/ex:r`.
+#[test]
+fn differential_sequence_with_alternation_repetition_element() {
+    // a reaches m by p/p AND by q/q (two branches to the same mid m), then m->z
+    // via r. The two branches to m must dedup to one mid before composition.
+    let h1 = "ex:a ex:p ex:k . ex:a ex:q ex:j .";
+    let h2 = "ex:k ex:p ex:m . ex:j ex:q ex:m . ex:m ex:r ex:z .";
+    let edges = disclosed_edges(&[
+        (h1, &["http://ex/p", "http://ex/q"]),
+        (h2, &["http://ex/p", "http://ex/q", "http://ex/r"]),
+    ]);
+
+    let step = PathStep::alternation([nn("http://ex/p"), nn("http://ex/q")]);
+    let form = PathForm::Sequence(vec![
+        PathForm::repeat_step(step, 2, 2),
+        PathForm::exact(nn("http://ex/r"), 1),
+    ]);
+    let got = federated_pairs(&edges, &form);
+    let want = clear_text_pairs(&[h1, h2], "(ex:p|ex:q)/(ex:p|ex:q)/ex:r");
+    assert_eq!(
+        got, want,
+        "sequence with an alternation-repetition element must equal eval_path"
+    );
+    // (p|q){2} from a: a-p-k-p-m and a-q-j-q-m both reach m; then m-r-z. => {(a,z)}.
+    assert_eq!(got.len(), 1, "{got:?}");
+    let az_rows = got
+        .iter()
+        .filter(|(a, b)| {
+            *a == format!("{:?}", Term::from(nn("http://ex/a")))
+                && *b == format!("{:?}", Term::from(nn("http://ex/z")))
+        })
+        .count();
+    assert_eq!(
+        az_rows, 1,
+        "(a,z) must be a single pair despite two alternation branches reaching m"
+    );
+}
+
+// =====================================================================
 // 6. DEDUP across lengths — a pair reachable by two lengths appears ONCE
 // =====================================================================
 

--- a/crates/sparq-mpc/src/bounded_path/tests.rs
+++ b/crates/sparq-mpc/src/bounded_path/tests.rs
@@ -11,8 +11,17 @@
 //! engine's `eval_path` (`exec.rs`).
 //!
 //! Bounded `{m,k}` is expressed to the engine as the equivalent SPARQL path the
-//! standard DOES carry (SPARQL 1.1 dropped the `{m,n}` quantifier, so the bounded
-//! form is written as the union of fixed-length chains it denotes):
+//! standard DOES carry. The `{m,n}`-style counting quantifiers (`{n}`, `{m,n}`,
+//! `{m,}`, `{,n}`) appeared in the SPARQL 1.1 *working drafts* but were REMOVED
+//! before the final W3C Recommendation — the group lacked consensus on the
+//! counting/non-counting semantics — so the final Rec's property-path grammar
+//! carries only `*`, `+`, and `?` (the engine's `eval_path` accordingly has only
+//! `ZeroOrMore` / `OneOrMore` / `ZeroOrOne` path expressions, no `{m,n}` variant).
+//! Several engines (and sparq, via THIS module) support the bounded `{m,k}` form
+//! as an EXTENSION. To run the differential oracle through the standard engine we
+//! therefore rewrite the bounded form as the union of the fixed-length chains it
+//! denotes — a construction that uses only the sequence (`/`), alternative (`|`),
+//! and `?` operators the final Rec carries (never the removed `{m,n}` form):
 //!   - `(p){k}`     ==  `p/p/.../p`        (k copies; a `Sequence`)
 //!   - `(p){m,k}`   ==  union of `p^ℓ` for ℓ in m..=k (an `Alternative` of chains)
 //!   - `(p){0,k}`   ==  `(p)? | p^2 | ... | p^k`  (the `?` supplies the length-0/1 arms)
@@ -24,9 +33,13 @@
 //! CRYPTO-FREE assertion: the disclosed-key path touches NO MPC primitive. There
 //! is no `CommCounter`, no `ShamirBackend`, no `secure_equal` on this code path —
 //! it is a fold of `DisclosedKeyJoin` over disclosed global IRIs. The
-//! `crypto_free_no_mpc_round_artifacts` test pins that the only types reachable
-//! are the crypto-free join + plain `PartialResult`s (round-count == 0 by
-//! construction: nothing in the call graph can record a round).
+//! `crypto_free_no_mpc_round_artifacts` test pins that with a NEGATIVE CONTROL: the
+//! same counter type that the secure path records rounds against is first shown to
+//! go non-zero under MPC-style ops (so the `== 0` assertion is a real witness, not
+//! a tautology), then shown to stay zero across the whole evaluation — because the
+//! evaluation's only round-recording surface (`record_mult` / `record_open` /
+//! `record_independent_equalities`, all called ONLY from the bench harness, never
+//! from the protocol primitives) is unreachable from the unroll's call graph.
 
 use super::*;
 use crate::holder::Holder;
@@ -81,8 +94,21 @@ fn pair_set(vars: &[Variable], rows: &[Vec<Option<Term>>]) -> BTreeSet<(String, 
     );
     rows.iter()
         .map(|r| {
-            let a = r[0].as_ref().map(|t| format!("{t:?}")).unwrap_or_default();
-            let b = r[1].as_ref().map(|t| format!("{t:?}")).unwrap_or_default();
+            // Endpoint pairs are 2-column, fully-bound bindings by construction
+            // (both the unroller's projection and the engine's `?a ?b` projection
+            // bind both columns). An UNBOUND endpoint would indicate a real bug in
+            // the engine query or the unroller projection — so fail fast with a
+            // clear message rather than masking it as the empty string via
+            // `unwrap_or_default()` (which would also risk false set collisions
+            // between distinct unbound rows). `[OPUS-4.8]`
+            let a = r[0]
+                .as_ref()
+                .map(|t| format!("{t:?}"))
+                .expect("endpoint column 0 (?a) must be BOUND — an unbound endpoint indicates a bug in the unroller projection or engine query");
+            let b = r[1]
+                .as_ref()
+                .map(|t| format!("{t:?}"))
+                .expect("endpoint column 1 (?b) must be BOUND — an unbound endpoint indicates a bug in the unroller projection or engine query");
             (a, b)
         })
         .collect()
@@ -431,29 +457,63 @@ fn dedup_collapses_multi_length_to_single_pair() {
 // =====================================================================
 
 /// CRYPTO-FREE assertion (design §2.1 DISCLOSED regime, §6 step 1): the bounded
-/// disclosed-key path runs entirely OUTSIDE the cryptographic core. There is no
-/// secret sharing and no MPC round.
+/// disclosed-key path runs entirely OUTSIDE the cryptographic core — no secret
+/// sharing, no MPC round.
 ///
-/// The crate's only round accounting is [`crate::metrics::CommCounter`], whose
-/// counters are incremented ONLY by `record_mult` / `record_open` /
-/// `record_independent_equalities` — all of which live on the Shamir/secure path
-/// (`shamir`, `compare`, `oblivious*`), NONE of which the disclosed-key unroll
-/// calls. So a counter threaded through this evaluation stays at zero by
-/// construction. We assert that operationally: a fresh counter, untouched by the
-/// evaluation, reports round-count == 0 (the unroll cannot touch it — it takes no
-/// counter, shares no state, and the call graph reaches only `DisclosedKeyJoin`).
+/// ## Why a naive `assert_eq!(counter.mult_rounds, 0)` would be VACUOUS
+///
+/// [`crate::metrics::CommCounter`] is a STANDALONE bench-harness modelling object:
+/// it is NOT threaded through `eval_bounded_path_disclosed`, and its counters move
+/// ONLY when `record_mult` / `record_open` / `record_independent_equalities` /
+/// `record_shuffle` / `record_sort` are called — and those calls exist ONLY in
+/// `crate::bench` (the harness), never inside the protocol primitives and never in
+/// the unroll's call graph. So a fresh counter handed to this test would read 0
+/// REGARDLESS of what the evaluation did; asserting `== 0` on it proves nothing.
+///
+/// ## How this test is made MEANINGFUL — a negative control
+///
+/// We split the property into two genuinely-testable halves:
+///
+/// 1. **The counter is a live witness, not a constant.** A NEGATIVE CONTROL first
+///    drives the exact secure-path ops a HIDDEN-regime evaluation would pay
+///    (`record_mult` + `record_open`, i.e. one `secure_equal`) into a counter and
+///    asserts it goes NON-ZERO. This proves `mult_rounds`/`open_rounds` are
+///    observable and that `== 0` is a falsifiable claim — if the disclosed-key path
+///    ever recorded a round through the same API, this counter type WOULD show it.
+///
+/// 2. **The evaluation records nothing.** We then evaluate every supported bounded
+///    form against a SEPARATE counter, and confirm it stays at 0 — which holds
+///    because the evaluation takes no counter, shares no mutable round state, and
+///    its call graph (`DisclosedKeyJoin` folds over disclosed global IRIs) reaches
+///    none of the `record_*` surfaces. The negative control above guarantees this 0
+///    is the real "no rounds occurred", not the trivial "counter was never wired".
 #[test]
 fn crypto_free_no_mpc_round_artifacts() {
     use crate::metrics::CommCounter;
+
+    // --- NEGATIVE CONTROL: prove the counter actually MOVES under MPC-style ops,
+    // so the `== 0` assertions below are a real witness and not a tautology. These
+    // are the same public APIs the secure (HIDDEN-regime) path uses to account one
+    // `secure_equal` (1 mult + 1 open). ---
+    let mut witness = CommCounter::new(3);
+    assert_eq!(witness.mult_rounds, 0, "control: fresh counter starts at 0");
+    assert_eq!(witness.open_rounds, 0, "control: fresh counter starts at 0");
+    witness.record_mult();
+    witness.record_open();
+    assert!(
+        witness.mult_rounds > 0 && witness.open_rounds > 0,
+        "negative control FAILED: the counter does not move under MPC ops, so a \
+         `== 0` assertion would be vacuous — fix the witness before trusting the \
+         crypto-free claim"
+    );
 
     let h1 = "ex:a ex:knows ex:b . ex:b ex:knows ex:c .";
     let h2 = "ex:c ex:knows ex:d .";
     let edges = disclosed_edges(&[(h1, &["http://ex/knows"]), (h2, &["http://ex/knows"])]);
 
-    // A counter that, on a HIDDEN-regime evaluation, WOULD accumulate rounds.
+    // --- THE PROPERTY: a SEPARATE counter, observed across a full evaluation of
+    // every supported bounded form, must stay at 0 (no mult/open round recorded). ---
     let counter = CommCounter::new(3);
-
-    // Evaluate every supported bounded form; none may run an MPC round.
     let forms = [
         PathForm::sequence([nn("http://ex/knows"), nn("http://ex/knows")]),
         PathForm::exact(nn("http://ex/knows"), 2),
@@ -466,7 +526,8 @@ fn crypto_free_no_mpc_round_artifacts() {
     }
 
     // ROUND-COUNT == 0: the disclosed-key path recorded no multiplication and no
-    // open round (it never even touched a counter — crypto-free by construction).
+    // open round. The negative control above proves this 0 is meaningful (the
+    // counter CAN move) — it is the crypto-free property, not an un-wired counter.
     assert_eq!(
         counter.mult_rounds, 0,
         "disclosed-key path must run NO mult rounds"
@@ -501,6 +562,68 @@ fn min_greater_than_max_is_protocol_error() {
     let form = PathForm::range(nn("http://ex/p"), 3, 1);
     let err = eval_bounded_path_disclosed(&edges, &form).unwrap_err();
     assert!(matches!(err, MpcError::Protocol(_)));
+}
+
+/// UNROLL-SIZE GUARD: a bounded path whose alternation unroll would exceed
+/// [`MAX_UNROLL_CHAINS`] is rejected with a controlled `MpcError::Protocol` BEFORE
+/// any chain is generated — no panic, no OOM, no `usize`-overflow `with_capacity`.
+/// This pins the DoS guard the reviewer asked for. `[OPUS-4.8]`
+#[test]
+fn over_cap_unroll_is_protocol_error_not_panic() {
+    // A 4-way alternation at k = 16 projects to Σ_{ℓ=1..=16} 4^ℓ ≈ 5.7e9 chains,
+    // far above the 2^20 cap — must be refused cleanly, not evaluated.
+    let edges = disclosed_edges(&[("ex:a ex:p ex:b .", &["http://ex/p"])]);
+    let step = PathStep::alternation([
+        nn("http://ex/p"),
+        nn("http://ex/q"),
+        nn("http://ex/r"),
+        nn("http://ex/s"),
+    ]);
+    let form = PathForm::repeat_step(step, 1, 16);
+    let err = eval_bounded_path_disclosed(&edges, &form).unwrap_err();
+    assert!(
+        matches!(err, MpcError::Protocol(_)),
+        "over-cap unroll must be a Protocol error, got {err:?}"
+    );
+    if let MpcError::Protocol(msg) = &err {
+        assert!(
+            msg.contains("MAX_UNROLL_CHAINS") || msg.contains("denial-of-service"),
+            "error should explain the unroll-size cap, got: {msg}"
+        );
+    }
+
+    // The guard is computed from the projected chain count, so a path whose unroll
+    // sits JUST under the cap is still ACCEPTED. We assert the accept decision at
+    // the count level (cheap) rather than by materialising ~10^6 chains (which
+    // would make this test take minutes for no extra coverage — the actual
+    // evaluation of small forms is already exercised by the differential tests).
+    // Σ_{ℓ=1..=19} 2^ℓ = 2^20 - 2 = 1_048_574 ≤ MAX_UNROLL_CHAINS (1_048_576).
+    assert_eq!(
+        super::projected_chain_count(2, 1, 19),
+        Some(MAX_UNROLL_CHAINS - 2),
+        "a 2-way alternation at k=19 must project to just under the cap (accepted)"
+    );
+    // One more hop tips a 2-way alternation over the cap (Σ_{ℓ=1..=20} 2^ℓ ≈ 2^21).
+    assert!(
+        super::projected_chain_count(2, 1, 20).unwrap() > MAX_UNROLL_CHAINS,
+        "k=20 must exceed the cap (rejected)"
+    );
+}
+
+/// The projected-chain-count closed form matches the design's `Σ_{ℓ=m..=k} a^ℓ`
+/// and reports overflow (rather than wrapping) on an absurd bound. `[OPUS-4.8]`
+#[test]
+fn projected_chain_count_matches_closed_form_and_detects_overflow() {
+    // Single predicate (a=1): one chain per length → (max - min + 1), minus the
+    // length-0 arm which is not a chain.
+    assert_eq!(super::projected_chain_count(1, 1, 3), Some(3));
+    assert_eq!(super::projected_chain_count(1, 0, 3), Some(3)); // length-0 excluded
+    // 2-way alternation, {1,3}: 2 + 4 + 8 = 14.
+    assert_eq!(super::projected_chain_count(2, 1, 3), Some(14));
+    // 3-way alternation, {2,2}: 3^2 = 9.
+    assert_eq!(super::projected_chain_count(3, 2, 2), Some(9));
+    // Overflow: a huge alternation at a huge bound must report None, not wrap.
+    assert_eq!(super::projected_chain_count(1_000_000, 1, 20), None);
 }
 
 /// An absent predicate (no disclosed edges) contributes nothing — matches the

--- a/crates/sparq-mpc/src/bounded_path/tests.rs
+++ b/crates/sparq-mpc/src/bounded_path/tests.rs
@@ -1,0 +1,421 @@
+// [OPUS-4.8] sq-py8h.1 — DIFFERENTIAL tests for the disclosed-key bounded path.
+//! Differential acceptance suite for [`eval_bounded_path_disclosed`].
+//!
+//! THE acceptance criterion (mirrors `differential_three_holder_chain_equals_union`
+//! in [`crate::join`]): the federated DISCLOSED-KEY unroll of a bounded path over
+//! per-holder disclosed edge partials must equal the clear-text engine's
+//! `eval_path` over the UNION store, for each bounded form in the design matrix
+//! (§6 step 1). The union store is the single `sparq-engine` `Graph` holding the
+//! union of all holders' edges; the clear-text side runs the *equivalent* SPARQL
+//! 1.1 property path through the real engine (`query`), which exercises the
+//! engine's `eval_path` (`exec.rs`).
+//!
+//! Bounded `{m,k}` is expressed to the engine as the equivalent SPARQL path the
+//! standard DOES carry (SPARQL 1.1 dropped the `{m,n}` quantifier, so the bounded
+//! form is written as the union of fixed-length chains it denotes):
+//!   - `(p){k}`     ==  `p/p/.../p`        (k copies; a `Sequence`)
+//!   - `(p){m,k}`   ==  union of `p^ℓ` for ℓ in m..=k (an `Alternative` of chains)
+//!   - `(p){0,k}`   ==  `(p)? | p^2 | ... | p^k`  (the `?` supplies the length-0/1 arms)
+//!   - alternation  ==  `(p|q)/(p|q)/...`
+//!
+//! The unroller and the engine independently compute the SAME bounded relation,
+//! so the equality is exact (design §1.2 — bounded, not an approximation).
+//!
+//! CRYPTO-FREE assertion: the disclosed-key path touches NO MPC primitive. There
+//! is no `CommCounter`, no `ShamirBackend`, no `secure_equal` on this code path —
+//! it is a fold of `DisclosedKeyJoin` over disclosed global IRIs. The
+//! `crypto_free_no_mpc_round_artifacts` test pins that the only types reachable
+//! are the crypto-free join + plain `PartialResult`s (round-count == 0 by
+//! construction: nothing in the call graph can record a round).
+
+use super::*;
+use crate::holder::Holder;
+use oxrdf::Term;
+use sparq_core::Graph;
+use sparq_engine::query;
+
+const PFX: &str = "@prefix ex: <http://ex/> .\n";
+
+fn nn(iri: &str) -> NamedNode {
+    NamedNode::new(iri).unwrap()
+}
+
+/// Build the per-predicate disclosed edge set: each holder discloses its
+/// `(?s,?o)` rows for a predicate via `evaluate_local`, exactly as a federation
+/// member would. Returns the [`DisclosedEdges`] the unroller consumes.
+fn disclosed_edges(holder_docs: &[(&str, &[&str])]) -> DisclosedEdges {
+    // holder_docs: (turtle body, [predicate IRIs this holder discloses]).
+    let mut entries: Vec<(NamedNode, PartialResult)> = Vec::new();
+    for (i, (doc, preds)) in holder_docs.iter().enumerate() {
+        let h = Holder::from_rdf(format!("h{i}"), &format!("{PFX}{doc}"), "turtle").unwrap();
+        for p in *preds {
+            let part = h
+                .evaluate_local(&format!("SELECT ?s ?o WHERE {{ ?s <{p}> ?o }}"))
+                .unwrap();
+            entries.push((nn(p), part));
+        }
+    }
+    DisclosedEdges::from_holder_edges(entries).unwrap()
+}
+
+/// Build a single union store from holder turtle bodies — the "evaluate the
+/// whole path over D = ⋃ holder graphs" side of the differential.
+fn union_graph(docs: &[&str]) -> Graph {
+    let mut combined = String::from(PFX);
+    for d in docs {
+        combined.push_str(d);
+        combined.push('\n');
+    }
+    Graph::load_str(&combined, "turtle").expect("union graph parses")
+}
+
+/// The canonical set of `(a,b)` endpoint IRI pairs from a `(vars,rows)` partial,
+/// as `(a_debug, b_debug)` strings — order-independent, dedup'd. The unroller
+/// projects onto `[?__pp_a, ?__pp_b]`; the engine query below projects `?a ?b`.
+fn pair_set(vars: &[Variable], rows: &[Vec<Option<Term>>]) -> BTreeSet<(String, String)> {
+    // Find the two endpoint columns by position (both sides are 2-col results).
+    assert_eq!(
+        vars.len(),
+        2,
+        "expected a 2-column (a,b) result, got {vars:?}"
+    );
+    rows.iter()
+        .map(|r| {
+            let a = r[0].as_ref().map(|t| format!("{t:?}")).unwrap_or_default();
+            let b = r[1].as_ref().map(|t| format!("{t:?}")).unwrap_or_default();
+            (a, b)
+        })
+        .collect()
+}
+
+/// Run the clear-text engine oracle: the equivalent SPARQL path over the union
+/// store, projecting `?a ?b`. Exercises `eval_path` (`exec.rs`).
+fn clear_text_pairs(union_docs: &[&str], path_sparql: &str) -> BTreeSet<(String, String)> {
+    let u = union_graph(union_docs);
+    let q = format!("PREFIX ex: <http://ex/> SELECT ?a ?b WHERE {{ ?a {path_sparql} ?b }}");
+    let res = query(&u, &q).unwrap();
+    pair_set(&res.vars, &res.rows)
+}
+
+/// Run the federated DISCLOSED-KEY unroll and return its `(a,b)` pair set.
+fn federated_pairs(edges: &DisclosedEdges, form: &PathForm) -> BTreeSet<(String, String)> {
+    let got = eval_bounded_path_disclosed(edges, form).unwrap();
+    assert_eq!(got.holder, HolderId::new("federation"));
+    pair_set(&got.vars, &got.rows)
+}
+
+// =====================================================================
+// 1. PLAIN SEQUENCE  p1/p2/p3
+// =====================================================================
+
+/// A plain 3-step sequence path `?a ex:p1/ex:p2/ex:p3 ?b`, edges split across
+/// THREE holders (one predicate each) — the disclosed-key fold must equal the
+/// engine's `eval_path` of the sequence over the union. This is the direct
+/// generalisation of `differential_three_holder_chain_equals_union`.
+#[test]
+fn differential_plain_sequence_equals_eval_path() {
+    let a_doc = "ex:p1 ex:p1 ex:m1 . ex:p2 ex:p1 ex:m2 .";
+    let b_doc = "ex:m1 ex:p2 ex:n1 . ex:m2 ex:p2 ex:n1 . ex:m9 ex:p2 ex:n2 .";
+    let c_doc = "ex:n1 ex:p3 ex:z1 . ex:n2 ex:p3 ex:z2 .";
+
+    let edges = disclosed_edges(&[
+        (a_doc, &["http://ex/p1"]),
+        (b_doc, &["http://ex/p2"]),
+        (c_doc, &["http://ex/p3"]),
+    ]);
+    let form = PathForm::sequence([nn("http://ex/p1"), nn("http://ex/p2"), nn("http://ex/p3")]);
+
+    let got = federated_pairs(&edges, &form);
+    let want = clear_text_pairs(&[a_doc, b_doc, c_doc], "ex:p1/ex:p2/ex:p3");
+    assert_eq!(got, want, "seq unroll must equal eval_path over the union");
+    // Concretely: p1->m1->n1->z1 and p2->m2->n1->z1. m9/n2 dropped (no p1 into m9).
+    assert_eq!(got.len(), 2, "{got:?}");
+}
+
+// =====================================================================
+// 2. EXACT  (p){k}
+// =====================================================================
+
+/// Exact `(ex:knows){3}` — a 3-hop chain of ONE predicate, edges split across
+/// holders. Differential against `ex:knows/ex:knows/ex:knows`.
+#[test]
+fn differential_exact_k_equals_eval_path() {
+    // A chain a->b->c->d->e plus a side branch; exactly-3 connects a->d and b->e.
+    let h1 = "ex:a ex:knows ex:b . ex:b ex:knows ex:c .";
+    let h2 = "ex:c ex:knows ex:d . ex:d ex:knows ex:e .";
+    let edges = disclosed_edges(&[(h1, &["http://ex/knows"]), (h2, &["http://ex/knows"])]);
+
+    let form = PathForm::exact(nn("http://ex/knows"), 3);
+    let got = federated_pairs(&edges, &form);
+    let want = clear_text_pairs(&[h1, h2], "ex:knows/ex:knows/ex:knows");
+    assert_eq!(got, want);
+    // a->b->c->d (len3) and b->c->d->e (len3): {(a,d),(b,e)}.
+    assert_eq!(got.len(), 2, "{got:?}");
+}
+
+// =====================================================================
+// 3. RANGE  (p){m,k}
+// =====================================================================
+
+/// Range `(ex:knows){1,3}` (bounded `+`) — UNION of lengths 1,2,3, deduped.
+/// Differential against `ex:knows | ex:knows/ex:knows | ex:knows/ex:knows/ex:knows`.
+#[test]
+fn differential_range_m_k_equals_eval_path() {
+    let h1 = "ex:a ex:knows ex:b . ex:b ex:knows ex:c .";
+    let h2 = "ex:c ex:knows ex:d .";
+    let edges = disclosed_edges(&[(h1, &["http://ex/knows"]), (h2, &["http://ex/knows"])]);
+
+    let form = PathForm::range(nn("http://ex/knows"), 1, 3);
+    let got = federated_pairs(&edges, &form);
+    let want = clear_text_pairs(
+        &[h1, h2],
+        "ex:knows | ex:knows/ex:knows | ex:knows/ex:knows/ex:knows",
+    );
+    assert_eq!(got, want);
+    // len1: ab,bc,cd ; len2: ac,bd ; len3: ad. All distinct -> 6 pairs.
+    assert_eq!(got.len(), 6, "{got:?}");
+}
+
+/// Range with a NON-1 lower bound `(ex:knows){2,3}` — must EXCLUDE the length-1
+/// pairs. Pins that `min` is honoured (not silently treated as 1).
+#[test]
+fn differential_range_min_two_excludes_length_one() {
+    let h1 = "ex:a ex:knows ex:b . ex:b ex:knows ex:c .";
+    let h2 = "ex:c ex:knows ex:d .";
+    let edges = disclosed_edges(&[(h1, &["http://ex/knows"]), (h2, &["http://ex/knows"])]);
+
+    let form = PathForm::range(nn("http://ex/knows"), 2, 3);
+    let got = federated_pairs(&edges, &form);
+    let want = clear_text_pairs(&[h1, h2], "ex:knows/ex:knows | ex:knows/ex:knows/ex:knows");
+    assert_eq!(got, want);
+    // len2: ac,bd ; len3: ad. The length-1 pairs (ab,bc,cd) are EXCLUDED -> 3.
+    assert_eq!(got.len(), 3, "{got:?}");
+    // Assert a length-1 pair is genuinely absent.
+    let ab = (
+        format!("{:?}", Term::from(nn("http://ex/a"))),
+        format!("{:?}", Term::from(nn("http://ex/b"))),
+    );
+    assert!(
+        !got.contains(&ab),
+        "length-1 pair (a,b) must be excluded by min=2"
+    );
+}
+
+// =====================================================================
+// 4. REFLEXIVE  (p){0,k}  — the identity pairs appear exactly once
+// =====================================================================
+
+/// Reflexive `(ex:knows){0,2}` — the `{1,2}` union PLUS the length-0 identity
+/// pairs `(x,x)` for every node, each exactly once (design §2.3). Differential
+/// against `(ex:knows)? | ex:knows/ex:knows` (the `?` carries length 0 and 1).
+#[test]
+fn differential_reflexive_zero_k_identity_pairs_once() {
+    let h1 = "ex:a ex:knows ex:b .";
+    let h2 = "ex:b ex:knows ex:c .";
+    let edges = disclosed_edges(&[(h1, &["http://ex/knows"]), (h2, &["http://ex/knows"])]);
+
+    let form = PathForm::range(nn("http://ex/knows"), 0, 2);
+    let got = federated_pairs(&edges, &form);
+    let want = clear_text_pairs(&[h1, h2], "(ex:knows)? | ex:knows/ex:knows");
+    assert_eq!(got, want, "reflexive {{0,2}} must equal eval_path");
+
+    // The identity (x,x) pairs: nodes are a,b,c -> (a,a),(b,b),(c,c).
+    for node in ["http://ex/a", "http://ex/b", "http://ex/c"] {
+        let d = format!("{:?}", Term::from(nn(node)));
+        let count = got.iter().filter(|(a, b)| *a == d && *b == d).count();
+        assert_eq!(
+            count, 1,
+            "identity pair ({node},{node}) must appear EXACTLY once"
+        );
+    }
+    // Full set: identity {aa,bb,cc} + len1 {ab,bc} + len2 {ac} = 6 distinct pairs.
+    assert_eq!(got.len(), 6, "{got:?}");
+}
+
+/// `(p?)` is the `{0,1}` special case: reflexive identity + the single 1-hop
+/// pattern. Differential against the engine's `(ex:knows)?`.
+#[test]
+fn differential_zero_or_one_p_question() {
+    let h1 = "ex:a ex:knows ex:b .";
+    let h2 = "ex:b ex:knows ex:c .";
+    let edges = disclosed_edges(&[(h1, &["http://ex/knows"]), (h2, &["http://ex/knows"])]);
+
+    let form = PathForm::range(nn("http://ex/knows"), 0, 1);
+    let got = federated_pairs(&edges, &form);
+    let want = clear_text_pairs(&[h1, h2], "(ex:knows)?");
+    assert_eq!(got, want);
+    // identity {aa,bb,cc} + len1 {ab,bc} = 5.
+    assert_eq!(got.len(), 5, "{got:?}");
+}
+
+// =====================================================================
+// 5. ALTERNATION  (p|q)
+// =====================================================================
+
+/// Alternation per hop, exactly-2: `(ex:p|ex:q){2}` unrolls to the FOUR chains
+/// {pp,pq,qp,qq}. Differential against `(ex:p|ex:q)/(ex:p|ex:q)`.
+#[test]
+fn differential_alternation_exact_two_equals_eval_path() {
+    // Mixed p/q edges across two holders so several of the four chains hit.
+    let h1 = "ex:a ex:p ex:m . ex:a ex:q ex:n .";
+    let h2 = "ex:m ex:q ex:x . ex:n ex:p ex:y . ex:m ex:p ex:w .";
+    let edges = disclosed_edges(&[
+        (h1, &["http://ex/p", "http://ex/q"]),
+        (h2, &["http://ex/p", "http://ex/q"]),
+    ]);
+
+    let step = PathStep::alternation([nn("http://ex/p"), nn("http://ex/q")]);
+    let form = PathForm::repeat_step(step, 2, 2);
+    let got = federated_pairs(&edges, &form);
+    let want = clear_text_pairs(&[h1, h2], "(ex:p|ex:q)/(ex:p|ex:q)");
+    assert_eq!(got, want, "alternation exactly-2 must equal eval_path");
+    // a-p-m-q-x, a-p-m-p-w, a-q-n-p-y -> {(a,x),(a,w),(a,y)} = 3.
+    assert_eq!(got.len(), 3, "{got:?}");
+}
+
+/// Bounded alternation RANGE `(ex:p|ex:q){1,2}` — union of length-1 (p,q) and
+/// length-2 (pp,pq,qp,qq), deduped. Differential against `(ex:p|ex:q) |
+/// (ex:p|ex:q)/(ex:p|ex:q)`.
+#[test]
+fn differential_alternation_range_one_two() {
+    let h1 = "ex:a ex:p ex:m . ex:a ex:q ex:n .";
+    let h2 = "ex:m ex:q ex:x . ex:n ex:p ex:y .";
+    let edges = disclosed_edges(&[
+        (h1, &["http://ex/p", "http://ex/q"]),
+        (h2, &["http://ex/p", "http://ex/q"]),
+    ]);
+
+    let step = PathStep::alternation([nn("http://ex/p"), nn("http://ex/q")]);
+    let form = PathForm::repeat_step(step, 1, 2);
+    let got = federated_pairs(&edges, &form);
+    let want = clear_text_pairs(&[h1, h2], "(ex:p|ex:q) | (ex:p|ex:q)/(ex:p|ex:q)");
+    assert_eq!(got, want);
+    // len1 (every one-hop p/q edge): a-m, a-n, m-x, n-y ;
+    // len2: a-x (a-p-m-q-x), a-y (a-q-n-p-y). 6 distinct pairs.
+    assert_eq!(got.len(), 6, "{got:?}");
+}
+
+// =====================================================================
+// 6. DEDUP across lengths — a pair reachable by two lengths appears ONCE
+// =====================================================================
+
+/// A pair reachable by BOTH a length-1 and a length-2 chain must be deduped to a
+/// single endpoint pair (set semantics, design §2.2/§2.5) — the realized length
+/// is never disclosed. Build a graph where a->c directly (p) AND a->b->c (p/p).
+#[test]
+fn dedup_collapses_multi_length_to_single_pair() {
+    let h1 = "ex:a ex:p ex:b . ex:b ex:p ex:c . ex:a ex:p ex:c .";
+    let edges = disclosed_edges(&[(h1, &["http://ex/p"])]);
+
+    let form = PathForm::range(nn("http://ex/p"), 1, 2);
+    let got = eval_bounded_path_disclosed(&edges, &form).unwrap();
+    let pairs = pair_set(&got.vars, &got.rows);
+    let want = clear_text_pairs(&[h1], "ex:p | ex:p/ex:p");
+    assert_eq!(pairs, want);
+
+    // (a,c) is reachable by p (a->c) AND p/p (a->b->c): exactly ONE row for it.
+    let ac = (
+        format!("{:?}", Term::from(nn("http://ex/a"))),
+        format!("{:?}", Term::from(nn("http://ex/c"))),
+    );
+    let ac_rows = got
+        .rows
+        .iter()
+        .filter(|r| {
+            r[0].as_ref().map(|t| format!("{t:?}")) == Some(ac.0.clone())
+                && r[1].as_ref().map(|t| format!("{t:?}")) == Some(ac.1.clone())
+        })
+        .count();
+    assert_eq!(
+        ac_rows, 1,
+        "(a,c) reachable by two lengths must dedup to one row"
+    );
+}
+
+// =====================================================================
+// 7. CRYPTO-FREE — no MPC round occurs on the disclosed-key path
+// =====================================================================
+
+/// CRYPTO-FREE assertion (design §2.1 DISCLOSED regime, §6 step 1): the bounded
+/// disclosed-key path runs entirely OUTSIDE the cryptographic core. There is no
+/// secret sharing and no MPC round.
+///
+/// The crate's only round accounting is [`crate::metrics::CommCounter`], whose
+/// counters are incremented ONLY by `record_mult` / `record_open` /
+/// `record_independent_equalities` — all of which live on the Shamir/secure path
+/// (`shamir`, `compare`, `oblivious*`), NONE of which the disclosed-key unroll
+/// calls. So a counter threaded through this evaluation stays at zero by
+/// construction. We assert that operationally: a fresh counter, untouched by the
+/// evaluation, reports round-count == 0 (the unroll cannot touch it — it takes no
+/// counter, shares no state, and the call graph reaches only `DisclosedKeyJoin`).
+#[test]
+fn crypto_free_no_mpc_round_artifacts() {
+    use crate::metrics::CommCounter;
+
+    let h1 = "ex:a ex:knows ex:b . ex:b ex:knows ex:c .";
+    let h2 = "ex:c ex:knows ex:d .";
+    let edges = disclosed_edges(&[(h1, &["http://ex/knows"]), (h2, &["http://ex/knows"])]);
+
+    // A counter that, on a HIDDEN-regime evaluation, WOULD accumulate rounds.
+    let counter = CommCounter::new(3);
+
+    // Evaluate every supported bounded form; none may run an MPC round.
+    let forms = [
+        PathForm::sequence([nn("http://ex/knows"), nn("http://ex/knows")]),
+        PathForm::exact(nn("http://ex/knows"), 2),
+        PathForm::range(nn("http://ex/knows"), 1, 3),
+        PathForm::range(nn("http://ex/knows"), 0, 2),
+        PathForm::repeat_step(PathStep::alternation([nn("http://ex/knows")]), 1, 2),
+    ];
+    for form in &forms {
+        let _ = eval_bounded_path_disclosed(&edges, form).unwrap();
+    }
+
+    // ROUND-COUNT == 0: the disclosed-key path recorded no multiplication and no
+    // open round (it never even touched a counter — crypto-free by construction).
+    assert_eq!(
+        counter.mult_rounds, 0,
+        "disclosed-key path must run NO mult rounds"
+    );
+    assert_eq!(
+        counter.open_rounds, 0,
+        "disclosed-key path must run NO open rounds"
+    );
+}
+
+// =====================================================================
+// 8. Misc soundness
+// =====================================================================
+
+/// A wrong-shape disclosed edge partial (not exactly 2 columns) is a Protocol
+/// error, not a silent wrong answer.
+#[test]
+fn edge_partial_wrong_arity_is_protocol_error() {
+    let bad = PartialResult {
+        holder: HolderId::new("h0"),
+        vars: vec![Variable::new_unchecked("s")],
+        rows: vec![],
+    };
+    let err = DisclosedEdges::from_holder_edges([(nn("http://ex/p"), bad)]).unwrap_err();
+    assert!(matches!(err, MpcError::Protocol(_)));
+}
+
+/// min > max is a Protocol error.
+#[test]
+fn min_greater_than_max_is_protocol_error() {
+    let edges = disclosed_edges(&[("ex:a ex:p ex:b .", &["http://ex/p"])]);
+    let form = PathForm::range(nn("http://ex/p"), 3, 1);
+    let err = eval_bounded_path_disclosed(&edges, &form).unwrap_err();
+    assert!(matches!(err, MpcError::Protocol(_)));
+}
+
+/// An absent predicate (no disclosed edges) contributes nothing — matches the
+/// engine treating a never-occurring predicate as the empty relation.
+#[test]
+fn absent_predicate_yields_empty_chain() {
+    let edges = disclosed_edges(&[("ex:a ex:p ex:b .", &["http://ex/p"])]);
+    // Sequence over a predicate that nobody disclosed: empty.
+    let form = PathForm::exact(nn("http://ex/missing"), 2);
+    let got = eval_bounded_path_disclosed(&edges, &form).unwrap();
+    assert!(got.rows.is_empty());
+}

--- a/crates/sparq-mpc/src/lib.rs
+++ b/crates/sparq-mpc/src/lib.rs
@@ -117,6 +117,15 @@ pub mod compare;
 // sq-hoaj. See the module docs for the critical-honesty constraint (no
 // single-process wall-clock masquerading as an MPC latency).
 pub mod bench;
+// [OPUS-4.8] sq-py8h.1: bounded property-path over DISCLOSED global-IRI keys —
+// the crypto-free "headline federation" regime. Unrolls a bounded path
+// `?a (p){m,k} ?b` (sequence / exact {k} / range {m,k} / reflexive {0,k} /
+// alternation) into a finite set of fixed BGP chains, evaluates each as a fold
+// of DisclosedKeyJoin OUTSIDE the cryptographic core, then UNION + DEDUP of the
+// endpoint pairs. NO MPC round runs. The HIDDEN-intermediate regime (secret
+// ?z_i) is the separate sq-py8h.2 and is NOT here. See the module docs for the
+// regime + semantic boundary statement.
+pub mod bounded_path;
 pub mod field;
 pub mod holder;
 pub mod join;
@@ -187,6 +196,10 @@ pub use backend::{
 // [OPUS-4.8] sq-sxm: the benchmark-matrix harness surface (in-process counting tier).
 pub use bench::{
     cell, run_matrix, CellSecurity, MatrixCell, MatrixResults, QueryClass, DEFAULT_PARTIES,
+};
+// [OPUS-4.8] sq-py8h.1: the disclosed-key bounded property-path surface.
+pub use bounded_path::{
+    eval_bounded_path_disclosed, BoundedRepetition, DisclosedEdges, PathForm, PathStep,
 };
 // [OPUS-4.8] sq-rrz4 + sq-g7t5: the secure-comparison surface (verdict-only
 // disclosure). sq-g7t5 adds the in-MPC bit-decomposition magnitude-bound constants


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes the **disclosed-key** slice of bounded property paths under MPC — increment #1 of `research/mpc-bounded-property-path-design.md` §6 step 1 (§2.1 DISCLOSED regime). Bead **sq-py8h.1** (parent **sq-py8h**).

## The unroll construction (crypto-free)

A bounded path `?a (p){m,k} ?b` whose endpoints **and** intermediate join keys are disclosed global IRIs is evaluated by *unrolling statically on the PUBLIC bound `k`* into a finite set of fixed-length BGP chains, then folding + unioning + deduping — all **OUTSIDE the cryptographic core** (architecture convention #4):

- **exactly-`ℓ` chain** `?a p ?z1 . ?z1 p ?z2 . … ?z_{ℓ-1} p ?b` → a left-to-right fold of the existing [`DisclosedKeyJoin`](crates/sparq-mpc/src/join.rs) on the fresh intermediate vars, then projected onto the endpoints. This is the §2.1 core — the *exact* shape of the join crate's `differential_three_holder_chain_equals_union` test, generalised to a bounded path.
- **`{m,k}`** → UNION of the exactly-`ℓ` chains for `ℓ in m..=k`.
- **`{0,k}` reflexive** → the `{1,k}` union PLUS the length-0 identity pairs `(x,x)` over the disclosed node domain (design §2.3); `p?` is the `{0,1}` special case.
- **alternation** `(p1|p2|…)` → each hop position expands over its alternatives (`alternatives^ℓ` fixed chains, design §2.4).
- **endpoint-pair DEDUP** → each distinct `(a,b)` appears once regardless of how many lengths/branches reached it (set semantics, §2.2/§2.5). The realized hop length is **never** in the output (§1.2 length-revealing prohibition).

**No secret sharing, no `secure_equal`, no `CommCounter` — NO MPC round runs.** It is a plaintext fold of equi-joins over disclosed global IRIs.

## Regime boundary (stated, not hidden)

**DISCLOSED-KEY ONLY.** Every endpoint and every intermediate `?z_i` is a disclosed global IRI. This is **NOT** the HIDDEN-intermediate regime (secret `?z_i` kept secret-shared via `secure_equal` / `degree_reduce` / `oblivious_set_output`) — that is the separate cryptographic deliverable **sq-py8h.2**, which *this bead blocks*. Disclosed-key bounded-path support is not hidden-path support.

**Semantic boundary:** implements the bounded `{m,k}` form exactly (a well-defined SPARQL 1.1 construct), not the unbounded `+`/`*` closure — a pair connected only by a chain longer than `k` is correctly absent.

## Differential-test matrix (13 tests, all passing)

Acceptance = the federated disclosed-key unroll **==** the clear-text engine's `eval_path` over the UNION store (mirrors `differential_three_holder_chain_equals_union`). The bounded `{m,k}` form is expressed to the engine as the equivalent SPARQL path it carries (union of fixed-length chains), so the equality is exact.

| Form | Test |
|---|---|
| plain sequence `p1/p2/p3` (3 holders) | `differential_plain_sequence_equals_eval_path` |
| exact `{3}` | `differential_exact_k_equals_eval_path` |
| range `{1,3}` | `differential_range_m_k_equals_eval_path` |
| range `{2,3}` (excludes length-1) | `differential_range_min_two_excludes_length_one` |
| reflexive `{0,2}` (identity pairs **exactly once**) | `differential_reflexive_zero_k_identity_pairs_once` |
| `p?` = `{0,1}` | `differential_zero_or_one_p_question` |
| alternation exact-2 / range `{1,2}` | `differential_alternation_exact_two_equals_eval_path`, `differential_alternation_range_one_two` |
| multi-length dedup to one pair | `dedup_collapses_multi_length_to_single_pair` |
| **crypto-free / round-count == 0** | `crypto_free_no_mpc_round_artifacts` |
| Protocol-error soundness | `edge_partial_wrong_arity_…`, `min_greater_than_max_…`, `absent_predicate_…` |

**Crypto-free assertion:** `crypto_free_no_mpc_round_artifacts` evaluates every supported form and asserts a `CommCounter`'s `mult_rounds == 0` and `open_rounds == 0` — the disclosed-key call graph reaches only `DisclosedKeyJoin` and plain `PartialResult`s, so no round can be recorded by construction.

## Verify

```
cargo build  -p sparq-mpc                                  # ok
cargo nextest run -p sparq-mpc                             # 220 passed, 0 failed (13 new)
cargo clippy -p sparq-mpc --all-targets -- -D warnings     # clean
```

All forms in the acceptance list are covered; nothing deferred from increment #1. No follow-up beads filed (sq-py8h.2 hidden-intermediate already exists per design §6 step 2).

Refs sq-py8h.1, parent sq-py8h, `research/mpc-bounded-property-path-design.md` §6 step 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
