### PR TITLE
chore(typos): ignore sq-<id> bead tokens in docs spell-check gate

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -26,6 +26,12 @@ extend-exclude = [
 [default]
 # Keep typos' default checks; we only extend the dictionaries below.
 
+# Ignore sparq bead IDs (`sq-<base36 suffix>`). typos splits these on the hyphen and
+# flags the suffix (e.g. `sq-iy3p` → `iy3p`/`iy`, `sq-1gir` → `gir`). Beads are
+# referenced by the dozen in compliance/research docs, so per-token allowlisting does
+# not scale — match the whole bead-id token shape instead. [OPUS-4.8]
+extend-ignore-re = ["\\bsq-[0-9a-z]{3,}\\b"]
+
 [default.extend-identifiers]
 # Author surnames + tool/library identifiers flagged as typos.
 Hendler = "Hendler"      # Jim Hendler (BitMat paper author)


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

Adds an `extend-ignore-re` entry to `_typos.toml` so the `typos (docs)` gate skips sparq **bead IDs** of the shape `sq-<base36>`.

```toml
extend-ignore-re = ["\\bsq-[0-9a-z]{3,}\\b"]
```

## Why

`typos` splits a hyphenated bead ID on the hyphen and flags the base36 suffix as a misspelling:

- `sq-iy3p` → `iy3p` / `iy`
- `sq-1gir` → `gir`
- `sq-cz89` → `cz89`

Compliance and research docs reference beads **by the dozen** (the upcoming cert-consolidation doc references dozens), so per-token allowlisting in `_typos.toml` does not scale. Matching the whole `sq-<id>` token shape with a single regex covers every existing and future bead reference while the gate keeps catching genuine prose typos.

This **unblocks the cert-consolidation doc**, whose many bead references would otherwise fail the gate.

## Verification

- `echo 'see sq-iy3p sq-1gir sq-cz89 sq-qhy4' | typos -` (with this config) exits `0`.
- Re-ran the workflow's doc-surface file list (`git ls-files '*.md'` minus research/zk/bench/js/.beads/.claude/.github/vendor) through `typos --file-list` → exits `0`.
- `typos` 1.47.2 (matches the workflow pin `typos@1.47.2`).

Only `_typos.toml` is changed.