### PR TITLE
ci: build+clippy+test the filtered-ann and shacl-af feature legs (sq-wuft)

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -136,6 +136,17 @@ jobs:
             crate: sparq-vectors
             features: vec-predicate,filtered-ann
             test: true
+          # [OPUS-4.8] sq-wuft: SHACL Advanced Features (SHACL-AF) rules — the `sh:rule`
+          # module (sparq-shacl/src/rules.rs + the gated arms of eval.rs/model.rs/lib.rs) is
+          # entirely `#[cfg(feature = "shacl-af")]`, so the default build/clippy/test never
+          # compiled it. This leg compiles it, runs `clippy --all-targets -D warnings` with the
+          # feature ON (the real gate), and runs the crate's tests — including the 11 in-module
+          # `rules.rs` unit tests, which only exist when `shacl-af` is enabled. No new dep: the
+          # rule engine reuses the same sparq-engine SPARQL machinery the `sh:sparql` path uses.
+          - name: sparq-shacl (shacl-af)
+            crate: sparq-shacl
+            features: shacl-af
+            test: true
           # sparq-geo: pure-Rust coordinate reprojection into CRS84.
           - name: sparq-geo (reproject)
             crate: sparq-geo


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-wuft**: ensure the opt-in, default-OFF feature-gated code is actually built + clippied + tested in CI.

## What this does
The `feature-matrix.yml` lane already gained the **filtered-ann** leg (`sparq-vectors --features vec-predicate,filtered-ann`) in a prior merge. This PR adds the still-missing **shacl-af** leg:

```yaml
- name: sparq-shacl (shacl-af)
  crate: sparq-shacl
  features: shacl-af
  test: true
```

The SHACL-AF `sh:rule` module (`sparq-shacl/src/rules.rs` + the `#[cfg(feature="shacl-af")]` arms of `eval.rs`/`model.rs`/`lib.rs`) is opt-in and OFF by default, so the default build/clippy/test never compiled it. This leg builds it, runs `clippy --all-targets -D warnings` with the feature ON (the real gate), and runs the crate's tests — including the 11 in-module `rules.rs` unit tests that only exist under the feature.

## Verified locally (both legs)
- `cargo clippy -p sparq-shacl --features shacl-af --all-targets -- -D warnings` → **pass**
- `cargo test -p sparq-shacl --features shacl-af` → **pass**
- `cargo clippy -p sparq-vectors --features vec-predicate,filtered-ann --all-targets -- -D warnings` → **pass** (existing leg, re-confirmed)

## Gate / aggregator
- YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`).
- The single required `ci-summary / gate` aggregator auto-discovers checks by NAME; `opt-in sparq-shacl (shacl-af)` contains neither "advisory" nor "informational", so it becomes a REQUIRED gating leg with **no edit to ci-summary.yml**.

CI-config only — no `crates/` or EC2/aws changes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>