### PR TITLE
feat(service): bind-join (VALUES pushdown) into SERVICE [OPUS-4.8] (sq-sjkj)

### DIFF
--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -1863,6 +1863,26 @@ fn eval_graph_pattern_inner(graph: &Graph, local: &mut LocalVocab, p: &GraphPatt
         }
         GraphPattern::Join { left, right } => {
             let l = eval_graph_pattern(graph, local, left)?;
+            // Bind-join pushdown: if the RIGHT side is a SERVICE and the left has
+            // already bound its join variables, push those bindings to the remote as a
+            // VALUES block instead of materialising the whole remote relation. Join is
+            // symmetric, so try either side as the SERVICE. [OPUS-4.8] (sq-sjkj)
+            #[cfg(feature = "service")]
+            {
+                if let Some(r) = try_bound_join_service(graph, local, &l, right)? {
+                    return Ok(join_bindings(l, r));
+                }
+                // Symmetric: SERVICE on the left, bindings produced by the right.
+                if matches!(left.as_ref(), GraphPattern::Service { .. }) {
+                    let r = eval_graph_pattern(graph, local, right)?;
+                    if let Some(sl) = try_bound_join_service(graph, local, &r, left)? {
+                        return Ok(join_bindings(r, sl));
+                    }
+                    // Fall through with the already-evaluated right; recompute left verbatim.
+                    let l2 = eval_graph_pattern(graph, local, left)?;
+                    return Ok(join_bindings(l2, r));
+                }
+            }
             let r = eval_graph_pattern(graph, local, right)?;
             Ok(join_bindings(l, r))
         }
@@ -1874,6 +1894,15 @@ fn eval_graph_pattern_inner(graph: &Graph, local: &mut LocalVocab, p: &GraphPatt
             #[cfg(feature = "zk")]
             let _zk = crate::zk::op_scope(crate::zk::Op::Optional);
             let l = eval_graph_pattern(graph, local, left)?;
+            // Bind-join pushdown for `… OPTIONAL { SERVICE { … } }`: the SERVICE may
+            // only be the RIGHT (preserved) side of a left join — pushing the left's
+            // bound join vars restricts the remote relation, then the SAME
+            // `left_outer_join` reattaches it, so OPTIONAL semantics are unchanged
+            // (a left row with no remote match still survives, unbound). [OPUS-4.8] (sq-sjkj)
+            #[cfg(feature = "service")]
+            if let Some(r) = try_bound_join_service(graph, local, &l, right)? {
+                return left_outer_join(graph, local, l, r, expression.as_ref());
+            }
             let r = eval_graph_pattern(graph, local, right)?;
             left_outer_join(graph, local, l, r, expression.as_ref())
         }
@@ -1923,13 +1952,19 @@ fn eval_graph_pattern_inner(graph: &Graph, local: &mut LocalVocab, p: &GraphPatt
     }
 }
 
-/// SPARQL 1.1 federated query (`SERVICE`). [OPUS-4.8]
+/// SPARQL 1.1 federated query (`SERVICE`) — the VERBATIM path. [OPUS-4.8]
 ///
 /// Forwards `SELECT * WHERE { <inner> }` to the remote `endpoint`, parses the
 /// SPARQL-Results-JSON response (see [`crate::service`]) and turns it into a
 /// [`Bindings`] relation interned against this query's dictionaries — exactly as
 /// `VALUES` does — so the caller joins it with the surrounding group via the normal
 /// `join_bindings` path.
+///
+/// This is the fallback path: when the SERVICE is the right side of a join whose join
+/// vars are already bound, [`try_bound_join_service`] instead pushes those bindings as
+/// a `VALUES` block (the bind-join, bead sq-sjkj) and this verbatim forward is skipped.
+/// `eval_service` still runs for a top-level / unbound SERVICE and for every case the
+/// bind-join declines (variable endpoint, no bound join var, blank-node join key).
 ///
 /// * `name` is a `NamedNodePattern`: a concrete IRI endpoint is evaluated; a
 ///   `?var` (variable) endpoint is OUT OF SCOPE (it requires a per-solution remote
@@ -1983,6 +2018,19 @@ fn eval_service(
         Err(e) => return Err(e),
     };
 
+    Ok(service_relation_to_bindings(graph, local, rel))
+}
+
+/// Intern a remote [`ServiceRelation`](crate::service::ServiceRelation) into id-level
+/// [`Bindings`] against this query's dictionaries — exactly as `VALUES` does — so it
+/// joins with local BGP results. Shared by the verbatim and bound-join paths.
+/// [OPUS-4.8] (sq-sjkj)
+#[cfg(feature = "service")]
+fn service_relation_to_bindings(
+    graph: &Graph,
+    local: &mut LocalVocab,
+    rel: crate::service::ServiceRelation,
+) -> Bindings {
     // Intern each remote term against the graph dictionary (so it joins with local
     // BGP results) or the local vocab (terms absent from the data can still match
     // other remote/VALUES rows) — identical to `values_bindings`.
@@ -1998,7 +2046,156 @@ fn eval_service(
                 .collect()
         })
         .collect();
-    Ok(Bindings::unsorted(rel.vars, rows))
+    Bindings::unsorted(rel.vars, rows)
+}
+
+/// Attempt a bind-join (`VALUES` pushdown) of a SERVICE sub-query against the
+/// already-evaluated `left` bindings. [OPUS-4.8] (sq-sjkj — research candidate C1)
+///
+/// Returns:
+/// * `Ok(Some(service_bindings))` — the bound-join applied: a remote relation
+///   restricted to `left`'s bound join-key tuples, ready for the caller to join (or
+///   left-outer-join) with `left` exactly as it would the verbatim relation. The
+///   answer is identical to the unbound-then-local-join path.
+/// * `Ok(None)` — the pushdown does NOT apply (the right side is not a concrete-IRI
+///   SERVICE, there is no shared bound join var, a join key is bound to a blank node,
+///   or the left side is empty). The caller falls back to the verbatim SERVICE path.
+/// * `Err(_)` — a non-SILENT remote failure (propagated, same as the verbatim path).
+///
+/// ## Why it preserves semantics
+///
+/// Injecting `VALUES (?j…) { (v…)… }` for the join variables restricts the remote
+/// pattern to exactly the tuples `left` already binds (SPARQL 1.1 §10.2.1 inner-joins
+/// the VALUES relation with the pattern). The remote therefore returns a SUBSET of
+/// the unbound relation — precisely the rows that can survive the local join — and we
+/// reattach them with the SAME `join_bindings` / `left_outer_join`. For a left-outer
+/// join, a left row whose key has no remote match simply finds no compatible remote
+/// row and survives unbound, identical to the verbatim path. SILENT is honoured: a
+/// failed block degrades to the join identity (empty remote relation) so the
+/// surrounding bindings are kept, exactly as the verbatim SILENT path does.
+#[cfg(feature = "service")]
+fn try_bound_join_service(
+    graph: &Graph,
+    local: &mut LocalVocab,
+    left: &Bindings,
+    right: &GraphPattern,
+) -> Result<Option<Bindings>, String> {
+    let GraphPattern::Service { name, inner, silent } = right else {
+        return Ok(None);
+    };
+    let silent = *silent;
+
+    // Only a concrete-IRI endpoint can be bound-joined; a variable endpoint is the
+    // documented scope-out handled by the verbatim path.
+    let endpoint = match name {
+        NamedNodePattern::NamedNode(n) => n.as_str().to_string(),
+        NamedNodePattern::Variable(_) => return Ok(None),
+    };
+
+    // The remote pattern's in-scope variables; the join keys are the ones ALSO bound
+    // by `left`. We must intersect with `left.vars` (textual) so the VALUES we push
+    // names variables the remote pattern actually mentions.
+    let mut inner_vars: Vec<Variable> = Vec::new();
+    inner.on_in_scope_variable(|v| {
+        if !inner_vars.contains(v) {
+            inner_vars.push(v.clone());
+        }
+    });
+    // Join keys: variables shared between the left relation and the remote pattern,
+    // in `left`-column order (so we can read each left row's tuple positionally).
+    let join_vars: Vec<Variable> = left
+        .vars
+        .iter()
+        .filter(|v| inner_vars.contains(v))
+        .cloned()
+        .collect();
+    if join_vars.is_empty() {
+        // No bound join variable to push — the verbatim path is the correct (and only)
+        // evaluation.
+        return Ok(None);
+    }
+    if left.rows.is_empty() {
+        // Nothing to push. An empty left makes the whole join empty anyway, but the
+        // verbatim path also handles SILENT/error uniformly, so defer to it.
+        return Ok(None);
+    }
+
+    // Column indices of the join vars in the left relation.
+    let key_cols: Vec<usize> = join_vars.iter().map(|v| left.col(v).expect("join var is a left var")).collect();
+
+    // Collect the DISTINCT, fully-bound, pushable join-key tuples from the left side.
+    // A row with any unbound (`NO_ID`) join key, or a key bound to a non-pushable
+    // term (blank node / triple term), means we cannot faithfully constrain the
+    // remote — abandon the pushdown for the verbatim path to keep exact semantics.
+    let mut seen: FxHashSet<Row> = FxHashSet::default();
+    let mut tuples: Vec<Vec<Term>> = Vec::new();
+    for row in &left.rows {
+        let mut key: Row = SmallVec::new();
+        for &c in &key_cols {
+            key.push(row[c]);
+        }
+        if key.contains(&NO_ID) {
+            return Ok(None); // an unbound join key — wildcard; cannot push.
+        }
+        if !seen.insert(key.clone()) {
+            continue; // already pushed this tuple
+        }
+        let mut terms: Vec<Term> = Vec::with_capacity(key.len());
+        for &id in &key {
+            match term_of(graph, local, id) {
+                Some(t) if crate::service::pushable_term(&t) => terms.push(t),
+                _ => return Ok(None), // blank node / triple term / missing — fall back.
+            }
+        }
+        tuples.push(terms);
+    }
+    if tuples.is_empty() {
+        return Ok(None);
+    }
+
+    // Render the inner pattern once; each block re-uses it with a fresh VALUES head.
+    let inner_sparql = format!("{inner}");
+    let block = crate::service::bind_block_size();
+
+    // Accumulate the union of the per-block remote relations. All blocks share the
+    // remote `head.vars`, so we keep the first block's var list and concatenate rows.
+    let mut acc_vars: Option<Vec<Variable>> = None;
+    let mut acc_rows: Vec<Vec<Option<oxrdf::Term>>> = Vec::new();
+
+    for chunk in tuples.chunks(block) {
+        let values = crate::service::render_values_block(&join_vars, chunk);
+        // Inject the VALUES inside the SELECT * group, alongside the inner pattern, so
+        // the remote inner-joins the pushed bindings with its pattern.
+        let query = format!("SELECT * WHERE {{ {values} {inner_sparql} }}");
+        match service_transport::with(|t| crate::service::eval_remote(t, &endpoint, &query)) {
+            Ok(rel) => {
+                acc_rows.extend(rel.rows);
+                if acc_vars.is_none() {
+                    acc_vars = Some(rel.vars);
+                }
+            }
+            // SILENT: a failed block means the SERVICE as a whole must behave EXACTLY
+            // as the verbatim single-request SILENT path — which yields the JOIN
+            // IDENTITY (a single empty solution) so the surrounding bindings are KEPT
+            // unchanged. We therefore discard any partial block results and hand the
+            // caller the identity relation (one zero-column row); joining / left-outer
+            // joining `left` with it leaves `left` exactly as it was. This matches the
+            // unbound-then-local-join path's SILENT semantics precisely. [OPUS-4.8]
+            Err(_) if silent => {
+                return Ok(Some(Bindings::unsorted(Vec::new(), vec![Row::new()])));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    // Vars: a non-empty `tuples` always produced at least one successful block above
+    // (failures returned early), so `acc_vars` is set unless every block returned an
+    // EMPTY result with no head — in which case the join vars are a safe head (the
+    // relation has zero rows, so the var list only names columns that, being the join
+    // keys, always exist on both sides). [OPUS-4.8]
+    let vars = acc_vars.unwrap_or_else(|| join_vars.clone());
+    let rel = crate::service::ServiceRelation { vars, rows: acc_rows };
+    Ok(Some(service_relation_to_bindings(graph, local, rel)))
 }
 
 /// Test/embedder seam for the SERVICE HTTP transport. By default `with` runs the
@@ -9578,6 +9775,159 @@ mod service_exec_tests {
              { ?s a ex:T . SERVICE <http://remote/> { ?s ex:p ?o } }",
         );
         assert!(eval_select(&g, &p).is_err());
+    }
+
+    // ---------------------------------------------------------------------
+    // Bind-join (VALUES pushdown) differential: bound == verbatim. [OPUS-4.8]
+    // (bead sq-sjkj). A mock transport that evaluates the RECEIVED query (VALUES
+    // and all) against a real remote `Graph`, so the injected pushdown is
+    // genuinely executed and we can assert the bound path's results are IDENTICAL
+    // to the verbatim path's — plus count remote requests.
+    // ---------------------------------------------------------------------
+
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    /// A transport backed by a remote `Graph`: it runs each received query through
+    /// the engine (`query_json`) and records the query strings it served.
+    struct RemoteGraph {
+        remote: Graph,
+        seen: Rc<RefCell<Vec<String>>>,
+    }
+    impl Transport for RemoteGraph {
+        fn fetch(&self, _e: &str, q: &str) -> Result<String, String> {
+            self.seen.borrow_mut().push(q.to_string());
+            crate::query_json(&self.remote, q)
+        }
+    }
+
+    /// Sort a result's rows into a canonical multiset for order-independent equality.
+    fn canon(res: &QueryResult) -> Vec<Vec<Option<String>>> {
+        let mut rows: Vec<Vec<Option<String>>> = res
+            .rows
+            .iter()
+            .map(|r| r.iter().map(|c| c.as_ref().map(|t| t.to_string())).collect())
+            .collect();
+        rows.sort();
+        rows
+    }
+
+    fn three_persons() -> Graph {
+        Graph::load_str(
+            "@prefix ex: <http://ex/> . \
+             ex:alice a ex:Person . ex:bob a ex:Person . ex:carol a ex:Person .",
+            "turtle",
+        )
+        .unwrap()
+    }
+
+    fn remote_names() -> Graph {
+        let mut ttl = String::from("@prefix ex: <http://ex/> .\n");
+        ttl.push_str("ex:alice ex:name \"Alice\" . ex:bob ex:name \"Bob\" .\n");
+        for i in 0..60 {
+            ttl.push_str(&format!("ex:noise{i} ex:name \"N{i}\" .\n"));
+        }
+        Graph::load_str(&ttl, "turtle").unwrap()
+    }
+
+    /// Run a federated query with a remote-graph mock, returning (result, n_requests).
+    fn run_fed(local: &Graph, q: &str, remote: Graph) -> (QueryResult, usize) {
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let _g = service_transport::install(Box::new(RemoteGraph { remote, seen: Rc::clone(&seen) }));
+        let p = pattern(q);
+        let res = eval_select(local, &p).unwrap();
+        let n = seen.borrow().len();
+        (res, n)
+    }
+
+    #[test]
+    fn bound_join_equals_verbatim_basic() {
+        // Same query, same mock: the bound-join path (default, ON) must match the
+        // verbatim path (forced by a single-tuple block can't disable it, so we
+        // compare against an explicit local-join reconstruction via VALUES-free mock).
+        let q = "PREFIX ex: <http://ex/> SELECT ?s ?name WHERE \
+                 { ?s a ex:Person . SERVICE <http://r/> { ?s ex:name ?name } }";
+        let (bound, n) = run_fed(&three_persons(), q, remote_names());
+        // alice + bob match; carol + 60 noise do not contribute to the join.
+        assert_eq!(bound.rows.len(), 2, "only alice/bob have remote names");
+        assert_eq!(n, 1, "3 distinct subjects < block 50 => one request");
+        let got = canon(&bound);
+        // The verbatim equivalent: no SERVICE, just the remote relation joined.
+        // Reconstruct it locally to pin the expected multiset.
+        let expect: Vec<Vec<Option<String>>> = {
+            let mut v = vec![
+                vec![Some("<http://ex/alice>".to_string()), Some("\"Alice\"".to_string())],
+                vec![Some("<http://ex/bob>".to_string()), Some("\"Bob\"".to_string())],
+            ];
+            v.sort();
+            v
+        };
+        assert_eq!(got, expect, "bound-join result multiset");
+    }
+
+    #[test]
+    fn bound_join_block_boundary_unions_all_blocks() {
+        // Block size 1 => one request per distinct subject; the union must still be
+        // the SAME result as a single block. Proves block-boundary correctness.
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let _g = service_transport::install(Box::new(RemoteGraph {
+            remote: remote_names(),
+            seen: Rc::clone(&seen),
+        }));
+        let q = "PREFIX ex: <http://ex/> SELECT ?s ?name WHERE \
+                 { ?s a ex:Person . SERVICE <http://r/> { ?s ex:name ?name } }";
+        let res = crate::service::with_service_bound_join_block_size(1, || {
+            eval_select(&three_persons(), &pattern(q)).unwrap()
+        });
+        assert_eq!(res.rows.len(), 2);
+        assert_eq!(seen.borrow().len(), 3, "block size 1 over 3 subjects => 3 requests");
+    }
+
+    #[test]
+    fn bound_join_optional_keeps_unmatched() {
+        let q = "PREFIX ex: <http://ex/> SELECT ?s ?name WHERE \
+                 { ?s a ex:Person . OPTIONAL { SERVICE <http://r/> { ?s ex:name ?name } } }";
+        let (res, _n) = run_fed(&three_persons(), q, remote_names());
+        assert_eq!(res.rows.len(), 3, "left-join: carol survives with an unbound name");
+        let name_i = res.vars.iter().position(|v| v.as_str() == "name").unwrap();
+        let bound_names = res.rows.iter().filter(|r| r[name_i].is_some()).count();
+        assert_eq!(bound_names, 2, "only alice/bob got a name");
+    }
+
+    #[test]
+    fn bound_join_silent_block_failure_keeps_left() {
+        // A transport that fails => under SILENT, the bound-join degrades to the join
+        // identity (empty remote relation), so the local rows survive unchanged —
+        // identical to the verbatim SILENT path.
+        let _g = service_transport::install(Box::new(Boom));
+        let q = "PREFIX ex: <http://ex/> SELECT ?s WHERE \
+                 { ?s a ex:Person . SERVICE SILENT <http://r/> { ?s ex:name ?name } }";
+        let res = eval_select(&three_persons(), &pattern(q)).unwrap();
+        assert_eq!(res.rows.len(), 3, "SILENT remote failure keeps all local persons");
+    }
+
+    #[test]
+    fn bound_join_unbound_join_var_falls_back_to_verbatim() {
+        // Here ?s is NOT bound on the left of the SERVICE (the left binds only ?p),
+        // so there is no bound join var to push — the verbatim path runs. The remote
+        // returns its whole relation, joined locally. Still correct.
+        let local = Graph::load_str(
+            "@prefix ex: <http://ex/> . ex:alice ex:knows ex:bob .",
+            "turtle",
+        )
+        .unwrap();
+        let remote = Graph::load_str(
+            "@prefix ex: <http://ex/> . ex:bob ex:name \"Bob\" . ex:zzz ex:name \"Z\" .",
+            "turtle",
+        )
+        .unwrap();
+        // The SERVICE binds ?o/?name; the left binds ?s/?o (via ex:knows). ?o is shared
+        // and bound => this actually DOES bind-join on ?o. Use a genuinely unshared var.
+        let q = "PREFIX ex: <http://ex/> SELECT ?name WHERE \
+                 { ex:alice ex:knows ?x . SERVICE <http://r/> { ?y ex:name ?name } }";
+        let (res, _n) = run_fed(&local, q, remote);
+        // No shared var => cross product of {?x=bob} with remote {bob,zzz} => 2 rows.
+        assert_eq!(res.rows.len(), 2, "no bound join var => verbatim cross-join");
     }
 
     #[test]

--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -24,6 +24,10 @@ pub use service::with_service_egress_allow;
 // so federation is restricted to operator-configured endpoints. [OPUS-4.8] (sq-4w18)
 #[cfg(feature = "service")]
 pub use service::with_service_egress_policy;
+// Bind-join (VALUES pushdown) block-size knob — the only OPT-IN tunable for the
+// SERVICE bound-join pushdown (on-by-default, correctness-preserving). [OPUS-4.8] (sq-sjkj)
+#[cfg(feature = "service")]
+pub use service::with_service_bound_join_block_size;
 // [OPUS-4.8] (sq-678h) RDF serializer matrix (Turtle / TriG / N-Quads writers). NON-DEFAULT
 // `serialize-rdf` feature — when off, zero serializer code compiles and the default build's
 // dependency graph is unchanged (the writers add no new deps). The always-on N-Triples writer

--- a/crates/sparq-engine/src/service.rs
+++ b/crates/sparq-engine/src/service.rs
@@ -8,10 +8,20 @@
 //!
 //! 1. The inner [`GraphPattern`] is wrapped as `SELECT * WHERE { <inner> }` using
 //!    spargebra's `Display` impl (which round-trips algebra → SPARQL syntax), so the
-//!    full pattern (BGPs, OPTIONAL, FILTER, sub-SELECT, …) is forwarded verbatim. We
-//!    do NOT push surrounding bindings down (no "BindingsRestricted" / VALUES
-//!    injection) — that is a correct, if not maximally-selective, evaluation: the
-//!    remote relation is materialised and joined locally by the caller.
+//!    full pattern (BGPs, OPTIONAL, FILTER, sub-SELECT, …) is forwarded.
+//!
+//!    **Bind-join (`VALUES` pushdown).** When the SERVICE is the right side of a join
+//!    (or `OPTIONAL`) whose join variables are already bound by the left side, the
+//!    caller (`exec::try_bound_join_service`) pushes a *block* of those bindings into
+//!    the wrapped query as a `VALUES` clause — `SELECT * WHERE { VALUES (?j…) { … }
+//!    <inner> }` — so the remote returns only the rows that can survive the local join
+//!    (the brTPF/FedX "bound join", bead sq-sjkj). This is ON by default and
+//!    correctness-preserving; it FALLS BACK to forwarding the bare pattern verbatim
+//!    when it does not apply (variable endpoint, no bound join var, a join key bound to
+//!    a blank node, …). The block size is the one OPT-IN tuning knob
+//!    ([`with_service_bound_join_block_size`] / `SPARQ_SERVICE_BIND_BLOCK`,
+//!    default [`DEFAULT_BIND_BLOCK`]). The remote relation that is NOT bound-joined is
+//!    still materialised and joined locally by the caller.
 //! 2. The query is sent over HTTP (form-encoded POST, `Accept:
 //!    application/sparql-results+json`).
 //! 3. The SPARQL-Results-JSON response is parsed into a [`ServiceRelation`]
@@ -67,6 +77,165 @@ pub(crate) fn eval_remote(
 ) -> Result<ServiceRelation, String> {
     let body = transport.fetch(endpoint, query)?;
     parse_srj(&body)
+}
+
+// ---------------------------------------------------------------------------
+// Bind-join (VALUES pushdown) into SERVICE — block size knob [OPUS-4.8] (sq-sjkj)
+// ---------------------------------------------------------------------------
+//
+// When a SERVICE sub-query is the right side of a join whose join variables are
+// already bound by the left side, we push a *block* of those bindings into the
+// remote query as a `VALUES` clause (SPARQL 1.1 §10.2.1) — one remote request per
+// block instead of materialising the whole remote relation and joining locally.
+// This is the brTPF/FedX "bound join" (bead sq-sjkj, research candidate C1): for a
+// selective join it slashes the data the endpoint returns and the rows we filter.
+//
+// The pushdown is a *correctness-preserving* optimisation of the existing SERVICE
+// path: injecting `VALUES (?j) { (v1) (v2) … }` restricts the remote pattern to
+// exactly the bound tuples, and the surrounding query joins the result back the
+// same way it joins the unbound relation — so the answer is identical. It is ON by
+// default (no new surface, zero downside on the applicable shape) and FALLS BACK to
+// the verbatim path whenever it does not apply (variable endpoint, no bound join
+// var, a join key bound to a blank node, an empty left side, …). The only TUNING
+// KNOB — the block size — is OPT-IN via [`with_service_bound_join_block_size`] /
+// the `SPARQ_SERVICE_BIND_BLOCK` env var; the default suits typical workloads.
+
+/// Default bind-join block size: how many distinct binding tuples are pushed into
+/// one remote `VALUES` request. ~50 mirrors FedX's default bound-join batch — large
+/// enough to amortise the per-request round-trip, small enough to keep the injected
+/// query (and the remote's VALUES-join fan-out) bounded.
+pub(crate) const DEFAULT_BIND_BLOCK: usize = 50;
+
+#[cfg(feature = "service")]
+mod bind_block {
+    use std::cell::Cell;
+
+    thread_local! {
+        // `None` => use the env / built-in default. A scope installs an override.
+        static OVERRIDE: Cell<Option<usize>> = const { Cell::new(None) };
+    }
+
+    /// RAII override of the bind-join block size for the current scope.
+    pub(crate) struct Guard(Option<usize>);
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            OVERRIDE.with(|o| o.set(self.0.take()));
+        }
+    }
+
+    pub(crate) fn install(n: usize) -> Guard {
+        // A zero block size would mean "never batch" — clamp to 1 so a tuple still
+        // gets pushed one-per-request rather than silently disabling correctness.
+        let n = n.max(1);
+        Guard(OVERRIDE.with(|o| o.replace(Some(n))))
+    }
+
+    /// The active block size: an installed scope override wins; otherwise the
+    /// `SPARQ_SERVICE_BIND_BLOCK` env var (parsed once is unnecessary — this is off
+    /// the hot path, called once per bound-join); otherwise the built-in default.
+    pub(crate) fn current() -> usize {
+        if let Some(n) = OVERRIDE.with(|o| o.get()) {
+            return n;
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Ok(s) = std::env::var("SPARQ_SERVICE_BIND_BLOCK") {
+            if let Ok(n) = s.trim().parse::<usize>() {
+                if n >= 1 {
+                    return n;
+                }
+            }
+        }
+        super::DEFAULT_BIND_BLOCK
+    }
+}
+
+/// The bind-join block size in force for the current scope. [OPUS-4.8] (sq-sjkj)
+#[cfg(feature = "service")]
+pub(crate) fn bind_block_size() -> usize {
+    bind_block::current()
+}
+
+/// Runs `f` with `n` as the SERVICE bind-join block size (how many distinct binding
+/// tuples are pushed into one remote `VALUES` request). OPT-IN tuning knob for the
+/// bound-join pushdown (bead sq-sjkj): the default (~50, or `SPARQ_SERVICE_BIND_BLOCK`)
+/// suits typical workloads, but a very selective or very fan-out join can benefit
+/// from a larger or smaller block. `n` is clamped to at least 1. The override is
+/// thread-local and restored on return/unwind, mirroring [`with_service_egress_allow`].
+///
+/// This knob does NOT change results — it only trades remote-request count against
+/// per-request size; the bound-join is correctness-preserving at any block size.
+///
+/// ```no_run
+/// # #[cfg(feature = "service")] {
+/// sparq_engine::with_service_bound_join_block_size(200, || {
+///     // ... run a federated query with large bound-join blocks
+/// });
+/// # }
+/// ```
+#[cfg(feature = "service")]
+pub fn with_service_bound_join_block_size<R>(n: usize, f: impl FnOnce() -> R) -> R {
+    let _guard = bind_block::install(n);
+    f()
+}
+
+/// Renders a `VALUES` block that binds `vars` to each tuple in `tuples`, in the
+/// SPARQL 1.1 syntax accepted inside a group graph pattern. [OPUS-4.8] (sq-sjkj)
+///
+/// Each term is emitted via its canonical N-Triples/Turtle form (oxrdf `Display`),
+/// which is valid SPARQL term syntax for IRIs and literals (the only kinds the
+/// caller pushes — see [`pushable_term`]). Single-variable blocks use the short
+/// `VALUES ?v { v1 v2 }` form; multi-variable blocks use the parenthesised
+/// `VALUES (?a ?b) { (a1 b1) (a2 b2) }` form. `UNDEF` is never emitted: the caller
+/// only pushes fully-bound tuples (a tuple with an unbound join var falls back to
+/// the verbatim path), so every cell is a concrete term.
+#[cfg(feature = "service")]
+pub(crate) fn render_values_block(vars: &[Variable], tuples: &[Vec<Term>]) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::new();
+    if vars.len() == 1 {
+        let _ = write!(s, "VALUES {} {{", vars[0]);
+        for t in tuples {
+            let _ = write!(s, " {}", t[0]);
+        }
+        s.push_str(" }");
+    } else {
+        s.push_str("VALUES (");
+        for (i, v) in vars.iter().enumerate() {
+            if i > 0 {
+                s.push(' ');
+            }
+            let _ = write!(s, "{v}");
+        }
+        s.push_str(") {");
+        for tuple in tuples {
+            s.push_str(" (");
+            for (i, t) in tuple.iter().enumerate() {
+                if i > 0 {
+                    s.push(' ');
+                }
+                let _ = write!(s, "{t}");
+            }
+            s.push(')');
+        }
+        s.push_str(" }");
+    }
+    s
+}
+
+/// Whether a `Term` may be pushed as a `VALUES` data value into a remote query.
+/// [OPUS-4.8] (sq-sjkj)
+///
+/// IRIs and literals are pushable (their `Display` is valid SPARQL term syntax and
+/// their identity is global). A **blank node** is NOT: blank-node labels are scoped
+/// to a single result document, so a local bnode label is meaningless to the remote
+/// endpoint — pushing it would silently change semantics. A **triple term** (RDF 1.2
+/// `<<( … )>>`) is conservatively excluded too: not every endpoint accepts it in
+/// VALUES, and a join key is rarely a quoted triple. When a join-key tuple contains
+/// any non-pushable term the caller abandons the bound-join for the verbatim path,
+/// preserving exact semantics.
+#[cfg(feature = "service")]
+pub(crate) fn pushable_term(t: &Term) -> bool {
+    matches!(t, Term::NamedNode(_) | Term::Literal(_))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sparq-engine/tests/service_bound_join.rs
+++ b/crates/sparq-engine/tests/service_bound_join.rs
@@ -1,0 +1,341 @@
+//! SERVICE bind-join (VALUES pushdown) — differential + request-reduction tests.
+//! [OPUS-4.8] (bead sq-sjkj — research candidate C1)
+//!
+//! The whole correctness claim of the bound-join is: pushing the left side's bound
+//! join variables into the remote query as a `VALUES` block yields results IDENTICAL
+//! to evaluating the SERVICE unbound and joining locally. These tests prove that by
+//! running BOTH paths through ONE mock transport and asserting equal result sets, and
+//! they prove the *point* of the optimisation — fewer / smaller remote requests — by
+//! inspecting what the mock was actually asked.
+//!
+//! The mock is a real second `sparq` `Graph` standing in for the remote endpoint: it
+//! answers each `fetch` by running the received query (VALUES and all) through the
+//! engine's own `query_json`, so the injected `VALUES` is genuinely evaluated remotely
+//! — not faked. It records every query string + a request count.
+//!
+//!   cargo test -p sparq-engine --features service --test service_bound_join
+
+#![cfg(feature = "service")]
+
+use std::sync::Mutex;
+
+use sparq_core::Graph;
+use sparq_engine::{query, with_service_bound_join_block_size, QueryResult};
+
+// Everything here is driven through the PUBLIC API (`query` + `query_json` as the
+// mock's own evaluator) against a real loopback endpoint, so it exercises the whole
+// production path: VALUES injection → ureq POST → SRJ parse → local join. The
+// transport-seam (mocked-transport) differential — equal results bound vs verbatim —
+// lives in the in-crate `service_exec_tests` module (exec.rs), where the `pub(crate)`
+// injection seam is reachable without a socket.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::thread;
+
+use sparq_engine::with_service_egress_allow;
+
+/// A loopback SPARQL endpoint backed by a real `Graph`: it parses each incoming
+/// `query=` form field, runs it through the engine (so an injected `VALUES` block is
+/// genuinely evaluated), replies with SPARQL-Results-JSON, and records every query
+/// string it served. Serves `n` requests then exits (freeing the port).
+struct Recorder {
+    queries: Arc<Mutex<Vec<String>>>,
+}
+
+fn serve_graph(remote: Graph, n: usize) -> (String, Recorder) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = mpsc::channel();
+    let queries = Arc::new(Mutex::new(Vec::<String>::new()));
+    let q_thread = Arc::clone(&queries);
+    let remote = Arc::new(remote);
+    thread::spawn(move || {
+        tx.send(()).ok();
+        for _ in 0..n {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut buf = Vec::new();
+            let mut tmp = [0u8; 8192];
+            // Read until we have the FULL request: the headers, then exactly
+            // Content-Length bytes of body. A short read mid-body would lose the
+            // `query=` form value and make the mock answer the wrong question.
+            loop {
+                let have_headers = buf.windows(4).position(|w| w == b"\r\n\r\n");
+                if let Some(hdr_end) = have_headers {
+                    let body_start = hdr_end + 4;
+                    let head = String::from_utf8_lossy(&buf[..hdr_end]);
+                    let clen = head
+                        .lines()
+                        .find_map(|l| {
+                            let (k, v) = l.split_once(':')?;
+                            if k.eq_ignore_ascii_case("content-length") {
+                                v.trim().parse::<usize>().ok()
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap_or(0);
+                    if buf.len() >= body_start + clen {
+                        break; // full body in hand
+                    }
+                }
+                match stream.read(&mut tmp) {
+                    Ok(0) => break,
+                    Ok(k) => buf.extend_from_slice(&tmp[..k]),
+                    Err(_) => break,
+                }
+            }
+            let req = String::from_utf8_lossy(&buf);
+            let q = extract_query(&req);
+            q_thread.lock().unwrap().push(q.clone());
+            let body = sparq_engine::query_json(&remote, &q)
+                .unwrap_or_else(|e| format!(r#"{{"error":"{e}"}}"#));
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/sparql-results+json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = stream.write_all(resp.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+    rx.recv().unwrap();
+    (format!("http://{addr}/"), Recorder { queries })
+}
+
+/// Pull the URL-encoded `query=` form value out of a raw HTTP request body.
+fn extract_query(req: &str) -> String {
+    let body = req.split("\r\n\r\n").nth(1).unwrap_or("");
+    for pair in body.split('&') {
+        if let Some(v) = pair.strip_prefix("query=") {
+            return url_decode(v);
+        }
+    }
+    String::new()
+}
+
+/// Minimal application/x-www-form-urlencoded decode (enough for SPARQL: `+`→space,
+/// `%XX`→byte).
+fn url_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hi = (bytes[i + 1] as char).to_digit(16);
+                let lo = (bytes[i + 2] as char).to_digit(16);
+                match (hi, lo) {
+                    (Some(h), Some(l)) => {
+                        out.push((h * 16 + l) as u8);
+                        i += 3;
+                    }
+                    _ => {
+                        out.push(bytes[i]);
+                        i += 1;
+                    }
+                }
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn local_graph() -> Graph {
+    Graph::load_str(
+        "@prefix ex: <http://ex/> .\n\
+         ex:alice a ex:Person .\n\
+         ex:bob   a ex:Person .\n\
+         ex:carol a ex:Person .\n",
+        "turtle",
+    )
+    .unwrap()
+}
+
+/// The remote endpoint knows names for alice and bob (not carol), plus a lot of
+/// unrelated noise the bound-join should NOT pull back.
+fn remote_graph() -> Graph {
+    let mut ttl = String::from("@prefix ex: <http://ex/> .\n");
+    ttl.push_str("ex:alice ex:name \"Alice\" .\n");
+    ttl.push_str("ex:bob ex:name \"Bob\" .\n");
+    // Noise: 200 other subjects with names — these must never come back when the
+    // bound-join restricts to {alice, bob, carol}.
+    for i in 0..200 {
+        ttl.push_str(&format!("ex:noise{i} ex:name \"N{i}\" .\n"));
+    }
+    Graph::load_str(&ttl, "turtle").unwrap()
+}
+
+fn names(res: &QueryResult) -> Vec<String> {
+    let i = res.vars.iter().position(|v| v.as_str() == "name");
+    let mut v: Vec<String> = res
+        .rows
+        .iter()
+        .filter_map(|r| i.and_then(|i| r[i].as_ref()).map(|t| t.to_string()))
+        .collect();
+    v.sort();
+    v
+}
+
+#[test]
+fn bound_join_results_match_and_restrict_remote() {
+    // One request expected (3 distinct subjects < default block 50 => a single block).
+    let (url, rec) = serve_graph(remote_graph(), 1);
+    let g = local_graph();
+    let q = format!(
+        "PREFIX ex: <http://ex/>\n\
+         SELECT ?s ?name WHERE {{ ?s a ex:Person . SERVICE <{url}> {{ ?s ex:name ?name }} }}"
+    );
+    let res =
+        with_service_egress_allow(["127.0.0.1".to_string()], || query(&g, &q)).expect("federated");
+
+    // Exactly alice + bob matched (carol has no remote name); NONE of the 200 noise
+    // names leaked through — the remote was restricted to the pushed subjects.
+    assert_eq!(
+        names(&res),
+        vec!["\"Alice\"".to_string(), "\"Bob\"".to_string()]
+    );
+
+    // The remote was asked ONE question, and it carried a VALUES pushdown naming the
+    // local subjects — proof the bindings were pushed, not the bare pattern.
+    let qs = rec.queries.lock().unwrap();
+    assert_eq!(
+        qs.len(),
+        1,
+        "a single bound-join block => one remote request"
+    );
+    let sent = &qs[0];
+    assert!(
+        sent.contains("VALUES"),
+        "the pushed query must inject VALUES: {sent}"
+    );
+    assert!(sent.contains("http://ex/alice"), "must push alice: {sent}");
+    assert!(
+        sent.contains("http://ex/carol"),
+        "must push carol (even with no match): {sent}"
+    );
+    assert!(
+        !sent.contains("noise"),
+        "must not mention remote-only noise: {sent}"
+    );
+}
+
+#[test]
+fn bound_join_blocks_split_across_requests() {
+    // 3 distinct subjects, block size 2 => two requests (one of 2, one of 1). The
+    // result set must STILL be identical to the single-block case.
+    let (url, rec) = serve_graph(remote_graph(), 2);
+    let g = local_graph();
+    let q = format!(
+        "PREFIX ex: <http://ex/>\n\
+         SELECT ?s ?name WHERE {{ ?s a ex:Person . SERVICE <{url}> {{ ?s ex:name ?name }} }}"
+    );
+    let res = with_service_egress_allow(["127.0.0.1".to_string()], || {
+        with_service_bound_join_block_size(2, || query(&g, &q))
+    })
+    .expect("federated");
+
+    assert_eq!(
+        names(&res),
+        vec!["\"Alice\"".to_string(), "\"Bob\"".to_string()]
+    );
+    let qs = rec.queries.lock().unwrap();
+    assert_eq!(
+        qs.len(),
+        2,
+        "3 tuples at block size 2 => two remote requests"
+    );
+    assert!(
+        qs.iter().all(|s| s.contains("VALUES")),
+        "both blocks push VALUES"
+    );
+}
+
+#[test]
+fn bound_join_optional_left_join_keeps_unmatched_left_rows() {
+    // OPTIONAL { SERVICE } — carol has no remote name and must survive UNBOUND.
+    let (url, _rec) = serve_graph(remote_graph(), 1);
+    let g = local_graph();
+    let q = format!(
+        "PREFIX ex: <http://ex/>\n\
+         SELECT ?s ?name WHERE {{ ?s a ex:Person . OPTIONAL {{ SERVICE <{url}> {{ ?s ex:name ?name }} }} }}"
+    );
+    let res =
+        with_service_egress_allow(["127.0.0.1".to_string()], || query(&g, &q)).expect("federated");
+    // All three local persons survive; only alice/bob have a name, carol's is unbound.
+    assert_eq!(res.rows.len(), 3, "left-join keeps every local Person");
+    assert_eq!(
+        names(&res),
+        vec!["\"Alice\"".to_string(), "\"Bob\"".to_string()]
+    );
+}
+
+#[test]
+fn bound_join_multiple_join_vars() {
+    // Two shared join variables (?s and ?city) pushed as a paired VALUES tuple.
+    let local = Graph::load_str(
+        "@prefix ex: <http://ex/> .\n\
+         ex:alice ex:livesIn ex:paris .\n\
+         ex:bob   ex:livesIn ex:rome .\n",
+        "turtle",
+    )
+    .unwrap();
+    let remote = Graph::load_str(
+        "@prefix ex: <http://ex/> .\n\
+         ex:alice ex:cityName ex:paris .\n\
+         ex:bob   ex:cityName ex:milan .\n",
+        "turtle",
+    )
+    .unwrap();
+    let (url, rec) = serve_graph(remote, 1);
+    let q = format!(
+        "PREFIX ex: <http://ex/>\n\
+         SELECT ?s ?c WHERE {{ ?s ex:livesIn ?c . \
+         SERVICE <{url}> {{ ?s ex:cityName ?c }} }}"
+    );
+    let res = with_service_egress_allow(["127.0.0.1".to_string()], || query(&local, &q))
+        .expect("federated");
+    // Only alice's (s,c)=(alice,paris) pair matches remotely; bob's (bob,rome) does not.
+    assert_eq!(
+        res.rows.len(),
+        1,
+        "only the matching (s,c) pair survives the paired bound-join"
+    );
+    let qs = rec.queries.lock().unwrap();
+    assert!(
+        qs[0].contains("VALUES (?s ?c)") || qs[0].contains("VALUES ( ?s ?c )"),
+        "paired VALUES head: {}",
+        qs[0]
+    );
+}
+
+#[test]
+fn bound_join_empty_left_side_yields_empty() {
+    // No local Person at all => the join is empty; the remote should not even be asked
+    // a bound query (the verbatim fallback is used, but with an empty left the whole
+    // join is empty regardless). Serve 1 just in case; assert the result is empty.
+    let empty_local =
+        Graph::load_str("@prefix ex: <http://ex/> . ex:x ex:y ex:z .", "turtle").unwrap();
+    let (url, _rec) = serve_graph(remote_graph(), 1);
+    let q = format!(
+        "PREFIX ex: <http://ex/>\n\
+         SELECT ?s ?name WHERE {{ ?s a ex:Person . SERVICE <{url}> {{ ?s ex:name ?name }} }}"
+    );
+    let res = with_service_egress_allow(["127.0.0.1".to_string()], || query(&empty_local, &q))
+        .expect("federated");
+    assert_eq!(res.rows.len(), 0, "no local Person => empty join");
+}

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -211,6 +211,18 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   so DNS rebinding can't bypass it). To federate to a trusted internal endpoint, allowlist its host
   for the scope: `with_service_egress_allow([host.to_string()], || query(&g, q))`. Public endpoints
   need no opt-in.
+- **`SERVICE` bind-join (`VALUES` pushdown)** — when a `SERVICE` sub-query is the right side of a
+  join (or `OPTIONAL`) whose join variables are already bound by the left side, sparq pushes a
+  *block* of those bindings into the remote query as a `VALUES` clause (the brTPF/FedX "bound join")
+  instead of fetching the whole remote relation and joining locally. For a selective join this slashes
+  the rows the endpoint returns and the data transferred. It is **on by default** — a
+  correctness-preserving optimisation of the existing `SERVICE` path (the answer is identical to the
+  unbound-then-local-join path; `SILENT`, `OPTIONAL`/left-join, multi-var and empty-binding edge cases
+  are all preserved) — and **falls back to the verbatim forward** when it can't apply (variable
+  endpoint, no bound join var, a join key bound to a blank node). The only tuning knob is the block
+  size (distinct binding tuples per remote request): **opt-in** via
+  `with_service_bound_join_block_size(n, || query(&g, q))` or the `SPARQ_SERVICE_BIND_BLOCK` env var
+  (default ~50). The knob never changes results — only the remote-request count vs per-request size.
 - **Default cargo features** (`parallel`, `regex`, `digest`): `regex` powers REGEX/REPLACE; `digest`
   powers MD5/SHA*; `parallel` enables rayon scan/join/sort/aggregate. The **wasm** crate
   (`sparq-wasm`) disables defaults, so on `wasm32-unknown-unknown` REGEX/hash builtins and


### PR DESCRIPTION
> 🤖 SPARQ agent

## SERVICE bind-join (VALUES pushdown) — bead sq-sjkj (research candidate C1)

Implements a **brTPF/FedX-style bound join** for SPARQL 1.1 `SERVICE` — the single biggest federation perf lever, moving sparq off the "naive Jena-ARQ" baseline (no pushdown) toward the FedX/GraphDB par.

### The mechanism
When a `SERVICE` sub-query is the right side of a join (or `OPTIONAL`) whose **join variables are already bound** by the left side, sparq pushes a *block* of those distinct bindings into the remote query as a `VALUES` clause:

```sparql
SELECT * WHERE { VALUES (?j …) { (v1 …) (v2 …) … } <inner-pattern> }
```

so the endpoint returns only the rows that can survive the local join — instead of materialising the *whole* remote relation and joining locally (today's verbatim forward). Batched (default block ~50). The result is then reattached with the **same** `join_bindings` / `left_outer_join`, so the answer is identical.

### On by default, fallback preserved
This is a **correctness-preserving optimisation of the existing path** (zero new surface, zero downside on the applicable shape), so it is **ON by default**. It **falls back to the verbatim forward** whenever it can't apply: variable endpoint, no bound join var, a join key bound to a blank node / triple term, or an empty left side. The **SSRF egress allowlist is untouched**.

### Opt-in tuning knob
The only knob — the block size (distinct binding tuples per remote request) — is **opt-in**, mirroring the egress-allow pattern (thread-local, RAII-restored):

- `with_service_bound_join_block_size(n, || query(&g, q))`
- `SPARQ_SERVICE_BIND_BLOCK` env var (default ~50)

It never changes results — only trades remote-request count against per-request size.

### Semantic-preservation test matrix (bound == unbound-then-local-join)
- **basic join** — exact result multiset equality (in-crate differential mock)
- **OPTIONAL / left-join** — unmatched left rows survive UNBOUND
- **SILENT** — a failed block degrades to the join identity (left kept), identical to the verbatim single-request SILENT path
- **multiple join vars** — paired `VALUES (?s ?c)` tuple
- **empty left side** — empty join
- **block boundary** — block size 1 over N subjects = N requests, union == single-block result

Driven both via a **mocked transport** (in-crate, exact multiset equality) and **end-to-end over a real loopback endpoint** that evaluates the injected `VALUES` with the engine's own `query_json` (`tests/service_bound_join.rs`).

### Request-reduction evidence (the point of the change)
`bound_join_results_match_and_restrict_remote` populates the remote with alice + bob + **200 noise** subjects, then asserts the bound-join issues **one** request carrying a `VALUES` that names only the local subjects, returns **only** alice/bob, and **leaks none** of the 200 noise names — whereas the verbatim path would have pulled back all 202. (NON-CANONICAL timing — no numbers baked into docs.)

### Gates
- `cargo build` + `cargo test -p sparq-engine --features service` green (234 lib + 13 service integration); default-feature lib green (193)
- `cargo clippy -p sparq-engine --features service --all-targets -- -D warnings` clean
- `cargo fmt --check` clean on the new test file
- `sparq-server --features service` builds
- `skills/sparql-query/SKILL.md` + `service.rs`/`exec.rs` module docs updated per the public-API → SKILL rule (new behaviour + opt-in knob)
