### PR TITLE
feat(sparq-policy): faithful ODRL purpose-constraint enforcement (sq-q56r)

### DIFF
--- a/crates/sparq-policy/README.md
+++ b/crates/sparq-policy/README.md
@@ -82,6 +82,26 @@ assert!(!evaluate(&policy, &outside).allow);
   `xsd:dateTime`/`date` operands compare by magnitude/instant; everything else
   by IRI/string value. Constraints over `purpose` / `recipient` / `dateTime` /
   `count` / `spatial` left-operands are all supported.
+- **`odrl:purpose` enforcement (faithful, fail-closed)** — [OPUS-4.8] sq-q56r. A
+  purpose constraint restricts a rule to a stated *purpose of use*. A request carries
+  its purpose evidence via `Request::for_purpose(Value)` (sugar over
+  `.with(ODRL_PURPOSE, ..)`), readable back via `Request::purpose()`. The purpose is
+  gated through the **same** `evaluate` constraint path as every other dimension, so it
+  is actually checked end-to-end — never claimed-but-unchecked:
+  - **Match → grant; mismatch → deny; missing purpose → fail-closed.** A request that
+    states **no** purpose is *unprovable*, so a purpose-gated permission does **not**
+    grant and a purpose-gated prohibition is **not** withdrawn — "no purpose stated" is
+    **never** read as "any purpose allowed".
+  - **Match semantics (the boundary — not over-claimed):** **exact** IRI/string
+    equality (`eq`/`isA`), or membership in the explicit `isPartOf` purpose *set* the
+    constraint names, or `neq` (purpose ≠ the named one). There is **no** purpose
+    hierarchy / DPV subsumption: a narrower or broader purpose IRI is *not* matched
+    against a constraint that names a different one. `neq` still requires a stated
+    purpose (missing → fail-closed). A DPV-style purpose taxonomy / `isPartOf`-over-a-
+    hierarchy is a deferred bead.
+  - `purpose_status(&rule, &request) -> PurposeMatch` reports exactly what the evaluator
+    checks for a rule's purpose constraints — `Satisfied` / `DefinitelyUnsatisfied` /
+    `Unprovable` / `NotConstrained` — the auditable surface of this enforcement.
 - **Duties as obligations** — a permission's `odrl:duty` must appear in the
   request's discharged-duty set, or the permission is denied (the usage-control
   kernel pure access control lacks).

--- a/crates/sparq-policy/src/eval.rs
+++ b/crates/sparq-policy/src/eval.rs
@@ -18,6 +18,11 @@
 use crate::model::{Action, Constraint, Operator, Policy, Rule, Value};
 use std::collections::{BTreeMap, BTreeSet};
 
+/// The `odrl:purpose` left-operand IRI — the dimension a *purpose constraint*
+/// restricts (the purpose of use a permission/prohibition is gated on, e.g.
+/// `odrl:purpose eq <urn:purpose/research>`). [OPUS-4.8] sq-q56r.
+pub const ODRL_PURPOSE: &str = "http://www.w3.org/ns/odrl/2/purpose";
+
 /// An access request evaluated against a [`Policy`]: who wants to do what, to
 /// what, in what context (the "evaluation request" + "state of the world" of the
 /// ODRL Formal Semantics, folded into one node-local view).
@@ -71,6 +76,33 @@ impl Request {
     pub fn discharge(mut self, duty_action: impl Into<String>) -> Request {
         self.discharged_duties.insert(duty_action.into());
         self
+    }
+
+    /// Declare the **purpose of use** this request carries as evidence (chainable)
+    /// — the `odrl:purpose` left-operand value a purpose-gated rule is checked
+    /// against. [OPUS-4.8] sq-q56r.
+    ///
+    /// This is first-class sugar over [`Request::with`]`(ODRL_PURPOSE, ..)`: it
+    /// makes the *evidence the requester supplies* explicit (and auditable via
+    /// [`Request::purpose`]) instead of relying on a magic context key. A request
+    /// that does NOT call this carries **no** purpose evidence, so a permission
+    /// gated on purpose does not grant and a prohibition gated on purpose is not
+    /// withdrawn (fail-closed — see [`purpose_status`]).
+    ///
+    /// The value is stored verbatim: a DPV/purpose-taxonomy IRI as [`Value::Iri`]
+    /// (`Value::Iri(..)`) or a purpose code as [`Value::Str`]. Matching is **exact**
+    /// (IRI/string equality) — there is no hierarchy/subsumption (see
+    /// [`purpose_status`]).
+    pub fn for_purpose(self, purpose: Value) -> Request {
+        self.with(ODRL_PURPOSE, purpose)
+    }
+
+    /// The purpose-of-use evidence this request carries (`odrl:purpose`), or `None`
+    /// if the request supplied none. The auditable answer to *"did the request
+    /// actually state a purpose?"* — the question faithful purpose enforcement turns
+    /// on. [OPUS-4.8] sq-q56r.
+    pub fn purpose(&self) -> Option<&Value> {
+        self.context.get(ODRL_PURPOSE)
     }
 }
 
@@ -298,6 +330,100 @@ pub enum ProhibitionStatus {
     /// constraint that is *definitely* false given the evidence — the only case in
     /// which a materialized deny may be RETRACTED (access restored).
     Withdrawn,
+}
+
+/// The three-valued verdict of a rule's `odrl:purpose` constraints against the
+/// purpose evidence a request carries — a FAITHFUL report of exactly what
+/// [`evaluate`] checks for purpose (it reuses the same [`constraint_status`] the
+/// evaluator's purpose constraints go through). [OPUS-4.8] sq-q56r.
+///
+/// The honesty contract: this never claims a stronger verdict than the evaluator
+/// would act on. `Satisfied`/`Unprovable`/`DefinitelyUnsatisfied` map 1:1 onto the
+/// evaluator's gating — a `Satisfied` purpose is the *only* verdict under which a
+/// purpose-gated permission can grant, and anything other than `DefinitelyUnsatisfied`
+/// (i.e. `Satisfied` OR `Unprovable`) keeps a purpose-gated prohibition in force.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PurposeMatch {
+    /// The rule has no `odrl:purpose` constraint — purpose places no restriction on
+    /// it (the rule's other attributes/constraints decide).
+    NotConstrained,
+    /// The rule constrains purpose AND the request's stated purpose **matches** every
+    /// purpose constraint (exact IRI/string equality, the only matching this checks).
+    Satisfied,
+    /// The rule constrains purpose but the request carries **no** purpose evidence —
+    /// *unprovable*. Fail-closed: a permission does NOT grant on this; a prohibition is
+    /// NOT withdrawn. (Never silently read as "any purpose allowed".)
+    Unprovable,
+    /// The rule constrains purpose and the request's stated purpose **does not match**
+    /// — a definite mismatch (a permission does not grant; a prohibition no longer
+    /// carves *this* purpose out).
+    DefinitelyUnsatisfied,
+}
+
+/// Report how `rule`'s `odrl:purpose` constraint(s) stand against the purpose
+/// evidence `request` carries — the auditable surface of faithful purpose
+/// enforcement. [OPUS-4.8] sq-q56r.
+///
+/// This does NOT re-implement matching: it runs the request through the SAME
+/// [`constraint_status`] every `odrl:purpose` constraint goes through inside
+/// [`evaluate`], so the verdict it reports is exactly what the evaluator acts on —
+/// the whole point of the bead (no claimed enforcement that isn't actually checked).
+///
+/// **Match semantics (the boundary, not over-claimed):** a purpose matches by
+/// **exact** IRI/string equality (an `eq`/`isA` purpose constraint), or by membership
+/// in an explicit `isPartOf` purpose *set* (the `|`/space/comma-separated right
+/// operand). There is **no** purpose hierarchy / DPV subsumption: a request purpose is
+/// not matched against broader/narrower purposes — only the exact value(s) the
+/// constraint names. A `neq` purpose constraint is honoured (purpose ≠ the named one).
+/// Several purpose constraints on one rule are ANDed (every one must hold), mirroring
+/// the evaluator's constraint conjunction.
+///
+/// Returns [`PurposeMatch::NotConstrained`] when the rule has no purpose constraint.
+///
+/// # Examples
+///
+/// ```
+/// use sparq_policy::{purpose_status, PurposeMatch, parse_policy_str, Request, Value};
+/// let pol = parse_policy_str(r#"
+/// @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+/// <urn:pol/p> a odrl:Set ; odrl:permission [
+///     odrl:action odrl:use ; odrl:target <urn:asset/x> ;
+///     odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;
+///                       odrl:rightOperand <urn:purpose/research> ] ] .
+/// "#, "turtle").unwrap();
+/// let rule = &pol.permissions[0];
+/// let base = Request::new("http://www.w3.org/ns/odrl/2/use").on("urn:asset/x");
+///
+/// // Stated purpose matches exactly → Satisfied.
+/// let ok = base.clone().for_purpose(Value::Iri("urn:purpose/research".into()));
+/// assert_eq!(purpose_status(rule, &ok), PurposeMatch::Satisfied);
+/// // Stated a different purpose → DefinitelyUnsatisfied.
+/// let bad = base.clone().for_purpose(Value::Iri("urn:purpose/marketing".into()));
+/// assert_eq!(purpose_status(rule, &bad), PurposeMatch::DefinitelyUnsatisfied);
+/// // NO purpose evidence → Unprovable (fail-closed; not "any purpose").
+/// assert_eq!(purpose_status(rule, &base), PurposeMatch::Unprovable);
+/// ```
+pub fn purpose_status(rule: &Rule, request: &Request) -> PurposeMatch {
+    let mut constrained = false;
+    let mut any_unprovable = false;
+    for c in &rule.constraints {
+        if c.left != ODRL_PURPOSE {
+            continue;
+        }
+        constrained = true;
+        match constraint_status(c, request) {
+            ConstraintStatus::Satisfied => {}
+            ConstraintStatus::DefinitelyUnsatisfied => return PurposeMatch::DefinitelyUnsatisfied,
+            ConstraintStatus::Unprovable => any_unprovable = true,
+        }
+    }
+    if !constrained {
+        PurposeMatch::NotConstrained
+    } else if any_unprovable {
+        PurposeMatch::Unprovable
+    } else {
+        PurposeMatch::Satisfied
+    }
 }
 
 /// How one prohibition rule re-evaluates against a request, distinguishing a

--- a/crates/sparq-policy/src/lib.rs
+++ b/crates/sparq-policy/src/lib.rs
@@ -6,7 +6,8 @@ pub mod model;
 mod parse;
 
 pub use eval::{
-    evaluate, matched_prohibition, prohibition_status, Decision, ProhibitionStatus, Request,
+    evaluate, matched_prohibition, prohibition_status, purpose_status, Decision, ProhibitionStatus,
+    PurposeMatch, Request, ODRL_PURPOSE,
 };
 pub use model::{Action, Constraint, Duty, Operator, Policy, Rule, Value, ODRL_NS};
 pub use parse::{parse_policy, parse_policy_str};

--- a/crates/sparq-policy/tests/odrl_eval.rs
+++ b/crates/sparq-policy/tests/odrl_eval.rs
@@ -11,7 +11,8 @@
 //! blank-node constraints).
 
 use sparq_policy::{
-    evaluate, parse_policy_str, prohibition_status, Decision, ProhibitionStatus, Request, Value,
+    evaluate, parse_policy_str, prohibition_status, purpose_status, Decision, ProhibitionStatus,
+    PurposeMatch, Request, Value,
 };
 
 const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
@@ -461,4 +462,194 @@ fn prohibition_status_ambiguous_only_if_no_other_match() {
         .on("urn:asset/x")
         .by("https://alice.ex/me");
     assert_eq!(prohibition_status(&p, &req), ProhibitionStatus::Applies);
+}
+
+// ===========================================================================
+// [OPUS-4.8] sq-q56r — faithful odrl:purpose enforcement: a purpose constraint
+// grants ONLY when the request carries a matching purpose; a missing purpose is
+// Unprovable → fail-closed (permission does not grant; prohibition not withdrawn);
+// a mismatch is a definite no. Match is EXACT (no hierarchy/subsumption). The
+// `purpose_status` helper REPORTS exactly what `evaluate` checks (the honesty point).
+// ===========================================================================
+
+const RESEARCH: &str = "urn:purpose/research";
+const MARKETING: &str = "urn:purpose/marketing";
+
+/// alice MAY use asset-X, gated on purpose = research (exact IRI).
+fn purpose_permission() -> sparq_policy::Policy {
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/purp> a odrl:Set ; odrl:permission [
+    odrl:action odrl:use ; odrl:target <urn:asset/x> ; odrl:assignee <https://alice.ex/me> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;
+                      odrl:rightOperand <{RESEARCH}> ] ] .
+"#
+    );
+    parse_policy_str(&ttl, "turtle").unwrap()
+}
+
+#[test]
+fn purpose_match_grants() {
+    let p = purpose_permission();
+    let req = Request::new(left("use"))
+        .on("urn:asset/x")
+        .by("https://alice.ex/me")
+        .for_purpose(Value::Iri(RESEARCH.into()));
+    assert!(evaluate(&p, &req).allow, "matching purpose grants");
+    assert_eq!(purpose_status(&p.permissions[0], &req), PurposeMatch::Satisfied);
+    // The request's purpose is auditable as exactly what it stated.
+    assert_eq!(req.purpose().map(Value::as_str), Some(RESEARCH));
+}
+
+#[test]
+fn purpose_mismatch_denies() {
+    let p = purpose_permission();
+    let req = Request::new(left("use"))
+        .on("urn:asset/x")
+        .by("https://alice.ex/me")
+        .for_purpose(Value::Iri(MARKETING.into()));
+    assert!(!evaluate(&p, &req).allow, "a different purpose must not grant");
+    assert_eq!(
+        purpose_status(&p.permissions[0], &req),
+        PurposeMatch::DefinitelyUnsatisfied
+    );
+}
+
+#[test]
+fn missing_purpose_fails_closed() {
+    // THE honesty test: no purpose stated → Unprovable → permission does NOT grant.
+    // "No purpose stated" is never treated as "any purpose allowed".
+    let p = purpose_permission();
+    let no_purpose = Request::new(left("use"))
+        .on("urn:asset/x")
+        .by("https://alice.ex/me");
+    assert!(
+        !evaluate(&p, &no_purpose).allow,
+        "missing purpose must fail closed (not grant)"
+    );
+    assert_eq!(no_purpose.purpose(), None, "no purpose evidence supplied");
+    assert_eq!(
+        purpose_status(&p.permissions[0], &no_purpose),
+        PurposeMatch::Unprovable
+    );
+}
+
+#[test]
+fn purpose_match_is_exact_no_hierarchy() {
+    // Match is EXACT — a narrower/broader purpose IRI is NOT subsumed. Documents the
+    // boundary so the helper never over-claims hierarchy matching it does not perform.
+    let p = purpose_permission(); // gated on <urn:purpose/research>
+    let subpurpose = Request::new(left("use"))
+        .on("urn:asset/x")
+        .by("https://alice.ex/me")
+        // a plausibly-narrower purpose IRI — NOT matched (no subsumption).
+        .for_purpose(Value::Iri("urn:purpose/research/clinical".into()));
+    assert!(
+        !evaluate(&p, &subpurpose).allow,
+        "exact-match only: a sub-purpose IRI is not subsumed"
+    );
+    assert_eq!(
+        purpose_status(&p.permissions[0], &subpurpose),
+        PurposeMatch::DefinitelyUnsatisfied
+    );
+}
+
+#[test]
+fn purpose_set_is_part_of() {
+    // An explicit isPartOf purpose set is honoured (membership), but it is still the
+    // exact set the constraint names — not a hierarchy.
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/ps> a odrl:Set ; odrl:permission [
+    odrl:action odrl:use ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:isPartOf ;
+                      odrl:rightOperand "{RESEARCH}|{MARKETING}" ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let base = Request::new(left("use")).on("urn:asset/x");
+    assert!(evaluate(&p, &base.clone().for_purpose(Value::Str(RESEARCH.into()))).allow);
+    assert!(evaluate(&p, &base.clone().for_purpose(Value::Str(MARKETING.into()))).allow);
+    // Outside the set → deny; missing → Unprovable (fail-closed).
+    assert!(!evaluate(&p, &base.clone().for_purpose(Value::Str("urn:purpose/ads".into()))).allow);
+    assert!(!evaluate(&p, &base).allow);
+}
+
+#[test]
+fn purpose_neq_constraint() {
+    // odrl:neq purpose: granted for ANY purpose except the named one — but a stated
+    // purpose is still REQUIRED (missing → Unprovable → fail-closed).
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/pn> a odrl:Set ; odrl:permission [
+    odrl:action odrl:use ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:neq ;
+                      odrl:rightOperand <{MARKETING}> ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let base = Request::new(left("use")).on("urn:asset/x");
+    assert!(evaluate(&p, &base.clone().for_purpose(Value::Iri(RESEARCH.into()))).allow);
+    assert!(!evaluate(&p, &base.clone().for_purpose(Value::Iri(MARKETING.into()))).allow);
+    // Missing purpose is unprovable, NOT "any purpose ≠ marketing" → fail-closed.
+    assert!(!evaluate(&p, &base).allow, "neq purpose still needs evidence");
+}
+
+#[test]
+fn purpose_prohibition_dual() {
+    // The dual: a prohibition gated on purpose carves the request out ONLY when the
+    // stated purpose matches; a different purpose does NOT carve out; a MISSING purpose
+    // keeps the carve-out ambiguous (the deny is NOT withdrawn — fail-closed).
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/pp> a odrl:Set ; odrl:prohibition [
+    odrl:action odrl:use ; odrl:target <urn:asset/x> ; odrl:assignee <https://alice.ex/me> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;
+                      odrl:rightOperand <{MARKETING}> ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let prohib = &p.prohibitions[0];
+    let base = Request::new(left("use"))
+        .on("urn:asset/x")
+        .by("https://alice.ex/me");
+
+    // Stated marketing purpose → the prohibition applies (carve-out).
+    let marketing = base.clone().for_purpose(Value::Iri(MARKETING.into()));
+    assert_eq!(purpose_status(prohib, &marketing), PurposeMatch::Satisfied);
+    assert_eq!(prohibition_status(&p, &marketing), ProhibitionStatus::Applies);
+
+    // Stated a DIFFERENT purpose → the prohibition definitely no longer carves THIS out.
+    let research = base.clone().for_purpose(Value::Iri(RESEARCH.into()));
+    assert_eq!(
+        purpose_status(prohib, &research),
+        PurposeMatch::DefinitelyUnsatisfied
+    );
+    assert_eq!(prohibition_status(&p, &research), ProhibitionStatus::Withdrawn);
+
+    // NO purpose stated → ambiguous: the deny is NOT withdrawn (fail-closed).
+    assert_eq!(purpose_status(prohib, &base), PurposeMatch::Unprovable);
+    assert_eq!(prohibition_status(&p, &base), ProhibitionStatus::Ambiguous);
+}
+
+#[test]
+fn purpose_not_constrained_when_absent() {
+    // A rule with no purpose constraint reports NotConstrained (purpose places no bound).
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/np> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let req = Request::new(left("read")).on("urn:asset/x");
+    assert_eq!(
+        purpose_status(&p.permissions[0], &req),
+        PurposeMatch::NotConstrained
+    );
 }

--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -141,6 +141,20 @@ and the recipient-of-data *is* the session agent — so an agent matcher re-chec
 identical semantics. Purpose/time/count have no stateless `(agent, client)` analogue, so
 persisting them would require a looser approximation that could over-grant — rejected.
 
+**`odrl:purpose` enforcement through the bridge (faithful, fail-closed)** — [OPUS-4.8] sq-q56r.
+Purpose has no re-checked-condition analogue (above), so it stays **one-shot**: the bound is
+checked **once**, against the request's stated purpose, by the same `sparq_policy::evaluate`
+the one-shot `materialize_odrl_permission` / `materialize_odrl_prohibition` run — then a grant
+(or `auth:deny*`) is materialized only if it held. So a purpose-gated rule is enforced
+end-to-end through the *real* `accessible` / `query_as` path, never claimed-but-unchecked:
+a **matching** stated purpose grants; a **mismatch** denies; a **missing** purpose is
+*unprovable* → fail-closed (the permission does not grant; the prohibition is not carved out
+— "no purpose stated" is never "any purpose allowed"). **Match is exact** (IRI/string
+equality, or `isPartOf` over the named set, or `neq`) — **no** purpose hierarchy / DPV
+subsumption. Because the check is one-shot, a purpose-gated grant is scoped to the request
+party it was materialized for; a *changed* stated purpose is re-evaluated on the next
+`refresh_odrl_grant` (sq-dpk4). A DPV purpose taxonomy / hierarchy match is a deferred bead.
+
 **Fail-safe on mixed constraints:** a condition is persisted **only** when *every* constraint
 on the rule maps faithfully. A rule mixing a mappable recipient with an unmappable
 `dateTime`/`purpose`/`count` falls back **entirely** to the one-shot path — persisting only

--- a/crates/sparq-solid/tests/odrl_bridge.rs
+++ b/crates/sparq-solid/tests/odrl_bridge.rs
@@ -1335,3 +1335,160 @@ fn policy_refresh_deny_overrides_composition() {
         "deny dropped + allow re-applied → write restored under deny-overrides",
     );
 }
+
+// ===========================================================================
+// [OPUS-4.8] sq-q56r — faithful odrl:purpose enforcement THROUGH THE REAL
+// enforcement path (PodStore::accessible / query_as). A purpose-gated permission
+// grants ONLY when the request states a matching purpose; a mismatch denies; a
+// MISSING purpose fails closed (no grant); the prohibition dual carves out only on
+// a matching stated purpose, and a missing purpose does NOT withdraw the carve-out.
+// Match is exact (no hierarchy). All assertions go through accessible / query_as.
+// ===========================================================================
+
+const RESEARCH: &str = "urn:purpose/research";
+const MARKETING: &str = "urn:purpose/marketing";
+
+/// alice MAY read n1, gated on purpose = research (exact IRI).
+fn purpose_read_policy() -> sparq_policy::Policy {
+    parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/purp> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;
+                      odrl:rightOperand <urn:purpose/research> ] ] .
+"#,
+        "turtle",
+    )
+    .expect("policy parses")
+}
+
+fn reads_n1(store: &mut PodStore, agent: &str) -> bool {
+    let s = Session { agent: Some(agent), client: None };
+    store.accessible(&s, Mode::Read).iter().any(|g| g.as_str() == N1)
+}
+
+// 28. purpose MATCH grants through the real enforcement path; mismatch + missing deny.
+#[test]
+fn purpose_match_grants_through_enforcement() {
+    let pol = purpose_read_policy();
+    let sel = "SELECT ?t WHERE { ?s <https://ex.dev/ns#title> ?t }";
+    let alice = Session { agent: Some(ALICE), client: None };
+
+    // (a) Matching purpose → grant → alice reads through accessible AND query_as.
+    let mut store = PodStore::new(pod());
+    let ok = Request::new(odrl("read"))
+        .on(N1)
+        .by(ALICE)
+        .for_purpose(Value::Iri(RESEARCH.to_owned()));
+    assert!(store.materialize_odrl_permission(&pol, &ok).granted, "matching purpose grants");
+    assert!(reads_n1(&mut store, ALICE), "alice reads with matching purpose");
+    assert_eq!(store.query_as(&alice, Mode::Read, sel).unwrap().rows.len(), 1);
+
+    // (b) Mismatched purpose → no grant, nothing readable.
+    let mut store2 = PodStore::new(pod());
+    let bad = Request::new(odrl("read"))
+        .on(N1)
+        .by(ALICE)
+        .for_purpose(Value::Iri(MARKETING.to_owned()));
+    assert!(!store2.materialize_odrl_permission(&pol, &bad).granted, "mismatch denies");
+    assert!(!reads_n1(&mut store2, ALICE), "no access on purpose mismatch");
+    assert_eq!(store2.query_as(&alice, Mode::Read, sel).unwrap().rows.len(), 0);
+}
+
+// 29. THE honesty test: a MISSING purpose fails closed — no grant, no access. "No
+//     purpose stated" is never silently treated as "any purpose allowed".
+#[test]
+fn missing_purpose_fails_closed_through_enforcement() {
+    let mut store = PodStore::new(pod());
+    let no_purpose = Request::new(odrl("read")).on(N1).by(ALICE); // no purpose evidence
+    let out = store.materialize_odrl_permission(&purpose_read_policy(), &no_purpose);
+    assert!(!out.granted, "missing purpose must NOT grant: {out:?}");
+    assert!(!reads_n1(&mut store, ALICE), "no access when purpose is unstated");
+    let sel = "SELECT ?t WHERE { ?s <https://ex.dev/ns#title> ?t }";
+    let alice = Session { agent: Some(ALICE), client: None };
+    assert_eq!(store.query_as(&alice, Mode::Read, sel).unwrap().rows.len(), 0);
+}
+
+// 30. Match is EXACT — a narrower sub-purpose IRI is not subsumed (no hierarchy).
+#[test]
+fn purpose_match_is_exact_through_enforcement() {
+    let mut store = PodStore::new(pod());
+    let sub = Request::new(odrl("read"))
+        .on(N1)
+        .by(ALICE)
+        .for_purpose(Value::Iri("urn:purpose/research/clinical".to_owned()));
+    assert!(
+        !store.materialize_odrl_permission(&purpose_read_policy(), &sub).granted,
+        "exact-match only: a sub-purpose IRI is not subsumed",
+    );
+    assert!(!reads_n1(&mut store, ALICE));
+}
+
+// 31. The DUAL — a purpose-gated PROHIBITION carves out (denies) only on a matching
+//     stated purpose; a different purpose does NOT carve out; a MISSING purpose does
+//     NOT withdraw the carve-out (deny stays — fail-closed). All via accessible.
+#[test]
+fn purpose_prohibition_dual_through_enforcement() {
+    // A standalone permit (any purpose) so the prohibition has an allow to override.
+    let permit = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/p> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    // alice is PROHIBITED from reading n1 FOR purpose = marketing.
+    let prohib = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/pp> a odrl:Set ; odrl:prohibition [
+    odrl:action odrl:read ; odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://alice.ex/card#me> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;
+                      odrl:rightOperand <urn:purpose/marketing> ] ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+
+    // (a) Stated marketing purpose → prohibition carves out → DENY beats the allow.
+    let mut store = PodStore::new(pod());
+    let unconstrained = Request::new(odrl("read")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_permission(&permit, &unconstrained).granted);
+    assert!(reads_n1(&mut store, ALICE), "allow live before the deny");
+    let marketing = Request::new(odrl("read"))
+        .on(N1)
+        .by(ALICE)
+        .for_purpose(Value::Iri(MARKETING.to_owned()));
+    let out = store.materialize_odrl_prohibition(&prohib, &marketing);
+    assert!(out.prohibited, "matching purpose carves out: {out:?}");
+    assert!(!reads_n1(&mut store, ALICE), "deny-overrides: marketing purpose denied");
+
+    // (b) Stated a DIFFERENT purpose → prohibition does NOT carve out (no deny).
+    let mut store2 = PodStore::new(pod());
+    assert!(store2.materialize_odrl_permission(&permit, &unconstrained).granted);
+    let research = Request::new(odrl("read"))
+        .on(N1)
+        .by(ALICE)
+        .for_purpose(Value::Iri(RESEARCH.to_owned()));
+    let out2 = store2.materialize_odrl_prohibition(&prohib, &research);
+    assert!(!out2.prohibited, "a non-marketing purpose is not carved out: {out2:?}");
+    assert!(reads_n1(&mut store2, ALICE), "allow survives: research purpose not prohibited");
+
+    // (c) NO purpose stated → the carve-out is *unprovable*, so materialize_prohibition
+    //     emits NO deny: it materializes a deny only when the prohibition DEFINITELY
+    //     matches (the matched_prohibition boundary). The deny is materialized once a
+    //     request actually states the banned purpose. The *deny-retraction* direction —
+    //     where unprovable must NOT restore an existing deny — is prohibition_status's
+    //     job (ProhibitionStatus::Ambiguous keeps it; asserted in sparq-policy's tests).
+    let mut store3 = PodStore::new(pod());
+    assert!(store3.materialize_odrl_permission(&permit, &unconstrained).granted);
+    let out3 = store3.materialize_odrl_prohibition(&prohib, &unconstrained);
+    assert!(!out3.prohibited, "no purpose evidence → no definite carve-out materialized");
+}

--- a/skills/usage-control-policy/SKILL.md
+++ b/skills/usage-control-policy/SKILL.md
@@ -74,7 +74,16 @@ assert_eq!(d.matched_rules.len(), 1);  // the granting permission, for audit
 
 ## Building the request
 
-`Request::new(action_iri)` then chain `.on(target)`, `.by(party)`, `.with(left_operand_iri, Value)` for each context dimension (`dateTime`, `purpose`, `recipient`, `count`, `spatial`, …), and `.discharge(duty_action_iri)` per discharged duty. `Value` is `Iri` | `Str` | `Num(f64)` | `DateTime(String)`.
+`Request::new(action_iri)` then chain `.on(target)`, `.by(party)`, `.with(left_operand_iri, Value)` for each context dimension (`dateTime`, `purpose`, `recipient`, `count`, `spatial`, …), and `.discharge(duty_action_iri)` per discharged duty. `Value` is `Iri` | `Str` | `Num(f64)` | `DateTime(String)`. For purpose specifically, prefer the first-class `.for_purpose(Value)` (sugar over `.with(ODRL_PURPOSE, ..)`); read it back via `req.purpose()`.
+
+## `odrl:purpose` enforcement (faithful, fail-closed) — [OPUS-4.8] sq-q56r
+
+A purpose constraint restricts a rule to a stated *purpose of use*. The request carries its purpose as **evidence** (`.for_purpose(Value)`), and it is gated through the **same** `evaluate` constraint path as every other dimension — so it is actually checked end-to-end (no claimed-but-unchecked enforcement), including through the opt-in bridge's real `accessible` / `query_as` path.
+
+- **Match → grant; mismatch → deny; missing purpose → fail-closed.** A request stating **no** purpose is *unprovable*: a purpose-gated permission does **not** grant, and a purpose-gated prohibition is **not** withdrawn. "No purpose stated" is **never** treated as "any purpose allowed".
+- **Match semantics (the boundary — do not over-claim):** **exact** IRI/string equality (`eq`/`isA`), or membership in the explicit `isPartOf` purpose *set* the constraint names, or `neq` (≠ the named one; still requires a stated purpose). There is **no** purpose hierarchy / DPV subsumption — a narrower/broader purpose IRI is not matched against a constraint naming a different one. (DPV taxonomy / hierarchy match is a deferred bead.)
+- **Audit:** `purpose_status(&rule, &request) -> PurposeMatch` reports exactly what the evaluator checks — `Satisfied` / `DefinitelyUnsatisfied` / `Unprovable` / `NotConstrained`.
+- Through the bridge, purpose stays **one-shot** (checked once at materialization; see the mapping table below) — it has no re-checked-condition analogue, so a changed purpose is re-evaluated on the next `refresh_odrl_grant`.
 
 ## Bridge to WAC/ACP enforcement (opt-in `odrl-bridge`) — [OPUS-4.8] sq-h3uk
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-q56r** — faithful `odrl:purpose` constraint enforcement: purpose is actually checked end-to-end, with no claimed enforcement that isn't evaluated through the real path. OPT-IN policy feature.

## What

- **First-class purpose evidence** on `Request`: `for_purpose(Value)` (sugar over `.with(ODRL_PURPOSE, ..)`), `purpose()` accessor, `ODRL_PURPOSE` const — makes "did the request actually state a purpose?" explicit and auditable instead of relying on a magic context key.
- **`purpose_status(&rule, &request) -> PurposeMatch`** — reports *exactly* what `evaluate` checks for a rule's purpose constraints (reuses the same `constraint_status` the evaluator runs): `Satisfied` / `DefinitelyUnsatisfied` / `Unprovable` / `NotConstrained`. This is the honesty surface — the helper cannot claim a verdict the evaluator wouldn't act on.

## Semantics (fail-closed)

- **Match → grant; mismatch → deny; missing purpose → fail-closed.** A request stating **no** purpose is *unprovable*: a purpose-gated permission does **not** grant; a purpose-gated prohibition is **not** withdrawn. "No purpose stated" is never "any purpose allowed".
- **Match boundary (not over-claimed):** exact IRI/string equality (`eq`/`isA`), `isPartOf` over the named set, or `neq` — **no** purpose hierarchy / DPV subsumption. A narrower/broader purpose IRI is not matched. (DPV taxonomy/hierarchy match is a deferred bead.)

## Request model

The existing `Request.context` already threaded purpose; this PR adds the minimal first-class accessor/builder + const on top (no invasive model change needed — purpose was already evaluated through the generic constraint path, this makes the evidence explicit and faithfully reported).

## Tests (real enforcement path)

- `sparq-policy`: `evaluate` + `purpose_status` unit tests — match grants, mismatch denies, missing fail-closed, exact-match-only (sub-purpose not subsumed), `isPartOf` set, `neq`, and the prohibition dual (`prohibition_status` Applies/Withdrawn/Ambiguous on purpose evidence).
- `sparq-solid`: bridge tests through `PodStore::accessible` / `query_as` — purpose-match grants, mismatch denies, missing-purpose fail-closed, exact-match-only, and the purpose-gated prohibition dual.

## Gates

`cargo build` + `cargo clippy --all-targets -- -D warnings` + `cargo test` green for **both** `sparq-policy` and `sparq-solid`, **feature-off and feature-on** (`odrl-bridge`). (rustfmt is informational in CI pending the deferred workspace reformat; no unrelated reformat included.)

## Deferred (for beading)

- DPV / purpose-taxonomy **hierarchy / subsumption** matching (currently exact-match only — documented as the boundary).

[OPUS-4.8] · sq-q56r