### PR TITLE
feat(site): MPC £100k secure-threshold flagship + 6 surface pages

### DIFF
--- a/site/src/app/showcase/[slug]/page.tsx
+++ b/site/src/app/showcase/[slug]/page.tsx
@@ -4,8 +4,12 @@ import { notFound } from "next/navigation";
 import { SurfacePlaceholder } from "@/components/surface-placeholder";
 import { FLAGSHIPS } from "@/data/surfaces";
 
+// The MPC flagship has its own real page at /showcase/mpc-100k; the remaining
+// flagships fall back to the honest placeholder until their pages are built.
 export function generateStaticParams() {
-  return FLAGSHIPS.map((s) => ({ slug: s.slug }));
+  return FLAGSHIPS.filter((s) => s.slug !== "mpc-100k").map((s) => ({
+    slug: s.slug,
+  }));
 }
 
 export const dynamicParams = false;

--- a/site/src/app/showcase/mpc-100k/page.tsx
+++ b/site/src/app/showcase/mpc-100k/page.tsx
@@ -1,0 +1,269 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  Lock,
+  Network,
+  Split,
+  Sigma,
+  Eye,
+  Info,
+  TriangleAlert,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { MpcDemo } from "@/components/mpc-demo";
+import { TIER_LABEL, TIER_VARIANT } from "@/data/surfaces";
+
+export const metadata: Metadata = {
+  title: "MPC £100k secure threshold",
+  description:
+    "Four flatmates learn only whether their combined income clears a £100k threshold — no salary, and not even the exact total, is revealed. A faithful in-tab illustration of the sparq-mpc secure-threshold protocol.",
+};
+
+export default function MpcFlagshipPage() {
+  return (
+    <div className="space-y-10">
+      <Button variant="ghost" size="sm" asChild className="-ml-2">
+        <Link href="/">
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Back to overview
+        </Link>
+      </Button>
+
+      {/* Hero */}
+      <header className="space-y-3">
+        <div className="flex items-center gap-3">
+          <span className="flex size-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <Lock className="size-5" aria-hidden="true" />
+          </span>
+          <div>
+            <h1 className="flex items-center gap-2 text-2xl font-semibold">
+              <span className="text-[var(--warning)]" aria-hidden="true">
+                ★
+              </span>
+              MPC £100k secure threshold
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Can a group collectively afford it — without anyone revealing their
+              salary?
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant={TIER_VARIANT["live-sim"]}>{TIER_LABEL["live-sim"]}</Badge>
+          <Badge variant="muted">Faithful illustration — not live MPC</Badge>
+        </div>
+      </header>
+
+      {/* Narrative */}
+      <section className="measure space-y-3 text-muted-foreground">
+        <p>
+          Four flatmates want to apply for a £100k mortgage together. The lender
+          only needs to know one thing:{" "}
+          <strong className="text-foreground">
+            does their combined income clear £100,000?
+          </strong>{" "}
+          Nobody wants to disclose their salary to the others, and the group does
+          not even want to reveal the exact total — only the yes/no answer.
+        </p>
+        <p>
+          Secure multi-party computation (MPC) lets the parties jointly compute
+          that single bit. Each party&rsquo;s income stays on their own device;
+          what crosses the wire is a set of <em>random shares</em> that, on their
+          own, reveal nothing. This mirrors the path tested in the native{" "}
+          <code className="font-mono text-foreground">sparq-mpc</code> crate
+          (30k + 28k + 26k + 24k = 108k → <strong className="text-foreground">true</strong>).
+        </p>
+      </section>
+
+      {/* The interactive demo */}
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Try it</h2>
+        <p className="text-sm text-muted-foreground">
+          Set each party&rsquo;s private income and run the secure threshold. The
+          page reveals only the verdict bit — watch the share matrix to see exactly
+          what is exchanged.
+        </p>
+        <MpcDemo />
+      </section>
+
+      {/* How the protocol works */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">How the protocol works</h2>
+        <div className="grid gap-4 md:grid-cols-3">
+          <FlowStep
+            icon={Split}
+            n={1}
+            title="Secret-share"
+            body="Each party splits its private value into N random shares whose sum equals the value. Any single share is a uniform random number — it leaks nothing. Each party keeps one share and sends the rest to its peers."
+          />
+          <FlowStep
+            icon={Sigma}
+            n={2}
+            title="Add over shares"
+            body="Addition is free on secret shares: every party locally sums the shares it holds. Combining those local sums yields a sharing of the grand total, without anyone ever seeing another party's value."
+          />
+          <FlowStep
+            icon={Eye}
+            n={3}
+            title="Reveal one bit"
+            body="A secure comparison opens only the boolean total ≥ £100k. The exact total is never reconstructed as an output — the lender learns one bit, and nothing else."
+          />
+        </div>
+      </section>
+
+      {/* What is shared vs private */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">What is shared vs. what stays private</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          <Card>
+            <CardHeader className="flex-row items-center gap-2 space-y-0">
+              <Lock className="size-5 text-primary" aria-hidden="true" />
+              <CardTitle className="text-base">Stays private</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm text-muted-foreground">
+              <p>
+                <strong className="text-foreground">Each party&rsquo;s income.</strong>{" "}
+                It never leaves the device in the clear; only random shares are
+                sent, and no party can see another&rsquo;s value.
+              </p>
+              <p>
+                <strong className="text-foreground">The exact total.</strong> It is
+                only ever held as a secret sharing and is never opened — only the
+                threshold comparison&rsquo;s result is.
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex-row items-center gap-2 space-y-0">
+              <Network className="size-5 text-[var(--success)]" aria-hidden="true" />
+              <CardTitle className="text-base">Shared / revealed</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm text-muted-foreground">
+              <p>
+                <strong className="text-foreground">Random shares between peers.</strong>{" "}
+                These cross the wire but are uniformly random — fewer than the
+                reconstruction threshold of them reveal nothing.
+              </p>
+              <p>
+                <strong className="text-foreground">The verdict bit.</strong> The
+                single output: whether the combined income meets £100k. The public
+                threshold itself is, of course, public.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      {/* HONESTY — mandatory framing */}
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Honesty: what this demo is, and is not</h2>
+        <Card className="ring-[var(--warning)]/30">
+          <CardHeader className="flex-row items-center gap-2 space-y-0">
+            <TriangleAlert
+              className="size-5 text-[var(--warning)]"
+              aria-hidden="true"
+            />
+            <CardTitle className="text-base">
+              A faithful illustration — not live MPC, and not a security claim
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <p>
+              This page is a{" "}
+              <strong className="text-foreground">
+                client-side illustration of the protocol shape
+              </strong>
+              , not the hardened crate running in your browser. The{" "}
+              <code className="font-mono">sparq-mpc</code> crate is deliberately
+              native-only and is absent from the wasm bundle, so nothing
+              cryptographic runs here. The in-tab code uses simple additive
+              (n-of-n) secret sharing with <code className="font-mono">Math.random</code>{" "}
+              to make the &ldquo;shares reveal nothing&rdquo; and &ldquo;addition
+              is free&rdquo; properties visible; the real crate uses honest-majority{" "}
+              <strong className="text-foreground">Shamir t-of-n</strong> sharing and
+              a bit-decomposition secure comparison.
+            </p>
+            <p>
+              Even the native crate makes{" "}
+              <strong className="text-foreground">no production security claim</strong>.
+              It is honest-majority <strong className="text-foreground">semi-honest</strong>{" "}
+              only — confidentiality holds against parties that follow the protocol
+              but try to learn more, not against actively-cheating parties in every
+              configuration. The collaborative zero-knowledge{" "}
+              <em>proof of correctness and source-attestation</em> is a stub that
+              returns <code className="font-mono">NotYetImplemented</code>. So this
+              demo does <strong className="text-foreground">not</strong> prove the
+              result is correct, only that the disclosure pattern is minimal.
+            </p>
+            <p>
+              No external cryptographer has reviewed sparq&rsquo;s bespoke MPC. Per
+              the project&rsquo;s published <code className="font-mono">SECURITY.md</code>{" "}
+              posture, treat this as a research / explainer artifact, not a
+              certified secure-computation system. The crypto-review readiness doc
+              states it plainly: <code className="font-mono">sparq-mpc</code> carries
+              no confidentiality, correctness, attestation, or malicious-security
+              guarantee today.
+            </p>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="flex flex-wrap gap-2">
+        <Button asChild variant="outline" size="sm">
+          <Link href="/surface/mpc">
+            <Info className="size-4" aria-hidden="true" />
+            The MPC surface in depth
+          </Link>
+        </Button>
+        <Button asChild variant="outline" size="sm">
+          <a
+            href="https://github.com/jeswr/sparq/tree/main/crates/sparq-mpc"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            sparq-mpc source on GitHub
+          </a>
+        </Button>
+      </section>
+    </div>
+  );
+}
+
+function FlowStep({
+  icon: Icon,
+  n,
+  title,
+  body,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  n: number;
+  title: string;
+  body: string;
+}) {
+  return (
+    <Card className="h-full">
+      <CardHeader className="gap-2">
+        <div className="flex items-center gap-2">
+          <span className="flex size-9 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <Icon className="size-4.5" aria-hidden="true" />
+          </span>
+          <Badge variant="muted">Step {n}</Badge>
+        </div>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <CardDescription className="leading-relaxed">{body}</CardDescription>
+      </CardContent>
+    </Card>
+  );
+}

--- a/site/src/app/surface/[slug]/page.tsx
+++ b/site/src/app/surface/[slug]/page.tsx
@@ -5,9 +5,23 @@ import { SurfacePlaceholder } from "@/components/surface-placeholder";
 import { ALL_SURFACES } from "@/data/surfaces";
 
 // Surfaces routed here are the ones whose interactive page is not built yet
-// (the REPL has its own /try page). Static export needs every slug enumerated.
+// (the REPL has its own /try page). Surfaces with a real, hand-built content
+// page live under src/app/surface/<slug>/page.tsx and are excluded here so the
+// static route takes precedence (no generateStaticParams collision).
+const BUILT_SURFACES = new Set([
+  "sparql",
+  "data-formats",
+  "javascript-wasm",
+  "shacl",
+  "mpc",
+  "zk",
+]);
 const PLACEHOLDER_SURFACES = ALL_SURFACES.filter(
-  (s) => s.slug !== "try" && s.slug !== "about" && s.href.startsWith("/surface/"),
+  (s) =>
+    s.slug !== "try" &&
+    s.slug !== "about" &&
+    s.href.startsWith("/surface/") &&
+    !BUILT_SURFACES.has(s.slug),
 );
 
 export function generateStaticParams() {

--- a/site/src/app/surface/data-formats/page.tsx
+++ b/site/src/app/surface/data-formats/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+import { Database } from "lucide-react";
+
+import { SurfaceContent } from "@/components/surface-content";
+
+export const metadata: Metadata = {
+  title: "Data formats",
+  description:
+    "Parse and load RDF into a sparq Graph — Turtle, N-Triples, N-Quads, TriG, compressed dumps, and the binary HDT archive format.",
+};
+
+export default function DataFormatsSurfacePage() {
+  return (
+    <SurfaceContent
+      icon={Database}
+      title="Data formats"
+      statement="Getting RDF into a sparq Graph: the four text formats, compressed ingest, and HDT."
+      tier="live"
+      intro={
+        <>
+          <p>
+            sparq parses the four standard RDF text formats —{" "}
+            <strong className="text-foreground">Turtle, N-Triples, N-Quads</strong>{" "}
+            and <strong className="text-foreground">TriG</strong> — in{" "}
+            <code className="font-mono text-foreground">sparq-core</code>, with
+            in-memory, streaming, parallel and external-memory loaders for large
+            dumps. The binary{" "}
+            <strong className="text-foreground">HDT</strong> archive format (and its
+            content-sniffed <code className="font-mono">.hdt.gz</code> /{" "}
+            <code className="font-mono">.hdt.zst</code> /{" "}
+            <code className="font-mono">.hdt.bz2</code> variants) lives in the
+            opt-in <code className="font-mono text-foreground">sparq-hdt</code>{" "}
+            crate.
+          </p>
+          <p>
+            These crates parse RDF <em>in</em>; to write RDF <em>out</em>, the
+            engine ships a writer matrix (Turtle / TriG / N-Quads / JSON-LD 1.1)
+            behind its <code className="font-mono">serialize-rdf</code> feature,
+            with the N-Triples writer always on.
+          </p>
+        </>
+      }
+      capabilities={[
+        {
+          title: "Turtle / N-Triples / N-Quads / TriG",
+          body: "All four text formats, with named-graph preservation for the quad formats.",
+        },
+        {
+          title: "Compressed ingest",
+          body: "gzip / zstd RDF dumps decode-and-load; in the browser via SparqStore.fromCompressed().",
+        },
+        {
+          title: "Streaming & parallel loaders",
+          body: "Chunk-parallel parsing for large N-Triples dumps; external-memory ingest (native).",
+        },
+        {
+          title: "HDT archives",
+          body: "Load .hdt and content-sniffed .hdt.gz/.zst/.bz2 via the opt-in sparq-hdt crate.",
+        },
+        {
+          title: "Copy-on-write snapshots",
+          body: "Cheap immutable Graph snapshots for concurrent serving.",
+        },
+        {
+          title: "RDF writer matrix",
+          body: "Serialize back out to Turtle / TriG / N-Quads / JSON-LD (engine serialize-rdf feature).",
+        },
+      ]}
+      runsNote={
+        <>
+          <p>
+            <strong className="text-foreground">Live in your tab</strong> for the
+            four text formats and gzip/zstd-compressed ingest — the same loaders
+            that ship in <code className="font-mono">@jeswr/sparq</code>.
+          </p>
+        </>
+      }
+      caveat={
+        <>
+          <p>
+            HDT loading, the mmap / external-memory ingest path, and the
+            fully-parallel fast loaders are <strong className="text-foreground">native-only</strong>
+            ; in the browser they fall back to the in-memory streaming loader.
+          </p>
+        </>
+      }
+      links={[{ href: "/try", label: "Load data in the REPL" }]}
+    />
+  );
+}

--- a/site/src/app/surface/javascript-wasm/page.tsx
+++ b/site/src/app/surface/javascript-wasm/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from "next";
+import { Boxes } from "lucide-react";
+
+import { SurfaceContent } from "@/components/surface-content";
+
+export const metadata: Metadata = {
+  title: "JavaScript / WASM",
+  description:
+    "Use the sparq engine from JavaScript/TypeScript via @jeswr/sparq — an idiomatic RDF/JS surface over the ~886 KB WebAssembly build, in Node or the browser.",
+};
+
+export default function JavascriptWasmSurfacePage() {
+  return (
+    <SurfaceContent
+      icon={Boxes}
+      title="JavaScript / WASM"
+      statement="The @jeswr/sparq RDF/JS API — the Rust engine compiled to a single ~886 KB wasm artifact."
+      tier="live"
+      intro={
+        <>
+          <p>
+            sparq is a Rust RDF triplestore + SPARQL engine compiled to a single{" "}
+            <strong className="text-foreground">~886 KB</strong> (≈314 KB gzipped)
+            WebAssembly artifact. The npm package{" "}
+            <code className="font-mono text-foreground">@jeswr/sparq</code> wraps it
+            in an idiomatic <a className="text-primary underline-offset-4 hover:underline" href="https://rdf.js.org/" target="_blank" rel="noopener noreferrer">RDF/JS</a>{" "}
+            surface — <code className="font-mono">SparqStore</code>, Map-like{" "}
+            <code className="font-mono">Bindings</code>, spec terms via{" "}
+            <code className="font-mono">@rdfjs/types</code> — and runs unchanged in
+            Node &ge; 18 and the browser.
+          </p>
+          <p>
+            This very site uses it: the live REPL constructs a{" "}
+            <code className="font-mono">Store</code>, loads Turtle, and runs your
+            SPARQL — all in the tab. A thin raw <code className="font-mono">Store</code>{" "}
+            class is available if you want SPARQL-JSON strings with no JS-side term
+            materialisation.
+          </p>
+        </>
+      }
+      capabilities={[
+        {
+          title: "SparqStore (RDF/JS)",
+          body: "fromString / fromCompressed, query() yielding Map-like Bindings, idiomatic terms.",
+        },
+        {
+          title: "Streaming cursors",
+          body: "Iterate large SELECT results without materialising the whole table.",
+        },
+        {
+          title: "count() without materialising",
+          body: "Get a result count without building every binding.",
+        },
+        {
+          title: "RDF/JS match() / countQuads()",
+          body: "The standard Source interface for pattern matching over the store.",
+        },
+        {
+          title: "applyDelta / SPARQL Update",
+          body: "Apply quad deltas or SPARQL Update to mutate the store.",
+        },
+        {
+          title: "Raw Store class",
+          body: "SPARQL-JSON strings + CONSTRUCT / DESCRIBE, skipping JS term materialisation.",
+        },
+      ]}
+      runsNote={
+        <>
+          <p>
+            <strong className="text-foreground">This is the engine.</strong> Every
+            live demo on this site calls this API. In Node it loads the same wasm
+            binary; in the browser it streams it on first use.
+          </p>
+        </>
+      }
+      caveat={
+        <>
+          <p>
+            The wrapper does not yet expose CONSTRUCT / DESCRIBE — drop to the raw{" "}
+            <code className="font-mono">Store</code> for those. The lean bundle
+            omits REGEX/REPLACE and the wall-clock query budget (see the SPARQL
+            surface), trading a smaller download for those native-only features.
+          </p>
+        </>
+      }
+      links={[
+        { href: "/try", label: "Open the live REPL" },
+        {
+          href: "https://www.npmjs.com/package/@jeswr/sparq",
+          label: "@jeswr/sparq on npm",
+          external: true,
+        },
+      ]}
+    />
+  );
+}

--- a/site/src/app/surface/mpc/page.tsx
+++ b/site/src/app/surface/mpc/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Network } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { SurfaceContent } from "@/components/surface-content";
+
+export const metadata: Metadata = {
+  title: "MPC federation",
+  description:
+    "Run a SPARQL query across mutually-distrusting RDF holders with sparq-mpc — per-holder local evaluation, disclosed-key joins, and honest-majority Shamir secret sharing for secure aggregates and threshold verdicts.",
+};
+
+export default function MpcSurfacePage() {
+  return (
+    <SurfaceContent
+      icon={Network}
+      title="MPC federation"
+      statement="Answer one SPARQL query across distrusting holders, minimising what each reveals."
+      tier="live-sim"
+      extraBadge="Native-only · research / semi-honest"
+      intro={
+        <>
+          <p>
+            <code className="font-mono text-foreground">sparq-mpc</code> lets a set
+            of mutually-distrusting <strong className="text-foreground">holders</strong>
+            , each owning private RDF named graphs, jointly answer one SPARQL query
+            over the <em>union</em> of their data while minimising what each
+            reveals. Each holder evaluates its fragment{" "}
+            <strong className="text-foreground">locally</strong> over its own graph;
+            only projected rows ever leave a holder.
+          </p>
+          <p>
+            On top of that it adds a crypto-free join on{" "}
+            <em>disclosed</em> global IRIs and an honest-majority{" "}
+            <strong className="text-foreground">Shamir secret-sharing</strong>{" "}
+            backend that powers secure cumulative aggregates, a hidden-value
+            (private-key) join, and a secure threshold comparison that opens{" "}
+            <em>only</em> a boolean verdict.
+          </p>
+        </>
+      }
+      capabilities={[
+        {
+          title: "Per-holder local evaluation",
+          body: "Each holder runs its own SELECT fragment over its own graph; the raw graph never leaves.",
+        },
+        {
+          title: "Disclosed-key global join",
+          body: "Crypto-free inner join on shared global IRIs, equal to union-store evaluation.",
+        },
+        {
+          title: "Secure cumulative aggregate",
+          body: "Sum private integers over Shamir shares (free local addition), reveal only the total.",
+        },
+        {
+          title: "Secure threshold verdict",
+          body: "Open only the bit `sum ≥ threshold` — the £100k flatmates example — never the operands.",
+        },
+        {
+          title: "Hidden-value join",
+          body: "Join on a private key via secret-shared equality; only matched payload columns disclosed.",
+        },
+        {
+          title: "Fail-closed backend selection",
+          body: "A federation states its security floor up front; an over-strong request is truthfully refused.",
+        },
+      ]}
+      runsNote={
+        <>
+          <p>
+            The flagship <Link className="text-primary underline-offset-4 hover:underline" href="/showcase/mpc-100k">£100k secure-threshold demo</Link>{" "}
+            runs a <strong className="text-foreground">faithful in-tab illustration</strong>{" "}
+            of the additive-secret-sharing flow. The hardened crate is{" "}
+            <strong className="text-foreground">native-only</strong> (it uses{" "}
+            <code className="font-mono">std::net</code> and runs as an in-process
+            simulation) and is deliberately absent from the wasm bundle.
+          </p>
+        </>
+      }
+      caveat={
+        <>
+          <p>
+            <strong className="text-foreground">Early / research, semi-honest.</strong>{" "}
+            Confidentiality holds against honest-but-curious parties up to the
+            threshold; tampering is detected and aborts where the (n, t) redundancy
+            allows, but malicious security is not complete and dishonest-majority is
+            future work. The collaborative ZK proof of correctness + source
+            attestation is a <strong className="text-foreground">stub</strong>{" "}
+            (returns <code className="font-mono">NotYetImplemented</code>) — this
+            surface makes no correctness or attestation guarantee, and no external
+            cryptographer has reviewed it.
+          </p>
+        </>
+      }
+      links={[{ href: "/showcase/mpc-100k", label: "★ Open the £100k flagship" }]}
+    >
+      <section className="space-y-2">
+        <Button asChild variant="default" size="sm">
+          <Link href="/showcase/mpc-100k">Try the interactive £100k demo →</Link>
+        </Button>
+      </section>
+    </SurfaceContent>
+  );
+}

--- a/site/src/app/surface/shacl/page.tsx
+++ b/site/src/app/surface/shacl/page.tsx
@@ -1,0 +1,88 @@
+import type { Metadata } from "next";
+import { ShieldCheck } from "lucide-react";
+
+import { SurfaceContent } from "@/components/surface-content";
+
+export const metadata: Metadata = {
+  title: "SHACL",
+  description:
+    "Validate RDF against SHACL shapes with the sparq engine — SHACL Core constraints, SHACL-SPARQL, custom constraint components, and the W3C validation report.",
+};
+
+export default function ShaclSurfacePage() {
+  return (
+    <SurfaceContent
+      icon={ShieldCheck}
+      title="SHACL"
+      statement="Validate RDF data against shapes — SHACL Core, SHACL-SPARQL, and the W3C validation report."
+      tier="live-new-wasm"
+      extraBadge="Portability spike first"
+      intro={
+        <>
+          <p>
+            <code className="font-mono text-foreground">sparq-shacl</code> validates
+            a <code className="font-mono">sparq_core::Graph</code> against SHACL
+            shapes and produces a{" "}
+            <strong className="text-foreground">W3C validation report</strong>{" "}
+            (conformance plus per-violation results) as Turtle or human-readable
+            text. It implements SHACL Core constraints, SHACL-SPARQL{" "}
+            <code className="font-mono">sh:sparql</code> constraints, and custom
+            SPARQL-based constraint components.
+          </p>
+          <p>
+            Because it is pure Rust over <code className="font-mono">sparq-engine</code>
+            , it is wasm-portable: a dedicated{" "}
+            <code className="font-mono text-foreground">sparq-shacl-wasm</code>{" "}
+            bundle can validate data + shapes in-tab, lazy-loaded only on this page.
+          </p>
+        </>
+      }
+      capabilities={[
+        {
+          title: "SHACL Core constraints",
+          body: "class, datatype, cardinality, value ranges, node/property shapes, paths.",
+        },
+        {
+          title: "Logical & qualified shapes",
+          body: "and / or / not / xone, qualified value shapes, closed shapes, in / hasValue.",
+        },
+        {
+          title: "SHACL-SPARQL (§5.2)",
+          body: "sh:sparql constraints expressed as SPARQL SELECT over the engine.",
+        },
+        {
+          title: "Custom constraint components (§6)",
+          body: "Define new sh:ConstraintComponent backed by SPARQL.",
+        },
+        {
+          title: "W3C validation report",
+          body: "Conformance boolean + sh:result violations, as Turtle or human text.",
+        },
+        {
+          title: "Path expressions",
+          body: "Property paths in shape targets and constraints, reusing the engine's path evaluator.",
+        },
+      ]}
+      runsNote={
+        <>
+          <p>
+            Planned <strong className="text-foreground">live in your tab via a new
+            wasm bundle</strong>. The validator is pure Rust over the engine, so it
+            ports cleanly; the bundle is lazy-loaded on this page only to keep the
+            landing page light.
+          </p>
+        </>
+      }
+      caveat={
+        <>
+          <p>
+            SHACL-SPARQL constraints rely on the engine&rsquo;s REGEX, which is
+            compiled out of the lean bundle — the SHACL bundle must include it (a
+            size trade-off confirmed by a portability spike). Until that bundle
+            ships, this surface is a captured-I/O walkthrough.
+          </p>
+        </>
+      }
+    />
+  );
+}

--- a/site/src/app/surface/sparql/page.tsx
+++ b/site/src/app/surface/sparql/page.tsx
@@ -1,0 +1,87 @@
+import type { Metadata } from "next";
+import { FileCode2 } from "lucide-react";
+
+import { SurfaceContent } from "@/components/surface-content";
+
+export const metadata: Metadata = {
+  title: "SPARQL 1.1 / 1.2",
+  description:
+    "SELECT / ASK / CONSTRUCT / UPDATE, property paths, RDF-star quoted triples, aggregates, subqueries — the sparq SPARQL engine, live in your tab.",
+};
+
+export default function SparqlSurfacePage() {
+  return (
+    <SurfaceContent
+      icon={FileCode2}
+      title="SPARQL 1.1 / 1.2"
+      statement="The full query language — SELECT, ASK, CONSTRUCT, UPDATE — over the sparq engine."
+      tier="live"
+      intro={
+        <>
+          <p>
+            sparq evaluates SPARQL 1.1/1.2 over a{" "}
+            <code className="font-mono text-foreground">sparq_core::Graph</code>{" "}
+            using a worst-case-optimal join (WCOJ) engine. The same engine that
+            powers the native crate is compiled to WebAssembly and ships as{" "}
+            <code className="font-mono text-foreground">@jeswr/sparq</code>, so you
+            can run real queries in this tab — nothing is sent to a server.
+          </p>
+          <p>
+            The query surface covers the algebra you would expect — basic graph
+            patterns, FILTER, OPTIONAL, UNION, MINUS, BIND, VALUES, aggregates and
+            GROUP BY, sub-SELECT, and property paths — plus RDF-star quoted triples
+            and named-graph dataset views.
+          </p>
+        </>
+      }
+      capabilities={[
+        {
+          title: "SELECT / ASK / CONSTRUCT / DESCRIBE",
+          body: "All four query forms, returning bindings, a boolean, or a constructed graph.",
+        },
+        {
+          title: "SPARQL Update",
+          body: "INSERT / DELETE / DELETE…WHERE and graph management, mutating the store in place.",
+        },
+        {
+          title: "Property paths",
+          body: "Sequence, alternative, inverse, and the transitive *, +, ? operators.",
+        },
+        {
+          title: "RDF-star",
+          body: "Quoted triples as subjects/objects, queried with the << >> syntax.",
+        },
+        {
+          title: "Aggregates & subqueries",
+          body: "COUNT / SUM / AVG / MIN / MAX / GROUP_CONCAT, GROUP BY / HAVING, and nested SELECT.",
+        },
+        {
+          title: "Extension functions",
+          body: "Register custom SPARQL functions via the engine's FunctionRegistry (native).",
+        },
+      ]}
+      runsNote={
+        <>
+          <p>
+            <strong className="text-foreground">Live in your browser tab.</strong>{" "}
+            The lean wasm bundle carries the parser, triplestore and SPARQL engine.
+            The live REPL on this site runs your queries against the sample graph
+            with no network round-trip.
+          </p>
+        </>
+      }
+      caveat={
+        <>
+          <p>
+            REGEX / REPLACE are compiled out of the lean wasm bundle to keep it
+            small; they are available in the native build. The query-budget
+            deadline (wall-clock timeout) is native-only — the wasm bundle enforces
+            a row cap instead. <code className="font-mono">EXPLAIN</code> exists in
+            the engine but is not yet a wasm export.
+          </p>
+        </>
+      }
+      links={[{ href: "/try", label: "Open the live REPL" }]}
+    />
+  );
+}

--- a/site/src/app/surface/zk/page.tsx
+++ b/site/src/app/surface/zk/page.tsx
@@ -1,0 +1,97 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Lock } from "lucide-react";
+
+import { SurfaceContent } from "@/components/surface-content";
+
+export const metadata: Metadata = {
+  title: "ZK query proofs",
+  description:
+    "Prove and verify a SPARQL query result over committed RDF Verifiable Credentials in zero knowledge with sparq-zk — Poseidon2 commitments, BGP + FILTER Noir proofs, issuer attestation, and revocation.",
+};
+
+export default function ZkSurfacePage() {
+  return (
+    <SurfaceContent
+      icon={Lock}
+      title="ZK query proofs"
+      statement="Prove a SPARQL answer over committed RDF credentials in zero knowledge."
+      tier="live-bbjs"
+      extraBadge="Research-grade · pending external review"
+      intro={
+        <>
+          <p>
+            <code className="font-mono text-foreground">sparq-zk</code> +{" "}
+            <code className="font-mono text-foreground">sparq-zk-compose</code> let
+            a holder prove that a SPARQL query result is faithfully derived from
+            issuer-attested RDF Verifiable Credentials —{" "}
+            <strong className="text-foreground">without revealing the underlying
+            graph</strong>. Graphs are committed with Poseidon2; the query logic
+            (BGP scan, integer FILTER, equality join) is proven with Noir circuits
+            compiled to Barretenberg UltraHonk.
+          </p>
+          <p>
+            Issuer attestation uses Schnorr signatures (including hidden-key set
+            membership), revocation is checked against a status list at a clear or
+            hidden index, and verifier nonces give single-use replay defence. The
+            whole proof is bundled as a{" "}
+            <code className="font-mono text-foreground">ProofManifest</code>.
+          </p>
+        </>
+      }
+      capabilities={[
+        {
+          title: "Per-graph Poseidon2 commitments",
+          body: "Commit a credential graph to a single field element the proof binds against.",
+        },
+        {
+          title: "BGP scan + integer FILTER",
+          body: "Prove a basic graph pattern matched and a numeric predicate (e.g. age ≥ 25) held.",
+        },
+        {
+          title: "Issuer attestation",
+          body: "Schnorr signatures, incl. hidden-key set membership (prove a trusted issuer without naming it).",
+        },
+        {
+          title: "Revocation",
+          body: "Status-list non-revocation at a clear or hidden index.",
+        },
+        {
+          title: "Equality join",
+          body: "Prove two credentials share a holder term without disclosing it.",
+        },
+        {
+          title: "Replay defence",
+          body: "Verifier-supplied nonces make each presentation single-use.",
+        },
+      ]}
+      runsNote={
+        <>
+          <p>
+            Planned <strong className="text-foreground">live in your tab via bb.js</strong>{" "}
+            (UltraHonk WASM): the circuit family is 6k–35k gates — roughly 15× under
+            the browser ceiling — so proving in-tab is feasible (single-threaded on
+            GitHub Pages; a COEP shim unlocks threads). See the{" "}
+            <Link className="text-primary underline-offset-4 hover:underline" href="/showcase/zk-car-hire">ZK car-hire flagship</Link>.
+          </p>
+        </>
+      }
+      caveat={
+        <>
+          <p>
+            <strong className="text-foreground">Research-grade (v1), pending external
+            review.</strong> An internal re-audit found the verifier sound{" "}
+            <em>as landed under its stated threat model</em> (the relying party
+            supplies its own trust anchors), but no external accredited cryptographer
+            has reviewed it, and the project&rsquo;s published{" "}
+            <code className="font-mono">SECURITY.md</code> posture is the
+            conservative one. Some privacy deferrals remain (e.g. status-list
+            IRI/version disclosure → linkability). Do not treat these proofs as
+            production-certified.
+          </p>
+        </>
+      }
+      links={[{ href: "/showcase/zk-car-hire", label: "★ ZK car-hire flagship" }]}
+    />
+  );
+}

--- a/site/src/components/mpc-demo.tsx
+++ b/site/src/components/mpc-demo.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+// [OPUS-4.8] sq-3hrc — the interactive MPC £100k secure-threshold demo.
+// Each of N parties enters a PRIVATE contribution; the page runs a faithful
+// in-tab illustration of additive secret sharing + a secure threshold and
+// reveals ONLY the boolean `total ≥ £100k`, never the individual values or the
+// exact sum. See src/lib/mpc-sim.ts for the protocol shape + the honesty notes.
+
+import * as React from "react";
+import {
+  Lock,
+  Unlock,
+  ArrowRight,
+  RotateCcw,
+  Eye,
+  EyeOff,
+  ShieldCheck,
+  ShieldAlert,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { runSecureThreshold, type MpcResult, type Party } from "@/lib/mpc-sim";
+
+const THRESHOLD = 100_000;
+const DEFAULT_VALUES = [30_000, 28_000, 26_000, 24_000]; // crate's tested 108k → true
+const NAMES = ["Alice", "Bob", "Carol", "Dave"];
+
+const gbp = (n: number) =>
+  new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+    maximumFractionDigits: 0,
+  }).format(n);
+
+export function MpcDemo() {
+  const [values, setValues] = React.useState<number[]>(DEFAULT_VALUES);
+  const [result, setResult] = React.useState<MpcResult | null>(null);
+  const [revealMatrix, setRevealMatrix] = React.useState(false);
+
+  const total = values.reduce((a, b) => a + b, 0);
+
+  const run = React.useCallback(() => {
+    const parties: Party[] = values.map((value, i) => ({
+      name: NAMES[i] ?? `Party ${i + 1}`,
+      value,
+    }));
+    setResult(runSecureThreshold(parties, THRESHOLD));
+  }, [values]);
+
+  const reset = React.useCallback(() => {
+    setValues(DEFAULT_VALUES);
+    setResult(null);
+    setRevealMatrix(false);
+  }, []);
+
+  const setValue = (i: number, v: number) => {
+    setValues((prev) => {
+      const next = [...prev];
+      next[i] = v;
+      return next;
+    });
+    // changing an input invalidates a stale verdict
+    setResult(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Inputs: each party's PRIVATE contribution */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            1 · Each party&rsquo;s private contribution
+          </CardTitle>
+          <CardDescription>
+            These values never leave their owner in the protocol. Adjust them and
+            run the secure threshold — only the verdict bit is revealed.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {values.map((v, i) => (
+            <div key={i} className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <label
+                  htmlFor={`party-${i}`}
+                  className="flex items-center gap-1.5 text-sm font-medium"
+                >
+                  <Lock className="size-3.5 text-primary" aria-hidden="true" />
+                  {NAMES[i]}&rsquo;s income
+                  <Badge variant="default" className="ml-1">
+                    private
+                  </Badge>
+                </label>
+                <span className="tabular text-sm font-semibold">{gbp(v)}</span>
+              </div>
+              <input
+                id={`party-${i}`}
+                type="range"
+                min={0}
+                max={60_000}
+                step={1_000}
+                value={v}
+                onChange={(e) => setValue(i, Number(e.target.value))}
+                aria-label={`${NAMES[i]}'s private income contribution in pounds`}
+                aria-valuetext={gbp(v)}
+                className="w-full accent-[var(--primary)]"
+              />
+            </div>
+          ))}
+          <div className="flex flex-wrap items-center gap-2 pt-1">
+            <Button onClick={run}>
+              <ShieldCheck className="size-4" aria-hidden="true" />
+              Run secure threshold
+            </Button>
+            <Button variant="outline" onClick={reset}>
+              <RotateCcw className="size-4" aria-hidden="true" />
+              Reset
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              Public threshold: <strong className="tabular">{gbp(THRESHOLD)}</strong>
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Result — only renders after running */}
+      {result && <MpcResultPanels result={result} revealMatrix={revealMatrix} onToggleMatrix={() => setRevealMatrix((r) => !r)} actualTotal={total} />}
+    </div>
+  );
+}
+
+function MpcResultPanels({
+  result,
+  revealMatrix,
+  onToggleMatrix,
+  actualTotal,
+}: {
+  result: MpcResult;
+  revealMatrix: boolean;
+  onToggleMatrix: () => void;
+  actualTotal: number;
+}) {
+  const n = result.parties.length;
+  return (
+    <div className="space-y-6">
+      {/* 2 · the share matrix — what crosses the wire */}
+      <Card>
+        <CardHeader className="flex-row items-start justify-between gap-2 space-y-0">
+          <div className="space-y-1.5">
+            <CardTitle className="text-base">
+              2 · Secret-share &amp; distribute
+            </CardTitle>
+            <CardDescription>
+              Each party splits its value into {n} random shares. Off-diagonal
+              cells are <strong>sent to a peer</strong> — this is all that crosses
+              the wire. Any single share is a uniform random number that reveals
+              nothing about the original value.
+            </CardDescription>
+          </div>
+          <Button variant="outline" size="sm" onClick={onToggleMatrix}>
+            {revealMatrix ? (
+              <>
+                <EyeOff className="size-3.5" aria-hidden="true" />
+                Hide share values
+              </>
+            ) : (
+              <>
+                <Eye className="size-3.5" aria-hidden="true" />
+                Reveal share values
+              </>
+            )}
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto rounded-xl ring-1 ring-foreground/10">
+            <table className="w-full text-left text-sm">
+              <caption className="sr-only">
+                Share distribution matrix: row = the party producing shares,
+                column = the party receiving them.
+              </caption>
+              <thead className="bg-muted/50">
+                <tr>
+                  <th scope="col" className="px-3 py-2 font-medium">
+                    From \ To
+                  </th>
+                  {result.parties.map((p) => (
+                    <th key={p.name} scope="col" className="px-3 py-2 font-medium">
+                      {p.name}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {result.matrix.map((row, i) => (
+                  <tr key={i} className="border-t">
+                    <th scope="row" className="px-3 py-2 font-medium">
+                      {result.parties[i].name}
+                    </th>
+                    {row.map((cell, j) => (
+                      <td
+                        key={j}
+                        className={cn(
+                          "tabular px-3 py-2",
+                          cell.kept
+                            ? "bg-[color-mix(in_oklch,var(--success)_10%,transparent)] text-[var(--success)]"
+                            : "text-muted-foreground",
+                        )}
+                      >
+                        <span className="block font-mono text-xs">
+                          {revealMatrix ? cell.value.toLocaleString() : "••••••"}
+                        </span>
+                        <span className="text-[10px] uppercase tracking-wide">
+                          {cell.kept ? "kept" : "→ sent"}
+                        </span>
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-3 text-xs text-muted-foreground">
+            Read a <strong>column</strong> to see what one party receives: a
+            mixture of one share from every party. No column reveals any single
+            input — addition over shares is what produces the answer.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* 3 · local sums → combine */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            3 · Add over shares (free, zero-round)
+          </CardTitle>
+          <CardDescription>
+            Each party sums the column of shares it holds. Combining these local
+            sums reconstructs the secret-shared total — without anyone ever
+            holding another party&rsquo;s value in the clear.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap items-center gap-3">
+            {result.localSums.map((s, j) => (
+              <div
+                key={j}
+                className="rounded-lg bg-muted px-3 py-2 text-center"
+              >
+                <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                  {result.parties[j].name}&rsquo;s local sum
+                </div>
+                <div className="tabular font-mono text-xs">
+                  {s.toLocaleString()}
+                </div>
+              </div>
+            ))}
+            <ArrowRight className="size-4 text-muted-foreground" aria-hidden="true" />
+            <div className="rounded-lg bg-primary/10 px-3 py-2 text-center text-primary">
+              <div className="text-[10px] uppercase tracking-wide">
+                secret-shared total
+              </div>
+              <div className="font-mono text-xs">never opened</div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 4 · reveal ONLY the verdict bit — the money shot */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">4 · Reveal only the verdict</CardTitle>
+          <CardDescription>
+            The secure comparison opens exactly one bit:{" "}
+            <code className="font-mono">total ≥ {gbp(THRESHOLD)}</code>. The exact
+            total is never an output of the computation.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div
+            className={cn(
+              "flex items-center gap-3 rounded-xl px-4 py-4 ring-1",
+              result.verdict
+                ? "bg-[color-mix(in_oklch,var(--success)_10%,transparent)] ring-[var(--success)]/30"
+                : "bg-destructive/10 ring-destructive/30",
+            )}
+            role="status"
+            aria-live="polite"
+          >
+            {result.verdict ? (
+              <Unlock className="size-6 text-[var(--success)]" aria-hidden="true" />
+            ) : (
+              <ShieldAlert className="size-6 text-destructive" aria-hidden="true" />
+            )}
+            <div>
+              <div
+                className={cn(
+                  "text-lg font-semibold",
+                  result.verdict ? "text-[var(--success)]" : "text-destructive",
+                )}
+              >
+                {result.verdict
+                  ? `Combined income clears ${gbp(THRESHOLD)}`
+                  : `Combined income is below ${gbp(THRESHOLD)}`}
+              </div>
+              <div className="text-sm text-muted-foreground">
+                The bank learns this one bit —{" "}
+                <code className="font-mono">
+                  {result.verdict ? "true" : "false"}
+                </code>{" "}
+                — and nothing else.
+              </div>
+            </div>
+          </div>
+
+          {/* what's shared vs what stays private */}
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="space-y-2 rounded-xl bg-muted/50 p-4 ring-1 ring-foreground/10">
+              <div className="flex items-center gap-1.5 text-sm font-semibold">
+                <Unlock className="size-4 text-[var(--success)]" aria-hidden="true" />
+                Revealed (one bit)
+              </div>
+              <ul className="space-y-1 text-sm text-muted-foreground">
+                <li>
+                  ✓ Whether the sum meets the £100k threshold:{" "}
+                  <strong className={result.verdict ? "text-[var(--success)]" : "text-destructive"}>
+                    {result.verdict ? "true" : "false"}
+                  </strong>
+                </li>
+                <li>✓ The public threshold itself ({gbp(THRESHOLD)})</li>
+              </ul>
+            </div>
+            <div className="space-y-2 rounded-xl bg-muted/50 p-4 ring-1 ring-foreground/10">
+              <div className="flex items-center gap-1.5 text-sm font-semibold">
+                <Lock className="size-4 text-primary" aria-hidden="true" />
+                Stays private (never revealed)
+              </div>
+              <ul className="space-y-1 text-sm text-muted-foreground">
+                {result.parties.map((p) => (
+                  <li key={p.name}>
+                    ✗ {p.name}&rsquo;s income{" "}
+                    <span className="font-mono text-xs line-through opacity-60">
+                      {gbp(p.value)}
+                    </span>
+                  </li>
+                ))}
+                <li>
+                  ✗ The exact total{" "}
+                  <span className="font-mono text-xs line-through opacity-60">
+                    {gbp(actualTotal)}
+                  </span>{" "}
+                  (redacted — not an output)
+                </li>
+              </ul>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/site/src/components/surface-content.tsx
+++ b/site/src/components/surface-content.tsx
@@ -1,0 +1,156 @@
+// [OPUS-4.8] sq-3hrc — shared layout for a real (non-placeholder) surface page.
+// Renders a consistent structure per research/feature-showcase-site-design.md §2:
+// capability statement → tier badge → capability list → "how this works" →
+// honest caveat → CTAs. Content is grounded in each surface's skills/*/SKILL.md.
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { ArrowLeft, Check, Info, TriangleAlert } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { type Tier, TIER_LABEL, TIER_VARIANT } from "@/data/surfaces";
+
+export interface SurfaceContentProps {
+  icon: LucideIcon;
+  title: string;
+  /** One-line capability statement. */
+  statement: string;
+  tier: Tier;
+  /** Optional extra badge label (e.g. "Native-only", "Research-grade"). */
+  extraBadge?: string;
+  /** Lead paragraphs of prose. */
+  intro: ReactNode;
+  /** The concrete capabilities this surface offers (bullet list). */
+  capabilities: { title: string; body: string }[];
+  /** "How this runs" honest note. */
+  runsNote: ReactNode;
+  /** Honest caveat / what is NOT covered. */
+  caveat: ReactNode;
+  /** Optional CTA links beyond the source link. */
+  links?: { href: string; label: string; external?: boolean }[];
+  /** Anything extra (e.g. an embedded REPL or table). */
+  children?: ReactNode;
+}
+
+export function SurfaceContent({
+  icon: Icon,
+  title,
+  statement,
+  tier,
+  extraBadge,
+  intro,
+  capabilities,
+  runsNote,
+  caveat,
+  links,
+  children,
+}: SurfaceContentProps) {
+  return (
+    <div className="space-y-10">
+      <Button variant="ghost" size="sm" asChild className="-ml-2">
+        <Link href="/">
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Back to overview
+        </Link>
+      </Button>
+
+      <header className="space-y-3">
+        <div className="flex items-center gap-3">
+          <span className="flex size-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <Icon className="size-5" aria-hidden="true" />
+          </span>
+          <div>
+            <h1 className="text-2xl font-semibold">{title}</h1>
+            <p className="text-sm text-muted-foreground">{statement}</p>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant={TIER_VARIANT[tier]}>{TIER_LABEL[tier]}</Badge>
+          {extraBadge && <Badge variant="muted">{extraBadge}</Badge>}
+        </div>
+      </header>
+
+      <section className="measure space-y-3 text-muted-foreground">{intro}</section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Capabilities</h2>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {capabilities.map((c) => (
+            <div
+              key={c.title}
+              className="flex gap-3 rounded-xl bg-muted/40 p-4 ring-1 ring-foreground/10"
+            >
+              <Check
+                className="mt-0.5 size-4 shrink-0 text-[var(--success)]"
+                aria-hidden="true"
+              />
+              <div>
+                <div className="text-sm font-semibold">{c.title}</div>
+                <div className="text-sm text-muted-foreground">{c.body}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {children}
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader className="flex-row items-center gap-2 space-y-0">
+            <Info className="size-5 text-primary" aria-hidden="true" />
+            <CardTitle className="text-base">How this runs</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm text-muted-foreground">
+            {runsNote}
+          </CardContent>
+        </Card>
+        <Card className="ring-[var(--warning)]/30">
+          <CardHeader className="flex-row items-center gap-2 space-y-0">
+            <TriangleAlert
+              className="size-5 text-[var(--warning)]"
+              aria-hidden="true"
+            />
+            <CardTitle className="text-base">Honest caveats</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm text-muted-foreground">
+            {caveat}
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="flex flex-wrap gap-2">
+        {links?.map((l) =>
+          l.external ? (
+            <Button key={l.href} asChild variant="outline" size="sm">
+              <a href={l.href} target="_blank" rel="noopener noreferrer">
+                {l.label}
+              </a>
+            </Button>
+          ) : (
+            <Button key={l.href} asChild variant="outline" size="sm">
+              <Link href={l.href}>{l.label}</Link>
+            </Button>
+          ),
+        )}
+        <Button asChild variant="outline" size="sm">
+          <a
+            href="https://github.com/jeswr/sparq"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Source on GitHub
+          </a>
+        </Button>
+      </section>
+    </div>
+  );
+}

--- a/site/src/data/surfaces.ts
+++ b/site/src/data/surfaces.ts
@@ -121,6 +121,7 @@ export const GROUPS: SurfaceGroup[] = [
         blurb: "SELECT / ASK / CONSTRUCT / UPDATE, property paths, RDF-star.",
         tier: "live",
         icon: FileCode2,
+        built: true,
       },
       {
         slug: "data-formats",
@@ -129,6 +130,7 @@ export const GROUPS: SurfaceGroup[] = [
         blurb: "Turtle / N-Triples / N-Quads / TriG + compressed ingest.",
         tier: "live",
         icon: Database,
+        built: true,
       },
       {
         slug: "javascript-wasm",
@@ -137,6 +139,7 @@ export const GROUPS: SurfaceGroup[] = [
         blurb: "The @jeswr/sparq browser & Node API — streaming cursors, match, applyDelta.",
         tier: "live",
         icon: Boxes,
+        built: true,
       },
     ],
   },
@@ -158,6 +161,7 @@ export const GROUPS: SurfaceGroup[] = [
         blurb: "SHACL Core + SHACL-SPARQL → W3C validation report.",
         tier: "live-new-wasm",
         icon: ShieldCheck,
+        built: true,
       },
     ],
   },
@@ -221,6 +225,7 @@ export const GROUPS: SurfaceGroup[] = [
         blurb: "Commitments, BGP + FILTER, issuer attestation, revocation.",
         tier: "live-bbjs",
         icon: Lock,
+        built: true,
       },
       {
         slug: "mpc",
@@ -229,6 +234,7 @@ export const GROUPS: SurfaceGroup[] = [
         blurb: "Federated SPARQL across distrusting holders (Shamir, threshold).",
         tier: "live-sim",
         icon: Network,
+        built: true,
       },
     ],
   },

--- a/site/src/lib/mpc-sim.ts
+++ b/site/src/lib/mpc-sim.ts
@@ -1,0 +1,149 @@
+// [OPUS-4.8] sq-3hrc — a FAITHFUL, in-tab JS illustration of the additive
+// secret-sharing flow that the native `sparq-mpc` crate runs for the "is the
+// combined income ≥ £100k?" secure-threshold example (crate path:
+// ShamirBackend::share_private_input → run_secure → secure-threshold /
+// disclose_threshold_verdict; SKILL.md recipe 2 / 2b).
+//
+// HONESTY (load-bearing): this is an ILLUSTRATION of the protocol SHAPE, not
+// the hardened crate and NOT live MPC. We use plain additive (n-out-of-n)
+// secret sharing over a prime field — the simplest sharing that already makes
+// the "no single share reveals anything" and "addition is free over shares"
+// properties visible. The native crate uses honest-majority *Shamir* t-of-n
+// sharing (degree-t polynomials) and a bit-decomposition secure comparison;
+// the additive variant here gives the same intuition without the polynomial
+// machinery. NO real MPC, NO network, NO cryptographic guarantee is provided
+// by this file — the page must say so. The native crate itself is honest-
+// majority *semi-honest* only (no malicious security; the collaborative ZK
+// proof-of-correctness layer is a stub) — see compliance/cryptoreview/README.md.
+
+// A small prime field, mirroring the crate's F_p (p = 2^61 - 1) in spirit.
+// We use a JS-safe prime well under 2^53 so all arithmetic stays exact in
+// IEEE-754 doubles (no BigInt needed for the salary magnitudes in the demo).
+export const FIELD_P = 2_147_483_647; // 2^31 - 1 (a Mersenne prime), exact in f64
+
+function mod(x: number): number {
+  const r = x % FIELD_P;
+  return r < 0 ? r + FIELD_P : r;
+}
+
+/**
+ * Split `secret` into `n` additive shares over F_p.
+ *
+ * Shares `s_0 … s_{n-2}` are uniform-random field elements; the last share is
+ * chosen so that `Σ s_i ≡ secret (mod p)`. Therefore ANY proper subset of the
+ * shares is uniformly random and independent of the secret — that is the
+ * confidentiality property the demo visualises (no party, seeing only the
+ * shares it holds, learns anything about another party's value).
+ */
+export function splitShares(secret: number, n: number, rand: () => number): number[] {
+  if (n < 2) throw new Error("need at least 2 parties");
+  const shares: number[] = [];
+  let acc = 0;
+  for (let i = 0; i < n - 1; i++) {
+    const r = Math.floor(rand() * FIELD_P);
+    shares.push(r);
+    acc = mod(acc + r);
+  }
+  // last share closes the sum to `secret`
+  shares.push(mod(mod(secret) - acc));
+  return shares;
+}
+
+/** Reconstruct a secret from a full set of additive shares: Σ shares (mod p). */
+export function reconstruct(shares: number[]): number {
+  return shares.reduce((a, s) => mod(a + s), 0);
+}
+
+export interface Party {
+  /** Display name. */
+  name: string;
+  /** The party's PRIVATE contribution (never leaves the party in the protocol). */
+  value: number;
+}
+
+export interface ShareMatrixCell {
+  /** Share value party `from` computed for party `to`. */
+  value: number;
+  /** True iff this share stays with the originating party (the diagonal). */
+  kept: boolean;
+}
+
+export interface MpcResult {
+  /** parties[i] = original input. */
+  parties: Party[];
+  /**
+   * matrix[i][j] = the share party i produced for party j.
+   * Off-diagonal cells (i ≠ j) are SENT to peer j (cross the wire).
+   * Diagonal cells (i === j) are KEPT by party i.
+   */
+  matrix: ShareMatrixCell[][];
+  /**
+   * received[j] = the column party j ends up holding (one share from every
+   * party, including its own). Summing this column would NOT reveal any single
+   * party's value — it is the per-party "local view".
+   */
+  received: number[][];
+  /** Per-party local partial sum over the shares it received (free addition). */
+  localSums: number[];
+  /** The reconstructed total — Σ localSums = Σ all inputs. In the real protocol
+   *  this is NEVER opened; we surface it only to show what is REDACTED. */
+  totalRedacted: number;
+  /** The public threshold. */
+  threshold: number;
+  /** The ONLY value revealed: total ≥ threshold. */
+  verdict: boolean;
+}
+
+/**
+ * Run the faithful additive-secret-sharing illustration of the secure sum +
+ * threshold. Mirrors the crate's flow:
+ *   1. each party secret-shares its private value (splitShares),
+ *   2. shares are distributed (the N×N matrix; off-diagonal = sent),
+ *   3. each party locally sums the shares it received (free, zero-round),
+ *   4. the per-party local sums are combined → the secret-shared total,
+ *   5. ONLY the boolean `total ≥ threshold` is revealed; the exact total is
+ *      never an output (here shown struck-through as `totalRedacted`).
+ *
+ * `rand` is injectable so the demo can be deterministic if desired; the default
+ * is `Math.random` (NOT a CSPRNG — this is illustration, not security).
+ */
+export function runSecureThreshold(
+  parties: Party[],
+  threshold: number,
+  rand: () => number = Math.random,
+): MpcResult {
+  const n = parties.length;
+  if (n < 2) throw new Error("need at least 2 parties");
+
+  // 1 + 2: every party splits its value into n shares (row i of the matrix).
+  const matrix: ShareMatrixCell[][] = parties.map((p) => {
+    const row = splitShares(p.value, n, rand);
+    return row.map((value): ShareMatrixCell => ({ value, kept: false }));
+  });
+  for (let i = 0; i < n; i++) matrix[i][i].kept = true;
+
+  // received[j] = column j across all rows = the shares party j now holds.
+  const received: number[][] = [];
+  for (let j = 0; j < n; j++) {
+    received.push(matrix.map((row) => row[j].value));
+  }
+
+  // 3: each party sums the shares it holds (a local share of the global sum).
+  const localSums = received.map((col) => reconstruct(col));
+
+  // 4 + 5: combining the local sums reconstructs Σ inputs. The real protocol
+  // never opens this; we compute it only to display the REDACTED value and to
+  // derive the one revealed bit.
+  const totalRedacted = reconstruct(localSums);
+  const verdict = totalRedacted >= threshold;
+
+  return {
+    parties,
+    matrix,
+    received,
+    localSums,
+    totalRedacted,
+    threshold,
+    verdict,
+  };
+}


### PR DESCRIPTION
> 🤖 SPARQ agent

Builds the **MPC £100k secure-threshold flagship** for the feature-showcase site (the example the maintainer specifically asked for — "show the £100k example and explain what data is shared between people"), plus six real per-surface content pages. Matches the solid-pod-manager design language and `research/feature-showcase-site-design.md` §4.2.

Refs **sq-3hrc** (FLAGSHIP 2), epic **sq-4r4b**.

## MPC £100k flagship — `/showcase/mpc-100k`
- **Interactive sim:** N=4 parties each enter a private income via a slider; the page runs a faithful in-tab illustration of additive secret sharing + a secure threshold and reveals **only** the boolean `total ≥ £100k` — never the individual values, never the exact sum. Mirrors the crate's tested 30k/28k/26k/24k = 108k → true path. Logic in `src/lib/mpc-sim.ts`, UI in `src/components/mpc-demo.tsx`.
- **What is shared vs what stays private:** an N×N **share matrix** (off-diagonal cells = sent to a peer = what crosses the wire; any single share is uniform-random → reveals nothing), the free local-addition combine step, and a reveal panel showing the exact total **struck-through/redacted** beside the one revealed verdict bit. Plus a two-column private/revealed contrast and a step-by-step protocol explainer (secret-share → add over shares → reveal one bit).

## Honesty framing (no overclaim)
The page is explicitly labelled a **faithful illustration of the protocol shape — not live MPC and not a security claim**. It states plainly that `sparq-mpc` is **native-only / absent from the wasm bundle**, **honest-majority semi-honest only** (no malicious-security guarantee in every config), that the collaborative ZK **proof of correctness + attestation is a `NotYetImplemented` stub**, and that **no external cryptographer has reviewed** the bespoke MPC (per `compliance/cryptoreview/README.md` + the published `SECURITY.md` posture). No cryptographic guarantee the estate does not have is claimed.

## Surface pages (real content, honest tier badges)
Converted six "coming soon" placeholders into real content pages grounded in `skills/*/SKILL.md`, via a shared `SurfaceContent` layout:
- **sparql**, **data-formats**, **javascript-wasm** — *Live in your tab*
- **shacl** — *Live (new wasm)*, portability-spike caveat
- **mpc**, **zk** — privacy surfaces, each carrying its research-grade / semi-honest honesty caveat

Static routes are excluded from the `[slug]` `generateStaticParams` so they take precedence with no collision.

## a11y (accessible-html-links + skills)
Real `<a href>` nav, `rel="noopener noreferrer"` on every external link, labelled range inputs (`aria-label`/`aria-valuetext`), `aria-live` verdict status, scoped table headers + `<caption>`, `aria-hidden` on decorative icons.

## Verify
- `cd site && npm run lint` → clean.
- `cd site && npm run build` → static-exports all 24 pages incl. `/showcase/mpc-100k` and the 6 surfaces.
- Sim sanity: reconstruct invariant holds over 10k random runs; computes 108k → true.

NON-CANONICAL timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)