### PR TITLE
ci(bench): cap benchmark-data history with max-items-in-chart (sq-3g6q)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -272,6 +272,17 @@ jobs:
           # /(root) the dashboard renders at https://jeswr.github.io/sparq/dev/bench (see header).
           gh-pages-branch: benchmark-data
           benchmark-data-dir-path: dev/bench
+          # [OPUS-4.8] sq-3g6q: CAP the retained history. github-action-benchmark accumulates EVERY
+          # commit's point with NO bound by default, so dev/bench/data.js grew unbounded (was 4.4 MB /
+          # ~160k lines → slow dashboard load). max-items-in-chart slices entries["sparq engine"] to the
+          # most-recent N COMMITS (one entry per commit; each entry carries ALL metrics, so N commits =
+          # N points per metric for the trend charts). N is deliberately modest because each entry is
+          # heavy: the suite now reports ~270 metrics/commit (~28 KB serialized), so the COMMIT COUNT —
+          # not a notional total-point count — is what drives file size. N=20 keeps a 20-commit trend
+          # window for every metric while holding data.js well under 1 MB (~0.74 MB). The dashboard
+          # (bench/dashboard/dashboard.js) renders the latest values + trend sparklines from exactly
+          # this bounded window. Matches the one-time prune of the existing benchmark-data history.
+          max-items-in-chart: 20
           # Comment + job-summary on EVERY run (incl. PRs) so the comparison table is always visible
           # pre-merge, not only when an alert fires. [OPUS-4.8]
           comment-always: true


### PR DESCRIPTION
> 🤖 SPARQ agent

Fixes the slow benchmark dashboard load (bead **sq-3g6q**). The published
`dev/bench/data.js` had grown to **4.4 MB / ~160k lines** because
`github-action-benchmark` accumulates every commit's point with **no history
cap** (its `max-items-in-chart` defaults to *no limit*).

## The real cost
The bloat is dominated by **metrics-per-commit**, not commit count: the
benchmark-data history holds only ~183 commits, but the suite now emits **~270
metrics per commit** (~28 KB serialized each). So the lever is the retained
**commit count**.

## Part 1 — cap future growth (this PR)
Add `max-items-in-chart: 20` to the *"Store + compare against history"* step.
The action then slices `entries["sparq engine"]` to the most-recent 20 commits.
Each entry carries all metrics, so **20 commits = a 20-point trend window per
metric** — enough for the dashboard's trend sparklines — while holding
`data.js` **well under 1 MB (~0.74 MB)**.

- `max-items-in-chart` confirmed as the correct input key for the pinned
  action version (`v1.22.1`); default is *no limit*, which is the cause.
- YAML validated (parses; integer under the correct step's `with`).
- `bench/dashboard/dashboard.js` reads `window.BENCHMARK_DATA` and renders the
  latest values + trends from exactly this bounded array, so a 20-commit window
  keeps all sparklines.

## Part 2 — one-time prune (direct to `benchmark-data`)
The existing live history is pruned to the same N=20 in a separate direct push
to the `benchmark-data` orphan branch (that branch is force-managed by the
action, not a normal code branch). Schema preserved exactly
(`{lastUpdate, repoUrl, entries:{"sparq engine":[{commit,date,tool,benches:[…]}]}}`),
latest entry byte-identical, all 271 metrics / 8 suites
(shacl/geo/text/deeptax/sp2/watdiv/lubm/bsbm) retained. **Before:** 4,412,284 B
→ **After:** 737,543 B. Verified: loads in node, dashboard pure-fns render
(8 featured suites, 20 trend points/metric, scaling families intact).

Refs sq-3g6q.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>