### PR TITLE
feat(vectors): predicate-constrained (filtered) ANN over the dict-id mask (sq-1wc1)

### DIFF
--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -27,6 +27,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
+# [OPUS-4.8] sq-1wc1: predicate-constrained (filtered) ANN — the RDF-native vector
+# differentiator. A SPARQL BGP carves out a candidate dict-id set (the "visit mask") and the
+# nearest-neighbour search returns only neighbours inside it. OPT-IN and OFF by default; it is a
+# LEAN feature — it adds NO new dependency (the mask reuses the in-tree `rustc-hash` set) and pulls
+# in NEITHER the engine NOR any heavy crate, so the default `sparq-vectors` build (and the core
+# query path) carry zero filtered-ANN code. The feature gates `filter.rs` (the `IdMask` +
+# `FilterConfig` + exact pre-filter) and the `DiskAnnIndex::nearest_filtered*` traversal path. The
+# engine-side BGP → mask wiring is a separate, deferred bead (see sq-1wc1); this feature is the core
+# sparq-vectors filtered API.
+filtered-ann = []
 # [OPUS-4.8] sq-k6ex (epic sq-3183): the `vec:` magic predicates — vector KNN
 # search expressed INSIDE plain SPARQL, mirroring sparq-text's `text:` rewrite.
 # OPT-IN and OFF by default: only this feature pulls `sparq-engine` (+ spargebra)

--- a/crates/sparq-vectors/src/ann.rs
+++ b/crates/sparq-vectors/src/ann.rs
@@ -220,6 +220,26 @@ impl VectorIndex {
             .collect()
     }
 
+    /// [OPUS-4.8] (sq-1wc1) **Predicate-constrained (filtered) top-`k`** over the HNSW index:
+    /// returns only neighbours whose id the `mask` permits (the candidate id-set a SPARQL BGP
+    /// selects). `instant-distance`'s adjacency is **not exposed**, so — unlike
+    /// [`DiskAnnIndex::nearest_filtered`](crate::DiskAnnIndex::nearest_filtered), which can do
+    /// predicate-agnostic graph traversal — the in-RAM HNSW cannot be walked with predicate-aware
+    /// acceptance. This therefore uses the **exact pre-filter** strategy (scan only the masked ids):
+    /// exact, and the right choice for a selective mask; for a broad mask over a large store prefer
+    /// the on-disk index's filtered traversal. Empty mask / all-zero query → no results.
+    #[cfg(feature = "filtered-ann")]
+    pub fn nearest_filtered(
+        &self,
+        query: &[f32],
+        mask: &crate::IdMask,
+        store: &VectorStore,
+        k: usize,
+    ) -> Vec<(Id, f32)> {
+        assert_eq!(query.len(), self.dim, "query dim {} != store dim {}", query.len(), self.dim);
+        crate::filter::nearest_exact_filtered(store, query, mask, k)
+    }
+
     /// [OPUS-4.8] (sq-32i5) [`nearest_term`](Self::nearest_term) with the staleness check: returns
     /// `Err` if `store` was built against a different graph generation than `graph` (which would
     /// otherwise return silently-wrong neighbours), else `Ok` with the neighbours. The HNSW index

--- a/crates/sparq-vectors/src/diskann.rs
+++ b/crates/sparq-vectors/src/diskann.rs
@@ -651,6 +651,129 @@ impl DiskAnnIndex {
         working.into_iter().map(|c| (c.slot, 1.0 - c.dist / 2.0)).collect()
     }
 
+    /// [OPUS-4.8] (sq-1wc1) **Filtered** greedy beam search: traverse the Vamana graph
+    /// *predicate-agnostically* (expand through every neighbour, beam-truncated toward `query` —
+    /// exactly as [`search_slots`](Self::search_slots) does, so connectivity is preserved) but only
+    /// **accept** into the result the slots whose dictionary id passes `accept`. ACORN / NaviX-style
+    /// predicate-aware acceptance. Returns the `k` accepted slots closest to `query`, best first.
+    ///
+    /// `accept` is the slot→keep predicate (the caller closes over an [`IdMask`](crate::IdMask),
+    /// translating slot to id once per visited node). The traversal beam is `beam`; because accepted
+    /// nodes are a subset of visited nodes, the caller widens `beam` over the unfiltered default so
+    /// `k` accepted nodes can still be collected (see [`FilterConfig`](crate::FilterConfig)).
+    #[cfg(feature = "filtered-ann")]
+    fn search_slots_filtered(
+        &self,
+        query: &[f32],
+        k: usize,
+        beam: usize,
+        accept: impl Fn(u32) -> bool,
+    ) -> Vec<(u32, f32)> {
+        if self.count == 0 {
+            return Vec::new();
+        }
+        let beam = beam.max(k).max(1);
+        // `working`: the traversal frontier (ALL nodes, mask-agnostic — drives expansion exactly as
+        // the unfiltered search, so the graph's short paths are kept). `accepted`: masked nodes seen
+        // so far, kept separately so a masked hit is never lost when the beam truncates it out.
+        let mut working: Vec<Cand> = Vec::with_capacity(beam + self.degree);
+        let mut accepted: Vec<Cand> = Vec::new();
+        let mut in_working = vec![false; self.count];
+        let mut expanded = vec![false; self.count];
+        let consider = |slot: u32, dist: f32, accepted: &mut Vec<Cand>| {
+            if accept(slot) {
+                accepted.push(Cand { dist, slot });
+            }
+        };
+        let start = self.medoid;
+        let start_d = sq_dist(query, self.node_vector(start));
+        working.push(Cand { dist: start_d, slot: start });
+        in_working[start as usize] = true;
+        consider(start, start_d, &mut accepted);
+        loop {
+            let next = working.iter().filter(|c| !expanded[c.slot as usize]).min().copied();
+            let Some(cur) = next else { break };
+            expanded[cur.slot as usize] = true;
+            let neighbours: Vec<u32> = self.node_neighbours(cur.slot).collect();
+            for nbr in neighbours {
+                if in_working[nbr as usize] {
+                    continue;
+                }
+                in_working[nbr as usize] = true;
+                let d = sq_dist(query, self.node_vector(nbr));
+                consider(nbr, d, &mut accepted);
+                working.push(Cand { dist: d, slot: nbr });
+            }
+            if working.len() > beam {
+                working.sort_unstable();
+                working.truncate(beam);
+            }
+        }
+        accepted.sort_unstable();
+        accepted.dedup_by_key(|c| c.slot);
+        accepted.truncate(k);
+        // d² over unit vectors → cosine: cos = 1 − d²/2.
+        accepted.into_iter().map(|c| (c.slot, 1.0 - c.dist / 2.0)).collect()
+    }
+
+    /// [OPUS-4.8] (sq-1wc1) **Predicate-constrained (filtered) approximate top-`k`**: like
+    /// [`nearest`](Self::nearest) but the result is restricted to ids the `mask` permits — the
+    /// RDF-native filtered-ANN path. The mask is the candidate id-set a SPARQL BGP selects (e.g.
+    /// `?node a :Car`); only neighbours in it are returned, while the traversal still hops through
+    /// non-matching nodes for connectivity.
+    ///
+    /// Strategy is chosen by the mask's **selectivity** ([`FilterConfig`](crate::FilterConfig)):
+    /// a *very selective* mask is served by an exact **pre-filter** scan over just the masked ids
+    /// (cheaper and exact than touching the whole graph), a *broad* mask by **filtered traversal**
+    /// of the Vamana graph. Both honour the mask; see the [`filter`](crate::filter) module docs and
+    /// `tests/filtered.rs` for the measured recall. Uses [`FilterConfig::default`]; for a custom
+    /// threshold/beam use [`nearest_filtered_with`](Self::nearest_filtered_with).
+    ///
+    /// An empty mask returns no results (the BGP matched nothing); an all-zero query returns no
+    /// results (same degenerate contract as [`nearest`](Self::nearest)).
+    #[cfg(feature = "filtered-ann")]
+    pub fn nearest_filtered(
+        &self,
+        query: &[f32],
+        mask: &crate::IdMask,
+        store: &VectorStore,
+        k: usize,
+    ) -> Vec<(Id, f32)> {
+        self.nearest_filtered_with(query, mask, store, k, crate::FilterConfig::default())
+    }
+
+    /// [OPUS-4.8] (sq-1wc1) [`nearest_filtered`](Self::nearest_filtered) with an explicit
+    /// [`FilterConfig`](crate::FilterConfig) (pre-filter ↔ traversal crossover and the traversal
+    /// beam factor). The `store` is needed for the pre-filter strategy (it scans the masked vectors
+    /// directly); for the traversal strategy it is unused, but the method takes it unconditionally so
+    /// the strategy choice stays an internal detail.
+    #[cfg(feature = "filtered-ann")]
+    pub fn nearest_filtered_with(
+        &self,
+        query: &[f32],
+        mask: &crate::IdMask,
+        store: &VectorStore,
+        k: usize,
+        cfg: crate::FilterConfig,
+    ) -> Vec<(Id, f32)> {
+        assert_eq!(query.len(), self.dim, "query dim {} != index dim {}", query.len(), self.dim);
+        if mask.is_empty() {
+            return Vec::new();
+        }
+        // Selective mask → exact pre-filter scan over just the masked ids (exact AND cheaper than
+        // walking the whole graph to accept a handful of nodes; also avoids a graph-connectivity
+        // miss to an isolated accepted node). Broad mask → filtered traversal.
+        if cfg.prefer_prefilter(mask.len(), self.count) {
+            return crate::filter::nearest_exact_filtered(store, query, mask, k);
+        }
+        let Some(q) = normalized(query) else { return Vec::new() };
+        let beam = (self.search_beam.max(k)) * cfg.traversal_beam_factor.max(1);
+        self.search_slots_filtered(&q, k, beam, |slot| mask.contains(self.node_id(slot)))
+            .into_iter()
+            .map(|(slot, cos)| (self.node_id(slot), cos))
+            .collect()
+    }
+
     /// Approximate top-`k` ids by cosine similarity to `query`, best first. An all-zero
     /// `query` returns no results (same contract as [`nearest_exact`](crate::ann::nearest_exact)
     /// and [`VectorIndex::nearest`](crate::ann::VectorIndex::nearest)).

--- a/crates/sparq-vectors/src/filter.rs
+++ b/crates/sparq-vectors/src/filter.rs
@@ -1,0 +1,192 @@
+//! [OPUS-4.8] (sq-1wc1) **Predicate-constrained (filtered) ANN** — the RDF-native vector
+//! differentiator.
+//!
+//! A SPARQL basic graph pattern constrains *which* graph nodes are eligible neighbours
+//! (e.g. `?node a :Car ; :seats ?s` carves out a candidate id-set), and the nearest-neighbour
+//! search must return only neighbours **within that set**. The caller (engine / `vec:` rewrite)
+//! computes the exact set of permitted dictionary ids from the BGP through the permutation
+//! indexes; this module's job is to *accept that set as a mask and honour it* during search.
+//!
+//! # The mask
+//!
+//! [`IdMask`] is a set of permitted dictionary [`Id`]s — the "visit mask" of allowed neighbours.
+//! It is deliberately a plain id set (backed by [`rustc_hash::FxHashSet`], already a crate dep),
+//! so building one is just `BGP-result-ids.collect()`; no new dependency enters the tree and the
+//! feature stays lean. Membership is the only operation search needs.
+//!
+//! # Two strategies (selectivity decides)
+//!
+//! Both strategies return **exactly** the same neighbours an exact full scan restricted to the
+//! mask would — but cost differently as the mask's selectivity changes:
+//!
+//! - **Pre-filter** ([`nearest_exact_filtered`]): scan only the masked ids and rank them by
+//!   cosine. Cost is O(|mask|·dim). When the mask is **very selective** (few eligible nodes) this
+//!   is both *exact* and *cheapest* — touching the whole ANN graph to find a handful of accepted
+//!   nodes would be wasteful, and a filtered graph traversal can even fail to reach an isolated
+//!   accepted node through unaccepted hops.
+//!
+//! - **Filtered traversal** ([`DiskAnnIndex::nearest_filtered`], ACORN / NaviX-style): walk the
+//!   Vamana proximity graph **predicate-agnostically** — expand through *every* neighbour for
+//!   connectivity — but **only accept** (collect into the result) nodes that are in the mask
+//!   (*predicate-aware acceptance*). This keeps the graph's short search paths while filtering the
+//!   output, and is the right choice when the mask is broad (a large fraction of the store passes),
+//!   where pre-filtering would scan almost everything.
+//!
+//! The crossover is governed by a **selectivity threshold** (see [`FilterConfig`]): below it the
+//! mask is "selective" and we pre-filter; above it we traverse. The default
+//! ([`FilterConfig::default`]) pre-filters when the mask admits **≤ 1%** of the store *or* ≤ 256
+//! nodes (whichever is larger), an honestly conservative line — pre-filter is exact, so erring
+//! toward it never hurts recall, only (mildly) throughput on a mid-selective mask. Callers that
+//! know their workload can move the line with [`FilterConfig`].
+//!
+//! Filtered traversal over an approximate graph is itself approximate: a target accepted node can
+//! sit behind a region the beam prunes. [`DiskAnnIndex::nearest_filtered`] therefore widens its
+//! own search beam (it must visit more nodes to *accept* `k`), and the
+//! [`tests`](../tests/filtered.rs) measure recall against the exact-filtered ground truth.
+//!
+//! # Why the on-disk Vamana index and not the HNSW one
+//!
+//! Filtered traversal needs the graph's **adjacency** to walk it. [`DiskAnnIndex`] owns its
+//! on-disk Vamana adjacency, so filtered traversal lives there. [`crate::ann::VectorIndex`] wraps
+//! `instant-distance`, whose adjacency is **not exposed**, so it cannot do predicate-agnostic
+//! traversal — for it (and as a universal fallback) [`nearest_exact_filtered`] is the filtered
+//! path. This mirrors the crate's existing split: `VectorIndex` is the in-RAM convenience, the
+//! on-disk graph is where the index internals are ours to extend.
+
+#[cfg(doc)]
+use crate::diskann::DiskAnnIndex;
+use crate::store::VectorStore;
+use rustc_hash::FxHashSet;
+use sparq_core::dict::Id;
+
+/// A set of permitted dictionary [`Id`]s — the **visit mask** a filtered ANN search restricts its
+/// accepted neighbours to. Built from the id-set a SPARQL BGP selects (e.g. all `?node` with
+/// `?node a :Car`); see the [module docs](self).
+///
+/// Backed by an [`FxHashSet`] so membership is O(1) and construction is a `collect`. An **empty**
+/// mask admits nothing — every filtered search returns no results (the honest answer when the BGP
+/// matched no nodes), distinct from "no mask" (an unfiltered search, which is the plain
+/// [`nearest`](DiskAnnIndex::nearest) / [`nearest_exact`](crate::ann::nearest_exact) path).
+#[derive(Clone, Debug, Default)]
+pub struct IdMask {
+    ids: FxHashSet<Id>,
+}
+
+impl IdMask {
+    /// An empty mask (admits no id). A filtered search against it returns no results.
+    pub fn new() -> IdMask {
+        IdMask {
+            ids: FxHashSet::default(),
+        }
+    }
+
+    /// Builds a mask from the permitted ids (duplicates collapse). This is the BGP → mask seam:
+    /// `IdMask::from_ids(bgp_solution_ids)`.
+    pub fn from_ids<I: IntoIterator<Item = Id>>(ids: I) -> IdMask {
+        IdMask {
+            ids: ids.into_iter().collect(),
+        }
+    }
+
+    /// Adds a permitted id. Returns `self` for chaining.
+    pub fn insert(&mut self, id: Id) -> &mut IdMask {
+        self.ids.insert(id);
+        self
+    }
+
+    /// Is `id` permitted?
+    pub fn contains(&self, id: Id) -> bool {
+        self.ids.contains(&id)
+    }
+
+    /// Number of permitted ids.
+    pub fn len(&self) -> usize {
+        self.ids.len()
+    }
+
+    /// Does the mask admit nothing?
+    pub fn is_empty(&self) -> bool {
+        self.ids.is_empty()
+    }
+
+    /// The permitted ids (unordered).
+    pub fn iter(&self) -> impl Iterator<Item = Id> + '_ {
+        self.ids.iter().copied()
+    }
+}
+
+impl FromIterator<Id> for IdMask {
+    fn from_iter<I: IntoIterator<Item = Id>>(iter: I) -> IdMask {
+        IdMask::from_ids(iter)
+    }
+}
+
+/// Tuning for the [filtered ANN](self) strategy choice and beam.
+///
+/// The two knobs pick the pre-filter ↔ filtered-traversal crossover; the third widens the beam so
+/// filtered traversal can still *accept* `k` despite skipping unmasked nodes.
+#[derive(Clone, Copy, Debug)]
+pub struct FilterConfig {
+    /// Pre-filter (exact scan over the mask) when `mask.len()` is at most this **fraction** of the
+    /// store. Below the crossover the mask is "selective" and scanning just the masked ids beats
+    /// (and is exact vs.) traversing the whole graph. `0.0` forces traversal except for the
+    /// absolute floor; `1.0` always pre-filters.
+    pub prefilter_fraction: f32,
+    /// …or when `mask.len()` is at most this **absolute** count — a floor so a tiny mask over a
+    /// huge store always pre-filters even if the fraction would not trip.
+    pub prefilter_floor: usize,
+    /// Filtered traversal multiplies the search beam by this factor (≥ 1): because traversal only
+    /// *accepts* masked nodes, it must visit proportionally more nodes to collect `k`. Higher =
+    /// better filtered recall, more work.
+    pub traversal_beam_factor: usize,
+}
+
+impl Default for FilterConfig {
+    fn default() -> Self {
+        // Conservative line: pre-filter (exact) up to 1% of the store or 256 nodes, whichever is
+        // larger. Pre-filter never costs recall, only mild throughput on a mid-selective mask, so
+        // erring toward it is the honest default. Traversal beam ×4 so accepting k stays robust
+        // under a moderately selective mask. [OPUS-4.8] non-canonical: see tests/filtered.rs for
+        // the measured recall these defaults clear.
+        FilterConfig {
+            prefilter_fraction: 0.01,
+            prefilter_floor: 256,
+            traversal_beam_factor: 4,
+        }
+    }
+}
+
+impl FilterConfig {
+    /// Should a mask of `mask_len` permitted ids over a `store_len`-vector store be served by the
+    /// **pre-filter** (exact scan) strategy rather than filtered traversal?
+    pub fn prefer_prefilter(&self, mask_len: usize, store_len: usize) -> bool {
+        let frac_cut = (store_len as f32 * self.prefilter_fraction) as usize;
+        mask_len <= frac_cut.max(self.prefilter_floor)
+    }
+}
+
+/// **Exact filtered top-`k`** — the ground-truth filtered search and the *pre-filter* strategy:
+/// rank only the masked ids by cosine and return the best `k`. The result is exactly what an
+/// unfiltered exact scan would yield after discarding every non-masked id, so it is the recall
+/// reference the approximate filtered traversal is measured against.
+///
+/// An empty mask, or a query with no direction (all-zero), returns no results — the same
+/// degenerate-case contract as [`nearest_exact`](crate::ann::nearest_exact). Ids absent from the
+/// store are silently skipped (a BGP can select an unembedded node).
+pub fn nearest_exact_filtered(
+    store: &VectorStore,
+    query: &[f32],
+    mask: &IdMask,
+    k: usize,
+) -> Vec<(Id, f32)> {
+    if mask.is_empty() || query.iter().all(|&v| v == 0.0) {
+        return Vec::new();
+    }
+    let mut scored: Vec<(Id, f32)> = mask
+        .iter()
+        .filter_map(|id| store.get(id).map(|v| (id, crate::ann::cosine(query, v))))
+        .collect();
+    scored.sort_unstable_by(|a, b| b.1.total_cmp(&a.1).then(a.0.cmp(&b.0)));
+    scored.truncate(k);
+    scored
+}

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -3,6 +3,8 @@
 pub mod ann;
 pub mod diskann;
 pub mod embed;
+#[cfg(feature = "filtered-ann")]
+pub mod filter;
 pub mod fingerprint;
 pub mod fuse;
 pub mod import;
@@ -33,6 +35,9 @@ pub use ann::{
 };
 pub use diskann::{sibling_graph_path, DiskAnnIndex, VamanaConfig, SPQG_MAGIC, SPQG_VERSION};
 pub use embed::{Embedder, HashEmbedder};
+// [OPUS-4.8] (sq-1wc1) Predicate-constrained (filtered) ANN — the `filtered-ann` feature only.
+#[cfg(feature = "filtered-ann")]
+pub use filter::{nearest_exact_filtered, FilterConfig, IdMask};
 pub use fingerprint::{check_against, Artifact, CheckResult, Fingerprint, FINGERPRINT_LEN};
 pub use fuse::{fuse_rrf, fuse_rrf_weighted, fuse_scores, hybrid_search, Retriever, RRF_K};
 pub use import::{ImportBinding, ImportSpec, MAX_NPY_HEADER_LEN};

--- a/crates/sparq-vectors/tests/filtered.rs
+++ b/crates/sparq-vectors/tests/filtered.rs
@@ -1,0 +1,278 @@
+//! [OPUS-4.8] (sq-1wc1) Predicate-constrained (filtered) ANN gate. Compiled only with the opt-in
+//! `filtered-ann` feature (`cargo test -p sparq-vectors --features filtered-ann`).
+//!
+//! Covers:
+//!  1. **recall** of filtered traversal (`DiskAnnIndex::nearest_filtered` over a *broad* mask) vs.
+//!     the exact-filtered ground truth (`nearest_exact_filtered`) on a 20k synthetic set;
+//!  2. the **pre-filter** strategy is exact (a selective mask matches the ground truth exactly);
+//!  3. **selectivity edge cases**: empty mask → no results, full mask → equals the unfiltered
+//!     search, single-element mask → that one id (when reachable / in store);
+//!  4. the **HNSW** filtered entry point (`VectorIndex::nearest_filtered`, exact pre-filter) agrees
+//!     with the ground truth;
+//!  5. `IdMask` / `FilterConfig` mechanics (construction, `prefer_prefilter` crossover).
+
+#![cfg(feature = "filtered-ann")]
+
+use sparq_vectors::{
+    nearest_exact, nearest_exact_filtered, DiskAnnIndex, FilterConfig, IdMask, VectorIndex,
+    VectorStore,
+};
+
+fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E3779B97F4A7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+    z ^ (z >> 31)
+}
+
+/// Uniform in [-1, 1).
+fn rand_vec(state: &mut u64, dim: usize) -> Vec<f32> {
+    (0..dim)
+        .map(|_| ((splitmix64(state) >> 40) as f32 / (1u64 << 23) as f32) * 2.0 - 1.0)
+        .collect()
+}
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("sparq-vectors-{name}-{}", std::process::id()))
+}
+
+/// Builds an N×DIM store with sparse ids `i*7+3`, returns (store, store_path, all_ids).
+fn build_store(n: usize, dim: usize, path: &std::path::Path) -> (VectorStore, Vec<u32>) {
+    let mut store = VectorStore::create(path, dim).unwrap();
+    let mut state = 0xC0FFEE_u64;
+    let mut ids = Vec::with_capacity(n);
+    for i in 0..n {
+        let id = (i as u32) * 7 + 3;
+        store.put(id, &rand_vec(&mut state, dim)).unwrap();
+        ids.push(id);
+    }
+    store.finalize().unwrap();
+    (store, ids)
+}
+
+#[test]
+fn filtered_traversal_recall_vs_exact_on_broad_mask() {
+    // A broad mask (~half the store passes) forces the FILTERED-TRAVERSAL strategy (above the
+    // pre-filter crossover) and measures its recall against the exact-filtered ground truth.
+    const N: usize = 20_000;
+    const DIM: usize = 32;
+    const K: usize = 10;
+    const QUERIES: usize = 100;
+
+    let store_path = tmp("filtered-recall.spqv");
+    let graph_path = tmp("filtered-recall.spqg");
+    let (store, ids) = build_store(N, DIM, &store_path);
+    let idx = DiskAnnIndex::build(&store, &graph_path).unwrap();
+
+    // ~50% mask: keep every other id. Well above the 1% pre-filter line, so traversal runs.
+    let mask: IdMask = ids.iter().copied().step_by(2).collect();
+    assert!(
+        !FilterConfig::default().prefer_prefilter(mask.len(), N),
+        "a ~50% mask must take the traversal path, not pre-filter"
+    );
+
+    let mut q_state = 0xDECAF_u64;
+    let mut hits = 0usize;
+    let mut total = 0usize;
+    for _ in 0..QUERIES {
+        let q = rand_vec(&mut q_state, DIM);
+        let truth: Vec<u32> = nearest_exact_filtered(&store, &q, &mask, K)
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+        let got: Vec<u32> = idx
+            .nearest_filtered(&q, &mask, &store, K)
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+        // Every returned id must be in the mask (the hard guarantee).
+        for id in &got {
+            assert!(
+                mask.contains(*id),
+                "filtered search returned an unmasked id {id}"
+            );
+        }
+        total += truth.len();
+        hits += got.iter().filter(|id| truth.contains(id)).count();
+    }
+    let recall = hits as f64 / total as f64;
+    eprintln!("filtered-traversal recall@{K} over {QUERIES} queries (~50% mask) on {N}x{DIM}: {recall:.4}");
+    assert!(
+        recall >= 0.90,
+        "filtered recall gate failed: {recall:.4} < 0.90"
+    );
+
+    let _ = std::fs::remove_file(&store_path);
+    let _ = std::fs::remove_file(&graph_path);
+}
+
+#[test]
+fn selective_mask_prefilter_is_exact() {
+    // A selective mask (≤ 1% / floor) takes the exact PRE-FILTER path; it must match the
+    // ground truth EXACTLY (pre-filter is exact, not approximate).
+    const N: usize = 20_000;
+    const DIM: usize = 32;
+    const K: usize = 10;
+
+    let store_path = tmp("filtered-selective.spqv");
+    let graph_path = tmp("filtered-selective.spqg");
+    let (store, ids) = build_store(N, DIM, &store_path);
+    let idx = DiskAnnIndex::build(&store, &graph_path).unwrap();
+
+    // 50 ids — under the 256 floor → pre-filter.
+    let mask: IdMask = ids.iter().copied().take(50).collect();
+    assert!(FilterConfig::default().prefer_prefilter(mask.len(), N));
+
+    let mut q_state = 0x1234_u64;
+    for _ in 0..50 {
+        let q = rand_vec(&mut q_state, DIM);
+        let truth = nearest_exact_filtered(&store, &q, &mask, K);
+        let got = idx.nearest_filtered(&q, &mask, &store, K);
+        assert_eq!(
+            got, truth,
+            "selective mask must be served exactly (pre-filter)"
+        );
+    }
+
+    let _ = std::fs::remove_file(&store_path);
+    let _ = std::fs::remove_file(&graph_path);
+}
+
+#[test]
+fn edge_cases_empty_full_single() {
+    const N: usize = 2_000;
+    const DIM: usize = 16;
+    const K: usize = 10;
+
+    let store_path = tmp("filtered-edge.spqv");
+    let graph_path = tmp("filtered-edge.spqg");
+    let (store, ids) = build_store(N, DIM, &store_path);
+    let idx = DiskAnnIndex::build(&store, &graph_path).unwrap();
+    let vidx = VectorIndex::build(&store);
+
+    let mut q_state = 0xBEEF_u64;
+    let q = rand_vec(&mut q_state, DIM);
+
+    // (a) EMPTY mask → no results, from every filtered path.
+    let empty = IdMask::new();
+    assert!(empty.is_empty());
+    assert!(idx.nearest_filtered(&q, &empty, &store, K).is_empty());
+    assert!(vidx.nearest_filtered(&q, &empty, &store, K).is_empty());
+    assert!(nearest_exact_filtered(&store, &q, &empty, K).is_empty());
+
+    // (b) FULL mask (every id) → equals the UNFILTERED exact search (filter is a no-op).
+    let full: IdMask = ids.iter().copied().collect();
+    assert!(
+        !FilterConfig::default().prefer_prefilter(full.len(), N),
+        "full mask is broad → traversal"
+    );
+    let unfiltered: Vec<u32> = nearest_exact(&store, &q, K)
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect();
+    let truth_full: Vec<u32> = nearest_exact_filtered(&store, &q, &full, K)
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect();
+    assert_eq!(
+        truth_full, unfiltered,
+        "a full mask must not change the exact result"
+    );
+    // Traversal over a full mask: every returned id is valid and it recovers the top hit.
+    let got_full = idx.nearest_filtered(&q, &full, &store, K);
+    assert_eq!(got_full.len(), K);
+    assert!(got_full.iter().all(|(id, _)| full.contains(*id)));
+    assert_eq!(
+        got_full[0].0, unfiltered[0],
+        "full-mask traversal must find the nearest"
+    );
+
+    // (c) SINGLE-element mask → exactly that id (it is in the store), score = cosine to it.
+    let only = ids[123];
+    let single = IdMask::from_ids([only]);
+    assert_eq!(single.len(), 1);
+    let got_single = idx.nearest_filtered(&q, &single, &store, K);
+    assert_eq!(got_single.len(), 1);
+    assert_eq!(got_single[0].0, only);
+    // ...and the score matches a direct cosine.
+    let direct = sparq_vectors::cosine(&q, store.get(only).unwrap());
+    assert!(
+        (got_single[0].1 - direct).abs() < 1e-4,
+        "score {} != cosine {direct}",
+        got_single[0].1
+    );
+
+    // (d) a mask id ABSENT from the store is silently skipped.
+    let absent = IdMask::from_ids([only, 999_999]);
+    let got_absent = nearest_exact_filtered(&store, &q, &absent, K);
+    assert_eq!(got_absent.len(), 1);
+    assert_eq!(got_absent[0].0, only);
+
+    let _ = std::fs::remove_file(&store_path);
+    let _ = std::fs::remove_file(&graph_path);
+}
+
+#[test]
+fn hnsw_filtered_agrees_with_ground_truth() {
+    // The in-RAM HNSW filtered entry point uses the exact pre-filter (instant-distance adjacency is
+    // not exposed), so it must match the ground truth exactly on any mask.
+    const N: usize = 5_000;
+    const DIM: usize = 16;
+    const K: usize = 10;
+
+    let store_path = tmp("filtered-hnsw.spqv");
+    let (store, ids) = build_store(N, DIM, &store_path);
+    let vidx = VectorIndex::build(&store);
+
+    let mask: IdMask = ids.iter().copied().step_by(3).collect();
+    let mut q_state = 0xFEED_u64;
+    for _ in 0..30 {
+        let q = rand_vec(&mut q_state, DIM);
+        let truth = nearest_exact_filtered(&store, &q, &mask, K);
+        let got = vidx.nearest_filtered(&q, &mask, &store, K);
+        assert_eq!(
+            got, truth,
+            "HNSW filtered (pre-filter) must equal the ground truth"
+        );
+    }
+
+    let _ = std::fs::remove_file(&store_path);
+}
+
+#[test]
+fn idmask_and_config_mechanics() {
+    // IdMask construction paths and FilterConfig crossover arithmetic.
+    let mut m = IdMask::new();
+    assert!(m.is_empty());
+    m.insert(5).insert(7).insert(5); // dup collapses
+    assert_eq!(m.len(), 2);
+    assert!(m.contains(5) && m.contains(7) && !m.contains(6));
+
+    let from_iter: IdMask = [1u32, 2, 3, 3].into_iter().collect();
+    assert_eq!(from_iter.len(), 3);
+    let mut got: Vec<u32> = from_iter.iter().collect();
+    got.sort_unstable();
+    assert_eq!(got, vec![1, 2, 3]);
+
+    let cfg = FilterConfig::default();
+    // Over a 1000-vector store: 1% = 10, but the 256 floor dominates → pre-filter up to 256.
+    assert!(cfg.prefer_prefilter(256, 1000));
+    assert!(!cfg.prefer_prefilter(257, 1000));
+    // Over a 1_000_000-vector store: 1% = 10_000 dominates the floor.
+    assert!(cfg.prefer_prefilter(10_000, 1_000_000));
+    assert!(!cfg.prefer_prefilter(10_001, 1_000_000));
+    // fraction 0 + floor 0 → only an empty mask "pre-filters" (degenerate); 1.0 → always.
+    let never = FilterConfig {
+        prefilter_fraction: 0.0,
+        prefilter_floor: 0,
+        traversal_beam_factor: 4,
+    };
+    assert!(!never.prefer_prefilter(1, 100));
+    let always = FilterConfig {
+        prefilter_fraction: 1.0,
+        prefilter_floor: 0,
+        traversal_beam_factor: 4,
+    };
+    assert!(always.prefer_prefilter(100, 100));
+}

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vector-search
-description: "Semantic / ANN vector search over a sparq RDF graph: build a memory-mapped per-term-id embedding store (.spqv), then run cosine top-k with an in-RAM HNSW, a persistent on-disk DiskANN/Vamana graph (.spqg), or an exact brute-force baseline; verbalize entities (label+type+description) for embedding, scalar/product quantize (SQ/PQ) for large stores, fuse with another ranked signal (RRF / score blend) for hybrid retrieval, and — behind the opt-in `vec-predicate` feature — run k-NN INSIDE plain SPARQL via the `vec:nearest` / `vec:search` magic predicates. Use when adding embedding/semantic-search/nearest-neighbour over a sparq Graph in the sparq-vectors crate."
+description: "Semantic / ANN vector search over a sparq RDF graph: build a memory-mapped per-term-id embedding store (.spqv), then run cosine top-k with an in-RAM HNSW, a persistent on-disk DiskANN/Vamana graph (.spqg), or an exact brute-force baseline; verbalize entities (label+type+description) for embedding, scalar/product quantize (SQ/PQ) for large stores, fuse with another ranked signal (RRF / score blend) for hybrid retrieval, run predicate-constrained (filtered) ANN over a BGP-selected dict-id mask behind the opt-in `filtered-ann` feature, and — behind the opt-in `vec-predicate` feature — run k-NN INSIDE plain SPARQL via the `vec:nearest` / `vec:search` magic predicates. Use when adding embedding/semantic-search/nearest-neighbour over a sparq Graph in the sparq-vectors crate."
 ---
 
 # sparq-vector-search
@@ -112,6 +112,17 @@ impl DiskAnnIndex { fn nearest(&self, &[f32], k) -> Vec<(Id, f32)>; fn nearest_t
                     fn fingerprint() -> Option<Fingerprint>; fn check_graph(&store, &Graph) -> Result<(), String>;
                     fn nearest_term_checked(&Term, &Graph, &store, k) -> Result<Vec<(Term, f32)>, String> }
 sibling_graph_path(&Path) -> PathBuf                                            // foo.spqv -> foo.spqg
+
+// --- predicate-constrained (filtered) ANN (src/filter.rs) --- feature = "filtered-ann" ONLY; LEAN, no new dep [OPUS-4.8] sq-1wc1
+IdMask::new() / ::from_ids(impl IntoIterator<Item=Id>) / FromIterator<Id>   // the BGP-selected "visit mask" of permitted dict-ids
+impl IdMask { fn insert(&mut self, Id) -> &mut Self; fn contains(Id)->bool; fn len()/is_empty(); fn iter() -> impl Iterator<Item=Id> }
+nearest_exact_filtered(&VectorStore, query: &[f32], &IdMask, k) -> Vec<(Id, f32)>   // EXACT ground truth = pre-filter strategy (scan only the mask)
+FilterConfig { prefilter_fraction: f32 /*0.01*/, prefilter_floor: usize /*256*/, traversal_beam_factor: usize /*4*/ }
+impl FilterConfig { fn prefer_prefilter(mask_len, store_len) -> bool }       // selectivity crossover: <= max(frac*store, floor) -> pre-filter
+impl DiskAnnIndex { fn nearest_filtered(&self, &[f32], &IdMask, &VectorStore, k) -> Vec<(Id, f32)>     // ACORN/NaviX filtered traversal OR pre-filter, by selectivity
+                    fn nearest_filtered_with(&self, &[f32], &IdMask, &VectorStore, k, FilterConfig) -> Vec<(Id, f32)> }
+impl VectorIndex  { fn nearest_filtered(&self, &[f32], &IdMask, &VectorStore, k) -> Vec<(Id, f32)> }   // HNSW: exact pre-filter only (instant-distance adjacency not exposed)
+// empty mask -> no results; full mask -> equals the unfiltered search; every returned id is guaranteed in the mask
 
 // --- quantization for large stores (src/quant.rs) ---
 ScalarQuantizer::fit(dim, vectors: impl IntoIterator<Item=&[f32]>) -> Result<ScalarQuantizer, String>   // f32->u8, 4x
@@ -353,6 +364,49 @@ literal's dimension must match the store; any other `vec:` IRI is unknown. An ab
 seed IRI yields no rows. Search is the **exact** `nearest_exact` scan (deterministic, the HNSW/
 DiskANN approximate indexes are not yet wired into the predicate — recorded follow-up).
 
+### 9. Predicate-constrained (filtered) ANN — only neighbours a BGP admits (opt-in, feature = `filtered-ann`)
+
+The RDF-native vector differentiator: a SPARQL BGP carves out the *eligible* graph nodes (e.g.
+`?node a :Car ; :seats ?s`), and the nearest-neighbour search returns only neighbours **inside that
+candidate set**. You compute the exact id-set from the BGP (via `graph.id_of` / the permutation
+indexes / a `query`'s solution `?node` column) and hand it to the search as an `IdMask` — the
+"visit mask". OPT-IN and OFF by default; the feature is **lean** — it adds *no new dependency* (the
+mask reuses the in-tree `rustc-hash` set) and pulls in neither the engine nor any heavy crate.
+
+```toml
+sparq-vectors = { path = "../sparq-vectors", features = ["filtered-ann"] }
+```
+
+```rust
+use sparq_vectors::{nearest_exact_filtered, DiskAnnIndex, IdMask, VectorIndex, VectorStore};
+
+let store = VectorStore::open("entities.spqv")?;
+
+// 1. Build the mask from whatever the BGP selected — here, ids of nodes typed :Car.
+let car_ids = /* graph.query("SELECT ?node { ?node a :Car }") -> ?node column -> graph.id_of */;
+let mask: IdMask = car_ids.into_iter().collect();          // empty mask => no results
+
+// 2a. Exact filtered (ground truth; the pre-filter strategy) — scans only the masked ids:
+let hits = nearest_exact_filtered(&store, query, &mask, 10); // every id is guaranteed in the mask
+
+// 2b. On-disk DiskANN filtered: picks the strategy by SELECTIVITY (FilterConfig::default):
+//   selective mask (<= 1% of store, or <= 256) -> exact pre-filter scan;
+//   broad mask -> ACORN/NaviX filtered traversal (walk the graph through ALL nodes for
+//   connectivity, ACCEPT only masked ones; the beam is widened so k accepted hits are collected).
+let idx = DiskAnnIndex::open("entities.spqg")?;
+let approx = idx.nearest_filtered(query, &mask, &store, 10); // recall@10 vs exact-filtered ~0.998 on a ~50% mask
+
+// 2c. In-RAM HNSW filtered: instant-distance adjacency is NOT exposed, so this is the exact
+//     pre-filter (the right path for a selective mask; use DiskAnnIndex for a broad mask):
+let vidx = VectorIndex::build(&store);
+let hnsw = vidx.nearest_filtered(query, &mask, &store, 10);
+```
+
+Tune the crossover / beam with `nearest_filtered_with(query, &mask, &store, k, FilterConfig { .. })`.
+The engine-side automatic BGP → mask wiring (a filtered form of the `vec:` predicate) is a recorded
+follow-up bead — for now you build the mask yourself, which keeps the filtered API a pure
+sparq-vectors surface with zero engine coupling.
+
 ## Gotchas / feature flags / prerequisites
 
 - **Opt-in.** Nothing in the workspace depends on `sparq-vectors`; the default engine
@@ -361,7 +415,8 @@ DiskANN approximate indexes are not yet wired into the predicate — recorded fo
   SPARQL-level integration is the optional `vec:` magic predicate (recipe 8 below), behind
   the **non-default `vec-predicate`** feature; with it OFF this crate has zero `sparq-engine`
   dependency and the base engine/core query path is byte-identical (see recipe 8). There is
-  still no `SERVICE`/function binding.
+  still no `SERVICE`/function binding. Predicate-constrained (filtered) ANN (recipe 9) is a
+  separate **non-default `filtered-ann`** feature — also lean (no new dep, no engine pull).
 - **`HashEmbedder` is TEST-ONLY.** It is lexical n-gram hashing with **no semantics**
   ("car" and "automobile" are unrelated). Use it to exercise the store/ANN/pipeline; bring
   a real `Embedder` for actual retrieval.
@@ -397,6 +452,16 @@ DiskANN approximate indexes are not yet wired into the predicate — recorded fo
   (`quant.rs`) exists and is tested but is **not yet wired into** `search_slots` (recorded
   follow-up in the crate's open beads, `bd list -l area:sparq-vectors`); run the PQ-filter + re-rank loop yourself
   (recipe 4).
+- **Filtered ANN (`filtered-ann` feature):** predicate-constrained search returns only ids in the
+  `IdMask`, and **every returned id is guaranteed in the mask**. An **empty** mask -> no results
+  (distinct from passing no mask = an unfiltered search); a **full** mask -> identical to the
+  unfiltered search. `DiskAnnIndex::nearest_filtered` is **exact** when it pre-filters (selective
+  mask) and **approximate** when it traverses (broad mask) — but pre-filter is exact, so erring
+  toward it (the conservative default crossover) only costs mild throughput, never recall. The
+  in-RAM `VectorIndex::nearest_filtered` is **always** the exact pre-filter (instant-distance
+  adjacency is not exposed, so the HNSW graph cannot be walked with predicate-aware acceptance);
+  use `DiskAnnIndex` for filtered traversal over a broad mask. Lean feature: no new dependency, no
+  engine pull. NON-CANONICAL timing.
 - **Little-endian only.** `.spqv`/`.spqg` reject big-endian targets at create/open.
 - **Determinism:** ties break on ascending id (searchers) or first appearance (fusion);
   HNSW/Vamana/PQ seeds are fixed by default so builds are reproducible.


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-1wc1**: predicate-constrained (filtered) ANN over the dict-id vector store — the RDF-native vector differentiator. A SPARQL BGP constrains *which* graph nodes are eligible (`?node a :Car ; :seats ?s` → a candidate id-set) and the ANN search returns only neighbours **inside that set**.

## Opt-in gating (lean core)
New **non-default `filtered-ann`** feature on `crates/sparq-vectors`. It is **lean**: adds **no new dependency** (the mask reuses the in-tree `rustc-hash` set), pulls in **neither `sparq-engine` nor any heavy crate**. With the feature **off** the default `sparq-vectors` build and the core query path carry **zero** filtered-ANN code and are byte-identical. The feature gates `src/filter.rs` and the `DiskAnnIndex::nearest_filtered*` traversal path; `lib.rs` re-exports are `#[cfg(feature = "filtered-ann")]`.

## Filter strategy — filtered-traversal vs pre-filter, by selectivity
The mask is an `IdMask` (an `FxHashSet<Id>` of permitted dict-ids; build it from the BGP solution: `bgp_ids.collect()`). The caller computes the exact set from the BGP; this PR is the sparq-vectors API that **accepts and honours** the mask. Strategy is chosen by the mask's **selectivity** (`FilterConfig`):

- **Pre-filter** (`nearest_exact_filtered`, the exact ground truth): scan only the masked ids — **exact** and cheapest for a *selective* mask. A graph traversal to accept a handful of nodes is wasteful and can even miss an isolated accepted node behind unaccepted hops.
- **Filtered traversal** (`DiskAnnIndex::nearest_filtered`, ACORN / NaviX-style): walk the on-disk Vamana graph **predicate-agnostically** (expand through *every* neighbour for connectivity) but **only accept** masked nodes (*predicate-aware acceptance*); the beam is widened ×4 so `k` accepted hits are still collected. Right for a *broad* mask.

**Threshold (documented, honest):** default pre-filters when the mask admits ≤ **1% of the store or ≤ 256 ids** (whichever is larger), else traverses. Pre-filter is exact, so erring toward it never costs recall — only mild throughput on a mid-selective mask. Movable via `FilterConfig` / `nearest_filtered_with`.

`VectorIndex` (in-RAM HNSW) gets `nearest_filtered` too, but as the **exact pre-filter only** — `instant-distance`'s adjacency is not exposed, so its graph can't be walked with predicate-aware acceptance (documented; use `DiskAnnIndex` for broad-mask traversal).

## Recall (NON-CANONICAL timing)
`tests/filtered.rs` (feature-gated): filtered-traversal recall@10 vs the exact-filtered ground truth is **~0.998** on a ~50% mask over 20k×32 (gate ≥ 0.90); pre-filter is **exact** on a selective mask; edge cases covered — empty mask → no results, full mask → equals the unfiltered search, single-element mask → that id, absent id silently skipped; every returned id is **guaranteed in the mask**.

## Verify
`cargo build` / `cargo clippy --all-targets -- -D warnings` clean with the feature **off AND on**; `cargo test -p sparq-vectors --features filtered-ann` green (42 lib + 7 doc + all integration incl. the 5 new filtered tests); feature-off lib tests unchanged (42). New code `rustfmt`-clean. `skills/vector-search/SKILL.md` updated (description, Key APIs, recipe 9, gotchas).

## Deferred
Engine-side automatic **BGP → mask wiring** (a filtered form of the `vec:` magic predicate) is a deferred follow-up — left as a bead for the orchestrator (the `bd` CLI is not available in the isolated worktree). This PR is the core sparq-vectors filtered API; the engine wiring is large enough to land separately.
