### PR TITLE
Certification readiness — CIS

### DIFF
--- a/compliance/cis/README.md
+++ b/compliance/cis/README.md
@@ -1,0 +1,79 @@
+<!-- [OPUS-4.8] sq-toze (cert-cis) — CIS framework intro/scope. Authored while Fable
+     unavailable — re-review when Fable returns. Engineer↔auditor loop (epic sq-toze). -->
+
+# CIS (Center for Internet Security) — framework slice
+
+**Frameworks mapped here**
+
+- **CIS Critical Security Controls v8** — the Safeguards (Implementation Group 1/2) that are
+  *properties of the artifact sparq ships* (a Rust library + `sparq-server` + a container image),
+  not properties of the network/endpoint estate the **operator** runs.
+- **CIS Docker Benchmark v1.x** (the *image-build* half, §4 "Container Images and Build File") —
+  the hardening posture of the repo's `Dockerfile`. The *host/daemon/runtime* half (§1–3, §5–7:
+  the Docker daemon config, host kernel, `docker run` flags) is **operator responsibility** and is
+  mapped as OOS below, because sparq ships an image, not a Docker host.
+
+**What sparq is, for CIS scoping**
+
+sparq is a Rust RDF/SPARQL **data engine** consumed as a dependency, plus an HTTP `sparq-server`
+and a SHA-pinned distroless container image (`Dockerfile` → `ghcr.io/jeswr/sparq-server`). It is
+**not** an enterprise IT estate. The CIS Controls v8 are written for an *organisation* securing its
+asset/software inventory, accounts, networks, and endpoints — so a large fraction of v8 maps to the
+**operator** who deploys sparq, not to the source/CI of sparq itself. This slice scopes each
+Safeguard honestly into one of:
+
+## Status legend
+
+- **PASS** — *implemented & verified*: a technical control in the codebase/CI with a re-runnable
+  evidence anchor (file path + line / test name / `.github/workflows/<wf>.yml#<job>`). The auditor
+  re-reads or re-runs the cited artifact.
+- **AUDIT-READY** — control + documentation in place, but the *certificate* needs an accredited
+  external assessor / an organizational ISMS we cannot substitute for.
+- **OPEN-gap** — not met (or only partially); recorded in [`gap-register.md`](./gap-register.md)
+  with a `bd` bead. **Not** papered over.
+- **N/A (operator)** — the Safeguard governs the *deployment environment* (the org's network,
+  endpoints, accounts, the Docker host/daemon, the live `docker run` flags), which is the
+  deploying operator's responsibility, not a property of sparq's source. Mapped, not silently
+  dropped.
+
+## What is OUT OF SCOPE for a library + server + image (and why)
+
+- **CIS Docker Benchmark §1 (Host), §2 (Daemon), §3 (Daemon config files), §5 (Container
+  runtime), §6 (Operations), §7 (Swarm)** — these govern the *Docker host and the `docker run`
+  invocation*. sparq ships a hardened *image*; the operator chooses the host, the daemon flags, and
+  the runtime flags (`--read-only`, `--cap-drop=ALL`, `--security-opt`, `--pids-limit`, a non-root
+  `--user`, seccomp). The image header (`Dockerfile` lines 16–34) documents the runtime hardening
+  the operator should apply; CIS §5 is **N/A (operator)** with that pointer.
+- **CIS Controls v8 families that are organisational/endpoint** — IG-level account management (CIS
+  5/6), malware defenses (CIS 10), network monitoring (CIS 13), email/web protections (CIS 9),
+  security-awareness training (CIS 14), incident-response *org program* (CIS 17), penetration
+  testing *program* (CIS 18) — these are the **operator's** IT program, not sparq's source. The
+  thin residual that *is* a sparq property (e.g. the source-code/dependency *inventory*, CI access
+  control, the published disclosure channel) is mapped PASS/AUDIT-READY in the control table.
+
+## The one real technical gap (honest headline)
+
+The `Dockerfile` hardening is genuinely strong and *verified against the actual file* (distroless
+`cc-debian12:nonroot`, both stages SHA-pinned by digest, `cargo auditable build --locked`,
+no shell/package-manager in the runtime layer, minimal labels-only metadata, `.dockerignore`
+scoping the context). A `docker-smoke` job builds + runs the image and curls it on every PR. **But
+there is no automated container-image vulnerability scan (Trivy/Grype) and no Dockerfile linter
+(Dockle/Hadolint) lane in CI** — verified by `grep -rIl -E 'trivy|grype|dockle|hadolint' .github/`
+returning only false-positive comment matches. That is gap **GX-12** (bead **sq-toze.31**); see
+[`gap-register.md`](./gap-register.md). Everything else in this slice is PASS or honestly N/A.
+
+## Files in this slice
+
+- [`controls.md`](./controls.md) — per-Safeguard / per-Benchmark-item → status → evidence → owner.
+  The spine the auditor checks.
+- [`evidence.md`](./evidence.md) — the re-runnable verification commands + their expected output
+  for each PASS claim (so a reviewer can reproduce, not just trust).
+- [`gap-register.md`](./gap-register.md) — open gaps, severity, remediation, target, `bd` bead id.
+
+## Honesty note (carried from the contract)
+
+This slice makes **no** claim about the ZK/MPC estate. The `sparq-zk`/`sparq-mpc` crates are
+research scaffolds; the documented verdict (`SECURITY.md`, `research/zk-soundness-audit.md`) is
+"**v1 ZK verifier is NOT sound**". No CIS Safeguard here is satisfied by, or implies a guarantee
+from, that estate. CIS is about the *deliverable artifact's* hygiene (image, dependencies, build,
+disclosure), which is independent of the crypto soundness question.

--- a/compliance/cis/controls.md
+++ b/compliance/cis/controls.md
@@ -1,0 +1,71 @@
+<!-- [OPUS-4.8] sq-toze (cert-cis) — CIS control table. Authored while Fable unavailable —
+     re-review when Fable returns. Engineer↔auditor loop (epic sq-toze). -->
+
+# CIS — control table
+
+**Scope:** CIS Critical Security Controls v8 (artifact-applicable Safeguards) + CIS Docker
+Benchmark v1.x (§4 image-build half). See [`README.md`](./README.md) for the scoping decisions and
+the status legend (PASS / AUDIT-READY / OPEN-gap / N/A-operator). Evidence paths are repo-relative;
+all of them are reproduced in [`evidence.md`](./evidence.md).
+
+> Honesty note. No row below is satisfied by the ZK/MPC estate; that estate's documented
+> "v1 verifier NOT sound" verdict (`SECURITY.md`) is untouched here. CIS is artifact-hygiene.
+
+## Part A — CIS Docker Benchmark §4 (Container Images and Build File)
+
+Verified **against the actual `Dockerfile`** (read in full, lines 1–106) — not the comments alone.
+
+| # | CIS Docker item | Status | Evidence (file / line / CI job) | Owner |
+|---|---|---|---|---|
+| D-4.1 | **Create a user for the container** (do not run as root). | **PASS** | Runtime stage `FROM gcr.io/distroless/cc-debian12:nonroot@sha256:b0ae…` (`Dockerfile:76`). The `:nonroot` distroless variant runs as UID **65532** (non-root) by default — no `USER root` override anywhere in the runtime stage; the `ENTRYPOINT` (`Dockerfile:104`) inherits that UID. | sparq |
+| D-4.2 | **Use trusted base images** (pin by digest, minimal). | **PASS** | Both stages pinned **by digest**: builder `rust:1.88-slim-bookworm@sha256:38bc…` (`Dockerfile:51`), runtime `distroless/cc-debian12:nonroot@sha256:b0ae…` (`Dockerfile:76`). Runtime is distroless (glibc + libgcc only). Scorecard `PinnedDependencies` covers this. | sparq |
+| D-4.3 | **Do not install unnecessary packages** (minimise the image). | **PASS** | Runtime stage installs nothing: it is distroless (no `apt`, no package manager, no shell). Only artifact copied in is the single static-ish server binary (`COPY --from=builder … /usr/local/bin/sparq-server`, `Dockerfile:84`). Builder packages stay in the discarded builder stage. | sparq |
+| D-4.4 | **Scan and rebuild images to include security patches.** | **OPEN-gap** (GX-12) | No Trivy/Grype image-CVE scan lane in CI (verified: `grep -rIl -E 'trivy\|grype' .github/` → only false-positive comment hits). Daily `dependency-monitoring.yml` watches *cargo* advisories, and SHA-pinned bases are bumped deliberately, but the *image's OS layer* is not CVE-scanned. Bead **sq-toze.31**. | sparq |
+| D-4.5 | **Enable Content Trust / verify image provenance.** | **PASS** | Pushed image carries buildkit max-mode SLSA provenance + an embedded SBOM (`release.yml` `docker:` job — `provenance: mode=max`, `sbom: true`). Verifiable with `gh attestation verify` / cosign. (Full SLSA-level claim lives in the `slsa` slice.) | sparq |
+| D-4.6 | **Add HEALTHCHECK instruction to the container image.** | **OPEN-gap** (GX-13, minor) | No `HEALTHCHECK` directive in the `Dockerfile` (verified: `grep -n HEALTHCHECK Dockerfile` → none). The server *does* expose `/health` (proven by `docker-smoke.sh`), so an orchestrator probe works, but the image does not self-declare it. Bead **sq-toze.36**. | sparq |
+| D-4.7 | **Do not use `latest` tag** (use a versioned/pinned tag for FROM). | **PASS** | Both `FROM`s are digest-pinned (D-4.2). The *published* image gets a `latest` tag for consumers (`release.yml` metadata `type=raw,value=latest`) **alongside** semver tags — that is the consumer-facing tag, not a `FROM`; the build itself never depends on a floating tag. | sparq |
+| D-4.8 | **Remove setuid/setgid permissions** from the image. | **PASS (by construction)** | The runtime image contains only the distroless base + one server binary copied with default perms; no setuid/setgid bit is set on the binary, and distroless ships no setuid utilities (no shell/coreutils). No `chmod u+s` anywhere. | sparq |
+| D-4.9 | **Use COPY instead of ADD.** | **PASS** | Every file-bring-in is `COPY` (`Dockerfile:57`, `:84`); `grep -n '^ADD ' Dockerfile` → none. | sparq |
+| D-4.10 | **Do not store secrets in the image / Dockerfile.** | **PASS** | No secret material in the `Dockerfile` (only `ARG CARGO_FLAGS` + the `SPARQ_ALLOW_REMOTE=1` boot flag, which is a *posture* env, not a secret). Auth tokens are passed at `docker run -e SPARQ_AUTH_TOKEN=…` (`Dockerfile:29–31`), never baked. `.dockerignore` excludes `.git/`, `.claude/`, secrets-bearing dev state. | sparq |
+| D-4.11 | **Install verified packages only** (the build uses a locked, reproducible dep set). | **PASS** | Builder runs `cargo auditable build --release --locked -p sparq-server` (`Dockerfile:70`) — `--locked` builds exactly the committed `Cargo.lock`; `cargo install --locked cargo-auditable` (`Dockerfile:64`) pins the tool too. Dependency trust is gated by `cargo-deny` + `cargo-vet` (`supply-chain.yml`). | sparq |
+| D-5.x | **Container runtime hardening** (`--read-only`, `--cap-drop=ALL`, `--pids-limit`, non-root `--user`, seccomp, `--security-opt`). | **N/A (operator)** | Runtime flags are set at `docker run`, not in the image. The `Dockerfile` header (`:16–34`) + `crates/sparq-server/README.md` document the recommended runtime hardening (gateway/TLS, Bearer token, read-only data mount `-v …:/data:ro` shown at `:11`). Operator responsibility. | operator |
+
+## Part B — CIS Controls v8 (artifact-applicable Safeguards)
+
+Only the Safeguards that are a property of *sparq's source/CI/disclosure* are scored PASS/
+AUDIT-READY; the rest are **N/A (operator)** because they govern the deploying organisation's IT
+estate (accounts, network, endpoints, the Docker host). Each is mapped, not dropped.
+
+| # | CIS v8 Safeguard | Status | Evidence (file / test / CI job) | Owner |
+|---|---|---|---|---|
+| C-2.1 | **2.1 Establish & maintain a software inventory** — for the *delivered artifact*, the dependency inventory. | **PASS** | CycloneDX SBOM per release (`release.yml` `sbom:` job → `scripts/gen-sbom-vex.sh`, attached + SLSA-attested) and in CI (`supply-chain.yml` `sbom:` job, `cargo cyclonedx --all`). `cargo auditable build` embeds the manifest *into the binary* (`Dockerfile:70`) → `cargo audit bin`. | sparq |
+| C-2.4 | **2.4 Utilise automated software-inventory tooling.** | **PASS** | SBOM generation is automated in CI (`supply-chain.yml#sbom`) and on release (`release.yml#sbom`). Dependabot tracks 4 ecosystems (`.github/dependabot.yml`). | sparq |
+| C-2.6 | **2.6 Allowlist authorised software / block unauthorised dependencies.** | **PASS** | `cargo-deny` **bans + sources + licenses** all GATING (`supply-chain.yml#deny`, `deny.toml`); `cargo-vet --locked` GATING (`supply-chain.yml#vet`) — an un-audited crate cannot enter silently. | sparq |
+| C-3.x | **3.x Data protection** (classify, encrypt, retain the *data sparq processes*). | **N/A (operator)** | sparq is a data *engine*; the operator is the controller for the RDF they load and owns classification/retention/encryption-at-rest. Mapped in the `privacy` slice (`compliance/data-flow.md` / `dpia.md`). | operator |
+| C-4.1 | **4.1 Establish & maintain a secure-configuration process** — for the *shipped image*. | **PASS** | Hardened, digest-pinned distroless `Dockerfile` (Part A D-4.1/4.2/4.3); secure-by-default server posture: a non-loopback bind is **refused** unless `SPARQ_ALLOW_REMOTE` is set, and the binary logs a loud no-auth WARNING at startup (`crates/sparq-server/src/main.rs:174,231–234`; `http.rs:175–180`). | sparq |
+| C-4.2 | **4.2 Maintain secure configuration on infrastructure (the deployed host/runtime).** | **N/A (operator)** | The `docker run` flags, host OS, daemon config are the operator's. Image-side guidance: `Dockerfile:16–34`. | operator |
+| C-6.x | **6.x Access-control management** (accounts/MFA/least-privilege) — for the *running service's users*. | **N/A (operator)** | `sparq-server` has, by documented design (threat-model boundary **B3**), no per-user auth; it ships an optional Bearer-token gate (`SPARQ_AUTH_TOKEN[_READ]`) and tells the operator to front it with a gateway / sparq-solid (`Dockerfile:33`, `http.rs`). End-user IAM is the operator's. Mapped explicitly in the `asvs` slice (the B3 decision). | operator |
+| C-6.8 | **6.8 Define & maintain role-based access control — for the *project's* CI/repo.** | **PASS (project-side)** | `CODEOWNERS` mandates review by owners; branch protection requires the `ci-summary / gate` aggregator (per `feedback-pr-workflow`); GitHub permissions are least-privilege (`permissions: contents: read` default in `ci.yml`, scoped opt-ins per job, e.g. `release.yml` `docker:` only adds `packages: write`). | sparq |
+| C-7.1 | **7.1 Establish & maintain a vulnerability-management process.** | **PASS** | `SECURITY.md` (GHSA + email, response targets) + RFC 9116 `.well-known/security.txt`; the `cra` slice maps the coordinated-disclosure obligation. Disclosure channel is machine-discoverable. | sparq |
+| C-7.3 | **7.3 Perform automated OS/application patch management — for the *delivered artifact's deps*.** | **PASS** | Dependabot (4 ecosystems, `.github/dependabot.yml`) opens dependency-bump PRs; SHA-pinned actions/bases are bumped deliberately. | sparq |
+| C-7.5/7.6 | **7.5/7.6 Perform automated application + infrastructure *vulnerability scanning*.** | **PARTIAL** | *Application/dependency* side PASS: `cargo-deny check advisories` GATING (`supply-chain.yml#deny`, un-degraded — GX-1 closed) + daily `dependency-monitoring.yml` advisory watchdog + CodeQL SAST (`codeql.yml`, gating). **Container-IMAGE** side **OPEN-gap** — no Trivy/Grype image scan (GX-12, bead **sq-toze.31**). | sparq |
+| C-7.7 | **7.7 Remediate detected vulnerabilities.** | **AUDIT-READY** | Process documented (`SECURITY.md` response targets, `compliance/policies/` vuln-management template); the *evidence of an SLA met over time* is an organisational record an external assessor reviews. | sparq + operator |
+| C-16.1 | **16.1 Establish & maintain a secure application-development process (SSDLC).** | **PASS (cross-ref)** | Full SSDLC mapping in the `ssdf` slice (NIST SP 800-218); gates: clippy `-D warnings`, conformance/SHACL/inference ratchets, coverage ratchet, Miri, fuzz, the unsafe-count ratchet — all in `ci.yml`/`fuzz.yml`/`miri.yml`. `research/threat-model.md` (STRIDE). | sparq |
+| C-16.11 | **16.11 Leverage vetted modules/services (supply-chain).** | **PASS** | `cargo-vet` per-dependency audit attestations GATING (`supply-chain.yml#vet`). | sparq |
+| C-16.12 | **16.12 Implement code-level security checks (SAST).** | **PASS** | CodeQL (`codeql.yml`, gating, results to code-scanning); clippy `-D warnings` (`ci.yml#lint`). | sparq |
+| C-16.13 | **16.13 Conduct application penetration testing — incl. fuzzing of the hostile-input surface.** | **PASS (fuzz) / AUDIT-READY (external pentest)** | cargo-fuzz over the RDF/SPARQL/SHACL/mmap surfaces (`fuzz/`, `fuzz.yml` PR smoke + nightly); the SHACL-diff differential fuzzer (`shacl-diff-fuzz.yml`). An *external* pentest engagement is an operator/org procurement, labelled. | sparq + operator |
+| C-16.14 | **16.14 Conduct threat modelling.** | **PASS** | `research/threat-model.md` — STRIDE, boundaries B1–B5. | sparq |
+| C-18.x | **18.x Penetration-testing *program*** (red team, scoped engagements). | **N/A (operator)** | An organisational program, not a source property. The artifact-side residual (fuzzing) is C-16.13. | operator |
+| C-1 / 5 / 9 / 10 / 13 / 14 / 17 | **Enterprise asset inventory, account mgmt, email/web protections, malware defenses, network monitoring, awareness training, incident-response program.** | **N/A (operator)** | Organisational/endpoint/network controls of the *deploying org*, not properties of a Rust library + image. Listed here so the auditor sees they were considered, not dropped. | operator |
+
+## Summary
+
+- **Docker Benchmark §4:** 9 PASS, 2 OPEN-gap (D-4.4 image-CVE-scan = GX-12; D-4.6 HEALTHCHECK =
+  GX-13), §5 runtime N/A-operator. The image is genuinely hardened; the holes are *scanning*, not
+  hardening.
+- **CIS v8 (artifact-applicable):** the software-inventory (2.x), secure-config of the artifact
+  (4.1), vuln-management/disclosure (7.1/7.3), CI access-control (6.8), and SSDLC/SAST/threat-model/
+  fuzz (16.x) Safeguards are PASS; 7.5/7.6 is PARTIAL pending GX-12; the org/endpoint/network
+  families are honestly N/A-operator.
+- **The single material technical gap is GX-12** (no container-image CVE scan + no Dockerfile
+  linter). Everything else is PASS, AUDIT-READY, or N/A-operator with a pointer.

--- a/compliance/cis/evidence.md
+++ b/compliance/cis/evidence.md
@@ -1,0 +1,167 @@
+<!-- [OPUS-4.8] sq-toze (cert-cis) — CIS evidence pack (re-runnable verification). Authored
+     while Fable unavailable — re-review when Fable returns. Engineer↔auditor loop (sq-toze). -->
+
+# CIS — evidence pack
+
+Each PASS / OPEN-gap claim in [`controls.md`](./controls.md) is reproduced here as a command an
+auditor can re-run from the **repo root** plus the output to expect. NON-CANONICAL timing (this
+session runs on an EC2 work box) — none of these are timing claims; they are presence/structure
+checks. Commands are deterministic source/CI scans (no build needed) unless noted.
+
+## E-1 — Container scan + Dockerfile-linter lane is ABSENT (the headline gap, GX-12)
+
+```sh
+grep -rIl -E 'trivy|grype|dockle|hadolint|docker.?scout|anchore' .github/workflows/
+```
+
+Expected: only `zk-toolchain.yml` and `ci-summary.yml` match, **and both are false positives** —
+verify by reading the matched lines:
+
+```sh
+grep -rInE 'trivy|grype|dockle|hadolint|docker.?scout|anchore' .github/workflows/
+#  zk-toolchain.yml:31:  ... "anchored" (substring of 'anchore')   <- comment, not a tool
+#  ci-summary.yml:145:   ... job literally named `gate` ... "anchored"  <- comment
+```
+
+Conclusion: **no** Trivy/Grype image-CVE scan and **no** Dockle/Hadolint Dockerfile linter exists.
+The only container-touching CI is the *smoke* run (E-7), which proves the image *boots and serves*,
+not that it is CVE-free or CIS-Benchmark-linted. → GX-12 (bead **sq-toze.31**).
+
+## E-2 — Runtime stage is non-root distroless, digest-pinned (D-4.1 / D-4.2 / D-4.7)
+
+```sh
+grep -nE '^FROM ' Dockerfile
+#  Dockerfile:51:  FROM rust:1.88-slim-bookworm@sha256:38bc5a86...d89 AS builder
+#  Dockerfile:76:  FROM gcr.io/distroless/cc-debian12:nonroot@sha256:b0ae8e98...985
+```
+
+Both `FROM`s pin a **digest** (`@sha256:…`), not a floating tag → D-4.2/D-4.7. The runtime base is
+`distroless/cc-debian12:nonroot`; the `:nonroot` distroless variant's default user is UID **65532**
+(documented by the distroless project), and there is no `USER root` in the runtime stage:
+
+```sh
+grep -nE '^USER ' Dockerfile        # → no output (no override back to root)
+```
+
+→ D-4.1 PASS (runs non-root by default).
+
+## E-3 — Minimal runtime: distroless, no shell/package-manager, single binary (D-4.3 / D-4.8)
+
+```sh
+# Nothing installed in the runtime stage; only the server binary is copied in:
+grep -nE '^(RUN|COPY|ADD) ' Dockerfile
+#  Dockerfile:57:  COPY . .                                   (builder context)
+#  Dockerfile:64:  RUN cargo install --locked cargo-auditable (builder only)
+#  Dockerfile:70:  RUN cargo auditable build --release ...    (builder only)
+#  Dockerfile:84:  COPY --from=builder .../sparq-server /usr/local/bin/sparq-server
+```
+
+All `RUN`/install steps are in the **builder** stage (discarded); the runtime stage only `COPY`s
+the single binary from the builder. Distroless ships no `apt`, shell, or coreutils → no setuid
+utilities (D-4.8), minimal surface (D-4.3).
+
+## E-4 — COPY not ADD; no secrets in the image (D-4.9 / D-4.10)
+
+```sh
+grep -nE '^ADD ' Dockerfile          # → no output → D-4.9 PASS (COPY only)
+grep -niE 'secret|password|token|api[_-]?key|BEGIN .*PRIVATE KEY' Dockerfile
+#  → only the security-note comments explaining that SPARQ_AUTH_TOKEN is passed at
+#    `docker run -e`, NEVER baked (Dockerfile:27-31). No secret VALUE present.
+```
+
+`.dockerignore` keeps secrets-bearing dev state out of the build context:
+
+```sh
+grep -nE '\.git/|\.claude/|\.vscode/|\.idea/' .dockerignore   # all excluded
+```
+
+→ D-4.10 PASS.
+
+## E-5 — Locked, auditable build (D-4.11 / C-2.1)
+
+```sh
+grep -nE 'cargo (auditable )?(install|build).*--locked' Dockerfile
+#  Dockerfile:64:  RUN cargo install --locked cargo-auditable
+#  Dockerfile:70:  RUN cargo auditable build --release --locked -p sparq-server ${CARGO_FLAGS}
+```
+
+`--locked` builds exactly the committed `Cargo.lock`; `cargo auditable` embeds the dependency
+manifest into the binary so the shipped image is self-describing (`cargo audit bin
+/usr/local/bin/sparq-server`). → D-4.11 + the artifact-side of C-2.1.
+
+## E-6 — Image provenance + SBOM on push (D-4.5 / C-2.4)
+
+```sh
+grep -nE 'provenance:|sbom:|attest-build-provenance' .github/workflows/release.yml
+#  release.yml: docker: job →  provenance: mode=max   /   sbom: true
+#  release.yml: archives + SBOM also actions/attest-build-provenance (SLSA)
+```
+
+The pushed `ghcr.io/jeswr/sparq-server` carries max-mode SLSA provenance + an embedded SBOM,
+verifiable with `gh attestation verify` / cosign. → D-4.5.
+
+## E-7 — Image boots + serves (the existing smoke gate; NOT a CVE scan)
+
+```sh
+grep -nE 'docker-smoke|docker run|/health' .github/workflows/ci.yml
+#  ci.yml: docker-smoke: job builds the image (build-push-action, load:true) then runs
+#          scripts/docker-smoke.sh sparq-server:smoke 3030  (docker run + curl /health + ASK)
+```
+
+This is the gate that makes a container which exits immediately un-shippable (it caught the sq-n6rv
+fail-closed-bind regression). It is **functional**, not a security scan — explicitly distinguished
+from GX-12 so the smoke job is never mistaken for vuln coverage.
+
+## E-8 — Secure-by-default server config + loud no-auth warning (C-4.1)
+
+```sh
+grep -nE 'no.?auth|ALLOW_REMOTE|WARN' crates/sparq-server/src/main.rs crates/sparq-server/src/http.rs
+#  main.rs:174  a non-loopback --addr is refused unless ... SPARQ_ALLOW_REMOTE / auth
+#  main.rs:231-234  Unset = no auth ... loud startup note
+#  http.rs:175-180  "By default the server has no authentication on any endpoint"
+```
+
+A non-loopback bind is **refused** (exits non-zero) unless explicitly opted in, and the binary logs
+a loud no-auth WARNING at startup → secure-config of the artifact (C-4.1). The *per-user IAM* hole
+is the documented B3 boundary (operator responsibility; mapped in the `asvs` slice), not a silent
+CIS gap.
+
+## E-9 — Dependency vuln scanning + allowlisting (C-2.6 / C-7.5 application side)
+
+```sh
+grep -nE 'deny check|cargo vet|cyclonedx' .github/workflows/supply-chain.yml
+#  supply-chain.yml#deny:  cargo deny check bans sources licenses   (GATING)
+#                          cargo deny check advisories              (GATING — GX-1 closed)
+#  supply-chain.yml#vet:   cargo vet --locked                       (GATING)
+#  supply-chain.yml#sbom:  cargo cyclonedx --all --format json
+```
+
+Plus daily `dependency-monitoring.yml` advisory watchdog and CodeQL SAST (`codeql.yml`). The
+*application/dependency* half of CIS 7.5/7.6 is covered; only the *image-OS* half is the GX-12 gap.
+
+## E-10 — CI access control + least-privilege (C-6.8)
+
+```sh
+head -1 CODEOWNERS                                  # owners-required review
+grep -nE 'permissions:|contents: read' .github/workflows/ci.yml | head
+#  ci.yml:  permissions: contents: read   (default least-privilege; per-job opt-ins only)
+```
+
+Branch protection requires the `ci-summary / gate` aggregator (governance per
+`feedback-pr-workflow`); the default workflow token is read-only with scoped per-job escalation
+(e.g. `release.yml` `docker:` adds only `packages: write`). → C-6.8 PASS (project-side).
+
+## E-11 — Disclosure channel is machine-discoverable (C-7.1)
+
+```sh
+ls SECURITY.md .well-known/security.txt
+head -2 .well-known/security.txt   # RFC 9116 channel pointing at SECURITY.md
+```
+
+→ C-7.1 PASS (GHSA + email + RFC 9116 `.well-known/security.txt`, GX-3 closed).
+
+## Reproduction note
+
+All of E-1…E-6, E-8…E-11 are pure source/CI scans (no Docker daemon, no build) and run in seconds.
+E-7's *execution* needs a Docker daemon (`scripts/docker-smoke.sh`); the *presence* of the gate is a
+source scan. No claim here depends on a benchmark timing.

--- a/compliance/cis/gap-register.md
+++ b/compliance/cis/gap-register.md
@@ -1,0 +1,59 @@
+<!-- [OPUS-4.8] sq-toze (cert-cis) — CIS gap register. Authored while Fable unavailable —
+     re-review when Fable returns. Engineer↔auditor loop (epic sq-toze). -->
+
+# CIS — gap register
+
+Open gaps for the CIS slice (CIS Controls v8 + CIS Docker Benchmark §4). Each carries a severity, a
+concrete remediation, a target, and the **`bd` bead** that tracks the fix (under epic `sq-toze`).
+No gap is papered over; the closed cross-cutting gaps that this slice *depends on* are listed at the
+bottom as context (owned by other slices).
+
+Severity: **P0** blocks a defensible CIS posture; **P1** needed for a clean score; **P2/P3**
+maturity/nice-to-have.
+
+## Open gaps (owned by this slice)
+
+| ID | Gap | Sev | CIS mapping | Remediation | Bead |
+|---|---|---|---|---|---|
+| **GX-12** | **No container-image vulnerability scan + no Dockerfile linter in CI.** The image is hardened and digest-pinned, and `docker-smoke` proves it *boots*, but no Trivy/Grype scans the built image for OS-layer CVEs and no Dockle/Hadolint lints the `Dockerfile` against the CIS Docker Benchmark. Verified absent (E-1). | **P1** | Docker Bench **§4.4**; CIS v8 **7.5/7.6** (image-OS half), **4.x** (artifact secure-config assurance), **16.x** (app-sec). | Add a PR-triggered CI job (so the `ci-summary` aggregator auto-discovers + gates it): (1) build the image, run **Trivy** (or Grype) image scan, fail on *fixable* HIGH/CRITICAL with a checked-in `.trivyignore` allowlist for triaged/non-applicable CVEs (VEX-aligned with the supply-chain slice); (2) run **Dockle**/**Hadolint** to assert non-root USER, pinned base, no secrets, COPY-not-ADD, minimal layers; (3) upload SARIF to code-scanning. Keep distroless → expect a small, mostly-glibc CVE surface; the allowlist documents each accepted item. | **sq-toze.31** |
+| **GX-13** | **No `HEALTHCHECK` instruction in the `Dockerfile`.** The server exposes `/health` (curled by `docker-smoke.sh`) but the image does not self-declare a healthcheck, so a bare `docker run` cannot report unhealthy-but-running. | **P3** (minor) | Docker Bench **§4.6**. | Add `HEALTHCHECK` against `127.0.0.1:3030/health`. **Constraint:** distroless has *no shell and no `wget`/`curl`*, so the check cannot be a shell command — it needs either a tiny static probe binary `COPY`d in or a `sparq-server --health-probe` subcommand invoked in exec-form. Track the small server addition in the bead. Orchestrators (k8s) typically use their own probes and ignore the image HEALTHCHECK, hence P3. | **sq-toze.36** |
+
+## Explicitly NOT gaps (architectural decisions / operator responsibility)
+
+These are recorded so the auditor sees they were *considered and scoped*, not missed:
+
+- **Container runtime hardening** (`--read-only`, `--cap-drop=ALL`, `--pids-limit`, non-root
+  `--user`, seccomp/`--security-opt`) — set at `docker run`, **operator responsibility**, documented
+  in `Dockerfile:16–34` + `crates/sparq-server/README.md`. CIS Docker §5 = **N/A (operator)**, not a
+  gap.
+- **`sparq-server` has no per-user authentication** — the documented **B3** threat-model decision
+  (`research/threat-model.md`); the image ships an optional Bearer-token gate and the guidance to
+  front it with a gateway / sparq-solid. End-user IAM (CIS 6.x) = **N/A (operator)**, mapped in the
+  `asvs` slice as an explicit decision, **not** a silent CIS gap.
+- **The `latest` consumer tag** on the *published* image is a deliberate convenience tag *alongside*
+  semver tags (`release.yml` metadata); the *build* never depends on a floating `FROM` (both `FROM`s
+  are digest-pinned), so CIS Docker §4.7 is PASS, not a gap.
+- **The CIS Docker §1/2/3/5/6/7 host/daemon/runtime/swarm families** — properties of the operator's
+  Docker host, not of a shipped image. N/A (operator).
+- **The CIS v8 enterprise families** (asset inventory C-1, account mgmt C-5/6 end-user, malware
+  C-10, network monitoring C-13, awareness C-14, IR program C-17, pentest program C-18) —
+  organisational/endpoint/network controls of the deploying org. N/A (operator).
+
+## Dependencies (closed gaps in other slices this slice relies on as evidence)
+
+These are **not** CIS-owned; they back CIS rows and are already closed/tracked elsewhere:
+
+- **GX-1** (cargo-deny advisories PR-gate un-degraded) — backs C-7.5 application side. Closed
+  (`sq-toze.2`, `supply-chain.yml#deny`).
+- **GX-2** (per-release CycloneDX SBOM + VEX) — backs C-2.1/2.4 + the GX-12 allowlist's VEX
+  alignment. Closed (`sq-toze.3`).
+- **GX-3** (RFC 9116 `.well-known/security.txt`) — backs C-7.1. Closed (`sq-toze.4`).
+- **GX-7** (cargo-auditable + cargo-vet) — backs D-4.11 + C-2.6/16.11. Closed (`sq-toze.8`).
+
+## Honesty statement
+
+The CIS slice has **exactly one P1 technical gap** (GX-12, the missing image-CVE-scan + Dockerfile
+linter) and one P3 minor gap (GX-13, HEALTHCHECK). The `Dockerfile` hardening itself is verified
+PASS against the actual file; the gaps are *automated scanning/linting* coverage, not a hardening
+deficiency. Nothing here is satisfied by the ZK/MPC estate, and no CIS claim contradicts the
+documented "v1 ZK verifier NOT sound" verdict.


### PR DESCRIPTION
> 🤖 SPARQ agent

CIS framework slice for the production-certification phase (epic **sq-toze**, branch `cert-cis`). Maps **CIS Controls v8** (artifact-applicable Safeguards) + **CIS Docker Benchmark §4** (the image-build half) to concrete repo evidence, verified against the **actual** `Dockerfile` and CI workflows.

## What this adds (docs only — `compliance/cis/**`, no `crates/` changes)

- `compliance/cis/README.md` — scope (library + server + image), status legend, OOS rationale (Docker §1–3/5–7 host/daemon/runtime + the CIS v8 enterprise/endpoint families = **operator responsibility**), honesty note (ZK/MPC estate excluded).
- `compliance/cis/controls.md` — per-item PASS / AUDIT-READY / OPEN-gap / N/A-operator. **Docker §4: 9 PASS + 2 gaps.** CIS v8 artifact families (2.x inventory, 4.1 secure-config, 6.8 CI access-control, 7.x vuln-mgmt/disclosure, 16.x SSDLC/SAST/fuzz/threat-model) PASS.
- `compliance/cis/evidence.md` — re-runnable source/CI scans per claim (E-1…E-11).
- `compliance/cis/gap-register.md` — the gaps + remediation beads.

## Honest headline

The `Dockerfile` hardening is **verified strong**: distroless `cc-debian12:nonroot` (UID 65532), **both** stages SHA-digest-pinned, `cargo auditable build --locked`, no shell/package-manager in the runtime layer, `COPY` not `ADD`, no baked secrets, secure-by-default server posture (non-loopback bind refused + loud no-auth WARNING). A `docker-smoke` job builds + runs the image on every PR.

## The one material gap

**GX-12 (P1):** there is **no container-image vulnerability scan (Trivy/Grype) and no Dockerfile linter (Dockle/Hadolint) lane in CI** — verified absent (`grep -rIl -E "trivy|grype|dockle|hadolint" .github/` returns only false-positive comment matches). The release `docker` job attaches an SBOM + SLSA provenance via buildkit but does **not** CVE-scan the image. Tracked: bead **sq-toze.31**.
**GX-13 (P3, minor):** no `HEALTHCHECK` in the `Dockerfile` (distroless has no shell/curl — needs a probe binary or a server subcommand). Tracked: bead **sq-toze.36**.

No CIS claim is satisfied by, or implies a guarantee from, the unsound ZK/MPC estate; the documented "v1 ZK verifier NOT sound" verdict (`SECURITY.md`) is untouched.

Paired with `compliance-auditor` — **draft**, no auto-merge, awaiting the adversarial review pass.