### PR TITLE
feat(vectors): `vec:` magic predicate — vector KNN inside SPARQL (sq-k6ex)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3556,7 +3556,9 @@ dependencies = [
  "reqwest",
  "rustc-hash 2.1.2",
  "serde_json",
+ "spargebra",
  "sparq-core",
+ "sparq-engine",
  "sparq-sim",
 ]
 

--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -27,6 +27,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
+# [OPUS-4.8] sq-k6ex (epic sq-3183): the `vec:` magic predicates — vector KNN
+# search expressed INSIDE plain SPARQL, mirroring sparq-text's `text:` rewrite.
+# OPT-IN and OFF by default: only this feature pulls `sparq-engine` (+ spargebra)
+# into this crate's dependency graph, so the default `sparq-vectors` build — and the
+# `sparq-core`/`sparq-engine` base query path — carry ZERO `vec:`-predicate code and
+# gain no new required deps. Like `text:`, the rewrite runs entirely at the
+# spargebra-algebra level through the engine's prepared-query seam, so the engine —
+# planner, executor, wasm bundle — is completely unaware of vector search.
+vec-predicate = ["dep:sparq-engine", "dep:spargebra"]
 # API shape for a live OpenAI-compatible `/v1/embeddings` provider. The HTTP transport
 # is supplied by the CALLER (a `Transport` impl over their HTTP client of choice);
 # this crate never opens a socket. Pulls in serde_json for request/response bodies.
@@ -51,6 +60,14 @@ memmap2.workspace = true
 # cleaner fit for an in-RAM index rebuilt from the mmap'd store on open.
 instant-distance.workspace = true
 serde_json = { version = "1", optional = true }
+# [OPUS-4.8] sq-k6ex: the `vec:` magic-predicate rewrite executes through the engine's
+# prepared-query seam (`PreparedQuery: From<spargebra::Query>`). Both deps are OPTIONAL
+# and ONLY pulled in by the `vec-predicate` feature — the default build (and anything
+# that does not opt in) never compiles the engine, so `sparq-core`/`sparq-engine` stay
+# lean and this crate stays a pure storage+ANN crate by default. `spargebra` walks/edits
+# the parsed algebra; it is already in the workspace tree via sparq-engine.
+sparq-engine = { path = "../sparq-engine", version = "0.1.0", optional = true }
+spargebra = { workspace = true, optional = true }
 # [OPUS-4.8] Concrete HTTP transport for the non-default `embeddings` feature only.
 # Blocking by design (the embed call is synchronous and this crate must not drag an
 # async runtime into the tree) — mirrors sparq-nlq's `live` reqwest dependency exactly.

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -8,8 +8,25 @@ pub mod fuse;
 pub mod import;
 pub mod labels;
 pub mod quant;
+#[cfg(feature = "vec-predicate")]
+pub mod rewrite;
 pub mod store;
 pub mod verbalize;
+
+/// The `vec:` vocabulary — magic predicates recognised by [`rewrite`]
+/// (`http://sparq.dev/vec#`, the sparq extension namespace). [OPUS-4.8] (sq-k6ex)
+pub mod vocab {
+    /// `vec:` — the sparq vector-search namespace.
+    pub const VEC_NS: &str = "http://sparq.dev/vec#";
+    /// `?node vec:nearest ( <query> <k> )` — binds `?node` to the `<k>` nearest
+    /// neighbours (best first) of `<query>`, which is either a node IRI (whose
+    /// stored vector is the query, the seed excluded) or a comma-separated
+    /// vector literal.
+    pub const NEAREST: &str = "http://sparq.dev/vec#nearest";
+    /// `( ?node ?score ) vec:search ( <query> <k> )` — like [`NEAREST`] but also
+    /// binds `?score` to each neighbour's cosine similarity (`xsd:double`).
+    pub const SEARCH: &str = "http://sparq.dev/vec#search";
+}
 
 pub use ann::{
     cosine, nearest_exact, nearest_term_exact, nearest_term_exact_checked, HnswConfig, VectorIndex,
@@ -23,6 +40,13 @@ pub use labels::{embed_labels, embed_labels_with, LabelConfig};
 pub use quant::{
     cosine_from_sq_dist, DistanceTable, EncodedStore, PqConfig, ProductQuantizer, ScalarQuantizer,
 };
+#[cfg(feature = "vec-predicate")]
+pub use rewrite::{prepare_vec, query_vec, query_vec_with_budget, rewrite_query};
+// Re-export the engine result/budget types the `vec:` entry points return/take, so
+// callers (and tests) need not also declare a direct `sparq-engine` dependency.
+// [OPUS-4.8] (sq-k6ex)
+#[cfg(feature = "vec-predicate")]
+pub use sparq_engine::{PreparedQuery, QueryBudget, QueryResult};
 pub use store::{StreamingWriter, VectorStore, SPQV_MAGIC, SPQV_VERSION};
 pub use verbalize::{
     description_predicates, embed_entities, label_predicates, verbalize, EntityTextConfig,

--- a/crates/sparq-vectors/src/rewrite.rs
+++ b/crates/sparq-vectors/src/rewrite.rs
@@ -1,0 +1,488 @@
+//! The `vec:` magic predicates: vector k-NN search inside plain SPARQL, with
+//! ZERO engine changes. [OPUS-4.8] (sq-k6ex, epic sq-3183)
+//!
+//! ```
+//! use sparq_core::Graph;
+//! use sparq_vectors::VectorStore;
+//! use oxrdf::NamedNode;
+//!
+//! # fn doit() -> Result<(), String> {
+//! let g = Graph::load_str(r#"
+//!     <http://ex/a> <http://ex/p> "a" .
+//!     <http://ex/b> <http://ex/p> "b" .
+//!     <http://ex/c> <http://ex/p> "c" .
+//! "#, "ntriples").unwrap();
+//! let id = |s: &str| g.id_of(&NamedNode::new(s).unwrap().into()).unwrap();
+//! let path = std::env::temp_dir().join("sparq_vec_doctest.spqv");
+//! let mut store = VectorStore::create(&path, 2).unwrap();
+//! store.put(id("http://ex/a"), &[1.0, 0.0]).unwrap();
+//! store.put(id("http://ex/b"), &[0.0, 1.0]).unwrap();
+//! store.put(id("http://ex/c"), &[0.9, 0.1]).unwrap();
+//! // The two entities most aligned with the x-axis query vector "1,0".
+//! let r = sparq_vectors::query_vec(&g,
+//!     "PREFIX vec: <http://sparq.dev/vec#>
+//!      SELECT ?node WHERE { ?node vec:nearest ( \"1,0\" 2 ) }",
+//!     &store)?;
+//! assert_eq!(r.len(), 2); // <http://ex/a> and <http://ex/c>
+//! # Ok(()) }
+//! # doit().unwrap();
+//! ```
+//!
+//! ## The rewrite
+//!
+//! [`rewrite_query`] walks the parsed spargebra algebra; in every basic graph
+//! pattern, each magic triple pattern
+//!
+//! - `?node vec:nearest ( <query> <k> )` — bind `?node` to the `<k>` nearest
+//!   neighbours (best first) of the query;
+//! - `( ?node ?score ) vec:search ( <query> <k> )` — the same, additionally
+//!   binding `?score` to each neighbour's cosine similarity (`xsd:double`).
+//!
+//! is REMOVED and replaced by an inline [`Values`](GraphPattern::Values) table
+//! of the search hits — the neighbour graph nodes (and, for `vec:search`, their
+//! scores), resolved through the graph's dictionary. The surrounding query then
+//! joins those nodes to triples through the store's ordinary permutation
+//! indexes; the rewritten algebra runs through sparq-engine's prepared-query
+//! seam ([`PreparedQuery`]`: From<spargebra::Query>`), so the engine — planner,
+//! executor, wasm bundle — is completely unaware of vector search.
+//!
+//! The argument lists `( … )` are ordinary SPARQL RDF collections — spargebra
+//! lowers them to `rdf:first`/`rdf:rest` blank-node chains in the same BGP, and
+//! the rewrite walks those chains back into the argument tuple, so the surface
+//! is plain SPARQL with no custom grammar.
+//!
+//! ## The query argument
+//!
+//! `<query>` is a **constant**, either of:
+//!
+//! - a **node IRI** (`<http://ex/seed>`) whose stored vector is the query — the
+//!   "neighbours of this entity" form (the seed is itself excluded from its
+//!   neighbours); empty if the IRI is absent from the graph or unembedded;
+//! - a **vector literal** — a comma-separated list of `dim` floats
+//!   (`"0.1,0.9,..."`) — a query-by-vector. The dimension must match the store.
+//!
+//! `<k>` is a **constant** non-negative integer literal.
+//!
+//! ## Constraints (each a hard query error, not a silent mismatch)
+//!
+//! the neighbour position(s) must be variables; the query/`k` arguments must be
+//! constants (bind-time rewriting has no per-row values); the object argument
+//! list must be exactly `( query k )`, and the `vec:search` subject list exactly
+//! `( ?node ?score )` with both positions variables. Any other IRI in the `vec:`
+//! namespace is unknown.
+//!
+//! Result ordering: `VALUES` rows carry no order through joins — sort with
+//! `ORDER BY DESC(?score)` over a `vec:search` score variable to recover the
+//! best-first order in the output.
+//!
+//! The store is per-graph (dictionary-local ids), so hits come from the store
+//! you pass — typically the one built against the default graph.
+
+use crate::ann::nearest_exact;
+use crate::store::VectorStore;
+use crate::vocab;
+use oxrdf::{Literal, NamedNode, Term};
+use rustc_hash::FxHashMap;
+use spargebra::algebra::GraphPattern;
+use spargebra::term::{GroundTerm, NamedNodePattern, TermPattern, TriplePattern, Variable};
+use spargebra::Query;
+use sparq_core::dict::Id;
+use sparq_core::Graph;
+use sparq_engine::{PreparedQuery, QueryBudget, QueryResult};
+
+/// `rdf:first`, `rdf:rest`, `rdf:nil` — the collection vocabulary spargebra
+/// lowers `( … )` argument lists into.
+const RDF_FIRST: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#first";
+const RDF_REST: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest";
+const RDF_NIL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
+
+/// Executes a SPARQL query that may use the `vec:` magic predicates: parse,
+/// [`rewrite_query`], then evaluate with the standard engine.
+pub fn query_vec(graph: &Graph, sparql: &str, store: &VectorStore) -> Result<QueryResult, String> {
+    sparq_engine::query_prepared(graph, &prepare_vec(graph, sparql, store)?)
+}
+
+/// [`query_vec`] under a cooperative [`QueryBudget`].
+pub fn query_vec_with_budget(
+    graph: &Graph,
+    sparql: &str,
+    store: &VectorStore,
+    budget: &QueryBudget,
+) -> Result<QueryResult, String> {
+    sparq_engine::query_prepared_with_budget(graph, &prepare_vec(graph, sparql, store)?, budget)
+}
+
+/// Parses and rewrites into a [`PreparedQuery`] — compose with any of the
+/// engine's `*_prepared` entry points (`ask_prepared`, `construct_prepared`,
+/// …). Note the hits are frozen at rewrite time: re-prepare after the graph
+/// (and store) change.
+pub fn prepare_vec(
+    graph: &Graph,
+    sparql: &str,
+    store: &VectorStore,
+) -> Result<PreparedQuery, String> {
+    let query = spargebra::SparqlParser::new()
+        .parse_query(sparql)
+        .map_err(|e| e.to_string())?;
+    Ok(PreparedQuery::from(rewrite_query(query, graph, store)?))
+}
+
+/// Rewrites every `vec:` magic pattern in the query into inline `VALUES` over
+/// the search hits (see the module docs). A query without `vec:` patterns
+/// passes through unchanged.
+pub fn rewrite_query(
+    mut query: Query,
+    graph: &Graph,
+    store: &VectorStore,
+) -> Result<Query, String> {
+    let pattern = match &mut query {
+        Query::Select { pattern, .. }
+        | Query::Construct { pattern, .. }
+        | Query::Describe { pattern, .. }
+        | Query::Ask { pattern, .. } => pattern,
+    };
+    rewrite_pattern(pattern, graph, store)?;
+    Ok(query)
+}
+
+/// Recursively rewrites the magic patterns inside `p`.
+fn rewrite_pattern(p: &mut GraphPattern, graph: &Graph, store: &VectorStore) -> Result<(), String> {
+    match p {
+        GraphPattern::Bgp { patterns } => {
+            let patterns = std::mem::take(patterns);
+            *p = rewrite_bgp(patterns, graph, store)?;
+        }
+        GraphPattern::Join { left, right }
+        | GraphPattern::LeftJoin { left, right, .. }
+        | GraphPattern::Union { left, right }
+        | GraphPattern::Minus { left, right }
+        | GraphPattern::Lateral { left, right } => {
+            rewrite_pattern(left, graph, store)?;
+            rewrite_pattern(right, graph, store)?;
+        }
+        GraphPattern::Filter { inner, .. }
+        | GraphPattern::Graph { inner, .. }
+        | GraphPattern::Extend { inner, .. }
+        | GraphPattern::OrderBy { inner, .. }
+        | GraphPattern::Project { inner, .. }
+        | GraphPattern::Distinct { inner }
+        | GraphPattern::Reduced { inner }
+        | GraphPattern::Slice { inner, .. }
+        | GraphPattern::Group { inner, .. }
+        | GraphPattern::Service { inner, .. } => rewrite_pattern(inner, graph, store)?,
+        // No BGPs inside: property paths and inline VALUES pass through.
+        GraphPattern::Path { .. } | GraphPattern::Values { .. } => {}
+    }
+    Ok(())
+}
+
+/// The query a `vec:` request searches by.
+enum QueryArg {
+    /// A node IRI whose stored vector is the query (and which is excluded from
+    /// its own neighbours).
+    Node(NamedNode),
+    /// An explicit query vector parsed from a comma-separated literal.
+    Vector(Vec<f32>),
+}
+
+/// One `vec:nearest`/`vec:search` request found in a BGP. The `score` variable
+/// is `Some` only for the `vec:search` form. [OPUS-4.8]
+struct KnnReq {
+    node: Variable,
+    score: Option<Variable>,
+    query: QueryArg,
+    k: usize,
+}
+
+/// Splits a BGP's `vec:` magic patterns out, runs the k-NN search, and joins
+/// the `VALUES` hit tables onto the remaining ordinary patterns. The collection
+/// (`rdf:first`/`rdf:rest`) triples that spargebra emitted for the argument
+/// lists are consumed by the rewrite and removed from the surviving BGP.
+fn rewrite_bgp(
+    patterns: Vec<TriplePattern>,
+    graph: &Graph,
+    store: &VectorStore,
+) -> Result<GraphPattern, String> {
+    // Index the rdf:first/rdf:rest triples by their (blank-node) list-cell
+    // subject so the magic-predicate handlers can walk each `( … )` chain.
+    let lists = ListCells::collect(&patterns);
+
+    let mut rest: Vec<TriplePattern> = Vec::with_capacity(patterns.len());
+    let mut reqs: Vec<KnnReq> = Vec::new();
+
+    for tp in &patterns {
+        // The collection-cell triples are an implementation detail of the
+        // argument lists; once consumed they must not survive into the engine.
+        if is_list_triple(tp) {
+            continue;
+        }
+        let NamedNodePattern::NamedNode(pred) = &tp.predicate else {
+            rest.push(tp.clone());
+            continue;
+        };
+        let iri = pred.as_str();
+        if !iri.starts_with(vocab::VEC_NS) {
+            rest.push(tp.clone());
+            continue;
+        }
+        match iri {
+            vocab::NEAREST => reqs.push(parse_nearest(tp, &lists)?),
+            vocab::SEARCH => reqs.push(parse_search(tp, &lists)?),
+            _ => {
+                return Err(format!(
+                    "vec: unknown magic predicate <{iri}> (supported: vec:nearest, vec:search)"
+                ))
+            }
+        }
+    }
+
+    // Join the hit tables onto the remaining ordinary patterns.
+    let mut out = GraphPattern::Bgp { patterns: rest };
+    for req in reqs {
+        let hits = run_knn(&req, graph, store)?;
+        let mut variables = vec![req.node];
+        if let Some(s) = &req.score {
+            variables.push(s.clone());
+        }
+        let score_wanted = req.score.is_some();
+        let bindings = hits
+            .into_iter()
+            .filter_map(|(id, score)| {
+                // Neighbour ids resolve to graph nodes (IRIs/literals); a blank
+                // node cannot appear in a VALUES row, so skip it (entities embed
+                // as IRIs in practice).
+                let node = term_to_ground(graph.dict.term(id))?;
+                let mut row = vec![Some(node)];
+                if score_wanted {
+                    row.push(Some(GroundTerm::Literal(Literal::from(f64::from(score)))));
+                }
+                Some(row)
+            })
+            .collect();
+        let values = GraphPattern::Values {
+            variables,
+            bindings,
+        };
+        out = match out {
+            // An all-magic BGP leaves an empty Bgp behind: drop the unit table.
+            GraphPattern::Bgp { ref patterns } if patterns.is_empty() => values,
+            other => GraphPattern::Join {
+                left: Box::new(values),
+                right: Box::new(other),
+            },
+        };
+    }
+    Ok(out)
+}
+
+/// True for the `rdf:first`/`rdf:rest` triples spargebra emits for a `( … )`
+/// collection — these are consumed by the rewrite, not passed to the engine.
+fn is_list_triple(tp: &TriplePattern) -> bool {
+    matches!(&tp.predicate, NamedNodePattern::NamedNode(p) if p.as_str() == RDF_FIRST || p.as_str() == RDF_REST)
+}
+
+/// The `rdf:first`/`rdf:rest` cells of every collection in a BGP, keyed by the
+/// list-cell blank node, so an argument list can be walked from its head.
+struct ListCells<'a> {
+    /// blank-node id → (first element, rest cell)
+    cells: FxHashMap<&'a str, (&'a TermPattern, &'a TermPattern)>,
+}
+
+impl<'a> ListCells<'a> {
+    fn collect(patterns: &'a [TriplePattern]) -> ListCells<'a> {
+        let mut firsts: FxHashMap<&str, &TermPattern> = FxHashMap::default();
+        let mut rests: FxHashMap<&str, &TermPattern> = FxHashMap::default();
+        for tp in patterns {
+            let TermPattern::BlankNode(b) = &tp.subject else {
+                continue;
+            };
+            let NamedNodePattern::NamedNode(p) = &tp.predicate else {
+                continue;
+            };
+            match p.as_str() {
+                RDF_FIRST => {
+                    firsts.insert(b.as_str(), &tp.object);
+                }
+                RDF_REST => {
+                    rests.insert(b.as_str(), &tp.object);
+                }
+                _ => {}
+            }
+        }
+        let cells = firsts
+            .iter()
+            .filter_map(|(&b, &first)| rests.get(b).map(|&rest| (b, (first, rest))))
+            .collect();
+        ListCells { cells }
+    }
+
+    /// Walks the collection whose head is `head` into its element [`TermPattern`]s.
+    /// `head` is the object/subject of a `vec:` predicate — a blank-node list
+    /// head, or `rdf:nil` for the empty list. Errors if the chain is malformed
+    /// (dangling cell, or a non-collection term where a list was required).
+    fn elements(&self, head: &'a TermPattern) -> Result<Vec<&'a TermPattern>, String> {
+        let mut out = Vec::new();
+        let mut cur = head;
+        let mut guard = 0usize;
+        loop {
+            match cur {
+                TermPattern::NamedNode(n) if n.as_str() == RDF_NIL => return Ok(out),
+                TermPattern::BlankNode(b) => {
+                    let Some(&(first, rest)) = self.cells.get(b.as_str()) else {
+                        return Err(
+                            "vec: malformed argument list (dangling rdf:rest cell)".to_string()
+                        );
+                    };
+                    out.push(first);
+                    cur = rest;
+                }
+                other => {
+                    return Err(format!(
+                        "vec: a vec: predicate requires a `( … )` argument list, got {other}"
+                    ))
+                }
+            }
+            guard += 1;
+            if guard > 1 << 20 {
+                return Err("vec: argument list is cyclic".to_string());
+            }
+        }
+    }
+}
+
+/// Parses `?node vec:nearest ( <query> <k> )`.
+fn parse_nearest(tp: &TriplePattern, lists: &ListCells) -> Result<KnnReq, String> {
+    let node = require_var(&tp.subject, "the subject of vec:nearest")?;
+    let (query, k) = parse_obj_args(&tp.object, lists)?;
+    Ok(KnnReq {
+        node,
+        score: None,
+        query,
+        k,
+    })
+}
+
+/// Parses `( ?node ?score ) vec:search ( <query> <k> )`.
+fn parse_search(tp: &TriplePattern, lists: &ListCells) -> Result<KnnReq, String> {
+    let subj = lists.elements(&tp.subject)?;
+    let [node, score] = subj.as_slice() else {
+        return Err(format!(
+            "vec: the subject of vec:search must be a 2-element list ( ?node ?score ), got {} \
+             element(s)",
+            subj.len()
+        ));
+    };
+    let node = require_var(node, "the first vec:search subject element")?;
+    let score = require_var(score, "the second vec:search subject element")?;
+    let (query, k) = parse_obj_args(&tp.object, lists)?;
+    Ok(KnnReq {
+        node,
+        score: Some(score),
+        query,
+        k,
+    })
+}
+
+/// Decodes the `( <query> <k> )` object argument list shared by both predicates.
+fn parse_obj_args(o: &TermPattern, lists: &ListCells) -> Result<(QueryArg, usize), String> {
+    let args = lists.elements(o)?;
+    let [query, k] = args.as_slice() else {
+        return Err(format!(
+            "vec: the argument list must be ( <query> <k> ) — exactly two elements, got {}",
+            args.len()
+        ));
+    };
+    Ok((parse_query_arg(query)?, parse_k(k)?))
+}
+
+/// `<query>` → an entity IRI or a parsed comma-separated query vector.
+fn parse_query_arg(t: &TermPattern) -> Result<QueryArg, String> {
+    match t {
+        TermPattern::NamedNode(n) => Ok(QueryArg::Node(n.clone())),
+        TermPattern::Literal(l) => {
+            let v: Result<Vec<f32>, _> = l
+                .value()
+                .split(',')
+                .map(|s| s.trim().parse::<f32>())
+                .collect();
+            let v = v.map_err(|_| {
+                format!(
+                    "vec: the query literal must be a comma-separated list of floats, got \"{}\"",
+                    l.value()
+                )
+            })?;
+            if v.is_empty() {
+                return Err("vec: the query vector literal is empty".to_string());
+            }
+            Ok(QueryArg::Vector(v))
+        }
+        other => Err(format!(
+            "vec: the query argument must be a node IRI or a vector literal, got {other}"
+        )),
+    }
+}
+
+/// `<k>` → a non-negative integer.
+fn parse_k(t: &TermPattern) -> Result<usize, String> {
+    let TermPattern::Literal(l) = t else {
+        return Err(format!(
+            "vec: k must be a non-negative integer literal, got {t}"
+        ));
+    };
+    l.value().parse::<usize>().map_err(|_| {
+        format!(
+            "vec: k must be a non-negative integer, got \"{}\"",
+            l.value()
+        )
+    })
+}
+
+/// Requires `t` to be a bare variable; `what` names the position for errors.
+fn require_var(t: &TermPattern, what: &str) -> Result<Variable, String> {
+    match t {
+        TermPattern::Variable(v) => Ok(v.clone()),
+        other => Err(format!("vec: {what} must be a variable, got {other}")),
+    }
+}
+
+/// Maps a dictionary [`Term`] to a [`GroundTerm`] for a VALUES row, or `None`
+/// for a blank node / quoted triple (not expressible in a VALUES neighbour slot).
+fn term_to_ground(t: Term) -> Option<GroundTerm> {
+    match t {
+        Term::NamedNode(n) => Some(GroundTerm::NamedNode(n)),
+        Term::Literal(l) => Some(GroundTerm::Literal(l)),
+        _ => None,
+    }
+}
+
+/// Runs the k-NN search for `req` and returns `(neighbour id, cosine score)`
+/// pairs, best first.
+fn run_knn(req: &KnnReq, graph: &Graph, store: &VectorStore) -> Result<Vec<(Id, f32)>, String> {
+    match &req.query {
+        QueryArg::Node(iri) => {
+            let term = Term::NamedNode(iri.clone());
+            let Some(id) = graph.id_of(&term) else {
+                return Ok(Vec::new());
+            };
+            let Some(query) = store.get(id) else {
+                return Ok(Vec::new());
+            };
+            // Over-fetch by one and drop the seed itself.
+            Ok(nearest_exact(store, query, req.k + 1)
+                .into_iter()
+                .filter(|&(n, _)| n != id)
+                .take(req.k)
+                .collect())
+        }
+        QueryArg::Vector(v) => {
+            if v.len() != store.dim() {
+                return Err(format!(
+                    "vec: query vector has {} dims but the store has {}",
+                    v.len(),
+                    store.dim()
+                ));
+            }
+            Ok(nearest_exact(store, v, req.k))
+        }
+    }
+}

--- a/crates/sparq-vectors/src/rewrite.rs
+++ b/crates/sparq-vectors/src/rewrite.rs
@@ -121,6 +121,14 @@ pub fn prepare_vec(
     sparql: &str,
     store: &VectorStore,
 ) -> Result<PreparedQuery, String> {
+    // [OPUS-4.8] Opportunistic staleness guard: the store is keyed by `graph`'s
+    // dictionary ids, so a store built against a DIFFERENT graph would silently
+    // mis-resolve neighbours. If the store carries a graph fingerprint, verify
+    // it now (hard error on mismatch). Unbound / legacy (version-1) stores carry
+    // no fingerprint and are left to work as before — we only check when we can.
+    if store.fingerprint().is_some() {
+        store.check_graph(graph)?;
+    }
     let query = spargebra::SparqlParser::new()
         .parse_query(sparql)
         .map_err(|e| e.to_string())?;
@@ -209,11 +217,20 @@ fn rewrite_bgp(
 
     let mut rest: Vec<TriplePattern> = Vec::with_capacity(patterns.len());
     let mut reqs: Vec<KnnReq> = Vec::new();
+    // [OPUS-4.8] Blank-node-subject rdf:first/rdf:rest cells are the lowered
+    // form of `( … )` argument lists. They are only an implementation detail of
+    // a `vec:` predicate, so we *defer* the decision to drop them: they are
+    // consumed (removed) ONLY if this BGP actually contains a `vec:` request.
+    // If no `vec:` predicate is present the BGP passes through unchanged —
+    // including any legitimate RDF-collection query — and these deferred cells
+    // are restored into `rest` below. User-authored `rdf:first`/`rest` patterns
+    // with variable/IRI subjects are never deferred (they fall through to
+    // `rest` like any other ordinary pattern).
+    let mut deferred_lists: Vec<&TriplePattern> = Vec::new();
 
     for tp in &patterns {
-        // The collection-cell triples are an implementation detail of the
-        // argument lists; once consumed they must not survive into the engine.
-        if is_list_triple(tp) {
+        if is_list_cell(tp) {
+            deferred_lists.push(tp);
             continue;
         }
         let NamedNodePattern::NamedNode(pred) = &tp.predicate else {
@@ -234,6 +251,13 @@ fn rewrite_bgp(
                 ))
             }
         }
+    }
+
+    // No `vec:` request in this BGP: it (and any RDF-collection cells in it)
+    // must pass through completely unchanged.
+    if reqs.is_empty() {
+        rest.extend(deferred_lists.into_iter().cloned());
+        return Ok(GraphPattern::Bgp { patterns: rest });
     }
 
     // Join the hit tables onto the remaining ordinary patterns.
@@ -275,10 +299,17 @@ fn rewrite_bgp(
     Ok(out)
 }
 
-/// True for the `rdf:first`/`rdf:rest` triples spargebra emits for a `( … )`
-/// collection — these are consumed by the rewrite, not passed to the engine.
-fn is_list_triple(tp: &TriplePattern) -> bool {
-    matches!(&tp.predicate, NamedNodePattern::NamedNode(p) if p.as_str() == RDF_FIRST || p.as_str() == RDF_REST)
+/// True for a *synthetic* list-cell triple — a `rdf:first`/`rdf:rest` triple
+/// with a **blank-node subject**, the exact shape spargebra emits when it lowers
+/// a `( … )` collection. [OPUS-4.8] The blank-node-subject restriction is
+/// load-bearing: it means user-authored collection patterns with variable or
+/// IRI subjects (e.g. `?x rdf:first ?y`) are NOT treated as argument-list cells
+/// and survive into the engine. (Combined with the caller only dropping these
+/// when a `vec:` predicate is present, a query with no `vec:` pattern is left
+/// entirely unchanged.)
+fn is_list_cell(tp: &TriplePattern) -> bool {
+    matches!(&tp.subject, TermPattern::BlankNode(_))
+        && matches!(&tp.predicate, NamedNodePattern::NamedNode(p) if p.as_str() == RDF_FIRST || p.as_str() == RDF_REST)
 }
 
 /// The `rdf:first`/`rdf:rest` cells of every collection in a BGP, keyed by the

--- a/crates/sparq-vectors/tests/vec_predicate.rs
+++ b/crates/sparq-vectors/tests/vec_predicate.rs
@@ -1,0 +1,219 @@
+//! End-to-end tests for the `vec:` magic predicates (sq-k6ex): real SPARQL
+//! queries with `vec:nearest` / `vec:search` evaluated against a tiny in-memory
+//! `.spqv` vector store, asserting the expected neighbours. [OPUS-4.8]
+#![cfg(feature = "vec-predicate")]
+
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+use sparq_vectors::{query_vec, QueryResult, VectorStore};
+
+fn tmp_path(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "sparq_vec_pred_{}_{}.spqv",
+        std::process::id(),
+        name
+    ));
+    p
+}
+
+/// Five entities on the unit circle; a-style vectors point along +x, b-style
+/// along +y, plus a near-x entity. The store is built (not finalized) in memory
+/// — `nearest_exact` scans the build-phase backing directly.
+fn fixture(name: &str) -> (Graph, VectorStore) {
+    let g = Graph::load_str(
+        r#"
+        <http://ex/a> <http://ex/label> "alpha" .
+        <http://ex/b> <http://ex/label> "beta" .
+        <http://ex/c> <http://ex/label> "gamma" .
+        <http://ex/d> <http://ex/label> "delta" .
+        <http://ex/e> <http://ex/label> "epsilon" .
+        "#,
+        "ntriples",
+    )
+    .unwrap();
+    let id = |s: &str| {
+        g.id_of(&Term::NamedNode(NamedNode::new(s).unwrap()))
+            .unwrap()
+    };
+    let mut store = VectorStore::create(tmp_path(name), 2).unwrap();
+    store.put(id("http://ex/a"), &[1.0, 0.0]).unwrap(); // +x
+    store.put(id("http://ex/b"), &[0.0, 1.0]).unwrap(); // +y
+    store.put(id("http://ex/c"), &[0.9, 0.1]).unwrap(); // near +x
+    store.put(id("http://ex/d"), &[-1.0, 0.0]).unwrap(); // -x
+    store.put(id("http://ex/e"), &[0.2, 0.98]).unwrap(); // near +y
+    (g, store)
+}
+
+/// Collects the single-projection IRI column of a result, in row order.
+fn iris(r: &QueryResult, col: usize) -> Vec<String> {
+    r.rows
+        .iter()
+        .filter_map(|row| match &row[col] {
+            Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn nearest_by_query_vector() {
+    let (g, store) = fixture("nearest_vec");
+    // Query "1,0" → the two most +x-aligned: a (exact) then c.
+    let r = query_vec(
+        &g,
+        "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?node WHERE { ?node vec:nearest ( \"1,0\" 2 ) }",
+        &store,
+    )
+    .unwrap();
+    let got = iris(&r, 0);
+    assert_eq!(
+        got,
+        vec!["http://ex/a".to_string(), "http://ex/c".to_string()],
+        "{r:?}"
+    );
+}
+
+#[test]
+fn nearest_by_seed_iri_excludes_self() {
+    let (g, store) = fixture("nearest_seed");
+    // Neighbours of <a> (which is +x); a itself is excluded → c is nearest.
+    let r = query_vec(
+        &g,
+        "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?node WHERE { ?node vec:nearest ( <http://ex/a> 1 ) }",
+        &store,
+    )
+    .unwrap();
+    let got = iris(&r, 0);
+    assert_eq!(
+        got,
+        vec!["http://ex/c".to_string()],
+        "seed must be excluded: {r:?}"
+    );
+}
+
+#[test]
+fn nearest_joins_to_surrounding_bgp() {
+    let (g, store) = fixture("nearest_join");
+    // The neighbours' labels, joined through the ordinary triple pattern.
+    let r = query_vec(
+        &g,
+        "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?label WHERE {
+           ?node vec:nearest ( \"0,1\" 2 ) .
+           ?node <http://ex/label> ?label .
+         }",
+        &store,
+    )
+    .unwrap();
+    let mut labels: Vec<String> = r
+        .rows
+        .iter()
+        .filter_map(|row| match &row[0] {
+            Some(Term::Literal(l)) => Some(l.value().to_string()),
+            _ => None,
+        })
+        .collect();
+    labels.sort();
+    // "0,1" → b (+y) and e (near +y): labels beta, epsilon.
+    assert_eq!(
+        labels,
+        vec!["beta".to_string(), "epsilon".to_string()],
+        "{r:?}"
+    );
+}
+
+#[test]
+fn search_binds_score_and_orders() {
+    let (g, store) = fixture("search_score");
+    // vec:search binds the cosine score; ORDER BY DESC recovers best-first.
+    let r = query_vec(
+        &g,
+        "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?node ?score WHERE {
+           ( ?node ?score ) vec:search ( \"1,0\" 3 )
+         } ORDER BY DESC(?score)",
+        &store,
+    )
+    .unwrap();
+    let order = iris(&r, 0);
+    // a (cos 1.0) > c (cos ~0.994) > b/e/d further; top-3 best-first.
+    assert_eq!(
+        order,
+        vec![
+            "http://ex/a".to_string(),
+            "http://ex/c".to_string(),
+            "http://ex/e".to_string()
+        ],
+        "{r:?}"
+    );
+    // a's score is ~1.0 (exact alignment).
+    let a_score = match &r.rows[0][1] {
+        Some(Term::Literal(l)) => l.value().parse::<f64>().unwrap(),
+        other => panic!("expected score literal, got {other:?}"),
+    };
+    assert!(
+        (a_score - 1.0).abs() < 1e-5,
+        "a should be cosine 1.0, got {a_score}"
+    );
+}
+
+#[test]
+fn unembedded_seed_yields_no_rows() {
+    let (g, store) = fixture("missing_seed");
+    let r = query_vec(
+        &g,
+        "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?node WHERE { ?node vec:nearest ( <http://ex/nope> 5 ) }",
+        &store,
+    )
+    .unwrap();
+    assert!(
+        r.is_empty(),
+        "an unembedded/absent seed has no neighbours: {r:?}"
+    );
+}
+
+#[test]
+fn dimension_mismatch_is_an_error() {
+    let (g, store) = fixture("dim_mismatch");
+    let err = query_vec(
+        &g,
+        "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?node WHERE { ?node vec:nearest ( \"1,0,0\" 2 ) }",
+        &store,
+    )
+    .unwrap_err();
+    assert!(
+        err.contains("dims"),
+        "expected a dimension error, got: {err}"
+    );
+}
+
+#[test]
+fn unknown_vec_predicate_is_rejected() {
+    let (g, store) = fixture("unknown_pred");
+    let err = query_vec(
+        &g,
+        "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?node WHERE { ?node vec:teleport ( \"1,0\" 2 ) }",
+        &store,
+    )
+    .unwrap_err();
+    assert!(err.contains("unknown magic predicate"), "got: {err}");
+}
+
+#[test]
+fn no_vec_predicate_passes_through() {
+    let (g, store) = fixture("passthrough");
+    // A query with no vec: predicate must evaluate exactly as the plain engine would.
+    let r = query_vec(
+        &g,
+        "SELECT ?node WHERE { ?node <http://ex/label> \"alpha\" }",
+        &store,
+    )
+    .unwrap();
+    assert_eq!(iris(&r, 0), vec!["http://ex/a".to_string()], "{r:?}");
+}

--- a/crates/sparq-vectors/tests/vec_predicate.rs
+++ b/crates/sparq-vectors/tests/vec_predicate.rs
@@ -217,3 +217,30 @@ fn no_vec_predicate_passes_through() {
     .unwrap();
     assert_eq!(iris(&r, 0), vec!["http://ex/a".to_string()], "{r:?}");
 }
+
+/// [OPUS-4.8] Regression: a query that legitimately uses the RDF collection
+/// vocabulary (`rdf:first`/`rdf:rest`) but NO `vec:` predicate must pass through
+/// unchanged — the rewrite must not strip those triples (it previously did,
+/// unconditionally). Here we query an actual `rdf:first` cell and expect the
+/// element back.
+#[test]
+fn rdf_collection_without_vec_predicate_is_preserved() {
+    let g = Graph::load_str(
+        r#"
+        <http://ex/list> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://ex/elem> .
+        <http://ex/list> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+        "#,
+        "ntriples",
+    )
+    .unwrap();
+    // An empty store (no fingerprint) — exercises the unbound/legacy path too.
+    let store = VectorStore::create(tmp_path("collection_passthrough"), 2).unwrap();
+    let r = query_vec(
+        &g,
+        "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n\
+         SELECT ?elem WHERE { <http://ex/list> rdf:first ?elem }",
+        &store,
+    )
+    .unwrap();
+    assert_eq!(iris(&r, 0), vec!["http://ex/elem".to_string()], "{r:?}");
+}

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vector-search
-description: "Semantic / ANN vector search over a sparq RDF graph: build a memory-mapped per-term-id embedding store (.spqv), then run cosine top-k with an in-RAM HNSW, a persistent on-disk DiskANN/Vamana graph (.spqg), or an exact brute-force baseline; verbalize entities (label+type+description) for embedding, scalar/product quantize (SQ/PQ) for large stores, and fuse with another ranked signal (RRF / score blend) for hybrid retrieval. Use when adding embedding/semantic-search/nearest-neighbour over a sparq Graph in the sparq-vectors crate."
+description: "Semantic / ANN vector search over a sparq RDF graph: build a memory-mapped per-term-id embedding store (.spqv), then run cosine top-k with an in-RAM HNSW, a persistent on-disk DiskANN/Vamana graph (.spqg), or an exact brute-force baseline; verbalize entities (label+type+description) for embedding, scalar/product quantize (SQ/PQ) for large stores, fuse with another ranked signal (RRF / score blend) for hybrid retrieval, and — behind the opt-in `vec-predicate` feature — run k-NN INSIDE plain SPARQL via the `vec:nearest` / `vec:search` magic predicates. Use when adding embedding/semantic-search/nearest-neighbour over a sparq Graph in the sparq-vectors crate."
 ---
 
 # sparq-vector-search
@@ -128,6 +128,14 @@ fuse_scores(a: &[(T,f64)], b: &[(T,f64)], alpha /*1.0=a only*/, top_k) -> Vec<(T
 // one-call hybrid: run N retriever closures on one query, fuse by item via RRF, dedup
 hybrid_search(query: &Q, top_k, k /*RRF_K*/, &mut [Retriever<'_, Q, T>]) -> Vec<(T, f64)>   // [OPUS-4.8] lifetime on alias use
 //   Retriever<'r, Q, T> = &'r mut dyn FnMut(&Q) -> Vec<(T, f64)>  (e.g. nearest_term / most_similar closures)
+
+// --- `vec:` magic predicate (src/rewrite.rs) --- feature = "vec-predicate" ONLY; pulls sparq-engine [OPUS-4.8] sq-k6ex
+query_vec(&Graph, sparql: &str, &VectorStore) -> Result<QueryResult, String>      // parse + rewrite + evaluate
+query_vec_with_budget(&Graph, &str, &VectorStore, &QueryBudget) -> Result<QueryResult, String>
+prepare_vec(&Graph, &str, &VectorStore) -> Result<PreparedQuery, String>          // compose with engine *_prepared entry points
+rewrite_query(Query, &Graph, &VectorStore) -> Result<Query, String>              // spargebra-algebra rewrite only
+// re-exported when the feature is on: PreparedQuery, QueryBudget, QueryResult (no direct sparq-engine dep needed)
+// vocab: vec::{VEC_NS, NEAREST, SEARCH}  (http://sparq.dev/vec#)  — exact-scan (nearest_exact) KNN
 ```
 
 ## Common recipes
@@ -302,12 +310,58 @@ malformed/oversized `.npy` header is an `Err` — never a silent reinterpretatio
 length and declared shape are bounded against the actual file size before any body allocation
 (sq-tzwa hardening). `import_*` need `std::fs` and are compiled off the wasm target.
 
+### 8. k-NN INSIDE SPARQL — the `vec:` magic predicate (opt-in, feature = `vec-predicate`)
+
+Express nearest-neighbour search in plain SPARQL, mirroring `sparq-text`'s `text:` predicate:
+the rewrite runs the k-NN, inlines the hit nodes as a `VALUES` table at the spargebra-algebra
+level, and evaluates through the engine's prepared-query seam — so the **engine, planner,
+executor and wasm bundle are unchanged**. This is the **only** SPARQL-level hook, and it is
+**OFF by default**: the feature is the only thing that pulls `sparq-engine` into this crate, so
+without it `sparq-vectors` is a pure storage+ANN crate and the base query path carries zero
+`vec:` code (`cargo tree -p sparq-vectors` lists no `sparq-engine`/`spargebra`).
+
+```toml
+sparq-vectors = { path = "../sparq-vectors", features = ["vec-predicate"] }
+```
+
+```rust
+use sparq_vectors::{query_vec, VectorStore};   // query_vec only exists with the feature on
+// store built/finalized as above, keyed by the SAME graph's dict ids.
+
+// vec:nearest — bind ?node to the k nearest neighbours of a query.
+//   query = a node IRI (its stored vector; the seed is excluded) OR a "f1,f2,…" vector literal.
+let r = query_vec(&graph,
+    "PREFIX vec: <http://sparq.dev/vec#>
+     SELECT ?label WHERE {
+       ?node vec:nearest ( <http://example.org/bolt> 5 ) .   # 5 neighbours of bolt
+       ?node rdfs:label ?label .                              # join to ordinary triples
+     }", &store)?;
+
+// vec:search — also bind a cosine score; ORDER BY DESC recovers best-first (VALUES is unordered).
+let r = query_vec(&graph,
+    "PREFIX vec: <http://sparq.dev/vec#>
+     SELECT ?node ?score WHERE {
+       ( ?node ?score ) vec:search ( \"0.1,0.9,…\" 10 )
+     } ORDER BY DESC(?score)", &store)?;
+```
+
+The argument lists `( … )` are ordinary SPARQL RDF collections (spargebra lowers them to
+`rdf:first`/`rdf:rest`, which the rewrite walks). Hard query errors (not silent mismatches):
+the neighbour position(s) must be variables; `query`/`k` must be constants; the object list must
+be exactly `( query k )` and the `vec:search` subject exactly `( ?node ?score )`; a query-vector
+literal's dimension must match the store; any other `vec:` IRI is unknown. An absent/unembedded
+seed IRI yields no rows. Search is the **exact** `nearest_exact` scan (deterministic, the HNSW/
+DiskANN approximate indexes are not yet wired into the predicate — recorded follow-up).
+
 ## Gotchas / feature flags / prerequisites
 
-- **Opt-in, no SPARQL hook.** Nothing in the workspace depends on `sparq-vectors`; the
-  default engine build does not compile it. There is **no** SPARQL-level integration (no
-  `SERVICE`, function, or graph binding to vectors) — this is a standalone Rust library
-  over sparq-core's public read API. You wire vectors into application code yourself.
+- **Opt-in.** Nothing in the workspace depends on `sparq-vectors`; the default engine
+  build does not compile it. The core Rust flow (store/ANN/embed) is a standalone library
+  over sparq-core's public read API — you wire it into application code yourself. The **one**
+  SPARQL-level integration is the optional `vec:` magic predicate (recipe 8 below), behind
+  the **non-default `vec-predicate`** feature; with it OFF this crate has zero `sparq-engine`
+  dependency and the base engine/core query path is byte-identical (see recipe 8). There is
+  still no `SERVICE`/function binding.
 - **`HashEmbedder` is TEST-ONLY.** It is lexical n-gram hashing with **no semantics**
   ("car" and "automobile" are unrelated). Use it to exercise the store/ANN/pipeline; bring
   a real `Embedder` for actual retrieval.


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-k6ex** (epic **sq-3183**): a `vec:` magic predicate so vector k-NN search is expressible **inside plain SPARQL** — the biggest, lowest-risk vector gap (every competitor exposes vectors in-query).

## Forms

- `?node vec:nearest ( <query> <k> )` — bind `?node` to the `k` nearest neighbours (best first) of `<query>`.
- `( ?node ?score ) vec:search ( <query> <k> )` — also bind `?score` to the cosine similarity (`xsd:double`); `ORDER BY DESC(?score)` recovers best-first (VALUES is unordered).

`<query>` is a constant **node IRI** (its stored vector is the query; the seed is excluded) **or** a `"f1,f2,…"` **vector literal**. `<k>` is a non-negative integer. The `( … )` argument lists are ordinary SPARQL RDF collections (spargebra lowers them to `rdf:first`/`rdf:rest`, which the rewrite walks).

## Mirrors `text:` exactly

Like `sparq-text`'s `text:` predicate, the rewrite walks the spargebra algebra, runs the k-NN (exact `nearest_exact` scan over the `.spqv` store), inlines the neighbour nodes/scores as a `VALUES` table, and evaluates through the engine's prepared-query seam (`PreparedQuery: From<spargebra::Query>`). **The engine, planner, executor and wasm bundle are completely unaware of vector search.**

## OPT-IN — core stays lean when off

Gated behind the **non-default `vec-predicate`** cargo feature, the **only** thing that pulls `sparq-engine`/`spargebra` into `sparq-vectors`. With the feature **OFF**:
- `cargo tree -p sparq-vectors` lists no `sparq-engine`/`spargebra` (verified: 0 hits),
- `sparq-core` and `sparq-engine` are unchanged (the dependency direction is `sparq-vectors -> sparq-engine`, exactly like `sparq-text`),
- the `vec:` code does not compile, and the integration test compiles to **0 tests** (`#![cfg(feature = "vec-predicate")]`).

## Verify

- `cargo build -p sparq-vectors` (feature off) and `--features vec-predicate` (on) both clean.
- `cargo clippy --all-targets -- -D warnings` clean in **both** feature states.
- New `tests/vec_predicate.rs`: real SPARQL `vec:nearest` / `vec:search` queries over a tiny in-memory vector index, asserting expected neighbours, score binding + ordering, seed exclusion, BGP join, and error paths — **8 tests + doctest, all green**.
- Full `cargo test -p sparq-vectors` green both feature states.
- `skills/vector-search/SKILL.md` updated per the AGENTS.md public-API → SKILL rule (new recipe 8, API block, amended "no SPARQL hook" gotcha).

Only `crates/sparq-vectors/*`, the new test, `skills/vector-search/SKILL.md`, and `Cargo.lock` change — `sparq-engine`/`sparq-core` are untouched.

Refs sq-k6ex, sq-3183.
