### PR TITLE
docs(agents): fold cross-crate/cross-surface parity principle (Closes #173)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,11 @@ Then edit the corresponding `skills/<surface>/SKILL.md` (sparql-query / data-for
 
 If you add a brand-new public surface, add a new `skills/<surface>/` (dir name == the skill's `name` frontmatter) and link it from the list above and from the README.
 
+## Fix a shared issue everywhere it applies — cross-crate/cross-surface parity
+
+<!-- [OPUS-4.8] charter cross-poll from PSS #173 -->
+When a bug or review finding describes a **class** of problem affecting more than one place — a parser edge case in Turtle that also hits TriG, an operator bug whose sibling operators share a code path, a `pub`-surface footgun repeated across the CLI / HTTP / Python / JS-WASM bindings — it must **eventually be addressed in every instance, not patched only where it surfaced.** **Prefer fixing the pattern ONCE in the shared place** (the common code path, or a `sparq-core` helper) so all surfaces inherit it; if a shared fix isn't feasible, fix each instance to the **same spec** and file a bead for the consolidation. Either way, when you fix one instance, **file a bead** (see *Task tracking* below) covering the other affected crates/surfaces so the parity work is tracked, not lost. This is the cross-crate analogue of the differential-fuzz philosophy (a finding in one path implies checking the others — see the *Post-batch re-evaluation checklist*).
+
 ## Task tracking — beads, not markdown TODOs
 
 This repo tracks work in **beads** (`bd`, a git-native dependency-graph issue tracker; the committed source-of-record is `.beads/issues.jsonl`). Rules for any agent working here:


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Adopts the cross-pollination convention proposed by the PSS agent in #173: **"Fix a shared issue everywhere it applies, not just where it was reported."**

Adapted to sparq's crate/surface reality (not PSS's Solid/UX framing). The folded principle:

- When a bug or review finding describes a **class** of problem affecting more than one place — a parser edge case in Turtle that also hits TriG, an operator bug whose siblings share a code path, a `pub`-surface footgun repeated across the CLI / HTTP / Python / JS-WASM bindings — it must **eventually be addressed in every instance**, not patched only where it surfaced.
- **Prefer fixing the pattern ONCE in the shared place** (common code path / a `sparq-core` helper) so all surfaces inherit it; otherwise fix each instance to the **same spec** and bead the consolidation.
- When you fix one instance, **file a bead** covering the other affected crates/surfaces so the parity work is tracked, not lost.

Cross-links the existing **differential-fuzz philosophy** (a finding in one path implies checking the others — *Post-batch re-evaluation checklist*) and the **TODOs→beads** rule.

New section added to `AGENTS.md` ("Fix a shared issue everywhere it applies — cross-crate/cross-surface parity"); the docs-quality markdownlint gate passes (0 errors).

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)