### PR TITLE
fix(flow-on): drop G1-redundant new-crate rule + gate skill-sync on net pub-API diff

### DIFF
--- a/scripts/flow-on-rules.toml
+++ b/scripts/flow-on-rules.toml
@@ -46,50 +46,36 @@
 #   labels    = ["extra", "labels"]         # optional; `flow-on` + `auto` are ALWAYS added
 # ---------------------------------------------------------------------------
 
-# --- New crate / public surface → benchmark + README + SKILL.md ----------------
-# Trigger: a brand-new `crates/<x>/Cargo.toml` is ADDED. A new crate must ship a
-# registered benchmark and (if it is a public surface) a SKILL.md. The gateable
-# subset (README template) is handled by check-readme-template.py; this flow-on
-# captures the out-of-band bench registration + SKILL authoring.
-[[rule]]
-id = "new-crate-bench-and-skill"
-description = "A new crate landed; ensure it has a registered benchmark and (if public) a SKILL.md."
-when_new_paths = ["crates/*/Cargo.toml"]
-
-[[rule.create]]
-dedup_key = "new-crate-bench-{crate}"
-title = "bench: register a benchmark for new crate {crate}"
-labels = ["bench"]
-body = """
-Merged PR #{pr} ({pr_title}) added a new crate `crates/{crate}`.
-
-Per the maintenance flow-on rules, a new crate must have a registered benchmark
-so it is visible to CATALOG / CI / the dashboard. Add a `[[benchmark]]` entry in
-`bench/benchmarks.toml` (with `source = crates/{crate}`), or — if the crate is an
-intentional stub — mark it `publish = false` and record an exemption bead.
-"""
-
-[[rule.create]]
-dedup_key = "new-crate-skill-{crate}"
-title = "docs: add a SKILL.md surface for new crate {crate}"
-labels = ["docs", "cert"]
-body = """
-Merged PR #{pr} ({pr_title}) added a new crate `crates/{crate}`.
-
-If `crates/{crate}` exposes a public surface (CLI / HTTP route / Py·JS binding /
-public Rust API), it needs a `skills/<surface>/SKILL.md` and a conformance/cert
-plan (cf. the sparq-shacl crate-local W3C ratchet). If it is internal-only,
-record that decision explicitly so the gap is not re-flagged.
-"""
+# --- New crate → benchmark + README + SKILL.md  [REMOVED — owned by gate G1] ----
+# There is intentionally NO reactive "register a bench / add a SKILL for the new
+# crate {crate}" rule here. The PROACTIVE merge gate G1 (scripts/gate-new-crate.py,
+# merged #221) ALREADY enforces — and BLOCKS the merge on — a registered benchmark
+# + README + (for a public crate) a SKILL.md *in the same PR* that adds the crate.
+# So by the time a new-crate PR is MERGED, those artifacts are guaranteed present;
+# a post-merge follow-on issue would be pure noise (dogfooded: this rule minted the
+# redundant #245 / #246 / #264 / #265 bench+SKILL follow-ons — bead sq-l0a0).
+#
+# G1 is the single owner of new-crate completeness. The stub escape hatch
+# (`publish = false`) is likewise handled there. If G1 is ever relaxed to a
+# non-blocking advisory, restore a SAFETY-NET reactive rule here — but it must
+# CHECK that the crate genuinely lacks the bench/SKILL on `main` before creating
+# (don't blindly mint), not re-emit unconditionally as the old rule did.
 
 # --- Changed public feature → docs / SKILL.md update ---------------------------
 # Trigger: a change under a published crate's surface, the CLI, the HTTP server,
-# or the Py/WASM bindings, WITHOUT a corresponding SKILL.md edit. (flow-on.py only
-# fires this when no skills/** file is in the same diff — see SKILL_PATHS in
-# flow-on.py.) Keeps the AGENTS.md public-API→SKILL.md norm from silently drifting.
+# or the Py/WASM bindings, WITHOUT a corresponding SKILL.md edit.
+#
+# [OPUS-4.8] The `when_paths` glob is only a CHEAP PRE-FILTER. flow-on.py fires
+# this rule ONLY when, in addition, (a) no skills/** file is in the same diff
+# (SKILL_PATHS) AND (b) the PR's unified diff NET-changes a `pub `-exported item
+# under one of these surfaces — using the SAME pub-item multiset diff as gate G2
+# (scripts/pub_api_diff.py). A comment-only / lint-attribute-only / pure-relocation
+# edit therefore does NOT mint a follow-on (dogfooded: PR #250 mis-fired this rule
+# on a comment+lint-attr-only diff — bead sq-l0a0). Keeps the AGENTS.md
+# public-API → SKILL.md norm from drifting without flagging inert edits.
 [[rule]]
 id = "changed-public-feature-docs"
-description = "A public surface changed without a SKILL.md update in the same PR."
+description = "A NET public-API change to a surface without a SKILL.md update in the same PR."
 when_paths = [
   "crates/sparq-cli/src/**",
   "crates/sparq-server/src/**",

--- a/scripts/flow-on.py
+++ b/scripts/flow-on.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
+import importlib.util
 import json
 import os
 import re
@@ -51,6 +52,29 @@ BASE_LABELS = ["flow-on", "auto"]
 # docs rule ONLY when no SKILL.md was touched in the same PR. A change anywhere
 # under skills/ counts as "the docs were synced", suppressing that rule.
 SKILL_PATHS = ("skills/",)
+
+# The reactive docs rule that the pub-API-diff gate below applies to.
+DOCS_RULE_ID = "changed-public-feature-docs"
+
+
+# [OPUS-4.8] The `changed-public-feature-docs` rule must fire ONLY on a NET
+# public-API change — never on a comment-only / lint-attribute-only / pure
+# relocation diff (dogfooded: PR #250 mis-minted a skill-sync follow-on for a
+# comment+lint-attr-only diff — bead sq-l0a0). We reuse the EXACT `pub `-item
+# multiset-diff used by merge gate G2, factored into scripts/pub_api_diff.py, so
+# the reactive engine and the proactive gate can never drift. Loaded by path
+# (the scripts dir is not an importable package).
+def _load_pub_api_diff():
+    spec = importlib.util.spec_from_file_location(
+        "pub_api_diff", REPO_ROOT / "scripts" / "pub_api_diff.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_pad = _load_pub_api_diff()
 
 
 @dataclass
@@ -176,7 +200,14 @@ def _any_glob_match(globs: list[str], paths: list[str]) -> bool:
     return False
 
 
-def rule_matches(rule: Rule, changed: list[str], added: list[str], labels: list[str], title: str) -> bool:
+def rule_matches(
+    rule: Rule,
+    changed: list[str],
+    added: list[str],
+    labels: list[str],
+    title: str,
+    pub_changed: set[str] | None = None,
+) -> bool:
     # ALL present predicates must pass; absent predicates are ignored.
     if rule.when_paths and not _any_glob_match(rule.when_paths, changed):
         return False
@@ -187,10 +218,27 @@ def rule_matches(rule: Rule, changed: list[str], added: list[str], labels: list[
     if rule.when_title is not None and not re.search(rule.when_title, title, re.IGNORECASE):
         return False
 
-    # Special case for the changed-public-feature docs rule: suppress it when the
-    # PR already touched a SKILL.md (the docs were synced in the same diff).
-    if rule.id == "changed-public-feature-docs":
+    # [OPUS-4.8] Special handling for the changed-public-feature docs rule
+    # (bead sq-l0a0). The when_paths glob is only a cheap pre-filter; on top of it
+    # two further conditions must hold for the follow-on to be genuine:
+    #   1. no SKILL.md was touched in the same diff (the docs were already synced
+    #      → suppress, identical to gate G2's SKILL suppression); AND
+    #   2. the PR's diff NET-changes a `pub `-exported item under one of the
+    #      matched surfaces (`pub_changed`), so a comment-only / lint-attr-only /
+    #      pure-relocation edit does NOT mint a redundant follow-on.
+    # `pub_changed` is the set of changed paths whose unified diff has a net
+    # public-API change. `None` means "diff not available" → conservatively treat
+    # as no net change (do NOT fire), so a caller that cannot inspect the diff
+    # never produces a false-positive follow-on.
+    if rule.id == DOCS_RULE_ID:
         if any(p.startswith(SKILL_PATHS) for p in changed):
+            return False
+        net = pub_changed or set()
+        # Fire only when at least one of THIS rule's matched surface paths has a
+        # net public-API change.
+        if not any(
+            _any_glob_match(rule.when_paths, [p]) and p in net for p in changed
+        ):
             return False
     return True
 
@@ -206,12 +254,13 @@ def evaluate(
     changed: list[str],
     added: list[str],
     labels: list[str],
+    pub_changed: set[str] | None = None,
 ) -> list[FollowOn]:
     ctx = build_context(pr, pr_title, changed, added)
     out: list[FollowOn] = []
     seen_keys: set[str] = set()
     for rule in rules:
-        if not rule_matches(rule, changed, added, labels, pr_title):
+        if not rule_matches(rule, changed, added, labels, pr_title, pub_changed):
             continue
         for tmpl in rule.creates:
             dedup_key = expand(tmpl.dedup_key, ctx)
@@ -249,23 +298,48 @@ def _gh(args: list[str]) -> str:
     return proc.stdout
 
 
-def fetch_pr_inputs(pr: int) -> tuple[str, list[str], list[str], list[str]]:
-    """Return (title, changed_files, added_files, labels) for a merged PR via gh."""
+def fetch_pr_inputs(pr: int) -> tuple[str, list[str], list[str], list[str], set[str]]:
+    """Return (title, changed_files, added_files, labels, pub_changed) for a
+    merged PR via gh. `pub_changed` is the set of changed paths whose unified diff
+    NET-changes a `pub `-exported item (used by the docs rule)."""
     info = json.loads(_gh(["pr", "view", str(pr), "--json", "title,labels,files"]))
     title = info.get("title", "")
     labels = [lbl["name"] for lbl in info.get("labels", [])]
     files = info.get("files", [])
     changed = [f["path"] for f in files]
-    # gh's files[].additions/deletions don't reveal status; use the diff to find
-    # purely-added files (status "A").
-    added = _added_files_via_diff(pr)
-    return title, changed, added, labels
-
-
-def _added_files_via_diff(pr: int) -> list[str]:
-    # `gh pr diff --name-only` lists changed files but not status. Use the patch
-    # and detect "new file mode" hunks for added-file paths.
+    # gh's files[].additions/deletions don't reveal status; parse the patch once
+    # for both purely-added files (status "A") and the per-file pub-API verdict.
     patch = _gh(["pr", "diff", str(pr)])
+    added = _added_files_from_patch(patch)
+    pub_changed = pub_changed_from_patch(patch)
+    return title, changed, added, labels, pub_changed
+
+
+def _split_patch_per_file(patch: str) -> dict[str, list[str]]:
+    """Split a unified `gh pr diff` patch into {dest_path: [diff lines]}.
+
+    The destination path is taken from each `+++ b/<path>` header; lines before
+    the first header are ignored. A deleted file (`+++ /dev/null`) is skipped."""
+    per_file: dict[str, list[str]] = {}
+    cur_path: str | None = None
+    for line in patch.splitlines():
+        if line.startswith("diff --git "):
+            cur_path = None
+            continue
+        if line.startswith("+++ b/"):
+            cur_path = line[len("+++ b/") :]
+            per_file.setdefault(cur_path, [])
+            continue
+        if line.startswith("+++ "):  # +++ /dev/null (deletion) — no dest path
+            cur_path = None
+            continue
+        if cur_path is not None:
+            per_file[cur_path].append(line)
+    return per_file
+
+
+def _added_files_from_patch(patch: str) -> list[str]:
+    # Detect "new file mode" hunks for added-file (status "A") paths.
     added: list[str] = []
     cur_new = False
     for line in patch.splitlines():
@@ -274,9 +348,22 @@ def _added_files_via_diff(pr: int) -> list[str]:
         elif line.startswith("new file mode"):
             cur_new = True
         elif line.startswith("+++ b/") and cur_new:
-            added.append(line[len("+++ b/"):])
+            added.append(line[len("+++ b/") :])
             cur_new = False
     return added
+
+
+def pub_changed_from_patch(patch: str) -> set[str]:
+    """Return the set of changed paths whose per-file diff NET-changes a
+    `pub `-exported item, using the shared gate-G2 multiset diff. Only
+    `crates/*/src/**` paths can qualify (matches the gate's scope)."""
+    out: set[str] = set()
+    for path, lines in _split_patch_per_file(patch).items():
+        if not re.match(r"^crates/[^/]+/src/.+", path):
+            continue
+        if _pad.diff_has_net_pub_change(lines):
+            out.add(path)
+    return out
 
 
 def open_issue_exists(dedup_key: str) -> bool:
@@ -359,6 +446,16 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--added-files", help="file with one ADDED path per line (subset of changed)")
     ap.add_argument("--labels-file", help="file with one PR label per line")
     ap.add_argument("--title", help="PR title")
+    # [OPUS-4.8] Hermetic injection of the "net public-API change" verdict used by
+    # the changed-public-feature-docs rule (bead sq-l0a0): one path per line, each
+    # a changed crate src file whose diff NET-changes a `pub `-item. When omitted
+    # in hermetic mode the set is EMPTY, so the docs rule does NOT fire (a
+    # comment-only diff mints nothing). The real gh path computes this from the
+    # PR patch via the shared gate-G2 pub-item multiset diff.
+    ap.add_argument(
+        "--pub-diff-file",
+        help="file with one changed src path per line that has a NET pub-API change",
+    )
     args = ap.parse_args(argv)
 
     rules = load_rules(Path(args.rules))
@@ -375,10 +472,11 @@ def main(argv: list[str] | None = None) -> int:
         added = _read_lines(args.added_files) if args.added_files else []
         labels = _read_lines(args.labels_file) if args.labels_file else []
         title = args.title
+        pub_changed = set(_read_lines(args.pub_diff_file)) if args.pub_diff_file else set()
     else:
-        title, changed, added, labels = fetch_pr_inputs(args.pr)
+        title, changed, added, labels, pub_changed = fetch_pr_inputs(args.pr)
 
-    follow_ons = evaluate(rules, args.pr, title, changed, added, labels)
+    follow_ons = evaluate(rules, args.pr, title, changed, added, labels, pub_changed)
 
     if not follow_ons:
         print(f"flow-on: no rules triggered for PR #{args.pr}.")

--- a/scripts/gate-api-skill.py
+++ b/scripts/gate-api-skill.py
@@ -70,6 +70,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import os
 import re
 import subprocess
@@ -77,6 +78,24 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# [OPUS-4.8] The `pub `-item multiset-diff logic now lives in ONE shared module
+# (scripts/pub_api_diff.py) so the reactive flow-on engine
+# (scripts/flow-on.py, rule `changed-public-feature-docs`) reuses the EXACT same
+# net-public-API-change test this gate uses — the two can no longer drift
+# (bead sq-l0a0). Loaded by path (the scripts dir is not an importable package).
+def _load_pub_api_diff():
+    spec = importlib.util.spec_from_file_location(
+        "pub_api_diff", REPO_ROOT / "scripts" / "pub_api_diff.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_pad = _load_pub_api_diff()
 
 # [OPUS-4.8] Binding / entry-point crates (sparq-cli/server/py/wasm). HISTORICALLY
 # any src/** change here was a public-surface change; that blanket rule
@@ -151,17 +170,12 @@ def crate_is_published(crate: str) -> bool:
     return re.search(r"^\s*publish\s*=\s*false\b", text, re.MULTILINE) is None
 
 
-# [OPUS-4.8] A line is a PUBLIC-ITEM signature iff, after the leading diff marker
-# (+/-) and any indentation, it begins with `pub ` (whitespace-separated) followed
-# by one of the exported item keywords. Requiring whitespace after `pub` excludes
-# restricted visibilities (`pub(crate)`/`pub(super)`/`pub(in …)`, all written
-# `pub(` with no space) — those are NOT the crate's public surface (AGENTS.md:
-# public API == exported items). The item-keyword anchor further excludes e.g. a
-# `pub` struct *field* (`pub name: T`) whose addition/removal is an internal-detail
-# edit, not a new exported path — only the eight item forms below count.
-_PUB_ITEM_RE = re.compile(
-    r"^[+-]\s*pub\s+(?:fn|struct|enum|trait|const|type|mod|use)\b"
-)
+# [OPUS-4.8] The PUBLIC-ITEM signature pattern + the diff scanner now live in the
+# shared scripts/pub_api_diff.py (so flow-on.py reuses the identical test). These
+# module-level aliases preserve the historical `_PUB_ITEM_RE` / `_scan_pub_diff`
+# names this gate (and test_gates.py) reference.
+_PUB_ITEM_RE = _pad.PUB_ITEM_RE
+_scan_pub_diff = _pad.scan_pub_diff
 
 
 def pub_diff_lines(path: str, base: str) -> tuple[list[str], list[str]]:
@@ -184,24 +198,6 @@ def pub_diff_lines(path: str, base: str) -> tuple[list[str], list[str]]:
     except subprocess.CalledProcessError:  # pragma: no cover - CI-only
         return [], []
     return _scan_pub_diff(out.splitlines())
-
-
-def _scan_pub_diff(diff_lines: list[str]) -> tuple[list[str], list[str]]:
-    """Pure helper: split unified-diff lines into (added, removed) public-item
-    signatures (marker stripped, inner whitespace normalised)."""
-    added: list[str] = []
-    removed: list[str] = []
-    for line in diff_lines:
-        # Skip file headers (`+++ b/…`, `--- a/…`) — never item signatures.
-        if line.startswith("+++") or line.startswith("---"):
-            continue
-        if not _PUB_ITEM_RE.match(line):
-            continue
-        # Normalise: drop the +/- marker, collapse inner whitespace so a moved
-        # signature matches itself regardless of re-indentation.
-        norm = " ".join(line[1:].split())
-        (added if line[0] == "+" else removed).append(norm)
-    return added, removed
 
 
 def pub_api_changed(path: str, base: str) -> bool:

--- a/scripts/pub_api_diff.py
+++ b/scripts/pub_api_diff.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Shared `pub `-item diff helper (bead sq-l0a0, branch
+# feat-flow-on-refine). Authored by Opus 4.8 (Fable unavailable; flag for
+# re-review when Fable returns).
+#
+# WHY THIS MODULE EXISTS
+# ----------------------
+# Both halves of the maintenance flow-on system need to answer the SAME question
+# — "does this unified diff NET-change a crate's PUBLIC Rust surface?" —
+# distinguishing a genuine new/removed `pub ` export from inert
+# comment / lint-attribute / pure-relocation edits:
+#
+#   * the PROACTIVE merge gate G2 (scripts/gate-api-skill.py) BLOCKS a PR that
+#     changes a public surface without syncing a SKILL.md;
+#   * the REACTIVE engine (scripts/flow-on.py, rule `changed-public-feature-docs`)
+#     mints a "sync SKILL.md" follow-on ISSUE after merge for the same case.
+#
+# G2 originally tripped on ANY src change to a binding crate; PR #258 replaced
+# that with a `pub `-item MULTISET diff (added vs removed signatures) so only a
+# NET public-API change counts. The reactive flow-on rule was NOT given the same
+# treatment, so it kept firing on comment-only / lint-attr-only / relocation
+# diffs (dogfooded: PR #250 minted a redundant skill-sync follow-on for a
+# comment+lint-attr-only diff — bead sq-l0a0). This module factors the G2 logic
+# into ONE place both scripts import, so the two halves can never drift again.
+#
+# stdlib-only; no I/O — callers feed it unified-diff lines they already have.
+
+from __future__ import annotations
+
+import re
+
+# [OPUS-4.8] A line is a PUBLIC-ITEM signature iff, after the leading diff marker
+# (+/-) and any indentation, it begins with `pub ` (whitespace-separated) followed
+# by one of the exported item keywords. Requiring whitespace after `pub` excludes
+# restricted visibilities (`pub(crate)`/`pub(super)`/`pub(in …)`, all written
+# `pub(` with no space) — those are NOT the crate's public surface. The
+# item-keyword anchor further excludes a `pub` struct *field* (`pub name: T`),
+# whose addition/removal is an internal-detail edit, not a new exported path —
+# only the eight item forms below count.
+PUB_ITEM_RE = re.compile(r"^[+-]\s*pub\s+(?:fn|struct|enum|trait|const|type|mod|use)\b")
+
+
+def scan_pub_diff(diff_lines: list[str]) -> tuple[list[str], list[str]]:
+    """Split unified-diff lines into (added, removed) public-item signatures.
+
+    Each returned string is the diff line with its leading +/- marker stripped and
+    inner whitespace collapsed, so an identical signature that is both added and
+    removed (a pure relocation / re-indentation) compares equal across the two
+    lists. File headers (`+++ b/…`, `--- a/…`) are skipped — they are never item
+    signatures."""
+    added: list[str] = []
+    removed: list[str] = []
+    for line in diff_lines:
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if not PUB_ITEM_RE.match(line):
+            continue
+        norm = " ".join(line[1:].split())
+        (added if line[0] == "+" else removed).append(norm)
+    return added, removed
+
+
+def diff_has_net_pub_change(diff_lines: list[str]) -> bool:
+    """True iff `diff_lines` (a unified diff) NET-changes a `pub `-exported item.
+
+    A pure RELOCATION — the same signature added once and removed once (net-zero)
+    — is NOT a public-API change. We compare added vs removed signatures as
+    MULTISETS and report a change only when they differ: a genuinely NEW or
+    DELETED export, or a signature whose text actually changed. Comment-only /
+    attribute-only / non-`pub` edits yield two empty lists → no change."""
+    added, removed = scan_pub_diff(diff_lines)
+    return sorted(added) != sorted(removed)

--- a/scripts/tests/test_flow_on.py
+++ b/scripts/tests/test_flow_on.py
@@ -45,7 +45,6 @@ class RuleLoadingTest(unittest.TestCase):
         ids = {r.id for r in rules}
         # The taxonomy rules the design requires must all be present.
         for required in (
-            "new-crate-bench-and-skill",
             "changed-public-feature-docs",
             "new-bench-dashboard-row",
             "competitor-feature-gather",
@@ -54,6 +53,11 @@ class RuleLoadingTest(unittest.TestCase):
             "new-zk-circuit-gatecount",
         ):
             self.assertIn(required, ids)
+        # [OPUS-4.8] (bead sq-l0a0) The new-crate bench/SKILL follow-on rule was
+        # REMOVED — merge gate G1 (scripts/gate-new-crate.py) already enforces a
+        # registered bench + README + SKILL in the SAME PR, so a post-merge
+        # follow-on for them was pure redundant noise (minted #245/#246/#264/#265).
+        self.assertNotIn("new-crate-bench-and-skill", ids)
         # Every rule has a trigger + at least one create template.
         for r in rules:
             self.assertTrue(
@@ -64,7 +68,10 @@ class RuleLoadingTest(unittest.TestCase):
 
 
 class NewCrateTest(unittest.TestCase):
-    """A PR that adds crates/sparq-foo/ must yield the bench + SKILL follow-ons."""
+    """[OPUS-4.8] (bead sq-l0a0) A new-crate PR must yield NO bench/SKILL
+    follow-on: merge gate G1 already guarantees a registered bench + README +
+    SKILL in the SAME PR, so the old reactive follow-on was pure redundant noise
+    (minted #245/#246/#264/#265). The rule was removed."""
 
     def setUp(self):
         self.rules = flow_on.load_rules(RULES)
@@ -74,31 +81,27 @@ class NewCrateTest(unittest.TestCase):
             self.rules, 42, title, changed, added, labels or []
         )
 
-    def test_new_crate_triggers_bench_and_skill(self):
+    def test_new_crate_with_bench_and_skill_yields_no_redundant_follow_on(self):
+        # A new crate that ships (as G1 requires) its bench + README + SKILL must
+        # NOT mint a bench/SKILL follow-on — G1 owns that, in-PR.
         added = [
             "crates/sparq-foo/Cargo.toml",
             "crates/sparq-foo/src/lib.rs",
             "crates/sparq-foo/README.md",
         ]
-        fos = self._eval(changed=added, added=added)
-        rule_ids = {fo.rule_id for fo in fos}
-        self.assertIn("new-crate-bench-and-skill", rule_ids)
-
+        changed = added + ["bench/benchmarks.toml", "skills/sparq-foo/SKILL.md"]
+        fos = self._eval(changed=changed, added=added)
         keys = {fo.dedup_key for fo in fos}
-        self.assertIn("new-crate-bench-sparq-foo", keys)
-        self.assertIn("new-crate-skill-sparq-foo", keys)
+        self.assertNotIn("new-crate-bench-sparq-foo", keys)
+        self.assertNotIn("new-crate-skill-sparq-foo", keys)
+        self.assertNotIn("new-crate-bench-and-skill", {fo.rule_id for fo in fos})
 
-        # The {crate} placeholder is expanded in titles + bodies.
-        bench_fo = next(fo for fo in fos if fo.dedup_key == "new-crate-bench-sparq-foo")
-        self.assertIn("sparq-foo", bench_fo.title)
-        self.assertIn("sparq-foo", bench_fo.body)
-        self.assertNotIn("{crate}", bench_fo.title)
-        self.assertNotIn("{crate}", bench_fo.body)
-
-        # Base labels always present; the idempotency marker is embedded.
-        self.assertIn("flow-on", bench_fo.labels)
-        self.assertIn("auto", bench_fo.labels)
-        self.assertIn(flow_on.key_marker("new-crate-bench-sparq-foo"), bench_fo.body)
+    def test_new_crate_alone_yields_no_redundant_follow_on(self):
+        # Even a bare new crate (which G1 would BLOCK at merge) mints no flow-on
+        # follow-on — the redundant rule is gone.
+        added = ["crates/sparq-foo/Cargo.toml", "crates/sparq-foo/src/lib.rs"]
+        fos = self._eval(changed=added, added=added)
+        self.assertNotIn("new-crate-bench-and-skill", {fo.rule_id for fo in fos})
 
     def test_modifying_existing_crate_file_does_not_fire_new_crate_rule(self):
         # Cargo.toml is CHANGED but not ADDED -> when_new_paths must not match.
@@ -112,15 +115,79 @@ class ChangedSurfaceTest(unittest.TestCase):
     def setUp(self):
         self.rules = flow_on.load_rules(RULES)
 
-    def test_cli_change_without_skill_fires_docs_rule(self):
+    def test_cli_pub_change_without_skill_fires_docs_rule(self):
+        # [OPUS-4.8] (bead sq-l0a0) A NET public-API change (the path is in
+        # pub_changed) without a SKILL.md DOES fire — the genuinely-useful case.
         changed = ["crates/sparq-cli/src/main.rs"]
-        fos = flow_on.evaluate(self.rules, 7, "add --explain flag", changed, [], [])
+        fos = flow_on.evaluate(
+            self.rules, 7, "add --explain flag", changed, [], [],
+            pub_changed={"crates/sparq-cli/src/main.rs"},
+        )
         self.assertIn("changed-public-feature-docs", {fo.rule_id for fo in fos})
 
-    def test_cli_change_with_skill_update_suppresses_docs_rule(self):
-        changed = ["crates/sparq-cli/src/main.rs", "skills/cli/SKILL.md"]
-        fos = flow_on.evaluate(self.rules, 8, "add --explain flag", changed, [], [])
+    def test_cli_comment_only_change_does_not_fire_docs_rule(self):
+        # [OPUS-4.8] (bead sq-l0a0) REGRESSION (mis-fired #250): a comment-only /
+        # lint-attribute-only edit to a public surface is NOT a net public-API
+        # change (the path is absent from pub_changed), so it mints NO skill-sync
+        # follow-on — even without a SKILL.md in the diff.
+        changed = ["crates/sparq-cli/src/main.rs"]
+        fos = flow_on.evaluate(
+            self.rules, 250, "add SAFETY comments + #![warn] attrs", changed, [], [],
+            pub_changed=set(),
+        )
         self.assertNotIn("changed-public-feature-docs", {fo.rule_id for fo in fos})
+
+    def test_cli_change_with_skill_update_suppresses_docs_rule(self):
+        # A SKILL.md in the same diff means the docs were synced → suppress, even
+        # on a real pub change.
+        changed = ["crates/sparq-cli/src/main.rs", "skills/cli/SKILL.md"]
+        fos = flow_on.evaluate(
+            self.rules, 8, "add --explain flag", changed, [], [],
+            pub_changed={"crates/sparq-cli/src/main.rs"},
+        )
+        self.assertNotIn("changed-public-feature-docs", {fo.rule_id for fo in fos})
+
+
+class PubApiDiffPlumbingTest(unittest.TestCase):
+    """[OPUS-4.8] (bead sq-l0a0) The docs rule reuses gate G2's shared pub-item
+    multiset diff (scripts/pub_api_diff.py). Verify the patch→pub_changed plumbing
+    distinguishes a genuine new `pub fn` from a comment/attr/relocation diff."""
+
+    def test_pub_changed_from_patch_detects_new_pub_fn(self):
+        patch = (
+            "diff --git a/crates/sparq-cli/src/main.rs b/crates/sparq-cli/src/main.rs\n"
+            "--- a/crates/sparq-cli/src/main.rs\n"
+            "+++ b/crates/sparq-cli/src/main.rs\n"
+            "@@ -1,0 +1,1 @@\n"
+            "+pub fn brand_new_flag() {}\n"
+        )
+        self.assertEqual(
+            flow_on.pub_changed_from_patch(patch),
+            {"crates/sparq-cli/src/main.rs"},
+        )
+
+    def test_pub_changed_from_patch_ignores_comment_and_attr_only(self):
+        patch = (
+            "diff --git a/crates/sparq-cli/src/main.rs b/crates/sparq-cli/src/main.rs\n"
+            "--- a/crates/sparq-cli/src/main.rs\n"
+            "+++ b/crates/sparq-cli/src/main.rs\n"
+            "@@ -1,0 +1,2 @@\n"
+            "+// SAFETY: this is sound because ...\n"
+            "+#![warn(clippy::all)]\n"
+        )
+        self.assertEqual(flow_on.pub_changed_from_patch(patch), set())
+
+    def test_pub_changed_from_patch_ignores_pure_relocation(self):
+        patch = (
+            "diff --git a/crates/sparq-cli/src/main.rs b/crates/sparq-cli/src/main.rs\n"
+            "--- a/crates/sparq-cli/src/main.rs\n"
+            "+++ b/crates/sparq-cli/src/main.rs\n"
+            "@@ -10,1 +10,0 @@\n"
+            "-pub fn moved() {}\n"
+            "@@ -40,0 +50,1 @@\n"
+            "+pub fn moved() {}\n"
+        )
+        self.assertEqual(flow_on.pub_changed_from_patch(patch), set())
 
 
 class CompetitorLabelTest(unittest.TestCase):
@@ -160,16 +227,18 @@ class IdempotencyTest(unittest.TestCase):
         self.rules = flow_on.load_rules(RULES)
 
     def test_dedup_key_stable_across_runs(self):
-        added = ["crates/sparq-foo/Cargo.toml"]
+        # [OPUS-4.8] (bead sq-l0a0) Repointed off the removed new-crate rule onto
+        # the new-bench-dashboard-row follow-on, which still fires and produces a
+        # stable, non-empty dedup key.
+        added = ["bench/widgets/benchmarks.toml"]
         a = flow_on.evaluate(self.rules, 42, "t", added, added, [])
         b = flow_on.evaluate(self.rules, 42, "t", added, added, [])
-        self.assertEqual(
-            sorted(fo.dedup_key for fo in a),
-            sorted(fo.dedup_key for fo in b),
-        )
+        keys_a = sorted(fo.dedup_key for fo in a)
+        self.assertIn("dashboard-row-widgets", keys_a)
+        self.assertEqual(keys_a, sorted(fo.dedup_key for fo in b))
 
     def test_marker_round_trips(self):
-        key = "new-crate-bench-sparq-foo"
+        key = "dashboard-row-widgets"
         body = "some body\n\n" + flow_on.key_marker(key)
         # open_issue_exists greps for exactly this marker substring.
         self.assertIn(flow_on.key_marker(key), body)
@@ -181,12 +250,14 @@ class DryRunTest(unittest.TestCase):
     We provide all inputs hermetically (changed-files/title) so fetch_pr_inputs
     is never reached, and --dry-run skips open_issue_exists/create_issue."""
 
-    def test_dry_run_on_new_crate_fixture(self):
+    def test_dry_run_on_new_bench_suite_fixture(self):
+        # [OPUS-4.8] (bead sq-l0a0) Repointed off the removed new-crate rule onto
+        # the surviving new-bench-suite → dashboard-row follow-on.
         import tempfile
 
         with tempfile.TemporaryDirectory() as td:
             changed = Path(td) / "changed.txt"
-            changed.write_text("crates/sparq-foo/Cargo.toml\ncrates/sparq-foo/src/lib.rs\n")
+            changed.write_text("bench/widgets/benchmarks.toml\nbench/widgets/run.sh\n")
             buf = io.StringIO()
             with redirect_stdout(buf):
                 rc = flow_on.main(
@@ -199,13 +270,47 @@ class DryRunTest(unittest.TestCase):
                         "--added-files",
                         str(changed),
                         "--title",
-                        "add sparq-foo crate",
+                        "add widgets bench suite",
                     ]
                 )
             out = buf.getvalue()
         self.assertEqual(rc, 0)
         self.assertIn("[dry-run] WOULD create", out)
-        self.assertIn("new-crate-bench-sparq-foo", out)
+        self.assertIn("dashboard-row-widgets", out)
+
+    def test_dry_run_on_new_crate_with_g1_artifacts_is_clean(self):
+        # [OPUS-4.8] (bead sq-l0a0) A new-crate PR that ships its G1 artifacts
+        # (bench + README + SKILL) triggers NO redundant flow-on follow-on.
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            changed = Path(td) / "changed.txt"
+            changed.write_text(
+                "crates/sparq-foo/Cargo.toml\ncrates/sparq-foo/src/lib.rs\n"
+                "crates/sparq-foo/README.md\nbench/benchmarks.toml\n"
+                "skills/sparq-foo/SKILL.md\n"
+            )
+            added = Path(td) / "added.txt"
+            added.write_text("crates/sparq-foo/Cargo.toml\ncrates/sparq-foo/src/lib.rs\n")
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = flow_on.main(
+                    [
+                        "--pr",
+                        "245",
+                        "--dry-run",
+                        "--changed-files",
+                        str(changed),
+                        "--added-files",
+                        str(added),
+                        "--title",
+                        "add sparq-foo crate (with bench+SKILL, as G1 requires)",
+                    ]
+                )
+            out = buf.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertNotIn("new-crate-bench", out)
+        self.assertNotIn("new-crate-skill", out)
 
     def test_dry_run_no_match_is_clean(self):
         import tempfile
@@ -225,13 +330,13 @@ class DryRunTest(unittest.TestCase):
     def test_hermetic_without_added_files_does_not_fire_new_path_rules(self):
         # [OPUS-4.8] Regression: when --added-files is omitted, `added` must
         # default to EMPTY, not to all changed files — otherwise a MODIFIED
-        # crate Cargo.toml would falsely fire the new-crate (when_new_paths)
-        # rule. Here Cargo.toml is changed-but-not-added.
+        # benchmarks.toml would falsely fire the new-bench (when_new_paths)
+        # rule. Here it is changed-but-not-added.
         import tempfile
 
         with tempfile.TemporaryDirectory() as td:
             changed = Path(td) / "changed.txt"
-            changed.write_text("crates/sparq-foo/Cargo.toml\n")
+            changed.write_text("bench/widgets/benchmarks.toml\n")
             buf = io.StringIO()
             with redirect_stdout(buf):
                 rc = flow_on.main(
@@ -242,13 +347,52 @@ class DryRunTest(unittest.TestCase):
                         "--changed-files",
                         str(changed),
                         "--title",
-                        "tweak sparq-foo manifest",
+                        "tweak widgets bench",
                     ]
                 )
             out = buf.getvalue()
         self.assertEqual(rc, 0)
-        self.assertNotIn("new-crate-bench-sparq-foo", out)
+        self.assertNotIn("dashboard-row-widgets", out)
         self.assertIn("no rules triggered", out)
+
+    def test_hermetic_comment_only_public_surface_is_clean(self):
+        # [OPUS-4.8] (bead sq-l0a0) End-to-end via main(): a public-surface src
+        # change WITHOUT --pub-diff-file (so pub_changed defaults to empty) mints
+        # NO skill-sync follow-on — the #250 mis-fire is fixed at the CLI layer.
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            changed = Path(td) / "changed.txt"
+            changed.write_text("crates/sparq-cli/src/main.rs\n")
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = flow_on.main(
+                    ["--pr", "250", "--dry-run", "--changed-files", str(changed),
+                     "--title", "add SAFETY comments"]
+                )
+            out = buf.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertIn("no rules triggered", out)
+
+    def test_hermetic_pub_change_fires_skill_sync(self):
+        # [OPUS-4.8] (bead sq-l0a0) With --pub-diff-file marking a net pub change,
+        # the skill-sync follow-on DOES fire (the useful case is preserved).
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            changed = Path(td) / "changed.txt"
+            changed.write_text("crates/sparq-cli/src/main.rs\n")
+            pub = Path(td) / "pub.txt"
+            pub.write_text("crates/sparq-cli/src/main.rs\n")
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = flow_on.main(
+                    ["--pr", "251", "--dry-run", "--changed-files", str(changed),
+                     "--pub-diff-file", str(pub), "--title", "add --explain flag"]
+                )
+            out = buf.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertIn("skill-sync-pr-251", out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 SPARQ agent

Refines the flow-on auto-task-creation engine, which was over-firing — it minted 5 redundant follow-on issues during dogfooding (#245/#246/#264/#265 = new-crate bench/SKILL; #250/#260 = skill-sync on comment-only / lint-attr-only diffs). Bead **sq-l0a0**.

## What changed

**1. Dropped the `new-crate-bench-and-skill` reactive rule (G1 redundancy).**
Merge gate **G1** (`scripts/gate-new-crate.py`, #221) already BLOCKS a new-crate PR unless the SAME PR ships a registered benchmark + README + (for a public crate) a `SKILL.md`. So by the time such a PR is merged, those artifacts are guaranteed present and a post-merge follow-on issue is pure noise — exactly the #245/#246/#264/#265 spam. G1 is now the single owner of new-crate completeness; `flow-on-rules.toml` documents that, plus how to restore a CHECK-don't-blindly-create safety-net rule if G1 is ever relaxed to advisory.

**2. Tightened `changed-public-feature-docs` to a NET public-API diff.**
The `when_paths` glob is now only a cheap pre-filter. `flow-on.py` additionally requires the PR's unified diff to NET-change a `pub `-exported item under one of the matched surfaces — reusing **gate G2's exact `pub`-item multiset diff** (the same fix #258 applied to G2 after #250). A comment-only / lint-attribute-only / pure-relocation edit no longer mints a skill-sync follow-on, fixing the #250/#260 mis-fires. The genuinely-useful case (a real new `pub fn` with no `SKILL.md`) still fires.

**3. Shared `pub`-API-diff helper (no drift).**
Factored the `pub`-item multiset logic into `scripts/pub_api_diff.py` (`PUB_ITEM_RE` / `scan_pub_diff` / `diff_has_net_pub_change`). Both `gate-api-skill.py` (G2, proactive) and `flow-on.py` (reactive) import it, so the two halves of the maintenance system can never diverge again.

## Verification
- `scripts/tests/test_flow_on.py` (20 tests) + `scripts/tests/test_gates.py` (19 tests) pass; `ruff` clean.
- Regression tests added: comment-only public-crate change → NO skill-sync follow-on; new crate with bench+SKILL (as G1 requires) → NO redundant bench/SKILL follow-on; genuine new `pub fn` without SKILL → still creates the follow-on.
- `--dry-run` over the dogfooded scenarios: new-crate-with-G1-artifacts → no follow-on; comment-only public surface (#250) → no follow-on; genuine new `pub fn` (#300) → still fires the skill-sync follow-on.

Surviving useful rules (new-bench → dashboard-row, competitor-gather, new-zk-circuit gate-count) are untouched and still fire.

NON-CANONICAL timing.