### PR TITLE
fix(server): unregistered geof: IRI stays a hard engine error under --all-features

### DIFF
--- a/crates/sparq-server/tests/geo.rs
+++ b/crates/sparq-server/tests/geo.rs
@@ -115,18 +115,30 @@ async fn update_where_with_geof_filter() {
 #[tokio::test]
 async fn unregistered_geof_iri_is_still_an_engine_error() {
     let base = spawn().await;
-    // geof:buffer is not in the registry: the engine's hard unknown-function
+    // geof:gmlToWkt is NOT in the registry — geo registers the KNOWN geof:
+    // functions, not the whole geof: namespace, so an unregistered geof: IRI is
+    // still an unknown extension function. The engine's hard unknown-function
     // error surfaces as the server's 500 engine-error response, not a 200.
+    //
+    // (geof:buffer would NOT work here: it IS registered, so a wrong-arity call
+    // is a per-row expression error → 200, never a hard query error. This must
+    // be a genuinely unregistered IRI — see sparq-geo's
+    // `unregistered_geof_iri_stays_a_hard_error`.)
     let resp = reqwest::Client::new()
         .get(format!("{base}/sparql"))
         .query(&[(
             "query",
-            format!("{PREFIXES} SELECT ?s WHERE {{ ?s ex:loc ?g . FILTER(geof:buffer(?g, 1.0) > 0) }}"),
+            format!("{PREFIXES} SELECT ?s WHERE {{ ?s ex:loc ?g . FILTER(geof:gmlToWkt(?g) = ?g) }}"),
         )])
         .send()
         .await
         .unwrap();
     assert_eq!(resp.status(), 500);
+    // The server SANITIZES engine error strings (they can embed loaded-graph term
+    // text) down to a stable generic class message; the detailed
+    // "unsupported SPARQL function: …" cause goes only to the server log. So the
+    // 500 status is the load-bearing assertion that the unknown geof: IRI is a
+    // hard engine error, and the body is the generic sanitized class.
     let body = resp.text().await.unwrap();
-    assert!(body.contains("unsupported SPARQL function"), "got: {body}");
+    assert!(body.contains("query execution error"), "got: {body}");
 }

--- a/crates/sparq-server/tests/service_allowlist.rs
+++ b/crates/sparq-server/tests/service_allowlist.rs
@@ -104,12 +104,16 @@ async fn empty_allowlist_refuses_service_before_any_network_call() {
         .await
         .unwrap();
     // A non-SILENT SERVICE that is refused fails the query — the server maps an engine
-    // execution error to a non-2xx. (500 here; the body names the egress refusal.)
+    // execution error to a non-2xx (500 here). The egress/allowlist detail names the
+    // refused host, so the server SANITIZES it (see `sanitized_error`/`execution_error`
+    // in http.rs, #241): the body carries only the stable generic class, and the host
+    // detail goes to the server log. The non-2xx status plus the "no socket dialled"
+    // assertion below are the load-bearing proof of the strict pre-DNS refusal.
     assert!(!resp.status().is_success(), "blocked SERVICE must not 200; got {}", resp.status());
     let body = resp.text().await.unwrap().to_lowercase();
     assert!(
-        body.contains("egress") || body.contains("allowlist") || body.contains("service"),
-        "expected an egress/allowlist refusal in the body, got: {body}"
+        body.contains("query execution error"),
+        "expected the sanitized engine-error class in the body, got: {body}"
     );
     // The query has already returned; give any in-flight dial a brief window, then assert
     // the live listener accepted NOTHING — i.e. the refusal happened before any socket


### PR DESCRIPTION
> 🤖 SPARQ agent

Fixes the `bug,geo` bead: `unregistered_geof_iri_is_still_an_engine_error` FAILS under `--all-features` (geo on) — reproduces on `main`, surfaced by #251 and red on #244's CI-matrix `geo` leg.

## Root cause — test expectation, not engine behavior

The `geo` feature registers the **KNOWN** `geof:` functions (`distance`, the `sf*`/`eh*`/`rcc8*` relations, `relate`, `envelope`/`boundary`/`convexHull`, the set ops, `buffer`, `getSRID`) — **not** the whole `geof:` namespace. So an unregistered `geof:` IRI **should** still be the engine's hard unknown-function error (HTTP 500), exactly as with `geo` off. That semantic is correct and unchanged. The bug was in the test.

1. **Wrong probe IRI.** The test used `geof:buffer` as its "not in the registry" probe — but `buffer` **is** registered. With `geo` on, the 2-arg call hit `buffer`'s arity check, which returns `Err(..)` from the registry function; the engine treats that as a per-row **expression** error (row filtered), not a hard query error → **200**, not 500. (With `geo` off the IRI is genuinely unknown, so the test passed by accident.) Switched to `geof:gmlToWkt`, a genuinely unregistered `geof:` IRI — mirroring sparq-geo's own `unregistered_geof_iri_stays_a_hard_error`.

2. **Stale body assertion.** The test checked the raw engine string `"unsupported SPARQL function"`, which the server **intentionally sanitizes** (#241, sq-cz89/sq-j9zs — engine error strings can embed loaded-graph term text). The body now carries only the stable generic class `"query execution error"`; the detail goes to the server log. The **500 status** is the load-bearing proof that the unknown geof: IRI is a hard engine error.

## Companion fix — same #241 sanitization

The same sanitization had also regressed `service_allowlist`'s `empty_allowlist_refuses_service_before_any_network_call` (only compiled under `--all-features`/the federation feature, so it went red on the all-features matrix): it asserted the body names the egress/allowlist refusal, now withheld. Assert the sanitized class instead; the **non-2xx status** and the **"no socket dialled"** check remain the load-bearing proof of the strict pre-DNS refusal.

## Correct semantics chosen

An unregistered geo function IRI **is** an engine error even with `geo` on — geo registers the known geof: functions, not all geof: IRIs. The test was not weakened or deleted; it now genuinely exercises that invariant against the server's sanitized error contract.

## Verification (NON-CANONICAL timing — EC2 work box)

- `cargo test -p sparq-server --all-features` — green (previously-failing test passes)
- `cargo test -p sparq-server` (default) — green
- `cargo test -p sparq-server --features geo` — green (all 4 geo tests)
- `cargo clippy -p sparq-server --all-targets --all-features -- -D warnings` — clean

(Pre-existing, unrelated: `sparq-reason` has a separate clippy failure and there is deferred workspace-wide fmt drift — both predate this branch and are out of scope here.)

Unblocks #244's geo matrix leg.