### PR TITLE
feat(sparq-solid): refresh/revoke bridged ODRL grants on policy change (sq-dpk4)

### DIFF
--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -147,6 +147,34 @@ on the rule maps faithfully. A rule mixing a mappable recipient with an unmappab
 the recipient would silently drop the other bound and over-grant. Reserved-encoded recipient
 IRIs are dropped from the grant head (anti-impersonation).
 
+### Refresh / revocation of bridged grants — [OPUS-4.8] sq-dpk4
+
+The `materialize_odrl_*` calls only **append**. When the ODRL policy changes — a permission is
+**withdrawn**, a **time window lapses**, or a re-evaluation now **Denies** — a previously
+materialized grant must lose access (the sq-h3uk/#280 correctness gap), and a wholesale static
+WAC/ACP re-materialization must not silently clobber a still-valid bridged grant. A `PodStore`
+tracks each bridged grant in a **ledger** and provides a refresh entry point:
+
+- **Provenance.** Every bridged auth triple is mirrored verbatim into a separate reserved graph
+  `<urn:sparq:auth-bridged>` (`AUTH_BRIDGED_GRAPH`): a triple is **bridged** iff it appears
+  there, **static** otherwise. The enforcement reader (`AuthIndex`) is unchanged — it still
+  reads `<urn:sparq:auth>`. The provenance graph lives in the reserved `urn:sparq:` space, so a
+  loaded dataset cannot forge it.
+- **Refresh / retract.** `PodStore::refresh_odrl_grant(&policy, &request, kind)` updates the
+  tracked grant slot `(kind, target, party)` with the new policy / request context, then
+  rebuilds the view as `static_baseline ∪ replay(still-valid bridged entries)`: it resets
+  `<urn:sparq:auth>` to the static baseline captured at the last `materialize_wac`/`_acp`,
+  clears the provenance graph, and re-evaluates every tracked `(policy, request)` through its
+  original bridge entry point. An entry that no longer holds emits nothing → it is **retracted**
+  (access gone). `refresh_odrl_grants()` (no args) replays everything as-tracked; a static
+  re-materialization auto-reconciles (valid bridged grants are replayed back on top).
+- **Fail-closed (access retraction).** A withdrawn / lapsed / now-Denied / now-prohibited /
+  ambiguous re-evaluation loses access — the underlying evaluator is fail-closed, so on doubt
+  the grant is retracted, never left stale. A **static** WAC/ACP grant is never in the ledger,
+  never re-evaluated, and always in the captured baseline (captured as the materializer output
+  verbatim, not by subtracting provenance — so a static grant byte-identical to a bridged one
+  still survives a refresh) — refresh can neither widen nor drop it.
+
 ## Security posture — fail-closed
 
 Absence of a grant means a graph is **invisible**, and a non-authorized graph is

--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -20,6 +20,8 @@ pub use odrl_bridge::{
     action_to_mode, materialize_permission, materialize_permission_conditional, materialize_policy,
     materialize_prohibition, BridgeOutcome,
 };
+#[cfg(feature = "odrl-bridge")]
+pub use odrl_bridge::{BridgeEntry, BridgeKind, BridgeLedger};
 pub use rewrite::{rewrite_for, wrap_for_view};
 
 use oxrdf::{NamedNode, Term};
@@ -58,6 +60,19 @@ use std::sync::Arc;
 /// under it (they are stripped — a dataset must not smuggle in a forged auth view),
 /// and agent/client/origin IRIs inside it are rejected at materialization time.
 pub const AUTH_GRAPH: &str = "urn:sparq:auth";
+
+/// The reserved named graph recording the **provenance** of bridged ODRL grants
+/// ([OPUS-4.8] sq-dpk4). Every auth triple the opt-in ODRL bridge writes into
+/// [`AUTH_GRAPH`] is mirrored here verbatim, so a bridged grant is structurally
+/// distinguishable from a static WAC/ACP grant: a triple is *bridged* iff it appears
+/// in this graph, *static* otherwise. This is what lets the refresh/retraction model
+/// (a) re-evaluate and retract only the bridged grants whose ODRL policy no longer
+/// holds, never touching a static grant, and (b) re-apply still-valid bridged grants
+/// after a wholesale static re-materialization rebuilds [`AUTH_GRAPH`].
+///
+/// It lives in the reserved `urn:sparq:` space, so a loaded dataset cannot smuggle a
+/// forged provenance record in (it is stripped by [`PodStore::new`] like the auth view).
+pub const AUTH_BRIDGED_GRAPH: &str = "urn:sparq:auth-bridged";
 
 /// Namespace of the materialized auth-view vocabulary
 /// (`auth:read`, `auth:denyWrite`, `auth:Public`, `auth:ConditionalGrant`, …).
@@ -107,6 +122,12 @@ pub struct PodStore {
     auth: Arc<AuthIndex>,
     epoch: u64,
     cache: FxHashMap<(Option<String>, Option<String>, Mode), SessionSets>,
+    /// [OPUS-4.8] sq-dpk4 — the bridged-ODRL-grant ledger: what was bridged from which
+    /// `(policy, request)`, plus the static-baseline auth view to rebuild from on a
+    /// refresh. Only present when the `odrl-bridge` feature is enabled (the core build
+    /// carries zero ODRL state).
+    #[cfg(feature = "odrl-bridge")]
+    bridge_ledger: odrl_bridge::BridgeLedger,
 }
 
 /// One session-cache entry: the same authorized graph set in the two shapes its two
@@ -143,7 +164,14 @@ impl PodStore {
     /// ```
     pub fn new(mut graph: Graph) -> PodStore {
         loader::strip_reserved_graphs(&mut graph);
-        PodStore { graph, auth: Arc::new(AuthIndex::default()), epoch: 0, cache: FxHashMap::default() }
+        PodStore {
+            graph,
+            auth: Arc::new(AuthIndex::default()),
+            epoch: 0,
+            cache: FxHashMap::default(),
+            #[cfg(feature = "odrl-bridge")]
+            bridge_ledger: odrl_bridge::BridgeLedger::new(),
+        }
     }
 
     /// (Re-)materialize the WAC auth view from the `.acl` graphs. Call again after any
@@ -161,9 +189,30 @@ impl PodStore {
     /// On error the previous auth view (if any) is left in place.
     pub fn materialize_wac(&mut self) -> Result<MaterializeStats, String> {
         let stats = materialize_wac(&mut self.graph)?;
+        self.reconcile_bridged_after_static();
         self.reindex();
         Ok(stats)
     }
+
+    /// [OPUS-4.8] sq-dpk4 — after a wholesale static (WAC/ACP) re-materialization has
+    /// rebuilt `<urn:sparq:auth>` (dropping any bridged grants that were on top),
+    /// capture the fresh static view as the refresh baseline and REPLAY the bridge
+    /// ledger so still-valid bridged grants are re-applied (and now-invalid ones stay
+    /// retracted). This reconciles the two grant sources: a static re-run can never drop
+    /// a valid bridged grant, and the replay can never widen or drop a static grant
+    /// (the baseline is the static view verbatim). No-op without the `odrl-bridge`
+    /// feature, or when no grants were ever bridged.
+    #[cfg(feature = "odrl-bridge")]
+    fn reconcile_bridged_after_static(&mut self) {
+        self.bridge_ledger.capture_static_baseline(&self.graph);
+        // refresh() rebuilds from the just-captured baseline and replays the ledger.
+        self.bridge_ledger.refresh(&mut self.graph);
+    }
+
+    /// No-op stub when the bridge is compiled out — the core build has no bridged state.
+    #[cfg(not(feature = "odrl-bridge"))]
+    #[inline]
+    fn reconcile_bridged_after_static(&mut self) {}
 
     /// (Re-)materialize the ACP auth view from the `.acr` graphs.
     ///
@@ -176,6 +225,7 @@ impl PodStore {
     /// agent/client IRIs; reasoner failure).
     pub fn materialize_acp(&mut self) -> Result<MaterializeStats, String> {
         let stats = materialize_acp(&mut self.graph)?;
+        self.reconcile_bridged_after_static();
         self.reindex();
         Ok(stats)
     }
@@ -454,7 +504,9 @@ impl PodStore {
     ) -> odrl_bridge::BridgeOutcome {
         let outcome = odrl_bridge::materialize_permission(&mut self.graph, policy, request);
         if outcome.granted {
-            self.reindex(); // a new grant changes the auth view → rebuild index + drop cache
+            // Track for refresh/retraction (sq-dpk4), then rebuild index + drop cache.
+            self.bridge_ledger.record(policy, request, odrl_bridge::BridgeKind::Permission);
+            self.reindex();
         }
         outcome
     }
@@ -481,7 +533,8 @@ impl PodStore {
     ) -> odrl_bridge::BridgeOutcome {
         let outcome = odrl_bridge::materialize_prohibition(&mut self.graph, policy, request);
         if outcome.prohibited {
-            self.reindex(); // a new deny changes the auth view → rebuild index + drop cache
+            self.bridge_ledger.record(policy, request, odrl_bridge::BridgeKind::Prohibition);
+            self.reindex();
         }
         outcome
     }
@@ -503,7 +556,8 @@ impl PodStore {
     ) -> odrl_bridge::BridgeOutcome {
         let outcome = odrl_bridge::materialize_policy(&mut self.graph, policy, request);
         if outcome.granted || outcome.prohibited {
-            self.reindex(); // a new grant/deny changes the auth view → rebuild + drop cache
+            self.bridge_ledger.record(policy, request, odrl_bridge::BridgeKind::Policy);
+            self.reindex();
         }
         outcome
     }
@@ -529,9 +583,93 @@ impl PodStore {
         let outcome =
             odrl_bridge::materialize_permission_conditional(&mut self.graph, policy, request);
         if outcome.granted {
-            self.reindex(); // a new (conditional) grant changes the auth view → rebuild
+            self.bridge_ledger.record(
+                policy,
+                request,
+                odrl_bridge::BridgeKind::PermissionConditional,
+            );
+            self.reindex();
         }
         outcome
+    }
+
+    /// [OPUS-4.8] sq-dpk4 — re-evaluate **every bridged ODRL grant** this store is
+    /// tracking against its (possibly changed) policy, and **retract** the ones that no
+    /// longer hold, while preserving static WAC/ACP grants and still-valid bridged
+    /// grants. Call this after an ODRL policy changes — a permission is withdrawn, a
+    /// time window lapses, or a re-evaluation now Denies — so a STALE bridged grant
+    /// loses access (the gap from sq-h3uk/#280: the bridge only ever appended, never
+    /// retracted).
+    ///
+    /// # How it works
+    ///
+    /// The auth view is rebuilt as `static_baseline ∪ replay(still-valid bridged
+    /// entries)`: the `<urn:sparq:auth>` view is reset to the static (WAC/ACP) baseline
+    /// captured at the last `materialize_wac`/`materialize_acp`, the bridged-provenance
+    /// graph is cleared, and each tracked `(policy, request)` is re-evaluated through its
+    /// original bridge entry point. An entry that still yields a grant is re-applied; an
+    /// entry that now yields nothing is dropped (retracted). The session index is rebuilt
+    /// and the cache dropped, so the change takes effect on the next
+    /// [`PodStore::accessible`] / [`PodStore::query_as`].
+    ///
+    /// Returns the number of bridged grants RETRACTED.
+    ///
+    /// # Fail-closed (security-sensitive — access retraction)
+    ///
+    /// - A withdrawn permission, a lapsed time window, or a re-evaluation that now Denies
+    ///   (including a now-matching prohibition) emits nothing on replay → the grant is
+    ///   removed → access is GONE. On any ambiguous re-evaluation the underlying ODRL
+    ///   evaluator denies, so the entry is retracted rather than left stale.
+    /// - A static WAC/ACP grant is never in the ledger, never re-evaluated, and always in
+    ///   the baseline — refresh can neither widen nor drop it.
+    /// - If the policy supplied to refresh differs from what was bridged, pass the new
+    ///   policy by re-running the relevant `materialize_odrl_*` (which re-records) before
+    ///   refreshing, OR rely on the policy embedded in the tracked entry; this method
+    ///   replays the policy AS TRACKED — to refresh against a mutated policy, call the
+    ///   bridge entry point again with the new policy first.
+    #[cfg(feature = "odrl-bridge")]
+    pub fn refresh_odrl_grants(&mut self) -> usize {
+        let retracted = self.bridge_ledger.refresh(&mut self.graph);
+        self.reindex();
+        retracted
+    }
+
+    /// [OPUS-4.8] sq-dpk4 — refresh the bridged grant for one slot against an **updated**
+    /// policy / request, then re-evaluate the whole ledger.
+    ///
+    /// This is the entry point for the real revocation cases: the ODRL `policy` changed
+    /// (a permission withdrawn, a prohibition added) or the request context moved on (a
+    /// time window lapsed — pass a `request` carrying the current `odrl:dateTime`). It
+    /// replaces the tracked `(policy, request)` for the grant slot matching
+    /// `(kind, request.target, request.party)` with the supplied ones, then runs
+    /// [`PodStore::refresh_odrl_grants`]: the updated entry is re-evaluated and, if it no
+    /// longer holds, RETRACTED — access is gone.
+    ///
+    /// Returns `(matched, retracted)`: `matched` is whether a tracked grant slot was
+    /// updated (`false` ⇒ nothing tracked for that `(kind, target, party)`, nothing
+    /// changed), and `retracted` is the total number of bridged grants retracted by the
+    /// ensuing refresh.
+    ///
+    /// Fail-closed exactly as [`PodStore::refresh_odrl_grants`]: a now-Deny / lapsed /
+    /// withdrawn / now-prohibited re-evaluation loses access, static grants are untouched.
+    #[cfg(feature = "odrl-bridge")]
+    pub fn refresh_odrl_grant(
+        &mut self,
+        policy: &sparq_policy::Policy,
+        request: &sparq_policy::Request,
+        kind: odrl_bridge::BridgeKind,
+    ) -> (bool, usize) {
+        let matched = self.bridge_ledger.update(policy, request, kind);
+        let retracted = self.bridge_ledger.refresh(&mut self.graph);
+        self.reindex();
+        (matched, retracted)
+    }
+
+    /// [OPUS-4.8] sq-dpk4 — the bridge ledger (tracked bridged grants + static
+    /// baseline), for inspection/audit. Only present under the `odrl-bridge` feature.
+    #[cfg(feature = "odrl-bridge")]
+    pub fn bridge_ledger(&self) -> &odrl_bridge::BridgeLedger {
+        &self.bridge_ledger
     }
 
     /// The current auth index (for direct inspection/tests).

--- a/crates/sparq-solid/src/odrl_bridge.rs
+++ b/crates/sparq-solid/src/odrl_bridge.rs
@@ -76,7 +76,7 @@
 //! and the deny **wins** at enforcement time.
 
 use crate::authindex::{Mode, AUTHENTICATED, PUBLIC};
-use crate::{AUTH_GRAPH, AUTH_NS};
+use crate::{AUTH_BRIDGED_GRAPH, AUTH_GRAPH, AUTH_NS};
 use oxrdf::{NamedNode, Term};
 use sparq_core::dict::Dict;
 use sparq_core::Graph;
@@ -169,6 +169,11 @@ pub struct BridgeOutcome {
     /// Human-readable reason a grant/deny was NOT materialized (the ODRL decision's
     /// caveats, an unmapped action, or a missing party/target). Empty on success.
     pub reasons: Vec<String>,
+    /// The exact auth-view triples this call materialized (allow grant, deny, and/or
+    /// the conditional-grant head triples), for the bridge ledger to track so a later
+    /// refresh can retract precisely these. Empty when nothing was materialized.
+    /// [OPUS-4.8] sq-dpk4.
+    pub(crate) emitted: Vec<[Term; 3]>,
 }
 
 impl BridgeOutcome {
@@ -269,12 +274,13 @@ pub fn materialize_permission(
 
     // 4. Materialize `party auth:<mode> target` into the auth view.
     let pred = format!("{AUTH_NS}{}", mode_predicate(mode));
-    append_grant(graph, party, &pred, target);
+    let triple = append_grant(graph, party, &pred, target);
 
     BridgeOutcome {
         granted: true,
         mode: Some(mode),
         grant_triple: Some((party.to_owned(), pred, target.to_owned())),
+        emitted: vec![triple],
         ..BridgeOutcome::default()
     }
 }
@@ -378,12 +384,13 @@ pub fn materialize_prohibition(
 
     // 4. Materialize `party auth:deny<Mode> target` into the auth view.
     let pred = format!("{AUTH_NS}{}", deny_predicate(mode));
-    append_grant(graph, party, &pred, target);
+    let triple = append_grant(graph, party, &pred, target);
 
     BridgeOutcome {
         prohibited: true,
         mode: Some(mode),
         deny_triple: Some((party.to_owned(), pred, target.to_owned())),
+        emitted: vec![triple],
         ..BridgeOutcome::default()
     }
 }
@@ -412,6 +419,8 @@ pub fn materialize_policy(graph: &mut Graph, policy: &Policy, request: &Request)
 
     let mut reasons = allow.reasons;
     reasons.extend(deny.reasons);
+    let mut emitted = allow.emitted;
+    emitted.extend(deny.emitted);
     BridgeOutcome {
         granted: allow.granted,
         prohibited: deny.prohibited,
@@ -420,41 +429,79 @@ pub fn materialize_policy(graph: &mut Graph, policy: &Policy, request: &Request)
         grant_triple: allow.grant_triple,
         deny_triple: deny.deny_triple,
         reasons,
+        emitted,
     }
 }
 
 /// Append a single `subject predicate object` triple to the `<urn:sparq:auth>`
-/// named graph, preserving the triples already there (the WAC/ACP grants). Rebuilds
-/// the auth sub-graph from its existing triples + the new one via [`Graph::from_parts`].
-fn append_grant(graph: &mut Graph, subject: &str, predicate: &str, object: &str) {
+/// named graph, preserving the triples already there (the WAC/ACP grants), and
+/// **mirror it into the bridged-provenance graph** ([`AUTH_BRIDGED_GRAPH`]) so the
+/// triple is structurally marked as bridged (vs static) — see [`mirror_bridged`].
+/// Returns the emitted triple so the caller can record it in its bridge ledger
+/// ([OPUS-4.8] sq-dpk4). Idempotent: an identical grant is not duplicated.
+fn append_grant(graph: &mut Graph, subject: &str, predicate: &str, object: &str) -> [Term; 3] {
     let s = Term::NamedNode(NamedNode::new_unchecked(subject));
     let p = Term::NamedNode(NamedNode::new_unchecked(predicate));
     let o = Term::NamedNode(NamedNode::new_unchecked(object));
-    let auth_name = Term::NamedNode(NamedNode::new_unchecked(AUTH_GRAPH));
+    let triple = [s, p, o];
+    append_bridged_triples(graph, std::slice::from_ref(&triple));
+    triple
+}
 
-    // Collect the existing auth-view triples (if any) as terms, add the grant, then
-    // re-intern into a fresh sub-graph dictionary (matches install_auth_view).
-    let mut terms: Vec<[Term; 3]> = match graph.named.iter().find(|(n, _)| *n == auth_name) {
+/// Append `new_triples` to BOTH the `<urn:sparq:auth>` enforcement view and the
+/// `<urn:sparq:auth-bridged>` provenance graph, preserving existing triples in each
+/// and skipping duplicates (idempotent). Mirroring into the provenance graph is what
+/// lets a later refresh/static-re-materialization tell bridged triples apart from
+/// static WAC/ACP grants without ever inspecting predicate shape. [OPUS-4.8] sq-dpk4.
+fn append_bridged_triples(graph: &mut Graph, new_triples: &[[Term; 3]]) {
+    extend_named_graph(graph, AUTH_GRAPH, new_triples);
+    extend_named_graph(graph, AUTH_BRIDGED_GRAPH, new_triples);
+}
+
+/// Re-intern `name`'s existing triples plus `additions` (deduplicated) into a fresh
+/// sub-graph dictionary and swap it in (matches `install_auth_view`'s rebuild shape).
+fn extend_named_graph(graph: &mut Graph, name: &str, additions: &[[Term; 3]]) {
+    let g_name = Term::NamedNode(NamedNode::new_unchecked(name));
+    let mut terms: Vec<[Term; 3]> = match graph.named.iter().find(|(n, _)| *n == g_name) {
         Some((_, sub)) => crate::loader::graph_triples(sub),
         None => Vec::new(),
     };
-    // Idempotent: don't duplicate an identical grant triple.
-    let new_triple = [s, p, o];
-    if !terms.contains(&new_triple) {
-        terms.push(new_triple);
+    for t in additions {
+        if !terms.contains(t) {
+            terms.push(t.clone());
+        }
     }
+    install_triples(graph, name, terms);
+}
 
+/// Replace `name`'s sub-graph with exactly `terms` (re-interned into a fresh dict).
+/// When `terms` is empty the named graph is removed entirely (fail-closed: no empty
+/// shell left behind that a reader could otherwise treat as an existing-but-empty view).
+fn install_triples(graph: &mut Graph, name: &str, terms: Vec<[Term; 3]>) {
+    let g_name = Term::NamedNode(NamedNode::new_unchecked(name));
+    if terms.is_empty() {
+        graph.named.retain(|(n, _)| *n != g_name);
+        return;
+    }
     let mut dict = Dict::new();
     let ids: Vec<[sparq_core::dict::Id; 3]> = terms
         .iter()
         .map(|t| [dict.intern(&t[0]), dict.intern(&t[1]), dict.intern(&t[2])])
         .collect();
-    let auth = Graph::from_parts(dict, ids);
-
-    if let Some(slot) = graph.named.iter_mut().find(|(n, _)| *n == auth_name) {
-        slot.1 = auth;
+    let sub = Graph::from_parts(dict, ids);
+    if let Some(slot) = graph.named.iter_mut().find(|(n, _)| *n == g_name) {
+        slot.1 = sub;
     } else {
-        graph.named.push((auth_name, auth));
+        graph.named.push((g_name, sub));
+    }
+}
+
+/// The triples currently in a named graph (empty if absent).
+fn named_graph_triples(graph: &Graph, name: &str) -> Vec<[Term; 3]> {
+    let g_name = Term::NamedNode(NamedNode::new_unchecked(name));
+    match graph.named.iter().find(|(n, _)| *n == g_name) {
+        Some((_, sub)) => crate::loader::graph_triples(sub),
+        None => Vec::new(),
     }
 }
 
@@ -651,11 +698,12 @@ pub fn materialize_permission_conditional(
                     ));
                     continue;
                 }
-                let first = append_conditional_grants(graph, &agents, mode, target);
+                let (first, emitted) = append_conditional_grants(graph, &agents, mode, target);
                 return BridgeOutcome {
                     granted: true,
                     mode: Some(mode),
                     grant_triple: Some(first),
+                    emitted,
                     ..BridgeOutcome::default()
                 };
             }
@@ -719,20 +767,17 @@ fn rule_action_target_match(rule: &Rule, request: &Request, _mode: Mode, target:
 }
 
 
-/// Append `auth:ConditionalGrant` allow triples for each agent head onto the
-/// `<urn:sparq:auth>` view, preserving existing triples. Returns the
-/// `(agent, auth:effect, graph)` audit anchor of the first grant.
+/// Append `auth:ConditionalGrant` allow triples for each agent head onto BOTH the
+/// `<urn:sparq:auth>` view and the bridged-provenance graph, preserving existing
+/// triples. Returns the `(agent, auth:effect, graph)` audit anchor of the first grant
+/// AND the full set of emitted head triples (for the bridge ledger). [OPUS-4.8] sq-dpk4.
 fn append_conditional_grants(
     graph: &mut Graph,
     agents: &[String],
     mode: Mode,
     target: &str,
-) -> (String, String, String) {
-    let auth_name = Term::NamedNode(NamedNode::new_unchecked(AUTH_GRAPH));
-    let mut terms: Vec<[Term; 3]> = match graph.named.iter().find(|(n, _)| *n == auth_name) {
-        Some((_, sub)) => crate::loader::graph_triples(sub),
-        None => Vec::new(),
-    };
+) -> ((String, String, String), Vec<[Term; 3]>) {
+    let mut emitted: Vec<[Term; 3]> = Vec::new();
 
     let type_p = NamedNode::new_unchecked(RDF_TYPE);
     let cond_class = NamedNode::new_unchecked(format!("{AUTH_NS}ConditionalGrant"));
@@ -767,8 +812,8 @@ fn append_conditional_grants(
             [g.clone(), Term::NamedNode(graph_p.clone()), Term::NamedNode(graph_o.clone())],
         ];
         for t in head {
-            if !terms.contains(&t) {
-                terms.push(t);
+            if !emitted.contains(&t) {
+                emitted.push(t);
             }
         }
         if first.is_none() {
@@ -780,20 +825,195 @@ fn append_conditional_grants(
         }
     }
 
-    let mut dict = Dict::new();
-    let ids: Vec<[sparq_core::dict::Id; 3]> = terms
-        .iter()
-        .map(|t| [dict.intern(&t[0]), dict.intern(&t[1]), dict.intern(&t[2])])
-        .collect();
-    let auth = Graph::from_parts(dict, ids);
-    if let Some(slot) = graph.named.iter_mut().find(|(n, _)| *n == auth_name) {
-        slot.1 = auth;
-    } else {
-        graph.named.push((auth_name, auth));
-    }
-
-    first.expect("at least one agent head emitted")
+    append_bridged_triples(graph, &emitted);
+    (first.expect("at least one agent head emitted"), emitted)
 }
 
 /// `rdf:type` IRI, for the conditional-grant class triple.
 const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+// ============================================================================
+// [OPUS-4.8] sq-dpk4 — refresh / revocation of bridged ODRL grants.
+//
+// THE GAP this closes: the materialize_* functions above only ever APPEND. When the
+// underlying ODRL policy changes — a permission withdrawn, a time window lapsed, a
+// re-evaluation that now Denies — the previously-materialized grant stays in the auth
+// view, so access that should be GONE persists. And a wholesale static WAC/ACP
+// re-materialization (`install_auth_view`) rebuilds `<urn:sparq:auth>` and would drop
+// every bridged grant. Both are reconciled by tracking each bridged materialization in
+// a ledger and REPLAYING the ledger over a captured static baseline on demand.
+//
+// FAIL-CLOSED: refresh rebuilds the auth view as `static_baseline ∪ replay(ledger)`.
+// An entry whose ODRL re-evaluation no longer yields a grant emits NOTHING on replay,
+// so it is dropped — a withdrawn / lapsed / now-Denied grant LOSES access. The static
+// baseline is captured independently (the exact `install_auth_view` output), so a
+// static grant is never inspected, re-evaluated, or dropped by this path.
+// ============================================================================
+
+/// Which bridge entry point produced a tracked grant — replayed verbatim on refresh so
+/// the SAME fail-closed evaluation re-runs (a withdrawn/lapsed/now-Denied policy emits
+/// nothing → the entry is retracted). [OPUS-4.8] sq-dpk4.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeKind {
+    /// [`materialize_permission`] — a definite-Permit allow grant.
+    Permission,
+    /// [`materialize_prohibition`] — a matched-Prohibition deny.
+    Prohibition,
+    /// [`materialize_policy`] — both sides of a policy at once.
+    Policy,
+    /// [`materialize_permission_conditional`] — a re-checked conditional grant (or its
+    /// one-shot fallback).
+    PermissionConditional,
+}
+
+/// One tracked bridged materialization: the originating ODRL `(policy, request, kind)`
+/// plus the auth triples it last emitted. The provenance that distinguishes a bridged
+/// grant from a static WAC/ACP one (those are never in the ledger), and the unit of
+/// retraction on refresh. [OPUS-4.8] sq-dpk4.
+#[derive(Debug, Clone)]
+pub struct BridgeEntry {
+    /// The ODRL policy this grant was bridged from.
+    pub policy: Policy,
+    /// The request `(action, target, party, context, duties)` it was evaluated against.
+    pub request: Request,
+    /// Which bridge entry point produced it (replayed verbatim).
+    pub kind: BridgeKind,
+}
+
+/// The ordered set of bridged materializations a [`crate::PodStore`] is tracking, plus
+/// the static-baseline auth view captured at the last static (WAC/ACP) materialization.
+///
+/// # The model (sq-dpk4)
+///
+/// - Each successful bridge call records a [`BridgeEntry`] (the `(policy, request, kind)`).
+/// - [`BridgeLedger::capture_static_baseline`] snapshots the EXACT `<urn:sparq:auth>`
+///   triples produced by a static WAC/ACP materialization — the grants the refresh must
+///   never touch. Capturing the install output directly (not by subtracting provenance)
+///   means a static grant byte-identical to a bridged one still survives a refresh.
+/// - [`BridgeLedger::refresh`] rebuilds the auth view as `static_baseline ∪
+///   replay(valid entries)`: it resets `<urn:sparq:auth>` to the baseline, clears the
+///   provenance graph, replays every entry, and DROPS the entries that re-evaluate to
+///   nothing (withdrawn permission / lapsed window / now-Deny / now-matching prohibition).
+///
+/// Fail-closed throughout: a retracted entry loses access immediately, and on any
+/// ambiguity the re-evaluation denies (the underlying evaluator is fail-closed), so the
+/// entry is dropped rather than left stale.
+#[derive(Debug, Clone, Default)]
+pub struct BridgeLedger {
+    entries: Vec<BridgeEntry>,
+    /// The static (WAC/ACP) `<urn:sparq:auth>` triples to rebuild from on refresh.
+    /// `None` until the first static materialization is captured (a store that only
+    /// ever bridged grants has an empty static baseline — refresh starts from nothing).
+    static_baseline: Option<Vec<[Term; 3]>>,
+}
+
+impl BridgeLedger {
+    /// A fresh, empty ledger.
+    pub fn new() -> BridgeLedger {
+        BridgeLedger::default()
+    }
+
+    /// The tracked bridged entries (for inspection/audit).
+    pub fn entries(&self) -> &[BridgeEntry] {
+        &self.entries
+    }
+
+    /// Record a successful bridge of `kind` for `(policy, request)`. Call this only when
+    /// the corresponding `materialize_*` returned a materialized outcome (`granted` /
+    /// `prohibited`). A no-op materialization is NOT tracked (nothing to retract).
+    ///
+    /// Idempotent on `(kind, target, party)`: re-recording the same grant slot REPLACES
+    /// the tracked `(policy, request)` rather than appending a duplicate, so a caller can
+    /// re-bridge with an updated policy/request and the ledger tracks exactly one entry
+    /// per logical grant.
+    pub fn record(&mut self, policy: &Policy, request: &Request, kind: BridgeKind) {
+        let slot = (kind, request.target.clone(), request.party.clone());
+        if let Some(e) = self.entries.iter_mut().find(|e| {
+            (e.kind, e.request.target.clone(), e.request.party.clone()) == slot
+        }) {
+            e.policy = policy.clone();
+            e.request = request.clone();
+            return;
+        }
+        self.entries.push(BridgeEntry { policy: policy.clone(), request: request.clone(), kind });
+    }
+
+    /// Replace the tracked `(policy, request)` for the grant slot matching
+    /// `(kind, request.target, request.party)` with the supplied (updated) ones, so the
+    /// next [`BridgeLedger::refresh`] re-evaluates against the NEW policy / request
+    /// context (a withdrawn permission, a lapsed window, a now-Deny). Returns `true` if a
+    /// tracked entry matched. A no-match returns `false` and changes nothing — there is
+    /// no bridged grant to refresh for that slot. [OPUS-4.8] sq-dpk4.
+    pub fn update(&mut self, policy: &Policy, request: &Request, kind: BridgeKind) -> bool {
+        let slot = (kind, request.target.clone(), request.party.clone());
+        match self.entries.iter_mut().find(|e| {
+            (e.kind, e.request.target.clone(), e.request.party.clone()) == slot
+        }) {
+            Some(e) => {
+                e.policy = policy.clone();
+                e.request = request.clone();
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Snapshot the current `<urn:sparq:auth>` triples as the static baseline — the
+    /// grants a refresh rebuilds from and never re-evaluates. Call this right after a
+    /// static WAC/ACP materialization (which produced the view) and BEFORE replaying any
+    /// bridged grant on top.
+    pub fn capture_static_baseline(&mut self, graph: &Graph) {
+        self.static_baseline = Some(named_graph_triples(graph, AUTH_GRAPH));
+    }
+
+    /// Re-evaluate every tracked bridged grant against its (possibly changed) ODRL
+    /// policy and rebuild the auth view as `static_baseline ∪ replay(still-valid
+    /// entries)`, retracting the grants that no longer hold. [OPUS-4.8] sq-dpk4.
+    ///
+    /// Returns the number of entries RETRACTED (re-evaluated to nothing). The caller
+    /// ([`crate::PodStore::refresh_odrl_grants`]) reindexes afterward so the change
+    /// takes effect on the next `accessible`/`query_as`.
+    ///
+    /// # Fail-closed
+    ///
+    /// - The view is first reset to the static baseline (or empty if none captured) and
+    ///   the provenance graph cleared, so NO stale bridged triple can survive unless an
+    ///   entry re-emits it.
+    /// - Each entry is replayed through its original `materialize_*` function, which
+    ///   re-runs the fail-closed ODRL evaluation: a withdrawn permission, a lapsed time
+    ///   window, a now-matching prohibition, or any ambiguous re-eval emits nothing, and
+    ///   the entry is dropped.
+    /// - A static grant is never in `entries`, never re-evaluated, and always present in
+    ///   the baseline — refresh cannot widen or drop it.
+    pub fn refresh(&mut self, graph: &mut Graph) -> usize {
+        // 1. Reset the enforcement view to the captured static baseline, and clear ALL
+        //    bridged provenance — nothing bridged survives unless an entry re-emits it.
+        let baseline = self.static_baseline.clone().unwrap_or_default();
+        install_triples(graph, AUTH_GRAPH, baseline);
+        install_triples(graph, AUTH_BRIDGED_GRAPH, Vec::new());
+
+        // 2. Replay each entry; keep only those that still materialize something.
+        let entries = std::mem::take(&mut self.entries);
+        let before = entries.len();
+        for entry in entries {
+            let out = replay(graph, &entry);
+            if !out.emitted.is_empty() {
+                self.entries.push(entry);
+            }
+        }
+        before - self.entries.len()
+    }
+}
+
+/// Re-run a tracked entry's original bridge function against the current graph,
+/// re-evaluating its ODRL policy and re-emitting iff it still holds. [OPUS-4.8] sq-dpk4.
+fn replay(graph: &mut Graph, entry: &BridgeEntry) -> BridgeOutcome {
+    match entry.kind {
+        BridgeKind::Permission => materialize_permission(graph, &entry.policy, &entry.request),
+        BridgeKind::Prohibition => materialize_prohibition(graph, &entry.policy, &entry.request),
+        BridgeKind::Policy => materialize_policy(graph, &entry.policy, &entry.request),
+        BridgeKind::PermissionConditional => {
+            materialize_permission_conditional(graph, &entry.policy, &entry.request)
+        }
+    }
+}

--- a/crates/sparq-solid/tests/odrl_bridge.rs
+++ b/crates/sparq-solid/tests/odrl_bridge.rs
@@ -727,3 +727,311 @@ fn no_constraint_conditional_grants_public() {
     assert!(reads(&mut store, BOB));
     assert!(!store.accessible(&Session::default(), Mode::Read).is_empty(), "anon public read");
 }
+
+// ===========================================================================
+// [OPUS-4.8] sq-dpk4 — refresh / REVOCATION of bridged ODRL grants when the
+// underlying ODRL policy changes. SECURITY-SENSITIVE: a withdrawn permission, a
+// lapsed time window, or a re-evaluation that now Denies must LOSE access; a static
+// WAC/ACP grant must NEVER be dropped; a still-valid bridged grant must survive.
+// All assertions go through the REAL enforcement path (accessible / query_as).
+// ===========================================================================
+use sparq_solid::BridgeKind;
+
+/// alice MAY read n1 ONLY until 2026-01-01 (a time-windowed permission).
+fn windowed_read_policy() -> sparq_policy::Policy {
+    parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/win> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lteq ;
+                      odrl:rightOperand "2026-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ] ] .
+"#,
+        "turtle",
+    )
+    .expect("policy parses")
+}
+
+/// A policy that grants NOTHING (the permission has been WITHDRAWN entirely).
+fn empty_policy() -> sparq_policy::Policy {
+    parse_policy_str(
+        r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> . <urn:pol/read> a odrl:Set ."#,
+        "turtle",
+    )
+    .expect("policy parses")
+}
+
+// 20. ADVERSARIAL "stale grant loses access": a bridged grant is materialized →
+//     access granted; the ODRL policy then WITHDRAWS the permission → refresh →
+//     access is GONE through the real enforcement path. We adversarially check the
+//     grant did not survive in ANY form (accessible, query_as, the raw auth view, the
+//     provenance graph) and that re-refreshing cannot resurrect it.
+#[test]
+fn withdrawn_permission_loses_access_after_refresh() {
+    let mut store = PodStore::new(pod());
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+
+    // Materialize → alice has read.
+    assert!(store.materialize_odrl_permission(&read_policy(), &req).granted);
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert!(
+        store.accessible(&alice, Mode::Read).iter().any(|g| g.as_str() == N1),
+        "bridged grant is live before withdrawal",
+    );
+    let sel = "SELECT ?t WHERE { ?s <https://ex.dev/ns#title> ?t }";
+    assert_eq!(store.query_as(&alice, Mode::Read, sel).unwrap().rows.len(), 1);
+
+    // The policy WITHDRAWS the permission → refresh against the new (empty) policy.
+    let (matched, retracted) =
+        store.refresh_odrl_grant(&empty_policy(), &req, BridgeKind::Permission);
+    assert!(matched, "the tracked grant slot matched");
+    assert_eq!(retracted, 1, "the withdrawn grant was retracted");
+
+    // ADVERSARIAL: access is GONE through every observable surface.
+    assert!(
+        store.accessible(&alice, Mode::Read).is_empty(),
+        "STALE GRANT MUST LOSE ACCESS: alice can no longer read n1",
+    );
+    assert_eq!(
+        store.query_as(&alice, Mode::Read, sel).unwrap().rows.len(),
+        0,
+        "query_as returns nothing after revocation",
+    );
+    // The raw auth view holds no residual bridged grant for alice…
+    let leftover = "SELECT ?p ?o WHERE { GRAPH <urn:sparq:auth> { \
+        <https://alice.ex/card#me> ?p ?o } }";
+    assert_eq!(sparq_engine::query(&store.graph, leftover).unwrap().rows.len(), 0,
+        "no residual alice triple in the enforcement view");
+    // …and the provenance graph was cleared of it.
+    let prov = "SELECT ?s ?p ?o WHERE { GRAPH <urn:sparq:auth-bridged> { ?s ?p ?o } }";
+    assert_eq!(sparq_engine::query(&store.graph, prov).unwrap().rows.len(), 0,
+        "no residual provenance after retraction");
+    // Re-refreshing cannot resurrect a dropped grant (the ledger is empty now).
+    assert_eq!(store.refresh_odrl_grants(), 0, "nothing left to retract");
+    assert!(store.accessible(&alice, Mode::Read).is_empty(), "stays revoked");
+}
+
+// 21. LAPSED TIME WINDOW: a windowed grant valid at materialization-time loses access
+//     once the window lapses (re-evaluate with a NOW past the bound) → refresh → gone.
+#[test]
+fn lapsed_time_window_loses_access_after_refresh() {
+    let mut store = PodStore::new(pod());
+    let pol = windowed_read_policy();
+
+    // In-window request → granted.
+    let in_window = Request::new(odrl("read"))
+        .on(N1)
+        .by(ALICE)
+        .with(odrl("dateTime"), Value::DateTime("2025-06-01T00:00:00Z".to_owned()));
+    assert!(store.materialize_odrl_permission(&pol, &in_window).granted);
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert!(store.accessible(&alice, Mode::Read).iter().any(|g| g.as_str() == N1));
+
+    // The window LAPSES: re-evaluate with a NOW past the bound (same policy, new ctx).
+    let now_past = Request::new(odrl("read"))
+        .on(N1)
+        .by(ALICE)
+        .with(odrl("dateTime"), Value::DateTime("2026-06-16T00:00:00Z".to_owned()));
+    let (matched, retracted) =
+        store.refresh_odrl_grant(&pol, &now_past, BridgeKind::Permission);
+    assert!(matched);
+    assert_eq!(retracted, 1, "lapsed window retracts the grant");
+    assert!(
+        store.accessible(&alice, Mode::Read).is_empty(),
+        "lapsed time window: access gone",
+    );
+}
+
+// 22. RE-EVAL NOW DENIES (a prohibition is added): a bridged write grant is revoked
+//     when the refreshed policy now carries a matching prohibition (deny-overrides).
+#[test]
+fn reeval_now_denies_loses_access_after_refresh() {
+    let mut store = PodStore::new(pod());
+    let permit = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/w> a odrl:Set ; odrl:permission [
+    odrl:action odrl:modify ; odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let req = Request::new(odrl("modify")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_policy(&permit, &req).granted);
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert!(store.accessible(&alice, Mode::Write).iter().any(|g| g.as_str() == N1));
+
+    // The policy now ADDS a prohibition on the same action → re-eval Denies.
+    let now_prohibited = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/w> a odrl:Set ;
+    odrl:permission [ odrl:action odrl:modify ; odrl:target <https://pod.ex/notes/n1> ;
+        odrl:assignee <https://alice.ex/card#me> ] ;
+    odrl:prohibition [ odrl:action odrl:modify ; odrl:target <https://pod.ex/notes/n1> ;
+        odrl:assignee <https://alice.ex/card#me> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let (matched, _) = store.refresh_odrl_grant(&now_prohibited, &req, BridgeKind::Policy);
+    assert!(matched);
+    // deny-overrides: even though materialize_policy emits a deny on replay, the net
+    // enforcement result is DENIED (the allow is overridden upstream / by the deny).
+    assert!(
+        store.accessible(&alice, Mode::Write).is_empty(),
+        "re-eval now Denies: alice can no longer write n1",
+    );
+}
+
+// 23. A STILL-VALID bridged grant SURVIVES refresh (no spurious retraction).
+#[test]
+fn valid_bridged_grant_survives_refresh() {
+    let mut store = PodStore::new(pod());
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_permission(&read_policy(), &req).granted);
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert!(store.accessible(&alice, Mode::Read).iter().any(|g| g.as_str() == N1));
+
+    // Plain refresh (policy unchanged) re-evaluates and KEEPS the still-valid grant.
+    assert_eq!(store.refresh_odrl_grants(), 0, "valid grant not retracted");
+    assert!(
+        store.accessible(&alice, Mode::Read).iter().any(|g| g.as_str() == N1),
+        "still-valid bridged grant survives refresh",
+    );
+    // Refresh against the SAME policy also keeps it.
+    let (matched, retracted) =
+        store.refresh_odrl_grant(&read_policy(), &req, BridgeKind::Permission);
+    assert!(matched);
+    assert_eq!(retracted, 0);
+    assert!(store.accessible(&alice, Mode::Read).iter().any(|g| g.as_str() == N1));
+}
+
+// 24. A STATIC WAC grant is NOT dropped by a bridged-grant refresh (provenance keeps
+//     static and bridged apart). bob (static) keeps read; alice (bridged, then revoked)
+//     loses it — in the SAME store, through the SAME enforcement path.
+#[test]
+fn static_grant_not_dropped_by_refresh() {
+    // bob's static .acl grant + a content graph.
+    let nq = r#"
+<https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> "hello" <https://pod.ex/notes/n1> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.ex/notes/n1> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#agent> <https://bob.ex/card#me> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/notes/n1.acl> .
+"#;
+    let mut store = PodStore::new(Graph::load_dataset(nq, "nquads").unwrap());
+    store.materialize_wac().expect("wac materializes");
+
+    fn reads_n1(s: &mut PodStore, agent: &str) -> bool {
+        let sess = Session { agent: Some(agent), client: None };
+        s.accessible(&sess, Mode::Read).iter().any(|g| g.as_str() == N1)
+    }
+
+    // Bridge alice on top of bob's static grant.
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_permission(&read_policy(), &req).granted);
+    assert!(reads_n1(&mut store, BOB), "bob static before");
+    assert!(reads_n1(&mut store, ALICE), "alice bridged before");
+
+    // Revoke alice's bridged grant. bob's STATIC grant must be untouched.
+    let (matched, retracted) =
+        store.refresh_odrl_grant(&empty_policy(), &req, BridgeKind::Permission);
+    assert!(matched);
+    assert_eq!(retracted, 1);
+    assert!(reads_n1(&mut store, BOB), "STATIC GRANT PRESERVED: bob still reads n1");
+    assert!(!reads_n1(&mut store, ALICE), "bridged grant revoked");
+}
+
+// 25. PROVENANCE distinguishes bridged vs static: a static grant never appears in the
+//     bridged-provenance graph; a bridged grant does (and exactly the auth triple it
+//     emitted).
+#[test]
+fn provenance_distinguishes_bridged_from_static() {
+    let nq = r#"
+<https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> "hello" <https://pod.ex/notes/n1> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.ex/notes/n1> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#agent> <https://bob.ex/card#me> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/notes/n1.acl> .
+"#;
+    let mut store = PodStore::new(Graph::load_dataset(nq, "nquads").unwrap());
+    store.materialize_wac().expect("wac materializes");
+    // After a pure static materialize, the provenance graph is empty.
+    let prov_all = "SELECT ?s ?p ?o WHERE { GRAPH <urn:sparq:auth-bridged> { ?s ?p ?o } }";
+    assert_eq!(sparq_engine::query(&store.graph, prov_all).unwrap().rows.len(), 0,
+        "no provenance for static grants");
+
+    // Bridge alice → exactly her grant triple appears in provenance, bob's does not.
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_permission(&read_policy(), &req).granted);
+    let alice_prov = "SELECT ?p WHERE { GRAPH <urn:sparq:auth-bridged> { \
+        <https://alice.ex/card#me> <https://sparq.dev/ns/auth#read> <https://pod.ex/notes/n1> } }";
+    assert_eq!(sparq_engine::query(&store.graph, alice_prov).unwrap().rows.len(), 1,
+        "alice's bridged grant is marked in provenance");
+    let bob_prov = "SELECT ?p ?o WHERE { GRAPH <urn:sparq:auth-bridged> { \
+        <https://bob.ex/card#me> ?p ?o } }";
+    assert_eq!(sparq_engine::query(&store.graph, bob_prov).unwrap().rows.len(), 0,
+        "bob's STATIC grant is NOT in provenance");
+}
+
+// 26. A STATIC RE-MATERIALIZATION re-applies still-valid bridged grants (reconcile):
+//     materialize_wac rebuilds <urn:sparq:auth> wholesale, but a valid bridged grant is
+//     replayed back on top — and a static grant change still takes effect.
+#[test]
+fn static_rematerialization_preserves_valid_bridged_grant() {
+    let nq = r#"
+<https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> "hello" <https://pod.ex/notes/n1> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.ex/notes/n1> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#agent> <https://bob.ex/card#me> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/notes/n1.acl> .
+"#;
+    let mut store = PodStore::new(Graph::load_dataset(nq, "nquads").unwrap());
+    store.materialize_wac().expect("wac");
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_permission(&read_policy(), &req).granted);
+
+    fn reads_n1(s: &mut PodStore, agent: &str) -> bool {
+        let sess = Session { agent: Some(agent), client: None };
+        s.accessible(&sess, Mode::Read).iter().any(|g| g.as_str() == N1)
+    }
+    assert!(reads_n1(&mut store, ALICE), "alice bridged before re-materialize");
+
+    // A wholesale static re-materialization would normally CLOBBER the bridged grant.
+    store.materialize_wac().expect("re-materialize");
+    assert!(reads_n1(&mut store, BOB), "bob static after re-materialize");
+    assert!(
+        reads_n1(&mut store, ALICE),
+        "RECONCILE: the valid bridged grant survives a wholesale static re-materialization",
+    );
+}
+
+// 27. FAIL-CLOSED on AMBIGUOUS re-eval: a windowed grant refreshed with NO dateTime
+//     evidence (cannot prove the window still holds) is RETRACTED (never left stale).
+#[test]
+fn ambiguous_reeval_retracts_fail_closed() {
+    let mut store = PodStore::new(pod());
+    let pol = windowed_read_policy();
+    let in_window = Request::new(odrl("read"))
+        .on(N1)
+        .by(ALICE)
+        .with(odrl("dateTime"), Value::DateTime("2025-06-01T00:00:00Z".to_owned()));
+    assert!(store.materialize_odrl_permission(&pol, &in_window).granted);
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert!(store.accessible(&alice, Mode::Read).iter().any(|g| g.as_str() == N1));
+
+    // Refresh with NO dateTime evidence → constraint cannot be proven → fail-closed Deny.
+    let no_evidence = Request::new(odrl("read")).on(N1).by(ALICE);
+    let (matched, retracted) =
+        store.refresh_odrl_grant(&pol, &no_evidence, BridgeKind::Permission);
+    assert!(matched);
+    assert_eq!(retracted, 1, "ambiguous re-eval is retracted, not left stale");
+    assert!(
+        store.accessible(&alice, Mode::Read).is_empty(),
+        "FAIL-CLOSED: no evidence the window holds → access retracted",
+    );
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -114,6 +114,17 @@ Materialize the authorization view from the access-control documents, then enfor
   stateless `(agent, client)` analogue and STAY one-shot; a rule mixing mappable +
   unmappable constraints falls back **entirely** to one-shot (fail-safe — never drops a
   bound). Mapping table in the [`usage-control-policy`](../usage-control-policy/SKILL.md) skill.
+- `store.refresh_odrl_grant(&Policy, &Request, BridgeKind)` / `refresh_odrl_grants()` —
+  **opt-in** (`odrl-bridge`; [OPUS-4.8] sq-dpk4): re-evaluate **bridged** ODRL grants when
+  the policy changes and **retract** the ones that no longer hold (a withdrawn permission, a
+  lapsed time window, a re-evaluation that now Denies) while preserving static WAC/ACP grants
+  and still-valid bridged grants. Bridged triples are tracked in a ledger and mirrored into a
+  provenance graph `<urn:sparq:auth-bridged>` (`AUTH_BRIDGED_GRAPH`) so they are structurally
+  distinguishable from static grants; refresh rebuilds the view as `static_baseline ∪
+  replay(valid bridged entries)`. **Fail-closed**: any ambiguous re-eval retracts (access
+  never left stale); a static grant is never re-evaluated or dropped. A wholesale static
+  re-materialization (`materialize_wac`/`materialize_acp`) auto-reconciles — valid bridged
+  grants are replayed back on top.
 - `Session { agent: Option<&str>, client: Option<&str> }` (caller-asserted WebID +
   `acl:origin`/`acp:client`; `None` = anonymous / any client); `Mode::{Read, Write,
   Append, Control}`; `wac_fixture()` / `acp_fixture()` (bundled demo pods).

--- a/skills/usage-control-policy/SKILL.md
+++ b/skills/usage-control-policy/SKILL.md
@@ -144,6 +144,21 @@ store.materialize_odrl_permission_conditional(&policy, &req); // policy: recipie
 
 **Why only recipient/assignee maps:** the ACP session re-check carries exactly `(agent, client)`. The recipient-of-data is precisely the session **agent**, so an agent matcher re-checks it with identical semantics. Purpose, time, and count have **no** stateless `(agent, client)` analogue, so persisting them would require either freezing the check (= the one-shot path, already correct) or a looser approximation that could over-grant — rejected.
 
+### Refresh / REVOCATION of bridged grants on policy change — [OPUS-4.8] sq-dpk4
+
+The `materialize_odrl_*` calls only ever **append**. When the underlying ODRL policy changes — a permission is **withdrawn**, a **time window lapses**, or a re-evaluation now **Denies** — the previously-materialized grant would otherwise stay in the auth view, so access that should be gone persists (the sq-h3uk/#280 correctness gap). And a wholesale static WAC/ACP re-materialization rebuilds `<urn:sparq:auth>` and would drop every bridged grant. Both are reconciled by a **bridge ledger** + a refresh entry point.
+
+- **Provenance.** Every auth triple the bridge writes into `<urn:sparq:auth>` is mirrored verbatim into a separate reserved graph `<urn:sparq:auth-bridged>` (`AUTH_BRIDGED_GRAPH`). A triple is **bridged** iff it appears there, **static** otherwise — so bridged and static grants are structurally distinguishable without inspecting predicate shape, and the enforcement reader (`AuthIndex`) is unchanged (it still reads `<urn:sparq:auth>`). The provenance graph is in the reserved `urn:sparq:` space, so a loaded dataset cannot forge it.
+- **Refresh / retract.** `PodStore::refresh_odrl_grant(&new_policy, &new_request, kind)` updates the tracked grant slot `(kind, target, party)` with the new policy / request context, then rebuilds the view as `static_baseline ∪ replay(still-valid bridged entries)`: it resets `<urn:sparq:auth>` to the static baseline captured at the last `materialize_wac`/`materialize_acp`, clears the provenance graph, and re-evaluates every tracked `(policy, request)` through its original bridge entry point. An entry that no longer holds emits nothing → it is **retracted** (access gone). `refresh_odrl_grants()` (no args) replays everything as-tracked (used to reconcile after a static re-materialization, which is automatic).
+- **Fail-closed (security-sensitive — access retraction).** A withdrawn / lapsed / now-Denied / now-prohibited / ambiguous re-evaluation loses access; the underlying evaluator is fail-closed, so on any doubt the grant is retracted, never left stale. A **static** WAC/ACP grant is never in the ledger, never re-evaluated, and always in the captured baseline (captured as the `install_auth_view` output verbatim, not by subtracting provenance — so a static grant byte-identical to a bridged one still survives) — refresh can neither widen nor drop it.
+
+```rust,ignore
+// alice was bridged a read grant; the policy then WITHDRAWS the permission.
+let (matched, retracted) =
+    store.refresh_odrl_grant(&withdrawn_policy, &req, BridgeKind::Permission);
+// matched == true, retracted == 1 → alice can no longer read (through accessible/query_as).
+```
+
 ## Learn more
 
 - Crate README: [`crates/sparq-policy/README.md`](../../crates/sparq-policy/README.md)


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-dpk4** (epic **sq-3183**): refresh / revocation of bridged ODRL grants when the underlying ODRL policy changes. Closes a real correctness gap introduced by **sq-h3uk / #280** (+#289/#294, all merged): the ODRL→AUTH_GRAPH bridge only ever **appended** a materialized grant and **never retracted** one — a withdrawn permission, a lapsed time window, or a re-evaluation that now Denies left a STALE grant, so access that should be gone persisted. Static WAC/ACP re-materialization also clobbered bridged grants. SECURITY-SENSITIVE (access retraction) — fail-closed is paramount.

All behind the off-by-default `odrl-bridge` feature; the core build carries zero ODRL state.

## Provenance (distinguish bridged vs static)
Every auth triple the bridge writes into `<urn:sparq:auth>` is mirrored verbatim into a separate reserved graph `<urn:sparq:auth-bridged>` (`AUTH_BRIDGED_GRAPH`). A triple is **bridged** iff it appears there, **static** otherwise. The enforcement reader (`AuthIndex`) is **unchanged** — it still reads `<urn:sparq:auth>`. The provenance graph is in the reserved `urn:sparq:` space, so a loaded dataset cannot forge it.

## Refresh / retraction
`PodStore` tracks each bridged `(policy, request, kind)` in a **ledger** plus the static-baseline auth view captured at the last `materialize_wac`/`materialize_acp`.
- `refresh_odrl_grant(&policy, &request, kind)` updates the tracked grant slot with the new policy/request context, then rebuilds the view as `static_baseline ∪ replay(still-valid bridged entries)`: reset `<urn:sparq:auth>` to the baseline, clear the provenance graph, re-evaluate every tracked entry through its original bridge entry point; an entry that no longer holds emits nothing → **retracted**.
- `refresh_odrl_grants()` replays everything as-tracked.
- A wholesale static re-materialization **auto-reconciles** — valid bridged grants are replayed back on top of the freshly-rebuilt static view.

## Fail-closed (security-sensitive)
A withdrawn / lapsed / now-Denied / now-prohibited / **ambiguous** re-evaluation loses access — the underlying evaluator is fail-closed, so on doubt the grant is **retracted, never left stale**. A **static** WAC/ACP grant is never in the ledger, never re-evaluated, and always in the captured baseline (captured as the materializer output verbatim, **not** by subtracting provenance — so a static grant byte-identical to a bridged one still survives a refresh) — refresh can neither widen nor drop it.

## Tests (load-bearing, through the REAL enforcement path `accessible`/`query_as`)
- **Adversarial "stale grant loses access"**: bridged grant live → policy withdraws permission → refresh → access GONE via `accessible`, `query_as`, the raw auth view, AND the provenance graph; re-refresh cannot resurrect it.
- Lapsed time window → retract; re-eval now Denies (prohibition added) → deny-overrides; still-valid bridged grant survives refresh; **static WAC grant NOT dropped** by a bridged refresh (same store, same path); provenance distinguishes bridged vs static; static re-materialization preserves a valid bridged grant; fail-closed on ambiguous re-eval (no dateTime evidence → retract).

## Gates
`cargo build` / `clippy --all-targets -D warnings` / `cargo test -p sparq-solid` clean **OFF and ON**; `sparq-policy` tests pass; `rustfmt --check` clean on the lines I touched (the crate predates the deferred workspace-wide reformat — fmt is informational in CI, clippy is the hard gate). Docs updated: `usage-control-policy` + `access-control` SKILL.md and the `sparq-solid` README (provenance + refresh/retraction + fail-closed). NON-CANONICAL timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)