### PR TITLE
feat(sparq-core): complete RDF 1.2 triple-term support — parallel triple-term merge + position-aware parser errors (sq-87bq)

### DIFF
--- a/crates/sparq-core/src/dict.rs
+++ b/crates/sparq-core/src/dict.rs
@@ -1807,20 +1807,17 @@ impl Dict {
     }
 
     /// [OPUS-4.8] (sq-hxgb) Whether this dict stores any RDF 1.2 triple term
-    /// (`Stored::Triple`). The parallel N-Triples loader checks each parsed PARTIAL with
-    /// this to pick the merge path: the SHARDED merge cannot consolidate triple terms
-    /// (a triple's components are both hash-routed to a shard AND referenced by the
-    /// triple, breaking the term↔id bijection on merge — see `intern_partials`), so a
-    /// document that contains any triple term falls back to the serial `merge_remap`,
-    /// which interns triple terms structurally and correctly. Arena-mode (partial) dicts
-    /// only — that is all the loader ever inspects here.
+    /// (`Stored::Triple`), used to GUARD a path that cannot represent them.
     //
-    // [OPUS-4.8] (sq-qmth) Gated on `parallel`: the only callers are the parallel
-    // N-Triples loader (`parse_ntriples_parallel`) and the external-build triple-term
-    // guard, both `#[cfg(feature = "parallel")]`. Without this gate the method is dead
-    // code on the wasm build (no `parallel` feature), which the wasm32 `clippy -D warnings`
-    // job promotes to a hard error (`-D dead-code`).
-    #[cfg(feature = "parallel")]
+    // [OPUS-4.8] (sq-87bq) Since the sharded in-RAM/external merge gained structural
+    // triple-term support (sq-t3rt) and the in-memory `merge_partials` serial-fallback guard
+    // was removed, the SOLE remaining caller is the DICT-SPILL external builder's rejection
+    // (`reject_triple_terms_in_external_build`, `#[cfg(feature = "dict-spill")]`), whose
+    // content-only on-disk term records still cannot encode a triple term (tracked as sq-jvbr).
+    // Gated to `dict-spill` so the method is not dead code on the default / wasm builds, which
+    // `clippy -D warnings` (`-D dead-code`) would otherwise reject. (`any_triple_terms`, the
+    // implementation, stays ungated — `intern_partials` uses it on every build.)
+    #[cfg(feature = "dict-spill")]
     pub(crate) fn has_triple_terms(&self) -> bool {
         self.any_triple_terms()
     }

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -3624,25 +3624,21 @@ fn parse_ntriples_parallel(bytes: &[u8]) -> Result<(Dict, Vec<[Id; 3]>), String>
 /// global `Dict` + remapped triples — the merge stage shared by the in-memory N-Triples loader
 /// ([`parse_ntriples_parallel`]) and the per-graph N-Quads loader ([`Graph::load_nquads_parallel`],
 /// which calls this once per graph). Sharded on ≥2 threads (the parallel dict consolidation that
-/// breaks the measured serial-`merge_remap` ceiling); serial `merge_remap` on one thread or when
-/// any partial carries an RDF 1.2 triple term (the sharded interner cannot represent those — see
-/// `ShardedDict::intern_partials`).
+/// breaks the measured serial-`merge_remap` ceiling); serial `merge_remap` on one thread.
 #[cfg(feature = "parallel")]
 fn merge_partials(partials: ChunkPartials) -> (Dict, Vec<[Id; 3]>) {
     let total: usize = partials.iter().map(|(_, t)| t.len()).sum();
-    // [OPUS-4.8] (sq-hxgb) The SHARDED merge cannot consolidate RDF 1.2 triple terms
-    // (a triple term's components are hash-routed to a shard AND referenced structurally
-    // by the triple, breaking the term↔id bijection across shards — see
-    // `ShardedDict::intern_partials`). The byte parser now accepts `<<( … )>>` object
-    // terms, so a document MAY contain them; when any partial does, take the serial
-    // `merge_remap` path, which interns triple terms structurally and correctly. Triple
-    // terms are rare (reification metadata), and detection is a single arena scan per
-    // partial (`Dict::has_triple_terms`) — no cost on the common triple-term-free input.
-    let has_triple_terms = partials.iter().any(|(d, _)| d.has_triple_terms());
-    // One rayon thread (or any triple-term partial): the sharded merge would only add
-    // routing/consolidation overhead (or cannot run at all) — keep the proven serial
-    // merge (also the byte-reference the differential tests pin).
-    if rayon::current_num_threads() <= 1 || has_triple_terms {
+    // [OPUS-4.8] (sq-87bq) RDF 1.2 triple terms are now consolidated by the SHARDED merge
+    // too: `ShardedDict::intern_partials` interns them structurally into a dedicated triple
+    // shard (a serial second pass keyed on their components' already-routed temp ids — see
+    // `intern_triple_terms`), preserving the cross-shard term↔id bijection. This is the SAME
+    // machinery the sharded external builder (sq-t3rt, #91) and the pipelined in-RAM loader
+    // (`load_ntriples_pipelined`) already use successfully with triple terms; the earlier
+    // `has_triple_terms ⇒ serial` guard here (added by sq-hxgb before that path was wired in)
+    // is therefore stale and removed, so RDF-star bulk loads keep full parse parallelism.
+    // One rayon thread: the sharded merge would only add routing/consolidation overhead —
+    // keep the proven serial merge (also the byte-reference the differential tests pin).
+    if rayon::current_num_threads() <= 1 {
         let cap = partials.iter().map(|(d, _)| d.len()).max().unwrap_or(0);
         let mut global = Dict::with_capacity(cap);
         let mut all = Vec::with_capacity(total);
@@ -3658,10 +3654,12 @@ fn merge_partials(partials: ChunkPartials) -> (Dict, Vec<[Id; 3]>) {
     // ceiling — load plateaued at ~1.8× on 4 identical cores — was exactly this stage).
     let mut sd = dict::ShardedDict::new(default_shards());
     let mut all: Vec<[Id; 3]> = Vec::with_capacity(total);
-    // [OPUS-4.8] `sharded_extend` can only `Err` on a malformed triple term, but the guard
-    // above (`has_triple_terms` ⇒ serial path) means this branch is triple-term-free — so an
-    // error here is an internal invariant breach, not recoverable input. Surface it loudly.
-    sharded_extend(&mut sd, &partials, &mut all).expect("sharded merge: triple-term-free path must not error");
+    // [OPUS-4.8] (sq-87bq) `sharded_extend` (well-formed input, incl. RDF 1.2 triple terms)
+    // only `Err`s on a MALFORMED triple term — a component id out of the partial's range or
+    // referencing an unpopulated slot. `parse_block` produces well-formed partials (children
+    // precede their parent triple in arena order), so an error here is an internal invariant
+    // breach, not recoverable input. Surface it loudly.
+    sharded_extend(&mut sd, &partials, &mut all).expect("sharded merge: well-formed partials must not error");
     finish_sharded(sd, all)
 }
 
@@ -4742,6 +4740,84 @@ mod tests {
         let (p, s) = differential(&boundary, 32, true);
         assert_eq!(p, s);
         assert_eq!(p, 801, "400 pre + 1 quoted + 400 post");
+    }
+
+    /// [OPUS-4.8] (sq-87bq) END-TO-END semantics of the RDF 1.2 Turtle reification surface
+    /// (the SPARQL-1.2 annotation sugar) through `Graph::load_str`: the reifying-triple
+    /// `<< s p o >>` (subject AND object position) and the annotation block `{| … |}` must
+    /// load to the standard desugaring — an `rdf:reifies <<( s p o )>>` reifier statement plus
+    /// any asserted base / annotation triples — with the triple TERM `<<( s p o )>>` a
+    /// first-class `Term::Triple` object. Pins the supported surface (oxttl-desugared), not
+    /// just chunked==serial parse equality.
+    #[test]
+    fn turtle_rdf12_reification_surface_loads_desugared() {
+        const REIFIES: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies";
+        // The triple TERM both forms desugar their reifier onto.
+        let tt = Term::Triple(Box::new(oxrdf::Triple::new(
+            oxrdf::NamedNode::new("http://ex/s").unwrap(),
+            oxrdf::NamedNode::new("http://ex/p").unwrap(),
+            Term::NamedNode(oxrdf::NamedNode::new("http://ex/o").unwrap()),
+        )));
+        let dump = |g: &Graph| {
+            let scan = g.store.scan(&[None, None, None]);
+            let mut v: Vec<(String, String, String)> = scan
+                .rows
+                .iter()
+                .map(|r| {
+                    let spo = scan.to_spo(r);
+                    (g.dict.term(spo[0]).to_string(), g.dict.term(spo[1]).to_string(), g.dict.term(spo[2]).to_string())
+                })
+                .collect();
+            v.sort();
+            v
+        };
+
+        // (1) NAMED reifier `<< s p o ~ ex:r >>`: deterministic reifier id, no anon bnode.
+        let g = Graph::load_str(
+            "@prefix ex: <http://ex/> . << ex:s ex:p ex:o ~ ex:r >> ex:certainty 0.9 .",
+            "turtle",
+        )
+        .unwrap();
+        // The reifier `ex:r` carries `rdf:reifies <<( ex:s ex:p ex:o )>>` and the annotation.
+        let r = g.dict.lookup(&Term::NamedNode(oxrdf::NamedNode::new("http://ex/r").unwrap()));
+        let reifies = g.dict.lookup(&Term::NamedNode(oxrdf::NamedNode::new(REIFIES).unwrap()));
+        let tt_id = g.dict.lookup(&tt);
+        assert!(tt_id != 0, "the triple term `<<( ex:s ex:p ex:o )>>` must be a first-class dict term");
+        let reifies_rows = g.store.scan(&[Some(r), Some(reifies), Some(tt_id)]).rows.len();
+        assert_eq!(reifies_rows, 1, "named reifier must carry exactly one `rdf:reifies <<( … )>>`");
+        // The annotation triple `ex:r ex:certainty 0.9` is present.
+        let cert = g.dict.lookup(&Term::NamedNode(oxrdf::NamedNode::new("http://ex/certainty").unwrap()));
+        assert_eq!(g.store.scan(&[Some(r), Some(cert), None]).rows.len(), 1, "annotation triple must load");
+
+        // (2) Annotation block `{| … |}` desugars to: the ASSERTED base triple + a reifier
+        //     (anon) `rdf:reifies <<( … )>>` + the annotation triple. The base triple is
+        //     asserted (unlike the bare `<< … >>` reifier, which does NOT assert it).
+        let g2 =
+            Graph::load_str("@prefix ex: <http://ex/> . ex:s ex:p ex:o {| ex:certainty 0.9 |} .", "turtle").unwrap();
+        let rows2 = dump(&g2);
+        assert!(
+            rows2.iter().any(|(s, p, o)| s == "<http://ex/s>" && p == "<http://ex/p>" && o == "<http://ex/o>"),
+            "annotation block must ASSERT the base triple, got {rows2:?}"
+        );
+        assert!(
+            rows2.iter().any(|(_, p, _)| p == &format!("<{REIFIES}>")),
+            "annotation block must emit an `rdf:reifies` reifier, got {rows2:?}"
+        );
+        assert!(g2.dict.lookup(&tt) != 0, "the annotated base triple must appear as a triple TERM object");
+
+        // (3) reifiedTriple in SUBJECT position `<< s p o >> p2 o2` (a Turtle construct the
+        //     legacy custom NT parser cannot express, here handled by the Turtle loader): the
+        //     reifier is the SUBJECT of the annotation, the base triple is NOT asserted.
+        let g3 = Graph::load_str("@prefix ex: <http://ex/> . << ex:s ex:p ex:o >> ex:src ex:doc1 .", "turtle").unwrap();
+        let rows3 = dump(&g3);
+        assert!(
+            !rows3.iter().any(|(s, p, o)| s == "<http://ex/s>" && p == "<http://ex/p>" && o == "<http://ex/o>"),
+            "a bare `<< … >>` reifier must NOT assert the base triple, got {rows3:?}"
+        );
+        assert!(
+            rows3.iter().any(|(_, p, o)| p == &format!("<{REIFIES}>") && o.starts_with("<<(")),
+            "subject-position reifier must carry `rdf:reifies <<( … )>>`, got {rows3:?}"
+        );
     }
 
     /// Decodes a parsed triple sequence to strings with blank nodes renumbered by FIRST
@@ -6573,6 +6649,86 @@ mod tests {
             v
         };
         assert_eq!(dump(&par), dump(&seq));
+    }
+
+    /// [OPUS-4.8] (sq-87bq) The NON-streaming in-memory merge (`merge_partials`, behind
+    /// `parse_ntriples_parallel` / the per-graph N-Quads merge) must consolidate RDF 1.2
+    /// triple terms through the SHARDED path — its earlier `has_triple_terms ⇒ serial`
+    /// guard was stale (the sharded interner gained structural triple-term support in
+    /// sq-t3rt). This test FORCES the sharded branch (≥2 threads in a scoped rayon pool) on
+    /// triple-term partials and pins the result to the serial `merge_remap` reference, so the
+    /// fix is covered deterministically regardless of the ambient thread count.
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn merge_partials_sharded_consolidates_triple_terms() {
+        // Several blocks' worth of triples with interleaved reification metadata, components
+        // in distinct namespaces (different leaf shards), a shared triple term (cross-shard
+        // dedup), a blank-node component, and a nested triple term.
+        let mut nt = String::new();
+        for i in 0..4000u32 {
+            nt.push_str(&format!(
+                "<http://ex/n{}> <http://ex/p{}> \"{}\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
+                i % 211,
+                i % 13,
+                i % 700
+            ));
+            if i % 700 == 0 {
+                // Same triple term referenced by two statements -> must dedup to one id.
+                nt.push_str("<http://ex/r1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( <http://alpha.example/alice> <http://beta.example/age> \"30\"^^<http://www.w3.org/2001/XMLSchema#integer> )>> .\n");
+                nt.push_str("<http://ex/r1b> <http://ex/sameAs> <<( <http://alpha.example/alice> <http://beta.example/age> \"30\"^^<http://www.w3.org/2001/XMLSchema#integer> )>> .\n");
+            }
+        }
+        nt.push_str("<http://ex/r2> <http://ex/about> <<( _:b0 <http://ex/p> \"v\" )>> .\n");
+        nt.push_str("<http://ex/r3> <http://ex/nested> <<( <http://gamma.example/x> <http://delta.example/q> <<( <http://eps.example/a> <http://zeta.example/b> <http://eta.example/c> )>> )>> .\n");
+        let bytes = nt.as_bytes();
+
+        // Round-trip a (dict, triples) pair to its sorted term-set (recursively expanding
+        // triple terms via `Dict::term`), so the comparison is id-assignment-order
+        // independent.
+        let dump = |dict: &Dict, triples: &[[Id; 3]]| {
+            let mut v: Vec<(String, String, String)> = triples
+                .iter()
+                .map(|&[s, p, o]| (dict.term(s).to_string(), dict.term(p).to_string(), dict.term(o).to_string()))
+                .collect();
+            v.sort();
+            v
+        };
+
+        // Reference: serial `merge_remap` consolidation (single thread -> serial branch).
+        let serial = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap()
+            .install(|| merge_partials(parse_block(bytes).unwrap()));
+        // Under test: the SHARDED branch (>=2 threads).
+        let sharded = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .unwrap()
+            .install(|| merge_partials(parse_block(bytes).unwrap()));
+
+        assert_eq!(sharded.1.len(), serial.1.len(), "sharded triple count differs from serial");
+        assert_eq!(sharded.0.len(), serial.0.len(), "sharded dict size differs from serial");
+        assert_eq!(
+            dump(&sharded.0, &sharded.1),
+            dump(&serial.0, &serial.1),
+            "sharded merge_partials differs from serial reference on triple-term input"
+        );
+
+        // Cross-shard dedup is OBSERVABLE: the triple term shared by <r1>/<r1b> is ONE dict
+        // entry, so both statements' objects carry the same id.
+        let tt = Term::Triple(Box::new(oxrdf::Triple::new(
+            oxrdf::NamedNode::new("http://alpha.example/alice").unwrap(),
+            oxrdf::NamedNode::new("http://beta.example/age").unwrap(),
+            Term::Literal(Literal::new_typed_literal("30", xsd::INTEGER)),
+        )));
+        let tt_id = sharded.0.lookup(&tt);
+        assert!(tt_id != 0, "the shared triple term must be in the sharded dict");
+        let r1 = sharded.0.lookup(&Term::NamedNode(oxrdf::NamedNode::new("http://ex/r1").unwrap()));
+        let r1b = sharded.0.lookup(&Term::NamedNode(oxrdf::NamedNode::new("http://ex/r1b").unwrap()));
+        let obj_of = |subj: Id| sharded.1.iter().find(|t| t[0] == subj).map(|t| t[2]);
+        assert_eq!(obj_of(r1), Some(tt_id), "<r1>'s object is the shared triple term");
+        assert_eq!(obj_of(r1b), Some(tt_id), "<r1b>'s object is the SAME shared triple-term id");
     }
 
     /// The streaming pipelined loader must be byte-exact against the serial loader for

--- a/crates/sparq-core/src/nt.rs
+++ b/crates/sparq-core/src/nt.rs
@@ -162,6 +162,13 @@ fn graph_key(b: &[u8], i: usize) -> Result<GraphKey, String> {
 #[cfg(feature = "parallel")]
 fn span_term(b: &[u8], i: usize) -> Result<usize, String> {
     match b.get(i) {
+        // [OPUS-4.8] (sq-87bq) Triple terms are OBJECT-ONLY (RDF 1.2); a `<<(` reaching the
+        // subject/predicate (or graph) span walk is a non-object triple term — reject with a
+        // precise message, mirroring `term`. See the grammar note there (prods. [7]/[8]/[9]).
+        Some(b'<') if b.get(i + 1) == Some(&b'<') && b.get(i + 2) == Some(&b'(') => Err(format!(
+            "N-Quads: RDF 1.2 triple term `<<( … )>>` is only valid in OBJECT position \
+             (subject/predicate/graph must be an IRI or blank node), at byte {i}"
+        )),
         Some(b'<') => {
             let (_s, _e, _esc, next) = scan_delim(b, i, b'>')?;
             Ok(next)
@@ -287,6 +294,18 @@ fn str_of(raw: &[u8]) -> Result<&str, String> {
 
 fn term(b: &[u8], i: usize, dict: &mut Dict) -> Result<(Id, usize), String> {
     match b.get(i) {
+        // [OPUS-4.8] (sq-87bq) A `<<(` here is an RDF 1.2 triple term in a NON-object
+        // position (subject, predicate, or a triple term's own subject/predicate). The RDF
+        // 1.2 N-Triples grammar makes triple terms OBJECT-ONLY — `subject ::= IRIREF |
+        // BLANK_NODE_LABEL` (prod. [7]) and `predicate ::= IRIREF` (prod. [8]); only
+        // `object ::= IRIREF | BLANK_NODE_LABEL | literal | tripleTerm` (prod. [9]) admits a
+        // `tripleTerm` (prod. [11]). (This differs from the legacy RDF-star CG `<< s p o >>`
+        // QUOTED-triple syntax, which DID allow subject quoting; RDF 1.2 deliberately dropped
+        // that.) Reject with a precise message instead of the generic "unexpected term start".
+        Some(b'<') if b.get(i + 1) == Some(&b'<') && b.get(i + 2) == Some(&b'(') => Err(format!(
+            "N-Triples: RDF 1.2 triple term `<<( … )>>` is only valid in OBJECT position \
+             (subject/predicate must be an IRI or blank node), at byte {i}"
+        )),
         Some(b'<') => iri(b, i, dict),
         Some(b'_') => blank(b, i, dict),
         Some(b'"') => literal(b, i, dict),
@@ -532,10 +551,39 @@ mod tests {
 
     #[test]
     fn triple_term_only_in_object_position() {
-        // A `<<(` in SUBJECT position is not a valid term start for `term` (subjects are
-        // never triple terms in RDF 1.2) — the parser must reject it rather than misparse.
-        let nt = b"<<( <http://ex/a> <http://ex/b> <http://ex/c> )>> <http://ex/p> <http://ex/o> .\n";
+        // [OPUS-4.8] (sq-87bq) RDF 1.2 makes triple terms OBJECT-ONLY (N-Triples grammar:
+        // `subject ::= IRIREF | BLANK_NODE_LABEL` [7], `predicate ::= IRIREF` [8], only
+        // `object` [9] admits a `tripleTerm` [11]). The parser must REJECT a `<<( … )>>` in
+        // subject OR predicate position with a precise, position-aware message — not misparse
+        // it, and not silently accept the legacy RDF-star CG `<< … >>` subject-quoting that
+        // RDF 1.2 dropped.
+
+        // Subject position.
+        let subj = b"<<( <http://ex/a> <http://ex/b> <http://ex/c> )>> <http://ex/p> <http://ex/o> .\n";
         let mut d = Dict::new();
-        assert!(parse_chunk(nt, &mut d).is_err(), "triple term in subject position must be rejected");
+        let e = parse_chunk(subj, &mut d).expect_err("triple term in subject position must be rejected");
+        assert!(e.contains("only valid in OBJECT position"), "message must explain the object-only rule, got: {e}");
+
+        // Predicate position.
+        let pred = b"<http://ex/s> <<( <http://ex/a> <http://ex/b> <http://ex/c> )>> <http://ex/o> .\n";
+        let mut d = Dict::new();
+        let e = parse_chunk(pred, &mut d).expect_err("triple term in predicate position must be rejected");
+        assert!(e.contains("only valid in OBJECT position"), "message must explain the object-only rule, got: {e}");
+
+        // A triple term's OWN subject must also be a plain term (recursion goes through
+        // `term`, not `object_term`): a nested `<<( … )>>` in the inner subject is rejected.
+        let inner_subj = b"<http://ex/s> <http://ex/p> <<( <<( <http://ex/a> <http://ex/b> <http://ex/c> )>> <http://ex/q> <http://ex/r> )>> .\n";
+        let mut d = Dict::new();
+        assert!(
+            parse_chunk(inner_subj, &mut d).is_err(),
+            "a triple term in a triple term's SUBJECT slot must be rejected (object-only nesting)"
+        );
+
+        // Sanity: the same triple term in OBJECT position parses fine (the rejection is
+        // strictly position-driven, not a blanket ban).
+        let obj = b"<http://ex/s> <http://ex/p> <<( <http://ex/a> <http://ex/b> <http://ex/c> )>> .\n";
+        let mut d = Dict::new();
+        assert!(parse_chunk(obj, &mut d).is_ok(), "the same triple term in object position must parse");
     }
 }
+

--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -217,6 +217,22 @@ cargo build -p sparq-cli --features serialize-rdf
   pipelined parser is **N-Triples only** (other formats silently fall back to serial
   `load_reader`). With `parallel` off (e.g. the wasm build, `--no-default-features`),
   everything parses serially.
+- **RDF 1.2 triple terms / RDF-star are first-class.** A triple term `<<( s p o )>>` is a
+  real `oxrdf::Term::Triple` (object position only — RDF 1.2 makes triple terms object-only;
+  a `<<( … )>>` in subject/predicate position is rejected with a precise error). Triple terms
+  may nest, take blank-node/literal components, and are content-addressed (an identical triple
+  term shares one dict id). They load through **every** path — serial, parallel-chunked,
+  streaming-pipelined, and the sharded external builder — at full parallelism (the in-memory
+  parallel merge no longer drops to a serial fallback when they are present). The **dict-spill**
+  external builder is the one exception: it rejects triple terms with a clear error (its
+  content-only on-disk records can't encode them — bead sq-jvbr); use the default sharded path
+  or an in-memory load for RDF-star + dict-spill datasets. In **Turtle/TriG**, the SPARQL-1.2
+  reification sugar is supported via the Turtle parser: the reifying triple `<< s p o >>`
+  (subject or object position, optionally `<< s p o ~ reifier >>`) and the annotation block
+  `s p o {| … |}` desugar to the standard `rdf:reifies <<( s p o )>>` form (the annotation block
+  also **asserts** the base triple; a bare `<< … >>` reifier does not). N-Triples/N-Quads carry
+  only the desugared `<<( … )>>` triple-term form (no `<<>>`/`{| |}` sugar — per the line-format
+  grammar).
 - **`build_external` / `open` / `save` require the `mmap` feature** (native only). The
   N-Triples external path also honors `SPARQ_SHARDED_DICT` (default on with ≥2 threads)
   and, with the `dict-spill` feature + `SPARQ_DICT_SPILL` env, bounds peak build RSS by

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -138,13 +138,20 @@ sparq_engine::query(&g,
 
 **RDF-star / RDF 1.2 quoted triples** (`<< s p o >>`) — stored structurally; patterns with variables
 inside the quoted triple match. Load with the `rdf-12` feature enabled on oxrdf/oxttl (default in
-this workspace):
+this workspace). In Turtle/TriG you can write the reifying triple `<< s p o >>` (subject or object
+position, optionally `<< s p o ~ reifier >>`) or the annotation block `s p o {| … |}` (which also
+**asserts** the base triple); both desugar to the standard `rdf:reifies <<( s p o )>>` form. The
+underlying triple TERM `<<( s p o )>>` is **object-position only** (RDF 1.2). See the SPARQL-star
+functions `TRIPLE`/`isTRIPLE`/`SUBJECT`/`PREDICATE`/`OBJECT` for constructing/decomposing them.
 
 ```rust
 let g = Graph::load_str(
     r#"@prefix ex: <http://ex/> . << ex:alice ex:age 30 >> ex:certainty 0.9 ."#, "turtle").unwrap();
 sparq_engine::query(&g,
     "PREFIX ex: <http://ex/> SELECT ?s ?o ?c WHERE { << ?s ex:age ?o >> ex:certainty ?c }").unwrap();
+// Annotation-block form (asserts ex:alice ex:age 30 AND records the certainty reifier):
+let g2 = Graph::load_str(
+    r#"@prefix ex: <http://ex/> . ex:alice ex:age 30 {| ex:certainty 0.9 |} ."#, "turtle").unwrap();
 ```
 
 **Custom extension functions** — register Rust closures under function IRIs, then `query_with_functions`:


### PR DESCRIPTION
> 🤖 SPARQ agent

Completes the **RDF 1.2 / RDF-star** surface flagged by the Hartig feature research (`research/feature-research-hartig.md` §4a–4c), refs **sq-87bq**.

## What shipped

**1. Triple-term-aware sharded dict merge (§4c) — the real fix.**
Removed the stale `has_triple_terms ⇒ serial` fallback in the in-memory `merge_partials` sharded branch (`lib.rs`). The sharded interner gained structural triple-term support in **sq-t3rt (#91)** — a dedicated triple shard + a serial second pass keyed on the components' already-routed temp ids — and the sharded *external* builder and the *pipelined* in-RAM loader already use it successfully. The fallback (added by sq-hxgb before that path was wired in) needlessly dropped RDF-star bulk loads to the serial path; removing it keeps **full parse parallelism** for triple-term datasets. `Dict::has_triple_terms` re-gated `parallel → dict-spill` (its sole remaining caller is the dict-spill rejection).

**2. Subject-position triple terms (§4a) — spec-correct rejection, now precise.**
Per the canonical RDF 1.2 grammar, triple terms `<<( s p o )>>` are **object-only** (`subject ::= IRIREF | BLANK_NODE_LABEL` [7], `predicate ::= IRIREF` [8]; only `object` [9] admits a `tripleTerm` [11]). The byte parser's rejection of subject/predicate-position triple terms is therefore **correct**, not a gap — the research doc conflated it with the legacy RDF-star CG `<< s p o >>` quoted-triple subject syntax that RDF 1.2 deliberately dropped. Kept the rejection but turned the generic error into a **precise, position-aware** message in both `term` (N-Triples) and `span_term` (N-Quads span walk).

**3. Annotation syntax `{| … |}` + reifiedTriple `<< … >>` (§4b) — already supported.**
Verified (probe) that oxttl 0.2.3 (`rdf-12`) fully desugars the Turtle/TriG reification sugar — `<< s p o >>` (subject **and** object position, optional `~ reifier`) and the annotation block `s p o {| … |}` — to the standard `rdf:reifies <<( s p o )>>` form. No parser work needed; added an **end-to-end semantics test** locking it in.

## Deferred (already tracked)
- **dict-spill external builder** still rejects triple terms (content-only on-disk records can't encode them) — tracked by existing bead **sq-jvbr**. No new bead needed.

## Tests
- `triple_term_only_in_object_position` — grammar-cited subject/predicate/nested-subject rejection + object-position sanity.
- `turtle_rdf12_reification_surface_loads_desugared` — named reifier, annotation block (asserts base triple), subject-position reifier (does NOT assert) through `Graph::load_str`.
- `merge_partials_sharded_consolidates_triple_terms` — **deterministically** forces the sharded branch (≥2-thread scoped rayon pool), pins to the serial `merge_remap` reference, and asserts observable cross-shard triple-term dedup.
- Existing triple-term coverage (sharded external builder, pipelined loader, dict round-trip) all green.

## Verification
- `cargo build -p sparq-core` clean.
- `cargo test -p sparq-core --features mmap,dict-spill` + `cargo test -p sparq-engine` green.
- `cargo clippy --all-targets -- -D warnings` clean on **default / `--no-default-features` (wasm-like) / `mmap,dict-spill`**.
- New code matches the surrounding style (repo defers a workspace-wide `cargo fmt`; CI fmt is informational — see `rustfmt.toml`).
- Conformance **accept/reject sets unchanged** (parser only gained better error messages + a byte-identical merge path) — no SPARQL/SHACL ratchet regression.
- SKILL updates: `data-formats` (RDF 1.2 triple-term / RDF-star gotcha) + `sparql-query` (annotation-block form).

*Timing is NON-canonical (work-box measurements not baked into docs/tests).*