### PR TITLE
ci: path-filter the heavy Rust matrix so non-Rust PRs merge fast (merge-throughput)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,74 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  # [OPUS-4.8] merge-throughput: path-filtered gate. Compute whether THIS change
+  # touches Rust at all, so a doc-only / compliance / CI-markdown / site PR can skip the
+  # ~15-minute Rust test matrix while the required `ci-summary / gate` still resolves
+  # SUCCESS for it. CORRECTNESS CONTRACT (the heavy jobs below `if:` on this):
+  #   • rust_changed == 'true'  -> every heavy job runs EXACTLY as before. A Rust PR can
+  #     never merge without the full matrix.
+  #   • rust_changed == 'false' -> the heavy jobs are `skipped`; the ci-summary aggregator
+  #     (ci-summary.yml) already treats a `skipped` conclusion as NON-failing
+  #     (`conclusion != "success" and != "skipped" and != "neutral"` is the only thing it
+  #     fails on), so the gate goes green fast. Fast doc/lint siblings (docs-quality, etc.)
+  #     still run and still gate.
+  # SAFE-BY-DEFAULT: rust_changed is forced 'true' on EVERY event except `pull_request`.
+  # On `push` to main (the canonical build), `merge_group` (the merge queue re-runs the
+  # whole set), `schedule`, and `workflow_dispatch` the full matrix ALWAYS runs — only a
+  # PR diff that is purely non-Rust is ever allowed to skip. The Rust path set is broad on
+  # purpose: any `*.rs`, any `Cargo.toml`, `Cargo.lock`, the `rust-toolchain*` pin, OR this
+  # workflow file itself (so editing a Rust job here re-runs that job). If the diff cannot
+  # be computed for any reason, the filter's absence of a match defaults to NOT skipping
+  # only because we hard-force 'true' off the PR path — i.e. we never silently skip Rust.
+  changes:
+    name: detect rust changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      rust_changed: ${{ steps.decide.outputs.rust_changed }}
+      # [OPUS-4.8] docker_changed is true when the SHIPPED image's inputs change but no
+      # Rust did (a Dockerfile/entrypoint/smoke-script edit). docker-smoke gates on
+      # rust_changed OR docker_changed so a Dockerfile-only PR (the sq-n6rv class of bug —
+      # the bind posture/entrypoint) still gets the image smoke even though the matrix skips.
+      docker_changed: ${{ steps.decide.outputs.docker_changed }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # Only run the path filter on pull_request; on every other event we force-run the
+      # full matrix (see decide step), so the filter's result is irrelevant there and we
+      # skip it to avoid the unreliable push/merge_group base-diff.
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain*'
+              - '.github/workflows/ci.yml'
+            docker:
+              - 'Dockerfile'
+              - '**/Dockerfile'
+              - 'scripts/docker-smoke.sh'
+              - '.github/workflows/ci.yml'
+      - name: Decide rust_changed (safe-by-default off the PR path)
+        id: decide
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # push / merge_group / schedule / workflow_dispatch -> always run the full matrix.
+            echo "rust_changed=true" >> "$GITHUB_OUTPUT"
+            echo "docker_changed=true" >> "$GITHUB_OUTPUT"
+            echo "event=${{ github.event_name }} -> forcing rust_changed=true + docker_changed=true (full matrix)"
+          else
+            echo "rust_changed=${{ steps.filter.outputs.rust }}" >> "$GITHUB_OUTPUT"
+            echo "docker_changed=${{ steps.filter.outputs.docker }}" >> "$GITHUB_OUTPUT"
+            echo "pull_request -> paths-filter says rust=${{ steps.filter.outputs.rust }} docker=${{ steps.filter.outputs.docker }}"
+          fi
+
   # [OPUS-4.8] BUILD-ONCE for the sharded test suite (sq-vyxy folded in). The old
   # design had every shard run `cargo build --workspace --all-targets` itself — the
   # 131s build FLOOR that rust-cache makes cheap for *deps* but cannot remove for
@@ -49,6 +117,8 @@ jobs:
   # once, off the warm build this job already has (was a guarded shard-1 step before).
   build-archive:
     name: build + archive test binaries (+ doctests once)
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -148,7 +218,12 @@ jobs:
     # fail-fast: false so one shard's failure does not cancel the others (we want the
     # full failure picture across the suite, not just the first shard to break).
     name: test (load-aware shard ${{ matrix.name }})
-    needs: build-archive
+    # [OPUS-4.8] needs BOTH: build-archive (artifact) AND changes (the path filter). With
+    # build-archive `if:`-skipped on a doc-only PR, this job is skipped too (a needed job
+    # was skipped) — exactly the intent. Keep the explicit `changes` need + `if:` so the
+    # skip is driven by the filter, not an incidental artifact-missing failure.
+    needs: [changes, build-archive]
+    if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     env:
       # [OPUS-4.8] THE single source of truth for the known-heavy tests. `test(=NAME)`
@@ -235,6 +310,8 @@ jobs:
 
   wasm:
     name: wasm build (sparq-wasm)
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -287,6 +364,8 @@ jobs:
     # and would have stopped the clippy gate from gating — verified by hand-tracing the
     # jq filter against every check name.)
     name: clippy (gate) + fmt (non-blocking)
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -327,6 +406,8 @@ jobs:
     #     workspace-floor pin.
     # If the root MSRV is bumped, update the `@1.88` toolchain pin below to match.
     name: MSRV check (Rust 1.88, declared floor)
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -347,6 +428,8 @@ jobs:
     # drop below the ratchet count is a conformance regression and fails CI. Never
     # lower the ratchet.
     name: W3C SPARQL conformance (ratchet >= 1229 pass+divergence)
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -401,6 +484,8 @@ jobs:
     # same `>= N` belt-and-braces check the conformance jobs use. Never lower the
     # ratchet (raise BASELINE_PASS / SHACL_SPARQL_FLOOR as coverage grows).
     name: W3C SHACL conformance (ratchet — core >= 98, sparql >= 5)
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -445,6 +530,8 @@ jobs:
     # same belt-and-braces `>= floor` gate the SHACL/SPARQL jobs use. Never lower
     # the floor (raise OGC_RATCHET_FLOOR as the corpus grows).
     name: W3C/OGC GeoSPARQL conformance (ratchet — topology pass >= 119)
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -494,6 +581,8 @@ jobs:
     # GATES exactly like the SPARQL ratchet above: a drop below the count is a
     # conformance regression and fails CI. Never lower the ratchet.
     name: Inference conformance (ratchet >= 1967 pass+divergence)
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -551,7 +640,12 @@ jobs:
     # well under the ~15-20 min budget; only the heavy sparq-vectors full set is
     # nightly. Never silently drop a crate — every exclusion is in the floor file.
     name: coverage ratchet + test-presence gate (per-crate)
-    if: github.event_name != 'schedule'
+    needs: changes
+    # [OPUS-4.8] Combine the pre-existing schedule exclusion with the rust-changed gate:
+    # the per-commit coverage tier still never runs on the nightly schedule, AND now also
+    # skips on a doc-only PR. On `push`/`merge_group` rust_changed is force-'true', so the
+    # canonical/queue coverage run is unchanged.
+    if: github.event_name != 'schedule' && needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -701,6 +795,8 @@ jobs:
     # report to break CI). Promote to a gate later only with a checked-in unsafe-count
     # ratchet (mirroring the coverage/conformance idiom) — out of scope here.
     name: unsafe report (cargo-geiger, informational)
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -739,6 +835,13 @@ jobs:
     # script against the tag's image before push. Builds with the SAME Dockerfile + buildx the
     # release job uses, so the artifact under test matches the one that ships.
     name: docker image smoke (run + curl /health + query)
+    # [OPUS-4.8] The image bakes the compiled sparq-server binary, so a Rust change can
+    # change what ships; gate on rust_changed. (A pure Dockerfile/entrypoint change also
+    # touches no `*.rs`, but the release.yml re-runs this script against the tag image
+    # before push, so a doc-only PR skipping it here is safe — the canonical push to main
+    # force-runs it, and any Dockerfile-affecting PR should accompany a build change.)
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.docker_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -57,7 +57,48 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  # [OPUS-4.8] merge-throughput: path-filtered gate (same pattern as ci.yml's `changes`).
+  # The opt-in feature matrix only compiles/tests Rust, so a doc-only PR can skip it while
+  # the required ci-summary gate still resolves SUCCESS (the aggregator treats the skipped
+  # leg's `skipped` conclusion as non-failing). SAFE-BY-DEFAULT: rust_changed is forced
+  # 'true' on every event except `pull_request`, so the canonical push/merge_group/manual
+  # runs ALWAYS compile the full feature matrix — only a purely non-Rust PR diff skips.
+  changes:
+    name: detect rust changes (feature-matrix)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      rust_changed: ${{ steps.decide.outputs.rust_changed }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain*'
+              - '.github/workflows/feature-matrix.yml'
+      - name: Decide rust_changed (safe-by-default off the PR path)
+        id: decide
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "rust_changed=true" >> "$GITHUB_OUTPUT"
+            echo "event=${{ github.event_name }} -> forcing rust_changed=true (full feature matrix)"
+          else
+            echo "rust_changed=${{ steps.filter.outputs.rust }}" >> "$GITHUB_OUTPUT"
+            echo "pull_request -> paths-filter says rust=${{ steps.filter.outputs.rust }}"
+          fi
+
   opt-in-features:
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
     # One matrix leg per crate + opt-in feature(group). Coexisting opt-in features of a
     # single crate are combined into ONE `--features a,b,c` leg (e.g. the sparq-server
     # federation/persistence/test seams) so the crate is compiled once per leg, not once

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -28,9 +28,57 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # [OPUS-4.8] merge-throughput: path-filtered gate (same pattern as ci.yml's `changes`).
+  # cargo-deny / cargo-vet / the SBOM all read the resolved DEPENDENCY GRAPH (Cargo.lock /
+  # Cargo.toml) and the source tree — a doc-only PR changes none of that, so the result is
+  # identical and these legs can skip while the required ci-summary gate still resolves
+  # SUCCESS (the skipped legs' `skipped` conclusion is non-failing in the aggregator). The
+  # daily dependency-monitoring.yml watchdog remains the defence-in-depth for advisories
+  # disclosed BETWEEN PRs on an unchanged graph. SAFE-BY-DEFAULT: rust_changed is forced
+  # 'true' on every event except `pull_request`, so the canonical push/merge_group/manual
+  # supply-chain runs ALWAYS execute the full set. The `vex-deny-sync` job is deliberately
+  # NOT gated: it validates the checked-in deny.toml↔vex.cdx.json invariant (which a doc/
+  # config PR can touch without changing Rust) and is fast pure-Python.
+  changes:
+    name: detect rust changes (supply-chain)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      rust_changed: ${{ steps.decide.outputs.rust_changed }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain*'
+              - 'deny.toml'
+              - 'supply-chain/**'
+              - '.github/workflows/supply-chain.yml'
+      - name: Decide rust_changed (safe-by-default off the PR path)
+        id: decide
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "rust_changed=true" >> "$GITHUB_OUTPUT"
+            echo "event=${{ github.event_name }} -> forcing rust_changed=true (full supply-chain)"
+          else
+            echo "rust_changed=${{ steps.filter.outputs.rust }}" >> "$GITHUB_OUTPUT"
+            echo "pull_request -> paths-filter says rust=${{ steps.filter.outputs.rust }}"
+          fi
+
   # ---- cargo-deny: advisories, bans, sources, licenses (all gating) ----
   audit:
     name: cargo-deny (advisories + bans + sources + licenses)
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -78,6 +126,8 @@ jobs:
   # "informational" word, so ci-summary treats it as GATING (intentional).
   vet:
     name: cargo-vet (per-dependency audit attestations) — GATING
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -116,6 +166,8 @@ jobs:
   # ---- CycloneDX SBOM ----
   sbom:
     name: generate CycloneDX SBOM
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
> 🤖 SPARQ agent

## What & why (merge-throughput: path-filtered gate)

Doc / compliance / CI-markdown / site PRs currently pay the full ~15-minute Rust test
matrix (`test` shards, `heavy-diskann`, `heavy-hnsw`, clippy, conformance ratchets,
coverage, the feature matrix, cargo-deny/vet/sbom) even though they change no Rust.
This adds an early **`changes`** job (`dorny/paths-filter`, SHA-pinned to `v3.0.3` =
`d1c1ffe0248fe513906c8e24db8ea791d46f8590`, matching the repo's SHA-pin posture) that
computes `rust_changed`, and gates every heavy Rust job on
`if: needs.changes.outputs.rust_changed == 'true'`.

The rust filter set is broad on purpose: `**/*.rs`, `**/Cargo.toml`, `Cargo.lock`,
`rust-toolchain*`, **and the workflow file itself** (so editing a Rust job re-runs it).

## Correctness argument — BOTH directions

**A Rust PR is UNCHANGED.** `rust_changed` is force-`'true'` on *every* event except
`pull_request`: `push` to `main` (the canonical build), `merge_group` (the merge queue
re-runs the whole set), `schedule`, and `workflow_dispatch` all ALWAYS run the full
matrix. On a `pull_request` whose diff touches any `.rs`/`Cargo.*`/toolchain/the
workflow, the filter returns `rust=true` and every gated job runs exactly as today. **A
Rust PR can never merge without the full test matrix.** If the diff can't be classified
as Rust, we never silently skip — the skip only ever happens on the `pull_request` path
with a confirmed non-Rust diff.

**A doc-only PR skips safely and the gate goes green.** With `rust_changed=false` the
heavy jobs are `skipped`. The required check is `ci-summary / gate`, whose aggregator
(`ci-summary.yml`) polls every sibling check-run and **only fails on
`conclusion != "success" and != "skipped" and != "neutral"`** — i.e. a `skipped`
(path-filtered) job is explicitly NON-failing (header line: "success / skipped / neutral
are non-failing"). A skipped job has `status == "completed"`, so it is not counted as
`pending` either — no hang. The fast doc checks (markdownlint / typos / internal-links
in `docs-quality.yml`) still run and still gate. So the gate resolves SUCCESS in ~1-2
min and the doc PR is mergeable.

**No edit to `ci-summary.yml` was needed** — it already handles `skipped` correctly. I
read and traced it to confirm.

## Scope of the gate
- **ci.yml**: `build-archive`, `test` (all 5 shards), `wasm`, `lint`/clippy, `msrv`, the
  four conformance ratchets (SPARQL/SHACL/Geo/inference), `coverage` (combined with its
  pre-existing `event_name != 'schedule'` condition), `geiger`. `docker-smoke` gates on
  `rust_changed OR docker_changed` (a separate `Dockerfile`/entrypoint/`docker-smoke.sh`
  filter) so the sq-n6rv class of bug — a broken released image — is still caught on a
  Dockerfile-only PR. `unsafe-register` stays **ungated** (fast pure-Python source scan).
  Nightly tier (`nightly-gate`/`coverage-nightly`) untouched.
- **feature-matrix.yml**: `opt-in-features` gated.
- **supply-chain.yml**: `audit`/`vet`/`sbom` gated (with `deny.toml` + `supply-chain/**`
  added to the filter so a policy-only PR still runs them); `vex-deny-sync` stays
  ungated (validates a checked-in invariant a config PR could touch; fast pure-Python).
  The daily `dependency-monitoring.yml` watchdog remains the between-PR advisory backstop.
- **CodeQL** deliberately left untouched (security-scanning lane; source-analysis, no
  cargo build) — conservative on the security posture.

## Validation
- `actionlint` clean on all three touched workflows (no expression / `needs:` errors).
- `python3 -c "import yaml…"` valid for ci.yml, feature-matrix.yml, supply-chain.yml,
  and (unchanged) ci-summary.yml.
- `dorny/paths-filter@v3` only runs on `pull_request`; on every other event a `decide`
  step force-sets `rust_changed=true`, sidestepping the unreliable push/merge_group
  base-diff.

## Residual risk
Low. The only behaviour change is on the `pull_request` event with a confirmed non-Rust
diff. If the filter ever misclassified a Rust change as non-Rust the matrix would skip —
but the filter set is deliberately broad (any `.rs`/`Cargo.*`/lock/toolchain) and the
canonical push-to-main + merge-queue always force the full matrix, so an
untested-Rust-change can't reach `main` even in that hypothetical.

[OPUS-4.8]

🤖 Generated with [Claude Code](https://claude.com/claude-code)