### PR TITLE
feat(zk): ZK join manifest schema — CircuitId/ProofInputs::JoinEq + JoinEdge (sq-fi03)

### DIFF
--- a/crates/sparq-zk-compose/src/build.rs
+++ b/crates/sparq-zk-compose/src/build.rs
@@ -35,6 +35,16 @@ pub const FILTER_INT_D_VALUES: &[u32] = &[1, 2, 3, 4];
 /// ceiling (value `< 2^53`, exact `f64::from`), so larger counts have no member
 /// and `derive_filter_f64_id` returns `None` (clean error, never a wrong-D).
 pub const FILTER_F64_D_VALUES: &[u32] = &[1, 2, 3, 4];
+/// Compiled graph-size buckets (`n_a`/`n_b`) of the hidden-join `join_eq` family,
+/// ascending (sq-bwwl / sq-fi03). The `join_eq_na{N_A}_nb{N_B}` member re-commits
+/// each witnessed graph with `[[Field; 3]; N]` slots (the `join_eq_check<N_A,
+/// N_B>` const generics), so a graph holding `<= N` triples is provable by the
+/// smallest compiled bucket `>= N` — exactly the scan `n`-bucket discipline. v1
+/// compiles the single symmetric `join_eq_na16_nb16` member, so only the `16`
+/// bucket exists; an out-of-family size derives `None` (clean error). The
+/// verifier gate that consumes the derived id is step 4 (sq-sfsi).
+// [OPUS-4.8] sq-bwwl / sq-fi03 (step 3): compiled join_eq graph-size buckets.
+pub const JOIN_EQ_N_BUCKETS: &[u32] = &[16];
 
 fn smallest_bucket(buckets: &[u32], need: u32) -> Option<u32> {
     buckets.iter().copied().find(|&b| b >= need)
@@ -93,6 +103,21 @@ pub fn derive_filter_f64_id(digits: u32) -> Option<CircuitId> {
     } else {
         None
     }
+}
+
+/// Derive the hidden-join `join_eq` circuit id for two graphs holding `n_a` /
+/// `n_b` triples (sq-bwwl / sq-fi03). Mirrors [`derive_scan_id`]'s `n`-bucket
+/// discipline: each side maps to the smallest compiled [`JOIN_EQ_N_BUCKETS`]
+/// bucket `>= size` (the member re-commits `[[Field; 3]; N]` slots per graph, so
+/// any graph with `<= N` triples fits the `N`-bucket member). `None` if either
+/// side exceeds every compiled bucket — a clean error, never a wrong-N member.
+/// Prover and verifier both derive the id this way so a `join_eq` proof can only
+/// verify against the member its witnesses fit (audit-#2 canonical-vk discipline).
+// [OPUS-4.8] sq-bwwl / sq-fi03 (step 3): derive the join_eq member id.
+pub fn derive_join_eq_id(n_a: u32, n_b: u32) -> Option<CircuitId> {
+    let n_a = smallest_bucket(JOIN_EQ_N_BUCKETS, n_a.max(1))?;
+    let n_b = smallest_bucket(JOIN_EQ_N_BUCKETS, n_b.max(1))?;
+    Some(CircuitId::JoinEq { n_a, n_b })
 }
 
 /// A constant or variable slot of a BGP triple pattern.

--- a/crates/sparq-zk-compose/src/manifest.rs
+++ b/crates/sparq-zk-compose/src/manifest.rs
@@ -566,6 +566,22 @@ pub enum CircuitId {
     /// is `bind_holder_pok` (T6/sq-i1dt), SEPARATE from this member registration.
     // [OPUS-4.8] sq-xqfg (HolderPoP T5): in-circuit holder-PoK circuit member.
     HolderPok,
+    /// `join_eq_na{n_a}_nb{n_b}` — hidden cross-credential JOIN
+    /// (sq-bwwl / sq-fi03, `research/zk-hidden-join-design.md` §2.2/§3.1). Proves
+    /// two scan rows share a value at chosen slots — `row_a[slot_a] ==
+    /// row_b[slot_b]` — WITHOUT disclosing the joined term encoding. The two graph
+    /// size buckets `n_a`/`n_b` select the compiled member (the `N_A`/`N_B` const
+    /// generics of `join_eq_check`), exactly as `Scan { k, n, r }` selects a scan
+    /// member, so a proof verifies only against the member its witnesses fit. The
+    /// proof's PUBLIC inputs are `[challenge, commit_a, commit_b, join_commitment,
+    /// slot_a, slot_b]` (see [`ProofInputs::JoinEq`]); the join VALUE, both graphs'
+    /// contents, the two joined rows, and the blinder are PRIVATE.
+    ///
+    /// This is SCHEMA ONLY (sq-fi03, step 3). The verifier gate `bind_joins`
+    /// (public-input reconstruction + canonical-vk + the `UnboundJoin` query
+    /// binding) is step 4 (sq-sfsi) and is NOT wired here.
+    // [OPUS-4.8] sq-bwwl / sq-fi03 (step 3): hidden cross-credential JOIN member.
+    JoinEq { n_a: u32, n_b: u32 },
 }
 
 impl CircuitId {
@@ -579,6 +595,9 @@ impl CircuitId {
             CircuitId::HiddenIssuer { depth } => format!("hidden_issuer_d{depth}"),
             // [OPUS-4.8] sq-xqfg (HolderPoP T5): depth-free single member.
             CircuitId::HolderPok => "holder_pok".to_string(),
+            // [OPUS-4.8] sq-bwwl / sq-fi03 (step 3): the `n_a`/`n_b` graph-size
+            // buckets name the compiled join member, e.g. `join_eq_na16_nb16`.
+            CircuitId::JoinEq { n_a, n_b } => format!("join_eq_na{n_a}_nb{n_b}"),
         }
     }
 }
@@ -646,6 +665,48 @@ pub enum ProofInputs {
         /// The disclosed verdict.
         expected: bool,
     },
+    /// `join_eq_na{n_a}_nb{n_b}`: hidden cross-credential JOIN
+    /// (sq-bwwl / sq-fi03, `research/zk-hidden-join-design.md` §2.2/§3.2). These
+    /// fields are EXACTLY the `pub` parameters of the `join_eq` member `main`, in
+    /// declaration order AFTER the prepended `challenge` (which `binding` carries,
+    /// like every member). The verifier's public-input reconstruction (step 4,
+    /// sq-sfsi) MUST emit them in this order:
+    ///
+    /// ```text
+    /// [challenge, commit_a, commit_b, join_commitment, slot_a, slot_b]
+    /// ```
+    ///
+    /// Cross-reference — the Noir source this layout MUST match (do not reorder;
+    /// the verifier rebuilds the vector in declaration order, audit-#1 discipline):
+    /// `zk/compose/join_eq_na16_nb16/src/main.nr` `fn main(challenge, commit_a,
+    /// commit_b, join_commitment, slot_a, slot_b, /* private */ …)`.
+    ///
+    /// The join VALUE is PRIVATE (never a public input — the headline privacy win);
+    /// only the two graph commitments, the HIDING `join_commitment`, and the two
+    /// query-bound join slots are public. The slots are public BY DESIGN (§4.4):
+    /// the query already reveals which column a shared variable occupies, so
+    /// disclosing the slot is not new leakage — only the join term stays hidden.
+    // [OPUS-4.8] sq-bwwl / sq-fi03 (step 3): hidden cross-credential JOIN inputs.
+    #[serde(rename = "join_eq")]
+    JoinEq {
+        id: CircuitId,
+        /// Graph-A commitment `C(G_a)`. Byte-bound (step 4, sq-sfsi) to equal the
+        /// scan-A sub-proof's `commitments[g_a]` — the anti-row-swap binding (A2).
+        commit_a: FieldHex,
+        /// Graph-B commitment `C(G_b)`. Byte-bound to scan-B's `commitments[g_b]`.
+        commit_b: FieldHex,
+        /// The HIDING commitment to the join value: `h3(SIG_DOMAIN_JOIN, value,
+        /// blinding)` (`sparq_zk::sig::join_value_commitment`). Per-presentation
+        /// blinded, so two presentations of the same join value are unlinkable and
+        /// a low-entropy key is not dictionary-attackable (design §1.4 R4 / §2.4).
+        join_commitment: FieldHex,
+        /// Graph-A join slot in `{0,1,2}` (s/p/o). PUBLIC and query-bound: the
+        /// verifier (step 4) requires it to equal the query-derived slot the shared
+        /// variable occupies in pattern A (§4.4 slot binding).
+        slot_a: u32,
+        /// Graph-B join slot in `{0,1,2}` — query-bound to pattern B's slot.
+        slot_b: u32,
+    },
 }
 
 impl ProofInputs {
@@ -654,6 +715,8 @@ impl ProofInputs {
             ProofInputs::Scan { id, .. } => id,
             ProofInputs::FilterInt { id, .. } => id,
             ProofInputs::FilterF64 { id, .. } => id,
+            // [OPUS-4.8] sq-bwwl / sq-fi03 (step 3): hidden cross-credential JOIN.
+            ProofInputs::JoinEq { id, .. } => id,
         }
     }
 }
@@ -686,6 +749,44 @@ pub struct BindingEdge {
     pub from_slot: usize,
     /// Index into `sub_proofs` of the consuming filter proof.
     pub to_proof: usize,
+}
+
+/// A hidden cross-credential JOIN edge (sq-bwwl / sq-fi03,
+/// `research/zk-hidden-join-design.md` §3.2): the hidden-key analogue of
+/// [`BindingEdge`]. Where a `BindingEdge` ties a **disclosed** scan slot to a
+/// filter operand, a `JoinEdge` ties **two scan sub-proofs' graph commitments**
+/// to a `join_eq` sub-proof — disclosing the *graph linkage* (which two
+/// credentials are joined, at which slots) but NOT the joined term value.
+///
+/// The edge names the two scan sub-proofs and which committed graph index within
+/// each (`commitments[graph_a]` / `commitments[graph_b]`) the join binds, plus
+/// the index of the `join_eq` sub-proof. The verifier gate `bind_joins` (step 4,
+/// sq-sfsi) resolves these, requires the `join_eq` proof's public
+/// `commit_a`/`commit_b` to byte-equal the two scans' `commitments[graph_*]` (the
+/// anti-A2 binding), and requires the proof's public `slot_a`/`slot_b` to equal
+/// the query-derived slots for the shared variable (the §4.4 slot binding). The
+/// manifest canonicalises by sorting on `(scan_a, graph_a, slot_a)` (the
+/// `BindingEdge` ordering convention, §2.5) — `join_eq` itself is unordered since
+/// the equality is symmetric.
+///
+/// SCHEMA ONLY (sq-fi03, step 3); the `bind_joins` gate that consumes this is
+/// step 4 (sq-sfsi).
+// [OPUS-4.8] sq-bwwl / sq-fi03 (step 3): hidden cross-credential JOIN edge.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JoinEdge {
+    /// Index into [`ProofManifest::sub_proofs`] of the scan sub-proof for graph A.
+    pub scan_a: usize,
+    /// Which committed graph of `scan_a` (index into its `commitments`) the join
+    /// binds — the `commitments[graph_a]` whose value must equal the `join_eq`
+    /// proof's public `commit_a`.
+    pub graph_a: usize,
+    /// Index into `sub_proofs` of the scan sub-proof for graph B.
+    pub scan_b: usize,
+    /// Which committed graph of `scan_b` the join binds (`commitments[graph_b]`).
+    pub graph_b: usize,
+    /// Index into `sub_proofs` of the `join_eq` sub-proof
+    /// ([`ProofInputs::JoinEq`]) that proves the hidden equality.
+    pub join_proof: usize,
 }
 
 /// The full query-result proof manifest.
@@ -771,6 +872,15 @@ pub struct ProofManifest {
     /// Binding-consistency edges between sub-proofs.
     #[serde(default)]
     pub binding_edges: Vec<BindingEdge>,
+    /// Hidden cross-credential JOIN edges (sq-bwwl / sq-fi03): each ties two scan
+    /// sub-proofs' graph commitments to a `join_eq` sub-proof that proves the two
+    /// rows share a value at the named slots WITHOUT disclosing it. Empty for a
+    /// manifest with no hidden joins (defaults so legacy manifests parse). The
+    /// `bind_joins` verifier gate that enforces these is step 4 (sq-sfsi); this
+    /// field is the schema it consumes.
+    // [OPUS-4.8] sq-bwwl / sq-fi03 (step 3): hidden cross-credential JOIN edges.
+    #[serde(default)]
+    pub join_edges: Vec<JoinEdge>,
     /// OPTIONAL hidden-index revocation proof (sq-3e5 / sq-h2v): a zero-knowledge
     /// proof that the credential's status bit at its (HIDDEN) index in the
     /// committed status list is UNSET, disclosing neither the index nor the other
@@ -1060,6 +1170,7 @@ mod holder_binding_tests {
             status_snapshots: vec![],
             sub_proofs: vec![],
             binding_edges: vec![],
+            join_edges: vec![],
             hidden_revocation: None,
             hidden_issuer_attestations: vec![],
         };
@@ -1153,6 +1264,149 @@ mod holder_binding_tests {
         assert!(
             matches!(parsed.binding, BindingMode::Challenge { .. }),
             "legacy bearer/challenge binding remains valid"
+        );
+    }
+}
+
+/// [OPUS-4.8] sq-bwwl / sq-fi03 (step 3): schema tests for the hidden
+/// cross-credential JOIN manifest types — `CircuitId::JoinEq`,
+/// `ProofInputs::JoinEq`, and `JoinEdge`. SCHEMA ONLY: the `bind_joins` verifier
+/// gate (commitment binding + `UnboundJoin` query binding) is step 4 (sq-sfsi).
+#[cfg(test)]
+mod join_schema_tests {
+    use super::*;
+
+    /// The PUBLIC-input field ordering the `join_eq` circuit's `main` declares,
+    /// AFTER the prepended `challenge` (which `binding` carries for every member).
+    /// This MUST stay byte-for-byte in step with
+    /// `zk/compose/join_eq_na16_nb16/src/main.nr` — the verifier's
+    /// `reconstruct_public_inputs` (audit-#1) emits the vector in exactly this
+    /// declaration order. If the Noir `main` reorders, this constant and the
+    /// reconstruction arm must move together.
+    const JOIN_EQ_PUBLIC_INPUT_LAYOUT: &[&str] = &[
+        "challenge",        // field 0 — every member's first `pub` (verifier nonce)
+        "commit_a",         // graph-A commitment C(G_a)
+        "commit_b",         // graph-B commitment C(G_b)
+        "join_commitment",  // HIDING commitment to the join value (design §2.4)
+        "slot_a",           // graph-A join slot in {0,1,2} (query-bound)
+        "slot_b",           // graph-B join slot in {0,1,2} (query-bound)
+    ];
+
+    fn join_inputs() -> ProofInputs {
+        ProofInputs::JoinEq {
+            id: CircuitId::JoinEq { n_a: 16, n_b: 16 },
+            commit_a: FieldHex("0x0a".to_string()),
+            commit_b: FieldHex("0x0b".to_string()),
+            join_commitment: FieldHex("0x0c".to_string()),
+            slot_a: 0,
+            slot_b: 2,
+        }
+    }
+
+    /// `CircuitId::JoinEq` enumerates and names its compiled member exactly like
+    /// the other members (`scan_k…`, `filter_int_d…`): the `(n_a, n_b)` buckets
+    /// drive the package directory `join_eq_na{n_a}_nb{n_b}`.
+    #[test]
+    fn circuit_id_join_eq_packages_like_other_members() {
+        assert_eq!(
+            CircuitId::JoinEq { n_a: 16, n_b: 16 }.package(),
+            "join_eq_na16_nb16",
+            "matches the landed Noir member directory (PR #170)"
+        );
+        // Asymmetric buckets name distinctly (forward-looking; v1 compiles 16x16).
+        assert_eq!(
+            CircuitId::JoinEq { n_a: 16, n_b: 64 }.package(),
+            "join_eq_na16_nb64"
+        );
+        // The id round-trips through serde with its `kind` tag like every variant.
+        let id = CircuitId::JoinEq { n_a: 16, n_b: 16 };
+        let json = serde_json::to_string(&id).expect("serializes");
+        assert!(json.contains("join_eq"), "snake_case `kind` tag is `join_eq`");
+        let back: CircuitId = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(back, id, "CircuitId::JoinEq round-trips");
+    }
+
+    /// `ProofInputs::JoinEq` round-trips through serde and exposes its id via the
+    /// `circuit_id()` accessor (the new exhaustive-match arm).
+    #[test]
+    fn proof_inputs_join_eq_round_trips_and_exposes_id() {
+        let inputs = join_inputs();
+        assert_eq!(
+            inputs.circuit_id(),
+            &CircuitId::JoinEq { n_a: 16, n_b: 16 },
+            "circuit_id() returns the JoinEq id"
+        );
+        let json = serde_json::to_string(&inputs).expect("serializes");
+        // The serde `circuit` tag (mirrors scan/filter) is `join_eq`.
+        assert!(json.contains("\"circuit\":\"join_eq\""), "tagged `join_eq`");
+        // The HIDDEN join value never appears as a field — only the public inputs.
+        assert!(
+            !json.contains("\"value\"") && !json.contains("\"blinding\""),
+            "join value + blinder are PRIVATE — never serialized in ProofInputs"
+        );
+        let back: ProofInputs = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(back, inputs, "ProofInputs::JoinEq round-trips");
+    }
+
+    /// `JoinEdge` round-trips through serde, and an empty `join_edges` default
+    /// keeps legacy (pre-join) manifests parseable (additive schema).
+    #[test]
+    fn join_edge_round_trips_and_is_additive() {
+        let edge = JoinEdge {
+            scan_a: 0,
+            graph_a: 0,
+            scan_b: 1,
+            graph_b: 0,
+            join_proof: 2,
+        };
+        let json = serde_json::to_string(&edge).expect("serializes");
+        let back: JoinEdge = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(back, edge, "JoinEdge round-trips");
+
+        // A manifest JSON with NO `join_edges` key parses (serde default), so the
+        // schema addition does not break existing manifests.
+        let no_joins = r#"{
+            "query": "SELECT * WHERE { ?s ?p ?o }",
+            "attributions": [[0]],
+            "entailment_regime": "simple",
+            "binding": { "mode": "challenge", "challenge": "0x1" },
+            "sub_proofs": []
+        }"#;
+        let m: ProofManifest = serde_json::from_str(no_joins).expect("legacy parses");
+        assert!(m.join_edges.is_empty(), "join_edges defaults to empty");
+
+        // And a manifest carrying join_edges round-trips through the full type.
+        let mut m2 = m.clone();
+        m2.join_edges = vec![edge.clone()];
+        let json = serde_json::to_string(&m2).expect("serializes");
+        let back: ProofManifest = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(back.join_edges, vec![edge], "manifest join_edges round-trip");
+    }
+
+    /// The `ProofInputs::JoinEq` field set is EXACTLY the public inputs the Noir
+    /// member exposes (minus the `binding`-carried `challenge`), in the same
+    /// order. Pins the schema↔circuit contract: if a field is added/removed/
+    /// reordered on either side without updating the other, this fails.
+    #[test]
+    fn join_eq_field_ordering_matches_circuit_layout() {
+        // The struct fields, in declaration order, that are PUBLIC inputs.
+        let struct_pub_fields = ["commit_a", "commit_b", "join_commitment", "slot_a", "slot_b"];
+        // The circuit layout minus field 0 (`challenge`, carried by `binding`).
+        let circuit_after_challenge = &JOIN_EQ_PUBLIC_INPUT_LAYOUT[1..];
+        assert_eq!(
+            struct_pub_fields.as_slice(),
+            circuit_after_challenge,
+            "ProofInputs::JoinEq public fields match join_eq main's order \
+             (zk/compose/join_eq_na16_nb16/src/main.nr)"
+        );
+        assert_eq!(
+            JOIN_EQ_PUBLIC_INPUT_LAYOUT[0], "challenge",
+            "field 0 is the verifier nonce, as every member"
+        );
+        assert_eq!(
+            JOIN_EQ_PUBLIC_INPUT_LAYOUT.len(),
+            6,
+            "join_eq exposes exactly 6 public inputs"
         );
     }
 }

--- a/crates/sparq-zk-compose/src/manifest.rs
+++ b/crates/sparq-zk-compose/src/manifest.rs
@@ -764,10 +764,16 @@ pub struct BindingEdge {
 /// sq-sfsi) resolves these, requires the `join_eq` proof's public
 /// `commit_a`/`commit_b` to byte-equal the two scans' `commitments[graph_*]` (the
 /// anti-A2 binding), and requires the proof's public `slot_a`/`slot_b` to equal
-/// the query-derived slots for the shared variable (the §4.4 slot binding). The
-/// manifest canonicalises by sorting on `(scan_a, graph_a, slot_a)` (the
-/// `BindingEdge` ordering convention, §2.5) — `join_eq` itself is unordered since
-/// the equality is symmetric.
+/// the query-derived slots for the shared variable (the §4.4 slot binding). Those
+/// slots live on the `join_eq` proof's public inputs, NOT on this edge.
+///
+/// # Ordering
+/// `join_edges` is currently stored in declaration order — the manifest does NOT
+/// yet canonicalise it. Canonical-order sorting (mirroring the `BindingEdge` §2.5
+/// convention, keyed on `(scan_a, graph_a, scan_b, graph_b)`) is deferred together
+/// with the equivalent `binding_edges` work (neither vector is sorted today); see
+/// the tracking bead. `join_eq` itself is value-symmetric, so the equality holds
+/// regardless of edge order.
 ///
 /// SCHEMA ONLY (sq-fi03, step 3); the `bind_joins` gate that consumes this is
 /// step 4 (sq-sfsi).

--- a/crates/sparq-zk-compose/src/toml.rs
+++ b/crates/sparq-zk-compose/src/toml.rs
@@ -258,5 +258,23 @@ pub fn prover_toml_for(
             );
             (id.clone(), toml)
         }
+        // [OPUS-4.8] sq-bwwl / sq-fi03 (step 3): hidden cross-credential JOIN.
+        // SCHEMA ONLY — this bead adds the manifest types, NOT the prover path.
+        // Generating a `join_eq` Prover.toml needs the join member's PRIVATE
+        // witnesses (`enc_a`/`counts_a`/`enc_b`/`counts_b`/`row_a`/`row_b`/
+        // `blinding`), none of which this function's `scan_*`/`filter_digits`
+        // parameters can carry — so the prover wiring is deferred to step 4
+        // (sq-sfsi), which extends the signature. This arm is UNREACHABLE in this
+        // bead: nothing constructs a `ProofInputs::JoinEq` for proving until
+        // sq-sfsi adds the join build path. It is `unimplemented!` (not a silent
+        // wrong stub) so a premature call fails loudly rather than emitting a
+        // bogus witness; sq-sfsi replaces it with the real join TOML emitter.
+        ProofInputs::JoinEq { .. } => {
+            unimplemented!(
+                "join_eq Prover.toml generation is sq-sfsi (step 4); sq-fi03 adds \
+                 the manifest schema only. The join member's private witnesses are \
+                 not yet plumbed through prover_toml_for."
+            )
+        }
     }
 }

--- a/crates/sparq-zk-compose/src/toml.rs
+++ b/crates/sparq-zk-compose/src/toml.rs
@@ -9,6 +9,36 @@
 
 use crate::manifest::{CircuitId, FieldHex, ProofInputs};
 
+/// Error returned by [`prover_toml_for`] when a `Prover.toml` cannot be emitted
+/// for the given inputs.
+///
+/// [OPUS-4.8] sq-fi03 / PR #178: `prover_toml_for` is a public fn, so a premature
+/// call on a not-yet-wired arm must surface a recoverable error rather than panic
+/// (a `unimplemented!` in a public fn is a downstream-crash footgun).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProverTomlError {
+    /// The `join_eq` Prover.toml emitter is deferred to sq-sfsi (step 4); sq-fi03
+    /// adds the manifest schema only. The join member's private witnesses
+    /// (`enc_a`/`counts_a`/`enc_b`/`counts_b`/`row_a`/`row_b`/`blinding`) are not
+    /// yet plumbed through this function's parameters, so it cannot emit a witness.
+    JoinEqUnsupported,
+}
+
+impl std::fmt::Display for ProverTomlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProverTomlError::JoinEqUnsupported => write!(
+                f,
+                "join_eq Prover.toml generation is not yet implemented (deferred to \
+                 sq-sfsi, step 4); sq-fi03 adds the manifest schema only. The join \
+                 member's private witnesses are not plumbed through prover_toml_for."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ProverTomlError {}
+
 /// Render the `Prover.toml` body for a scan proof.
 ///
 /// Order MUST match `scan_k{k}_n{n}_r{r}/src/main.nr`:
@@ -178,6 +208,11 @@ pub fn canonical_digits(value: u64) -> Vec<u8> {
 
 /// Render the witness-bearing `Prover.toml` for any `ProofInputs`, given the
 /// private witnesses the manifest does not carry. Returns the package id too.
+///
+/// Returns [`ProverTomlError::JoinEqUnsupported`] for [`ProofInputs::JoinEq`],
+/// whose prover path is deferred to sq-sfsi (step 4). This is a recoverable
+/// error so a downstream caller (or a CLI loading a manifest containing
+/// `join_eq`) gets a structured failure rather than a panic. [OPUS-4.8]
 pub fn prover_toml_for(
     inputs: &ProofInputs,
     challenge: &FieldHex,
@@ -187,8 +222,8 @@ pub fn prover_toml_for(
     scan_enc: &[Vec<[FieldHex; 3]>],
     // filter witness (ignored for scan): canonical decimal digits.
     filter_digits: &[u8],
-) -> (CircuitId, String) {
-    match inputs {
+) -> Result<(CircuitId, String), ProverTomlError> {
+    let out = match inputs {
         ProofInputs::Scan {
             id,
             commitments,
@@ -264,17 +299,11 @@ pub fn prover_toml_for(
         // witnesses (`enc_a`/`counts_a`/`enc_b`/`counts_b`/`row_a`/`row_b`/
         // `blinding`), none of which this function's `scan_*`/`filter_digits`
         // parameters can carry — so the prover wiring is deferred to step 4
-        // (sq-sfsi), which extends the signature. This arm is UNREACHABLE in this
-        // bead: nothing constructs a `ProofInputs::JoinEq` for proving until
-        // sq-sfsi adds the join build path. It is `unimplemented!` (not a silent
-        // wrong stub) so a premature call fails loudly rather than emitting a
+        // (sq-sfsi), which extends the signature. Until then this arm returns a
+        // recoverable `Err` (NOT a panic): a public fn must not crash a downstream
+        // caller that loads a manifest containing `join_eq`. It also never emits a
         // bogus witness; sq-sfsi replaces it with the real join TOML emitter.
-        ProofInputs::JoinEq { .. } => {
-            unimplemented!(
-                "join_eq Prover.toml generation is sq-sfsi (step 4); sq-fi03 adds \
-                 the manifest schema only. The join member's private witnesses are \
-                 not yet plumbed through prover_toml_for."
-            )
-        }
-    }
+        ProofInputs::JoinEq { .. } => return Err(ProverTomlError::JoinEqUnsupported),
+    };
+    Ok(out)
 }

--- a/crates/sparq-zk-compose/src/verifier.rs
+++ b/crates/sparq-zk-compose/src/verifier.rs
@@ -103,7 +103,9 @@
 //! public-input reconstruction that binds the JSON statement (incl. attribution
 //! bits) and the verifier's nonce to the proofs.
 
-use crate::build::{derive_filter_f64_id, derive_filter_int_id, derive_scan_id};
+use crate::build::{
+    derive_filter_f64_id, derive_filter_int_id, derive_join_eq_id, derive_scan_id,
+};
 use crate::driver::{CircuitProver, DriverError};
 use crate::manifest::{
     BindingMode, CircuitId, EntailmentRegime, FieldHex, ProofInputs, ProofManifest,
@@ -1614,6 +1616,21 @@ fn derive_id(inputs: &ProofInputs) -> Option<CircuitId> {
                 _ => return None,
             };
             derive_filter_f64_id(d)
+        }
+        // [OPUS-4.8] sq-bwwl / sq-fi03 (step 3): hidden cross-credential JOIN. The
+        // two graph sizes are PRIVATE (the witnessed graph contents are not public
+        // inputs — only the commitments are), so — exactly as scan trusts the
+        // declared `n` and filter the declared `d` — the verifier re-derives the
+        // member id from the declared `(n_a, n_b)` buckets carried in the inputs'
+        // id. The full CircuitId is what the step-4 (sq-sfsi) public-input
+        // reconstruction + canonical-vk recompute pin, so a wrong bucket cannot
+        // byte-match a real member's proof.
+        ProofInputs::JoinEq { .. } => {
+            let (n_a, n_b) = match inputs.circuit_id() {
+                CircuitId::JoinEq { n_a, n_b } => (*n_a, *n_b),
+                _ => return None,
+            };
+            derive_join_eq_id(n_a, n_b)
         }
     }
 }
@@ -3900,6 +3917,23 @@ fn reconstruct_public_inputs(
             push_uint(&mut out, u64::from(op.code()));
             push_uint(&mut out, *b_bits);
             push_uint(&mut out, u64::from(*expected));
+        }
+        // [OPUS-4.8] sq-bwwl / sq-fi03 (step 3): hidden cross-credential JOIN
+        // public inputs, in the `join_eq` member's `main` declaration order:
+        // challenge (pushed above), commit_a, commit_b, join_commitment, slot_a,
+        // slot_b. Cross-reference `zk/compose/join_eq_na16_nb16/src/main.nr`. This
+        // is the pure public-input SERIALIZATION (the audit-#1 byte-layout) — it
+        // does NOT perform the `bind_joins` gate (commitment-equality to the scan
+        // proofs, the `UnboundJoin` query binding, the slot binding), which is
+        // step 4 (sq-sfsi). Reconstructing the vector here only lets a `join_eq`
+        // sub-proof's bb verification run; it bypasses no check, because no check
+        // beyond plain bb verification is wired for joins until sq-sfsi.
+        ProofInputs::JoinEq { commit_a, commit_b, join_commitment, slot_a, slot_b, .. } => {
+            push_field(&mut out, commit_a, proof, "commit_a")?;
+            push_field(&mut out, commit_b, proof, "commit_b")?;
+            push_field(&mut out, join_commitment, proof, "join_commitment")?;
+            push_uint(&mut out, u64::from(*slot_a));
+            push_uint(&mut out, u64::from(*slot_b));
         }
     }
     Ok(out)

--- a/crates/sparq-zk-compose/tests/audit_forge_map.rs
+++ b/crates/sparq-zk-compose/tests/audit_forge_map.rs
@@ -822,7 +822,7 @@ fn honest_filter_d1(
 ) -> (ProofInputs, ProofArtifacts) {
     let operand_enc = encode_int_literal(value);
     let (filter, digits) = build_filter_int(operand_enc, value, op, bound, expected).unwrap();
-    let (id, toml) = prover_toml_for(&filter, challenge, &[], &[], &digits);
+    let (id, toml) = prover_toml_for(&filter, challenge, &[], &[], &digits).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).expect("filter proves");
     (filter, art)
@@ -840,7 +840,7 @@ fn honest_age_scan(challenge: &FieldHex, prover: &CircuitProver, tag: &str) -> (
     };
     let scan = build_scan(std::slice::from_ref(&commit), &pattern).expect("scan builds");
     let (id, toml) =
-        prover_toml_for(&scan.inputs, challenge, &scan.witness.counts, &scan.witness.enc, &[]);
+        prover_toml_for(&scan.inputs, challenge, &scan.witness.counts, &scan.witness.enc, &[]).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).expect("scan proves");
     (scan.inputs, encode_artifacts(&art))
@@ -1031,7 +1031,7 @@ fn finding_11_n_relabel_bb_rejected() {
         "#11 bb: the >16-slot graph must derive the scan_k2_n64_r8 member"
     );
     let (id, toml) =
-        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]);
+        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]).unwrap();
     let out = scratch("f11bb");
     let art = prover.prove_in(&id, &toml, &out, "f11bb").expect("scan_k2_n64_r8 proves");
 

--- a/crates/sparq-zk-compose/tests/audit_forge_map.rs
+++ b/crates/sparq-zk-compose/tests/audit_forge_map.rs
@@ -199,6 +199,7 @@ fn honest_scan_only_manifest() -> (ProofManifest, Fr, Fr) {
         status_snapshots: vec![fixture_snapshot(false)],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -405,6 +406,7 @@ fn scan_plus_filter_manifest(
             SubProof { inputs: filter, proof_hex: String::new() },
         ],
         binding_edges: edge.into_iter().collect(),
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     }
@@ -581,6 +583,7 @@ fn finding_08_attribution_collapse_rejected() {
         status_snapshots: vec![fixture_snapshot(false)],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -643,6 +646,7 @@ fn finding_09_salt_reused_rejected() {
         status_snapshots: vec![fixture_snapshot(false)],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -872,6 +876,7 @@ fn composed_manifest(
             SubProof { inputs: filter_inputs, proof_hex: filter_hex },
         ],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     }
@@ -1053,6 +1058,7 @@ fn finding_11_n_relabel_bb_rejected() {
         status_snapshots: vec![fixture_snapshot(false)],
         sub_proofs: vec![SubProof { inputs: forged, proof_hex: encode_artifacts(&art) }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };

--- a/crates/sparq-zk-compose/tests/differential_fuzz.rs
+++ b/crates/sparq-zk-compose/tests/differential_fuzz.rs
@@ -328,7 +328,7 @@ fn run_differential(iters: u64, full_prove: bool) -> u64 {
             &scan.witness.counts,
             &scan.witness.enc,
             &[],
-        );
+        ).unwrap();
         let tag = format!("fuzz_scan_{i}");
         prover.compile(&scan_id).expect("scan compiles");
         prover
@@ -357,7 +357,7 @@ fn run_differential(iters: u64, full_prove: bool) -> u64 {
                     continue;
                 };
                 let (fid, ftoml) =
-                    prover_toml_for(&filter_inputs, &challenge, &[], &[], &digits);
+                    prover_toml_for(&filter_inputs, &challenge, &[], &[], &digits).unwrap();
                 let ftag = format!("fuzz_filter_{i}");
                 prover.compile(&fid).expect("filter compiles");
 
@@ -380,7 +380,7 @@ fn run_differential(iters: u64, full_prove: bool) -> u64 {
                     continue;
                 };
                 let (lid, ltoml) =
-                    prover_toml_for(&lie_inputs, &challenge, &[], &[], &lie_digits);
+                    prover_toml_for(&lie_inputs, &challenge, &[], &[], &lie_digits).unwrap();
                 let ltag = format!("fuzz_filter_lie_{i}");
                 let lie_witness = prover.gen_witness_tagged(&lid, &ltoml, &ltag);
                 assert!(
@@ -499,7 +499,7 @@ fn sq_wto_three_digit_operand_proves_not_silently_unprovable() {
     let (inputs, digits) = build_filter_int(operand_enc.clone(), value, op, bound, expected)
         .expect("3-digit FILTER must be in-family (sq-wto: d=3 member exists)");
     assert_eq!(*inputs.circuit_id(), CircuitId::FilterInt { d: 3 });
-    let (id, toml) = prover_toml_for(&inputs, &FieldHex("0x2a".into()), &[], &[], &digits);
+    let (id, toml) = prover_toml_for(&inputs, &FieldHex("0x2a".into()), &[], &[], &digits).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).expect("filter_int_d3 compiles");
     prover
@@ -512,7 +512,7 @@ fn sq_wto_three_digit_operand_proves_not_silently_unprovable() {
     // 2) Soundness preserved: the FLIPPED verdict must be UNprovable.
     let (lie_inputs, lie_digits) =
         build_filter_int(operand_enc, value, op, bound, !expected).expect("builds");
-    let (lid, ltoml) = prover_toml_for(&lie_inputs, &FieldHex("0x2a".into()), &[], &[], &lie_digits);
+    let (lid, ltoml) = prover_toml_for(&lie_inputs, &FieldHex("0x2a".into()), &[], &[], &lie_digits).unwrap();
     let lie = prover.gen_witness_tagged(&lid, &ltoml, "wto_d3_lie");
     assert!(
         lie.is_err(),

--- a/crates/sparq-zk-compose/tests/e2e.rs
+++ b/crates/sparq-zk-compose/tests/e2e.rs
@@ -403,6 +403,7 @@ fn sample_manifest() -> ProofManifest {
             from_slot: 2,
             to_proof: 1,
         }],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -727,6 +728,7 @@ fn full_manifest_prove_verify_scan() {
             proof_hex: encode_artifacts(&art),
         }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -848,6 +850,7 @@ fn filter_manifest(
             SubProof { inputs, proof_hex },
         ],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -1202,6 +1205,7 @@ fn nonce_binding_mismatch_rejected() {
             status_snapshots: vec![fixture_snapshot(false)],
             sub_proofs: vec![SubProof { inputs: scan.clone(), proof_hex: String::new() }],
             binding_edges: vec![],
+            join_edges: vec![],
             hidden_revocation: None,
             hidden_issuer_attestations: vec![],
         };
@@ -1299,6 +1303,7 @@ fn holder_pop_manifest(holder_hex: &str, pop_hex: &str, cryptosuite: &str) -> Pr
         status_snapshots: vec![fixture_snapshot(false)],
         sub_proofs: vec![SubProof { inputs: scan, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -1568,6 +1573,7 @@ fn holder_bound_manifest(
             proof_hex: String::new(),
         }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -1943,6 +1949,7 @@ fn holder_pop_valid_verifies_end_to_end() {
         status_snapshots: vec![fixture_snapshot(false)],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: encode_artifacts(&art) }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -1997,6 +2004,7 @@ fn malformed_proof_hex_rejected_not_panicked() {
             status_snapshots: vec![fixture_snapshot(false)],
             sub_proofs: vec![SubProof { inputs: scan.clone(), proof_hex: proof_hex.into() }],
             binding_edges: vec![],
+            join_edges: vec![],
             hidden_revocation: None,
             hidden_issuer_attestations: vec![],
         };
@@ -2263,6 +2271,7 @@ fn filter_reject_comparison_substitution_17_vs_18() {
             SubProof { inputs: filt, proof_hex: String::new() },
         ],
         binding_edges: vec![BindingEdge { from_proof: 0, from_row: 0, from_slot: 2, to_proof: 1 }],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -2293,6 +2302,7 @@ fn filter_reject_filter_add_on_scan_only() {
         status_snapshots: vec![],
         sub_proofs: vec![SubProof { inputs: scan, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -2323,6 +2333,7 @@ fn filter_reject_constant_swap_age_as_salary() {
         status_snapshots: vec![],
         sub_proofs: vec![SubProof { inputs: scan, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -2373,6 +2384,7 @@ fn filter_reject_operand_slot_substitution() {
         ],
         // Edge points at proof 0 (salary scan) slot 2 — the WRONG column for ?age.
         binding_edges: vec![BindingEdge { from_proof: 0, from_row: 0, from_slot: 2, to_proof: 2 }],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -2417,6 +2429,7 @@ fn filter_reject_false_verdict_row() {
             SubProof { inputs: filt, proof_hex: String::new() },
         ],
         binding_edges: vec![BindingEdge { from_proof: 0, from_row: 0, from_slot: 2, to_proof: 1 }],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -2447,6 +2460,7 @@ fn filter_reject_unbindable_filter_fragment() {
         status_snapshots: vec![],
         sub_proofs: vec![SubProof { inputs: scan, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -2490,6 +2504,7 @@ fn filter_binding_happy_path_structure() {
             SubProof { inputs: filt, proof_hex: String::new() },
         ],
         binding_edges: vec![BindingEdge { from_proof: 0, from_row: 0, from_slot: 2, to_proof: 1 }],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -2555,6 +2570,7 @@ fn filter_reject_unproven_failing_row() {
         ],
         // Edge only for row 0 — row 1 has no true-verdict filter proof.
         binding_edges: vec![BindingEdge { from_proof: 0, from_row: 0, from_slot: 2, to_proof: 1 }],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -2609,6 +2625,7 @@ fn filter_two_rows_both_gated_verifies() {
             BindingEdge { from_proof: 0, from_row: 0, from_slot: 2, to_proof: 1 },
             BindingEdge { from_proof: 0, from_row: 1, from_slot: 2, to_proof: 2 },
         ],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -2667,6 +2684,7 @@ fn scan_only_manifest(graph: &[Triple], salt_byte: u8) -> (ProofManifest, Fr, Fr
         status_snapshots: vec![fixture_snapshot(false)],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -2809,6 +2827,7 @@ fn issuer_reject_drop_triple_recommit_suppression() {
         status_snapshots: vec![],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -3128,6 +3147,7 @@ fn cross_graph_manifest(
             SubProof { inputs: scan_role.inputs, proof_hex: String::new() },
         ],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -3741,6 +3761,7 @@ fn revocation_stale_status_list_rejected() {
         }],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -3934,6 +3955,7 @@ fn revocation_within_window_verifies() {
         }],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -4113,6 +4135,7 @@ fn hidden_scan_manifest(prover: &CircuitProver, tag: &str) -> (ProofManifest, Fr
             proof_hex: encode_artifacts(&art),
         }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -4194,6 +4217,7 @@ fn committed_index_without_hidden_revocation_rejected() {
         status_snapshots: vec![],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None, // <- MISSING; committed-index requires it
         hidden_issuer_attestations: vec![],
         derivation_steps: vec![],
@@ -4240,6 +4264,7 @@ fn committed_index_disclosed_commitment_mismatch_rejected() {
         status_snapshots: vec![],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
         derivation_steps: vec![],
@@ -4472,6 +4497,7 @@ fn hi_scan_manifest(prover: &CircuitProver, signer_sk: &SecretKey, tag: &str) ->
         status_snapshots: vec![fixture_snapshot(false)],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: encode_artifacts(&art) }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -4645,6 +4671,7 @@ fn hi_scan_manifest_no_clear_attestation(
         status_snapshots: vec![fixture_snapshot(false)],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: encode_artifacts(&art) }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
         derivation_steps: vec![],
@@ -5042,6 +5069,7 @@ fn filter_f64_composes_end_to_end() {
         ],
         // Binding edge: scan proof 0, row 0, object slot (2) -> float filter proof 1.
         binding_edges: vec![BindingEdge { from_proof: 0, from_row: 0, from_slot: 2, to_proof: 1 }],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -5142,6 +5170,7 @@ fn entailment_manifest(regime: EntailmentRegime, steps: Vec<DerivationStep>) -> 
         status_snapshots: vec![fixture_snapshot(false)],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };

--- a/crates/sparq-zk-compose/tests/e2e.rs
+++ b/crates/sparq-zk-compose/tests/e2e.rs
@@ -505,7 +505,7 @@ fn witness_gen_filter_int_satisfiable() {
         &[],
         &[],
         &digits,
-    );
+    ).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).expect("compiles");
     prover
@@ -526,7 +526,7 @@ fn witness_gen_filter_int_rejects_false_verdict() {
     let (filter, digits) =
         build_filter_int(operand_enc, 17, FilterOp::Ge, 18, true).unwrap();
     let (id, toml) =
-        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits);
+        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).unwrap();
     assert!(
@@ -550,7 +550,7 @@ fn witness_gen_filter_int_ne_satisfiable() {
     let (filter, digits) =
         build_filter_int(operand_enc, 30, FilterOp::Ne, 18, true).unwrap();
     let (id, toml) =
-        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits);
+        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).expect("compiles");
     prover
@@ -572,7 +572,7 @@ fn witness_gen_filter_int_ne_rejects_false_verdict() {
     let (filter, digits) =
         build_filter_int(operand_enc, 18, FilterOp::Ne, 18, true).unwrap();
     let (id, toml) =
-        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits);
+        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).unwrap();
     assert!(
@@ -601,7 +601,7 @@ fn witness_gen_scan_satisfiable() {
         &scan.witness.counts,
         &scan.witness.enc,
         &[],
-    );
+    ).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).expect("compiles");
     // [OPUS-4.8] tag-isolated witness gen.
@@ -623,7 +623,7 @@ fn full_prove_verify_filter_int_d1() {
     let (filter, digits) =
         build_filter_int(operand_enc, 5, FilterOp::Lt, 10, true).unwrap();
     let (id, toml) =
-        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits);
+        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits).unwrap();
     assert_eq!(id, CircuitId::FilterInt { d: 1 });
 
     let prover = CircuitProver::from_crate_root();
@@ -660,7 +660,7 @@ fn full_prove_verify_filter_int_ne_d1() {
     let (filter, digits) =
         build_filter_int(operand_enc, 5, FilterOp::Ne, 9, true).unwrap();
     let (id, toml) =
-        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits);
+        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits).unwrap();
     assert_eq!(id, CircuitId::FilterInt { d: 1 });
 
     let prover = CircuitProver::from_crate_root();
@@ -703,7 +703,7 @@ fn full_manifest_prove_verify_scan() {
         &scan.witness.counts,
         &scan.witness.enc,
         &[],
-    );
+    ).unwrap();
     let prover = CircuitProver::from_crate_root();
     let out = scratch("manifest_scan");
     // [OPUS-4.8] tag-isolated prove.
@@ -776,7 +776,7 @@ fn honest_filter_d1(
     let operand_enc = encode_int_literal(value);
     let (filter, digits) =
         build_filter_int(operand_enc, value, op, bound, expected).unwrap();
-    let (id, toml) = prover_toml_for(&filter, challenge, &[], &[], &digits);
+    let (id, toml) = prover_toml_for(&filter, challenge, &[], &[], &digits).unwrap();
     assert_eq!(id, CircuitId::FilterInt { d: 1 });
     let out = scratch(tag);
     // [OPUS-4.8] tag-isolated prove: every forge test targets filter_int_d1, so
@@ -813,7 +813,7 @@ fn honest_age_scan(
         &scan.witness.counts,
         &scan.witness.enc,
         &[],
-    );
+    ).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).expect("scan prove succeeds");
     (scan.inputs, encode_artifacts(&art))
@@ -1920,7 +1920,7 @@ fn holder_pop_valid_verifies_end_to_end() {
         &scan.witness.counts,
         &scan.witness.enc,
         &[],
-    );
+    ).unwrap();
     let prover = CircuitProver::from_crate_root();
     let out = scratch("holder_pop_scan");
     let art = prover.prove_in(&id, &toml, &out, "holder_pop_scan").unwrap();
@@ -3483,7 +3483,7 @@ fn probe_scan_public_inputs_hex() {
     let scan = build_scan(&[commit], &pattern).unwrap();
     let challenge = FieldHex("0x2a".into());
     let (id, toml) =
-        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]);
+        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]).unwrap();
     let prover = CircuitProver::from_crate_root();
     let out = scratch("probe_scan_pi");
     let art = prover.prove_in(&id, &toml, &out, "probe_scan_pi").unwrap();
@@ -3515,7 +3515,7 @@ fn probe_filter_f64_public_inputs_hex() {
         build_filter_f64(operand_enc, value, FilterOp::Ge, 18.0_f64, true).expect("d2 builds");
     assert_eq!(*inputs.circuit_id(), CircuitId::FilterF64 { d: 2 });
     let challenge = FieldHex("0x2a".into());
-    let (id, toml) = prover_toml_for(&inputs, &challenge, &[], &[], &digits);
+    let (id, toml) = prover_toml_for(&inputs, &challenge, &[], &[], &digits).unwrap();
     let prover = CircuitProver::from_crate_root();
     let out = scratch("probe_filter_f64_pi");
     let art = prover.prove_in(&id, &toml, &out, "probe_filter_f64_pi").unwrap();
@@ -3567,7 +3567,7 @@ fn probe_scan_k2_public_inputs_hex() {
     );
     let challenge = FieldHex("0x2a".into());
     let (id, toml) =
-        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]);
+        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]).unwrap();
     let prover = CircuitProver::from_crate_root();
     let out = scratch("probe_scan_k2_pi");
     let art = prover.prove_in(&id, &toml, &out, "probe_scan_k2_pi").unwrap();
@@ -4111,7 +4111,7 @@ fn hidden_scan_manifest(prover: &CircuitProver, tag: &str) -> (ProofManifest, Fr
         &scan.witness.counts,
         &scan.witness.enc,
         &[],
-    );
+    ).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).unwrap();
     let mut manifest = ProofManifest {
@@ -4479,7 +4479,7 @@ fn hi_scan_manifest(prover: &CircuitProver, signer_sk: &SecretKey, tag: &str) ->
     };
     let scan = build_scan(&[commit], &pattern).unwrap();
     let challenge = FieldHex("0x2a".into());
-    let (id, toml) = prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]);
+    let (id, toml) = prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).unwrap();
     let mut manifest = ProofManifest {
@@ -4654,7 +4654,7 @@ fn hi_scan_manifest_no_clear_attestation(
     let scan = build_scan(&[commit], &pattern).unwrap();
     let challenge = FieldHex("0x2a".into());
     let (id, toml) =
-        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]);
+        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).unwrap();
     let manifest = ProofManifest {
@@ -4951,7 +4951,7 @@ fn filter_f64_witness_honest_proves_lie_rejected() {
         build_filter_f64(operand_enc.clone(), value, FilterOp::Ge, bound, true)
             .expect("25.0 >= 18.0 builds (d=2 member)");
     assert_eq!(*inputs.circuit_id(), CircuitId::FilterF64 { d: 2 });
-    let (id, toml) = prover_toml_for(&inputs, &FieldHex("0x2a".into()), &[], &[], &digits);
+    let (id, toml) = prover_toml_for(&inputs, &FieldHex("0x2a".into()), &[], &[], &digits).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).expect("filter_f64_d2 compiles");
     prover
@@ -4961,7 +4961,7 @@ fn filter_f64_witness_honest_proves_lie_rejected() {
     // The FLIPPED verdict (false) must be UNprovable — soundness.
     let (lie_inputs, lie_digits) =
         build_filter_f64(operand_enc, value, FilterOp::Ge, bound, false).expect("builds");
-    let (lid, ltoml) = prover_toml_for(&lie_inputs, &FieldHex("0x2a".into()), &[], &[], &lie_digits);
+    let (lid, ltoml) = prover_toml_for(&lie_inputs, &FieldHex("0x2a".into()), &[], &[], &lie_digits).unwrap();
     let lie = prover.gen_witness_tagged(&lid, &ltoml, "f64_lie");
     assert!(
         lie.is_err(),
@@ -4989,7 +4989,7 @@ fn filter_f64_operand_binding_rejects_substituted_value() {
     // Force the operand_enc to the committed 25's encoding while the digits witness
     // says 99 (build_filter_f64 already set operand_enc to the passed value; here we
     // pass operand_enc_25 but value=99 so the digit witness is "99").
-    let (id, toml) = prover_toml_for(&inputs, &FieldHex("0x2a".into()), &[], &[], b"99");
+    let (id, toml) = prover_toml_for(&inputs, &FieldHex("0x2a".into()), &[], &[], b"99").unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).expect("compiles");
     let res = prover.gen_witness_tagged(&id, &toml, "f64_subst");
@@ -5032,7 +5032,7 @@ fn filter_f64_composes_end_to_end() {
         &scan.witness.counts,
         &scan.witness.enc,
         &[],
-    );
+    ).unwrap();
     let scan_out = scratch("f64_compose_scan");
     let scan_art = prover.prove_in(&scan_id, &scan_toml, &scan_out, "f64_compose_scan").unwrap();
 
@@ -5046,7 +5046,7 @@ fn filter_f64_composes_end_to_end() {
     // Prove the composable float-FILTER sub-proof: ?score >= 18.0 (true).
     let (filter_inputs, fdigits) =
         build_filter_f64(operand_enc, score, FilterOp::Ge, 18.0, true).expect("filter builds");
-    let (fid, ftoml) = prover_toml_for(&filter_inputs, &challenge, &[], &[], &fdigits);
+    let (fid, ftoml) = prover_toml_for(&filter_inputs, &challenge, &[], &[], &fdigits).unwrap();
     let f_out = scratch("f64_compose_filter");
     let filter_art = prover.prove_in(&fid, &ftoml, &f_out, "f64_compose_filter").unwrap();
 

--- a/crates/sparq-zk-compose/tests/forge_gates.rs
+++ b/crates/sparq-zk-compose/tests/forge_gates.rs
@@ -496,7 +496,7 @@ fn honest_filter_d1(
 ) -> (ProofInputs, ProofArtifacts) {
     let operand_enc = encode_int_literal(value);
     let (filter, digits) = build_filter_int(operand_enc, value, op, bound, expected).unwrap();
-    let (id, toml) = prover_toml_for(&filter, challenge, &[], &[], &digits);
+    let (id, toml) = prover_toml_for(&filter, challenge, &[], &[], &digits).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).expect("filter proves");
     (filter, art)
@@ -514,7 +514,7 @@ fn honest_age_scan(challenge: &FieldHex, prover: &CircuitProver, tag: &str) -> (
         o: Slot::Var,
     };
     let scan = build_scan(std::slice::from_ref(&commit), &pattern).expect("scan builds");
-    let (id, toml) = prover_toml_for(&scan.inputs, challenge, &scan.witness.counts, &scan.witness.enc, &[]);
+    let (id, toml) = prover_toml_for(&scan.inputs, challenge, &scan.witness.counts, &scan.witness.enc, &[]).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).expect("scan proves");
     (scan.inputs, encode_artifacts(&art))
@@ -846,7 +846,7 @@ fn forge_scan_duplicate_commitment_circuit_rejected() {
         &scan.witness.counts,
         &scan.witness.enc,
         &[],
-    );
+    ).unwrap();
     // The in-circuit `commitments[0] < commitments[1]` (= `c0 < c0`) is FALSE, so
     // the relation is unsatisfiable: nargo writes no witness => Err.
     let res = prover.gen_witness_tagged(&id, &toml, "fg_dup_commit");
@@ -883,7 +883,7 @@ fn honest_k2_distinct_scan_proves_and_verifies() {
         &scan.witness.counts,
         &scan.witness.enc,
         &[],
-    );
+    ).unwrap();
     let out = scratch("honest_k2_distinct_prove");
     let art = prover
         .prove_in(&id, &toml, &out, "honest_k2_distinct")

--- a/crates/sparq-zk-compose/tests/forge_gates.rs
+++ b/crates/sparq-zk-compose/tests/forge_gates.rs
@@ -176,6 +176,7 @@ fn honest_scan_only_manifest() -> (ProofManifest, Fr, Fr) {
         status_snapshots: vec![fixture_snapshot(false)],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -341,6 +342,7 @@ fn forge_attribution_under_declared_rejected() {
         status_snapshots: vec![fixture_snapshot(false)],
         sub_proofs: vec![SubProof { inputs: scan.inputs, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };
@@ -549,6 +551,7 @@ fn composed_manifest(
             SubProof { inputs: filter_inputs, proof_hex: filter_hex },
         ],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     }
@@ -689,6 +692,7 @@ fn k2_scan_only_manifest(
         status_snapshots: vec![fixture_snapshot(false)],
         sub_proofs: vec![SubProof { inputs: scan_inputs, proof_hex: String::new() }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     }

--- a/crates/sparq-zk-compose/tests/holder_pop_forge.rs
+++ b/crates/sparq-zk-compose/tests/holder_pop_forge.rs
@@ -270,6 +270,7 @@ fn holder_manifest(
             proof_hex: String::new(),
         }],
         binding_edges: vec![],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     }

--- a/crates/sparq-zk-compose/tests/host_helpers.rs
+++ b/crates/sparq-zk-compose/tests/host_helpers.rs
@@ -24,7 +24,7 @@ use sparq_zk_compose::manifest::{
 };
 use sparq_zk_compose::toml::{
     canonical_digits, filter_f64_prover_toml, filter_int_prover_toml, pad_hex, pad_rows,
-    prover_toml_for, scan_prover_toml,
+    prover_toml_for, scan_prover_toml, ProverTomlError,
 };
 
 // --------------------------------------------------------------------------
@@ -159,6 +159,28 @@ fn canonical_digits_are_ascii_byte_codes() {
     }
 }
 
+// [OPUS-4.8] sq-fi03 / PR #178: `prover_toml_for` is a public fn whose `join_eq`
+// arm is deferred to sq-sfsi. It must return a recoverable `Err` (NOT panic via
+// `unimplemented!`) so a downstream caller loading a manifest with `join_eq` gets
+// a structured failure rather than a crash.
+#[test]
+fn prover_toml_for_join_eq_returns_err_not_panic() {
+    let inputs = ProofInputs::JoinEq {
+        id: CircuitId::JoinEq { n_a: 16, n_b: 16 },
+        commit_a: fh("0x0a"),
+        commit_b: fh("0x0b"),
+        join_commitment: fh("0x0c"),
+        slot_a: 0,
+        slot_b: 2,
+    };
+    let res = prover_toml_for(&inputs, &fh("0xchal"), &[], &[], &[]);
+    assert_eq!(
+        res,
+        Err(ProverTomlError::JoinEqUnsupported),
+        "join_eq prover toml is deferred (sq-sfsi) and must fail gracefully"
+    );
+}
+
 #[test]
 fn prover_toml_for_filter_int_uses_op_code_and_digits() {
     let inputs = ProofInputs::FilterInt {
@@ -168,7 +190,7 @@ fn prover_toml_for_filter_int_uses_op_code_and_digits() {
         bound: 7,
         expected: false,
     };
-    let (id, toml) = prover_toml_for(&inputs, &fh("0xchal"), &[], &[], b"7");
+    let (id, toml) = prover_toml_for(&inputs, &fh("0xchal"), &[], &[], b"7").unwrap();
     assert_eq!(id, CircuitId::FilterInt { d: 1 });
     assert!(toml.contains("op = \"5\"\n"), "FilterOp::Ne code is 5");
     assert!(toml.contains("bound = \"7\"\n"));
@@ -186,7 +208,7 @@ fn prover_toml_for_filter_f64_uses_b_bits() {
         b_bits: bits,
         expected: true,
     };
-    let (id, toml) = prover_toml_for(&inputs, &fh("0xchal"), &[], &[], b"18");
+    let (id, toml) = prover_toml_for(&inputs, &fh("0xchal"), &[], &[], b"18").unwrap();
     assert_eq!(id, CircuitId::FilterF64 { d: 2 });
     assert!(toml.contains(&format!("b_bits = \"{bits}\"\n")));
     assert!(toml.contains("op = \"1\"\n"), "FilterOp::Le code is 1");
@@ -210,7 +232,7 @@ fn prover_toml_for_scan_pads_rows_and_enc_to_circuit_dimensions() {
         [fh("0xe00"), fh("0xe01"), fh("0xe02")],
         [fh("0xe10"), fh("0xe11"), fh("0xe12")],
     ]];
-    let (id, toml) = prover_toml_for(&inputs, &fh("0xchal"), &[2], &scan_enc, &[]);
+    let (id, toml) = prover_toml_for(&inputs, &fh("0xchal"), &[2], &scan_enc, &[]).unwrap();
     assert_eq!(id, CircuitId::Scan { k: 1, n: 3, r: 2 });
     // rows padded from 1 -> 2 (the second row is the zero row).
     assert!(

--- a/crates/sparq-zk-compose/tests/host_helpers.rs
+++ b/crates/sparq-zk-compose/tests/host_helpers.rs
@@ -372,6 +372,7 @@ fn proof_manifest_json_round_trips_and_defaults_type() {
             proof_hex: String::new(),
         }],
         binding_edges: vec![BindingEdge { from_proof: 0, from_row: 0, from_slot: 2, to_proof: 1 }],
+        join_edges: vec![],
         hidden_revocation: None,
         hidden_issuer_attestations: vec![],
     };


### PR DESCRIPTION
> 🤖 SPARQ agent

**Bead sq-fi03 (P2) — step 3 of sq-bwwl** (the hidden cross-credential JOIN). Adds the **manifest-level schema** for the `join_eq` member, following `research/zk-hidden-join-design.md` §2.2/§3.1–§3.2. Steps 1–2 (host `join_value_commitment` + the `join_eq_na16_nb16` Noir member, public-input layout `[challenge, commit_a, commit_b, join_commitment, slot_a, slot_b]`) landed on main via PR #170; this PR wires their host-side schema.

## The 3 schema additions (mirror the existing scan/filter members exactly)

1. **`CircuitId::JoinEq { n_a, n_b }`** — the `(n_a, n_b)` graph-size buckets name the compiled member `join_eq_na{n_a}_nb{n_b}` via `package()`, exactly as `Scan { k, n, r }` names `scan_k…`. `derive_join_eq_id` + `JOIN_EQ_N_BUCKETS` in `build.rs` mirror `derive_scan_id`/`SCAN_N_BUCKETS` (v1 compiles the single symmetric 16×16 member).

2. **`ProofInputs::JoinEq { id, commit_a, commit_b, join_commitment, slot_a, slot_b }`** — the typed public-input struct, **exactly** the `join_eq` member's `pub` params after the `binding`-carried `challenge`, in the same declaration order. The join **VALUE** and **blinder** are PRIVATE — never serialized (asserted by a test). `circuit_id()` gains the arm.

3. **`JoinEdge { scan_a, graph_a, scan_b, graph_b, join_proof }`** + a `join_edges: Vec<JoinEdge>` field on `ProofManifest` (`#[serde(default)]` so legacy manifests parse) — the hidden-key analogue of `BindingEdge`: ties two scans' commitments to a `join_eq` sub-proof, disclosing the graph linkage but **not** the joined value.

## Public-input layout cross-reference

`ProofInputs::JoinEq`'s field order = the Noir member's `main` declaration order, pinned by a documented constant `JOIN_EQ_PUBLIC_INPUT_LAYOUT` and a test, cross-referencing `zk/compose/join_eq_na16_nb16/src/main.nr`:
```
[challenge, commit_a, commit_b, join_commitment, slot_a, slot_b]
```
`reconstruct_public_inputs` emits this byte-layout (audit-#1 discipline) in the new `JoinEq` arm — pure serialization, matching the Noir order; it bypasses no check.

## Scope boundary (honest)

**SCHEMA + types ONLY.** The `bind_joins` verifier gate — commitment-equality to the scan proofs (anti-A2), canonical-vk by re-derived `CircuitId::JoinEq` (anti-A1), the `UnboundJoin` query binding, the slot binding, and the `JoinPolicy` — is **sq-sfsi (step 4)**, now **unblocked**. It is NOT implemented here.

## Avoiding a reachable panic for the deferred path

Three exhaustive matches over `ProofInputs` gain `JoinEq` arms so the workspace compiles: `circuit_id()` (returns the id), `derive_id` (re-derives from the declared `(n_a, n_b)` buckets, exactly as scan trusts declared `n`), and `reconstruct_public_inputs` (the PI byte-layout above). The only `unimplemented!` is in `prover_toml_for`'s `JoinEq` arm — and it is **not a silent stub**: that arm is **unreachable in this bead** (nothing constructs a `ProofInputs::JoinEq` for *proving* until step 4), and the function's signature cannot carry the join member's private witnesses (`enc_a`/`counts_a`/…/`blinding`), so the prover path is deferred to sq-sfsi which extends the signature. A premature call fails loudly rather than emitting a bogus witness.

## Tests (`manifest::join_schema_tests`)

- serde round-trip of `ProofInputs::JoinEq`, `JoinEdge`, and `CircuitId::JoinEq`;
- `CircuitId::JoinEq` enumeration → `package()` (`join_eq_na16_nb16`, matches the landed member);
- additive default: a join-less manifest JSON still parses (`join_edges` defaults empty);
- field-ordering pin cross-referencing the Noir `main`;
- the hidden join value/blinder are absent from the serialized public inputs.

## Verification

- `cargo build` (workspace) — clean (catches the exhaustive-match breakage in 42 test struct-literal sites, all fixed with `join_edges: vec![]`).
- `cargo nextest run -p sparq-zk-compose` — **219/219 pass** (4 new), `sparq-zk` 87/87.
- `cargo clippy -p sparq-zk-compose --all-targets -- -D warnings` — clean.
- `cargo fmt`: informational per repo policy (clippy is the hard gate); only my intended files committed, no workspace-wide reformat (pre-existing deferred fmt drift left untouched).

Refs sq-fi03, parent sq-bwwl (step 3). Unblocks sq-sfsi (step 4).