### PR TITLE
feat(site): pre-warm the in-browser ZK prover on the car-hire route

### DIFF
--- a/site/src/components/zk-car-hire.tsx
+++ b/site/src/components/zk-car-hire.tsx
@@ -32,6 +32,7 @@ import {
 import { cn } from "@/lib/utils";
 import {
   proveAgeEligibility,
+  prewarmProver,
   PROVABLE_AGES,
   AGE_THRESHOLD,
   type ProofResult,
@@ -53,9 +54,38 @@ type Phase =
   | { kind: "rejected"; message: string } // under-age → unsatisfiable
   | { kind: "error"; message: string };
 
+// [OPUS-4.8] Prover warm-up lifecycle, surfaced as a subtle indicator — mirrors the
+// SPARQL REPL's Engine pill. The dynamic-import + circuit fetch + Barretenberg WASM
+// instantiate is kicked off on mount (prewarmProver) so the first "Generate ZK proof"
+// pays no cold start. The proving path awaits the same shared promise as a safety net.
+type ProverState = "cold" | "warming" | "ready" | "error";
+
 export function ZkCarHire() {
   const [age, setAge] = React.useState(30);
   const [phase, setPhase] = React.useState<Phase>({ kind: "idle" });
+  const [prover, setProver] = React.useState<ProverState>("cold");
+
+  // Pre-warm the in-browser ZK prover in the background on mount, off the render path.
+  // A failure resets the indicator; proveAgeEligibility still awaits the shared init,
+  // so the button never silently no-ops or throws on a cold prover. Route-scoped (this
+  // component only renders on the ZK pages) so the ~MB bb.js WASM is never fetched on
+  // other routes — the prover assets stay off /try, /papers, /benchmarks, etc.
+  React.useEffect(() => {
+    let cancelled = false;
+    setProver("warming");
+    prewarmProver()
+      .then(() => {
+        if (!cancelled) setProver("ready");
+      })
+      .catch(() => {
+        // Transient load failure (fetch/instantiate) — the cache self-resets, so the
+        // next "Generate ZK proof" retries the cold start. Surface it on the pill only.
+        if (!cancelled) setProver("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const run = React.useCallback(async () => {
     try {
@@ -64,6 +94,8 @@ export function ZkCarHire() {
       await new Promise((r) => setTimeout(r, 0));
       setPhase({ kind: "proving" });
       const result = await proveAgeEligibility(age);
+      // The shared prover init resolved (proveAgeEligibility awaits it): reflect ready.
+      setProver("ready");
       setPhase({ kind: "verifying" });
       // verifyProof already ran inside proveAgeEligibility; reflect it.
       setPhase({ kind: "done", result });
@@ -148,9 +180,12 @@ export function ZkCarHire() {
               <ShieldCheck className="size-4 text-primary" />
               The desk’s eligibility query (public)
             </CardTitle>
-            <Badge variant="success">
-              <Cpu className="size-3" /> Live via bb.js
-            </Badge>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <ProverIndicator prover={prover} />
+              <Badge variant="success">
+                <Cpu className="size-3" /> Live via bb.js
+              </Badge>
+            </div>
           </CardHeader>
           <CardContent className="space-y-4">
             <pre className="overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-[11.5px] leading-relaxed">
@@ -231,6 +266,30 @@ export function ZkCarHire() {
       {/* ── Honesty ── */}
       <HonestyPanel />
     </div>
+  );
+}
+
+// [OPUS-4.8] Subtle prover-readiness pill. Reuses the badge tokens; never blocks the
+// UI and never alters any security claim — it only reports cold-start progress.
+function ProverIndicator({ prover }: { prover: ProverState }) {
+  if (prover === "ready") {
+    return (
+      <Badge variant="muted" aria-live="polite">
+        <CircleCheck className="size-3 text-[var(--success)]" /> Prover ready
+      </Badge>
+    );
+  }
+  if (prover === "error") {
+    return (
+      <Badge variant="warning" aria-live="polite">
+        <CircleAlert className="size-3" /> Prover load failed — retries on proof
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="muted" aria-live="polite">
+      <Loader2 className="size-3 animate-spin" /> Initializing ZK prover…
+    </Badge>
   );
 }
 

--- a/site/src/lib/zk-prover.ts
+++ b/site/src/lib/zk-prover.ts
@@ -81,24 +81,70 @@ interface BbModule {
   };
 }
 
-let circuitPromise: Promise<{ bytecode: string }> | null = null;
-
 function basePath(): string {
   return process.env.NEXT_PUBLIC_BASE_PATH ?? "/sparq";
 }
 
-/** Fetches the committed ACIR artifact once. */
-async function loadCircuit(): Promise<{ bytecode: string }> {
-  if (!circuitPromise) {
-    circuitPromise = fetch(`${basePath()}/zk/filter_int_d2.json`).then((r) => {
-      if (!r.ok) throw new Error(`circuit fetch failed: ${r.status}`);
-      return r.json();
-    });
-    circuitPromise.catch(() => {
-      circuitPromise = null;
+/**
+ * [OPUS-4.8] The cold-start cost of the in-browser prover, paid once and shared.
+ *
+ * Three expensive things must happen before the first proof can be produced, and
+ * none of them depend on the chosen age:
+ *   1. dynamic-import the `@noir-lang/noir_js` + `@aztec/bb.js` chunks (the ~MB WASM
+ *      glue, deliberately kept out of the main page bundle), and
+ *   2. fetch + parse the committed ACIR artifact (`/zk/filter_int_d2.json`), and
+ *   3. instantiate the Barretenberg WASM backend (`Barretenberg.new` — the dominant
+ *      cold cost) and build the `UltraHonkBackend` over the circuit bytecode.
+ *
+ * {@link prewarmProver} kicks this off in the background on ZK-route mount so the
+ * first "Generate ZK proof" click pays none of it. {@link proveAgeEligibility}
+ * awaits the SAME promise as a safety net, so a click that lands before pre-warm
+ * finishes (or when pre-warm was never called) is still correct — it simply waits.
+ */
+interface ProverContext {
+  Noir: NoirModule["Noir"];
+  backend: InstanceType<BbModule["UltraHonkBackend"]>;
+  circuit: { bytecode: string };
+  threads: number;
+}
+
+let proverPromise: Promise<ProverContext> | null = null;
+
+async function loadProver(): Promise<ProverContext> {
+  if (!proverPromise) {
+    proverPromise = (async () => {
+      const [{ Noir }, bb, circuit] = await Promise.all([
+        import(/* webpackChunkName: "noir-js" */ "@noir-lang/noir_js") as Promise<NoirModule>,
+        import(/* webpackChunkName: "bb-js" */ "@aztec/bb.js") as Promise<BbModule>,
+        fetch(`${basePath()}/zk/filter_int_d2.json`).then((r) => {
+          if (!r.ok) throw new Error(`circuit fetch failed: ${r.status}`);
+          return r.json() as Promise<{ bytecode: string }>;
+        }),
+      ]);
+
+      const threads = maxThreads();
+      const api = await bb.Barretenberg.new({ threads });
+      const backend = new bb.UltraHonkBackend(circuit.bytecode, api);
+      return { Noir, backend, circuit, threads };
+    })();
+    proverPromise.catch(() => {
+      proverPromise = null; // allow retry on transient failure (fetch/instantiate)
     });
   }
-  return circuitPromise;
+  return proverPromise;
+}
+
+/**
+ * [OPUS-4.8] Eagerly pre-warm the ZK prover (dynamic-import + circuit fetch + WASM
+ * backend instantiate) without blocking render. Safe to call on route mount and to
+ * call repeatedly — it shares the single {@link loadProver} promise, so the cold
+ * start happens at most once. Returns a promise that resolves when the prover is
+ * ready (or rejects on a load failure, which resets the cache so a later click can
+ * retry). This is a UX/perf measure only — it does not change what is proved, nor
+ * any security property of the proof.
+ */
+export function prewarmProver(): Promise<unknown> {
+  return loadProver();
 }
 
 /** Cross-origin isolation gates bb.js multithreading (SharedArrayBuffer). GitHub
@@ -128,11 +174,10 @@ export async function proveAgeEligibility(age: number): Promise<ProofResult> {
   }
   const eligible = age >= AGE_THRESHOLD;
 
-  const [{ Noir }, bb, circuit] = await Promise.all([
-    import(/* webpackChunkName: "noir-js" */ "@noir-lang/noir_js") as Promise<NoirModule>,
-    import(/* webpackChunkName: "bb-js" */ "@aztec/bb.js") as Promise<BbModule>,
-    loadCircuit(),
-  ]);
+  // Reuse the shared, pre-warmed prover context (dynamic imports + circuit fetch +
+  // instantiated UltraHonk backend). If pre-warm has not finished, this awaits the
+  // same in-flight promise — never a second cold start.
+  const { Noir, backend, circuit, threads } = await loadProver();
 
   const inputs = {
     challenge: "0x1", // per-presentation verifier nonce (fixed here for the demo)
@@ -146,10 +191,6 @@ export async function proveAgeEligibility(age: number): Promise<ProofResult> {
   const noir = new Noir(circuit);
   // For an under-age claim the verdict assertion fails here: no proof possible.
   const { witness } = await noir.execute(inputs);
-
-  const threads = maxThreads();
-  const api = await bb.Barretenberg.new({ threads });
-  const backend = new bb.UltraHonkBackend(circuit.bytecode, api);
 
   const t0 = performance.now();
   const proof = await backend.generateProof(witness);


### PR DESCRIPTION
> 🤖 SPARQ agent

## What & why
Maintainer request: like the SPARQL REPL pre-warm, the first **"Generate ZK proof"** on the ZK car-hire demo paid a long cold start. This pre-warms the in-browser prover in the background on page load so the first proof is fast, with a readiness indicator.

## How the prover loaded before
`proveAgeEligibility()` lazily, on the first click, did all of: dynamic-import `@noir-lang/noir_js` + `@aztec/bb.js` (the ~MB WASM glue, deliberately code-split out of the page bundle), `fetch` the committed ACIR artifact (`/zk/filter_int_d2.json`), and instantiate the **Barretenberg WASM backend** (`Barretenberg.new` — the dominant cost) + build the `UltraHonkBackend`. None of those depend on the chosen age.

## The change (mirrors the REPL idiom)
- **`site/src/lib/zk-prover.ts`** — hoist the three age-independent steps into a single shared, cached init promise `loadProver()` (self-resets on failure for retry); export **`prewarmProver()`**. `proveAgeEligibility()` now awaits the **same** promise, so a click that lands before pre-warm finishes just waits — it never re-pays a second cold start, never silently no-ops/throws.
- **`site/src/components/zk-car-hire.tsx`** — a background `useEffect` on mount kicks off `prewarmProver()` off the render path, with a subtle **"Initializing ZK prover… / Prover ready"** pill (same pattern as the REPL's "Engine ready").

## Route-scoped (not global), by design
`ZkCarHire` only renders on `/showcase/zk-car-hire`, so pre-warm — and the heavy `bb.js` WASM — never touch other routes. Verified in the export: the named `bb-js.*.js` chunk is referenced by **no** page HTML (loaded on demand), and the ZK page chunk is referenced only by the ZK page, **not** `/try`, `/papers`, or root. No load regression elsewhere. Assets fetched with the correct `basePath` (`/sparq`).

## Honesty
UX/perf only — proves the same relation and asserts **no** new or strengthened security claim. Every not-externally-audited / research-grade caveat in the honesty panel is preserved. The privacy-claims gate passes locally.

## Verification
- `npm install` + `npm run lint` (clean) + `tsc --noEmit` (pass) + `npm run build` static export → **green, 41 pages** incl. the ZK page, `/try`, `/papers`, `/benchmarks`.
- "First proof pays no cold start" reasoned through the shared-promise design + verified via the route-scoped lazy bundle. **No browser driver is available in this env**, so this was not asserted by an automated browser run — deferred as bead **sq-5q63** (Playwright smoke test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)