### PR TITLE
feat(flow-on): merge-triggered auto-task-creation engine (sq-ncvq)

### DIFF
--- a/.github/workflows/flow-on.yml
+++ b/.github/workflows/flow-on.yml
@@ -1,0 +1,41 @@
+# [OPUS-4.8] Merge-triggered flow-on engine (bead sq-ncvq.3, epic sq-ncvq).
+# Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# On every MERGED pull request, evaluate scripts/flow-on-rules.toml against the
+# PR's changed files / labels / title and open a GitHub issue (labelled
+# `flow-on` + `auto`, idempotent) for each triggered follow-on. The orchestrator
+# reconciles those issues into beads — we do NOT touch `bd` / `.beads/` in CI.
+#
+# This is NOT a gate: it never blocks a merge (it runs AFTER merge) and the job
+# name carries no `advisory`/`informational` token so it stays visible. It only
+# mints follow-on issues.
+name: flow-on
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: flow-on-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  flow-on:
+    name: flow-on
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Run flow-on engine
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/flow-on.py --pr "${{ github.event.pull_request.number }}"

--- a/scripts/flow-on-rules.toml
+++ b/scripts/flow-on-rules.toml
@@ -1,0 +1,181 @@
+# [OPUS-4.8] Flow-on rule table (bead sq-ncvq.1, epic sq-ncvq). Authored by
+# Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# This is the REACTIVE half of the maintenance flow-on engine
+# (research/maintenance-flow-on-automation-design.md §2.2 / §3). It captures the
+# *un-gateable* follow-on work — the maintenance that cannot be enforced as a
+# merge gate because the artifact is produced out-of-band (a dashboard row, a
+# competitor gather, a cert plan) or because it is judgment/research work.
+#
+# Each rule fires on a MERGED PR. scripts/flow-on.py reads the merged PR's
+# changed-file list + labels + title, evaluates every rule, and for each match
+# opens ONE GitHub issue (labelled `flow-on` + `auto`) per `create` template.
+# The orchestrator later reconciles those issues into beads (`bd create`) — we do
+# NOT touch `bd`/`.beads/` from CI because the dolt DB lives only in the
+# orchestrator's checkout and is gitignored.
+#
+# Idempotency: every `create` template has a `dedup_key`. flow-on.py searches for
+# an OPEN issue carrying a hidden marker `<!-- flow-on-key: <expanded-key> -->`;
+# if one exists the create is skipped. So re-running the workflow (or re-merging)
+# never duplicates a follow-on.
+#
+# ---------------------------------------------------------------------------
+# Rule schema
+# ---------------------------------------------------------------------------
+#   [[rule]]
+#   id          = "stable-slug"            # required; used in issue body for audit
+#   description = "what this rule is for"  # optional human note
+#
+#   # Trigger predicates (a rule fires when ALL present predicates pass; an
+#   # absent predicate is ignored). At least one must be present.
+#   when_paths      = ["glob", ...]   # fnmatch-style globs over changed files (ANY match)
+#   when_new_paths  = ["glob", ...]   # like when_paths but only counts ADDED files (status "A")
+#   when_label      = "label"          # PR must carry this label (opt-in rules)
+#   when_title      = "regex"          # case-insensitive regex over the PR title
+#
+#   # One or more follow-on issue templates. Placeholders expanded from the match:
+#   #   {pr}        merged PR number
+#   #   {pr_title}  merged PR title
+#   #   {crate}     crate dir name, when a crates/<crate>/... path matched
+#   #   {suite}     bench suite dir name, when a bench/<suite>/... path matched
+#   #   {surface}   skill surface dir name, when a skills/<surface>/... path matched
+#   [[rule.create]]
+#   dedup_key = "kind-{crate}"            # required; expanded, then used as the idempotency key
+#   title     = "..."                      # required; issue title (placeholders expanded)
+#   body      = "..."                       # required; issue body (placeholders expanded)
+#   labels    = ["extra", "labels"]         # optional; `flow-on` + `auto` are ALWAYS added
+# ---------------------------------------------------------------------------
+
+# --- New crate / public surface → benchmark + README + SKILL.md ----------------
+# Trigger: a brand-new `crates/<x>/Cargo.toml` is ADDED. A new crate must ship a
+# registered benchmark and (if it is a public surface) a SKILL.md. The gateable
+# subset (README template) is handled by check-readme-template.py; this flow-on
+# captures the out-of-band bench registration + SKILL authoring.
+[[rule]]
+id = "new-crate-bench-and-skill"
+description = "A new crate landed; ensure it has a registered benchmark and (if public) a SKILL.md."
+when_new_paths = ["crates/*/Cargo.toml"]
+
+[[rule.create]]
+dedup_key = "new-crate-bench-{crate}"
+title = "bench: register a benchmark for new crate {crate}"
+labels = ["bench"]
+body = """
+Merged PR #{pr} ({pr_title}) added a new crate `crates/{crate}`.
+
+Per the maintenance flow-on rules, a new crate must have a registered benchmark
+so it is visible to CATALOG / CI / the dashboard. Add a `[[benchmark]]` entry in
+`bench/benchmarks.toml` (with `source = crates/{crate}`), or — if the crate is an
+intentional stub — mark it `publish = false` and record an exemption bead.
+"""
+
+[[rule.create]]
+dedup_key = "new-crate-skill-{crate}"
+title = "docs: add a SKILL.md surface for new crate {crate}"
+labels = ["docs", "cert"]
+body = """
+Merged PR #{pr} ({pr_title}) added a new crate `crates/{crate}`.
+
+If `crates/{crate}` exposes a public surface (CLI / HTTP route / Py·JS binding /
+public Rust API), it needs a `skills/<surface>/SKILL.md` and a conformance/cert
+plan (cf. the sparq-shacl crate-local W3C ratchet). If it is internal-only,
+record that decision explicitly so the gap is not re-flagged.
+"""
+
+# --- Changed public feature → docs / SKILL.md update ---------------------------
+# Trigger: a change under a published crate's surface, the CLI, the HTTP server,
+# or the Py/WASM bindings, WITHOUT a corresponding SKILL.md edit. (flow-on.py only
+# fires this when no skills/** file is in the same diff — see SKILL_PATHS in
+# flow-on.py.) Keeps the AGENTS.md public-API→SKILL.md norm from silently drifting.
+[[rule]]
+id = "changed-public-feature-docs"
+description = "A public surface changed without a SKILL.md update in the same PR."
+when_paths = [
+  "crates/sparq-cli/src/**",
+  "crates/sparq-server/src/**",
+  "crates/sparq-py/src/**",
+  "crates/sparq-wasm/src/**",
+]
+
+[[rule.create]]
+dedup_key = "skill-sync-pr-{pr}"
+title = "docs: sync SKILL.md after public-surface change in PR #{pr}"
+labels = ["docs"]
+body = """
+Merged PR #{pr} ({pr_title}) changed a public surface (CLI / HTTP / Py / WASM)
+but did not touch any `skills/**/SKILL.md` in the same diff.
+
+Per the AGENTS.md public-API → SKILL.md rule, update the matching
+`skills/<surface>/SKILL.md` (and crate README / `llms.txt` if relevant) so the
+docs match the shipped surface. If no doc change is warranted, note why and close.
+"""
+
+# --- New bench suite → dashboard row -------------------------------------------
+# Trigger: a brand-new `bench/<suite>/` directory (detected via an added
+# benchmarks.toml or run.sh under it). A capability suite should get a
+# FEATURED_SUITES row in the dashboard (produced out-of-band, so un-gateable).
+[[rule]]
+id = "new-bench-dashboard-row"
+description = "A new bench suite landed; add a dashboard FEATURED_SUITES row (or flag it unfeatured)."
+when_new_paths = ["bench/*/benchmarks.toml", "bench/*/run.sh"]
+
+[[rule.create]]
+dedup_key = "dashboard-row-{suite}"
+title = "dashboard: add a FEATURED_SUITES row for bench suite {suite}"
+labels = ["docs", "dashboard"]
+body = """
+Merged PR #{pr} ({pr_title}) added a new bench suite `bench/{suite}`.
+
+Add a `FEATURED_SUITES` entry for it in `bench/dashboard/dashboard.js` (with the
+correct `key`/`title`/`aliases`) so its metrics surface on the dashboard, or flag
+it `featured = false` in its `benchmarks.toml` entry if it is intentionally
+unfeatured (e.g. a research spike).
+"""
+
+# --- Competitor-relevant engine change → gather follow-up ----------------------
+# Opt-in via the `competitor-relevant` label (the author marks engine/store work
+# that moves us against a competitor). Triggers an out-of-band gather refresh.
+[[rule]]
+id = "competitor-feature-gather"
+description = "A competitor-relevant engine/store change merged; refresh competitor baselines."
+when_paths = [
+  "crates/sparq-engine/src/exec/**",
+  "crates/sparq-core/src/store/**",
+]
+when_label = "competitor-relevant"
+
+[[rule.create]]
+dedup_key = "gather-pr-{pr}"
+title = "gather: refresh competitor baselines after PR #{pr}"
+labels = ["bench", "gather"]
+body = """
+Merged PR #{pr} ({pr_title}) touched a competitor-relevant engine/store path and
+was labelled `competitor-relevant`.
+
+Re-run the competitor gather (`bench/` competitor harness) and refresh
+`bench/competitors.json` so the dashboard's competitive deltas reflect this
+change. This is out-of-band work that cannot be gated at merge time.
+"""
+
+# --- New ZK circuit member → gate-count baseline note --------------------------
+# The compose-member gate-count snapshot is enforced in-tree
+# (snapshot_covers_every_member). This flow-on covers NEW top-level `zk/` circuits
+# (outside zk/compose/), which that test does not yet reach — a baseline must be
+# added so the circuit's gate count is tracked.
+[[rule]]
+id = "new-zk-circuit-gatecount"
+description = "A new top-level ZK circuit landed; record a gate-count baseline."
+when_new_paths = ["zk/*/Nargo.toml", "zk/*/src/main.nr"]
+
+[[rule.create]]
+dedup_key = "zk-gatecount-{suite}"
+title = "zk: add a gate-count baseline for new circuit {suite}"
+labels = ["zk", "bench"]
+body = """
+Merged PR #{pr} ({pr_title}) added a new top-level ZK circuit `zk/{suite}`.
+
+Record a gate-count baseline for it (run the gate-count harness and add the row),
+so circuit bloat is caught by the regression gate. Compose members are already
+covered by `snapshot_covers_every_member`; top-level circuits are not yet, so
+this needs a baseline.
+"""

--- a/scripts/flow-on.py
+++ b/scripts/flow-on.py
@@ -281,6 +281,13 @@ def _added_files_via_diff(pr: int) -> list[str]:
 
 def open_issue_exists(dedup_key: str) -> bool:
     marker = key_marker(dedup_key)
+    # [OPUS-4.8] Search by the stable, punctuation-light substring
+    # `flow-on-key: <key>` rather than the full HTML-comment marker — GitHub's
+    # search tokeniser handles `<!--`/`-->` unreliably, which could miss an
+    # existing issue and break idempotency (create a duplicate). The full marker
+    # is still verified against each returned body below, so the dedup decision
+    # stays exact; the looser query only widens the candidate set.
+    search = f"flow-on-key: {dedup_key}"
     out = _gh(
         [
             "issue",
@@ -290,7 +297,7 @@ def open_issue_exists(dedup_key: str) -> bool:
             "--label",
             "flow-on",
             "--search",
-            marker,
+            search,
             "--json",
             "number,body",
             "--limit",
@@ -303,9 +310,34 @@ def open_issue_exists(dedup_key: str) -> bool:
     return False
 
 
+# Labels we have already ensured exist this run (avoid redundant gh calls).
+_ENSURED_LABELS: set[str] = set()
+
+
+def ensure_label(label: str) -> None:
+    """[OPUS-4.8] Idempotently ensure `label` exists before it is applied.
+
+    `gh issue create --label X` ERRORS if label X does not yet exist, so on a
+    fresh repo (where none of the per-rule labels — bench/docs/zk/… — nor
+    `flow-on`/`auto` exist yet) no follow-on issue would ever be created. We
+    create-if-missing with `gh label create --force` (upsert; needs only the
+    `issues: write` token the workflow already grants). Failures are swallowed:
+    if the label can't be created (e.g. it already exists from a concurrent run)
+    the subsequent create still succeeds, and a genuinely un-creatable label
+    surfaces as the create's own error rather than masking it here."""
+    if label in _ENSURED_LABELS:
+        return
+    try:
+        _gh(["label", "create", label, "--force"])
+    except Exception:  # noqa: BLE001 - best-effort upsert; create_issue reports real failures
+        pass
+    _ENSURED_LABELS.add(label)
+
+
 def create_issue(fo: FollowOn) -> str:
     args = ["issue", "create", "--title", fo.title, "--body", fo.body]
     for lbl in fo.labels:
+        ensure_label(lbl)
         args += ["--label", lbl]
     return _gh(args).strip()
 
@@ -334,7 +366,13 @@ def main(argv: list[str] | None = None) -> int:
     hermetic = args.changed_files is not None and args.title is not None
     if hermetic:
         changed = _read_lines(args.changed_files)
-        added = _read_lines(args.added_files) if args.added_files else list(changed)
+        # [OPUS-4.8] Default `added` to EMPTY, not `list(changed)`: a changed
+        # file is not provably newly-added (mirrors the real `gh` path, which
+        # derives `added` from "new file mode" diff hunks). Defaulting to all
+        # changed files made `when_new_paths` rules fire on every modified path,
+        # producing false follow-ons in hermetic/CI dry-runs. Pass --added-files
+        # to exercise new-path rules.
+        added = _read_lines(args.added_files) if args.added_files else []
         labels = _read_lines(args.labels_file) if args.labels_file else []
         title = args.title
     else:

--- a/scripts/flow-on.py
+++ b/scripts/flow-on.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Merge-triggered flow-on engine (bead sq-ncvq.2, epic sq-ncvq).
+# Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# Reads a MERGED PR's changed-file list + labels + title, evaluates the
+# declarative rules in scripts/flow-on-rules.toml, and opens ONE GitHub issue
+# (labelled `flow-on` + `auto`) per triggered follow-on template.
+#
+# WHY GITHUB ISSUES, NOT `bd create`:
+# (research/maintenance-flow-on-automation-design.md §2.2) In CI there is NO `bd`
+# dolt DB — it lives only in the orchestrator's main checkout and is gitignored,
+# and hand-editing `.beads/` is forbidden. So this script must NOT touch `bd` or
+# `.beads/`. Instead it emits each follow-on as a GitHub issue; the orchestrator
+# reconciles those issues into beads (`bd create`) out-of-band.
+#
+# IDEMPOTENCY: each `create` template has a `dedup_key`. After expansion the key
+# is embedded in the issue body as `<!-- flow-on-key: <key> -->`. Before creating,
+# this script searches OPEN issues for that marker and skips if one exists. So
+# re-running the workflow (or re-merging) never duplicates a follow-on.
+#
+# Usage:
+#   flow-on.py --pr 123                      # read changed files/labels/title via gh, create issues
+#   flow-on.py --pr 123 --dry-run            # print what WOULD be created; no gh writes
+#   flow-on.py --pr 123 --changed-files f.txt --labels-file l.txt --title "..."   # hermetic inputs (tests)
+#   flow-on.py --pr 123 --rules path.toml    # override rule file
+#
+# Hermetic mode: if --changed-files / --labels-file / --title are all provided,
+# the script makes NO gh calls for inputs. With --dry-run it makes no gh calls at
+# all, so it is fully testable without network access.
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_RULES = REPO_ROOT / "scripts" / "flow-on-rules.toml"
+
+# Labels every flow-on issue carries (in addition to a rule's own labels).
+BASE_LABELS = ["flow-on", "auto"]
+
+# Public-surface paths whose change should trigger the "changed-public-feature"
+# docs rule ONLY when no SKILL.md was touched in the same PR. A change anywhere
+# under skills/ counts as "the docs were synced", suppressing that rule.
+SKILL_PATHS = ("skills/",)
+
+
+@dataclass
+class CreateTemplate:
+    dedup_key: str
+    title: str
+    body: str
+    labels: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Rule:
+    id: str
+    description: str = ""
+    when_paths: list[str] = field(default_factory=list)
+    when_new_paths: list[str] = field(default_factory=list)
+    when_label: str | None = None
+    when_title: str | None = None
+    creates: list[CreateTemplate] = field(default_factory=list)
+
+
+@dataclass
+class FollowOn:
+    """A fully-expanded follow-on issue ready to be created (or printed)."""
+
+    rule_id: str
+    dedup_key: str
+    title: str
+    body: str
+    labels: list[str]
+
+
+# --------------------------------------------------------------------------- #
+# Rule loading
+# --------------------------------------------------------------------------- #
+def load_rules(path: Path) -> list[Rule]:
+    with path.open("rb") as fh:
+        data = tomllib.load(fh)
+    rules: list[Rule] = []
+    for raw in data.get("rule", []):
+        creates = [
+            CreateTemplate(
+                dedup_key=c["dedup_key"],
+                title=c["title"],
+                body=c["body"],
+                labels=list(c.get("labels", [])),
+            )
+            for c in raw.get("create", [])
+        ]
+        rule = Rule(
+            id=raw["id"],
+            description=raw.get("description", ""),
+            when_paths=list(raw.get("when_paths", [])),
+            when_new_paths=list(raw.get("when_new_paths", [])),
+            when_label=raw.get("when_label"),
+            when_title=raw.get("when_title"),
+            creates=creates,
+        )
+        if not (rule.when_paths or rule.when_new_paths or rule.when_label or rule.when_title):
+            raise ValueError(f"rule {rule.id!r} has no trigger predicate")
+        if not rule.creates:
+            raise ValueError(f"rule {rule.id!r} has no create templates")
+        rules.append(rule)
+    return rules
+
+
+# --------------------------------------------------------------------------- #
+# Placeholder extraction
+# --------------------------------------------------------------------------- #
+def _first_segment_after(prefix: str, paths: list[str]) -> str | None:
+    """Return the directory name immediately under `prefix` for the first path
+    that starts with it (e.g. prefix='crates/', 'crates/sparq-foo/Cargo.toml'
+    -> 'sparq-foo')."""
+    for p in paths:
+        if p.startswith(prefix):
+            rest = p[len(prefix):]
+            seg = rest.split("/", 1)[0]
+            if seg:
+                return seg
+    return None
+
+
+def build_context(
+    pr: int,
+    pr_title: str,
+    changed: list[str],
+    added: list[str],
+) -> dict[str, str]:
+    """Compute the placeholder dict for {pr}/{pr_title}/{crate}/{suite}/{surface}.
+
+    Prefer ADDED paths for crate/suite (the rules that use them are new-* rules),
+    falling back to all changed paths so changed-surface rules still resolve."""
+    pool_for_dir = added + changed  # added first so "new crate" wins
+    crate = _first_segment_after("crates/", pool_for_dir)
+    suite = _first_segment_after("bench/", pool_for_dir) or _first_segment_after("zk/", pool_for_dir)
+    surface = _first_segment_after("skills/", pool_for_dir)
+    return {
+        "pr": str(pr),
+        "pr_title": pr_title,
+        "crate": crate or "",
+        "suite": suite or "",
+        "surface": surface or "",
+    }
+
+
+def expand(text: str, ctx: dict[str, str]) -> str:
+    # Only expand known placeholders; leave unknown braces untouched.
+    def repl(m: re.Match[str]) -> str:
+        key = m.group(1)
+        return ctx.get(key, m.group(0))
+
+    return re.sub(r"\{([a-z_]+)\}", repl, text)
+
+
+# --------------------------------------------------------------------------- #
+# Rule evaluation
+# --------------------------------------------------------------------------- #
+def _any_glob_match(globs: list[str], paths: list[str]) -> bool:
+    for g in globs:
+        for p in paths:
+            if fnmatch.fnmatch(p, g):
+                return True
+    return False
+
+
+def rule_matches(rule: Rule, changed: list[str], added: list[str], labels: list[str], title: str) -> bool:
+    # ALL present predicates must pass; absent predicates are ignored.
+    if rule.when_paths and not _any_glob_match(rule.when_paths, changed):
+        return False
+    if rule.when_new_paths and not _any_glob_match(rule.when_new_paths, added):
+        return False
+    if rule.when_label is not None and rule.when_label not in labels:
+        return False
+    if rule.when_title is not None and not re.search(rule.when_title, title, re.IGNORECASE):
+        return False
+
+    # Special case for the changed-public-feature docs rule: suppress it when the
+    # PR already touched a SKILL.md (the docs were synced in the same diff).
+    if rule.id == "changed-public-feature-docs":
+        if any(p.startswith(SKILL_PATHS) for p in changed):
+            return False
+    return True
+
+
+def key_marker(dedup_key: str) -> str:
+    return f"<!-- flow-on-key: {dedup_key} -->"
+
+
+def evaluate(
+    rules: list[Rule],
+    pr: int,
+    pr_title: str,
+    changed: list[str],
+    added: list[str],
+    labels: list[str],
+) -> list[FollowOn]:
+    ctx = build_context(pr, pr_title, changed, added)
+    out: list[FollowOn] = []
+    seen_keys: set[str] = set()
+    for rule in rules:
+        if not rule_matches(rule, changed, added, labels, pr_title):
+            continue
+        for tmpl in rule.creates:
+            dedup_key = expand(tmpl.dedup_key, ctx)
+            if dedup_key in seen_keys:
+                continue  # de-dup within a single run
+            seen_keys.add(dedup_key)
+            body = expand(tmpl.body, ctx).rstrip() + "\n\n" + key_marker(dedup_key)
+            body += (
+                f"\n\n> 🤖 SPARQ agent — auto-generated by the flow-on engine "
+                f"(rule `{rule.id}`) from merged PR #{pr}. Reconcile into a bead."
+            )
+            labels_full = list(dict.fromkeys(BASE_LABELS + tmpl.labels))
+            out.append(
+                FollowOn(
+                    rule_id=rule.id,
+                    dedup_key=dedup_key,
+                    title=expand(tmpl.title, ctx),
+                    body=body,
+                    labels=labels_full,
+                )
+            )
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# gh I/O
+# --------------------------------------------------------------------------- #
+def _gh(args: list[str]) -> str:
+    proc = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout
+
+
+def fetch_pr_inputs(pr: int) -> tuple[str, list[str], list[str], list[str]]:
+    """Return (title, changed_files, added_files, labels) for a merged PR via gh."""
+    info = json.loads(_gh(["pr", "view", str(pr), "--json", "title,labels,files"]))
+    title = info.get("title", "")
+    labels = [lbl["name"] for lbl in info.get("labels", [])]
+    files = info.get("files", [])
+    changed = [f["path"] for f in files]
+    # gh's files[].additions/deletions don't reveal status; use the diff to find
+    # purely-added files (status "A").
+    added = _added_files_via_diff(pr)
+    return title, changed, added, labels
+
+
+def _added_files_via_diff(pr: int) -> list[str]:
+    # `gh pr diff --name-only` lists changed files but not status. Use the patch
+    # and detect "new file mode" hunks for added-file paths.
+    patch = _gh(["pr", "diff", str(pr)])
+    added: list[str] = []
+    cur_new = False
+    for line in patch.splitlines():
+        if line.startswith("diff --git "):
+            cur_new = False
+        elif line.startswith("new file mode"):
+            cur_new = True
+        elif line.startswith("+++ b/") and cur_new:
+            added.append(line[len("+++ b/"):])
+            cur_new = False
+    return added
+
+
+def open_issue_exists(dedup_key: str) -> bool:
+    marker = key_marker(dedup_key)
+    out = _gh(
+        [
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--label",
+            "flow-on",
+            "--search",
+            marker,
+            "--json",
+            "number,body",
+            "--limit",
+            "100",
+        ]
+    )
+    for issue in json.loads(out):
+        if marker in (issue.get("body") or ""):
+            return True
+    return False
+
+
+def create_issue(fo: FollowOn) -> str:
+    args = ["issue", "create", "--title", fo.title, "--body", fo.body]
+    for lbl in fo.labels:
+        args += ["--label", lbl]
+    return _gh(args).strip()
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _read_lines(path: str) -> list[str]:
+    return [ln.strip() for ln in Path(path).read_text().splitlines() if ln.strip()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Merge-triggered flow-on follow-on issue emitter.")
+    ap.add_argument("--pr", type=int, required=True, help="merged PR number")
+    ap.add_argument("--rules", default=str(DEFAULT_RULES), help="rule TOML path")
+    ap.add_argument("--dry-run", action="store_true", help="print what WOULD be created; no gh writes")
+    # Hermetic inputs (for tests / local runs without gh).
+    ap.add_argument("--changed-files", help="file with one changed path per line")
+    ap.add_argument("--added-files", help="file with one ADDED path per line (subset of changed)")
+    ap.add_argument("--labels-file", help="file with one PR label per line")
+    ap.add_argument("--title", help="PR title")
+    args = ap.parse_args(argv)
+
+    rules = load_rules(Path(args.rules))
+
+    hermetic = args.changed_files is not None and args.title is not None
+    if hermetic:
+        changed = _read_lines(args.changed_files)
+        added = _read_lines(args.added_files) if args.added_files else list(changed)
+        labels = _read_lines(args.labels_file) if args.labels_file else []
+        title = args.title
+    else:
+        title, changed, added, labels = fetch_pr_inputs(args.pr)
+
+    follow_ons = evaluate(rules, args.pr, title, changed, added, labels)
+
+    if not follow_ons:
+        print(f"flow-on: no rules triggered for PR #{args.pr}.")
+        return 0
+
+    created = 0
+    skipped = 0
+    for fo in follow_ons:
+        if args.dry_run:
+            print(f"[dry-run] WOULD create issue (rule={fo.rule_id}, key={fo.dedup_key}):")
+            print(f"          title : {fo.title}")
+            print(f"          labels: {', '.join(fo.labels)}")
+            continue
+        if open_issue_exists(fo.dedup_key):
+            print(f"flow-on: skip (open issue exists) key={fo.dedup_key} rule={fo.rule_id}")
+            skipped += 1
+            continue
+        url = create_issue(fo)
+        print(f"flow-on: created {url} (rule={fo.rule_id}, key={fo.dedup_key})")
+        created += 1
+
+    if not args.dry_run:
+        print(f"flow-on: done — {created} created, {skipped} skipped (already open).")
+        # Write a GitHub Actions step summary if available.
+        summary = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary:
+            with open(summary, "a") as fh:
+                fh.write(f"### flow-on (PR #{args.pr})\n\n")
+                fh.write(f"- created: {created}\n- skipped (already open): {skipped}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_flow_on.py
+++ b/scripts/tests/test_flow_on.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Hermetic unit/dry-run tests for the flow-on engine (bead sq-ncvq.2,
+# epic sq-ncvq). Authored by Opus 4.8 (Fable unavailable; flag for re-review when
+# Fable returns).
+#
+# Fully hermetic: imports scripts/flow-on.py and exercises rule evaluation +
+# idempotency-key generation against fixture diffs. NO live `gh` calls — we only
+# drive `evaluate()` and `main(--dry-run)`, neither of which touches the network.
+#
+# Run:  python3 scripts/tests/test_flow_on.py
+# (stdlib only; no pytest required.)
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FLOW_ON = REPO_ROOT / "scripts" / "flow-on.py"
+RULES = REPO_ROOT / "scripts" / "flow-on-rules.toml"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("flow_on", FLOW_ON)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclasses can resolve forward annotations
+    # (cls.__module__ lookup in _is_type) for the module-level @dataclass types.
+    sys.modules["flow_on"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+flow_on = _load_module()
+
+
+class RuleLoadingTest(unittest.TestCase):
+    def test_rules_load_and_are_well_formed(self):
+        rules = flow_on.load_rules(RULES)
+        self.assertTrue(rules, "expected at least one rule")
+        ids = {r.id for r in rules}
+        # The taxonomy rules the design requires must all be present.
+        for required in (
+            "new-crate-bench-and-skill",
+            "changed-public-feature-docs",
+            "new-bench-dashboard-row",
+            "competitor-feature-gather",
+        ):
+            self.assertIn(required, ids)
+        # Every rule has a trigger + at least one create template.
+        for r in rules:
+            self.assertTrue(
+                r.when_paths or r.when_new_paths or r.when_label or r.when_title,
+                f"{r.id} has no trigger",
+            )
+            self.assertTrue(r.creates, f"{r.id} has no create templates")
+
+
+class NewCrateTest(unittest.TestCase):
+    """A PR that adds crates/sparq-foo/ must yield the bench + SKILL follow-ons."""
+
+    def setUp(self):
+        self.rules = flow_on.load_rules(RULES)
+
+    def _eval(self, changed, added, labels=None, title="add sparq-foo crate"):
+        return flow_on.evaluate(
+            self.rules, 42, title, changed, added, labels or []
+        )
+
+    def test_new_crate_triggers_bench_and_skill(self):
+        added = [
+            "crates/sparq-foo/Cargo.toml",
+            "crates/sparq-foo/src/lib.rs",
+            "crates/sparq-foo/README.md",
+        ]
+        fos = self._eval(changed=added, added=added)
+        rule_ids = {fo.rule_id for fo in fos}
+        self.assertIn("new-crate-bench-and-skill", rule_ids)
+
+        keys = {fo.dedup_key for fo in fos}
+        self.assertIn("new-crate-bench-sparq-foo", keys)
+        self.assertIn("new-crate-skill-sparq-foo", keys)
+
+        # The {crate} placeholder is expanded in titles + bodies.
+        bench_fo = next(fo for fo in fos if fo.dedup_key == "new-crate-bench-sparq-foo")
+        self.assertIn("sparq-foo", bench_fo.title)
+        self.assertIn("sparq-foo", bench_fo.body)
+        self.assertNotIn("{crate}", bench_fo.title)
+        self.assertNotIn("{crate}", bench_fo.body)
+
+        # Base labels always present; the idempotency marker is embedded.
+        self.assertIn("flow-on", bench_fo.labels)
+        self.assertIn("auto", bench_fo.labels)
+        self.assertIn(flow_on.key_marker("new-crate-bench-sparq-foo"), bench_fo.body)
+
+    def test_modifying_existing_crate_file_does_not_fire_new_crate_rule(self):
+        # Cargo.toml is CHANGED but not ADDED -> when_new_paths must not match.
+        changed = ["crates/sparq-core/Cargo.toml", "crates/sparq-core/src/store/mod.rs"]
+        added: list[str] = []
+        fos = self._eval(changed=changed, added=added)
+        self.assertNotIn("new-crate-bench-and-skill", {fo.rule_id for fo in fos})
+
+
+class ChangedSurfaceTest(unittest.TestCase):
+    def setUp(self):
+        self.rules = flow_on.load_rules(RULES)
+
+    def test_cli_change_without_skill_fires_docs_rule(self):
+        changed = ["crates/sparq-cli/src/main.rs"]
+        fos = flow_on.evaluate(self.rules, 7, "add --explain flag", changed, [], [])
+        self.assertIn("changed-public-feature-docs", {fo.rule_id for fo in fos})
+
+    def test_cli_change_with_skill_update_suppresses_docs_rule(self):
+        changed = ["crates/sparq-cli/src/main.rs", "skills/cli/SKILL.md"]
+        fos = flow_on.evaluate(self.rules, 8, "add --explain flag", changed, [], [])
+        self.assertNotIn("changed-public-feature-docs", {fo.rule_id for fo in fos})
+
+
+class CompetitorLabelTest(unittest.TestCase):
+    def setUp(self):
+        self.rules = flow_on.load_rules(RULES)
+
+    def test_engine_change_requires_label(self):
+        changed = ["crates/sparq-engine/src/exec/join.rs"]
+        # Without the label, the gather rule must NOT fire.
+        fos = flow_on.evaluate(self.rules, 9, "faster joins", changed, [], [])
+        self.assertNotIn("competitor-feature-gather", {fo.rule_id for fo in fos})
+        # With the label, it fires.
+        fos = flow_on.evaluate(
+            self.rules, 9, "faster joins", changed, [], ["competitor-relevant"]
+        )
+        self.assertIn("competitor-feature-gather", {fo.rule_id for fo in fos})
+
+
+class NewBenchTest(unittest.TestCase):
+    def setUp(self):
+        self.rules = flow_on.load_rules(RULES)
+
+    def test_new_bench_suite_triggers_dashboard_row(self):
+        added = ["bench/widgets/benchmarks.toml", "bench/widgets/run.sh"]
+        fos = flow_on.evaluate(self.rules, 11, "add widgets bench", added, added, [])
+        dash = [fo for fo in fos if fo.rule_id == "new-bench-dashboard-row"]
+        self.assertTrue(dash)
+        self.assertEqual(dash[0].dedup_key, "dashboard-row-widgets")
+        self.assertIn("widgets", dash[0].title)
+
+
+class IdempotencyTest(unittest.TestCase):
+    """The dedup-key marker is what open_issue_exists() searches for; verify the
+    key is stable + embedded so a re-run is a no-op once the issue is open."""
+
+    def setUp(self):
+        self.rules = flow_on.load_rules(RULES)
+
+    def test_dedup_key_stable_across_runs(self):
+        added = ["crates/sparq-foo/Cargo.toml"]
+        a = flow_on.evaluate(self.rules, 42, "t", added, added, [])
+        b = flow_on.evaluate(self.rules, 42, "t", added, added, [])
+        self.assertEqual(
+            sorted(fo.dedup_key for fo in a),
+            sorted(fo.dedup_key for fo in b),
+        )
+
+    def test_marker_round_trips(self):
+        key = "new-crate-bench-sparq-foo"
+        body = "some body\n\n" + flow_on.key_marker(key)
+        # open_issue_exists greps for exactly this marker substring.
+        self.assertIn(flow_on.key_marker(key), body)
+
+
+class DryRunTest(unittest.TestCase):
+    """main(--dry-run) must print the would-create plan and make NO gh calls.
+
+    We provide all inputs hermetically (changed-files/title) so fetch_pr_inputs
+    is never reached, and --dry-run skips open_issue_exists/create_issue."""
+
+    def test_dry_run_on_new_crate_fixture(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            changed = Path(td) / "changed.txt"
+            changed.write_text("crates/sparq-foo/Cargo.toml\ncrates/sparq-foo/src/lib.rs\n")
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = flow_on.main(
+                    [
+                        "--pr",
+                        "42",
+                        "--dry-run",
+                        "--changed-files",
+                        str(changed),
+                        "--added-files",
+                        str(changed),
+                        "--title",
+                        "add sparq-foo crate",
+                    ]
+                )
+            out = buf.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertIn("[dry-run] WOULD create", out)
+        self.assertIn("new-crate-bench-sparq-foo", out)
+
+    def test_dry_run_no_match_is_clean(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            changed = Path(td) / "changed.txt"
+            changed.write_text("README.md\n")
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = flow_on.main(
+                    ["--pr", "1", "--dry-run", "--changed-files", str(changed), "--title", "docs"]
+                )
+            out = buf.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertIn("no rules triggered", out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_flow_on.py
+++ b/scripts/tests/test_flow_on.py
@@ -49,6 +49,9 @@ class RuleLoadingTest(unittest.TestCase):
             "changed-public-feature-docs",
             "new-bench-dashboard-row",
             "competitor-feature-gather",
+            # [OPUS-4.8] ZK circuit gate-count follow-on (a PR-description
+            # deliverable, present in the rules file) — enforce the contract.
+            "new-zk-circuit-gatecount",
         ):
             self.assertIn(required, ids)
         # Every rule has a trigger + at least one create template.
@@ -217,6 +220,34 @@ class DryRunTest(unittest.TestCase):
                 )
             out = buf.getvalue()
         self.assertEqual(rc, 0)
+        self.assertIn("no rules triggered", out)
+
+    def test_hermetic_without_added_files_does_not_fire_new_path_rules(self):
+        # [OPUS-4.8] Regression: when --added-files is omitted, `added` must
+        # default to EMPTY, not to all changed files — otherwise a MODIFIED
+        # crate Cargo.toml would falsely fire the new-crate (when_new_paths)
+        # rule. Here Cargo.toml is changed-but-not-added.
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            changed = Path(td) / "changed.txt"
+            changed.write_text("crates/sparq-foo/Cargo.toml\n")
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = flow_on.main(
+                    [
+                        "--pr",
+                        "7",
+                        "--dry-run",
+                        "--changed-files",
+                        str(changed),
+                        "--title",
+                        "tweak sparq-foo manifest",
+                    ]
+                )
+            out = buf.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertNotIn("new-crate-bench-sparq-foo", out)
         self.assertIn("no rules triggered", out)
 
 


### PR DESCRIPTION
> 🤖 SPARQ agent

## Flow-on auto-task-creation engine (epic `sq-ncvq`)

Implements the **reactive half** of the maintenance flow-on automation exactly per the authoritative design (`research/maintenance-flow-on-automation-design.md` §2.2 / §3, PR #211) — a **thin local layer, no beads fork**. On every MERGED PR it evaluates a declarative rule table and opens a follow-on GitHub issue so nothing falls through the gaps while the maintainer is away.

### CI constraint honoured
There is **no `bd` dolt DB in CI** (it lives only in the orchestrator's checkout and is gitignored) and hand-editing `.beads/` is forbidden. So follow-ons are emitted through a CI-available channel: **one GitHub issue per follow-on**, labelled `flow-on` + `auto`, which the orchestrator reconciles into beads. The engine never calls `bd` and never writes `.beads/`.

### Deliverables
- **`scripts/flow-on-rules.toml`** (`sq-ncvq.1`) — declarative `trigger -> follow-on template` rules from the taxonomy:
  - **new crate** (`crates/*/Cargo.toml` added) → register a benchmark + add a SKILL.md/cert plan
  - **changed public surface** (`sparq-cli`/`-server`/`-py`/`-wasm` src) **without** a SKILL.md edit → sync the SKILL.md
  - **new bench suite** (`bench/*/benchmarks.toml`|`run.sh` added) → add a dashboard `FEATURED_SUITES` row
  - **competitor-relevant engine/store change** (opt-in `competitor-relevant` label) → `gather` refresh
  - **new top-level ZK circuit** (`zk/*/Nargo.toml`|`main.nr` added) → record a gate-count baseline
- **`scripts/flow-on.py`** (`sq-ncvq.2`) — reads a merged PR's changed files/labels/title (via `gh`), evaluates rules, opens one issue per template. **Idempotent**: each template has a `dedup_key`; the expanded key is embedded as a hidden `<!-- flow-on-key: ... -->` marker and searched among open issues before creating — skip if present. `--dry-run` + hermetic input flags (no network). stdlib-only (`tomllib`).
- **`.github/workflows/flow-on.yml`** (`sq-ncvq.3`) — `on: pull_request: [closed]`, `if: github.event.pull_request.merged == true`. **SHA-pinned** actions, least-privilege `issues: write`. Not a gate (runs post-merge, never blocks).
- **`scripts/tests/test_flow_on.py`** — hermetic unit/dry-run tests (11 cases, no live `gh`): rule eval, placeholder expansion, idempotency-key stability, SKILL-suppression, label opt-in, `--dry-run`.

### Verification
- 11/11 tests pass (`python3 scripts/tests/test_flow_on.py`)
- `flow-on.yml` passes **actionlint** (v1.7.7) clean
- `ruff check` clean (matches repo convention — existing scripts are also lint-clean, not auto-formatted)
- `--dry-run` correct on a multi-rule sample
- No `bd` calls, no `.beads/` writes

### Deferred (with beads)
The **proactive merge-gate half** (G1–G6 diff-aware DoD checks) and the reusable `drift-scan.py` from the design (§2.1, §3, §5) are out of scope for this epic's three beads and are tracked separately under `sq-ncvq`.

References: `sq-ncvq.1`, `sq-ncvq.2`, `sq-ncvq.3`, epic `sq-ncvq`.
