### PR TITLE
Certification readiness — NIST SSDF

### DIFF
--- a/compliance/ssdf/README.md
+++ b/compliance/ssdf/README.md
@@ -22,7 +22,7 @@ deploying organization can lift into its own attestation — not a pending exter
 
 | File | Purpose |
 |---|---|
-| [`controls.md`](./controls.md) | The spine: every SSDF task (PO/PS/PW/RV, 41 tasks) → status → repo evidence (file / test / CI job) → owner. |
+| [`controls.md`](./controls.md) | The spine: every SSDF task (PO/PS/PW/RV, 42 task rows) → status → repo evidence (file / test / CI job) → owner. |
 | [`evidence.md`](./evidence.md) | By-artifact index resolving each control claim to a concrete, checkable location + how to reproduce it locally. |
 | [`gap-register.md`](./gap-register.md) | Open gaps (severity, remediation, target, `bd` bead). |
 
@@ -51,8 +51,10 @@ deploying organization can lift into its own attestation — not a pending exter
 
 ## Honesty posture
 
-The coverage summary in `controls.md` reports **27 implemented & verified / 13 audit-ready
-/ 1 gap** across the 41 SSDF tasks. The single technical gap is **PW.6.2 reproducible-build
+The coverage summary in `controls.md` reports **28 implemented & verified / 13 audit-ready
+/ 1 gap** across the 42 SSDF task rows (one of which, `RV.1.4`, is an explicitly-flagged
+sparq-local sub-task supporting standard task RV.1.3 — see the footnote in `controls.md`).
+The single technical gap is **PW.6.2 reproducible-build
 evidence** (GX-8, bead **sq-toze.9**). No row presents the `sparq-zk*` / `sparq-mpc`
 research scaffold as a met security control — its documented **"v1 verifier is NOT sound"**
 verdict (`SECURITY.md`, `research/zk-soundness-audit.md`) is a correctly-disclosed

--- a/compliance/ssdf/README.md
+++ b/compliance/ssdf/README.md
@@ -1,0 +1,59 @@
+<!-- [OPUS-4.8] SSDF framework intro (cert framework `ssdf`, epic sq-toze, bead
+     sq-toze.13). Re-review when Fable returns. NON-CANONICAL timing. -->
+
+# NIST SSDF (SP 800-218 v1.1) — secure-software-development framework
+
+The **NIST Secure Software Development Framework** (SP 800-218 v1.1) is the canonical
+*implementer-side* secure-SDLC framework: a set of practices (grouped **PO** Prepare the
+Organization, **PS** Protect the Software, **PW** Produce Well-Secured Software, **RV**
+Respond to Vulnerabilities) that a software *producer* follows so the artifacts it ships
+are well-secured. sparq is shipped as a dependency (crates.io / npm / PyPI / ghcr), so SSDF
+is a high-fit framework — and, because the practices map directly onto sparq's existing
+gate stack, it is largely a **mapping** exercise rather than a build-out.
+
+## Why SSDF (vs a certification framework)
+
+SSDF is **not a certificate**. There is no "SSDF auditor" who issues a pass/fail seal; it is
+the practice catalogue that producers self-attest to (e.g. in a US federal software
+attestation form). So the deliverables here are an honest **practice → evidence** mapping a
+deploying organization can lift into its own attestation — not a pending external cert.
+
+## What this folder contains
+
+| File | Purpose |
+|---|---|
+| [`controls.md`](./controls.md) | The spine: every SSDF task (PO/PS/PW/RV, 41 tasks) → status → repo evidence (file / test / CI job) → owner. |
+| [`evidence.md`](./evidence.md) | By-artifact index resolving each control claim to a concrete, checkable location + how to reproduce it locally. |
+| [`gap-register.md`](./gap-register.md) | Open gaps (severity, remediation, target, `bd` bead). |
+
+## Scope — what's in, what's the operator's job
+
+**In scope (the producer = sparq project):**
+- The secure-SDLC *gates* — clippy `-D warnings`, CodeQL SAST, `cargo test`/conformance
+  ratchets, Miri, fuzz, the unsafe-count ratchet, cargo-deny advisories/bans/sources/
+  licenses (gating), cargo-vet, the CycloneDX SBOM + VEX, SLSA build provenance, and the
+  `ci-summary / gate` aggregator.
+- The secure-coding standard (`CONTRIBUTING.md`), the threat model
+  (`research/threat-model.md`), the dependency policy (`deny.toml`), and the coordinated
+  vulnerability-disclosure programme (`SECURITY.md` + `.well-known/security.txt`).
+
+**Out of scope (the operator/deploying organization owns):**
+- SSDF practices about the *operating environment* — production deployment, environment
+  separation in *their* infra (PO.5 partially), runtime monitoring, and their own incident
+  response. sparq is a library/engine; the deploying org runs the SSDF programme for its
+  service.
+- The server's **authentication/authorization** is, by documented design (threat-model
+  boundary **B3**), the operator's responsibility ("front with a gateway / sparq-solid") —
+  an explicit architectural decision, not an SSDF gap.
+- **Formal external attestation** of the audit-ready practices — for a single-maintainer
+  volunteer project these are documented + automated and asserted; an org adopting sparq
+  performs the formal attestation against its own ISMS.
+
+## Honesty posture
+
+The coverage summary in `controls.md` reports **27 implemented & verified / 13 audit-ready
+/ 1 gap** across the 41 SSDF tasks. The single technical gap is **PW.6.2 reproducible-build
+evidence** (GX-8, bead **sq-toze.9**). No row presents the `sparq-zk*` / `sparq-mpc`
+research scaffold as a met security control — its documented **"v1 verifier is NOT sound"**
+verdict (`SECURITY.md`, `research/zk-soundness-audit.md`) is a correctly-disclosed
+limitation, and SSDF PW.4/PW.5/PW.8 are scored on the engine, never on the crypto scaffold.

--- a/compliance/ssdf/controls.md
+++ b/compliance/ssdf/controls.md
@@ -1,0 +1,120 @@
+<!-- [OPUS-4.8] NIST SSDF (SP 800-218) control→evidence mapping (cert framework `ssdf`,
+     epic sq-toze, bead sq-toze.13). Authored while Fable unavailable — re-review when
+     Fable returns. NON-CANONICAL timing (EC2 work box) — no measured numbers here. -->
+
+# NIST SSDF (SP 800-218 v1.1) — control → status → evidence
+
+This is the spine the SSDF auditor checks. One row per SSDF **task** (the SP 800-218
+practice tasks PO.1–PO.5, PS.1–PS.3, PW.1–PW.9, RV.1–RV.3). Each row carries an honest
+status label and **repo-relative evidence** (the file that enforces the control, the test
+that regresses it, the `.github/workflows/<wf>.yml` CI job that gates it).
+
+**Status legend** (per the honesty contract):
+
+- **Implemented & verified** — a technical control in the codebase/CI with passing
+  evidence (a file, a gating CI job, a test).
+- **Audit-ready** — the control + its documentation exist, but a *formal attestation* of
+  the practice is an organizational/ISMS act an accredited auditor performs against the
+  operating organization; SSDF is an *implementer/producer* framework with no certificate,
+  so for a single-maintainer research project these are the practices that are **mapped and
+  evidenced** but whose continuous operation is asserted, not externally certified.
+- **Gap** — not met; tracked in [`gap-register.md`](./gap-register.md) with a `bd` bead.
+
+**Scope note.** SSDF is written for an *organization* producing software. sparq is a
+pre-1.0, best-effort, single-maintainer (`@jeswr`) research project (see `SECURITY.md`,
+`AGENTS.md`). Where SSDF assumes an org with roles/RACI/management buy-in, the honest
+mapping is "the practice is implemented as a *documented, automated gate* rather than an
+org-process artifact." Those are labelled **audit-ready** with the gate cited as evidence.
+The **producer = sparq project**; the **acquirer/operator = whoever deploys it** — the
+operator's own SSDF programme (their deployment, monitoring, IR) is out of sparq's scope.
+
+> The single most load-bearing honesty item in this repo is the documented verdict that
+> the **v1 ZK verifier is NOT sound** (`SECURITY.md`, `research/zk-soundness-audit.md`).
+> No SSDF row below claims the `sparq-zk*`/`sparq-mpc` estate provides a security guarantee
+> — PW.4/PW.5/PW.8 are scored on the *engine* (`sparq-core`/`-engine`/`-server`), and the
+> crypto scaffold's disclaimer is treated as a *correctly disclosed* limitation, not a met
+> control.
+
+---
+
+## PO — Prepare the Organization
+
+| Task | Practice | Status | Evidence (file / test / CI job) | Owner |
+|---|---|---|---|---|
+| **PO.1.1** | Define security requirements for software development; maintain them over time. | Audit-ready | `CONTRIBUTING.md` "Secure coding" section (secure-coding standard) + `SECURITY.md` (hardened-input expectations for `sparq-core`/`-engine`/`-server`) + `research/threat-model.md` (STRIDE, boundaries B1–B5). The requirements are documented and version-controlled; a formal org-level requirements register is the operator/org act. | @jeswr |
+| **PO.1.2** | Define roles and responsibilities for the SDLC throughout. | Audit-ready | `CODEOWNERS` (security-sensitive paths — `sparq-zk*`, `sparq-mpc`, `sparq-core`, `sparq-server`, `.github/`, `deny.toml`, `SECURITY.md` — route to `@jeswr` for required review) + `docs/branch-protection.md` (review-before-merge ruleset). Single-maintainer roles are explicit; a multi-role RACI is N/A for a solo project. | @jeswr |
+| **PO.1.3** | Implement supporting toolchains; integrate security tooling; keep it current. | Implemented & verified | The CI toolchain: `.github/workflows/{ci,supply-chain,codeql,miri,fuzz,scorecard,dependency-monitoring,release}.yml`; `.github/dependabot.yml` (4 ecosystems) keeps the toolchain + deps current; pinned-by-SHA actions across all workflows. | @jeswr |
+| **PO.2.1** | Define security checks / criteria for each SDLC stage (gate definitions). | Implemented & verified | `CONTRIBUTING.md` "The gate" + `docs/branch-protection.md` (single required check `ci-summary / gate`) + `.github/PULL_REQUEST_TEMPLATE.md` (per-change re-evaluation checklist tied to AGENTS.md). | @jeswr |
+| **PO.2.2** | Provide role-based training / guidance to development personnel. | Audit-ready | `AGENTS.md` + `CONTRIBUTING.md` "Secure coding" are the contributor secure-coding guidance (unsafe policy, input-validation, supply-chain). For a solo/volunteer project this is the guidance artifact; formal training records are an org act. | @jeswr |
+| **PO.2.3** | Obtain management commitment / leadership support for secure development. | Audit-ready | Implicit for a single-maintainer project (maintainer = decision authority). The disclosure SLAs in `SECURITY.md` and the gating CI are the standing commitment. No separate management-sign-off artifact applies. | @jeswr |
+| **PO.3.1** | Specify which tools (or tool types) are mandated/recommended for each stage. | Implemented & verified | `deny.toml` (cargo-deny policy) + `.github/workflows/supply-chain.yml` (cargo-deny / cargo-vet / cargo-cyclonedx) + `codeql.yml` (CodeQL SAST) + `miri.yml` + `fuzz.yml` + `ci.yml` clippy/fmt. The mandated tool set is encoded as gating jobs. | @jeswr |
+| **PO.3.2** | Configure tools to improve assurance & enforce; integrate into the SDLC. | Implemented & verified | clippy `-D warnings` (gate, `ci.yml#clippy`), CodeQL `security-and-quality` queries (`codeql.yml`), cargo-deny `bans sources licenses` **and** `advisories` gating (`supply-chain.yml#audit`), cargo-vet gating (`supply-chain.yml#vet`), the unsafe-count ratchet (`ci.yml#unsafe-register`, `scripts/unsafe-gate.py`). | @jeswr |
+| **PO.3.3** | Generate, collect & safeguard artifacts that provide evidence of tool use. | Implemented & verified | CI uploads: SBOM artifact (`supply-chain.yml#sbom`), per-release SBOM+VEX (`release.yml`), Scorecard SARIF to code-scanning (`scorecard.yml`), conformance/coverage/unsafe-snapshot artifacts (`ci.yml`), fuzz reproducer artifacts (`fuzz.yml`). `ci-summary / gate` is the aggregated evidence-of-pass per PR. | @jeswr |
+| **PO.4.1** | Define criteria for software-security checks; gather data to determine if met. | Implemented & verified | The conformance/coverage/perf **ratchets** (`CONTRIBUTING.md` "never lower" rule) + the unsafe-count snapshot `bench/unsafe-snapshot.json` are the quantitative criteria; `ci-summary / gate` decides met/not-met per PR. | @jeswr |
+| **PO.4.2** | Implement processes/mechanisms to gather check info from the toolchain. | Implemented & verified | Each gating job writes to `$GITHUB_STEP_SUMMARY` (e.g. `ci.yml` unsafe report, coverage/conformance summaries); `ci-summary.yml#gate` polls every sibling check-run and aggregates the verdict. | @jeswr |
+| **PO.5.1** | Separate & protect each development environment / its integrity. | Audit-ready | CI runs on isolated GitHub-hosted runners (per-job ephemeral VMs); `permissions: contents: read` least-privilege default in workflows; release uses OIDC (no long-lived secrets) for Sigstore attestation. There is no sparq-operated prod environment (it is a library); operator-side environment separation is the operator's responsibility. | @jeswr / operator |
+| **PO.5.2** | Secure & harden development endpoints / enforce config. | Audit-ready | SHA-pinned actions (no floating tags), least-privilege `permissions:` blocks, `concurrency` guards, the distroless non-root container build (`Dockerfile`, `release.yml#container`). Developer-workstation hardening is the contributor/operator's environment, not a property of the source. | @jeswr / operator |
+
+## PS — Protect the Software
+
+| Task | Practice | Status | Evidence (file / test / CI job) | Owner |
+|---|---|---|---|---|
+| **PS.1.1** | Store all forms of code with integrity/provenance/least-privilege access control. | Implemented & verified | Git on GitHub (commit history + signed-tag-capable); `docs/branch-protection.md` (no direct pushes incl. admins, PR-only, required review on CODEOWNERS paths); `CODEOWNERS` restricts who can approve security-sensitive paths. | @jeswr |
+| **PS.2.1** | Make software integrity verifiable to acquirers (signing / provenance). | Implemented & verified | `release.yml`: `actions/attest-build-provenance` (Sigstore-signed SLSA provenance over each archive + the SBOM/VEX), `SHA256SUMS` over all archives, and buildkit `provenance: mode=max` + `sbom: true` on the ghcr.io image. Verify with `gh attestation verify <file> --repo jeswr/sparq`. | @jeswr |
+| **PS.3.1** | Archive & protect each software release (reproducible retrieval of the released bits). | Implemented & verified | GitHub Releases retain the packaged archives + `SHA256SUMS` + SBOM + VEX (`release.yml#release`); the published crates/npm/PyPI artifacts are immutable per their registries; `Cargo.lock` is committed (the exact resolved tree is retrievable). | @jeswr |
+| **PS.3.2** | Collect, safeguard & share provenance data for all components of each release (SBOM). | Implemented & verified | Per-release CycloneDX SBOM **and VEX** (`release.yml#sbom-vex`), provenance-attested; the SBOM maps the NTIA minimum elements (supplier, component, version, PURL, dependency relationship, author, timestamp). `cargo auditable build` embeds the dependency manifest *inside* the released `sparq-cli` binary (`release.yml`, readable via `cargo audit bin`). Daily SBOM-artifact in CI (`supply-chain.yml#sbom`). | @jeswr |
+
+## PW — Produce Well-Secured Software
+
+| Task | Practice | Status | Evidence (file / test / CI job) | Owner |
+|---|---|---|---|---|
+| **PW.1.1** | Use forms of risk modelling (threat modelling, attack surface mapping) to assess. | Implemented & verified | `research/threat-model.md` (STRIDE, boundaries B1–B5, incl. B3 no-auth server boundary + B5 mmap/unsafe boundary); `research/zk-soundness-audit.md` (adversarial ZK soundness audit). | @jeswr |
+| **PW.1.2** | Track & maintain security requirements / risk responses over time. | Implemented & verified | Risk responses tracked as `bd` beads (the gap-fix beads under epic `sq-toze`; the unsafe register's `NEEDS-REVIEW` discipline in `CONTRIBUTING.md`); `compliance/memsafety/unsafe-register.md` is the live per-site risk register for the B5 boundary. | @jeswr |
+| **PW.1.3** | Where applicable, require approval of exceptions to security requirements. | Implemented & verified | `deny.toml` license/advisory **exceptions** each carry a reason + tracking bead; the unsafe register's `NEEDS-REVIEW`+bead rule (`CONTRIBUTING.md`) is the documented exception path; conformance-ratchet divergences require a recorded spec-justified rationale (`CONTRIBUTING.md` "never lower" rule). | @jeswr |
+| **PW.2.1** | Have a qualified person review the software design against security requirements. | Audit-ready | `CODEOWNERS` mandates `@jeswr` review on the security-sensitive paths; `research/` design records (threat-model, zk-soundness-audit) are the documented design-review-of-record. A formally-credentialed independent design reviewer is an external/org act (the ZK estate explicitly carries the "external-cryptographer sign-off out of scope" caveat). | @jeswr |
+| **PW.4.1** | Acquire & reuse well-secured components (vetted dependencies). | Implemented & verified | cargo-vet gating (`supply-chain.yml#vet`, `supply-chain/config.toml` imports Mozilla/Google/Bytecode-Alliance/ISRG/Embark/Zcash trusted audit sets); cargo-deny `sources` (crates.io-only) + `bans` + `licenses` gating (`supply-chain.yml#audit`, `deny.toml`); Dependabot (`.github/dependabot.yml`). | @jeswr |
+| **PW.4.4** | Verify that acquired components comply with requirements (vuln/license/source checks). | Implemented & verified | cargo-deny `advisories` **GATING** at PR time (`supply-chain.yml#audit`) + the daily watchdog (`dependency-monitoring.yml`) as defence-in-depth; `licenses` allowlist + per-crate exceptions in `deny.toml`; `sources` deny-unknown-registry/git. | @jeswr |
+| **PW.5.1** | Adhere to secure coding practices (the secure-coding standard). | Implemented & verified | `CONTRIBUTING.md` "Secure coding" standard (unsafe policy, input validation at the boundary, no unwrap/panic/unbounded-alloc on untrusted input, clean error/log output); enforced by clippy `-D warnings` (`ci.yml#clippy`), `#![forbid(unsafe_code)]` in the non-core crates, and the `// SAFETY:` + register rule on every `unsafe` block. | @jeswr |
+| **PW.6.1** | Configure the build process to improve executable security (hardening flags, opts). | Implemented & verified | `cargo auditable build --release --locked` for the released binary (`release.yml`) embeds the dep manifest; `--locked` pins the exact tree; the distroless non-root read-only-friendly container (`Dockerfile`). | @jeswr |
+| **PW.6.2** | Determine which compiler/interpreter/build-tool features improve security & use them; preserve provenance/reproducibility. | **Gap** | The release build is `--locked` + provenance-attested, but there is **no documented reproducible-build claim/evidence** (GX-8, bead **sq-toze.9**) — SSDF PW.6.2 wants either reproducibility evidence or an honest "not reproducible because…". Tracked as a gap below. (Memory-safety hardening — `#![forbid(unsafe_code)]` + Miri — is covered under PW.5/PW.8.) | @jeswr |
+| **PW.7.1** | Determine whether code review and/or analysis should be used; configure it. | Implemented & verified | PR-only flow with required `@jeswr` review on CODEOWNERS paths (`docs/branch-protection.md`); SAST = CodeQL `security-and-quality` (`codeql.yml`, gating via ci-summary). Both human review and automated analysis are mandated. | @jeswr |
+| **PW.7.2** | Perform the code review / static analysis per org policy. | Implemented & verified | CodeQL runs on push/PR/merge_group + schedule (`codeql.yml`); clippy `-D warnings` (`ci.yml#clippy`); the aggregate `ci-summary / gate` blocks merge until they pass. Code-scanning alerts are kept at zero (policy). | @jeswr |
+| **PW.8.1** | Determine whether executable code testing should be performed; configure it. | Implemented & verified | `ci.yml` (build + nextest sharded `cargo test --workspace` + doctests), W3C SPARQL/SHACL/inference conformance ratchets; the dynamic-analysis lanes are configured and scheduled (Miri, fuzz). | @jeswr |
+| **PW.8.2** | Perform the executable testing & assess results (incl. dynamic/negative testing). | Implemented & verified | `cargo test --workspace` (gating); coverage-guided fuzz over parsers + mmap loader (`fuzz.yml`, libFuzzer, PR-smoke + nightly); Miri UB lane over the `sparq-core` unsafe surface (`miri.yml`, nightly); the mmap-corruption oracle for B5 sites Miri cannot reach (`compliance/memsafety/unsafe-register.md`). | @jeswr |
+| **PW.9.1** | Configure software to have secure settings by default. | Audit-ready | The library/server defaults are conservative (the server documents the no-auth boundary B3 and the "front with a gateway / sparq-solid" guidance — `research/threat-model.md`, `SECURITY.md` — an explicit architectural decision, *not* a silent insecure default); the crypto scaffolds are gated behind opt-in features and carry the no-guarantee disclaimer. Operator-side deployment config (TLS, gateway, resource limits) is the operator's responsibility. | @jeswr / operator |
+| **PW.9.2** | Document the secure default settings & the security implications of changing them. | Audit-ready | `SECURITY.md` (the no-auth boundary, the research-scaffold caveats), `CONTRIBUTING.md` (input-validation expectations), and the per-surface `skills/<surface>/SKILL.md` document the secure-use envelope. A consolidated operator hardening guide is an operator-facing doc the deploying org owns. | @jeswr / operator |
+
+## RV — Respond to Vulnerabilities
+
+| Task | Practice | Status | Evidence (file / test / CI job) | Owner |
+|---|---|---|---|---|
+| **RV.1.1** | Gather information from acquirers/users/sources on potential vulnerabilities. | Implemented & verified | `SECURITY.md` (private GHSA + email channels, response SLAs) + `.well-known/security.txt` (RFC 9116 machine-discoverable pointer); `.github/ISSUE_TEMPLATE/security.yml` + `config.yml` redirect public reports to the private channels. | @jeswr |
+| **RV.1.2** | Review, analyze & confirm reported potential vulnerabilities (triage). | Audit-ready | `SECURITY.md` documents the triage workflow + targets (acknowledge ≤5 business days, initial assessment ≤10). Continuous operation of triage is asserted by the maintainer (best-effort volunteer project); no external attestation applies. | @jeswr |
+| **RV.1.3** | Have a vulnerability-disclosure programme & process to intake reports. | Implemented & verified | GitHub Security Advisories ("Report a vulnerability") + `jesse@jeswr.org` + `.well-known/security.txt` (`Contact`/`Policy`/`Canonical`); coordinated-disclosure language in `SECURITY.md`; `CONTRIBUTING.md` redirects discoverers to the private channels. | @jeswr |
+| **RV.1.4** | Continuously monitor known-vulnerability sources for the software's components. | Implemented & verified | Daily advisory watchdog (`dependency-monitoring.yml` — cargo-deny advisories → single idempotent `security:dependency-vuln` tracking issue) **plus** PR-time `cargo deny check advisories` gating (`supply-chain.yml#audit`) + Dependabot security updates (`.github/dependabot.yml`). | @jeswr |
+| **RV.2.1** | Analyze each vulnerability to gather enough information to plan its remediation. | Audit-ready | `SECURITY.md` "initial assessment" step (severity, reproduce, remediation path); the per-release **VEX** (`release.yml`) is the documented exploitability-analysis artifact for flagged advisories. Per-report analysis records are produced per-incident. | @jeswr |
+| **RV.2.2** | Develop & implement remediation plans for each vulnerability. | Implemented & verified | Fixes land on `main` and ship in the next release (`SECURITY.md` "Supported versions"); remediation work is tracked as `bd` beads (the ZK-soundness remediation beads anchored on `research/zk-soundness-audit.md`; the gap-fix beads under `sq-toze`); the VEX records non-applicable advisories with justification. | @jeswr |
+| **RV.3.1** | Analyze identified vulnerabilities to determine root cause. | Audit-ready | `research/zk-soundness-audit.md` is a worked root-cause analysis (the v1 verifier soundness gaps traced to the missing binding layer); the threat model + register capture systemic causes. Per-incident RCA is produced per report. | @jeswr |
+| **RV.3.2** | Analyze the root cause over time to identify patterns / systemic weaknesses. | Audit-ready | The gap register (`research/production-certification-plan.md` §2 + these `compliance/*/gap-register.md` files) is the standing systemic-weakness ledger; recurring causes feed back into `CONTRIBUTING.md`/`deny.toml`/the ratchets. A formal trend-analysis cadence is an org act. | @jeswr |
+| **RV.3.3** | Review the SDLC to see if the root cause could be avoided in future (feed back). | Implemented & verified | The "never lower a ratchet — fix the regression" rule (`CONTRIBUTING.md`), the unsafe register's `NEEDS-REVIEW`+bead discipline, and the gating-tool additions (advisories PR-gate, cargo-vet, unsafe ratchet) are concrete SDLC feedback from prior root causes; each `deny.toml` exception carries a bead so it is revisited. | @jeswr |
+| **RV.3.4** | Review the SDLC to detect classes of the vulnerability proactively (e.g. add a check). | Implemented & verified | New gating checks added in direct response to risk classes: the fuzz lane (parse/mmap crash classes), the Miri lane (UB classes on the unsafe surface), the unsafe-count ratchet (unsafe-creep class), CodeQL (SAST class). Each is a proactive class-detection control. | @jeswr |
+
+---
+
+## Coverage summary
+
+| Practice group | Tasks | Implemented & verified | Audit-ready | Gap |
+|---|---|---|---|---|
+| **PO** (Prepare the Organization) | 12 | 7 | 5 | 0 |
+| **PS** (Protect the Software) | 4 | 4 | 0 | 0 |
+| **PW** (Produce Well-Secured Software) | 14 | 10 | 3 | 1 |
+| **RV** (Respond to Vulnerabilities) | 11 | 6 | 5 | 0 |
+| **Total** | **41** | **27** | **13** | **1** |
+
+The single technical **gap** is **PW.6.2 reproducible-build evidence** (GX-8 / bead
+sq-toze.9). The **audit-ready** rows are the practices that are documented + automated but
+whose *continuous operation* / *formal attestation* is an organizational act SSDF leaves to
+the producing org — for a single-maintainer volunteer project these are asserted with the
+gate/doc cited, not externally certified. No row overclaims, and none presents the
+`sparq-zk*`/`sparq-mpc` estate as a met cryptographic control — its no-guarantee disclaimer
+is a correctly-disclosed limitation (`SECURITY.md`, `research/zk-soundness-audit.md`).

--- a/compliance/ssdf/controls.md
+++ b/compliance/ssdf/controls.md
@@ -91,7 +91,7 @@ operator's own SSDF programme (their deployment, monitoring, IR) is out of sparq
 | **RV.1.1** | Gather information from acquirers/users/sources on potential vulnerabilities. | Implemented & verified | `SECURITY.md` (private GHSA + email channels, response SLAs) + `.well-known/security.txt` (RFC 9116 machine-discoverable pointer); `.github/ISSUE_TEMPLATE/security.yml` + `config.yml` redirect public reports to the private channels. | @jeswr |
 | **RV.1.2** | Review, analyze & confirm reported potential vulnerabilities (triage). | Audit-ready | `SECURITY.md` documents the triage workflow + targets (acknowledge ≤5 business days, initial assessment ≤10). Continuous operation of triage is asserted by the maintainer (best-effort volunteer project); no external attestation applies. | @jeswr |
 | **RV.1.3** | Have a vulnerability-disclosure programme & process to intake reports. | Implemented & verified | GitHub Security Advisories ("Report a vulnerability") + `jesse@jeswr.org` + `.well-known/security.txt` (`Contact`/`Policy`/`Canonical`); coordinated-disclosure language in `SECURITY.md`; `CONTRIBUTING.md` redirects discoverers to the private channels. | @jeswr |
-| **RV.1.4** | Continuously monitor known-vulnerability sources for the software's components. | Implemented & verified | Daily advisory watchdog (`dependency-monitoring.yml` — cargo-deny advisories → single idempotent `security:dependency-vuln` tracking issue) **plus** PR-time `cargo deny check advisories` gating (`supply-chain.yml#audit`) + Dependabot security updates (`.github/dependabot.yml`). | @jeswr |
+| **RV.1.4** ⚑ | Continuously monitor known-vulnerability sources for the software's components. **(sparq-local sub-task — NOT a standard SP 800-218 v1.1 task id; see footnote ⚑.)** | Implemented & verified | Daily advisory watchdog (`dependency-monitoring.yml` — cargo-deny advisories → single idempotent `security:dependency-vuln` tracking issue) **plus** PR-time `cargo deny check advisories` gating (`supply-chain.yml#audit`) + Dependabot security updates (`.github/dependabot.yml`). | @jeswr |
 | **RV.2.1** | Analyze each vulnerability to gather enough information to plan its remediation. | Audit-ready | `SECURITY.md` "initial assessment" step (severity, reproduce, remediation path); the per-release **VEX** (`release.yml`) is the documented exploitability-analysis artifact for flagged advisories. Per-report analysis records are produced per-incident. | @jeswr |
 | **RV.2.2** | Develop & implement remediation plans for each vulnerability. | Implemented & verified | Fixes land on `main` and ship in the next release (`SECURITY.md` "Supported versions"); remediation work is tracked as `bd` beads (the ZK-soundness remediation beads anchored on `research/zk-soundness-audit.md`; the gap-fix beads under `sq-toze`); the VEX records non-applicable advisories with justification. | @jeswr |
 | **RV.3.1** | Analyze identified vulnerabilities to determine root cause. | Audit-ready | `research/zk-soundness-audit.md` is a worked root-cause analysis (the v1 verifier soundness gaps traced to the missing binding layer); the threat model + register capture systemic causes. Per-incident RCA is produced per report. | @jeswr |
@@ -99,17 +99,33 @@ operator's own SSDF programme (their deployment, monitoring, IR) is out of sparq
 | **RV.3.3** | Review the SDLC to see if the root cause could be avoided in future (feed back). | Implemented & verified | The "never lower a ratchet — fix the regression" rule (`CONTRIBUTING.md`), the unsafe register's `NEEDS-REVIEW`+bead discipline, and the gating-tool additions (advisories PR-gate, cargo-vet, unsafe ratchet) are concrete SDLC feedback from prior root causes; each `deny.toml` exception carries a bead so it is revisited. | @jeswr |
 | **RV.3.4** | Review the SDLC to detect classes of the vulnerability proactively (e.g. add a check). | Implemented & verified | New gating checks added in direct response to risk classes: the fuzz lane (parse/mmap crash classes), the Miri lane (UB classes on the unsafe surface), the unsafe-count ratchet (unsafe-creep class), CodeQL (SAST class). Each is a proactive class-detection control. | @jeswr |
 
+> ⚑ **`RV.1.4` is a sparq-local sub-task, not a standard SP 800-218 v1.1 task id.** The
+> publication defines RV.1 with exactly three tasks — **RV.1.1 / RV.1.2 / RV.1.3** — and the
+> "continuously monitor known-vulnerability sources" obligation is part of RV.1's existing text
+> (gather/monitor information about potential vulnerabilities) rather than a separate numbered
+> task. We retain `RV.1.4` as an explicitly-flagged sparq-local row because the underlying
+> control (the daily advisory watchdog + the PR-time advisories gate + Dependabot) is a real,
+> well-evidenced extension of RV.1.3's continuous-monitoring intent; it is **never** asserted as
+> a standard framework control number. An assessor mapping IDs back to the publication should
+> read this row as evidence *supporting RV.1.3*, sub-labelled `RV.1.4` for local traceability.
+
 ---
 
 ## Coverage summary
 
 | Practice group | Tasks | Implemented & verified | Audit-ready | Gap |
 |---|---|---|---|---|
-| **PO** (Prepare the Organization) | 12 | 7 | 5 | 0 |
+| **PO** (Prepare the Organization) | 13 | 7 | 6 | 0 |
 | **PS** (Protect the Software) | 4 | 4 | 0 | 0 |
-| **PW** (Produce Well-Secured Software) | 14 | 10 | 3 | 1 |
-| **RV** (Respond to Vulnerabilities) | 11 | 6 | 5 | 0 |
-| **Total** | **41** | **27** | **13** | **1** |
+| **PW** (Produce Well-Secured Software) | 15 | 11 | 3 | 1 |
+| **RV** (Respond to Vulnerabilities) | 10 | 6 | 4 | 0 |
+| **Total** | **42** | **28** | **13** | **1** |
+
+These totals are re-derived mechanically from the rows above and cross-foot exactly: the
+**Tasks** column sums to 42 (13 + 4 + 15 + 10) and equals the status columns (28 + 13 + 1); each
+group's row count equals its own status split. (The RV count includes the sparq-local `RV.1.4`
+sub-task flagged above; it is evidence supporting standard task RV.1.3, not a separate framework
+task — see footnote ⚑.)
 
 The single technical **gap** is **PW.6.2 reproducible-build evidence** (GX-8 / bead
 sq-toze.9). The **audit-ready** rows are the practices that are documented + automated but

--- a/compliance/ssdf/evidence.md
+++ b/compliance/ssdf/evidence.md
@@ -34,14 +34,19 @@ repo-relative. "Gating" means the artifact is a required CI check folded into
 | `ci.yml#coverage` | per-crate coverage + test-presence ratchet | PO.4.1 |
 | `ci.yml#unsafe-register` | unsafe-count ratchet (`scripts/unsafe-gate.py`, `bench/unsafe-snapshot.json`) | PO.3.2, PO.4.1, RV.3.4 |
 | `codeql.yml` | CodeQL `security-and-quality` SAST | PO.3.2, PW.7.1, PW.7.2 |
-| `supply-chain.yml#audit` | `cargo deny check bans sources licenses` **and** `advisories` (all gating) | PO.3.2, PW.4.1, PW.4.4, RV.1.4 |
+| `supply-chain.yml#audit` | `cargo deny check bans sources licenses` **and** `advisories` (all gating) | PO.3.2, PW.4.1, PW.4.4, RV.1.3 (sparq-local `RV.1.4`) |
 | `supply-chain.yml#vet` | `cargo vet --locked` (per-dependency audit attestations, gating) | PW.4.1 |
 | `supply-chain.yml#sbom` | CycloneDX SBOM artifact (`**/*.cdx.json`) | PO.3.3, PS.3.2 |
 | `miri.yml#miri` | UB lane over `sparq-core` unsafe surface (nightly) | PW.8.2 |
 | `fuzz.yml#fuzz` | coverage-guided fuzz (parsers + mmap loader) | PW.8.2, RV.3.4 |
 | `scorecard.yml#analysis` | OpenSSF Scorecard → SARIF + public dashboard | PO.3.3 |
-| `dependency-monitoring.yml` | daily advisory watchdog → tracking issue | RV.1.4 |
+| `dependency-monitoring.yml` | daily advisory watchdog → tracking issue | RV.1.3 (sparq-local `RV.1.4`) |
 | `ci-summary.yml#gate` | the single required aggregator (merge gate) | PO.2.1, PO.4.2, PO.3.3 |
+
+> **`RV.1.4` is a sparq-local sub-task, not a standard SP 800-218 v1.1 task id.** RV.1 defines
+> only RV.1.1 / RV.1.2 / RV.1.3; the continuous-monitoring obligation lives in RV.1.3's text.
+> The watchdog/advisories-gate/Dependabot evidence above is mapped to standard **RV.1.3** and
+> carries the `RV.1.4` label only for local traceability — see the footnote in `controls.md`.
 
 ## 3. Release & provenance artifacts (PS, PW.6)
 
@@ -53,7 +58,7 @@ repo-relative. "Gating" means the artifact is a required CI check folded into
 | `cargo auditable` embedded dependency manifest in `sparq-cli` | `release.yml` (`cargo auditable build --release --locked`) | PS.3.2, PW.6.1 |
 | Container SLSA provenance + embedded SBOM (`provenance: mode=max`, `sbom: true`) | `release.yml#container`, `Dockerfile` | PS.2.1, PS.3.2, PW.6.1 |
 | Committed `Cargo.lock` (exact resolved tree) | `Cargo.lock` | PS.3.1, PW.6.1 |
-| Dependency update automation (4 ecosystems) | `.github/dependabot.yml` | PO.1.3, PW.4.1, RV.1.4 |
+| Dependency update automation (4 ecosystems) | `.github/dependabot.yml` | PO.1.3, PW.4.1, RV.1.3 (sparq-local `RV.1.4`) |
 
 ## 4. How to reproduce the evidence locally
 

--- a/compliance/ssdf/evidence.md
+++ b/compliance/ssdf/evidence.md
@@ -1,0 +1,94 @@
+<!-- [OPUS-4.8] SSDF evidence index (cert framework `ssdf`, epic sq-toze, bead
+     sq-toze.13). Re-review when Fable returns. NON-CANONICAL timing. -->
+
+# NIST SSDF (SP 800-218) — evidence index
+
+A by-artifact index of the repo evidence the [`controls.md`](./controls.md) rows cite, so
+the auditor can resolve each claim to a concrete, checkable location. Paths are
+repo-relative. "Gating" means the artifact is a required CI check folded into
+`ci-summary / gate` (the single required status check — `docs/branch-protection.md`).
+
+## 1. Governance & policy artifacts (PO, RV)
+
+| Artifact | Path | SSDF tasks it evidences |
+|---|---|---|
+| Security policy + disclosure + SLAs + research-scaffold caveats | `SECURITY.md` | PO.1.1, RV.1.1, RV.1.2, RV.1.3, RV.2.1, RV.2.2, PW.9.2 |
+| Machine-readable disclosure pointer (RFC 9116) | `.well-known/security.txt` | RV.1.1, RV.1.3 |
+| Contributor secure-coding standard | `CONTRIBUTING.md` ("Secure coding" + "The gate") | PO.1.1, PO.2.1, PO.2.2, PW.1.3, PW.5.1, RV.3.3 |
+| Code ownership / required-reviewer routing | `CODEOWNERS` | PO.1.2, PS.1.1, PW.2.1, PW.7.1 |
+| Branch-protection doc-of-record | `docs/branch-protection.md` | PO.2.1, PS.1.1, PW.7.1 |
+| PR template (per-change re-evaluation checklist) | `.github/PULL_REQUEST_TEMPLATE.md` | PO.2.1, PW.8.1 |
+| Issue templates redirecting security reports | `.github/ISSUE_TEMPLATE/{security,config}.yml` | RV.1.1, RV.1.3 |
+| Threat model (STRIDE, boundaries B1–B5) | `research/threat-model.md` | PW.1.1, PW.9.1 |
+| ZK soundness audit (root-cause analysis of record) | `research/zk-soundness-audit.md` | PW.1.1, RV.3.1, PW.2.1 |
+| Per-site `unsafe` justification register (B5 boundary) | `compliance/memsafety/unsafe-register.md` | PW.1.2, PW.8.2 |
+| Dependency policy | `deny.toml` + `supply-chain/config.toml` | PO.3.1, PW.1.3, PW.4.1, PW.4.4 |
+
+## 2. CI gates (the enforced controls)
+
+| CI job (workflow#job) | What it gates | SSDF tasks |
+|---|---|---|
+| `ci.yml#clippy` | clippy `-D warnings` (gating) + fmt (non-blocking today) | PO.3.2, PW.5.1, PW.7.2 |
+| `ci.yml#test` (sharded) | `cargo test --workspace` + doctests | PW.8.1, PW.8.2 |
+| `ci.yml#conformance` (SPARQL/SHACL/inference ratchets) | spec-conformance floors (never lowered) | PO.4.1, PW.8.2 |
+| `ci.yml#coverage` | per-crate coverage + test-presence ratchet | PO.4.1 |
+| `ci.yml#unsafe-register` | unsafe-count ratchet (`scripts/unsafe-gate.py`, `bench/unsafe-snapshot.json`) | PO.3.2, PO.4.1, RV.3.4 |
+| `codeql.yml` | CodeQL `security-and-quality` SAST | PO.3.2, PW.7.1, PW.7.2 |
+| `supply-chain.yml#audit` | `cargo deny check bans sources licenses` **and** `advisories` (all gating) | PO.3.2, PW.4.1, PW.4.4, RV.1.4 |
+| `supply-chain.yml#vet` | `cargo vet --locked` (per-dependency audit attestations, gating) | PW.4.1 |
+| `supply-chain.yml#sbom` | CycloneDX SBOM artifact (`**/*.cdx.json`) | PO.3.3, PS.3.2 |
+| `miri.yml#miri` | UB lane over `sparq-core` unsafe surface (nightly) | PW.8.2 |
+| `fuzz.yml#fuzz` | coverage-guided fuzz (parsers + mmap loader) | PW.8.2, RV.3.4 |
+| `scorecard.yml#analysis` | OpenSSF Scorecard → SARIF + public dashboard | PO.3.3 |
+| `dependency-monitoring.yml` | daily advisory watchdog → tracking issue | RV.1.4 |
+| `ci-summary.yml#gate` | the single required aggregator (merge gate) | PO.2.1, PO.4.2, PO.3.3 |
+
+## 3. Release & provenance artifacts (PS, PW.6)
+
+| Artifact | Path / where produced | SSDF tasks |
+|---|---|---|
+| SLSA build-provenance attestation (Sigstore-signed) over archives | `release.yml` `actions/attest-build-provenance` step | PS.2.1, PS.3.2 |
+| `SHA256SUMS` over release archives | `release.yml#release` | PS.2.1, PS.3.1 |
+| Per-release CycloneDX SBOM **+ VEX** | `release.yml#sbom-vex` (provenance-attested) | PS.3.2, PW.4.4 |
+| `cargo auditable` embedded dependency manifest in `sparq-cli` | `release.yml` (`cargo auditable build --release --locked`) | PS.3.2, PW.6.1 |
+| Container SLSA provenance + embedded SBOM (`provenance: mode=max`, `sbom: true`) | `release.yml#container`, `Dockerfile` | PS.2.1, PS.3.2, PW.6.1 |
+| Committed `Cargo.lock` (exact resolved tree) | `Cargo.lock` | PS.3.1, PW.6.1 |
+| Dependency update automation (4 ecosystems) | `.github/dependabot.yml` | PO.1.3, PW.4.1, RV.1.4 |
+
+## 4. How to reproduce the evidence locally
+
+```sh
+# Dependency policy (the currently-gating subset + advisories)
+cargo deny check bans sources licenses
+cargo deny check advisories            # gating again post-GX-1 (CVSS-4.0 parse fixed)
+cargo vet --locked                     # per-dependency audit attestations
+
+# SBOM
+cargo cyclonedx --all --format json    # CycloneDX SBOMs (**/*.cdx.json)
+
+# Memory-safety / unsafe attestation
+python3 scripts/unsafe-gate.py --check # the unsafe-count ratchet
+cargo +nightly miri test -p sparq-core # UB lane (needs nightly + miri component)
+
+# Provenance verification of a published release artifact
+gh attestation verify <archive> --repo jeswr/sparq
+
+# Read the embedded dependency manifest of a released binary
+cargo audit bin <path-to-sparq-cli>
+```
+
+## 5. Honest gaps (do not read these as met)
+
+- **PW.6.2 — reproducible builds (GX-8, bead sq-toze.9).** The release is `--locked` +
+  provenance-attested, but there is no reproducible-build claim or evidence yet. See
+  [`gap-register.md`](./gap-register.md). This is the only *technical* SSDF gap.
+- The **audit-ready** rows in `controls.md` (PO.1.x/PO.2.x/PO.5.x, several RV tasks) are
+  *documented + automated* but their continuous operation / formal attestation is an
+  organizational act; for a single-maintainer volunteer project they are asserted with the
+  cited gate/doc, not externally certified. SSDF itself ships **no certificate** — it is an
+  implementer-side practice framework — so "audit-ready" here means *evidenced and ready for
+  an org to assert*, not "a cert is pending".
+- The `sparq-zk*` / `sparq-mpc` estate is **not** counted as a met security control
+  anywhere in this mapping; its no-guarantee disclaimer (`SECURITY.md`,
+  `research/zk-soundness-audit.md`) is a correctly-disclosed limitation. Any future control
+  claim that contradicts the "v1 verifier is NOT sound" verdict is out of bounds.

--- a/compliance/ssdf/gap-register.md
+++ b/compliance/ssdf/gap-register.md
@@ -1,0 +1,60 @@
+<!-- [OPUS-4.8] SSDF gap register (cert framework `ssdf`, epic sq-toze, bead sq-toze.13).
+     Re-review when Fable returns. NON-CANONICAL timing. -->
+
+# NIST SSDF (SP 800-218) — gap register
+
+Open gaps for the SSDF mapping, each with severity, the affected SSDF task, a remediation
+plan, a target, and the **`bd` bead** that tracks the fix (gap-fix beads live under epic
+`sq-toze`). A gap is recorded here only when a practice is **not** met by current
+codebase/CI evidence — controls that are met are in [`controls.md`](./controls.md), and
+*audit-ready* practices (documented + automated, formal attestation = org act) are **not**
+gaps and are not listed here.
+
+SSDF coverage is high because it is largely a **mapping** of sparq's existing gate stack
+(see `controls.md` coverage summary: 27 implemented & verified / 13 audit-ready / **1
+gap**). The cross-cutting supply-chain/secure-coding gaps that other frameworks share
+(GX-1 advisories PR-gate, GX-5 unsafe register, GX-6 secure-coding section, GX-7
+cargo-auditable/vet) have **already landed** in the codebase and are cited as evidence in
+`controls.md` — they are *not* re-listed as SSDF gaps.
+
+## Open gaps
+
+### SSDF-G1 — PW.6.2: no reproducible-build evidence
+
+| Field | Value |
+|---|---|
+| **SSDF task** | PW.6.2 (use build features that preserve provenance/reproducibility) |
+| **Cross-cutting id** | GX-8 |
+| **Severity** | P2 (raises assurance; not a vulnerability) |
+| **Bead** | **sq-toze.9** (`[cert][gap GX-8] Reproducible-build evidence`) — already open under epic `sq-toze` |
+| **Status** | Open |
+| **What's missing** | The release build is `cargo auditable build --release --locked` and SLSA-provenance-attested, but there is **no documented reproducible-build claim or evidence** — neither a "byte-for-byte reproducible from this commit + toolchain" demonstration nor an honest "not reproducible because <X>" statement. SSDF PW.6.2 (and CRA integrity / SLSA higher levels) want one or the other. |
+| **Remediation plan** | (1) Attempt a double-build of `sparq-cli` for one target and diff the artifacts; (2) if reproducible, document the pinned inputs (toolchain version, `--locked`, `RUSTFLAGS`, `SOURCE_DATE_EPOCH`) and add a CI job that rebuilds + compares digests; (3) if **not** reproducible, document the specific non-determinism source(s) (e.g. embedded build paths, parallel-codegen ordering, timestamps) as an honest PW.6.2 statement and link it from `controls.md`. Either outcome closes the gap honestly. |
+| **Target** | Before a 1.0 release; not a pre-1.0 blocker (the project is explicitly pre-1.0, `SECURITY.md`). |
+| **Owner** | @jeswr |
+
+## Watch items (not gaps — evidence present, bead still open)
+
+These are **not** SSDF gaps: the technical control is present and cited in `controls.md`.
+They are listed only so the auditor knows the corresponding `sq-toze` bead is still open
+(closing it is a bookkeeping act once the lead consolidates), so there is no
+record-vs-reality drift.
+
+| Item | SSDF tasks | Evidence (present) | Bead (open) |
+|---|---|---|---|
+| cargo-auditable + cargo-vet | PW.4.1, PS.3.2, PW.6.1 | `supply-chain.yml#vet` (gating), `release.yml` (`cargo auditable build`), `supply-chain/config.toml` | sq-toze.8 (GX-7) |
+
+> The bead for the **advisories PR-gate** (GX-1, sq-toze.2), the **per-release SBOM+VEX**
+> (GX-2, sq-toze.3), **`security.txt`** (GX-3, sq-toze.4), the **unsafe register + ratchet**
+> (GX-5, sq-toze.6), and the **secure-coding section** (GX-6, sq-toze.7) are all **closed**
+> and their controls are cited as met evidence in `controls.md` — they are not gaps.
+
+## Discovered work (new beads filed by this SSDF pass)
+
+This pass filed the following bead(s) under epic `sq-toze` for SSDF-specific follow-up that
+the existing gap-fix beads did not already cover. (`bd` beads are created from the main
+checkout per repo policy; they are referenced here, never hand-edited into `.beads/`.)
+
+| Bead | Title | Why |
+|---|---|---|
+| **sq-5ty0** | SSDF PO.1.1 — publish a stand-alone Secure-SDLC policy template | SSDF PO.1.1/PO.2.1 are evidenced today by `CONTRIBUTING.md` + `SECURITY.md` + the threat model (mapping-level, **audit-ready**). A consolidated, stand-alone *Secure-SDLC policy* template (under `compliance/policies/`) would let a deploying **org** adopt sparq's SDLC posture as a formal policy artifact and lift PO.1.1/PO.2.1 from audit-ready toward a clean org-level attestation. Not a codebase gap — a policy-template deliverable. Filed under epic `sq-toze` (blocks it). |

--- a/compliance/ssdf/gap-register.md
+++ b/compliance/ssdf/gap-register.md
@@ -11,8 +11,8 @@ codebase/CI evidence — controls that are met are in [`controls.md`](./controls
 gaps and are not listed here.
 
 SSDF coverage is high because it is largely a **mapping** of sparq's existing gate stack
-(see `controls.md` coverage summary: 27 implemented & verified / 13 audit-ready / **1
-gap**). The cross-cutting supply-chain/secure-coding gaps that other frameworks share
+(see `controls.md` coverage summary: 28 implemented & verified / 13 audit-ready / **1
+gap**, across 42 task rows). The cross-cutting supply-chain/secure-coding gaps that other frameworks share
 (GX-1 advisories PR-gate, GX-5 unsafe register, GX-6 secure-coding section, GX-7
 cargo-auditable/vet) have **already landed** in the codebase and are cited as evidence in
 `controls.md` — they are *not* re-listed as SSDF gaps.


### PR DESCRIPTION
> 🤖 SPARQ agent

NIST SSDF (SP 800-218 v1.1) certification-readiness slice. Refs epic **sq-toze**, bead **sq-toze.13**.

## What this adds (docs only — no `crates/` changes)

`compliance/ssdf/`:
- **`controls.md`** — the spine: every SSDF task (PO/PS/PW/RV, **42 task rows**) → status → repo evidence (file / test / CI job) → owner.
- **`evidence.md`** — by-artifact index resolving each claim to a checkable location + local-repro commands.
- **`gap-register.md`** — open gaps + severity + remediation + `bd` bead.
- **`README.md`** — framework intro + scope (producer vs operator split).

## Honest coverage

| | Implemented & verified | Audit-ready | Gap |
|---|---|---|---|
| 42 SSDF task rows | **28** | **13** | **1** |

Per-group cross-foot (re-derived mechanically from the rows): **PO 13** (7/6/0) · **PS 4** (4/0/0) · **PW 15** (11/3/1) · **RV 10** (6/4/0) = **42 / 28 / 13 / 1**.

- **Single technical gap: PW.6.2 reproducible-build evidence** (GX-8 / bead **sq-toze.9**, already open).
- *Audit-ready* = documented + automated practices whose **formal attestation is an org/ISMS act** — SSDF ships no certificate, so these are evidenced and ready for an org to assert, not a pending external cert.
- One RV row, **`RV.1.4`**, is an explicitly-flagged **sparq-local sub-task** supporting standard task **RV.1.3** (SP 800-218 v1.1's RV.1 defines only .1/.2/.3); it is never asserted as a standard framework task id — see the footnote in `controls.md`.
- SSDF is largely a **mapping** of sparq's existing gate stack; cross-cutting gap-fixes already landed (advisories PR-gate GX-1, per-release SBOM+VEX GX-2, security.txt GX-3, unsafe register+ratchet GX-5, secure-coding section GX-6, cargo-auditable+vet GX-7) are **cited as met evidence, not re-claimed**.

## Honesty contract

No row presents the `sparq-zk*` / `sparq-mpc` scaffold as a met security control. The documented **"v1 ZK verifier is NOT sound"** verdict (`SECURITY.md`, `research/zk-soundness-audit.md`) is preserved as a correctly-disclosed limitation; SSDF PW.4/PW.5/PW.8 are scored on the engine only.

## Audit findings — addressed

The SSDF compliance-auditor returned **FINDINGS: 2** (`compliance/audit/ssdf-findings.md`). Both fixed:
- **F1 (medium):** the coverage-summary table now cross-foots exactly with its rows — **42 / 28 / 13 / 1**, per-group **PO 13 / PW 15 / RV 10** — and the corrected totals are propagated to `README.md`, `evidence.md`, `gap-register.md`, and this PR body.
- **F2 (low):** `RV.1.4` (not a real SP 800-218 v1.1 task id) is remapped onto standard **RV.1.3** in `evidence.md` and footnoted in `controls.md` as a sparq-local sub-task — no fabricated standard control number remains.

## Discovered work
- **sq-5ty0** — publish a stand-alone Secure-SDLC policy template (lifts PO.1.1/PO.2.1 toward org attestation). Filed under `sq-toze` (blocks it).
