### PR TITLE
Certification readiness — memsafety (sq-toze)

### DIFF
--- a/compliance/audit/memsafety-findings-1.md
+++ b/compliance/audit/memsafety-findings-1.md
@@ -1,0 +1,99 @@
+<!-- [OPUS-4.8] sq-toze — memsafety AUDIT round 1. Adversarial internal auditor.
+     Re-review when Fable returns. -->
+
+# Memory-safety attestation — audit findings, round 1
+
+Auditor stance: skeptical, evidence-or-it-didn't-happen. I re-ran the ratchet, re-read every
+cited workflow job and file, and probed the gating logic of the `ci-summary` aggregator
+against the actual `unsafe-register` job. The control set is **substantively sound** — the
+register/snapshot/ratchet triangulate, the B5 coverage matrix is honest about what Miri can
+and cannot reach, and no claim contradicts the ZK-not-sound verdict (the `sparq-zk-compose`
+`flock` sites are correctly scoped as *memory*-safety FFI, not a crypto guarantee). The
+findings below are real but bounded — one is a live documentation overclaim that must be
+fixed in the register itself (the engineer's gap-register says "corrected" but the register
+file still carries the overclaiming sentence).
+
+## Findings
+
+### F1 — MEDIUM — register still asserts a clippy lint that is not enabled (MS-5 / MS-G2)
+**Control:** MS-5 (per-site `// SAFETY:` justification, "local enforcement").
+**What I checked:** `grep -n undocumented_unsafe_blocks compliance/memsafety/unsafe-register.md`
+→ line 45 still reads *"clippy `undocumented_unsafe_blocks` is the local enforcement."*
+`grep -rn undocumented_unsafe_blocks crates/ Cargo.toml` → the lint is set **only** in
+`vendor/spargebra/Cargo.toml`, NOT in any first-party crate.
+**Why it fails:** the register makes a control claim (a clippy lint enforces the `// SAFETY:`
+token) that the codebase does not back. `controls.md`/`evidence.md`/`gap-register.md` already
+acknowledge this (MS-5 caveat + MS-G2), but the **authoritative register file itself** still
+overclaims — an external reader of the register alone would be misled. Misrepresentation in
+the spine document is worse than the underlying gap.
+**Remediation:** edit `unsafe-register.md` line 45 to state the enforcement honestly — the
+`// SAFETY:` requirement is enforced by **the register + review + the count ratchet**, with
+`clippy::undocumented_unsafe_blocks` listed as a *recommended, not-yet-enabled* gap (MS-G2).
+Do not claim the lint until it is actually added to the 5 unsafe crates.
+
+### F2 — LOW — "every site has a `// SAFETY:` comment" is literally false (6/56) (MS-5)
+**Control:** MS-5 / register §"How each site is bounded" + the NEEDS-REVIEW section's claim
+"every one of the 56 sites has … a corresponding `// SAFETY:` comment in source."
+**What I checked:** counted literal `SAFETY:` tokens per crate → 50; identified the 6 sites
+(`dict.rs:483`, `dict.rs:2192-93`, `dictspill.rs:720-21`) that use an *adjacent block
+comment* with a sound argument but not the literal token.
+**Why it fails:** the substance is fine (all 6 are documented + sound), but the register's
+absolute phrasing "every one of the 56 sites has … a `// SAFETY:` comment" is inaccurate.
+**Remediation:** either (a) normalise the 6 to the literal `// SAFETY:` token (preferred —
+also unblocks MS-G2's lint), or (b) soften the register phrasing to "every site has a
+documented safety argument (50 via the `// SAFETY:` token, 6 via an adjacent justification
+comment)". Pick one; do not leave the absolute claim standing.
+
+### F3 — LOW — cross-doc unsafe-count drift, threat-model says 39 vs register 42 (MS-G5)
+**Control:** MS-2 (the count is the attested figure) vs `research/threat-model.md`.
+**What I checked:** `research/threat-model.md` line 21 → "Yes — 39 sites"; register +
+`bench/unsafe-snapshot.json` + `scripts/unsafe-gate.py --check` → 42 in sparq-core.
+**Why it fails:** two repo documents disagree on the headline number. The register is
+authoritative (it is the ratchet source), so this is a *stale neighbouring doc*, not a defect
+in the attestation — but a relying party reading the threat-model would get the wrong count.
+**Remediation:** MS-G5 already tracks the one-line fix to `threat-model.md`. Acceptable to
+leave as a tracked gap since `threat-model.md` is owned by a different surface, **provided**
+`evidence.md`/`gap-register.md` flag the discrepancy explicitly (they do). No change required
+in the memsafety deliverables beyond keeping MS-G5 open.
+
+## Assessed and PASS (no finding)
+
+- **MS-1** confined surface — re-ran the grep; 20 forbid + 5 unsafe = 25 crates. Correct.
+- **MS-2/MS-3** register + ratchet — re-ran `--check` (PASS, 56==56) and `--list` (TOTAL=56);
+  per-crate matches snapshot + register. Verified the `unsafe-register` job has no
+  `continue-on-error`, its name lacks the `\b(advisory|informational)\b` exclusion tokens, and
+  `ci.yml` triggers on `pull_request`+`merge_group` so `ci-summary / gate` discovers and gates
+  it. The ratchet is genuinely merge-blocking. Strong PASS.
+- **MS-4** geiger informational — confirmed `continue-on-error: true` + name-exclusion; honestly
+  labelled non-gating. PASS.
+- **MS-6** Miri — confirmed `miri.yml` runs `cargo miri test -p sparq-core` nightly/dispatch
+  only, with no PR trigger, and the header honestly states the 16 mmap + 7 dict-spill sites are
+  structurally out of Miri's reach. No overclaim. PASS.
+- **MS-7** oracle — `crates/sparq-core/tests/mmap_corruption_oracle.rs` exists with the named
+  sweep/survives functions. PASS.
+- **MS-8/MS-9** fuzz + ASan — `fuzz/fuzz_targets/graph_open.rs` is the genuine B5 mmap-loader
+  target; `fuzz.yml` builds nightly with `-Zsanitizer` on the gnu target. The MS-9 caveat (no
+  standalone ASan lane) is honest. PASS.
+- **MS-10** clippy `-D warnings` — gating, not `continue-on-error`. PASS.
+- **MS-11** dependency memory-safety — `cargo deny check advisories bans sources licenses` all
+  gating (GX-1 un-degraded). PASS.
+- **MS-12/MS-13** edition-2024 env sites + no-unsafe-in-untrusted-text-path — verified against
+  the register rows + the forbid list. PASS.
+- **ZK honesty tripwire** — the `sparq-zk-compose` flock sites are scoped as memory-safety FFI
+  only; nothing in the memsafety deliverables claims a cryptographic guarantee or contradicts
+  the v1-ZK-NOT-sound verdict. PASS (tripwire clear).
+
+## Coverage note
+
+I assessed all 13 controls + the coverage matrix + the ZK tripwire. I did **not** execute the
+Miri/fuzz/oracle suites (heavy; the EC2 box is NON-CANONICAL for timing) — I verified their
+existence, wiring, triggers, and scope instead, which is the correct evidence level for an
+attestation audit. I did re-run the ratchet (`--check`/`--list`) since it is hermetic + fast.
+
+## Verdict
+
+`FINDINGS: 3` (1 medium, 2 low). **No critical/high.** No sign-off this round: F1 is a live
+overclaim in the authoritative register file and must be corrected before sign-off. F2 should
+be resolved (normalise or soften). F3 is acceptable as a tracked cross-doc gap. The
+*substantive* memory-safety posture is sound; the findings are documentation-accuracy issues,
+not safety defects.

--- a/compliance/audit/memsafety-findings-2.md
+++ b/compliance/audit/memsafety-findings-2.md
@@ -1,0 +1,49 @@
+<!-- [OPUS-4.8] sq-toze — memsafety AUDIT round 2 (sign-off). Re-review when Fable returns. -->
+
+# Memory-safety attestation — audit findings, round 2
+
+Re-audit of the three round-1 findings after the engineer's fixes.
+
+## F1 — MEDIUM — register clippy overclaim → **RESOLVED**
+`grep -n undocumented_unsafe_blocks compliance/memsafety/unsafe-register.md` → line 45 now
+reads enforcement is "the **register + review + the count ratchet**" and explicitly states
+`clippy::undocumented_unsafe_blocks` is "**recommended but NOT yet enabled**", linking gap
+MS-G2. The overclaim is gone; the authoritative register is now consistent with
+`controls.md`/`gap-register.md`. **Closed.**
+
+## F2 — LOW — absolute "every site has a `// SAFETY:` comment" → **RESOLVED**
+Register §NEEDS-REVIEW now reads "50 via the literal `// SAFETY:` token, and 6 via an
+adjacent justification block comment", naming the 6 sites. The phrasing is now literally
+true. **Closed.**
+
+## F3 — LOW — threat-model 39 vs register 42 → **ACCEPTED as tracked gap MS-G5**
+The discrepancy is flagged in `evidence.md` (§Verified-but-noted) and `gap-register.md`
+(MS-G5, with the one-line remediation against `research/threat-model.md`, a doc this
+framework does not own). Per round-1 reasoning this is acceptable to carry as a tracked
+cross-doc gap rather than a memsafety-deliverable defect. **No open finding.**
+
+## Verdict
+
+`FINDINGS: 0` — **SIGN-OFF.**
+
+The memory-safety attestation is sound and honestly evidenced:
+- Unsafe surface confined to 5 crates; 20 crates `#![forbid(unsafe_code)]` (verified).
+- All 56 first-party `unsafe` sites enumerated + justified in the register; count
+  triangulated across register / `bench/unsafe-snapshot.json` / `scripts/unsafe-gate.py`.
+- A genuinely merge-blocking unsafe-count ratchet (verified against the `ci-summary`
+  aggregator's own gating rule + the `ci.yml` PR/merge_group triggers).
+- B5 mmap boundary covered by the deterministic corruption oracle + the `graph_open` fuzz
+  target running under AddressSanitizer; Miri honestly scoped to the pure-Rust sites it can
+  reach, with the structural mmap limitation documented, not hidden.
+- No claim contradicts the v1-ZK-NOT-sound verdict; the `sparq-zk-compose` flock sites are
+  correctly scoped as memory-safety FFI only.
+
+**Standing external caveats (out of agent scope, correctly labelled AUDIT-READY):** formal
+verification / model checking of the mmap validators (MS-G4) and an accredited third-party
+memory-safety audit remain external by definition. The two deferred deeper-assurance lanes
+(MS-G2 clippy-token lint, MS-G3 standalone-ASan lane) are tracked, not papered over.
+
+Overall status: **PASS** on every applicable codebase/CI control, with 4 honestly-recorded
+OPEN gaps (1 medium-now-resolved-in-doc + tracked-for-code, 3 low) and the formal-proof /
+external-audit ceiling labelled external. This is a defensible attestation, not a
+rubber-stamp.

--- a/compliance/memsafety/audit-log.md
+++ b/compliance/memsafety/audit-log.md
@@ -1,0 +1,80 @@
+<!-- [OPUS-4.8] sq-toze — memsafety engineer↔auditor loop log + final verdict.
+     Re-review when Fable returns. -->
+
+# Memory-safety attestation — engineer↔auditor loop log
+
+Epic `sq-toze`. Branch `cert-memsafety-certification`. This is the **proof-of-pattern** run
+before the loop fans out to the other 11 frameworks. The loop ran the engineer and auditor
+roles adversarially against the *actual repo*, not the docs.
+
+## Round 0 — engineer
+
+Authored `controls.md` (13 controls + a B5 coverage matrix), `evidence.md` (re-runnable
+verification per control), `gap-register.md` (closed GX-5; 4 honest OPEN gaps). Every cited
+artifact was verified to exist *before* it was cited: re-ran `scripts/unsafe-gate.py
+--check` (56==56 PASS) and `--list` (TOTAL=56); confirmed 20 `forbid(unsafe_code)` crates;
+confirmed `mmap_corruption_oracle.rs`, `graph_open.rs`, `miri.yml`, the gating `cargo deny
+check advisories`, and the `ci.yml` ratchet job exist and are wired as claimed.
+
+## Round 1 — auditor → `FINDINGS: 3` (1 medium, 2 low)
+
+`compliance/audit/memsafety-findings-1.md`. Re-verified the gating logic independently
+against the `ci-summary` aggregator's whole-word `\b(advisory|informational)\b` exclusion
+rule and the `ci.yml` PR/merge_group triggers — confirmed the ratchet genuinely gates. ZK
+honesty tripwire clear. Findings, all documentation-accuracy (not safety defects):
+- **F1 (medium):** the authoritative `unsafe-register.md` still asserted clippy
+  `undocumented_unsafe_blocks` "is the local enforcement" — but that lint is enabled only in
+  `vendor/spargebra`, not first-party. A live overclaim in the spine doc.
+- **F2 (low):** register's "every site has a `// SAFETY:` comment" is literally false (50/56
+  use the token; 6 use an adjacent block comment).
+- **F3 (low):** `research/threat-model.md` says 39 sparq-core sites vs the register's 42.
+
+## Round 1 fix — engineer
+
+Edited `unsafe-register.md`: line 45 now states enforcement is the register + review +
+ratchet, with the clippy lint labelled recommended-but-not-yet-enabled (→ MS-G2); the
+NEEDS-REVIEW section now says "50 via the literal token, 6 via adjacent comment". F3 left as
+tracked gap MS-G5 (threat-model is owned by another surface).
+
+## Round 2 — auditor → `FINDINGS: 0` → **SIGN-OFF**
+
+`compliance/audit/memsafety-findings-2.md`. F1 + F2 verified resolved in the register; F3
+accepted as tracked MS-G5. Sign-off with the standing external caveats (formal
+verification + accredited third-party audit are external by definition).
+
+## Final verdict (auditor)
+
+**PASS** on every applicable codebase/CI memory-safety control, with **4 honestly-recorded
+OPEN gaps** (none a safety defect):
+
+| Status | Controls |
+|---|---|
+| **PASS-with-evidence** | MS-1, MS-2, MS-3, MS-4, MS-6, MS-7, MS-8, MS-10, MS-11, MS-12, MS-13 (11) |
+| **PASS-with-caveat** (tracked gap) | MS-5 (→MS-G2), MS-9 (→MS-G3) (2) |
+| **AUDIT-READY** (external) | formal proof (MS-G4) + accredited third-party audit |
+
+Open gaps: **MS-G2** (enable clippy `undocumented_unsafe_blocks` + normalise 6 sites,
+medium/P1), **MS-G3** (standalone ASan lane over the oracle, low/P2), **MS-G4** (Kani/formal
+proof of mmap validators, low/P2), **MS-G5** (threat-model 39→42 doc sync, low/P2).
+
+**Rounds to convergence: 2** (one findings round, one sign-off round).
+
+## Pattern readiness for fan-out
+
+The loop pattern is **ready to fan out** to the other 11 frameworks (asvs, cis, sbom,
+iso27001, iso27701-folded-into-privacy, iso27017-18-CUT, soc2-folded, gdpr-folded, cyberess-
+CUT-replaced-by-cra, cdmc, crypto). What worked and should carry over:
+1. **Verify-before-cite in the engineer pass** kept round-1 findings to documentation
+   accuracy, not fabricated evidence — the most expensive auditor failure mode (overclaiming
+   a control that doesn't exist) never occurred. Brief every engineer to re-run/re-read each
+   citation before writing the row.
+2. **The auditor independently re-deriving the gating logic** (not trusting the engineer's
+   "this gates") is what gives the sign-off weight; budget the auditor a real source pass.
+3. **`bd` is unavailable in the isolated worktrees** — gaps must be listed for the
+   orchestrator to create as beads. Bake that into every brief.
+4. Memsafety had *pre-existing strong evidence* (the GX-5 register/ratchet from PR #217), so
+   it converged in 2 rounds. Frameworks with more *missing* technical controls (sbom GX-1/2,
+   cis Trivy lane, openssf Best-Practices badge) will likely need a real code/CI change +
+   green-gate cycle before the auditor can sign off — expect more rounds there, and gate
+   their fan-out on the cross-cutting gap-fix beads landing first (per the orchestration
+   runbook's stage gate).

--- a/compliance/memsafety/controls.md
+++ b/compliance/memsafety/controls.md
@@ -1,0 +1,71 @@
+<!-- [OPUS-4.8] sq-toze — memsafety framework control table. Authored while Fable
+     unavailable — re-review when Fable returns. Engineer↔auditor loop (epic sq-toze). -->
+
+# Memory-safety attestation — control table
+
+**Framework:** Memory-safety attestation (sparq's headline safety claim — a Rust
+RDF/SPARQL data-engine consumed as a dependency in high-security settings).
+**Scope:** the first-party `crates/` tree only. Threat-model boundary **B5**
+(`research/threat-model.md`): *hostile on-disk index → mmap loader → `unsafe` pointer
+reinterpret* is the load-bearing surface.
+**Companion docs:** [`evidence.md`](./evidence.md) (per-claim file/CI verification),
+[`gap-register.md`](./gap-register.md) (open gaps + beads),
+[`unsafe-register.md`](./unsafe-register.md) (the 56-site per-site justification register),
+[`audit-log.md`](./audit-log.md) (the engineer↔auditor rounds + final verdict).
+
+## Status legend
+
+- **PASS** — a technical control in the codebase/CI with verified, re-runnable evidence
+  (file path + line / test name / CI job). The auditor re-ran or re-read the cited
+  artifact.
+- **AUDIT-READY** — control + documentation in place, but a *certificate* needs an
+  accredited external body / formal verification we cannot substitute for.
+- **OPEN-gap** — not met (or only partially); recorded in `gap-register.md` with a `bd`
+  bead. **Not** papered over.
+
+> Honesty note. This framework does **not** touch the ZK/MPC estate's soundness — that is
+> `cryptoreview`. The `sparq-zk-compose` advisory-lock `unsafe` (2 sites) is in scope here
+> only as *memory*-safety (a `libc::flock` FFI), **not** as a cryptographic guarantee. The
+> "v1 ZK verifier NOT sound" verdict (`SECURITY.md`) is untouched by any claim below.
+
+## Controls
+
+| # | Control | Status | Evidence (file / test / CI job) |
+|---|---|---|---|
+| MS-1 | **Unsafe surface is *confined*** — only 5 first-party crates contain `unsafe`; the other 20 are `#![forbid(unsafe_code)]`, so a new `unsafe` anywhere else fails to compile. | **PASS** | `#![forbid(unsafe_code)]` in 20 crates (verified: `grep -rl forbid(unsafe_code) crates/` → 20 crates; 25 crates total). Enumerated in `evidence.md` §MS-1. |
+| MS-2 | **Every first-party `unsafe` site is enumerated + justified** — the 56-site register records each site's kind, the invariant it relies on, and how it is bounded/tested. | **PASS** | `compliance/memsafety/unsafe-register.md` (56 rows). Count cross-checked: `scripts/unsafe-gate.py --list` → `TOTAL=56`, matching `bench/unsafe-snapshot.json` (`total: 56`) and the register's per-crate split (sparq-core 42, sparq-vectors 9, sparq-cli 2, sparq-zk-compose 2, sparq-bench 1). |
+| MS-3 | **Unsafe-count RATCHET gates every PR** — a PR cannot add an `unsafe` site without updating the register + re-seeding the snapshot; the count gate is merge-blocking. | **PASS** | `scripts/unsafe-gate.py --check` (re-run: PASS, live 56 == snapshot 56). CI job `unsafe-register (count ratchet)` in `.github/workflows/ci.yml` (`unsafe-register:` job, no `continue-on-error`, name has no "informational"/"advisory" token ⇒ the `ci-summary / gate` aggregator treats it as REQUIRED). |
+| MS-4 | **cargo-geiger visibility** — third-party + first-party `unsafe` is surfaced in the CI summary. | **PASS** (informational by design) | `geiger` job `unsafe report (cargo-geiger, informational)` in `ci.yml` — `continue-on-error: true`, name contains "informational" ⇒ NON-gating. The *gating* control is MS-3 (the deterministic ratchet); geiger is visibility only. Honestly labelled: cargo-geiger is **not** the gate. |
+| MS-5 | **Per-site `// SAFETY:` justification in source** — the safety argument lives next to the code. | **PASS-with-caveat** | 50 `// SAFETY:` comments across the 5 unsafe crates; the remaining 6 sites (the `from_utf8_unchecked` TRUSTED fast path `dict.rs:483`, and the two `unsafe impl Send`/`Sync for SlotPtr` pairs in `dict.rs:2192-93` + `dictspill.rs:720-21`) carry a justification in an adjacent block comment rather than the literal `// SAFETY:` token. **Caveat:** there is NO first-party clippy `undocumented_unsafe_blocks` lint enforcing the literal token (see OPEN-gap MS-G2) — enforcement of the *token* is by the register + review, not by a lint. |
+| MS-6 | **Miri UB lane** over the pure-Rust unsafe reachable without mmap — aliasing / provenance / data-race detection on the parallel scatter writes, POD↔bytes reinterprets, `from_utf8_unchecked` over in-memory buffers, `MaybeUninit`+`set_len`. | **PASS** (nightly safety-net) | `.github/workflows/miri.yml` — `cargo miri test -p sparq-core` under `-Zmiri-tree-borrows`, nightly + `workflow_dispatch`. **Honestly scoped:** Miri *structurally cannot* run the 16 mmap-backed sites (file-backed mappings) — that is MS-7, not Miri. Off the per-PR critical path by design (nightly), so it is a standing safety net, not a merge gate. |
+| MS-7 | **Deterministic corruption oracle** for the B5 mmap sites Miri cannot reach — a hostile/corrupt on-disk index must reject or stay in-bounds, never UB. | **PASS** | `crates/sparq-core/tests/mmap_corruption_oracle.rs` (`corruption_sweep`, `mmap_loader_survives_corruption_raw/_compressed`, `open_rejects_corrupt_index`), run under `--features mmap,dict-spill`. Verified the file exists + names the B5 surface. |
+| MS-8 | **Coverage-guided fuzzing of the mmap loader** — libFuzzer drives hostile bytes into every on-disk byte-parser (counts/lengths/magic/offset tables/manifest). | **PASS** | `fuzz/fuzz_targets/graph_open.rs` (`sparq_core::Graph::open` over a corrupt store dir; threat-model `T-MMAP-FUZZ`). Plus `load_reader_parallel.rs`, `parse_rdf_str.rs`, `parse_sparql.rs`, `validate_shacl.rs`. CI: `.github/workflows/fuzz.yml` (PR smoke + nightly; `cargo fuzz list` auto-enumerates targets). |
+| MS-9 | **AddressSanitizer over the hostile-input path** — the fuzz lane builds with `-Zsanitizer=address` (cargo-fuzz default) on the gnu (dynamic-libc) target, so the mmap loader's reads run under ASan during fuzzing. | **PASS-with-caveat** | `fuzz.yml` uses nightly + `-Zsanitizer` (libFuzzer sancov); the musl target is rejected by ASan, the gnu target is sanitizer-compatible. **Caveat:** there is no *standalone* ASan unit-test lane over the corpus/oracle outside fuzzing (MS-G3, deferred) — ASan coverage is only as deep as the fuzz corpus reaches. |
+| MS-10 | **`clippy -D warnings` gate** — the lint-clean workspace bars classes of memory/aliasing footguns clippy detects. | **PASS** | `ci.yml` `cargo clippy --workspace --all-targets -- -D warnings` (GATING) + a `wasm32` clippy gate. Verified the `-D warnings` invocation is present and not `continue-on-error`. |
+| MS-11 | **Dependency memory-safety** — third-party `unsafe` (memmap2, libc, rayon, hdt, …) is governed by the supply-chain lane, not silently trusted. | **PASS** (defers per-dep proof to supply-chain) | `cargo deny check advisories bans sources licenses` — **all gating** (`.github/workflows/supply-chain.yml`; GX-1 advisories un-degraded, `continue-on-error` removed). Daily `dependency-monitoring.yml` watchdog. The *register* explicitly scopes third-party `unsafe` OUT to this lane (no laundering of dep unsafe into a first-party claim). |
+| MS-12 | **Edition-2024 `unsafe` hygiene** — the new edition-2024 `unsafe` obligations (`set_var`/`remove_var` now `unsafe`) are enumerated, not hidden — the 2 test-only env sites are in the register with their single-threaded-test invariant. | **PASS** | `unsafe-register.md` rows `src/lib.rs:6229`, `:6231` (TEST-only, restored before return). Counted by the ratchet like any other site. |
+| MS-13 | **No `unsafe` in the parser / planner / executor / reasoner / SHACL layers** — the RDF/SPARQL ingest + query path that touches untrusted *query/data* text is 100% safe Rust (the untrusted-bytes-to-mmap boundary is the only unsafe surface). | **PASS** | `sparq-engine`, `sparq-parse`, `sparq-reason`, `sparq-shacl`, vendored `spargebra` are all `#![forbid(unsafe_code)]` / no `unsafe` (per MS-1 list + `research/threat-model.md` §scope table). Untrusted *text* never reaches `unsafe`; only the on-disk index (B5) does. |
+
+## External / out-of-agent-scope items (label, do not claim)
+
+- **Formal verification of the unsafe core** (e.g. Kani / Prusti / a separation-logic
+  proof of the mmap validators) is **not** done — the assurance is Miri + oracle + fuzz +
+  the per-site argument, which is strong but is *testing/justification*, not *proof*. An
+  external formal-methods review would be the certificate-grade step. Tracked: gap MS-G4.
+- **An accredited third-party memory-safety audit** of the B5 surface is external by
+  definition; the register + coverage matrix is the evidence pack such an auditor would
+  consume.
+
+## Coverage matrix (which mechanism bounds which class of site)
+
+| Site class | # sites | Miri (MS-6) | Oracle (MS-7) | Fuzz+ASan (MS-8/9) | Per-site arg (MS-2/5) |
+|---|---|:--:|:--:|:--:|:--:|
+| Pure-Rust in-memory (scatter writes, POD↔bytes, `from_utf8_unchecked` over our buffers, `set_len`) | ~26 | ✅ runs | n/a | partial (reached via parse path) | ✅ |
+| mmap-backed B5 (every `Mmap::map`/`MmapMut`, slice-reinterpret off a live map, `madvise`) | 16 | ❌ structurally cannot | ✅ | ✅ (`graph_open`) | ✅ |
+| dict-spill scatter + FFI (`sysconf`/`statvfs`, hash-routed `*mut u64`) | 7 | ❌ (`dict-spill`⇒`mmap`) | ✅ | ✅ | ✅ |
+| Prefetch hints / asm (`_mm_prefetch`, `prfm`, ptr `add` for hint) | ~4 | ✅ (hint-only, cannot fault) | n/a | n/a | ✅ |
+| Bench/CLI/zk-compose FFI (`getrusage`, `flock`, dump-perm mmap) | ~3 | n/a (non-core) | n/a | n/a | ✅ |
+
+The matrix is the honest answer to "is every unsafe site covered by *something*": yes —
+every site has at least the per-site argument (MS-2), and every B5 mmap site that Miri
+cannot reach is covered by the oracle **and** the fuzz+ASan lane.

--- a/compliance/memsafety/evidence.md
+++ b/compliance/memsafety/evidence.md
@@ -1,0 +1,164 @@
+<!-- [OPUS-4.8] sq-toze — memsafety evidence pack (re-runnable verification of each
+     control in controls.md). Re-review when Fable returns. NON-CANONICAL timing. -->
+
+# Memory-safety attestation — evidence pack
+
+Each control in [`controls.md`](./controls.md) is backed here by the **exact** file path,
+test, or CI job, plus the command an auditor re-runs to confirm it. Paths are
+repo-relative. No timing is recorded (NON-CANONICAL EC2 box).
+
+## MS-1 — confined unsafe surface (20 `forbid` crates, 5 unsafe crates)
+
+```sh
+grep -rl 'forbid(unsafe_code)' crates/ --include='*.rs' | sed 's#crates/##;s#/src.*##' | sort -u
+```
+→ 20 crates: sparq-conformance, sparq-engine, sparq-geo, sparq-gpu, sparq-hdt,
+sparq-introspect, sparq-mpc, sparq-nlq, sparq-parse, sparq-py, sparq-reason, sparq-rsp,
+sparq-serve, sparq-server, sparq-shacl, sparq-sim, sparq-solid, sparq-text, sparq-wasm,
+sparq-zk.
+
+```sh
+ls crates/ | wc -l            # → 25 total crates
+```
+Accounting: **20 forbid + 5 with unsafe (sparq-core, sparq-vectors, sparq-cli,
+sparq-zk-compose, sparq-bench) = 25.** No crate is unaccounted-for.
+
+## MS-2 — 56-site register, count-verified
+
+```sh
+python3 scripts/unsafe-gate.py --list | tail -1     # → TOTAL=56
+```
+Per-crate (from `--check`, matching `bench/unsafe-snapshot.json` and the register §headers):
+
+| crate | snapshot | live | register rows |
+|---|---:|---:|---:|
+| sparq-core | 42 | 42 | 42 |
+| sparq-vectors | 9 | 9 | 9 |
+| sparq-cli | 2 | 2 | 2 |
+| sparq-zk-compose | 2 | 2 | 2 |
+| sparq-bench | 1 | 1 | 1 |
+| **total** | **56** | **56** | **56** |
+
+Every row carries the site kind, the invariant relied on, and how it is bounded — see
+[`unsafe-register.md`](./unsafe-register.md).
+
+## MS-3 — gating ratchet
+
+```sh
+python3 scripts/unsafe-gate.py --check    # → "unsafe-count ratchet: PASS"; exit 0
+```
+CI wiring — `.github/workflows/ci.yml`, job `unsafe-register:`:
+```yaml
+  unsafe-register:
+    name: unsafe-register (count ratchet)
+    steps:
+      - name: Ratchet first-party unsafe count against the snapshot
+        run: python3 scripts/unsafe-gate.py --check
+```
+No `continue-on-error`; the job name contains no "informational"/"advisory" token, so the
+`ci-summary / gate` aggregator (which polls sibling check-runs and treats any
+non-informational lane as required) blocks merge on a ratchet regression. A PR adding an
+`unsafe` site fails until: (1) a register row is added, (2) a `// SAFETY:` comment is
+added in source, (3) `scripts/unsafe-gate.py --seed` re-seeds `bench/unsafe-snapshot.json`
+— all three land in the same reviewable diff.
+
+## MS-4 — cargo-geiger (informational, NOT the gate)
+
+`.github/workflows/ci.yml`, job `geiger:` — `name: unsafe report (cargo-geiger,
+informational)`, `continue-on-error: true`, every step `continue-on-error`. The name's
+"informational" token makes the aggregator skip it. Honest posture: geiger is visibility,
+the ratchet (MS-3) is the gate. (cargo-geiger cannot run the virtual workspace manifest —
+hence the deterministic scan in MS-3 is what we actually ratchet.)
+
+## MS-5 — per-site `// SAFETY:` (50/56 literal token; 6 adjacent-block-comment)
+
+```sh
+for c in sparq-core sparq-vectors sparq-cli sparq-zk-compose sparq-bench; do
+  echo -n "$c: "; grep -rn 'SAFETY:' crates/$c/src | wc -l; done
+# sparq-core: 36  sparq-vectors: 9  sparq-cli: 2  sparq-zk-compose: 2  sparq-bench: 1  → 50
+```
+The 6 sites without the literal token, each WITH an adjacent justification comment:
+- `crates/sparq-core/src/dict.rs:483` — `from_utf8_unchecked`, preceded by a 5-line
+  "TRUSTED fast path … untrusted mmap path MUST NOT reach here … bead sq-znld" comment.
+- `crates/sparq-core/src/dict.rs:2192-2193` — `unsafe impl Send/Sync for SlotPtr`,
+  preceded by the "routes each … slot to exactly one shard, nobody reads until the
+  parallel scope ends" comment.
+- `crates/sparq-core/src/dictspill.rs:720-721` — the `dict-spill` `SlotPtr` Send/Sync pair,
+  same disjoint-routing justification above.
+
+**Honest caveat (→ gap MS-G2):** these are *documented*, but not via the literal
+`// SAFETY:` token, and there is **no** first-party `clippy::undocumented_unsafe_blocks`
+lint enforcing the token. The register's earlier sentence "clippy
+`undocumented_unsafe_blocks` is the local enforcement" overstated this — corrected here and
+tracked as MS-G2.
+
+## MS-6 — Miri lane
+
+`.github/workflows/miri.yml` — `cargo +nightly miri test -p sparq-core` under
+`MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-ignore-leaks -Zmiri-disable-isolation`. Triggers:
+`schedule` (nightly 05:11 UTC) + `workflow_dispatch`. **No** `pull_request`/`merge_group`
+trigger — so it is a nightly UB safety net, not a per-PR gate, and the aggregator does not
+wait on it. The header documents (load-bearing) that the mmap/dict-spill features are NOT
+enabled because Miri rejects file-backed mappings — those 16+7 sites are covered by MS-7/8.
+
+## MS-7 — corruption oracle
+
+`crates/sparq-core/tests/mmap_corruption_oracle.rs`:
+```sh
+grep -n 'fn ' crates/sparq-core/tests/mmap_corruption_oracle.rs
+# open_rejects_corrupt_index, corrupt_truncate, corrupt_flip, corruption_sweep,
+# mmap_loader_survives_corruption_raw, mmap_loader_survives_corruption_compressed
+```
+Run under `--features mmap,dict-spill` (the features Miri cannot run). The sweep
+truncates/flips each on-disk file and asserts the loader rejects-or-stays-in-bounds.
+
+## MS-8 — fuzz (mmap loader)
+
+`fuzz/fuzz_targets/graph_open.rs` — header documents the surface as `Graph::open` over a
+CORRUPT on-disk store dir (perm0..5, dict-*.bin, numerics/temporals, predstats, named.bin),
+threat-model `T-MMAP-FUZZ`, invariant "clean `Err`, never panic/OOB/UB". Targets enumerated
+by `cargo fuzz list` in `.github/workflows/fuzz.yml` (PR smoke + nightly). Other targets:
+`load_reader_parallel.rs`, `parse_rdf_str.rs`, `parse_sparql.rs`, `validate_shacl.rs`.
+
+## MS-9 — ASan via cargo-fuzz
+
+`.github/workflows/fuzz.yml` builds on nightly with `-Zsanitizer` (libFuzzer sancov) on the
+`x86_64-unknown-linux-gnu` target (the musl target is ASan-incompatible — documented in the
+workflow). So the mmap loader's reads execute under AddressSanitizer during fuzzing. Caveat
+(MS-G3): no standalone ASan unit-test lane outside fuzzing.
+
+## MS-10 — clippy `-D warnings`
+
+`.github/workflows/ci.yml`: `cargo clippy --workspace --all-targets -- -D warnings`
+(GATING) + `cargo clippy -p sparq-wasm --target wasm32-unknown-unknown --all-targets -- -D
+warnings`. Neither is `continue-on-error`.
+
+## MS-11 — dependency memory-safety (supply-chain lane)
+
+`.github/workflows/supply-chain.yml`: `cargo deny check bans sources licenses` (gating) +
+`cargo deny check advisories` (gating — GX-1 un-degraded; CVSS-4.0 blocker sq-q8de
+resolved; `continue-on-error` removed). Daily watchdog `dependency-monitoring.yml`. The
+register explicitly scopes third-party `unsafe` (memmap2/libc/rayon/hdt) OUT to this lane.
+
+## MS-12 — edition-2024 unsafe (test-only env)
+
+`unsafe-register.md` rows `src/lib.rs:6229` (`set_var`) + `:6231` (`remove_var`) — TEST-only
+(`external_quads_fd_*`), single-threaded, var restored before return; counted by the ratchet.
+
+## MS-13 — no unsafe in the untrusted-text path
+
+The parser/planner/executor/reasoner/SHACL layers are in the MS-1 forbid list (or have no
+`unsafe`): untrusted *query/data text* never reaches `unsafe`; only the on-disk index does
+(B5). `research/threat-model.md` §scope table confirms `sparq-engine`/`sparq-reason`/
+`sparq-shacl`/spargebra carry no executor/parser `unsafe`.
+
+---
+
+### Verified-but-noted inconsistencies (for the auditor)
+
+1. **`research/threat-model.md` says "39 sites" in sparq-core**, the register/snapshot say
+   **42**. The register is the authoritative count (it is the GX-5 artifact + the ratchet
+   source). The threat-model number is stale prose. This framework does not own
+   `threat-model.md`; tracked as low-severity drift MS-G5 (one-line fix for the doc owner).
+2. The register's `undocumented_unsafe_blocks` enforcement sentence is an overstatement
+   (MS-G2) — corrected in MS-5/evidence and in the register itself.

--- a/compliance/memsafety/gap-register.md
+++ b/compliance/memsafety/gap-register.md
@@ -1,0 +1,53 @@
+<!-- [OPUS-4.8] sq-toze — memsafety gap register. Honest open gaps + remediation beads.
+     Re-review when Fable returns. -->
+
+# Memory-safety attestation — gap register
+
+Open gaps for the memsafety framework, with severity, remediation, and the `bd` bead that
+tracks the fix. The headline GX-5 gap (no unsafe register + cargo-geiger informational-only)
+from `research/production-certification-plan.md` is **CLOSED** by this framework's work
+(register + gating ratchet — see below). The remaining gaps are the honest residue: a
+documentation overclaim, two deferred deeper-coverage lanes, a formal-verification ceiling,
+and a cross-doc count drift.
+
+> `bd` is not available in this isolated worktree, so beads are listed here for the
+> orchestrator to create (`bd create … --epic sq-toze`); they are NOT hand-edited into
+> `.beads/`. Each remediation names the exact change.
+
+## CLOSED by this framework (was GX-5 — P0)
+
+| ID | What | Evidence it is closed |
+|---|---|---|
+| GX-5a | No per-site unsafe justification register | `compliance/memsafety/unsafe-register.md` — 56 rows, 100% of first-party sites. |
+| GX-5b | cargo-geiger informational only (no gating ratchet) | `scripts/unsafe-gate.py` + `bench/unsafe-snapshot.json` + the **gating** `unsafe-register (count ratchet)` CI lane in `ci.yml`. cargo-geiger stays as a separate visibility lane. |
+| GX-5c | B5 mmap sites "not attested in one place" | The coverage matrix in `controls.md` + the oracle (`mmap_corruption_oracle.rs`) + fuzz (`graph_open.rs`) citations attest each B5 site. |
+
+## OPEN gaps
+
+| ID | Gap | Sev | Remediation | Bead (to create) |
+|---|---|---|---|---|
+| **MS-G2** | **No first-party `clippy::undocumented_unsafe_blocks` lint.** The register claimed clippy `undocumented_unsafe_blocks` is "the local enforcement" of the `// SAFETY:` requirement, but that lint is set only in `vendor/spargebra`, NOT in the 5 first-party unsafe crates. So the `// SAFETY:`-token requirement is enforced by review + the register, not by a lint — and 6 of 56 sites use an adjacent block comment, not the literal token. | **Medium** | Add `#![warn(clippy::undocumented_unsafe_blocks)]` (or `deny`) to the 5 unsafe crates, normalise the 6 adjacent-comment sites to the literal `// SAFETY:` token so the lint passes, and let the existing `clippy -D warnings` gate enforce it. Until then, the register text is corrected to not claim the lint. | `memsafety: enable clippy::undocumented_unsafe_blocks on the 5 unsafe crates` (P1, sq-toze) |
+| **MS-G3** | **No standalone AddressSanitizer lane** outside cargo-fuzz. ASan currently runs only *inside* the fuzz build (MS-9), so ASan coverage of the B5 reads is only as deep as the fuzz corpus reaches; the deterministic oracle (MS-7) runs *without* ASan. | **Low** | Add a CI lane that runs `crates/sparq-core/tests/mmap_corruption_oracle.rs` (+ the vector/diskann corruption tests) under `-Zsanitizer=address` on the gnu target (nightly), so the deterministic corruption corpus executes under ASan. Deferred in the original miri.yml header; this makes it a tracked gap, not a silent omission. | `memsafety: ASan lane over the corruption oracle (not just fuzz)` (P2, sq-toze) |
+| **MS-G4** | **No formal verification / model checking of the unsafe core.** Assurance is Miri + oracle + fuzz + per-site argument (strong *testing/justification*) but not a *proof* of the mmap validators (`MappedDict::validate`, `VectorStore::open_validated`, DiskANN `open`). | **Low** (assurance ceiling, not a defect) | Evaluate Kani (bounded model checking of the offset/length validators) or a Prusti/Creusot annotation of the `validate` functions; treat as the certificate-grade external/formal-methods step. AUDIT-READY label stands until then. | `memsafety: evaluate Kani bounded-proof of the mmap validators` (P2, sq-toze) |
+| **MS-G5** | **Cross-doc unsafe-count drift.** `research/threat-model.md` says sparq-core has "39 sites"; the register/snapshot/ratchet say **42**. The register is authoritative; the threat-model prose is stale. | **Low** | One-line fix to `research/threat-model.md` (owned by the threat-model doc, not this framework) — update "39" → "42" (or reference the ratchet snapshot so it can't drift again). | `docs: sync threat-model unsafe-count to the ratchet snapshot (39→42)` (P2, sq-toze) |
+
+## NOT gaps (decisions, recorded so the auditor does not re-flag them)
+
+- **Miri does not gate per-PR.** Intentional — Miri is ~100× native; it is a nightly UB
+  safety net (like fuzz-nightly / zk-toolchain). The per-PR gate is the *ratchet* (MS-3) +
+  `clippy -D warnings` (MS-10) + the oracle/fuzz smoke. Not a gap.
+- **Miri does not run the 16 mmap + 7 dict-spill sites.** Structural (Miri rejects
+  file-backed mappings) — covered by the oracle + fuzz+ASan instead. Documented, not a gap.
+- **Third-party `unsafe` (memmap2/libc/rayon/hdt) is not in this register.** Scoped to the
+  supply-chain lane (cargo-deny, SBOM/VEX). Correct separation of concerns, not a gap.
+
+## Honest overall posture
+
+The memsafety framework is **substantively PASS**: the unsafe surface is confined (20 forbid
+crates), fully enumerated + justified (56-site register), gated by a merge-blocking ratchet,
+and covered by a Miri+oracle+fuzz+ASan matrix with the B5 boundary explicitly handled. The
+open gaps are **not** missing safety — they are (a) one documentation overclaim now corrected
+(MS-G2), (b) two *deeper-assurance* lanes that are deferred-but-tracked (MS-G3 ASan-standalone,
+MS-G4 formal proof), and (c) a stale number in a neighbouring doc (MS-G5). None of these
+contradicts the safety claim; the certificate-grade ceiling (formal proof + external audit) is
+external by definition and labelled AUDIT-READY.

--- a/compliance/memsafety/unsafe-register.md
+++ b/compliance/memsafety/unsafe-register.md
@@ -42,7 +42,7 @@ register distinguishes two trust classes of `unsafe`:
 | `mmap_corruption_oracle` test (`crates/sparq-core/tests/`, run under `--features mmap,dict-spill`) + `fuzz` lane's mmap-loader target | the **B5** mmap sites Miri structurally cannot run (file-backed mappings): hostile/corrupt index → loader must reject or stay in-bounds, never UB. |
 | `#![forbid(unsafe_code)]` on 20 crates (sq-emay) | proves the unsafe surface is *confined* to the 5 crates below; a new `unsafe` anywhere else fails to compile. |
 | `scripts/unsafe-gate.py --check` (this PR, GX-5) | the count **ratchet** — a PR cannot add `unsafe` without updating this register + re-seeding the snapshot. |
-| `// SAFETY:` comment required on every site (CONTRIBUTING) | the per-site argument lives next to the code; clippy `undocumented_unsafe_blocks` is the local enforcement. |
+| `// SAFETY:` / adjacent-comment argument on every site (CONTRIBUTING) | the per-site argument lives next to the code. Enforcement is the **register + review + the count ratchet** (a new `unsafe` cannot land without a register row, a source comment, and a re-seed). `clippy::undocumented_unsafe_blocks` (which would mechanically require the literal `// SAFETY:` token) is **recommended but NOT yet enabled on the first-party unsafe crates** — tracked as gap MS-G2 in [`gap-register.md`](./gap-register.md). [OPUS-4.8] |
 
 ## Register
 
@@ -143,8 +143,12 @@ Recurring invariant shorthands used below:
 
 ## NEEDS-REVIEW
 
-**None.** Every one of the 56 sites has a clear, sound safety argument and a
-corresponding `// SAFETY:` comment in source. Should a future site lack one, mark it
+**None.** Every one of the 56 sites has a clear, sound safety argument in source: 50
+via the literal `// SAFETY:` token, and 6 via an adjacent justification block comment
+(the `from_utf8_unchecked` TRUSTED fast path `dict.rs:483`, and the two `unsafe impl
+Send`/`Sync for SlotPtr` pairs `dict.rs:2192-93` + `dictspill.rs:720-21`). Normalising
+those 6 to the literal token — and enabling `clippy::undocumented_unsafe_blocks` to keep
+them there — is gap MS-G2. Should a future site lack any argument, mark it
 `NEEDS-REVIEW` here and open a bead (`bd create`) rather than fabricating a
 justification — do **not** re-seed the snapshot over an unjustified `unsafe`.
 


### PR DESCRIPTION
> 🤖 SPARQ agent

## Certification readiness — memsafety (epic `sq-toze`)

Proof-of-pattern run of the certification **engineer↔auditor loop** for the **memory-safety attestation** framework, before fan-out to the other frameworks. Both roles were run adversarially against the *actual repo*, not the docs.

### What landed (`compliance/memsafety/**` + `compliance/audit/**`)
- **`controls.md`** — 13 memsafety controls (MS-1..MS-13) + a B5 coverage matrix, each mapped to concrete repo evidence (file/line + test + CI job) and status-labelled PASS / PASS-with-caveat / AUDIT-READY.
- **`evidence.md`** — re-runnable verification per control (the exact `grep`/`unsafe-gate.py`/workflow citations).
- **`gap-register.md`** — closes the headline **GX-5** gap (per-site unsafe register + gating count ratchet); records 4 honest OPEN gaps (MS-G2..G5).
- **`audit-log.md`** — the loop rounds + final verdict.
- **`unsafe-register.md`** — corrected (the round-1 overclaim).
- **`compliance/audit/memsafety-findings-{1,2}.md`** — the auditor's two rounds.

### The honest verdict
- **PASS-with-evidence:** MS-1/2/3/4/6/7/8/10/11/12/13 (11 controls) — unsafe surface confined to 5 crates (20 `#![forbid(unsafe_code)]`), all 56 first-party `unsafe` sites enumerated + justified, a genuinely merge-blocking unsafe-count ratchet (verified against the `ci-summary` gating rule), B5 mmap boundary covered by the corruption oracle + the `graph_open` fuzz target under ASan, Miri honestly scoped to the pure-Rust sites it can reach.
- **PASS-with-caveat (tracked gap):** MS-5 (→MS-G2), MS-9 (→MS-G3).
- **AUDIT-READY (external):** formal proof of the mmap validators (MS-G4) + accredited third-party audit.
- No claim contradicts the **v1-ZK-NOT-sound** verdict; the `sparq-zk-compose` `flock` sites are scoped as memory-safety FFI only.

### Loop
**2 rounds.** Round 1 → `FINDINGS: 3` (1 medium: the register asserted a clippy `undocumented_unsafe_blocks` lint that is only enabled in `vendor/spargebra`, not first-party; 2 low). Engineer corrected the register. Round 2 → `FINDINGS: 0` → **SIGN-OFF**.

### Remediation beads (to create — `bd` unavailable in the worktree; orchestrator action)
- **MS-G2** (P1): enable `clippy::undocumented_unsafe_blocks` on the 5 unsafe crates + normalise the 6 adjacent-comment sites to the literal `// SAFETY:` token.
- **MS-G3** (P2): standalone ASan lane over the corruption oracle (not just fuzz).
- **MS-G4** (P2): evaluate Kani bounded-proof of the mmap validators.
- **MS-G5** (P2): sync `research/threat-model.md` sparq-core count 39→42 to the ratchet snapshot.

Docs-only — touches no code, no other framework dir. NON-CANONICAL timing.
