### PR TITLE
feat(site): pre-warmed SPARQL REPL + dataset viewer/picker/upload (try playground)

### DIFF
--- a/site/src/components/repl-datasets.tsx
+++ b/site/src/components/repl-datasets.tsx
@@ -1,0 +1,454 @@
+"use client";
+
+// [OPUS-4.8] sq-repl-datasets — dataset source controls (built-in picker / file upload /
+// URL load) and the triple viewer dialog for the live SPARQL REPL. These drive the store
+// the REPL queries against; all parsing runs in the wasm Store (no mocks, no server).
+
+import * as React from "react";
+import {
+  Database,
+  Upload,
+  Link2,
+  Loader2,
+  Table2,
+  FileText,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import {
+  formatTerm,
+  type SparqlResults,
+  type WasmStore,
+} from "@/lib/sparq-wasm";
+import { BUILTIN_DATASETS } from "@/data/sample-graph";
+
+/** What's currently loaded into the REPL store, for the viewer's heading. */
+export interface ActiveDataset {
+  label: string;
+  description: string;
+}
+
+const ALL_TRIPLES_QUERY =
+  "SELECT ?s ?p ?o WHERE { ?s ?p ?o } ORDER BY ?s ?p ?o";
+
+// Formats the wasm engine's `load`/`loadDataset` accept, keyed by the file extension
+// or user choice. The engine takes a single format string per the lib.rs docs.
+const FORMAT_OPTIONS: { value: string; label: string; exts: string[] }[] = [
+  { value: "turtle", label: "Turtle (.ttl)", exts: ["ttl", "turtle"] },
+  { value: "ntriples", label: "N-Triples (.nt)", exts: ["nt", "ntriples"] },
+  { value: "nquads", label: "N-Quads (.nq)", exts: ["nq", "nquads"] },
+  { value: "trig", label: "TriG (.trig)", exts: ["trig"] },
+];
+
+/** Best-effort format guess from a filename/URL; falls back to Turtle. */
+export function guessFormat(name: string): string {
+  const ext = name.split(/[?#]/)[0].split(".").pop()?.toLowerCase() ?? "";
+  const hit = FORMAT_OPTIONS.find((f) => f.exts.includes(ext));
+  return hit?.value ?? "turtle";
+}
+
+// ---------------------------------------------------------------------------
+// Dataset source controls
+// ---------------------------------------------------------------------------
+
+export interface DatasetControlsProps {
+  /** Currently selected built-in id, or null when a custom source is loaded. */
+  activeBuiltinId: string | null;
+  /** Replace the store from a built-in dataset. */
+  onSelectBuiltin: (id: string) => void;
+  /** Replace OR add a custom RDF document (text + format). */
+  onLoadText: (
+    text: string,
+    format: string,
+    label: string,
+    mode: "replace" | "add",
+  ) => Promise<void>;
+  /** Disable controls while the engine is still cold. */
+  disabled?: boolean;
+}
+
+/**
+ * The dataset source row: a built-in picker plus "Upload" and "From URL" actions.
+ * Each path parses through the wasm Store; failures surface a clear inline error.
+ */
+export function DatasetControls({
+  activeBuiltinId,
+  onSelectBuiltin,
+  onLoadText,
+  disabled,
+}: DatasetControlsProps) {
+  const [mode, setMode] = React.useState<"replace" | "add">("replace");
+  const [urlOpen, setUrlOpen] = React.useState(false);
+  const fileRef = React.useRef<HTMLInputElement | null>(null);
+
+  const onFile = React.useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      // Reset the input so re-selecting the same file fires onChange again.
+      e.target.value = "";
+      if (!file) return;
+      const text = await file.text();
+      await onLoadText(text, guessFormat(file.name), file.name, mode);
+    },
+    [onLoadText, mode],
+  );
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-lg border bg-muted/30 p-2">
+      <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <Database className="size-3.5" /> Dataset
+      </span>
+
+      <label htmlFor="repl-dataset" className="sr-only">
+        Built-in dataset
+      </label>
+      <select
+        id="repl-dataset"
+        value={activeBuiltinId ?? "__custom__"}
+        disabled={disabled}
+        onChange={(e) => onSelectBuiltin(e.target.value)}
+        className="h-7 rounded-md border bg-background px-2 text-xs outline-none focus-visible:ring-3 focus-visible:ring-ring/40 disabled:opacity-50"
+      >
+        {BUILTIN_DATASETS.map((d) => (
+          <option key={d.id} value={d.id}>
+            {d.label}
+          </option>
+        ))}
+        {activeBuiltinId === null && (
+          <option value="__custom__">Custom (loaded)</option>
+        )}
+      </select>
+
+      <span className="ml-auto flex items-center gap-2">
+        <label
+          htmlFor="repl-mode"
+          className="text-[11px] text-muted-foreground"
+        >
+          On load
+        </label>
+        <select
+          id="repl-mode"
+          value={mode}
+          disabled={disabled}
+          onChange={(e) => setMode(e.target.value as "replace" | "add")}
+          className="h-7 rounded-md border bg-background px-2 text-xs outline-none focus-visible:ring-3 focus-visible:ring-ring/40 disabled:opacity-50"
+        >
+          <option value="replace">Replace</option>
+          <option value="add">Add to current</option>
+        </select>
+
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".ttl,.turtle,.nt,.ntriples,.nq,.nquads,.trig,text/turtle,application/n-triples,application/n-quads,application/trig"
+          className="hidden"
+          onChange={onFile}
+        />
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          onClick={() => fileRef.current?.click()}
+        >
+          <Upload className="size-3.5" /> Upload
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          onClick={() => setUrlOpen(true)}
+        >
+          <Link2 className="size-3.5" /> From URL
+        </Button>
+      </span>
+
+      <UrlLoadDialog
+        open={urlOpen}
+        onOpenChange={setUrlOpen}
+        defaultMode={mode}
+        onLoadText={onLoadText}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// URL load dialog
+// ---------------------------------------------------------------------------
+
+function UrlLoadDialog({
+  open,
+  onOpenChange,
+  defaultMode,
+  onLoadText,
+}: {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  defaultMode: "replace" | "add";
+  onLoadText: DatasetControlsProps["onLoadText"];
+}) {
+  const [url, setUrl] = React.useState("");
+  const [format, setFormat] = React.useState("turtle");
+  const [busy, setBusy] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const submit = React.useCallback(async () => {
+    const target = url.trim();
+    if (!target) return;
+    setBusy(true);
+    setError(null);
+    try {
+      let res: Response;
+      try {
+        res = await fetch(target, { headers: { Accept: "text/turtle, application/n-triples, application/n-quads, application/trig, */*" } });
+      } catch {
+        // A network/CORS rejection throws a TypeError with no useful detail in the
+        // browser — be explicit about the most likely cause rather than failing silently.
+        throw new Error(
+          "Could not fetch the URL. The server likely does not send CORS headers " +
+            "(Access-Control-Allow-Origin), so the browser blocks the cross-origin read. " +
+            "Try a CORS-enabled host, or download the file and use Upload.",
+        );
+      }
+      if (!res.ok) {
+        throw new Error(`Fetch failed: HTTP ${res.status} ${res.statusText}`);
+      }
+      const text = await res.text();
+      const fmt = format === "__auto__" ? guessFormat(target) : format;
+      await onLoadText(text, fmt, shortName(target), defaultMode);
+      onOpenChange(false);
+      setUrl("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }, [url, format, defaultMode, onLoadText, onOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[min(34rem,calc(100vw-2rem))]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Link2 className="size-4 text-primary" /> Load RDF from a URL
+          </DialogTitle>
+          <DialogDescription>
+            Fetched and parsed entirely in your browser tab. The host must allow
+            cross-origin reads (CORS).
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <label htmlFor="repl-url" className="text-xs font-medium">
+              URL
+            </label>
+            <input
+              id="repl-url"
+              type="url"
+              value={url}
+              placeholder="https://example.org/data.ttl"
+              spellCheck={false}
+              onChange={(e) => setUrl(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !busy) void submit();
+              }}
+              className="w-full rounded-lg border bg-muted/40 px-3 py-2 font-mono text-[13px] outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor="repl-url-format" className="text-xs font-medium">
+              Format
+            </label>
+            <select
+              id="repl-url-format"
+              value={format}
+              onChange={(e) => setFormat(e.target.value)}
+              className="h-8 w-full rounded-lg border bg-background px-2 text-sm outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+            >
+              <option value="__auto__">Auto-detect from extension</option>
+              {FORMAT_OPTIONS.map((f) => (
+                <option key={f.value} value={f.value}>
+                  {f.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {error && (
+            <p className="rounded-lg border border-destructive/30 bg-destructive/5 p-2.5 text-xs text-destructive">
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button size="sm" disabled={busy || !url.trim()} onClick={submit}>
+              {busy ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Link2 className="size-3.5" />
+              )}
+              Fetch & load
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function shortName(url: string): string {
+  try {
+    const u = new URL(url);
+    const last = u.pathname.split("/").filter(Boolean).pop();
+    return last || u.hostname;
+  } catch {
+    return url.slice(0, 40);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dataset viewer dialog
+// ---------------------------------------------------------------------------
+
+export interface DatasetViewerProps {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  store: WasmStore | null;
+  size: number | null;
+  active: ActiveDataset;
+}
+
+/**
+ * The triple viewer: opened by the triple-count badge. Reads the actual triples out of
+ * the live store (a `SELECT ?s ?p ?o` query — real data, not the source text) and shows
+ * them as a table or as an N-Triples listing.
+ */
+export function DatasetViewer({
+  open,
+  onOpenChange,
+  store,
+  size,
+  active,
+}: DatasetViewerProps) {
+  const [view, setView] = React.useState<"table" | "ntriples">("table");
+  const [rows, setRows] = React.useState<SparqlResults["results"]["bindings"]>(
+    [],
+  );
+  const [error, setError] = React.useState<string | null>(null);
+
+  // Re-read the triples whenever the dialog opens against the current store.
+  React.useEffect(() => {
+    if (!open || !store) return;
+    try {
+      const parsed = JSON.parse(store.query(ALL_TRIPLES_QUERY)) as SparqlResults;
+      setRows(parsed.results.bindings);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setRows([]);
+    }
+  }, [open, store]);
+
+  const ntriples = React.useMemo(
+    () =>
+      rows
+        .map(
+          (r) =>
+            `${formatTerm(r.s)} ${formatTerm(r.p)} ${formatTerm(r.o)} .`,
+        )
+        .join("\n"),
+    [rows],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Database className="size-4 text-primary" /> {active.label}
+          </DialogTitle>
+          <DialogDescription>
+            {active.description}
+            {size !== null && ` · ${size} triples`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-1.5">
+          <Button
+            variant={view === "table" ? "default" : "outline"}
+            size="sm"
+            onClick={() => setView("table")}
+          >
+            <Table2 className="size-3.5" /> Table
+          </Button>
+          <Button
+            variant={view === "ntriples" ? "default" : "outline"}
+            size="sm"
+            onClick={() => setView("ntriples")}
+          >
+            <FileText className="size-3.5" /> N-Triples
+          </Button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto rounded-lg border">
+          {error ? (
+            <pre className="p-3 text-xs text-destructive">{error}</pre>
+          ) : rows.length === 0 ? (
+            <p className="p-3 text-sm text-muted-foreground">
+              The store is empty.
+            </p>
+          ) : view === "table" ? (
+            <table className="w-full text-left text-sm">
+              <thead className="sticky top-0 bg-muted">
+                <tr>
+                  {["subject", "predicate", "object"].map((h) => (
+                    <th key={h} className="px-3 py-2 font-medium">
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r, i) => (
+                  <tr key={i} className="border-t">
+                    {(["s", "p", "o"] as const).map((k) => (
+                      <td
+                        key={k}
+                        className={cn(
+                          "px-3 py-1.5 font-mono text-[12px]",
+                          k === "o" && "break-all",
+                        )}
+                      >
+                        {formatTerm(r[k])}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <pre className="overflow-x-auto p-3 font-mono text-[12px] leading-relaxed">
+              {ntriples}
+            </pre>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Play, Loader2, Database, Zap } from "lucide-react";
+import { Play, Loader2, Database, Zap, CheckCircle2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -15,35 +15,98 @@ import {
 import { cn } from "@/lib/utils";
 import {
   loadSparq,
+  prewarmSparq,
+  storeToNTriples,
   formatTerm,
   type SparqlResults,
   type WasmStore,
 } from "@/lib/sparq-wasm";
-import { SAMPLE_TURTLE, EXAMPLE_QUERIES } from "@/data/sample-graph";
+import { EXAMPLE_QUERIES, BUILTIN_DATASETS } from "@/data/sample-graph";
+import {
+  DatasetControls,
+  DatasetViewer,
+  type ActiveDataset,
+} from "@/components/repl-datasets";
 
 type RunState =
   | { kind: "idle" }
-  | { kind: "loading" }
   | { kind: "running" }
   | { kind: "select"; results: SparqlResults; ms: number }
   | { kind: "boolean"; value: boolean; ms: number }
   | { kind: "error"; message: string };
 
+// [OPUS-4.8] Engine warm-up lifecycle, surfaced as a subtle indicator. The wasm fetch +
+// instantiate is kicked off on mount (prewarmSparq) so the first "Run query" is instant.
+type EngineState = "cold" | "warming" | "ready" | "error";
+
+const DEFAULT_DATASET = BUILTIN_DATASETS[0];
+
 export function Repl() {
   const [sparql, setSparql] = React.useState(EXAMPLE_QUERIES[0].sparql);
   const [state, setState] = React.useState<RunState>({ kind: "idle" });
   const [size, setSize] = React.useState<number | null>(null);
+  const [engine, setEngine] = React.useState<EngineState>("cold");
+  const [viewerOpen, setViewerOpen] = React.useState(false);
+  const [active, setActive] = React.useState<ActiveDataset>({
+    label: DEFAULT_DATASET.label,
+    description: DEFAULT_DATASET.description,
+  });
+  const [activeBuiltinId, setActiveBuiltinId] = React.useState<string | null>(
+    DEFAULT_DATASET.id,
+  );
   const storeRef = React.useRef<WasmStore | null>(null);
 
+  // Build (or rebuild) the store from RDF text + format. Centralises error handling so
+  // every load path (default, picker, upload, URL) reports failures the same way.
+  const buildStore = React.useCallback(
+    async (text: string, format: string): Promise<WasmStore> => {
+      const Store = await loadSparq();
+      const store = Store.load(text, format);
+      storeRef.current = store;
+      setSize(store.size);
+      return store;
+    },
+    [],
+  );
+
+  // Pre-warm the engine AND parse the default dataset eagerly on mount, off the render
+  // path. The first "Run query" then runs against an already-built store with no cold
+  // start. A failure resets the indicator so a later run can retry via ensureStore.
+  React.useEffect(() => {
+    let cancelled = false;
+    setEngine("warming");
+    prewarmSparq()
+      .then(async () => {
+        if (cancelled || storeRef.current) return;
+        await buildStore(DEFAULT_DATASET.text, DEFAULT_DATASET.format);
+      })
+      .then(() => {
+        if (!cancelled) setEngine("ready");
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setEngine("error");
+        toast.error("Engine failed to load", {
+          description: e instanceof Error ? e.message : String(e),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [buildStore]);
+
+  // Guarantees a store exists before a query runs — the safety net if pre-warm hasn't
+  // finished (or failed): never lets "Run query" no-op or throw on a cold engine.
   const ensureStore = React.useCallback(async (): Promise<WasmStore> => {
     if (storeRef.current) return storeRef.current;
-    setState({ kind: "loading" });
-    const Store = await loadSparq();
-    const store = Store.load(SAMPLE_TURTLE, "turtle");
-    storeRef.current = store;
-    setSize(store.size);
+    setEngine("warming");
+    const store = await buildStore(
+      DEFAULT_DATASET.text,
+      DEFAULT_DATASET.format,
+    );
+    setEngine("ready");
     return store;
-  }, []);
+  }, [buildStore]);
 
   const run = React.useCallback(async () => {
     try {
@@ -65,7 +128,71 @@ export function Repl() {
     }
   }, [ensureStore, sparql]);
 
-  const busy = state.kind === "loading" || state.kind === "running";
+  // Switch to a built-in dataset: reload the store, reset the count + active descriptor.
+  const selectBuiltin = React.useCallback(
+    async (id: string) => {
+      const ds = BUILTIN_DATASETS.find((d) => d.id === id);
+      if (!ds) return;
+      try {
+        await buildStore(ds.text, ds.format);
+        setActiveBuiltinId(ds.id);
+        setActive({ label: ds.label, description: ds.description });
+        setState({ kind: "idle" });
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        toast.error("Could not load dataset", { description: message });
+      }
+    },
+    [buildStore],
+  );
+
+  // Load a custom RDF document (upload / URL). "replace" swaps the store; "add" merges
+  // by concatenating both graphs' N-Triples and re-parsing — format-agnostic and correct.
+  const loadText = React.useCallback(
+    async (
+      text: string,
+      format: string,
+      label: string,
+      mode: "replace" | "add",
+    ) => {
+      try {
+        const Store = await loadSparq();
+        // Parse the incoming doc first so a parse error aborts BEFORE mutating state.
+        const incoming = Store.load(text, format);
+        if (mode === "add" && storeRef.current) {
+          const merged =
+            storeToNTriples(storeRef.current) +
+            "\n" +
+            storeToNTriples(incoming);
+          await buildStore(merged, "ntriples");
+          setActive((a) => ({
+            label: `${a.label} + ${label}`,
+            description: `Merged graph (${size ?? 0} + new triples).`,
+          }));
+        } else {
+          storeRef.current = incoming;
+          setSize(incoming.size);
+          setActive({
+            label,
+            description: `Custom ${format} dataset loaded in your tab.`,
+          });
+        }
+        setActiveBuiltinId(null);
+        setState({ kind: "idle" });
+        toast.success("Dataset loaded", {
+          description: `${label} — ${storeRef.current.size} triples`,
+        });
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        toast.error("Could not parse dataset", { description: message });
+        throw e; // let the URL dialog surface it inline too
+      }
+    },
+    [buildStore, size],
+  );
+
+  const busy = state.kind === "running";
+  const controlsDisabled = engine === "warming" || engine === "cold";
 
   return (
     <Card>
@@ -75,15 +202,32 @@ export function Repl() {
           Live SPARQL REPL
         </CardTitle>
         <div className="flex items-center gap-2">
-          <Badge variant="success">Live in your tab</Badge>
+          <EngineIndicator engine={engine} />
           {size !== null && (
-            <Badge variant="muted" className="tabular">
-              <Database className="size-3" /> {size} triples
-            </Badge>
+            <button
+              type="button"
+              onClick={() => setViewerOpen(true)}
+              aria-label={`View the ${size} triples in the loaded dataset`}
+              className="rounded-4xl outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+            >
+              <Badge
+                variant="muted"
+                className="tabular cursor-pointer transition-colors hover:bg-muted-foreground/20"
+              >
+                <Database className="size-3" /> {size} triples
+              </Badge>
+            </button>
           )}
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
+        <DatasetControls
+          activeBuiltinId={activeBuiltinId}
+          onSelectBuiltin={selectBuiltin}
+          onLoadText={loadText}
+          disabled={controlsDisabled}
+        />
+
         <div className="flex flex-wrap gap-1.5">
           {EXAMPLE_QUERIES.map((q) => (
             <Button
@@ -116,23 +260,53 @@ export function Repl() {
             ) : (
               <Play className="size-4" />
             )}
-            {state.kind === "loading" ? "Loading engine…" : "Run query"}
+            Run query
           </Button>
-          <p
-            aria-live="polite"
-            className="text-xs text-muted-foreground"
-          >
+          <p aria-live="polite" className="text-xs text-muted-foreground">
             {state.kind === "select" &&
               `${state.results.results.bindings.length} rows · ${state.ms.toFixed(1)} ms`}
             {state.kind === "boolean" && `${state.ms.toFixed(1)} ms`}
-            {state.kind === "loading" && "Fetching the wasm bundle…"}
             {state.kind === "running" && "Running on the wasm engine…"}
+            {state.kind === "idle" &&
+              engine === "warming" &&
+              "Pre-warming the wasm engine…"}
           </p>
         </div>
 
         <ResultPanel state={state} />
       </CardContent>
+
+      <DatasetViewer
+        open={viewerOpen}
+        onOpenChange={setViewerOpen}
+        store={storeRef.current}
+        size={size}
+        active={active}
+      />
     </Card>
+  );
+}
+
+// [OPUS-4.8] Subtle engine-readiness pill. Reuses the badge tokens; never blocks the UI.
+function EngineIndicator({ engine }: { engine: EngineState }) {
+  if (engine === "ready") {
+    return (
+      <Badge variant="success" aria-live="polite">
+        <CheckCircle2 className="size-3" /> Engine ready
+      </Badge>
+    );
+  }
+  if (engine === "error") {
+    return (
+      <Badge variant="warning" aria-live="polite">
+        Engine failed — retries on run
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="muted" aria-live="polite">
+      <Loader2 className="size-3 animate-spin" /> Engine loading…
+    </Badge>
   );
 }
 

--- a/site/src/components/ui/dialog.tsx
+++ b/site/src/components/ui/dialog.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+// [OPUS-4.8] sq-repl-datasets — a centred modal Dialog (radix-ui Dialog primitive, the
+// same one src/components/ui/sheet.tsx uses for its side drawer). Used by the REPL's
+// dataset viewer. Styling mirrors the site's Card/Sheet conventions.
+
+import * as React from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogClose = DialogPrimitive.Close;
+const DialogPortal = DialogPrimitive.Portal;
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      className={cn(
+        "fixed inset-0 z-50 bg-black/40 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        className={cn(
+          "bg-card text-card-foreground fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[min(46rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 flex-col gap-4 rounded-xl p-5 shadow-lg ring-1 ring-foreground/10 transition data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-md opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40">
+          <X className="size-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("flex flex-col gap-1.5", className)} {...props} />;
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      className={cn("text-foreground font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+};

--- a/site/src/data/sample-graph.ts
+++ b/site/src/data/sample-graph.ts
@@ -29,6 +29,95 @@ ex:dan a foaf:Person ;
   ex:city "Cardiff" .
 `;
 
+// [OPUS-4.8] sq-repl-datasets — a small set of self-contained built-in datasets the
+// REPL's dataset picker can switch between. Each is real RDF parsed by the wasm Store
+// (no mocks). `format` is the engine format string ("turtle" | "ntriples" | "nquads" |
+// "trig"); these built-ins are all Turtle.
+
+export interface BuiltinDataset {
+  /** Stable id used for the picker's selection state. */
+  id: string;
+  /** Human label shown in the picker. */
+  label: string;
+  /** One-line description of what's in the graph. */
+  description: string;
+  /** The RDF source text. */
+  text: string;
+  /** Engine format string for Store.load(). */
+  format: string;
+}
+
+// A second sample: a tiny library catalogue (books, authors, subjects) — different
+// vocabulary + shape from the social graph, so example queries exercise other joins.
+export const LIBRARY_TURTLE = `@prefix ex:   <http://example.org/lib/> .
+@prefix dc:   <http://purl.org/dc/terms/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+ex:book1 a ex:Book ;
+  dc:title "The Pragmatic Programmer" ;
+  ex:author ex:hunt, ex:thomas ;
+  dc:subject "Software" ;
+  ex:year 1999 .
+
+ex:book2 a ex:Book ;
+  dc:title "Designing Data-Intensive Applications" ;
+  ex:author ex:kleppmann ;
+  dc:subject "Databases" ;
+  ex:year 2017 .
+
+ex:book3 a ex:Book ;
+  dc:title "Types and Programming Languages" ;
+  ex:author ex:pierce ;
+  dc:subject "Software" ;
+  ex:year 2002 .
+
+ex:hunt      ex:name "Andrew Hunt" .
+ex:thomas    ex:name "David Thomas" .
+ex:kleppmann ex:name "Martin Kleppmann" .
+ex:pierce    ex:name "Benjamin C. Pierce" .
+`;
+
+// A third sample: a tiny geography graph (countries, capitals, population) — numeric
+// FILTER / ORDER BY / aggregate friendly.
+export const GEO_TURTLE = `@prefix ex:   <http://example.org/geo/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+ex:france   a ex:Country ; ex:name "France" ;
+  ex:capital "Paris" ; ex:population 67000000 ; ex:continent "Europe" .
+ex:japan    a ex:Country ; ex:name "Japan" ;
+  ex:capital "Tokyo" ; ex:population 125000000 ; ex:continent "Asia" .
+ex:brazil   a ex:Country ; ex:name "Brazil" ;
+  ex:capital "Brasília" ; ex:population 214000000 ; ex:continent "Americas" .
+ex:kenya    a ex:Country ; ex:name "Kenya" ;
+  ex:capital "Nairobi" ; ex:population 54000000 ; ex:continent "Africa" .
+ex:germany  a ex:Country ; ex:name "Germany" ;
+  ex:capital "Berlin" ; ex:population 83000000 ; ex:continent "Europe" .
+`;
+
+export const BUILTIN_DATASETS: BuiltinDataset[] = [
+  {
+    id: "social",
+    label: "Social graph (default)",
+    description: "People, ages, cities and foaf:knows links — the REPL's default.",
+    text: SAMPLE_TURTLE,
+    format: "turtle",
+  },
+  {
+    id: "library",
+    label: "Library catalogue",
+    description: "Books, authors and subjects (Dublin Core).",
+    text: LIBRARY_TURTLE,
+    format: "turtle",
+  },
+  {
+    id: "geo",
+    label: "World geography",
+    description: "Countries, capitals, populations and continents.",
+    text: GEO_TURTLE,
+    format: "turtle",
+  },
+];
+
 export interface ExampleQuery {
   label: string;
   sparql: string;

--- a/site/src/lib/sparq-wasm.ts
+++ b/site/src/lib/sparq-wasm.ts
@@ -11,6 +11,7 @@
 export interface WasmStore {
   readonly size: number;
   query(sparql: string): string; // SPARQL 1.1 JSON results document
+  queryQuads(sparql: string): string; // CONSTRUCT/DESCRIBE -> N-Triples
 }
 
 interface WasmModule {
@@ -21,6 +22,15 @@ interface WasmModule {
   };
 }
 
+/**
+ * [OPUS-4.8] Serialises a store's whole default graph to N-Triples (a valid Turtle
+ * subset) via a CONSTRUCT. Used to merge two graphs format-agnostically when the user
+ * chooses "add to current": concatenate both stores' N-Triples and re-load as ntriples.
+ */
+export function storeToNTriples(store: WasmStore): string {
+  return store.queryQuads("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }");
+}
+
 let modulePromise: Promise<WasmModule> | null = null;
 
 function basePath(): string {
@@ -29,7 +39,12 @@ function basePath(): string {
   return process.env.NEXT_PUBLIC_BASE_PATH ?? "/sparq";
 }
 
-/** Loads + initialises the wasm engine once; subsequent calls reuse it. */
+/**
+ * [OPUS-4.8] Loads + initialises the wasm engine once; subsequent calls reuse it.
+ *
+ * The fetch + compile + instantiate is the expensive cold start. {@link prewarmSparq}
+ * kicks this off eagerly on route mount so the first `Run query` pays no cold start.
+ */
 export async function loadSparq(): Promise<WasmModule["Store"]> {
   if (!modulePromise) {
     modulePromise = (async () => {
@@ -48,6 +63,17 @@ export async function loadSparq(): Promise<WasmModule["Store"]> {
   }
   const mod = await modulePromise;
   return mod.Store;
+}
+
+/**
+ * [OPUS-4.8] Eagerly pre-warm the wasm engine (fetch + compile + instantiate) without
+ * blocking render. Safe to call on route mount and to call repeatedly — it shares the
+ * single {@link loadSparq} promise, so the cold start happens at most once. Returns a
+ * promise that resolves when the engine is ready (or rejects on a load failure, which
+ * resets the cache so a later `Run query` can retry).
+ */
+export function prewarmSparq(): Promise<unknown> {
+  return loadSparq();
 }
 
 // ---- minimal SPARQL 1.1 JSON shapes for rendering ----


### PR DESCRIPTION
> 🤖 SPARQ agent

Makes the live SPARQL REPL (`/try`) instant on first run and lets visitors inspect, switch, and supply their own datasets — all client-side (static export, no server).

## Demo
- **Pre-warmed engine** — the wasm fetch+instantiate is kicked off on route mount (off the render path) and the default dataset is parsed eagerly, so the **first "Run query" runs immediately** with no cold-start retry. A subtle `Engine loading… → Engine ready` badge shows the state; a safety-net `ensureStore()` guarantees the button never no-ops or throws on a cold engine.
- **View the dataset** — the "N triples" indicator is now a real, keyboard-focusable button (`aria-label`) that opens a modal showing the store's **actual triples** (a `SELECT ?s ?p ?o` query, not the source text) as a table or an N-Triples listing.
- **Dataset picker** — three built-in samples: social graph (default), library catalogue, world geography. Selecting one reloads the store and updates the count + viewer.
- **Bring your own data** — **upload** a local RDF file (Turtle / N-Triples / N-Quads / TriG) or **load from a public URL** (fetched + parsed in-tab; CORS/network failures surface a clear, honest message). Choose **Replace** or **Add to current** (add merges both graphs via a format-agnostic N-Triples re-parse).

## Notes
- Front-end only — consumes the existing `sparq-wasm` build unchanged (no `crates/` changes).
- Gates: `next build` (static export) green, `next lint` clean, TypeScript type-checks (no `any` escape hatches). wasm `Store` API paths (`load`, `query`, `queryQuads`, ntriples merge) smoke-tested in Node.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)