### PR TITLE
feat(sparq-solid): materialize ODRL permissions into AUTH_GRAPH (sq-h3uk)

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -131,6 +131,12 @@ jobs:
             crate: sparq-mpc
             features: insecure-test-rng
             test: true
+          # [OPUS-4.8] sq-h3uk: the ODRL->AUTH_GRAPH bridge (pulls the optional
+          # sparq-policy ODRL evaluator) — keeps the opt-in ON path from rotting.
+          - name: sparq-solid (odrl-bridge)
+            crate: sparq-solid
+            features: odrl-bridge
+            test: true
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust (stable)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3566,6 +3566,7 @@ dependencies = [
  "spargebra",
  "sparq-core",
  "sparq-engine",
+ "sparq-policy",
  "sparq-reason",
 ]
 

--- a/crates/sparq-solid/Cargo.toml
+++ b/crates/sparq-solid/Cargo.toml
@@ -26,6 +26,17 @@ rustdoc-args = ["--cfg", "docsrs"]
 sparq-core = { path = "../sparq-core", version = "0.1.0", default-features = false }
 sparq-engine = { path = "../sparq-engine", version = "0.1.0", default-features = false }
 sparq-reason = { path = "../sparq-reason", version = "0.1.0", default-features = false }
+# [OPUS-4.8] sq-h3uk: the ODRL→AUTH_GRAPH bridge. OPTIONAL + behind the `odrl-bridge`
+# feature (OFF by default), so the default sparq-solid build carries zero ODRL code,
+# deps, or runtime cost — sparq-policy is NOT forced onto the default build. Research
+# track (the single-node bridge of epic sq-3183), NOT a production cutover.
+sparq-policy = { path = "../sparq-policy", version = "0.1.0", default-features = false, optional = true }
 oxrdf.workspace = true
 spargebra.workspace = true
 rustc-hash.workspace = true
+
+[features]
+# [OPUS-4.8] sq-h3uk: materialize matched ODRL permissions into the AUTH_GRAPH so the
+# existing graph-level WAC/ACP enforcement applies them. OFF by default (lean core);
+# pulls in the optional sparq-policy ODRL evaluator only when enabled.
+odrl-bridge = ["dep:sparq-policy"]

--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -49,6 +49,39 @@ let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len(
   path that enforces the same policy on any standard SPARQL 1.1 engine.
 - **Write-path gating** — `update_as` / `update_as_acp` check every graph an update could
   mutate before applying it, and auto-re-materialize on `.acl`/`.acr` writes.
+- **ODRL bridge (opt-in, research-track)** — behind the off-by-default `odrl-bridge`
+  cargo feature, `materialize_permission` / `PodStore::materialize_odrl_permission` runs the
+  [`sparq-policy`](../sparq-policy) ODRL evaluator and, on a **definite Permit**, materializes
+  the equivalent WAC/ACP grant into the auth view — so the existing graph-level enforcement
+  honours it with **no new enforcement engine**. See below.
+
+## ODRL → AUTH_GRAPH bridge (opt-in `odrl-bridge` feature) — [OPUS-4.8] sq-h3uk
+
+The single-node bridge of epic sq-3183 (**research-track, not a production cutover**). Enable
+it with `--features odrl-bridge` (it pulls in the optional `sparq-policy` dependency only then;
+the default build carries zero ODRL code). A matched ODRL `Permission` becomes a concrete
+`principal auth:<mode> graph` triple in `<urn:sparq:auth>`, **appended** to whatever WAC/ACP
+view already exists.
+
+**Action → mode mapping** (the ODRL *request* action is mapped; conservative — a Permit only
+ever grants the narrowest mode the action denotes):
+
+| ODRL action (`odrl:`)                         | WAC/ACP mode            |
+|-----------------------------------------------|-------------------------|
+| `read`, `display`, `present`, `print`, `play` | `acl:Read`              |
+| `append`                                      | `acl:Append`            |
+| `modify`, `delete`, `write`                   | `acl:Write`             |
+| anything else (incl. the `odrl:use` umbrella) | **unmapped → no grant** |
+
+`odrl:use` is deliberately left unmapped: it subsumes every action, so picking one WAC mode
+for it would have to pick the widest — request `odrl:read` explicitly instead (a `use`
+permission in the policy still *grants* a concrete `read` request, and the bridge maps that
+concrete request).
+
+**Fail-closed:** a grant is materialized **only** on a definite Permit *and* a mappable action
+*and* a concrete party (WebID) + target graph. A Deny, an unsatisfied constraint, an
+undischarged duty, an unmapped action, or a partyless/targetless request materializes
+**nothing** — access is never widened on ambiguity.
 
 ## Security posture — fail-closed
 

--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -5,12 +5,18 @@ mod authindex;
 pub mod fixture;
 mod loader;
 mod materialize;
+// [OPUS-4.8] sq-h3uk: ODRL→AUTH_GRAPH bridge — opt-in (`odrl-bridge` feature), OFF by
+// default, so the core sparq-solid build carries zero ODRL/sparq-policy code.
+#[cfg(feature = "odrl-bridge")]
+pub mod odrl_bridge;
 mod rewrite;
 mod update; // [OPUS-4.8] sq-xor3: write/update-path enforcement
 
 pub use authindex::{pair_principal, AuthIndex, Mode, Session};
 pub use fixture::{acp_fixture, wac_fixture};
 pub use materialize::{materialize_acp, materialize_wac, MaterializeStats};
+#[cfg(feature = "odrl-bridge")]
+pub use odrl_bridge::{action_to_mode, materialize_permission, BridgeOutcome};
 pub use rewrite::{rewrite_for, wrap_for_view};
 
 use oxrdf::{NamedNode, Term};
@@ -413,6 +419,41 @@ impl PodStore {
             }
         }
         Ok(())
+    }
+
+    /// [OPUS-4.8] sq-h3uk — evaluate an ODRL `policy` against `request` and, on a
+    /// definite Permit, materialize the equivalent WAC/ACP grant into this store's
+    /// `<urn:sparq:auth>` view, then rebuild the session index so the grant takes
+    /// effect on the next [`PodStore::accessible`] / [`PodStore::query_as`] call.
+    ///
+    /// This is the [`PodStore`] entry point for the opt-in ODRL bridge
+    /// ([`odrl_bridge::materialize_permission`]): a matched ODRL `Permission`
+    /// (action + constraints satisfied + duties discharged) becomes a concrete
+    /// `principal auth:<mode> graph` triple honoured by the existing graph-level
+    /// enforcement — **no new enforcement engine**. The grant is APPENDED to the
+    /// current auth view (any WAC/ACP grants already materialized are preserved).
+    ///
+    /// **Fail-closed:** a Deny, an ambiguous evaluation, an unmapped ODRL action, or
+    /// a request without a concrete party/target materializes NOTHING and leaves the
+    /// auth view (and so the session index) untouched — see
+    /// [`odrl_bridge::materialize_permission`] for the exact predicates and the
+    /// [action→mode mapping](odrl_bridge#action--mode-mapping).
+    ///
+    /// Call [`PodStore::materialize_wac`] / [`materialize_acp`](PodStore::materialize_acp)
+    /// FIRST if you also want the static WAC/ACP grants present; the bridge adds to
+    /// whatever auth view currently exists (or creates a fresh one holding just the
+    /// bridged grant).
+    #[cfg(feature = "odrl-bridge")]
+    pub fn materialize_odrl_permission(
+        &mut self,
+        policy: &sparq_policy::Policy,
+        request: &sparq_policy::Request,
+    ) -> odrl_bridge::BridgeOutcome {
+        let outcome = odrl_bridge::materialize_permission(&mut self.graph, policy, request);
+        if outcome.granted {
+            self.reindex(); // a new grant changes the auth view → rebuild index + drop cache
+        }
+        outcome
     }
 
     /// The current auth index (for direct inspection/tests).

--- a/crates/sparq-solid/src/odrl_bridge.rs
+++ b/crates/sparq-solid/src/odrl_bridge.rs
@@ -1,0 +1,263 @@
+//! [OPUS-4.8] sq-h3uk — bridge the `sparq-policy` ODRL evaluator into the
+//! `<urn:sparq:auth>` AUTH_GRAPH so the existing graph-level WAC/ACP enforcement
+//! applies a matched ODRL [`Permission`](sparq_policy::Rule).
+//!
+//! # What this is (and is NOT)
+//!
+//! This is the **single-node** bridge of epic sq-3183 — a research-track surface,
+//! NOT a production cutover and NOT the federated/ZK-disclosure path (that one is
+//! gated on ZK soundness remediation). It composes two opt-in crates:
+//!
+//! - `sparq-policy` answers a usage-control question — *may this party USE this
+//!   asset, for purpose P, until time T, with obligation O discharged?* — and
+//!   returns a fail-closed [`Decision`](sparq_policy::Decision).
+//! - `sparq-solid` enforces graph-level access: a principal × [`Mode`] → graph set
+//!   is read out of the `<urn:sparq:auth>` view (see [`crate::AuthIndex`]).
+//!
+//! The bridge **materializes** a definite ODRL Permit as the very same
+//! `principal auth:<mode> graphName` triples the existing enforcement already
+//! understands, appending them into the AUTH_GRAPH. Net effect: an ODRL
+//! `Permission` (action + constraints satisfied + duties discharged) becomes a
+//! concrete WAC/ACP grant honoured by the current enforcement — **no new
+//! enforcement engine**, the existing one is reused unchanged.
+//!
+//! # Fail-closed
+//!
+//! A grant is materialized **only** when [`sparq_policy::evaluate`] returns a
+//! definite Permit (`decision.allow == true`) AND the requested ODRL action maps to
+//! a concrete WAC/ACP [`Mode`] AND the request names a concrete WebID party + target
+//! graph IRI. A Deny, an ambiguous evaluation, an unmapped action, or a missing
+//! party/target materializes **nothing** — access is never widened on ambiguity.
+//!
+//! # Action → Mode mapping
+//!
+//! The ODRL request's `action` IRI is mapped to a WAC/ACP [`Mode`] by
+//! [`action_to_mode`]. The mapping is deliberately conservative (a permit only ever
+//! grants the *narrowest* mode the action denotes):
+//!
+//! | ODRL action (`odrl:`)                                   | WAC/ACP [`Mode`] |
+//! |---------------------------------------------------------|------------------|
+//! | `read`, `display`, `present`, `print`, `play`           | [`Mode::Read`]   |
+//! | `append`                                                | [`Mode::Append`] |
+//! | `modify`, `delete`, `write`                             | [`Mode::Write`]  |
+//! | anything else (incl. the `odrl:use` umbrella)           | **unmapped → no grant** |
+//!
+//! The `odrl:use` umbrella is intentionally **not** mapped to a write/control mode:
+//! `use` subsumes every action in the ODRL hierarchy, so materializing it as a
+//! single WAC mode would have to pick the widest, violating fail-closed. A caller
+//! that wants `use → Read` should request `odrl:read` explicitly (a `use` permission
+//! in the policy still *grants* a `read` request — `odrl:use` permits any action in
+//! the evaluator — so the bridge maps the **request** action, which is concrete).
+
+use crate::authindex::Mode;
+use crate::{AUTH_GRAPH, AUTH_NS};
+use oxrdf::{NamedNode, Term};
+use sparq_core::dict::Dict;
+use sparq_core::Graph;
+use sparq_policy::{evaluate, Policy, Request};
+
+/// The ODRL namespace prefix (`odrl:`), re-exported for caller convenience.
+pub const ODRL_NS: &str = sparq_policy::ODRL_NS;
+
+/// Map an ODRL **request action** IRI to the WAC/ACP [`Mode`] it materializes as,
+/// or `None` if the action has no faithful single-mode mapping (fail-closed: an
+/// unmapped action never materializes a grant).
+///
+/// See the [module docs](self#action--mode-mapping) for the full table and the
+/// rationale for leaving the `odrl:use` umbrella unmapped.
+///
+/// # Examples
+///
+/// ```
+/// # use sparq_solid::odrl_bridge::action_to_mode;
+/// # use sparq_solid::Mode;
+/// assert_eq!(action_to_mode("http://www.w3.org/ns/odrl/2/read"), Some(Mode::Read));
+/// assert_eq!(action_to_mode("http://www.w3.org/ns/odrl/2/modify"), Some(Mode::Write));
+/// assert_eq!(action_to_mode("http://www.w3.org/ns/odrl/2/append"), Some(Mode::Append));
+/// // the umbrella action and unknown actions are unmapped (no grant)
+/// assert_eq!(action_to_mode("http://www.w3.org/ns/odrl/2/use"), None);
+/// ```
+pub fn action_to_mode(action_iri: &str) -> Option<Mode> {
+    let local = action_iri.strip_prefix(ODRL_NS)?;
+    Some(match local {
+        // Read-family: observe/render the resource's content.
+        "read" | "display" | "present" | "print" | "play" => Mode::Read,
+        // Append: add without removing (the strictly weaker write).
+        "append" => Mode::Append,
+        // Write-family: mutate/replace/remove the resource's content.
+        "modify" | "delete" | "write" => Mode::Write,
+        // `use` (umbrella) and everything else: no faithful single-mode mapping.
+        _ => return None,
+    })
+}
+
+/// The `auth:` view predicate a [`Mode`] grant is materialized under — the SAME
+/// predicate the WAC/ACP rules emit and [`crate::AuthIndex`] reads
+/// (`auth:read|write|append|control`).
+fn mode_predicate(mode: Mode) -> &'static str {
+    match mode {
+        Mode::Read => "read",
+        Mode::Write => "write",
+        Mode::Append => "append",
+        Mode::Control => "control",
+    }
+}
+
+/// What [`materialize_permission`] decided and (on a Permit) materialized.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BridgeOutcome {
+    /// Whether the ODRL evaluation was a definite Permit AND produced a grant.
+    /// `false` ⇒ nothing was written to the AUTH_GRAPH (fail-closed).
+    pub granted: bool,
+    /// On a grant: the WAC/ACP mode the matched ODRL action mapped to.
+    pub mode: Option<Mode>,
+    /// On a grant: the materialized `principal auth:<mode> graph` triple, as
+    /// `(principal_iri, mode_predicate_iri, graph_iri)`, for audit/justification.
+    pub grant_triple: Option<(String, String, String)>,
+    /// Human-readable reason a grant was NOT materialized (the ODRL decision's
+    /// caveats, an unmapped action, or a missing party/target). Empty on a grant.
+    pub reasons: Vec<String>,
+}
+
+impl BridgeOutcome {
+    fn denied(reasons: Vec<String>) -> BridgeOutcome {
+        BridgeOutcome { granted: false, mode: None, grant_triple: None, reasons }
+    }
+}
+
+/// Evaluate `policy` against `request` and, **iff** the result is a definite Permit
+/// for a mappable action with a concrete party + target, materialize the equivalent
+/// `principal auth:<mode> graph` grant into the dataset's `<urn:sparq:auth>` view —
+/// the triple the existing WAC/ACP enforcement ([`crate::AuthIndex`],
+/// [`crate::PodStore::accessible`]) already honours.
+///
+/// The grant is **appended** to the current auth view: any WAC/ACP grants already
+/// materialized there are preserved (this widens nothing they denied — it only adds
+/// an allow triple, which the `∪ allow ∖ ∪ deny` semantics still subtract any
+/// matching deny from). If no `<urn:sparq:auth>` graph exists yet, one is created
+/// holding just the bridged grant.
+///
+/// # Fail-closed
+///
+/// Returns a [`BridgeOutcome`] with `granted == false` and writes **nothing** when:
+/// the ODRL [`Decision`](sparq_policy::Decision) is a Deny (or any caveat blocked the
+/// permission); the requested action does not [`action_to_mode`]-map; or the request
+/// omits the party (assignee/WebID) or the target graph IRI. The grant principal is
+/// the request's `party` (a concrete WebID) — an anonymous/partyless request never
+/// materializes a grant, since a partyless grant would widen access to everyone.
+///
+/// # Note (PodStore observation)
+///
+/// Like [`crate::materialize_wac`], a direct call on a [`crate::PodStore`]'s `graph`
+/// field does NOT rebuild its session index/cache. Use
+/// [`crate::PodStore::materialize_odrl_permission`], which reindexes afterward.
+///
+/// # Examples
+///
+/// ```
+/// use oxrdf::Term;
+/// use sparq_solid::odrl_bridge::materialize_permission;
+/// use sparq_policy::{parse_policy_str, Request};
+///
+/// // alice MAY read the target graph (a bare matching permission).
+/// let pol = parse_policy_str(r#"
+/// @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+/// <urn:pol/1> a odrl:Set ; odrl:permission [
+///     odrl:action odrl:read ;
+///     odrl:target <https://pod.ex/notes/n1> ;
+///     odrl:assignee <https://alice.ex/card#me> ] .
+/// "#, "turtle")?;
+///
+/// let mut graph = sparq_core::Graph::load_dataset(
+///     "<https://pod.ex/notes/n1#it> <https://ex.dev/ns#t> \"x\" <https://pod.ex/notes/n1> .",
+///     "nquads")?;
+/// let req = Request::new("http://www.w3.org/ns/odrl/2/read")
+///     .on("https://pod.ex/notes/n1")
+///     .by("https://alice.ex/card#me");
+///
+/// let out = materialize_permission(&mut graph, &pol, &req);
+/// assert!(out.granted);
+/// // a concrete WAC/ACP grant now lives in the auth view
+/// assert!(graph.named.iter().any(|(name, _)| matches!(
+///     name, Term::NamedNode(n) if n.as_str() == sparq_solid::AUTH_GRAPH)));
+/// # Ok::<(), String>(())
+/// ```
+pub fn materialize_permission(
+    graph: &mut Graph,
+    policy: &Policy,
+    request: &Request,
+) -> BridgeOutcome {
+    // 1. ODRL evaluation — the single source of the allow/deny decision.
+    let decision = evaluate(policy, request);
+    if !decision.allow {
+        // Deny / ambiguous → materialize NOTHING (fail-closed).
+        return BridgeOutcome::denied(decision.unmet_constraints);
+    }
+
+    // 2. Action → Mode. An unmapped action (incl. the `use` umbrella) → no grant.
+    let Some(mode) = action_to_mode(&request.action) else {
+        return BridgeOutcome::denied(vec![format!(
+            "ODRL action <{}> has no WAC/ACP mode mapping; no grant materialized",
+            request.action
+        )]);
+    };
+
+    // 3. Concrete party (WebID principal) + target graph required — a partyless or
+    //    targetless grant would widen access (fail-closed).
+    let Some(party) = request.party.as_deref() else {
+        return BridgeOutcome::denied(vec![
+            "ODRL Permit has no concrete party (assignee/WebID); no grant materialized".to_owned(),
+        ]);
+    };
+    let Some(target) = request.target.as_deref() else {
+        return BridgeOutcome::denied(vec![
+            "ODRL Permit has no concrete target graph IRI; no grant materialized".to_owned(),
+        ]);
+    };
+
+    // 4. Materialize `party auth:<mode> target` into the auth view.
+    let pred = format!("{AUTH_NS}{}", mode_predicate(mode));
+    append_grant(graph, party, &pred, target);
+
+    BridgeOutcome {
+        granted: true,
+        mode: Some(mode),
+        grant_triple: Some((party.to_owned(), pred, target.to_owned())),
+        reasons: Vec::new(),
+    }
+}
+
+/// Append a single `subject predicate object` triple to the `<urn:sparq:auth>`
+/// named graph, preserving the triples already there (the WAC/ACP grants). Rebuilds
+/// the auth sub-graph from its existing triples + the new one via [`Graph::from_parts`].
+fn append_grant(graph: &mut Graph, subject: &str, predicate: &str, object: &str) {
+    let s = Term::NamedNode(NamedNode::new_unchecked(subject));
+    let p = Term::NamedNode(NamedNode::new_unchecked(predicate));
+    let o = Term::NamedNode(NamedNode::new_unchecked(object));
+    let auth_name = Term::NamedNode(NamedNode::new_unchecked(AUTH_GRAPH));
+
+    // Collect the existing auth-view triples (if any) as terms, add the grant, then
+    // re-intern into a fresh sub-graph dictionary (matches install_auth_view).
+    let mut terms: Vec<[Term; 3]> = match graph.named.iter().find(|(n, _)| *n == auth_name) {
+        Some((_, sub)) => crate::loader::graph_triples(sub),
+        None => Vec::new(),
+    };
+    // Idempotent: don't duplicate an identical grant triple.
+    let new_triple = [s, p, o];
+    if !terms.contains(&new_triple) {
+        terms.push(new_triple);
+    }
+
+    let mut dict = Dict::new();
+    let ids: Vec<[sparq_core::dict::Id; 3]> = terms
+        .iter()
+        .map(|t| [dict.intern(&t[0]), dict.intern(&t[1]), dict.intern(&t[2])])
+        .collect();
+    let auth = Graph::from_parts(dict, ids);
+
+    if let Some(slot) = graph.named.iter_mut().find(|(n, _)| *n == auth_name) {
+        slot.1 = auth;
+    } else {
+        graph.named.push((auth_name, auth));
+    }
+}

--- a/crates/sparq-solid/tests/odrl_bridge.rs
+++ b/crates/sparq-solid/tests/odrl_bridge.rs
@@ -1,0 +1,270 @@
+//! [OPUS-4.8] sq-h3uk — the ODRL→AUTH_GRAPH bridge: a definite ODRL Permit
+//! materializes the equivalent WAC/ACP grant into `<urn:sparq:auth>` so the EXISTING
+//! graph-level enforcement honours it; a Deny / ambiguous / unmapped eval
+//! materializes NOTHING (fail-closed); the action→mode mapping is correct; and a
+//! round-trip through the real enforcement path (`PodStore::accessible` /
+//! `query_as`) grants exactly the intended access.
+//!
+//! Gated by the `odrl-bridge` feature (the whole test file no-ops without it).
+#![cfg(feature = "odrl-bridge")]
+
+use sparq_core::Graph;
+use sparq_policy::{parse_policy_str, Request, Value};
+use sparq_solid::{action_to_mode, materialize_permission, Mode, PodStore, Session};
+
+const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
+const ALICE: &str = "https://alice.ex/card#me";
+const N1: &str = "https://pod.ex/notes/n1";
+
+fn odrl(local: &str) -> String {
+    format!("{ODRL}{local}")
+}
+
+/// A pod with one content graph + no static ACL (so the only grants are bridged ones).
+fn pod() -> Graph {
+    Graph::load_dataset(
+        "<https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> \"hello\" <https://pod.ex/notes/n1> .",
+        "nquads",
+    )
+    .expect("pod loads")
+}
+
+/// alice MAY read n1 (a bare matching permission, no constraints).
+fn read_policy() -> sparq_policy::Policy {
+    parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/read> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ] .
+"#,
+        "turtle",
+    )
+    .expect("policy parses")
+}
+
+// ---------------------------------------------------------------------------
+// 1. action → mode mapping correctness.
+// ---------------------------------------------------------------------------
+#[test]
+fn action_mode_mapping() {
+    assert_eq!(action_to_mode(&odrl("read")), Some(Mode::Read));
+    assert_eq!(action_to_mode(&odrl("display")), Some(Mode::Read));
+    assert_eq!(action_to_mode(&odrl("present")), Some(Mode::Read));
+    assert_eq!(action_to_mode(&odrl("print")), Some(Mode::Read));
+    assert_eq!(action_to_mode(&odrl("play")), Some(Mode::Read));
+    assert_eq!(action_to_mode(&odrl("append")), Some(Mode::Append));
+    assert_eq!(action_to_mode(&odrl("modify")), Some(Mode::Write));
+    assert_eq!(action_to_mode(&odrl("delete")), Some(Mode::Write));
+    assert_eq!(action_to_mode(&odrl("write")), Some(Mode::Write));
+    // fail-closed: the umbrella + unknown + non-odrl actions are unmapped.
+    assert_eq!(action_to_mode(&odrl("use")), None);
+    assert_eq!(action_to_mode(&odrl("aggregate")), None);
+    assert_eq!(action_to_mode("https://example.org/custom"), None);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Permit → materializes the expected grant triple in AUTH_GRAPH.
+// ---------------------------------------------------------------------------
+#[test]
+fn permit_materializes_grant_triple() {
+    let mut g = pod();
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    let out = materialize_permission(&mut g, &read_policy(), &req);
+
+    assert!(out.granted, "definite Permit should grant: {out:?}");
+    assert_eq!(out.mode, Some(Mode::Read));
+    assert_eq!(
+        out.grant_triple,
+        Some((ALICE.to_owned(), "https://sparq.dev/ns/auth#read".to_owned(), N1.to_owned())),
+    );
+
+    // The grant is a real triple in the <urn:sparq:auth> view, readable as such.
+    let q = "SELECT ?who WHERE { GRAPH <urn:sparq:auth> { \
+        ?who <https://sparq.dev/ns/auth#read> <https://pod.ex/notes/n1> } }";
+    let rows = sparq_engine::query(&g, q).expect("query");
+    assert_eq!(rows.rows.len(), 1, "exactly alice's read grant");
+}
+
+// ---------------------------------------------------------------------------
+// 3. Round-trip through the REAL enforcement path (PodStore::accessible / query_as).
+//    The bridged grant grants exactly the intended access, nothing more.
+// ---------------------------------------------------------------------------
+#[test]
+fn round_trip_through_enforcement() {
+    let mut store = PodStore::new(pod());
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    let out = store.materialize_odrl_permission(&read_policy(), &req);
+    assert!(out.granted);
+
+    let alice = Session { agent: Some(ALICE), client: None };
+    // alice can READ n1 via the materialized grant…
+    assert!(store.accessible(&alice, Mode::Read).iter().any(|gph| gph.as_str() == N1));
+    // …but NOT write (the bridge only materialized a read grant — fail-closed)…
+    assert!(store.accessible(&alice, Mode::Write).is_empty());
+
+    // …and a DIFFERENT agent gets nothing (the grant is scoped to alice's WebID).
+    let mallory = Session { agent: Some("https://mallory.ex/card#me"), client: None };
+    assert!(store.accessible(&mallory, Mode::Read).is_empty());
+    // anonymous likewise.
+    assert!(store.accessible(&Session::default(), Mode::Read).is_empty());
+
+    // End-to-end: alice's authorized query returns the content; others see nothing.
+    let sel = "SELECT ?t WHERE { ?s <https://ex.dev/ns#title> ?t }";
+    assert_eq!(store.query_as(&alice, Mode::Read, sel).unwrap().rows.len(), 1);
+    assert_eq!(store.query_as(&mallory, Mode::Read, sel).unwrap().rows.len(), 0);
+    assert_eq!(store.query_as(&Session::default(), Mode::Read, sel).unwrap().rows.len(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Deny → materializes NOTHING (fail-closed). Wrong party never matches.
+// ---------------------------------------------------------------------------
+#[test]
+fn deny_materializes_nothing() {
+    let mut store = PodStore::new(pod());
+    // Mallory is not the assignee → no permission matches → DENY.
+    let req = Request::new(odrl("read")).on(N1).by("https://mallory.ex/card#me");
+    let out = store.materialize_odrl_permission(&read_policy(), &req);
+    assert!(!out.granted, "deny must not grant: {out:?}");
+    assert!(out.grant_triple.is_none());
+
+    // Nobody gains access — the auth view holds no bridged grant.
+    let mallory = Session { agent: Some("https://mallory.ex/card#me"), client: None };
+    assert!(store.accessible(&mallory, Mode::Read).is_empty());
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert!(store.accessible(&alice, Mode::Read).is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// 5. Ambiguous / unsatisfied-constraint eval → NOTHING (fail-closed).
+//    A time-windowed permission with NO dateTime context fails the constraint.
+// ---------------------------------------------------------------------------
+#[test]
+fn unsatisfied_constraint_materializes_nothing() {
+    let pol = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/win> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ;
+                      odrl:operator odrl:lteq ;
+                      odrl:rightOperand "2020-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ] ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+
+    let mut store = PodStore::new(pod());
+    // Out-of-window request (after the bound) → constraint unsatisfied → DENY → nothing.
+    let req = Request::new(odrl("read"))
+        .on(N1)
+        .by(ALICE)
+        .with(odrl("dateTime"), Value::DateTime("2026-06-16T00:00:00Z".to_owned()));
+    let out = store.materialize_odrl_permission(&pol, &req);
+    assert!(!out.granted, "out-of-window must not grant: {out:?}");
+    assert!(store.accessible(&Session { agent: Some(ALICE), client: None }, Mode::Read).is_empty());
+
+    // And the SAME policy with NO dateTime evidence also fails closed.
+    let mut store2 = PodStore::new(pod());
+    let req2 = Request::new(odrl("read")).on(N1).by(ALICE);
+    assert!(!store2.materialize_odrl_permission(&pol, &req2).granted);
+}
+
+// ---------------------------------------------------------------------------
+// 6. Unmapped action (the umbrella) → Permit but NO grant (fail-closed).
+//    `odrl:use` PERMITS a `use` request in the evaluator, yet `use` has no faithful
+//    single WAC mode, so the bridge must materialize nothing.
+// ---------------------------------------------------------------------------
+#[test]
+fn unmapped_action_materializes_nothing() {
+    let pol = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/use> a odrl:Set ; odrl:permission [
+    odrl:action odrl:use ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+
+    let mut g = pod();
+    // The request action is `odrl:use` itself — a definite Permit, but unmapped.
+    let req = Request::new(odrl("use")).on(N1).by(ALICE);
+    let out = materialize_permission(&mut g, &pol, &req);
+    assert!(!out.granted, "umbrella action has no mode mapping: {out:?}");
+    assert!(out.grant_triple.is_none());
+    assert!(!out.reasons.is_empty());
+
+    // But a CONCRETE `read` request against the same `use` permission DOES grant
+    // (the evaluator's umbrella permits it; the bridge maps the concrete request).
+    let mut g2 = pod();
+    let req2 = Request::new(odrl("read")).on(N1).by(ALICE);
+    let out2 = materialize_permission(&mut g2, &pol, &req2);
+    assert!(out2.granted, "use permission + concrete read request grants: {out2:?}");
+    assert_eq!(out2.mode, Some(Mode::Read));
+}
+
+// ---------------------------------------------------------------------------
+// 7. Partyless / targetless Permit → NOTHING (a partyless grant would widen access).
+// ---------------------------------------------------------------------------
+#[test]
+fn partyless_or_targetless_materializes_nothing() {
+    // An unrefined permission (no assignee, no target) matches an anonymous request
+    // — but a grant with no concrete principal would widen access to everyone.
+    let pol = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/any> a odrl:Set ; odrl:permission [ odrl:action odrl:read ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+
+    // No party.
+    let mut g = pod();
+    let no_party = Request::new(odrl("read")).on(N1);
+    assert!(!materialize_permission(&mut g, &pol, &no_party).granted);
+
+    // Party but no target.
+    let mut g2 = pod();
+    let no_target = Request::new(odrl("read")).by(ALICE);
+    assert!(!materialize_permission(&mut g2, &pol, &no_target).granted);
+}
+
+// ---------------------------------------------------------------------------
+// 8. The bridge APPENDS to an existing WAC view without clobbering static grants.
+// ---------------------------------------------------------------------------
+#[test]
+fn bridge_preserves_existing_wac_grants() {
+    // A pod whose static .acl grants BOB read on n1.
+    let nq = r#"
+<https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> "hello" <https://pod.ex/notes/n1> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.ex/notes/n1> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#agent> <https://bob.ex/card#me> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/notes/n1.acl> .
+"#;
+    let mut store = PodStore::new(Graph::load_dataset(nq, "nquads").unwrap());
+    store.materialize_wac().expect("wac materializes");
+
+    // Does `agent` have read on n1 through the store's current enforcement view?
+    fn reads_n1(s: &mut PodStore, agent: &str) -> bool {
+        let sess = Session { agent: Some(agent), client: None };
+        s.accessible(&sess, Mode::Read).iter().any(|g| g.as_str() == N1)
+    }
+
+    assert!(reads_n1(&mut store, "https://bob.ex/card#me"), "bob's static grant");
+
+    // Now bridge an ODRL read grant for alice on the same graph.
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_permission(&read_policy(), &req).granted);
+
+    // BOTH grants hold: bob (static WAC) AND alice (bridged ODRL).
+    assert!(reads_n1(&mut store, "https://bob.ex/card#me"), "bob preserved");
+    assert!(reads_n1(&mut store, ALICE), "alice bridged");
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -94,6 +94,12 @@ Materialize the authorization view from the access-control documents, then enfor
   `store.accessible_set(...)` / `store.view_for(...) -> DatasetView` /
   `store.auth() -> &AuthIndex` — inspect the authorized graph set or the materialized
   index directly.
+- `store.materialize_odrl_permission(&Policy, &Request) -> BridgeOutcome` — **opt-in**
+  (`odrl-bridge` feature, OFF by default; [OPUS-4.8] sq-h3uk): run the `sparq-policy` ODRL
+  evaluator and, on a *definite Permit*, materialize the equivalent `principal auth:<mode>
+  graph` grant into the auth view, then reindex — so this same enforcement path applies it.
+  Fail-closed (Deny / unmapped action / partyless / targetless → no grant). See the
+  [`usage-control-policy`](../usage-control-policy/SKILL.md) skill for the action→mode mapping.
 - `Session { agent: Option<&str>, client: Option<&str> }` (caller-asserted WebID +
   `acl:origin`/`acp:client`; `None` = anonymous / any client); `Mode::{Read, Write,
   Append, Control}`; `wac_fixture()` / `acp_fixture()` (bundled demo pods).

--- a/skills/usage-control-policy/SKILL.md
+++ b/skills/usage-control-policy/SKILL.md
@@ -76,6 +76,27 @@ assert_eq!(d.matched_rules.len(), 1);  // the granting permission, for audit
 
 `Request::new(action_iri)` then chain `.on(target)`, `.by(party)`, `.with(left_operand_iri, Value)` for each context dimension (`dateTime`, `purpose`, `recipient`, `count`, `spatial`, …), and `.discharge(duty_action_iri)` per discharged duty. `Value` is `Iri` | `Str` | `Num(f64)` | `DateTime(String)`.
 
+## Bridge to WAC/ACP enforcement (opt-in `odrl-bridge`) — [OPUS-4.8] sq-h3uk
+
+`sparq-solid` can **materialize** a matched ODRL permission into its `<urn:sparq:auth>` AUTH_GRAPH so the existing graph-level WAC/ACP enforcement applies it — **no new enforcement engine**. Behind the off-by-default `odrl-bridge` cargo feature on `sparq-solid` (it pulls in `sparq-policy` only when enabled; the default solid build stays ODRL-free). This is the **single-node** bridge of epic sq-3183, **research-track**, NOT the (gated) federated/ZK-disclosure path.
+
+```rust,ignore
+// cargo: sparq-solid with --features odrl-bridge
+use sparq_solid::{PodStore, Session, Mode};
+use sparq_policy::Request;
+let req = Request::new("http://www.w3.org/ns/odrl/2/read")
+    .on("https://pod.ex/notes/n1").by("https://alice.ex/card#me");
+// On a definite Permit, appends `alice auth:read n1` to the auth view, then reindexes.
+let out = store.materialize_odrl_permission(&policy, &req);
+assert!(out.granted);
+// …now honoured by the unchanged enforcement path:
+assert!(!store.accessible(&Session { agent: Some("https://alice.ex/card#me"), client: None }, Mode::Read).is_empty());
+```
+
+**Action → mode** (the ODRL *request* action; conservative — narrowest mode only): `read`/`display`/`present`/`print`/`play` → `acl:Read`; `append` → `acl:Append`; `modify`/`delete`/`write` → `acl:Write`; **anything else (incl. the `odrl:use` umbrella) is unmapped → no grant**. `use` is left unmapped because it subsumes every action (mapping it would have to pick the widest mode) — request `odrl:read` explicitly; a `use` permission still grants that concrete request.
+
+**Fail-closed:** a grant is materialized only on a *definite Permit* AND a *mappable action* AND a *concrete party (WebID) + target graph*. A Deny, unsatisfied constraint, undischarged duty, unmapped action, or partyless/targetless request materializes **nothing**.
+
 ## Learn more
 
 - Crate README: [`crates/sparq-policy/README.md`](../../crates/sparq-policy/README.md)


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-h3uk** (from sq-r06h / #261; epic **sq-3183**): bridge the `sparq-policy` ODRL evaluator into `sparq-solid` by **materializing** matched ODRL permissions into the `<urn:sparq:auth>` AUTH_GRAPH, so the existing graph-level WAC/ACP enforcement applies them — **no new enforcement engine**.

## What it does

On a **definite Permit**, `materialize_permission(&mut Graph, &Policy, &Request)` / `PodStore::materialize_odrl_permission(&Policy, &Request)` runs `sparq_policy::evaluate` and writes the equivalent `principal auth:<mode> graph` triple — the exact shape `AuthIndex` / `PodStore::accessible` already consume — **appended** into the auth view (preserving any static WAC/ACP grants already there). The `PodStore` entry point reindexes so the grant takes effect on the next query.

### Action → mode mapping

The ODRL **request** action IRI is mapped (conservative — a Permit only ever grants the *narrowest* mode the action denotes):

| ODRL action (`odrl:`)                         | WAC/ACP mode            |
|-----------------------------------------------|-------------------------|
| `read`, `display`, `present`, `print`, `play` | `acl:Read`              |
| `append`                                      | `acl:Append`            |
| `modify`, `delete`, `write`                   | `acl:Write`             |
| anything else (incl. the `odrl:use` umbrella) | **unmapped → no grant** |

`odrl:use` is deliberately unmapped: it subsumes every action, so mapping it to one WAC mode would have to pick the widest (violating fail-closed). Request `odrl:read` explicitly — a `use` permission still grants that concrete request, and the bridge maps the concrete request.

### Fail-closed semantics

A grant is materialized **only** on a definite Permit **and** a mappable action **and** a concrete party (WebID) + target graph IRI. A Deny, an unsatisfied constraint, an undischarged duty, an unmapped action, or a partyless/targetless request materializes **nothing** — access is never widened on ambiguity.

## Opt-in / research-track

Behind the off-by-default **`odrl-bridge`** cargo feature on `sparq-solid`, which pulls in `sparq-policy` as an **optional** dependency only when enabled. The default `sparq-solid` build carries zero ODRL code/deps; `sparq-core`/`sparq-engine` untouched. This is the **single-node** bridge of epic sq-3183 — **research-track, NOT a production cutover**, and NOT the (gated) federated/ZK-disclosure path.

## Gates (all pass, features OFF and ON)

- `cargo build` clean OFF + ON
- `cargo test -p sparq-solid` green OFF + ON (8 new integration tests + doctests)
- `cargo clippy --all-targets -- -D warnings` clean OFF + ON
- touched files hand-formatted (≤100 col, matching the crate style)

Tests prove: Permit materializes the expected grant triple; round-trip through the **real** enforcement path (`PodStore::accessible` / `query_as`) grants exactly the intended access and nothing more (other agents / anonymous / write-mode all fail-closed); Deny / unsatisfied-constraint / unmapped-action / partyless / targetless materialize nothing; action→mode mapping correctness; the bridge appends to an existing WAC view without clobbering static grants.

Docs updated per the public-API → SKILL rule: crate README + `usage-control-policy` & `access-control` SKILL.md.

NON-CANONICAL timing (work-box EC2) — no measured timings recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
