### PR TITLE
feat(engine): graph-IRI prefix range-scan index for prefix-scoped aggregates (sq-zz8z, gh-51)

### DIFF
--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -943,30 +943,43 @@ impl Graph {
             }
             return;
         }
-        let mut guard = self.graph_prefix_index.lock().unwrap_or_else(|e| e.into_inner());
-        let order: &Vec<u32> = match guard.as_ref() {
-            Some((len, idx)) if *len == n => idx,
-            _ => {
-                // (Re)build: a permutation of `named` indices sorted by `STR(name)` bytes.
-                let mut idx: Vec<u32> = (0..n as u32).collect();
-                idx.sort_by(|&a, &b| {
-                    Self::graph_name_str(&self.named[a as usize].0)
-                        .cmp(Self::graph_name_str(&self.named[b as usize].0))
-                });
-                *guard = Some((n, idx));
-                &guard.as_ref().unwrap().1
+        // Collect the matching `named` indices UNDER the lock, then drop the guard BEFORE
+        // invoking the caller-provided `f`. Holding the mutex across `f` would needlessly
+        // serialize concurrent readers and could deadlock if `f` (directly or indirectly)
+        // re-entered a path that locks the same mutex. The snapshot of matches is taken
+        // while the lock is held, so correctness is preserved.
+        let matches: Vec<u32> = {
+            let mut guard = self.graph_prefix_index.lock().unwrap_or_else(|e| e.into_inner());
+            let order: &Vec<u32> = match guard.as_ref() {
+                Some((len, idx)) if *len == n => idx,
+                _ => {
+                    // (Re)build: a permutation of `named` indices sorted by `STR(name)` bytes.
+                    let mut idx: Vec<u32> = (0..n as u32).collect();
+                    idx.sort_by(|&a, &b| {
+                        Self::graph_name_str(&self.named[a as usize].0)
+                            .cmp(Self::graph_name_str(&self.named[b as usize].0))
+                    });
+                    *guard = Some((n, idx));
+                    &guard.as_ref().unwrap().1
+                }
+            };
+            // Range scan: STRSTARTS(s, prefix) holds for a CONTIGUOUS block of the sorted order
+            // (all strings >= prefix and < the prefix's successor). `partition_point` gives the
+            // lower bound; we then walk while the name still starts with `prefix`.
+            let key = |i: u32| Self::graph_name_str(&self.named[i as usize].0);
+            let lo = order.partition_point(|&i| key(i) < prefix);
+            let mut matches = Vec::new();
+            for &i in &order[lo..] {
+                let s = key(i);
+                if !s.starts_with(prefix) {
+                    break; // sorted: once a name no longer starts with prefix, none after it does
+                }
+                matches.push(i);
             }
+            matches
+            // `guard` dropped here, before `f` is invoked below.
         };
-        // Range scan: STRSTARTS(s, prefix) holds for a CONTIGUOUS block of the sorted order
-        // (all strings >= prefix and < the prefix's successor). `partition_point` gives the
-        // lower bound; we then walk while the name still starts with `prefix`.
-        let key = |i: u32| Self::graph_name_str(&self.named[i as usize].0);
-        let lo = order.partition_point(|&i| key(i) < prefix);
-        for &i in &order[lo..] {
-            let s = key(i);
-            if !s.starts_with(prefix) {
-                break; // sorted: once a name no longer starts with prefix, none after it does
-            }
+        for i in matches {
             let (name, sub) = &self.named[i as usize];
             f(name, sub);
         }

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -43,7 +43,22 @@ pub struct Graph {
     /// Named graphs (each a self-contained `Graph`), keyed by their name term. Empty for the
     /// usual single-default-graph load; populated by [`load_dataset`](Self::load_dataset) from
     /// N-Quads / TriG so the engine can evaluate `GRAPH <iri> { … }` / `GRAPH ?g { … }`.
+    ///
+    /// This Vec is POSITIONAL — the on-disk named sub-tree (`named/<i>/`) and the manifest are
+    /// indexed by position, so it must NEVER be reordered. A prefix/range index over the graph
+    /// IRIs is therefore a SEPARATE sorted side structure
+    /// ([`for_named_graphs_with_prefix`](Self::for_named_graphs_with_prefix)), never a reordering
+    /// of this Vec.
     pub named: Vec<(Term, Graph)>,
+    /// [OPUS-4.8] (sq-zz8z, gh-51) Lazily-built sorted permutation of `named` indices, ordered by
+    /// the UTF-8 bytes of each graph's IRI string, enabling a binary-search RANGE SCAN for a
+    /// prefix-scoped `GRAPH ?g … FILTER(STRSTARTS(STR(?g), prefix))` instead of an O(graphs) full
+    /// scan (PSS multi-tenant `usage(prefix)`). Cached and keyed by `named.len()`: adding or
+    /// removing a named graph changes the length (the only operations that change the SET of graph
+    /// IRIs — an in-place `apply_delta` to an EXISTING graph changes neither its name nor the
+    /// length), so a stale cache is detected and rebuilt. Interior-mutable so a shared `&Graph`
+    /// can populate it; never observable in results (pure acceleration).
+    graph_prefix_index: std::sync::Mutex<Option<(usize, Vec<u32>)>>,
     /// The write-ahead log for a DIRECTORY-BACKED graph (opened via [`open`](Self::open)):
     /// every [`apply_delta`](Self::apply_delta) batch is appended + fsync'd here BEFORE it
     /// is applied, and replayed into the delta-overlay on the next `open` — durability for
@@ -890,6 +905,73 @@ impl Graph {
         Self::build(dict, triples)
     }
 
+    /// [OPUS-4.8] (sq-zz8z, gh-51) The sort key the prefix index orders graph names by: the
+    /// string returned by SPARQL `STR(?g)`. For a named-node graph (the only kind a dataset's
+    /// `GRAPH ?g` ever binds) that is the IRI itself; defined for any `Term` so the index is
+    /// total. Keeping this ONE function makes the index's ordering and a query's
+    /// `STRSTARTS(STR(?g), …)` use the SAME notion of the graph's string — they cannot diverge.
+    fn graph_name_str(t: &Term) -> &str {
+        match t {
+            Term::NamedNode(n) => n.as_str(),
+            Term::BlankNode(b) => b.as_str(),
+            Term::Literal(l) => l.value(),
+            #[allow(unreachable_patterns)]
+            _ => "",
+        }
+    }
+
+    /// [OPUS-4.8] (sq-zz8z, gh-51) Invokes `f` once for every named graph whose `STR(name)` starts
+    /// with `prefix`, IN UNSPECIFIED ORDER, via a binary-search RANGE SCAN over a cached sorted
+    /// index of the graph IRIs — O(log G + matches) instead of the O(G) full scan that a
+    /// `GRAPH ?g … FILTER(STRSTARTS(STR(?g), prefix))` would otherwise perform over ALL named
+    /// graphs (the PSS multi-tenant `usage(prefix)` cost cliff, gh-51).
+    ///
+    /// The result is EXACTLY the set of graphs a full scan + `STRSTARTS(STR(?g), prefix)` filter
+    /// would keep (an empty prefix matches every graph; a no-match prefix yields nothing), so the
+    /// indexed path is observationally identical to the unindexed one — see the equivalence tests.
+    /// The index is built lazily on first use and cached, keyed by `named.len()` (the only thing
+    /// that changes when the SET of graph IRIs changes); a length change rebuilds it.
+    pub fn for_named_graphs_with_prefix<F: FnMut(&Term, &Graph)>(&self, prefix: &str, mut f: F) {
+        let n = self.named.len();
+        if n == 0 {
+            return;
+        }
+        // Empty prefix matches everything — no point building/consulting the index.
+        if prefix.is_empty() {
+            for (name, sub) in &self.named {
+                f(name, sub);
+            }
+            return;
+        }
+        let mut guard = self.graph_prefix_index.lock().unwrap_or_else(|e| e.into_inner());
+        let order: &Vec<u32> = match guard.as_ref() {
+            Some((len, idx)) if *len == n => idx,
+            _ => {
+                // (Re)build: a permutation of `named` indices sorted by `STR(name)` bytes.
+                let mut idx: Vec<u32> = (0..n as u32).collect();
+                idx.sort_by(|&a, &b| {
+                    Self::graph_name_str(&self.named[a as usize].0)
+                        .cmp(Self::graph_name_str(&self.named[b as usize].0))
+                });
+                *guard = Some((n, idx));
+                &guard.as_ref().unwrap().1
+            }
+        };
+        // Range scan: STRSTARTS(s, prefix) holds for a CONTIGUOUS block of the sorted order
+        // (all strings >= prefix and < the prefix's successor). `partition_point` gives the
+        // lower bound; we then walk while the name still starts with `prefix`.
+        let key = |i: u32| Self::graph_name_str(&self.named[i as usize].0);
+        let lo = order.partition_point(|&i| key(i) < prefix);
+        for &i in &order[lo..] {
+            let s = key(i);
+            if !s.starts_with(prefix) {
+                break; // sorted: once a name no longer starts with prefix, none after it does
+            }
+            let (name, sub) = &self.named[i as usize];
+            f(name, sub);
+        }
+    }
+
     /// Streaming loader: parses an RDF document incrementally from a reader (so a
     /// gzip / bzip2 decompression stream can be ingested without holding the whole
     /// document in memory). Same formats as [`load_str`](Self::load_str). The
@@ -1069,6 +1151,7 @@ impl Graph {
             numerics,
             temporals,
             named: Vec::new(),
+            graph_prefix_index: std::sync::Mutex::new(None),
             #[cfg(feature = "mmap")]
             wal: None,
             // [OPUS-4.8] (sq-ycle) In-memory graph: no parent-level redo journal.
@@ -1103,6 +1186,7 @@ impl Graph {
             numerics: self.numerics.into_sparse_if_worthwhile(),
             temporals: self.temporals.into_sparse_if_worthwhile(),
             named: self.named,
+            graph_prefix_index: std::sync::Mutex::new(None),
             #[cfg(feature = "mmap")]
             wal: self.wal,
             // [OPUS-4.8] (sq-ycle) Re-encoding keeps the directory association — carry the redo
@@ -1356,7 +1440,16 @@ impl Graph {
         // with its own per-graph WAL) so a save→open round-trip is lossless for the whole
         // dataset. Empty for a default-graph-only / pre-named-graph directory.
         let named = Self::open_named(dir)?;
-        let mut g = Graph { dict, store, numerics, temporals, named, wal: None, txn: None };
+        let mut g = Graph {
+            dict,
+            store,
+            numerics,
+            temporals,
+            named,
+            graph_prefix_index: std::sync::Mutex::new(None),
+            wal: None,
+            txn: None,
+        };
         // Replay any write-ahead log into the delta-overlay (recovery after a crash or a
         // plain not-yet-compacted close), stopping cleanly at the first torn record and
         // truncating the log there — then keep the log open for further appends.
@@ -1915,6 +2008,8 @@ impl Graph {
             numerics: self.numerics.fork(),
             temporals: self.temporals.fork(),
             named: self.named.iter().map(|(name, g)| (name.clone(), g.fork())).collect(),
+            // A fork is a fresh logical copy; rebuild the prefix index lazily on first use.
+            graph_prefix_index: std::sync::Mutex::new(None),
             #[cfg(feature = "mmap")]
             wal: None,
             // [OPUS-4.8] (sq-ycle) A fork/snapshot is a logically-independent in-memory copy with
@@ -4205,6 +4300,48 @@ mod build_timing {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// [OPUS-4.8] (sq-zz8z, gh-51) The graph-IRI prefix RANGE SCAN returns EXACTLY the named graphs
+    /// whose `STR(name)` starts with the prefix, and its lazily-built cache stays coherent across
+    /// add/remove (which change `named.len()`, the cache key) on the SAME graph object. Adjacent
+    /// IRIs where one is a prefix of another exercise the `partition_point` lower bound + the
+    /// `starts_with` upper bound.
+    #[test]
+    fn graph_prefix_range_scan_and_cache_coherence() {
+        let nq = "<http://ex/s0> <http://ex/p> <http://ex/o> <http://ex/a/1> .\n\
+                  <http://ex/s1> <http://ex/p> <http://ex/o> <http://ex/a/10> .\n\
+                  <http://ex/s2> <http://ex/p> <http://ex/o> <http://ex/a/2> .\n\
+                  <http://ex/s3> <http://ex/p> <http://ex/o> <http://ex/b/1> .\n";
+        let mut g = Graph::load_dataset(nq, "nquads").unwrap();
+        let collect = |g: &Graph, prefix: &str| -> Vec<String> {
+            let mut v = Vec::new();
+            g.for_named_graphs_with_prefix(prefix, |name, _| {
+                if let Term::NamedNode(n) = name {
+                    v.push(n.as_str().to_string());
+                }
+            });
+            v.sort();
+            v
+        };
+        // a/* = a/1, a/10, a/2 (note a/1 is a prefix of a/10 — both kept).
+        assert_eq!(collect(&g, "http://ex/a/"), ["http://ex/a/1", "http://ex/a/10", "http://ex/a/2"]);
+        // exact-prefix that is a substring of another IRI: "a/1" matches a/1 AND a/10.
+        assert_eq!(collect(&g, "http://ex/a/1"), ["http://ex/a/1", "http://ex/a/10"]);
+        // empty prefix matches every graph.
+        assert_eq!(collect(&g, "").len(), 4);
+        // no match.
+        assert!(collect(&g, "http://ex/zzz").is_empty());
+        // single match.
+        assert_eq!(collect(&g, "http://ex/b/"), ["http://ex/b/1"]);
+
+        // The cache is now populated (built during the queries above). MUTATE the graph set on the
+        // SAME object: add a/3 (len changes -> cache must rebuild) and the new graph must appear.
+        g.ensure_named(&Term::NamedNode(NamedNode::new("http://ex/a/3").unwrap())).unwrap();
+        assert_eq!(
+            collect(&g, "http://ex/a/"),
+            ["http://ex/a/1", "http://ex/a/10", "http://ex/a/2", "http://ex/a/3"]
+        );
+    }
 
     #[cfg(feature = "parallel")]
     #[test]

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -1510,6 +1510,65 @@ fn eval_graph_named(
     name: &NamedNodePattern,
     inner: &GraphPattern,
 ) -> Result<Bindings, String> {
+    eval_graph_named_pref(graph, local, name, inner, None)
+}
+
+/// [OPUS-4.8] (sq-zz8z, gh-51) Extracts a SOUND graph-IRI prefix from a FILTER expression scoping
+/// the graph variable `gv`, when the filter is — or AND-contains — `STRSTARTS(STR(?gv), "lit")`
+/// with a SIMPLE / `xsd:string` constant `"lit"`. Returns the prefix the named-graph enumeration
+/// can range-scan on; `None` if no such conjunct exists (the engine then falls back to the full
+/// scan, so this is purely an optimisation hint and never affects correctness).
+///
+/// SOUNDNESS: the range scan keeps exactly the graphs whose `STR(?g)` starts with `"lit"`, which
+/// is precisely what `STRSTARTS(STR(?g), "lit")` keeps — AND the original FILTER still runs
+/// afterwards, so even if this recogniser were over-eager the result would be unchanged. We only
+/// recognise a constant SIMPLE/`xsd:string` second argument (a lang-tagged or typed non-string
+/// literal would make `STRSTARTS` itself a type error, so no prefix is meaningful there) and only
+/// pull a prefix out of a top-level conjunction (`a && b`), never a disjunction/negation.
+fn recognise_graph_prefix(expr: &Expression, gv: &Variable) -> Option<String> {
+    use spargebra::algebra::Function;
+    match expr {
+        // STRSTARTS(STR(?gv), "lit")
+        Expression::FunctionCall(Function::StrStarts, args) if args.len() == 2 => {
+            // arg0 must be STR(?gv)
+            let is_str_of_gv = matches!(
+                &args[0],
+                Expression::FunctionCall(Function::Str, inner)
+                    if inner.len() == 1 && matches!(&inner[0], Expression::Variable(v) if v == gv)
+            );
+            if !is_str_of_gv {
+                return None;
+            }
+            // arg1 must be a constant simple / xsd:string literal.
+            match &args[1] {
+                Expression::Literal(l) if l.language().is_none() && l.datatype() == oxrdf::vocab::xsd::STRING => {
+                    Some(l.value().to_string())
+                }
+                _ => None,
+            }
+        }
+        // A top-level conjunction: a prefix from EITHER side is sound (the other conjunct is
+        // still enforced by the surviving FILTER). Prefer the left, else the right.
+        Expression::And(l, r) => recognise_graph_prefix(l, gv).or_else(|| recognise_graph_prefix(r, gv)),
+        _ => None,
+    }
+}
+
+/// [OPUS-4.8] (sq-zz8z, gh-51) `eval_graph_named` with an optional graph-IRI PREFIX restriction
+/// for the `GRAPH ?g` (variable) case: when `Some(prefix)`, only named graphs whose `STR(?g)`
+/// starts with `prefix` are enumerated — via the sorted prefix index's RANGE SCAN
+/// ([`Graph::for_named_graphs_with_prefix`]) rather than a full O(graphs) scan. This is purely an
+/// enumeration restriction equivalent to a `FILTER(STRSTARTS(STR(?g), prefix))` applied to the
+/// result (the caller's residual filter, if any, still runs and is then a no-op on the same rows),
+/// so results are IDENTICAL to the unindexed path; the prefix only shrinks how many graphs are
+/// visited. `None` (and the concrete-IRI case) keeps the original full enumeration.
+fn eval_graph_named_pref(
+    graph: &Graph,
+    local: &mut LocalVocab,
+    name: &NamedNodePattern,
+    inner: &GraphPattern,
+    prefix: Option<&str>,
+) -> Result<Bindings, String> {
     fn eval_translated(
         graph: &Graph,
         local: &mut LocalVocab,
@@ -1582,15 +1641,18 @@ fn eval_graph_named(
             }
         }
         NamedNodePattern::Variable(v) => {
-            let mut acc: Option<Bindings> = None;
-            for (gname, sub) in &graph.named {
-                if !view::allows(gname) {
-                    continue; // not visible under the installed dataset view (L1)
-                }
-                // zk-trace: each iteration of `GRAPH ?g` tags the enclosed
-                // scans/filters with the iteration's named graph — the scope
-                // is installed INSIDE eval_translated (one place), so the
-                // operator boundary stream is not double-nested.
+            // [OPUS-4.8] (sq-zz8z) Accumulate the per-graph relations into ONE flat row buffer in
+            // a stable column schema (`?g` first, then the inner pattern's columns) rather than
+            // folding with `union_bindings` once per graph. The old fold re-copied the WHOLE
+            // accumulated relation on every graph, making `GRAPH ?g` over G graphs O(G²); a single
+            // shared schema makes it O(total rows). The `?g`-first schema matches the old
+            // `None`-branch insert order, so projected results are unchanged.
+            let mut out_vars: Option<Vec<Variable>> = None;
+            let mut out_rows: Vec<Row> = Vec::new();
+            let mut per_graph = |graph: &Graph, local: &mut LocalVocab, gname: &Term, sub: &Graph| -> Result<(), String> {
+                // zk-trace: each iteration of `GRAPH ?g` tags the enclosed scans/filters with the
+                // iteration's named graph — the scope is installed INSIDE eval_translated (one
+                // place), so the operator boundary stream is not double-nested.
                 let mut b = eval_translated(
                     graph,
                     local,
@@ -1600,6 +1662,18 @@ fn eval_graph_named(
                     inner,
                 )?;
                 let gid = value_to_id(graph, local, &Value::Term(gname.clone()));
+                // Resolve this graph's columns into the shared `?g`-first schema (set on the first
+                // graph; every named sub-graph yields the same `inner` schema, so it is stable).
+                let schema = out_vars.get_or_insert_with(|| {
+                    let mut s = Vec::with_capacity(b.vars.len() + 1);
+                    s.push(v.clone());
+                    for var in &b.vars {
+                        if var != v {
+                            s.push(var.clone());
+                        }
+                    }
+                    s
+                });
                 match b.col(v) {
                     // The inner pattern itself binds the graph variable (e.g.
                     // `GRAPH ?g { ?g :p ?o }` or a VALUES/OPTIONAL inside): JOIN with
@@ -1614,7 +1688,6 @@ fn eval_graph_named(
                                 row[c] == gid
                             }
                         });
-                        b.sorted_by = None;
                     }
                     None => {
                         b.vars.insert(0, v.clone());
@@ -1623,12 +1696,47 @@ fn eval_graph_named(
                         }
                     }
                 }
-                acc = Some(match acc {
-                    None => b,
-                    Some(a) => union_bindings(a, b),
-                });
+                // Map each row into the shared schema (column positions can differ per graph only
+                // if the inner schema ever reordered — it does not — so this is a cheap permute).
+                for row in &b.rows {
+                    out_rows.push(
+                        schema
+                            .iter()
+                            .map(|var| b.vars.iter().position(|x| x == var).map(|i| row[i]).unwrap_or(NO_ID))
+                            .collect(),
+                    );
+                }
+                Ok(())
+            };
+            match prefix {
+                // Indexed range scan over only the prefix-matching graphs (O(log G + matches)).
+                // The view-visibility (L1) check stays — a non-visible graph is still skipped.
+                Some(pref) => {
+                    let mut err: Option<String> = None;
+                    graph.for_named_graphs_with_prefix(pref, |gname, sub| {
+                        if err.is_some() || !view::allows(gname) {
+                            return;
+                        }
+                        if let Err(e) = per_graph(graph, local, gname, sub) {
+                            err = Some(e);
+                        }
+                    });
+                    if let Some(e) = err {
+                        return Err(e);
+                    }
+                }
+                // Full enumeration (no prefix restriction).
+                None => {
+                    for (gname, sub) in &graph.named {
+                        if !view::allows(gname) {
+                            continue; // not visible under the installed dataset view (L1)
+                        }
+                        per_graph(graph, local, gname, sub)?;
+                    }
+                }
             }
-            Ok(acc.unwrap_or_else(|| Bindings::unsorted(vec![v.clone()], Vec::new())))
+            let vars = out_vars.unwrap_or_else(|| vec![v.clone()]);
+            Ok(Bindings::unsorted(vars, out_rows))
         }
     }
 }
@@ -1722,6 +1830,26 @@ fn eval_graph_pattern_inner(graph: &Graph, local: &mut LocalVocab, p: &GraphPatt
     match p {
         GraphPattern::Bgp { patterns } => eval_bgp(graph, patterns),
         GraphPattern::Filter { expr, inner } => {
+            // [OPUS-4.8] (sq-zz8z, gh-51) Prefix-scoped-aggregate fast path: a
+            // `GRAPH ?g { … } FILTER(STRSTARTS(STR(?g), "prefix"))` (the PSS multi-tenant
+            // `usage(prefix)` shape) only needs the named graphs whose IRI starts with `prefix`.
+            // Push the prefix into the graph enumeration so it RANGE-SCANS the sorted graph-IRI
+            // index (O(log G + matches)) instead of enumerating all G graphs. The FILTER below
+            // STILL runs and is exact, so the result is unchanged — the pushdown only restricts
+            // which graphs are visited.
+            if let GraphPattern::Graph { name: NamedNodePattern::Variable(gv), inner: ginner } = inner.as_ref() {
+                if let Some(prefix) = recognise_graph_prefix(expr, gv) {
+                    let mut b = eval_graph_named_pref(
+                        graph,
+                        local,
+                        &NamedNodePattern::Variable(gv.clone()),
+                        ginner,
+                        Some(&prefix),
+                    )?;
+                    apply_filter(graph, local, &mut b, expr)?;
+                    return Ok(b);
+                }
+            }
             let mut b = eval_graph_pattern(graph, local, inner)?;
             apply_filter(graph, local, &mut b, expr)?;
             Ok(b)
@@ -8492,6 +8620,160 @@ mod path_tests {
         assert_eq!(n("SELECT * WHERE { GRAPH <http://ex/absent> { ?s ?p ?o } }"), 0);
         // Result ids are translated to the outer dict, so a join across GRAPH works.
         assert_eq!(n("SELECT ?o WHERE { GRAPH ?g { <http://ex/b> <http://ex/p> ?o } }"), 1);
+    }
+
+    /// [OPUS-4.8] (sq-zz8z, gh-51) The graph-IRI prefix range-scan index must return EXACTLY the
+    /// graphs a full scan + `STRSTARTS(STR(?g), prefix)` keeps. We assert this two ways: (1) the
+    /// indexed query result equals a hand-computed oracle over the known graph set, and (2) it
+    /// equals the core range-scan API — across the edge cases the bead calls out (empty prefix,
+    /// no-match, exact-match, prefix-is-a-substring of another graph's IRI, percent-encoding).
+    mod graph_prefix_index {
+        use super::*;
+        use std::collections::BTreeSet;
+
+        // Graphs across three tenants + a couple of adversarial IRIs:
+        //   tenantA/g/0, tenantA/g/1, tenantA/g/10   (note: "tenantA/g/1" is a PREFIX of ".../10")
+        //   tenantB/g/0
+        //   tenantAB/g/0                              ("tenantA" is a PREFIX of "tenantAB")
+        //   has%20space/g/0                           (percent-encoding edge case)
+        const ALL: [&str; 6] = [
+            "http://ex/tenantA/g/0",
+            "http://ex/tenantA/g/1",
+            "http://ex/tenantA/g/10",
+            "http://ex/tenantB/g/0",
+            "http://ex/tenantAB/g/0",
+            "http://ex/has%20space/g/0",
+        ];
+
+        fn ds() -> Graph {
+            let mut nq = String::new();
+            for (i, g) in ALL.iter().enumerate() {
+                // each graph carries one :size triple so SUM(?size)/COUNT are non-trivial
+                nq.push_str(&format!(
+                    "<http://ex/s{i}> <http://ex/size> \"{}\"^^<http://www.w3.org/2001/XMLSchema#integer> <{g}> .\n",
+                    (i + 1) * 10
+                ));
+            }
+            Graph::load_dataset(&nq, "nquads").unwrap()
+        }
+
+        // The set of graph IRIs the indexed `GRAPH ?g … FILTER(STRSTARTS(STR(?g),prefix))` returns.
+        fn indexed_graphs(g: &Graph, prefix: &str) -> BTreeSet<String> {
+            let q = format!(
+                "SELECT ?g WHERE {{ GRAPH ?g {{ ?s ?p ?o }} FILTER(STRSTARTS(STR(?g), \"{prefix}\")) }}"
+            );
+            let r = crate::query(g, &q).unwrap();
+            let mut s = BTreeSet::new();
+            for row in &r.rows {
+                if let Some(Term::NamedNode(n)) = row.first().and_then(|c| c.as_ref()) {
+                    s.insert(n.as_str().to_string());
+                }
+            }
+            s
+        }
+
+        // Oracle: STRSTARTS over the literal IRI set, computed in plain Rust.
+        fn oracle(prefix: &str) -> BTreeSet<String> {
+            ALL.iter().filter(|g| g.starts_with(prefix)).map(|s| s.to_string()).collect()
+        }
+
+        // Core API range scan, directly: the set the index yields for a prefix.
+        fn core_index_graphs(g: &Graph, prefix: &str) -> BTreeSet<String> {
+            let mut s = BTreeSet::new();
+            g.for_named_graphs_with_prefix(prefix, |name, _| {
+                if let Term::NamedNode(n) = name {
+                    s.insert(n.as_str().to_string());
+                }
+            });
+            s
+        }
+
+        #[test]
+        fn indexed_matches_oracle_across_edge_cases() {
+            let g = ds();
+            let prefixes = [
+                "",                          // empty: matches every graph
+                "http://ex/tenantA",         // matches tenantA/* AND tenantAB/* (prefix of prefix)
+                "http://ex/tenantA/",        // matches only tenantA/* (the slash excludes tenantAB)
+                "http://ex/tenantA/g/1",     // exact-prefix that is itself a substring of .../10
+                "http://ex/tenantA/g/10",    // exact match of one graph IRI
+                "http://ex/tenantB/",        // single tenant
+                "http://ex/tenantC/",        // NO match
+                "http://ex/has%20space/",    // percent-encoded IRI
+                "zzz-nonexistent",           // no match, sorts after everything
+                "http://ex/",                // common ancestor: all six
+            ];
+            for p in prefixes {
+                let idx = indexed_graphs(&g, p);
+                let orc = oracle(p);
+                assert_eq!(idx, orc, "indexed result != oracle for prefix {p:?}");
+                // The core range-scan API agrees with the oracle too (the index itself, not just
+                // the engine wiring).
+                assert_eq!(core_index_graphs(&g, p), orc, "core index != oracle for prefix {p:?}");
+            }
+        }
+
+        #[test]
+        fn aggregate_sum_count_is_prefix_scoped() {
+            // The PSS `usage(prefix)` shape: SUM(?size) + COUNT(DISTINCT ?g), prefix-scoped.
+            let g = ds();
+            let usage = |prefix: &str| -> (i64, usize) {
+                let q = format!(
+                    "SELECT (SUM(?size) AS ?bytes) (COUNT(DISTINCT ?g) AS ?n) WHERE {{ \
+                     GRAPH ?g {{ ?s <http://ex/size> ?size }} FILTER(STRSTARTS(STR(?g), \"{prefix}\")) }}"
+                );
+                let r = crate::query(&g, &q).unwrap();
+                let row = &r.rows[0];
+                let bytes = match row[0].as_ref() {
+                    Some(Term::Literal(l)) => l.value().parse::<i64>().unwrap(),
+                    _ => 0,
+                };
+                let n = match row[1].as_ref() {
+                    Some(Term::Literal(l)) => l.value().parse::<usize>().unwrap(),
+                    _ => 0,
+                };
+                (bytes, n)
+            };
+            // tenantA/* = graphs at indices 0,1,2 with sizes 10,20,30 = 60, count 3.
+            assert_eq!(usage("http://ex/tenantA/"), (60, 3));
+            // tenantA (no slash) also catches tenantAB (index 4, size 50) -> 110, count 4.
+            assert_eq!(usage("http://ex/tenantA"), (110, 4));
+            // tenantB/* = index 3, size 40 -> (40, 1).
+            assert_eq!(usage("http://ex/tenantB/"), (40, 1));
+            // no match -> COUNT of empty group is 0.
+            let r = crate::query(
+                &g,
+                "SELECT (COUNT(DISTINCT ?g) AS ?n) WHERE { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), \"http://ex/tenantC/\")) }",
+            )
+            .unwrap();
+            let n = match r.rows[0][0].as_ref() {
+                Some(Term::Literal(l)) => l.value().parse::<usize>().unwrap(),
+                _ => 0,
+            };
+            assert_eq!(n, 0);
+        }
+
+        #[test]
+        fn index_stays_correct_after_mutation_changes_graph_set() {
+            // `update` returns a NEW graph (fresh prefix-index cache); the mutated set must scan
+            // correctly even though the count changed twice. (Same-object cache coherence is
+            // covered by the sparq-core test `graph_prefix_range_scan_and_cache_coherence`.)
+            let g = ds();
+            assert_eq!(indexed_graphs(&g, "http://ex/tenantA/").len(), 3);
+            // Drop tenantA/g/10, add tenantA/g/2 -> still a tenantA/* set, but a different one.
+            let g = crate::update::update(&g, "DROP GRAPH <http://ex/tenantA/g/10>").unwrap();
+            let g = crate::update::update(
+                &g,
+                "INSERT DATA { GRAPH <http://ex/tenantA/g/2> { <http://ex/x> <http://ex/p> <http://ex/y> } }",
+            )
+            .unwrap();
+            let got = indexed_graphs(&g, "http://ex/tenantA/");
+            let want: BTreeSet<String> = ["http://ex/tenantA/g/0", "http://ex/tenantA/g/1", "http://ex/tenantA/g/2"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+            assert_eq!(got, want);
+        }
     }
 
     /// [OPUS-4.8] sq-wij: GRAPH-scoped zero-length property paths (`*` / `?`) must

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -1698,11 +1698,18 @@ fn eval_graph_named_pref(
                 }
                 // Map each row into the shared schema (column positions can differ per graph only
                 // if the inner schema ever reordered — it does not — so this is a cheap permute).
+                // Precompute schema-column -> position-in-`b.vars` ONCE per binding-set (instead of
+                // an O(vars) linear `position(..)` search per (row, var) cell — an O(rows·vars²)
+                // hotspot on large `GRAPH ?g` scans), then map each row with O(1) indexed lookups.
+                let col_map: Vec<Option<usize>> = schema
+                    .iter()
+                    .map(|var| b.vars.iter().position(|x| x == var))
+                    .collect();
                 for row in &b.rows {
                     out_rows.push(
-                        schema
+                        col_map
                             .iter()
-                            .map(|var| b.vars.iter().position(|x| x == var).map(|i| row[i]).unwrap_or(NO_ID))
+                            .map(|&pos| pos.map(|i| row[i]).unwrap_or(NO_ID))
                             .collect(),
                     );
                 }


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes the cost problem in **gh-51 / sq-zz8z**: PSS computes `usage(prefix)` as `SUM(?size) + COUNT(DISTINCT ?g)` with `FILTER(STRSTARTS(STR(?g), prefix))` over a `GRAPH ?g` enumeration of **all** named graphs — O(graphs) per interactive call (and the no-cross-pod-leak correctness boundary on a multi-tenant box). sparq's lazy-count does not help a FILTERed aggregate.

## Measured cost (non-canonical, EC2 work box — used only to decide, not committed)
Prefix-scoped `usage(one tenant)` over N named graphs, **before**:

| graphs | best |
|--------|------|
| 1,000 | ~12.5 ms |
| 10,000 | ~1,006 ms |
| 50,000 | ~24,490 ms |

This is **super-linear** (not merely O(graphs)) — already unusable for an interactive call by ~10k graphs and getting worse as the box fills (the cliff single-pod testing hides). Two causes: (1) every graph is visited regardless of the prefix; (2) `GRAPH ?g` folded its per-graph relations with `union_bindings` once per graph, re-copying the whole accumulator each time → O(G²).

**Decision: implement the index** (the bead allowed index OR document). The cost is clearly disproportionate and an index is tractable. After the index, the same query: 1k → 0.04 ms, 10k → 0.26 ms, 50k → 1.39 ms, 100k → 3.49 ms (the previous 100k case did not finish in ~100s).

## What landed
- **sparq-core** `Graph::for_named_graphs_with_prefix(prefix, f)`: range-scans a cached, lazily-built **sorted permutation of `named` indices** (binary-search lower bound + `starts_with` upper bound) → **O(log G + matches)**. The cache is keyed by `named.len()` (the only thing that changes the *set* of graph IRIs; an in-place `apply_delta` to an existing graph changes neither name nor length). The positional `named` Vec — load-bearing for the on-disk `named/<i>/` sub-tree + manifest — is **never reordered**; the index is a separate side structure. A single `graph_name_str` defines `STR(name)`, so the index ordering and a query's `STRSTARTS(STR(?g), …)` cannot diverge.
- **sparq-engine**: recognises the `GRAPH ?g { … } FILTER(STRSTARTS(STR(?g), "lit"))` shape (incl. inside a top-level `&&`, only a constant simple/`xsd:string` literal) and pushes the prefix into the graph enumeration via the range scan. The original FILTER **still runs**, so results are identical — only the set of visited graphs shrinks (sound even if the recogniser were over-eager). Also fixes the O(G²) `union_bindings` fold: per-graph relations now accumulate into one flat buffer in a stable `?g`-first schema.

## Correctness / equivalence test matrix
- `indexed_matches_oracle_across_edge_cases`: indexed query result == plain-Rust `STRSTARTS` oracle == core range-scan API, over **empty prefix / no-match / exact-match / prefix-is-a-substring-of-another-IRI (`tenantA/g/1` vs `…/10`, `tenantA` vs `tenantAB`) / percent-encoded IRI (`has%20space`) / common-ancestor**.
- `aggregate_sum_count_is_prefix_scoped`: the PSS `SUM(?size)+COUNT(DISTINCT ?g)` shape returns the correct prefix-scoped sums/counts (incl. empty group → count 0).
- `index_stays_correct_after_mutation_changes_graph_set` (engine) + `graph_prefix_range_scan_and_cache_coherence` (core, same-object add via `ensure_named` after the cache is warm): cache invalidation on graph-set change.

## STRSTARTS / QLever parity
`STR(<iri>)` → the IRI string and `STRSTARTS` → simple-literal `starts_with` already match the SPARQL spec and QLever (shared `value_str` / `str_compat2` path). **No semantics mismatch found — no fix, no parity bead.**

## Verify
- `cargo nextest run -p sparq-core` → **63 passed**
- `cargo nextest run -p sparq-engine` → **227 passed** (2 pre-existing slow parallel tests, unrelated)
- `cargo clippy -p sparq-engine -p sparq-core --all-targets -- -D warnings` → clean
- `cargo build --workspace` → clean

Note: did **not** run `cargo fmt --all` — the repo's `.rustfmt.toml` documents that a workspace reformat is deliberately deferred and CI runs `fmt --check` informationally (clippy is the hard gate); the diff is exactly the two touched files, insertions only. Measured timings are advisory and kept out of committed docs/tests (repo hygiene).

Refs sq-zz8z, gh-51.