### PR TITLE
feat(sparq-solid): map ODRL constraints to ACP conditional grants (sq-hiz4)

### DIFF
--- a/crates/sparq-policy/README.md
+++ b/crates/sparq-policy/README.md
@@ -90,6 +90,15 @@ lexical form; mixed-offset normalization, DPV `purpose` hierarchies, and
 `Duty → proof-manifest` discharge are tracked as follow-on beads. See
 `research/feature-research-odrl-policy.md`.
 
+**Constraint persistence vs. one-shot** (sq-hiz4, in `sparq-solid`'s opt-in bridge):
+`materialize_odrl_permission_conditional` persists a `odrl:recipient`/`odrl:assignee`
+constraint (`eq`/`isA`/`isPartOf`) as a **re-checked** ACP `auth:ConditionalGrant`
+(agent matcher) — the only constraint with a faithful stateless `(agent, client)`
+analogue. `odrl:purpose`/`dateTime`/`count` have none and stay **one-shot** (checked
+once at materialization). Mapping table: the
+[`usage-control-policy`](../../skills/usage-control-policy/SKILL.md) skill +
+[`sparq-solid` README](../sparq-solid/README.md).
+
 ## 📚 Learn more
 
 - Skill: [`skills/usage-control-policy/SKILL.md`](../../skills/usage-control-policy/SKILL.md)

--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -55,7 +55,9 @@ let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len(
   the equivalent WAC/ACP grant into the auth view — so the existing graph-level enforcement
   honours it with **no new enforcement engine**. A matched **Prohibition** materializes the dual
   `auth:deny*` triple (`materialize_prohibition` / `materialize_policy`), and the existing
-  enforcement applies **deny-overrides** ([OPUS-4.8] sq-w693). See below.
+  enforcement applies **deny-overrides** ([OPUS-4.8] sq-w693). `materialize_odrl_permission_conditional`
+  (sq-hiz4) persists a faithfully-mappable recipient/assignee constraint as a **re-checked**
+  ACP `auth:ConditionalGrant` instead of a one-shot allow. See below.
 
 ## ODRL → AUTH_GRAPH bridge (opt-in `odrl-bridge` feature) — [OPUS-4.8] sq-h3uk
 
@@ -114,6 +116,36 @@ the request out.)
 action is mappable *and* the party+target are concrete. An unmatched / unmapped / partyless /
 targetless prohibition materializes **nothing**; an unmappable carve-out is *reported* in
 `reasons`, never silently dropped (dropping a deny would widen access).
+
+### Constraint → ACP **conditional** grant (`materialize_odrl_permission_conditional`) — [OPUS-4.8] sq-hiz4
+
+The one-shot `materialize_odrl_permission` *freezes* every constraint into a single allow
+scoped to the supplied request party. `materialize_odrl_permission_conditional` persists a
+**faithfully-mappable** constraint as an ACP `auth:ConditionalGrant` (the existing `noneOf`
+machinery) so the granted agent is **re-checked per session** through the unchanged
+enforcement path — not by re-running the ODRL evaluator. Constraints with no faithful ACP
+analogue keep the one-shot behaviour.
+
+| ODRL constraint | Operator | Maps to | Behaviour |
+|---|---|---|---|
+| `odrl:recipient` / `odrl:assignee` | `eq` / `isA` | `auth:agent <webid>` (agent matcher) | **re-checked condition** |
+| `odrl:recipient` / `odrl:assignee` | `isPartOf` | one `auth:agent` head per set member | **re-checked condition** |
+| `odrl:recipient` / `odrl:assignee` | `neq` / order | — (needs per-session `noneOf`) | one-shot (frozen) |
+| `odrl:purpose` | any | — (ACP session has no purpose) | one-shot (frozen) |
+| `odrl:dateTime` / time window | any | — (ACP has no "now") | one-shot (frozen) |
+| `odrl:count` | any | — (ACP is stateless) | one-shot (frozen) |
+| *no constraint* | — | `auth:agent auth:Public` | re-checked (public) |
+
+**Why only recipient/assignee:** the ACP session re-check carries exactly `(agent, client)`,
+and the recipient-of-data *is* the session agent — so an agent matcher re-checks it with
+identical semantics. Purpose/time/count have no stateless `(agent, client)` analogue, so
+persisting them would require a looser approximation that could over-grant — rejected.
+
+**Fail-safe on mixed constraints:** a condition is persisted **only** when *every* constraint
+on the rule maps faithfully. A rule mixing a mappable recipient with an unmappable
+`dateTime`/`purpose`/`count` falls back **entirely** to the one-shot path — persisting only
+the recipient would silently drop the other bound and over-grant. Reserved-encoded recipient
+IRIs are dropped from the grant head (anti-impersonation).
 
 ## Security posture — fail-closed
 

--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -17,8 +17,8 @@ pub use fixture::{acp_fixture, wac_fixture};
 pub use materialize::{materialize_acp, materialize_wac, MaterializeStats};
 #[cfg(feature = "odrl-bridge")]
 pub use odrl_bridge::{
-    action_to_mode, materialize_permission, materialize_policy, materialize_prohibition,
-    BridgeOutcome,
+    action_to_mode, materialize_permission, materialize_permission_conditional, materialize_policy,
+    materialize_prohibition, BridgeOutcome,
 };
 pub use rewrite::{rewrite_for, wrap_for_view};
 
@@ -504,6 +504,32 @@ impl PodStore {
         let outcome = odrl_bridge::materialize_policy(&mut self.graph, policy, request);
         if outcome.granted || outcome.prohibited {
             self.reindex(); // a new grant/deny changes the auth view → rebuild + drop cache
+        }
+        outcome
+    }
+
+    /// [OPUS-4.8] sq-hiz4 — like [`PodStore::materialize_odrl_permission`], but persists a
+    /// FAITHFULLY-mappable ODRL constraint (recipient/assignee) as a re-checked ACP
+    /// `auth:ConditionalGrant` rather than freezing it into a one-shot allow: the
+    /// granted agent is re-verified per session through the SAME enforcement path
+    /// ([`PodStore::accessible`] / [`PodStore::query_as`]), not re-running the ODRL
+    /// evaluator.
+    ///
+    /// A constraint with **no** faithful ACP-condition analogue (`odrl:purpose`,
+    /// `odrl:dateTime`/time windows, `odrl:count`, a `neq`/order recipient) keeps the
+    /// one-shot materialization-time behaviour (checked once, frozen) — see
+    /// [`odrl_bridge::materialize_permission_conditional`] for the full mapping table
+    /// and the fail-closed rationale.
+    #[cfg(feature = "odrl-bridge")]
+    pub fn materialize_odrl_permission_conditional(
+        &mut self,
+        policy: &sparq_policy::Policy,
+        request: &sparq_policy::Request,
+    ) -> odrl_bridge::BridgeOutcome {
+        let outcome =
+            odrl_bridge::materialize_permission_conditional(&mut self.graph, policy, request);
+        if outcome.granted {
+            self.reindex(); // a new (conditional) grant changes the auth view → rebuild
         }
         outcome
     }

--- a/crates/sparq-solid/src/odrl_bridge.rs
+++ b/crates/sparq-solid/src/odrl_bridge.rs
@@ -75,12 +75,12 @@
 //! a permission and a prohibition on the same principal+target+mode emits both triples,
 //! and the deny **wins** at enforcement time.
 
-use crate::authindex::Mode;
+use crate::authindex::{Mode, AUTHENTICATED, PUBLIC};
 use crate::{AUTH_GRAPH, AUTH_NS};
 use oxrdf::{NamedNode, Term};
 use sparq_core::dict::Dict;
 use sparq_core::Graph;
-use sparq_policy::{evaluate, matched_prohibition, Policy, Request};
+use sparq_policy::{evaluate, matched_prohibition, Operator, Policy, Request, Rule, Value};
 
 /// The ODRL namespace prefix (`odrl:`), re-exported for caller convenience.
 pub const ODRL_NS: &str = sparq_policy::ODRL_NS;
@@ -457,3 +457,343 @@ fn append_grant(graph: &mut Graph, subject: &str, predicate: &str, object: &str)
         graph.named.push((auth_name, auth));
     }
 }
+
+// ============================================================================
+// [OPUS-4.8] sq-hiz4 — persist a FAITHFULLY-mappable ODRL constraint as an ACP
+// re-checked condition (`auth:ConditionalGrant`) instead of freezing it into a
+// one-shot materialization-time allow.
+// ============================================================================
+
+/// The `acl:` mode IRI a [`Mode`] is written as on a conditional grant's
+/// `auth:mode` (the form [`crate::AuthIndex`] reads via `from_mode_iri`).
+fn mode_iri(mode: Mode) -> &'static str {
+    match mode {
+        Mode::Read => "http://www.w3.org/ns/auth/acl#Read",
+        Mode::Write => "http://www.w3.org/ns/auth/acl#Write",
+        Mode::Append => "http://www.w3.org/ns/auth/acl#Append",
+        Mode::Control => "http://www.w3.org/ns/auth/acl#Control",
+    }
+}
+
+/// The ODRL `recipient` constraint left-operand IRI.
+const ODRL_RECIPIENT: &str = "http://www.w3.org/ns/odrl/2/recipient";
+/// The ODRL `assignee` constraint left-operand IRI (the party as a *constraint*,
+/// distinct from the `odrl:assignee` rule attribute the evaluator already matches).
+const ODRL_ASSIGNEE: &str = "http://www.w3.org/ns/odrl/2/assignee";
+
+/// What [`map_constraints_to_agents`] concluded about a permission's constraints.
+enum AgentMapping {
+    /// Every constraint maps faithfully to an agent-dimension matcher; persist a
+    /// `ConditionalGrant` whose `auth:agent` re-checks each of these principals.
+    /// Empty ⇒ no agent restriction (the grant applies to `auth:Public`).
+    Faithful(Vec<String>),
+    /// At least one constraint has NO faithful ACP-condition analogue (purpose /
+    /// dateTime window / count): the rule MUST stay one-shot (fail-closed — never
+    /// approximate an unmappable constraint with a looser persisted condition).
+    Unmappable,
+}
+
+/// Inspect a matched permission's constraints and decide whether the WHOLE rule can
+/// be persisted as re-checked ACP agent conditions.
+///
+/// **Faithful (→ agent matcher):** an `odrl:recipient`/`odrl:assignee` constraint
+/// under `eq`/`isA` (the recipient IS this principal) or `isPartOf` (the recipient is
+/// a member of a static principal set). The recipient-of-data is exactly the session
+/// agent the ACP `auth:agent` head re-checks, so the persisted condition has the SAME
+/// semantics — it just re-evaluates per session instead of being frozen.
+///
+/// **Unmappable (→ stay one-shot):** `odrl:purpose` (ACP sessions carry no purpose —
+/// a client app is not a purpose-of-use, so mapping it to a client matcher would
+/// over-grant), `odrl:dateTime`/time windows (ACP has no "now" dimension — matcher
+/// accept-sets are static, so a persisted condition could not re-check the clock),
+/// `odrl:count` (ACP is stateless — no usage counter), and any unrecognised
+/// left-operand. A `neq` recipient (everyone EXCEPT one) has no faithful single-grant
+/// analogue either (it would need a `noneOf` exception matcher built per session) and
+/// is treated as unmappable. Any one such constraint forces the whole rule one-shot.
+fn map_constraints_to_agents(rule: &Rule) -> AgentMapping {
+    let mut agents: Vec<String> = Vec::new();
+    for c in &rule.constraints {
+        if c.left != ODRL_RECIPIENT && c.left != ODRL_ASSIGNEE {
+            // purpose / dateTime / count / anything else → no faithful condition.
+            return AgentMapping::Unmappable;
+        }
+        match c.operator {
+            // recipient IS this principal (identity) → one agent matcher.
+            Operator::Eq | Operator::IsA => match &c.right {
+                Value::Iri(s) | Value::Str(s) => agents.push(s.clone()),
+                // a numeric/dateTime recipient is malformed → fail-closed.
+                _ => return AgentMapping::Unmappable,
+            },
+            // recipient ∈ {a|b|c} (static set) → one agent matcher per member.
+            Operator::IsPartOf => {
+                let members: Vec<String> = c
+                    .right
+                    .as_str()
+                    .split(['|', ' ', ','])
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_owned)
+                    .collect();
+                if members.is_empty() {
+                    return AgentMapping::Unmappable;
+                }
+                agents.extend(members);
+            }
+            // `neq`/order operators on a recipient have no faithful single-grant ACP
+            // analogue (an "everyone except" needs a per-session noneOf) → one-shot.
+            _ => return AgentMapping::Unmappable,
+        }
+    }
+    AgentMapping::Faithful(agents)
+}
+
+/// Whether a recipient principal IRI is safe to write as an `auth:agent` head: it
+/// must NOT smuggle the reserved pair encoding (`urn:sparq:` / `&client=`), or a
+/// crafted recipient could impersonate a minted pair principal (defense in depth,
+/// mirrors [`crate::loader::session_value_allowed`]). The session-layer check
+/// already rejects such SESSIONS; this also keeps them out of the GRANT head.
+fn recipient_principal_allowed(p: &str) -> bool {
+    crate::loader::session_value_allowed(p)
+}
+
+/// Evaluate `policy` against `request` and, for the matched permission, EITHER
+/// persist its recipient/assignee constraint as a re-checked ACP
+/// `auth:ConditionalGrant` (so the granted agent is verified per session through the
+/// real enforcement path) OR — when the permission carries a constraint with no
+/// faithful ACP-condition analogue — fall back to the one-shot
+/// [`materialize_permission`] (the constraint is checked once, at materialization).
+///
+/// # When a conditional grant is emitted (faithful)
+///
+/// All of the matched permission's constraints are `odrl:recipient`/`odrl:assignee`
+/// constraints under `eq`/`isA`/`isPartOf` (see [`map_constraints_to_agents`]). The
+/// emitted grant is:
+///
+/// ```text
+/// <grant> a auth:ConditionalGrant ; auth:effect auth:Allow ;
+///         auth:agent <recipient> ; auth:client auth:AnyClient ;
+///         auth:mode acl:<Mode> ; auth:graph <target> .
+/// ```
+///
+/// re-checked by [`crate::AuthIndex::accessible`]: a session whose agent is the
+/// recipient is granted; any other agent (or anonymous) is denied — **without**
+/// re-running the ODRL evaluator. A recipient *set* emits one grant per member (the
+/// auth view unions the allows). When the rule has NO recipient constraint, the grant
+/// head is `auth:Public` (any session) — only valid because the action/target/duties
+/// were already satisfied at materialization.
+///
+/// # Fail-closed
+///
+/// - A Deny (prohibition override, unmet *unmappable* constraint, undischarged duty)
+///   materializes **nothing** — exactly as the one-shot path.
+/// - An unmapped action, or a missing target, materializes nothing.
+/// - **Mixed constraints fail safe:** if ANY constraint is unmappable (`purpose`,
+///   `dateTime`, `count`, a `neq`/order recipient), the WHOLE rule falls back to the
+///   one-shot path so the unmappable bound is still enforced (frozen) — a persisted
+///   condition is emitted ONLY when every constraint maps faithfully.
+/// - A recipient IRI inside the reserved pair encoding is dropped from the grant head
+///   (it could otherwise impersonate a minted pair principal).
+///
+/// Returns a [`BridgeOutcome`]; on a conditional grant `grant_triple` reports the
+/// `(agent, auth:effect, graph)` of the FIRST emitted grant (audit anchor) and
+/// `mode` the mapped mode. The free-function form does not reindex a [`crate::PodStore`]
+/// — use [`crate::PodStore::materialize_odrl_permission_conditional`].
+pub fn materialize_permission_conditional(
+    graph: &mut Graph,
+    policy: &Policy,
+    request: &Request,
+) -> BridgeOutcome {
+    // 1. Action → Mode (shared with the one-shot path). Unmapped → no grant.
+    let Some(mode) = action_to_mode(&request.action) else {
+        return BridgeOutcome::denied(vec![format!(
+            "ODRL action <{}> has no WAC/ACP mode mapping; no grant materialized",
+            request.action
+        )]);
+    };
+
+    // 2. Find the permission whose action/target match AND whose duties are
+    //    discharged AND whose constraints map faithfully to agent conditions. The
+    //    recipient constraint is NOT required to hold against the request party here
+    //    — the persisted condition re-checks it per session. Prohibitions still
+    //    override (deny-overrides), so consult the evaluator's prohibition verdict.
+    if let Some(p) = matched_prohibition(policy, request) {
+        return BridgeOutcome::denied(vec![format!(
+            "prohibition {} matches the request (deny-overrides); no grant materialized",
+            p.id
+        )]);
+    }
+    let Some(target) = request.target.as_deref() else {
+        return BridgeOutcome::denied(vec![
+            "ODRL Permit has no concrete target graph IRI; no grant materialized".to_owned(),
+        ]);
+    };
+
+    let mut fallback_reasons: Vec<String> = Vec::new();
+    for rule in &policy.permissions {
+        // Action + target must agree (assignee/recipient are handled as conditions).
+        if !rule_action_target_match(rule, request, mode, target) {
+            continue;
+        }
+        // Duties must be discharged at materialization (no ACP analogue → one-shot
+        // semantics; an undischarged duty blocks this rule).
+        if rule.duties.iter().any(|d| !request.discharged_duties.contains(&d.action.0)) {
+            fallback_reasons.push(format!("permission {} has an undischarged duty", rule.id));
+            continue;
+        }
+        match map_constraints_to_agents(rule) {
+            AgentMapping::Faithful(recipients) => {
+                let agents = condition_agents(rule, &recipients);
+                if agents.is_empty() {
+                    // every recipient was reserved-encoded → fail-closed, nothing.
+                    fallback_reasons.push(format!(
+                        "permission {} recipients are all reserved-encoded; no grant",
+                        rule.id
+                    ));
+                    continue;
+                }
+                let first = append_conditional_grants(graph, &agents, mode, target);
+                return BridgeOutcome {
+                    granted: true,
+                    mode: Some(mode),
+                    grant_triple: Some(first),
+                    ..BridgeOutcome::default()
+                };
+            }
+            AgentMapping::Unmappable => {
+                // This permission carries a constraint with no faithful condition
+                // analogue → the one-shot path must check it (frozen) instead.
+                fallback_reasons.push(format!(
+                    "permission {} has a constraint with no faithful ACP condition; one-shot path",
+                    rule.id
+                ));
+            }
+        }
+    }
+
+    // 3. No faithfully-conditional permission applied → fall back to the EXISTING
+    //    one-shot behaviour (which evaluates the unmappable constraints against the
+    //    supplied request context and emits a frozen allow iff they hold).
+    let out = materialize_permission(graph, policy, request);
+    if !out.granted && out.reasons.is_empty() {
+        return BridgeOutcome::denied(fallback_reasons);
+    }
+    out
+}
+
+/// The principal-space `auth:agent` heads for a faithful recipient set, dropping any
+/// reserved-encoded recipient. An empty recipient list means the rule had NO agent
+/// restriction → a single `auth:Public` head (any session matches).
+fn condition_agents(_rule: &Rule, recipients: &[String]) -> Vec<String> {
+    if recipients.is_empty() {
+        return vec![PUBLIC.to_owned()];
+    }
+    recipients
+        .iter()
+        .filter(|r| recipient_principal_allowed(r))
+        .map(|r| normalise_recipient_principal(r))
+        .collect()
+}
+
+/// Map an ODRL recipient value to a principal-space `auth:agent` IRI. The two ODRL
+/// "any recipient" sentinels are folded onto the auth principals the session layer
+/// already understands; a concrete WebID passes through unchanged.
+fn normalise_recipient_principal(r: &str) -> String {
+    match r {
+        "http://www.w3.org/ns/odrl/2/All" | "http://www.w3.org/ns/odrl/2/Group" => PUBLIC.to_owned(),
+        "http://www.w3.org/ns/odrl/2/AllConnections" => AUTHENTICATED.to_owned(),
+        _ => r.to_owned(),
+    }
+}
+
+/// Does the rule's action permit `mode`'s action and its target agree with the
+/// request? (Assignee/recipient are deferred to the persisted condition.)
+fn rule_action_target_match(rule: &Rule, request: &Request, _mode: Mode, target: &str) -> bool {
+    let req_action = sparq_policy::Action(request.action.clone());
+    if !rule.action.permits(&req_action) {
+        return false;
+    }
+    match &rule.target {
+        Some(t) => t == target,
+        None => true,
+    }
+}
+
+
+/// Append `auth:ConditionalGrant` allow triples for each agent head onto the
+/// `<urn:sparq:auth>` view, preserving existing triples. Returns the
+/// `(agent, auth:effect, graph)` audit anchor of the first grant.
+fn append_conditional_grants(
+    graph: &mut Graph,
+    agents: &[String],
+    mode: Mode,
+    target: &str,
+) -> (String, String, String) {
+    let auth_name = Term::NamedNode(NamedNode::new_unchecked(AUTH_GRAPH));
+    let mut terms: Vec<[Term; 3]> = match graph.named.iter().find(|(n, _)| *n == auth_name) {
+        Some((_, sub)) => crate::loader::graph_triples(sub),
+        None => Vec::new(),
+    };
+
+    let type_p = NamedNode::new_unchecked(RDF_TYPE);
+    let cond_class = NamedNode::new_unchecked(format!("{AUTH_NS}ConditionalGrant"));
+    let effect_p = NamedNode::new_unchecked(format!("{AUTH_NS}effect"));
+    let allow_o = NamedNode::new_unchecked(format!("{AUTH_NS}Allow"));
+    let agent_p = NamedNode::new_unchecked(format!("{AUTH_NS}agent"));
+    let client_p = NamedNode::new_unchecked(format!("{AUTH_NS}client"));
+    let any_client = NamedNode::new_unchecked(crate::authindex::ANY_CLIENT);
+    let mode_p = NamedNode::new_unchecked(format!("{AUTH_NS}mode"));
+    let mode_o = NamedNode::new_unchecked(mode_iri(mode));
+    let graph_p = NamedNode::new_unchecked(format!("{AUTH_NS}graph"));
+    let graph_o = NamedNode::new_unchecked(target);
+
+    let mut first: Option<(String, String, String)> = None;
+    for agent in agents {
+        // A deterministic grant IRI keyed on (agent, mode, graph) so re-materializing
+        // the same condition is idempotent (no duplicate heads).
+        let grant_iri = format!(
+            "urn:sparq:odrl-cond?agent={}&mode={}&graph={}",
+            sparq_reason::n3::encode_for_uri(agent),
+            sparq_reason::n3::encode_for_uri(mode_iri(mode)),
+            sparq_reason::n3::encode_for_uri(target),
+        );
+        let g = Term::NamedNode(NamedNode::new_unchecked(&grant_iri));
+        let agent_o = Term::NamedNode(NamedNode::new_unchecked(agent));
+        let head = [
+            [g.clone(), Term::NamedNode(type_p.clone()), Term::NamedNode(cond_class.clone())],
+            [g.clone(), Term::NamedNode(effect_p.clone()), Term::NamedNode(allow_o.clone())],
+            [g.clone(), Term::NamedNode(agent_p.clone()), agent_o],
+            [g.clone(), Term::NamedNode(client_p.clone()), Term::NamedNode(any_client.clone())],
+            [g.clone(), Term::NamedNode(mode_p.clone()), Term::NamedNode(mode_o.clone())],
+            [g.clone(), Term::NamedNode(graph_p.clone()), Term::NamedNode(graph_o.clone())],
+        ];
+        for t in head {
+            if !terms.contains(&t) {
+                terms.push(t);
+            }
+        }
+        if first.is_none() {
+            first = Some((
+                agent.clone(),
+                format!("{AUTH_NS}effect"),
+                target.to_owned(),
+            ));
+        }
+    }
+
+    let mut dict = Dict::new();
+    let ids: Vec<[sparq_core::dict::Id; 3]> = terms
+        .iter()
+        .map(|t| [dict.intern(&t[0]), dict.intern(&t[1]), dict.intern(&t[2])])
+        .collect();
+    let auth = Graph::from_parts(dict, ids);
+    if let Some(slot) = graph.named.iter_mut().find(|(n, _)| *n == auth_name) {
+        slot.1 = auth;
+    } else {
+        graph.named.push((auth_name, auth));
+    }
+
+    first.expect("at least one agent head emitted")
+}
+
+/// `rdf:type` IRI, for the conditional-grant class triple.
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";

--- a/crates/sparq-solid/tests/odrl_bridge.rs
+++ b/crates/sparq-solid/tests/odrl_bridge.rs
@@ -17,6 +17,8 @@ use sparq_solid::{
 
 const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
 const ALICE: &str = "https://alice.ex/card#me";
+const BOB: &str = "https://bob.ex/card#me";
+const CAROL: &str = "https://carol.ex/card#me";
 const N1: &str = "https://pod.ex/notes/n1";
 
 fn odrl(local: &str) -> String {
@@ -486,4 +488,242 @@ fn permit_only_regression_via_policy() {
     assert!(store.materialize_odrl_policy(&read_policy(), &req).granted);
     let alice = Session { agent: Some(ALICE), client: None };
     assert!(store.accessible(&alice, Mode::Read).iter().any(|g| g.as_str() == N1));
+}
+
+// ===========================================================================
+// [OPUS-4.8] sq-hiz4 — conditional grants: a FAITHFULLY-mappable constraint
+// (recipient/assignee → agent matcher) persists as an `auth:ConditionalGrant`
+// and is RE-CHECKED per session; an UNmappable constraint stays one-shot.
+// ===========================================================================
+use sparq_solid::materialize_permission_conditional;
+
+fn reads(store: &mut PodStore, agent: &str) -> bool {
+    let s = Session { agent: Some(agent), client: None };
+    store.accessible(&s, Mode::Read).iter().any(|g| g.as_str() == N1)
+}
+
+/// Count `auth:ConditionalGrant` heads naming `agent` (or any, if `agent` is None) in
+/// the materialized auth view of a freshly-bridged `graph`.
+fn cond_grants_for(graph: &Graph, agent: Option<&str>) -> usize {
+    let q = match agent {
+        Some(a) => format!(
+            "SELECT ?g WHERE {{ GRAPH <urn:sparq:auth> {{ \
+             ?g <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> \
+                <https://sparq.dev/ns/auth#ConditionalGrant> ; \
+                <https://sparq.dev/ns/auth#agent> <{a}> }} }}"
+        ),
+        None => "SELECT ?g WHERE { GRAPH <urn:sparq:auth> { \
+             ?g <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> \
+                <https://sparq.dev/ns/auth#ConditionalGrant> } }"
+            .to_owned(),
+    };
+    sparq_engine::query(graph, &q).expect("query").rows.len()
+}
+
+/// A permission whose RECIPIENT is constrained to carol (not whoever materialized it).
+fn recipient_policy() -> sparq_policy::Policy {
+    parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/recip> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:constraint [ odrl:leftOperand odrl:recipient ;
+                      odrl:operator odrl:eq ;
+                      odrl:rightOperand <https://carol.ex/card#me> ] ] .
+"#,
+        "turtle",
+    )
+    .expect("policy parses")
+}
+
+// 14. A recipient constraint persists as a ConditionalGrant re-checked per session:
+//     carol (the recipient) is granted; everyone else is denied — through accessible/
+//     query_as — even though ALICE materialized it.
+#[test]
+fn recipient_constraint_persists_as_rechecked_condition() {
+    // Inspect the materialized triples via the free-function form (we own the Graph).
+    // Note: the materializing request party is ALICE, but the constraint names CAROL.
+    let mut g = pod();
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    let out = materialize_permission_conditional(&mut g, &recipient_policy(), &req);
+    assert!(out.granted, "faithful recipient maps to a condition: {out:?}");
+    // A real ConditionalGrant head naming carol now lives in the auth view.
+    assert_eq!(cond_grants_for(&g, Some(CAROL)), 1, "carol condition present");
+    assert_eq!(cond_grants_for(&g, Some(ALICE)), 0, "no condition for the materializer");
+
+    // RE-CHECK through the real enforcement path: rebuild a store over the SAME graph.
+    let mut store = PodStore::new(pod());
+    assert!(store.materialize_odrl_permission_conditional(&recipient_policy(), &req).granted);
+    assert!(reads(&mut store, CAROL), "recipient carol granted");
+    assert!(!reads(&mut store, ALICE), "materializing party is NOT auto-granted");
+    assert!(!reads(&mut store, BOB), "unrelated agent denied");
+    assert!(!reads(&mut store, "https://x.ex/#m"), "stranger denied");
+    assert!(store.accessible(&Session::default(), Mode::Read).is_empty(), "anonymous denied");
+
+    // End-to-end through query_as: only carol sees the content.
+    let sel = "SELECT ?t WHERE { ?s <https://ex.dev/ns#title> ?t }";
+    let carol = Session { agent: Some(CAROL), client: None };
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert_eq!(store.query_as(&carol, Mode::Read, sel).unwrap().rows.len(), 1);
+    assert_eq!(store.query_as(&alice, Mode::Read, sel).unwrap().rows.len(), 0);
+}
+
+// 15. A recipient `isPartOf` SET → one re-checked condition per member (OR).
+#[test]
+fn recipient_set_persists_as_multiple_conditions() {
+    let pol = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/set> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:constraint [ odrl:leftOperand odrl:recipient ;
+                      odrl:operator odrl:isPartOf ;
+                      odrl:rightOperand "https://bob.ex/card#me|https://carol.ex/card#me" ] ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let mut store = PodStore::new(pod());
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_permission_conditional(&pol, &req).granted);
+
+    assert!(reads(&mut store, BOB), "bob in set");
+    assert!(reads(&mut store, CAROL), "carol in set");
+    assert!(!reads(&mut store, ALICE), "alice not in set");
+    assert!(!reads(&mut store, "https://dave.ex/#m"), "dave not in set");
+}
+
+// 16. An UNmappable constraint (`odrl:purpose`) STAYS one-shot: the persisted view
+//     holds NO ConditionalGrant; access is the frozen check against the supplied
+//     request context (granted only if purpose matched at materialization), scoped
+//     to the materializing party.
+#[test]
+fn purpose_constraint_stays_one_shot() {
+    let pol = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/purp> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ;
+                      odrl:operator odrl:eq ;
+                      odrl:rightOperand "research" ] ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+
+    // (a) purpose SATISFIED at materialization → one-shot grant (frozen) for alice.
+    let req = Request::new(odrl("read"))
+        .on(N1)
+        .by(ALICE)
+        .with(odrl("purpose"), Value::Str("research".to_owned()));
+    let mut g = pod();
+    let out = materialize_permission_conditional(&mut g, &pol, &req);
+    assert!(out.granted, "purpose satisfied → one-shot grant: {out:?}");
+    // NO ConditionalGrant was persisted (purpose has no faithful ACP analogue).
+    assert_eq!(cond_grants_for(&g, None), 0, "purpose must NOT become a re-checked condition");
+
+    // The frozen grant is scoped to the materializing party (alice).
+    let mut store = PodStore::new(pod());
+    assert!(store.materialize_odrl_permission_conditional(&pol, &req).granted);
+    assert!(reads(&mut store, ALICE), "alice one-shot grant");
+    assert!(!reads(&mut store, CAROL), "no widening");
+
+    // (b) purpose NOT satisfied (missing context) → fail-closed, nothing granted.
+    let mut store2 = PodStore::new(pod());
+    let bad = Request::new(odrl("read")).on(N1).by(ALICE); // no purpose context
+    assert!(!store2.materialize_odrl_permission_conditional(&pol, &bad).granted);
+    assert!(!reads(&mut store2, ALICE), "unsatisfied purpose grants nothing");
+}
+
+// 17. MIXED constraints fail SAFE: recipient (mappable) + dateTime (unmappable) →
+//     the WHOLE rule stays one-shot so the time bound is still enforced (frozen).
+//     A persisted recipient-only condition would have LOST the time bound (over-grant).
+#[test]
+fn mixed_mappable_and_unmappable_stays_one_shot() {
+    let pol = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/mix> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:constraint [ odrl:leftOperand odrl:recipient ;
+                      odrl:operator odrl:eq ;
+                      odrl:rightOperand <https://carol.ex/card#me> ] ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ;
+                      odrl:operator odrl:lteq ;
+                      odrl:rightOperand "2020-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ] ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+
+    // Out-of-window request → DENY → nothing (the time bound is NOT dropped).
+    let req = Request::new(odrl("read"))
+        .on(N1)
+        .by(CAROL)
+        .with(odrl("dateTime"), Value::DateTime("2026-06-16T00:00:00Z".to_owned()));
+    let mut g = pod();
+    let out = materialize_permission_conditional(&mut g, &pol, &req);
+    assert!(!out.granted, "out-of-window with mixed constraints must NOT grant: {out:?}");
+    // No ConditionalGrant leaked carol an unconditional re-checked allow.
+    assert_eq!(cond_grants_for(&g, None), 0, "no condition emitted when a bound is unmappable");
+    let mut store = PodStore::new(pod());
+    assert!(!store.materialize_odrl_permission_conditional(&pol, &req).granted);
+    assert!(!reads(&mut store, CAROL), "no over-grant from dropping the time bound");
+}
+
+// 18. Compose-with-deny: a matching prohibition overrides the conditional path
+//     (deny-overrides) — nothing is materialized.
+#[test]
+fn prohibition_overrides_conditional_path() {
+    let pol = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/po> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <https://pod.ex/notes/n1> ;
+    odrl:constraint [ odrl:leftOperand odrl:recipient ; odrl:operator odrl:eq ;
+                      odrl:rightOperand <https://carol.ex/card#me> ] ] ;
+  odrl:prohibition [ odrl:action odrl:read ; odrl:target <https://pod.ex/notes/n1> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let mut store = PodStore::new(pod());
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    let out = store.materialize_odrl_permission_conditional(&pol, &req);
+    assert!(!out.granted, "prohibition overrides: {out:?}");
+    assert!(!reads(&mut store, CAROL), "deny-overrides: carol gets nothing");
+}
+
+// 19. A bare permission with NO constraints, via the conditional entry point, grants
+//     PUBLIC (any session) — only valid because action/target/duties already held.
+//     (Documents the no-constraint → auth:Public head behaviour.)
+#[test]
+fn no_constraint_conditional_grants_public() {
+    let pol = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/pub> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <https://pod.ex/notes/n1> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    // Free-function form: a PUBLIC ConditionalGrant head is materialized.
+    let mut g = pod();
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    let out = materialize_permission_conditional(&mut g, &pol, &req);
+    assert!(out.granted, "bare permission grants: {out:?}");
+    assert_eq!(cond_grants_for(&g, Some("https://sparq.dev/ns/auth#Public")), 1);
+
+    // Through the real enforcement path: public read = any agent AND anonymous.
+    let mut store = PodStore::new(pod());
+    assert!(store.materialize_odrl_permission_conditional(&pol, &req).granted);
+    assert!(reads(&mut store, BOB));
+    assert!(!store.accessible(&Session::default(), Mode::Read).is_empty(), "anon public read");
 }

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -105,6 +105,15 @@ Materialize the authorization view from the access-control documents, then enfor
   `principal auth:deny<Mode> graph` triple, honoured by this enforcement under **deny-overrides**
   (`∪ allow ∖ ∪ deny` — a deny beats any allow for the same principal+target+mode). `…_policy`
   does both sides at once. Same fail-closed rules; no new enforcement engine.
+- `store.materialize_odrl_permission_conditional(&Policy, &Request) -> BridgeOutcome` —
+  **opt-in** (`odrl-bridge`; [OPUS-4.8] sq-hiz4): persists a *faithfully-mappable* ODRL
+  constraint as a re-checked ACP `auth:ConditionalGrant` (agent matcher) instead of a
+  one-shot allow — so the granted agent is verified **per session**, not frozen to the
+  materializing party. Only `odrl:recipient`/`odrl:assignee` (`eq`/`isA`/`isPartOf`) maps
+  faithfully (recipient-of-data = session agent); `odrl:purpose`/`dateTime`/`count` have no
+  stateless `(agent, client)` analogue and STAY one-shot; a rule mixing mappable +
+  unmappable constraints falls back **entirely** to one-shot (fail-safe — never drops a
+  bound). Mapping table in the [`usage-control-policy`](../usage-control-policy/SKILL.md) skill.
 - `Session { agent: Option<&str>, client: Option<&str> }` (caller-asserted WebID +
   `acl:origin`/`acp:client`; `None` = anonymous / any client); `Mode::{Read, Write,
   Append, Control}`; `wac_fixture()` / `acp_fixture()` (bundled demo pods).

--- a/skills/usage-control-policy/SKILL.md
+++ b/skills/usage-control-policy/SKILL.md
@@ -115,6 +115,35 @@ let out = store.materialize_odrl_policy(&policy, &req);
 
 **Fail-closed (deny):** a deny is materialized only when a prohibition **matches** the request (decided by `sparq_policy::matched_prohibition` — the evaluator's own conflict test, *not* `Decision.allow == false`, which conflates a carve-out with a plain no-permission deny) AND the action is mappable AND the party+target are concrete. An unmatched / unmapped / partyless / targetless prohibition materializes **nothing** — and an unmappable carve-out is *reported* in `reasons`, never silently dropped (dropping a deny would widen access).
 
+### Persisting a constraint as a re-checked ACP condition (`materialize_odrl_permission_conditional`) — [OPUS-4.8] sq-hiz4
+
+The one-shot `materialize_odrl_permission` *freezes* every constraint into a single allow scoped to the supplied request party. `materialize_odrl_permission_conditional` instead persists a **faithfully-mappable** constraint as an ACP `auth:ConditionalGrant` (the same `noneOf` machinery the ACP materializer emits), so the granted agent is **re-checked per session** through the unchanged enforcement path — not re-running the ODRL evaluator. A constraint with **no** faithful ACP analogue keeps the one-shot behaviour (checked once, frozen).
+
+```rust,ignore
+// The recipient constraint names carol — NOT whoever materializes the grant.
+let req = Request::new("http://www.w3.org/ns/odrl/2/read")
+    .on("https://pod.ex/notes/n1").by("https://alice.ex/card#me");
+store.materialize_odrl_permission_conditional(&policy, &req); // policy: recipient eq carol
+// Re-checked per session: carol is granted; alice (the materializer) is NOT.
+```
+
+**Constraint → ACP condition mapping table** (fail-closed: map ONLY when the ACP analogue is the *same or stricter*):
+
+| ODRL constraint | Operator | ACP analogue | Faithful? | Behaviour |
+|---|---|---|---|---|
+| `odrl:recipient` / `odrl:assignee` | `eq` / `isA` | `auth:agent <webid>` on a `ConditionalGrant` (agent matcher) | ✅ recipient-of-data IS the session agent | **persisted, re-checked per session** |
+| `odrl:recipient` / `odrl:assignee` | `isPartOf` (static set) | one `auth:agent` head per member (OR) | ✅ set membership = agent ∈ set | **persisted** (one grant/member) |
+| `odrl:recipient` / `odrl:assignee` | `neq` / order | "everyone EXCEPT" needs a per-session `noneOf` | ❌ no faithful single-grant analogue | **one-shot** (frozen) |
+| `odrl:purpose` | any | (none — a client app ≠ a purpose-of-use) | ❌ ACP session carries no purpose dimension; client-matcher would over-grant | **one-shot** (frozen) |
+| `odrl:dateTime` / time window | `lteq` / `lt` / `gteq` / `gt` | (none — matcher accept-sets are static; no "now") | ❌ ACP has no clock dimension to re-check | **one-shot** (frozen) |
+| `odrl:count` | any | (none — ACP is stateless) | ❌ no usage counter exists | **one-shot** (frozen) |
+| any unrecognised left-operand | any | (none) | ❌ | **one-shot** (frozen) |
+| *no constraint* | — | `auth:agent auth:Public` (action/target/duties already held) | ✅ | persisted (public) |
+
+**Fail-safe on mixed constraints:** a persisted condition is emitted ONLY when **every** constraint on the rule maps faithfully. A rule mixing a mappable recipient with an unmappable `dateTime`/`purpose`/`count` falls back **entirely** to the one-shot path — persisting only the recipient would silently drop the time/purpose/count bound and over-grant. Recipient IRIs inside the reserved pair encoding (`urn:sparq:` / `&client=`) are dropped from the grant head (anti-impersonation). The two ODRL "any recipient" sentinels fold onto auth principals: `odrl:All`/`odrl:Group` → `auth:Public`, `odrl:AllConnections` → `auth:Authenticated`.
+
+**Why only recipient/assignee maps:** the ACP session re-check carries exactly `(agent, client)`. The recipient-of-data is precisely the session **agent**, so an agent matcher re-checks it with identical semantics. Purpose, time, and count have **no** stateless `(agent, client)` analogue, so persisting them would require either freezing the check (= the one-shot path, already correct) or a looser approximation that could over-grant — rejected.
+
 ## Learn more
 
 - Crate README: [`crates/sparq-policy/README.md`](../../crates/sparq-policy/README.md)


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-hiz4** (follow-up to sq-h3uk/#280; epic **sq-3183**): map selected ODRL constraints onto sparq-solid's ACP conditional-grant machinery so a constraint can PERSIST as a re-checked condition rather than being baked into a one-shot materialization-time grant.

## Did ACP conditional-grant machinery pre-exist?

**Pre-existed.** `auth:ConditionalGrant` (with `auth:effect/agent/client/mode/graph/exceptMatcher` + `solidx:acceptsAgentP/acceptsClientP` matcher accept-sets) is already built and enforced in `authindex.rs` as the ACP `noneOf` path — re-checked per session by `AuthIndex::accessible`. This PR adds **no new enforcement engine**; it only *emits into* that machinery from the ODRL bridge via the new `materialize_permission_conditional` / `PodStore::materialize_odrl_permission_conditional` (behind the existing off-by-default `odrl-bridge` feature). (Note: the predecessor #289 prohibition→deny path referenced in the brief is not present in this tree; only #280's permit path was. The conditional path composes with the evaluator's prohibition deny-overrides regardless.)

## Constraint → ACP-condition mapping table

Fail-closed rule: map **only** when the ACP analogue is the *same or stricter*.

| ODRL constraint | Operator | Maps to | Faithful? | Behaviour |
|---|---|---|---|---|
| `odrl:recipient` / `odrl:assignee` | `eq` / `isA` | `auth:agent <webid>` (agent matcher) | ✅ recipient-of-data IS the session agent | **persisted, re-checked per session** |
| `odrl:recipient` / `odrl:assignee` | `isPartOf` (static set) | one `auth:agent` head per member (OR) | ✅ set membership = agent ∈ set | **persisted** |
| `odrl:recipient` / `odrl:assignee` | `neq` / order | needs per-session `noneOf` exception | ❌ no faithful single-grant analogue | **one-shot** (→ sq-5037) |
| `odrl:purpose` | any | — (a client ≠ a purpose-of-use) | ❌ ACP session has no purpose dim | **one-shot** (→ sq-q56r) |
| `odrl:dateTime` / time window | any | — (accept-sets static; no "now") | ❌ ACP has no clock dim | **one-shot** (→ sq-idnv) |
| `odrl:count` | any | — (ACP is stateless) | ❌ no usage counter | **one-shot** (→ sq-zi5w) |
| any unrecognised left-operand | any | — | ❌ | **one-shot** |
| *no constraint* | — | `auth:agent auth:Public` | ✅ (action/target/duties already held) | persisted (public) |

## What stayed one-shot, and why

The ACP session re-check carries exactly `(agent, client)`. The recipient-of-data **is** the session agent, so an agent matcher re-checks it with identical semantics — the one faithful case. `purpose`/`dateTime`/`count` have **no** stateless `(agent, client)` analogue; persisting them would require either freezing the check (= the one-shot path, already correct) or a looser approximation that could over-grant — **rejected**. They keep the existing one-shot `materialize_permission` behaviour (checked once against the supplied request context, frozen).

## Fail-closed / fail-safe rationale

- A condition is persisted **only** when *every* constraint on the rule maps faithfully. A rule mixing a mappable recipient with an unmappable `dateTime`/`purpose`/`count` falls back **entirely** to one-shot — persisting only the recipient would silently drop the other bound → over-grant. (Test 12.)
- Prohibition deny-overrides still applies on the conditional path (test 13).
- Reserved-encoded recipient IRIs (`urn:sparq:` / `&client=`) are dropped from the grant head (anti-impersonation, mirrors the session-value check).
- Deny / unmapped action / targetless / undischarged-duty → nothing.

## Re-checked-condition tests (through the REAL enforcement path)

`tests/odrl_bridge.rs` (+6, total 14): a recipient constraint naming **carol** materialized by **alice** grants carol and denies alice/bob/anon via `accessible`/`query_as` (test 9 — proves it is re-checked, not frozen to the materializer); `isPartOf` set → one grant/member (10); `purpose` stays one-shot with NO `ConditionalGrant` persisted, scoped to the materializer (11); mixed recipient+dateTime fails safe to one-shot (12); prohibition overrides (13); no-constraint → public re-checked (14).

## Gates (all green, OFF + ON)

- `cargo clippy --workspace --exclude sparq-py --all-targets --features odrl-bridge -- -D warnings`: clean. Per-crate clippy clean OFF and ON.
- `cargo test -p sparq-solid` OFF and ON (incl. doctests) + `cargo test -p sparq-policy`: all pass.
- Touched files respect `rustfmt.toml` (max_width=100, house compact style); `cargo fmt` is the repo's *informational* lane.
- Docs updated: `usage-control-policy` + `access-control` SKILL.md, `sparq-solid` + `sparq-policy` READMEs (mapping table + explicitly-NOT-mapped list).

**NON-CANONICAL timing** (this session runs on an EC2 work box).

Deferred beads: **sq-q56r** (purpose), **sq-idnv** (dateTime temporal condition), **sq-zi5w** (count usage-counter), **sq-5037** (neq recipient → noneOf exception matcher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)