### PR TITLE
feat(dashboard): promote all benchmarked families to dashboard rows (ZK + Solid/HDT/RSP/GenAI/GPU)

### DIFF
--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -404,14 +404,32 @@
   // (normalised lower-case); `prefixes` are a structural fallback matched against the raw metric
   // name's leading token so a not-yet-labelled metric (e.g. a future `vectors_*`) still lands in
   // the right family. Pure + node-testable.
+  //
+  // [OPUS-4.8] sq-ncvq.15 / drift-scan §5.D: the dashboard previously covered only the suites that
+  // already FLOW to benchmark-data via scripts/ci-bench.sh (core/sparql + the four capability
+  // surfaces + reasoning). The drift scan flagged that MANY registered benchmark families
+  // (bench/benchmarks.toml) had NO dashboard row at all — most notably the entire ZK estate
+  // (zk / zk-trace / zk-compose), plus Solid/WAC access-control, HDT ingest, RSP streaming,
+  // GenAI (similarity / introspection) and the GPU kernel experiment. These are stdout/criterion
+  // benches today (they do NOT yet emit into ci-bench.sh's customSmallerIsBetter feed), so the rows
+  // below render as "not yet reported" until a ci-bench hook lands — which is exactly the dashboard's
+  // HONEST graceful-degradation contract (buildFamilies keeps every family, count 0 -> a nav chip +
+  // a "not yet reported" section). When a hook DOES start emitting (e.g. `zk_commit_us`,
+  // `hdt_load_s`, …), the metric lands in the right family automatically via these prefixes — no
+  // further dashboard change. The headline gap (ZK) is listed FIRST among the new families.
   var FAMILIES = [
     { key: 'core',     title: 'Core (load · dict · memory)', kind: 'core',
       suites: ['pipeline', 'memory / size'],
       prefixes: ['load', 'parse', 'store', 'dict', 'wasm', 'rdfs'] },
     { key: 'sparql',   title: 'SPARQL query suites', kind: 'sparql',
+      // [OPUS-4.8] sq-ncvq.15: selective (index-nested-loop / bind join) + u64 (inline value-id /
+      // dict-resolve) are SPARQL micro-suites run through the same cli `bench` runner (q01_* stems).
+      // They emit no dashboard metric today; recognise their suite names + `selective`/`u64` prefixes
+      // so a future hook groups them under SPARQL, not orphaned.
       suites: ['sp2bench', 'watdiv', 'lubm (reasoning)', 'bsbm', 'dbpsb',
-               'synthetic (qlever-style)', 'operators'],
-      prefixes: ['sp2b', 'watdiv', 'lubm', 'bsbm', 'dbpsb', 'op', 'q01', 'q02', 'q03', 'q04',
+               'synthetic (qlever-style)', 'operators', 'selective', 'u64 / value-ids'],
+      prefixes: ['sp2b', 'watdiv', 'lubm', 'bsbm', 'dbpsb', 'op', 'selective', 'u64',
+                 'q01', 'q02', 'q03', 'q04',
                  'q05', 'q06', 'q07', 'q08', 'q09', 'q10', 'q11', 'q12'] },
     { key: 'shacl',    title: 'SHACL validation', kind: 'capability',
       suites: ['shacl validation', 'shacl'], prefixes: ['shacl'] },
@@ -422,9 +440,34 @@
     { key: 'vector',   title: 'Vector / ANN', kind: 'capability',
       suites: ['vector', 'vector / ann', 'vectors', 'ann'],
       prefixes: ['vector', 'vectors', 'vec', 'ann', 'knn', 'hnsw', 'diskann'] },
-    { key: 'reasoning', title: 'Reasoning (Deep Taxonomy)', kind: 'capability',
-      suites: ['deep taxonomy', 'deeptax', 'deep-taxonomy', 'deeptaxonomy'],
-      prefixes: ['deeptax', 'deep'] }
+    { key: 'reasoning', title: 'Reasoning (N3 · RDFS · OWL-RL)', kind: 'capability',
+      // [OPUS-4.8] sq-ncvq.15: broaden beyond Deep Taxonomy — the inference estate also has the
+      // RDFS/OWL-RL materialization (owl-bench) + incremental-maintenance benches. Recognise their
+      // likely hook prefixes so they share the Reasoning section if/when they start emitting.
+      // NB: `rdfs_infer_s` stays in Core — its label-map suite is "Pipeline" (suiteFor wins over the
+      // prefix pass), and we deliberately do NOT claim the bare `rdfs` token here to avoid ambiguity.
+      suites: ['deep taxonomy', 'deeptax', 'deep-taxonomy', 'deeptaxonomy', 'reasoning', 'inference'],
+      prefixes: ['deeptax', 'deep', 'owl', 'infer', 'incremental', 'reason'] },
+    // ---- newly-promoted capability families (sq-ncvq.15 / drift-scan §5.D) ------------------------
+    // [OPUS-4.8] ZK is the HEADLINE gap: the whole commitment + trace + circuit estate (the zk,
+    // zk-trace and zk-compose benchmark suites) had no dashboard presence at all. Prefixes cover the
+    // likely ci-bench emit names (zk_commit_us / zk_canon_* / zktrace_* / zkcompose_gates / …).
+    { key: 'zk', title: 'Zero-knowledge (commit · trace · circuit)', kind: 'capability',
+      suites: ['zk', 'zk-trace', 'zk trace', 'zk-compose', 'zk compose', 'zero-knowledge'],
+      prefixes: ['zk', 'zktrace', 'zkcompose', 'poseidon2', 'rdfc10', 'commitment'] },
+    { key: 'solid', title: 'Solid / access control (WAC · ACP)', kind: 'capability',
+      suites: ['solid', 'wac', 'acp', 'access control'],
+      prefixes: ['solid', 'wac', 'acp'] },
+    { key: 'hdt', title: 'HDT archive ingest', kind: 'capability',
+      suites: ['hdt'], prefixes: ['hdt'] },
+    { key: 'rsp', title: 'RDF Stream Processing (continuous queries)', kind: 'capability',
+      suites: ['rsp', 'rdf stream processing', 'streaming'],
+      prefixes: ['rsp', 'stream', 'window'] },
+    { key: 'genai', title: 'GenAI (similarity · introspection)', kind: 'capability',
+      suites: ['similarity', 'introspect', 'introspection', 'genai'],
+      prefixes: ['sim', 'similarity', 'introspect'] },
+    { key: 'gpu', title: 'GPU kernels (experimental)', kind: 'capability',
+      suites: ['gpu'], prefixes: ['gpu'] }
   ];
 
   // The top-level family a metric belongs to. Consults suiteFor() (label-map driven) FIRST, then a

--- a/bench/dashboard/index.html
+++ b/bench/dashboard/index.html
@@ -52,13 +52,16 @@
 
     <!-- [OPUS-4.8] sq-rltn: capability FAMILIES — the primary, summary-first view. dashboard.js
          paints #families SYNCHRONOUSLY from window.BENCHMARK_DATA (no Chart.js, no label fetch) so
-         the WHOLE picture appears immediately and visibly covers ALL query types: a family nav chip
-         row, then one section per family (Core · SPARQL query suites · SHACL validation · GeoSPARQL ·
-         Full-Text · Vector/ANN · Reasoning), each with a latest-value-per-metric summary table.
+         the WHOLE picture appears immediately and visibly covers ALL benchmarked families: a family
+         nav chip row, then one section per family (Core · SPARQL query suites · SHACL validation ·
+         GeoSPARQL · Full-Text · Vector/ANN · Reasoning · Zero-knowledge · Solid/access-control · HDT ·
+         RSP streaming · GenAI · GPU), each with a latest-value-per-metric summary table.
          Trend charts inside each section are LAZY — built only when the section's "Trends" disclosure
          is expanded / scrolls into view (IntersectionObserver), so first paint never instantiates the
          thousands of SPARQL series. A family with no data yet still shows ("not yet reported") so the
-         coverage is honest. -->
+         coverage is honest — the ZK estate (zk / zk-trace / zk-compose) and the Solid/HDT/RSP/GenAI/GPU
+         families are registered here even though they are stdout/criterion benches that do not yet emit
+         into the per-commit feed; a metric appears the moment a ci-bench hook starts emitting it. -->
     <section class="card" id="families-card">
       <h2>Benchmark families</h2>
       <p class="hint">Every query type sparq benchmarks, grouped into capability families. The table

--- a/scripts/dashboard-smoke.js
+++ b/scripts/dashboard-smoke.js
@@ -285,6 +285,29 @@ ok(typeof D.buildFamilies === 'function', 'dashboard.js exports buildFamilies');
   ok(D.FAMILIES.some(function (f) { return f.key === k; }), 'FAMILIES includes the ' + k + ' family');
 });
 
+// [OPUS-4.8] sq-ncvq.15 / drift-scan §5.D: the newly-promoted families that close the dashboard
+// coverage gap — the ZK estate (headline) plus Solid/HDT/RSP/GenAI/GPU. They have NO flowing data
+// yet (stdout/criterion benches), so they render as "not yet reported"; assert they EXIST in the
+// taxonomy AND that a representative (still unlabelled) metric routes to each via the prefix
+// fallback, so when a ci-bench hook starts emitting, the metric lands in the right family.
+['zk', 'solid', 'hdt', 'rsp', 'genai', 'gpu'].forEach(function (k) {
+  ok(D.FAMILIES.some(function (f) { return f.key === k; }), 'FAMILIES includes the new ' + k + ' family (coverage gap closed)');
+});
+eq(D.familyOf('zk_commit_us').key, 'zk', 'unlabelled zk-commit metric -> ZK family (headline gap)');
+eq(D.familyOf('zktrace_bgp_us').key, 'zk', 'unlabelled zk-trace metric -> ZK family');
+eq(D.familyOf('zkcompose_gates').key, 'zk', 'unlabelled zk-compose gate-count metric -> ZK family');
+eq(D.familyOf('solid_wac_materialize_us').key, 'solid', 'unlabelled solid/WAC metric -> Solid family');
+eq(D.familyOf('hdt_load_s').key, 'hdt', 'unlabelled HDT-load metric -> HDT family');
+eq(D.familyOf('rsp_throughput').key, 'rsp', 'unlabelled RSP-throughput metric -> RSP family');
+eq(D.familyOf('sim_most_similar_us').key, 'genai', 'unlabelled similarity metric -> GenAI family');
+eq(D.familyOf('introspect_build_s').key, 'genai', 'unlabelled introspection metric -> GenAI family');
+eq(D.familyOf('gpu_filter_us').key, 'gpu', 'unlabelled GPU-kernel metric -> GPU family');
+// selective + u64 are SPARQL micro-suites (cli `bench` q01_* stems) — recognise them under SPARQL.
+eq(D.familyOf('selective_q01_count_us').key, 'sparql', 'unlabelled selective-join metric -> SPARQL family');
+eq(D.familyOf('u64_q03_materialize_us').key, 'sparql', 'unlabelled u64 value-id metric -> SPARQL family');
+// the existing capability routings must be UNCHANGED by the new families (no mis-bucketing).
+eq(D.familyOf('rdfs_infer_s').key, 'core', 'rdfs_infer_s still routes to Core (Pipeline suite wins)');
+
 // familyOf: each query type lands in its OWN family (SPARQL volume must not swallow capabilities).
 eq(D.familyOf('watdiv_S1_count_us').key, 'sparql', 'watdiv -> SPARQL family');
 eq(D.familyOf('sp2b_q1_count_us').key, 'sparql', 'sp2b -> SPARQL family');


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

Closes the dashboard coverage gap flagged by the drift-scan (**sq-ncvq.15 / drift-scan §5.D**): the benchmark dashboard's `FAMILIES` taxonomy covered only the suites already flowing to `benchmark-data` via `scripts/ci-bench.sh` (core / SPARQL + the four capability surfaces + reasoning), while **many registered benchmark families** (`bench/benchmarks.toml`) had **no dashboard row at all**.

### Suites/families added

- **Zero-knowledge** — `zk` / `zk-trace` / `zk-compose` (the **headline gap**: the entire ZK commitment + trace + circuit estate had zero dashboard presence)
- **Solid / access control** — WAC / ACP auth-view materialization
- **HDT archive ingest**
- **RSP** — RDF Stream Processing (continuous queries)
- **GenAI** — entity similarity + introspection
- **GPU kernels** (experimental)

Plus: the **selective** + **u64 / value-id** SPARQL micro-suites are now recognised under the SPARQL family, and the Reasoning family is broadened beyond Deep Taxonomy to the RDFS / OWL-RL + incremental-inference estate.

`FAMILIES` goes 7 → 13.

## How missing data degrades

These are **stdout / criterion benches today** — they do **not** yet emit into `ci-bench.sh`'s `customSmallerIsBetter` feed. So they render via the dashboard's existing **HONEST graceful-degradation** contract: `buildFamilies` keeps every family at count 0, so each new family shows as a **nav chip + a "not yet reported" section** (no fabricated rows). The moment a ci-bench hook starts emitting a metric (e.g. `zk_commit_us`, `hdt_load_s`, `rsp_throughput`), it lands in the right family automatically via the family `prefixes` — **no further dashboard change**. The summary-first / lazy-charts fast-load design is untouched.

`rdfs_infer_s` deliberately stays in **Core** (its `Pipeline` label-map suite wins over the prefix pass) — asserted in the smoke test.

## Verify — `dashboard labels (lint + drift)` CI check

All four steps of the CI `dashboard-labels` job pass locally:

- `python3 -c "json.load(... metric-labels.json)"` — valid JSON
- `scripts/gen-metric-labels.py --check` — **up to date** (no new label keys: the new families have no flowing metrics yet)
- `node --check bench/dashboard/dashboard.js` — OK
- `node scripts/dashboard-smoke.js` — **PASS** (DOM sim now renders all 13 family sections; new assertions verify the 6 new families exist + route, ZK included)

NON-CANONICAL timing — **no hard-coded perf numbers** added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)