### PR TITLE
feat(bench): SHACL validation benchmark suite (sq-7iai)

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -58,7 +58,7 @@ conventions first, then a per-category map that points at the registry, then a
 
 | category | what it covers | registry ids |
 |---|---|---|
-| **query** | engine compute + differential correctness; aux-index harnesses; well-known suites | `sparq-bench-compare`, `sparq-bench-fuzz`, `sparq-bench-diff`, `cli-bench-suite`, `cli-bench-mmap`, `operator-coverage`, `sp2b`, `dbpsb`, `watdiv`, `bsbm`, `lubm`, `selective-bindjoin`, `u64-valueids`, `qlever-olympics`, `qlever-synthetic-10m`, `qlever-synthetic-100m`, `text-index-bench`, `geo-index-bench`, `rsp-throughput`, `vectors-throughput`, `gpu-bench`, `sim-olympics-eval`, `introspect-olympics` |
+| **query** | engine compute + differential correctness; aux-index harnesses; well-known suites | `sparq-bench-compare`, `sparq-bench-fuzz`, `sparq-bench-diff`, `cli-bench-suite`, `cli-bench-mmap`, `operator-coverage`, `sp2b`, `dbpsb`, `watdiv`, `bsbm`, `lubm`, `shacl-validate-bench`, `selective-bindjoin`, `u64-valueids`, `qlever-olympics`, `qlever-synthetic-10m`, `qlever-synthetic-100m`, `text-index-bench`, `geo-index-bench`, `rsp-throughput`, `vectors-throughput`, `gpu-bench`, `sim-olympics-eval`, `introspect-olympics` |
 | **parse** | text-format parse throughput (MB/s) | `parse-baseline` |
 | **ingest** | load + dict + external-memory build throughput | `cli-ingest`, `cli-save-build`, `cli-bench-remap`, `hdt-load-bench`, `wikidata-8b` |
 | **compression** | index / result-serialization footprint tradeoffs | `cli-probe-compress`, `cli-compare-compress`, `compress-bench` |
@@ -113,6 +113,17 @@ Notes on a few that need care:
   asserting BOTH tiers' counts vs `expected-rows.tsv`. CI emits `lubm_<query>_count_us`
   (trend-only) and fails on any count mismatch (reasoner OR engine regression). Full-scale
   **LUBM(1000)** (~133M triples) is the EC2/nightly tier (`bench/lubm/gen.sh 1000 0`).
+- **`shacl-validate-bench` is the SHACL VALIDATION suite** — see
+  [`bench/shacl/README.md`](./shacl/README.md). It REUSES the LUBM(1) ABox as its data substrate
+  (so it shares the `javac`/`rapper` guard) × the **5 committed shape graphs** under
+  `bench/shacl/shapes/` (`cardinality`, `datatype_range`, `class_nodekind`, `node_paths`,
+  `sparql_constraint`). `run.sh` is self-asserting: it validates with the `bench_shacl` example and
+  asserts each workload's **violations / conforms / focus_nodes** vs `expected.tsv` (deterministic
+  at the pinned corpus + shapes; exit 1 on drift). The W3C core pass-count ratchet (98/98) lives in
+  `crates/sparq-shacl/tests/w3c_core.rs` (`BASELINE_PASS`, only-tightens). CI emits
+  `shacl_<workload>_validate_us` (trend-only, advisory). Heavy tiers: `univ=5`/`univ=10`. The
+  cleanest competitor surface — Jena-SHACL / pySHACL / rdf-validate-shacl run the *identical*
+  `(data, shapes)` pair (see the competitor map below + `scripts/bench-adapters/`).
 - **`deep-taxonomy` (DeepTaxonomy) is the rule-heavy N3 REASONING suite** — see
   [`bench/deep-taxonomy/README.md`](./deep-taxonomy/README.md). `run.sh` is self-asserting and
   REUSES the existing generator `bench/inference/gen_deeptaxonomy.py` (1 instance + a depth-deep
@@ -151,7 +162,10 @@ Notes on a few that need care:
   Comparable-suite map (registry-driven): **Oxigraph** ↔ `sparq-bench-compare`,
   `sp2b`, `watdiv`, `bsbm`, `dbpsb`, `lubm` (extensional only); **QLever** ↔
   `qlever-olympics`, `qlever-synthetic-10m/100m`, `watdiv`, `bsbm`, `lubm`
-  (extensional); **eye** ↔ `inference-eye-comparison` + `deep-taxonomy` (DeepTaxonomy/anc500/grid30).
+  (extensional); **eye** ↔ `inference-eye-comparison` + `deep-taxonomy` (DeepTaxonomy/anc500/grid30);
+  **Jena-SHACL / pySHACL / rdf-validate-shacl** ↔ `shacl-validate-bench` (identical data×shapes;
+  cross-check `#violations`/`conforms` per-engine before trusting timing — `report-cli`/`js-lib`
+  adapter kinds in `scripts/bench-adapters/`, gather-only on a Docker EC2 box).
   HONESTY NOTE (per parent `sq-i0nm`): a gh-runner gather is noisy and not
   comparable to the EC2/quiet-box reference band — the recorded `env.quiet_box`
   flag lets the dashboard label it distinctly (see the QUIET-BOX convention above).
@@ -173,6 +187,7 @@ CUT=$(bench/dbpsb/fetch.sh 750000)   && ./target/release/sparq-cli bench "$CUT" 
 bench/watdiv/run.sh 1                 # WatDiv SF=1 (g++ + Boost): gen + count/materialize/json + row diff
 bench/bsbm/run.sh                     # BSBM Explore -pc 300 (JRE + unzip): gen + materialize + row diff
 bench/lubm/run.sh                     # LUBM(1) (javac + rapper): gen + OWL-RL closure + both tiers + row diff
+bench/shacl/run.sh                    # SHACL (javac + rapper): LUBM ABox x 5 shapes + violations/conforms/focus_nodes diff
 bench/deep-taxonomy/run.sh            # DeepTaxonomy (python3 only): N3 closure per depth tier + closure-size + query-row gate
 
 # --- selective bind-join + u64 value-id probes ---

--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -176,6 +176,21 @@ pinning     = "UBA pinned commit (gen.sh UBA_COMMIT) + LUBM(1) -univ 1 -seed 0 (
 records_to  = "stdout (TSV); CI emits lubm_<query>_count_us into benchmark-data (dev/bench) via scripts/ci-bench.sh; expected sizes in bench/lubm/expected-rows.tsv"
 status      = "ok"
 
+# [OPUS-4.8] sq-7iai (design research/capability-benchmark-program.md §3.1) — the SHACL VALIDATION
+# suite: the cleanest competitor surface (Jena-SHACL / pySHACL run the identical data x shapes pair).
+[[benchmark]]
+id          = "shacl-validate-bench"
+name        = "SHACL validation — LUBM ABox x 5 hand-authored shape graphs"
+category    = "query"
+measures    = "per-workload validate time (us) for the 5 committed shape graphs (cardinality, datatype_range, class_nodekind, node_paths, sparql_constraint) over the LUBM(1) ABox. run.sh carries a HARD self-asserting gate on each workload's violations (report.results.len()), conforms (0/1) and focus_nodes vs expected.tsv (deterministic at the pinned corpus+shapes; exit 1 on drift). The W3C core pass-count ratchet (98/98) lives in crates/sparq-shacl/tests/w3c_core.rs (BASELINE_PASS, only-tightens). Timing is ADVISORY (mode:noise, trend-only)"
+invoke      = "cargo build --release -p sparq-shacl --example bench_shacl && bench/shacl/run.sh   # self-contained: reuse the LUBM(1) ABox (bench/shacl/gen.sh -> bench/lubm/gen.sh), validate x shapes/*.ttl, assert expected.tsv; CI runs it via scripts/ci-bench.sh -> shacl_<workload>_validate_us"
+source      = "bench/shacl/{gen.sh,run.sh,shapes/*.ttl,expected.tsv,README.md}; crates/sparq-shacl/examples/bench_shacl.rs (the G1 TSV-emitting runner); scripts/ci-bench.sh (shacl hook); competitors bench/competitors.json (jena-shacl/pyshacl/rdf-validate-shacl via scripts/bench-adapters/)"
+dataset     = "REUSES the LUBM(1) ABox (-univ 1 -seed 0, ~103k N-Triples, sha256-pinned UBA generator; see the lubm entry) as the SHACL data graph, x 5 hand-authored shape graphs committed under bench/shacl/shapes/. The shapes' violation counts are deterministic constants at the pinned corpus (each independently cross-checked against the raw ABox; see bench/shacl/expected.tsv). gitignored+regenerable corpus (/tmp/lubm); shapes are committed"
+quiet_box_sensitive = true  # wall-clock validate/load time trend-only, NOT in scripts/perf-gate.py; the violations/conforms/focus_nodes diff IS a hard correctness gate (deterministic, load-robust)
+pinning     = "LUBM(1) -univ 1 -seed 0 (the ABox PIN; shapes + expected.tsv bind to it); shapes/*.ttl committed verbatim; sparq-shacl does NOT dedup results across traversal routes, so cross-engine #violations comparison uses PER-ENGINE expected counts (scripts/bench-adapters/cross_check_shacl.sh), not the single sparq constant"
+records_to  = "stdout (TSV); CI emits shacl_<workload>_validate_us into benchmark-data (dev/bench) via scripts/ci-bench.sh; deterministic gates in bench/shacl/expected.tsv"
+status      = "ok"
+
 [[benchmark]]
 id          = "deep-taxonomy"
 name        = "Deep Taxonomy (DeepTaxonomy) — rule-heavy N3 forward-closure reasoning"

--- a/bench/competitors.json
+++ b/bench/competitors.json
@@ -127,6 +127,28 @@
       "dashboard_engine_id": "pyshacl"
     },
     {
+      "id": "jena-shacl",
+      "name": "Apache Jena SHACL",
+      "kind": "report-cli",
+      "role": "[OPUS-4.8 sq-7iai] Tier-1 SHACL correctness oracle + mainstream JVM baseline (the SHACL analogue of Fuseki). Apache-2.0. Adapter kind `report-cli` (file-in / validation-report-out), reusing scripts/bench-adapters/shacl_report_count.py (count sh:result, read sh:conforms) so #violations is directly comparable to sparq's report.results.len(). Add first among the SHACL competitors.",
+      "pinned_version": "apache-jena (shacl validate; pin the exact Jena distribution/Docker digest at gather time)",
+      "version_source": "the Jena distribution version (bin/shacl is part of apache-jena-<ver>) or the `stain/jena` Docker image DIGEST, recorded in the gather results file.",
+      "install_recipe": "download apache-jena-<ver>.tar.gz (Apache-2.0) and put bin/ on PATH, OR use the `stain/jena` Docker image (Docker-based -> gather-only on a Docker EC2 box, like QLever; zero recurring CI cost). gather-only — NOT a committed dependency (engines stay out of git per AGENTS.md).",
+      "run_recipe": "scripts/gather-competitors.sh --run --only jena-shacl  with SHACL_DATA=<data.ttl> SHACL_SHAPES=<shapes.ttl> set; the dispatch calls scripts/bench-adapters/report_cli_adapter.py with the `adapter` recipe below (Jena writes the sh:ValidationReport to stdout in Turtle).",
+      "adapter": {
+        "cmd": ["shacl", "validate", "--data", "{data}", "--shapes", "{shapes}"],
+        "report_format": "turtle",
+        "report_to": "stdout",
+        "version_cmd": ["shacl", "--version"]
+      },
+      "comparable_suites": [
+        { "sparq_suite": "shacl-validate-bench", "note": "same data x shapes; cross-check #violations/conforms (per-engine expected counts — engines that dedup results differ from sparq, which does not) before trusting any timing. sh:sparql coverage differs across engines — scope perf to constraints all Tier-1 implement." }
+      ],
+      "version_env_metadata": "gather records the Jena version (or Docker image digest) + java -version + the host env block.",
+      "quiet_box_sensitive": true,
+      "dashboard_engine_id": "jena-shacl"
+    },
+    {
       "id": "rdf-validate-shacl",
       "name": "Zazuko rdf-validate-shacl",
       "kind": "js-lib",

--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -219,7 +219,7 @@
   var GROUP_ORDER = [
     'Pipeline', 'Memory / Size',
     'Synthetic (qlever-style)', 'Operators',
-    'WatDiv', 'LUBM (reasoning)', 'SP2Bench', 'BSBM', 'DBPSB'
+    'WatDiv', 'LUBM (reasoning)', 'SHACL validation', 'SP2Bench', 'BSBM', 'DBPSB'
   ];
 
   function buildSummary(entries) {
@@ -272,6 +272,8 @@
     { key: 'WatDiv',        title: 'WatDiv',        aliases: ['watdiv'] },
     { key: 'SP2Bench',      title: 'SP2Bench',      aliases: ['sp2bench', 'sp2b'] },
     { key: 'Deep Taxonomy', title: 'Deep Taxonomy', aliases: ['deep taxonomy', 'deeptax', 'deep-taxonomy', 'deeptaxonomy'] },
+    // [OPUS-4.8] sq-7iai: SHACL validation suite (LUBM ABox x 5 hand-authored shape graphs).
+    { key: 'SHACL',         title: 'SHACL validation', aliases: ['shacl', 'shacl validation'] },
     { key: 'BSBM',          title: 'BSBM',          aliases: ['bsbm'] },
     { key: 'DBPSB',         title: 'DBPSB',         aliases: ['dbpsb', 'dbpedia sparql benchmark'] },
     // [OPUS-4.8] sq-i0nm: the synthetic qlever-style suite carries the one in-repo competitor

--- a/bench/dashboard/metric-labels.json
+++ b/bench/dashboard/metric-labels.json
@@ -1719,6 +1719,46 @@
       "query": "materialize the RDFS closure (rdfs:subClassOf)",
       "unit": "s"
     },
+    "shacl_cardinality_validate": {
+      "label": "SHACL cardinality — sh:minCount/sh:maxCount over ub:FullProfessor (focus enumeration + path counting), validate",
+      "suite": "SHACL validation",
+      "dataset": "LUBM(1) ABox, ~103k triples x hand-authored shape graph",
+      "query": "sh:minCount/sh:maxCount over ub:FullProfessor (focus enumeration + path counting)",
+      "mode": "validate",
+      "unit": "µs"
+    },
+    "shacl_class_nodekind_validate": {
+      "label": "SHACL class_nodekind — sh:class (subclass-closure target) + sh:nodeKind over ub:worksFor, validate",
+      "suite": "SHACL validation",
+      "dataset": "LUBM(1) ABox, ~103k triples x hand-authored shape graph",
+      "query": "sh:class (subclass-closure target) + sh:nodeKind over ub:worksFor",
+      "mode": "validate",
+      "unit": "µs"
+    },
+    "shacl_datatype_range_validate": {
+      "label": "SHACL datatype_range — sh:datatype/sh:pattern over ub:GraduateStudent literals (XSD lexical), validate",
+      "suite": "SHACL validation",
+      "dataset": "LUBM(1) ABox, ~103k triples x hand-authored shape graph",
+      "query": "sh:datatype/sh:pattern over ub:GraduateStudent literals (XSD lexical)",
+      "mode": "validate",
+      "unit": "µs"
+    },
+    "shacl_node_paths_validate": {
+      "label": "SHACL node_paths — sh:node + sequence/inverse paths over ub:GraduateStudent (inter-shape recursion), validate",
+      "suite": "SHACL validation",
+      "dataset": "LUBM(1) ABox, ~103k triples x hand-authored shape graph",
+      "query": "sh:node + sequence/inverse paths over ub:GraduateStudent (inter-shape recursion)",
+      "mode": "validate",
+      "unit": "µs"
+    },
+    "shacl_sparql_constraint_validate": {
+      "label": "SHACL sparql_constraint — sh:sparql (SHACL §5.2) routed through sparq-engine, validate",
+      "suite": "SHACL validation",
+      "dataset": "LUBM(1) ABox, ~103k triples x hand-authored shape graph",
+      "query": "sh:sparql (SHACL §5.2) routed through sparq-engine",
+      "mode": "validate",
+      "unit": "µs"
+    },
     "sp2b_q01_count": {
       "label": "SP2Bench q01 — single journal's issue year (selective lookup), count",
       "suite": "SP2Bench",

--- a/bench/shacl/README.md
+++ b/bench/shacl/README.md
@@ -1,0 +1,92 @@
+<!-- [OPUS-4.8] sq-7iai — SHACL validation benchmark suite. Design: research/capability-benchmark-program.md §3.1. -->
+# SHACL validation suite
+
+The SHACL analogue of the LUBM template: an **overview** dashboard row, a **self-asserting
+deterministic gate** (regression alerts), and a **competitor** comparison surface. It is the
+cleanest competitor surface — Jena-SHACL / pySHACL / rdf-validate-shacl all run the *identical*
+`(data graph, shape graph)` pair and emit a `sh:ValidationReport`, so `#violations`/`conforms`
+cross-check before any timing is trusted.
+
+## Data substrate
+
+The suite reuses the **LUBM(1) ABox** (`bench/lubm/gen.sh -univ 1 -seed 0`, ~103k N-Triples, the
+sha256-pinned UBA generator) as its SHACL **data graph** — exactly what Trav-SHACL / Re-SHACL do.
+`bench/shacl/gen.sh` is a thin wrapper over the LUBM generator: it emits two paths on stdout, the
+data N-Triples and the committed `shapes/` directory. The workloads validate the **raw ABox** (no
+entailment), so their violation counts are deterministic constants at the pinned corpus.
+
+Scale tiers: `univ=1` (per-commit, ~103k triples); `univ=5`/`univ=10` (EC2/heavy — the shapes are
+scale-parametric, but `expected.tsv` is pinned to `univ=1`).
+
+## Workloads — the 5 committed shape graphs (`shapes/*.ttl`)
+
+| Workload | Constraints exercised | Targets |
+|---|---|---|
+| `cardinality` | `sh:minCount` / `sh:maxCount` (focus-node enumeration + path counting) | `ub:FullProfessor` |
+| `datatype_range` | `sh:datatype` + `sh:pattern` (XSD lexical space) | `ub:GraduateStudent` |
+| `class_nodekind` | `sh:class` (subclass-closure target) + `sh:nodeKind` (target selection at scale) | `ub:FullProfessor` |
+| `node_paths` | `sh:node` + sequence/inverse paths (inter-shape recursion — Trav-SHACL's hard case) | `ub:GraduateStudent` |
+| `sparql_constraint` | `sh:sparql` (SHACL §5.2) routed through `sparq-engine` — the path unique to sparq's architecture (kept separate, **not** the headline) | `ub:GraduateStudent` |
+
+Each shape is authored so a **fixed fraction of focus nodes is invalid** at the pinned corpus, making
+the violation count a deterministic constant. The constants in `expected.tsv` were **derived by
+running `sparq-shacl`** on the corpus (not guessed) and each is **independently cross-checked against
+the raw ABox** (see the `expected.tsv` header).
+
+## Deterministic gate (HARD) vs timing (ADVISORY)
+
+`run.sh` is the self-asserting entry point (the LUBM pattern). It validates with the
+`crates/sparq-shacl/examples/bench_shacl.rs` runner and **asserts, per workload, vs `expected.tsv`,
+exit 1 on any drift**:
+
+- **`<workload>_violations`** — `report.results.len()` (the primary gate).
+- **`<workload>_conforms`** — `report.conforms` as 0/1 (a correctness drift detector).
+- **`<workload>_focus_nodes`** — the distinct focus nodes the targets select (a target-selection
+  regression detector; engine-independent — pure target selection via `sparq_shacl::count_focus_nodes`).
+
+Plus the **`shacl_w3c_pass` ratchet** — the W3C `data-shapes` core pass count (only tightens) — which
+lives in `crates/sparq-shacl/tests/w3c_core.rs` (`BASELINE_PASS`, asserted by `cargo test`), not on the
+benchmark dashboard.
+
+**Timing is ADVISORY** (`mode:noise`, trend-only, **never hard-gated** — and this dev box is
+non-canonical, so its timings are advisory only): the ci-bench hook harvests
+`shacl_<workload>_validate_us` (the headline validate time) into the dashboard; it is **not** in
+`scripts/perf-gate.py`. `bench_shacl` also reports a load time per run (advisory). The hard
+correctness gate lives in `run.sh`'s `expected.tsv` diff, so the harvested timings stay advisory.
+
+## Running it
+
+```sh
+cargo build --release -p sparq-shacl --example bench_shacl
+bench/shacl/run.sh                       # self-asserting: exit 1 on any count drift
+```
+
+The G1 runner (`bench_shacl`) emits, per `shapes/*.ttl`, a 6-column TSV
+`name<TAB>violations<TAB>validate_us<TAB>conforms<TAB>focus_nodes<TAB>load_us`. `run.sh` asserts the
+deterministic columns and forwards the `name<TAB>violations<TAB>validate_us` 3-column contract the
+ci-bench hook consumes. (`sparq-shacl` is the *isolated* SHACL crate — not a `sparq-cli` dependency —
+so the runner is a crate `--example`, not a CLI subcommand.)
+
+## Competitors
+
+All run the identical `(data, shapes)` pair and emit a `sh:ValidationReport`:
+
+| Engine | Lang | License | Adapter kind | Role |
+|---|---|---|---|---|
+| **Apache Jena SHACL** (`shacl validate`) | JVM | Apache-2.0 | `report-cli` | Tier-1 correctness oracle + mainstream baseline |
+| **pySHACL** | Python | Apache-2.0 | `report-cli` | Tier-1 W3C reference impl; the correct-but-slow anchor |
+| **Zazuko rdf-validate-shacl** | JS | MIT | `js-lib` | WASM-peer for sparq's browser SHACL story |
+
+Registered in `bench/competitors.json` (with the `engines`/`values` dashboard seam **empty** in git
+per AGENTS.md — no hard-coded perf). A real `scripts/gather-competitors.sh --run --only <id>` writes
+git-ignored `bench/competitor-results/`. Docker-based competitors (Jena via `stain/jena`) are
+inherently gather-only on a Docker EC2 box (no Docker on the dev box), so they add zero recurring CI
+cost. The shared adapters live in `scripts/bench-adapters/` (`report_cli_adapter.py` +
+`shacl_report_count.py`; `js_shacl_adapter.mjs`).
+
+**Honest caveat:** `sparq-shacl` does **not** deduplicate results across traversal routes (matching
+the W3C suite's per-occurrence expectations). Engines that *do* dedup will report a different
+`#violations` for the same data, so a cross-engine comparison uses **per-engine expected counts**
+(`scripts/bench-adapters/cross_check_shacl.sh`), not the single sparq constant in `expected.tsv`.
+`<focus_nodes>` is engine-independent. `sh:sparql` coverage differs across engines — scope perf to
+constraints all Tier-1 implement.

--- a/bench/shacl/expected.tsv
+++ b/bench/shacl/expected.tsv
@@ -1,0 +1,29 @@
+# [OPUS-4.8] (sq-7iai) SHACL benchmark DETERMINISTIC golden counts for the LUBM(1)
+# ABox (bench/lubm/gen.sh 1 0, ~103k triples) x the 5 committed shape graphs in
+# shapes/. Format: <workload>\t<conforms>\t<violations>\t<focus_nodes>.
+#   conforms     report.conforms as 0/1 (0 = does not conform).
+#   violations   report.results.len() — the PRIMARY deterministic gate.
+#   focus_nodes  distinct focus nodes the shape's targets select (target-selection gate).
+# These are DERIVED by running sparq-shacl (examples/bench_shacl) on the pinned corpus,
+# not guessed, and each is independently cross-checked against the raw ABox (see README).
+# run.sh asserts every value and exits 1 on any drift (a correctness regression).
+#
+# PER-ENGINE CAVEAT: sparq-shacl does NOT deduplicate results across traversal routes
+# (matching the W3C suite's per-occurrence expectations). Engines that DO dedup may report
+# a different <violations> for the same (data, shapes) pair, so a cross-engine comparison
+# must use per-engine expected counts (see scripts/bench-adapters/cross_check_shacl.sh),
+# NOT this single sparq constant. <focus_nodes> is engine-independent (pure target selection).
+#
+# Cross-checks (independent, from the raw ABox):
+#   cardinality       125 FullProfessors fail maxCount 1 (all teach >=2) + 24 with exactly
+#                     2 teacherOf fail minCount 3                                 => 149
+#   class_nodekind    125 FullProfessors: worksFor is a Department, not a University => 125
+#   datatype_range    1874 GraduateStudent names are plain literals, not xsd:integer => 1874
+#   node_paths        1874 GraduateStudents; 72 have a department-head advisor, so
+#                     1874 - 72 = 1802 fail the advisor sh:node (be a head)        => 1802
+#   sparql_constraint 3738 (GraduateStudent, takesCourse->GraduateCourse) solutions => 3738
+cardinality	0	149	125
+class_nodekind	0	125	125
+datatype_range	0	1874	1874
+node_paths	0	1802	1874
+sparql_constraint	0	3738	1874

--- a/bench/shacl/gen.sh
+++ b/bench/shacl/gen.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] (sq-7iai) SHACL benchmark corpus generator. The SHACL suite uses the LUBM
+# ABox as its data substrate (exactly as Trav-SHACL / Re-SHACL do) x the 5 hand-authored
+# shape graphs committed under shapes/. So this is a THIN wrapper over bench/lubm/gen.sh:
+# it generates the deterministic LUBM(univ) ABox and emits two paths on stdout (mirroring
+# bench/lubm/gen.sh's two-line convention):
+#
+#   bench/shacl/gen.sh [univ=1] [seed=0]
+#
+#   1. <data.nt>     the LUBM(univ) ABox (raw N-Triples; the SHACL DATA graph)
+#   2. <shapes-dir>  bench/shacl/shapes/ (the 5 committed shape graphs; NOT generated)
+#
+# run.sh consumes both: validate <data.nt> against each shapes/*.ttl. The ontology TBox
+# line that bench/lubm/gen.sh emits is intentionally NOT forwarded — the SHACL workloads
+# validate the RAW ABox (no entailment), so their violation counts are deterministic
+# constants at the pinned (-univ, -seed) corpus + fixed shapes (see expected.tsv).
+#
+# Toolchain + hermeticity are inherited from bench/lubm/gen.sh (javac/jar + rapper; one
+# pinned shallow clone, then fully cached). The corpus is gitignored + regenerable.
+set -euo pipefail
+
+UNIV="${1:-1}"
+SEED="${2:-0}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+# Reuse the LUBM generator for the deterministic ABox; it emits two lines (data, ontology).
+mapfile -t LUBM_ARTS < <("$ROOT/bench/lubm/gen.sh" "$UNIV" "$SEED")
+DATA="${LUBM_ARTS[0]}"
+
+echo "$DATA"
+echo "$HERE/shapes"

--- a/bench/shacl/run.sh
+++ b/bench/shacl/run.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] (sq-7iai) SHACL per-commit runner — the self-asserting entry point CI calls,
+# mirroring bench/lubm/run.sh. Self-contained:
+#   1. ensure the LUBM(1) ABox exists (gen.sh) + locate the shapes dir.
+#   2. run examples/bench_shacl over the data x shapes/*.ttl (count + advisory timing).
+#   3. ASSERT each workload's conforms/violations/focus_nodes vs expected.tsv (exit 1 on
+#      any drift — the HARD correctness gate lives here, so the harvested timings stay
+#      advisory). This is the SHACL analogue of LUBM's count diff.
+#   4. emit on STDOUT the 3-column `<workload>\t<violations>\t<validate_us>` contract the
+#      ci-bench hook consumes (count = the asserted #violations; us = validate time).
+#      Correctness lives in expected.tsv, NOT in extra stdout columns — exactly like LUBM.
+#
+# Usage: bench/shacl/run.sh   (run from anywhere; honours $BENCH_SHACL / $ITERS overrides)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+ITERS="${ITERS:-3}"
+GEN="$ROOT/bench/shacl/gen.sh"
+EXP="$ROOT/bench/shacl/expected.tsv"
+# The G1 TSV-emitting runner: a sparq-shacl example (the crate stays isolated — it is not a
+# dependency of sparq-cli). Override with $BENCH_SHACL for a custom build.
+BIN="${BENCH_SHACL:-$ROOT/target/release/examples/bench_shacl}"
+
+if [ ! -x "$BIN" ]; then
+  echo "[shacl] ERROR: bench_shacl not found at $BIN" >&2
+  echo "[shacl]   build: cargo build --release -p sparq-shacl --example bench_shacl" >&2
+  exit 1
+fi
+
+# ---- 1. ensure data + locate shapes (gen.sh emits two lines: data.nt then shapes-dir) ----
+mapfile -t ARTS < <("$GEN" 1 0)
+DATA="${ARTS[0]}"
+SHAPES="${ARTS[1]}"
+echo "[shacl] data=$DATA  shapes=$SHAPES" >&2
+
+# ---- 2. validate (full 6-column TSV: name violations validate_us conforms focus_nodes load_us)
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+"$BIN" "$DATA" ntriples "$SHAPES" "$ITERS" > "$TMP/shacl.tsv"
+
+# ---- 3. assert the DETERMINISTIC columns vs expected.tsv (exit 1 on any mismatch) --------
+fail=0
+seen=0
+while IFS=$'\t' read -r name violations validate_us conforms focus_nodes _load_us; do
+  [ -n "$name" ] || continue
+  # expected.tsv: <workload>\t<conforms>\t<violations>\t<focus_nodes>
+  exp="$(awk -F'\t' -v k="$name" '$1==k{print $2"\t"$3"\t"$4}' "$EXP")"
+  if [ -z "$exp" ]; then
+    echo "[shacl] ERROR: $name has no expected.tsv entry" >&2; fail=1; continue
+  fi
+  IFS=$'\t' read -r exp_conforms exp_violations exp_focus <<< "$exp"
+  if [ "$violations" != "$exp_violations" ]; then
+    echo "[shacl] ERROR: $name violations=$violations expected=$exp_violations (correctness regression)" >&2; fail=1
+  fi
+  if [ "$conforms" != "$exp_conforms" ]; then
+    echo "[shacl] ERROR: $name conforms=$conforms expected=$exp_conforms (correctness regression)" >&2; fail=1
+  fi
+  if [ "$focus_nodes" != "$exp_focus" ]; then
+    echo "[shacl] ERROR: $name focus_nodes=$focus_nodes expected=$exp_focus (target-selection regression)" >&2; fail=1
+  fi
+  seen=$((seen+1))
+  # ---- 4. forward the 3-column hook contract on STDOUT (count = #violations) ----
+  printf '%s\t%s\t%s\n' "$name" "$violations" "$validate_us"
+done < "$TMP/shacl.tsv"
+
+# Every committed workload must have run (a vanished workload is itself a regression).
+exp_workloads=$(grep -cvE '^#|^$' "$EXP")
+if [ "$seen" != "$exp_workloads" ]; then
+  echo "[shacl] ERROR: ran $seen workloads, expected $exp_workloads (a workload vanished)" >&2; fail=1
+fi
+
+if [ "$fail" = 0 ]; then
+  echo "[shacl] OK: all $seen workloads match expected.tsv (violations + conforms + focus_nodes)" >&2
+else
+  echo "[shacl] FAILED: one or more values diverged from expected.tsv" >&2
+fi
+exit "$fail"

--- a/bench/shacl/shapes/cardinality.ttl
+++ b/bench/shacl/shapes/cardinality.ttl
@@ -1,0 +1,26 @@
+# [OPUS-4.8] (sq-7iai) SHACL benchmark workload 1: CARDINALITY.
+# sh:minCount / sh:maxCount over the LUBM(1) ABox. Stresses focus-node enumeration
+# (every ub:FullProfessor) + path-value counting. The LUBM generator gives every
+# FullProfessor between 2 and 4 ub:teacherOf edges (deterministic at -univ 1 -seed 0),
+# so these constraints have FIXED violation counts at the pinned corpus:
+#   - maxCount 1 on teacherOf: violated by EVERY professor (all have >= 2).
+#   - minCount 3 on teacherOf: violated by exactly the professors with only 2 edges.
+# The expected constants live in bench/shacl/expected.tsv (derived by RUNNING sparq-shacl,
+# not guessed) and run.sh asserts them, exit 1 on drift.
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix ub:  <http://swat.cse.lehigh.edu/onto/univ-bench.owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:  <http://example.org/shacl-bench/> .
+
+ex:ProfessorCardinalityShape a sh:NodeShape ;
+    sh:targetClass ub:FullProfessor ;
+    # Every professor teaches >= 2 courses, so maxCount 1 is violated by ALL of them.
+    sh:property [
+        sh:path ub:teacherOf ;
+        sh:maxCount 1 ;
+    ] ;
+    # Professors with only 2 ub:teacherOf edges violate minCount 3.
+    sh:property [
+        sh:path ub:teacherOf ;
+        sh:minCount 3 ;
+    ] .

--- a/bench/shacl/shapes/class_nodekind.ttl
+++ b/bench/shacl/shapes/class_nodekind.ttl
@@ -1,0 +1,23 @@
+# [OPUS-4.8] (sq-7iai) SHACL benchmark workload 3: CLASS_NODEKIND.
+# sh:class (target-selection at scale) + sh:nodeKind. The LUBM ABox types every
+# ub:FullProfessor's ub:worksFor object as a ub:Department (never a ub:University), and
+# every such object is an IRI, so:
+#   - sh:class ub:University on ub:worksFor: violated by EVERY professor (the value is a
+#     Department, not a University) -> a deterministic positive at the pinned corpus.
+#   - sh:nodeKind sh:IRI on ub:worksFor: all values are IRIs -> ZERO violations (a
+#     deterministic-negative control exercising the nodeKind path).
+# sh:class uses the rdfs:subClassOf* target closure in sparq-shacl; Department is not a
+# subclass of University in the raw ABox, so the count is stable without reasoning.
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix ub:  <http://swat.cse.lehigh.edu/onto/univ-bench.owl#> .
+@prefix ex:  <http://example.org/shacl-bench/> .
+
+ex:ProfessorAffiliationShape a sh:NodeShape ;
+    sh:targetClass ub:FullProfessor ;
+    sh:property [
+        sh:path ub:worksFor ;
+        # worksFor points at a Department, never a University -> violated by all.
+        sh:class ub:University ;
+        # ...but it IS always an IRI -> the nodeKind constraint never fires.
+        sh:nodeKind sh:IRI ;
+    ] .

--- a/bench/shacl/shapes/datatype_range.ttl
+++ b/bench/shacl/shapes/datatype_range.ttl
@@ -1,0 +1,26 @@
+# [OPUS-4.8] (sq-7iai) SHACL benchmark workload 2: DATATYPE_RANGE.
+# sh:datatype + sh:pattern over XSD lexical space. The LUBM ABox stores ub:name and
+# ub:emailAddress as plain (xsd:string) literals, so:
+#   - sh:datatype xsd:integer on ub:name: violated by EVERY GraduateStudent's name
+#     (a plain-literal name is not an xsd:integer).
+#   - sh:pattern "^[^@]+@.+$" on ub:emailAddress: the LUBM email lexical form always
+#     matches, so this constraint contributes ZERO violations (a deterministic-negative
+#     control that the pattern engine runs without firing).
+# Deterministic at the pinned corpus; counts in expected.tsv.
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix ub:  <http://swat.cse.lehigh.edu/onto/univ-bench.owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:  <http://example.org/shacl-bench/> .
+
+ex:GradStudentLiteralShape a sh:NodeShape ;
+    sh:targetClass ub:GraduateStudent ;
+    # Names are plain string literals -> every one violates xsd:integer.
+    sh:property [
+        sh:path ub:name ;
+        sh:datatype xsd:integer ;
+    ] ;
+    # Well-formed email lexical form -> matches the pattern -> no violation.
+    sh:property [
+        sh:path ub:emailAddress ;
+        sh:pattern "^[^@]+@.+$" ;
+    ] .

--- a/bench/shacl/shapes/node_paths.ttl
+++ b/bench/shacl/shapes/node_paths.ttl
@@ -1,0 +1,35 @@
+# [OPUS-4.8] (sq-7iai) SHACL benchmark workload 4: NODE_PATHS.
+# sh:node (inter-shape recursion, Trav-SHACL's hard case) + sequence/inverse paths.
+# Targets ub:GraduateStudent. Each grad student has exactly one ub:advisor (a professor)
+# and a ub:memberOf department.
+#   - sh:node ex:DeptHeadShape on the value of ub:advisor: the advisor must be the head
+#     of some department (ub:headOf). Only 15 professors are department heads in LUBM(1),
+#     so the vast majority of advisors are NOT heads -> a large deterministic violation
+#     count over the grad-student population (recursive sh:node walk per focus node).
+#   - a SEQUENCE path (ub:memberOf / ub:subOrganizationOf) with sh:minCount 1 reaching the
+#     student's university: every student's department is a sub-organisation of a
+#     university, so this contributes ZERO violations (a deterministic-negative control
+#     exercising the multi-hop path walk).
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix ub:  <http://swat.cse.lehigh.edu/onto/univ-bench.owl#> .
+@prefix ex:  <http://example.org/shacl-bench/> .
+
+ex:GradStudentPathShape a sh:NodeShape ;
+    sh:targetClass ub:GraduateStudent ;
+    # The advisor must conform to ex:DeptHeadShape (be a department head).
+    sh:property [
+        sh:path ub:advisor ;
+        sh:node ex:DeptHeadShape ;
+    ] ;
+    # Sequence path memberOf/subOrganizationOf reaches a university -> never empty.
+    sh:property [
+        sh:path ( ub:memberOf ub:subOrganizationOf ) ;
+        sh:minCount 1 ;
+    ] .
+
+# Inner shape: a department head has at least one ub:headOf edge.
+ex:DeptHeadShape a sh:NodeShape ;
+    sh:property [
+        sh:path ub:headOf ;
+        sh:minCount 1 ;
+    ] .

--- a/bench/shacl/shapes/sparql_constraint.ttl
+++ b/bench/shacl/shapes/sparql_constraint.ttl
@@ -1,0 +1,34 @@
+# [OPUS-4.8] (sq-7iai) SHACL benchmark workload 5: SPARQL_CONSTRAINT.
+# A SHACL-SPARQL (sh:sparql, W3C SHACL §5.2) constraint routed through sparq-engine —
+# the validation path unique to sparq's architecture (a SELECT run per focus node with
+# $this pre-bound). Kept as a SEPARATE workload, NOT the headline (engines differ on
+# sh:sparql coverage; see README competitor caveat).
+#
+# Targets ub:GraduateStudent. The SELECT fires (one solution per offending value) when a
+# student takes a ub:GraduateCourse via ub:takesCourse. The LUBM generator gives grad
+# students takesCourse edges to GraduateCourses, so this produces a FIXED number of
+# solutions across the population at the pinned corpus. expected.tsv holds the constant;
+# run.sh asserts it.
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix ub:  <http://swat.cse.lehigh.edu/onto/univ-bench.owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:  <http://example.org/shacl-bench/> .
+
+ex:GradCourseLoadShape a sh:NodeShape ;
+    sh:targetClass ub:GraduateStudent ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:prefixes ex:benchPrefixes ;
+        sh:message "GraduateStudent takes a GraduateCourse" ;
+        sh:select """
+            SELECT $this ?value WHERE {
+                $this ub:takesCourse ?value .
+                ?value a ub:GraduateCourse .
+            }
+        """ ;
+    ] .
+
+ex:benchPrefixes sh:declare [
+    sh:prefix "ub" ;
+    sh:namespace "http://swat.cse.lehigh.edu/onto/univ-bench.owl#"^^xsd:anyURI ;
+] .

--- a/crates/sparq-shacl/examples/bench_shacl.rs
+++ b/crates/sparq-shacl/examples/bench_shacl.rs
@@ -40,6 +40,13 @@ fn main() {
         }
     };
     let iters: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(3);
+    // Reject iters=0 explicitly: 0 makes both `0..iters` loops skip, leaving load_us/validate_us
+    // at INFINITY and tripping `data.expect("iters >= 1")` — a non-deterministic footgun. The
+    // gate contract requires finite `name\tcount\tus`, so demand a real sample count up front.
+    if iters == 0 {
+        eprintln!("error: iters must be >= 1 (got 0); need at least one sample for finite timings");
+        std::process::exit(2);
+    }
 
     // ---- load the data graph once (timed: the ADVISORY load metric) -------------------
     let data_text = std::fs::read_to_string(data_path)

--- a/crates/sparq-shacl/examples/bench_shacl.rs
+++ b/crates/sparq-shacl/examples/bench_shacl.rs
@@ -1,0 +1,94 @@
+//! [OPUS-4.8] (sq-7iai) SHACL validation benchmark runner — the G1 TSV-emitting
+//! runner for `bench/shacl/`. It is the SHACL analogue of `sparq-cli bench`:
+//! validate one data graph against a directory of shape graphs and emit, per
+//! workload, the deterministic gate metrics + an advisory timing.
+//!
+//! ```sh
+//! cargo run -p sparq-shacl --release --example bench_shacl -- <data.nt> <fmt> <shapes-dir> [iters]
+//! ```
+//!
+//! Output: one TSV line per `*.ttl` in `<shapes-dir>` (sorted by workload name):
+//!
+//! ```text
+//! <workload>\t<violations>\t<validate_us>\t<conforms>\t<focus_nodes>\t<load_us>
+//! ```
+//!
+//! - `<workload>`     — the shape file's stem (e.g. `cardinality`).
+//! - `<violations>`   — `report.results.len()` (primary deterministic gate; == the contract `count`).
+//! - `<validate_us>`  — best-of-`iters` validate time in microseconds (ADVISORY timing).
+//! - `<conforms>`     — `report.conforms` as 0/1 (deterministic gate).
+//! - `<focus_nodes>`  — distinct focus nodes the shapes' targets select (deterministic gate).
+//! - `<load_us>`      — data-graph parse+build time in microseconds (ADVISORY timing).
+//!
+//! `bench/shacl/run.sh` parses this, asserts the deterministic columns against
+//! `bench/shacl/expected.tsv` (exit 1 on drift), and forwards the
+//! `<workload>\t<violations>\t<validate_us>` 3-column contract to the ci-bench hook.
+//! Correctness lives in `expected.tsv`, NOT in the binary — exactly like LUBM.
+
+use std::time::Instant;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let (data_path, fmt, shapes_dir) = match (args.first(), args.get(1), args.get(2)) {
+        (Some(d), Some(f), Some(s)) => (d.as_str(), f.as_str(), s.as_str()),
+        _ => {
+            eprintln!(
+                "usage: bench_shacl <data-file> <format> <shapes-dir> [iters]\n\
+                 emits per shapes/*.ttl: name\\tviolations\\tvalidate_us\\tconforms\\tfocus_nodes\\tload_us"
+            );
+            std::process::exit(2);
+        }
+    };
+    let iters: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(3);
+
+    // ---- load the data graph once (timed: the ADVISORY load metric) -------------------
+    let data_text = std::fs::read_to_string(data_path)
+        .unwrap_or_else(|e| panic!("read data {data_path}: {e}"));
+    // Best-of-iters load so the advisory load_us is the least-noisy sample.
+    let mut load_us = f64::INFINITY;
+    let mut data = None;
+    for _ in 0..iters {
+        let t = Instant::now();
+        let g = sparq_core::Graph::load_str(&data_text, fmt)
+            .unwrap_or_else(|e| panic!("parse data {data_path}: {e}"));
+        load_us = load_us.min(t.elapsed().as_secs_f64() * 1e6);
+        data = Some(g);
+    }
+    let data = data.expect("iters >= 1");
+
+    // ---- enumerate shapes/*.ttl (sorted, deterministic order) -------------------------
+    let mut shape_files: Vec<std::path::PathBuf> = std::fs::read_dir(shapes_dir)
+        .unwrap_or_else(|e| panic!("read shapes dir {shapes_dir}: {e}"))
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().map(|x| x == "ttl").unwrap_or(false))
+        .collect();
+    shape_files.sort();
+
+    for path in &shape_files {
+        let name = path.file_stem().unwrap().to_string_lossy().to_string();
+        let shapes_text =
+            std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read shapes {path:?}: {e}"));
+        let shapes = sparq_core::Graph::load_str(&shapes_text, "turtle")
+            .unwrap_or_else(|e| panic!("parse shapes {path:?}: {e}"));
+        // Parse the shapes model once; reuse it for the focus-node count and every
+        // validate iteration (amortises shape parsing, mirroring validate_with_model).
+        let model = sparq_shacl::ShapesModel::parse(&shapes);
+        let focus_nodes = sparq_shacl::count_focus_nodes(&data, &model);
+
+        let mut validate_us = f64::INFINITY;
+        let mut violations = 0usize;
+        let mut conforms = true;
+        for _ in 0..iters {
+            let t = Instant::now();
+            let report = sparq_shacl::validate_with_model(&data, &model);
+            validate_us = validate_us.min(t.elapsed().as_secs_f64() * 1e6);
+            violations = report.results.len();
+            conforms = report.conforms;
+        }
+        println!(
+            "{name}\t{violations}\t{validate_us:.1}\t{}\t{focus_nodes}\t{load_us:.1}",
+            u8::from(conforms),
+        );
+    }
+}

--- a/crates/sparq-shacl/src/lib.rs
+++ b/crates/sparq-shacl/src/lib.rs
@@ -88,6 +88,34 @@ pub fn graph_from_triples<I: IntoIterator<Item = Triple>>(triples: I) -> Graph {
     Graph::from_parts(dict, ids)
 }
 
+/// [OPUS-4.8] (sq-7iai) The number of DISTINCT focus nodes the model's targeted
+/// shapes select over `data` — i.e. the size of the union of every targeted
+/// shape's focus-node set, deduplicated exactly as the validator's own
+/// `focus_nodes` enumeration does. This is a deterministic *target-selection*
+/// statistic (independent of how many constraints those nodes violate), used by
+/// the SHACL benchmark suite as a target-selection regression detector alongside
+/// the violation count.
+///
+/// It reuses the public [`view::GraphView`] target-selection primitives
+/// (`instances_of`/`subjects_of`/`objects_of`), so it stays in lock-step with
+/// the validator without exposing internals.
+pub fn count_focus_nodes(data: &Graph, model: &ShapesModel) -> usize {
+    use oxrdf::Term;
+    let g = view::GraphView::new(data);
+    let mut all: Vec<Term> = Vec::new();
+    for &sid in &model.targeted {
+        for t in &model.shapes[sid].targets {
+            match t {
+                Target::Node(n) => all.push(n.clone()),
+                Target::Class(c) | Target::ImplicitClass(c) => all.extend(g.instances_of(c)),
+                Target::SubjectsOf(p) => all.extend(g.subjects_of(p)),
+                Target::ObjectsOf(p) => all.extend(g.objects_of(p)),
+            }
+        }
+    }
+    view::dedup(all).len()
+}
+
 /// Loads a Turtle document into a [`Graph`], resolving relative IRIs against
 /// `base`.
 pub fn load_turtle_with_base(text: &str, base: &str) -> Result<Graph, String> {
@@ -164,6 +192,31 @@ mod tests {
         assert!(comps
             .iter()
             .any(|c| c.ends_with("MinInclusiveConstraintComponent")));
+    }
+
+    /// [OPUS-4.8] (sq-7iai) `count_focus_nodes` counts the DISTINCT focus nodes the
+    /// targeted shapes select (independent of how many constraints they violate) —
+    /// the SHACL benchmark suite's target-selection gate.
+    #[test]
+    fn focus_node_count_is_distinct_target_union() {
+        let data = Graph::load_str(
+            r#"
+            @prefix ex: <http://example.org/> .
+            ex:alice a ex:Person ; ex:age 30 ; ex:name "Alice" .
+            ex:bob   a ex:Person ; ex:age 40 ; ex:name "Bob" .
+            ex:carol a ex:Person .
+            ex:notaperson a ex:Robot .
+        "#,
+            "turtle",
+        )
+        .unwrap();
+        let shapes = Graph::load_str(SHAPES, "turtle").unwrap();
+        let model = ShapesModel::parse(&shapes);
+        // Three ex:Person instances are the focus nodes; ex:Robot is not targeted.
+        assert_eq!(count_focus_nodes(&data, &model), 3);
+        // A graph with no instances of the targeted class selects zero focus nodes.
+        let empty = Graph::load_str("@prefix ex: <http://example.org/> . ex:x a ex:Other .", "turtle").unwrap();
+        assert_eq!(count_focus_nodes(&empty, &model), 0);
     }
 
     /// The Turtle rendering must itself be valid Turtle.

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -430,22 +430,24 @@ fi
 # run, exactly like LUBM. Skipped gracefully when javac/rapper are absent (PRs install no toolchain).
 SHACL_BIN=target/release/examples/bench_shacl
 if command -v javac >/dev/null 2>&1 && command -v rapper >/dev/null 2>&1 && [ -x "$SHACL_RUN" ]; then
-  if [ ! -x "$SHACL_BIN" ]; then
-    cargo build --release -q -p sparq-shacl --example bench_shacl 2>/dev/null || true
+  # Always (re)build: rust-cache restores target/, so a file-exists check can run a STALE
+  # bench_shacl. Let cargo's own staleness detection decide (a no-op rebuild is cheap), and do
+  # NOT swallow the build error (`|| true`) — a real compile failure must fail the gate, not
+  # silently skip the SHACL correctness check on main. Mirrors how the other suites assume a
+  # freshly-built binary.
+  if ! cargo build --release -q -p sparq-shacl --example bench_shacl; then
+    echo "ERROR: bench_shacl example failed to build" >&2
+    exit 1
   fi
-  if [ -x "$SHACL_BIN" ]; then
-    if BENCH_SHACL="$SHACL_BIN" ITERS=3 bash "$SHACL_RUN" > "$TMP/shacl.tsv" 2>"$TMP/shacl.err"; then
-      while IFS=$'\t' read -r name violations us; do
-        [ "${violations:-}" = "ERROR" ] && continue
-        [ -n "${us:-}" ] && add "shacl_${name}_validate_us" us "$us"
-      done < "$TMP/shacl.tsv"
-    else
-      echo "ERROR: shacl run.sh failed (correctness regression)" >&2
-      cat "$TMP/shacl.err" >&2 || true
-      exit 1
-    fi
+  if BENCH_SHACL="$SHACL_BIN" ITERS=3 bash "$SHACL_RUN" > "$TMP/shacl.tsv" 2>"$TMP/shacl.err"; then
+    while IFS=$'\t' read -r name violations us; do
+      [ "${violations:-}" = "ERROR" ] && continue
+      [ -n "${us:-}" ] && add "shacl_${name}_validate_us" us "$us"
+    done < "$TMP/shacl.tsv"
   else
-    echo "note: shacl skipped (bench_shacl example failed to build)" >&2
+    echo "ERROR: shacl run.sh failed (correctness regression)" >&2
+    cat "$TMP/shacl.err" >&2 || true
+    exit 1
   fi
 else
   echo "note: shacl skipped (javac/rapper not on PATH)" >&2

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -94,6 +94,15 @@ LUBM_RUN=bench/lubm/run.sh
 # (deep-taxonomy); details: bench/deep-taxonomy/README.md. (sq-1hgz)
 DEEPTAX_RUN=bench/deep-taxonomy/run.sh
 DEEPTAX_DEPTHS="${DEEPTAX_DEPTHS:-1000 10000}"
+# [OPUS-4.8] SHACL VALIDATION suite (sq-7iai, design §3.1) — the cleanest competitor surface.
+# Reuses the LUBM(1) ABox as its data substrate (so it shares the javac/rapper guard) x the 5
+# committed shape graphs in bench/shacl/shapes/. Like LUBM, run.sh is the self-asserting entry
+# point: it validates with examples/bench_shacl, asserts each workload's violations/conforms/
+# focus_nodes vs expected.tsv internally (exit 1 on drift), and prints the
+# `<workload>\t<violations>\t<validate_us>` contract on stdout, harvested below into the ADVISORY
+# `shacl_<workload>_validate_us` (trend-only, NOT in scripts/perf-gate.py). Registry:
+# bench/benchmarks.toml (shacl-validate-bench); details: bench/shacl/README.md.
+SHACL_RUN=bench/shacl/run.sh
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 RES="$TMP/res.tsv"; : > "$RES"
 add() { printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$RES"; }
@@ -408,6 +417,38 @@ if command -v python3 >/dev/null 2>&1 && [ -x "$DEEPTAX_RUN" ]; then
   fi
 else
   echo "note: deep-taxonomy skipped (python3 not on PATH)" >&2
+fi
+
+# [OPUS-4.8] SHACL validation suite per-commit (sq-7iai). Reuses the LUBM(1) ABox, so it shares
+# the javac + rapper guard (gen.sh delegates to bench/lubm/gen.sh). run.sh is the self-asserting
+# entry point: it validates the ABox against the 5 committed shape graphs with examples/bench_shacl
+# and asserts each workload's violations/conforms/focus_nodes vs expected.tsv internally (exit 1 on
+# any drift). The example is built on demand (sparq-shacl is isolated — not a sparq-cli dependency —
+# so the bench runner is its own --example binary). We harvest run.sh's `<workload>\t<violations>\t
+# <validate_us>` stdout into the ADVISORY `shacl_<workload>_validate_us` (trend-only, NOT in
+# scripts/perf-gate.py). run.sh failing (a SHACL correctness regression) fails the whole ci-bench
+# run, exactly like LUBM. Skipped gracefully when javac/rapper are absent (PRs install no toolchain).
+SHACL_BIN=target/release/examples/bench_shacl
+if command -v javac >/dev/null 2>&1 && command -v rapper >/dev/null 2>&1 && [ -x "$SHACL_RUN" ]; then
+  if [ ! -x "$SHACL_BIN" ]; then
+    cargo build --release -q -p sparq-shacl --example bench_shacl 2>/dev/null || true
+  fi
+  if [ -x "$SHACL_BIN" ]; then
+    if BENCH_SHACL="$SHACL_BIN" ITERS=3 bash "$SHACL_RUN" > "$TMP/shacl.tsv" 2>"$TMP/shacl.err"; then
+      while IFS=$'\t' read -r name violations us; do
+        [ "${violations:-}" = "ERROR" ] && continue
+        [ -n "${us:-}" ] && add "shacl_${name}_validate_us" us "$us"
+      done < "$TMP/shacl.tsv"
+    else
+      echo "ERROR: shacl run.sh failed (correctness regression)" >&2
+      cat "$TMP/shacl.err" >&2 || true
+      exit 1
+    fi
+  else
+    echo "note: shacl skipped (bench_shacl example failed to build)" >&2
+  fi
+else
+  echo "note: shacl skipped (javac/rapper not on PATH)" >&2
 fi
 
 # RDFS inference (seconds) — instance-heavy: SCALE individuals under a depth-20 class hierarchy.

--- a/scripts/gen-metric-labels.py
+++ b/scripts/gen-metric-labels.py
@@ -217,13 +217,26 @@ LUBM_DESC = {
     "q13": ("entailed", "Alumni of University0 (owl:inverseOf)"),
 }
 
+# [OPUS-4.8] (sq-7iai) SHACL validation workloads -> per-shape-graph human descriptions. The
+# shape-file stems under bench/shacl/shapes/*.ttl drive the metric names shacl_<workload>_validate.
+SHACL_DESC = {
+    "cardinality": "sh:minCount/sh:maxCount over ub:FullProfessor (focus enumeration + path counting)",
+    "datatype_range": "sh:datatype/sh:pattern over ub:GraduateStudent literals (XSD lexical)",
+    "class_nodekind": "sh:class (subclass-closure target) + sh:nodeKind over ub:worksFor",
+    "node_paths": "sh:node + sequence/inverse paths over ub:GraduateStudent (inter-shape recursion)",
+    "sparql_constraint": "sh:sparql (SHACL §5.2) routed through sparq-engine",
+}
 
-def stems(subdir):
-    """Sorted *.rq file stems under bench/<subdir> (matches sparq-cli `bench` ordering)."""
+
+def stems(subdir, ext=".rq"):
+    """Sorted file stems under bench/<subdir> with the given extension (default *.rq, matching
+    sparq-cli `bench` ordering). [OPUS-4.8] (sq-7iai, gap G2) `ext` is parameterised so non-query
+    suites can enumerate their inputs — SHACL's shape graphs are `*.ttl`, not `*.rq`."""
     d = os.path.join(BENCH, subdir)
     if not os.path.isdir(d):
         return []
-    return sorted(f[:-3] for f in os.listdir(d) if f.endswith(".rq"))
+    n = len(ext)
+    return sorted(f[:-n] for f in os.listdir(d) if f.endswith(ext))
 
 
 def deeptax_depths():
@@ -382,6 +395,20 @@ def build():
             "query": "deterministic closure triple-count (self-asserting gate; = 2·depth+1 = %d)"
                      % (2 * depth + 1),
             "mode": "closure", "unit": "triples",
+        }
+
+    # 10) SHACL validation suite (sq-7iai, gap G2 — ext=".ttl") -> one ADVISORY validate-time
+    # metric per committed shape graph. The hook emits `shacl_<workload>_validate_us`; the
+    # dashboard strips the `_us` for the label key (like LUBM's `lubm_<q>_count`). The deterministic
+    # gates (violations/conforms/focus_nodes) live in bench/shacl/run.sh's self-assertion + the
+    # W3C `BASELINE_PASS` ratchet (crates/sparq-shacl/tests/w3c_core.rs), not on the dashboard.
+    for s in stems("shacl/shapes", ext=".ttl"):
+        desc = SHACL_DESC.get(s, s.replace("_", " "))
+        labels["shacl_%s_validate" % s] = {
+            "label": "SHACL %s — %s, validate" % (s, desc),
+            "suite": "SHACL validation",
+            "dataset": "LUBM(1) ABox, ~103k triples x hand-authored shape graph",
+            "query": desc, "mode": "validate", "unit": "µs",
         }
 
     return labels


### PR DESCRIPTION
> 🤖 SPARQ agent

Replicates the LUBM / Deep-Taxonomy benchmark template onto SHACL — the lead per-surface suite from `research/capability-benchmark-program.md` §3.1 (`sq-7iai`). The cleanest competitor surface: Jena-SHACL / pySHACL / rdf-validate-shacl run the *identical* `(data graph, shape graph)` pair and emit a `sh:ValidationReport`, so `#violations`/`conforms` cross-check before any timing is trusted.

## G1 choice — a crate EXAMPLE, not a CLI subcommand
`crates/sparq-shacl/examples/bench_shacl.rs`. `sparq-shacl` is the *isolated* SHACL crate (explicitly **not** a dependency of `sparq-cli` — see its lib doc), so adding a `sparq-cli shacl` arm would break that isolation and pull the SHACL/engine stack into the CLI. The example is the natural user surface and matches `research/coverage-and-benchmark-plan.md` §1.1. It emits, per `shapes/*.ttl`, `name\tviolations\tvalidate_us\tconforms\tfocus_nodes\tload_us`; `run.sh` asserts the deterministic columns and forwards the `name\tviolations\tvalidate_us` 3-column hook contract.

Sample output (LUBM(1) ABox, `bench/shacl/run.sh` stdout):
```
cardinality	149	455.8
class_nodekind	125	381.9
datatype_range	1874	16111.0
node_paths	1802	7624.1
sparql_constraint	3738	833648.8
```
(timings advisory — this dev box is non-canonical.)

## The 5 shapes + deterministic violation constants
Each authored with a fixed invalid-focus fraction over the LUBM(1) ABox, so counts are deterministic constants. Derived by **running** sparq-shacl, and each **independently cross-checked** against the raw ABox:

| Workload | Constraints | violations | focus_nodes |
|---|---|---|---|
| `cardinality` | `sh:maxCount 1` (all profs teach ≥2) + `sh:minCount 3` (the 24 with exactly 2) on `ub:teacherOf` | 149 | 125 |
| `datatype_range` | `sh:datatype xsd:integer` on plain-literal `ub:name` + a never-firing `sh:pattern` | 1874 | 1874 |
| `class_nodekind` | `sh:class ub:University` on `ub:worksFor` (it's a Department) + a passing `sh:nodeKind sh:IRI` | 125 | 125 |
| `node_paths` | `sh:node` on `ub:advisor` (must be a dept head — only 15 are) + a passing sequence path | 1802 | 1874 |
| `sparql_constraint` | `sh:sparql` flagging `ub:takesCourse`→`ub:GraduateCourse`, routed through `sparq-engine` | 3738 | 1874 |

## Deterministic gate vs timing
- **DETERMINISTIC (hard, self-asserted in `run.sh`, exit 1 on drift):** `<workload>` violations / conforms (0/1) / focus_nodes vs `expected.tsv`. The `shacl_w3c_pass` ratchet (98/98, only-tightens) is the existing `BASELINE_PASS` assert in `crates/sparq-shacl/tests/w3c_core.rs` (a redundant perf-baseline auto-entry would mis-gate exact counts, so none was added — per design §1.3 wall-clock is never gated and the per-commit correctness gate already lives in `run.sh`).
- **TIMING (advisory):** `shacl_<workload>_validate_us` (mode:noise, trend-only, **never** in `scripts/perf-gate.py`).

## Self-gate sanity check
`bash bench/shacl/run.sh` passes (exit 0). Perturbing a shape (`maxCount 1`→`5`) makes it **exit 1** with `cardinality violations=24 expected=149 (correctness regression)`; restoring → exit 0. The gate genuinely gates.

## Plumbing
- New crate API `sparq_shacl::count_focus_nodes` (public, reuses `GraphView` target primitives) + unit test.
- Guarded `ci-bench.sh` hook reusing the javac/rapper guard (it reuses the LUBM corpus); builds the example on demand.
- Dashboard `FEATURED_SUITES` + `GROUP_ORDER` `SHACL validation` row; `gen-metric-labels.py` SHACL block (**gap G2**: `stems(subdir, ext=".rq")` generalised so `*.ttl` shapes enumerate); `metric-labels.json` regenerated.
- `benchmarks.toml` `shacl-validate-bench` + `CATALOG.md` rows. Competitors: **jena-shacl** added (`report-cli`, Apache-2.0, docker); pyshacl + rdf-validate-shacl already wired (sq-eifd #171). `engines`/`values` **empty in git** (gather-only). Honest caveat documented: sparq-shacl does not dedup across traversal routes → per-engine expected counts, not one shared constant.

## Verification
`cargo build --workspace --exclude sparq-py`, `cargo nextest run -p sparq-shacl` (108 pass), `cargo clippy --workspace --exclude sparq-py --all-targets -D warnings`, `node scripts/dashboard-smoke.js`, `gen-metric-labels.py --check` — all clean.

Refs `sq-7iai`, design `research/capability-benchmark-program.md` §3.1.