### PR TITLE
feat(server): graceful degradation on transient durable-write I/O error (sq-vpx4)

### DIFF
--- a/crates/sparq-serve/src/applier.rs
+++ b/crates/sparq-serve/src/applier.rs
@@ -104,13 +104,14 @@ impl ApplyUpdates for GraphApplier {
     /// reaches the threshold, so overlay merge-on-read cost and per-fork delta
     /// copies stay bounded while the O(graph) fold runs only once per
     /// ~threshold/batch commits.
-    fn seal(&mut self, mut working: Graph) -> Graph {
+    fn seal(&mut self, mut working: Graph) -> Result<Graph, String> {
         if working.pending_delta_len() >= self.compact_threshold {
             // In-memory compaction cannot fail; a (directory-backed) failure
             // publishes the correct-but-uncompacted copy and retries next seal.
             let _ = working.compact();
         }
-        working
+        // [OPUS-4.8] (sq-vpx4) This applier has no durable side, so seal never fails.
+        Ok(working)
     }
 
     /// Conservative graph-level write footprint parsed from the update text

--- a/crates/sparq-serve/src/writer.rs
+++ b/crates/sparq-serve/src/writer.rs
@@ -470,16 +470,22 @@ fn commit<A: ApplyUpdates>(
 
     // [OPUS-4.8] (sq-vpx4) Seal is the durable-commit point for an applier with a
     // `--persist` mirror. On `Err` the batch did NOT durably commit: publish NOTHING
-    // (so no reader ever sees it), ack NOTHING with success, and fail every pending
-    // submitter with `Unavailable` (a retryable 503-class refusal). We then `return`
-    // — the writer thread survives the failure, so reads keep flowing from the last
-    // published generation and a subsequent batch is tried once durability recovers.
-    // This turns a transient durable-write error from a process-killing panic into a
-    // refused-but-honest write, WITHOUT weakening fail-closed: a write that didn't
-    // durably commit is still never acked 2xx nor published.
+    // (so no reader ever sees it) and ack NOTHING with success. We then `return` — the
+    // writer thread survives the failure, so reads keep flowing from the last published
+    // generation and a subsequent batch is tried once durability recovers. This turns a
+    // transient durable-write error from a process-killing panic into a refused-but-honest
+    // write, WITHOUT weakening fail-closed: a write that didn't durably commit is still
+    // never acked 2xx nor published.
+    //
+    // Failure semantics are per-submitter, NOT batch-wide: only submitters whose writes
+    // were actually pending durable commit (they applied cleanly — `errs[i] == None`) get
+    // the retryable `Unavailable` (503-class). Submitters already rejected during `apply`
+    // (`errs[i] == Some(_)`, e.g. a malformed/unauthorized update) keep their original
+    // `Rejected` reason — a deterministic 400-class error must NOT be masked as a retryable
+    // 503 just because an unrelated peer in the same batch failed to seal.
     let snapshot = match applier.seal(working) {
         Ok(s) => s,
-        Err(e) => return fail_all_unavailable(batch, &e),
+        Err(e) => return fail_batch_after_seal_error(batch, errs, &e),
     };
     let touched = applied.iter().flat_map(|&i| batch[i].touched.iter().cloned());
     let number = ring.publish(snapshot, touched).number();
@@ -531,15 +537,25 @@ fn fail_all<U>(batch: Vec<Msg<U>>, reason: &str) {
     }
 }
 
-/// [OPUS-4.8] (sq-vpx4) Fails every pending submitter with [`WriteError::Unavailable`]
-/// — used when [`ApplyUpdates::seal`] could not make the batch durable. Distinct from
-/// [`fail_all`] (a `Rejected`/400-class application error): `Unavailable` is a retryable
-/// 503-class refusal of an otherwise-valid write, and crucially the writer thread does
-/// NOT exit, so reads stay served and later writes can recover.
-fn fail_all_unavailable<U>(batch: Vec<Msg<U>>, reason: &str) {
-    for msg in batch {
+/// [OPUS-4.8] (sq-vpx4) Resolves a batch when [`ApplyUpdates::seal`] could not make it
+/// durable. Failure semantics are per-submitter, preserving the rejected-vs-pending
+/// distinction:
+///   * a submitter rejected during `apply` (`errs[i] == Some(reason)`) keeps that
+///     original `Rejected` reason — a deterministic 400-class error is NOT laundered into
+///     a retryable 503 just because an unrelated peer failed to seal;
+///   * a submitter that applied cleanly (`errs[i] == None`) was pending durable commit, so
+///     it gets [`WriteError::Unavailable`] (a retryable 503-class refusal of an otherwise
+///     valid write).
+///
+/// Crucially the writer thread does NOT exit, so reads stay served and later writes can
+/// recover, and fail-closed is preserved: nothing was published or acked 2xx.
+fn fail_batch_after_seal_error<U>(batch: Vec<Msg<U>>, mut errs: Vec<Option<String>>, reason: &str) {
+    for (i, msg) in batch.into_iter().enumerate() {
         if let Some(ack) = msg.ack {
-            let _ = ack.send(Err(WriteError::Unavailable(reason.to_string())));
+            let _ = ack.send(match errs[i].take() {
+                Some(rejected) => Err(WriteError::Rejected(rejected)),
+                None => Err(WriteError::Unavailable(reason.to_string())),
+            });
         }
     }
 }

--- a/crates/sparq-serve/src/writer.rs
+++ b/crates/sparq-serve/src/writer.rs
@@ -178,7 +178,19 @@ pub trait ApplyUpdates: Send + 'static {
     fn apply(&mut self, working: &mut Self::Working, update: &Self::Update) -> Result<(), String>;
 
     /// Finalizes the working copy into a publishable snapshot.
-    fn seal(&mut self, working: Self::Working) -> Self::Snapshot;
+    ///
+    /// [OPUS-4.8] (sq-vpx4) Fallible so an applier with a DURABLE side (e.g. the
+    /// server's `--persist` mirror) can refuse a batch whose durable commit failed
+    /// WITHOUT tearing down the writer thread. `Err(msg)` means "this batch did not
+    /// durably commit": the writer publishes NOTHING for it and fails every pending
+    /// submitter with [`WriteError::Unavailable`] — the fail-closed contract (never
+    /// ack/publish a write that didn't durably commit) is preserved, but a transient
+    /// I/O error (e.g. a brief `ENOSPC` that later clears) becomes a refused request
+    /// the client can retry rather than a process-killing panic. The writer thread
+    /// survives, so reads keep being served from the last published snapshot and a
+    /// later write succeeds once durability recovers. Purely in-memory appliers never
+    /// fail here (return `Ok`).
+    fn seal(&mut self, working: Self::Working) -> Result<Self::Snapshot, String>;
 
     /// The update's conservative write footprint, used only under
     /// [`CommitGranularity::CommuteGroup`] to form commuting runs. The default
@@ -201,6 +213,14 @@ pub enum WriteError {
     /// The writer has shut down (or its thread panicked); the update was not
     /// applied.
     Shutdown,
+    /// [OPUS-4.8] (sq-vpx4) The update applied cleanly in memory but its batch
+    /// could NOT be made durable ([`ApplyUpdates::seal`] returned `Err`, e.g. a
+    /// transient `ENOSPC`/I/O error on the `--persist` mirror). Nothing was
+    /// published and nothing was acked — the write is REFUSED, not silently lost,
+    /// and is safe to RETRY (a 503-class outcome). The writer thread stays alive,
+    /// so reads keep being served and a later write succeeds once durability
+    /// recovers. Carries the durability error.
+    Unavailable(String),
 }
 
 impl std::fmt::Display for WriteError {
@@ -208,6 +228,7 @@ impl std::fmt::Display for WriteError {
         match self {
             WriteError::Rejected(e) => write!(f, "update rejected: {e}"),
             WriteError::Shutdown => f.write_str("writer has shut down"),
+            WriteError::Unavailable(e) => write!(f, "update not durably committed (retryable): {e}"),
         }
     }
 }
@@ -447,7 +468,19 @@ fn commit<A: ApplyUpdates>(
         return;
     }
 
-    let snapshot = applier.seal(working);
+    // [OPUS-4.8] (sq-vpx4) Seal is the durable-commit point for an applier with a
+    // `--persist` mirror. On `Err` the batch did NOT durably commit: publish NOTHING
+    // (so no reader ever sees it), ack NOTHING with success, and fail every pending
+    // submitter with `Unavailable` (a retryable 503-class refusal). We then `return`
+    // — the writer thread survives the failure, so reads keep flowing from the last
+    // published generation and a subsequent batch is tried once durability recovers.
+    // This turns a transient durable-write error from a process-killing panic into a
+    // refused-but-honest write, WITHOUT weakening fail-closed: a write that didn't
+    // durably commit is still never acked 2xx nor published.
+    let snapshot = match applier.seal(working) {
+        Ok(s) => s,
+        Err(e) => return fail_all_unavailable(batch, &e),
+    };
     let touched = applied.iter().flat_map(|&i| batch[i].touched.iter().cloned());
     let number = ring.publish(snapshot, touched).number();
     for (i, msg) in batch.into_iter().enumerate() {
@@ -494,6 +527,19 @@ fn fail_all<U>(batch: Vec<Msg<U>>, reason: &str) {
     for msg in batch {
         if let Some(ack) = msg.ack {
             let _ = ack.send(Err(WriteError::Rejected(reason.to_string())));
+        }
+    }
+}
+
+/// [OPUS-4.8] (sq-vpx4) Fails every pending submitter with [`WriteError::Unavailable`]
+/// — used when [`ApplyUpdates::seal`] could not make the batch durable. Distinct from
+/// [`fail_all`] (a `Rejected`/400-class application error): `Unavailable` is a retryable
+/// 503-class refusal of an otherwise-valid write, and crucially the writer thread does
+/// NOT exit, so reads stay served and later writes can recover.
+fn fail_all_unavailable<U>(batch: Vec<Msg<U>>, reason: &str) {
+    for msg in batch {
+        if let Some(ack) = msg.ack {
+            let _ = ack.send(Err(WriteError::Unavailable(reason.to_string())));
         }
     }
 }

--- a/crates/sparq-serve/tests/commute.rs
+++ b/crates/sparq-serve/tests/commute.rs
@@ -72,7 +72,7 @@ fn serial_result(updates: &[(&str, &str)]) -> usize {
     for (upd, _) in updates {
         let mut w = applier.fork(&g).unwrap();
         applier.apply(&mut w, &(*upd).to_string()).unwrap();
-        g = applier.seal(w);
+        g = applier.seal(w).unwrap(); // [OPUS-4.8] (sq-vpx4) seal is now fallible (in-memory: never Err)
     }
     total_quads(&g)
 }

--- a/crates/sparq-serve/tests/tokens.rs
+++ b/crates/sparq-serve/tests/tokens.rs
@@ -38,8 +38,8 @@ impl ApplyUpdates for LogApplier {
         working.push(update.clone());
         Ok(())
     }
-    fn seal(&mut self, working: Log) -> Log {
-        working
+    fn seal(&mut self, working: Log) -> Result<Log, String> {
+        Ok(working) // [OPUS-4.8] (sq-vpx4) no durable side: seal is infallible
     }
 }
 

--- a/crates/sparq-serve/tests/writer.rs
+++ b/crates/sparq-serve/tests/writer.rs
@@ -25,11 +25,41 @@ struct MockApplier {
     /// Artificial per-fork cost, for the reader-stall stress (simulates the
     /// O(graph) fork of the production applier).
     fork_delay: Duration,
+    /// [OPUS-4.8] (sq-vpx4) Injected durable-write failures: when > 0, `seal`
+    /// fails (returns `Err`) and decrements — modelling a transient `ENOSPC`/I/O
+    /// error on a `--persist` mirror that later clears. Lets a test drive the
+    /// "writer survives a seal failure, the batch is refused, a later batch after
+    /// recovery succeeds" path against the mock.
+    seal_fails: Arc<AtomicUsize>,
+    /// Counts the seals the writer actually attempted (success or failure), so a
+    /// test can assert the writer kept running and re-attempted after a refusal.
+    seals: Arc<AtomicUsize>,
 }
 
 impl MockApplier {
     fn new(forks: &Arc<AtomicUsize>) -> Self {
-        MockApplier { forks: forks.clone(), fork_delay: Duration::ZERO }
+        MockApplier {
+            forks: forks.clone(),
+            fork_delay: Duration::ZERO,
+            seal_fails: Arc::new(AtomicUsize::new(0)),
+            seals: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// [OPUS-4.8] (sq-vpx4) Build a mock sharing the seal-failure and seal-count
+    /// handles with the test, so the test can arm transient durable-write failures
+    /// and observe that the writer survived them and re-attempted later.
+    fn with_seal_control(
+        forks: &Arc<AtomicUsize>,
+        seal_fails: &Arc<AtomicUsize>,
+        seals: &Arc<AtomicUsize>,
+    ) -> Self {
+        MockApplier {
+            forks: forks.clone(),
+            fork_delay: Duration::ZERO,
+            seal_fails: seal_fails.clone(),
+            seals: seals.clone(),
+        }
     }
 }
 
@@ -58,8 +88,16 @@ impl ApplyUpdates for MockApplier {
         Ok(())
     }
 
-    fn seal(&mut self, working: Log) -> Log {
-        working
+    fn seal(&mut self, working: Log) -> Result<Log, String> {
+        self.seals.fetch_add(1, Ordering::SeqCst);
+        // [OPUS-4.8] (sq-vpx4) Transient durable-write failure injection: consume one
+        // armed failure (if any) and refuse the batch. The writer must NOT publish and
+        // must NOT panic — it fails the submitters with `Unavailable` and keeps running.
+        if self.seal_fails.load(Ordering::SeqCst) > 0 {
+            self.seal_fails.fetch_sub(1, Ordering::SeqCst);
+            return Err("injected transient durable-write error (ENOSPC)".into());
+        }
+        Ok(working)
     }
 }
 
@@ -301,7 +339,12 @@ fn readers_never_stall_while_writer_commits() {
     let ring = Arc::new(GenerationRing::new(Log::new()));
     let writer = Arc::new(Writer::spawn(
         ring.clone(),
-        MockApplier { forks: forks.clone(), fork_delay: Duration::from_millis(2) },
+        MockApplier {
+            forks: forks.clone(),
+            fork_delay: Duration::from_millis(2),
+            seal_fails: Arc::new(AtomicUsize::new(0)),
+            seals: Arc::new(AtomicUsize::new(0)),
+        },
         WriterConfig { window: Duration::from_millis(1), max_batch: 64, ..WriterConfig::default() },
     ));
 
@@ -358,4 +401,93 @@ fn readers_never_stall_while_writer_commits() {
         // writer's batch application would blow straight past this.
         assert!(p99 < 1_000_000, "reader p99 = {p99} ns — a read blocked on the write path");
     }
+}
+
+/// [OPUS-4.8] (sq-vpx4) A TRANSIENT durable-write error (one armed seal failure that
+/// then clears) must REFUSE the in-flight write with `WriteError::Unavailable` (a
+/// retryable 503-class outcome) WITHOUT killing the writer thread, WITHOUT publishing,
+/// and WITHOUT acking 2xx — and a SUBSEQUENT write after recovery must succeed and
+/// publish. This is the core graceful-degradation contract.
+#[test]
+fn transient_seal_failure_refuses_then_recovers() {
+    let forks = Arc::new(AtomicUsize::new(0));
+    let seal_fails = Arc::new(AtomicUsize::new(0));
+    let seals = Arc::new(AtomicUsize::new(0));
+    let ring = Arc::new(GenerationRing::new(Log::new()));
+    let writer = Writer::spawn(
+        ring.clone(),
+        MockApplier::with_seal_control(&forks, &seal_fails, &seals),
+        // One update per window so each is its own batch / generation attempt.
+        WriterConfig { window: Duration::from_millis(5), max_batch: 1, ..WriterConfig::default() },
+    );
+
+    // Baseline: a normal write publishes generation 1.
+    let g1 = writer.submit("ok-1".to_string(), pods(&["pod:a"])).unwrap();
+    assert_eq!(g1, 1, "happy-path write must publish");
+    assert_eq!(ring.current().number(), 1);
+
+    // Arm ONE transient durable-write failure, then submit. The seal fails once.
+    seal_fails.store(1, Ordering::SeqCst);
+    let refused = writer.submit("will-be-refused".to_string(), pods(&["pod:a"]));
+    assert!(
+        matches!(refused, Err(WriteError::Unavailable(_))),
+        "transient durable-write error must be a retryable Unavailable refusal, got {refused:?}",
+    );
+
+    // FAIL-CLOSED: nothing was published — the ring is byte-identical to before
+    // (still generation 1, the refused update's effect absent).
+    assert_eq!(
+        ring.current().number(),
+        1,
+        "a refused (non-durable) write must NOT publish a new generation",
+    );
+    assert_eq!(
+        ring.current().snapshot(),
+        &vec!["ok-1".to_string()],
+        "the refused write must leave the published snapshot byte-identical",
+    );
+
+    // The writer thread SURVIVED: a subsequent write after recovery succeeds + publishes.
+    let g2 = writer.submit("ok-2".to_string(), pods(&["pod:a"])).unwrap();
+    assert_eq!(g2, 2, "writer must keep running and publish after a transient failure");
+    assert_eq!(ring.current().snapshot(), &vec!["ok-1".to_string(), "ok-2".to_string()]);
+
+    // Sanity: the writer actually re-attempted the seal after the refusal.
+    assert!(seals.load(Ordering::SeqCst) >= 3, "writer must have re-attempted seal after refusal");
+}
+
+/// [OPUS-4.8] (sq-vpx4) A PERSISTENT durable-write error → every write is refused with
+/// `Unavailable` (no panic, no publish), the writer stays alive across all of them, and
+/// reads keep being served from the last published snapshot the whole time (degraded
+/// read-only mode). When durability finally recovers, writes resume.
+#[test]
+fn persistent_seal_failure_refuses_repeatedly_reads_survive() {
+    let forks = Arc::new(AtomicUsize::new(0));
+    let seal_fails = Arc::new(AtomicUsize::new(0));
+    let seals = Arc::new(AtomicUsize::new(0));
+    let ring = Arc::new(GenerationRing::new(Log::new()));
+    let writer = Writer::spawn(
+        ring.clone(),
+        MockApplier::with_seal_control(&forks, &seal_fails, &seals),
+        WriterConfig { window: Duration::from_millis(5), max_batch: 1, ..WriterConfig::default() },
+    );
+
+    // Establish a published snapshot, then jam durability "persistently".
+    writer.submit("ok-1".to_string(), pods(&["pod:a"])).unwrap();
+    seal_fails.store(5, Ordering::SeqCst);
+
+    for n in 0..5 {
+        let r = writer.submit(format!("refused-{n}"), pods(&["pod:a"]));
+        assert!(
+            matches!(r, Err(WriteError::Unavailable(_))),
+            "write #{n} under persistent durability failure must be Unavailable, got {r:?}",
+        );
+        // Reads still served from the last good snapshot throughout the outage.
+        assert_eq!(ring.current().number(), 1, "reads must keep serving generation 1 during the outage");
+        assert_eq!(ring.current().snapshot(), &vec!["ok-1".to_string()]);
+    }
+
+    // Durability recovered (all armed failures consumed): writes resume.
+    let g = writer.submit("ok-2".to_string(), pods(&["pod:a"])).unwrap();
+    assert_eq!(g, 2, "writes must resume once durability recovers");
 }

--- a/crates/sparq-serve/tests/writer.rs
+++ b/crates/sparq-serve/tests/writer.rs
@@ -456,6 +456,59 @@ fn transient_seal_failure_refuses_then_recovers() {
     assert!(seals.load(Ordering::SeqCst) >= 3, "writer must have re-attempted seal after refusal");
 }
 
+/// [OPUS-4.8] (sq-vpx4) Per-submitter failure semantics when `seal` fails on a MIXED
+/// batch: one update is rejected during `apply` (a deterministic 400-class error) and one
+/// applies cleanly (pending durable commit). The seal then fails. The rejected submitter
+/// must keep its ORIGINAL `Rejected` reason (NOT laundered into a retryable 503), while the
+/// clean-but-undurable submitter gets `Unavailable`. Fail-closed holds: nothing publishes.
+#[test]
+fn seal_failure_keeps_apply_rejection_distinct_from_unavailable() {
+    let forks = Arc::new(AtomicUsize::new(0));
+    let seal_fails = Arc::new(AtomicUsize::new(0));
+    let seals = Arc::new(AtomicUsize::new(0));
+    let ring = Arc::new(GenerationRing::new(Log::new()));
+    // One wide window so both staggered submitters land in the SAME batch.
+    let writer = Arc::new(Writer::spawn(
+        ring.clone(),
+        MockApplier::with_seal_control(&forks, &seal_fails, &seals),
+        WriterConfig { window: Duration::from_millis(300), max_batch: 64, ..WriterConfig::default() },
+    ));
+
+    // Arm ONE seal failure: it fires when the writer seals this batch.
+    seal_fails.store(1, Ordering::SeqCst);
+
+    let spawn_submit = |update: &str, pod: &str, delay_ms: u64| {
+        let writer = writer.clone();
+        let update = update.to_string();
+        let pod = PodId::from(pod);
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(delay_ms));
+            writer.submit(update, [pod])
+        })
+    };
+    // A rejected-during-apply update + a valid one, both inside the open window.
+    let rejected = spawn_submit("fail:bad-request", "pod:bad", 0);
+    let valid = spawn_submit("ok", "pod:ok", 60);
+
+    // The to-be-rejected update keeps ITS 400-class reason, not a 503 Unavailable.
+    assert_eq!(
+        rejected.join().unwrap().unwrap_err(),
+        WriteError::Rejected("bad-request".into()),
+        "an update rejected during apply must keep its original Rejected reason after a seal failure",
+    );
+    // The valid-but-undurable update is refused with the retryable Unavailable.
+    assert!(
+        matches!(valid.join().unwrap(), Err(WriteError::Unavailable(_))),
+        "a clean update that was pending durable commit must get Unavailable when seal fails",
+    );
+
+    // FAIL-CLOSED: nothing published; the writer survived and recovers on the next write.
+    assert_eq!(ring.current().number(), 0, "a seal-failed batch must publish no generation");
+    assert!(ring.current().snapshot().is_empty());
+    let g = writer.submit("ok-after".to_string(), pods(&["pod:ok"])).unwrap();
+    assert_eq!(g, 1, "writer must keep running and publish once durability recovers");
+}
+
 /// [OPUS-4.8] (sq-vpx4) A PERSISTENT durable-write error → every write is refused with
 /// `Unavailable` (no panic, no publish), the writer stays alive across all of them, and
 /// reads keep being served from the last published snapshot the whole time (degraded

--- a/crates/sparq-serve/tests/writer_graph.rs
+++ b/crates/sparq-serve/tests/writer_graph.rs
@@ -136,7 +136,7 @@ fn fork_cost_measurement() {
         let first = applier.fork(&g).unwrap();
         let first_cost = t.elapsed();
         assert_eq!(first.len(), n);
-        let frozen = applier.seal(first);
+        let frozen = applier.seal(first).unwrap(); // [OPUS-4.8] (sq-vpx4) fallible seal; in-memory never Err
 
         // Steady-state fork off the frozen lineage (no pending delta).
         let mut best = Duration::MAX;
@@ -165,7 +165,7 @@ fn fork_cost_measurement() {
                     .join(" ")
             );
             applier.apply(&mut w, &upd).unwrap();
-            base = applier.seal(w);
+            base = applier.seal(w).unwrap();
         }
         let total = t.elapsed();
         assert_eq!(base.len(), n + commits as usize * 10);
@@ -194,7 +194,7 @@ fn pending_delta_stays_bounded_under_sustained_updates() {
              <http://ex/b{c}> <http://ex/r> <http://ex/t{c}> }}"
         );
         applier.apply(&mut w, &upd).unwrap();
-        let sealed = applier.seal(w);
+        let sealed = applier.seal(w).unwrap();
         let pending = sealed.pending_delta_len();
         max_pending = max_pending.max(pending);
         if pending == 0 && c > 0 {

--- a/crates/sparq-server/Cargo.toml
+++ b/crates/sparq-server/Cargo.toml
@@ -36,6 +36,12 @@ required-features = ["server"]
 # are never part of the bundle. Kept behind a feature so a consumer can depend on the
 # pure serializer library (XML/CSV/TSV) without dragging in the runtime.
 default = ["server"]
+# [OPUS-4.8] (sq-vpx4) Compiles internal TEST SEAMS — currently the durable-write
+# failure-injection hook on the `--persist` seal path, exposed via
+# `AppState::with_config_inject_durable_failure` for the graceful-degradation
+# integration test. Production builds never enable it (the seam field + constructor
+# vanish), so production behaviour is byte-identical to a build without this feature.
+test-seams = []
 # [OPUS-4.8] (sq-7cxr, gh-44) `server` turns on `sparq-core/mmap` so the binary can use the
 # engine's durable directory-backed `Graph` (`Graph::open`/`save` + the per-graph write-ahead
 # log + named-graph persistence) behind the `--persist <DIR>` flag — the QLever `--persist-updates`

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -148,11 +148,17 @@ Semantics:
   so a non-deterministic or side-effecting update (`NOW()`/`RAND()`/`UUID()`/`BNODE()`,
   `LOAD <remote>`) persists the EXACT value that was acked — never a re-rolled one — so a restart
   surfaces precisely what the client saw.
-- **Deferred hardening (beaded, not yet wired):** byte-accounted durability metrics, graceful
-  degradation on a *transient* disk-I/O error (today a durability failure is fatal — the write
-  is refused rather than silently lost), online compaction tuning under sustained write load,
-  and WAL-durable `CLEAR`/`DROP GRAPH <g>` of an *existing* named graph (today those operations
-  are applied in memory and persisted only at the next compaction).
+- **Graceful degradation on a durable-write error (sq-vpx4).** A durable-write failure (e.g. a
+  transient `ENOSPC` / I/O error on the `--persist` mirror) no longer kills the server: the
+  in-flight write is **refused with `503` (retryable)** — never acked `2xx`, never published —
+  and the writer thread stays alive. Reads keep being served from the last published snapshot
+  (degraded read-only), and a subsequent write succeeds once durability recovers; a persistent
+  error simply yields repeated `503`s. The fail-closed invariant is unchanged: a write that did
+  not durably commit is never observed by any reader.
+- **Deferred hardening (beaded, not yet wired):** byte-accounted durability metrics, online
+  compaction tuning under sustained write load, and WAL-durable `CLEAR`/`DROP GRAPH <g>` of an
+  *existing* named graph (today those operations are applied in memory and persisted only at the
+  next compaction).
 
 ## 🐳 Running the container image (ghcr.io)
 

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -857,6 +857,14 @@ fn open_or_create_durable(dir: &std::path::Path, seed: Graph) -> Result<Graph, S
     Graph::open(dir).map_err(|e| format!("opening freshly-initialised persist dir {}: {e}", dir.display()))
 }
 
+/// [OPUS-4.8] (sq-vpx4) Internal marker prefixed onto the error string of a
+/// [`WriteError::Unavailable`] (durable-write refusal) as it crosses from
+/// [`AppState::apply_update`] to the HTTP response mapper, so
+/// [`update_rejection_response`] can route it to HTTP 503 (retryable) rather than the
+/// default 400 (client error). Never leaves the process — stripped before the message
+/// reaches the client.
+const DURABLE_UNAVAILABLE_PREFIX: &str = "\u{1}durable-unavailable\u{1}";
+
 struct ServerApplier {
     inner: GraphApplier,
     /// The config the writer thread enforces around every engine call (carries the
@@ -891,6 +899,41 @@ struct ServerApplier {
 struct DurableStore {
     graph: Graph,
     batch: Vec<sparq_engine::UpdateEffect>,
+    /// [OPUS-4.8] (sq-vpx4) TEST SEAM for injecting durable-write I/O failures into the
+    /// seal path. In production this is `None` and the real [`sparq_engine::apply_effects`]
+    /// runs. A test can install a hook that fails the durable commit (e.g. once with a
+    /// simulated `ENOSPC`, then clears) WITHOUT touching the production code path — the
+    /// hook decides per-call whether to fail. Boxed `FnMut` so it can hold per-call state
+    /// (a "fail the next N seals" counter). Production behaviour is unchanged: `None` ⇒
+    /// exactly the prior `apply_effects` call.
+    #[cfg(any(test, feature = "test-seams"))]
+    fail_seal: Option<Box<dyn FnMut() -> Option<String> + Send>>,
+}
+
+impl DurableStore {
+    fn new(graph: Graph) -> Self {
+        DurableStore {
+            graph,
+            batch: Vec::new(),
+            #[cfg(any(test, feature = "test-seams"))]
+            fail_seal: None,
+        }
+    }
+
+    /// [OPUS-4.8] (sq-vpx4) Commit the buffered batch durably. Returns `Err` on a
+    /// durable-write failure (real I/O error, or an injected one via the test seam) —
+    /// the caller ([`ServerApplier::seal`]) propagates this WITHOUT publishing or
+    /// acking, so a write that didn't durably commit is never observed.
+    fn commit_batch(&mut self) -> Result<(), String> {
+        let batch = std::mem::take(&mut self.batch);
+        #[cfg(any(test, feature = "test-seams"))]
+        if let Some(hook) = self.fail_seal.as_mut() {
+            if let Some(e) = hook() {
+                return Err(e);
+            }
+        }
+        sparq_engine::apply_effects(&mut self.graph, &batch)
+    }
 }
 
 impl ServerApplier {
@@ -905,7 +948,7 @@ impl ServerApplier {
         Self {
             inner: GraphApplier::default(),
             config,
-            durable: Some(DurableStore { graph, batch: Vec::new() }),
+            durable: Some(DurableStore::new(graph)),
         }
     }
 }
@@ -952,7 +995,7 @@ impl ApplyUpdates for ServerApplier {
         Ok(())
     }
 
-    fn seal(&mut self, working: Graph) -> Graph {
+    fn seal(&mut self, working: Graph) -> Result<Graph, String> {
         // [OPUS-4.8] (sq-7cxr, gh-44) Persist the committed batch to the durable graph BEFORE
         // returning — `seal` runs on the writer thread immediately before `publish`, so the
         // batch is WAL-durable (fsync'd by `Graph::apply_delta`) before the generation is
@@ -965,17 +1008,22 @@ impl ApplyUpdates for ServerApplier {
         // (`NOW()`/`RAND()`/`UUID()`/`BNODE()`, `LOAD <remote>`): both apply the identical
         // resolved triples, in the same order, starting from one shared seed.
         //
-        // FAIL-CLOSED: a durable-write error (disk full, I/O error) panics the writer thread.
-        // `seal` runs before `publish`, so unwinding here means the generation is NOT published
-        // and every pending submitter's ack channel drops → they get `WriteError::Shutdown`, NOT
-        // a false success. A server that can no longer make writes durable must not keep silently
-        // accepting them. (Graceful degradation on a TRANSIENT I/O error is deferred hardening —
-        // bead; today a durability failure is treated as fatal, which is honest for a persisted
-        // store.)
+        // [OPUS-4.8] FAIL-CLOSED, GRACEFULLY (sq-vpx4, was sq-7cxr fatal-panic): a durable-write
+        // error (disk full, I/O error) is propagated as `Err` rather than panicking the writer
+        // thread. `seal` runs BEFORE `publish`, so returning `Err` here means the generation is
+        // NEVER published and the in-flight batch's submitters are failed with
+        // `WriteError::Unavailable` (HTTP 503, retryable) — NOT a false 2xx success. The
+        // fail-closed correctness invariant is unchanged (a write that didn't durably commit is
+        // never acked nor published); what changes is that a TRANSIENT error (e.g. a brief
+        // `ENOSPC` that later clears) no longer kills the writer thread / the whole server. The
+        // writer stays alive (degraded), so reads keep being served from the last published
+        // snapshot and a subsequent write succeeds once durability recovers. A PERSISTENT error
+        // simply yields repeated 503s. The in-memory `working` is dropped on `Err` (never
+        // published), so the durable store and the published lineage cannot diverge.
         if let Some(d) = &mut self.durable {
-            let batch = std::mem::take(&mut d.batch);
-            sparq_engine::apply_effects(&mut d.graph, &batch)
-                .unwrap_or_else(|e| panic!("durable persist failed (sq-7cxr); refusing to ack the write: {e}"));
+            d.commit_batch().map_err(|e| {
+                format!("durable persist failed (sq-vpx4); write refused (not acked, not published): {e}")
+            })?;
         }
         self.inner.seal(working)
     }
@@ -1044,6 +1092,37 @@ impl AppState {
     /// [`ServerApplier::seal`]). With `persist_dir == None` this is exactly the historical
     /// in-memory path (the ring is seeded from `graph`; no durable mirror; never errors).
     pub fn try_with_config(graph: Graph, config: ServerConfig) -> Result<Self, String> {
+        Self::try_with_config_inner(
+            graph,
+            config,
+            #[cfg(any(test, feature = "test-seams"))]
+            None,
+        )
+    }
+
+    /// [OPUS-4.8] (sq-vpx4) Like [`try_with_config`](Self::try_with_config) but installs a
+    /// durable-write failure-injection hook on the `--persist` seal path. The hook is called
+    /// once per seal; returning `Some(msg)` makes that seal fail (modelling a transient/persistent
+    /// I/O error), `None` lets the real durable commit run. For the graceful-degradation
+    /// integration test ONLY — gated behind the `test-seams` feature so it cannot exist in a
+    /// production build. Requires `config.persist_dir` to be set (else the hook has nothing to
+    /// gate).
+    #[cfg(feature = "test-seams")]
+    pub fn with_config_inject_durable_failure(
+        graph: Graph,
+        config: ServerConfig,
+        fail_seal: Box<dyn FnMut() -> Option<String> + Send>,
+    ) -> Result<Self, String> {
+        Self::try_with_config_inner(graph, config, Some(fail_seal))
+    }
+
+    fn try_with_config_inner(
+        graph: Graph,
+        config: ServerConfig,
+        #[cfg(any(test, feature = "test-seams"))] fail_seal: Option<
+            Box<dyn FnMut() -> Option<String> + Send>,
+        >,
+    ) -> Result<Self, String> {
         // [OPUS-4.8] sq-7cxr: resolve the durable graph (open existing / create fresh) when a
         // persistence dir is configured. `seed` is what the ring starts from; `durable` is the
         // on-disk graph the writer mirrors committed batches to.
@@ -1078,7 +1157,17 @@ impl AppState {
         // [OPUS-4.8] sq-7cxr: a durable-mirroring applier when persistence is on, else the
         // historical in-memory applier.
         let applier = match durable {
-            Some(g) => ServerApplier::with_durable(config.clone(), g),
+            Some(g) => {
+                #[allow(unused_mut)]
+                let mut a = ServerApplier::with_durable(config.clone(), g);
+                // [OPUS-4.8] (sq-vpx4) Install the durable-write failure-injection hook, if any
+                // (test-seams only). A no-op in production (the field/parameter do not exist).
+                #[cfg(any(test, feature = "test-seams"))]
+                if let (Some(d), Some(hook)) = (a.durable.as_mut(), fail_seal) {
+                    d.fail_seal = Some(hook);
+                }
+                a
+            }
             None => ServerApplier::new(config.clone()),
         };
         let writer = Arc::new(Writer::spawn(ring.clone(), applier, WriterConfig::default()));
@@ -1149,6 +1238,13 @@ impl AppState {
             }
             Err(WriteError::Rejected(e)) => Err(e),
             Err(WriteError::Shutdown) => Err("update writer has shut down".to_string()),
+            // [OPUS-4.8] (sq-vpx4) Durable-write failure (e.g. transient ENOSPC on the
+            // `--persist` mirror): the write was REFUSED — not durably committed, not
+            // published, not acked. It is retryable, so it maps to HTTP 503 (see
+            // `update_rejection_response`'s `DURABLE_UNAVAILABLE_PREFIX` sniff), NOT a
+            // 400 (the update itself was valid) and NOT a 500 (the server is healthy
+            // and still serving reads). The writer thread is alive; the client may retry.
+            Err(WriteError::Unavailable(e)) => Err(format!("{DURABLE_UNAVAILABLE_PREFIX}{e}")),
         }
     }
 
@@ -1871,6 +1967,16 @@ fn engine_error_response(e: &str, config: &ServerConfig, apply_max_results: bool
 /// hit (the memory cap / deadline tripped inside a `DELETE/INSERT … WHERE`) is a 413 / 503,
 /// exactly like a query; any other rejection (parse / semantic error) is the client's 400.
 fn update_rejection_response(e: &str, config: &ServerConfig) -> Response {
+    // [OPUS-4.8] (sq-vpx4) A durable-write refusal is a retryable 503, NOT a 400. The write
+    // was valid but could not be made durable (transient ENOSPC/I/O on the `--persist` mirror);
+    // nothing was published or acked, the server is still serving reads, and the client should
+    // retry. Sniffed before the budget/parse mapping so it always wins.
+    if let Some(detail) = e.strip_prefix(DURABLE_UNAVAILABLE_PREFIX) {
+        return json_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            &format!("update not durably committed (transient durable-write error); the write was refused and NOT applied — retry: {detail}"),
+        );
+    }
     if e.contains("query budget exceeded") {
         // Updates budget from `--max-query-rows` alone (`update_budget`, no `--max-results`),
         // so the 413 message must not consider `--max-results` → `apply_max_results = false`.
@@ -3177,5 +3283,36 @@ mod service_allow_config_tests {
         e.sort();
         // Exact host verbatim; the wildcard in the engine's leading-dot form.
         assert_eq!(e, vec![".internal".to_string(), "sparql.example.org".to_string()]);
+    }
+}
+
+/// [OPUS-4.8] (sq-vpx4) The HTTP status CONTRACT for a durable-write refusal: a
+/// `WriteError::Unavailable` (carried across `apply_update` with the internal
+/// `DURABLE_UNAVAILABLE_PREFIX`) maps to HTTP 503 (retryable) — NOT the default 400 for a
+/// rejected update, and NOT a 500. The internal marker must never leak to the client.
+#[cfg(test)]
+mod durable_degrade_tests {
+    use super::{update_rejection_response, ServerConfig, DURABLE_UNAVAILABLE_PREFIX};
+    use axum::http::StatusCode;
+
+    #[test]
+    fn durable_unavailable_maps_to_503_and_hides_marker() {
+        let cfg = ServerConfig::default();
+        let tagged = format!("{DURABLE_UNAVAILABLE_PREFIX}injected ENOSPC");
+        let resp = update_rejection_response(&tagged, &cfg);
+        assert_eq!(
+            resp.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a durable-write refusal must be a retryable 503, not a 400/500",
+        );
+    }
+
+    #[test]
+    fn ordinary_update_rejection_still_400() {
+        // A plain application error (parse/semantic) keeps its 400 — the 503 sniff must not
+        // hijack the normal rejection path.
+        let cfg = ServerConfig::default();
+        let resp = update_rejection_response("some parse error", &cfg);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -3295,8 +3295,8 @@ mod durable_degrade_tests {
     use super::{update_rejection_response, ServerConfig, DURABLE_UNAVAILABLE_PREFIX};
     use axum::http::StatusCode;
 
-    #[test]
-    fn durable_unavailable_maps_to_503_and_hides_marker() {
+    #[tokio::test]
+    async fn durable_unavailable_maps_to_503_and_hides_marker() {
         let cfg = ServerConfig::default();
         let tagged = format!("{DURABLE_UNAVAILABLE_PREFIX}injected ENOSPC");
         let resp = update_rejection_response(&tagged, &cfg);
@@ -3304,6 +3304,27 @@ mod durable_degrade_tests {
             resp.status(),
             StatusCode::SERVICE_UNAVAILABLE,
             "a durable-write refusal must be a retryable 503, not a 400/500",
+        );
+
+        // The internal marker must NEVER reach the client: assert it is absent from the
+        // BODY (not just that the status is right). A future leak of the prefix into the
+        // client-facing JSON — raw OR JSON-escaped (`json_error` escapes the U+0001 control
+        // chars to ``) — is caught here. The human-readable detail after the marker
+        // is expected to survive; only the marker bytes must be stripped.
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(
+            !body.contains(DURABLE_UNAVAILABLE_PREFIX),
+            "raw internal marker leaked into the client-facing body: {body:?}",
+        );
+        // The JSON-escaped form of the marker's control bytes (U+0001 -> ).
+        assert!(
+            !body.contains("\\u0001"),
+            "JSON-escaped internal marker leaked into the client-facing body: {body:?}",
+        );
+        assert!(
+            body.contains("injected ENOSPC"),
+            "the human-readable detail must still be reported to the client: {body:?}",
         );
     }
 

--- a/crates/sparq-server/tests/persist.rs
+++ b/crates/sparq-server/tests/persist.rs
@@ -470,3 +470,125 @@ async fn existing_store_wins_over_seed() {
     // discarding the join result (which would silently mask a server-side failure).
     task.await.expect("server serve task panicked / failed");
 }
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-vpx4) GRACEFUL DEGRADATION on a TRANSIENT durable-write I/O error.
+//
+// Before sq-vpx4 a durable-write failure in `ServerApplier::seal` PANICKED the writer
+// thread (fail-closed but server-killing). These tests prove the new contract end-to-end
+// over HTTP: a durable-write error REFUSES the in-flight write with HTTP 503 (retryable)
+// WITHOUT tearing down the writer / the server, the refused write is NEVER published or
+// acked (fail-closed preserved — byte-identical store), reads keep being served from the
+// last published snapshot, and a SUBSEQUENT write after recovery succeeds (204) + is
+// durable across a restart.
+//
+// The failure is injected via the `test-seams`-only seam
+// (`AppState::with_config_inject_durable_failure`) — production code is unchanged.
+// ---------------------------------------------------------------------------
+
+/// Boots a `--persist` server whose seal path fails its first `n_fail` durable commits
+/// (then succeeds), modelling a transient `ENOSPC` that clears. `test-seams` only.
+#[cfg(feature = "test-seams")]
+async fn start_with_transient_failures(config: ServerConfig, n_fail: usize) -> Server {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Arc;
+    let graph = Graph::load_str("", "turtle").unwrap();
+    let remaining = Arc::new(AtomicUsize::new(n_fail));
+    let hook: Box<dyn FnMut() -> Option<String> + Send> = Box::new(move || {
+        if remaining.load(Ordering::SeqCst) > 0 {
+            remaining.fetch_sub(1, Ordering::SeqCst);
+            Some("injected transient durable-write error (ENOSPC)".to_string())
+        } else {
+            None
+        }
+    });
+    let state = AppState::with_config_inject_durable_failure(graph, config, hook)
+        .expect("durable open with injected failure seam");
+    let app = router(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let task = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    Server { base: format!("http://{addr}"), shutdown: Some(tx), task: Some(task) }
+}
+
+/// A TRANSIENT durable-write error → the in-flight write gets HTTP 503, the writer thread
+/// SURVIVES (no panic, server still serving), reads keep working, and a SUBSEQUENT write
+/// after recovery succeeds (204) + publishes + is durable across a restart.
+#[cfg(feature = "test-seams")]
+#[tokio::test]
+async fn transient_durable_write_error_503_then_recovers() {
+    let scratch = ScratchDir::new();
+    let cl = reqwest::Client::new();
+
+    // First seal fails once, then durability is healthy.
+    let s = start_with_transient_failures(persist_config(scratch.path()), 1).await;
+
+    // The FIRST update hits the injected failure → 503 (the write is refused).
+    let refused = post_update(&cl, &s.base, "INSERT DATA { <http://ex/a> <http://ex/p> <http://ex/v> }").await;
+    assert_eq!(
+        refused, 503,
+        "a transient durable-write error must refuse the in-flight write with 503 (retryable)",
+    );
+
+    // FAIL-CLOSED: the refused write was NOT published — it must be absent.
+    assert_eq!(
+        count_rows(&cl, &s.base, "SELECT * WHERE { ?s ?p ?o }").await,
+        0,
+        "a refused (non-durable) write must NOT be published / queryable",
+    );
+
+    // The writer SURVIVED: reads still work (server alive), and the SAME write retried now
+    // succeeds (durability recovered) — 204 + queryable.
+    let retried = post_update(&cl, &s.base, "INSERT DATA { <http://ex/a> <http://ex/p> <http://ex/v> }").await;
+    assert_eq!(retried, 204, "after recovery the retried write must succeed (writer survived)");
+    assert_eq!(count_rows(&cl, &s.base, "SELECT * WHERE { ?s ?p ?o }").await, 1);
+
+    // The recovered write is genuinely DURABLE: restart on the same dir and it's still there.
+    s.stop().await;
+    let s2 = Server::start(persist_config(scratch.path())).await;
+    assert_eq!(
+        count_rows(&cl, &s2.base, "SELECT * WHERE { ?s ?p ?o }").await,
+        1,
+        "the post-recovery write must survive a restart (it really was made durable)",
+    );
+    s2.stop().await;
+}
+
+/// A PERSISTENT durable-write error → every write is refused 503 (no panic), the writer
+/// stays alive, and reads keep being served from the last published snapshot the whole time
+/// (degraded read-only mode).
+#[cfg(feature = "test-seams")]
+#[tokio::test]
+async fn persistent_durable_write_error_repeated_503_reads_survive() {
+    let scratch = ScratchDir::new();
+    let cl = reqwest::Client::new();
+
+    // Jam durability from the start (a large failure budget) and assert the (empty) last
+    // published snapshot keeps serving reads under repeated refusals.
+    let s = start_with_transient_failures(persist_config(scratch.path()), 1_000).await;
+
+    for n in 0..4 {
+        let status = post_update(
+            &cl,
+            &s.base,
+            &format!("INSERT DATA {{ <http://ex/x{n}> <http://ex/p> <http://ex/v> }}"),
+        )
+        .await;
+        assert_eq!(status, 503, "write #{n} under persistent durability failure must be 503");
+        // Reads keep being served (the server is alive, degraded read-only).
+        assert_eq!(
+            count_rows(&cl, &s.base, "SELECT * WHERE { ?s ?p ?o }").await,
+            0,
+            "reads must keep being served from the (empty) last published snapshot during the outage",
+        );
+    }
+    s.stop().await;
+}


### PR DESCRIPTION
> 🤖 SPARQ agent

## What & why (sq-vpx4, refs gh-44)

Under `--persist`, a durable-write failure in `ServerApplier::seal` used to **panic the writer thread**, which is honest (no false ack, no publish) but **kills the whole server** on a *transient* error (e.g. a brief `ENOSPC` that later clears). This PR turns that process-kill into a **refused request + degraded mode**.

## Approach: fallible seal → refuse 503 + degraded read-only (writer survives)

`ApplyUpdates::seal` is now **fallible** (`-> Result<Snapshot, String>`). On a durable-write error the writer thread:
- publishes **nothing** and fails the in-flight batch's submitters with a new `WriteError::Unavailable` (retryable), then **continues its loop** — the thread does **not** exit;
- so **reads keep being served from the last published snapshot** (degraded read-only), and a **subsequent write succeeds once durability recovers**; a **persistent** error yields repeated 503s.

I chose the *degraded read-only + refuse 503* shape over server-side retry/backoff: it is the minimal change that fits the existing single-sequenced-writer / ArcSwap-publish model, keeps the writer non-blocking for readers, and lets the **client** own the retry policy (the write is cleanly refused, not held). The client can retry immediately.

## How the fail-closed invariant is PRESERVED (sacred)

`seal` runs on the writer thread **before** `ring.publish`. Returning `Err`:
- means the generation is **never published** (no reader ever observes the write), and
- the in-memory `working` graph is **dropped** (never published), so the durable store and the published lineage **cannot diverge**;
- the submitters are failed with `Unavailable` → **no 2xx ack**.

So a write that didn't durably commit is **never acked and never published** — unchanged from the old panic behaviour. The *only* thing that changed is: a transient durable error no longer tears down the writer/server.

## HTTP status contract

`WriteError::Unavailable` → **HTTP 503** (retryable), distinct from a rejected (invalid) update's **400** and from a panic's **500**. The 503 body tells the client the write was refused and NOT applied — retry. (An internal marker prefix carries `Unavailable` across `apply_update` to the response mapper and is stripped before reaching the client.)

## Test matrix

Writer-level (`sparq-serve/tests/writer.rs`, against a mock with an injectable seal failure):
- **transient recovers** — one armed seal failure → `Unavailable` refusal, ring **byte-identical** (no new generation, snapshot unchanged), writer survives, next write publishes; asserts the writer re-attempted seal.
- **persistent** — repeated `Unavailable`, reads keep serving the last snapshot, writes resume after recovery.

HTTP-level (`sparq-server/tests/persist.rs`, `test-seams` feature, real `--persist` server):
- **transient → 503 then 204** — first write 503, store empty (not published), retried write 204 + queryable, and the recovered write **survives a restart** (genuinely durable).
- **persistent → repeated 503** — every write 503, **reads keep being served** (degraded read-only), no panic.

Unit (`http.rs`): `Unavailable` → 503 (marker hidden); ordinary rejection still 400.

Plus the **happy path** (durable write acks 204 + publishes) is unchanged and still covered by the existing persist suite.

## Test seam

A `test-seams` cargo feature (OFF by default, never in production) exposes `DurableStore.fail_seal` + `AppState::with_config_inject_durable_failure` to inject I/O failures into the seal path. Production behaviour is byte-identical to a build without the feature (the field/constructor are `#[cfg]`-gated out).

## Verify

- `cargo nextest run -p sparq-serve` → **55/55** (1 skipped)
- `cargo nextest run -p sparq-server --features test-seams` → **209/209** (1 skipped)
- `cargo clippy -p sparq-serve --all-targets -- -D warnings` and `cargo clippy -p sparq-server --all-targets [--features test-seams] -- -D warnings` → clean

Non-canonical timing (EC2 work box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)