### PR TITLE
feat(sparq-mpc): batched hidden-value join over row columns + oblivious output (sq-khf9)

### DIFF
--- a/crates/sparq-mpc/src/join.rs
+++ b/crates/sparq-mpc/src/join.rs
@@ -41,7 +41,7 @@ use crate::batched::{BatchedShares, RowBinding};
 use crate::field::Fp;
 use crate::oblivious_join::{self, Candidate, MatchBit, ObliviousOutputCost};
 use crate::partial::{HolderId, MpcError, PartialResult};
-use crate::shamir::{self, ShamirBackend, ShamirDealer};
+use crate::shamir::{self, ShamirBackend, ShamirDealer, Share};
 use oxrdf::{Term, Variable};
 use std::collections::BTreeMap;
 
@@ -411,6 +411,30 @@ impl HiddenValueJoin {
     /// deferred WI-4 / bead sq-6d6g). Detection at `n > 2t + 1` thus requires
     /// running the equality test on MORE than the minimal party count.
     fn secure_equal(&self, dealer: &mut ShamirDealer, a: Fp, b: Fp) -> Result<bool, MpcError> {
+        // Secret-share both keys, then run the shared-input core. The scalar path
+        // deals its own shares; the batched path deals a whole key COLUMN up front
+        // (a `BatchedShares`) and passes the per-row sharings straight in.
+        let sa = dealer.share(a);
+        let sb = dealer.share(b);
+        self.secure_equal_shared(dealer, &sa, &sb)
+    }
+
+    /// The match-bit core of [`Self::secure_equal`], over keys that are ALREADY
+    /// secret-shared. This is the entry point the batched join uses so the
+    /// `BatchedShares` dealt up front by [`BatchedHiddenInput::shared_keys`] are the
+    /// actual sharings compared — the keys are dealt ONCE, not re-shared per
+    /// candidate. `sa` / `sb` must be degree-`t` sharings on the dealer's `n`-party
+    /// points (exactly what `share` / `share_batch` produce).
+    ///
+    /// `m = (a - b)·r` is opened at degree `2t`; `m == 0 ⇔ a == b`, and for unequal
+    /// keys `m` is uniform nonzero — so ONLY the match bit is revealed, never either
+    /// key or their difference.
+    fn secure_equal_shared(
+        &self,
+        dealer: &mut ShamirDealer,
+        sa: &[Share],
+        sb: &[Share],
+    ) -> Result<bool, MpcError> {
         let t = dealer.threshold();
         // Honest-majority headroom: one multiplication needs 2t+1 <= n parties.
         if dealer.parties() < 2 * t + 1 {
@@ -420,16 +444,13 @@ impl HiddenValueJoin {
                 t
             )));
         }
-        // Secret-share both keys and a fresh nonzero mask.
-        let sa = dealer.share(a);
-        let sb = dealer.share(b);
         // Fresh nonzero mask r from the masking RNG (a CSPRNG in production —
         // sq-1vt). Zero is rejected inside `draw_nonzero_fp`: masking by zero
         // would make m=0 even for unequal keys (a false match).
         let mask_value = dealer.draw_nonzero_fp();
         let r = dealer.share(mask_value);
         // d = a - b (local, degree t).
-        let d = shamir::sub_shares(&sa, &sb)?;
+        let d = shamir::sub_shares(sa, sb)?;
         // m = d * r (one multiplication, degree 2t).
         let m_shares = shamir::mul_shares_raw(&d, &r)?;
         // Open m at degree 2t. m == 0  <=>  d == 0  <=>  a == b.
@@ -503,10 +524,11 @@ impl HiddenValueJoin {
 /// row's key gets its OWN fresh degree-`t` masking polynomial and any `≤ t`
 /// parties' shares of the whole key column are jointly independent of every key
 /// (the batched-Shamir hiding property). This is the structural reason the keys
-/// never leak: the cleartext column is consumed only to deal the batch, exactly as
-/// the four-flatmates aggregate does for its salary column. The DISCLOSED payload
-/// columns ride alongside in the clear (disclosure-minimisation, convention #4 —
-/// only the *key* is hidden).
+/// never leak: the cleartext keys are used ONLY as the local inputs to Shamir
+/// sharing and to the secure-equality test ([`HiddenValueJoin::secure_equal_shared`]),
+/// and are NEVER reconstructed from shares — exactly as the four-flatmates aggregate
+/// uses its salary column. The DISCLOSED payload columns ride alongside in the clear
+/// (disclosure-minimisation, convention #4 — only the *key* is hidden).
 #[derive(Debug, Clone)]
 pub struct BatchedHiddenInput {
     /// The holder that owns this column.
@@ -653,23 +675,29 @@ impl HiddenValueJoin {
         let mut dealer = self.backend.dealer();
 
         // (1) Secret-share each holder's private key column as a BatchedShares (the
-        // sq-dwb5 primitive). We do not need to OPEN these — `secure_equal` shares
-        // the keys it compares internally — but dealing the batch here exercises the
-        // documented primitive + validates the keyed-binding key counts, and is the
-        // structural point at which the cleartext keys are consumed into shares.
-        let _l_shared = left.shared_keys(&mut dealer)?;
-        let _r_shared = right.shared_keys(&mut dealer)?;
+        // sq-dwb5 primitive): each row's key gets its OWN fresh degree-`t` masking
+        // polynomial, the cleartext column is consumed ONCE into the batch, and the
+        // keyed-binding key counts are validated. These are the SAME sharings the
+        // comparisons below consume — the keys are dealt once, never re-shared per
+        // candidate.
+        let l_shared = left.shared_keys(&mut dealer)?;
+        let r_shared = right.shared_keys(&mut dealer)?;
 
         // (2) Enumerate the candidate row pairs the RowBinding permits.
         let pairs = candidate_pairs(&left.binding, &right.binding, left.len(), right.len())?;
 
         // (3) Decide each candidate's match with the secure-equal primitive lifted to
-        // the row dimension. The join KEY/VALUE is never opened — only the match bit.
+        // the row dimension — over the BATCHED shares dealt in (1), NOT a per-row
+        // re-share. The join KEY/VALUE is never opened — only the match bit.
         let mut candidates: Vec<Candidate> = Vec::with_capacity(pairs.len());
         for (li, rj) in pairs {
-            let (lkey, lpay) = &left.rows[li];
-            let (rkey, rpay) = &right.rows[rj];
-            let matched = self.secure_equal(&mut dealer, *lkey, *rkey)?;
+            let (_lkey, lpay) = &left.rows[li];
+            let (_rkey, rpay) = &right.rows[rj];
+            let matched = self.secure_equal_shared(
+                &mut dealer,
+                &l_shared.elements()[li],
+                &r_shared.elements()[rj],
+            )?;
             let mut payload = lpay.clone();
             payload.extend(rpay.iter().cloned());
             // Pad / validate to the uniform output arity so the oblivious output's
@@ -1542,57 +1570,83 @@ mod batched_hidden_value_tests {
 
     // ============================== Privacy ==============================
 
-    /// PRIVACY (L1 at the OUTPUT): two candidate sets with DIFFERENT true match
-    /// counts but the SAME candidate count + bound reveal the IDENTICAL number of
-    /// output SLOTS — the oblivious output bounds the revealed cardinality to B, so
-    /// the protocol/parties learn B, not the true count. (The recipient who filters
-    /// dummies learns the true count; that is inherent and documented.)
+    /// PRIVACY (L1 at the OUTPUT — substantive, not the bound echo): two scenarios
+    /// with DIFFERENT true match counts (1 vs 3) but the SAME candidate count + bound
+    /// reveal the IDENTICAL number of output SLOTS — exactly `B`, ALL of which are
+    /// observed as a flat slot vector whose LENGTH is `B` regardless of the true
+    /// count. We go through the lower-level `oblivious_set_output` (which exposes the
+    /// SLOTS that `batched_join` filters) so the obliviousness is asserted on the
+    /// actual revealed structure, not just the `cost.bound` the input echoes. We also
+    /// assert the hidden join KEY never appears in any revealed slot.
     #[test]
     fn output_cardinality_is_bounded_to_b_not_true_count() {
-        // Same B and candidate count, different number of true matches.
-        let one = positional(
-            "L",
-            &["a"],
-            &[
-                (1u64, vec![lit("p")]),
-                (2, vec![lit("q")]),
-                (3, vec![lit("r")]),
-            ],
-        );
-        let one_r = positional(
-            "R",
-            &["b"],
-            &[
-                (1u64, vec![lit("p")]),
-                (9, vec![lit("q")]),
-                (8, vec![lit("r")]),
-            ],
-        ); // 1 match
-        let three_r = positional(
-            "R",
-            &["b"],
-            &[
-                (1u64, vec![lit("p")]),
-                (2, vec![lit("q")]),
-                (3, vec![lit("r")]),
-            ],
-        ); // 3 matches
+        use crate::oblivious_join::oblivious_set_output;
 
-        let join = HiddenValueJoin::new(ShamirBackend::new_seeded(3, 0x5217).unwrap());
-        // Use the lower-level oblivious set output via batched_join's transform by
-        // counting revealed slots: re-run the transform with a padded bound B=5.
-        // batched_join returns the FILTERED PartialResult, so to observe the SLOT
-        // count we go through the candidate path with the same B and compare the
-        // transform's `cost.bound` (the revealed count) — identical regardless of
-        // true matches.
-        let (_, c1) = join.batched_join(&one, &one_r, 5).unwrap();
-        let (_, c3) = join.batched_join(&one, &three_r, 5).unwrap();
+        // A SECRET join key the parties must never see in the output, used in the
+        // matching rows of both scenarios.
+        let secret_key = 0x5EC5_E700u64;
+        // Build the candidates a batched positional join would produce, deciding each
+        // match with the SAME secure-equal core, for `n_matches` of 3 rows.
+        let candidates_for = |n_matches: usize, backend: &ShamirBackend| -> Vec<Candidate> {
+            let join = HiddenValueJoin::new(backend.clone());
+            let mut dealer = backend.dealer();
+            // Left column: 3 rows, all keyed on the secret key.
+            let left = [secret_key, secret_key, secret_key];
+            // Right column: the first `n_matches` rows share the secret key (a true
+            // match); the rest carry distinct non-matching keys.
+            let right: Vec<u64> = (0..3)
+                .map(|i| {
+                    if i < n_matches {
+                        secret_key
+                    } else {
+                        0xD15 + i as u64
+                    }
+                })
+                .collect();
+            (0..3)
+                .map(|i| {
+                    let matched = join
+                        .secure_equal(&mut dealer, Fp::new(left[i]), Fp::new(right[i]))
+                        .unwrap();
+                    Candidate {
+                        // Payload discloses only the row index, NEVER the key.
+                        payload: vec![lit(&format!("L{i}")), lit(&format!("R{i}"))],
+                        matched: MatchBit::Public(matched),
+                    }
+                })
+                .collect()
+        };
+
+        let b = 5usize; // public bound padded above the 3 candidates
+        let backend = ShamirBackend::new_seeded(3, 0x5217).unwrap();
+        let (slots1, c1) =
+            oblivious_set_output(&backend, &candidates_for(1, &backend), 2, b).unwrap();
+        let (slots3, c3) =
+            oblivious_set_output(&backend, &candidates_for(3, &backend), 2, b).unwrap();
+
+        // (a) The REVEALED SLOT VECTOR has length exactly B in BOTH cases — the
+        // parties observe the same output cardinality whether 1 or 3 rows truly
+        // matched. This is the substantive obliviousness, not the bound echo.
+        assert_eq!(slots1.len(), b, "1-match: parties see exactly B slots");
+        assert_eq!(slots3.len(), b, "3-match: parties see exactly B slots");
         assert_eq!(
-            c1.bound, c3.bound,
-            "revealed slot bound must not depend on true match count"
+            slots1.len(),
+            slots3.len(),
+            "revealed slot count is independent of the true match count"
         );
-        assert_eq!(c1.bound, 5);
-        assert_eq!(c1.select_mults, 5);
+        // The modelled cost (slot count / selects) is likewise B-driven, not count-driven.
+        assert_eq!(c1.bound, b);
+        assert_eq!((c1.bound, c1.select_mults), (c3.bound, c3.select_mults));
+
+        // (b) The hidden join KEY never appears in ANY revealed slot of either run —
+        // only the disclosed payload is ever materialised.
+        for slots in [&slots1, &slots3] {
+            let rendered = format!("{slots:?}");
+            assert!(
+                !rendered.contains(&secret_key.to_string()),
+                "the hidden join key {secret_key} must NOT appear in any revealed slot: {rendered}"
+            );
+        }
     }
 
     /// PRIVACY (key never opened): the batched join discloses ONLY the payload
@@ -1691,10 +1745,9 @@ mod batched_hidden_value_tests {
         for n in [3usize, 5, 7] {
             let join =
                 HiddenValueJoin::new(ShamirBackend::new_seeded(n, 0xF0F0 + n as u64).unwrap());
-            // Left claims key 42; right has only 7 and 8 — no honest match exists.
+            // Control: both sides claim key 42 — a GENUINELY equal key DOES match.
             let l = positional("L", &["a"], &[(42u64, vec![lit("forged")])]);
             let r = positional("R", &["b"], &[(42u64, vec![lit("real")])]);
-            // Sanity: with a GENUINELY equal key it DOES match (control).
             let (ok, _) = join.batched_join(&l, &r, 1).unwrap();
             assert_eq!(
                 ok.rows.len(),

--- a/crates/sparq-mpc/src/join.rs
+++ b/crates/sparq-mpc/src/join.rs
@@ -37,7 +37,9 @@
 //! [`crate::backend::MpcBackend`] (M3) and on the Q2 trust-model fork + the Q3
 //! BGP-join obliviousness-cost analysis (RQ2b). No fake crypto here.
 
+use crate::batched::{BatchedShares, RowBinding};
 use crate::field::Fp;
+use crate::oblivious_join::{self, Candidate, MatchBit, ObliviousOutputCost};
 use crate::partial::{HolderId, MpcError, PartialResult};
 use crate::shamir::{self, ShamirBackend, ShamirDealer};
 use oxrdf::{Term, Variable};
@@ -474,6 +476,279 @@ impl HiddenValueJoin {
     }
 }
 
+// =====================================================================
+// [OPUS-4.8] sq-khf9 — the BATCHED hidden-value join: wire the
+// `BatchedShares` / `RowBinding` primitive (sq-dwb5) + the oblivious output
+// transform (`oblivious_join`, sq-jnkm) into the hidden join so it ranges over
+// a COLUMN of rows per holder under a documented row-binding, with the output
+// cardinality / ordering hidden.
+// =====================================================================
+
+/// A holder's BATCHED contribution to a hidden-value join: a COLUMN of rows
+/// addressed under an explicit [`RowBinding`] (sq-dwb5). The single-scalar
+/// [`HiddenKeyedRows`] caps a holder to an unstructured bag of rows; this carries
+/// the same per-row `(private_key_fp, disclosed_payload)` pairs **plus the
+/// row-binding contract** that says how rows correlate across holders.
+///
+/// Why a dedicated type (vs reusing [`HiddenKeyedRows`]). The row-binding is
+/// load-bearing for correctness: it decides which `(i, j)` pairs are even
+/// *candidates* (every pair under `Positional` aligned columns vs only same-key
+/// pairs under `Keyed`). It must travel WITH the rows so the join cannot silently
+/// correlate them the wrong way (the `batched.rs` contract).
+///
+/// ## Privacy of the key column (the sq-dwb5 primitive, actually used)
+///
+/// [`Self::shared_keys`] runs the holder's private key column through
+/// [`crate::shamir::ShamirDealer::share_batch`] → a [`BatchedShares`], so each
+/// row's key gets its OWN fresh degree-`t` masking polynomial and any `≤ t`
+/// parties' shares of the whole key column are jointly independent of every key
+/// (the batched-Shamir hiding property). This is the structural reason the keys
+/// never leak: the cleartext column is consumed only to deal the batch, exactly as
+/// the four-flatmates aggregate does for its salary column. The DISCLOSED payload
+/// columns ride alongside in the clear (disclosure-minimisation, convention #4 —
+/// only the *key* is hidden).
+#[derive(Debug, Clone)]
+pub struct BatchedHiddenInput {
+    /// The holder that owns this column.
+    pub holder: HolderId,
+    /// Disclosed payload column names (NOT including the hidden key).
+    pub payload_vars: Vec<Variable>,
+    /// One entry per row: `(private_key_fp, disclosed_payload_terms)`, in this
+    /// holder's local row order.
+    pub rows: Vec<(Fp, Vec<Option<Term>>)>,
+    /// How row `i` correlates across holders (see [`RowBinding`]).
+    pub binding: RowBinding,
+}
+
+impl BatchedHiddenInput {
+    /// Assemble a batched hidden input, validating the [`RowBinding::Keyed`] key
+    /// count against the row count (a mismatch is an ambiguous binding → a protocol
+    /// error, mirroring [`BatchedShares::new`]).
+    pub fn new(
+        holder: HolderId,
+        payload_vars: Vec<Variable>,
+        rows: Vec<(Fp, Vec<Option<Term>>)>,
+        binding: RowBinding,
+    ) -> Result<Self, MpcError> {
+        if let RowBinding::Keyed(keys) = &binding {
+            if keys.len() != rows.len() {
+                return Err(MpcError::Protocol(format!(
+                    "BatchedHiddenInput: keyed binding has {} keys but {} rows",
+                    keys.len(),
+                    rows.len()
+                )));
+            }
+        }
+        Ok(BatchedHiddenInput {
+            holder,
+            payload_vars,
+            rows,
+            binding,
+        })
+    }
+
+    /// Number of rows in this batch.
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Whether the batch is empty (a holder with no private rows).
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// Secret-share this holder's private KEY column as a [`BatchedShares`] under
+    /// the same [`RowBinding`] — the sq-dwb5 batched primitive, actually used. Each
+    /// key gets a fresh degree-`t` masking polynomial; the cleartext column is
+    /// consumed only to deal the batch.
+    pub fn shared_keys(&self, dealer: &mut ShamirDealer) -> Result<BatchedShares, MpcError> {
+        let keys: Vec<Fp> = self.rows.iter().map(|(k, _)| *k).collect();
+        BatchedShares::new(dealer.share_batch(&keys), self.binding.clone())
+    }
+}
+
+/// The result of a batched hidden join: the oblivious [`PartialResult`] (real rows
+/// only, dummies filtered, federation-attributed, canonical order) plus the
+/// MODELLED cost of the oblivious output transform.
+pub type BatchedJoinOutput = (PartialResult, ObliviousOutputCost);
+
+impl HiddenValueJoin {
+    /// **The batched hidden-value join (sq-khf9).** Join two holders' BATCHED
+    /// row-columns on a PRIVATE key, ranging over MANY rows per holder rather than
+    /// the single bag [`Self::join`] consumed, and route the result through the
+    /// **oblivious output transform** ([`crate::oblivious_join`]) so the output
+    /// cardinality (bounded to the public `bound` `B`) and ordering reveal nothing
+    /// about WHICH rows matched.
+    ///
+    /// ## How the batched inputs + [`RowBinding`] wire in
+    ///
+    /// 1. Each holder's private key column is secret-shared as a [`BatchedShares`]
+    ///    via [`BatchedHiddenInput::shared_keys`] (the sq-dwb5 primitive): the
+    ///    cleartext keys never leave, only the batched shares, and any `≤ t` parties'
+    ///    shares of the whole column are jointly independent of every key.
+    /// 2. The [`RowBinding`] decides the CANDIDATE pairs (the row-dimension lift of
+    ///    the secure-equal):
+    ///    - [`RowBinding::Positional`] — row `i` of L pairs ONLY with row `i` of R
+    ///      (index-correlated). Both batches must be the same length (aligned
+    ///      columns); a mismatch fails closed. `k` candidate pairs.
+    ///    - [`RowBinding::Keyed`] — rows correlate by the DISCLOSED public row key:
+    ///      row `i` of L pairs with row `j` of R iff `lkeys[i] == rkeys[j]`. The keys
+    ///      are disclosed (convention #4); the VALUE stays hidden. Correlation is by
+    ///      key, not index, so the orders need not match.
+    /// 3. For each candidate pair the match is decided by the existing
+    ///    [`Self::secure_equal`] over the secret-shared keys — the join key/value is
+    ///    NEVER opened; only the match bit is (see the honesty note).
+    /// 4. The candidates feed [`crate::oblivious_join::oblivious_join_output`] with
+    ///    [`MatchBit::Public`] bits and the public bound `B`: non-matches become
+    ///    indistinguishable dummies, the slots are oblivious-shuffled, and exactly
+    ///    `B` are revealed — so the OUTPUT does not leak the true match count
+    ///    (bounded to `B`) or which input pair produced which row.
+    ///
+    /// ## Privacy property enforced (state it precisely — empirical-honesty rule)
+    ///
+    /// - **The join KEY/VALUE is never reconstructed.** Only `secure_equal`'s masked
+    ///   product `m = d·r` is opened per candidate; `m = 0 ⇔ keys equal`, and for
+    ///   unequal keys `m` is uniform nonzero — it reveals ONLY the match bit, never
+    ///   either key or their difference (the sq-dwb5 batched-Shamir hiding lifts this
+    ///   to the whole column: ≤ t parties' views are independent of every key).
+    /// - **The OUTPUT cardinality + ordering are oblivious** to the protocol/parties:
+    ///   bounded to the public `B`, shuffled so position → candidate linkage is
+    ///   destroyed (`oblivious_join` L1-bounded / L2-destroyed at the OUTPUT).
+    ///
+    /// HONESTY (the gated half — NOT faked). The per-candidate match BIT is still
+    /// *opened* by `secure_equal` (the same L2-at-decision leak the scalar
+    /// [`Self::join`] has): deriving a SECRET-shared match bit from the keys WITHOUT
+    /// opening it needs a secure equality-to-shared-bit (bead sq-rrz4 on the
+    /// degree-reduction round sq-dvuc), the gate `oblivious_join`'s hidden-key entry
+    /// point names. So this closes the OUTPUT leaks (L1/L2 of the result set) but not
+    /// the decision-time match-graph leak; the fully-oblivious upgrade is a follow-up
+    /// bead. We do NOT claim the match graph is hidden from the parties. Semi-honest
+    /// only, unchanged from the [`ShamirBackend`] layer.
+    ///
+    /// ## Fail-closed contracts
+    ///
+    /// - `Positional`: both batches must be the same length (aligned columns) — else
+    ///   [`MpcError::Protocol`]. The candidate set is the `k` index-aligned pairs.
+    /// - `Keyed`: both batches must be `Keyed`; mixing bindings is a protocol error
+    ///   (the correlation rule would be ambiguous). Keys are matched in the clear.
+    /// - Mixed bindings (one `Positional`, one `Keyed`) → protocol error.
+    /// - `bound` must cover the candidate count (`oblivious_join_output` fails closed
+    ///   otherwise — never truncating a candidate, which could drop a true match).
+    /// - Both holders must agree on the disclosed payload arity per side; the output
+    ///   schema is `left.payload_vars ++ right.payload_vars`.
+    pub fn batched_join(
+        &self,
+        left: &BatchedHiddenInput,
+        right: &BatchedHiddenInput,
+        bound: usize,
+    ) -> Result<BatchedJoinOutput, MpcError> {
+        // Output schema: left payload vars then right payload vars (the key is NOT
+        // projected — it stays hidden, exactly as the scalar HiddenValueJoin).
+        let mut out_vars = left.payload_vars.clone();
+        out_vars.extend(right.payload_vars.iter().cloned());
+        let payload_arity = out_vars.len();
+
+        // Mint ONE fresh dealer for this protocol run (production: a fresh OS-seeded
+        // CSPRNG, sq-1vt) — independent masks, never a reused keystream across joins.
+        let mut dealer = self.backend.dealer();
+
+        // (1) Secret-share each holder's private key column as a BatchedShares (the
+        // sq-dwb5 primitive). We do not need to OPEN these — `secure_equal` shares
+        // the keys it compares internally — but dealing the batch here exercises the
+        // documented primitive + validates the keyed-binding key counts, and is the
+        // structural point at which the cleartext keys are consumed into shares.
+        let _l_shared = left.shared_keys(&mut dealer)?;
+        let _r_shared = right.shared_keys(&mut dealer)?;
+
+        // (2) Enumerate the candidate row pairs the RowBinding permits.
+        let pairs = candidate_pairs(&left.binding, &right.binding, left.len(), right.len())?;
+
+        // (3) Decide each candidate's match with the secure-equal primitive lifted to
+        // the row dimension. The join KEY/VALUE is never opened — only the match bit.
+        let mut candidates: Vec<Candidate> = Vec::with_capacity(pairs.len());
+        for (li, rj) in pairs {
+            let (lkey, lpay) = &left.rows[li];
+            let (rkey, rpay) = &right.rows[rj];
+            let matched = self.secure_equal(&mut dealer, *lkey, *rkey)?;
+            let mut payload = lpay.clone();
+            payload.extend(rpay.iter().cloned());
+            // Pad / validate to the uniform output arity so the oblivious output's
+            // recipient sees one schema (a short row is a malformed input, not a
+            // silent truncation).
+            if payload.len() != payload_arity {
+                return Err(MpcError::Protocol(format!(
+                    "batched_join: candidate payload arity {} != schema arity {payload_arity} \
+                     (left {} + right {} payload vars)",
+                    payload.len(),
+                    left.payload_vars.len(),
+                    right.payload_vars.len()
+                )));
+            }
+            candidates.push(Candidate {
+                payload,
+                matched: MatchBit::Public(matched),
+            });
+        }
+
+        // (4) Route through the oblivious output transform: hide which candidates
+        // matched (shuffle) and bound the revealed cardinality to the public `B`.
+        oblivious_join::oblivious_join_output(&self.backend, &candidates, out_vars, bound)
+    }
+}
+
+/// Enumerate the candidate `(left_row, right_row)` index pairs the row-binding
+/// permits — the row-dimension lift of which pairs the secure-equal even tests.
+///
+/// - [`RowBinding::Positional`] (both sides): index-correlated. The two columns
+///   must be the same length (aligned positional columns, the `batched.rs`
+///   contract); the candidates are the `k` pairs `(i, i)`.
+/// - [`RowBinding::Keyed`] (both sides): correlated by the DISCLOSED public row
+///   key. Candidate `(i, j)` iff `lkeys[i] == rkeys[j]` — a clear-text bucketed
+///   join over the disclosed keys (convention #4); the VALUE stays hidden and is
+///   still decided by `secure_equal`.
+/// - Mixed bindings are a protocol error (the correlation rule is ambiguous).
+fn candidate_pairs(
+    left: &RowBinding,
+    right: &RowBinding,
+    llen: usize,
+    rlen: usize,
+) -> Result<Vec<(usize, usize)>, MpcError> {
+    match (left, right) {
+        (RowBinding::Positional, RowBinding::Positional) => {
+            if llen != rlen {
+                return Err(MpcError::Protocol(format!(
+                    "batched_join (Positional): left has {llen} rows but right has {rlen} — \
+                     index-correlated columns must be equal length"
+                )));
+            }
+            Ok((0..llen).map(|i| (i, i)).collect())
+        }
+        (RowBinding::Keyed(lkeys), RowBinding::Keyed(rkeys)) => {
+            // Bucket the right rows by disclosed key, then emit (i, j) for every
+            // left row whose key hits a bucket — a clear-text equi-join over the
+            // DISCLOSED keys (the value stays hidden, decided by secure_equal).
+            let mut right_by_key: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
+            for (j, k) in rkeys.iter().enumerate() {
+                right_by_key.entry(k.as_str()).or_default().push(j);
+            }
+            let mut pairs = Vec::new();
+            for (i, k) in lkeys.iter().enumerate() {
+                if let Some(js) = right_by_key.get(k.as_str()) {
+                    for &j in js {
+                        pairs.push((i, j));
+                    }
+                }
+            }
+            Ok(pairs)
+        }
+        _ => Err(MpcError::Protocol(
+            "batched_join: mixed row-bindings (one Positional, one Keyed) — \
+             both holders must share the same correlation contract"
+                .into(),
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     //! M2 tests: the disclosed-key global-IRI equi-join. The load-bearing one is
@@ -497,7 +772,10 @@ mod tests {
     /// results are equal as SPARQL solution multisets iff this is equal. Used to
     /// compare the federated join against the union-store evaluation regardless
     /// of column order or row order.
-    fn canonical_multiset(vars: &[Variable], rows: &[Vec<Option<Term>>]) -> Vec<Vec<(String, String)>> {
+    fn canonical_multiset(
+        vars: &[Variable],
+        rows: &[Vec<Option<Term>>],
+    ) -> Vec<Vec<(String, String)>> {
         let mut out: Vec<Vec<(String, String)>> = rows
             .iter()
             .map(|row| {
@@ -553,8 +831,13 @@ mod tests {
             .evaluate_local("PREFIX ex: <http://ex/> SELECT ?x ?n WHERE { ?x ex:name ?n }")
             .unwrap();
 
-        let plan = JoinPlan { join_var: var("x"), key_disclosed: true };
-        let joined = DisclosedKeyJoin.join(&[pa, pb], &plan).expect("disclosed-key join ok");
+        let plan = JoinPlan {
+            join_var: var("x"),
+            key_disclosed: true,
+        };
+        let joined = DisclosedKeyJoin
+            .join(&[pa, pb], &plan)
+            .expect("disclosed-key join ok");
 
         // Federated result is attributed to the synthetic federation holder, not
         // to any single source.
@@ -598,7 +881,10 @@ mod tests {
             .unwrap();
         assert!(pb.is_empty(), "Holder B discloses no rows for its fragment");
 
-        let plan = JoinPlan { join_var: var("x"), key_disclosed: true };
+        let plan = JoinPlan {
+            join_var: var("x"),
+            key_disclosed: true,
+        };
         let joined = DisclosedKeyJoin.join(&[pa, pb], &plan).unwrap();
         assert!(joined.is_empty(), "join with an empty partial is empty");
 
@@ -633,7 +919,10 @@ mod tests {
             .evaluate_local("PREFIX ex: <http://ex/> SELECT ?x ?n WHERE { ?x ex:name ?n }")
             .unwrap();
 
-        let plan = JoinPlan { join_var: var("x"), key_disclosed: true };
+        let plan = JoinPlan {
+            join_var: var("x"),
+            key_disclosed: true,
+        };
         let joined = DisclosedKeyJoin.join(&[pa, pb], &plan).unwrap();
         assert_eq!(joined.rows.len(), 4, "2 knowers × 2 names on the x1 key");
 
@@ -666,9 +955,7 @@ mod tests {
             .evaluate_local("PREFIX ex: <http://ex/> SELECT ?p ?x WHERE { ?p ex:knows ?x }")
             .unwrap();
         let pb = b
-            .evaluate_local(
-                "PREFIX ex: <http://ex/> SELECT ?x ?y WHERE { ?x ex:supervisedBy ?y }",
-            )
+            .evaluate_local("PREFIX ex: <http://ex/> SELECT ?x ?y WHERE { ?x ex:supervisedBy ?y }")
             .unwrap();
         let pc = c
             .evaluate_local("PREFIX ex: <http://ex/> SELECT ?y ?n WHERE { ?y ex:name ?n }")
@@ -679,10 +966,22 @@ mod tests {
         // each step naming its shared var. (A single JoinPlan models one join;
         // the chain is two joins.)
         let ab = DisclosedKeyJoin
-            .join(&[pa, pb], &JoinPlan { join_var: var("x"), key_disclosed: true })
+            .join(
+                &[pa, pb],
+                &JoinPlan {
+                    join_var: var("x"),
+                    key_disclosed: true,
+                },
+            )
             .unwrap();
         let abc = DisclosedKeyJoin
-            .join(&[ab, pc], &JoinPlan { join_var: var("y"), key_disclosed: true })
+            .join(
+                &[ab, pc],
+                &JoinPlan {
+                    join_var: var("y"),
+                    key_disclosed: true,
+                },
+            )
             .unwrap();
 
         let u = union_graph(&[a_doc, b_doc, c_doc]);
@@ -715,7 +1014,10 @@ mod tests {
             .evaluate_local("PREFIX ex: <http://ex/> SELECT ?x ?n WHERE { ?x ex:name ?n }")
             .unwrap();
         // Planner names ?wrong — present in NEITHER partial.
-        let plan = JoinPlan { join_var: var("wrong"), key_disclosed: true };
+        let plan = JoinPlan {
+            join_var: var("wrong"),
+            key_disclosed: true,
+        };
         let err = DisclosedKeyJoin.join(&[pa, pb], &plan).unwrap_err();
         match err {
             MpcError::Protocol(m) => assert!(m.contains("did not disclose the join key")),
@@ -726,7 +1028,10 @@ mod tests {
     /// An empty federation is a Protocol precondition violation, not a panic.
     #[test]
     fn empty_federation_is_a_protocol_error() {
-        let plan = JoinPlan { join_var: var("x"), key_disclosed: true };
+        let plan = JoinPlan {
+            join_var: var("x"),
+            key_disclosed: true,
+        };
         let err = DisclosedKeyJoin.join(&[], &plan).unwrap_err();
         assert!(matches!(err, MpcError::Protocol(_)));
     }
@@ -741,8 +1046,13 @@ mod tests {
         let pa = a
             .evaluate_local("PREFIX ex: <http://ex/> SELECT ?p ?x WHERE { ?p ex:knows ?x }")
             .unwrap();
-        let plan = JoinPlan { join_var: var("x"), key_disclosed: true };
-        let joined = DisclosedKeyJoin.join(std::slice::from_ref(&pa), &plan).unwrap();
+        let plan = JoinPlan {
+            join_var: var("x"),
+            key_disclosed: true,
+        };
+        let joined = DisclosedKeyJoin
+            .join(std::slice::from_ref(&pa), &plan)
+            .unwrap();
         assert_eq!(joined.rows.len(), pa.rows.len());
         assert_eq!(
             canonical_multiset(&joined.vars, &joined.rows),
@@ -762,7 +1072,10 @@ mod tests {
             .evaluate_local("PREFIX ex: <http://ex/> SELECT ?p ?x WHERE { ?p ex:knows ?x }")
             .unwrap();
         // key_disclosed == false → the private-value regime.
-        let plan = JoinPlan { join_var: var("x"), key_disclosed: false };
+        let plan = JoinPlan {
+            join_var: var("x"),
+            key_disclosed: false,
+        };
         let err = DisclosedKeyJoin.join(&[pa], &plan).unwrap_err();
         match err {
             MpcError::NotYetImplemented { gated_on, what } => {
@@ -870,7 +1183,11 @@ mod hidden_value_tests {
         assert_eq!(got.holder, HolderId::new("federation"));
 
         let expected = plaintext_join(&l_rows, &r_rows);
-        assert_eq!(multiset(&got.rows), multiset(&expected), "hidden join must equal plaintext join");
+        assert_eq!(
+            multiset(&got.rows),
+            multiset(&expected),
+            "hidden join must equal plaintext join"
+        );
         // Concretely: Bob-Leeds, Carol-York. 2 rows.
         assert_eq!(got.rows.len(), 2);
     }
@@ -885,7 +1202,10 @@ mod hidden_value_tests {
             .join(&keyed("L", &["l"], &l_rows), &keyed("R", &["r"], &r_rows))
             .unwrap();
         assert!(got.rows.is_empty());
-        assert_eq!(multiset(&got.rows), multiset(&plaintext_join(&l_rows, &r_rows)));
+        assert_eq!(
+            multiset(&got.rows),
+            multiset(&plaintext_join(&l_rows, &r_rows))
+        );
     }
 
     /// Multi-match fan-out: a private key shared by several rows on each side
@@ -904,7 +1224,10 @@ mod hidden_value_tests {
             .join(&keyed("L", &["l"], &l_rows), &keyed("R", &["r"], &r_rows))
             .unwrap();
         assert_eq!(got.rows.len(), 4, "2x2 cartesian on key 42");
-        assert_eq!(multiset(&got.rows), multiset(&plaintext_join(&l_rows, &r_rows)));
+        assert_eq!(
+            multiset(&got.rows),
+            multiset(&plaintext_join(&l_rows, &r_rows))
+        );
     }
 
     /// Empty side → empty join (an empty holder contributes nothing).
@@ -927,11 +1250,19 @@ mod hidden_value_tests {
         let backend = ShamirBackend::new_seeded(5, 0xD00D).unwrap();
         let join = HiddenValueJoin::new(backend);
         let mut dealer = join.backend.dealer();
-        assert!(join.secure_equal(&mut dealer, Fp::new(12345), Fp::new(12345)).unwrap());
-        assert!(!join.secure_equal(&mut dealer, Fp::new(12345), Fp::new(12346)).unwrap());
+        assert!(join
+            .secure_equal(&mut dealer, Fp::new(12345), Fp::new(12345))
+            .unwrap());
+        assert!(!join
+            .secure_equal(&mut dealer, Fp::new(12345), Fp::new(12346))
+            .unwrap());
         // Zero is a valid key value and equality with zero still works.
-        assert!(join.secure_equal(&mut dealer, Fp::zero(), Fp::zero()).unwrap());
-        assert!(!join.secure_equal(&mut dealer, Fp::zero(), Fp::new(1)).unwrap());
+        assert!(join
+            .secure_equal(&mut dealer, Fp::zero(), Fp::zero())
+            .unwrap());
+        assert!(!join
+            .secure_equal(&mut dealer, Fp::zero(), Fp::new(1))
+            .unwrap());
     }
 
     /// The honest-majority constructor never under-provisions for the single
@@ -941,7 +1272,9 @@ mod hidden_value_tests {
     fn secure_equal_does_not_falsely_guard_party_count() {
         let join = HiddenValueJoin::new(ShamirBackend::new_seeded(3, 0).unwrap());
         let mut dealer = join.backend.dealer();
-        assert!(join.secure_equal(&mut dealer, Fp::new(5), Fp::new(5)).is_ok());
+        assert!(join
+            .secure_equal(&mut dealer, Fp::new(5), Fp::new(5))
+            .is_ok());
     }
 
     /// STRESS / adversarial: the secure equality test must have ZERO false
@@ -966,9 +1299,480 @@ mod hidden_value_tests {
                     ShamirBackend::new_seeded(n, trial.wrapping_mul(31).wrapping_add(1)).unwrap(),
                 );
                 let mut dealer = join.backend.dealer();
-                let got = join.secure_equal(&mut dealer, Fp::new(a), Fp::new(b)).unwrap();
-                assert_eq!(got, a == b, "n={n} a={a} b={b}: secure_equal disagreed with plaintext");
+                let got = join
+                    .secure_equal(&mut dealer, Fp::new(a), Fp::new(b))
+                    .unwrap();
+                assert_eq!(
+                    got,
+                    a == b,
+                    "n={n} a={a} b={b}: secure_equal disagreed with plaintext"
+                );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod batched_hidden_value_tests {
+    //! sq-khf9 — the BATCHED hidden-value join over a COLUMN of rows per holder,
+    //! wiring the sq-dwb5 `BatchedShares`/`RowBinding` primitive + the sq-jnkm
+    //! oblivious output transform into `HiddenValueJoin::batched_join`. The
+    //! load-bearing tests:
+    //! - `differential_*`: the batched join's REAL (dummy-filtered) output multiset
+    //!   equals the plaintext join over the union of the two holders' row columns,
+    //!   under each row-binding regime — keys PRIVATE, never reconstructed.
+    //! - row-binding correctness (Positional + Keyed) across n ∈ {3,5,7}.
+    //! - privacy: the join VALUE is never opened (only the oblivious output is) and
+    //!   the revealed output cardinality is the public bound B, not the true count.
+    //! - a forged-match soundness case (a fabricated key cannot induce a match,
+    //!   consistent with the existing secure-equal soundness).
+    use super::*;
+    use crate::oblivious_join::OutputSlot;
+    use crate::shamir::ShamirBackend;
+
+    fn var(n: &str) -> Variable {
+        Variable::new_unchecked(n)
+    }
+
+    fn lit(s: &str) -> Option<Term> {
+        Some(Term::Literal(oxrdf::Literal::new_simple_literal(s)))
+    }
+
+    /// Build a POSITIONAL batched input from `(key, payload)` rows.
+    fn positional(
+        holder: &str,
+        payload_vars: &[&str],
+        rows: &[(u64, Vec<Option<Term>>)],
+    ) -> BatchedHiddenInput {
+        BatchedHiddenInput::new(
+            HolderId::new(holder),
+            payload_vars.iter().map(|v| var(v)).collect(),
+            rows.iter().map(|(k, p)| (Fp::new(*k), p.clone())).collect(),
+            RowBinding::Positional,
+        )
+        .unwrap()
+    }
+
+    /// Build a KEYED batched input from `(disclosed_key, hidden_key, payload)` rows.
+    /// The DISCLOSED key is the public row id (correlation), the HIDDEN key is the
+    /// `Fp` value matched under secure-equal.
+    fn keyed(
+        holder: &str,
+        payload_vars: &[&str],
+        rows: &[(&str, u64, Vec<Option<Term>>)],
+    ) -> BatchedHiddenInput {
+        let disclosed: Vec<String> = rows.iter().map(|(k, _, _)| (*k).to_string()).collect();
+        BatchedHiddenInput::new(
+            HolderId::new(holder),
+            payload_vars.iter().map(|v| var(v)).collect(),
+            rows.iter()
+                .map(|(_, h, p)| (Fp::new(*h), p.clone()))
+                .collect(),
+            RowBinding::Keyed(disclosed),
+        )
+        .unwrap()
+    }
+
+    /// The REAL (non-dummy) rows of a join output, as an order-independent multiset.
+    fn real_multiset(result: &PartialResult) -> Vec<String> {
+        let mut m: Vec<String> = result.rows.iter().map(|r| format!("{r:?}")).collect();
+        m.sort();
+        m
+    }
+
+    fn expect_multiset(rows: &[Vec<Option<Term>>]) -> Vec<String> {
+        let mut m: Vec<String> = rows.iter().map(|r| format!("{r:?}")).collect();
+        m.sort();
+        m
+    }
+
+    // ============================ POSITIONAL regime ============================
+
+    /// THE Positional differential across n ∈ {3,5,7}: two equal-length columns,
+    /// row `i` of L paired with row `i` of R; the batched join's real output equals
+    /// the index-aligned plaintext join — keys PRIVATE, never reconstructed.
+    #[test]
+    fn positional_differential_equals_plaintext_across_party_counts() {
+        // Row i matches iff lkeys[i] == rkeys[i]. Rows 0 and 2 match (10, 30); row 1
+        // does not (20 vs 99).
+        let l = [
+            (10u64, vec![lit("L0")]),
+            (20, vec![lit("L1")]),
+            (30, vec![lit("L2")]),
+        ];
+        let r = [
+            (10u64, vec![lit("R0")]),
+            (99, vec![lit("R1")]),
+            (30, vec![lit("R2")]),
+        ];
+        // Plaintext index-aligned join.
+        let expected: Vec<Vec<Option<Term>>> = (0..l.len())
+            .filter(|&i| l[i].0 == r[i].0)
+            .map(|i| {
+                let mut row = l[i].1.clone();
+                row.extend(r[i].1.iter().cloned());
+                row
+            })
+            .collect();
+
+        for n in [3usize, 5, 7] {
+            let backend = ShamirBackend::new_seeded(n, 0xB47C + n as u64).unwrap();
+            let join = HiddenValueJoin::new(backend);
+            let li = positional("L", &["lname"], &l);
+            let ri = positional("R", &["rname"], &r);
+            // Bound B = candidate count (3); the revealed slot count is B, not the
+            // true 2 matches.
+            let (result, cost) = join.batched_join(&li, &ri, 3).unwrap();
+            assert_eq!(result.holder, HolderId::new("federation"));
+            assert_eq!(result.vars, vec![var("lname"), var("rname")]);
+            assert_eq!(cost.bound, 3, "n={n}: revealed slot bound is B");
+            assert_eq!(
+                real_multiset(&result),
+                expect_multiset(&expected),
+                "n={n}: batched positional join != plaintext index-aligned join"
+            );
+            assert_eq!(result.rows.len(), 2, "n={n}: exactly the 2 matching rows");
+        }
+    }
+
+    /// Positional fails closed on mis-aligned (unequal-length) columns — never a
+    /// silent wrong answer.
+    #[test]
+    fn positional_unequal_lengths_fails_closed() {
+        let join = HiddenValueJoin::new(ShamirBackend::new_seeded(3, 1).unwrap());
+        let l = positional("L", &["a"], &[(1u64, vec![lit("x")]), (2, vec![lit("y")])]);
+        let r = positional("R", &["b"], &[(1u64, vec![lit("p")])]);
+        let err = join.batched_join(&l, &r, 4).unwrap_err();
+        assert!(matches!(err, MpcError::Protocol(m) if m.contains("equal length")));
+    }
+
+    // ============================== KEYED regime ==============================
+
+    /// THE Keyed differential across n ∈ {3,5,7}: rows correlate by the DISCLOSED
+    /// public key (orders need NOT match); within a shared disclosed key the HIDDEN
+    /// value still gates the match via secure-equal. Real output == plaintext join.
+    #[test]
+    fn keyed_differential_equals_plaintext_across_party_counts() {
+        // Disclosed keys correlate rows; hidden values gate the actual match.
+        // ("r1", hidden 100) on both → match. ("r2", hidden 200 vs 999) → key
+        // correlates but hidden values differ → NO match. ("r3") only on left.
+        let l = [
+            ("r1", 100u64, vec![lit("LA")]),
+            ("r2", 200, vec![lit("LB")]),
+            ("r3", 300, vec![lit("LC")]),
+        ];
+        // R in a DIFFERENT order to prove key-correlation (not index).
+        let r = [
+            ("r2", 999u64, vec![lit("RB")]),
+            ("r1", 100, vec![lit("RA")]),
+        ];
+        // Plaintext keyed join: same disclosed key AND same hidden value.
+        let mut expected: Vec<Vec<Option<Term>>> = Vec::new();
+        for (lk, lh, lp) in &l {
+            for (rk, rh, rp) in &r {
+                if lk == rk && lh == rh {
+                    let mut row = lp.clone();
+                    row.extend(rp.iter().cloned());
+                    expected.push(row);
+                }
+            }
+        }
+
+        for n in [3usize, 5, 7] {
+            let backend = ShamirBackend::new_seeded(n, 0x6EE7 + n as u64).unwrap();
+            let join = HiddenValueJoin::new(backend);
+            let li = keyed("L", &["lname"], &l);
+            let ri = keyed("R", &["rname"], &r);
+            // Candidate count = key-bucket matches: r1 (1×1) + r2 (1×1) = 2.
+            let (result, cost) = join.batched_join(&li, &ri, 2).unwrap();
+            assert_eq!(cost.bound, 2, "n={n}");
+            assert_eq!(
+                real_multiset(&result),
+                expect_multiset(&expected),
+                "n={n}: batched keyed join != plaintext keyed join"
+            );
+            // Only ("r1", 100) actually matches on the hidden value.
+            assert_eq!(result.rows.len(), 1, "n={n}: only the r1/100 row matches");
+            assert_eq!(result.rows[0], vec![lit("LA"), lit("RA")]);
+        }
+    }
+
+    /// Keyed multi-row fan-out within a shared disclosed key: 2×2 hidden-value
+    /// matches inside one key bucket → cartesian, equal to plaintext.
+    #[test]
+    fn keyed_fanout_within_a_key_bucket() {
+        // All under disclosed key "k", hidden value 7 shared by 2 rows each side.
+        let l = [
+            ("k", 7u64, vec![lit("L1")]),
+            ("k", 7, vec![lit("L2")]),
+            ("k", 8, vec![lit("L3")]), // hidden 8 → no right match
+        ];
+        let r = [("k", 7u64, vec![lit("R1")]), ("k", 7, vec![lit("R2")])];
+        let join = HiddenValueJoin::new(ShamirBackend::new_seeded(5, 0xFA00).unwrap());
+        let li = keyed("L", &["l"], &l);
+        let ri = keyed("R", &["r"], &r);
+        // Candidate pairs in the "k" bucket: 3 left × 2 right = 6; B must cover them.
+        let (result, _) = join.batched_join(&li, &ri, 6).unwrap();
+        // Hidden-value matches: the two 7-rows on each side → 2×2 = 4.
+        assert_eq!(result.rows.len(), 4, "2×2 cartesian on hidden value 7");
+    }
+
+    /// Disjoint disclosed keys → zero candidates → empty real output.
+    #[test]
+    fn keyed_disjoint_keys_is_empty() {
+        let l = [("a", 1u64, vec![lit("x")])];
+        let r = [("b", 1u64, vec![lit("y")])];
+        let join = HiddenValueJoin::new(ShamirBackend::new_seeded(3, 2).unwrap());
+        let (result, _) = join
+            .batched_join(&keyed("L", &["l"], &l), &keyed("R", &["r"], &r), 0)
+            .unwrap();
+        assert!(result.rows.is_empty());
+    }
+
+    /// Mixed bindings (one Positional, one Keyed) is a protocol error — the
+    /// correlation rule would be ambiguous.
+    #[test]
+    fn mixed_bindings_is_a_protocol_error() {
+        let join = HiddenValueJoin::new(ShamirBackend::new_seeded(3, 1).unwrap());
+        let l = positional("L", &["a"], &[(1u64, vec![lit("x")])]);
+        let r = keyed("R", &["b"], &[("k", 1u64, vec![lit("y")])]);
+        let err = join.batched_join(&l, &r, 1).unwrap_err();
+        assert!(matches!(err, MpcError::Protocol(m) if m.contains("mixed row-bindings")));
+    }
+
+    // ============================== Privacy ==============================
+
+    /// PRIVACY (L1 at the OUTPUT): two candidate sets with DIFFERENT true match
+    /// counts but the SAME candidate count + bound reveal the IDENTICAL number of
+    /// output SLOTS — the oblivious output bounds the revealed cardinality to B, so
+    /// the protocol/parties learn B, not the true count. (The recipient who filters
+    /// dummies learns the true count; that is inherent and documented.)
+    #[test]
+    fn output_cardinality_is_bounded_to_b_not_true_count() {
+        // Same B and candidate count, different number of true matches.
+        let one = positional(
+            "L",
+            &["a"],
+            &[
+                (1u64, vec![lit("p")]),
+                (2, vec![lit("q")]),
+                (3, vec![lit("r")]),
+            ],
+        );
+        let one_r = positional(
+            "R",
+            &["b"],
+            &[
+                (1u64, vec![lit("p")]),
+                (9, vec![lit("q")]),
+                (8, vec![lit("r")]),
+            ],
+        ); // 1 match
+        let three_r = positional(
+            "R",
+            &["b"],
+            &[
+                (1u64, vec![lit("p")]),
+                (2, vec![lit("q")]),
+                (3, vec![lit("r")]),
+            ],
+        ); // 3 matches
+
+        let join = HiddenValueJoin::new(ShamirBackend::new_seeded(3, 0x5217).unwrap());
+        // Use the lower-level oblivious set output via batched_join's transform by
+        // counting revealed slots: re-run the transform with a padded bound B=5.
+        // batched_join returns the FILTERED PartialResult, so to observe the SLOT
+        // count we go through the candidate path with the same B and compare the
+        // transform's `cost.bound` (the revealed count) — identical regardless of
+        // true matches.
+        let (_, c1) = join.batched_join(&one, &one_r, 5).unwrap();
+        let (_, c3) = join.batched_join(&one, &three_r, 5).unwrap();
+        assert_eq!(
+            c1.bound, c3.bound,
+            "revealed slot bound must not depend on true match count"
+        );
+        assert_eq!(c1.bound, 5);
+        assert_eq!(c1.select_mults, 5);
+    }
+
+    /// PRIVACY (key never opened): the batched join discloses ONLY the payload
+    /// columns; the hidden key column is never projected into the output schema,
+    /// and the output rows contain only the payload terms — never the key value.
+    #[test]
+    fn key_value_is_never_in_the_output() {
+        let secret_key = 0xDEAD_BEEFu64;
+        let l = positional("L", &["lname"], &[(secret_key, vec![lit("Alice")])]);
+        let r = positional("R", &["rname"], &[(secret_key, vec![lit("Leeds")])]);
+        let join = HiddenValueJoin::new(ShamirBackend::new_seeded(3, 0xABCD).unwrap());
+        let (result, _) = join.batched_join(&l, &r, 1).unwrap();
+        // Schema is payload-only — the key var is absent.
+        assert_eq!(result.vars, vec![var("lname"), var("rname")]);
+        assert_eq!(result.rows.len(), 1);
+        // No output term encodes the secret key (it is hidden; only payload shows).
+        let rendered = format!("{:?}", result.rows);
+        assert!(
+            !rendered.contains(&secret_key.to_string()),
+            "the hidden key {secret_key} must NOT appear in the disclosed output: {rendered}"
+        );
+        assert_eq!(result.rows[0], vec![lit("Alice"), lit("Leeds")]);
+    }
+
+    /// PRIVACY (output order is shuffled): across several seeds the Row/Dummy
+    /// classification of the OUTPUT SLOTS varies — the oblivious shuffle destroyed
+    /// the position→candidate linkage. We observe via the lower-level set output so
+    /// we can see slots (batched_join filters dummies). This mirrors the
+    /// `oblivious_join` L2 test, exercised through the batched candidate path.
+    #[test]
+    fn output_order_is_oblivious_across_seeds() {
+        use crate::oblivious_join::oblivious_set_output;
+        // Build candidates exactly as batched_join would for a positional column
+        // with matches at fixed input positions 0,2,4.
+        let l = [
+            (1u64, vec![lit("p0")]),
+            (2, vec![lit("p1")]),
+            (3, vec![lit("p2")]),
+            (4, vec![lit("p3")]),
+            (5, vec![lit("p4")]),
+        ];
+        let r = [
+            (1u64, vec![lit("q0")]),
+            (99, vec![lit("q1")]),
+            (3, vec![lit("q2")]),
+            (98, vec![lit("q3")]),
+            (5, vec![lit("q4")]),
+        ];
+        let mut patterns = std::collections::HashSet::new();
+        for seed in 0..32u64 {
+            let backend = ShamirBackend::new_seeded(3, 2000 + seed).unwrap();
+            let join = HiddenValueJoin::new(backend.clone());
+            let mut dealer = backend.dealer();
+            // Reproduce candidate decisions (positional, index-aligned).
+            let mut cands = Vec::new();
+            for i in 0..l.len() {
+                let matched = join
+                    .secure_equal(&mut dealer, Fp::new(l[i].0), Fp::new(r[i].0))
+                    .unwrap();
+                let mut payload = l[i].1.clone();
+                payload.extend(r[i].1.iter().cloned());
+                cands.push(Candidate {
+                    payload,
+                    matched: MatchBit::Public(matched),
+                });
+            }
+            let (slots, _) = oblivious_set_output(&backend, &cands, 2, 5).unwrap();
+            let pat: Vec<bool> = slots
+                .iter()
+                .map(|s| matches!(s, OutputSlot::Row(_)))
+                .collect();
+            patterns.insert(pat);
+            assert_eq!(
+                slots
+                    .iter()
+                    .filter(|s| matches!(s, OutputSlot::Row(_)))
+                    .count(),
+                3
+            );
+        }
+        assert!(
+            patterns.len() > 1,
+            "output match positions never moved — not oblivious"
+        );
+    }
+
+    // ============================== Soundness ==============================
+
+    /// SOUNDNESS / negative: a forged key cannot manufacture a match. A left row
+    /// whose key differs from every right key yields NO match through secure-equal
+    /// (the masked product opens to a uniform nonzero, never 0), so it is filtered
+    /// to a dummy and never appears in the disclosed output — consistent with the
+    /// existing secure-equal soundness. Run across n ∈ {3,5,7}.
+    #[test]
+    fn forged_match_attempt_fails() {
+        for n in [3usize, 5, 7] {
+            let join =
+                HiddenValueJoin::new(ShamirBackend::new_seeded(n, 0xF0F0 + n as u64).unwrap());
+            // Left claims key 42; right has only 7 and 8 — no honest match exists.
+            let l = positional("L", &["a"], &[(42u64, vec![lit("forged")])]);
+            let r = positional("R", &["b"], &[(42u64, vec![lit("real")])]);
+            // Sanity: with a GENUINELY equal key it DOES match (control).
+            let (ok, _) = join.batched_join(&l, &r, 1).unwrap();
+            assert_eq!(
+                ok.rows.len(),
+                1,
+                "n={n}: a genuine equal key matches (control)"
+            );
+
+            // Now the forge: distinct keys must NOT match.
+            let l_bad = positional("L", &["a"], &[(42u64, vec![lit("forged")])]);
+            let r_bad = positional("R", &["b"], &[(43u64, vec![lit("real")])]);
+            let (bad, _) = join.batched_join(&l_bad, &r_bad, 1).unwrap();
+            assert!(
+                bad.rows.is_empty(),
+                "n={n}: distinct keys must not produce a match (no forged match)"
+            );
+        }
+    }
+
+    /// Bound below the candidate count fails closed (the oblivious transform never
+    /// truncates a candidate, which could drop a true match).
+    #[test]
+    fn bound_below_candidate_count_fails_closed() {
+        let join = HiddenValueJoin::new(ShamirBackend::new_seeded(3, 1).unwrap());
+        // 3 positional candidates but B = 1.
+        let l = positional(
+            "L",
+            &["a"],
+            &[
+                (1u64, vec![lit("x")]),
+                (2, vec![lit("y")]),
+                (3, vec![lit("z")]),
+            ],
+        );
+        let r = positional(
+            "R",
+            &["b"],
+            &[
+                (1u64, vec![lit("p")]),
+                (2, vec![lit("q")]),
+                (3, vec![lit("r")]),
+            ],
+        );
+        let err = join.batched_join(&l, &r, 1).unwrap_err();
+        assert!(matches!(err, MpcError::Protocol(m) if m.contains("truncate")));
+    }
+
+    /// A keyed binding with a mismatched disclosed-key count is rejected at
+    /// construction (ambiguous binding), mirroring `BatchedShares::new`.
+    #[test]
+    fn keyed_input_key_count_must_match_rows() {
+        let err = BatchedHiddenInput::new(
+            HolderId::new("L"),
+            vec![var("a")],
+            vec![(Fp::new(1), vec![lit("x")]), (Fp::new(2), vec![lit("y")])],
+            RowBinding::Keyed(vec!["only-one".into()]),
+        )
+        .unwrap_err();
+        assert!(matches!(err, MpcError::Protocol(m) if m.contains("keyed binding")));
+    }
+
+    /// The sq-dwb5 batched primitive is actually exercised: `shared_keys` produces a
+    /// `BatchedShares` whose length matches the row count and whose binding is
+    /// preserved (the documented row-binding travels with the shares).
+    #[test]
+    fn shared_keys_uses_the_batched_primitive() {
+        let backend = ShamirBackend::new_seeded(5, 0x5151).unwrap();
+        let input = positional(
+            "L",
+            &["a"],
+            &[
+                (11u64, vec![lit("x")]),
+                (22, vec![lit("y")]),
+                (33, vec![lit("z")]),
+            ],
+        );
+        let mut dealer = backend.dealer();
+        let shared = input.shared_keys(&mut dealer).unwrap();
+        assert_eq!(shared.len(), 3, "one batched sharing per row");
+        assert_eq!(*shared.binding(), RowBinding::Positional);
     }
 }

--- a/crates/sparq-mpc/src/lib.rs
+++ b/crates/sparq-mpc/src/lib.rs
@@ -223,7 +223,10 @@ pub use compare::{
 };
 pub use field::Fp;
 pub use holder::{Holder, HolderResult};
-pub use join::{DisclosedKeyJoin, GlobalJoin, HiddenKeyedRows, HiddenValueJoin, JoinPlan};
+pub use join::{
+    BatchedHiddenInput, BatchedJoinOutput, DisclosedKeyJoin, GlobalJoin, HiddenKeyedRows,
+    HiddenValueJoin, JoinPlan,
+};
 pub use metrics::{CommCounter, FIELD_BYTES};
 pub use oblivious::{
     shuffle, sort_by, sort_with_keys, AccessPattern, Comparator, SecretColumn, ShuffleCost,


### PR DESCRIPTION
> 🤖 SPARQ agent

Wires the **sq-dwb5 `BatchedShares`/`RowBinding` primitive** (#191) and the **sq-jnkm oblivious output transform** into `HiddenValueJoin` so the hidden-value join can range over a **column of rows per holder** under a documented row-binding, with the output cardinality/ordering hidden. Closes the JOIN half of the multi-row work (the multi-row secure AGGREGATE landed in #191). Refs **sq-khf9**, **sq-dwb5**.

## How the batched inputs + RowBinding wire into the join

- **`BatchedHiddenInput`** (new): a holder's per-row `(private_key_fp, disclosed_payload)` column **plus its `RowBinding`**. `shared_keys()` deals the private key column as a **`BatchedShares`** via `ShamirDealer::share_batch` — the sq-dwb5 primitive, actually used: each row's key gets its own fresh degree-`t` masking polynomial, so any `≤ t` parties' shares of the whole key column are jointly independent of every key. The disclosed payload columns ride alongside in the clear (disclosure-minimisation, convention #4 — only the *key* is hidden).
- **`HiddenValueJoin::batched_join(left, right, B)`** lifts the existing `secure_equal` to the row dimension. The `RowBinding` decides the **candidate pairs**:
  - **Positional** — index-correlated: row `i` of L pairs only with row `i` of R; both columns must be equal length (fails closed otherwise). `k` candidates.
  - **Keyed** — correlated by the **disclosed** public row key (orders need not match): `(i,j)` is a candidate iff `lkeys[i] == rkeys[j]`; the VALUE stays hidden and is still gated by `secure_equal`.
  - Mixed bindings → protocol error.

## The oblivious output

Each candidate's match (decided by `secure_equal`) feeds **`oblivious_join_output`** as a `MatchBit::Public` bit with a **public padded bound `B`**: non-matches become indistinguishable dummies, the slots are oblivious-shuffled, and exactly `B` are revealed. So the **output reveals neither the true match count (bounded to `B`) nor which input pair produced which row** (L1-bounded / L2-destroyed at the output). Fails closed if `B < candidate count` (never truncates a candidate → never silently drops a match).

## Regimes landed vs deferred

- **Landed:** both **Positional** and **Keyed**, with the join key/value never disclosed + the oblivious output transform.
- **Deferred (honest, beaded — `sq-xhaw`):** the per-candidate match **bit** is still *opened* by `secure_equal` (the same decision-time L2 leak the scalar `HiddenValueJoin` has). Deriving a **secret-shared** match bit from the keys without opening it needs a secure equality-to-shared-bit (sq-rrz4 on the degree-reduction round sq-dvuc) — the gate `oblivious_join`'s hidden-key entry point already names. We do **not** claim the match graph is hidden from the parties. Semi-honest only, unchanged from the `ShamirBackend` layer.

## Privacy property enforced (and how)

- **Join key/value never reconstructed** — only `secure_equal`'s masked product `m = d·r` is opened per candidate (`m=0 ⇔ keys equal`; for unequal keys `m` is uniform nonzero → reveals only the match bit). The sq-dwb5 batched-Shamir hiding lifts this to the whole column.
- **Output cardinality + ordering oblivious** to the parties — bounded to `B`, shuffled (the `oblivious_join` substrate). The key var is never in the output schema.

## Test matrix (13 new, in `join::batched_hidden_value_tests`)

- Positional + Keyed **differential vs plaintext** join across **n ∈ {3,5,7}** (keys private, never reconstructed).
- Keyed **fan-out** within a shared disclosed-key bucket (2×2 cartesian).
- Privacy: **output cardinality bounded to `B`** (not true count); **key value never appears** in the disclosed output; **output order oblivious** across 32 seeds.
- **Forged-match soundness** across n ∈ {3,5,7} (distinct keys cannot manufacture a match; genuine-equal control passes).
- Fail-closed: mixed bindings / unequal positional columns / `B < candidates` / keyed key-count mismatch.
- `shared_keys` exercises the batched primitive (length + binding preserved).

## Verify

```
cargo build -p sparq-mpc      # clean
cargo nextest run -p sparq-mpc  # 265 tests run: 265 passed, 0 skipped
cargo clippy -p sparq-mpc --all-targets -- -D warnings  # clean
cargo fmt
```

NON-CANONICAL timing (this box is an EC2 work box, not a bench instance).