### PR TITLE
feat(sparq-fedplan): EWMA-smoothed latency in adaptive-replan cost model (sq-b51o follow-up)

### DIFF
--- a/crates/sparq-fedplan/README.md
+++ b/crates/sparq-fedplan/README.md
@@ -114,7 +114,8 @@ A build that does not enable the feature compiles **zero** adaptive code (the mo
 
 - **Capture actual stats** — `RuntimeStats` records the *observed* per-pattern leaf
   cardinality (real row counts the sources returned) and per-source latency, fed in by the
-  executor as each stage completes.
+  executor as each stage completes. Latency is **EWMA-smoothed** per source (below), so the
+  cost model reacts to the trend, not the last raw sample.
 - **Re-plan trigger** — at each **stage boundary** (between two leaf joins of the left-deep
   plan), if a *not-yet-executed* pattern's observed cardinality `o` diverges from its
   estimate `e` past `ReplanPolicy::divergence_factor` `k` in either direction (`o > k·e` or
@@ -129,7 +130,7 @@ A build that does not enable the feature compiles **zero** adaptive code (the mo
   by a latency factor derived from the **slowest** observed latency over the pattern's retained
   sources (a union is bottlenecked by its slowest arm):
   `factor = clamp(1 + latency_weight·(s − 1), latency_floor, latency_cap)` where
-  `s = observed_latency / latency_baseline`. A source at baseline — **or with no latency
+  `s = ewma_latency / latency_baseline`. A source at baseline — **or with no latency
   observation** — gets `factor = 1.0`, so a measurement-free re-plan is byte-identical to the
   cardinality-only planner; a 2×-slow source costs 1.5× at the default `latency_weight = 0.5`,
   and the `latency_cap` (default 4.0) stops one outlier from dominating. The constants
@@ -139,6 +140,19 @@ A build that does not enable the feature compiles **zero** adaptive code (the mo
   plan. Latency enters only the *cost* term (and the suffix-selection score), **never** the
   output cardinality — so results are unchanged (see the soundness boundary). Set
   `latency_weight = 0` to disable it entirely (pure cardinality planning).
+- **Latency EWMA smoothing (sq-b51o follow-up) — a HEURISTIC α, not optimal.** The cost model
+  + trigger are fed not the single last latency sample but a per-source **exponentially-weighted
+  moving average**: each `RuntimeStats::record_source_latency` folds the new sample in as
+  `ewma_new = α·observed + (1−α)·ewma_prev` (the first sample seeds the average). α is
+  `RuntimeStats::latency_alpha`, default `RuntimeStats::DEFAULT_LATENCY_ALPHA = 0.3` — a
+  **hand-picked** smoothing factor (latest sample 30%, history 70%), **not** a workload-derived
+  optimum. This is the cleaner anti-thrash discipline that replaces the bare single-sample value:
+  a **single transient spike** moves the average only a fraction of the way and does *not*, by
+  itself, clear the re-plan trigger, while a **sustained** shift converges past it within a few
+  samples. The absolute `latency_floor`/`latency_cap` clamp is kept as a **final guard** on the
+  resulting cost factor. Use `RuntimeStats::with_latency_alpha(α)` to override (`α = 1.0` recovers
+  the old un-smoothed "last sample wins" behaviour); higher α tracks faster but is twitchier,
+  lower α is calmer but laggier.
 - **Hysteresis / anti-thrash** — the re-planned suffix is adopted **only** if its estimated
   remaining cost (cardinality- **and** latency-weighted) beats the current suffix's by more
   than `ReplanPolicy::improvement_margin` (default 10%) and there is a hard `max_replans`
@@ -155,10 +169,13 @@ the switch unchanged, so no binding is lost or duplicated. **The latency weighti
 move this boundary**: it enters only the cost/ordering, never the output cardinality or the
 pattern set, so a latency-driven reorder is the same kind of pure suffix permutation. This
 result-equivalence is proven in `adaptive::tests::replan_result_equals_static` (a
-cardinality-driven re-plan) **and** `latency_replan_result_equals_static` (a re-plan whose
-reorder is driven purely by latency) — each genuinely flips the order yet yields the identical
-multiset to the static plan — backed by an exhaustive all-permutations order-independence test.
-Mid-*operator* adaptivity and live source failover are deferred (epic sq-3183).
+cardinality-driven re-plan), `latency_replan_result_equals_static` (a re-plan driven purely by
+latency) **and** `ewma_replan_result_equals_static` (a re-plan driven by the EWMA-smoothed
+latency) — each genuinely flips the order yet yields the identical multiset to the static plan —
+backed by an exhaustive all-permutations order-independence test. The EWMA changes only *when*
+the latency path fires (anti-thrash), never the soundness boundary: re-planning is still a
+sub-query / **stage-boundary** suffix reorder, never a mid-operator swap. Mid-*operator*
+adaptivity and live source failover are deferred (epic sq-3183).
 
 ## Streaming join (quick use)
 

--- a/crates/sparq-fedplan/src/adaptive.rs
+++ b/crates/sparq-fedplan/src/adaptive.rs
@@ -31,9 +31,34 @@
 //!
 //! Cardinality is not the only thing the static estimates get wrong: a source can be
 //! *slow* (contended, far, rate-limited) even when its row counts are exactly as predicted.
-//! [`RuntimeStats`] already captures the *observed* per-source latency; sq-b51o folds it
-//! into the cost model so the re-planner prefers orderings that defer sub-queries against
-//! an observably slow source.
+//! [`RuntimeStats`] captures the *observed* per-source latency; sq-b51o folds it into the
+//! cost model so the re-planner prefers orderings that defer sub-queries against an
+//! observably slow source.
+//!
+//! ## Latency EWMA smoothing (sq-b51o follow-up) — a HEURISTIC α, not optimal
+//!
+//! The cost model is fed not the **single last** latency observation but a per-source
+//! **exponentially-weighted moving average** (EWMA). Each call to
+//! [`RuntimeStats::record_source_latency`] folds the new observation into the running
+//! average for that source:
+//!
+//! > `ewma_new = α · observed + (1 − α) · ewma_prev`  (first observation seeds `ewma = observed`).
+//!
+//! The smoothing factor α ∈ (0, 1] is [`RuntimeStats::latency_alpha`], default `0.3` — a
+//! **hand-picked heuristic, not a derived optimum**: it weights the latest sample at 30% and
+//! the accumulated history at 70%, so a *single* transient spike moves the average only a
+//! fraction of the way and does **not**, on its own, clear the re-plan trigger — but a
+//! **sustained** shift (several consecutive high samples) does, as the average converges
+//! toward the new level. This is the cleaner anti-thrash discipline the follow-up replaces
+//! the bare single-sample-plus-clamp with: the EWMA itself absorbs noise; the absolute
+//! `latency_floor`/`latency_cap` clamp on the resulting cost factor is kept as a **final
+//! guard** (an outlier that *does* survive the average still cannot dominate the order).
+//! Higher α tracks faster but is twitchier; lower α is calmer but laggier — 0.3 is a middle
+//! bias, picked by hand, not tuned against a workload.
+//!
+//! The EWMA (not the raw last value) feeds **both** the latency cost factor *and* the
+//! re-plan trigger, so the whole latency path is smoothed consistently. A source with no
+//! observation has no EWMA and contributes `factor = 1.0` (inert), exactly as before.
 //!
 //! The weighting is deliberately simple and **honest about being a heuristic** (see
 //! [`ReplanPolicy::latency_weight`]): for a candidate pattern, take the **slowest** observed
@@ -183,23 +208,75 @@ impl ReplanPolicy {
 /// Observed runtime statistics, accumulated as execution proceeds. Distinct from the
 /// descriptor-derived *estimates*: every value here is a real count / measurement the
 /// executor fed in at a stage boundary.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct RuntimeStats {
     /// Observed leaf cardinality per pattern index (rows the pattern actually returned,
     /// union over its sources). Present only for patterns that have been (at least
     /// partially) evaluated.
     observed_leaf_card: HashMap<usize, f64>,
-    /// Observed per-source latency, in abstract time units (e.g. ms). [OPUS-4.8] sq-b51o:
-    /// folded into the cost model — a slow source's joins cost more, biasing the re-plan
-    /// toward faster sources / deferring the slow one (see [`ReplanPolicy::latency_weight`]).
-    /// Affects cost/ordering ONLY, never the result multiset.
+    /// Per-source **EWMA-smoothed** latency, in abstract time units (e.g. ms). [OPUS-4.8]
+    /// sq-b51o (+ follow-up): each [`Self::record_source_latency`] folds the new observation
+    /// into a per-source exponentially-weighted moving average rather than overwriting — this
+    /// is the value fed into the cost model + the re-plan trigger, so a single transient spike
+    /// is damped and only a *sustained* shift moves the planner. A slow source's joins cost
+    /// more, biasing the re-plan toward faster sources / deferring the slow one (see
+    /// [`ReplanPolicy::latency_weight`]). Affects cost/ordering ONLY, never the result multiset.
     observed_latency: HashMap<usize, f64>,
+    /// [OPUS-4.8] sq-b51o follow-up. EWMA smoothing factor α ∈ (0, 1] applied per source in
+    /// [`Self::record_source_latency`]: `ewma_new = α·observed + (1−α)·ewma_prev`. A
+    /// **hand-picked HEURISTIC**, default [`Self::DEFAULT_LATENCY_ALPHA`] (`0.3`) — see the
+    /// module docs. Lower = calmer/laggier, higher = twitchier/faster-tracking; not derived
+    /// from a workload. Clamped to `(0, 1]` on construction.
+    latency_alpha: f64,
+}
+
+impl Default for RuntimeStats {
+    fn default() -> Self {
+        RuntimeStats {
+            observed_leaf_card: HashMap::new(),
+            observed_latency: HashMap::new(),
+            latency_alpha: RuntimeStats::DEFAULT_LATENCY_ALPHA,
+        }
+    }
 }
 
 impl RuntimeStats {
-    /// A fresh, empty statistics store.
+    /// [OPUS-4.8] sq-b51o follow-up. Default per-source latency EWMA smoothing factor α — a
+    /// hand-picked heuristic (latest sample weighted 30%, history 70%): enough history to damp
+    /// a single transient spike below the re-plan trigger, enough recency to converge on a
+    /// sustained shift within a few samples. NOT a derived optimum.
+    pub const DEFAULT_LATENCY_ALPHA: f64 = 0.3;
+
+    /// A fresh, empty statistics store with the default latency EWMA α
+    /// ([`Self::DEFAULT_LATENCY_ALPHA`]).
     pub fn new() -> RuntimeStats {
         RuntimeStats::default()
+    }
+
+    /// [OPUS-4.8] sq-b51o follow-up. A fresh, empty statistics store with an explicit latency
+    /// EWMA smoothing factor `alpha` (clamped to `(0, 1]`). `alpha = 1.0` recovers the old
+    /// "single last observation" behaviour (no smoothing); the default
+    /// ([`Self::DEFAULT_LATENCY_ALPHA`]) is `0.3`.
+    pub fn with_latency_alpha(alpha: f64) -> RuntimeStats {
+        RuntimeStats {
+            latency_alpha: Self::clamp_alpha(alpha),
+            ..RuntimeStats::default()
+        }
+    }
+
+    /// The configured latency EWMA smoothing factor α (always in `(0, 1]`).
+    pub fn latency_alpha(&self) -> f64 {
+        self.latency_alpha
+    }
+
+    /// Clamp a requested α into the valid `(0, 1]` range (a degenerate `α ≤ 0` would freeze
+    /// the average at its seed; `α > 1` would over-shoot). Uses `f64::MIN_POSITIVE` as the
+    /// strictly-positive floor.
+    fn clamp_alpha(alpha: f64) -> f64 {
+        if alpha.is_nan() {
+            return Self::DEFAULT_LATENCY_ALPHA;
+        }
+        alpha.clamp(f64::MIN_POSITIVE, 1.0)
     }
 
     /// Record the *observed* cardinality of a pattern's leaf (the real row count its
@@ -208,9 +285,26 @@ impl RuntimeStats {
         self.observed_leaf_card.insert(pattern, observed.max(0.0));
     }
 
-    /// Record the *observed* latency of a source (abstract time units).
+    /// Record an *observed* latency sample for `source` (abstract time units), folding it into
+    /// that source's **EWMA**: `ewma_new = α·observed + (1−α)·ewma_prev`, where α is
+    /// [`Self::latency_alpha`]. The **first** sample for a source seeds the average
+    /// (`ewma = observed`); subsequent samples decay the history. The smoothed value — not the
+    /// raw sample — is what [`Self::observed_latency_of`] returns and the cost model/trigger
+    /// read, so a single transient spike is damped (anti-thrash) while a sustained shift
+    /// converges. [OPUS-4.8] sq-b51o follow-up. Affects cost/ordering ONLY, never results.
     pub fn record_source_latency(&mut self, source: usize, latency: f64) {
-        self.observed_latency.insert(source, latency.max(0.0));
+        let observed = latency.max(0.0);
+        let entry = self.observed_latency.entry(source);
+        match entry {
+            std::collections::hash_map::Entry::Occupied(mut o) => {
+                let prev = *o.get();
+                let next = self.latency_alpha * observed + (1.0 - self.latency_alpha) * prev;
+                o.insert(next);
+            }
+            std::collections::hash_map::Entry::Vacant(v) => {
+                v.insert(observed);
+            }
+        }
     }
 
     /// The observed leaf cardinality for `pattern`, if recorded.
@@ -218,7 +312,9 @@ impl RuntimeStats {
         self.observed_leaf_card.get(&pattern).copied()
     }
 
-    /// The observed latency for `source`, if recorded.
+    /// The **EWMA-smoothed** observed latency for `source`, if any sample has been recorded.
+    /// This is the smoothed running average, not the last raw sample ([OPUS-4.8] sq-b51o
+    /// follow-up) — it is what the latency cost factor and the re-plan trigger consume.
     pub fn observed_latency_of(&self, source: usize) -> Option<f64> {
         self.observed_latency.get(&source).copied()
     }
@@ -427,10 +523,13 @@ impl<'a> AdaptiveExecutor<'a> {
                     (Some(&e), Some(o)) => diverges(e, o, &self.policy),
                     _ => false,
                 });
-        // [OPUS-4.8] sq-b51o: a not-yet-executed pattern bound to an observably slow source
-        // (slowest source past divergence_factor× baseline) is also enough to *consider* a
-        // re-plan — a latency-bound query reacts even when cardinalities are spot-on. The
-        // hysteresis margin still gates whether a switch is actually *adopted* (anti-thrash).
+        // [OPUS-4.8] sq-b51o (+ EWMA follow-up): a not-yet-executed pattern bound to an
+        // observably slow source — whose slowest source's EWMA-SMOOTHED latency is past
+        // divergence_factor× baseline — is also enough to *consider* a re-plan: a latency-bound
+        // query reacts even when cardinalities are spot-on. Reading the EWMA (not the raw last
+        // sample) means one transient spike does not move the smoothed value over the threshold,
+        // so the trigger is anti-thrashed at the source; only a sustained shift converges past
+        // it. The hysteresis margin still gates whether a switch is actually *adopted*.
         let lat_triggered = self.policy.latency_weight > 0.0
             && self.remaining.iter().any(|&p| {
                 pattern_relative_slowness(p, self.base_selection, stats, &self.policy)
@@ -1375,5 +1474,201 @@ mod tests {
             ..ReplanPolicy::default()
         };
         assert_eq!(off.latency_factor(9999.0), 1.0, "weight 0 ⇒ always neutral");
+    }
+
+    // ============================================================================
+    // [OPUS-4.8] sq-b51o follow-up — per-source latency EWMA smoothing.
+    // ============================================================================
+
+    // ---- EWMA mechanics + the default α are pinned. First sample seeds the average; each
+    //      subsequent sample folds in at α = 0.3 (latest 30%, history 70%).
+    #[test]
+    fn ewma_smoothing_constants() {
+        assert_eq!(
+            RuntimeStats::DEFAULT_LATENCY_ALPHA, 0.3,
+            "default latency EWMA α is the documented 0.3 heuristic"
+        );
+        let mut stats = RuntimeStats::new();
+        assert_eq!(stats.latency_alpha(), 0.3);
+        // First sample SEEDS the average (no history to decay).
+        stats.record_source_latency(0, 100.0);
+        assert_eq!(stats.observed_latency_of(0), Some(100.0), "first sample seeds EWMA");
+        // Second sample: 0.3·1000 + 0.7·100 = 300 + 70 = 370.
+        stats.record_source_latency(0, 1000.0);
+        assert_eq!(
+            stats.observed_latency_of(0),
+            Some(370.0),
+            "EWMA = α·observed + (1-α)·prev = 0.3·1000 + 0.7·100"
+        );
+        // Third sample at the same high level: 0.3·1000 + 0.7·370 = 300 + 259 = 559.
+        stats.record_source_latency(0, 1000.0);
+        assert_eq!(
+            stats.observed_latency_of(0),
+            Some(559.0),
+            "EWMA converges toward a sustained level across samples"
+        );
+        // α = 1.0 recovers the old "single last sample" behaviour (no smoothing).
+        let mut sharp = RuntimeStats::with_latency_alpha(1.0);
+        sharp.record_source_latency(0, 100.0);
+        sharp.record_source_latency(0, 1000.0);
+        assert_eq!(sharp.observed_latency_of(0), Some(1000.0), "α=1 ⇒ no smoothing");
+        // α is clamped into (0, 1]: a degenerate 0.0 / negative request never freezes the seed.
+        assert!(RuntimeStats::with_latency_alpha(0.0).latency_alpha() > 0.0);
+        assert_eq!(RuntimeStats::with_latency_alpha(5.0).latency_alpha(), 1.0);
+    }
+
+    // ---- ANTI-THRASH: a single TRANSIENT latency spike, after the source has an established
+    //      (baseline) EWMA history, does NOT move the smoothed latency past the trigger — so no
+    //      re-plan fires. This is the headline EWMA property the follow-up buys over the bare
+    //      single-sample-plus-clamp.
+    #[test]
+    fn transient_latency_spike_does_not_trigger_replan() {
+        let (bgp, srcs) = three_source_star();
+        let sel = select_sources(&bgp, &srcs);
+        let plan = plan_bgp(&bgp, &sel, &srcs, &PlanOptions::default()).unwrap();
+        let mut exec = AdaptiveExecutor::new(
+            &bgp,
+            &srcs,
+            &sel,
+            &plan,
+            PlanOptions::default(),
+            ReplanPolicy::default(),
+        );
+        let _ = exec.advance(); // execute :a seed.
+
+        // Source 1 (serving :b) has been running at the baseline for a while: seed + several
+        // at-baseline samples ⇒ EWMA sits at 100.0.
+        let mut stats = RuntimeStats::new();
+        for _ in 0..5 {
+            stats.record_source_latency(1, 100.0);
+        }
+        // One transient spike of 1000.0 (10× baseline — which, as a RAW sample, would clear the
+        // 4× divergence trigger). Under EWMA it lifts the average only to 0.3·1000 + 0.7·100 =
+        // 370 < 400 (= divergence_factor × baseline), so the trigger stays silent.
+        stats.record_source_latency(1, 1000.0);
+        assert!(
+            stats.observed_latency_of(1).unwrap() < 400.0,
+            "one spike must not push the EWMA past the 4× trigger band"
+        );
+        assert_eq!(
+            exec.maybe_replan(&stats),
+            ReplanOutcome::NoDivergence,
+            "a single transient latency spike (damped by the EWMA) must NOT trigger a re-plan"
+        );
+        assert_eq!(
+            exec.remaining_order(),
+            &[1, 2],
+            "suffix order untouched by a transient spike"
+        );
+    }
+
+    // ---- SUSTAINED SHIFT: the SAME source held at the SAME high latency for several
+    //      consecutive samples DOES converge the EWMA past the trigger and re-plans — the EWMA
+    //      reacts to a real regime change, it just refuses to react to a one-off.
+    #[test]
+    fn sustained_latency_shift_does_trigger_replan() {
+        let (bgp, srcs) = three_source_star();
+        let sel = select_sources(&bgp, &srcs);
+        let plan = plan_bgp(&bgp, &sel, &srcs, &PlanOptions::default()).unwrap();
+        let mut exec = AdaptiveExecutor::new(
+            &bgp,
+            &srcs,
+            &sel,
+            &plan,
+            PlanOptions::default(),
+            ReplanPolicy::default(),
+        );
+        let _ = exec.advance(); // execute :a seed.
+
+        // Same starting history as the transient test: source 1 established at baseline …
+        let mut stats = RuntimeStats::new();
+        for _ in 0..5 {
+            stats.record_source_latency(1, 100.0);
+        }
+        // … then a SUSTAINED jump to 1000.0 for several consecutive samples. The EWMA climbs
+        // 370 → 559 → 691 → 784 … crossing 400 (= 4× baseline) by the 2nd sustained sample.
+        stats.record_source_latency(1, 1000.0); // 370 — not yet over.
+        stats.record_source_latency(1, 1000.0); // 559 — over the 400 trigger band.
+        assert!(
+            stats.observed_latency_of(1).unwrap() > 400.0,
+            "a sustained shift must converge the EWMA past the trigger band"
+        );
+        let outcome = exec.maybe_replan(&stats);
+        assert_eq!(
+            outcome,
+            ReplanOutcome::Switched,
+            "a sustained latency shift (EWMA converged past the trigger) MUST re-plan + switch"
+        );
+        assert_eq!(
+            exec.remaining_order(),
+            &[2, 1],
+            "the sustainedly-slow :b arm is deferred behind the faster :c arm"
+        );
+    }
+
+    // ---- RESULT-EQUIVALENCE under an EWMA-driven (sustained-latency) reorder: the smoothed
+    //      latency path is still a pure suffix permutation — same result multiset as static.
+    //      Mirrors latency_replan_result_equals_static but drives the switch via the EWMA
+    //      (multiple samples), not a single raw value.
+    #[test]
+    fn ewma_replan_result_equals_static() {
+        let (bgp, srcs) = three_source_star();
+        let solutions: SolutionSets = vec![
+            vec![
+                t(&[("s", "s1"), ("x", "x1")]),
+                t(&[("s", "s2"), ("x", "x2")]),
+                t(&[("s", "s3"), ("x", "x3")]),
+            ],
+            vec![
+                t(&[("s", "s1"), ("y", "y1")]),
+                t(&[("s", "s1"), ("y", "y7")]),
+                t(&[("s", "s2"), ("y", "y2")]),
+            ],
+            vec![
+                t(&[("s", "s1"), ("z", "z1")]),
+                t(&[("s", "s3"), ("z", "z3")]),
+            ],
+        ];
+        let sel = select_sources(&bgp, &srcs);
+        let plan = plan_bgp(&bgp, &sel, &srcs, &PlanOptions::default()).unwrap();
+        let static_order = plan.join_order();
+        let static_result = evaluate(&bgp, &solutions, &static_order);
+
+        let mut exec = AdaptiveExecutor::new(
+            &bgp,
+            &srcs,
+            &sel,
+            &plan,
+            PlanOptions::default(),
+            ReplanPolicy::default(),
+        );
+        let _seed = exec.advance().unwrap();
+        // Sustained slow :b, accumulated via the EWMA (several samples), converging past trigger.
+        let mut stats = RuntimeStats::new();
+        for _ in 0..6 {
+            stats.record_source_latency(1, 1000.0);
+        }
+        assert_eq!(
+            exec.maybe_replan(&stats),
+            ReplanOutcome::Switched,
+            "fixture is designed to switch on the EWMA-smoothed latency"
+        );
+        let mut adaptive_order = exec.executed_order().to_vec();
+        adaptive_order.extend_from_slice(exec.remaining_order());
+        assert_ne!(
+            adaptive_order, static_order,
+            "the EWMA-driven re-plan must actually change the order (non-vacuous)"
+        );
+        let mut a_sorted = adaptive_order.clone();
+        let mut s_sorted = static_order.clone();
+        a_sorted.sort();
+        s_sorted.sort();
+        assert_eq!(a_sorted, s_sorted, "EWMA re-plan preserves the pattern SET");
+        let adaptive_result = evaluate(&bgp, &solutions, &adaptive_order);
+        assert!(
+            multiset_eq(&static_result, &adaptive_result),
+            "EWMA-reordered result MUST equal the static plan's result multiset"
+        );
+        assert!(!static_result.is_empty(), "fixture must produce some rows");
     }
 }

--- a/skills/federated-planning/SKILL.md
+++ b/skills/federated-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: federated-planning
-description: "Cost-based federated SPARQL source selection + bind-vs-hash join planning over already-fetched source descriptors, plus an ANAPSID-style non-blocking streaming join with operator spill, via the opt-in sparq-fedplan crate. Use when planning a federated BGP across multiple SPARQL endpoints from their served statistics (VoID property/class partitions + mined scs: characteristic sets): deciding which sources can contribute to each triple pattern (HiBISCuS recall-safe pruning + CostFed skew-aware cardinality), choosing a join order with per-join bind-vs-hash-vs-streaming algorithm selection (characteristic-set star cardinality for intermediate sizes), and executing a memory-bounded non-blocking symmetric hash join over incrementally-arriving sub-results (StreamJoin, spill to a backing store, result multiset-equal to a blocking join). Pure + deterministic planning, no network I/O. Off by default; does not touch sparq-core/sparq-engine's lean build. Also covers live adaptive RE-planning at stage boundaries (mid-execution plan switching when observed cardinalities diverge from estimates, or when a source is observed to be slow — per-source latency is folded into the cost model as a documented heuristic bias toward faster sources) via the further opt-in adaptive-replan feature (AdaptiveExecutor) — sound because BGP join is order-independent (latency changes ordering/cost only, never results), with mid-operator swap + live source failover deferred."
+description: "Cost-based federated SPARQL source selection + bind-vs-hash join planning over already-fetched source descriptors, plus an ANAPSID-style non-blocking streaming join with operator spill, via the opt-in sparq-fedplan crate. Use when planning a federated BGP across multiple SPARQL endpoints from their served statistics (VoID property/class partitions + mined scs: characteristic sets): deciding which sources can contribute to each triple pattern (HiBISCuS recall-safe pruning + CostFed skew-aware cardinality), choosing a join order with per-join bind-vs-hash-vs-streaming algorithm selection (characteristic-set star cardinality for intermediate sizes), and executing a memory-bounded non-blocking symmetric hash join over incrementally-arriving sub-results (StreamJoin, spill to a backing store, result multiset-equal to a blocking join). Pure + deterministic planning, no network I/O. Off by default; does not touch sparq-core/sparq-engine's lean build. Also covers live adaptive RE-planning at stage boundaries (mid-execution plan switching when observed cardinalities diverge from estimates, or when a source is observed to be slow — per-source EWMA-smoothed latency is folded into the cost model as a documented heuristic bias toward faster sources, smoothing out transient spikes) via the further opt-in adaptive-replan feature (AdaptiveExecutor) — sound because BGP join is order-independent (latency changes ordering/cost only, never results), with mid-operator swap + live source failover deferred."
 ---
 
 # sparq-fedplan — cost-based federated source selection + join planning
@@ -146,7 +146,9 @@ and holds, at all times, the patterns already joined (the **prefix**) and the pa
 to join (the **suffix**).
 
 - **Capture** — `RuntimeStats` records the *observed* per-pattern leaf cardinality (real row
-  counts the sources returned) and per-source latency, fed in as each stage completes.
+  counts the sources returned) and per-source latency, fed in as each stage completes. Latency
+  is **EWMA-smoothed per source** (below) so the cost model + trigger track the trend, not the
+  last raw sample.
 - **Trigger** — at each **stage boundary**, `maybe_replan(&stats)` checks whether a
   *not-yet-executed* pattern's observed cardinality `o` diverges from its estimate `e` past
   `ReplanPolicy::divergence_factor` `k` either way (`o > k·e` or `e > k·o`; default `k = 4`),
@@ -159,7 +161,7 @@ to join (the **suffix**).
   *slow* (contended / far / rate-limited) even at exactly its predicted cardinality, so the
   re-planner also folds observed latency into the cost. Each candidate join's cost is scaled by
   `factor = clamp(1 + latency_weight·(s − 1), latency_floor, latency_cap)` where
-  `s = slowest_observed_source_latency / latency_baseline` over the pattern's retained sources.
+  `s = slowest_ewma_source_latency / latency_baseline` over the pattern's retained sources.
   A source at baseline — **or with no observation** — yields `factor = 1.0`, so a re-plan with
   no latency data is byte-identical to the cardinality-only planner; a 2×-slow source costs
   1.5× at the default `latency_weight = 0.5`, with `latency_cap` (4.0) bounding any one
@@ -168,6 +170,16 @@ to join (the **suffix**).
   faster sources / deferring a slow one, **not** a claim to compute the latency-optimal plan.
   Latency enters only the *cost* term (and the suffix-selection score), **never** the output
   cardinality, so results are unchanged. `latency_weight = 0` disables it.
+- **Latency EWMA smoothing (sq-b51o follow-up) — a HEURISTIC α, not optimal.** The cost factor
+  and the trigger read a per-source **exponentially-weighted moving average**, not the single
+  last sample: `record_source_latency` folds each sample in as `ewma = α·observed + (1−α)·prev`
+  (first sample seeds it), with α = `RuntimeStats::latency_alpha`, default
+  `DEFAULT_LATENCY_ALPHA = 0.3` — a **hand-picked** factor (latest 30% / history 70%), *not*
+  workload-derived. This is the cleaner anti-thrash than a bare last-sample-plus-clamp: a
+  **single transient spike** does not move the average over the trigger band, but a **sustained**
+  shift converges past it in a few samples. The `latency_floor`/`latency_cap` clamp is kept as a
+  **final guard**. `RuntimeStats::with_latency_alpha(α)` overrides (α = 1.0 ⇒ un-smoothed
+  last-sample behaviour); higher α = faster-tracking/twitchier, lower α = calmer/laggier.
 - **Hysteresis** — the re-planned suffix is adopted **only** if its estimated remaining cost
   (cardinality- **and** latency-weighted) beats the current suffix's by more than
   `ReplanPolicy::improvement_margin` (default 10%), with a hard `max_replans` budget
@@ -182,10 +194,13 @@ associative**: any order over the same patterns yields the **same** result multi
 already-produced prefix is carried across the switch unchanged (no binding lost or
 duplicated). The latency weighting does **not** move this boundary — it touches only
 cost/ordering, never the output cardinality or the pattern set, so a latency-driven reorder is
-the same kind of pure suffix permutation. Proven by `adaptive::tests::replan_result_equals_static`
-(cardinality-driven) and `latency_replan_result_equals_static` (latency-driven) — each
-genuinely flips the order yet yields the identical multiset to the static plan — plus an
-exhaustive all-permutations order-independence test.
+the same kind of pure suffix permutation; the EWMA smoothing changes only *when* the latency
+path fires, never this boundary — re-planning stays a sub-query / **stage-boundary** reorder,
+never mid-operator. Proven by `adaptive::tests::replan_result_equals_static`
+(cardinality-driven), `latency_replan_result_equals_static` (latency-driven) and
+`ewma_replan_result_equals_static` (EWMA-smoothed-latency-driven) — each genuinely flips the
+order yet yields the identical multiset to the static plan — plus an exhaustive
+all-permutations order-independence test.
 
 ## Deferred (NOT here)
 
@@ -195,4 +210,4 @@ a replica mid-stage when a source goes dark — observed latency now *biases the
 toward faster sources, but hard failover needs the live multi-source execution layer this pure
 crate does not own) are out of scope. Filed as roadmap beads under epic **sq-3183**.
 
-[OPUS-4.8] sq-a35t / sq-vf7q / sq-7s4z — flag for Fable re-review.
+[OPUS-4.8] sq-a35t / sq-vf7q / sq-7s4z / sq-b51o — flag for Fable re-review.


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

Follow-up to **sq-b51o**: the \`adaptive-replan\` cost model previously fed a source's **single last** latency observation (plus an absolute floor/cap clamp) into the latency factor + re-plan trigger. This replaces that with a per-source **decayed running average (EWMA)** — a cleaner anti-thrash than the bare clamp.

\`\`\`
ewma_new = α·observed + (1−α)·ewma_prev      (first sample seeds ewma = observed)
\`\`\`

- α is \`RuntimeStats::latency_alpha\`, default \`DEFAULT_LATENCY_ALPHA = 0.3\` — a **hand-picked HEURISTIC** (latest sample 30%, history 70%), **not** a workload-derived optimum (documented as such).
- The **EWMA** (not the raw last value) feeds **both** the latency cost factor **and** the re-plan trigger, so the whole latency path is smoothed consistently.
- The absolute \`latency_floor\`/\`latency_cap\` clamp is **kept as a final guard**.
- \`RuntimeStats::with_latency_alpha(α)\` overrides; \`α = 1.0\` recovers the old un-smoothed "last sample wins" behaviour.

## Soundness (load-bearing, unchanged)

Latency affects **only cost/ordering, never the output multiset**. Re-planning is still a **sub-query / stage-boundary** suffix reorder — never mid-operator. The EWMA only changes *when* the latency path fires (anti-thrash), not the boundary.

## Tests (feature \`adaptive-replan\`)

- \`ewma_smoothing_constants\` — pins α = 0.3 + the EWMA arithmetic + α-clamp.
- \`transient_latency_spike_does_not_trigger_replan\` — one spike (10× baseline as a raw sample) is damped below the 4× trigger ⇒ no re-plan.
- \`sustained_latency_shift_does_trigger_replan\` — the same source held high converges the EWMA past the trigger ⇒ switches.
- \`ewma_replan_result_equals_static\` — result-equivalence across an EWMA-driven reorder (mirrors \`replan_result_equals_static\` / \`latency_replan_result_equals_static\`, non-vacuous).

## Gates — green in ALL three feature states (default off / \`fedplan\` / \`adaptive-replan\`)

\`cargo build\`, \`cargo clippy --all-targets -- -D warnings\`, \`cargo test\` — all pass (48 tests under \`adaptive-replan\`, +4 new).

Docs updated: \`crates/sparq-fedplan/README.md\` + \`skills/federated-planning/SKILL.md\` (EWMA + heuristic caveat + unchanged soundness boundary).

[OPUS-4.8] sq-b51o follow-up · epic sq-3183 — flagged for Fable re-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)