### PR TITLE
feat(sparq-engine): SPARQL window functions + custom aggregate registry, opt-in (sq-5qz9)

### DIFF
--- a/crates/sparq-engine/Cargo.toml
+++ b/crates/sparq-engine/Cargo.toml
@@ -64,6 +64,20 @@ service = ["dep:serde_json", "dep:ureq"]
 # pull in ZERO new dependencies (oxrdf is already a direct dep), so the default build's
 # dependency graph is byte-for-byte unchanged when this is off.
 serialize-rdf = []
+# [OPUS-4.8] (sq-5qz9) SPARQL window functions + custom aggregate registry.
+# Two extension surfaces, OFF by default:
+#   * a `CustomAggregateRegistry` whose named (IRI) user aggregates are callable in
+#     real SPARQL `GROUP BY` (the vendored spargebra already parses a declared custom
+#     aggregate IRI — `SparqlParser::with_custom_aggregate_function`); the engine
+#     evaluates `AggregateFunction::Custom` against the installed registry.
+#   * a programmatic window-function pass (`window` module) — ROW_NUMBER / RANK /
+#     DENSE_RANK + a windowed aggregate over a result table, with PARTITION BY +
+#     ORDER BY window specs. These are a NON-STANDARD extension (no W3C-REC SPARQL
+#     window syntax exists); the surface follows the SQL:2003 OVER (PARTITION BY …
+#     ORDER BY …) window-spec model that Stardog/AnzoGraph expose.
+# When off, ZERO window/custom-aggregate code compiles and the default build is
+# byte-identical (no new dependencies — oxrdf is already a direct dep).
+window-functions = []
 
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io

--- a/crates/sparq-engine/README.md
+++ b/crates/sparq-engine/README.md
@@ -40,6 +40,14 @@ let json = sparq_engine::query_json(&g, "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?
 - **Custom functions** — register Rust closures under function IRIs (the
   [SPARQL extension mechanism](https://www.w3.org/TR/sparql11-query/#extensionFunctions));
   see [`docs/extension-functions.md`](../../docs/extension-functions.md).
+- **Custom aggregates + window functions** *(opt-in `window-functions` feature, OFF by default)* —
+  register a named user aggregate (`CustomAggregateRegistry`) callable from a real SPARQL `GROUP BY`,
+  and a programmatic window-function pass (`window::apply_window` — `ROW_NUMBER` / `RANK` /
+  `DENSE_RANK` + a windowed aggregate, with `PARTITION BY` + `ORDER BY` specs). **Window functions
+  are a NON-STANDARD extension** — SPARQL has no W3C-REC `OVER` syntax, so they are exposed as an
+  explicit API over a result table (the SQL:2003 model Stardog / AnzoGraph expose), NOT inline query
+  syntax; the engine's SPARQL surface stays exactly SPARQL 1.1. When the feature is off, zero
+  window/aggregate-registry code compiles and the default build is byte-identical (no new deps).
 - **`forbid(unsafe_code)`** — the crate contains zero `unsafe`.
 
 ## 📚 Learn more

--- a/crates/sparq-engine/src/aggregate.rs
+++ b/crates/sparq-engine/src/aggregate.rs
@@ -1,0 +1,226 @@
+//! Custom aggregate registry (sq-5qz9) — register a named (IRI) user aggregate
+//! and call it from a real SPARQL `GROUP BY`.
+//!
+//! [OPUS-4.8] This is the aggregate analogue of [`crate::FunctionRegistry`]: an
+//! extension surface that lets a caller add a SPARQL aggregate function without
+//! forking the engine. Unlike a scalar extension function (one row in, one term
+//! out), an aggregate FOLDS the whole multiset of a group's per-member values
+//! into a single term.
+//!
+//! ## Standard-ness
+//!
+//! Custom aggregate FUNCTION IRIs *are* part of the SPARQL 1.1 grammar's
+//! extension point: `Aggregate ::= … | FunctionCall` where a `FunctionCall`
+//! resolving to an IRI the engine recognises as an aggregate is evaluated as
+//! one (SPARQL 1.1 §11.6 — "an implementation may provide … extension
+//! aggregates"). The vendored `spargebra` parser already supports this via
+//! [`spargebra::SparqlParser::with_custom_aggregate_function`]; this module
+//! supplies the EVALUATION side (an `AggregateFunction::Custom` IRI dispatched
+//! to the installed registry) plus the parse glue that declares every
+//! registered IRI to the parser so the query parses in the first place.
+//!
+//! ## Boundary type
+//!
+//! Like [`crate::ExtFn`], the closure works in `oxrdf::Term`s — the public,
+//! dictionary-independent representation — so a registry can be built without
+//! touching engine internals. Each group member contributes `Option<Term>`
+//! (`None` ≡ the aggregate's argument expression is UNBOUND for that row, e.g.
+//! an `OPTIONAL` column); the aggregate returns `Option<Term>` (`None` ≡ an
+//! unbound aggregate result, exactly like `SUM` over an all-unbound group), or
+//! `Err` for a SPARQL expression error (→ the aggregate is unbound, matching
+//! how the builtin `SUM`/`AVG` report a type error).
+
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+use spargebra::SparqlParser;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::{PreparedQuery, QueryBudget, QueryResult};
+
+/// A user aggregate: folds a group's per-member values (`None` ≡ unbound for
+/// that member) into a single result term (`None` ≡ unbound aggregate). `Err`
+/// is a SPARQL expression error — the aggregate result is unbound, never a hard
+/// query failure (matching the builtin aggregates' error discipline). The
+/// message is only for a human debugging the extension.
+///
+/// `Arc`-shared so a registry clones cheaply and is `Send + Sync` for the
+/// engine's parallel group-evaluation path.
+pub type AggFn = Arc<dyn Fn(&[Option<Term>]) -> Result<Option<Term>, String> + Send + Sync>;
+
+/// A map from aggregate-function IRIs to [`AggFn`]s, consulted by the evaluator
+/// for `AggregateFunction::Custom` IRIs in a `GROUP BY`. Installed per query by
+/// [`query_with_aggregates`] / [`with_aggregates`]; the registry-free entry
+/// points never consult it, so an undeclared custom aggregate stays a parse
+/// error there (the parser does not know the IRI is an aggregate).
+///
+/// Cloning is cheap (the aggregates are `Arc`-shared), so a long-lived registry
+/// can be built once and reused across queries and threads.
+#[derive(Clone, Default)]
+pub struct CustomAggregateRegistry {
+    map: HashMap<String, AggFn>,
+}
+
+impl CustomAggregateRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers `f` as the aggregate under the IRI (replacing any previous
+    /// registration). The IRI is both what the query writes — `<iri>(?x)` in a
+    /// projection over a `GROUP BY` — and what the parser is told to treat as an
+    /// aggregate rather than a scalar function.
+    pub fn register(
+        &mut self,
+        iri: impl Into<String>,
+        f: impl Fn(&[Option<Term>]) -> Result<Option<Term>, String> + Send + Sync + 'static,
+    ) {
+        self.map.insert(iri.into(), Arc::new(f));
+    }
+
+    /// The aggregate registered under `iri`, if any.
+    pub fn get(&self, iri: &str) -> Option<&AggFn> {
+        self.map.get(iri)
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// The registered IRIs, for declaring them to a [`SparqlParser`].
+    pub(crate) fn iris(&self) -> impl Iterator<Item = &str> {
+        self.map.keys().map(String::as_str)
+    }
+}
+
+/// Parses `sparql` with every registry IRI declared to the parser as a custom
+/// aggregate, so `<iri>(?x)` in a `GROUP BY` projection parses as an aggregate
+/// (not a scalar function call). A malformed registry IRI is reported as a
+/// parse-level error rather than panicking.
+fn parse_with_aggregates(sparql: &str, reg: &CustomAggregateRegistry) -> Result<PreparedQuery, String> {
+    let mut parser = SparqlParser::new();
+    for iri in reg.iris() {
+        let nn = NamedNode::new(iri).map_err(|e| format!("custom aggregate IRI {iri:?}: {e}"))?;
+        parser = parser.with_custom_aggregate_function(nn);
+    }
+    let query = parser.parse_query(sparql).map_err(|e| e.to_string())?;
+    Ok(PreparedQuery::from(query))
+}
+
+/// Runs `f` with `reg` installed as the active custom-aggregate registry — the
+/// scoped form behind [`query_with_aggregates`], for callers that route a query
+/// through one of the OTHER entry points themselves. The registry is visible to
+/// every query the closure runs on this thread (installed thread-locally and
+/// propagated into the engine's rayon workers) and uninstalled when the closure
+/// returns. Composes with [`crate::with_functions`] in either nesting order.
+///
+/// NOTE: this only INSTALLS the registry for evaluation; to also PARSE a custom
+/// aggregate the parser must be told the IRI is an aggregate. Use
+/// [`query_with_aggregates`] (which does both), or build the [`PreparedQuery`]
+/// via a [`SparqlParser`] with the same IRIs declared.
+pub fn with_aggregates<T>(reg: &CustomAggregateRegistry, f: impl FnOnce() -> T) -> T {
+    let _guard = crate::exec::aggregates::install(reg);
+    f()
+}
+
+/// [`crate::query`] with a custom-aggregate registry: a declared aggregate IRI in
+/// a `GROUP BY` projection is evaluated against `reg`. The parser is told about
+/// every registry IRI so the query parses; evaluation dispatches
+/// `AggregateFunction::Custom` to the installed aggregate.
+pub fn query_with_aggregates(
+    graph: &Graph,
+    sparql: &str,
+    reg: &CustomAggregateRegistry,
+) -> Result<QueryResult, String> {
+    query_with_aggregates_and_budget(graph, sparql, reg, &QueryBudget::unlimited())
+}
+
+/// [`query_with_aggregates`] under a cooperative [`QueryBudget`].
+pub fn query_with_aggregates_and_budget(
+    graph: &Graph,
+    sparql: &str,
+    reg: &CustomAggregateRegistry,
+    budget: &QueryBudget,
+) -> Result<QueryResult, String> {
+    let prepared = parse_with_aggregates(sparql, reg)?;
+    with_aggregates(reg, || crate::query_prepared_with_budget(graph, &prepared, budget))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxrdf::Literal;
+    use sparq_core::Graph;
+
+    const DATA: &str = r#"
+        @prefix ex: <http://ex/> .
+        ex:a ex:dept "eng"  ; ex:sales 10 .
+        ex:b ex:dept "eng"  ; ex:sales 20 .
+        ex:c ex:dept "eng"  ; ex:sales 30 .
+        ex:d ex:dept "sales"; ex:sales 5 .
+        ex:e ex:dept "sales"; ex:sales 7 .
+    "#;
+
+    fn g() -> Graph {
+        Graph::load_str(DATA, "turtle").unwrap()
+    }
+
+    /// A PRODUCT custom aggregate, registered and called through a real SPARQL
+    /// `GROUP BY` — the headline deliverable: a user aggregate computing
+    /// correctly per group.
+    #[test]
+    fn custom_product_aggregate_through_group_by() {
+        let mut reg = CustomAggregateRegistry::new();
+        reg.register("http://ex/agg#product", |members: &[Option<Term>]| {
+            let mut acc: i64 = 1;
+            for m in members {
+                if let Some(Term::Literal(l)) = m {
+                    acc *= l.value().parse::<i64>().map_err(|e| e.to_string())?;
+                }
+            }
+            Ok(Some(Term::Literal(Literal::from(acc))))
+        });
+        let q = "PREFIX ex: <http://ex/> PREFIX agg: <http://ex/agg#> \
+                 SELECT ?d (agg:product(?s) AS ?p) WHERE { ?x ex:dept ?d ; ex:sales ?s } \
+                 GROUP BY ?d ORDER BY ?d";
+        let r = query_with_aggregates(&g(), q, &reg).unwrap();
+        // eng: 10*20*30 = 6000; sales: 5*7 = 35.
+        let got: Vec<(String, String)> = r
+            .rows
+            .iter()
+            .map(|row| (row[0].as_ref().unwrap().to_string(), row[1].as_ref().unwrap().to_string()))
+            .collect();
+        assert!(got[0].0.contains("eng") && got[0].1.contains("\"6000\""), "eng row: {got:?}");
+        assert!(got[1].0.contains("sales") && got[1].1.contains("\"35\""), "sales row: {got:?}");
+    }
+
+    /// A whole-dataset custom aggregate (no GROUP BY): one group over every row.
+    /// `<iri>(?x)` counting the members it sees collapses to the row count.
+    #[test]
+    fn custom_aggregate_whole_dataset() {
+        let mut reg = CustomAggregateRegistry::new();
+        reg.register("http://ex/agg#cnt", |members: &[Option<Term>]| {
+            Ok(Some(Term::Literal(Literal::from(members.len() as i64))))
+        });
+        let q = "PREFIX ex: <http://ex/> PREFIX agg: <http://ex/agg#> \
+                 SELECT (agg:cnt(?s) AS ?c) WHERE { ?x ex:sales ?s }";
+        let r = query_with_aggregates(&g(), q, &reg).unwrap();
+        // 5 sales triples in DATA.
+        assert!(r.rows[0][0].as_ref().unwrap().to_string().contains("\"5\""));
+    }
+
+    /// An unregistered custom-looking IRI in aggregate position is a parse error
+    /// (the parser was not told it is an aggregate), matching the registry-free
+    /// engine's "unsupported function" discipline.
+    #[test]
+    fn unregistered_aggregate_iri_is_error() {
+        let reg = CustomAggregateRegistry::new(); // empty
+        let q = "PREFIX ex: <http://ex/> SELECT (<http://ex/agg#nope>(?s) AS ?p) \
+                 WHERE { ?x ex:sales ?s } GROUP BY ?x";
+        assert!(query_with_aggregates(&g(), q, &reg).is_err());
+    }
+}

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -319,6 +319,65 @@ pub(crate) mod functions {
     }
 }
 
+// ---- Custom aggregate registry (sq-5qz9) ----------------------------------------
+//
+// Mirrors `functions` exactly (install guard + rayon-worker snapshot/re-install)
+// so a custom `AggregateFunction::Custom` IRI in a `GROUP BY` is visible to the
+// off-thread group-evaluation path. The overwhelmingly common case is NO registry
+// installed, which makes the snapshot path free. NON-DEFAULT `window-functions`
+// feature: when off, this module does not compile and the default build is
+// byte-identical. [OPUS-4.8]
+#[cfg(feature = "window-functions")]
+pub(crate) mod aggregates {
+    use crate::CustomAggregateRegistry;
+    use std::cell::RefCell;
+    use std::sync::Arc;
+
+    thread_local! {
+        static ACTIVE: RefCell<Option<Arc<CustomAggregateRegistry>>> = const { RefCell::new(None) };
+    }
+
+    pub(crate) struct Guard;
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            ACTIVE.with(|a| a.borrow_mut().take());
+        }
+    }
+
+    pub(crate) fn install(reg: &CustomAggregateRegistry) -> Guard {
+        ACTIVE.with(|a| *a.borrow_mut() = Some(Arc::new(reg.clone())));
+        Guard
+    }
+
+    #[cfg_attr(not(feature = "parallel"), allow(dead_code))]
+    pub(crate) fn snapshot() -> Option<Arc<CustomAggregateRegistry>> {
+        ACTIVE.with(|a| a.borrow().clone())
+    }
+
+    pub(crate) struct WorkerGuard(Option<Option<Arc<CustomAggregateRegistry>>>);
+    impl Drop for WorkerGuard {
+        fn drop(&mut self) {
+            if let Some(prev) = self.0.take() {
+                ACTIVE.with(|a| *a.borrow_mut() = prev);
+            }
+        }
+    }
+
+    #[cfg_attr(not(feature = "parallel"), allow(dead_code))]
+    pub(crate) fn worker_install(snap: &Option<Arc<CustomAggregateRegistry>>) -> WorkerGuard {
+        match snap {
+            None => WorkerGuard(None),
+            Some(reg) => WorkerGuard(Some(ACTIVE.with(|a| a.borrow_mut().replace(reg.clone())))),
+        }
+    }
+
+    /// The aggregate registered for `iri`, if a registry is installed and
+    /// contains it.
+    pub(crate) fn lookup(iri: &str) -> Option<crate::AggFn> {
+        ACTIVE.with(|a| a.borrow().as_ref().and_then(|reg| reg.get(iri).cloned()))
+    }
+}
+
 // ---- Spatial index (sq-mg9) ----------------------------------------------------
 //
 // The thread-local [`SpatialProvider`] installed by `with_spatial_index`. The
@@ -5199,6 +5258,10 @@ fn group_aggregate(
         let fns = functions::snapshot();
         let vw = view::snapshot();
         let spx = spatial::snapshot(); // sq-mg9: keep the spatial index visible under EXISTS re-entry.
+        // [OPUS-4.8] (sq-5qz9) keep a custom-aggregate registry visible off-thread, like `fns`.
+        // (`self::` because the `aggregates` *parameter* below shadows the module name.)
+        #[cfg(feature = "window-functions")]
+        let aggs = self::aggregates::snapshot();
         // Process `members`/`order` in PAR_THRESHOLD-sized batches: evaluate + read-only
         // resolve each batch in parallel, then serially intern only that batch's genuinely
         // new terms and emit its rows. Peak `Value` footprint is one batch, not all groups.
@@ -5211,6 +5274,8 @@ fn group_aggregate(
                     let _fns = functions::worker_install(&fns);
                     let _vw = view::worker_install(&vw);
                     let _spx = spatial::worker_install(&spx);
+                    #[cfg(feature = "window-functions")]
+                    let _aggs = self::aggregates::worker_install(&aggs);
                     aggregates
                         .iter()
                         .map(|(_, agg)| eval_aggregate(graph, lv, bref, members, agg).map(|v| value_to_id_readonly(graph, lv, &v)))
@@ -5268,6 +5333,17 @@ fn eval_aggregate(graph: &Graph, local: &LocalVocab, b: &Bindings, members: &[us
                     return Ok(v);
                 }
             }
+            // [OPUS-4.8] (sq-5qz9) A declared custom aggregate IRI: fold the group's
+            // per-member values through the installed registry. Unlike the builtins,
+            // the user aggregate sees the FULL member sequence (an unbound member is
+            // passed as `None`, not skipped) so it can implement count-style or
+            // unbound-sensitive aggregates; DISTINCT de-duplicates the materialised
+            // member terms first (treating two unbound members as equal). The closure
+            // works in `oxrdf::Term`, so the per-member value is materialised to a term.
+            #[cfg(feature = "window-functions")]
+            if let AggregateFunction::Custom(iri) = name {
+                return eval_custom_aggregate(graph, local, b, members, expr, *distinct, iri.as_str());
+            }
             // Collect the per-member values of `expr`. [OPUS-4.8] An UNBOUND member (a variable
             // with no binding in that row, e.g. an OPTIONAL one) is SKIPPED for every aggregate,
             // matching SPARQL "aggregate over the bound values": SUM/AVG over an OPTIONAL column
@@ -5317,6 +5393,48 @@ fn eval_aggregate(graph: &Graph, local: &LocalVocab, b: &Bindings, members: &[us
                 _ => Err("M2: unsupported aggregate".into()),
             }
         }
+    }
+}
+
+/// [OPUS-4.8] (sq-5qz9) Evaluate a declared custom aggregate IRI against the
+/// installed [`crate::CustomAggregateRegistry`]. Materialises each group member's
+/// value of `expr` to an `Option<Term>` (`None` ≡ unbound for that member —
+/// passed THROUGH, not skipped, so a user count-style aggregate can see it),
+/// applies DISTINCT over the materialised members, then folds via the closure.
+/// A missing registry / unregistered IRI is the same hard error the registry-free
+/// path raises; a closure `Err` is a SPARQL expression error (→ unbound result).
+#[cfg(feature = "window-functions")]
+fn eval_custom_aggregate(
+    graph: &Graph,
+    local: &LocalVocab,
+    b: &Bindings,
+    members: &[usize],
+    expr: &Expression,
+    distinct: bool,
+    iri: &str,
+) -> Result<Value, String> {
+    let Some(f) = aggregates::lookup(iri) else {
+        return Err(format!("unsupported SPARQL function: no custom aggregate registered for <{iri}>"));
+    };
+    let mut args: Vec<Option<Term>> = Vec::with_capacity(members.len());
+    for &ri in members {
+        let v = eval_expr(graph, local, b, &b.rows[ri], expr)?;
+        // A genuine expression error inside the argument makes the aggregate a
+        // SPARQL error (→ unbound), mirroring SUM/AVG; an unbound member is a
+        // first-class `None` argument the user aggregate decides how to treat.
+        if matches!(v, Value::Error) {
+            return Ok(Value::Error);
+        }
+        args.push(value_as_term(&v));
+    }
+    if distinct {
+        let mut seen: FxHashSet<Option<Term>> = FxHashSet::default();
+        args.retain(|t| seen.insert(t.clone()));
+    }
+    match f(&args) {
+        Ok(Some(t)) => Ok(Value::Term(t)),
+        Ok(None) => Ok(Value::Unbound),
+        Err(_) => Ok(Value::Error), // expression error → unbound aggregate (builtin discipline)
     }
 }
 

--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -153,6 +153,21 @@ pub fn with_functions<T>(fns: &FunctionRegistry, f: impl FnOnce() -> T) -> T {
     f()
 }
 
+// ---- Custom aggregate registry + window functions (sq-5qz9) -----------------
+//
+// NON-DEFAULT `window-functions` feature. Two distinct, OPT-IN extension surfaces;
+// when the feature is off, NOTHING below compiles and the default build is
+// byte-identical (these add no dependencies). [OPUS-4.8]
+#[cfg(feature = "window-functions")]
+mod aggregate;
+#[cfg(feature = "window-functions")]
+pub mod window;
+#[cfg(feature = "window-functions")]
+pub use aggregate::{
+    query_with_aggregates, query_with_aggregates_and_budget, with_aggregates, AggFn,
+    CustomAggregateRegistry,
+};
+
 // ---- Spatial pushdown seam (sq-mg9) -----------------------------------------
 //
 // The engine is GEOMETRY-FREE: the dependency direction is sparq-geo ->

--- a/crates/sparq-engine/src/window.rs
+++ b/crates/sparq-engine/src/window.rs
@@ -1,0 +1,490 @@
+//! SPARQL window functions (sq-5qz9) — a NON-STANDARD, OPT-IN extension.
+//!
+//! [OPUS-4.8] **There is no W3C-REC syntax for SPARQL window functions.** SPARQL
+//! 1.1 has no `OVER (PARTITION BY … ORDER BY …)` clause, and no SPARQL-community
+//! SEP defines one. Engines that offer windowing (Stardog's `WINDOW`/`OVER`,
+//! AnzoGraph, GraphDB's ranking extensions) each invent their own surface. So
+//! rather than smuggle a non-standard `OVER` clause into the (W3C-conformance
+//! tracking) vendored parser, this module exposes window functions as a
+//! **programmatic pass over a [`QueryResult`]** whose semantics follow the
+//! SQL:2003 windowing model (`PARTITION BY`, then `ORDER BY` within a partition,
+//! then a ranking / aggregate function) — the model Stardog and AnzoGraph
+//! expose. The caller runs an ordinary SELECT, then applies a [`WindowSpec`].
+//!
+//! This keeps the extension HONEST (the engine's SPARQL surface stays exactly
+//! SPARQL 1.1; the window layer is an explicit, separate API a caller opts into)
+//! and avoids any conformance-harness regression.
+//!
+//! ## Supported functions
+//!
+//! * [`WindowFunction::RowNumber`] — `ROW_NUMBER()`: 1-based sequential position
+//!   within the partition, in the window `ORDER BY` order (ties broken by input
+//!   order, i.e. stable).
+//! * [`WindowFunction::Rank`] — `RANK()`: 1-based, with GAPS after ties (rows
+//!   that compare equal under the window `ORDER BY` share a rank; the next
+//!   distinct row's rank skips by the size of the tie group).
+//! * [`WindowFunction::DenseRank`] — `DENSE_RANK()`: 1-based, NO gaps (ties share
+//!   a rank, the next distinct row is +1).
+//! * [`WindowFunction::Aggregate`] — a windowed aggregate over the WHOLE
+//!   partition (frame = the entire partition, the SQL default for an aggregate
+//!   with `PARTITION BY` and no explicit frame): every row in a partition gets
+//!   the same value, the aggregate of a chosen column over that partition.
+//!
+//! Each appends one new bound column (`new_var`) to every row; the row order of
+//! the input `QueryResult` is preserved (window functions are computed, not a
+//! re-sort).
+
+use oxrdf::{Literal, NamedNode, Term, Variable};
+use std::cmp::Ordering;
+
+use crate::QueryResult;
+
+/// A caller-supplied windowed-aggregate fold: maps a partition's per-row cells
+/// (`None` ≡ unbound for that row) to the partition's window value (`None` ≡
+/// unbound). Used by [`WindowAggregate::Custom`].
+pub type WindowFold = Box<dyn Fn(&[Option<Term>]) -> Option<Term>>;
+
+/// A window sort key: a variable plus a direction. Comparison follows a
+/// SPARQL-ORDER-BY-like total order over the bound terms (see [`cmp_terms`]):
+/// numeric literals by value, everything else by a stable lexical/kind order;
+/// an unbound cell sorts first (ascending).
+#[derive(Debug, Clone)]
+pub struct SortKey {
+    pub var: Variable,
+    /// `true` = descending (`DESC`), `false` = ascending (`ASC`, the default).
+    pub descending: bool,
+}
+
+impl SortKey {
+    pub fn asc(var: Variable) -> Self {
+        Self { var, descending: false }
+    }
+    pub fn desc(var: Variable) -> Self {
+        Self { var, descending: true }
+    }
+}
+
+/// The aggregate a windowed [`WindowFunction::Aggregate`] computes over a
+/// partition. The numeric ones operate on the numeric VALUE of each bound,
+/// non-null cell; `Count` counts bound cells (`Count`-of-`*` semantics for the
+/// chosen column); a fully custom fold is [`Self::Custom`].
+pub enum WindowAggregate {
+    /// COUNT of bound (non-null) values of the column.
+    Count,
+    /// SUM of the numeric values; an empty/all-unbound partition is `0`.
+    Sum,
+    /// AVG of the numeric values; an empty partition yields an unbound result.
+    Avg,
+    /// MIN by the [`cmp_terms`] order over bound cells (unbound for empty).
+    Min,
+    /// MAX by the [`cmp_terms`] order over bound cells (unbound for empty).
+    Max,
+    /// A caller-supplied fold over the partition's per-row cells (`None` ≡
+    /// unbound for that row): returns the partition's window value (`None` ≡
+    /// unbound result).
+    Custom(WindowFold),
+}
+
+/// The window function to evaluate per partition.
+pub enum WindowFunction {
+    /// `ROW_NUMBER()` — see the module docs.
+    RowNumber,
+    /// `RANK()` — gaps after ties.
+    Rank,
+    /// `DENSE_RANK()` — no gaps.
+    DenseRank,
+    /// A windowed aggregate over the whole partition, of the given column.
+    Aggregate { agg: WindowAggregate, of: Variable },
+}
+
+/// A window specification: PARTITION BY zero or more columns, ORDER BY zero or
+/// more sort keys, a [`WindowFunction`], and the name of the column to append.
+///
+/// Empty `partition_by` ≡ a single partition over the whole result. Empty
+/// `order_by` for a ranking function ≡ every row is a peer (so `RANK`/
+/// `DENSE_RANK` are all `1` and `ROW_NUMBER` follows input order).
+pub struct WindowSpec {
+    pub partition_by: Vec<Variable>,
+    pub order_by: Vec<SortKey>,
+    pub function: WindowFunction,
+    /// The new variable the computed window value is bound to.
+    pub new_var: Variable,
+}
+
+/// Applies `spec` to `result`, returning a new [`QueryResult`] with `spec.new_var`
+/// appended as the last column. Row order is preserved.
+///
+/// `Err` if a referenced variable (`partition_by` / `order_by` / the aggregate's
+/// `of`) is not a column of `result`.
+pub fn apply_window(result: &QueryResult, spec: &WindowSpec) -> Result<QueryResult, String> {
+    let col = |v: &Variable| -> Result<usize, String> {
+        result
+            .vars
+            .iter()
+            .position(|c| c == v)
+            .ok_or_else(|| format!("window: variable ?{} is not a result column", v.as_str()))
+    };
+    let part_cols: Vec<usize> = spec.partition_by.iter().map(&col).collect::<Result<_, _>>()?;
+    let order_cols: Vec<(usize, bool)> =
+        spec.order_by.iter().map(|k| col(&k.var).map(|c| (c, k.descending))).collect::<Result<_, _>>()?;
+
+    // Group row indices into partitions by their partition-key tuple, preserving
+    // first-seen partition order and input row order within a partition.
+    let mut partitions: Vec<Vec<usize>> = Vec::new();
+    let mut keys: Vec<Vec<Option<Term>>> = Vec::new();
+    for (ri, row) in result.rows.iter().enumerate() {
+        let key: Vec<Option<Term>> = part_cols.iter().map(|&c| row[c].clone()).collect();
+        match keys.iter().position(|k| *k == key) {
+            Some(pi) => partitions[pi].push(ri),
+            None => {
+                keys.push(key);
+                partitions.push(vec![ri]);
+            }
+        }
+    }
+
+    // The computed window value for each input row index.
+    let mut values: Vec<Option<Term>> = vec![None; result.rows.len()];
+    for part in &partitions {
+        // Order the partition's rows by the window ORDER BY (stable, so input
+        // order breaks ties — required for ROW_NUMBER determinism).
+        let mut ordered: Vec<usize> = part.clone();
+        ordered.sort_by(|&a, &b| order_rows(result, &order_cols, a, b));
+        compute_partition(result, spec, part, &ordered, &order_cols, &mut values);
+    }
+
+    let mut vars = result.vars.clone();
+    vars.push(spec.new_var.clone());
+    let rows: Vec<Vec<Option<Term>>> = result
+        .rows
+        .iter()
+        .enumerate()
+        .map(|(ri, row)| {
+            let mut r = row.clone();
+            r.push(values[ri].take());
+            r
+        })
+        .collect();
+    Ok(QueryResult { vars, rows })
+}
+
+/// Computes the window value for one partition, writing into `values` at each
+/// row's input index. `ordered` is the partition's rows in window-ORDER-BY order.
+fn compute_partition(
+    result: &QueryResult,
+    spec: &WindowSpec,
+    part: &[usize],
+    ordered: &[usize],
+    order_cols: &[(usize, bool)],
+    values: &mut [Option<Term>],
+) {
+    match &spec.function {
+        WindowFunction::RowNumber => {
+            for (n, &ri) in ordered.iter().enumerate() {
+                values[ri] = Some(int_term((n + 1) as i64));
+            }
+        }
+        WindowFunction::Rank => {
+            let mut rank: i64 = 0;
+            let mut seen: i64 = 0;
+            let mut prev: Option<usize> = None;
+            for &ri in ordered {
+                seen += 1;
+                let tie = prev.is_some_and(|p| peers(result, order_cols, p, ri));
+                if !tie {
+                    rank = seen; // gap: jump to the running count
+                }
+                values[ri] = Some(int_term(rank));
+                prev = Some(ri);
+            }
+        }
+        WindowFunction::DenseRank => {
+            let mut rank: i64 = 0;
+            let mut prev: Option<usize> = None;
+            for &ri in ordered {
+                let tie = prev.is_some_and(|p| peers(result, order_cols, p, ri));
+                if !tie {
+                    rank += 1; // no gap
+                }
+                values[ri] = Some(int_term(rank));
+                prev = Some(ri);
+            }
+        }
+        WindowFunction::Aggregate { agg, of } => {
+            let of_col = result.vars.iter().position(|c| c == of);
+            let cells: Vec<Option<Term>> = part
+                .iter()
+                .map(|&ri| of_col.and_then(|c| result.rows[ri][c].clone()))
+                .collect();
+            let v = eval_window_aggregate(agg, &cells);
+            // The whole-partition frame: every row in the partition gets `v`.
+            for &ri in part {
+                values[ri] = v.clone();
+            }
+        }
+    }
+}
+
+/// Whether rows `a` and `b` are PEERS under the window ORDER BY (compare equal on
+/// every order key). With no `ORDER BY`, all rows are peers.
+fn peers(result: &QueryResult, order_cols: &[(usize, bool)], a: usize, b: usize) -> bool {
+    order_rows(result, order_cols, a, b) == Ordering::Equal
+}
+
+/// Compare two rows by the window ORDER BY keys (direction applied), then Equal.
+/// (Stable sort preserves input order for full ties, so ROW_NUMBER is deterministic.)
+fn order_rows(result: &QueryResult, order_cols: &[(usize, bool)], a: usize, b: usize) -> Ordering {
+    for &(c, desc) in order_cols {
+        let ord = cmp_terms(result.rows[a][c].as_ref(), result.rows[b][c].as_ref());
+        let ord = if desc { ord.reverse() } else { ord };
+        if ord != Ordering::Equal {
+            return ord;
+        }
+    }
+    Ordering::Equal
+}
+
+fn eval_window_aggregate(agg: &WindowAggregate, cells: &[Option<Term>]) -> Option<Term> {
+    match agg {
+        WindowAggregate::Count => Some(int_term(cells.iter().filter(|c| c.is_some()).count() as i64)),
+        WindowAggregate::Sum => {
+            let sum: f64 = cells.iter().filter_map(|c| c.as_ref()).filter_map(numeric_value).sum();
+            Some(num_term(sum))
+        }
+        WindowAggregate::Avg => {
+            let vals: Vec<f64> = cells.iter().filter_map(|c| c.as_ref()).filter_map(numeric_value).collect();
+            if vals.is_empty() {
+                None
+            } else {
+                Some(num_term(vals.iter().sum::<f64>() / vals.len() as f64))
+            }
+        }
+        WindowAggregate::Min => cells
+            .iter()
+            .filter_map(|c| c.as_ref())
+            .min_by(|a, b| cmp_terms(Some(a), Some(b)))
+            .cloned(),
+        WindowAggregate::Max => cells
+            .iter()
+            .filter_map(|c| c.as_ref())
+            .max_by(|a, b| cmp_terms(Some(a), Some(b)))
+            .cloned(),
+        WindowAggregate::Custom(f) => f(cells),
+    }
+}
+
+/// The numeric VALUE of a term, if it is a numeric literal (xsd integer / decimal
+/// / float / double, or anything whose lexical form parses as an `f64`).
+fn numeric_value(t: &Term) -> Option<f64> {
+    match t {
+        Term::Literal(l) => l.value().parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+/// A SPARQL-ORDER-BY-like total order over optional bound terms, self-contained
+/// so the window pass needs no engine internals. Ordering: unbound (`None`) sorts
+/// FIRST; then by KIND (blank < IRI < literal — a stable, deterministic order);
+/// within literals, two NUMERIC literals compare by value, otherwise by
+/// `(datatype, language, lexical)`. This is a TOTAL order (every pair is
+/// comparable), which a window sort requires.
+pub fn cmp_terms(a: Option<&Term>, b: Option<&Term>) -> Ordering {
+    match (a, b) {
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Less,
+        (Some(_), None) => Ordering::Greater,
+        (Some(x), Some(y)) => cmp_bound(x, y),
+    }
+}
+
+fn kind_rank(t: &Term) -> u8 {
+    match t {
+        Term::BlankNode(_) => 0,
+        Term::NamedNode(_) => 1,
+        Term::Literal(_) => 2,
+        // oxrdf may expose a Triple term under rdf-star; order it last, stably.
+        _ => 3,
+    }
+}
+
+fn cmp_bound(x: &Term, y: &Term) -> Ordering {
+    match (x, y) {
+        (Term::Literal(lx), Term::Literal(ly)) => {
+            if let (Some(nx), Some(ny)) = (numeric_value(&Term::Literal(lx.clone())), numeric_value(&Term::Literal(ly.clone()))) {
+                if let Some(o) = nx.partial_cmp(&ny) {
+                    if o != Ordering::Equal {
+                        return o;
+                    }
+                }
+            }
+            lx.datatype()
+                .as_str()
+                .cmp(ly.datatype().as_str())
+                .then_with(|| lx.language().unwrap_or("").cmp(ly.language().unwrap_or("")))
+                .then_with(|| lx.value().cmp(ly.value()))
+        }
+        (Term::NamedNode(a), Term::NamedNode(b)) => a.as_str().cmp(b.as_str()),
+        (Term::BlankNode(a), Term::BlankNode(b)) => a.as_str().cmp(b.as_str()),
+        _ => kind_rank(x).cmp(&kind_rank(y)).then_with(|| x.to_string().cmp(&y.to_string())),
+    }
+}
+
+/// An `xsd:integer` term for a rank / count.
+fn int_term(n: i64) -> Term {
+    Term::Literal(Literal::from(n))
+}
+
+/// A numeric term: an `xsd:integer` if the value is integral, else an
+/// `xsd:double`. (Window SUM/AVG over integer inputs commonly want an integer
+/// back when exact; AVG of an odd sum stays a double.)
+fn num_term(v: f64) -> Term {
+    if v.fract() == 0.0 && v.is_finite() && v.abs() < 9.007_199_254_740_992e15 {
+        int_term(v as i64)
+    } else {
+        Term::Literal(Literal::new_typed_literal(
+            {
+                let mut s = v.to_string();
+                if !s.contains(['.', 'e', 'E', 'N', 'i']) {
+                    s.push_str(".0");
+                }
+                s
+            },
+            NamedNode::new_unchecked("http://www.w3.org/2001/XMLSchema#double"),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxrdf::NamedNode as NN;
+
+    fn var(s: &str) -> Variable {
+        Variable::new(s).unwrap()
+    }
+    fn iri(s: &str) -> Term {
+        Term::NamedNode(NN::new(s).unwrap())
+    }
+    fn int(n: i64) -> Term {
+        Term::Literal(Literal::from(n))
+    }
+
+    /// Three depts, sales values, to rank within partition.
+    /// (?emp ?dept ?sales): a/eng/30, b/eng/30, c/eng/20, d/sales/10
+    fn sample() -> QueryResult {
+        QueryResult {
+            vars: vec![var("emp"), var("dept"), var("sales")],
+            rows: vec![
+                vec![Some(iri("http://ex/a")), Some(iri("http://ex/eng")), Some(int(30))],
+                vec![Some(iri("http://ex/b")), Some(iri("http://ex/eng")), Some(int(30))],
+                vec![Some(iri("http://ex/c")), Some(iri("http://ex/eng")), Some(int(20))],
+                vec![Some(iri("http://ex/d")), Some(iri("http://ex/sales")), Some(int(10))],
+            ],
+        }
+    }
+
+    fn val(r: &QueryResult, row: usize, col: usize) -> String {
+        r.rows[row][col].as_ref().unwrap().to_string()
+    }
+
+    #[test]
+    fn row_number_partition_order() {
+        // PARTITION BY dept ORDER BY sales DESC -> ROW_NUMBER per dept.
+        let spec = WindowSpec {
+            partition_by: vec![var("dept")],
+            order_by: vec![SortKey::desc(var("sales"))],
+            function: WindowFunction::RowNumber,
+            new_var: var("rn"),
+        };
+        let out = apply_window(&sample(), &spec).unwrap();
+        // new column is appended at index 3; rows stay in input order.
+        // eng partition (a=30,b=30,c=20) ordered desc -> a,b are 30 (tie, input order a<b), c=20.
+        // a -> 1, b -> 2, c -> 3 ; sales partition d -> 1.
+        assert_eq!(val(&out, 0, 3), int(1).to_string()); // a
+        assert_eq!(val(&out, 1, 3), int(2).to_string()); // b
+        assert_eq!(val(&out, 2, 3), int(3).to_string()); // c
+        assert_eq!(val(&out, 3, 3), int(1).to_string()); // d
+    }
+
+    #[test]
+    fn rank_has_gaps_dense_rank_does_not() {
+        let mk = |f| WindowSpec {
+            partition_by: vec![var("dept")],
+            order_by: vec![SortKey::desc(var("sales"))],
+            function: f,
+            new_var: var("r"),
+        };
+        let rank = apply_window(&sample(), &mk(WindowFunction::Rank)).unwrap();
+        // eng: a=30,b=30 -> both rank 1; c=20 -> rank 3 (GAP).
+        assert_eq!(val(&rank, 0, 3), int(1).to_string());
+        assert_eq!(val(&rank, 1, 3), int(1).to_string());
+        assert_eq!(val(&rank, 2, 3), int(3).to_string());
+        let dense = apply_window(&sample(), &mk(WindowFunction::DenseRank)).unwrap();
+        // eng: a,b -> 1; c -> 2 (NO gap).
+        assert_eq!(val(&dense, 0, 3), int(1).to_string());
+        assert_eq!(val(&dense, 1, 3), int(1).to_string());
+        assert_eq!(val(&dense, 2, 3), int(2).to_string());
+    }
+
+    #[test]
+    fn windowed_sum_over_partition() {
+        let spec = WindowSpec {
+            partition_by: vec![var("dept")],
+            order_by: vec![],
+            function: WindowFunction::Aggregate { agg: WindowAggregate::Sum, of: var("sales") },
+            new_var: var("total"),
+        };
+        let out = apply_window(&sample(), &spec).unwrap();
+        // eng total = 30+30+20 = 80 for every eng row; sales total = 10.
+        assert_eq!(val(&out, 0, 3), int(80).to_string());
+        assert_eq!(val(&out, 1, 3), int(80).to_string());
+        assert_eq!(val(&out, 2, 3), int(80).to_string());
+        assert_eq!(val(&out, 3, 3), int(10).to_string());
+    }
+
+    #[test]
+    fn windowed_count_and_custom() {
+        let cnt = apply_window(
+            &sample(),
+            &WindowSpec {
+                partition_by: vec![var("dept")],
+                order_by: vec![],
+                function: WindowFunction::Aggregate { agg: WindowAggregate::Count, of: var("sales") },
+                new_var: var("n"),
+            },
+        )
+        .unwrap();
+        assert_eq!(val(&cnt, 0, 3), int(3).to_string()); // eng count
+        assert_eq!(val(&cnt, 3, 3), int(1).to_string()); // sales count
+
+        // Custom fold: max sales as a string, to prove the closure boundary.
+        let custom = apply_window(
+            &sample(),
+            &WindowSpec {
+                partition_by: vec![var("dept")],
+                order_by: vec![],
+                function: WindowFunction::Aggregate {
+                    agg: WindowAggregate::Custom(Box::new(|cells: &[Option<Term>]| {
+                        cells.iter().filter_map(|c| c.as_ref()).max_by(|a, b| cmp_terms(Some(a), Some(b))).cloned()
+                    })),
+                    of: var("sales"),
+                },
+                new_var: var("m"),
+            },
+        )
+        .unwrap();
+        assert_eq!(val(&custom, 0, 3), int(30).to_string()); // eng max
+        assert_eq!(val(&custom, 3, 3), int(10).to_string()); // sales max
+    }
+
+    #[test]
+    fn unknown_variable_is_error() {
+        let spec = WindowSpec {
+            partition_by: vec![var("nope")],
+            order_by: vec![],
+            function: WindowFunction::RowNumber,
+            new_var: var("rn"),
+        };
+        assert!(apply_window(&sample(), &spec).is_err());
+    }
+}

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -101,6 +101,10 @@ Extension functions (SPARQL 17.6) and dataset views:
 - `DatasetView { base: &Graph, named: Arc<FxHashSet<Term>>, default: DefaultGraphMode }`;
   `query_view` / `ask_view` / `count_view` / `query_json_view` (+ `_with_budget`), or
   `with_view(&v, || …)`.
+- *(opt-in `window-functions`)* `CustomAggregateRegistry::new()` + `.register(iri, |members:
+  &[Option<Term>]| -> Result<Option<Term>, String>)`; `query_with_aggregates(&Graph, &str, &reg)`
+  (+ `_and_budget`) parses+installs, `with_aggregates(&reg, || …)` scopes it. Window functions:
+  `window::{WindowSpec, WindowFunction, WindowAggregate, SortKey, apply_window}` (programmatic pass).
 
 Introspection: `explain(&Graph, &str)` (plan-only) and `explain_analyze(&Graph, &str)` (plan + per-
 operator execution trace).
@@ -172,6 +176,53 @@ let r = query_with_functions(&g,
 // To use the registry with ANOTHER entry point: with_functions(&reg, || sparq_engine::ask(&g, q))
 ```
 
+**Custom aggregate registry** (opt-in `window-functions` feature) — register a Rust closure as a
+named aggregate IRI, then call it from a real SPARQL `GROUP BY`. Unlike a scalar extension function,
+the closure FOLDS the group's per-member values (`None` ≡ unbound for that member) into one term:
+
+```rust
+// Cargo.toml: sparq-engine = { version = "0.1", features = ["window-functions"] }
+use oxrdf::{Literal, Term};
+use sparq_engine::{query_with_aggregates, CustomAggregateRegistry};
+
+let mut reg = CustomAggregateRegistry::new();
+reg.register("http://ex/agg#product", |members: &[Option<Term>]| {
+    let mut acc: i64 = 1;
+    for m in members { if let Some(Term::Literal(l)) = m { acc *= l.value().parse::<i64>().map_err(|e| e.to_string())?; } }
+    Ok(Some(Term::Literal(Literal::from(acc))))
+});
+let r = query_with_aggregates(&g,
+    "PREFIX ex: <http://ex/> PREFIX agg: <http://ex/agg#> \
+     SELECT ?d (agg:product(?s) AS ?p) WHERE { ?x ex:dept ?d ; ex:sales ?s } GROUP BY ?d",
+    &reg).unwrap();
+// query_with_aggregates DECLARES every registry IRI to the parser (so `agg:product(?s)` parses as an
+// aggregate, not a scalar call) AND installs the registry for evaluation. `with_aggregates(&reg, ||..)`
+// is the scoped form (composes with with_functions / with_view).
+// CAVEAT: a `DISTINCT` custom aggregate (`agg:product(DISTINCT ?s)`) does not currently PARSE in the
+// vendored spargebra (a parser limitation, tracked as a follow-up bead); non-DISTINCT works.
+```
+
+**Window functions** (opt-in `window-functions` feature) — **NON-STANDARD extension**: SPARQL has no
+W3C-REC `OVER (PARTITION BY … ORDER BY …)` syntax, so sparq exposes windowing as a *programmatic pass
+over a `QueryResult`* whose semantics follow the SQL:2003 window model (the surface Stardog / AnzoGraph
+expose). Run an ordinary SELECT, then apply a `WindowSpec` (`ROW_NUMBER` / `RANK` / `DENSE_RANK`, or a
+windowed aggregate over the whole partition). One column is appended; row order is preserved:
+
+```rust
+use sparq_engine::window::{apply_window, SortKey, WindowFunction, WindowSpec};
+use oxrdf::Variable;
+
+let result = sparq_engine::query(&g, "SELECT ?emp ?dept ?sales WHERE { … }").unwrap();
+let spec = WindowSpec {
+    partition_by: vec![Variable::new("dept").unwrap()],
+    order_by: vec![SortKey::desc(Variable::new("sales").unwrap())],
+    function: WindowFunction::Rank,            // RANK() over (PARTITION BY ?dept ORDER BY ?sales DESC)
+    new_var: Variable::new("rank").unwrap(),
+};
+let ranked = apply_window(&result, &spec).unwrap(); // ?rank appended; RANK has gaps after ties
+// Windowed aggregate (whole-partition frame): WindowFunction::Aggregate { agg: WindowAggregate::Sum, of }
+```
+
 **Budgets / timeouts / ASK-style early exit** — a `QueryBudget` is checked cooperatively at coarse
 sites; tripping it fails with `"query budget exceeded (timeout)"` / `"... (max-rows)"`:
 
@@ -230,6 +281,14 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   size (distinct binding tuples per remote request): **opt-in** via
   `with_service_bound_join_block_size(n, || query(&g, q))` or the `SPARQ_SERVICE_BIND_BLOCK` env var
   (default ~50). The knob never changes results — only the remote-request count vs per-request size.
+- **Window functions + custom aggregate registry** are the non-default `window-functions` cargo
+  feature. **Window functions are a NON-STANDARD extension** — there is no W3C-REC SPARQL `OVER`
+  syntax — so they are a programmatic pass over a `QueryResult` (the SQL:2003 model Stardog/AnzoGraph
+  expose), `ROW_NUMBER`/`RANK`/`DENSE_RANK` + a whole-partition windowed aggregate, NOT inline query
+  syntax (the engine's SPARQL surface stays exactly SPARQL 1.1, so conformance is unaffected). The
+  custom-aggregate side DOES ride real SPARQL `GROUP BY` (a declared aggregate IRI is part of the
+  SPARQL 1.1 extension grammar). When the feature is off, zero window/aggregate-registry code compiles
+  and the default build is byte-identical (no new dependencies). See the recipes above.
 - **Default cargo features** (`parallel`, `regex`, `digest`): `regex` powers REGEX/REPLACE; `digest`
   powers MD5/SHA*; `parallel` enables rayon scan/join/sort/aggregate. The **wasm** crate
   (`sparq-wasm`) disables defaults, so on `wasm32-unknown-unknown` REGEX/hash builtins and


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-5qz9** — two opt-in extension surfaces behind a new `window-functions` cargo feature (OFF by default; core stays lean, the default build is byte-identical, no new dependencies).

## Custom aggregate registry
Register a named (IRI) user aggregate — a closure folding a group's per-member `Option<Term>` values into one term — callable from a **real SPARQL `GROUP BY`**. The vendored spargebra already parses a *declared* custom aggregate IRI (`SparqlParser::with_custom_aggregate_function`); this wires the **evaluation** side (`AggregateFunction::Custom` → installed registry, with a thread-local install + rayon-worker snapshot mirroring the existing `FunctionRegistry`) plus `query_with_aggregates` / `with_aggregates` entry points that declare every registry IRI to the parser. A declared aggregate IRI is part of the SPARQL 1.1 extension grammar, so **conformance is unaffected**.

```rust
let mut reg = CustomAggregateRegistry::new();
reg.register("http://ex/agg#product", |members: &[Option<Term>]| { /* fold */ });
query_with_aggregates(&g, "… SELECT ?d (agg:product(?s) AS ?p) … GROUP BY ?d", &reg)
```

## Window functions — NON-STANDARD extension (honest scoping)
`ROW_NUMBER` / `RANK` / `DENSE_RANK` + a whole-partition windowed aggregate (SUM/AVG/MIN/MAX/COUNT/custom fold) with `PARTITION BY` + `ORDER BY` specs. **There is no W3C-REC SPARQL `OVER` syntax**, so windowing is exposed as a **programmatic pass over a `QueryResult`** (`window::apply_window` + `WindowSpec`) following the SQL:2003 window model that Stardog / AnzoGraph expose — NOT inline query syntax. The engine's SPARQL surface stays exactly SPARQL 1.1.

## Gates (both feature states)
- `cargo build` / `cargo clippy --all-targets -D warnings` / `cargo test` — green **feature-off** (default) and **feature-on**.
- Tests: ROW_NUMBER/RANK/DENSE_RANK over a known partition+order; windowed SUM/COUNT/custom fold; a custom PRODUCT aggregate computed correctly through GROUP BY; the feature-off build does not expose the surface.
- Conformance unchanged (nothing added to the default SPARQL path; `sparq-conformance` builds).

## Docs
`skills/sparql-query/SKILL.md` + the crate README document the registry API, the syntax source, and the non-standard-extension caveat.

## Deferred (for follow-up beads)
- `DISTINCT` custom aggregate does not **parse** in the vendored spargebra (`expected ENCODE_FOR_URI`) even though the grammar has the rule and non-DISTINCT works; the engine-side DISTINCT de-dup is implemented and correct.
- Inline `OVER (PARTITION BY … ORDER BY …)` query syntax (would require conformance-parser surgery + a SPARQ-PATCHES/upstream proposal).