### PR TITLE
feat(sparq-policy): ODRL dateTime + conditional-deny + recipient coverage (sq-idnv, sq-4r70, sq-5037)

### DIFF
--- a/crates/sparq-policy/README.md
+++ b/crates/sparq-policy/README.md
@@ -118,6 +118,21 @@ assert!(!evaluate(&policy, &outside).allow);
     evaluator checks — `Satisfied` / `DefinitelyUnsatisfied` / `Unprovable` /
     `NotConstrained` — the recipient dual of `purpose_status`. (In the `sparq-solid`
     bridge, `recipient neq X` maps to an ACP `noneOf` exception, re-checked per session.)
+  - **Combined `recipient eq A AND neq B` (one rule)** — the constraints are ANDed (the
+    recipient must BE `A` and must NOT BE `B`); in the bridge this emits one
+    `ConditionalGrant` headed by `A` carrying an `exceptMatcher` carving out `B`.
+- **`odrl:dateTime` time-window enforcement (faithful, fail-closed)** — [OPUS-4.8] sq-idnv.
+  A `dateTime` constraint gates a rule to a **time window** (`lteq T` / `lt T` / `gteq T`
+  / `gt T`, or a two-sided `gteq lower` + `lteq upper`, ANDed). The actual instant is the
+  request's evaluation time, supplied via the first-class `Request::at(instant)` sugar
+  (over `.with(ODRL_DATETIME, Value::DateTime(..))`; read back via `req.request_time()`).
+  Instants compare by magnitude. **Missing time → *unprovable* → fail-closed:** a
+  time-gated permission does not grant on an unknown clock; a time-gated prohibition is
+  not withdrawn.
+  - `datetime_status(&rule, &request) -> DateTimeMatch` reports exactly what the evaluator
+    checks — `Satisfied` / `DefinitelyUnsatisfied` / `Unprovable` / `NotConstrained` — the
+    temporal dual of `purpose_status`/`recipient_status`. (In the `sparq-solid` bridge,
+    `dateTime` stays **one-shot** — ACP has no "now" dimension to re-check.)
 - **`odrl:count` enforcement (stateful, opt-in, fail-closed)** — [OPUS-4.8] sq-zi5w.
   `odrl:count` limits the **number of times** a permission may be exercised ("may read
   at most 5 times"). Unlike the stateless constraints above, this is **stateful** — the

--- a/crates/sparq-policy/src/eval.rs
+++ b/crates/sparq-policy/src/eval.rs
@@ -37,6 +37,16 @@ pub const ODRL_COUNT: &str = "http://www.w3.org/ns/odrl/2/count";
 /// [`recipient_status`]). [OPUS-4.8] sq-5037.
 pub const ODRL_RECIPIENT: &str = "http://www.w3.org/ns/odrl/2/recipient";
 
+/// The `odrl:dateTime` left-operand IRI — the dimension a *temporal constraint*
+/// restricts (the instant a permission/prohibition is gated on, e.g.
+/// `odrl:dateTime lteq "2026-12-31T23:59:59Z"`, the upper edge of a validity
+/// window). The actual instant is the request's evaluation time, supplied as
+/// [`Value::DateTime`] evidence (see [`Request::at`] / [`datetime_status`]); a
+/// request that supplies **no** time carries no temporal evidence, so a temporal
+/// permission does not grant and a temporal prohibition is not withdrawn
+/// (fail-closed). [OPUS-4.8] sq-idnv.
+pub const ODRL_DATETIME: &str = "http://www.w3.org/ns/odrl/2/dateTime";
+
 /// An access request evaluated against a [`Policy`]: who wants to do what, to
 /// what, in what context (the "evaluation request" + "state of the world" of the
 /// ODRL Formal Semantics, folded into one node-local view).
@@ -132,6 +142,34 @@ impl Request {
     /// on. [OPUS-4.8] sq-q56r.
     pub fn purpose(&self) -> Option<&Value> {
         self.context.get(ODRL_PURPOSE)
+    }
+
+    /// Declare the **evaluation time** this request is made at as evidence
+    /// (chainable) — the `odrl:dateTime` left-operand value a temporal (time-window)
+    /// rule is checked against. [OPUS-4.8] sq-idnv.
+    ///
+    /// First-class sugar over [`Request::with`]`(ODRL_DATETIME, Value::DateTime(..))`:
+    /// it makes the *time evidence the requester supplies* explicit (and auditable via
+    /// [`Request::request_time`]) instead of relying on a magic context key. A request
+    /// that does NOT call this carries **no** time evidence, so a permission gated on a
+    /// time window does not grant and a prohibition gated on a time window is not
+    /// withdrawn (fail-closed — see [`datetime_status`]).
+    ///
+    /// The instant is stored verbatim as a normalized xsd:dateTime lexical key; it is
+    /// compared by magnitude under the lt/gt/lteq/gteq/eq/neq operators (the same
+    /// instant ordering the evaluator's `order`/`compare` applies — see the README
+    /// caveat on mixed timezone offsets).
+    pub fn at(self, instant: impl Into<String>) -> Request {
+        self.with(ODRL_DATETIME, Value::DateTime(instant.into()))
+    }
+
+    /// The evaluation-time evidence this request carries (`odrl:dateTime`), or `None`
+    /// if the request supplied none. The auditable answer to *"did the request supply
+    /// a time to check the window against?"* — the question faithful time-window
+    /// enforcement turns on (a missing time is Unprovable, not "any time").
+    /// [OPUS-4.8] sq-idnv.
+    pub fn request_time(&self) -> Option<&Value> {
+        self.context.get(ODRL_DATETIME)
     }
 }
 
@@ -546,6 +584,103 @@ pub fn recipient_status(rule: &Rule, request: &Request) -> RecipientMatch {
         RecipientMatch::Unprovable
     } else {
         RecipientMatch::Satisfied
+    }
+}
+
+/// The three-valued verdict of a rule's `odrl:dateTime` (time-window) constraints
+/// against the evaluation-time evidence a request carries — a FAITHFUL report of
+/// exactly what [`evaluate`] checks for the clock (it reuses the same
+/// [`constraint_status`] the evaluator's `odrl:dateTime` constraints go through).
+/// [OPUS-4.8] sq-idnv.
+///
+/// The honesty contract mirrors [`PurposeMatch`] / [`RecipientMatch`]: this never
+/// claims a stronger verdict than the evaluator acts on. `Satisfied` is the ONLY
+/// verdict under which a time-gated permission grants; anything other than
+/// `DefinitelyUnsatisfied` (i.e. `Satisfied` OR `Unprovable`) keeps a time-gated
+/// prohibition in force.
+///
+/// **The time-window shape:** a `dateTime lteq T` (or `lt`/`gteq`/`gt`/`eq`/`neq T`)
+/// constraint is `Satisfied` when the request's instant meets the bound,
+/// `DefinitelyUnsatisfied` when the request supplies an instant that fails the bound
+/// (e.g. a `lteq` upper edge that has provably lapsed), and `Unprovable` when the
+/// request supplies no time at all — fail-closed: a time-gated permission does NOT
+/// grant on an unknown clock, and a time-gated prohibition is NOT withdrawn. Several
+/// `dateTime` constraints on one rule are ANDed (a two-sided window `gteq lower` +
+/// `lteq upper` must both hold), mirroring the evaluator's constraint conjunction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DateTimeMatch {
+    /// The rule has no `odrl:dateTime` constraint — time places no restriction on it.
+    NotConstrained,
+    /// The rule constrains time AND the request's instant **meets** every time
+    /// constraint (inside the window).
+    Satisfied,
+    /// The rule constrains time but the request carries **no** time evidence —
+    /// *unprovable*. Fail-closed: a permission does NOT grant; a prohibition is NOT
+    /// withdrawn. (Never silently read as "any time allowed".)
+    Unprovable,
+    /// The rule constrains time and the request's instant **fails** the window — a
+    /// definite no (the window has not opened yet, or has provably lapsed).
+    DefinitelyUnsatisfied,
+}
+
+/// Report how `rule`'s `odrl:dateTime` (time-window) constraint(s) stand against the
+/// evaluation-time evidence `request` carries — the auditable surface of faithful
+/// temporal enforcement. [OPUS-4.8] sq-idnv.
+///
+/// Like [`purpose_status`] / [`recipient_status`], this does NOT re-implement
+/// matching: it runs the request through the SAME [`constraint_status`] every
+/// `odrl:dateTime` constraint goes through inside [`evaluate`], so the verdict it
+/// reports is exactly what the evaluator acts on (no claimed enforcement that isn't
+/// actually checked — the whole point of the bead). The time evidence is the
+/// `odrl:dateTime` context value the request supplies (via [`Request::at`]).
+///
+/// Returns [`DateTimeMatch::NotConstrained`] when the rule has no time constraint.
+///
+/// # Examples
+///
+/// ```
+/// use sparq_policy::{datetime_status, DateTimeMatch, parse_policy_str, Request};
+/// // "may read until 2026-12-31" (a half-open validity window).
+/// let pol = parse_policy_str(r#"
+/// @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+/// @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+/// <urn:pol/p> a odrl:Set ; odrl:permission [
+///     odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+///     odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lteq ;
+///                       odrl:rightOperand "2026-12-31T23:59:59Z"^^xsd:dateTime ] ] .
+/// "#, "turtle").unwrap();
+/// let rule = &pol.permissions[0];
+/// let base = Request::new("http://www.w3.org/ns/odrl/2/read").on("urn:asset/x");
+///
+/// // Inside the window → Satisfied.
+/// let inside = base.clone().at("2026-06-16T09:00:00Z");
+/// assert_eq!(datetime_status(rule, &inside), DateTimeMatch::Satisfied);
+/// // After the window → DefinitelyUnsatisfied.
+/// let lapsed = base.clone().at("2027-03-01T00:00:00Z");
+/// assert_eq!(datetime_status(rule, &lapsed), DateTimeMatch::DefinitelyUnsatisfied);
+/// // No time at all → Unprovable (fail-closed; not "any time").
+/// assert_eq!(datetime_status(rule, &base), DateTimeMatch::Unprovable);
+/// ```
+pub fn datetime_status(rule: &Rule, request: &Request) -> DateTimeMatch {
+    let mut constrained = false;
+    let mut any_unprovable = false;
+    for c in &rule.constraints {
+        if c.left != ODRL_DATETIME {
+            continue;
+        }
+        constrained = true;
+        match constraint_status(c, request) {
+            ConstraintStatus::Satisfied => {}
+            ConstraintStatus::DefinitelyUnsatisfied => return DateTimeMatch::DefinitelyUnsatisfied,
+            ConstraintStatus::Unprovable => any_unprovable = true,
+        }
+    }
+    if !constrained {
+        DateTimeMatch::NotConstrained
+    } else if any_unprovable {
+        DateTimeMatch::Unprovable
+    } else {
+        DateTimeMatch::Satisfied
     }
 }
 

--- a/crates/sparq-policy/src/lib.rs
+++ b/crates/sparq-policy/src/lib.rs
@@ -11,9 +11,9 @@ pub mod model;
 mod parse;
 
 pub use eval::{
-    evaluate, matched_prohibition, prohibition_status, purpose_status, recipient_status, Decision,
-    ProhibitionStatus, PurposeMatch, RecipientMatch, Request, ODRL_COUNT, ODRL_PURPOSE,
-    ODRL_RECIPIENT,
+    datetime_status, evaluate, matched_prohibition, prohibition_status, purpose_status,
+    recipient_status, DateTimeMatch, Decision, ProhibitionStatus, PurposeMatch, RecipientMatch,
+    Request, ODRL_COUNT, ODRL_DATETIME, ODRL_PURPOSE, ODRL_RECIPIENT,
 };
 pub use model::{Action, Constraint, Duty, Operator, Policy, Rule, Value, ODRL_NS};
 pub use parse::{parse_policy, parse_policy_str};

--- a/crates/sparq-policy/tests/odrl_eval.rs
+++ b/crates/sparq-policy/tests/odrl_eval.rs
@@ -11,12 +11,14 @@
 //! blank-node constraints).
 
 use sparq_policy::{
-    evaluate, parse_policy_str, prohibition_status, purpose_status, recipient_status, Decision,
-    ProhibitionStatus, PurposeMatch, RecipientMatch, Request, Value,
+    datetime_status, evaluate, parse_policy_str, prohibition_status, purpose_status,
+    recipient_status, DateTimeMatch, Decision, ProhibitionStatus, PurposeMatch, RecipientMatch,
+    Request, Value,
 };
 
 const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
 const XSD_DT: &str = "http://www.w3.org/2001/XMLSchema#dateTime";
+const XSD_DT_NS: &str = "http://www.w3.org/2001/XMLSchema#";
 
 fn dt(s: &str) -> Value {
     Value::DateTime(s.to_owned())
@@ -758,4 +760,208 @@ fn recipient_status_reports_what_evaluate_checks() {
         recipient_status(&bare.permissions[0], &base.by(CAROL)),
         RecipientMatch::NotConstrained
     );
+}
+
+// ===========================================================================
+// [OPUS-4.8] sq-5037 follow-up — COMBINED recipient `eq A AND neq B` in ONE rule.
+// The per-head exception (`agents=[A]`, `except=[B]`) is structurally emitted by the
+// bridge but was untested at the evaluator level. Both constraints are ANDed: the
+// recipient must BE A and must NOT BE B. (A and B distinct, so only A is ever granted;
+// the neq is a redundant-but-honoured second guard exercising the conjunction path.)
+// ===========================================================================
+#[test]
+fn recipient_eq_a_and_neq_b_combined() {
+    // "carol (and only carol), but never bob, may read asset-X" — two recipient
+    // constraints on ONE permission (eq carol AND neq bob), logically ANDed.
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/comb> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:recipient ; odrl:operator odrl:eq ;
+                      odrl:rightOperand <{CAROL}> ] ;
+    odrl:constraint [ odrl:leftOperand odrl:recipient ; odrl:operator odrl:neq ;
+                      odrl:rightOperand <{BOB}> ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let rule = &p.permissions[0];
+    let base = Request::new(left("read")).on("urn:asset/x");
+
+    // carol: eq carol ✓ AND neq bob ✓ → BOTH hold → granted.
+    assert!(evaluate(&p, &base.clone().by(CAROL)).allow, "carol satisfies eq carol AND neq bob");
+    assert_eq!(recipient_status(rule, &base.clone().by(CAROL)), RecipientMatch::Satisfied);
+
+    // bob: eq carol ✗ (and neq bob ✗ too) → DENY; the conjunction reports a definite no.
+    assert!(!evaluate(&p, &base.clone().by(BOB)).allow, "bob fails eq carol");
+    assert_eq!(
+        recipient_status(rule, &base.clone().by(BOB)),
+        RecipientMatch::DefinitelyUnsatisfied
+    );
+
+    // dave: eq carol ✗ → DENY (and neq bob ✓ — but the AND still fails).
+    let dave = "https://dave.ex/card#me";
+    assert!(!evaluate(&p, &base.clone().by(dave)).allow, "dave is not carol");
+    assert_eq!(
+        recipient_status(rule, &base.clone().by(dave)),
+        RecipientMatch::DefinitelyUnsatisfied
+    );
+
+    // No identity at all → Unprovable → fail-closed (neither constraint provable).
+    assert!(!evaluate(&p, &base).allow, "missing identity → fail-closed");
+    assert_eq!(recipient_status(rule, &base), RecipientMatch::Unprovable);
+}
+
+#[test]
+fn recipient_eq_a_and_neq_b_prohibition_dual() {
+    // The prohibition dual: a carve-out gated on `recipient eq carol AND neq bob`. Only
+    // carol satisfies BOTH, so only carol's request is carved out; everyone else (incl.
+    // bob, who fails eq carol) is NOT carved out → Withdrawn.
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/combp> a odrl:Set ; odrl:prohibition [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:recipient ; odrl:operator odrl:eq ;
+                      odrl:rightOperand <{CAROL}> ] ;
+    odrl:constraint [ odrl:leftOperand odrl:recipient ; odrl:operator odrl:neq ;
+                      odrl:rightOperand <{BOB}> ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let base = Request::new(left("read")).on("urn:asset/x");
+    // carol: both hold → carved out → Applies.
+    assert_eq!(prohibition_status(&p, &base.clone().by(CAROL)), ProhibitionStatus::Applies);
+    // bob: eq carol definitely false → not carved out → Withdrawn.
+    assert_eq!(prohibition_status(&p, &base.clone().by(BOB)), ProhibitionStatus::Withdrawn);
+    // no identity → unprovable → Ambiguous (deny kept, fail-closed).
+    assert_eq!(prohibition_status(&p, &base), ProhibitionStatus::Ambiguous);
+}
+
+// ===========================================================================
+// [OPUS-4.8] sq-idnv — odrl:dateTime time-window enforcement + the `datetime_status`
+// audit helper (the temporal dual of purpose_status / recipient_status). A time-gated
+// rule grants ONLY when the request supplies an instant inside the window; a missing
+// time is Unprovable → fail-closed; a lapsed/early instant is a definite no.
+// ===========================================================================
+
+/// "may read asset-X ONLY until 2026-12-31T23:59:59Z" — an upper time bound.
+fn windowed_read_permission() -> sparq_policy::Policy {
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+@prefix xsd: <{XSD_DT_NS}> .
+<urn:pol/win> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lteq ;
+                      odrl:rightOperand "2026-12-31T23:59:59Z"^^xsd:dateTime ] ] .
+"#
+    );
+    parse_policy_str(&ttl, "turtle").unwrap()
+}
+
+#[test]
+fn datetime_status_reports_what_evaluate_checks() {
+    let p = windowed_read_permission();
+    let rule = &p.permissions[0];
+    let base = Request::new(left("read")).on("urn:asset/x");
+
+    // Inside the window → Satisfied AND evaluate grants. The Request::at sugar carries
+    // the instant as odrl:dateTime evidence (auditable via request_time).
+    let inside = base.clone().at("2026-06-16T09:00:00Z");
+    assert_eq!(datetime_status(rule, &inside), DateTimeMatch::Satisfied);
+    assert!(evaluate(&p, &inside).allow, "inside window grants");
+    assert_eq!(inside.request_time().map(Value::as_str), Some("2026-06-16T09:00:00Z"));
+
+    // After the window → DefinitelyUnsatisfied AND evaluate denies.
+    let lapsed = base.clone().at("2027-03-01T00:00:00Z");
+    assert_eq!(datetime_status(rule, &lapsed), DateTimeMatch::DefinitelyUnsatisfied);
+    assert!(!evaluate(&p, &lapsed).allow, "after window denies");
+
+    // No time supplied → Unprovable → fail-closed (NOT "any time allowed").
+    assert_eq!(datetime_status(rule, &base), DateTimeMatch::Unprovable);
+    assert!(!evaluate(&p, &base).allow, "missing time fails closed");
+    assert_eq!(base.request_time(), None, "no time evidence supplied");
+}
+
+#[test]
+fn datetime_two_sided_window_anded() {
+    // A two-sided window: gteq lower AND lteq upper — both must hold (conjunction).
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+@prefix xsd: <{XSD_DT_NS}> .
+<urn:pol/win2> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:gteq ;
+                      odrl:rightOperand "2026-01-01T00:00:00Z"^^xsd:dateTime ] ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lteq ;
+                      odrl:rightOperand "2026-12-31T23:59:59Z"^^xsd:dateTime ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let rule = &p.permissions[0];
+    let base = Request::new(left("read")).on("urn:asset/x");
+
+    // Inside both bounds → Satisfied.
+    assert_eq!(datetime_status(rule, &base.clone().at("2026-06-16T00:00:00Z")), DateTimeMatch::Satisfied);
+    // Before the lower bound → one constraint definitely false → DefinitelyUnsatisfied.
+    assert_eq!(
+        datetime_status(rule, &base.clone().at("2025-12-31T23:59:59Z")),
+        DateTimeMatch::DefinitelyUnsatisfied
+    );
+    // After the upper bound → DefinitelyUnsatisfied.
+    assert_eq!(
+        datetime_status(rule, &base.clone().at("2027-01-01T00:00:00Z")),
+        DateTimeMatch::DefinitelyUnsatisfied
+    );
+    // Missing time → Unprovable.
+    assert_eq!(datetime_status(rule, &base), DateTimeMatch::Unprovable);
+}
+
+#[test]
+fn datetime_prohibition_dual() {
+    // The dual: a prohibition gated on a time window carves the request out ONLY while
+    // the window holds; a lapsed window is definitely Withdrawn; missing time is
+    // Ambiguous (the deny is NOT withdrawn — fail-closed). "alice prohibited until
+    // 2026-01-01" (a `lt` lower edge — the prohibition lapses once we reach the bound).
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+@prefix xsd: <{XSD_DT_NS}> .
+<urn:pol/pwin> a odrl:Set ; odrl:prohibition [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ; odrl:assignee <https://alice.ex/me> ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lt ;
+                      odrl:rightOperand "2026-01-01T00:00:00Z"^^xsd:dateTime ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let prohib = &p.prohibitions[0];
+    let base = Request::new(left("read")).on("urn:asset/x").by("https://alice.ex/me");
+
+    // Now < bound → the window holds → carve-out Applies; datetime_status Satisfied.
+    let inside = base.clone().at("2025-06-01T00:00:00Z");
+    assert_eq!(datetime_status(prohib, &inside), DateTimeMatch::Satisfied);
+    assert_eq!(prohibition_status(&p, &inside), ProhibitionStatus::Applies);
+
+    // Now >= bound → the window lapsed → definitely no → Withdrawn.
+    let lapsed = base.clone().at("2026-06-01T00:00:00Z");
+    assert_eq!(datetime_status(prohib, &lapsed), DateTimeMatch::DefinitelyUnsatisfied);
+    assert_eq!(prohibition_status(&p, &lapsed), ProhibitionStatus::Withdrawn);
+
+    // No time → unprovable → Ambiguous (deny kept).
+    assert_eq!(datetime_status(prohib, &base), DateTimeMatch::Unprovable);
+    assert_eq!(prohibition_status(&p, &base), ProhibitionStatus::Ambiguous);
+}
+
+#[test]
+fn datetime_not_constrained_when_absent() {
+    // A rule with no dateTime constraint → NotConstrained (time places no bound).
+    let ttl = format!(
+        r#"@prefix odrl: <{ODRL}> . <urn:pol/nt> a odrl:Set ; odrl:permission [
+           odrl:action odrl:read ; odrl:target <urn:asset/x> ] ."#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let req = Request::new(left("read")).on("urn:asset/x").at("2026-06-16T00:00:00Z");
+    assert_eq!(datetime_status(&p.permissions[0], &req), DateTimeMatch::NotConstrained);
 }

--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -155,6 +155,28 @@ would impersonate a minted pair principal), so rather than emit an exception tha
 fails to bite — which would re-admit `X` — the whole rule falls back to the one-shot path
 (never widen to a public everyone-except grant on an unenforceable exclusion).
 
+**Combined `recipient eq A AND neq B` (one rule)** — [OPUS-4.8] sq-5037. The constraints are
+ANDed: the bridge emits a single `ConditionalGrant` headed by `A` (the positive `eq`) carrying
+an `auth:exceptMatcher` carving out `B` (the `neq`) — the per-head exception. Only `A` keeps
+the grant (everyone else fails the `eq` head; `B` is doubly excluded).
+
+### Constraint-conditional **DENY** (`materialize_odrl_prohibition_conditional`) — [OPUS-4.8] sq-4r70
+
+The dual of the conditional grant: a matched **prohibition** whose recipient/assignee constraints
+map faithfully (same table above) is persisted as a re-checked `auth:ConditionalGrant` with
+**`auth:effect auth:Deny`** rather than a frozen one-shot `auth:deny*`. The carve-out is
+re-verified per session through the SAME `AuthIndex::accessible` path, and **composes with
+deny-overrides**: a matching deny condition adds the target to the `denied` set, which is
+subtracted from `allowed` — so a conditional deny **beats any allow** for the same
+principal+target+mode. A prohibition `recipient eq carol` → a deny on carol's sessions;
+`recipient neq bob` → a deny on everyone EXCEPT bob (an `exceptMatcher` carving bob back IN).
+**Fail-closed:** a prohibition carrying an unmappable constraint (`purpose`/`dateTime`/`count`)
+falls back to the one-shot `materialize_odrl_prohibition` (frozen) so the bound is still enforced;
+a reserved-encoded recipient falls back to one-shot rather than emit a deny that silently fails
+to bite (which would FAIL OPEN — a dropped deny widens access). Tracked as
+`BridgeKind::ProhibitionConditional`; refresh re-checks the carve-out per session and retracts the
+deny only when the prohibition is genuinely withdrawn (deny-retraction, sq-2pcf).
+
 ¹ **Stateful `odrl:count` enforcement** — [OPUS-4.8] sq-zi5w. `odrl:count` limits the *number
 of times* a permission may be exercised; faithful enforcement is **stateful** (a usage counter
 persisting across requests), which ACP — stateless, with static matcher accept-sets and no
@@ -179,6 +201,15 @@ equality, or `isPartOf` over the named set, or `neq`) — **no** purpose hierarc
 subsumption. Because the check is one-shot, a purpose-gated grant is scoped to the request
 party it was materialized for; a *changed* stated purpose is re-evaluated on the next
 `refresh_odrl_grant` (sq-dpk4). A DPV purpose taxonomy / hierarchy match is a deferred bead.
+
+**`odrl:dateTime` time-window enforcement through the bridge** — [OPUS-4.8] sq-idnv. Like
+purpose, a time window has **no** re-checked-condition analogue (ACP matcher accept-sets are
+static — there is no "now" dimension), so it stays **one-shot**: the window is checked once,
+against the instant the request supplies (`Request::at(..)`), by the same `sparq_policy::evaluate`
+the one-shot path runs — a grant (or `auth:deny*`) materializes only if the instant was inside the
+window. A **missing** time is *unprovable* → fail-closed. Because the check is one-shot, a *lapsed*
+window is caught on the next `refresh_odrl_grant` (re-evaluate with a `now` past the bound → the
+grant emits nothing → retracted; sq-dpk4). Re-checking the clock live inside ACP is a deferred bead.
 
 **Fail-safe on mixed constraints:** a condition is persisted **only** when *every* constraint
 on the rule maps faithfully. A rule mixing a mappable recipient with an unmappable

--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -18,7 +18,7 @@ pub use materialize::{materialize_acp, materialize_wac, MaterializeStats};
 #[cfg(feature = "odrl-bridge")]
 pub use odrl_bridge::{
     action_to_mode, materialize_permission, materialize_permission_conditional, materialize_policy,
-    materialize_prohibition, BridgeOutcome,
+    materialize_prohibition, materialize_prohibition_conditional, BridgeOutcome,
 };
 #[cfg(feature = "odrl-bridge")]
 pub use odrl_bridge::{BridgeEntry, BridgeKind, BridgeLedger};
@@ -587,6 +587,37 @@ impl PodStore {
                 policy,
                 request,
                 odrl_bridge::BridgeKind::PermissionConditional,
+            );
+            self.reindex();
+        }
+        outcome
+    }
+
+    /// [OPUS-4.8] sq-4r70 — the deny dual of
+    /// [`PodStore::materialize_odrl_permission_conditional`]: persist a matched ODRL
+    /// **prohibition** whose recipient/assignee constraints map faithfully as a
+    /// re-checked ACP **conditional deny** (`auth:effect auth:Deny`) rather than freezing
+    /// it one-shot. The carve-out is re-verified per session through the SAME enforcement
+    /// path ([`PodStore::accessible`] / [`PodStore::query_as`]); the deny **overrides**
+    /// any allow for the same principal+target+mode (deny-overrides).
+    ///
+    /// A prohibition carrying a constraint with **no** faithful ACP-condition analogue
+    /// (`odrl:purpose`, `odrl:dateTime`, `odrl:count`) falls back to the one-shot deny
+    /// ([`odrl_bridge::materialize_prohibition`], frozen at materialization) — see
+    /// [`odrl_bridge::materialize_prohibition_conditional`] for the full rationale.
+    #[cfg(feature = "odrl-bridge")]
+    pub fn materialize_odrl_prohibition_conditional(
+        &mut self,
+        policy: &sparq_policy::Policy,
+        request: &sparq_policy::Request,
+    ) -> odrl_bridge::BridgeOutcome {
+        let outcome =
+            odrl_bridge::materialize_prohibition_conditional(&mut self.graph, policy, request);
+        if outcome.prohibited {
+            self.bridge_ledger.record(
+                policy,
+                request,
+                odrl_bridge::BridgeKind::ProhibitionConditional,
             );
             self.reindex();
         }

--- a/crates/sparq-solid/src/odrl_bridge.rs
+++ b/crates/sparq-solid/src/odrl_bridge.rs
@@ -769,7 +769,7 @@ pub fn materialize_permission_conditional(
                     continue;
                 }
                 let (first, emitted) =
-                    append_conditional_grants(graph, &agents, &excepts, mode, target);
+                    append_conditional_grants(graph, &agents, &excepts, mode, target, GrantEffect::Allow);
                 return BridgeOutcome {
                     granted: true,
                     mode: Some(mode),
@@ -794,6 +794,125 @@ pub fn materialize_permission_conditional(
     //    supplied request context and emits a frozen allow iff they hold).
     let out = materialize_permission(graph, policy, request);
     if !out.granted && out.reasons.is_empty() {
+        return BridgeOutcome::denied(fallback_reasons);
+    }
+    out
+}
+
+/// Evaluate `policy`'s **prohibitions** against `request` and, for a prohibition whose
+/// recipient/assignee constraints map faithfully to agent conditions, persist a
+/// re-checked ACP **conditional deny** (`auth:ConditionalGrant` with `auth:effect
+/// auth:Deny`) — the dual of [`materialize_permission_conditional`]. [OPUS-4.8] sq-4r70.
+///
+/// This is the constraint-CONDITIONAL deny: instead of freezing a deny at
+/// materialization time (one-shot [`materialize_prohibition`]), the carve-out is
+/// persisted as a condition the session layer re-checks per session. A prohibition
+/// `recipient eq bob` materializes a deny that applies **only to bob's sessions**; a
+/// `recipient neq bob` materializes a deny that applies to **everyone except bob** (an
+/// ACP `noneOf` exception carving bob back IN to access). The deny composes with
+/// deny-overrides via the SAME `∪ allow ∖ ∪ deny` enforcement
+/// ([`crate::AuthIndex::accessible`]) — a conditional deny that applies to a session
+/// removes the target from that session's accessible set, beating any allow.
+///
+/// # When a conditional deny is emitted (faithful)
+///
+/// All of the matched prohibition's constraints are `odrl:recipient`/`odrl:assignee`
+/// constraints under `eq`/`isA`/`isPartOf`/`neq` (see [`map_constraints_to_agents`]),
+/// the action [`action_to_mode`]-maps, and the request names a target. The recipient
+/// constraint is NOT required to hold against the request party — the persisted
+/// condition re-checks it per session, exactly as the allow path.
+///
+/// # Fail-closed
+///
+/// - **Mixed / unmappable constraints fall back to one-shot:** if the prohibition
+///   carries a constraint with no faithful ACP-condition analogue (`purpose`,
+///   `dateTime`, `count`), the WHOLE rule falls back to [`materialize_prohibition`], so
+///   the unmappable bound is still enforced (the one-shot deny is materialized iff the
+///   prohibition currently matches — frozen). A persisted deny condition is emitted ONLY
+///   when every constraint maps faithfully.
+/// - An unmapped action or a missing target materializes nothing.
+/// - A reserved-encoded recipient/exclusion cannot become an enforceable matcher; the
+///   rule falls back to one-shot rather than emit a deny condition that cannot bite
+///   (which would FAIL OPEN — a deny silently dropped widens access).
+///
+/// Returns a [`BridgeOutcome`]; on a conditional deny `prohibited == true`,
+/// `deny_triple` reports the `(agent, auth:effect, graph)` anchor of the first emitted
+/// deny head and `mode` the mapped mode. The free-function form does not reindex a
+/// [`crate::PodStore`] — go through a `materialize_*` method for that.
+pub fn materialize_prohibition_conditional(
+    graph: &mut Graph,
+    policy: &Policy,
+    request: &Request,
+) -> BridgeOutcome {
+    // 1. Action → Mode (shared with the one-shot path). Unmapped → no deny.
+    let Some(mode) = action_to_mode(&request.action) else {
+        return BridgeOutcome::denied(vec![format!(
+            "ODRL action <{}> has no WAC/ACP mode mapping; no deny materialized",
+            request.action
+        )]);
+    };
+    let Some(target) = request.target.as_deref() else {
+        return BridgeOutcome::denied(vec![
+            "ODRL prohibition has no concrete target graph IRI; no deny materialized".to_owned(),
+        ]);
+    };
+
+    // 2. Find a prohibition whose action/target match AND whose constraints map
+    //    faithfully to agent conditions. The recipient/assignee constraint is NOT
+    //    required to hold against the request party — the persisted condition re-checks
+    //    it per session (the dual of the conditional allow path).
+    let mut fallback_reasons: Vec<String> = Vec::new();
+    for rule in &policy.prohibitions {
+        if !rule_action_target_match(rule, request, mode, target) {
+            continue;
+        }
+        match map_constraints_to_agents(rule) {
+            AgentMapping::Faithful { agents: recipients, except } => {
+                let agents = condition_agents(rule, &recipients);
+                if agents.is_empty() {
+                    fallback_reasons.push(format!(
+                        "prohibition {} recipients are all reserved-encoded; no deny",
+                        rule.id
+                    ));
+                    continue;
+                }
+                let excepts = condition_excepts(&except);
+                if excepts.len() != except.len() {
+                    // A reserved-encoded exclusion would silently re-admit the carved-out
+                    // party to the DENY (i.e. they'd escape it) — fail-closed to one-shot.
+                    fallback_reasons.push(format!(
+                        "prohibition {} has a reserved-encoded neq recipient; one-shot path",
+                        rule.id
+                    ));
+                    continue;
+                }
+                let (first, emitted) = append_conditional_grants(
+                    graph, &agents, &excepts, mode, target, GrantEffect::Deny,
+                );
+                return BridgeOutcome {
+                    prohibited: true,
+                    mode: Some(mode),
+                    deny_triple: Some(first),
+                    emitted,
+                    ..BridgeOutcome::default()
+                };
+            }
+            AgentMapping::Unmappable => {
+                // A constraint with no faithful condition analogue (purpose / dateTime /
+                // count) → the one-shot deny path must check it (frozen) instead.
+                fallback_reasons.push(format!(
+                    "prohibition {} has a constraint with no faithful ACP condition; one-shot path",
+                    rule.id
+                ));
+            }
+        }
+    }
+
+    // 3. No faithfully-conditional prohibition applied → fall back to the EXISTING
+    //    one-shot deny (which checks the unmappable constraints against the supplied
+    //    request context and emits a frozen `auth:deny*` iff the prohibition matches).
+    let out = materialize_prohibition(graph, policy, request);
+    if !out.prohibited && out.reasons.is_empty() {
         return BridgeOutcome::denied(fallback_reasons);
     }
     out
@@ -849,10 +968,33 @@ fn rule_action_target_match(rule: &Rule, request: &Request, _mode: Mode, target:
 }
 
 
-/// Append `auth:ConditionalGrant` allow triples for each agent head onto BOTH the
-/// `<urn:sparq:auth>` view and the bridged-provenance graph, preserving existing
-/// triples. Returns the `(agent, auth:effect, graph)` audit anchor of the first grant
-/// AND the full set of emitted head triples (for the bridge ledger). [OPUS-4.8] sq-dpk4.
+/// The deontic force of a materialized `auth:ConditionalGrant` — selects the
+/// `auth:effect` object emitted by [`append_conditional_grants`]. [OPUS-4.8] sq-4r70.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GrantEffect {
+    /// A conditional **allow** (`auth:effect auth:Allow`) — the recipient is granted.
+    Allow,
+    /// A conditional **deny** (`auth:effect auth:Deny`) — the dual: the matched
+    /// session is denied, and the deny overrides any allow for the same
+    /// principal+target+mode (the session layer subtracts `∪ deny` from `∪ allow`).
+    Deny,
+}
+
+impl GrantEffect {
+    /// The `auth:`-local effect object (`Allow` / `Deny`) and the grant-IRI key.
+    fn iri_local(self) -> &'static str {
+        match self {
+            GrantEffect::Allow => "Allow",
+            GrantEffect::Deny => "Deny",
+        }
+    }
+}
+
+/// Append `auth:ConditionalGrant` triples (allow OR deny — see `effect`) for each agent
+/// head onto BOTH the `<urn:sparq:auth>` view and the bridged-provenance graph,
+/// preserving existing triples. Returns the `(agent, auth:effect, graph)` audit anchor
+/// of the first grant AND the full set of emitted head triples (for the bridge ledger).
+/// [OPUS-4.8] sq-dpk4 / sq-4r70.
 ///
 /// `excepts` are the principals carved OUT (the `recipient neq X` / "everyone-except"
 /// shape — [OPUS-4.8] sq-5037). Each becomes an ACP `noneOf` exception: the grant gets
@@ -862,19 +1004,28 @@ fn rule_action_target_match(rule: &Rule, request: &Request, _mode: Mode, target:
 /// session the matcher accepts — i.e. for `X` under any client — so `X` is denied while
 /// every other session keeps the grant. This is EXACTLY the shape the WAC/ACP `noneOf`
 /// rules (`rules/acp-c.n3`) emit, re-checked by the same code path.
+///
+/// `effect` selects the deontic force ([OPUS-4.8] sq-4r70): [`GrantEffect::Allow`]
+/// emits `auth:effect auth:Allow` (the conditional grant); [`GrantEffect::Deny`] emits
+/// `auth:effect auth:Deny` (the conditional deny — the dual). A conditional deny is
+/// honoured by the SAME [`crate::AuthIndex::accessible`] path: a matching deny condition
+/// adds the graph to the `denied` set, which is subtracted from `allowed`
+/// (deny-overrides). The deny's grant IRI carries an `&effect=deny` key so it never
+/// collides with an allow grant for the same `(agent, mode, graph, excepts)`.
 fn append_conditional_grants(
     graph: &mut Graph,
     agents: &[String],
     excepts: &[String],
     mode: Mode,
     target: &str,
+    effect: GrantEffect,
 ) -> ((String, String, String), Vec<[Term; 3]>) {
     let mut emitted: Vec<[Term; 3]> = Vec::new();
 
     let type_p = NamedNode::new_unchecked(RDF_TYPE);
     let cond_class = NamedNode::new_unchecked(format!("{AUTH_NS}ConditionalGrant"));
     let effect_p = NamedNode::new_unchecked(format!("{AUTH_NS}effect"));
-    let allow_o = NamedNode::new_unchecked(format!("{AUTH_NS}Allow"));
+    let effect_o = NamedNode::new_unchecked(format!("{AUTH_NS}{}", effect.iri_local()));
     let agent_p = NamedNode::new_unchecked(format!("{AUTH_NS}agent"));
     let client_p = NamedNode::new_unchecked(format!("{AUTH_NS}client"));
     let any_client = NamedNode::new_unchecked(crate::authindex::ANY_CLIENT);
@@ -908,17 +1059,18 @@ fn append_conditional_grants(
             .collect::<Vec<_>>()
             .join(",");
         let grant_iri = format!(
-            "urn:sparq:odrl-cond?agent={}&mode={}&graph={}&except={}",
+            "urn:sparq:odrl-cond?agent={}&mode={}&graph={}&except={}&effect={}",
             sparq_reason::n3::encode_for_uri(agent),
             sparq_reason::n3::encode_for_uri(mode_iri(mode)),
             sparq_reason::n3::encode_for_uri(target),
             except_key,
+            effect.iri_local(),
         );
         let g = Term::NamedNode(NamedNode::new_unchecked(&grant_iri));
         let agent_o = Term::NamedNode(NamedNode::new_unchecked(agent));
         let mut head = vec![
             [g.clone(), Term::NamedNode(type_p.clone()), Term::NamedNode(cond_class.clone())],
-            [g.clone(), Term::NamedNode(effect_p.clone()), Term::NamedNode(allow_o.clone())],
+            [g.clone(), Term::NamedNode(effect_p.clone()), Term::NamedNode(effect_o.clone())],
             [g.clone(), Term::NamedNode(agent_p.clone()), agent_o],
             [g.clone(), Term::NamedNode(client_p.clone()), Term::NamedNode(any_client.clone())],
             [g.clone(), Term::NamedNode(mode_p.clone()), Term::NamedNode(mode_o.clone())],
@@ -984,6 +1136,9 @@ pub enum BridgeKind {
     /// [`materialize_permission_conditional`] — a re-checked conditional grant (or its
     /// one-shot fallback).
     PermissionConditional,
+    /// [`materialize_prohibition_conditional`] — a re-checked conditional deny (or its
+    /// one-shot fallback). [OPUS-4.8] sq-4r70.
+    ProhibitionConditional,
 }
 
 /// One tracked bridged materialization: the originating ODRL `(policy, request, kind)`
@@ -1151,7 +1306,57 @@ fn replay(graph: &mut Graph, entry: &BridgeEntry) -> BridgeOutcome {
         BridgeKind::PermissionConditional => {
             materialize_permission_conditional(graph, &entry.policy, &entry.request)
         }
+        BridgeKind::ProhibitionConditional => {
+            refresh_prohibition_conditional(graph, &entry.policy, &entry.request)
+        }
     }
+}
+
+/// Re-evaluate a tracked **conditional deny** ([`materialize_prohibition_conditional`])
+/// on refresh with the fail-closed deny-retraction rule (sq-2pcf). [OPUS-4.8] sq-4r70.
+///
+/// A faithfully-conditional deny re-checks its recipient/assignee carve-out per session
+/// at enforcement time, so on refresh the question is only whether the prohibition still
+/// *structurally* names the request (action/target) — which is exactly what
+/// [`materialize_prohibition_conditional`] re-checks before re-emitting. A prohibition
+/// withdrawn entirely (or whose action/target no longer match) re-emits nothing → the
+/// deny condition is retracted → access restored (correct: the prohibition is gone).
+///
+/// When the tracked deny FELL BACK to one-shot (an unmappable `dateTime`/`purpose`/
+/// `count` constraint), [`materialize_prohibition_conditional`]'s fallback runs the
+/// one-shot [`materialize_prohibition`] — which would retract on an *unprovable*
+/// constraint, FAIL-OPEN. So for the one-shot fallback we route through the deny-
+/// retraction-aware [`refresh_prohibition`] (re-emit on Ambiguous, retract only on a
+/// definite Withdrawn), exactly as the plain [`BridgeKind::Prohibition`] refresh does.
+/// We detect the fallback case by whether ANY prohibition maps faithfully for the
+/// request's action/target.
+fn refresh_prohibition_conditional(
+    graph: &mut Graph,
+    policy: &Policy,
+    request: &Request,
+) -> BridgeOutcome {
+    if prohibition_maps_faithfully(policy, request) {
+        // Faithful conditional deny: the recipient carve-out is re-checked per session,
+        // so re-emitting whenever the prohibition structurally names the request is
+        // correct (and fail-closed: a withdrawn prohibition emits nothing → retracted).
+        materialize_prohibition_conditional(graph, policy, request)
+    } else {
+        // One-shot fallback (an unmappable constraint): apply the deny-retraction rule
+        // so an unprovable bound KEEPS the deny rather than restoring access (fail-open).
+        refresh_prohibition(graph, policy, request)
+    }
+}
+
+/// Whether SOME prohibition in `policy` whose action/target structurally name `request`
+/// maps faithfully to agent conditions (so the conditional-deny path would emit a
+/// re-checked condition rather than fall back to one-shot). [OPUS-4.8] sq-4r70.
+fn prohibition_maps_faithfully(policy: &Policy, request: &Request) -> bool {
+    let Some(mode) = action_to_mode(&request.action) else { return false };
+    let Some(target) = request.target.as_deref() else { return false };
+    policy.prohibitions.iter().any(|rule| {
+        rule_action_target_match(rule, request, mode, target)
+            && matches!(map_constraints_to_agents(rule), AgentMapping::Faithful { .. })
+    })
 }
 
 /// Re-evaluate a tracked **Prohibition** deny on refresh with the fail-closed

--- a/crates/sparq-solid/tests/odrl_bridge.rs
+++ b/crates/sparq-solid/tests/odrl_bridge.rs
@@ -1646,3 +1646,242 @@ fn recipient_neq_reserved_encoded_does_not_widen_to_public() {
     assert!(reads(&mut store, ALICE), "alice (the materializer, non-excluded) granted");
     assert!(!reads(&mut store, CAROL), "no public widening from a reserved exclusion");
 }
+
+// ===========================================================================
+// [OPUS-4.8] sq-5037 follow-up — COMBINED recipient `eq A AND neq B` in ONE rule
+// through the BRIDGE. The bridge emits `agents=[A]` (positive head) + `except=[B]`
+// (a noneOf exceptMatcher) — both on the SAME ConditionalGrant. Structurally emitted
+// by sq-5037 but untested at the bridge level (the per-head exception path).
+// ===========================================================================
+
+/// "carol (and only carol), but never bob, may read n1" — recipient eq carol AND neq bob.
+fn recipient_eq_and_neq_policy() -> sparq_policy::Policy {
+    parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/comb> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:constraint [ odrl:leftOperand odrl:recipient ; odrl:operator odrl:eq ;
+                      odrl:rightOperand <https://carol.ex/card#me> ] ;
+    odrl:constraint [ odrl:leftOperand odrl:recipient ; odrl:operator odrl:neq ;
+                      odrl:rightOperand <https://bob.ex/card#me> ] ] .
+"#,
+        "turtle",
+    )
+    .expect("policy parses")
+}
+
+// 22. The COMBINED bridge shape: a single ConditionalGrant whose positive head is carol
+//     AND which carries an exceptMatcher carving out bob (the per-head exception).
+#[test]
+fn recipient_eq_and_neq_emits_carol_head_with_bob_exception() {
+    let mut g = pod();
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    let out = materialize_permission_conditional(&mut g, &recipient_eq_and_neq_policy(), &req);
+    assert!(out.granted, "combined eq+neq maps to a faithful condition: {out:?}");
+
+    // Exactly one ConditionalGrant, headed by carol (the positive eq constraint) — NOT
+    // a public head (the eq narrows it to carol).
+    assert_eq!(cond_grants_for(&g, Some(CAROL)), 1, "carol positive head present");
+    assert_eq!(
+        cond_grants_for(&g, Some("https://sparq.dev/ns/auth#Public")),
+        0,
+        "eq carol means the head is carol, not public"
+    );
+    // ... carrying an exception matcher that carves out bob (the neq constraint).
+    let ms = except_matchers(&g);
+    assert_eq!(ms.len(), 1, "one exceptMatcher (the neq bob carve-out): {ms:?}");
+    assert!(ms[0].1.contains("bob.ex"), "exception carves out bob: {ms:?}");
+}
+
+// 23. RE-CHECKED end-to-end: only carol reads. Bob is excluded by BOTH the eq head (he
+//     is not carol) AND the neq exception; everyone else is excluded by the eq head.
+#[test]
+fn recipient_eq_and_neq_grants_only_carol() {
+    let pol = recipient_eq_and_neq_policy();
+    let mut store = PodStore::new(pod());
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_permission_conditional(&pol, &req).granted);
+
+    assert!(reads(&mut store, CAROL), "carol satisfies the eq head and is not excepted");
+    assert!(!reads(&mut store, BOB), "bob is not carol AND is excepted");
+    assert!(!reads(&mut store, DAVE), "dave is not carol → eq head excludes him");
+    assert!(!reads(&mut store, ALICE), "the materializer is not auto-granted");
+    assert!(store.accessible(&Session::default(), Mode::Read).is_empty(), "anonymous denied");
+
+    // End-to-end via query_as: only carol sees the content.
+    let sel = "SELECT ?t WHERE { ?s <https://ex.dev/ns#title> ?t }";
+    let carol = Session { agent: Some(CAROL), client: None };
+    let bob = Session { agent: Some(BOB), client: None };
+    assert_eq!(store.query_as(&carol, Mode::Read, sel).unwrap().rows.len(), 1);
+    assert_eq!(store.query_as(&bob, Mode::Read, sel).unwrap().rows.len(), 0);
+}
+
+// ===========================================================================
+// [OPUS-4.8] sq-4r70 — CONSTRAINT-CONDITIONAL DENY: an ACP-style deny that is
+// conditional on a recipient/assignee constraint (the dual of the conditional grant).
+// Materialized as a re-checked `auth:ConditionalGrant` with `auth:effect auth:Deny`,
+// composing with deny-overrides. The deny appears/retracts as the condition flips.
+// ===========================================================================
+use sparq_solid::materialize_prohibition_conditional;
+
+/// Count `auth:ConditionalGrant` heads with `auth:effect auth:Deny` naming `agent`
+/// (or any) in `graph`'s auth view (the conditional-DENY dual of `cond_grants_for`).
+fn cond_denies_for(graph: &Graph, agent: Option<&str>) -> usize {
+    let head = "?g <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> \
+        <https://sparq.dev/ns/auth#ConditionalGrant> ; \
+        <https://sparq.dev/ns/auth#effect> <https://sparq.dev/ns/auth#Deny>";
+    let q = match agent {
+        Some(a) => format!(
+            "SELECT ?g WHERE {{ GRAPH <urn:sparq:auth> {{ {head} ; \
+             <https://sparq.dev/ns/auth#agent> <{a}> }} }}"
+        ),
+        None => format!("SELECT ?g WHERE {{ GRAPH <urn:sparq:auth> {{ {head} }} }}"),
+    };
+    sparq_engine::query(graph, &q).expect("query").rows.len()
+}
+
+/// "carol (recipient) is PROHIBITED from reading n1" — a recipient-eq prohibition that
+/// the conditional path maps to a per-session deny carving out exactly carol.
+fn prohibit_recipient_carol_policy() -> sparq_policy::Policy {
+    parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/pcond> a odrl:Set ; odrl:prohibition [
+    odrl:action odrl:read ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:constraint [ odrl:leftOperand odrl:recipient ; odrl:operator odrl:eq ;
+                      odrl:rightOperand <https://carol.ex/card#me> ] ] .
+"#,
+        "turtle",
+    )
+    .expect("policy parses")
+}
+
+// 24. The conditional-deny BRIDGE SHAPE: a recipient-eq prohibition materializes a
+//     ConditionalGrant with auth:effect auth:Deny headed by carol (re-checked, NOT frozen).
+#[test]
+fn conditional_deny_emits_deny_effect_condition() {
+    let mut g = pod();
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    let out = materialize_prohibition_conditional(&mut g, &prohibit_recipient_carol_policy(), &req);
+    assert!(out.prohibited, "faithful recipient prohibition maps to a deny condition: {out:?}");
+    assert_eq!(cond_denies_for(&g, Some(CAROL)), 1, "carol deny condition present");
+    assert_eq!(cond_denies_for(&g, Some(ALICE)), 0, "no deny for the materializer");
+    // It is a DENY, not an allow (the audit anchor reports the effect predicate).
+    assert_eq!(out.deny_triple.as_ref().map(|t| t.1.as_str()),
+        Some("https://sparq.dev/ns/auth#effect"), "deny anchor: {out:?}");
+}
+
+// 25. RE-CHECKED end-to-end with DENY-OVERRIDES: a public allow grant is in force, and a
+//     conditional deny carves out carol. carol is denied (deny beats allow); everyone
+//     else keeps the allow. This composes the conditional deny with an existing allow.
+#[test]
+fn conditional_deny_overrides_allow_for_carved_party() {
+    let mut store = PodStore::new(pod());
+    // A public allow: everyone may read n1 (a bare permission, conditional path → Public).
+    let permit = parse_policy_str(
+        r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+        <urn:pol/pub> a odrl:Set ; odrl:permission [
+            odrl:action odrl:read ; odrl:target <https://pod.ex/notes/n1> ] ."#,
+        "turtle",
+    )
+    .unwrap();
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_permission_conditional(&permit, &req).granted);
+    assert!(reads(&mut store, CAROL), "everyone reads before the deny");
+    assert!(reads(&mut store, BOB), "bob reads before the deny");
+
+    // Now layer the conditional deny carving out carol.
+    let out = store.materialize_odrl_prohibition_conditional(&prohibit_recipient_carol_policy(), &req);
+    assert!(out.prohibited, "deny condition materialized: {out:?}");
+    assert!(!reads(&mut store, CAROL), "DENY-OVERRIDES: carol loses access");
+    assert!(reads(&mut store, BOB), "bob keeps the allow (only carol is denied)");
+    // End-to-end query_as: carol sees nothing, bob sees the content.
+    let sel = "SELECT ?t WHERE { ?s <https://ex.dev/ns#title> ?t }";
+    let carol = Session { agent: Some(CAROL), client: None };
+    let bob = Session { agent: Some(BOB), client: None };
+    assert_eq!(store.query_as(&carol, Mode::Read, sel).unwrap().rows.len(), 0);
+    assert_eq!(store.query_as(&bob, Mode::Read, sel).unwrap().rows.len(), 1);
+}
+
+// 26. The deny APPEARS/RETRACTS as the condition flips: a recipient-neq prohibition maps
+//     to a deny on everyone EXCEPT bob; when the prohibition is WITHDRAWN, refresh
+//     retracts the deny and access is restored (composes with sq-2pcf deny-retraction).
+#[test]
+fn conditional_deny_retracts_when_prohibition_withdrawn() {
+    let mut store = PodStore::new(pod());
+    // Baseline public allow so we can observe the deny biting and then lifting.
+    let permit = parse_policy_str(
+        r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+        <urn:pol/pub> a odrl:Set ; odrl:permission [
+            odrl:action odrl:read ; odrl:target <https://pod.ex/notes/n1> ] ."#,
+        "turtle",
+    )
+    .unwrap();
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_permission_conditional(&permit, &req).granted);
+
+    // "everyone EXCEPT bob is prohibited" → a deny condition with a bob exception.
+    let prohib = parse_policy_str(
+        r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+        <urn:pol/pneq> a odrl:Set ; odrl:prohibition [
+            odrl:action odrl:read ; odrl:target <https://pod.ex/notes/n1> ;
+            odrl:constraint [ odrl:leftOperand odrl:recipient ; odrl:operator odrl:neq ;
+                              odrl:rightOperand <https://bob.ex/card#me> ] ] ."#,
+        "turtle",
+    )
+    .unwrap();
+    assert!(store.materialize_odrl_prohibition_conditional(&prohib, &req).prohibited);
+    // The deny carves out everyone except bob: carol denied, bob keeps the allow.
+    assert!(!reads(&mut store, CAROL), "carol (not bob) is denied by the conditional deny");
+    assert!(reads(&mut store, BOB), "bob is excepted from the deny → keeps the allow");
+
+    // WITHDRAW the prohibition entirely → refresh → the deny is retracted → access back.
+    let empty = parse_policy_str(
+        r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> . <urn:pol/x> a odrl:Set ."#,
+        "turtle",
+    )
+    .unwrap();
+    let (matched, retracted) =
+        store.refresh_odrl_grant(&empty, &req, BridgeKind::ProhibitionConditional);
+    assert!(matched, "the tracked deny slot matched");
+    assert_eq!(retracted, 1, "the withdrawn deny condition was retracted");
+    assert!(reads(&mut store, CAROL), "deny withdrawn → carol regains access");
+    assert_eq!(cond_denies_for(&store.graph, None), 0, "no residual deny condition");
+}
+
+// 27. MIXED / unmappable constraint falls back to ONE-SHOT: a recipient-eq + dateTime
+//     prohibition cannot persist the time bound as a condition (ACP has no clock), so it
+//     falls back to the one-shot deny (frozen, materialized iff the prohibition matches).
+#[test]
+fn conditional_deny_mixed_constraint_falls_back_one_shot() {
+    let pol = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/mix> a odrl:Set ; odrl:prohibition [
+    odrl:action odrl:read ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:assignee <https://carol.ex/card#me> ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lt ;
+                      odrl:rightOperand "2027-01-01T00:00:00Z"^^xsd:dateTime ] ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    // carol asking, with a time INSIDE the window → the one-shot deny materializes
+    // (frozen `auth:denyRead`), NOT a re-checked deny condition.
+    let mut g = pod();
+    let req = Request::new(odrl("read"))
+        .on(N1)
+        .by(CAROL)
+        .with(odrl("dateTime"), Value::DateTime("2026-06-16T00:00:00Z".to_owned()));
+    let out = materialize_prohibition_conditional(&mut g, &pol, &req);
+    assert!(out.prohibited, "one-shot deny materializes inside the window: {out:?}");
+    // No re-checked deny CONDITION emitted — the time bound forced the one-shot path.
+    assert_eq!(cond_denies_for(&g, None), 0, "unmappable dateTime → no deny condition");
+    // The frozen one-shot deny names carol via auth:denyRead.
+    assert_eq!(out.deny_triple.as_ref().map(|t| t.1.contains("denyRead")), Some(true), "{out:?}");
+}

--- a/skills/usage-control-policy/SKILL.md
+++ b/skills/usage-control-policy/SKILL.md
@@ -74,7 +74,7 @@ assert_eq!(d.matched_rules.len(), 1);  // the granting permission, for audit
 
 ## Building the request
 
-`Request::new(action_iri)` then chain `.on(target)`, `.by(party)`, `.with(left_operand_iri, Value)` for each context dimension (`dateTime`, `purpose`, `recipient`, `count`, `spatial`, …), and `.discharge(duty_action_iri)` per discharged duty. `Value` is `Iri` | `Str` | `Num(f64)` | `DateTime(String)`. For purpose specifically, prefer the first-class `.for_purpose(Value)` (sugar over `.with(ODRL_PURPOSE, ..)`); read it back via `req.purpose()`.
+`Request::new(action_iri)` then chain `.on(target)`, `.by(party)`, `.with(left_operand_iri, Value)` for each context dimension (`dateTime`, `purpose`, `recipient`, `count`, `spatial`, …), and `.discharge(duty_action_iri)` per discharged duty. `Value` is `Iri` | `Str` | `Num(f64)` | `DateTime(String)`. For purpose specifically, prefer the first-class `.for_purpose(Value)` (sugar over `.with(ODRL_PURPOSE, ..)`; read it back via `req.purpose()`); for the evaluation time prefer `.at(instant)` (sugar over `.with(ODRL_DATETIME, Value::DateTime(..))`; read it back via `req.request_time()`).
 
 ## `odrl:purpose` enforcement (faithful, fail-closed) — [OPUS-4.8] sq-q56r
 
@@ -92,7 +92,16 @@ A `recipient` constraint restricts **who the data may be disclosed to**. The rec
 - **`recipient neq X` ("everyone EXCEPT X"):** grants/forbids for any recipient that is **not** `X`. A request whose recipient IS `X` is the carve-out (deny on a permission; the prohibition no longer carves *this* party out). **Missing identity (no `odrl:recipient` AND no party) is *unprovable* → fail-closed:** a `neq` permission does **not** grant to an unknown recipient, and a `neq` prohibition is **not** withdrawn.
 - **`eq`/`isA`** = recipient IS the named party; **`isPartOf`** = recipient ∈ static set. Match is **exact** IRI/string equality (no recipient hierarchy).
 - **Audit:** `recipient_status(&rule, &request) -> RecipientMatch` reports exactly what the evaluator checks — `Satisfied` / `DefinitelyUnsatisfied` / `Unprovable` / `NotConstrained` (the recipient dual of `purpose_status`).
+- **Combined `recipient eq A AND neq B` (one rule):** the constraints are ANDed — the recipient must BE `A` and must NOT BE `B`. Through the bridge this emits a single `ConditionalGrant` headed by `A` (positive) carrying an `exceptMatcher` carving out `B` (the per-head exception).
 - Through the bridge, `recipient neq X` maps to an ACP **`noneOf`** exception (see the mapping table + the bridge note below) — re-checked per session.
+
+## `odrl:dateTime` time-window enforcement (faithful, fail-closed) — [OPUS-4.8] sq-idnv
+
+A `dateTime` constraint gates a permission/prohibition to a **time window** — e.g. `dateTime lteq T` (valid until `T`), `dateTime gteq T` (valid from `T`), or a two-sided window (`gteq lower` + `lteq upper`, ANDed). The actual instant is the request's **evaluation time**, supplied as `xsd:dateTime` evidence via the first-class `Request::at(instant)` sugar (over `.with(ODRL_DATETIME, Value::DateTime(..))`); read it back via `req.request_time()`.
+
+- **Semantics:** inside the window → grant (permission) / carve-out applies (prohibition); outside → deny / carve-out gone. Instants compare by magnitude (the `lt`/`lteq`/`gt`/`gteq`/`eq`/`neq` ordering). **Missing time → *unprovable* → fail-closed:** a time-gated permission does **not** grant on an unknown clock; a time-gated prohibition is **not** withdrawn (never silently read as "any time").
+- **Audit:** `datetime_status(&rule, &request) -> DateTimeMatch` reports exactly what the evaluator checks — `Satisfied` / `DefinitelyUnsatisfied` / `Unprovable` / `NotConstrained` (the temporal dual of `purpose_status`/`recipient_status`).
+- Through the bridge, `dateTime` stays **one-shot** (frozen at materialization — ACP matcher accept-sets are static, there is no "now" dimension to re-check; see the mapping table). A changed window is re-evaluated on the next `refresh_odrl_grant` — a lapsed window then retracts the grant. (`dateTime` ordering compares the lexical form — mixed-offset normalization is a deferred bead.)
 
 ## `odrl:count` enforcement (stateful, opt-in `count-enforcement`) — [OPUS-4.8] sq-zi5w
 
@@ -184,6 +193,14 @@ store.materialize_odrl_permission_conditional(&policy, &req); // policy: recipie
 **Fail-safe on mixed constraints:** a persisted condition is emitted ONLY when **every** constraint on the rule maps faithfully. A rule mixing a mappable recipient with an unmappable `dateTime`/`purpose`/`count` falls back **entirely** to the one-shot path — persisting only the recipient would silently drop the time/purpose/count bound and over-grant. Recipient IRIs inside the reserved pair encoding (`urn:sparq:` / `&client=`) are dropped from the grant head (anti-impersonation). The two ODRL "any recipient" sentinels fold onto auth principals: `odrl:All`/`odrl:Group` → `auth:Public`, `odrl:AllConnections` → `auth:Authenticated`.
 
 **Why only recipient/assignee maps:** the ACP session re-check carries exactly `(agent, client)`. The recipient-of-data is precisely the session **agent**, so an agent matcher re-checks it with identical semantics. Purpose, time, and count have **no** stateless `(agent, client)` analogue, so persisting them would require either freezing the check (= the one-shot path, already correct) or a looser approximation that could over-grant — rejected.
+
+### Constraint-conditional DENY (`materialize_odrl_prohibition_conditional`) — [OPUS-4.8] sq-4r70
+
+The dual of the conditional grant: a matched ODRL **prohibition** whose recipient/assignee constraints map faithfully is persisted as a re-checked `auth:ConditionalGrant` with **`auth:effect auth:Deny`** (rather than a frozen one-shot `auth:deny*`). The carve-out is re-verified per session through the SAME `accessible`/`query_as` path, and **composes with deny-overrides**: the session layer subtracts `∪ deny` from `∪ allow`, so a conditional deny that applies to a session removes the target from its accessible set — beating any allow for the same principal+target+mode.
+
+- A prohibition `recipient eq carol` → a deny condition headed by carol (only carol's sessions are denied); `recipient neq bob` → a deny on **everyone EXCEPT bob** (an `exceptMatcher` carving bob back IN to access). Same mapping table as the allow path (recipient/assignee `eq`/`isA`/`isPartOf`/`neq` are faithful; `purpose`/`dateTime`/`count` are unmappable).
+- **Fail-safe fallback:** a prohibition carrying an unmappable constraint (`purpose`/`dateTime`/`count`) falls back to the one-shot `materialize_odrl_prohibition` (frozen, materialized iff the prohibition currently matches) so the bound is still enforced — a persisted deny condition is emitted ONLY when every constraint maps faithfully. A reserved-encoded recipient cannot become a matcher, so the rule falls back to one-shot rather than emit a deny that silently fails to bite (which would FAIL OPEN — a dropped deny widens access).
+- **Refresh.** Tracked as `BridgeKind::ProhibitionConditional`. On refresh the recipient carve-out is re-checked per session, so the deny is re-emitted while the prohibition still structurally names the request; a withdrawn prohibition re-emits nothing → the deny condition is **retracted** → access restored. A one-shot fallback uses the asymmetric deny-retraction rule below (re-emit on `Ambiguous`, retract only on a definite `Withdrawn`).
 
 ### Refresh / REVOCATION of bridged grants on policy change — [OPUS-4.8] sq-dpk4
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Three related ODRL deliverables in one PR (all in `sparq-policy` / `sparq-solid` — same crates), behind the existing opt-in policy features.

**Stacked on #343 (sq-5037).** This PR's base is `feat-odrl-recipient-neq` so the diff shows only the three deliverables below; deliverable #3 is the explicit follow-up to #343. GitHub will auto-retarget to `main` once #343 merges.

### sq-idnv — `odrl:dateTime` time-window constraint
- `ODRL_DATETIME` const + `Request::at(instant)` sugar + `Request::request_time()` accessor (temporal analogue of `for_purpose`/`purpose`).
- New `datetime_status -> DateTimeMatch` audit surface (temporal dual of `purpose_status`/`recipient_status`) reporting exactly what `evaluate` checks: `Satisfied` / `DefinitelyUnsatisfied` / `Unprovable` / `NotConstrained`. Inside-window grants; lapsed/early denies; **missing time → Unprovable → fail-closed** (permission does not grant; prohibition not withdrawn). Two-sided windows ANDed.
- **Bridge:** dateTime has no faithful re-checked ACP analogue (matcher accept-sets are static — no "now"), so it stays **one-shot** (frozen); a lapsed window retracts on the next `refresh_odrl_grant`. Documented honestly, not over-claimed.

### sq-4r70 — constraint-conditional deny (the dual of the conditional grant)
- New `materialize_prohibition_conditional` + `PodStore::materialize_odrl_prohibition_conditional`: a matched prohibition whose recipient/assignee constraints map faithfully persists as a re-checked `auth:ConditionalGrant` with **`auth:effect auth:Deny`** (generalised `append_conditional_grants` via a `GrantEffect`). Composes with **deny-overrides** through the SAME `accessible` path (the conditional deny adds to the `denied` set, beating any allow).
- Unmappable (`purpose`/`dateTime`/`count`) or reserved-encoded recipient → falls back to the one-shot deny (**fail-closed** — a dropped deny would FAIL OPEN). Tracked as `BridgeKind::ProhibitionConditional`; refresh re-checks per session and retracts only on a genuine withdrawal (sq-2pcf deny-retraction). Tested: deny **appears/retracts** as the condition flips.

### sq-5037 follow-up — combined `recipient eq A AND neq B`
- The per-head exception (`agents=[A]` + `except=[B]` noneOf) was structurally emitted by #343 but untested. Added evaluator-level + bridge-level tests: carol positive head + bob `exceptMatcher`; only carol granted end-to-end; the prohibition dual.

### Gates (run once for the bundle — green BOTH feature states)
`cargo build` / `clippy --all-targets -D warnings` / `test` for `sparq-policy` (default + `count-enforcement`) and `sparq-solid` (default + `odrl-bridge`). All green, incl. doctests. Tests go through the REAL path (`accessible`/`query_as`, end-to-end parse+evaluate).

Docs updated for all three: `skills/usage-control-policy/SKILL.md` + `crates/sparq-policy/README.md` + `crates/sparq-solid/README.md`.

Refs sq-idnv, sq-4r70, sq-5037.