### PR TITLE
ci(feature-matrix): exercise audit-log + filtered-ann opt-in tests (sq-21kp, sq-wuft)

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -110,11 +110,31 @@ jobs:
             crate: sparq-server
             features: federation-descriptors,service,time-travel,geo,test-seams
             test: true
+          # [OPUS-4.8] sq-21kp: the OPT-IN per-query access audit log (CDMC CD-2 /
+          # ISO 27001 A.8.15 / EU CRA logging) — exercises tests/audit_log.rs, which is
+          # `#![cfg(feature = "audit-log")]` and so never ran under the default build.
+          # `audit-log` pulls `server` (it operates on the async HTTP Response + tracing);
+          # composed with the same server feature set as the leg above so it compiles + the
+          # gated test is discovered and actually executes.
+          - name: sparq-server (audit-log + server features)
+            crate: sparq-server
+            features: audit-log,federation-descriptors,service,time-travel,geo,test-seams
+            test: true
           # sparq-vectors: the vec: magic predicates (pulls sparq-engine), and the
           # /v1/embeddings provider request/response shape (serde only, no socket).
           - name: sparq-vectors (vec-predicate, provider)
             crate: sparq-vectors
             features: vec-predicate,provider
+            test: true
+          # [OPUS-4.8] sq-wuft (actionable part): predicate-constrained (filtered) ANN.
+          # tests/filtered_bgp.rs + tests/filtered_bgp_transitive.rs are
+          # `#![cfg(all(feature = "vec-predicate", feature = "filtered-ann"))]`, so BOTH
+          # features must be ON together for the engine-side BGP→IdMask wiring tests to run.
+          # The existing `(vec-predicate, provider)` leg lacks `filtered-ann`, so those
+          # suites were never exercised in CI — this leg runs them.
+          - name: sparq-vectors (vec-predicate, filtered-ann)
+            crate: sparq-vectors
+            features: vec-predicate,filtered-ann
             test: true
           # sparq-geo: pure-Rust coordinate reprojection into CRS84.
           - name: sparq-geo (reproject)


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes a CI coverage gap from the coverage/bench gap audit (research/coverage-bench-gap-audit.md, PR #293): two opt-in features ship gated test suites, but the feature-matrix lane never built those crates with the feature ON — so the tests were silently `#[cfg]`-stripped and could rot unnoticed. Refs **sq-21kp** (audit-log) and the actionable part of **sq-wuft** (filtered-ann).

## Legs added
- **`sparq-server (audit-log + server features)`** (sq-21kp): `--features audit-log,federation-descriptors,service,time-travel,geo,test-seams`. Runs `tests/audit_log.rs` (`#![cfg(feature = "audit-log")]`). `audit-log` pulls `server` (it operates on the async HTTP `Response` + `tracing`), composed with the same server feature set as the existing server leg.
- **`sparq-vectors (vec-predicate, filtered-ann)`** (sq-wuft, actionable part): `--features vec-predicate,filtered-ann`. Runs `tests/filtered_bgp.rs` + `tests/filtered_bgp_transitive.rs` (`#![cfg(all(feature = "vec-predicate", feature = "filtered-ann"))]`). The existing `(vec-predicate, provider)` leg lacks `filtered-ann`, so those suites were never exercised.

Both legs follow the exact existing leg style (matrix `name`/`crate`/`features`/`test` entry, no `advisory`/`informational` in the name) so the required `ci-summary / gate` aggregator auto-discovers them as gating check-runs.

## Verification (local, this branch)
- `tests/audit_log.rs`: **1 test passes** (single `#[tokio::test]` by design — one global tracing subscriber per process).
- `tests/filtered_bgp.rs`: **5 tests pass**; `tests/filtered_bgp_transitive.rs`: **5 tests pass**.
- Both leg feature combos: `cargo clippy --all-targets -- -D warnings` clean (the leg's clippy step).
- YAML validates.
- No real test failures surfaced — the gated suites were green once actually run.

## Deferred
- **No `shacl-af` leg** in this PR: per the audit, `shacl-af` is not yet a feature on `main` (SHACL-AF PR #239 still open). The shacl-af leg is deferred until #239 merges; tracked on **sq-wuft** (left open for it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)