### PR TITLE
docs(security): reconcile SECURITY.md with the ZK verifier re-audit (sq-gbp4)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,34 +62,61 @@ deliberate, documented limitation, not an undisclosed weakness — so reports th
 restate the gaps below are already known (but reports of *new* classes of failure, or of
 a gap in a part we claim *is* sound, are very welcome).
 
-### `sparq-zk` and `sparq-zk-compose` — the v1 ZK verifier is NOT sound
+<!-- [OPUS-4.8] Reconciled with the post-remediation re-audit (bead sq-zrt5); see
+     research/zk-verifier-reaudit.md (sq-gbp4). Do NOT relax the no-production-guarantee
+     posture or the external-pending (sq-qhy4) caveat. -->
+### `sparq-zk` and `sparq-zk-compose` — ZK verifier: remediated, but NOT externally audited
 
 The zero-knowledge query-proof estate (`sparq-zk`, `sparq-zk-compose`, and the Noir
-circuits under `zk/`) is a faithful research scaffold of the **in-circuit relations**
-(the scan completeness/soundness relation and the integer/float filter-comparison
-relations are correctly constrained in-circuit). **However, the verifier-side binding
-layer that would make those relations mean anything to a third party does not yet exist,
-and so the v1 verifier (`verify_manifest`) provides NO meaningful soundness guarantee to
-a relying party.** A prover that controls its own side can make the verifier return
-success over arbitrary, false query results.
+circuits under `zk/`) is a research scaffold of the **in-circuit relations** (the scan
+completeness/soundness relation and the integer/float filter-comparison relations are
+correctly constrained in-circuit).
 
-This is the documented verdict of an adversarial soundness audit — see
-[`research/zk-soundness-audit.md`](./research/zk-soundness-audit.md) for the full
-analysis. In summary, the audit confirmed (among others) that:
+**Status — what changed.** The **original** adversarial soundness audit
+([`research/zk-soundness-audit.md`](./research/zk-soundness-audit.md), 2026-06-13) found
+the **v1 verifier BROKEN**: the verifier-side binding layer that ties the in-circuit
+relations to a relying party did not exist, so `verify_manifest` proved essentially
+nothing and a prover controlling its own side could make it return success over
+arbitrary, false results. **That audit predated the remediation.** The `sq-1s2`
+verifier-soundness epic (17 remediation commits) has since **landed** the binding layer:
+`verify_manifest` now reconstructs the bb public inputs from the *declared* statement
+under the *verifier's own nonce* and byte-compares them against each proof
+(`PublicInputMismatch`); recomputes the canonical verification key verifier-side rather
+than trusting the prover's; verifies real issuer Schnorr signatures against an external
+trusted key set; enforces single-use replay/freshness binding; and binds the query's
+FILTER operator/bound/verdict and BGP constants into the proof.
 
-- the cryptographically verified public inputs are never reconstructed from, or compared
-  against, the declared manifest statement — so a prover can attach a genuine proof of a
-  *different* statement while advertising a false result;
-- the verification key handed to the proof backend is taken from the prover's own blob
-  rather than recomputed from the canonical circuit;
-- there is no issuer-signature / key-set membership check — commitments are unsigned,
-  prover-chosen field elements, so credential provenance has no cryptographic backing;
-- there is no replay/freshness binding — a captured manifest is infinitely replayable;
-- FILTER operator/bound/verdict and the query text are not bound to the proof.
+A post-remediation **re-audit** ([`research/zk-verifier-reaudit.md`](./research/zk-verifier-reaudit.md),
+bead `sq-gbp4`) re-ran the same 12-finding adversarial pass against the verifier **as
+landed** and found every prior finding (including all five CRITICALs) **CLOSED with code
+evidence**. Its bottom-line verdict, in its own qualified words, is that the verifier is
+**"SOUND as landed for the threat model the prior audit assumed"** — a prover that fully
+controls its own side, presenting a manifest to a relying party that supplies the
+external trust anchors (trusted key set, fresh nonce, authoritative revocation snapshot).
 
-**Do not present the v1 ZK verifier as proving anything to a relying party.** Treat any
-"verified" result from it as untrusted. The remediation work for these gaps is tracked in
-the issue tracker (beads); the audit document is the design-of-record for the fixes.
+**The load-bearing caveats — read these.** "Sound as landed under the re-audit's stated
+threat model" is **NOT** a production security guarantee, and this estate remains a
+research scaffold a relying party MUST NOT depend on for any production security, privacy,
+or integrity guarantee. Specifically:
+
+- **External sign-off is still PENDING.** No independent accredited cryptographer has
+  audited the verifier or the Noir circuits. That review (bead `sq-qhy4`, P0) is
+  **REQUIRED before any production ZK security claim** and has not happened. The internal
+  re-audit was run by an LLM agent and is itself pending external re-review.
+- **The re-audit's closure rests partly on code-reading, not on tests running in CI.**
+  The cryptographic-chain forge tests and the real `bb` prove/verify end-to-end cases are
+  `#[ignore]`d (slow; require the nargo/bb toolchain) and do not run in default CI; only
+  two empirical bb-output anchors are pinned. A toolchain change could silently shift the
+  public-input serialization with no failing test (re-audit NEW-1).
+- **Documented residual deferrals remain** (re-audit NEW-2): among trusted holders the
+  proof-of-possession is not yet bound to the *specific* credential at every tier, and the
+  revocation-list IRI / snapshot version (and the clear-index path's index) are disclosed
+  — privacy/linkability residuals, not soundness holes.
+
+**Do not present a "verified" result from this estate as a production-grade guarantee to a
+relying party** until the external cryptographer audit (`sq-qhy4`) completes. The re-audit
+is the design-of-record for the closed findings; the original audit is preserved for the
+forge-and-verify regression map (`sq-1gir`).
 
 ### `sparq-mpc` — cryptography deferred
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Reconciles the most load-bearing security-honesty text in the repo. `SECURITY.md` was out of date relative to the post-remediation ZK verifier re-audit and the two disagreed about the verifier's status. This makes `SECURITY.md` **more accurate without laundering the verdict into a clean bill of health**.

### What was wrong
`SECURITY.md` cited only the **original** soundness audit (`research/zk-soundness-audit.md`, 2026-06-13), which found the v1 verifier BROKEN and stated the verifier-side binding layer **"does not yet exist."** That audit predated the `sq-1s2` remediation. The re-audit (`research/zk-verifier-reaudit.md`, bead `sq-gbp4`) found the remediation **landed** and every prior finding (all 5 CRITICALs) **CLOSED with code evidence** — the binding layer now exists.

I verified the re-audit's central claims against the actual crate code (`crates/sparq-zk-compose/verifier.rs` + `driver.rs`) before editing — did not take the summary on faith: `verify_manifest` takes the verifier's nonce, records it single-use first (`NonceReplay`), reconstructs public inputs under that nonce and byte-compares (`PublicInputMismatch`), recomputes the canonical vk verifier-side (driver `canonical_vk`; legacy bundled-vk `verify` explicitly NOT called by `verify_manifest`), and runs the `bind_*` issuer/query/attribution/revocation/holder gates.

### Status wording — before → after
- **Before:** heading *"the v1 ZK verifier is NOT sound"*; *"the verifier-side binding layer … does not yet exist, and so the v1 verifier (`verify_manifest`) provides NO meaningful soundness guarantee … A prover that controls its own side can make the verifier return success over arbitrary, false query results."* Cited only the original audit.
- **After:** heading *"ZK verifier: remediated, but NOT externally audited"*. Records the original BROKEN verdict as **history that predated remediation**, then states `sq-1s2` landed the binding layer and the re-audit found all findings CLOSED. Uses the re-audit's **own qualified words**: the verifier is *"SOUND as landed for the threat model the prior audit assumed"* (prover controls its own side; relying party supplies external trust anchors) — **not strengthened**.

### Honesty preserved (load-bearing)
- External accredited-cryptographer sign-off **still PENDING** — bead `sq-qhy4` (P0), REQUIRED before any production ZK security claim; internal re-audit was LLM-run and itself pending external re-review.
- **No production** security/privacy/integrity guarantee; estate remains a research scaffold a relying party MUST NOT depend on. `sparq-mpc` semi-honest-only / no guarantee (unchanged section).
- Re-audit closure rests partly on **code-reading, not CI**: crypto-chain forge + real-`bb` e2e tests are `#[ignore]`d, only two empirical anchors pinned (re-audit NEW-1).
- Residual **privacy deferrals** noted (NEW-2: HolderPop not credential-bound at every tier; revocation list IRI / version disclosed).
- Original audit verdict kept on record for the `sq-1gir` forge-and-verify regression map.

DOC-ONLY (`SECURITY.md` only). No `crates/` changes, no EC2/aws. markdownlint-clean.

Bead: `sq-zrt5`. Refs: `sq-gbp4`, `sq-qhy4`, `sq-1s2`.