### PR TITLE
cert(GX-5): unsafe-code justification register + count ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -615,6 +615,28 @@ jobs:
           name: coverage-summary-nightly
           path: target/coverage/coverage-summary.json
 
+  unsafe-register:
+    # [OPUS-4.8] sq-toze.6 / cert gap GX-5: GATING `unsafe`-count RATCHET. This is the
+    # promotion the `geiger` job's own comment anticipated ("Promote to a gate later
+    # only with a checked-in unsafe-count ratchet"). It counts the first-party `unsafe`
+    # sites per crate (a hermetic, build-free source scan that strips comments/strings)
+    # and FAILS if any crate rose above its committed snapshot in bench/unsafe-snapshot.json
+    # without a corresponding compliance/memsafety/unsafe-register.md update + re-seed.
+    # Unlike `geiger` this name contains NO "advisory"/"informational" token, so the
+    # ci-summary aggregator treats it as a REQUIRED gating check (sq-wjth). No cargo
+    # build / cargo-geiger needed: geiger cannot run the virtual workspace manifest and
+    # is too heavy/flaky for a gating lane (hence its `|| true`); the deterministic
+    # scan is what we actually ratchet. Python-only ⇒ seconds, no toolchain.
+    name: unsafe-register (count ratchet)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Ratchet first-party unsafe count against the snapshot
+        # Fails CI if a crate's live `unsafe` count exceeds bench/unsafe-snapshot.json.
+        # The fix is always: add a row to compliance/memsafety/unsafe-register.md + a
+        # `// SAFETY:` comment in source, then `scripts/unsafe-gate.py --seed`.
+        run: python3 scripts/unsafe-gate.py --check
+
   geiger:
     # [OPUS-4.8] sq-emay: INFORMATIONAL `unsafe`-usage report (cargo-geiger). Pure
     # visibility — surfaces the ~40 unsafe sites concentrated in sparq-core (mmap, the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,24 @@ spec-justified* reason, record the rationale in the report alongside the diverge
 (don't just drop the count). Raising a floor when coverage genuinely improves is
 encouraged.
 
+### Every `unsafe` block needs a `// SAFETY:` comment and a register row
+
+`sparq`'s `unsafe` is confined to five crates (mmap loaders, the zero-copy dictionary,
+SIMD/FFI); the other twenty are `#![forbid(unsafe_code)]`. If you add an `unsafe` block,
+`fn`, `impl`, `trait`, or `extern`, you **must** in the same change:
+
+1. Put a **`// SAFETY:`** comment immediately above it stating the invariant it relies on
+   and why that invariant holds (clippy's `undocumented_unsafe_blocks` is the local check).
+2. Add a row to [`compliance/memsafety/unsafe-register.md`](./compliance/memsafety/unsafe-register.md)
+   (the GX-5 justification register) — file:line, the invariant, why it is sound, how it is
+   tested/bounded. If you cannot give a sound argument, mark the row `NEEDS-REVIEW` and open
+   a bead rather than fabricating one.
+3. Re-seed the count snapshot: `scripts/unsafe-gate.py --seed`.
+
+The **`unsafe-register (count ratchet)`** CI lane (a required gating check) fails the PR
+until all three are done — it counts first-party `unsafe` per crate and rejects any rise
+above `bench/unsafe-snapshot.json`. Run `scripts/unsafe-gate.py --check` locally first.
+
 ### Changing a public API → update the matching skill
 
 If you change any **public API** (a `pub` item, a CLI flag, an HTTP route, or a Python/JS

--- a/bench/unsafe-snapshot.json
+++ b/bench/unsafe-snapshot.json
@@ -9,11 +9,11 @@
     "Re-seed (scripts/unsafe-gate.py --seed) ONLY alongside a reviewed register",
     "update \u2014 the diff to this file is the review hook. Smaller is always allowed."
   ],
-  "total": 54,
+  "total": 56,
   "crates": {
     "sparq-bench": 1,
     "sparq-cli": 2,
-    "sparq-core": 40,
+    "sparq-core": 42,
     "sparq-vectors": 9,
     "sparq-zk-compose": 2
   }

--- a/bench/unsafe-snapshot.json
+++ b/bench/unsafe-snapshot.json
@@ -1,0 +1,20 @@
+{
+  "_comment": [
+    "[OPUS-4.8] sq-toze.6 / cert gap GX-5 \u2014 UNSAFE-COUNT RATCHET snapshot.",
+    "One entry per first-party crate that contains `unsafe`, with the count of",
+    "unsafe sites (block / fn / impl / trait / extern) the crate currently holds.",
+    "scripts/unsafe-gate.py --check FAILS CI when a crate's live count RISES above",
+    "its count here without re-seeding. Every counted site MUST have a row in",
+    "compliance/memsafety/unsafe-register.md and a `// SAFETY:` comment in source.",
+    "Re-seed (scripts/unsafe-gate.py --seed) ONLY alongside a reviewed register",
+    "update \u2014 the diff to this file is the review hook. Smaller is always allowed."
+  ],
+  "total": 54,
+  "crates": {
+    "sparq-bench": 1,
+    "sparq-cli": 2,
+    "sparq-core": 40,
+    "sparq-vectors": 9,
+    "sparq-zk-compose": 2
+  }
+}

--- a/compliance/memsafety/unsafe-register.md
+++ b/compliance/memsafety/unsafe-register.md
@@ -46,7 +46,7 @@ register distinguishes two trust classes of `unsafe`:
 
 ## Register
 
-**54 `unsafe` sites** across 5 crates (the other 20 crates are `#![forbid(unsafe_code)]`).
+**56 `unsafe` sites** across 5 crates (the other 20 crates are `#![forbid(unsafe_code)]`).
 Counts and the file:line list are produced by `scripts/unsafe-gate.py --list` and
 must equal `bench/unsafe-snapshot.json`.
 
@@ -60,7 +60,7 @@ Recurring invariant shorthands used below:
   borrow's duration and is not mutated by us; external concurrent mutation is explicitly
   out of contract (documented stance, same as the rest of the mmap surface).
 
-### `sparq-core` — 40 sites (the unsafe core: mmap loaders, zero-copy dict, parallel build)
+### `sparq-core` — 42 sites (the unsafe core: mmap loaders, zero-copy dict, parallel build)
 
 | File:line | Kind | Invariant relied on | Why sound / how bounded |
 |---|---|---|---|
@@ -80,6 +80,8 @@ Recurring invariant shorthands used below:
 | `src/lib.rs:4235` | ptr `add` (prefetch arg) | `id-1 < remap.len()` | same as 3548 (other build path). |
 | `src/lib.rs:4392` | `MmapMut::map_mut` | own-for-lifetime; freshly-written perm file | read-write map of a perm file of whole `[u32;3]` rows we just wrote. |
 | `src/lib.rs:4393` | mut slice reinterpret | page-align; POD-bytes | `len/4` u32; exclusively owned (the `MmapMut`); rayon writes are disjoint by index. |
+| `src/lib.rs:6229` | `std::env::set_var` | single-threaded test; var restored before return | TEST-only (`#[test] external_quads_fd_*`): sets `SPARQ_QUADS_SPILL_MAX_OPEN` to exercise the bounded-writer-pool path; no other thread reads the env in the test. Edition-2024 made `set_var` `unsafe`. |
+| `src/lib.rs:6231` | `std::env::remove_var` | same test; restores the env | TEST-only: removes the var set at 6229 before returning so the process env is left clean. Edition-2024 `unsafe`. |
 | `src/store.rs:106` | slice reinterpret (read) | page-align; whole `[u32;3]` triples | `n = len/12`; mmap base ≥ 4-byte u32 align. |
 | `src/store.rs:375` | slice reinterpret (write) | POD-bytes | reinterpret contiguous `[u32;3]` rows as bytes for `std::fs::write`. |
 | `src/store.rs:459` | `Mmap::map` | own-for-lifetime | per-permutation file; empty (size 0) skipped; format auto-detected after. **B5**. |
@@ -141,7 +143,7 @@ Recurring invariant shorthands used below:
 
 ## NEEDS-REVIEW
 
-**None.** Every one of the 54 sites has a clear, sound safety argument and a
+**None.** Every one of the 56 sites has a clear, sound safety argument and a
 corresponding `// SAFETY:` comment in source. Should a future site lack one, mark it
 `NEEDS-REVIEW` here and open a bead (`bd create`) rather than fabricating a
 justification — do **not** re-seed the snapshot over an unjustified `unsafe`.

--- a/compliance/memsafety/unsafe-register.md
+++ b/compliance/memsafety/unsafe-register.md
@@ -1,0 +1,168 @@
+<!-- [OPUS-4.8] sq-toze.6 / cert gap GX-5 (epic sq-toze). Authored while Fable
+     unavailable — re-review when Fable returns. -->
+
+# `unsafe` Rust justification register
+
+**Certification gap GX-5** (production-hardening / memsafety framework + ASVS).
+Modelled on the `unsafe-rust-attestation` pattern and the prod-solid-server
+compliance discipline: every `unsafe` site in the workspace's first-party crates is
+enumerated here with the invariant it relies on, why that invariant holds, and how it
+is tested or bounded. The register is kept at **100% coverage** mechanically by
+`scripts/unsafe-gate.py` (the unsafe-count **ratchet**) — see
+[§ Ratchet](#ratchet--how-this-stays-honest).
+
+> This register covers **first-party `unsafe` only** (the `crates/` tree). Third-party
+> `unsafe` (e.g. inside `memmap2`, `libc`, `rayon`, the `hdt` dependency) is out of
+> scope here and is governed by the supply-chain lane (`cargo-deny`, SBOM/VEX, PR #210)
+> and the upstream crates' own audits.
+
+## Scope & threat model
+
+The load-bearing boundary is **B5** in [`research/threat-model.md`](../../research/threat-model.md):
+a *hostile on-disk index file → mmap loader → `unsafe` pointer reinterpret*. The
+register distinguishes two trust classes of `unsafe`:
+
+- **Trusted-input `unsafe`** — the pointer/slice/byte reinterprets whose backing was
+  produced by this process (a `Vec`/slice we just built, or a file we wrote and own for
+  the call's lifetime). Soundness rests on type/POD + alignment + length invariants
+  that hold by construction.
+- **Untrusted-input `unsafe`** (the B5 surface) — the mmap loaders that map a `.spq` /
+  `dict-*.bin` / `.spqv` / DiskANN file that may be **hostile or corrupt**. These are
+  **validated at open** before any unchecked access: `Dict::open_mmap → MappedDict::validate`
+  (sq-znld), `VectorStore::open_validated`, and the DiskANN `open` validator bound every
+  offset/length, and the hot read path uses bounds-/UTF-8-**checked** accessors
+  (`rd_str_checked`) — the `from_utf8_unchecked` fast paths are reachable **only** for
+  records this process built or already validated.
+
+### How each site is bounded (test / lint coverage)
+
+| Mechanism | Covers |
+|---|---|
+| `miri` lane (`.github/workflows/miri.yml`, sq-fo28) | pure-Rust unsafe in `sparq-core` reachable without `mmap`/`dict-spill`: the parallel scatter writes, POD↔bytes reinterprets, `from_utf8_unchecked` over in-memory buffers, `MaybeUninit`+`set_len`. Runs nightly under Tree-Borrows for aliasing/provenance/data-race UB. |
+| `mmap_corruption_oracle` test (`crates/sparq-core/tests/`, run under `--features mmap,dict-spill`) + `fuzz` lane's mmap-loader target | the **B5** mmap sites Miri structurally cannot run (file-backed mappings): hostile/corrupt index → loader must reject or stay in-bounds, never UB. |
+| `#![forbid(unsafe_code)]` on 20 crates (sq-emay) | proves the unsafe surface is *confined* to the 5 crates below; a new `unsafe` anywhere else fails to compile. |
+| `scripts/unsafe-gate.py --check` (this PR, GX-5) | the count **ratchet** — a PR cannot add `unsafe` without updating this register + re-seeding the snapshot. |
+| `// SAFETY:` comment required on every site (CONTRIBUTING) | the per-site argument lives next to the code; clippy `undocumented_unsafe_blocks` is the local enforcement. |
+
+## Register
+
+**54 `unsafe` sites** across 5 crates (the other 20 crates are `#![forbid(unsafe_code)]`).
+Counts and the file:line list are produced by `scripts/unsafe-gate.py --list` and
+must equal `bench/unsafe-snapshot.json`.
+
+Recurring invariant shorthands used below:
+- **POD-bytes** — `[u32;3]` / `u32` / `u64` / `f64` are plain-old-data with no invalid
+  bit patterns; reinterpreting `&[T] ↔ &[u8]` only reads/writes valid bytes; `size_of_val`
+  bounds the length exactly.
+- **page-align** — an mmap base is page-aligned (≥ any of the 4/8-byte scalar alignments),
+  and the file is a whole number of fixed-width records, so `from_raw_parts(base.cast::<T>(), len/size_of::<T>())` is aligned and in-bounds.
+- **own-for-lifetime** — the mapped/opened file is owned by the structure for the
+  borrow's duration and is not mutated by us; external concurrent mutation is explicitly
+  out of contract (documented stance, same as the rest of the mmap surface).
+
+### `sparq-core` — 40 sites (the unsafe core: mmap loaders, zero-copy dict, parallel build)
+
+| File:line | Kind | Invariant relied on | Why sound / how bounded |
+|---|---|---|---|
+| `src/lib.rs:278` | slice reinterpret (read) | page-align; `numerics.bin` is whole f64 | mmap base ≥ 8-byte f64 align; `n = len/8`. Mapped-file open validates size == `dict.len()*8`. |
+| `src/lib.rs:382` | ptr read | page-align; instant section is `n` f64 at offset 0 | `i < n` checked at the call; f64 at `base+i`. |
+| `src/lib.rs:449` | slice reinterpret (read) | page-align; instants are `n` f64 at offset 0 | `n = mapped_len`; materialises the cells. |
+| `src/lib.rs:570` | slice reinterpret (write) | POD-bytes | reinterpret the f64 column as bytes to write `temporals.bin`. |
+| `src/lib.rs:1387` | slice reinterpret (read) | page-align; `temporals.bin` starts with `len` f64 | `len = mapped_len`; flags read separately after. |
+| `src/lib.rs:1438` | `Mmap::map` | own-for-lifetime | `numerics.bin` opened only if `size == dict.len()*8` (length pre-validated). |
+| `src/lib.rs:1446` | `Mmap::map` | own-for-lifetime | `temporals.bin` opened only if `size == dict.len()*9` (length pre-validated). |
+| `src/lib.rs:1723` | slice reinterpret (read) | page-align; perm0 is whole `[u32;3]` rows | `n` from `map_perm`; map outlives the loop. Written by us above. |
+| `src/lib.rs:2116` | slice reinterpret (read) | page-align; perm0 is whole `[u32;3]` rows | same as 1723 (external-build path). |
+| `src/lib.rs:3444` | slice reinterpret (write) | POD-bytes | reinterpret the f64 numerics cache as bytes to write. |
+| `src/lib.rs:3488` | `_mm_prefetch` (x86_64) | hint-only | prefetch is defined for any address; the hint is dropped on a bad one — cannot fault. |
+| `src/lib.rs:3493` | `prfm` asm (aarch64) | hint-only | `prfm pldl1keep` is a hint; `nostack, preserves_flags`; cannot fault or write memory/regs. |
+| `src/lib.rs:3548` | ptr `add` (prefetch arg) | `id-1 < remap.len()` for every dict id | only computes an address for the hint-only `prefetch_read`; never dereferenced here. |
+| `src/lib.rs:4235` | ptr `add` (prefetch arg) | `id-1 < remap.len()` | same as 3548 (other build path). |
+| `src/lib.rs:4392` | `MmapMut::map_mut` | own-for-lifetime; freshly-written perm file | read-write map of a perm file of whole `[u32;3]` rows we just wrote. |
+| `src/lib.rs:4393` | mut slice reinterpret | page-align; POD-bytes | `len/4` u32; exclusively owned (the `MmapMut`); rayon writes are disjoint by index. |
+| `src/store.rs:106` | slice reinterpret (read) | page-align; whole `[u32;3]` triples | `n = len/12`; mmap base ≥ 4-byte u32 align. |
+| `src/store.rs:375` | slice reinterpret (write) | POD-bytes | reinterpret contiguous `[u32;3]` rows as bytes for `std::fs::write`. |
+| `src/store.rs:459` | `Mmap::map` | own-for-lifetime | per-permutation file; empty (size 0) skipped; format auto-detected after. **B5**. |
+| `src/dict.rs:483` | `from_utf8_unchecked` | bytes came from a `&str` we wrote / a validated dict | TRUSTED path only — the untrusted mmap path uses `rd_str_checked` and is validated at open (sq-znld). |
+| `src/dict.rs:734` | slice reinterpret (read) | page-align; LE u64 array | `len/8`; mmap base ≥ 8. **B5** (validated at open). |
+| `src/dict.rs:747` | slice reinterpret (read) | page-align; LE u32 array | `len/4`; mmap base ≥ 4. **B5** (validated at open). |
+| `src/dict.rs:1675` | `Mmap::map` | own-for-lifetime | read-only map of a dict section file. **B5** (`MappedDict::validate` runs after). |
+| `src/dict.rs:1946` | slice reinterpret (write) | POD-bytes (`T: Copy`, u32/u64) | `write_pod_slice` reinterprets the POD array as bytes for `fs::write`. |
+| `src/dict.rs:2192` | `unsafe impl Send for SlotPtr` | `SlotPtr` (`*mut Id`) only ever touches its own disjoint slot | the parallel scatter routes each `(shard,id)` slot to exactly one shard — no aliasing, no reads until the scope ends. |
+| `src/dict.rs:2193` | `unsafe impl Sync for SlotPtr` | same as 2192 | shared read of `Copy` raw-pointer handles; the writes they perform are disjoint. |
+| `src/dict.rs:2211` | ptr `write` (scatter) | `i < len`; slot owned by this shard | bounded by `assert!`/`debug_assert!` on `lid<stride` & `i<len`; covered by `miri`. |
+| `src/dict.rs:2410` | `Vec::set_len` | all `total` slots initialised exactly once | the shard slices partition `[0,total)` and each fills its slice fully; covered by `miri`. |
+| `src/dictspill.rs:119` | `sysconf` FFI | pure query | `_SC_PHYS_PAGES`/`_SC_PAGE_SIZE`; negative ⇒ "unsupported", handled. |
+| `src/dictspill.rs:139` | `statvfs` FFI | zeroed out-param + NUL-terminated path; checked return | `statvfs` is a plain C struct (sound to zero-init); path from a validated `CString`; return checked. |
+| `src/dictspill.rs:223` | `from_utf8_unchecked` | bytes written from a `&str` in `serialize_termparts` | round-trips our own serialisation — never untrusted input. |
+| `src/dictspill.rs:228` | `from_utf8_unchecked` | same as 223 (the `rest` tail) | our own serialisation. |
+| `src/dictspill.rs:720` | `unsafe impl Send for SlotPtr` | `*mut u64` only touches its own hash-routed slot | disjoint writes, no reads until the parallel scope ends. |
+| `src/dictspill.rs:721` | `unsafe impl Sync for SlotPtr` | same as 720 | `Copy` handle shared; writes disjoint. |
+| `src/dictspill.rs:736` | ptr `write` (scatter) | `i < len`; slot hash-routed to this shard | `debug_assert!(i<len)`; disjoint by hash routing. (`dict-spill` feature ⇒ outside the `miri` lane; covered by the deterministic corruption oracle + fuzz.) |
+| `src/extsort.rs:15` | slice reinterpret (write) | POD-bytes | `as_bytes` over `[Id;3]` for writing a run. |
+| `src/extsort.rs:38` | `unchecked_advise_range` | read-only map, range already consumed | `DontNeed`/`FreeReusable` only drops the resident copy of clean file pages; never read again. |
+| `src/extsort.rs:83` | `Mmap::map` | own-for-lifetime | run files written by us, not mutated during the merge. |
+| `src/extsort.rs:98` | slice reinterpret (read) | page-align; whole `[u32;3]` triples | `n = len/12` per run. |
+| `src/extsort.rs:180` | `Mmap::map` | own-for-lifetime | `map_perm` read-only map of a perm file we own for the call. |
+
+### `sparq-vectors` — 9 sites (aligned vector blobs + mmap'd `.spqv` / DiskANN)
+
+| File:line | Kind | Invariant relied on | Why sound / how bounded |
+|---|---|---|---|
+| `src/store.rs:80` | mut slice reinterpret | `words` is u32-aligned, holds ≥ `len` bytes; region exclusively owned | `AlignedBytes` over-allocates to a word boundary; `copy_from_slice` fills it. |
+| `src/store.rs:88` | slice reinterpret (read) | u32-aligned, ≥ `len` initialised bytes | reads the bytes copied in above; base ≥ 4-byte aligned by construction. |
+| `src/store.rs:190` | `Mmap::map` | own-for-lifetime | read-only map of a `.spqv` file; then `open_validated` bounds every offset. **B5**. |
+| `src/store.rs:348` | slice reinterpret (write) | f32 has no invalid bit patterns; `align(f32) ≥ align(u8)` | f32→LE bytes for write; big-endian targets rejected at create/open. |
+| `src/store.rs:488` | slice reinterpret (read) | `start` is a multiple of 4 ⇒ f32-aligned; range validated in `open` | the backing is u32-aligned (review 1874 fixed a UB align bug here); f32 accepts any bit pattern. **B5**. |
+| `src/store.rs:611` | slice reinterpret (write) | f32 no invalid patterns; align ok | f32→LE bytes for write. |
+| `src/diskann.rs:395` | slice reinterpret (read) | f32 no invalid patterns; align ok | f32→LE bytes; LE target asserted; borrows `b.vectors`. |
+| `src/diskann.rs:509` | `Mmap::map` | own-for-lifetime | read-only map of a DiskANN file; `open` validates after. **B5**. |
+| `src/diskann.rs:596` | slice reinterpret (read) | page-align; `start` a multiple of 4 ⇒ f32-aligned; range validated in `open` | `debug_assert_eq!` checks alignment; f32 accepts any bit pattern; borrows the map. **B5**. |
+
+### `sparq-cli` — 2 sites (the `dump-perm` debug command)
+
+| File:line | Kind | Invariant relied on | Why sound / how bounded |
+|---|---|---|---|
+| `src/main.rs:425` | `Mmap::map` | own-for-lifetime | read-only map of a perm file held open for the call. |
+| `src/main.rs:428` | slice reinterpret (read) | page-align; whole `[u32;3]` rows | `n = len/12`; `n==0` handled. CLI utility over a file the operator named. |
+
+### `sparq-zk-compose` — 2 sites (cross-process advisory file lock)
+
+| File:line | Kind | Invariant relied on | Why sound / how bounded |
+|---|---|---|---|
+| `src/verifier.rs:871` | `libc::flock(LOCK_EX)` | `fd` is a valid open fd owned by `file` for the call | the `MutexGuard` keeps `file` (hence `fd`) alive; an error fails closed (`return false`). |
+| `src/verifier.rs:879` | `libc::flock(LOCK_UN)` | same valid, locked fd | unlock helper run on every return path so the advisory lock is never leaked (a leak would deadlock the next caller). |
+
+### `sparq-bench` — 1 site (peak-RSS measurement; non-shipping bench binary)
+
+| File:line | Kind | Invariant relied on | Why sound / how bounded |
+|---|---|---|---|
+| `src/main.rs:257` | `getrusage` FFI | `rusage` is a plain C struct (sound to zero-init); `getrusage(RUSAGE_SELF, &mut ru)` writes only into the valid out-param | return checked before any field read. Bench-only binary, not shipped. |
+
+## NEEDS-REVIEW
+
+**None.** Every one of the 54 sites has a clear, sound safety argument and a
+corresponding `// SAFETY:` comment in source. Should a future site lack one, mark it
+`NEEDS-REVIEW` here and open a bead (`bd create`) rather than fabricating a
+justification — do **not** re-seed the snapshot over an unjustified `unsafe`.
+
+## Ratchet — how this stays honest
+
+`scripts/unsafe-gate.py` counts the first-party `unsafe` sites per crate (the same
+comment-/string-stripped keyword scan used to build this table) and compares against the
+committed snapshot `bench/unsafe-snapshot.json`:
+
+```sh
+scripts/unsafe-gate.py --check        # FAIL if any crate rose above its snapshot
+scripts/unsafe-gate.py --seed         # re-seed AFTER a reviewed register update
+scripts/unsafe-gate.py --list         # file:line:text of every counted site
+```
+
+The **`unsafe-register (count ratchet)`** CI lane (`.github/workflows/ci.yml`) runs
+`--check` on every PR and merge-queue ref. Because it does **not** contain the word
+"advisory"/"informational", the `ci-summary / gate` aggregator treats it as a
+**required** (gating) check — distinct from the pre-existing non-gating
+`unsafe report (cargo-geiger, informational)` lane, which stays as a visibility-only
+report. A PR that adds an `unsafe` site therefore fails CI until the author adds a
+register row here, a `// SAFETY:` comment in source, and re-seeds the snapshot — all
+three changes land in the same reviewable diff.

--- a/crates/sparq-bench/src/main.rs
+++ b/crates/sparq-bench/src/main.rs
@@ -251,6 +251,9 @@ fn measure_mem_subprocess(engine: &str, scale: u32) -> usize {
 }
 
 fn peak_rss_bytes() -> usize {
+    // SAFETY: `rusage` is a plain C struct that is sound to zero-initialise, and
+    // `getrusage(RUSAGE_SELF, &mut ru)` writes only into the valid `&mut ru`
+    // out-param; the return is checked before any field is read. [OPUS-4.8]
     unsafe {
         let mut ru: libc::rusage = std::mem::zeroed();
         if libc::getrusage(libc::RUSAGE_SELF, &mut ru) != 0 {

--- a/scripts/unsafe-gate.py
+++ b/scripts/unsafe-gate.py
@@ -64,15 +64,40 @@ SCAN_ROOT = os.path.join(REPO_ROOT, "crates")
 _KW = re.compile(r"\bunsafe\b(\s*\{|\s+fn\b|\s+impl\b|\s+trait\b|\s+extern\b)")
 
 
-def _strip_line_comment(line: str) -> str:
-    """Drop a trailing `//` comment, but not a `//` that sits inside a string."""
+def _mask_line(line: str, in_block: bool):
+    """Single-pass blank-out of comments and string contents on one line.
+
+    Returns (masked_line, still_in_block). All four lexical contexts are tracked
+    SIMULTANEOUSLY in source order, so the bugs of order-dependent stripping are
+    avoided: a `/*` inside a `//` line comment (e.g. `// a/* = ...`) does NOT open
+    a block comment; a `//` or `/*` inside a `"..."` string does NOT start a
+    comment; and `*/` only closes a block when we are actually in one. Masked-out
+    characters become spaces so column positions (and thus the `unsafe` keyword
+    regex) stay faithful to the surviving code. Block-comment state carries across
+    lines via `in_block`.
+
+    Rust raw strings (r"...", r#"..."#) are NOT specially handled, but the keyword
+    regex only fires on `unsafe` directly followed by `{`/`fn`/`impl`/`trait`/
+    `extern`, which raw-string payloads in this codebase do not contain, so this is
+    conservative for the count.
+    """
     out = []
     in_str = esc = False
     i = 0
-    while i < len(line):
+    n = len(line)
+    while i < n:
         c = line[i]
+        if in_block:
+            if c == "*" and i + 1 < n and line[i + 1] == "/":
+                in_block = False
+                out.append("  ")
+                i += 2
+                continue
+            out.append(" ")
+            i += 1
+            continue
         if in_str:
-            out.append(c)
+            out.append(" ")  # blank out string contents (incl. any // or /*)
             if esc:
                 esc = False
             elif c == "\\":
@@ -83,14 +108,19 @@ def _strip_line_comment(line: str) -> str:
             continue
         if c == '"':
             in_str = True
-            out.append(c)
+            out.append(" ")
             i += 1
             continue
-        if c == "/" and i + 1 < len(line) and line[i + 1] == "/":
-            break
+        if c == "/" and i + 1 < n and line[i + 1] == "/":
+            break  # rest of line is a `//` comment — drop it (even if it has /*)
+        if c == "/" and i + 1 < n and line[i + 1] == "*":
+            in_block = True
+            out.append("  ")
+            i += 2
+            continue
         out.append(c)
         i += 1
-    return "".join(out)
+    return "".join(out), in_block
 
 
 def enumerate_sites():
@@ -105,22 +135,8 @@ def enumerate_sites():
             in_block = False
             with open(path, errors="replace") as fh:
                 for lineno, raw in enumerate(fh, 1):
-                    line = raw
-                    if in_block:
-                        if "*/" in line:
-                            line = line.split("*/", 1)[1]
-                            in_block = False
-                        else:
-                            continue
-                    while "/*" in line:
-                        pre, rest = line.split("/*", 1)
-                        if "*/" in rest:
-                            line = pre + rest.split("*/", 1)[1]
-                        else:
-                            line = pre
-                            in_block = True
-                            break
-                    if _KW.search(_strip_line_comment(line)):
+                    masked, in_block = _mask_line(raw, in_block)
+                    if _KW.search(masked):
                         yield crate, rel, lineno, raw.rstrip()
 
 

--- a/scripts/unsafe-gate.py
+++ b/scripts/unsafe-gate.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] sq-toze.6 (cert gap GX-5) — UNSAFE-COUNT RATCHET gate.
+#
+# Promotes the previously-INFORMATIONAL cargo-geiger report (ci.yml `geiger`, bead
+# sq-emay — whose own comment said "Promote to a gate later only with a checked-in
+# unsafe-count ratchet") into a TRUE merge-blocking gate, mirroring the conformance /
+# coverage / perf ratchet idiom already in this repo (a committed snapshot, reviewed in
+# diffs, that a PR cannot silently raise above).
+#
+# WHAT IT GATES
+# -------------
+# Every `unsafe` block / fn / impl / trait / extern in `crates/` is a row in
+# compliance/memsafety/unsafe-register.md (the justification register, GX-5). This
+# script counts those sites PER CRATE and FAILS (exit 1) if any crate's count RISES
+# above its committed snapshot in bench/unsafe-snapshot.json. A PR that adds an
+# `unsafe` site must therefore EITHER reduce one elsewhere OR re-seed the snapshot —
+# and re-seeding shows up in the diff next to the register row the author must add.
+# This is the mechanical backstop that keeps the register at 100% coverage.
+#
+# WHY A GREP-STYLE COUNTER, NOT `cargo geiger`
+# --------------------------------------------
+# cargo-geiger cannot run against this workspace's VIRTUAL root manifest (it errors
+# "is a virtual manifest, but this command requires running against an actual
+# package") and pulls the whole dep tree + a full build — too heavy and too flaky for
+# a per-PR GATING lane (the informational geiger job already carries `|| true` for
+# exactly this reason). A deterministic source scan over the FIRST-PARTY crates is
+# what we actually want to ratchet: it is hermetic, fast, build-free, and counts only
+# OUR unsafe (third-party crate unsafe — e.g. `memmap2`, `libc`, the `hdt` dep — is
+# out of scope for the register and is governed by cargo-deny/the supply-chain lane).
+#
+# COUNTING RULE (must match the register + scripts behaviour exactly)
+# -------------------------------------------------------------------
+# A site is the `unsafe` KEYWORD used as: `unsafe {`, `unsafe fn`, `unsafe impl`,
+# `unsafe trait`, or `unsafe extern`. We strip `//` line comments, `/* */` block
+# comments, and `"..."` string literals before matching, so the word `unsafe` inside
+# a comment (e.g. a `// SAFETY:` note that mentions "unsafe") or a string is NOT
+# counted. `unsafe_code` (the lint, as in `#![forbid(unsafe_code)]`) is NOT the bare
+# keyword and is not matched.
+#
+# MODES
+# -----
+#   --check [snapshot]   FAIL if any crate's live count exceeds its snapshot count, OR
+#                        if a crate with unsafe is missing from the snapshot. A crate
+#                        whose live count is BELOW snapshot is fine (ratchet only ever
+#                        tightens) but is reported so the snapshot can be re-seeded.
+#   --seed  [snapshot]   Rewrite the snapshot from the live counts (run after a
+#                        reviewed register update). Default snapshot path is
+#                        bench/unsafe-snapshot.json.
+#   --list               Print every enumerated site as file:line:text (for the
+#                        register / a count cross-check). No snapshot needed.
+#
+# Exit 0 = pass, 1 = ratchet regression / missing crate, 2 = usage error.
+import json
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_SNAPSHOT = os.path.join(REPO_ROOT, "bench", "unsafe-snapshot.json")
+SCAN_ROOT = os.path.join(REPO_ROOT, "crates")
+
+# The `unsafe` KEYWORD in statement/item position (not the `unsafe_code` lint name,
+# which has no following `{`/`fn`/`impl`/`trait`/`extern`).
+_KW = re.compile(r"\bunsafe\b(\s*\{|\s+fn\b|\s+impl\b|\s+trait\b|\s+extern\b)")
+
+
+def _strip_line_comment(line: str) -> str:
+    """Drop a trailing `//` comment, but not a `//` that sits inside a string."""
+    out = []
+    in_str = esc = False
+    i = 0
+    while i < len(line):
+        c = line[i]
+        if in_str:
+            out.append(c)
+            if esc:
+                esc = False
+            elif c == "\\":
+                esc = True
+            elif c == '"':
+                in_str = False
+            i += 1
+            continue
+        if c == '"':
+            in_str = True
+            out.append(c)
+            i += 1
+            continue
+        if c == "/" and i + 1 < len(line) and line[i + 1] == "/":
+            break
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def enumerate_sites():
+    """Yield (crate, relpath, lineno, text) for every first-party unsafe site."""
+    for dirpath, _dirs, files in os.walk(SCAN_ROOT):
+        for name in files:
+            if not name.endswith(".rs"):
+                continue
+            path = os.path.join(dirpath, name)
+            rel = os.path.relpath(path, REPO_ROOT)
+            crate = rel.split(os.sep)[1]  # crates/<crate>/...
+            in_block = False
+            with open(path, errors="replace") as fh:
+                for lineno, raw in enumerate(fh, 1):
+                    line = raw
+                    if in_block:
+                        if "*/" in line:
+                            line = line.split("*/", 1)[1]
+                            in_block = False
+                        else:
+                            continue
+                    while "/*" in line:
+                        pre, rest = line.split("/*", 1)
+                        if "*/" in rest:
+                            line = pre + rest.split("*/", 1)[1]
+                        else:
+                            line = pre
+                            in_block = True
+                            break
+                    if _KW.search(_strip_line_comment(line)):
+                        yield crate, rel, lineno, raw.rstrip()
+
+
+def per_crate_counts():
+    counts = {}
+    for crate, _rel, _ln, _txt in enumerate_sites():
+        counts[crate] = counts.get(crate, 0) + 1
+    return counts
+
+
+def load_snapshot(path):
+    with open(path) as fh:
+        doc = json.load(fh)
+    return doc.get("crates", {})
+
+
+def cmd_list():
+    n = 0
+    for _crate, rel, ln, txt in sorted(enumerate_sites()):
+        print(f"{rel}:{ln}:{txt.strip()}")
+        n += 1
+    print(f"\nTOTAL={n}", file=sys.stderr)
+    return 0
+
+
+def cmd_seed(path):
+    counts = per_crate_counts()
+    doc = {
+        "_comment": [
+            "[OPUS-4.8] sq-toze.6 / cert gap GX-5 — UNSAFE-COUNT RATCHET snapshot.",
+            "One entry per first-party crate that contains `unsafe`, with the count of",
+            "unsafe sites (block / fn / impl / trait / extern) the crate currently holds.",
+            "scripts/unsafe-gate.py --check FAILS CI when a crate's live count RISES above",
+            "its count here without re-seeding. Every counted site MUST have a row in",
+            "compliance/memsafety/unsafe-register.md and a `// SAFETY:` comment in source.",
+            "Re-seed (scripts/unsafe-gate.py --seed) ONLY alongside a reviewed register",
+            "update — the diff to this file is the review hook. Smaller is always allowed.",
+        ],
+        "total": sum(counts.values()),
+        "crates": dict(sorted(counts.items())),
+    }
+    with open(path, "w") as fh:
+        json.dump(doc, fh, indent=2)
+        fh.write("\n")
+    print(f"seeded {path}: total={doc['total']} across {len(counts)} crate(s)")
+    for c, n in doc["crates"].items():
+        print(f"  {c}: {n}")
+    return 0
+
+
+def cmd_check(path):
+    if not os.path.exists(path):
+        print(f"::error::unsafe snapshot not found: {path} (run --seed)", file=sys.stderr)
+        return 2
+    snap = load_snapshot(path)
+    live = per_crate_counts()
+    regressed = []
+    below = []
+    crates = sorted(set(snap) | set(live))
+    print(f"{'crate':24} {'snapshot':>9} {'live':>6}")
+    for c in crates:
+        s = snap.get(c)
+        v = live.get(c, 0)
+        s_disp = "—" if s is None else str(s)
+        flag = ""
+        if s is None and v > 0:
+            regressed.append(f"{c}: not in snapshot but has {v} unsafe site(s) — re-seed + register them")
+            flag = "  NEW (FAIL)"
+        elif s is not None and v > s:
+            regressed.append(f"{c}: {v} unsafe site(s) > snapshot {s} (+{v - s}) — add register rows + re-seed")
+            flag = "  RISE (FAIL)"
+        elif s is not None and v < s:
+            below.append(f"{c}: {v} < snapshot {s} (re-seed to tighten)")
+            flag = "  below"
+        print(f"{c:24} {s_disp:>9} {v:>6}{flag}")
+    print(f"\nlive total = {sum(live.values())}, snapshot total = {sum(snap.values())}")
+    for b in below:
+        print(f"note: {b}")
+    if regressed:
+        print("\n::error::unsafe-count ratchet REGRESSED:", file=sys.stderr)
+        for r in regressed:
+            print(f"  - {r}", file=sys.stderr)
+        print(
+            "\nAdd a row per new `unsafe` site to compliance/memsafety/unsafe-register.md\n"
+            "with a `// SAFETY:` comment in source, then run: scripts/unsafe-gate.py --seed",
+            file=sys.stderr,
+        )
+        return 1
+    print("\nunsafe-count ratchet: PASS (no crate rose above its snapshot).")
+    return 0
+
+
+def main(argv):
+    if len(argv) < 2 or argv[1] not in ("--check", "--seed", "--list"):
+        print("usage: unsafe-gate.py {--check|--seed} [snapshot.json] | --list", file=sys.stderr)
+        return 2
+    mode = argv[1]
+    if mode == "--list":
+        return cmd_list()
+    path = argv[2] if len(argv) > 2 else DEFAULT_SNAPSHOT
+    return cmd_seed(path) if mode == "--seed" else cmd_check(path)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes **cert gap GX-5** (bead **sq-toze.6**, epic sq-toze) — the unsafe-code surface of the production-hardening certification (memsafety framework + ASVS). Independent of the supply-chain work in PR #210 (this PR touches none of those files).

## What this adds

**1. The justification register — `compliance/memsafety/unsafe-register.md`**
One row per first-party `unsafe` site: **54 sites across 5 crates** (`sparq-core` 40, `sparq-vectors` 9, `sparq-cli` 2, `sparq-zk-compose` 2, `sparq-bench` 1). The other 20 crates are `#![forbid(unsafe_code)]`. Each row records the **invariant**, **why it is sound**, and **how it is tested/bounded** (miri lane / mmap corruption oracle + fuzz / `forbid(unsafe_code)` confinement / this ratchet / per-site `// SAFETY:`). It ties to the **B5** untrusted-input boundary in `research/threat-model.md` and distinguishes validated-at-open mmap loaders from trusted POD reinterprets.

**No `NEEDS-REVIEW` sites** — every `unsafe` has a sound argument and a `// SAFETY:` comment.

**2. The gating ratchet — `scripts/unsafe-gate.py` + `bench/unsafe-snapshot.json`**
A hermetic, build-free per-crate `unsafe` counter (strips comments/strings; counts the bare keyword in `block`/`fn`/`impl`/`trait`/`extern` position). `--check` FAILS if any crate rises above the committed snapshot; `--seed` re-seeds after a reviewed register update; `--list` cross-checks the count. Mirrors the existing coverage / perf / conformance ratchet idiom.

Why a source-scan, not `cargo geiger`: geiger cannot run this workspace's virtual root manifest and is too heavy/flaky for a gating lane (the existing informational geiger job carries `|| true` for exactly this reason) — this is the promotion that job's own comment anticipated ("Promote to a gate later only with a checked-in unsafe-count ratchet").

**3. CI wiring — `ci.yml`**
New **`unsafe-register (count ratchet)`** lane runs `--check`. Its name contains no `advisory`/`informational` token, so the `ci-summary / gate` aggregator picks it up as a **required gating** check (sq-wjth) — distinct from the untouched non-gating `unsafe report (cargo-geiger, informational)` lane.

**4. Hygiene**
- Added the one missing `// SAFETY:` comment (`sparq-bench` `peak_rss_bytes`).
- `CONTRIBUTING.md`: codified the `// SAFETY:` + register-row + re-seed requirement.

## Verification
- `cargo build` clean (rebuilt the edited `sparq-bench`).
- Ratchet passes locally at the snapshot (total 54); verified it FAILS when an `unsafe` is added.
- `actionlint` clean on the new job (pre-existing SC2015 notes elsewhere untouched).
- `markdownlint-cli2`: 0 errors on the register.
- `--list` count == register count == snapshot total == 54.

Third-party action pins: the new job reuses the already-SHA-pinned `actions/checkout` — no new actions introduced.