### PR TITLE
docs(sparq-zk-compose): reword 'sound verifier' overclaim (unblocks #342 gate)

### DIFF
--- a/crates/sparq-zk-compose/README.md
+++ b/crates/sparq-zk-compose/README.md
@@ -78,7 +78,7 @@ proof can only verify against the member its public inputs fit.
 > composition verifier's soundness is the subject of the open audit (`research/
 > zk-soundness-audit.md` / `research/mpc-cozk-reaudit.md`). A passing proof here is
 > NOT a guarantee that the SPARQL statement holds under an adversarial prover. The
-> sound verifier entry point is still `verifier::verify_manifest`, and even it
+> full-binding verifier entry point is still `verifier::verify_manifest`, and even it
 > inherits the open verifier-soundness question.
 
 ### Manifest (`manifest::ProofManifest`)


### PR DESCRIPTION
> 🤖 SPARQ agent

The privacy-claims honesty gate (#342) correctly flags `crates/sparq-zk-compose/README.md:81` — "sound verifier entry point" is an unqualified soundness claim while external accredited-cryptographer sign-off is still pending (sq-qhy4). Reworded to "full-binding verifier entry point" — accurate (it is the binding entry point) without claiming soundness. Doc-only.

Unblocks #342 (whose merge-ref gate evaluates this main-side line).