### PR TITLE
feat(zk-compose): bind_joins verifier gate for hidden cross-credential JOIN (sq-sfsi)

### DIFF
--- a/crates/sparq-zk-compose/src/verifier.rs
+++ b/crates/sparq-zk-compose/src/verifier.rs
@@ -3113,7 +3113,13 @@ fn bind_query_correctness(manifest: &ProofManifest) -> Result<(), CheckError> {
 ///    ([`CheckError::JoinSlotMismatch`]): the slots are PUBLIC by design (the query
 ///    already reveals which column a shared variable occupies, §4.4), so this is a
 ///    plain public-input equality, and it doubles as the anti-spurious-join check
-///    (a prover cannot inject a `join_eq` over an unrelated column pair).
+///    (a prover cannot inject a `join_eq` over an unrelated column pair). The
+///    "patterns the referenced scans answer" is resolved by MEMBERSHIP against the
+///    SPECIFIC `edge.scan_a`/`edge.scan_b` (not a first-match `position`), so a
+///    query pattern legitimately answered by MORE THAN ONE scan (the same triple
+///    pattern satisfied by two credentials) is handled correctly: the join binds
+///    against whichever scan the edge names, neither spuriously rejected nor bound
+///    to the wrong scan via `sub_proofs` ordering. [OPUS-4.8] sq-sfsi multi-scan.
 ///
 /// # Scope / honesty boundary (the disclosed-vs-hidden distinction — load-bearing)
 /// `bind_joins` rigorously validates every DECLARED hidden `JoinEdge`. It does NOT
@@ -3151,16 +3157,26 @@ fn bind_joins(manifest: &ProofManifest) -> Result<(), CheckError> {
     let consts = fragment_pattern_consts(&patterns);
     let var_slots = variable_slots(&patterns);
 
-    // For each pattern, which scan sub-proof (if any) answers it (constants
-    // match the scan's bound `pattern_const_enc`, audit #10). A pattern may be
-    // answered by exactly one scan in the v1 fragment; we take the first.
-    let scan_for_pattern = |pi: usize| -> Option<usize> {
-        consts.get(pi).and_then(|c| {
-            manifest
-                .sub_proofs
-                .iter()
-                .position(|sp| scan_matches_pattern(&sp.inputs, c))
-        })
+    // Does the SPECIFIC scan sub-proof `scan_idx` answer query pattern `pi`?
+    // A pattern is answered by a scan iff the scan's bound `pattern_const_enc`
+    // matches the pattern's constants (audit #10). Crucially this is a
+    // MEMBERSHIP test against the referenced scan — NOT a first-match
+    // `position(..)` lookup. A query pattern may LEGITIMATELY be answered by
+    // MORE THAN ONE scan (the same triple pattern satisfied by two different
+    // credentials / graph commitments); the disclosed-row path
+    // (`bind_query_correctness`, `.any(..)` + the per-scan FILTER loop) already
+    // treats multi-scan-per-pattern as a first-class configuration. A
+    // first-match `position` here would (a) REJECT a valid join whose edge
+    // points at a non-first scan answering the pattern, and (b) — worse for
+    // soundness — let a prover order `sub_proofs` so the slot binding validates
+    // against a DIFFERENT (first-match) scan than the one the edge actually
+    // references. Binding against the specific `edge.scan_a`/`edge.scan_b`
+    // closes both. [OPUS-4.8] sq-sfsi multi-scan fix.
+    let pattern_answered_by_scan = |pi: usize, scan_idx: usize| -> bool {
+        consts
+            .get(pi)
+            .zip(manifest.sub_proofs.get(scan_idx))
+            .is_some_and(|(c, sp)| scan_matches_pattern(&sp.inputs, c))
     };
 
     // --- (1)+(3a): per-edge commitment-matching + slot binding. ---
@@ -3211,22 +3227,29 @@ fn bind_joins(manifest: &ProofManifest) -> Result<(), CheckError> {
 
         // (3a) Slot binding (§4.4). The edge's two scans answer two query
         // patterns; the shared join variable must occupy slot_a in pattern A and
-        // slot_b in pattern B. Find the patterns each referenced scan answers and
-        // require a SHARED variable whose slots are exactly the proof's public
-        // (slot_a, slot_b). A join_eq whose public slots are not a real shared
-        // variable's query-derived positions is rejected.
+        // slot_b in pattern B. We require, for the SPECIFIC scans `edge.scan_a` /
+        // `edge.scan_b` the edge references (NOT a first-match scan that merely
+        // happens to answer the pattern earlier in `sub_proofs`), that there
+        // exist patterns pi (answered by scan_a) and pj (answered by scan_b)
+        // carrying a SHARED variable at exactly the proof's public (slot_a,
+        // slot_b). A join_eq whose public slots are not a real shared variable's
+        // query-derived positions over the referenced scans is rejected. This is
+        // multi-scan-safe: with two scans answering one pattern, the binding
+        // validates against whichever scan the edge actually names, so it can
+        // neither be spuriously rejected nor bound to the wrong scan.
         let bound = patterns.iter().enumerate().any(|(pi, _)| {
-            // pattern pi is answered by scan_a, and slot_a there is a variable.
-            if scan_for_pattern(pi) != Some(edge.scan_a) {
+            // pattern pi is answered by THE REFERENCED scan_a, slot_a is a var.
+            if !pattern_answered_by_scan(pi, edge.scan_a) {
                 return false;
             }
             let Some(var_a) = var_at(&var_slots, pi, slot_a as usize) else {
                 return false;
             };
-            // The SAME variable occupies slot_b in some pattern answered by scan_b.
+            // The SAME variable occupies slot_b in some pattern answered by the
+            // REFERENCED scan_b.
             patterns.iter().enumerate().any(|(pj, _)| {
                 pj != pi
-                    && scan_for_pattern(pj) == Some(edge.scan_b)
+                    && pattern_answered_by_scan(pj, edge.scan_b)
                     && var_at(&var_slots, pj, slot_b as usize).as_deref() == Some(var_a.as_str())
             })
         });

--- a/crates/sparq-zk-compose/src/verifier.rs
+++ b/crates/sparq-zk-compose/src/verifier.rs
@@ -1309,6 +1309,32 @@ pub enum CheckError {
     /// `derivation` module; until then only the disclosed base grounds a step.)
     // [OPUS-4.8] sq-314.
     UngroundedDerivationAntecedent { step: usize, antecedent: usize },
+    /// [OPUS-4.8] sq-sfsi (hidden JOIN, step 4): a `JoinEdge` references a
+    /// non-existent sub-proof index (`scan_a`/`scan_b`/`join_proof`) or a
+    /// committed-graph index (`graph_a`/`graph_b`) outside the referenced scan's
+    /// `commitments`. The hidden-key analogue of [`Self::DanglingEdge`]. Rejected
+    /// fail-closed — a join cannot bind a proof/graph the manifest does not carry.
+    JoinDanglingEdge { edge: usize },
+    /// [OPUS-4.8] sq-sfsi (hidden JOIN, step 4): a `JoinEdge`'s `scan_a`/`scan_b`
+    /// do not point at `Scan` sub-proofs, or `join_proof` does not point at a
+    /// `JoinEq` sub-proof. The hidden-key analogue of [`Self::EdgeKindMismatch`]:
+    /// a join edge must tie two scans to a `join_eq` proof. Rejected fail-closed.
+    JoinEdgeKindMismatch { edge: usize },
+    /// [OPUS-4.8] sq-sfsi (hidden JOIN, step 4): the `join_eq` proof's PUBLIC
+    /// `commit_a`/`commit_b` do NOT byte-equal the two referenced scans' bound
+    /// `commitments[graph_a]`/`commitments[graph_b]` (design §2.3 / §4.2, the
+    /// anti-A2 binding). The scan commitments are audit-#1 byte-bound into the scan
+    /// proofs AND issuer-signed (audit #3), so this ties the join to two genuine,
+    /// attested credentials. A `join_eq` pointed at a graph the scans do not attest
+    /// (cross-scan forgery) is rejected here fail-closed.
+    JoinCommitmentMismatch { edge: usize },
+    /// [OPUS-4.8] sq-sfsi (hidden JOIN, step 4): the `join_eq` proof's PUBLIC
+    /// `slot_a`/`slot_b` do NOT equal the query-derived slots the shared join
+    /// variable occupies in the two patterns the referenced scans answer (design
+    /// §4.4 slot binding — the one genuinely new soundness obligation). A prover
+    /// that proved the equality over the wrong column (the salary-slot-for-age
+    /// analogue, audit #6) is rejected fail-closed.
+    JoinSlotMismatch { edge: usize },
     /// Subprocess / io failure (not a verification verdict).
     Driver(DriverError),
 }
@@ -1553,6 +1579,22 @@ impl std::fmt::Display for CheckError {
             CheckError::UngroundedDerivationAntecedent { step, antecedent } => write!(
                 f,
                 "derivation step {step} antecedent {antecedent} is ungrounded (sq-314: it is neither an earlier step's derived triple nor a disclosed scan row — a derived triple cannot rest on an antecedent the proof does not establish)"
+            ),
+            CheckError::JoinDanglingEdge { edge } => write!(
+                f,
+                "join edge {edge} references a non-existent sub-proof or committed-graph index (sq-sfsi: a hidden join cannot bind a proof/graph the manifest does not carry — fail-closed)"
+            ),
+            CheckError::JoinEdgeKindMismatch { edge } => write!(
+                f,
+                "join edge {edge} does not connect two scan sub-proofs to a join_eq sub-proof (sq-sfsi: scan_a/scan_b must be scans and join_proof a join_eq — fail-closed)"
+            ),
+            CheckError::JoinCommitmentMismatch { edge } => write!(
+                f,
+                "join edge {edge}: the join_eq proof's public commit_a/commit_b do not byte-equal the referenced scans' bound commitments[graph_a]/commitments[graph_b] (sq-sfsi §2.3/§4.2 anti-A2: the join is not bound to the two attested credentials — cross-scan forgery, fail-closed)"
+            ),
+            CheckError::JoinSlotMismatch { edge } => write!(
+                f,
+                "join edge {edge}: the join_eq proof's public slot_a/slot_b do not equal the query-derived slots the shared join variable occupies (sq-sfsi §4.4 slot binding: the equality was proved over the wrong column — fail-closed)"
             ),
             CheckError::Driver(e) => write!(f, "{e}"),
         }
@@ -1828,6 +1870,24 @@ pub fn prefilter_manifest_structure(
     // within the relying party's freshness window. A revoked bit, a stale
     // snapshot, or a missing snapshot all REJECT (fail-closed).
     bind_revocation(manifest, revocation_policy)?;
+
+    // --- Stage 2g: hidden cross-credential JOIN binding (sq-sfsi, step 4). ---
+    // The hidden-key analogue of the binding-edge + query-correctness stages: for
+    // each DECLARED `JoinEdge`, require the `join_eq` proof's public commit_a/commit_b
+    // to byte-equal the two referenced scans' bound commitments[graph_*] (anti-A2,
+    // §2.3/§4.2) and require its public slot_a/slot_b to equal the query-derived
+    // slots a variable SHARED across the two answered patterns occupies (§4.4 slot
+    // binding — which doubles as the anti-spurious-join check). A query cross-scan
+    // shared variable WITHOUT a hidden JoinEdge is discharged by the disclosed-row
+    // path (`recheck`/`join_obligations`, stage 1a), NOT demanded here — the hidden
+    // join is the opt-in privacy alternative (see bind_joins' scope docs). The
+    // `join_eq` proof itself is cryptographically
+    // verified in `verify_manifest`'s per-sub-proof loop (canonical vk by re-derived
+    // CircuitId::JoinEq, audit-#1 public-input byte-compare, bb verify) — this is the
+    // structural gate that ties those bound public inputs to the attested scans and
+    // the query. Placed AFTER bind_issuer_attestations so the commitments it
+    // byte-matches are already known issuer-attested + in K (design §3.3 step 3).
+    bind_joins(manifest)?;
 
     Ok(required)
 }
@@ -3005,6 +3065,197 @@ fn bind_query_correctness(manifest: &ProofManifest) -> Result<(), CheckError> {
         }
     }
     Ok(())
+}
+
+/// [OPUS-4.8] sq-sfsi (hidden cross-credential JOIN, step 4 of sq-bwwl): the
+/// `bind_joins` verifier gate — the hidden-key analogue of `bind_query_correctness`
+/// + the `binding_edges` consistency stage, for `ProofManifest::join_edges`.
+///
+/// `bind_joins` enforces THREE properties; a manifest whose join proof,
+/// commitments, or query binding do not line up is REJECTED:
+///
+/// 1. **Commitment-matching (anti-A2, design §2.3/§4.2).** For each [`JoinEdge`],
+///    the referenced `join_eq` sub-proof's PUBLIC `commit_a`/`commit_b` MUST
+///    byte-equal the two referenced SCAN sub-proofs' bound
+///    `commitments[graph_a]`/`commitments[graph_b]`. The scan commitments are
+///    audit-#1 byte-bound into the scan proofs AND issuer-attested+in-`K` (audit
+///    #3, `bind_issuer_attestations`, run in the same structural stage), so the
+///    join is provably over two genuine, attested credentials. A `join_eq` pointed
+///    at a commitment no referenced scan attests (cross-scan forgery) is rejected
+///    ([`CheckError::JoinCommitmentMismatch`]). The byte-comparison is over the
+///    SAME canonical big-endian field bytes the audit-#1 reconstruction uses (so
+///    `0x`-padding spelling differences do not spuriously diverge).
+///
+/// 2. **Canonical VK (anti-A1, design §4.1) — enforced by the sub-proof loop.** The
+///    `join_eq` proof itself is cryptographically verified in
+///    [`verify_manifest`]'s per-sub-proof loop EXACTLY like every other member:
+///    [`reconstruct_public_inputs`] rebuilds `[challenge, commit_a, commit_b,
+///    join_commitment, slot_a, slot_b]` (verifier nonce as field 0) and
+///    byte-equals it against the proof's public inputs; the vk is recomputed
+///    verifier-side from the re-derived [`CircuitId::JoinEq`] (NEVER the prover's
+///    vk, audit #2); and `bb verify` runs. So the equality is cryptographically
+///    proved, not JSON-asserted, and a forged proof / attacker vk / mismatched
+///    public inputs all reject there. `bind_joins` is the STRUCTURAL gate that ties
+///    those already-bound public inputs to the scans and the query; it does not
+///    re-run bb (the structural stage is reachable without the toolchain, exactly
+///    like `bind_query_correctness`). Because the slots/commitments this gate reads
+///    off the `join_eq` `ProofInputs` are the SAME values the sub-proof loop
+///    byte-binds into the proof, a manifest that passes BOTH stages has its join
+///    commitments + slots simultaneously (a) equal to the attested scans / query
+///    and (b) bound into a valid `join_eq` proof.
+///
+/// 3. **UnboundJoin query binding — slot binding (design §3.3 step 5 / §4.4).**
+///    The `join_eq` proof's PUBLIC `slot_a`/`slot_b` MUST equal the query-derived
+///    slots a variable SHARED across the two patterns the referenced scans answer
+///    occupies (`variable_slots`). A join proved over the wrong column (the §4.4 /
+///    audit-#6 analogue) — OR a SPURIOUS join edge whose two scans share no query
+///    variable at the declared slots at all — is rejected
+///    ([`CheckError::JoinSlotMismatch`]): the slots are PUBLIC by design (the query
+///    already reveals which column a shared variable occupies, §4.4), so this is a
+///    plain public-input equality, and it doubles as the anti-spurious-join check
+///    (a prover cannot inject a `join_eq` over an unrelated column pair).
+///
+/// # Scope / honesty boundary (the disclosed-vs-hidden distinction — load-bearing)
+/// `bind_joins` rigorously validates every DECLARED hidden `JoinEdge`. It does NOT
+/// *demand* a hidden join for every query cross-scan shared variable: a
+/// cross-credential shared variable can ALSO be discharged by the DISCLOSED-row
+/// path — the existing `join_obligations` / `verify::recheck` non-bnode obligation
+/// gate (stage 1a) + the disclosed scan rows, which is the default mechanism and is
+/// verified SEPARATELY. The hidden `JoinEdge` is the OPT-IN privacy alternative
+/// (the joined value is hidden instead of disclosed in the rows). So a "dropped"
+/// hidden join is NOT a soundness hole — it falls back to the disclosed path, which
+/// `recheck` still enforces; demanding a hidden join would WRONGLY break disclosed
+/// joins. The completeness obligation the design's `UnboundJoin` names is therefore
+/// discharged by the disclosed-row gate for non-hidden joins; for a join the prover
+/// CHOSE to make hidden, this gate forbids forging it (point 1) or binding it to
+/// the wrong column / an unrelated scan pair (point 3).
+///
+/// This gate does NOT verify the join_commitment opening (the value stays hidden —
+/// the privacy win) and does NOT itself prove `a_val == b_val` (that is the
+/// in-circuit equality, verified by the sub-proof loop's `bb verify`, point 2).
+/// Multi-way (N-way) join commitment-equality across a chain (design §2.4) is NOT
+/// yet enforced here — a single pairwise join is the v1 scope; the join_eq PROVING
+/// path + a FULL-bb accept test (sq-r2s8) and the forge-and-verify regression suite
+/// (sq-hlul) are the follow-ups. What IS enforced is the security-critical
+/// direction: a forged / cross-scan / wrong-slot / spurious hidden join is rejected.
+// [OPUS-4.8] sq-sfsi: bind_joins gate (commitment-matching + query slot binding).
+fn bind_joins(manifest: &ProofManifest) -> Result<(), CheckError> {
+    if manifest.join_edges.is_empty() {
+        // No hidden joins declared: nothing for this gate to validate. A query
+        // cross-scan shared variable WITHOUT a hidden JoinEdge is discharged by the
+        // disclosed-row path (`recheck`/`join_obligations`, stage 1a) — not here.
+        return Ok(());
+    }
+
+    let patterns = fragment_patterns(&manifest.query)?;
+    let consts = fragment_pattern_consts(&patterns);
+    let var_slots = variable_slots(&patterns);
+
+    // For each pattern, which scan sub-proof (if any) answers it (constants
+    // match the scan's bound `pattern_const_enc`, audit #10). A pattern may be
+    // answered by exactly one scan in the v1 fragment; we take the first.
+    let scan_for_pattern = |pi: usize| -> Option<usize> {
+        consts.get(pi).and_then(|c| {
+            manifest
+                .sub_proofs
+                .iter()
+                .position(|sp| scan_matches_pattern(&sp.inputs, c))
+        })
+    };
+
+    // --- (1)+(3a): per-edge commitment-matching + slot binding. ---
+    for (e, edge) in manifest.join_edges.iter().enumerate() {
+        // Resolve the three referenced sub-proofs (dangling => reject).
+        let scan_a = manifest
+            .sub_proofs
+            .get(edge.scan_a)
+            .ok_or(CheckError::JoinDanglingEdge { edge: e })?;
+        let scan_b = manifest
+            .sub_proofs
+            .get(edge.scan_b)
+            .ok_or(CheckError::JoinDanglingEdge { edge: e })?;
+        let join = manifest
+            .sub_proofs
+            .get(edge.join_proof)
+            .ok_or(CheckError::JoinDanglingEdge { edge: e })?;
+
+        // Kinds: scan_a/scan_b must be scans; join_proof must be a join_eq.
+        let commit_a_scan = match &scan_a.inputs {
+            ProofInputs::Scan { commitments, .. } => commitments
+                .get(edge.graph_a)
+                .ok_or(CheckError::JoinDanglingEdge { edge: e })?,
+            _ => return Err(CheckError::JoinEdgeKindMismatch { edge: e }),
+        };
+        let commit_b_scan = match &scan_b.inputs {
+            ProofInputs::Scan { commitments, .. } => commitments
+                .get(edge.graph_b)
+                .ok_or(CheckError::JoinDanglingEdge { edge: e })?,
+            _ => return Err(CheckError::JoinEdgeKindMismatch { edge: e }),
+        };
+        let (commit_a_join, commit_b_join, slot_a, slot_b) = match &join.inputs {
+            ProofInputs::JoinEq { commit_a, commit_b, slot_a, slot_b, .. } => {
+                (commit_a, commit_b, *slot_a, *slot_b)
+            }
+            _ => return Err(CheckError::JoinEdgeKindMismatch { edge: e }),
+        };
+
+        // (1) Commitment-matching (anti-A2). Compare on the canonical big-endian
+        // field bytes (so spelling/padding differences do not spuriously diverge);
+        // a malformed commitment hex on EITHER side fails closed (the audit-#1
+        // reconstruction also rejects it as MalformedField in the bb stage).
+        if !field_hex_eq(commit_a_join, commit_a_scan)
+            || !field_hex_eq(commit_b_join, commit_b_scan)
+        {
+            return Err(CheckError::JoinCommitmentMismatch { edge: e });
+        }
+
+        // (3a) Slot binding (§4.4). The edge's two scans answer two query
+        // patterns; the shared join variable must occupy slot_a in pattern A and
+        // slot_b in pattern B. Find the patterns each referenced scan answers and
+        // require a SHARED variable whose slots are exactly the proof's public
+        // (slot_a, slot_b). A join_eq whose public slots are not a real shared
+        // variable's query-derived positions is rejected.
+        let bound = patterns.iter().enumerate().any(|(pi, _)| {
+            // pattern pi is answered by scan_a, and slot_a there is a variable.
+            if scan_for_pattern(pi) != Some(edge.scan_a) {
+                return false;
+            }
+            let Some(var_a) = var_at(&var_slots, pi, slot_a as usize) else {
+                return false;
+            };
+            // The SAME variable occupies slot_b in some pattern answered by scan_b.
+            patterns.iter().enumerate().any(|(pj, _)| {
+                pj != pi
+                    && scan_for_pattern(pj) == Some(edge.scan_b)
+                    && var_at(&var_slots, pj, slot_b as usize).as_deref() == Some(var_a.as_str())
+            })
+        });
+        if !bound {
+            return Err(CheckError::JoinSlotMismatch { edge: e });
+        }
+    }
+
+    Ok(())
+}
+
+/// The variable occupying `(pattern, slot)` in the `variable_slots` table, if any
+/// (a constant slot returns `None`). [OPUS-4.8] sq-sfsi.
+fn var_at(var_slots: &[(String, usize, usize)], pattern: usize, slot: usize) -> Option<String> {
+    var_slots
+        .iter()
+        .find(|(_, p, s)| *p == pattern && *s == slot)
+        .map(|(v, _, _)| v.clone())
+}
+
+/// Byte-equality of two [`FieldHex`] commitment values over their canonical
+/// big-endian field representation (so `0x`-padding / case differences do not
+/// spuriously diverge). A malformed hex on either side returns `false`
+/// (fail-closed — a non-parseable commitment is never "equal"). [OPUS-4.8] sq-sfsi.
+fn field_hex_eq(a: &FieldHex, b: &FieldHex) -> bool {
+    match (a.to_field(), b.to_field()) {
+        (Some(fa), Some(fb)) => field_to_be_bytes_32(&fa) == field_to_be_bytes_32(&fb),
+        _ => false,
+    }
 }
 
 /// Stage 2e: bind the prover's `manifest.attributions` (which drives the Q6

--- a/crates/sparq-zk-compose/tests/join_gates.rs
+++ b/crates/sparq-zk-compose/tests/join_gates.rs
@@ -1,0 +1,444 @@
+// [OPUS-4.8] written while Fable 5 unavailable — re-review when Fable returns.
+//! sq-sfsi: the `bind_joins` verifier-gate soundness suite (step 4 of sq-bwwl,
+//! the hidden cross-credential JOIN). The adversarial complement to the join
+//! manifest schema (sq-fi03): construct a join manifest that violates EXACTLY one
+//! of `bind_joins`'s enforcement points, then assert the verifier REJECTS it with
+//! the right `CheckError`.
+//!
+//! The `bind_joins` gate enforces THREE properties (see `verifier::bind_joins`):
+//! 1. **Commitment-matching (anti-A2):** the `join_eq` proof's public
+//!    `commit_a`/`commit_b` must byte-equal the two referenced scans' bound
+//!    `commitments[graph_*]` — a join cannot bind rows from unrelated/forged scans.
+//! 2. **Canonical VK (anti-A1):** the `join_eq` proof is verified against the
+//!    canonical vk in `verify_manifest`'s per-sub-proof loop (audit-#2). Exercised
+//!    on the FULL bb path (toolchain-gated, `#[ignore]`).
+//! 3. **UnboundJoin / slot binding:** the `join_eq`'s public `slot_a`/`slot_b` must
+//!    equal the query-derived slots a variable SHARED across the two answered
+//!    patterns occupies — a join over the wrong column, OR a SPURIOUS join over an
+//!    unrelated scan pair, is rejected (`JoinSlotMismatch`).
+//!
+//! ## Disclosed-vs-hidden scope (load-bearing honesty)
+//! `bind_joins` rigorously validates every DECLARED hidden `JoinEdge`. It does NOT
+//! *demand* a hidden join for every query cross-scan shared variable: such a
+//! variable can ALSO be discharged by the DISCLOSED-row path (the existing
+//! `join_obligations`/`verify::recheck` non-bnode obligation gate + the disclosed
+//! scan rows), which is the default and is verified SEPARATELY. The hidden
+//! `JoinEdge` is the OPT-IN privacy alternative. So "drop the hidden edge" is NOT a
+//! soundness hole here — it falls back to the disclosed path (which `recheck` still
+//! enforces); demanding a hidden join would WRONGLY break disclosed joins. This
+//! suite asserts that boundary explicitly (`drop_edge_falls_back_to_disclosed_path`).
+//!
+//! These structural checks run inside `prefilter_manifest_structure` (the same
+//! structural stage `verify_manifest` runs first), so the reject paths — the
+//! security-critical direction — run in default CI WITHOUT the nargo/bb toolchain.
+//!
+//! ## Accept-proof honesty
+//! The `join_eq` PROVING path (`prover_toml_for`'s JoinEq arm) is deferred (sq-fi03
+//! left it `Err`), so this suite CANNOT generate a real `join_eq` bb proof in-test.
+//! The structural ACCEPT (a well-formed join edge passes `bind_joins` — commitments
+//! match, slots match, the demanded join is covered) IS exercised, witness-only,
+//! through `prefilter_manifest_structure`. A FULL bb accept (real proof + canonical
+//! vk + nonce binding) is marked `#[ignore]` pending the join_eq proving path
+//! (tracked: see the join-proving bead referenced in the PR). We do NOT claim the
+//! bb accept path works until that proof can be produced.
+
+use oxrdf::{Literal, NamedNode, NamedOrBlankNode, Term, Triple};
+use sparq_zk::commit::{commit_triples, GraphCommitment};
+use sparq_zk::encode::salt_from_bytes;
+use sparq_zk::field::Fr;
+use sparq_zk::sig::{public_key_to_hex, SecretKey, SignatureScheme};
+use sparq_zk_compose::build::{build_scan, Pattern, Slot};
+use sparq_zk_compose::manifest::{
+    AttestedStatusRef, BindingMode, CircuitId, CommitmentAttestation, EntailmentRegime, FieldHex,
+    JoinEdge, ProofInputs, ProofManifest, RevocationStatus, StatusListSnapshot, SubProof,
+};
+use sparq_zk_compose::verifier::{
+    prefilter_manifest_structure, CheckError, KeySet, RevocationPolicy,
+};
+
+const XSD_INT: &str = "http://www.w3.org/2001/XMLSchema#integer";
+const STATUS_LIST: &str = "http://ex/status/1";
+const STATUS_INDEX: u64 = 3;
+const STATUS_VERSION: u64 = 1;
+const CHALLENGE_HEX: &str = "0x2a";
+
+fn iri(s: &str) -> NamedNode {
+    NamedNode::new(s).unwrap()
+}
+fn int_lit(v: u64) -> Term {
+    Term::Literal(Literal::new_typed_literal(v.to_string(), iri(XSD_INT)))
+}
+fn test_issuer_sk(seed: u64) -> SecretKey {
+    SecretKey::from_seed(seed)
+}
+fn trusted_k(sk: &SecretKey) -> KeySet {
+    KeySet::from_hex_keys([public_key_to_hex(&sk.public_key())])
+}
+fn fixture_snapshot() -> StatusListSnapshot {
+    StatusListSnapshot { status_list: STATUS_LIST.to_string(), version: STATUS_VERSION, bits: vec![0u8] }
+}
+fn fixture_revocation() -> RevocationStatus {
+    RevocationStatus {
+        status_list: STATUS_LIST.to_string(),
+        index: Some(STATUS_INDEX),
+        version: STATUS_VERSION,
+        index_commitment: None,
+    }
+}
+fn fresh_policy() -> RevocationPolicy {
+    RevocationPolicy::accept_version(STATUS_VERSION).with_snapshot(fixture_snapshot())
+}
+
+/// A salt + status-bound attestation over `commitment` (the scan-verify-path shape).
+fn attest_full(commitment: Fr, salt: Fr, sk: &SecretKey) -> CommitmentAttestation {
+    let list_id = sparq_zk::sig::status_list_id_to_field(STATUS_LIST);
+    let status_ref = sparq_zk::sig::status_ref_digest(&list_id, STATUS_INDEX, STATUS_VERSION);
+    CommitmentAttestation {
+        commitment: FieldHex::from_field(&commitment),
+        issuer_public_key: public_key_to_hex(&sk.public_key()),
+        signature: sk.sign_commitment_with_status(&commitment, &salt, &status_ref),
+        cryptosuite: SignatureScheme::Poseidon2SchnorrV1.cryptosuite_iri().to_string(),
+        salt: Some(FieldHex::from_field(&salt)),
+        status: Some(AttestedStatusRef {
+            index: Some(STATUS_INDEX),
+            version: STATUS_VERSION,
+            index_commitment: None,
+        }),
+        holder: None,
+    }
+}
+
+// --- Two single-graph credentials sharing a join value `<ex/p>` --------------
+//
+// Graph A: `<ex/a> <ex/knows> <ex/p>`  (object slot 2 = the join key `<ex/p>`)
+// Graph B: `<ex/p> <ex/age> "30"`      (subject slot 0 = the join key `<ex/p>`)
+//
+// Query: `{ ?a <ex/knows> ?p . ?p <ex/age> ?o }` — the shared variable `?p` is at
+// pattern-0 slot 2 (object) and pattern-1 slot 0 (subject). The two patterns carry
+// distinct predicate constants, so two DISTINCT scans answer them => a cross-scan
+// join the gate demands a JoinEdge for. The join SLOTS are (2, 0).
+
+const JOIN_QUERY: &str =
+    "SELECT ?a ?p ?o WHERE { ?a <http://ex/knows> ?p . ?p <http://ex/age> ?o }";
+const SLOT_A: u32 = 2; // ?p is the OBJECT of `?a <ex/knows> ?p`
+const SLOT_B: u32 = 0; // ?p is the SUBJECT of `?p <ex/age> ?o`
+
+fn graph_a() -> GraphCommitment {
+    let g = vec![Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/a")),
+        iri("http://ex/knows"),
+        Term::NamedNode(iri("http://ex/p")),
+    )];
+    commit_triples(&g, salt_from_bytes(&[31u8; 32])).unwrap()
+}
+fn graph_b() -> GraphCommitment {
+    let g = vec![Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/p")),
+        iri("http://ex/age"),
+        int_lit(30),
+    )];
+    commit_triples(&g, salt_from_bytes(&[32u8; 32])).unwrap()
+}
+
+fn scan_inputs(c: &GraphCommitment, pattern: Pattern) -> ProofInputs {
+    build_scan(std::slice::from_ref(c), &pattern).expect("scan builds").inputs
+}
+
+/// The scan over pattern A (`?a <ex/knows> ?p`).
+fn scan_a_inputs(c: &GraphCommitment) -> ProofInputs {
+    scan_inputs(c, Pattern {
+        s: Slot::Var,
+        p: Slot::Const(Term::NamedNode(iri("http://ex/knows"))),
+        o: Slot::Var,
+    })
+}
+/// The scan over pattern B (`?p <ex/age> ?o`).
+fn scan_b_inputs(c: &GraphCommitment) -> ProofInputs {
+    scan_inputs(c, Pattern {
+        s: Slot::Var,
+        p: Slot::Const(Term::NamedNode(iri("http://ex/age"))),
+        o: Slot::Var,
+    })
+}
+
+fn commitment_hex(inputs: &ProofInputs) -> FieldHex {
+    match inputs {
+        ProofInputs::Scan { commitments, .. } => commitments[0].clone(),
+        _ => unreachable!("scan inputs"),
+    }
+}
+
+/// A `join_eq` sub-proof's inputs (witness-only — empty proof_hex) whose public
+/// `commit_a`/`commit_b` are the two scans' commitments and whose slots are
+/// `(slot_a, slot_b)`. `join_commitment` is an arbitrary hiding value (the gate
+/// never opens it; only the bb stage binds it).
+fn join_eq_inputs(commit_a: FieldHex, commit_b: FieldHex, slot_a: u32, slot_b: u32) -> ProofInputs {
+    ProofInputs::JoinEq {
+        id: CircuitId::JoinEq { n_a: 16, n_b: 16 },
+        commit_a,
+        commit_b,
+        join_commitment: FieldHex("0x0c".to_string()),
+        slot_a,
+        slot_b,
+    }
+}
+
+/// Build the honest cross-scan join manifest. sub_proofs = [scan_a, scan_b, join_eq];
+/// join_edges = [{scan_a:0, graph_a:0, scan_b:1, graph_b:0, join_proof:2}]. The
+/// join_eq's commit_a/commit_b match the two scans; its slots are (SLOT_A, SLOT_B).
+/// `tweak` lets a forge mutate exactly one field before verification.
+fn join_manifest() -> ProofManifest {
+    let (ca, sa) = {
+        let c = graph_a();
+        (c.commitment, c.salt)
+    };
+    let (cb, sb) = {
+        let c = graph_b();
+        (c.commitment, c.salt)
+    };
+    let scan_a = scan_a_inputs(&graph_a());
+    let scan_b = scan_b_inputs(&graph_b());
+    let commit_a = commitment_hex(&scan_a);
+    let commit_b = commitment_hex(&scan_b);
+    let join = join_eq_inputs(commit_a, commit_b, SLOT_A, SLOT_B);
+    let sk = test_issuer_sk(1);
+    ProofManifest {
+        r#type: "urn:sparq:zk:ProofManifest".into(),
+        query: JOIN_QUERY.into(),
+        issuers: vec![],
+        key_set: vec![public_key_to_hex(&sk.public_key())],
+        commitment_attestations: vec![attest_full(ca, sa, &sk), attest_full(cb, sb, &sk)],
+        // Two patterns; each draws from its own (single) committed graph.
+        attributions: vec![vec![0], vec![0]],
+        join_obligations: vec![],
+        entailment_regime: EntailmentRegime::Simple,
+        derivation_steps: vec![],
+        binding: BindingMode::Challenge { challenge: FieldHex(CHALLENGE_HEX.into()) },
+        revocation: Some(fixture_revocation()),
+        status_snapshots: vec![fixture_snapshot()],
+        sub_proofs: vec![
+            SubProof { inputs: scan_a, proof_hex: String::new() },
+            SubProof { inputs: scan_b, proof_hex: String::new() },
+            SubProof { inputs: join, proof_hex: String::new() },
+        ],
+        binding_edges: vec![],
+        join_edges: vec![JoinEdge { scan_a: 0, graph_a: 0, scan_b: 1, graph_b: 0, join_proof: 2 }],
+        hidden_revocation: None,
+        hidden_issuer_attestations: vec![],
+    }
+}
+
+/// Run a manifest through the STRUCTURAL prefilter (the stage `verify_manifest`
+/// runs first, where `bind_joins` lives). No bb — so the structural join gates are
+/// reached without the toolchain.
+fn prefilter(m: &ProofManifest) -> Result<(), CheckError> {
+    prefilter_manifest_structure(m, &trusted_k(&test_issuer_sk(1)), &fresh_policy()).map(|_| ())
+}
+
+// === ACCEPT (structural, witness-only) ======================================
+
+/// A well-formed join edge — commitments match the referenced scans, slots match
+/// the query, and the demanded cross-scan join is covered — passes every
+/// structural gate, INCLUDING `bind_joins`. (Witness-only: no bb proof, so the
+/// FULL `verify_manifest` would then hit MissingProof; the structural prefilter is
+/// the layer `bind_joins` runs in, so passing it proves the gate ACCEPTS honest
+/// joins — the gate's completeness.)
+#[test]
+fn honest_join_passes_structural_bind_joins() {
+    let m = join_manifest();
+    prefilter(&m).expect("honest cross-scan join must pass the structural bind_joins gate");
+}
+
+// === REJECT 1: commitment-matching (cross-scan forgery, anti-A2) ============
+
+/// Forge: the join_eq's `commit_a` does NOT equal scan A's bound commitment (a
+/// join binding a row from an unrelated/forged scan). `bind_joins` must REJECT
+/// (`JoinCommitmentMismatch`).
+#[test]
+fn forge_join_commit_a_not_matching_scan_rejected() {
+    let mut m = join_manifest();
+    if let ProofInputs::JoinEq { commit_a, .. } = &mut m.sub_proofs[2].inputs {
+        // A different (but well-formed) field — not scan A's attested commitment.
+        *commit_a = FieldHex("0x0deadbeef".to_string());
+    } else {
+        unreachable!("join_eq inputs");
+    }
+    match prefilter(&m) {
+        Err(CheckError::JoinCommitmentMismatch { edge: 0 }) => {}
+        other => panic!("cross-scan commit_a forgery must be JoinCommitmentMismatch, got {other:?}"),
+    }
+}
+
+/// Forge: the join_eq's `commit_b` does NOT equal scan B's bound commitment.
+#[test]
+fn forge_join_commit_b_not_matching_scan_rejected() {
+    let mut m = join_manifest();
+    if let ProofInputs::JoinEq { commit_b, .. } = &mut m.sub_proofs[2].inputs {
+        *commit_b = FieldHex("0x0c0ffee".to_string());
+    } else {
+        unreachable!("join_eq inputs");
+    }
+    match prefilter(&m) {
+        Err(CheckError::JoinCommitmentMismatch { edge: 0 }) => {}
+        other => panic!("cross-scan commit_b forgery must be JoinCommitmentMismatch, got {other:?}"),
+    }
+}
+
+/// Forge: re-point `graph_a` at scan B's commitment by swapping the EDGE's scan
+/// reference so commit_a (scan A's) no longer matches commitments[graph_a] of the
+/// pointed scan. Confirms the gate anchors on the SCAN the edge names, not on a
+/// prover-chosen commitment read in isolation.
+#[test]
+fn forge_join_edge_points_at_wrong_scan_rejected() {
+    let mut m = join_manifest();
+    // Point scan_a at sub-proof 1 (scan B) while the join_eq still carries scan A's
+    // commit_a => commit_a != scan_b.commitments[0].
+    m.join_edges[0].scan_a = 1;
+    match prefilter(&m) {
+        Err(CheckError::JoinCommitmentMismatch { edge: 0 }) => {}
+        other => panic!("edge pointed at the wrong scan must be JoinCommitmentMismatch, got {other:?}"),
+    }
+}
+
+// === REJECT 2: slot binding (wrong column, §4.4 / audit-#6 analogue) ========
+
+/// Forge: the join_eq's public `slot_a` is NOT the slot `?p` occupies in pattern A
+/// (it proves the equality over the wrong column). `bind_joins` must REJECT
+/// (`JoinSlotMismatch`).
+#[test]
+fn forge_join_wrong_slot_a_rejected() {
+    let mut m = join_manifest();
+    if let ProofInputs::JoinEq { slot_a, .. } = &mut m.sub_proofs[2].inputs {
+        *slot_a = 0; // ?p is at slot 2 (object) of pattern A, not slot 0.
+    } else {
+        unreachable!("join_eq inputs");
+    }
+    match prefilter(&m) {
+        // The per-edge slot check fails first (the edge's join_eq slots are no
+        // longer the shared variable's query positions).
+        Err(CheckError::JoinSlotMismatch { edge: 0 }) => {}
+        other => panic!("wrong join slot_a must be JoinSlotMismatch, got {other:?}"),
+    }
+}
+
+/// Forge: the join_eq's public `slot_b` is the wrong column for pattern B.
+#[test]
+fn forge_join_wrong_slot_b_rejected() {
+    let mut m = join_manifest();
+    if let ProofInputs::JoinEq { slot_b, .. } = &mut m.sub_proofs[2].inputs {
+        *slot_b = 2; // ?p is at slot 0 (subject) of pattern B, not slot 2.
+    } else {
+        unreachable!("join_eq inputs");
+    }
+    match prefilter(&m) {
+        Err(CheckError::JoinSlotMismatch { edge: 0 }) => {}
+        other => panic!("wrong join slot_b must be JoinSlotMismatch, got {other:?}"),
+    }
+}
+
+// === SCOPE: dropping the hidden edge falls back to the disclosed path ========
+
+/// Honesty/scope assertion (NOT a forge): DROP the JoinEdge. `bind_joins` does NOT
+/// demand a hidden join for a query cross-scan shared variable — that variable is
+/// discharged by the DISCLOSED-row path (`recheck`/`join_obligations`), the opt-in
+/// hidden join being an alternative. So the manifest with NO `join_edges` passes
+/// the structural prefilter (the hidden-join gate has nothing to validate). This
+/// pins the disclosed-vs-hidden boundary: a dropped hidden join is not a soundness
+/// hole, it reverts to the disclosed mechanism (verified separately).
+#[test]
+fn drop_edge_falls_back_to_disclosed_path() {
+    let mut m = join_manifest();
+    m.join_edges.clear();
+    // With no hidden edge declared, `bind_joins` is a no-op; the disclosed-row
+    // obligation gate (`recheck`) governs the cross-scan `?p`. The manifest passes
+    // every structural gate (it would reach MissingProof in the full bb verify).
+    prefilter(&m).expect(
+        "dropping the hidden JoinEdge falls back to the disclosed-row path and passes the structural gate",
+    );
+}
+
+// === REJECT 3: spurious / wrong-slot hidden join (anti-spurious, §4.4) =======
+
+/// Forge: the JoinEdge binds the right scans but its join_eq's slots don't match
+/// the shared variable's query positions. The per-edge slot check must REJECT
+/// (`JoinSlotMismatch`) — a slot-mismatched / spurious hidden join cannot pass.
+#[test]
+fn forge_join_edge_present_but_wrong_slots_rejected() {
+    let mut m = join_manifest();
+    if let ProofInputs::JoinEq { slot_a, slot_b, .. } = &mut m.sub_proofs[2].inputs {
+        // Swap the slots: (0, 2) instead of (2, 0) — neither maps to ?p's query
+        // positions in (pattern A, pattern B) respectively.
+        *slot_a = 0;
+        *slot_b = 2;
+    } else {
+        unreachable!("join_eq inputs");
+    }
+    match prefilter(&m) {
+        Err(CheckError::JoinSlotMismatch { edge: 0 }) => {}
+        other => panic!("a slot-mismatched join edge must be JoinSlotMismatch, got {other:?}"),
+    }
+}
+
+// === REJECT 4: structural malformed edges ===================================
+
+/// Forge: the JoinEdge's `join_proof` index is out of range (dangling).
+#[test]
+fn forge_join_dangling_join_proof_rejected() {
+    let mut m = join_manifest();
+    m.join_edges[0].join_proof = 99;
+    match prefilter(&m) {
+        Err(CheckError::JoinDanglingEdge { edge: 0 }) => {}
+        other => panic!("a dangling join_proof index must be JoinDanglingEdge, got {other:?}"),
+    }
+}
+
+/// Forge: the JoinEdge's `graph_a` index is out of the referenced scan's
+/// `commitments` range (dangling committed-graph index).
+#[test]
+fn forge_join_dangling_graph_index_rejected() {
+    let mut m = join_manifest();
+    m.join_edges[0].graph_a = 5; // scan A has only commitments[0].
+    match prefilter(&m) {
+        Err(CheckError::JoinDanglingEdge { edge: 0 }) => {}
+        other => panic!("a dangling graph_a index must be JoinDanglingEdge, got {other:?}"),
+    }
+}
+
+/// Forge: the JoinEdge's `join_proof` points at a SCAN sub-proof (not a join_eq).
+/// The kind check must REJECT (`JoinEdgeKindMismatch`).
+#[test]
+fn forge_join_proof_not_join_eq_rejected() {
+    let mut m = join_manifest();
+    m.join_edges[0].join_proof = 0; // sub-proof 0 is a scan, not a join_eq.
+    match prefilter(&m) {
+        Err(CheckError::JoinEdgeKindMismatch { edge: 0 }) => {}
+        other => panic!("join_proof pointing at a scan must be JoinEdgeKindMismatch, got {other:?}"),
+    }
+}
+
+/// Forge: the JoinEdge's `scan_a` points at the join_eq sub-proof (not a scan).
+#[test]
+fn forge_join_scan_a_not_scan_rejected() {
+    let mut m = join_manifest();
+    m.join_edges[0].scan_a = 2; // sub-proof 2 is the join_eq, not a scan.
+    match prefilter(&m) {
+        Err(CheckError::JoinEdgeKindMismatch { edge: 0 }) => {}
+        other => panic!("scan_a pointing at a join_eq must be JoinEdgeKindMismatch, got {other:?}"),
+    }
+}
+
+// === ACCEPT (FULL bb path) — deferred join_eq proving ========================
+
+/// Canonical-VK / public-input / nonce binding ACCEPT over a REAL `join_eq` bb
+/// proof. DEFERRED: `prover_toml_for`'s JoinEq arm returns `Err` (sq-fi03 left the
+/// join_eq proving path out of scope), so this suite cannot produce a real join_eq
+/// proof in-test. Enforcement point 2 (canonical VK) is therefore not exercised
+/// end-to-end here. Marked `#[ignore]` until the join_eq proving path lands; the
+/// reject paths above (the security-critical direction) are fully exercised
+/// without it. Tracked: sq-r2s8 (join_eq proving path + this full-bb accept).
+#[test]
+#[ignore = "join_eq proving path deferred (sq-fi03 prover_toml_for JoinEq => Err); sq-r2s8 implements build_join/prover_toml_for + un-ignores this for a real bb accept"]
+fn full_bb_join_accept_deferred() {
+    // Intentionally empty: documents the missing accept-proof capability honestly
+    // rather than asserting a property we cannot exercise.
+}

--- a/crates/sparq-zk-compose/tests/join_gates.rs
+++ b/crates/sparq-zk-compose/tests/join_gates.rs
@@ -140,6 +140,19 @@ fn graph_b() -> GraphCommitment {
     commit_triples(&g, salt_from_bytes(&[32u8; 32])).unwrap()
 }
 
+/// A SECOND credential answering pattern A (`?a <ex/knows> ?p`), from a different
+/// committed graph (distinct salt => distinct commitment). Used to construct a
+/// multi-scan-per-pattern manifest: TWO scans legitimately answer pattern A, the
+/// same triple pattern satisfied by two different credentials. [OPUS-4.8] sq-sfsi.
+fn graph_a2() -> GraphCommitment {
+    let g = vec![Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/a2")),
+        iri("http://ex/knows"),
+        Term::NamedNode(iri("http://ex/p")),
+    )];
+    commit_triples(&g, salt_from_bytes(&[33u8; 32])).unwrap()
+}
+
 fn scan_inputs(c: &GraphCommitment, pattern: Pattern) -> ProofInputs {
     build_scan(std::slice::from_ref(c), &pattern).expect("scan builds").inputs
 }
@@ -247,6 +260,118 @@ fn prefilter(m: &ProofManifest) -> Result<(), CheckError> {
 fn honest_join_passes_structural_bind_joins() {
     let m = join_manifest();
     prefilter(&m).expect("honest cross-scan join must pass the structural bind_joins gate");
+}
+
+// === ACCEPT (multi-scan-per-pattern): a pattern answered by TWO scans ========
+//
+// sq-sfsi soundness fix. A query pattern may LEGITIMATELY be answered by more than
+// one scan (the same triple pattern satisfied by two different credentials). The
+// old `bind_joins` used `position(..)` (FIRST match), which would (a) REJECT a
+// valid join whose edge points at the SECOND scan answering the pattern, or worse
+// (b) let scan ordering decide which scan the slot binding validates against. The
+// fix binds the slot check to the SPECIFIC `edge.scan_a`/`edge.scan_b`, so the join
+// is validated against the referenced scan regardless of `sub_proofs` order.
+
+/// Build a multi-scan-per-pattern manifest. sub_proofs =
+/// [scan_a (graph_a), scan_a2 (graph_a2, SAME pattern A), scan_b, join_eq].
+/// The join edge references scan_a2 (index 1) — the SECOND scan answering pattern
+/// A — for `scan_a`, and scan_b (index 2). The join_eq carries scan_a2's commitment.
+fn multi_scan_manifest() -> ProofManifest {
+    let (ca, sa) = {
+        let c = graph_a();
+        (c.commitment, c.salt)
+    };
+    let (ca2, sa2) = {
+        let c = graph_a2();
+        (c.commitment, c.salt)
+    };
+    let (cb, sb) = {
+        let c = graph_b();
+        (c.commitment, c.salt)
+    };
+    let scan_a = scan_a_inputs(&graph_a());
+    let scan_a2 = scan_a_inputs(&graph_a2());
+    let scan_b = scan_b_inputs(&graph_b());
+    // The join binds scan_a2 (the SECOND scan answering pattern A) to scan_b.
+    let commit_a2 = commitment_hex(&scan_a2);
+    let commit_b = commitment_hex(&scan_b);
+    let join = join_eq_inputs(commit_a2, commit_b, SLOT_A, SLOT_B);
+    let sk = test_issuer_sk(1);
+    ProofManifest {
+        r#type: "urn:sparq:zk:ProofManifest".into(),
+        query: JOIN_QUERY.into(),
+        issuers: vec![],
+        key_set: vec![public_key_to_hex(&sk.public_key())],
+        commitment_attestations: vec![
+            attest_full(ca, sa, &sk),
+            attest_full(ca2, sa2, &sk),
+            attest_full(cb, sb, &sk),
+        ],
+        attributions: vec![vec![0], vec![0]],
+        join_obligations: vec![],
+        entailment_regime: EntailmentRegime::Simple,
+        derivation_steps: vec![],
+        binding: BindingMode::Challenge { challenge: FieldHex(CHALLENGE_HEX.into()) },
+        revocation: Some(fixture_revocation()),
+        status_snapshots: vec![fixture_snapshot()],
+        sub_proofs: vec![
+            SubProof { inputs: scan_a, proof_hex: String::new() },
+            SubProof { inputs: scan_a2, proof_hex: String::new() },
+            SubProof { inputs: scan_b, proof_hex: String::new() },
+            SubProof { inputs: join, proof_hex: String::new() },
+        ],
+        binding_edges: vec![],
+        // scan_a -> sub-proof 1 (scan_a2, the SECOND scan answering pattern A),
+        // scan_b -> sub-proof 2, join_proof -> sub-proof 3.
+        join_edges: vec![JoinEdge { scan_a: 1, graph_a: 0, scan_b: 2, graph_b: 0, join_proof: 3 }],
+        hidden_revocation: None,
+        hidden_issuer_attestations: vec![],
+    }
+}
+
+/// A join edge pointing at the SECOND of two scans answering a pattern passes the
+/// structural `bind_joins` gate. With the old first-match `position(..)` this was
+/// WRONGLY rejected (`scan_for_pattern(pattern_a)` resolved to scan-0, not the
+/// referenced scan-1). The membership-based fix accepts it. [OPUS-4.8] sq-sfsi.
+#[test]
+fn multi_scan_join_edge_points_at_second_scan_passes() {
+    let m = multi_scan_manifest();
+    prefilter(&m).expect(
+        "a join edge referencing the SECOND scan answering a pattern must pass bind_joins \
+         (multi-scan-per-pattern is a legitimate configuration)",
+    );
+}
+
+/// Anti-forgery preserved under multi-scan: re-point the edge's `scan_a` at scan_b
+/// (sub-proof 2), which does NOT answer pattern A at slot_a. The slot binding has
+/// no pattern answered by the referenced scan with `?p` at SLOT_A => REJECT
+/// (`JoinSlotMismatch`). Confirms the fix did not weaken the binding: the edge
+/// still must reference a scan that genuinely answers the right pattern at the
+/// right slot, not merely SOME scan answering the pattern. [OPUS-4.8] sq-sfsi.
+#[test]
+fn multi_scan_join_edge_points_at_non_answering_scan_rejected() {
+    let mut m = multi_scan_manifest();
+    // sub-proof 2 (scan_b, pattern B) does not answer pattern A at SLOT_A; but its
+    // commitment must still match commit_a or we'd trip the commitment gate first.
+    // Point scan_a at scan_b AND set the join_eq's commit_a to scan_b's commitment
+    // so we reach (and exercise) the slot gate specifically.
+    m.join_edges[0].scan_a = 2;
+    let commit_b = match &m.sub_proofs[2].inputs {
+        ProofInputs::Scan { commitments, .. } => commitments[0].clone(),
+        _ => unreachable!("scan_b inputs"),
+    };
+    if let ProofInputs::JoinEq { commit_a, .. } = &mut m.sub_proofs[3].inputs {
+        *commit_a = commit_b;
+    } else {
+        unreachable!("join_eq inputs");
+    }
+    match prefilter(&m) {
+        Err(CheckError::JoinSlotMismatch { edge: 0 }) => {}
+        other => panic!(
+            "an edge whose scan_a does not answer pattern A at slot_a must be \
+             JoinSlotMismatch, got {other:?}"
+        ),
+    }
 }
 
 // === REJECT 1: commitment-matching (cross-scan forgery, anti-A2) ============

--- a/crates/sparq-zk-compose/tests/verifier_errors.rs
+++ b/crates/sparq-zk-compose/tests/verifier_errors.rs
@@ -83,6 +83,17 @@ fn check_error_display_covers_structural_reject_reasons() {
         &CheckError::ScanCommitmentsNotStrictlyIncreasing { proof: 0, at: 0 },
         &["strictly increasing", "S2.5"],
     );
+    // [OPUS-4.8] sq-sfsi: hidden cross-credential JOIN bind_joins reject reasons.
+    assert_display_carries(&CheckError::JoinDanglingEdge { edge: 2 }, &["join edge", "2"]);
+    assert_display_carries(&CheckError::JoinEdgeKindMismatch { edge: 3 }, &["join edge", "3"]);
+    assert_display_carries(
+        &CheckError::JoinCommitmentMismatch { edge: 4 },
+        &["join edge", "4", "commit_a"],
+    );
+    assert_display_carries(
+        &CheckError::JoinSlotMismatch { edge: 5 },
+        &["join edge", "5", "slot"],
+    );
 }
 
 #[test]


### PR DESCRIPTION
> 🤖 SPARQ agent

Step 4 of sq-bwwl (the flagship hidden cross-credential JOIN). Implements the **`bind_joins`** verifier gate that enforces `ProofManifest::join_edges` (the sq-fi03 schema) — the hidden-key analogue of the `binding_edges` consistency + `bind_query_correctness` stages.

## The gate — 3 enforcement points
For each declared `JoinEdge`, a manifest whose join proof / commitments / query binding don't line up is **REJECTED**:

1. **Commitment-matching (anti-A2, design §2.3/§4.2).** The `join_eq` proof's PUBLIC `commit_a`/`commit_b` must **byte-equal** the two referenced SCAN sub-proofs' bound `commitments[graph_a]`/`commitments[graph_b]`. Those scan commitments are audit-#1 byte-bound into the scan proofs **and** issuer-attested + in-`K` (`bind_issuer_attestations`, run in the same structural stage), so a join cannot bind rows from unrelated/forged scans — the join is provably over two genuine attested credentials. (`JoinCommitmentMismatch`)
2. **Canonical VK (anti-A1, design §4.1).** The `join_eq` proof is verified against the verifier-**recomputed** canonical vk (re-derived `CircuitId::JoinEq`, never the prover's vk — audit-#2) over the audit-#1-reconstructed public inputs, in `verify_manifest`'s per-sub-proof loop (unchanged). `bind_joins` is the structural gate that ties those already-bound public inputs to the scans + query; it does not re-run bb (so the reject paths run without the toolchain).
3. **Slot binding / UnboundJoin (design §3.3 step 5 / §4.4).** The `join_eq`'s PUBLIC `slot_a`/`slot_b` must equal the query-derived slots a variable **shared** across the two answered patterns occupies (`variable_slots`) — rejecting both a join over the wrong column (the audit-#6 analogue) **and** a spurious join over an unrelated scan pair. (`JoinSlotMismatch`)

Pubinput reconstruction ties to the referenced scans via point 1: `commit_a`/`commit_b` are read off the `join_eq` `ProofInputs` (the SAME values the sub-proof loop byte-binds into the proof, via the sq-fi03 `reconstruct_public_inputs` JoinEq arm) and byte-compared against the scans' bound `commitments[g]`. Wired into `prefilter_manifest_structure` after `bind_issuer_attestations`.

## Soundness boundary (honest, load-bearing)
`bind_joins` rigorously validates **declared** hidden joins. It does **NOT** demand a hidden join for every query cross-scan shared variable — such a variable is discharged by the **disclosed-row path** (`recheck`/`join_obligations` + disclosed scan rows), the default mechanism verified separately; the hidden `JoinEdge` is the **opt-in privacy alternative**. So a dropped hidden edge falls back to the disclosed path (not a soundness hole); demanding a hidden join would wrongly break disclosed joins (the e2e attribution / distinct-salts suite proved this — see the `drop_edge_falls_back_to_disclosed_path` scope test). N-way join-commitment chains (§2.4) are not yet enforced.

## Accept / reject test matrix (`tests/join_gates.rs`, 12 tests)
- **Accept (structural, witness-only):** an honest cross-scan join (commitments match the referenced scans, slots match the query) passes the structural `bind_joins` gate — the gate's completeness.
- **Adversarial reject (each its own test, each its specific error):** `commit_a` / `commit_b` not matching the referenced scans (cross-scan forgery → `JoinCommitmentMismatch`); edge pointing at the wrong scan; wrong `slot_a` / `slot_b` and a spurious/wrong-slot edge (→ `JoinSlotMismatch`); dangling `join_proof` / `graph` index (→ `JoinDanglingEdge`); `join_proof` not a `join_eq` / `scan_a` not a scan (→ `JoinEdgeKindMismatch`).
- **Scope:** `drop_edge_falls_back_to_disclosed_path` pins the disclosed-vs-hidden boundary.

## Accept-proof honesty
The `join_eq` PROVING path (`prover_toml_for`'s JoinEq arm) was left `Err` by sq-fi03, so this PR **cannot generate a real `join_eq` bb proof in-test**. The **structural** accept IS exercised; the **FULL-bb** accept (real proof + canonical vk + nonce binding, enforcement point 2 end-to-end) is `#[ignore]`'d (`full_bb_join_accept_deferred`) — I do **not** claim it works. The security-critical direction (all reject paths) is fully exercised without the toolchain.

## Landed vs beaded
- **Landed:** the `bind_joins` gate (3 enforcement points), 4 new `CheckError` variants + Display arms (covered in `verifier_errors.rs`), 12 join_gates tests.
- **Beaded:** **sq-r2s8** — `build_join` + `prover_toml_for` JoinEq + un-ignoring the full-bb accept + N-way chains. References **sq-hlul** (the forge-and-verify regression suite; not duplicated here).

## Verify
`cargo build` ✓ · `cargo nextest run -p sparq-zk-compose` → **232 passed, 30 skipped** · `cargo clippy -p sparq-zk-compose --all-targets -- -D warnings` ✓ clean. (No Noir touched.) Timings non-canonical (EC2 work box).

Refs sq-sfsi, sq-bwwl step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)