### PR TITLE
fix(site): bump postcss >=8.5.10 (GHSA-qx2v-qp2m-jg93, sq-zkrt)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -6526,34 +6526,6 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",

--- a/site/package.json
+++ b/site/package.json
@@ -28,6 +28,9 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0"
   },
+  "overrides": {
+    "postcss": ">=8.5.10"
+  },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@tailwindcss/postcss": "^4.1.0",


### PR DESCRIPTION
> 🤖 SPARQ agent

`[OPUS-4.8]`

Clears Dependabot alert **#4** (GHSA-qx2v-qp2m-jg93 — medium XSS via unescaped `</style>` in PostCSS's CSS stringify output, vulnerable `<8.5.10`). Bead **sq-zkrt**.

## What & why
The vulnerable copy was `next@15.5.19`'s **exactly-pinned** transitive `postcss@8.4.31`. `npm update postcss` could not lift it (Next pins the exact version), so this adds a minimal `overrides` entry in `site/package.json`:

```json
"overrides": { "postcss": ">=8.5.10" }
```

After `npm install`, both copies dedupe to **postcss@8.5.15**:

```
├─┬ @tailwindcss/postcss@4.3.1
│ └── postcss@8.5.15 overridden
└─┬ next@15.5.19
  └── postcss@8.5.15 deduped
```

before → after: `8.4.31` (next's transitive) → `8.5.15`.

## Lockfile churn
Minimal — the only lockfile change is removal of the duplicated `node_modules/next/node_modules/postcss@8.4.31` block (+3 / −28). No unrelated deps bumped.

## Gates
- `npm install` succeeds; **`npm audit` → 0 vulnerabilities** (no remaining vulnerable copy; no new flagged version introduced).
- `npm ls postcss` → all resolve to **8.5.15** (>=8.5.10 ✓).
- `npm run build` (static export) green end-to-end, incl. the `/papers` route and the WASM bundle prereq (35/35 static pages, exported 2/2).
- `npm run lint` clean (no ESLint warnings or errors).

Dependabot #4 will clear once this merges to `main`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)