### PR TITLE
chore(orchestration): bead-close/orphan-check/refill-candidate scripts (#374 Phase A/C/F)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,44 @@ This is the standing orchestration loop that ties the sections above together. R
 
 **Done when** `bd ready` minus `needs:user` is empty and no PR / agent / CI is in flight.
 
+### Orchestration automation scripts (manual-invoke; mechanical substrate for the loop)
+
+The deterministic, no-judgment parts of the loop above are factored into small shell
+scripts under `scripts/`. They follow the mechanical-vs-judgment boundary set out in
+`research/orchestration-automation-design.md` (PR #374): **automate the DETECTION and
+the bookkeeping; never automate the DECISION.** The first three (PR #374 Phases A/C/F)
+are shipped. They are **invoked manually for now** — there are deliberately **no
+auto-running mutating hooks or monitors wired yet**; wiring them (a `SessionStart`
+orphan-check hook, a merge-watcher monitor, a `PostToolUse` bead-export hook) is a
+documented follow-up in the design doc's phased plan (§5, Beads B/D/E + H), to be added
+only after the scripts are proven in manual use. Each script is `bash -n`/`shellcheck`
+clean and carries a `--dry-run-self-test` (hermetic; no network).
+
+- **`scripts/bead-close-on-merge.sh <pr> [--apply]`** (Phase A) — closes the bead a PR
+  maps to, but **only after verifying the merge against the API** (`gh pr view --json
+  mergedAt` must be non-null; a parsed log/monitor line is never the source of truth).
+  Resolves the bead id from an `sq-XXXX` token in the PR title or in a linked issue's
+  title/body. **Default is dry-run** (prints what it *would* close); acts only with
+  `--apply`; idempotent (a bead already closed is a no-op). The guardrail makes the
+  dangerous case — closing a bead for a PR that did **not** merge — impossible.
+- **`scripts/orphan-check-bench.sh [--apply] [--region r]`** (Phase C) — lists
+  running/pending EC2 instances carrying the **exact** tag `purpose=sparq-bench`
+  (allow-list semantics, not deny-list) and greps the local process table for in-flight
+  `gather-*` launchers. **Default is dry-run** (prints orphans only); `--apply`
+  terminates **only** tag-matched instances and **never** the prod (`i-090531b4ede8f2d3f`)
+  or dev (`i-00f76802f345b6b77`) box — those are a hard, unconditional exclusion list,
+  asserted by the self-test. Degrades to a graceful no-op when `aws` is unconfigured.
+- **`scripts/refill-candidates.sh`** (Phase F) — **read-only, advisory only.** Lists
+  `bd ready` beads grouped by inferred crate/surface and flags surfaces that already have
+  an open PR or in-flight worktree (contention). It is the **substrate** for the refill
+  decision (loop step 3), **not** the decision: it never dispatches, closes, or mutates
+  anything. Surface inference and contention flags are heuristic (free-form branch names)
+  and advisory by design.
+
+See `research/orchestration-automation-design.md` §1.3 (the five judgment behaviours that
+must stay with the orchestrator), §6 (failure modes + the guardrail behind each), and §5
+(the full phased stand-up plan with per-phase rollback).
+
 ## No hard-coded performance numbers
 
 Do not bake benchmark numbers (MB/s, ×-faster, recall, gate counts, latencies) into markdown. Reference the **generated structured data** instead (the benchmark harnesses emit JSON; CI publishes results). If you cite a number, cite where it was generated.

--- a/scripts/bead-close-on-merge.sh
+++ b/scripts/bead-close-on-merge.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] Orchestration automation — Phase A of research/orchestration-automation-design.md
+# (PR #374). Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# bead-close-on-merge.sh <pr> [--apply]
+#
+# Close the bead a PR maps to — but ONLY IF the PR *genuinely merged*. This is the
+# single most error-prone bookkeeping step the orchestrator does by hand (design §1.1
+# T2 / §5 Bead A), and the one with a sharp failure mode: closing a bead for a PR that
+# did NOT merge (closed-unmerged, or a stale/spoofed signal). The guardrail (design §6,
+# "Auto-close a bead for a PR that DIDN'T merge"):
+#
+#   * The merge is VERIFIED against the GitHub API — `gh pr view --json mergedAt` must be
+#     non-null. We NEVER infer a merge from a parsed log/monitor line; a monitor event is
+#     only a *wake*, and this script re-checks the API as the source of truth.
+#   * DEFAULT is --dry-run: it prints WHAT it would close and exits 0 without mutating bd.
+#     Closing requires the explicit --apply flag.
+#   * Idempotent: a bead already closed is a no-op (reported, not re-closed).
+#
+# Bead-id resolution (in priority order):
+#   1. `closingIssuesReferences` — but those are GitHub *issues*, not beads. We only honour
+#      them when the issue title / the linked-issue body carries an sq-XXXX bead token
+#      (the flow-on bridge mints GH issues that name their bead). A bare GH issue number is
+#      NOT a bead id and is ignored (with a note).
+#   2. an sq-XXXX (or sq-XXXX.NN) token in the PR title — the convention the brief documents
+#      ("a sq-XXXX token in the title").
+# If neither yields a bead id, the script reports "no mapped bead" and exits 0 (nothing to
+# do is not an error — many PRs are chores with no bead).
+#
+# Run:
+#   scripts/bead-close-on-merge.sh 374            # dry-run (default): what WOULD close
+#   scripts/bead-close-on-merge.sh 374 --apply    # actually close, iff verified-merged
+#   scripts/bead-close-on-merge.sh --dry-run-self-test   # hermetic self-test (no network)
+set -euo pipefail
+
+PROG="bead-close-on-merge"
+log()  { printf '[%s] %s\n' "$PROG" "$*" >&2; }
+die()  { printf '[%s] ERROR: %s\n' "$PROG" "$*" >&2; exit 1; }
+
+# --- bead-id extraction (pure-text; the hermetic, testable core) -----------------------
+# Echo every distinct sq-XXXX / sq-XXXX.NN token found in stdin, one per line, in order.
+# Bead ids are `sq-` + a short base36-ish slug, optionally a `.NN` molecule suffix
+# (e.g. sq-qhy4, sq-toze.37). We match conservatively and de-duplicate preserving order.
+extract_bead_ids() {
+  grep -oE 'sq-[a-z0-9]+(\.[0-9]+)?' 2>/dev/null | awk '!seen[$0]++' || true
+}
+
+# --- the --dry-run self-test (no network, asserts the extraction + guard logic) --------
+self_test() {
+  local fails=0 got
+  _check() { # _check "<label>" "<got>" "<want>"
+    if [ "$2" = "$3" ]; then
+      printf '  ok   %s\n' "$1"
+    else
+      printf '  FAIL %s\n       got:  %q\n       want: %q\n' "$1" "$2" "$3"
+      fails=$((fails + 1))
+    fi
+  }
+  log "running --dry-run self-test (hermetic; no gh/bd calls)"
+
+  got="$(printf 'fix(sparq-core): dict spill (sq-glw2)\n' | extract_bead_ids)"
+  _check "title token sq-glw2"                     "$got" "sq-glw2"
+
+  got="$(printf 'cert(sbom): purl thing (sq-tmyw, sq-toze.27)\n' | extract_bead_ids)"
+  _check "two tokens incl molecule suffix"         "$got" "$(printf 'sq-tmyw\nsq-toze.27')"
+
+  got="$(printf 'closes sq-abcd and again sq-abcd\n' | extract_bead_ids)"
+  _check "dedupe preserves first occurrence"       "$got" "sq-abcd"
+
+  got="$(printf 'chore(orchestration): no bead here #374\n' | extract_bead_ids)"
+  _check "no token => empty"                        "$got" ""
+
+  # A bare GH issue reference (#123) must NOT be mistaken for a bead.
+  got="$(printf 'closingIssuesReferences: #123 #456\n' | extract_bead_ids)"
+  _check "bare GH issue numbers are not beads"      "$got" ""
+
+  # The verified-merge guard predicate (mergedAt non-null) — exercised directly.
+  is_verified_merged 'null'  && fails=$((fails + 1)) && printf '  FAIL null mergedAt treated as merged\n' || printf '  ok   null mergedAt => NOT merged\n'
+  is_verified_merged ''      && fails=$((fails + 1)) && printf '  FAIL empty mergedAt treated as merged\n' || printf '  ok   empty mergedAt => NOT merged\n'
+  if is_verified_merged '2026-06-16T17:08:58Z'; then printf '  ok   real timestamp => merged\n'; else printf '  FAIL real timestamp not treated as merged\n'; fails=$((fails + 1)); fi
+
+  echo
+  if [ "$fails" -eq 0 ]; then
+    log "self-test PASSED"
+    return 0
+  fi
+  die "self-test FAILED ($fails check(s))"
+}
+
+# A merge is verified IFF mergedAt is a non-empty, non-"null" value. Pure predicate so the
+# self-test can assert it without a network round-trip.
+is_verified_merged() {
+  local merged_at="${1-}"
+  [ -n "$merged_at" ] && [ "$merged_at" != "null" ]
+}
+
+# --- arg parsing -----------------------------------------------------------------------
+APPLY=0
+PR=""
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run-self-test) self_test; exit 0 ;;
+    --apply)             APPLY=1 ;;
+    --dry-run)           APPLY=0 ;;
+    -h|--help)
+      sed -n '2,40p' "$0"; exit 0 ;;
+    -*)
+      die "unknown flag: $arg (try --apply, --dry-run, --dry-run-self-test, --help)" ;;
+    *)
+      [ -z "$PR" ] || die "unexpected extra argument: $arg"
+      PR="$arg" ;;
+  esac
+done
+
+[ -n "$PR" ] || die "usage: $PROG <pr> [--apply]  (default is --dry-run)"
+case "$PR" in
+  ''|*[!0-9]*) die "PR must be a number, got: $PR" ;;
+esac
+
+command -v gh >/dev/null 2>&1 || die "gh CLI not found (needed to verify the merge via the API)"
+command -v bd >/dev/null 2>&1 || die "bd not found (needed to close the bead)"
+
+# --- 1. VERIFY the merge against the API (never a parsed log line) ----------------------
+log "querying gh for PR #$PR (mergedAt,state,title,closingIssuesReferences)"
+PR_JSON="$(gh pr view "$PR" --json mergedAt,state,title,closingIssuesReferences 2>/dev/null)" \
+  || die "gh pr view #$PR failed (does the PR exist? is gh authenticated?)"
+
+MERGED_AT="$(printf '%s' "$PR_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("mergedAt") or "null")')"
+STATE="$(printf '%s' "$PR_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("state") or "")')"
+TITLE="$(printf '%s' "$PR_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("title") or "")')"
+
+if ! is_verified_merged "$MERGED_AT"; then
+  log "PR #$PR is NOT verified-merged (state=$STATE, mergedAt=$MERGED_AT) — refusing to close any bead."
+  log "This is the guardrail: a bead is closed ONLY for an API-verified merge (mergedAt != null)."
+  exit 0
+fi
+log "verified merge: PR #$PR mergedAt=$MERGED_AT state=$STATE"
+
+# --- 2. RESOLVE the bead id ------------------------------------------------------------
+# (a) sq-XXXX tokens carried by linked issues' titles/bodies (the flow-on bead bridge).
+LINKED_TOKENS="$(printf '%s' "$PR_JSON" \
+  | python3 -c 'import json,sys
+d=json.load(sys.stdin)
+refs=d.get("closingIssuesReferences") or []
+for r in refs:
+    print(r.get("title") or "")
+    print(r.get("body") or "")' 2>/dev/null | extract_bead_ids)"
+
+# (b) sq-XXXX tokens in the PR title (the documented convention).
+TITLE_TOKENS="$(printf '%s\n' "$TITLE" | extract_bead_ids)"
+
+mapfile -t BEAD_IDS < <(printf '%s\n%s\n' "$LINKED_TOKENS" "$TITLE_TOKENS" | grep -E '^sq-' | awk '!seen[$0]++' || true)
+
+if [ "${#BEAD_IDS[@]}" -eq 0 ]; then
+  log "PR #$PR merged but maps to NO bead (no sq-XXXX token in title or linked issues) — nothing to close."
+  exit 0
+fi
+
+log "resolved bead id(s) for merged PR #$PR:"
+printf '  %s\n' "${BEAD_IDS[@]}" >&2
+
+# --- 3. CLOSE (or, in dry-run, report) — idempotent ------------------------------------
+rc=0
+for bid in "${BEAD_IDS[@]}"; do
+  # Idempotency: skip beads already closed.
+  status="$(bd show "$bid" --json 2>/dev/null \
+    | python3 -c 'import json,sys
+try:
+    d=json.load(sys.stdin)
+    if isinstance(d, list): d = d[0] if d else {}
+    print(d.get("status") or "")
+except Exception:
+    print("")' 2>/dev/null || true)"
+
+  if [ -z "$status" ]; then
+    log "  $bid: not found in bd (or bd show failed) — skipping (no-op)."
+    continue
+  fi
+  if [ "$status" = "closed" ]; then
+    log "  $bid: already closed — no-op (idempotent)."
+    continue
+  fi
+
+  if [ "$APPLY" -eq 1 ]; then
+    if bd close "$bid" --reason "merged via PR #$PR (verified mergedAt=$MERGED_AT)" >/dev/null 2>&1; then
+      log "  $bid: CLOSED (merged via PR #$PR)."
+    else
+      log "  $bid: bd close FAILED."
+      rc=1
+    fi
+  else
+    log "  $bid: WOULD close (currently '$status'). Re-run with --apply to act."
+  fi
+done
+
+if [ "$APPLY" -eq 0 ]; then
+  log "dry-run (default): no beads were modified. Re-run with --apply to close the above."
+fi
+exit "$rc"

--- a/scripts/orphan-check-bench.sh
+++ b/scripts/orphan-check-bench.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] Orchestration automation — Phase C of research/orchestration-automation-design.md
+# (PR #374). Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# orphan-check-bench.sh [--apply] [--region <r>]
+#
+# Find — and, with --apply, terminate — ORPHANED benchmark EC2 instances: instances that
+# carry the EXACT tag purpose=sparq-bench and are still running/pending after their bench
+# should have self-terminated (the gather launchers set
+# --instance-initiated-shutdown-behavior=terminate + a 3h watchdog, but an agent death or a
+# stuck gather can leave a box alive and burning ~$5/day — MEMORY: feedback-ec2-benchmarks).
+# It also greps the local process table for in-flight `gather-*` launchers so a fresh
+# session can see what is (or isn't) still driving a box.
+#
+# SAFETY (design §6, "Orphan-check terminates a PROD/DEV box" — Critical/irreversible):
+#   * DEFAULT --dry-run: prints the orphans it WOULD terminate and exits 0 WITHOUT calling
+#     terminate-instances. Actually terminating requires the explicit --apply flag.
+#   * ALLOW-LIST (not deny-list) semantics: an instance is a termination candidate ONLY IF
+#     it carries the EXACT tag purpose=sparq-bench. We never terminate by "everything except
+#     the excludes"; the filter is positive.
+#   * HARD exclusion list on top of that: the prod box (i-090531b4ede8f2d3f) and the dev box
+#     (i-00f76802f345b6b77) are NEVER terminated even if (mis-)tagged. They are removed from
+#     the kill set unconditionally, and the self-test asserts they can never be in it.
+#   * The EC2 query itself filters on tag:purpose=sparq-bench AND state in {running,pending}
+#     server-side, so the prod/dev boxes never even enter the candidate set under normal
+#     conditions; the hard exclusion is the belt-and-braces second line.
+#
+# Run:
+#   scripts/orphan-check-bench.sh                       # dry-run (default): list orphans
+#   scripts/orphan-check-bench.sh --apply               # terminate tag-matched orphans
+#   scripts/orphan-check-bench.sh --region us-east-1    # override region
+#   scripts/orphan-check-bench.sh --dry-run-self-test   # hermetic self-test (no aws)
+set -euo pipefail
+
+PROG="orphan-check-bench"
+log()  { printf '[%s] %s\n' "$PROG" "$*" >&2; }
+die()  { printf '[%s] ERROR: %s\n' "$PROG" "$*" >&2; exit 1; }
+
+# The EXACT tag that marks a disposable bench box (allow-list key). Matches the gather
+# launchers' TAGSPEC (scripts/gather-ec2*.sh: Tags=[{Key=purpose,Value=sparq-bench}]).
+readonly BENCH_TAG_KEY="purpose"
+readonly BENCH_TAG_VALUE="sparq-bench"
+
+# HARD never-touch instance ids (prod + dev). Editing this list is the ONLY way to change
+# what is protected; nothing else can add to or bypass it.
+readonly PROD_INSTANCE="i-090531b4ede8f2d3f"
+readonly DEV_INSTANCE="i-00f76802f345b6b77"
+readonly -a NEVER_TOUCH=("$PROD_INSTANCE" "$DEV_INSTANCE")
+
+# Drop any hard-excluded id from a newline-separated id list on stdin. Pure-text + testable.
+drop_excluded() {
+  local ids; ids="$(cat)"
+  local id keep
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    keep=1
+    for ex in "${NEVER_TOUCH[@]}"; do
+      [ "$id" = "$ex" ] && { keep=0; break; }
+    done
+    [ "$keep" -eq 1 ] && printf '%s\n' "$id"
+  done <<< "$ids"
+  return 0
+}
+
+# --- the --dry-run self-test (no aws; asserts the exclusion + allow-list invariants) ---
+self_test() {
+  local fails=0 got
+  _check() {
+    if [ "$2" = "$3" ]; then printf '  ok   %s\n' "$1"
+    else printf '  FAIL %s\n       got:  %q\n       want: %q\n' "$1" "$2" "$3"; fails=$((fails + 1)); fi
+  }
+  log "running --dry-run self-test (hermetic; no aws calls)"
+
+  # The load-bearing invariant: prod/dev ids are NEVER in the kill set, even if a bench-
+  # tagged query (wrongly) returned them.
+  got="$(printf '%s\n%s\n%s\n' "i-aaaa111122223333a" "$PROD_INSTANCE" "$DEV_INSTANCE" | drop_excluded)"
+  _check "prod+dev dropped, bench kept"            "$got" "i-aaaa111122223333a"
+
+  got="$(printf '%s\n%s\n' "$PROD_INSTANCE" "$DEV_INSTANCE" | drop_excluded)"
+  _check "only prod+dev => empty kill set"         "$got" ""
+
+  got="$(printf 'i-orphan1\ni-orphan2\n' | drop_excluded)"
+  _check "two genuine orphans both kept"           "$got" "$(printf 'i-orphan1\ni-orphan2')"
+
+  got="$(printf '\n\n' | drop_excluded)"
+  _check "blank input => empty"                    "$got" ""
+
+  # Allow-list key shape (the server-side filter we will pass to aws).
+  _check "tag filter key"                          "$BENCH_TAG_KEY"   "purpose"
+  _check "tag filter value"                        "$BENCH_TAG_VALUE" "sparq-bench"
+
+  # Defensive: the hard list contains exactly prod + dev.
+  _check "never-touch count is 2"                  "${#NEVER_TOUCH[@]}" "2"
+
+  echo
+  if [ "$fails" -eq 0 ]; then log "self-test PASSED"; return 0; fi
+  die "self-test FAILED ($fails check(s))"
+}
+
+# --- arg parsing -----------------------------------------------------------------------
+APPLY=0
+REGION="${AWS_REGION:-eu-west-2}"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run-self-test) self_test; exit 0 ;;
+    --apply)             APPLY=1 ;;
+    --dry-run)           APPLY=0 ;;
+    --region)            shift; [ "$#" -gt 0 ] || die "--region needs a value"; REGION="$1" ;;
+    --region=*)          REGION="${1#--region=}" ;;
+    -h|--help)           sed -n '2,40p' "$0"; exit 0 ;;
+    *)                   die "unknown argument: $1 (try --apply, --region, --dry-run-self-test, --help)" ;;
+  esac
+  shift
+done
+
+# --- 1. grep the local process table for in-flight gather launchers (advisory) ---------
+# (SC2009: pgrep can't print etime+args in one shot, and we want both for the operator's
+#  briefing, so an explicit ps|grep is intended here. The grep -v grep drops the matcher.)
+log "in-flight gather launchers on THIS host (advisory):"
+# shellcheck disable=SC2009
+if procs="$(ps -eo pid,etime,args 2>/dev/null | grep -E 'gather-(ec2|competitors|ec2-sparql)\.sh' | grep -v grep)"; then
+  printf '%s\n' "$procs" | sed 's/^/  /' >&2
+else
+  log "  (none)"
+fi
+
+# --- 2. query EC2 for running/pending instances with the EXACT bench tag ---------------
+command -v aws >/dev/null 2>&1 || {
+  log "aws CLI not found — process-table scan done; EC2 query skipped (graceful no-op)."
+  exit 0
+}
+
+log "querying EC2 (region=$REGION) for state in {running,pending} AND tag:$BENCH_TAG_KEY=$BENCH_TAG_VALUE"
+# Allow-list filter: ONLY instances carrying the exact tag are even returned.
+if ! INSTANCES_RAW="$(aws ec2 describe-instances \
+  --region "$REGION" \
+  --filters "Name=tag:${BENCH_TAG_KEY},Values=${BENCH_TAG_VALUE}" \
+            "Name=instance-state-name,Values=running,pending" \
+  --query 'Reservations[].Instances[].InstanceId' \
+  --output text 2>/dev/null | tr '\t' '\n' | sed '/^$/d')"; then
+  log "aws describe-instances failed (credentials/region?) — no action taken."
+  exit 0
+fi
+
+mapfile -t INSTANCES <<< "$INSTANCES_RAW"
+# Drop the trailing empty element a here-string leaves when the input is empty.
+[ "${#INSTANCES[@]}" -eq 1 ] && [ -z "${INSTANCES[0]}" ] && INSTANCES=()
+
+if [ "${#INSTANCES[@]}" -eq 0 ]; then
+  log "no running/pending sparq-bench instances — clean (no orphans)."
+  exit 0
+fi
+
+log "tag-matched running/pending instances:"
+printf '  %s\n' "${INSTANCES[@]}" >&2
+
+# Belt-and-braces: drop the hard never-touch ids before they can ever reach terminate.
+mapfile -t KILL_SET < <(printf '%s\n' "${INSTANCES[@]}" | drop_excluded)
+
+# If anything was filtered, say so loudly (a prod/dev box wrongly carrying the bench tag is
+# itself a finding worth surfacing — but we still never terminate it).
+for ex in "${NEVER_TOUCH[@]}"; do
+  if printf '%s\n' "${INSTANCES[@]}" | grep -qxF "$ex"; then
+    log "WARNING: protected instance $ex carries the bench tag but is HARD-EXCLUDED — NOT terminating it."
+  fi
+done
+
+if [ "${#KILL_SET[@]}" -eq 0 ]; then
+  log "after hard exclusion, no terminable orphans remain."
+  exit 0
+fi
+
+log "ORPHAN candidates (tag-matched, prod/dev excluded):"
+printf '  %s\n' "${KILL_SET[@]}" >&2
+
+if [ "$APPLY" -eq 0 ]; then
+  log "dry-run (default): nothing terminated. Re-run with --apply to terminate the above."
+  exit 0
+fi
+
+# --- 3. --apply: terminate ONLY the kill set (tag-matched, prod/dev already removed) ---
+log "--apply: terminating orphan(s): ${KILL_SET[*]}"
+if aws ec2 terminate-instances --region "$REGION" --instance-ids "${KILL_SET[@]}" >/dev/null 2>&1; then
+  log "terminate-instances submitted for: ${KILL_SET[*]}"
+else
+  die "terminate-instances FAILED for: ${KILL_SET[*]}"
+fi

--- a/scripts/refill-candidates.sh
+++ b/scripts/refill-candidates.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] Orchestration automation — Phase F of research/orchestration-automation-design.md
+# (PR #374). Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# refill-candidates.sh   (READ-ONLY; advisory only — NO mutation, NO dispatch)
+#
+# Print the `bd ready` beads grouped by crate/surface, and FLAG each surface that already
+# has an open PR / in-flight worktree (contention). This is the SUBSTRATE for the
+# orchestrator's refill DECISION (design §1.1 T5 / §5 Bead F), NOT the decision: choosing
+# *which* bead to dispatch, writing the brief, and respecting the one-branch-per-contended-
+# surface rule is JUDGMENT and stays with the orchestrator. This script only assembles the
+# "ready, grouped, contention-flagged" candidate list so that judgment is well-informed.
+#
+# It is strictly read-only: it runs `bd ready`, `gh pr list`, and `git worktree list`, and
+# prints. It NEVER closes/creates/dispatches anything.
+#
+# Surface derivation (best-effort, deterministic): a bead's surface is inferred from its
+# title — a leading `crate:` / `crate(...)` / `[tag]` token, or any `sparq-<crate>` mention,
+# matched against the actual crate list under crates/. Beads with no recognised surface are
+# bucketed under "(unscoped)".
+#
+# Contention: a surface is "in flight" if an OPEN PR's head branch or a local worktree's
+# branch name contains the surface token. This is heuristic (branch names are free-form) and
+# advisory — a flag is a prompt to check, not a hard block.
+#
+# Run:
+#   scripts/refill-candidates.sh                    # the candidate briefing
+#   scripts/refill-candidates.sh --dry-run-self-test   # hermetic self-test (no bd/gh/git)
+set -euo pipefail
+
+PROG="refill-candidates"
+log()  { printf '[%s] %s\n' "$PROG" "$*" >&2; }
+die()  { printf '[%s] ERROR: %s\n' "$PROG" "$*" >&2; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# --- surface inference (pure-text; the hermetic, testable core) ------------------------
+# Given a bead TITLE on $1 and a space-separated list of known crate short-names on $2,
+# echo the inferred surface token (e.g. "sparq-core", or a bracket/prefix tag), else "".
+# Precedence: explicit sparq-<crate> mention > leading prefix:/[tag] > "".
+infer_surface() {
+  local title="$1" crates="$2" c tag
+  # 1. an explicit sparq-<crate> mention anywhere in the title.
+  for c in $crates; do
+    case "$title" in
+      *"$c"*) printf '%s\n' "$c"; return 0 ;;
+    esac
+  done
+  # 2. a leading bracket tag: "[cert] ...", "[epic] ..." -> "cert" / "epic".
+  case "$title" in
+    \[*\]*)
+      tag="${title#\[}"; tag="${tag%%\]*}"
+      printf '%s\n' "$tag"; return 0 ;;
+  esac
+  # 3. a leading "prefix: ..." or "prefix(scope): ..." token (e.g. "site:", "SBOM:").
+  case "$title" in
+    *:*)
+      tag="${title%%:*}"
+      # strip a "(scope)" suffix and lowercase; reject if it looks like prose (has spaces).
+      tag="${tag%%(*}"
+      case "$tag" in
+        *' '*) ;;                       # has a space -> it's prose, not a prefix tag.
+        *) printf '%s\n' "$tag"; return 0 ;;
+      esac ;;
+  esac
+  printf '\n'
+}
+
+# --- self-test (no external calls) -----------------------------------------------------
+self_test() {
+  local fails=0 got CR
+  CR="sparq-core sparq-server sparq-hdt sparq-zk sparq-mpc"
+  _check() {
+    if [ "$2" = "$3" ]; then printf '  ok   %s\n' "$1"
+    else printf '  FAIL %s\n       got:  %q\n       want: %q\n' "$1" "$2" "$3"; fails=$((fails + 1)); fi
+  }
+  log "running --dry-run self-test (hermetic; no bd/gh/git calls)"
+
+  got="$(infer_surface 'fix(sparq-core): dict spill (sq-glw2)' "$CR")"
+  _check "explicit crate mention"                  "$got" "sparq-core"
+
+  got="$(infer_surface '[cert][cryptoreview] external audit' "$CR")"
+  _check "leading bracket tag"                     "$got" "cert"
+
+  got="$(infer_surface 'site: browser smoke test for ZK' "$CR")"
+  _check "leading prefix: tag"                     "$got" "site"
+
+  got="$(infer_surface 'SBOM: dedicated npm SBOM (GS-3)' "$CR")"
+  _check "uppercase prefix tag"                    "$got" "SBOM"
+
+  got="$(infer_surface 'cert(sbom): purl canonicality' "$CR")"
+  _check "prefix(scope): tag strips scope"         "$got" "cert"
+
+  got="$(infer_surface 'Federation TPF follow-ups: brTPF' "$CR")"
+  _check "prose-before-colon => unscoped"          "$got" ""
+
+  got="$(infer_surface 'server hardening for sparq-server limits' "$CR")"
+  _check "crate mention wins over prose"           "$got" "sparq-server"
+
+  echo
+  if [ "$fails" -eq 0 ]; then log "self-test PASSED"; return 0; fi
+  die "self-test FAILED ($fails check(s))"
+}
+
+# --- arg parsing -----------------------------------------------------------------------
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run-self-test) self_test; exit 0 ;;
+    -h|--help)           sed -n '2,30p' "$0"; exit 0 ;;
+    *)                   die "unknown argument: $arg (try --dry-run-self-test, --help)" ;;
+  esac
+done
+
+command -v bd >/dev/null 2>&1 || die "bd not found (this script lists 'bd ready' beads)"
+
+# Known crate short-names (from crates/), longest-first so e.g. sparq-zk-compose is tried
+# before sparq-zk (a substring match would otherwise mis-bucket it).
+CRATES=""
+if [ -d "$ROOT/crates" ]; then
+  for d in "$ROOT"/crates/*/; do
+    [ -d "$d" ] || continue
+    name="${d%/}"; name="${name##*/}"
+    CRATES+="$name"$'\n'
+  done
+  CRATES="$(printf '%s' "$CRATES" | awk 'NF { print length, $0 }' | sort -rn | cut -d' ' -f2- | tr '\n' ' ')"
+fi
+[ -n "$CRATES" ] || log "WARNING: no crates/ dir found — surface inference will fall back to title tags only."
+
+# --- 1. gather contention signals: open-PR branches + worktree branches ----------------
+CONTENTION_BRANCHES=""
+if command -v gh >/dev/null 2>&1; then
+  CONTENTION_BRANCHES="$(gh pr list --state open --limit 200 --json headRefName \
+    -q '.[].headRefName' 2>/dev/null || true)"
+else
+  log "gh not found — open-PR contention flags will be omitted (worktree branches still used)."
+fi
+WT_BRANCHES="$(git -C "$ROOT" worktree list --porcelain 2>/dev/null \
+  | sed -n 's/^branch refs\/heads\///p' || true)"
+ALL_BRANCHES="$(printf '%s\n%s\n' "$CONTENTION_BRANCHES" "$WT_BRANCHES" | sed '/^$/d' | sort -u)"
+
+# Is surface $1 contended (its token appears in any open-PR/worktree branch name)?
+is_contended() {
+  local surface="$1"
+  [ -n "$surface" ] || return 1
+  printf '%s\n' "$ALL_BRANCHES" | grep -qiF -- "$surface"
+}
+
+# --- 2. read bd ready and group by inferred surface ------------------------------------
+READY_JSON="$(bd ready --json 2>/dev/null)" || die "bd ready --json failed"
+
+# Emit "surface<TAB>id<TAB>P<priority><TAB>title" lines via python (robust JSON parse).
+ROWS="$(printf '%s' "$READY_JSON" | python3 -c '
+import json,sys
+data=json.load(sys.stdin)
+for it in data:
+    print("\t".join([
+        it.get("id",""),
+        str(it.get("priority","")),
+        (it.get("title","") or "").replace("\t"," ").replace("\n"," "),
+    ]))
+' 2>/dev/null)" || die "could not parse bd ready --json"
+
+[ -n "$ROWS" ] || { log "no ready beads — nothing to refill."; exit 0; }
+
+# Build a temp grouping: surface => list of "id Pn title".
+declare -A GROUP
+declare -A GROUP_COUNT
+total=0
+while IFS=$'\t' read -r id prio title; do
+  [ -n "$id" ] || continue
+  surface="$(infer_surface "$title" "$CRATES")"
+  [ -n "$surface" ] || surface="(unscoped)"
+  GROUP["$surface"]+="    $id  P$prio  $title"$'\n'
+  GROUP_COUNT["$surface"]=$(( ${GROUP_COUNT["$surface"]:-0} + 1 ))
+  total=$((total + 1))
+done <<< "$ROWS"
+
+# --- 3. print the briefing (surfaces sorted; contended ones flagged) -------------------
+echo "refill-candidates — $total ready bead(s), grouped by inferred surface (READ-ONLY, advisory)"
+echo "  contention sources: $(printf '%s\n' "$ALL_BRANCHES" | sed '/^$/d' | wc -l | tr -d ' ') open-PR/worktree branch name(s)"
+echo
+
+# List free (uncontended) surfaces first — those are the safest refill targets.
+for pass in free contended; do
+  for surface in $(printf '%s\n' "${!GROUP[@]}" | sort); do
+    if is_contended "$surface"; then state="contended"; else state="free"; fi
+    [ "$state" = "$pass" ] || continue
+    if [ "$state" = "contended" ]; then
+      printf '== %s  (%d ready)  [CONTENDED: open PR/worktree touches this surface — confirm before dispatch] ==\n' \
+        "$surface" "${GROUP_COUNT[$surface]}"
+    else
+      printf '== %s  (%d ready)  [free] ==\n' "$surface" "${GROUP_COUNT[$surface]}"
+    fi
+    printf '%s' "${GROUP[$surface]}"
+    echo
+  done
+done
+
+echo "NOTE: advisory only. The orchestrator chooses WHICH beads to dispatch (judgment); this"
+echo "      script does not dispatch, close, or mutate anything (design §1.1 T5)."


### PR DESCRIPTION
> 🤖 SPARQ agent

Stands up the three **LOW-RISK** orchestration-automation scripts from `research/orchestration-automation-design.md` (PR #374, now on `main`), as pure shell tools **invoked manually for now**. No auto-running mutating hooks or monitors are wired — that is the design doc's documented phased follow-up (Beads B/D/E + H in §5).

Each script is `bash -n` clean, `shellcheck` clean, and ships a hermetic `--dry-run-self-test` (no network).

### (A) `scripts/bead-close-on-merge.sh <pr> [--apply]` — Phase A
Closes the PR's mapped bead **only after verifying the merge against the API** — `gh pr view --json mergedAt,state,title,closingIssuesReferences` must show `mergedAt != null` (never a parsed log/monitor line). Resolves the bead id from an `sq-XXXX` token in the PR title or a linked issue's title/body. **Default `--dry-run`** (prints what it *would* close); acts only with `--apply`; idempotent (already-closed bead ⇒ no-op). The verified-merge guard makes the dangerous case — closing a bead for a PR that did **not** merge — impossible (design §6).

### (C) `scripts/orphan-check-bench.sh [--apply] [--region r]` — Phase C
Lists running/pending EC2 instances carrying the **exact** tag `purpose=sparq-bench` (allow-list semantics, not deny-list) and greps the local process table for in-flight `gather-*` launchers. **Default `--dry-run`** (prints orphans only); `--apply` terminates **only** tag-matched instances and **never** prod (`i-090531b4ede8f2d3f`) or dev (`i-00f76802f345b6b77`) — a hard, unconditional exclusion list asserted by the self-test. Graceful no-op when `aws` is unconfigured.

### (F) `scripts/refill-candidates.sh` — Phase F
**Read-only, advisory only.** Lists `bd ready` beads grouped by inferred crate/surface and flags surfaces that already have an open PR / in-flight worktree (contention). It is the **substrate** for the refill decision (loop step 3), **not** the decision — it never dispatches, closes, or mutates anything.

### Docs
New `AGENTS.md` subsection ("Orchestration automation scripts") under the maintenance loop documents all three, the **manual-invoke-now / hooks-deferred** posture, and cites PR #374's phased plan + guardrails (§1.3 / §5 / §6).

### Gates (all run locally)
- `bash -n`: clean on all three
- `shellcheck`: clean on all three
- `--dry-run-self-test`: PASS on all three (bead-id extraction + verified-merge predicate; prod/dev hard-exclusion invariant; surface inference)
- Live dry-runs exercised: bead-close on merged PRs #374/#367 (verified-merge + token resolution + idempotent no-op), orphan-check (process scan + graceful aws no-op), refill-candidates (100 ready beads grouped + contention flagged)
- `check-privacy-claims.sh`: OK; `typos`: OK

### Deferred (documented, not built here)
- The `SessionStart` orphan-check hook, the merge-watcher monitor wired to (A), and the `PostToolUse` bead-export hook (design §5 Beads B/D/E/H) — to be added only after these scripts are proven in manual use.
- `refill-candidates` surface inference is heuristic (case-sensitive grouping over free-form branch names) and advisory by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)