### PR TITLE
feat(zk-compose): join_eq proving path + N-way chain + real bb accept (sq-r2s8)

### DIFF
--- a/crates/sparq-zk-compose/src/build.rs
+++ b/crates/sparq-zk-compose/src/build.rs
@@ -11,6 +11,7 @@ use crate::manifest::{CircuitId, FieldHex, FilterOp, ProofInputs};
 use sparq_zk::commit::GraphCommitment;
 use sparq_zk::encode::encode_term;
 use sparq_zk::field::{field_to_be_bytes_32, field_to_hex, Fr};
+use sparq_zk::sig::join_value_commitment;
 use oxrdf::{NamedNode, Term};
 
 /// Compiled slot buckets (`n`) of the scan family, ascending.
@@ -371,4 +372,159 @@ fn subj_term(t: &oxrdf::Triple) -> Term {
         oxrdf::NamedOrBlankNode::NamedNode(n) => Term::NamedNode(n.clone()),
         oxrdf::NamedOrBlankNode::BlankNode(b) => Term::BlankNode(b.clone()),
     }
+}
+
+// === Hidden cross-credential JOIN (sq-bwwl / sq-r2s8, step 4 proving path) ====
+// [OPUS-4.8] sq-r2s8: assemble the `join_eq` witness for proving — the host
+// analogue of `build_scan`. Mirrors the scan build_* pattern: re-encode each
+// witnessed graph's canonical triples (same salt convention the commitment used,
+// so the in-circuit `commit_fold` recompute reproduces `C(G)`), locate the two
+// rows whose chosen slots carry the SAME join value, and bind that value under a
+// per-presentation blinder into the public hiding `join_commitment`. The join
+// VALUE and both rows are PRIVATE witnesses; only the two commitments, the hiding
+// commitment, and the two query-bound slots are public.
+
+/// The private witnesses a `join_eq` proof needs but the manifest never carries —
+/// exactly the `main` PRIVATE parameters of `join_eq_na{n_a}_nb{n_b}` (in
+/// declaration order): the two graphs' per-slot encodings + active counts, the two
+/// joined rows, and the per-presentation blinder. `build` does NOT pad to the
+/// circuit's `N` slots; [`crate::toml::join_prover_toml`] pads `enc_a`/`enc_b` to
+/// the member's bucket exactly as `prover_toml_for`'s scan arm pads `enc`.
+// [OPUS-4.8] sq-r2s8: hidden cross-credential JOIN witness (mirrors ScanWitness).
+#[derive(Debug, Clone)]
+pub struct JoinWitness {
+    /// Graph-A per-slot term encodings of every canonical triple (active leaves).
+    pub enc_a: Vec<[FieldHex; 3]>,
+    /// Active triple count of graph A (`<= n_a`).
+    pub counts_a: u32,
+    /// Graph-B per-slot term encodings.
+    pub enc_b: Vec<[FieldHex; 3]>,
+    /// Active triple count of graph B (`<= n_b`).
+    pub counts_b: u32,
+    /// The joined row of graph A (the row whose `slot_a` carries the join value).
+    pub row_a: [FieldHex; 3],
+    /// The joined row of graph B (the row whose `slot_b` carries the join value).
+    pub row_b: [FieldHex; 3],
+    /// The per-presentation blinder folded into the public `join_commitment`.
+    pub blinding: FieldHex,
+}
+
+/// A built hidden-join proof: the public inputs ([`ProofInputs::JoinEq`]) + the
+/// private witness ([`JoinWitness`]). Mirrors [`BuiltScan`].
+// [OPUS-4.8] sq-r2s8.
+#[derive(Debug, Clone)]
+pub struct BuiltJoin {
+    pub inputs: ProofInputs,
+    pub witness: JoinWitness,
+}
+
+/// One graph's canonical triples re-encoded both as field elements (to locate the
+/// joined rows) and as hex (the witness the toml emits). [OPUS-4.8] sq-r2s8.
+type EncodedGraph = (Vec<[Fr; 3]>, Vec<[FieldHex; 3]>);
+
+/// Re-encode every canonical triple of `c` under its recorded salt — the same
+/// re-derivation [`build_scan`] performs. `None` if a term is not committable.
+// [OPUS-4.8] sq-r2s8.
+fn encode_join_graph(c: &GraphCommitment) -> Option<EncodedGraph> {
+    let salt = c.salt;
+    let mut fr = Vec::with_capacity(c.canonical.triples.len());
+    let mut hex = Vec::with_capacity(c.canonical.triples.len());
+    for t in &c.canonical.triples {
+        let s = encode_term(&subj_term(t), &salt)?;
+        let p = encode_term(&Term::NamedNode(t.predicate.clone()), &salt)?;
+        let o = encode_term(&t.object, &salt)?;
+        fr.push([s, p, o]);
+        hex.push([hexf(&s), hexf(&p), hexf(&o)]);
+    }
+    Some((fr, hex))
+}
+
+/// Build a hidden cross-credential JOIN proof's inputs + witness from the two
+/// graph commitments and the two query-bound join slots, blinding the joined
+/// value with `blinding` (sq-bwwl / sq-r2s8, design §2.2/§3.2).
+///
+/// `slot_a`/`slot_b` (in `{0,1,2}` for s/p/o) are the query-derived positions the
+/// shared variable occupies in each pattern — the SAME slots the verifier's
+/// `bind_joins` gate pins (design §4.4). This builder finds the first `(row_a,
+/// row_b)` whose `row_a[slot_a] == row_b[slot_b]` (the join value), so an honest
+/// caller need only supply the two committed graphs and the slots. Both graphs
+/// must use the salt convention recorded in their [`GraphCommitment`] (the
+/// in-circuit `commit_fold` recomputes `C(G)` from the re-encoded leaves — a wrong
+/// encoding would fail that recompute, so this re-derivation is sound by
+/// construction, exactly as in [`build_scan`]).
+///
+/// Returns `None` if: either slot is out of `{0,1,2}`; no row pair shares a value
+/// at the chosen slots (no honest join — the prover has no satisfying witness); or
+/// either graph's size has no compiled [`JOIN_EQ_N_BUCKETS`] member
+/// ([`derive_join_eq_id`] => `None`, a clean error, never a wrong-N member).
+///
+/// `blinding` is a per-presentation random field element; two presentations of the
+/// same join value under different blinders produce UNLINKABLE `join_commitment`s
+/// (design §2.4 R4). The caller draws it (e.g. from its CSPRNG mapped into the
+/// field), exactly as the ingest salt is drawn.
+// [OPUS-4.8] sq-r2s8: hidden cross-credential JOIN builder.
+pub fn build_join(
+    commit_a: &GraphCommitment,
+    slot_a: u32,
+    commit_b: &GraphCommitment,
+    slot_b: u32,
+    blinding: Fr,
+) -> Option<BuiltJoin> {
+    if slot_a > 2 || slot_b > 2 {
+        return None;
+    }
+
+    // Re-encode each graph's canonical triples under its recorded salt — the same
+    // re-derivation `build_scan` does (the leaf is `h3(enc)`, so a wrong encoding
+    // fails the in-circuit commitment recompute). The field form locates the joined
+    // rows; the hex form is the witness the toml emits.
+    let (fr_a, enc_a) = encode_join_graph(commit_a)?;
+    let (fr_b, enc_b) = encode_join_graph(commit_b)?;
+    let counts_a = fr_a.len() as u32;
+    let counts_b = fr_b.len() as u32;
+
+    let id = derive_join_eq_id(counts_a, counts_b)?;
+
+    // Locate the join: the first row pair whose chosen slots carry the same value.
+    // `slot_a`/`slot_b` are bounds-checked above, so the indexing is in range.
+    let (sa, sb) = (slot_a as usize, slot_b as usize);
+    let mut joined: Option<(usize, usize, Fr)> = None;
+    'outer: for (ia, ra) in fr_a.iter().enumerate() {
+        for (ib, rb) in fr_b.iter().enumerate() {
+            if ra[sa] == rb[sb] {
+                joined = Some((ia, ib, ra[sa]));
+                break 'outer;
+            }
+        }
+    }
+    let (ia, ib, value) = joined?;
+
+    let row_a = enc_a[ia].clone();
+    let row_b = enc_b[ib].clone();
+
+    // Bind the join value under the per-presentation blinder — the in-circuit step
+    // 5 recomputes this identically (single source of truth: the Rust + Noir
+    // `join_value_commitment` agree byte-for-byte), so the public `join_commitment`
+    // matches what the proof binds.
+    let join_commitment = hexf(&join_value_commitment(&value, &blinding));
+
+    Some(BuiltJoin {
+        inputs: ProofInputs::JoinEq {
+            id,
+            commit_a: hexf(&commit_a.commitment),
+            commit_b: hexf(&commit_b.commitment),
+            join_commitment,
+            slot_a,
+            slot_b,
+        },
+        witness: JoinWitness {
+            enc_a,
+            counts_a,
+            enc_b,
+            counts_b,
+            row_a,
+            row_b,
+            blinding: hexf(&blinding),
+        },
+    })
 }

--- a/crates/sparq-zk-compose/src/toml.rs
+++ b/crates/sparq-zk-compose/src/toml.rs
@@ -7,6 +7,7 @@
 //! Private witnesses (graph encodings, filter digits) are supplied by the
 //! prover driver, never present in the manifest.
 
+use crate::build::JoinWitness;
 use crate::manifest::{CircuitId, FieldHex, ProofInputs};
 
 /// Error returned by [`prover_toml_for`] when a `Prover.toml` cannot be emitted
@@ -17,21 +18,26 @@ use crate::manifest::{CircuitId, FieldHex, ProofInputs};
 /// (a `unimplemented!` in a public fn is a downstream-crash footgun).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProverTomlError {
-    /// The `join_eq` Prover.toml emitter is deferred to sq-sfsi (step 4); sq-fi03
-    /// adds the manifest schema only. The join member's private witnesses
-    /// (`enc_a`/`counts_a`/`enc_b`/`counts_b`/`row_a`/`row_b`/`blinding`) are not
-    /// yet plumbed through this function's parameters, so it cannot emit a witness.
-    JoinEqUnsupported,
+    /// A [`ProofInputs::JoinEq`] was passed without its private [`JoinWitness`]:
+    /// the `join_eq` member's private inputs
+    /// (`enc_a`/`counts_a`/`enc_b`/`counts_b`/`row_a`/`row_b`/`blinding`) live in
+    /// the witness, not the manifest, so a join Prover.toml cannot be emitted
+    /// without it. The caller obtains the witness from [`crate::build::build_join`]
+    /// and threads it through `prover_toml_for`'s `join_witness` parameter.
+    // [OPUS-4.8] sq-r2s8: the join proving path is now implemented; this error is
+    // the "witness omitted for a JoinEq input" recoverable failure (no panic in a
+    // public fn).
+    JoinEqMissingWitness,
 }
 
 impl std::fmt::Display for ProverTomlError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ProverTomlError::JoinEqUnsupported => write!(
+            ProverTomlError::JoinEqMissingWitness => write!(
                 f,
-                "join_eq Prover.toml generation is not yet implemented (deferred to \
-                 sq-sfsi, step 4); sq-fi03 adds the manifest schema only. The join \
-                 member's private witnesses are not plumbed through prover_toml_for."
+                "join_eq Prover.toml generation requires the private JoinWitness \
+                 (enc_a/counts_a/enc_b/counts_b/row_a/row_b/blinding) — obtain it \
+                 from build_join and pass it via prover_toml_for's join_witness arg"
             ),
         }
     }
@@ -158,6 +164,50 @@ pub fn filter_f64_prover_toml(
     s
 }
 
+/// Render the `Prover.toml` body for a hidden cross-credential `join_eq` proof
+/// ([OPUS-4.8] sq-r2s8). Order MUST match `join_eq_na{n_a}_nb{n_b}/src/main.nr`:
+/// PUBLIC `challenge, commit_a, commit_b, join_commitment, slot_a, slot_b` then
+/// PRIVATE `enc_a, counts_a, enc_b, counts_b, row_a, row_b, blinding`. `enc_a`/
+/// `enc_b` are padded to `n_a`/`n_b` slots by the caller (mirrors the scan arm).
+#[allow(clippy::too_many_arguments)]
+pub fn join_prover_toml(
+    challenge: &FieldHex,
+    commit_a: &FieldHex,
+    commit_b: &FieldHex,
+    join_commitment: &FieldHex,
+    slot_a: u32,
+    slot_b: u32,
+    enc_a: &[[FieldHex; 3]],
+    counts_a: u32,
+    enc_b: &[[FieldHex; 3]],
+    counts_b: u32,
+    row_a: &[FieldHex; 3],
+    row_b: &[FieldHex; 3],
+    blinding: &FieldHex,
+) -> String {
+    let mut s = String::new();
+    s.push_str(&format!("challenge = \"{}\"\n", challenge.0));
+    s.push_str(&format!("commit_a = \"{}\"\n", commit_a.0));
+    s.push_str(&format!("commit_b = \"{}\"\n", commit_b.0));
+    s.push_str(&format!("join_commitment = \"{}\"\n", join_commitment.0));
+    s.push_str(&format!("slot_a = \"{slot_a}\"\n"));
+    s.push_str(&format!("slot_b = \"{slot_b}\"\n"));
+    s.push_str(&format!("enc_a = {}\n", rows_array(enc_a)));
+    s.push_str(&format!("counts_a = \"{counts_a}\"\n"));
+    s.push_str(&format!("enc_b = {}\n", rows_array(enc_b)));
+    s.push_str(&format!("counts_b = \"{counts_b}\"\n"));
+    s.push_str(&format!(
+        "row_a = [\"{}\", \"{}\", \"{}\"]\n",
+        row_a[0].0, row_a[1].0, row_a[2].0
+    ));
+    s.push_str(&format!(
+        "row_b = [\"{}\", \"{}\", \"{}\"]\n",
+        row_b[0].0, row_b[1].0, row_b[2].0
+    ));
+    s.push_str(&format!("blinding = \"{}\"\n", blinding.0));
+    s
+}
+
 fn hex_array(items: &[FieldHex]) -> String {
     format!(
         "[{}]",
@@ -209,10 +259,13 @@ pub fn canonical_digits(value: u64) -> Vec<u8> {
 /// Render the witness-bearing `Prover.toml` for any `ProofInputs`, given the
 /// private witnesses the manifest does not carry. Returns the package id too.
 ///
-/// Returns [`ProverTomlError::JoinEqUnsupported`] for [`ProofInputs::JoinEq`],
-/// whose prover path is deferred to sq-sfsi (step 4). This is a recoverable
-/// error so a downstream caller (or a CLI loading a manifest containing
-/// `join_eq`) gets a structured failure rather than a panic. [OPUS-4.8]
+/// For [`ProofInputs::JoinEq`] the private [`JoinWitness`] MUST be supplied via
+/// `join_witness` (obtained from [`crate::build::build_join`]); omitting it returns
+/// [`ProverTomlError::JoinEqMissingWitness`] — a recoverable error, never a panic
+/// (a public fn must not crash a downstream caller). The `join_witness` argument is
+/// ignored for every non-join input, exactly as `scan_*` is ignored for filters.
+/// [OPUS-4.8] sq-r2s8: the join_eq proving path is now implemented.
+#[allow(clippy::too_many_arguments)]
 pub fn prover_toml_for(
     inputs: &ProofInputs,
     challenge: &FieldHex,
@@ -222,6 +275,9 @@ pub fn prover_toml_for(
     scan_enc: &[Vec<[FieldHex; 3]>],
     // filter witness (ignored for scan): canonical decimal digits.
     filter_digits: &[u8],
+    // join witness (ignored for scan/filter): the join_eq member's private inputs
+    // (enc_a/counts_a/enc_b/counts_b/row_a/row_b/blinding). [OPUS-4.8] sq-r2s8.
+    join_witness: Option<&JoinWitness>,
 ) -> Result<(CircuitId, String), ProverTomlError> {
     let out = match inputs {
         ProofInputs::Scan {
@@ -293,17 +349,44 @@ pub fn prover_toml_for(
             );
             (id.clone(), toml)
         }
-        // [OPUS-4.8] sq-bwwl / sq-fi03 (step 3): hidden cross-credential JOIN.
-        // SCHEMA ONLY — this bead adds the manifest types, NOT the prover path.
-        // Generating a `join_eq` Prover.toml needs the join member's PRIVATE
-        // witnesses (`enc_a`/`counts_a`/`enc_b`/`counts_b`/`row_a`/`row_b`/
-        // `blinding`), none of which this function's `scan_*`/`filter_digits`
-        // parameters can carry — so the prover wiring is deferred to step 4
-        // (sq-sfsi), which extends the signature. Until then this arm returns a
-        // recoverable `Err` (NOT a panic): a public fn must not crash a downstream
-        // caller that loads a manifest containing `join_eq`. It also never emits a
-        // bogus witness; sq-sfsi replaces it with the real join TOML emitter.
-        ProofInputs::JoinEq { .. } => return Err(ProverTomlError::JoinEqUnsupported),
+        // [OPUS-4.8] sq-bwwl / sq-r2s8 (step 4 proving path): hidden cross-credential
+        // JOIN. The public inputs (commit_a/commit_b/join_commitment/slot_a/slot_b)
+        // come from `inputs`; the PRIVATE witnesses
+        // (enc_a/counts_a/enc_b/counts_b/row_a/row_b/blinding) come from the
+        // `join_witness` the caller built with `build_join`. Omitting it is a
+        // recoverable `Err` (no panic in a public fn). `enc_a`/`enc_b` are padded to
+        // the member's `n_a`/`n_b` buckets, exactly as the scan arm pads `enc`.
+        ProofInputs::JoinEq {
+            id,
+            commit_a,
+            commit_b,
+            join_commitment,
+            slot_a,
+            slot_b,
+        } => {
+            let CircuitId::JoinEq { n_a, n_b } = id else {
+                unreachable!("join_eq inputs carry a join_eq id")
+            };
+            let w = join_witness.ok_or(ProverTomlError::JoinEqMissingWitness)?;
+            let enc_a = pad_rows(w.enc_a.clone(), *n_a as usize);
+            let enc_b = pad_rows(w.enc_b.clone(), *n_b as usize);
+            let toml = join_prover_toml(
+                challenge,
+                commit_a,
+                commit_b,
+                join_commitment,
+                *slot_a,
+                *slot_b,
+                &enc_a,
+                w.counts_a,
+                &enc_b,
+                w.counts_b,
+                &w.row_a,
+                &w.row_b,
+                &w.blinding,
+            );
+            (id.clone(), toml)
+        }
     };
     Ok(out)
 }

--- a/crates/sparq-zk-compose/src/verifier.rs
+++ b/crates/sparq-zk-compose/src/verifier.rs
@@ -1335,6 +1335,17 @@ pub enum CheckError {
     /// that proved the equality over the wrong column (the salary-slot-for-age
     /// analogue, audit #6) is rejected fail-closed.
     JoinSlotMismatch { edge: usize },
+    /// [OPUS-4.8] sq-r2s8 (hidden JOIN, N-way chain — design §2.4): two declared
+    /// `JoinEdge`s join the SAME query variable (a multi-hop / N-way join chain),
+    /// but their `join_eq` sub-proofs carry DIFFERENT `join_commitment`s. The N-way
+    /// composition is sound only when every pairwise `join_eq` over the chained
+    /// variable binds the SAME hiding commitment (the prover uses one blinder), so
+    /// equality of the join VALUE composes transitively across the chain
+    /// (`a_val == b_val` per hop + a shared commitment). Distinct commitments mean
+    /// the hops proved equalities over potentially DIFFERENT values, so the claimed
+    /// N-way join is unproven — rejected fail-closed. `edge` is the first chained
+    /// edge whose commitment diverges from the chain's first edge.
+    JoinCommitmentChainMismatch { edge: usize },
     /// Subprocess / io failure (not a verification verdict).
     Driver(DriverError),
 }
@@ -1595,6 +1606,10 @@ impl std::fmt::Display for CheckError {
             CheckError::JoinSlotMismatch { edge } => write!(
                 f,
                 "join edge {edge}: the join_eq proof's public slot_a/slot_b do not equal the query-derived slots the shared join variable occupies (sq-sfsi §4.4 slot binding: the equality was proved over the wrong column — fail-closed)"
+            ),
+            CheckError::JoinCommitmentChainMismatch { edge } => write!(
+                f,
+                "join edge {edge}: an N-way join chain over a shared variable carries differing join_commitments across its pairwise join_eq proofs (sq-r2s8 §2.4: every hop of a multi-way join must bind the SAME hiding commitment so the join value composes transitively — distinct commitments leave the N-way join unproven, fail-closed)"
             ),
             CheckError::Driver(e) => write!(f, "{e}"),
         }
@@ -3179,6 +3194,13 @@ fn bind_joins(manifest: &ProofManifest) -> Result<(), CheckError> {
             .is_some_and(|(c, sp)| scan_matches_pattern(&sp.inputs, c))
     };
 
+    // For the N-way chain check (design §2.4): record, per edge that passes the
+    // slot binding, the SHARED join VARIABLE it binds and the join_eq proof's
+    // `join_commitment`. Two edges that join the SAME query variable form a multi-
+    // hop chain and MUST carry byte-equal commitments (enforced after the loop).
+    // [OPUS-4.8] sq-r2s8.
+    let mut chain: Vec<(String, FieldHex, usize)> = Vec::new();
+
     // --- (1)+(3a): per-edge commitment-matching + slot binding. ---
     for (e, edge) in manifest.join_edges.iter().enumerate() {
         // Resolve the three referenced sub-proofs (dangling => reject).
@@ -3208,9 +3230,9 @@ fn bind_joins(manifest: &ProofManifest) -> Result<(), CheckError> {
                 .ok_or(CheckError::JoinDanglingEdge { edge: e })?,
             _ => return Err(CheckError::JoinEdgeKindMismatch { edge: e }),
         };
-        let (commit_a_join, commit_b_join, slot_a, slot_b) = match &join.inputs {
-            ProofInputs::JoinEq { commit_a, commit_b, slot_a, slot_b, .. } => {
-                (commit_a, commit_b, *slot_a, *slot_b)
+        let (commit_a_join, commit_b_join, join_commitment, slot_a, slot_b) = match &join.inputs {
+            ProofInputs::JoinEq { commit_a, commit_b, join_commitment, slot_a, slot_b, .. } => {
+                (commit_a, commit_b, join_commitment, *slot_a, *slot_b)
             }
             _ => return Err(CheckError::JoinEdgeKindMismatch { edge: e }),
         };
@@ -3237,24 +3259,47 @@ fn bind_joins(manifest: &ProofManifest) -> Result<(), CheckError> {
         // multi-scan-safe: with two scans answering one pattern, the binding
         // validates against whichever scan the edge actually names, so it can
         // neither be spuriously rejected nor bound to the wrong scan.
-        let bound = patterns.iter().enumerate().any(|(pi, _)| {
+        // The shared variable the edge binds, if the slot binding holds (its NAME
+        // identifies the N-way chain this edge belongs to — design §2.4).
+        let join_var = patterns.iter().enumerate().find_map(|(pi, _)| {
             // pattern pi is answered by THE REFERENCED scan_a, slot_a is a var.
             if !pattern_answered_by_scan(pi, edge.scan_a) {
-                return false;
+                return None;
             }
-            let Some(var_a) = var_at(&var_slots, pi, slot_a as usize) else {
-                return false;
-            };
+            let var_a = var_at(&var_slots, pi, slot_a as usize)?;
             // The SAME variable occupies slot_b in some pattern answered by the
             // REFERENCED scan_b.
-            patterns.iter().enumerate().any(|(pj, _)| {
+            let shared = patterns.iter().enumerate().any(|(pj, _)| {
                 pj != pi
                     && pattern_answered_by_scan(pj, edge.scan_b)
                     && var_at(&var_slots, pj, slot_b as usize).as_deref() == Some(var_a.as_str())
-            })
+            });
+            shared.then_some(var_a)
         });
-        if !bound {
+        let Some(join_var) = join_var else {
             return Err(CheckError::JoinSlotMismatch { edge: e });
+        };
+        chain.push((join_var, join_commitment.clone(), e));
+    }
+
+    // --- (4) N-way chain commitment-equality (design §2.4). ---
+    // A query variable joined across MORE THAN TWO patterns is composed from
+    // several pairwise `join_eq` sub-proofs. The composition is sound only if every
+    // pairwise proof binds the SAME hiding `join_commitment` (the prover uses one
+    // blinder), so `a_val == b_val` per hop + the shared commitment compose into a
+    // transitive N-way equality WITHOUT disclosing the value. We group the bound
+    // edges by their join VARIABLE and require all `join_commitment`s in a group to
+    // byte-equal the group's first; a divergence means the hops proved equalities
+    // over potentially different values, so the N-way join is unproven. A single
+    // edge per variable (the 2-way case) trivially passes. [OPUS-4.8] sq-r2s8.
+    for (i, (var_i, commit_i, _)) in chain.iter().enumerate() {
+        // Compare against the FIRST edge sharing this variable (the chain anchor).
+        if let Some((_, anchor_commit, _)) =
+            chain.iter().take(i).find(|(v, _, _)| v == var_i)
+        {
+            if !field_hex_eq(commit_i, anchor_commit) {
+                return Err(CheckError::JoinCommitmentChainMismatch { edge: chain[i].2 });
+            }
         }
     }
 

--- a/crates/sparq-zk-compose/tests/audit_forge_map.rs
+++ b/crates/sparq-zk-compose/tests/audit_forge_map.rs
@@ -822,7 +822,7 @@ fn honest_filter_d1(
 ) -> (ProofInputs, ProofArtifacts) {
     let operand_enc = encode_int_literal(value);
     let (filter, digits) = build_filter_int(operand_enc, value, op, bound, expected).unwrap();
-    let (id, toml) = prover_toml_for(&filter, challenge, &[], &[], &digits).unwrap();
+    let (id, toml) = prover_toml_for(&filter, challenge, &[], &[], &digits, None).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).expect("filter proves");
     (filter, art)
@@ -840,7 +840,7 @@ fn honest_age_scan(challenge: &FieldHex, prover: &CircuitProver, tag: &str) -> (
     };
     let scan = build_scan(std::slice::from_ref(&commit), &pattern).expect("scan builds");
     let (id, toml) =
-        prover_toml_for(&scan.inputs, challenge, &scan.witness.counts, &scan.witness.enc, &[]).unwrap();
+        prover_toml_for(&scan.inputs, challenge, &scan.witness.counts, &scan.witness.enc, &[], None).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).expect("scan proves");
     (scan.inputs, encode_artifacts(&art))
@@ -1031,7 +1031,7 @@ fn finding_11_n_relabel_bb_rejected() {
         "#11 bb: the >16-slot graph must derive the scan_k2_n64_r8 member"
     );
     let (id, toml) =
-        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]).unwrap();
+        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[], None).unwrap();
     let out = scratch("f11bb");
     let art = prover.prove_in(&id, &toml, &out, "f11bb").expect("scan_k2_n64_r8 proves");
 

--- a/crates/sparq-zk-compose/tests/differential_fuzz.rs
+++ b/crates/sparq-zk-compose/tests/differential_fuzz.rs
@@ -327,7 +327,7 @@ fn run_differential(iters: u64, full_prove: bool) -> u64 {
             &challenge,
             &scan.witness.counts,
             &scan.witness.enc,
-            &[],
+            &[], None
         ).unwrap();
         let tag = format!("fuzz_scan_{i}");
         prover.compile(&scan_id).expect("scan compiles");
@@ -357,7 +357,7 @@ fn run_differential(iters: u64, full_prove: bool) -> u64 {
                     continue;
                 };
                 let (fid, ftoml) =
-                    prover_toml_for(&filter_inputs, &challenge, &[], &[], &digits).unwrap();
+                    prover_toml_for(&filter_inputs, &challenge, &[], &[], &digits, None).unwrap();
                 let ftag = format!("fuzz_filter_{i}");
                 prover.compile(&fid).expect("filter compiles");
 
@@ -380,7 +380,7 @@ fn run_differential(iters: u64, full_prove: bool) -> u64 {
                     continue;
                 };
                 let (lid, ltoml) =
-                    prover_toml_for(&lie_inputs, &challenge, &[], &[], &lie_digits).unwrap();
+                    prover_toml_for(&lie_inputs, &challenge, &[], &[], &lie_digits, None).unwrap();
                 let ltag = format!("fuzz_filter_lie_{i}");
                 let lie_witness = prover.gen_witness_tagged(&lid, &ltoml, &ltag);
                 assert!(
@@ -499,7 +499,7 @@ fn sq_wto_three_digit_operand_proves_not_silently_unprovable() {
     let (inputs, digits) = build_filter_int(operand_enc.clone(), value, op, bound, expected)
         .expect("3-digit FILTER must be in-family (sq-wto: d=3 member exists)");
     assert_eq!(*inputs.circuit_id(), CircuitId::FilterInt { d: 3 });
-    let (id, toml) = prover_toml_for(&inputs, &FieldHex("0x2a".into()), &[], &[], &digits).unwrap();
+    let (id, toml) = prover_toml_for(&inputs, &FieldHex("0x2a".into()), &[], &[], &digits, None).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).expect("filter_int_d3 compiles");
     prover
@@ -512,7 +512,7 @@ fn sq_wto_three_digit_operand_proves_not_silently_unprovable() {
     // 2) Soundness preserved: the FLIPPED verdict must be UNprovable.
     let (lie_inputs, lie_digits) =
         build_filter_int(operand_enc, value, op, bound, !expected).expect("builds");
-    let (lid, ltoml) = prover_toml_for(&lie_inputs, &FieldHex("0x2a".into()), &[], &[], &lie_digits).unwrap();
+    let (lid, ltoml) = prover_toml_for(&lie_inputs, &FieldHex("0x2a".into()), &[], &[], &lie_digits, None).unwrap();
     let lie = prover.gen_witness_tagged(&lid, &ltoml, "wto_d3_lie");
     assert!(
         lie.is_err(),

--- a/crates/sparq-zk-compose/tests/e2e.rs
+++ b/crates/sparq-zk-compose/tests/e2e.rs
@@ -504,7 +504,7 @@ fn witness_gen_filter_int_satisfiable() {
         &FieldHex("0x2a".into()),
         &[],
         &[],
-        &digits,
+        &digits, None
     ).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).expect("compiles");
@@ -526,7 +526,7 @@ fn witness_gen_filter_int_rejects_false_verdict() {
     let (filter, digits) =
         build_filter_int(operand_enc, 17, FilterOp::Ge, 18, true).unwrap();
     let (id, toml) =
-        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits).unwrap();
+        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits, None).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).unwrap();
     assert!(
@@ -550,7 +550,7 @@ fn witness_gen_filter_int_ne_satisfiable() {
     let (filter, digits) =
         build_filter_int(operand_enc, 30, FilterOp::Ne, 18, true).unwrap();
     let (id, toml) =
-        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits).unwrap();
+        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits, None).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).expect("compiles");
     prover
@@ -572,7 +572,7 @@ fn witness_gen_filter_int_ne_rejects_false_verdict() {
     let (filter, digits) =
         build_filter_int(operand_enc, 18, FilterOp::Ne, 18, true).unwrap();
     let (id, toml) =
-        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits).unwrap();
+        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits, None).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).unwrap();
     assert!(
@@ -600,7 +600,7 @@ fn witness_gen_scan_satisfiable() {
         &FieldHex("0x2a".into()),
         &scan.witness.counts,
         &scan.witness.enc,
-        &[],
+        &[], None
     ).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).expect("compiles");
@@ -623,7 +623,7 @@ fn full_prove_verify_filter_int_d1() {
     let (filter, digits) =
         build_filter_int(operand_enc, 5, FilterOp::Lt, 10, true).unwrap();
     let (id, toml) =
-        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits).unwrap();
+        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits, None).unwrap();
     assert_eq!(id, CircuitId::FilterInt { d: 1 });
 
     let prover = CircuitProver::from_crate_root();
@@ -660,7 +660,7 @@ fn full_prove_verify_filter_int_ne_d1() {
     let (filter, digits) =
         build_filter_int(operand_enc, 5, FilterOp::Ne, 9, true).unwrap();
     let (id, toml) =
-        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits).unwrap();
+        prover_toml_for(&filter, &FieldHex("0x2a".into()), &[], &[], &digits, None).unwrap();
     assert_eq!(id, CircuitId::FilterInt { d: 1 });
 
     let prover = CircuitProver::from_crate_root();
@@ -702,7 +702,7 @@ fn full_manifest_prove_verify_scan() {
         &challenge,
         &scan.witness.counts,
         &scan.witness.enc,
-        &[],
+        &[], None
     ).unwrap();
     let prover = CircuitProver::from_crate_root();
     let out = scratch("manifest_scan");
@@ -776,7 +776,7 @@ fn honest_filter_d1(
     let operand_enc = encode_int_literal(value);
     let (filter, digits) =
         build_filter_int(operand_enc, value, op, bound, expected).unwrap();
-    let (id, toml) = prover_toml_for(&filter, challenge, &[], &[], &digits).unwrap();
+    let (id, toml) = prover_toml_for(&filter, challenge, &[], &[], &digits, None).unwrap();
     assert_eq!(id, CircuitId::FilterInt { d: 1 });
     let out = scratch(tag);
     // [OPUS-4.8] tag-isolated prove: every forge test targets filter_int_d1, so
@@ -812,7 +812,7 @@ fn honest_age_scan(
         challenge,
         &scan.witness.counts,
         &scan.witness.enc,
-        &[],
+        &[], None
     ).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).expect("scan prove succeeds");
@@ -1919,7 +1919,7 @@ fn holder_pop_valid_verifies_end_to_end() {
         &challenge,
         &scan.witness.counts,
         &scan.witness.enc,
-        &[],
+        &[], None
     ).unwrap();
     let prover = CircuitProver::from_crate_root();
     let out = scratch("holder_pop_scan");
@@ -3483,7 +3483,7 @@ fn probe_scan_public_inputs_hex() {
     let scan = build_scan(&[commit], &pattern).unwrap();
     let challenge = FieldHex("0x2a".into());
     let (id, toml) =
-        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]).unwrap();
+        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[], None).unwrap();
     let prover = CircuitProver::from_crate_root();
     let out = scratch("probe_scan_pi");
     let art = prover.prove_in(&id, &toml, &out, "probe_scan_pi").unwrap();
@@ -3515,7 +3515,7 @@ fn probe_filter_f64_public_inputs_hex() {
         build_filter_f64(operand_enc, value, FilterOp::Ge, 18.0_f64, true).expect("d2 builds");
     assert_eq!(*inputs.circuit_id(), CircuitId::FilterF64 { d: 2 });
     let challenge = FieldHex("0x2a".into());
-    let (id, toml) = prover_toml_for(&inputs, &challenge, &[], &[], &digits).unwrap();
+    let (id, toml) = prover_toml_for(&inputs, &challenge, &[], &[], &digits, None).unwrap();
     let prover = CircuitProver::from_crate_root();
     let out = scratch("probe_filter_f64_pi");
     let art = prover.prove_in(&id, &toml, &out, "probe_filter_f64_pi").unwrap();
@@ -3567,7 +3567,7 @@ fn probe_scan_k2_public_inputs_hex() {
     );
     let challenge = FieldHex("0x2a".into());
     let (id, toml) =
-        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]).unwrap();
+        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[], None).unwrap();
     let prover = CircuitProver::from_crate_root();
     let out = scratch("probe_scan_k2_pi");
     let art = prover.prove_in(&id, &toml, &out, "probe_scan_k2_pi").unwrap();
@@ -4110,7 +4110,7 @@ fn hidden_scan_manifest(prover: &CircuitProver, tag: &str) -> (ProofManifest, Fr
         &challenge,
         &scan.witness.counts,
         &scan.witness.enc,
-        &[],
+        &[], None
     ).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).unwrap();
@@ -4479,7 +4479,7 @@ fn hi_scan_manifest(prover: &CircuitProver, signer_sk: &SecretKey, tag: &str) ->
     };
     let scan = build_scan(&[commit], &pattern).unwrap();
     let challenge = FieldHex("0x2a".into());
-    let (id, toml) = prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]).unwrap();
+    let (id, toml) = prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[], None).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).unwrap();
     let mut manifest = ProofManifest {
@@ -4654,7 +4654,7 @@ fn hi_scan_manifest_no_clear_attestation(
     let scan = build_scan(&[commit], &pattern).unwrap();
     let challenge = FieldHex("0x2a".into());
     let (id, toml) =
-        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[]).unwrap();
+        prover_toml_for(&scan.inputs, &challenge, &scan.witness.counts, &scan.witness.enc, &[], None).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).unwrap();
     let manifest = ProofManifest {
@@ -4951,7 +4951,7 @@ fn filter_f64_witness_honest_proves_lie_rejected() {
         build_filter_f64(operand_enc.clone(), value, FilterOp::Ge, bound, true)
             .expect("25.0 >= 18.0 builds (d=2 member)");
     assert_eq!(*inputs.circuit_id(), CircuitId::FilterF64 { d: 2 });
-    let (id, toml) = prover_toml_for(&inputs, &FieldHex("0x2a".into()), &[], &[], &digits).unwrap();
+    let (id, toml) = prover_toml_for(&inputs, &FieldHex("0x2a".into()), &[], &[], &digits, None).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).expect("filter_f64_d2 compiles");
     prover
@@ -4961,7 +4961,7 @@ fn filter_f64_witness_honest_proves_lie_rejected() {
     // The FLIPPED verdict (false) must be UNprovable — soundness.
     let (lie_inputs, lie_digits) =
         build_filter_f64(operand_enc, value, FilterOp::Ge, bound, false).expect("builds");
-    let (lid, ltoml) = prover_toml_for(&lie_inputs, &FieldHex("0x2a".into()), &[], &[], &lie_digits).unwrap();
+    let (lid, ltoml) = prover_toml_for(&lie_inputs, &FieldHex("0x2a".into()), &[], &[], &lie_digits, None).unwrap();
     let lie = prover.gen_witness_tagged(&lid, &ltoml, "f64_lie");
     assert!(
         lie.is_err(),
@@ -4989,7 +4989,7 @@ fn filter_f64_operand_binding_rejects_substituted_value() {
     // Force the operand_enc to the committed 25's encoding while the digits witness
     // says 99 (build_filter_f64 already set operand_enc to the passed value; here we
     // pass operand_enc_25 but value=99 so the digit witness is "99").
-    let (id, toml) = prover_toml_for(&inputs, &FieldHex("0x2a".into()), &[], &[], b"99").unwrap();
+    let (id, toml) = prover_toml_for(&inputs, &FieldHex("0x2a".into()), &[], &[], b"99", None).unwrap();
     let prover = CircuitProver::from_crate_root();
     prover.compile(&id).expect("compiles");
     let res = prover.gen_witness_tagged(&id, &toml, "f64_subst");
@@ -5031,7 +5031,7 @@ fn filter_f64_composes_end_to_end() {
         &challenge,
         &scan.witness.counts,
         &scan.witness.enc,
-        &[],
+        &[], None
     ).unwrap();
     let scan_out = scratch("f64_compose_scan");
     let scan_art = prover.prove_in(&scan_id, &scan_toml, &scan_out, "f64_compose_scan").unwrap();
@@ -5046,7 +5046,7 @@ fn filter_f64_composes_end_to_end() {
     // Prove the composable float-FILTER sub-proof: ?score >= 18.0 (true).
     let (filter_inputs, fdigits) =
         build_filter_f64(operand_enc, score, FilterOp::Ge, 18.0, true).expect("filter builds");
-    let (fid, ftoml) = prover_toml_for(&filter_inputs, &challenge, &[], &[], &fdigits).unwrap();
+    let (fid, ftoml) = prover_toml_for(&filter_inputs, &challenge, &[], &[], &fdigits, None).unwrap();
     let f_out = scratch("f64_compose_filter");
     let filter_art = prover.prove_in(&fid, &ftoml, &f_out, "f64_compose_filter").unwrap();
 

--- a/crates/sparq-zk-compose/tests/forge_gates.rs
+++ b/crates/sparq-zk-compose/tests/forge_gates.rs
@@ -496,7 +496,7 @@ fn honest_filter_d1(
 ) -> (ProofInputs, ProofArtifacts) {
     let operand_enc = encode_int_literal(value);
     let (filter, digits) = build_filter_int(operand_enc, value, op, bound, expected).unwrap();
-    let (id, toml) = prover_toml_for(&filter, challenge, &[], &[], &digits).unwrap();
+    let (id, toml) = prover_toml_for(&filter, challenge, &[], &[], &digits, None).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).expect("filter proves");
     (filter, art)
@@ -514,7 +514,7 @@ fn honest_age_scan(challenge: &FieldHex, prover: &CircuitProver, tag: &str) -> (
         o: Slot::Var,
     };
     let scan = build_scan(std::slice::from_ref(&commit), &pattern).expect("scan builds");
-    let (id, toml) = prover_toml_for(&scan.inputs, challenge, &scan.witness.counts, &scan.witness.enc, &[]).unwrap();
+    let (id, toml) = prover_toml_for(&scan.inputs, challenge, &scan.witness.counts, &scan.witness.enc, &[], None).unwrap();
     let out = scratch(tag);
     let art = prover.prove_in(&id, &toml, &out, tag).expect("scan proves");
     (scan.inputs, encode_artifacts(&art))
@@ -845,7 +845,7 @@ fn forge_scan_duplicate_commitment_circuit_rejected() {
         &challenge,
         &scan.witness.counts,
         &scan.witness.enc,
-        &[],
+        &[], None
     ).unwrap();
     // The in-circuit `commitments[0] < commitments[1]` (= `c0 < c0`) is FALSE, so
     // the relation is unsatisfiable: nargo writes no witness => Err.
@@ -882,7 +882,7 @@ fn honest_k2_distinct_scan_proves_and_verifies() {
         &challenge,
         &scan.witness.counts,
         &scan.witness.enc,
-        &[],
+        &[], None
     ).unwrap();
     let out = scratch("honest_k2_distinct_prove");
     let art = prover

--- a/crates/sparq-zk-compose/tests/host_helpers.rs
+++ b/crates/sparq-zk-compose/tests/host_helpers.rs
@@ -159,12 +159,13 @@ fn canonical_digits_are_ascii_byte_codes() {
     }
 }
 
-// [OPUS-4.8] sq-fi03 / PR #178: `prover_toml_for` is a public fn whose `join_eq`
-// arm is deferred to sq-sfsi. It must return a recoverable `Err` (NOT panic via
-// `unimplemented!`) so a downstream caller loading a manifest with `join_eq` gets
-// a structured failure rather than a crash.
+// [OPUS-4.8] sq-fi03 / PR #178 / sq-r2s8: `prover_toml_for` is a public fn whose
+// `join_eq` arm now emits a real witness — BUT only when the private `JoinWitness`
+// is supplied. A `JoinEq` input with NO `join_witness` must return a recoverable
+// `Err` (NOT panic via `unimplemented!`) so a downstream caller loading a manifest
+// with `join_eq` gets a structured failure rather than a crash.
 #[test]
-fn prover_toml_for_join_eq_returns_err_not_panic() {
+fn prover_toml_for_join_eq_without_witness_returns_err_not_panic() {
     let inputs = ProofInputs::JoinEq {
         id: CircuitId::JoinEq { n_a: 16, n_b: 16 },
         commit_a: fh("0x0a"),
@@ -173,11 +174,11 @@ fn prover_toml_for_join_eq_returns_err_not_panic() {
         slot_a: 0,
         slot_b: 2,
     };
-    let res = prover_toml_for(&inputs, &fh("0xchal"), &[], &[], &[]);
+    let res = prover_toml_for(&inputs, &fh("0xchal"), &[], &[], &[], None);
     assert_eq!(
         res,
-        Err(ProverTomlError::JoinEqUnsupported),
-        "join_eq prover toml is deferred (sq-sfsi) and must fail gracefully"
+        Err(ProverTomlError::JoinEqMissingWitness),
+        "join_eq prover toml without a witness must fail gracefully (no panic)"
     );
 }
 
@@ -190,7 +191,7 @@ fn prover_toml_for_filter_int_uses_op_code_and_digits() {
         bound: 7,
         expected: false,
     };
-    let (id, toml) = prover_toml_for(&inputs, &fh("0xchal"), &[], &[], b"7").unwrap();
+    let (id, toml) = prover_toml_for(&inputs, &fh("0xchal"), &[], &[], b"7", None).unwrap();
     assert_eq!(id, CircuitId::FilterInt { d: 1 });
     assert!(toml.contains("op = \"5\"\n"), "FilterOp::Ne code is 5");
     assert!(toml.contains("bound = \"7\"\n"));
@@ -208,7 +209,7 @@ fn prover_toml_for_filter_f64_uses_b_bits() {
         b_bits: bits,
         expected: true,
     };
-    let (id, toml) = prover_toml_for(&inputs, &fh("0xchal"), &[], &[], b"18").unwrap();
+    let (id, toml) = prover_toml_for(&inputs, &fh("0xchal"), &[], &[], b"18", None).unwrap();
     assert_eq!(id, CircuitId::FilterF64 { d: 2 });
     assert!(toml.contains(&format!("b_bits = \"{bits}\"\n")));
     assert!(toml.contains("op = \"1\"\n"), "FilterOp::Le code is 1");
@@ -232,7 +233,7 @@ fn prover_toml_for_scan_pads_rows_and_enc_to_circuit_dimensions() {
         [fh("0xe00"), fh("0xe01"), fh("0xe02")],
         [fh("0xe10"), fh("0xe11"), fh("0xe12")],
     ]];
-    let (id, toml) = prover_toml_for(&inputs, &fh("0xchal"), &[2], &scan_enc, &[]).unwrap();
+    let (id, toml) = prover_toml_for(&inputs, &fh("0xchal"), &[2], &scan_enc, &[], None).unwrap();
     assert_eq!(id, CircuitId::Scan { k: 1, n: 3, r: 2 });
     // rows padded from 1 -> 2 (the second row is the zero row).
     assert!(

--- a/crates/sparq-zk-compose/tests/join_gates.rs
+++ b/crates/sparq-zk-compose/tests/join_gates.rs
@@ -542,7 +542,10 @@ fn chain_manifest(shared_commitment: bool) -> ProofManifest {
         *join_commitment = if shared_commitment {
             shared.clone()
         } else {
-            FieldHex("0xdiff".to_string())
+            // Valid but DIFFERENT field element from `shared` (0x0c): the
+            // rejection is specifically due to divergent commitments, not a
+            // malformed-hex parse failure.
+            FieldHex("0xdeadbeef".to_string())
         };
     }
 

--- a/crates/sparq-zk-compose/tests/join_gates.rs
+++ b/crates/sparq-zk-compose/tests/join_gates.rs
@@ -47,7 +47,7 @@ use sparq_zk::commit::{commit_triples, GraphCommitment};
 use sparq_zk::encode::salt_from_bytes;
 use sparq_zk::field::Fr;
 use sparq_zk::sig::{public_key_to_hex, SecretKey, SignatureScheme};
-use sparq_zk_compose::build::{build_scan, Pattern, Slot};
+use sparq_zk_compose::build::{build_join, build_scan, Pattern, Slot};
 use sparq_zk_compose::manifest::{
     AttestedStatusRef, BindingMode, CircuitId, CommitmentAttestation, EntailmentRegime, FieldHex,
     JoinEdge, ProofInputs, ProofManifest, RevocationStatus, StatusListSnapshot, SubProof,
@@ -482,6 +482,133 @@ fn drop_edge_falls_back_to_disclosed_path() {
     );
 }
 
+// === N-WAY CHAIN: shared-commitment composition (design §2.4) ================
+//
+// [OPUS-4.8] sq-r2s8: a query variable joined across MORE THAN TWO patterns is
+// composed from several pairwise `join_eq` sub-proofs. The composition is sound
+// only if every pairwise proof binds the SAME hiding `join_commitment` (one
+// blinder), so `a_val == b_val` per hop + the shared commitment compose into a
+// transitive N-way equality. `bind_joins` now enforces this: edges joining the
+// SAME query variable must carry byte-equal `join_commitment`s.
+
+// Graph C: `<ex/p> <ex/city> <ex/london>` — a THIRD credential sharing `<ex/p>` at
+// the SUBJECT (slot 0). Joins `?p` across a third pattern, forming a 3-way chain.
+fn graph_c() -> GraphCommitment {
+    let g = vec![Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/p")),
+        iri("http://ex/city"),
+        Term::NamedNode(iri("http://ex/london")),
+    )];
+    commit_triples(&g, salt_from_bytes(&[34u8; 32])).unwrap()
+}
+
+const CHAIN_QUERY: &str = "SELECT ?a ?p ?o ?c WHERE { \
+    ?a <http://ex/knows> ?p . ?p <http://ex/age> ?o . ?p <http://ex/city> ?c }";
+const SLOT_C: u32 = 0; // ?p is the SUBJECT of `?p <ex/city> ?c`
+
+/// The scan over pattern C (`?p <ex/city> ?c`).
+fn scan_c_inputs(c: &GraphCommitment) -> ProofInputs {
+    scan_inputs(c, Pattern {
+        s: Slot::Var,
+        p: Slot::Const(Term::NamedNode(iri("http://ex/city"))),
+        o: Slot::Var,
+    })
+}
+
+/// A 3-way join manifest over `?p` shared across patterns A, B, C. Two hidden join
+/// edges: (scan_a, scan_b) and (scan_b, scan_c), BOTH joining `?p`. With
+/// `shared_commitment = true` both join_eq sub-proofs carry the SAME
+/// `join_commitment` (the honest N-way construction); with `false` the second hop
+/// carries a DIFFERENT commitment (the chain-forge). sub_proofs =
+/// [scan_a, scan_b, scan_c, join_ab, join_bc].
+fn chain_manifest(shared_commitment: bool) -> ProofManifest {
+    let (ga, gb, gc) = (graph_a(), graph_b(), graph_c());
+    let scan_a = scan_a_inputs(&ga);
+    let scan_b = scan_b_inputs(&gb);
+    let scan_c = scan_c_inputs(&gc);
+    let commit_a = commitment_hex(&scan_a);
+    let commit_b = commitment_hex(&scan_b);
+    let commit_c = commitment_hex(&scan_c);
+
+    // Hop 1: A.object(2) == B.subject(0). Hop 2: B.subject(0) == C.subject(0).
+    let mut join_ab = join_eq_inputs(commit_a, commit_b.clone(), SLOT_A, SLOT_B);
+    let mut join_bc = join_eq_inputs(commit_b, commit_c, SLOT_B, SLOT_C);
+    // Honest N-way: both hops bind the SAME hiding commitment. Forge: hop 2 differs.
+    let shared = FieldHex("0x0c".to_string());
+    if let ProofInputs::JoinEq { join_commitment, .. } = &mut join_ab {
+        *join_commitment = shared.clone();
+    }
+    if let ProofInputs::JoinEq { join_commitment, .. } = &mut join_bc {
+        *join_commitment = if shared_commitment {
+            shared.clone()
+        } else {
+            FieldHex("0xdiff".to_string())
+        };
+    }
+
+    let sk = test_issuer_sk(1);
+    ProofManifest {
+        r#type: "urn:sparq:zk:ProofManifest".into(),
+        query: CHAIN_QUERY.into(),
+        issuers: vec![],
+        key_set: vec![public_key_to_hex(&sk.public_key())],
+        commitment_attestations: vec![
+            attest_full(ga.commitment, ga.salt, &sk),
+            attest_full(gb.commitment, gb.salt, &sk),
+            attest_full(gc.commitment, gc.salt, &sk),
+        ],
+        attributions: vec![vec![0], vec![0], vec![0]],
+        join_obligations: vec![],
+        entailment_regime: EntailmentRegime::Simple,
+        derivation_steps: vec![],
+        binding: BindingMode::Challenge { challenge: FieldHex(CHALLENGE_HEX.into()) },
+        revocation: Some(fixture_revocation()),
+        status_snapshots: vec![fixture_snapshot()],
+        sub_proofs: vec![
+            SubProof { inputs: scan_a, proof_hex: String::new() },
+            SubProof { inputs: scan_b, proof_hex: String::new() },
+            SubProof { inputs: scan_c, proof_hex: String::new() },
+            SubProof { inputs: join_ab, proof_hex: String::new() },
+            SubProof { inputs: join_bc, proof_hex: String::new() },
+        ],
+        binding_edges: vec![],
+        join_edges: vec![
+            JoinEdge { scan_a: 0, graph_a: 0, scan_b: 1, graph_b: 0, join_proof: 3 },
+            JoinEdge { scan_a: 1, graph_a: 0, scan_b: 2, graph_b: 0, join_proof: 4 },
+        ],
+        hidden_revocation: None,
+        hidden_issuer_attestations: vec![],
+    }
+}
+
+/// A 3-way join chain over `?p` whose two pairwise join_eq sub-proofs bind the SAME
+/// hiding commitment passes the structural `bind_joins` gate — the honest N-way
+/// composition (design §2.4). [OPUS-4.8] sq-r2s8.
+#[test]
+fn nway_chain_shared_commitment_passes() {
+    let m = chain_manifest(true);
+    prefilter(&m).expect(
+        "an N-way join chain whose pairwise hops bind the SAME join_commitment must pass bind_joins",
+    );
+}
+
+/// A 3-way join chain over `?p` whose second hop binds a DIFFERENT `join_commitment`
+/// is REJECTED (`JoinCommitmentChainMismatch`): the hops may have proved equalities
+/// over different values, so the claimed N-way join is unproven. This is the
+/// soundness obligation N-way composition adds over independent pairwise joins.
+/// [OPUS-4.8] sq-r2s8.
+#[test]
+fn nway_chain_divergent_commitment_rejected() {
+    let m = chain_manifest(false);
+    match prefilter(&m) {
+        Err(CheckError::JoinCommitmentChainMismatch { edge: 1 }) => {}
+        other => panic!(
+            "an N-way chain with a divergent join_commitment must be \
+             JoinCommitmentChainMismatch on edge 1, got {other:?}"
+        ),
+    }
+}
+
 // === REJECT 3: spurious / wrong-slot hidden join (anti-spurious, §4.4) =======
 
 /// Forge: the JoinEdge binds the right scans but its join_eq's slots don't match
@@ -552,18 +679,188 @@ fn forge_join_scan_a_not_scan_rejected() {
     }
 }
 
-// === ACCEPT (FULL bb path) — deferred join_eq proving ========================
+// === ACCEPT (FULL bb path) — REAL join_eq proof end-to-end ===================
+//
+// [OPUS-4.8] sq-r2s8: the join_eq PROVING path (`build_join` + `prover_toml_for`'s
+// JoinEq arm) now produces a real bb proof, so this test — previously
+// `#[ignore]`'d as `full_bb_join_accept_deferred` because no real join_eq proof
+// could be generated — now generates one and asserts it VERIFIES end-to-end
+// through `verify_manifest`: public-input reconstruction (audit #1), CANONICAL VK
+// by `CircuitId::JoinEq` (audit #2, enforcement point 2 — proved end-to-end with a
+// genuine proof), bb verify, the nonce binding (audit #4), AND the `bind_joins`
+// structural gate. The two scan sub-proofs ALSO carry real bb proofs (verify_manifest
+// verifies every sub-proof), so this is a faithful 3-proof composed manifest.
+//
+// TIER: this is the heavy toolchain/nightly lane — THREE real bb proves (two scans +
+// the join). It is `#[ignore]`'d so it does NOT run on the per-PR fast path, exactly
+// like `full_manifest_prove_verify_scan` in `e2e.rs`. It RUNS in the zk-toolchain /
+// nightly lane via `cargo nextest run -p sparq-zk-compose --run-ignored all`
+// (or `cargo test -- --ignored`) on a box with `nargo`+`bb`. The SECURITY-CRITICAL
+// reject paths above run WITHOUT the toolchain on every PR.
 
-/// Canonical-VK / public-input / nonce binding ACCEPT over a REAL `join_eq` bb
-/// proof. DEFERRED: `prover_toml_for`'s JoinEq arm returns `Err` (sq-fi03 left the
-/// join_eq proving path out of scope), so this suite cannot produce a real join_eq
-/// proof in-test. Enforcement point 2 (canonical VK) is therefore not exercised
-/// end-to-end here. Marked `#[ignore]` until the join_eq proving path lands; the
-/// reject paths above (the security-critical direction) are fully exercised
-/// without it. Tracked: sq-r2s8 (join_eq proving path + this full-bb accept).
+use sparq_zk::field::field_from_hex_str;
+use sparq_zk_compose::driver::CircuitProver;
+use sparq_zk_compose::toml::prover_toml_for;
+use sparq_zk_compose::verifier::{
+    verify_manifest, encode_artifacts, EntailmentPolicy, HolderBindingPolicy, HolderRegistry,
+    InMemorySeenNonces, VerifierNonce,
+};
+
+fn toolchain_available() -> bool {
+    fn on_path(tool: &str) -> bool {
+        std::process::Command::new(tool)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+    on_path("nargo") && on_path("bb")
+}
+
+fn scratch(name: &str) -> std::path::PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("sparq_zk_compose_join_{name}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn nonce_for(hex: &str) -> VerifierNonce {
+    VerifierNonce::from_hex(hex).expect("parseable nonce")
+}
+
+/// REAL full-bb ACCEPT: a genuine `join_eq` proof (plus the two genuine scan
+/// proofs) verifies end-to-end through `verify_manifest`. Replaces the previously
+/// `#[ignore]`d-EMPTY `full_bb_join_accept_deferred` with an actual proof. Proves
+/// enforcement point 2 (canonical VK, audit #2) end-to-end for the join member.
 #[test]
-#[ignore = "join_eq proving path deferred (sq-fi03 prover_toml_for JoinEq => Err); sq-r2s8 implements build_join/prover_toml_for + un-ignores this for a real bb accept"]
-fn full_bb_join_accept_deferred() {
-    // Intentionally empty: documents the missing accept-proof capability honestly
-    // rather than asserting a property we cannot exercise.
+#[ignore = "heavy toolchain/nightly lane: THREE real bb proves (two scans + the join_eq). \
+            Runs via `cargo nextest run -p sparq-zk-compose --run-ignored all` (or \
+            `cargo test -- --ignored`) on a box with nargo+bb; sq-r2s8."]
+fn full_bb_join_accept_real_proof() {
+    if !toolchain_available() {
+        eprintln!("nargo/bb absent; skipping full-bb join accept");
+        return;
+    }
+
+    let challenge = FieldHex(CHALLENGE_HEX.into());
+    let prover = CircuitProver::from_crate_root();
+
+    // The two committed credentials (same fixtures the structural suite uses): A
+    // holds `<ex/a> <ex/knows> <ex/p>` (join key at OBJECT, slot 2); B holds
+    // `<ex/p> <ex/age> "30"` (join key at SUBJECT, slot 0).
+    let ga = graph_a();
+    let gb = graph_b();
+
+    // --- scan A (real proof) ---
+    let pattern_a = Pattern {
+        s: Slot::Var,
+        p: Slot::Const(Term::NamedNode(iri("http://ex/knows"))),
+        o: Slot::Var,
+    };
+    let scan_a = build_scan(std::slice::from_ref(&ga), &pattern_a).expect("scan A builds");
+    let (sa_id, sa_toml) = prover_toml_for(
+        &scan_a.inputs,
+        &challenge,
+        &scan_a.witness.counts,
+        &scan_a.witness.enc,
+        &[],
+        None,
+    )
+    .expect("scan A toml");
+    let sa_art = prover
+        .prove_in(&sa_id, &sa_toml, &scratch("scan_a"), "join_scan_a")
+        .expect("scan A proves");
+
+    // --- scan B (real proof) ---
+    let pattern_b = Pattern {
+        s: Slot::Var,
+        p: Slot::Const(Term::NamedNode(iri("http://ex/age"))),
+        o: Slot::Var,
+    };
+    let scan_b = build_scan(std::slice::from_ref(&gb), &pattern_b).expect("scan B builds");
+    let (sb_id, sb_toml) = prover_toml_for(
+        &scan_b.inputs,
+        &challenge,
+        &scan_b.witness.counts,
+        &scan_b.witness.enc,
+        &[],
+        None,
+    )
+    .expect("scan B toml");
+    let sb_art = prover
+        .prove_in(&sb_id, &sb_toml, &scratch("scan_b"), "join_scan_b")
+        .expect("scan B proves");
+
+    // --- join_eq (real proof) — the headline path under test. ---
+    // A fixed (test-only) blinder; production draws it per-presentation.
+    let blinding = field_from_hex_str("0x1234abcd").expect("blinder parses");
+    let built_join =
+        build_join(&ga, SLOT_A, &gb, SLOT_B, blinding).expect("honest join builds (shared <ex/p>)");
+    let (j_id, j_toml) = prover_toml_for(
+        &built_join.inputs,
+        &challenge,
+        &[],
+        &[],
+        &[],
+        Some(&built_join.witness),
+    )
+    .expect("join toml emits with the witness");
+    assert_eq!(j_id, CircuitId::JoinEq { n_a: 16, n_b: 16 });
+    let j_art = prover
+        .prove_in(&j_id, &j_toml, &scratch("join_eq"), "join_eq")
+        .expect("join_eq proves (the relation is satisfiable for a real join)");
+    assert!(!j_art.proof.is_empty(), "join_eq produced a non-empty proof");
+
+    // The join's public commit_a/commit_b MUST equal the two scans' commitments
+    // (the bind_joins anti-A2 binding) — they do, because build_join read them from
+    // the SAME GraphCommitments build_scan committed.
+    assert_eq!(commitment_hex(&scan_a.inputs), match &built_join.inputs {
+        ProofInputs::JoinEq { commit_a, .. } => commit_a.clone(),
+        _ => unreachable!(),
+    });
+
+    // --- assemble the full manifest with REAL proofs on every sub-proof. ---
+    let sk = test_issuer_sk(1);
+    let manifest = ProofManifest {
+        r#type: "urn:sparq:zk:ProofManifest".into(),
+        query: JOIN_QUERY.into(),
+        issuers: vec![],
+        key_set: vec![public_key_to_hex(&sk.public_key())],
+        commitment_attestations: vec![
+            attest_full(ga.commitment, ga.salt, &sk),
+            attest_full(gb.commitment, gb.salt, &sk),
+        ],
+        attributions: vec![vec![0], vec![0]],
+        join_obligations: vec![],
+        entailment_regime: EntailmentRegime::Simple,
+        derivation_steps: vec![],
+        binding: BindingMode::Challenge { challenge: challenge.clone() },
+        revocation: Some(fixture_revocation()),
+        status_snapshots: vec![fixture_snapshot()],
+        sub_proofs: vec![
+            SubProof { inputs: scan_a.inputs, proof_hex: encode_artifacts(&sa_art) },
+            SubProof { inputs: scan_b.inputs, proof_hex: encode_artifacts(&sb_art) },
+            SubProof { inputs: built_join.inputs, proof_hex: encode_artifacts(&j_art) },
+        ],
+        binding_edges: vec![],
+        join_edges: vec![JoinEdge { scan_a: 0, graph_a: 0, scan_b: 1, graph_b: 0, join_proof: 2 }],
+        hidden_revocation: None,
+        hidden_issuer_attestations: vec![],
+    };
+    // The verifier nonce that all three proofs committed (CHALLENGE_HEX) is bound
+    // as field 0 of every sub-proof by the audit-#1 reconstruction.
+    verify_manifest(
+        &manifest,
+        &prover,
+        &scratch("verify"),
+        &trusted_k(&sk),
+        &fresh_policy(),
+        &HolderRegistry::empty(),
+        &HolderBindingPolicy::allow_bearer(),
+        &EntailmentPolicy::simple_only(),
+        &nonce_for(CHALLENGE_HEX),
+        &InMemorySeenNonces::new(),
+    )
+    .expect("a real join_eq proof (canonical VK + pubinput + bb verify + bind_joins) must verify");
 }

--- a/crates/sparq-zk-compose/tests/verifier_errors.rs
+++ b/crates/sparq-zk-compose/tests/verifier_errors.rs
@@ -94,6 +94,11 @@ fn check_error_display_covers_structural_reject_reasons() {
         &CheckError::JoinSlotMismatch { edge: 5 },
         &["join edge", "5", "slot"],
     );
+    // [OPUS-4.8] sq-r2s8: N-way join chain commitment-equality reject reason.
+    assert_display_carries(
+        &CheckError::JoinCommitmentChainMismatch { edge: 6 },
+        &["join edge", "6", "N-way"],
+    );
 }
 
 #[test]


### PR DESCRIPTION
> 🤖 SPARQ agent

Completes the hidden cross-credential JOIN end-to-end (epic sq-bwwl, bead **sq-r2s8**): the `join_eq` **PROVING path** that sq-fi03 (#178) left as an `Err`, plus the full-bb accept the sq-sfsi (#183) `bind_joins` suite had `#[ignore]`'d because no real `join_eq` proof could be generated yet.

## `build_join` helper
`build::build_join(commit_a, slot_a, commit_b, slot_b, blinding)` assembles the join_eq witness (`enc_a`/`counts_a`/`enc_b`/`counts_b`/`row_a`/`row_b`/`blinding`) from the two `GraphCommitment`s and the two query-bound slots — mirroring the `build_scan` build_* pattern. It re-encodes each graph's canonical triples under its recorded salt (the in-circuit `commit_fold` recompute reproduces `C(G)`, so the re-derivation is sound by construction), locates the shared-value row pair, and binds that hidden value under a per-presentation blinder into the public hiding `join_commitment` (single source of truth with `sparq_zk::sig::join_value_commitment`). The join VALUE and both rows stay PRIVATE.

## `prover_toml_for` JoinEq arm
Replaces the `Err` with real witness-bearing TOML emission via the new `toml::join_prover_toml` (PUBLIC `challenge, commit_a, commit_b, join_commitment, slot_a, slot_b` then PRIVATE `enc_a, counts_a, enc_b, counts_b, row_a, row_b, blinding`, in `main` declaration order; `enc_a`/`enc_b` padded to the member buckets exactly as the scan arm pads `enc`). A `JoinEq` input passed WITHOUT its `JoinWitness` returns the recoverable `ProverTomlError::JoinEqMissingWitness` (no panic in a public fn). The function gains a trailing `join_witness: Option<&JoinWitness>` param; all non-join callers pass `None`.

## Full-bb accept (enforcement point 2, end-to-end)
`full_bb_join_accept_real_proof` (was the `#[ignore]`d-empty `full_bb_join_accept_deferred`) now generates a **REAL** `join_eq` bb proof — plus the two real scan proofs — and asserts it verifies end-to-end through `verify_manifest`: audit-#1 public-input reconstruction, audit-#2 **CANONICAL VK** by `CircuitId::JoinEq` (**enforcement point 2, proved end-to-end with a genuine proof**), bb verify, audit-#4 nonce binding, AND the `bind_joins` structural gate.

**Tier:** `#[ignore]`'d off the per-PR fast path (heavy — three real bb proves), runs in the zk-toolchain/nightly lane via `cargo nextest run -p sparq-zk-compose --run-ignored all` (or `cargo test -- --ignored`) on a box with `nargo`+`bb`, exactly like `full_manifest_prove_verify_scan`. **Confirmed RUNS + PASSES** with `nargo 1.0.0-beta.21` + `bb 5.0.0-nightly`.

## N-way chain — LANDED (design §2.4)
`bind_joins` now enforces N-way chain composition: `JoinEdge`s joining the **same** query variable (a multi-hop chain) must carry **byte-equal** `join_commitment`s, else `JoinCommitmentChainMismatch` (fail-closed). This makes the per-hop `a_val == b_val` + the shared hiding commitment compose into a transitive N-way join without disclosing the value. Structural tests added: honest 3-way shared-commitment ACCEPT + divergent-commitment REJECT. (Not beaded — landed here.)

## Verification
- `cargo build` (workspace) + `cargo clippy -p sparq-zk-compose --all-targets -- -D warnings` clean.
- `cargo nextest run -p sparq-zk-compose`: **236 passed, 30 skipped**.
- Un-ignored full-bb accept: **1 passed** with a real proof (toolchain lane).
- NON-CANONICAL timing (work box).

References sq-r2s8, sq-bwwl, sq-fi03 (#178), sq-sfsi (#183).