### PR TITLE
cert: certification skills foundation — TDD vendor + 2 attestation skills (sq-toze.1)

### DIFF
--- a/.claude/skills/rust-supply-chain-attestation/SKILL.md
+++ b/.claude/skills/rust-supply-chain-attestation/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: rust-supply-chain-attestation
+description: How sparq attests its Rust/cargo supply chain — cargo-deny (advisories/bans/licenses/sources), cargo-vet/cargo-auditable, CycloneDX SBOM + VEX, SLSA build provenance, and OpenSSF Scorecard — and which evidence each tool produces for the SBOM, SLSA, NIST SSDF, EU CRA, and OpenSSF certification frameworks. Use when working any of the sbom/slsa/ssdf/cra/openssf certification worktrees, when adding or changing a supply-chain CI lane, when filling out an SBOM/VEX or a SLSA-level claim, or when asked what evidence a given framework wants from a cargo workspace. Grounded in sparq's real deny.toml + supply-chain.yml + scorecard.yml + dependency-monitoring.yml + release.yml.
+---
+
+# Rust supply-chain attestation (sparq)
+
+How sparq proves the integrity of what it ships — a Rust **library + binaries +
+container** consumed as a dependency on crates.io / npm (WASM) / PyPI / ghcr.
+The dominant risk for a dependency is **supply-chain integrity + build
+provenance**, so this is the highest-fit framework family. This skill is the
+cargo-specific recipe so the `sbom`, `slsa`, `ssdf`, `cra`, and `openssf`
+engineers do not re-derive it.
+
+> NON-CANONICAL timing. No measured numbers belong in this file.
+
+## The tools, what they prove, and which framework consumes the evidence
+
+| Tool | What it asserts | Evidence artifact | Frameworks |
+|---|---|---|---|
+| **cargo-deny** (advisories) | No known-vulnerable / yanked dependency in the tree | CI log + the daily tracking issue | SBOM, SSDF (RV), CRA (vuln-handling) |
+| **cargo-deny** (bans) | No banned/duplicate-version crate sneaks in | CI log | SSDF (PW), SBOM |
+| **cargo-deny** (licenses) | Every dependency is permissive / explicitly excepted | CI log + `deny.toml` allowlist | SBOM (NTIA "license"), ISO 27001, CRA |
+| **cargo-deny** (sources) | Crates come only from crates.io (no rogue git/registry) | CI log + `deny.toml [sources]` | SLSA, SSDF (PS), SBOM (supplier) |
+| **CycloneDX SBOM** (`cargo-cyclonedx`) | The full component inventory of the build | `*.cdx.json` | SBOM (the artifact itself), CRA (Annex I §2), SSDF (PS.3) |
+| **VEX** (CycloneDX/CSAF) | Why a flagged advisory is *not exploitable* in sparq | `*.vex.json` alongside the SBOM | SBOM, CRA (vuln-handling) |
+| **cargo-auditable** | The exact dependency manifest is embedded *inside* the binary | `cargo audit bin <file>` reads it | SLSA, SBOM, SSDF |
+| **cargo-vet** | Each dependency carries a human audit attestation | `supply-chain/audits.toml` | SLSA (higher assurance), SSDF (PS) |
+| **attest-build-provenance** | This binary was built by *this* workflow run (Sigstore-signed) | `gh attestation verify` | SLSA (the core L2 claim), CRA, SSDF |
+| **OpenSSF Scorecard** | Aggregate posture score (pinned deps, branch protection, SAST…) | SARIF in Security tab + public dashboard | OpenSSF, SSDF |
+
+## How each is wired in sparq today (ground truth — cite these, don't re-propose)
+
+### cargo-deny — `deny.toml` + `.github/workflows/supply-chain.yml`
+The policy lives in `deny.toml` (schema targets cargo-deny >= 0.18, "version 2"
+advisories/licenses). The `supply-chain.yml` `audit` job runs on the **host
+stable toolchain** (not the EmbarkStudios Docker action — its bundled cargo 1.83
+can't parse the vendored `spargebra`, which needs `edition2024` / cargo >= 1.85).
+
+- **GATING now:** `cargo deny check bans sources licenses` (every push/PR/merge_group).
+- **Licenses:** an allowlist of permissive licenses only (MIT, Apache-2.0, BSD-*,
+  ISC, Unicode-3.0, CC0-1.0, Zlib, BlueOak-1.0.0) plus **per-crate exceptions**
+  (CeCILL-B for the sophia/HDT tree, AFL-3.0 for `ntriple`, MPL-2.0 for `resiter`,
+  Apache-2.0-WITH-LLVM-exception, CDLA-Permissive-2.0 for `webpki-roots`). Each
+  exception is scoped to one crate so the broad allowlist stays permissive-only.
+- **Sources:** `unknown-registry = "deny"`, `unknown-git = "deny"`, only
+  crates.io allowed. The vendored `spargebra` is a `[patch.crates-io]` PATH source
+  (a path patch is not a registry/git source, so it doesn't trip the gate);
+  `allow-git = []` is the hook for any deliberately-allowed future git source.
+- **Advisories ignore list:** only `unmaintained` *informational* advisories on
+  transitive deps with no safe upgrade (e.g. `paste` via wgpu → bead sq-l8bv;
+  `rustls-pemfile` via ureq → bead sq-g2xs). A real **vulnerability** or a
+  **yanked** crate FAILS the gate.
+
+### The advisories-gate gap (GX-1 — know this)
+`cargo deny check advisories` is currently **`continue-on-error` (non-gating)**:
+cargo-deny 0.19.x can't parse RustSec advisories that use **CVSS v4.0** — it
+fails *loading* the freshly-cloned advisory DB ("unsupported CVSS version: 4.0"),
+a DB-wide parse error before any per-advisory `ignore` applies, so it can't be
+configured around. The **real** advisory gate today is the daily watchdog
+(`dependency-monitoring.yml`), which runs advisories-only off-peak and
+opens/updates a single idempotent `security:dependency-vuln` tracking issue.
+Flip the PR-time advisories check back to gating once cargo-deny ships CVSS-4.0
+support — **bead sq-q8de tracks it**. When an auditor asks "is there PR-time vuln
+gating?", the honest answer is *no, the daily watchdog is the gate* — say so.
+
+### CycloneDX SBOM — `supply-chain.yml` `sbom` job
+`cargo cyclonedx --all --format json` emits one SBOM per workspace member plus an
+aggregate (`**/*.cdx.json`), uploaded as a CI **artifact**. Gaps the `sbom`/`cra`
+engineers must close (GX-2): there is **no checked-in / per-release SBOM** and
+**no VEX** yet. CRA/SBOM want a *published, per-release* SBOM with VEX to justify
+non-applicable advisories. Map the SBOM to the **NTIA minimum elements**
+(supplier, component name, version, unique identifier/PURL, dependency
+relationship, author, timestamp) when scoring.
+
+### SLSA build provenance — `release.yml`
+- `actions/attest-build-provenance` (SHA-pinned) signs (Sigstore) an attestation
+  binding each packaged archive's digest to the workflow run; verify with
+  `gh attestation verify <file>`. Plus `SHA256SUMS` over all archives.
+- The container build uses buildkit `provenance: mode=max` + `sbom: true`,
+  attaching SLSA provenance + an embedded SBOM to the ghcr.io image (verifiable
+  via cosign / gh).
+- **Honest level:** ≈ **SLSA L2** on GitHub-hosted runners (signed provenance,
+  hosted build platform). The gaps to higher (GX-7/GX-8): no `cargo-auditable`
+  (binaries don't embed their dependency manifest), no `cargo-vet`, and no
+  reproducible-build evidence. State the level *honestly* and name the gap —
+  never inflate to L3.
+
+### OpenSSF Scorecard — `scorecard.yml`
+Runs on push-to-main + weekly; `publish_results: true` uploads to the public
+OpenSSF dashboard (required for the Scorecard badge) and to code-scanning (SARIF).
+Gaps for the `openssf` worktree: the **Best-Practices (bestpractices.dev / CII)**
+questionnaire isn't filled (GX-4), and there's no `.well-known/security.txt`
+(RFC 9116) machine-discoverable disclosure pointer (GX-3).
+
+## How to use this when working a certification framework
+
+1. **Don't re-propose existing controls.** The list above is the live posture;
+   cite the file (`deny.toml:line`, `supply-chain.yml:job`) as evidence.
+2. **Gap-fixes land test-first.** Use the `test-driven-development` skill — a new
+   CI lane or a checked-in SBOM lands with a verifying check before the change.
+3. **Frameworks → evidence:** SBOM → the `*.cdx.json` + NTIA mapping + VEX; SLSA →
+   the provenance attestation + the honest level statement; SSDF → map PO/PS/PW/RV
+   to these tools; CRA → SBOM + coordinated-disclosure discoverability +
+   security-update channel; OpenSSF → Scorecard score + Best-Practices badge.
+4. **Honesty contract.** Never let a control table launder a gap (the degraded
+   advisories PR-gate, the missing per-release SBOM/VEX, the SLSA-L2-not-L3
+   reality) into a "done". Record each gap as a bead, not a silent pass.
+
+## Local commands
+```
+cargo install --locked cargo-deny cargo-cyclonedx cargo-auditable cargo-audit
+cargo deny check                 # advisories + bans + sources + licenses
+cargo deny check bans sources licenses   # the currently-gating subset
+cargo cyclonedx --all --format json      # CycloneDX SBOMs
+gh attestation verify <archive> --owner jeswr   # SLSA provenance check
+```
+
+<!-- [OPUS-4.8] Authored for bead sq-toze.1 (epic sq-toze, cert framework). Grounded in
+deny.toml + .github/workflows/{supply-chain,scorecard,dependency-monitoring,release}.yml.
+Re-review when Fable returns. -->

--- a/.claude/skills/test-driven-development/SKILL.md
+++ b/.claude/skills/test-driven-development/SKILL.md
@@ -1,0 +1,377 @@
+---
+name: test-driven-development
+description: Use when implementing any feature or bugfix, before writing implementation code
+---
+
+<!-- VENDORED from jeswr/prod-solid-server `.agents/skills/test-driven-development/`
+(SKILL.md + testing-anti-patterns.md), unmodified. The upstream repository carries
+no LICENSE file at vendor time; vendored by arrangement with the owner (@jeswr).
+Mirrored here for sparq's certification framework (epic sq-toze, bead sq-toze.1) so
+gap-fixes across the memsafety/sbom/cis/asvs worktrees land test-first. [OPUS-4.8] -->
+
+# Test-Driven Development (TDD)
+
+## Overview
+
+Write the test first. Watch it fail. Write minimal code to pass.
+
+**Core principle:** If you didn't watch the test fail, you don't know if it tests the right thing.
+
+**Violating the letter of the rules is violating the spirit of the rules.**
+
+## When to Use
+
+**Always:**
+- New features
+- Bug fixes
+- Refactoring
+- Behavior changes
+
+**Exceptions (ask your human partner):**
+- Throwaway prototypes
+- Generated code
+- Configuration files
+
+Thinking "skip TDD just this once"? Stop. That's rationalization.
+
+## The Iron Law
+
+```
+NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
+```
+
+Write code before the test? Delete it. Start over.
+
+**No exceptions:**
+- Don't keep it as "reference"
+- Don't "adapt" it while writing tests
+- Don't look at it
+- Delete means delete
+
+Implement fresh from tests. Period.
+
+## Red-Green-Refactor
+
+```dot
+digraph tdd_cycle {
+    rankdir=LR;
+    red [label="RED\nWrite failing test", shape=box, style=filled, fillcolor="#ffcccc"];
+    verify_red [label="Verify fails\ncorrectly", shape=diamond];
+    green [label="GREEN\nMinimal code", shape=box, style=filled, fillcolor="#ccffcc"];
+    verify_green [label="Verify passes\nAll green", shape=diamond];
+    refactor [label="REFACTOR\nClean up", shape=box, style=filled, fillcolor="#ccccff"];
+    next [label="Next", shape=ellipse];
+
+    red -> verify_red;
+    verify_red -> green [label="yes"];
+    verify_red -> red [label="wrong\nfailure"];
+    green -> verify_green;
+    verify_green -> refactor [label="yes"];
+    verify_green -> green [label="no"];
+    refactor -> verify_green [label="stay\ngreen"];
+    verify_green -> next;
+    next -> red;
+}
+```
+
+### RED - Write Failing Test
+
+Write one minimal test showing what should happen.
+
+<Good>
+```typescript
+test('retries failed operations 3 times', async () => {
+  let attempts = 0;
+  const operation = () => {
+    attempts++;
+    if (attempts < 3) throw new Error('fail');
+    return 'success';
+  };
+
+  const result = await retryOperation(operation);
+
+  expect(result).toBe('success');
+  expect(attempts).toBe(3);
+});
+```
+Clear name, tests real behavior, one thing
+</Good>
+
+<Bad>
+```typescript
+test('retry works', async () => {
+  const mock = jest.fn()
+    .mockRejectedValueOnce(new Error())
+    .mockRejectedValueOnce(new Error())
+    .mockResolvedValueOnce('success');
+  await retryOperation(mock);
+  expect(mock).toHaveBeenCalledTimes(3);
+});
+```
+Vague name, tests mock not code
+</Bad>
+
+**Requirements:**
+- One behavior
+- Clear name
+- Real code (no mocks unless unavoidable)
+
+### Verify RED - Watch It Fail
+
+**MANDATORY. Never skip.**
+
+```bash
+npm test path/to/test.test.ts
+```
+
+Confirm:
+- Test fails (not errors)
+- Failure message is expected
+- Fails because feature missing (not typos)
+
+**Test passes?** You're testing existing behavior. Fix test.
+
+**Test errors?** Fix error, re-run until it fails correctly.
+
+### GREEN - Minimal Code
+
+Write simplest code to pass the test.
+
+<Good>
+```typescript
+async function retryOperation<T>(fn: () => Promise<T>): Promise<T> {
+  for (let i = 0; i < 3; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (i === 2) throw e;
+    }
+  }
+  throw new Error('unreachable');
+}
+```
+Just enough to pass
+</Good>
+
+<Bad>
+```typescript
+async function retryOperation<T>(
+  fn: () => Promise<T>,
+  options?: {
+    maxRetries?: number;
+    backoff?: 'linear' | 'exponential';
+    onRetry?: (attempt: number) => void;
+  }
+): Promise<T> {
+  // YAGNI
+}
+```
+Over-engineered
+</Bad>
+
+Don't add features, refactor other code, or "improve" beyond the test.
+
+### Verify GREEN - Watch It Pass
+
+**MANDATORY.**
+
+```bash
+npm test path/to/test.test.ts
+```
+
+Confirm:
+- Test passes
+- Other tests still pass
+- Output pristine (no errors, warnings)
+
+**Test fails?** Fix code, not test.
+
+**Other tests fail?** Fix now.
+
+### REFACTOR - Clean Up
+
+After green only:
+- Remove duplication
+- Improve names
+- Extract helpers
+
+Keep tests green. Don't add behavior.
+
+### Repeat
+
+Next failing test for next feature.
+
+## Good Tests
+
+| Quality | Good | Bad |
+|---------|------|-----|
+| **Minimal** | One thing. "and" in name? Split it. | `test('validates email and domain and whitespace')` |
+| **Clear** | Name describes behavior | `test('test1')` |
+| **Shows intent** | Demonstrates desired API | Obscures what code should do |
+
+## Why Order Matters
+
+**"I'll write tests after to verify it works"**
+
+Tests written after code pass immediately. Passing immediately proves nothing:
+- Might test wrong thing
+- Might test implementation, not behavior
+- Might miss edge cases you forgot
+- You never saw it catch the bug
+
+Test-first forces you to see the test fail, proving it actually tests something.
+
+**"I already manually tested all the edge cases"**
+
+Manual testing is ad-hoc. You think you tested everything but:
+- No record of what you tested
+- Can't re-run when code changes
+- Easy to forget cases under pressure
+- "It worked when I tried it" ≠ comprehensive
+
+Automated tests are systematic. They run the same way every time.
+
+**"Deleting X hours of work is wasteful"**
+
+Sunk cost fallacy. The time is already gone. Your choice now:
+- Delete and rewrite with TDD (X more hours, high confidence)
+- Keep it and add tests after (30 min, low confidence, likely bugs)
+
+The "waste" is keeping code you can't trust. Working code without real tests is technical debt.
+
+**"TDD is dogmatic, being pragmatic means adapting"**
+
+TDD IS pragmatic:
+- Finds bugs before commit (faster than debugging after)
+- Prevents regressions (tests catch breaks immediately)
+- Documents behavior (tests show how to use code)
+- Enables refactoring (change freely, tests catch breaks)
+
+"Pragmatic" shortcuts = debugging in production = slower.
+
+**"Tests after achieve the same goals - it's spirit not ritual"**
+
+No. Tests-after answer "What does this do?" Tests-first answer "What should this do?"
+
+Tests-after are biased by your implementation. You test what you built, not what's required. You verify remembered edge cases, not discovered ones.
+
+Tests-first force edge case discovery before implementing. Tests-after verify you remembered everything (you didn't).
+
+30 minutes of tests after ≠ TDD. You get coverage, lose proof tests work.
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "Too simple to test" | Simple code breaks. Test takes 30 seconds. |
+| "I'll test after" | Tests passing immediately prove nothing. |
+| "Tests after achieve same goals" | Tests-after = "what does this do?" Tests-first = "what should this do?" |
+| "Already manually tested" | Ad-hoc ≠ systematic. No record, can't re-run. |
+| "Deleting X hours is wasteful" | Sunk cost fallacy. Keeping unverified code is technical debt. |
+| "Keep as reference, write tests first" | You'll adapt it. That's testing after. Delete means delete. |
+| "Need to explore first" | Fine. Throw away exploration, start with TDD. |
+| "Test hard = design unclear" | Listen to test. Hard to test = hard to use. |
+| "TDD will slow me down" | TDD faster than debugging. Pragmatic = test-first. |
+| "Manual test faster" | Manual doesn't prove edge cases. You'll re-test every change. |
+| "Existing code has no tests" | You're improving it. Add tests for existing code. |
+
+## Red Flags - STOP and Start Over
+
+- Code before test
+- Test after implementation
+- Test passes immediately
+- Can't explain why test failed
+- Tests added "later"
+- Rationalizing "just this once"
+- "I already manually tested it"
+- "Tests after achieve the same purpose"
+- "It's about spirit not ritual"
+- "Keep as reference" or "adapt existing code"
+- "Already spent X hours, deleting is wasteful"
+- "TDD is dogmatic, I'm being pragmatic"
+- "This is different because..."
+
+**All of these mean: Delete code. Start over with TDD.**
+
+## Example: Bug Fix
+
+**Bug:** Empty email accepted
+
+**RED**
+```typescript
+test('rejects empty email', async () => {
+  const result = await submitForm({ email: '' });
+  expect(result.error).toBe('Email required');
+});
+```
+
+**Verify RED**
+```bash
+$ npm test
+FAIL: expected 'Email required', got undefined
+```
+
+**GREEN**
+```typescript
+function submitForm(data: FormData) {
+  if (!data.email?.trim()) {
+    return { error: 'Email required' };
+  }
+  // ...
+}
+```
+
+**Verify GREEN**
+```bash
+$ npm test
+PASS
+```
+
+**REFACTOR**
+Extract validation for multiple fields if needed.
+
+## Verification Checklist
+
+Before marking work complete:
+
+- [ ] Every new function/method has a test
+- [ ] Watched each test fail before implementing
+- [ ] Each test failed for expected reason (feature missing, not typo)
+- [ ] Wrote minimal code to pass each test
+- [ ] All tests pass
+- [ ] Output pristine (no errors, warnings)
+- [ ] Tests use real code (mocks only if unavoidable)
+- [ ] Edge cases and errors covered
+
+Can't check all boxes? You skipped TDD. Start over.
+
+## When Stuck
+
+| Problem | Solution |
+|---------|----------|
+| Don't know how to test | Write wished-for API. Write assertion first. Ask your human partner. |
+| Test too complicated | Design too complicated. Simplify interface. |
+| Must mock everything | Code too coupled. Use dependency injection. |
+| Test setup huge | Extract helpers. Still complex? Simplify design. |
+
+## Debugging Integration
+
+Bug found? Write failing test reproducing it. Follow TDD cycle. Test proves fix and prevents regression.
+
+Never fix bugs without a test.
+
+## Testing Anti-Patterns
+
+When adding mocks or test utilities, read @testing-anti-patterns.md to avoid common pitfalls:
+- Testing mock behavior instead of real behavior
+- Adding test-only methods to production classes
+- Mocking without understanding dependencies
+
+## Final Rule
+
+```
+Production code → test exists and failed first
+Otherwise → not TDD
+```
+
+No exceptions without your human partner's permission.

--- a/.claude/skills/test-driven-development/testing-anti-patterns.md
+++ b/.claude/skills/test-driven-development/testing-anti-patterns.md
@@ -1,0 +1,299 @@
+# Testing Anti-Patterns
+
+**Load this reference when:** writing or changing tests, adding mocks, or tempted to add test-only methods to production code.
+
+## Overview
+
+Tests must verify real behavior, not mock behavior. Mocks are a means to isolate, not the thing being tested.
+
+**Core principle:** Test what the code does, not what the mocks do.
+
+**Following strict TDD prevents these anti-patterns.**
+
+## The Iron Laws
+
+```
+1. NEVER test mock behavior
+2. NEVER add test-only methods to production classes
+3. NEVER mock without understanding dependencies
+```
+
+## Anti-Pattern 1: Testing Mock Behavior
+
+**The violation:**
+```typescript
+// ❌ BAD: Testing that the mock exists
+test('renders sidebar', () => {
+  render(<Page />);
+  expect(screen.getByTestId('sidebar-mock')).toBeInTheDocument();
+});
+```
+
+**Why this is wrong:**
+- You're verifying the mock works, not that the component works
+- Test passes when mock is present, fails when it's not
+- Tells you nothing about real behavior
+
+**your human partner's correction:** "Are we testing the behavior of a mock?"
+
+**The fix:**
+```typescript
+// ✅ GOOD: Test real component or don't mock it
+test('renders sidebar', () => {
+  render(<Page />);  // Don't mock sidebar
+  expect(screen.getByRole('navigation')).toBeInTheDocument();
+});
+
+// OR if sidebar must be mocked for isolation:
+// Don't assert on the mock - test Page's behavior with sidebar present
+```
+
+### Gate Function
+
+```
+BEFORE asserting on any mock element:
+  Ask: "Am I testing real component behavior or just mock existence?"
+
+  IF testing mock existence:
+    STOP - Delete the assertion or unmock the component
+
+  Test real behavior instead
+```
+
+## Anti-Pattern 2: Test-Only Methods in Production
+
+**The violation:**
+```typescript
+// ❌ BAD: destroy() only used in tests
+class Session {
+  async destroy() {  // Looks like production API!
+    await this._workspaceManager?.destroyWorkspace(this.id);
+    // ... cleanup
+  }
+}
+
+// In tests
+afterEach(() => session.destroy());
+```
+
+**Why this is wrong:**
+- Production class polluted with test-only code
+- Dangerous if accidentally called in production
+- Violates YAGNI and separation of concerns
+- Confuses object lifecycle with entity lifecycle
+
+**The fix:**
+```typescript
+// ✅ GOOD: Test utilities handle test cleanup
+// Session has no destroy() - it's stateless in production
+
+// In test-utils/
+export async function cleanupSession(session: Session) {
+  const workspace = session.getWorkspaceInfo();
+  if (workspace) {
+    await workspaceManager.destroyWorkspace(workspace.id);
+  }
+}
+
+// In tests
+afterEach(() => cleanupSession(session));
+```
+
+### Gate Function
+
+```
+BEFORE adding any method to production class:
+  Ask: "Is this only used by tests?"
+
+  IF yes:
+    STOP - Don't add it
+    Put it in test utilities instead
+
+  Ask: "Does this class own this resource's lifecycle?"
+
+  IF no:
+    STOP - Wrong class for this method
+```
+
+## Anti-Pattern 3: Mocking Without Understanding
+
+**The violation:**
+```typescript
+// ❌ BAD: Mock breaks test logic
+test('detects duplicate server', () => {
+  // Mock prevents config write that test depends on!
+  vi.mock('ToolCatalog', () => ({
+    discoverAndCacheTools: vi.fn().mockResolvedValue(undefined)
+  }));
+
+  await addServer(config);
+  await addServer(config);  // Should throw - but won't!
+});
+```
+
+**Why this is wrong:**
+- Mocked method had side effect test depended on (writing config)
+- Over-mocking to "be safe" breaks actual behavior
+- Test passes for wrong reason or fails mysteriously
+
+**The fix:**
+```typescript
+// ✅ GOOD: Mock at correct level
+test('detects duplicate server', () => {
+  // Mock the slow part, preserve behavior test needs
+  vi.mock('MCPServerManager'); // Just mock slow server startup
+
+  await addServer(config);  // Config written
+  await addServer(config);  // Duplicate detected ✓
+});
+```
+
+### Gate Function
+
+```
+BEFORE mocking any method:
+  STOP - Don't mock yet
+
+  1. Ask: "What side effects does the real method have?"
+  2. Ask: "Does this test depend on any of those side effects?"
+  3. Ask: "Do I fully understand what this test needs?"
+
+  IF depends on side effects:
+    Mock at lower level (the actual slow/external operation)
+    OR use test doubles that preserve necessary behavior
+    NOT the high-level method the test depends on
+
+  IF unsure what test depends on:
+    Run test with real implementation FIRST
+    Observe what actually needs to happen
+    THEN add minimal mocking at the right level
+
+  Red flags:
+    - "I'll mock this to be safe"
+    - "This might be slow, better mock it"
+    - Mocking without understanding the dependency chain
+```
+
+## Anti-Pattern 4: Incomplete Mocks
+
+**The violation:**
+```typescript
+// ❌ BAD: Partial mock - only fields you think you need
+const mockResponse = {
+  status: 'success',
+  data: { userId: '123', name: 'Alice' }
+  // Missing: metadata that downstream code uses
+};
+
+// Later: breaks when code accesses response.metadata.requestId
+```
+
+**Why this is wrong:**
+- **Partial mocks hide structural assumptions** - You only mocked fields you know about
+- **Downstream code may depend on fields you didn't include** - Silent failures
+- **Tests pass but integration fails** - Mock incomplete, real API complete
+- **False confidence** - Test proves nothing about real behavior
+
+**The Iron Rule:** Mock the COMPLETE data structure as it exists in reality, not just fields your immediate test uses.
+
+**The fix:**
+```typescript
+// ✅ GOOD: Mirror real API completeness
+const mockResponse = {
+  status: 'success',
+  data: { userId: '123', name: 'Alice' },
+  metadata: { requestId: 'req-789', timestamp: 1234567890 }
+  // All fields real API returns
+};
+```
+
+### Gate Function
+
+```
+BEFORE creating mock responses:
+  Check: "What fields does the real API response contain?"
+
+  Actions:
+    1. Examine actual API response from docs/examples
+    2. Include ALL fields system might consume downstream
+    3. Verify mock matches real response schema completely
+
+  Critical:
+    If you're creating a mock, you must understand the ENTIRE structure
+    Partial mocks fail silently when code depends on omitted fields
+
+  If uncertain: Include all documented fields
+```
+
+## Anti-Pattern 5: Integration Tests as Afterthought
+
+**The violation:**
+```
+✅ Implementation complete
+❌ No tests written
+"Ready for testing"
+```
+
+**Why this is wrong:**
+- Testing is part of implementation, not optional follow-up
+- TDD would have caught this
+- Can't claim complete without tests
+
+**The fix:**
+```
+TDD cycle:
+1. Write failing test
+2. Implement to pass
+3. Refactor
+4. THEN claim complete
+```
+
+## When Mocks Become Too Complex
+
+**Warning signs:**
+- Mock setup longer than test logic
+- Mocking everything to make test pass
+- Mocks missing methods real components have
+- Test breaks when mock changes
+
+**your human partner's question:** "Do we need to be using a mock here?"
+
+**Consider:** Integration tests with real components often simpler than complex mocks
+
+## TDD Prevents These Anti-Patterns
+
+**Why TDD helps:**
+1. **Write test first** → Forces you to think about what you're actually testing
+2. **Watch it fail** → Confirms test tests real behavior, not mocks
+3. **Minimal implementation** → No test-only methods creep in
+4. **Real dependencies** → You see what the test actually needs before mocking
+
+**If you're testing mock behavior, you violated TDD** - you added mocks without watching test fail against real code first.
+
+## Quick Reference
+
+| Anti-Pattern | Fix |
+|--------------|-----|
+| Assert on mock elements | Test real component or unmock it |
+| Test-only methods in production | Move to test utilities |
+| Mock without understanding | Understand dependencies first, mock minimally |
+| Incomplete mocks | Mirror real API completely |
+| Tests as afterthought | TDD - tests first |
+| Over-complex mocks | Consider integration tests |
+
+## Red Flags
+
+- Assertion checks for `*-mock` test IDs
+- Methods only called in test files
+- Mock setup is >50% of test
+- Test fails when you remove mock
+- Can't explain why mock is needed
+- Mocking "just to be safe"
+
+## The Bottom Line
+
+**Mocks are tools to isolate, not things to test.**
+
+If TDD reveals you're testing mock behavior, you've gone wrong.
+
+Fix: Test real behavior or question why you're mocking at all.

--- a/.claude/skills/unsafe-rust-attestation/SKILL.md
+++ b/.claude/skills/unsafe-rust-attestation/SKILL.md
@@ -6,7 +6,7 @@ description: How sparq attests memory safety — the forbid(unsafe_code) posture
 # Unsafe-Rust attestation (sparq)
 
 sparq's headline safety claim is memory safety. This skill is how to *attest* it
-honestly for the `memsafety` certification worktree — the `forbid(unsafe)`
+honestly for the `memsafety` certification worktree — the `forbid(unsafe_code)`
 posture, the concentrated `sparq-core` unsafe surface (threat-model boundary
 **B5**), and the verification estate (Miri + fuzz + the deterministic oracle).
 
@@ -19,9 +19,15 @@ posture, the concentrated `sparq-core` unsafe surface (threat-model boundary
   others — `grep -rl "forbid(unsafe_code)" crates/`). `forbid` (not `deny`) means
   the lint can't even be locally `#[allow]`-ed away — a hard compile error if any
   `unsafe` is introduced. **This is the strongest attestable claim and it's free.**
-- **`sparq-core` is the *only* crate with `unsafe`.** All memory-safety risk is
-  concentrated there by design, which is what makes attestation tractable: the
-  audit surface is one crate, not the whole tree.
+- **`sparq-core` carries the *vast majority* of the `unsafe`, and all of the B5
+  (untrusted-input) risk.** A few other crates have small, non-B5 unsafe surfaces
+  (e.g. `sparq-vectors` mmap/raw-slice casts, `sparq-cli`'s loader mmap in
+  `main.rs`, `sparq-zk-compose`'s `libc::flock` FFI in `verifier.rs`, one
+  `sparq-bench` block) — these do **not** carry `forbid(unsafe_code)`, so the
+  audit surface is "the crates without `forbid` " not "one crate". Verify the
+  live set with `grep -rL "forbid(unsafe_code)" $(git ls-files 'crates/*/src/lib.rs')`.
+  Attestation stays tractable because the *dangerous* (hostile-input → unsafe)
+  risk is still concentrated in `sparq-core`'s B5 boundary, enumerated below.
 
 When scoring, the honest statement is: *"N of M crates forbid unsafe; the residual
 unsafe is concentrated in sparq-core's B5 boundary, enumerated and verified
@@ -31,7 +37,8 @@ below."* Verify the live count with grep before quoting it — don't hard-code i
 
 B5 = **hostile on-disk index file → mmap loader → unsafe code** — an
 *untrusted-input → unsafe-code* boundary, the most dangerous class in the system.
-`grep -rn "unsafe" crates/sparq-core/src` returns ~39 sites across five files:
+`grep -rn "unsafe" crates/sparq-core/src` enumerates the sites — concentrated
+across five files (run it for the live count; don't hard-code one here):
 
 | File | Nature of the unsafe |
 |---|---|
@@ -60,7 +67,7 @@ the attestation doesn't overstate the threat there.
 
 | Verifier | Wired in | Reaches | Does NOT reach |
 |---|---|---|---|
-| **Miri** (UB) | `.github/workflows/miri.yml`, nightly | pure-Rust unsafe with default features (`parallel`): the `par_iter_mut` scatter writes in `dict.rs`, POD↔bytes reinterprets, `from_utf8_unchecked` over in-memory buffers, `MaybeUninit`+`set_len` remap | the ~16 **mmap-backed** sites — Miri rejects file-backed mappings ("Miri does not support file-backed memory mappings"), so `mmap`/`dict-spill` features are **off** in this lane |
+| **Miri** (UB) | `.github/workflows/miri.yml`, nightly | pure-Rust unsafe with default features (`parallel`): the `par_iter_mut` scatter writes in `dict.rs`, POD↔bytes reinterprets, `from_utf8_unchecked` over in-memory buffers, `MaybeUninit`+`set_len` remap | the **mmap-backed** sites — Miri rejects file-backed mappings ("Miri does not support file-backed memory mappings"), so `mmap`/`dict-spill` features are **off** in this lane |
 | **mmap_corruption_oracle** (deterministic) | `ci.yml` under `--features mmap,dict-spill` | the mmap B5 sites Miri can't reach | non-determinism (it's a fixed oracle, not a fuzzer) |
 | **fuzz** lane (cargo-fuzz) | `fuzz.yml`, PR smoke + nightly | hostile-input panics/OOM on the loader | UB detection (panics ≠ UB) |
 | **cargo-geiger** | `ci.yml` `geiger` job, **informational** | counts unsafe sites (sparq-core, via `--manifest-path`; can't run the virtual root) | nothing gates on it yet (GX-5) |

--- a/.claude/skills/unsafe-rust-attestation/SKILL.md
+++ b/.claude/skills/unsafe-rust-attestation/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: unsafe-rust-attestation
+description: How sparq attests memory safety — the forbid(unsafe_code) posture across most crates, the concentrated sparq-core unsafe surface (mmap / dict-spill / SIMD, threat-model boundary B5), the nightly Miri lane, cargo-geiger, and the per-site unsafe-justification register (gap GX-5) — and how to document plus verify every unsafe block for the memory-safety attestation framework. Use when working the memsafety certification worktree, enumerating or justifying an unsafe site, wiring the cargo-geiger ratchet, reasoning about what Miri can and cannot reach, or attesting the Miri/fuzz/oracle coverage matrix. Grounded in sparq's real research/threat-model.md + crates/sparq-core + .github/workflows/miri.yml.
+---
+
+# Unsafe-Rust attestation (sparq)
+
+sparq's headline safety claim is memory safety. This skill is how to *attest* it
+honestly for the `memsafety` certification worktree — the `forbid(unsafe)`
+posture, the concentrated `sparq-core` unsafe surface (threat-model boundary
+**B5**), and the verification estate (Miri + fuzz + the deterministic oracle).
+
+> NON-CANONICAL timing. No measured numbers belong in this file.
+
+## The posture: forbid where you can, concentrate + justify where you can't
+
+- **`#![forbid(unsafe_code)]`** is declared in the large majority of workspace
+  crates (sparq-serve, sparq-reason, sparq-zk, sparq-nlq, sparq-shacl, and most
+  others — `grep -rl "forbid(unsafe_code)" crates/`). `forbid` (not `deny`) means
+  the lint can't even be locally `#[allow]`-ed away — a hard compile error if any
+  `unsafe` is introduced. **This is the strongest attestable claim and it's free.**
+- **`sparq-core` is the *only* crate with `unsafe`.** All memory-safety risk is
+  concentrated there by design, which is what makes attestation tractable: the
+  audit surface is one crate, not the whole tree.
+
+When scoring, the honest statement is: *"N of M crates forbid unsafe; the residual
+unsafe is concentrated in sparq-core's B5 boundary, enumerated and verified
+below."* Verify the live count with grep before quoting it — don't hard-code it.
+
+## The B5 unsafe surface (`research/threat-model.md` §B5)
+
+B5 = **hostile on-disk index file → mmap loader → unsafe code** — an
+*untrusted-input → unsafe-code* boundary, the most dangerous class in the system.
+`grep -rn "unsafe" crates/sparq-core/src` returns ~39 sites across five files:
+
+| File | Nature of the unsafe |
+|---|---|
+| `lib.rs` | `Graph::open` loader: mmap of permutation + dict + numerics/temporals caches; POD↔bytes reinterprets |
+| `dict.rs` | zero-copy dictionary: `MappedDict::stored` (attacker-controlled `u64` offset), `rd_str` → `from_utf8_unchecked` over the mmap'd blob |
+| `store.rs` | `TripleStore::open` raw-perm reinterpret (`from_raw_parts` over mmap bytes) |
+| `dictspill.rs` | `#[cfg(feature = "dict-spill")]` ingest spill: libc `sysconf`/`statvfs` FFI, `from_utf8_unchecked` on own records, parallel scatter `ptr.add().write` |
+| `extsort.rs` | external-sort buffer reinterprets |
+
+**The sharpest edges (track these — they have beads):**
+- **T-MMAP-UB (sq-znld):** `rd_str` calls `from_utf8_unchecked` on the mmap'd blob
+  with **no UTF-8 check** → immediate UB on a hostile/corrupt store. Fix: checked
+  `from_utf8` + bounds-check every offset (`dict-offs.bin` length `== len*8`,
+  every offset `< dict-terms.bin.len()`) at open time.
+- **T-MMAP-DoS (sq-ed2i):** `CompressedPerm::from_mmap` header arithmetic has no
+  overflow guard + unchecked per-block offsets/varints → panic / OOB-read. Fix:
+  `checked_mul`/`checked_add` + bounds-check directory offsets and every varint.
+- **T-MMAP-FUZZ (sq-ky2a):** the loader isn't fuzzed against corrupt/truncated
+  files. Fix: a fuzz target asserting *error-not-UB* under `--features dict-spill`.
+
+The dict-spill unsafe is **NOT** the B5 attack surface (it operates on
+internally-produced spill files, not hostile index files) — say so explicitly so
+the attestation doesn't overstate the threat there.
+
+## The verification estate — what reaches each site
+
+| Verifier | Wired in | Reaches | Does NOT reach |
+|---|---|---|---|
+| **Miri** (UB) | `.github/workflows/miri.yml`, nightly | pure-Rust unsafe with default features (`parallel`): the `par_iter_mut` scatter writes in `dict.rs`, POD↔bytes reinterprets, `from_utf8_unchecked` over in-memory buffers, `MaybeUninit`+`set_len` remap | the ~16 **mmap-backed** sites — Miri rejects file-backed mappings ("Miri does not support file-backed memory mappings"), so `mmap`/`dict-spill` features are **off** in this lane |
+| **mmap_corruption_oracle** (deterministic) | `ci.yml` under `--features mmap,dict-spill` | the mmap B5 sites Miri can't reach | non-determinism (it's a fixed oracle, not a fuzzer) |
+| **fuzz** lane (cargo-fuzz) | `fuzz.yml`, PR smoke + nightly | hostile-input panics/OOM on the loader | UB detection (panics ≠ UB) |
+| **cargo-geiger** | `ci.yml` `geiger` job, **informational** | counts unsafe sites (sparq-core, via `--manifest-path`; can't run the virtual root) | nothing gates on it yet (GX-5) |
+
+**Miri flags (load-bearing — `miri.yml`):** `-Zmiri-tree-borrows` (rayon's
+`crossbeam-epoch` violates Stacked Borrows; Tree Borrows is the correct model and
+still catches real UB in sparq-core), `-Zmiri-ignore-leaks` (rayon daemon threads
+outlive `main`), `-Zmiri-disable-isolation` (incidental clock/temp access). It's
+**nightly-only** (Miri ships only on nightly; pinned by date) with **no PR
+trigger**, so it creates no check-run and the ci-summary gate never waits on it —
+the same "nightly safety net, not a per-PR tax" posture as fuzz/zk-toolchain.
+
+The intended future addition is an **ASan lane** (`-Zsanitizer=address`, non-musl
+target) to reach the mmap sites dynamically — deferred (noted in the sq-fo28 PR).
+
+## The two attestation deliverables for memsafety (GX-5)
+
+GX-5 is the open gap: *the unsafe surface has no per-site justification register,
+and cargo-geiger is informational only (no gating ratchet).* Two things close it:
+
+### 1. The unsafe-justification register
+One document enumerating every `sparq-core` unsafe site with, per site:
+- **Location** (`file.rs:line`) and **operation** (e.g. `from_utf8_unchecked`).
+- **Safety invariant** — the precondition the caller must uphold for soundness.
+- **Why it holds** — or, for the B5 untrusted-input sites, the validation that
+  *must* run first (and the bead if it doesn't yet — sq-znld, sq-ed2i).
+- **Which verifier covers it** — the Miri / oracle / fuzz column from the matrix.
+This is the SSDF/memsafety evidence: every `unsafe` block has a written, reviewed
+justification. Pair each with a `// SAFETY:` comment in source.
+
+### 2. The cargo-geiger ratchet
+Promote the informational geiger job to a **gating unsafe-count ratchet**:
+check a checked-in expected count, fail if the count *increases* without an
+accompanying register update (mirror the coverage/conformance ratchet idiom). A
+PR that adds `unsafe` then can't merge without justifying it.
+
+## How to use this
+
+1. **Cite, don't re-derive.** The posture + verification estate above is live —
+   reference `miri.yml`, the threat-model §B5, the `geiger` job in `ci.yml`.
+2. **Gap-fixes land test-first** (`test-driven-development` skill): a register
+   entry pairs with a `// SAFETY:` comment; the geiger ratchet lands with the
+   checked-in count + a failing-on-increase test.
+3. **Honesty contract.** Don't claim Miri covers the mmap sites (it structurally
+   can't) — attest the *split* coverage (Miri for pure-Rust UB, oracle+fuzz for
+   mmap) honestly. Don't claim "no unsafe" — claim "unsafe concentrated, enumerated,
+   justified, verified". The known UB gaps (sq-znld) are real until fixed — never
+   paper over them in a control table.
+
+## Local commands
+```
+grep -rln "forbid(unsafe_code)" crates/          # the forbid-unsafe crate set
+grep -rn "unsafe" crates/sparq-core/src          # enumerate the B5 surface
+cargo +nightly miri test -p sparq-core           # the UB lane (no mmap features)
+cargo test -p sparq-core --features mmap,dict-spill mmap_corruption_oracle
+cargo geiger --manifest-path crates/sparq-core/Cargo.toml   # unsafe report
+```
+
+<!-- [OPUS-4.8] Authored for bead sq-toze.1 (epic sq-toze, cert framework). Grounded in
+research/threat-model.md §B5, crates/sparq-core/src, .github/workflows/miri.yml + ci.yml geiger.
+Re-review when Fable returns. -->


### PR DESCRIPTION
> 🤖 SPARQ agent

Foundation skills for the certification framework-assessment agents (epic **sq-toze**, bead **sq-toze.1**). Per `research/production-certification-plan.md` §1.

## What's here

**1. Vendored `test-driven-development`** (`.claude/skills/test-driven-development/`)
- `SKILL.md` + `testing-anti-patterns.md`, copied unmodified from `jeswr/prod-solid-server` `.agents/skills/test-driven-development/`.
- **Attribution:** a provenance note at the top of the body records the source. The upstream repo carries **no LICENSE file** at vendor time, so no license text was reproduced; vendored by arrangement with the owner (@jeswr).
- Drives the "gap-fixes land test-first" rule across the technical worktrees (memsafety/sbom/cis/asvs).

**2. NEW `rust-supply-chain-attestation`** (`.claude/skills/rust-supply-chain-attestation/SKILL.md`)
- The cargo-specific evidence recipe: cargo-deny (advisories/bans/licenses/sources), CycloneDX SBOM + VEX, cargo-auditable/cargo-vet, SLSA `attest-build-provenance`, OpenSSF Scorecard — each mapped to the SBOM/SLSA/SSDF/CRA/OpenSSF frameworks.
- Grounded in the **real** setup: `deny.toml` + `.github/workflows/{supply-chain,scorecard,dependency-monitoring,release}.yml`, including the honest gaps (advisories PR-gate degraded by CVSS-4.0 lag — GX-1; no per-release SBOM/VEX — GX-2; SLSA ≈L2-not-L3 — GX-7/8).

**3. NEW `unsafe-rust-attestation`** (`.claude/skills/unsafe-rust-attestation/SKILL.md`)
- The memory-safety attestation recipe: the `forbid(unsafe_code)` posture, the concentrated `sparq-core` B5 surface (mmap/dict-spill/SIMD ~39 sites), the nightly Miri lane (what it reaches vs the mmap sites it structurally can't), cargo-geiger, and the GX-5 deliverables (per-site unsafe-justification register + a geiger gating ratchet).
- Grounded in `research/threat-model.md` §B5 + `crates/sparq-core` + `.github/workflows/miri.yml` + the `ci.yml` geiger job.

## Verification
All three `SKILL.md` pass `python3 scripts/check-skill-frontmatter.py` — valid YAML frontmatter (name + description), 0 broken / 0 warnings.

Refs: bead **sq-toze.1**, epic **sq-toze**.