### PR TITLE
ci(flow-on): proactive merge-gates G1 new-crate-completeness + G2 public-api→skill (sq-ncvq.4/.5)

### DIFF
--- a/.github/workflows/flow-on-gates.yml
+++ b/.github/workflows/flow-on-gates.yml
@@ -1,0 +1,99 @@
+# [OPUS-4.8] Proactive maintenance merge-gates G1/G2 (beads sq-ncvq.4 + sq-ncvq.5,
+# epic sq-ncvq). Authored by Opus 4.8 (Fable unavailable; flag for re-review when
+# Fable returns).
+#
+# This is the PROACTIVE / merge-time half of the maintenance flow-on system
+# (research/maintenance-flow-on-automation-design.md §2.1). It is the COMPLEMENT of
+# the REACTIVE engine in flow-on.yml + scripts/flow-on*.{py,toml} (PR #220): that
+# engine mints follow-on ISSUES after a PR merges; THESE gates BLOCK a PR before it
+# merges when it would create maintenance debt. The two mechanisms are deliberately
+# consistent — G2's suppression mirrors flow-on.py's SKILL_PATHS exactly, so a PR a
+# gate lets through is also a PR the reactive engine would not re-flag.
+#
+# GATING (not advisory): the job NAMES here contain NO "advisory"/"informational"/
+# "non-blocking" token, so the `ci-summary / gate` aggregator (ci-summary.yml) — the
+# SINGLE required check on `main` — treats them as REQUIRED gating checks and folds
+# their conclusions into the merge verdict. There is NO branch-protection edit and
+# NO ci.yml/ci-summary.yml edit needed: the aggregator discovers every sibling
+# check-run on the head commit by name, so adding this workflow is enough to make
+# the gates required. (A gate that should ever soft-launch would run with the
+# scripts' `--advisory` flag OR be renamed to carry the "advisory" word; these run
+# HARD because the back-catalogue is already clean — verified by running each gate
+# against current HEAD with no violation.)
+#
+# Each gate reads the PR diff via `git diff --name-only origin/<base>...HEAD` (the
+# scripts derive added vs changed from `--name-status`) and exits non-zero with a
+# clear, actionable message on violation.
+name: flow-on-gates
+
+on:
+  pull_request:
+  # Required checks must also run on the merge-queue ref so ci-summary finds the
+  # identical sibling set there (mirrors ci-summary.yml's merge_group handling).
+  merge_group:
+
+# Read-only: the gates only read the diff against the base ref.
+permissions:
+  contents: read
+
+concurrency:
+  group: flow-on-gates-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  new-crate-completeness:
+    name: new-crate-completeness (G1)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for the merge-base diff)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: G1 — new crate ships bench + README (+ SKILL if public)
+        env:
+          # On pull_request github.base_ref is the bare target branch ('main'); on
+          # merge_group it is empty, so fall back to merge_group.base_ref (a full
+          # 'refs/heads/main' ref — the scripts normalize the refs/heads/ prefix).
+          GATE_BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}
+        run: python3 scripts/gate-new-crate.py --base "$GATE_BASE_REF"
+
+  public-api-skill:
+    name: public-api-skill (G2)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for the merge-base diff)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Read PR labels (for the skill-not-needed escape hatch)
+        id: labels
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --json labels --jq '.labels[].name' > pr-labels.txt || : > pr-labels.txt
+          echo "have_labels=1" >> "$GITHUB_OUTPUT"
+      - name: G2 — public-surface change requires a SKILL.md edit
+        env:
+          # On pull_request github.base_ref is the bare target branch ('main'); on
+          # merge_group it is empty, so fall back to merge_group.base_ref (a full
+          # 'refs/heads/main' ref — the scripts normalize the refs/heads/ prefix).
+          GATE_BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}
+        run: |
+          set -euo pipefail
+          if [ -f pr-labels.txt ]; then
+            python3 scripts/gate-api-skill.py --base "$GATE_BASE_REF" --labels-file pr-labels.txt
+          else
+            python3 scripts/gate-api-skill.py --base "$GATE_BASE_REF"
+          fi

--- a/.github/workflows/flow-on-gates.yml
+++ b/.github/workflows/flow-on-gates.yml
@@ -32,9 +32,11 @@ on:
   # identical sibling set there (mirrors ci-summary.yml's merge_group handling).
   merge_group:
 
-# Read-only: the gates only read the diff against the base ref.
+# Least privilege: the gates read the diff against the base ref (contents) and
+# the PR's labels for the skill-not-needed escape hatch (pull-requests). [OPUS-4.8]
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: flow-on-gates-${{ github.event.pull_request.number || github.ref }}
@@ -75,14 +77,29 @@ jobs:
           python-version: "3.12"
       - name: Read PR labels (for the skill-not-needed escape hatch)
         id: labels
-        if: ${{ github.event_name == 'pull_request' }}
+        # [OPUS-4.8] Run on BOTH pull_request AND merge_group so the escape-hatch
+        # label is honoured in the merge queue too (otherwise a PR that legitimately
+        # carried `skill-not-needed` would pass the PR gate but fail the identical
+        # merge_group gate, blocking the queue). On merge_group the PR number is not
+        # in the event payload, so resolve it from the head commit's associated PR.
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
-          gh pr view "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
-            --json labels --jq '.labels[].name' > pr-labels.txt || : > pr-labels.txt
+          : > pr-labels.txt
+          num="${PR_NUMBER:-}"
+          if [ -z "$num" ] && [ -n "${MERGE_SHA:-}" ]; then
+            # Resolve the PR associated with the merge-queue head commit.
+            num="$(gh api "repos/${{ github.repository }}/commits/${MERGE_SHA}/pulls" \
+                     --jq '.[0].number' 2>/dev/null || true)"
+          fi
+          if [ -n "$num" ]; then
+            gh pr view "$num" \
+              --repo "${{ github.repository }}" \
+              --json labels --jq '.labels[].name' > pr-labels.txt || : > pr-labels.txt
+          fi
           echo "have_labels=1" >> "$GITHUB_OUTPUT"
       - name: G2 — public-surface change requires a SKILL.md edit
         env:

--- a/scripts/gate-api-skill.py
+++ b/scripts/gate-api-skill.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Gate G2 — public-api→skill (bead sq-ncvq.5, epic sq-ncvq).
+# Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# PROACTIVE / merge-time half of the maintenance flow-on system
+# (research/maintenance-flow-on-automation-design.md §2.1, gate G2). Complements
+# the reactive engine (scripts/flow-on.py, PR #220): that engine mints a
+# "sync SKILL.md" follow-on ISSUE after merge; THIS gate BLOCKS the PR before it
+# merges so the docs never drift in the first place.
+#
+# RULE (G2): when a PR changes a PUBLIC SURFACE without touching any
+# skills/**/SKILL.md in the same diff, FAIL and point at the AGENTS.md
+# public-API → SKILL.md maintenance rule.
+#
+# A "public surface" is (matching AGENTS.md:44-51 and the reactive rule's
+# `changed-public-feature-docs` paths in flow-on-rules.toml):
+#   - any changed file under one of the binding/entry crates' `src/**`:
+#       crates/sparq-cli/src/**, crates/sparq-server/src/**,
+#       crates/sparq-py/src/**,  crates/sparq-wasm/src/**;
+#   - a `pub` API change in a PUBLISHED Rust crate: a changed `crates/<x>/src/**`
+#       file whose crate is NOT `publish = false` and whose diff adds/removes a
+#       `pub` item (heuristic — see pub_api_changed()). The four binding crates
+#       above are always in scope regardless of the `pub` heuristic.
+#
+# SUPPRESSION (mirrors flow-on.py's SKILL_PATHS exactly): the gate is satisfied
+# the moment the SAME diff touches ANY skills/**/SKILL.md — that is the signal
+# "the docs were synced in this change", identical to the reactive engine's
+# suppression of its docs rule. This keeps the two halves consistent: a PR that
+# the gate lets through is also a PR the reactive engine would NOT re-flag.
+#
+# ESCAPE HATCH (design §2.1): the per-PR label `skill-not-needed` (justified in
+# the PR body) suppresses the gate. In CI the label list is passed via
+# --labels-file; locally/in tests it is injected. (The reactive engine is
+# orthogonal — it runs post-merge and is not a blocker.)
+#
+# DIFF SOURCE: git diff --name-only origin/<base>...HEAD (CI), or a fixture file
+# (--changed-files, one path per line, optionally status-prefixed) for tests.
+# To evaluate the `pub` heuristic for non-binding crates we read the unified
+# diff (git diff origin/<base>...HEAD -- <file>) for added/removed `pub` lines;
+# in hermetic mode the caller may inject this via pub_overrides.
+#
+# EXIT: 0 when no public surface changed, or a SKILL.md was touched, or the
+# escape-hatch label is present; 1 (with the AGENTS.md pointer) otherwise.
+#
+# Usage:
+#   gate-api-skill.py                        # CI: diff vs origin/<base>
+#   gate-api-skill.py --base main
+#   gate-api-skill.py --advisory             # warn-only soft-launch
+#   gate-api-skill.py --dry-run --changed-files files.txt [--labels-file l.txt]
+#
+# stdlib-only.
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Binding / entry-point crates: ANY src/** change here is a public-surface change
+# (their entire src is the public contract — CLI flags, HTTP routes, Py/JS
+# bindings). Mirrors flow-on-rules.toml `changed-public-feature-docs` when_paths.
+BINDING_SURFACE_PREFIXES = (
+    "crates/sparq-cli/src/",
+    "crates/sparq-server/src/",
+    "crates/sparq-py/src/",
+    "crates/sparq-wasm/src/",
+)
+
+# Suppression signal — identical to flow-on.py's SKILL_PATHS: any SKILL.md under
+# skills/ means the docs were synced in this diff.
+SKILL_SUFFIX = "SKILL.md"
+SKILL_PREFIX = "skills/"
+
+# Escape-hatch label (design §2.1).
+SKILL_NOT_NEEDED_LABEL = "skill-not-needed"
+
+_STATUS_RE = re.compile(r"^([A-Z])\d*\t(.*)$")
+_CRATE_SRC_RE = re.compile(r"^crates/([^/]+)/src/.+")
+
+
+def parse_paths(lines: list[str]) -> list[str]:
+    """Extract paths from a `git diff --name-only` / `--name-status` listing."""
+    paths: list[str] = []
+    for raw in lines:
+        line = raw.rstrip("\n")
+        if not line.strip():
+            continue
+        m = _STATUS_RE.match(line)
+        if m:
+            paths.append(m.group(2).split("\t")[-1])
+        else:
+            paths.append(line)
+    return paths
+
+
+def _normalize_base(base: str) -> str:
+    """Accept a bare branch ('main') or a full ref ('refs/heads/main', as the
+    merge_group event supplies in github.event.merge_group.base_ref) and return
+    the remote-tracking ref to diff against ('origin/main')."""
+    base = base.strip()
+    if base.startswith("refs/heads/"):
+        base = base[len("refs/heads/") :]
+    if base.startswith("origin/") or base == "HEAD":
+        return base
+    return f"origin/{base}"
+
+
+def git_changed(base: str) -> list[str]:
+    ref = _normalize_base(base)
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", f"{ref}...HEAD"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except subprocess.CalledProcessError as e:  # pragma: no cover - CI-only
+        sys.stderr.write(f"error: git diff failed: {e.stderr}\n")
+        sys.exit(2)
+    return parse_paths(out.splitlines())
+
+
+def crate_is_published(crate: str) -> bool:
+    """True iff crates/<crate>/Cargo.toml does NOT declare `publish = false`."""
+    cargo = REPO_ROOT / "crates" / crate / "Cargo.toml"
+    try:
+        text = cargo.read_text(encoding="utf-8")
+    except OSError:
+        # Unknown crate manifest — treat as published (strict default).
+        return True
+    return re.search(r"^\s*publish\s*=\s*false\b", text, re.MULTILINE) is None
+
+
+def pub_api_changed(path: str, base: str) -> bool:
+    """Heuristic: does the unified diff for `path` add or remove a `pub` item?
+
+    A `pub fn/struct/enum/trait/const/...` (or `pub use`) line being added or
+    removed signals a public-API surface change. Reads the per-file unified diff
+    from git; on any error returns False (conservative — never a CI-only crash)."""
+    ref = _normalize_base(base)
+    try:
+        out = subprocess.run(
+            ["git", "diff", f"{ref}...HEAD", "--", path],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except subprocess.CalledProcessError:  # pragma: no cover - CI-only
+        return False
+    pub_re = re.compile(r"^[+-]\s*pub(\s|\()")
+    for line in out.splitlines():
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if (line.startswith("+") or line.startswith("-")) and pub_re.match(line):
+            return True
+    return False
+
+
+def public_surface_changes(
+    changed: list[str],
+    base: str,
+    *,
+    pub_overrides: dict[str, bool] | None = None,
+) -> list[str]:
+    """Return the changed paths that constitute a public-surface change."""
+    pub_overrides = pub_overrides or {}
+    hits: list[str] = []
+    for p in changed:
+        if p.startswith(BINDING_SURFACE_PREFIXES):
+            hits.append(p)
+            continue
+        m = _CRATE_SRC_RE.match(p)
+        if m:
+            crate = m.group(1)
+            if not crate_is_published(crate):
+                continue
+            is_pub = pub_overrides.get(p)
+            if is_pub is None:
+                is_pub = pub_api_changed(p, base)
+            if is_pub:
+                hits.append(p)
+    return hits
+
+
+def skill_touched(changed: list[str]) -> bool:
+    return any(p.startswith(SKILL_PREFIX) and p.endswith(SKILL_SUFFIX) for p in changed)
+
+
+def evaluate(
+    changed: list[str],
+    labels: list[str],
+    base: str,
+    *,
+    pub_overrides: dict[str, bool] | None = None,
+) -> tuple[bool, list[str]]:
+    """Return (ok, surface_hits). ok=True means the gate PASSES.
+
+    PASS when: no public surface changed; OR a SKILL.md was touched; OR the
+    `skill-not-needed` escape-hatch label is present."""
+    hits = public_surface_changes(changed, base, pub_overrides=pub_overrides)
+    if not hits:
+        return True, []
+    if skill_touched(changed):
+        return True, hits
+    if SKILL_NOT_NEEDED_LABEL in labels:
+        return True, hits
+    return False, hits
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="G2 public-api→skill gate (sq-ncvq.5)."
+    )
+    ap.add_argument(
+        "--base",
+        default=os.environ.get("GATE_BASE_REF", "main"),
+        help="base ref to diff against (origin/<base>); default 'main'.",
+    )
+    ap.add_argument("--changed-files", help="hermetic input: file of diff lines.")
+    ap.add_argument(
+        "--labels-file",
+        help="hermetic input: file of PR labels, one per line (for the escape hatch).",
+    )
+    ap.add_argument("--dry-run", action="store_true", help="never exit non-zero.")
+    ap.add_argument(
+        "--advisory", action="store_true", help="soft-launch: report but exit 0."
+    )
+    args = ap.parse_args(argv)
+
+    if args.changed_files:
+        lines = Path(args.changed_files).read_text(encoding="utf-8").splitlines()
+        changed = parse_paths(lines)
+    else:
+        changed = git_changed(args.base)
+
+    labels: list[str] = []
+    if args.labels_file:
+        labels = [
+            ln.strip()
+            for ln in Path(args.labels_file).read_text(encoding="utf-8").splitlines()
+            if ln.strip()
+        ]
+
+    ok, hits = evaluate(changed, labels, args.base)
+
+    if ok:
+        if hits:
+            print(
+                "G2 public-api→skill: PASS — public surface changed and a "
+                "SKILL.md (or the skill-not-needed label) is present."
+            )
+        else:
+            print("G2 public-api→skill: PASS — no public surface changed.")
+        return 0
+
+    print("G2 public-api→skill: FAIL")
+    print("\n  These changed files are a public surface, but NO skills/**/SKILL.md")
+    print("  was edited in the same PR:")
+    for p in hits:
+        print(f"    - {p}")
+    print(
+        "\nThe AGENTS.md public-API → SKILL.md maintenance rule (AGENTS.md "
+        '"MAINTENANCE RULE (REQUIRED)" / "Public-API → SKILL.md maintenance rule") '
+        "requires updating the matching skills/<surface>/SKILL.md in the SAME "
+        "change. Edit the relevant SKILL.md (the surface map is in "
+        "skills/SKILL.md), or — if no doc change is warranted — add the "
+        f"`{SKILL_NOT_NEEDED_LABEL}` label with a justification in the PR body."
+    )
+
+    if args.advisory or args.dry_run:
+        print("\n(advisory/dry-run: not failing the build)")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gate-api-skill.py
+++ b/scripts/gate-api-skill.py
@@ -142,7 +142,14 @@ def pub_api_changed(path: str, base: str) -> bool:
 
     A `pub fn/struct/enum/trait/const/...` (or `pub use`) line being added or
     removed signals a public-API surface change. Reads the per-file unified diff
-    from git; on any error returns False (conservative — never a CI-only crash)."""
+    from git; on any error returns False (conservative — never a CI-only crash).
+
+    [OPUS-4.8] RESTRICTED visibilities — `pub(crate)`, `pub(super)`,
+    `pub(in …)` — are NOT part of the crate's public surface (AGENTS.md: public
+    API == exported items), so they must NOT trip the gate. They are always
+    written `pub(` with no space, so requiring whitespace after `pub`
+    (`pub\\s`) matches exactly the exported forms (`pub fn`, `pub use`,
+    `pub struct`, …) while excluding the restricted ones."""
     ref = _normalize_base(base)
     try:
         out = subprocess.run(
@@ -154,7 +161,7 @@ def pub_api_changed(path: str, base: str) -> bool:
         ).stdout
     except subprocess.CalledProcessError:  # pragma: no cover - CI-only
         return False
-    pub_re = re.compile(r"^[+-]\s*pub(\s|\()")
+    pub_re = re.compile(r"^[+-]\s*pub\s")
     for line in out.splitlines():
         if line.startswith("+++") or line.startswith("---"):
             continue

--- a/scripts/gate-new-crate.py
+++ b/scripts/gate-new-crate.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Gate G1 — new-crate-completeness (bead sq-ncvq.4, epic sq-ncvq).
+# Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# This is the PROACTIVE / merge-time half of the maintenance flow-on system
+# (research/maintenance-flow-on-automation-design.md §2.1, gate G1). It is the
+# COMPLEMENT of the reactive engine in scripts/flow-on.py (PR #220): that engine
+# mints follow-on ISSUES after a PR merges; THIS script BLOCKS the PR before it
+# merges when a new crate would land without its required maintenance artifacts.
+#
+# RULE (G1): when a PR ADDS a new `crates/<x>/Cargo.toml`, fail unless the SAME
+# PR also provides, for that crate:
+#   (a) a registered benchmark — a `[[benchmark]]` entry in bench/benchmarks.toml
+#       whose `source` references `crates/<x>` (matching the reactive rule's
+#       `source = crates/<x>` expectation in flow-on-rules.toml); OR the crate is
+#       an intentional stub marked `publish = false` in its Cargo.toml (the
+#       design's documented stub-exemption escape hatch);
+#   (b) a README.md (crates/<x>/README.md) — the template content itself is
+#       separately enforced by check-readme-template.py; G1 only requires its
+#       PRESENCE so a new crate is never undocumented;
+#   (c) a SKILL.md — ONLY if the crate is a PUBLIC surface. A crate is treated as
+#       public iff its Cargo.toml does NOT carry `publish = false`. A public crate
+#       must have at least one skills/<surface>/SKILL.md touched in the same PR
+#       (the AGENTS.md public-API → SKILL.md rule applied to a brand-new surface).
+#       A `publish = false` stub is internal-only and exempt from (c) — and, via
+#       the same marker, exempt from (a) as well.
+#
+# ESCAPE HATCH (design §2.1): `publish = false` in the new crate's Cargo.toml
+# marks it an intentional stub — exempt from the bench (a) and SKILL (c)
+# requirements. The README (b) is still required (a stub still needs a one-line
+# "what/why" README).
+#
+# DIFF SOURCE: the PR's changed-file list. In CI this is
+#   git diff --name-only origin/<base>...HEAD          (changed files)
+#   git diff --name-status origin/<base>...HEAD        (to find ADDED files)
+# In tests / --dry-run it is read from a fixture file (one path per line, each
+# optionally prefixed with a git status letter + tab, e.g. "A\tcrates/x/...").
+#
+# EXIT: 0 when every newly-added crate satisfies G1 (or there are none); 1 with a
+# clear per-crate message naming exactly what is missing otherwise.
+#
+# Usage:
+#   gate-new-crate.py                       # CI: derive diff from git vs origin/<base>
+#   gate-new-crate.py --base main           # override base ref
+#   gate-new-crate.py --advisory            # warn-only soft-launch (never exit 1)
+#   gate-new-crate.py --dry-run --changed-files files.txt   # hermetic (tests)
+#
+# stdlib-only.
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BENCH_REGISTRY = REPO_ROOT / "bench" / "benchmarks.toml"
+
+# A line in a status-prefixed diff: "A\tpath", "M\tpath", "R100\told\tnew", etc.
+_STATUS_RE = re.compile(r"^([A-Z])\d*\t(.*)$")
+
+
+def parse_status_lines(lines: list[str]) -> tuple[list[str], list[str]]:
+    """Split a `git diff --name-status`-style list into (changed, added).
+
+    Each line is either "<STATUS>\t<path>" (optionally "<STATUS>\t<old>\t<new>"
+    for renames/copies) or a bare path (treated as a generic change, NOT added).
+    Returns (all_changed_paths, added_paths)."""
+    changed: list[str] = []
+    added: list[str] = []
+    for raw in lines:
+        line = raw.rstrip("\n")
+        if not line.strip():
+            continue
+        m = _STATUS_RE.match(line)
+        if m:
+            status, rest = m.group(1), m.group(2)
+            # For renames/copies the destination path is the last tab field.
+            path = rest.split("\t")[-1]
+            changed.append(path)
+            if status == "A":
+                added.append(path)
+        else:
+            # Bare path (e.g. `git diff --name-only`): a change, not provably added.
+            changed.append(line)
+    return changed, added
+
+
+def _normalize_base(base: str) -> str:
+    """Accept a bare branch ('main') or a full ref ('refs/heads/main', as the
+    merge_group event supplies in github.event.merge_group.base_ref) and return
+    the remote-tracking ref to diff against ('origin/main')."""
+    base = base.strip()
+    if base.startswith("refs/heads/"):
+        base = base[len("refs/heads/") :]
+    # Already an origin/* ref — use as-is.
+    if base.startswith("origin/") or base == "HEAD":
+        return base
+    return f"origin/{base}"
+
+
+def git_diff(base: str) -> tuple[list[str], list[str]]:
+    """Return (changed, added) from git vs the base ref using a 3-dot diff."""
+    ref = _normalize_base(base)
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-status", f"{ref}...HEAD"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except subprocess.CalledProcessError as e:  # pragma: no cover - CI-only path
+        sys.stderr.write(f"error: git diff failed: {e.stderr}\n")
+        sys.exit(2)
+    return parse_status_lines(out.splitlines())
+
+
+def added_crates(added: list[str]) -> list[str]:
+    """Crate names whose Cargo.toml was ADDED (a brand-new crate)."""
+    crates: list[str] = []
+    for p in added:
+        m = re.match(r"^crates/([^/]+)/Cargo\.toml$", p)
+        if m:
+            crates.append(m.group(1))
+    # Stable, de-duplicated order.
+    seen: set[str] = set()
+    out: list[str] = []
+    for c in crates:
+        if c not in seen:
+            seen.add(c)
+            out.append(c)
+    return out
+
+
+def crate_is_stub(crate: str, changed: list[str]) -> bool:
+    """True iff the new crate's Cargo.toml declares `publish = false` (an
+    intentional stub, exempt from bench + SKILL requirements).
+
+    Reads the on-disk Cargo.toml in the worktree (the PR's checkout already has
+    the added file). In hermetic tests the file may not exist on disk; callers
+    pass the stub status explicitly via the fixture, so a missing file is simply
+    treated as NOT a stub (the strict default)."""
+    cargo = REPO_ROOT / "crates" / crate / "Cargo.toml"
+    try:
+        text = cargo.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return re.search(r"^\s*publish\s*=\s*false\b", text, re.MULTILINE) is not None
+
+
+def crate_has_registered_bench(crate: str) -> bool:
+    """True iff bench/benchmarks.toml has a `source` field referencing the crate.
+
+    Mirrors the reactive rule's expectation (`source = crates/<x>`): we match any
+    benchmark whose `source` line contains `crates/<crate>/` or `crates/<crate>"`
+    (end of the path component), so a registered bench for the crate counts."""
+    try:
+        text = BENCH_REGISTRY.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    needle = re.compile(
+        rf"^\s*source\s*=.*crates/{re.escape(crate)}(?:/|\b)", re.MULTILINE
+    )
+    return needle.search(text) is not None
+
+
+def evaluate(
+    changed: list[str],
+    added: list[str],
+    *,
+    stub_overrides: dict[str, bool] | None = None,
+    bench_overrides: dict[str, bool] | None = None,
+) -> list[tuple[str, list[str]]]:
+    """Return [(crate, [missing-reasons])] for every newly-added crate that
+    violates G1. An empty list means the gate PASSES.
+
+    stub_overrides / bench_overrides let hermetic tests inject the
+    publish-status and bench-registration facts without touching disk."""
+    stub_overrides = stub_overrides or {}
+    bench_overrides = bench_overrides or {}
+    violations: list[tuple[str, list[str]]] = []
+
+    for crate in added_crates(added):
+        is_stub = stub_overrides.get(crate)
+        if is_stub is None:
+            is_stub = crate_is_stub(crate, changed)
+
+        missing: list[str] = []
+
+        # (b) README.md — always required (even for stubs).
+        readme = f"crates/{crate}/README.md"
+        if readme not in changed:
+            missing.append(
+                f"a README at {readme} (added in the same PR)"
+            )
+
+        if not is_stub:
+            # (a) registered benchmark.
+            has_bench = bench_overrides.get(crate)
+            if has_bench is None:
+                has_bench = crate_has_registered_bench(crate)
+            if not has_bench:
+                missing.append(
+                    "a registered benchmark in bench/benchmarks.toml "
+                    f"(a [[benchmark]] whose `source` references crates/{crate}) "
+                    "— or mark the crate `publish = false` if it is an intentional stub"
+                )
+            # (c) SKILL.md — required because the crate is a public surface.
+            if not any(
+                p.startswith("skills/") and p.endswith("SKILL.md") for p in changed
+            ):
+                missing.append(
+                    "a skills/<surface>/SKILL.md for the new public surface "
+                    "(AGENTS.md public-API → SKILL.md rule) — or mark the crate "
+                    "`publish = false` if it is internal-only"
+                )
+
+        if missing:
+            violations.append((crate, missing))
+
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="G1 new-crate-completeness gate (sq-ncvq.4)."
+    )
+    ap.add_argument(
+        "--base",
+        default=os.environ.get("GATE_BASE_REF", "main"),
+        help="base ref to diff against (origin/<base>); default 'main'.",
+    )
+    ap.add_argument(
+        "--changed-files",
+        help="hermetic input: a file of diff lines (status-prefixed or bare paths).",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="never exit non-zero; print the verdict only (for local/testing).",
+    )
+    ap.add_argument(
+        "--advisory",
+        action="store_true",
+        help="soft-launch: report violations but always exit 0.",
+    )
+    args = ap.parse_args(argv)
+
+    if args.changed_files:
+        lines = Path(args.changed_files).read_text(encoding="utf-8").splitlines()
+        changed, added = parse_status_lines(lines)
+    else:
+        changed, added = git_diff(args.base)
+
+    violations = evaluate(changed, added)
+
+    if not violations:
+        print("G1 new-crate-completeness: PASS — no new crate missing artifacts.")
+        return 0
+
+    print("G1 new-crate-completeness: FAIL")
+    for crate, missing in violations:
+        print(f"\n  crates/{crate} is a new crate but is missing:")
+        for m in missing:
+            print(f"    - {m}")
+    print(
+        "\nA new crate must ship its maintenance artifacts in the SAME PR "
+        "(research/maintenance-flow-on-automation-design.md §2.1, gate G1). "
+        "Stub crates may set `publish = false` in Cargo.toml to opt out of the "
+        "bench + SKILL requirements (README still required)."
+    )
+
+    if args.advisory or args.dry_run:
+        print("\n(advisory/dry-run: not failing the build)")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gate-new-crate.py
+++ b/scripts/gate-new-crate.py
@@ -81,7 +81,12 @@ def parse_status_lines(lines: list[str]) -> tuple[list[str], list[str]]:
             # For renames/copies the destination path is the last tab field.
             path = rest.split("\t")[-1]
             changed.append(path)
-            if status == "A":
+            # [OPUS-4.8] `A` (added) and `C` (copied) both materialise a NEW
+            # destination path. Git only emits `C` with copy-detection enabled
+            # (-C/--find-copies), but if a crate directory is introduced via a
+            # copy the gate must still treat it as added, or new-crate detection
+            # could be evaded (accidentally or deliberately).
+            if status in ("A", "C"):
                 added.append(path)
         else:
             # Bare path (e.g. `git diff --name-only`): a change, not provably added.

--- a/scripts/tests/test_gates.py
+++ b/scripts/tests/test_gates.py
@@ -3,12 +3,15 @@
 # sq-ncvq.4 + sq-ncvq.5, epic sq-ncvq). Authored by Opus 4.8 (Fable unavailable;
 # flag for re-review when Fable returns).
 #
-# Fully hermetic: imports scripts/gate-new-crate.py + scripts/gate-api-skill.py
-# and drives their pure evaluate()/main() entry points against FIXTURE diff
-# listings. NO live git — the fact lookups that would hit disk/git (crate stub
-# status, bench registration, `pub`-diff heuristic) are injected via the
-# *_overrides kwargs, and main() is driven with --changed-files fixtures written
-# to a temp dir + --dry-run so it never shells out.
+# Hermetic w.r.t. git/network: imports scripts/gate-new-crate.py +
+# scripts/gate-api-skill.py and drives their pure evaluate()/main() entry points
+# against FIXTURE diff listings. NO live git and NO subprocess — the
+# evaluate()-level tests inject every git/subprocess fact (crate stub status,
+# bench registration, `pub`-diff heuristic) via the *_overrides kwargs, and
+# main() is driven with --changed-files fixtures + --dry-run so it never shells
+# out. [OPUS-4.8] (Caveat: the main() smoke tests call main() WITHOUT overrides,
+# so they may still consult the in-repo bench/benchmarks.toml on disk — that is a
+# committed file, not git/network state, so the runs stay deterministic.)
 #
 # Run:  python3 scripts/tests/test_gates.py
 # (stdlib only; no pytest required — also discoverable by `pytest`.)
@@ -124,6 +127,16 @@ class G1Test(unittest.TestCase):
         self.assertEqual(g1.added_crates(added), [])
         self.assertEqual(g1.evaluate(changed, added), [])
 
+    def test_copied_crate_counts_as_added(self):
+        # [OPUS-4.8] `git diff -C` reports a newly-introduced path as a copy
+        # (`C`/`C100`, "C<score>\t<old>\t<new>"); the destination must still be
+        # treated as added so a copy can't evade new-crate detection.
+        changed, added = g1.parse_status_lines(
+            ["C100\tcrates/sparq-old/Cargo.toml\tcrates/sparq-new/Cargo.toml"]
+        )
+        self.assertIn("crates/sparq-new/Cargo.toml", added)
+        self.assertEqual(g1.added_crates(added), ["sparq-new"])
+
 
 # --------------------------------------------------------------------------- #
 # G2 — public-api → skill
@@ -142,6 +155,27 @@ class G2Test(unittest.TestCase):
         ]
         ok, _ = g2.evaluate(changed, labels=[], base="main")
         self.assertTrue(ok)
+
+    def test_pub_diff_regex_excludes_restricted_visibility(self):
+        # [OPUS-4.8] The pub-diff heuristic must match exported items
+        # (`pub fn`/`pub use`/…) but NOT restricted visibilities
+        # (`pub(crate)`/`pub(super)`/`pub(in …)`), which are private surface.
+        # Guard: this pattern literal MUST mirror pub_api_changed's `pub_re`
+        # in scripts/gate-api-skill.py — assert that the source still uses it.
+        import inspect
+        import re
+
+        src = inspect.getsource(g2.pub_api_changed)
+        self.assertIn(r'r"^[+-]\s*pub\s"', src, "pub_re drifted from this test")
+        pub_re = re.compile(r"^[+-]\s*pub\s")
+        for exported in ("+pub fn foo()", "-pub use crate::X;", "+    pub struct S"):
+            self.assertTrue(pub_re.match(exported), exported)
+        for restricted in (
+            "+pub(crate) fn foo()",
+            "-pub(super) struct S",
+            "+    pub(in crate::a) const X: u8 = 0;",
+        ):
+            self.assertFalse(pub_re.match(restricted), restricted)
 
     def test_cli_change_suppressed_by_skill_not_needed_label(self):
         changed = ["crates/sparq-cli/src/main.rs"]

--- a/scripts/tests/test_gates.py
+++ b/scripts/tests/test_gates.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Hermetic tests for the proactive merge-gate scripts G1/G2 (beads
+# sq-ncvq.4 + sq-ncvq.5, epic sq-ncvq). Authored by Opus 4.8 (Fable unavailable;
+# flag for re-review when Fable returns).
+#
+# Fully hermetic: imports scripts/gate-new-crate.py + scripts/gate-api-skill.py
+# and drives their pure evaluate()/main() entry points against FIXTURE diff
+# listings. NO live git — the fact lookups that would hit disk/git (crate stub
+# status, bench registration, `pub`-diff heuristic) are injected via the
+# *_overrides kwargs, and main() is driven with --changed-files fixtures written
+# to a temp dir + --dry-run so it never shells out.
+#
+# Run:  python3 scripts/tests/test_gates.py
+# (stdlib only; no pytest required — also discoverable by `pytest`.)
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / filename)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+g1 = _load("gate_new_crate", "gate-new-crate.py")
+g2 = _load("gate_api_skill", "gate-api-skill.py")
+
+
+def _statused(added: list[str], modified: list[str] | None = None) -> list[str]:
+    """Build a `git diff --name-status`-style fixture listing."""
+    lines = [f"A\t{p}" for p in added]
+    lines += [f"M\t{p}" for p in (modified or [])]
+    return lines
+
+
+def _write(tmp: Path, name: str, lines: list[str]) -> str:
+    p = tmp / name
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(p)
+
+
+# --------------------------------------------------------------------------- #
+# G1 — new-crate-completeness
+# --------------------------------------------------------------------------- #
+class G1Test(unittest.TestCase):
+    def test_new_crate_with_nothing_else_fails(self):
+        changed, added = g1.parse_status_lines(
+            _statused(["crates/sparq-foo/Cargo.toml"])
+        )
+        violations = g1.evaluate(
+            changed,
+            added,
+            stub_overrides={"sparq-foo": False},
+            bench_overrides={"sparq-foo": False},
+        )
+        self.assertEqual(len(violations), 1)
+        crate, missing = violations[0]
+        self.assertEqual(crate, "sparq-foo")
+        # All three artifacts are missing: README, bench, SKILL.
+        self.assertEqual(len(missing), 3)
+        joined = " ".join(missing)
+        self.assertIn("README", joined)
+        self.assertIn("benchmark", joined)
+        self.assertIn("SKILL.md", joined)
+
+    def test_new_crate_with_bench_readme_skill_passes(self):
+        added = ["crates/sparq-foo/Cargo.toml", "crates/sparq-foo/README.md"]
+        modified = ["skills/sparq-foo/SKILL.md", "bench/benchmarks.toml"]
+        changed, added_paths = g1.parse_status_lines(_statused(added, modified))
+        violations = g1.evaluate(
+            changed,
+            added_paths,
+            stub_overrides={"sparq-foo": False},
+            bench_overrides={"sparq-foo": True},
+        )
+        self.assertEqual(violations, [])
+
+    def test_stub_crate_needs_only_readme(self):
+        # publish = false → bench + SKILL are waived; README still required.
+        added = ["crates/sparq-foo/Cargo.toml", "crates/sparq-foo/README.md"]
+        changed, added_paths = g1.parse_status_lines(_statused(added))
+        violations = g1.evaluate(
+            changed,
+            added_paths,
+            stub_overrides={"sparq-foo": True},
+            bench_overrides={"sparq-foo": False},
+        )
+        self.assertEqual(violations, [])
+
+    def test_stub_crate_missing_readme_still_fails(self):
+        changed, added = g1.parse_status_lines(
+            _statused(["crates/sparq-foo/Cargo.toml"])
+        )
+        violations = g1.evaluate(
+            changed, added, stub_overrides={"sparq-foo": True}
+        )
+        self.assertEqual(len(violations), 1)
+        _, missing = violations[0]
+        self.assertEqual(len(missing), 1)
+        self.assertIn("README", missing[0])
+
+    def test_no_new_crate_passes(self):
+        changed, added = g1.parse_status_lines(
+            _statused([], ["crates/sparq-cli/src/main.rs"])
+        )
+        self.assertEqual(g1.evaluate(changed, added), [])
+
+    def test_changed_not_added_cargo_does_not_trigger(self):
+        # An edit to an EXISTING crate's Cargo.toml is not a "new crate".
+        changed, added = g1.parse_status_lines(
+            _statused([], ["crates/sparq-cli/Cargo.toml"])
+        )
+        self.assertEqual(g1.added_crates(added), [])
+        self.assertEqual(g1.evaluate(changed, added), [])
+
+
+# --------------------------------------------------------------------------- #
+# G2 — public-api → skill
+# --------------------------------------------------------------------------- #
+class G2Test(unittest.TestCase):
+    def test_server_src_change_without_skill_fails(self):
+        changed = ["crates/sparq-server/src/routes.rs"]
+        ok, hits = g2.evaluate(changed, labels=[], base="main")
+        self.assertFalse(ok)
+        self.assertIn("crates/sparq-server/src/routes.rs", hits)
+
+    def test_server_src_change_with_skill_passes(self):
+        changed = [
+            "crates/sparq-server/src/routes.rs",
+            "skills/http-server/SKILL.md",
+        ]
+        ok, _ = g2.evaluate(changed, labels=[], base="main")
+        self.assertTrue(ok)
+
+    def test_cli_change_suppressed_by_skill_not_needed_label(self):
+        changed = ["crates/sparq-cli/src/main.rs"]
+        ok, _ = g2.evaluate(
+            changed, labels=["skill-not-needed"], base="main"
+        )
+        self.assertTrue(ok)
+
+    def test_published_crate_pub_change_without_skill_fails(self):
+        # A pub API change in a published (non-binding) crate is in scope.
+        path = "crates/sparq-core/src/store.rs"
+        ok, hits = g2.evaluate(
+            [path], labels=[], base="main", pub_overrides={path: True}
+        )
+        # crate_is_published reads disk; sparq-core has no publish=false, so it's
+        # published. The injected pub_override makes it a pub change.
+        self.assertFalse(ok)
+        self.assertIn(path, hits)
+
+    def test_published_crate_nonpub_change_passes(self):
+        # A non-pub internal change is NOT a public surface.
+        path = "crates/sparq-core/src/internal.rs"
+        ok, hits = g2.evaluate(
+            [path], labels=[], base="main", pub_overrides={path: False}
+        )
+        self.assertTrue(ok)
+        self.assertEqual(hits, [])
+
+    def test_non_surface_change_passes(self):
+        ok, hits = g2.evaluate(
+            ["research/notes.md", "bench/watdiv/run.sh"], labels=[], base="main"
+        )
+        self.assertTrue(ok)
+        self.assertEqual(hits, [])
+
+    def test_py_binding_change_without_skill_fails(self):
+        ok, hits = g2.evaluate(
+            ["crates/sparq-py/src/lib.rs"], labels=[], base="main"
+        )
+        self.assertFalse(ok)
+        self.assertIn("crates/sparq-py/src/lib.rs", hits)
+
+
+# --------------------------------------------------------------------------- #
+# main() smoke (hermetic, via --changed-files + --dry-run; no git/network)
+# --------------------------------------------------------------------------- #
+class MainSmokeTest(unittest.TestCase):
+    def test_g1_main_dry_run_reports_violation_but_exits_zero(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            f = _write(tmp, "diff.txt", _statused(["crates/sparq-zzznew/Cargo.toml"]))
+            rc = g1.main(["--dry-run", "--changed-files", f])
+            self.assertEqual(rc, 0)  # dry-run never fails
+
+    def test_g2_main_dry_run_on_clean_diff_passes(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            f = _write(tmp, "diff.txt", ["research/foo.md"])
+            rc = g2.main(["--dry-run", "--changed-files", f])
+            self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 SPARQ agent

Builds the **proactive / merge-time half** of the maintenance flow-on system (epic **sq-ncvq**, beads **sq-ncvq.4** G1 + **sq-ncvq.5** G2; design `research/maintenance-flow-on-automation-design.md` §2.1). These gates BLOCK a PR before merge when it would create maintenance debt — the complement of the REACTIVE auto-issue engine in PR #220 (`flow-on.yml` + `scripts/flow-on*.{py,toml}`), which mints follow-on *issues* after merge. The two halves are kept consistent (G2 suppression mirrors `flow-on.py`'s `SKILL_PATHS` exactly), so a PR a gate lets through is one the reactive engine would not re-flag. None of PR #220's files or `ci.yml`/`ci-summary.yml` are touched.

## The two gates

**G1 — new-crate-completeness** (`scripts/gate-new-crate.py`, sq-ncvq.4)
Trigger: a PR **adds** `crates/<x>/Cargo.toml`. Fails unless the same PR also provides, for that crate:
- (a) a **registered benchmark** — a `bench/benchmarks.toml` `[[benchmark]]` whose `source` references `crates/<x>`;
- (b) a **README** (`crates/<x>/README.md`);
- (c) a **SKILL.md** — only if the crate is a **public surface** (i.e. not `publish = false`).

Escape hatch (design §2.1): `publish = false` in the new crate's Cargo.toml marks an intentional stub, exempt from (a)+(c); the README (b) is still required.

**G2 — public-api→skill** (`scripts/gate-api-skill.py`, sq-ncvq.5)
Trigger: a change to a **public surface** — `sparq-cli`/`sparq-server`/`sparq-py`/`sparq-wasm` `src/**`, or a `pub` API change in a published crate's `src/**` — **without** a matching `skills/**/SKILL.md` edit in the same PR. Fails with a message pointing at the **AGENTS.md public-API → SKILL.md** rule. Suppression mirrors `flow-on.py`'s `SKILL_PATHS`: any `skills/**/SKILL.md` edit satisfies it. Escape hatch: the per-PR `skill-not-needed` label.

## Wiring — treated as GATING by the aggregator

New workflow `.github/workflows/flow-on-gates.yml` (on `pull_request` + `merge_group`). Its job names — `new-crate-completeness (G1)` and `public-api-skill (G2)` — contain **no** `advisory`/`informational`/`non-blocking` token, so the `ci-summary / gate` aggregator (the single required check on `main`) discovers them as REQUIRED gating check-runs and folds their conclusions into the merge verdict. **No branch-protection or `ci.yml`/`ci-summary.yml` edit is needed** — adding the workflow is sufficient. Actions are SHA-pinned (reusing `ci.yml`'s `actions/checkout` SHA). Scripts read the PR diff via `git diff --name-only origin/<base>...HEAD` and are stdlib-only.

## Verification
- `scripts/tests/test_gates.py` — 15 hermetic tests (no live git): new crate with nothing else → G1 fails; with bench+README+SKILL → passes; stub needs only README; `sparq-server`/`sparq-py` src change without SKILL → G2 fails; with SKILL (or `skill-not-needed` label) → passes.
- **No retro-break:** both gates run against current repo HEAD with no violation → PASS; synthetic violating diffs → exit 1.
- `ruff` clean, `actionlint` clean.

## Deferred (remaining sq-ncvq children)
G3 (new-bench→registry+dashboard), G4 (new-unsafe→justification), G5 (zk-circuit-member→gate-count), G6 (new-config/flag→docs) stay as deferred sq-ncvq children — not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)