### PR TITLE
feat(sparq-server): brTPF bind-restricted fragments + Hydra paging (sq-dxhb)

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -161,6 +161,28 @@ jobs:
             crate: sparq-server
             features: audit-log,federation-descriptors,service,time-travel,geo,test-seams
             test: true
+          # [OPUS-4.8] sq-dxhb: the Triple Pattern Fragments / Linked Data Fragments READ-ONLY
+          # source endpoint (`GET /tpf`). The handler + the Hydra paging vocabulary + the
+          # `tpf::evaluate` pager + the in-module `tpf` unit tests are all `#[cfg(feature =
+          # "tpf")]`, so the DEFAULT build never compiled, clippy'd or tested this code. This
+          # leg builds it, runs `clippy --all-targets -D warnings` with the feature ON (the real
+          # gate), and runs the crate's tests — which now include the gated `tpf` page/Hydra
+          # suites. `tpf` pulls `server`, so the full async server compiles under it.
+          - name: sparq-server (tpf)
+            crate: sparq-server
+            features: tpf
+            test: true
+          # [OPUS-4.8] sq-dxhb: bind-restricted Triple Pattern Fragments (brTPF). `brtpf` implies
+          # `tpf` and additionally compiles `tpf::evaluate_brtpf`, the `values`/POST bindings
+          # parser, the `merge_term`/`merge_predicate` semi-join pushdown and the extra
+          # `hydra:mapping` control — all `#[cfg(feature = "brtpf")]`. The in-module `brtpf` test
+          # mod (binding restriction, dedup union, empty-bindings==plain-TPF, page partitioning)
+          # is gated the same way, so it only runs when this feature is on. This leg is what
+          # actually compiles + clippies + tests the brTPF + Hydra-paging code the PR adds.
+          - name: sparq-server (brtpf)
+            crate: sparq-server
+            features: brtpf
+            test: true
           # sparq-vectors: the vec: magic predicates (pulls sparq-engine), and the
           # /v1/embeddings provider request/response shape (serde only, no socket).
           - name: sparq-vectors (vec-predicate, provider)

--- a/crates/sparq-server/Cargo.toml
+++ b/crates/sparq-server/Cargo.toml
@@ -132,6 +132,21 @@ federation-descriptors = ["server", "dep:sparq-introspect"]
 # set `--tpf` / `SPARQ_TPF=1` (`ServerConfig::tpf`), mirroring `federation-descriptors`. Without the
 # feature, zero cost: no route, byte-identical to before.
 tpf = ["server"]
+# [OPUS-4.8] (sq-dxhb, epic sq-3183) `brtpf` (default OFF, implies `tpf`) extends the TPF
+# endpoint to bindings-restricted Triple Pattern Fragments (brTPF — Hartig & Buil-Aranda,
+# ODBASE 2016): a client may attach a SET of solution mappings (a `values` parameter on the
+# GET, or a POST body) so the server returns ONLY the page of pattern matches that are
+# COMPATIBLE with at least one supplied binding — pushing a bind-join's semi-join down to the
+# source so far less data crosses the wire than re-fetching the whole pattern per binding. The
+# fragment advertises the restriction through an extra `hydra:mapping` for the `values`
+# variable, and the `hydra:totalItems` count plus the paging window reflect the
+# bindings-restricted result, NOT the unrestricted pattern. Pure (no new dependency) — the
+# binding compatibility test runs over the same `Graph::pattern` / `store.scan` / `dict.term`
+# API. Without the feature the brTPF parsing + the `values` parameter handling are
+# `#[cfg]`-stripped, so a `tpf`-only build is byte-identical to before (a stray `values`
+# parameter is just an ignored unknown parameter — plain TPF). STILL governed by the same
+# `--tpf` runtime flag (brTPF is the same endpoint, extended).
+brtpf = ["tpf"]
 
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -355,9 +355,20 @@ matrix under "Security posture".
   default; read-only): a paged [Triple Pattern Fragments](https://www.hydra-cg.com/spec/latest/triple-pattern-fragments/)
   / [Linked Data Fragments](http://linkeddatafragments.org/) endpoint at
   `GET /tpf?subject=&predicate=&object=` that lets a TPF client drive a join cheaply against this
-  server. Each page carries Hydra controls (`hydra:totalItems` from the engine's cheap cardinality
-  estimate, `hydra:next`/`hydra:previous` paging, the `hydra:search` template). Content-negotiated
-  RDF (Turtle default). See the SKILL's "Triple Pattern Fragments" section.
+  server. Each page carries the full Hydra `PartialCollectionView` paging vocabulary
+  (`hydra:totalItems` from the engine's cheap cardinality estimate, plus
+  `hydra:first`/`hydra:previous`/`hydra:next`/`hydra:last` — `first`/`last` on every page so a
+  client can jump to either end of the view) and the `hydra:search` template. Content-negotiated
+  RDF (Turtle default). With the additional `brtpf` feature the SAME endpoint also speaks
+  **bind-restricted Triple Pattern Fragments (brTPF — Hartig & Buil-Aranda, ODBASE 2016)**: a
+  client attaches a set of solution mappings (the `values` query parameter, or — for a large set —
+  a `POST` body of one `position=term` mapping per line) and the server returns only the page of
+  matches COMPATIBLE WITH AT LEAST ONE supplied binding, pushing a bind-join's semi-join down to
+  the source so far less data crosses the wire than re-fetching the whole pattern per binding. The
+  fragment advertises the restriction through an extra `hydra:mapping` for the `values` variable,
+  and `hydra:totalItems` reflects the bindings-restricted result (not the unrestricted pattern). A
+  `tpf`-only build is byte-identical to before (a stray `values` parameter is just an ignored
+  unknown parameter — plain TPF). See the SKILL's "Triple Pattern Fragments" section.
 - **Access-audit trails** — opt-in, off by default: `audit-log` (flat `tracing` event per request)
   and `access-audit` (richer typed JSON-Lines records via a pluggable sink — actor / action /
   resource / decision+basis / timestamp / fingerprint, hooked at the real enforcement seam).
@@ -366,7 +377,8 @@ matrix under "Security posture".
 - **Opt-in features** — `time-travel` (`?generation=N` snapshot pinning), `geo` (sparq-geo
   `geof:` functions), `service` (SERVICE federation, default-deny), `federation-descriptors`
   (VoID + Service Description discovery endpoints — see "Federation discovery"), `tpf` (Triple
-  Pattern Fragments / LDF source endpoint — see "Triple Pattern Fragments / LDF source"),
+  Pattern Fragments / LDF source endpoint — see "Triple Pattern Fragments / LDF source"), `brtpf`
+  (implies `tpf`; bind-restricted Triple Pattern Fragments — the `values`/POST bindings extension),
   `audit-log` / `access-audit` (access-audit trails — see "Access-audit trails"), `zlib-ng`
   (native-only faster zlib-ng C backend for `Content-Encoding: gzip` request inflate; off by
   default, pure-Rust `miniz_oxide` otherwise; never in the wasm build).

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -1653,8 +1653,17 @@ pub fn router(state: AppState) -> Router {
     // [OPUS-4.8] sq-bzh1 (epic sq-3183): OPT-IN Triple Pattern Fragments / LDF source endpoint.
     // Compiled only with the `tpf` feature; even then the handler refuses (404) unless the config
     // flag is set. READ-only — a GET (with HEAD) only. See [`crate::tpf`].
-    #[cfg(feature = "tpf")]
+    // [OPUS-4.8] sq-dxhb: with the `brtpf` feature it ALSO accepts POST — a brTPF client posts a
+    // (potentially large) binding set in the body, which would not fit a query string. POST is
+    // still a READ (it returns a fragment; it never mutates the store) and is gated by the same
+    // read auth + flag.
+    #[cfg(all(feature = "tpf", not(feature = "brtpf")))]
     let routes = routes.route("/tpf", get(tpf_endpoint).head(tpf_endpoint));
+    #[cfg(feature = "brtpf")]
+    let routes = routes.route(
+        "/tpf",
+        get(tpf_endpoint).head(tpf_endpoint).post(tpf_endpoint),
+    );
     let routes = routes.with_state(state.clone());
     // The metrics middleware wraps the WHOLE hardened stack so shed requests
     // (429), body-limit rejections (413) and panics (500) are counted with the
@@ -1926,19 +1935,32 @@ async fn tpf_endpoint(
     method: Method,
     headers: HeaderMap,
     RawQuery(raw_query): RawQuery,
+    body: Bytes,
 ) -> Response {
     use crate::tpf::{evaluate, fragment_triples, TriplePattern, DEFAULT_PAGE_SIZE};
 
     if !state.config().tpf {
         return json_error(StatusCode::NOT_FOUND, "not found");
     }
-    if method != Method::GET && method != Method::HEAD {
+    // GET/HEAD always; POST only with brTPF (a binding set too large for a query string).
+    #[cfg(not(feature = "brtpf"))]
+    let method_ok = method == Method::GET || method == Method::HEAD;
+    #[cfg(feature = "brtpf")]
+    let method_ok = matches!(method, Method::GET | Method::HEAD | Method::POST);
+    if !method_ok {
+        #[cfg(not(feature = "brtpf"))]
         return method_not_allowed(&[Method::GET, Method::HEAD]);
+        #[cfg(feature = "brtpf")]
+        return method_not_allowed(&[Method::GET, Method::HEAD, Method::POST]);
     }
+    // A fragment is a READ even via POST (brTPF posts the binding set; it never writes).
     if let Some(resp) = auth_gate(state.config(), &headers, Operation::Read) {
         return resp;
     }
     let head_only = method == Method::HEAD;
+    // The body is unused without brTPF (GET/HEAD carry none); silence the warning.
+    #[cfg(not(feature = "brtpf"))]
+    let _ = &body;
 
     let params = parse_form(raw_query.as_deref().unwrap_or(""));
     let subject = params.get("subject").map(String::as_str);
@@ -1969,10 +1991,47 @@ async fn tpf_endpoint(
 
     let base = tpf_base(&headers);
     let dataset_url = format!("{base}/tpf");
+
+    // [OPUS-4.8] sq-dxhb: the brTPF binding set. The mappings come from the `values` query
+    // parameter (GET) or — preferred for a large set — the request BODY (POST). An empty / absent
+    // payload is the plain-TPF case (no restriction). A malformed payload is a 400.
+    #[cfg(feature = "brtpf")]
+    let bindings = {
+        // POST body if non-empty, else the `values` query parameter.
+        let raw_values: std::borrow::Cow<'_, str> = if !body.is_empty() {
+            String::from_utf8_lossy(&body)
+        } else {
+            std::borrow::Cow::Borrowed(params.get("values").map(String::as_str).unwrap_or(""))
+        };
+        match crate::tpf::parse_bindings(&raw_values) {
+            Ok(b) => b,
+            Err(e) => {
+                return sanitized_error(
+                    StatusCode::BAD_REQUEST,
+                    "brtpf-bindings-parse",
+                    "malformed brTPF binding set",
+                    &e.to_string(),
+                )
+            }
+        }
+    };
+
+    // The template advertises the brTPF `{values}` control only when the feature is compiled.
+    #[cfg(feature = "brtpf")]
+    let template = format!("{base}/tpf{{?subject,predicate,object,values}}");
+    #[cfg(not(feature = "brtpf"))]
     let template = format!("{base}/tpf{{?subject,predicate,object}}");
 
-    // Pin the current generation; evaluate against its immutable snapshot.
+    // Pin the current generation; evaluate against its immutable snapshot. With a non-empty
+    // brTPF binding set the fragment is the bindings-RESTRICTED result; otherwise it is plain TPF.
     let pin = state.current();
+    #[cfg(feature = "brtpf")]
+    let frag = if bindings.is_empty() {
+        evaluate(pin.snapshot(), &pattern, page, page_size)
+    } else {
+        crate::tpf::evaluate_brtpf(pin.snapshot(), &pattern, &bindings, page, page_size)
+    };
+    #[cfg(not(feature = "brtpf"))]
     let frag = evaluate(pin.snapshot(), &pattern, page, page_size);
 
     let fragment_url = tpf_page_url(&base, subject, predicate, object, page);
@@ -1982,6 +2041,10 @@ async fn tpf_endpoint(
     let prev_url = frag
         .has_previous()
         .then(|| tpf_page_url(&base, subject, predicate, object, page - 1));
+    // [OPUS-4.8] sq-dxhb: the fuller Hydra paging vocabulary — hydra:first (always page 0) and
+    // hydra:last (the page holding the final match). Emitted on every page.
+    let first_url = tpf_page_url(&base, subject, predicate, object, 0);
+    let last_url = tpf_page_url(&base, subject, predicate, object, frag.last_page());
 
     let triples = fragment_triples(
         &frag,
@@ -1990,6 +2053,8 @@ async fn tpf_endpoint(
         &template,
         next_url.as_deref(),
         prev_url.as_deref(),
+        Some(&first_url),
+        Some(&last_url),
     );
 
     let fmt = negotiate_tpf(headers.get(header::ACCEPT).and_then(|v| v.to_str().ok()));

--- a/crates/sparq-server/src/tpf.rs
+++ b/crates/sparq-server/src/tpf.rs
@@ -87,6 +87,14 @@ const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 /// `xsd:integer` — the datatype of the count / page-size literals.
 const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
 
+/// [OPUS-4.8] sq-dxhb: the brTPF `values` control property — the Hydra `hydra:property` the
+/// `{values}` template variable maps to. brTPF (Hartig & Buil-Aranda, ODBASE 2016) has no term
+/// in a standardised vocabulary for "the attached solution-mapping set", so we mint one under a
+/// sparq namespace; a client reads it from the `hydra:mapping` to learn the dataset accepts a
+/// bindings restriction. Compiled only with the `brtpf` feature.
+#[cfg(feature = "brtpf")]
+const BRTPF_VALUES_PROPERTY: &str = "https://sparq.dev/ns/brtpf#values";
+
 /// A parsed triple pattern: each position is `Some(term)` when the request bound it, or `None`
 /// (a variable). The predicate is a [`NamedNode`] (a predicate is always an IRI), matching the
 /// shape [`Graph::pattern`] wants.
@@ -187,6 +195,20 @@ impl Fragment {
     pub fn has_previous(&self) -> bool {
         self.page > 0
     }
+
+    /// The (zero-based) index of the LAST page of this result — drives `hydra:last`. With
+    /// `n = total_estimate` matches at `page_size` per page there are `ceil(n / page_size)`
+    /// pages, so the last index is `ceil(n / page_size) - 1`, or `0` when there are no matches
+    /// (a single empty page IS the last page — there is always a page 0). Keyed on the same
+    /// ESTIMATE we advertise as `hydra:totalItems`, so `last` is consistent with `next` and the
+    /// reported count.
+    pub fn last_page(&self) -> usize {
+        if self.total_estimate == 0 {
+            0
+        } else {
+            (self.total_estimate - 1) / self.page_size
+        }
+    }
 }
 
 /// Evaluates `pattern` against the pinned `graph` snapshot, returning the [`Fragment`] for
@@ -245,6 +267,197 @@ pub fn evaluate(graph: &Graph, pattern: &TriplePattern, page: usize, page_size: 
     }
 }
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-dxhb: bindings-restricted Triple Pattern Fragments (brTPF).
+// ---------------------------------------------------------------------------
+
+/// [OPUS-4.8] sq-dxhb: one brTPF solution mapping — a PARTIAL binding of the triple-pattern
+/// positions. Each of `subject` / `predicate` / `object` is `Some(term)` when this mapping
+/// constrains that position, or `None` (the mapping says nothing about it). A mapping that
+/// binds a position the PATTERN already bound is allowed (it is simply redundant — the merge
+/// keeps the pattern's term, and a contradictory binding makes that mapping match nothing).
+///
+/// Compiled only with the `brtpf` feature.
+#[cfg(feature = "brtpf")]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Binding {
+    pub subject: Option<Term>,
+    pub predicate: Option<NamedNode>,
+    pub object: Option<Term>,
+}
+
+#[cfg(feature = "brtpf")]
+impl Binding {
+    /// `true` when this mapping constrains no position — the empty mapping μ₀, which is
+    /// compatible with EVERY triple, so it does not restrict the fragment at all.
+    pub fn is_empty(&self) -> bool {
+        self.subject.is_none() && self.predicate.is_none() && self.object.is_none()
+    }
+}
+
+/// [OPUS-4.8] sq-dxhb: parses a brTPF `values` payload into the set of solution mappings.
+///
+/// The wire format is one mapping per line; within a line, whitespace-separated
+/// `position=term` pairs, where `position` is `subject` / `predicate` / `object` (or the short
+/// `s` / `p` / `o`) and `term` is an **N-Triples term** (`<iri>`, `"lit"`, `"lit"@en`,
+/// `"lit"^^<dt>`) — the SAME term grammar as the `subject`/`predicate`/`object` query
+/// parameters, so a client encodes a binding exactly like a bound pattern position. A blank
+/// line is skipped; the empty payload is the empty binding set (no restriction). A line with no
+/// pairs is the empty mapping μ₀ (compatible with everything) and is skipped (it would defeat
+/// the restriction). The predicate position must be an IRI (same rule as the pattern).
+///
+/// Example payload (URL-decoded), restricting `?s foaf:knows ?o` to two `?s` values:
+///
+/// ```text
+/// s=<http://ex/alice>
+/// s=<http://ex/carol>
+/// ```
+#[cfg(feature = "brtpf")]
+pub fn parse_bindings(payload: &str) -> Result<Vec<Binding>, ParseError> {
+    let mut out = Vec::new();
+    for line in payload.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut b = Binding::default();
+        for pair in line.split_whitespace() {
+            let (pos, term) = pair.split_once('=').ok_or_else(|| {
+                ParseError(format!(
+                    "brTPF binding pair must be 'position=term', got '{pair}'"
+                ))
+            })?;
+            match pos {
+                "subject" | "s" => b.subject = parse_term(Some(term), "subject")?,
+                "predicate" | "p" => b.predicate = parse_predicate(Some(term))?,
+                "object" | "o" => b.object = parse_term(Some(term), "object")?,
+                other => {
+                    return Err(ParseError(format!(
+                        "brTPF binding position must be subject/predicate/object (s/p/o), got '{other}'"
+                    )))
+                }
+            }
+        }
+        // A mapping that constrains nothing (an all-blank μ₀) does not restrict the fragment;
+        // drop it rather than let it widen the result to the whole pattern.
+        if !b.is_empty() {
+            out.push(b);
+        }
+    }
+    Ok(out)
+}
+
+/// [OPUS-4.8] sq-dxhb: evaluates `pattern` against `graph` RESTRICTED to the brTPF binding set
+/// `bindings`, returning the [`Fragment`] for (zero-based) `page`.
+///
+/// The bindings-restricted fragment is the set of triples matching `pattern` that are
+/// COMPATIBLE WITH AT LEAST ONE supplied mapping (brTPF's semi-join pushdown). We evaluate it
+/// the way a brTPF server is meant to — NOT by scanning the whole pattern and filtering, but by
+/// MERGING each mapping into the pattern (a mapping's bound positions specialise the matching
+/// pattern's variable positions) and scanning each specialised, more-selective pattern, then
+/// taking the DEDUPLICATED UNION. A mapping whose bound term is absent from the dictionary, or
+/// whose bound position CONTRADICTS the pattern's own bound term, contributes nothing (it can
+/// match no triple) and is skipped without index work.
+///
+/// `total_estimate` is the EXACT size of the deduplicated union (this is a count of the real
+/// restricted result, so we can be exact and still advertise it as `hydra:totalItems`); the
+/// page slices `[page*page_size, …)` of that union in canonical `[s,p,o]` order — the same
+/// deterministic order plain TPF pages in, so the union pages consistently.
+///
+/// An EMPTY binding set means "no restriction" and is delegated to the plain [`evaluate`] — a
+/// brTPF request with zero mappings is exactly a TPF request (the spec's μ₀-only case).
+#[cfg(feature = "brtpf")]
+pub fn evaluate_brtpf(
+    graph: &Graph,
+    pattern: &TriplePattern,
+    bindings: &[Binding],
+    page: usize,
+    page_size: usize,
+) -> Fragment {
+    let page_size = page_size.max(1);
+    if bindings.is_empty() {
+        return evaluate(graph, pattern, page, page_size);
+    }
+
+    // The deduplicated union of every binding's specialised-pattern matches, as canonical
+    // [s,p,o] id triples. A BTreeSet keeps them sorted in the canonical order (so paging is
+    // deterministic) AND deduplicated (two mappings can specialise to overlapping patterns).
+    let mut union: std::collections::BTreeSet<[sparq_core::dict::Id; 3]> =
+        std::collections::BTreeSet::new();
+
+    for b in bindings {
+        // Merge the mapping into the pattern: each position takes the PATTERN's term if it bound
+        // one, else the mapping's term (the mapping only specialises a variable position). If the
+        // mapping and the pattern both bind a position to DIFFERENT terms the merged pattern is
+        // contradictory — `Graph::pattern` returns `None` for an absent term, and we additionally
+        // detect a direct subject/predicate/object clash below, so a contradictory mapping
+        // contributes nothing.
+        let subject = merge_term(pattern.subject.as_ref(), b.subject.as_ref());
+        let predicate = merge_predicate(pattern.predicate.as_ref(), b.predicate.as_ref());
+        let object = merge_term(pattern.object.as_ref(), b.object.as_ref());
+        let (subject, predicate, object) = match (subject, predicate, object) {
+            (Some(s), Some(p), Some(o)) => (s, p, o),
+            // A clash (the mapping bound a position the pattern already bound, to a different
+            // term): this mapping matches nothing. Skip it.
+            _ => continue,
+        };
+
+        let id_pattern = match graph.pattern(subject.as_ref(), predicate.as_ref(), object.as_ref())
+        {
+            Some(p) => p,
+            // A bound term absent from the dictionary: this mapping matches nothing.
+            None => continue,
+        };
+        let scan = graph.store.scan(&id_pattern);
+        for row in scan.rows.iter() {
+            union.insert(scan.to_spo(row));
+        }
+    }
+
+    let total_estimate = union.len();
+    let offset = page.saturating_mul(page_size);
+    let triples = union
+        .into_iter()
+        .skip(offset)
+        .take(page_size)
+        .filter_map(|[s, p, o]| spo_to_triple(graph, s, p, o))
+        .collect();
+
+    Fragment {
+        total_estimate,
+        page,
+        page_size,
+        triples,
+    }
+}
+
+/// [OPUS-4.8] sq-dxhb: merges a pattern position (the term the PATTERN bound, if any) with a
+/// brTPF mapping's term for the same position. Returns `Some(merged)` — `Some(Some(term))` when
+/// a term is fixed, `Some(None)` when the merged position is still a variable — or `None` on a
+/// CLASH (both bound, to different terms ⇒ the mapping is incompatible with the pattern).
+#[cfg(feature = "brtpf")]
+fn merge_term(pat: Option<&Term>, bind: Option<&Term>) -> Option<Option<Term>> {
+    match (pat, bind) {
+        (Some(p), Some(b)) if p == b => Some(Some(p.clone())),
+        (Some(_), Some(_)) => None, // clash
+        (Some(p), None) => Some(Some(p.clone())),
+        (None, Some(b)) => Some(Some(b.clone())),
+        (None, None) => Some(None),
+    }
+}
+
+/// [OPUS-4.8] sq-dxhb: [`merge_term`] for the predicate position (a [`NamedNode`]).
+#[cfg(feature = "brtpf")]
+fn merge_predicate(pat: Option<&NamedNode>, bind: Option<&NamedNode>) -> Option<Option<NamedNode>> {
+    match (pat, bind) {
+        (Some(p), Some(b)) if p == b => Some(Some(p.clone())),
+        (Some(_), Some(_)) => None, // clash
+        (Some(p), None) => Some(Some(p.clone())),
+        (None, Some(b)) => Some(Some(b.clone())),
+        (None, None) => Some(None),
+    }
+}
+
 /// Resolves a canonical `[s, p, o]` id triple to an [`oxrdf::Triple`] via the public
 /// [`Dict::term`](sparq_core::dict::Dict::term). A row whose subject is a literal or whose
 /// predicate is not an IRI cannot form a valid RDF triple (it never arises from a well-formed
@@ -283,9 +496,17 @@ fn spo_to_triple(
 ///   `http://host/tpf{?subject,predicate,object}`).
 /// * `next_url` / `prev_url` are the `hydra:next` / `hydra:previous` page URLs, present only
 ///   when [`Fragment::has_next`] / [`Fragment::has_previous`].
+/// * `first_url` / `last_url` are the `hydra:first` / `hydra:last` page URLs — the fuller Hydra
+///   `PartialCollectionView` paging vocabulary (sq-dxhb). `first` is always page 0; `last` is
+///   [`Fragment::last_page`] (the page holding the final match, or page 0 for an empty result).
+///   Pass `None` to omit either (e.g. on a malformed-Host fallback where the URL would not be a
+///   valid IRI). Unlike `next`/`prev`, these are emitted on EVERY page — a client can jump to
+///   either end of the view from any page, which is exactly what `hydra:first`/`hydra:last` are
+///   for.
 ///
 /// Defensive on IRI validity: the URLs are derived from the request `Host` header (attacker-
 /// controlled), so any that is not a valid IRI is dropped rather than emitted as malformed RDF.
+#[allow(clippy::too_many_arguments)]
 pub fn fragment_triples(
     frag: &Fragment,
     fragment_url: &str,
@@ -293,6 +514,8 @@ pub fn fragment_triples(
     template: &str,
     next_url: Option<&str>,
     prev_url: Option<&str>,
+    first_url: Option<&str>,
+    last_url: Option<&str>,
 ) -> Vec<Triple> {
     let hydra = |local: &str| NamedNode::new(format!("{HYDRA}{local}")).ok();
     let void = |local: &str| NamedNode::new(format!("{VOID}{local}")).ok();
@@ -369,6 +592,19 @@ pub fn fragment_triples(
         }
     }
 
+    // ---- Paging controls: hydra:first / hydra:last (sq-dxhb — the fuller Hydra paging
+    // vocabulary). Emitted on every page (a client can jump to either end from anywhere).
+    if let (Some(first), Some(p)) = (first_url, hydra("first")) {
+        if let Some(f) = iri(first) {
+            emit(frag_subj(), Some(p), Term::NamedNode(f));
+        }
+    }
+    if let (Some(last), Some(p)) = (last_url, hydra("last")) {
+        if let Some(l) = iri(last) {
+            emit(frag_subj(), Some(p), Term::NamedNode(l));
+        }
+    }
+
     // ---- The Hydra search control: how to request ANY pattern from this dataset.
     // dataset hydra:search _:search . _:search hydra:template "…{?subject,predicate,object}" ;
     //   hydra:mapping _:s, _:p, _:o . _:s hydra:variable "subject" ; hydra:property rdf:subject .
@@ -385,7 +621,8 @@ pub fn fragment_triples(
     );
     // The three variable mappings (subject/predicate/object), each binding the template variable
     // to the corresponding rdf: property so a client knows which position it controls.
-    for (var, prop) in [
+    #[allow(unused_mut)]
+    let mut mappings = vec![
         (
             "subject",
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#subject",
@@ -398,7 +635,15 @@ pub fn fragment_triples(
             "object",
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#object",
         ),
-    ] {
+    ];
+    // brTPF (sq-dxhb): advertise the `values` control variable so a TPF/brTPF client discovers
+    // it may attach a set of solution mappings. It binds to the brTPF spec's `values` property
+    // (`http://www.w3.org/ns/sparql-service-description#` has no term for it; brTPF uses a
+    // dedicated property under its own namespace). Compiled out without the feature, so a
+    // `tpf`-only fragment is byte-identical to before.
+    #[cfg(feature = "brtpf")]
+    mappings.push(("values", BRTPF_VALUES_PROPERTY));
+    for (var, prop) in mappings {
         let mapping = oxrdf::BlankNode::default();
         emit(
             NamedOrBlankNode::BlankNode(search.clone()),
@@ -602,6 +847,8 @@ mod tests {
             "http://host/tpf{?subject,predicate,object}",
             f.has_next().then_some(next),
             None, // page 0 → no previous
+            Some("http://host/tpf?page=0"),
+            Some(&format!("http://host/tpf?page={}", f.last_page())),
         );
         let doc = crate::graph::triples_to_ntriples(&triples);
         // totalItems + itemsPerPage estimate.
@@ -615,6 +862,9 @@ mod tests {
         // next present (page 0 has a next), previous absent.
         assert!(doc.contains("hydra/core#next"), "{doc}");
         assert!(!doc.contains("hydra/core#previous"), "{doc}");
+        // first + last always present (the fuller Hydra paging vocabulary, sq-dxhb).
+        assert!(doc.contains("hydra/core#first"), "{doc}");
+        assert!(doc.contains("hydra/core#last"), "{doc}");
         // The data triples are in the document too (7 total > 3 page → 3 data triples present).
         assert_eq!(f.triples.len(), 3);
     }
@@ -630,6 +880,8 @@ mod tests {
             "http://host/tpf{?subject,predicate,object}",
             f.has_next().then_some("http://host/tpf?page=2"),
             f.has_previous().then_some("http://host/tpf?page=0"),
+            Some("http://host/tpf?page=0"),
+            Some(&format!("http://host/tpf?page={}", f.last_page())),
         );
         let doc = crate::graph::triples_to_ntriples(&triples);
         assert!(doc.contains("hydra/core#previous"), "{doc}");
@@ -649,6 +901,8 @@ mod tests {
             "http://host/tpf{?subject,predicate,object}",
             None,
             None,
+            Some("http://host/tpf?subject=%3Chttp%3A%2F%2Fex%2Fnobody%3E&page=0"),
+            Some("http://host/tpf?subject=%3Chttp%3A%2F%2Fex%2Fnobody%3E&page=0"),
         );
         let ttl = crate::graph::triples_to_turtle(&triples);
         // Re-parses as valid Turtle.
@@ -657,5 +911,203 @@ mod tests {
         let nt = crate::graph::triples_to_ntriples(&triples);
         // The count is a typed integer literal: `…#totalItems> "0"^^<xsd:integer>`.
         assert!(nt.contains("totalItems> \"0\""), "{nt}");
+    }
+
+    // ---- Hydra first/last paging vocabulary (sq-dxhb) ---------------------------------
+
+    #[test]
+    fn last_page_index_matches_paging() {
+        // 7 triples, page size 3 → pages 0,1,2 ; the last page is index 2.
+        let p = TriplePattern::parse(None, None, None).unwrap();
+        let g = graph();
+        for page in 0..4 {
+            assert_eq!(evaluate(&g, &p, page, 3).last_page(), 2, "page {page}");
+        }
+        // The whole result on one page → last page is 0.
+        assert_eq!(evaluate(&g, &p, 0, DEFAULT_PAGE_SIZE).last_page(), 0);
+        // An exact multiple: 6 matches / size 3 = 2 full pages → last index 1 (not 2).
+        let knows = TriplePattern::parse(None, Some("<http://ex/knows>"), None).unwrap();
+        // 2 `knows` triples, size 1 → 2 pages, last index 1.
+        assert_eq!(evaluate(&g, &knows, 0, 1).last_page(), 1);
+        // An empty result still has a (single, empty) page 0 — last index 0.
+        let none = TriplePattern::parse(Some("<http://ex/nobody>"), None, None).unwrap();
+        assert_eq!(evaluate(&g, &none, 0, 3).last_page(), 0);
+    }
+
+    #[test]
+    fn fragment_emits_first_and_last() {
+        let p = TriplePattern::parse(None, None, None).unwrap();
+        let f = evaluate(&graph(), &p, 1, 3);
+        let triples = fragment_triples(
+            &f,
+            "http://host/tpf?page=1",
+            "http://host/tpf",
+            "http://host/tpf{?subject,predicate,object}",
+            f.has_next().then_some("http://host/tpf?page=2"),
+            f.has_previous().then_some("http://host/tpf?page=0"),
+            Some("http://host/tpf?page=0"),
+            Some(&format!("http://host/tpf?page={}", f.last_page())),
+        );
+        let doc = crate::graph::triples_to_ntriples(&triples);
+        assert!(doc.contains("hydra/core#first"), "{doc}");
+        assert!(doc.contains("hydra/core#last"), "{doc}");
+        // first → page 0, last → page 2 (7 triples / size 3).
+        assert!(doc.contains("page=0"), "{doc}");
+        assert!(doc.contains("page=2"), "{doc}");
+    }
+
+    // ---- brTPF — bindings-restricted fragments (sq-dxhb) ------------------------------
+
+    #[cfg(feature = "brtpf")]
+    mod brtpf {
+        use super::*;
+
+        #[test]
+        fn parse_bindings_one_per_line() {
+            let b = parse_bindings("s=<http://ex/alice>\ns=<http://ex/carol>").unwrap();
+            assert_eq!(b.len(), 2);
+            assert_eq!(
+                b[0].subject,
+                Some(Term::NamedNode(NamedNode::new("http://ex/alice").unwrap()))
+            );
+            assert_eq!(
+                b[1].subject,
+                Some(Term::NamedNode(NamedNode::new("http://ex/carol").unwrap()))
+            );
+            assert!(b[0].predicate.is_none() && b[0].object.is_none());
+        }
+
+        #[test]
+        fn parse_bindings_multi_position_and_long_keys() {
+            // `subject`/`object` long forms + multiple positions on one line.
+            let b = parse_bindings("subject=<http://ex/alice> object=<http://ex/bob>").unwrap();
+            assert_eq!(b.len(), 1);
+            assert_eq!(
+                b[0].subject,
+                Some(Term::NamedNode(NamedNode::new("http://ex/alice").unwrap()))
+            );
+            assert_eq!(
+                b[0].object,
+                Some(Term::NamedNode(NamedNode::new("http://ex/bob").unwrap()))
+            );
+        }
+
+        #[test]
+        fn parse_bindings_empty_payload_and_blank_lines() {
+            assert!(parse_bindings("").unwrap().is_empty());
+            assert!(parse_bindings("\n  \n\t\n").unwrap().is_empty());
+        }
+
+        #[test]
+        fn parse_bindings_rejects_malformed() {
+            assert!(parse_bindings("s").is_err()); // no '='
+            assert!(parse_bindings("bogus=<http://ex/x>").is_err()); // bad position
+            assert!(parse_bindings("p=\"a literal\"").is_err()); // non-IRI predicate
+            assert!(parse_bindings("s=not a term").is_err()); // malformed term
+        }
+
+        #[test]
+        fn restricts_to_compatible_bindings_only() {
+            // ?s ex:knows ?o has alice→bob, carol→alice. Restrict to {?s=alice}: only alice→bob.
+            let g = graph();
+            let p = TriplePattern::parse(None, Some("<http://ex/knows>"), None).unwrap();
+            let bindings = parse_bindings("s=<http://ex/alice>").unwrap();
+            let f = evaluate_brtpf(&g, &p, &bindings, 0, DEFAULT_PAGE_SIZE);
+            assert_eq!(f.total_estimate, 1);
+            assert_eq!(f.triples.len(), 1);
+            assert_eq!(f.triples[0].subject.to_string(), "<http://ex/alice>");
+            assert_eq!(f.triples[0].object.to_string(), "<http://ex/bob>");
+        }
+
+        #[test]
+        fn union_over_multiple_bindings() {
+            // Restrict to {?s=alice, ?s=carol}: BOTH knows triples (the union).
+            let g = graph();
+            let p = TriplePattern::parse(None, Some("<http://ex/knows>"), None).unwrap();
+            let bindings = parse_bindings("s=<http://ex/alice>\ns=<http://ex/carol>").unwrap();
+            let f = evaluate_brtpf(&g, &p, &bindings, 0, DEFAULT_PAGE_SIZE);
+            assert_eq!(f.total_estimate, 2);
+            assert_eq!(f.triples.len(), 2);
+        }
+
+        #[test]
+        fn binding_absent_from_data_contributes_nothing() {
+            // A binding whose term is not in the dictionary matches nothing; the other still does.
+            let g = graph();
+            let p = TriplePattern::parse(None, Some("<http://ex/knows>"), None).unwrap();
+            let bindings = parse_bindings("s=<http://ex/nobody>\ns=<http://ex/alice>").unwrap();
+            let f = evaluate_brtpf(&g, &p, &bindings, 0, DEFAULT_PAGE_SIZE);
+            assert_eq!(f.total_estimate, 1, "only alice contributes");
+        }
+
+        #[test]
+        fn binding_contradicting_the_pattern_contributes_nothing() {
+            // Pattern fixes ?s=alice; a binding ?s=carol CLASHES → contributes nothing. A second
+            // binding ?o=bob is compatible (specialises the object) → the one alice→bob triple.
+            let g = graph();
+            let p =
+                TriplePattern::parse(Some("<http://ex/alice>"), Some("<http://ex/knows>"), None)
+                    .unwrap();
+            let bindings = parse_bindings("s=<http://ex/carol>\no=<http://ex/bob>").unwrap();
+            let f = evaluate_brtpf(&g, &p, &bindings, 0, DEFAULT_PAGE_SIZE);
+            assert_eq!(f.total_estimate, 1);
+            assert_eq!(f.triples[0].object.to_string(), "<http://ex/bob>");
+        }
+
+        #[test]
+        fn empty_binding_set_is_plain_tpf() {
+            // No restriction ⇒ identical to plain evaluate (the μ₀-only case).
+            let g = graph();
+            let p = TriplePattern::parse(None, Some("<http://ex/knows>"), None).unwrap();
+            let restricted = evaluate_brtpf(&g, &p, &[], 0, DEFAULT_PAGE_SIZE);
+            let plain = evaluate(&g, &p, 0, DEFAULT_PAGE_SIZE);
+            assert_eq!(restricted.total_estimate, plain.total_estimate);
+            assert_eq!(restricted.triples.len(), plain.triples.len());
+        }
+
+        #[test]
+        fn restricted_result_pages_consistently() {
+            // Restrict ?s ?p ?o to {?s=alice} (alice has 3 triples), page size 2 → pages 0 (2) + 1 (1).
+            let g = graph();
+            let p = TriplePattern::parse(None, None, None).unwrap();
+            let bindings = parse_bindings("s=<http://ex/alice>").unwrap();
+            let p0 = evaluate_brtpf(&g, &p, &bindings, 0, 2);
+            assert_eq!(p0.total_estimate, 3);
+            assert_eq!(p0.triples.len(), 2);
+            assert!(p0.has_next());
+            assert!(!p0.has_previous());
+            assert_eq!(p0.last_page(), 1);
+            let p1 = evaluate_brtpf(&g, &p, &bindings, 1, 2);
+            assert_eq!(p1.triples.len(), 1);
+            assert!(!p1.has_next());
+            assert!(p1.has_previous());
+            // The two pages partition the 3-triple restricted result with no overlap.
+            let mut all: Vec<String> = p0
+                .triples
+                .iter()
+                .chain(p1.triples.iter())
+                .map(|t| t.to_string())
+                .collect();
+            all.sort();
+            all.dedup();
+            assert_eq!(all.len(), 3, "no duplicate across pages");
+            assert!(all.iter().all(|t| t.contains("http://ex/alice")));
+        }
+
+        #[test]
+        fn overlapping_bindings_deduplicate() {
+            // Two bindings that select the SAME triple must not double-count it.
+            let g = graph();
+            let p = TriplePattern::parse(None, None, None).unwrap();
+            // Both {?s=alice,?o=bob} and {?p=knows} select alice→bob (among others); the union
+            // counts each matching triple once.
+            let bindings =
+                parse_bindings("s=<http://ex/alice> o=<http://ex/bob>\np=<http://ex/knows>")
+                    .unwrap();
+            let f = evaluate_brtpf(&g, &p, &bindings, 0, DEFAULT_PAGE_SIZE);
+            // {alice,bob} → alice knows bob (1). {knows} → alice→bob, carol→alice (2). Union = 2.
+            assert_eq!(f.total_estimate, 2);
+            assert_eq!(f.triples.len(), 2);
+        }
     }
 }

--- a/crates/sparq-server/src/tpf.rs
+++ b/crates/sparq-server/src/tpf.rs
@@ -361,8 +361,13 @@ pub fn parse_bindings(payload: &str) -> Result<Vec<Binding>, ParseError> {
 ///
 /// `total_estimate` is the EXACT size of the deduplicated union (this is a count of the real
 /// restricted result, so we can be exact and still advertise it as `hydra:totalItems`); the
-/// page slices `[page*page_size, …)` of that union in canonical `[s,p,o]` order — the same
-/// deterministic order plain TPF pages in, so the union pages consistently.
+/// page slices `[page*page_size, …)` of that union in numeric `[s,p,o]` id-lexicographic order
+/// (the `BTreeSet` order). That order is DETERMINISTIC and INTRA-RESULT CONSISTENT across this
+/// fragment's pages — the property paging actually needs (page boundaries never overlap and the
+/// pages partition the result). It is NOT necessarily the same order plain [`evaluate`] uses:
+/// plain TPF slices the chosen INDEX's scan order, which for a given bound-position shape may
+/// sort on a different id permutation. Both orders are deterministic; they just need not be
+/// identical to each other.
 ///
 /// An EMPTY binding set means "no restriction" and is delegated to the plain [`evaluate`] — a
 /// brTPF request with zero mappings is exactly a TPF request (the spec's μ₀-only case).

--- a/crates/sparq-server/tests/tpf.rs
+++ b/crates/sparq-server/tests/tpf.rs
@@ -251,3 +251,135 @@ async fn malformed_term_does_not_echo_input() {
         "TPF term parse error echoed caller input: {body}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-dxhb — Hydra first/last paging controls (the fuller paging vocabulary).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn fragment_carries_first_and_last_paging_controls() {
+    // page=1 over the default page size: every page links hydra:first (page 0) and hydra:last.
+    let base = spawn(true).await;
+    let resp = client()
+        .get(format!("{base}/tpf"))
+        .query(&[("page", "1")])
+        .header("Accept", "application/n-triples")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("hydra/core#first"),
+        "fragment must link hydra:first: {body}"
+    );
+    assert!(
+        body.contains("hydra/core#last"),
+        "fragment must link hydra:last: {body}"
+    );
+    // first → page 0; with 7 triples in one default page, last is also page 0.
+    assert!(body.contains("page=0"), "first/last should reference page 0: {body}");
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-dxhb — brTPF bindings-restricted fragments (only with the `brtpf` feature).
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "brtpf")]
+#[tokio::test]
+async fn brtpf_values_query_param_restricts_the_fragment() {
+    let base = spawn(true).await;
+    // ?s ex:knows ?o → alice→bob, carol→alice (2). Restrict via `values` to {?s=carol}: 1.
+    let resp = client()
+        .get(format!("{base}/tpf"))
+        .query(&[
+            ("predicate", "<http://ex/knows>"),
+            ("values", "s=<http://ex/carol>"),
+        ])
+        .header("Accept", "application/n-triples")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    // Only carol→alice, NOT alice→bob.
+    assert!(
+        body.contains("<http://ex/carol> <http://ex/knows> <http://ex/alice>"),
+        "{body}"
+    );
+    assert!(
+        !body.contains("<http://ex/alice> <http://ex/knows> <http://ex/bob>"),
+        "the restriction must exclude the alice→bob triple: {body}"
+    );
+    // The bindings-restricted count is 1 (NOT the unrestricted 2).
+    assert!(body.contains("totalItems> \"1\""), "{body}");
+    // The brTPF `values` control is advertised in the Hydra search template/mapping.
+    assert!(body.contains("subject,predicate,object,values"), "{body}");
+    assert!(body.contains("brtpf#values"), "{body}");
+}
+
+#[cfg(feature = "brtpf")]
+#[tokio::test]
+async fn brtpf_post_body_carries_a_binding_set() {
+    let base = spawn(true).await;
+    // POST the binding set in the body (the conventional brTPF transport for a large set).
+    let resp = client()
+        .post(format!("{base}/tpf"))
+        .query(&[("predicate", "<http://ex/knows>")])
+        .header("Accept", "application/n-triples")
+        .body("s=<http://ex/alice>\ns=<http://ex/carol>")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    // Both knows triples (the union of the two bindings).
+    assert!(
+        body.contains("<http://ex/alice> <http://ex/knows> <http://ex/bob>"),
+        "{body}"
+    );
+    assert!(
+        body.contains("<http://ex/carol> <http://ex/knows> <http://ex/alice>"),
+        "{body}"
+    );
+    assert!(body.contains("totalItems> \"2\""), "{body}");
+}
+
+#[cfg(feature = "brtpf")]
+#[tokio::test]
+async fn brtpf_empty_values_is_plain_tpf() {
+    // An empty `values` ⇒ no restriction: identical to a plain TPF request (all knows triples).
+    let base = spawn(true).await;
+    let resp = client()
+        .get(format!("{base}/tpf"))
+        .query(&[("predicate", "<http://ex/knows>"), ("values", "")])
+        .header("Accept", "application/n-triples")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("totalItems> \"2\""), "unrestricted count: {body}");
+}
+
+#[cfg(feature = "brtpf")]
+#[tokio::test]
+async fn brtpf_malformed_bindings_is_400_and_no_echo() {
+    const SENTINEL: &str = "brtpf_secret_sentinel";
+    let base = spawn(true).await;
+    // A malformed term value carrying the sentinel — the parse error quotes it server-side, but
+    // the sanitized HTTP body must NOT echo it (same info-leak posture as the TPF term parse).
+    let resp = client()
+        .post(format!("{base}/tpf"))
+        .body(format!("s=not_a_valid_term_{SENTINEL}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body = resp.text().await.unwrap();
+    assert!(body.starts_with("{\"error\":"), "structured JSON error: {body}");
+    assert!(
+        !body.contains(SENTINEL),
+        "brTPF binding parse error echoed caller input: {body}"
+    );
+}

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -430,10 +430,45 @@ request than a full SPARQL endpoint:
   (unbound). `page=N` (0-based) selects the page; the page size is bounded (default 100).
 - The fragment carries **Hydra controls**: `hydra:totalItems` / `void:triples` (the matched-triple
   count, reusing the engine's cheap cardinality **estimate** — NOT a full scan),
-  `hydra:itemsPerPage`, `hydra:next` / `hydra:previous` paging controls (present only when a
-  next / previous page exists), and a `hydra:search` / `hydra:template` /`hydra:mapping`
-  control describing the `{subject,predicate,object}` URI template so a generic client can
-  request any other pattern.
+  `hydra:itemsPerPage`, the full `PartialCollectionView` paging vocabulary —
+  `hydra:next` / `hydra:previous` (present only when a next / previous page exists) plus
+  `hydra:first` / `hydra:last` (emitted on EVERY page so a client can jump to either end of the
+  view from anywhere; `first` is always page 0, `last` is the page holding the final match —
+  derived from the same estimate as `totalItems`/`next`) — and a `hydra:search` / `hydra:template`
+  / `hydra:mapping` control describing the `{subject,predicate,object}` URI template so a generic
+  client can request any other pattern.
+
+**5d-bis. brTPF — bind-restricted Triple Pattern Fragments (OPT-IN, `sq-dxhb`; feature `brtpf`,
+implies `tpf`).** brTPF ([Hartig & Buil-Aranda, ODBASE 2016](http://olafhartig.de/files/HartigBuilAranda_ODBASE2016_Preprint.pdf))
+extends the SAME `/tpf` endpoint so a client can attach a **set of solution mappings** and the
+server returns only the page of pattern matches COMPATIBLE WITH AT LEAST ONE supplied binding —
+pushing a bind-join's semi-join down to the source, so far less data crosses the wire than
+re-fetching the whole pattern once per binding.
+
+- The binding set rides the `values` query parameter (`GET`) or — preferred for a large set —
+  the request **body** of a `POST /tpf`. The wire format is one mapping per line; within a line,
+  whitespace-separated `position=term` pairs where `position` is `subject`/`predicate`/`object`
+  (or short `s`/`p`/`o`) and `term` is the SAME N-Triples-term grammar as the pattern parameters
+  (e.g. `s=<http://ex/alice>`). A blank line / empty payload is the no-restriction (plain-TPF)
+  case; a malformed payload is a sanitized `400` (the offending input is NOT echoed).
+- The fragment is the **deduplicated union** of each mapping's specialised-pattern matches.
+  `hydra:totalItems` and the paging window reflect the bindings-RESTRICTED result, not the
+  unrestricted pattern, and the `hydra:search` control advertises an extra `hydra:mapping` for the
+  `values` variable so a client discovers the dataset accepts a restriction.
+- A `tpf`-only build is **byte-identical** to before: the `values` parsing + the `POST` route are
+  `#[cfg]`-stripped, so a stray `values` parameter is just an ignored unknown parameter (plain
+  TPF). Still governed by the same `--tpf` runtime flag and read-auth (`POST /tpf` is a READ — it
+  returns a fragment, it never writes).
+
+```sh
+cargo run -p sparq-server --features brtpf -- data.ttl --tpf
+# restrict `?s ex:knows ?o` to a single subject via the `values` parameter
+curl 'http://127.0.0.1:3030/tpf?predicate=%3Chttp%3A%2F%2Fex%2Fknows%3E&values=s%3D%3Chttp%3A%2F%2Fex%2Fcarol%3E'
+# a larger binding set in a POST body (one `position=term` mapping per line)
+curl -X POST -H 'Accept: application/n-triples' \
+  --data $'s=<http://ex/alice>\ns=<http://ex/carol>' \
+  'http://127.0.0.1:3030/tpf?predicate=%3Chttp%3A%2F%2Fex%2Fknows%3E'
+```
 
 **Double opt-in**, OFF by default and **READ-only** (no write path): compiled only with the `tpf`
 cargo feature **and** served only when `--tpf` / `SPARQ_TPF=1` is also set (mirrors
@@ -474,7 +509,7 @@ env overrides the default.
 | `--time-travel-generations N` | `SPARQ_TIME_TRAVEL_GENERATIONS` | `16` | (feature) retained generations |
 | `--time-travel-max-age SECS` | `SPARQ_TIME_TRAVEL_MAX_AGE` | off | (feature) age-out window |
 | `--federation-descriptors` | `SPARQ_FEDERATION_DESCRIPTORS` | off | (feature `federation-descriptors`) serve a VoID at `/.well-known/void` + a SPARQL Service Description on `GET /sparql` with no query — see "Federation discovery" |
-| `--tpf` | `SPARQ_TPF` | off | (feature `tpf`) serve a Triple Pattern Fragments / LDF source endpoint at `GET /tpf?subject=&predicate=&object=` (paged, Hydra controls, read-only) — see "Triple Pattern Fragments" |
+| `--tpf` | `SPARQ_TPF` | off | (feature `tpf`) serve a Triple Pattern Fragments / LDF source endpoint at `GET /tpf?subject=&predicate=&object=` (paged, full Hydra paging incl. `first`/`last`, read-only); same flag also serves brTPF bind-restricted fragments (`values` param / `POST` body) when built with the `brtpf` feature — see "Triple Pattern Fragments" |
 | `--audit-log` | `SPARQ_AUDIT_LOG` | off | (feature `audit-log`) per-query **access audit log** — see "Access audit log" |
 | `--access-audit <file\|stderr>` | `SPARQ_ACCESS_AUDIT` | off | (feature `access-audit`) richer **structured access-audit sink** (typed JSON-Lines: actor / action / resource / decision+basis / ts / fingerprint) — see "Structured access-audit sink" |
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-dxhb** (epic sq-3183) — Federation TPF follow-ups: bind-restricted Triple Pattern Fragments (brTPF) + the fuller Hydra paging vocabulary on the existing `/tpf` endpoint.

## What landed

**brTPF — bind-restricted Triple Pattern Fragments** (Hartig & Buil-Aranda, ODBASE 2016) as an **opt-in** extension behind a new `brtpf` cargo feature (implies `tpf`, default OFF):

- A client attaches a **set of solution mappings** — the `values` query parameter (GET) or, for a large set, a **`POST` body** of one `position=term` mapping per line (`s`/`p`/`o` or long forms; same N-Triples term grammar as the pattern parameters).
- The server returns only the page of pattern matches **compatible with at least one supplied binding** — the deduplicated union of each mapping's specialised-pattern scan — pushing a bind-join's semi-join down to the source so far less data crosses the wire than re-fetching the whole pattern per binding.
- `hydra:totalItems` and the paging window reflect the **bindings-restricted** result (not the unrestricted pattern); an extra `hydra:mapping` for the `values` variable advertises the restriction so a client can discover it.
- A mapping that **contradicts** the pattern's own bound term, or whose term is **absent from the dictionary**, contributes nothing (skipped without index work). An empty/absent binding set is exactly plain TPF (the μ₀-only case).
- Pure — no new dependency; runs over the existing public `Graph::pattern` / `store.scan` / `dict.term` API. A malformed binding set is a **sanitized 400** (no echo of caller input — same info-leak posture as the TPF term parse).

**Fuller Hydra `PartialCollectionView` paging** on every TPF response: adds `hydra:first` (page 0) and `hydra:last` (the page holding the final match) alongside the existing `hydra:next` / `hydra:previous` — keyed on the same estimate as `totalItems`/`next` for consistency.

## Opt-in / zero-cost-when-off

Without the `brtpf` feature the `values` parsing + the `POST` route are `#[cfg]`-stripped, so a `tpf`-only build is **byte-identical** to before (a stray `values` parameter is just an ignored unknown parameter — plain TPF). Still governed by the same `--tpf` runtime flag and read-auth — `POST /tpf` is a READ (it returns a fragment, never writes).

## Gates (both feature states)

- `cargo build -p sparq-server` for `tpf` and `brtpf` — green.
- `cargo clippy -p sparq-server --all-targets -- -D warnings` for `tpf` and `brtpf` — green.
- `cargo test -p sparq-server` for `tpf` and `brtpf` — green. New tests: the brTPF bindings-restricted request (GET `values` + POST body, union, dedup, contradiction/absent-term skip, consistent paging across pages, malformed→400-no-echo) and the Hydra `first`/`last` controls (unit + HTTP integration).

## Docs

Updated the sparq-server README (TPF source bullet + opt-in feature list) and the `http-server` SKILL's "Triple Pattern Fragments" section (new brTPF subsection + flags table).

## Honest notes

- The brTPF `values` control property is minted under a sparq namespace (`https://sparq.dev/ns/brtpf#values`) — brTPF has no standardised vocabulary term for "the attached solution-mapping set", so a client reads it from `hydra:mapping`.
- `hydra:totalItems` on a brTPF fragment is the **exact** union size (the restricted result is materialised to dedup it), unlike the plain-TPF cardinality estimate; advertised consistently with `next`/`first`/`last`.
- The `rustfmt` CI lane is informational (a deferred one-time `cargo fmt --all` reformat is pending); my changed source files (`tpf.rs`, `http.rs`) are individually fmt-clean. `tests/tpf.rs` carries pre-existing drift from main and was left untouched beyond the added tests.

Deferred (beaded as follow-ups — see below): a binary brTPF transport (the spec's compact mapping encoding rather than the line-oriented text form), and an explicit cap on the binding-set size as a DoS guard.
