### PR TITLE
feat(site): in-site benchmark trend + scaling charts (sq-hsyg)

### DIFF
--- a/site/scripts/sync-benchmarks.mjs
+++ b/site/scripts/sync-benchmarks.mjs
@@ -16,8 +16,17 @@
 //                         mirror; THIS file is the canonical source we read.
 //
 // OUTPUT: site/src/data/benchmarks.generated.json — a single typed JSON:
-//   { generatedAt, source, latest: { commit, date, benches }, labels, competitors }
+//   { generatedAt, source, latest: { commit, date, benches },
+//     history: [ { commit, date, benches }, ... ], labels, competitors }
 // committed so the site builds offline; re-run this script to refresh from the branch.
+//
+// [OPUS-4.8] sq-hsyg — `history` carries the trailing HISTORY_WINDOW (20) commits of the
+// SAME series the standalone bench/dashboard renders (window.BENCHMARK_DATA), so the site
+// can draw per-metric TREND charts (metric over commits) + SCALING charts (metric vs a
+// size/depth token in the metric name) WITHOUT a chart fetch at runtime. `latest` is kept
+// (it is history[history.length-1]) so every existing page is unaffected. We never
+// fabricate points: if the series is shorter than the window, history is just what exists,
+// and when the benchmark-data ref is unavailable we keep whatever history was committed.
 //
 // HOW THE BRANCH IS READ: data.js is NOT on `main`; it lives on `benchmark-data`. We
 // `git show origin/benchmark-data:dev/bench/data.js`. If that ref is absent (a shallow
@@ -51,6 +60,25 @@ function readBranchDataJs() {
   return null;
 }
 
+// [OPUS-4.8] sq-hsyg — same trailing window the standalone dashboard trends over.
+const HISTORY_WINDOW = 20;
+
+// Normalise one github-action-benchmark series entry to the site's slim shape
+// ({ commit, date, benches:[{name,value,unit}] }). `commit` is the short-or-full id; `date`
+// is the epoch-ms the entry carries (the site formats it). Defensive against a missing
+// commit/benches so a malformed entry never throws the build.
+function normEntry(entry) {
+  return {
+    commit: (entry.commit && entry.commit.id) || null,
+    date: entry.date || null,
+    benches: (entry.benches || []).map((b) => ({
+      name: b.name,
+      value: b.value,
+      unit: b.unit || "",
+    })),
+  };
+}
+
 function parseDataJs(text) {
   const json = text
     .replace(/^\s*window\.BENCHMARK_DATA\s*=\s*/, "")
@@ -60,16 +88,10 @@ function parseDataJs(text) {
   if (!Array.isArray(series) || series.length === 0) {
     throw new Error("benchmark series 'sparq engine' is empty");
   }
-  const latest = series[series.length - 1];
-  return {
-    commit: (latest.commit && latest.commit.id) || null,
-    date: latest.date || null,
-    benches: latest.benches.map((b) => ({
-      name: b.name,
-      value: b.value,
-      unit: b.unit || "",
-    })),
-  };
+  // Trailing HISTORY_WINDOW commits, chronological (oldest → newest). `latest` is the last
+  // element so the existing summary/competitive views read it exactly as before.
+  const history = series.slice(-HISTORY_WINDOW).map(normEntry);
+  return { latest: history[history.length - 1], history };
 }
 
 const labels = JSON.parse(
@@ -88,16 +110,21 @@ for (const k of Object.keys(competitorsRaw)) {
 
 const dataJs = readBranchDataJs();
 let latest;
+let history;
 let source;
 if (dataJs) {
-  latest = parseDataJs(dataJs);
+  ({ latest, history } = parseDataJs(dataJs));
   source = "benchmark-data branch (dev/bench/data.js)";
 } else if (existsSync(out)) {
   const prev = JSON.parse(readFileSync(out, "utf8"));
   latest = prev.latest;
+  // Keep whatever history was committed; fall back to a single-point history derived from
+  // `latest` so the trend charts still render (one marker) on a fork without the branch.
+  history =
+    Array.isArray(prev.history) && prev.history.length ? prev.history : [latest];
   source = prev.source + " (kept — benchmark-data ref unavailable this run)";
   console.warn(
-    "[sync-benchmarks] origin/benchmark-data not found — keeping committed latest, refreshing labels+competitors only.",
+    "[sync-benchmarks] origin/benchmark-data not found — keeping committed latest+history, refreshing labels+competitors only.",
   );
 } else {
   console.error(
@@ -110,6 +137,7 @@ const payload = {
   generatedAt: new Date().toISOString(),
   source,
   latest,
+  history,
   labels,
   competitors,
 };
@@ -118,5 +146,7 @@ writeFileSync(out, JSON.stringify(payload, null, 2) + "\n");
 console.log(
   `[sync-benchmarks] wrote ${latest.benches.length} benches (commit ${
     latest.commit ? latest.commit.slice(0, 8) : "?"
-  }) + ${Object.keys(labels).length} labels → src/data/benchmarks.generated.json`,
+  }) + ${history.length}-commit history + ${
+    Object.keys(labels).length
+  } labels → src/data/benchmarks.generated.json`,
 );

--- a/site/src/components/benchmarks/line-chart.tsx
+++ b/site/src/components/benchmarks/line-chart.tsx
@@ -1,0 +1,144 @@
+// [OPUS-4.8] sq-hsyg — a tiny dependency-free SVG line chart, used for both the per-metric
+// TREND (metric over commits) and SCALING (metric vs dataset size/depth) views ported from
+// the standalone bench/dashboard (dashboard.js Chart.js cards). Why hand-rolled SVG and not
+// recharts/Chart.js: the site is a STATIC EXPORT (`output: export`) on React 19; an SVG
+// component is SSR-safe, adds zero bundle weight + zero peer-dep risk, and these are simple
+// single-series line/area plots. The chart is computed entirely from passed-in points (no
+// fabrication) and degrades gracefully — a single point renders as one marker, empty renders
+// nothing. Colours use the site's --chart-* theme tokens so it matches the AppShell.
+import * as React from "react";
+
+export interface ChartPoint {
+  x: number; // numeric x (epoch-ms for trend, size/depth for scaling)
+  y: number; // metric value (smaller is better)
+  label: string; // x-axis tick / tooltip label (date or size)
+}
+
+const W = 520;
+const H = 200;
+const PAD = { top: 12, right: 16, bottom: 28, left: 52 };
+
+function niceTicks(min: number, max: number, count: number): number[] {
+  if (min === max) return [min];
+  const step = (max - min) / count;
+  const ticks: number[] = [];
+  for (let i = 0; i <= count; i++) ticks.push(min + step * i);
+  return ticks;
+}
+
+// Compact numeric formatter for axis ticks (mirrors dashboard.js fmtNum altitude).
+function fmtTick(v: number): string {
+  const abs = Math.abs(v);
+  if (abs >= 1_000_000) return (v / 1_000_000).toLocaleString("en-US", { maximumFractionDigits: 1 }) + "M";
+  if (abs >= 1000) return (v / 1000).toLocaleString("en-US", { maximumFractionDigits: 1 }) + "k";
+  if (abs >= 1) return (Math.round(v * 100) / 100).toLocaleString("en-US");
+  return (Math.round(v * 10000) / 10000).toString();
+}
+
+export function LineChart({
+  points,
+  unit,
+  colorVar = "--chart-1",
+  xTickFormat,
+  ariaLabel,
+}: {
+  points: ChartPoint[];
+  unit: string;
+  colorVar?: string;
+  xTickFormat?: (x: number) => string;
+  ariaLabel: string;
+}) {
+  if (!points.length) return null;
+
+  const plotW = W - PAD.left - PAD.right;
+  const plotH = H - PAD.top - PAD.bottom;
+
+  const xs = points.map((p) => p.x);
+  const ys = points.map((p) => p.y);
+  const xMin = Math.min(...xs);
+  const xMax = Math.max(...xs);
+  const yMin = Math.min(...ys, 0); // include 0 baseline so magnitude reads honestly
+  const yMaxRaw = Math.max(...ys);
+  const yMax = yMaxRaw === yMin ? yMin + 1 : yMaxRaw;
+
+  const sx = (x: number) =>
+    PAD.left + (xMax === xMin ? plotW / 2 : ((x - xMin) / (xMax - xMin)) * plotW);
+  const sy = (y: number) => PAD.top + plotH - ((y - yMin) / (yMax - yMin)) * plotH;
+
+  const linePath = points
+    .map((p, i) => `${i === 0 ? "M" : "L"}${sx(p.x).toFixed(1)},${sy(p.y).toFixed(1)}`)
+    .join(" ");
+  const areaPath =
+    `M${sx(points[0].x).toFixed(1)},${sy(yMin).toFixed(1)} ` +
+    points.map((p) => `L${sx(p.x).toFixed(1)},${sy(p.y).toFixed(1)}`).join(" ") +
+    ` L${sx(points[points.length - 1].x).toFixed(1)},${sy(yMin).toFixed(1)} Z`;
+
+  const yTicks = niceTicks(yMin, yMax, 4);
+  // X ticks: first / mid / last so a 20-point window stays legible.
+  const xTickIdx =
+    points.length <= 3
+      ? points.map((_, i) => i)
+      : [0, Math.floor((points.length - 1) / 2), points.length - 1];
+
+  const stroke = `var(${colorVar})`;
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      className="h-44 w-full"
+      role="img"
+      aria-label={ariaLabel}
+      preserveAspectRatio="none"
+    >
+      {/* y grid + ticks */}
+      {yTicks.map((t, i) => (
+        <g key={`y${i}`}>
+          <line
+            x1={PAD.left}
+            x2={W - PAD.right}
+            y1={sy(t)}
+            y2={sy(t)}
+            stroke="var(--border)"
+            strokeWidth={1}
+          />
+          <text
+            x={PAD.left - 6}
+            y={sy(t)}
+            textAnchor="end"
+            dominantBaseline="middle"
+            className="fill-muted-foreground text-[10px]"
+          >
+            {fmtTick(t)}
+          </text>
+        </g>
+      ))}
+      {/* x ticks */}
+      {xTickIdx.map((idx) => {
+        const p = points[idx];
+        return (
+          <text
+            key={`x${idx}`}
+            x={sx(p.x)}
+            y={H - 8}
+            textAnchor={idx === 0 ? "start" : idx === points.length - 1 ? "end" : "middle"}
+            className="fill-muted-foreground text-[10px]"
+          >
+            {xTickFormat ? xTickFormat(p.x) : p.label}
+          </text>
+        );
+      })}
+      {/* area + line */}
+      <path d={areaPath} fill={stroke} fillOpacity={0.12} stroke="none" />
+      <path d={linePath} fill="none" stroke={stroke} strokeWidth={2} />
+      {/* point markers (only when sparse, so a 20-pt trend stays clean) */}
+      {points.length <= 8 &&
+        points.map((p, i) => (
+          <circle key={`pt${i}`} cx={sx(p.x)} cy={sy(p.y)} r={3} fill={stroke}>
+            <title>
+              {p.label}: {fmtTick(p.y)} {unit}
+            </title>
+          </circle>
+        ))}
+    </svg>
+  );
+}

--- a/site/src/components/benchmarks/scaling-charts.tsx
+++ b/site/src/components/benchmarks/scaling-charts.tsx
@@ -1,0 +1,88 @@
+// [OPUS-4.8] sq-hsyg — SCALING charts (metric vs dataset size/depth), ported from the
+// standalone bench/dashboard's scaling view (dashboard.js sizeAxisOf/buildScalingFamilies/
+// renderScaling). For SIZE-PARAMETRISED metrics — e.g. the Deep Taxonomy depth series
+// (deeptax_d1000_* / deeptax_d10000_*) — the harness encodes the size in the metric name;
+// we plot the latest value vs that axis so the reader sees how it SCALES. Where the data has
+// no size-parametrised metrics for a family, this renders nothing (no fabricated curve). The
+// axis is the real size token; numbers are the existing indicative CI series.
+"use client";
+
+import * as React from "react";
+import { ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Card } from "@/components/ui/card";
+import { LineChart, type ChartPoint } from "@/components/benchmarks/line-chart";
+import { fmtNum, type ScalingFamily } from "@/data/benchmarks";
+
+const CHART_VARS = ["--chart-2", "--chart-4", "--chart-1", "--chart-5", "--chart-3"];
+
+function fmtAxis(n: number): string {
+  if (n >= 1_000_000) return n / 1_000_000 + "M";
+  if (n >= 1000) return n / 1000 + "k";
+  return String(n);
+}
+
+export function ScalingCharts({ families }: { families: ScalingFamily[] }) {
+  const [open, setOpen] = React.useState(false);
+  if (families.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex items-center gap-2 text-sm font-medium hover:text-primary"
+      >
+        <ChevronRight
+          aria-hidden
+          className={cn("size-4 transition-transform", open && "rotate-90")}
+        />
+        Scaling ({families.length} size-parametrised metric
+        {families.length === 1 ? "" : "s"})
+      </button>
+
+      {open && (
+        <>
+          <p className="text-xs text-muted-foreground">
+            Latest value vs dataset size/depth, derived from the size token in each metric
+            name (smaller-is-better; indicative CI-runner numbers).
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {families.map((f, i) => {
+              const points: ChartPoint[] = f.points.map((p) => ({
+                x: p.axis,
+                y: p.value,
+                label: fmtAxis(p.axis),
+              }));
+              return (
+                <Card key={f.base} className="gap-1 p-3">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="truncate text-sm font-medium" title={f.label}>
+                      {f.label}
+                    </span>
+                    <span className="shrink-0 text-xs text-muted-foreground">{f.unit}</span>
+                  </div>
+                  <code className="text-[11px] text-muted-foreground">{f.base}</code>
+                  <LineChart
+                    points={points}
+                    unit={f.unit}
+                    colorVar={CHART_VARS[i % CHART_VARS.length]}
+                    xTickFormat={fmtAxis}
+                    ariaLabel={`Scaling of ${f.label} vs ${f.axisLabel}`}
+                  />
+                  <p className="text-[11px] text-muted-foreground">
+                    x: {f.axisLabel} ·{" "}
+                    {f.points.map((p) => `${fmtAxis(p.axis)}→${fmtNum(p.value)}`).join(", ")}
+                    {f.points.length === 1 && " (single point — no scaling curve yet)"}
+                  </p>
+                </Card>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/site/src/components/benchmarks/suite-group.tsx
+++ b/site/src/components/benchmarks/suite-group.tsx
@@ -14,6 +14,8 @@ import { Card } from "@/components/ui/card";
 import { MetricTable } from "@/components/benchmarks/metric-table";
 import { SameBoxTable } from "@/components/benchmarks/same-box-table";
 import { ReferencesNote } from "@/components/benchmarks/references-note";
+import { TrendCharts } from "@/components/benchmarks/trend-charts";
+import { ScalingCharts } from "@/components/benchmarks/scaling-charts";
 import {
   SummaryDetail,
   SummaryPill,
@@ -23,6 +25,8 @@ import type {
   MetricRow,
   ReferenceBaseline,
   SameBoxComparison,
+  ScalingFamily,
+  TrendSeries,
 } from "@/data/benchmarks";
 
 export interface SuiteGroupData {
@@ -31,6 +35,8 @@ export interface SuiteGroupData {
   summary: CompetitiveSummary;
   sameBox?: SameBoxComparison;
   references: ReferenceBaseline[];
+  trends: TrendSeries[];
+  scaling: ScalingFamily[];
 }
 
 export function SuiteGroup({
@@ -72,6 +78,8 @@ export function SuiteGroup({
         <div id={bodyId} className="space-y-4 border-t px-4 py-4">
           <SummaryDetail suite={data.suite} summary={data.summary} />
           <MetricTable rows={data.rows} />
+          <TrendCharts series={data.trends} />
+          <ScalingCharts families={data.scaling} />
           {data.sameBox && (
             <div className="space-y-2">
               <h4 className="text-sm font-medium">Same-box cross-engine comparison</h4>

--- a/site/src/components/benchmarks/trend-charts.tsx
+++ b/site/src/components/benchmarks/trend-charts.tsx
@@ -1,0 +1,89 @@
+// [OPUS-4.8] sq-hsyg — per-metric TREND charts (metric over commits), ported from the
+// standalone bench/dashboard's Chart.js trend cards (dashboard.js trendCard/trendPoints).
+// One card per metric in the suite, showing its value across the committed history window.
+// Numbers are exactly the existing benchmark series (CI-runner band — INDICATIVE, the same
+// labelling the rest of the in-site benchmarks carry); we never fabricate a missing point —
+// a metric measured in fewer commits simply plots fewer points, a single-point metric shows
+// one marker. The "Show trends" disclosure keeps first paint light when a suite has many
+// metrics. Client component (collapsible state); the series is computed server-side + passed.
+"use client";
+
+import * as React from "react";
+import { ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Card } from "@/components/ui/card";
+import { LineChart, type ChartPoint } from "@/components/benchmarks/line-chart";
+import type { TrendSeries } from "@/data/benchmarks";
+
+const CHART_VARS = ["--chart-1", "--chart-2", "--chart-3", "--chart-4", "--chart-5"];
+
+function fmtDate(ms: number): string {
+  if (!Number.isFinite(ms)) return "";
+  return new Date(ms).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+export function TrendCharts({ series }: { series: TrendSeries[] }) {
+  const [open, setOpen] = React.useState(false);
+  // Only metrics with at least one history point are chartable (always true here, but keep
+  // the guard so an empty history degrades to "nothing to plot" rather than a broken card).
+  const chartable = series.filter((s) => s.points.length > 0);
+  if (chartable.length === 0) return null;
+
+  const multiPoint = chartable.filter((s) => s.points.length > 1).length;
+
+  return (
+    <div className="space-y-3">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex items-center gap-2 text-sm font-medium hover:text-primary"
+      >
+        <ChevronRight
+          aria-hidden
+          className={cn("size-4 transition-transform", open && "rotate-90")}
+        />
+        Trends over commits ({chartable.length} metric{chartable.length === 1 ? "" : "s"})
+      </button>
+
+      {open && (
+        <>
+          <p className="text-xs text-muted-foreground">
+            Value across the last {chartable[0].points.length} recorded commit
+            {chartable[0].points.length === 1 ? "" : "s"} (every metric smaller-is-better;
+            indicative CI-runner numbers — see the note above).
+            {multiPoint === 0 && " History is sparse — only the latest point exists so far."}
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {chartable.map((s, i) => {
+              const points: ChartPoint[] = s.points.map((p, idx) => ({
+                x: p.date ?? idx,
+                y: p.value,
+                label: p.date != null ? fmtDate(p.date) : `commit ${idx + 1}`,
+              }));
+              return (
+                <Card key={s.name} className="gap-1 p-3">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="truncate text-sm font-medium" title={s.label}>
+                      {s.label}
+                    </span>
+                    <span className="shrink-0 text-xs text-muted-foreground">{s.unit}</span>
+                  </div>
+                  <code className="text-[11px] text-muted-foreground">{s.name}</code>
+                  <LineChart
+                    points={points}
+                    unit={s.unit}
+                    colorVar={CHART_VARS[i % CHART_VARS.length]}
+                    xTickFormat={(x) => fmtDate(x)}
+                    ariaLabel={`Trend of ${s.label} over commits`}
+                  />
+                </Card>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/site/src/data/benchmarks.generated.json
+++ b/site/src/data/benchmarks.generated.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T12:12:28.878Z",
+  "generatedAt": "2026-06-16T16:09:17.098Z",
   "source": "benchmark-data branch (dev/bench/data.js)",
   "latest": {
     "commit": "fd219babd41d36e36b8e72e161c5c4c8277583fe",
@@ -1397,6 +1397,26443 @@
       }
     ]
   },
+  "history": [
+    {
+      "commit": "9603de6d5fcdc660b323c7d9e4c775189be6ded7",
+      "date": 1781537365291,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.555,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 5.0492,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.2,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3089,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4446.9,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5.8,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 751.4,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 12304,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 56457.8,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 150236.8,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 4598.2,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 5.1,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 40711.8,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 8943.9,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 60911.8,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 161760.5,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 3254.4,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 5.9,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 40335.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 3.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 29440.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 14.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 1666784.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 9.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6404.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3782.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3490.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7348.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 511493.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 12592.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 32978.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 54061.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3645.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 22099.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 140164.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 96089.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 170298.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 7.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 8.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 35585.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 6520.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 12920.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 5.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 29442.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 17,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 1844998.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6503.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3737.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3393.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 9068.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 512530.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 12491.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 32239.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 54397.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3686.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 21838,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 13.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 139768.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 96898.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 171602.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 11.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 34531.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 6746.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 13172.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 29805.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 18.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 1870070.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6473.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3951.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3445.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 9202.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 510702.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 12472.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 32235.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 53821.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3880.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 21840.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 12.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 140793.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 95577.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 169619.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 9.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 9.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 34636.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 6888,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 12803.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6310.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 15425.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 15113.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 14793.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 437706.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 15460.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 22031.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 286379.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 20888.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 4.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 22140.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 282886.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 5.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 14.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 9157.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 17571.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 14908.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 14738.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 472707.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 16117.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 22132.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 284829.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 20348.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 68.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 22803.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 284628.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 5.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 15.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 13773.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 20406.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 15249,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 14926.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 480874.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 16762.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 22291.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 285658.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 20252.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 144.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 22637,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 284620.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 62.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 32.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 28.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 103.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 18.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 17.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 38.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 15.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 11.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 10.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 885.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 27.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 27.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 109,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 18.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 16.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 13.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 126.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 30.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 23.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 11,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1553,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 29.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 29.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 130.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 23.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 21.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 127,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 32.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 22.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 17.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 29.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 58.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 72.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 78.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 104,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 465.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 164.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 264.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 542.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 9.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 48.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 62.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 82.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 81.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 105.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 461.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 177,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 277,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 549.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 47.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 64.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 171.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 97,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 110.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 479.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 190.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 303.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 543.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 13,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 48.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 591.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 63,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 28.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 29.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2696.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 3869.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 17.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 9.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 23.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 17.2,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.061,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 5.4,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.144,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1588686,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "e56f8515072502c8e076c2ebf9941c9d7d079cdd",
+      "date": 1781538547155,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.57,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 5.2419,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.6,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3090.1,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4459.4,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5.8,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 5.4,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 750.4,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 13234.5,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 62396.3,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 165643.9,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 6614.6,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 5.7,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 44827.2,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 9328.7,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 66836,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 170951.3,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 6295.9,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 6.5,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 43145.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 3.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 29665,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 27.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 2199344.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6617.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3748,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3460.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7564.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 511161.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 12455.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 35084.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 54737.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3794.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 22467.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 152876.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 108330.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 193333,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 8.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 37726.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 6885.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 13387.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 29931.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 16.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 2320388,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 11.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6482.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3822.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3526.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 9413.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 515321.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 12606.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 35055.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 54400.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3895.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 23473.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 14.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 164257.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 116277.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 213037,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 40076.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 7036,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 13451,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 9.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 30749.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 18.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 3073093.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6621.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3917.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3506.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 9797.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 519799.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 13101.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 35057.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 54401.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3981.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 23338.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 13.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 166325.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 110111.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 196928.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 10.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 12.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 38123.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 6943.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 13397.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 9.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 10.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6378.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 16140.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 15879.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 15478,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 466878.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 16451.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 23646.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 294541.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 21250.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 4.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 24292.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 289510.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 5.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 14.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 10361.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 18049.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 14795.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 14975.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 504789.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 18939.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 23468.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 286537.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 21191.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 72,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 23432.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 291969.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 6.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 15.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 13805.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 20972.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 15182.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 15244.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 510765.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 17461.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 22509.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 286922.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 21129.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 135.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 22961.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 290756.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 6.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 61.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 33.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 28.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 100.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 18,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 17.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 38.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 14.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 12.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 11.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 10.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 864,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 27.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 27.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 113.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 17.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 16.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 13.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 10.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 122.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 32.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 23.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 11.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1527,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 29.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 30.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 134.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 20.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 18,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 21.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 136.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 32.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 22.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 17.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 28.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 13,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 57.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 74.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 79.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 112.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 473.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 170.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 271.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 563.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 9.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 48.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 63.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 84.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 80.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 131.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 463.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 173.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 278.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 551.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 48.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 61.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 190.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 81.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 112.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 482.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 200.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 324.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 548.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 13.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 47.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 597.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 67.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 31.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 7.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 29.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2723.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 3918.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 19.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 26,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 17.2,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.5,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.068,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 5.4,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.148,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1588686,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "81998a51fa8586c1ace411c15d824b3d5d66cdd7",
+      "date": 1781538793773,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.547,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 5.0106,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.6,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3339.5,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4849.8,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5.8,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 822.5,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 13114.7,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 60526.5,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 162225.8,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 2770.5,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 42716.9,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 8268.2,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 59252.7,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 161281.6,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 2545.5,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 5.9,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 38972.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 3.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 29953.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 16.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 2143225.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 9.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6426.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3768.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3578,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7209.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 480224.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 12932.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 31078.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 54196.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3825.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 22518.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 12.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 145258.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 107178.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 175401.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 7.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 36200.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 6961.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 13131.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 9.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 30015.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 17.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 2296700.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6580.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3803,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3537.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 9095.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 481483,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 13170.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 31105.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 54147.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3784.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 22431.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 13.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 146516.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 105734.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 178823.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 9.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 12.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 8.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 35757.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 7123.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 13261.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 9.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 30056.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 19.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 2247915.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6557,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3795.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3555.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 9293.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 477149,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 13593.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 32419.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 54428.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 4161.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 22663.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 13.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 145597,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 105379.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 178766.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 10.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 13.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 8.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 38327.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 6968.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 13222.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 9.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6682.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 17034.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 16500.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 16670.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 453794.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 17359.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 24311.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 288095.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 22969.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 4.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 23357.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 295997.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 5.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 14.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 9498.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 19724.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 16807.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 16572.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 504444.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 18709.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 24169.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 295636.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 23749.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 65.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 23588.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 294639.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 16.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 14070.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 21683.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 16599,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 16447.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 518591.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 19046.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 24702.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 291395,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 23288.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 129.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 23640.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 300142.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 61.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 33.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 28.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 102,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 18.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 26.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 32.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 12.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 10.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 939.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 26.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 29.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 119.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 18.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 16.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 14.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 10.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 118.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 31.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 23.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 10.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1556.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 28.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 28.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 128.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 20.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 21,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 117.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 33.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 22.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 16.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 28.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 62.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 67.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 77.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 103.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 502.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 174.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 291.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 598.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 50.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 54.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 95.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 75,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 103.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 506.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 191.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 302.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 622.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 46.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 69.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 163.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 85.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 108,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 503.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 199.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 344.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 633.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 14.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 45.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 598.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 70.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 29.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 6.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 31.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2973.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 4056.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 17.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 24.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 18.7,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.064,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 334.9,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 320,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 13443.5,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6648,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 672689,
+          "unit": "us"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.145,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1588686,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "62e068dd91be32dc7589d91bc525a69495746edb",
+      "date": 1781539162695,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.558,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 5.0877,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.6,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3075.2,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4370.5,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5.1,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 689.1,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 12714.8,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 57358.9,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 156243.8,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 4146.6,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 5.4,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 48836.5,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 8064.4,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 62932.1,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 159550.4,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 3882.8,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 39397.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 3.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 29874.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 15.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 1366560,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6201.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3679,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3403.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7219.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 519725.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 12319.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 34045.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 52426.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3609.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 22917.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 135574.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 91064.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 162445.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 35942.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 7653.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 13244,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 9.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 29823.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 16.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 1550462.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6297.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3688.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3415,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 8680,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 510933.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 12702.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 34376.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 53830.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3670.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 21649.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 13.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 137808.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 89949.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 158747.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 11.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 7.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 8.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 35426.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 6616.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 13201.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 30244.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 23.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 1260209.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6243.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3694.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3346.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 8228.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 505050.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 12078.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 34236.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 52672.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3717.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 22230.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 142807.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 96603.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 166698.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 12.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 9.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 38695.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 7323.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 14505.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 9.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6293,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 15843.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 15286.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 15135.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 454942.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 16318.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 22722.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 297327.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 21675.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 22317.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 289972.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 5.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 15.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 9487.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 16912.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 15117.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 14971.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 494478.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 17694.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 22347.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 288024.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 21947.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 58.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 23278.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 292069.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 15.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 13005.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 21115.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 15553,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 15137.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 510068.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 17852.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 22637.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 289123.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 21594.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 114.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 23459.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 289432.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 56.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 32.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 29.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 115.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 17.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 17.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 38.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 14.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 12.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 12.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 874.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 27.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 28.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 108,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 17.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 17.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 14.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 122.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 30.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 24.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1401.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 28.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 30.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 129.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 19.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 18.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 20.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 130.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 33.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 21.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 17.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 28,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 55.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 69.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 77.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 101.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 478.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 164.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 266,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 555.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 9.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 51.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 60.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 81.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 79.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 106.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 476.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 176.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 276.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 558.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 49.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 58,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 149,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 80.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 115.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 467.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 185.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 297.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 554.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 47.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 595.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 15.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 67.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 30.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 29.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2699.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 3985.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 19,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 23.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 19.7,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.007,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.068,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 393.2,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 343.2,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 13221.9,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 7137.8,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 791972.9,
+          "unit": "us"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.167,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "f37bab4b5c7576d4c1bb9937ee915c192a6ebb1c",
+      "date": 1781539411954,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.55,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 5.0106,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.5,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3258.7,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4771.6,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5.9,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 778.7,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 13304.7,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 59235.4,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 164492,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 4098.7,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 42294.9,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 7267.4,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 57679.8,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 149142.1,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 2238.2,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 6,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 38478.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 29862.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 16.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 1587234.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6157.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3727.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3573.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7247.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 475636.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 13231.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 31345.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 54508.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 4144.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 22511.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 147229.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 108461.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 190130,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 9.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 6.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 6.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 37278.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 7203.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 13458.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 29765.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 16.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 1489746.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6192.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3803.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3526.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 8339.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 476560,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 12676.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 30857.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 54191.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3787.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 22372.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 13.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 139189.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 103680.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 174503.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 10.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 37005.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 6892.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 13089.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 29752.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 18.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 1675445.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6256.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3780.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3499.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 8721.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 475638.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 12822.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 32022.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 54828.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3689.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 22198.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 11.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 144505.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 103508.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 173812.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 11.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 7.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 7.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 36482.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 7014.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 13206.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 9.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 9.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6697.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 16785.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 16258.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 16204.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 450863.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 17347.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 23550.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 295179,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 22484.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 22692,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 286143.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 6.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 12.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 9159.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 19272.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 16635.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 16405.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 492592,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 18354.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 24084.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 292357.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 22914.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 62.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 22620.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 289787.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 5.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 15.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 12938.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 20077.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 16262.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 16148.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 496937.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 18658.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 24056.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 295357.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 23004.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 93.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 22446.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 295805.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 52,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 31.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 28,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 110.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 18,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 17.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 31.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 14.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 936.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 25.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 26.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 107.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 18,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 16,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 14.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 108.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 31.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 22.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 10.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 10.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1356.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 27.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 27.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 119.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 19.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 19.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 10.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 111.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 34,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 21.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 16.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 27.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 11.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 54.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 65.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 75.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 100.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 489.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 170.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 278.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 602.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 45.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 58.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 77.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 81.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 101.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 506.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 179.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 284.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 603.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 45.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 58.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 147,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 75,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 114,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 483.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 189.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 321.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 6.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 610.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 45.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 616.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 66.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 29,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 6.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 29.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2919.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 4040.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 17.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 9.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 23,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 18,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.5,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.065,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 354.1,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 303.6,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 13119.5,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6556.7,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 666741,
+          "unit": "us"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.149,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "b3aaeca193ee291954ff9bd9d7f8fa730da0a454",
+      "date": 1781539950089,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.598,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 5.7044,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.1,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3101.5,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4832,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 6,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 4.7,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 766,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 16643.4,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 71606.6,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 191185.2,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 2835.4,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 5.5,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 52026.1,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 9865.6,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 66744.5,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 171605.7,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 3684.1,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 6.4,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 48576.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 3.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 32395.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 15.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 2063242.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 7655.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 4459.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 4454.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 9291.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 539288.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 14880.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 44982.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 67684.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 4694.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 23335,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 10.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 152279.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 108557.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 200834.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 8.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 6.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 6.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 38340.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 8451.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 14330.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 32000.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 18.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 2154275.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 8085.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 4773,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 4334.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 10451.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 531766.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 14958.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 44721.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 66753.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 4623.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 24428.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 151393.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 105360,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 191857.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 6.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 38832.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 7861.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 14255.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 32941.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 17.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 2241233.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 7856.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 5111.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 4690.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 10878.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 544823.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 15160.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 45601,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 67166.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 4783.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 23619.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 152439.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 109822.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 196835.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 39213,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 8110.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 14539.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 9.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 11.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 5950.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 17086,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 16178.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 16786.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 543694.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 17017.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 22548.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 324473.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 22883.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 20677.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 333139.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 5.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 16,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 9340.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 19765.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 16921.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 16734.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 605288.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 17686.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 21828.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 328090.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 22946.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 51.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 20003.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 318083.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 14.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 11644.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 20624.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 16708.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 16180.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 594720.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 18578,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 23362.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 326408.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 23906.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 81.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 20666.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 328447.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 53.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 30.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 27.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 104.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 15.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 15.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 6.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 5.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 37.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 13.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 11.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 10.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 824.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 24.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 26.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 109.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 15.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 13.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 9.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 134.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 28.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 15.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 14,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 20.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 10,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 9.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1192.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 26.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 26.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 141.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 17.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 15,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 16,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 10,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 137.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 30.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 19.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 15.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 24.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 10.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 10.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 53.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 61.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 73.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 102.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 421.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 164.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 249.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 506.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 8.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 43.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 75.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 109.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 108.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 139.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 423.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 164.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 253.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 6.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 518.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 9.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 43.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 73.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 155.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 76.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 105,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 426.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 177.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 305.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 511.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 10.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 43.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 522.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 17.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 4.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 84.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 32.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 6.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 31.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2434,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 3670.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 23.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 10.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 28.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 22.8,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.007,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.075,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 5.3,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 344.9,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 314.6,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 12862.2,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6509,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 678104.6,
+          "unit": "us"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.187,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "396d71d9d18a92ea0a7ab756383f5559b84ab0a4",
+      "date": 1781540913433,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.559,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 4.9336,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.5,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3075.6,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4395.3,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5.6,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 697.4,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 12306.4,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 55268,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 146628.2,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 2549.5,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 4.7,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 39373.5,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 7838.3,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 56153.2,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 152843.7,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 3121.8,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 5.9,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 38044.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 29364,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 15.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 1309583.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6255,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3709.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3391.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7190.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 503959.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 12340.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 30889.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 51808.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3941.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 21079.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 11.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 123002.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 91055.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 154901.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 8.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 34756,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 6631.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 12545.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 28534.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 16.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 1177220.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6318.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3723.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3438.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 7999,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 527212.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 12130.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 31191.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 51522.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3766.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 22094.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 12.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 122303.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 90390.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 153470.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 11.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 11.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 34039,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 6365.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 12607.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 28416.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 18,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 1185860.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6425.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3695.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3390.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 8150.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 510614.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 11956.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 30203.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 51515.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3615.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 21421.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 13.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 119784.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 90461.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 153959.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 10,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 12.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 34651.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 6199.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 12484.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6848.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 15192.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 14784.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 14802.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 410862,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 15151.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 21872,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 281959.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 21123.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 3.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 21485.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 283339.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 5.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 13.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 8487.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 15974.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 14789.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 14586.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 461198.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 16275.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 21775,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 283854.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 20786.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 54.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 21301.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 281248,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 6.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 15.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 11458.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 17644.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 14930.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 14953.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 454563.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 16386,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 22303.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 283492.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 20637.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 107.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 22684.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 283659.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 48.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 32.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 31.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 102.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 17.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 17.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 37.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 14.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 13.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 862.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 27,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 27.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 112.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 18.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 16.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 13.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 123.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 32.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 18,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 23.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 11.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 10.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1310,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 28.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 29,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 124.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 19.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 20.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 125.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 33.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 21.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 17.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 27.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 12.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 56.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 68.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 80,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 104.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 480.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 164.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 267.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 7.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 554.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 48.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 57.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 82.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 89,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 107.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 495.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 172.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 269.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 549.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 49.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 57.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 150.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 82.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 110.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 477.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 192.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 299.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 545.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 12.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 48.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 10,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 580.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 65.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 27.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 29,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2660,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 3865.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 16.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 22.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 19.3,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.061,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 354.5,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 333.7,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 13116.8,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6953.4,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 764177.7,
+          "unit": "us"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.148,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "4afca70a897d3eb113bd3f5ddc453366155f6771",
+      "date": 1781541161313,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.545,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 5.0106,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.1,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3303.9,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4759.4,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 775.9,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 12920.4,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 60486.7,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 162919.9,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 2601.4,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 4.7,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 41528.6,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 7100.1,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 59041.8,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 155940.9,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 2324.5,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 5.4,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 38226.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 3.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 29348.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 16,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 2238293.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6340.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3816.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3617,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7223.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 481076.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 13251.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 30313.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 53294.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3849.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 22533.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 12.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 135384.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 111261.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 176678.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 10.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 35983.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 6964.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 12981.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 9.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 29894.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 17.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 2399226.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6553,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3829.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 5114,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 9773.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 486792.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 12783.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 30898.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 53401.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3774,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 22264.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 136852.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 103577.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 180750.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 12.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 7.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 37132.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 7465.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 13014.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 9.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 29844.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 18,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 2575123.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6496,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3971,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3611.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 9343.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 484515.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 12902.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 30846.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 53541.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3731.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 22328.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 142075.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 111704.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 207456.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 37311.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 7100.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 13040.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6747.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 17475.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 17070.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 17012.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 462520.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 18141.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 24917.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 288401.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 22572.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 4.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 24884.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 291521.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 13.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 9610.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 18918.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 16295.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 16196.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 497826.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 18479.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 24772.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 290391.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 23727.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 62.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 23372,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 288691.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 6.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 15.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 13175.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 21800.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 17119.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 16337.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 503998.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 19518.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 24888.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 294629.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 24284.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 94,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 24713.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 300948.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 45,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 31.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 27.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 99.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 18.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 17.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 31,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 12.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 959.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 25,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 27.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 104.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 18.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 16.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 14.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 112,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 31.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 23,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 10.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1357.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 27.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 27.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 122.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 20.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 19.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 112.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 32.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 20.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 16.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 27.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 12.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 57.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 73.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 76,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 99.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 501.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 178.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 285.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 594.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 45.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 57.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 77.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 81,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 102.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 496.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 177.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 285.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 615.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 47,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 58.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 157.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 81.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 107,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 504.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 199.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 326.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 6.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 625.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 12.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 45.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 618.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 5.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 68.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 28.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 6.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 30,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2938.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 4073.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 18.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 24.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 18.4,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.071,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 5.1,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 335.5,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 314.4,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 13360.5,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6572.5,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 662378.3,
+          "unit": "us"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.149,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "2e983668313af8b94ee8fff4ab2ff8d17d0b603e",
+      "date": 1781543892656,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.56,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 4.9721,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.6,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3385.2,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4852.5,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 6.5,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 6.1,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 797.3,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 13267.9,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 62511,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 168379.4,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 4287.1,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 44604,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 8450.6,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 62717.7,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 177664.2,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 2948.8,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 6.5,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 41930.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 30024.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 16,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 2304596.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 10.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6443.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3892,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3500.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7251.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 474148.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 12947.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 32491.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 54206.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3773.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 22609.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 163223.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 113681.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 192305.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 11.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 7.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 8.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 37356,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 7184.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 13227,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 9.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 5.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 30584.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 18.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 2777958,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 9.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6510.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3862.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3658.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 9517.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 481678.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 13506.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 33001.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 54825.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 4133.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 24905.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 14.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 151554.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 111381.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 191760,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 13.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 38090.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 7366.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 13354.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 10,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 30488,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 21.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 2242283.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 9.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6358,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3752.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3587.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 9025.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 477115.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 14383.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 33254.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 55468.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3916,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 22986.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 14.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 153276.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 105916.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 184807,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 13.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 36083.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 7301.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 13428.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6677.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 16696.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 16258.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 16121.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 446126.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 17546.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 24154.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 292124.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 22714.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 22270.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 289968.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 6.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 15.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 9275.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 19713.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 16326.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 16471.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 501096.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 18766.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 24585.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 301426.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 22973,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 68.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 23487,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 294014.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 17.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 14034.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 21045.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 16433.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 16210.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 510143.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 20303.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 24184.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 291697,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 22714.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 130.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 22621,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 295874.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 60.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 32.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 30.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 99.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 18.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 17.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 31.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 13.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 11.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 10.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 9.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 930,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 25.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 26.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 106.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 18.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 15.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 13.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 112.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 36.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 22.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 10.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1576.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 28.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 27.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 124.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 20.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 21.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 130.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 35.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 21.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 16.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 27.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 11.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 65.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 64.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 72.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 106,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 491.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 173.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 291.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 606.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 45.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 59.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 78.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 74.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 106.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 492.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 180.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 288.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 601.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 45,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 61.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 159,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 75.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 106.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 489.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 197.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 327.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 601.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 12.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 44.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 604.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 15.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 70.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 29.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 30.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2964.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 4092.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 18.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 24.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 18.5,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.076,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 5.1,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 339.6,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 308.5,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 13309.6,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6608.1,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 682701,
+          "unit": "us"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.147,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "602c77200fa6574c6226458c081730585641a316",
+      "date": 1781544177566,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.535,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 4.9721,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.5,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3104.5,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4352.9,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5.6,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 816.8,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 12485.5,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 56655.8,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 148625.3,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 2897.3,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 40077.8,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 9137.9,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 60844.9,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 163129.2,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 2810.1,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 5.8,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 39758.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 3.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 29117.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 15.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 1374113.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6121.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3665.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3339,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7184.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 501164.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 12147.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 31881.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 53075.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3558,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 21508.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 13.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 127553.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 90416.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 154013.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 11,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 34476,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 6026.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 12660.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 28768.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 17.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 1420192.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 9.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6069.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3643,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3395.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 8343.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 504420,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 12173.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 32629.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 52560.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3673,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 21432,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 127215.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 92461.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 155386.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 11.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 7.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 33852.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 6728.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 12902.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 28790,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 19.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 1436189.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6141.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3641.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3347.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 9267.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 496012.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 12155.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 32585.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 53166.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3656.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 21421.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 12.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 133068.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 91124.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 156293.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 11.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 7.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 33957.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 7145.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 12582.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6243.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 15144.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 15002.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 14703.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 415426.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 15303.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 22224.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 283742.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 20563.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 3.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 22182.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 288754.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 5.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 14.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 8395.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 16842.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 14938.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 14707.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 449484.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 16221.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 22008.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 277825.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 20708.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 56.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 21165.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 282553.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 13.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 12549.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 18796,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 14936.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 14629,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 468460.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 16790,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 22372.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 283271.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 20898.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 136.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 21484.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 284634.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 64.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 36.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 28.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 100.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 17.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 16.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 39.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 14.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 862.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 26.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 27.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 108.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 18.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 16.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 14.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 125.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 30.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 22.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 11.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1528.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 29,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 28.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 141.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 20.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 21.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 11.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 145,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 31.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 22,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 17.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 29,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 69.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 68.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 78.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 111.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 468.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 168,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 268.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 537.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 47,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 57.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 82.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 78.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 105,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 458.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 173.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 269.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 550.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 47.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 59.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 170.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 82.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 111.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 461.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 186.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 305.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 562.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 47.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 592,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 61.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 27.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 29,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2643,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 3864.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 16.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 22.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 16.8,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.061,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 359.2,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 327.7,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 12884.3,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6747.6,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 757567.9,
+          "unit": "us"
+        },
+        {
+          "name": "text_and_terms_us",
+          "value": 13.9,
+          "unit": "us"
+        },
+        {
+          "name": "text_near_slop2_us",
+          "value": 1.5,
+          "unit": "us"
+        },
+        {
+          "name": "text_or_terms_us",
+          "value": 22.5,
+          "unit": "us"
+        },
+        {
+          "name": "text_phrase_us",
+          "value": 1.4,
+          "unit": "us"
+        },
+        {
+          "name": "text_prefix4_us",
+          "value": 3649.2,
+          "unit": "us"
+        },
+        {
+          "name": "fts_bytes_per_doc",
+          "value": 371,
+          "unit": "bytes"
+        },
+        {
+          "name": "text_build_s",
+          "value": 0.454104,
+          "unit": "s"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.138,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "96df2cf343265ab1233845bd845ffa74335a39bb",
+      "date": 1781544498799,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.44,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 4.0085,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 2.9,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 2597.5,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 3758,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 4.1,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 612.7,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 10336.4,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 50314.8,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 133555.8,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 4053.2,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 3.8,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 36025.8,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 6953,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 53716.3,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 142298.8,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 2683.4,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 36009.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 3.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 24000.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 13.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 3026709.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 5099.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 2972.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 2804.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 5655.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 371578.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 9984.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 27520.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 42069.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 2991.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 18313.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 10.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 131939.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 105015.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 174621.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 5.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 6.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 5.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 32278.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 5595.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 10463.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 23818.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 19.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 3171644.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 7.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 5201.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3055.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 2864.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 7666,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 373445.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 10682.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 26597.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 42706.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3012.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 18294.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 12.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 134982.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 104578,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 189186.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 11.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 6.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 6.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 31108.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 6012.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 10538,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 3.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 23892,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 15.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 3328362.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 5219.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3056.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 2896.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 8007.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 372612.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 10369.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 27096.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 43318.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3137.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 18425.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 13,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 138237.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 108116.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 191204.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 9.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 10.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 6.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 6.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 6.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 30484.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 5925.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 10551.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 5167.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 13121.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 12611.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 12837.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 381267.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 13899.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 19727.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 226313,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 18735.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 4.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 19280,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 230840,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 5.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 13,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 8161.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 16747.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 13000.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 12931.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 421592.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 15356.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 20361.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 228335.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 18297.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 55.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 18917,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 230701.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 5.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 14.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 11847.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 18282.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 13313.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 13401.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 432052.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 15010,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 19893.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 234868.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 18965.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 103.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 18537.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 228151,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 47.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 27.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 21,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 90.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 13.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 13.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 5.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 4.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 24.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 10,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 9.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 9.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 8.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 7.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 728.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 20.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 23.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 87.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 13.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 12.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 10.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 83.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 25.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 11.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 17.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 8.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1210.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 21.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 21.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 94.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 15.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 13.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 16.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 96.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 25.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 16.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 21.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 9.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 46.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 56.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 61,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 86.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 390.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 140.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 225.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 5.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 474.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 34.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 45,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 63.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 56.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 80.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 383.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 140,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 229.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 468.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 35,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 46.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 126.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 69.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 86.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 385.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 151.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 261.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 5.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 471.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 34.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 465.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 3.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 56.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 23,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 5.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 23.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2315.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 3136.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 14.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 7.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 20.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 14.3,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.005,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.1,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.061,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 4.3,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 258.6,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 236.3,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 10402.7,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 5125.9,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 524933.9,
+          "unit": "us"
+        },
+        {
+          "name": "text_and_terms_us",
+          "value": 10.4,
+          "unit": "us"
+        },
+        {
+          "name": "text_near_slop2_us",
+          "value": 0.9,
+          "unit": "us"
+        },
+        {
+          "name": "text_or_terms_us",
+          "value": 17.3,
+          "unit": "us"
+        },
+        {
+          "name": "text_phrase_us",
+          "value": 0.9,
+          "unit": "us"
+        },
+        {
+          "name": "text_prefix4_us",
+          "value": 3133.2,
+          "unit": "us"
+        },
+        {
+          "name": "fts_bytes_per_doc",
+          "value": 371,
+          "unit": "bytes"
+        },
+        {
+          "name": "text_build_s",
+          "value": 0.447182,
+          "unit": "s"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.12,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "f9a5df270e8431bb69dd6fa117d0e3d2d7cab6f2",
+      "date": 1781545474670,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.545,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 4.9721,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.8,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3329.9,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4848.4,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5.4,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 796.4,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 12814.1,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 58003.7,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 155647.7,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 3561.5,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 40910.9,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 8233.4,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 57103.9,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 160027.5,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 2619.7,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 5.5,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 37885.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 4.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 33757.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 19,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 1423600.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6168.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3782.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3483,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7135.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 478351.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 12545.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 31074.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 53469.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3751.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 22178.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 11.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 126897.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 99939.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 167753.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 6.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 36407.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 6758.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 12974.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 29660.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 18.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 1463413.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6201.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3738.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3613,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 8178.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 473056.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 12982,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 30305.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 54417.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 4097.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 22576,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 13.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 133124,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 101382.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 168215,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 7.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 7.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 34683.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 7001.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 12959.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 29329.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 19.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 1420894.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6346.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3795.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3603.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 8300.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 477851.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 12781.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 30582.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 53777.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 4010.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 22264.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 128722.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 100638.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 166823.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 9.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 6.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 36807,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 6703.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 12940,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 9.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6719.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 16641.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 16262.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 16305.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 431763.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 17176.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 24149.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 284735.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 22599.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 22488.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 283889.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 5.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 14.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 8940.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 17806.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 16234.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 16046.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 472986.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 18150.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 23973.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 285230.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 22502.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 60.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 23091.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 285545.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 6.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 15.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 13064,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 20135.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 16381.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 16287.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 476716,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 18582.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 24608.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 283419.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 22478.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 130.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 22634.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 283750.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 61.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 32.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 28.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 103.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 18.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 17.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 31.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 13.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 10.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 927.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 25.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 26.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 123.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 17.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 15.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 13.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 10,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 107.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 33.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 19,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 22.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 10.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1565.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 28.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 28.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 144.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 20.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 21.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 112,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 33.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 21.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 17.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 27.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 11.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 56.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 64,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 73.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 102,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 492,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 180.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 296.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 613.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 45.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 55.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 76.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 74.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 101.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 494.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 178.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 296.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 604.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 44.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 59.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 157,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 75.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 107.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 498.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 193,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 325.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 612.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 44.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 630.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 65.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 28.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 10.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 29.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2920.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 4026.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 17.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 9.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 23.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 18,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.06,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 342.7,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 307.1,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 13017.5,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6508.6,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 659914.4,
+          "unit": "us"
+        },
+        {
+          "name": "text_and_terms_us",
+          "value": 13.5,
+          "unit": "us"
+        },
+        {
+          "name": "text_near_slop2_us",
+          "value": 1.4,
+          "unit": "us"
+        },
+        {
+          "name": "text_or_terms_us",
+          "value": 22.3,
+          "unit": "us"
+        },
+        {
+          "name": "text_phrase_us",
+          "value": 1.5,
+          "unit": "us"
+        },
+        {
+          "name": "text_prefix4_us",
+          "value": 3878,
+          "unit": "us"
+        },
+        {
+          "name": "fts_bytes_per_doc",
+          "value": 371,
+          "unit": "bytes"
+        },
+        {
+          "name": "text_build_s",
+          "value": 0.472617,
+          "unit": "s"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.139,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "cafe5ff67a71a65c730a1601144354e904d1ffa8",
+      "date": 1781547999796,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.546,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 5.0106,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.8,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3328.8,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4839.1,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5.1,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 5.1,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 795.5,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 13097.7,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 57765.1,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 155028.8,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 3893.7,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 4.7,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 41252.7,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 8155.5,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 57537.8,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 155668.8,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 3256.3,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 5.8,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 38466.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 3.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 29400.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 23.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 1516981.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6194.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3739.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3546.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7202.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 480833.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 13095.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 30502.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 54842.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3723.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 22448.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 132349,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 106507.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 175579.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 9.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 35354.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 7091.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 12993.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 29761.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 18,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 1508314.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6418.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3789.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3484.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 8473.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 480470.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 12893.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 31033.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 53013.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3799,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 22263.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 136520.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 103788.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 178112.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 12.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 8.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 35662.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 6880.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 13115.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 9.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 29548.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 20.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 1516782.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6208.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3756.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3507.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 8671.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 475695,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 13030.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 31368.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 53266.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3760.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 23454.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 12.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 134990.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 100959.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 169498.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 12.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 36561.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 6576.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 13304.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 10,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6688.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 16918.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 16675.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 16626.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 436102.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 17252.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 24296.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 296549.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 22929.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 4.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 22686.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 296202.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 6.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 15,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 9159.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 18432,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 16389.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 16310.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 483112.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 18690.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 24320.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 287615.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 22645.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 65.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 22056,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 285079,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 5.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 15.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 12990.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 20372.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 16659.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 16311.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 479348.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 18498.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 24553.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 289826,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 23087.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 129.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 22252.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 288438.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 61.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 33.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 28.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 108.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 18.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 17.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 32.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 13,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 11.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 10.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 929.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 26,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 26.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 105.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 17.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 15.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 14.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 112.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 33,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 22.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1541.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 28.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 27.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 123.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 19.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 21.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 111.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 34,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 21.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 16.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 27.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 11.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 57.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 65.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 77.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 109.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 489.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 178,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 292.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 612.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 44.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 54,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 76.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 73.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 100,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 491.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 183.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 301.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 626.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 44.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 58.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 158.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 74.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 113.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 494.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 197.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 330.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 613,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 13.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 45.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 615.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 4.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 69.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 29.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 6.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 30,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2982.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 4043.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 17.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 21.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 18.2,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.062,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 5.5,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 352.3,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 308.4,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 13050.3,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6630.7,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 674314.1,
+          "unit": "us"
+        },
+        {
+          "name": "text_and_terms_us",
+          "value": 13.4,
+          "unit": "us"
+        },
+        {
+          "name": "text_near_slop2_us",
+          "value": 1.5,
+          "unit": "us"
+        },
+        {
+          "name": "text_or_terms_us",
+          "value": 22.2,
+          "unit": "us"
+        },
+        {
+          "name": "text_phrase_us",
+          "value": 1.5,
+          "unit": "us"
+        },
+        {
+          "name": "text_prefix4_us",
+          "value": 3884,
+          "unit": "us"
+        },
+        {
+          "name": "fts_bytes_per_doc",
+          "value": 371,
+          "unit": "bytes"
+        },
+        {
+          "name": "text_build_s",
+          "value": 0.478735,
+          "unit": "s"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.14,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "7db50c0838a21f9e70b8809fdc812d4cad2c1c05",
+      "date": 1781548325267,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.554,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 5.0106,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.5,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3082.5,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4338.8,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 6,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 8.1,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 821.9,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 13031.8,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 56778.7,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 150205.2,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 4298.4,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 40582.6,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 9220.9,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 63739,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 168254.1,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 2649.1,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 5.7,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 40328.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 28503.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 15.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 1667982.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 11.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6244.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3705.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3380.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7254.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 508752.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 12556.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 32837.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 53749.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3767.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 21901.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 137334.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 100700.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 160022.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 11.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 7.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 36003.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 7177.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 14012.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 29240.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 17.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 1676598.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6578.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3769.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3509,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 9161.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 506939.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 12422.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 32520.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 53395.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3981.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 22365.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 135391.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 97356.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 180956.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 8.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 36042.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 6541.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 13021,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 14.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 29566.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 19.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 1553512.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6375.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3794.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3449.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 9373.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 499941.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 12262.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 32806.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 52499.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3977.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 21364.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 134564.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 100407.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 164222,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 12.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 34035.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 6087.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 12398.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 11,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6228.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 15164.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 15193.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 14682.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 427778.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 15621.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 22249.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 291338.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 21969.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 22718.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 285074.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 6.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 14.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 8944.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 18032.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 15458.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 14815.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 472538.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 16834.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 22456.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 287667.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 20857.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 52.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 22404.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 285357,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 6.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 15.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 13913.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 21124.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 14968.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 14661.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 491729.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 17261.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 22609.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 283797.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 20825,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 136.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 22183.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 281900.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 6.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 60.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 32.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 28.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 106.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 20.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 17,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 37.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 16.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 12.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 12.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 10.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 873.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 26.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 27.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 107.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 17.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 16.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 13.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 10.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 121.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 29.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 22.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 11,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1549.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 34.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 29,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 130.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 20,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 21.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 11.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 127.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 31.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 21.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 17.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 28.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 55.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 69,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 78,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 104.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 459.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 172,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 261.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 538,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 50.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 56.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 94.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 80.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 103.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 464.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 171,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 266.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 543.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 47.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 63.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 174.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 80.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 110.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 467.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 188.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 299,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 540.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 13,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 50.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 576.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 70,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 29.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 6.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 30.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2699.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 3885.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 17.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 9.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 23.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 18.3,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.064,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 365.4,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 321.6,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 13028.4,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6723.3,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 785229.5,
+          "unit": "us"
+        },
+        {
+          "name": "geo_within10km_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "geo_within50km_us",
+          "value": 145.4,
+          "unit": "us"
+        },
+        {
+          "name": "geo_nearest_k10_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "geo_nearest_k100_us",
+          "value": 83.5,
+          "unit": "us"
+        },
+        {
+          "name": "geo_geof_within_us",
+          "value": 101251,
+          "unit": "us"
+        },
+        {
+          "name": "geo_geo_compliance_pass_us",
+          "value": 94.1,
+          "unit": "us"
+        },
+        {
+          "name": "geo_compliance_deficit",
+          "value": 0,
+          "unit": "fixtures"
+        },
+        {
+          "name": "text_and_terms_us",
+          "value": 13.8,
+          "unit": "us"
+        },
+        {
+          "name": "text_near_slop2_us",
+          "value": 1.5,
+          "unit": "us"
+        },
+        {
+          "name": "text_or_terms_us",
+          "value": 22.2,
+          "unit": "us"
+        },
+        {
+          "name": "text_phrase_us",
+          "value": 1.4,
+          "unit": "us"
+        },
+        {
+          "name": "text_prefix4_us",
+          "value": 3833.2,
+          "unit": "us"
+        },
+        {
+          "name": "fts_bytes_per_doc",
+          "value": 371,
+          "unit": "bytes"
+        },
+        {
+          "name": "text_build_s",
+          "value": 0.513315,
+          "unit": "s"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.14,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "ad01dd83fbd384e1fdf9aebbe7aa10b1a38ad705",
+      "date": 1781548625866,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.533,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 4.9336,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.4,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3084.6,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4350.6,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 4.7,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 812.5,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 12350.7,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 55414.1,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 144873.7,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 4418.6,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 39320.3,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 8725,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 57011.9,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 153054.9,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 2528.4,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 5.5,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 39194.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 3.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 28363.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 15.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 1150301.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6218,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3582.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3262.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7140.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 491927.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 12193.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 30569,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 51971.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3576.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 20977,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 126888.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 91423.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 151155.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 11.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 35499.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 6547.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 12266.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 28249,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 17,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 1136353.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6198.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3643.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3314.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 8025.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 498986.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 11867.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 30266.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 51819.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3680,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 20945.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 125515,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 89468.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 151199.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 9.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 36772.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 6359.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 12327.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 28058.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 17.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 1142935.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6267.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3682.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3365.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 8545.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 493559,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 12242.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 30280.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 53060.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 4079.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 20966.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 121621.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 89597.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 150313.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 9.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 11.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 33631.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 6038.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 12307.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 8.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 9.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6197.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 15200.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 14838.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 14664.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 410769.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 15270.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 22415.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 286557.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 20466.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 3.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 21729.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 279237.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 5.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 14.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 8362.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 16040.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 14799.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 14572.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 450022.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 16139.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 22138.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 278791.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 20475.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 49.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 20627.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 280176.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 5.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 14.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 12383.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 18099.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 14801.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 14571.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 457601.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 16463.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 22474.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 277370.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 20342.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 136.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 20788.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 284760.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 65,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 32,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 28.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 113.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 18,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 17.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 37.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 16.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 11.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 866.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 25.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 27,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 108.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 17.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 15.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 13.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 10.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 122.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 30.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 18,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 16.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 22.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 11,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1537.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 28.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 28.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 129.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 19.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 21.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 133.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 33.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 22.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 17.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 27.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 55.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 68.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 78.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 102.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 471.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 163,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 262.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 550.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 47.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 52.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 82.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 80,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 105.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 472.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 170.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 270.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 546.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 47.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 58.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 174.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 80.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 110,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 465.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 196.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 304.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 544.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 47.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 596.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 61.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 27.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 6.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 28.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2661.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 3858.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 16.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 9.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 22.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 16.8,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.057,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 357.2,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 321.5,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 12838.7,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6707.8,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 772254.4,
+          "unit": "us"
+        },
+        {
+          "name": "geo_within10km_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "geo_within50km_us",
+          "value": 144.1,
+          "unit": "us"
+        },
+        {
+          "name": "geo_nearest_k10_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "geo_nearest_k100_us",
+          "value": 84,
+          "unit": "us"
+        },
+        {
+          "name": "geo_geof_within_us",
+          "value": 101251.7,
+          "unit": "us"
+        },
+        {
+          "name": "geo_geo_compliance_pass_us",
+          "value": 91.5,
+          "unit": "us"
+        },
+        {
+          "name": "geo_compliance_deficit",
+          "value": 0,
+          "unit": "fixtures"
+        },
+        {
+          "name": "text_and_terms_us",
+          "value": 13.9,
+          "unit": "us"
+        },
+        {
+          "name": "text_near_slop2_us",
+          "value": 1.5,
+          "unit": "us"
+        },
+        {
+          "name": "text_or_terms_us",
+          "value": 22.3,
+          "unit": "us"
+        },
+        {
+          "name": "text_phrase_us",
+          "value": 1.4,
+          "unit": "us"
+        },
+        {
+          "name": "text_prefix4_us",
+          "value": 3627.7,
+          "unit": "us"
+        },
+        {
+          "name": "fts_bytes_per_doc",
+          "value": 371,
+          "unit": "bytes"
+        },
+        {
+          "name": "text_build_s",
+          "value": 0.494063,
+          "unit": "s"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.134,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "24ae8ceaf210f95d819fd73d615aa871dc6ccb7f",
+      "date": 1781551481647,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.559,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 4.9721,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.5,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3090.3,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4361.5,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 822.6,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 12993.6,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 60169.1,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 161128.8,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 3443.4,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 42807.8,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 9293.6,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 66883.9,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 166257.3,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 3440.5,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 6.1,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 46338.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 29559.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 15.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 2678879.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6897,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3866.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3503.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7404.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 500331.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 13561.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 34468.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 56756.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3993.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 22821.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 13,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 160743.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 117651.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 215204.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 9.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 11.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 38191.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 6724.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 13465.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 9.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 34616.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 16.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 3055022.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6577.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3903.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3690.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 9422,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 506716.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 12205.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 33668.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 56358.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 4083.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 24026.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 13,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 142746.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 100289.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 176574.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 38322.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 6771.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 13370.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 9.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 29576.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 19.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 2467818.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 7886.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3748.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3350.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 9362,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 503636.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 12077.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 34609.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 55919.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3626.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 21499.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 147832.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 100311.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 164945.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 11.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 7.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 8.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 34240.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 6997.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 13563.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 9.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6381.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 15735.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 15692.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 15759.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 439579.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 15394.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 22473.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 288987.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 21784.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 4.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 23240.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 294301.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 6.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 14.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 10091.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 19768.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 16494.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 16770.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 495656.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 16973.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 22695.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 293020.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 22297.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 62.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 22968.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 290637.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 17.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 12829.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 21862,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 16099.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 15662,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 488049.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 18332.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 23176.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 288290.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 21411.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 134.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 22795,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 281304.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 67.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 33.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 30.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 106.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 17.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 17.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 37.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 15.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 12.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 12.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 10.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 884,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 26.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 28.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 109.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 23.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 16,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 13.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 124,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 30.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 23,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1563.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 29.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 28.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 132.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 19.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 21.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 10.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 136.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 32.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 21.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 16.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 28.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 56.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 78.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 78.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 103.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 466.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 164.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 265.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 539,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 49.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 57.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 83.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 77.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 105.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 465.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 171.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 273.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 547.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 46.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 60.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 177.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 81.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 109.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 458.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 190.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 302.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 547.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 13.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 50.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 589.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 61.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 29.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 6.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 37.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2715.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 3889.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 18.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 24.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 17.6,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.008,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 9,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.074,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 348.7,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 324.3,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 13254.3,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 7090.7,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 779260,
+          "unit": "us"
+        },
+        {
+          "name": "geo_within10km_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "geo_within50km_us",
+          "value": 151.1,
+          "unit": "us"
+        },
+        {
+          "name": "geo_nearest_k10_us",
+          "value": 7.6,
+          "unit": "us"
+        },
+        {
+          "name": "geo_nearest_k100_us",
+          "value": 84.6,
+          "unit": "us"
+        },
+        {
+          "name": "geo_geof_within_us",
+          "value": 101882.4,
+          "unit": "us"
+        },
+        {
+          "name": "geo_geo_compliance_pass_us",
+          "value": 94.2,
+          "unit": "us"
+        },
+        {
+          "name": "geo_compliance_deficit",
+          "value": 0,
+          "unit": "fixtures"
+        },
+        {
+          "name": "text_and_terms_us",
+          "value": 14,
+          "unit": "us"
+        },
+        {
+          "name": "text_near_slop2_us",
+          "value": 1.4,
+          "unit": "us"
+        },
+        {
+          "name": "text_or_terms_us",
+          "value": 22.6,
+          "unit": "us"
+        },
+        {
+          "name": "text_phrase_us",
+          "value": 1.4,
+          "unit": "us"
+        },
+        {
+          "name": "text_prefix4_us",
+          "value": 3683.5,
+          "unit": "us"
+        },
+        {
+          "name": "fts_bytes_per_doc",
+          "value": 371,
+          "unit": "bytes"
+        },
+        {
+          "name": "text_build_s",
+          "value": 0.478461,
+          "unit": "s"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.139,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "752e402ddc82b528cc13d8f393b61c53b215199b",
+      "date": 1781551863522,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.549,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 5.0106,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.9,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3307.4,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4884.5,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5.7,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 4.5,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 790.8,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 13189.4,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 59798.9,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 163666.5,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 4120.3,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 41841,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 8255.8,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 59156.6,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 164792,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 4023.1,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 5.5,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 40452.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 4.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 29593,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 17,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 1884600.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 9.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6341.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3780.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3555.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7306.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 475047.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 12698.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 30887.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 53506,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3735.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 22600.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 135167.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 104979.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 176972.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 11.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 6.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 8.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 35314.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 7411.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 13282.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 9.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 29677.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 17.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 1870279.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 9.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6316.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3820.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3499.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 8813,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 478372.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 12867.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 31474.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 53639.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3740.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 22595.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 14.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 145888,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 105766.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 175949.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 9.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 36665.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 6935.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 13008,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 9.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 29545,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 20.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 1651533.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6254.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3752,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3521.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 8604.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 476248.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 12903.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 31280,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 53849.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3747.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 22479.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 13.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 141791.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 103063.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 176740.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 10,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 12.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 7.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 35410.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 7223.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 13598.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 9.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6689,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 16434.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 16302.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 16304.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 459212.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 17651.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 24535,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 283781.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 22738,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 5.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 23057.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 284164,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 14.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 9537.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 19213.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 16320,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 16321.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 494572.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 18380.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 24409.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 291378.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 23829.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 64.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 22999.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 290869.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 6.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 17.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 14742.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 22736.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 16957.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 16743.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 506341.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 19444.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 25125.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 288838.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 23533.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 133.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 24118.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 291805.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 61.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 32.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 27.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 98,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 18,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 16.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 10.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 31.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 13,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 11.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 11.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 10.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 9.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 941.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 26.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 30.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 101.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 18.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 16.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 14.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 113.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 32,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 23,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 10.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 10.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1551.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 27.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 28.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 125.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 21.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 21.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 133.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 33.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 21.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 16.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 27.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 12.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 55.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 76.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 71.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 99.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 502.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 174.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 283.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 599.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 44.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 57,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 94.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 76.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 102.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 500.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 191.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 301.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 618,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 44.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 69.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 156.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 85,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 107.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 502.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 197.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 321.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 7.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 599.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 13.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 45.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 10.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 601.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 15,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 4.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 70.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 29.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 30.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2952.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 4066.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 17.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 10.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 23.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 18.6,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.7,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.067,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 5.4,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 350.6,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 314.6,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 13310.5,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6557.4,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 685714.8,
+          "unit": "us"
+        },
+        {
+          "name": "geo_within10km_us",
+          "value": 8.3,
+          "unit": "us"
+        },
+        {
+          "name": "geo_within50km_us",
+          "value": 148.3,
+          "unit": "us"
+        },
+        {
+          "name": "geo_nearest_k10_us",
+          "value": 7.7,
+          "unit": "us"
+        },
+        {
+          "name": "geo_nearest_k100_us",
+          "value": 80.8,
+          "unit": "us"
+        },
+        {
+          "name": "geo_geof_within_us",
+          "value": 107292.6,
+          "unit": "us"
+        },
+        {
+          "name": "geo_geo_compliance_pass_us",
+          "value": 95.9,
+          "unit": "us"
+        },
+        {
+          "name": "geo_compliance_deficit",
+          "value": 0,
+          "unit": "fixtures"
+        },
+        {
+          "name": "text_and_terms_us",
+          "value": 13.3,
+          "unit": "us"
+        },
+        {
+          "name": "text_near_slop2_us",
+          "value": 1.3,
+          "unit": "us"
+        },
+        {
+          "name": "text_or_terms_us",
+          "value": 22.6,
+          "unit": "us"
+        },
+        {
+          "name": "text_phrase_us",
+          "value": 1.3,
+          "unit": "us"
+        },
+        {
+          "name": "text_prefix4_us",
+          "value": 3888.5,
+          "unit": "us"
+        },
+        {
+          "name": "fts_bytes_per_doc",
+          "value": 371,
+          "unit": "bytes"
+        },
+        {
+          "name": "text_build_s",
+          "value": 0.534897,
+          "unit": "s"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.141,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "61f64e256dedcde004c0486d99a016f776990242",
+      "date": 1781555207966,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.538,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 4.9721,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.5,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3074,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4340.2,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5.7,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 5.1,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 820.7,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 12967,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 55633,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 147988.2,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 2762,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 40111.4,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 11626.2,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 69209.7,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 157322.7,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 2426.2,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 5.2,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 39509.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 3.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 29308.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 15.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 1482101.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 8.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6225.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3689.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3397.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7167.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 510743.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 12650.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 31375.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 52286.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3634.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 21600.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 11.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 136760.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 93400.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 157164.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 8.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 6.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 33673.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 6260.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 12650.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 28660.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 16.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 1349081,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 8.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6127.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3685.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3355.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 9152.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 505809,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 12425.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 32760.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 53057.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3582.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 21261.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 12.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 128953.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 89024.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 153605.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 9.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 11.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 7.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 35064.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 6889.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 12812.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 9.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 29021.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 18.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 1295821.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6383.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3656.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3393.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 8711.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 506112.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 12840.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 31482.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 53101.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3933.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 21475.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 129262.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 89721.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 155244.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 11.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 10.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 34032.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 6337.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 12420.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 8.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 10.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6195.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 15215.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 14938.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 14826.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 407996.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 15193.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 21829,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 285138,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 20568.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 3.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 20789,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 282354.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 13.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 8424.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 16836.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 14801,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 14543.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 459383.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 16400.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 22208.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 280327.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 20481.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 58.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 20726.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 280557.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 5.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 15.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 12603.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 18006,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 14874.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 14553.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 464283.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 16786.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 21956,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 280192.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 20473,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 135.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 21003,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 280637.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 65.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 32.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 28.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 101.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 18.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 17,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 12.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 38.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 14.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 12.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 11.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 866.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 26.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 28.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 110.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 18.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 16.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 13.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 11,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 128.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 30.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 23.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 11,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1503.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 28.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 31.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 129,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 20.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 21.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 11.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 126.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 31.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 22.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 17.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 28.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 55.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 77.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 77.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 102.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 464.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 160.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 296.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 538.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 47.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 59,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 83.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 78.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 105,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 467.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 173.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 272.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 548.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 47.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 58.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 172.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 84.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 110.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 474.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 185.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 307,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 546.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 12.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 47.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 10,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 589.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 4.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 62.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 27.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 6.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 29.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2701.8,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 3845.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 16.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 9.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 22.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 17.1,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.3,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.062,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 349.3,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 325.6,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 12956.2,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6689.1,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 770049.3,
+          "unit": "us"
+        },
+        {
+          "name": "geo_within10km_us",
+          "value": 6.8,
+          "unit": "us"
+        },
+        {
+          "name": "geo_within50km_us",
+          "value": 143.4,
+          "unit": "us"
+        },
+        {
+          "name": "geo_nearest_k10_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "geo_nearest_k100_us",
+          "value": 83.4,
+          "unit": "us"
+        },
+        {
+          "name": "geo_geof_within_us",
+          "value": 102277,
+          "unit": "us"
+        },
+        {
+          "name": "geo_geo_compliance_pass_us",
+          "value": 94.5,
+          "unit": "us"
+        },
+        {
+          "name": "geo_compliance_deficit",
+          "value": 0,
+          "unit": "fixtures"
+        },
+        {
+          "name": "text_and_terms_us",
+          "value": 13.9,
+          "unit": "us"
+        },
+        {
+          "name": "text_near_slop2_us",
+          "value": 1.4,
+          "unit": "us"
+        },
+        {
+          "name": "text_or_terms_us",
+          "value": 22.3,
+          "unit": "us"
+        },
+        {
+          "name": "text_phrase_us",
+          "value": 1.3,
+          "unit": "us"
+        },
+        {
+          "name": "text_prefix4_us",
+          "value": 3685.1,
+          "unit": "us"
+        },
+        {
+          "name": "fts_bytes_per_doc",
+          "value": 371,
+          "unit": "bytes"
+        },
+        {
+          "name": "text_build_s",
+          "value": 0.452312,
+          "unit": "s"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.138,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "b2404eafe9b36003868136f9204782c0a843c50b",
+      "date": 1781555499196,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.542,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 4.8565,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.3,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3084.1,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4341,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5.8,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 814.7,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 12474.2,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 55615.3,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 148867.8,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 3872.7,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 39294.4,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 9025.4,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 58327.8,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 158210.1,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 2573.3,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 5.6,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 47113.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 3.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 28975.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 15.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 1208139.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6232.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3648.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3402.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7162.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 509566.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 11753.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 31325.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 52712,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3574.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 21181.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 125568.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 89488.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 149814.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 34765.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 6518.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 12871.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 9.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 28426.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 16.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 1181881.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 8.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6197.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3708.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3356.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 8296.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 512084.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 12298.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 37923.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 51976.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3657.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 21074.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 12.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 124717.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 93157.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 158431.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 10.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 12,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 7.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 8.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 33422.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 6953.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 12917,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 28600.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 17.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 1170795.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6131.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3651.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3374.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 8449.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 507681.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 12151.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 30912.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 52704.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3602.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 20972.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 12.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 123336.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 89205.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 152351.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 11.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 6.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 8.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 33343.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 6549.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 12482.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6279.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 15098.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 14823.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 14838.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 406595,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 15206.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 22251.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 283945.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 20830.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 4.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 21434.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 283152.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 5.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 15.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 8695.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 17306.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 14891.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 14739.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 461339.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 16172.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 22035.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 278000.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 20469,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 62.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 20824.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 282167.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 5.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 16.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 12575.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 18266.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 14769.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 14544.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 475784.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 16676.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 22158.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 285722.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 20946.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 135.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 22193.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 285458,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 59.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 31.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 28.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 107.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 17.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 17,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 37.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 15.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 12.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 11.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 10.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 876.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 26.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 27.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 112.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 17.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 16.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 13.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 11,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 123.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 32.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 22.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 11.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 11,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1538.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 28.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 28.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 131.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 20.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 21.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 124.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 32.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 22.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 17.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 28.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 56.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 73.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 79.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 101.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 467.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 163.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 261.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 547.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 46.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 56.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 80.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 87.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 104.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 462.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 170.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 272.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 550.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 47.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 58.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 177.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 79.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 109.5,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 463.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 196.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 316.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 13.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 565,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 13,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 47.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 587.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 76.2,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 29.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 6.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 28.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2644.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 3850.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 16.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 22.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 17.2,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 4.5,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.058,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 356.2,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 334.6,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 13054.8,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6685.3,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 775881.3,
+          "unit": "us"
+        },
+        {
+          "name": "geo_within10km_us",
+          "value": 6.8,
+          "unit": "us"
+        },
+        {
+          "name": "geo_within50km_us",
+          "value": 153.2,
+          "unit": "us"
+        },
+        {
+          "name": "geo_nearest_k10_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "geo_nearest_k100_us",
+          "value": 83.5,
+          "unit": "us"
+        },
+        {
+          "name": "geo_geof_within_us",
+          "value": 103143.5,
+          "unit": "us"
+        },
+        {
+          "name": "geo_geo_compliance_pass_us",
+          "value": 95.4,
+          "unit": "us"
+        },
+        {
+          "name": "geo_compliance_deficit",
+          "value": 0,
+          "unit": "fixtures"
+        },
+        {
+          "name": "text_and_terms_us",
+          "value": 14,
+          "unit": "us"
+        },
+        {
+          "name": "text_near_slop2_us",
+          "value": 1.4,
+          "unit": "us"
+        },
+        {
+          "name": "text_or_terms_us",
+          "value": 22.6,
+          "unit": "us"
+        },
+        {
+          "name": "text_phrase_us",
+          "value": 1.4,
+          "unit": "us"
+        },
+        {
+          "name": "text_prefix4_us",
+          "value": 3701.9,
+          "unit": "us"
+        },
+        {
+          "name": "fts_bytes_per_doc",
+          "value": 371,
+          "unit": "bytes"
+        },
+        {
+          "name": "text_build_s",
+          "value": 0.505946,
+          "unit": "s"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.134,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    },
+    {
+      "commit": "fd219babd41d36e36b8e72e161c5c4c8277583fe",
+      "date": 1781556283889,
+      "benches": [
+        {
+          "name": "load_s",
+          "value": 0.538,
+          "unit": "s"
+        },
+        {
+          "name": "store_bytes_per_triple",
+          "value": 92,
+          "unit": "bytes"
+        },
+        {
+          "name": "dict_bytes_per_term",
+          "value": 53,
+          "unit": "bytes"
+        },
+        {
+          "name": "parse_ns_per_byte",
+          "value": 4.895,
+          "unit": "ns/byte"
+        },
+        {
+          "name": "store_bytes_per_triple_small",
+          "value": 88,
+          "unit": "bytes"
+        },
+        {
+          "name": "q02_type_person_count_us",
+          "value": 3.2,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_count_us",
+          "value": 3077.6,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_count_us",
+          "value": 4345.7,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_count_us",
+          "value": 5.4,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_count_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_count_us",
+          "value": 820.7,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_materialize_us",
+          "value": 12484.5,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_materialize_us",
+          "value": 54529.3,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_materialize_us",
+          "value": 141055.3,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_materialize_us",
+          "value": 2396.8,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_materialize_us",
+          "value": 4.6,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_materialize_us",
+          "value": 38893.8,
+          "unit": "us"
+        },
+        {
+          "name": "q02_type_person_json_us",
+          "value": 8818.6,
+          "unit": "us"
+        },
+        {
+          "name": "q03_star3_json_us",
+          "value": 56832.9,
+          "unit": "us"
+        },
+        {
+          "name": "q04_follows_name_json_us",
+          "value": 154039.8,
+          "unit": "us"
+        },
+        {
+          "name": "q06_filter_age_json_us",
+          "value": 2704.6,
+          "unit": "us"
+        },
+        {
+          "name": "q09_count_edges_json_us",
+          "value": 5.7,
+          "unit": "us"
+        },
+        {
+          "name": "q10_optional_age_json_us",
+          "value": 37913.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_count_us",
+          "value": 3.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_count_us",
+          "value": 27981.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_count_us",
+          "value": 15.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_count_us",
+          "value": 1145557.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_count_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_count_us",
+          "value": 6100.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_count_us",
+          "value": 3623,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_count_us",
+          "value": 3412.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_count_us",
+          "value": 7096,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_count_us",
+          "value": 505675.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_count_us",
+          "value": 11969.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_count_us",
+          "value": 29783.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_count_us",
+          "value": 52429.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_count_us",
+          "value": 3620.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_count_us",
+          "value": 21033.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_count_us",
+          "value": 12.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_count_us",
+          "value": 123062.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_count_us",
+          "value": 88967.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_count_us",
+          "value": 150950.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_count_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_count_us",
+          "value": 10.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_count_us",
+          "value": 7.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_count_us",
+          "value": 7.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_count_us",
+          "value": 7.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_count_us",
+          "value": 33892.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_count_us",
+          "value": 6543,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_count_us",
+          "value": 12457.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_count_us",
+          "value": 8.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_materialize_us",
+          "value": 4.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_materialize_us",
+          "value": 28307.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_materialize_us",
+          "value": 16.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_materialize_us",
+          "value": 1146871.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_materialize_us",
+          "value": 8.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_materialize_us",
+          "value": 6258,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_materialize_us",
+          "value": 3633.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_materialize_us",
+          "value": 3300.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_materialize_us",
+          "value": 8016.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_materialize_us",
+          "value": 498437.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_materialize_us",
+          "value": 11879.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_materialize_us",
+          "value": 30494.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_materialize_us",
+          "value": 51742.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_materialize_us",
+          "value": 3753.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_materialize_us",
+          "value": 20935.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_materialize_us",
+          "value": 12.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_materialize_us",
+          "value": 119734.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_materialize_us",
+          "value": 90281.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_materialize_us",
+          "value": 150772.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_materialize_us",
+          "value": 9.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_materialize_us",
+          "value": 12.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_materialize_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_materialize_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_materialize_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_materialize_us",
+          "value": 34768.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_materialize_us",
+          "value": 6603.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_materialize_us",
+          "value": 12421.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_materialize_us",
+          "value": 9.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q01_bgp_json_us",
+          "value": 4.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q02_star3_json_us",
+          "value": 28484.8,
+          "unit": "us"
+        },
+        {
+          "name": "op_q03_chain_json_us",
+          "value": 18.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q04_triangle_json_us",
+          "value": 1136408.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q05_union_json_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "op_q06_optional_json_us",
+          "value": 6105.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q07_optional_notbound_json_us",
+          "value": 3741.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q08_minus_json_us",
+          "value": 3371.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q09_filter_numeric_json_us",
+          "value": 8775.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q10_filter_string_json_us",
+          "value": 502139.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q11_filter_in_json_us",
+          "value": 11729.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q12_filter_exists_json_us",
+          "value": 30838.5,
+          "unit": "us"
+        },
+        {
+          "name": "op_q13_bind_json_us",
+          "value": 52271.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q14_values_json_us",
+          "value": 3567.6,
+          "unit": "us"
+        },
+        {
+          "name": "op_q15_agg_group_having_json_us",
+          "value": 21098.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q16_distinct_json_us",
+          "value": 22.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q17_orderby_limit_offset_json_us",
+          "value": 118928.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q18_path_plus_json_us",
+          "value": 89547.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q19_path_star_json_us",
+          "value": 151484,
+          "unit": "us"
+        },
+        {
+          "name": "op_q20_path_opt_json_us",
+          "value": 10.3,
+          "unit": "us"
+        },
+        {
+          "name": "op_q21_path_seq_json_us",
+          "value": 11.7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q22_path_alt_json_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "op_q23_path_inverse_json_us",
+          "value": 8.1,
+          "unit": "us"
+        },
+        {
+          "name": "op_q24_path_negated_pset_json_us",
+          "value": 7.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q25_subquery_json_us",
+          "value": 35919.9,
+          "unit": "us"
+        },
+        {
+          "name": "op_q26_ask_json_us",
+          "value": 6328.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q27_construct_json_us",
+          "value": 12569.4,
+          "unit": "us"
+        },
+        {
+          "name": "op_q28_describe_json_us",
+          "value": 8.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_count_us",
+          "value": 10.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_count_us",
+          "value": 6199,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_count_us",
+          "value": 15248.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_count_us",
+          "value": 14824.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_count_us",
+          "value": 14721.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_count_us",
+          "value": 410692.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_count_us",
+          "value": 15075.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_count_us",
+          "value": 21961.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_count_us",
+          "value": 284129.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_count_us",
+          "value": 20569.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_count_us",
+          "value": 3.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_count_us",
+          "value": 21155.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_count_us",
+          "value": 280658.7,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_count_us",
+          "value": 6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_materialize_us",
+          "value": 13.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_materialize_us",
+          "value": 8362.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_materialize_us",
+          "value": 16049.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_materialize_us",
+          "value": 14634,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_materialize_us",
+          "value": 14586.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_materialize_us",
+          "value": 446819.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_materialize_us",
+          "value": 16071.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_materialize_us",
+          "value": 22207.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_materialize_us",
+          "value": 282716.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_materialize_us",
+          "value": 20417.5,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_materialize_us",
+          "value": 58,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_materialize_us",
+          "value": 20685.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_materialize_us",
+          "value": 277510.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_materialize_us",
+          "value": 5.6,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q01_json_us",
+          "value": 15.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q02_json_us",
+          "value": 12261,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03a_json_us",
+          "value": 17982.9,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03b_json_us",
+          "value": 14892.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q03c_json_us",
+          "value": 14694.3,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q04_json_us",
+          "value": 459869.1,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q05b_json_us",
+          "value": 16267.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q07_json_us",
+          "value": 22030.2,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q08_json_us",
+          "value": 277711.8,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q09_json_us",
+          "value": 20667,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q10_json_us",
+          "value": 135.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q11_json_us",
+          "value": 20860,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12b_json_us",
+          "value": 279690.4,
+          "unit": "us"
+        },
+        {
+          "name": "sp2b_q12c_json_us",
+          "value": 5.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_count_us",
+          "value": 60.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_count_us",
+          "value": 32.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_count_us",
+          "value": 28.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_count_us",
+          "value": 102,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_count_us",
+          "value": 19.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_count_us",
+          "value": 18.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_count_us",
+          "value": 7.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_count_us",
+          "value": 6.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_count_us",
+          "value": 11.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_count_us",
+          "value": 38.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_count_us",
+          "value": 15.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_count_us",
+          "value": 13,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_count_us",
+          "value": 12.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_count_us",
+          "value": 12.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_count_us",
+          "value": 11.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_count_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_materialize_us",
+          "value": 867.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_materialize_us",
+          "value": 26.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_materialize_us",
+          "value": 27.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_materialize_us",
+          "value": 108.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_materialize_us",
+          "value": 18.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_materialize_us",
+          "value": 16.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_materialize_us",
+          "value": 13.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_materialize_us",
+          "value": 8.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_materialize_us",
+          "value": 13.7,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_materialize_us",
+          "value": 123.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_materialize_us",
+          "value": 30.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_materialize_us",
+          "value": 17.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_materialize_us",
+          "value": 15.6,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_materialize_us",
+          "value": 22.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_materialize_us",
+          "value": 11.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_materialize_us",
+          "value": 11.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_C3_json_us",
+          "value": 1523.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F2_json_us",
+          "value": 29.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F3_json_us",
+          "value": 28.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_F5_json_us",
+          "value": 131.2,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L1_json_us",
+          "value": 20.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L2_json_us",
+          "value": 17.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L3_json_us",
+          "value": 21.8,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L4_json_us",
+          "value": 9.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_L5_json_us",
+          "value": 11.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S1_json_us",
+          "value": 130.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S2_json_us",
+          "value": 32.4,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S3_json_us",
+          "value": 21.9,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S4_json_us",
+          "value": 17.1,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S5_json_us",
+          "value": 28.5,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S6_json_us",
+          "value": 12.3,
+          "unit": "us"
+        },
+        {
+          "name": "watdiv_S7_json_us",
+          "value": 12.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_count_us",
+          "value": 54.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_count_us",
+          "value": 69,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_count_us",
+          "value": 108.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_count_us",
+          "value": 102.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_count_us",
+          "value": 476,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_count_us",
+          "value": 163.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_count_us",
+          "value": 266.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_count_us",
+          "value": 7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_count_us",
+          "value": 554.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_count_us",
+          "value": 8.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_count_us",
+          "value": 46.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_materialize_us",
+          "value": 54.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_materialize_us",
+          "value": 82.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_materialize_us",
+          "value": 80.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_materialize_us",
+          "value": 106.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_materialize_us",
+          "value": 473.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_materialize_us",
+          "value": 181.8,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_materialize_us",
+          "value": 268,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_materialize_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_materialize_us",
+          "value": 541.6,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_materialize_us",
+          "value": 9.9,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_materialize_us",
+          "value": 47.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query01_json_us",
+          "value": 57.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query02_json_us",
+          "value": 169.7,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query03_json_us",
+          "value": 79.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query04_json_us",
+          "value": 109.1,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query05_json_us",
+          "value": 475.2,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query07_json_us",
+          "value": 189.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query08_json_us",
+          "value": 301,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query09_json_us",
+          "value": 7.4,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query10_json_us",
+          "value": 546.3,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query11_json_us",
+          "value": 13,
+          "unit": "us"
+        },
+        {
+          "name": "bsbm_query12_json_us",
+          "value": 49.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q01_count_us",
+          "value": 10.1,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q02_count_us",
+          "value": 587.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q03_count_us",
+          "value": 14.4,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q14_count_us",
+          "value": 5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q04_count_us",
+          "value": 61.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q05_count_us",
+          "value": 29.3,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q06_count_us",
+          "value": 6.5,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q07_count_us",
+          "value": 28.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q08_count_us",
+          "value": 2626.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q09_count_us",
+          "value": 3843.9,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q10_count_us",
+          "value": 16.7,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q11_count_us",
+          "value": 10.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q12_count_us",
+          "value": 22.6,
+          "unit": "us"
+        },
+        {
+          "name": "lubm_q13_count_us",
+          "value": 17.6,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_s",
+          "value": 0.006,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d1000_query_us",
+          "value": 9.2,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d1000_closure_triples",
+          "value": 2001,
+          "unit": "triples"
+        },
+        {
+          "name": "deeptax_d10000_closure_s",
+          "value": 0.058,
+          "unit": "s"
+        },
+        {
+          "name": "deeptax_d10000_query_us",
+          "value": 4.8,
+          "unit": "us"
+        },
+        {
+          "name": "deeptax_d10000_closure_triples",
+          "value": 20001,
+          "unit": "triples"
+        },
+        {
+          "name": "shacl_cardinality_validate_us",
+          "value": 347.9,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_class_nodekind_validate_us",
+          "value": 328.8,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_datatype_range_validate_us",
+          "value": 12979.3,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_node_paths_validate_us",
+          "value": 6755.7,
+          "unit": "us"
+        },
+        {
+          "name": "shacl_sparql_constraint_validate_us",
+          "value": 760170.2,
+          "unit": "us"
+        },
+        {
+          "name": "geo_within10km_us",
+          "value": 7.1,
+          "unit": "us"
+        },
+        {
+          "name": "geo_within50km_us",
+          "value": 154,
+          "unit": "us"
+        },
+        {
+          "name": "geo_nearest_k10_us",
+          "value": 10.9,
+          "unit": "us"
+        },
+        {
+          "name": "geo_nearest_k100_us",
+          "value": 87.1,
+          "unit": "us"
+        },
+        {
+          "name": "geo_geof_within_us",
+          "value": 100260.6,
+          "unit": "us"
+        },
+        {
+          "name": "geo_geo_compliance_pass_us",
+          "value": 96.2,
+          "unit": "us"
+        },
+        {
+          "name": "geo_compliance_deficit",
+          "value": 0,
+          "unit": "fixtures"
+        },
+        {
+          "name": "text_and_terms_us",
+          "value": 13.8,
+          "unit": "us"
+        },
+        {
+          "name": "text_near_slop2_us",
+          "value": 1.5,
+          "unit": "us"
+        },
+        {
+          "name": "text_or_terms_us",
+          "value": 22.4,
+          "unit": "us"
+        },
+        {
+          "name": "text_phrase_us",
+          "value": 1.4,
+          "unit": "us"
+        },
+        {
+          "name": "text_prefix4_us",
+          "value": 3615.6,
+          "unit": "us"
+        },
+        {
+          "name": "fts_bytes_per_doc",
+          "value": 371,
+          "unit": "bytes"
+        },
+        {
+          "name": "text_build_s",
+          "value": 0.427311,
+          "unit": "s"
+        },
+        {
+          "name": "vectors_diskann_recall_at10",
+          "value": 34,
+          "unit": "milli"
+        },
+        {
+          "name": "vectors_diskann_query_us",
+          "value": 330.2,
+          "unit": "us"
+        },
+        {
+          "name": "vectors_hnsw_recall_at10",
+          "value": 0,
+          "unit": "milli"
+        },
+        {
+          "name": "vectors_hnsw_query_us",
+          "value": 390.5,
+          "unit": "us"
+        },
+        {
+          "name": "vectors_pq_recall_at10",
+          "value": 22,
+          "unit": "milli"
+        },
+        {
+          "name": "vectors_pq_query_us",
+          "value": 408.1,
+          "unit": "us"
+        },
+        {
+          "name": "vectors_build_s",
+          "value": 41.935511,
+          "unit": "s"
+        },
+        {
+          "name": "rdfs_infer_s",
+          "value": 0.133,
+          "unit": "s"
+        },
+        {
+          "name": "wasm_bundle_bytes",
+          "value": 1604690,
+          "unit": "bytes"
+        }
+      ]
+    }
+  ],
   "labels": {
     "bsbm_query01_count": {
       "label": "BSBM query01 — find products by type + two features (ORDER/LIMIT), count",

--- a/site/src/data/benchmarks.ts
+++ b/site/src/data/benchmarks.ts
@@ -98,10 +98,20 @@ interface CompetitorsData {
   same_box_comparisons: SameBoxComparison[];
 }
 
+// [OPUS-4.8] sq-hsyg — one commit's worth of the github-action-benchmark series. `date` is
+// the epoch-ms the series carries (github-action-benchmark writes a number).
+export interface HistoryEntry {
+  commit: string | null;
+  date: number | null;
+  benches: Bench[];
+}
+
 interface Snapshot {
   generatedAt: string;
   source: string;
-  latest: { commit: string | null; date: string | null; benches: Bench[] };
+  latest: HistoryEntry;
+  // sq-hsyg: trailing window of commits (oldest -> newest), latest === history[last].
+  history?: HistoryEntry[];
   labels: Record<string, MetricLabel>;
   competitors: CompetitorsData;
 }
@@ -111,6 +121,13 @@ const SNAPSHOT = data as unknown as Snapshot;
 export const LATEST = SNAPSHOT.latest;
 export const SOURCE = SNAPSHOT.source;
 export const GENERATED_AT = SNAPSHOT.generatedAt;
+// History is optional in the schema (a pre-sq-hsyg JSON, or a fork without the
+// benchmark-data branch); fall back to a single-point series so trend charts still render
+// one marker and never crash on an empty/absent history.
+export const HISTORY: HistoryEntry[] =
+  Array.isArray(SNAPSHOT.history) && SNAPSHOT.history.length
+    ? SNAPSHOT.history
+    : [SNAPSHOT.latest];
 const LABELS = SNAPSHOT.labels;
 export const COMPETITORS = SNAPSHOT.competitors;
 
@@ -332,15 +349,24 @@ export interface FullSuiteGroup {
   summary: CompetitiveSummary;
   sameBox?: SameBoxComparison;
   references: ReferenceBaseline[];
+  // sq-hsyg: per-suite trend series (one per metric) + scaling families (size-parametrised).
+  trends: TrendSeries[];
+  scaling: ScalingFamily[];
 }
 
 export function fullSuiteGroupsForFamily(key: string): FullSuiteGroup[] {
+  // Derive the family's trend + scaling once, then slice per suite (cheap; the series count
+  // is small). Trend/scaling carry a `suite` so the per-suite filter is exact.
+  const allTrends = trendSeriesForFamily(key);
+  const allScaling = scalingFamiliesForFamily(key);
   return suiteGroupsForFamily(key).map((g) => ({
     suite: g.suite,
     rows: g.rows,
     summary: g.summary,
     sameBox: sameBoxFor(g.suite),
     references: referencesForSuite(g.suite),
+    trends: allTrends.filter((t) => t.suite === g.suite),
+    scaling: allScaling.filter((s) => s.suite === g.suite),
   }));
 }
 
@@ -524,6 +550,156 @@ export function fmtNum(v: number | null | undefined): string {
   if (abs >= 1000) return v.toLocaleString("en-US", { maximumFractionDigits: 0 });
   if (abs >= 1) return (Math.round(v * 100) / 100).toLocaleString("en-US");
   return (Math.round(v * 10000) / 10000).toString();
+}
+
+// ---- TREND series (sq-hsyg; mirror of dashboard.js trendPoints) -----------------------
+// Per-metric history points {date, value} across the committed window, oldest → newest.
+// Points are only emitted for commits that actually carry the metric — no fabricated gaps.
+
+export interface TrendPoint {
+  date: number | null; // epoch-ms (as the series carries it)
+  commit: string | null;
+  value: number;
+}
+
+export interface TrendSeries {
+  name: string;
+  label: string;
+  unit: string;
+  suite: string;
+  points: TrendPoint[];
+}
+
+function trendPointsFor(name: string): TrendPoint[] {
+  const pts: TrendPoint[] = [];
+  for (const entry of HISTORY) {
+    const b = entry.benches.find((x) => x.name === name);
+    if (b) {
+      pts.push({
+        date: entry.date == null ? null : Number(entry.date),
+        commit: entry.commit,
+        value: b.value,
+      });
+    }
+  }
+  return pts;
+}
+
+// Trend series for every metric in a family, ordered by suite then label (same order the
+// metric tables use). A metric with a single point is kept (degenerate single-marker chart).
+export function trendSeriesForFamily(key: string): TrendSeries[] {
+  const series = benchesForFamily(key).map((b) => ({
+    name: b.name,
+    label: labelFor(b.name),
+    unit: b.unit,
+    suite: suiteFor(b.name),
+    points: trendPointsFor(b.name),
+  }));
+  return series.sort((a, b) =>
+    a.suite !== b.suite
+      ? a.suite < b.suite
+        ? -1
+        : 1
+      : a.label < b.label
+        ? -1
+        : a.label > b.label
+          ? 1
+          : 0,
+  );
+}
+
+// ---- SCALING families (sq-hsyg; mirror of dashboard.js sizeAxisOf/buildScalingFamilies) -
+// For SIZE-PARAMETRISED metrics (Deep Taxonomy depth, WatDiv scale factor, …) the harness
+// encodes the size in the metric NAME (e.g. `deeptax_d10000_closure_s`). We split that size
+// token out so two sizes of the same query share a `base` and form one scaling family, then
+// plot the LATEST value vs the size axis. No fabricated points — only real metrics appear.
+
+interface SizeAxis {
+  base: string;
+  axisLabel: string;
+  axis: number;
+}
+
+const SIZE_TOKENS: { re: RegExp; label: string }[] = [
+  { re: /_sf(\d+)([km]?)(?![0-9])/i, label: "scale factor" },
+  { re: /_depth(\d+)(?![0-9])/i, label: "depth" },
+  { re: /_d(\d+)(?![0-9])/i, label: "depth" },
+  { re: /_scale(\d+)([km]?)(?![0-9])/i, label: "scale" },
+  { re: /_size(\d+)([km]?)(?![0-9])/i, label: "size" },
+];
+
+function sizeAxisOf(name: string): SizeAxis | null {
+  for (const t of SIZE_TOKENS) {
+    const m = name.match(t.re);
+    if (m) {
+      let mag = parseInt(m[1], 10);
+      const suffix = (m[2] || "").toLowerCase();
+      if (suffix === "k") mag *= 1000;
+      else if (suffix === "m") mag *= 1_000_000;
+      // Removing the token leaves a placeholder `_`; collapse repeats + trim so the displayed
+      // base stem renders cleanly (`deeptax_closure_s`). Two sizes still share one base.
+      const base = name
+        .replace(m[0], "_")
+        .replace(/_{2,}/g, "_")
+        .replace(/^_|_$/g, "");
+      return { base, axisLabel: t.label, axis: mag };
+    }
+  }
+  return null;
+}
+
+export interface ScalingPoint {
+  axis: number;
+  value: number;
+  name: string;
+  unit: string;
+}
+
+export interface ScalingFamily {
+  base: string;
+  label: string;
+  suite: string;
+  axisLabel: string;
+  unit: string;
+  points: ScalingPoint[];
+}
+
+// Group the LATEST commit's benches in a family into scaling families keyed by `base`. Each
+// family's points are sorted ascending by the size axis. A family with a single point is kept
+// (single marker). Families with NO size token never appear. Sorted by suite then label.
+export function scalingFamiliesForFamily(key: string): ScalingFamily[] {
+  const fams: Record<string, ScalingFamily> = {};
+  for (const b of benchesForFamily(key)) {
+    const s = sizeAxisOf(b.name);
+    if (!s) continue;
+    const fam =
+      fams[s.base] ||
+      (fams[s.base] = {
+        base: s.base,
+        label: labelFor(b.name).replace(/\s*\([^()]*\)\s*$/, "").trim(),
+        suite: suiteFor(b.name),
+        axisLabel: s.axisLabel,
+        unit: b.unit,
+        points: [],
+      });
+    fam.points.push({ axis: s.axis, value: b.value, name: b.name, unit: b.unit });
+  }
+  return Object.values(fams)
+    .map((f) => {
+      f.points.sort((a, b) => a.axis - b.axis);
+      return f;
+    })
+    .sort((a, b) =>
+      a.suite !== b.suite
+        ? a.suite < b.suite
+          ? -1
+          : 1
+        : a.label < b.label
+          ? -1
+          : a.label > b.label
+            ? 1
+            : 0,
+    );
 }
 
 // A one-line headline for a suite's collapsed group header.


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-hsyg** — port the standalone \`bench/dashboard/\` Chart.js history (trend) + scaling views into the Next.js site. The in-site benchmarks previously carried only \`latest\` (no series, no chart lib); this adds the series and renders it.

## What changed (site/ + bench-data emitter only)

**1. Emit history** — \`site/scripts/sync-benchmarks.mjs\` now writes a \`history\` field: the trailing 20-commit window of the SAME \`sparq engine\` series the standalone dashboard reads (\`benchmark-data\` branch / \`dev/bench/data.js\`). \`latest\` is kept (\`= history[last]\`) so every existing page is unaffected. Graceful fallback to a single-point history when the \`benchmark-data\` ref is unavailable (fork / shallow clone). No fabricated points.

**2. Trend charts** — per-metric value over commits, ported from \`dashboard.js\` \`trendPoints\`. Collapsible section inside each suite group.

**3. Scaling charts** — metric vs dataset size/depth, ported from \`dashboard.js\` \`sizeAxisOf\`/\`buildScalingFamilies\`. The size token is parsed from the metric name (e.g. the Deep Taxonomy depth series \`deeptax_d1000_*\` / \`deeptax_d10000_*\`). Renders nothing where a family has no size-parametrised metrics — no fabricated curve.

**Chart lib:** a small **dependency-free SVG** \`LineChart\` (\`line-chart.tsx\`). Chosen for static-export safety — SSR-clean, zero bundle weight, no React-19 peer-dep risk (vs recharts/Chart.js). Uses the site's \`--chart-*\` theme tokens to match the AppShell.

**Honesty:** numbers are the existing **indicative CI-runner** series, kept labelled indicative (not relabelled canonical). Sparse/single-point series render what exists. No unqualified ZK/MPC claims in chart copy.

## Gates
- \`cd site && npm install && npm run build\` (static export) **green end-to-end** — all 7 \`/benchmarks/[type]\` pages build with charts; \`/papers\`, \`/try\`, \`/surface\`, \`/showcase\` unaffected.
- \`npm run lint\` clean; \`tsc --noEmit\` passes. No new dependencies.
- \`basePath: /sparq\` preserved.

## Covered vs deferred
- **Covered:** trend (20-commit window, every metric) + scaling (Deep Taxonomy depth families today).
- **Deferred (existing data gaps, not regressions):** scaling is only as rich as the size-parametrised metrics the CI feed currently emits (Deep Taxonomy depth — WatDiv scale-factor / SP2Bench scale series would light up automatically once the harness emits them). The competitor-matrix / capability-families coverage gaps already tracked separately remain out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)