### PR TITLE
fix(server): stop error bodies leaking caller input / loaded RDF / fs paths (sq-cz89, sq-j9zs, sq-zg0u)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,6 +3494,7 @@ dependencies = [
  "tokio-tungstenite 0.24.0",
  "tower",
  "tower-http",
+ "tracing",
  "tracing-subscriber",
 ]
 

--- a/crates/sparq-server/Cargo.toml
+++ b/crates/sparq-server/Cargo.toml
@@ -48,7 +48,7 @@ test-seams = []
 # equivalent. Feature unification means the `sparq-core` `sparq-engine` resolves also gains `mmap`,
 # so the WAL-durable `apply_delta` path is live on the shared graph. Without `--persist` the server
 # is in-memory exactly as before (the flag, not the feature, selects durability).
-server = ["dep:sparq-serve", "dep:axum", "dep:tokio", "dep:tower", "dep:tower-http", "dep:tracing-subscriber", "dep:futures-util", "dep:serde_json", "dep:flate2", "sparq-core/mmap"]
+server = ["dep:sparq-serve", "dep:axum", "dep:tokio", "dep:tower", "dep:tower-http", "dep:tracing", "dep:tracing-subscriber", "dep:futures-util", "dep:serde_json", "dep:flate2", "sparq-core/mmap"]
 # [OPUS-4.8] (sq-i3xc, lever H5) `zlib-ng`: opt-in, OFF by default, NATIVE-ONLY faster
 # gzip backend (zlib-ng C library) for the server's `Content-Encoding: gzip` request
 # inflate (MultiGzDecoder) — a measured 1.5–3× at ~zero code change. The weak
@@ -142,6 +142,10 @@ tower = { version = "0.5", optional = true, features = ["limit", "load-shed", "u
 tower-http = { version = "0.6", optional = true, features = ["trace", "catch-panic"] }
 # Emits the TraceLayer request log when the binary runs with --verbose.
 tracing-subscriber = { version = "0.3", optional = true, default-features = false, features = ["fmt", "env-filter"] }
+# [OPUS-4.8] (sq-cz89/sq-j9zs) Detailed error diagnostics (the offending query/RDF/path) are
+# emitted to the SERVER-SIDE `tracing` log instead of the HTTP response body, so they surface
+# only via the operator's opt-in `--verbose` / RUST_LOG subscriber — never leaking to callers.
+tracing = { version = "0.1", optional = true, default-features = false, features = ["std"] }
 # `stream::iter` feeds the streamed SELECT body (T16) — already in axum's dependency
 # graph, so this adds no new transitive code.
 futures-util = { version = "0.3", optional = true, default-features = false }

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -1809,7 +1809,17 @@ async fn run_query_pinned(
 ) -> Response {
     let prepared = match prepare(sparql) {
         Ok(p) => p,
-        Err(PrepareError::Malformed(msg)) => return bad_request(&format!("malformed query: {msg}")),
+        // [OPUS-4.8] (sq-cz89/sq-j9zs) The parser echoes the offending query token verbatim;
+        // withhold it from the body (it is caller input, but an info-leak contract regardless)
+        // — the operator gets the full parse error in the server log.
+        Err(PrepareError::Malformed(msg)) => {
+            return sanitized_error(
+                StatusCode::BAD_REQUEST,
+                "query-parse",
+                "malformed query",
+                &msg,
+            )
+        }
     };
     // The generation was pinned ONCE per request (the caller's `resolve_pin`: the
     // current generation, or — under the `time-travel` feature — the requested
@@ -2103,9 +2113,14 @@ fn update_rejection_response(e: &str, config: &ServerConfig) -> Response {
     // nothing was published or acked, the server is still serving reads, and the client should
     // retry. Sniffed before the budget/parse mapping so it always wins.
     if let Some(detail) = e.strip_prefix(DURABLE_UNAVAILABLE_PREFIX) {
-        return json_error(
+        // [OPUS-4.8] (sq-cz89/sq-j9zs) `detail` is the underlying I/O error, which carries the
+        // server's `--persist` filesystem path (e.g. an ENOSPC on the mirror) — withhold it
+        // from the client; the operator sees the path in the server log.
+        return sanitized_error(
             StatusCode::SERVICE_UNAVAILABLE,
-            &format!("update not durably committed (transient durable-write error); the write was refused and NOT applied — retry: {detail}"),
+            "durable-unavailable",
+            "update not durably committed (transient durable-write error); the write was refused and NOT applied — retry",
+            detail,
         );
     }
     if e.contains("query budget exceeded") {
@@ -2113,7 +2128,15 @@ fn update_rejection_response(e: &str, config: &ServerConfig) -> Response {
         // so the 413 message must not consider `--max-results` → `apply_max_results = false`.
         return engine_error_response(e, config, false);
     }
-    bad_request(&format!("update failed: {e}"))
+    // [OPUS-4.8] (sq-cz89/sq-j9zs) A parse/semantic rejection echoes the offending UPDATE
+    // token (and, for a `DELETE/INSERT … WHERE`, can quote loaded data); withhold it — the
+    // full reason is in the server log.
+    sanitized_error(
+        StatusCode::BAD_REQUEST,
+        "update-parse",
+        "update failed: invalid SPARQL update",
+        e,
+    )
 }
 
 fn timeout_response(config: &ServerConfig) -> Response {
@@ -2290,7 +2313,17 @@ fn body_to_ntriples(body: &Bytes, content_type: &str, base: Option<&str>) -> Res
     match format {
         BodyFormat::Core(format) => {
             let text = std::str::from_utf8(body).map_err(|_| bad_request("request body is not valid UTF-8"))?;
-            let graph = Graph::load_str(text, format).map_err(|e| bad_request(&format!("malformed RDF body: {e}")))?;
+            // [OPUS-4.8] (sq-cz89/sq-j9zs) `oxttl` echoes the offending body token verbatim
+            // (e.g. an invalid subject quotes the loaded term) — withhold it; the operator
+            // gets the full parse error in the server log.
+            let graph = Graph::load_str(text, format).map_err(|e| {
+                sanitized_error(
+                    StatusCode::BAD_REQUEST,
+                    "rdf-body-parse",
+                    "malformed RDF body",
+                    &e,
+                )
+            })?;
             // Re-emit as canonical N-Triples via the engine scan — no private store API needed,
             // and the terms are exactly what `INSERT DATA` will re-intern.
             nt_dump(&graph, &QueryBudget::default()).map_err(|e| execution_error(&e))
@@ -2299,7 +2332,15 @@ fn body_to_ntriples(body: &Bytes, content_type: &str, base: Option<&str>) -> Res
         // `oxrdf`'s Display is canonical N-Triples term syntax, exactly what `INSERT DATA`
         // re-interns, so no Graph round-trip is needed (and RDF/XML is not a loader token).
         BodyFormat::RdfXml => {
-            let triples = crate::graph::parse_rdfxml(body, base).map_err(|e| bad_request(&format!("malformed RDF/XML body: {e}")))?;
+            // [OPUS-4.8] (sq-cz89/sq-j9zs) `oxrdfxml` echoes the offending body fragment — withhold it.
+            let triples = crate::graph::parse_rdfxml(body, base).map_err(|e| {
+                sanitized_error(
+                    StatusCode::BAD_REQUEST,
+                    "rdfxml-body-parse",
+                    "malformed RDF/XML body",
+                    &e,
+                )
+            })?;
             Ok(crate::graph::triples_to_ntriples(&triples))
         }
     }
@@ -2655,9 +2696,12 @@ enum DecodeError {
     /// `Content-Encoding` names a codec we do not decode (only `gzip`/`x-gzip` and
     /// `identity` are supported) → 415.
     Unsupported(String),
-    /// The decompressed image crossed the ratio/absolute ceiling → 413 (zip-bomb guard),
-    /// or the gzip stream was malformed → 400.
+    /// The decompressed image crossed the ratio/absolute ceiling → 413 (zip-bomb guard).
+    /// The message is server-constructed (sizes/knob names only — no caller content).
     TooLarge(String),
+    /// The gzip stream was malformed → 400. The payload is the underlying decoder error,
+    /// which can quote bytes of the caller's compressed body — it is the WITHHELD detail
+    /// ([OPUS-4.8] sq-cz89/sq-j9zs), routed to the server log, never the response body.
     Malformed(String),
 }
 
@@ -2666,7 +2710,13 @@ impl DecodeError {
         match self {
             DecodeError::Unsupported(m) => json_error(StatusCode::UNSUPPORTED_MEDIA_TYPE, &m),
             DecodeError::TooLarge(m) => json_error(StatusCode::PAYLOAD_TOO_LARGE, &m),
-            DecodeError::Malformed(m) => bad_request(&m),
+            // [OPUS-4.8] (sq-cz89/sq-j9zs) Generic class to the client; decoder detail to the log.
+            DecodeError::Malformed(detail) => sanitized_error(
+                StatusCode::BAD_REQUEST,
+                "gzip-decode",
+                "malformed gzip body",
+                &detail,
+            ),
         }
     }
 }
@@ -2735,7 +2785,9 @@ fn decode_gzip_bounded(body: &Bytes, config: &ServerConfig) -> Result<Bytes, Dec
     let mut out = Vec::with_capacity(ceiling.min(64 * 1024));
     decoder
         .read_to_end(&mut out)
-        .map_err(|e| DecodeError::Malformed(format!("malformed gzip body: {e}")))?;
+        // [OPUS-4.8] (sq-cz89/sq-j9zs) Carry only the raw decoder detail; `into_response`
+        // logs it server-side and returns a generic "malformed gzip body" to the client.
+        .map_err(|e| DecodeError::Malformed(e.to_string()))?;
     if out.len() > ceiling {
         return Err(DecodeError::TooLarge(format!(
             "decompressed body exceeds the server's decompression-ratio cap (compressed {} bytes \
@@ -2856,8 +2908,45 @@ fn bad_request(msg: &str) -> Response {
     json_error(StatusCode::BAD_REQUEST, msg)
 }
 
+// ---------------------------------------------------------------------------
+// Information-leak guard (sq-cz89 / sq-j9zs / sq-zg0u) [OPUS-4.8]
+//
+// On the B3 no-auth-by-default path an unauthenticated caller could provoke an error
+// whose body echoed its own (or the loaded data's, or the server's filesystem path's)
+// content verbatim — parse errors from `oxttl` / `spargebra` quote the offending token,
+// `io::Error` carries paths, etc. That is an information leak: it confirms loaded triples
+// (e.g. `patient_alice_smith is not a valid subject`) and discloses server-side paths.
+//
+// Fix: HTTP error bodies carry only a STABLE, GENERIC class message — never the caller's
+// input, loaded-data fragments, or filesystem paths. The full detail is preserved for the
+// operator on the SERVER SIDE via `tracing` (surfaced by the existing opt-in `--verbose` /
+// RUST_LOG subscriber set up in `main.rs`), exactly the posture the TraceLayer request log
+// already uses. Detail in the log, class in the body.
+// ---------------------------------------------------------------------------
+
+/// Emits the full (potentially sensitive) `detail` to the server-side `tracing` log under
+/// the `sparq_server` target — visible only to the operator who opted into `--verbose` /
+/// `RUST_LOG` — and returns a SANITIZED [`Response`] carrying just `safe_msg`, which MUST NOT
+/// contain any caller-submitted input, loaded-data fragment, or filesystem path.
+///
+/// `class` names the error category for the log line so an operator can correlate a generic
+/// client-facing message back to its detailed cause.
+fn sanitized_error(status: StatusCode, class: &str, safe_msg: &str, detail: &str) -> Response {
+    // Detail (the echoed token / path / input) goes ONLY to the server log, gated behind the
+    // operator's opt-in subscriber — never into the response body.
+    tracing::warn!(target: "sparq_server", class = class, detail = %detail, "request error (detail withheld from client)");
+    json_error(status, safe_msg)
+}
+
 fn execution_error(msg: &str) -> Response {
-    json_error(StatusCode::INTERNAL_SERVER_ERROR, &format!("query execution error: {msg}"))
+    // Engine error strings can embed term text drawn from the loaded graph — withhold them
+    // from the client; the operator sees the full message in the server log.
+    sanitized_error(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "query-execution",
+        "query execution error",
+        msg,
+    )
 }
 
 fn method_not_allowed(allow: &[Method]) -> Response {
@@ -3453,9 +3542,17 @@ mod durable_degrade_tests {
             !body.contains("\\u0001"),
             "JSON-escaped internal marker leaked into the client-facing body: {body:?}",
         );
+        // [OPUS-4.8] (sq-cz89/sq-j9zs) The post-marker detail is the underlying I/O error,
+        // which can carry the server's `--persist` filesystem PATH (an info-leak). It is now
+        // WITHHELD from the client body (routed to the server log instead). The client gets
+        // only the stable, retry-actionable class message.
         assert!(
-            body.contains("injected ENOSPC"),
-            "the human-readable detail must still be reported to the client: {body:?}",
+            !body.contains("injected ENOSPC"),
+            "the underlying detail (may carry a server path) must NOT reach the client: {body:?}",
+        );
+        assert!(
+            body.contains("retry") && body.contains("NOT applied"),
+            "the client must still get the stable retry-actionable class message: {body:?}",
         );
     }
 

--- a/crates/sparq-server/tests/hardening.rs
+++ b/crates/sparq-server/tests/hardening.rs
@@ -466,3 +466,102 @@ async fn errors_are_structured_json() {
     let body = resp.text().await.unwrap();
     assert!(body.starts_with("{\"error\":"), "got: {body}");
 }
+
+// ---------------------------------------------------------------------------
+// (6) Information-leak guard (sq-cz89 / sq-j9zs / sq-zg0u) [OPUS-4.8]
+//
+// On the no-auth-by-default path an error body MUST NOT echo the caller's submitted input,
+// a fragment of the loaded RDF, or a server-side filesystem path. Each test provokes an
+// error whose triggering content contains a SENTINEL token and asserts the sentinel does
+// NOT appear in the (still structured-JSON) error body. The detail is logged server-side
+// instead — never returned to the caller.
+// ---------------------------------------------------------------------------
+
+/// A token vanishingly unlikely to occur in any generic class message — its presence in a
+/// response body would mean the server echoed caller/loaded/path content back.
+const SENTINEL: &str = "secret_sentinel_value";
+
+#[tokio::test]
+async fn no_echo_query_parse_error() {
+    let base = spawn_with(DATA, ServerConfig::default()).await;
+    // A malformed query whose offending token is the sentinel — `spargebra` would normally
+    // quote it verbatim in the parse error.
+    let q = format!("SELECT * WHERE {{ {SENTINEL} }}");
+    let resp = client().get(format!("{base}/sparql")).query(&[("query", q.as_str())]).send().await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let body = resp.text().await.unwrap();
+    assert!(body.starts_with("{\"error\":"), "structured JSON error, got: {body}");
+    assert!(!body.contains(SENTINEL), "query parse error echoed caller input: {body}");
+}
+
+#[tokio::test]
+async fn no_echo_update_parse_error() {
+    let base = spawn_with(DATA, ServerConfig::default()).await;
+    // A malformed UPDATE carrying the sentinel as a bare (invalid) token.
+    let upd = format!("INSERT DATA {{ {SENTINEL} }}");
+    let resp = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .body(upd)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body = resp.text().await.unwrap();
+    assert!(body.starts_with("{\"error\":"), "structured JSON error, got: {body}");
+    assert!(!body.contains(SENTINEL), "update parse error echoed caller input: {body}");
+}
+
+#[tokio::test]
+async fn no_echo_rdf_body_parse_error() {
+    let base = spawn_with(DATA, ServerConfig::default()).await;
+    // Malformed N-Triples whose offending subject token is the sentinel — `oxttl` quotes
+    // the bad token verbatim (the exact leak the Privacy audit surfaced for loaded RDF).
+    let bad = format!("{SENTINEL} <http://ex/p> <http://ex/o> .\n");
+    let resp = client()
+        .put(format!("{base}/graphs/leak"))
+        .header("content-type", "application/n-triples")
+        .body(bad)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body = resp.text().await.unwrap();
+    assert!(body.starts_with("{\"error\":"), "structured JSON error, got: {body}");
+    assert!(!body.contains(SENTINEL), "RDF-body parse error echoed loaded-data fragment: {body}");
+}
+
+#[tokio::test]
+async fn no_echo_malformed_gzip_body() {
+    let base = spawn_with(DATA, ServerConfig::default()).await;
+    // A body that ADVERTISES gzip but is not a valid gzip stream — the decoder error can
+    // quote bytes of the (caller-supplied) body. Embed the sentinel in those bytes.
+    let mut not_gzip = vec![0x1f, 0x8b, 0x08, 0x00]; // gzip magic so it enters the decode path
+    not_gzip.extend_from_slice(SENTINEL.as_bytes());
+    not_gzip.extend_from_slice(&[0xff; 16]);
+    let resp = client()
+        .put(format!("{base}/graphs/gz"))
+        .header("content-type", "text/turtle")
+        .header("content-encoding", "gzip")
+        .body(not_gzip)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400, "a corrupt gzip stream is a 400");
+    let body = resp.text().await.unwrap();
+    assert!(body.starts_with("{\"error\":"), "structured JSON error, got: {body}");
+    assert!(!body.contains(SENTINEL), "gzip decode error echoed caller body bytes: {body}");
+}
+
+#[tokio::test]
+async fn no_echo_execution_error() {
+    let base = spawn_with(DATA, ServerConfig::default()).await;
+    // A syntactically valid query that fails at EXECUTION — the engine error string can
+    // embed term text drawn from the query/graph. Use a sentinel IRI in a construct so the
+    // engine error (if any) would quote it; assert it never reaches the body. Even when the
+    // query SUCCEEDS this is a no-op assertion (no error body), so it is robust either way.
+    let q = format!("SELECT * WHERE {{ ?s ?p ?o . FILTER(?s = <http://ex/{SENTINEL}> && SAMETERM(?s, 1/0)) }}");
+    let resp = client().get(format!("{base}/sparql")).query(&[("query", q.as_str())]).send().await.unwrap();
+    let body = resp.text().await.unwrap();
+    assert!(!body.contains(SENTINEL), "execution error echoed query/graph content: {body}");
+}

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -527,6 +527,18 @@ and `update_in_place_with_budget`, and wrap calls in
   `Content-Type: application/json` (the `405` keeps its `Allow` header). POST query
   requires `Content-Type: application/sparql-query` or `application/x-www-form-urlencoded`
   (else `415`); a GET without `query=` is `400`.
+- **Error bodies are sanitized — no information leak (sq-cz89 / sq-j9zs).** On the
+  no-auth-by-default path an error body carries only a **stable, generic CLASS message**
+  (e.g. `malformed query`, `malformed RDF body`, `malformed gzip body`,
+  `query execution error`, `update failed: invalid SPARQL update`). It deliberately does
+  **NOT** echo the caller's submitted query/UPDATE/RDF text, a fragment of the loaded RDF
+  (parsers like `oxttl`/`spargebra` quote the offending token — that would confirm loaded
+  triples), or any server-side filesystem path (e.g. a `--persist` mirror's path inside a
+  transient durable-write `503`). The full detailed cause is preserved for the **operator**
+  via the server-side `tracing` log (target `sparq_server`), surfaced only through the
+  opt-in `--verbose` / `RUST_LOG` subscriber — never the HTTP response. Status semantics
+  (the `400`/`413`/`415`/`503`/`500` classification) are unchanged; only the prose detail
+  is withheld. Regression tests assert a sentinel token never appears in any error body.
 - **mimalloc** is the binary's global allocator (matters under concurrent load).
 
 ## See also


### PR DESCRIPTION
> 🤖 SPARQ agent

Fixes an **unauthenticated information leak** (refs **sq-cz89** P1, **sq-j9zs** ASVS-G3, regression **sq-zg0u**) surfaced + empirically confirmed by the Privacy + ASVS cert audits.

## The leak
On the B3 no-auth-by-default path, HTTP error response bodies echoed the offending content **verbatim** back to an unauthenticated caller:

- **query parse** errors quoted the caller's query token (`spargebra`)
- **UPDATE parse** errors quoted the caller's update token
- **RDF-body load** errors quoted the offending body token — and `oxttl` quotes the **loaded term** (e.g. `patient_alice_smith is not a valid subject`), *confirming loaded triples* to an outsider
- **malformed-gzip** errors quoted caller body bytes
- **engine execution** errors could embed term text drawn from the graph
- a transient **durable-write 503** echoed the `--persist` mirror's **filesystem path**

## The fix — sanitize at the HTTP boundary
A single choke point (`sanitized_error(status, class, safe_msg, detail)`) routes the full detail to the **server-side `tracing` log** (target `sparq_server`, surfaced only via the existing opt-in `--verbose` / `RUST_LOG` subscriber — the same posture as the TraceLayer request log) and returns **only a stable, generic CLASS message** in the body.

Rewired all six sites: query-parse, update-parse, rdf-body-parse, rdfxml-body-parse, gzip-decode (`DecodeError::Malformed`), `execution_error`, and the durable-unavailable 503 (strips the post-marker path detail).

- **Status semantics unchanged** — `400/413/415/503/500` classification and the structured-JSON `{"error":…}` envelope are preserved; only the prose detail is withheld.
- `sparq-core::Graph::load_str` is **left untouched** — its detailed string now reaches only the server log, never the client. The HTTP boundary sanitizes regardless of what the core emits (the cleaner, future-proof seam).

## Regression tests (sq-zg0u)
Five HTTP no-echo tests POST/GET content containing a `secret_sentinel_value` token and assert it **never** appears in the error body — one per path: query parse, UPDATE parse, RDF-body load, malformed gzip, execution. The durable-degrade unit test is updated to assert the underlying detail (which can carry a server path) is now **withheld** from the client while the stable retry message survives.

The 401-parity / structured-error contract tests (`hardening.rs` / `auth.rs`) stay green — the error contract is unchanged, only the echo is stopped. `skills/http-server/SKILL.md` documents the sanitized error contract.

## Verify
- `cargo build` clean
- `cargo test -p sparq-server -p sparq-core` green (incl. the 5 new no-echo tests + updated durable test)
- `cargo clippy --all-targets -D warnings` clean on both crates
- NON-CANONICAL timing
