### PR TITLE
design: academic paper-factory — phase-3 design + skill (sq-gum8)

### DIFF
--- a/research/paper-factory-design.md
+++ b/research/paper-factory-design.md
@@ -1,0 +1,360 @@
+# Academic Paper-Factory — Phase-3 Design
+
+<!-- [OPUS-4.8] phase-3 actionable design for epic sq-gum8 (academic paper factory). -->
+
+> 🤖 **SPARQ agent** design record. This consolidates the two completed research phases —
+> the novel-contribution inventory + identification process
+> (`research/paper-contributions-inventory.md`, PR #317) and the auto-gen + live + PDF
+> stack research (`research/paper-factory-research.md`, PR #319) — into one concrete,
+> buildable phase-3 design. It is **DOC-ONLY**: no site/crate code is written here. The
+> build comes after maintainer review; the phased plan in §7 enumerates each future bead.
+
+**The two load-bearing constraints inherited from the research (never softened):**
+
+1. **No ZK/MPC security property may be claimed as proven.** The single-prover ZK verifier
+   is internally re-audited "sound-as-landed for its threat model" but has **no external
+   audit** (bead **sq-qhy4**, open + externally gated); the collaborative/multi-prover path
+   is re-open (**sq-9hrn**) and the malicious-secure MPC layer is a stub. A ZK/MPC paper
+   today is an **honest design / limitations / negative-result** contribution — arXiv/WIP
+   only — and **must cite sq-qhy4** as the gate.
+2. **All wall-clock numbers on the dev work-box are NON-CANONICAL.** The session runs on an
+   AWS EC2 box (`-aws` kernel, virtualized host). Only **deterministic integer metrics** are
+   canonical today (W3C/OGC conformance floors, byte-identity invariants, recall floors,
+   gate/round/byte counts, differential-fuzz pass). A speed/memory claim needs the
+   **canonical runner** before publication. Indicative work-box numbers are **never
+   co-tabulated with canonical numbers** and never feed an aggregate figure-of-merit.
+
+---
+
+## 1. Factory architecture — the end-to-end pipeline
+
+The factory turns one sparq contribution into (a) a live in-site HTML paper and (b) a
+downloadable venue-credible PDF, both bound to the same live benchmark data, with empirical
+honesty enforced at the data layer rather than only in prose. Cheap glue runs in the
+orchestrator; intensive stages (drafting, review, canonical benchmark runs) are delegated
+to subagents per the project's delegation discipline.
+
+```text
+  CONTRIBUTION  (family A: DB-perf | B: SemWeb | C: crypto-WIP)
+        │
+        ▼
+  ┌─ STAGE 0 — INTAKE (re-runnable identification process, from #317) ──────────────┐
+  │  scan 6 sources (crates / research / beads / bench-deltas / scoreboard / skills) │
+  │  → score 4 criteria (novelty / evidence / generality / honesty-soundness)        │
+  │  → assign readiness verdict (PUBLISHABLE-NOW | NEEDS-CANONICAL-BENCHMARKS |       │
+  │     NOT-YET-SOUND) → rank by readiness × impact → diff vs inventory               │
+  └─────────────────────────────────────┬────────────────────────────────────────────┘
+        ▼
+  ┌─ STAGE 1 — CLASSIFY & VENUE-TARGET ─────────────────────────────────────────────┐
+  │  map contribution → venue (§ venue map) + track (research / resource / workshop)  │
+  │  pick Typst template: charged-ieee | arkheion (arXiv) | acmart-style | para-lipics│
+  │  crypto-WIP ⇒ arXiv/workshop track + mandatory soundness-gap disclaimer            │
+  └─────────────────────────────────────┬────────────────────────────────────────────┘
+        ▼
+  ┌─ STAGE 2 — CANONICAL BENCHMARK CAPTURE (the honesty boundary) ───────────────────┐
+  │  run eval on the pinned CANONICAL runner (bare-metal, freq-pinned)                │
+  │  emit result records: { key, value, unit, n_reps, dispersion(CI|stddev),          │
+  │      environment: canonical|indicative, cpu, kernel, rustc, dataset_sha256,        │
+  │      seed, commit }  →  benchmark-data branch  →  benchmarks.generated.json        │
+  │  CI GATE: any record with environment=indicative is BLOCKED from paper-bound tables│
+  └─────────────────────────────────────┬────────────────────────────────────────────┘
+        ▼
+  ┌─ STAGE 3 — DRAFT (single-source .typ, §1 writing methodology) ───────────────────┐
+  │  contributions list FIRST (refutable, forward-referenced); 4-sentence abstract;   │
+  │  ≤1pp intro; related-work-late & charitable; eval references #bench.<key>          │
+  │  (never hard-coded numbers); run SIGPLAN-7 + benchmarking-crimes self-check         │
+  └─────────────────────────────────────┬────────────────────────────────────────────┘
+        ▼
+  ┌─ STAGE 4 — BUILD (one source → two artifacts, data-bound) ───────────────────────┐
+  │  PDF : typst compile paper.typ public/papers/<slug>.pdf \                          │
+  │          --input data="$(cat site/src/data/benchmarks.generated.json)"             │
+  │  HTML: typst.ts (@myriaddreamin/typst.react) renders the SAME .typ at /papers/<slug>│
+  │  anonymized-build toggle (--input anon=true) strips jeswr/sparq identity for        │
+  │  double-blind venues                                                               │
+  └─────────────────────────────────────┬────────────────────────────────────────────┘
+        ▼
+  ┌─ STAGE 5 — REVIEW GATE (claims ↔ evidence, §1.4/§1.5 rubric) ────────────────────┐
+  │  section reviewers + cross-cutting honesty/repro check (subagents); resolve all    │
+  │  findings; final: claims↔evidence loop closed; NO indicative number in any claim   │
+  └─────────────────────────────────────┬────────────────────────────────────────────┘
+        ▼
+  ┌─ STAGE 6 — PUBLISH & AUTO-UPDATE ───────────────────────────────────────────────┐
+  │  merge ⇒ next build serves /papers/<slug> + /papers/<slug>.pdf (static export)     │
+  │  benchmarks.generated.json refresh ⇒ paper numbers AUTO-UPDATE on rebuild           │
+  │  each paper carries a provenance stamp (commit + runner + dataset hash)             │
+  │  venue camera-ready ⇒ optional Typst→LaTeX export step                              │
+  └─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+**What each guarantee buys:**
+
+- **Single source of truth for numbers** — the eval section binds to
+  `benchmarks.generated.json`; HTML and PDF cannot disagree, and a paper auto-updates as
+  benchmarks improve (Stage 6).
+- **Empirical honesty is enforced, not hoped-for** — the `environment` flag + CI gate
+  (Stage 2) makes it *impossible* to cite a non-canonical work-box number in a paper claim.
+- **Repeatable** — `skills/academic-paper/SKILL.md` encodes the Stage 0/1/3/5 methodology;
+  Stages 2/4/6 are scripted; any agent can run the factory.
+
+### Stack decision (from #319, restated as the design commitment)
+
+- **Single source = Typst `.typ`.** Author once; inject the live JSON at build via
+  `--input` / `sys.inputs`; emit a credible PDF (Typst native PDF/A+PDF/UA export) **and**
+  an in-site HTML page (via **typst.ts / `@myriaddreamin/typst.react`** rendering, the
+  robust choice today — Typst's own HTML export is still experimental).
+- **Fallback (camera-ready only):** Pandoc Markdown → LaTeX via Tectonic against the
+  official `acmart`/`IEEEtran`/`lipics` class, for the final publisher upload when a venue
+  rejects Typst→LaTeX conversion. Not the day-to-day source.
+- **Anti-pattern (rejected):** `@react-pdf/renderer` — forces a second document tree, so
+  numbers/layout are authored twice and single-source breaks.
+
+---
+
+## 2. Live data flow — how a paper's numbers stay live
+
+The repo already produces `site/src/data/benchmarks.generated.json` via
+`site/scripts/sync-benchmarks.mjs` (run by `prebuild`, pulling the `benchmark-data` branch).
+The factory layers paper-binding on top of that *existing* seam — it adds no second data
+source.
+
+**One JSON → both artifacts, zero duplicated numbers:**
+
+1. **HTML page** — the React route at `/papers/<slug>` renders the `.typ` via typst.ts. The
+   `.typ` is fed the JSON exactly as the PDF build is (same `sys.inputs.data`), so the
+   in-site render reads the *same* numbers the site's existing benchmark UI uses. (typst.ts
+   compiles `.typ` → inline SVG/canvas in the browser at full visual fidelity.)
+2. **PDF** — a build step runs `typst compile` with `--input data="$(cat
+   site/src/data/benchmarks.generated.json)"`, dropping `public/papers/<slug>.pdf`. The
+   static export then serves it as a plain asset.
+3. **In the `.typ`:** `#let bench = json(bytes(sys.inputs.data))` once at the top; the eval
+   section references `#bench.<key>` (e.g. `#bench.filtered_ann.recall_at_10`) — never a
+   literal number.
+
+**Rebuild-on-change (CI trigger):** when the `benchmark-data` branch updates (or
+`benchmarks.generated.json` changes on `main`), the site deploy workflow re-runs `prebuild`
++ `next build`, which re-runs the paper build step, which recompiles every registered
+`.typ` against the fresh JSON. Both the HTML render and the PDF asset regenerate with
+current numbers. No manual edit, no number drift.
+
+**Concrete file/route layout under `site/`** (files to create — design only):
+
+```text
+site/
+  src/
+    data/
+      benchmarks.generated.json      # EXISTS — the single number source
+      papers.ts                      # NEW — paper registry (slug, title, authors,
+                                     #       .typ path, venue, status, family, anon)
+    app/
+      papers/
+        layout.tsx                   # NEW — wraps AppShell; "Papers" sidebar section
+        page.tsx                     # NEW — /papers index (one card per registered paper)
+        [slug]/
+          page.tsx                   # NEW — per-paper page: typst.ts HTML render +
+                                     #       "Download PDF" button + provenance stamp
+    components/
+      papers/
+        typst-render.tsx             # NEW ("use client") — wraps @myriaddreamin/typst.react
+        paper-provenance.tsx         # NEW — commit + runner + dataset-hash stamp footer
+  scripts/
+    build-papers.mjs                 # NEW — for each registered paper: typst compile →
+                                     #       public/papers/<slug>.pdf with --input data=JSON
+  public/
+    papers/
+      <slug>.pdf                     # GENERATED by build-papers.mjs (static asset)
+  papers/                            # NEW — the .typ sources + templates live here
+    <slug>/paper.typ
+    _templates/{charged-ieee,arkheion,...}.typ
+    _lib/bench.typ                   # shared helpers: json-load + #bench accessor + anon toggle
+```
+
+`build-papers.mjs` is wired into `package.json` `prebuild` (after `sync-benchmarks.mjs`) so
+`next build` always rebuilds PDFs against fresh data, and into `dev` so local previews bind
+live too. (The `papers/` `.typ` sources sit at `site/papers/` so the Typst compile and the
+typst.ts import resolve from one tree; `public/papers/*.pdf` are git-ignored build outputs,
+regenerable like `benchmarks.generated.json`.)
+
+---
+
+## 3. The `/papers` site route design
+
+A papers index + a per-paper page, consistent with the existing AppShell + sidebar-nav and
+the in-site benchmarks layout. **Design only — files listed in §2; no site code written
+now.**
+
+- **`/papers` (index)** — `app/papers/page.tsx`. One `Card` per paper from `papers.ts`
+  (reusing `components/ui/card`, mirroring `app/benchmarks/page.tsx`): title, authors (or
+  "anonymized" when `anon`), venue/track target, a **status `Badge`** (PUBLISHABLE-NOW /
+  WIP-arXiv / DRAFT, reusing `TIER_VARIANT`-style variants), the contribution family (A/B/C),
+  and links to the per-paper page + a direct "PDF" link. An honest provenance line up top
+  (same pattern as the benchmarks overview's provenance framing).
+- **`/papers/<slug>` (per paper)** — `app/papers/[slug]/page.tsx`, using
+  `generateStaticParams()` over `papers.ts` (exact pattern of `app/surface/[slug]/page.tsx`)
+  so the static export emits one HTML file per paper. Body:
+  - the **typst.ts HTML render** of the paper's `.typ` (`components/papers/typst-render.tsx`,
+    a `"use client"` wrapper around `@myriaddreamin/typst.react`), fed the same JSON the PDF
+    gets;
+  - a prominent **"Download PDF"** button linking the static
+    `/papers/<slug>.pdf` asset (basePath-prefixed `/sparq/papers/<slug>.pdf`);
+  - a **provenance stamp** footer (`components/papers/paper-provenance.tsx`): the commit,
+    canonical-runner fingerprint, and dataset SHA-256 the numbers came from.
+- **Nav** — add a **"Papers"** entry to `components/layout/sidebar-nav.tsx`, after
+  "Benchmarks", as its own section (one `NavLink` per paper, like the Showcase section maps
+  `FLAGSHIPS`). `isActive("/papers")` highlights it. AppShell is untouched (the route inherits
+  it via `app/papers/layout.tsx`, mirroring `app/benchmarks/layout.tsx`).
+
+**basePath note:** the site is served under `/sparq/` (GitHub Pages); every PDF link and
+typst.ts asset URL must carry the `/sparq` prefix (Next config `basePath`/`assetPrefix`), as
+the existing routes already do.
+
+---
+
+## 4. The repeatable trigger — "any novel contribution / benchmark improvement → its own paper"
+
+The factory is event-driven off the §1 STAGE-0 re-runnable identification process
+(from PR #317). The events that regenerate or create a paper:
+
+| Event | Factory action |
+| --- | --- |
+| **New crate / opt-in feature lands** | re-run intake (scan 6 sources, score 4 criteria); if a new PUBLISHABLE-NOW candidate appears, register a new paper (new `papers.ts` entry + `papers/<slug>/paper.typ`) |
+| **A benchmark improves / a canonical run completes** | (a) every registered paper auto-updates its numbers on rebuild (§2); (b) re-evaluate every NEEDS-CANONICAL-BENCHMARKS candidate — promote to PUBLISHABLE-NOW if now canonical-backed, then register its paper |
+| **A conformance floor rises** (`scoreboard.rs`) | strengthens any conformance-backed claim; re-rank; affected paper's numbers refresh on rebuild |
+| **An audit bead changes state** (esp. **sq-qhy4** external ZK audit, **sq-9hrn** coZK re-audit, **sq-1gir** forge-tests-in-CI) | a sq-qhy4 *pass* moves the single-prover ZK candidate out of NOT-YET-SOUND → it may be promoted from arXiv-WIP to a real venue; until then it cannot move |
+| **A new `research/*-measured.md` / negative-result doc** | a measured correction may itself be a (small) contribution; intake screens it |
+
+**How a new paper is registered** (the minimal mechanical step): add an entry to
+`site/src/data/papers.ts` (slug, title, authors, `.typ` path, venue, track, status, family,
+`anon` default) and create `site/papers/<slug>/paper.typ` from a template. The index, the
+per-paper route (`generateStaticParams`), the sidebar nav, and the PDF build step are all
+data-driven off `papers.ts`, so registration is the only manual touch — everything else is
+generated. Wiring the intake re-run into the maintenance-automation framework
+(`research/maintenance-flow-on-automation-design.md`) is the long-term goal so the diff
+against the inventory opens/closes paper-candidate beads automatically.
+
+---
+
+## 5. Honesty / soundness gates baked in
+
+The factory makes the two load-bearing constraints **mechanical**, not advisory:
+
+1. **The `environment` field + CI gate (the canonical/indicative boundary).** Every result
+   record in `benchmarks.generated.json` carries `environment: canonical | indicative` plus
+   the full pinned fingerprint (cpu / kernel / rustc / dataset_sha256 / seed / n_reps /
+   dispersion). A CI check (Stage 2) **fails the build** if any `#bench.<key>` referenced by
+   a paper-bound table resolves to an `environment: indicative` record. This turns the
+   project's memory rule ("EC2 measurements are NON-canonical; gate only deterministic
+   metrics") into an enforced pipeline invariant. Work-box numbers are **never co-tabulated
+   with canonical numbers** and never feed an aggregate figure-of-merit (cite the
+   EC2-non-canonical constraint). Until the canonical runner exists
+   (`research/ci-ec2-design.md`, blocked on one IAM step), a paper may publish only the
+   deterministic metrics (conformance counts, recall floors, byte-identity, gate/round/byte
+   counts) — which are canonical today.
+2. **The ZK/MPC not-yet-sound disclaimer.** Any paper whose contribution family is C
+   (crypto) carries a **mandatory soundness-gap disclaimer** citing **sq-qhy4**, is marked
+   **arXiv/WIP-only** in `papers.ts` (status `WIP-arXiv`), and **may never assert a proven
+   security / privacy / integrity / attestation property**. The Stage-5 review gate rejects
+   any C-family draft that uses "secure" / "verifiable" / "private" as a *proven* claim
+   rather than a *design goal*. A C-family paper graduates to a real venue (PoPETs / USENIX)
+   only when sq-qhy4 (and, for the multi-prover path, sq-9hrn) close.
+
+The Stage-5 claims↔evidence review also applies the general SIGPLAN-7 + Heiser
+benchmarking-crimes rubric (no overclaiming, fair baselines, error bars, full platform
+spec) — codified in the skill (§ Deliverable 2).
+
+---
+
+## 6. Pilot selection — the first paper
+
+**Pilot the factory with A1 + A2 together** (the inventory's own recommendation; both are
+PUBLISHABLE-NOW, need no canonical runner and no external audit):
+
+### A1 — RDF-native filtered-ANN (the central contribution)
+
+*"Filter-as-Query: Predicate-Constrained Vector Search where the Filter is an Exact RDF
+Basic Graph Pattern over the Engine's Own Dictionary Ids."* Target: **ISWC / ESWC research
+track** as a systems/integration paper (could reach EDBT). Frame as integration, **not** an
+algorithmic ANN novelty.
+
+| Has today (canonical) | Needs |
+| --- | --- |
+| IMPLEMENTED: `crates/sparq-vectors/src/{filter.rs,rewrite.rs}`, selectivity-gated prefilter vs filtered-traversal crossover | If a **latency** headline is wanted, it becomes NEEDS-CANONICAL-BENCHMARKS (canonical runner) — so the pilot makes the **correctness/exactness** claim, not a speed claim |
+| **Canonical recall vs exact-filtered ground truth** (`tests/filtered.rs`) — deterministic | A reviewer's "what's new vs ACORN/NaviX/PathFinder?" answered by: exactness + same-id-space + **transitive/connected-component pushdown** + the answer-safety ("narrow-never-widen") argument |
+| BGP→`IdMask` caching is implemented (PR #292 / sq-36ol) but is **engineering, not novelty** — do NOT frame it as a contribution | a clear prior-art positioning section |
+
+### A2 — Honest same-box benchmark methodology (the methods companion)
+
+*"Honest Same-Box Benchmarking for RDF Engines: Differential-Correctness-Gated,
+Hardware-Labelled, Negative-Results-Inclusive."* Target: a reproducibility / E&A track (VLDB
+E&A or an ISWC resources/reproducibility track) or a methods note. **It strengthens A1's (and
+every paper's) evaluation section** — which is exactly why it pilots alongside A1.
+
+| Has today | Needs |
+| --- | --- |
+| The methodology needs no benchmark to *describe* | nothing to publish the methods description |
+| IMPLEMENTED registry seam: `bench/competitors.json`, gather scripts, per-commit deterministic dashboard | the EC2-OIDC canonical lane is **designed-not-executed** (one IAM step); A2 honestly describes the methodology including the canonical-runner design even though that lane is not yet executed |
+
+Be explicit in A2 that it is *methodology, not a performance result*, and that the canonical
+lane is designed-not-executed. A2 doubles as the live demonstration of the §5 honesty gate.
+
+---
+
+## 7. Phased build plan (each item → a future bead)
+
+Ordered; the orchestrator will bead each (this worktree cannot run `bd`). Items touching
+`site/` are **serialized** — only one site branch in flight at a time (per the project's
+one-site-branch discipline).
+
+1. **(a) Author the factory skill — `skills/academic-paper/SKILL.md`.** [THIS PR — doc-only,
+   no `site/`.] The repeatable PROCESS (intake → classify → venue → draft → build → review),
+   the Typst single-source + live-`--input` recipe, the condensed venue map, the
+   empirical-honesty rules, the claims↔evidence rubric.
+2. **(b) Typst + typst.ts toolchain + CI build.** Add Typst to CI (digest-pinned), add
+   `@myriaddreamin/typst.react` + the typst.ts wasm to `site/`, add `site/papers/_lib/bench.typ`
+   + `_templates/`, add `site/scripts/build-papers.mjs`, wire it into `prebuild`/`dev`.
+   *Touches `site/`.*
+3. **(c) `/papers` route scaffold.** `papers.ts` registry, `app/papers/{layout,page}.tsx`,
+   `app/papers/[slug]/page.tsx` (`generateStaticParams`), `components/papers/*`, the sidebar
+   "Papers" nav entry. Renders an empty index until a paper is registered. *Touches `site/`.*
+4. **(d) First pilot paper — A1 (+ A2 as the methods/eval companion).** Author
+   `site/papers/filter-as-query/paper.typ` binding `#bench.<key>` to the canonical
+   recall/correctness metrics; register it in `papers.ts`. *Touches `site/`.*
+5. **(e) The honesty CI gate.** The `environment: canonical|indicative` schema check on
+   `benchmarks.generated.json` + the gate that fails the build if a paper-bound table cites
+   an `indicative` record (and refuses to co-tabulate the two tiers). Pairs with (b)/(d).
+   *Touches CI; reads `site/`.*
+6. **(f) Auto-update wiring.** The CI trigger so a `benchmark-data` / `benchmarks.generated.json`
+   change re-runs the paper build (PDF + HTML regenerate); the per-paper provenance stamp;
+   the long-term hook into the maintenance-automation intake re-run (§4). *Touches CI + `site/`.*
+
+**New follow-up work surfaced here (for the orchestrator to bead):**
+
+- **Canonical-runner execution is still blocked on one IAM admin step**
+  (`research/ci-ec2-design.md`). Until it lands, the pilot publishes only deterministic
+  metrics; any latency/memory headline (A1-latency, all of Tier B) stays blocked. This is a
+  hard prerequisite for (e)'s value and for promoting Tier-B candidates.
+- **typst.ts v0.7.0's pinned upstream compiler version** (whether it includes Typst 0.15
+  features used by the templates) is unconfirmed — verify in (b) before relying on 0.15
+  features; mitigation is to pin the template feature set to what v0.7.0's compiler supports.
+- **Zenodo DOI snapshot + ctuning artifact-appendix** for any paper actually submitted to a
+  venue with artifact evaluation (a per-submission task, not part of the live-site pipeline).
+
+---
+
+## 8. Open design question for the maintainer (genuinely needs a decision)
+
+**Where do the `.typ` sources live — `site/papers/` or a top-level `papers/`?** This design
+places them under `site/papers/` so the Typst CLI compile and the typst.ts browser import
+resolve from one tree and the build step is a plain `site/` script. The alternative (a
+repo-root `papers/`) keeps paper sources out of the web app but then needs a copy/symlink
+step into `site/` at build. The `site/papers/` choice is recommended (simpler build, matches
+the "numbers live in the site" goal), but it couples paper sources to the web app — worth a
+maintainer call before (b).
+
+(Lesser uncertainties — venue page limits/deadlines/blinding policies drift yearly and must
+be re-verified against the current CFP before any submission; Typst HTML export is still
+experimental, mitigated by using typst.ts today — are carried from #319 §7 and need no
+decision now.)
+
+---
+
+> 🤖 SPARQ agent — epic sq-gum8 phase 3. Non-sycophantic by mandate. Consolidates #317 + #319.

--- a/skills/academic-paper/SKILL.md
+++ b/skills/academic-paper/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: academic-paper
+description: "Use when turning a sparq contribution into an academic paper — identifying a genuinely-novel contribution (the re-runnable intake), classifying it and picking a venue (ISWC/ESWC Resource for the engine, PVLDB/SIGMOD/EDBT for DB-systems, arXiv/workshop for not-yet-sound ZK/MPC), drafting a single-source Typst (.typ) paper whose eval section binds to live benchmark data via --input/sys.inputs, building both a PDF and an in-site HTML page from that one source, and reviewing claims↔evidence under sparq's empirical-honesty mandate (canonical vs indicative numbers; the ZK/MPC not-yet-sound disclaimer). The paper-factory for epic sq-gum8."
+---
+
+# academic-paper — the sparq paper-factory
+
+This is the repeatable PROCESS for producing one paper from a sparq contribution. It is
+**factory machinery**, not prose advice: it enforces sparq's empirical-honesty mandate at
+the *data* layer, binds every number to live benchmark data, and emits a PDF + an in-site
+HTML page from one Typst source. Design record: `research/paper-factory-design.md`
+(consolidates the contribution inventory + the auto-gen/PDF research). Epic **sq-gum8**.
+
+**Two non-negotiable constraints govern every step.** They are the point of the factory; do
+not soften them.
+
+1. **No ZK/MPC security property may be claimed as proven.** The single-prover ZK verifier
+   has no external audit (bead **sq-qhy4**, open); the multi-prover path is re-open
+   (**sq-9hrn**); the malicious-secure MPC layer is a stub. A ZK/MPC paper today is an
+   **honest design / limitations / negative-result** contribution, arXiv/WIP only, and
+   **must cite sq-qhy4**. Never write "secure" / "verifiable" / "private" as a *proven*
+   property — only as a *design goal*.
+2. **Work-box (EC2 `-aws`) wall-clock numbers are NON-CANONICAL.** Only deterministic
+   integer metrics are canonical today (W3C/OGC conformance floors, byte-identity, recall
+   floors, gate/round/byte counts, differential-fuzz pass). A speed/memory claim needs the
+   **canonical runner** (`research/ci-ec2-design.md`). Indicative numbers are **never
+   co-tabulated with canonical ones** and never feed an aggregate figure-of-merit.
+
+The factory has six stages. Stages 0/1/3/5 are the methodology this skill encodes; 2/4/6 are
+scripted (see `research/paper-factory-design.md` §1–§2 for the script/route layout).
+
+---
+
+## Stage 0 — Intake: identify a genuinely-novel contribution (re-runnable)
+
+Run before claiming anything is publishable. This is the re-runnable identification process;
+its current ranked output is `research/paper-contributions-inventory.md` — read it first and
+diff against it rather than starting from scratch.
+
+**Scan six sources:** crates (`crates/sparq-*/src`, READMEs — what is IMPLEMENTED vs
+designed-only; `NotYetImplemented`/`#[ignore]` markers); `research/*.md` (claimed technique +
+prior-art + the author's own honesty hedges + negative results); beads
+(`.beads/issues.jsonl` — open audit/gating beads, esp. sq-qhy4/sq-9hrn/sq-1gir);
+benchmark deltas (`research/BENCHMARKS.md`, `bench/` — which numbers exist, canonical vs
+work-box); the conformance scoreboard (`crates/sparq-conformance/src/scoreboard.rs` — the
+only fully-canonical evidence); skills (`skills/*/SKILL.md` — distilled durable findings).
+
+**Score four criteria — a candidate must pass all four:**
+
+1. **Novelty vs prior art** — a new algorithm/construction/finding, or a faithful
+   re-implementation of cited prior art? Name the prior systems (ACORN, NaviX, QLever,
+   RDFox, CostFed, SPDZ, coZK, …). Integration *can* be a contribution — but framed as a
+   *systems/integration* paper, never dressed as a new algorithm. A measured negative result
+   is also a contribution.
+2. **Evidence available** — canonical evidence *today*, or only work-box numbers / a design?
+3. **Generality** — does the claim generalise beyond sparq's exact code, or is it a local
+   tuning artefact?
+4. **Honesty / soundness** — for crypto: proven, or merely implemented + internally
+   reviewed? For perf: canonical or not? **This is the veto against overclaiming.**
+
+**Assign a readiness verdict:** PUBLISHABLE-NOW (sound claim + canonical evidence today, or a
+design/methodology contribution needing no benchmark) | NEEDS-CANONICAL-BENCHMARKS (honest +
+real, but the headline rests on work-box numbers — publishable once re-gathered on the
+canonical runner) | NOT-YET-SOUND / NEEDS-EXTERNAL-AUDIT (ZK/MPC — honest design / negative
+result only; cite sq-qhy4). **Rank by readiness × impact** (a PUBLISHABLE-NOW candidate with
+a real audience outranks a high-impact unaudited crypto claim).
+
+**Re-run triggers:** a new crate/feature lands; a benchmark improves or a canonical run
+completes (re-evaluate every NEEDS-CANONICAL-BENCHMARKS candidate); a conformance floor rises;
+an audit bead changes state (a sq-qhy4 *pass* moves the ZK candidate out of NOT-YET-SOUND —
+until then it cannot move); a new `*-measured.md`/negative-result doc appears. The re-run is
+cheap: re-scan, re-score, re-verdict, re-rank, diff the inventory, open/close paper beads.
+
+---
+
+## Stage 1 — Classify & venue-target
+
+Map the contribution to its family, then to a venue + track + Typst template. **Verify every
+page limit / deadline / blinding policy against the current-year CFP before submitting — they
+drift yearly.** Maintainer precedent (jeswr, Oxford / ODI / W3C) centres on **ISWC/ESWC**;
+the engine-as-artifact maps exactly to their **Resource track**.
+
+| Family | Best venues | Track / notes |
+| --- | --- | --- |
+| **A — DB/engine performance** (indexes, parallel/streaming/mmap exec, ingest, compression) | **PVLDB** (rolling monthly, single-blind, EA&B track for measurement-heavy papers); **SIGMOD** (fixed rounds, double-blind); **ICDE**; **EDBT** (most accessible first DB paper) | systems/empirical; reproducibility/artifact tracks near-universal |
+| **B — Semantic Web / RDF / SPARQL** (federation, SHACL, GeoSPARQL, RSP-QL, inference, GenAI-over-RDF, RDFC-1.0) | **ISWC** (home venue; **Resource track purpose-built for a reusable engine**); **ESWC** (European sibling; note its strict no-preprint window conflicts with arXiv-first); TheWebConf; SEMANTiCS; JWS (journal) | Research / **Resource** / In-Use + posters/demos/workshops |
+| **C — Security/privacy (ZK/MPC), NOT-yet-sound** | **arXiv preprint + workshop NOW** (HotPETs / ZKProof / WPES / ISWC-ESWC privacy workshops); **PoPETs** = best real target *once sound* (journal, 4 rolling deadlines/yr); USENIX/CCS/S&P aspirational | preprint/WIP today; graduate to a real venue only when sq-qhy4 (and sq-9hrn) close |
+
+**Template:** `charged-ieee` (IEEE 2-col) | `arkheion` (arXiv-style) | `para-lipics` (LIPIcs;
+accepted papers need a Typst→LaTeX conversion for the publisher) | an acmart-style template.
+**Double-blind venues** (SIGMOD/VLDB/ICDE/WWW/CCS/S&P) require the anonymized build (Stage 4);
+ISWC/ESWC blinding varies by track. **Rolling cadence** (PVLDB monthly, PoPETs quarterly,
+SIGMOD multi-round) → target submit-when-ready, not one annual crunch.
+
+---
+
+## Stage 2 — Canonical benchmark capture (the honesty boundary)
+
+Run the eval on the pinned **canonical runner** (bare-metal / frequency-pinned —
+`research/ci-ec2-design.md`). Emit result records into the `benchmark-data` branch (which
+`site/scripts/sync-benchmarks.mjs` folds into `site/src/data/benchmarks.generated.json`),
+each carrying:
+
+```json
+{ "key": "filtered_ann.recall_at_10", "value": 0.98, "unit": "recall",
+  "n_reps": 30, "dispersion": { "ci95": [0.97, 0.99] },
+  "environment": "canonical",
+  "cpu": "...", "kernel": "...", "rustc": "...", "dataset_sha256": "...",
+  "seed": 42, "commit": "<sha>" }
+```
+
+**The CI gate:** any record with `environment: "indicative"` is **BLOCKED** from a
+paper-bound table — the build fails if a paper's `#bench.<key>` resolves to an indicative
+record. Indicative and canonical numbers are never in the same table and never feed an
+aggregate. Until the canonical runner exists (blocked on one IAM step), publish **only the
+deterministic metrics** (conformance counts, recall floors, byte-identity, gate/round/byte
+counts) — those are canonical today.
+
+---
+
+## Stage 3 — Draft: single-source Typst, bound to live data
+
+**Writing methodology (the order matters):**
+
+- **Contributions list FIRST** — it drives the whole paper ("the paper substantiates the
+  claims"). Each bullet is **refutable** (names *what* is achieved, specific enough to be
+  disproved) and **forward-references the section that delivers the evidence**. PJ's
+  contrast: NO = "We describe the WizWoz system. It is really cool."; YES = "We give the
+  syntax and semantics … (§3); we prove the type system sound … (§4); … half the length of
+  the Java version (§5)."
+- **Abstract = 4 sentences, written last:** (1) the problem; (2) why it is interesting;
+  (3) what your solution achieves; (4) what follows.
+- **Introduction ≤ 1 page**, in order: what is the problem / why important / why hard (why
+  naive approaches fail) / why unsolved before (what distinguishes you) / key components +
+  results → ending in the bulleted contributions list. The new contribution must be clear by
+  **end of page 3**. Delete "the rest of this paper is organized as follows" — the
+  contributions list does that job.
+- **Real examples, never `foo`/`bar`; active voice; self-contained figure captions that tell
+  the reader what to notice** (reviewers skim).
+- **Related work late & charitable** — "credit is not like money": be generous; compare and
+  contrast, don't list; label any inferior approach explicitly and up front; write it "as if
+  telling the cited authors why they should care." Defer to near the end unless a concise
+  early defensive stance is needed.
+- **Conclusion** with concrete numbers; **no wishlist "future work"** ("no partial credit for
+  neat things you wanted to do but didn't").
+
+**The live-data recipe (the load-bearing factory mechanism).** Author one `.typ`; inject the
+live JSON at build via `--input` / `sys.inputs`. At the top of the paper:
+
+```typ
+#let bench = json(bytes(sys.inputs.data))
+#let anon  = sys.inputs.at("anon", default: "false") == "true"
+```
+
+Then the eval section references `#bench.<key>` — **never a hard-coded number**:
+
+```typ
+We observe recall@10 of #bench.filtered_ann.recall_at_10
+over #bench.filtered_ann.n_queries queries (#bench.filtered_ann.n_reps reps,
+95% CI #bench.filtered_ann.dispersion.ci95).
+```
+
+Run the self-check before handing off to review:
+
+- **SIGPLAN-7 rubric** (red/yellow/green, supports judgment not a binary gate): (1) claims
+  clearly stated + scoped, no implied generality; (2) suitable, fairly-configured baseline;
+  (3) principled benchmark choice (established suites, justify subsets, no cherry-picking,
+  don't test on the training set); (4) adequate analysis (enough trials; geometric mean for
+  ratios, harmonic for rates, median under outliers; report variability/CIs); (5) relevant
+  metrics (measure *all* important effects — index/compile time alongside runtime); (6) clear
+  reproducible design (full platform spec, key parameters explored); (7) appropriate
+  presentation (zero-based axes, right precision, distribution-reflecting summary).
+- **Benchmarking-crimes self-check** (Heiser): full HW spec (CPU+µarch, cores, clock/turbo
+  policy, cache levels, RAM, kernel release, storage); full SW spec (`rustc` + `Cargo.lock` +
+  flags, baseline-system versions); dataset name+version+SHA-256+seed; report absolutes not
+  ratios-only; never summarize 4/6/7/49% as "up to 49%"; never use a competitor's sub-optimal
+  config (Heiser: that "probably constitutes scientific misconduct").
+
+---
+
+## Stage 4 — Build: one source → PDF + in-site HTML
+
+```bash
+# PDF (static asset served by the Next.js static export):
+typst compile site/papers/<slug>/paper.typ site/public/papers/<slug>.pdf \
+  --input data="$(cat site/src/data/benchmarks.generated.json)"
+
+# anonymized build for a double-blind venue (strips jeswr/sparq identity):
+typst compile site/papers/<slug>/paper.typ /tmp/<slug>-anon.pdf \
+  --input data="$(cat site/src/data/benchmarks.generated.json)" --input anon=true
+```
+
+The **in-site HTML** page at `/papers/<slug>` renders the *same* `.typ` via **typst.ts**
+(`@myriaddreamin/typst.react`), fed the same JSON — so HTML and PDF cannot show different
+numbers. (Typst's own HTML export is still experimental; use typst.ts today.) The build step
+(`site/scripts/build-papers.mjs`) is wired into `prebuild`, so `next build` regenerates every
+paper's PDF against fresh data; a `benchmark-data` change re-triggers it (numbers
+auto-update). For a venue that rejects Typst→LaTeX, the camera-ready fallback is Pandoc/LaTeX
+via Tectonic against `acmart`/`IEEEtran`/`lipics`. **Do not** author the PDF with
+`@react-pdf/renderer` — it duplicates the numbers (breaks single-source).
+
+---
+
+## Stage 5 — Review gate: claims ↔ evidence
+
+For every claim in the intro/contributions list, identify its evidence (analysis / theorem /
+measurement / case study) and confirm the forward-reference resolves. The gate (run as
+subagent section-reviewers + one cross-cutting honesty/repro reviewer) **blocks** on:
+
+- **Any indicative number in a claim** (the Stage-2 CI gate enforces this mechanically; the
+  reviewer also checks no indicative/canonical co-tabulation).
+- **A C-family (ZK/MPC) draft using "secure"/"verifiable"/"private" as a proven property** —
+  must be a design goal, with the sq-qhy4 soundness-gap disclaimer present.
+- **Overclaiming / implied generality, weak/unfair baselines, missing ablations, no error
+  bars, irreproducibility** (the SIGPLAN-7 + benchmarking-crimes findings from Stage 3).
+
+Resolve **all** findings before publish. Final check: the claims↔evidence loop is closed and
+every headline number is canonical.
+
+---
+
+## Stage 6 — Publish & auto-update
+
+Merge → `next build` serves `/papers/<slug>` + `/papers/<slug>.pdf` (static export, under the
+`/sparq` basePath). A `benchmarks.generated.json` refresh re-runs the build → both artifacts
+regenerate with current numbers. Each paper carries a **provenance stamp** (commit + canonical
+runner fingerprint + dataset SHA-256). A venue camera-ready triggers the optional Typst→LaTeX
+export. To **register a new paper**, add an entry to `site/src/data/papers.ts` and a
+`site/papers/<slug>/paper.typ` — the index, the per-paper route, the nav, and the PDF build
+are all data-driven off `papers.ts`.
+
+---
+
+## Empirical-honesty rules (the rubric, condensed)
+
+- **Canonical vs indicative** — headline tables/figures use only `environment: canonical`
+  records, reported with variability. Indicative (EC2 `-aws`) numbers live only in clearly
+  labelled "indicative development measurement" callouts that name the instance type + `-aws`
+  kernel, state they are not the basis of any claim, and are never co-tabulated with canonical
+  numbers. Never quote a speedup blending the two.
+- **ZK/MPC not-yet-sound disclaimer** — every C-family paper cites **sq-qhy4**, is marked
+  arXiv/WIP-only, and frames any security/privacy/integrity/attestation property as a *design
+  goal*, never proven. It graduates to a real venue only when sq-qhy4 (and, for the
+  multi-prover path, sq-9hrn) close.
+- **Honesty norm** — be scrupulously honest; don't over-sell, hide drawbacks, or disparage
+  others' work; submit only if proud to attach your name as-is; anticipate scepticism and
+  state how the approach could fail.
+
+## Pilot
+
+The factory's first pilot is **A1 + A2** together (both PUBLISHABLE-NOW, no canonical runner
+or external audit needed): **A1** = RDF-native filtered-ANN ("Filter-as-Query" — exact
+transitive-BGP filter over the engine's own dict-ids + answer-safety; canonical recall
+evidence today; frame as integration, not an ANN-algorithm novelty); **A2** = the honest
+same-box benchmark methodology (a methods/reproducibility contribution that strengthens A1's
+eval). See `research/paper-contributions-inventory.md` (Part 2) and
+`research/paper-factory-design.md` (§6).
+
+## Notes
+
+- This skill was **authored in-repo** (not installed). The strongest external pipeline
+  (Imbad0202/academic-research-skills) is CC-BY-NC — incompatible with this permissively
+  licensed repo; the MIT K-Dense scientific-writer is life-sciences-leaning and lacks
+  sparq's venue map + non-canonical-benchmark handling + the live-data Typst pipeline. Those
+  two sparq specifics ARE the contribution of the factory.
+- This is a **site/process** surface, not a public crate API, so it is not in the
+  `skills/SKILL.md` public-surface router (that router lists code-integration surfaces).
+  Keep this skill in sync with `research/paper-factory-design.md` if the pipeline changes.
+- Verify before relying on version-specific features: typst.ts's pinned upstream compiler vs
+  Typst 0.15; the current-year CFP for any target venue.


### PR DESCRIPTION
> 🤖 SPARQ agent — phase-3 design for the academic paper-factory (epic **sq-gum8**). DOC-ONLY: no site/crate code yet — the build comes after maintainer review. Consolidates the two completed research phases into one actionable design and authors the in-repo factory skill. Non-sycophantic by mandate. `[OPUS-4.8]`.

## What this adds

**`research/paper-factory-design.md`** — the actionable phase-3 design, consolidating PR #317 (contribution inventory + re-runnable identification process) and PR #319 (auto-gen/live/PDF stack research):

1. **Factory architecture** — end-to-end pipeline: intake (the re-runnable identification process) → classify + venue-target → **canonical benchmark capture with the honesty gate** → single-source `.typ` draft (eval binds `#bench.<key>`) → build (Typst PDF + typst.ts HTML, double-blind anon toggle) → claims↔evidence review → `/papers` publish + auto-update.
2. **Live data flow** — `benchmarks.generated.json` → `--input`/`sys.inputs` into the `.typ` → both PDF and in-site HTML show current numbers; rebuild-on-change CI trigger; concrete `site/` file/route layout.
3. **`/papers` route design** — index + per-paper page (typst.ts HTML render) + "Download PDF" button; sidebar nav consistent with the existing AppShell. Files-to-create only; no site code.
4. **The repeatable trigger** — any novel contribution / benchmark improvement → its own paper; how registration works (data-driven off `papers.ts`).
5. **Honesty/soundness gates** — `environment: canonical|indicative` field + CI gate blocking indicative numbers from paper tables; ZK/MPC not-yet-sound disclaimer (cite **sq-qhy4**, arXiv/WIP-only); work-box numbers never co-tabulated with canonical.
6. **Pilot = A1 + A2** — RDF-native filtered-ANN (canonical recall evidence today) + honest same-box methodology; exactly what each has vs needs.
7. **Phased build plan** — (a) skill [this PR] → (b) Typst+typst.ts toolchain → (c) `/papers` scaffold → (d) pilot A1 → (e) honesty CI gate → (f) auto-update wiring; site-touching items serialized.

**`skills/academic-paper/SKILL.md`** — the in-repo factory skill (authored, not installed — the strongest external pipeline is CC-BY-NC): the repeatable 6-stage PROCESS, the Typst single-source + live-`--input` recipe, the condensed venue map, the empirical-honesty rubric, the claims↔evidence review gate.

## Notes

- DOC-ONLY. markdownlint-clean. One open maintainer question in §8 (where the `.typ` sources live — recommend `site/papers/`).
- References #317, #319. Epic sq-gum8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)