### PR TITLE
feat(sparq-fedplan): ANAPSID-style non-blocking streaming join + spill (sq-vf7q)

### DIFF
--- a/crates/sparq-fedplan/README.md
+++ b/crates/sparq-fedplan/README.md
@@ -73,6 +73,17 @@ println!("estimated total cost: {}", plan.total_cost);
   right with the left's bindings — cheap when the left is small + right selective) or a
   **hash/symmetric join** (scan both sides once — cheap when the left is large), and the
   decision *flips* at the expected cost threshold (tunable `PlanOptions::request_cost`).
+- **ANAPSID-style non-blocking streaming join + bounded spill** (`StreamJoin`) — the
+  execution-side operator the planner's `JoinAlgo::Streaming` choice names. It consumes two
+  incrementally-arriving tuple streams (federated sub-results at different rates), builds *and*
+  probes both sides, and emits matches as soon as both sides have a join key — without first
+  materialising either full input. Memory is bounded by `StreamJoinOptions::mem_budget_tuples`:
+  over-budget join-key partitions spill to a backing store (a temp file by default — `std`
+  only, no new dependency) and are reconciled on probe. **Correctness invariant** (tested): the
+  streamed + spilled result is *multiset-equal* to the equivalent blocking hash join
+  (`blocking_hash_join`) for any stream interleaving and any budget — no loss, no duplication.
+  A large hash-class join (`L + R` past `PlanOptions::stream_threshold`) is marked
+  `JoinAlgo::Streaming` so it runs non-blocking + spillable rather than materialising a side.
 - **Opt-in, zero core overhead** — a standalone member (like `sparq-canon`/`sparq-prov`),
   gated behind the `fedplan` cargo feature, **off by default**. Nothing in sparq's
   default build or the wasm artifact depends on it; the lean core is byte-identical
@@ -85,11 +96,27 @@ println!("estimated total cost: {}", plan.total_cost);
 |---|---|
 | Source selection (HiBISCuS prune + CostFed cardinality) | ✅ covered here |
 | Bind-vs-hash decision + greedy join order + CS star cardinality | ✅ covered here |
-| ANAPSID-style non-blocking streaming joins with operator spill | ⏳ deferred (roadmap bead, epic sq-3183) |
-| Live adaptive re-planning mid-execution | ⏳ deferred (same bead) |
+| ANAPSID-style non-blocking streaming join with operator spill (`StreamJoin`) | ✅ covered here (sq-vf7q) |
+| Live adaptive re-planning mid-execution | ⏳ deferred (roadmap bead, epic sq-3183) |
 
-This slice is a *static* plan computed up front; the deferred adaptive/streaming work is
-filed as a bead under epic sq-3183.
+The plan is still computed up front (static); sq-vf7q adds the streaming + spill *operator*
+the plan can name. Mid-execution adaptive re-planning is filed as a bead under epic sq-3183.
+
+## Streaming join (quick use)
+
+```rust
+use sparq_fedplan::{StreamJoin, StreamJoinOptions, Tuple, Var, blocking_hash_join};
+
+let mut join = StreamJoin::new([Var::new("s")], StreamJoinOptions::default());
+// Feed tuples from either side as they arrive; each push returns newly-derivable results.
+let _ = join.push_left(Tuple::new([(Var::new("s"), "a".into()), (Var::new("o"), "1".into())]));
+let out = join.push_right(Tuple::new([(Var::new("s"), "a".into()), (Var::new("n"), "x".into())]));
+assert_eq!(out.len(), 1); // emitted as soon as both sides have key `s=a` — non-blocking.
+```
+
+Cap memory with `StreamJoinOptions::mem_budget_tuples`; over-budget partitions spill
+(`SpillStore::TempFile` by default, `SpillStore::Memory` for tests). The result equals
+`blocking_hash_join` regardless of budget or arrival order.
 
 ## 📚 Learn more
 

--- a/crates/sparq-fedplan/src/lib.rs
+++ b/crates/sparq-fedplan/src/lib.rs
@@ -46,15 +46,28 @@
 //! byte-identical with or without it. A build that does not enable `fedplan` compiles
 //! an empty crate.
 //!
+//! ## Streaming execution (sq-vf7q)
+//!
+//! 3. [`StreamJoin`] — an **ANAPSID-style non-blocking streaming join with bounded
+//!    operator spill** ([`stream`]): the execution-side operator the planner's
+//!    [`JoinAlgo::Streaming`] choice corresponds to. It consumes two incrementally-arriving
+//!    tuple streams (federated sub-results returning at different rates), builds *and*
+//!    probes both sides, and emits matches without first materialising either full input.
+//!    Memory is bounded by [`StreamJoinOptions::mem_budget_tuples`]: over-budget join-key
+//!    partitions spill to a backing store (a temp file by default — std only) and are
+//!    reconciled on probe. The load-bearing invariant — proven by tests — is that the
+//!    streamed + spilled result is **multiset-equal** to the equivalent blocking hash join
+//!    ([`blocking_hash_join`]) for any interleaving and any budget.
+//!
 //! ## Deferred (NOT in this slice — tracked as a roadmap bead)
 //!
-//! **ANAPSID-style non-blocking streaming joins with operator spill** and **live
-//! adaptive re-planning** are explicitly out of scope here. This slice is a *static*
-//! cost-based plan computed up front from descriptors; it does not adapt mid-execution,
-//! and it does not model memory-bounded streaming operators. Those are the natural next
-//! slice (see the roadmap bead filed from sq-a35t under epic sq-3183).
+//! **Live adaptive re-planning** — switching the join algorithm or source mid-execution
+//! when observed cardinalities/rates diverge from the estimate (the harder half of
+//! ANAPSID's adaptivity) — remains out of scope. This slice adds the non-blocking
+//! operator + bounded spill (sq-vf7q) on top of the static plan; mid-execution
+//! re-planning is filed as a roadmap bead under epic sq-3183.
 //!
-//! [OPUS-4.8] sq-a35t — flagged for Fable re-review.
+//! [OPUS-4.8] sq-a35t / sq-vf7q — flagged for Fable re-review.
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-a35t: crate has zero `unsafe`.
 #![cfg_attr(not(feature = "fedplan"), allow(dead_code, unused_imports))]
 
@@ -66,6 +79,9 @@ mod pattern;
 mod plan;
 #[cfg(feature = "fedplan")]
 mod selection;
+// [OPUS-4.8] sq-vf7q: the execution-side non-blocking streaming join + spill operator.
+#[cfg(feature = "fedplan")]
+mod stream;
 
 #[cfg(feature = "fedplan")]
 pub use descriptor::{
@@ -77,3 +93,8 @@ pub use pattern::{Bgp, Term, TriplePattern, Var};
 pub use plan::{plan_bgp, JoinAlgo, JoinNode, JoinTree, PlanOptions};
 #[cfg(feature = "fedplan")]
 pub use selection::{select_sources, PatternSources, SourceCandidate};
+// [OPUS-4.8] sq-vf7q.
+#[cfg(feature = "fedplan")]
+pub use stream::{
+    blocking_hash_join, run_streaming, SpillStore, StreamJoin, StreamJoinOptions, Tuple,
+};

--- a/crates/sparq-fedplan/src/plan.rs
+++ b/crates/sparq-fedplan/src/plan.rs
@@ -46,13 +46,23 @@
 //! in [`PlanOptions::request_cost`]. The decision *flips* as `L` grows past the point
 //! where `L·req` overtakes `R`.
 //!
+//! ## Streaming (sq-vf7q)
+//!
+//! A third [`JoinAlgo::Streaming`] choice marks a hash-class join for **non-blocking
+//! streaming execution with operator spill** (the [`crate::StreamJoin`] operator). The
+//! planner picks it over a plain [`JoinAlgo::Hash`] when both inputs are large enough
+//! that materialising a side up front is the risk: the combined estimated input rows
+//! exceed [`PlanOptions::stream_threshold`]. It is the same abstract cost as Hash (one
+//! scan per side) — the difference is the execution discipline (emit-as-you-go, bounded
+//! memory), not the cost. Setting the threshold to `f64::INFINITY` disables it.
+//!
 //! ## DEFERRED (not in this slice)
 //!
-//! ANAPSID-style **non-blocking streaming joins with operator spill** and **live
-//! adaptive re-planning** are out of scope — this is a static plan. See the roadmap
-//! bead filed from sq-a35t (epic sq-3183).
+//! Live **adaptive re-planning** (mid-execution plan switching) remains out of scope —
+//! this is still a static plan; sq-vf7q adds the streaming *operator* the plan can name,
+//! not mid-flight adaptivity. See the roadmap bead filed from sq-vf7q (epic sq-3183).
 //!
-//! [OPUS-4.8] sq-a35t.
+//! [OPUS-4.8] sq-a35t / sq-vf7q.
 
 use crate::descriptor::SourceDescriptor;
 use crate::pattern::{Bgp, Term, Var};
@@ -67,6 +77,14 @@ pub enum JoinAlgo {
     /// Hash / symmetric join — scan both sides once, join locally. Cheap when the left
     /// is large or the right unselective.
     Hash,
+    /// ANAPSID-style **non-blocking streaming join with bounded operator spill** — the
+    /// execution-side [`crate::StreamJoin`]. Chosen over a plain [`JoinAlgo::Hash`] when
+    /// the combined inputs are large (past [`PlanOptions::stream_threshold`]): the
+    /// streaming operator emits matches as federated sub-results arrive and spills
+    /// over-budget partitions instead of OOMing, while producing the identical result
+    /// multiset. Same abstract cost as Hash (one scan of each side); the distinction is
+    /// the *execution discipline*, not the cost model. [OPUS-4.8] sq-vf7q.
+    Streaming,
 }
 
 /// A node of the planned (left-deep) join tree.
@@ -139,11 +157,20 @@ pub struct PlanOptions {
     /// to hash joins at a smaller left cardinality. Default `1.0` (one request ≈ one
     /// retrieved row).
     pub request_cost: f64,
+    /// [OPUS-4.8] sq-vf7q. Combined-input-rows threshold above which a hash-class join is
+    /// marked [`JoinAlgo::Streaming`] (non-blocking + spill) instead of [`JoinAlgo::Hash`].
+    /// When the estimated `L + R` of a hash join exceeds this, materialising a side up
+    /// front is the latency/memory risk, so the streaming operator is preferred. Set to
+    /// `f64::INFINITY` to always use plain hash. Default `100_000` rows.
+    pub stream_threshold: f64,
 }
 
 impl Default for PlanOptions {
     fn default() -> Self {
-        PlanOptions { request_cost: 1.0 }
+        PlanOptions {
+            request_cost: 1.0,
+            stream_threshold: 100_000.0,
+        }
     }
 }
 
@@ -276,6 +303,10 @@ fn cost_join(
     let hash_cost = r + l;
     let (algo, cost) = if bind_cost <= hash_cost {
         (JoinAlgo::Bind, bind_cost)
+    } else if l + r > opts.stream_threshold {
+        // [OPUS-4.8] sq-vf7q: a large hash join runs as the non-blocking + spill operator.
+        // Same abstract cost as plain hash; the choice is the execution discipline.
+        (JoinAlgo::Streaming, hash_cost)
     } else {
         (JoinAlgo::Hash, hash_cost)
     };
@@ -412,7 +443,10 @@ mod tests {
             .build();
         let srcs = [small_left];
         let sel = select_sources(&bgp, &srcs);
-        let opts = PlanOptions { request_cost: 50.0 };
+        let opts = PlanOptions {
+            request_cost: 50.0,
+            ..PlanOptions::default()
+        };
         let tree = plan_bgp(&bgp, &sel, &srcs, &opts).unwrap();
         // The single join: left seed is the small pattern (:p, card 5). Bind should win.
         if let JoinNode::Join { algo, .. } = &tree.root {
@@ -432,6 +466,45 @@ mod tests {
         let tree2 = plan_bgp(&bgp, &sel2, &bigs, &opts).unwrap();
         if let JoinNode::Join { algo, .. } = &tree2.root {
             assert_eq!(*algo, JoinAlgo::Hash, "large left ⇒ hash join");
+        } else {
+            panic!("expected a join");
+        }
+    }
+
+    #[test]
+    fn large_hash_join_becomes_streaming() {
+        // [OPUS-4.8] sq-vf7q. Both sides large + unselective ⇒ hash class; combined rows
+        // past stream_threshold ⇒ the planner marks it Streaming (non-blocking + spill).
+        let bgp = Bgp::new(vec![
+            TriplePattern::new(var("s"), iri("http://ex/p"), var("o")),
+            TriplePattern::new(var("s"), iri("http://ex/q"), var("z")),
+        ]);
+        let big = SourceDescriptor::builder(SourceId::new("S"))
+            .total_triples(10_000_000)
+            .predicate(pred("http://ex/p", 500_000, 500_000, 500_000))
+            .predicate(pred("http://ex/q", 500_000, 500_000, 500_000))
+            .build();
+        let srcs = [big];
+        let sel = select_sources(&bgp, &srcs);
+        // Low stream_threshold so the large combined input trips streaming.
+        let opts = PlanOptions {
+            request_cost: 50.0,
+            stream_threshold: 1000.0,
+        };
+        let tree = plan_bgp(&bgp, &sel, &srcs, &opts).unwrap();
+        if let JoinNode::Join { algo, .. } = &tree.root {
+            assert_eq!(*algo, JoinAlgo::Streaming, "large hash join ⇒ streaming");
+        } else {
+            panic!("expected a join");
+        }
+        // With the threshold raised above the inputs, the same join is plain Hash.
+        let opts_hi = PlanOptions {
+            request_cost: 50.0,
+            stream_threshold: f64::INFINITY,
+        };
+        let tree_hi = plan_bgp(&bgp, &sel, &srcs, &opts_hi).unwrap();
+        if let JoinNode::Join { algo, .. } = &tree_hi.root {
+            assert_eq!(*algo, JoinAlgo::Hash, "threshold disabled ⇒ plain hash");
         } else {
             panic!("expected a join");
         }

--- a/crates/sparq-fedplan/src/stream.rs
+++ b/crates/sparq-fedplan/src/stream.rs
@@ -1,0 +1,727 @@
+//! **ANAPSID-style non-blocking streaming join with bounded operator spill**.
+//!
+//! The static [`crate::plan`] decides *which* algorithm a binary join uses. This module
+//! is the **execution-side operator** for the streaming case: a symmetric (XJoin-style)
+//! hash join that consumes two *incrementally-arriving* tuple streams — as federated
+//! sub-queries to different sources return results at different rates — and emits joined
+//! results **without first materialising either full input**. It is memory-bounded: when
+//! the in-memory hash tables exceed a configured budget, whole join-key partitions are
+//! **spilled** to a backing store and reconciled on probe, so the operator is bounded,
+//! not OOM-prone, on inputs larger than memory.
+//!
+//! Like the rest of `sparq-fedplan`, this drives off in-memory incremental iterators /
+//! fixtures rather than live network I/O, and is fully deterministic.
+//!
+//! ## The operator (symmetric hash join)
+//!
+//! A binary join over two streams `L` and `R` on a set of shared **join variables**. Both
+//! sides build *and* probe:
+//!
+//! * On a new **left** tuple `t` (key `k` = its join-var values): probe the right side for
+//!   key `k` and emit `t ⋈ r` for every right tuple `r` already seen with that key, then
+//!   store `t` on the left side.
+//! * On a new **right** tuple, symmetrically.
+//!
+//! Because each side probes the other *as tuples arrive*, a match `(l, r)` is emitted the
+//! moment the **later-arriving** of the two is processed — never waiting for either input
+//! to finish. That is the non-blocking property: output is produced before either stream
+//! is exhausted (asserted in `emits_before_inputs_exhausted`).
+//!
+//! ## Bounded spill (XJoin-style)
+//!
+//! The operator caps the number of tuples held in memory at
+//! [`StreamJoinOptions::mem_budget_tuples`]. When an insert would exceed the budget, it
+//! **spills** the currently-largest in-memory partition (one join key, the larger of the
+//! two sides for that key) to a backing run — by default a temp file under
+//! [`std::env::temp_dir`], using only `std` (no new dependency); an in-memory simulation
+//! is available for tests via [`SpillStore::Memory`]. Spilling only *moves* tuples out of
+//! the live tables; it never drops them.
+//!
+//! ### Correctness invariant (load-bearing)
+//!
+//! > The streamed + spilled result is **multiset-equal** to the equivalent *blocking*
+//! > hash join — same tuples, no loss, no duplication — for any interleaving of the two
+//! > input streams and any memory budget (including a budget so low that every partition
+//! > spills).
+//!
+//! *Proof sketch.* Every output row corresponds to a unique ordered pair `(l, r)` of a
+//! left and a right tuple sharing a join key. A pair is emitted exactly once: when the
+//! **second** of `l, r` to arrive is processed, it probes the opposite side for its key.
+//! The probe consults **both** the in-memory bucket *and* every spilled run for that key,
+//! and spilling only relocates a tuple (memory bucket → spill run) without deleting it, so
+//! the first-arrived tuple of the pair is always found in exactly one place. Hence each
+//! matching pair is emitted once and only once, regardless of budget or interleaving — the
+//! same multiset the blocking join `{ l ⋈ r : key(l)=key(r) }` produces. Verified by
+//! `streamed_equals_blocking_*` and `spill_path_equals_no_spill_*`.
+//!
+//! ## DEFERRED (filed as a bead, not built here)
+//!
+//! Live **adaptive re-planning** — switching the join algorithm or source mid-execution
+//! when observed rates diverge from the estimate (the harder half of ANAPSID's
+//! adaptivity) — is out of scope for this slice. This is the non-blocking operator + the
+//! bounded spill only. See the roadmap bead filed from sq-vf7q under epic sq-3183.
+//!
+//! [OPUS-4.8] sq-vf7q.
+
+use crate::pattern::Var;
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+
+/// A solution tuple: variable bindings as `(variable, value)` pairs. Values are stored as
+/// their lexical string (an IRI bare, a literal already rendered), matching the light term
+/// model the planner uses ([`crate::pattern::Term`]). Bindings are kept in a stable,
+/// variable-sorted order so equal tuples are byte-identical (deterministic spill + compare).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tuple {
+    bindings: Vec<(Var, String)>,
+}
+
+impl Tuple {
+    /// Builds a tuple from `(var, value)` pairs. Duplicate variables keep the first value;
+    /// bindings are sorted by variable name for a canonical representation.
+    pub fn new(bindings: impl IntoIterator<Item = (Var, String)>) -> Tuple {
+        let mut seen: Vec<(Var, String)> = Vec::new();
+        for (v, val) in bindings {
+            if !seen.iter().any(|(sv, _)| sv == &v) {
+                seen.push((v, val));
+            }
+        }
+        seen.sort_by(|a, b| a.0.cmp(&b.0));
+        Tuple { bindings: seen }
+    }
+
+    /// The value bound to `var`, if any.
+    pub fn get(&self, var: &Var) -> Option<&str> {
+        self.bindings
+            .iter()
+            .find(|(v, _)| v == var)
+            .map(|(_, val)| val.as_str())
+    }
+
+    /// The bindings, in canonical (variable-sorted) order.
+    pub fn bindings(&self) -> &[(Var, String)] {
+        &self.bindings
+    }
+
+    /// The join key for this tuple over `join_vars`: the values of those variables in the
+    /// given order, joined with a delimiter that cannot occur in an IRI/literal lexical
+    /// form unescaped (a unit separator). A tuple missing a join var yields `None` (it
+    /// cannot join and is dropped — same as a blocking join's unbound-key behaviour).
+    fn key(&self, join_vars: &[Var]) -> Option<String> {
+        let mut k = String::new();
+        for (i, v) in join_vars.iter().enumerate() {
+            if i > 0 {
+                k.push('\u{1f}');
+            }
+            k.push_str(self.get(v)?);
+        }
+        Some(k)
+    }
+
+    /// Merges this (left) tuple with a `right` tuple. The join variables already agree (the
+    /// keys matched); the right's non-join bindings are added. On the join variables the
+    /// left value is kept (they are equal by construction). Result is re-canonicalised.
+    fn merge(&self, right: &Tuple) -> Tuple {
+        let mut pairs = self.bindings.clone();
+        for (v, val) in &right.bindings {
+            if !pairs.iter().any(|(pv, _)| pv == v) {
+                pairs.push((v.clone(), val.clone()));
+            }
+        }
+        Tuple::new(pairs)
+    }
+
+    /// Serialises to one line for a spill run: `var\u{1f}value\u{1e}var\u{1f}value...`.
+    fn encode(&self) -> String {
+        let mut s = String::new();
+        for (i, (v, val)) in self.bindings.iter().enumerate() {
+            if i > 0 {
+                s.push('\u{1e}');
+            }
+            s.push_str(&v.0);
+            s.push('\u{1f}');
+            s.push_str(val);
+        }
+        s
+    }
+
+    /// Parses a line written by [`Tuple::encode`].
+    fn decode(line: &str) -> Tuple {
+        if line.is_empty() {
+            return Tuple {
+                bindings: Vec::new(),
+            };
+        }
+        let bindings = line.split('\u{1e}').filter_map(|field| {
+            let (v, val) = field.split_once('\u{1f}')?;
+            Some((Var::new(v), val.to_string()))
+        });
+        // Already canonical on disk, but re-canonicalise defensively.
+        Tuple::new(bindings)
+    }
+}
+
+/// Where spilled partitions are kept. Defaults to a temp file under [`std::env::temp_dir`]
+/// (real, OS-backed, bounded memory — std only, no new dependency). [`SpillStore::Memory`]
+/// keeps spilled runs in a side `Vec` instead — a deterministic in-process simulation used
+/// by tests to exercise the spill *logic* without touching the filesystem. Both paths
+/// produce the identical result multiset (the spill is transparent to correctness).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpillStore {
+    /// Spill partitions to append-only temp files (default; bounds resident memory).
+    TempFile,
+    /// Keep spilled partitions in process memory (a simulation for deterministic tests).
+    Memory,
+}
+
+/// Tuning knobs for [`StreamJoin`].
+#[derive(Debug, Clone)]
+pub struct StreamJoinOptions {
+    /// Maximum number of tuples held across both in-memory hash tables before a partition
+    /// is spilled. A smaller budget forces more (and earlier) spilling. `0` is treated as
+    /// `1` (always spill on the second tuple) so the spill path is reachable in tests.
+    pub mem_budget_tuples: usize,
+    /// Where spilled partitions go.
+    pub spill_store: SpillStore,
+}
+
+impl Default for StreamJoinOptions {
+    fn default() -> Self {
+        StreamJoinOptions {
+            // A generous default: most federated intermediates fit; spill is the safety
+            // valve for the unselective tail, not the common path.
+            mem_budget_tuples: 1 << 20,
+            spill_store: SpillStore::TempFile,
+        }
+    }
+}
+
+/// One side's state: live (in-memory) buckets keyed by join key, plus spilled runs.
+struct Side {
+    /// Live tuples per join key.
+    mem: HashMap<String, Vec<Tuple>>,
+    /// Spilled runs per join key. Each run is a [`SpillRun`] (a temp file or memory vec).
+    spilled: HashMap<String, Vec<SpillRun>>,
+    /// Resident tuple count (sum over `mem` buckets).
+    resident: usize,
+}
+
+impl Side {
+    fn new() -> Side {
+        Side {
+            mem: HashMap::new(),
+            spilled: HashMap::new(),
+            resident: 0,
+        }
+    }
+}
+
+/// A spilled partition: tuples for a single join key relocated out of memory.
+enum SpillRun {
+    /// Tuples written to (and re-read from) a temp file.
+    File(std::path::PathBuf),
+    /// Tuples kept in memory (the [`SpillStore::Memory`] simulation).
+    Memory(Vec<Tuple>),
+}
+
+impl SpillRun {
+    /// Streams the tuples in this run for probing.
+    fn read(&self) -> Vec<Tuple> {
+        match self {
+            SpillRun::Memory(v) => v.clone(),
+            SpillRun::File(path) => {
+                let f = std::fs::File::open(path).expect("[OPUS-4.8] sq-vf7q: spill run readable");
+                BufReader::new(f)
+                    .lines()
+                    .map(|l| Tuple::decode(&l.expect("spill line")))
+                    .collect()
+            }
+        }
+    }
+}
+
+impl Drop for SpillRun {
+    fn drop(&mut self) {
+        if let SpillRun::File(path) = self {
+            let _ = std::fs::remove_file(path); // best-effort temp cleanup.
+        }
+    }
+}
+
+/// A symmetric, non-blocking streaming hash join with bounded operator spill.
+///
+/// Feed it tuples from either side as they arrive ([`StreamJoin::push_left`] /
+/// [`StreamJoin::push_right`]); each call returns the joined tuples that newly became
+/// derivable from that arrival. The operator never blocks on either input being complete.
+pub struct StreamJoin {
+    join_vars: Vec<Var>,
+    left: Side,
+    right: Side,
+    opts: StreamJoinOptions,
+    /// Monotonic id for unique spill file names.
+    spill_seq: u64,
+}
+
+impl StreamJoin {
+    /// Creates a streaming join on the shared `join_vars` (the variables both inputs bind
+    /// — the equi-join key). The order of `join_vars` is canonicalised internally.
+    pub fn new(join_vars: impl IntoIterator<Item = Var>, opts: StreamJoinOptions) -> StreamJoin {
+        let mut jv: Vec<Var> = join_vars.into_iter().collect();
+        jv.sort();
+        jv.dedup();
+        StreamJoin {
+            join_vars: jv,
+            left: Side::new(),
+            right: Side::new(),
+            opts,
+            spill_seq: 0,
+        }
+    }
+
+    /// Feeds one tuple from the **left** input; returns every result that this arrival
+    /// completes (probing the right side, both in memory and spilled).
+    pub fn push_left(&mut self, tuple: Tuple) -> Vec<Tuple> {
+        self.push(tuple, true)
+    }
+
+    /// Feeds one tuple from the **right** input; returns every newly-derivable result.
+    pub fn push_right(&mut self, tuple: Tuple) -> Vec<Tuple> {
+        self.push(tuple, false)
+    }
+
+    fn push(&mut self, tuple: Tuple, from_left: bool) -> Vec<Tuple> {
+        let Some(key) = tuple.key(&self.join_vars) else {
+            // A tuple that does not bind every join variable can never match — drop it,
+            // exactly as a blocking equi-join would (an unbound key joins with nothing).
+            return Vec::new();
+        };
+
+        // Probe the OPPOSITE side for this key: in-memory bucket + every spilled run.
+        let mut out = Vec::new();
+        let opposite = if from_left { &self.right } else { &self.left };
+        if let Some(bucket) = opposite.mem.get(&key) {
+            for other in bucket {
+                out.push(merge_ordered(&tuple, other, from_left));
+            }
+        }
+        if let Some(runs) = opposite.spilled.get(&key) {
+            for run in runs {
+                for other in run.read() {
+                    out.push(merge_ordered(&tuple, &other, from_left));
+                }
+            }
+        }
+
+        // Store this tuple on its OWN side, then enforce the memory budget.
+        {
+            let side = if from_left {
+                &mut self.left
+            } else {
+                &mut self.right
+            };
+            side.mem.entry(key).or_default().push(tuple);
+            side.resident += 1;
+        }
+        self.enforce_budget();
+        out
+    }
+
+    /// Spills partitions until resident memory is within budget. The victim each round is
+    /// the largest live bucket across both sides (most memory reclaimed per spill);
+    /// ties break on (side, key) for determinism.
+    fn enforce_budget(&mut self) {
+        let budget = self.opts.mem_budget_tuples.max(1);
+        while self.left.resident + self.right.resident > budget {
+            // Find the largest bucket; prefer left on a tie, then smallest key.
+            let left_best = largest_bucket(&self.left.mem).map(|(k, n)| (k.clone(), n));
+            let right_best = largest_bucket(&self.right.mem).map(|(k, n)| (k.clone(), n));
+            let spill_left = match (&left_best, &right_best) {
+                (None, None) => break, // nothing left to spill (every bucket empty).
+                (Some(_), None) => true,
+                (None, Some(_)) => false,
+                (Some((_, ln)), Some((_, rn))) => ln >= rn,
+            };
+            if spill_left {
+                let key = left_best.unwrap().0;
+                self.spill_key(true, &key);
+            } else {
+                let key = right_best.unwrap().0;
+                self.spill_key(false, &key);
+            }
+        }
+    }
+
+    /// Moves one join-key bucket out of memory into a spill run on the given side.
+    fn spill_key(&mut self, from_left: bool, key: &str) {
+        let store = self.opts.spill_store;
+        let seq = self.spill_seq;
+        self.spill_seq += 1;
+        let side = if from_left {
+            &mut self.left
+        } else {
+            &mut self.right
+        };
+        let Some(bucket) = side.mem.remove(key) else {
+            return;
+        };
+        side.resident -= bucket.len();
+        let run = match store {
+            SpillStore::Memory => SpillRun::Memory(bucket),
+            SpillStore::TempFile => {
+                let mut path = std::env::temp_dir();
+                path.push(format!(
+                    "sparq-fedplan-spill-{}-{}-{}.run",
+                    std::process::id(),
+                    if from_left { "l" } else { "r" },
+                    seq
+                ));
+                let f =
+                    std::fs::File::create(&path).expect("[OPUS-4.8] sq-vf7q: spill run creatable");
+                let mut w = BufWriter::new(f);
+                for t in &bucket {
+                    writeln!(w, "{}", t.encode()).expect("[OPUS-4.8] sq-vf7q: spill write");
+                }
+                w.flush().expect("spill flush");
+                SpillRun::File(path)
+            }
+        };
+        side.spilled.entry(key.to_string()).or_default().push(run);
+    }
+
+    /// Whether any partition has been spilled (for tests / introspection).
+    pub fn spilled(&self) -> bool {
+        !self.left.spilled.is_empty() || !self.right.spilled.is_empty()
+    }
+}
+
+/// Merges in the canonical (left, right) order regardless of which side `tuple` came from,
+/// so the output binding set is independent of arrival order.
+fn merge_ordered(tuple: &Tuple, other: &Tuple, tuple_is_left: bool) -> Tuple {
+    if tuple_is_left {
+        tuple.merge(other)
+    } else {
+        other.merge(tuple)
+    }
+}
+
+/// The largest bucket in a side's live map, as `(&key, len)`; ties break on smallest key.
+fn largest_bucket(mem: &HashMap<String, Vec<Tuple>>) -> Option<(&String, usize)> {
+    mem.iter()
+        .filter(|(_, v)| !v.is_empty())
+        .map(|(k, v)| (k, v.len()))
+        .max_by(|a, b| a.1.cmp(&b.1).then(b.0.cmp(a.0)))
+}
+
+/// A reference **blocking** hash join, used both as a building block and as the test
+/// oracle: materialise the whole right side into a hash table keyed by join key, then scan
+/// the left and emit every match. Result order is left-scan × bucket order. This is the
+/// multiset the streaming operator must reproduce.
+pub fn blocking_hash_join(left: &[Tuple], right: &[Tuple], join_vars: &[Var]) -> Vec<Tuple> {
+    let mut jv: Vec<Var> = join_vars.to_vec();
+    jv.sort();
+    jv.dedup();
+    let mut table: HashMap<String, Vec<&Tuple>> = HashMap::new();
+    for r in right {
+        if let Some(k) = r.key(&jv) {
+            table.entry(k).or_default().push(r);
+        }
+    }
+    let mut out = Vec::new();
+    for l in left {
+        if let Some(k) = l.key(&jv) {
+            if let Some(bucket) = table.get(&k) {
+                for r in bucket {
+                    out.push(l.merge(r));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Drives a [`StreamJoin`] over two fully-known inputs by interleaving their arrivals
+/// according to `schedule` (each `true` takes the next left tuple, each `false` the next
+/// right), returning the full result. Whatever the schedule does not cover is drained at
+/// the end. Used by tests to exercise arbitrary stream interleavings deterministically.
+pub fn run_streaming(
+    left: &[Tuple],
+    right: &[Tuple],
+    join_vars: &[Var],
+    opts: StreamJoinOptions,
+    schedule: &[bool],
+) -> Vec<Tuple> {
+    let mut join = StreamJoin::new(join_vars.iter().cloned(), opts);
+    let mut li = 0usize;
+    let mut ri = 0usize;
+    let mut out = Vec::new();
+    for &take_left in schedule {
+        if take_left && li < left.len() {
+            out.extend(join.push_left(left[li].clone()));
+            li += 1;
+        } else if !take_left && ri < right.len() {
+            out.extend(join.push_right(right[ri].clone()));
+            ri += 1;
+        }
+    }
+    // Drain whatever the schedule did not cover (schedule is a hint, not a guarantee).
+    while li < left.len() {
+        out.extend(join.push_left(left[li].clone()));
+        li += 1;
+    }
+    while ri < right.len() {
+        out.extend(join.push_right(right[ri].clone()));
+        ri += 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(pairs: &[(&str, &str)]) -> Tuple {
+        Tuple::new(pairs.iter().map(|(v, val)| (Var::new(*v), val.to_string())))
+    }
+
+    /// Multiset equality: same elements with the same multiplicities, order-insensitive.
+    fn multiset_eq(a: &[Tuple], b: &[Tuple]) -> bool {
+        if a.len() != b.len() {
+            return false;
+        }
+        let mut a: Vec<String> = a.iter().map(|x| x.encode()).collect();
+        let mut b: Vec<String> = b.iter().map(|x| x.encode()).collect();
+        a.sort();
+        b.sort();
+        a == b
+    }
+
+    fn jv(names: &[&str]) -> Vec<Var> {
+        names.iter().map(|n| Var::new(*n)).collect()
+    }
+
+    // ---- The blocking oracle itself, on a known case.
+    #[test]
+    fn blocking_oracle_basic() {
+        let left = [t(&[("s", "a"), ("o", "1")]), t(&[("s", "b"), ("o", "2")])];
+        let right = [t(&[("s", "a"), ("n", "x")]), t(&[("s", "a"), ("n", "y")])];
+        let out = blocking_hash_join(&left, &right, &jv(&["s"]));
+        // s=a left row joins both s=a right rows; s=b joins nothing.
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|r| r.get(&Var::new("s")) == Some("a")));
+    }
+
+    // ---- Correctness invariant: streamed == blocking, several interleavings.
+    #[test]
+    fn streamed_equals_blocking_interleavings() {
+        let left: Vec<Tuple> = (0..20)
+            .map(|i| t(&[("s", &format!("k{}", i % 5)), ("o", &format!("lo{}", i))]))
+            .collect();
+        let right: Vec<Tuple> = (0..20)
+            .map(|i| t(&[("s", &format!("k{}", i % 5)), ("n", &format!("rn{}", i))]))
+            .collect();
+        let oracle = blocking_hash_join(&left, &right, &jv(&["s"]));
+        // Several deterministic schedules: all-left-first, all-right-first, alternating,
+        // and a skewed bursty one.
+        let schedules: Vec<Vec<bool>> = vec![
+            vec![true; 40],
+            vec![false; 40],
+            (0..40).map(|i| i % 2 == 0).collect(),
+            (0..40).map(|i| i % 3 != 0).collect(),
+        ];
+        for sched in &schedules {
+            let got = run_streaming(
+                &left,
+                &right,
+                &jv(&["s"]),
+                StreamJoinOptions::default(),
+                sched,
+            );
+            assert!(
+                multiset_eq(&got, &oracle),
+                "streamed result must equal blocking join for schedule"
+            );
+        }
+    }
+
+    // ---- Spill correctness: a tiny budget (forces heavy spilling) == no-spill result.
+    #[test]
+    fn spill_path_equals_no_spill_memory_store() {
+        let left: Vec<Tuple> = (0..30)
+            .map(|i| t(&[("s", &format!("k{}", i % 4)), ("o", &format!("lo{}", i))]))
+            .collect();
+        let right: Vec<Tuple> = (0..30)
+            .map(|i| t(&[("s", &format!("k{}", i % 4)), ("n", &format!("rn{}", i))]))
+            .collect();
+        let oracle = blocking_hash_join(&left, &right, &jv(&["s"]));
+        let sched: Vec<bool> = (0..60).map(|i| i % 2 == 0).collect();
+        // Budget of 2 tuples forces almost everything to spill.
+        let tiny = StreamJoinOptions {
+            mem_budget_tuples: 2,
+            spill_store: SpillStore::Memory,
+        };
+        let got = run_streaming(&left, &right, &jv(&["s"]), tiny, &sched);
+        assert!(
+            multiset_eq(&got, &oracle),
+            "spill (memory store) == blocking"
+        );
+    }
+
+    // ---- Spill correctness with the real temp-FILE backing store.
+    #[test]
+    fn spill_path_equals_no_spill_file_store() {
+        let left: Vec<Tuple> = (0..30)
+            .map(|i| t(&[("s", &format!("k{}", i % 4)), ("o", &format!("lo{}", i))]))
+            .collect();
+        let right: Vec<Tuple> = (0..30)
+            .map(|i| t(&[("s", &format!("k{}", i % 4)), ("n", &format!("rn{}", i))]))
+            .collect();
+        let oracle = blocking_hash_join(&left, &right, &jv(&["s"]));
+        let sched: Vec<bool> = (0..60).map(|i| i % 3 != 0).collect();
+        let tiny = StreamJoinOptions {
+            mem_budget_tuples: 3,
+            spill_store: SpillStore::TempFile,
+        };
+        let mut join = StreamJoin::new(jv(&["s"]), tiny);
+        let mut out = Vec::new();
+        let (mut li, mut ri) = (0usize, 0usize);
+        for &take_left in &sched {
+            if take_left && li < left.len() {
+                out.extend(join.push_left(left[li].clone()));
+                li += 1;
+            } else if !take_left && ri < right.len() {
+                out.extend(join.push_right(right[ri].clone()));
+                ri += 1;
+            }
+        }
+        while li < left.len() {
+            out.extend(join.push_left(left[li].clone()));
+            li += 1;
+        }
+        while ri < right.len() {
+            out.extend(join.push_right(right[ri].clone()));
+            ri += 1;
+        }
+        assert!(join.spilled(), "tiny budget must trigger the spill path");
+        assert!(multiset_eq(&out, &oracle), "spill (temp file) == blocking");
+    }
+
+    // ---- Non-blocking behaviour: a match is emitted BEFORE either input is exhausted.
+    #[test]
+    fn emits_before_inputs_exhausted() {
+        let mut join = StreamJoin::new(jv(&["s"]), StreamJoinOptions::default());
+        // Feed one matching tuple per side, with MORE tuples still to come on both sides.
+        let r0 = join.push_left(t(&[("s", "a"), ("o", "1")]));
+        assert!(r0.is_empty(), "no right tuple yet ⇒ nothing emitted");
+        let r1 = join.push_right(t(&[("s", "a"), ("n", "x")]));
+        assert_eq!(
+            r1.len(),
+            1,
+            "match emitted as soon as both sides have key a"
+        );
+        // Crucially we have NOT exhausted either input — more arrive after the emission:
+        let r2 = join.push_left(t(&[("s", "b"), ("o", "2")]));
+        let r3 = join.push_right(t(&[("s", "b"), ("n", "y")]));
+        assert!(r2.is_empty());
+        assert_eq!(r3.len(), 1);
+        // The first emission happened at r1, before these later arrivals — non-blocking.
+    }
+
+    // ---- Edge: empty inputs.
+    #[test]
+    fn empty_inputs() {
+        let empty: Vec<Tuple> = Vec::new();
+        let some = [t(&[("s", "a"), ("o", "1")])];
+        assert!(blocking_hash_join(&empty, &some, &jv(&["s"])).is_empty());
+        assert!(blocking_hash_join(&some, &empty, &jv(&["s"])).is_empty());
+        let got = run_streaming(
+            &empty,
+            &empty,
+            &jv(&["s"]),
+            StreamJoinOptions::default(),
+            &[],
+        );
+        assert!(got.is_empty());
+    }
+
+    // ---- Edge: one-sided (no matching keys ⇒ empty, both algos agree).
+    #[test]
+    fn one_sided_no_match() {
+        let left = [t(&[("s", "a"), ("o", "1")]), t(&[("s", "b"), ("o", "2")])];
+        let right = [t(&[("s", "c"), ("n", "x")])];
+        let oracle = blocking_hash_join(&left, &right, &jv(&["s"]));
+        assert!(oracle.is_empty());
+        let sched: Vec<bool> = vec![true, false, true, false];
+        let got = run_streaming(
+            &left,
+            &right,
+            &jv(&["s"]),
+            StreamJoinOptions::default(),
+            &sched,
+        );
+        assert!(multiset_eq(&got, &oracle));
+    }
+
+    // ---- Edge: duplicate join keys produce the full cross product per key (multiset).
+    #[test]
+    fn duplicate_keys_cross_product() {
+        let left = [
+            t(&[("s", "a"), ("o", "1")]),
+            t(&[("s", "a"), ("o", "2")]),
+            t(&[("s", "a"), ("o", "3")]),
+        ];
+        let right = [t(&[("s", "a"), ("n", "x")]), t(&[("s", "a"), ("n", "y")])];
+        let oracle = blocking_hash_join(&left, &right, &jv(&["s"]));
+        assert_eq!(oracle.len(), 6, "3×2 cross product on key a");
+        // Streamed, with spill, must reproduce all 6 exactly once each.
+        let sched: Vec<bool> = vec![true, false, true, false, true, false, false, true];
+        let tiny = StreamJoinOptions {
+            mem_budget_tuples: 1,
+            spill_store: SpillStore::Memory,
+        };
+        let got = run_streaming(&left, &right, &jv(&["s"]), tiny, &sched);
+        assert!(
+            multiset_eq(&got, &oracle),
+            "duplicate-key cross product preserved under spill"
+        );
+    }
+
+    // ---- Multi-variable join key.
+    #[test]
+    fn multi_var_join_key() {
+        let left = [
+            t(&[("s", "a"), ("p", "1"), ("o", "x")]),
+            t(&[("s", "a"), ("p", "2"), ("o", "y")]),
+        ];
+        let right = [
+            t(&[("s", "a"), ("p", "1"), ("n", "hit")]),
+            t(&[("s", "a"), ("p", "9"), ("n", "miss")]),
+        ];
+        let oracle = blocking_hash_join(&left, &right, &jv(&["s", "p"]));
+        assert_eq!(oracle.len(), 1, "only (a,1) matches on both s and p");
+        let got = run_streaming(
+            &left,
+            &right,
+            &jv(&["s", "p"]),
+            StreamJoinOptions::default(),
+            &[true, true, false, false],
+        );
+        assert!(multiset_eq(&got, &oracle));
+    }
+
+    // ---- Tuple with a missing join var is dropped (cannot key), matching blocking.
+    #[test]
+    fn unbound_join_var_dropped() {
+        let left = [t(&[("o", "1")])]; // no `s` binding
+        let right = [t(&[("s", "a"), ("n", "x")])];
+        let oracle = blocking_hash_join(&left, &right, &jv(&["s"]));
+        assert!(oracle.is_empty());
+        let got = run_streaming(
+            &left,
+            &right,
+            &jv(&["s"]),
+            StreamJoinOptions::default(),
+            &[true, false],
+        );
+        assert!(multiset_eq(&got, &oracle));
+    }
+}

--- a/skills/federated-planning/SKILL.md
+++ b/skills/federated-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: federated-planning
-description: "Cost-based federated SPARQL source selection + bind-vs-hash join planning over already-fetched source descriptors, via the opt-in sparq-fedplan crate. Use when planning a federated BGP across multiple SPARQL endpoints from their served statistics (VoID property/class partitions + mined scs: characteristic sets): deciding which sources can contribute to each triple pattern (HiBISCuS recall-safe pruning + CostFed skew-aware cardinality), and choosing a join order with per-join bind-vs-hash algorithm selection (characteristic-set star cardinality for intermediate sizes). Pure + deterministic, no network I/O. Off by default; does not touch sparq-core/sparq-engine's lean build. NOT for live streaming/adaptive joins (ANAPSID — deferred)."
+description: "Cost-based federated SPARQL source selection + bind-vs-hash join planning over already-fetched source descriptors, plus an ANAPSID-style non-blocking streaming join with operator spill, via the opt-in sparq-fedplan crate. Use when planning a federated BGP across multiple SPARQL endpoints from their served statistics (VoID property/class partitions + mined scs: characteristic sets): deciding which sources can contribute to each triple pattern (HiBISCuS recall-safe pruning + CostFed skew-aware cardinality), choosing a join order with per-join bind-vs-hash-vs-streaming algorithm selection (characteristic-set star cardinality for intermediate sizes), and executing a memory-bounded non-blocking symmetric hash join over incrementally-arriving sub-results (StreamJoin, spill to a backing store, result multiset-equal to a blocking join). Pure + deterministic planning, no network I/O. Off by default; does not touch sparq-core/sparq-engine's lean build. NOT for live adaptive RE-planning mid-execution (ANAPSID adaptivity — deferred)."
 ---
 
 # sparq-fedplan — cost-based federated source selection + join planning
@@ -98,10 +98,47 @@ where per-row requests overtake a full scan; tune the round-trip penalty with
 cardinality (`Σ_{C⊇Q} count(C)·Π avg_mult`) for intermediate sizes, capturing the
 predicate correlation an independence product loses.
 
+## Non-blocking streaming join + spill (`StreamJoin`, sq-vf7q)
+
+The planner's `JoinAlgo::Streaming` choice corresponds to an execution-side operator:
+`StreamJoin`, an ANAPSID/XJoin-style **symmetric hash join** over two
+incrementally-arriving tuple streams. Feed tuples from either side as federated sub-results
+arrive; each `push` returns the results that arrival newly completes — it never blocks on
+either input finishing.
+
+```rust
+use sparq_fedplan::{StreamJoin, StreamJoinOptions, SpillStore, Tuple, Var, blocking_hash_join};
+
+let opts = StreamJoinOptions { mem_budget_tuples: 100_000, spill_store: SpillStore::TempFile };
+let mut join = StreamJoin::new([Var::new("s")], opts);
+let _ = join.push_left(Tuple::new([(Var::new("s"), "a".into()), (Var::new("o"), "1".into())]));
+let out = join.push_right(Tuple::new([(Var::new("s"), "a".into()), (Var::new("n"), "x".into())]));
+assert_eq!(out.len(), 1); // emitted the moment both sides hold key s=a — non-blocking.
+```
+
+**Bounded spill.** Memory is capped at `mem_budget_tuples`; when an insert would exceed it,
+the largest in-memory join-key partition is spilled to a backing run (a temp file under
+`std::env::temp_dir` by default — `std` only, no new dependency; `SpillStore::Memory` is an
+in-process simulation for tests). Spilling only relocates tuples; the probe consults both
+the live bucket and every spilled run for the key.
+
+**Correctness invariant (load-bearing).** The streamed + spilled result is *multiset-equal*
+to `blocking_hash_join(left, right, join_vars)` — same tuples, no loss, no duplication — for
+**any** stream interleaving and **any** budget (including one so low every partition spills).
+Each matching pair `(l, r)` is emitted exactly once, when the second of the two arrives and
+probes the other side (found in memory or a spill run). Proven by the `streamed_equals_*`,
+`spill_path_equals_*`, `duplicate_keys_*`, and `emits_before_inputs_exhausted` tests.
+
+The planner picks `Streaming` over plain `Hash` when a hash-class join's combined estimated
+inputs `L + R` exceed `PlanOptions::stream_threshold` (default 100 000 rows; set to
+`f64::INFINITY` to always use plain hash) — large joins run non-blocking + spillable rather
+than materialising a side up front.
+
 ## Deferred (NOT here)
 
-**ANAPSID-style non-blocking streaming joins with operator spill** and **live adaptive
-re-planning** are out of scope — this is a *static* plan computed up front. They are filed
-as a roadmap bead under epic **sq-3183**.
+**Live adaptive RE-planning** — switching the join algorithm or source mid-execution when
+observed rates diverge from the estimate (the harder half of ANAPSID's adaptivity) — is out
+of scope. The plan is still computed up front; sq-vf7q adds the streaming + spill *operator*
+the plan can name, not mid-flight re-planning. Filed as a roadmap bead under epic **sq-3183**.
 
-[OPUS-4.8] sq-a35t — flag for Fable re-review.
+[OPUS-4.8] sq-a35t / sq-vf7q — flag for Fable re-review.


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-vf7q** (deferred from **sq-a35t** / #278; epic **sq-3183**): the execution-side **ANAPSID-style non-blocking streaming join with bounded operator spill** for the opt-in `sparq-fedplan` planner crate.

## What this adds

- **`StreamJoin`** — a symmetric (XJoin-style) hash join over two *incrementally-arriving* tuple streams. Both sides build *and* probe; a match `(l, r)` is emitted the moment the **later-arriving** of the two is processed, so output is produced **without first materialising either full input** (the non-blocking property). Drives off in-memory incremental feeds — deterministic, no network I/O, like the rest of the crate.
- **Bounded operator spill** — memory is capped at `StreamJoinOptions::mem_budget_tuples`; over-budget join-key partitions are spilled to a backing store and reconciled on probe. Default backing store is a temp file under `std::env::temp_dir` (**`std` only — no new dependency**); `SpillStore::Memory` is an in-process simulation for tests. Spilling only *relocates* tuples (never drops them), and the probe consults both the live bucket and every spilled run for the key.
- **`JoinAlgo::Streaming`** — a new planner variant. A large hash-class join (estimated `L + R` past `PlanOptions::stream_threshold`, default 100 000) is marked `Streaming` so it runs non-blocking + spillable instead of materialising a side; `f64::INFINITY` disables it (stays plain `Hash`).

## Correctness invariant (load-bearing)

> The streamed + spilled result is **multiset-equal** to the equivalent **blocking hash join** (`blocking_hash_join`) — same tuples, no loss, no duplication — for **any** stream interleaving and **any** memory budget (including one so low every partition spills).

*Why it holds:* each output row is a unique ordered pair `(l, r)` sharing a join key, emitted exactly once when the second of the two arrives and probes the opposite side; since spilling only relocates tuples, the first-arrived tuple is always found (memory bucket or spill run). Tests proving it:
- `streamed_equals_blocking_interleavings` — 4 interleavings (all-left-first, all-right-first, alternating, bursty) vs the blocking oracle.
- `spill_path_equals_no_spill_memory_store` / `spill_path_equals_no_spill_file_store` — tiny budget (forces heavy spilling; the file test asserts `spilled()`) == blocking.
- `emits_before_inputs_exhausted` — a match emitted before either input is drained (non-blocking).
- `duplicate_keys_cross_product`, `multi_var_join_key`, `empty_inputs`, `one_sided_no_match`, `unbound_join_var_dropped` — edge cases.
- `large_hash_join_becomes_streaming` — planner selects `Streaming` past the threshold, `Hash` when disabled.

## Gates

`cargo build` / `clippy --all-targets -D warnings` / `cargo test` all green for `sparq-fedplan` with the `fedplan` feature **OFF and ON** (32 tests pass ON). `rustfmt --check` clean on touched files. **NON-CANONICAL timing** (work-box EC2).

## Opt-in / scope

Behind the `fedplan` cargo feature (**OFF by default**); `publish = false` crate; `sparq-core`/`sparq-engine` untouched. README + `skills/federated-planning/SKILL.md` updated per the public-API→SKILL rule.

**Deferred:** live **adaptive RE-planning** (mid-execution plan switching) — the harder half of ANAPSID's adaptivity — is out of scope here and filed as bead **sq-7s4z** under epic sq-3183. This slice is the non-blocking operator + bounded spill.

[OPUS-4.8] — flagged for Fable re-review.