### PR TITLE
bench(qlever): same-box indexed-server gather recipe (sq-52fo)

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -218,6 +218,30 @@ Notes on a few that need care:
   HONESTY NOTE (per parent `sq-i0nm`): a gh-runner gather is noisy and not
   comparable to the EC2/quiet-box reference band — the recorded `env.quiet_box`
   flag lets the dashboard label it distinctly (see the QUIET-BOX convention above).
+- **Same-box SPARQL gather — the QLever indexed-server step** (sq-52fo). The
+  same-box competitor gather [`scripts/gather-ec2-sparql.sh`](../scripts/gather-ec2-sparql.sh)
+  compares sparq vs Oxigraph on ONE generated SP2Bench corpus (always on). QLever is
+  **opt-in** behind `GATHER_QLEVER=1` because — unlike Oxigraph/EYE — it is NOT a
+  file-in/answer-out CLI: it needs a dedicated **index build → running server → HTTP
+  query → teardown** dance. That dance lives in [`scripts/qlever-same-box.sh`](../scripts/qlever-same-box.sh),
+  which the gather invokes on the bench box. Recipe (all via the
+  `docker.io/adfreiburg/qlever:latest` image):
+  1. **index** — `IndexBuilderMain -i <base> -F ttl|nt -s <settings> < corpus` into a
+     `mktemp -d` index dir (df-guarded, hard `QLEVER_INDEX_TIMEOUT`, default 20 min);
+  2. **server** — `ServerMain -i <base> -p <port> -j <jobs>` detached with a fixed
+     `--name`, then a **bounded** readiness poll (a counted for-loop, default 2 min,
+     aborts early if the container exits) — this is the fix for the prior ~53-min hang;
+  3. **query** — one bounded HTTP POST per (query, iter), min-of-K wall micros, emitting
+     the harness's `<name>\t<rows>\t<best_us>` TSV (`ERROR` rows stay honest-n/a);
+  4. **teardown** — an **EXIT trap that always runs** (`docker rm -f` the container +
+     `rm -rf` the index dir) on success, failure, timeout, or Ctrl-C — no orphan server,
+     no leaked disk. The gather also wraps the whole recipe in an outer `timeout 1800`.
+  Run it: `GATHER_QLEVER=1 AWS_PROFILE=pss scripts/gather-ec2-sparql.sh <branch>`.
+  With `GATHER_QLEVER=0` (the default) the QLever block is a complete no-op and the
+  Oxigraph-only path is byte-for-byte unchanged. The recipe is **bench-only and
+  documented-untested in the authoring worktree** (no Docker there) — validate on the
+  next `GATHER_QLEVER=1` gather. (The separate `bench/qlever-*` suites use the upstream
+  `qlever` Python CLI instead; this same-box recipe is the standalone Docker variant.)
 
 ## Replicate everything — quickstart
 

--- a/scripts/gather-ec2-sparql.sh
+++ b/scripts/gather-ec2-sparql.sh
@@ -12,10 +12,13 @@
 #   Both engines load the SAME generated SP2Bench corpus and run the SAME query files, so
 #   the two TSVs (<name>\t<rows>\t<best_us>) are a self-consistent same-box comparison.
 #   Solution counts are cross-checked against bench/sp2b/expected-rows.tsv (correctness).
-#   3. qlever   : BEST-EFFORT (GATHER_QLEVER=1). Builds a QLever index over the same corpus
-#                 in Docker, starts the server, runs the same queries via the http-sparql
-#                 adapter. If Docker/index/server is too heavy/flaky in the bounded window,
-#                 it is SKIPPED and stays honest-n/a (the recipe is beaded separately).
+#   3. qlever   : BEST-EFFORT (GATHER_QLEVER=1). Delegates to scripts/qlever-same-box.sh
+#                 (sq-52fo): builds a QLever index over the same corpus in Docker
+#                 (IndexBuilderMain), starts ServerMain on a port, polls readiness, runs the
+#                 same queries over HTTP, then ALWAYS tears the server + temp index down via
+#                 an EXIT trap. EVERY step is timeout-bounded (pull/index/ready/query) so it
+#                 can never hang the gather (the prior ~53min stall). If Docker/index/server
+#                 is too heavy/flaky in the bounded window it is SKIPPED and stays honest-n/a.
 #
 # Corpus scale is BOUNDED + documented: SP2Bench is the cheapest deterministic featured
 # corpus (real Freiburg sp2b_gen, g++ -O2, sha256-pinned, byte-identical output; ~250k
@@ -152,65 +155,27 @@ NPROC=\$(nproc)
 KERNEL=\$(uname -r)
 NOW=\$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-# qlever best-effort
+# qlever best-effort  [OPUS-4.8] sq-52fo
+# Delegates the heavy index->server->query->teardown dance to the dedicated, BOUNDED,
+# orphan-safe recipe scripts/qlever-same-box.sh (every step timeout-capped, an EXIT trap
+# always tears down the server container + temp index — fixes the prior ~53min hang / leaked
+# server). This block stays a no-op unless GATHER_QLEVER=1 AND docker is present, so the
+# Oxigraph-only path is byte-for-byte unchanged.
 QLEVER_STATUS="skipped"
 QLEVER_TSV=""
 if [ "$GATHER_QLEVER" = "1" ] && command -v docker >/dev/null 2>&1; then
-  echo "=== qlever best-effort ==="
-  QDIR=/root/qlever; mkdir -p "\$QDIR"
-  # sp2b_gen emits Turtle; QLever indexes N-Triples/Turtle. Build an index then start server.
-  cp "\$CORPUS" "\$QDIR/sp2b.ttl"
-  ( cd "\$QDIR"
-    docker pull -q docker.io/adfreiburg/qlever:latest || true
-    # IndexBuilder over the Turtle corpus
-    timeout 1200 docker run --rm -v "\$QDIR":/data -w /data docker.io/adfreiburg/qlever:latest \
-      bash -lc "IndexBuilderMain -i /data/sp2b -f /data/sp2b.ttl -F ttl 2>&1 | tail -20" \
-      && echo "QLEVER_INDEX_OK" || echo "QLEVER_INDEX_FAIL"
-    docker run -d --name qlever-srv -p 7001:7001 -v "\$QDIR":/data -w /data docker.io/adfreiburg/qlever:latest \
-      ServerMain -i /data/sp2b -p 7001 -j 4 || echo "QLEVER_SERVER_FAIL"
-  ) || true
-  # poll the endpoint
-  for _ in \$(seq 1 30); do
-    curl -s "http://localhost:7001/?query=SELECT%20*%20WHERE%7B%3Fs%20%3Fp%20%3Fo%7D%20LIMIT%201" >/dev/null 2>&1 && break
-    sleep 3
-  done
-  python3 -m venv /root/qenv && /root/qenv/bin/pip install -q requests
-  : > /tmp/qlever.tsv
-  for q in bench/sp2b/queries/*.rq; do
-    name=\$(basename "\$q" .rq)
-    /root/qenv/bin/python3 - "\$q" "\$name" <<'PYQ' >> /tmp/qlever.tsv 2>/tmp/qlever.err || true
-import sys, time, requests
-qf, name = sys.argv[1], sys.argv[2]
-q = open(qf).read()
-best = None; rows = "ERROR"
-for _ in range($ITERS):
-    t = time.perf_counter()
-    try:
-        r = requests.post("http://localhost:7001", data={"query": q},
-                          headers={"Accept": "application/sparql-results+json"}, timeout=120)
-        j = r.json()
-        if "results" in j and "bindings" in j["results"]:
-            rows = len(j["results"]["bindings"])
-        elif "boolean" in j:
-            rows = 1 if j["boolean"] else 0
-        else:
-            rows = "ERROR"; break
-        us = (time.perf_counter() - t) * 1e6
-        best = us if best is None else min(best, us)
-    except Exception as e:
-        rows = "ERROR"; break
-if rows == "ERROR" or best is None:
-    print(f"{name}\tERROR\tqlever")
-else:
-    print(f"{name}\t{rows}\t{best:.1f}")
-PYQ
-  done
-  echo "=== qlever.tsv ==="; cat /tmp/qlever.tsv || true
-  if [ -s /tmp/qlever.tsv ] && grep -qv ERROR /tmp/qlever.tsv; then
+  echo "=== qlever best-effort (scripts/qlever-same-box.sh) ==="
+  # sp2b_gen emits Turtle, so format=ttl; the recipe also accepts nt for N-Triples corpora.
+  # The recipe is itself bounded + trap-cleaned, but we ALSO wrap it in an outer 'timeout'
+  # as a belt-and-braces ceiling so it can never extend the gather window indefinitely.
+  if QLEVER_PORT=7001 QLEVER_INDEX_TIMEOUT=1200 QLEVER_READY_TIMEOUT=120 QLEVER_QUERY_TIMEOUT=60 \
+       timeout 1800 bash scripts/qlever-same-box.sh "\$CORPUS" ttl bench/sp2b/queries "$ITERS" /tmp/qlever.tsv; then
     QLEVER_STATUS="ok"
     QLEVER_TSV=\$(python3 -c 'import json,sys; print(json.dumps(open("/tmp/qlever.tsv").read()))')
   else
+    echo "qlever recipe failed/timed out — keeping dashboard cell honest-n/a"
     QLEVER_STATUS="failed"
+    [ -s /tmp/qlever.tsv ] && QLEVER_TSV=\$(python3 -c 'import json,sys; print(json.dumps(open("/tmp/qlever.tsv").read()))')
   fi
 fi
 

--- a/scripts/qlever-same-box.sh
+++ b/scripts/qlever-same-box.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] sq-52fo — dedicated same-box QLever index->server->query->teardown recipe.
+# Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# WHY THIS SCRIPT EXISTS
+#   QLever is NOT a simple file-in/answer-out CLI like Oxigraph or EYE. To benchmark a
+#   QLever query you must (1) build an on-disk INDEX over the dataset with IndexBuilderMain,
+#   then (2) start a long-lived ServerMain HTTP server on a port, then (3) query it over
+#   HTTP, then (4) STOP the server and delete the index. The old same-box gather inlined a
+#   fragile version of this in gather-ec2-sparql.sh's user-data heredoc with NO server
+#   teardown and weak bounds, so a failed/slow index build or a server that never became
+#   ready left the gather hanging (~53 min observed) and could leak a running container.
+#
+#   This script is the SELF-CONTAINED, BOUNDED, ORPHAN-SAFE recipe. Every external process
+#   it starts (the QLever server container) and every byte of scratch it writes (the temp
+#   index dir) is removed by an EXIT trap — on success, on failure, on timeout, on SIGINT.
+#   Every wait is hard-bounded; there is no unbounded poll anywhere.
+#
+# USAGE
+#   scripts/qlever-same-box.sh <corpus-file> <format> <queries-dir> <iters> <out-tsv>
+#     <corpus-file>  path to the dataset (Turtle .ttl or N-Triples .nt)
+#     <format>       ttl | nt   (QLever -F file-format for IndexBuilderMain)
+#     <queries-dir>  dir of *.rq SPARQL queries (e.g. bench/sp2b/queries)
+#     <iters>        min-of-K per query
+#     <out-tsv>      where to write the result TSV (<name>\t<rows>\t<best_us>)
+#
+#   Exit status: 0 if the index built, the server became ready, and at least one query
+#   produced a non-ERROR row; non-zero otherwise. The caller treats a non-zero exit as
+#   "qlever skipped/failed" and keeps the dashboard cell honest-n/a — it NEVER hangs the
+#   gather, because every step here is timeout-bounded.
+#
+# TUNABLES (env; all have safe defaults):
+#   QLEVER_IMAGE        Docker image                 (default docker.io/adfreiburg/qlever:latest)
+#   QLEVER_PORT         server port                  (default 7001)
+#   QLEVER_INDEX_TIMEOUT  index-build hard cap, s    (default 1200 = 20 min)
+#   QLEVER_PULL_TIMEOUT   image-pull hard cap, s     (default 600  = 10 min)
+#   QLEVER_READY_TIMEOUT  server-readiness cap, s    (default 120  = 2 min)
+#   QLEVER_QUERY_TIMEOUT  per-HTTP-query cap, s      (default 60)
+#   QLEVER_JOBS         ServerMain worker threads    (default 4)
+#   QLEVER_MIN_FREE_GB  abort index if free disk <   (default 10)
+#   QLEVER_NAME         container name               (default qlever-srv-$$)
+#
+# OUTPUT TSV FORMAT (matches the harness's <name>\t<rows>\t<best_us>):
+#   q01<TAB>123<TAB>4567.8        — rows + best wall micros over <iters> runs
+#   q07<TAB>ERROR<TAB>qlever      — query failed (server error / timeout)
+# The caller (gather-ec2-sparql.sh) JSON-encodes this file into the same-box envelope's
+# "qlever_tsv" field and sets qlever_status from this script's exit code.
+#
+# ORPHAN-SAFETY / BOUNDEDNESS GUARANTEES (the bug this fixes):
+#   * trap-cleanup ALWAYS runs (EXIT) and: docker rm -f the server container (idempotent,
+#     never errors if absent) + rm -rf the temp index dir. No orphan server, no leaked disk.
+#   * docker pull / IndexBuilderMain / each HTTP query all run under `timeout` — no step can
+#     block forever. The readiness poll is a bounded for-loop, not `while :`.
+#   * df guard before the (disk-heavy) index build; refuses to start if free space is low.
+set -euo pipefail
+
+CORPUS="${1:?usage: qlever-same-box.sh <corpus> <ttl|nt> <queries-dir> <iters> <out-tsv>}"
+FORMAT="${2:?missing format (ttl|nt)}"
+QUERIES_DIR="${3:?missing queries dir}"
+ITERS="${4:?missing iters}"
+OUT_TSV="${5:?missing out-tsv}"
+
+QLEVER_IMAGE="${QLEVER_IMAGE:-docker.io/adfreiburg/qlever:latest}"
+QLEVER_PORT="${QLEVER_PORT:-7001}"
+QLEVER_INDEX_TIMEOUT="${QLEVER_INDEX_TIMEOUT:-1200}"
+QLEVER_PULL_TIMEOUT="${QLEVER_PULL_TIMEOUT:-600}"
+QLEVER_READY_TIMEOUT="${QLEVER_READY_TIMEOUT:-120}"
+QLEVER_QUERY_TIMEOUT="${QLEVER_QUERY_TIMEOUT:-60}"
+QLEVER_JOBS="${QLEVER_JOBS:-4}"
+QLEVER_MIN_FREE_GB="${QLEVER_MIN_FREE_GB:-10}"
+QLEVER_NAME="${QLEVER_NAME:-qlever-srv-$$}"
+
+log()  { printf '[qlever] %s\n' "$*" >&2; }
+die()  { printf '[qlever] ERROR: %s\n' "$*" >&2; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+case "$FORMAT" in ttl|nt) ;; *) die "format must be 'ttl' or 'nt' (got '$FORMAT')" ;; esac
+case "$ITERS" in ''|*[!0-9]*) die "iters must be a positive integer (got '$ITERS')" ;; esac
+[ "$ITERS" -ge 1 ] || die "iters must be >= 1"
+[ -f "$CORPUS" ] || die "corpus file not found: $CORPUS"
+[ -d "$QUERIES_DIR" ] || die "queries dir not found: $QUERIES_DIR"
+have docker || die "docker not installed (required for the QLever image)"
+have python3 || die "python3 required (HTTP query client + TSV emit)"
+
+# ---- scratch index dir + ALWAYS-RUN teardown -------------------------------------------
+INDEX_DIR="$(mktemp -d "${TMPDIR:-/tmp}/qlever-idx.XXXXXX")"
+INDEX_BASE="$INDEX_DIR/idx"   # IndexBuilderMain -i base name (writes idx.* alongside)
+
+cleanup() {
+  set +e
+  # [OPUS-4.8] sq-52fo: tear the server container down UNCONDITIONALLY (rm -f is idempotent —
+  # exits 0 even if the container was never created or already gone), then drop the temp
+  # index. This is the fix for the leaked-server / leaked-disk bug: it fires on success,
+  # on `die`, on a `timeout` SIGTERM bubbling up, and on Ctrl-C.
+  docker rm -f "$QLEVER_NAME" >/dev/null 2>&1
+  rm -rf "$INDEX_DIR" >/dev/null 2>&1
+  log "teardown: removed container '$QLEVER_NAME' (if any) + index dir"
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM   # ensure the EXIT trap runs on signal
+
+# ---- df guard (index build is the disk-heavy step) -------------------------------------
+free_gb="$(df -BG --output=avail "$INDEX_DIR" 2>/dev/null | tail -1 | tr -dc '0-9' || true)"
+if [ -n "$free_gb" ]; then
+  log "disk: ${free_gb} GB free (floor ${QLEVER_MIN_FREE_GB} GB)"
+  [ "$free_gb" -ge "$QLEVER_MIN_FREE_GB" ] \
+    || die "free disk ${free_gb} GB < floor ${QLEVER_MIN_FREE_GB} GB — refusing QLever index build"
+else
+  log "could not read free disk space; skipping df guard"
+fi
+
+# ---- 0. pull the image (bounded) -------------------------------------------------------
+log "pulling $QLEVER_IMAGE (<= ${QLEVER_PULL_TIMEOUT}s)"
+timeout "$QLEVER_PULL_TIMEOUT" docker pull -q "$QLEVER_IMAGE" \
+  || log "pull failed/slow — continuing with any locally cached image"
+
+# Resolve a host path the container can bind-mount. Both the corpus and the index dir are
+# mounted read-only/read-write respectively under /data.
+CORPUS_DIR="$(cd "$(dirname "$CORPUS")" && pwd)"
+CORPUS_FILE="$(basename "$CORPUS")"
+
+# ---- 1. INDEX BUILD (bounded) ----------------------------------------------------------
+# QLever's IndexBuilderMain reads the dataset on stdin and is told the format with -F.
+#   -i <base>   index base name (writes <base>.* files)
+#   -F <fmt>    input format: ttl (Turtle) | nt (N-Triples) | nq | tsv
+#   -s <json>   settings (ascii-prefixes-only:false handles full Unicode IRIs)
+# We cat the corpus into the builder's stdin (the documented `IndexBuilderMain ... < file`
+# form), avoiding a brittle in-container path for the input file.
+log "building index (<= ${QLEVER_INDEX_TIMEOUT}s) from $CORPUS_FILE [$FORMAT]"
+SETTINGS='{ "ascii-prefixes-only": false, "num-triples-per-batch": 100000 }'
+if timeout "$QLEVER_INDEX_TIMEOUT" docker run --rm \
+      -v "$CORPUS_DIR":/in:ro -v "$INDEX_DIR":/data -w /data \
+      "$QLEVER_IMAGE" \
+      bash -lc "IndexBuilderMain -i /data/idx -F '$FORMAT' -s '$SETTINGS' < '/in/$CORPUS_FILE'" \
+      >&2; then
+  log "index build OK"
+else
+  rc=$?
+  [ "$rc" = 124 ] && die "index build hit the ${QLEVER_INDEX_TIMEOUT}s timeout — aborting (no hang)"
+  die "index build failed (rc=$rc)"
+fi
+[ -e "${INDEX_BASE}.meta" ] || [ -e "${INDEX_BASE}.vocabulary.internal" ] || ls "$INDEX_DIR" >&2 || true
+
+# ---- 2. START SERVER + bounded readiness poll ------------------------------------------
+# ServerMain serves the built index over HTTP:
+#   -i <base>   the index base built above
+#   -p <port>   listen port
+#   -j <n>      worker threads
+# Run detached (-d) with a fixed --name so teardown can target it; publish the port.
+log "starting ServerMain on :$QLEVER_PORT (container '$QLEVER_NAME')"
+docker rm -f "$QLEVER_NAME" >/dev/null 2>&1 || true   # belt-and-braces: no stale same-name
+docker run -d --name "$QLEVER_NAME" -p "${QLEVER_PORT}:${QLEVER_PORT}" \
+  -v "$INDEX_DIR":/data -w /data "$QLEVER_IMAGE" \
+  ServerMain -i /data/idx -p "$QLEVER_PORT" -j "$QLEVER_JOBS" >/dev/null \
+  || die "failed to start ServerMain container"
+
+# Bounded readiness poll — a FOR loop with a hard count, NOT `while :`. Probes a trivial
+# query; the server answers it once the index is mmapped and the HTTP listener is up.
+PROBE='SELECT * WHERE { ?s ?p ?o } LIMIT 1'
+ready=0
+poll_n=$(( QLEVER_READY_TIMEOUT / 2 ))
+[ "$poll_n" -ge 1 ] || poll_n=1
+for _ in $(seq 1 "$poll_n"); do
+  # If the container has already died, stop polling immediately (don't burn the budget).
+  if ! docker ps --filter "name=^${QLEVER_NAME}$" --filter status=running -q | grep -q .; then
+    log "server container exited during startup — dumping last logs:"
+    docker logs --tail 30 "$QLEVER_NAME" >&2 2>&1 || true
+    die "QLever server did not stay up"
+  fi
+  if curl -fsS --max-time 5 \
+      --data-urlencode "query=$PROBE" \
+      -H 'Accept: application/sparql-results+json' \
+      "http://localhost:${QLEVER_PORT}" >/dev/null 2>&1; then
+    ready=1; break
+  fi
+  sleep 2
+done
+[ "$ready" = 1 ] || die "server not ready within ${QLEVER_READY_TIMEOUT}s — aborting (no hang)"
+log "server ready"
+
+# ---- 3. RUN QUERIES over HTTP, emit TSV ------------------------------------------------
+# One bounded HTTP request per (query, iter); min wall micros over <iters>. The Python
+# client uses urllib (always present) with a per-request timeout, so a single slow query
+# cannot exceed QLEVER_QUERY_TIMEOUT and the whole loop is bounded by
+# (#queries * iters * QLEVER_QUERY_TIMEOUT) in the absolute worst case.
+: > "$OUT_TSV"
+shopt -s nullglob
+any_ok=0
+for q in "$QUERIES_DIR"/*.rq; do
+  name="$(basename "$q" .rq)"
+  row="$(QLEVER_PORT="$QLEVER_PORT" QLEVER_QUERY_TIMEOUT="$QLEVER_QUERY_TIMEOUT" ITERS="$ITERS" \
+    python3 - "$q" "$name" <<'PY'
+import os, sys, time, json, urllib.parse, urllib.request
+qf, name = sys.argv[1], sys.argv[2]
+port = os.environ["QLEVER_PORT"]
+to   = float(os.environ["QLEVER_QUERY_TIMEOUT"])
+iters = int(os.environ["ITERS"])
+endpoint = f"http://localhost:{port}"
+query = open(qf, encoding="utf-8").read()
+best = None
+rows = "ERROR"
+for _ in range(iters):
+    data = urllib.parse.urlencode({"query": query}).encode()
+    req = urllib.request.Request(
+        endpoint, data=data,
+        headers={"Accept": "application/sparql-results+json"})
+    t = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, timeout=to) as r:
+            obj = json.loads(r.read())
+    except Exception:
+        rows = "ERROR"; best = None; break
+    res = obj.get("results")
+    if isinstance(res, dict) and "bindings" in res:
+        rows = len(res["bindings"])
+    elif "boolean" in obj:
+        rows = 1 if obj["boolean"] else 0
+    else:
+        rows = "ERROR"; best = None; break
+    us = (time.perf_counter() - t) * 1e6
+    best = us if best is None else min(best, us)
+if rows == "ERROR" or best is None:
+    print(f"{name}\tERROR\tqlever")
+else:
+    print(f"{name}\t{rows}\t{best:.1f}")
+PY
+)"
+  printf '%s\n' "$row" >> "$OUT_TSV"
+  case "$row" in *$'\tERROR\t'*) ;; *) any_ok=1 ;; esac
+done
+shopt -u nullglob
+
+log "wrote $OUT_TSV:"
+cat "$OUT_TSV" >&2 || true
+
+# trap cleanup tears down the server + index on the way out (any exit path).
+[ "$any_ok" = 1 ] || die "no query produced a non-ERROR row"
+log "done (>=1 query succeeded)"


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-52fo** — the same-box SPARQL gather needs a dedicated QLever indexed-server step.

## Problem
QLever is not a file-in/answer-out CLI like Oxigraph/EYE. Benchmarking it requires an **index build** (`IndexBuilderMain`) and a **running server** (`ServerMain`) queried over HTTP. The same-box gather (`scripts/gather-ec2-sparql.sh`) inlined a fragile version with **no server teardown** and weak bounds, so a slow/failed index or a server that never became ready **hung the gather (~53 min observed)** and could leak a container.

## Fix — `scripts/qlever-same-box.sh` (new, self-contained, orphan-safe)
`<corpus> <ttl|nt> <queries-dir> <iters> <out-tsv>` →
1. **df guard** then bounded `docker pull`;
2. **index**: `IndexBuilderMain -i <base> -F <fmt> -s <settings> < corpus` into a `mktemp -d` index dir, hard `QLEVER_INDEX_TIMEOUT` (20 min);
3. **server**: `ServerMain -i <base> -p <port> -j <jobs>` detached with a fixed `--name`, then a **bounded readiness poll** (counted for-loop, 2 min, aborts early if the container exits) — the hang fix;
4. **query**: one bounded HTTP POST per (query, iter), min-of-K wall micros → harness `<name>\t<rows>\t<best_us>` TSV;
5. **teardown**: an **EXIT trap that always runs** (`docker rm -f` container + `rm -rf` index dir) on success/failure/timeout/Ctrl-C.

`gather-ec2-sparql.sh`'s `GATHER_QLEVER` block now delegates to it (wrapped in an outer `timeout 1800`).

## Guarantees
- **No hang**: pull/index/readiness/query are all `timeout`-bounded; the readiness poll is a counted for-loop, never `while :`.
- **No orphan**: EXIT trap idempotently tears down the server container + temp index on every exit path.
- **`GATHER_QLEVER=0` unchanged**: the whole block is gated behind `if [ "$GATHER_QLEVER" = "1" ] && command -v docker`, so the Oxigraph-only path is byte-for-byte unchanged.

## Testing
- `bash -n` clean on both scripts; `qlever-same-box.sh` is **shellcheck-clean** (the one SC2015 in `gather-ec2-sparql.sh` is pre-existing, not in this diff).
- Arg-validation + early-die paths exercised; trap-cleanup verified with a fake `docker` binary (temp index dir confirmed removed on mid-run failure).
- **Documented-untested for the real Docker path** (no Docker in the authoring worktree) — validate on the next `GATHER_QLEVER=1` gather.

Run: `GATHER_QLEVER=1 AWS_PROFILE=pss scripts/gather-ec2-sparql.sh <branch>`

[OPUS-4.8] authored by Opus 4.8 (Fable unavailable; flag for re-review).