### PR TITLE
cert(ssdf): correct controls.md coverage-summary miscount (sq-ce97)

### DIFF
--- a/compliance/ssdf/README.md
+++ b/compliance/ssdf/README.md
@@ -52,8 +52,10 @@ deploying organization can lift into its own attestation — not a pending exter
 ## Honesty posture
 
 The coverage summary in `controls.md` reports **28 implemented & verified / 13 audit-ready
-/ 1 gap** across the 42 SSDF task rows (one of which, `RV.1.4`, is an explicitly-flagged
-sparq-local sub-task supporting standard task RV.1.3 — see the footnote in `controls.md`).
+/ 1 gap** across **42 rows = 41 standard SP 800-218 v1.1 tasks + 1 flagged sparq-local row**
+(`RV.1.4`, the daily advisory watchdog — evidence supporting standard task RV.1.3, **not** a
+separate framework task; see the footnote in `controls.md`). <!-- [OPUS-4.8] sq-ce97: 41
+standard (RV.1 has 3 tasks) + 1 local row = 42 rows; status tally 28/13/1 unchanged. -->
 The single technical gap is **PW.6.2 reproducible-build
 evidence** (GX-8, bead **sq-toze.9**). No row presents the `sparq-zk*` / `sparq-mpc`
 research scaffold as a met security control — its documented **"v1 verifier is NOT sound"**

--- a/compliance/ssdf/controls.md
+++ b/compliance/ssdf/controls.md
@@ -113,19 +113,29 @@ operator's own SSDF programme (their deployment, monitoring, IR) is out of sparq
 
 ## Coverage summary
 
-| Practice group | Tasks | Implemented & verified | Audit-ready | Gap |
-|---|---|---|---|---|
-| **PO** (Prepare the Organization) | 13 | 7 | 6 | 0 |
-| **PS** (Protect the Software) | 4 | 4 | 0 | 0 |
-| **PW** (Produce Well-Secured Software) | 15 | 11 | 3 | 1 |
-| **RV** (Respond to Vulnerabilities) | 10 | 6 | 4 | 0 |
-| **Total** | **42** | **28** | **13** | **1** |
+<!-- [OPUS-4.8] sq-ce97: the **Tasks** column is a ROW count. SP 800-218 v1.1 defines
+     41 standard tasks (RV.1 has exactly 3 — RV.1.1/1.2/1.3); the 42nd row, `RV.1.4`, is the
+     explicitly-flagged sparq-local sub-task (footnote ⚑). The columns below therefore split
+     "standard tasks" from "+ local row" so "42" can never be misread as "42 standard SSDF
+     tasks." The status tallies (28 / 13 / 1) are unchanged and cross-foot exactly. -->
 
-These totals are re-derived mechanically from the rows above and cross-foot exactly: the
-**Tasks** column sums to 42 (13 + 4 + 15 + 10) and equals the status columns (28 + 13 + 1); each
-group's row count equals its own status split. (The RV count includes the sparq-local `RV.1.4`
-sub-task flagged above; it is evidence supporting standard task RV.1.3, not a separate framework
-task — see footnote ⚑.)
+| Practice group | Standard tasks | + sparq-local rows | Rows total | Implemented & verified | Audit-ready | Gap |
+|---|---|---|---|---|---|---|
+| **PO** (Prepare the Organization) | 13 | 0 | 13 | 7 | 6 | 0 |
+| **PS** (Protect the Software) | 4 | 0 | 4 | 4 | 0 | 0 |
+| **PW** (Produce Well-Secured Software) | 15 | 0 | 15 | 11 | 3 | 1 |
+| **RV** (Respond to Vulnerabilities) | 9 | 1 | 10 | 6 | 4 | 0 |
+| **Total** | **41** | **1** | **42** | **28** | **13** | **1** |
+
+These totals are re-derived mechanically from the rows above and cross-foot exactly. The
+**Standard tasks** column counts the SP 800-218 v1.1 publication tasks (PO 13 + PS 4 + PW 15
++ RV 9 = **41**); RV.1 has exactly three publication tasks (RV.1.1/1.2/1.3), so standard RV is
+**9**, not 10. The single **+ sparq-local row** is `RV.1.4` (the daily advisory watchdog —
+evidence *supporting* standard task RV.1.3, **not** a separate framework task; see footnote ⚑),
+which brings the **Rows total** to **42**. The status columns sum to **28 + 13 + 1 = 42** rows,
+and each group's row count equals its own status split (PO 7+6+0=13, PS 4+0+0=4, PW 11+3+1=15,
+RV 6+4+0=10). So: **41 standard SSDF tasks + 1 flagged local row = 42 rows; 28 implemented &
+verified / 13 audit-ready / 1 gap.**
 
 The single technical **gap** is **PW.6.2 reproducible-build evidence** (GX-8 / bead
 sq-toze.9). The **audit-ready** rows are the practices that are documented + automated but


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements bead **sq-ce97** (epic **sq-toze**): fix the NIST SSDF (SP 800-218 v1.1) `controls.md` coverage-summary miscount. DOC-only — touches only `compliance/ssdf/`.

## Finding (honest)

The **status tally** in `compliance/ssdf/controls.md` — **28 implemented & verified / 13 audit-ready / 1 gap** across **42 rows** — already cross-foots **exactly** against the per-group rows, the total row, the README, and the gap-register. I re-counted every row mechanically (`awk` over the status column): PO 13/7/6/0, PS 4/4/0/0, PW 15/11/3/1, RV 10/6/4/0; total 42/28/13/1. **No status count was wrong.**

The genuine defect was a **task-vs-row count conflation**: the headline `Tasks = 42` (and the RV group `Tasks = 10`) counted **rows**, but SP 800-218 v1.1 defines only **41 standard tasks** — RV.1 has exactly three (RV.1.1/1.2/1.3). The 42nd row, `RV.1.4`, is the document's own **explicitly-flagged sparq-local sub-task** (footnote ⚑, evidence *supporting* standard RV.1.3). As written, "42" / "RV Tasks 10" could be misread as "42 standard SSDF tasks" / "10 standard RV tasks".

## Fix (minimal, no re-scope)

- Split the coverage-summary table into **Standard tasks** (41) + **sparq-local rows** (1) = **Rows total** (42), correcting **standard RV from 10 → 9**.
- The status tally **28 / 13 / 1 is unchanged** and still cross-foots (28+13+1 = 42 rows).
- README headline aligned to "**41 standard tasks + 1 flagged local row = 42 rows**".
- No control relabelled; no assessment re-scoped. `[OPUS-4.8]` markers on the new notes.

## Internal-consistency sanity check

Per-control statuses are internally consistent and honestly evidenced; the load-bearing ZK "v1 verifier is NOT sound" disclaimer is preserved (no `sparq-zk*`/`sparq-mpc` row claims a met crypto control). markdownlint-cli2 (repo config): **0 errors**.

Refs sq-ce97, epic sq-toze.