### PR TITLE
feat(sparq-vectors): filtered-ANN pre/post-filter cost model (sq-7hx6)

### DIFF
--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -78,7 +78,12 @@ let _neighbours = index.nearest_term(&some_term, &graph, &store, 10);
   against an unchanged graph reuse the component's mask instead of re-running the constraint
   SELECT, and **any** graph change (added/removed/changed triple or term, or a dict-id shift)
   changes the fingerprint and misses the cache — so a stale mask is never served (the invalidation
-  is sound; when in doubt it recomputes). The cache is transparent (no API change).
+  is sound; when in doubt it recomputes). The cache is transparent (no API change). With the mask in
+  hand, a per-query **cost model** (`CostModel`, sq-7hx6) chooses **pre-filter** (scan only the mask)
+  vs **post-filter** (scan the whole store, drop non-members) by the mask's selectivity — pre-filter
+  iff `mask_len · scatter_penalty ≤ store_len` (default crossover ≈ half the store). Both branches
+  return the **byte-identical** top-k (asserted in tests), so the choice trades only throughput,
+  never the answer; it is a heuristic over a cost estimate, not an optimum.
 - **Verbalization** — `verbalize` / `embed_entities` render `<label>. a <type>. <description>`
   per entity (multilingual, char-budgeted); `embed_labels` is the label-only special case.
 - **Quantization** — `ScalarQuantizer` (4×) and `ProductQuantizer` (asymmetric distance) for

--- a/crates/sparq-vectors/src/cost.rs
+++ b/crates/sparq-vectors/src/cost.rs
@@ -1,0 +1,382 @@
+//! [OPUS-4.8] (sq-7hx6, epic sq-3183) **Filtered-ANN pre-filter vs post-filter cost model** —
+//! deciding when materialising a transitive [`IdMask`](crate::filter::IdMask) and pre-filtering
+//! the search is worth it, versus running the search unfiltered and dropping the disallowed hits
+//! afterwards.
+//!
+//! This is the cost concern recorded as sq-ic0n ("when transitive masking pays"); sq-7hx6 IS that
+//! cost model, so sq-ic0n is **subsumed** by this module.
+//!
+//! # The two strategies (and why they return the same answer)
+//!
+//! For a `vec:` neighbour variable constrained by a sub-BGP, the *answer* is unambiguous: the
+//! top-`k` stored vectors **whose id is admitted by the constraint**, ranked by cosine. There are
+//! two ways to compute it, and — this is the load-bearing invariant — **they return byte-identical
+//! results** (same ids, same order; cosine ties break on ascending id in both):
+//!
+//! - **Pre-filter** ([`crate::filter::nearest_exact_filtered`]): scan only the masked ids and rank
+//!   them. Work ≈ `|mask| · dim` distance computations. This is what the `vec:` rewrite has always
+//!   done once a mask is derived.
+//!
+//! - **Post-filter** ([`postfilter_exact`]): run the *unfiltered* exact scan over the whole store
+//!   (already a full sort by cosine), then walk that ranking dropping ids not in the mask until `k`
+//!   admitted hits are collected. Work ≈ `store_len · dim` distance computations (the full scan)
+//!   regardless of selectivity.
+//!
+//! Because the unfiltered scan is a *complete* ranking of the store, post-filtering it can never
+//! under-fill `k` unless the mask itself admits fewer than `k` stored-and-embedded vectors — in
+//! which case **both** strategies return the same short list (the pre-filter scan of the mask is
+//! also short). So there is no over-fetch recall boundary for the exact-scan backend: post-filter
+//! over a full ranking is answer-complete by construction. (The over-fetch *boundary* only bites an
+//! **approximate** index that returns a bounded candidate list; see [`overfetch_target`] and the
+//! honest caveat there — that path is a documented follow-up, not the exact backend used here.)
+//!
+//! # The cost the mask itself carries
+//!
+//! Both strategies still need to know *which* ids are admitted, but they pay for it differently.
+//! Pre-filter **must** materialise the full mask (it scans it). Post-filter only needs *membership*
+//! — and crucially, deriving the mask through the engine (a full SELECT over the sub-BGP, in the
+//! `vec:` rewrite under the `vec-predicate` feature) costs roughly the sub-BGP's cardinality `c`
+//! regardless. So the model's job is
+//! NOT "mask vs no mask" (we derive the mask either way to stay answer-safe); it is **"having a mask,
+//! is it cheaper to scan the mask (pre-filter) or scan the whole store and drop non-members
+//! (post-filter)?"** — i.e. is `|mask| · dim` (plus the mask's hash-set build) below `store_len · dim`
+//! by enough to be worth the worse cache behaviour of gathering scattered masked rows?
+//!
+//! # The heuristic (NOT optimal — estimates only)
+//!
+//! Let `m = |mask|`, `n = store_len`. Pre-filter touches `m` rows, post-filter touches `n`. Pre-filter
+//! gathers *scattered* rows (random-access into the mmap) whereas post-filter streams the store
+//! sequentially, so a masked row is modelled as `scatter_penalty ×` (default `2.0`) the cost of a
+//! sequential row. **Pre-filter is chosen when**
+//!
+//! ```text
+//!     m · scatter_penalty  ≤  n
+//! ```
+//!
+//! i.e. when the mask is selective enough that even at the scatter penalty, scanning it beats a full
+//! sequential scan. With the default penalty that is `m ≤ n / 2` — pre-filter for a mask admitting up
+//! to half the store, post-filter for a broader one. `k` and `dim` cancel out of the *exact-scan*
+//! comparison (both strategies do `dim`-width distance work per touched row and both then take `k`),
+//! so they do not enter this crossover; they are surfaced in [`CostEstimate`] for callers wiring an
+//! approximate backend (where `k`/over-fetch *do* matter) and to keep the estimate honest about what
+//! it did and did not model.
+//!
+//! This is a **heuristic over a cost *estimate***, not a proven optimum: `scatter_penalty` is a
+//! single modelled constant, real cache/SIMD behaviour is hardware-dependent, and the sub-BGP
+//! cardinality is the *materialised* mask size (exact here, but an estimate in a planner that has not
+//! evaluated it). The one thing it is NOT allowed to get wrong is the **answer**: whichever branch it
+//! picks, the returned top-`k` is identical (asserted in the tests), so a mis-estimate costs only
+//! throughput, never correctness.
+
+use crate::ann::nearest_exact;
+use crate::filter::{nearest_exact_filtered, IdMask};
+use crate::store::VectorStore;
+use sparq_core::dict::Id;
+
+/// Tuning for the [pre-filter ↔ post-filter](self) decision. Separate from
+/// [`FilterConfig`](crate::filter::FilterConfig) (which tunes the *pre-filter ↔ filtered-traversal*
+/// choice on the on-disk index): this governs the **`vec:` rewrite's** choice between scanning the
+/// derived mask and scanning the whole store then dropping non-members.
+#[derive(Clone, Copy, Debug)]
+pub struct CostModel {
+    /// How much more expensive a *scattered* masked-row access (random-access gather into the mmap)
+    /// is than a *sequential* full-scan row. `1.0` = no penalty (decide purely on row counts `m` vs
+    /// `n`); the default `2.0` reflects that gathering scattered rows defeats sequential prefetch and
+    /// is the honestly conservative line — it errs toward post-filter (the strategy whose cost does
+    /// not depend on a possibly-mis-estimated mask size) on a mid-selective mask. Must be ≥ 1.0.
+    pub scatter_penalty: f32,
+}
+
+impl Default for CostModel {
+    fn default() -> Self {
+        // [OPUS-4.8] non-canonical constant: a single modelled scatter penalty, not a measured fit.
+        // It only shifts the crossover (m ≤ n / scatter_penalty); it never affects the answer.
+        CostModel {
+            scatter_penalty: 2.0,
+        }
+    }
+}
+
+/// Which strategy the [`CostModel`] picked, with the estimate it was based on — returned so callers
+/// (and tests) can assert the *decision*, not just the result.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Strategy {
+    /// Scan only the masked ids ([`nearest_exact_filtered`]). Chosen for a **selective** mask.
+    PreFilter,
+    /// Scan the whole store then drop non-masked hits ([`postfilter_exact`]). Chosen for a **broad**
+    /// mask, where the mask scan would touch almost the whole store anyway (at the scatter penalty).
+    PostFilter,
+}
+
+/// The cost estimate behind a [`Strategy`] choice — the modelled work of each branch, so the
+/// decision is inspectable and testable. The units are *modelled row-touches* (not wall-clock); only
+/// their ratio matters.
+#[derive(Clone, Copy, Debug)]
+pub struct CostEstimate {
+    /// `|mask|` — masked rows the pre-filter would touch.
+    pub mask_len: usize,
+    /// `store_len` — rows the post-filter (full scan) would touch.
+    pub store_len: usize,
+    /// `k` — requested neighbours (does not enter the exact-scan crossover; recorded for an
+    /// approximate backend where over-fetch makes it matter).
+    pub k: usize,
+    /// Modelled pre-filter cost: `mask_len · scatter_penalty`.
+    pub prefilter_cost: f32,
+    /// Modelled post-filter cost: `store_len` (one sequential touch per row).
+    pub postfilter_cost: f32,
+    /// The chosen strategy.
+    pub strategy: Strategy,
+}
+
+impl CostModel {
+    /// Estimate both branches' cost for a mask of `mask_len` over a `store_len`-vector store and
+    /// pick the cheaper. `k` does not change the exact-scan crossover (see the [module docs](self))
+    /// but is carried into the [`CostEstimate`].
+    ///
+    /// Pre-filter wins iff `mask_len · scatter_penalty ≤ store_len`.
+    pub fn decide(&self, mask_len: usize, store_len: usize, k: usize) -> CostEstimate {
+        let prefilter_cost = mask_len as f32 * self.scatter_penalty;
+        let postfilter_cost = store_len as f32;
+        let strategy = if prefilter_cost <= postfilter_cost {
+            Strategy::PreFilter
+        } else {
+            Strategy::PostFilter
+        };
+        CostEstimate {
+            mask_len,
+            store_len,
+            k,
+            prefilter_cost,
+            postfilter_cost,
+            strategy,
+        }
+    }
+}
+
+/// **Post-filter exact top-`k`**: rank the WHOLE store unfiltered, then keep only ids admitted by
+/// `mask`, best-first, up to `k`. The alternative to [`nearest_exact_filtered`] when the mask is too
+/// broad for pre-filtering to pay.
+///
+/// # Identical result to the pre-filter (the load-bearing invariant)
+///
+/// [`nearest_exact`] returns a *complete* cosine ranking of every stored vector (ties on ascending
+/// id). Dropping the non-masked ids from that ranking and taking the first `k` yields **exactly** the
+/// same `(id, score)` list, in the same order, as [`nearest_exact_filtered`] (which ranks the masked
+/// ids directly with the identical comparator). So this is answer-safe with **no over-fetch boundary
+/// for the exact backend**: a full ranking cannot under-fill `k` unless the mask admits fewer than
+/// `k` stored vectors, in which case the pre-filter scan is equally short and the two agree on the
+/// short list. (An *approximate* index would return a bounded candidate list and could under-fill —
+/// see [`overfetch_target`].)
+///
+/// An empty mask, or an all-zero query, returns no results — the same degenerate-case contract as
+/// [`nearest_exact_filtered`].
+pub fn postfilter_exact(
+    store: &VectorStore,
+    query: &[f32],
+    mask: &IdMask,
+    k: usize,
+) -> Vec<(Id, f32)> {
+    if mask.is_empty() || k == 0 || query.iter().all(|&v| v == 0.0) {
+        return Vec::new();
+    }
+    // Full unfiltered ranking (best-first, deterministic ties). `k = store.len()` so it is the
+    // COMPLETE ranking — post-filtering a complete ranking is answer-complete (no over-fetch needed).
+    nearest_exact(store, query, store.len())
+        .into_iter()
+        .filter(|&(id, _)| mask.contains(id))
+        .take(k)
+        .collect()
+}
+
+/// **Cost-model-driven filtered top-`k`**: pick pre-filter or post-filter by [`CostModel::decide`],
+/// run the chosen branch, and return both the hits and the [`CostEstimate`] (so the decision is
+/// observable). Both branches return the **identical** answer (see [`postfilter_exact`]); the model
+/// only trades throughput.
+///
+/// This is the seam the `vec:` rewrite uses when both `vec-predicate` and `filtered-ann` are on: it
+/// already derived the `mask` (it must, to stay answer-safe), and this decides how to *use* it.
+pub fn nearest_filtered_costed(
+    store: &VectorStore,
+    query: &[f32],
+    mask: &IdMask,
+    k: usize,
+    model: &CostModel,
+) -> (Vec<(Id, f32)>, CostEstimate) {
+    let est = model.decide(mask.len(), store.len(), k);
+    let hits = match est.strategy {
+        Strategy::PreFilter => nearest_exact_filtered(store, query, mask, k),
+        Strategy::PostFilter => postfilter_exact(store, query, mask, k),
+    };
+    (hits, est)
+}
+
+/// [OPUS-4.8] How many candidates an **approximate** index must over-fetch to expect `k` survivors
+/// after post-filtering at selectivity `mask_len / store_len`. `ceil(k / selectivity)`, clamped to
+/// the store size and to at least `k`.
+///
+/// This is **not used by the exact-scan backend** (which post-filters a *complete* ranking and so
+/// never under-fills). It is provided — and documented as a HEURISTIC with a real recall boundary —
+/// for a future approximate filtered `vec:` path: an approximate index returns a bounded candidate
+/// list, so post-filtering it can under-fill `k` if too few survive. The honest handling is
+/// **iterative over-fetch**: fetch `overfetch_target(k, …)`, and if fewer than `k` survive, re-fetch
+/// a larger candidate list (doubling) until `k` survive or the store is exhausted — at which point
+/// the mask genuinely admits fewer than `k` and the short list is correct. The recall boundary is
+/// that a *single* over-fetch sized by the average selectivity can under-fill when the admitted ids
+/// cluster *below* the fetched prefix; iterative over-fetch removes that boundary at the cost of
+/// extra index probes. Wiring an approximate filtered backend is a deferred follow-up (own bead).
+pub fn overfetch_target(k: usize, mask_len: usize, store_len: usize) -> usize {
+    if mask_len == 0 || store_len == 0 {
+        return k;
+    }
+    let selectivity = mask_len as f64 / store_len as f64;
+    let target = (k as f64 / selectivity).ceil() as usize;
+    target.max(k).min(store_len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::VectorStore;
+
+    fn tmp(name: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!("sparq_vec_cost_{}_{name}.spqv", std::process::id()));
+        p
+    }
+
+    /// A small store of points on the unit circle, ids 1..=n, each at angle 2πi/n.
+    fn ring_store(name: &str, n: usize) -> VectorStore {
+        let mut store = VectorStore::create(tmp(name), 2).unwrap();
+        for i in 0..n {
+            let theta = std::f32::consts::TAU * (i as f32) / (n as f32);
+            // id 0 is reserved-ish; use i+1 as the dict id.
+            store
+                .put((i as u32) + 1, &[theta.cos(), theta.sin()])
+                .unwrap();
+        }
+        store.finalize().unwrap();
+        store
+    }
+
+    /// The decision crossover: with the default scatter_penalty 2.0, pre-filter iff m ≤ n/2.
+    #[test]
+    fn decision_crossover_default_penalty() {
+        let m = CostModel::default();
+        // n = 100. m ≤ 50 → pre-filter; m > 50 → post-filter.
+        assert_eq!(m.decide(10, 100, 5).strategy, Strategy::PreFilter);
+        assert_eq!(m.decide(50, 100, 5).strategy, Strategy::PreFilter); // boundary: 50·2 = 100 ≤ 100
+        assert_eq!(m.decide(51, 100, 5).strategy, Strategy::PostFilter);
+        assert_eq!(m.decide(100, 100, 5).strategy, Strategy::PostFilter);
+    }
+
+    /// scatter_penalty 1.0 decides purely on row counts (m ≤ n → pre-filter).
+    #[test]
+    fn penalty_one_decides_on_row_counts() {
+        let m = CostModel {
+            scatter_penalty: 1.0,
+        };
+        assert_eq!(m.decide(99, 100, 5).strategy, Strategy::PreFilter);
+        assert_eq!(m.decide(100, 100, 5).strategy, Strategy::PreFilter);
+        // m can't exceed n in practice, but the comparison is still well-defined.
+    }
+
+    /// CORRECTNESS: pre-filter and post-filter return BYTE-IDENTICAL (id, score) lists for a
+    /// selective mask, a broad mask, and k larger than the mask. This is the load-bearing invariant.
+    #[test]
+    fn prefilter_and_postfilter_identical() {
+        let store = ring_store("identical", 64);
+        let query = [1.0f32, 0.0];
+        // A few masks of different selectivity, including ones smaller than k.
+        for ids in [
+            vec![1u32, 5, 9, 13, 33],           // selective, scattered
+            (1u32..=64).step_by(2).collect(),   // ~half
+            (1u32..=64).collect(),              // full
+            vec![2u32, 4],                      // smaller than k=5
+        ] {
+            let mask: IdMask = ids.into_iter().collect();
+            for k in [1usize, 3, 5, 10] {
+                let pre = nearest_exact_filtered(&store, &query, &mask, k);
+                let post = postfilter_exact(&store, &query, &mask, k);
+                assert_eq!(
+                    pre, post,
+                    "pre/post-filter must be identical (mask_len={}, k={k})",
+                    mask.len()
+                );
+            }
+        }
+    }
+
+    /// The costed entry point returns the same hits regardless of which branch the model picks —
+    /// force each branch via the penalty and check the hits match the direct pre-filter.
+    #[test]
+    fn costed_entry_point_branch_agnostic_result() {
+        let store = ring_store("costed", 64);
+        let query = [0.0f32, 1.0];
+        let mask: IdMask = (1u32..=64).step_by(3).collect();
+        let k = 4;
+
+        // Force pre-filter (penalty 1.0, m ≤ n).
+        let always_pre = CostModel {
+            scatter_penalty: 1.0,
+        };
+        let (pre_hits, pre_est) = nearest_filtered_costed(&store, &query, &mask, k, &always_pre);
+        assert_eq!(pre_est.strategy, Strategy::PreFilter);
+
+        // Force post-filter (huge penalty makes any non-empty mask "broad").
+        let always_post = CostModel {
+            scatter_penalty: 1e6,
+        };
+        let (post_hits, post_est) = nearest_filtered_costed(&store, &query, &mask, k, &always_post);
+        assert_eq!(post_est.strategy, Strategy::PostFilter);
+
+        assert_eq!(
+            pre_hits, post_hits,
+            "the model's branch choice must never change the answer"
+        );
+        // And both equal the ground-truth pre-filter.
+        assert_eq!(pre_hits, nearest_exact_filtered(&store, &query, &mask, k));
+    }
+
+    /// Degenerate cases match nearest_exact_filtered's contract.
+    #[test]
+    fn postfilter_degenerate_cases() {
+        let store = ring_store("degenerate", 16);
+        let mask: IdMask = (1u32..=16).collect();
+        // empty mask
+        assert!(postfilter_exact(&store, &[1.0, 0.0], &IdMask::new(), 5).is_empty());
+        // zero query
+        assert!(postfilter_exact(&store, &[0.0, 0.0], &mask, 5).is_empty());
+        // k = 0
+        assert!(postfilter_exact(&store, &[1.0, 0.0], &mask, 0).is_empty());
+    }
+
+    /// overfetch_target: ceil(k / selectivity), clamped. (Backend-agnostic arithmetic check.)
+    #[test]
+    fn overfetch_target_arithmetic() {
+        // 10% selective, k=5 → fetch ~50.
+        assert_eq!(overfetch_target(5, 100, 1000), 50);
+        // full mask → fetch exactly k.
+        assert_eq!(overfetch_target(5, 1000, 1000), 5);
+        // never below k, never above store.
+        assert_eq!(overfetch_target(5, 1, 10), 10); // 5/(1/10)=50, clamped to store_len 10
+        assert_eq!(overfetch_target(5, 0, 1000), 5); // empty mask guard
+    }
+
+    /// Sanity: the post-filter never returns an id outside the mask, and respects best-first order.
+    #[test]
+    fn postfilter_respects_mask_and_order() {
+        let store = ring_store("respect", 32);
+        let query = [1.0f32, 0.0];
+        let mask: IdMask = vec![3u32, 7, 11, 19].into_iter().collect();
+        let hits = postfilter_exact(&store, &query, &mask, 10);
+        for &(id, _) in &hits {
+            assert!(mask.contains(id), "post-filter returned an unmasked id {id}");
+        }
+        // Scores are non-increasing (best-first).
+        for w in hits.windows(2) {
+            assert!(w[0].1 >= w[1].1, "post-filter not best-first: {hits:?}");
+        }
+        // Identical to ground truth, including the recompute path.
+        assert_eq!(hits, nearest_exact_filtered(&store, &query, &mask, 10));
+    }
+}

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -3,6 +3,9 @@
 #![warn(clippy::undocumented_unsafe_blocks)]
 
 pub mod ann;
+// [OPUS-4.8] (sq-7hx6) Filtered-ANN pre-filter vs post-filter cost model — `filtered-ann` only.
+#[cfg(feature = "filtered-ann")]
+pub mod cost;
 pub mod diskann;
 pub mod embed;
 #[cfg(feature = "filtered-ann")]
@@ -40,6 +43,11 @@ pub use embed::{Embedder, HashEmbedder};
 // [OPUS-4.8] (sq-1wc1) Predicate-constrained (filtered) ANN — the `filtered-ann` feature only.
 #[cfg(feature = "filtered-ann")]
 pub use filter::{nearest_exact_filtered, FilterConfig, IdMask};
+// [OPUS-4.8] (sq-7hx6) Pre-filter vs post-filter cost model — the `filtered-ann` feature only.
+#[cfg(feature = "filtered-ann")]
+pub use cost::{
+    nearest_filtered_costed, overfetch_target, postfilter_exact, CostEstimate, CostModel, Strategy,
+};
 pub use fingerprint::{check_against, Artifact, CheckResult, Fingerprint, FINGERPRINT_LEN};
 pub use fuse::{fuse_rrf, fuse_rrf_weighted, fuse_scores, hybrid_search, Retriever, RRF_K};
 pub use import::{ImportBinding, ImportSpec, MAX_NPY_HEADER_LEN};

--- a/crates/sparq-vectors/src/rewrite.rs
+++ b/crates/sparq-vectors/src/rewrite.rs
@@ -95,11 +95,14 @@ use sparq_engine::{PreparedQuery, QueryBudget, QueryResult};
 // patterns carve out the eligible graph nodes (the candidate id-set), and the k-NN
 // search is restricted to that set — correct (and, for a selective constraint, faster)
 // than post-filtering the unfiltered neighbours. This needs the `filtered-ann` API
-// (`IdMask` + `nearest_exact_filtered`), so the whole derive-and-filter path is
-// additionally gated on `filtered-ann`; with that feature off the `vec:` predicate
-// behaves EXACTLY as before (plain unfiltered `nearest_exact`).
+// (`IdMask` + the cost-model `nearest_filtered_costed`, sq-7hx6, which picks pre-filter
+// vs post-filter by selectivity — identical answer either way), so the whole
+// derive-and-filter path is additionally gated on `filtered-ann`; with that feature off
+// the `vec:` predicate behaves EXACTLY as before (plain unfiltered `nearest_exact`).
 #[cfg(feature = "filtered-ann")]
-use crate::filter::{nearest_exact_filtered, IdMask};
+use crate::cost::{nearest_filtered_costed, CostModel};
+#[cfg(feature = "filtered-ann")]
+use crate::filter::IdMask;
 // [OPUS-4.8] (sq-36ol, epic sq-3183) The derived-mask cache: a `vec:` predicate that shares its
 // neighbour variable with constraining patterns re-evaluates that sub-BGP (a full SELECT through
 // the engine) on EVERY prepare to build the `IdMask`. Against an unchanged graph the answer is
@@ -548,7 +551,13 @@ fn run_knn(
                 // Filtered: search only BGP-admitted candidates. Over-fetch by one so
                 // dropping the seed (if it satisfies the constraint and so sits in the
                 // mask) still leaves up to k neighbours, matching the unfiltered form.
-                return Ok(nearest_exact_filtered(store, query, mask, req.k + 1)
+                // [OPUS-4.8] (sq-7hx6) The cost model picks pre-filter (scan the mask) vs
+                // post-filter (scan the whole store + drop non-members) by the mask's
+                // selectivity; BOTH branches return the identical top-(k+1), so the seed
+                // drop and the final answer are unchanged either way.
+                let (hits, _est) =
+                    nearest_filtered_costed(store, query, mask, req.k + 1, &CostModel::default());
+                return Ok(hits
                     .into_iter()
                     .filter(|&(n, _)| n != id)
                     .take(req.k)
@@ -571,7 +580,11 @@ fn run_knn(
             }
             #[cfg(feature = "filtered-ann")]
             if let Some(mask) = &mask {
-                return Ok(nearest_exact_filtered(store, v, mask, req.k));
+                // [OPUS-4.8] (sq-7hx6) Cost-model choice of pre-filter vs post-filter;
+                // identical answer either way.
+                let (hits, _est) =
+                    nearest_filtered_costed(store, v, mask, req.k, &CostModel::default());
+                return Ok(hits);
             }
             Ok(nearest_exact(store, v, req.k))
         }

--- a/crates/sparq-vectors/tests/cost_model.rs
+++ b/crates/sparq-vectors/tests/cost_model.rs
@@ -1,0 +1,220 @@
+//! [OPUS-4.8] (sq-7hx6, epic sq-3183) Tests for the filtered-ANN **pre-filter vs post-filter cost
+//! model** — the public `CostModel` / `nearest_filtered_costed` / `postfilter_exact` seam.
+//!
+//! What is proven here:
+//! - the heuristic picks **pre-filter for a selective mask** and **post-filter for a broad mask**
+//!   (assert the *decision*, via [`CostModel::decide`] and the [`Strategy`] in the estimate);
+//! - whichever branch is chosen, the result is **byte-identical** (the load-bearing correctness
+//!   invariant) — `nearest_exact_filtered`, `postfilter_exact`, and the costed entry point all agree;
+//! - the model wired into the `vec:` rewrite leaves the end-to-end answer unchanged (the same query
+//!   answer whether the mask is selective or broad), proven through the public `query_vec` seam.
+//!
+//! Gated on `filtered-ann` (the cost model). The end-to-end section additionally needs
+//! `vec-predicate` (the rewrite) and is gated inline.
+#![cfg(feature = "filtered-ann")]
+
+use sparq_vectors::{
+    nearest_exact_filtered, nearest_filtered_costed, postfilter_exact, CostModel, IdMask, Strategy,
+    VectorStore,
+};
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("sparq_vec_costtest_{}_{name}.spqv", std::process::id()));
+    p
+}
+
+/// Points on the unit circle, dict ids 1..=n.
+fn ring(name: &str, n: usize) -> VectorStore {
+    let mut store = VectorStore::create(tmp(name), 2).unwrap();
+    for i in 0..n {
+        let theta = std::f32::consts::TAU * (i as f32) / (n as f32);
+        store
+            .put((i as u32) + 1, &[theta.cos(), theta.sin()])
+            .unwrap();
+    }
+    store.finalize().unwrap();
+    store
+}
+
+/// The HEURISTIC decision: a selective mask → pre-filter; a non-selective (broad) mask →
+/// post-filter. (Default scatter_penalty 2.0 ⇒ crossover at half the store.)
+#[test]
+fn heuristic_picks_prefilter_when_selective_postfilter_when_broad() {
+    let model = CostModel::default();
+    let n = 1000;
+
+    // Selective: 5% of the store → pre-filter.
+    let selective = model.decide(50, n, 10);
+    assert_eq!(
+        selective.strategy,
+        Strategy::PreFilter,
+        "a selective mask (5% of store) must pre-filter: {selective:?}"
+    );
+
+    // Broad: 80% of the store → post-filter (50·.. no — 800·2 = 1600 > 1000).
+    let broad = model.decide(800, n, 10);
+    assert_eq!(
+        broad.strategy,
+        Strategy::PostFilter,
+        "a broad mask (80% of store) must post-filter: {broad:?}"
+    );
+
+    // The estimate exposes WHY: prefilter_cost < postfilter_cost on the selective case, and the
+    // reverse on the broad one.
+    assert!(selective.prefilter_cost < selective.postfilter_cost);
+    assert!(broad.prefilter_cost > broad.postfilter_cost);
+}
+
+/// CORRECTNESS INVARIANT: the two strategies return byte-identical (id, score) lists across a range
+/// of selectivities and k, including k larger than the mask. Whichever the heuristic picks, the
+/// answer is the same.
+#[test]
+fn pre_and_post_filter_return_identical_results() {
+    let store = ring("identical", 128);
+    let query = [1.0f32, 0.0];
+
+    for ids in [
+        vec![1u32, 17, 33, 49, 65],        // selective, scattered
+        (1u32..=128).step_by(2).collect(), // half
+        (1u32..=128).collect(),            // full
+        vec![3u32, 9],                     // fewer than k
+    ] {
+        let mask: IdMask = ids.into_iter().collect();
+        for k in [1usize, 4, 8, 20] {
+            let pre = nearest_exact_filtered(&store, &query, &mask, k);
+            let post = postfilter_exact(&store, &query, &mask, k);
+            assert_eq!(
+                pre, post,
+                "pre/post-filter must be identical (mask_len={}, k={k})",
+                mask.len()
+            );
+
+            // The costed entry point agrees regardless of which branch the model would pick:
+            // force each branch and confirm the hits match the ground-truth pre-filter.
+            let force_pre = CostModel {
+                scatter_penalty: 1.0,
+            };
+            let force_post = CostModel {
+                scatter_penalty: 1e9,
+            };
+            let (h_pre, e_pre) = nearest_filtered_costed(&store, &query, &mask, k, &force_pre);
+            let (h_post, e_post) = nearest_filtered_costed(&store, &query, &mask, k, &force_post);
+            // (A full mask under penalty 1.0 sits exactly at the boundary → still pre-filter.)
+            assert_eq!(e_pre.strategy, Strategy::PreFilter);
+            assert_eq!(e_post.strategy, Strategy::PostFilter);
+            assert_eq!(h_pre, pre, "forced pre-filter must match ground truth");
+            assert_eq!(h_post, pre, "forced post-filter must match ground truth");
+        }
+    }
+}
+
+/// End-to-end through the public `vec:` seam: the rewrite uses the cost model internally, so the
+/// query answer must be the SAME whether the mask is selective or broad — i.e. the cost model is
+/// answer-transparent. We compare a constrained `vec:` query against the post-filter computed by
+/// hand from the unfiltered result.
+#[cfg(feature = "vec-predicate")]
+mod end_to_end {
+    use super::*;
+    use oxrdf::{NamedNode, Term};
+    use sparq_core::Graph;
+    use sparq_vectors::{query_vec, QueryResult};
+
+    const PFX: &str = "PREFIX vec: <http://sparq.dev/vec#> ";
+
+    fn fixture(name: &str) -> (Graph, VectorStore) {
+        // 12 entities on a ring; even ids are :Car, odd ids are :Boat. A :Car constraint admits
+        // half the embedded entities — broad enough that the cost model would post-filter — while
+        // still exercising the answer-identity through the rewrite.
+        let mut ttl = String::new();
+        for i in 1..=12u32 {
+            let kind = if i % 2 == 0 { "Car" } else { "Boat" };
+            ttl.push_str(&format!(
+                "<http://ex/n{i}> <http://ex/kind> <http://ex/{kind}> .\n"
+            ));
+        }
+        let g = Graph::load_str(&ttl, "ntriples").unwrap();
+        let id = |s: &str| {
+            g.id_of(&Term::NamedNode(NamedNode::new(s).unwrap()))
+                .unwrap()
+        };
+        let mut store = VectorStore::create(tmp(name), 2).unwrap();
+        for i in 1..=12u32 {
+            let theta = std::f32::consts::TAU * (i as f32) / 12.0;
+            store
+                .put(id(&format!("http://ex/n{i}")), &[theta.cos(), theta.sin()])
+                .unwrap();
+        }
+        store.finalize().unwrap();
+        (g, store)
+    }
+
+    fn iris(r: &QueryResult, col: usize) -> Vec<String> {
+        r.rows
+            .iter()
+            .filter_map(|row| match &row[col] {
+                Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The constrained `vec:search` (which goes through the cost model) returns exactly the
+    /// post-filter of the unfiltered ranking by the same constraint — proving the model wired into
+    /// the rewrite is answer-transparent, whichever branch it takes.
+    #[test]
+    fn rewrite_answer_matches_manual_postfilter() {
+        let (g, store) = fixture("e2e");
+        let k = 3;
+
+        // Unfiltered best-first order over ALL 12.
+        let unfiltered = query_vec(
+            &g,
+            &format!("{PFX} SELECT ?node ?s WHERE {{ ( ?node ?s ) vec:search ( \"1,0\" 12 ) }} ORDER BY DESC(?s)"),
+            &store,
+        )
+        .unwrap();
+        let order = iris(&unfiltered, 0);
+
+        // The Car set.
+        let cars: std::collections::HashSet<String> = query_vec(
+            &g,
+            "SELECT ?node WHERE { ?node <http://ex/kind> <http://ex/Car> }",
+            &store,
+        )
+        .unwrap()
+        .rows
+        .iter()
+        .filter_map(|row| match &row[0] {
+            Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+            _ => None,
+        })
+        .collect();
+
+        let manual: Vec<String> = order
+            .iter()
+            .filter(|n| cars.contains(*n))
+            .take(k)
+            .cloned()
+            .collect();
+
+        // Constrained search — runs through the cost model in the rewrite.
+        let filtered = query_vec(
+            &g,
+            &format!(
+                "{PFX} SELECT ?node ?s WHERE {{
+                   ( ?node ?s ) vec:search ( \"1,0\" {k} ) .
+                   ?node <http://ex/kind> <http://ex/Car> .
+                 }} ORDER BY DESC(?s)"
+            ),
+            &store,
+        )
+        .unwrap();
+
+        assert_eq!(
+            iris(&filtered, 0),
+            manual,
+            "the cost-model-routed rewrite answer must equal the manual post-filter"
+        );
+    }
+}

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -124,6 +124,16 @@ impl DiskAnnIndex { fn nearest_filtered(&self, &[f32], &IdMask, &VectorStore, k)
 impl VectorIndex  { fn nearest_filtered(&self, &[f32], &IdMask, &VectorStore, k) -> Vec<(Id, f32)> }   // HNSW: exact pre-filter only (instant-distance adjacency not exposed)
 // empty mask -> no results; full mask -> equals the unfiltered search; every returned id is guaranteed in the mask
 
+// --- pre-filter vs post-filter cost model (src/cost.rs) --- feature = "filtered-ann" ONLY [OPUS-4.8] sq-7hx6 (subsumes sq-ic0n)
+CostModel { scatter_penalty: f32 /*2.0*/ }                                       // scattered masked-row cost vs sequential full-scan row; >= 1.0
+impl CostModel { fn decide(mask_len, store_len, k) -> CostEstimate }             // pre-filter iff mask_len * scatter_penalty <= store_len
+Strategy::{PreFilter, PostFilter}                                                // the chosen branch (assert the decision)
+CostEstimate { mask_len, store_len, k, prefilter_cost, postfilter_cost, strategy }   // the modelled estimate behind a decision
+postfilter_exact(&VectorStore, query: &[f32], &IdMask, k) -> Vec<(Id, f32)>      // scan WHOLE store, drop non-masked -> IDENTICAL to nearest_exact_filtered (no over-fetch boundary: full ranking)
+nearest_filtered_costed(&VectorStore, &[f32], &IdMask, k, &CostModel) -> (Vec<(Id, f32)>, CostEstimate)   // decide + run chosen branch
+overfetch_target(k, mask_len, store_len) -> usize                               // ceil(k/selectivity) clamped; ONLY for a future APPROX backend (exact backend never under-fills)
+// HEURISTIC over an ESTIMATE, not optimal: scatter_penalty is one modelled constant; pre/post return the IDENTICAL top-k either way (answer-safe)
+
 // --- quantization for large stores (src/quant.rs) ---
 ScalarQuantizer::fit(dim, vectors: impl IntoIterator<Item=&[f32]>) -> Result<ScalarQuantizer, String>   // f32->u8, 4x
 ProductQuantizer::fit(dim, vectors, PqConfig{m, k, iters, seed}) -> Result<ProductQuantizer, String>    // M bytes/vec, 8-32x
@@ -416,8 +426,17 @@ predicate is always unfiltered — this composition adds nothing to the `vec-pre
 :ownedBy ?node`, or a longer cycle among intermediates) are handled correctly (sq-p5oy): the
 connected-component computation is a per-pattern fixpoint so it always **terminates** on a cycle,
 and the cyclic sub-BGP is evaluated through the standard engine, so the mask is exactly the engine's
-(cycle-correct) binding — `filtered == post-filter` holds for cyclic constraints too. Deferred (own
-beads): a cost-model choice of when transitive masking pays (sq-ic0n).
+(cycle-correct) binding — `filtered == post-filter` holds for cyclic constraints too.
+
+**Pre-filter vs post-filter — the cost model (sq-7hx6, subsumes sq-ic0n).** Once the mask is derived,
+the rewrite still has a *choice*: **pre-filter** (scan only the masked ids, `nearest_exact_filtered`)
+or **post-filter** (scan the whole store unfiltered, then drop the disallowed hits, `postfilter_exact`).
+Both return the **byte-identical** top-k (same ids, same order — see recipe 10), so the choice is purely
+about throughput. The rewrite picks per query via `CostModel` (recipe 10): pre-filter when the mask is
+selective (`mask_len · scatter_penalty ≤ store_len`, default crossover ≈ half the store), post-filter
+when it is broad. This is a HEURISTIC over a cost ESTIMATE, not an optimum — it never affects the answer,
+only the work. (Deriving the mask itself is unconditional: we must, to stay answer-safe; the cost model
+only decides how to *use* it.)
 
 ### 9. Predicate-constrained (filtered) ANN — only neighbours a BGP admits (opt-in, feature = `filtered-ann`)
 
@@ -463,6 +482,51 @@ zero engine coupling. The engine-side **automatic** BGP → mask wiring — deri
 the surrounding BGP and running a filtered `vec:` search — is wired in recipe 8 (sq-bvmd, when both
 `vec-predicate` and `filtered-ann` are on), and is built on exactly this `nearest_exact_filtered`
 seam.
+
+### 10. Pre-filter vs post-filter — the cost model (opt-in, feature = `filtered-ann`)
+
+Deriving a mask is one cost; *using* it is another. With a mask in hand there are two ways to the
+**same** top-k: **pre-filter** (scan only the masked ids) or **post-filter** (scan the whole store
+unfiltered, then drop the disallowed hits). `CostModel` estimates both and picks the cheaper per
+query. The `vec:` rewrite (recipe 8) calls this automatically; you can also drive it directly.
+
+```rust
+use sparq_vectors::{nearest_filtered_costed, postfilter_exact, CostModel, Strategy};
+
+// Decision only (no search): pre-filter iff mask_len * scatter_penalty <= store_len.
+let est = CostModel::default().decide(/*mask_len*/ 50, /*store_len*/ 1000, /*k*/ 10);
+assert_eq!(est.strategy, Strategy::PreFilter);   // 50*2 = 100 <= 1000 → selective → pre-filter
+//   est.prefilter_cost / est.postfilter_cost expose WHY.
+
+// Decide + run the chosen branch in one call; the second tuple element is the estimate.
+let (hits, est) = nearest_filtered_costed(&store, query, &mask, 10, &CostModel::default());
+
+// Post-filter directly (the broad-mask branch). IDENTICAL result to nearest_exact_filtered:
+let post = postfilter_exact(&store, query, &mask, 10);
+assert_eq!(post, sparq_vectors::nearest_exact_filtered(&store, query, &mask, 10));
+```
+
+**The model.** `m = |mask|`, `n = store_len`. Pre-filter touches `m` *scattered* rows (random-access
+gather into the mmap), post-filter streams `n` rows sequentially; a scattered row is modelled as
+`scatter_penalty ×` (default `2.0`) a sequential one. **Pre-filter iff `m · scatter_penalty ≤ n`** —
+default crossover ≈ half the store. `k`/`dim` cancel out of the exact-scan comparison (both branches
+do `dim`-width work per touched row, then take `k`), so they do not enter the crossover; they are
+surfaced in `CostEstimate` for a future approximate backend.
+
+**Why it is answer-safe.** `nearest_exact` returns a *complete* ranking of the store, so post-filtering
+it and pre-filtering the mask reduce to ranking the same admitted ids by the same comparator — the
+top-k is **byte-identical** (asserted in `tests/cost_model.rs`). There is **no over-fetch recall
+boundary** for this exact backend: a full ranking can only under-fill `k` when the mask admits fewer
+than `k` stored vectors, and then the pre-filter scan is equally short. (`overfetch_target(k, m, n) =
+ceil(k/selectivity)` exists for a *future approximate* backend, whose bounded candidate list CAN
+under-fill — the honest handling there is iterative over-fetch until `k` survive; that approximate
+filtered `vec:` path is a deferred follow-up.)
+
+**Honest scope.** This is a **HEURISTIC over a cost estimate, not an optimum**: `scatter_penalty` is a
+single modelled constant (non-canonical, not a measured fit), real cache/SIMD behaviour is
+hardware-dependent, and a planner that has *not* yet evaluated the sub-BGP would feed an *estimated*
+cardinality (here the mask is materialised, so `m` is exact). A mis-estimate costs only throughput —
+never the answer.
 
 ## Gotchas / feature flags / prerequisites
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-7hx6** — filtered-ANN pre-filter vs post-filter cost model. **Subsumes sq-ic0n** ("when transitive masking pays"): this bead IS that cost model.

## What

Once the `vec:` rewrite derives a transitive `IdMask` for a constrained neighbour variable, it now chooses **per query** between two answer-equivalent ways to use it:

- **Pre-filter** (`nearest_exact_filtered`) — scan only the masked ids. Work ≈ `|mask|·dim`.
- **Post-filter** (`postfilter_exact`, new) — scan the whole store unfiltered (a complete cosine ranking), then drop the disallowed hits. Work ≈ `store_len·dim`.

`CostModel::decide` picks: **pre-filter iff `mask_len · scatter_penalty ≤ store_len`** (default `scatter_penalty = 2.0` ⇒ crossover ≈ half the store). `k`/`dim` cancel out of the exact-scan crossover; they are surfaced in `CostEstimate` for a future approximate backend.

## Correctness invariant (load-bearing)

Both branches return the **byte-identical** top-k (same ids, same order — cosine ties break on ascending id in both). `postfilter_exact` post-filters a *complete* `nearest_exact` ranking, so there is **no over-fetch recall boundary** for the exact backend: it can only under-fill `k` when the mask admits fewer than `k` stored vectors, where the pre-filter scan is equally short and the two agree. `overfetch_target` + iterative over-fetch are documented (not wired) for a future **approximate** backend whose bounded candidate list *can* under-fill.

Honest: a **HEURISTIC over a cost estimate, not an optimum** — `scatter_penalty` is one modelled constant; a mis-estimate costs throughput, never the answer.

## Tests (`tests/cost_model.rs` + in-lib `cost::tests`)

- The heuristic picks **pre-filter for a selective** mask and **post-filter for a broad** one (asserts the `Strategy` decision).
- Pre/post return **identical** `(id, score)` lists across selectivities and `k` (incl. `k > |mask|`).
- The costed entry point is **branch-agnostic** (force each branch, hits match ground truth).
- End-to-end through `query_vec`: the rewrite answer equals the manual post-filter of the unfiltered ranking.

## Gates (all green)

`cargo build` / `clippy --all-targets -D warnings` / `cargo test` (+ doctests) for `sparq-vectors` in **all three feature states**: feature-off, `filtered-ann`-only, and `vec-predicate`+`filtered-ann`. No regressions on the existing transitive/cyclic filtered-BGP suites.

Opt-in: cost model gated on `filtered-ann`; core stays lean.

## Deferred (orchestrator to bead)

Approximate filtered `vec:` backend (HNSW/DiskANN) with **iterative over-fetch** — the bounded-candidate path where `overfetch_target` and the recall boundary actually bite. `bd` was not on PATH in this worktree.
