### PR TITLE
feat(sparq-solid): retract bridged ODRL deny on prohibition withdrawal (sq-2pcf)

### DIFF
--- a/crates/sparq-policy/README.md
+++ b/crates/sparq-policy/README.md
@@ -69,6 +69,14 @@ assert!(!evaluate(&policy, &outside).allow);
   out), so a downstream materializer can distinguish a *carve-out* deny from a
   plain no-permission deny — `sparq-solid`'s ODRL bridge uses it to emit explicit
   `auth:deny*` triples (deny-overrides). [OPUS-4.8] sq-w693.
+  `prohibition_status(&policy, &request) -> ProhibitionStatus` is the three-valued
+  *deny-retraction* dual ([OPUS-4.8] sq-2pcf): `Applies` (a prohibition still carves
+  the request out), `Ambiguous` (one still structurally names the request but a
+  constraint is unprovable for lack of evidence), or `Withdrawn` (no prohibition names
+  the request, or every one is *definitely* false given the supplied evidence). The
+  bridge retracts a materialized deny **only** on `Withdrawn` — keeping it on `Ambiguous`
+  so access is never restored on missing evidence (`matched_prohibition().is_none()`
+  alone conflates the two, which would be fail-OPEN for a deny).
 - **Constraint operators** — `eq`, `neq`, `lt`, `lteq`, `gt`, `gteq`,
   `isPartOf` (set membership), `isA`. Numeric (`xsd:integer`/`decimal`/…) and
   `xsd:dateTime`/`date` operands compare by magnitude/instant; everything else

--- a/crates/sparq-policy/src/eval.rs
+++ b/crates/sparq-policy/src/eval.rs
@@ -209,6 +209,173 @@ pub fn matched_prohibition<'p>(policy: &'p Policy, request: &Request) -> Option<
         .find(|rule| rule_matches(rule, request, &req_action).is_match)
 }
 
+/// Whether `policy`'s prohibitions still carve `request` out — and, when they do
+/// not, **whether that is a definite no or merely unprovable**. [OPUS-4.8] sq-2pcf.
+///
+/// This is the *deny-retraction dual* of [`matched_prohibition`]. A bare
+/// `matched_prohibition(..).is_none()` collapses two semantically different worlds:
+///
+/// - the prohibition was genuinely **withdrawn / no longer structurally applies**
+///   (its action/target/assignee no longer name this request, or a constraint it
+///   carries is *definitely* false because the request supplies evidence that fails
+///   the bound), and
+/// - the prohibition still structurally names this request but a constraint is
+///   **unprovable** because the request lacks evidence for that dimension
+///   (`constraint_satisfied` returns `false` on a missing context value).
+///
+/// For a *grant* both collapse to "deny access" — fail-closed. But for **retracting a
+/// materialized `auth:deny*`** they must NOT: retracting on the second case would
+/// RESTORE access on missing evidence (fail-OPEN). This function keeps them apart so
+/// the bridge only retracts a deny on a *definite* "no longer holds".
+///
+/// Returns:
+/// - [`ProhibitionStatus::Applies`] if some prohibition still carves the request out
+///   (every structural attribute agrees AND every constraint is *satisfied*).
+/// - [`ProhibitionStatus::Ambiguous`] if no prohibition matches, but at least one
+///   prohibition still structurally names the request (action/target/assignee agree)
+///   and fails ONLY because a constraint is unprovable for lack of evidence.
+/// - [`ProhibitionStatus::Withdrawn`] otherwise — every prohibition either does not
+///   structurally name the request or carries a constraint that is *definitely* false
+///   given the supplied evidence. This is the only case in which a deny may be retracted.
+///
+/// # Examples
+///
+/// ```
+/// use sparq_policy::{prohibition_status, ProhibitionStatus, parse_policy_str, Request, Value};
+/// let pol = parse_policy_str(r#"
+/// @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+/// <urn:pol/p> a odrl:Set ; odrl:prohibition [
+///     odrl:action odrl:write ;
+///     odrl:target <https://pod.ex/n1> ;
+///     odrl:assignee <https://alice.ex/card#me> ;
+///     odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lt ;
+///        odrl:rightOperand "2026-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ] ] .
+/// "#, "turtle").unwrap();
+/// let base = Request::new("http://www.w3.org/ns/odrl/2/write")
+///     .on("https://pod.ex/n1").by("https://alice.ex/card#me");
+///
+/// // Evidence the window holds → still carves out.
+/// let inside = base.clone()
+///     .with("http://www.w3.org/ns/odrl/2/dateTime", Value::DateTime("2025-06-01T00:00:00Z".into()));
+/// assert_eq!(prohibition_status(&pol, &inside), ProhibitionStatus::Applies);
+///
+/// // Evidence the window has LAPSED → definitely withdrawn.
+/// let lapsed = base.clone()
+///     .with("http://www.w3.org/ns/odrl/2/dateTime", Value::DateTime("2026-06-01T00:00:00Z".into()));
+/// assert_eq!(prohibition_status(&pol, &lapsed), ProhibitionStatus::Withdrawn);
+///
+/// // NO evidence for the window → unprovable → ambiguous (keep the deny).
+/// assert_eq!(prohibition_status(&pol, &base), ProhibitionStatus::Ambiguous);
+/// ```
+pub fn prohibition_status(policy: &Policy, request: &Request) -> ProhibitionStatus {
+    let req_action = Action(request.action.clone());
+    let mut any_ambiguous = false;
+    for rule in &policy.prohibitions {
+        match classify_prohibition(rule, request, &req_action) {
+            RuleClass::Match => return ProhibitionStatus::Applies,
+            RuleClass::Ambiguous => any_ambiguous = true,
+            RuleClass::DefinitelyNo => {}
+        }
+    }
+    if any_ambiguous {
+        ProhibitionStatus::Ambiguous
+    } else {
+        ProhibitionStatus::Withdrawn
+    }
+}
+
+/// The deny-retraction verdict for a request's prohibitions — see
+/// [`prohibition_status`]. [OPUS-4.8] sq-2pcf.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProhibitionStatus {
+    /// A prohibition still carves the request out — a materialized deny must be KEPT.
+    Applies,
+    /// No prohibition matches, but one still structurally names the request and fails
+    /// only for lack of evidence — the deny must be KEPT (fail-closed: do not restore
+    /// access on an unprovable carve-out).
+    Ambiguous,
+    /// No prohibition structurally names the request, or every one that does carries a
+    /// constraint that is *definitely* false given the evidence — the only case in
+    /// which a materialized deny may be RETRACTED (access restored).
+    Withdrawn,
+}
+
+/// How one prohibition rule re-evaluates against a request, distinguishing a
+/// *definite* non-match from an *unprovable* one (missing-evidence constraint).
+/// [OPUS-4.8] sq-2pcf.
+enum RuleClass {
+    /// Structural attributes agree AND every constraint is satisfied.
+    Match,
+    /// Structural attributes agree, but a constraint is unprovable (no evidence).
+    Ambiguous,
+    /// A structural attribute disagrees, OR a constraint is *definitely* false
+    /// (evidence present, comparison failed), OR a constraint is malformed.
+    DefinitelyNo,
+}
+
+/// Classify a single prohibition rule for deny-retraction. Structural attributes
+/// (action / target / assignee) are definite (no "world state" needed). Constraints
+/// split into *definitely false* (evidence present, bound not met — a definite no) vs
+/// *unprovable* (no evidence for the dimension — ambiguous). [OPUS-4.8] sq-2pcf.
+fn classify_prohibition(rule: &Rule, request: &Request, req_action: &Action) -> RuleClass {
+    // Structural attributes are definite: if any disagrees the rule no longer names
+    // this request at all (a genuine withdrawal of *this* carve-out).
+    if !rule.action.permits(req_action) {
+        return RuleClass::DefinitelyNo;
+    }
+    if let Some(t) = &rule.target {
+        if request.target.as_deref() != Some(t.as_str()) {
+            return RuleClass::DefinitelyNo;
+        }
+    }
+    if let Some(a) = &rule.assignee {
+        if request.party.as_deref() != Some(a.as_str()) {
+            return RuleClass::DefinitelyNo;
+        }
+    }
+    // Structural attributes agree — the constraints decide. A constraint that is
+    // *definitely* false (we have evidence and it fails) is a definite no; one that is
+    // unprovable for lack of evidence is ambiguous (a deny must NOT be retracted on it).
+    let mut any_ambiguous = false;
+    for c in &rule.constraints {
+        match constraint_status(c, request) {
+            ConstraintStatus::Satisfied => {}
+            ConstraintStatus::DefinitelyUnsatisfied => return RuleClass::DefinitelyNo,
+            ConstraintStatus::Unprovable => any_ambiguous = true,
+        }
+    }
+    if any_ambiguous {
+        RuleClass::Ambiguous
+    } else {
+        RuleClass::Match
+    }
+}
+
+/// Whether one constraint is satisfied, *definitely* unsatisfied, or *unprovable* for
+/// lack of evidence — the three-valued refinement of [`constraint_satisfied`] that
+/// deny-retraction needs (a plain bool conflates the last two). [OPUS-4.8] sq-2pcf.
+enum ConstraintStatus {
+    /// The request supplies evidence and the comparison holds.
+    Satisfied,
+    /// The request supplies evidence and the comparison FAILS — a definite no.
+    DefinitelyUnsatisfied,
+    /// The request supplies no value for this dimension — we cannot tell.
+    Unprovable,
+}
+
+fn constraint_status(c: &Constraint, request: &Request) -> ConstraintStatus {
+    match request.context.get(&c.left) {
+        None => ConstraintStatus::Unprovable,
+        Some(actual) => {
+            if compare(actual, c.operator, &c.right) {
+                ConstraintStatus::Satisfied
+            } else {
+                ConstraintStatus::DefinitelyUnsatisfied
+            }
+        }
+    }
+}
+
 /// Outcome of matching a single rule against a request.
 struct Match {
     is_match: bool,

--- a/crates/sparq-policy/src/lib.rs
+++ b/crates/sparq-policy/src/lib.rs
@@ -5,6 +5,8 @@ mod eval;
 pub mod model;
 mod parse;
 
-pub use eval::{evaluate, matched_prohibition, Decision, Request};
+pub use eval::{
+    evaluate, matched_prohibition, prohibition_status, Decision, ProhibitionStatus, Request,
+};
 pub use model::{Action, Constraint, Duty, Operator, Policy, Rule, Value, ODRL_NS};
 pub use parse::{parse_policy, parse_policy_str};

--- a/crates/sparq-policy/tests/odrl_eval.rs
+++ b/crates/sparq-policy/tests/odrl_eval.rs
@@ -10,7 +10,9 @@
 //! blank-node permission/prohibition carrying action/target/assignee and
 //! blank-node constraints).
 
-use sparq_policy::{evaluate, parse_policy_str, Decision, Request, Value};
+use sparq_policy::{
+    evaluate, parse_policy_str, prohibition_status, Decision, ProhibitionStatus, Request, Value,
+};
 
 const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
 const XSD_DT: &str = "http://www.w3.org/2001/XMLSchema#dateTime";
@@ -361,4 +363,102 @@ fn datetime_xsd_typed_constant_roundtrips() {
     );
     // Before the lower bound → DENY.
     assert!(!evaluate(&p, &base.with(left("dateTime"), dt("2025-12-31T00:00:00Z"))).allow);
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-2pcf — prohibition_status: the three-valued deny-retraction dual
+// of matched_prohibition (Applies / Ambiguous / Withdrawn). The bridge uses this to
+// retract a materialized deny ONLY on a DEFINITE withdrawal, never on missing evidence.
+// ---------------------------------------------------------------------------
+fn windowed_prohibition() -> sparq_policy::Policy {
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/p> a odrl:Set ; odrl:prohibition [
+    odrl:action odrl:write ; odrl:target <urn:asset/x> ;
+    odrl:assignee <https://alice.ex/me> ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lt ;
+        odrl:rightOperand "2026-01-01T00:00:00Z"^^<{XSD_DT}> ] ] .
+"#
+    );
+    parse_policy_str(&ttl, "turtle").unwrap()
+}
+
+#[test]
+fn prohibition_status_applies_when_constraint_holds() {
+    let p = windowed_prohibition();
+    // Evidence the window holds (now < bound) → still carves out → KEEP the deny.
+    let req = Request::new(left("write"))
+        .on("urn:asset/x")
+        .by("https://alice.ex/me")
+        .with(left("dateTime"), dt("2025-06-01T00:00:00Z"));
+    assert_eq!(prohibition_status(&p, &req), ProhibitionStatus::Applies);
+}
+
+#[test]
+fn prohibition_status_withdrawn_when_constraint_definitely_false() {
+    let p = windowed_prohibition();
+    // Evidence the window LAPSED (now >= bound, operator lt) → definitely no → RETRACT.
+    let req = Request::new(left("write"))
+        .on("urn:asset/x")
+        .by("https://alice.ex/me")
+        .with(left("dateTime"), dt("2026-06-01T00:00:00Z"));
+    assert_eq!(prohibition_status(&p, &req), ProhibitionStatus::Withdrawn);
+}
+
+#[test]
+fn prohibition_status_ambiguous_when_no_evidence() {
+    let p = windowed_prohibition();
+    // NO dateTime evidence → cannot prove the window lapsed → AMBIGUOUS → KEEP the deny.
+    let req = Request::new(left("write"))
+        .on("urn:asset/x")
+        .by("https://alice.ex/me");
+    assert_eq!(prohibition_status(&p, &req), ProhibitionStatus::Ambiguous);
+}
+
+#[test]
+fn prohibition_status_withdrawn_on_structural_mismatch() {
+    let p = windowed_prohibition();
+    // A different party is not carved out at all — structurally Withdrawn, even with
+    // NO constraint evidence (a structural attribute is a DEFINITE non-match).
+    let other = Request::new(left("write"))
+        .on("urn:asset/x")
+        .by("https://bob.ex/me");
+    assert_eq!(prohibition_status(&p, &other), ProhibitionStatus::Withdrawn);
+    // An empty policy (prohibition removed) is also Withdrawn.
+    let empty = parse_policy_str(
+        &format!(r#"@prefix odrl: <{ODRL}> . <urn:pol/p> a odrl:Set ."#),
+        "turtle",
+    )
+    .unwrap();
+    let req = Request::new(left("write"))
+        .on("urn:asset/x")
+        .by("https://alice.ex/me");
+    assert_eq!(
+        prohibition_status(&empty, &req),
+        ProhibitionStatus::Withdrawn
+    );
+}
+
+#[test]
+fn prohibition_status_ambiguous_only_if_no_other_match() {
+    // Two prohibitions: one unconstrained (always matches) + one windowed (ambiguous w/o
+    // evidence). The unconstrained one still matches → Applies wins over Ambiguous.
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/p> a odrl:Set ;
+    odrl:prohibition [ odrl:action odrl:write ; odrl:target <urn:asset/x> ;
+        odrl:assignee <https://alice.ex/me> ] ;
+    odrl:prohibition [ odrl:action odrl:write ; odrl:target <urn:asset/x> ;
+        odrl:assignee <https://alice.ex/me> ;
+        odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lt ;
+            odrl:rightOperand "2026-01-01T00:00:00Z"^^<{XSD_DT}> ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let req = Request::new(left("write"))
+        .on("urn:asset/x")
+        .by("https://alice.ex/me");
+    assert_eq!(prohibition_status(&p, &req), ProhibitionStatus::Applies);
 }

--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -169,11 +169,24 @@ tracks each bridged grant in a **ledger** and provides a refresh entry point:
   (access gone). `refresh_odrl_grants()` (no args) replays everything as-tracked; a static
   re-materialization auto-reconciles (valid bridged grants are replayed back on top).
 - **Fail-closed (access retraction).** A withdrawn / lapsed / now-Denied / now-prohibited /
-  ambiguous re-evaluation loses access — the underlying evaluator is fail-closed, so on doubt
-  the grant is retracted, never left stale. A **static** WAC/ACP grant is never in the ledger,
-  never re-evaluated, and always in the captured baseline (captured as the materializer output
-  verbatim, not by subtracting provenance — so a static grant byte-identical to a bridged one
-  still survives a refresh) — refresh can neither widen nor drop it.
+  ambiguous re-evaluation of an **allow grant** loses access — the underlying evaluator is
+  fail-closed, so on doubt the grant is retracted, never left stale. A **static** WAC/ACP grant
+  is never in the ledger, never re-evaluated, and always in the captured baseline (captured as
+  the materializer output verbatim, not by subtracting provenance — so a static grant
+  byte-identical to a bridged one still survives a refresh) — refresh can neither widen nor drop it.
+- **Deny retraction is asymmetric — [OPUS-4.8] sq-2pcf.** A bridged `auth:deny*` (a
+  `BridgeKind::Prohibition` / `Policy` entry) carves access *out*, so retracting it *restores*
+  access — that must happen only when the ODRL Prohibition is **definitely** withdrawn or
+  lapsed, never on doubt. Reusing the grant rule would be **fail-OPEN** (an unprovable carve-out
+  would restore access). Deny refresh therefore consults `sparq_policy::prohibition_status`
+  (`Applies` / `Ambiguous` / `Withdrawn`): the deny is **retracted only on `Withdrawn`** — no
+  prohibition structurally names the request, or every one carries a constraint that is
+  *definitely* false given the supplied evidence (e.g. a `dateTime < bound` window with an
+  actual time past the bound). On `Applies` **or** `Ambiguous` (a structurally-matching
+  prohibition whose constraint is unprovable for lack of evidence) the deny is **kept**
+  (re-emitted). A retracted deny may re-expose an allow grant for the same
+  principal+target+mode — correct, because the prohibition is genuinely gone. Static `auth:deny*`
+  rules are never in the ledger and so are never retracted.
 
 ## Security posture — fail-closed
 

--- a/crates/sparq-solid/src/odrl_bridge.rs
+++ b/crates/sparq-solid/src/odrl_bridge.rs
@@ -74,13 +74,50 @@
 //! grant AND every matched-Prohibition deny for the request, so a policy carrying both
 //! a permission and a prohibition on the same principal+target+mode emits both triples,
 //! and the deny **wins** at enforcement time.
+//!
+//! # Deny RETRACTION on prohibition withdrawal — [OPUS-4.8] sq-2pcf
+//!
+//! The sq-dpk4 [`BridgeLedger`] replays each tracked materialization on
+//! [`refresh`](BridgeLedger::refresh), dropping the ones that no longer hold. For an
+//! *allow* grant the rule is simple: re-evaluate, and a non-Permit (withdrawn / lapsed
+//! / now-Denied / **ambiguous**) emits nothing → the grant is dropped → access is GONE.
+//! Dropping on ambiguity is the right (fail-closed) call for an allow.
+//!
+//! A materialized **deny** is the mirror image, and so its retraction rule must be the
+//! mirror image too. A deny should be RETRACTED — restoring access — only when the
+//! underlying ODRL Prohibition is genuinely **withdrawn or lapses**. If we reused the
+//! allow rule (drop the deny whenever the prohibition no longer matches), an *ambiguous*
+//! re-evaluation — a prohibition that still structurally names the request but carries a
+//! constraint the refresh request supplies no evidence for — would silently retract the
+//! deny and **restore access on missing evidence: fail-OPEN**. That is exactly the trap
+//! this bead closes.
+//!
+//! So deny retraction consults [`sparq_policy::prohibition_status`], a three-valued
+//! refinement of [`matched_prohibition`]:
+//!
+//! | [`ProhibitionStatus`]                       | meaning                                                     | deny action        |
+//! |---------------------------------------------|-------------------------------------------------------------|--------------------|
+//! | [`Applies`](ProhibitionStatus::Applies)     | a prohibition still carves the request out                  | **keep** (re-emit) |
+//! | [`Ambiguous`](ProhibitionStatus::Ambiguous) | still structurally names it, but a constraint is unprovable | **keep** (re-emit) |
+//! | [`Withdrawn`](ProhibitionStatus::Withdrawn) | no prohibition names it, or every one is *definitely* false | **retract** (drop) |
+//!
+//! "Definitely false" means the refresh request DID supply evidence for the dimension
+//! and the comparison failed (e.g. a `dateTime < 2026-01-01` window with an actual time
+//! of `2026-06-01` — the window has provably lapsed). Only then is the carve-out known
+//! to be gone. A retracted deny composes with deny-overrides as expected: it may
+//! re-expose an allow grant for the same principal+target+mode — correct, *because the
+//! prohibition is genuinely gone*. Static (non-bridged) `auth:deny*` rules are never in
+//! the ledger and so are never re-evaluated or retracted by this path.
 
 use crate::authindex::{Mode, AUTHENTICATED, PUBLIC};
 use crate::{AUTH_BRIDGED_GRAPH, AUTH_GRAPH, AUTH_NS};
 use oxrdf::{NamedNode, Term};
 use sparq_core::dict::Dict;
 use sparq_core::Graph;
-use sparq_policy::{evaluate, matched_prohibition, Operator, Policy, Request, Rule, Value};
+use sparq_policy::{
+    evaluate, matched_prohibition, prohibition_status, Operator, Policy, ProhibitionStatus,
+    Request, Rule, Value,
+};
 
 /// The ODRL namespace prefix (`odrl:`), re-exported for caller convenience.
 pub const ODRL_NS: &str = sparq_policy::ODRL_NS;
@@ -1007,13 +1044,110 @@ impl BridgeLedger {
 
 /// Re-run a tracked entry's original bridge function against the current graph,
 /// re-evaluating its ODRL policy and re-emitting iff it still holds. [OPUS-4.8] sq-dpk4.
+///
+/// # Deny retraction is asymmetric to grant retraction — [OPUS-4.8] sq-2pcf
+///
+/// A grant replays straight through its `materialize_*`: any non-Permit (withdrawn /
+/// lapsed / now-Denied / ambiguous) emits nothing → the grant is dropped → access is
+/// GONE. That is fail-closed for an *allow*.
+///
+/// A **deny** must NOT use the same rule. [`materialize_prohibition`] re-emits only
+/// when [`matched_prohibition`] currently matches; on *any* non-match it emits nothing,
+/// so the deny would be retracted — restoring access. But `matched_prohibition` returns
+/// no-match both when the prohibition is genuinely withdrawn AND when it is merely
+/// *unprovable* (a constraint with no evidence in the refresh request). Retracting in
+/// the unprovable case is fail-OPEN. So for the deny side we consult
+/// [`prohibition_status`] and re-emit the deny on [`ProhibitionStatus::Ambiguous`] just
+/// as on [`ProhibitionStatus::Applies`]; the deny is retracted ONLY on a definite
+/// [`ProhibitionStatus::Withdrawn`].
 fn replay(graph: &mut Graph, entry: &BridgeEntry) -> BridgeOutcome {
     match entry.kind {
         BridgeKind::Permission => materialize_permission(graph, &entry.policy, &entry.request),
-        BridgeKind::Prohibition => materialize_prohibition(graph, &entry.policy, &entry.request),
-        BridgeKind::Policy => materialize_policy(graph, &entry.policy, &entry.request),
+        BridgeKind::Prohibition => refresh_prohibition(graph, &entry.policy, &entry.request),
+        BridgeKind::Policy => refresh_policy(graph, &entry.policy, &entry.request),
         BridgeKind::PermissionConditional => {
             materialize_permission_conditional(graph, &entry.policy, &entry.request)
         }
+    }
+}
+
+/// Re-evaluate a tracked **Prohibition** deny on refresh with the fail-closed
+/// deny-retraction rule (sq-2pcf): re-emit the `auth:deny*` triple unless the
+/// prohibition is *definitely* withdrawn. [OPUS-4.8] sq-2pcf.
+///
+/// - [`ProhibitionStatus::Applies`] — a prohibition still carves the request out:
+///   re-emit (identical to [`materialize_prohibition`]).
+/// - [`ProhibitionStatus::Ambiguous`] — a prohibition still structurally names the
+///   request but a constraint is unprovable for lack of evidence: **re-emit anyway**
+///   (KEEP the deny — never restore access on an unprovable carve-out).
+/// - [`ProhibitionStatus::Withdrawn`] — no prohibition names the request, or every one
+///   that does is *definitely* false given the evidence: emit nothing → the deny is
+///   retracted and access is restored (subject to deny-overrides composition).
+fn refresh_prohibition(graph: &mut Graph, policy: &Policy, request: &Request) -> BridgeOutcome {
+    match prohibition_status(policy, request) {
+        // Genuinely gone → behave exactly like the materialize path (which now also
+        // finds no match), emitting nothing so the deny is dropped.
+        ProhibitionStatus::Withdrawn => materialize_prohibition(graph, policy, request),
+        // Still applies → re-emit through the normal match path.
+        ProhibitionStatus::Applies => materialize_prohibition(graph, policy, request),
+        // Unprovable → KEEP the deny by re-emitting it directly (fail-closed).
+        ProhibitionStatus::Ambiguous => reemit_deny(graph, request),
+    }
+}
+
+/// Re-evaluate a tracked **Policy** (both sides) on refresh: the allow side keeps the
+/// fail-closed grant semantics ([`materialize_permission`]); the deny side uses the
+/// fail-closed deny-retraction rule ([`refresh_prohibition`]). Composed exactly as
+/// [`materialize_policy`] so deny-overrides still holds. [OPUS-4.8] sq-2pcf.
+fn refresh_policy(graph: &mut Graph, policy: &Policy, request: &Request) -> BridgeOutcome {
+    let allow = materialize_permission(graph, policy, request);
+    let deny = refresh_prohibition(graph, policy, request);
+
+    let mut reasons = allow.reasons;
+    reasons.extend(deny.reasons);
+    let mut emitted = allow.emitted;
+    emitted.extend(deny.emitted);
+    BridgeOutcome {
+        granted: allow.granted,
+        prohibited: deny.prohibited,
+        mode: deny.mode.or(allow.mode),
+        grant_triple: allow.grant_triple,
+        deny_triple: deny.deny_triple,
+        reasons,
+        emitted,
+    }
+}
+
+/// Re-emit the `principal auth:deny<Mode> target` deny for `request` WITHOUT consulting
+/// the prohibition match — used by [`refresh_prohibition`] on an *ambiguous* re-eval to
+/// KEEP a deny we cannot prove is gone (fail-closed). The deny triple is fully
+/// determined by the request (party + action→mode + target), the same one
+/// [`materialize_prohibition`] would emit when the prohibition matched. [OPUS-4.8] sq-2pcf.
+///
+/// If the request lacks a mappable action or a concrete party/target the deny cannot be
+/// reconstructed; that emits nothing (and so retracts) — but such an entry could never
+/// have been materialized in the first place (those are the exact fail-closed gates in
+/// [`materialize_prohibition`]), so this branch is unreachable for a tracked deny.
+fn reemit_deny(graph: &mut Graph, request: &Request) -> BridgeOutcome {
+    let Some(mode) = action_to_mode(&request.action) else {
+        return BridgeOutcome::denied(vec![
+            "ambiguous prohibition re-eval but action no longer maps; deny not re-emitted"
+                .to_owned(),
+        ]);
+    };
+    let (Some(party), Some(target)) = (request.party.as_deref(), request.target.as_deref()) else {
+        return BridgeOutcome::denied(vec![
+            "ambiguous prohibition re-eval but request lost its party/target; deny not re-emitted"
+                .to_owned(),
+        ]);
+    };
+    let pred = format!("{AUTH_NS}{}", deny_predicate(mode));
+    let triple = append_grant(graph, party, &pred, target);
+    BridgeOutcome {
+        prohibited: true,
+        mode: Some(mode),
+        deny_triple: Some((party.to_owned(), pred, target.to_owned())),
+        emitted: vec![triple],
+        ..BridgeOutcome::default()
     }
 }

--- a/crates/sparq-solid/tests/odrl_bridge.rs
+++ b/crates/sparq-solid/tests/odrl_bridge.rs
@@ -1035,3 +1035,303 @@ fn ambiguous_reeval_retracts_fail_closed() {
         "FAIL-CLOSED: no evidence the window holds → access retracted",
     );
 }
+
+// ===========================================================================
+// [OPUS-4.8] sq-2pcf — DENY RETRACTION on prohibition withdrawal. The symmetric
+// dual of sq-dpk4's grant retraction, but with the OPPOSITE fail-closed bias: a
+// materialized `auth:deny*` is retracted (access restored) ONLY when the underlying
+// ODRL Prohibition is DEFINITELY withdrawn / lapsed — on an *ambiguous* re-eval the
+// deny is KEPT (never restore access on missing evidence). These tests drive the
+// real enforcement path (`accessible` / `query_as` / `update_as`).
+// ===========================================================================
+
+/// alice is prohibited from writing n1 ONLY while a window holds (dateTime < bound).
+/// Used to exercise definite-lapse vs ambiguous (no-evidence) deny retraction.
+fn windowed_write_prohibition() -> sparq_policy::Policy {
+    parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/winprohib> a odrl:Set ; odrl:prohibition [
+    odrl:action odrl:modify ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lt ;
+                      odrl:rightOperand "2026-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ] ] .
+"#,
+        "turtle",
+    )
+    .expect("policy parses")
+}
+
+/// A policy that prohibits NOTHING (the prohibition has been WITHDRAWN entirely).
+fn empty_prohibition_policy() -> sparq_policy::Policy {
+    parse_policy_str(
+        r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> . <urn:pol/prohib> a odrl:Set ."#,
+        "turtle",
+    )
+    .expect("policy parses")
+}
+
+// 28. WITHDRAWN PROHIBITION → DENY RETRACTED → access RESTORED through the real
+//     enforcement path — but ONLY because a still-valid allow grant re-exposes the
+//     slot. A standalone deny that is withdrawn restores nothing (test 29).
+#[test]
+fn withdrawn_prohibition_restores_access_after_refresh() {
+    let mut store = PodStore::new(pod());
+    let wreq = Request::new(odrl("modify")).on(N1).by(ALICE);
+
+    // alice has a (still-valid, unconstrained) WRITE permit AND a matching prohibition
+    // → deny-overrides denies write now.
+    let permit = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/w> a odrl:Set ; odrl:permission [
+    odrl:action odrl:modify ; odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    assert!(store.materialize_odrl_permission(&permit, &wreq).granted);
+    assert!(store.materialize_odrl_prohibition(&write_prohibition(), &wreq).prohibited);
+
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert!(
+        store.accessible(&alice, Mode::Write).is_empty(),
+        "deny-overrides: alice is denied write while the prohibition holds",
+    );
+
+    // The Prohibition is WITHDRAWN entirely → refresh the deny entry against the empty
+    // policy. The deny is DEFINITELY gone (no prohibition structurally names the request).
+    let (matched, retracted) =
+        store.refresh_odrl_grant(&empty_prohibition_policy(), &wreq, BridgeKind::Prohibition);
+    assert!(matched, "the tracked deny slot matched");
+    assert_eq!(retracted, 1, "the withdrawn prohibition's deny was retracted");
+
+    // ACCESS RESTORED: deny gone + the allow grant survives → alice can write again.
+    assert!(
+        store.accessible(&alice, Mode::Write).iter().any(|g| g.as_str() == N1),
+        "deny retracted + allow grant intact → write access restored",
+    );
+    // And the write-path update enforcement now permits it.
+    let ins = "INSERT DATA { GRAPH <https://pod.ex/notes/n1> { \
+        <https://pod.ex/notes/n1#it> <https://ex.dev/ns#tag> \"y\" } }";
+    assert!(store.update_as(&alice, ins).is_ok(), "restored write update succeeds");
+    // No residual deny triple in the auth view.
+    let leftover = "SELECT ?o WHERE { GRAPH <urn:sparq:auth> { \
+        <https://alice.ex/card#me> <https://sparq.dev/ns/auth#denyWrite> ?o } }";
+    assert_eq!(sparq_engine::query(&store.graph, leftover).unwrap().rows.len(), 0,
+        "no residual denyWrite after retraction");
+}
+
+// 29. WITHDRAWN STANDALONE DENY restores NOTHING: a deny with no underlying allow grant,
+//     when retracted, does not widen access (the lack of a grant still denies — the deny
+//     retraction is fail-closed by construction).
+#[test]
+fn withdrawn_standalone_deny_grants_no_access() {
+    let mut store = PodStore::new(pod());
+    let wreq = Request::new(odrl("modify")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_prohibition(&write_prohibition(), &wreq).prohibited);
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert!(store.accessible(&alice, Mode::Write).is_empty(), "no grant → denied");
+
+    // Withdraw the prohibition; the deny is retracted but there was never an allow.
+    let (matched, retracted) =
+        store.refresh_odrl_grant(&empty_prohibition_policy(), &wreq, BridgeKind::Prohibition);
+    assert!(matched);
+    assert_eq!(retracted, 1, "the standalone deny is retracted");
+    assert!(
+        store.accessible(&alice, Mode::Write).is_empty(),
+        "retracting a standalone deny restores no access (no grant to re-expose)",
+    );
+}
+
+// 30. A STILL-APPLICABLE prohibition SURVIVES refresh — the deny is KEPT, access stays
+//     denied (no spurious restoration).
+#[test]
+fn applicable_prohibition_survives_refresh() {
+    let mut store = PodStore::new(pod());
+    let wreq = Request::new(odrl("modify")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_prohibition(&write_prohibition(), &wreq).prohibited);
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert!(store.accessible(&alice, Mode::Write).is_empty());
+
+    // Plain refresh (policy unchanged) → the prohibition still matches → deny KEPT.
+    assert_eq!(store.refresh_odrl_grants(), 0, "applicable deny not retracted");
+    assert!(
+        store.accessible(&alice, Mode::Write).is_empty(),
+        "still-applicable prohibition: deny survives refresh, access stays denied",
+    );
+    // Refresh against the SAME prohibition policy also keeps it.
+    let (matched, retracted) =
+        store.refresh_odrl_grant(&write_prohibition(), &wreq, BridgeKind::Prohibition);
+    assert!(matched);
+    assert_eq!(retracted, 0, "deny kept on an unchanged, still-matching prohibition");
+    assert!(store.accessible(&alice, Mode::Write).is_empty(), "stays denied");
+}
+
+// 31. CORE sq-2pcf: AMBIGUOUS re-eval of a windowed prohibition KEEPS the deny
+//     (fail-closed) — access is NOT restored when we cannot prove the carve-out is gone.
+//     This is the asymmetry vs grant retraction (a windowed GRANT is dropped on ambiguity).
+#[test]
+fn ambiguous_prohibition_reeval_keeps_deny_fail_closed() {
+    let mut store = PodStore::new(pod());
+    // A windowed prohibition that holds at materialization time (now < bound).
+    let in_window = Request::new(odrl("modify"))
+        .on(N1)
+        .by(ALICE)
+        .with(odrl("dateTime"), Value::DateTime("2025-06-01T00:00:00Z".to_owned()));
+    assert!(store
+        .materialize_odrl_prohibition(&windowed_write_prohibition(), &in_window)
+        .prohibited);
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert!(store.accessible(&alice, Mode::Write).is_empty(), "denied while window holds");
+
+    // Refresh with NO dateTime evidence → we CANNOT prove the window lapsed → AMBIGUOUS.
+    // The deny must be KEPT (fail-closed: do NOT restore access on missing evidence).
+    let no_evidence = Request::new(odrl("modify")).on(N1).by(ALICE);
+    let (matched, retracted) = store.refresh_odrl_grant(
+        &windowed_write_prohibition(),
+        &no_evidence,
+        BridgeKind::Prohibition,
+    );
+    assert!(matched);
+    assert_eq!(retracted, 0, "AMBIGUOUS deny is KEPT, not retracted");
+    assert!(
+        store.accessible(&alice, Mode::Write).is_empty(),
+        "FAIL-CLOSED: no evidence the prohibition lapsed → deny kept → access stays denied",
+    );
+    // The denyWrite triple is still present in the auth view (re-emitted on refresh).
+    let still = "SELECT ?o WHERE { GRAPH <urn:sparq:auth> { \
+        <https://alice.ex/card#me> <https://sparq.dev/ns/auth#denyWrite> ?o } }";
+    assert_eq!(sparq_engine::query(&store.graph, still).unwrap().rows.len(), 1,
+        "ambiguous deny re-emitted (kept) in the enforcement view");
+}
+
+// 32. DEFINITELY-LAPSED window → deny RETRACTED: when the refresh request supplies
+//     evidence the window has PROVABLY lapsed (now >= bound), the carve-out is known
+//     gone → deny retracted. Paired with an allow grant → access restored.
+#[test]
+fn definitely_lapsed_prohibition_retracts_deny() {
+    let mut store = PodStore::new(pod());
+
+    // alice has a still-valid WRITE permit + a windowed prohibition (holds now).
+    let permit = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/w> a odrl:Set ; odrl:permission [
+    odrl:action odrl:modify ; odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let permit_req = Request::new(odrl("modify")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_permission(&permit, &permit_req).granted);
+    let in_window = Request::new(odrl("modify"))
+        .on(N1)
+        .by(ALICE)
+        .with(odrl("dateTime"), Value::DateTime("2025-06-01T00:00:00Z".to_owned()));
+    assert!(store
+        .materialize_odrl_prohibition(&windowed_write_prohibition(), &in_window)
+        .prohibited);
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert!(store.accessible(&alice, Mode::Write).is_empty(), "denied while window holds");
+
+    // Refresh with evidence the window has PROVABLY lapsed (now >= 2026-01-01 bound,
+    // operator is `lt`, so now is NOT < bound → constraint definitely false → Withdrawn).
+    let now_lapsed = Request::new(odrl("modify"))
+        .on(N1)
+        .by(ALICE)
+        .with(odrl("dateTime"), Value::DateTime("2026-06-16T00:00:00Z".to_owned()));
+    let (matched, retracted) = store.refresh_odrl_grant(
+        &windowed_write_prohibition(),
+        &now_lapsed,
+        BridgeKind::Prohibition,
+    );
+    assert!(matched);
+    assert_eq!(retracted, 1, "provably-lapsed prohibition's deny is retracted");
+    assert!(
+        store.accessible(&alice, Mode::Write).iter().any(|g| g.as_str() == N1),
+        "provably-lapsed deny retracted + allow intact → write access restored",
+    );
+}
+
+// 33. A STATIC WAC grant is NEVER retracted by a bridged-deny refresh — only the bridged
+//     deny is. bob's static read grant survives the full ledger refresh.
+#[test]
+fn static_grant_never_dropped_by_deny_refresh() {
+    let nq = r#"
+<https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> "hello" <https://pod.ex/notes/n1> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.ex/notes/n1> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#agent> <https://bob.ex/card#me> <https://pod.ex/notes/n1.acl> .
+<https://pod.ex/notes/n1.acl#a> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/notes/n1.acl> .
+"#;
+    let mut store = PodStore::new(Graph::load_dataset(nq, "nquads").unwrap());
+    store.materialize_wac().expect("wac materializes");
+
+    fn reads_n1(s: &mut PodStore, agent: &str) -> bool {
+        let sess = Session { agent: Some(agent), client: None };
+        s.accessible(&sess, Mode::Read).iter().any(|g| g.as_str() == N1)
+    }
+    assert!(reads_n1(&mut store, BOB), "bob static read before");
+
+    // Bridge alice's WRITE prohibition (a bridged deny) on top of the static baseline.
+    let wreq = Request::new(odrl("modify")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_prohibition(&write_prohibition(), &wreq).prohibited);
+
+    // Withdraw alice's prohibition → refresh. The bridged deny is retracted; bob's STATIC
+    // grant (in the captured baseline, never in the ledger) is untouched.
+    let (matched, retracted) =
+        store.refresh_odrl_grant(&empty_prohibition_policy(), &wreq, BridgeKind::Prohibition);
+    assert!(matched);
+    assert_eq!(retracted, 1, "only the bridged deny is retracted");
+    assert!(
+        reads_n1(&mut store, BOB),
+        "STATIC GRANT PRESERVED across a bridged-deny refresh",
+    );
+}
+
+// 34. DENY-OVERRIDES composition stays correct ACROSS a deny refresh: a permit + a
+//     prohibition bridged via a single Policy entry; the refresh re-applies the allow and
+//     re-evaluates the deny with the fail-closed deny rule. A withdrawn prohibition (in
+//     the refreshed Policy) drops the deny and re-exposes the allow.
+#[test]
+fn policy_refresh_deny_overrides_composition() {
+    let mut store = PodStore::new(pod());
+    let both = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/both> a odrl:Set ;
+    odrl:permission [ odrl:action odrl:modify ; odrl:target <https://pod.ex/notes/n1> ;
+        odrl:assignee <https://alice.ex/card#me> ] ;
+    odrl:prohibition [ odrl:action odrl:modify ; odrl:target <https://pod.ex/notes/n1> ;
+        odrl:assignee <https://alice.ex/card#me> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let req = Request::new(odrl("modify")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_policy(&both, &req).prohibited);
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert!(store.accessible(&alice, Mode::Write).is_empty(), "deny-overrides denies");
+
+    // Refresh against a Policy that keeps the permission but DROPS the prohibition.
+    let permit_only = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/both> a odrl:Set ;
+    odrl:permission [ odrl:action odrl:modify ; odrl:target <https://pod.ex/notes/n1> ;
+        odrl:assignee <https://alice.ex/card#me> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let (matched, _retracted) = store.refresh_odrl_grant(&permit_only, &req, BridgeKind::Policy);
+    assert!(matched);
+    assert!(
+        store.accessible(&alice, Mode::Write).iter().any(|g| g.as_str() == N1),
+        "deny dropped + allow re-applied → write restored under deny-overrides",
+    );
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -121,10 +121,15 @@ Materialize the authorization view from the access-control documents, then enfor
   and still-valid bridged grants. Bridged triples are tracked in a ledger and mirrored into a
   provenance graph `<urn:sparq:auth-bridged>` (`AUTH_BRIDGED_GRAPH`) so they are structurally
   distinguishable from static grants; refresh rebuilds the view as `static_baseline ∪
-  replay(valid bridged entries)`. **Fail-closed**: any ambiguous re-eval retracts (access
-  never left stale); a static grant is never re-evaluated or dropped. A wholesale static
-  re-materialization (`materialize_wac`/`materialize_acp`) auto-reconciles — valid bridged
-  grants are replayed back on top.
+  replay(valid bridged entries)`. **Fail-closed**: any ambiguous re-eval of an *allow grant*
+  retracts (access never left stale); a static grant is never re-evaluated or dropped. A
+  wholesale static re-materialization (`materialize_wac`/`materialize_acp`) auto-reconciles —
+  valid bridged grants are replayed back on top. A bridged **deny** ([OPUS-4.8] sq-2pcf) is
+  the dual and uses the OPPOSITE fail-closed rule: a materialized `auth:deny*` is retracted
+  only when the ODRL Prohibition is **definitely** withdrawn/lapsed (`prohibition_status ==
+  Withdrawn`); an *ambiguous* re-eval **keeps** the deny (never restore access on missing
+  evidence). A retracted deny may re-expose an allow grant — correct, since the prohibition
+  is genuinely gone.
 - `Session { agent: Option<&str>, client: Option<&str> }` (caller-asserted WebID +
   `acl:origin`/`acp:client`; `None` = anonymous / any client); `Mode::{Read, Write,
   Append, Control}`; `wac_fixture()` / `acp_fixture()` (bundled demo pods).

--- a/skills/usage-control-policy/SKILL.md
+++ b/skills/usage-control-policy/SKILL.md
@@ -150,13 +150,33 @@ The `materialize_odrl_*` calls only ever **append**. When the underlying ODRL po
 
 - **Provenance.** Every auth triple the bridge writes into `<urn:sparq:auth>` is mirrored verbatim into a separate reserved graph `<urn:sparq:auth-bridged>` (`AUTH_BRIDGED_GRAPH`). A triple is **bridged** iff it appears there, **static** otherwise — so bridged and static grants are structurally distinguishable without inspecting predicate shape, and the enforcement reader (`AuthIndex`) is unchanged (it still reads `<urn:sparq:auth>`). The provenance graph is in the reserved `urn:sparq:` space, so a loaded dataset cannot forge it.
 - **Refresh / retract.** `PodStore::refresh_odrl_grant(&new_policy, &new_request, kind)` updates the tracked grant slot `(kind, target, party)` with the new policy / request context, then rebuilds the view as `static_baseline ∪ replay(still-valid bridged entries)`: it resets `<urn:sparq:auth>` to the static baseline captured at the last `materialize_wac`/`materialize_acp`, clears the provenance graph, and re-evaluates every tracked `(policy, request)` through its original bridge entry point. An entry that no longer holds emits nothing → it is **retracted** (access gone). `refresh_odrl_grants()` (no args) replays everything as-tracked (used to reconcile after a static re-materialization, which is automatic).
-- **Fail-closed (security-sensitive — access retraction).** A withdrawn / lapsed / now-Denied / now-prohibited / ambiguous re-evaluation loses access; the underlying evaluator is fail-closed, so on any doubt the grant is retracted, never left stale. A **static** WAC/ACP grant is never in the ledger, never re-evaluated, and always in the captured baseline (captured as the `install_auth_view` output verbatim, not by subtracting provenance — so a static grant byte-identical to a bridged one still survives) — refresh can neither widen nor drop it.
+- **Fail-closed (security-sensitive — access retraction).** A withdrawn / lapsed / now-Denied / now-prohibited / ambiguous re-evaluation of an **allow grant** loses access; the underlying evaluator is fail-closed, so on any doubt the grant is retracted, never left stale. A **static** WAC/ACP grant is never in the ledger, never re-evaluated, and always in the captured baseline (captured as the `install_auth_view` output verbatim, not by subtracting provenance — so a static grant byte-identical to a bridged one still survives) — refresh can neither widen nor drop it.
+
+#### Deny RETRACTION is asymmetric to grant retraction — [OPUS-4.8] sq-2pcf
+
+A materialized `auth:deny*` (from a `BridgeKind::Prohibition` / `Policy` entry) is **retracted on the OPPOSITE rule**: a deny carves access *out*, so retracting it *restores* access — that must happen only when the ODRL Prohibition is **definitely** withdrawn or lapsed, never on doubt. Reusing the grant rule (drop the deny whenever `matched_prohibition` no longer matches) would be **fail-OPEN**: an *ambiguous* re-eval — a prohibition still structurally naming the request but carrying a constraint the refresh request gives no evidence for — would silently restore access.
+
+So deny retraction consults `sparq_policy::prohibition_status`, a three-valued refinement of `matched_prohibition`:
+
+| `ProhibitionStatus` | meaning | deny on refresh |
+|---|---|---|
+| `Applies` | a prohibition still carves the request out | **kept** (re-emitted) |
+| `Ambiguous` | still structurally names it, but a constraint is unprovable (no evidence) | **kept** (re-emitted) |
+| `Withdrawn` | no prohibition names it, or every one is *definitely* false given the evidence | **retracted** (dropped) |
+
+"Definitely false" means the refresh request supplied evidence for the dimension and the comparison failed (e.g. a `dateTime < 2026-01-01` window with an actual time of `2026-06-01` — provably lapsed). A retracted deny composes with deny-overrides: it may re-expose an allow grant for the same principal+target+mode — correct, *because the prohibition is genuinely gone*. Static (non-bridged) `auth:deny*` rules are never in the ledger and so are never re-evaluated or retracted.
 
 ```rust,ignore
 // alice was bridged a read grant; the policy then WITHDRAWS the permission.
 let (matched, retracted) =
     store.refresh_odrl_grant(&withdrawn_policy, &req, BridgeKind::Permission);
 // matched == true, retracted == 1 → alice can no longer read (through accessible/query_as).
+
+// A bridged DENY is the dual: retracted only when the Prohibition is DEFINITELY gone.
+let (matched, retracted) =
+    store.refresh_odrl_grant(&withdrawn_prohibition, &write_req, BridgeKind::Prohibition);
+// definite withdrawal → retracted == 1 (deny gone, access restored if an allow exists);
+// ambiguous re-eval (no constraint evidence) → retracted == 0 (deny KEPT, fail-closed).
 ```
 
 ## Learn more


### PR DESCRIPTION
> 🤖 SPARQ agent

Extends the ODRL bridge's grant-revocation (sq-dpk4) and prohibition-deny (sq-w693) to **RETRACT** a materialized `auth:deny*` when the underlying ODRL Prohibition is genuinely withdrawn or lapses — so access is restored when the carve-out is removed, **fail-closed**. Epic sq-3183.

## The model — deny retraction is asymmetric to grant retraction

A grant drops on any non-Permit re-eval (withdrawn / lapsed / now-Denied / **ambiguous**) — fail-closed for an *allow*. A **deny** must use the OPPOSITE rule: retracting it *restores* access, so it may drop only on a **definite** withdrawal. Reusing the grant rule (drop the deny whenever `matched_prohibition` no longer matches) would be **fail-OPEN**, because `matched_prohibition().is_none()` conflates a genuine withdrawal with an *unprovable* carve-out (a constraint the refresh request supplies no evidence for) — silently restoring access on missing evidence.

- **sparq-policy**: new `prohibition_status(&policy, &request) -> ProhibitionStatus` — a three-valued refinement of `matched_prohibition`:
  - `Applies` — a prohibition still carves the request out → **keep** the deny.
  - `Ambiguous` — one still structurally names the request but a constraint is unprovable for lack of evidence → **keep** the deny.
  - `Withdrawn` — no prohibition names it, or every one is *definitely* false given the supplied evidence (e.g. a `dateTime < bound` window with an actual time past the bound) → **retract** the deny.
- **sparq-solid `odrl_bridge`**: deny replay (`Prohibition` + `Policy` kinds) now routes through `refresh_prohibition`/`refresh_policy`, retracting the deny **only on `Withdrawn`** and re-emitting it on `Applies`/`Ambiguous`. Composes with deny-overrides: a retracted deny may re-expose an allow grant — correct, *because the prohibition is genuinely gone*. Static `auth:deny*` rules are never in the ledger and never retracted.

## Tests (real enforcement path: `accessible` / `query_as` / `update_as`)

- withdrawn prohibition → deny retracted → write access **restored** (only because a still-valid allow grant re-exposes the slot)
- withdrawn standalone deny restores **nothing** (no grant to re-expose)
- still-applicable prohibition **survives** refresh (deny kept, access stays denied)
- **CORE fail-closed**: ambiguous re-eval (no constraint evidence) **KEEPS** the deny → access stays denied
- provably-lapsed window → deny **retracted** → access restored
- static grant **preserved** across a bridged-deny refresh
- deny-overrides composition correct across a `Policy` refresh
- `prohibition_status` unit tests (Applies / Ambiguous / Withdrawn / structural mismatch / multi-prohibition)

## Gates

- build + `clippy -D warnings` + `test -p sparq-solid` green **feature off and on**
- `sparq-policy` tests + doctests pass
- docs updated: usage-control-policy + access-control SKILLs, sparq-solid + sparq-policy READMEs

Refs sq-2pcf, sq-dpk4, sq-w693, epic sq-3183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)