### PR TITLE
fix: positional format args to clear CodeQL rust/unused-variable FPs (code-scanning→0)

### DIFF
--- a/crates/sparq-server/src/tpf.rs
+++ b/crates/sparq-server/src/tpf.rs
@@ -141,7 +141,7 @@ fn parse_term(raw: Option<&str>, pos: &str) -> Result<Option<Term>, ParseError> 
         None | Some("") => Ok(None),
         Some(s) => Term::from_str(s)
             .map(Some)
-            .map_err(|e| ParseError(format!("invalid {pos} term '{s}': {e}"))),
+            .map_err(|e| ParseError(format!("invalid {} term '{}': {e}", pos, s))),
     }
 }
 

--- a/crates/sparq-shacl/src/rules.rs
+++ b/crates/sparq-shacl/src/rules.rs
@@ -443,9 +443,9 @@ mod tests {
     /// True iff the inferred set contains a triple `<s> <p> <o>` (IRI terms).
     fn has(inf: &Inference, s: &str, p: &str, o: &str) -> bool {
         inf.triples.iter().any(|t| {
-            t.subject.to_string() == format!("<{s}>")
+            t.subject.to_string() == format!("<{}>", s)
                 && t.predicate.as_str() == p
-                && t.object.to_string() == format!("<{o}>")
+                && t.object.to_string() == format!("<{}>", o)
         })
     }
 


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

Three OPEN CodeQL `rust/unused-variable` (note-level) alerts on `main` are **false positives** on inline format-string captures. The variables ARE used — but inside `format!("…{var}…")` interpolation, which CodeQL's Rust analyzer does not track. (clippy `-D warnings` correctly does *not* flag them.)

This converts the flagged inline captures to **positional args** (`format!("<{s}>")` → `format!("<{}>", s)`), which is byte-for-byte identical output but lets CodeQL see the use.

## The FPs fixed

- `crates/sparq-shacl/src/rules.rs:446,448` — alerts **#150**, **#151** — `s` and `o`, used in `format!("<{s}>")` / `format!("<{o}>")` in the `has(…)` test helper.
- `crates/sparq-server/src/tpf.rs:144` — alert **#170** — `pos`, used in the `format!("invalid {pos} term '{s}': {e}")` error message.

(Note: `p` in `rules.rs` was *not* an inline capture — it's compared directly — so it was not flagged and is untouched. No genuinely-unused variables were found; all three are real format-captures.)

## Verification

- `cargo build -p sparq-shacl -p sparq-server` ✅
- `cargo clippy -p sparq-shacl -p sparq-server --all-targets -- -D warnings` ✅
- `cargo test -p sparq-shacl -p sparq-server` ✅ (all green, output unchanged)
- `rustfmt --check` clean on both touched files ✅

Restores **code-scanning to 0** once CodeQL re-analyzes `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
