### PR TITLE
ci(codeql): exclude redundant FP-prone rust/unused-variable (clippy -D is the real gate) → code-scanning 0 (refs #150/#151/#170)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,27 @@
+# CodeQL configuration for the Rust workspace SAST gate. [OPUS-4.8]
+#
+# Referenced from .github/workflows/codeql.yml's `github/codeql-action/init`
+# step via `config-file:`. It keeps the full `security-and-quality` query suite
+# (declared in the workflow) and only narrows it with the query-filter below.
+#
+# Why exclude `rust/unused-variable`:
+#   - It is a note-level *quality* query (NOT a security query), so excluding it
+#     does NOT reduce security coverage — every security query plus every other
+#     quality query in `security-and-quality` still runs.
+#   - It is redundant with the repo's REAL unused-variable gate: clippy run with
+#     `-D warnings` in ci.yml. clippy is the authoritative, reliable check and it
+#     correctly does NOT flag the sites CodeQL trips on.
+#   - CodeQL's Rust analyzer does not track variable uses through the `format!`
+#     macro's arguments, so it false-positives on variables that ARE used inside
+#     `format!(...)`. This was confirmed redundant/FP-only here: even after
+#     converting inline `{s}` captures to positional `format!("{}", s)` args
+#     (PR #311), a completed CodeQL run STILL flagged the same sites.
+#   - Refs the three open false-positive alerts this removes:
+#       #150 / #151 — crates/sparq-shacl/src/rules.rs
+#       #170        — crates/sparq-server/src/tpf.rs
+#
+# This is a TARGETED exclusion of exactly one redundant, FP-prone quality rule.
+# Do not broaden it.
+query-filters:
+  - exclude:
+      id: rust/unused-variable

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,6 +71,14 @@ jobs:
           # security-and-quality runs the security queries plus the maintainability/
           # reliability quality queries — the SAST gate Scorecard's `SAST` check wants.
           queries: security-and-quality
+          # [OPUS-4.8] Config file adds a query-filter that excludes exactly one
+          # redundant, note-level quality query: `rust/unused-variable`. It is NOT a
+          # security query (security coverage is unchanged) and is redundant with the
+          # repo's real unused-variable gate — clippy `-D warnings` in ci.yml, which
+          # understands `format!` captures. CodeQL's Rust analyzer false-positives on
+          # variables used only inside `format!(...)` macro args (confirmed: positional
+          # args in PR #311 did not stop the flags). Removes FP alerts #150/#151/#170.
+          config-file: ./.github/codeql/codeql-config.yml
 
       # Buildless extraction (build-mode: none) above means no explicit build step is
       # required for Rust. If a build mode that traces compilation is adopted later,


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

Adds `.github/codeql/codeql-config.yml` (referenced from the `github/codeql-action/init` step via `config-file:`) with a single query-filter:

```yaml
query-filters:
  - exclude:
      id: rust/unused-variable
```

The full `security-and-quality` suite is otherwise unchanged.

## Why

`rust/unused-variable` is a **note-level quality query, not a security query**, so excluding it does **not** reduce security coverage — every security query plus every other quality query in `security-and-quality` still runs.

It is **redundant** with the repo's real unused-variable gate: clippy with `-D warnings` in `ci.yml`. clippy is the authoritative check, understands `format!` captures, and correctly does **not** flag the affected sites.

CodeQL's Rust analyzer does not track variable uses through the `format!` macro's arguments, so it **false-positives** on variables that are used only inside `format!(...)`. This was confirmed FP-only here: even after converting inline `{s}` captures to positional `format!("{}", s)` args in #311, a completed CodeQL run **still** flagged the same sites.

This removes the three open false-positive alerts:
- #150 / #151 — `crates/sparq-shacl/src/rules.rs`
- #170 — `crates/sparq-server/src/tpf.rs`

## Result

After merge and CodeQL re-analyzes `main`, the rule no longer runs, so the 3 existing alerts auto-resolve to **fixed** and **code-scanning returns to 0**. This is a targeted exclusion of exactly one redundant, FP-prone quality query — security coverage is unchanged.
