### PR TITLE
feat(site): ZK browser-prover perf — proof-size relabel + evm-flavor (-43%, still ZK) + coi-serviceworker multithreading (~4x)

### DIFF
--- a/site/public/coi-serviceworker.js
+++ b/site/public/coi-serviceworker.js
@@ -1,0 +1,176 @@
+/*! coi-serviceworker v0.1.7 - Guido Zuidhof and contributors, licensed under MIT */
+// [OPUS-4.8] Vendored from https://github.com/gzuidhof/coi-serviceworker (MIT).
+//
+// WHY: GitHub Pages cannot set the COOP/COEP response headers that browsers require
+// before they expose `SharedArrayBuffer` / set `window.crossOriginIsolated = true`.
+// Without cross-origin isolation, `@aztec/bb.js` cannot spin worker threads, so the
+// in-tab UltraHonk prover runs single-threaded (see src/lib/zk-prover.ts:maxThreads).
+//
+// This self-registering service worker re-serves every same-origin response with the
+// isolation headers synthesised, so `crossOriginIsolated` becomes true on plain static
+// hosting and bb.js can multithread (~4x faster proving on a multicore client).
+//
+// We use COEP `credentialless` (not `require-corp`) so cross-origin subresources that
+// lack a CORP/CORS header still load — this keeps the rest of the static site working
+// under isolation. The first load registers the SW and reloads once; thereafter the
+// page is isolated. This changes NOTHING about what the ZK proof proves or its
+// zero-knowledge property — it only unlocks the worker threads bb.js already supports.
+//
+// Served from /public, so under the `/sparq` basePath it lives at
+// `/sparq/coi-serviceworker.js` with scope `/sparq/`, covering every app route.
+
+let coepCredentialless = false;
+if (typeof window === 'undefined') {
+    self.addEventListener("install", () => self.skipWaiting());
+    self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+
+    self.addEventListener("message", (ev) => {
+        if (!ev.data) {
+            return;
+        } else if (ev.data.type === "deregister") {
+            self.registration
+                .unregister()
+                .then(() => {
+                    return self.clients.matchAll();
+                })
+                .then((clients) => {
+                    clients.forEach((client) => client.navigate(client.url));
+                });
+        } else if (ev.data.type === "coepCredentialless") {
+            coepCredentialless = ev.data.value;
+        }
+    });
+
+    self.addEventListener("fetch", function (event) {
+        const r = event.request;
+        if (r.cache === "only-if-cached" && r.mode !== "same-origin") {
+            return;
+        }
+
+        const request = (coepCredentialless && r.mode === "no-cors")
+            ? new Request(r, {
+                credentials: "omit",
+            })
+            : r;
+        event.respondWith(
+            fetch(request)
+                .then((response) => {
+                    if (response.status === 0) {
+                        return response;
+                    }
+
+                    const newHeaders = new Headers(response.headers);
+                    newHeaders.set("Cross-Origin-Embedder-Policy",
+                        coepCredentialless ? "credentialless" : "require-corp"
+                    );
+                    if (!coepCredentialless) {
+                        newHeaders.set("Cross-Origin-Resource-Policy", "cross-origin");
+                    }
+                    newHeaders.set("Cross-Origin-Opener-Policy", "same-origin");
+
+                    return new Response(response.body, {
+                        status: response.status,
+                        statusText: response.statusText,
+                        headers: newHeaders,
+                    });
+                })
+                .catch((e) => console.error(e))
+        );
+    });
+
+} else {
+    (() => {
+        const reloadedBySelf = window.sessionStorage.getItem("coiReloadedBySelf");
+        window.sessionStorage.removeItem("coiReloadedBySelf");
+        const coepDegrading = (reloadedBySelf == "coepdegrade");
+
+        // You can customize the behavior of this script through a global `coi` variable.
+        const coi = {
+            shouldRegister: () => !reloadedBySelf,
+            shouldDeregister: () => false,
+            coepCredentialless: () => true,
+            coepDegrade: () => true,
+            doReload: () => window.location.reload(),
+            quiet: false,
+            ...window.coi
+        };
+
+        const n = navigator;
+        const controlling = n.serviceWorker && n.serviceWorker.controller;
+
+        // Record the failure if the page is served by serviceWorker.
+        if (controlling && !window.crossOriginIsolated) {
+            window.sessionStorage.setItem("coiCoepHasFailed", "true");
+        }
+        const coepHasFailed = window.sessionStorage.getItem("coiCoepHasFailed");
+
+        if (controlling) {
+            // Reload only on the first failure.
+            const reloadToDegrade = coi.coepDegrade() && !(
+                coepDegrading || window.crossOriginIsolated
+            );
+            n.serviceWorker.controller.postMessage({
+                type: "coepCredentialless",
+                value: (reloadToDegrade || coepHasFailed && coi.coepDegrade())
+                    ? false
+                    : coi.coepCredentialless(),
+            });
+            if (reloadToDegrade) {
+                !coi.quiet && console.log("Reloading page to degrade COEP.");
+                window.sessionStorage.setItem("coiReloadedBySelf", "coepdegrade");
+                coi.doReload("coepdegrade");
+            }
+
+            if (coi.shouldDeregister()) {
+                n.serviceWorker.controller.postMessage({ type: "deregister" });
+            }
+        }
+
+        // If we're already coi: do nothing. Perhaps it's due to this script doing its job, or COOP/COEP are
+        // already set from the origin server. Also if the browser has no notion of crossOriginIsolated, just give up here.
+        if (window.crossOriginIsolated !== false || !coi.shouldRegister()) return;
+
+        if (!window.isSecureContext) {
+            !coi.quiet && console.log("COOP/COEP Service Worker not registered, a secure context is required.");
+            return;
+        }
+
+        // In some environments (e.g. Firefox private mode) this won't be available
+        if (!n.serviceWorker) {
+            !coi.quiet && console.error("COOP/COEP Service Worker not registered, perhaps due to private mode.");
+            return;
+        }
+
+        // Register the service worker from its own location so the scope matches the
+        // basePath (e.g. /sparq/coi-serviceworker.js → scope /sparq/). [OPUS-4.8]
+        // `document.currentScript.src` is the upstream path and resolves to the
+        // basePath-prefixed URL when the browser runs this external script. Next.js
+        // loads `beforeInteractive` scripts via its own bootstrap (`__next_s`); should
+        // `currentScript` ever be null there, fall back to the basePath-prefixed
+        // absolute path so the scope is still `/sparq/` (mirrors next.config basePath).
+        const swPath =
+            (document.currentScript && document.currentScript.src) ||
+            (window.coiServiceWorkerPath || "/sparq/coi-serviceworker.js");
+        n.serviceWorker.register(swPath).then(
+            (registration) => {
+                !coi.quiet && console.log("COOP/COEP Service Worker registered", registration.scope);
+
+                registration.addEventListener("updatefound", () => {
+                    !coi.quiet && console.log("Reloading page to make use of updated COOP/COEP Service Worker.");
+                    window.sessionStorage.setItem("coiReloadedBySelf", "updatefound");
+                    coi.doReload();
+                });
+
+                // If the registration is active, but it's not controlling the page
+                if (registration.active && !n.serviceWorker.controller) {
+                    !coi.quiet && console.log("Reloading page to make use of COOP/COEP Service Worker.");
+                    window.sessionStorage.setItem("coiReloadedBySelf", "notcontrolling");
+                    coi.doReload();
+                }
+            },
+            (err) => {
+                !coi.quiet && console.error("COOP/COEP Service Worker failed to register:", err);
+            }
+        );
+    })();
+}

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import { Toaster } from "sonner";
 
 import "./globals.css";
@@ -35,6 +36,19 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* [OPUS-4.8] coi-serviceworker shim — synthesises COOP/COEP so
+            `window.crossOriginIsolated` becomes true on GitHub Pages (which cannot
+            set those headers itself). That unlocks SharedArrayBuffer, so @aztec/bb.js
+            can spin worker threads and the in-tab ZK prover multithreads (~4x). Loaded
+            beforeInteractive with an absolute, basePath-prefixed src so the service
+            worker registers from /sparq/coi-serviceworker.js with scope /sparq/. It
+            changes only thread count — never what any proof proves or its ZK property. */}
+        <Script
+          src="/sparq/coi-serviceworker.js"
+          strategy="beforeInteractive"
+        />
+      </head>
       <body className={`${inter.variable} font-sans antialiased`}>
         <ThemeProvider
           attribute="class"

--- a/site/src/components/zk-car-hire.tsx
+++ b/site/src/components/zk-car-hire.tsx
@@ -383,7 +383,13 @@ function VerdictPanel({ phase, age }: { phase: Phase; age: number }) {
 
         <div className="grid gap-3 sm:grid-cols-2">
           <Stat label="Proof verified in your tab" value={r.verified ? "yes" : "no"} />
-          <Stat label="Proof size (fields)" value={r.proofByteLength.toString()} />
+          {/* [OPUS-4.8] proofByteLength is BYTES (= fields × 32). Surface KB honestly
+              and derive the field count, instead of mislabelling raw bytes as "fields". */}
+          <Stat
+            label="Proof size"
+            value={`${(r.proofByteLength / 1024).toFixed(1)} KB`}
+            sub={`${Math.round(r.proofByteLength / 32)} fields`}
+          />
           <Stat label="Prove time" value={`${r.proveMs.toFixed(0)} ms`} sub="non-canonical" />
           <Stat label="Verify time" value={`${r.verifyMs.toFixed(0)} ms`} sub="non-canonical" />
         </div>
@@ -529,6 +535,22 @@ function HonestyPanel() {
           verified by <code className="font-mono">@aztec/bb.js</code> in your
           browser. The exact age is the private witness and never appears in the
           public inputs.
+        </p>
+        <p>
+          <strong className="text-foreground">On proof size and speed.</strong>{" "}
+          The proof is <strong>inherently KB-scale</strong>: UltraHonk is a
+          transparent, no-trusted-setup proof system whose proofs are kilobytes of
+          field elements — not the ~200&nbsp;byte single proof of a Groth16 SNARK, and
+          there is no compact mode (a sub-KB single proof would need recursive
+          aggregation, which is out of scope here). This page uses the keccak-oracle
+          flavour (<code className="font-mono">verifierTarget:&nbsp;&apos;evm&apos;</code>),
+          which is ~43% smaller than the default while staying{" "}
+          <strong>fully zero-knowledge</strong>. As a hard guardrail, the demo never
+          uses any <code className="font-mono">*-no-zk</code> flavour
+          (<code className="font-mono">disableZk:&nbsp;true</code>): those strip the
+          ZK masking and would make the private age recoverable in principle. On plain
+          GitHub Pages a service-worker shim is the only lever that unlocks
+          multithreaded proving (timings are non-canonical and host-dependent).
         </p>
         <p>
           <strong className="text-foreground">

--- a/site/src/lib/zk-prover.ts
+++ b/site/src/lib/zk-prover.ts
@@ -65,6 +65,16 @@ interface NoirModule {
     execute(inputs: Record<string, unknown>): Promise<{ witness: Uint8Array }>;
   };
 }
+/** Subset of `@aztec/bb.js`'s `UltraHonkBackendOptions` we use. We pass
+ *  `verifierTarget: 'evm'` (the keccak-oracle flavour) to BOTH prove and verify —
+ *  it leaves `disableZk` at its default `false`, so the proof stays FULLY
+ *  zero-knowledge (age-hiding), while shrinking the wire proof ~43% (14656 → 8384 B).
+ *  We NEVER pass any `*-no-zk` flavour: those set `disableZk:true` and strip the
+ *  ZK masking, which would make the private age recoverable in principle. */
+type VerifierTarget = "evm" | "noir-recursive" | "starknet";
+interface BbBackendOptions {
+  verifierTarget?: VerifierTarget;
+}
 interface BbModule {
   Barretenberg: { new: (opts: { threads: number }) => Promise<unknown> };
   UltraHonkBackend: new (
@@ -73,13 +83,34 @@ interface BbModule {
   ) => {
     generateProof(
       witness: Uint8Array,
+      options?: BbBackendOptions,
     ): Promise<{ proof: Uint8Array; publicInputs: string[] }>;
-    verifyProof(proof: {
-      proof: Uint8Array;
-      publicInputs: string[];
-    }): Promise<boolean>;
+    verifyProof(
+      proof: {
+        proof: Uint8Array;
+        publicInputs: string[];
+      },
+      options?: BbBackendOptions,
+    ): Promise<boolean>;
   };
 }
+
+/**
+ * [OPUS-4.8] The UltraHonk proving/verifying flavour. `verifierTarget: 'evm'` selects
+ * the keccak transcript oracle and yields a ~43% smaller proof (8384 B vs the default
+ * poseidon2 flavour's 14656 B) at no measured time cost, while keeping `disableZk`
+ * false — i.e. the proof is STILL zero-knowledge and the private age is still hidden
+ * (verified by a Node re-measurement: two proofs of the same witness differ, and the
+ * age digits never appear in the 5 public inputs).
+ *
+ * Prove and verify MUST be passed the SAME options or the in-tab self-verify fails.
+ *
+ * ⚠️ `@aztec/bb.js` is pinned to a NIGHTLY (see package.json). The `verifierTarget`
+ * option surface can shift between nightlies — RE-TEST this flavour (size still
+ * ~8384 B, `verified === true`, proofs still randomised, age still not public) on ANY
+ * bb.js version bump before trusting it. Never substitute a `*-no-zk` flavour.
+ */
+const PROOF_OPTIONS: BbBackendOptions = { verifierTarget: "evm" };
 
 function basePath(): string {
   return process.env.NEXT_PUBLIC_BASE_PATH ?? "/sparq";
@@ -193,11 +224,13 @@ export async function proveAgeEligibility(age: number): Promise<ProofResult> {
   const { witness } = await noir.execute(inputs);
 
   const t0 = performance.now();
-  const proof = await backend.generateProof(witness);
+  const proof = await backend.generateProof(witness, PROOF_OPTIONS);
   const proveMs = performance.now() - t0;
 
   const t1 = performance.now();
-  const verified = await backend.verifyProof(proof);
+  // Verify with the SAME options as prove (the keccak-oracle flavour) — a mismatch
+  // would make the in-tab self-verify reject a perfectly valid proof.
+  const verified = await backend.verifyProof(proof, PROOF_OPTIONS);
   const verifyMs = performance.now() - t1;
 
   return {


### PR DESCRIPTION
> 🤖 SPARQ agent

Three proof-preserving fixes for the in-browser ZK age-gate prover, from `research/zk-browser-perf-assessment.md` (#377) + an empirical Node measurement. All are **perf / config / presentation** only — the zero-knowledge (age-hiding) property and the not-externally-audited caveat (`sq-qhy4`) are preserved. No `crates/` changes; site lane only.

### Fix 1 — honest proof-size label (`zk-car-hire.tsx`)
`proofByteLength` is **bytes** (= fields × 32) but was shown under "Proof size (fields)", so a 14.6 KB proof read as `14656` "fields". Now renders KB with the derived field count as a sub-label (e.g. `8.2 KB · 262 fields`). Touches no proving/verifying code.

### Fix 2 — `verifierTarget: 'evm'` for a ~43% smaller, STILL-ZK proof (`zk-prover.ts`)
Pass `{ verifierTarget: 'evm' }` (keccak oracle, `disableZk` stays `false` → full ZK) to **both** `generateProof` and `verifyProof`. Cuts the wire proof **14656 → 8384 B (~43%)** at no measured time cost.

**ZK preserved — verified by a throwaway Node measurement** (NOT committed) on the same ACIR + bb.js path:
- (a) evm proof = **8384 bytes** (262 fields), 5 public inputs; default flavour = 14656 B for contrast
- (b) `verified === true` with the same options
- (c) two proofs of the **same** witness have **different sha256** (`926ed224…` vs `72f2f438…`) → ZK randomisation/masking present; both verify
- (d) public inputs are `[challenge=1, operand_enc, op=3, bound=0x19=25, expected=1]` — the private age digits (51/48) and age (30) are **NOT** present

A code comment warns the bb.js **nightly** `verifierTarget` API must be re-tested on any bump; `*-no-zk` flavours are forbidden (they strip age-hiding).

### Fix 3 — `coi-serviceworker` for cross-origin isolation → multithreading (~4x)
GitHub Pages can't set COOP/COEP, so `window.crossOriginIsolated` is false and bb.js runs single-threaded. Vendored the MIT `coi-serviceworker` shim to `site/public/`, registered `beforeInteractive` from `/sparq/coi-serviceworker.js` (scope `/sparq/`) via `next/script`. Uses COEP **credentialless** so same-origin WASM + assets still load under isolation. Static-export verified: SW present in `out/`, preload + `__next_s` injection with the basePath-prefixed src, build green. The shim hardens SW-path resolution (`currentScript.src` with a basePath fallback).

### Honesty docs
`HonestyPanel` now states the proof is **inherently KB-scale UltraHonk** (not Groth16 ~200 B; no compact mode) so the size is expected, and that any `*-no-zk` flavour is forbidden (strips age-hiding). All existing not-externally-audited caveats kept.

### Gates
- `npm install` + `npm run build` (static export) green end-to-end — all 41 routes exported (`/papers`, `/try`, `/benchmarks`, `/showcase/*`, `/surface/*` unaffected)
- `tsc --noEmit` clean; `npm run lint` clean; `typos` clean on changed files
- Working tree clean (generated `benchmarks.generated.json` and `package-lock.json` rewrites from the build were restored; the throwaway Node measurement was deleted)

Auto-merge intentionally **not** armed — orchestrator reviews + arms.