### PR TITLE
feat(sparq-engine): filtered-ANN BGP->IdMask wiring for vec: predicate (sq-bvmd)

### DIFF
--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -34,8 +34,8 @@ default = []
 # in NEITHER the engine NOR any heavy crate, so the default `sparq-vectors` build (and the core
 # query path) carry zero filtered-ANN code. The feature gates `filter.rs` (the `IdMask` +
 # `FilterConfig` + exact pre-filter) and the `DiskAnnIndex::nearest_filtered*` traversal path. The
-# engine-side BGP → mask wiring is a separate, deferred bead (see sq-1wc1); this feature is the core
-# sparq-vectors filtered API.
+# engine-side automatic BGP → mask wiring (a filtered form of the `vec:` predicate) is wired in
+# `rewrite.rs` and activates when this composes with `vec-predicate` (sq-bvmd, follow-up to sq-1wc1).
 filtered-ann = []
 # [OPUS-4.8] sq-k6ex (epic sq-3183): the `vec:` magic predicates — vector KNN
 # search expressed INSIDE plain SPARQL, mirroring sparq-text's `text:` rewrite.

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -59,6 +59,16 @@ let _neighbours = index.nearest_term(&some_term, &graph, &store, 10);
   byte-identical output to the in-RAM builder.
 - **Search** — `nearest_exact` (ground-truth baseline), in-RAM HNSW (`VectorIndex`), and the
   persistent on-disk `DiskAnnIndex` (`.spqg`, build once / open with no rebuild).
+- **Predicate-constrained (filtered) ANN (opt-in `filtered-ann`)** — restrict the search to the
+  graph nodes a SPARQL BGP admits: build an `IdMask` from the BGP-selected dict-ids and call
+  `nearest_exact_filtered` / `DiskAnnIndex::nearest_filtered`. Lean feature (no new dependency, no
+  engine pull). Every returned id is in the mask; empty mask → no results; full mask → the
+  unfiltered search.
+- **k-NN inside SPARQL (opt-in `vec-predicate`)** — the `vec:nearest` / `vec:search` magic
+  predicates run vector k-NN in plain SPARQL via a spargebra-algebra rewrite (the engine is
+  unchanged). Composed with `filtered-ann`, a `vec:` neighbour variable that is **also constrained
+  by ordinary BGP patterns** is searched as a *filtered* ANN automatically — the surrounding BGP
+  derives the candidate `IdMask`, so the filtered top-k equals post-filtering the unfiltered top-k.
 - **Verbalization** — `verbalize` / `embed_entities` render `<label>. a <type>. <description>`
   per entity (multilingual, char-budgeted); `embed_labels` is the label-only special case.
 - **Quantization** — `ScalarQuantizer` (4×) and `ProductQuantizer` (asymmetric distance) for

--- a/crates/sparq-vectors/src/rewrite.rs
+++ b/crates/sparq-vectors/src/rewrite.rs
@@ -90,6 +90,17 @@ use sparq_core::dict::Id;
 use sparq_core::Graph;
 use sparq_engine::{PreparedQuery, QueryBudget, QueryResult};
 
+// [OPUS-4.8] (sq-bvmd, epic sq-3183) Filtered-ANN BGP→IdMask wiring: when a `vec:`
+// request shares its neighbour variable with ordinary patterns in the SAME BGP, those
+// patterns carve out the eligible graph nodes (the candidate id-set), and the k-NN
+// search is restricted to that set — correct (and, for a selective constraint, faster)
+// than post-filtering the unfiltered neighbours. This needs the `filtered-ann` API
+// (`IdMask` + `nearest_exact_filtered`), so the whole derive-and-filter path is
+// additionally gated on `filtered-ann`; with that feature off the `vec:` predicate
+// behaves EXACTLY as before (plain unfiltered `nearest_exact`).
+#[cfg(feature = "filtered-ann")]
+use crate::filter::{nearest_exact_filtered, IdMask};
+
 /// `rdf:first`, `rdf:rest`, `rdf:nil` — the collection vocabulary spargebra
 /// lowers `( … )` argument lists into.
 const RDF_FIRST: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#first";
@@ -260,9 +271,19 @@ fn rewrite_bgp(
         return Ok(GraphPattern::Bgp { patterns: rest });
     }
 
+    // [OPUS-4.8] (sq-bvmd) The ordinary patterns that survive this BGP are also the
+    // patterns that *constrain* each `vec:` neighbour variable: the subjects they admit
+    // are the candidate id-set for a filtered ANN search. Derive that set from `rest`
+    // BEFORE it is moved into the output (the borrow ends with `mask_constraint`).
+    #[cfg(feature = "filtered-ann")]
+    let mask_constraint = rest.clone();
+
     // Join the hit tables onto the remaining ordinary patterns.
     let mut out = GraphPattern::Bgp { patterns: rest };
     for req in reqs {
+        #[cfg(feature = "filtered-ann")]
+        let hits = run_knn(&req, graph, store, &mask_constraint)?;
+        #[cfg(not(feature = "filtered-ann"))]
         let hits = run_knn(&req, graph, store)?;
         let mut variables = vec![req.node];
         if let Some(s) = &req.score {
@@ -488,7 +509,24 @@ fn term_to_ground(t: Term) -> Option<GroundTerm> {
 
 /// Runs the k-NN search for `req` and returns `(neighbour id, cosine score)`
 /// pairs, best first.
-fn run_knn(req: &KnnReq, graph: &Graph, store: &VectorStore) -> Result<Vec<(Id, f32)>, String> {
+///
+/// [OPUS-4.8] (sq-bvmd) When the `filtered-ann` feature is on, `constraint` is the
+/// BGP's surviving ordinary patterns; if any of them constrain `req.node`, the search
+/// is restricted to the candidate id-set those patterns admit (filtered ANN) instead
+/// of scanning the whole store and joining afterwards. When no pattern constrains the
+/// neighbour variable — or with `filtered-ann` off — this is the plain unfiltered
+/// `nearest_exact` path, byte-identical to the pre-sq-bvmd behaviour.
+fn run_knn(
+    req: &KnnReq,
+    graph: &Graph,
+    store: &VectorStore,
+    #[cfg(feature = "filtered-ann")] constraint: &[TriplePattern],
+) -> Result<Vec<(Id, f32)>, String> {
+    // Derive the candidate id-set (IdMask) from the patterns that constrain `req.node`.
+    // `None` => no constraining pattern => fall through to the unfiltered path.
+    #[cfg(feature = "filtered-ann")]
+    let mask = derive_mask(&req.node, constraint, graph)?;
+
     match &req.query {
         QueryArg::Node(iri) => {
             let term = Term::NamedNode(iri.clone());
@@ -498,6 +536,17 @@ fn run_knn(req: &KnnReq, graph: &Graph, store: &VectorStore) -> Result<Vec<(Id, 
             let Some(query) = store.get(id) else {
                 return Ok(Vec::new());
             };
+            #[cfg(feature = "filtered-ann")]
+            if let Some(mask) = &mask {
+                // Filtered: search only BGP-admitted candidates. Over-fetch by one so
+                // dropping the seed (if it satisfies the constraint and so sits in the
+                // mask) still leaves up to k neighbours, matching the unfiltered form.
+                return Ok(nearest_exact_filtered(store, query, mask, req.k + 1)
+                    .into_iter()
+                    .filter(|&(n, _)| n != id)
+                    .take(req.k)
+                    .collect());
+            }
             // Over-fetch by one and drop the seed itself.
             Ok(nearest_exact(store, query, req.k + 1)
                 .into_iter()
@@ -513,7 +562,75 @@ fn run_knn(req: &KnnReq, graph: &Graph, store: &VectorStore) -> Result<Vec<(Id, 
                     store.dim()
                 ));
             }
+            #[cfg(feature = "filtered-ann")]
+            if let Some(mask) = &mask {
+                return Ok(nearest_exact_filtered(store, v, mask, req.k));
+            }
             Ok(nearest_exact(store, v, req.k))
         }
     }
+}
+
+/// [OPUS-4.8] (sq-bvmd) Builds the candidate [`IdMask`] for `node` from the surrounding
+/// BGP `constraint` patterns — the dictionary ids of every binding `node` takes when the
+/// constraining sub-BGP is evaluated against `graph`.
+///
+/// Only the patterns that actually mention `node` form the constraint (an unrelated
+/// pattern in the same BGP does not narrow the neighbour set — it would be joined as a
+/// cartesian product, which never *removes* a candidate). If `node` is unconstrained
+/// the function returns `Ok(None)` and the caller runs the plain unfiltered search,
+/// preserving the existing `vec:` semantics exactly.
+///
+/// The constraining sub-BGP is evaluated through the standard engine (the same seam the
+/// outer query uses), so FILTERs / shared join variables are honoured correctly: the
+/// mask is exactly the set the engine would bind to `node`, hence the filtered top-k is
+/// identical to post-filtering the unfiltered top-k by that same set (the correctness
+/// invariant — see tests/filtered_bgp.rs).
+#[cfg(feature = "filtered-ann")]
+fn derive_mask(
+    node: &Variable,
+    constraint: &[TriplePattern],
+    graph: &Graph,
+) -> Result<Option<IdMask>, String> {
+    // Keep only the patterns that mention `node`; the rest cannot narrow the candidate
+    // set (they would join as a cross product, never dropping a `node` binding).
+    let sub: Vec<TriplePattern> = constraint
+        .iter()
+        .filter(|tp| pattern_mentions(tp, node))
+        .cloned()
+        .collect();
+    if sub.is_empty() {
+        return Ok(None);
+    }
+
+    // SELECT ?node WHERE { <constraining sub-BGP> } — evaluate the constraint through the
+    // engine and collect the ids it binds to `node`.
+    let select = Query::Select {
+        dataset: None,
+        pattern: GraphPattern::Project {
+            inner: Box::new(GraphPattern::Bgp { patterns: sub }),
+            variables: vec![node.clone()],
+        },
+        base_iri: None,
+    };
+    let result = sparq_engine::query_prepared(graph, &PreparedQuery::from(select))?;
+
+    // Map each bound `node` term back to its dictionary id. A row whose `node` is unbound
+    // (impossible for a BGP-only projection, but cheap to guard) or whose term is not in
+    // the dictionary contributes nothing — it cannot match a stored vector anyway.
+    let mask: IdMask = result
+        .rows
+        .iter()
+        .filter_map(|row| row.first().and_then(|c| c.as_ref()))
+        .filter_map(|term| graph.id_of(term))
+        .collect();
+    Ok(Some(mask))
+}
+
+/// [OPUS-4.8] (sq-bvmd) Does `tp` mention `node` in any term position?
+#[cfg(feature = "filtered-ann")]
+fn pattern_mentions(tp: &TriplePattern, node: &Variable) -> bool {
+    let in_term = |t: &TermPattern| matches!(t, TermPattern::Variable(v) if v == node);
+    let in_named = matches!(&tp.predicate, NamedNodePattern::Variable(v) if v == node);
+    in_term(&tp.subject) || in_named || in_term(&tp.object)
 }

--- a/crates/sparq-vectors/tests/filtered_bgp.rs
+++ b/crates/sparq-vectors/tests/filtered_bgp.rs
@@ -1,0 +1,264 @@
+//! [OPUS-4.8] (sq-bvmd, epic sq-3183) End-to-end tests for the engine-side
+//! **filtered-ANN BGP→IdMask wiring** of the `vec:` magic predicate (follow-up to
+//! sq-1wc1/#242). When a `vec:` neighbour variable is also constrained by ordinary
+//! patterns in the same BGP, those patterns carve out a candidate id-set (the
+//! `IdMask`) and the k-NN search is restricted to it.
+//!
+//! Correctness invariant proven here:
+//! - the filtered top-k is **identical** to post-filtering the *unfiltered* top-k by
+//!   the same BGP constraint (filtered-search ≡ post-filter, the whole point — same
+//!   answer, derived without scanning the rest of the store);
+//! - the filtered result is therefore a **subset** of the unfiltered result;
+//! - an **unconstrained** neighbour variable falls back to the exact unfiltered path
+//!   (the pre-sq-bvmd behaviour, preserved).
+//!
+//! The path is gated on BOTH `vec-predicate` (the rewrite) and `filtered-ann` (the
+//! `IdMask` API), so the whole file only compiles with both on.
+#![cfg(all(feature = "vec-predicate", feature = "filtered-ann"))]
+
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+use sparq_vectors::{query_vec, QueryResult, VectorStore};
+
+fn tmp_path(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "sparq_vec_fbgp_{}_{}.spqv",
+        std::process::id(),
+        name
+    ));
+    p
+}
+
+/// Six entities on the unit circle, each tagged with a `:kind` so a BGP can carve out
+/// a candidate subset. The +x cluster (a, c) and the +y cluster (b, e) let a query
+/// pick a winner that is *excluded* by the constraint, exercising the filter.
+///
+/// kinds: a,b,c → :Car ; d,e,f → :Boat. Vectors:
+///   a (+x)        :Car
+///   c (near +x)   :Car
+///   b (+y)        :Car
+///   d (-x)        :Boat
+///   e (near +y)   :Boat
+///   f (near +x)   :Boat   <- closest non-a to a +x query, but a Boat
+fn fixture(name: &str) -> (Graph, VectorStore) {
+    let g = Graph::load_str(
+        r#"
+        <http://ex/a> <http://ex/kind> <http://ex/Car> .
+        <http://ex/b> <http://ex/kind> <http://ex/Car> .
+        <http://ex/c> <http://ex/kind> <http://ex/Car> .
+        <http://ex/d> <http://ex/kind> <http://ex/Boat> .
+        <http://ex/e> <http://ex/kind> <http://ex/Boat> .
+        <http://ex/f> <http://ex/kind> <http://ex/Boat> .
+        "#,
+        "ntriples",
+    )
+    .unwrap();
+    let id = |s: &str| {
+        g.id_of(&Term::NamedNode(NamedNode::new(s).unwrap()))
+            .unwrap()
+    };
+    let mut store = VectorStore::create(tmp_path(name), 2).unwrap();
+    store.put(id("http://ex/a"), &[1.0, 0.0]).unwrap(); // +x   Car
+    store.put(id("http://ex/b"), &[0.0, 1.0]).unwrap(); // +y   Car
+    store.put(id("http://ex/c"), &[0.9, 0.1]).unwrap(); // ~+x  Car
+    store.put(id("http://ex/d"), &[-1.0, 0.0]).unwrap(); // -x   Boat
+    store.put(id("http://ex/e"), &[0.2, 0.98]).unwrap(); // ~+y  Boat
+    store.put(id("http://ex/f"), &[0.95, 0.05]).unwrap(); // ~+x  Boat (closest to +x after a)
+    (g, store)
+}
+
+fn iris(r: &QueryResult, col: usize) -> Vec<String> {
+    r.rows
+        .iter()
+        .filter_map(|row| match &row[col] {
+            Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+const PFX: &str = "PREFIX vec: <http://sparq.dev/vec#> ";
+
+/// The candidate id-set (mask) derived from `?node a/:kind :Car` admits ONLY Cars, so a
+/// +x query that would otherwise pull the Boat `f` instead returns the next-best Car.
+/// Proves: the result contains only candidates that satisfy the rest of the BGP.
+#[test]
+fn mask_restricts_to_bgp_satisfying_candidates() {
+    let (g, store) = fixture("mask_restrict");
+    let r = query_vec(
+        &g,
+        &format!(
+            "{PFX} SELECT ?node WHERE {{
+               ?node vec:nearest ( \"1,0\" 3 ) .
+               ?node <http://ex/kind> <http://ex/Car> .
+             }}"
+        ),
+        &store,
+    )
+    .unwrap();
+    let mut got = iris(&r, 0);
+    got.sort();
+    // +x query, restricted to Cars {a,b,c}: top-3 are a, c, b (b is the only other Car).
+    // The Boat `f` (cosine ~0.999, beats b) must NOT appear — it fails the BGP.
+    assert_eq!(
+        got,
+        vec![
+            "http://ex/a".to_string(),
+            "http://ex/b".to_string(),
+            "http://ex/c".to_string()
+        ],
+        "filtered result must be only BGP-satisfying (Car) candidates: {r:?}"
+    );
+    assert!(
+        !got.contains(&"http://ex/f".to_string()),
+        "the closer Boat `f` must be filtered out by the :Car constraint: {r:?}"
+    );
+}
+
+/// Filtered top-k ≡ post-filtering the unfiltered top-k by the same constraint, AND the
+/// filtered result ⊆ unfiltered result. We compute both inside one process: the
+/// unfiltered neighbours (large k) intersected with the BGP-admitted set must equal the
+/// filtered neighbours.
+#[test]
+fn filtered_equals_postfilter_and_is_subset() {
+    let (g, store) = fixture("postfilter");
+
+    // Unfiltered: all 6 neighbours of a +x query, best-first.
+    let unfiltered = query_vec(
+        &g,
+        &format!("{PFX} SELECT ?node WHERE {{ ?node vec:nearest ( \"1,0\" 6 ) }}"),
+        &store,
+    )
+    .unwrap();
+    let unfiltered_order = iris(&unfiltered, 0);
+
+    // The BGP-admitted set (Cars), via a plain SPARQL query (no vec:).
+    let cars: std::collections::HashSet<String> = query_vec(
+        &g,
+        "SELECT ?node WHERE { ?node <http://ex/kind> <http://ex/Car> }",
+        &store,
+    )
+    .unwrap()
+    .rows
+    .iter()
+    .filter_map(|row| match &row[0] {
+        Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+        _ => None,
+    })
+    .collect();
+
+    // Post-filter: unfiltered order, keep only Cars, take top-2.
+    let k = 2;
+    let postfilter: Vec<String> = unfiltered_order
+        .iter()
+        .filter(|n| cars.contains(*n))
+        .take(k)
+        .cloned()
+        .collect();
+
+    // Filtered search: same query + the :Car constraint, k=2 (use vec:search +
+    // ORDER BY to get a deterministic best-first order to compare against).
+    let filtered = query_vec(
+        &g,
+        &format!(
+            "{PFX} SELECT ?node WHERE {{
+               ( ?node ?score ) vec:search ( \"1,0\" {k} ) .
+               ?node <http://ex/kind> <http://ex/Car> .
+             }} ORDER BY DESC(?score)"
+        ),
+        &store,
+    )
+    .unwrap();
+    let filtered_order = iris(&filtered, 0);
+
+    assert_eq!(
+        filtered_order, postfilter,
+        "filtered top-k must equal post-filtering the unfiltered top-k\nfiltered={filtered_order:?}\npostfilter={postfilter:?}"
+    );
+    // ⊆ unfiltered.
+    let unfiltered_set: std::collections::HashSet<&String> = unfiltered_order.iter().collect();
+    for n in &filtered_order {
+        assert!(
+            unfiltered_set.contains(n),
+            "filtered neighbour {n} not in the unfiltered result {unfiltered_order:?}"
+        );
+    }
+}
+
+/// No constraining pattern on the neighbour variable → fall back to the exact unfiltered
+/// search (pre-sq-bvmd behaviour). The closest Boat `f` is now allowed back in.
+#[test]
+fn unconstrained_falls_back_to_unfiltered() {
+    let (g, store) = fixture("fallback");
+    let r = query_vec(
+        &g,
+        // `?other` is constrained, but the NEIGHBOUR variable `?node` is not — so no
+        // mask is derived and the search is the plain unfiltered top-2.
+        &format!(
+            "{PFX} SELECT ?node WHERE {{
+               ?node vec:nearest ( \"1,0\" 2 ) .
+               ?other <http://ex/kind> <http://ex/Car> .
+             }}"
+        ),
+        &store,
+    )
+    .unwrap();
+    // Cross-product join keeps every (?node, ?other) pair, so each neighbour repeats per
+    // Car; dedup the neighbour column.
+    let mut got: Vec<String> = iris(&r, 0);
+    got.sort();
+    got.dedup();
+    // Unfiltered +x top-2 over ALL kinds: a (1.0) then f (~0.999) — a Boat that the
+    // constrained-path test excluded. Its presence proves the fallback path.
+    assert_eq!(
+        got,
+        vec!["http://ex/a".to_string(), "http://ex/f".to_string()],
+        "unconstrained ?node must use the unfiltered search (Boat f returns): {r:?}"
+    );
+}
+
+/// A constraint that admits NOTHING (no entity is a :Plane) yields no neighbours — the
+/// honest answer, distinct from "unfiltered".
+#[test]
+fn empty_constraint_yields_no_rows() {
+    let (g, store) = fixture("empty_mask");
+    let r = query_vec(
+        &g,
+        &format!(
+            "{PFX} SELECT ?node WHERE {{
+               ?node vec:nearest ( \"1,0\" 3 ) .
+               ?node <http://ex/kind> <http://ex/Plane> .
+             }}"
+        ),
+        &store,
+    )
+    .unwrap();
+    assert!(
+        r.is_empty(),
+        "an unsatisfiable constraint admits no candidates: {r:?}"
+    );
+}
+
+/// The seed (node-IRI) form, filtered: neighbours of `a` restricted to Cars exclude the
+/// seed itself AND the closer Boat `f`, leaving Car `c`.
+#[test]
+fn seed_form_filtered_excludes_self_and_non_candidates() {
+    let (g, store) = fixture("seed_filtered");
+    let r = query_vec(
+        &g,
+        &format!(
+            "{PFX} SELECT ?node WHERE {{
+               ?node vec:nearest ( <http://ex/a> 1 ) .
+               ?node <http://ex/kind> <http://ex/Car> .
+             }}"
+        ),
+        &store,
+    )
+    .unwrap();
+    assert_eq!(
+        iris(&r, 0),
+        vec!["http://ex/c".to_string()],
+        "neighbours of a, restricted to Cars, exclude self (a) and the Boat f → c: {r:?}"
+    );
+}

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -364,6 +364,33 @@ literal's dimension must match the store; any other `vec:` IRI is unknown. An ab
 seed IRI yields no rows. Search is the **exact** `nearest_exact` scan (deterministic, the HNSW/
 DiskANN approximate indexes are not yet wired into the predicate — recorded follow-up).
 
+**Automatic filtered ANN (compose with `filtered-ann`, sq-bvmd).** When **both**
+`vec-predicate` *and* `filtered-ann` are on, the rewrite derives the candidate id-set
+([`IdMask`], recipe 9) automatically: if the `vec:` neighbour variable is **also constrained by
+ordinary patterns in the same BGP**, those patterns carve out the eligible nodes and the k-NN is
+run as a **filtered** search (`nearest_exact_filtered`) over just that set — no separate API call.
+
+```rust
+// ?node is the neighbour AND is constrained to be a :Car: the search only ever
+// considers Cars (the IdMask), so a closer non-Car neighbour is never returned.
+let r = query_vec(&graph,
+    "PREFIX vec: <http://sparq.dev/vec#>
+     SELECT ?node WHERE {
+       ?node vec:nearest ( \"1,0\" 5 ) .
+       ?node <http://ex/kind> <http://ex/Car> .   # ← carves out the candidate id-set
+     }", &store)?;
+```
+
+The mask is exactly the set the engine binds to the neighbour variable when the constraining
+sub-BGP is evaluated, so the filtered top-k is **identical to post-filtering the unfiltered
+top-k** by that same constraint (and therefore a subset of the unfiltered result) — correct, and
+for a selective constraint it avoids scanning the rest of the store. If the neighbour variable is
+**unconstrained** the search falls back to the plain unfiltered `nearest_exact` (recipe 8's exact
+behaviour, unchanged). With `filtered-ann` **off**, the `vec:` predicate is always unfiltered —
+this composition adds nothing to the `vec-predicate`-only build. Deferred (own beads): multi-
+variable mask intersection (sq-3tjd), mask caching (sq-36ol), and a cost-model choice of
+filtered-vs-post-filter (sq-ic0n).
+
 ### 9. Predicate-constrained (filtered) ANN — only neighbours a BGP admits (opt-in, feature = `filtered-ann`)
 
 The RDF-native vector differentiator: a SPARQL BGP carves out the *eligible* graph nodes (e.g.
@@ -403,9 +430,11 @@ let hnsw = vidx.nearest_filtered(query, &mask, &store, 10);
 ```
 
 Tune the crossover / beam with `nearest_filtered_with(query, &mask, &store, k, FilterConfig { .. })`.
-The engine-side automatic BGP → mask wiring (a filtered form of the `vec:` predicate) is a recorded
-follow-up bead — for now you build the mask yourself, which keeps the filtered API a pure
-sparq-vectors surface with zero engine coupling.
+You build the mask yourself here, which keeps this filtered API a pure sparq-vectors surface with
+zero engine coupling. The engine-side **automatic** BGP → mask wiring — deriving the `IdMask` from
+the surrounding BGP and running a filtered `vec:` search — is wired in recipe 8 (sq-bvmd, when both
+`vec-predicate` and `filtered-ann` are on), and is built on exactly this `nearest_exact_filtered`
+seam.
 
 ## Gotchas / feature flags / prerequisites
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-bvmd** (epic sq-3183) — the engine-side **filtered-ANN BGP→IdMask wiring** for the `vec:` magic predicate. Follow-up to **sq-1wc1 / #242**, which added the core `sparq-vectors` filtered API (`IdMask`, `nearest_exact_filtered`, `DiskAnnIndex::nearest_filtered`) and explicitly deferred the engine-side automatic wiring to this bead.

## What it does

When a `vec:nearest` / `vec:search` neighbour variable is **also constrained by ordinary patterns in the same BGP** (e.g. `?node vec:nearest (…) . ?node :kind :Car`), those patterns carve out the eligible graph nodes. The rewrite now derives the candidate id-set (an `IdMask`) from them and runs a **filtered** ANN search over just that set — instead of scanning the whole store and joining/post-filtering afterwards.

## IdMask derivation (`crates/sparq-vectors/src/rewrite.rs`)

- `rewrite_bgp` hands the surviving ordinary patterns to `run_knn`.
- `derive_mask(node, constraint, graph)` keeps the patterns that mention the neighbour variable, evaluates `SELECT ?node WHERE { <constraining sub-BGP> }` through the engine's prepared-query seam, and collects the bound dict-ids into an `IdMask`.
- No constraining pattern → `None` → **unfiltered fallback** (plain `nearest_exact`, byte-identical to the pre-sq-bvmd path).
- `run_knn` calls `nearest_exact_filtered(store, query, &mask, k)` when a mask exists; the seed (node-IRI) form over-fetches `+1` and drops the seed exactly as the unfiltered form does.

## Correctness invariant

The mask is **exactly** what the engine binds to the neighbour variable for the constraining sub-BGP, so the **filtered top-k equals post-filtering the unfiltered top-k** by that same constraint — and therefore the filtered result is a **subset** of the unfiltered result. `tests/filtered_bgp.rs` proves:

- the mask restricts to only BGP-satisfying candidates (a closer non-`:Car` neighbour is excluded);
- **filtered == post-filter** AND **filtered ⊆ unfiltered** (computed in one process);
- an **unconstrained** neighbour variable falls back to the unfiltered search;
- an unsatisfiable constraint → no rows; the seed form excludes self + non-candidates.

## Opt-in gating

Gated on **BOTH** `vec-predicate` (the rewrite, from #222) **AND** `filtered-ann` (the `IdMask` API, from #242). With `filtered-ann` **off**, the `vec:` predicate behaves exactly as before. No new dependencies; `sparq-core` / `sparq-engine` untouched (dependency direction is `sparq-vectors → sparq-engine`, like `sparq-text`).

## Gates (all green)

- `cargo build` clean: features OFF, `vec-predicate` only, and both ON.
- `cargo clippy --all-targets -D warnings` clean: OFF, `vec-predicate` only, both ON.
- `cargo test -p sparq-vectors --features vec-predicate,filtered-ann` green — full suite incl. new `filtered_bgp` (5), existing `vec_predicate` (9), `filtered` (5), unit (42), doctests.
- `rustfmt --check` clean on touched files.
- `skills/vector-search/SKILL.md` + crate `README.md` updated per the public-API → SKILL rule (recipe 8 documents the automatic filtered path; the stale "deferred follow-up" notes are retired).

NON-CANONICAL timing (work-box EC2) — no measured timings in docs.

## Deferred (beads)

- multi-variable mask intersection — **sq-3tjd**
- mask caching across prepares — **sq-36ol**
- cost-model choice of filtered-vs-post-filter — **sq-ic0n**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
