### PR TITLE
ci: cover silently-skipped opt-in-feature test suites + guard (sq-vya1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,20 +149,20 @@ jobs:
       # .tar.zst is self-contained (binaries + the metadata nextest needs to run them
       # on another runner with `--archive-file`), so the shards never recompile.
       #
-      # [OPUS-4.8] (#363) `--features approx-ann,filtered-ann,vec-predicate` is LOAD-BEARING.
-      # sparq-vectors' accuracy/recall gates are gated behind these opt-in features at the
-      # MODULE level (`#![cfg(feature = ...)]` in tests/recall.rs, tests/overfetch.rs,
-      # tests/filtered*.rs, …). Without the features the gated test binaries compile EMPTY,
-      # so the dedicated heavy-hnsw shard's exact filter `test(=hnsw_recall_…on_50k)` matches
-      # ZERO tests and nextest exits 4 ("no tests to run") — the failure this fixes. These
-      # are the THREE features that gate sparq-vectors tests (approx-ann → HNSW recall +
-      # throughput + olympics + hybrid; filtered-ann → filtered + over-fetch; vec-predicate
-      # → the `vec:`-predicate BGP tests + cost_model). `provider`/`embeddings` gate NO test
-      # (API-shape + HTTP deps only), so they stay OFF. This is the TEST build only — it does
-      # not change any crate's default/shipped feature set; the opt-in features simply have to
-      # be ON for their gate tests to exist. The shard filters/partition are unchanged: the
-      # two recall tests are the known heavies, the rest (incl. the now-compiled gated tests)
-      # ride the bulk `not ( $HEAVY )` partition.
+      # [OPUS-4.8] The archive runs `--features approx-ann,filtered-ann,vec-predicate`
+      # (#363, LOAD-BEARING): sparq-vectors' heavy recall/over-fetch/vec-predicate tests are
+      # MODULE-gated (`#![cfg(feature = ...)]`) and MUST run in this sharded lane — without
+      # these the gated binaries compile EMPTY and the heavy-hnsw shard's exact filter matches
+      # ZERO tests (nextest exit 4). These three are the ONLY opt-in features carried here.
+      # GUARD (sq-vya1): the archive carries NO OTHER opt-in features (we deliberately avoid
+      # `--all-features` — cross-crate conflicts + heavy/native/network deps would not even
+      # resolve; see feature-matrix.yml's SCOPE). Any test behind a DEFAULT-OFF feature OTHER
+      # than those three compiles EMPTY here and runs SILENTLY-zero in the shards — its coverage
+      # is the JOB OF feature-matrix.yml (per-leg `cargo test -p <crate> --features <set>`,
+      # gated by ci-summary). When you add/feature-gate a test: a sparq-vectors recall/vec test
+      # rides these archive features; ANYTHING ELSE must be wired into a feature-matrix.yml leg
+      # (read that file's GUARD block). Prove a suite is reached: `cargo nextest list -p <crate>
+      # --features <set>` must SHOW its test names.
       - name: Build + archive test binaries (nextest archive)
         run: cargo nextest archive --workspace --all-targets --features approx-ann,filtered-ann,vec-predicate --archive-file nextest.tar.zst
       # [OPUS-4.8] Upload the archive immediately after the build, BEFORE doctests, so

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -17,6 +17,25 @@
 # and fails the merge if any opt-in build/clippy/test breaks. No edit to ci-summary.yml
 # is needed — the aggregator polls by name, not by a hard-coded list.
 #
+# GUARD — THE RULE THAT KEEPS THIS LANE HONEST (sq-vya1). A test module/file behind
+# `#[cfg(feature = "X")]` / `#![cfg(feature = "X")]` for a DEFAULT-OFF feature is compiled
+# EMPTY by ci.yml's `cargo nextest archive --workspace --all-targets` (it passes NO
+# `--features`), so the sharded `test` lane there runs ZERO of those tests — silently. The
+# ONLY thing that exercises such a suite is a leg HERE whose `cargo test -p <crate>
+# --features <…>` set is a SUPERSET of every feature the suite's cfg names. THEREFORE:
+# whenever you add (or feature-gate) a test behind a default-OFF feature, you MUST either
+#   (a) add that feature to a leg below whose crate matches (combine with an existing leg
+#       if the features co-enable cleanly — see the sparq-server `audit-log,access-audit,…`
+#       leg), OR
+#   (b) add a NEW leg (if the feature must be isolated — e.g. it changes a `not(feature=…)`
+#       code path, like brTPF vs TPF — give it its own leg so both code paths are tested).
+# To verify a suite is actually wired: `cargo nextest list -p <crate> --features <set>`
+# must SHOW the previously-skipped test names. The aggregator gate (ci-summary.yml) treats
+# every leg NAME here as REQUIRED (none contains the words "advisory"/"informational"), so
+# a broken opt-in build/clippy/test blocks the merge — but ONLY for suites a leg reaches.
+# A suite with no leg and no default coverage is the silent gap this whole lane exists to
+# close; do NOT let one back in. (ci.yml carries the mirror-image of this guard.)
+#
 # SCOPE — what this lane deliberately does NOT cover, and why (each is a separate gate
 # or a documented exclusion, NOT an oversight):
 #   • `zlib-ng` (sparq-cli / sparq-server / sparq-parse / sparq-hdt): swaps flate2's
@@ -139,6 +158,18 @@ jobs:
             crate: sparq-engine
             features: service
             test: true
+          # [OPUS-4.8] sq-vya1: SPARQL window functions + the custom-aggregate registry.
+          # The `window` module, the `AggregateFunction::Custom` eval arm and their 8 in-src
+          # tests (`window::tests::*` + `aggregate::tests::custom_*`/`unregistered_*`) are all
+          # `#[cfg(feature = "window-functions")]`, so the default build (and ci.yml's archive)
+          # compiled them EMPTY and no prior engine leg enabled the feature — 8 tests never ran.
+          # No new dep (oxrdf already direct) and no `not(feature)` divergence, so a single
+          # isolated leg (matching the per-feature engine legs above) covers it; verified
+          # `cargo nextest list -p sparq-engine --features window-functions` shows the 8 tests.
+          - name: sparq-engine (window-functions)
+            crate: sparq-engine
+            features: window-functions
+            test: true
           # sparq-cli: the `dump` re-serializer (forwards sparq-engine/serialize-rdf).
           - name: sparq-cli (serialize-rdf)
             crate: sparq-cli
@@ -157,9 +188,19 @@ jobs:
           # `audit-log` pulls `server` (it operates on the async HTTP Response + tracing);
           # composed with the same server feature set as the leg above so it compiles + the
           # gated test is discovered and actually executes.
-          - name: sparq-server (audit-log + server features)
+          # [OPUS-4.8] sq-vya1: `access-audit` ADDED here. tests/access_audit.rs is
+          # `#![cfg(feature = "access-audit")]` and the 7 in-src `access_audit::tests::*`
+          # unit tests are `#[cfg(feature = "access-audit")]`, so the default build (and
+          # EVERY prior leg) compiled them EMPTY and ran ZERO of them — the silent gap this
+          # bead closes. `access-audit` only pulls `server` (no conflict — it is a SECOND,
+          # independent audit sink alongside `audit-log`), so it co-enables cleanly with this
+          # leg's set; verified: `cargo nextest list -p sparq-server --features access-audit,…`
+          # now shows the 9 access_audit tests, and the leg's `clippy --all-targets -D
+          # warnings` gates the feature surface. Folded in here (not a new leg) to avoid a
+          # near-duplicate full-server-compile.
+          - name: sparq-server (audit-log, access-audit + server features)
             crate: sparq-server
-            features: audit-log,federation-descriptors,service,time-travel,geo,test-seams
+            features: audit-log,access-audit,federation-descriptors,service,time-travel,geo,test-seams
             test: true
           # [OPUS-4.8] sq-dxhb: the Triple Pattern Fragments / Linked Data Fragments READ-ONLY
           # source endpoint (`GET /tpf`). The handler + the Hydra paging vocabulary + the
@@ -230,6 +271,33 @@ jobs:
           - name: sparq-solid (odrl-bridge)
             crate: sparq-solid
             features: odrl-bridge
+            test: true
+          # [OPUS-4.8] sq-vya1: sparq-policy STATEFUL `odrl:count` enforcement. The whole
+          # tests/odrl_count.rs file is `#![cfg(feature = "count-enforcement")]` and the
+          # `count` module is feature-gated, so the default build (and ci.yml's
+          # archive) compiled them EMPTY — the 10 odrl_count tests (lteq/lt/eq budgets,
+          # fail-closed on a missing/malformed counter, per-(party,target,rule) isolation,
+          # the concurrent-overgrant oracle) NEVER ran. sparq-policy had NO leg at all here.
+          # `count-enforcement` is std-only (no new dep, no socket/fixture), so this is a
+          # fast leg; verified `cargo nextest list -p sparq-policy --features
+          # count-enforcement` now shows the 10 previously-skipped tests.
+          - name: sparq-policy (count-enforcement)
+            crate: sparq-policy
+            features: count-enforcement
+            test: true
+          # [OPUS-4.8] sq-vya1: sparq-fedplan. The ENTIRE crate (lib.rs + every module) is
+          # `#[cfg(feature = "fedplan")]` and `default = []`, so the default build compiled
+          # it empty and ci.yml's archive listed ZERO of its 48 in-src `#[test]`s — the
+          # single biggest silent gap this bead found, and sparq-fedplan had NO leg here.
+          # `adaptive-replan` IMPLIES `fedplan` and its tests are a strict SUPERSET (32 with
+          # `fedplan` ⊂ 48 with `adaptive-replan`; the extra 16 are adaptive.rs); the only
+          # `not(feature=…)` cfg in the crate is a harmless `allow(dead_code)`, so there is
+          # NO divergent code path that a `fedplan`-only leg would reach — ONE
+          # `adaptive-replan` leg covers everything. Verified: `cargo nextest run -p
+          # sparq-fedplan --features adaptive-replan` => 48 tests run, 48 passed.
+          - name: sparq-fedplan (adaptive-replan, implies fedplan)
+            crate: sparq-fedplan
+            features: adaptive-replan
             test: true
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
> 🤖 SPARQ agent

## Problem (sq-vya1)

`ci.yml`'s `build-archive` runs `cargo nextest archive --workspace --all-targets` with **no `--features`**, so it compiles the **DEFAULT feature set only**. Any test module/file behind a default-OFF `#[cfg(feature = "X")]` / `#![cfg(feature = "X")]` compiles **empty**, and the sharded `test` lane runs **ZERO** of those tests — silently, with a green run. The same bit hit #363 (heavy-hnsw) and #383 (brTPF). `feature-matrix.yml` covered most opt-in features, but an exhaustive audit found genuine gaps.

## Audit

Grepped every `cfg(feature=...)` gate on a test module/file across all crates and cross-checked each against (a) the ci.yml archive's default set and (b) every feature-matrix.yml leg's `cargo test -p <crate> --features <set>`. Empirically confirmed with `cargo nextest list` (default vs `--features`).

**Genuinely uncovered (FIXED):**

| Suite | Feature | Tests | Fix |
|---|---|---|---|
| `sparq-fedplan` (whole crate, `default=[]`) | `adaptive-replan` (⊇ `fedplan`) | **48** (was 0 listed) | new leg |
| `sparq-engine` `window::` + custom-agg | `window-functions` | **8** | new leg |
| `sparq-policy/tests/odrl_count.rs` | `count-enforcement` | **10** | new leg (crate had none) |
| `sparq-server/tests/access_audit.rs` + 7 in-src | `access-audit` | **9** | folded into the `audit-log,…` server leg |

`sparq-fedplan` was the single biggest gap: its entire `lib.rs` is `#[cfg(feature="fedplan")]`, so the archive listed **0** of its in-src tests. `adaptive-replan` implies `fedplan` and its test set is a strict superset (32 ⊂ 48; only `not(feature)` is a harmless `allow(dead_code)`), so one leg covers all 48.

**Uncovered BY DESIGN (left as documented exclusions):** `hdt` (sparq-cli) / `write` (sparq-hdt) — hdt-crate MSRV 1.87 + heavy decode stack, needs its own toolchain lane (already in feature-matrix.yml's SCOPE block); `live` / `embeddings` (real network) and `zlib-ng` (C toolchain, no first-party Rust) — also documented exclusions.

## What was wired

- **New feature-matrix.yml legs:** `sparq-fedplan (adaptive-replan)`, `sparq-engine (window-functions)`, `sparq-policy (count-enforcement)`.
- **Extended leg:** the `sparq-server` audit leg now enables `access-audit` alongside `audit-log` (it only pulls `server`, co-enables cleanly — no conflict, no near-duplicate full-server compile).
- **GUARD (the rule that keeps this honest):** a prominent comment added to **both** `ci.yml` (on the archive step: "this passes no `--features`; opt-in tests are NOT covered here; wire them into a feature-matrix.yml leg; `--all-features` would not even resolve") **and** `feature-matrix.yml` (top-of-file GUARD block: how to add/verify a leg, combine-vs-isolate, the `nextest list --features` proof) so a new opt-in test feature cannot be silently excluded again.

## Local verification

For each new/extended leg: feature compiles; `cargo nextest list -p <crate> --features <set>` shows the previously-skipped tests (before: skipped; after: present); `cargo test -p <crate> --features <set>` passes (fedplan 48/48, window-functions all green, policy 10/10, access-audit 2 integration + 7 unit). `clippy --all-targets -D warnings` clean for every new feature set. YAML valid (21 matrix legs). No new leg name contains the whole-word `advisory`/`informational` token, so `ci-summary / gate` auto-discovers each as a **REQUIRED** gating check.