### PR TITLE
feat(sparq-fedplan): cost-based federated source selection + bind-vs-hash join planner (sq-a35t)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,6 +3353,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sparq-fedplan"
+version = "0.1.0"
+dependencies = [
+ "oxrdf 0.3.3",
+ "oxttl 0.2.3",
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
 name = "sparq-geo"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/sparq-core", "crates/sparq-engine", "crates/sparq-cli", "crates/sparq-bench", "crates/sparq-wasm", "crates/sparq-reason", "crates/sparq-server", "crates/sparq-serve", "crates/sparq-conformance", "crates/sparq-py", "crates/sparq-shacl", "crates/sparq-hdt", "crates/sparq-sim", "crates/sparq-geo", "crates/sparq-introspect", "crates/sparq-nlq", "crates/sparq-vectors", "crates/sparq-rsp", "crates/sparq-gpu", "crates/sparq-solid", "crates/sparq-policy", "crates/sparq-parse", "crates/sparq-text", "crates/sparq-canon", "crates/sparq-zk", "crates/sparq-zk-compose", "crates/sparq-mpc", "crates/sparq-prov"]
+members = ["crates/sparq-core", "crates/sparq-engine", "crates/sparq-cli", "crates/sparq-bench", "crates/sparq-wasm", "crates/sparq-reason", "crates/sparq-server", "crates/sparq-serve", "crates/sparq-conformance", "crates/sparq-py", "crates/sparq-shacl", "crates/sparq-hdt", "crates/sparq-sim", "crates/sparq-geo", "crates/sparq-introspect", "crates/sparq-nlq", "crates/sparq-vectors", "crates/sparq-rsp", "crates/sparq-gpu", "crates/sparq-solid", "crates/sparq-policy", "crates/sparq-parse", "crates/sparq-text", "crates/sparq-canon", "crates/sparq-zk", "crates/sparq-zk-compose", "crates/sparq-mpc", "crates/sparq-prov", "crates/sparq-fedplan"]
 # `fuzz` is the cargo-fuzz harness (bead sq-ovnf): it requires a NIGHTLY toolchain
 # (libFuzzer codegen), so it is excluded from the workspace to keep the STABLE
 # `cargo build`/`cargo test`/`clippy --workspace` gate from ever trying to compile it.

--- a/crates/sparq-fedplan/Cargo.toml
+++ b/crates/sparq-fedplan/Cargo.toml
@@ -1,0 +1,41 @@
+# [OPUS-4.8] sq-a35t (epic sq-3183): OPT-IN cost-based federated source selection +
+# bind-vs-hash join planning. Plans over already-fetched source DESCRIPTORS (served
+# VoID + mined characteristic-set stats) — pure, deterministic, NO network I/O.
+[package]
+name = "sparq-fedplan"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Cost-based federated source selection (HiBISCuS prune + CostFed cardinality) and bind-vs-hash join planning over served source descriptors — opt-in, no network I/O"
+publish = false
+
+# OPT-IN, lean core. NOTHING in the workspace's default build depends on this crate:
+# it is a standalone member (like `sparq-canon` / `sparq-prov`), so `sparq-core`'s
+# default build and the wasm artifact are byte-identical with or without it. The
+# capability is therefore OFF BY DEFAULT at the dependency level — the leanest gating,
+# with zero core overhead when absent. A `publish = false` PLANNING crate (no runtime
+# data path, like `sparq-canon`/`sparq-prov`) is bench-exempt under gate G1.
+# [OPUS-4.8] sq-a35t, branch feat-fedplan-cost-selection.
+
+[features]
+# The whole planner is feature-gated so even a crate that DOES depend on sparq-fedplan
+# pays zero for it unless `fedplan` is enabled. OFF by default.
+default = []
+fedplan = []
+
+[dependencies]
+# Term model (oxrdf 0.3 re-export) — used only to type the public IRI surface and to
+# parse a served VoID+scs descriptor document. No sparq-core/engine dependency: this
+# slice plans over descriptors, never over a live Graph.
+oxrdf = { workspace = true }
+oxttl = { workspace = true }
+rustc-hash = { workspace = true }
+
+[dev-dependencies]
+# Round-trip a descriptor parsed from the served N-Triples form.
+oxttl = { workspace = true }

--- a/crates/sparq-fedplan/README.md
+++ b/crates/sparq-fedplan/README.md
@@ -1,0 +1,104 @@
+# sparq-fedplan
+
+Cost-based **federated source selection** + **bind-vs-hash join planning** over
+already-fetched source descriptors — a small, **opt-in** planner that consumes the
+statistics a sparq-server already serves, with **no network I/O**.
+
+Given a SPARQL Basic Graph Pattern (BGP) and a set of `SourceDescriptor`s — each
+carrying a remote endpoint's W3C VoID property/class partitions plus its mined
+**characteristic sets** (served under the `scs:` vocab) — this crate decides which
+sources can contribute to each pattern (HiBISCuS-style **recall-safe** pruning +
+CostFed-style skew-aware cardinality), then builds a join plan with a per-join
+**bind-vs-hash** decision and a greedy join order, using characteristic-set star-join
+cardinality to estimate intermediate-result sizes.
+
+The planner is **pure and deterministic**: it plans from descriptors a caller has
+already fetched; it never contacts the network. Timing here is **non-canonical**
+(work-box EC2) and is therefore not recorded.
+
+> Model: Opus 4.8 (Fable unavailable — flag for re-review when Fable returns).
+> Bead **sq-a35t** · epic **sq-3183** (cost-based federated source selection + join planning).
+
+## 🚀 Quickstart
+
+```rust
+use sparq_fedplan::{
+    Bgp, TriplePattern, Term, Var, SourceDescriptor, SourceId, PredPartition,
+    select_sources, plan_bgp, PlanOptions,
+};
+
+// A two-arm star: ?s foaf:knows ?o . ?s foaf:name ?n
+let bgp = Bgp::new(vec![
+    TriplePattern::new(Term::Var(Var::new("s")),
+        Term::Iri("http://xmlns.com/foaf/0.1/knows".into()), Term::Var(Var::new("o"))),
+    TriplePattern::new(Term::Var(Var::new("s")),
+        Term::Iri("http://xmlns.com/foaf/0.1/name".into()), Term::Var(Var::new("n"))),
+]);
+
+// A source described by its served VoID partitions (build programmatically or parse
+// the served N-Triples with `SourceDescriptor::from_void_nt`).
+let src = SourceDescriptor::builder(SourceId::new("https://endpoint.example/sparql"))
+    .total_triples(10_000)
+    .predicate(PredPartition { predicate: "http://xmlns.com/foaf/0.1/knows".into(),
+        triples: 2000, distinct_subjects: 1000, distinct_objects: 1800 })
+    .predicate(PredPartition { predicate: "http://xmlns.com/foaf/0.1/name".into(),
+        triples: 1000, distinct_subjects: 1000, distinct_objects: 990 })
+    .build();
+let sources = [src];
+
+// 1. Source selection (recall-safe prune + skew-aware cardinality).
+let selection = select_sources(&bgp, &sources);
+// 2. Join plan (bind-vs-hash decision + greedy join order).
+let plan = plan_bgp(&bgp, &selection, &sources, &PlanOptions::default()).unwrap();
+
+println!("join order: {:?}", plan.join_order());
+println!("estimated total cost: {}", plan.total_cost);
+```
+
+## ✨ Features
+
+- **HiBISCuS-style source selection** — prunes a source for a pattern only on positive
+  evidence it cannot contribute (a bound predicate absent from the source's complete
+  predicate partition set; a bound class absent from a *declared* class section; a bound
+  subject/object authority absent from a *complete* authority capability set). The
+  **recall-safety invariant** holds: a source that could return any binding is never
+  pruned — uncertainty always keeps the source. Proven by `recall_safe_*` tests.
+- **CostFed-style skew-aware cardinality** — per-(pattern, source) cardinality comes from
+  the served per-predicate triple count and average multiplicity, not a uniform guess, so
+  per-predicate skew and bound-position selectivity (subject/object) are preserved.
+- **Characteristic-set star cardinality** — joining star arms (`?s p₁ ?a . ?s p₂ ?b`) is
+  estimated with Neumann & Moerkotte's `Σ_{C⊇Q} count(C)·Π avg_mult`, capturing the
+  predicate *correlation* a per-predicate-independence product loses.
+- **Bind-vs-hash join decision** — each binary join picks a **bind join** (probe the
+  right with the left's bindings — cheap when the left is small + right selective) or a
+  **hash/symmetric join** (scan both sides once — cheap when the left is large), and the
+  decision *flips* at the expected cost threshold (tunable `PlanOptions::request_cost`).
+- **Opt-in, zero core overhead** — a standalone member (like `sparq-canon`/`sparq-prov`),
+  gated behind the `fedplan` cargo feature, **off by default**. Nothing in sparq's
+  default build or the wasm artifact depends on it; the lean core is byte-identical
+  without it. No `sparq-core`/`sparq-engine` dependency — it plans over descriptors only.
+- **Pure & deterministic** — no network I/O; same descriptors + same BGP ⇒ same plan.
+
+## Scope — covered vs deferred
+
+| Capability | Status |
+|---|---|
+| Source selection (HiBISCuS prune + CostFed cardinality) | ✅ covered here |
+| Bind-vs-hash decision + greedy join order + CS star cardinality | ✅ covered here |
+| ANAPSID-style non-blocking streaming joins with operator spill | ⏳ deferred (roadmap bead, epic sq-3183) |
+| Live adaptive re-planning mid-execution | ⏳ deferred (same bead) |
+
+This slice is a *static* plan computed up front; the deferred adaptive/streaming work is
+filed as a bead under epic sq-3183.
+
+## 📚 Learn more
+
+- Skill: `skills/federated-planning/SKILL.md`
+- Served source statistics: `crates/sparq-introspect` (VoID + `scs:` characteristic sets)
+- Federation discovery descriptors: `crates/sparq-server/src/descriptors.rs`
+- HiBISCuS (Saleem & Ngonga Ngomo, ESWC 2014); CostFed (Saleem et al., SEMANTiCS 2018);
+  characteristic sets (Neumann & Moerkotte, ICDE 2011); ANAPSID (Acosta et al., ISWC 2011).
+
+## License
+
+MIT — `publish = false` workspace member. [OPUS-4.8]

--- a/crates/sparq-fedplan/src/descriptor.rs
+++ b/crates/sparq-fedplan/src/descriptor.rs
@@ -1,0 +1,613 @@
+//! The source **descriptor** model — what the planner knows about each remote source
+//! *before* contacting it, and how to build it from the served statistics.
+//!
+//! A `sparq-server` already serves, at `/.well-known/void`, a W3C VoID description of
+//! its dataset (triple/entity/class/property counts + per-class and per-predicate
+//! partitions) **plus** the mined **characteristic sets** under the `scs:` vocab
+//! (`http://sparq.dev/ns/cs#`). A [`SourceDescriptor`] is the in-planner image of that
+//! document for one source: its capability set (predicates, classes, IRI authorities)
+//! and its skew-aware per-predicate / per-characteristic-set statistics.
+//!
+//! Build one with the typed [`SourceDescriptor::builder`] API, or parse it straight
+//! from the served N-Triples with [`SourceDescriptor::from_void_nt`].
+//!
+//! [OPUS-4.8] sq-a35t.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+
+/// The VoID vocabulary namespace.
+pub const VOID_NS: &str = "http://rdfs.org/ns/void#";
+/// The served characteristic-set vocabulary namespace (`scs:`).
+pub const CS_NS: &str = "http://sparq.dev/ns/cs#";
+
+/// A stable identifier for a federated source (conventionally its endpoint URL). Used
+/// as the deterministic tie-break key throughout the planner.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SourceId(pub String);
+
+impl SourceId {
+    pub fn new(id: impl Into<String>) -> SourceId {
+        SourceId(id.into())
+    }
+}
+
+/// One `void:propertyPartition`: a predicate this source holds, with its triple count
+/// and (when known) the per-subject average multiplicity — the skew signal CostFed-style
+/// cardinality uses instead of a uniform guess.
+#[derive(Debug, Clone)]
+pub struct PredPartition {
+    pub predicate: String,
+    /// `void:triples` for this predicate (total triples with this predicate).
+    pub triples: u64,
+    /// `void:distinctSubjects` for this predicate (distinct subjects), 0 if unknown.
+    pub distinct_subjects: u64,
+    /// Distinct objects for this predicate, 0 if unknown. (VoID's per-predicate
+    /// `void:distinctObjects` when served; otherwise left 0 and treated as unknown.)
+    pub distinct_objects: u64,
+}
+
+impl PredPartition {
+    /// Average per-subject multiplicity (`triples / distinctSubjects`); `1.0` when the
+    /// distinct-subject count is unknown (the recall-safe non-skewed default).
+    pub fn avg_multiplicity(&self) -> f64 {
+        if self.distinct_subjects == 0 {
+            1.0
+        } else {
+            self.triples as f64 / self.distinct_subjects as f64
+        }
+    }
+}
+
+/// One `void:classPartition`: a class this source holds, with its instance count.
+#[derive(Debug, Clone)]
+pub struct ClassPartition {
+    pub class: String,
+    /// `void:entities` for this class (instances).
+    pub entities: u64,
+}
+
+/// One served **characteristic set** (`scs:CharacteristicSet`): a distinct per-subject
+/// predicate set, its subject count (`scs:subjects`) and per-predicate average
+/// multiplicity (`scs:avgMultiplicity`, aligned with `predicates`). This is the
+/// correlation signal the marginals lose — the planner uses it for star-join
+/// cardinality.
+#[derive(Debug, Clone)]
+pub struct CharSet {
+    /// Predicate IRIs of this set, sorted ascending (so superset tests are merge walks).
+    pub predicates: Vec<String>,
+    /// `scs:subjects` — subjects whose exact predicate set this is.
+    pub subjects: u64,
+    /// `scs:avgMultiplicity`, aligned with `predicates` — avg triples per subject for
+    /// each predicate in the set.
+    pub avg_multiplicity: Vec<f64>,
+}
+
+/// A federated source's full descriptor: capability set + skew-aware statistics, as
+/// mined from the served VoID + `scs:` document. The capability sets (`authorities`,
+/// predicate keys, class keys) drive **recall-safe** HiBISCuS pruning; the counts and
+/// multiplicities drive CostFed/CS cardinality.
+#[derive(Debug, Clone)]
+pub struct SourceDescriptor {
+    /// Stable source id (endpoint URL).
+    pub id: SourceId,
+    /// `void:triples` — total triples this source holds (0 if unknown).
+    pub total_triples: u64,
+    /// Per-predicate partitions, keyed by predicate IRI.
+    predicates: FxHashMap<String, PredPartition>,
+    /// Per-class partitions, keyed by class IRI.
+    classes: FxHashMap<String, ClassPartition>,
+    /// Served characteristic sets (for star-join cardinality).
+    char_sets: Vec<CharSet>,
+    /// The set of IRI **authorities** this source is known to mint terms under
+    /// (scheme-and-host, e.g. `http://dbpedia.org`). Derived from every IRI seen in a
+    /// partition (predicates, classes). A pattern's bound-IRI position whose authority
+    /// is absent here *cannot* match this source — the HiBISCuS prune. EMPTY means
+    /// "unknown authorities" ⇒ never prune on authority (recall-safe).
+    authorities: FxHashSet<String>,
+    /// Whether the authority set is *complete* — i.e. the descriptor enumerated every
+    /// IRI authority the source can produce. Only a complete authority set may prune a
+    /// pattern whose bound IRI's authority is absent. A descriptor parsed from VoID
+    /// partitions sees only predicate/class authorities, NOT subject/object instance
+    /// authorities, so it is **incomplete** and authority-pruning of subject/object
+    /// positions is disabled (recall-safe). Predicate-position pruning still applies
+    /// because the predicate partition set IS the complete predicate capability set.
+    authorities_complete: bool,
+}
+
+/// Builder for a [`SourceDescriptor`] (the typed construction path; the parse path
+/// [`SourceDescriptor::from_void_nt`] funnels through it too).
+pub struct SourceDescriptorBuilder {
+    id: SourceId,
+    total_triples: u64,
+    predicates: FxHashMap<String, PredPartition>,
+    classes: FxHashMap<String, ClassPartition>,
+    char_sets: Vec<CharSet>,
+    authorities_complete: bool,
+}
+
+impl SourceDescriptor {
+    /// Starts a typed builder for the source named `id`.
+    pub fn builder(id: SourceId) -> SourceDescriptorBuilder {
+        SourceDescriptorBuilder {
+            id,
+            total_triples: 0,
+            predicates: FxHashMap::default(),
+            classes: FxHashMap::default(),
+            char_sets: Vec::new(),
+            authorities_complete: false,
+        }
+    }
+
+    /// This source's id.
+    pub fn id(&self) -> &SourceId {
+        &self.id
+    }
+
+    /// The predicate partition for `predicate`, if this source holds it.
+    pub fn predicate(&self, predicate: &str) -> Option<&PredPartition> {
+        self.predicates.get(predicate)
+    }
+
+    /// Whether this source holds *any* triple with `predicate` (its predicate
+    /// capability set membership).
+    pub fn has_predicate(&self, predicate: &str) -> bool {
+        self.predicates.contains_key(predicate)
+    }
+
+    /// The class partition for `class`, if this source holds instances of it.
+    pub fn class(&self, class: &str) -> Option<&ClassPartition> {
+        self.classes.get(class)
+    }
+
+    /// Whether this source holds any instance of `class`.
+    pub fn has_class(&self, class: &str) -> bool {
+        self.classes.contains_key(class)
+    }
+
+    /// Whether the descriptor declares ANY `void:classPartition`. A descriptor with no
+    /// class section means "class membership unknown" (so a bound-class prune must NOT
+    /// fire — recall-safe); a descriptor WITH class partitions enumerates every class
+    /// the source holds instances of, so an absent class then proves no instances.
+    pub fn declares_any_class(&self) -> bool {
+        !self.classes.is_empty()
+    }
+
+    /// The served characteristic sets.
+    pub fn char_sets(&self) -> &[CharSet] {
+        &self.char_sets
+    }
+
+    /// Whether the descriptor's IRI-authority capability set is complete (every
+    /// authority the source can produce is enumerated). When false, authority pruning
+    /// of subject/object positions is disabled (recall-safe).
+    pub fn authorities_complete(&self) -> bool {
+        self.authorities_complete
+    }
+
+    /// Whether `iri`'s authority is in this source's known authority set. Returns
+    /// `true` (cannot rule out) when the authority set is incomplete or the IRI has no
+    /// extractable authority — the recall-safe default.
+    pub fn may_hold_authority(&self, iri: &str) -> bool {
+        if !self.authorities_complete {
+            return true;
+        }
+        match authority_of(iri) {
+            Some(a) => self.authorities.contains(&a),
+            None => true, // unparseable authority ⇒ cannot rule out.
+        }
+    }
+
+    /// `Σ_{C ⊇ q} subjects(C)`: distinct subjects on this source carrying EVERY
+    /// predicate of `q` (the star's subject-variable ndv estimate). `q` is sorted
+    /// ascending by the caller.
+    pub fn star_subjects(&self, q: &[String]) -> u64 {
+        self.char_sets
+            .iter()
+            .filter(|c| is_subset(q, &c.predicates))
+            .map(|c| c.subjects)
+            .sum()
+    }
+
+    /// Neumann & Moerkotte's star estimate over this source's characteristic sets:
+    /// `Σ_{C ⊇ q} subjects(C) · Π_{p∈q} avg_mult(C, p)` — the expected result rows of
+    /// the star `?s p ?o_p` for every `p ∈ q`. `q` is sorted ascending. Returns 0.0
+    /// when no served set covers `q` (the caller falls back to the marginal estimate).
+    pub fn star_cardinality(&self, q: &[String]) -> f64 {
+        let mut total = 0.0f64;
+        for c in &self.char_sets {
+            if !is_subset(q, &c.predicates) {
+                continue;
+            }
+            let mut rows = c.subjects as f64;
+            for p in q {
+                let i = c
+                    .predicates
+                    .binary_search(p)
+                    .expect("subset member present");
+                rows *= c.avg_multiplicity[i];
+            }
+            total += rows;
+        }
+        total
+    }
+}
+
+impl SourceDescriptorBuilder {
+    /// Sets `void:triples` (total triples).
+    pub fn total_triples(mut self, n: u64) -> Self {
+        self.total_triples = n;
+        self
+    }
+
+    /// Adds a `void:propertyPartition`.
+    pub fn predicate(mut self, p: PredPartition) -> Self {
+        self.predicates.insert(p.predicate.clone(), p);
+        self
+    }
+
+    /// Adds a `void:classPartition`.
+    pub fn class(mut self, c: ClassPartition) -> Self {
+        self.classes.insert(c.class.clone(), c);
+        self
+    }
+
+    /// Adds a served `scs:CharacteristicSet`. Predicates are normalised to sorted
+    /// order (keeping `avg_multiplicity` aligned). Sets with `subjects == 0` or a
+    /// length mismatch are dropped (mirrors the engine's `CsTable::new`).
+    pub fn char_set(mut self, mut cs: CharSet) -> Self {
+        if cs.subjects == 0 || cs.predicates.len() != cs.avg_multiplicity.len() {
+            return self;
+        }
+        if !cs.predicates.windows(2).all(|w| w[0] < w[1]) {
+            let mut paired: Vec<(String, f64)> =
+                cs.predicates.into_iter().zip(cs.avg_multiplicity).collect();
+            paired.sort_by(|a, b| a.0.cmp(&b.0));
+            cs = CharSet {
+                predicates: paired.iter().map(|(p, _)| p.clone()).collect(),
+                avg_multiplicity: paired.iter().map(|(_, m)| *m).collect(),
+                subjects: cs.subjects,
+            };
+        }
+        self.char_sets.push(cs);
+        self
+    }
+
+    /// Declares the IRI-authority capability set **complete**: authority pruning of
+    /// subject/object positions becomes active for this source. Use only when the
+    /// descriptor truly enumerates every authority the source can mint (e.g. a
+    /// HiBISCuS-style capability set / `void:uriSpace` declaration). A descriptor built
+    /// only from VoID predicate/class partitions must NOT call this (recall-safe).
+    pub fn authorities_complete(mut self) -> Self {
+        self.authorities_complete = true;
+        self
+    }
+
+    /// Finalises the descriptor, deriving the authority set from every predicate/class
+    /// IRI (and any explicitly-declared instance authority — none in this slice).
+    pub fn build(self) -> SourceDescriptor {
+        let mut authorities = FxHashSet::default();
+        for p in self.predicates.keys() {
+            if let Some(a) = authority_of(p) {
+                authorities.insert(a);
+            }
+        }
+        for c in self.classes.keys() {
+            if let Some(a) = authority_of(c) {
+                authorities.insert(a);
+            }
+        }
+        SourceDescriptor {
+            id: self.id,
+            total_triples: self.total_triples,
+            predicates: self.predicates,
+            classes: self.classes,
+            char_sets: self.char_sets,
+            authorities,
+            authorities_complete: self.authorities_complete,
+        }
+    }
+}
+
+impl SourceDescriptor {
+    /// Parses a served descriptor from its N-Triples form — the document a
+    /// `sparq-server` serves at `/.well-known/void` (VoID partitions + `scs:`
+    /// characteristic sets). Blank-node-keyed partitions (`void:propertyPartition`,
+    /// `void:classPartition`, `scs:` sets) are reassembled by blank-node label.
+    ///
+    /// The parse path produces an **incomplete** authority set (VoID partitions reveal
+    /// only predicate/class authorities, never subject/object instance authorities), so
+    /// subject/object authority-pruning stays disabled — recall-safe by construction.
+    /// To enable it, build via [`SourceDescriptor::builder`] and call
+    /// [`SourceDescriptorBuilder::authorities_complete`] with a vetted capability set.
+    pub fn from_void_nt(id: SourceId, nt: &str) -> Result<SourceDescriptor, String> {
+        use oxrdf::{NamedOrBlankNode, Term as OxTerm};
+        let v = |local: &str| format!("{VOID_NS}{local}");
+        let cs = |local: &str| format!("{CS_NS}{local}");
+
+        // Collect blank-node partition rows: bnode label -> (predicate -> objects).
+        let mut bn: FxHashMap<String, FxHashMap<String, Vec<OxTerm>>> = FxHashMap::default();
+        let mut total_triples = 0u64;
+        // scs ordered-list members: bnode -> Vec<(index, value)> for predicate/mult lists.
+        for r in oxttl::NTriplesParser::new().for_slice(nt.as_bytes()) {
+            let t = r.map_err(|e| format!("malformed descriptor N-Triples: {e}"))?;
+            let pred = t.predicate.as_str().to_string();
+            // Top-level dataset void:triples (subject is an IRI, not a partition bnode).
+            if pred == v("triples") {
+                if let NamedOrBlankNode::NamedNode(_) = &t.subject {
+                    if let Some(n) = as_u64(&t.object) {
+                        total_triples = total_triples.max(n);
+                    }
+                    continue;
+                }
+            }
+            if let NamedOrBlankNode::BlankNode(b) = &t.subject {
+                bn.entry(b.as_str().to_string())
+                    .or_default()
+                    .entry(pred)
+                    .or_default()
+                    .push(t.object.clone());
+            }
+        }
+
+        let mut builder = SourceDescriptor::builder(id).total_triples(total_triples);
+
+        for props in bn.values() {
+            // --- void:propertyPartition: keyed by void:property.
+            if let Some(p) = props.get(&v("property")).and_then(|o| first_iri(o)) {
+                builder = builder.predicate(PredPartition {
+                    predicate: p,
+                    triples: props
+                        .get(&v("triples"))
+                        .and_then(|o| first_u64(o))
+                        .unwrap_or(0),
+                    distinct_subjects: props
+                        .get(&v("distinctSubjects"))
+                        .and_then(|o| first_u64(o))
+                        .unwrap_or(0),
+                    distinct_objects: props
+                        .get(&v("distinctObjects"))
+                        .and_then(|o| first_u64(o))
+                        .unwrap_or(0),
+                });
+                continue;
+            }
+            // --- void:classPartition: keyed by void:class.
+            if let Some(c) = props.get(&v("class")).and_then(|o| first_iri(o)) {
+                builder = builder.class(ClassPartition {
+                    class: c,
+                    entities: props
+                        .get(&v("entities"))
+                        .and_then(|o| first_u64(o))
+                        .unwrap_or(0),
+                });
+                continue;
+            }
+            // --- scs:CharacteristicSet: scs:subjects + per-predicate scs:predicateStat
+            //     blank nodes (each carrying void:property + scs:avgMultiplicity).
+            let is_cs = props
+                .get(RDF_TYPE)
+                .map(|o| o.iter().any(|t| iri_eq(t, &cs("CharacteristicSet"))))
+                .unwrap_or(false);
+            if is_cs {
+                let subjects = props
+                    .get(&cs("subjects"))
+                    .and_then(|o| first_u64(o))
+                    .unwrap_or(0);
+                let mut preds: Vec<(String, f64)> = Vec::new();
+                if let Some(stats) = props.get(&cs("predicateStat")) {
+                    for st in stats {
+                        if let OxTerm::BlankNode(sb) = st {
+                            if let Some(stat) = bn.get(sb.as_str()) {
+                                if let Some(p) = stat.get(&v("property")).and_then(|o| first_iri(o))
+                                {
+                                    let m = stat
+                                        .get(&cs("avgMultiplicity"))
+                                        .and_then(|o| first_f64(o))
+                                        .unwrap_or(1.0);
+                                    preds.push((p, m));
+                                }
+                            }
+                        }
+                    }
+                }
+                preds.sort_by(|a, b| a.0.cmp(&b.0));
+                builder = builder.char_set(CharSet {
+                    predicates: preds.iter().map(|(p, _)| p.clone()).collect(),
+                    avg_multiplicity: preds.iter().map(|(_, m)| *m).collect(),
+                    subjects,
+                });
+            }
+        }
+
+        Ok(builder.build())
+    }
+}
+
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+// ---- small RDF-term helpers ----------------------------------------------------
+
+fn iri_eq(t: &oxrdf::Term, iri: &str) -> bool {
+    matches!(t, oxrdf::Term::NamedNode(n) if n.as_str() == iri)
+}
+
+fn first_iri(os: &[oxrdf::Term]) -> Option<String> {
+    os.iter().find_map(|t| match t {
+        oxrdf::Term::NamedNode(n) => Some(n.as_str().to_string()),
+        _ => None,
+    })
+}
+
+fn as_u64(t: &oxrdf::Term) -> Option<u64> {
+    match t {
+        oxrdf::Term::Literal(l) => l.value().parse::<u64>().ok(),
+        _ => None,
+    }
+}
+
+fn first_u64(os: &[oxrdf::Term]) -> Option<u64> {
+    os.iter().find_map(as_u64)
+}
+
+fn first_f64(os: &[oxrdf::Term]) -> Option<f64> {
+    os.iter().find_map(|t| match t {
+        oxrdf::Term::Literal(l) => l.value().parse::<f64>().ok(),
+        _ => None,
+    })
+}
+
+/// The IRI **authority** (scheme + `://` + host[:port]) of an absolute IRI, e.g.
+/// `http://dbpedia.org/resource/Berlin` ⇒ `http://dbpedia.org`. `None` for IRIs with no
+/// `://` (relative, `urn:`, etc.) — those are never used to prune (recall-safe).
+fn authority_of(iri: &str) -> Option<String> {
+    let scheme_end = iri.find("://")?;
+    let after = scheme_end + 3;
+    let rest = &iri[after..];
+    // Authority ends at the first `/`, `?`, `#`, or end of string.
+    let host_len = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    if host_len == 0 {
+        return None;
+    }
+    Some(iri[..after + host_len].to_string())
+}
+
+/// `a ⊆ b` over two ascending-sorted string slices (merge walk).
+fn is_subset(a: &[String], b: &[String]) -> bool {
+    let mut j = 0;
+    'outer: for x in a {
+        while j < b.len() {
+            match b[j].as_str().cmp(x.as_str()) {
+                std::cmp::Ordering::Less => j += 1,
+                std::cmp::Ordering::Equal => {
+                    j += 1;
+                    continue 'outer;
+                }
+                std::cmp::Ordering::Greater => return false,
+            }
+        }
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authority_extraction() {
+        assert_eq!(
+            authority_of("http://dbpedia.org/resource/Berlin"),
+            Some("http://dbpedia.org".to_string())
+        );
+        assert_eq!(
+            authority_of("https://www.wikidata.org/entity/Q64"),
+            Some("https://www.wikidata.org".to_string())
+        );
+        assert_eq!(
+            authority_of("http://example.org:8080/x#y"),
+            Some("http://example.org:8080".to_string())
+        );
+        // No authority ⇒ None (never prunes).
+        assert_eq!(authority_of("urn:isbn:123"), None);
+        assert_eq!(authority_of("relativeThing"), None);
+    }
+
+    #[test]
+    fn avg_multiplicity_defaults_to_one_when_unknown() {
+        let p = PredPartition {
+            predicate: "http://ex/p".into(),
+            triples: 100,
+            distinct_subjects: 0,
+            distinct_objects: 0,
+        };
+        assert_eq!(p.avg_multiplicity(), 1.0);
+        let p2 = PredPartition {
+            distinct_subjects: 50,
+            ..p
+        };
+        assert_eq!(p2.avg_multiplicity(), 2.0);
+    }
+
+    #[test]
+    fn star_cardinality_matches_cs_model() {
+        // 100 subjects {a,b} (a avg 1x, b avg 2x), 50 subjects {a,c} (a 1x, c 1x).
+        let d = SourceDescriptor::builder(SourceId::new("s"))
+            .char_set(CharSet {
+                predicates: vec!["http://ex/a".into(), "http://ex/b".into()],
+                subjects: 100,
+                avg_multiplicity: vec![1.0, 2.0],
+            })
+            .char_set(CharSet {
+                predicates: vec!["http://ex/a".into(), "http://ex/c".into()],
+                subjects: 50,
+                avg_multiplicity: vec![1.0, 1.0],
+            })
+            .build();
+        let a = "http://ex/a".to_string();
+        let b = "http://ex/b".to_string();
+        let c = "http://ex/c".to_string();
+        assert_eq!(d.star_subjects(std::slice::from_ref(&a)), 150);
+        assert_eq!(d.star_subjects(&[a.clone(), b.clone()]), 100);
+        assert_eq!(d.star_subjects(&[b.clone(), c.clone()]), 0);
+        assert_eq!(d.star_cardinality(std::slice::from_ref(&a)), 150.0);
+        assert_eq!(d.star_cardinality(&[a.clone(), b.clone()]), 200.0); // 100 * 1 * 2
+        assert_eq!(d.star_cardinality(&[b, c]), 0.0);
+    }
+
+    #[test]
+    fn parse_void_nt_predicate_and_class_partitions() {
+        // Minimal served VoID document with one property + one class partition.
+        let nt = r#"<http://s/> <http://rdfs.org/ns/void#triples> "300"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://s/> <http://rdfs.org/ns/void#propertyPartition> _:p1 .
+_:p1 <http://rdfs.org/ns/void#property> <http://xmlns.com/foaf/0.1/knows> .
+_:p1 <http://rdfs.org/ns/void#triples> "200"^^<http://www.w3.org/2001/XMLSchema#integer> .
+_:p1 <http://rdfs.org/ns/void#distinctSubjects> "100"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://s/> <http://rdfs.org/ns/void#classPartition> _:c1 .
+_:c1 <http://rdfs.org/ns/void#class> <http://xmlns.com/foaf/0.1/Person> .
+_:c1 <http://rdfs.org/ns/void#entities> "100"^^<http://www.w3.org/2001/XMLSchema#integer> .
+"#;
+        let d = SourceDescriptor::from_void_nt(SourceId::new("http://s/"), nt).unwrap();
+        assert_eq!(d.total_triples, 300);
+        let p = d.predicate("http://xmlns.com/foaf/0.1/knows").unwrap();
+        assert_eq!(p.triples, 200);
+        assert_eq!(p.distinct_subjects, 100);
+        assert_eq!(p.avg_multiplicity(), 2.0);
+        assert!(d.has_class("http://xmlns.com/foaf/0.1/Person"));
+        assert_eq!(
+            d.class("http://xmlns.com/foaf/0.1/Person")
+                .unwrap()
+                .entities,
+            100
+        );
+        // Parsed descriptors are authority-INCOMPLETE (recall-safe).
+        assert!(!d.authorities_complete());
+    }
+
+    #[test]
+    fn parse_void_nt_characteristic_set() {
+        let nt = r#"<http://s/> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sparq.dev/ns/cs#CharacteristicSet> .
+_:cs1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sparq.dev/ns/cs#CharacteristicSet> .
+_:cs1 <http://sparq.dev/ns/cs#subjects> "100"^^<http://www.w3.org/2001/XMLSchema#integer> .
+_:cs1 <http://sparq.dev/ns/cs#predicateStat> _:st1 .
+_:cs1 <http://sparq.dev/ns/cs#predicateStat> _:st2 .
+_:st1 <http://rdfs.org/ns/void#property> <http://ex/a> .
+_:st1 <http://sparq.dev/ns/cs#avgMultiplicity> "1.0"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:st2 <http://rdfs.org/ns/void#property> <http://ex/b> .
+_:st2 <http://sparq.dev/ns/cs#avgMultiplicity> "2.0"^^<http://www.w3.org/2001/XMLSchema#double> .
+"#;
+        let d = SourceDescriptor::from_void_nt(SourceId::new("http://s/"), nt).unwrap();
+        assert_eq!(d.char_sets().len(), 1);
+        let cs = &d.char_sets()[0];
+        assert_eq!(cs.subjects, 100);
+        assert_eq!(
+            cs.predicates,
+            vec!["http://ex/a".to_string(), "http://ex/b".to_string()]
+        );
+        assert_eq!(cs.avg_multiplicity, vec![1.0, 2.0]);
+        assert_eq!(
+            d.star_cardinality(&["http://ex/a".into(), "http://ex/b".into()]),
+            200.0
+        );
+    }
+}

--- a/crates/sparq-fedplan/src/lib.rs
+++ b/crates/sparq-fedplan/src/lib.rs
@@ -1,0 +1,79 @@
+//! sparq-fedplan: **cost-based federated source selection + bind-vs-hash join
+//! planning** over already-fetched source *descriptors* — the first opt-in slice of
+//! cost-based federation (bead sq-a35t, epic sq-3183).
+//!
+//! This crate plans a federated SPARQL Basic Graph Pattern (BGP) across a set of
+//! remote SPARQL endpoints whose **statistics are already in hand** — each source is
+//! described by a [`SourceDescriptor`] carrying the W3C VoID property/class partitions
+//! (`void:propertyPartition` / `void:classPartition`) that a `sparq-server` already
+//! serves at `/.well-known/void`, *plus* the mined **characteristic sets** the server
+//! also serves under the `scs:` vocab (`http://sparq.dev/ns/cs#`). The planner is:
+//!
+//! * **Pure** — it consumes descriptors, never the network. No I/O, no live `Graph`.
+//!   A caller fetches descriptors once (or builds them programmatically /
+//!   [`SourceDescriptor::from_void_nt`] from the served N-Triples) and hands them in.
+//! * **Deterministic** — same descriptors + same BGP ⇒ same plan, every time. Every
+//!   internal ordering breaks ties on a stable key (source id, then pattern index).
+//!
+//! ## What it produces (this slice)
+//!
+//! 1. [`select_sources`] — **source selection**: for each triple pattern, which
+//!    sources *can* contribute, with a per-(pattern, source) cardinality estimate.
+//!    Two complementary techniques:
+//!    * **HiBISCuS-style authority/prefix pruning** ([`selection`]) — a source is
+//!      pruned for a pattern only when its capability set (the IRI authorities /
+//!      predicates / classes it is known to hold) makes a contribution *impossible*.
+//!      This is **recall-safe**: a source is dropped only on positive evidence of
+//!      non-contribution; *any* uncertainty keeps it. See [`selection`] for the
+//!      invariant and its proof obligations (tested in `selection::tests`).
+//!    * **CostFed-style skew-aware cardinality** — the per-pattern, per-source
+//!      cardinality is estimated from the served per-predicate stats (triples, average
+//!      multiplicity) carried in the characteristic sets, *not* a uniform-distribution
+//!      guess; predicate skew is preserved.
+//! 2. [`plan_bgp`] — a **bind-vs-hash join planner** ([`plan`]): a greedy join-order
+//!    heuristic over the selected sources that, for each join, chooses a **bind join**
+//!    (probe the right side with the left side's bindings — cheap when the left is
+//!    small and the bound variable is selective) or a **hash/symmetric join** (scan
+//!    both sides once — cheap when both sides are large), using characteristic-set
+//!    star-join cardinality to estimate intermediate-result sizes. The output is a
+//!    [`JoinTree`] with per-node estimated cardinality and cost.
+//!
+//! ## Opt-in (hard constraint)
+//!
+//! The whole planner is behind the **`fedplan` cargo feature, OFF by default**, and the
+//! crate is a standalone workspace member with `publish = false` — `sparq-core` /
+//! `sparq-engine` never depend on it, so the default engine and the WASM artifact are
+//! byte-identical with or without it. A build that does not enable `fedplan` compiles
+//! an empty crate.
+//!
+//! ## Deferred (NOT in this slice — tracked as a roadmap bead)
+//!
+//! **ANAPSID-style non-blocking streaming joins with operator spill** and **live
+//! adaptive re-planning** are explicitly out of scope here. This slice is a *static*
+//! cost-based plan computed up front from descriptors; it does not adapt mid-execution,
+//! and it does not model memory-bounded streaming operators. Those are the natural next
+//! slice (see the roadmap bead filed from sq-a35t under epic sq-3183).
+//!
+//! [OPUS-4.8] sq-a35t — flagged for Fable re-review.
+#![forbid(unsafe_code)] // [OPUS-4.8] sq-a35t: crate has zero `unsafe`.
+#![cfg_attr(not(feature = "fedplan"), allow(dead_code, unused_imports))]
+
+#[cfg(feature = "fedplan")]
+mod descriptor;
+#[cfg(feature = "fedplan")]
+mod pattern;
+#[cfg(feature = "fedplan")]
+mod plan;
+#[cfg(feature = "fedplan")]
+mod selection;
+
+#[cfg(feature = "fedplan")]
+pub use descriptor::{
+    CharSet, ClassPartition, PredPartition, SourceDescriptor, SourceId, CS_NS, VOID_NS,
+};
+#[cfg(feature = "fedplan")]
+pub use pattern::{Bgp, Term, TriplePattern, Var};
+#[cfg(feature = "fedplan")]
+pub use plan::{plan_bgp, JoinAlgo, JoinNode, JoinTree, PlanOptions};
+#[cfg(feature = "fedplan")]
+pub use selection::{select_sources, PatternSources, SourceCandidate};

--- a/crates/sparq-fedplan/src/pattern.rs
+++ b/crates/sparq-fedplan/src/pattern.rs
@@ -1,0 +1,168 @@
+//! The BGP / triple-pattern model the planner plans over.
+//!
+//! A federated planner reasons about a Basic Graph Pattern (a conjunction of triple
+//! patterns) before any source is contacted, so the pattern model here is a *light*,
+//! self-contained one (an IRI/literal term or a named variable per position) rather
+//! than the engine's full algebra term — this slice plans over descriptors, never over
+//! a live `Graph`, and pulling in the engine's term type would couple the lean planner
+//! to the execution stack. [OPUS-4.8] sq-a35t.
+
+/// A query variable, identified by name (without the leading `?`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Var(pub String);
+
+impl Var {
+    pub fn new(name: impl Into<String>) -> Var {
+        Var(name.into())
+    }
+}
+
+/// One position of a triple pattern: a bound IRI/literal *term* (stored as its lexical
+/// string — IRIs bare, literals already rendered) or an unbound *variable*.
+///
+/// Only the *shape* matters to the planner: whether a position is bound, and — for
+/// bound IRIs — what authority/namespace it carries (so HiBISCuS pruning can compare it
+/// against a source's capability set). Literals are bound terms with no authority.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Term {
+    /// A bound IRI (stored bare, e.g. `http://dbpedia.org/resource/Berlin`).
+    Iri(String),
+    /// A bound literal (any non-IRI constant — its authority is irrelevant to pruning).
+    Literal(String),
+    /// An unbound variable.
+    Var(Var),
+}
+
+impl Term {
+    /// The variable at this position, if it is unbound.
+    pub fn as_var(&self) -> Option<&Var> {
+        match self {
+            Term::Var(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// The bound IRI at this position, if any (used for authority pruning).
+    pub fn as_iri(&self) -> Option<&str> {
+        match self {
+            Term::Iri(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    pub fn is_bound(&self) -> bool {
+        !matches!(self, Term::Var(_))
+    }
+}
+
+/// A triple pattern `(subject, predicate, object)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TriplePattern {
+    pub subject: Term,
+    pub predicate: Term,
+    pub object: Term,
+}
+
+impl TriplePattern {
+    pub fn new(subject: Term, predicate: Term, object: Term) -> TriplePattern {
+        TriplePattern {
+            subject,
+            predicate,
+            object,
+        }
+    }
+
+    /// The bound predicate IRI of this pattern, if the predicate position is a bound
+    /// IRI. CostFed/CS cardinality and HiBISCuS predicate pruning both key on this.
+    pub fn predicate_iri(&self) -> Option<&str> {
+        self.predicate.as_iri()
+    }
+
+    /// The variables this pattern *produces* (its unbound positions), de-duplicated in
+    /// position order (subject, predicate, object). The join graph connects two
+    /// patterns iff they share at least one such variable.
+    pub fn vars(&self) -> Vec<&Var> {
+        let mut out = Vec::new();
+        for t in [&self.subject, &self.predicate, &self.object] {
+            if let Some(v) = t.as_var() {
+                if !out.contains(&v) {
+                    out.push(v);
+                }
+            }
+        }
+        out
+    }
+}
+
+/// A Basic Graph Pattern: an ordered list of triple patterns. Order is the caller's
+/// query order; the planner chooses its own join order over the selected sources.
+#[derive(Debug, Clone, Default)]
+pub struct Bgp {
+    pub patterns: Vec<TriplePattern>,
+}
+
+impl Bgp {
+    pub fn new(patterns: Vec<TriplePattern>) -> Bgp {
+        Bgp { patterns }
+    }
+
+    pub fn len(&self) -> usize {
+        self.patterns.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
+
+    /// Whether patterns `i` and `j` share a variable (i.e. they join). Two patterns
+    /// with no shared variable form a Cartesian product, which the planner avoids
+    /// while any connected candidate remains.
+    pub fn shares_var(&self, i: usize, j: usize) -> bool {
+        let vi = self.patterns[i].vars();
+        self.patterns[j].vars().iter().any(|v| vi.contains(v))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn iri(s: &str) -> Term {
+        Term::Iri(s.to_string())
+    }
+    fn var(s: &str) -> Term {
+        Term::Var(Var::new(s))
+    }
+
+    #[test]
+    fn vars_dedup_and_position_order() {
+        // ?s :p ?s  — same var in subject and object: produced once.
+        let tp = TriplePattern::new(var("s"), iri("http://ex/p"), var("s"));
+        assert_eq!(tp.vars(), vec![&Var::new("s")]);
+        let tp2 = TriplePattern::new(var("s"), var("p"), var("o"));
+        assert_eq!(
+            tp2.vars(),
+            vec![&Var::new("s"), &Var::new("p"), &Var::new("o")]
+        );
+    }
+
+    #[test]
+    fn predicate_iri_only_when_bound() {
+        let bound = TriplePattern::new(var("s"), iri("http://ex/p"), var("o"));
+        assert_eq!(bound.predicate_iri(), Some("http://ex/p"));
+        let unbound = TriplePattern::new(var("s"), var("p"), var("o"));
+        assert_eq!(unbound.predicate_iri(), None);
+    }
+
+    #[test]
+    fn shares_var_detects_join_edge() {
+        let bgp = Bgp::new(vec![
+            TriplePattern::new(var("s"), iri("http://ex/p"), var("o")),
+            TriplePattern::new(var("o"), iri("http://ex/q"), var("z")), // joins on ?o
+            TriplePattern::new(var("a"), iri("http://ex/r"), var("b")), // disjoint
+        ]);
+        assert!(bgp.shares_var(0, 1));
+        assert!(!bgp.shares_var(0, 2));
+        assert!(!bgp.shares_var(1, 2));
+    }
+}

--- a/crates/sparq-fedplan/src/plan.rs
+++ b/crates/sparq-fedplan/src/plan.rs
@@ -1,0 +1,540 @@
+//! **Join planning**: a greedy join-order heuristic over the selected sources, with a
+//! per-join **bind-vs-hash** algorithm decision, producing a [`JoinTree`] of estimated
+//! cardinalities and costs.
+//!
+//! ## Inputs
+//!
+//! The planner consumes the per-pattern source selection ([`crate::select_sources`]) —
+//! each pattern's retained sources and their CostFed cardinality estimates — plus the
+//! source descriptors (for characteristic-set star-join cardinality). It never touches
+//! the network: every estimate comes from the descriptors.
+//!
+//! ## Join order (greedy, selectivity-first)
+//!
+//! Start from the lowest-cardinality pattern; repeatedly join the connected pattern
+//! (sharing a variable with the result so far) whose join yields the smallest estimated
+//! output. This is the standard greedy left-deep heuristic; it avoids Cartesian
+//! products while any connected pattern remains, and falls back to the next smallest
+//! disconnected pattern only when the result component is exhausted. Ties break on
+//! pattern index for determinism.
+//!
+//! ## Intermediate-result cardinality
+//!
+//! When several joined patterns form a **star** (share a subject variable, with bound
+//! predicates), the size of joining the next star arm is estimated from the
+//! characteristic sets — Neumann & Moerkotte's `Σ_{C⊇Q} count(C)·Π avg_mult` — which
+//! captures the predicate *correlation* a per-predicate-independence product loses
+//! (CS estimates are taken on the source contributing the star; a multi-source star
+//! sums per source). Non-star joins fall back to an independence estimate scaled by the
+//! joined predicate's selectivity.
+//!
+//! ## Bind vs hash (the per-join algorithm decision)
+//!
+//! For a join of a left intermediate result (`L` rows) with a right pattern
+//! (`R` rows total over its sources, fan-out `f` = expected matches per bound value):
+//!
+//! * **Bind join** — issue, per left row, a bound request to the right's sources
+//!   (`?s p ?o` with `?s` bound). Cost ≈ `L · (req + f)`: one request per left row plus
+//!   the matched rows. Wins when `L` is small and the right is selective per bound value
+//!   (small `f`). This is the SERVICE-style nested-loop / VALUES-pushdown join.
+//! * **Hash / symmetric join** — scan both sides once and hash-join locally. Cost ≈
+//!   `R + L`: one full retrieval of each side. Wins when `L` is large (so per-row
+//!   requests would dominate) or the right is unselective.
+//!
+//! The planner picks the cheaper of the two estimated costs; the per-request constant
+//! `req` (the round-trip penalty that makes bind joins expensive at scale) is the knob
+//! in [`PlanOptions::request_cost`]. The decision *flips* as `L` grows past the point
+//! where `L·req` overtakes `R`.
+//!
+//! ## DEFERRED (not in this slice)
+//!
+//! ANAPSID-style **non-blocking streaming joins with operator spill** and **live
+//! adaptive re-planning** are out of scope — this is a static plan. See the roadmap
+//! bead filed from sq-a35t (epic sq-3183).
+//!
+//! [OPUS-4.8] sq-a35t.
+
+use crate::descriptor::SourceDescriptor;
+use crate::pattern::{Bgp, Term, Var};
+use crate::selection::PatternSources;
+
+/// The join algorithm chosen for a binary join node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JoinAlgo {
+    /// Nested-loop / bound-request (SERVICE / VALUES-pushdown) join — probe the right
+    /// with the left's bindings. Cheap when the left is small + right selective.
+    Bind,
+    /// Hash / symmetric join — scan both sides once, join locally. Cheap when the left
+    /// is large or the right unselective.
+    Hash,
+}
+
+/// A node of the planned (left-deep) join tree.
+#[derive(Debug, Clone)]
+pub enum JoinNode {
+    /// A leaf: one triple pattern, evaluated against its retained sources (a union).
+    Leaf {
+        /// Pattern index within the BGP.
+        pattern: usize,
+        /// Estimated rows (union over the pattern's retained sources).
+        cardinality: f64,
+    },
+    /// A binary join of `left` with the leaf pattern `right`.
+    Join {
+        left: Box<JoinNode>,
+        /// Pattern index of the right (leaf) operand.
+        right: usize,
+        /// Chosen join algorithm.
+        algo: JoinAlgo,
+        /// Estimated output rows of this join.
+        cardinality: f64,
+        /// Estimated cost of this join (in the planner's abstract cost units).
+        cost: f64,
+    },
+}
+
+impl JoinNode {
+    /// The estimated output cardinality of this (sub)tree.
+    pub fn cardinality(&self) -> f64 {
+        match self {
+            JoinNode::Leaf { cardinality, .. } => *cardinality,
+            JoinNode::Join { cardinality, .. } => *cardinality,
+        }
+    }
+}
+
+/// The full planned join tree for a BGP.
+#[derive(Debug, Clone)]
+pub struct JoinTree {
+    /// The root of the left-deep join tree.
+    pub root: JoinNode,
+    /// Total estimated cost (sum of every join node's cost).
+    pub total_cost: f64,
+}
+
+impl JoinTree {
+    /// The patterns in the order the planner joins them (left-deep traversal).
+    pub fn join_order(&self) -> Vec<usize> {
+        let mut order = Vec::new();
+        collect_order(&self.root, &mut order);
+        order
+    }
+}
+
+fn collect_order(node: &JoinNode, order: &mut Vec<usize>) {
+    match node {
+        JoinNode::Leaf { pattern, .. } => order.push(*pattern),
+        JoinNode::Join { left, right, .. } => {
+            collect_order(left, order);
+            order.push(*right);
+        }
+    }
+}
+
+/// Tuning knobs for [`plan_bgp`].
+#[derive(Debug, Clone)]
+pub struct PlanOptions {
+    /// Abstract cost of one bound remote request in a bind join — the round-trip
+    /// penalty that makes bind joins expensive at scale. Higher ⇒ the planner switches
+    /// to hash joins at a smaller left cardinality. Default `1.0` (one request ≈ one
+    /// retrieved row).
+    pub request_cost: f64,
+}
+
+impl Default for PlanOptions {
+    fn default() -> Self {
+        PlanOptions { request_cost: 1.0 }
+    }
+}
+
+/// Plans the join over `bgp` given the per-pattern source `selection`
+/// ([`crate::select_sources`]) and the source `descriptors`. Returns `None` when the
+/// BGP is empty. Deterministic: greedy choices break ties on pattern index.
+pub fn plan_bgp(
+    bgp: &Bgp,
+    selection: &[PatternSources],
+    descriptors: &[SourceDescriptor],
+    opts: &PlanOptions,
+) -> Option<JoinTree> {
+    if bgp.is_empty() || selection.is_empty() {
+        return None;
+    }
+    // Per-pattern leaf cardinality (union over retained sources).
+    let leaf_card: Vec<f64> = selection
+        .iter()
+        .map(|s| s.total_cardinality().max(0.0))
+        .collect();
+
+    // Greedy left-deep: seed with the smallest-cardinality pattern.
+    let n = bgp.len();
+    let mut remaining: Vec<usize> = (0..n).collect();
+    let seed = *remaining
+        .iter()
+        .min_by(|&&a, &&b| {
+            leaf_card[a]
+                .partial_cmp(&leaf_card[b])
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.cmp(&b))
+        })
+        .expect("non-empty");
+    remaining.retain(|&p| p != seed);
+
+    let mut root = JoinNode::Leaf {
+        pattern: seed,
+        cardinality: leaf_card[seed],
+    };
+    let mut joined: Vec<usize> = vec![seed];
+
+    while !remaining.is_empty() {
+        // Prefer a CONNECTED pattern (shares a var with something already joined); only
+        // if none is connected do we accept a Cartesian arm (smallest leaf).
+        let cur_card = root.cardinality();
+        let mut best: Option<(usize, f64, f64, JoinAlgo, bool)> = None; // (pat, card, cost, algo, connected)
+        for &cand in &remaining {
+            let connected = joined.iter().any(|&j| bgp.shares_var(j, cand));
+            let (card, cost, algo) = cost_join(
+                bgp,
+                cur_card,
+                &joined,
+                cand,
+                &leaf_card,
+                descriptors,
+                selection,
+                opts,
+                connected,
+            );
+            let better = match &best {
+                None => true,
+                Some((_, _, _, _, best_conn)) => {
+                    // Connected always beats disconnected; within the same class, lower
+                    // output card wins; tie-break on pattern index for determinism.
+                    match (connected, best_conn) {
+                        (true, false) => true,
+                        (false, true) => false,
+                        _ => {
+                            let (_, best_card, ..) = best.as_ref().unwrap();
+                            card < *best_card
+                                || (card == *best_card && cand < best.as_ref().unwrap().0)
+                        }
+                    }
+                }
+            };
+            if better {
+                best = Some((cand, card, cost, algo, connected));
+            }
+        }
+        let (pat, card, cost, algo, _) = best.expect("remaining non-empty");
+        root = JoinNode::Join {
+            left: Box::new(root),
+            right: pat,
+            algo,
+            cardinality: card,
+            cost,
+        };
+        joined.push(pat);
+        remaining.retain(|&p| p != pat);
+    }
+
+    let total_cost = sum_cost(&root);
+    Some(JoinTree { root, total_cost })
+}
+
+/// Estimates `(output_cardinality, cost, algo)` for joining leaf pattern `cand` onto a
+/// left intermediate of `cur_card` rows.
+#[allow(clippy::too_many_arguments)]
+fn cost_join(
+    bgp: &Bgp,
+    cur_card: f64,
+    joined: &[usize],
+    cand: usize,
+    leaf_card: &[f64],
+    descriptors: &[SourceDescriptor],
+    selection: &[PatternSources],
+    opts: &PlanOptions,
+    connected: bool,
+) -> (f64, f64, JoinAlgo) {
+    let r = leaf_card[cand].max(1.0); // right side total rows.
+    let l = cur_card.max(1.0); // left intermediate rows.
+
+    // ---- Output cardinality.
+    let out = if connected {
+        // Try a characteristic-set star estimate first (captures predicate correlation
+        // when `cand` extends a star already joined on its subject variable).
+        star_estimate(bgp, joined, cand, descriptors, selection)
+            .unwrap_or_else(|| independence_estimate(bgp, cur_card, joined, cand, leaf_card))
+    } else {
+        // Disconnected (Cartesian): product. Only chosen when nothing connects.
+        l * r
+    };
+
+    // ---- Bind vs hash.
+    // Bind: one bound request per left row + the matched rows it returns.
+    //   fan-out f = output / left  (avg matches per left row).
+    let fan_out = (out / l).max(0.0);
+    let bind_cost = l * (opts.request_cost + fan_out);
+    // Hash/symmetric: one full retrieval of each side.
+    let hash_cost = r + l;
+    let (algo, cost) = if bind_cost <= hash_cost {
+        (JoinAlgo::Bind, bind_cost)
+    } else {
+        (JoinAlgo::Hash, hash_cost)
+    };
+    (out, cost, algo)
+}
+
+/// Characteristic-set star estimate for joining `cand` onto the star already joined on
+/// `cand`'s subject variable. Returns `None` when `cand` is not a star arm (subject not
+/// a variable, predicate not bound, or no covering characteristic set on any source).
+fn star_estimate(
+    bgp: &Bgp,
+    joined: &[usize],
+    cand: usize,
+    descriptors: &[SourceDescriptor],
+    selection: &[PatternSources],
+) -> Option<f64> {
+    let tp = &bgp.patterns[cand];
+    let sv = star_subject_var(tp)?;
+    let cand_pred = tp.predicate_iri()?.to_string();
+
+    // The predicates already joined on this subject variable (the star Q).
+    let mut q: Vec<String> = Vec::new();
+    for &j in joined {
+        let jtp = &bgp.patterns[j];
+        if star_subject_var(jtp) == Some(sv) {
+            if let Some(p) = jtp.predicate_iri() {
+                if !q.contains(&p.to_string()) {
+                    q.push(p.to_string());
+                }
+            }
+        }
+    }
+    if q.is_empty() || q.contains(&cand_pred) {
+        return None; // no prior star arm, or repeated predicate (CS model can't condition).
+    }
+    q.sort();
+    let mut q_new = q.clone();
+    let pos = q_new.binary_search(&cand_pred).unwrap_err();
+    q_new.insert(pos, cand_pred);
+
+    // Sum the CS estimate over the sources retained for `cand` (a multi-source star is a
+    // union). card(Q∪{p}) is the joined output; we report it directly (it already
+    // conditions on the whole star).
+    let mut total = 0.0f64;
+    let mut covered = false;
+    for c in &selection[cand].candidates {
+        let src = &descriptors[c.source];
+        let card_q = src.star_cardinality(&q);
+        if card_q <= 0.0 {
+            continue;
+        }
+        covered = true;
+        total += src.star_cardinality(&q_new);
+    }
+    covered.then_some(total)
+}
+
+/// The subject variable of a star arm `?s <p> ?o`/`?s <p> lit` — a variable subject with
+/// a bound predicate. `None` otherwise.
+fn star_subject_var(tp: &crate::pattern::TriplePattern) -> Option<&Var> {
+    match (&tp.subject, &tp.predicate) {
+        (Term::Var(v), Term::Iri(_)) => Some(v),
+        _ => None,
+    }
+}
+
+/// Independence-assumption output estimate (the non-star fallback): the left rows scaled
+/// by the right pattern's per-join selectivity. We approximate the right's selectivity
+/// as `min(1, distinct-binding fraction)` via its leaf cardinality and the joined
+/// pattern's cardinality — a coarse but monotone estimate (smaller right ⇒ smaller out).
+fn independence_estimate(
+    bgp: &Bgp,
+    cur_card: f64,
+    joined: &[usize],
+    cand: usize,
+    leaf_card: &[f64],
+) -> f64 {
+    let l = cur_card.max(1.0);
+    let r = leaf_card[cand].max(1.0);
+    // If the right shares a variable, the expected matches per left row ≈ r / ndv, with
+    // ndv approximated by the larger of the two joined leaf cardinalities (a standard
+    // join-selectivity heuristic: out = l*r/max(|L|,|R|)). Bounded below by 1 result
+    // when any match is possible, above by the Cartesian product.
+    let any_left = joined.iter().map(|&j| leaf_card[j]).fold(1.0f64, f64::max);
+    let ndv = any_left.max(r).max(1.0);
+    let _ = bgp; // shape already validated by the caller's `connected` flag.
+    (l * r / ndv).clamp(0.0, l * r)
+}
+
+fn sum_cost(node: &JoinNode) -> f64 {
+    match node {
+        JoinNode::Leaf { .. } => 0.0,
+        JoinNode::Join { left, cost, .. } => cost + sum_cost(left),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::descriptor::{CharSet, PredPartition, SourceId};
+    use crate::pattern::{TriplePattern, Var};
+    use crate::selection::select_sources;
+
+    fn iri(s: &str) -> Term {
+        Term::Iri(s.to_string())
+    }
+    fn var(s: &str) -> Term {
+        Term::Var(Var::new(s))
+    }
+    fn pred(p: &str, triples: u64, subjects: u64, objects: u64) -> PredPartition {
+        PredPartition {
+            predicate: p.into(),
+            triples,
+            distinct_subjects: subjects,
+            distinct_objects: objects,
+        }
+    }
+
+    #[test]
+    fn bind_vs_hash_flips_at_threshold() {
+        // Single binary join; control L (left) and R (right) directly via leaf cards.
+        // Bind cost = L*(req + out/L); Hash cost = R + L. With request_cost large, a big
+        // L makes bind expensive ⇒ Hash; a small L makes bind cheap ⇒ Bind.
+        // Build a 2-pattern star: ?s :p ?o (left), ?s :q ?z (right).
+        let bgp = Bgp::new(vec![
+            TriplePattern::new(var("s"), iri("http://ex/p"), var("o")),
+            TriplePattern::new(var("s"), iri("http://ex/q"), var("z")),
+        ]);
+        // Source with both predicates; choose stats so the left is tiny or huge.
+        let small_left = SourceDescriptor::builder(SourceId::new("S"))
+            .total_triples(10_000)
+            .predicate(pred("http://ex/p", 5, 5, 5)) // left leaf card = 5 (small)
+            .predicate(pred("http://ex/q", 1000, 1000, 1000))
+            .build();
+        let srcs = [small_left];
+        let sel = select_sources(&bgp, &srcs);
+        let opts = PlanOptions { request_cost: 50.0 };
+        let tree = plan_bgp(&bgp, &sel, &srcs, &opts).unwrap();
+        // The single join: left seed is the small pattern (:p, card 5). Bind should win.
+        if let JoinNode::Join { algo, .. } = &tree.root {
+            assert_eq!(*algo, JoinAlgo::Bind, "small left ⇒ bind join");
+        } else {
+            panic!("expected a join");
+        }
+
+        // Now make BOTH sides large so left intermediate is large ⇒ hash wins.
+        let big = SourceDescriptor::builder(SourceId::new("S"))
+            .total_triples(10_000)
+            .predicate(pred("http://ex/p", 5000, 5000, 5000))
+            .predicate(pred("http://ex/q", 5000, 5000, 5000))
+            .build();
+        let bigs = [big];
+        let sel2 = select_sources(&bgp, &bigs);
+        let tree2 = plan_bgp(&bgp, &sel2, &bigs, &opts).unwrap();
+        if let JoinNode::Join { algo, .. } = &tree2.root {
+            assert_eq!(*algo, JoinAlgo::Hash, "large left ⇒ hash join");
+        } else {
+            panic!("expected a join");
+        }
+    }
+
+    #[test]
+    fn join_order_starts_with_most_selective() {
+        // Three patterns chained: ?s :p ?o . ?o :q ?z . ?z :r ?w .
+        // Make :q the most selective leaf ⇒ it must be the seed (first in order).
+        let bgp = Bgp::new(vec![
+            TriplePattern::new(var("s"), iri("http://ex/p"), var("o")),
+            TriplePattern::new(var("o"), iri("http://ex/q"), var("z")),
+            TriplePattern::new(var("z"), iri("http://ex/r"), var("w")),
+        ]);
+        let src = SourceDescriptor::builder(SourceId::new("S"))
+            .total_triples(100_000)
+            .predicate(pred("http://ex/p", 1000, 1000, 1000))
+            .predicate(pred("http://ex/q", 10, 10, 10)) // most selective.
+            .predicate(pred("http://ex/r", 500, 500, 500))
+            .build();
+        let srcs = [src];
+        let sel = select_sources(&bgp, &srcs);
+        let tree = plan_bgp(&bgp, &sel, &srcs, &PlanOptions::default()).unwrap();
+        assert_eq!(
+            tree.join_order()[0],
+            1,
+            "most-selective pattern :q seeds the plan"
+        );
+        // All three patterns appear exactly once.
+        let mut order = tree.join_order();
+        order.sort();
+        assert_eq!(order, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn star_join_uses_characteristic_sets() {
+        // A 2-arm star ?s :a ?x . ?s :b ?y on a source whose CS says {a,b} co-occur on
+        // 100 subjects (a 1x, b 2x) ⇒ joined card = 200, NOT the independence product.
+        let bgp = Bgp::new(vec![
+            TriplePattern::new(var("s"), iri("http://ex/a"), var("x")),
+            TriplePattern::new(var("s"), iri("http://ex/b"), var("y")),
+        ]);
+        let src = SourceDescriptor::builder(SourceId::new("S"))
+            .total_triples(10_000)
+            .predicate(pred("http://ex/a", 100, 100, 100))
+            .predicate(pred("http://ex/b", 200, 100, 100))
+            .char_set(CharSet {
+                predicates: vec!["http://ex/a".into(), "http://ex/b".into()],
+                subjects: 100,
+                avg_multiplicity: vec![1.0, 2.0],
+            })
+            .build();
+        let srcs = [src];
+        let sel = select_sources(&bgp, &srcs);
+        let tree = plan_bgp(&bgp, &sel, &srcs, &PlanOptions::default()).unwrap();
+        // Root join output is the CS star cardinality 200 (100 subjects * 1 * 2).
+        assert_eq!(
+            tree.root.cardinality(),
+            200.0,
+            "star join uses CS correlation, not independence"
+        );
+    }
+
+    #[test]
+    fn empty_bgp_yields_no_plan() {
+        let bgp = Bgp::new(vec![]);
+        assert!(plan_bgp(&bgp, &[], &[], &PlanOptions::default()).is_none());
+    }
+
+    #[test]
+    fn single_pattern_is_a_leaf() {
+        let bgp = Bgp::new(vec![TriplePattern::new(
+            var("s"),
+            iri("http://ex/p"),
+            var("o"),
+        )]);
+        let src = SourceDescriptor::builder(SourceId::new("S"))
+            .predicate(pred("http://ex/p", 42, 42, 42))
+            .build();
+        let srcs = [src];
+        let sel = select_sources(&bgp, &srcs);
+        let tree = plan_bgp(&bgp, &sel, &srcs, &PlanOptions::default()).unwrap();
+        assert!(matches!(tree.root, JoinNode::Leaf { pattern: 0, .. }));
+        assert_eq!(tree.total_cost, 0.0, "a single leaf has no join cost");
+        assert_eq!(tree.join_order(), vec![0]);
+    }
+
+    #[test]
+    fn deterministic_plan() {
+        // Same inputs ⇒ identical plan (join order + algos) across runs.
+        let bgp = Bgp::new(vec![
+            TriplePattern::new(var("s"), iri("http://ex/p"), var("o")),
+            TriplePattern::new(var("o"), iri("http://ex/q"), var("z")),
+        ]);
+        let src = SourceDescriptor::builder(SourceId::new("S"))
+            .predicate(pred("http://ex/p", 100, 100, 100))
+            .predicate(pred("http://ex/q", 50, 50, 50))
+            .build();
+        let srcs = [src];
+        let sel = select_sources(&bgp, &srcs);
+        let a = plan_bgp(&bgp, &sel, &srcs, &PlanOptions::default()).unwrap();
+        let b = plan_bgp(&bgp, &sel, &srcs, &PlanOptions::default()).unwrap();
+        assert_eq!(a.join_order(), b.join_order());
+        assert_eq!(a.total_cost, b.total_cost);
+    }
+}

--- a/crates/sparq-fedplan/src/selection.rs
+++ b/crates/sparq-fedplan/src/selection.rs
@@ -1,0 +1,381 @@
+//! **Source selection**: for each triple pattern of a BGP, which sources can
+//! contribute, and at what estimated cardinality.
+//!
+//! Two complementary techniques, both reading only the served [`SourceDescriptor`]s:
+//!
+//! ## HiBISCuS-style authority/prefix pruning
+//!
+//! A source is *pruned* for a pattern only when its capability set makes a contribution
+//! **impossible**. Three prune rules, each firing only on positive evidence:
+//!
+//! 1. **Bound-predicate prune** — when the pattern's predicate is a bound IRI and the
+//!    source's predicate capability set (its `void:propertyPartition`s, which *are* the
+//!    complete set of predicates it holds) does not contain it. A source with no triple
+//!    using predicate `p` cannot match `?s p ?o` — provably.
+//! 2. **Authority prune** (subject / object positions) — when a position is a bound IRI
+//!    whose authority is *not* in the source's authority capability set, AND that set is
+//!    declared **complete** ([`SourceDescriptor::authorities_complete`]). A
+//!    VoID-parsed descriptor has an *incomplete* authority set (it sees only
+//!    predicate/class authorities, never instance authorities), so this rule is
+//!    **disabled** for it — never pruning on partial knowledge.
+//! 3. **Bound-class prune** — when the pattern is `?x rdf:type C` with `C` a bound IRI
+//!    and the source declares class partitions but none for `C`. (Only fires when the
+//!    source declares *some* class partition — an absent class section means "unknown",
+//!    not "no instances".)
+//!
+//! ### Recall-safety invariant (the load-bearing property)
+//!
+//! > **If a source `S` could return any binding for a pattern `tp`, [`select_sources`]
+//! > retains `S` for `tp`.**
+//!
+//! Equivalently: a source is dropped for a pattern only when the descriptor *proves* it
+//! holds no matching triple. Every prune rule fires only on positive evidence of
+//! non-contribution; on any uncertainty (unknown predicate set membership impossible —
+//! the predicate set is complete; incomplete authority set; absent class section) the
+//! source is **kept**. The cardinality estimate never causes a prune: a source with an
+//! estimate of 0 is still retained (estimates are lossy; only capability evidence
+//! prunes). This is exactly HiBISCuS's design goal — maximise pruning subject to never
+//! losing a result. Proven by the `recall_safe_*` tests below.
+//!
+//! ## CostFed-style skew-aware cardinality
+//!
+//! For each retained (pattern, source) pair, the cardinality is estimated from the
+//! served per-predicate statistics — `void:triples` and the per-subject average
+//! multiplicity — **not** a uniform-distribution guess, so per-predicate skew is
+//! preserved. Bound subject/object positions divide the predicate's triple count by its
+//! distinct-subject / distinct-object count respectively (CostFed's selectivity buckets).
+//!
+//! [OPUS-4.8] sq-a35t.
+
+use crate::descriptor::SourceDescriptor;
+use crate::pattern::{Bgp, Term, TriplePattern};
+
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+/// One source retained for a pattern, with its estimated contributed cardinality.
+#[derive(Debug, Clone)]
+pub struct SourceCandidate {
+    /// Index into the `sources` slice passed to [`select_sources`].
+    pub source: usize,
+    /// CostFed-style estimated triples this source contributes to the pattern.
+    pub estimated_cardinality: f64,
+}
+
+/// The sources retained for one triple pattern (by [`select_sources`]).
+#[derive(Debug, Clone)]
+pub struct PatternSources {
+    /// Index of the pattern within the BGP.
+    pub pattern: usize,
+    /// Retained sources, ascending by source index (deterministic).
+    pub candidates: Vec<SourceCandidate>,
+}
+
+impl PatternSources {
+    /// Total estimated cardinality of the pattern across all retained sources (the
+    /// per-pattern input size the join planner starts from — a union over sources).
+    pub fn total_cardinality(&self) -> f64 {
+        self.candidates
+            .iter()
+            .map(|c| c.estimated_cardinality)
+            .sum()
+    }
+
+    /// Whether any source was retained for this pattern.
+    pub fn is_empty(&self) -> bool {
+        self.candidates.is_empty()
+    }
+}
+
+/// Source selection for every pattern of `bgp` against `sources`.
+///
+/// Returns, per pattern, the retained sources and their CostFed cardinality estimates.
+/// **Recall-safe** (see the module docs): a source is pruned for a pattern only when
+/// the descriptor proves it cannot contribute. Deterministic: candidates are ordered by
+/// source index.
+pub fn select_sources(bgp: &Bgp, sources: &[SourceDescriptor]) -> Vec<PatternSources> {
+    bgp.patterns
+        .iter()
+        .enumerate()
+        .map(|(pi, tp)| {
+            let mut candidates: Vec<SourceCandidate> = Vec::new();
+            for (si, src) in sources.iter().enumerate() {
+                if can_contribute(tp, src) {
+                    candidates.push(SourceCandidate {
+                        source: si,
+                        estimated_cardinality: estimate_cardinality(tp, src),
+                    });
+                }
+            }
+            // Already in ascending source-index order (enumeration order); explicit for
+            // determinism guarantees if the loop ever changes.
+            candidates.sort_by_key(|c| c.source);
+            PatternSources {
+                pattern: pi,
+                candidates,
+            }
+        })
+        .collect()
+}
+
+/// The HiBISCuS prune decision for one (pattern, source): `true` iff the source might
+/// contribute. **Recall-safe**: returns `true` on any uncertainty; returns `false` only
+/// on positive evidence of non-contribution.
+fn can_contribute(tp: &TriplePattern, src: &SourceDescriptor) -> bool {
+    // Rule 1 — bound-predicate prune. The predicate partition set is the COMPLETE set
+    // of predicates the source holds, so a bound predicate absent from it ⇒ no match.
+    if let Some(p) = tp.predicate_iri() {
+        if !src.has_predicate(p) {
+            return false;
+        }
+    }
+
+    // Rule 3 — bound-class prune for `?x rdf:type C`. Only when the source declares
+    // SOME class partition (otherwise the class section is unknown, not empty).
+    if matches!(&tp.predicate, Term::Iri(p) if p == RDF_TYPE) {
+        if let Some(c) = tp.object.as_iri() {
+            // `src.has_class` membership is meaningful only if the source declares any
+            // class at all; a descriptor with no class section can't prune here.
+            if src.declares_any_class() && !src.has_class(c) {
+                return false;
+            }
+        }
+    }
+
+    // Rule 2 — authority prune (subject/object). Disabled unless the source's authority
+    // set is COMPLETE; `may_hold_authority` returns true (keep) when incomplete.
+    if let Some(s) = tp.subject.as_iri() {
+        if !src.may_hold_authority(s) {
+            return false;
+        }
+    }
+    if let Some(o) = tp.object.as_iri() {
+        if !src.may_hold_authority(o) {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// CostFed-style skew-aware cardinality estimate for a (pattern, source) the prune kept.
+///
+/// * Unbound predicate (`?s ?p ?o`): the source's total triples — the only sound bound
+///   when the predicate is open.
+/// * Bound predicate, both subject and object unbound: the predicate's `void:triples`.
+/// * Bound predicate + bound subject: `triples / distinctSubjects` (avg multiplicity) —
+///   the expected fan-out of one subject.
+/// * Bound predicate + bound object: `triples / distinctObjects` when known, else the
+///   conservative `triples` (recall-safe over-estimate — never prunes).
+/// * Bound predicate + both bound: `triples / (distinctSubjects · distinctObjects)`,
+///   floored at 0 (presence is uncertain; the join planner treats it as a probe).
+fn estimate_cardinality(tp: &TriplePattern, src: &SourceDescriptor) -> f64 {
+    let Some(p) = tp.predicate_iri() else {
+        // Open predicate: bound only by the source's total triples.
+        return src.total_triples.max(1) as f64;
+    };
+    let Some(part) = src.predicate(p) else {
+        // Prune kept it but predicate absent — only reachable for non-IRI predicate;
+        // be conservative.
+        return src.total_triples.max(1) as f64;
+    };
+    let triples = part.triples.max(1) as f64;
+    let s_bound = tp.subject.is_bound();
+    let o_bound = tp.object.is_bound();
+    match (s_bound, o_bound) {
+        (false, false) => triples,
+        (true, false) => {
+            // Expected objects for one subject = avg multiplicity.
+            triples / part.distinct_subjects.max(1) as f64
+        }
+        (false, true) => {
+            if part.distinct_objects > 0 {
+                triples / part.distinct_objects as f64
+            } else {
+                triples // unknown distinct-objects ⇒ conservative.
+            }
+        }
+        (true, true) => {
+            let denom = part.distinct_subjects.max(1) as f64 * part.distinct_objects.max(1) as f64;
+            (triples / denom).max(0.0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::descriptor::{CharSet, ClassPartition, PredPartition, SourceId};
+    use crate::pattern::Var;
+
+    fn iri(s: &str) -> Term {
+        Term::Iri(s.to_string())
+    }
+    fn var(s: &str) -> Term {
+        Term::Var(Var::new(s))
+    }
+    fn pred(p: &str, triples: u64, subjects: u64, objects: u64) -> PredPartition {
+        PredPartition {
+            predicate: p.into(),
+            triples,
+            distinct_subjects: subjects,
+            distinct_objects: objects,
+        }
+    }
+
+    // Source A holds foaf:knows (dbpedia authority); Source B holds foaf:name only.
+    fn source_a() -> SourceDescriptor {
+        SourceDescriptor::builder(SourceId::new("A"))
+            .total_triples(1000)
+            .predicate(pred("http://xmlns.com/foaf/0.1/knows", 200, 100, 80))
+            .build()
+    }
+    fn source_b() -> SourceDescriptor {
+        SourceDescriptor::builder(SourceId::new("B"))
+            .total_triples(500)
+            .predicate(pred("http://xmlns.com/foaf/0.1/name", 300, 300, 290))
+            .build()
+    }
+
+    #[test]
+    fn bound_predicate_prunes_source_without_it() {
+        // ?s foaf:knows ?o — only A holds foaf:knows; B is pruned.
+        let bgp = Bgp::new(vec![TriplePattern::new(
+            var("s"),
+            iri("http://xmlns.com/foaf/0.1/knows"),
+            var("o"),
+        )]);
+        let sel = select_sources(&bgp, &[source_a(), source_b()]);
+        assert_eq!(sel[0].candidates.len(), 1);
+        assert_eq!(sel[0].candidates[0].source, 0); // A
+    }
+
+    #[test]
+    fn recall_safe_unbound_predicate_keeps_all_sources() {
+        // ?s ?p ?o — predicate open: NO source may be pruned (any source could match).
+        let bgp = Bgp::new(vec![TriplePattern::new(var("s"), var("p"), var("o"))]);
+        let sel = select_sources(&bgp, &[source_a(), source_b()]);
+        assert_eq!(
+            sel[0].candidates.len(),
+            2,
+            "open predicate must keep every source"
+        );
+    }
+
+    #[test]
+    fn recall_safe_incomplete_authority_never_prunes_subject_object() {
+        // A bound subject IRI on a foreign authority must NOT prune a source whose
+        // authority set is incomplete (VoID-parsed) — only the predicate prunes.
+        // Source A holds foaf:knows; subject is a wikidata IRI A never declared an
+        // authority for. Because A's authority set is incomplete, A is KEPT.
+        let bgp = Bgp::new(vec![TriplePattern::new(
+            iri("http://www.wikidata.org/entity/Q42"),
+            iri("http://xmlns.com/foaf/0.1/knows"),
+            var("o"),
+        )]);
+        let sel = select_sources(&bgp, &[source_a()]);
+        assert_eq!(
+            sel[0].candidates.len(),
+            1,
+            "incomplete authority set must not prune"
+        );
+    }
+
+    #[test]
+    fn complete_authority_prunes_foreign_subject_but_keeps_local() {
+        // A source with a COMPLETE authority set (HiBISCuS capability) DOES prune a
+        // bound subject on a foreign authority — but keeps a local-authority subject.
+        let src = SourceDescriptor::builder(SourceId::new("DBp"))
+            .predicate(pred("http://xmlns.com/foaf/0.1/knows", 200, 100, 80))
+            .authorities_complete() // declares: I only mint foaf authority terms.
+            .build();
+        let srcs = [src];
+        // foreign-authority subject ⇒ pruned.
+        let foreign = Bgp::new(vec![TriplePattern::new(
+            iri("http://www.wikidata.org/entity/Q42"),
+            iri("http://xmlns.com/foaf/0.1/knows"),
+            var("o"),
+        )]);
+        assert!(select_sources(&foreign, &srcs)[0].is_empty());
+        // local-authority subject ⇒ kept (foaf authority is in the capability set).
+        let local = Bgp::new(vec![TriplePattern::new(
+            iri("http://xmlns.com/foaf/0.1/agentX"),
+            iri("http://xmlns.com/foaf/0.1/knows"),
+            var("o"),
+        )]);
+        assert!(!select_sources(&local, &srcs)[0].is_empty());
+    }
+
+    #[test]
+    fn bound_class_prunes_only_when_class_section_declared() {
+        // ?x rdf:type :Person — a source that declares classes but NOT :Person prunes;
+        // a source with NO class section is KEPT (recall-safe: absent ≠ empty).
+        let typed = TriplePattern::new(var("x"), iri(RDF_TYPE), iri("http://ex/Person"));
+        let bgp = Bgp::new(vec![typed]);
+        // Source with class section but no :Person ⇒ pruned.
+        let declares = SourceDescriptor::builder(SourceId::new("C"))
+            .predicate(pred(RDF_TYPE, 10, 10, 5))
+            .class(ClassPartition {
+                class: "http://ex/Company".into(),
+                entities: 5,
+            })
+            .build();
+        assert!(select_sources(&bgp, &[declares])[0].is_empty());
+        // Source with rdf:type predicate but NO class section ⇒ kept.
+        let no_classes = SourceDescriptor::builder(SourceId::new("D"))
+            .predicate(pred(RDF_TYPE, 10, 10, 5))
+            .build();
+        assert!(!select_sources(&bgp, &[no_classes])[0].is_empty());
+    }
+
+    #[test]
+    fn costfed_cardinality_is_skew_aware() {
+        // foaf:knows on A: 200 triples, 100 subjects, 80 objects.
+        let a = source_a();
+        // ?s knows ?o — full predicate triples.
+        let open = TriplePattern::new(var("s"), iri("http://xmlns.com/foaf/0.1/knows"), var("o"));
+        assert_eq!(estimate_cardinality(&open, &a), 200.0);
+        // bound subject ⇒ avg multiplicity 200/100 = 2.
+        let sb = TriplePattern::new(
+            iri("http://ex/x"),
+            iri("http://xmlns.com/foaf/0.1/knows"),
+            var("o"),
+        );
+        assert_eq!(estimate_cardinality(&sb, &a), 2.0);
+        // bound object ⇒ 200/80 = 2.5.
+        let ob = TriplePattern::new(
+            var("s"),
+            iri("http://xmlns.com/foaf/0.1/knows"),
+            iri("http://ex/y"),
+        );
+        assert_eq!(estimate_cardinality(&ob, &a), 2.5);
+        // open predicate ⇒ total triples bound.
+        let op = TriplePattern::new(var("s"), var("p"), var("o"));
+        assert_eq!(estimate_cardinality(&op, &a), 1000.0);
+    }
+
+    #[test]
+    fn estimate_never_prunes_zero_cardinality_source() {
+        // A source whose CS-derived estimate would be tiny must still be RETAINED:
+        // estimates are lossy, only capability evidence prunes (recall-safety).
+        let a = SourceDescriptor::builder(SourceId::new("A"))
+            .total_triples(1)
+            .predicate(pred("http://ex/p", 1, 1, 1))
+            .char_set(CharSet {
+                predicates: vec!["http://ex/p".into()],
+                subjects: 1,
+                avg_multiplicity: vec![0.0], // pathological zero-multiplicity.
+            })
+            .build();
+        let bgp = Bgp::new(vec![TriplePattern::new(
+            var("s"),
+            iri("http://ex/p"),
+            var("o"),
+        )]);
+        let sel = select_sources(&bgp, &[a]);
+        assert_eq!(
+            sel[0].candidates.len(),
+            1,
+            "low/zero estimate must not prune the source"
+        );
+    }
+}

--- a/skills/federated-planning/SKILL.md
+++ b/skills/federated-planning/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: federated-planning
+description: "Cost-based federated SPARQL source selection + bind-vs-hash join planning over already-fetched source descriptors, via the opt-in sparq-fedplan crate. Use when planning a federated BGP across multiple SPARQL endpoints from their served statistics (VoID property/class partitions + mined scs: characteristic sets): deciding which sources can contribute to each triple pattern (HiBISCuS recall-safe pruning + CostFed skew-aware cardinality), and choosing a join order with per-join bind-vs-hash algorithm selection (characteristic-set star cardinality for intermediate sizes). Pure + deterministic, no network I/O. Off by default; does not touch sparq-core/sparq-engine's lean build. NOT for live streaming/adaptive joins (ANAPSID — deferred)."
+---
+
+# sparq-fedplan — cost-based federated source selection + join planning
+
+`sparq-fedplan` plans a federated SPARQL **Basic Graph Pattern** (BGP) across several
+remote endpoints **from statistics already in hand** — it never contacts the network. A
+caller fetches each source's descriptor once (the W3C VoID document a `sparq-server`
+serves at `/.well-known/void`, including the mined `scs:` characteristic sets), and the
+planner decides, deterministically:
+
+1. **which sources can contribute** to each triple pattern, and
+2. **a join order + per-join bind-vs-hash algorithm** over the selected sources.
+
+It is the **opt-in public surface** for cost-based federation planning. Add it
+explicitly and enable the `fedplan` feature; it is **not** in sparq's default build
+(`sparq-core`/`sparq-engine` stay lean, the wasm artifact is unchanged unless you pull it
+in). There is no `sparq-core`/`sparq-engine` dependency — it plans over descriptors only.
+
+## Add the dependency
+
+```toml
+[dependencies]
+sparq-fedplan = { path = "crates/sparq-fedplan", features = ["fedplan"] }
+oxrdf = { version = "0.3", features = ["rdf-12"] }
+```
+
+The whole planner is behind the `fedplan` feature (off by default), so even a crate that
+depends on `sparq-fedplan` pays nothing for it unless the feature is enabled.
+
+## Build source descriptors
+
+Either programmatically via the builder, or by parsing the served N-Triples document.
+
+```rust
+use sparq_fedplan::{SourceDescriptor, SourceId, PredPartition, ClassPartition};
+
+// Programmatic (VoID property/class partitions).
+let src = SourceDescriptor::builder(SourceId::new("https://a.example/sparql"))
+    .total_triples(10_000)
+    .predicate(PredPartition { predicate: "http://xmlns.com/foaf/0.1/knows".into(),
+        triples: 2000, distinct_subjects: 1000, distinct_objects: 1800 })
+    .class(ClassPartition { class: "http://xmlns.com/foaf/0.1/Person".into(), entities: 1000 })
+    .build();
+
+// Or parse the served descriptor (the /.well-known/void N-Triples form, with scs: sets):
+let parsed = SourceDescriptor::from_void_nt(SourceId::new("https://b.example/sparql"), nt)?;
+```
+
+A descriptor **parsed from VoID partitions is authority-incomplete** (it sees only
+predicate/class authorities, never subject/object instance authorities), so
+subject/object authority-pruning is disabled for it — recall-safe by construction. To
+enable authority pruning, build via `.builder(..)` and call `.authorities_complete()`
+only when you truly enumerate every authority the source mints (a HiBISCuS-style
+capability set / `void:uriSpace` declaration).
+
+## Select sources for a BGP (recall-safe)
+
+```rust
+use sparq_fedplan::{Bgp, TriplePattern, Term, Var, select_sources};
+
+let bgp = Bgp::new(vec![
+    TriplePattern::new(Term::Var(Var::new("s")),
+        Term::Iri("http://xmlns.com/foaf/0.1/knows".into()), Term::Var(Var::new("o"))),
+]);
+let sources = [src];
+let selection = select_sources(&bgp, &sources);
+// selection[i].candidates: the sources retained for pattern i, with estimated_cardinality.
+```
+
+**Recall-safety invariant:** a source is pruned for a pattern *only when the descriptor
+proves it holds no matching triple*. A bound predicate absent from the source's (complete)
+predicate-partition set prunes; a bound class absent from a *declared* class section
+prunes; a bound subject/object whose authority is absent prunes *only* when the authority
+set is complete. On any uncertainty — open predicate, incomplete authority set, absent
+class section — the source is **kept**. The cardinality estimate never prunes (a source
+with a tiny or zero estimate is still retained). This is HiBISCuS's design goal: maximise
+pruning subject to never losing a result.
+
+## Plan the join (bind vs hash)
+
+```rust
+use sparq_fedplan::{plan_bgp, PlanOptions, JoinAlgo, JoinNode};
+
+let plan = plan_bgp(&bgp, &selection, &sources, &PlanOptions::default()).unwrap();
+let order: Vec<usize> = plan.join_order(); // patterns in join order (left-deep)
+let cost: f64 = plan.total_cost;
+```
+
+Each binary join is a **bind join** (cost ≈ `L·(req + fan_out)` — probe the right with the
+left's bindings; cheap when the left is small and the right selective) or a **hash /
+symmetric join** (cost ≈ `R + L` — scan both sides once; cheap when the left is large or
+the right unselective). The decision flips as the left intermediate grows past the point
+where per-row requests overtake a full scan; tune the round-trip penalty with
+`PlanOptions::request_cost`. Star arms (`?s p₁ ?a . ?s p₂ ?b`) use characteristic-set
+cardinality (`Σ_{C⊇Q} count(C)·Π avg_mult`) for intermediate sizes, capturing the
+predicate correlation an independence product loses.
+
+## Deferred (NOT here)
+
+**ANAPSID-style non-blocking streaming joins with operator spill** and **live adaptive
+re-planning** are out of scope — this is a *static* plan computed up front. They are filed
+as a roadmap bead under epic **sq-3183**.
+
+[OPUS-4.8] sq-a35t — flag for Fable re-review.


### PR DESCRIPTION
> 🤖 SPARQ agent

First opt-in slice of **cost-based federated source selection + join planning** — bead **sq-a35t**, epic **sq-3183**. Plans a federated SPARQL BGP from **already-fetched source descriptors** (the served VoID + mined `scs:` characteristic-set stats); **pure, deterministic, NO network I/O**.

## Opt-in gating (hard constraint)
New standalone workspace member `crates/sparq-fedplan`, `publish = false`, gated behind the **`fedplan` cargo feature — OFF by default**. **No `sparq-core`/`sparq-engine` dependency** — the lean core and the WASM artifact are byte-identical with or without it; a build that doesn't enable `fedplan` compiles an empty crate. Bench-exempt under gate G1 like `sparq-canon`/`sparq-prov` (planning crate, no runtime data path).

## What it builds
1. **Source selection** (`select_sources`) — per triple pattern, which sources can contribute + a per-(pattern, source) cardinality:
   - **HiBISCuS-style recall-safe pruning** — a source is pruned for a pattern only on *positive evidence* it cannot contribute: a bound predicate absent from the source's (complete) predicate-partition set; a bound class absent from a *declared* class section; a bound subject/object authority absent from a *complete* authority capability set. **Recall-safety invariant:** a source that could return any binding is **never** pruned — any uncertainty keeps it (open predicate, incomplete authority set, absent class section). The cardinality estimate never prunes. Documented in the module + README + SKILL, proven by `recall_safe_*` tests.
   - **CostFed-style skew-aware cardinality** — from the served per-predicate triples + average multiplicity (not a uniform guess); bound subject/object positions divide by distinct-subjects/objects (selectivity buckets).
2. **Join planning** (`plan_bgp`) — greedy left-deep join order + a per-join **bind-vs-hash** decision:
   - **Bind** (cost ≈ `L·(req + fan_out)`) wins when the left is small + right selective; **Hash/symmetric** (cost ≈ `R + L`) wins when the left is large. The decision **flips at the expected threshold** (tunable `PlanOptions::request_cost`; tested).
   - **Characteristic-set star cardinality** (`Σ_{C⊇Q} count(C)·Π avg_mult`, Neumann & Moerkotte) for intermediate-result sizes, capturing the predicate correlation an independence product loses.

## Deferred (NOT in this slice)
**ANAPSID-style non-blocking streaming joins with operator spill** + **live adaptive re-planning** — this is a *static* plan computed up front. Filed as a roadmap bead under epic sq-3183 (id in the agent report) and noted in the module docs.

## Gates
- `cargo build` / `cargo test` (21 tests) / `cargo clippy --all-targets -D warnings` clean — **feature OFF and ON**.
- `rustfmt --check` clean on touched files.
- `python3 scripts/gate-new-crate.py` PASS; `check-readme-template.py` PASS.
- Crate `README.md` + `skills/federated-planning/SKILL.md` added per the public-API → SKILL rule.

NON-CANONICAL timing (work-box EC2) — no measured timings baked into docs.

[OPUS-4.8] — new code carries inline `[OPUS-4.8]` markers for Fable re-review.