### PR TITLE
feat(sparq-engine): SPARQL inline OVER() window-clause syntax (sq-h564)

### DIFF
--- a/crates/sparq-engine/README.md
+++ b/crates/sparq-engine/README.md
@@ -42,12 +42,16 @@ let json = sparq_engine::query_json(&g, "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?
   see [`docs/extension-functions.md`](../../docs/extension-functions.md).
 - **Custom aggregates + window functions** *(opt-in `window-functions` feature, OFF by default)* —
   register a named user aggregate (`CustomAggregateRegistry`) callable from a real SPARQL `GROUP BY`,
-  and a programmatic window-function pass (`window::apply_window` — `ROW_NUMBER` / `RANK` /
-  `DENSE_RANK` + a windowed aggregate, with `PARTITION BY` + `ORDER BY` specs). **Window functions
-  are a NON-STANDARD extension** — SPARQL has no W3C-REC `OVER` syntax, so they are exposed as an
-  explicit API over a result table (the SQL:2003 model Stardog / AnzoGraph expose), NOT inline query
-  syntax; the engine's SPARQL surface stays exactly SPARQL 1.1. When the feature is off, zero
-  window/aggregate-registry code compiles and the default build is byte-identical (no new deps).
+  and a window-function surface (`ROW_NUMBER` / `RANK` / `DENSE_RANK` + a windowed aggregate, with
+  `PARTITION BY` + `ORDER BY`) available two ways: a programmatic pass (`window::apply_window` over a
+  `QueryResult`) and an inline `OVER(…)` query syntax (`query_over` — `(ROW_NUMBER() OVER (PARTITION BY
+  ?x ORDER BY ?y) AS ?rn)` in the SELECT). **Window functions are a NON-STANDARD extension** — SPARQL
+  has no W3C-REC `OVER` syntax. The inline form is a *source rewrite* in front of the engine recognised
+  ONLY on `query_over` (it does NOT change the vendored parser), so the standard `query`/`ask`/… surface
+  stays exactly SPARQL 1.1 and conformance is unaffected. Inline covers the three ranking functions;
+  windowed aggregates / frames / `LAG`/`LEAD`/`NTILE` are inline-deferred (use the programmatic API).
+  When the feature is off, zero window/aggregate-registry code compiles and the default build is
+  byte-identical (no new deps).
 - **`forbid(unsafe_code)`** — the crate contains zero `unsafe`.
 
 ## 📚 Learn more

--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -170,11 +170,18 @@ pub fn with_functions<T>(fns: &FunctionRegistry, f: impl FnOnce() -> T) -> T {
 mod aggregate;
 #[cfg(feature = "window-functions")]
 pub mod window;
+// Inline `OVER(…)` window-clause SYNTAX (sq-h564) — a source-rewrite front end over
+// the programmatic `window` pass, on the dedicated `query_over` entry point only. It
+// does NOT touch the (conformance-tracking) vendored spargebra parser. [OPUS-4.8]
+#[cfg(feature = "window-functions")]
+mod window_syntax;
 #[cfg(feature = "window-functions")]
 pub use aggregate::{
     query_with_aggregates, query_with_aggregates_and_budget, with_aggregates, AggFn,
     CustomAggregateRegistry,
 };
+#[cfg(feature = "window-functions")]
+pub use window_syntax::{query_over, query_over_with_budget};
 
 // ---- Spatial pushdown seam (sq-mg9) -----------------------------------------
 //

--- a/crates/sparq-engine/src/window_syntax.rs
+++ b/crates/sparq-engine/src/window_syntax.rs
@@ -1,0 +1,868 @@
+//! Inline `OVER(...)` window-clause SYNTAX (sq-h564) — a NON-STANDARD, OPT-IN
+//! extension on top of the programmatic window pass in [`crate::window`].
+//!
+//! [OPUS-4.8] **There is still no W3C-REC syntax for SPARQL window functions**
+//! (see the [`crate::window`] module docs). SPARQL 1.1 has no
+//! `OVER (PARTITION BY … ORDER BY …)` clause and no community SEP defines one;
+//! engines that offer windowing each invent their own surface. PR #370 landed
+//! windowing as a *programmatic* pass over a [`QueryResult`] to keep the engine's
+//! SPARQL surface exactly SPARQL 1.1 (no conformance-harness regression). This
+//! module adds an INLINE query syntax for the same pass **without touching the
+//! (W3C-conformance-tracking) vendored `spargebra` parser**: it is a *source
+//! rewrite* in front of the ordinary engine, only enabled on the dedicated
+//! [`query_over`] / [`query_over_with_budget`] entry points. Every other entry
+//! point — and the plain `spargebra` parser — is untouched, so an `OVER(…)`
+//! clause is still a parse error on the standard surface (conformance is
+//! unaffected).
+//!
+//! ## Syntax accepted
+//!
+//! Inside a top-level `SELECT` projection, a window expression is written
+//!
+//! ```text
+//! ( <FN>() OVER ( [PARTITION BY ?v …] [ORDER BY [ASC|DESC]? ?v …] ) AS ?out )
+//! ```
+//!
+//! where `<FN>` is one of `ROW_NUMBER`, `RANK`, `DENSE_RANK` (case-insensitive),
+//! the empty `()` after the function name is required, and the `AS ?out` alias is
+//! required. This mirrors the SQL:2003 / Stardog / AnzoGraph window surface (the
+//! same model the programmatic [`crate::window`] pass follows) restricted to the
+//! three ranking functions.
+//!
+//! Example:
+//!
+//! ```text
+//! SELECT ?emp ?dept ?sales
+//!        (ROW_NUMBER() OVER (PARTITION BY ?dept ORDER BY DESC(?sales)) AS ?rn)
+//! WHERE { ?emp :dept ?dept ; :sales ?sales }
+//! ```
+//!
+//! Both `ORDER BY DESC(?sales)` and `ORDER BY ?sales DESC` (the SQL trailing-
+//! keyword form) are accepted; bare `?sales` is ASC. `PARTITION BY` and the whole
+//! `ORDER BY` are each optional (an absent `PARTITION BY` is a single partition
+//! over the whole result; an absent `ORDER BY` makes every row a peer).
+//!
+//! ## Covered vs deferred
+//!
+//! * **Covered:** `ROW_NUMBER()`, `RANK()`, `DENSE_RANK()`, `PARTITION BY` over
+//!   one or more variables, `ORDER BY` over one or more variables (ASC/DESC, both
+//!   `DESC(?v)` and `?v DESC` spellings). Multiple window columns in one SELECT.
+//!   Other (non-window) projection items — plain variables and `(expr AS ?v)`
+//!   aliases — pass through to the ordinary engine unchanged.
+//! * **Deferred (beaded):** windowed AGGREGATES inline (`SUM(?x) OVER (…)` etc.),
+//!   explicit window frames (`ROWS BETWEEN …`), `LAG`/`LEAD`/`NTILE`, a named
+//!   `WINDOW` clause, and `OVER` over an order key that is a computed expression
+//!   rather than a projected variable. Those remain available via the
+//!   programmatic [`crate::window`] API.
+
+use oxrdf::Variable;
+use sparq_core::Graph;
+
+use crate::window::{apply_window, SortKey, WindowFunction, WindowSpec};
+use crate::{QueryBudget, QueryResult};
+
+/// One parsed inline window item lifted out of a SELECT projection: the function,
+/// its `PARTITION BY` / `ORDER BY` variables, and the output alias.
+#[derive(Debug, Clone)]
+struct WindowItem {
+    func: RankFunc,
+    partition_by: Vec<String>,
+    order_by: Vec<(String, bool)>, // (var, descending)
+    out: String,
+}
+
+/// A parsed `OVER ( … )` spec: the `PARTITION BY` variable names and the
+/// `ORDER BY` keys as `(variable, descending)` pairs.
+type OverSpec = (Vec<String>, Vec<(String, bool)>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RankFunc {
+    RowNumber,
+    Rank,
+    DenseRank,
+}
+
+impl RankFunc {
+    fn parse(name: &str) -> Option<Self> {
+        match name.to_ascii_uppercase().as_str() {
+            "ROW_NUMBER" => Some(Self::RowNumber),
+            "RANK" => Some(Self::Rank),
+            "DENSE_RANK" => Some(Self::DenseRank),
+            _ => None,
+        }
+    }
+    fn to_window_function(self) -> WindowFunction {
+        match self {
+            Self::RowNumber => WindowFunction::RowNumber,
+            Self::Rank => WindowFunction::Rank,
+            Self::DenseRank => WindowFunction::DenseRank,
+        }
+    }
+}
+
+/// [`crate::query`] extended with inline `OVER(…)` window syntax. A query with no
+/// `OVER` clause is run by the ordinary engine unchanged (so this is a strict
+/// superset of [`crate::query`] on the syntactic level — a non-window query is
+/// byte-for-byte the same). See the module docs for the exact syntax.
+pub fn query_over(graph: &Graph, sparql: &str) -> Result<QueryResult, String> {
+    query_over_with_budget(graph, sparql, &QueryBudget::unlimited())
+}
+
+/// [`query_over`] under a cooperative [`QueryBudget`]. The budget governs the
+/// rewritten inner SELECT; the window pass itself is a post-pass over the already
+/// budget-bounded result.
+pub fn query_over_with_budget(
+    graph: &Graph,
+    sparql: &str,
+    budget: &QueryBudget,
+) -> Result<QueryResult, String> {
+    let Some(plan) = extract_windows(sparql)? else {
+        // No OVER clause: ordinary SPARQL, evaluated by the unmodified engine.
+        return crate::query_with_budget(graph, sparql, budget);
+    };
+    // Run the rewritten (window-stripped) SELECT, then apply each window spec.
+    let mut result = crate::query_with_budget(graph, &plan.rewritten, budget)?;
+    for item in &plan.windows {
+        let spec = WindowSpec {
+            partition_by: item.partition_by.iter().map(|v| var(v)).collect::<Result<_, _>>()?,
+            order_by: item
+                .order_by
+                .iter()
+                .map(|(v, desc)| Ok(SortKey { var: var(v)?, descending: *desc }))
+                .collect::<Result<_, String>>()?,
+            function: item.func.to_window_function(),
+            new_var: var(&item.out)?,
+        };
+        result = apply_window(&result, &spec)?;
+    }
+    // Project to exactly the columns the original SELECT named, in order. The
+    // rewritten inner query may have introduced helper columns (partition/order
+    // variables referenced only by a window) that the user did not ask for.
+    project(result, &plan.output_vars)
+}
+
+fn var(name: &str) -> Result<Variable, String> {
+    Variable::new(name).map_err(|e| format!("inline OVER: invalid variable ?{name}: {e}"))
+}
+
+/// The output of stripping windows from a SELECT: the rewritten plain-SPARQL
+/// query, the window items to apply, and the final output column order.
+struct RewritePlan {
+    rewritten: String,
+    windows: Vec<WindowItem>,
+    output_vars: Vec<String>,
+}
+
+/// Restricts `result` to the columns named in `output_vars` (in that order). An
+/// output variable absent from the result is an error (it was never produced).
+fn project(result: QueryResult, output_vars: &[String]) -> Result<QueryResult, String> {
+    // SELECT * (empty output_vars sentinel handled by the caller) keeps all columns.
+    if output_vars.is_empty() {
+        return Ok(result);
+    }
+    let idx: Vec<usize> = output_vars
+        .iter()
+        .map(|name| {
+            result
+                .vars
+                .iter()
+                .position(|v| v.as_str() == name)
+                .ok_or_else(|| format!("inline OVER: output ?{name} was not produced"))
+        })
+        .collect::<Result<_, _>>()?;
+    let vars = idx.iter().map(|&i| result.vars[i].clone()).collect();
+    let rows = result
+        .rows
+        .into_iter()
+        .map(|row| idx.iter().map(|&i| row[i].clone()).collect())
+        .collect();
+    Ok(QueryResult { vars, rows })
+}
+
+/// Scans `sparql` for inline `OVER(…)` window items in the top-level SELECT
+/// projection. Returns `Ok(None)` when there is no `OVER` clause (the query is
+/// ordinary SPARQL and must be run unmodified), or `Ok(Some(plan))` with the
+/// rewritten query + extracted windows. `Err` for malformed window syntax.
+fn extract_windows(sparql: &str) -> Result<Option<RewritePlan>, String> {
+    // Fast path: no `OVER` token at all → ordinary SPARQL. The check is a
+    // word-boundary, case-insensitive scan so it does not trip on e.g. `?over`.
+    if !contains_keyword(sparql, "OVER") {
+        return Ok(None);
+    }
+    // Locate the top-level SELECT projection: between the SELECT keyword (after an
+    // optional DISTINCT/REDUCED) and the WHERE clause / the `{` that opens it.
+    let (sel_start, proj_start) = find_select_projection_start(sparql)
+        .ok_or("inline OVER: could not locate the SELECT projection")?;
+    let proj_end = find_projection_end(sparql, proj_start)
+        .ok_or("inline OVER: could not locate the end of the SELECT projection (missing WHERE/{)")?;
+
+    let projection = &sparql[proj_start..proj_end];
+    let items = split_projection_items(projection)?;
+
+    let mut windows = Vec::new();
+    let mut output_vars = Vec::new();
+    let mut helper_vars: Vec<String> = Vec::new();
+    let mut rewritten_items: Vec<String> = Vec::new();
+    let mut select_star = false;
+
+    for item in &items {
+        let t = item.trim();
+        if t == "*" {
+            select_star = true;
+            continue;
+        }
+        if let Some(win) = parse_window_item(t)? {
+            // The window's input columns (partition/order vars) must survive the
+            // inner SELECT so the post-pass can read them; project them through.
+            for v in win.partition_by.iter().chain(win.order_by.iter().map(|(v, _)| v)) {
+                if !helper_vars.contains(v) {
+                    helper_vars.push(v.clone());
+                }
+            }
+            output_vars.push(win.out.clone());
+            windows.push(win);
+        } else {
+            // A non-window projection item: a bare ?var or an (expr AS ?v). Keep it
+            // verbatim in the inner query and record its OUTPUT variable.
+            rewritten_items.push(t.to_string());
+            output_vars.push(projection_item_output_var(t)?);
+        }
+    }
+
+    if windows.is_empty() {
+        // `OVER` appeared as a token but not as a window clause we recognise
+        // (e.g. a variable or IRI containing the letters). Leave the query alone.
+        return Ok(None);
+    }
+
+    // Build the inner projection: every non-window item, plus any helper var a
+    // window needs that is not already projected. With `SELECT *` the inner query
+    // keeps `*` (all in-scope vars), which already covers the helpers.
+    let mut inner_proj = rewritten_items.clone();
+    if select_star {
+        inner_proj.insert(0, "*".to_string());
+    } else {
+        for h in &helper_vars {
+            let already = rewritten_items.iter().any(|it| projection_item_mentions_output(it, h));
+            if !already {
+                inner_proj.push(format!("?{h}"));
+            }
+        }
+    }
+    if inner_proj.is_empty() {
+        return Err("inline OVER: the rewritten query has no projected columns".into());
+    }
+
+    let inner = inner_proj.join(" ");
+    let rewritten = format!("{} {} {}", &sparql[..proj_start], inner, &sparql[proj_end..]);
+    // `select_star` ⇒ keep all produced columns (no explicit reprojection), which
+    // also matches `SELECT *` semantics (the window column is appended).
+    let output_vars = if select_star { Vec::new() } else { output_vars };
+
+    let _ = sel_start; // retained for clarity / future diagnostics
+    Ok(Some(RewritePlan { rewritten, windows, output_vars }))
+}
+
+/// Parses one trimmed projection item as a window expression, or `Ok(None)` if it
+/// is not a window item. A `(… OVER …)` shape that fails to parse is an `Err`.
+fn parse_window_item(item: &str) -> Result<Option<WindowItem>, String> {
+    // A window item is parenthesised: `( FN() OVER ( … ) AS ?out )`.
+    let inner = match strip_outer_parens(item) {
+        Some(i) => i,
+        None => return Ok(None),
+    };
+    // Must contain the OVER keyword to be a window item.
+    let over_pos = match find_keyword(inner, "OVER") {
+        Some(p) => p,
+        None => return Ok(None),
+    };
+    let head = inner[..over_pos].trim();
+    let rest = inner[over_pos + 4..].trim_start();
+
+    // head := FN ( ) — function name then an empty argument list.
+    let lp = head.find('(').ok_or("inline OVER: window function call needs '()'")?;
+    let fname = head[..lp].trim();
+    let args = head[lp..].trim();
+    let func = RankFunc::parse(fname)
+        .ok_or_else(|| format!("inline OVER: unsupported window function {fname:?} (covered: ROW_NUMBER, RANK, DENSE_RANK)"))?;
+    if args != "()" {
+        return Err(format!(
+            "inline OVER: window function {fname} must be called with empty args '()' (got {args:?}); windowed aggregates are deferred"
+        ));
+    }
+
+    // rest := ( PARTITION BY … ORDER BY … ) AS ?out — split the balanced `( … )`
+    // spec from its trailing `AS ?out` alias.
+    let (spec_body, alias) = split_spec_and_alias(rest.trim())?;
+    let (partition_by, order_by) = parse_over_spec(&spec_body)?;
+    Ok(Some(WindowItem { func, partition_by, order_by, out: alias }))
+}
+
+/// Splits `( spec ) AS ?out` into (`spec`, `out`). Requires the `AS ?out` alias.
+fn split_spec_and_alias(s: &str) -> Result<(String, String), String> {
+    let s = s.trim();
+    if !s.starts_with('(') {
+        return Err("inline OVER: expected `( … )` after OVER".into());
+    }
+    // Find the matching close paren for the opening one.
+    let close = matching_paren(s, 0)
+        .ok_or("inline OVER: unbalanced parentheses in OVER ( … )")?;
+    let spec = s[1..close].to_string();
+    let tail = s[close + 1..].trim();
+    // tail := AS ?out
+    let tail_up = tail.to_ascii_uppercase();
+    if !tail_up.starts_with("AS") {
+        return Err("inline OVER: window expression must end with `AS ?out`".into());
+    }
+    let after_as = tail[2..].trim();
+    let out = after_as
+        .strip_prefix('?')
+        .or_else(|| after_as.strip_prefix('$'))
+        .ok_or("inline OVER: `AS` must be followed by an output variable ?out")?;
+    let out = out.trim();
+    if out.is_empty() || !out.chars().all(is_varname_char) {
+        return Err(format!("inline OVER: invalid output variable {after_as:?} after AS"));
+    }
+    Ok((spec, out.to_string()))
+}
+
+/// Parses the body of an `OVER ( … )` spec into (partition vars, order keys).
+fn parse_over_spec(spec: &str) -> Result<OverSpec, String> {
+    let spec = spec.trim();
+    let spec_up = spec.to_ascii_uppercase();
+    let part_kw = find_keyword(spec, "PARTITION");
+    let order_kw = find_keyword(spec, "ORDER");
+
+    let mut partition_by = Vec::new();
+    let mut order_by = Vec::new();
+
+    // Partition segment runs from after `PARTITION BY` to the ORDER keyword (or end).
+    if let Some(p) = part_kw {
+        let after = &spec[p..];
+        let after_up = &spec_up[p..];
+        let by = after_up
+            .find("BY")
+            .ok_or("inline OVER: PARTITION must be followed by BY")?;
+        let seg_start = p + by + 2;
+        let seg_end = order_kw.unwrap_or(spec.len());
+        if seg_end < seg_start {
+            return Err("inline OVER: ORDER BY must come after PARTITION BY".into());
+        }
+        partition_by = parse_var_list(&spec[seg_start..seg_end])?;
+        if partition_by.is_empty() {
+            return Err("inline OVER: PARTITION BY needs at least one variable".into());
+        }
+        let _ = after;
+    }
+
+    if let Some(o) = order_kw {
+        let after_up = &spec_up[o..];
+        let by = after_up.find("BY").ok_or("inline OVER: ORDER must be followed by BY")?;
+        let seg_start = o + by + 2;
+        order_by = parse_order_list(&spec[seg_start..])?;
+        if order_by.is_empty() {
+            return Err("inline OVER: ORDER BY needs at least one variable".into());
+        }
+    }
+
+    Ok((partition_by, order_by))
+}
+
+/// Parses a whitespace/comma-separated list of `?var` into bare names.
+fn parse_var_list(s: &str) -> Result<Vec<String>, String> {
+    let mut out = Vec::new();
+    for tok in s.split([',', ' ', '\t', '\n', '\r']).filter(|t| !t.is_empty()) {
+        let name = tok
+            .strip_prefix('?')
+            .or_else(|| tok.strip_prefix('$'))
+            .ok_or_else(|| format!("inline OVER: expected a ?variable in PARTITION BY, got {tok:?}"))?;
+        if name.is_empty() || !name.chars().all(is_varname_char) {
+            return Err(format!("inline OVER: invalid variable {tok:?}"));
+        }
+        out.push(name.to_string());
+    }
+    Ok(out)
+}
+
+/// Parses an ORDER BY list: `?v`, `ASC(?v)`, `DESC(?v)`, or `?v ASC`/`?v DESC`.
+fn parse_order_list(s: &str) -> Result<Vec<(String, bool)>, String> {
+    // Tokenise on commas first; each comma-separated key is one sort key.
+    let mut keys = Vec::new();
+    for raw in split_top_level_commas(s) {
+        let key = raw.trim();
+        if key.is_empty() {
+            continue;
+        }
+        keys.push(parse_one_order_key(key)?);
+    }
+    Ok(keys)
+}
+
+fn parse_one_order_key(key: &str) -> Result<(String, bool), String> {
+    let up = key.to_ascii_uppercase();
+    // DESC( ?v ) / ASC( ?v )
+    for (kw, desc) in [("DESC", true), ("ASC", false)] {
+        if up.starts_with(kw) {
+            let after = key[kw.len()..].trim_start();
+            if let Some(inner) = strip_outer_parens(after) {
+                let v = parse_single_var(inner.trim())?;
+                return Ok((v, desc));
+            }
+            // `?v ASC` / `?v DESC` trailing-keyword form is handled below; a bare
+            // `ASC`/`DESC` with no parens and no following token is malformed.
+        }
+    }
+    // Trailing-keyword form: `?v` | `?v ASC` | `?v DESC`.
+    let toks: Vec<&str> = key.split_whitespace().collect();
+    match toks.as_slice() {
+        [v] => Ok((parse_single_var(v)?, false)),
+        [v, dir] => {
+            let d = dir.to_ascii_uppercase();
+            let desc = match d.as_str() {
+                "DESC" => true,
+                "ASC" => false,
+                _ => return Err(format!("inline OVER: expected ASC/DESC after order var, got {dir:?}")),
+            };
+            Ok((parse_single_var(v)?, desc))
+        }
+        _ => Err(format!("inline OVER: malformed ORDER BY key {key:?}")),
+    }
+}
+
+fn parse_single_var(tok: &str) -> Result<String, String> {
+    let name = tok
+        .strip_prefix('?')
+        .or_else(|| tok.strip_prefix('$'))
+        .ok_or_else(|| format!("inline OVER: expected a ?variable, got {tok:?}"))?;
+    if name.is_empty() || !name.chars().all(is_varname_char) {
+        return Err(format!("inline OVER: invalid variable {tok:?}"));
+    }
+    Ok(name.to_string())
+}
+
+// ---- low-level lexical helpers ----------------------------------------------
+
+fn is_varname_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// `true` if `kw` (case-insensitive) appears in `s` as a whole word (not as a
+/// substring of an identifier / IRI). Used as the cheap `OVER`-presence gate.
+fn contains_keyword(s: &str, kw: &str) -> bool {
+    find_keyword(s, kw).is_some()
+}
+
+/// The byte offset of the first whole-word, case-insensitive occurrence of `kw`
+/// in `s`, or `None`. A "whole word" is bounded by non-identifier characters on
+/// both sides (so `OVER` does not match inside `?leftover` or `<.../over>`).
+fn find_keyword(s: &str, kw: &str) -> Option<usize> {
+    let su = s.to_ascii_uppercase();
+    let ku = kw.to_ascii_uppercase();
+    let bytes = su.as_bytes();
+    let mut from = 0;
+    while let Some(rel) = su[from..].find(&ku) {
+        let at = from + rel;
+        let before_ok = at == 0 || !is_ident_byte(bytes[at - 1]);
+        let after = at + ku.len();
+        let after_ok = after >= bytes.len() || !is_ident_byte(bytes[after]);
+        if before_ok && after_ok {
+            return Some(at);
+        }
+        from = at + 1;
+    }
+    None
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Finds (SELECT-keyword offset, projection-start offset) for the top-level
+/// SELECT. The projection starts after `SELECT` and any `DISTINCT`/`REDUCED`.
+fn find_select_projection_start(s: &str) -> Option<(usize, usize)> {
+    let sel = find_keyword(s, "SELECT")?;
+    let mut pos = sel + "SELECT".len();
+    // Skip whitespace then an optional DISTINCT / REDUCED modifier.
+    loop {
+        let rest = &s[pos..];
+        let trimmed_len = rest.len() - rest.trim_start().len();
+        pos += trimmed_len;
+        let rest = &s[pos..];
+        let up = rest.to_ascii_uppercase();
+        if up.starts_with("DISTINCT") && !rest[8..].starts_with(|c: char| is_varname_char(c)) {
+            pos += "DISTINCT".len();
+            continue;
+        }
+        if up.starts_with("REDUCED") && !rest[7..].starts_with(|c: char| is_varname_char(c)) {
+            pos += "REDUCED".len();
+            continue;
+        }
+        break;
+    }
+    // Re-skip whitespace before the first projection item.
+    let rest = &s[pos..];
+    pos += rest.len() - rest.trim_start().len();
+    Some((sel, pos))
+}
+
+/// Finds the byte offset where the SELECT projection ends: the top-level `WHERE`
+/// keyword, or the `{` that opens the group graph pattern (WHERE is optional in
+/// SPARQL). Scanning starts at `from` and respects nested parens (so a `(… {…})`
+/// inside the projection — which can't legally happen, but be safe — and IRIs are
+/// not mistaken for the WHERE block).
+fn find_projection_end(s: &str, from: usize) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut depth: i32 = 0;
+    let mut i = from;
+    let su = s.to_ascii_uppercase();
+    while i < bytes.len() {
+        let b = bytes[i];
+        match b {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            b'<' => {
+                // Skip an IRI ref so a '{'/'}' inside it is ignored.
+                if let Some(close) = s[i..].find('>') {
+                    i += close;
+                }
+            }
+            b'{' if depth == 0 => return Some(i),
+            _ => {
+                if depth == 0 && su[i..].starts_with("WHERE") {
+                    let after = i + 5;
+                    let before_ok = i == 0 || !is_ident_byte(bytes[i - 1]);
+                    let after_ok = after >= bytes.len() || !is_ident_byte(bytes[after]);
+                    if before_ok && after_ok {
+                        return Some(i);
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Splits a projection string into its top-level items: a bare `?var`, a
+/// parenthesised `( … AS ?v )`, or `*`. Items are separated by whitespace EXCEPT
+/// inside parentheses (a `( … )` is one item however much whitespace it holds).
+fn split_projection_items(proj: &str) -> Result<Vec<String>, String> {
+    let mut items = Vec::new();
+    let bytes = proj.as_bytes();
+    let mut i = 0;
+    while i < proj.len() {
+        // Skip whitespace.
+        while i < proj.len() && (bytes[i] as char).is_whitespace() {
+            i += 1;
+        }
+        if i >= proj.len() {
+            break;
+        }
+        if bytes[i] == b'(' {
+            let close =
+                matching_paren(proj, i).ok_or("inline OVER: unbalanced '(' in SELECT projection")?;
+            items.push(proj[i..=close].to_string());
+            i = close + 1;
+        } else {
+            let start = i;
+            while i < proj.len() && !(bytes[i] as char).is_whitespace() && bytes[i] != b'(' {
+                i += 1;
+            }
+            items.push(proj[start..i].to_string());
+        }
+    }
+    Ok(items)
+}
+
+/// Splits a string on top-level commas (commas not inside parentheses).
+fn split_top_level_commas(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut depth: i32 = 0;
+    let mut start = 0;
+    let bytes = s.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            b',' if depth == 0 => {
+                out.push(s[start..i].to_string());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    out.push(s[start..].to_string());
+    out
+}
+
+/// If `s` (trimmed) is a single fully-parenthesised group, returns its interior.
+/// `(a (b) c)` → `a (b) c`. Returns `None` if `s` does not start with `(` or the
+/// first `(` does not close at the very end.
+fn strip_outer_parens(s: &str) -> Option<&str> {
+    let s = s.trim();
+    if !s.starts_with('(') {
+        return None;
+    }
+    let close = matching_paren(s, 0)?;
+    if close == s.len() - 1 {
+        Some(&s[1..close])
+    } else {
+        None
+    }
+}
+
+/// The byte offset of the `)` matching the `(` at byte offset `open` in `s`.
+fn matching_paren(s: &str, open: usize) -> Option<usize> {
+    let bytes = s.as_bytes();
+    if bytes.get(open) != Some(&b'(') {
+        return None;
+    }
+    let mut depth: i32 = 0;
+    let mut i = open;
+    while i < s.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            b'<' => {
+                if let Some(rel) = s[i..].find('>') {
+                    i += rel;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// The OUTPUT variable a non-window projection item binds: `?v` → `v`, or the
+/// `?v` from a `( expr AS ?v )` alias.
+fn projection_item_output_var(item: &str) -> Result<String, String> {
+    let t = item.trim();
+    if let Some(name) = t.strip_prefix('?').or_else(|| t.strip_prefix('$')) {
+        if name.chars().all(is_varname_char) && !name.is_empty() {
+            return Ok(name.to_string());
+        }
+    }
+    if let Some(inner) = strip_outer_parens(t) {
+        // ( expr AS ?v ): the alias var is after the last top-level `AS`.
+        if let Some(as_pos) = find_keyword(inner, "AS") {
+            let after = inner[as_pos + 2..].trim();
+            if let Some(name) = after.strip_prefix('?').or_else(|| after.strip_prefix('$')) {
+                let name = name.trim();
+                if name.chars().all(is_varname_char) && !name.is_empty() {
+                    return Ok(name.to_string());
+                }
+            }
+        }
+    }
+    Err(format!("inline OVER: cannot determine the output variable of projection item {item:?}"))
+}
+
+/// `true` if a non-window projection item's OUTPUT var equals `name` (so a helper
+/// var need not be re-projected).
+fn projection_item_mentions_output(item: &str, name: &str) -> bool {
+    projection_item_output_var(item).map(|v| v == name).unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DATA: &str = r#"@prefix ex: <http://ex/> .
+        ex:a ex:dept ex:eng   ; ex:sales 30 .
+        ex:b ex:dept ex:eng   ; ex:sales 30 .
+        ex:c ex:dept ex:eng   ; ex:sales 20 .
+        ex:d ex:dept ex:sales ; ex:sales 10 ."#;
+
+    fn g() -> Graph {
+        Graph::load_str(DATA, "turtle").unwrap()
+    }
+
+    fn cell(r: &QueryResult, row: usize, col: usize) -> String {
+        r.rows[row][col].as_ref().map(|t| t.to_string()).unwrap_or_default()
+    }
+
+    // ---- unit tests on the rewriter ----
+
+    #[test]
+    fn detects_no_over_returns_none() {
+        assert!(extract_windows("SELECT ?s WHERE { ?s ?p ?o }").unwrap().is_none());
+        // `?over` must NOT trip the keyword scan.
+        assert!(extract_windows("SELECT ?over WHERE { ?over ?p ?o }").unwrap().is_none());
+    }
+
+    #[test]
+    fn parses_row_number_item() {
+        let w = parse_window_item("(ROW_NUMBER() OVER (PARTITION BY ?dept ORDER BY DESC(?sales)) AS ?rn)")
+            .unwrap()
+            .unwrap();
+        assert_eq!(w.func, RankFunc::RowNumber);
+        assert_eq!(w.partition_by, vec!["dept".to_string()]);
+        assert_eq!(w.order_by, vec![("sales".to_string(), true)]);
+        assert_eq!(w.out, "rn");
+    }
+
+    #[test]
+    fn parses_trailing_keyword_order_form() {
+        let w = parse_window_item("(RANK() OVER (PARTITION BY ?dept ORDER BY ?sales DESC) AS ?r)")
+            .unwrap()
+            .unwrap();
+        assert_eq!(w.func, RankFunc::Rank);
+        assert_eq!(w.order_by, vec![("sales".to_string(), true)]);
+    }
+
+    #[test]
+    fn rejects_windowed_aggregate_inline() {
+        // A windowed aggregate (`SUM(?x) OVER …`) is DEFERRED: SUM is not in the
+        // covered ranking-function set, so it is rejected as unsupported.
+        let e = parse_window_item("(SUM(?sales) OVER (PARTITION BY ?dept) AS ?t)").unwrap_err();
+        assert!(e.contains("unsupported window function") && e.contains("SUM"), "{e}");
+        // And a covered function called WITH args (the other way to write a windowed
+        // aggregate) is rejected for the non-empty arg list, naming the deferral.
+        let e2 = parse_window_item("(RANK(?sales) OVER (PARTITION BY ?dept) AS ?t)").unwrap_err();
+        assert!(e2.contains("empty args") && e2.contains("aggregate"), "{e2}");
+    }
+
+    #[test]
+    fn rejects_unknown_window_function() {
+        let e = parse_window_item("(NTILE() OVER (ORDER BY ?x) AS ?n)").unwrap_err();
+        assert!(e.contains("unsupported window function"), "{e}");
+    }
+
+    // ---- end-to-end parse + eval ----
+
+    #[test]
+    fn row_number_over_partition_order() {
+        let q = "PREFIX ex: <http://ex/> \
+            SELECT ?emp ?dept ?sales (ROW_NUMBER() OVER (PARTITION BY ?dept ORDER BY DESC(?sales)) AS ?rn) \
+            WHERE { ?emp ex:dept ?dept ; ex:sales ?sales } ORDER BY ?dept DESC(?sales) ?emp";
+        let r = query_over(&g(), q).unwrap();
+        // Columns: emp, dept, sales, rn.
+        assert_eq!(r.vars.iter().map(|v| v.as_str()).collect::<Vec<_>>(), ["emp", "dept", "sales", "rn"]);
+        // eng (30,30,20) desc → rn 1,2,3 (a,b tie at 30, broken by ?emp asc); sales (10) → rn 1.
+        // Row order by ORDER BY ?dept DESC(?sales) ?emp: sales/d first (dept "sales" > "eng" lexically? IRIs).
+        // Be order-agnostic: collect (dept,sales,rn) and check the multiset of rn per dept.
+        let mut eng_rns: Vec<i64> = Vec::new();
+        let mut sales_rns: Vec<i64> = Vec::new();
+        for row in &r.rows {
+            let dept = row[1].as_ref().unwrap().to_string();
+            let rn: i64 = row[3].as_ref().unwrap().to_string().trim_matches('"').split('"').next().unwrap()
+                .parse().unwrap_or_else(|_| literal_int(&row[3]));
+            if dept.contains("/eng") {
+                eng_rns.push(rn);
+            } else {
+                sales_rns.push(rn);
+            }
+        }
+        eng_rns.sort();
+        sales_rns.sort();
+        assert_eq!(eng_rns, vec![1, 2, 3]);
+        assert_eq!(sales_rns, vec![1]);
+    }
+
+    fn literal_int(cell: &Option<oxrdf::Term>) -> i64 {
+        if let Some(oxrdf::Term::Literal(l)) = cell {
+            l.value().parse().unwrap()
+        } else {
+            panic!("not an integer literal: {cell:?}")
+        }
+    }
+
+    #[test]
+    fn rank_and_dense_rank_sequence() {
+        // RANK has gaps after ties; DENSE_RANK does not. eng sales 30,30,20.
+        let qr = "PREFIX ex: <http://ex/> \
+            SELECT ?emp (RANK() OVER (PARTITION BY ?dept ORDER BY DESC(?sales)) AS ?r) \
+            WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }";
+        let r = query_over(&g(), qr).unwrap();
+        // Map emp → rank.
+        let rank_of = |r: &QueryResult, emp: &str| -> i64 {
+            for row in &r.rows {
+                if row[0].as_ref().unwrap().to_string().contains(emp) {
+                    return literal_int(&row[1]);
+                }
+            }
+            panic!("emp {emp} not found");
+        };
+        assert_eq!(rank_of(&r, "/a"), 1);
+        assert_eq!(rank_of(&r, "/b"), 1);
+        assert_eq!(rank_of(&r, "/c"), 3); // GAP after the 2-way tie
+        assert_eq!(rank_of(&r, "/d"), 1); // own partition
+
+        let qd = "PREFIX ex: <http://ex/> \
+            SELECT ?emp (DENSE_RANK() OVER (PARTITION BY ?dept ORDER BY DESC(?sales)) AS ?r) \
+            WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }";
+        let d = query_over(&g(), qd).unwrap();
+        let drank_of = |emp: &str| -> i64 {
+            for row in &d.rows {
+                if row[0].as_ref().unwrap().to_string().contains(emp) {
+                    return literal_int(&row[1]);
+                }
+            }
+            panic!();
+        };
+        assert_eq!(drank_of("/a"), 1);
+        assert_eq!(drank_of("/c"), 2); // NO gap
+    }
+
+    #[test]
+    fn helper_var_not_in_output_is_projected_through_then_dropped() {
+        // ?sales is used only by the window ORDER BY and is NOT in the SELECT output;
+        // it must be projected through the inner query then dropped from the result.
+        let q = "PREFIX ex: <http://ex/> \
+            SELECT ?emp (RANK() OVER (ORDER BY DESC(?sales)) AS ?r) \
+            WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }";
+        let r = query_over(&g(), q).unwrap();
+        assert_eq!(r.vars.iter().map(|v| v.as_str()).collect::<Vec<_>>(), ["emp", "r"]);
+        // Single partition (no PARTITION BY): 30,30,20,10 → ranks 1,1,3,4.
+        let mut ranks: Vec<i64> = r.rows.iter().map(|row| literal_int(&row[1])).collect();
+        ranks.sort();
+        assert_eq!(ranks, vec![1, 1, 3, 4]);
+    }
+
+    #[test]
+    fn select_star_with_window_keeps_all_plus_window_col() {
+        let q = "PREFIX ex: <http://ex/> \
+            SELECT * (ROW_NUMBER() OVER (PARTITION BY ?dept ORDER BY ?sales) AS ?rn) \
+            WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }";
+        let r = query_over(&g(), q).unwrap();
+        let names: Vec<&str> = r.vars.iter().map(|v| v.as_str()).collect();
+        assert!(names.contains(&"emp") && names.contains(&"dept") && names.contains(&"sales"));
+        assert!(names.contains(&"rn"), "window column appended: {names:?}");
+    }
+
+    #[test]
+    fn non_window_query_is_unchanged() {
+        // A query with no OVER goes straight through the ordinary engine.
+        let q = "PREFIX ex: <http://ex/> SELECT ?emp WHERE { ?emp ex:dept ?d }";
+        let r = query_over(&g(), q).unwrap();
+        assert_eq!(r.vars.iter().map(|v| v.as_str()).collect::<Vec<_>>(), ["emp"]);
+        assert_eq!(r.rows.len(), 4);
+    }
+
+    #[test]
+    fn two_window_columns_in_one_select() {
+        let q = "PREFIX ex: <http://ex/> \
+            SELECT ?emp \
+                (ROW_NUMBER() OVER (PARTITION BY ?dept ORDER BY DESC(?sales)) AS ?rn) \
+                (DENSE_RANK() OVER (PARTITION BY ?dept ORDER BY DESC(?sales)) AS ?dr) \
+            WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }";
+        let r = query_over(&g(), q).unwrap();
+        assert_eq!(r.vars.iter().map(|v| v.as_str()).collect::<Vec<_>>(), ["emp", "rn", "dr"]);
+        let _ = cell(&r, 0, 1);
+    }
+
+    #[test]
+    fn malformed_over_is_error() {
+        // Missing AS alias.
+        assert!(query_over(&g(), "PREFIX ex: <http://ex/> SELECT (ROW_NUMBER() OVER (ORDER BY ?sales)) WHERE { ?emp ex:sales ?sales }").is_err());
+        // Non-empty args (a windowed aggregate, deferred).
+        assert!(query_over(&g(), "PREFIX ex: <http://ex/> SELECT (SUM(?sales) OVER (PARTITION BY ?dept) AS ?t) WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }").is_err());
+    }
+}

--- a/crates/sparq-engine/tests/window_inline_over.rs
+++ b/crates/sparq-engine/tests/window_inline_over.rs
@@ -1,0 +1,104 @@
+//! Integration test for the inline `OVER(…)` window-clause SYNTAX (sq-h564),
+//! exercised through the public `sparq_engine::query_over` entry point — a
+//! NON-STANDARD, OPT-IN extension (the `window-functions` cargo feature). This is
+//! the end-to-end "parse + eval an inline-OVER query" check the bead asks for:
+//! a `ROW_NUMBER()` / `RANK()` over a known `PARTITION BY` / `ORDER BY` yields the
+//! correct sequence. [OPUS-4.8]
+#![cfg(feature = "window-functions")]
+
+use oxrdf::Term;
+use sparq_core::Graph;
+use sparq_engine::{query_over, QueryResult};
+
+const DATA: &str = r#"@prefix ex: <http://ex/> .
+    ex:a ex:dept "eng"   ; ex:sales 30 .
+    ex:b ex:dept "eng"   ; ex:sales 30 .
+    ex:c ex:dept "eng"   ; ex:sales 20 .
+    ex:d ex:dept "sales" ; ex:sales 10 .
+    ex:e ex:dept "sales" ; ex:sales 40 ."#;
+
+fn g() -> Graph {
+    Graph::load_str(DATA, "turtle").unwrap()
+}
+
+fn int(cell: &Option<Term>) -> i64 {
+    match cell {
+        Some(Term::Literal(l)) => l.value().parse().expect("integer literal"),
+        other => panic!("expected an integer literal, got {other:?}"),
+    }
+}
+
+/// emp short name (`ex:a` → `a`).
+fn name(cell: &Option<Term>) -> String {
+    match cell {
+        Some(Term::NamedNode(n)) => n.as_str().rsplit('/').next().unwrap().to_string(),
+        other => panic!("expected an IRI, got {other:?}"),
+    }
+}
+
+/// Find the value in `col` for the row whose `emp` (col 0) short name is `emp`.
+fn for_emp(r: &QueryResult, emp: &str, col: usize) -> i64 {
+    for row in &r.rows {
+        if name(&row[0]) == emp {
+            return int(&row[col]);
+        }
+    }
+    panic!("emp {emp} not found in result");
+}
+
+#[test]
+fn row_number_over_partition_by_order_by() {
+    let q = "PREFIX ex: <http://ex/> \
+        SELECT ?emp \
+            (ROW_NUMBER() OVER (PARTITION BY ?dept ORDER BY DESC(?sales)) AS ?rn) \
+        WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }";
+    let r = query_over(&g(), q).unwrap();
+    assert_eq!(r.vars.iter().map(|v| v.as_str()).collect::<Vec<_>>(), ["emp", "rn"]);
+    // eng partition desc by sales: a=30,b=30 tie (broken stably by input order → a<b),
+    // then c=20 → row numbers a=1, b=2, c=3.
+    assert_eq!(for_emp(&r, "a", 1), 1);
+    assert_eq!(for_emp(&r, "b", 1), 2);
+    assert_eq!(for_emp(&r, "c", 1), 3);
+    // sales partition desc: e=40, d=10 → e=1, d=2.
+    assert_eq!(for_emp(&r, "e", 1), 1);
+    assert_eq!(for_emp(&r, "d", 1), 2);
+}
+
+#[test]
+fn rank_has_gaps_after_ties() {
+    let q = "PREFIX ex: <http://ex/> \
+        SELECT ?emp \
+            (RANK() OVER (PARTITION BY ?dept ORDER BY DESC(?sales)) AS ?r) \
+        WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }";
+    let r = query_over(&g(), q).unwrap();
+    // eng: a=30,b=30 → rank 1; c=20 → rank 3 (GAP after the 2-way tie).
+    assert_eq!(for_emp(&r, "a", 1), 1);
+    assert_eq!(for_emp(&r, "b", 1), 1);
+    assert_eq!(for_emp(&r, "c", 1), 3);
+    // sales: e=40 → 1, d=10 → 2.
+    assert_eq!(for_emp(&r, "e", 1), 1);
+    assert_eq!(for_emp(&r, "d", 1), 2);
+}
+
+#[test]
+fn trailing_keyword_order_direction() {
+    // `ORDER BY ?sales DESC` (the SQL trailing-keyword spelling) parses the same
+    // as `ORDER BY DESC(?sales)`.
+    let q = "PREFIX ex: <http://ex/> \
+        SELECT ?emp \
+            (DENSE_RANK() OVER (PARTITION BY ?dept ORDER BY ?sales DESC) AS ?dr) \
+        WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }";
+    let r = query_over(&g(), q).unwrap();
+    // eng dense rank: 30→1, 30→1, 20→2 (no gap).
+    assert_eq!(for_emp(&r, "a", 1), 1);
+    assert_eq!(for_emp(&r, "c", 1), 2);
+}
+
+#[test]
+fn ordinary_query_passes_through_unchanged() {
+    // No OVER clause → identical to sparq_engine::query.
+    let q = "PREFIX ex: <http://ex/> SELECT ?emp WHERE { ?emp ex:dept ?d }";
+    let viaq = query_over(&g(), q).unwrap();
+    assert_eq!(viaq.rows.len(), 5);
+    assert_eq!(viaq.vars.iter().map(|v| v.as_str()).collect::<Vec<_>>(), ["emp"]);
+}

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -104,7 +104,9 @@ Extension functions (SPARQL 17.6) and dataset views:
 - *(opt-in `window-functions`)* `CustomAggregateRegistry::new()` + `.register(iri, |members:
   &[Option<Term>]| -> Result<Option<Term>, String>)`; `query_with_aggregates(&Graph, &str, &reg)`
   (+ `_and_budget`) parses+installs, `with_aggregates(&reg, || …)` scopes it. Window functions:
-  `window::{WindowSpec, WindowFunction, WindowAggregate, SortKey, apply_window}` (programmatic pass).
+  `window::{WindowSpec, WindowFunction, WindowAggregate, SortKey, apply_window}` (programmatic pass),
+  or `query_over(&Graph, &str)` (+ `_with_budget`) for the inline `OVER(…)` query syntax (a source
+  rewrite over the engine; covers `ROW_NUMBER`/`RANK`/`DENSE_RANK` with `PARTITION BY`/`ORDER BY`).
 
 Introspection: `explain(&Graph, &str)` (plan-only) and `explain_analyze(&Graph, &str)` (plan + per-
 operator execution trace).
@@ -203,10 +205,13 @@ let r = query_with_aggregates(&g,
 ```
 
 **Window functions** (opt-in `window-functions` feature) — **NON-STANDARD extension**: SPARQL has no
-W3C-REC `OVER (PARTITION BY … ORDER BY …)` syntax, so sparq exposes windowing as a *programmatic pass
-over a `QueryResult`* whose semantics follow the SQL:2003 window model (the surface Stardog / AnzoGraph
-expose). Run an ordinary SELECT, then apply a `WindowSpec` (`ROW_NUMBER` / `RANK` / `DENSE_RANK`, or a
-windowed aggregate over the whole partition). One column is appended; row order is preserved:
+W3C-REC `OVER (PARTITION BY … ORDER BY …)` syntax, so sparq exposes windowing two ways, both following
+the SQL:2003 window model (the surface Stardog / AnzoGraph expose) and neither touching the engine's
+W3C-conformance SPARQL surface.
+
+*(a) Programmatic pass over a `QueryResult`* — the full surface. Run an ordinary SELECT, then apply a
+`WindowSpec` (`ROW_NUMBER` / `RANK` / `DENSE_RANK`, or a windowed aggregate over the whole partition).
+One column is appended; row order is preserved:
 
 ```rust
 use sparq_engine::window::{apply_window, SortKey, WindowFunction, WindowSpec};
@@ -222,6 +227,30 @@ let spec = WindowSpec {
 let ranked = apply_window(&result, &spec).unwrap(); // ?rank appended; RANK has gaps after ties
 // Windowed aggregate (whole-partition frame): WindowFunction::Aggregate { agg: WindowAggregate::Sum, of }
 ```
+
+*(b) Inline `OVER(…)` query syntax* (sq-h564) — write the window directly in the SELECT projection and
+run it with `query_over` / `query_over_with_budget`. This is a **source rewrite in front of the engine**
+(it does NOT change the vendored `spargebra` parser): `query_over` lifts each `(FN() OVER (…) AS ?out)`
+item out of the projection, runs the window-stripped SELECT through the ordinary engine, applies the
+programmatic pass above, then reprojects. **Covered subset:** `ROW_NUMBER()`, `RANK()`, `DENSE_RANK()`
+(case-insensitive), `PARTITION BY ?v …`, `ORDER BY` over projected variables in both `DESC(?v)` and
+`?v DESC` spellings, multiple window columns, and `SELECT *`. A query with no `OVER` clause is run
+unchanged (so `query_over` is a strict superset of `query` for non-window queries):
+
+```rust
+// Cargo.toml: sparq-engine = { version = "0.1", features = ["window-functions"] }
+let r = sparq_engine::query_over(&g,
+    "PREFIX ex: <http://ex/> \
+     SELECT ?emp (ROW_NUMBER() OVER (PARTITION BY ?dept ORDER BY DESC(?sales)) AS ?rn) \
+     WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }").unwrap(); // ?rn = per-?dept rank, descending by ?sales
+```
+
+**Inline-OVER caveats (HONEST):** the `OVER` surface is a sparq extension, not W3C SPARQL, recognised
+ONLY on the `query_over` entry point (a `(… OVER …)` clause is still a parse error on `query`/the
+standard surface). The function call must be empty (`ROW_NUMBER()`), the `AS ?out` alias is required,
+and `ORDER BY` keys must be projected variables. **Deferred (programmatic API only, beaded):** inline
+windowed AGGREGATES (`SUM(?x) OVER (…)`), explicit frames (`ROWS BETWEEN …`), `LAG`/`LEAD`/`NTILE`, a
+named `WINDOW` clause, and ordering by a computed expression.
 
 **Budgets / timeouts / ASK-style early exit** — a `QueryBudget` is checked cooperatively at coarse
 sites; tripping it fails with `"query budget exceeded (timeout)"` / `"... (max-rows)"`:
@@ -283,12 +312,16 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   (default ~50). The knob never changes results — only the remote-request count vs per-request size.
 - **Window functions + custom aggregate registry** are the non-default `window-functions` cargo
   feature. **Window functions are a NON-STANDARD extension** — there is no W3C-REC SPARQL `OVER`
-  syntax — so they are a programmatic pass over a `QueryResult` (the SQL:2003 model Stardog/AnzoGraph
-  expose), `ROW_NUMBER`/`RANK`/`DENSE_RANK` + a whole-partition windowed aggregate, NOT inline query
-  syntax (the engine's SPARQL surface stays exactly SPARQL 1.1, so conformance is unaffected). The
-  custom-aggregate side DOES ride real SPARQL `GROUP BY` (a declared aggregate IRI is part of the
-  SPARQL 1.1 extension grammar). When the feature is off, zero window/aggregate-registry code compiles
-  and the default build is byte-identical (no new dependencies). See the recipes above.
+  syntax. sparq exposes them as a programmatic pass over a `QueryResult` (the SQL:2003 model
+  Stardog/AnzoGraph expose), `ROW_NUMBER`/`RANK`/`DENSE_RANK` + a whole-partition windowed aggregate,
+  AND as an inline `OVER(…)` query syntax via the dedicated `query_over` entry point (a *source rewrite*
+  in front of the engine — it does NOT change the vendored parser, so the standard `query`/`ask`/… surface
+  stays exactly SPARQL 1.1 and conformance is unaffected; `OVER` is a parse error everywhere except
+  `query_over`). The inline syntax covers the three ranking functions with `PARTITION BY`/`ORDER BY`;
+  windowed aggregates, frames, `LAG`/`LEAD`/`NTILE` and a named `WINDOW` clause are inline-deferred (use
+  the programmatic API). The custom-aggregate side DOES ride real SPARQL `GROUP BY` (a declared aggregate
+  IRI is part of the SPARQL 1.1 extension grammar). When the feature is off, zero window/aggregate-registry
+  code compiles and the default build is byte-identical (no new dependencies). See the recipes above.
 - **Default cargo features** (`parallel`, `regex`, `digest`): `regex` powers REGEX/REPLACE; `digest`
   powers MD5/SHA*; `parallel` enables rayon scan/join/sort/aggregate. The **wasm** crate
   (`sparq-wasm`) disables defaults, so on `wasm32-unknown-unknown` REGEX/hash builtins and


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

Adds **inline `OVER(...)` window-clause SYNTAX** to `sparq-engine`, behind the **existing `window-functions` cargo feature** (no new feature → no new feature-matrix leg). Window functions + the custom-aggregate registry already landed in PR #370 (sq-5qz9) via the *programmatic* API; this bead (sq-h564) adds the **inline query syntax** so a query can write e.g. `ROW_NUMBER() OVER (PARTITION BY ?x ORDER BY ?y)`.

A new entry point `query_over` / `query_over_with_budget` recognises window items in the SELECT projection. It is implemented as a **source rewrite in front of the engine** — it lifts each `(FN() OVER (…) AS ?out)` item out of the projection, runs the window-stripped SELECT through the ordinary engine, applies the programmatic `window::apply_window` pass, then reprojects. **It does NOT touch the vendored (W3C-conformance-tracking) `spargebra` parser**, so the standard `query`/`ask`/… surface stays exactly SPARQL 1.1 and `OVER` is still a parse error everywhere except `query_over`.

## OVER syntax + source

SPARQL has **no W3C-REC window syntax** — this is a NON-STANDARD, opt-in extension following the **SQL:2003 / Stardog / AnzoGraph** `OVER (PARTITION BY … ORDER BY …)` convention (the same model the programmatic pass from #370 already documents), restricted to the three ranking functions:

```sparql
SELECT ?emp ?dept ?sales
       (ROW_NUMBER() OVER (PARTITION BY ?dept ORDER BY DESC(?sales)) AS ?rn)
WHERE { ?emp :dept ?dept ; :sales ?sales }
```

Both `ORDER BY DESC(?sales)` and `ORDER BY ?sales DESC` are accepted.

## Covered vs deferred

**Covered:** `ROW_NUMBER()`, `RANK()`, `DENSE_RANK()` (case-insensitive); `PARTITION BY` over ≥1 var; `ORDER BY` over projected vars (ASC/DESC, both spellings); multiple window columns; `SELECT *`; a non-window query passes through unchanged (`query_over` ⊇ `query`).

**Deferred (programmatic API still covers these), beaded:**
- `sq-83l0` — inline windowed aggregates (`SUM(?x) OVER (…)`) + explicit frames (`ROWS BETWEEN …`)
- `sq-hqhc` — `LAG`/`LEAD`/`NTILE` + a named `WINDOW` clause
- `sq-5bxk` — `ORDER BY` a computed expression (not just a projected var)

## Tests

- **12 unit tests** in `window_syntax.rs` — the rewriter (keyword detection, item parsing, both ORDER-direction spellings, helper-var projection, `SELECT *`, error paths) + parse-and-eval (`ROW_NUMBER`/`RANK`/`DENSE_RANK` sequences, two window columns).
- **4 integration tests** in `tests/window_inline_over.rs` — end-to-end through the public `query_over`: `ROW_NUMBER()`/`RANK()` over a known `PARTITION BY`/`ORDER BY` yield the correct sequence (incl. tie/gap behaviour), trailing-keyword direction, ordinary-query pass-through.

## Gates (both feature states)

- **feature ON** (`--features window-functions`): `build` ✓ · `clippy --all-targets -D warnings` ✓ · `test` ✓ (213 lib + integration, 0 failures) · doctests ✓
- **feature OFF**: `build` ✓ · `clippy --all-targets -D warnings` ✓ · `test` ✓ (193 lib + integration, 0 failures)
- **Conformance not regressed**: the change is structurally inert on the standard path — no existing entry point calls into the new module, and the vendored parser is unmodified; `sparq-conformance` crate tests still green.

## Docs

`skills/sparql-query/SKILL.md` + `crates/sparq-engine/README.md` updated with the inline `OVER` syntax, the `query_over` entry point, and the non-standard / source-rewrite / deferral caveats.