### PR TITLE
feat(bench): wire ZK-family metrics into the dashboard data feed [OPUS-4.8]

### DIFF
--- a/bench/dashboard/metric-labels.json
+++ b/bench/dashboard/metric-labels.json
@@ -2835,6 +2835,462 @@
       "query": "star query",
       "mode": "materialize",
       "unit": "µs"
+    },
+    "zk_canon_bnode_1024": {
+      "label": "sparq-zk RDFC10 canon — bnode graph, 1024 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "RDFC-1.0 canonicalisation (criterion mean)",
+      "mode": "canon",
+      "unit": "µs"
+    },
+    "zk_canon_bnode_256": {
+      "label": "sparq-zk RDFC10 canon — bnode graph, 256 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "RDFC-1.0 canonicalisation (criterion mean)",
+      "mode": "canon",
+      "unit": "µs"
+    },
+    "zk_canon_bnode_64": {
+      "label": "sparq-zk RDFC10 canon — bnode graph, 64 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "RDFC-1.0 canonicalisation (criterion mean)",
+      "mode": "canon",
+      "unit": "µs"
+    },
+    "zk_canon_iri_1024": {
+      "label": "sparq-zk RDFC10 canon — iri graph, 1024 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "RDFC-1.0 canonicalisation (criterion mean)",
+      "mode": "canon",
+      "unit": "µs"
+    },
+    "zk_canon_iri_256": {
+      "label": "sparq-zk RDFC10 canon — iri graph, 256 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "RDFC-1.0 canonicalisation (criterion mean)",
+      "mode": "canon",
+      "unit": "µs"
+    },
+    "zk_canon_iri_64": {
+      "label": "sparq-zk RDFC10 canon — iri graph, 64 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "RDFC-1.0 canonicalisation (criterion mean)",
+      "mode": "canon",
+      "unit": "µs"
+    },
+    "zk_commit_bnode_1024": {
+      "label": "sparq-zk end-to-end commit — bnode graph, 1024 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "RDFC10 + leaf encode + Poseidon2 fold (criterion mean)",
+      "mode": "commit",
+      "unit": "µs"
+    },
+    "zk_commit_bnode_256": {
+      "label": "sparq-zk end-to-end commit — bnode graph, 256 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "RDFC10 + leaf encode + Poseidon2 fold (criterion mean)",
+      "mode": "commit",
+      "unit": "µs"
+    },
+    "zk_commit_bnode_64": {
+      "label": "sparq-zk end-to-end commit — bnode graph, 64 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "RDFC10 + leaf encode + Poseidon2 fold (criterion mean)",
+      "mode": "commit",
+      "unit": "µs"
+    },
+    "zk_commit_iri_1024": {
+      "label": "sparq-zk end-to-end commit — iri graph, 1024 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "RDFC10 + leaf encode + Poseidon2 fold (criterion mean)",
+      "mode": "commit",
+      "unit": "µs"
+    },
+    "zk_commit_iri_256": {
+      "label": "sparq-zk end-to-end commit — iri graph, 256 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "RDFC10 + leaf encode + Poseidon2 fold (criterion mean)",
+      "mode": "commit",
+      "unit": "µs"
+    },
+    "zk_commit_iri_64": {
+      "label": "sparq-zk end-to-end commit — iri graph, 64 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "RDFC10 + leaf encode + Poseidon2 fold (criterion mean)",
+      "mode": "commit",
+      "unit": "µs"
+    },
+    "zk_commit_leaves_fold_1024": {
+      "label": "sparq-zk recommit (leaves+fold) — precomputed canon, 1024 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "leaf encode + Poseidon2 fold over precomputed canonical form (criterion mean)",
+      "mode": "commit",
+      "unit": "µs"
+    },
+    "zk_commit_leaves_fold_256": {
+      "label": "sparq-zk recommit (leaves+fold) — precomputed canon, 256 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "leaf encode + Poseidon2 fold over precomputed canonical form (criterion mean)",
+      "mode": "commit",
+      "unit": "µs"
+    },
+    "zk_commit_leaves_fold_64": {
+      "label": "sparq-zk recommit (leaves+fold) — precomputed canon, 64 triples",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain), credential scale",
+      "query": "leaf encode + Poseidon2 fold over precomputed canonical form (criterion mean)",
+      "mode": "commit",
+      "unit": "µs"
+    },
+    "zk_compose_filter_f64_gates": {
+      "label": "zk/compose filter_f64 — ultra_honk circuit gate count",
+      "suite": "Zero-knowledge",
+      "dataset": "compiled Noir circuits (zk/compose, nargo compile --workspace); bb gates -s ultra_honk",
+      "query": "deterministic circuit_size (bb gates); smaller is better",
+      "mode": "gates",
+      "unit": "gates"
+    },
+    "zk_compose_filter_int_d1_gates": {
+      "label": "zk/compose filter_int_d1 — ultra_honk circuit gate count",
+      "suite": "Zero-knowledge",
+      "dataset": "compiled Noir circuits (zk/compose, nargo compile --workspace); bb gates -s ultra_honk",
+      "query": "deterministic circuit_size (bb gates); smaller is better",
+      "mode": "gates",
+      "unit": "gates"
+    },
+    "zk_compose_filter_int_d2_gates": {
+      "label": "zk/compose filter_int_d2 — ultra_honk circuit gate count",
+      "suite": "Zero-knowledge",
+      "dataset": "compiled Noir circuits (zk/compose, nargo compile --workspace); bb gates -s ultra_honk",
+      "query": "deterministic circuit_size (bb gates); smaller is better",
+      "mode": "gates",
+      "unit": "gates"
+    },
+    "zk_compose_filter_int_d4_gates": {
+      "label": "zk/compose filter_int_d4 — ultra_honk circuit gate count",
+      "suite": "Zero-knowledge",
+      "dataset": "compiled Noir circuits (zk/compose, nargo compile --workspace); bb gates -s ultra_honk",
+      "query": "deterministic circuit_size (bb gates); smaller is better",
+      "mode": "gates",
+      "unit": "gates"
+    },
+    "zk_compose_join_eq_na16_nb16_gates": {
+      "label": "zk/compose join_eq_na16_nb16 — ultra_honk circuit gate count",
+      "suite": "Zero-knowledge",
+      "dataset": "compiled Noir circuits (zk/compose, nargo compile --workspace); bb gates -s ultra_honk",
+      "query": "deterministic circuit_size (bb gates); smaller is better",
+      "mode": "gates",
+      "unit": "gates"
+    },
+    "zk_compose_scan_k1_n16_r4_gates": {
+      "label": "zk/compose scan_k1_n16_r4 — ultra_honk circuit gate count",
+      "suite": "Zero-knowledge",
+      "dataset": "compiled Noir circuits (zk/compose, nargo compile --workspace); bb gates -s ultra_honk",
+      "query": "deterministic circuit_size (bb gates); smaller is better",
+      "mode": "gates",
+      "unit": "gates"
+    },
+    "zk_compose_scan_k2_n16_r8_gates": {
+      "label": "zk/compose scan_k2_n16_r8 — ultra_honk circuit gate count",
+      "suite": "Zero-knowledge",
+      "dataset": "compiled Noir circuits (zk/compose, nargo compile --workspace); bb gates -s ultra_honk",
+      "query": "deterministic circuit_size (bb gates); smaller is better",
+      "mode": "gates",
+      "unit": "gates"
+    },
+    "zk_compose_scan_k2_n64_r8_gates": {
+      "label": "zk/compose scan_k2_n64_r8 — ultra_honk circuit gate count",
+      "suite": "Zero-knowledge",
+      "dataset": "compiled Noir circuits (zk/compose, nargo compile --workspace); bb gates -s ultra_honk",
+      "query": "deterministic circuit_size (bb gates); smaller is better",
+      "mode": "gates",
+      "unit": "gates"
+    },
+    "zk_poseidon2_hash40": {
+      "label": "sparq-zk Poseidon2-BN254 hash — 40 elements",
+      "suite": "Zero-knowledge",
+      "dataset": "fixed 40-element input",
+      "query": "Poseidon2 sponge over 40 field elements (criterion mean)",
+      "mode": "hash",
+      "unit": "µs"
+    },
+    "zk_poseidon2_permutation": {
+      "label": "sparq-zk Poseidon2-BN254 permutation",
+      "suite": "Zero-knowledge",
+      "dataset": "fixed 4-element BN254 state",
+      "query": "one Poseidon2 permutation (criterion mean)",
+      "mode": "perm",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_bgp_chain_traced_1000": {
+      "label": "zk-trace bgp_chain — BGP chain join (follows then age), traced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP chain join (follows then age); recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_bgp_chain_untraced_1000": {
+      "label": "zk-trace bgp_chain — BGP chain join (follows then age), untraced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP chain join (follows then age); default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_bgp_star_traced_1000": {
+      "label": "zk-trace bgp_star — BGP star join (age/name/city on ?s), traced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP star join (age/name/city on ?s); recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_bgp_star_untraced_1000": {
+      "label": "zk-trace bgp_star — BGP star join (age/name/city on ?s), untraced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP star join (age/name/city on ?s); default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_bgp_triangle_traced_1000": {
+      "label": "zk-trace bgp_triangle — BGP triangle (3-way follows cycle), traced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP triangle (3-way follows cycle); recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_bgp_triangle_untraced_1000": {
+      "label": "zk-trace bgp_triangle — BGP triangle (3-way follows cycle), untraced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP triangle (3-way follows cycle); default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_count_traced_1000": {
+      "label": "zk-trace count — COUNT aggregate over age, traced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "COUNT aggregate over age; recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_count_untraced_1000": {
+      "label": "zk-trace count — COUNT aggregate over age, untraced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "COUNT aggregate over age; default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_distinct_traced_1000": {
+      "label": "zk-trace distinct — DISTINCT projection over city, traced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "DISTINCT projection over city; recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_distinct_untraced_1000": {
+      "label": "zk-trace distinct — DISTINCT projection over city, untraced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "DISTINCT projection over city; default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_filter_traced_1000": {
+      "label": "zk-trace filter — BGP + numeric FILTER(?a > 50), traced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP + numeric FILTER(?a > 50); recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_filter_untraced_1000": {
+      "label": "zk-trace filter — BGP + numeric FILTER(?a > 50), untraced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP + numeric FILTER(?a > 50); default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_optional_traced_1000": {
+      "label": "zk-trace optional — left join (OPTIONAL follows), traced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "left join (OPTIONAL follows); recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_optional_untraced_1000": {
+      "label": "zk-trace optional — left join (OPTIONAL follows), untraced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "left join (OPTIONAL follows); default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_union_traced_1000": {
+      "label": "zk-trace union — UNION of two single-pattern arms, traced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "UNION of two single-pattern arms; recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_1000entities_union_untraced_1000": {
+      "label": "zk-trace union — UNION of two single-pattern arms, untraced, 1000 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "UNION of two single-pattern arms; default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_bgp_chain_traced_100": {
+      "label": "zk-trace bgp_chain — BGP chain join (follows then age), traced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP chain join (follows then age); recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_bgp_chain_untraced_100": {
+      "label": "zk-trace bgp_chain — BGP chain join (follows then age), untraced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP chain join (follows then age); default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_bgp_star_traced_100": {
+      "label": "zk-trace bgp_star — BGP star join (age/name/city on ?s), traced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP star join (age/name/city on ?s); recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_bgp_star_untraced_100": {
+      "label": "zk-trace bgp_star — BGP star join (age/name/city on ?s), untraced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP star join (age/name/city on ?s); default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_bgp_triangle_traced_100": {
+      "label": "zk-trace bgp_triangle — BGP triangle (3-way follows cycle), traced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP triangle (3-way follows cycle); recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_bgp_triangle_untraced_100": {
+      "label": "zk-trace bgp_triangle — BGP triangle (3-way follows cycle), untraced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP triangle (3-way follows cycle); default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_count_traced_100": {
+      "label": "zk-trace count — COUNT aggregate over age, traced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "COUNT aggregate over age; recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_count_untraced_100": {
+      "label": "zk-trace count — COUNT aggregate over age, untraced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "COUNT aggregate over age; default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_distinct_traced_100": {
+      "label": "zk-trace distinct — DISTINCT projection over city, traced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "DISTINCT projection over city; recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_distinct_untraced_100": {
+      "label": "zk-trace distinct — DISTINCT projection over city, untraced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "DISTINCT projection over city; default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_filter_traced_100": {
+      "label": "zk-trace filter — BGP + numeric FILTER(?a > 50), traced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP + numeric FILTER(?a > 50); recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_filter_untraced_100": {
+      "label": "zk-trace filter — BGP + numeric FILTER(?a > 50), untraced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "BGP + numeric FILTER(?a > 50); default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_optional_traced_100": {
+      "label": "zk-trace optional — left join (OPTIONAL follows), traced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "left join (OPTIONAL follows); recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_optional_untraced_100": {
+      "label": "zk-trace optional — left join (OPTIONAL follows), untraced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "left join (OPTIONAL follows); default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_union_traced_100": {
+      "label": "zk-trace union — UNION of two single-pattern arms, traced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "UNION of two single-pattern arms; recorder armed + drained (proving path) (criterion mean)",
+      "mode": "traced",
+      "unit": "µs"
+    },
+    "zk_trace_100entities_union_untraced_100": {
+      "label": "zk-trace union — UNION of two single-pattern arms, untraced, 100 entities",
+      "suite": "Zero-knowledge",
+      "dataset": "synthetic social graph (WatDiv-flavoured, ~9 triples/entity), generated in-bench",
+      "query": "UNION of two single-pattern arms; default execution (no recorder) (criterion mean)",
+      "mode": "untraced",
+      "unit": "µs"
     }
   }
 }

--- a/bench/zk/criterion_harvest.py
+++ b/bench/zk/criterion_harvest.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Criterion -> github-action-benchmark TSV harvester for the ZK benches
+# (sq dashboard-data-feed). Walks a criterion output tree and prints one
+# `<metric_name>\t<unit>\t<value>` line per benchmark, so scripts/ci-bench.sh can
+# `add` the ZK timing series into the customSmallerIsBetter feed (smaller-is-better:
+# the value is the criterion MEAN point estimate, converted to microseconds).
+#
+# Both ZK criterion suites (bench/zk commitment pipeline, bench/zk-trace per-operator
+# capture) are STANDALONE cargo projects whose `cargo bench` writes
+#   target/criterion/<group>/<bench_fn>/<param>/new/estimates.json
+# with mean.point_estimate in NANOSECONDS. Criterion sanitises any `/` inside the
+# group/bench-id into `_`, so the relative path components ARE the metric tokens.
+#
+# Usage:
+#   criterion_harvest.py <criterion_dir> <metric_prefix>
+#     <criterion_dir>  target/criterion of a built+run ZK bench project
+#     <metric_prefix>  e.g. "zk_commit" or "zk_trace" — the leading token MUST be
+#                      `zk` so the dashboard's Zero-knowledge family prefix routing
+#                      (familyOf: name.split('_')[0]) buckets the metric correctly.
+#
+# Emits `<prefix>_<path tokens>_us`  unit=us  value=<mean ns / 1000>. Deterministic
+# key order (sorted) so re-runs diff cleanly. NON-CANONICAL timing (wall-clock; the
+# value tracks a cross-commit trend on the dashboard, it is NOT a gate).
+import json
+import os
+import re
+import sys
+
+
+def slug(s):
+    # path component -> metric token: lowercase, non-alnum collapsed to `_`.
+    return re.sub(r"[^a-z0-9]+", "_", s.lower()).strip("_")
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.stderr.write("usage: criterion_harvest.py <criterion_dir> <metric_prefix>\n")
+        return 0  # absent/empty tree is not an error — the suite is just skipped.
+    root, prefix = sys.argv[1], sys.argv[2]
+    if not os.path.isdir(root):
+        return 0
+    rows = {}
+    for dirpath, _dirs, files in os.walk(root):
+        if "estimates.json" not in files:
+            continue
+        # we only want the freshly-measured estimates (…/new/estimates.json), not …/base.
+        if os.path.basename(dirpath) != "new":
+            continue
+        rel = os.path.relpath(os.path.dirname(dirpath), root)
+        # rel = "<group>/<bench_fn>/<param>" (criterion already flattened internal `/`).
+        tokens = [slug(p) for p in rel.split(os.sep) if slug(p)]
+        if not tokens:
+            continue
+        try:
+            with open(os.path.join(dirpath, "estimates.json")) as fh:
+                est = json.load(fh)
+            mean_ns = float(est["mean"]["point_estimate"])
+        except (OSError, ValueError, KeyError):
+            continue
+        name = "%s_%s_us" % (prefix, "_".join(tokens))
+        rows[name] = round(mean_ns / 1000.0, 3)  # ns -> us
+    for name in sorted(rows):
+        sys.stdout.write("%s\tus\t%s\n" % (name, rows[name]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -635,6 +635,70 @@ else
   echo "note: vector skipped (cargo not on PATH or $VECTOR_RUN missing)" >&2
 fi
 
+# [OPUS-4.8] ZERO-KNOWLEDGE family (sq dashboard-data-feed) — feeds the dashboard's
+# Zero-knowledge family (FAMILIES key `zk`, #253) so its rows show real data instead of
+# "not yet reported". EVERY ZK metric name leads with the token `zk` so the dashboard's
+# prefix routing (familyOf: name.split('_')[0]) buckets it into the ZK family. Three feeds,
+# each grounded in an EXISTING bench (bench/benchmarks.toml zk-* registrations) — nothing
+# invented:
+#
+#  1. zk_compose_<member>_gates  — DETERMINISTIC ultra_honk circuit gate counts for the
+#     zk/compose circuit family. The headline ZK measurement. `bb gates` is the ground
+#     truth (noir-optimisation SKILL §) but needs nargo+bb (NOT installed in CI), so we
+#     harvest the COMMITTED, reproducible bench/zk-compose/gate_counts_latest.json (a fixed
+#     toolchain pins it; re-measure with bench/zk-compose/scripts/gate_counts.sh). Gate
+#     counts are toolchain-deterministic, so the committed JSON is a faithful per-commit
+#     value — emitted on EVERY tier (no toolchain guard). Trend-only/advisory here (NOT in
+#     scripts/perf-gate.py); a tightening is tracked on the dashboard.
+#  2. zk_commit_*  — sparq-zk commitment-pipeline criterion means (RDFC10 canon, end-to-end
+#     commit, leaves+fold, Poseidon2) in µs. Standalone cargo project (bench/zk), cargo-only.
+#  3. zk_trace_*  — zk-trace per-operator capture overhead criterion means (traced vs
+#     untraced, per plan shape) in µs. Standalone cargo project (bench/zk-trace), cargo-only.
+#
+# (2)+(3) are WALL-CLOCK criterion runs, so — exactly like the FTS/vector/geo hooks — they
+# are PINNED to the MAIN/local tier (run on push-to-main or a LOCAL run where GITHUB_REF is
+# unset; SKIPPED on the PR tier) to keep the criterion build+run off per-PR CI. A short
+# measurement window (criterion --measurement-time) bounds the cost. NON-CANONICAL timing:
+# the values are cross-commit TREND signals, never hard-coded into docs/tests.
+# The zk-compose prove+verify suite (bench/zk-compose/scripts/prove_verify.sh) is wall-clock
+# and needs nargo+bb, so it has NO CI-runnable bench — intentionally NOT emitted here.
+ZK_GATES_JSON=bench/zk-compose/gate_counts_latest.json
+if [ -f "$ZK_GATES_JSON" ]; then
+  # Deterministic gate counts from the committed JSON -> zk_compose_<member>_gates.
+  while IFS=$'\t' read -r member gates; do
+    [ -n "${member:-}" ] && [ -n "${gates:-}" ] && add "zk_compose_${member}_gates" gates "$gates"
+  done < <(python3 -c "import json,sys
+d=json.load(open(sys.argv[1])).get('benchmarks',{})
+for k in sorted(d):
+    print('%s\t%s' % (k, d[k]['circuit_size']))" "$ZK_GATES_JSON")
+fi
+
+ZK_HARVEST=bench/zk/criterion_harvest.py
+ZK_REF="${GITHUB_REF:-}"
+if [ -n "$ZK_REF" ] && [ "$ZK_REF" != "refs/heads/main" ]; then
+  echo "note: zk criterion suites skipped (PR tier — criterion build/run is main-only, like the fts/vector hooks)" >&2
+elif command -v cargo >/dev/null 2>&1 && [ -f "$ZK_HARVEST" ]; then
+  # sparq-zk commitment-pipeline throughput (bench/zk; standalone cargo project).
+  if (cd bench/zk && cargo bench -q -- --warm-up-time 0.5 --measurement-time 1 --sample-size 10) >/dev/null 2>"$TMP/zk.err"; then
+    while IFS=$'\t' read -r name unit value; do
+      [ -n "${name:-}" ] && [ -n "${value:-}" ] && add "$name" "${unit:-us}" "$value"
+    done < <(python3 "$ZK_HARVEST" bench/zk/target/criterion zk)
+  else
+    echo "ERROR: zk commit bench failed" >&2; cat "$TMP/zk.err" >&2 || true; exit 1
+  fi
+  # zk-trace per-operator capture overhead (bench/zk-trace; standalone cargo project,
+  # sparq-engine built WITH the non-default `zk` feature).
+  if (cd bench/zk-trace && cargo bench -q -- --warm-up-time 0.5 --measurement-time 1 --sample-size 10) >/dev/null 2>"$TMP/zkt.err"; then
+    while IFS=$'\t' read -r name unit value; do
+      [ -n "${name:-}" ] && [ -n "${value:-}" ] && add "$name" "${unit:-us}" "$value"
+    done < <(python3 "$ZK_HARVEST" bench/zk-trace/target/criterion zk)
+  else
+    echo "ERROR: zk-trace bench failed" >&2; cat "$TMP/zkt.err" >&2 || true; exit 1
+  fi
+else
+  echo "note: zk criterion suites skipped (cargo not on PATH or $ZK_HARVEST missing)" >&2
+fi
+
 # RDFS inference (seconds) — instance-heavy: SCALE individuals under a depth-20 class hierarchy.
 { echo '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .'; echo '@prefix : <http://ex/> .'
   for k in $(seq 0 19); do echo ":c$k rdfs:subClassOf :c$((k+1)) ."; done

--- a/scripts/gen-metric-labels.py
+++ b/scripts/gen-metric-labels.py
@@ -522,6 +522,81 @@ def build():
         "mode": "deficit", "unit": "fixtures",
     }
 
+    # 14) ZERO-KNOWLEDGE family (sq dashboard-data-feed; ci-bench ZK hooks). EVERY ZK metric
+    # name leads with the token `zk` so the dashboard's Zero-knowledge family prefix routing
+    # buckets it. Three feeds, each grounded in an EXISTING bench (bench/benchmarks.toml zk-*):
+    #   - zk_compose_<member>_gates : DETERMINISTIC ultra_honk circuit gate counts harvested
+    #     from the committed bench/zk-compose/gate_counts_latest.json (members FIXED in
+    #     bench/zk-compose/scripts/gate_counts.sh). The headline ZK measurement.
+    #   - zk_canon_/zk_commit_<shape>_<n> : sparq-zk commitment-pipeline criterion MEANS (µs)
+    #     from bench/zk/benches/zk_throughput.rs (canon + end-to-end commit, shapes iri/bnode
+    #     at n=64/256/1024; commit also has leaves+fold/<n>; plus poseidon2 permutation/hash40).
+    #   - zk_trace_<n>entities_<shape>_<arm> : zk-trace per-operator capture overhead criterion
+    #     MEANS (µs) from bench/zk-trace/benches/trace_overhead.rs (8 plan shapes x traced/
+    #     untraced at n=100/1000 entities). Wall-clock; trend-only (advisory), never a gate.
+    # The metric STEMS here MUST match what scripts/ci-bench.sh emits (criterion path tokens)
+    # so the gen-metric-labels --check drift gate stays green.
+    ZK_GATE_MEMBERS = [
+        "scan_k1_n16_r4", "scan_k2_n16_r8", "scan_k2_n64_r8",
+        "filter_int_d1", "filter_int_d2", "filter_int_d4", "filter_f64",
+        "join_eq_na16_nb16",
+    ]
+    ZK_GATES_DS = "compiled Noir circuits (zk/compose, nargo compile --workspace); bb gates -s ultra_honk"
+    for m in ZK_GATE_MEMBERS:
+        labels["zk_compose_%s_gates" % m] = {
+            "label": "zk/compose %s — ultra_honk circuit gate count" % m,
+            "suite": "Zero-knowledge", "dataset": ZK_GATES_DS,
+            "query": "deterministic circuit_size (bb gates); smaller is better",
+            "mode": "gates", "unit": "gates",
+        }
+    ZK_COMMIT_DS = ("synthetic graph shapes generated in-bench (iri = all-ground; "
+                    "bnode = bnode chain), credential scale")
+    for n in (64, 256, 1024):
+        for shape in ("iri", "bnode"):
+            labels["zk_canon_%s_%d" % (shape, n)] = {
+                "label": "sparq-zk RDFC10 canon — %s graph, %d triples" % (shape, n),
+                "suite": "Zero-knowledge", "dataset": ZK_COMMIT_DS,
+                "query": "RDFC-1.0 canonicalisation (criterion mean)", "mode": "canon", "unit": "µs"}
+            labels["zk_commit_%s_%d" % (shape, n)] = {
+                "label": "sparq-zk end-to-end commit — %s graph, %d triples" % (shape, n),
+                "suite": "Zero-knowledge", "dataset": ZK_COMMIT_DS,
+                "query": "RDFC10 + leaf encode + Poseidon2 fold (criterion mean)",
+                "mode": "commit", "unit": "µs"}
+        labels["zk_commit_leaves_fold_%d" % n] = {
+            "label": "sparq-zk recommit (leaves+fold) — precomputed canon, %d triples" % n,
+            "suite": "Zero-knowledge", "dataset": ZK_COMMIT_DS,
+            "query": "leaf encode + Poseidon2 fold over precomputed canonical form (criterion mean)",
+            "mode": "commit", "unit": "µs"}
+    labels["zk_poseidon2_permutation"] = {
+        "label": "sparq-zk Poseidon2-BN254 permutation",
+        "suite": "Zero-knowledge", "dataset": "fixed 4-element BN254 state",
+        "query": "one Poseidon2 permutation (criterion mean)", "mode": "perm", "unit": "µs"}
+    labels["zk_poseidon2_hash40"] = {
+        "label": "sparq-zk Poseidon2-BN254 hash — 40 elements",
+        "suite": "Zero-knowledge", "dataset": "fixed 40-element input",
+        "query": "Poseidon2 sponge over 40 field elements (criterion mean)", "mode": "hash", "unit": "µs"}
+    ZK_TRACE_DS = ("synthetic social graph (WatDiv-flavoured, ~9 triples/entity), "
+                   "generated in-bench")
+    ZK_TRACE_SHAPES = {
+        "bgp_star": "BGP star join (age/name/city on ?s)",
+        "bgp_chain": "BGP chain join (follows then age)",
+        "bgp_triangle": "BGP triangle (3-way follows cycle)",
+        "filter": "BGP + numeric FILTER(?a > 50)",
+        "optional": "left join (OPTIONAL follows)",
+        "union": "UNION of two single-pattern arms",
+        "distinct": "DISTINCT projection over city",
+        "count": "COUNT aggregate over age",
+    }
+    for n in (100, 1000):
+        for shape, desc in ZK_TRACE_SHAPES.items():
+            for arm, arm_desc in (("traced", "recorder armed + drained (proving path)"),
+                                  ("untraced", "default execution (no recorder)")):
+                labels["zk_trace_%dentities_%s_%s_%d" % (n, shape, arm, n)] = {
+                    "label": "zk-trace %s — %s, %s, %d entities" % (shape, desc, arm, n),
+                    "suite": "Zero-knowledge", "dataset": ZK_TRACE_DS,
+                    "query": "%s; %s (criterion mean)" % (desc, arm_desc),
+                    "mode": arm, "unit": "µs"}
+
     return labels
 
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Follow-up to the **dashboard-data-feed** bead (label \`bench\`; the #253 ZK-family follow-up). The Zero-knowledge family rows added to the dashboard in **#253** showed *"not yet reported"* because no ZK metrics flowed through \`scripts/ci-bench.sh\`. This wires the **existing** ZK benches (registered in \`bench/benchmarks.toml\` as \`zk-*\`) to emit real \`customSmallerIsBetter\` metrics that \`ci-bench.sh\` picks up.

## ZK metrics that now flow
Every metric name leads with the token \`zk\` so it routes to the dashboard's Zero-knowledge family via the prefix fallback (\`familyOf\`: \`name.split('_')[0]\`).

| feed | metrics | source bench | tier |
|---|---|---|---|
| **Circuit gate counts** (headline) | \`zk_compose_<member>_gates\` (8 members) | committed \`bench/zk-compose/gate_counts_latest.json\` (zk-compose-gates) | **every tier** — deterministic, no toolchain needed |
| **Commitment pipeline** | \`zk_canon_*\`, \`zk_commit_*\`, \`zk_poseidon2_*\` (µs) | \`bench/zk\` criterion (zk-commit-throughput) | main/local |
| **Trace overhead** | \`zk_trace_<n>entities_<shape>_<arm>\` (µs, traced vs untraced) | \`bench/zk-trace\` criterion (zk-trace-overhead) | main/local |

- **Gate counts** are toolchain-deterministic (\`bb gates\` needs nargo+bb, absent in CI), so the committed JSON is a faithful per-commit value — emitted on **every** tier as the headline ZK measurement. The two **criterion** suites are wall-clock, so — like the existing fts/vector/geo hooks — they are pinned to the **main/local tier** (GITHUB_REF guard) to keep the build+run off per-PR CI; a short criterion \`--measurement-time\` bounds the cost.
- **NON-CANONICAL timing**: the criterion values are cross-commit TREND signals, never gates (not in \`perf-gate.py\`); no measured numbers are baked into any doc.

## Honest gap
The **zk-compose prove+verify** suite (\`bench/zk-compose/scripts/prove_verify.sh\`) needs nargo+bb and is wall-clock — it has **no CI-runnable bench**, so it is intentionally **not** emitted (no fabrication).

## What changed
- \`scripts/ci-bench.sh\` — three ZK hooks (gate-count harvest + two criterion suites), consistent with the operator/fts/vector hooks.
- \`bench/zk/criterion_harvest.py\` — new helper: walks a criterion tree, prints \`<name>\\tunit\\tvalue\` (mean ns → µs); both criterion hooks reuse it.
- \`scripts/gen-metric-labels.py\` + \`bench/dashboard/metric-labels.json\` — ZK label block; regenerated.
- Did **not** touch \`bench/dashboard/dashboard.js\` (held by #253).

## CI checks
- \`dashboard labels (lint + drift)\`: \`gen-metric-labels.py --check\` ✅, \`dashboard-smoke.js\` ✅, JSON valid ✅.
- Emitted names cross-checked against label keys: **57/57 matched, 0 unlabelled, 0 stale**.
- \`bash -n scripts/ci-bench.sh\` ✅; harvester graceful on absent criterion tree ✅; full ZK aggregation emits valid JSON ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)