### PR TITLE
feat(bench): full-text-search benchmark suite (sq-ustq) — bench/fts/

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -124,6 +124,20 @@ Notes on a few that need care:
   `shacl_<workload>_validate_us` (trend-only, advisory). Heavy tiers: `univ=5`/`univ=10`. The
   cleanest competitor surface — Jena-SHACL / pySHACL / rdf-validate-shacl run the *identical*
   `(data, shapes)` pair (see the competitor map below + `scripts/bench-adapters/`).
+- **`text-index-bench` is the FULL-TEXT-SEARCH suite** — see
+  [`bench/fts/README.md`](./fts/README.md). It exercises `sparq-text` (BM25 inverted index +
+  `text:` magic predicates) over a **synthetic** corpus generated **in-process** (no external
+  generator — no `javac`/`rapper`): N seeded 8-word literals over a ~10k-term Zipf vocab. `run.sh`
+  is self-asserting: it runs the `bench_text` example and asserts each workload's **total hit
+  count** (`and_terms` / `or_terms` / `prefix4` / `phrase` / `near_slop2`, summed over a FIXED
+  200-query set drawn from an independent seed) and the integer **index bytes-per-doc** vs
+  `expected.tsv` (deterministic at the pinned `N=100000 seed=0` corpus; exit 1 on drift).
+  `fts_bytes_per_doc` also has a `mode:auto` ratchet in `bench/perf-baseline.json`. CI emits
+  `text_<workload>_us` + `text_build_s` (trend-only, advisory). Heavy/latency tier: `N=1000000`.
+  An IR-quality BEIR axis (Recall@100 / nDCG@10) is gather-only and not yet wired (follow-up bead).
+  Competitor honesty: **Solr/ES are NOT SPARQL competitors and stay off the dashboard**; the
+  surface peer is Fuseki + `jena-text` (`http-sparql`), the kernel ref is Lucene/Anserini (labelled
+  *sub-component, not an RDF benchmark*).
 - **`deep-taxonomy` (DeepTaxonomy) is the rule-heavy N3 REASONING suite** — see
   [`bench/deep-taxonomy/README.md`](./deep-taxonomy/README.md). `run.sh` is self-asserting and
   REUSES the existing generator `bench/inference/gen_deeptaxonomy.py` (1 instance + a depth-deep
@@ -188,6 +202,7 @@ bench/watdiv/run.sh 1                 # WatDiv SF=1 (g++ + Boost): gen + count/m
 bench/bsbm/run.sh                     # BSBM Explore -pc 300 (JRE + unzip): gen + materialize + row diff
 bench/lubm/run.sh                     # LUBM(1) (javac + rapper): gen + OWL-RL closure + both tiers + row diff
 bench/shacl/run.sh                    # SHACL (javac + rapper): LUBM ABox x 5 shapes + violations/conforms/focus_nodes diff
+cargo build --release -p sparq-text --example bench_text && bench/fts/run.sh   # Full-text (no external tool): synthetic BM25 corpus + hit-count/bytes-per-doc diff
 bench/deep-taxonomy/run.sh            # DeepTaxonomy (python3 only): N3 closure per depth tier + closure-size + query-row gate
 
 # --- selective bind-join + u64 value-id probes ---

--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -518,17 +518,20 @@ status      = "ok"
 # GENAI / AUX-INDEX measurement harnesses (crate examples)
 # =============================================================================
 
+# [OPUS-4.8] (sq-ustq, design §3.4) FULL-TEXT-SEARCH suite — exercises sparq-text (BM25 inverted
+# index + text: magic predicates: matches/matchesAny/prefix/phrase/near). Two axes: a deterministic
+# latency-axis STRUCTURE gate (per-commit) + an IR-quality BEIR axis (gather-only, not yet wired).
 [[benchmark]]
 id          = "text-index-bench"
-name        = "sparq-text full-text index build + query"
+name        = "Full-text search — synthetic BM25 corpus (text:matches/phrase/near)"
 category    = "query"
-measures    = "build time, index size, AND/OR/prefix query latency on synthetic literal-heavy data"
-invoke      = "cargo run --release -p sparq-text --example bench_text"
-source      = "crates/sparq-text/examples/bench_text.rs"
-dataset     = "N seeded Zipf-flavoured sentences over ~10k-word vocab, loaded as N-Triples in-example"
-quiet_box_sensitive = true
-pinning     = "seeded generator"
-records_to  = "stdout; sparq-text crate README"
+measures    = "per-workload query latency (us) for and_terms/or_terms/prefix4/phrase/near_slop2 over a synthetic BM25 index, plus the advisory index build time. run.sh carries a HARD self-asserting gate: each workload's TOTAL hit count (summed over a FIXED 200-query set, drawn from an independent seed) AND the integer index bytes-per-doc are asserted vs expected.tsv (deterministic at the pinned corpus; exit 1 on drift). The bytes-per-doc additionally has a mode:auto ratchet (fts_bytes_per_doc in bench/perf-baseline.json). Timing is ADVISORY (mode:noise, trend-only)"
+invoke      = "cargo build --release -p sparq-text --example bench_text && bench/fts/run.sh   # self-contained: synthetic in-process corpus (N=100000 seed=0), assert hit counts + bytes_per_doc vs expected.tsv; CI runs it via scripts/ci-bench.sh -> text_<workload>_us + fts_bytes_per_doc"
+source      = "bench/fts/{gen.sh,run.sh,expected.tsv,README.md}; crates/sparq-text/examples/bench_text.rs (the G1 TSV-emitting runner); scripts/ci-bench.sh (fts hook); competitors bench/competitors.json (jena-text http-sparql / lucene-anserini python-lib)"
+dataset     = "SYNTHETIC, generated in-process (no external generator): N seeded 8-word literals over a ~10k-term Zipf-skewed vocab, loaded as N-Triples; per-commit N=100000 seed=0, heavy/latency tier N=1000000. The hit counts + bytes-per-doc are deterministic constants at the pinned (N, seed); the FIXED query set is drawn from an INDEPENDENT seed so counts shift only on search-semantics changes. IR-quality (BEIR Recall@100/nDCG@10) axis is gather-only, not yet wired (follow-up bead)"
+quiet_box_sensitive = true  # wall-clock query/build time trend-only, NOT in scripts/perf-gate.py; the hit-count + bytes_per_doc diff IS a hard gate (deterministic, load-robust)
+pinning     = "N=100000 seed=0 (the corpus PIN; expected.tsv binds to it); FIXED 200-query set seeded independently; fts_bytes_per_doc floor in bench/perf-baseline.json. Solr/ES are NOT SPARQL competitors and are kept off the dashboard; surface peer is Fuseki+jena-text (http-sparql), kernel ref is Lucene/Anserini (labelled sub-component, not an RDF benchmark)"
+records_to  = "stdout (TSV); CI emits text_<workload>_us + text_build_s (advisory) and fts_bytes_per_doc (gated) into benchmark-data via scripts/ci-bench.sh; deterministic gates in bench/fts/expected.tsv"
 status      = "ok"
 
 [[benchmark]]

--- a/bench/competitors.json
+++ b/bench/competitors.json
@@ -164,6 +164,45 @@
       "version_env_metadata": "gather records the resolved npm version + node --version + the host env block.",
       "quiet_box_sensitive": true,
       "dashboard_engine_id": "rdf-validate-shacl"
+    },
+    {
+      "id": "jena-text",
+      "name": "Apache Jena Fuseki + jena-text (Lucene SAIL)",
+      "kind": "http-sparql",
+      "role": "[OPUS-4.8 sq-ustq] The ONLY like-for-like full-text-search-over-SPARQL comparator: Fuseki with the jena-text text-index assembler exposes `text:query` over a Lucene index, the surface analogue of sparq-text's `text:matches`. Apache-2.0. Adapter kind `http-sparql` (POST a SPARQL query with a text:query clause -> parse SPARQL-results-JSON -> count), reusing scripts/bench-adapters/http_sparql_adapter.py so the hit count is directly comparable to sparq-text's search().len(). The DASHBOARD FTS peer. Solr/Elasticsearch are deliberately NOT registered — they have no RDF/SPARQL surface (RDF4J even deprecated its Solr backend), so they are off the dashboard.",
+      "pinned_version": "apache-jena-fuseki + jena-text (pin the Fuseki distribution version or the stain/jena-fuseki Docker image DIGEST at gather time)",
+      "version_source": "the Fuseki distribution version, or the Docker image DIGEST, recorded in the gather results file.",
+      "install_recipe": "download apache-jena-fuseki-<ver>.tar.gz (Apache-2.0), configure a TDB2 dataset + a jena-text text-index assembler (Lucene), load the FTS corpus as RDF literals, OR use a `stain/jena-fuseki` Docker image (Docker-based -> gather-only on a Docker EC2 box, like QLever; zero recurring CI cost). gather-only — NOT a committed dependency (engines stay out of git per AGENTS.md).",
+      "run_recipe": "start Fuseki with the jena-text assembler over the loaded corpus, then scripts/gather-competitors.sh --run --only jena-text with the endpoint URL set; the dispatch calls scripts/bench-adapters/http_sparql_adapter.py with each text:query rewrite of the bench/fts query set.",
+      "adapter": {
+        "endpoint_env": "JENA_TEXT_ENDPOINT",
+        "note": "POST `SELECT (COUNT(?s) AS ?n) WHERE { ?s text:query (rdfs:comment \"<terms>\") }` (the jena-text analogue of text:matches); parse SPARQL-results-JSON, read ?n. Scope to AND/OR/prefix/phrase — match sparq-text's BM25 k1=1.2/b=0.75 where Fuseki exposes it."
+      },
+      "comparable_suites": [
+        { "sparq_suite": "text-index-bench", "note": "same corpus loaded as RDF literals; cross-check the HIT COUNT (text:query result size vs sparq-text search().len()) before trusting any timing. jena-text ranking/analyzer differs from sparq-text's UAX#29-tokenized BM25, so scope the comparison to AND/OR/prefix/phrase result SETS, not score order." }
+      ],
+      "version_env_metadata": "gather records the Fuseki version (or Docker image digest) + java -version + the host env block.",
+      "quiet_box_sensitive": true,
+      "dashboard_engine_id": "jena-text"
+    },
+    {
+      "id": "lucene-anserini",
+      "name": "Lucene (embedded) via Anserini — BM25 kernel reference",
+      "kind": "python-lib",
+      "role": "[OPUS-4.8 sq-ustq] KERNEL BM25 reference: the EMBEDDED Lucene library (NOT Solr/Elasticsearch the servers — a server adds an unfair network layer; sparq-text is embedded), driven via Anserini for standard BM25 on BEIR. Apache-2.0. LABELLED 'sub-component, not an RDF benchmark' — it has NO SPARQL/RDF surface, so it is kept OFF the dashboard and lives in its OWN IR harness, not a SPARQL-suite reuse. Scope to what sparq-text implements (token AND/OR, prefix, phrase, proximity/slop, BM25 k1=1.2/b=0.75) or the comparison is unfair.",
+      "pinned_version": "anserini (pin the exact release/Maven coordinate + Lucene version at gather time)",
+      "version_source": "the Anserini release version + bundled Lucene version, recorded in the gather results file.",
+      "install_recipe": "Anserini (Apache-2.0) via its fatjar / pyserini, plus a BEIR cut (SciFact or TREC-COVID + qrels) downloaded at gather time. gather-only — NOT committed; the BEIR corpus is NOT redistributable in-repo (see the text-index-bench BEIR follow-up bead).",
+      "run_recipe": "Anserini's OWN IR harness: index the BEIR corpus, run BM25 retrieval against the qrels, report Recall@100 / nDCG@10 + latency. This is the IR-quality oracle for sparq-text's BEIR axis once that axis is wired (currently gather-only).",
+      "adapter": {
+        "kind_note": "Lucene/Anserini is a kernel IR sub-component with its own harness (not the shared http-sparql/report-cli path); its results are the BM25 quality oracle, comparable ONLY on the IR-quality axis (Recall@100/nDCG@10), never as a SPARQL benchmark."
+      },
+      "comparable_suites": [
+        { "sparq_suite": "text-index-bench", "note": "KERNEL-ONLY, IR-quality axis: compare Recall@100/nDCG@10 on the same BEIR cut + qrels. NOT a SPARQL benchmark (no RDF surface) and NOT on the dashboard. Scope to AND/OR/prefix/phrase/slop + BM25 k1=1.2/b=0.75 to stay fair." }
+      ],
+      "version_env_metadata": "gather records the Anserini + Lucene versions, the BEIR cut + qrels checksum, java -version, and the host env block.",
+      "quiet_box_sensitive": true,
+      "dashboard_engine_id": null
     }
   ],
 

--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -219,7 +219,7 @@
   var GROUP_ORDER = [
     'Pipeline', 'Memory / Size',
     'Synthetic (qlever-style)', 'Operators',
-    'WatDiv', 'LUBM (reasoning)', 'SHACL validation', 'SP2Bench', 'BSBM', 'DBPSB'
+    'WatDiv', 'LUBM (reasoning)', 'SHACL validation', 'Full-Text', 'SP2Bench', 'BSBM', 'DBPSB'
   ];
 
   function buildSummary(entries) {
@@ -274,6 +274,8 @@
     { key: 'Deep Taxonomy', title: 'Deep Taxonomy', aliases: ['deep taxonomy', 'deeptax', 'deep-taxonomy', 'deeptaxonomy'] },
     // [OPUS-4.8] sq-7iai: SHACL validation suite (LUBM ABox x 5 hand-authored shape graphs).
     { key: 'SHACL',         title: 'SHACL validation', aliases: ['shacl', 'shacl validation'] },
+    // [OPUS-4.8] sq-ustq: Full-text-search suite (synthetic BM25 corpus; text:matches/phrase/near).
+    { key: 'Full-Text',     title: 'Full-Text',    aliases: ['full-text', 'fulltext', 'fts', 'text'] },
     { key: 'BSBM',          title: 'BSBM',          aliases: ['bsbm'] },
     { key: 'DBPSB',         title: 'DBPSB',         aliases: ['dbpsb', 'dbpedia sparql benchmark'] },
     // [OPUS-4.8] sq-i0nm: the synthetic qlever-style suite carries the one in-repo competitor

--- a/bench/dashboard/metric-labels.json
+++ b/bench/dashboard/metric-labels.json
@@ -756,6 +756,14 @@
       "query": "term-dictionary memory layout footprint",
       "unit": "bytes"
     },
+    "fts_bytes_per_doc": {
+      "label": "Full-Text — index bytes per document",
+      "suite": "Full-Text",
+      "dataset": "synthetic FTS corpus — 100k 8-word literals, ~10k-term Zipf vocab, BM25 positions-enabled index (bench/fts/gen.sh)",
+      "query": "deterministic index heap_bytes()/len() (mode:auto ratchet gate)",
+      "mode": "bytes",
+      "unit": "bytes"
+    },
     "load_s": {
       "label": "Load — parse + index build (synthetic)",
       "suite": "Pipeline",
@@ -2180,6 +2188,54 @@
       "dataset": "synthetic, fixed 50k-entity corpus (deterministic)",
       "query": "per-triple overhead on a second, fixed scale",
       "unit": "bytes"
+    },
+    "text_and_terms": {
+      "label": "Full-Text and_terms — text:matches — docs containing BOTH terms (AND), query",
+      "suite": "Full-Text",
+      "dataset": "synthetic FTS corpus — 100k 8-word literals, ~10k-term Zipf vocab, BM25 positions-enabled index (bench/fts/gen.sh)",
+      "query": "text:matches — docs containing BOTH terms (AND)",
+      "mode": "query",
+      "unit": "µs"
+    },
+    "text_build_s": {
+      "label": "Full-Text — BM25 index build time",
+      "suite": "Full-Text",
+      "dataset": "synthetic FTS corpus — 100k 8-word literals, ~10k-term Zipf vocab, BM25 positions-enabled index (bench/fts/gen.sh)",
+      "query": "build the positions-enabled BM25 inverted index over the corpus",
+      "mode": "build",
+      "unit": "s"
+    },
+    "text_near_slop2": {
+      "label": "Full-Text near_slop2 — text:near (slop 2) — two in-order terms within gap 2, query",
+      "suite": "Full-Text",
+      "dataset": "synthetic FTS corpus — 100k 8-word literals, ~10k-term Zipf vocab, BM25 positions-enabled index (bench/fts/gen.sh)",
+      "query": "text:near (slop 2) — two in-order terms within gap 2",
+      "mode": "query",
+      "unit": "µs"
+    },
+    "text_or_terms": {
+      "label": "Full-Text or_terms — text:matchesAny — docs containing at least one term (OR), query",
+      "suite": "Full-Text",
+      "dataset": "synthetic FTS corpus — 100k 8-word literals, ~10k-term Zipf vocab, BM25 positions-enabled index (bench/fts/gen.sh)",
+      "query": "text:matchesAny — docs containing at least one term (OR)",
+      "mode": "query",
+      "unit": "µs"
+    },
+    "text_phrase": {
+      "label": "Full-Text phrase — text:phrase — two adjacent in-order terms, query",
+      "suite": "Full-Text",
+      "dataset": "synthetic FTS corpus — 100k 8-word literals, ~10k-term Zipf vocab, BM25 positions-enabled index (bench/fts/gen.sh)",
+      "query": "text:phrase — two adjacent in-order terms",
+      "mode": "query",
+      "unit": "µs"
+    },
+    "text_prefix4": {
+      "label": "Full-Text prefix4 — text:matches 'abcd*' — 4-char prefix (autocomplete), query",
+      "suite": "Full-Text",
+      "dataset": "synthetic FTS corpus — 100k 8-word literals, ~10k-term Zipf vocab, BM25 positions-enabled index (bench/fts/gen.sh)",
+      "query": "text:matches 'abcd*' — 4-char prefix (autocomplete)",
+      "mode": "query",
+      "unit": "µs"
     },
     "wasm_bundle_bytes": {
       "label": "WASM bundle size",

--- a/bench/fts/README.md
+++ b/bench/fts/README.md
@@ -1,0 +1,114 @@
+<!-- [OPUS-4.8] sq-ustq — full-text-search benchmark suite. Design: research/capability-benchmark-program.md §3.4. -->
+# Full-text-search suite
+
+The FTS analogue of the LUBM / SHACL template: an **overview** dashboard row, a
+**self-asserting deterministic gate** (regression alerts), and a **competitor** comparison
+surface. It exercises `sparq-text` — the opt-in BM25 inverted index + `text:` magic
+predicates (`text:matches` AND, `text:matchesAny` OR, prefix `foo*`, `text:phrase`,
+`text:near` proximity/slop).
+
+## Two axes (design §3.4)
+
+1. **Latency axis (engine surface)** — `crates/sparq-text/examples/bench_text.rs` over N
+   synthetic 8-word literals (a ~10k-term Zipf-skewed vocabulary, deterministic seed),
+   loaded into a sparq `Graph`, positions-enabled BM25 index, AND / OR / prefix / phrase /
+   near query latency. Per-commit corpus N=100000 (sub-5s); the design's **1M**-literal
+   axis is the heavy/latency tier (`bench/fts/gen.sh 1000000`).
+2. **IR-quality axis (BEIR)** — Recall@100 / nDCG@10 on a small BEIR cut (SciFact /
+   TREC-COVID) loaded as RDF literals vs qrels. **Status: GATHER-ONLY, NOT YET WIRED.** The
+   BEIR corpus is not redistributable in-repo, so it is a download-step (gather /
+   nightly), not a committed per-PR gate. Tracked as a follow-up bead (see below); the
+   per-commit gate is the deterministic latency-axis structure below.
+
+## Data substrate
+
+`bench/fts/gen.sh [N] [seed]` is a thin **parameter source** — the corpus is synthetic and
+generated **in-process** by `bench_text` from a deterministic seed, so there is no external
+generator (no rapper/javac) and nothing to materialise on disk. It echoes the two pinned
+corpus parameters (N then seed) the way LUBM's `gen.sh` echoes its two artifact paths.
+
+Per-commit tier: `N=100000, seed=0`. Heavy/latency tier: `N=1000000` (the design's
+1M-literal axis; advisory timing only).
+
+## Workloads
+
+The FIXED 200-query set is drawn from an **independent** seed inside `bench_text`, so the
+asserted hit counts shift only when search **semantics** change — never as an artefact of
+how many RNG draws corpus generation happened to consume. Each query is a two-term pair:
+
+| Workload | Predicate | Count meaning |
+|---|---|---|
+| `and_terms` | `text:matches "a b"` | docs containing BOTH terms (AND) |
+| `or_terms` | `text:matchesAny "a b"` | docs containing AT LEAST ONE term (OR) |
+| `prefix4` | `text:matches "abcd*"` | docs matching the 4-char prefix of term a |
+| `phrase` | `text:phrase "a b"` | docs with a, b adjacent and in order |
+| `near_slop2` | `text:near "a b"` (slop 2) | docs with a, b in order within gap 2 |
+
+Plus the index footprint:
+
+| Metric | Meaning |
+|---|---|
+| `bytes_per_doc` | `index.heap_bytes() / index.len()` truncated to an integer |
+
+## Deterministic gate (HARD) vs timing (ADVISORY)
+
+`run.sh` is the self-asserting entry point (the LUBM pattern). It runs `bench_text` on the
+pinned corpus and **asserts, per workload, the `count` column vs `expected.tsv`, exit 1 on
+any drift**:
+
+- **the query hit counts** (`and_terms` / `or_terms` / `prefix4` / `phrase` / `near_slop2`)
+  — the TOTAL hits summed over the fixed query set (the FTS `expected-rows.tsv`; the primary
+  semantic gate, integer-exact).
+- **`bytes_per_doc`** — the integer index footprint per document (the FTS analogue of
+  `store_bytes_per_triple`; runner-noise-immune, integer-exact).
+
+The constants in `expected.tsv` were **derived by running `sparq-text`** on the pinned
+corpus (not guessed); the header records the monotonicity cross-checks
+(`phrase <= near_slop2 <= and_terms`, `or_terms >= and_terms`, `prefix4 >> or_terms`).
+
+These deterministic metrics also have `mode:"auto"` entries in
+`bench/perf-baseline.json` (`fts_bytes_per_doc`) so a footprint regression cross-commit is
+ratcheted in addition to the per-commit `expected.tsv` diff.
+
+**Timing is ADVISORY** (`mode:noise`, trend-only, **never hard-gated** — and this dev box is
+non-canonical, so its timings are advisory only): the ci-bench hook harvests
+`text_and_us` / `text_prefix_us` / `text_build_s` into the dashboard; they are **not** in
+`scripts/perf-gate.py`. The hard gate lives in `run.sh`'s `expected.tsv` diff.
+
+## Running it
+
+```sh
+cargo build --release -p sparq-text --example bench_text
+bench/fts/run.sh                       # self-asserting: exit 1 on any count drift
+# heavy/latency tier (advisory timing, 1M literals):
+FTS_N=1000000 bench/fts/run.sh
+```
+
+`bench_text` emits, per workload, the same `name<TAB>count<TAB>us` 3-column contract the
+ci-bench hook consumes (`sparq-text` is the *isolated* FTS crate — not a `sparq-cli`
+dependency — so the runner is a crate `--example`, not a CLI subcommand).
+
+## Competitors
+
+**Be honest: Solr / Elasticsearch are NOT SPARQL competitors** (no RDF/SPARQL surface; RDF4J
+deprecated its Solr backend) — they are **kept OFF the dashboard**. Two legitimate
+references are registered in `bench/competitors.json` (with the `engines`/`values` dashboard
+seam **empty** in git per AGENTS.md — no hard-coded perf):
+
+| Engine | Lang | License | Adapter kind | Role |
+|---|---|---|---|---|
+| **Apache Jena Fuseki + `jena-text` (Lucene SAIL)** | JVM | Apache-2.0 | `http-sparql` | The only like-for-like FTS-over-SPARQL: `text:query` ≈ `text:matches`. Surface peer (dashboard). Gather-only docker. |
+| **Lucene (embedded) via Anserini** | JVM | Apache-2.0 | `python-lib` (its OWN IR harness) | Kernel BM25 reference on BEIR. **Labelled "sub-component, not an RDF benchmark"** — off the dashboard. |
+
+Scope the kernel comparison to what `sparq-text` implements (token AND/OR, prefix, phrase,
+proximity/slop, BM25 k1=1.2/b=0.75) or it is unfair. A real
+`scripts/gather-competitors.sh --run --only <id>` writes git-ignored
+`bench/competitor-results/`; docker-based competitors are inherently gather-only on a Docker
+EC2 box (no Docker on the dev box), so they add zero recurring CI cost.
+
+## Follow-up
+
+The BEIR IR-quality axis (Recall@100 / nDCG@10 as deficits, G4) is captured as a bead — it
+needs a download/gather step (corpus not redistributable in-repo) before it can become a
+deterministic gate. Until then the per-commit gate is the deterministic latency-axis
+structure (hit counts + `bytes_per_doc`) above.

--- a/bench/fts/README.md
+++ b/bench/fts/README.md
@@ -71,9 +71,11 @@ These deterministic metrics also have `mode:"auto"` entries in
 ratcheted in addition to the per-commit `expected.tsv` diff.
 
 **Timing is ADVISORY** (`mode:noise`, trend-only, **never hard-gated** — and this dev box is
-non-canonical, so its timings are advisory only): the ci-bench hook harvests
-`text_and_us` / `text_prefix_us` / `text_build_s` into the dashboard; they are **not** in
-`scripts/perf-gate.py`. The hard gate lives in `run.sh`'s `expected.tsv` diff.
+non-canonical, so its timings are advisory only): the ci-bench hook harvests one
+`text_<workload>_us` per query workload (`text_and_terms_us` / `text_or_terms_us` /
+`text_prefix4_us` / `text_phrase_us` / `text_near_slop2_us`) plus `text_build_s` into the
+dashboard; they are **not** in `scripts/perf-gate.py`. The hard gate lives in `run.sh`'s
+`expected.tsv` diff.
 
 ## Running it
 

--- a/bench/fts/expected.tsv
+++ b/bench/fts/expected.tsv
@@ -1,0 +1,26 @@
+# [OPUS-4.8] (sq-ustq) Full-text-search DETERMINISTIC golden values for the pinned
+# synthetic corpus (bench/fts/gen.sh => N=100000 literals, seed=0; ~10k-term Zipf vocab,
+# 8-word sentences) and the FIXED 200-query set (drawn from an independent seed inside
+# examples/bench_text). Format: <workload>\t<count>.
+#   count   the integer the run.sh self-gate asserts (exit 1 on any drift):
+#     and_terms / or_terms / prefix4 / phrase / near_slop2  => TOTAL hit count summed over
+#         the 200 fixed two-term queries (text:matches / text:matchesAny / prefix /
+#         text:phrase / text:near slop=2). This is the FTS analogue of LUBM's row-count diff.
+#     bytes_per_doc => index heap_bytes() / len() truncated to an integer — the FTS
+#         analogue of store_bytes_per_triple (runner-noise-immune, integer-exact).
+# These are DERIVED by RUNNING examples/bench_text on the pinned corpus (not guessed);
+# run.sh re-runs it every commit and exits 1 on any mismatch. The us column bench_text also
+# emits is ADVISORY (wall-clock, non-canonical dev box) and is NEVER asserted here.
+#
+# Monotonicity cross-checks (independent of the exact RNG):
+#   and_terms <= phrase <= near_slop2 is FALSE in general, but for THIS query set the
+#     adjacency/proximity counts are a SUBSET of the AND count (a phrase/near match implies
+#     both terms co-occur), so phrase <= near_slop2 <= and_terms must always hold.
+#   or_terms >= and_terms (OR admits a superset of AND).
+#   prefix4 >> or_terms (a 4-char prefix matches a whole stem family => far more docs).
+and_terms	52
+near_slop2	21
+or_terms	71643
+phrase	6
+prefix4	6727493
+bytes_per_doc	371

--- a/bench/fts/gen.sh
+++ b/bench/fts/gen.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] (sq-ustq) Full-text-search benchmark corpus parameters. Unlike LUBM/SHACL
+# (which need an external generator + rapper), the FTS corpus is SYNTHETIC and generated
+# IN-PROCESS by examples/bench_text from a deterministic seed — there is no file to
+# materialise and no toolchain to install. So gen.sh is a thin parameter source: it echoes
+# the two pinned corpus parameters on stdout (mirroring the two-line gen.sh convention),
+# which run.sh + the ci-bench hook consume to drive bench_text:
+#
+#   bench/fts/gen.sh [N] [seed]
+#
+#   1. <N>      number of synthetic 8-word literals (the per-commit corpus size)
+#   2. <seed>   the corpus RNG seed
+#
+# At a fixed (N, seed) the corpus — and therefore every hit count and the index
+# bytes-per-doc — is a deterministic constant (see expected.tsv). The FIXED query set is
+# drawn from an INDEPENDENT seed inside bench_text, so the asserted counts shift only when
+# search SEMANTICS change, never as an artefact of corpus-gen RNG consumption.
+#
+# Per-commit tier: N=100000 (sub-second build, ~100k docs). Heavy/latency tier: N=1000000
+# (the 1M-literal axis in the design); the latency numbers there are ADVISORY only and the
+# dev box is non-canonical, so they are never gated.
+set -euo pipefail
+
+N="${1:-100000}"
+SEED="${2:-0}"
+
+echo "$N"
+echo "$SEED"

--- a/bench/fts/run.sh
+++ b/bench/fts/run.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] (sq-ustq) Full-text-search per-commit runner — the self-asserting entry point
+# CI calls, mirroring bench/lubm/run.sh + bench/shacl/run.sh. Self-contained:
+#   1. read the pinned corpus parameters (N, seed) from gen.sh.
+#   2. run examples/bench_text on that corpus (deterministic counts + advisory timing).
+#   3. ASSERT each workload's `count` vs expected.tsv (exit 1 on any drift — the HARD
+#      correctness/structure gate lives here, so the harvested timings stay advisory).
+#      This is the FTS analogue of LUBM's count diff: the query hit counts + the integer
+#      index bytes-per-doc.
+#   4. emit on STDOUT the 3-column `<workload>\t<count>\t<us>` contract the ci-bench hook
+#      consumes (count = the asserted value; us = the advisory timing). Correctness lives in
+#      expected.tsv, NOT in extra stdout columns — exactly like LUBM / SHACL.
+#
+# Usage: bench/fts/run.sh   (run from anywhere; honours $BENCH_TEXT / $ITERS / $FTS_N
+#                            / $FTS_SEED overrides)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+ITERS="${ITERS:-3}"
+GEN="$ROOT/bench/fts/gen.sh"
+EXP="$ROOT/bench/fts/expected.tsv"
+# The G1 TSV-emitting runner: a sparq-text example (the crate is isolated — not a sparq-cli
+# dependency). Override with $BENCH_TEXT for a custom build.
+BIN="${BENCH_TEXT:-$ROOT/target/release/examples/bench_text}"
+
+if [ ! -x "$BIN" ]; then
+  echo "[fts] ERROR: bench_text not found at $BIN" >&2
+  echo "[fts]   build: cargo build --release -p sparq-text --example bench_text" >&2
+  exit 1
+fi
+
+# ---- 1. resolve the pinned corpus parameters (gen.sh emits two lines: N then seed) -------
+mapfile -t PARAMS < <("$GEN" "${FTS_N:-}" "${FTS_SEED:-}" 2>/dev/null || "$GEN")
+N="${PARAMS[0]}"
+SEED="${PARAMS[1]}"
+echo "[fts] corpus: N=$N seed=$SEED iters=$ITERS" >&2
+
+# ---- 2. run bench_text (TSV: name count us) ----------------------------------------------
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+"$BIN" "$N" "$SEED" "$ITERS" > "$TMP/fts.tsv"
+
+# ---- 3. assert the DETERMINISTIC count column vs expected.tsv (exit 1 on any mismatch) ---
+fail=0
+seen=0
+while IFS=$'\t' read -r name count us; do
+  [ -n "$name" ] || continue
+  exp="$(awk -F'\t' -v k="$name" '$1==k{print $2}' "$EXP")"
+  if [ -z "$exp" ]; then
+    echo "[fts] ERROR: $name has no expected.tsv entry" >&2; fail=1; continue
+  fi
+  if [ "$count" != "$exp" ]; then
+    echo "[fts] ERROR: $name count=$count expected=$exp (correctness/structure regression)" >&2; fail=1
+  fi
+  seen=$((seen+1))
+  # ---- 4. forward the 3-column hook contract on STDOUT (count = the asserted value) ----
+  printf '%s\t%s\t%s\n' "$name" "$count" "$us"
+done < "$TMP/fts.tsv"
+
+# Every expected workload must have run (a vanished workload is itself a regression).
+exp_workloads=$(grep -cvE '^#|^$' "$EXP")
+if [ "$seen" != "$exp_workloads" ]; then
+  echo "[fts] ERROR: ran $seen workloads, expected $exp_workloads (a workload vanished)" >&2; fail=1
+fi
+
+if [ "$fail" = 0 ]; then
+  echo "[fts] OK: all $seen workloads match expected.tsv (hit counts + bytes_per_doc)" >&2
+else
+  echo "[fts] FAILED: one or more values diverged from expected.tsv" >&2
+fi
+exit "$fail"

--- a/bench/perf-baseline.json
+++ b/bench/perf-baseline.json
@@ -52,6 +52,11 @@
       "floor": 4.9721,
       "threshold": 0.12,
       "mode": "noise"
+    },
+    "fts_bytes_per_doc": {
+      "floor": 371,
+      "threshold": 0.02,
+      "mode": "auto"
     }
   }
 }

--- a/crates/sparq-text/examples/bench_text.rs
+++ b/crates/sparq-text/examples/bench_text.rs
@@ -13,6 +13,10 @@
 //!    asserts against `expected.tsv`.
 //!
 //! ```sh
+//! # No args reproduces the PINNED per-commit corpus (N=100000, seed=0) that
+//! # bench/fts/gen.sh + expected.tsv are derived from — so a casual `cargo run`
+//! # reproduces the gated counts. The heavy/latency 1M tier is opt-in via the first arg.
+//! cargo run -p sparq-text --release --example bench_text              # N=100000 seed=0 iters=3
 //! cargo run -p sparq-text --release --example bench_text -- [N] [seed] [iters]
 //! ```
 //!
@@ -47,10 +51,17 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use sparq_core::Graph;
 use sparq_text::TextIndex;
 
-/// The seed for the corpus RNG (distinct from the query-set seed so the two are
-/// independent — the query set never shifts when the corpus generation changes its
-/// RNG consumption, which is what makes the hit counts a STABLE gate).
-const CORPUS_SEED: u64 = 20260612;
+/// The DEFAULT corpus RNG seed — pinned to match `bench/fts/gen.sh` (seed 0) so a no-arg
+/// `cargo run --example bench_text` reproduces EXACTLY the committed `bench/fts/expected.tsv`
+/// corpus. (Distinct from the query-set seed below so the two are independent — the query
+/// set never shifts when corpus generation changes its RNG consumption, which is what makes
+/// the hit counts a STABLE gate.)
+const CORPUS_SEED: u64 = 0;
+
+/// The DEFAULT corpus size — pinned to match `bench/fts/gen.sh` (N=100000, the per-commit
+/// tier) so a no-arg run reproduces the gated `expected.tsv` counts. The heavy/latency
+/// 1M-literal tier is opt-in via the first arg (`cargo run --example bench_text -- 1000000`).
+const CORPUS_N: usize = 100_000;
 
 const STEMS: [&str; 20] = [
     "data", "graph", "query", "index", "store", "term", "literal", "token", "search", "join",
@@ -81,7 +92,7 @@ fn fixed_queries(n: usize) -> Vec<(String, String)> {
 const QUERIES: usize = 200;
 
 fn main() {
-    let n: usize = std::env::args().nth(1).and_then(|a| a.parse().ok()).unwrap_or(1_000_000);
+    let n: usize = std::env::args().nth(1).and_then(|a| a.parse().ok()).unwrap_or(CORPUS_N);
     let seed: u64 = std::env::args().nth(2).and_then(|a| a.parse().ok()).unwrap_or(CORPUS_SEED);
     let iters: usize = std::env::args().nth(3).and_then(|a| a.parse().ok()).unwrap_or(3);
     let iters = iters.max(1);

--- a/crates/sparq-text/examples/bench_text.rs
+++ b/crates/sparq-text/examples/bench_text.rs
@@ -1,16 +1,45 @@
-//! TextIndex benchmark: build time, index size and query latency on a
-//! synthetic literal-heavy dataset.
+//! [OPUS-4.8] (sq-ustq) TextIndex benchmark runner — the G1 TSV-emitting runner for
+//! `bench/fts/`, the full-text-search analogue of `sparq-cli bench` / `bench_shacl`.
 //!
-//! Run with:
+//! Two axes, one binary (design: research/capability-benchmark-program.md §3.4):
+//!
+//! 1. **Latency axis (engine surface):** N synthetic 8-word literals over a ~10k-term
+//!    Zipf-skewed vocabulary (deterministic seed) loaded into a sparq Graph; a
+//!    positions-enabled BM25 index; AND / OR / prefix / phrase / near query latency.
+//! 2. **Deterministic IR-structure axis:** the TOTAL hit count over a FIXED query set
+//!    (independent of the corpus-gen RNG draw order) and the index BYTES-PER-DOC are
+//!    integer-exact at the pinned `(N, seed)` corpus — the FTS analogue of LUBM's count
+//!    diff / `store_bytes_per_triple`. These are the hard gate columns `bench/fts/run.sh`
+//!    asserts against `expected.tsv`.
+//!
 //! ```sh
-//! cargo run --release -p sparq-text --example bench_text
+//! cargo run -p sparq-text --release --example bench_text -- [N] [seed] [iters]
 //! ```
 //!
-//! Generates N distinct literals (seeded; 8-word Zipf-flavoured sentences
-//! over a ~10k-word vocabulary, so token frequencies span common -> rare),
-//! loads them into a sparq Graph as N-Triples, builds the TextIndex, then
-//! measures AND / OR / prefix query latency. Numbers land in the crate
-//! README (with the contended-machine caveat).
+//! Output: one TSV line per workload (sorted by name), the same `name\tcount\tus`
+//! 3-column contract the ci-bench hook consumes, PLUS the deterministic `bytes_per_doc`
+//! row whose `count` is the integer index footprint per document:
+//!
+//! ```text
+//! and_terms     <total_hits>   <min_us_per_query>
+//! or_terms      <total_hits>   <min_us_per_query>
+//! prefix4       <total_hits>   <min_us_per_query>
+//! phrase        <total_hits>   <min_us_per_query>
+//! near_slop2    <total_hits>   <min_us_per_query>
+//! bytes_per_doc <bytes_per_doc> <build_us>
+//! ```
+//!
+//! - `count` for the query workloads = the TOTAL hit count summed over the fixed query
+//!   set (a deterministic integer at the pinned corpus — the gate).
+//! - `count` for `bytes_per_doc` = `heap_bytes() / len()` truncated to an integer
+//!   (deterministic, runner-noise-immune — like `store_bytes_per_triple`).
+//! - `us` = the best-of-`iters` time (ADVISORY; this dev box is non-canonical).
+//!   For the query rows it is microseconds-per-query; for `bytes_per_doc` it is the
+//!   index BUILD time in microseconds (advisory `text_build`).
+//!
+//! `bench/fts/run.sh` parses this, asserts the `count` columns against
+//! `bench/fts/expected.tsv` (exit 1 on drift), and forwards the same 3-column contract.
+//! Correctness lives in `expected.tsv`, NOT in the binary — exactly like LUBM / SHACL.
 
 use std::time::Instant;
 
@@ -18,25 +47,47 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use sparq_core::Graph;
 use sparq_text::TextIndex;
 
-/// A ~10k-word vocabulary: 100 stems x 100 numbered suffixes; a Zipf-ish
-/// skew comes from drawing the suffix index quadratically (low numbers
-/// common, high numbers rare).
+/// The seed for the corpus RNG (distinct from the query-set seed so the two are
+/// independent — the query set never shifts when the corpus generation changes its
+/// RNG consumption, which is what makes the hit counts a STABLE gate).
+const CORPUS_SEED: u64 = 20260612;
+
+const STEMS: [&str; 20] = [
+    "data", "graph", "query", "index", "store", "term", "literal", "token", "search", "join",
+    "plan", "merge", "scan", "parse", "shard", "cache", "delta", "score", "match", "prefix",
+];
+
+/// A ~10k-word vocabulary: 20 stems x ~500 numbered suffixes; a Zipf-ish skew comes
+/// from drawing the suffix index quadratically (low numbers common, high numbers rare).
 fn word(rng: &mut StdRng) -> String {
-    const STEMS: [&str; 20] = [
-        "data", "graph", "query", "index", "store", "term", "literal", "token", "search", "join",
-        "plan", "merge", "scan", "parse", "shard", "cache", "delta", "score", "match", "prefix",
-    ];
     let stem = STEMS[rng.random_range(0..STEMS.len())];
     let r: f64 = rng.random_range(0.0..1.0);
     let suffix = (r * r * 500.0) as u32; // quadratic skew: ~common head, long tail
     format!("{stem}{suffix}")
 }
 
+/// A FIXED query set, derived ONLY from a dedicated seed (NOT from the post-corpus RNG
+/// state). This is the load-bearing determinism trick: the same `(a, b)` term pairs are
+/// drawn no matter how the corpus generator evolves, so the asserted hit counts only
+/// change when search SEMANTICS change (the regression we want to catch), never as an
+/// artefact of how many RNG draws the corpus consumed. Returns `QUERIES` term pairs.
+fn fixed_queries(n: usize) -> Vec<(String, String)> {
+    let mut q = StdRng::seed_from_u64(0xF7501); // "FTS-01" — independent query seed
+    (0..n).map(|_| (word(&mut q), word(&mut q))).collect()
+}
+
+/// Number of queries in the fixed set (kept modest so the per-commit corpus stays
+/// sub-second; the hit-count SUM over this set is the deterministic gate).
+const QUERIES: usize = 200;
+
 fn main() {
     let n: usize = std::env::args().nth(1).and_then(|a| a.parse().ok()).unwrap_or(1_000_000);
-    let mut rng = StdRng::seed_from_u64(20260612);
+    let seed: u64 = std::env::args().nth(2).and_then(|a| a.parse().ok()).unwrap_or(CORPUS_SEED);
+    let iters: usize = std::env::args().nth(3).and_then(|a| a.parse().ok()).unwrap_or(3);
+    let iters = iters.max(1);
 
-    // ---- data generation + graph load ------------------------------------------
+    // ---- data generation + graph load ------------------------------------------------
+    let mut rng = StdRng::seed_from_u64(seed);
     let mut nt = String::with_capacity(n * 120);
     for i in 0..n {
         let sentence: Vec<String> = (0..8).map(|_| word(&mut rng)).collect();
@@ -45,54 +96,111 @@ fn main() {
             sentence.join(" ")
         ));
     }
-    let t = Instant::now();
     let graph = Graph::load_str(&nt, "ntriples").unwrap();
-    let load = t.elapsed();
-    println!("graph load     : {n} literal triples in {load:.2?}");
 
-    // ---- index build -------------------------------------------------------------
-    let t = Instant::now();
-    let index = TextIndex::build(&graph);
-    let build = t.elapsed();
-    println!(
-        "index build    : {} docs, {} tokens in {build:.2?} ({:.2} Mdocs/s)",
-        index.len(),
-        index.token_count(),
-        index.len() as f64 / build.as_secs_f64() / 1e6
-    );
-    println!(
-        "index size     : ~{:.1} MiB heap ({:.1} B/doc)",
-        index.heap_bytes() as f64 / (1024.0 * 1024.0),
-        index.heap_bytes() as f64 / index.len() as f64
-    );
-
-    // ---- queries ------------------------------------------------------------------
-    let queries: Vec<(String, String)> = (0..1000)
-        .map(|_| (word(&mut rng), word(&mut rng)))
-        .collect();
-    for (label, all) in [("AND 2 terms", true), ("OR  2 terms", false)] {
+    // ---- index build (positions enabled so phrase/near are exercised) -----------------
+    // Best-of-iters build for the advisory `text_build` timing; the resulting index is
+    // identical every iteration (build is a pure function of the graph), so heap_bytes()
+    // and every hit count are deterministic.
+    let mut build_us = f64::INFINITY;
+    let mut index = TextIndex::default();
+    for _ in 0..iters {
         let t = Instant::now();
-        let mut total = 0usize;
-        for (a, b) in &queries {
-            let q = format!("{a} {b}");
-            total += if all { index.search(&q).len() } else { index.search_any(&q).len() };
+        index = TextIndex::build_with_positions(&graph);
+        build_us = build_us.min(t.elapsed().as_secs_f64() * 1e6);
+    }
+    let docs = index.len();
+    assert!(docs > 0, "empty index — corpus generation produced no literals");
+    // Integer bytes-per-doc (truncating div) — runner-noise-immune, like store_bytes_per_triple.
+    let bytes_per_doc = index.heap_bytes() / docs;
+
+    // ---- the fixed query set ----------------------------------------------------------
+    let queries = fixed_queries(QUERIES);
+
+    // Each workload: (name, total-hit-count over the query set, best-of-iters µs/query).
+    // The count is summed deterministically; the timing is best-of-iters / |queries|.
+    let mut rows: Vec<(String, usize, f64)> = Vec::new();
+
+    // AND of two terms (`text:matches`): docs containing BOTH terms.
+    {
+        let (mut count, mut us) = (0usize, f64::INFINITY);
+        for _ in 0..iters {
+            let t = Instant::now();
+            let mut c = 0usize;
+            for (a, b) in &queries {
+                c += index.search(&format!("{a} {b}")).len();
+            }
+            us = us.min(t.elapsed().as_secs_f64() * 1e6 / queries.len() as f64);
+            count = c;
         }
-        let el = t.elapsed();
-        println!(
-            "{label}    : {:>8.1} µs/query ({:.1} avg hits)",
-            el.as_micros() as f64 / queries.len() as f64,
-            total as f64 / queries.len() as f64
-        );
+        rows.push(("and_terms".into(), count, us));
     }
-    let t = Instant::now();
-    let mut total = 0usize;
-    for (a, _) in &queries {
-        total += index.search(&format!("{}*", &a[..a.len().min(4)])).len();
+
+    // OR of two terms (`text:matchesAny`): docs containing AT LEAST ONE term.
+    {
+        let (mut count, mut us) = (0usize, f64::INFINITY);
+        for _ in 0..iters {
+            let t = Instant::now();
+            let mut c = 0usize;
+            for (a, b) in &queries {
+                c += index.search_any(&format!("{a} {b}")).len();
+            }
+            us = us.min(t.elapsed().as_secs_f64() * 1e6 / queries.len() as f64);
+            count = c;
+        }
+        rows.push(("or_terms".into(), count, us));
     }
-    let el = t.elapsed();
-    println!(
-        "prefix (4 ch)  : {:>8.1} µs/query ({:.1} avg hits)",
-        el.as_micros() as f64 / queries.len() as f64,
-        total as f64 / queries.len() as f64
-    );
+
+    // Prefix (4 chars) of the first term — autocomplete shape (`text:matches "foo*"`).
+    {
+        let (mut count, mut us) = (0usize, f64::INFINITY);
+        for _ in 0..iters {
+            let t = Instant::now();
+            let mut c = 0usize;
+            for (a, _) in &queries {
+                let p = &a[..a.len().min(4)];
+                c += index.search(&format!("{p}*")).len();
+            }
+            us = us.min(t.elapsed().as_secs_f64() * 1e6 / queries.len() as f64);
+            count = c;
+        }
+        rows.push(("prefix4".into(), count, us));
+    }
+
+    // Phrase (two adjacent, in-order terms — `text:phrase "foo bar"`).
+    {
+        let (mut count, mut us) = (0usize, f64::INFINITY);
+        for _ in 0..iters {
+            let t = Instant::now();
+            let mut c = 0usize;
+            for (a, b) in &queries {
+                c += index.phrase(&format!("{a} {b}")).len();
+            }
+            us = us.min(t.elapsed().as_secs_f64() * 1e6 / queries.len() as f64);
+            count = c;
+        }
+        rows.push(("phrase".into(), count, us));
+    }
+
+    // Proximity / slop (two in-order terms within gap 2 — `text:near "foo bar"` slop 2).
+    {
+        let (mut count, mut us) = (0usize, f64::INFINITY);
+        for _ in 0..iters {
+            let t = Instant::now();
+            let mut c = 0usize;
+            for (a, b) in &queries {
+                c += index.phrase_near(&format!("{a} {b}"), 2).len();
+            }
+            us = us.min(t.elapsed().as_secs_f64() * 1e6 / queries.len() as f64);
+            count = c;
+        }
+        rows.push(("near_slop2".into(), count, us));
+    }
+
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
+    for (name, count, us) in &rows {
+        println!("{name}\t{count}\t{us:.1}");
+    }
+    // The deterministic index-footprint gate (count = integer B/doc; us = advisory build time).
+    println!("bytes_per_doc\t{bytes_per_doc}\t{build_us:.1}");
 }

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -103,6 +103,16 @@ DEEPTAX_DEPTHS="${DEEPTAX_DEPTHS:-1000 10000}"
 # `shacl_<workload>_validate_us` (trend-only, NOT in scripts/perf-gate.py). Registry:
 # bench/benchmarks.toml (shacl-validate-bench); details: bench/shacl/README.md.
 SHACL_RUN=bench/shacl/run.sh
+# [OPUS-4.8] FULL-TEXT-SEARCH suite (sq-ustq, design §3.4). Exercises sparq-text (BM25 inverted
+# index + text: magic predicates). Unlike LUBM/SHACL the corpus is SYNTHETIC + generated
+# in-process by examples/bench_text from a deterministic seed — NO external generator (no
+# rapper/javac). run.sh is the self-asserting entry point: it runs bench_text on the pinned
+# corpus, asserts each workload's hit count + the integer index bytes-per-doc vs expected.tsv
+# (exit 1 on drift), and prints the `<workload>\t<count>\t<us>` contract on stdout. The hit
+# counts/bytes_per_doc are the HARD gate (in run.sh); the timings harvested below are ADVISORY
+# (text_*_us/text_build_s, trend-only, NOT in scripts/perf-gate.py). The integer bytes-per-doc
+# additionally gets a mode:auto ratchet in bench/perf-baseline.json (fts_bytes_per_doc).
+FTS_RUN=bench/fts/run.sh
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 RES="$TMP/res.tsv"; : > "$RES"
 add() { printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$RES"; }
@@ -451,6 +461,48 @@ if command -v javac >/dev/null 2>&1 && command -v rapper >/dev/null 2>&1 && [ -x
   fi
 else
   echo "note: shacl skipped (javac/rapper not on PATH)" >&2
+fi
+
+# [OPUS-4.8] FULL-TEXT-SEARCH suite per-commit (sq-ustq). The corpus is SYNTHETIC (generated
+# in-process by examples/bench_text from a seed), so there is NO external-toolchain guard like
+# the LUBM/SHACL javac/rapper — the only requirement is the bench_text example binary, built on
+# demand (sparq-text is isolated — not a sparq-cli dependency). run.sh is the self-asserting
+# entry point: it runs bench_text on the pinned N=100000/seed=0 corpus and asserts each
+# workload's hit count + the integer index bytes-per-doc vs expected.tsv internally (exit 1 on
+# any drift), failing the whole ci-bench run on a regression exactly like LUBM/SHACL. We harvest
+# run.sh's `<workload>\t<count>\t<us>` stdout: the `bytes_per_doc` row feeds the DETERMINISTIC
+# fts_bytes_per_doc ratchet (mode:auto, scripts/perf-gate.py), and the query rows feed ADVISORY
+# timings (text_<workload>_us, trend-only, NOT in perf-gate). Build is guarded so a missing
+# cargo/toolchain skips gracefully (PRs build no examples ⇒ zero PR cost).
+FTS_BIN=target/release/examples/bench_text
+if command -v cargo >/dev/null 2>&1 && [ -x "$FTS_RUN" ]; then
+  # Always (re)build: rust-cache restores target/, so a file-exists check can run a STALE
+  # bench_text. Let cargo's staleness detection decide (a no-op rebuild is cheap); do NOT
+  # swallow a real compile failure (it must fail the gate, not silently skip the FTS check).
+  if ! cargo build --release -q -p sparq-text --example bench_text; then
+    echo "ERROR: bench_text example failed to build" >&2
+    exit 1
+  fi
+  if BENCH_TEXT="$FTS_BIN" ITERS=3 bash "$FTS_RUN" > "$TMP/fts.tsv" 2>"$TMP/fts.err"; then
+    while IFS=$'\t' read -r name count us; do
+      [ "${count:-}" = "ERROR" ] && continue
+      if [ "$name" = "bytes_per_doc" ]; then
+        # DETERMINISTIC (integer, runner-noise-immune) — the mode:auto ratchet metric.
+        [ -n "${count:-}" ] && add fts_bytes_per_doc bytes "$count"
+        # us here is the advisory index BUILD time (microseconds -> seconds for the trend).
+        [ -n "${us:-}" ] && add text_build_s s "$(awk -v u="$us" 'BEGIN{printf "%.6f", u/1e6}')"
+      else
+        # ADVISORY per-query latency (microseconds): text_<workload>_us, trend-only.
+        [ -n "${us:-}" ] && add "text_${name}_us" us "$us"
+      fi
+    done < "$TMP/fts.tsv"
+  else
+    echo "ERROR: fts run.sh failed (correctness/structure regression)" >&2
+    cat "$TMP/fts.err" >&2 || true
+    exit 1
+  fi
+else
+  echo "note: fts skipped (cargo not on PATH)" >&2
 fi
 
 # RDFS inference (seconds) — instance-heavy: SCALE individuals under a depth-20 class hierarchy.

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -465,17 +465,28 @@ fi
 
 # [OPUS-4.8] FULL-TEXT-SEARCH suite per-commit (sq-ustq). The corpus is SYNTHETIC (generated
 # in-process by examples/bench_text from a seed), so there is NO external-toolchain guard like
-# the LUBM/SHACL javac/rapper — the only requirement is the bench_text example binary, built on
-# demand (sparq-text is isolated — not a sparq-cli dependency). run.sh is the self-asserting
-# entry point: it runs bench_text on the pinned N=100000/seed=0 corpus and asserts each
-# workload's hit count + the integer index bytes-per-doc vs expected.tsv internally (exit 1 on
-# any drift), failing the whole ci-bench run on a regression exactly like LUBM/SHACL. We harvest
-# run.sh's `<workload>\t<count>\t<us>` stdout: the `bytes_per_doc` row feeds the DETERMINISTIC
+# the LUBM/SHACL javac/rapper — bench_text only needs `cargo`, which is ALWAYS present (incl. on
+# PRs). The other suites avoid per-PR cost because their toolchains (javac/rapper/g++/JRE) are
+# main-only (bench.yml installs them only on `github.ref == refs/heads/main`), so their
+# `command -v` guard skips them on PRs. To match that discipline — and keep the FTS example
+# build+run (release compile of bench_text + N=100000 corpus) OFF the per-PR path — we gate this
+# hook to the MAIN tier: it runs on push-to-main (GITHUB_REF=refs/heads/main) and on a LOCAL run
+# (GITHUB_REF unset, so devs/`bench/fts/run.sh` still work), but is SKIPPED on the PR tier. The
+# deterministic correctness gate therefore runs once per merge to main (alongside the other
+# example-building suites), not on every PR build. run.sh is the self-asserting entry point: it
+# runs bench_text on the pinned N=100000/seed=0 corpus and asserts each workload's hit count +
+# the integer index bytes-per-doc vs expected.tsv internally (exit 1 on any drift), failing the
+# whole ci-bench run on a regression exactly like LUBM/SHACL. We harvest run.sh's
+# `<workload>\t<count>\t<us>` stdout: the `bytes_per_doc` row feeds the DETERMINISTIC
 # fts_bytes_per_doc ratchet (mode:auto, scripts/perf-gate.py), and the query rows feed ADVISORY
-# timings (text_<workload>_us, trend-only, NOT in perf-gate). Build is guarded so a missing
-# cargo/toolchain skips gracefully (PRs build no examples ⇒ zero PR cost).
+# timings (text_<workload>_us, trend-only, NOT in perf-gate).
 FTS_BIN=target/release/examples/bench_text
-if command -v cargo >/dev/null 2>&1 && [ -x "$FTS_RUN" ]; then
+# PR-tier skip: run only on main (or locally, where GITHUB_REF is unset) — mirrors the
+# main-only-toolchain skip the LUBM/SHACL hooks get for free, keeping the FTS example build off PRs.
+FTS_REF="${GITHUB_REF:-}"
+if [ -n "$FTS_REF" ] && [ "$FTS_REF" != "refs/heads/main" ]; then
+  echo "note: fts skipped (PR tier — FTS example build/run is main-only, like the javac/rapper suites)" >&2
+elif command -v cargo >/dev/null 2>&1 && [ -x "$FTS_RUN" ]; then
   # Always (re)build: rust-cache restores target/, so a file-exists check can run a STALE
   # bench_text. Let cargo's staleness detection decide (a no-op rebuild is cheap); do NOT
   # swallow a real compile failure (it must fail the gate, not silently skip the FTS check).
@@ -502,7 +513,9 @@ if command -v cargo >/dev/null 2>&1 && [ -x "$FTS_RUN" ]; then
     exit 1
   fi
 else
-  echo "note: fts skipped (cargo not on PATH)" >&2
+  # Reached only on the MAIN/local tier (the PR tier is handled by the skip branch above) when
+  # cargo or the run.sh entry point is missing.
+  echo "note: fts skipped (cargo not on PATH or $FTS_RUN missing)" >&2
 fi
 
 # RDFS inference (seconds) — instance-heavy: SCALE individuals under a depth-20 class hierarchy.

--- a/scripts/gen-metric-labels.py
+++ b/scripts/gen-metric-labels.py
@@ -227,6 +227,20 @@ SHACL_DESC = {
     "sparql_constraint": "sh:sparql (SHACL §5.2) routed through sparq-engine",
 }
 
+# [OPUS-4.8] (sq-ustq) Full-text-search workloads -> human descriptions. These are FIXED
+# workload names emitted by examples/bench_text (the FTS corpus is synthetic, generated
+# in-process — there are no *.rq / *.ttl input files to glob), driving the ADVISORY metric
+# names text_<workload>_us (per-query latency) + text_build_s (index build). The deterministic
+# gate (hit counts + fts_bytes_per_doc) lives in bench/fts/run.sh's self-assertion + the
+# fts_bytes_per_doc mode:auto ratchet (bench/perf-baseline.json), not on the dashboard.
+FTS_DESC = {
+    "and_terms": "text:matches — docs containing BOTH terms (AND)",
+    "or_terms": "text:matchesAny — docs containing at least one term (OR)",
+    "prefix4": "text:matches 'abcd*' — 4-char prefix (autocomplete)",
+    "phrase": "text:phrase — two adjacent in-order terms",
+    "near_slop2": "text:near (slop 2) — two in-order terms within gap 2",
+}
+
 
 def stems(subdir, ext=".rq"):
     """Sorted file stems under bench/<subdir> with the given extension (default *.rq, matching
@@ -410,6 +424,32 @@ def build():
             "dataset": "LUBM(1) ABox, ~103k triples x hand-authored shape graph",
             "query": desc, "mode": "validate", "unit": "µs",
         }
+
+    # 11) Full-text-search suite (sq-ustq, design §3.4) -> one ADVISORY per-query-latency metric
+    # per workload (text_<workload>_us; dashboard strips the _us for the label key) + the index
+    # build time (text_build_s). The corpus is synthetic (in-process), so the workload names are
+    # FIXED (not file stems). The deterministic gates (hit counts + fts_bytes_per_doc) live in
+    # bench/fts/run.sh's self-assertion + the fts_bytes_per_doc mode:auto ratchet, not here.
+    FTS_DATASET = ("synthetic FTS corpus — 100k 8-word literals, ~10k-term Zipf vocab, "
+                   "BM25 positions-enabled index (bench/fts/gen.sh)")
+    for s, desc in FTS_DESC.items():
+        labels["text_%s" % s] = {
+            "label": "Full-Text %s — %s, query" % (s, desc),
+            "suite": "Full-Text", "dataset": FTS_DATASET,
+            "query": desc, "mode": "query", "unit": "µs",
+        }
+    labels["text_build_s"] = {
+        "label": "Full-Text — BM25 index build time",
+        "suite": "Full-Text", "dataset": FTS_DATASET,
+        "query": "build the positions-enabled BM25 inverted index over the corpus",
+        "mode": "build", "unit": "s",
+    }
+    labels["fts_bytes_per_doc"] = {
+        "label": "Full-Text — index bytes per document",
+        "suite": "Full-Text", "dataset": FTS_DATASET,
+        "query": "deterministic index heap_bytes()/len() (mode:auto ratchet gate)",
+        "mode": "bytes", "unit": "bytes",
+    }
 
     return labels
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Stamps the LUBM/SHACL per-surface benchmark template onto **sparq-text** (full-text search), per `research/capability-benchmark-program.md` **§3.4**. Bead **sq-ustq**.

## Two axes (design §3.4)

1. **Latency axis (engine surface).** Rewrote `crates/sparq-text/examples/bench_text.rs` to the G1 `name\tcount\tus` contract: N synthetic 8-word literals over a ~10k-term Zipf-skewed vocab (deterministic seed), positions-enabled BM25 index, AND / OR / prefix / phrase / near per-query latency. Per-commit corpus `N=100000 seed=0` (~4s, hermetic); heavy/latency tier `N=1000000` (the design's 1M-literal axis; advisory timing only).
2. **IR-quality axis (BEIR Recall@100 / nDCG@10).** **GATHER-ONLY, NOT yet wired** — the BEIR corpus (SciFact / TREC-COVID) is not redistributable in-repo, so it must be a download/gather step, not a committed per-PR gate. Captured as follow-up bead **sq-1fz0** (blocked on sq-ustq); the `lucene-anserini` competitor is already registered as the BM25 quality oracle for it. **What's committed vs gather-only is documented honestly** in `bench/fts/README.md`.

## Deterministic gate (HARD) + self-check

`bench/fts/run.sh` is the self-asserting entry point (LUBM pattern). It runs `bench_text` on the pinned corpus and asserts, per workload, the `count` column vs `expected.tsv` (**exit 1 on any drift**):

- **hit counts** — total hits summed over a **FIXED 200-query set drawn from an INDEPENDENT seed**, so the asserted counts shift only when search *semantics* change, never as an artefact of corpus-gen RNG consumption (the load-bearing determinism trick). The FTS analogue of LUBM's row-count diff.
- **`bytes_per_doc`** — integer `heap_bytes()/len()`, the FTS analogue of `store_bytes_per_triple` (runner-noise-immune). Also gets a `mode:auto` ratchet `fts_bytes_per_doc` in `bench/perf-baseline.json` (cross-commit footprint ratchet).

All values **derived by running sparq-text** on the pinned corpus (no hard-coded perf in markdown). **Proved the gate gates:** perturbing any expected count → `exit 1` (verified for `and_terms` and `prefix4`); `perf-gate.py` confirmed failing `fts_bytes_per_doc` on a +7.8% regression.

## Timing advisory (never gated)

Guarded `ci-bench.sh` hook (cargo-only guard ⇒ PRs skip, zero PR cost) harvests `text_<workload>_us` + `text_build_s` (mode:noise, trend-only, NOT in `perf-gate.py`). This dev box is non-canonical, so timings are advisory only.

## Dashboard (+ the rebase)

Per the brief, did the FTS work first, then `git fetch origin && git merge origin/main` before touching dashboard files — only a beads re-export had landed (geo PR #184 not yet merged), so **no conflict**. Added the **Full-Text** row to `FEATURED_SUITES` + `GROUP_ORDER` + a `gen-metric-labels.py` block, and regenerated `metric-labels.json`. Registry (`benchmarks.toml`) + `CATALOG.md` updated (`text-index-bench` is now the self-asserting FTS suite).

## Competitor honesty

**Solr / Elasticsearch are NOT SPARQL competitors** (no RDF/SPARQL surface) and are **kept OFF the dashboard**. Registered in `bench/competitors.json` (`engines`/`values` **empty** in git per AGENTS.md):

- **`jena-text`** — Fuseki + `jena-text` Lucene SAIL (`http-sparql`, Apache-2.0, gather-only docker): the **only like-for-like FTS-over-SPARQL** comparator (`text:query` ≈ `text:matches`). The dashboard peer.
- **`lucene-anserini`** — embedded Lucene BM25 via Anserini on BEIR (`python-lib`, Apache-2.0): kernel reference, its OWN IR harness, **`dashboard_engine_id: null`** = labelled *sub-component, not an RDF benchmark*, off-dashboard. Scoped to what sparq-text implements (AND/OR, prefix, phrase, slop, BM25 k1=1.2/b=0.75).

## Verify

- `cargo build -p sparq-text --example bench_text` + run → finite `name\tcount\tus` (counts deterministic across runs).
- `bash bench/fts/run.sh` passes its self-gate; perturb → exit 1 (proved).
- `cargo nextest run -p sparq-text` → 58/58; `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings` clean.
- `node scripts/dashboard-smoke.js` + `gen-metric-labels.py --check` + `perf-gate.py --self-test` all pass.

Refs sq-ustq, design §3.4. Follow-up: sq-1fz0 (BEIR axis).