### PR TITLE
feat(sparq-solid): ACP acp:issuer matcher — (agent,client,issuer) principal (sq-3jtd.6)

### DIFF
--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -31,7 +31,7 @@ store.materialize_wac()?; // run the N3 rules → install <urn:sparq:auth>
 
 // The SAME query, different sessions, different results — fail-closed.
 let q = "SELECT ?title WHERE { ?s <https://ex.dev/ns#title> ?title }";
-let alice = Session { agent: Some("https://alice.ex/card#me"), client: None };
+let alice = Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None };
 let _authorized = store.query_as(&alice, Mode::Read, q)?.rows.len();
 let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len();
 # Ok(()) }
@@ -40,8 +40,11 @@ let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len(
 ## ✨ Features
 
 - **WAC + ACP** — Web Access Control (`.acl`) and Access Control Policy (`.acr`), including
-  inheritance, agent classes, groups, the `allOf`/`anyOf`/`noneOf` combinators, and
-  normative deny-overrides. The full support matrix is in the design doc (linked below).
+  inheritance, agent classes, groups, the `allOf`/`anyOf`/`noneOf` combinators, the ACP
+  matcher's `acp:agent` / `acp:client` / `acp:issuer` attributes (the three-dimensional
+  `(agent, client, issuer)` principal — a Matcher can gate on the OIDC issuer that vouched
+  for the requester, not just the WebID), and normative deny-overrides. The full support
+  matrix is in the design doc (linked below).
 - **Triples-native** — pods, ACL/ACR documents, and the materialized authorization view are
   all ordinary named graphs; "who can read G?" is one SPARQL pattern.
 - **Zero-copy enforcement** — the default query path evaluates through the engine's zero-copy

--- a/crates/sparq-solid/examples/bench.rs
+++ b/crates/sparq-solid/examples/bench.rs
@@ -52,7 +52,7 @@ fn main() {
     println!("    auth view: {} triples, closure per stratum {:?}\n", astats.auth_triples, astats.strata_facts);
 
     // 2. per-query: v1 rewrite+copy vs full-dataset direct query
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     let allowed = store.accessible(&alice, Mode::Read);
     println!("alice readable graphs: {}", allowed.len());
     let direct = timed("engine::query, FULL dataset (GRAPH ?g over all graphs)", || {
@@ -118,7 +118,7 @@ fn main() {
     assert_eq!(fat_vnothing.rows.len(), 0);
 
     // 3. session graph-set: cold vs cached
-    let bob = Session { agent: Some(sparq_solid::fixture::BOB), client: None };
+    let bob = Session { agent: Some(sparq_solid::fixture::BOB), client: None, issuer: None };
     let t = Instant::now();
     let cold = store.accessible(&bob, Mode::Read);
     println!("{:64} {:10.3} ms", "session graph-set, cold (AuthIndex walk)", t.elapsed().as_secs_f64() * 1e3);

--- a/crates/sparq-solid/examples/quickstart.rs
+++ b/crates/sparq-solid/examples/quickstart.rs
@@ -26,9 +26,9 @@ fn main() -> Result<(), String> {
     //    visibility is an O(1) hash check, nothing is copied per query.
     let query = "SELECT ?title WHERE { ?s <https://ex.dev/ns#title> ?title }";
     for (label, session) in [
-        ("alice (pod owner)", Session { agent: Some(ALICE), client: None }),
-        ("carol (team member)", Session { agent: Some(CAROL), client: None }),
-        ("bob via app.ex (acl:origin pair)", Session { agent: Some(BOB), client: Some(APP) }),
+        ("alice (pod owner)", Session { agent: Some(ALICE), client: None, issuer: None }),
+        ("carol (team member)", Session { agent: Some(CAROL), client: None, issuer: None }),
+        ("bob via app.ex (acl:origin pair)", Session { agent: Some(BOB), client: Some(APP), issuer: None }),
         ("anonymous", Session::default()),
     ] {
         let readable = store.accessible(&session, Mode::Read).len();
@@ -45,7 +45,7 @@ fn main() -> Result<(), String> {
     println!("auth view: {:?} read grants", who.rows[0][0].as_ref().map(|t| t.to_string()));
 
     // sanity: the fixture's hand-derived counts (same as tests/e2e.rs)
-    let alice = store.query_as(&Session { agent: Some(ALICE), client: None }, Mode::Read, query)?;
+    let alice = store.query_as(&Session { agent: Some(ALICE), client: None, issuer: None }, Mode::Read, query)?;
     let anon = store.query_as(&Session::default(), Mode::Read, query)?;
     assert_eq!(alice.rows.len(), 599);
     assert_eq!(anon.rows.len(), 144);

--- a/crates/sparq-solid/rules/acp-a.n3
+++ b/crates/sparq-solid/rules/acp-a.n3
@@ -1,19 +1,23 @@
 # ACP (https://solidproject.org/TR/acp) — STRATUM A (monotone + input-only negation):
 # effective policies, matcher accept-sets over the principal lattice, candidate
-# (agent, client) pairs. Strata B/C (separate reason_n3 calls) add the NAF layers; see
-# research/solid-access-control-design.md §3.4–3.5.
+# (agent, client, issuer) triples. Strata B/C (separate reason_n3 calls) add the NAF
+# layers; see research/solid-access-control-design.md §3.4–3.5.
 #
 # Principal lattice: auth:Public ⊒ auth:Authenticated ⊒ concrete WebID;
-# auth:AnyClient ⊒ concrete client id. A matcher "accepts" a principal iff it accepts
-# EVERY context the principal denotes, so surviving candidates are sound grants.
+# auth:AnyClient ⊒ concrete client id; auth:AnyIssuer ⊒ concrete issuer (OIDC IdP).
+# [OPUS-4.8] sq-3jtd.6: the issuer dimension is the exact twin of the client dimension
+# (design doc §3.6 — "acp:issuer is the same shape as acp:client"). A matcher "accepts" a
+# principal iff it accepts EVERY context the principal denotes, so surviving candidates
+# are sound grants.
 #
 # Loader-synthesized inputs (besides common.n3's): <R> solidx:ownAcr <R.acr> ;
 # <A> solidx:isWebId true for concrete agent IRIs seen in ACR/group docs.
 #
 # Outputs (stratum B's inputs): ?pol solidx:appliesToResource ?r (ACP §"Effective
 # Policies": own accessControl + cumulative ancestor memberAccessControl);
-# ?m solidx:acceptsAgentP/acceptsClientP ?p (matcher accept-sets, ACP §"Matchers");
-# ?pol solidx:candPair ?k with solidx:pairAgent/pairClient (candidate principals).
+# ?m solidx:acceptsAgentP/acceptsClientP/acceptsIssuerP ?p (matcher accept-sets, ACP
+# §"Matchers"); ?pol solidx:candTriple ?k with solidx:pairAgent/pairClient/pairIssuer
+# (candidate principals).
 
 @prefix acp:    <http://www.w3.org/ns/solid/acp#> .
 @prefix auth:   <https://sparq.dev/ns/auth#> .
@@ -41,6 +45,11 @@
 { ?m solidx:isMatcher true . ?m acp:client ?c . ?c log:notEqualTo acp:PublicClient . }
 => { ?m solidx:clientValP ?c . } .
 { ?m acp:client acp:PublicClient . }      => { ?m solidx:clientValP auth:AnyClient . } .
+# [OPUS-4.8] sq-3jtd.6: acp:issuer — a concrete OIDC issuer IRI is its own principal value
+# (there is no ACP "public issuer" special; an absent acp:issuer means issuer-unconstrained,
+# handled by the accept-set top rule below, exactly like an absent acp:client).
+{ ?m solidx:isMatcher true . ?m acp:issuer ?i . }
+=> { ?m solidx:issuerValP ?i . } .
 
 # ── accept-sets: downward-closed over the principal lattice ────────────────────────────
 { ?m solidx:agentValP ?a . } => { ?m solidx:acceptsAgentP ?a . } .
@@ -58,21 +67,34 @@
 { ?m solidx:acceptsClientP auth:AnyClient . ?c solidx:isCandClient true . }
 => { ?m solidx:acceptsClientP ?c . } .
 
+# [OPUS-4.8] sq-3jtd.6: issuer accept-set, the twin of the client one above.
+{ ?m solidx:issuerValP ?i . } => { ?m solidx:acceptsIssuerP ?i . } .
+{ ?m solidx:isMatcher true . ?UNSCOPED log:notIncludes { ?m acp:issuer ?x . } . }
+=> { ?m solidx:acceptsIssuerP auth:AnyIssuer . } .
+{ ?m solidx:acceptsIssuerP auth:AnyIssuer . ?i solidx:isCandIssuer true . }
+=> { ?m solidx:acceptsIssuerP ?i . } .
+
 # ── candidates per policy: its matchers' values + the dimension tops ───────────────────
 # (the tops require >=1 allOf/anyOf matcher — encodes ACP's "at least one matcher" rule)
 { ?pol solidx:hasMatcher ?m . ?m solidx:agentValP ?a . }  => { ?pol solidx:candAgent ?a . } .
 { ?pol solidx:hasMatcher ?m . ?m solidx:clientValP ?c . } => { ?pol solidx:candClient ?c . } .
+{ ?pol solidx:hasMatcher ?m . ?m solidx:issuerValP ?i . } => { ?pol solidx:candIssuer ?i . } .
 { ?pol solidx:hasMatcher ?m . }
-=> { ?pol solidx:candAgent auth:Public . ?pol solidx:candClient auth:AnyClient . } .
+=> { ?pol solidx:candAgent auth:Public . ?pol solidx:candClient auth:AnyClient .
+     ?pol solidx:candIssuer auth:AnyIssuer . } .
 { ?pol solidx:candAgent ?a . ?a solidx:isWebId true . }       => { ?a solidx:isCandAgent true . } .
 { ?pol solidx:candClient ?c . ?c log:notEqualTo auth:AnyClient . } => { ?c solidx:isCandClient true . } .
+{ ?pol solidx:candIssuer ?i . ?i log:notEqualTo auth:AnyIssuer . } => { ?i solidx:isCandIssuer true . } .
 
-# ── candidate (agent, client) pairs, minted deterministically ──────────────────────────
-# (components percent-encoded — string:encodeForUri — so distinct (pol, agent, client)
-#  triples can never concatenate to the same candidate key)
-{ ?pol solidx:candAgent ?pa . ?pol solidx:candClient ?pc .
-  ?pol log:uri ?pols . ?pa log:uri ?pas . ?pc log:uri ?pcs .
-  ?pols string:encodeForUri ?pole . ?pas string:encodeForUri ?pae . ?pcs string:encodeForUri ?pce .
-  ("urn:sparq:cand?pol=" ?pole "&agent=" ?pae "&client=" ?pce) string:concatenation ?ks .
+# ── candidate (agent, client, issuer) triples, minted deterministically ────────────────
+# (components percent-encoded — string:encodeForUri — so distinct (pol, agent, client,
+#  issuer) tuples can never concatenate to the same candidate key)
+{ ?pol solidx:candAgent ?pa . ?pol solidx:candClient ?pc . ?pol solidx:candIssuer ?pi .
+  ?pol log:uri ?pols . ?pa log:uri ?pas . ?pc log:uri ?pcs . ?pi log:uri ?pis .
+  ?pols string:encodeForUri ?pole . ?pas string:encodeForUri ?pae .
+  ?pcs string:encodeForUri ?pce . ?pis string:encodeForUri ?pie .
+  ("urn:sparq:cand?pol=" ?pole "&agent=" ?pae "&client=" ?pce "&issuer=" ?pie)
+      string:concatenation ?ks .
   ?k log:uri ?ks . }
-=> { ?pol solidx:candPair ?k . ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc . } .
+=> { ?pol solidx:candTriple ?k .
+     ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc . ?k solidx:pairIssuer ?pi . } .

--- a/crates/sparq-solid/rules/acp-b.n3
+++ b/crates/sparq-solid/rules/acp-b.n3
@@ -1,25 +1,32 @@
 # ACP — STRATUM B: negation-as-failure over stratum A's (now complete) accept-sets.
-# Derives per-candidate-pair allOf rejections and anyOf satisfaction (ACP §"Policies":
+# Derives per-candidate-triple allOf rejections and anyOf satisfaction (ACP §"Policies":
 # allOf = every matcher satisfied, anyOf = at least one). Runs as its own reason_n3
 # call seeded with stratum A's closure (design doc §3.5).
 #
-# Inputs: stratum A's closure (candPair/pairAgent/pairClient, acceptsAgentP/ClientP)
-# + the original acp:allOf/anyOf facts. Outputs (stratum C's inputs):
-# ?k solidx:allOfRejected true ; ?k solidx:anyOfSat true .
+# Inputs: stratum A's closure (candTriple/pairAgent/pairClient/pairIssuer,
+# acceptsAgentP/ClientP/IssuerP) + the original acp:allOf/anyOf facts. Outputs (stratum
+# C's inputs): ?k solidx:allOfRejected true ; ?k solidx:anyOfSat true .
+#
+# [OPUS-4.8] sq-3jtd.6: the issuer dimension is the exact twin of the client dimension.
 
 @prefix acp:    <http://www.w3.org/ns/solid/acp#> .
 @prefix solidx: <https://sparq.dev/ns/solidx#> .
 @prefix log:    <http://www.w3.org/2000/10/swap/log#> .
 
-# an allOf matcher that does not accept the pair's agent (resp. client) dimension
-{ ?pol solidx:candPair ?k . ?k solidx:pairAgent ?pa . ?pol acp:allOf ?m .
+# an allOf matcher that does not accept the triple's agent (resp. client, issuer) dimension
+{ ?pol solidx:candTriple ?k . ?k solidx:pairAgent ?pa . ?pol acp:allOf ?m .
   ?UNSCOPED log:notIncludes { ?m solidx:acceptsAgentP ?pa . } . }
 => { ?k solidx:allOfRejected true . } .
-{ ?pol solidx:candPair ?k . ?k solidx:pairClient ?pc . ?pol acp:allOf ?m .
+{ ?pol solidx:candTriple ?k . ?k solidx:pairClient ?pc . ?pol acp:allOf ?m .
   ?UNSCOPED log:notIncludes { ?m solidx:acceptsClientP ?pc . } . }
 => { ?k solidx:allOfRejected true . } .
+{ ?pol solidx:candTriple ?k . ?k solidx:pairIssuer ?pi . ?pol acp:allOf ?m .
+  ?UNSCOPED log:notIncludes { ?m solidx:acceptsIssuerP ?pi . } . }
+=> { ?k solidx:allOfRejected true . } .
 
-# at least one anyOf matcher accepts both dimensions
-{ ?pol solidx:candPair ?k . ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc .
-  ?pol acp:anyOf ?m . ?m solidx:acceptsAgentP ?pa . ?m solidx:acceptsClientP ?pc . }
+# at least one anyOf matcher accepts all three dimensions
+{ ?pol solidx:candTriple ?k . ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc .
+  ?k solidx:pairIssuer ?pi .
+  ?pol acp:anyOf ?m . ?m solidx:acceptsAgentP ?pa . ?m solidx:acceptsClientP ?pc .
+  ?m solidx:acceptsIssuerP ?pi . }
 => { ?k solidx:anyOfSat true . } .

--- a/crates/sparq-solid/rules/acp-c.n3
+++ b/crates/sparq-solid/rules/acp-c.n3
@@ -8,7 +8,13 @@
 # Inputs: stratum B's closure. Outputs (the auth view, filtered into <urn:sparq:auth>
 # by src/materialize.rs): <principal> auth:read|write|append|control <graphName>,
 # <principal> auth:denyRead|denyWrite|denyAppend|denyControl <graphName>, and
-# auth:ConditionalGrant nodes (auth:effect/agent/client/mode/graph/exceptMatcher).
+# auth:ConditionalGrant nodes (auth:effect/agent/client/issuer/mode/graph/exceptMatcher).
+#
+# [OPUS-4.8] sq-3jtd.6: the principal term now spans three dimensions — agent, client,
+# issuer. To keep the unconstrained-issuer grants byte-identical to the pre-issuer
+# pair-principal model, the minting is staged: an issuer-unconstrained candidate
+# (auth:AnyIssuer) reuses the agent / urn:sparq:pair?… principal exactly as before; only
+# an issuer-CONSTRAINED candidate mints a urn:sparq:triple?agent=…&client=…&issuer=… term.
 
 @prefix acp:    <http://www.w3.org/ns/solid/acp#> .
 @prefix acl:    <http://www.w3.org/ns/auth/acl#> .
@@ -23,29 +29,39 @@ acl:Write   solidx:allowPred auth:write   ; solidx:denyPred auth:denyWrite .
 acl:Append  solidx:allowPred auth:append  ; solidx:denyPred auth:denyAppend .
 acl:Control solidx:allowPred auth:control ; solidx:denyPred auth:denyControl .
 
-# ── policy satisfaction for a candidate pair ───────────────────────────────────────────
-{ ?pol solidx:candPair ?k . ?k solidx:anyOfSat true . } => { ?k solidx:anyOfOk true . } .
-{ ?pol solidx:candPair ?k . ?UNSCOPED log:notIncludes { ?pol acp:anyOf ?m . } . }
+# ── policy satisfaction for a candidate triple ─────────────────────────────────────────
+{ ?pol solidx:candTriple ?k . ?k solidx:anyOfSat true . } => { ?k solidx:anyOfOk true . } .
+{ ?pol solidx:candTriple ?k . ?UNSCOPED log:notIncludes { ?pol acp:anyOf ?m . } . }
 => { ?k solidx:anyOfOk true . } .
-{ ?pol solidx:candPair ?k . ?k solidx:anyOfOk true .
+{ ?pol solidx:candTriple ?k . ?k solidx:anyOfOk true .
   ?UNSCOPED log:notIncludes { ?k solidx:allOfRejected true . } . }
 => { ?k solidx:satisfied true . } .
 
-# ── the pair's principal term: the agent when client-unconstrained, else a minted pair ─
-{ ?k solidx:pairAgent ?pa . ?k solidx:pairClient auth:AnyClient . }
+# ── the candidate's principal term ─────────────────────────────────────────────────────
+# issuer-unconstrained: fall back to the agent (client-unconstrained) / minted pair model.
+{ ?k solidx:pairIssuer auth:AnyIssuer . ?k solidx:pairAgent ?pa . ?k solidx:pairClient auth:AnyClient . }
 => { ?k solidx:principal ?pa . } .
-{ ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc . ?pc log:notEqualTo auth:AnyClient .
+{ ?k solidx:pairIssuer auth:AnyIssuer . ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc .
+  ?pc log:notEqualTo auth:AnyClient .
   ?pa log:uri ?pas . ?pc log:uri ?pcs .
   ?pas string:encodeForUri ?pae . ?pcs string:encodeForUri ?pce .
   ("urn:sparq:pair?agent=" ?pae "&client=" ?pce) string:concatenation ?ps . ?p log:uri ?ps . }
 => { ?k solidx:principal ?p . } .
+# issuer-CONSTRAINED: a minted (agent, client, issuer) triple principal. [OPUS-4.8] sq-3jtd.6
+{ ?k solidx:pairIssuer ?pi . ?pi log:notEqualTo auth:AnyIssuer .
+  ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc .
+  ?pa log:uri ?pas . ?pc log:uri ?pcs . ?pi log:uri ?pis .
+  ?pas string:encodeForUri ?pae . ?pcs string:encodeForUri ?pce . ?pis string:encodeForUri ?pie .
+  ("urn:sparq:triple?agent=" ?pae "&client=" ?pce "&issuer=" ?pie) string:concatenation ?ps .
+  ?p log:uri ?ps . }
+=> { ?k solidx:principal ?p . } .
 
 # ── SIMPLE grants (policy has no noneOf) ───────────────────────────────────────────────
-{ ?pol solidx:candPair ?k . ?k solidx:satisfied true . ?k solidx:principal ?p .
+{ ?pol solidx:candTriple ?k . ?k solidx:satisfied true . ?k solidx:principal ?p .
   ?pol solidx:appliesToResource ?r . ?pol acp:allow ?mode . ?mode solidx:allowPred ?pred .
   ?UNSCOPED log:notIncludes { ?pol acp:noneOf ?nm . } . }
 => { ?p ?pred ?r . } .
-{ ?pol solidx:candPair ?k . ?k solidx:satisfied true . ?k solidx:principal ?p .
+{ ?pol solidx:candTriple ?k . ?k solidx:satisfied true . ?k solidx:principal ?p .
   ?pol solidx:appliesToResource ?r . ?pol acp:deny ?mode . ?mode solidx:denyPred ?pred .
   ?UNSCOPED log:notIncludes { ?pol acp:noneOf ?nm . } . }
 => { ?p ?pred ?r . } .
@@ -55,23 +71,23 @@ acl:Control solidx:allowPred auth:control ; solidx:denyPred auth:denyControl .
 #  No encoding needed here for injectivity: ?ks is a minted cand IRI whose components
 #  are already percent-encoded (acp-a.n3) — it cannot contain a raw "&mode=" — ?modes
 #  is one of four fixed acl: IRIs, and ?rs is the final component.)
-{ ?pol solidx:candPair ?k . ?k solidx:satisfied true .
-  ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc .
+{ ?pol solidx:candTriple ?k . ?k solidx:satisfied true .
+  ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc . ?k solidx:pairIssuer ?pi .
   ?pol solidx:appliesToResource ?r . ?pol acp:allow ?mode . ?pol acp:noneOf ?nm .
   ?k log:uri ?ks . ?mode log:uri ?modes . ?r log:uri ?rs .
-  ("urn:sparq:grant?pair=" ?ks "&mode=" ?modes "&effect=allow&graph=" ?rs)
+  ("urn:sparq:grant?cand=" ?ks "&mode=" ?modes "&effect=allow&graph=" ?rs)
       string:concatenation ?gs .
   ?g log:uri ?gs . }
 => { ?g a auth:ConditionalGrant . ?g auth:effect auth:Allow .
-     ?g auth:agent ?pa . ?g auth:client ?pc . ?g auth:mode ?mode . ?g auth:graph ?r .
-     ?g auth:exceptMatcher ?nm . } .
-{ ?pol solidx:candPair ?k . ?k solidx:satisfied true .
-  ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc .
+     ?g auth:agent ?pa . ?g auth:client ?pc . ?g auth:issuer ?pi .
+     ?g auth:mode ?mode . ?g auth:graph ?r . ?g auth:exceptMatcher ?nm . } .
+{ ?pol solidx:candTriple ?k . ?k solidx:satisfied true .
+  ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc . ?k solidx:pairIssuer ?pi .
   ?pol solidx:appliesToResource ?r . ?pol acp:deny ?mode . ?pol acp:noneOf ?nm .
   ?k log:uri ?ks . ?mode log:uri ?modes . ?r log:uri ?rs .
-  ("urn:sparq:grant?pair=" ?ks "&mode=" ?modes "&effect=deny&graph=" ?rs)
+  ("urn:sparq:grant?cand=" ?ks "&mode=" ?modes "&effect=deny&graph=" ?rs)
       string:concatenation ?gs .
   ?g log:uri ?gs . }
 => { ?g a auth:ConditionalGrant . ?g auth:effect auth:Deny .
-     ?g auth:agent ?pa . ?g auth:client ?pc . ?g auth:mode ?mode . ?g auth:graph ?r .
-     ?g auth:exceptMatcher ?nm . } .
+     ?g auth:agent ?pa . ?g auth:client ?pc . ?g auth:issuer ?pi .
+     ?g auth:mode ?mode . ?g auth:graph ?r . ?g auth:exceptMatcher ?nm . } .

--- a/crates/sparq-solid/src/authindex.rs
+++ b/crates/sparq-solid/src/authindex.rs
@@ -19,14 +19,22 @@ pub const PUBLIC: &str = "https://sparq.dev/ns/auth#Public";
 pub const AUTHENTICATED: &str = "https://sparq.dev/ns/auth#Authenticated";
 /// Client IRI matched by any client in conditional-grant heads (ACP `acp:PublicClient`).
 pub const ANY_CLIENT: &str = "https://sparq.dev/ns/auth#AnyClient";
+/// Issuer IRI matched by any OIDC issuer (the issuer-dimension top; ACP has no "public
+/// issuer" special, so an absent `acp:issuer` is issuer-unconstrained ⇒ this top).
+/// [OPUS-4.8] sq-3jtd.6.
+pub const ANY_ISSUER: &str = "https://sparq.dev/ns/auth#AnyIssuer";
 
-/// A request context: who (WebID) through what (client identifier / origin).
-/// `agent: None` = anonymous.
+/// A request context: who (WebID) through what (client identifier / origin) and vouched
+/// for by which OIDC issuer (`acp:issuer`). `agent: None` = anonymous.
 ///
-/// A session expands to at most 6 principals when grants are looked up: always
-/// `auth:Public`; plus `auth:Authenticated` and the WebID itself when `agent` is
-/// given; plus the minted `urn:sparq:pair?agent=…&client=…` pair of each of those
-/// when `client` is given. Expansion is internal — callers just construct the pair:
+/// A session expands to at most 12 principals when grants are looked up ([OPUS-4.8]
+/// sq-3jtd.6 — the issuer dimension doubles the pre-issuer ≤6): always `auth:Public`;
+/// plus `auth:Authenticated` and the WebID itself when `agent` is given; for each of
+/// those agent-principals `ap`, the minted `urn:sparq:pair?agent=…&client=…` pair when
+/// `client` is given, the minted `urn:sparq:triple?agent=…&client=…&issuer=…` term when
+/// `issuer` is given (with the client component being `auth:AnyClient` when no `client`),
+/// and the full triple when both are given. Expansion is internal — callers just supply
+/// the request context:
 ///
 /// # Examples
 ///
@@ -34,25 +42,32 @@ pub const ANY_CLIENT: &str = "https://sparq.dev/ns/auth#AnyClient";
 /// use sparq_solid::Session;
 ///
 /// let anonymous = Session::default();
-/// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None };
-/// let alice_via_app =
-///     Session { agent: Some("https://alice.ex/card#me"), client: Some("https://app.ex") };
+/// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None };
+/// let alice_via_app = Session {
+///     agent: Some("https://alice.ex/card#me"),
+///     client: Some("https://app.ex"),
+///     issuer: Some("https://idp.ex"),
+/// };
 /// assert!(anonymous.agent.is_none());
 /// # let _ = (alice, alice_via_app);
 /// ```
 ///
 /// # Invariants (fail-closed)
 ///
-/// Agent/client values inside the reserved `urn:sparq:` IRI space, or containing the
-/// literal pair-encoding delimiter `&client=`, are never matched against grants: the
+/// Agent/client/issuer values inside the reserved `urn:sparq:` IRI space, or containing
+/// the literal pair-encoding delimiter `&client=`, are never matched against grants: the
 /// accessible set for such a session is empty (they could otherwise impersonate a
-/// minted pair principal — see [`AuthIndex::accessible`]).
+/// minted pair/triple principal — see [`AuthIndex::accessible`]).
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Session<'a> {
     /// The authenticated agent's WebID; `None` = anonymous.
     pub agent: Option<&'a str>,
     /// The client identifier (WAC `acl:origin` / ACP `acp:client`); `None` = any client.
     pub client: Option<&'a str>,
+    /// The OIDC issuer that vouched for the WebID (ACP `acp:issuer`); `None` = any issuer.
+    /// [OPUS-4.8] sq-3jtd.6 — only ACP matchers constrain on it; WAC has no issuer notion,
+    /// so a WAC pod ignores it (no grant ever names a triple principal).
+    pub issuer: Option<&'a str>,
 }
 
 /// An access mode, matching WAC's `acl:Read`/`Write`/`Append`/`Control` (ACP reuses
@@ -130,11 +145,43 @@ pub fn pair_principal(agent: &str, client: &str) -> String {
     format!("urn:sparq:pair?agent={a}&client={c}")
 }
 
+/// [OPUS-4.8] sq-3jtd.6 — the deterministic THREE-dimension principal IRI minted by the
+/// ACP rules for an issuer-constrained grant (`string:encodeForUri` +
+/// `string:concatenation` in rules/acp-c.n3 — keep in sync; the same RFC 3986
+/// percent-encoding makes the minting INJECTIVE, so no agent/client/issuer value can
+/// smuggle a `&client=`/`&issuer=` delimiter into another principal's term).
+///
+/// The `client` component is `auth:AnyClient` ([`ANY_CLIENT`]) for a matcher that
+/// constrains the issuer but not the client; only an issuer-CONSTRAINED candidate mints a
+/// triple — an issuer-unconstrained grant reuses the agent / [`pair_principal`] term.
+///
+/// ```
+/// use sparq_solid::triple_principal;
+/// assert_eq!(
+///     triple_principal("https://bob.ex/card#me", "https://app.ex", "https://idp.ex"),
+///     "urn:sparq:triple?agent=https%3A%2F%2Fbob.ex%2Fcard%23me\
+///      &client=https%3A%2F%2Fapp.ex&issuer=https%3A%2F%2Fidp.ex",
+/// );
+/// // injective: a delimiter inside a value cannot re-bracket the triple
+/// assert_ne!(
+///     triple_principal("a&issuer=b", "c", "d"),
+///     triple_principal("a", "c", "b&issuer=d"),
+/// );
+/// ```
+pub fn triple_principal(agent: &str, client: &str, issuer: &str) -> String {
+    let a = sparq_reason::n3::encode_for_uri(agent);
+    let c = sparq_reason::n3::encode_for_uri(client);
+    let i = sparq_reason::n3::encode_for_uri(issuer);
+    format!("urn:sparq:triple?agent={a}&client={c}&issuer={i}")
+}
+
 #[derive(Debug, Default)]
 struct ConditionalGrant {
     allow: bool,
     agent: String,  // principal-space: WebID | auth:Public | auth:Authenticated
     client: String, // auth:AnyClient | concrete client id
+    // [OPUS-4.8] sq-3jtd.6: auth:AnyIssuer (issuer-unconstrained) | concrete OIDC issuer id.
+    issuer: String,
     mode: Option<Mode>,
     graph: Option<NamedNode>,
     except: Vec<String>, // matcher IRIs
@@ -168,7 +215,7 @@ struct ConditionalGrant {
 /// materialize_wac(&mut graph)?;
 ///
 /// let index = AuthIndex::from_graph(&graph);
-/// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None };
+/// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None };
 /// assert_eq!(index.accessible(&alice, Mode::Read).len(), 2); // n1 + notes/
 /// assert!(index.accessible(&alice, Mode::Write).is_empty()); // fail-closed
 /// # Ok::<(), String>(())
@@ -182,6 +229,8 @@ pub struct AuthIndex {
     /// matcher IRI → accept-sets (principal space), for exceptMatcher evaluation.
     matcher_agents: FxHashMap<String, FxHashSet<String>>,
     matcher_clients: FxHashMap<String, FxHashSet<String>>,
+    /// [OPUS-4.8] sq-3jtd.6 — the issuer-dimension twin of `matcher_clients`.
+    matcher_issuers: FxHashMap<String, FxHashSet<String>>,
 }
 
 impl AuthIndex {
@@ -224,6 +273,13 @@ impl AuthIndex {
                             ix.matcher_clients.entry(subj).or_default().insert(o.as_str().to_owned());
                         }
                     }
+                    // [OPUS-4.8] sq-3jtd.6: the issuer-dimension matcher accept-set fact.
+                    "https://sparq.dev/ns/solidx#acceptsIssuerP" => {
+                        if let Term::NamedNode(o) = &t[2] {
+                            let set = ix.matcher_issuers.entry(subj).or_default();
+                            set.insert(o.as_str().to_owned());
+                        }
+                    }
                     _ => {}
                 }
                 continue;
@@ -233,6 +289,8 @@ impl AuthIndex {
                 ("effect", Term::NamedNode(o)) => entry.allow = o.as_str() == format!("{AUTH_NS}Allow"),
                 ("agent", Term::NamedNode(o)) => entry.agent = o.as_str().to_owned(),
                 ("client", Term::NamedNode(o)) => entry.client = o.as_str().to_owned(),
+                // [OPUS-4.8] sq-3jtd.6: the conditional grant's issuer head.
+                ("issuer", Term::NamedNode(o)) => entry.issuer = o.as_str().to_owned(),
                 ("mode", Term::NamedNode(o)) => entry.mode = Mode::from_mode_iri(o.as_str()),
                 ("graph", Term::NamedNode(o)) => entry.graph = Some(o.clone()),
                 ("exceptMatcher", Term::NamedNode(o)) => entry.except.push(o.as_str().to_owned()),
@@ -253,12 +311,30 @@ impl AuthIndex {
         ps
     }
 
-    /// All principals the session matches (agent-dimension + (agent, client) pairs).
+    /// All principals the session matches: the agent-dimension principals, plus, for each
+    /// one, the minted `(agent, client)` pair (when a client is given), the minted
+    /// `(agent, client, issuer)` triple (when an issuer is given — with `auth:AnyClient`
+    /// as the client component if no client was supplied), and the full triple. [OPUS-4.8]
+    /// sq-3jtd.6: ≤12 lookups (the pre-issuer ≤6 doubled by the issuer dimension).
     fn principals(s: &Session) -> Vec<String> {
-        let mut ps = Self::agent_principals(s);
+        let agents = Self::agent_principals(s);
+        let mut ps = agents.clone();
         if let Some(c) = s.client {
-            for a in Self::agent_principals(s) {
-                ps.push(pair_principal(&a, c));
+            for a in &agents {
+                ps.push(pair_principal(a, c));
+            }
+        }
+        // The issuer dimension mints a triple principal. A grant that constrains the
+        // issuer but not the client mints `triple(agent, auth:AnyClient, issuer)`, so the
+        // session must match that term too — hence the `auth:AnyClient` client component
+        // when the session has no client.
+        if let Some(i) = s.issuer {
+            let client = s.client.unwrap_or(ANY_CLIENT);
+            for a in &agents {
+                ps.push(triple_principal(a, client, i));
+                if s.client.is_some() {
+                    ps.push(triple_principal(a, ANY_CLIENT, i));
+                }
             }
         }
         ps
@@ -282,20 +358,30 @@ impl AuthIndex {
                 set.contains(ANY_CLIENT) || s.client.map(|c| set.contains(c)).unwrap_or(false)
             }
         };
-        agent_ok && client_ok
+        // [OPUS-4.8] sq-3jtd.6: the issuer-dimension twin of the client check.
+        let issuer_ok = match self.matcher_issuers.get(matcher) {
+            None => false,
+            Some(set) => {
+                set.contains(ANY_ISSUER) || s.issuer.map(|i| set.contains(i)).unwrap_or(false)
+            }
+        };
+        agent_ok && client_ok && issuer_ok
     }
 
-    /// Does a conditional grant's (agent, client) head apply to this session?
+    /// Does a conditional grant's (agent, client, issuer) head apply to this session?
+    /// [OPUS-4.8] sq-3jtd.6: the issuer head is the twin of the client head — the grant's
+    /// `auth:AnyIssuer` matches any session, else the session's issuer must equal it.
     fn cond_applies(&self, g: &ConditionalGrant, s: &Session) -> bool {
         let agent_ok = Self::agent_principals(s).contains(&g.agent);
         let client_ok = g.client == ANY_CLIENT || s.client == Some(g.client.as_str());
-        agent_ok && client_ok && !g.except.iter().any(|m| self.matcher_accepts(m, s))
+        let issuer_ok = g.issuer == ANY_ISSUER || s.issuer == Some(g.issuer.as_str());
+        agent_ok && client_ok && issuer_ok && !g.except.iter().any(|m| self.matcher_accepts(m, s))
     }
 
     /// The sorted, deduplicated graph set this session may access in `mode`:
     /// `∪ allow(principals) ∖ ∪ deny(principals)` (deny-overrides across principals),
     /// with conditional grants/denies (ACP `noneOf`) applied when their
-    /// (agent, client) head matches the session and no exception matcher accepts it.
+    /// (agent, client, issuer) head matches the session and no exception matcher accepts it.
     ///
     /// Never panics and never errors — every unauthorized condition degrades to the
     /// **empty set**:
@@ -307,10 +393,12 @@ impl AuthIndex {
     ///   impersonate a minted pair principal (roborev 1727).
     ///
     /// Prefer [`crate::PodStore::accessible`], which memoizes this walk per
-    /// (agent, client, mode) until the next re-materialization.
+    /// (agent, client, issuer, mode) until the next re-materialization.
     pub fn accessible(&self, s: &Session, mode: Mode) -> Vec<NamedNode> {
         let invalid = |v: Option<&str>| v.is_some_and(|x| !crate::loader::session_value_allowed(x));
-        if invalid(s.agent) || invalid(s.client) {
+        // [OPUS-4.8] sq-3jtd.6: the issuer is a triple-principal ingredient too — a session
+        // issuer inside the reserved space could otherwise impersonate a minted triple.
+        if invalid(s.agent) || invalid(s.client) || invalid(s.issuer) {
             return Vec::new();
         }
         let principals = Self::principals(s);

--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -12,7 +12,7 @@ pub mod odrl_bridge;
 mod rewrite;
 mod update; // [OPUS-4.8] sq-xor3: write/update-path enforcement
 
-pub use authindex::{pair_principal, AuthIndex, Mode, Session};
+pub use authindex::{pair_principal, triple_principal, AuthIndex, Mode, Session};
 pub use fixture::{acp_fixture, wac_fixture};
 pub use materialize::{materialize_acp, materialize_wac, MaterializeStats};
 #[cfg(feature = "odrl-bridge")]
@@ -108,7 +108,7 @@ pub const SOLIDX_NS: &str = "https://sparq.dev/ns/solidx#";
 /// let mut store = PodStore::new(sparq_core::Graph::load_dataset(nquads, "nquads")?);
 /// store.materialize_wac()?;
 ///
-/// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None };
+/// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None };
 /// // alice was granted acl:Read only — Write fails closed
 /// assert_eq!(store.accessible(&alice, Mode::Read).len(), 2); // n1 + the notes/ container
 /// assert_eq!(store.accessible(&alice, Mode::Write).len(), 0);
@@ -121,7 +121,11 @@ pub struct PodStore {
     pub graph: Graph,
     auth: Arc<AuthIndex>,
     epoch: u64,
-    cache: FxHashMap<(Option<String>, Option<String>, Mode), SessionSets>,
+    // [OPUS-4.8] sq-3jtd.6: the cache key ([`SessionKey`]) spans all three session
+    // dimensions — agent, client, AND issuer — so two sessions differing only by issuer
+    // (e.g. the same WebID vouched for by a trusted vs an untrusted IdP) never collide on
+    // a cached graph set.
+    cache: FxHashMap<SessionKey, SessionSets>,
     /// [OPUS-4.8] sq-dpk4 — the bridged-ODRL-grant ledger: what was bridged from which
     /// `(policy, request)`, plus the static-baseline auth view to rebuild from on a
     /// refresh. Only present when the `odrl-bridge` feature is enabled (the core build
@@ -129,6 +133,11 @@ pub struct PodStore {
     #[cfg(feature = "odrl-bridge")]
     bridge_ledger: odrl_bridge::BridgeLedger,
 }
+
+/// The owned session-cache key: the three request dimensions ([`Session`] is borrowed,
+/// so the cache owns `String` copies) plus the [`Mode`]. [OPUS-4.8] sq-3jtd.6 added the
+/// issuer slot — keep all three dimensions here so issuer-distinct sessions never collide.
+type SessionKey = (Option<String>, Option<String>, Option<String>, Mode);
 
 /// One session-cache entry: the same authorized graph set in the two shapes its two
 /// consumers need — sorted (the v1 `FROM NAMED` rewrite, [`PodStore::accessible`])
@@ -158,7 +167,7 @@ impl PodStore {
     /// <https://mallory.ex/card#me> <https://sparq.dev/ns/auth#read> <https://pod.ex/secret> <urn:sparq:auth> .
     /// "#;
     /// let mut store = PodStore::new(sparq_core::Graph::load_dataset(forged, "nquads")?);
-    /// let mallory = Session { agent: Some("https://mallory.ex/card#me"), client: None };
+    /// let mallory = Session { agent: Some("https://mallory.ex/card#me"), client: None, issuer: None };
     /// assert!(store.accessible(&mallory, Mode::Read).is_empty());
     /// # Ok::<(), String>(())
     /// ```
@@ -265,7 +274,8 @@ impl PodStore {
     }
 
     fn session_sets(&mut self, s: &Session, mode: Mode) -> &SessionSets {
-        let key = (s.agent.map(str::to_owned), s.client.map(str::to_owned), mode);
+        let key =
+            (s.agent.map(str::to_owned), s.client.map(str::to_owned), s.issuer.map(str::to_owned), mode);
         let auth = Arc::clone(&self.auth);
         self.cache.entry(key).or_insert_with(|| {
             let sorted = auth.accessible(s, mode);
@@ -324,7 +334,7 @@ impl PodStore {
     /// # let mut store = PodStore::new(sparq_core::Graph::load_dataset(nquads, "nquads")?);
     /// # store.materialize_wac()?;
     /// let q = "SELECT ?title WHERE { ?s <https://ex.dev/ns#title> ?title }";
-    /// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None };
+    /// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None };
     /// assert_eq!(store.query_as(&alice, Mode::Read, q)?.rows.len(), 1);
     /// assert_eq!(store.query_as(&Session::default(), Mode::Read, q)?.rows.len(), 0);
     /// # Ok::<(), String>(())
@@ -437,7 +447,7 @@ impl PodStore {
     /// let mut store = PodStore::new(sparq_core::Graph::load_dataset(nquads, "nquads")?);
     /// store.materialize_wac()?;
     ///
-    /// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None };
+    /// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None };
     /// let ins = "INSERT DATA { GRAPH <https://pod.ex/notes/n1> { \
     ///     <https://pod.ex/notes/n1#it> <https://ex.dev/ns#tag> \"x\" } }";
     /// // alice has acl:Write on n1 -> permitted

--- a/crates/sparq-solid/src/loader.rs
+++ b/crates/sparq-solid/src/loader.rs
@@ -21,6 +21,9 @@ const ACL_AGENT_GROUP: &str = "http://www.w3.org/ns/auth/acl#agentGroup";
 const ACL_ORIGIN: &str = "http://www.w3.org/ns/auth/acl#origin";
 const ACP_AGENT: &str = "http://www.w3.org/ns/solid/acp#agent";
 const ACP_CLIENT: &str = "http://www.w3.org/ns/solid/acp#client";
+// [OPUS-4.8] sq-3jtd.6: acp:issuer is a pair/triple-principal ingredient too, so its
+// values go through the same reserved-encoding validation as agents/clients/origins.
+const ACP_ISSUER: &str = "http://www.w3.org/ns/solid/acp#issuer";
 const VCARD_MEMBER: &str = "http://www.w3.org/2006/vcard/ns#hasMember";
 
 /// Reserved IRI space: the auth view, the rewrite sentinel, minted pair/candidate/grant
@@ -217,8 +220,8 @@ pub(crate) fn assemble_input(graph: &Graph, system: System) -> Result<String, St
 }
 
 /// Concrete agents + group documents mentioned by an access-control triple; every
-/// pair-principal ingredient (agents, group members, origins, clients) is recorded for
-/// reserved-encoding validation.
+/// pair/triple-principal ingredient (agents, group members, origins, clients, issuers)
+/// is recorded for reserved-encoding validation.
 fn collect_agents(
     t: &[Term; 3],
     webids: &mut FxHashSet<String>,
@@ -233,7 +236,7 @@ fn collect_agents(
             }
             principal_iris.insert(o.as_str().to_owned());
         }
-        ACL_ORIGIN | ACP_CLIENT => {
+        ACL_ORIGIN | ACP_CLIENT | ACP_ISSUER => {
             principal_iris.insert(o.as_str().to_owned());
         }
         ACL_AGENT_GROUP => {

--- a/crates/sparq-solid/src/materialize.rs
+++ b/crates/sparq-solid/src/materialize.rs
@@ -25,9 +25,13 @@ const ACP_C: &str = include_str!("../rules/acp-c.n3");
 const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 const EXCEPT_MATCHER: &str = "https://sparq.dev/ns/auth#exceptMatcher";
 /// solidx facts copied into the auth view for matchers referenced by conditional
-/// grants (the session layer evaluates `exceptMatcher`s from these).
-const MATCHER_FACTS: [&str; 2] =
-    ["https://sparq.dev/ns/solidx#acceptsAgentP", "https://sparq.dev/ns/solidx#acceptsClientP"];
+/// grants (the session layer evaluates `exceptMatcher`s from these). [OPUS-4.8]
+/// sq-3jtd.6 adds `acceptsIssuerP` — the noneOf exception check is three-dimensional.
+const MATCHER_FACTS: [&str; 3] = [
+    "https://sparq.dev/ns/solidx#acceptsAgentP",
+    "https://sparq.dev/ns/solidx#acceptsClientP",
+    "https://sparq.dev/ns/solidx#acceptsIssuerP",
+];
 
 /// What a `materialize_*` run produced: auth-view size, per-stratum closure sizes,
 /// and wall-clock time. Purely informational (logging / benchmarking) — the result
@@ -134,7 +138,7 @@ pub fn materialize_wac(graph: &mut Graph) -> Result<MaterializeStats, String> {
 /// assert_eq!(stats.strata_facts.len(), 3); // accepts → rejections → grants
 ///
 /// let index = sparq_solid::AuthIndex::from_graph(&graph);
-/// let alice = sparq_solid::Session { agent: Some("https://alice.ex/card#me"), client: None };
+/// let alice = sparq_solid::Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None };
 /// assert_eq!(index.accessible(&alice, sparq_solid::Mode::Read).len(), 2); // n1 + notes/
 /// # Ok::<(), String>(())
 /// ```

--- a/crates/sparq-solid/src/odrl_bridge.rs
+++ b/crates/sparq-solid/src/odrl_bridge.rs
@@ -676,7 +676,7 @@ fn recipient_principal_allowed(p: &str) -> bool {
 ///
 /// ```text
 /// <grant> a auth:ConditionalGrant ; auth:effect auth:Allow ;
-///         auth:agent <recipient> ; auth:client auth:AnyClient ;
+///         auth:agent <recipient> ; auth:client auth:AnyClient ; auth:issuer auth:AnyIssuer ;
 ///         auth:mode acl:<Mode> ; auth:graph <target> .
 /// ```
 ///
@@ -1029,6 +1029,12 @@ fn append_conditional_grants(
     let agent_p = NamedNode::new_unchecked(format!("{AUTH_NS}agent"));
     let client_p = NamedNode::new_unchecked(format!("{AUTH_NS}client"));
     let any_client = NamedNode::new_unchecked(crate::authindex::ANY_CLIENT);
+    // [OPUS-4.8] sq-3jtd.6: a bridged grant carries no issuer constraint, so it spans the
+    // issuer-dimension top — exactly as it spans the client top. The head MUST state this
+    // explicitly: the session layer treats a conditional grant whose `auth:issuer` head is
+    // absent as fail-closed (it never applies), matching the `auth:client` convention.
+    let issuer_p = NamedNode::new_unchecked(format!("{AUTH_NS}issuer"));
+    let any_issuer = NamedNode::new_unchecked(crate::authindex::ANY_ISSUER);
     let mode_p = NamedNode::new_unchecked(format!("{AUTH_NS}mode"));
     let mode_o = NamedNode::new_unchecked(mode_iri(mode));
     let graph_p = NamedNode::new_unchecked(format!("{AUTH_NS}graph"));
@@ -1036,15 +1042,26 @@ fn append_conditional_grants(
     let except_p = NamedNode::new_unchecked(format!("{AUTH_NS}exceptMatcher"));
     let accepts_agent_p = NamedNode::new_unchecked(format!("{SOLIDX_NS}acceptsAgentP"));
     let accepts_client_p = NamedNode::new_unchecked(format!("{SOLIDX_NS}acceptsClientP"));
+    let accepts_issuer_p = NamedNode::new_unchecked(format!("{SOLIDX_NS}acceptsIssuerP"));
 
     // One deterministic exception matcher per carved-out principal, shared across the
     // grant heads (its accept-set is the same regardless of which positive head it
-    // attaches to). Each accepts (agent = X, client = any) → suppresses the grant for X.
-    let except_matchers: Vec<(String, [Term; 2])> = excepts
+    // attaches to). Each accepts (agent = X, client = any, issuer = any) → suppresses the
+    // grant for X. [OPUS-4.8] sq-3jtd.6: the issuer accept (auth:AnyIssuer) makes the
+    // carve-out span the issuer dimension too — without it the three-dimensional
+    // matcher_accepts would never fire (it requires all three dimensions to accept).
+    let except_matchers: Vec<(String, [Term; 3])> = excepts
         .iter()
         .map(|x| {
             let m = format!("urn:sparq:odrl-except?agent={}", sparq_reason::n3::encode_for_uri(x));
-            (m, [Term::NamedNode(NamedNode::new_unchecked(x)), Term::NamedNode(any_client.clone())])
+            (
+                m,
+                [
+                    Term::NamedNode(NamedNode::new_unchecked(x)),
+                    Term::NamedNode(any_client.clone()),
+                    Term::NamedNode(any_issuer.clone()),
+                ],
+            )
         })
         .collect();
 
@@ -1073,15 +1090,17 @@ fn append_conditional_grants(
             [g.clone(), Term::NamedNode(effect_p.clone()), Term::NamedNode(effect_o.clone())],
             [g.clone(), Term::NamedNode(agent_p.clone()), agent_o],
             [g.clone(), Term::NamedNode(client_p.clone()), Term::NamedNode(any_client.clone())],
+            [g.clone(), Term::NamedNode(issuer_p.clone()), Term::NamedNode(any_issuer.clone())],
             [g.clone(), Term::NamedNode(mode_p.clone()), Term::NamedNode(mode_o.clone())],
             [g.clone(), Term::NamedNode(graph_p.clone()), Term::NamedNode(graph_o.clone())],
         ];
         // Wire each exception matcher onto the grant + materialize its accept-set facts.
-        for (m, [agent_accept, client_accept]) in &except_matchers {
+        for (m, [agent_accept, client_accept, issuer_accept]) in &except_matchers {
             let m_node = Term::NamedNode(NamedNode::new_unchecked(m));
             head.push([g.clone(), Term::NamedNode(except_p.clone()), m_node.clone()]);
             head.push([m_node.clone(), Term::NamedNode(accepts_agent_p.clone()), agent_accept.clone()]);
-            head.push([m_node, Term::NamedNode(accepts_client_p.clone()), client_accept.clone()]);
+            head.push([m_node.clone(), Term::NamedNode(accepts_client_p.clone()), client_accept.clone()]);
+            head.push([m_node, Term::NamedNode(accepts_issuer_p.clone()), issuer_accept.clone()]);
         }
         for t in head {
             if !emitted.contains(&t) {

--- a/crates/sparq-solid/tests/acp.rs
+++ b/crates/sparq-solid/tests/acp.rs
@@ -15,7 +15,19 @@ fn store() -> PodStore {
 }
 
 fn can(s: &mut PodStore, agent: Option<&str>, client: Option<&str>, mode: Mode, graph: &str) -> bool {
-    s.accessible(&Session { agent, client }, mode).iter().any(|g| g.as_str() == graph)
+    s.accessible(&Session { agent, client, issuer: None }, mode).iter().any(|g| g.as_str() == graph)
+}
+
+/// [OPUS-4.8] sq-3jtd.6: as [`can`] but with the issuer dimension supplied.
+fn can_iss(
+    s: &mut PodStore,
+    agent: Option<&str>,
+    client: Option<&str>,
+    issuer: Option<&str>,
+    mode: Mode,
+    graph: &str,
+) -> bool {
+    s.accessible(&Session { agent, client, issuer }, mode).iter().any(|g| g.as_str() == graph)
 }
 
 #[test]
@@ -90,21 +102,184 @@ fn acp_write_enforcement_matches_grants() {
 
     let priv0 = "https://pod.ex/priv0/c4/g0/d0.ttl";
     assert!(can(&mut s, Some(ALICE), None, Mode::Write, priv0));
-    s.update_as_acp(&Session { agent: Some(ALICE), client: None }, &ins(priv0))
+    s.update_as_acp(&Session { agent: Some(ALICE), client: None, issuer: None }, &ins(priv0))
         .expect("alice (cumulative owner) writes priv0");
     assert!(!can(&mut s, Some(BOB), None, Mode::Write, priv0));
     assert!(
-        s.update_as_acp(&Session { agent: Some(BOB), client: None }, &ins(priv0)).is_err(),
+        s.update_as_acp(&Session { agent: Some(BOB), client: None, issuer: None }, &ins(priv0)).is_err(),
         "bob has no write on priv0"
     );
 
     let team2 = "https://pod.ex/team2/c3/g0/d0.ttl";
     assert!(can(&mut s, Some(BOB), None, Mode::Write, team2));
-    s.update_as_acp(&Session { agent: Some(BOB), client: None }, &ins(team2))
+    s.update_as_acp(&Session { agent: Some(BOB), client: None, issuer: None }, &ins(team2))
         .expect("bob (anyOf) writes team2");
     assert!(!can(&mut s, Some(DAVE), None, Mode::Write, team2));
     assert!(
-        s.update_as_acp(&Session { agent: Some(DAVE), client: None }, &ins(team2)).is_err(),
+        s.update_as_acp(&Session { agent: Some(DAVE), client: None, issuer: None }, &ins(team2)).is_err(),
         "dave denied write on team2"
     );
+}
+
+// ── [OPUS-4.8] sq-3jtd.6: acp:issuer support — the (agent, client, issuer) principal ──
+//
+// The issuer dimension is the exact twin of the client dimension (design doc §3.6): an
+// ACP Matcher can constrain on the OIDC issuer that vouched for the requester's WebID.
+// These tests build small inline ACP pods (one .acr graph) so the issuer matrix is
+// hand-verifiable, and exercise BOTH outcomes — allow when the issuer matches, deny when
+// it does not (or is absent), through the unchanged `materialize_acp` + `accessible` path.
+
+const GOOD_IDP: &str = "https://good-idp.ex";
+const EVIL_IDP: &str = "https://evil-idp.ex";
+const ISS_DOC: &str = "https://pod.ex/iss/d0.ttl";
+const ISS_ACR: &str = "https://pod.ex/iss/.acr";
+
+/// One inline ACP pod: a single document `iss/d0.ttl` whose containing `iss/` ACR
+/// (`iss/.acr`) carries `policy_body` (raw N-Triple body lines, sharing the `#pol` policy
+/// node) under `acp:memberAccessControl`, so the policy applies cumulatively to the
+/// member document — the same inheritance shape as the shared fixture.
+fn iss_store(policy_body: &str) -> PodStore {
+    let acr = format!(
+        "<{ISS_DOC}#it> <https://ex.dev/ns#title> \"iss\" <{ISS_DOC}> .\n\
+         <{ISS_ACR}> <http://www.w3.org/ns/solid/acp#memberAccessControl> <{ISS_ACR}#ctl> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#ctl> <http://www.w3.org/ns/solid/acp#apply> <{ISS_ACR}#pol> <{ISS_ACR}> .\n\
+         {policy_body}"
+    );
+    let g = Graph::load_dataset(&acr, "nquads").expect("inline acp pod loads");
+    let mut s = PodStore::new(g);
+    s.materialize_acp().expect("acp materializes");
+    s
+}
+
+/// allOf { acp:agent BOB ; acp:issuer GOOD_IDP }: BOB is granted Read ONLY when the
+/// session's issuer is GOOD_IDP. Allow AND deny are both decided by the issuer.
+#[test]
+fn acp_issuer_allof_allow_and_deny() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let body = format!(
+        "<{ISS_ACR}#pol> <{acp}allow> <{acl}Read> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#pol> <{acp}allOf> <{ISS_ACR}#m> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#m> <{acp}agent> <{BOB}> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#m> <{acp}issuer> <{GOOD_IDP}> <{ISS_ACR}> .\n"
+    );
+    let mut s = iss_store(&body);
+    let r = Mode::Read;
+
+    // ALLOW: bob through the trusted issuer.
+    assert!(can_iss(&mut s, Some(BOB), None, Some(GOOD_IDP), r, ISS_DOC), "bob @ good-idp allowed");
+    // DENY decided by issuer: same agent, wrong issuer.
+    assert!(!can_iss(&mut s, Some(BOB), None, Some(EVIL_IDP), r, ISS_DOC), "bob @ evil-idp denied");
+    // DENY fail-closed: issuer-constrained grant never matches a session with no issuer.
+    assert!(!can_iss(&mut s, Some(BOB), None, None, r, ISS_DOC), "bob w/o issuer denied");
+    // DENY: right issuer, wrong agent (allOf needs both).
+    assert!(!can_iss(&mut s, Some(CAROL), None, Some(GOOD_IDP), r, ISS_DOC), "carol @ good-idp denied");
+}
+
+/// anyOf { acp:issuer GOOD_IDP } (issuer-only, no agent attr): ANY agent vouched for by
+/// GOOD_IDP is granted, regardless of WebID; nobody from another issuer is.
+#[test]
+fn acp_issuer_only_matcher_any_agent() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let body = format!(
+        "<{ISS_ACR}#pol> <{acp}allow> <{acl}Read> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#pol> <{acp}anyOf> <{ISS_ACR}#m> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#m> <{acp}issuer> <{GOOD_IDP}> <{ISS_ACR}> .\n"
+    );
+    let mut s = iss_store(&body);
+    let r = Mode::Read;
+
+    // ALLOW: any agent from the trusted issuer (the agent dimension is unconstrained).
+    assert!(can_iss(&mut s, Some(BOB), None, Some(GOOD_IDP), r, ISS_DOC), "bob @ good-idp allowed");
+    assert!(can_iss(&mut s, Some(CAROL), None, Some(GOOD_IDP), r, ISS_DOC), "carol @ good-idp allowed");
+    // DENY decided by issuer: wrong issuer, or no issuer asserted at all.
+    assert!(!can_iss(&mut s, Some(BOB), None, Some(EVIL_IDP), r, ISS_DOC), "bob @ evil-idp denied");
+    assert!(!can_iss(&mut s, Some(CAROL), None, None, r, ISS_DOC), "carol w/o issuer denied");
+    assert!(!can_iss(&mut s, None, None, None, r, ISS_DOC), "anonymous w/o issuer denied");
+    // The matcher is agent-unconstrained, so it grants the agent-dimension top
+    // (auth:Public): a session presenting only the trusted issuer is accepted even without
+    // a WebID — faithful, since the matcher asserts nothing about the agent.
+    assert!(can_iss(&mut s, None, None, Some(GOOD_IDP), r, ISS_DOC), "any context @ good-idp allowed");
+}
+
+/// allOf { acp:agent BOB ; acp:client APP ; acp:issuer GOOD_IDP }: the full three-
+/// dimension principal — exactly the (user, app, issuer) triple, nothing wider.
+#[test]
+fn acp_issuer_client_triple() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let body = format!(
+        "<{ISS_ACR}#pol> <{acp}allow> <{acl}Read> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#pol> <{acp}allOf> <{ISS_ACR}#m> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#m> <{acp}agent> <{BOB}> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#m> <{acp}client> <{APP}> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#m> <{acp}issuer> <{GOOD_IDP}> <{ISS_ACR}> .\n"
+    );
+    let mut s = iss_store(&body);
+    let r = Mode::Read;
+
+    // ALLOW: the exact triple.
+    assert!(can_iss(&mut s, Some(BOB), Some(APP), Some(GOOD_IDP), r, ISS_DOC), "bob+app@good-idp allowed");
+    // DENY decided by issuer alone (agent + client correct).
+    assert!(!can_iss(&mut s, Some(BOB), Some(APP), Some(EVIL_IDP), r, ISS_DOC), "wrong issuer denied");
+    // DENY: missing the issuer dimension entirely.
+    assert!(!can_iss(&mut s, Some(BOB), Some(APP), None, r, ISS_DOC), "no issuer denied");
+    // DENY: correct agent + issuer, wrong client.
+    assert!(
+        !can_iss(&mut s, Some(BOB), Some("https://evil.ex"), Some(GOOD_IDP), r, ISS_DOC),
+        "wrong client denied"
+    );
+}
+
+/// noneOf { acp:issuer EVIL_IDP } on an otherwise-public policy: a CONDITIONAL grant whose
+/// exception is evaluated per session on the ISSUER dimension. Everyone reads EXCEPT a
+/// session asserting the excluded issuer — the deny is decided by the issuer.
+#[test]
+fn acp_issuer_noneof_conditional_grant() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let public_agent = format!("{acp}PublicAgent");
+    let body = format!(
+        "<{ISS_ACR}#pol> <{acp}allow> <{acl}Read> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#pol> <{acp}anyOf> <{ISS_ACR}#mpub> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#mpub> <{acp}agent> <{public_agent}> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#pol> <{acp}noneOf> <{ISS_ACR}#mno> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#mno> <{acp}issuer> <{EVIL_IDP}> <{ISS_ACR}> .\n"
+    );
+    let mut s = iss_store(&body);
+    let r = Mode::Read;
+
+    // ALLOW: public — anonymous, and any issuer that is NOT the excluded one.
+    assert!(can_iss(&mut s, None, None, None, r, ISS_DOC), "anonymous reads");
+    assert!(can_iss(&mut s, Some(BOB), None, Some(GOOD_IDP), r, ISS_DOC), "bob @ good-idp reads");
+    assert!(can_iss(&mut s, Some(CAROL), None, None, r, ISS_DOC), "carol w/o issuer reads");
+    // DENY decided by the issuer exception: a session asserting the excluded issuer is
+    // carved out (the noneOf exception matcher accepts it, suppressing the grant).
+    assert!(!can_iss(&mut s, Some(BOB), None, Some(EVIL_IDP), r, ISS_DOC), "bob @ evil-idp carved out");
+}
+
+/// Fail-closed: a malicious `acp:issuer` value inside the reserved `urn:sparq:` space (or
+/// carrying the pair delimiter) is rejected at materialization, exactly like a malicious
+/// agent/client value — it cannot smuggle a forged triple principal into the auth view.
+#[test]
+fn acp_issuer_reserved_encoding_rejected() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let evil = "urn:sparq:triple?agent=x&client=y&issuer=z";
+    let body = format!(
+        "<{ISS_ACR}#pol> <{acp}allow> <{acl}Read> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#pol> <{acp}allOf> <{ISS_ACR}#m> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#m> <{acp}agent> <{BOB}> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#m> <{acp}issuer> <{evil}> <{ISS_ACR}> .\n"
+    );
+    let acr = format!(
+        "<{ISS_DOC}#it> <https://ex.dev/ns#title> \"iss\" <{ISS_DOC}> .\n\
+         <{ISS_ACR}> <{acp}accessControl> <{ISS_ACR}#ctl> <{ISS_ACR}> .\n\
+         <{ISS_ACR}#ctl> <{acp}apply> <{ISS_ACR}#pol> <{ISS_ACR}> .\n\
+         {body}"
+    );
+    let g = Graph::load_dataset(&acr, "nquads").expect("loads");
+    let mut s = PodStore::new(g);
+    assert!(s.materialize_acp().is_err(), "reserved-space issuer IRI rejected at materialization");
 }

--- a/crates/sparq-solid/tests/e2e.rs
+++ b/crates/sparq-solid/tests/e2e.rs
@@ -29,14 +29,14 @@ const TITLES: &str = "SELECT ?title WHERE { ?s <https://ex.dev/ns#title> ?title 
 #[test]
 fn same_query_different_agents_different_results() {
     let mut s = store();
-    let alice = s.query_as(&Session { agent: Some(ALICE), client: None }, Mode::Read, TITLES).unwrap();
-    let carol = s.query_as(&Session { agent: Some(CAROL), client: None }, Mode::Read, TITLES).unwrap();
+    let alice = s.query_as(&Session { agent: Some(ALICE), client: None, issuer: None }, Mode::Read, TITLES).unwrap();
+    let carol = s.query_as(&Session { agent: Some(CAROL), client: None, issuer: None }, Mode::Read, TITLES).unwrap();
     let anon = s.query_as(&Session::default(), Mode::Read, TITLES).unwrap();
     assert_eq!(alice.rows.len(), 599, "alice sees her documents");
     assert_eq!(carol.rows.len(), 407, "carol sees group + public + deep-override docs");
     assert_eq!(anon.rows.len(), 144, "anonymous sees only the public subtree");
     // the kept v1 portability path (FROM NAMED rewrite) returns the same counts
-    let v1 = s.query_as_rewrite(&Session { agent: Some(ALICE), client: None }, Mode::Read, TITLES).unwrap();
+    let v1 = s.query_as_rewrite(&Session { agent: Some(ALICE), client: None, issuer: None }, Mode::Read, TITLES).unwrap();
     assert_eq!(v1.rows.len(), 599);
 }
 
@@ -53,13 +53,13 @@ fn graph_patterns_and_cross_document_joins_stay_inside_the_sandbox() {
     let join = "SELECT ?s ?child WHERE { \
                   ?s <https://ex.dev/ns#inSubtree> <https://pod.ex/team2/> . \
                   <https://pod.ex/team2/> <http://www.w3.org/ns/ldp#contains> ?child }";
-    let carol = s.query_as(&Session { agent: Some(CAROL), client: None }, Mode::Read, join).unwrap();
+    let carol = s.query_as(&Session { agent: Some(CAROL), client: None, issuer: None }, Mode::Read, join).unwrap();
     assert_eq!(carol.rows.len(), 144 * 6, "join across document + container graphs");
     let bob_no_container =
-        s.query_as(&Session { agent: Some(BOB), client: None }, Mode::Read, join).unwrap();
+        s.query_as(&Session { agent: Some(BOB), client: None, issuer: None }, Mode::Read, join).unwrap();
     // bob reads team2 docs too (group member) and the container via… also group
     assert_eq!(bob_no_container.rows.len(), 144 * 6);
-    let alice = s.query_as(&Session { agent: Some(ALICE), client: None }, Mode::Read, join).unwrap();
+    let alice = s.query_as(&Session { agent: Some(ALICE), client: None, issuer: None }, Mode::Read, join).unwrap();
     assert_eq!(alice.rows.len(), 0, "alice is shadowed out of team2 entirely");
 }
 
@@ -70,7 +70,7 @@ fn explicit_named_graph_query_cannot_escape() {
     let q = "SELECT ?o WHERE { GRAPH <https://pod.ex/priv0/c4/g0/d0.ttl> { ?s ?p ?o } }";
     let anon = s.query_as(&Session::default(), Mode::Read, q).unwrap();
     assert_eq!(anon.rows.len(), 0, "unauthorized graph behaves as absent");
-    let alice = s.query_as(&Session { agent: Some(ALICE), client: None }, Mode::Read, q).unwrap();
+    let alice = s.query_as(&Session { agent: Some(ALICE), client: None, issuer: None }, Mode::Read, q).unwrap();
     assert!(!alice.rows.is_empty());
     // …and a pre-existing FROM NAMED is intersected, never widened
     let widened = "SELECT ?o FROM NAMED <https://pod.ex/priv0/c4/g0/d0.ttl> \
@@ -107,9 +107,9 @@ fn view_path_and_rewrite_path_return_identical_json() {
         "SELECT (COUNT(?s) AS ?n) WHERE { ?s <https://ex.dev/ns#title> ?title }",
     ];
     let sessions = [
-        ("alice", Session { agent: Some(ALICE), client: None }),
-        ("carol", Session { agent: Some(CAROL), client: None }),
-        ("bob+app (origin pair)", Session { agent: Some(BOB), client: Some(APP) }),
+        ("alice", Session { agent: Some(ALICE), client: None, issuer: None }),
+        ("carol", Session { agent: Some(CAROL), client: None, issuer: None }),
+        ("bob+app (origin pair)", Session { agent: Some(BOB), client: Some(APP), issuer: None }),
         ("anonymous", Session::default()),
     ];
     for (label, session) in sessions {

--- a/crates/sparq-solid/tests/hardening.rs
+++ b/crates/sparq-solid/tests/hardening.rs
@@ -23,7 +23,7 @@ fn sentinel_graph_cannot_be_smuggled() {
     s.materialize_wac().unwrap();
     let q = "SELECT ?o WHERE { GRAPH ?g { ?s ?p ?o } }";
     // a session with zero grants must see nothing — even the sentinel-named graph
-    let stranger = Session { agent: Some("https://stranger.ex/card#me"), client: None };
+    let stranger = Session { agent: Some("https://stranger.ex/card#me"), client: None, issuer: None };
     let denied_modes = s.accessible(&stranger, Mode::Write);
     assert!(denied_modes.is_empty());
     let res = s.query_as(&stranger, Mode::Write, q).unwrap();
@@ -64,25 +64,25 @@ fn reserved_session_values_fail_closed() {
     let mut s = PodStore::new(Graph::load_dataset(&wac_fixture(), "nquads").unwrap());
     s.materialize_wac().unwrap();
     let spoof = "urn:sparq:pair?agent=https://bob.ex/card#me&client=https://app.ex";
-    assert!(s.accessible(&Session { agent: Some(spoof), client: None }, Mode::Read).is_empty());
+    assert!(s.accessible(&Session { agent: Some(spoof), client: None, issuer: None }, Mode::Read).is_empty());
     assert!(s
         .accessible(
-            &Session { agent: Some("https://bob.ex/card#me"), client: Some("urn:sparq:x") },
+            &Session { agent: Some("https://bob.ex/card#me"), client: Some("urn:sparq:x"), issuer: None },
             Mode::Read
         )
         .is_empty());
     // delimiter-only values (NOT in the reserved space) must fail closed too: a WebID
     // embedding `&client=` could otherwise complete someone else's pair encoding
     let delim_agent = format!("https://x.ex/a{}https://app.ex", "&client=");
-    assert!(s.accessible(&Session { agent: Some(&delim_agent), client: None }, Mode::Read).is_empty());
+    assert!(s.accessible(&Session { agent: Some(&delim_agent), client: None, issuer: None }, Mode::Read).is_empty());
     assert!(s
         .accessible(
-            &Session { agent: Some("https://bob.ex/card#me"), client: Some(&delim_agent) },
+            &Session { agent: Some("https://bob.ex/card#me"), client: Some(&delim_agent), issuer: None },
             Mode::Read
         )
         .is_empty());
     // …while the REAL pair still works
-    let real = Session { agent: Some("https://bob.ex/card#me"), client: Some("https://app.ex") };
+    let real = Session { agent: Some("https://bob.ex/card#me"), client: Some("https://app.ex"), issuer: None };
     assert!(s
         .accessible(&real, Mode::Read)
         .iter()
@@ -96,7 +96,7 @@ fn normal_path_still_green_after_hardening() {
     s.materialize_wac().unwrap();
     let res = s
         .query_as(
-            &Session { agent: Some(ALICE), client: None },
+            &Session { agent: Some(ALICE), client: None, issuer: None },
             Mode::Read,
             "SELECT ?title WHERE { ?s <https://ex.dev/ns#title> ?title }",
         )

--- a/crates/sparq-solid/tests/odrl_bridge.rs
+++ b/crates/sparq-solid/tests/odrl_bridge.rs
@@ -103,14 +103,14 @@ fn round_trip_through_enforcement() {
     let out = store.materialize_odrl_permission(&read_policy(), &req);
     assert!(out.granted);
 
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     // alice can READ n1 via the materialized grant…
     assert!(store.accessible(&alice, Mode::Read).iter().any(|gph| gph.as_str() == N1));
     // …but NOT write (the bridge only materialized a read grant — fail-closed)…
     assert!(store.accessible(&alice, Mode::Write).is_empty());
 
     // …and a DIFFERENT agent gets nothing (the grant is scoped to alice's WebID).
-    let mallory = Session { agent: Some("https://mallory.ex/card#me"), client: None };
+    let mallory = Session { agent: Some("https://mallory.ex/card#me"), client: None, issuer: None };
     assert!(store.accessible(&mallory, Mode::Read).is_empty());
     // anonymous likewise.
     assert!(store.accessible(&Session::default(), Mode::Read).is_empty());
@@ -135,9 +135,9 @@ fn deny_materializes_nothing() {
     assert!(out.grant_triple.is_none());
 
     // Nobody gains access — the auth view holds no bridged grant.
-    let mallory = Session { agent: Some("https://mallory.ex/card#me"), client: None };
+    let mallory = Session { agent: Some("https://mallory.ex/card#me"), client: None, issuer: None };
     assert!(store.accessible(&mallory, Mode::Read).is_empty());
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert!(store.accessible(&alice, Mode::Read).is_empty());
 }
 
@@ -170,7 +170,7 @@ fn unsatisfied_constraint_materializes_nothing() {
         .with(odrl("dateTime"), Value::DateTime("2026-06-16T00:00:00Z".to_owned()));
     let out = store.materialize_odrl_permission(&pol, &req);
     assert!(!out.granted, "out-of-window must not grant: {out:?}");
-    assert!(store.accessible(&Session { agent: Some(ALICE), client: None }, Mode::Read).is_empty());
+    assert!(store.accessible(&Session { agent: Some(ALICE), client: None, issuer: None }, Mode::Read).is_empty());
 
     // And the SAME policy with NO dateTime evidence also fails closed.
     let mut store2 = PodStore::new(pod());
@@ -259,7 +259,7 @@ fn bridge_preserves_existing_wac_grants() {
 
     // Does `agent` have read on n1 through the store's current enforcement view?
     fn reads_n1(s: &mut PodStore, agent: &str) -> bool {
-        let sess = Session { agent: Some(agent), client: None };
+        let sess = Session { agent: Some(agent), client: None, issuer: None };
         s.accessible(&sess, Mode::Read).iter().any(|g| g.as_str() == N1)
     }
 
@@ -340,7 +340,7 @@ fn deny_overrides_allow_through_enforcement() {
     let wreq = Request::new(odrl("modify")).on(N1).by(ALICE);
     assert!(store.materialize_odrl_permission(&permit, &wreq).granted);
 
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     // Sanity: the allow grant is live through the real enforcement path.
     assert!(
         store.accessible(&alice, Mode::Write).iter().any(|g| g.as_str() == N1),
@@ -401,7 +401,7 @@ fn permit_plus_prohibition_same_subject_is_denied() {
     assert!(out.deny_triple.is_some());
 
     // Net effect through the real enforcement: alice is DENIED.
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert!(
         store.accessible(&alice, Mode::Write).is_empty(),
         "deny-overrides: a permission + prohibition on the same subject denies",
@@ -486,7 +486,7 @@ fn permit_only_regression_via_policy() {
     // End-to-end through the enforcement path: alice reads, deny absent.
     let mut store = PodStore::new(pod());
     assert!(store.materialize_odrl_policy(&read_policy(), &req).granted);
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert!(store.accessible(&alice, Mode::Read).iter().any(|g| g.as_str() == N1));
 }
 
@@ -498,7 +498,7 @@ fn permit_only_regression_via_policy() {
 use sparq_solid::materialize_permission_conditional;
 
 fn reads(store: &mut PodStore, agent: &str) -> bool {
-    let s = Session { agent: Some(agent), client: None };
+    let s = Session { agent: Some(agent), client: None, issuer: None };
     store.accessible(&s, Mode::Read).iter().any(|g| g.as_str() == N1)
 }
 
@@ -563,8 +563,8 @@ fn recipient_constraint_persists_as_rechecked_condition() {
 
     // End-to-end through query_as: only carol sees the content.
     let sel = "SELECT ?t WHERE { ?s <https://ex.dev/ns#title> ?t }";
-    let carol = Session { agent: Some(CAROL), client: None };
-    let alice = Session { agent: Some(ALICE), client: None };
+    let carol = Session { agent: Some(CAROL), client: None, issuer: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert_eq!(store.query_as(&carol, Mode::Read, sel).unwrap().rows.len(), 1);
     assert_eq!(store.query_as(&alice, Mode::Read, sel).unwrap().rows.len(), 0);
 }
@@ -775,7 +775,7 @@ fn withdrawn_permission_loses_access_after_refresh() {
 
     // Materialize → alice has read.
     assert!(store.materialize_odrl_permission(&read_policy(), &req).granted);
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert!(
         store.accessible(&alice, Mode::Read).iter().any(|g| g.as_str() == N1),
         "bridged grant is live before withdrawal",
@@ -826,7 +826,7 @@ fn lapsed_time_window_loses_access_after_refresh() {
         .by(ALICE)
         .with(odrl("dateTime"), Value::DateTime("2025-06-01T00:00:00Z".to_owned()));
     assert!(store.materialize_odrl_permission(&pol, &in_window).granted);
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert!(store.accessible(&alice, Mode::Read).iter().any(|g| g.as_str() == N1));
 
     // The window LAPSES: re-evaluate with a NOW past the bound (same policy, new ctx).
@@ -861,7 +861,7 @@ fn reeval_now_denies_loses_access_after_refresh() {
     .unwrap();
     let req = Request::new(odrl("modify")).on(N1).by(ALICE);
     assert!(store.materialize_odrl_policy(&permit, &req).granted);
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert!(store.accessible(&alice, Mode::Write).iter().any(|g| g.as_str() == N1));
 
     // The policy now ADDS a prohibition on the same action → re-eval Denies.
@@ -893,7 +893,7 @@ fn valid_bridged_grant_survives_refresh() {
     let mut store = PodStore::new(pod());
     let req = Request::new(odrl("read")).on(N1).by(ALICE);
     assert!(store.materialize_odrl_permission(&read_policy(), &req).granted);
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert!(store.accessible(&alice, Mode::Read).iter().any(|g| g.as_str() == N1));
 
     // Plain refresh (policy unchanged) re-evaluates and KEEPS the still-valid grant.
@@ -927,7 +927,7 @@ fn static_grant_not_dropped_by_refresh() {
     store.materialize_wac().expect("wac materializes");
 
     fn reads_n1(s: &mut PodStore, agent: &str) -> bool {
-        let sess = Session { agent: Some(agent), client: None };
+        let sess = Session { agent: Some(agent), client: None, issuer: None };
         s.accessible(&sess, Mode::Read).iter().any(|g| g.as_str() == N1)
     }
 
@@ -996,7 +996,7 @@ fn static_rematerialization_preserves_valid_bridged_grant() {
     assert!(store.materialize_odrl_permission(&read_policy(), &req).granted);
 
     fn reads_n1(s: &mut PodStore, agent: &str) -> bool {
-        let sess = Session { agent: Some(agent), client: None };
+        let sess = Session { agent: Some(agent), client: None, issuer: None };
         s.accessible(&sess, Mode::Read).iter().any(|g| g.as_str() == N1)
     }
     assert!(reads_n1(&mut store, ALICE), "alice bridged before re-materialize");
@@ -1021,7 +1021,7 @@ fn ambiguous_reeval_retracts_fail_closed() {
         .by(ALICE)
         .with(odrl("dateTime"), Value::DateTime("2025-06-01T00:00:00Z".to_owned()));
     assert!(store.materialize_odrl_permission(&pol, &in_window).granted);
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert!(store.accessible(&alice, Mode::Read).iter().any(|g| g.as_str() == N1));
 
     // Refresh with NO dateTime evidence → constraint cannot be proven → fail-closed Deny.
@@ -1095,7 +1095,7 @@ fn withdrawn_prohibition_restores_access_after_refresh() {
     assert!(store.materialize_odrl_permission(&permit, &wreq).granted);
     assert!(store.materialize_odrl_prohibition(&write_prohibition(), &wreq).prohibited);
 
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert!(
         store.accessible(&alice, Mode::Write).is_empty(),
         "deny-overrides: alice is denied write while the prohibition holds",
@@ -1132,7 +1132,7 @@ fn withdrawn_standalone_deny_grants_no_access() {
     let mut store = PodStore::new(pod());
     let wreq = Request::new(odrl("modify")).on(N1).by(ALICE);
     assert!(store.materialize_odrl_prohibition(&write_prohibition(), &wreq).prohibited);
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert!(store.accessible(&alice, Mode::Write).is_empty(), "no grant → denied");
 
     // Withdraw the prohibition; the deny is retracted but there was never an allow.
@@ -1153,7 +1153,7 @@ fn applicable_prohibition_survives_refresh() {
     let mut store = PodStore::new(pod());
     let wreq = Request::new(odrl("modify")).on(N1).by(ALICE);
     assert!(store.materialize_odrl_prohibition(&write_prohibition(), &wreq).prohibited);
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert!(store.accessible(&alice, Mode::Write).is_empty());
 
     // Plain refresh (policy unchanged) → the prohibition still matches → deny KEPT.
@@ -1184,7 +1184,7 @@ fn ambiguous_prohibition_reeval_keeps_deny_fail_closed() {
     assert!(store
         .materialize_odrl_prohibition(&windowed_write_prohibition(), &in_window)
         .prohibited);
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert!(store.accessible(&alice, Mode::Write).is_empty(), "denied while window holds");
 
     // Refresh with NO dateTime evidence → we CANNOT prove the window lapsed → AMBIGUOUS.
@@ -1235,7 +1235,7 @@ fn definitely_lapsed_prohibition_retracts_deny() {
     assert!(store
         .materialize_odrl_prohibition(&windowed_write_prohibition(), &in_window)
         .prohibited);
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert!(store.accessible(&alice, Mode::Write).is_empty(), "denied while window holds");
 
     // Refresh with evidence the window has PROVABLY lapsed (now >= 2026-01-01 bound,
@@ -1272,7 +1272,7 @@ fn static_grant_never_dropped_by_deny_refresh() {
     store.materialize_wac().expect("wac materializes");
 
     fn reads_n1(s: &mut PodStore, agent: &str) -> bool {
-        let sess = Session { agent: Some(agent), client: None };
+        let sess = Session { agent: Some(agent), client: None, issuer: None };
         s.accessible(&sess, Mode::Read).iter().any(|g| g.as_str() == N1)
     }
     assert!(reads_n1(&mut store, BOB), "bob static read before");
@@ -1314,7 +1314,7 @@ fn policy_refresh_deny_overrides_composition() {
     .unwrap();
     let req = Request::new(odrl("modify")).on(N1).by(ALICE);
     assert!(store.materialize_odrl_policy(&both, &req).prohibited);
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert!(store.accessible(&alice, Mode::Write).is_empty(), "deny-overrides denies");
 
     // Refresh against a Policy that keeps the permission but DROPS the prohibition.
@@ -1366,7 +1366,7 @@ fn purpose_read_policy() -> sparq_policy::Policy {
 }
 
 fn reads_n1(store: &mut PodStore, agent: &str) -> bool {
-    let s = Session { agent: Some(agent), client: None };
+    let s = Session { agent: Some(agent), client: None, issuer: None };
     store.accessible(&s, Mode::Read).iter().any(|g| g.as_str() == N1)
 }
 
@@ -1375,7 +1375,7 @@ fn reads_n1(store: &mut PodStore, agent: &str) -> bool {
 fn purpose_match_grants_through_enforcement() {
     let pol = purpose_read_policy();
     let sel = "SELECT ?t WHERE { ?s <https://ex.dev/ns#title> ?t }";
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
 
     // (a) Matching purpose → grant → alice reads through accessible AND query_as.
     let mut store = PodStore::new(pod());
@@ -1408,7 +1408,7 @@ fn missing_purpose_fails_closed_through_enforcement() {
     assert!(!out.granted, "missing purpose must NOT grant: {out:?}");
     assert!(!reads_n1(&mut store, ALICE), "no access when purpose is unstated");
     let sel = "SELECT ?t WHERE { ?s <https://ex.dev/ns#title> ?t }";
-    let alice = Session { agent: Some(ALICE), client: None };
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None };
     assert_eq!(store.query_as(&alice, Mode::Read, sel).unwrap().rows.len(), 0);
 }
 
@@ -1575,8 +1575,8 @@ fn recipient_neq_grants_everyone_except_named_party() {
 
     // End-to-end via query_as: bob sees nothing, carol sees the content.
     let sel = "SELECT ?t WHERE { ?s <https://ex.dev/ns#title> ?t }";
-    let bob = Session { agent: Some(BOB), client: None };
-    let carol = Session { agent: Some(CAROL), client: None };
+    let bob = Session { agent: Some(BOB), client: None, issuer: None };
+    let carol = Session { agent: Some(CAROL), client: None, issuer: None };
     assert_eq!(store.query_as(&bob, Mode::Read, sel).unwrap().rows.len(), 0);
     assert_eq!(store.query_as(&carol, Mode::Read, sel).unwrap().rows.len(), 1);
 }
@@ -1712,8 +1712,8 @@ fn recipient_eq_and_neq_grants_only_carol() {
 
     // End-to-end via query_as: only carol sees the content.
     let sel = "SELECT ?t WHERE { ?s <https://ex.dev/ns#title> ?t }";
-    let carol = Session { agent: Some(CAROL), client: None };
-    let bob = Session { agent: Some(BOB), client: None };
+    let carol = Session { agent: Some(CAROL), client: None, issuer: None };
+    let bob = Session { agent: Some(BOB), client: None, issuer: None };
     assert_eq!(store.query_as(&carol, Mode::Read, sel).unwrap().rows.len(), 1);
     assert_eq!(store.query_as(&bob, Mode::Read, sel).unwrap().rows.len(), 0);
 }
@@ -1800,8 +1800,8 @@ fn conditional_deny_overrides_allow_for_carved_party() {
     assert!(reads(&mut store, BOB), "bob keeps the allow (only carol is denied)");
     // End-to-end query_as: carol sees nothing, bob sees the content.
     let sel = "SELECT ?t WHERE { ?s <https://ex.dev/ns#title> ?t }";
-    let carol = Session { agent: Some(CAROL), client: None };
-    let bob = Session { agent: Some(BOB), client: None };
+    let carol = Session { agent: Some(CAROL), client: None, issuer: None };
+    let bob = Session { agent: Some(BOB), client: None, issuer: None };
     assert_eq!(store.query_as(&carol, Mode::Read, sel).unwrap().rows.len(), 0);
     assert_eq!(store.query_as(&bob, Mode::Read, sel).unwrap().rows.len(), 1);
 }

--- a/crates/sparq-solid/tests/update.rs
+++ b/crates/sparq-solid/tests/update.rs
@@ -24,7 +24,7 @@ fn wac_store() -> PodStore {
 }
 
 fn sess(agent: Option<&str>) -> Session<'_> {
-    Session { agent, client: None }
+    Session { agent, client: None, issuer: None }
 }
 
 /// How many triples a graph currently holds (0 if absent).

--- a/crates/sparq-solid/tests/wac.rs
+++ b/crates/sparq-solid/tests/wac.rs
@@ -13,7 +13,8 @@ fn store() -> PodStore {
 }
 
 fn can(s: &mut PodStore, agent: Option<&str>, client: Option<&str>, mode: Mode, graph: &str) -> bool {
-    s.accessible(&Session { agent, client }, mode).iter().any(|g| g.as_str() == graph)
+    // WAC has no issuer dimension; the field stays None for these cases. [OPUS-4.8] sq-3jtd.6
+    s.accessible(&Session { agent, client, issuer: None }, mode).iter().any(|g| g.as_str() == graph)
 }
 
 use sparq_solid::fixture::{ALICE, APP, BOB, CAROL, DAVE};
@@ -104,21 +105,21 @@ fn wac_write_enforcement_matches_grants() {
     // owner writes inherited to depth 4 (read-matrix #1 has the Read twin)
     let priv0 = "https://pod.ex/priv0/c4/g0/d0.ttl";
     assert!(can(&mut s, Some(ALICE), None, Mode::Write, priv0));
-    s.update_as(&Session { agent: Some(ALICE), client: None }, &ins(priv0)).expect("alice writes");
+    s.update_as(&Session { agent: Some(ALICE), client: None, issuer: None }, &ins(priv0)).expect("alice writes");
     // …and nobody else (read-matrix #2 twin)
     assert!(!can(&mut s, Some(BOB), None, Mode::Write, priv0));
-    assert!(s.update_as(&Session { agent: Some(BOB), client: None }, &ins(priv0)).is_err());
+    assert!(s.update_as(&Session { agent: Some(BOB), client: None, issuer: None }, &ins(priv0)).is_err());
 
     // group read+write; nearest-ACL shadows alice (read-matrix #4/#5 twins)
     let team2 = "https://pod.ex/team2/c3/g0/d0.ttl";
     assert!(can(&mut s, Some(CAROL), None, Mode::Write, team2));
-    s.update_as(&Session { agent: Some(CAROL), client: None }, &ins(team2)).expect("carol writes");
+    s.update_as(&Session { agent: Some(CAROL), client: None, issuer: None }, &ins(team2)).expect("carol writes");
     assert!(!can(&mut s, Some(ALICE), None, Mode::Write, team2));
-    assert!(s.update_as(&Session { agent: Some(ALICE), client: None }, &ins(team2)).is_err());
+    assert!(s.update_as(&Session { agent: Some(ALICE), client: None, issuer: None }, &ins(team2)).is_err());
 
     // Control gates the .acl document: writing it needs Write, granted only to alice
     let acl = "https://pod.ex/.acl";
     assert!(can(&mut s, Some(ALICE), None, Mode::Write, acl)); // via Control->write
     assert!(!can(&mut s, Some(BOB), None, Mode::Write, acl));
-    assert!(s.update_as(&Session { agent: Some(BOB), client: None }, &ins(acl)).is_err());
+    assert!(s.update_as(&Session { agent: Some(BOB), client: None, issuer: None }, &ins(acl)).is_err());
 }

--- a/research/solid-access-control-design.md
+++ b/research/solid-access-control-design.md
@@ -438,10 +438,15 @@ The materializer (§4.2) hardcodes this order; each stratum is still pure N3 in 
 Covered: WAC accessTo, default with nearest-ancestor discovery (incl. multi-level), agent,
 agentClass foaf:Agent + acl:AuthenticatedAgent, agentGroup (+ group docs as graphs), origin
 (as pair principal), 4 modes with Control→ACL-resource semantics; ACP accessControl +
-transitive memberAccessControl, allOf/anyOf/noneOf, agent/client attrs incl.
+transitive memberAccessControl, allOf/anyOf/noneOf, agent/client/**issuer** attrs incl.
 Public/Authenticated/PublicClient specials, allow/deny with deny-overrides.
-Not covered (documented gaps, §7): `acp:issuer` (same shape as client — extend the principal
-to a triple, combinatorially noted), `acp:vc`, `acp:CreatorAgent`/`OwnerAgent` (need
+`acp:issuer` ([OPUS-4.8] sq-3jtd.6): the third principal dimension — the OIDC issuer that
+vouched for the WebID — is the exact twin of the client dimension. A constrained issuer mints
+a three-component `urn:sparq:triple?agent=A&client=C&issuer=I` principal (an unconstrained
+issuer keeps the agent / `urn:sparq:pair?…` term byte-identical), the candidate enumeration
+gains an `issuer × {matcher values, auth:AnyIssuer top}` factor (still bounded as the client
+dimension is), and the session expands to ≤12 lookups (the pre-issuer ≤6 doubled).
+Not covered (documented gaps, §7): `acp:vc`, `acp:CreatorAgent`/`OwnerAgent` (need
 per-resource creator facts from the storage layer), `acl:accessToClass`, custom ACP modes
 (design supports any mode IRI; prototype maps the 4 standard ones).
 
@@ -455,7 +460,8 @@ pub fn materialize_acp(graph: &mut Graph) -> Result<MaterializeStats, String>;
 //   both: strip reserved graphs → assemble facts (§4.2) → reason_n3 strata →
 //   REPLACE <urn:sparq:auth> in graph.named
 
-pub struct Session<'a> { pub agent: Option<&'a str>, pub client: Option<&'a str> }
+pub struct Session<'a> { pub agent: Option<&'a str>, pub client: Option<&'a str>, pub issuer: Option<&'a str> }
+//   [OPUS-4.8] sq-3jtd.6: `issuer` (ACP acp:issuer, the OIDC IdP); None = any issuer.
 pub enum Mode { Read, Write, Append, Control }
 pub struct AuthIndex { /* principal → mode → graph names; conditional grants; matcher accept-sets */ }
 impl AuthIndex {

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: access-control
-description: "Graph-level Solid-style access control over a sparq RDF dataset with the opt-in sparq-solid crate: store pods as named-graph-per-document, keep WAC (.acl) / ACP (.acr) documents as queryable triples, materialize their semantics to a queryable authorization view (urn:sparq:auth) via N3 rules, then filter every SPARQL query/update per (WebID, client) session to the authorized graph set — fail-closed. Use when gating which named graphs a session may read/append/write, mapping WAC/ACP to an allow-deny model, or querying the materialized auth view. RESEARCH/architecture track — this is the authorization LAYER, NOT a production Solid Pod HTTP server, and it does NOT authenticate (the caller asserts the WebID)."
+description: "Graph-level Solid-style access control over a sparq RDF dataset with the opt-in sparq-solid crate: store pods as named-graph-per-document, keep WAC (.acl) / ACP (.acr) documents as queryable triples, materialize their semantics to a queryable authorization view (urn:sparq:auth) via N3 rules, then filter every SPARQL query/update per (WebID, client, issuer) session to the authorized graph set — fail-closed. Use when gating which named graphs a session may read/append/write, mapping WAC/ACP to an allow-deny model, or querying the materialized auth view. RESEARCH/architecture track — this is the authorization LAYER, NOT a production Solid Pod HTTP server, and it does NOT authenticate (the caller asserts the WebID, client, and issuer)."
 license: MIT
 metadata:
   version: "0.1.0"
@@ -15,20 +15,28 @@ sparq RDF dataset at the **named-graph** granularity. A pod is stored as
 documents stay as plain queryable triples; their semantics are encoded as **N3 rules**
 (run by `sparq-reason`) that **materialize** a queryable authorization view in the
 reserved `<urn:sparq:auth>` graph. Every query/update is then filtered per
-`(WebID, client)` session to the named graphs that session may access — **fail-closed**,
-with zero Solid-specific code in the engine itself (the crate is a dependency of nothing
-in the workspace).
+`(WebID, client, issuer)` session to the named graphs that session may access —
+**fail-closed**, with zero Solid-specific code in the engine itself (the crate is a
+dependency of nothing in the workspace).
 
 ## What this is — and is NOT (read first)
 
 This is an **architecture / research-track** layer, not a deployable Solid server.
 
-- It is the **authorization** half only. It answers *"may this `(WebID, client)`
+- It is the **authorization** half only. It answers *"may this `(WebID, client, issuer)`
   session read/append/write named graph G?"* by materializing WAC/ACP into a queryable
   view and filtering the dataset. It does **NOT authenticate**: a `Session.agent` is a
   caller-asserted WebID string — there is **no WebID-OIDC / DPoP / token verification**.
   The relying application is responsible for authenticating the WebID before it hands one
   to `query_as`. Treat a `Session` as a trusted claim, not a verified one.
+- The `Session.issuer` field (ACP `acp:issuer`) does **NOT** add WebID-OIDC
+  authentication. It is one more **caller-asserted** matcher dimension: the caller states
+  *which OIDC issuer it claims vouched for the WebID*, and an ACP `acp:issuer` matcher
+  decides whether that asserted issuer is acceptable. sparq-solid never contacts an IdP,
+  validates an ID token, or verifies the issuer binding — it only string-matches the
+  asserted issuer against the grant. As with `agent`, the relying application must verify
+  the issuer↔WebID binding before asserting it. WAC has no issuer notion, so a WAC pod
+  ignores the field entirely.
 - It is **NOT a Solid Pod HTTP server.** There is no HTTP resource protocol, no LDP
   container CRUD, no `Link rel=acl` discovery over the wire, no Solid notifications. The
   document→named-graph naming is a storage convention (design §2.2), not an HTTP server.
@@ -63,8 +71,8 @@ store.materialize_wac()?;                 // run the N3 rules → install <urn:s
 
 let q = "SELECT ?title WHERE { ?s <https://ex.dev/ns#title> ?title }";
 
-// WebID is CALLER-ASSERTED — sparq-solid does NOT authenticate it.
-let alice = Session { agent: Some("https://alice.ex/card#me"), client: None };
+// WebID / client / issuer are all CALLER-ASSERTED — sparq-solid does NOT authenticate them.
+let alice = Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None };
 let authorized = store.query_as(&alice, Mode::Read, q)?;            // alice's authorized graphs
 let public_only = store.query_as(&Session::default(), Mode::Read, q)?; // anonymous: public graphs only
 let _ = (authorized.rows.len(), public_only.rows.len());
@@ -130,9 +138,23 @@ Materialize the authorization view from the access-control documents, then enfor
   Withdrawn`); an *ambiguous* re-eval **keeps** the deny (never restore access on missing
   evidence). A retracted deny may re-expose an allow grant — correct, since the prohibition
   is genuinely gone.
-- `Session { agent: Option<&str>, client: Option<&str> }` (caller-asserted WebID +
-  `acl:origin`/`acp:client`; `None` = anonymous / any client); `Mode::{Read, Write,
-  Append, Control}`; `wac_fixture()` / `acp_fixture()` (bundled demo pods).
+- `Session { agent: Option<&str>, client: Option<&str>, issuer: Option<&str> }`
+  (all three caller-asserted: WebID + `acl:origin`/`acp:client` + the OIDC `acp:issuer`;
+  `None` = anonymous / any client / any issuer respectively). [OPUS-4.8] sq-3jtd.6: the
+  `issuer` field is the third matcher dimension (ACP only — WAC ignores it) and is a
+  STRING MATCH on a caller-asserted issuer, **not** an authentication step (see
+  "What this is — and is NOT"). `Mode::{Read, Write, Append, Control}`; `wac_fixture()` /
+  `acp_fixture()` (bundled demo pods).
+- `triple_principal(agent, client, issuer) -> String` / `pair_principal(agent, client) ->
+  String` — the deterministic minted principal IRIs (`urn:sparq:triple?…` /
+  `urn:sparq:pair?…`) that the ACP/WAC N3 rules emit for an issuer- / client-constrained
+  grant, kept in sync with the rules. Both use RFC 3986 percent-encoding and are
+  INJECTIVE, so no agent/client/issuer value can smuggle a `&client=`/`&issuer=`
+  delimiter into another principal's term. Exposed for inspection/round-trip tests.
+- `ANY_ISSUER` / `ANY_CLIENT` / `PUBLIC` / `AUTHENTICATED` — the principal-lattice top
+  IRIs (`https://sparq.dev/ns/auth#AnyIssuer` etc.). [OPUS-4.8] sq-3jtd.6: an ACP grant
+  with no `acp:issuer` matcher is issuer-unconstrained ⇒ `ANY_ISSUER` (the issuer-dimension
+  top); a session with `issuer: None` matches it.
 
 The materialized view is itself just triples — *"who can read G?"* is one SPARQL
 pattern: `GRAPH <urn:sparq:auth> { ?who <https://sparq.dev/ns/auth#read> ?doc }`.
@@ -143,9 +165,17 @@ pattern: `GRAPH <urn:sparq:auth> { ?who <https://sparq.dev/ns/auth#read> ?doc }`
   `acl:AuthenticatedAgent`, `acl:agentGroup`, `acl:default` inheritance, the
   `acl:Read/Write/Append/Control` modes.
 - **ACP** (`.acr`) — policies / matchers with the `allOf` / `anyOf` / `noneOf`
-  combinators and normative **deny-overrides**.
-- Principal lattice: `Public ⊒ Authenticated ⊒ concrete-WebID` and
-  `AnyClient ⊒ concrete-client`.
+  combinators and normative **deny-overrides**. [OPUS-4.8] sq-3jtd.6: matchers may now
+  also constrain on `acp:issuer` (the caller-asserted OIDC issuer), the third principal
+  dimension.
+- Principal lattice — three independent dimensions (agent, client, issuer):
+  `Public ⊒ Authenticated ⊒ concrete-WebID`, `AnyClient ⊒ concrete-client`, and
+  ([OPUS-4.8] sq-3jtd.6) `AnyIssuer ⊒ concrete-issuer`. A session expands to the agent
+  principals, plus — when a client is given — the minted `(agent, client)` pair, plus —
+  when an issuer is given — the minted `(agent, client, issuer)` triple (with
+  `AnyClient` as the client component when no client was supplied), for ≤12 grant lookups.
+  Only an issuer-CONSTRAINED grant mints a triple principal; an issuer-unconstrained grant
+  (`AnyIssuer`) reuses the agent / pair term, so issuer-blind pods are unaffected.
 
 ## Security posture — fail-closed
 
@@ -153,8 +183,11 @@ Absence of a grant means a graph is **invisible**, and a non-authorized graph is
 indistinguishable from an absent one. The reasoner is fed only ACL/ACR + structural
 facts — **never pod content** — so no writable document can grant itself access; the
 reserved `urn:sparq:` namespace is rejected on input and any forged `<urn:sparq:auth>`
-graph is stripped at load. (Again: this is the *authorization* boundary — authentication
-of the WebID is the relying application's job.)
+graph is stripped at load. A session whose `agent`/`client`/`issuer` falls inside the
+reserved `urn:sparq:` encoding (or carries the `&client=`/`&issuer=` delimiter) fails
+CLOSED — it cannot impersonate a minted pair/triple principal. (Again: this is the
+*authorization* boundary — authenticating the WebID **and verifying the issuer↔WebID
+binding** are the relying application's job.)
 
 ## Related skills
 
@@ -171,9 +204,12 @@ _(status: RESEARCH / architecture track. The crate is `shipped` per the design r
 (`research/solid-access-control-design.md`) — the zero-copy `DatasetView` query path and
 the write-gating path are implemented and tested (`tests/update.rs` + the crate suite) —
 but the SCOPE is the graph-level authorization layer ONLY: it does NOT authenticate (the
-WebID is caller-asserted) and it is NOT a Solid Pod HTTP server (no HTTP/LDP/OIDC). Verified
-against `crates/sparq-solid/src/{lib,authindex,fixture}.rs` + README on branch
-`feat-skill-drift-catchup` (2026-06-16); workspace v0.1.0, opt-in (depends on nothing in
+WebID, client, and `acp:issuer` are all caller-asserted — the issuer dimension matches a
+presented credential issuer, it does NOT add WebID-OIDC authentication) and it is NOT a
+Solid Pod HTTP server (no HTTP/LDP/OIDC). Verified against
+`crates/sparq-solid/src/{lib,authindex,fixture}.rs` + README on branch
+`feat/sq-3jtd-acp-issuer` (2026-06-16; the (agent, client, issuer) three-dimension
+principal model, sq-3jtd.6); workspace v0.1.0, opt-in (depends on nothing in
 the workspace), native-side. Conservative WAC/ACP sub-cases are noted in design §4.4; perf
 is measured by `cargo run -p sparq-solid --example bench` and NOT baked into docs. Code
 carries [OPUS-4.8] review markers pending re-review.)_


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-3jtd.6**: `sparq-solid` support for `acp:issuer`. Extends the ACP principal/matcher model so a Matcher can match on the **issuer** (`acp:issuer`) — the OIDC Identity Provider that vouched for the requester's WebID — not just the agent. The issuer is the exact twin of the existing client dimension (design doc §3.6).

## What changed

**N3 rules (`rules/acp-a/b/c.n3`)** — the issuer is a third principal dimension, parallel to client:
- issuer accept-sets (`solidx:acceptsIssuerP`, lattice top `auth:AnyIssuer`),
- an `issuer` candidate dimension and the candidate cross-product becomes (agent × client × issuer),
- `allOf`-rejection + `anyOf`-satisfaction over all three dimensions,
- a minted three-component principal `urn:sparq:triple?agent=A&client=C&issuer=I` for an issuer-constrained grant. An **unconstrained** issuer keeps the agent / `urn:sparq:pair?…` term **byte-identical**, so every pre-issuer grant is unchanged (the existing ACP correctness matrix still passes verbatim).

**Session + AuthIndex (`src/authindex.rs`)**
- `Session` gains `issuer: Option<&str>` (`None` = any issuer).
- a session expands to **≤12** principals (the pre-issuer ≤6 doubled by the issuer dimension),
- reads the `auth:issuer` conditional-grant head + `acceptsIssuerP` matcher facts,
- fails closed on a session issuer inside the reserved `urn:sparq:` space (it could otherwise impersonate a minted triple), and `triple_principal()` is exported as the public minting twin of `pair_principal()`.

**Loader + materialize** — `acp:issuer` values go through the same reserved-encoding validation as agents/clients/origins; `acceptsIssuerP` is copied into the auth view for `noneOf` exception matchers.

## Two bugs caught (by the deny tests)
- **Cache-key collision (core path):** the `PodStore` session cache key did not include the issuer, so two sessions differing only by issuer (same WebID via a trusted vs an untrusted IdP) collided on a cached graph set — a soundness hole. Fixed: the key now spans all three dimensions.
- **`odrl-bridge` feature:** bridged conditional grants now emit `auth:issuer auth:AnyIssuer` and their exception matchers assert `acceptsIssuerP auth:AnyIssuer`, so the now-three-dimensional `matcher_accepts` still fires.

## Tests (`tests/acp.rs`) — allow AND deny decided by issuer
- `allOf { agent ; issuer }`: allow @ trusted issuer, **deny** @ wrong issuer / no issuer / wrong agent,
- issuer-only `anyOf`: any agent from the trusted issuer; **deny** otherwise,
- the full `(agent, client, issuer)` triple,
- a `noneOf` issuer carve-out (conditional grant evaluated on the issuer dimension),
- fail-closed rejection of a reserved-space issuer at materialization.

## Opt-in / lean core
`sparq-solid` is already a separate opt-in crate (a dependency of nothing in the workspace), so this carries zero cost into `sparq-core`/`sparq-engine`. The `odrl-bridge` feature is unaffected by default.

## Gate — PASS in BOTH feature states
- `cargo build -p sparq-solid --all-targets` (default and `--all-features`)
- `cargo clippy -p sparq-solid --all-targets -- -D warnings` (default and `--all-features`)
- tests: default **68 pass / 0 fail**, `--all-features` **119 pass / 0 fail**

(rustfmt is informational/deferred workspace-wide per `rustfmt.toml`; clippy is the hard gate and is clean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)