### PR TITLE
feat(sparq-mpc): batched/vector secret sharing + row-binding (sq-dwb5)

### DIFF
--- a/crates/sparq-mpc/src/backend.rs
+++ b/crates/sparq-mpc/src/backend.rs
@@ -733,13 +733,17 @@ pub trait MpcBackend {
     /// secure aggregate / hidden-value join can range over many rows per holder.
     ///
     /// **Row-binding contract.** The binding is POSITIONAL: every holder evaluates
-    /// the SAME `fragment` projecting one integer column, ordered DETERMINISTICALLY
-    /// (the implementation sorts the holder's rows by their disclosed value so two
-    /// holders' batches line up by position regardless of local row order — see
-    /// [`crate::shamir::ShamirBackend::share_private_inputs`]). Downstream
-    /// (per-row secure aggregate, hidden join) correlate across holders by output
-    /// index. For a KEYED binding (element `i` ↔ a disclosed row id), pair the
-    /// returned batch with the holder's disclosed key column out-of-band.
+    /// the SAME `fragment` projecting one integer column, ordered DETERMINISTICALLY.
+    /// Nothing about the column is disclosed — the values ARE the secret inputs. The
+    /// implementation imposes the deterministic order by **sorting the holder's rows
+    /// by their (secret) value LOCALLY, before any sharing**, so two holders' batches
+    /// line up by position regardless of local row order; the values themselves never
+    /// leave the holder — only their shares do (see
+    /// [`crate::shamir::ShamirBackend::share_private_inputs`]). Downstream (per-row
+    /// secure aggregate, hidden join) correlate across holders by output index. For a
+    /// KEYED binding (element `i` ↔ a row id that IS disclosed), the caller pairs the
+    /// returned batch with the holder's disclosed key column out-of-band and uses that
+    /// public key — not the secret value — to define the cross-holder order.
     ///
     /// Returns one trait-`Share` PER ROW (so a single-scalar contribution is the
     /// `k = 1` case). Each `Self::Share` is the per-party sharing of one private

--- a/crates/sparq-mpc/src/backend.rs
+++ b/crates/sparq-mpc/src/backend.rs
@@ -723,6 +723,40 @@ pub trait MpcBackend {
     /// holder's single private integer and Shamir-shares it across the parties.
     fn share_private_input(&self, holder: &Holder) -> Result<Vec<Self::Share>, MpcError>;
 
+    /// [OPUS-4.8] sq-dwb5 — **batched / vector** secret-sharing of a holder's
+    /// private contribution: the holder surfaces a `Vec` of private integers (a
+    /// per-row hidden-value / salary vector / per-graph commitment column) via a
+    /// caller-supplied fragment, each row is Shamir-shared, and the result is
+    /// *positionally* row-bound — output index `i` is the sharing of the holder's
+    /// `i`-th private row. This generalises [`Self::share_private_input`] (which is
+    /// the `k = 1` special case) to MORE than one secret value per source, so the
+    /// secure aggregate / hidden-value join can range over many rows per holder.
+    ///
+    /// **Row-binding contract.** The binding is POSITIONAL: every holder evaluates
+    /// the SAME `fragment` projecting one integer column, ordered DETERMINISTICALLY
+    /// (the implementation sorts the holder's rows by their disclosed value so two
+    /// holders' batches line up by position regardless of local row order — see
+    /// [`crate::shamir::ShamirBackend::share_private_inputs`]). Downstream
+    /// (per-row secure aggregate, hidden join) correlate across holders by output
+    /// index. For a KEYED binding (element `i` ↔ a disclosed row id), pair the
+    /// returned batch with the holder's disclosed key column out-of-band.
+    ///
+    /// Returns one trait-`Share` PER ROW (so a single-scalar contribution is the
+    /// `k = 1` case). Each `Self::Share` is the per-party sharing of one private
+    /// value; index `i` is row `i` under the row-binding above.
+    ///
+    /// Default impl: the single-scalar fallback so existing backends/stubs keep
+    /// compiling — it returns a length-1 batch via [`Self::share_private_input`]
+    /// (the `share_private_input` result is itself one trait-`Share`).
+    /// [`crate::shamir::ShamirBackend`] overrides it with the real vector path.
+    fn share_private_inputs(
+        &self,
+        holder: &Holder,
+        _fragment: &str,
+    ) -> Result<Vec<Self::Share>, MpcError> {
+        self.share_private_input(holder)
+    }
+
     /// Run the secure computation over secret-shared inputs from all holders
     /// (e.g. the cumulative-salary aggregate whose per-source addends stay
     /// private). Returns the shares of the result.
@@ -739,7 +773,10 @@ pub trait MpcBackend {
     ///
     /// Implemented by [`crate::shamir::ShamirBackend`] (M3) via Lagrange
     /// interpolation of the result sharing at `x = 0`.
-    fn reconstruct_disclosed(&self, result_shares: &[Self::Share]) -> Result<PartialResult, MpcError>;
+    fn reconstruct_disclosed(
+        &self,
+        result_shares: &[Self::Share],
+    ) -> Result<PartialResult, MpcError>;
 }
 
 // =============================================================================
@@ -1378,7 +1415,10 @@ mod axis_tests {
         // n = 2, t = 1 → DishonestMajority (n <= 2t). Even with robust_cheaters = 0
         // (the detect-and-abort case) this must not claim honest-majority security.
         let desc = SecurityDescriptor::shamir_degree_recon(2, 1, 0);
-        assert_eq!(desc.threshold, CorruptionThreshold::DishonestMajority { t: 1 });
+        assert_eq!(
+            desc.threshold,
+            CorruptionThreshold::DishonestMajority { t: 1 }
+        );
         assert_eq!(desc.trust_model(), TrustModel::DishonestMajority);
         assert_eq!(desc.adversary, AdversaryModel::SemiHonest);
         // Degrades to the no-detection selective-abort baseline...
@@ -1388,7 +1428,10 @@ mod axis_tests {
         );
         // ...so the back-compat projection is SemiHonestOnly, NOT HonestMajorityAbort.
         // The two projections are now mutually consistent.
-        assert_eq!(desc.malicious_security(0), MaliciousSecurity::SemiHonestOnly);
+        assert_eq!(
+            desc.malicious_security(0),
+            MaliciousSecurity::SemiHonestOnly
+        );
         assert!(!desc.malicious_security(0).is_malicious_secure());
 
         // Even a non-zero correction budget cannot resurrect an honest-majority

--- a/crates/sparq-mpc/src/batched.rs
+++ b/crates/sparq-mpc/src/batched.rs
@@ -1,0 +1,495 @@
+// [OPUS-4.8] sq-dwb5: batched / vector secret sharing — generalise the
+// single-scalar `share_private_input` to a holder sharing a `Vec<Fp>` (per-row
+// hidden values / a salary vector / per-graph commitments) under a DOCUMENTED
+// row-binding, so the secure aggregate and the hidden-value join can range over
+// more than one value per source.
+//! Batched (vector) secret sharing + its row-binding contract.
+//!
+//! Architecture refs: §4.3 step 4 (the secure computation over secret-shared
+//! per-source values), §4.2 (minimise inter-source disclosure). Skill
+//! `mpc-protocols`: batched secret sharing is the standard way to secure a
+//! *column* of private values under one MPC session.
+//!
+//! ## The gap this closes
+//!
+//! [`crate::shamir::ShamirBackend::share_private_input`] caps a holder's secure
+//! contribution to ONE scalar (one row, one column — its single salary). The
+//! four-flatmates aggregate works because each flatmate has exactly one private
+//! salary; but the moment a holder has a *column* of private values (per-row
+//! hidden join keys, a salary history, a per-graph commitment vector) the single
+//! scalar is not enough. This module is the batched primitive: a holder shares a
+//! `Vec<Fp>`, and the result carries an EXPLICIT row-binding so downstream
+//! operators correlate elements across holders correctly.
+//!
+//! ## Row-binding contract (READ THIS — it is load-bearing for correctness)
+//!
+//! A [`BatchedShares`] is an ordered `Vec` of per-element Shamir sharings. The
+//! binding of element `i` to a logical row is one of two documented modes,
+//! recorded in [`RowBinding`]:
+//!
+//! - [`RowBinding::Positional`] — element `i` is row `i`. Two holders' batches
+//!   correlate by INDEX. This is sound only when both holders impose the SAME
+//!   deterministic order on their rows; [`crate::shamir::ShamirBackend::share_private_inputs`]
+//!   enforces this by value-sorting before sharing, so positional batches from
+//!   different holders line up regardless of local row order. Use for a per-row
+//!   secure aggregate where row `i` of holder A pairs with row `i` of holder B
+//!   (e.g. element-wise cumulative sum of two equal-length salary vectors).
+//! - [`RowBinding::Keyed`] — element `i` is bound to the DISCLOSED row key
+//!   `keys[i]` (a public global IRI / row id, convention #6). Correlation across
+//!   holders is by KEY, not index, so the orders need not match. The key column
+//!   is disclosed (convention #4) and travels alongside the shares; the VALUE
+//!   stays hidden. Use when rows are addressed by a public id rather than by
+//!   position.
+//!
+//! Both preserve the single-scalar privacy guarantee element-wise: each element
+//! has its own fresh degree-`t` masking polynomial (see
+//! [`crate::shamir::ShamirDealer::share_batch`]), so any `≤ t` parties' shares of
+//! the WHOLE batch are jointly independent of all the values.
+//!
+//! ## What is wired end-to-end here
+//!
+//! - [`BatchedShares`] / [`BatchedAuthShares`] — the carrier + binding metadata.
+//! - [`BatchedShares::reconstruct`] — element-wise open (the inverse of sharing).
+//! - [`per_row_sum`] — the multi-row secure aggregate: element-wise cumulative
+//!   sum across several holders' positional batches, the zero-round Shamir
+//!   linear fold lifted to a vector. This is the demonstrated end-to-end
+//!   multi-row path (tested against the plaintext per-row sum).
+//!
+//! The full batched HIDDEN-VALUE join (a [`crate::join::HiddenValueJoin`] ranging
+//! over many rows per holder via these batches, with the oblivious output
+//! transform of [`crate::oblivious_join`]) is a larger wiring job tracked
+//! separately — see the crate's bead tracker (follow-up to sq-dwb5). The
+//! primitive + binding it needs is exactly what this module lands.
+
+use crate::field::Fp;
+use crate::partial::MpcError;
+use crate::shamir::{add_shares, ShamirBackend, ShareVec};
+
+/// How element `i` of a [`BatchedShares`] binds to a logical row — the documented
+/// correlation contract downstream operators MUST honour (see module docs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RowBinding {
+    /// Element `i` is row `i`; holders correlate by INDEX. Sound only when every
+    /// holder imposes the same deterministic row order (the value-sort in
+    /// [`ShamirBackend::share_private_inputs`] guarantees this).
+    Positional,
+    /// Element `i` is bound to the DISCLOSED public row key `keys[i]` (a global
+    /// IRI / row id rendered to a `String`); holders correlate by KEY. The key
+    /// column is disclosed (convention #4); the value stays hidden. The keys MUST
+    /// be the same length as the batch.
+    Keyed(Vec<String>),
+}
+
+/// A batched (vector) secret sharing: one per-element Shamir sharing
+/// ([`ShareVec`]) per row, plus the [`RowBinding`] that says which row each
+/// element is. Index `i` is the sharing of value `i` under the binding.
+///
+/// This is the batched generalisation of a single trait-`Share`
+/// ([`ShareVec`]); the existing single-scalar path is the `len() == 1`
+/// [`RowBinding::Positional`] special case.
+#[derive(Debug, Clone)]
+pub struct BatchedShares {
+    /// One sharing per element; `elements[i]` is the degree-`t` Shamir sharing of
+    /// value `i`. Each is on the canonical `n`-party points `x = 1..=n`.
+    elements: Vec<ShareVec>,
+    /// How `elements[i]` binds to a logical row (see [`RowBinding`]).
+    binding: RowBinding,
+}
+
+impl BatchedShares {
+    /// Assemble a batched sharing from its per-element sharings and a binding.
+    /// A [`RowBinding::Keyed`] whose key count differs from the element count is
+    /// a protocol error (the binding would be ambiguous).
+    pub fn new(elements: Vec<ShareVec>, binding: RowBinding) -> Result<Self, MpcError> {
+        if let RowBinding::Keyed(keys) = &binding {
+            if keys.len() != elements.len() {
+                return Err(MpcError::Protocol(format!(
+                    "BatchedShares: keyed binding has {} keys but {} elements",
+                    keys.len(),
+                    elements.len()
+                )));
+            }
+        }
+        Ok(BatchedShares { elements, binding })
+    }
+
+    /// Number of shared rows in the batch.
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// Whether the batch is empty (a holder with no private rows).
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    /// The per-element sharings (index `i` is the sharing of value `i`).
+    pub fn elements(&self) -> &[ShareVec] {
+        &self.elements
+    }
+
+    /// The row-binding contract for this batch.
+    pub fn binding(&self) -> &RowBinding {
+        &self.binding
+    }
+
+    /// Element-wise reconstruct the whole batch to the plaintext value vector —
+    /// the inverse of batched sharing. Each element opens via the backend's
+    /// consistency-checked degree-`t` reconstruction. Used to open a DISCLOSED
+    /// batched result (never to open a value that must stay hidden).
+    pub fn reconstruct(&self, backend: &ShamirBackend) -> Result<Vec<Fp>, MpcError> {
+        self.elements
+            .iter()
+            .map(|e| backend.reconstruct(e))
+            .collect()
+    }
+}
+
+/// [OPUS-4.8] sq-dwb5 — the **multi-row secure aggregate**: element-wise
+/// cumulative sum across several holders' POSITIONAL batches. This is the Shamir
+/// zero-round linear fold ([`add_shares`]) lifted to a vector — row `i` of the
+/// result is the sum of row `i` across every holder's batch — so the secure
+/// aggregate now ranges over more than one value per source.
+///
+/// **Preconditions (fail-closed):** at least one batch; every batch the same
+/// length `k` (the positional row-binding requires aligned columns); every batch
+/// [`RowBinding::Positional`]. A length / binding mismatch is an
+/// [`MpcError::Protocol`], never a silent wrong answer. The result carries the
+/// `k`-row positional binding. Zero communication rounds (pure local addition),
+/// the honest-majority Shamir sweet spot.
+pub fn per_row_sum(batches: &[BatchedShares]) -> Result<BatchedShares, MpcError> {
+    let first = batches
+        .first()
+        .ok_or_else(|| MpcError::Protocol("per_row_sum: no input batches".into()))?;
+    let k = first.len();
+    for (h, b) in batches.iter().enumerate() {
+        if b.binding != RowBinding::Positional {
+            return Err(MpcError::Protocol(format!(
+                "per_row_sum: batch {h} is not positionally bound — \
+                 element-wise summation requires the positional row-binding"
+            )));
+        }
+        if b.len() != k {
+            return Err(MpcError::Protocol(format!(
+                "per_row_sum: batch {h} has {} rows but the first batch has {k} — \
+                 a per-row aggregate needs equal-length positional columns",
+                b.len()
+            )));
+        }
+    }
+
+    // Element-wise fold: row i of the result = Σ_holder (row i of that holder).
+    let mut acc: Vec<ShareVec> = first.elements.clone();
+    for b in &batches[1..] {
+        for (a, next) in acc.iter_mut().zip(b.elements.iter()) {
+            *a = add_shares(a, next)?;
+        }
+    }
+    BatchedShares::new(acc, RowBinding::Positional)
+}
+
+/// A batched AUTHENTICATED (IT-MAC) sharing: one
+/// [`crate::authenticated::AuthenticatedShare`] per row, all under ONE session
+/// MAC key `α`, plus the [`RowBinding`]. The vector analogue of a single
+/// authenticated share — minted by
+/// [`crate::shamir::MacSession::authenticated_share_batch`].
+///
+/// Linear ops on authenticated shares ([`crate::authenticated::auth_add`] …)
+/// compose element-wise, so an authenticated per-row aggregate stays free and
+/// keeps the MAC relation on every element. `α` is never reconstructed (the same
+/// structural guarantee as the single-scalar [`crate::authenticated::AuthenticatedShare`]).
+#[derive(Debug, Clone)]
+pub struct BatchedAuthShares {
+    elements: Vec<crate::authenticated::AuthenticatedShare>,
+    binding: RowBinding,
+}
+
+impl BatchedAuthShares {
+    /// Assemble a batched authenticated sharing. A [`RowBinding::Keyed`] with a
+    /// mismatched key count is a protocol error.
+    pub fn new(
+        elements: Vec<crate::authenticated::AuthenticatedShare>,
+        binding: RowBinding,
+    ) -> Result<Self, MpcError> {
+        if let RowBinding::Keyed(keys) = &binding {
+            if keys.len() != elements.len() {
+                return Err(MpcError::Protocol(format!(
+                    "BatchedAuthShares: keyed binding has {} keys but {} elements",
+                    keys.len(),
+                    elements.len()
+                )));
+            }
+        }
+        Ok(BatchedAuthShares { elements, binding })
+    }
+
+    /// Number of authenticated rows.
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// Whether empty.
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    /// The per-element authenticated sharings (index `i` is value `i`).
+    pub fn elements(&self) -> &[crate::authenticated::AuthenticatedShare] {
+        &self.elements
+    }
+
+    /// The row-binding contract.
+    pub fn binding(&self) -> &RowBinding {
+        &self.binding
+    }
+
+    /// The openable VALUE sharing of every element (index `i` → `[value_i]`). The
+    /// MAC stays crate-private exactly as for a single authenticated share — there
+    /// is no batched MAC opener here (a back door round the "α never reconstructed"
+    /// guarantee); the value sharings open via the backend's reconstruct.
+    pub fn value_shares(&self) -> Vec<ShareVec> {
+        self.elements
+            .iter()
+            .map(|e| e.value_shares().to_vec())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! sq-dwb5 batched-sharing acceptance suite. The load-bearing tests:
+    //! - `batched_round_trip_*`: a `Vec<Fp>` shares + reconstructs element-wise
+    //!   across n ∈ {3,5,7}.
+    //! - `t_shares_of_batch_are_independent_of_values`: ≤ t parties' shares of the
+    //!   WHOLE batch are independent of the values (vector privacy).
+    //! - `authenticated_batch_*`: the batched shares carry MACs; the MAC relation
+    //!   holds element-wise; α is never reconstructable through the batched API.
+    //! - `per_row_sum_equals_plaintext`: the multi-row secure aggregate matches
+    //!   the plaintext per-row sum (the row-binding correctness differential).
+    use super::*;
+    use crate::field::P;
+    use crate::shamir::{reconstruct_at_zero, Share};
+
+    /// ACCEPTANCE: batched share → element-wise reconstruct round-trips across the
+    /// honest-majority party counts n ∈ {3,5,7}.
+    #[test]
+    fn batched_round_trip_across_party_counts() {
+        let values: Vec<Fp> = [0u64, 1, 42, 100_000, P - 1]
+            .into_iter()
+            .map(Fp::new)
+            .collect();
+        for n in [3usize, 5, 7] {
+            let backend = ShamirBackend::new_seeded(n, 0xBA7C + n as u64).unwrap();
+            let mut dealer = backend.dealer();
+            let elements = dealer.share_batch(&values);
+            assert_eq!(elements.len(), values.len());
+            let batch = BatchedShares::new(elements, RowBinding::Positional).unwrap();
+            let opened = batch.reconstruct(&backend).unwrap();
+            assert_eq!(opened, values, "n={n}: batch must reconstruct element-wise");
+        }
+    }
+
+    /// ACCEPTANCE (privacy): any ≤ t parties' shares of the WHOLE batch are
+    /// independent of the values — the single-scalar hiding property lifted to the
+    /// vector. We witness it per element: t shares of EACH element are consistent
+    /// with a DIFFERENT value, so the joint t-party view pins down nothing.
+    #[test]
+    fn t_shares_of_batch_are_independent_of_values() {
+        let backend = ShamirBackend::new_seeded(7, 0x5EED).unwrap(); // t = 3
+        let t = backend.threshold();
+        assert_eq!(t, 3);
+        let mut dealer = backend.dealer();
+        let values: Vec<Fp> = [11u64, 22, 33].into_iter().map(Fp::new).collect();
+        let batch =
+            BatchedShares::new(dealer.share_batch(&values), RowBinding::Positional).unwrap();
+
+        for (i, element) in batch.elements().iter().enumerate() {
+            let t_views = &element[..t];
+            // For a DIFFERENT target value, forge a (t+1)-th share so the t views
+            // interpolate to it. Its existence is the information-theoretic hiding.
+            let target = values[i].add(Fp::new(7777 + i as u64));
+            let forged = forge_next_share(t_views, target, t);
+            let mut combined = t_views.to_vec();
+            combined.push(forged);
+            assert_eq!(
+                reconstruct_at_zero(&combined, t).unwrap(),
+                target,
+                "element {i}: t shares are consistent with a different value → they hide it"
+            );
+        }
+    }
+
+    /// ACCEPTANCE (authenticated): the batched shares carry IT-MACs; the MAC
+    /// relation `reconstruct([α·xᵢ]) == α·xᵢ` holds for EVERY element, and the
+    /// value sharings round-trip. Mirrors the single-scalar
+    /// `authenticated_share_round_trips`, extended to the vector.
+    #[test]
+    fn authenticated_batch_round_trips_and_stays_authenticated() {
+        let backend = ShamirBackend::new_seeded(5, 0xA17C).unwrap();
+        let t = backend.threshold();
+        let mut dealer = backend.dealer();
+        let mut session = dealer.new_mac_session();
+        let alpha = session.alpha_for_test();
+
+        let values: Vec<Fp> = [30_000u64, 45_000, 0, 1, P - 1]
+            .into_iter()
+            .map(Fp::new)
+            .collect();
+        let auth = session.authenticated_share_batch(&values);
+        let batch = BatchedAuthShares::new(auth, RowBinding::Positional).unwrap();
+
+        for (i, element) in batch.elements().iter().enumerate() {
+            let v = backend.reconstruct(element.value_shares()).unwrap();
+            assert_eq!(v, values[i], "element {i} value round-trips");
+            // The MAC relation holds element-wise (MAC opened only inside the test).
+            let m = reconstruct_at_zero(element.mac_shares(), t).unwrap();
+            assert_eq!(m, alpha.mul(values[i]), "element {i} MAC == α·value");
+        }
+    }
+
+    /// ACCEPTANCE (α-leak): the batched authenticated API exposes NO MAC opener —
+    /// `value_shares()` opens only the values; there is no path that reconstructs
+    /// `α` from the batch (mirrors the single-scalar `x = 1` α-leak guard). The
+    /// worst case x = 1 (whose MAC is α) is reachable only via the crate-private
+    /// `mac_shares()`, never through the public batched surface.
+    #[test]
+    fn batched_authenticated_api_never_opens_alpha() {
+        let backend = ShamirBackend::new_seeded(5, 0x1234).unwrap();
+        let mut dealer = backend.dealer();
+        let mut session = dealer.new_mac_session();
+
+        // Mint a batch containing x = 1 (its MAC is α·1 = α — the worst case).
+        let auth = session.authenticated_share_batch(&[Fp::one(), Fp::new(2)]);
+        let batch = BatchedAuthShares::new(auth, RowBinding::Positional).unwrap();
+
+        // The PUBLIC batched surface yields only the VALUE sharings; opening them
+        // gives the values (1, 2), never α.
+        let value_sharings = batch.value_shares();
+        assert_eq!(backend.reconstruct(&value_sharings[0]).unwrap(), Fp::one());
+        assert_eq!(backend.reconstruct(&value_sharings[1]).unwrap(), Fp::new(2));
+        // There is deliberately no `batch.mac_shares()` / `batch.reconstruct_mac()`:
+        // the MAC opener stays crate-private on each AuthenticatedShare.
+    }
+
+    /// ACCEPTANCE (row-binding correctness): the multi-row secure aggregate over
+    /// several holders' positional batches equals the plaintext per-row sum. This
+    /// is the differential that proves the row-binding correlates elements
+    /// correctly across holders — row i of the secure result = Σ row i.
+    #[test]
+    fn per_row_sum_equals_plaintext() {
+        let backend = ShamirBackend::new_seeded(5, 0xC0DE).unwrap();
+        let mut dealer = backend.dealer();
+
+        // Three holders, each a 4-row salary vector (the multi-row generalisation
+        // of the four-flatmates single salary).
+        let holders: [[u64; 4]; 3] = [
+            [30_000, 12_000, 0, 5],
+            [45_000, 8_000, 1, 0],
+            [28_000, 0, 2, 100_000],
+        ];
+        let batches: Vec<BatchedShares> = holders
+            .iter()
+            .map(|rows| {
+                let fps: Vec<Fp> = rows.iter().map(|&v| Fp::new(v)).collect();
+                BatchedShares::new(dealer.share_batch(&fps), RowBinding::Positional).unwrap()
+            })
+            .collect();
+
+        let summed = per_row_sum(&batches).unwrap();
+        let got = summed.reconstruct(&backend).unwrap();
+
+        // Plaintext per-row sum.
+        let expected: Vec<Fp> = (0..4)
+            .map(|i| Fp::new(holders.iter().map(|h| h[i]).sum::<u64>()))
+            .collect();
+        assert_eq!(
+            got, expected,
+            "per-row secure sum must equal plaintext per-row sum"
+        );
+    }
+
+    /// per_row_sum fails closed on a length mismatch (mis-aligned positional
+    /// columns) and on a non-positional binding — never a silent wrong answer.
+    #[test]
+    fn per_row_sum_rejects_misaligned_or_keyed_batches() {
+        let backend = ShamirBackend::new_seeded(3, 1).unwrap();
+        let mut dealer = backend.dealer();
+        let a = BatchedShares::new(
+            dealer.share_batch(&[Fp::new(1), Fp::new(2)]),
+            RowBinding::Positional,
+        )
+        .unwrap();
+        let b_short =
+            BatchedShares::new(dealer.share_batch(&[Fp::new(3)]), RowBinding::Positional).unwrap();
+        assert!(matches!(
+            per_row_sum(&[a.clone(), b_short]),
+            Err(MpcError::Protocol(_))
+        ));
+
+        let keyed = BatchedShares::new(
+            dealer.share_batch(&[Fp::new(3), Fp::new(4)]),
+            RowBinding::Keyed(vec!["r0".into(), "r1".into()]),
+        )
+        .unwrap();
+        assert!(matches!(
+            per_row_sum(&[a, keyed]),
+            Err(MpcError::Protocol(_))
+        ));
+    }
+
+    /// A keyed binding with a mismatched key count is rejected at construction.
+    #[test]
+    fn keyed_binding_key_count_must_match() {
+        let backend = ShamirBackend::new_seeded(3, 2).unwrap();
+        let mut dealer = backend.dealer();
+        let elements = dealer.share_batch(&[Fp::new(1), Fp::new(2)]);
+        assert!(matches!(
+            BatchedShares::new(elements, RowBinding::Keyed(vec!["only-one-key".into()])),
+            Err(MpcError::Protocol(_))
+        ));
+    }
+
+    /// An empty batch reconstructs to an empty vector (a holder with no private
+    /// rows contributes nothing) — the OWA-safe empty case.
+    #[test]
+    fn empty_batch_round_trips() {
+        let backend = ShamirBackend::new_seeded(3, 3).unwrap();
+        let mut dealer = backend.dealer();
+        let batch = BatchedShares::new(dealer.share_batch(&[]), RowBinding::Positional).unwrap();
+        assert!(batch.is_empty());
+        assert_eq!(batch.reconstruct(&backend).unwrap(), Vec::<Fp>::new());
+    }
+
+    /// Given `t` shares on a degree-`t` polynomial, produce ONE more share so the
+    /// `t+1` interpolate to `target` at `x = 0` (the hiding witness for the
+    /// independence test). Mirrors `authenticated::tests::forge_next_share`.
+    fn forge_next_share(views: &[Share], target: Fp, t: usize) -> Share {
+        assert_eq!(views.len(), t, "need exactly t shares to leave one DOF");
+        let xnew = (1..=10_000u64)
+            .find(|x| views.iter().all(|s| s.x != *x))
+            .expect("a fresh evaluation point exists");
+        let mut xs: Vec<u64> = views.iter().map(|s| s.x).collect();
+        xs.push(xnew);
+        let weight = |i: usize| -> Fp {
+            let xi = Fp::new(xs[i]);
+            let mut num = Fp::one();
+            let mut den = Fp::one();
+            for (j, &xj) in xs.iter().enumerate() {
+                if i == j {
+                    continue;
+                }
+                let xj = Fp::new(xj);
+                num = num.mul(xj.neg());
+                den = den.mul(xi.sub(xj));
+            }
+            num.mul(den.inv())
+        };
+        let mut acc = Fp::zero();
+        for (i, v) in views.iter().enumerate() {
+            acc = acc.add(v.y.mul(weight(i)));
+        }
+        let l_new = weight(views.len());
+        let y_new = target.sub(acc).mul(l_new.inv());
+        Share { x: xnew, y: y_new }
+    }
+}

--- a/crates/sparq-mpc/src/lib.rs
+++ b/crates/sparq-mpc/src/lib.rs
@@ -100,6 +100,15 @@
 // docs and research/mpc-malicious-security-design.md §2.1–2.2.
 pub mod authenticated;
 pub mod backend;
+// [OPUS-4.8] sq-dwb5: batched / vector secret sharing — generalise the
+// single-scalar `share_private_input` to a holder sharing a `Vec<Fp>` (per-row
+// hidden values / a salary vector / per-graph commitments) under a DOCUMENTED
+// row-binding (`RowBinding::Positional` / `Keyed`), so the secure aggregate +
+// hidden-value join can range over more than one value per source. Carries the
+// `BatchedShares` / `BatchedAuthShares` types, element-wise reconstruct, and the
+// multi-row `per_row_sum` secure aggregate (the demonstrated end-to-end path).
+// See the module docs for the row-binding contract.
+pub mod batched;
 // [OPUS-4.8] sq-rrz4: secure secret-shared greater-than / threshold over Fp that
 // opens ONLY the boolean verdict bit, never the operands. Bit-decomposition
 // MSB-first comparison chaining multiplications via mul_shares_raw + the landed
@@ -193,6 +202,8 @@ pub use backend::{
     MaliciousSecurity, MpcBackend, OperatorClass, OutputGuarantee, PublicVerifiability,
     SecurityDescriptor, SecurityRequirement, TrustModel,
 };
+// [OPUS-4.8] sq-dwb5: the batched / vector secret-sharing surface + row-binding.
+pub use batched::{per_row_sum, BatchedAuthShares, BatchedShares, RowBinding};
 // [OPUS-4.8] sq-sxm: the benchmark-matrix harness surface (in-process counting tier).
 pub use bench::{
     cell, run_matrix, CellSecurity, MatrixCell, MatrixResults, QueryClass, DEFAULT_PARTIES,

--- a/crates/sparq-mpc/src/shamir.rs
+++ b/crates/sparq-mpc/src/shamir.rs
@@ -1107,13 +1107,26 @@ fn extract_integer_vector(p: &PartialResult) -> Result<Vec<u64>, MpcError> {
     }
     p.rows
         .iter()
-        .map(|row| match row.first() {
-            Some(Some(oxrdf::Term::Literal(l))) => l.value().parse::<u64>().map_err(|e| {
-                MpcError::Protocol(format!("batched private input not a u64 integer: {e}"))
-            }),
-            other => Err(MpcError::Protocol(format!(
-                "batched private input must be an integer literal in each row, got {other:?}"
-            ))),
+        .map(|row| {
+            // Fail closed on a malformed row shape: the column COUNT is checked
+            // once via `p.vars.len()`, but a hand-built / adversarial
+            // `PartialResult` can desync the per-row arity from `vars`. Require
+            // each row to carry exactly one cell so a multi-column row can't
+            // silently mis-extract by ignoring the trailing columns.
+            if row.len() != 1 {
+                return Err(MpcError::Protocol(format!(
+                    "batched private input row must have exactly one column, got {}",
+                    row.len()
+                )));
+            }
+            match row.first() {
+                Some(Some(oxrdf::Term::Literal(l))) => l.value().parse::<u64>().map_err(|e| {
+                    MpcError::Protocol(format!("batched private input not a u64 integer: {e}"))
+                }),
+                other => Err(MpcError::Protocol(format!(
+                    "batched private input must be an integer literal in each row, got {other:?}"
+                ))),
+            }
         })
         .collect()
 }
@@ -1599,5 +1612,36 @@ mod tests {
         // Value-sorted: alice = [1000,2000,3000], bob = [500,1500,2500] → per-row
         // sums [1500, 3500, 5500].
         assert_eq!(got, vec![Fp::new(1500), Fp::new(3500), Fp::new(5500)]);
+    }
+
+    /// [OPUS-4.8] sq-dwb5 — `extract_integer_vector` must fail CLOSED on a row
+    /// whose arity desyncs from `vars`: a malformed/adversarial `PartialResult`
+    /// can claim one column in `vars` yet carry rows with extra cells. We must
+    /// reject (not silently use the first column and drop the rest).
+    #[test]
+    fn extract_integer_vector_rejects_multi_column_row() {
+        use crate::partial::PartialResult;
+        use oxrdf::{Literal, Term, Variable};
+        let int = |n: u64| Some(Term::Literal(Literal::from(n as i64)));
+        let p = PartialResult {
+            holder: crate::partial::HolderId::new("mallory"),
+            // `vars` claims a single column...
+            vars: vec![Variable::new("salary").unwrap()],
+            // ...but a row sneaks in a second cell.
+            rows: vec![vec![int(1000)], vec![int(2000), int(9999)]],
+        };
+        let err = extract_integer_vector(&p).unwrap_err();
+        assert!(
+            matches!(&err, MpcError::Protocol(m) if m.contains("exactly one column")),
+            "expected per-row arity rejection, got {err:?}"
+        );
+
+        // A well-formed single-column partial still extracts in row order.
+        let ok = PartialResult {
+            holder: crate::partial::HolderId::new("alice"),
+            vars: vec![Variable::new("salary").unwrap()],
+            rows: vec![vec![int(1000)], vec![int(2000)]],
+        };
+        assert_eq!(extract_integer_vector(&ok).unwrap(), vec![1000, 2000]);
     }
 }

--- a/crates/sparq-mpc/src/shamir.rs
+++ b/crates/sparq-mpc/src/shamir.rs
@@ -385,6 +385,31 @@ impl ShamirDealer {
             .collect()
     }
 
+    /// [OPUS-4.8] sq-dwb5 — **batched / vector secret sharing.** Share a whole
+    /// `Vec<Fp>` element-wise: each `values[i]` gets its OWN fresh, INDEPENDENT
+    /// degree-`t` masking polynomial, yielding one sharing (`ShareVec`) per
+    /// element. The returned `Vec<ShareVec>` is *positionally* row-bound: output
+    /// index `i` is the sharing of `values[i]` — the documented row-binding
+    /// contract (see [`crate::batched::BatchedShares`]).
+    ///
+    /// **Why one fresh polynomial per element (NOT one polynomial carrying all
+    /// values).** A single masking polynomial whose *coefficients* are the secrets
+    /// would couple the elements: opening one element's evaluation would constrain
+    /// the others, and `≤ t` parties' views would no longer be independent of the
+    /// vector. Independent per-element polynomials preserve the exact single-scalar
+    /// privacy guarantee for EVERY element simultaneously — any `≤ t` parties'
+    /// shares of the whole batch are jointly independent of all the values (each
+    /// element's masking coefficients are fresh, so the joint view is a product of
+    /// independent uniform sharings). This is the standard batched-Shamir layout;
+    /// it trades share count (`n·k`) for the unchanged per-element security.
+    ///
+    /// Linear ops ([`add_shares`] / [`scale`] / …) compose element-wise across two
+    /// equally-sized batches, so a per-row secure aggregate is the element-wise
+    /// fold of the per-holder batches — still zero communication rounds.
+    pub fn share_batch(&mut self, values: &[Fp]) -> Vec<ShareVec> {
+        values.iter().map(|&v| self.share(v)).collect()
+    }
+
     /// **BGW/GRR degree-reduction round (sq-dvuc).** Reduce a degree-`2t` product
     /// sharing back to a fresh degree-`t` sharing of the SAME secret, so that
     /// secret-shared multiplications can **chain** (`a·b·c`, secure comparison /
@@ -627,6 +652,29 @@ impl MacSession<'_> {
         // point-alignment invariant in `AuthenticatedShare::new` always holds.
         crate::authenticated::AuthenticatedShare::new(value, mac)
             .expect("share() emits matched canonical party points for value and MAC")
+    }
+
+    /// [OPUS-4.8] sq-dwb5 — **batched / vector AUTHENTICATED sharing.** Produce one
+    /// [`crate::authenticated::AuthenticatedShare`] `[[values[i]]] = ([values[i]],
+    /// [α·values[i]])` per element, ALL under THIS session's single MAC key `α`.
+    /// The returned vector is *positionally* row-bound: index `i` is the
+    /// authenticated sharing of `values[i]` (see
+    /// [`crate::batched::BatchedAuthShares`]).
+    ///
+    /// Every element draws TWO fresh independent degree-`t` masking polynomials
+    /// (value + MAC), so any `≤ t` parties' views of the whole batch are jointly
+    /// independent of all the values AND of `α`. Sharing the WHOLE batch under one
+    /// `α` is exactly what makes the later batched MAC-check (sq-km34.4) able to
+    /// authenticate a vector with a single random linear combination — the
+    /// vectorised analogue of the single-scalar MAC. `α` is never reconstructed.
+    pub fn authenticated_share_batch(
+        &mut self,
+        values: &[Fp],
+    ) -> Vec<crate::authenticated::AuthenticatedShare> {
+        values
+            .iter()
+            .map(|&v| self.authenticated_share(v))
+            .collect()
     }
 
     /// **Test-only.** The cleartext session MAC key `α`, so tests can verify the
@@ -932,6 +980,40 @@ impl MpcBackend for ShamirBackend {
         Ok(vec![dealer.share(Fp::new(v))])
     }
 
+    /// [OPUS-4.8] sq-dwb5 — **batched / vector** secret-sharing of a holder's
+    /// private contribution. The holder evaluates `fragment` (which MUST project
+    /// exactly one integer-valued column) over its OWN data and we share EVERY row
+    /// it returns — generalising [`Self::share_private_input`] (the single-row
+    /// special case using the fixed [`PRIVATE_SALARY_FRAGMENT`]) to a per-row
+    /// hidden-value / salary vector / per-graph commitment column.
+    ///
+    /// **Row-binding (POSITIONAL, value-sorted).** The values are extracted and
+    /// then sorted ascending ([`extract_integer_vector`] returns them in the
+    /// holder's local row order; we sort here) so two holders running the same
+    /// fragment produce batches whose index `i` refers to the same logical row
+    /// position regardless of each holder's local row ordering — exactly the
+    /// contract a per-row secure aggregate / hidden join relies on. The cleartext
+    /// values NEVER leave; only their `n·k` shares do, and any `≤ t` parties'
+    /// shares of the whole batch are jointly independent of all the values.
+    ///
+    /// One fresh dealer (fresh OS-seeded CSPRNG in production, sq-1vt) shares the
+    /// whole batch, so every row gets an independent masking polynomial without
+    /// reusing a keystream across rows.
+    fn share_private_inputs(
+        &self,
+        holder: &Holder,
+        fragment: &str,
+    ) -> Result<Vec<Self::Share>, MpcError> {
+        let private = holder.evaluate_local(fragment)?;
+        let mut values = extract_integer_vector(&private)?;
+        // Positional row-binding: a deterministic order so two holders' batches
+        // line up by index regardless of local row order (the documented contract).
+        values.sort_unstable();
+        let fps: Vec<Fp> = values.into_iter().map(Fp::new).collect();
+        let mut dealer = self.dealer();
+        Ok(dealer.share_batch(&fps))
+    }
+
     /// Run the secure computation over the shared inputs. For the v1 aggregate
     /// this is the **cumulative sum** of the holders' private values: a pure
     /// linear function, so it is the local component-wise addition of the
@@ -1006,6 +1088,34 @@ fn extract_single_integer(p: &PartialResult) -> Result<u64, MpcError> {
             "private input must be an integer literal, got {other:?}"
         ))),
     }
+}
+
+/// [OPUS-4.8] sq-dwb5 — pull a VECTOR of non-negative integers out of a
+/// single-column (any number of rows) partial — the batched generalisation of
+/// [`extract_single_integer`]. Each row must bind exactly one integer literal in
+/// the one projected column; an empty result is a valid empty vector (a holder
+/// with no private rows contributes nothing). A multi-column partial, a missing
+/// binding, or a non-integer literal is a protocol error — we never guess.
+/// Values are returned in the holder's local row order; the caller imposes the
+/// row-binding order (see [`ShamirBackend::share_private_inputs`]).
+fn extract_integer_vector(p: &PartialResult) -> Result<Vec<u64>, MpcError> {
+    if p.vars.len() != 1 {
+        return Err(MpcError::Protocol(format!(
+            "batched private input must project exactly one column, got {}",
+            p.vars.len()
+        )));
+    }
+    p.rows
+        .iter()
+        .map(|row| match row.first() {
+            Some(Some(oxrdf::Term::Literal(l))) => l.value().parse::<u64>().map_err(|e| {
+                MpcError::Protocol(format!("batched private input not a u64 integer: {e}"))
+            }),
+            other => Err(MpcError::Protocol(format!(
+                "batched private input must be an integer literal in each row, got {other:?}"
+            ))),
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -1406,5 +1516,88 @@ mod tests {
         let summed = backend.run_secure(&sa).unwrap();
         let got = backend.reconstruct(&summed[0]).unwrap();
         assert_eq!(got, Fp::new(75_000));
+    }
+
+    /// [OPUS-4.8] sq-dwb5 — BACKWARD-COMPAT: the single-scalar `share_private_input`
+    /// path is unchanged, AND the default `share_private_inputs` over the fixed
+    /// single-salary fragment yields the SAME length-1 batch (the k=1 special case
+    /// the generalisation must preserve).
+    #[test]
+    fn share_private_inputs_subsumes_single_scalar_path() {
+        const PFX: &str =
+            "@prefix ex: <http://ex/> . @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n";
+        let alice = Holder::from_rdf(
+            "alice",
+            &format!("{PFX} ex:alice ex:salary \"30000\"^^xsd:integer ."),
+            "turtle",
+        )
+        .unwrap();
+        let backend = ShamirBackend::new(2).unwrap();
+        // The original single path still works.
+        let single = backend.share_private_input(&alice).unwrap();
+        assert_eq!(single.len(), 1);
+        assert_eq!(backend.reconstruct(&single[0]).unwrap(), Fp::new(30_000));
+        // The batched path over the SAME single-salary fragment yields one row.
+        let batched = backend
+            .share_private_inputs(&alice, PRIVATE_SALARY_FRAGMENT)
+            .unwrap();
+        assert_eq!(batched.len(), 1, "k=1 special case is a length-1 batch");
+        assert_eq!(backend.reconstruct(&batched[0]).unwrap(), Fp::new(30_000));
+    }
+
+    /// [OPUS-4.8] sq-dwb5 — ROW-BINDING end-to-end: two holders each have a
+    /// MULTI-ROW private salary column; the batched share + the multi-row secure
+    /// aggregate (`batched::per_row_sum`) over their positional batches equals the
+    /// plaintext per-row sum. The value-sort row-binding makes the two holders'
+    /// rows line up by position regardless of local triple order. This is the
+    /// multi-row path the single-scalar `share_private_input` could not express.
+    #[test]
+    fn batched_multi_row_per_holder_aggregate_matches_plaintext() {
+        use crate::batched::{per_row_sum, BatchedShares, RowBinding};
+        const PFX: &str =
+            "@prefix ex: <http://ex/> . @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n";
+        // Each holder has a 3-row salary column (e.g. monthly payslips). The triples
+        // are written in DIFFERENT orders per holder to exercise the value-sort.
+        let alice = Holder::from_rdf(
+            "alice",
+            &format!(
+                "{PFX} ex:a1 ex:salary \"3000\"^^xsd:integer . \
+                 ex:a2 ex:salary \"1000\"^^xsd:integer . \
+                 ex:a3 ex:salary \"2000\"^^xsd:integer ."
+            ),
+            "turtle",
+        )
+        .unwrap();
+        let bob = Holder::from_rdf(
+            "bob",
+            &format!(
+                "{PFX} ex:b1 ex:salary \"500\"^^xsd:integer . \
+                 ex:b2 ex:salary \"1500\"^^xsd:integer . \
+                 ex:b3 ex:salary \"2500\"^^xsd:integer ."
+            ),
+            "turtle",
+        )
+        .unwrap();
+
+        let frag = PRIVATE_SALARY_FRAGMENT; // SELECT ?salary WHERE { ?p ex:salary ?salary }
+        let backend = ShamirBackend::new_seeded(5, 0xBA7C).unwrap();
+        let a = BatchedShares::new(
+            backend.share_private_inputs(&alice, frag).unwrap(),
+            RowBinding::Positional,
+        )
+        .unwrap();
+        let b = BatchedShares::new(
+            backend.share_private_inputs(&bob, frag).unwrap(),
+            RowBinding::Positional,
+        )
+        .unwrap();
+        assert_eq!(a.len(), 3);
+        assert_eq!(b.len(), 3);
+
+        let summed = per_row_sum(&[a, b]).unwrap();
+        let got = summed.reconstruct(&backend).unwrap();
+        // Value-sorted: alice = [1000,2000,3000], bob = [500,1500,2500] → per-row
+        // sums [1500, 3500, 5500].
+        assert_eq!(got, vec![Fp::new(1500), Fp::new(3500), Fp::new(5500)]);
     }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent

Generalises the single-scalar `share_private_input` (which extracted exactly ONE integer per holder — single-row / single-column) to **batched / vector secret sharing**, so the secure aggregate and the hidden-value join can range over more than one private value per source. Closes the cap flagged in **sq-dwb5**.

## Batched-sharing API (added alongside the single path — nothing broken)

- **`batched` module** — `BatchedShares` (plain) and `BatchedAuthShares` (IT-MAC authenticated) carriers, each holding one per-element Shamir sharing per row plus a `RowBinding`.
- **`ShamirDealer::share_batch(values: &[Fp]) -> Vec<ShareVec>`** — element-wise sharing; **each element gets its own fresh degree-`t` masking polynomial** (NOT one polynomial carrying all values), so per-element privacy is preserved for the whole vector simultaneously.
- **`MacSession::authenticated_share_batch(&[Fp])`** — the authenticated analogue; every element authenticated under the session's single `α`.
- **`MpcBackend::share_private_inputs(holder, fragment)`** — trait method with a default single-scalar fallback (existing stub backends keep compiling unchanged); `ShamirBackend` overrides it with the real vector path via a new `extract_integer_vector`.
- **`batched::per_row_sum`** — the multi-row secure aggregate (the zero-round Shamir linear fold lifted to a vector).

## Row-binding contract (documented, load-bearing)

`RowBinding` records how element `i` correlates across holders:
- **`Positional`** — element `i` is row `i`; holders correlate by INDEX. Sound only when both holders impose the same deterministic order, so `share_private_inputs` **value-sorts** before sharing → positional batches from different holders line up regardless of local triple/row order.
- **`Keyed(Vec<String>)`** — element `i` bound to the DISCLOSED public row key `keys[i]` (a global IRI / row id, convention #6); holders correlate by KEY, orders need not match. The key column is disclosed (convention #4); the value stays hidden.

Both preserve the single-scalar hiding guarantee element-wise.

## Wired end-to-end vs deferred

- **Wired:** batched share → element-wise reconstruct; the multi-row **secure aggregate** `per_row_sum`, demonstrated end-to-end from two multi-row holders (`share_private_inputs` → `per_row_sum` → reconstruct == plaintext per-row sum).
- **Deferred (honestly):** the full batched **hidden-value join** (`HiddenValueJoin` ranging over many rows/holder via these batches + the `oblivious_join` output transform) is a larger wiring job. The primitive + binding it needs is landed; the join integration is a follow-up. **Suggest a follow-up bead** (orchestrator: `bd` not available in the isolated worktree) for "wire `BatchedShares`/`RowBinding` into `HiddenValueJoin` (multi-row hidden join + oblivious output)".

## Test matrix

- **Round-trip:** a `Vec<Fp>` shares + reconstructs element-wise across n ∈ {3,5,7}.
- **Privacy:** ≤ t parties' shares of the whole batch are independent of the values (single-scalar test extended to the vector, per element).
- **Authenticated:** batched shares carry IT-MACs; MAC relation `α·xᵢ` holds element-wise; `α` never reconstructable through the batched API (x=1 α-leak guard, mirroring the single-scalar pattern).
- **Row-binding:** multi-holder per-row secure sum == plaintext per-row sum (the correlation differential); plus a two-holder multi-row end-to-end holder test.
- **Backward-compat:** the single-scalar `share_private_input` path is unchanged; `share_private_inputs` over the fixed single-salary fragment yields the same length-1 batch.
- Fail-closed guards: misaligned/keyed batches rejected by `per_row_sum`; keyed key-count mismatch rejected at construction; empty batch round-trips.

## Verify

`cargo build -p sparq-mpc && cargo nextest run -p sparq-mpc && cargo clippy -p sparq-mpc --all-targets -- -D warnings` all pass — **251 tests, 0 failures**; clippy clean. (Non-canonical EC2 timing — not baked into docs.)

References sq-dwb5.