### PR TITLE
docs: refresh stale MPC/ZK capability matrix to match main (sq-k4of)

### DIFF
--- a/research/mpc-sparql-capability-matrix.md
+++ b/research/mpc-sparql-capability-matrix.md
@@ -5,6 +5,22 @@
 **Status:** Deep-research design record (no implementation; doc-only). Author: Opus 4.8
 (Fable unavailable — flag for re-review). Date: 2026-06-15.
 
+> **[OPUS-4.8] Last reconciled against `main`: 2026-06-16** (bead **sq-k4of**, per the
+> docs-stay-current rule; reconciliation source
+> [`mpc-zkp-build-out-delta.md`](./mpc-zkp-build-out-delta.md), epic **sq-pwr**). The
+> 2026-06-15 draft of this matrix marked the MPC **degree-reduction keystone** and everything
+> behind it as OPEN; **that is now stale.** The keystone (`sq-dvuc`), secure comparison
+> (`sq-rrz4`), bounded property paths (`sq-py8h`), the end-to-end federated pipeline driver
+> (`sq-6y92`), and the ZK-soundness gate (epic `sq-1s2`, re-audited
+> [`zk-verifier-reaudit.md`](./zk-verifier-reaudit.md) — **SOUND as landed for the assumed
+> threat model**) have all **LANDED on `main`** and verified against source below. The
+> *genuinely* remaining frontier is unchanged and stays honestly gated: the collaborative-proof
+> / distributed-attestation join is a **DEFERRED, audit-gated spike** (`sq-bjl`), and the
+> external accredited-cryptographer audit (`sq-qhy4`, P0) remains **externally gated**. The new
+> delta beads `sq-f7bu` (M4-v1 verifier-side attestation gate assembly) and `sq-9hrn` (fresh
+> coZK soundness re-audit of the collaborative path) track the net-new frontier work. Inline
+> **[RECONCILED 2026-06-16]** markers flag each corrected cell below.
+
 **What this is.** The project owner's standing directive for the MPC track asks for *"the
 most performant ways of handling ALL queries at ALL configurations, the most
 privacy-preserving way, any other desirable MPC properties, and a deep understanding of
@@ -74,10 +90,15 @@ ground truth. Verified by reading the files:
 
 **Single most important correction:** the parent record names *"the entire oblivious
 shuffle+sort foundation is ABSENT"* as the highest-leverage gap. **The shuffle is now BUILT
-and sound; the sort network is BUILT.** What remains is the **secure comparator** that the
-sort and `MIN`/`MAX`/range-`FILTER` depend on — and that is blocked on **degree reduction
-(sq-dvuc, OPEN)**. The leverage point has moved one layer down: *multiplication chaining*
-is now the keystone, not shuffle/sort.
+and sound; the sort network is BUILT.** The 2026-06-15 draft then named the **secure
+comparator** + *multiplication chaining* (degree reduction) as the new keystone, *"blocked on
+degree reduction (sq-dvuc, OPEN)."* **[RECONCILED 2026-06-16] That keystone has LANDED:**
+`degree_reduce` (BGW reshare-and-recombine, `sq-dvuc` **CLOSED**), the secure comparator
+opening only the verdict bit (`compare.rs`, `sq-rrz4` **CLOSED**), and bounded property paths
+(`bounded_path.rs`, `sq-py8h` **CLOSED**) are all on `main`. The leverage point has therefore
+**moved past the arithmetic keystone entirely** — the remaining frontier is the
+collaborative-proof / distributed-attestation join (DEFERRED spike `sq-bjl`), not a missing
+in-crate primitive.
 
 ### 1.2 The benchmark harness — what is BUILT and what is still gated (corrected 2026-06-15)
 
@@ -129,15 +150,15 @@ configuration grid yet, not because no harness exists. The dominant real-world c
 cells on the loopback tier; the shaped LAN/WAN multiplier awaits the privileged/EC2 run.
 - **One protocol family only: Shamir/BGW, honest-majority,** `t = ⌊(n−1)/2⌋`
   (`shamir.rs`). No replicated 3PC, no SPDZ/MASCOT, no GMW, no garbled circuits, no FSS/DPF.
-- **No degree reduction (on `main`).** `mul_shares_raw` yields a degree-`2t` product and the
-  crate **only ever opens it once** (the equality test). Any multiplication *chain* — secure
-  comparison, products of match bits, conjunctive hidden-pattern joins, segmented
-  group-agg scans, AVG — is **unbuilt on `main`** (`shamir.rs:455–469`; bead **sq-dvuc OPEN**).
-  `degree_reduce` is **in-flight in PR #119, not yet merged**, so it is correctly absent from
-  the `main` tree at the time of writing — `mul_shares_raw` is still single-product here. This
-  is the load-bearing blocker for ~half the operator surface until #119 lands. *(This is the
-  one current-state claim from the earlier draft that was accurate — degree reduction genuinely
-  is not on `main` yet; only the transport/metrics/bench "do not exist" claims were wrong.)*
+- **[RECONCILED 2026-06-16] Degree reduction is LANDED on `main`.** The 2026-06-15 draft said
+  *"No degree reduction (on `main`) … `degree_reduce` is in-flight in PR #119, not yet merged."*
+  **PR #119 has merged: `ShamirDealer::degree_reduce(shares_2t) → shares_t` (BGW
+  reshare-and-recombine) is on `main` and tested** (`shamir.rs`, bead **sq-dvuc CLOSED**). It
+  fail-closes when `n < 2t+1` (over-determined-recombination precondition). Multiplication
+  *chains* — secure comparison, products of match bits, conjunctive hidden-pattern joins,
+  segmented group-agg scans, AVG — are therefore **unblocked at the primitive layer**;
+  malicious hardening of the reshare (IT-MACs / verifiable resharing) is future work behind the
+  same backend (`sq-km34.*`), not claimed by the semi-honest `degree_reduce` itself.
 - **The hidden equi-join is still all-pairs** `O(|L|·|R|)` `secure_equal` (`join.rs:411,
   443`). ORQ-style O(n log n) sort-merge is **OPEN** (bead **sq-ujz8**).
 - **No collaborative ZK proof; no in-circuit signature.** `proof.rs` is honest
@@ -172,9 +193,9 @@ classes, cheapest → most expensive in the secret-sharing model:
 | **P1 Single product** | one share-multiply + one open (no chaining) | 1 mult round + 1 open | BUILT (`mul_shares_raw` + `secure_equal`) |
 | **P2 Equality-to-zero** | P1 specialised (`d=a−b`, mask `d·r`, open) | 1 mult + 1 open | BUILT (`secure_equal`, `join.rs:411`) |
 | **P3 Oblivious shuffle** | re-randomise + permute by hidden permutation | O(n log n) swaps, O(log n) rounds (deployed) | **BUILT & sound** (`oblivious.rs`) |
-| **P4 Mult chaining** | degree reduction after each product (BGW/DN/ATLAS) | +1 round / mult depth | **OPEN (sq-dvuc)** — the keystone blocker |
-| **P5 Secure comparison** (`<`,`≤`,`>`) | bit-decomposition / edaBits / Rabbit / DGK — mult-depth >1 | O(log p) bit-ops or O(1)-round constant-round | **OPEN (sq-rrz4, blocked on sq-dvuc)** |
-| **P6 Oblivious sort** (secret key) | sort network + P5 comparator | O(n log²n) gates, O(log²n) rounds | substrate BUILT; comparator OPEN (needs P5) |
+| **P4 Mult chaining** | degree reduction after each product (BGW/DN/ATLAS) | +1 round / mult depth | **BUILT** (`degree_reduce`, `sq-dvuc` CLOSED) — semi-honest; malicious hardening `sq-km34.*` |
+| **P5 Secure comparison** (`<`,`≤`,`>`) | bit-decomposition / edaBits / Rabbit / DGK — mult-depth >1 | O(log p) bit-ops or O(1)-round constant-round | **BUILT** (`compare.rs` `secure_greater_than`/`secure_threshold`, opens only the verdict bit; `sq-rrz4` CLOSED) |
+| **P6 Oblivious sort** (secret key) | sort network + P5 comparator | O(n log²n) gates, O(log²n) rounds | network BUILT; **secure comparator now BUILT** (P5/`sq-rrz4`) — the wired secret-key sort path is the remaining integration step |
 | **P7 Oblivious data-dependent access** | DORAM (Duoram/Floram/3PDORAM) | O((κ+D) log N)/access | **OPEN** (not needed until data > RAM-in-MPC) |
 
 Now, per SPARQL 1.1 algebra node, the **minimum primitive class** it requires in the hidden
@@ -201,16 +222,20 @@ regime (this is the "what it fundamentally requires" the directive asks for):
 | **DISTINCT / dedup** | P6 | oblivious sort + adjacent-equality scan + oblivious compaction |
 | **ORDER BY** | P6 | oblivious sorting network (Batcher / bitonic / Waksman+key) |
 | **LIMIT / OFFSET / top-k** | P6 (partial) or P5 selection | after an oblivious sort, reveal a padded prefix; top-k = oblivious selection |
-| **Property paths** (`*`,`+`, arbitrary length) | **OPEN** (super-linear; structure leak) | transitive closure of a SECRET edge set; only BOUNDED length is tractable |
+| **Property paths** (`*`,`+`, arbitrary length) | **bounded length BUILT** (`bounded_path.rs`, `sq-py8h`, over disclosed global-IRI keys); unbounded over a SECRET edge set stays OPEN (super-linear; structure leak) | transitive closure of a SECRET edge set; only BOUNDED length is tractable, and that bounded slice has landed for the disclosed-key regime |
 | **SERVICE / federation** | P0–P2 (global-IRI key) | the headline: global IRI is a *public* cross-holder id → disclosed-key join is crypto-free; only hidden values enter circuit-PSI/P2 |
 | **Subquery (sub-SELECT)** | inherits inner | composes IFF inner result disclosed (recompute) or kept secret-shared (compose ORQ "with itself") |
 
 **The structural takeaway:** the SPARQL surface partitions into three cost zones —
 - **CHEAP (P0–P3, BUILT):** SUM/COUNT, single equality FILTER, inner equi-join (all-pairs),
   UNION (via shuffle), and — newly — anything reducible to oblivious shuffle.
-- **MEDIUM (P4–P6, mostly OPEN):** everything needing mult-chaining or a secure comparator —
-  range FILTER, MIN/MAX, GROUP BY, DISTINCT, ORDER BY, OPTIONAL/MINUS, multi-pattern BGP,
-  AVG-by-secret-count. **All blocked behind the single sq-dvuc degree-reduction keystone.**
+- **MEDIUM (P4–P6, keystone now BUILT):** everything needing mult-chaining or a secure
+  comparator — range FILTER, MIN/MAX, GROUP BY, DISTINCT, ORDER BY, OPTIONAL/MINUS,
+  multi-pattern BGP, AVG-by-secret-count. **[RECONCILED 2026-06-16] The sq-dvuc
+  degree-reduction keystone and the sq-rrz4 secure comparator have LANDED**, so these are no
+  longer blocked at the primitive layer — what remains per-operator is *integration* (wiring the
+  BUILT P4/P5/P6 primitives into each operator's secret-key path) plus the SOTA-cost sort-merge
+  join (`sq-ujz8`), tracked operator-by-operator below.
 - **OUT-OF-REACH (P7 / unbounded):** property paths of unbounded length over a secret graph,
   and data-dependent private indexing (DORAM) — bounded-length / scoped-fragment only.
 
@@ -282,7 +307,7 @@ leaks the boolean) or needs P5 to keep the sum itself secret (OPEN — see §4.2
 | SH, HM, **disclosed global-IRI key** | **BUILT, crypto-free** | hash-join `O(\|L\|+\|R\|)` in cleartext — sparq's genuine lead (global IRIs as cross-holder join keys) | `DisclosedKeyJoin` (`join.rs:119`) |
 | Mal, HM, N=3 | KNOWN | **ORQ 4-party Fantastic Four** sort-merge; relational SOTA | not built |
 | Mal, DM | KNOWN | malicious circuit-PSI (VOLE-PSI, malicious, single equi-join only — does NOT compose into multi-pattern BGP) | no backend |
-| any, multi-pattern BGP | **OPEN** | sort-merge composed per pattern (P6) needs the secure comparator + mult-chaining | blocked on sq-dvuc/sq-rrz4/sq-ujz8 |
+| any, multi-pattern BGP | **primitives BUILT; awaits sort-merge join** | sort-merge composed per pattern (P6) needs the secure comparator + mult-chaining | **[RECONCILED 2026-06-16]** the secure comparator (`sq-rrz4`) + mult-chaining (`sq-dvuc`) are CLOSED; the remaining dependency is the SOTA sort-merge join (`sq-ujz8`, OPEN) |
 
 **Cost note (N, network):** all-pairs join is the **cost center** at every config (the parent
 record's ORQ anchor: even SOTA O(n log n) joins are minutes-to-tens-of-minutes on LAN, ×1.2–6.9
@@ -301,60 +326,69 @@ shaped WAN slowdown awaits the netem/EC2 run (`netprofiles.rs::wan()` + sq-hoaj)
 | SH/Mal, HM, hidden | **KNOWN (substrate BUILT)** | oblivious **concat + pad + shuffle** (P3) so a row's source side is hidden — the shuffle is BUILT and sound | shuffle BUILT (`oblivious.rs`); the UNION wrapper (concat+pad) not wired |
 | disclosed | BUILT (crypto-free) | verifier recomputes union of disclosed multisets | parent convention #4 |
 
-### 4.2 The MEDIUM zone (mostly OPEN — all gated behind degree reduction sq-dvuc)
+### 4.2 The MEDIUM zone ([RECONCILED 2026-06-16] keystone LANDED — was "all gated behind degree reduction sq-dvuc")
+
+> **[RECONCILED 2026-06-16]** This whole zone was marked OPEN/"blocked behind sq-dvuc" in the
+> 2026-06-15 draft. The keystone has since landed: `degree_reduce` (`sq-dvuc`), the secure
+> comparator (`sq-rrz4`), and bounded property paths (`sq-py8h`) are CLOSED on `main`. The
+> per-cell "sparq" column below is updated: the **primitive** each operator needs now exists;
+> what remains for the still-not-fully-wired operators is operator-level *integration* of those
+> BUILT primitives (and the SOTA sort-merge join `sq-ujz8`), not a missing keystone.
 
 #### FILTER (<, ≤, >) — secure comparison
 | Config | Tier | Most performant known protocol | sparq |
 |---|---|---|---|
 | disclosed operands | **BUILT (crypto-free)** | verifier recomputes the comparison | `operator_descriptor(Comparison)` honestly reports "no in-crypto guarantee" (`shamir.rs:250`) |
-| SH/Mal, HM, hidden | **OPEN in sparq / KNOWN in literature** | **edaBits** (Crypto'20) for mixed arith/Boolean; **Rabbit** (eprint 2021/119) ~constant-round less-than; **DGK / bit-decomposition** for the classic O(log p)-bit route; constant-round (DGK-style) wins on **WAN**, bit-decomposition is fine on **LAN** | **not built — blocked on degree reduction (sq-dvuc)**; tracked as bead **sq-rrz4** |
+| SH, HM, hidden | **[RECONCILED 2026-06-16] BUILT** | **edaBits** (Crypto'20) for mixed arith/Boolean; **Rabbit** (eprint 2021/119) ~constant-round less-than; **DGK / bit-decomposition** for the classic O(log p)-bit route; constant-round (DGK-style) wins on **WAN**, bit-decomposition is fine on **LAN** | **BUILT** — `compare.rs::secure_greater_than`/`secure_threshold` (bit-decomposition over secret shares, consuming the landed `degree_reduce`), opening **only the verdict bit** (`open_verdict`); bead **sq-rrz4 CLOSED** |
+| Mal, HM, hidden | partial → KNOWN | same comparator with IT-MAC-checked opens | the comparator is BUILT semi-honest; malicious hardening rides the IT-MAC line (`sq-km34.*`, in flight) |
 
-**This is the single most-requested missing primitive:** the £100k verdict's `>` (if the sum
-is to stay secret), every range FILTER, MIN/MAX, GROUP BY's is-new-group bit, top-k. **The
-trade-off** is round-complexity: bit-decomposition is O(log p) rounds (bad on WAN), Rabbit/DGK
-are ~constant-round (WAN-friendly) but heavier per-round. sparq should target **edaBits** (it
-amortises the bit-Beaver generation and is the modern SOTA for mixed circuits over both HM and
-DM), once degree reduction (P4) lands.
+**[RECONCILED 2026-06-16] This was named "the single most-requested missing primitive"; it is
+now BUILT** — the £100k verdict's `>` can keep the sum secret (open only the boolean), and the
+comparator is available for every range FILTER, MIN/MAX, GROUP BY's is-new-group bit, top-k.
+**The trade-off** carried forward: bit-decomposition is O(log p) rounds (bad on WAN), Rabbit/DGK
+are ~constant-round (WAN-friendly) but heavier per-round; the landed path is bit-decomposition
+(LAN-first). A constant-round/edaBits WAN variant remains future work (`sq-38zk`).
 
 #### MIN / MAX
 | Config | Tier | Most performant | sparq |
 |---|---|---|---|
 | disclosed | BUILT (verifier) | recompute | convention #4 |
-| hidden | **OPEN** | comparison **tournament** (O(log n) rounds, n−1 comparisons) for a single extreme; or oblivious-**sort** then take the end (reuses the BUILT sort network once P5 exists) | needs P5 (sq-rrz4) → P4 (sq-dvuc) |
+| hidden | **primitives BUILT; operator integration remaining** | comparison **tournament** (O(log n) rounds, n−1 comparisons) for a single extreme; or oblivious-**sort** then take the end (reuses the BUILT sort network) | **[RECONCILED 2026-06-16]** P5 (`sq-rrz4`) and P4 (`sq-dvuc`) are CLOSED — the comparator the tournament/sort needs is BUILT; wiring the MIN/MAX operator over it is the remaining integration step |
 
 #### GROUP BY (hidden key) / GROUP_CONCAT / HAVING
 | Config | Tier | Most performant | sparq |
 |---|---|---|---|
 | disclosed key | **BUILT-able (verifier)** | recompute group-agg over disclosed keys | convention #4 (HAVING/GROUP-BY-over-hidden is *forbidden* in RQ1 by design) |
-| hidden key | **OPEN** | **ORQ**: oblivious sort-on-key (P6) + segmented prefix-sum gated by a secret is-new-group bit (P4 chain) — O(n log n) work, O(log n) rounds | sort substrate BUILT; the segmented scan + is-new-group bit need P4/P5 (sq-dvuc/sq-rrz4) |
+| hidden key | **primitives BUILT; operator integration remaining** | **ORQ**: oblivious sort-on-key (P6) + segmented prefix-sum gated by a secret is-new-group bit (P4 chain) — O(n log n) work, O(log n) rounds | **[RECONCILED 2026-06-16]** sort substrate BUILT and P4/P5 (`sq-dvuc`/`sq-rrz4`) CLOSED — the segmented scan + is-new-group bit now have their primitives; the GROUP-BY operator integration is the remaining step |
 
 #### DISTINCT / ORDER BY / LIMIT (top-k)
 | Config | Tier | Most performant | sparq |
 |---|---|---|---|
 | disclosed | **BUILT (verifier)** | recompute over disclosed multiset (no-proof-of-revealed-properties) | convention #4 — the fast default |
 | ORDER BY, **disclosed key, secret payload** | **BUILT** | Batcher sort network over secret-shared rows keyed by a **disclosed** sort key — already wired | `sort_with_keys` (`oblivious.rs:927`) |
-| ORDER BY / DISTINCT, **hidden key** | **OPEN** | oblivious sort with a **secure** comparator (Batcher / bitonic O(n log²n), or Waksman O(n log n) + key); DISTINCT = sort + adjacent-equality (P2) scan + oblivious compaction | sort network BUILT; secure comparator OPEN (sq-rrz4) |
-| LIMIT/top-k, hidden | **OPEN** | oblivious **selection** (partial sort) or sort + reveal padded prefix | needs P5/P6 |
+| ORDER BY / DISTINCT, **hidden key** | **primitives BUILT; operator integration remaining** | oblivious sort with a **secure** comparator (Batcher / bitonic O(n log²n), or Waksman O(n log n) + key); DISTINCT = sort + adjacent-equality (P2) scan + oblivious compaction | **[RECONCILED 2026-06-16]** sort network BUILT and the secure comparator (`sq-rrz4`) now CLOSED; wiring the secret-key sort/DISTINCT path is the remaining integration step |
+| LIMIT/top-k, hidden | **primitives BUILT; operator integration remaining** | oblivious **selection** (partial sort) or sort + reveal padded prefix | **[RECONCILED 2026-06-16]** P5/P6 primitives BUILT (`sq-rrz4` CLOSED); operator integration remaining |
 
 #### OPTIONAL (left-join) / MINUS (anti-join)
 | Config | Tier | Most performant | sparq |
 |---|---|---|---|
 | disclosed | BUILT (verifier) | recompute | convention #4 |
-| hidden | **OPEN** | **ORQ** outer/anti: same sort-merge, different gating bits + a per-left-row "had-any-match" OR-fold (P4) to drive NULL padding (OPTIONAL) / row retention (MINUS) | needs sort-merge join (sq-ujz8) + P4 (sq-dvuc) |
+| hidden | **P4 BUILT; awaits sort-merge join** | **ORQ** outer/anti: same sort-merge, different gating bits + a per-left-row "had-any-match" OR-fold (P4) to drive NULL padding (OPTIONAL) / row retention (MINUS) | **[RECONCILED 2026-06-16]** P4 (`sq-dvuc`) CLOSED; the OR-fold primitive exists. The remaining dependency is the SOTA sort-merge join (`sq-ujz8`, OPEN) it composes over |
 
 #### BIND / expression eval / arithmetic
 | Config | Tier | Most performant | sparq |
 |---|---|---|---|
 | `+`,`−`,`× const` on secrets | **BUILT** | linear (free) | `add_shares`/`scale`/`add_constant` |
 | `× var` (single) | **BUILT** | one product | `mul_shares_raw` |
-| `× var` (chained), `/`, comparisons | **OPEN** | degree reduction (P4) for products; secure division via Newton/Goldschmidt over shares (needs P4); comparisons P5 | sq-dvuc / sq-rrz4 |
+| `× var` (chained), comparisons | **[RECONCILED 2026-06-16] BUILT** | degree reduction (P4) for products; comparisons P5 | `degree_reduce` (`sq-dvuc` CLOSED) + `compare.rs` (`sq-rrz4` CLOSED) |
+| `/` (secure division) | **OPEN** | secure division via Newton/Goldschmidt over shares (composes the BUILT P4 mult-chain) | composable over the landed `degree_reduce`; the division operator itself not yet wired |
 | string ops, hashing, regex | **OPEN/KNOWN** | Boolean circuit via **GMW** (round-per-AND-depth) or **garbled/BMR** (constant-round, WAN winner) — the worst case for Shamir SS | wrong family for sparq's Shamir core; would need a Boolean backend |
 
 #### AVG
 | Config | Tier | Most performant | sparq |
 |---|---|---|---|
 | disclosed/public count | **near-BUILT** | secure SUM (free) ÷ public count (free scale by inverse) | SUM BUILT; division-by-public-constant is a free scale |
-| secret count | **OPEN** | secure division (P4/P5) | needs degree reduction |
+| secret count | **P4/P5 BUILT; division operator remaining** | secure division (P4/P5) | **[RECONCILED 2026-06-16]** degree reduction (`sq-dvuc`) CLOSED — the mult-chain the division composes over exists; the division operator itself is the remaining step |
 
 ### 4.3 The OUT-OF-REACH zone
 
@@ -362,6 +396,7 @@ DM), once degree reduction (P4) lands.
 | Config | Tier | Note |
 |---|---|---|
 | unbounded length, hidden graph | **OPEN / effectively IMPOSSIBLE at scale** | transitive closure of a SECRET edge set leaks structure (each fixpoint iteration reveals reachability growth) and is super-linear; GORAM does ego-centric traversal but is *confidentiality-only*, not correct/attested. **Scope to BOUNDED length only** (unroll to a fixed hop count), where it reduces to a fixed BGP chain (P4+P6). |
+| **bounded length, disclosed global-IRI keys** | **[RECONCILED 2026-06-16] BUILT** | The tractable bounded slice has landed for the crypto-free disclosed-key regime — `bounded_path.rs` (`sq-py8h` CLOSED) unrolls to a fixed hop count over disclosed global IRIs. The bounded-length-over-*secret*-edges variant (P4+P6 BGP chain) remains the integration follow-on. |
 
 #### Data-dependent private indexing (any operator over a store larger than RAM-in-MPC)
 | Config | Tier | Note |
@@ -386,7 +421,10 @@ The directive asks the cost of hardening each operator. Per primitive:
 | P6 sort | inherits comparator + checked opens | inherits |
 
 **Headline:** at **honest majority**, malicious security is **close to free** (Goyal–Song /
-Goyal–Song–Liu) for the arithmetic operators *once the primitives exist*; the cost is in the
+Goyal–Song–Liu) for the arithmetic operators *once the primitives exist* — and
+**[RECONCILED 2026-06-16] those primitives (P4 `degree_reduce`/P5 comparator) now exist**, so
+this lift is now realisable rather than hypothetical; the IT-MAC machinery that delivers it is
+in flight (`authenticated.rs`, `sq-km34.1` CLOSED + `sq-km34.2–.9` OPEN). The cost is in the
 checked-open machinery (BUILT for degree-`t`/`2t`-with-redundancy) plus an IT-MAC for the one
 no-redundancy cell. At **dishonest majority** there is NO free lunch: every malicious cell
 pays the SPDZ preprocessing tax (Beaver triples + MACs), and — critically — **no published
@@ -496,26 +534,41 @@ sq-a6p1/sq-jnkm state:
 - SUM/COUNT aggregate — **privacy-optimal, cheap, malicious-detect at over-provisioned N.**
 - FILTER `=`/`≠` (single equality) — **BUILT** (semi-honest; malicious-detect except the
   minimal-N degree-2t hole that needs an IT-MAC).
+- **[RECONCILED 2026-06-16] FILTER `<`/`≤`/`>` (secure comparison)** — **BUILT** (`compare.rs`,
+  `sq-rrz4`, opens only the verdict bit; semi-honest), so the £100k `>` can keep the sum secret.
 - Inner equi-join over **disclosed global-IRI keys** — **BUILT, crypto-free** (sparq's lead).
 - Inner equi-join over **hidden keys** — **BUILT but naive** all-pairs `O(|L|·|R|)` (correct;
   not SOTA cost; leaks the match graph L2).
 - ORDER BY over **disclosed sort key** with secret payload — **BUILT** (Batcher network).
+- **[RECONCILED 2026-06-16] Bounded property paths over disclosed global-IRI keys** — **BUILT**
+  (`bounded_path.rs`, `sq-py8h`).
 - Oblivious **shuffle** (and therefore the substrate for UNION, result-size protection,
   match-bit aggregation) — **BUILT and sound.**
+- **[RECONCILED 2026-06-16] Degree reduction (P4 mult-chaining) + secure comparator (P5)** —
+  **BUILT** (`degree_reduce`/`compare.rs`, `sq-dvuc`/`sq-rrz4`), unblocking the medium zone at
+  the primitive layer.
+- **[RECONCILED 2026-06-16] End-to-end federated pipeline driver** (holder → share → join →
+  secure-threshold → ProofStatement, the four-flatmates scenario) — **BUILT** (`pipeline.rs`,
+  `sq-6y92`).
 - The disclosed regime for DISTINCT/ORDER BY/LIMIT/COUNT/SUM/AVG/MIN/MAX/joins/UNION/OPTIONAL
   (verifier recomputes outside the crypto) — **the fast default** (convention #4).
 
-**ASPIRATIONAL (KNOWN protocols exist; NOT in sparq; the medium zone, all behind sq-dvuc):**
-- Range FILTER, MIN/MAX, GROUP BY (hidden key), DISTINCT/ORDER BY (hidden key),
-  OPTIONAL/MINUS (hidden), AVG-by-secret-count, multi-pattern BGP, top-k — every one needs
-  degree reduction (P4) and/or a secure comparator (P5). **None is research-novel; all are
-  standard once the keystone lands.**
-- O(n log n) sort-merge join (replace all-pairs) — KNOWN (ORQ), bead sq-ujz8.
-- DP result-size protection — KNOWN (ShrinkWrap), bead sq-shk5.
+**[RECONCILED 2026-06-16] INTEGRATION-REMAINING (primitives BUILT; per-operator secret-key
+wiring is the remaining engineering — was "ASPIRATIONAL, all behind sq-dvuc"):**
+- MIN/MAX, GROUP BY (hidden key), DISTINCT/ORDER BY (hidden key), AVG-by-secret-count,
+  secure division, multi-pattern BGP, top-k — the degree reduction (P4, `sq-dvuc`) and secure
+  comparator (P5, `sq-rrz4`) they need are **CLOSED**; what remains is wiring each operator's
+  secret-key path over the landed primitives. **None is research-novel.**
+- OPTIONAL/MINUS (hidden) and the SOTA O(n log n) sort-merge join (replace all-pairs) — KNOWN
+  (ORQ), bead `sq-ujz8` (the remaining structural dependency for these two).
+- DP result-size protection — KNOWN (ShrinkWrap), bead `sq-shk5`.
 
 **RESEARCH-NOVEL / OPEN (budget as risk, never "seconds"):**
-- In-circuit unlinkable attested-source membership ("the join nobody has built", sq-bwwl) —
-  two steps out, audit-gated.
+- In-circuit *unlinkable* attested-source membership over **secret-shared** data — the
+  collaborative-proof / distributed-attestation join ("the join nobody has built", DEFERRED
+  spike `sq-bjl`); two research steps out, audit-gated. *(Distinct from the **single-prover**
+  in-circuit hidden cross-credential join `sq-bwwl`, which has LANDED — PR #170, CLOSED — and is
+  part of the now-sound single-prover ZK estate, not this collaborative frontier.)*
 - Dishonest-majority-malicious correctness for *any* SPARQL operator — zero published instances.
 - The full composition (coZK ⊕ malicious DM MPC ⊕ oblivious BGP joins ⊕ attested inputs ⊕ WAN)
   — zero performance data points.
@@ -529,14 +582,21 @@ sq-a6p1/sq-jnkm state:
 ## 8. Gap analysis → sequenced roadmap (cross-referenced to beads)
 
 Ordered by leverage. Each gap names whether a bead already covers it.
+**[RECONCILED 2026-06-16] items 1, 2 (and the bounded-path slice of the §4.3 zone) have since
+LANDED on `main`** — see the per-item ✅ DONE notes.
 
 1. **Degree reduction (BGW/DN/ATLAS) — `degree_reduce(shares_2t) → shares_t`.** THE keystone:
    unblocks P4–P6 → range FILTER, MIN/MAX, GROUP BY, DISTINCT/ORDER-BY (hidden), OPTIONAL,
    AVG-secret-count, multi-pattern BGP, and the secure sort comparator — **~half the operator
-   surface in one primitive.** Bead **sq-dvuc (OPEN)** ✅ tracked.
+   surface in one primitive.** **[RECONCILED 2026-06-16] ✅ DONE — bead `sq-dvuc` CLOSED**
+   (`shamir.rs::degree_reduce`, semi-honest; malicious hardening rides `sq-km34.*`).
 2. **Secure comparison (edaBits / Rabbit) opening only the verdict bit.** The £100k `>` with a
-   secret sum, every range FILTER, the secure sort comparator. Blocked on (1). Bead **sq-rrz4
-   (OPEN)** ✅ tracked.
+   secret sum, every range FILTER, the secure sort comparator. **[RECONCILED 2026-06-16]
+   ✅ DONE — bead `sq-rrz4` CLOSED** (`compare.rs::secure_greater_than`/`secure_threshold`,
+   bit-decomposition; the WAN constant-round/edaBits variant is the carried-forward follow-on
+   `sq-38zk`). Bounded property paths (`bounded_path.rs`, **`sq-py8h` CLOSED**) and the
+   end-to-end federated pipeline driver (`pipeline.rs`, **`sq-6y92` CLOSED**) also landed in this
+   wave.
 3. **ORQ-style O(n log n) sort-merge join-aggregation** (replace all-pairs `HiddenValueJoin`;
    consume the BUILT shuffle; emit shuffled padded prefix → closes L1/L2 on the join path).
    Bead **sq-ujz8 (OPEN)** ✅ tracked. **NOT-yet-beaded sub-gap:** wiring the CLOSED sq-jnkm
@@ -546,8 +606,10 @@ Ordered by leverage. Each gap names whether a bead already covers it.
    set-returning query. Bead **sq-shk5 (OPEN)** ✅ tracked.
 5. **IT-MAC for the degree-2t equality open at minimal N=2t+1.** Promotes `secure_equal` from
    semi-honest-only to detect/abort at minimal N; also closes the coZK-2025/1026 confidentiality
-   interaction. Seam noted in **sq-6d6g (OPEN, P3)** as a *deferred-seam doc*, but the actual
-   IT-MAC *implementation* for the equality path is **not its own bead.** → **FILED below.**
+   interaction. **[RECONCILED 2026-06-16] Now beaded and IN FLIGHT:** the authenticated-sharing
+   foundation (`authenticated.rs`, **`sq-km34.1` CLOSED**) has landed; the remaining IT-MAC work
+   (MAC-carrying mult, batched MAC-check, malicious equality/comparison, registry wiring,
+   adversarial catch-tests, the bench AXIS-1 lift) is decomposed into **`sq-km34.2–.9` (OPEN)**.
 6. **Distributed randomness (PRSS / dealer-less VSS).** Replace the single-dealer simulation so
    masks/correlated randomness are jointly generated — prerequisite for any real federation and
    for P4/P5 correlated randomness. Bead **sq-yyro (OPEN)** ✅ tracked.
@@ -564,7 +626,9 @@ Ordered by leverage. Each gap names whether a bead already covers it.
    work genuinely not yet built is oblivious shuffle/sort OVER the transport — a noted
    sq-tg6b follow-up — and the scale-out itself, sq-hoaj.)*
 8. **Bounded-length property-path operator** (unroll to fixed hop count → fixed BGP chain).
-   The only tractable slice of property paths. **Not beaded.** → **FILED below.**
+   The only tractable slice of property paths. **[RECONCILED 2026-06-16] ✅ DONE — bead
+   `sq-py8h` CLOSED** (`bounded_path.rs`, over disclosed global-IRI keys; the
+   bounded-over-secret-edges BGP-chain variant is the integration follow-on).
 9. **WAN-tier protocol selection (constant-round comparison; BMR for Boolean/regex).** The
    round-per-depth family is wrong for WAN; needs a constant-round comparison and a Boolean
    backend for string ops. **Not beaded** (parent open-Q 2). → **FILED below.**
@@ -572,22 +636,41 @@ Ordered by leverage. Each gap names whether a bead already covers it.
     validation). **Not beaded.** → **FILED below.**
 11. **`BackendInfo.requires_preprocessing` cost field** so federations can budget the
     usually-hidden offline cost. **Not beaded** (small, but a real honesty gap). → **FILED below.**
-12. **In-circuit unlinkable attested-source join** ("the join nobody has built"). Bead
-    **sq-bwwl (OPEN)** ✅ tracked; gated on RQ1 remediation + a fresh coZK audit + the
-    single-prover in-circuit sig gadget.
+12. **In-circuit unlinkable attested-source join** ("the join nobody has built", over
+    **secret-shared** data — the *collaborative-proof* frontier). **[RECONCILED 2026-06-16]**
+    Held as the **DEFERRED spike `sq-bjl`** — RQ1 ZK-soundness gate (epic `sq-1s2`) is now
+    CLOSED + re-audited (`zk-verifier-reaudit.md`, SOUND as landed for the assumed threat model),
+    so the *build* prerequisite is satisfied; the production attestation claim is still
+    externally gated on the accredited-cryptographer audit (`sq-qhy4`, P0) and a fresh coZK
+    soundness re-audit of the **collaborative** path (`sq-9hrn`, the M-D delta bead). The
+    *single-prover* in-circuit hidden cross-credential join (`sq-bwwl`) has separately LANDED
+    (PR #170, CLOSED) — that is the single-prover estate, not this collaborative spike.
 
 Already-CLOSED (do not re-file): sq-18lk (shuffle/sort substrate), sq-mq8q (3-axis descriptor),
 sq-a6p1 (selection registry), sq-uu0u/sq-m34i/sq-7q9i (robust reconstruct), sq-jnkm (result-size
 protection standalone), sq-1vt (CSPRNG), **sq-sxm (tier-1 modelled counters + matrix runner —
 `metrics.rs`/`bench.rs`)**, **sq-tg6b (tier-2 loopback transport + tier-3 netem profiles —
-`transport.rs`/`netprofiles.rs`/`scripts/mpc-netem.sh`)**.
+`transport.rs`/`netprofiles.rs`/`scripts/mpc-netem.sh`)**,
+**[RECONCILED 2026-06-16] `sq-dvuc` (degree reduction — `shamir.rs::degree_reduce`)**,
+**`sq-rrz4` (secure comparison — `compare.rs`)**, **`sq-py8h` (bounded property paths —
+`bounded_path.rs`)**, **`sq-6y92` (end-to-end federated pipeline driver — `pipeline.rs`)**,
+**`sq-km34.1` (authenticated-sharing IT-MAC foundation — `authenticated.rs`)**, and the ZK
+side: epic **`sq-1s2`** (verifier-soundness remediation, 17/17, re-audited SOUND) +
+**`sq-bwwl`** (single-prover in-circuit hidden cross-credential join, PR #170).
 
-Beads filed by this record for the genuinely-open sub-gaps (verified against source 2026-06-15):
-sq-y32f (#3 wire sq-jnkm into the join), sq-km34 (#5 IT-MAC degree-2t at minimal N), sq-py8h
-(#8 bounded property paths), sq-38zk (#9 WAN constant-round comparison + Boolean backend),
-sq-aaop (#10 composition/UC record), sq-4i39 (#11 `BackendInfo.requires_preprocessing` field).
-The earlier sq-5gnv (#7 "build transport + instrumentation") was filed on a mistaken premise
-and has been **CLOSED as redundant** — that work already shipped (sq-sxm + sq-tg6b).
+Beads filed by the original 2026-06-15 record for the then-open sub-gaps:
+sq-y32f (#3 wire sq-jnkm into the join), sq-km34 (#5 IT-MAC — now decomposed `sq-km34.1` CLOSED
++ `sq-km34.2–.9` OPEN), sq-py8h (#8 bounded property paths — **now CLOSED**),
+sq-38zk (#9 WAN constant-round comparison + Boolean backend), sq-aaop (#10 composition/UC
+record), sq-4i39 (#11 `BackendInfo.requires_preprocessing` field). The earlier sq-5gnv (#7
+"build transport + instrumentation") was filed on a mistaken premise and has been **CLOSED as
+redundant** — that work already shipped (sq-sxm + sq-tg6b).
+**[RECONCILED 2026-06-16] New frontier beads** (from
+[`mpc-zkp-build-out-delta.md`](./mpc-zkp-build-out-delta.md) §6): **`sq-f7bu`** (M4-v1
+verifier-side authenticated-input attestation **gate assembly** — Dutta/Artemis interim, P2,
+production-gated on the audits) and **`sq-9hrn`** (fresh **coZK** soundness re-audit of the
+**collaborative** path against eprint 2025/1026, P2 — distinct from the external single-prover
+`sq-qhy4`).
 
 ---
 
@@ -597,20 +680,29 @@ and has been **CLOSED as redundant** — that work already shipped (sq-sxm + sq-
    case is near-frontier), single-equality FILTER, disclosed-global-IRI join (crypto-free —
    sparq's lead), and — newly landed — a **sound oblivious shuffle** plus the sort network and
    3-axis configurable security with Cleve as a type-invariant.
-2. **EXPENSIVE / aspirational:** the hidden equi-join is the cost center (all-pairs today,
-   O(n log n) ORQ sort-merge is the target; minutes-to-tens-of-minutes even at SOTA, ×1.2–6.9
-   on WAN). The entire MEDIUM operator zone — range FILTER, MIN/MAX, GROUP BY, DISTINCT/ORDER
-   BY (hidden), OPTIONAL, AVG-secret-count, multi-pattern BGP — is **all blocked behind ONE
-   primitive: degree reduction (sq-dvuc) → secure comparison (sq-rrz4).** That is the
-   highest-leverage next build; none of it is research-novel.
+2. **[RECONCILED 2026-06-16] The keystone has LANDED.** The 2026-06-15 draft said the entire
+   MEDIUM operator zone — range FILTER, MIN/MAX, GROUP BY, DISTINCT/ORDER BY (hidden), OPTIONAL,
+   AVG-secret-count, multi-pattern BGP — was *"all blocked behind ONE primitive: degree
+   reduction (sq-dvuc) → secure comparison (sq-rrz4)."* **Both are now CLOSED** (plus bounded
+   property paths `sq-py8h` and the federated pipeline driver `sq-6y92`), so range FILTER is
+   itself BUILT and the rest of the zone is **integration-remaining, not keystone-blocked** —
+   per-operator secret-key wiring over the landed primitives (and the SOTA O(n log n)
+   sort-merge join `sq-ujz8`, the carried cost center; all-pairs is the present, correct-but-not-
+   SOTA hidden join). None of it is research-novel.
 3. **OUT OF REACH:** dishonest-majority-malicious correctness for *any* SPARQL operator (zero
    published instances — the registry rightly refuses it); unbounded property paths over a
    secret graph; in-circuit *unlinkable* attested-source membership (two research steps out).
    Fairness/GOD under dishonest majority is **impossible** (Cleve) and is enforced in the type
    system.
-4. **The leverage point has MOVED:** the prior record's "oblivious shuffle+sort is the #1 gap"
-   is **resolved** (sq-18lk closed). The new keystone is **multiplication chaining**; building
-   it unlocks roughly half the operator surface at once.
+4. **[RECONCILED 2026-06-16] The leverage point has MOVED AGAIN.** The prior record's
+   "oblivious shuffle+sort is the #1 gap" was resolved (sq-18lk), and this matrix then named
+   **multiplication chaining** (degree reduction) the new keystone. **That keystone is now also
+   resolved** (`sq-dvuc` + `sq-rrz4` CLOSED) — it unlocked roughly half the operator surface as
+   predicted. The leverage point has moved past the in-crate arithmetic primitives entirely: the
+   remaining frontier is (a) per-operator *integration* + the SOTA sort-merge join (`sq-ujz8`),
+   (b) honest-majority malicious hardening (the IT-MAC line `sq-km34.*`), and (c) the
+   genuinely-novel, audit-gated **collaborative-proof / distributed-attestation** join
+   (DEFERRED spike `sq-bjl`; new delta beads `sq-f7bu`/`sq-9hrn`).
 
 ---
 
@@ -651,13 +743,18 @@ Dutta authenticated-input MPC (eprint 2022/1648) + Artemis (arXiv 2409.12055) (a
 coZK soundness pitfalls (CRYPTO'25, eprint 2025/1026); Canetti UC (FOCS'01); GORAM (PVLDB'25)
 (confidentiality-only graph traversal).
 
-**In-repo ground truth (verified 2026-06-15):** `crates/sparq-mpc/src/{backend,shamir,robust,
-join,oblivious,oblivious_join,proof,holder,partial,field,rng,metrics,bench,transport,
-netprofiles}.rs` + `crates/sparq-mpc/examples/{mpc_bench_matrix,mpc_net_bench,mpc_party}.rs`
+**In-repo ground truth (verified 2026-06-15; re-verified against `main` 2026-06-16):**
+`crates/sparq-mpc/src/{backend,shamir,robust,join,oblivious,oblivious_join,proof,holder,partial,
+field,rng,metrics,bench,transport,netprofiles,compare,bounded_path,pipeline,authenticated}.rs`
++ `crates/sparq-mpc/examples/{mpc_bench_matrix,mpc_net_bench,mpc_party}.rs`
 + `scripts/mpc-netem.sh` — specifically `backend.rs:111–340` (3-axis descriptor + Cleve
-invariant), `shamir.rs:216–252` (`operator_descriptor`), `shamir.rs:455–516`
-(`mul_shares_raw` single-product + `reconstruct_degree`; **no `degree_reduce` on `main` — it
-is in-flight in PR #119**), `oblivious.rs` (`WaksmanNetwork`/`shuffle` sound;
+invariant), `shamir.rs:216–252` (`operator_descriptor`),
+**[RECONCILED 2026-06-16] `shamir.rs::degree_reduce` (BGW reshare-and-recombine — LANDED on
+`main`; PR #119 merged, `sq-dvuc` CLOSED; the prior "no `degree_reduce` on `main`, in-flight in
+PR #119" note is now stale)**, `compare.rs` (`secure_greater_than`/`secure_threshold`/
+`open_verdict` — `sq-rrz4`), `bounded_path.rs` (`sq-py8h`), `pipeline.rs` (federated driver,
+`sq-6y92`), `authenticated.rs` (IT-MAC foundation, `sq-km34.1`),
+`oblivious.rs` (`WaksmanNetwork`/`shuffle` sound;
 `SortingNetwork`/`sort_with_keys`; `SimulatedSecretComparator` INSECURE cfg-gated),
 `join.rs:119,382,411,443` (`DisclosedKeyJoin` / `HiddenValueJoin` all-pairs).
 **Benchmark harness (the §1.2 correction):** `metrics.rs` (`CommCounter` — byte/round/mult
@@ -665,6 +762,10 @@ counters, tier-1) + `bench.rs` (`run_matrix`/`MatrixResults`, the model×N×quer
 landed via **sq-sxm**; `transport.rs` (real loopback multi-process TCP transport — `Message`/
 `Channel`/`Coordinator`/`NetworkCell`/`run_cell_networked`) + `netprofiles.rs`
 (`NetemProfile::lan/wan/loopback` + `tc` generator) landed via **sq-tg6b** (both CLOSED).
-Beads: sq-pwr / sq-0jsc (epics), sq-dvuc / sq-rrz4 / sq-ujz8 / sq-shk5 / sq-yyro / sq-bwwl /
-sq-6d6g (OPEN gaps), sq-18lk / sq-mq8q / sq-a6p1 / sq-uu0u / sq-m34i / sq-7q9i / sq-jnkm /
-sq-1vt / **sq-sxm / sq-tg6b** (CLOSED), sq-hoaj (OPEN — netem/EC2 scale-out).
+Beads **[RECONCILED 2026-06-16]:** sq-pwr / sq-0jsc / sq-1s2 (epics — `sq-1s2` ZK-soundness
+17/17 CLOSED, re-audited SOUND); CLOSED gaps: sq-dvuc / sq-rrz4 / sq-py8h / sq-6y92 / sq-bwwl /
+sq-km34.1 / sq-18lk / sq-mq8q / sq-a6p1 / sq-uu0u / sq-m34i / sq-7q9i / sq-jnkm / sq-1vt /
+sq-sxm / sq-tg6b; OPEN gaps: sq-ujz8 / sq-shk5 / sq-yyro / sq-6d6g / sq-km34.2–.9 / sq-38zk /
+sq-aaop / sq-4i39 / sq-hoaj (netem/EC2 scale-out) / sq-qhy4 (external audit, P0) /
+sq-f7bu (M4-v1 attestation gate) / sq-9hrn (collaborative coZK re-audit); DEFERRED: sq-bjl
+(collaborative-proof / distributed-attestation spike).


### PR DESCRIPTION
> 🤖 SPARQ agent

Refreshes the stale MPC/ZK capability matrix (`research/mpc-sparql-capability-matrix.md`, dated 2026-06-15) so it matches `main`. Doc-only, low-risk. Bead **sq-k4of**; reconciliation source **sq-pwr** (`research/mpc-zkp-build-out-delta.md`, which explicitly flagged this matrix as partly stale). Inline **[RECONCILED 2026-06-16]** markers flag every corrected cell; an **[OPUS-4.8]** "last reconciled against main" note sits under the doc status.

### Stale → corrected (each VERIFIED against `main` source)
| Was (2026-06-15 draft) | Now | Verified on `main` |
|---|---|---|
| degree reduction **OPEN**, "`degree_reduce` in-flight in PR #119, not merged" | **CLOSED / BUILT** | `shamir.rs::degree_reduce` (BGW reshare-and-recombine), `sq-dvuc` |
| secure comparison "**not built — blocked on sq-dvuc**" | **CLOSED / BUILT** (opens only the verdict bit) | `compare.rs::secure_greater_than`/`secure_threshold`/`open_verdict`, `sq-rrz4` |
| bounded property paths **OPEN / "not beaded"** | **CLOSED / BUILT** (disclosed global-IRI regime) | `bounded_path.rs`, `sq-py8h` |
| federated pipeline driver — not present | **BUILT** (holder→share→join→secure-threshold→ProofStatement, four-flatmates) | `pipeline.rs`, `sq-6y92` |
| entire MEDIUM zone "**all blocked behind ONE primitive (sq-dvuc→sq-rrz4)**" | **integration-remaining, not keystone-blocked** (primitives BUILT; per-operator secret-key wiring + sort-merge join `sq-ujz8` remain) | §2/§4.2/§7/§8/§9 updated |
| IT-MAC equality hole "**not its own bead**" | foundation **CLOSED** (`sq-km34.1`), rest beaded `sq-km34.2–.9` | `authenticated.rs` |
| ZK soundness "v1 is BROKEN" posture / RQ1 gate open | epic **`sq-1s2` 17/17 + re-audit SOUND** as landed for the assumed threat model | `zk-verifier-reaudit.md`; single-prover hidden-join `sq-bwwl` CLOSED (PR #170) |

### Kept accurately gated / deferred (no overclaim)
- Collaborative-proof / distributed-attestation join ("the join nobody has built") stays a **DEFERRED, audit-gated spike** (`sq-bjl`).
- External accredited-cryptographer audit (`sq-qhy4`, P0) stays **externally gated**; no production ZK security claim asserted.
- Soundness stated only **"as landed, for the assumed threat model"** — no claim beyond the re-audit.
- New delta beads **`sq-f7bu`** (M4-v1 verifier-side attestation gate assembly) and **`sq-9hrn`** (fresh coZK re-audit of the *collaborative* path) referenced for the net-new frontier.

### Gate
Internal links valid; no abs paths; no new perf numbers. The 14 `MD058` markdownlint findings are **pre-existing** (identical count with/without this change) and reflect the doc's established header-then-table style — left untouched to keep the diff minimal.

(Docs-only → light CI; `code_quality` eval may add minor latency — expected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)