### PR TITLE
bench: register/add benches for drift-flagged crates (sq-ncvq.12)

### DIFF
--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -668,6 +668,87 @@ pinning     = "dataset version"
 records_to  = "stdout; research/genai-design.md §4 gate"
 status      = "ok"
 
+# [OPUS-4.8] sq-ncvq.12 (drift catch-up A) — sparq-nlq OFFLINE NL→SPARQL micro-bench.
+# Closes the bench-missing drift item for sparq-nlq. Pure offline: the LLM is an
+# in-example fixed-completion stub (no `live` feature, no network), so it measures
+# the crate's deterministic core — schema grounding, prompt construction, and the
+# extract→spargebra-validate→budgeted-execute loop — not an Anthropic round-trip.
+[[benchmark]]
+id          = "nlq-offline-bench"
+name        = "sparq-nlq offline NL→SPARQL loop (ground + prompt + ask)"
+category    = "query"
+measures    = "grounding (Introspection scan + token-budgeted summary render via Nlq::new), prompt_for construction (us), and one full ask loop (extract SPARQL → spargebra validate → budgeted execute) using a deterministic fixed-completion stub LLM; best-of-K"
+invoke      = "cargo run -p sparq-nlq --example bench --release [n-entities=2000]"
+source      = "crates/sparq-nlq/examples/bench.rs"
+dataset     = "synthetic typed graph generated in-example (N entities x {rdf:type, rdfs:label, ex:age}); deterministic; no external data, no network (offline stub LLM)"
+quiet_box_sensitive = true
+pinning     = "in-example synthetic graph is deterministic; pin N for comparable numbers; offline path (no `live` feature)"
+records_to  = "stdout (us per phase)"
+status      = "ok"
+
+# [OPUS-4.8] sq-ncvq.12 (drift catch-up A) — sparq-serve concurrent-serving-core
+# micro-bench. Closes the bench-missing drift item for sparq-serve. Lightweight:
+# a cheap usize snapshot type isolates the ring/scheduler machinery from graph-build
+# cost (that is the engine ingest benches), so the numbers are the lock-free
+# primitives the crate exists for.
+[[benchmark]]
+id          = "serve-core-bench"
+name        = "sparq-serve generation-ring + scheduler primitives"
+category    = "serve"
+measures    = "lock-free current() reader-pin latency (ns/op), publish() snapshot-swap + epoch-bump latency (ns/op), two-lane Scheduler::run cheap/heavy round-trip (ns/op), and a concurrent arm reporting aggregate reader pins/s while a writer publishes (readers-never-block invariant)"
+invoke      = "cargo run -p sparq-serve --example bench --release"
+source      = "crates/sparq-serve/examples/bench.rs"
+dataset     = "none — synthetic in-example (usize snapshot to isolate ring/scheduler cost from graph-build); deterministic structure, NON-CANONICAL wall-clock"
+quiet_box_sensitive = true
+pinning     = "in-example op counts fixed; the cheap usize snapshot isolates the measured machinery; numbers calibrate research/concurrent-serving.md §6"
+records_to  = "stdout (ns/op per primitive)"
+status      = "ok"
+
+# [OPUS-4.8] sq-ncvq.12 (drift catch-up A) — sparq-mpc in-process counting-tier
+# bench matrix. Closes the bench-missing drift item for sparq-mpc by registering
+# the EXISTING example harness (it pre-dated the registry). HONESTY: this is the
+# single-process counting tier — MODELLED communication (bytes/party, rounds,
+# multiplications) + the per-cell ACTUAL security guarantee, NOT measured network
+# cost (the multi-process transport is examples/mpc_net_bench.rs; LAN/WAN netem +
+# EC2 scale-out are separate beads sq-tg6b / sq-hoaj). The correctness gates that
+# co-run the REAL primitives need the seedable simulation RNG (insecure-test-rng,
+# OFF by default — the feature name is the warning; it only makes the SIMULATION
+# reproducible, never a production claim).
+[[benchmark]]
+id          = "mpc-bench-matrix"
+name        = "sparq-mpc (security-model × N × query-class) modelled-cost matrix"
+category    = "query"
+measures    = "deterministic MODELLED communication per cell — bytes/party, total bytes, sequential+batched rounds, multiplications, field elements opened/shared, offline bytes — plus the per-cell ACTUAL security guarantee, over party counts N∈{2,3,5,7} × query classes {cumulative-sum aggregate, hidden-value equi-join, oblivious shuffle, oblivious sort}; emitted as a human table + structured JSON. With insecure-test-rng the REAL primitives co-run as correctness gates (aggregate/join/shuffle/sort)"
+invoke      = "cargo run -p sparq-mpc --example mpc_bench_matrix [--features insecure-test-rng] [-- --json]   # default build prints the cost matrix + skips the seeded correctness gates; the feature adds the co-run gates"
+source      = "crates/sparq-mpc/examples/mpc_bench_matrix.rs (in-process counting tier); crates/sparq-mpc/examples/mpc_net_bench.rs (multi-process MEASURED network tier, driver for the sibling mpc_party); crates/sparq-mpc/src/bench.rs (run_matrix + correctness gates)"
+dataset     = "synthetic in-process (capped scales: join_scale=6, shuffle_scale=16) — the counting tier needs no external data"
+quiet_box_sensitive = false  # modelled bytes/rounds/mults are DETERMINISTIC (counting tier); only mpc_net_bench's wall-clock is timing
+pinning     = "DEFAULT_PARTIES {2,3,5,7}, join/shuffle scales fixed in the example; correctness-gate seed 0x5347585140D5043... fixed under insecure-test-rng (simulation reproducibility only, NEVER a production claim)"
+records_to  = "stdout (human table + JSON schema); research/mpc design record §5"
+status      = "ok"
+
+# [OPUS-4.8] sq-ncvq.12 (drift catch-up A) — sparq-wasm browser-bundle size.
+# Closes the bench-missing drift item for sparq-wasm. The wasm crate is a thin
+# #[wasm_bindgen] glue layer over sparq-engine (load/query/count/ask/update); its
+# QUERY logic is ALREADY measured by the CLI/operator-coverage suites over the same
+# engine, so the crate's distinct, measurable surface is its BROWSER BUNDLE SIZE —
+# a DETERMINISTIC byte count that gates the "zero wasm bundle impact" rule for
+# opt-in features. This is exactly the wasm_bundle_bytes metric ci-bench.sh already
+# emits per-commit (records_to below); this entry registers that measurement under
+# the wasm crate so the drift-scanner + CATALOG see it.
+[[benchmark]]
+id          = "wasm-bundle"
+name        = "sparq-wasm browser bundle size (deterministic byte count)"
+category    = "compression"
+measures    = "release wasm32-unknown-unknown bundle size in bytes (deterministic) — the 'zero wasm bundle impact' gate: any opt-in feature that leaks into the browser build shows up here per commit"
+invoke      = "cargo build --release -p sparq-wasm --target wasm32-unknown-unknown && wc -c < target/wasm32-unknown-unknown/release/sparq_wasm.wasm   # CI emits it as wasm_bundle_bytes via scripts/ci-bench.sh"
+source      = "crates/sparq-wasm/src/lib.rs (the #[wasm_bindgen] Store glue measured); scripts/ci-bench.sh (wasm_bundle_bytes emitter)"
+dataset     = "none — the artifact under test is the compiled wasm binary itself"
+quiet_box_sensitive = false  # byte count is fully deterministic (runner-noise-immune)
+pinning     = "release profile + wasm32-unknown-unknown target; the crate's no-default-features (no rayon) + compact 3-perm cfg pin the bundle composition"
+records_to  = "stdout (wc -c); CI emits wasm_bundle_bytes into benchmark-data (dev/bench) via scripts/ci-bench.sh (a DETERMINISTIC regression gate, NOT trend-only)"
+status      = "ok"
+
 # =============================================================================
 # CONFORMANCE — correctness against official W3C suites (NOT perf)
 # =============================================================================

--- a/crates/sparq-nlq/examples/bench.rs
+++ b/crates/sparq-nlq/examples/bench.rs
@@ -1,0 +1,101 @@
+//! sparq-nlq offline NL→SPARQL micro-benchmark. [OPUS-4.8] sq-ncvq.12. Run:
+//!     cargo run -p sparq-nlq --example bench --release
+//!
+//! Measures the crate's deterministic, OFFLINE core operations — NO network, NO
+//! `live` feature, no Anthropic call. The LLM is a tiny in-example stub that
+//! returns a fixed valid SPARQL completion, so the loop exercises the real
+//! retrieve→generate→validate(spargebra)→execute path against a synthetic graph:
+//!   1. grounding — `Nlq::with_config` (the sparq-introspect schema scan +
+//!      token-budgeted summary render: the once-per-graph cost);
+//!   2. prompt — `prompt_for(question)` (schema-grounded prompt construction);
+//!   3. ask loop — one full `ask` (extract SPARQL → spargebra validate →
+//!      budgeted execute), with the stub LLM, best-of-K.
+//!
+//! NON-CANONICAL timing (this box is not a quiet bench instance) — the numbers are
+//! a sanity-scale signal, not a published baseline.
+
+use sparq_core::Graph;
+use sparq_nlq::{Llm, Nlq};
+use std::time::Instant;
+
+/// Deterministic offline stub: returns a fixed, schema-valid SPARQL query in a
+/// fenced block (the shape `extract_sparql` expects), independent of the prompt —
+/// so the bench measures the loop, never an LLM. NOT a `ReplayLlm` (that needs an
+/// exact prompt match); this is the minimal happy-path `Llm` for benchmarking.
+struct FixedLlm(String);
+
+impl Llm for FixedLlm {
+    fn complete(&self, _prompt: &str) -> Result<String, String> {
+        Ok(format!("Here is the query:\n```sparql\n{}\n```", self.0))
+    }
+}
+
+/// Synthetic typed graph: `n` people of one of two types with a label + an age, so
+/// the introspection scan sees real predicate/type structure to summarise and the
+/// generated SELECT returns a non-empty result.
+fn synth_graph(n: usize) -> Graph {
+    let mut ttl = String::from(
+        "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n\
+         @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\
+         @prefix ex: <http://ex/> .\n",
+    );
+    for i in 0..n {
+        let ty = if i % 2 == 0 { "Person" } else { "Org" };
+        ttl.push_str(&format!(
+            "ex:e{i} rdf:type ex:{ty} ; rdfs:label \"entity {i}\" ; ex:age {} .\n",
+            20 + (i % 50)
+        ));
+    }
+    Graph::load_str(&ttl, "turtle").expect("synthetic graph parses")
+}
+
+fn timed<T>(label: &str, iters: u32, mut f: impl FnMut() -> T) -> T {
+    let mut best = f64::MAX;
+    let mut out = None;
+    for _ in 0..iters {
+        let t = Instant::now();
+        out = Some(f());
+        best = best.min(t.elapsed().as_secs_f64() * 1e6);
+    }
+    println!("{label:48} {best:12.2} us");
+    out.unwrap()
+}
+
+fn main() {
+    let n: usize = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(2000);
+    let graph = synth_graph(n);
+    println!("synthetic graph: {n} entities, {} triples\n", graph.len());
+
+    // The query the stub LLM "generates" — valid against the synthetic schema.
+    let sparql = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n\
+                  SELECT ?type (COUNT(?s) AS ?count)\n\
+                  WHERE { ?s rdf:type ?type }\n\
+                  GROUP BY ?type";
+
+    // 1. grounding: the introspection scan + summary render, once per graph.
+    let nlq = timed("ground (introspect scan + summary)", 5, || {
+        Nlq::new(&graph, Box::new(FixedLlm(sparql.to_string())))
+    });
+
+    // 2. prompt construction (deterministic, grounding-free of further index work).
+    let prompt = timed("prompt_for (build grounded prompt)", 100, || {
+        nlq.prompt_for("How many entities of each type are there?")
+    });
+    println!("  prompt: {} chars\n", prompt.len());
+
+    // 3. one full ask loop: extract → spargebra validate → budgeted execute.
+    let answer = timed("ask (extract + validate + execute)", 50, || {
+        nlq.ask("How many entities of each type are there?")
+            .expect("offline ask succeeds with the fixed stub")
+    });
+    println!(
+        "  answered in {} repair round(s); result rows = {}",
+        answer.repairs,
+        answer.result.len()
+    );
+
+    println!("\nok");
+}

--- a/crates/sparq-serve/examples/bench.rs
+++ b/crates/sparq-serve/examples/bench.rs
@@ -1,0 +1,115 @@
+//! sparq-serve concurrent-serving-core micro-benchmark. [OPUS-4.8] sq-ncvq.12. Run:
+//!     cargo run -p sparq-serve --example bench --release
+//!
+//! Measures the lock-free serving primitives that motivate the crate (the
+//! generation ring replacing the double-buffered snapshot scheme, §4.3/§4.4):
+//!   1. current() — the lock-free `ArcSwap::load` read every reader does on
+//!      entry to pin a generation (the hot path; must be ~ns);
+//!   2. publish() — one writer-side generation publish (arc-swap of a new
+//!      immutable snapshot + per-pod epoch bump), the cost a reader NEVER pays;
+//!   3. scheduler — `run` round-trip through the two-lane cost-aware pool for a
+//!      cheap job and a heavy job (submit → worker → result).
+//!
+//! The snapshot type is a cheap `usize` so the numbers isolate the ring/scheduler
+//! machinery, NOT graph-build cost (that is the engine's ingest benches). A
+//! concurrent-reader arm reports aggregate current() throughput while a writer
+//! publishes, exercising the readers-never-block-the-writer invariant.
+//!
+//! NON-CANONICAL timing (this box is not a quiet bench instance) — the numbers are
+//! a sanity-scale signal, not a published baseline.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use sparq_serve::{Cost, GenerationRing, PodId, Scheduler};
+
+fn timed(label: &str, iters: u64, mut f: impl FnMut()) {
+    // Best-of-5 over `iters` ops; report per-op nanoseconds.
+    let mut best = f64::MAX;
+    for _ in 0..5 {
+        let t = Instant::now();
+        for _ in 0..iters {
+            f();
+        }
+        let per = t.elapsed().as_secs_f64() * 1e9 / iters as f64;
+        best = best.min(per);
+    }
+    println!("{label:48} {best:12.2} ns/op");
+}
+
+fn main() {
+    let pods: Vec<PodId> = (0..8).map(|i| PodId::from(format!("pod{i}"))).collect();
+    let ring: Arc<GenerationRing<usize>> = Arc::new(GenerationRing::new(0usize));
+
+    // 1. lock-free reader pin — the hot path.
+    timed("current() (lock-free reader pin)", 5_000_000, || {
+        std::hint::black_box(ring.current());
+    });
+
+    // 2. writer publish — arc-swap a new snapshot + bump the touched pods' epochs.
+    {
+        let mut n = 0usize;
+        let pods = pods.clone();
+        timed("publish() (snapshot swap + epoch bump)", 200_000, || {
+            n += 1;
+            ring.publish(n, [pods[n % pods.len()].clone()]);
+        });
+    }
+
+    // 3. scheduler round-trip: a cheap job and a heavy job through the two lanes.
+    let sched: Arc<Scheduler<u64>> = Scheduler::with_defaults();
+    let cheap: Cost = 1;
+    let heavy: Cost = 1_000_000;
+    timed("scheduler.run cheap-lane round-trip", 50_000, || {
+        let r = sched.run(cheap, || 7u64).expect("cheap job runs");
+        std::hint::black_box(r);
+    });
+    timed("scheduler.run heavy-lane round-trip", 50_000, || {
+        let r = sched.run(heavy, || 9u64).expect("heavy job runs");
+        std::hint::black_box(r);
+    });
+
+    // 4. concurrent invariant: readers pin generations at full speed while a
+    //    writer publishes — readers-never-block-the-writer (§4.3). Reports the
+    //    aggregate reader throughput observed during a fixed publish burst.
+    {
+        let stop = Arc::new(AtomicBool::new(false));
+        let reads = Arc::new(AtomicU64::new(0));
+        let mut handles = Vec::new();
+        for _ in 0..4 {
+            let ring = ring.clone();
+            let stop = stop.clone();
+            let reads = reads.clone();
+            handles.push(std::thread::spawn(move || {
+                let mut local = 0u64;
+                while !stop.load(Ordering::Relaxed) {
+                    std::hint::black_box(ring.current());
+                    local += 1;
+                }
+                reads.fetch_add(local, Ordering::Relaxed);
+            }));
+        }
+        let t = Instant::now();
+        let mut n = 1_000_000usize;
+        for _ in 0..50_000 {
+            n += 1;
+            ring.publish(n, [pods[n % pods.len()].clone()]);
+        }
+        let publish_s = t.elapsed().as_secs_f64();
+        stop.store(true, Ordering::Relaxed);
+        for h in handles {
+            h.join().expect("reader thread joins");
+        }
+        let total_reads = reads.load(Ordering::Relaxed);
+        println!(
+            "\nconcurrent: 50000 publishes in {:.4}s; 4 readers did {} pins \
+             (~{:.1} M pins/s aggregate) — none blocked",
+            publish_s,
+            total_reads,
+            total_reads as f64 / publish_s / 1e6
+        );
+    }
+
+    println!("\nok");
+}

--- a/scripts/drift-scan.py
+++ b/scripts/drift-scan.py
@@ -72,9 +72,20 @@ BASE_LABELS = ["drift", "auto"]
 #     suites (cli-bench-*, sparq-bench-compare, operator-coverage, …) drive;
 #   - sparq-canon: a thin RDFC-1.0 lib surfaced via the rdf-canon skill, no
 #     standalone perf surface.
+#   - sparq-py: a thin pyo3 binding (`crate-type = ["cdylib"]`, publish = false).
+#     It exposes NO native Rust-callable surface a Rust example/criterion bench
+#     could touch — it is loadable ONLY as a CPython extension module (built by
+#     maturin), and its engine logic is a thin wrapper over sparq-core/engine/
+#     reason that the CLI / operator-coverage suites already measure. A meaningful
+#     Python-level bench would need a built wheel + a pytest-benchmark harness in
+#     CI (outside the Rust-bench registry model), so it is HONESTLY exempted here
+#     rather than carrying a fake Rust bench. (sq-ncvq.12, drift catch-up A.)
 # Everything NOT listed here is scanned — so genuinely unbenched surfaces
-# (sparq-nlq, sparq-py, sparq-serve, sparq-mpc, sparq-wasm, the zk crates …)
-# still surface, matching the design's concrete §5.A gap list.
+# still surface, matching the design's concrete §5.A gap list. The other §5.A
+# crates are now COVERED by registered benches (sq-ncvq.12): sparq-mpc
+# (mpc-bench-matrix, the existing counting-tier example), sparq-wasm (wasm-bundle,
+# the deterministic browser-bundle-size measurement), sparq-nlq (nlq-offline-bench),
+# and sparq-serve (serve-core-bench).
 BENCH_EXEMPT_CRATES = frozenset(
     {
         "sparq-bench",
@@ -83,6 +94,7 @@ BENCH_EXEMPT_CRATES = frozenset(
         "sparq-engine",
         "sparq-cli",
         "sparq-canon",
+        "sparq-py",
     }
 )
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Bead **sq-ncvq.12** (drift catch-up A). The periodic drift-scanner (#252, `scripts/drift-scan.py` §5.A `bench-missing`) flagged five crates with NO registered benchmark in `bench/benchmarks.toml`. This closes all five.

## Crates covered

| Crate | Action | Registry id |
|---|---|---|
| `sparq-mpc` | **Registered existing** `examples/mpc_bench_matrix.rs` (in-process counting tier: deterministic MODELLED communication + per-cell security guarantee; co-run correctness gates under `insecure-test-rng`) | `mpc-bench-matrix` |
| `sparq-wasm` | **Registered existing** deterministic browser-bundle-size measurement (`wasm_bundle_bytes`, already emitted by `ci-bench.sh`) under the crate — its distinct surface, since query/load is thin glue over the already-benched engine | `wasm-bundle` |
| `sparq-nlq` | **New** small OFFLINE example bench: schema grounding + `prompt_for` + one full extract→spargebra-validate→execute `ask` loop with an in-example fixed-completion stub LLM (no `live`, no network) | `nlq-offline-bench` |
| `sparq-serve` | **New** small example bench of the lock-free serving primitives: `current()` reader-pin, `publish()` snapshot-swap + epoch-bump, two-lane `Scheduler::run` round-trip, concurrent readers-never-block arm | `serve-core-bench` |
| `sparq-py` | **Honestly exempted** in the drift-scanner — a thin pyo3 `crate-type=["cdylib"]`, `publish=false` binding with NO native Rust-callable surface a Rust bench could touch (loadable only as a CPython ext module via maturin); engine logic already measured by the CLI/operator-coverage suites. Real bench would need a built wheel + pytest-benchmark harness (outside the Rust-bench registry model) — exempted, not faked | — |

## Verify
- `drift-scan --dry-run` bench-missing: **8 → 3** (remaining: `sparq-server`, `sparq-zk`, `sparq-zk-compose` — out of scope; zk is the separate ZK bench feed)
- New example benches **build + run** clean (`cargo build --examples`); `cargo clippy` clean on new bench code + mpc examples
- `benchmarks.toml` parses (`tomllib`, 58 entries, no dup ids, all required fields present for the dashboard / run+track CI lanes)
- 21/21 `scripts/tests/test_drift_scan.py` pass
- Staged explicit paths only; **NON-CANONICAL** timing — no hard-coded perf numbers

Refs sq-ncvq.12.