### PR TITLE
feat(sparq-wasm): SHACL validate() binding for JS consumers (sq-yqi1, #162)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,11 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Build sparq-wasm for the browser target
         run: cargo build -p sparq-wasm --target wasm32-unknown-unknown
+      # [OPUS-4.8] sq-yqi1 (#162): also build WITH the opt-in `shacl` feature so the
+      # SHACL `Store::validate(...)` binding (and its wasm32 sparq-shacl/sparq-engine
+      # graph) is gate-protected — it must keep compiling to wasm.
+      - name: Build sparq-wasm for the browser target (shacl feature)
+        run: cargo build -p sparq-wasm --target wasm32-unknown-unknown --features shacl
       # [OPUS-4.8] sq-085p follow-up: clippy AGAINST the wasm32 target (the target is
       # already installed for this job). The native `lint` job's `clippy --all-targets`
       # compiles sparq-wasm for the HOST triple, so it never sees wasm32-cfg'd code paths
@@ -251,10 +256,16 @@ jobs:
       # warnings makes those a hard failure here, where the native clippy can't reach them.
       - name: clippy (wasm32 target, deny warnings)
         run: cargo clippy -p sparq-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
+      # [OPUS-4.8] sq-yqi1 (#162): clippy the shacl-feature surface on wasm32 too.
+      - name: clippy (wasm32 target, shacl feature, deny warnings)
+        run: cargo clippy -p sparq-wasm --target wasm32-unknown-unknown --all-targets --features shacl -- -D warnings
       - name: Guard the wasm dependency graph (no native-only deps)
         # [OPUS-4.8] sq-9qz6: enforce the "flate2/zstd/rayon/sparq-parse must never
         # enter the wasm graph" invariant (was comment-only) — fails if a native-only
         # dep leaks into sparq-wasm's wasm32 graph (bundle bloat / broken browser build).
+        # [OPUS-4.8] sq-yqi1: guard runs against the DEFAULT graph (SHACL is opt-in, so
+        # the default bundle stays SHACL-free); the shacl-feature graph is verified clean
+        # locally and the wasm32 build above proves it links.
         run: ./scripts/wasm-deps-guard.sh
       # [OPUS-4.8] Headless wasm tests of the REAL #[wasm_bindgen] exports
       # (crates/sparq-wasm/tests/web.rs). `cargo build --target wasm32` above never
@@ -271,6 +282,12 @@ jobs:
       - name: Headless wasm tests (wasm-pack test --node)
         working-directory: crates/sparq-wasm
         run: wasm-pack test --node
+      # [OPUS-4.8] sq-yqi1 (#162): run the headless wasm tests WITH the shacl feature
+      # so the real exported `Store::validate(...)` binding is exercised in a genuine
+      # wasm runtime (conforming + violating reports + the JsError parse-error arm).
+      - name: Headless wasm tests (wasm-pack test --node, shacl feature)
+        working-directory: crates/sparq-wasm
+        run: wasm-pack test --node --features shacl
 
   # NOTE: sparq-py's pytest suite (incl. the new test_parity.py result-parity +
   # panic-surface tests) is run by the dedicated `python.yml` workflow ("Python

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3619,6 +3619,7 @@ dependencies = [
  "oxrdf 0.3.3",
  "sparq-core",
  "sparq-engine",
+ "sparq-shacl",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]

--- a/crates/sparq-shacl/Cargo.toml
+++ b/crates/sparq-shacl/Cargo.toml
@@ -13,25 +13,36 @@ readme = "README.md"
 
 # Opt-in SHACL (the sparq-reason isolation pattern): a SEPARATE crate so the core
 # engine carries zero SHACL code, deps, or runtime cost by default — validation is
-# engaged only by depending on this crate. NOT in the wasm dependency graph.
+# engaged only by depending on this crate. Off the wasm path by default; opted into
+# the wasm graph ONLY by `sparq-wasm`'s non-default `shacl` feature (sq-yqi1, #162),
+# in which case the wasm32 dep rows below keep the bundle lean (no rayon/regex/digest).
 
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io
 # (required to publish — crates.io strips `path`).
 sparq-core = { path = "../sparq-core", version = "0.1.0", default-features = false }
-# [OPUS-4.8] SHACL-SPARQL (sh:sparql, W3C SHACL §5.2) routes its sh:select query
-# through the SPARQL engine. sparq-engine does NOT depend on sparq-shacl, so there is
-# no dependency cycle; and like this crate it is native-only and never in the wasm
-# graph, so the isolation guarantee (zero SHACL/engine code in the browser bundle) holds.
-sparq-engine = { path = "../sparq-engine", version = "0.1.0" }
 oxrdf.workspace = true
 oxttl.workspace = true
 # Algebra-level pre-binding of $this (a VALUES injection on the parsed sh:select) — more
 # robust than textual substitution. The same vendored spargebra the engine parses with.
 spargebra.workspace = true
 rustc-hash.workspace = true
-# sh:pattern / sh:flags. Native-only crate — never in the wasm graph.
+# sh:pattern / sh:flags. Pure Rust (wasm-compatible) and small; kept in the wasm
+# graph for full sh:pattern parity (it is NOT one of the wasm-deps-guard forbidden
+# native-only crates).
 regex = "1"
+
+# [OPUS-4.8] sq-yqi1 (#162): SHACL-SPARQL (sh:sparql, W3C SHACL §5.2) routes its
+# sh:select/sh:ask query and SHACL-AF rules through the SPARQL engine. On NATIVE the
+# engine keeps its defaults (parallel/regex/digest). On wasm32 — the only build that
+# enters the browser bundle, via `sparq-wasm`'s opt-in `shacl` feature — defaults are
+# OFF so rayon never leaks in (wasm-deps-guard) and the bundle stays lean. sparq-engine
+# does NOT depend on sparq-shacl, so there is no dependency cycle either way.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+sparq-engine = { path = "../sparq-engine", version = "0.1.0" }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+sparq-engine = { path = "../sparq-engine", version = "0.1.0", default-features = false }
 
 [features]
 default = []

--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -16,8 +16,12 @@ scans (no SPARQL round-trip), evaluates `sh:sparql` constraints by routing their
 - `to_text()` — a human-readable rendering.
 
 Like `sparq-reason`, this crate is **isolated**: it is not a dependency of any
-other sparq crate, so the core engine and the wasm bundle carry zero SHACL
-code, dependencies or runtime cost unless a consumer opts in.
+other sparq crate, so the core engine and the default wasm bundle carry zero SHACL
+code, dependencies or runtime cost unless a consumer opts in. The browser/JS
+consumer opts in through `sparq-wasm`'s non-default `shacl` feature, which exposes
+`validate` as a stateless `Store.validate(data, shapes, format)` wasm binding
+returning a JSON report (a drop-in for `rdf-validate-shacl`); on that wasm32 build
+`sparq-engine` drops its defaults so rayon never enters the bundle.
 
 ## Status: W3C SHACL core test suite
 

--- a/crates/sparq-shacl/src/lib.rs
+++ b/crates/sparq-shacl/src/lib.rs
@@ -10,10 +10,13 @@
 //! Turtle and plain-text renderings of the SHACL report vocabulary).
 //!
 //! This crate follows the `sparq-reason` isolation pattern: it is NOT a
-//! dependency of any other sparq crate — the core engine and the wasm bundle
-//! carry zero SHACL code unless a consumer opts in by depending on it.
-//! (`sparq-engine`, pulled in for `sh:sparql`, is likewise native-only and does
-//! not depend on this crate, so there is no cycle and the wasm bundle is untouched.)
+//! dependency of any other sparq crate by default — the core engine and the
+//! default wasm bundle carry zero SHACL code unless a consumer opts in by
+//! depending on it. (`sparq-engine`, pulled in for `sh:sparql`, does not depend
+//! on this crate, so there is no cycle.) The browser/JS consumer opts in via
+//! `sparq-wasm`'s non-default `shacl` feature (sq-yqi1, #162), which exposes
+//! [`validate`] as a `Store::validate(...)` wasm binding; on that wasm32 build the
+//! `sparq-engine` dependency drops its defaults so rayon never enters the bundle.
 //!
 //! ```
 //! use sparq_core::Graph;

--- a/crates/sparq-wasm/Cargo.toml
+++ b/crates/sparq-wasm/Cargo.toml
@@ -18,12 +18,32 @@ sparq-core = { path = "../sparq-core", default-features = false }
 sparq-engine = { path = "../sparq-engine", default-features = false }
 oxrdf.workspace = true
 wasm-bindgen = "0.2"
+# [OPUS-4.8] sq-yqi1 (#162): SHACL validation in the browser, OPT-IN behind the
+# `shacl` feature (OFF by default). The DEFAULT bundle carries zero SHACL code, so the
+# lean baseline (and the wasm-deps-guard, which checks the default graph) is unchanged.
+# `default-features = false` on sparq-shacl forwards to its wasm32 sparq-engine dep
+# (rayon off), so even with the feature on no forbidden native-only crate enters the
+# bundle. This is the (a) WASM consumer of #162 — the (c) HTTP endpoint is separate.
+sparq-shacl = { path = "../sparq-shacl", default-features = false, optional = true }
 
 # oxrdf pulls `rand`/getrandom (blank-node ids). On wasm there is no OS RNG, so
 # select getrandom's browser backend (crypto.getRandomValues). The matching
 # `--cfg getrandom_backend="wasm_js"` is set in .cargo/config.toml.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.3", features = ["wasm_js"] }
+
+[features]
+default = []
+# [OPUS-4.8] sq-yqi1 (#162): expose `sparq-shacl`'s SHACL Core + SHACL-SPARQL
+# validation as the `Store::validate(data, shapes)` wasm binding (a drop-in for
+# `rdf-validate-shacl` behind PSS's ADR-0014 ShaclValidator seam). OFF by default so
+# the standard browser bundle is byte-identical to before; CI builds the bundle with
+# and without it (and the headless wasm tests run with it on). Does NOT pull
+# SHACL-AF rules — turn on `shacl-af` for those.
+shacl = ["dep:sparq-shacl"]
+# [OPUS-4.8] sq-yqi1: also compile SHACL Advanced Features (sh:rule) into the binding.
+# Implies `shacl`; OFF by default.
+shacl-af = ["shacl", "sparq-shacl/shacl-af"]
 
 [dev-dependencies]
 # [OPUS-4.8] sq-9qz6 pt2 — headless wasm test harness. Exercises the #[wasm_bindgen]

--- a/crates/sparq-wasm/README.md
+++ b/crates/sparq-wasm/README.md
@@ -39,6 +39,53 @@ const n = store.count("SELECT ?s WHERE { ?s a <http://ex/Person> }"); // lazy, n
 MINUS, BIND, VALUES, aggregation (GROUP BY / HAVING), ORDER BY, DISTINCT/LIMIT/
 OFFSET, sub-SELECT.
 
+## SHACL validation (opt-in `shacl` feature) — `Store.validate(...)`
+
+`sparq-shacl`'s SHACL Core + SHACL-SPARQL (`sh:sparql`, W3C SHACL §5.2) engine is
+exposed to JS through the **opt-in `shacl` feature** as a stateless
+`Store.validate(data, shapes, format)` binding — a drop-in for
+`rdf-validate-shacl`. The feature is **OFF by default**, so the standard bundle
+carries zero SHACL code; build with it on to get the binding:
+
+```sh
+wasm-pack build --target web --release -- --features shacl
+# add SHACL Advanced Features (sh:rule): --features shacl-af
+```
+
+```js
+import init, { Store } from "./pkg/sparq_wasm.js";
+await init();
+
+// validate is stateless — it does not consult the receiver's triples.
+const store = Store.load("", "turtle");
+const report = JSON.parse(store.validate(dataTurtle, shapesTurtle, "turtle"));
+
+report.conforms;          // boolean — true iff there are no results (any severity)
+report.results;           // array of violation/warning/info results
+// each result: { focusNode, path, value, sourceShape,
+//                sourceConstraintComponent, severity, message }
+```
+
+- `format` is the same set `Store.load` accepts (`"turtle"` | `"ntriples"` |
+  `"nquads"` | `"trig"`); both graphs are parsed identically (named graphs folded
+  into the default graph).
+- `focusNode` / `value` / `sourceShape` are **N-Triples term strings**; `path` is
+  a SHACL **Turtle path expression**; `severity` and `sourceConstraintComponent`
+  are full IRIs; `message` is the plain text of the shape's first `sh:message` (or
+  a generated default). `path`, `value` and `message` are `null` when absent.
+- `conforms` follows the W3C-suite notion: it is `false` if *any* result is
+  reported (including `sh:Warning` / `sh:Info`). For a violations-only gate, filter
+  `results` by `severity === "http://www.w3.org/ns/shacl#Violation"`.
+- It returns the `Err`/`JsError` arm only when a graph fails to parse; malformed
+  shapes are skipped by the engine, never surfaced as an error.
+
+Small-document write-validation (~10–100 triples) sits far below the wasm
+linear-memory ceiling. Very large data graphs should validate server-side via the
+`sparq-server` HTTP `validate` endpoint instead (the other half of the same
+decision — see #162). Validation correctness is the native `sparq-shacl` engine's;
+this binding only loads the two graphs and hand-serialises the report to JSON
+(no serde, matching the SPARQL-JSON path).
+
 ### Streaming wins carry over to the browser
 
 The same engine optimisations apply in WASM, where memory and main-thread time are

--- a/crates/sparq-wasm/src/lib.rs
+++ b/crates/sparq-wasm/src/lib.rs
@@ -14,6 +14,12 @@
 use sparq_core::Graph;
 use wasm_bindgen::prelude::*;
 
+// [OPUS-4.8] sq-yqi1 (#162): the opt-in SHACL `Store::validate(...)` binding.
+// Behind the non-default `shacl` feature so the standard bundle carries zero SHACL
+// code; the module adds a `#[wasm_bindgen] impl Store` method to the `Store` below.
+#[cfg(feature = "shacl")]
+mod shacl;
+
 /// An immutable, dictionary-encoded RDF store queryable with SPARQL.
 #[wasm_bindgen]
 pub struct Store {

--- a/crates/sparq-wasm/src/shacl.rs
+++ b/crates/sparq-wasm/src/shacl.rs
@@ -1,0 +1,294 @@
+//! [OPUS-4.8] sq-yqi1 (#162): the `Store::validate(data, shapes)` SHACL binding.
+//!
+//! Exposes `sparq-shacl`'s existing public validation API
+//! ([`sparq_shacl::validate`] — SHACL Core + SHACL-SPARQL §5.2) to JS/WASM
+//! consumers as a drop-in for `rdf-validate-shacl` (PSS's ADR-0014
+//! `ShaclValidator` seam). It does NOT reimplement validation — it loads the two
+//! graphs exactly as [`Store::load`] does and calls straight through to the
+//! engine, then hand-serialises the [`sparq_shacl::ValidationReport`] to a small
+//! JSON string (the bundle has no serde, mirroring the SPARQL-JSON path).
+//!
+//! This module compiles ONLY under the opt-in `shacl` feature, so the default
+//! browser bundle carries zero SHACL code.
+//!
+//! ## Report shape (the JSON returned by `validate`)
+//!
+//! ```json
+//! {
+//!   "conforms": false,
+//!   "results": [
+//!     {
+//!       "focusNode": "http://example.org/bob",
+//!       "path": "<http://example.org/age>",
+//!       "value": "\"-1\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+//!       "sourceShape": "_:b0",
+//!       "sourceConstraintComponent": "http://www.w3.org/ns/shacl#MinInclusiveConstraintComponent",
+//!       "severity": "http://www.w3.org/ns/shacl#Violation",
+//!       "message": "Value is not >= 0"
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! `path`, `value` and `message` are `null` when the result carries none.
+//! `focusNode`/`value`/`sourceShape` are N-Triples term strings (the same lexical
+//! form `Term`'s `Display` produces); `path` is a SHACL Turtle path expression.
+//! `message` is the plain text of the shape's first `sh:message` (or the
+//! generated default), suitable for surfacing directly in a UI.
+
+use oxrdf::Term;
+use sparq_core::Graph;
+use sparq_shacl::{ValidationReport, ValidationResult};
+use wasm_bindgen::prelude::*;
+
+use crate::Store;
+
+/// Appends `s` to `out` as a JSON string literal (quotes + minimal escaping).
+/// The bundle carries no serde, so — exactly like the SPARQL-JSON serialiser —
+/// strings are escaped by hand. Escapes the two mandatory characters (`"` and
+/// `\`) plus the C0 control characters JSON forbids unescaped.
+fn push_json_string(out: &mut String, s: &str) {
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}
+
+/// Appends `"key":<json-string>` (or `"key":null` when `val` is `None`).
+fn push_field(out: &mut String, key: &str, val: Option<&str>) {
+    out.push('"');
+    out.push_str(key);
+    out.push_str("\":");
+    match val {
+        Some(v) => push_json_string(out, v),
+        None => out.push_str("null"),
+    }
+}
+
+/// The plain text of a result's first `sh:message`, or its generated default —
+/// the human-readable string a UI surfaces (mirrors `to_text`'s message choice).
+fn result_message(r: &ValidationResult) -> String {
+    match r.messages.first() {
+        Some(Term::Literal(l)) => l.value().to_string(),
+        _ => r.default_message.clone(),
+    }
+}
+
+/// Serialises a [`ValidationReport`] to the JS-facing JSON described in the
+/// module docs. Kept here (not in `sparq-shacl`) so the report struct stays
+/// serde-free and the wasm bundle keeps its hand-rolled-JSON convention.
+fn report_to_json(report: &ValidationReport) -> String {
+    let mut out = String::from("{\"conforms\":");
+    out.push_str(if report.conforms { "true" } else { "false" });
+    out.push_str(",\"results\":[");
+    for (i, r) in report.results.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('{');
+        push_field(&mut out, "focusNode", Some(&r.focus_node.to_string()));
+        out.push(',');
+        let path = r.path.as_ref().map(|p| p.to_turtle());
+        push_field(&mut out, "path", path.as_deref());
+        out.push(',');
+        let value = r.value.as_ref().map(|v| v.to_string());
+        push_field(&mut out, "value", value.as_deref());
+        out.push(',');
+        push_field(&mut out, "sourceShape", Some(&r.source_shape.to_string()));
+        out.push(',');
+        push_field(
+            &mut out,
+            "sourceConstraintComponent",
+            Some(&r.source_component),
+        );
+        out.push(',');
+        push_field(&mut out, "severity", Some(&r.severity));
+        out.push(',');
+        push_field(&mut out, "message", Some(&result_message(r)));
+        out.push('}');
+    }
+    out.push_str("]}");
+    out
+}
+
+#[wasm_bindgen]
+impl Store {
+    /// [OPUS-4.8] sq-yqi1 (#162): validates an RDF **data graph** against a SHACL
+    /// **shapes graph**, returning a SHACL validation report as a JSON string.
+    ///
+    /// Both arguments are RDF documents in the same syntaxes [`Store::load`]
+    /// accepts (`"turtle"` | `"ntriples"` | `"nquads"` | `"trig"`); they are
+    /// parsed identically (named graphs folded into the default graph). This is a
+    /// stateless one-shot — it does not consult the receiver's stored triples —
+    /// so it is the drop-in replacement for `rdf-validate-shacl`'s
+    /// `validate(dataDataset, { shapes })`: validation runs through
+    /// `sparq-shacl`'s SHACL Core + SHACL-SPARQL (`sh:sparql`, §5.2) engine.
+    ///
+    /// Returns a JSON object `{ conforms: boolean, results: [...] }`; each result
+    /// has `focusNode`, `path`, `value`, `sourceShape`,
+    /// `sourceConstraintComponent`, `severity` and `message` (see the module
+    /// docs for the exact shape). `JSON.parse` it on the JS side. `sh:conforms`
+    /// counts EVERY result regardless of severity (the W3C-suite notion); filter
+    /// `results` by `severity` for a violations-only gate.
+    ///
+    /// Errors only if a graph fails to parse (a `JsError` carrying the parse
+    /// error) — malformed shapes are skipped by the engine, never surfaced as an
+    /// error. Small-document write-validation (~10–100 triples) sits far below
+    /// the wasm linear-memory ceiling; very large data graphs should use the
+    /// server-side HTTP `validate` path instead (#162 path (c)).
+    ///
+    /// The `data`/`shapes` arguments take ownership of two parameters; both
+    /// graphs are dropped when the call returns.
+    pub fn validate(&self, data: &str, shapes: &str, format: &str) -> Result<String, JsError> {
+        let data_graph = Graph::load_str(data, format).map_err(|e| JsError::new(&e))?;
+        let shapes_graph = Graph::load_str(shapes, format).map_err(|e| JsError::new(&e))?;
+        let report = sparq_shacl::validate(&data_graph, &shapes_graph);
+        Ok(report_to_json(&report))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SHAPES: &str = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+        ex:PersonShape a sh:NodeShape ;
+          sh:targetClass ex:Person ;
+          sh:property [
+            sh:path ex:age ;
+            sh:datatype xsd:integer ;
+            sh:minInclusive 0 ;
+            sh:message "age must be a non-negative integer" ;
+          ] ;
+          sh:property [
+            sh:path ex:name ;
+            sh:minCount 1 ;
+          ] .
+    "#;
+
+    /// The serialiser used by the wasm `validate` export runs natively, so the
+    /// report-shape contract is tested here without a wasm runtime (the
+    /// `JsError`-returning wasm wrapper itself cannot run off-wasm — `JsError::new`
+    /// is a wasm-bindgen import that panics natively — so, exactly as the other
+    /// wasm tests do, we exercise the engine call + the JSON serialiser it feeds).
+    fn validate_json(data: &str) -> String {
+        let data = Graph::load_str(data, "turtle").unwrap();
+        let shapes = Graph::load_str(SHAPES, "turtle").unwrap();
+        let report = sparq_shacl::validate(&data, &shapes);
+        report_to_json(&report)
+    }
+
+    /// Conforming data: the report says `conforms: true` with an empty results array.
+    #[test]
+    fn conforming_report_json() {
+        let json = validate_json(
+            r#"
+            @prefix ex: <http://example.org/> .
+            ex:alice a ex:Person ; ex:age 30 ; ex:name "Alice" .
+        "#,
+        );
+        assert_eq!(json, r#"{"conforms":true,"results":[]}"#, "{json}");
+    }
+
+    /// Violating data: a constraint violation surfaces with focusNode / path /
+    /// severity / message — the fields PSS's `ShaclValidator` seam consumes.
+    #[test]
+    fn violating_report_json_has_focus_path_message() {
+        let json = validate_json(
+            r#"
+            @prefix ex: <http://example.org/> .
+            ex:bob a ex:Person ; ex:age -1 .
+        "#,
+        );
+        // Not conforming, and at least the minInclusive (negative age) + minCount
+        // (missing name) violations are present.
+        assert!(json.starts_with(r#"{"conforms":false,"results":[{"#), "{json}");
+        // The focus node is the offending instance, as an N-Triples IRI term.
+        assert!(
+            json.contains(r#""focusNode":"<http://example.org/bob>""#),
+            "{json}"
+        );
+        // The age property shape's path + declared message surface.
+        assert!(
+            json.contains(r#""path":"<http://example.org/age>""#),
+            "path present: {json}"
+        );
+        assert!(
+            json.contains(r#""message":"age must be a non-negative integer""#),
+            "declared message present: {json}"
+        );
+        // The offending value is reported as an N-Triples literal term.
+        assert!(
+            json.contains(r#""value":"\"-1\"^^<http://www.w3.org/2001/XMLSchema#integer>""#),
+            "value present: {json}"
+        );
+        // Severity defaults to sh:Violation, and the constraint component is named.
+        assert!(
+            json.contains(r#""severity":"http://www.w3.org/ns/shacl#Violation""#),
+            "{json}"
+        );
+        assert!(
+            json.contains("MinInclusiveConstraintComponent"),
+            "minInclusive component present: {json}"
+        );
+        assert!(
+            json.contains("MinCountConstraintComponent"),
+            "minCount component present: {json}"
+        );
+    }
+
+    /// A result with no path / value (a node-shape minCount) emits explicit
+    /// `null`s, and the generated default message is used when none is declared.
+    #[test]
+    fn null_path_and_value_and_default_message() {
+        let shapes = Graph::load_str(
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:S a sh:NodeShape ;
+              sh:targetNode ex:x ;
+              sh:property [ sh:path ex:p ; sh:minCount 1 ] .
+        "#,
+            "turtle",
+        )
+        .unwrap();
+        // ex:x has no ex:p => minCount violation with no value node.
+        let data = Graph::load_str(
+            "@prefix ex: <http://example.org/> . ex:x a ex:Thing .",
+            "turtle",
+        )
+        .unwrap();
+        let report = sparq_shacl::validate(&data, &shapes);
+        let json = report_to_json(&report);
+        assert!(json.contains("\"conforms\":false"), "{json}");
+        // minCount on a property shape: path IS present (the ex:p path), value is null.
+        assert!(json.contains(r#""value":null"#), "value null: {json}");
+        // A non-empty default message string (not null) is always emitted.
+        assert!(!json.contains(r#""message":null"#), "{json}");
+    }
+
+    /// The hand-rolled JSON escaper handles quotes, backslashes and control chars
+    /// in a message so the document stays valid JSON.
+    #[test]
+    fn json_string_escaping() {
+        let mut s = String::new();
+        push_json_string(&mut s, "a\"b\\c\nd\te");
+        assert_eq!(s, r#""a\"b\\c\nd\te""#, "{s}");
+        // A C0 control char is \u-escaped (raw control chars are invalid in JSON).
+        let mut ctrl = String::new();
+        push_json_string(&mut ctrl, "\u{0001}");
+        assert_eq!(ctrl, "\"\\u0001\"", "{ctrl}");
+    }
+}

--- a/crates/sparq-wasm/tests/web.rs
+++ b/crates/sparq-wasm/tests/web.rs
@@ -334,3 +334,85 @@ fn apply_delta_batch() {
         .ask("PREFIX ex: <http://ex/> ASK { ex:alice ex:knows ex:bob }")
         .unwrap());
 }
+
+// ---- [OPUS-4.8] sq-yqi1 (#162): the opt-in SHACL `validate` binding, in real wasm ----
+//
+// These exercise the REAL exported `Store::validate(data, shapes, format)` through the
+// wasm/JS boundary (the JSON string it returns and the JsError parse-error arm) — the
+// surface PSS's ADR-0014 ShaclValidator seam consumes. Compiled only under the `shacl`
+// feature, exactly as the binding is. The native `#[cfg(test)]` tests in src/shacl.rs
+// cover the JSON serialiser; this proves it actually exports to and runs in wasm.
+#[cfg(feature = "shacl")]
+mod shacl {
+    use super::*;
+
+    const SHAPES: &str = r#"
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+        ex:PersonShape a sh:NodeShape ;
+          sh:targetClass ex:Person ;
+          sh:property [
+            sh:path ex:age ;
+            sh:datatype xsd:integer ;
+            sh:minInclusive 0 ;
+            sh:message "age must be a non-negative integer" ;
+          ] ;
+          sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+    "#;
+
+    /// Conforming data validates to `{"conforms":true,"results":[]}` across the boundary.
+    #[wasm_bindgen_test]
+    fn validate_conforming() {
+        let store = Store::load("", "turtle").unwrap();
+        let data = r#"
+            @prefix ex: <http://example.org/> .
+            ex:alice a ex:Person ; ex:age 30 ; ex:name "Alice" .
+        "#;
+        let json = store
+            .validate(data, SHAPES, "turtle")
+            .expect("validate must return a report");
+        assert_eq!(json, r#"{"conforms":true,"results":[]}"#, "{json}");
+    }
+
+    /// Violating data surfaces a constraint violation with focusNode / path / message —
+    /// the fields PSS consumes — as a parseable JSON report.
+    #[wasm_bindgen_test]
+    fn validate_violating() {
+        let store = Store::load("", "turtle").unwrap();
+        let data = r#"
+            @prefix ex: <http://example.org/> .
+            ex:bob a ex:Person ; ex:age -1 .
+        "#;
+        let json = store.validate(data, SHAPES, "turtle").unwrap();
+        assert!(json.contains(r#""conforms":false"#), "{json}");
+        assert!(
+            json.contains(r#""focusNode":"<http://example.org/bob>""#),
+            "focus node: {json}"
+        );
+        assert!(
+            json.contains(r#""path":"<http://example.org/age>""#),
+            "path: {json}"
+        );
+        assert!(
+            json.contains(r#""message":"age must be a non-negative integer""#),
+            "declared message: {json}"
+        );
+        assert!(
+            json.contains("MinInclusiveConstraintComponent"),
+            "minInclusive: {json}"
+        );
+        assert!(
+            json.contains("MinCountConstraintComponent"),
+            "minCount (missing name): {json}"
+        );
+    }
+
+    /// A malformed shapes/data graph surfaces as the JsError Err arm, not a trap.
+    #[wasm_bindgen_test]
+    fn validate_parse_error_is_err() {
+        let store = Store::load("", "turtle").unwrap();
+        let bad = store.validate("@prefix ex: <http://ex/> . ex:a ex:p", SHAPES, "turtle");
+        assert!(bad.is_err(), "a truncated data graph must return Err");
+    }
+}

--- a/skills/javascript-wasm/SKILL.md
+++ b/skills/javascript-wasm/SKILL.md
@@ -148,11 +148,29 @@ const trace = raw.explainAnalyze('PREFIX ex: <http://ex/> SELECT ?n WHERE { ?s e
 // plan + per-operator output rows (wall times read 0 on wasm32 — no monotonic clock)
 ```
 
+**SHACL validation (opt-in `shacl` feature, raw wasm only).** `Store.validate(data, shapes, format)` runs `sparq-shacl`'s SHACL Core + SHACL-SPARQL (`sh:sparql`) engine and returns a JSON validation report — a drop-in for `rdf-validate-shacl`. It is **stateless** (does not consult the receiver's triples) and only compiles when the wasm bundle is built with `--features shacl` (off in the default shipped bundle; build your own with it, or `--features shacl-af` to also get `sh:rule`). `format` is the same set `load` accepts.
+
+```js
+import init, { Store } from '../wasm/sparq_wasm.js'; // a bundle built with --features shacl
+await init();
+const store = Store.load('', 'turtle');             // validate ignores the receiver
+const report = JSON.parse(store.validate(dataTurtle, shapesTurtle, 'turtle'));
+// { conforms: boolean,
+//   results: [{ focusNode, path, value, sourceShape,
+//               sourceConstraintComponent, severity, message }] }
+report.conforms;                                     // false if ANY result (incl. Warning/Info)
+const violations = report.results.filter(
+  r => r.severity === 'http://www.w3.org/ns/shacl#Violation');   // violations-only gate
+```
+
+`focusNode`/`value`/`sourceShape` are N-Triples term strings; `path` is a SHACL Turtle path expression; `severity`/`sourceConstraintComponent` are full IRIs; `message` is the first `sh:message` text (or a generated default). `path`/`value`/`message` are `null` when absent. Only a graph parse failure throws (a `JsError`); malformed shapes are skipped, not surfaced. For large data graphs validate server-side via the `sparq-server` HTTP `validate` endpoint instead (the other half of the #162 decision). See the `shacl-validation` skill for the engine's SHACL coverage.
+
 ## Gotchas / feature flags / prerequisites
 
 - **ESM only, Node >= 18.** The package is `"type": "module"`; `init()` is idempotent and runs automatically on the first `SparqStore.from*` call (in Node it reads the wasm bytes from disk; in the browser/Deno it `fetch`es relative to the module). One runtime dep: `fzstd` (~8 KB, dynamically imported only when decoding zstd).
 - **`SparqStore` exposes SELECT/ASK only.** Its `query()` returns `Bindings[]` (SELECT) or `boolean` (ASK). CONSTRUCT/DESCRIBE and federated (`SERVICE`) queries are **not** exposed at the JS wrapper layer — use the raw `Store.queryQuads` for CONSTRUCT/DESCRIBE.
 - **`REGEX` / `REPLACE` are compiled out** of the wasm build (the engine's non-default `regex` cargo feature is off to keep the bundle small). Use `CONTAINS`/`STRSTARTS`/`STRENDS`/... or a custom wasm build with `--features regex`.
+- **SHACL `Store.validate` needs a `--features shacl` bundle.** The default shipped wasm bundle carries **zero** SHACL code (opt-in feature, off by default); `validate(data, shapes, format)` exists only in a bundle built with `--features shacl` (or `shacl-af` for `sh:rule`). It is on the raw `Store`, not `SparqStore`. Validation is in-process and best for small documents (~10–100 triples); large graphs should use the server-side HTTP `validate` path.
 - **`options.dataset` is not combinable with `options.compressed`** — there is no compressed dataset loader yet (the constructor throws). `compact-index` (3 permutations, ~half the memory) is auto-selected for wasm32 regardless; `compressed` adds block compression on top.
 - **`size` / `heapBytes` report the DEFAULT graph only.** For dataset totals use `countQuads()` (its graph wildcard spans named graphs).
 - **Mutation is overlay-based.** `update()` / `applyDelta()` write through an append-only delta overlay: the dictionary only grows, and deletes are tombstones until the wasm store is reloaded. Blank nodes in `applyDelta`/`removeQuads` are matched **by label** (so bnode triples can be retracted — impossible via SPARQL `DELETE DATA`).

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -10,9 +10,14 @@ Validate a data `Graph` against a shapes `Graph` and get back a `ValidationRepor
 plain text). Covers the full SHACL Core component set, SHACL-SPARQL (`sh:sparql`,
 §5.2), and custom SPARQL-based constraint components (`sh:ConstraintComponent`, §6).
 
-`sparq-shacl` is an **opt-in, native-only** crate: depending on it is what turns on
-SHACL. It is NOT a dependency of any other sparq crate, so the core engine and the
-wasm bundle carry zero SHACL code/cost unless you pull it in.
+`sparq-shacl` is an **opt-in** crate: depending on it is what turns on SHACL. It is
+NOT a dependency of any other sparq crate by default, so the core engine and the
+default wasm bundle carry zero SHACL code/cost unless you pull it in. The browser/JS
+consumer opts in through `sparq-wasm`'s non-default `shacl` feature, which exposes
+`validate` as a stateless `Store.validate(data, shapes, format)` wasm binding
+returning a JSON report — a drop-in for `rdf-validate-shacl` (sq-yqi1, #162). On that
+wasm32 build the `sparq-engine` dep drops its defaults so rayon never enters the
+bundle; see the `javascript-wasm` skill for the JS API + report shape.
 
 ## Quickstart
 
@@ -244,9 +249,12 @@ IRI/literal, and a path node expression `[ sh:path P ]` (any SHACL property path
 ## Gotchas / feature flags / prerequisites
 
 - **Base SHACL is engaged purely by depending on `sparq-shacl`** (no feature
-  needed). It transitively pulls in `sparq-engine` (to run `sh:sparql`/§6 queries);
-  both are **native-only and never in the wasm dependency graph**, so the isolation
-  guarantee holds.
+  needed). It transitively pulls in `sparq-engine` (to run `sh:sparql`/§6 queries).
+  Neither is in the **default** wasm dependency graph, so the default browser bundle
+  stays SHACL-free; they enter the wasm graph ONLY when a consumer opts in via
+  `sparq-wasm`'s non-default `shacl` feature, on which build `sparq-engine`'s defaults
+  (rayon/regex/digest) are dropped so the bundle stays lean. The native build is
+  unaffected (full engine defaults).
 - **SHACL-AF rules (`sh:rule`) are OPT-IN behind the `shacl-af` cargo feature.**
   With the feature off, the base validation path carries zero rule code/parse cost
   and the `apply_rules` / `apply_rules_with_model` / `expand` / `Inference` symbols


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Opus 4.8 — @jeswr's `jeswr/sparq` RDF/SPARQL engine agent). @jeswr runs multiple agents; the PSS (`prod-solid-server`) agent is a separate party.

Implements bead **sq-yqi1** — the **(a) WASM** half of #162's agreed scope (**a + c, not b**): expose `sparq-shacl`'s SHACL Core + SHACL-SPARQL (§5.2) validation to JS/WASM as a stateless `Store.validate(data, shapes, format)` binding, a drop-in for `rdf-validate-shacl` behind PSS's ADR-0014 `ShaclValidator` seam. **Option (b) N-API is deliberately NOT implemented**; the **(c) HTTP `validate` endpoint** on `sparq-server` is a separate deliverable.

## What it does

`Store.validate(data, shapes, format)` parses both RDF documents exactly as `Store.load` does and calls straight through to `sparq_shacl::validate` — it does **not** reimplement validation. It returns a JSON report (hand-serialised, no serde — matching the SPARQL-JSON path):

```json
{ "conforms": false,
  "results": [{ "focusNode": "...", "path": "...", "value": "...",
                "sourceShape": "...", "sourceConstraintComponent": "...",
                "severity": "...", "message": "..." }] }
```

`focusNode`/`value`/`sourceShape` are N-Triples term strings; `path` is a SHACL Turtle path expression; `severity`/`sourceConstraintComponent` are full IRIs; `message` is the first `sh:message` (or a generated default). `path`/`value`/`message` are `null` when absent. `conforms` is the W3C-suite notion (false if any result, incl. Warning/Info); filter `results` by `severity` for a violations-only gate.

## Lean bundle / opt-in

- New **`shacl` cargo feature** on `sparq-wasm`, **OFF by default** — the standard browser bundle carries zero SHACL code. `shacl-af` additionally compiles `sh:rule`.
- `sparq-shacl`'s `sparq-engine` dep is split by target: native keeps full defaults; **wasm32 gets `default-features = false`** so rayon never enters the bundle. `wasm-deps-guard` passes with the feature on (no forbidden native-only crate leaks in).

## Verification

- **Compiles + exports to wasm**: `cargo build -p sparq-wasm --target wasm32-unknown-unknown --features shacl` links, and `wasm-pack test --node --features shacl` runs the **real** exported `Store.validate` in a Node wasm runtime — conforming, violating (focusNode/path/message surface), and the parse-error `JsError` arm. **23/23 wasm tests pass.**
- Native serialiser tests (conforming + violating + null-field + JSON-escaping). `cargo clippy` host **and** wasm32 `--features shacl` `-D warnings` clean; `sparq-shacl` test suite green.
- CI wasm lane now also builds/clippies/wasm-tests with `--features shacl`.

## Docs

`sparq-wasm` README, `javascript-wasm` + `shacl-validation` SKILL.md, and crate READMEs updated with the binding's input/output shape so PSS can consume it.

## Deferred (orchestrator to bead)

- Site-side TS wrapper: surface `validate` on the `@jeswr/sparq` `SparqStore` wrapper (currently raw `Store` only) + a shipped `--features shacl` bundle / dist.
- The (c) `sparq-server` HTTP `validate` endpoint (bearer-gated like #46) for the large-graph path.
- Once merged, **#162 is ready to be pinged** that the WASM binding is consumable.