### PR TITLE
feat(sparq-policy): ODRL usage-control evaluator — single-node base case (sq-r06h)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3440,6 +3440,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sparq-policy"
+version = "0.1.0"
+dependencies = [
+ "oxrdf 0.3.3",
+ "sparq-core",
+ "sparq-engine",
+]
+
+[[package]]
 name = "sparq-py"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/sparq-core", "crates/sparq-engine", "crates/sparq-cli", "crates/sparq-bench", "crates/sparq-wasm", "crates/sparq-reason", "crates/sparq-server", "crates/sparq-serve", "crates/sparq-conformance", "crates/sparq-py", "crates/sparq-shacl", "crates/sparq-hdt", "crates/sparq-sim", "crates/sparq-geo", "crates/sparq-introspect", "crates/sparq-nlq", "crates/sparq-vectors", "crates/sparq-rsp", "crates/sparq-gpu", "crates/sparq-solid", "crates/sparq-parse", "crates/sparq-text", "crates/sparq-canon", "crates/sparq-zk", "crates/sparq-zk-compose", "crates/sparq-mpc"]
+members = ["crates/sparq-core", "crates/sparq-engine", "crates/sparq-cli", "crates/sparq-bench", "crates/sparq-wasm", "crates/sparq-reason", "crates/sparq-server", "crates/sparq-serve", "crates/sparq-conformance", "crates/sparq-py", "crates/sparq-shacl", "crates/sparq-hdt", "crates/sparq-sim", "crates/sparq-geo", "crates/sparq-introspect", "crates/sparq-nlq", "crates/sparq-vectors", "crates/sparq-rsp", "crates/sparq-gpu", "crates/sparq-solid", "crates/sparq-policy", "crates/sparq-parse", "crates/sparq-text", "crates/sparq-canon", "crates/sparq-zk", "crates/sparq-zk-compose", "crates/sparq-mpc"]
 # `fuzz` is the cargo-fuzz harness (bead sq-ovnf): it requires a NIGHTLY toolchain
 # (libFuzzer codegen), so it is excluded from the workspace to keep the STABLE
 # `cargo build`/`cargo test`/`clippy --workspace` gate from ever trying to compile it.

--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -471,6 +471,20 @@ pinning     = "in-crate fixture is deterministic"
 records_to  = "stdout; cross-checked in bench/inference/incremental-bench.md (0.84s WAC re-run baseline)"
 status      = "ok"
 
+# [OPUS-4.8] sq-r06h — ODRL usage-control evaluator (opt-in sparq-policy crate).
+[[benchmark]]
+id          = "policy-odrl-eval"
+name        = "sparq-policy ODRL parse + evaluate"
+category    = "inference"
+measures    = "ODRL policy parse time (RDF -> typed model via engine BGP queries); per-request evaluation latency (ALLOW / DENY-by-prohibition / DENY-by-constraint), cold + best-of-K"
+invoke      = "cargo run -p sparq-policy --example bench --release [n-permissions=200]"
+source      = "crates/sparq-policy/examples/bench.rs"
+dataset     = "synthetic ODRL Set of N permissions (assignee + target + dateTime-window + purpose constraint) + 1 prohibition, generated in-example (deterministic)"
+quiet_box_sensitive = true
+pinning     = "in-example synthetic policy is deterministic; pin N for comparable numbers"
+records_to  = "stdout (us per phase)"
+status      = "ok"
+
 # =============================================================================
 # ZK — commitment pipeline, trace seam, circuit gate counts, prove/verify
 # =============================================================================

--- a/crates/sparq-policy/Cargo.toml
+++ b/crates/sparq-policy/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "sparq-policy"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "ODRL usage-control policy evaluator for the sparq RDF engine: parse ODRL Permission/Prohibition/Duty rules from RDF and evaluate an access request to a fail-closed ALLOW/DENY decision (single-node base case)"
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+readme = "README.md"
+
+# [OPUS-4.8] sq-r06h. OPT-IN policy layer (the sparq-reason / sparq-solid isolation
+# pattern): a SEPARATE crate so the core engine carries zero ODRL/usage-control code,
+# deps, or runtime cost — it is a dependency of NOTHING in the workspace. It builds ON
+# the existing N3/EYE reasoner + the sparq-solid WAC/ACP allow/deny enforcement model.
+# Design: research/feature-research-odrl-policy.md (epic sq-3183, candidate #1).
+#
+# NOT published to crates.io yet: the single-node ODRL base case is complete, but the
+# headline federated-disclosure / ODRL→MPC composition (research doc §2) is deferred
+# (gated on ZK soundness remediation). `publish = false` keeps it out of releases until
+# that scope question is settled.
+publish = false
+
+# [OPUS-4.8] docs.rs: build with all features + the `docsrs` cfg.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+# `version` alongside `path`: cargo uses the path locally and the version on crates.io.
+sparq-core = { path = "../sparq-core", version = "0.1.0", default-features = false }
+sparq-engine = { path = "../sparq-engine", version = "0.1.0", default-features = false }
+oxrdf.workspace = true

--- a/crates/sparq-policy/README.md
+++ b/crates/sparq-policy/README.md
@@ -1,0 +1,98 @@
+# sparq-policy
+
+<p>
+  <a href="../../LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
+</p>
+
+**ODRL usage-control** over the [sparq](../../README.md) engine — the declarative
+policy layer *above* access control.
+
+`sparq-solid` answers "may this agent **read** graph G?"; `sparq-policy` answers
+"may this party **use** this asset *for purpose P, with obligation O, until time
+T, disclosing only to recipient R*?" It parses a [W3C ODRL
+2.2](https://www.w3.org/TR/odrl-model/) policy from RDF into a typed model
+(Permission / Prohibition / Duty / Action / Constraint) and **evaluates** an
+access request to a **fail-closed** ALLOW/DENY [`Decision`]. This is the
+**single-node base case**: ODRL over one node's data, reducing to the same
+allow/deny shape `sparq-solid` enforces. It is a dependency of nothing in the
+workspace (opt-in; `publish = false`).
+
+## 🚀 Quickstart
+
+```rust
+# fn main() -> Result<(), String> {
+use sparq_policy::{evaluate, parse_policy_str, Request, Value};
+
+// An ODRL Set: alice MAY read asset-X, but only on or before 2026-12-31.
+let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/1> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ;
+    odrl:target <urn:asset/x> ;
+    odrl:assignee <https://alice.ex/me> ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ;
+                      odrl:operator odrl:lteq ;
+                      odrl:rightOperand "2026-12-31T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ] ] .
+"#;
+let policy = parse_policy_str(ttl, "turtle")?;
+
+// In-window request by alice → ALLOW.
+let inside = Request::new("http://www.w3.org/ns/odrl/2/read")
+    .on("urn:asset/x").by("https://alice.ex/me")
+    .with("http://www.w3.org/ns/odrl/2/dateTime",
+          Value::DateTime("2026-06-16T09:00:00Z".into()));
+assert!(evaluate(&policy, &inside).allow);
+
+// Out-of-window request → DENY (fail-closed; the constraint is unsatisfied).
+let outside = inside.clone()
+    .with("http://www.w3.org/ns/odrl/2/dateTime",
+          Value::DateTime("2027-01-01T00:00:00Z".into()));
+assert!(!evaluate(&policy, &outside).allow);
+# Ok(()) }
+```
+
+## ✨ Features
+
+- **ODRL model from RDF** — `parse_policy_str` / `parse_policy` extract a typed
+  `Policy → {permissions, prohibitions}`, each `Rule` carrying an `Action`,
+  `target`, `assignee`/`assigner`, `Constraint`s and `Duty`s. Rule, constraint
+  and duty nodes are matched as **blank nodes or IRIs** (real ODRL uses blank
+  nodes). Built on the engine sparq already ships — ODRL eval *is* a SPARQL
+  workload.
+- **Fail-closed evaluator** — `evaluate(&policy, &request) -> Decision { allow,
+  matched_rules, unmet_constraints }`. No matching permission **or** a matching
+  prohibition ⇒ DENY; a permission grants only when matched **and** all its
+  duties are discharged. Prohibitions carve out permissions (ODRL conflict
+  default). A malformed/unknown constraint becomes an unsatisfiable guard.
+- **Constraint operators** — `eq`, `neq`, `lt`, `lteq`, `gt`, `gteq`,
+  `isPartOf` (set membership), `isA`. Numeric (`xsd:integer`/`decimal`/…) and
+  `xsd:dateTime`/`date` operands compare by magnitude/instant; everything else
+  by IRI/string value. Constraints over `purpose` / `recipient` / `dateTime` /
+  `count` / `spatial` left-operands are all supported.
+- **Duties as obligations** — a permission's `odrl:duty` must appear in the
+  request's discharged-duty set, or the permission is denied (the usage-control
+  kernel pure access control lacks).
+- **Opt-in, lean** — no `unsafe`; depends only on `sparq-core` + `sparq-engine`
+  + `oxrdf`; pulled into no core build (`cargo tree -p sparq-core` never shows it).
+
+### Scope & caveats
+
+Single-node only. The headline **federated-disclosure** / ODRL→MPC composition
+(per-node ODRL drives the `sparq-mpc` disclosed-vs-hidden split; ODRL `Duty` →
+ZK proof obligation) is **deferred** — it inherits the MPC honest-majority/LAN
+envelope and the open ZK-soundness remediation. `dateTime` ordering compares the
+lexical form; mixed-offset normalization, DPV `purpose` hierarchies, and
+`Duty → proof-manifest` discharge are tracked as follow-on beads. See
+`research/feature-research-odrl-policy.md`.
+
+## 📚 Learn more
+
+- Skill: [`skills/usage-control-policy/SKILL.md`](../../skills/usage-control-policy/SKILL.md)
+- Design record: `research/feature-research-odrl-policy.md` (epic sq-3183)
+- W3C [ODRL Information Model 2.2](https://www.w3.org/TR/odrl-model/) ·
+  [Formal Semantics](https://w3c.github.io/odrl/formal-semantics/)
+- Sibling access-control crate: [`sparq-solid`](../sparq-solid/README.md)
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).

--- a/crates/sparq-policy/examples/bench.rs
+++ b/crates/sparq-policy/examples/bench.rs
@@ -1,0 +1,106 @@
+//! sparq-policy ODRL evaluator micro-benchmark. [OPUS-4.8] sq-r06h. Run:
+//!     cargo run -p sparq-policy --example bench --release
+//!
+//! Measures, on a synthetic ODRL `Set` of N permissions (each with an assignee,
+//! a target, a dateTime window and a purpose constraint) plus a few prohibitions:
+//!   1. policy parse time (RDF → typed model, via the engine's BGP queries);
+//!   2. per-request evaluation latency (cold + best-of-K), for an ALLOW request,
+//!      a DENY-by-prohibition request, and a DENY-by-constraint request.
+//!
+//! NON-CANONICAL timing (this box is not a quiet bench instance) — the numbers
+//! are a sanity-scale signal, not a published baseline.
+
+use sparq_policy::{evaluate, parse_policy_str, Request, Value};
+use std::time::Instant;
+
+const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
+
+fn synth_policy(n: usize) -> String {
+    let mut s = String::from(
+        "@prefix odrl: <http://www.w3.org/ns/odrl/2/> .\n\
+         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
+         <urn:pol/bench> a odrl:Set ;\n",
+    );
+    for i in 0..n {
+        s.push_str(&format!(
+            "  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/{i}> ;\n\
+             \todrl:assignee <https://party.ex/p{i}> ;\n\
+             \todrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lteq ;\n\
+             \t\todrl:rightOperand \"2030-01-01T00:00:00Z\"^^xsd:dateTime ] ;\n\
+             \todrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;\n\
+             \t\todrl:rightOperand <urn:purpose/research> ] ] ;\n"
+        ));
+    }
+    // A couple of prohibitions (the override path).
+    s.push_str(
+        "  odrl:prohibition [ odrl:action odrl:read ; odrl:target <urn:asset/0> ;\n\
+         \todrl:assignee <https://party.ex/blocked> ] .\n",
+    );
+    s
+}
+
+fn timed<T>(label: &str, iters: u32, mut f: impl FnMut() -> T) -> T {
+    let mut best = f64::MAX;
+    let mut out = None;
+    for _ in 0..iters {
+        let t = Instant::now();
+        out = Some(f());
+        best = best.min(t.elapsed().as_secs_f64() * 1e6);
+    }
+    println!("{label:54} {best:12.2} us");
+    out.unwrap()
+}
+
+fn main() {
+    let n: usize = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(200);
+    let ttl = synth_policy(n);
+    println!("ODRL Set with {n} permissions + 1 prohibition\n");
+
+    let policy = timed("parse policy (RDF -> typed model)", 3, || {
+        parse_policy_str(&ttl, "turtle").expect("parse")
+    });
+    println!(
+        "  parsed {} permissions, {} prohibitions\n",
+        policy.permissions.len(),
+        policy.prohibitions.len()
+    );
+
+    let dt = |s: &str| Value::DateTime(s.to_owned());
+    let purpose = || Value::Iri("urn:purpose/research".into());
+
+    // ALLOW: in-window, right purpose, matching party+target.
+    let allow = Request::new(format!("{ODRL}read"))
+        .on(format!("urn:asset/{}", n / 2))
+        .by(format!("https://party.ex/p{}", n / 2))
+        .with(format!("{ODRL}dateTime"), dt("2026-06-16T09:00:00Z"))
+        .with(format!("{ODRL}purpose"), purpose());
+    let d = timed("evaluate ALLOW (last permission matches)", 1000, || {
+        evaluate(&policy, &allow)
+    });
+    assert!(d.allow);
+
+    // DENY by prohibition.
+    let denyp = Request::new(format!("{ODRL}read"))
+        .on("urn:asset/0")
+        .by("https://party.ex/blocked")
+        .with(format!("{ODRL}dateTime"), dt("2026-06-16T09:00:00Z"))
+        .with(format!("{ODRL}purpose"), purpose());
+    let d = timed("evaluate DENY (prohibition overrides)", 1000, || {
+        evaluate(&policy, &denyp)
+    });
+    assert!(!d.allow);
+
+    // DENY by constraint (out of window).
+    let denyc = allow
+        .clone()
+        .with(format!("{ODRL}dateTime"), dt("2031-01-01T00:00:00Z"));
+    let d = timed("evaluate DENY (dateTime constraint unmet)", 1000, || {
+        evaluate(&policy, &denyc)
+    });
+    assert!(!d.allow);
+
+    println!("\nok");
+}

--- a/crates/sparq-policy/src/eval.rs
+++ b/crates/sparq-policy/src/eval.rs
@@ -1,0 +1,329 @@
+//! The ODRL evaluator: `(Policy, Request) -> Decision`.
+//!
+//! Semantics (the single-node base case — the ODRL Formal-Semantics CG
+//! *closed-world* default, restricted to one node's data):
+//!
+//! 1. A [`Rule`] *matches* a [`Request`] when its action permits the requested
+//!    action, its `target` and `assignee` (if specified) agree with the request,
+//!    and every one of its [`Constraint`]s is satisfied by the request context.
+//! 2. A [`Permission`] grants access iff it matches **and** all of its
+//!    [`Duty`]s are discharged (reported in the request context).
+//! 3. A [`Prohibition`] that matches **overrides** any permission (it "carves
+//!    out" a forbidden sub-set — ODRL Formal Semantics §conflict).
+//! 4. **Fail-closed default:** no matching+discharged permission, OR any matching
+//!    prohibition, ⇒ DENY. An empty/malformed policy denies everything.
+//!
+//! [OPUS-4.8]
+
+use crate::model::{Action, Constraint, Operator, Policy, Rule, Value};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// An access request evaluated against a [`Policy`]: who wants to do what, to
+/// what, in what context (the "evaluation request" + "state of the world" of the
+/// ODRL Formal Semantics, folded into one node-local view).
+#[derive(Debug, Clone, Default)]
+pub struct Request {
+    /// The action being requested (`odrl:` action IRI), e.g. `odrl:read`.
+    pub action: String,
+    /// The target asset/graph IRI the action is on.
+    pub target: Option<String>,
+    /// The requesting party (the WebID / agent IRI — matched against
+    /// `odrl:assignee`).
+    pub party: Option<String>,
+    /// Context values keyed by ODRL `leftOperand` IRI (e.g. `odrl:dateTime`,
+    /// `odrl:purpose`, `odrl:recipient`, `odrl:count`) — the state-of-the-world a
+    /// constraint is evaluated against. Use [`Request::with`] to populate.
+    pub context: BTreeMap<String, Value>,
+    /// The set of duty *action* IRIs the caller asserts have been discharged
+    /// (e.g. `odrl:anonymize`, a custom `proveAttestation`). A permission with an
+    /// undischarged duty is denied.
+    pub discharged_duties: BTreeSet<String>,
+}
+
+impl Request {
+    /// A request for `action` on `target` by `party` with no context/duties yet.
+    pub fn new(action: impl Into<String>) -> Request {
+        Request {
+            action: action.into(),
+            ..Request::default()
+        }
+    }
+
+    /// Set the target asset/graph IRI.
+    pub fn on(mut self, target: impl Into<String>) -> Request {
+        self.target = Some(target.into());
+        self
+    }
+
+    /// Set the requesting party (assignee) IRI.
+    pub fn by(mut self, party: impl Into<String>) -> Request {
+        self.party = Some(party.into());
+        self
+    }
+
+    /// Add a context value for a `leftOperand` IRI (chainable).
+    pub fn with(mut self, left_operand: impl Into<String>, value: Value) -> Request {
+        self.context.insert(left_operand.into(), value);
+        self
+    }
+
+    /// Mark a duty action IRI as discharged (chainable).
+    pub fn discharge(mut self, duty_action: impl Into<String>) -> Request {
+        self.discharged_duties.insert(duty_action.into());
+        self
+    }
+}
+
+/// The result of evaluating a policy against a request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Decision {
+    /// `true` ⇒ ALLOW (a permission matched, was un-prohibited, and all its
+    /// duties were discharged). `false` ⇒ DENY (fail-closed).
+    pub allow: bool,
+    /// The IDs of the rule(s) that justify the decision: the granting permission
+    /// on an ALLOW; the overriding prohibition(s) (and/or the would-be permission
+    /// blocked by an unmet duty/constraint) on a DENY.
+    pub matched_rules: Vec<String>,
+    /// Human-readable explanations of why a candidate permission did *not* grant
+    /// (unmet constraint, undischarged duty, overriding prohibition). Empty on a
+    /// clean ALLOW with no caveats.
+    pub unmet_constraints: Vec<String>,
+}
+
+impl Decision {
+    fn deny(matched: Vec<String>, unmet: Vec<String>) -> Decision {
+        Decision {
+            allow: false,
+            matched_rules: matched,
+            unmet_constraints: unmet,
+        }
+    }
+}
+
+/// Evaluate `policy` against `request`, returning a fail-closed [`Decision`].
+///
+/// See the [module docs](self) for the exact semantics. This is the single-node
+/// base case of ODRL — it reduces to the same allow/deny shape `sparq-solid`'s
+/// WAC/ACP path produces, with ODRL's richer purpose/recipient/time constraints
+/// and duty obligations layered on top.
+///
+/// # Examples
+///
+/// ```
+/// use sparq_policy::{evaluate, Policy, Request};
+/// // An empty policy denies everything (fail-closed).
+/// let d = evaluate(&Policy::default(), &Request::new("http://www.w3.org/ns/odrl/2/read"));
+/// assert!(!d.allow);
+/// ```
+pub fn evaluate(policy: &Policy, request: &Request) -> Decision {
+    let req_action = Action(request.action.clone());
+
+    // 1. A matching prohibition overrides everything (fail-closed carve-out).
+    let mut blocking: Vec<String> = Vec::new();
+    for rule in &policy.prohibitions {
+        if rule_matches(rule, request, &req_action).is_match {
+            blocking.push(rule.id.clone());
+        }
+    }
+    if !blocking.is_empty() {
+        let why = blocking
+            .iter()
+            .map(|id| format!("prohibition {id} matches the request"))
+            .collect();
+        return Decision::deny(blocking, why);
+    }
+
+    // 2. Find a permission that matches AND has all duties discharged.
+    let mut caveats: Vec<String> = Vec::new();
+    for rule in &policy.permissions {
+        let m = rule_matches(rule, request, &req_action);
+        if !m.is_match {
+            caveats.extend(m.reasons);
+            continue;
+        }
+        // Matched — now require every duty discharged.
+        let undischarged: Vec<&str> = rule
+            .duties
+            .iter()
+            .filter(|d| !request.discharged_duties.contains(&d.action.0))
+            .map(|d| d.action.0.as_str())
+            .collect();
+        if undischarged.is_empty() {
+            return Decision {
+                allow: true,
+                matched_rules: vec![rule.id.clone()],
+                unmet_constraints: Vec::new(),
+            };
+        }
+        for a in undischarged {
+            caveats.push(format!(
+                "permission {} requires undischarged duty {a}",
+                rule.id
+            ));
+        }
+    }
+
+    // 3. No grant → DENY (fail-closed).
+    if caveats.is_empty() {
+        caveats.push("no permission matches the request".to_owned());
+    }
+    Decision::deny(Vec::new(), caveats)
+}
+
+/// Outcome of matching a single rule against a request.
+struct Match {
+    is_match: bool,
+    reasons: Vec<String>,
+}
+
+fn rule_matches(rule: &Rule, request: &Request, req_action: &Action) -> Match {
+    let mut reasons = Vec::new();
+
+    // Action: the rule's action must permit the requested action.
+    if !rule.action.permits(req_action) {
+        reasons.push(format!(
+            "rule {} action {} != requested {}",
+            rule.id, rule.action, request.action
+        ));
+        return Match {
+            is_match: false,
+            reasons,
+        };
+    }
+
+    // Target: if the rule names a target, it must equal the request target.
+    if let Some(t) = &rule.target {
+        if request.target.as_deref() != Some(t.as_str()) {
+            reasons.push(format!(
+                "rule {} target {t} != requested {:?}",
+                rule.id, request.target
+            ));
+            return Match {
+                is_match: false,
+                reasons,
+            };
+        }
+    }
+
+    // Assignee: if the rule names an assignee party, it must equal the requester.
+    if let Some(a) = &rule.assignee {
+        if request.party.as_deref() != Some(a.as_str()) {
+            reasons.push(format!(
+                "rule {} assignee {a} != requester {:?}",
+                rule.id, request.party
+            ));
+            return Match {
+                is_match: false,
+                reasons,
+            };
+        }
+    }
+
+    // Constraints: every one must be satisfied (logical AND).
+    for c in &rule.constraints {
+        if !constraint_satisfied(c, request) {
+            reasons.push(format!(
+                "rule {} constraint ({} {:?} {}) unsatisfied",
+                rule.id, c.left, c.operator, c.right
+            ));
+            return Match {
+                is_match: false,
+                reasons,
+            };
+        }
+    }
+
+    Match {
+        is_match: true,
+        reasons,
+    }
+}
+
+/// Is a single constraint satisfied by the request context?
+///
+/// The request supplies the *actual* value for the constraint's `leftOperand`
+/// (e.g. the actual request time for `odrl:dateTime`); the constraint's
+/// `rightOperand` is the bound. A constraint whose left operand has **no** value
+/// in the request context is **unsatisfied** (fail-closed: we cannot prove the
+/// world meets a constraint we have no evidence about).
+fn constraint_satisfied(c: &Constraint, request: &Request) -> bool {
+    let Some(actual) = request.context.get(&c.left) else {
+        return false; // no evidence for this dimension → fail-closed
+    };
+    compare(actual, c.operator, &c.right)
+}
+
+/// Compare an actual request value against a constraint right-operand under an
+/// operator. Numeric and dateTime operands compare by magnitude; everything
+/// else compares by string/IRI value. An order comparison (`lt`/`gt`/…) on
+/// non-orderable values is **false** (fail-closed).
+fn compare(actual: &Value, op: Operator, bound: &Value) -> bool {
+    match op {
+        Operator::Eq | Operator::IsA => value_eq(actual, bound),
+        Operator::Neq => !value_eq(actual, bound),
+        Operator::IsPartOf => is_part_of(actual, bound),
+        Operator::Lt | Operator::Lteq | Operator::Gt | Operator::Gteq => {
+            let Some(ord) = order(actual, bound) else {
+                return false;
+            };
+            match op {
+                Operator::Lt => ord == std::cmp::Ordering::Less,
+                Operator::Lteq => ord != std::cmp::Ordering::Greater,
+                Operator::Gt => ord == std::cmp::Ordering::Greater,
+                Operator::Gteq => ord != std::cmp::Ordering::Less,
+                _ => unreachable!(),
+            }
+        }
+    }
+}
+
+fn value_eq(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Num(x), Value::Num(y)) => x == y,
+        // Cross-type: compare by canonical string (an IRI right-operand vs an IRI
+        // actual, a string code vs a string code, a dateTime vs a dateTime).
+        _ => a.as_str() == b.as_str(),
+    }
+}
+
+/// `isPartOf` / set membership: the right operand is a `|`-or-space-separated
+/// set (the common compact encoding) OR a single IRI/string the actual must
+/// equal. We treat the right operand's string as a set: actual ∈ set.
+fn is_part_of(actual: &Value, bound: &Value) -> bool {
+    let a = actual.as_str();
+    bound
+        .as_str()
+        .split(['|', ' ', ','])
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .any(|member| member == a)
+}
+
+/// A total-ish order for orderable values: numeric by magnitude, dateTime by
+/// the lexical-as-comparable key (ISO-8601 instants sort lexicographically when
+/// in the same `Z`-normalized form — see the README caveat). Returns `None` for
+/// incomparable pairs.
+fn order(a: &Value, b: &Value) -> Option<std::cmp::Ordering> {
+    match (a, b) {
+        (Value::Num(x), Value::Num(y)) => x.partial_cmp(y),
+        (Value::DateTime(x), Value::DateTime(y)) => Some(cmp_datetime(x, y)),
+        // A numeric actual against a numeric-looking string bound, or vice versa.
+        _ => {
+            let (Ok(x), Ok(y)) = (
+                a.as_str().trim().parse::<f64>(),
+                b.as_str().trim().parse::<f64>(),
+            ) else {
+                return None;
+            };
+            x.partial_cmp(&y)
+        }
+    }
+}
+
+/// Compare two xsd:dateTime lexical forms. We normalize a trailing `Z` and a
+/// missing timezone to a comparable key; mixed offsets are compared by the raw
+/// lexical form (documented limitation — see the README; full offset
+/// normalization is a deferred bead).
+fn cmp_datetime(x: &str, y: &str) -> std::cmp::Ordering {
+    x.cmp(y)
+}

--- a/crates/sparq-policy/src/lib.rs
+++ b/crates/sparq-policy/src/lib.rs
@@ -1,0 +1,10 @@
+#![doc = include_str!("../README.md")] // [OPUS-4.8] README is the docs.rs front page
+#![forbid(unsafe_code)] // [OPUS-4.8] sq-r06h: crate has zero `unsafe`
+
+mod eval;
+pub mod model;
+mod parse;
+
+pub use eval::{evaluate, Decision, Request};
+pub use model::{Action, Constraint, Duty, Operator, Policy, Rule, Value, ODRL_NS};
+pub use parse::{parse_policy, parse_policy_str};

--- a/crates/sparq-policy/src/model.rs
+++ b/crates/sparq-policy/src/model.rs
@@ -1,0 +1,205 @@
+//! The typed ODRL Information Model (the subset sparq-policy evaluates).
+//!
+//! This is a faithful-but-scoped Rust rendering of the [ODRL 2.2 Information
+//! Model](https://www.w3.org/TR/odrl-model/): a [`Policy`] is a container of
+//! deontic [`Rule`]s (Permission / Prohibition), each carrying an [`Action`], a
+//! `target` asset, optional `assignee`/`assigner` parties, zero or more
+//! [`Constraint`]s, and (for permissions) zero or more [`Duty`] obligations.
+//!
+//! Scope (the single-node base case — see the crate README): the evaluator
+//! supports `Permission` and `Prohibition` rules with the common
+//! `leftOperand`/`operator`/`rightOperand` constraints; `Offer`/`Agreement`
+//! policy subtypes are parsed identically to `Set` (the subtype affects
+//! contracting, not single-node evaluation).
+//! [OPUS-4.8]
+
+use std::fmt;
+
+/// The ODRL namespace IRI prefix (`odrl:`).
+pub const ODRL_NS: &str = "http://www.w3.org/ns/odrl/2/";
+
+/// An ODRL policy: a container of deontic rules.
+///
+/// A policy is evaluated as a whole against a single request: a [`Permission`]
+/// whose action/target/constraints all match the request grants access, and any
+/// matching [`Prohibition`] overrides it (fail-closed — see
+/// [`crate::evaluate`]).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Policy {
+    /// The policy IRI (the `odrl:Policy`/`Set`/`Offer`/`Agreement` subject), if any.
+    pub iri: Option<String>,
+    /// `odrl:permission` rules — each, if matched and unprohibited, grants access.
+    pub permissions: Vec<Rule>,
+    /// `odrl:prohibition` rules — each, if matched, forbids access (overrides).
+    pub prohibitions: Vec<Rule>,
+}
+
+/// A deontic rule (a Permission or a Prohibition). They share the same shape;
+/// the [`Policy`] field they live under fixes their deontic force.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Rule {
+    /// The rule node IRI/blank-id (for justification in the decision).
+    pub id: String,
+    /// The regulated [`Action`] (`odrl:action`).
+    pub action: Action,
+    /// The target asset IRI (`odrl:target`) — the data/graph the rule is about.
+    /// `None` means the rule applies to any target (an unrefined rule).
+    pub target: Option<String>,
+    /// The party the rule is assigned to (`odrl:assignee`) — the requesting
+    /// party it grants/forbids for. `None` = applies to any party.
+    pub assignee: Option<String>,
+    /// The party issuing the rule (`odrl:assigner`). Informational for single-node
+    /// evaluation; carried for justification + audit.
+    pub assigner: Option<String>,
+    /// Constraints (`odrl:constraint`) that must all hold for the rule to be
+    /// *satisfied* (logical AND, per the ODRL default `odrl:and`).
+    pub constraints: Vec<Constraint>,
+    /// Duties (`odrl:duty`) — obligations that must be discharged for a
+    /// *permission* to be exercisable. Ignored on prohibitions (a prohibition
+    /// has no pre-condition duty in this base case).
+    pub duties: Vec<Duty>,
+}
+
+/// An ODRL action: the regulated operation (`odrl:use`, `odrl:read`,
+/// `odrl:distribute`, `odrl:aggregate`, `odrl:anonymize`, …).
+///
+/// Stored as the full IRI. The well-known `odrl:use` action is the ODRL
+/// "umbrella" action: a permission for `odrl:use` matches a request for any
+/// action (per the ODRL action hierarchy, `use` is a super-action). All other
+/// actions match by exact IRI equality in this base case.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Action(pub String);
+
+impl Action {
+    /// The `odrl:use` umbrella action IRI.
+    pub fn use_() -> Action {
+        Action(format!("{ODRL_NS}use"))
+    }
+
+    /// True iff this action permits a request for `requested`: exact-IRI match,
+    /// or this action is the `odrl:use` umbrella (which subsumes every action).
+    pub fn permits(&self, requested: &Action) -> bool {
+        self == requested || self.0 == format!("{ODRL_NS}use")
+    }
+}
+
+impl fmt::Display for Action {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// An ODRL constraint: a `(leftOperand, operator, rightOperand)` triple
+/// (`odrl:Constraint`) evaluated against the request + state-of-the-world.
+///
+/// Example: `(odrl:dateTime, odrl:lteq, "2026-12-31T00:00:00Z")` — the request
+/// must occur at or before that instant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Constraint {
+    /// The dimension being constrained (`odrl:leftOperand`), e.g. `odrl:dateTime`,
+    /// `odrl:purpose`, `odrl:recipient`, `odrl:spatial`, `odrl:count`. Stored as
+    /// the full IRI.
+    pub left: String,
+    /// The comparison [`Operator`] (`odrl:operator`).
+    pub operator: Operator,
+    /// The value to compare against (`odrl:rightOperand`), as a typed
+    /// [`Value`].
+    pub right: Value,
+}
+
+/// The constraint comparison operators sparq-policy supports (the common ODRL
+/// operator set — [ODRL operators](https://www.w3.org/TR/odrl-vocab/#constraintLeftOperandCommon)).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Operator {
+    /// `odrl:eq` — equality.
+    Eq,
+    /// `odrl:neq` — inequality.
+    Neq,
+    /// `odrl:lt` — strictly less than (numeric or dateTime).
+    Lt,
+    /// `odrl:lteq` — less than or equal.
+    Lteq,
+    /// `odrl:gt` — strictly greater than.
+    Gt,
+    /// `odrl:gteq` — greater than or equal.
+    Gteq,
+    /// `odrl:isPartOf` — the request value is a member of / part of the
+    /// right-operand set or hierarchy (set membership in this base case).
+    IsPartOf,
+    /// `odrl:isA` — the request value IS the right operand (a type/identity
+    /// membership check, treated as equality here).
+    IsA,
+}
+
+impl Operator {
+    /// Parse an `odrl:` operator IRI into an [`Operator`]. Unknown operators
+    /// return `None` (and an unparseable constraint fails closed).
+    pub fn from_iri(iri: &str) -> Option<Operator> {
+        let local = iri.strip_prefix(ODRL_NS)?;
+        Some(match local {
+            "eq" => Operator::Eq,
+            "neq" => Operator::Neq,
+            "lt" => Operator::Lt,
+            "lteq" => Operator::Lteq,
+            "gt" => Operator::Gt,
+            "gteq" => Operator::Gteq,
+            "isPartOf" => Operator::IsPartOf,
+            "isA" => Operator::IsA,
+            _ => return None,
+        })
+    }
+}
+
+/// A constraint right-operand or request value, kept as a typed scalar so the
+/// evaluator can compare numerically / temporally where appropriate and fall
+/// back to string equality otherwise.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    /// An IRI (an `odrl:rightOperandReference` or a named resource/party/purpose).
+    Iri(String),
+    /// A plain or typed string literal (purpose codes, recipient ids, regions).
+    Str(String),
+    /// An `xsd:decimal`/`integer`/`double` numeric literal (for `odrl:count`, …).
+    Num(f64),
+    /// An `xsd:dateTime`/`xsd:date` literal, normalized to a comparable key.
+    DateTime(String),
+}
+
+impl Value {
+    /// The value as a string for equality / membership comparison.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Value::Iri(s) | Value::Str(s) | Value::DateTime(s) => s,
+            Value::Num(_) => "",
+        }
+    }
+}
+
+impl Eq for Value {}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Value::Iri(s) => write!(f, "<{s}>"),
+            Value::Str(s) | Value::DateTime(s) => write!(f, "{s:?}"),
+            Value::Num(n) => write!(f, "{n}"),
+        }
+    }
+}
+
+/// An ODRL duty (`odrl:duty`): an obligation that must be discharged for a
+/// permission to be exercisable (the "usage-control kernel" pure access control
+/// lacks). In the single-node base case a duty is modelled by its [`Action`] and
+/// (optionally) its own constraints; the evaluator checks whether the request
+/// context reports the duty as discharged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Duty {
+    /// The duty node IRI/blank-id (for justification).
+    pub id: String,
+    /// The action that must be performed (`odrl:action`), e.g.
+    /// `odrl:anonymize`, `odrl:compensate`, a custom `proveAttestation`.
+    pub action: Action,
+    /// Constraints refining the duty (e.g. compensate `count = 5`). Carried for
+    /// justification; the base case checks discharge by action.
+    pub constraints: Vec<Constraint>,
+}

--- a/crates/sparq-policy/src/parse.rs
+++ b/crates/sparq-policy/src/parse.rs
@@ -1,0 +1,343 @@
+//! Parse an ODRL policy expressed in RDF into the typed [`Policy`] model.
+//!
+//! The parser runs SPARQL queries (via [`sparq_engine::query`]) over the loaded
+//! policy graph — ODRL evaluation *is* a SPARQL/SHACL/N3 workload, so extracting
+//! the model with the engine sparq already ships keeps this crate in-family and
+//! dependency-light (no bespoke RDF walker).
+//!
+//! Rule and constraint nodes are matched by **variable** (never by a literal
+//! blank-node label), because real ODRL policies overwhelmingly express rules,
+//! constraints and duties as *blank nodes*; the whole rule structure is joined
+//! in one query per (rule-kind, attribute) so a blank-node constraint is bound
+//! through its incident edge, not re-named.
+//!
+//! Input forms accepted by [`parse_policy_str`]: any RDF serialization
+//! `sparq_core::Graph::load_str` accepts (`turtle`, `ntriples`, …). The policy
+//! IRI is whichever subject is `a odrl:Policy`/`Set`/`Offer`/`Agreement`, or —
+//! if none is typed — whichever subject carries `odrl:permission`/`prohibition`.
+//! [OPUS-4.8]
+
+use crate::model::{Action, Constraint, Duty, Operator, Policy, Rule, Value, ODRL_NS};
+use oxrdf::{Literal, Term};
+use sparq_core::Graph;
+use std::collections::BTreeMap;
+
+const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+
+/// Parse an ODRL policy from an RDF string in `format` (e.g. `"turtle"`).
+///
+/// # Errors
+///
+/// Returns `Err` if the RDF does not parse, or if a query over it fails. A
+/// well-formed RDF document with no ODRL rules parses to an empty [`Policy`]
+/// (which then denies everything — fail-closed).
+pub fn parse_policy_str(rdf: &str, format: &str) -> Result<Policy, String> {
+    let graph = Graph::load_str(rdf, format)?;
+    parse_policy(&graph)
+}
+
+/// Parse an ODRL policy from an already-loaded [`Graph`].
+///
+/// # Errors
+///
+/// Returns `Err` if a query over the graph fails.
+pub fn parse_policy(graph: &Graph) -> Result<Policy, String> {
+    let iri = policy_iri(graph)?;
+    let permissions = rules(graph, "permission", true)?;
+    let prohibitions = rules(graph, "prohibition", false)?;
+    Ok(Policy {
+        iri,
+        permissions,
+        prohibitions,
+    })
+}
+
+/// A stable string key identifying a rule/constraint/duty node, used to group
+/// the flat rows of a join query back into structured rules. IRIs and blank
+/// nodes both get a distinct key.
+fn node_key(t: &Term) -> String {
+    match t {
+        Term::NamedNode(n) => format!("<{}>", n.as_str()),
+        Term::BlankNode(b) => format!("_:{}", b.as_str()),
+        Term::Literal(l) => format!("\"{}\"", l.value()),
+        #[allow(unreachable_patterns)]
+        _ => String::new(),
+    }
+}
+
+fn term_str(t: &Term) -> String {
+    match t {
+        Term::NamedNode(n) => n.as_str().to_owned(),
+        Term::BlankNode(b) => format!("_:{}", b.as_str()),
+        Term::Literal(l) => l.value().to_owned(),
+        #[allow(unreachable_patterns)]
+        _ => String::new(),
+    }
+}
+
+fn policy_iri(graph: &Graph) -> Result<Option<String>, String> {
+    let typed = sparq_engine::query(
+        graph,
+        &format!(
+            "SELECT ?p WHERE {{ ?p a ?t . \
+             VALUES ?t {{ <{ODRL_NS}Policy> <{ODRL_NS}Set> <{ODRL_NS}Offer> <{ODRL_NS}Agreement> }} }}"
+        ),
+    )?;
+    if let Some(Term::NamedNode(n)) = typed
+        .rows
+        .into_iter()
+        .next()
+        .and_then(|r| r.into_iter().next().flatten())
+    {
+        return Ok(Some(n.into_string()));
+    }
+    let withrule = sparq_engine::query(
+        graph,
+        &format!(
+            "SELECT ?p WHERE {{ ?p ?r ?x . \
+             VALUES ?r {{ <{ODRL_NS}permission> <{ODRL_NS}prohibition> }} }}"
+        ),
+    )?;
+    Ok(
+        match withrule
+            .rows
+            .into_iter()
+            .next()
+            .and_then(|r| r.into_iter().next().flatten())
+        {
+            Some(Term::NamedNode(n)) => Some(n.into_string()),
+            _ => None,
+        },
+    )
+}
+
+/// Index `?rule -> attribute` rows from a single query into per-rule lists.
+fn group_by_first(graph: &Graph, sparql: &str) -> Result<BTreeMap<String, Vec<Term>>, String> {
+    let res = sparq_engine::query(graph, sparql)?;
+    let mut out: BTreeMap<String, Vec<Term>> = BTreeMap::new();
+    for row in res.rows {
+        let mut it = row.into_iter();
+        let (Some(Some(key_t)), Some(Some(val_t))) = (it.next(), it.next()) else {
+            continue;
+        };
+        out.entry(node_key(&key_t)).or_default().push(val_t);
+    }
+    Ok(out)
+}
+
+/// All rules of a kind (`"permission"`/`"prohibition"`). `with_duties` controls
+/// whether duty obligations are parsed (permissions only in the base case).
+fn rules(graph: &Graph, kind: &str, with_duties: bool) -> Result<Vec<Rule>, String> {
+    // Enumerate the rule nodes first (keyed), then attach attributes by join.
+    // (BIND a copy so the projection has two distinct variables — the engine
+    // rejects `SELECT ?rule ?rule`.)
+    let nodes = group_by_first(
+        graph,
+        &format!("SELECT ?rule ?rule2 WHERE {{ ?policy <{ODRL_NS}{kind}> ?rule . BIND(?rule AS ?rule2) }}"),
+    )?;
+
+    let actions = group_by_first(
+        graph,
+        &format!("SELECT ?rule ?a WHERE {{ ?policy <{ODRL_NS}{kind}> ?rule . ?rule <{ODRL_NS}action> ?a }}"),
+    )?;
+    let targets = group_by_first(
+        graph,
+        &format!("SELECT ?rule ?t WHERE {{ ?policy <{ODRL_NS}{kind}> ?rule . ?rule <{ODRL_NS}target> ?t }}"),
+    )?;
+    let assignees = group_by_first(
+        graph,
+        &format!("SELECT ?rule ?p WHERE {{ ?policy <{ODRL_NS}{kind}> ?rule . ?rule <{ODRL_NS}assignee> ?p }}"),
+    )?;
+    let assigners = group_by_first(
+        graph,
+        &format!("SELECT ?rule ?p WHERE {{ ?policy <{ODRL_NS}{kind}> ?rule . ?rule <{ODRL_NS}assigner> ?p }}"),
+    )?;
+
+    let constraints = constraints_for(graph, kind, "constraint")?;
+    let duties = if with_duties {
+        duties_for(graph, kind)?
+    } else {
+        BTreeMap::new()
+    };
+
+    let mut out = Vec::new();
+    for (rule_key, rule_terms) in nodes {
+        let node = rule_terms.first().cloned().expect("group has >=1 row");
+        let action = first_str(&actions, &rule_key)
+            .map(Action)
+            .unwrap_or_else(Action::use_);
+        out.push(Rule {
+            id: term_str(&node),
+            action,
+            target: first_str(&targets, &rule_key),
+            assignee: first_str(&assignees, &rule_key),
+            assigner: first_str(&assigners, &rule_key),
+            constraints: constraints.get(&rule_key).cloned().unwrap_or_default(),
+            duties: duties.get(&rule_key).cloned().unwrap_or_default(),
+        });
+    }
+    Ok(out)
+}
+
+fn first_str(m: &BTreeMap<String, Vec<Term>>, key: &str) -> Option<String> {
+    m.get(key).and_then(|v| v.first()).map(term_str)
+}
+
+/// Parse the constraints attached (via `odrl:<pred>`) to each rule of `kind`,
+/// keyed by rule node. Constraint *nodes* are bound by variable, so blank-node
+/// constraints are handled correctly.
+fn constraints_for(
+    graph: &Graph,
+    kind: &str,
+    pred: &str,
+) -> Result<BTreeMap<String, Vec<Constraint>>, String> {
+    // One row per (rule, constraint-node, left, operator, right). LEFT/OP/RIGHT
+    // are OPTIONAL so a structurally incomplete constraint still surfaces (and is
+    // turned into an unsatisfiable guard — fail-closed).
+    let q = format!(
+        "SELECT ?rule ?c ?left ?op ?right WHERE {{ \
+           ?policy <{ODRL_NS}{kind}> ?rule . \
+           ?rule <{ODRL_NS}{pred}> ?c . \
+           OPTIONAL {{ ?c <{ODRL_NS}leftOperand> ?left }} \
+           OPTIONAL {{ ?c <{ODRL_NS}operator> ?op }} \
+           OPTIONAL {{ ?c <{ODRL_NS}rightOperand> ?right }} \
+           OPTIONAL {{ ?c <{ODRL_NS}rightOperandReference> ?right }} \
+         }}"
+    );
+    let res = sparq_engine::query(graph, &q)?;
+    let mut out: BTreeMap<String, Vec<Constraint>> = BTreeMap::new();
+    // De-dup by (rule, constraint-node) so multiple OPTIONAL combos don't double-count.
+    let mut seen: BTreeMap<String, ()> = BTreeMap::new();
+    for row in res.rows {
+        let mut it = row.into_iter();
+        let rule_t = it.next().flatten();
+        let c_t = it.next().flatten();
+        let left = it.next().flatten();
+        let op = it.next().flatten();
+        let right = it.next().flatten();
+        let (Some(rule_t), Some(c_t)) = (rule_t, c_t) else {
+            continue;
+        };
+        let rkey = node_key(&rule_t);
+        let ckey = format!("{rkey}|{}", node_key(&c_t));
+        if seen.insert(ckey, ()).is_some() {
+            continue;
+        }
+        out.entry(rkey)
+            .or_default()
+            .push(build_constraint(left, op, right));
+    }
+    Ok(out)
+}
+
+/// Build a [`Constraint`], turning anything malformed/unknown into an
+/// unsatisfiable guard (fail-closed): the enclosing rule can then never match.
+fn build_constraint(left: Option<Term>, op: Option<Term>, right: Option<Term>) -> Constraint {
+    let unsat = || Constraint {
+        left: "urn:sparq-policy:malformed".to_owned(),
+        operator: Operator::Neq,
+        right: Value::Iri("urn:sparq-policy:malformed".to_owned()),
+    };
+    let (Some(left), Some(op), Some(right)) = (left, op, right) else {
+        return unsat();
+    };
+    let operator = match Operator::from_iri(&term_str(&op)) {
+        Some(o) => o,
+        None => return unsat(),
+    };
+    Constraint {
+        left: term_str(&left),
+        operator,
+        right: value_of(&right),
+    }
+}
+
+/// Parse duties (and their actions/constraints) per rule node.
+fn duties_for(graph: &Graph, kind: &str) -> Result<BTreeMap<String, Vec<Duty>>, String> {
+    let q = format!(
+        "SELECT ?rule ?d ?a WHERE {{ \
+           ?policy <{ODRL_NS}{kind}> ?rule . \
+           ?rule <{ODRL_NS}duty> ?d . \
+           OPTIONAL {{ ?d <{ODRL_NS}action> ?a }} \
+         }}"
+    );
+    let res = sparq_engine::query(graph, &q)?;
+    let mut out: BTreeMap<String, Vec<Duty>> = BTreeMap::new();
+    let mut seen: BTreeMap<String, ()> = BTreeMap::new();
+    for row in res.rows {
+        let mut it = row.into_iter();
+        let rule_t = it.next().flatten();
+        let d_t = it.next().flatten();
+        let a_t = it.next().flatten();
+        let (Some(rule_t), Some(d_t)) = (rule_t, d_t) else {
+            continue;
+        };
+        let rkey = node_key(&rule_t);
+        let dkey = format!("{rkey}|{}", node_key(&d_t));
+        if seen.insert(dkey, ()).is_some() {
+            continue;
+        }
+        let action = a_t
+            .map(|t| Action(term_str(&t)))
+            .unwrap_or_else(Action::use_);
+        out.entry(rkey).or_default().push(Duty {
+            id: term_str(&d_t),
+            action,
+            constraints: Vec::new(),
+        });
+    }
+    Ok(out)
+}
+
+/// Classify a [`Term`] into a typed [`Value`] (numeric/dateTime/iri/string).
+pub(crate) fn value_of(t: &Term) -> Value {
+    match t {
+        Term::NamedNode(n) => Value::Iri(n.as_str().to_owned()),
+        Term::BlankNode(b) => Value::Str(format!("_:{}", b.as_str())),
+        Term::Literal(l) => literal_value(l),
+        #[allow(unreachable_patterns)]
+        _ => Value::Str(String::new()),
+    }
+}
+
+fn literal_value(l: &Literal) -> Value {
+    let dt = l.datatype();
+    let v = l.value();
+    if is_datetime(dt) {
+        Value::DateTime(v.to_owned())
+    } else if is_numeric(dt) {
+        match v.trim().parse::<f64>() {
+            Ok(n) => Value::Num(n),
+            Err(_) => Value::Str(v.to_owned()),
+        }
+    } else {
+        Value::Str(v.to_owned())
+    }
+}
+
+fn is_datetime(dt: oxrdf::NamedNodeRef<'_>) -> bool {
+    matches!(
+        dt.as_str().strip_prefix(XSD),
+        Some("dateTime" | "date" | "dateTimeStamp")
+    )
+}
+
+fn is_numeric(dt: oxrdf::NamedNodeRef<'_>) -> bool {
+    matches!(
+        dt.as_str().strip_prefix(XSD),
+        Some(
+            "integer"
+                | "decimal"
+                | "double"
+                | "float"
+                | "long"
+                | "int"
+                | "short"
+                | "byte"
+                | "nonNegativeInteger"
+                | "positiveInteger"
+                | "unsignedLong"
+                | "unsignedInt"
+        )
+    )
+}

--- a/crates/sparq-policy/tests/odrl_eval.rs
+++ b/crates/sparq-policy/tests/odrl_eval.rs
@@ -1,0 +1,364 @@
+//! End-to-end ODRL parse + evaluate tests. [OPUS-4.8] sq-r06h.
+//!
+//! Coverage: permission grant, prohibition-overrides-permission, constraint
+//! gating (inside/outside time window; purpose eq/neq; recipient isPartOf;
+//! count gt/lteq), duty-not-discharged, fail-closed defaults (empty policy,
+//! unknown action/target/party, malformed constraint, unknown operator).
+//!
+//! Policies are hand-authored in Turtle following the W3C ODRL 2.2 examples
+//! (the public test-suite examples are equivalent shapes: a `odrl:Set` with a
+//! blank-node permission/prohibition carrying action/target/assignee and
+//! blank-node constraints).
+
+use sparq_policy::{evaluate, parse_policy_str, Decision, Request, Value};
+
+const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
+const XSD_DT: &str = "http://www.w3.org/2001/XMLSchema#dateTime";
+
+fn dt(s: &str) -> Value {
+    Value::DateTime(s.to_owned())
+}
+fn left(local: &str) -> String {
+    format!("{ODRL}{local}")
+}
+
+// ---------------------------------------------------------------------------
+// 1. Permission grant — a bare permission with a matching action/target/party.
+// ---------------------------------------------------------------------------
+#[test]
+fn permission_grants() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/grant> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ;
+    odrl:target <urn:asset/x> ;
+    odrl:assignee <https://alice.ex/me> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    assert_eq!(p.permissions.len(), 1);
+    let req = Request::new(left("read"))
+        .on("urn:asset/x")
+        .by("https://alice.ex/me");
+    let d = evaluate(&p, &req);
+    assert!(d.allow, "{d:?}");
+    assert_eq!(d.matched_rules.len(), 1);
+}
+
+#[test]
+fn wrong_party_denied_fail_closed() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/grant> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:assignee <https://alice.ex/me> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    // Mallory is not the assignee → no permission matches → DENY.
+    let req = Request::new(left("read"))
+        .on("urn:asset/x")
+        .by("https://mallory.ex/me");
+    assert!(!evaluate(&p, &req).allow);
+    // Wrong target → DENY.
+    let req2 = Request::new(left("read"))
+        .on("urn:asset/secret")
+        .by("https://alice.ex/me");
+    assert!(!evaluate(&p, &req2).allow);
+    // Wrong action → DENY.
+    let req3 = Request::new(left("write"))
+        .on("urn:asset/x")
+        .by("https://alice.ex/me");
+    assert!(!evaluate(&p, &req3).allow);
+}
+
+#[test]
+fn use_umbrella_action_subsumes() {
+    // odrl:use is the umbrella action — a permission for `use` permits `read`.
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/u> a odrl:Set ; odrl:permission [
+    odrl:action odrl:use ; odrl:target <urn:asset/x> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let req = Request::new(left("read")).on("urn:asset/x");
+    assert!(evaluate(&p, &req).allow);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Prohibition overrides permission.
+// ---------------------------------------------------------------------------
+#[test]
+fn prohibition_overrides_permission() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/po> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] ;
+  odrl:prohibition [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+                     odrl:assignee <https://mallory.ex/me> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    // Alice: permission applies, no prohibition matches her → ALLOW.
+    let alice = Request::new(left("read"))
+        .on("urn:asset/x")
+        .by("https://alice.ex/me");
+    assert!(evaluate(&p, &alice).allow);
+    // Mallory: the prohibition matches → DENY even though the permission would.
+    let mallory = Request::new(left("read"))
+        .on("urn:asset/x")
+        .by("https://mallory.ex/me");
+    let d = evaluate(&p, &mallory);
+    assert!(!d.allow);
+    assert_eq!(
+        d.matched_rules.len(),
+        1,
+        "the prohibition is the justification"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Constraint gating — dateTime window (inside ALLOW, outside DENY).
+// ---------------------------------------------------------------------------
+#[test]
+fn datetime_window_gates() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/t> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ;
+                      odrl:operator odrl:lteq ;
+                      odrl:rightOperand "2026-12-31T23:59:59Z"^^xsd:dateTime ] ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let base = Request::new(left("read")).on("urn:asset/x");
+    // Inside the window → ALLOW.
+    assert!(
+        evaluate(
+            &p,
+            &base
+                .clone()
+                .with(left("dateTime"), dt("2026-06-16T09:00:00Z"))
+        )
+        .allow
+    );
+    // After the window → DENY.
+    assert!(
+        !evaluate(
+            &p,
+            &base
+                .clone()
+                .with(left("dateTime"), dt("2027-03-01T00:00:00Z"))
+        )
+        .allow
+    );
+    // No dateTime supplied at all → DENY (fail-closed: no evidence).
+    assert!(!evaluate(&p, &base).allow);
+}
+
+#[test]
+fn purpose_eq_and_neq() {
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/p> a odrl:Set ; odrl:permission [
+    odrl:action odrl:use ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ;
+                      odrl:operator odrl:eq ;
+                      odrl:rightOperand <urn:purpose/research> ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let base = Request::new(left("use")).on("urn:asset/x");
+    // Matching purpose → ALLOW.
+    let ok = base
+        .clone()
+        .with(left("purpose"), Value::Iri("urn:purpose/research".into()));
+    assert!(evaluate(&p, &ok).allow);
+    // Different purpose → DENY.
+    let bad = base.with(left("purpose"), Value::Iri("urn:purpose/marketing".into()));
+    assert!(!evaluate(&p, &bad).allow);
+}
+
+#[test]
+fn recipient_is_part_of_set() {
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/r> a odrl:Set ; odrl:permission [
+    odrl:action odrl:distribute ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:recipient ;
+                      odrl:operator odrl:isPartOf ;
+                      odrl:rightOperand "nodeB|nodeC" ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let base = Request::new(left("distribute")).on("urn:asset/x");
+    assert!(
+        evaluate(
+            &p,
+            &base
+                .clone()
+                .with(left("recipient"), Value::Str("nodeB".into()))
+        )
+        .allow
+    );
+    assert!(
+        evaluate(
+            &p,
+            &base
+                .clone()
+                .with(left("recipient"), Value::Str("nodeC".into()))
+        )
+        .allow
+    );
+    // Not in the permitted recipient set → DENY.
+    assert!(
+        !evaluate(
+            &p,
+            &base.with(left("recipient"), Value::Str("nodeD".into()))
+        )
+        .allow
+    );
+}
+
+#[test]
+fn count_numeric_operators() {
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/c> a odrl:Set ; odrl:permission [
+    odrl:action odrl:use ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:count ;
+                      odrl:operator odrl:lteq ;
+                      odrl:rightOperand "5"^^xsd:integer ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let base = Request::new(left("use")).on("urn:asset/x");
+    assert!(evaluate(&p, &base.clone().with(left("count"), Value::Num(3.0))).allow);
+    assert!(evaluate(&p, &base.clone().with(left("count"), Value::Num(5.0))).allow);
+    assert!(!evaluate(&p, &base.with(left("count"), Value::Num(6.0))).allow);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Duty not discharged → DENY; discharged → ALLOW.
+// ---------------------------------------------------------------------------
+#[test]
+fn duty_must_be_discharged() {
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/d> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:duty [ odrl:action odrl:anonymize ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    assert_eq!(p.permissions[0].duties.len(), 1);
+    let base = Request::new(left("read")).on("urn:asset/x");
+    // Duty not discharged → DENY.
+    let d = evaluate(&p, &base);
+    assert!(!d.allow);
+    assert!(
+        d.unmet_constraints.iter().any(|m| m.contains("duty")),
+        "{d:?}"
+    );
+    // Discharged → ALLOW.
+    let ok = base.discharge(left("anonymize"));
+    assert!(evaluate(&p, &ok).allow);
+}
+
+// ---------------------------------------------------------------------------
+// 5. Fail-closed defaults.
+// ---------------------------------------------------------------------------
+#[test]
+fn empty_policy_denies_everything() {
+    let p = parse_policy_str("@prefix odrl: <http://www.w3.org/ns/odrl/2/> .", "turtle").unwrap();
+    let d: Decision = evaluate(&p, &Request::new(left("read")).on("urn:asset/x"));
+    assert!(!d.allow);
+    assert!(d.matched_rules.is_empty());
+}
+
+#[test]
+fn unknown_operator_fails_closed() {
+    // odrl:hasPart is not a comparison operator we support → the constraint
+    // becomes an unsatisfiable guard, so the permission can never match.
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/x> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ;
+                      odrl:operator odrl:hasPart ;
+                      odrl:rightOperand <urn:purpose/research> ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let req = Request::new(left("read"))
+        .on("urn:asset/x")
+        .with(left("purpose"), Value::Iri("urn:purpose/research".into()));
+    assert!(
+        !evaluate(&p, &req).allow,
+        "unknown operator must fail closed"
+    );
+}
+
+#[test]
+fn malformed_constraint_fails_closed() {
+    // A constraint missing its operator/rightOperand is an unsatisfiable guard.
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/m> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let req = Request::new(left("read")).on("urn:asset/x");
+    assert!(!evaluate(&p, &req).allow);
+}
+
+#[test]
+fn untyped_policy_with_rules_is_parsed() {
+    // No `a odrl:Set` — the parser still finds the rule via odrl:permission.
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/untyped> odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    assert_eq!(p.iri.as_deref(), Some("urn:pol/untyped"));
+    assert!(evaluate(&p, &Request::new(left("read")).on("urn:asset/x")).allow);
+}
+
+#[test]
+fn datetime_xsd_typed_constant_roundtrips() {
+    // Make sure the XSD dateTime datatype is recognized (parses to Value::DateTime,
+    // compared by instant not string-coincidence).
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/t2> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ;
+                      odrl:operator odrl:gteq ;
+                      odrl:rightOperand "2026-01-01T00:00:00Z"^^<{XSD_DT}> ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let base = Request::new(left("read")).on("urn:asset/x");
+    // At/after the lower bound → ALLOW.
+    assert!(
+        evaluate(
+            &p,
+            &base
+                .clone()
+                .with(left("dateTime"), dt("2026-06-16T00:00:00Z"))
+        )
+        .allow
+    );
+    // Before the lower bound → DENY.
+    assert!(!evaluate(&p, &base.with(left("dateTime"), dt("2025-12-31T00:00:00Z"))).allow);
+}

--- a/skills/usage-control-policy/SKILL.md
+++ b/skills/usage-control-policy/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: usage-control-policy
+description: Evaluate W3C ODRL 2.2 usage-control policies over RDF with the opt-in sparq-policy crate — parse an ODRL Set/Offer/Agreement into a typed Policy of Permission/Prohibition rules (action, target, assignee, Constraint, Duty), then evaluate an access Request to a fail-closed ALLOW/DENY Decision. Use when gating a query/asset by purpose, recipient, time window, count, or a duty obligation; when mapping ODRL to the sparq-solid WAC/ACP allow-deny model; or when wiring usage control above access control. Single-node base case; federated ODRL-to-MPC disclosure is deferred.
+---
+
+# usage-control-policy
+
+`sparq-policy` is the declarative **usage-control** layer above access control. Where `sparq-solid` answers "may this agent **read** graph G?", `sparq-policy` answers "may this party **use** this asset *for purpose P, with obligation O, until time T, disclosing only to recipient R*?" — by evaluating a [W3C ODRL 2.2](https://www.w3.org/TR/odrl-model/) policy.
+
+It parses an ODRL policy from RDF into a typed model (`Policy → {permissions, prohibitions}`, each `Rule` carrying an `Action`, `target`, `assignee`/`assigner`, `Constraint`s and `Duty`s) and evaluates an access `Request` to a **fail-closed** `Decision { allow, matched_rules, unmet_constraints }`. This is the **single-node base case**: ODRL over one node's data, reducing to the same allow/deny shape `sparq-solid` enforces.
+
+> **Scope.** Single-node only. The headline federated-disclosure / ODRL→MPC composition (per-node ODRL drives the `sparq-mpc` disclosed-vs-hidden split; ODRL `Duty` → ZK proof obligation) is **deferred** — it inherits the MPC honest-majority/LAN envelope and the open ZK-soundness remediation. See `research/feature-research-odrl-policy.md`.
+
+## Prerequisites
+
+- **Cargo dep** — `sparq-policy` is `publish = false`, a non-default workspace member (nothing in core depends on it; `cargo tree -p sparq-core` never shows it). Add it as a path dep:
+  ```toml
+  sparq-policy = { path = "crates/sparq-policy" }
+  ```
+- No external toolchain. It depends only on `sparq-core` + `sparq-engine` + `oxrdf`; zero `unsafe`.
+
+## Quickstart
+
+Parse an ODRL `Set` and evaluate a time-windowed permission. Compiles and runs against the current API.
+
+```rust
+use sparq_policy::{evaluate, parse_policy_str, Request, Value};
+
+// alice MAY read asset-X, on or before 2026-12-31, for research purpose.
+let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/1> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ;
+    odrl:target <urn:asset/x> ;
+    odrl:assignee <https://alice.ex/me> ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lteq ;
+                      odrl:rightOperand "2026-12-31T00:00:00Z"^^xsd:dateTime ] ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;
+                      odrl:rightOperand <urn:purpose/research> ] ] .
+"#;
+let policy = parse_policy_str(ttl, "turtle").expect("parse");
+
+const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
+let req = Request::new(format!("{ODRL}read"))
+    .on("urn:asset/x")
+    .by("https://alice.ex/me")
+    .with(format!("{ODRL}dateTime"), Value::DateTime("2026-06-16T09:00:00Z".into()))
+    .with(format!("{ODRL}purpose"),  Value::Iri("urn:purpose/research".into()));
+
+let d = evaluate(&policy, &req);
+assert!(d.allow);                      // in-window, right party, right purpose
+assert_eq!(d.matched_rules.len(), 1);  // the granting permission, for audit
+```
+
+## The model
+
+- **`Policy`** — `permissions: Vec<Rule>`, `prohibitions: Vec<Rule>`, optional `iri`. `Set`/`Offer`/`Agreement` parse identically (subtype affects contracting, not single-node eval).
+- **`Rule`** — `action: Action`, `target`/`assignee`/`assigner: Option<String>`, `constraints: Vec<Constraint>`, `duties: Vec<Duty>` (duties on permissions only).
+- **`Action`** — full IRI. `odrl:use` is the **umbrella** action: a permission for `use` permits *any* requested action. All others match by exact IRI.
+- **`Constraint`** — `(left: leftOperand-IRI, operator, right: Value)`. The request supplies the *actual* value for `left` in its `context`; the constraint's `right` is the bound.
+- **`Duty`** — an obligation (`action`) that must be in the request's `discharged_duties` set, or the permission is denied.
+
+## Evaluation semantics (fail-closed)
+
+1. A `Rule` **matches** when its action permits the request action, its `target`/`assignee` (if set) agree, and **every** `Constraint` is satisfied (logical AND).
+2. A `Permission` grants iff it matches **and** all its `Duty`s are discharged.
+3. A matching `Prohibition` **overrides** any permission (carve-out — ODRL Formal Semantics conflict default).
+4. **DENY by default:** no matching+discharged permission, or any matching prohibition ⇒ DENY. An empty/malformed policy denies everything; a constraint with no request value, an unknown operator, or a structurally incomplete constraint all fail closed.
+
+## Constraint operators
+
+`eq`, `neq`, `lt`, `lteq`, `gt`, `gteq`, `isPartOf` (set membership: `right` is a `|`/space/comma-separated set), `isA` (identity, ≈ `eq`). Numeric (`xsd:integer`/`decimal`/`double`/…) and `xsd:dateTime`/`date` operands compare by magnitude/instant; everything else by IRI/string value. Order comparison on non-orderable values is `false` (fail-closed). `dateTime` ordering compares the lexical form — mixed-offset normalization is a deferred bead.
+
+## Building the request
+
+`Request::new(action_iri)` then chain `.on(target)`, `.by(party)`, `.with(left_operand_iri, Value)` for each context dimension (`dateTime`, `purpose`, `recipient`, `count`, `spatial`, …), and `.discharge(duty_action_iri)` per discharged duty. `Value` is `Iri` | `Str` | `Num(f64)` | `DateTime(String)`.
+
+## Learn more
+
+- Crate README: [`crates/sparq-policy/README.md`](../../crates/sparq-policy/README.md)
+- Design record: `research/feature-research-odrl-policy.md` (epic sq-3183)
+- Sibling access-control skill: [`skills/http-server`](../http-server/SKILL.md) (Solid WAC/ACP via `sparq-solid`)
+- W3C [ODRL Information Model 2.2](https://www.w3.org/TR/odrl-model/) · [Formal Semantics](https://w3c.github.io/odrl/formal-semantics/)


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-r06h** (epic sq-3183, ODRL candidate #1): a new **opt-in `sparq-policy` crate** — a single-node W3C **ODRL 2.2** usage-control evaluator. Design: `research/feature-research-odrl-policy.md`.

## What this is

The declarative **usage-control** layer *above* access control. `sparq-solid` answers "may this agent **read** graph G?"; `sparq-policy` answers "may this party **use** this asset *for purpose P, with obligation O, until time T, to recipient R*?" The **base case of ODRL reduces to the same fail-closed allow/deny decision** the `sparq-solid` WAC/ACP path already produces — so this lands as a strictly richer policy source, built ON the existing engine.

`publish = false`, a **dependency of nothing** in the workspace — zero footprint on the core build (`cargo tree -p sparq-core` does not show it).

## ODRL model + evaluator

- **Model** (`src/model.rs`): typed ODRL Information Model subset — `Policy → {permissions, prohibitions}`, each `Rule` with an `Action`, `target`, `assignee`/`assigner`, `Constraint`s and (permissions) `Duty`s. Typed `Value` (`Iri`/`Str`/`Num`/`DateTime`); `odrl:use` is the umbrella action.
- **Parser** (`src/parse.rs`): parses ODRL from RDF via the engine's own BGP queries (ODRL evaluation *is* a SPARQL workload — in-family, no bespoke RDF walker). Rule/constraint/duty nodes are matched by **variable**, so blank-node ODRL (the common shape) works.
- **Evaluator** (`src/eval.rs`): `evaluate(&policy, &request) -> Decision { allow, matched_rules, unmet_constraints }`.

### Constraint operators
`eq`, `neq`, `lt`, `lteq`, `gt`, `gteq`, `isPartOf` (set membership), `isA`. Numeric (`xsd:integer`/`decimal`/…) and `xsd:dateTime`/`date` compare by magnitude/instant; everything else by IRI/string.

### Fail-closed semantics
A matching **prohibition overrides** any permission; a permission grants only when it matches **and** all its duties are discharged; **no match ⇒ DENY**. An empty/malformed policy, a missing request-context value, an unknown operator, or a structurally incomplete constraint all **deny**.

## Scope — single-node only

The headline **federated-disclosure / ODRL→MPC** composition (per-node ODRL drives the `sparq-mpc` disclosed-vs-hidden split; ODRL `Duty` → ZK proof obligation) is **deferred** — it inherits the MPC honest-majority/LAN envelope and the open ZK-soundness remediation (the `ambiguous-ask-user` item in the research doc). This PR delivers the buildable-today base case.

## G1 new-crate gate compliance
- ✅ `crates/sparq-policy/README.md` (template-compliant: 🚀/✨/📚 + License)
- ✅ `skills/usage-control-policy/SKILL.md` (valid frontmatter)
- ✅ registered benchmark `policy-odrl-eval` in `bench/benchmarks.toml` (`examples/bench.rs`)

## Verification
- `cargo test -p sparq-policy`: **14 integration tests + 2 doctests green** (permission grant, prohibition-overrides-permission, dateTime-window gating, purpose eq/neq, recipient isPartOf, count numeric ops, duty-not-discharged, empty/unknown-operator/malformed fail-closed).
- `cargo clippy -p sparq-policy --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean. `cargo check --workspace`: clean.
- `cargo tree -p sparq-core`: sparq-policy absent (isolation confirmed).

NON-CANONICAL timing (bench numbers are a sanity-scale signal, not a published baseline).

### Deferred ODRL follow-ons (to be filed as beads in the main checkout)
- ODRL→sparq-solid bridge (materialize ODRL access permissions into `AUTH_GRAPH`).
- DPV `purpose` hierarchies + `isPartOf` over purpose/spatial trees.
- `Duty → proof-manifest` discharge (`proveAttestation` → issuer set-membership proof).
- `dateTime` mixed-offset normalization.
- ODRL policy conflict/containment detection.
- Federated ODRL-driven disclosure split (`ambiguous-ask-user`; gated on ZK soundness).