### PR TITLE
feat(sparq-vectors): transitive/multi-variable IdMask for filtered-ANN (sq-3tjd)

### DIFF
--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -66,9 +66,13 @@ let _neighbours = index.nearest_term(&some_term, &graph, &store, 10);
   unfiltered search.
 - **k-NN inside SPARQL (opt-in `vec-predicate`)** — the `vec:nearest` / `vec:search` magic
   predicates run vector k-NN in plain SPARQL via a spargebra-algebra rewrite (the engine is
-  unchanged). Composed with `filtered-ann`, a `vec:` neighbour variable that is **also constrained
-  by ordinary BGP patterns** is searched as a *filtered* ANN automatically — the surrounding BGP
-  derives the candidate `IdMask`, so the filtered top-k equals post-filtering the unfiltered top-k.
+  unchanged). Composed with `filtered-ann`, a `vec:` neighbour variable that is **constrained by
+  ordinary BGP patterns** is searched as a *filtered* ANN automatically — the **join-connected
+  sub-BGP** of the neighbour variable (its connected component in the BGP join-graph, so
+  **transitive / multi-variable** constraints like `?node :owns ?x . ?x a :Vehicle` are honoured)
+  derives the candidate `IdMask`, so the filtered top-k equals post-filtering the unfiltered top-k
+  by that same constraint. A direct-mention-only constraint is the single-variable special case;
+  disconnected patterns never narrow the mask; each `vec:` request gets its own component mask.
 - **Verbalization** — `verbalize` / `embed_entities` render `<label>. a <type>. <description>`
   per entity (multilingual, char-budgeted); `embed_labels` is the label-only special case.
 - **Quantization** — `ScalarQuantizer` (4×) and `ProductQuantizer` (asymmetric distance) for

--- a/crates/sparq-vectors/src/rewrite.rs
+++ b/crates/sparq-vectors/src/rewrite.rs
@@ -571,40 +571,51 @@ fn run_knn(
     }
 }
 
-/// [OPUS-4.8] (sq-bvmd) Builds the candidate [`IdMask`] for `node` from the surrounding
-/// BGP `constraint` patterns — the dictionary ids of every binding `node` takes when the
-/// constraining sub-BGP is evaluated against `graph`.
+/// [OPUS-4.8] (sq-3tjd, epic sq-3183) Builds the candidate [`IdMask`] for `node` from the
+/// surrounding BGP `constraint` patterns — the dictionary ids of every binding `node` takes
+/// when the **join-connected** constraining sub-BGP is evaluated against `graph`, then
+/// projected back onto `node`.
 ///
-/// Only the patterns that actually mention `node` form the constraint (an unrelated
-/// pattern in the same BGP does not narrow the neighbour set — it would be joined as a
-/// cartesian product, which never *removes* a candidate). If `node` is unconstrained
-/// the function returns `Ok(None)` and the caller runs the plain unfiltered search,
-/// preserving the existing `vec:` semantics exactly.
+/// The constraining sub-BGP is the **connected component of the BGP join-graph** that
+/// contains `node`: starting from the patterns that mention `node`, follow shared variables
+/// transitively into the patterns those reach, and so on. This generalises the original
+/// single-variable (#281/sq-bvmd) rule — a *direct-mention-only* component reduces to exactly
+/// the old behaviour — to **transitive / multi-variable** constraints: `?node :owns ?x .
+/// ?x a :Vehicle` restricts `?node` to subjects that own a `:Vehicle` even though the second
+/// pattern never names `?node`.
 ///
-/// The constraining sub-BGP is evaluated through the standard engine (the same seam the
-/// outer query uses), so FILTERs / shared join variables are honoured correctly: the
-/// mask is exactly the set the engine would bind to `node`, hence the filtered top-k is
-/// identical to post-filtering the unfiltered top-k by that same set (the correctness
-/// invariant — see tests/filtered_bgp.rs).
+/// Patterns *not* reachable from `node` through shared variables are deliberately excluded:
+/// a disconnected pattern joins as a cartesian product, which never *removes* a `node`
+/// binding, so pulling it in could only widen (a cross-product can drop a binding only if it
+/// is empty — but an empty disconnected BGP would zero the whole join in the outer query too,
+/// which is a different concern handled by the engine, not a mask we may narrow with). We
+/// only ever **narrow**, never widen: the projected `node` set of the connected component is
+/// a superset of (or equal to) the set the full outer BGP would bind, so the filtered top-k
+/// stays a subset of the unfiltered top-k and equals post-filtering by the (now transitive)
+/// constraint. If `node` is unconstrained (no pattern mentions it) the function returns
+/// `Ok(None)` and the caller runs the plain unfiltered search, preserving the existing
+/// `vec:` semantics exactly.
+///
+/// The connected sub-BGP is evaluated through the standard engine (the same seam the outer
+/// query uses), so shared join variables are honoured correctly: the mask is exactly the set
+/// the engine binds to `node` for that component.
 #[cfg(feature = "filtered-ann")]
 fn derive_mask(
     node: &Variable,
     constraint: &[TriplePattern],
     graph: &Graph,
 ) -> Result<Option<IdMask>, String> {
-    // Keep only the patterns that mention `node`; the rest cannot narrow the candidate
-    // set (they would join as a cross product, never dropping a `node` binding).
-    let sub: Vec<TriplePattern> = constraint
-        .iter()
-        .filter(|tp| pattern_mentions(tp, node))
-        .cloned()
-        .collect();
+    // The connected component of the BGP join-graph that contains `node`: every pattern
+    // join-reachable from `node` through shared variables. A direct-mention-only BGP yields
+    // exactly the same patterns the old single-variable rule did (strict no-regression).
+    let sub = connected_component(node, constraint);
     if sub.is_empty() {
         return Ok(None);
     }
 
-    // SELECT ?node WHERE { <constraining sub-BGP> } — evaluate the constraint through the
-    // engine and collect the ids it binds to `node`.
+    // SELECT ?node WHERE { <connected sub-BGP> } — evaluate the constraint through the engine
+    // and collect the ids it binds to `node`. Projecting `node` discards the intermediate
+    // join variables (e.g. `?x` above), so the mask is precisely the eligible neighbour set.
     let select = Query::Select {
         dataset: None,
         pattern: GraphPattern::Project {
@@ -627,10 +638,69 @@ fn derive_mask(
     Ok(Some(mask))
 }
 
-/// [OPUS-4.8] (sq-bvmd) Does `tp` mention `node` in any term position?
+/// [OPUS-4.8] (sq-3tjd) The connected component of the BGP join-graph containing `node`.
+///
+/// Models the BGP as a graph whose nodes are *variables* and whose edges link the variables
+/// that co-occur in a triple pattern; the component is every pattern reachable from `node`
+/// through shared variables. Implemented as a worklist over a frontier of "live" variables:
+/// seed with `node`, and repeatedly admit any not-yet-taken pattern that mentions a live
+/// variable, adding that pattern's own variables to the frontier — a transitive closure that
+/// terminates because each pass either consumes a pattern or grows no further.
+///
+/// Returns the patterns in the component (empty iff no pattern mentions `node`, i.e. `node`
+/// is unconstrained). The order mirrors the input BGP for determinism.
 #[cfg(feature = "filtered-ann")]
-fn pattern_mentions(tp: &TriplePattern, node: &Variable) -> bool {
-    let in_term = |t: &TermPattern| matches!(t, TermPattern::Variable(v) if v == node);
-    let in_named = matches!(&tp.predicate, NamedNodePattern::Variable(v) if v == node);
-    in_term(&tp.subject) || in_named || in_term(&tp.object)
+fn connected_component(node: &Variable, patterns: &[TriplePattern]) -> Vec<TriplePattern> {
+    // Live variables whose patterns are (transitively) part of the component.
+    let mut live: Vec<Variable> = vec![node.clone()];
+    // `taken[i]` once pattern `i` has been pulled into the component.
+    let mut taken = vec![false; patterns.len()];
+
+    loop {
+        let mut grew = false;
+        for (i, tp) in patterns.iter().enumerate() {
+            if taken[i] {
+                continue;
+            }
+            let vars = pattern_vars(tp);
+            if vars.iter().any(|v| live.contains(v)) {
+                taken[i] = true;
+                grew = true;
+                // Promote this pattern's other variables into the live frontier so the
+                // closure follows the join transitively.
+                for v in vars {
+                    if !live.contains(&v) {
+                        live.push(v);
+                    }
+                }
+            }
+        }
+        if !grew {
+            break;
+        }
+    }
+
+    patterns
+        .iter()
+        .zip(&taken)
+        .filter(|(_, &t)| t)
+        .map(|(tp, _)| tp.clone())
+        .collect()
+}
+
+/// [OPUS-4.8] (sq-3tjd) The variables `tp` mentions, in any term position (subject,
+/// predicate, object).
+#[cfg(feature = "filtered-ann")]
+fn pattern_vars(tp: &TriplePattern) -> Vec<Variable> {
+    let mut out = Vec::with_capacity(3);
+    if let TermPattern::Variable(v) = &tp.subject {
+        out.push(v.clone());
+    }
+    if let NamedNodePattern::Variable(v) = &tp.predicate {
+        out.push(v.clone());
+    }
+    if let TermPattern::Variable(v) = &tp.object {
+        out.push(v.clone());
+    }
+    out
 }

--- a/crates/sparq-vectors/tests/filtered_bgp_transitive.rs
+++ b/crates/sparq-vectors/tests/filtered_bgp_transitive.rs
@@ -1,0 +1,330 @@
+//! [OPUS-4.8] (sq-3tjd, epic sq-3183) End-to-end tests for the **transitive /
+//! multi-variable** filtered-ANN BGP→IdMask derivation of the `vec:` magic predicate
+//! (follow-up to sq-bvmd/#281). The single-variable wiring restricted the candidate
+//! id-set to patterns that DIRECTLY mention the neighbour variable; sq-3tjd extends the
+//! mask to the projection of the whole **join-connected sub-BGP** — patterns that
+//! constrain the neighbour variable transitively through intermediate variables.
+//!
+//! Invariants proven here (preserved + extended from sq-bvmd):
+//! - a 2-hop constraint (`?node :owns ?x . ?x a :Vehicle`) restricts `?node` to subjects
+//!   join-connected to a `:Vehicle`, and matches post-filtering the unfiltered top-k by
+//!   that same transitive constraint;
+//! - a **disconnected** pattern (no shared variable path to `?node`) does NOT affect the
+//!   mask;
+//! - the **single-variable** case is unchanged (regression guard vs the old rule);
+//! - **multiple** `vec:` requests each get their own connected-component mask;
+//! - filtered ⊆ unfiltered holds transitively.
+//!
+//! Gated on BOTH `vec-predicate` (the rewrite) and `filtered-ann` (the `IdMask` API).
+#![cfg(all(feature = "vec-predicate", feature = "filtered-ann"))]
+
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+use sparq_vectors::{query_vec, QueryResult, VectorStore};
+
+fn tmp_path(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "sparq_vec_fbgpt_{}_{}.spqv",
+        std::process::id(),
+        name
+    ));
+    p
+}
+
+/// Six owner entities a..f on the unit circle. Each `:owns` a thing; only some of those
+/// things are a `:Vehicle`. The neighbour variable is the OWNER `?node`; the `:Vehicle`
+/// type sits one hop away on the owned thing — so the constraint only bites through a
+/// transitive (2-hop) join.
+///
+/// Owners + vectors (same geometry as filtered_bgp.rs so a +x query has a known order):
+///   a (+x)        owns ta — ta a :Vehicle
+///   c (~+x)       owns tc — tc a :Vehicle
+///   b (+y)        owns tb — tb a :Vehicle
+///   d (-x)        owns td — td a :Gadget   (NOT a Vehicle)
+///   e (~+y)       owns te — te a :Gadget   (NOT a Vehicle)
+///   f (~+x)       owns tf — tf a :Gadget   (NOT a Vehicle)  <- closest non-a to +x, but no Vehicle
+///
+/// So the Vehicle-owners are {a,b,c}; the +x query's closest non-a (f) is a Gadget-owner
+/// that the transitive constraint must exclude — exactly the single-variable fixture's
+/// shape, lifted one join hop.
+fn fixture(name: &str) -> (Graph, VectorStore) {
+    let g = Graph::load_str(
+        r#"
+        <http://ex/a> <http://ex/owns> <http://ex/ta> .
+        <http://ex/b> <http://ex/owns> <http://ex/tb> .
+        <http://ex/c> <http://ex/owns> <http://ex/tc> .
+        <http://ex/d> <http://ex/owns> <http://ex/td> .
+        <http://ex/e> <http://ex/owns> <http://ex/te> .
+        <http://ex/f> <http://ex/owns> <http://ex/tf> .
+        <http://ex/ta> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ex/Vehicle> .
+        <http://ex/tb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ex/Vehicle> .
+        <http://ex/tc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ex/Vehicle> .
+        <http://ex/td> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ex/Gadget> .
+        <http://ex/te> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ex/Gadget> .
+        <http://ex/tf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ex/Gadget> .
+        "#,
+        "ntriples",
+    )
+    .unwrap();
+    let id = |s: &str| {
+        g.id_of(&Term::NamedNode(NamedNode::new(s).unwrap()))
+            .unwrap()
+    };
+    let mut store = VectorStore::create(tmp_path(name), 2).unwrap();
+    store.put(id("http://ex/a"), &[1.0, 0.0]).unwrap(); // +x   Vehicle-owner
+    store.put(id("http://ex/b"), &[0.0, 1.0]).unwrap(); // +y   Vehicle-owner
+    store.put(id("http://ex/c"), &[0.9, 0.1]).unwrap(); // ~+x  Vehicle-owner
+    store.put(id("http://ex/d"), &[-1.0, 0.0]).unwrap(); // -x  Gadget-owner
+    store.put(id("http://ex/e"), &[0.2, 0.98]).unwrap(); // ~+y Gadget-owner
+    store.put(id("http://ex/f"), &[0.95, 0.05]).unwrap(); // ~+x Gadget-owner (closest to +x after a)
+    (g, store)
+}
+
+fn iris(r: &QueryResult, col: usize) -> Vec<String> {
+    r.rows
+        .iter()
+        .filter_map(|row| match &row[col] {
+            Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+const PFX: &str = "PREFIX vec: <http://sparq.dev/vec#> PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ";
+
+/// 2-hop transitive constraint: `?node :owns ?x . ?x a :Vehicle` restricts `?node` to
+/// owners of a Vehicle even though `?node` never appears in the `:Vehicle` pattern. The
+/// closer Gadget-owner `f` must be excluded; the next Vehicle-owner `b` returns instead.
+#[test]
+fn transitive_two_hop_restricts_correctly() {
+    let (g, store) = fixture("transitive");
+    let r = query_vec(
+        &g,
+        &format!(
+            "{PFX} SELECT ?node WHERE {{
+               ?node vec:nearest ( \"1,0\" 3 ) .
+               ?node <http://ex/owns> ?x .
+               ?x rdf:type <http://ex/Vehicle> .
+             }}"
+        ),
+        &store,
+    )
+    .unwrap();
+    let mut got = iris(&r, 0);
+    got.sort();
+    got.dedup();
+    // +x query restricted to Vehicle-owners {a,b,c}: top-3 are a, c, b.
+    assert_eq!(
+        got,
+        vec![
+            "http://ex/a".to_string(),
+            "http://ex/b".to_string(),
+            "http://ex/c".to_string()
+        ],
+        "transitive constraint must admit only Vehicle-owners: {r:?}"
+    );
+    assert!(
+        !got.contains(&"http://ex/f".to_string()),
+        "the closer Gadget-owner `f` must be filtered out by the 2-hop :Vehicle constraint: {r:?}"
+    );
+}
+
+/// Filtered top-k via the transitive constraint ≡ post-filtering the unfiltered top-k by
+/// the SAME (transitive) constraint, AND filtered ⊆ unfiltered.
+#[test]
+fn transitive_filtered_equals_postfilter_and_is_subset() {
+    let (g, store) = fixture("transitive_postfilter");
+
+    // Unfiltered: all 6 neighbours of a +x query, best-first.
+    let unfiltered = query_vec(
+        &g,
+        &format!("{PFX} SELECT ?node WHERE {{ ?node vec:nearest ( \"1,0\" 6 ) }}"),
+        &store,
+    )
+    .unwrap();
+    let unfiltered_order = iris(&unfiltered, 0);
+
+    // The transitively-admitted set (Vehicle-owners), via plain SPARQL (no vec:).
+    let owners: std::collections::HashSet<String> = query_vec(
+        &g,
+        &format!(
+            "{PFX} SELECT ?node WHERE {{
+               ?node <http://ex/owns> ?x . ?x rdf:type <http://ex/Vehicle> }}"
+        ),
+        &store,
+    )
+    .unwrap()
+    .rows
+    .iter()
+    .filter_map(|row| match &row[0] {
+        Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+        _ => None,
+    })
+    .collect();
+
+    // Post-filter: unfiltered order, keep only Vehicle-owners, take top-2.
+    let k = 2;
+    let postfilter: Vec<String> = unfiltered_order
+        .iter()
+        .filter(|n| owners.contains(*n))
+        .take(k)
+        .cloned()
+        .collect();
+
+    // Filtered search: same query + the transitive constraint, k=2.
+    let filtered = query_vec(
+        &g,
+        &format!(
+            "{PFX} SELECT ?node WHERE {{
+               ( ?node ?score ) vec:search ( \"1,0\" {k} ) .
+               ?node <http://ex/owns> ?x .
+               ?x rdf:type <http://ex/Vehicle> .
+             }} ORDER BY DESC(?score)"
+        ),
+        &store,
+    )
+    .unwrap();
+    let filtered_order = iris(&filtered, 0);
+
+    assert_eq!(
+        filtered_order, postfilter,
+        "transitive filtered top-k must equal post-filtering the unfiltered top-k\nfiltered={filtered_order:?}\npostfilter={postfilter:?}"
+    );
+    let unfiltered_set: std::collections::HashSet<&String> = unfiltered_order.iter().collect();
+    for n in &filtered_order {
+        assert!(
+            unfiltered_set.contains(n),
+            "filtered neighbour {n} not in the unfiltered result {unfiltered_order:?}"
+        );
+    }
+}
+
+/// A pattern with no shared-variable path to `?node` (`?y rdf:type :Vehicle`, where `?y`
+/// is bound by nothing the neighbour touches) is DISCONNECTED and must not narrow the
+/// mask. Without it the +x top-2 over all owners is {a, f}; the disconnected pattern must
+/// leave that unchanged (Gadget-owner `f` survives).
+#[test]
+fn disconnected_pattern_does_not_affect_mask() {
+    let (g, store) = fixture("disconnected");
+    let r = query_vec(
+        &g,
+        // `?node :owns ?x` connects ?node↔?x. `?y rdf:type :Vehicle` shares NO variable
+        // with that component (?y is fresh), so it is disconnected from ?node and must not
+        // constrain it. The mask is derived from `?node :owns ?x` alone (all owners), so
+        // the Gadget-owner f is admitted — exactly the unfiltered-over-owners top-2.
+        &format!(
+            "{PFX} SELECT ?node WHERE {{
+               ?node vec:nearest ( \"1,0\" 2 ) .
+               ?node <http://ex/owns> ?x .
+               ?y rdf:type <http://ex/Vehicle> .
+             }}"
+        ),
+        &store,
+    )
+    .unwrap();
+    let mut got = iris(&r, 0);
+    got.sort();
+    got.dedup();
+    assert_eq!(
+        got,
+        vec!["http://ex/a".to_string(), "http://ex/f".to_string()],
+        "a disconnected `?y a :Vehicle` must NOT narrow ?node's mask (f survives): {r:?}"
+    );
+}
+
+/// Regression guard: the single-variable case (constraint mentions `?node` directly, no
+/// intermediate join) must yield exactly the old mask. Same shape as the sq-bvmd
+/// `mask_restricts_to_bgp_satisfying_candidates`, but here the direct constraint sits on
+/// the OWNED-thing identity to prove the 1-hop component equals the old direct-mention set.
+#[test]
+fn single_variable_case_unchanged() {
+    // A fixture where `?node` is directly typed (no transitive hop) — the component is the
+    // single directly-mentioning pattern, identical to the pre-sq-3tjd rule.
+    let g = Graph::load_str(
+        r#"
+        <http://ex/a> <http://ex/kind> <http://ex/Car> .
+        <http://ex/b> <http://ex/kind> <http://ex/Car> .
+        <http://ex/c> <http://ex/kind> <http://ex/Car> .
+        <http://ex/f> <http://ex/kind> <http://ex/Boat> .
+        "#,
+        "ntriples",
+    )
+    .unwrap();
+    let id = |s: &str| {
+        g.id_of(&Term::NamedNode(NamedNode::new(s).unwrap()))
+            .unwrap()
+    };
+    let mut store = VectorStore::create(tmp_path("single_var"), 2).unwrap();
+    store.put(id("http://ex/a"), &[1.0, 0.0]).unwrap();
+    store.put(id("http://ex/b"), &[0.0, 1.0]).unwrap();
+    store.put(id("http://ex/c"), &[0.9, 0.1]).unwrap();
+    store.put(id("http://ex/f"), &[0.95, 0.05]).unwrap();
+
+    let r = query_vec(
+        &g,
+        &format!(
+            "{PFX} SELECT ?node WHERE {{
+               ?node vec:nearest ( \"1,0\" 3 ) .
+               ?node <http://ex/kind> <http://ex/Car> .
+             }}"
+        ),
+        &store,
+    )
+    .unwrap();
+    let mut got = iris(&r, 0);
+    got.sort();
+    got.dedup();
+    assert_eq!(
+        got,
+        vec![
+            "http://ex/a".to_string(),
+            "http://ex/b".to_string(),
+            "http://ex/c".to_string()
+        ],
+        "single-variable direct constraint must behave exactly as before (no Boat f): {r:?}"
+    );
+}
+
+/// Multiple `vec:` requests in one BGP, each with its OWN connecting constraint, get their
+/// own connected-component mask. `?n1` is constrained to Vehicle-owners (transitive);
+/// `?n2` is left unconstrained — proving the per-request component derivation is
+/// independent (one request's constraint does not leak into the other's mask).
+#[test]
+fn multiple_requests_each_own_component_mask() {
+    let (g, store) = fixture("multi_request");
+    let r = query_vec(
+        &g,
+        &format!(
+            "{PFX} SELECT ?n1 ?n2 WHERE {{
+               ?n1 vec:nearest ( \"1,0\" 2 ) .
+               ?n1 <http://ex/owns> ?x .
+               ?x rdf:type <http://ex/Vehicle> .
+               ?n2 vec:nearest ( \"1,0\" 2 ) .
+             }}"
+        ),
+        &store,
+    )
+    .unwrap();
+
+    // ?n1: transitively constrained to Vehicle-owners → +x top-2 = {a, c} (f excluded).
+    let mut n1: Vec<String> = iris(&r, 0);
+    n1.sort();
+    n1.dedup();
+    assert_eq!(
+        n1,
+        vec!["http://ex/a".to_string(), "http://ex/c".to_string()],
+        "?n1's own component (Vehicle-owners) must exclude f: {r:?}"
+    );
+
+    // ?n2: unconstrained → plain unfiltered +x top-2 = {a, f} (the Gadget-owner returns,
+    // proving ?n1's mask did NOT leak into ?n2's search).
+    let mut n2: Vec<String> = iris(&r, 1);
+    n2.sort();
+    n2.dedup();
+    assert_eq!(
+        n2,
+        vec!["http://ex/a".to_string(), "http://ex/f".to_string()],
+        "?n2 is unconstrained → unfiltered (f returns), independent of ?n1's mask: {r:?}"
+    );
+}

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -364,32 +364,51 @@ literal's dimension must match the store; any other `vec:` IRI is unknown. An ab
 seed IRI yields no rows. Search is the **exact** `nearest_exact` scan (deterministic, the HNSW/
 DiskANN approximate indexes are not yet wired into the predicate — recorded follow-up).
 
-**Automatic filtered ANN (compose with `filtered-ann`, sq-bvmd).** When **both**
+**Automatic filtered ANN (compose with `filtered-ann`, sq-bvmd + sq-3tjd).** When **both**
 `vec-predicate` *and* `filtered-ann` are on, the rewrite derives the candidate id-set
-([`IdMask`], recipe 9) automatically: if the `vec:` neighbour variable is **also constrained by
+([`IdMask`], recipe 9) automatically: if the `vec:` neighbour variable is **constrained by
 ordinary patterns in the same BGP**, those patterns carve out the eligible nodes and the k-NN is
 run as a **filtered** search (`nearest_exact_filtered`) over just that set — no separate API call.
 
+The constraint is the **join-connected sub-BGP** of the neighbour variable (sq-3tjd): not only
+patterns that *directly mention* it, but every pattern reachable from it through shared variables
+— so the mask honours **transitive / multi-variable** constraints. A direct-mention-only BGP is a
+special case of this (the connected component is just those patterns), so the single-variable
+behaviour from sq-bvmd is unchanged.
+
 ```rust
-// ?node is the neighbour AND is constrained to be a :Car: the search only ever
-// considers Cars (the IdMask), so a closer non-Car neighbour is never returned.
+// Direct (single-variable): ?node is the neighbour AND is itself a :Car —
+// the search only ever considers Cars, so a closer non-Car is never returned.
 let r = query_vec(&graph,
     "PREFIX vec: <http://sparq.dev/vec#>
      SELECT ?node WHERE {
        ?node vec:nearest ( \"1,0\" 5 ) .
        ?node <http://ex/kind> <http://ex/Car> .   # ← carves out the candidate id-set
      }", &store)?;
+
+// Transitive (multi-variable, 2-hop): ?node is restricted to subjects that own a
+// :Vehicle even though ?node never appears in the `?x a :Vehicle` pattern — the
+// connected component {?node :owns ?x, ?x a :Vehicle} is evaluated and ?node projected.
+let r = query_vec(&graph,
+    "PREFIX vec: <http://sparq.dev/vec#> PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+     SELECT ?node WHERE {
+       ?node vec:nearest ( \"1,0\" 5 ) .
+       ?node <http://ex/owns> ?x .
+       ?x rdf:type <http://ex/Vehicle> .          # ← reached transitively through ?x
+     }", &store)?;
 ```
 
-The mask is exactly the set the engine binds to the neighbour variable when the constraining
-sub-BGP is evaluated, so the filtered top-k is **identical to post-filtering the unfiltered
-top-k** by that same constraint (and therefore a subset of the unfiltered result) — correct, and
-for a selective constraint it avoids scanning the rest of the store. If the neighbour variable is
-**unconstrained** the search falls back to the plain unfiltered `nearest_exact` (recipe 8's exact
-behaviour, unchanged). With `filtered-ann` **off**, the `vec:` predicate is always unfiltered —
-this composition adds nothing to the `vec-predicate`-only build. Deferred (own beads): multi-
-variable mask intersection (sq-3tjd), mask caching (sq-36ol), and a cost-model choice of
-filtered-vs-post-filter (sq-ic0n).
+The mask is exactly the set the engine binds to the neighbour variable when that connected
+sub-BGP is evaluated and the neighbour variable projected, so the filtered top-k is **identical to
+post-filtering the unfiltered top-k** by that same (now transitive) constraint — and therefore a
+subset of the unfiltered result. A pattern **disconnected** from the neighbour variable (no
+shared-variable path) is excluded, so it never narrows the mask. Each `vec:` request in a BGP gets
+its **own** connected-component mask, derived independently. If the neighbour variable is
+**unconstrained** (no pattern mentions it) the search falls back to the plain unfiltered
+`nearest_exact` (recipe 8's exact behaviour, unchanged). With `filtered-ann` **off**, the `vec:`
+predicate is always unfiltered — this composition adds nothing to the `vec-predicate`-only build.
+Deferred (own beads): cyclic-join handling, a cost-model choice of when transitive masking pays
+(sq-ic0n), and mask caching (sq-36ol).
 
 ### 9. Predicate-constrained (filtered) ANN — only neighbours a BGP admits (opt-in, feature = `filtered-ann`)
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-3tjd** (epic **sq-3183**), the follow-up to **sq-bvmd / #281**.

## What

Extends the filtered-ANN `vec:` BGP→`IdMask` derivation from patterns that **directly mention** the neighbour variable to the projection of the whole **join-connected sub-BGP**:

- `derive_mask` now computes the **connected component** of the BGP join-graph containing the neighbour variable (`connected_component` + `pattern_vars`): seed the live-variable frontier with `?node`, transitively admit any pattern sharing a live variable, growing the frontier with that pattern's variables until fixpoint.
- It then evaluates `SELECT ?node WHERE { <connected sub-BGP> }` and projects the neighbour var, discarding intermediate join variables (e.g. `?x`), to build the `IdMask`.

This honours **transitive / multi-variable** constraints: `?node :owns ?x . ?x a :Vehicle` restricts `?node` to subjects that own a `:Vehicle`, even though `?node` never appears in the `:Vehicle` pattern.

## Preserved correctness invariant

- filtered top-k **== post-filtering** the unfiltered top-k by the same (now transitive) constraint; filtered **⊆** unfiltered.
- The single-variable case (sq-bvmd) is a **strict subset** of the new logic — a direct-mention-only BGP's connected component is exactly those patterns, so the old mask is reproduced (regression guard test).
- **Disconnected** patterns (no shared-variable path) are excluded → never narrow the mask.
- No constraining pattern → `None` → unfiltered fallback (unchanged).
- Each `vec:` request derives its **own** component mask independently.

## Tests (`tests/filtered_bgp_transitive.rs`)

2-hop `?node :owns ?x . ?x a :Vehicle` restricts correctly + `== post-filter` + `⊆ unfiltered`; disconnected `?y a :Vehicle` is a no-op; single-variable case unchanged; multiple `vec:` requests each get their own component mask (one constrained, one not → no leak).

## Gates

`cargo build` / `clippy --all-targets -D warnings` / full `cargo test` all green **features OFF and ON** (`vec-predicate` + `filtered-ann`); `rustfmt --check` clean on touched files. Same opt-in gating, no new deps, `sparq-core`/`sparq-engine` untouched.

NON-CANONICAL timing (work-box EC2).

Co-Authored-By: Claude Opus 4.8 (1M context)