### PR TITLE
feat(sparq-solid): materialize ODRL Prohibitions as explicit AUTH_GRAPH deny (sq-w693)

### DIFF
--- a/crates/sparq-policy/README.md
+++ b/crates/sparq-policy/README.md
@@ -64,6 +64,11 @@ assert!(!evaluate(&policy, &outside).allow);
   prohibition ⇒ DENY; a permission grants only when matched **and** all its
   duties are discharged. Prohibitions carve out permissions (ODRL conflict
   default). A malformed/unknown constraint becomes an unsatisfiable guard.
+  `matched_prohibition(&policy, &request) -> Option<&Rule>` exposes the
+  evaluator's own conflict test (the first prohibition that carves the request
+  out), so a downstream materializer can distinguish a *carve-out* deny from a
+  plain no-permission deny — `sparq-solid`'s ODRL bridge uses it to emit explicit
+  `auth:deny*` triples (deny-overrides). [OPUS-4.8] sq-w693.
 - **Constraint operators** — `eq`, `neq`, `lt`, `lteq`, `gt`, `gteq`,
   `isPartOf` (set membership), `isA`. Numeric (`xsd:integer`/`decimal`/…) and
   `xsd:dateTime`/`date` operands compare by magnitude/instant; everything else

--- a/crates/sparq-policy/src/eval.rs
+++ b/crates/sparq-policy/src/eval.rs
@@ -170,6 +170,45 @@ pub fn evaluate(policy: &Policy, request: &Request) -> Decision {
     Decision::deny(Vec::new(), caveats)
 }
 
+/// The first [`Prohibition`](crate::model::Rule) in `policy` that **matches**
+/// `request` (its action permits the requested action, its target/assignee agree,
+/// and every constraint is satisfied), or `None` if no prohibition carves the
+/// request out. [OPUS-4.8] sq-w693.
+///
+/// This is the same match test [`evaluate`] applies in step 1 (a matching
+/// prohibition overrides everything) — exposed so the `sparq-solid` ODRL→AUTH_GRAPH
+/// bridge can materialize a matched prohibition as an explicit `auth:deny*` triple
+/// (deny-overrides) WITHOUT re-implementing the match logic. A `Decision` with
+/// `allow == false` is NOT sufficient: it conflates a carve-out prohibition with a
+/// plain no-matching-permission deny, and only the former should materialize a deny.
+///
+/// # Examples
+///
+/// ```
+/// use sparq_policy::{matched_prohibition, parse_policy_str, Request};
+/// let pol = parse_policy_str(r#"
+/// @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+/// <urn:pol/p> a odrl:Set ; odrl:prohibition [
+///     odrl:action odrl:write ;
+///     odrl:target <https://pod.ex/n1> ;
+///     odrl:assignee <https://alice.ex/card#me> ] .
+/// "#, "turtle").unwrap();
+/// let req = Request::new("http://www.w3.org/ns/odrl/2/write")
+///     .on("https://pod.ex/n1").by("https://alice.ex/card#me");
+/// assert!(matched_prohibition(&pol, &req).is_some());
+/// // a different party is not carved out
+/// let other = Request::new("http://www.w3.org/ns/odrl/2/write")
+///     .on("https://pod.ex/n1").by("https://bob.ex/card#me");
+/// assert!(matched_prohibition(&pol, &other).is_none());
+/// ```
+pub fn matched_prohibition<'p>(policy: &'p Policy, request: &Request) -> Option<&'p Rule> {
+    let req_action = Action(request.action.clone());
+    policy
+        .prohibitions
+        .iter()
+        .find(|rule| rule_matches(rule, request, &req_action).is_match)
+}
+
 /// Outcome of matching a single rule against a request.
 struct Match {
     is_match: bool,

--- a/crates/sparq-policy/src/lib.rs
+++ b/crates/sparq-policy/src/lib.rs
@@ -5,6 +5,6 @@ mod eval;
 pub mod model;
 mod parse;
 
-pub use eval::{evaluate, Decision, Request};
+pub use eval::{evaluate, matched_prohibition, Decision, Request};
 pub use model::{Action, Constraint, Duty, Operator, Policy, Rule, Value, ODRL_NS};
 pub use parse::{parse_policy, parse_policy_str};

--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -53,7 +53,9 @@ let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len(
   cargo feature, `materialize_permission` / `PodStore::materialize_odrl_permission` runs the
   [`sparq-policy`](../sparq-policy) ODRL evaluator and, on a **definite Permit**, materializes
   the equivalent WAC/ACP grant into the auth view — so the existing graph-level enforcement
-  honours it with **no new enforcement engine**. See below.
+  honours it with **no new enforcement engine**. A matched **Prohibition** materializes the dual
+  `auth:deny*` triple (`materialize_prohibition` / `materialize_policy`), and the existing
+  enforcement applies **deny-overrides** ([OPUS-4.8] sq-w693). See below.
 
 ## ODRL → AUTH_GRAPH bridge (opt-in `odrl-bridge` feature) — [OPUS-4.8] sq-h3uk
 
@@ -82,6 +84,36 @@ concrete request).
 *and* a concrete party (WebID) + target graph. A Deny, an unsatisfied constraint, an
 undischarged duty, an unmapped action, or a partyless/targetless request materializes
 **nothing** — access is never widened on ambiguity.
+
+### Prohibitions → explicit `auth:deny*` (deny-overrides) — [OPUS-4.8] sq-w693
+
+A matched ODRL **Prohibition** is the dual of a Permit: `materialize_prohibition` /
+`PodStore::materialize_odrl_prohibition` materializes it as the explicit
+`principal auth:deny<Mode> graph` triple the enforcement already understands, via the **same**
+action→mode mapping above (`denyRead` / `denyWrite` / `denyAppend` / `denyControl`).
+`materialize_policy` / `PodStore::materialize_odrl_policy` does both sides at once.
+
+| ODRL Prohibition action (`odrl:`)             | materialized deny predicate |
+|-----------------------------------------------|-----------------------------|
+| `read`, `display`, `present`, `print`, `play` | `auth:denyRead`             |
+| `append`                                      | `auth:denyAppend`           |
+| `modify`, `delete`, `write`                   | `auth:denyWrite`            |
+| anything else (incl. the `odrl:use` umbrella) | **unmapped → no deny**      |
+
+**Deny-overrides:** the deny is honoured by the **existing, unchanged** enforcement — the
+session layer already computes `∪ allow ∖ ∪ deny` (`AuthIndex::accessible`) and `Mode::from_pred`
+already parses `auth:deny*`, so a materialized deny **beats any allow grant** for the same
+principal+target+mode. No new enforcement engine; the bridge only emits the triple. (Within a
+single policy the ODRL evaluator *also* applies deny-overrides upstream — the would-be Permit
+returns `allow == false`, so its allow triple is never even emitted when a prohibition carves
+the request out.)
+
+**Fail-closed (deny):** a deny is materialized **only** when a prohibition *matches* the request
+(decided by `sparq_policy::matched_prohibition` — the evaluator's own conflict test, *not*
+`Decision.allow == false`, which conflates a carve-out with a plain no-permission deny) *and* the
+action is mappable *and* the party+target are concrete. An unmatched / unmapped / partyless /
+targetless prohibition materializes **nothing**; an unmappable carve-out is *reported* in
+`reasons`, never silently dropped (dropping a deny would widen access).
 
 ## Security posture — fail-closed
 

--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -16,7 +16,10 @@ pub use authindex::{pair_principal, AuthIndex, Mode, Session};
 pub use fixture::{acp_fixture, wac_fixture};
 pub use materialize::{materialize_acp, materialize_wac, MaterializeStats};
 #[cfg(feature = "odrl-bridge")]
-pub use odrl_bridge::{action_to_mode, materialize_permission, BridgeOutcome};
+pub use odrl_bridge::{
+    action_to_mode, materialize_permission, materialize_policy, materialize_prohibition,
+    BridgeOutcome,
+};
 pub use rewrite::{rewrite_for, wrap_for_view};
 
 use oxrdf::{NamedNode, Term};
@@ -452,6 +455,55 @@ impl PodStore {
         let outcome = odrl_bridge::materialize_permission(&mut self.graph, policy, request);
         if outcome.granted {
             self.reindex(); // a new grant changes the auth view → rebuild index + drop cache
+        }
+        outcome
+    }
+
+    /// [OPUS-4.8] sq-w693 — evaluate an ODRL `policy`'s prohibitions against `request`
+    /// and, on a matched Prohibition that carves the request out, materialize the
+    /// equivalent `principal auth:deny<Mode> graph` DENY into this store's
+    /// `<urn:sparq:auth>` view, then rebuild the session index so the deny takes effect
+    /// on the next [`PodStore::accessible`] / [`PodStore::query_as`] call.
+    ///
+    /// The materialized deny is honoured by the EXISTING enforcement under
+    /// **deny-overrides**: the session layer computes `∪ allow ∖ ∪ deny`, so the deny
+    /// beats any allow grant for the same principal+target+mode — see
+    /// [`odrl_bridge::materialize_prohibition`].
+    ///
+    /// **Fail-closed:** no matching prohibition, an unmapped action, or a request
+    /// without a concrete party/target materializes NOTHING and leaves the auth view
+    /// (and session index) untouched.
+    #[cfg(feature = "odrl-bridge")]
+    pub fn materialize_odrl_prohibition(
+        &mut self,
+        policy: &sparq_policy::Policy,
+        request: &sparq_policy::Request,
+    ) -> odrl_bridge::BridgeOutcome {
+        let outcome = odrl_bridge::materialize_prohibition(&mut self.graph, policy, request);
+        if outcome.prohibited {
+            self.reindex(); // a new deny changes the auth view → rebuild index + drop cache
+        }
+        outcome
+    }
+
+    /// [OPUS-4.8] sq-w693 — materialize **both** sides of an ODRL `policy` for
+    /// `request` into this store's `<urn:sparq:auth>` view: the Permit allow grant AND
+    /// the matched-Prohibition deny ([`odrl_bridge::materialize_policy`]), then rebuild
+    /// the session index if either materialized.
+    ///
+    /// A policy with both a permission and a prohibition for the same
+    /// principal+target+mode materializes both triples; the deny **wins** at
+    /// enforcement time (deny-overrides — the session layer subtracts `∪ deny` from
+    /// `∪ allow`). Each side is independently fail-closed.
+    #[cfg(feature = "odrl-bridge")]
+    pub fn materialize_odrl_policy(
+        &mut self,
+        policy: &sparq_policy::Policy,
+        request: &sparq_policy::Request,
+    ) -> odrl_bridge::BridgeOutcome {
+        let outcome = odrl_bridge::materialize_policy(&mut self.graph, policy, request);
+        if outcome.granted || outcome.prohibited {
+            self.reindex(); // a new grant/deny changes the auth view → rebuild + drop cache
         }
         outcome
     }

--- a/crates/sparq-solid/src/odrl_bridge.rs
+++ b/crates/sparq-solid/src/odrl_bridge.rs
@@ -48,13 +48,39 @@
 //! that wants `use → Read` should request `odrl:read` explicitly (a `use` permission
 //! in the policy still *grants* a `read` request — `odrl:use` permits any action in
 //! the evaluator — so the bridge maps the **request** action, which is concrete).
+//!
+//! # Prohibitions → `auth:deny<Mode>` (deny-overrides) — [OPUS-4.8] sq-w693
+//!
+//! A matched ODRL **Prohibition** is the dual of a Permit: it carves an action out
+//! of access. [`materialize_prohibition`] materializes it as the explicit
+//! `principal auth:deny<Mode> target` triple the enforcement already understands —
+//! `auth:denyRead`/`denyWrite`/`denyAppend`/`denyControl`, via the SAME
+//! [`action_to_mode`] mapping (the request's concrete action → the narrowest denied
+//! mode). The existing session layer ([`crate::AuthIndex::accessible`]) computes
+//! `∪ allow ∖ ∪ deny`, so a materialized deny **takes precedence over any allow
+//! grant** for the same principal+target+mode — *deny-overrides*, the same conflict
+//! resolution the ODRL evaluator applies (a matching prohibition overrides any
+//! permission). No new enforcement engine: the deny path already existed
+//! ([`Mode::from_pred`](crate::Mode) parses `deny*`); the bridge only emits the triples.
+//!
+//! A prohibition materializes a deny **only** when [`sparq_policy::matched_prohibition`]
+//! reports it carves THIS request out (action permits + target/assignee agree +
+//! constraints satisfied) AND the request action [`action_to_mode`]-maps AND the
+//! request names a concrete party (WebID) + target graph IRI. An un-matched / unmapped
+//! / partyless / targetless prohibition materializes **nothing** — fail-closed; a deny
+//! is never widened on ambiguity (and certainly never silently dropped to widen access).
+//!
+//! [`materialize_policy`] composes the two: it materializes every applicable Permit
+//! grant AND every matched-Prohibition deny for the request, so a policy carrying both
+//! a permission and a prohibition on the same principal+target+mode emits both triples,
+//! and the deny **wins** at enforcement time.
 
 use crate::authindex::Mode;
 use crate::{AUTH_GRAPH, AUTH_NS};
 use oxrdf::{NamedNode, Term};
 use sparq_core::dict::Dict;
 use sparq_core::Graph;
-use sparq_policy::{evaluate, Policy, Request};
+use sparq_policy::{evaluate, matched_prohibition, Policy, Request};
 
 /// The ODRL namespace prefix (`odrl:`), re-exported for caller convenience.
 pub const ODRL_NS: &str = sparq_policy::ODRL_NS;
@@ -103,25 +129,51 @@ fn mode_predicate(mode: Mode) -> &'static str {
     }
 }
 
-/// What [`materialize_permission`] decided and (on a Permit) materialized.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// The `auth:deny<Mode>` view predicate a [`Mode`] DENY is materialized under — the
+/// SAME predicate [`crate::AuthIndex`] parses into its deny map
+/// (`auth:denyRead|denyWrite|denyAppend|denyControl`), so a materialized deny is
+/// subtracted from the allow set by the existing `∪ allow ∖ ∪ deny` enforcement.
+/// [OPUS-4.8] sq-w693.
+fn deny_predicate(mode: Mode) -> &'static str {
+    match mode {
+        Mode::Read => "denyRead",
+        Mode::Write => "denyWrite",
+        Mode::Append => "denyAppend",
+        Mode::Control => "denyControl",
+    }
+}
+
+/// What the bridge decided and (on a Permit / matched Prohibition) materialized.
+///
+/// [`materialize_permission`] sets the `granted` / `grant_triple` fields;
+/// [`materialize_prohibition`] sets the `prohibited` / `deny_triple` fields
+/// ([OPUS-4.8] sq-w693); [`materialize_policy`] may set both at once (a policy with a
+/// permission AND a prohibition for the request — the deny wins at enforcement time).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct BridgeOutcome {
-    /// Whether the ODRL evaluation was a definite Permit AND produced a grant.
-    /// `false` ⇒ nothing was written to the AUTH_GRAPH (fail-closed).
+    /// Whether a definite Permit produced an allow grant.
+    /// `false` ⇒ no allow triple was written to the AUTH_GRAPH (fail-closed).
     pub granted: bool,
-    /// On a grant: the WAC/ACP mode the matched ODRL action mapped to.
+    /// Whether a matched Prohibition produced a DENY. `false` ⇒ no `auth:deny*`
+    /// triple was written (fail-closed). [OPUS-4.8] sq-w693.
+    pub prohibited: bool,
+    /// On a grant: the WAC/ACP mode the matched ODRL action mapped to. On a deny:
+    /// the mode the prohibited action mapped to (`deny_triple`'s mode).
     pub mode: Option<Mode>,
     /// On a grant: the materialized `principal auth:<mode> graph` triple, as
     /// `(principal_iri, mode_predicate_iri, graph_iri)`, for audit/justification.
     pub grant_triple: Option<(String, String, String)>,
-    /// Human-readable reason a grant was NOT materialized (the ODRL decision's
-    /// caveats, an unmapped action, or a missing party/target). Empty on a grant.
+    /// On a deny: the materialized `principal auth:deny<Mode> graph` triple, as
+    /// `(principal_iri, deny_predicate_iri, graph_iri)`. [OPUS-4.8] sq-w693.
+    pub deny_triple: Option<(String, String, String)>,
+    /// Human-readable reason a grant/deny was NOT materialized (the ODRL decision's
+    /// caveats, an unmapped action, or a missing party/target). Empty on success.
     pub reasons: Vec<String>,
 }
 
 impl BridgeOutcome {
     fn denied(reasons: Vec<String>) -> BridgeOutcome {
-        BridgeOutcome { granted: false, mode: None, grant_triple: None, reasons }
+        BridgeOutcome { reasons, ..BridgeOutcome::default() }
     }
 }
 
@@ -223,7 +275,151 @@ pub fn materialize_permission(
         granted: true,
         mode: Some(mode),
         grant_triple: Some((party.to_owned(), pred, target.to_owned())),
-        reasons: Vec::new(),
+        ..BridgeOutcome::default()
+    }
+}
+
+/// Evaluate `policy`'s **prohibitions** against `request` and, **iff** a prohibition
+/// matches (carves the request out — action permits + target/assignee agree +
+/// constraints satisfied) for a mappable action with a concrete party + target,
+/// materialize the equivalent `principal auth:deny<Mode> graph` DENY triple into the
+/// dataset's `<urn:sparq:auth>` view. [OPUS-4.8] sq-w693.
+///
+/// The deny is **appended** to the current auth view (any grants/denies already there
+/// are preserved). Because the session layer computes `∪ allow ∖ ∪ deny`
+/// ([`crate::AuthIndex::accessible`]), this materialized deny **takes precedence over
+/// any allow grant** for the same principal+target+mode — *deny-overrides*. The deny
+/// path is honoured by the EXISTING enforcement unchanged ([`crate::Mode`]'s
+/// `from_pred` already parses `auth:deny*`); this function only emits the triple.
+///
+/// Whether a prohibition carves THIS request out is decided by
+/// [`sparq_policy::matched_prohibition`] — the same match test the ODRL evaluator
+/// applies in its conflict step — NOT by `evaluate(...).allow == false`, which would
+/// conflate a carve-out with a plain no-matching-permission deny.
+///
+/// # Fail-closed
+///
+/// Returns a [`BridgeOutcome`] with `prohibited == false` and writes **nothing** when:
+/// no prohibition matches the request; the requested action does not [`action_to_mode`]
+/// -map; or the request omits the party (assignee/WebID) or the target graph IRI.
+/// A deny is never widened on ambiguity, and an unmappable carve-out is reported (not
+/// silently dropped — dropping a deny would widen access).
+///
+/// # Examples
+///
+/// ```
+/// use oxrdf::Term;
+/// use sparq_solid::odrl_bridge::materialize_prohibition;
+/// use sparq_solid::Mode;
+/// use sparq_policy::{parse_policy_str, Request};
+///
+/// // alice is PROHIBITED from writing the target graph.
+/// let pol = parse_policy_str(r#"
+/// @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+/// <urn:pol/1> a odrl:Set ; odrl:prohibition [
+///     odrl:action odrl:modify ;
+///     odrl:target <https://pod.ex/notes/n1> ;
+///     odrl:assignee <https://alice.ex/card#me> ] .
+/// "#, "turtle")?;
+///
+/// let mut graph = sparq_core::Graph::load_dataset(
+///     "<https://pod.ex/notes/n1#it> <https://ex.dev/ns#t> \"x\" <https://pod.ex/notes/n1> .",
+///     "nquads")?;
+/// let req = Request::new("http://www.w3.org/ns/odrl/2/modify")
+///     .on("https://pod.ex/notes/n1")
+///     .by("https://alice.ex/card#me");
+///
+/// let out = materialize_prohibition(&mut graph, &pol, &req);
+/// assert!(out.prohibited);
+/// assert_eq!(out.mode, Some(Mode::Write));
+/// // an explicit auth:denyWrite triple now lives in the auth view
+/// assert!(graph.named.iter().any(|(name, _)| matches!(
+///     name, Term::NamedNode(n) if n.as_str() == sparq_solid::AUTH_GRAPH)));
+/// # Ok::<(), String>(())
+/// ```
+pub fn materialize_prohibition(
+    graph: &mut Graph,
+    policy: &Policy,
+    request: &Request,
+) -> BridgeOutcome {
+    // 1. Does a prohibition CARVE THIS REQUEST OUT? (Same match test the evaluator's
+    //    conflict step uses — not `!decision.allow`, which over-fires on a plain
+    //    no-permission deny.)
+    if matched_prohibition(policy, request).is_none() {
+        return BridgeOutcome::denied(vec![
+            "no ODRL prohibition matches the request; no deny materialized".to_owned(),
+        ]);
+    }
+
+    // 2. Action → Mode. An unmapped action (incl. the `use` umbrella) → no deny.
+    //    Fail-closed: we do NOT widen the deny to a default mode, but we also must
+    //    not silently drop it — the carve-out is reported in `reasons`.
+    let Some(mode) = action_to_mode(&request.action) else {
+        return BridgeOutcome::denied(vec![format!(
+            "ODRL prohibition matched but action <{}> has no WAC/ACP mode mapping; \
+             no deny materialized",
+            request.action
+        )]);
+    };
+
+    // 3. Concrete party (WebID) + target graph required (fail-closed): a partyless
+    //    deny would be meaningless / a targetless deny ambiguous.
+    let Some(party) = request.party.as_deref() else {
+        return BridgeOutcome::denied(vec![
+            "ODRL prohibition has no concrete party (assignee/WebID); no deny materialized"
+                .to_owned(),
+        ]);
+    };
+    let Some(target) = request.target.as_deref() else {
+        return BridgeOutcome::denied(vec![
+            "ODRL prohibition has no concrete target graph IRI; no deny materialized".to_owned(),
+        ]);
+    };
+
+    // 4. Materialize `party auth:deny<Mode> target` into the auth view.
+    let pred = format!("{AUTH_NS}{}", deny_predicate(mode));
+    append_grant(graph, party, &pred, target);
+
+    BridgeOutcome {
+        prohibited: true,
+        mode: Some(mode),
+        deny_triple: Some((party.to_owned(), pred, target.to_owned())),
+        ..BridgeOutcome::default()
+    }
+}
+
+/// Materialize **both** sides of `policy` for `request`: the Permit allow grant (via
+/// [`materialize_permission`]) AND the matched-Prohibition deny (via
+/// [`materialize_prohibition`]), composing them into one [`BridgeOutcome`].
+/// [OPUS-4.8] sq-w693.
+///
+/// A policy carrying both a permission and a prohibition for the same
+/// principal+target+mode materializes **both** triples. The deny **wins** at
+/// enforcement time — the session layer subtracts `∪ deny` from `∪ allow`
+/// ([`crate::AuthIndex::accessible`]), so *deny-overrides* falls out of the existing
+/// enforcement without any conflict logic here. Each side is independently
+/// fail-closed: a side that does not produce a definite, mappable, concrete result
+/// materializes nothing for that side.
+///
+/// The returned outcome carries `granted`/`grant_triple` from the Permit side and
+/// `prohibited`/`deny_triple` from the Prohibition side; `mode` reflects the deny
+/// mode when a deny was materialized (the operative decision under deny-overrides),
+/// else the grant mode; `reasons` aggregates the caveats of whichever side(s) did not
+/// materialize.
+pub fn materialize_policy(graph: &mut Graph, policy: &Policy, request: &Request) -> BridgeOutcome {
+    let allow = materialize_permission(graph, policy, request);
+    let deny = materialize_prohibition(graph, policy, request);
+
+    let mut reasons = allow.reasons;
+    reasons.extend(deny.reasons);
+    BridgeOutcome {
+        granted: allow.granted,
+        prohibited: deny.prohibited,
+        // Under deny-overrides the deny is the operative decision when present.
+        mode: deny.mode.or(allow.mode),
+        grant_triple: allow.grant_triple,
+        deny_triple: deny.deny_triple,
+        reasons,
     }
 }
 

--- a/crates/sparq-solid/tests/odrl_bridge.rs
+++ b/crates/sparq-solid/tests/odrl_bridge.rs
@@ -10,7 +10,10 @@
 
 use sparq_core::Graph;
 use sparq_policy::{parse_policy_str, Request, Value};
-use sparq_solid::{action_to_mode, materialize_permission, Mode, PodStore, Session};
+use sparq_solid::{
+    action_to_mode, materialize_permission, materialize_policy, materialize_prohibition, Mode,
+    PodStore, Session,
+};
 
 const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
 const ALICE: &str = "https://alice.ex/card#me";
@@ -267,4 +270,220 @@ fn bridge_preserves_existing_wac_grants() {
     // BOTH grants hold: bob (static WAC) AND alice (bridged ODRL).
     assert!(reads_n1(&mut store, "https://bob.ex/card#me"), "bob preserved");
     assert!(reads_n1(&mut store, ALICE), "alice bridged");
+}
+
+// ===========================================================================
+// [OPUS-4.8] sq-w693 — Prohibition → explicit auth:deny<Mode> (deny-overrides).
+// ===========================================================================
+
+/// alice is PROHIBITED from writing n1 (a bare matching prohibition, no constraints).
+fn write_prohibition() -> sparq_policy::Policy {
+    parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/prohib> a odrl:Set ; odrl:prohibition [
+    odrl:action odrl:modify ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ] .
+"#,
+        "turtle",
+    )
+    .expect("policy parses")
+}
+
+// ---------------------------------------------------------------------------
+// 9. A matched Prohibition materializes the expected auth:deny<Mode> triple.
+// ---------------------------------------------------------------------------
+#[test]
+fn prohibition_materializes_deny_triple() {
+    let mut g = pod();
+    let req = Request::new(odrl("modify")).on(N1).by(ALICE);
+    let out = materialize_prohibition(&mut g, &write_prohibition(), &req);
+
+    assert!(out.prohibited, "matched Prohibition should deny: {out:?}");
+    assert!(!out.granted, "a prohibition is not a grant");
+    assert_eq!(out.mode, Some(Mode::Write));
+    assert_eq!(
+        out.deny_triple,
+        Some((ALICE.to_owned(), "https://sparq.dev/ns/auth#denyWrite".to_owned(), N1.to_owned())),
+    );
+
+    // The deny is a real triple in the <urn:sparq:auth> view, readable as such.
+    let q = "SELECT ?who WHERE { GRAPH <urn:sparq:auth> { \
+        ?who <https://sparq.dev/ns/auth#denyWrite> <https://pod.ex/notes/n1> } }";
+    let rows = sparq_engine::query(&g, q).expect("query");
+    assert_eq!(rows.rows.len(), 1, "exactly alice's denyWrite");
+}
+
+// ---------------------------------------------------------------------------
+// 10. DENY-OVERRIDES through the REAL enforcement path: a principal with BOTH an
+//     allow grant AND a deny for the same mode is DENIED (deny beats allow).
+// ---------------------------------------------------------------------------
+#[test]
+fn deny_overrides_allow_through_enforcement() {
+    let mut store = PodStore::new(pod());
+
+    // First grant alice WRITE on n1 (an ODRL Permit → auth:write).
+    let permit = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/w> a odrl:Set ; odrl:permission [
+    odrl:action odrl:modify ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let wreq = Request::new(odrl("modify")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_permission(&permit, &wreq).granted);
+
+    let alice = Session { agent: Some(ALICE), client: None };
+    // Sanity: the allow grant is live through the real enforcement path.
+    assert!(
+        store.accessible(&alice, Mode::Write).iter().any(|g| g.as_str() == N1),
+        "alice can write n1 BEFORE the deny is materialized",
+    );
+
+    // Now materialize the matching Prohibition (auth:denyWrite for the same mode).
+    let dreq = Request::new(odrl("modify")).on(N1).by(ALICE);
+    let out = store.materialize_odrl_prohibition(&write_prohibition(), &dreq);
+    assert!(out.prohibited, "deny materialized: {out:?}");
+
+    // DENY-OVERRIDES: alice is now DENIED write through the real enforcement path,
+    // even though the allow grant is still present in the auth view.
+    assert!(
+        store.accessible(&alice, Mode::Write).is_empty(),
+        "deny beats allow: alice can no longer write n1",
+    );
+    // And the write-path update enforcement honours it too (fail-closed).
+    let ins = "INSERT DATA { GRAPH <https://pod.ex/notes/n1> { \
+        <https://pod.ex/notes/n1#it> <https://ex.dev/ns#tag> \"x\" } }";
+    assert!(store.update_as(&alice, ins).is_err(), "denied write update fails closed");
+}
+
+// ---------------------------------------------------------------------------
+// 11. A single policy with BOTH a permission and a prohibition on the same
+//     principal/target/mode → materialize both → DENIED (deny wins).
+// ---------------------------------------------------------------------------
+#[test]
+fn permit_plus_prohibition_same_subject_is_denied() {
+    let pol = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/both> a odrl:Set ;
+    odrl:permission [
+        odrl:action odrl:modify ;
+        odrl:target <https://pod.ex/notes/n1> ;
+        odrl:assignee <https://alice.ex/card#me> ] ;
+    odrl:prohibition [
+        odrl:action odrl:modify ;
+        odrl:target <https://pod.ex/notes/n1> ;
+        odrl:assignee <https://alice.ex/card#me> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+
+    let mut store = PodStore::new(pod());
+    let req = Request::new(odrl("modify")).on(N1).by(ALICE);
+    let out = store.materialize_odrl_policy(&pol, &req);
+
+    // The prohibition side materializes a deny. The permit side does NOT: the ODRL
+    // evaluator ALREADY applies deny-overrides (a matching prohibition overrides any
+    // permission), so `evaluate(...).allow == false` and no allow grant is emitted —
+    // deny-overrides holds even more strongly (the allow is never written at all).
+    assert!(!out.granted, "the permit is overridden by the prohibition (evaluator): {out:?}");
+    assert!(out.prohibited, "the prohibition side materialized: {out:?}");
+    assert_eq!(out.mode, Some(Mode::Write), "deny mode is operative under deny-overrides");
+    assert!(out.deny_triple.is_some());
+
+    // Net effect through the real enforcement: alice is DENIED.
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert!(
+        store.accessible(&alice, Mode::Write).is_empty(),
+        "deny-overrides: a permission + prohibition on the same subject denies",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 12. No matching prohibition (wrong party / different mode / unmapped / partyless /
+//     targetless) → materialize NOTHING (fail-closed; access never silently widened).
+// ---------------------------------------------------------------------------
+#[test]
+fn unmatched_prohibition_materializes_nothing() {
+    // (a) Wrong party — the prohibition names alice; mallory isn't carved out.
+    let mut g = pod();
+    let wrong_party = Request::new(odrl("modify")).on(N1).by("https://mallory.ex/card#me");
+    let out = materialize_prohibition(&mut g, &write_prohibition(), &wrong_party);
+    assert!(!out.prohibited, "wrong party is not carved out: {out:?}");
+    assert!(out.deny_triple.is_none());
+
+    // (b) Different action/mode — the prohibition forbids modify (Write); a read
+    //     request matches no prohibition, so no deny is materialized.
+    let mut g2 = pod();
+    let read_req = Request::new(odrl("read")).on(N1).by(ALICE);
+    assert!(!materialize_prohibition(&mut g2, &write_prohibition(), &read_req).prohibited);
+
+    // (c) Unmapped action — a prohibition on the `use` umbrella matches a `use`
+    //     request, but `use` has no faithful single mode → materialize nothing, and
+    //     SAY SO (a dropped deny would widen access).
+    let use_prohib = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/u> a odrl:Set ; odrl:prohibition [
+    odrl:action odrl:use ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let mut g3 = pod();
+    let use_req = Request::new(odrl("use")).on(N1).by(ALICE);
+    let out3 = materialize_prohibition(&mut g3, &use_prohib, &use_req);
+    assert!(!out3.prohibited, "unmapped umbrella deny not materialized: {out3:?}");
+    assert!(!out3.reasons.is_empty(), "the unmappable carve-out is reported, not silent");
+
+    // (d) Partyless prohibition (no assignee) matched by a partyless request → nothing
+    //     (a deny with no concrete principal is meaningless here).
+    let any_prohib = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/anyp> a odrl:Set ; odrl:prohibition [ odrl:action odrl:modify ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let mut g4 = pod();
+    let no_party = Request::new(odrl("modify")).on(N1);
+    assert!(!materialize_prohibition(&mut g4, &any_prohib, &no_party).prohibited);
+
+    // (e) Targetless request → nothing.
+    let mut g5 = pod();
+    let no_target = Request::new(odrl("modify")).by(ALICE);
+    assert!(!materialize_prohibition(&mut g5, &any_prohib, &no_target).prohibited);
+}
+
+// ---------------------------------------------------------------------------
+// 13. Regression: the Permit-only path still works unchanged via materialize_policy
+//     (a policy with no prohibition grants exactly as before, no deny emitted).
+// ---------------------------------------------------------------------------
+#[test]
+fn permit_only_regression_via_policy() {
+    let mut g = pod();
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    let out = materialize_policy(&mut g, &read_policy(), &req);
+
+    assert!(out.granted, "permit-only still grants: {out:?}");
+    assert!(!out.prohibited, "no prohibition → no deny");
+    assert_eq!(out.mode, Some(Mode::Read));
+    assert!(out.deny_triple.is_none());
+    assert!(out.grant_triple.is_some());
+
+    // End-to-end through the enforcement path: alice reads, deny absent.
+    let mut store = PodStore::new(pod());
+    assert!(store.materialize_odrl_policy(&read_policy(), &req).granted);
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert!(store.accessible(&alice, Mode::Read).iter().any(|g| g.as_str() == N1));
 }

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -100,6 +100,11 @@ Materialize the authorization view from the access-control documents, then enfor
   graph` grant into the auth view, then reindex — so this same enforcement path applies it.
   Fail-closed (Deny / unmapped action / partyless / targetless → no grant). See the
   [`usage-control-policy`](../usage-control-policy/SKILL.md) skill for the action→mode mapping.
+- `store.materialize_odrl_prohibition(&Policy, &Request)` / `materialize_odrl_policy(...)` —
+  same opt-in feature ([OPUS-4.8] sq-w693): a matched ODRL **Prohibition** materializes the dual
+  `principal auth:deny<Mode> graph` triple, honoured by this enforcement under **deny-overrides**
+  (`∪ allow ∖ ∪ deny` — a deny beats any allow for the same principal+target+mode). `…_policy`
+  does both sides at once. Same fail-closed rules; no new enforcement engine.
 - `Session { agent: Option<&str>, client: Option<&str> }` (caller-asserted WebID +
   `acl:origin`/`acp:client`; `None` = anonymous / any client); `Mode::{Read, Write,
   Append, Control}`; `wac_fixture()` / `acp_fixture()` (bundled demo pods).

--- a/skills/usage-control-policy/SKILL.md
+++ b/skills/usage-control-policy/SKILL.md
@@ -97,6 +97,24 @@ assert!(!store.accessible(&Session { agent: Some("https://alice.ex/card#me"), cl
 
 **Fail-closed:** a grant is materialized only on a *definite Permit* AND a *mappable action* AND a *concrete party (WebID) + target graph*. A Deny, unsatisfied constraint, undischarged duty, unmapped action, or partyless/targetless request materializes **nothing**.
 
+### Prohibitions → explicit `auth:deny*` (deny-overrides) — [OPUS-4.8] sq-w693
+
+A matched ODRL **Prohibition** is materialized as the dual triple — `principal auth:deny<Mode> target` — via `materialize_odrl_prohibition` (or `materialize_odrl_policy`, which does both sides at once). The **same** action→mode mapping picks the mode, so the deny predicate is `auth:denyRead` / `auth:denyWrite` / `auth:denyAppend` / `auth:denyControl`.
+
+```rust,ignore
+// Prohibition side: appends `alice auth:denyWrite n1`, then reindexes.
+let dreq = Request::new("http://www.w3.org/ns/odrl/2/modify")
+    .on("https://pod.ex/notes/n1").by("https://alice.ex/card#me");
+let out = store.materialize_odrl_prohibition(&policy, &dreq);
+assert!(out.prohibited);
+// Both sides of a policy at once (permit grant + matched-prohibition deny):
+let out = store.materialize_odrl_policy(&policy, &req);
+```
+
+**Deny-overrides:** the deny is honoured by the **existing, unchanged** enforcement — the session layer already computes `∪ allow ∖ ∪ deny` (`AuthIndex::accessible`) and `Mode::from_pred` already parses `auth:deny*`, so a materialized deny **beats any allow grant** for the same principal+target+mode. No new enforcement engine; the bridge only emits the triple. (Within one policy the ODRL evaluator *also* applies deny-overrides upstream, so the permit allow triple is never even emitted when a prohibition carves the request out.)
+
+**Fail-closed (deny):** a deny is materialized only when a prohibition **matches** the request (decided by `sparq_policy::matched_prohibition` — the evaluator's own conflict test, *not* `Decision.allow == false`, which conflates a carve-out with a plain no-permission deny) AND the action is mappable AND the party+target are concrete. An unmatched / unmapped / partyless / targetless prohibition materializes **nothing** — and an unmappable carve-out is *reported* in `reasons`, never silently dropped (dropping a deny would widen access).
+
 ## Learn more
 
 - Crate README: [`crates/sparq-policy/README.md`](../../crates/sparq-policy/README.md)


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing **sq-w693** (epic **sq-3183**), extending the ODRL→AUTH_GRAPH bridge from **sq-h3uk / #280** (just merged).

## What

A matched ODRL **Prohibition** now materializes an explicit `auth:deny<Mode>` triple (`denyRead`/`denyWrite`/`denyAppend`/`denyControl`) for the carved-out principal+target, via the **same** action→mode mapping the Permit path uses. So an ODRL carve-out becomes a concrete WAC/ACP deny honoured by the existing enforcement.

## Deny-overrides — already enforced, NOT new

The existing enforcement **already honoured** `auth:deny*` with deny-overrides semantics — verified, did not add it:
- `Mode::from_pred` already parses `denyRead/denyWrite/denyAppend/denyControl` into the deny map.
- `AuthIndex::accessible` already computes `∪ allow ∖ ∪ deny`.

So a materialized deny **beats any allow grant** for the same principal+target+mode. **No new enforcement engine** — the bridge only emits the triple; the unchanged session layer applies deny-beats-allow.

## Carve-out detection (not `allow == false`)

Whether a prohibition carves *this* request out is decided by the new public `sparq_policy::matched_prohibition` — the evaluator's own conflict test — **not** by `Decision.allow == false`, which conflates a real carve-out with a plain no-matching-permission deny (only the former should emit a deny).

## Fail-closed

A deny is materialized **only** on a *matched* prohibition AND a *mappable* action AND a *concrete party (WebID) + target graph*. Unmatched / unmapped (incl. `odrl:use` umbrella) / partyless / targetless → **nothing**. An unmappable carve-out is *reported* in `reasons`, never silently dropped (dropping a deny would widen access).

## Composition

`materialize_policy` / `PodStore::materialize_odrl_policy` materialize both sides at once. Within one policy the ODRL evaluator *also* applies deny-overrides upstream (the would-be Permit returns `allow == false`), so the allow triple isn't even emitted when a prohibition carves the request out — deny-overrides holds even more strongly.

## API (behind off-by-default `odrl-bridge` feature)

- `sparq_policy::matched_prohibition(&Policy, &Request) -> Option<&Rule>`
- `sparq_solid::{materialize_prohibition, materialize_policy}`
- `PodStore::{materialize_odrl_prohibition, materialize_odrl_policy}`
- `BridgeOutcome` gains `prohibited` + `deny_triple`

## Tests (all new, feature ON)

- matched Prohibition materializes the expected `auth:deny<Mode>` triple
- **deny-overrides through the REAL enforcement path** (`accessible` + `update_as`): a principal with a live allow grant AND a deny for the same mode is **DENIED**
- permit + prohibition on the same principal/target → denied
- unmatched / unmapped / partyless / targetless prohibition → nothing
- Permit-only regression via `materialize_policy`

## Gates

`cargo build` / `cargo test -p sparq-solid` / `cargo clippy --all-targets -- -D warnings` — clean **feature OFF and ON**; doctests pass; `sparq-policy` tests + doctests pass. Docs updated: `usage-control-policy` + `access-control` SKILL.md, `sparq-solid` + `sparq-policy` README (deny-overrides + action→deny-mode mapping). NON-CANONICAL timing (work-box EC2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
