### PR TITLE
feat(sparq-policy): stateful ODRL count-constraint enforcement (sq-zi5w)

### DIFF
--- a/crates/sparq-policy/Cargo.toml
+++ b/crates/sparq-policy/Cargo.toml
@@ -33,3 +33,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 sparq-core = { path = "../sparq-core", version = "0.1.0", default-features = false }
 sparq-engine = { path = "../sparq-engine", version = "0.1.0", default-features = false }
 oxrdf.workspace = true
+
+[features]
+# [OPUS-4.8] sq-zi5w: STATEFUL `odrl:count` constraint enforcement — a usage-counter
+# store + an atomic exercise path that increments per use and denies once the limit is
+# reached. OFF by default (lean core): the default evaluator treats `odrl:count` as the
+# stateless numeric constraint it always was (the caller supplies the count in the
+# request context). Turning this on adds ONLY the `count` module (an injectable
+# `UsageCounterStore` trait + an in-memory `Mutex`-backed default impl, std-only — no
+# new deps); it does NOT change the stateless `evaluate` path.
+count-enforcement = []

--- a/crates/sparq-policy/README.md
+++ b/crates/sparq-policy/README.md
@@ -102,6 +102,34 @@ assert!(!evaluate(&policy, &outside).allow);
   - `purpose_status(&rule, &request) -> PurposeMatch` reports exactly what the evaluator
     checks for a rule's purpose constraints — `Satisfied` / `DefinitelyUnsatisfied` /
     `Unprovable` / `NotConstrained` — the auditable surface of this enforcement.
+- **`odrl:count` enforcement (stateful, opt-in, fail-closed)** — [OPUS-4.8] sq-zi5w.
+  `odrl:count` limits the **number of times** a permission may be exercised ("may read
+  at most 5 times"). Unlike the stateless constraints above, this is **stateful** — the
+  count lives in a usage counter that persists across requests. Behind the
+  `count-enforcement` feature (OFF by default; the default build is unchanged and treats
+  `odrl:count` as the stateless numeric comparison), `evaluate_and_exercise(&policy,
+  &request, &store) -> ExerciseDecision` runs the **real** `evaluate` decision and, on a
+  grant, **atomically consumes** one unit of the applicable count budget:
+  - **First *N* exercises grant; the *(N+1)*th denies.** A *denied* request burns **no**
+    budget. `lteq N`/`eq N` = at most *N*; `lt N` = at most *N-1*.
+  - **Counter-store seam.** `UsageCounterStore` is an injectable trait; the in-memory
+    default `InMemoryCounterStore` is the reference impl. The budget key is
+    `(rule_id, party, target)` (`CountKey`) — per-assignee, per-asset, per-rule.
+  - **Atomicity / concurrency boundary.** The single mutating op is the atomic
+    `try_consume` (check-and-consume under one lock in the in-memory store), **not** a
+    read-then-increment — so the in-process TOCTOU race is closed (a concurrency test
+    asserts exactly the limit is granted, never one more). A **distributed** store
+    (Redis `INCR`, SQL `UPDATE … WHERE consumed < limit`) is the operator's concern and
+    MUST provide the same atomicity; cross-process atomicity is a deferred bead.
+  - **Fail-closed.** An *unavailable* counter (`ConsumeResult::Unavailable`) or a
+    *malformed* limit denies — never silently treated as "unlimited".
+    `count_status(&rule, &request, &store) -> CountStatus` is the side-effect-free audit
+    surface (`Satisfied{consumed,limit}` / `DefinitelyUnsatisfied{..}` / `Unprovable` /
+    `NotConstrained`), the count dual of `purpose_status`.
+  - **Deferred (honest):** the stateless `sparq-solid` ODRL→ACP bridge does **not** wire
+    this stateful path — a bridged ACP grant does not self-retract on count exhaustion;
+    the bridge keeps `odrl:count` one-shot/unmappable. This crate provides the
+    evaluator + store seam such a bridge would build on.
 - **Duties as obligations** — a permission's `odrl:duty` must appear in the
   request's discharged-duty set, or the permission is denied (the usage-control
   kernel pure access control lacks).
@@ -122,8 +150,12 @@ lexical form; mixed-offset normalization, DPV `purpose` hierarchies, and
 `materialize_odrl_permission_conditional` persists a `odrl:recipient`/`odrl:assignee`
 constraint (`eq`/`isA`/`isPartOf`) as a **re-checked** ACP `auth:ConditionalGrant`
 (agent matcher) — the only constraint with a faithful stateless `(agent, client)`
-analogue. `odrl:purpose`/`dateTime`/`count` have none and stay **one-shot** (checked
-once at materialization). Mapping table: the
+analogue. `odrl:purpose`/`dateTime`/`count` have no *stateless* ACP analogue and stay
+**one-shot** in the bridge (checked once at materialization). Stateful `odrl:count`
+enforcement itself (the usage counter) lives in this crate's `count-enforcement`
+feature (`evaluate_and_exercise` + `UsageCounterStore`); wiring it *through* the
+stateless ACP bridge so a bridged grant self-retracts on exhaustion is a deferred bead.
+Mapping table: the
 [`usage-control-policy`](../../skills/usage-control-policy/SKILL.md) skill +
 [`sparq-solid` README](../sparq-solid/README.md).
 

--- a/crates/sparq-policy/src/count.rs
+++ b/crates/sparq-policy/src/count.rs
@@ -1,0 +1,487 @@
+//! Stateful `odrl:count` constraint enforcement. [OPUS-4.8] sq-zi5w.
+//!
+//! `odrl:count` limits the **number of times** a permission may be exercised (the
+//! ODRL [count left-operand](https://www.w3.org/TR/odrl-vocab/#term-count) — e.g.
+//! "may read at most 5 times"). Unlike the *stateless* constraints the base evaluator
+//! checks ([`crate::evaluate`] — purpose, dateTime, recipient: a single
+//! `(leftOperand, operator, rightOperand)` test against evidence the request carries),
+//! a count limit is **stateful**: the truth of "have we used this up?" lives in a
+//! usage counter that persists *across requests*, not in any one request's context.
+//!
+//! This module adds that statefulness as an **opt-in** layer (the `count-enforcement`
+//! feature) ON TOP OF the unchanged evaluator. It does NOT change how
+//! [`crate::evaluate`] treats `odrl:count`: a caller who supplies a count value in the
+//! request context still gets the stateless numeric comparison. What this module adds
+//! is a counter store the *engine itself* owns and increments per exercise, so the
+//! limit is enforced even when no caller volunteers a (truthful) count.
+//!
+//! # The honesty boundary (what is enforced end-to-end vs deferred)
+//!
+//! [`evaluate_and_exercise`] is the soundly-checkable core, and it is wired end-to-end
+//! through the **real** [`crate::evaluate`] decision: a request is granted ONLY if the
+//! base evaluator grants it AND every applicable count limit still has budget, and the
+//! grant **atomically consumes** one unit of that budget. The first *N* exercises of an
+//! "at most *N*" permission grant; the *(N+1)*th denies; and a counter whose state is
+//! unavailable denies (fail-closed — never silently grant beyond the limit). All of
+//! this is exercised by the unit tests through this real path.
+//!
+//! **Deferred (documented, not claimed):** the `sparq-solid` ODRL→ACP bridge is
+//! *stateless* — ACP grants are re-checked per session against static matcher
+//! accept-sets, with no usage counter to decrement. Wiring this stateful path through
+//! the materialized ACP enforcement (so a bridged grant *self-retracts* once the count
+//! is reached) is a distinct, more invasive change and is **not** done here — the
+//! bridge continues to treat `odrl:count` as one-shot/unmappable (see the
+//! `usage-control-policy` skill mapping table). This module is the evaluator + store
+//! seam that such a bridge would build on.
+//!
+//! # Concurrency / atomicity boundary
+//!
+//! A naive "read the count, decide, then increment" is a **TOCTOU race**: two
+//! concurrent exercises could both read `count == N-1`, both decide "ok", and both
+//! increment to `N+1` — granting *twice* over the limit. To close that within the
+//! engine, the [`UsageCounterStore`] seam is **check-and-consume**, not read-then-write:
+//! [`UsageCounterStore::try_consume`] is the single atomic operation "if budget remains,
+//! consume one unit and report success; else report exhausted". The default
+//! [`InMemoryCounterStore`] makes this atomic with a `Mutex` (the whole compare-and-
+//! increment happens under one lock). A *distributed* store (Redis `INCR`, a SQL
+//! `UPDATE ... WHERE count < limit RETURNING`, …) is the operator's concern; it MUST
+//! provide the same atomicity, and the trait contract says so explicitly. We do not
+//! pretend a multi-process deployment is safe with the in-memory store — that boundary
+//! is documented, and the "atomic across processes" hardening is a deferred bead.
+
+use crate::eval::{evaluate, Decision, Request, ODRL_COUNT};
+use crate::model::{Operator, Policy, Rule, Value};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// A stable identity for a single counted permission-exercise budget. Two requests
+/// that should share a usage counter (the same party exercising the same permission on
+/// the same target) map to the **same** key; requests that should be counted
+/// independently map to **different** keys. [OPUS-4.8] sq-zi5w.
+///
+/// The key is `(rule_id, party, target)`:
+/// - `rule_id` — *which* count-constrained rule's budget (a policy may carry several).
+/// - `party` — *whose* budget (an "at most 5 reads" limit is per-assignee; one party
+///   exhausting it must not lock out another). A request with no party shares the
+///   anonymous bucket (`""`).
+/// - `target` — *which asset's* budget (the same rule on different targets counts
+///   separately). A request with no target shares the bucket (`""`).
+///
+/// The bound itself (the `N` of "at most N") is NOT part of the key: it lives in the
+/// policy, and [`evaluate_and_exercise`] re-reads it each call, so raising/lowering the
+/// limit takes effect on the next exercise without resetting the consumed count.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CountKey {
+    /// The count-constrained rule's id (`Rule::id`).
+    pub rule_id: String,
+    /// The exercising party (WebID), or `""` for an anonymous/partyless request.
+    pub party: String,
+    /// The target asset/graph IRI, or `""` for a targetless request.
+    pub target: String,
+}
+
+impl CountKey {
+    /// The usage-counter key for `rule` exercised by `request` (see the type docs for
+    /// the `(rule_id, party, target)` rationale).
+    pub fn for_rule(rule: &Rule, request: &Request) -> CountKey {
+        CountKey {
+            rule_id: rule.id.clone(),
+            party: request.party.clone().unwrap_or_default(),
+            target: request.target.clone().unwrap_or_default(),
+        }
+    }
+}
+
+/// An injectable usage-counter store: the persistence seam for stateful `odrl:count`
+/// enforcement. The engine core keeps only the in-memory default
+/// ([`InMemoryCounterStore`]); the real persistence (Redis, SQL, a Solid pod resource)
+/// is the operator's concern. [OPUS-4.8] sq-zi5w.
+///
+/// # The atomicity contract (load-bearing — read this)
+///
+/// The single mutating operation is [`try_consume`](UsageCounterStore::try_consume),
+/// and it MUST be **atomic**: the "is there budget? if so, consume one unit"
+/// check-and-decrement happens as one indivisible step, even under concurrent callers
+/// for the same [`CountKey`]. This is deliberately NOT a read-then-write API — a
+/// `current(key)` + `increment(key)` pair would reintroduce the TOCTOU race
+/// [`evaluate_and_exercise`] exists to avoid. An implementation that cannot make
+/// `try_consume` atomic (across the processes that share the limit) does NOT satisfy
+/// this contract and MUST fail closed.
+///
+/// # Fail-closed
+///
+/// `try_consume` returns a [`ConsumeResult`]. [`ConsumeResult::Unavailable`] (the store
+/// could not be read/written — a backend outage, a poisoned lock) is treated by
+/// [`evaluate_and_exercise`] as a DENY: the engine never grants beyond a limit it
+/// cannot account for.
+pub trait UsageCounterStore {
+    /// Atomically: if the budget for `key` has fewer than `limit` units consumed,
+    /// consume one unit and return [`ConsumeResult::Consumed`] with the *new* consumed
+    /// count (`1..=limit`); if the budget is already fully consumed
+    /// (`consumed >= limit`), consume nothing and return [`ConsumeResult::Exhausted`];
+    /// if the store cannot be accessed, return [`ConsumeResult::Unavailable`].
+    ///
+    /// `limit` is the `N` of the policy's "at most N" (a non-negative integer; a limit
+    /// of 0 means the permission can never be exercised). The store does not persist
+    /// `limit` — it is supplied each call so a policy change takes effect immediately.
+    fn try_consume(&self, key: &CountKey, limit: u64) -> ConsumeResult;
+
+    /// The number of units already consumed for `key` (for audit/inspection), or `None`
+    /// if the store cannot be read. Pure read — does NOT consume. Never used to *gate*
+    /// an exercise (that is [`try_consume`]'s atomic job); only to report state.
+    fn consumed(&self, key: &CountKey) -> Option<u64>;
+}
+
+/// The outcome of an atomic [`UsageCounterStore::try_consume`]. [OPUS-4.8] sq-zi5w.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsumeResult {
+    /// One unit was consumed; the budget had room. Carries the new consumed count
+    /// (`1..=limit`).
+    Consumed(u64),
+    /// The budget was already fully consumed (`consumed >= limit`) — nothing consumed.
+    Exhausted,
+    /// The store could not be read/written — fail-closed (treated as a DENY upstream;
+    /// no unit consumed).
+    Unavailable,
+}
+
+/// The default in-memory [`UsageCounterStore`]: a `Mutex<HashMap<CountKey, u64>>`.
+/// [OPUS-4.8] sq-zi5w.
+///
+/// `try_consume` performs the whole compare-and-increment **under one lock**, so it is
+/// atomic with respect to other threads sharing this store — the in-process TOCTOU race
+/// is closed (see [`UsageCounterStore`]). The counts live only in this process's
+/// memory: this is correct for a single-process deployment and for tests, and is the
+/// reference semantics a persistent store must reproduce. It is NOT shared across
+/// processes — a multi-process / distributed deployment needs a shared atomic backend
+/// (deferred bead).
+///
+/// A poisoned lock (a prior panic while holding it) is reported as
+/// [`ConsumeResult::Unavailable`] rather than propagated — fail-closed.
+#[derive(Debug, Default)]
+pub struct InMemoryCounterStore {
+    counts: Mutex<HashMap<CountKey, u64>>,
+}
+
+impl InMemoryCounterStore {
+    /// A fresh store with every budget at zero consumed.
+    pub fn new() -> InMemoryCounterStore {
+        InMemoryCounterStore::default()
+    }
+}
+
+impl UsageCounterStore for InMemoryCounterStore {
+    fn try_consume(&self, key: &CountKey, limit: u64) -> ConsumeResult {
+        // The entire read-decide-write is under one lock → atomic; no other thread can
+        // observe or mutate this key's count between the compare and the increment.
+        let Ok(mut counts) = self.counts.lock() else {
+            return ConsumeResult::Unavailable; // poisoned → fail-closed
+        };
+        let entry = counts.entry(key.clone()).or_insert(0);
+        if *entry >= limit {
+            return ConsumeResult::Exhausted;
+        }
+        *entry += 1;
+        ConsumeResult::Consumed(*entry)
+    }
+
+    fn consumed(&self, key: &CountKey) -> Option<u64> {
+        let counts = self.counts.lock().ok()?;
+        Some(counts.get(key).copied().unwrap_or(0))
+    }
+}
+
+/// The three-valued verdict of a rule's `odrl:count` limit(s) against the usage state —
+/// the count analogue of [`crate::PurposeMatch`], reporting exactly what
+/// [`evaluate_and_exercise`] would act on WITHOUT consuming a unit. [OPUS-4.8] sq-zi5w.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CountStatus {
+    /// The rule has no `odrl:count` constraint — count places no restriction on it.
+    NotConstrained,
+    /// The rule has a count limit AND budget remains (a further exercise would be
+    /// granted). Carries `(consumed, limit)`.
+    Satisfied { consumed: u64, limit: u64 },
+    /// The rule has a count limit and it is fully consumed (`consumed >= limit`) — a
+    /// further exercise is a definite DENY. Carries `(consumed, limit)`.
+    DefinitelyUnsatisfied { consumed: u64, limit: u64 },
+    /// The rule has a count limit but the usage state is **unavailable** (store outage)
+    /// or the limit is **malformed** (a count constraint whose right-operand is not a
+    /// usable non-negative integer bound). Fail-closed: a further exercise is DENIED;
+    /// the limit is never silently treated as "unlimited".
+    Unprovable,
+}
+
+/// Report how `rule`'s `odrl:count` limit stands against `store` for `request`, WITHOUT
+/// consuming a unit — the auditable, side-effect-free surface of count enforcement (the
+/// count dual of [`crate::purpose_status`]). [OPUS-4.8] sq-zi5w.
+///
+/// This does NOT gate an exercise (that is [`evaluate_and_exercise`]'s atomic job, which
+/// *consumes*). It answers "would the next exercise have count budget?" for inspection.
+/// Several `odrl:count` constraints on one rule are ANDed: the tightest verdict wins
+/// (any `Unprovable` ⇒ `Unprovable`; else any `DefinitelyUnsatisfied` ⇒
+/// `DefinitelyUnsatisfied`; else `Satisfied` reporting the tightest remaining budget).
+pub fn count_status(rule: &Rule, request: &Request, store: &dyn UsageCounterStore) -> CountStatus {
+    let mut constrained = false;
+    let mut tightest: Option<CountStatus> = None;
+    for c in &rule.constraints {
+        if c.left != ODRL_COUNT {
+            continue;
+        }
+        constrained = true;
+        let Some(limit) = count_limit(c.operator, &c.right) else {
+            return CountStatus::Unprovable; // malformed bound → fail-closed
+        };
+        let key = CountKey::for_rule(rule, request);
+        let Some(consumed) = store.consumed(&key) else {
+            return CountStatus::Unprovable; // store unavailable → fail-closed
+        };
+        let status = if consumed >= limit {
+            CountStatus::DefinitelyUnsatisfied { consumed, limit }
+        } else {
+            CountStatus::Satisfied { consumed, limit }
+        };
+        tightest = Some(match (tightest, status) {
+            // A definite no anywhere dominates a satisfied elsewhere.
+            (Some(CountStatus::DefinitelyUnsatisfied { .. }), _) => {
+                CountStatus::DefinitelyUnsatisfied { consumed, limit }
+            }
+            (_, CountStatus::DefinitelyUnsatisfied { .. }) => status,
+            _ => status,
+        });
+    }
+    match (constrained, tightest) {
+        (false, _) => CountStatus::NotConstrained,
+        (true, Some(s)) => s,
+        (true, None) => CountStatus::Unprovable,
+    }
+}
+
+/// The result of [`evaluate_and_exercise`]: the base ODRL [`Decision`] plus, when a
+/// count limit applied, what the counter store did. [OPUS-4.8] sq-zi5w.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExerciseDecision {
+    /// `true` ⇒ the exercise was granted AND (if count-constrained) one unit was
+    /// consumed. `false` ⇒ DENY — and **no** unit was consumed (a denied request never
+    /// burns budget; fail-closed both ways).
+    pub allow: bool,
+    /// The granting rule on an ALLOW, else the rules implicated in the DENY (mirrors
+    /// [`Decision::matched_rules`]).
+    pub matched_rules: Vec<String>,
+    /// Why the exercise was denied (the base decision's caveats, or a count-exhausted /
+    /// count-unavailable reason). Empty on a clean ALLOW.
+    pub reasons: Vec<String>,
+    /// On a granted count-constrained exercise: the new consumed count (`1..=limit`).
+    /// `None` when the grant was not count-constrained or the request was denied.
+    pub consumed: Option<u64>,
+}
+
+impl ExerciseDecision {
+    fn deny(matched: Vec<String>, reasons: Vec<String>) -> ExerciseDecision {
+        ExerciseDecision { allow: false, matched_rules: matched, reasons, consumed: None }
+    }
+}
+
+/// Evaluate `policy` against `request` and, on a grant, **atomically consume** one unit
+/// of any applicable `odrl:count` budget from `store` — the stateful enforcement entry
+/// point. [OPUS-4.8] sq-zi5w.
+///
+/// Semantics, wired through the **real** [`evaluate`] decision (no parallel evaluator):
+///
+/// 1. Run [`evaluate`]. A base DENY (no permission, a prohibition carve-out, an unmet
+///    stateless constraint, an undischarged duty) is returned verbatim — **nothing is
+///    consumed** (a denied request never burns count budget).
+/// 2. On a base ALLOW, find the granting rule and its `odrl:count` limit(s). If it has
+///    none, the grant stands as-is (no counter touched).
+/// 3. If it has a count limit `N`, call [`UsageCounterStore::try_consume`] (the single
+///    atomic check-and-consume):
+///    - [`ConsumeResult::Consumed(n)`](ConsumeResult::Consumed) (`n <= N`) ⇒ ALLOW, one
+///      unit consumed. The first `N` exercises take this branch.
+///    - [`ConsumeResult::Exhausted`] (`consumed >= N`) ⇒ DENY. The `(N+1)`th exercise
+///      takes this branch — the limit is reached.
+///    - [`ConsumeResult::Unavailable`] ⇒ DENY (fail-closed: never grant beyond a limit
+///      we cannot account for).
+///
+/// A *malformed* count constraint (a right-operand that is not a usable non-negative
+/// integer) denies (fail-closed) — the base evaluator already rejects the request via
+/// its stateless count comparison in most shapes, but this path denies regardless.
+///
+/// **Multiple count limits on one rule** are all consumed atomically-per-store-op but
+/// not as one cross-store transaction: each is consumed in turn, and if a later one is
+/// exhausted the earlier consumptions have already happened. To avoid that partial-burn
+/// the function first checks every limit has budget ([`count_status`]) and only then
+/// consumes — a tiny TOCTOU window remains *between* the multi-limit pre-check and the
+/// consume for the multi-constraint case (single-constraint, the overwhelmingly common
+/// shape, is fully atomic). This narrow multi-limit window is documented and beaded.
+pub fn evaluate_and_exercise(
+    policy: &Policy,
+    request: &Request,
+    store: &dyn UsageCounterStore,
+) -> ExerciseDecision {
+    // 1. The real base decision — the single source of allow/deny for everything that
+    //    is NOT the stateful count. The `odrl:count` constraints are STRIPPED from the
+    //    rules for this base evaluation (the stateless evaluator would otherwise deny on
+    //    a missing/`Unprovable` count value); count is enforced below against the store
+    //    instead. Everything else (action/target/assignee, prohibitions, purpose,
+    //    dateTime, recipient, duties) is checked by the unchanged evaluator on the real
+    //    policy shape.
+    let stripped = strip_count_constraints(policy);
+    let decision = evaluate(&stripped, request);
+    if !decision.allow {
+        return ExerciseDecision::deny(decision.matched_rules, decision.unmet_constraints);
+    }
+
+    // 2. Which rule granted? `evaluate` returns its id in `matched_rules` on an ALLOW.
+    //    Look it up in the ORIGINAL policy (which still carries the count constraints).
+    let Some(rule) = decision
+        .matched_rules
+        .first()
+        .and_then(|id| policy.permissions.iter().find(|r| &r.id == id))
+    else {
+        // ALLOW with no identifiable rule (should not happen for a permission grant) —
+        // pass through unchanged; nothing to count.
+        return granted(decision, None);
+    };
+
+    // 3. Gather this rule's count limits. None → grant unchanged.
+    let limits: Vec<u64> = collect_count_limits(rule);
+    if rule_has_count_constraint(rule) && limits.len() != count_constraint_count(rule) {
+        // A count constraint was present but malformed → fail-closed.
+        return ExerciseDecision::deny(
+            vec![rule.id.clone()],
+            vec![format!("permission {} has a malformed odrl:count limit", rule.id)],
+        );
+    }
+    if limits.is_empty() {
+        return granted(decision, None);
+    }
+
+    let key = CountKey::for_rule(rule, request);
+
+    // 4a. Multi-limit pre-check (avoid a partial burn across several limits) — a no-op
+    //     side-effect-free read. Single-limit skips straight to the atomic consume.
+    if limits.len() > 1 {
+        match count_status(rule, request, store) {
+            CountStatus::Satisfied { .. } | CountStatus::NotConstrained => {}
+            CountStatus::DefinitelyUnsatisfied { consumed, limit } => {
+                return ExerciseDecision::deny(
+                    vec![rule.id.clone()],
+                    vec![format!(
+                        "permission {} count limit reached ({consumed}/{limit})",
+                        rule.id
+                    )],
+                );
+            }
+            CountStatus::Unprovable => {
+                return ExerciseDecision::deny(
+                    vec![rule.id.clone()],
+                    vec![format!(
+                        "permission {} count state unavailable; denied (fail-closed)",
+                        rule.id
+                    )],
+                );
+            }
+        }
+    }
+
+    // 4b. Atomically consume one unit of every applicable limit.
+    let mut new_count = None;
+    for limit in limits {
+        match store.try_consume(&key, limit) {
+            ConsumeResult::Consumed(n) => new_count = Some(n),
+            ConsumeResult::Exhausted => {
+                return ExerciseDecision::deny(
+                    vec![rule.id.clone()],
+                    vec![format!(
+                        "permission {} count limit reached (>= {limit}); denied",
+                        rule.id
+                    )],
+                );
+            }
+            ConsumeResult::Unavailable => {
+                return ExerciseDecision::deny(
+                    vec![rule.id.clone()],
+                    vec![format!(
+                        "permission {} count state unavailable; denied (fail-closed)",
+                        rule.id
+                    )],
+                );
+            }
+        }
+    }
+
+    granted(decision, new_count)
+}
+
+fn granted(decision: Decision, consumed: Option<u64>) -> ExerciseDecision {
+    ExerciseDecision {
+        allow: true,
+        matched_rules: decision.matched_rules,
+        reasons: Vec::new(),
+        consumed,
+    }
+}
+
+/// The integer count bound `N` of an `odrl:count` constraint under a "≤"-shaped
+/// operator, or `None` if the constraint does not express a usable upper bound.
+///
+/// A count *limit* is "at most N times": `lteq N` (≤ N) and `lt N` (< N, i.e. at most
+/// `N-1`) express upper bounds and are honoured. `eq N` is treated as "exactly/at most
+/// N" (the common shorthand "count = 5" for a 5-use allowance). Order operators that do
+/// NOT bound from above (`gt`/`gteq`) and equality-set operators (`neq`/`isPartOf`/
+/// `isA`) do not express a usage *ceiling* and return `None` (the stateful path then
+/// treats them as having no limit — they are left to the stateless evaluator). A
+/// negative or non-integer right-operand is rejected (`None`).
+fn count_limit(op: Operator, right: &Value) -> Option<u64> {
+    let n = match right {
+        Value::Num(x) => *x,
+        // a numeric-looking string bound
+        Value::Str(s) => s.trim().parse::<f64>().ok()?,
+        _ => return None,
+    };
+    if !n.is_finite() || n < 0.0 || n.fract() != 0.0 {
+        return None;
+    }
+    let n = n as u64;
+    match op {
+        // "at most N" allowances.
+        Operator::Lteq | Operator::Eq => Some(n),
+        // "< N" ⇒ at most N-1 (a 0 bound stays 0 — never exercisable).
+        Operator::Lt => Some(n.saturating_sub(1)),
+        // gt/gteq/neq/isPartOf/isA do not express a usage ceiling.
+        _ => None,
+    }
+}
+
+/// A copy of `policy` with every `odrl:count` constraint removed from its
+/// **permission** rules, so the stateless [`evaluate`] does not deny a count-limited
+/// permission for lack of a request-supplied count value — the count is enforced
+/// separately against the [`UsageCounterStore`]. Prohibitions are left untouched: a
+/// prohibition is a carve-out, never a permission grant, so a count constraint there
+/// keeps its (stateless) meaning and is not part of usage-counter enforcement.
+fn strip_count_constraints(policy: &Policy) -> Policy {
+    let mut out = policy.clone();
+    for rule in &mut out.permissions {
+        rule.constraints.retain(|c| c.left != ODRL_COUNT);
+    }
+    out
+}
+
+fn rule_has_count_constraint(rule: &Rule) -> bool {
+    rule.constraints.iter().any(|c| c.left == ODRL_COUNT)
+}
+
+fn count_constraint_count(rule: &Rule) -> usize {
+    rule.constraints.iter().filter(|c| c.left == ODRL_COUNT).count()
+}
+
+/// All upper-bound count limits on `rule` (one per ceiling-shaped `odrl:count`
+/// constraint). A count constraint that does not express a ceiling is skipped here (it
+/// is the stateless evaluator's concern), so this returns only the limits the stateful
+/// path enforces.
+fn collect_count_limits(rule: &Rule) -> Vec<u64> {
+    rule.constraints
+        .iter()
+        .filter(|c| c.left == ODRL_COUNT)
+        .filter_map(|c| count_limit(c.operator, &c.right))
+        .collect()
+}

--- a/crates/sparq-policy/src/eval.rs
+++ b/crates/sparq-policy/src/eval.rs
@@ -23,6 +23,12 @@ use std::collections::{BTreeMap, BTreeSet};
 /// `odrl:purpose eq <urn:purpose/research>`). [OPUS-4.8] sq-q56r.
 pub const ODRL_PURPOSE: &str = "http://www.w3.org/ns/odrl/2/purpose";
 
+/// The `odrl:count` left-operand IRI — the dimension a *count constraint* restricts
+/// (the number of times a permission may be exercised, e.g. `odrl:count lteq 5`).
+/// Stateful enforcement of this lives in the opt-in [`crate::count`] module.
+/// [OPUS-4.8] sq-zi5w.
+pub const ODRL_COUNT: &str = "http://www.w3.org/ns/odrl/2/count";
+
 /// An access request evaluated against a [`Policy`]: who wants to do what, to
 /// what, in what context (the "evaluation request" + "state of the world" of the
 /// ODRL Formal Semantics, folded into one node-local view).

--- a/crates/sparq-policy/src/lib.rs
+++ b/crates/sparq-policy/src/lib.rs
@@ -1,13 +1,26 @@
 #![doc = include_str!("../README.md")] // [OPUS-4.8] README is the docs.rs front page
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-r06h: crate has zero `unsafe`
 
+// [OPUS-4.8] sq-zi5w: stateful `odrl:count` enforcement, gated on `count-enforcement`
+// (OFF by default — the default build carries zero counter-store code or runtime cost).
+#[cfg(feature = "count-enforcement")]
+pub mod count;
+
 mod eval;
 pub mod model;
 mod parse;
 
 pub use eval::{
     evaluate, matched_prohibition, prohibition_status, purpose_status, Decision, ProhibitionStatus,
-    PurposeMatch, Request, ODRL_PURPOSE,
+    PurposeMatch, Request, ODRL_COUNT, ODRL_PURPOSE,
 };
 pub use model::{Action, Constraint, Duty, Operator, Policy, Rule, Value, ODRL_NS};
 pub use parse::{parse_policy, parse_policy_str};
+
+// [OPUS-4.8] sq-zi5w: re-export the count-enforcement surface at the crate root when the
+// feature is on (matches how the stateless evaluator surface is flat-exported).
+#[cfg(feature = "count-enforcement")]
+pub use count::{
+    count_status, evaluate_and_exercise, ConsumeResult, CountKey, CountStatus, ExerciseDecision,
+    InMemoryCounterStore, UsageCounterStore,
+};

--- a/crates/sparq-policy/tests/odrl_count.rs
+++ b/crates/sparq-policy/tests/odrl_count.rs
@@ -1,0 +1,289 @@
+//! Stateful `odrl:count` enforcement tests, through the REAL evaluator +
+//! counter-store path. [OPUS-4.8] sq-zi5w.
+//!
+//! Coverage: first N exercises grant + (N+1)th denies (`lteq`, `lt`, `eq`); a denied
+//! base decision burns no budget; per-(party, target, rule) budget isolation; the
+//! counter-unavailable fail-closed path; the malformed-limit fail-closed path; the
+//! atomicity of the default in-memory store under concurrency; and `count_status` as a
+//! side-effect-free audit surface.
+//!
+//! Gated on `count-enforcement` (the whole feature). The default-feature test suite
+//! (`odrl_eval.rs`) still exercises the *stateless* `odrl:count` comparison unchanged.
+#![cfg(feature = "count-enforcement")]
+
+use sparq_policy::{
+    count_status, evaluate_and_exercise, parse_policy_str, ConsumeResult, CountKey, CountStatus,
+    InMemoryCounterStore, Request, UsageCounterStore,
+};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
+
+fn read() -> String {
+    format!("{ODRL}read")
+}
+
+/// "alice may read asset/x at most N times" under `operator`.
+fn policy_at_most(operator: &str, bound: &str) -> sparq_policy::Policy {
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/c> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:assignee <https://alice.ex/me> ;
+    odrl:constraint [ odrl:leftOperand odrl:count ;
+                      odrl:operator odrl:{operator} ;
+                      odrl:rightOperand "{bound}"^^xsd:integer ] ] .
+"#
+    );
+    parse_policy_str(&ttl, "turtle").unwrap()
+}
+
+fn alice_reads() -> Request {
+    Request::new(read()).on("urn:asset/x").by("https://alice.ex/me")
+}
+
+// ---------------------------------------------------------------------------
+// 1. lteq N: the first N exercises grant; the (N+1)th denies.
+// ---------------------------------------------------------------------------
+#[test]
+fn lteq_grants_n_then_denies() {
+    let p = policy_at_most("lteq", "3");
+    let store = InMemoryCounterStore::new();
+    let req = alice_reads();
+
+    for expected in 1..=3 {
+        let d = evaluate_and_exercise(&p, &req, &store);
+        assert!(d.allow, "exercise {expected} should grant: {d:?}");
+        assert_eq!(d.consumed, Some(expected));
+    }
+    // 4th: limit reached → DENY, and nothing further consumed.
+    let d = evaluate_and_exercise(&p, &req, &store);
+    assert!(!d.allow, "4th exercise must deny");
+    assert_eq!(d.consumed, None);
+    // The store still reports exactly 3 consumed (the deny did not burn budget).
+    let key = CountKey {
+        rule_id: p.permissions[0].id.clone(),
+        party: "https://alice.ex/me".into(),
+        target: "urn:asset/x".into(),
+    };
+    assert_eq!(store.consumed(&key), Some(3));
+}
+
+// ---------------------------------------------------------------------------
+// 2. lt N: "< N" means at most N-1 exercises.
+// ---------------------------------------------------------------------------
+#[test]
+fn lt_means_n_minus_one() {
+    let p = policy_at_most("lt", "3"); // at most 2
+    let store = InMemoryCounterStore::new();
+    let req = alice_reads();
+    assert!(evaluate_and_exercise(&p, &req, &store).allow);
+    assert!(evaluate_and_exercise(&p, &req, &store).allow);
+    assert!(!evaluate_and_exercise(&p, &req, &store).allow, "3rd must deny under lt 3");
+}
+
+// ---------------------------------------------------------------------------
+// 3. eq N: the "exactly N uses" shorthand = at most N.
+// ---------------------------------------------------------------------------
+#[test]
+fn eq_means_at_most_n() {
+    let p = policy_at_most("eq", "2");
+    let store = InMemoryCounterStore::new();
+    let req = alice_reads();
+    assert!(evaluate_and_exercise(&p, &req, &store).allow);
+    assert!(evaluate_and_exercise(&p, &req, &store).allow);
+    assert!(!evaluate_and_exercise(&p, &req, &store).allow);
+}
+
+// ---------------------------------------------------------------------------
+// 4. A base DENY (wrong party) burns NO budget.
+// ---------------------------------------------------------------------------
+#[test]
+fn base_deny_consumes_nothing() {
+    let p = policy_at_most("lteq", "2");
+    let store = InMemoryCounterStore::new();
+    let mallory = Request::new(read()).on("urn:asset/x").by("https://mallory.ex/me");
+    // Mallory is not the assignee → base evaluator denies → no consume.
+    let d = evaluate_and_exercise(&p, &mallory, &store);
+    assert!(!d.allow);
+    assert_eq!(d.consumed, None);
+    // Alice still has her full budget of 2.
+    assert!(evaluate_and_exercise(&p, &alice_reads(), &store).allow);
+    assert!(evaluate_and_exercise(&p, &alice_reads(), &store).allow);
+    assert!(!evaluate_and_exercise(&p, &alice_reads(), &store).allow);
+}
+
+// ---------------------------------------------------------------------------
+// 5. Budget is isolated per (party, target): one party exhausting does not lock
+//    out another, and a different target counts separately.
+// ---------------------------------------------------------------------------
+#[test]
+fn budget_isolated_per_party_and_target() {
+    // No assignee on the rule → any party may read (count is per-party regardless).
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/c> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ;
+    odrl:constraint [ odrl:leftOperand odrl:count ; odrl:operator odrl:lteq ;
+                      odrl:rightOperand "1"^^xsd:integer ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let store = InMemoryCounterStore::new();
+
+    let alice = Request::new(read()).on("urn:asset/x").by("https://alice.ex/me");
+    let bob = Request::new(read()).on("urn:asset/x").by("https://bob.ex/me");
+    let alice_other = Request::new(read()).on("urn:asset/y").by("https://alice.ex/me");
+
+    assert!(evaluate_and_exercise(&p, &alice, &store).allow);
+    assert!(!evaluate_and_exercise(&p, &alice, &store).allow, "alice's budget on x is spent");
+    // Bob has his own budget on x.
+    assert!(evaluate_and_exercise(&p, &bob, &store).allow);
+    // Alice has a separate budget on a different target.
+    assert!(evaluate_and_exercise(&p, &alice_other, &store).allow);
+}
+
+// ---------------------------------------------------------------------------
+// 6. Counter UNAVAILABLE → DENY (fail-closed): never grant beyond an unaccountable
+//    limit.
+// ---------------------------------------------------------------------------
+struct UnavailableStore;
+impl UsageCounterStore for UnavailableStore {
+    fn try_consume(&self, _k: &CountKey, _l: u64) -> ConsumeResult {
+        ConsumeResult::Unavailable
+    }
+    fn consumed(&self, _k: &CountKey) -> Option<u64> {
+        None
+    }
+}
+
+#[test]
+fn counter_unavailable_fails_closed() {
+    let p = policy_at_most("lteq", "5");
+    let store = UnavailableStore;
+    let d = evaluate_and_exercise(&p, &alice_reads(), &store);
+    assert!(!d.allow, "an unavailable counter must DENY, not grant");
+    assert!(d.reasons.iter().any(|r| r.contains("unavailable")));
+    // count_status agrees: Unprovable (never silently "unlimited").
+    assert_eq!(
+        count_status(&p.permissions[0], &alice_reads(), &store),
+        CountStatus::Unprovable
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7. Malformed count bound → DENY (fail-closed).
+// ---------------------------------------------------------------------------
+#[test]
+fn malformed_limit_fails_closed() {
+    // A non-numeric right-operand on the count constraint.
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/c> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ; odrl:assignee <https://alice.ex/me> ;
+    odrl:constraint [ odrl:leftOperand odrl:count ; odrl:operator odrl:lteq ;
+                      odrl:rightOperand "not-a-number" ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let store = InMemoryCounterStore::new();
+    let d = evaluate_and_exercise(&p, &alice_reads(), &store);
+    assert!(!d.allow, "a malformed count bound must DENY");
+}
+
+// ---------------------------------------------------------------------------
+// 8. count_status: side-effect-free audit surface (does NOT consume).
+// ---------------------------------------------------------------------------
+#[test]
+fn count_status_does_not_consume() {
+    let p = policy_at_most("lteq", "2");
+    let store = InMemoryCounterStore::new();
+    let rule = &p.permissions[0];
+    let req = alice_reads();
+
+    // Before any exercise: Satisfied(0/2). Querying it twice consumes nothing.
+    assert_eq!(count_status(rule, &req, &store), CountStatus::Satisfied { consumed: 0, limit: 2 });
+    assert_eq!(count_status(rule, &req, &store), CountStatus::Satisfied { consumed: 0, limit: 2 });
+
+    // Exercise once → status reflects 1 consumed, still satisfied.
+    assert!(evaluate_and_exercise(&p, &req, &store).allow);
+    assert_eq!(count_status(rule, &req, &store), CountStatus::Satisfied { consumed: 1, limit: 2 });
+
+    // Exhaust → DefinitelyUnsatisfied.
+    assert!(evaluate_and_exercise(&p, &req, &store).allow);
+    assert_eq!(
+        count_status(rule, &req, &store),
+        CountStatus::DefinitelyUnsatisfied { consumed: 2, limit: 2 }
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 9. A permission with NO count constraint is unaffected (NotConstrained) and grants
+//    unboundedly.
+// ---------------------------------------------------------------------------
+#[test]
+fn no_count_constraint_unbounded() {
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/c> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ; odrl:assignee <https://alice.ex/me> ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let store = InMemoryCounterStore::new();
+    assert_eq!(count_status(&p.permissions[0], &alice_reads(), &store), CountStatus::NotConstrained);
+    for _ in 0..10 {
+        let d = evaluate_and_exercise(&p, &alice_reads(), &store);
+        assert!(d.allow);
+        assert_eq!(d.consumed, None, "an unconstrained grant touches no counter");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 10. ATOMICITY: under concurrent exercises against the SAME key, the in-memory store
+//     grants EXACTLY the limit — never over-grants (the TOCTOU race is closed).
+// ---------------------------------------------------------------------------
+#[test]
+fn concurrent_exercises_never_overgrant() {
+    const LIMIT: u64 = 100;
+    const THREADS: usize = 16;
+    const PER_THREAD: usize = 50; // 16*50 = 800 attempts >> 100 budget
+
+    let p = Arc::new(policy_at_most("lteq", "100"));
+    let store = Arc::new(InMemoryCounterStore::new());
+    let granted = Arc::new(AtomicU64::new(0));
+
+    let mut handles = Vec::new();
+    for _ in 0..THREADS {
+        let p = Arc::clone(&p);
+        let store = Arc::clone(&store);
+        let granted = Arc::clone(&granted);
+        handles.push(std::thread::spawn(move || {
+            let req = alice_reads();
+            for _ in 0..PER_THREAD {
+                if evaluate_and_exercise(&p, &req, &*store).allow {
+                    granted.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+    // EXACTLY the limit was granted — not one more (atomicity) and not fewer (no lost
+    // grant), and the store's final consumed count agrees.
+    assert_eq!(granted.load(Ordering::Relaxed), LIMIT, "must grant exactly the limit");
+    let key = CountKey {
+        rule_id: p.permissions[0].id.clone(),
+        party: "https://alice.ex/me".into(),
+        target: "urn:asset/x".into(),
+    };
+    assert_eq!(store.consumed(&key), Some(LIMIT));
+}

--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -133,13 +133,24 @@ analogue keep the one-shot behaviour.
 | `odrl:recipient` / `odrl:assignee` | `neq` / order | — (needs per-session `noneOf`) | one-shot (frozen) |
 | `odrl:purpose` | any | — (ACP session has no purpose) | one-shot (frozen) |
 | `odrl:dateTime` / time window | any | — (ACP has no "now") | one-shot (frozen) |
-| `odrl:count` | any | — (ACP is stateless) | one-shot (frozen) |
+| `odrl:count` | any | — (ACP is stateless; no per-session usage counter) | one-shot (frozen) in the bridge¹ |
 | *no constraint* | — | `auth:agent auth:Public` | re-checked (public) |
 
 **Why only recipient/assignee:** the ACP session re-check carries exactly `(agent, client)`,
 and the recipient-of-data *is* the session agent — so an agent matcher re-checks it with
 identical semantics. Purpose/time/count have no stateless `(agent, client)` analogue, so
 persisting them would require a looser approximation that could over-grant — rejected.
+
+¹ **Stateful `odrl:count` enforcement** — [OPUS-4.8] sq-zi5w. `odrl:count` limits the *number
+of times* a permission may be exercised; faithful enforcement is **stateful** (a usage counter
+persisting across requests), which ACP — stateless, with static matcher accept-sets and no
+per-session counter — cannot express, so the bridge keeps it **one-shot** (the limit is checked
+once against any count value the request supplies, at materialization). The actual stateful
+enforcement lives in `sparq-policy`'s opt-in `count-enforcement` feature
+(`evaluate_and_exercise` + the injectable `UsageCounterStore`; atomic `try_consume`,
+fail-closed on an unavailable counter — see the [`sparq-policy` README](../sparq-policy/README.md)).
+Wiring that path *through* this stateless ACP bridge — so a bridged grant self-retracts once the
+count is reached — is a distinct, more invasive change and is a **deferred bead**.
 
 **`odrl:purpose` enforcement through the bridge (faithful, fail-closed)** — [OPUS-4.8] sq-q56r.
 Purpose has no re-checked-condition analogue (above), so it stays **one-shot**: the bound is

--- a/skills/usage-control-policy/SKILL.md
+++ b/skills/usage-control-policy/SKILL.md
@@ -85,6 +85,26 @@ A purpose constraint restricts a rule to a stated *purpose of use*. The request 
 - **Audit:** `purpose_status(&rule, &request) -> PurposeMatch` reports exactly what the evaluator checks — `Satisfied` / `DefinitelyUnsatisfied` / `Unprovable` / `NotConstrained`.
 - Through the bridge, purpose stays **one-shot** (checked once at materialization; see the mapping table below) — it has no re-checked-condition analogue, so a changed purpose is re-evaluated on the next `refresh_odrl_grant`.
 
+## `odrl:count` enforcement (stateful, opt-in `count-enforcement`) — [OPUS-4.8] sq-zi5w
+
+`odrl:count` limits the **number of times** a permission may be exercised ("read at most 5 times"). Unlike `purpose`/`dateTime`/`recipient` (stateless — a single test against evidence the request carries), a count limit is **stateful**: it lives in a usage counter that persists *across* requests. Behind the off-by-default `count-enforcement` feature on `sparq-policy` (the default build is unchanged — it treats `odrl:count` as the stateless numeric comparison), `evaluate_and_exercise` runs the **real** `evaluate` decision and, on a grant, **atomically consumes** one unit of budget.
+
+```rust,ignore
+// cargo: sparq-policy with --features count-enforcement
+use sparq_policy::{evaluate_and_exercise, InMemoryCounterStore, Request};
+let store = InMemoryCounterStore::new();           // injectable UsageCounterStore
+let req = Request::new("http://www.w3.org/ns/odrl/2/read")
+    .on("urn:asset/x").by("https://alice.ex/me");  // policy: count lteq 3
+for _ in 0..3 { assert!(evaluate_and_exercise(&policy, &req, &store).allow); }
+assert!(!evaluate_and_exercise(&policy, &req, &store).allow); // 4th: limit reached → DENY
+```
+
+- **Semantics through the real path.** A grant requires the base `evaluate` to grant (the `odrl:count` constraint is stripped from *permissions* for that base check, since the stateless evaluator would otherwise deny for a missing count value; everything else — action/target/assignee, prohibitions, purpose, dateTime, recipient, duties — is checked unchanged) AND the count budget to have room. **First *N* exercises grant; the *(N+1)*th denies.** A *denied* request consumes **nothing**. `lteq N`/`eq N` = at most *N*; `lt N` = at most *N-1*; `gt`/`gteq`/`neq`/`isPartOf` express no ceiling (left to the stateless path).
+- **Counter-store seam.** `UsageCounterStore` is an injectable trait; `InMemoryCounterStore` is the in-memory reference impl. The budget key is `(rule_id, party, target)` (`CountKey`) — **per-assignee, per-asset, per-rule** (one party exhausting a limit never locks out another; the same rule on a different target counts separately). A partyless/targetless request shares the `""` bucket.
+- **Atomicity / concurrency boundary (load-bearing).** The single mutating op is the **atomic** `try_consume` (the whole check-and-consume under one lock in the in-memory store) — deliberately **not** a `current()`+`increment()` pair, which would reintroduce a TOCTOU race (two concurrent exercises both reading `N-1`, both granting → over-grant). A concurrency test asserts exactly the limit is granted under 16 threads, never one more. The in-memory store is atomic **in-process only**; a **distributed** deployment needs a shared atomic backend (Redis `INCR`, SQL `UPDATE … WHERE consumed < limit RETURNING`) and MUST honour the same `try_consume` atomicity contract. Cross-process atomicity is a **deferred bead**. There is also a narrow pre-check→consume window for the *multiple*-count-limits-on-one-rule case (single-limit, the common shape, is fully atomic); documented + beaded.
+- **Fail-closed.** `ConsumeResult::Unavailable` (store outage / poisoned lock) or a malformed limit → **DENY** — never silently "unlimited". `count_status(&rule, &request, &store) -> CountStatus` is the side-effect-free audit surface (`Satisfied{consumed,limit}` / `DefinitelyUnsatisfied{..}` / `Unprovable` / `NotConstrained`), the count dual of `purpose_status`.
+- **Deferred (honest).** The stateless ODRL→ACP **bridge does NOT wire this stateful path** — a bridged ACP grant does not self-retract on count exhaustion (ACP has no usage counter; the bridge keeps `odrl:count` one-shot/unmappable, see the mapping table). This feature is the evaluator + store seam such a bridge would build on.
+
 ## Bridge to WAC/ACP enforcement (opt-in `odrl-bridge`) — [OPUS-4.8] sq-h3uk
 
 `sparq-solid` can **materialize** a matched ODRL permission into its `<urn:sparq:auth>` AUTH_GRAPH so the existing graph-level WAC/ACP enforcement applies it — **no new enforcement engine**. Behind the off-by-default `odrl-bridge` cargo feature on `sparq-solid` (it pulls in `sparq-policy` only when enabled; the default solid build stays ODRL-free). This is the **single-node** bridge of epic sq-3183, **research-track**, NOT the (gated) federated/ZK-disclosure path.
@@ -145,7 +165,7 @@ store.materialize_odrl_permission_conditional(&policy, &req); // policy: recipie
 | `odrl:recipient` / `odrl:assignee` | `neq` / order | "everyone EXCEPT" needs a per-session `noneOf` | ❌ no faithful single-grant analogue | **one-shot** (frozen) |
 | `odrl:purpose` | any | (none — a client app ≠ a purpose-of-use) | ❌ ACP session carries no purpose dimension; client-matcher would over-grant | **one-shot** (frozen) |
 | `odrl:dateTime` / time window | `lteq` / `lt` / `gteq` / `gt` | (none — matcher accept-sets are static; no "now") | ❌ ACP has no clock dimension to re-check | **one-shot** (frozen) |
-| `odrl:count` | any | (none — ACP is stateless) | ❌ no usage counter exists | **one-shot** (frozen) |
+| `odrl:count` | any | (none — ACP is stateless; no per-session usage counter) | ❌ in the bridge | **one-shot** (frozen) in the bridge — stateful enforcement lives in `sparq-policy`'s `count-enforcement` feature (`evaluate_and_exercise`), not yet wired through ACP |
 | any unrecognised left-operand | any | (none) | ❌ | **one-shot** (frozen) |
 | *no constraint* | — | `auth:agent auth:Public` (action/target/duties already held) | ✅ | persisted (public) |
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements bead **sq-zi5w**: stateful `odrl:count` usage-counter enforcement. OPT-IN policy feature, following the established three-valued / fail-closed constraint pattern (sq-q56r purpose, sq-2pcf deny-retraction).

## What this adds

`odrl:count` limits the **number of times** a permission may be exercised ("read at most 5 times"). Unlike the stateless constraints (purpose, dateTime, recipient — a single test against request evidence), this is **stateful**: the count lives in a usage counter persisting across requests. Behind the off-by-default **`count-enforcement`** feature on `sparq-policy`:

- **`UsageCounterStore`** — injectable persistence-seam trait; in-memory default `InMemoryCounterStore`. Budget key `(rule_id, party, target)` (`CountKey`) — per-assignee, per-asset, per-rule.
- **`evaluate_and_exercise(&policy, &request, &store)`** — runs the **real** `evaluate` decision (count constraints stripped from permissions for the base check; everything else — action/target/assignee, prohibitions, purpose, dateTime, recipient, duties — checked unchanged) and, on a grant, **atomically consumes** one unit of budget. First *N* exercises grant; the *(N+1)*th denies; a denied request burns **no** budget. `lteq N`/`eq N` = at most *N*; `lt N` = at most *N-1*.
- **`count_status`** — side-effect-free audit surface (`Satisfied{consumed,limit}` / `DefinitelyUnsatisfied{..}` / `Unprovable` / `NotConstrained`), the count dual of `purpose_status`.

## The honesty points

- **Wired end-to-end through the real evaluator** — not a parallel decision path. Granting requires the base `evaluate` to grant AND count budget to remain.
- **Atomicity / concurrency boundary (documented):** the single mutating op is the atomic `try_consume` (check-and-consume under one lock), **not** a read-then-increment pair — closing the in-process TOCTOU race. A concurrency test asserts exactly the limit is granted under 16 threads × 50 attempts, never one more. The in-memory store is atomic **in-process only**; a distributed backend must honour the same contract (deferred bead for cross-process atomicity, and a narrow multi-limit pre-check→consume window).
- **Fail-closed:** an unavailable counter or a malformed limit DENIES — never silently "unlimited".
- **Deferred, not claimed:** the stateless ODRL→ACP bridge does **not** wire this stateful path (a bridged ACP grant does not self-retract on exhaustion — ACP has no usage counter). The bridge keeps `odrl:count` one-shot/unmappable; this feature is the evaluator + store seam such a bridge would build on. Documented in all three docs.

## Gates (green BOTH feature states)

`cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` for **sparq-policy** (feature off + `count-enforcement`) and **sparq-solid** (feature off + `odrl-bridge`). 10 new count tests through the real path: N-grant/(N+1)-deny for `lteq`/`lt`/`eq`; denied-request-burns-nothing; per-(party,target) isolation; counter-unavailable fail-closed; malformed-limit fail-closed; `count_status` no-consume; concurrency/atomicity.

## Docs

`crates/sparq-policy/README.md`, `crates/sparq-solid/README.md`, `skills/usage-control-policy/SKILL.md` — count enforcement, the counter-store seam, and the concurrency boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
