### PR TITLE
ci: harden privacy-claims gate against predicate-form soundness overclaims (sq-qhy4)

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -178,6 +178,14 @@ jobs:
           persist-credentials: false
       - name: No unqualified ZK/MPC privacy/soundness claims
         run: bash scripts/check-privacy-claims.sh
+      # [OPUS-4.8] sq-qhy4: both-direction self-tests for the predicate-form soundness
+      # coverage — should-FAIL overclaims ("the verifier is sound", "…are COMPLETE and
+      # SOUND", "provably sound") must be caught; should-PASS negated/hedged/non-crypto
+      # lines (incl. the canonical "SOUND as landed for the … threat model" verdict) must
+      # not regress. Hermetic (no git/network) — pins the gate classification. Runs in
+      # this same HARD job so a coverage regression also fails the ci-summary gate.
+      - name: Self-test the privacy-claims gate (both directions)
+        run: bash scripts/tests/test_privacy_claims.sh
 
   # ----------------------------- ADVISORY -----------------------------
   markdownlint-advisory:

--- a/scripts/check-privacy-claims.sh
+++ b/scripts/check-privacy-claims.sh
@@ -46,14 +46,63 @@ ALLOW_MARKER='privacy-claims-allow'
 # FORBIDDEN phrases — settled-property claim shapes for the ZK/MPC estate. Case-
 # insensitive, extended-regex. Each is a phrasing that, UNHEDGED, asserts a privacy
 # or soundness guarantee the estate does not yet provide.
+#
+# Two tiers (different exemption rules):
+#   PATTERNS         — ABSOLUTE forbidden phrases. A hit fails UNLESS the line carries
+#                      the `privacy-claims-allow:` marker. These shapes have no honest
+#                      unhedged reading (e.g. "provably secure", "privacy-preserving"),
+#                      so an inline-marker justification is the only escape.
+#   SOUNDNESS_CLAIMS — PREDICATE-FORM positive soundness overclaims about a ZK/MPC
+#                      *artifact* (the verifier / proof / protocol / scheme / circuit /
+#                      prover / SNARK / system / estate / construction is/are SOUND, or
+#                      "provably/fully/… sound"). [OPUS-4.8] sq-qhy4: the prior
+#                      `sound(ness)?-(verifier|proof)` adjacency pattern missed
+#                      predicate-form overclaims ("the verifier is SOUND",
+#                      "…are COMPLETE and SOUND") — one sat in zk/compose/STATUS.md
+#                      undetected until a manual sweep (PR #391). These are subject-
+#                      ANCHORED (a ZK/MPC artifact noun) so they don't trip honest
+#                      non-crypto "is sound" uses (an unsafe-code invariant, a cache
+#                      invalidation, an MPC detection heuristic, "sound engineering
+#                      choices"). A hit is EXEMPT if the line carries the allow-marker
+#                      OR a same-line negator/hedge (NEGATOR_HEDGE_RE) — so honest
+#                      "NOT sound", "is not sound", "unsound", and the project's
+#                      canonical hedged verdict "SOUND as landed for the … threat
+#                      model" all still PASS.
 PATTERNS=(
   'zero[- ]?knowledge[- ]secure'
-  'provably[- ](private|secure)'
+  'provably[- ](private|secure|sound)'
   'sound(ness)?[- ](verifier|proof)s?'
   'privacy[- ]?preserving'
   'malicious(ly)?[- ]secure'
   'cryptographically[- ](private|sound|secure)'
+  '(fully|completely|totally|unconditionally|perfectly)[- ]sound'
 )
+
+# [OPUS-4.8] Predicate-form soundness overclaim, subject-anchored on a ZK/MPC artifact
+# noun + copula + "sound" (e.g. "the verifier is sound", "the proofs are sound", "the
+# protocol is sound"). The anchoring keeps it OFF honest non-crypto "is sound" lines.
+ZK_ARTIFACT='(verifier|proof|protocol|scheme|circuit|prover|snark|construction|the[- ]zk[- ]?(system|estate|pipeline))'
+# Copula clause: the artifact noun, then is/are/'s/'re, then "sound" — allowing up to two
+# intervening conjoined adjectives ("complete and sound", "correct, complete and sound")
+# so the PR-#391 shape ("…are COMPLETE and SOUND") is caught, not just bare "is sound".
+COPULA='[- ]+(is|are|s|re)[- ]+([a-z]+[- ,]+(and[- ]+)?){0,2}sound'
+SOUNDNESS_CLAIMS=(
+  "${ZK_ARTIFACT}s?${COPULA}"
+)
+
+# Same-line NEGATOR / HEDGE exemption — applies ONLY to a SOUNDNESS_CLAIMS hit (not to
+# the absolute PATTERNS). If any of these is present on the offending line, the soundness
+# mention is honest (negated / qualified / aspirational) and PASSES:
+#   - negators:  not / never / no / isn't / aren't / n't / un(sound) / yet-(not-) ...
+#   - the project's load-bearing hedge: "sound AS LANDED [for the … threat model]" and
+#     scoped "sound FOR <axis>" (e.g. "sound for integrity"), plus an explicit open/
+#     pending/unverified/whether/question uncertainty qualifier on the same line.
+# Deliberately NARROW (structural negators + the canonical hedges + genuine-uncertainty
+# words) — NO broad lexical escape hatch like a bare "if"/"claim", so an overclaim can't
+# slip past on an incidental word; verified that no honest in-repo line relies on those.
+# An over-matched legitimate line still has the explicit `privacy-claims-allow:` escape.
+# Case-insensitive (matched with grep -i below).
+NEGATOR_HEDGE_RE='\bnot\b|\bnever\b|\bno\b|\bn'"'"'t\b|\bun(sound|verified|audited)|not[- ]yet|yet[- ]to|\bopen\b|\bpending\b|\bunverified\b|\bremediat|sound[- ]+as[- ]+landed|sound[- ]+for[- ]+(the[- ]+)?(integrity|threat|assumed|stated)|\bwhether\b|\bquestion\b'
 
 # Path surface to scan = the OUTWARD claim surface (docs/READMEs/skills/site copy /
 # the compliance index). Excludes:
@@ -76,9 +125,17 @@ mapfile -t FILES < <(
     | sort -u
 )
 
-# Build one alternation regex.
+# Build the two alternation regexes.
+#   RE          — absolute forbidden phrases (allow-marker is the only exemption).
+#   SOUNDNESS_RE — predicate-form soundness overclaims (allow-marker OR same-line
+#                  negator/hedge exempts).
 RE="$(printf '%s|' "${PATTERNS[@]}")"
 RE="${RE%|}"
+SOUNDNESS_RE="$(printf '%s|' "${SOUNDNESS_CLAIMS[@]}")"
+SOUNDNESS_RE="${SOUNDNESS_RE%|}"
+# A single union for the per-line scan; the per-line classification below decides
+# whether a given hit was an absolute one or a guarded soundness one.
+UNION_RE="${RE}|${SOUNDNESS_RE}"
 
 fail=0
 hits=0
@@ -87,8 +144,16 @@ for f in "${FILES[@]}"; do
   # -n line numbers, -i case-insensitive, -E extended.
   while IFS= read -r line; do
     # `line` is "LINENO:CONTENT".
+    content="${line#*:}"   # strip the "LINENO:" prefix for content-only checks.
     if printf '%s\n' "$line" | grep -qiF "$ALLOW_MARKER"; then
       continue   # explicitly allow-listed with an inline justification.
+    fi
+    # If the ONLY thing this line matched was a guarded soundness claim (it does NOT
+    # match an absolute PATTERN), a same-line negator/hedge exempts it as honest.
+    if ! printf '%s\n' "$content" | grep -qiE "$RE"; then
+      if printf '%s\n' "$content" | grep -qiE "$NEGATOR_HEDGE_RE"; then
+        continue   # negated / qualified / aspirational soundness mention — honest.
+      fi
     fi
     hits=$((hits + 1))
     if [ "$fail" -eq 0 ]; then
@@ -97,7 +162,7 @@ for f in "${FILES[@]}"; do
     fi
     echo "  ${f}:${line}"
     fail=1
-  done < <(grep -niE "$RE" "$f" 2>/dev/null || true)
+  done < <(grep -niE "$UNION_RE" "$f" 2>/dev/null || true)
 done
 
 if [ "$fail" -ne 0 ]; then

--- a/scripts/tests/test_privacy_claims.sh
+++ b/scripts/tests/test_privacy_claims.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] Hermetic both-direction self-tests for scripts/check-privacy-claims.sh
+# (bead sq-qhy4 — the ZK-soundness honesty gate). Authored by Opus 4.8 (Fable
+# unavailable; flag for re-review when Fable returns).
+#
+# WHY: the gate's `sound(ness)?-(verifier|proof)` pattern caught adjacency
+# ("sound verifier") but NOT predicate-form overclaims ("the verifier is SOUND",
+# "…are COMPLETE and SOUND", "provably/fully sound") — a real overclaim sat in
+# zk/compose/STATUS.md undetected until a manual sweep (PR #391). This harness pins
+# BOTH directions so the predicate-form coverage can't silently regress:
+#   - should-FAIL : positive predicate-form soundness overclaims about a ZK/MPC
+#                   artifact MUST be caught (exit 1).
+#   - should-PASS : negated / qualified / hedged / allow-marked / non-crypto "sound"
+#                   usages MUST NOT regress (exit 0).
+#
+# HERMETIC w.r.t. git/network/repo content: each case is a single fixture LINE fed to
+# the gate's matching logic in isolation. We do NOT run the whole-repo scan here (that
+# is the CI step `bash scripts/check-privacy-claims.sh`, run separately); we extract
+# and exercise the gate's PATTERNS / SOUNDNESS_CLAIMS / NEGATOR_HEDGE_RE classification
+# by sourcing the script's variable block and replaying the exact per-line decision.
+#
+# Run:  bash scripts/tests/test_privacy_claims.sh   (exit 0 = all pass, 1 = a case failed)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GATE="${ROOT}/scripts/check-privacy-claims.sh"
+
+[ -f "$GATE" ] || { echo "FATAL: gate script not found at ${GATE}"; exit 2; }
+
+# --------------------------------------------------------------------------- #
+# Extract the gate's regex definitions WITHOUT running its scan. The script is
+# `set -euo pipefail` and runs the scan at source-time, so we instead lift just the
+# variable-definition block (everything up to the `mapfile` that begins the scan).
+# This keeps the test reading the SAME patterns the gate ships — no duplication.
+# --------------------------------------------------------------------------- #
+DEFS="$(sed -n '/^ALLOW_MARKER=/,/^mapfile -t FILES/p' "$GATE" | sed '/^mapfile -t FILES/d')"
+# shellcheck disable=SC1090,SC2086
+eval "$DEFS"
+
+# Rebuild the same union + tiered regexes the gate builds.
+RE="$(printf '%s|' "${PATTERNS[@]}")"; RE="${RE%|}"
+SOUNDNESS_RE="$(printf '%s|' "${SOUNDNESS_CLAIMS[@]}")"; SOUNDNESS_RE="${SOUNDNESS_RE%|}"
+UNION_RE="${RE}|${SOUNDNESS_RE}"
+
+# Replay the gate's exact per-line verdict for one content line.
+# Echoes "FAIL" if the line would be reported as a violation, "PASS" otherwise.
+verdict() {
+  local content="$1"
+  if printf '%s\n' "$content" | grep -qiF "$ALLOW_MARKER"; then echo PASS; return; fi
+  if printf '%s\n' "$content" | grep -qiE "$UNION_RE"; then
+    # Matched something. If it is ONLY a guarded soundness claim, a negator/hedge exempts.
+    if ! printf '%s\n' "$content" | grep -qiE "$RE"; then
+      if printf '%s\n' "$content" | grep -qiE "$NEGATOR_HEDGE_RE"; then echo PASS; return; fi
+    fi
+    echo FAIL; return
+  fi
+  echo PASS
+}
+
+pass=0
+fail=0
+check() {  # check <expected FAIL|PASS> <line>
+  local want="$1" line="$2" got
+  got="$(verdict "$line")"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    printf 'CASE FAILED: wanted=%-4s got=%-4s  | %s\n' "$want" "$got" "$line"
+  fi
+}
+
+# --------------------------------------------------------------------------- #
+# Direction A — these MUST be newly CAUGHT (predicate-form positive overclaims).
+# --------------------------------------------------------------------------- #
+check FAIL "The verifier is sound."
+check FAIL "The v1 verifier is SOUND."
+check FAIL "Our proofs are sound and complete."
+check FAIL "The proof is sound under the BN254 assumption."
+check FAIL "The protocol is sound against a malicious prover."
+check FAIL "The circuit is sound."
+check FAIL "These query proofs are provably sound."
+check FAIL "The verifier is fully sound for production use."
+check FAIL "The construction is sound; relying parties may trust it."
+# The PR-#391 shape — conjoined adjectives between the copula and "sound" MUST be caught.
+check FAIL "The composed verifier and proofs are COMPLETE and SOUND."
+check FAIL "The recursive proof is correct, complete and sound."
+# Adjacency form still caught (no regression of the original pattern).
+check FAIL "Ship the sound verifier today."
+
+# --------------------------------------------------------------------------- #
+# Direction B — these MUST still PASS (negated / qualified / hedged / non-crypto).
+# --------------------------------------------------------------------------- #
+check PASS "The verifier is NOT-yet-sound."
+check PASS "The verifier is not sound."
+check PASS "The proof is not sound pending external audit."
+check PASS "The verifier isn't sound yet."
+check PASS "These proofs are never sound without the binding layer."
+check PASS "The verifier is unsound (see the audit)."
+check PASS "There is no soundness guarantee for the ZK estate."
+check PASS "Whether the verifier is sound is an open question."
+check PASS "Soundness is PENDING external cryptographer sign-off."
+# The project's canonical hedged verdict — the load-bearing one that must survive.
+check PASS 'The v1 verifier is SOUND as landed for the threat model the prior audit assumed.'
+check PASS "the internal re-audit argues it is sound as landed) but the claim is unverified"
+# Scoped / engineering / non-crypto "is sound" — subject anchoring keeps these clear.
+check PASS "These are sound engineering choices for a ZK system."
+check PASS "the GX-5 register records why each unsafe block is sound, how it is tested"
+check PASS "the cache invalidation is SOUND; when in doubt it recomputes"
+check PASS "MPC mismatch detection is sound; sharpening is heuristic"
+check PASS "is sound or production-safe is a separate and currently open question"
+# Legitimately AXIS-SCOPED hedge ("sound for integrity") still passes; an UNSCOPED
+# "sound for <anything>" overclaim does NOT get the free pass.
+check PASS "the Tier-A controls are sound for integrity, independent of the privacy axis"
+check FAIL "the scheme is sound for production relying parties"
+# Allow-marker still exempts an otherwise-forbidden line.
+check PASS "The verifier is sound. <!-- privacy-claims-allow: illustrating the gate -->"
+check PASS "Documents the phrase 'privacy-preserving'. privacy-claims-allow: phrase list"
+
+# --------------------------------------------------------------------------- #
+echo ""
+echo "test_privacy_claims: ${pass} passed, ${fail} failed."
+[ "$fail" -eq 0 ] || exit 1
+echo "test_privacy_claims: OK — both-direction soundness-claim coverage holds."


### PR DESCRIPTION
> 🤖 SPARQ agent

Hardens the LIVE privacy-claims honesty gate (`scripts/check-privacy-claims.sh`) to close its **soundness-claim blind spot**: the existing `sound(ness)?-(verifier|proof)` pattern caught only adjacency ("sound verifier") and missed **predicate-form** overclaims — "the verifier is SOUND", "...are COMPLETE and SOUND", "provably sound", "fully sound". A real overclaim of that exact shape sat in `zk/compose/STATUS.md` undetected until a manual sweep (PR #391).

## What changed
`scripts/check-privacy-claims.sh`:
- **Absolute patterns** added: `provably sound` and `(fully|completely|totally|unconditionally|perfectly) sound` — shapes with no honest unhedged reading.
- **Subject-ANCHORED predicate pattern**: a ZK/MPC artifact noun (`verifier|proof|protocol|scheme|circuit|prover|snark|construction|the ZK system/estate/pipeline`) + copula (`is|are|'s|'re`) + up to two conjoined adjectives + `sound`. The conjoined-adjective span is what catches the PR-#391 shape `...are COMPLETE and SOUND`, not just bare `is sound`.
- **Same-line NEGATOR/HEDGE exemption** applied ONLY to the soundness tier (the absolute `PATTERNS` are unaffected): `not / never / no / n't / un(sound) / not-yet`, the uncertainty words `open / pending / unverified / whether / question`, and the project's **canonical hedges** `SOUND as landed [for the ... threat model]` + axis-scoped `sound for integrity`. Deliberately narrow — no broad `if`/`claim` escape hatch; an over-matched legit line still has the existing `privacy-claims-allow:` marker.

Subject-anchoring keeps the gate **OFF** honest non-crypto `is sound` lines (an unsafe-code invariant, a cache invalidation, an MPC detection heuristic, "sound engineering choices").

## Tests — both directions
`scripts/tests/test_privacy_claims.sh` (hermetic; no git/network) replays the gate's exact per-line classification:
- **12 should-FAIL** overclaims (incl. `provably sound`, `...are COMPLETE and SOUND`, `the proof is sound`, the original adjacency form) — all caught.
- **20 should-PASS** lines — negated (`not sound`, `unsound`, `isn't sound`), hedged (the canonical `SOUND as landed for the ... threat model`), allow-marked, and non-crypto `is sound` — all preserved.

Wired as a step inside the **same HARD `privacy-claims` job** so a coverage regression also fails the `ci-summary / gate` aggregator.

## Gate validation
- `shellcheck` clean on both scripts.
- `docs-quality.yml` is valid YAML; all actions remain SHA-pinned (`@<40-hex> # vX.Y.Z`).
- **`ci-summary / gate` unaffected** — only a step was added to an existing HARD job; no check-run added/renamed, job name carries no `advisory`/`informational` token, so it still gates.
- **Full-repo scan stays CLEAN** — 267 files, **zero** new false positives. Every `sound`-matching line in the scanned surface was enumerated and verified honest (negated/hedged/allow-marked/non-crypto).

Closes the soundness-claim blind spot the PR-#391 manual sweep exposed; honest level: the gate now catches predicate-form positive soundness assertions about the ZK/MPC estate while preserving every documented honest/negated/hedged usage.