### PR TITLE
feat(js): surface SHACL validate() on SparqStore + shacl-enabled bundle (sq-pxls, #162)

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -38,9 +38,17 @@ browser. (The wasm bundle bytes are tracked per-commit on the perf dashboard,
 The package ships the wasm artifact; from a source checkout build it first:
 
 ```sh
-npm run build   # wasm-pack build ../crates/sparq-wasm + tsc
+npm run build   # wasm-pack build ../crates/sparq-wasm (--features shacl) + tsc
 npm test        # node --test against the built dist/
 ```
+
+The default build (and the published bundle) ships with `--features shacl` so
+`SparqStore.validate` works out of the box. SHACL is not free in the wasm
+binary — it pulls in the SHACL engine + `regex` + the SPARQL query path for
+`sh:sparql`, which roughly **doubles** the `.wasm` (measured ~1.21 MiB → ~2.19
+MiB, +~1.0 MiB / +85%, before gzip). If you do not need validation and bundle
+size matters, build the lean variant — `npm run build:wasm:lean` — which omits
+SHACL entirely (`SparqStore.validate` then throws a clear error if called).
 
 ## Usage
 
@@ -101,6 +109,15 @@ const fromZst = await SparqStore.fromCompressed(zstBytes, 'ntriples');
 const compact = await SparqStore.fromString(bigTurtle, 'turtle', { compressed: true });
 compact.heapBytes(); // rough wasm-side footprint
 
+// SHACL validation (data graph vs shapes graph) → a typed ValidationReport.
+// Stateless one-shot: does NOT consult the store's own triples (a drop-in for
+// rdf-validate-shacl). conforms counts every result; filter by severity for a gate.
+const report = store.validate(dataTurtle, shapesTurtle, 'turtle'); // format defaults to 'turtle'
+report.conforms;                                                    // boolean
+for (const r of report.results) {
+  console.log(r.focusNode, r.path, r.severity, r.message);          // per-violation fields
+}
+
 store.free(); // release wasm memory (also `using store = …` via Symbol.dispose)
 ```
 
@@ -134,6 +151,10 @@ verified warm-up from `GET /dictionary/{dict-id}` for the *next* request.
   graph (use `countQuads()` for dataset totals). `dataset` is not combinable
   with `compressed` yet.
 - CONSTRUCT / DESCRIBE / federated queries are not supported (tracked in beads — `bd list -l area:js`).
+- `validate()` (SHACL) runs in-process and is best for small documents
+  (~10–100 triples); for large data graphs validate server-side via the
+  `sparq-server` HTTP `validate` path. It needs a `--features shacl` bundle
+  (shipped by default; `build:wasm:lean` omits it — see *Install / build*).
 - `REGEX`/`REPLACE` are compiled out of the wasm build (the engine's
   non-default `regex` cargo feature) to keep the bundle small — use
   `CONTAINS`/`STRSTARTS`/… or a custom build.

--- a/js/package.json
+++ b/js/package.json
@@ -33,7 +33,9 @@
     "node": ">=18"
   },
   "scripts": {
-    "build:wasm": "wasm-pack build ../crates/sparq-wasm --target web --release && rm -rf wasm && mkdir wasm && cp ../crates/sparq-wasm/pkg/sparq_wasm.js ../crates/sparq-wasm/pkg/sparq_wasm.d.ts ../crates/sparq-wasm/pkg/sparq_wasm_bg.wasm ../crates/sparq-wasm/pkg/sparq_wasm_bg.wasm.d.ts wasm/",
+    "_copy:wasm": "rm -rf wasm && mkdir wasm && cp ../crates/sparq-wasm/pkg/sparq_wasm.js ../crates/sparq-wasm/pkg/sparq_wasm.d.ts ../crates/sparq-wasm/pkg/sparq_wasm_bg.wasm ../crates/sparq-wasm/pkg/sparq_wasm_bg.wasm.d.ts wasm/",
+    "build:wasm": "wasm-pack build ../crates/sparq-wasm --target web --release -- --features shacl && npm run _copy:wasm",
+    "build:wasm:lean": "wasm-pack build ../crates/sparq-wasm --target web --release && npm run _copy:wasm",
     "build:ts": "tsc",
     "build": "npm run build:wasm && npm run build:ts",
     "test": "node --test \"test/*.test.mjs\"",

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -1,4 +1,10 @@
-export { SparqStore, type RdfFormat, type SparqStoreOptions } from './store.js';
+export {
+  SparqStore,
+  type RdfFormat,
+  type SparqStoreOptions,
+  type ValidationReport,
+  type ValidationResult,
+} from './store.js';
 export { Bindings } from './bindings.js';
 export { DataFactory, NamedNode, BlankNode, Literal, Variable, DefaultGraph, Quad } from './terms.js';
 export {

--- a/js/src/store.ts
+++ b/js/src/store.ts
@@ -21,6 +21,38 @@ import { init, WasmStore } from './wasm.js';
 
 export type RdfFormat = 'turtle' | 'ntriples' | 'nquads' | 'trig';
 
+/**
+ * [OPUS-4.8] sq-pxls (#162): one SHACL validation result — the per-violation
+ * shape PSS's ADR-0014 `ShaclValidator` seam consumes (a drop-in for
+ * `rdf-validate-shacl`'s result records). `focusNode`/`value`/`sourceShape`
+ * are N-Triples term strings (the lexical form sparq's `Term` `Display`
+ * produces); `path` is a SHACL Turtle path expression;
+ * `sourceConstraintComponent`/`severity` are full IRIs (e.g.
+ * `http://www.w3.org/ns/shacl#Violation`); `message` is the first declared
+ * `sh:message` text or a generated default. `path`/`value`/`message` are
+ * `null` when the underlying result carries none.
+ */
+export interface ValidationResult {
+  focusNode: string;
+  path: string | null;
+  value: string | null;
+  sourceShape: string;
+  sourceConstraintComponent: string;
+  severity: string;
+  message: string | null;
+}
+
+/**
+ * [OPUS-4.8] sq-pxls (#162): a SHACL validation report — the typed parse of
+ * the JSON the wasm `Store.validate` binding returns. `conforms` counts EVERY
+ * result regardless of severity (the W3C-suite notion); filter `results` by
+ * `severity` for a violations-only gate.
+ */
+export interface ValidationReport {
+  conforms: boolean;
+  results: ValidationResult[];
+}
+
 export interface SparqStoreOptions {
   /**
    * Store the index block-compressed (~half the index memory at a bounded
@@ -209,6 +241,40 @@ export class SparqStore {
    */
   count(sparql: string): number {
     return this.#inner.count(sparql);
+  }
+
+  /**
+   * [OPUS-4.8] sq-pxls (#162): validates an RDF **data graph** against a SHACL
+   * **shapes graph**, returning a typed SHACL {@link ValidationReport}.
+   *
+   * Both arguments are RDF documents in the same `format` {@link fromString}
+   * accepts (`"turtle"` (default) | `"ntriples"` | `"nquads"` | `"trig"`);
+   * they are parsed identically (named graphs folded into the default graph).
+   * This is a **stateless one-shot** — it does NOT consult the receiver's
+   * stored triples — so it is the ergonomic drop-in for `rdf-validate-shacl`'s
+   * `validate(dataDataset, { shapes })`, running through `sparq-shacl`'s SHACL
+   * Core + SHACL-SPARQL (`sh:sparql`, §5.2) engine inside wasm. The JSON the
+   * binding returns is parsed into the typed report here, so the caller never
+   * touches the raw string.
+   *
+   * `report.conforms` counts EVERY result regardless of severity (the W3C-suite
+   * notion); filter `report.results` by `severity` for a violations-only gate.
+   * Throws only if a graph fails to parse; malformed shapes are skipped by the
+   * engine, never surfaced. Validation is in-process and best for small
+   * documents (~10–100 triples); validate large graphs server-side via the
+   * `sparq-server` HTTP `validate` path instead (the other half of #162).
+   *
+   * Requires a `shacl`-enabled wasm bundle (the published `@jeswr/sparq` ships
+   * one); a `shacl`-less custom build throws a clear error here rather than a
+   * cryptic "not a function".
+   */
+  validate(data: string, shapes: string, format: RdfFormat = 'turtle'): ValidationReport {
+    if (typeof this.#inner.validate !== 'function') {
+      throw new Error(
+        'SparqStore.validate requires a SHACL-enabled wasm bundle (build sparq-wasm with --features shacl)',
+      );
+    }
+    return JSON.parse(this.#inner.validate(data, shapes, format)) as ValidationReport;
   }
 
   /**

--- a/js/test/shacl.test.mjs
+++ b/js/test/shacl.test.mjs
@@ -1,0 +1,83 @@
+// [OPUS-4.8] sq-pxls (#162): end-to-end exercise of `SparqStore.validate` —
+// the ergonomic SHACL surface PSS's ADR-0014 `ShaclValidator` seam consumes
+// (a drop-in for `rdf-validate-shacl`). This runs in a REAL wasm runtime
+// against the built `dist/`, so it also proves the SHIPPED bundle was built
+// with `--features shacl` (a shacl-less bundle would make `validate` throw the
+// "requires a SHACL-enabled wasm bundle" guard).
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { SparqStore } from '../dist/index.js';
+
+const SHAPES = `
+  @prefix sh: <http://www.w3.org/ns/shacl#> .
+  @prefix ex: <http://example.org/> .
+  @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+  ex:PersonShape a sh:NodeShape ;
+    sh:targetClass ex:Person ;
+    sh:property [
+      sh:path ex:age ;
+      sh:datatype xsd:integer ;
+      sh:minInclusive 0 ;
+      sh:message "age must be a non-negative integer" ;
+    ] ;
+    sh:property [
+      sh:path ex:name ;
+      sh:minCount 1 ;
+    ] .
+`;
+
+// validate is stateless — it does not consult the receiver's triples — so an
+// empty store is the natural caller (mirroring rdf-validate-shacl's API shape).
+const emptyStore = () => SparqStore.fromString('', 'turtle');
+
+test('validate() reports conforms:true for conforming data', async () => {
+  const store = await emptyStore();
+  const report = store.validate(
+    `@prefix ex: <http://example.org/> .
+     ex:alice a ex:Person ; ex:age 30 ; ex:name "Alice" .`,
+    SHAPES,
+    'turtle',
+  );
+  assert.equal(report.conforms, true);
+  assert.deepEqual(report.results, []);
+});
+
+test('validate() surfaces a violation with focusNode + message for violating data', async () => {
+  const store = await emptyStore();
+  const report = store.validate(
+    `@prefix ex: <http://example.org/> .
+     ex:bob a ex:Person ; ex:age -1 .`,
+    SHAPES,
+    'turtle',
+  );
+  assert.equal(report.conforms, false);
+  assert.ok(report.results.length >= 1, 'at least one violation');
+
+  // The negative-age violation carries the offending focus node, the property
+  // path, the declared message, the value, severity and the constraint IRI.
+  const ageViolation = report.results.find(
+    (r) => r.sourceConstraintComponent.endsWith('MinInclusiveConstraintComponent'),
+  );
+  assert.ok(ageViolation, 'minInclusive violation present');
+  assert.equal(ageViolation.focusNode, '<http://example.org/bob>');
+  assert.equal(ageViolation.path, '<http://example.org/age>');
+  assert.equal(ageViolation.message, 'age must be a non-negative integer');
+  assert.equal(ageViolation.severity, 'http://www.w3.org/ns/shacl#Violation');
+  assert.match(ageViolation.value, /-1/);
+
+  // The missing-name (minCount) violation is also reported.
+  assert.ok(
+    report.results.some((r) => r.sourceConstraintComponent.endsWith('MinCountConstraintComponent')),
+    'minCount violation present',
+  );
+});
+
+test('validate() defaults format to turtle', async () => {
+  const store = await emptyStore();
+  const report = store.validate(
+    `@prefix ex: <http://example.org/> .
+     ex:carol a ex:Person ; ex:age 40 ; ex:name "Carol" .`,
+    SHAPES,
+  );
+  assert.equal(report.conforms, true);
+});

--- a/skills/javascript-wasm/SKILL.md
+++ b/skills/javascript-wasm/SKILL.md
@@ -70,6 +70,9 @@ count(sparql): number                                // solution count, no mater
 queryBindingsStream(sparql): Generator<Bindings>     // stream solutions, for...of / for await...of
 queryJsonChunks(sparql): Generator<string>           // raw ~64 KiB JSON chunks (concat == queryJson)
 
+// SHACL validation (data graph vs shapes graph) — typed report; needs a shacl bundle (shipped by default)
+validate(data: string, shapes: string, format?: RdfFormat): ValidationReport  // { conforms, results[] }; stateless
+
 // RDF/JS quad lookup (null/undefined/Variable = wildcard; generated SELECT under the hood)
 match(s?, p?, o?, g?): Quad[]
 countQuads(s?, p?, o?, g?): number
@@ -86,7 +89,7 @@ free(): void                                         // also Symbol.dispose
 
 Other named exports from `@jeswr/sparq`: `DataFactory` (RDF/JS factory: `namedNode`, `blankNode`, `literal`, `variable`, `quad`, ...) and term classes `NamedNode/BlankNode/Literal/Variable/DefaultGraph/Quad`; `init` (idempotent wasm bootstrap); compression helpers `decompress / decompressToString / sniffCodec`; SPARQL helpers `termFromSparqlJson / termToNT / quadsToNQuads / detectQueryForm / askToSelect / SparqlJsonRowsParser`; and the `SparqDictionaryClient` (server dictionary-fetch protocol).
 
-Raw wasm `Store` (from `../wasm/sparq_wasm.js`, re-exported as `WasmStore` internally) — use only when you need CONSTRUCT/DESCRIBE, batch cursors, or **query-plan introspection**. Methods return SPARQL-JSON / N-Triples / plan-text **strings**, not RDF/JS terms: `Store.load/loadDataset/loadCompressed(text, format)`, `.query(sparql)`, `.queryChunks(sparql)`, `.queryCursor(sparql, batchSize)`, `.queryQuads(sparql)` (CONSTRUCT/DESCRIBE -> N-Triples), `.queryQuadsChunks(sparql, batchSize)`, `.count`, `.ask`, `.askWithMaxRows(sparql, maxRows)`, `.explain(sparql)`, `.explainAnalyze(sparql)`, `.update`, `.updateInPlace`, `.applyDelta(inserts, deletes)`, `.size`, `.heapBytes()`.
+Raw wasm `Store` (from `../wasm/sparq_wasm.js`, re-exported as `WasmStore` internally) — use only when you need CONSTRUCT/DESCRIBE, batch cursors, or **query-plan introspection**. Methods return SPARQL-JSON / N-Triples / plan-text **strings**, not RDF/JS terms: `Store.load/loadDataset/loadCompressed(text, format)`, `.query(sparql)`, `.queryChunks(sparql)`, `.queryCursor(sparql, batchSize)`, `.queryQuads(sparql)` (CONSTRUCT/DESCRIBE -> N-Triples), `.queryQuadsChunks(sparql, batchSize)`, `.count`, `.ask`, `.askWithMaxRows(sparql, maxRows)`, `.explain(sparql)`, `.explainAnalyze(sparql)`, `.validate(data, shapes, format)` (SHACL report as a JSON **string**, shacl bundle only), `.update`, `.updateInPlace`, `.applyDelta(inserts, deletes)`, `.size`, `.heapBytes()`.
 
 ## Common recipes
 
@@ -148,29 +151,29 @@ const trace = raw.explainAnalyze('PREFIX ex: <http://ex/> SELECT ?n WHERE { ?s e
 // plan + per-operator output rows (wall times read 0 on wasm32 — no monotonic clock)
 ```
 
-**SHACL validation (opt-in `shacl` feature, raw wasm only).** `Store.validate(data, shapes, format)` runs `sparq-shacl`'s SHACL Core + SHACL-SPARQL (`sh:sparql`) engine and returns a JSON validation report — a drop-in for `rdf-validate-shacl`. It is **stateless** (does not consult the receiver's triples) and only compiles when the wasm bundle is built with `--features shacl` (off in the default shipped bundle; build your own with it, or `--features shacl-af` to also get `sh:rule`). `format` is the same set `load` accepts.
+**SHACL validation (`SparqStore.validate`, shipped by default).** `validate(data, shapes, format?)` validates an RDF **data graph** against a SHACL **shapes graph** and returns a typed `ValidationReport` (the JSON the wasm binding emits, parsed for you). It runs `sparq-shacl`'s SHACL Core + SHACL-SPARQL (`sh:sparql`) engine inside wasm — a drop-in for `rdf-validate-shacl`. It is **stateless** (does not consult the store's own triples). `format` defaults to `'turtle'` and accepts the same set as `fromString`.
 
-```js
-import init, { Store } from '../wasm/sparq_wasm.js'; // a bundle built with --features shacl
-await init();
-const store = Store.load('', 'turtle');             // validate ignores the receiver
-const report = JSON.parse(store.validate(dataTurtle, shapesTurtle, 'turtle'));
-// { conforms: boolean,
-//   results: [{ focusNode, path, value, sourceShape,
-//               sourceConstraintComponent, severity, message }] }
+```ts
+import { SparqStore, type ValidationReport } from '@jeswr/sparq';
+
+const store = await SparqStore.fromString('', 'turtle'); // validate ignores the receiver
+const report: ValidationReport = store.validate(dataTurtle, shapesTurtle); // format defaults to 'turtle'
+// ValidationReport = { conforms: boolean;
+//   results: Array<{ focusNode; path; value; sourceShape;
+//                    sourceConstraintComponent; severity; message }> }
 report.conforms;                                     // false if ANY result (incl. Warning/Info)
 const violations = report.results.filter(
   r => r.severity === 'http://www.w3.org/ns/shacl#Violation');   // violations-only gate
 ```
 
-`focusNode`/`value`/`sourceShape` are N-Triples term strings; `path` is a SHACL Turtle path expression; `severity`/`sourceConstraintComponent` are full IRIs; `message` is the first `sh:message` text (or a generated default). `path`/`value`/`message` are `null` when absent. Only a graph parse failure throws (a `JsError`); malformed shapes are skipped, not surfaced. For large data graphs validate server-side via the `sparq-server` HTTP `validate` endpoint instead (the other half of the #162 decision). See the `shacl-validation` skill for the engine's SHACL coverage.
+The raw `Store.validate(data, shapes, format)` returns the same report as a JSON **string** (`JSON.parse` it yourself). `focusNode`/`value`/`sourceShape` are N-Triples term strings; `path` is a SHACL Turtle path expression; `severity`/`sourceConstraintComponent` are full IRIs; `message` is the first `sh:message` text (or a generated default). `path`/`value`/`message` are `null` when absent. Only a graph parse failure throws; malformed shapes are skipped, not surfaced. For large data graphs validate server-side via the `sparq-server` HTTP `validate` endpoint instead (the other half of the #162 decision). See the `shacl-validation` skill for the engine's SHACL coverage.
 
 ## Gotchas / feature flags / prerequisites
 
 - **ESM only, Node >= 18.** The package is `"type": "module"`; `init()` is idempotent and runs automatically on the first `SparqStore.from*` call (in Node it reads the wasm bytes from disk; in the browser/Deno it `fetch`es relative to the module). One runtime dep: `fzstd` (~8 KB, dynamically imported only when decoding zstd).
 - **`SparqStore` exposes SELECT/ASK only.** Its `query()` returns `Bindings[]` (SELECT) or `boolean` (ASK). CONSTRUCT/DESCRIBE and federated (`SERVICE`) queries are **not** exposed at the JS wrapper layer — use the raw `Store.queryQuads` for CONSTRUCT/DESCRIBE.
 - **`REGEX` / `REPLACE` are compiled out** of the wasm build (the engine's non-default `regex` cargo feature is off to keep the bundle small). Use `CONTAINS`/`STRSTARTS`/`STRENDS`/... or a custom wasm build with `--features regex`.
-- **SHACL `Store.validate` needs a `--features shacl` bundle.** The default shipped wasm bundle carries **zero** SHACL code (opt-in feature, off by default); `validate(data, shapes, format)` exists only in a bundle built with `--features shacl` (or `shacl-af` for `sh:rule`). It is on the raw `Store`, not `SparqStore`. Validation is in-process and best for small documents (~10–100 triples); large graphs should use the server-side HTTP `validate` path.
+- **SHACL is on `SparqStore.validate` (typed) AND raw `Store.validate` (JSON string), shipped by default.** The published bundle is built with `--features shacl`, so `validate` works out of the box. SHACL is **not free in the binary** — it pulls in the SHACL engine + `regex` + the `sh:sparql` query path, which roughly **doubles** the `.wasm` (measured ~1.21 MiB → ~2.19 MiB, +~1.0 MiB / +85%, pre-gzip). Size-sensitive consumers can build the lean variant (`npm run build:wasm:lean`, equivalently `wasm-pack build … --release` with no `--features`), which omits SHACL — `SparqStore.validate` then throws a clear "requires a SHACL-enabled wasm bundle" error. Use `--features shacl-af` to also compile `sh:rule`. Validation is in-process and best for small documents (~10–100 triples); large graphs should use the server-side HTTP `validate` path.
 - **`options.dataset` is not combinable with `options.compressed`** — there is no compressed dataset loader yet (the constructor throws). `compact-index` (3 permutations, ~half the memory) is auto-selected for wasm32 regardless; `compressed` adds block compression on top.
 - **`size` / `heapBytes` report the DEFAULT graph only.** For dataset totals use `countQuads()` (its graph wildcard spans named graphs).
 - **Mutation is overlay-based.** `update()` / `applyDelta()` write through an append-only delta overlay: the dictionary only grows, and deletes are tombstones until the wasm store is reloaded. Blank nodes in `applyDelta`/`removeQuads` are matched **by label** (so bnode triples can be retracted — impossible via SPARQL `DELETE DATA`).


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Opus 4.8, @jeswr's sparq agent) — bead **sq-pxls**, consumer of #162.

Surfaces the SHACL `validate()` binding (wasm `Store.validate`, landed behind the `shacl` cargo feature in #339 / sq-yqi1) on the published **`@jeswr/sparq`** JS client's `SparqStore` wrapper, and ships a `--features shacl` dist bundle, so PSS (#162) can consume it drop-in in place of `rdf-validate-shacl`.

## What changed (all in `js/` + the `javascript-wasm` SKILL doc)

- **`SparqStore.validate(data, shapes, format = 'turtle'): ValidationReport`** — calls the underlying wasm `Store.validate` and parses its JSON report into a typed TS shape:
  ```ts
  interface ValidationReport { conforms: boolean; results: ValidationResult[] }
  interface ValidationResult {
    focusNode: string; path: string | null; value: string | null;
    sourceShape: string; sourceConstraintComponent: string;
    severity: string; message: string | null;
  }
  ```
  Stateless one-shot (ignores the receiver's own triples — mirrors `rdf-validate-shacl`'s `validate(data, { shapes })`). A shacl-less custom build is guarded with a clear error rather than a cryptic "not a function". `ValidationReport`/`ValidationResult` are exported from the package entry point.

- **Bundle / build** — the default `build:wasm` (and so the published bundle) now builds `--features shacl` so `validate` is present out of the box. Added **`build:wasm:lean`** (no SHACL) for size-sensitive consumers.

  **Bundle-size impact (honest):** SHACL roughly **doubles** the `.wasm` — measured **1.21 MiB → 2.19 MiB (+~1.0 MiB / +85%)**, pre-gzip — because it pulls in the SHACL engine + `regex` + the `sh:sparql` query path. Decision: ship it on-by-default because `validate` is the headline ask of #162 and PSS needs it drop-in; the lean variant is one `npm run build:wasm:lean` away for consumers who don't need validation. The `shacl` cargo feature stays **off by default** in the crate, so the `wasm-deps-guard` (which checks the default graph) and any other default-feature consumer are unchanged.

- **Test** — `js/test/shacl.test.mjs` exercises `SparqStore.validate` end-to-end in a real wasm runtime against the built `dist/`: conforming → `conforms: true`; violating → a result with `focusNode`/`path`/`message`/`severity`. Because it runs against the shipped bundle, it also proves the bundle was built with `--features shacl`.

- **Docs** — `js/README.md` (usage + Install/build size note + Notes & limits) and `skills/javascript-wasm/SKILL.md` (Key APIs, the SHACL recipe, the feature-flag gotcha) document `SparqStore.validate`, the typed report, and the bundle-size trade-off.

## Gates

- `cargo build -p sparq-wasm --features shacl` — green.
- `cargo clippy -p sparq-wasm --target wasm32-unknown-unknown --features shacl --all-targets -D warnings` — clean.
- `wasm-deps-guard.sh` — OK (default no-shacl graph unchanged; no native-only dep leaks).
- `tsc` — clean; `dist/` exports `validate` + the new types.
- New test passes (3/3). The two pre-existing zstd tests (`compressed`, `dictionary`) fail **only on the dev box's Node 20** — they use Node ≥ 22's `zstdCompressSync`; CI's `js.yml` runs Node 22, where they pass. Unrelated to this change.
- Existing `@jeswr/sparq` API is unchanged (additive only).

## Deferred (maintainer)

- **npm publish** of the shacl-enabled `@jeswr/sparq` bundle — left to the orchestrator/maintainer.
- **Ping #162 / the PSS agent** once the shacl-enabled bundle is published, so PSS can switch its `ShaclValidator` seam to `SparqStore.validate`.

Refs sq-pxls, #162 (consumer (a) WASM/JS; the (c) HTTP `validate` endpoint is a separate lane).