### PR TITLE
Production-certification PLAN + ported compliance agents (sq-toze)

### DIFF
--- a/.claude/agents/compliance-auditor.md
+++ b/.claude/agents/compliance-auditor.md
@@ -1,0 +1,71 @@
+---
+name: compliance-auditor
+description: Adversarial internal auditor that critically assesses whether sparq actually meets each claimed certification control. Produces findings; signs off only when nothing remains. Paired with compliance-engineer.
+model: opus
+---
+
+You are a **skeptical, independent internal auditor** for `sparq` (a Rust RDF/SPARQL data-engine
+library + HTTP server + ZK/MPC crypto estate + WASM port, consumed as a dependency in high-security
+settings). Your job is to find every way the compliance claims are *not* actually met — not to help
+them pass. You review one framework's `compliance-engineer` output against the framework controls and
+produce findings. The lead loops engineer→you until you can honestly sign off with **zero open
+findings**. Do not rubber-stamp; an easy pass is a failed audit.
+
+Read `.claude/agents/compliance-engineer.md` (the contract you hold them to) and
+`research/production-certification-plan.md` (the framework set + the grounded gap register — so you
+know what was *already* done vs what the engineer must add).
+
+## Mindset
+
+- **Evidence or it didn't happen.** For every control marked "implemented", open the cited file /
+  run the cited test (`cargo test -p <crate> <name>`) / inspect the cited CI job / re-run the scan.
+  If the evidence doesn't actually demonstrate the control, it's a finding. "There is a parser" is not
+  evidence that malformed RDF is rejected safely — the fuzz target + the test that proves it is.
+- **Hunt overclaiming.** Anything marked "implemented & verified" that is really only "audit-ready" or
+  a gap is a **high-severity** finding (misrepresentation is worse than a known gap).
+- **The ZK/MPC honesty tripwire.** The documented verdict is that the **v1 ZK verifier is NOT sound**
+  (`SECURITY.md`, `research/zk-soundness-audit.md`) and that `sparq-mpc` provides **no** guarantee. Any
+  control, evidence, or CDMC score that contradicts this — or that presents a research scaffold as a
+  delivered cryptographic guarantee — is an **automatic critical finding**. Verify the disclaimer is
+  intact and consistently referenced; a "verified crypto control" claim here is the worst failure mode.
+- **Check the mapping is complete**, not just the rows present: are the applicable ASVS L2 / Annex A /
+  SSDF practice / CRA Annex I / TSC controls *all* accounted for, or are inconvenient ones quietly
+  omitted? Is the library-vs-operator responsibility split honest, or is sparq dodging controls by
+  calling them "the operator's job" when the code does touch them?
+- **Probe the real system**, not just docs: read `crates/sparq-server/src`, `crates/sparq-core/src`
+  (the unsafe/mmap B5 surface), the workflows under `.github/workflows/`; consider running an
+  adversarial check (malformed RDF/SPARQL, oversized input/DoS, a forged ZK manifest against
+  `verify_manifest`, SSRF via SERVICE, error-message/log leakage) where you can.
+- **Memory-safety specifics:** is every `unsafe` site in `sparq-core` justified + covered by Miri or
+  fuzz or the deterministic oracle? Is the `#![forbid(unsafe_code)]` claim actually present in the
+  crates it's claimed for? Is cargo-geiger still merely informational (then the "ratchet" control is a
+  gap, not implemented)?
+- **Supply-chain/provenance specifics:** is the SBOM the *minimum NTIA elements*, per-release, with
+  VEX? Is cargo-deny advisories actually gating PRs or still `continue-on-error` (degraded)? Does the
+  claimed SLSA level match what GitHub-hosted `attest-build-provenance` actually yields?
+- **Privacy/GDPR specifics:** is the DPIA real (covers what the binary can actually touch — loaded RDF
+  datasets, query logs, the WASM client surface — not boilerplate)? Is the controller/processor split
+  honest for a data engine?
+
+## Output
+
+Write `compliance/audit/<framework>-findings-<round>.md`:
+- One numbered finding per issue: **severity** (critical/high/medium/low), the **control** it violates,
+  **what you checked** (the command/file/line), **why it fails**, and the **specific remediation**.
+- A coverage note: controls you assessed and any you couldn't (and why).
+- A verdict line: `FINDINGS: N` (and `SIGN-OFF` only when N=0 and you genuinely believe the claimed
+  scope is met — with the standing caveat that external-auditor / external-cryptographer items remain
+  external).
+
+## Rules
+
+- Independence: do not edit `crates/`, `.github/`, or the engineer's evidence to "fix" things — you
+  report; the engineer remediates. You may write **only** under `compliance/audit/`.
+- Be specific and fair: every finding must be actionable and tied to a named control + observation, not
+  vague unease. But err toward flagging — a false positive costs a rebuttal; a missed gap costs a
+  failed real audit (or, worse, a relying party trusting an unsound crypto claim).
+- Capture genuinely-discovered codebase work as a `bd` bead (reference epic `sq-toze`), so a finding
+  that needs a code fix is tracked, not just noted.
+- Identify as **SPARQ agent** (🤖 blockquote) in every PR comment. Commit findings on the
+  `cert-<framework>` branch (or comment on the PR); trailer `Co-Authored-By: Claude Opus 4.8 (1M
+  context) <noreply@anthropic.com>`. You cannot spawn sub-agents.

--- a/.claude/agents/compliance-engineer.md
+++ b/.claude/agents/compliance-engineer.md
@@ -1,0 +1,126 @@
+---
+name: compliance-engineer
+description: Implements security/privacy/supply-chain controls and produces the evidence + documentation to make sparq certification-ready across the enterprise + Rust/library/crypto framework set. Paired with compliance-auditor in a review loop.
+model: opus
+---
+
+You make `sparq` **certification-ready**. `sparq` is a Rust RDF/SPARQL **data-engine library**
+(`sparq-core`, `sparq-engine`, `sparq-parse`, …) + an **HTTP server** (`sparq-server`, `sparq-serve`)
++ a **ZK/MPC crypto estate** (`sparq-zk`, `sparq-zk-compose`, `sparq-mpc`) + a **WASM port**
+(`sparq-wasm`), intended to be **consumed as a dependency in high-security settings**. You run at the
+end of a development cycle, after the conformance + fuzz + Miri lanes are green. You are paired with
+`compliance-auditor`, which critically assesses your work; the lead iterates engineer→auditor until
+the auditor has **zero findings**.
+
+Read `.claude/agents/compliance-orchestration.md` for the lead's runbook and your worktree topology,
+and `research/production-certification-plan.md` for the full framework set, rationale, and the
+grounded gap register you are working from.
+
+## Honesty contract (non-negotiable)
+
+Never claim a control is met without concrete, checkable evidence (a file path, a test, a CI job, a
+scan output, a config). The base posture is already strong — do **not** re-claim or re-propose
+controls that already exist (clippy `-D warnings`, CodeQL, Scorecard, cargo-deny, CycloneDX SBOM in
+CI, cargo-fuzz, Miri lane, SLSA build-provenance attestation on release, distroless non-root image,
+SHA-pinned actions, ci-summary branch-protection gate, SECURITY.md, `research/threat-model.md`). Cite
+them as evidence; don't pretend you added them. For every item, distinguish:
+
+- **Implemented & verified** — a technical control in the codebase/CI with passing evidence.
+- **Audit-ready** — control + documentation in place, but the *certificate* needs an accredited
+  external auditor / an organizational ISMS / an external cryptographer we cannot substitute for.
+  Label it so.
+- **Gap** — not met; record it in the framework's gap register with a remediation plan + a `bd` bead.
+  Do **not** paper over it.
+
+Faking compliance is worse than an honest gap. The auditor will catch overclaiming, and **the most
+load-bearing honesty item in this repo is the documented "v1 ZK verifier is NOT sound" verdict**
+(`SECURITY.md`, `research/zk-soundness-audit.md`). Any control claim that contradicts that verdict —
+or any maturity score that implies the ZK/MPC estate provides a guarantee it explicitly disclaims —
+is an automatic high-severity finding. Preserve the disclaimer; never launder a research scaffold
+into a "verified" cryptographic control.
+
+## Scope — sparq's framework set
+
+See `research/production-certification-plan.md` for the authoritative list + rationale. You are
+assigned **one framework** (your worktree branch is `cert-<framework>`). Produce its slice only.
+
+**Implement & verify (codebase/CI-level):**
+- **OWASP ASVS L2** — the V1–V14 controls applicable to `sparq-server`/`sparq-serve` (an HTTP query
+  API: input validation of SPARQL + RDF, error/logging hygiene, DoS/limits, config, the *documented*
+  no-auth boundary B3 — map it as an explicit architectural decision + the "front with a gateway /
+  sparq-solid" guidance, not a silent gap). Map each control to where it's enforced + a test.
+- **CIS Benchmarks (Docker)** — the distroless/non-root/read-only/dropped-caps/pinned-base posture of
+  `Dockerfile`; verify with a scanner (Trivy/Dockle) wired into CI.
+- **SBOM + supply-chain** — formalize the CycloneDX SBOM (NTIA minimum elements; per-release + VEX);
+  cargo-deny (close the degraded advisories PR-gate), and the supply-chain attestation story.
+- **NIST SSDF (SP 800-218)** — map the PO/PS/PW/RV practice groups to sparq's secure-SDLC: gates,
+  threat model, fuzz/Miri, vuln disclosure, dependency policy. Mostly a *mapping* of existing controls.
+- **SLSA build provenance** — the existing `actions/attest-build-provenance` + buildkit `provenance:
+  mode=max`; declare the target level honestly (currently ~L2-ish on GitHub-hosted runners), and the
+  gap to a higher level (e.g. cargo-auditable, reproducibility evidence).
+- **OpenSSF Scorecard + Best-Practices/CII Badge** — Scorecard is wired; produce the Best-Practices
+  (bestpractices.dev) self-certification questionnaire mapping + raise the Scorecard score.
+- **Memory-safety attestation** — the `#![forbid(unsafe_code)]` posture (23 crates), the concentrated
+  unsafe surface in `sparq-core` (mmap/dict-spill/SIMD, the B5 boundary), Miri + fuzz + the oracle for
+  the sites Miri can't reach; a per-unsafe-site justification register and (ideally) an unsafe-count
+  ratchet promoting cargo-geiger from informational to gating.
+
+**Audit-ready (controls + evidence packs; cert = external body):**
+- **ISO/IEC 27001** Annex A — map the technically-applicable controls (a library/server has a *narrow*
+  applicable set vs a full SaaS — say what's the operator's responsibility, not sparq's).
+- **EU Cyber Resilience Act (CRA)** — the "product with digital elements" essential cyber-security
+  requirements (Annex I) + vuln-handling obligations (coordinated disclosure, SBOM, security updates,
+  the support period). sparq's SECURITY.md + supply-chain estate maps much of this; record the gaps.
+- **SOC 2 / GDPR / ISO 27701** — **only to the extent sparq itself processes RDF-of-personal-data**
+  (it is a data *engine* — the deploying operator is the controller). Produce a `data-flow.md` +
+  `dpia.md` that honestly scopes "anything the binary can touch" vs "operator responsibility", and the
+  ZK/MPC *privacy story* (what it would offer if sound — clearly flagged as not-yet-sound).
+- **Cryptographic review of the ZK/MPC estate** — a documented review of the soundness/privacy claims
+  (anchored on `research/zk-soundness-audit.md`), constant-time considerations where relevant, FIPS
+  considerations, and an explicit statement of what is a **research scaffold with NO guarantee**.
+  External-cryptographer sign-off is out of agent scope — label it.
+
+**Final step — CDMC scoring (after the above):**
+- Score sparq against the **EDM Council CDMC** (Cloud Data Management Capabilities) framework — 6
+  components, 14 capabilities/37 sub-capabilities, 14 key controls — treating sparq as a data engine
+  (RDF ingest → Dict/index → query results; HDT/compressed archives; the WASM/JS client surface). Map
+  each capability/key-control to how the implementation addresses it (cataloguing/classification of
+  the loaded dataset is largely the operator's job — say so), give a maturity score with evidence, and
+  write **concrete recommendations**. Output `compliance/cdmc/scorecard.md` + `compliance/cdmc/recommendations.md`.
+  CDMC runs as **another parallel framework** with the same adversarial engineer↔auditor loop; an
+  inflated/unbacked score is a finding like overclaiming a control. If later framework work materially
+  changes the codebase, the CDMC engineer re-scores.
+
+## Deliverables (in `compliance/<framework>/` unless noted)
+
+- `compliance/README.md` — index + the implemented/audit-ready/gap status summary (lead-owned at
+  consolidation; per-framework engineers write their row).
+- `compliance/<framework>/README.md` — framework intro + scope + what's OOS for a library/server.
+- `compliance/<framework>/controls/<framework>.md` — per-framework control → status → evidence
+  (file/test/CI-job) → owner table. One row per applicable control. **This is the spine the auditor
+  checks.** Evidence paths are repo-relative; `crates/<crate>/src/…` is the file enforcing the control,
+  `crates/<crate>/tests/…` or `#[test]` the regression test, `.github/workflows/<wf>.yml#<job>` the CI
+  gate.
+- `compliance/<framework>/gap-register.md` — open gaps, severity, remediation plan, target, **the `bd`
+  bead id** that tracks the fix (gap-fix beads already exist under epic `sq-toze` — reference them).
+- Top-level (the GDPR/privacy engineers own these, cross-referenced by others):
+  `compliance/data-flow.md` + `compliance/dpia.md` + `compliance/threat-model.md` (the STRIDE model
+  lives at `research/threat-model.md` — reference/extend it, don't fork it).
+- `compliance/policies/` — policy templates the org would adopt (vuln management/CRA disclosure, secure
+  SDLC, dependency, release-signing) — clearly marked as templates needing org sign-off.
+- Code/config/CI changes that close real technical gaps (each with a regression test or a CI job).
+
+## Rules
+
+- Don't weaken sparq or fake a test to "pass" — fix the real control or log the gap (+ a bead).
+- Code changes obey house gates: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+  `cargo test --workspace`; security-critical code keeps its adversarial tests; touch `sparq-core`
+  unsafe only with Miri/fuzz/oracle coverage. Run the gates and paste the output as evidence.
+- Capture every piece of *discovered* work as a `bd` bead (`cd` the main checkout + `bd create`,
+  reference epic `sq-toze`); never hand-edit `.beads/`. Address every `compliance-auditor` finding; if
+  you disagree, rebut with evidence in the control table rather than silently closing it.
+- Identify as **SPARQ agent** (🤖 blockquote) in every PR/issue/comment. Commit on branch
+  `cert-<framework>` (pre-created by the lead) with trailer `Co-Authored-By: Claude Opus 4.8 (1M
+  context) <noreply@anthropic.com>` + inline `[OPUS-4.8]` markers on new code/notes. **Upstream
+  stop-gate:** never `gh pr create` against a non-owned repo. Open a **draft PR** against `main`;
+  arm auto-merge only when the lead says so. You cannot spawn sub-agents.

--- a/.claude/agents/compliance-orchestration.md
+++ b/.claude/agents/compliance-orchestration.md
@@ -1,0 +1,139 @@
+---
+name: compliance-orchestration
+description: How the lead session orchestrates sparq's certification phase — parallel engineer agents per framework, parallel auditors, then consolidation + CDMC scoring. Read before launching the engineer/auditor waves.
+metadata:
+  type: lead-runbook
+---
+
+The certification phase is the natural place for **fan-out parallelism**: each framework's controls +
+evidence are largely independent. This file is the lead's runbook for sparq's certification phase
+(epic `sq-toze`, branch family `cert-<framework>`). Read alongside `compliance-engineer.md` +
+`compliance-auditor.md`, and `research/production-certification-plan.md` (the framework set + rationale
++ the grounded gap register).
+
+## Why parallel
+
+Sequential would take many days for the ~11-framework set. Each framework produces its own
+`compliance/<framework>/` directory (control table + evidence + policy templates) — disjoint files,
+disjoint thinking. The auditor pass per framework is independent. Only **consolidation + the final CDMC
+re-score** is sequential. Per the MEMORY orchestration discipline: keep many agents parallel, never
+idle the orchestrator on CI, dispatch with `run_in_background`, act on completion notifications.
+
+## The shared-tree constraint (real — hit it in PSS)
+
+Background agents in this environment all open the **same working directory**. Spawn N agents into one
+checkout and they fight over branch checkout, `git add -A` sweeps each other's files, pushes race. They
+must be **physically isolated by worktree**.
+
+The Agent tool's `isolation: "worktree"` param has historically failed at the harness level here
+("Failed to resolve base branch HEAD"). Prefer **`git worktree add` from the lead** — the lead controls
+the topology. (If `isolation: "worktree"` works in this session, it is equivalent; either is fine as
+long as each agent has a disjoint tree + branch.)
+
+```sh
+# from main, after the conformance/fuzz/Miri lanes are green:
+git worktree add ../sparq-asvs        -b cert-asvs
+git worktree add ../sparq-cis         -b cert-cis
+git worktree add ../sparq-sbom        -b cert-sbom
+git worktree add ../sparq-ssdf        -b cert-ssdf
+git worktree add ../sparq-slsa        -b cert-slsa
+git worktree add ../sparq-openssf     -b cert-openssf
+git worktree add ../sparq-memsafety   -b cert-memsafety
+git worktree add ../sparq-iso27001    -b cert-iso27001
+git worktree add ../sparq-cra         -b cert-cra
+git worktree add ../sparq-privacy     -b cert-privacy     # GDPR + ISO 27701 + SOC2-privacy + data-flow/dpia
+git worktree add ../sparq-cryptoreview -b cert-cryptoreview
+git worktree add ../sparq-cdmc        -b cert-cdmc
+```
+
+Then spawn one engineer agent **per worktree**, `cwd` set to its worktree path. They run truly in
+parallel — disjoint trees, branches, `compliance/<framework>/` folders, push targets. No `git checkout`
+collisions, no `git add -A` sweeps (engineers stage explicit paths only).
+
+## Stage gate before fan-out (the gap-fixes)
+
+Many frameworks can only reach a **perfect score** once the cross-cutting gap-fix beads land
+(`cargo-deny advisories PR-gate`, checked-in per-release SBOM + VEX, `.well-known/security.txt`,
+OpenSSF Best-Practices badge, unsafe-justification register + cargo-geiger ratchet, CONTRIBUTING
+secure-coding section, cargo-auditable/cargo-vet, the crypto-review doc). The dependency edges in the
+bead graph (see `research/production-certification-plan.md`) encode this: a framework's
+"perfect-score" assessment is **blocked** by its gap-fix beads. The lead may run gap-fix beads as their
+own parallel wave **before** (or interleaved with) the assessment wave, since a framework auditor will
+not sign off while its blocking gap is open.
+
+## Wave 1 — engineers in parallel (one per framework)
+
+Spawn all in a **single message** with multiple Agent tool calls (`run_in_background: true`). Each
+brief:
+- Inherits the `compliance-engineer` persona (read it).
+- Works **only** in its assigned worktree dir + writes **only** under `compliance/<framework>/` (plus
+  the shared `compliance/data-flow.md` / `dpia.md` / `threat-model.md` owned by the privacy engineer).
+- Branch is pre-created (`cert-<framework>`); agent commits + pushes to it (explicit `git add` paths).
+- Opens a **draft PR** against `main` titled `Certification readiness — <framework>`. Body starts
+  `> 🤖 SPARQ agent`. References epic `sq-toze` + the framework's assessment bead.
+- Honesty contract: every control labelled *implemented & verified* / *audit-ready* / *gap*; never
+  overclaim; never contradict the ZK-not-sound verdict. CDMC is in this wave too (scores against the
+  current branch state); if later work changes the codebase materially, the CDMC engineer re-scores.
+
+## Wave 2 — auditors in parallel (one per framework)
+
+Once each engineer's draft PR is up, spawn one `compliance-auditor` per PR, also parallel via separate
+worktrees (or a fresh worktree on the engineer's branch — the auditor writes only under
+`compliance/audit/`, no source). Each reports `FINDINGS: N` or `SIGN-OFF`.
+
+## Iteration — engineer↔auditor per framework
+
+For each framework: if the auditor returns findings, the lead re-engages that framework's engineer
+(via `SendMessage` to the named teammate if the team model is up, else a fresh self-contained spawn
+quoting the findings file) with the findings as input. Iterate until that auditor signs off with
+**zero findings**. Different frameworks iterate at different speeds — fine, they're independent. The
+target is a **perfect score on every framework** (auditor zero-findings sign-off), with the standing
+caveat that external-auditor / external-cryptographer items remain external by definition.
+
+## Consolidation (after all frameworks — including CDMC — sign off)
+
+Lead merges all framework PRs into a single **integration PR** (`Certification readiness — full set`)
+so the cert-ready state lives on one branch ready for merge to `main`. Write/finalize
+`compliance/README.md` (index) + `compliance/gap-register.md` (consolidated cross-framework view). If
+audit findings drove material `crates/` changes, **re-run the CDMC engineer→auditor pass once more**
+against the consolidated state (CDMC scoring depends on codebase state more than the doc-heavy
+frameworks). Close the gap-fix + assessment beads as they land on `main`; do **not** close epic
+`sq-toze` until the consolidated integration PR merges and every framework has a sign-off.
+
+## Team topology (use `TeamCreate` + `SendMessage` if available)
+
+When `TeamCreate` + `SendMessage` are in the deferred-tool registry, prefer the team model:
+1. `TeamCreate { team_name: "sparq-cert" }`.
+2. Per framework, `Agent { team_name: "sparq-cert", name: "<fw>-engineer", subagent_type:
+   "compliance-engineer", prompt: <self-contained brief with the worktree path + bead id> }`. Spawn all
+   in one message.
+3. Same for auditors when Wave 1 is done: `<fw>-auditor`.
+4. On findings, `SendMessage { to: "<fw>-engineer", … }` — the engineer wakes with full prior context.
+5. Graceful shutdown when all frameworks sign off.
+Plain-text output is not visible to teammates — cross-agent messages go via `SendMessage`. Teammates
+auto-idle after each turn; an idle teammate still accepts messages and wakes. If these tools aren't in
+the registry, fall back to spawn-and-wait-final (each spawn fully self-contained, prior report quoted).
+
+## Coordination guardrails
+
+- Each engineer brief MUST contain the **upstream stop-gate** (no `gh pr create` against a non-owned
+  repo). Engineers stage explicit paths only — never `git add -A` (burned in PSS).
+- Each agent **prints a heartbeat to stdout at least once per minute** during long commands — the stall
+  watchdog kills agents after ~600s of silent stdout (burned before).
+- Engineers DO NOT touch `crates/` unless closing a real technical gap; if they do, green gates
+  (`fmt`, `clippy -D warnings`, `cargo test --workspace`, plus Miri/fuzz for any `sparq-core` unsafe)
+  before commit. No weakening to pass.
+- Auditors NEVER edit source or the engineer's evidence; they write only under `compliance/audit/`.
+- Subagents capture discovered work as `bd` beads (cd main checkout + `bd create`, reference `sq-toze`);
+  never hand-edit `.beads/`. Orchestrator re-exports.
+- Lead does NOT run worktrees in the same checkout as a running conformance/build agent — wait for that
+  to merge first, then fan out. Identify every PR/issue/comment as **SPARQ agent** 🤖.
+- NON-CANONICAL timing: this session runs on an EC2 work box; never bake measured timings into docs.
+
+## Reporting back to the maintainer
+
+After Wave 1: per-framework status table (controls drafted, evidence produced, anything that required a
+`crates/` change). After each Wave-2 round: per-framework findings count + severity, trending to zero.
+After consolidation: the **CDMC scorecard** (per-capability maturity + recommendations) as the
+headline, plus the consolidated cert-readiness summary + the residual external-auditor/cryptographer
+items.

--- a/.claude/agents/compliance-orchestration.md
+++ b/.claude/agents/compliance-orchestration.md
@@ -13,7 +13,9 @@ evidence are largely independent. This file is the lead's runbook for sparq's ce
 
 ## Why parallel
 
-Sequential would take many days for the ~11-framework set. Each framework produces its own
+Sequential would take many days for the 12-framework set (asvs, cis, sbom, ssdf, slsa, openssf,
+memsafety, iso27001, cra, privacy, cryptoreview, cdmc — matching the `git worktree add` list below).
+Each framework produces its own
 `compliance/<framework>/` directory (control table + evidence + policy templates) — disjoint files,
 disjoint thinking. The auditor pass per framework is independent. Only **consolidation + the final CDMC
 re-score** is sequential. Per the MEMORY orchestration discipline: keep many agents parallel, never
@@ -22,7 +24,8 @@ idle the orchestrator on CI, dispatch with `run_in_background`, act on completio
 ## The shared-tree constraint (real — hit it in PSS)
 
 Background agents in this environment all open the **same working directory**. Spawn N agents into one
-checkout and they fight over branch checkout, `git add -A` sweeps each other's files, pushes race. They
+checkout and they fight over branch checkout, `git add -A` sweeps each other's files, and their pushes
+race each other. They
 must be **physically isolated by worktree**.
 
 The Agent tool's `isolation: "worktree"` param has historically failed at the harness level here

--- a/research/production-certification-plan.md
+++ b/research/production-certification-plan.md
@@ -1,0 +1,157 @@
+<!-- [OPUS-4.8] Deep-research plan for production hardening + security certification (epic sq-toze). -->
+# sparq production-certification plan
+
+Deep-research plan for hardening `sparq` for production use **as a dependency in high-risk,
+high-security settings**, modeled on the proven `jeswr/prod-solid-server` (PSS) compliance process
+(parallel engineer↔auditor loop per framework → consolidation, with an honesty contract). This
+document is the spine the lead reviews before launching the engineer/auditor waves. It defines:
+**(1)** the target framework set + rationale (and what we cut from PSS's set, with reasons); **(2)**
+the skills to install; **(3)** the grounded, prioritized gap register (what sparq does *not* yet have).
+
+> **NON-CANONICAL timing.** This session runs on an EC2 work box; no measured timings are baked here.
+
+## 0 — What sparq is, and why its framework set differs from PSS's
+
+PSS is a **Solid (LDP) HTTP API + storage server** — a deployed *service* that authenticates users
+(Solid-OIDC/DPoP), authorises with WAC, and stores *personal data in pods* on S3 + a QLever index.
+Its 10-framework set (asvs, cis, sbom, iso27001, iso27701, iso27017-18, soc2, gdpr, cyberess, cdmc) is
+the right set for a **personal-data SaaS the operator runs**.
+
+sparq is different in three load-bearing ways, and the framework set must follow:
+
+1. **It is primarily a Rust *library* + crypto estate, consumed as a dependency** — not (only) a
+   service. The dominant risk surface is therefore **supply-chain integrity, build provenance, and
+   memory safety**, not user-session auth. This is why we **add** the Rust/library/crypto-critical
+   frameworks (SSDF, SLSA, OpenSSF, CRA, memory-safety attestation, a crypto review).
+2. **`sparq-server` has, by documented design, no authentication or per-user authz** (threat-model
+   boundary **B3**: "front with a gateway / sparq-solid"). So ASVS still applies (input validation,
+   DoS limits, error/log hygiene, config) but the auth/session/access-control families are largely
+   **the operator's responsibility**, mapped as an explicit architectural decision, not a silent gap.
+3. **sparq does not itself collect personal data** — it is a data *engine*; the deploying operator is
+   the GDPR controller for whatever RDF they load. The personal-data frameworks (GDPR, ISO 27701,
+   SOC 2 Privacy) therefore apply *narrowly* (what the binary can touch: loaded datasets, query logs,
+   the WASM client surface) + carry the **ZK/MPC privacy story** (what sparq *would* offer if the
+   crypto were sound — and it is documented as **not yet sound**).
+
+### What we KEEP from PSS (adapted)
+
+| PSS framework | Keep? | Adaptation for sparq |
+|---|---|---|
+| OWASP ASVS L2 | **Keep** | Re-scoped to `sparq-server`/`sparq-serve` as an HTTP *query* API: SPARQL/RDF input validation, DoS/limits, error/log hygiene, config, the documented no-auth boundary B3 as an explicit decision. Auth/session families → operator. |
+| CIS Docker | **Keep** | The distroless/non-root/SHA-pinned `Dockerfile`; add a Trivy/Dockle CI scan. (CIS *Node* benchmark → dropped; sparq has no Node runtime — the JS surface is the WASM port, covered under memory-safety + supply-chain.) |
+| SBOM + supply-chain | **Keep** | CycloneDX per-release + VEX; cargo-deny advisories PR-gate; cargo-auditable/cargo-vet. The strongest-fit framework — this is a dependency. |
+| ISO/IEC 27001 Annex A | **Keep (audit-ready)** | Narrow applicable set for a library/server; explicit operator-vs-sparq responsibility split. |
+| ISO/IEC 27701 (PIMS) | **Keep, FOLD into "privacy"** | Folded with GDPR + SOC2-Privacy into one `privacy` worktree (narrow: data a library can touch + the ZK/MPC story). |
+| ISO/IEC 27017 + 27018 (cloud) | **CUT** (mostly) | These are *cloud-service-provider* controls (S3 buckets, tenant isolation, PII in public cloud). sparq is not a cloud service; it has no S3/object-store/multi-tenant surface of its own. The thin residual (operator deploys it in cloud) is captured as operator responsibility in ISO 27001 + the data-flow doc. Cut to avoid a hollow control table. |
+| SOC 2 Type II (TSC) | **Keep, FOLD into "privacy"** | Only the Privacy + Confidentiality criteria apply narrowly; Security TSC is covered by ASVS/SSDF/memory-safety; Availability is a library SLA the operator owns. Folded into `privacy`, not a standalone worktree. |
+| UK GDPR / GDPR | **Keep, FOLD into "privacy"** | Controller = operator; sparq = technical means. Honest data-flow + DPIA of what the binary touches + the ZK/MPC privacy story. |
+| UK Cyber Essentials | **CUT** | The five controls (firewalls, secure config, access control, malware, patch management) are *organisational/deployment* controls for the org running infrastructure — not properties of a Rust library. They map to the operator's environment, not sparq's source. Replaced by **EU CRA**, which is the regime that actually binds a "product with digital elements" placed on the market. |
+| CDMC scoring | **Keep** | sparq is a data engine (RDF ingest → Dict/index → results); score the 6 components/14 capabilities, with cataloguing/classification largely operator-owned. |
+
+### What we ADD (Rust / library / crypto-critical)
+
+| New framework | Why it applies to sparq |
+|---|---|
+| **NIST SSDF (SP 800-218)** | The canonical *secure-software-development* framework for a code artifact shipped as a dependency. Maps PO/PS/PW/RV practice groups to sparq's existing gate stack, threat model, fuzz/Miri, vuln disclosure, dependency policy — mostly a mapping exercise, high coverage already. |
+| **SLSA build provenance** | A dependency's supply-chain trust hinges on *verifiable build provenance*. sparq already emits `attest-build-provenance` + buildkit `provenance: mode=max` on release; declare the honest level (≈L2 on GitHub-hosted runners) + the gap to higher (reproducibility, cargo-auditable). |
+| **OpenSSF Scorecard + Best-Practices (CII) Badge** | The de-facto open-source-security posture signal consumers check. Scorecard is wired (`scorecard.yml`, `publish_results`); add the Best-Practices self-certification + raise the score. |
+| **EU Cyber Resilience Act (CRA)** | sparq, distributed on crates.io/npm/PyPI/ghcr, is a "product with digital elements." CRA's Annex I essential requirements + vuln-handling obligations (coordinated disclosure, SBOM, security updates, support period) are the *binding regulatory* regime — replaces Cyber Essentials as the right "you must do this to ship in the EU" anchor. |
+| **Memory-safety attestation** | sparq's headline safety claim. Attest the `#![forbid(unsafe_code)]` posture (23 crates), enumerate + justify the concentrated `sparq-core` unsafe (mmap/dict-spill/SIMD = threat-model boundary **B5**), and the Miri + fuzz + oracle coverage; promote cargo-geiger to a gating unsafe-count ratchet. |
+| **Cryptographic review (ZK/MPC)** | sparq ships `sparq-zk`/`sparq-zk-compose`/`sparq-mpc`. A documented crypto review of the soundness/privacy claims (anchored on `research/zk-soundness-audit.md`), constant-time + FIPS considerations, and the explicit "research scaffold, NO guarantee" statement. External-cryptographer sign-off is out of agent scope. |
+
+### Final target set (12 worktrees)
+
+`asvs`, `cis`, `sbom`, `ssdf`, `slsa`, `openssf`, `memsafety`, `iso27001`, `cra`, `privacy`
+(GDPR+27701+SOC2-Privacy+data-flow+dpia), `cryptoreview`, `cdmc`. **Cut from PSS:** iso27017-18 (no
+cloud-service surface), cyberess (org/deployment controls, superseded by CRA), and CIS-Node (no Node
+runtime). This is a defensible ~12-framework set right-sized to a Rust security-critical data-engine
+dependency.
+
+## 1 — Skills to install
+
+PSS-style compliance work is largely *evidence-gathering + adversarial review*; the heavy crypto-review
+framework leans on sparq's existing ZK/MPC skills. Plan:
+
+| Skill | Source | Where it applies |
+|---|---|---|
+| **test-driven-development** | `jeswr/solid-ai-coding` (install) | Every framework that closes a *technical* gap (memsafety, sbom, cis, asvs) — gap-fixes land with a regression test first. |
+| **secure-coding / threat-modelling** (if present in PSS `.agents/skills`) | `jeswr/prod-solid-server` `.agents/skills/` | ASVS, SSDF, CRA, threat-model extension. Install whichever PSS shipped; if none, author a thin sparq one. |
+| **(NEW) `rust-supply-chain-attestation`** | author in sparq `.agents/skills/` | SBOM (CycloneDX + VEX + NTIA elements), SLSA level evidence, cargo-deny/vet/auditable. Codifies the cargo-specific attestation recipe so the sbom + slsa engineers don't reinvent it. |
+| **(NEW) `unsafe-rust-attestation`** | author in sparq `.agents/skills/` | memsafety framework: how to enumerate `unsafe`, write per-site justifications, wire the cargo-geiger ratchet, and what Miri can/can't reach (the mmap sites). |
+| **mpc-protocols**, **noir-optimisation**, **noir-circuit-patterns**, **verifiable-credentials-zk**, **sparql-formal-semantics** | already in repo | `cryptoreview` framework — these are the existing ZK/MPC reference skills the crypto-review engineer reads to assess soundness/privacy claims honestly. |
+| **code-review / security-review** | built-in | Auditor agents may invoke for an extra adversarial pass on `crates/` changes. |
+
+The two NEW sparq-specific skills are small and high-leverage (they prevent the supply-chain and
+memory-safety engineers from re-deriving the cargo/Rust-specific recipe). Authoring them is its own
+bead (`skills-install`).
+
+## 2 — Gap register (grounded, prioritized)
+
+Status of the existing posture (from a code/CI audit of this branch) is summarized so we **do not
+re-propose existing controls**. Legend: **P0** blocks a perfect score on a high-value framework; **P1**
+needed for a perfect score; **P2** raises maturity / nice-to-have.
+
+### Already done — DO NOT re-propose (cite as evidence)
+clippy `-D warnings` (gating), CodeQL SAST (gating), OpenSSF Scorecard (`scorecard.yml`, published),
+cargo-deny bans/sources/licenses (gating), CycloneDX SBOM *in CI as artifact*, cargo-fuzz (PR smoke +
+nightly), Miri lane (nightly, `sparq-core`), SLSA `attest-build-provenance` + buildkit `provenance:
+mode=max` + SHA256SUMS on release, distroless non-root SHA-pinned `Dockerfile` + docker-smoke gate,
+SHA-pinned actions (policy), ci-summary branch-protection aggregator, `SECURITY.md` (GHSA + email,
+response targets, the ZK-not-sound + MPC-deferred caveats), `research/threat-model.md` (STRIDE,
+boundaries B1–B5), `#![forbid(unsafe_code)]` in 23 crates, daily dependency-monitoring advisory
+watchdog, Dependabot (4 ecosystems), CODEOWNERS, CONTRIBUTING.md (with disclosure redirect).
+
+### Cross-cutting gaps
+
+| ID | Gap | Sev | Framework(s) | Bead |
+|---|---|---|---|---|
+| GX-1 | **cargo-deny advisories PR-gate is degraded** (`continue-on-error`, can't parse CVSS-4.0 advisories — sq-q8de). The *real* gate is the daily watchdog; PR-time vuln gating is absent. | P0 | sbom, ssdf, cra | gap-fix |
+| GX-2 | **No checked-in / per-release SBOM with VEX.** SBOM exists only as a CI artifact; no VEX (Vulnerability Exploitability eXchange) to justify non-applicable advisories. CRA/SBOM want a published, signed, per-release SBOM. | P0 | sbom, cra, slsa | gap-fix |
+| GX-3 | **No `.well-known/security.txt` (RFC 9116).** SECURITY.md exists but the machine-discoverable disclosure pointer is absent. | P1 | cra, openssf, asvs | gap-fix |
+| GX-4 | **No OpenSSF Best-Practices (bestpractices.dev/CII) badge / self-certification.** Scorecard badge is eligible but the Best-Practices questionnaire isn't filled. | P1 | openssf | gap-fix |
+| GX-5 | **Unsafe surface has no per-site justification register, and cargo-geiger is informational only** (no gating ratchet). The B5 mmap sites can't run under Miri — coverage is via oracle + fuzz but isn't *attested* in one place. | P0 | memsafety, ssdf | gap-fix |
+| GX-6 | **No CONTRIBUTING secure-coding section** (unsafe-review checklist, input-validation guidance). SSDF PW + ASVS V1 want a documented secure-coding standard. | P1 | ssdf, asvs, iso27001 | gap-fix |
+| GX-7 | **No cargo-auditable / cargo-vet.** Binaries don't embed their dependency manifest; no per-dependency audit attestations. Raises SLSA/supply-chain assurance. | P2 | slsa, sbom, ssdf | gap-fix |
+| GX-8 | **No reproducible-build evidence.** SLSA higher levels + CRA integrity want a documented reproducibility claim (or an honest "not reproducible because…"). | P2 | slsa, cra | gap-fix |
+
+### Per-framework gaps (beyond cross-cutting)
+
+- **asvs** (P1): re-scope V1–V14 to an HTTP query API; document the B3 no-auth boundary as an explicit
+  decision (not a gap); add an ASVS-control test job for input-validation/DoS-limit controls. Verify
+  error/log hygiene (no SPARQL/RDF content or internal paths leaked in error responses/logs).
+- **cis** (P1): add a Trivy/Dockle container-hardening scan job to CI (currently no automated CIS-Docker
+  scan — only the smoke test). Add a `HEALTHCHECK`-equivalent attestation.
+- **sbom** (P0): GX-1, GX-2; map the NTIA minimum elements + supplier enrichment; per-release publish.
+- **ssdf** (P1): write the SP 800-218 PO/PS/PW/RV → sparq-control mapping (mostly existing controls);
+  GX-5, GX-6 are the real holes.
+- **slsa** (P1): declare the honest level + threat-coverage; GX-7, GX-8 to raise it.
+- **openssf** (P1): fill the Best-Practices questionnaire (GX-4); raise the Scorecard score (signed
+  releases, GX-3, branch-protection evidence already strong).
+- **memsafety** (P0): the unsafe-justification register + cargo-geiger ratchet (GX-5); attest the
+  Miri/fuzz/oracle coverage matrix over every `sparq-core` unsafe site (the B5 boundary).
+- **iso27001** (audit-ready): map the narrow applicable Annex A set; explicit operator-responsibility
+  split. Mostly documentation; no large code gap.
+- **cra** (P1): map Annex I essential requirements + the vuln-handling obligations; GX-1/2/3 are the
+  binding holes (SBOM + coordinated disclosure machine-discoverability + security-update channel).
+- **privacy** (audit-ready): write `compliance/data-flow.md` + `dpia.md` honestly scoped to what the
+  binary touches (loaded RDF, query logs, WASM client) + the ZK/MPC privacy story (flagged not-sound).
+  Honest controller(operator)/processor(sparq-as-tool) split. No large code gap; the risk is boilerplate.
+- **cryptoreview** (P0 honesty): the documented review must *preserve and extend* the
+  `research/zk-soundness-audit.md` verdict — v1 verifier NOT sound, MPC NO guarantee — and never let a
+  control table or CDMC score launder a scaffold into a "verified" guarantee. The gap is producing the
+  consolidated review doc + constant-time/FIPS notes; the *crypto itself* is tracked by the existing ZK
+  remediation beads, not this epic.
+- **cdmc** (P1): score the 6 components; cataloguing/classification of loaded datasets is largely
+  operator-owned — say so; recommendations target lineage/retention over the Dict/index + the
+  HDT/compressed-archive ingest surface.
+
+### Honest top-level posture statement
+
+sparq's *technical* security posture is already strong (the "already done" list is long and CI-gating).
+The certification gaps are concentrated in **(a) supply-chain attestation completeness** (advisories
+PR-gate, per-release SBOM+VEX, cargo-auditable/vet — GX-1/2/7), **(b) memory-safety attestation
+formality** (the unsafe register + geiger ratchet — GX-5), and **(c) the documentation/evidence packs**
+the audit-ready frameworks need (privacy data-flow/DPIA, ISO 27001 mapping, CRA mapping, the crypto
+review). The ZK/MPC estate must be presented exactly as the existing audit found it — **not sound** —
+and certification work must never contradict that. There is **no** finding that sparq currently
+*overclaims* security; the honesty contract is already lived in SECURITY.md, and this plan preserves it.


### PR DESCRIPTION
> 🤖 SPARQ agent

PLANNING + AGENT-SETUP phase of the production-hardening + security-certification epic **sq-toze**, modeled on `jeswr/prod-solid-server`'s proven parallel engineer↔auditor compliance process (honesty contract; one framework slice per worktree; loop to an auditor zero-findings sign-off). **Not** the per-framework certification work yet — this is the plan the lead reviews before launching the engineer/auditor waves.

## Deliverable 1 — `research/production-certification-plan.md`

**Final target framework set (12 worktrees):** `asvs`, `cis`, `sbom`, `ssdf`, `slsa`, `openssf`, `memsafety`, `iso27001`, `cra`, `privacy` (GDPR+27701+SOC2-Privacy+data-flow+dpia), `cryptoreview`, `cdmc`.

**Kept from PSS (adapted to a Rust library/server/crypto dependency):** ASVS L2 (re-scoped to the `sparq-server` query API; B3 no-auth as an explicit decision), CIS-Docker (distroless/non-root + a new Trivy/Dockle scan), SBOM+supply-chain, ISO 27001 (narrow, audit-ready), and GDPR+ISO 27701+SOC2-Privacy **folded into one `privacy` slice** (sparq = data engine, operator = controller).

**Added (Rust/library/crypto-critical):** NIST SSDF (SP 800-218), SLSA build provenance, OpenSSF Scorecard + Best-Practices badge, EU Cyber Resilience Act, memory-safety attestation (the `#![forbid(unsafe_code)]` posture + the `sparq-core` B5 unsafe surface), and a documented cryptographic review of the ZK/MPC estate.

**Cut from PSS's 10, with rationale:** **iso27017-18** (cloud-service-provider controls; sparq has no S3/multi-tenant surface of its own), **cyberess** (org/deployment controls, superseded by CRA as the binding "product with digital elements" regime), **CIS-Node** (no Node runtime; the JS surface is the WASM port).

**Gap register (grounded — does NOT re-propose existing controls):** the "already done" list (clippy `-D`, CodeQL, Scorecard, cargo-deny, CycloneDX-in-CI, fuzz, Miri, SLSA attest-build-provenance, distroless image, SHA-pinned actions, SECURITY.md, threat-model) is cited as evidence, not re-claimed. Top gaps: **GX-1** cargo-deny advisories PR-gate is degraded (CVSS-4.0); **GX-2** no per-release SBOM+VEX; **GX-3** no `.well-known/security.txt`; **GX-4** no OpenSSF Best-Practices badge; **GX-5** no unsafe-justification register + cargo-geiger only informational; **GX-6** no CONTRIBUTING secure-coding section; **GX-7** no cargo-auditable/cargo-vet; **GX-8** no reproducible-build evidence. Honest top-line: sparq does **not** overclaim today; the load-bearing honesty item is the documented **v1-ZK-verifier-NOT-sound** verdict, which the plan preserves.

## Deliverable 2 — ported compliance agents

`.claude/agents/compliance-engineer.md`, `compliance-auditor.md`, `compliance-orchestration.md` — adapted from PSS to sparq's Rust crates, framework set, CI gates, `bd` tracking, and worktree-isolation discipline. Both engineer + auditor carry a **ZK/MPC honesty tripwire**: any control/score that contradicts the not-sound verdict, or launders a research scaffold into a "verified" guarantee, is an automatic critical finding.

## Deliverable 3 — bead graph (epic sq-toze)

- **skills-install:** `sq-toze.1`
- **gap-fixes (GX-1..GX-8):** `sq-toze.2` … `sq-toze.9`
- **framework engineer+auditor assessments:** ASVS `.10`, CIS `.11`, SBOM `.12`, SSDF `.13`, SLSA `.14`, OpenSSF `.15`, memsafety `.16`, ISO27001 `.17`, CRA `.18`, privacy `.19`, cryptoreview `.20`, CDMC `.21`
- **consolidation/CDMC re-score:** `sq-toze.22`

**Dependencies (gap-fixes block the blocked frameworks' perfect score; all assessments block consolidation; no cycles):**
`.1`→ all `.10–.21`; `.2`→`.12,.13,.18`; `.3`→`.12,.18,.14`; `.4`→`.18,.15,.10`; `.5`→`.15`; `.6`→`.16,.13`; `.7`→`.13,.10,.17`; `.8`→`.14,.12,.13`; `.9`→`.14,.18`; `.10–.21`→`.22`.

Refs sq-toze (epic kept OPEN). NON-CANONICAL timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)