### PR TITLE
ci(bench): seed competitors.json onto the Pages dashboard (sq-kehk)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -316,7 +316,10 @@ jobs:
           # [OPUS-4.8] vendor/Chart.min.js (sq-0rv3) is loaded by index.html now that the
           # CDN dep is dropped — seed it (in its subdir) so the published Pages dashboard
           # doesn't 404. The path has a dirname, so mkdir -p before copying.
-          for f in index.html dashboard.js dashboard.css metric-labels.json vendor/Chart.min.js; do
+          # [OPUS-4.8] competitors.json (sq-kehk) is FETCHED by dashboard.js boot() (sq-rltn / #200)
+          # as the single competitor-data sink — copy it alongside metric-labels.json so the live
+          # fetch resolves instead of 404ing into the empty embedded COMPETITORS_DATA mirror.
+          for f in index.html dashboard.js dashboard.css metric-labels.json competitors.json vendor/Chart.min.js; do
             if [ ! -f "$tmp/dev/bench/$f" ] || ! cmp -s "$src/$f" "$tmp/dev/bench/$f"; then
               mkdir -p "$(dirname "$tmp/dev/bench/$f")"
               cp "$src/$f" "$tmp/dev/bench/$f"
@@ -339,7 +342,7 @@ jobs:
           git -C "$tmp" -c user.name='github-actions[bot]' \
                         -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
                         add index.html dev/bench/index.html dev/bench/dashboard.js dev/bench/dashboard.css \
-                            dev/bench/metric-labels.json dev/bench/vendor/Chart.min.js
+                            dev/bench/metric-labels.json dev/bench/competitors.json dev/bench/vendor/Chart.min.js
           git -C "$tmp" -c user.name='github-actions[bot]' \
                         -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
                         commit -q -m "chore(bench): seed/update Pages dashboard (dev/bench + root redirect) [skip ci]"


### PR DESCRIPTION
> 🤖 SPARQ agent

**One-line change:** add `competitors.json` to the Pages dashboard seed step in `bench.yml`, alongside `metric-labels.json`.

## Why
`bench/dashboard/dashboard.js` boot() (sq-rltn / #200) now **fetches** `competitors.json` as the single competitor-data sink, falling back to the empty embedded `COMPETITORS_DATA` mirror when the fetch fails. But the Pages "seed" step on `benchmark-data` copied `index.html` / `dashboard.js` / `dashboard.css` / `metric-labels.json` (+ `vendor/Chart.min.js`) into `dev/bench/` and **not** `competitors.json`. So the live fetch **404'd → empty fallback** and competitor cells stayed **N/A** even after a gather populated `bench/dashboard/competitors.json`.

## Change
Two lines in `.github/workflows/bench.yml`, both mirroring the proven `metric-labels.json` path (same `$src/bench/dashboard` source → same `dev/bench/` destination):
- Added `competitors.json` to the seed copy loop (`for f in index.html dashboard.js dashboard.css metric-labels.json competitors.json vendor/Chart.min.js`). The loop already does the `cmp`/diff existence check + `mkdir -p`.
- Added `dev/bench/competitors.json` to the `git add` list of the seed commit.

On the next `main` bench run, `dev/bench/competitors.json` is published next to `data.js` + `metric-labels.json` + `dashboard.js`, so the dashboard fetch resolves live — unblocking the competitor-N/A fill.

## Verify
- YAML valid (`python3 -c "import yaml; yaml.safe_load(...)"` → OK; actionlint not installed on box).
- Copy parallels the metric-labels.json path exactly; full live publish can only be confirmed on a real `main` bench run, but it reuses the proven idiom.

Refs sq-kehk; depends on sq-rltn (#200) for the fetch consumer.
