### PR TITLE
docs(skill): update academic-paper SKILL to as-built (native HTML export, paper-evidence.json)

### DIFF
--- a/skills/academic-paper/SKILL.md
+++ b/skills/academic-paper/SKILL.md
@@ -94,27 +94,45 @@ SIGMOD multi-round) → target submit-when-ready, not one annual crunch.
 
 ---
 
-## Stage 2 — Canonical benchmark capture (the honesty boundary)
+## Stage 2 — Evidence capture (the honesty boundary)
 
-Run the eval on the pinned **canonical runner** (bare-metal / frequency-pinned —
-`research/ci-ec2-design.md`). Emit result records into the `benchmark-data` branch (which
-`site/scripts/sync-benchmarks.mjs` folds into `site/src/data/benchmarks.generated.json`),
-each carrying:
+Paper-bound numbers live in a **dedicated evidence file, `site/src/data/paper-evidence.json`**
+— distinct from `site/src/data/benchmarks.generated.json`. The two MUST NOT be conflated:
+
+- **`paper-evidence.json`** — the *canonical-only* paper evidence. Every record is a
+  deterministic, machine-INDEPENDENT metric (a recall floor, an answer-safety invariant, a
+  cost-model crossover) lifted from a named test, so each is `environment: "canonical"` and
+  carries a `source` field tracing it to that test/dataset. [OPUS-4.8: as-built, PR #336.]
+- **`benchmarks.generated.json`** — per-commit *timing* on the dev work-box, **all
+  `environment: "indicative"`** (folded in by `site/scripts/sync-benchmarks.mjs` from the
+  `benchmark-data` branch). It feeds the site's benchmark widgets, **never** a paper headline.
+
+A paper-evidence record:
 
 ```json
-{ "key": "filtered_ann.recall_at_10", "value": 0.98, "unit": "recall",
-  "n_reps": 30, "dispersion": { "ci95": [0.97, 0.99] },
-  "environment": "canonical",
-  "cpu": "...", "kernel": "...", "rustc": "...", "dataset_sha256": "...",
-  "seed": 42, "commit": "<sha>" }
+{ "value": 0.90, "unit": "recall@10", "environment": "canonical",
+  "kind": "deterministic-floor",
+  "source": "crates/sparq-vectors/tests/filtered.rs::filtered_traversal_recall_vs_exact_on_broad_mask",
+  "note": "machine-independent: a deterministic seed + an assertion threshold, not a timing." }
 ```
 
-**The CI gate:** any record with `environment: "indicative"` is **BLOCKED** from a
-paper-bound table — the build fails if a paper's `#bench.<key>` resolves to an indicative
-record. Indicative and canonical numbers are never in the same table and never feed an
-aggregate. Until the canonical runner exists (blocked on one IAM step), publish **only the
-deterministic metrics** (conformance counts, recall floors, byte-identity, gate/round/byte
-counts) — those are canonical today.
+**The honesty gate (two layers, both as-built in PR #336):**
+
+1. **Data layer — `site/scripts/build-papers.mjs::runHonestyGate()` runs FIRST**, before any
+   compile: it schema-checks `paper-evidence.json` (every record needs a valid `environment`
+   ∈ {canonical, indicative}, a `source`, and a `value`) so a malformed/untraceable record is
+   a clear early build failure, not a Typst stack trace.
+2. **Compile layer — `headline(key)` in `site/papers/_lib/bench.typ` panics the Typst
+   compile** if a record's `environment != "canonical"`. `headline()` is the ONLY accessor
+   allowed inside a headline result table/figure; the ungated `ev(key)` is for
+   clearly-labelled *indicative* callouts only.
+
+So any non-canonical (work-box / indicative) number can never appear as a paper's headline
+evidence. Indicative and canonical numbers are never in the same table and never feed an
+aggregate. Until the canonical *latency* runner exists (`research/ci-ec2-design.md`, blocked
+on one IAM step), publish **only the deterministic metrics** (conformance counts, recall
+floors, byte-identity / answer-safety invariants, gate/round/byte counts) — those are
+canonical today and are exactly what `paper-evidence.json` holds.
 
 ---
 
@@ -144,20 +162,23 @@ counts) — those are canonical today.
 - **Conclusion** with concrete numbers; **no wishlist "future work"** ("no partial credit for
   neat things you wanted to do but didn't").
 
-**The live-data recipe (the load-bearing factory mechanism).** Author one `.typ`; inject the
-live JSON at build via `--input` / `sys.inputs`. At the top of the paper:
+**The live-data recipe (the load-bearing factory mechanism).** Author one `.typ`; the build
+injects `paper-evidence.json` via `--input data=...`. Numbers are read through the shared
+`site/papers/_lib/bench.typ` helpers, **never** hard-coded:
 
 ```typ
-#let bench = json(bytes(sys.inputs.data))
-#let anon  = sys.inputs.at("anon", default: "false") == "true"
+#import "_lib/bench.typ": headline, ev, provenance, authors, anon
 ```
 
-Then the eval section references `#bench.<key>` — **never a hard-coded number**:
+`bench.typ` binds `#let evidence = json(bytes(sys.inputs.data))` once and exposes the
+accessors. The eval section uses `#headline(key)` for any headline table/figure (it panics
+the compile on a non-canonical record — the honesty gate), and the ungated `#ev(key)` only
+inside an explicitly-labelled *indicative* callout:
 
 ```typ
-We observe recall@10 of #bench.filtered_ann.recall_at_10
-over #bench.filtered_ann.n_queries queries (#bench.filtered_ann.n_reps reps,
-95% CI #bench.filtered_ann.dispersion.ci95).
+The filtered top-k matches the exact-filtered ground truth at recall@10
+>= #headline("filtered_ann.recall_at_10_floor").
+#provenance("filtered_ann.recall_at_10_floor")
 ```
 
 Run the self-check before handing off to review:
@@ -180,23 +201,38 @@ Run the self-check before handing off to review:
 
 ## Stage 4 — Build: one source → PDF + in-site HTML
 
-```bash
-# PDF (static asset served by the Next.js static export):
-typst compile site/papers/<slug>/paper.typ site/public/papers/<slug>.pdf \
-  --input data="$(cat site/src/data/benchmarks.generated.json)"
+`site/scripts/build-papers.mjs` (wired into `prebuild` + `dev`) drives both artifacts for
+every paper in `papers.ts`, injecting the SAME `paper-evidence.json` so they cannot diverge.
+The two compile invocations it runs (paths relative to `site/`, `--root site`):
 
-# anonymized build for a double-blind venue (strips jeswr/sparq identity):
-typst compile site/papers/<slug>/paper.typ /tmp/<slug>-anon.pdf \
-  --input data="$(cat site/src/data/benchmarks.generated.json)" --input anon=true
+```bash
+# PDF (the download — static asset under public/papers/, served by the Next.js export):
+typst compile papers/<source>.typ public/papers/<slug>.pdf \
+  --root . --input data="$(cat src/data/paper-evidence.json)"
+
+# In-site HTML — Typst NATIVE HTML export (NOT typst.ts):
+typst compile papers/<source>.typ src/generated/papers/<slug>.html \
+  --root . --format html --features html --input data="$(cat src/data/paper-evidence.json)"
+
+# anonymized build for a double-blind venue (the .typ's authors()/anon honour this):
+typst compile papers/<source>.typ /tmp/<slug>-anon.pdf \
+  --root . --input data="$(cat src/data/paper-evidence.json)" --input anon=true
 ```
 
-The **in-site HTML** page at `/papers/<slug>` renders the *same* `.typ` via **typst.ts**
-(`@myriaddreamin/typst.react`), fed the same JSON — so HTML and PDF cannot show different
-numbers. (Typst's own HTML export is still experimental; use typst.ts today.) The build step
-(`site/scripts/build-papers.mjs`) is wired into `prebuild`, so `next build` regenerates every
-paper's PDF against fresh data; a `benchmark-data` change re-triggers it (numbers
-auto-update). For a venue that rejects Typst→LaTeX, the camera-ready fallback is Pandoc/LaTeX
-via Tectonic against `acmart`/`IEEEtran`/`lipics`. **Do not** author the PDF with
+[OPUS-4.8: as-built, PR #336.] The **in-site HTML** page at `/papers/<slug>` uses **Typst's
+native HTML export** — *not* typst.ts/`@myriaddreamin/typst.react`. The build extracts the
+`<body>` inner HTML and the React route (`components/papers/paper-html.tsx`) injects it as a
+static fragment into a scoped `.paper-prose` block (no WASM compiler shipped to the browser).
+The PDF and the HTML are built from the *same* `.typ` + the *same* injected evidence, so the
+numbers can't diverge. **Trade-off:** native HTML export is experimental, so **layout-only
+constructs (centring, alignment, page rules / horizontal rules) drop in the HTML view** — the
+expected `--features html` "experimental feature" + page-rule warnings on stderr are harmless;
+those constructs are **preserved in the PDF**. Author for both: rely on semantic structure
+(headings, tables, paragraphs) for meaning, treat alignment as PDF-only polish. If Typst is
+not on `PATH`, the script emits an honest placeholder fragment and warns (CI installs Typst so
+real artifacts always build). A `benchmark-data`/evidence change re-triggers `next build` and
+both artifacts regenerate. For a venue that rejects Typst→LaTeX, the camera-ready fallback is
+Pandoc/LaTeX via Tectonic against `acmart`/`IEEEtran`/`lipics`. **Do not** author the PDF with
 `@react-pdf/renderer` — it duplicates the numbers (breaks single-source).
 
 ---
@@ -207,8 +243,9 @@ For every claim in the intro/contributions list, identify its evidence (analysis
 measurement / case study) and confirm the forward-reference resolves. The gate (run as
 subagent section-reviewers + one cross-cutting honesty/repro reviewer) **blocks** on:
 
-- **Any indicative number in a claim** (the Stage-2 CI gate enforces this mechanically; the
-  reviewer also checks no indicative/canonical co-tabulation).
+- **Any indicative number in a claim** (the Stage-2 build-time honesty gate —
+  `build-papers.mjs` schema-check + the `headline()` compile panic — enforces this
+  mechanically; the reviewer also checks no indicative/canonical co-tabulation).
 - **A C-family (ZK/MPC) draft using "secure"/"verifiable"/"private" as a proven property** —
   must be a design goal, with the sq-qhy4 soundness-gap disclaimer present.
 - **Overclaiming / implied generality, weak/unfair baselines, missing ablations, no error
@@ -222,11 +259,12 @@ every headline number is canonical.
 ## Stage 6 — Publish & auto-update
 
 Merge → `next build` serves `/papers/<slug>` + `/papers/<slug>.pdf` (static export, under the
-`/sparq` basePath). A `benchmarks.generated.json` refresh re-runs the build → both artifacts
-regenerate with current numbers. Each paper carries a **provenance stamp** (commit + canonical
-runner fingerprint + dataset SHA-256). A venue camera-ready triggers the optional Typst→LaTeX
-export. To **register a new paper**, add an entry to `site/src/data/papers.ts` and a
-`site/papers/<slug>/paper.typ` — the index, the per-paper route, the nav, and the PDF build
+`/sparq` basePath). A `paper-evidence.json` refresh re-runs the build → both artifacts
+regenerate with current numbers. Each headline number carries its **provenance** inline (the
+`provenance(key)` helper prints the record's `source` test + `environment`). A venue
+camera-ready triggers the optional Typst→LaTeX export. To **register a new paper**, add an
+entry to `site/src/data/papers.ts` (`slug` + `source`) and a `site/papers/<source>.typ` (e.g.
+`filtered-ann.typ`) — the index, the per-paper route, the nav, and the PDF build
 are all data-driven off `papers.ts`.
 
 ---
@@ -266,5 +304,6 @@ eval). See `research/paper-contributions-inventory.md` (Part 2) and
 - This is a **site/process** surface, not a public crate API, so it is not in the
   `skills/SKILL.md` public-surface router (that router lists code-integration surfaces).
   Keep this skill in sync with `research/paper-factory-design.md` if the pipeline changes.
-- Verify before relying on version-specific features: typst.ts's pinned upstream compiler vs
-  Typst 0.15; the current-year CFP for any target venue.
+- Verify before relying on version-specific features: Typst's native HTML export is still
+  experimental (the layout-only-drop caveat in Stage 4 — re-check each Typst release whether
+  more layout survives the HTML view); the current-year CFP for any target venue.


### PR DESCRIPTION
> 🤖 SPARQ agent

Updates `skills/academic-paper/SKILL.md` (from PR #322, written at design time) to match what was ACTUALLY built in the paper factory (PR #336, branch `feat-paper-factory`). DOC-ONLY — no `crates/` changes, no EC2. Every as-built claim verified against the real site sources (`site/scripts/build-papers.mjs`, `site/papers/_lib/bench.typ`, `site/src/data/paper-evidence.json`, `site/src/data/papers.ts`, `site/src/components/papers/paper-html.tsx`).

## Two design-time assumptions corrected

**Stage 4 — in-site HTML render.** Was: rendered via **typst.ts** (`@myriaddreamin/typst.react`) in the browser. As-built: **Typst NATIVE HTML export** (`typst compile --format html --features html`); the `<body>` inner HTML is extracted at build time and injected as a static fragment into a scoped `.paper-prose` block (no WASM compiler shipped to the browser). Same `.typ` + same injected evidence feed PDF and HTML so numbers can't diverge. Documents the **layout-only-drop caveat** (centring / alignment / page+horizontal rules drop in the HTML view but are preserved in the PDF) and the Typst-not-on-PATH placeholder fallback.

**Stage 2 — canonical evidence path.** Was: paper numbers come from `benchmarks.generated.json` via a `#bench.<key>` binding. As-built: a dedicated **`site/src/data/paper-evidence.json`** (deterministic, canonical-only, `environment`-tagged, every record traces to a named test via `source`), **distinct** from `benchmarks.generated.json` (per-commit work-box timing, all `environment: indicative`, never a paper headline). Two-layer honesty gate documented: `build-papers.mjs::runHonestyGate()` schema-checks the evidence first, then `headline(key)` in `papers/_lib/bench.typ` panics the Typst compile if `environment != "canonical"`.

Stage 3's live-data recipe and Stages 5/6 + Notes were realigned to the real `_lib/bench.typ` accessors (`headline`/`ev`/`provenance`) and the `papers.ts` (`slug` + `source`) registration shape, since they referenced the now-corrected file/binding.

The empirical-honesty rules (canonical vs indicative; no headline work-box latency; ZK/MPC not-externally-validated, cites sq-qhy4) are kept intact.

Reality matched the brief on all points. markdownlint-clean. paper-factory as-built SKILL bead + sq-gum8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)