### PR TITLE
fix(sparq-engine): custom aggregate honours DISTINCT end-to-end (sq-fldo)

### DIFF
--- a/crates/sparq-engine/src/aggregate.rs
+++ b/crates/sparq-engine/src/aggregate.rs
@@ -70,6 +70,13 @@ impl CustomAggregateRegistry {
     /// registration). The IRI is both what the query writes — `<iri>(?x)` in a
     /// projection over a `GROUP BY` — and what the parser is told to treat as an
     /// aggregate rather than a scalar function.
+    ///
+    /// [OPUS-4.8] (sq-fldo) `DISTINCT` is honoured by the ENGINE, not the
+    /// closure: `<iri>(DISTINCT ?x)` de-duplicates the materialised member
+    /// multiset (by `Option<Term>` equality, so two unbound members collapse to
+    /// one) before `f` is called, matching the built-in `COUNT(DISTINCT ?x)` /
+    /// `SUM(DISTINCT ?x)` semantics. `f` therefore always folds an already-
+    /// de-duplicated slice and never has to implement DISTINCT itself.
     pub fn register(
         &mut self,
         iri: impl Into<String>,
@@ -222,5 +229,95 @@ mod tests {
         let q = "PREFIX ex: <http://ex/> SELECT (<http://ex/agg#nope>(?s) AS ?p) \
                  WHERE { ?x ex:sales ?s } GROUP BY ?x";
         assert!(query_with_aggregates(&g(), q, &reg).is_err());
+    }
+
+    /// [OPUS-4.8] (sq-fldo) A dataset whose `ex:tag` column has DUPLICATE values
+    /// WITHIN a single (one-row-per-subject) group, so an aggregate that folds the
+    /// argument multiset gives a DIFFERENT result with vs without DISTINCT. `ex:t`
+    /// has three rows but only two distinct tag values ("x","x","y").
+    const DUP_DATA: &str = r#"
+        @prefix ex: <http://ex/> .
+        ex:t1 ex:grp "g" ; ex:tag "x" .
+        ex:t2 ex:grp "g" ; ex:tag "x" .
+        ex:t3 ex:grp "g" ; ex:tag "y" .
+    "#;
+
+    fn gd() -> Graph {
+        Graph::load_str(DUP_DATA, "turtle").unwrap()
+    }
+
+    /// A member-COUNTING custom aggregate (counts the `Option<Term>`s it is
+    /// handed) demonstrates the DISTINCT contract for custom aggregates: the
+    /// engine de-duplicates the materialised member multiset BEFORE the closure
+    /// runs, so the SAME registered aggregate sees 3 members without DISTINCT but
+    /// only 2 (the distinct tag values "x","y") with DISTINCT — matching the
+    /// built-in `COUNT(?x)` vs `COUNT(DISTINCT ?x)` semantics. Both forms are run
+    /// against the same registry/graph so the only difference is the modifier.
+    #[test]
+    fn custom_aggregate_distinct_dedups_members() {
+        let mut reg = CustomAggregateRegistry::new();
+        reg.register("http://ex/agg#cnt", |members: &[Option<Term>]| {
+            Ok(Some(Term::Literal(Literal::from(members.len() as i64))))
+        });
+        let graph = gd();
+
+        // WITHOUT DISTINCT: the aggregate sees all 3 group members.
+        let q_all = "PREFIX ex: <http://ex/> PREFIX agg: <http://ex/agg#> \
+                     SELECT (agg:cnt(?t) AS ?c) WHERE { ?x ex:grp ?g ; ex:tag ?t } \
+                     GROUP BY ?g";
+        let all = query_with_aggregates(&graph, q_all, &reg).unwrap();
+        let all_c = all.rows[0][0].as_ref().unwrap().to_string();
+        assert!(all_c.contains("\"3\""), "without DISTINCT should count 3 members, got {all_c:?}");
+
+        // WITH DISTINCT: members are de-duplicated to the 2 distinct tag values first.
+        let q_distinct = "PREFIX ex: <http://ex/> PREFIX agg: <http://ex/agg#> \
+                          SELECT (agg:cnt(DISTINCT ?t) AS ?c) WHERE { ?x ex:grp ?g ; ex:tag ?t } \
+                          GROUP BY ?g";
+        let distinct = query_with_aggregates(&graph, q_distinct, &reg).unwrap();
+        let distinct_c = distinct.rows[0][0].as_ref().unwrap().to_string();
+        assert!(distinct_c.contains("\"2\""), "with DISTINCT should count 2 distinct members, got {distinct_c:?}");
+    }
+
+    /// [OPUS-4.8] (sq-fldo) A SUM-style custom aggregate over a column with a
+    /// repeated VALUE confirms DISTINCT de-duplicates the materialised member
+    /// terms (not just adjacent ones) before the fold. `ex:n` over the group is
+    /// {10, 10, 20}: the plain sum is 40, the DISTINCT sum is 30.
+    #[test]
+    fn custom_aggregate_distinct_sum_dedups_repeated_value() {
+        let mut reg = CustomAggregateRegistry::new();
+        reg.register("http://ex/agg#sum", |members: &[Option<Term>]| {
+            let mut acc: i64 = 0;
+            for m in members {
+                if let Some(Term::Literal(l)) = m {
+                    acc += l.value().parse::<i64>().map_err(|e| e.to_string())?;
+                }
+            }
+            Ok(Some(Term::Literal(Literal::from(acc))))
+        });
+        let data = r#"
+            @prefix ex: <http://ex/> .
+            ex:r1 ex:grp "g" ; ex:n 10 .
+            ex:r2 ex:grp "g" ; ex:n 10 .
+            ex:r3 ex:grp "g" ; ex:n 20 .
+        "#;
+        let graph = Graph::load_str(data, "turtle").unwrap();
+
+        let q_all = "PREFIX ex: <http://ex/> PREFIX agg: <http://ex/agg#> \
+                     SELECT (agg:sum(?n) AS ?s) WHERE { ?x ex:grp ?g ; ex:n ?n } GROUP BY ?g";
+        let all = query_with_aggregates(&graph, q_all, &reg).unwrap();
+        assert!(
+            all.rows[0][0].as_ref().unwrap().to_string().contains("\"40\""),
+            "without DISTINCT sum should be 10+10+20=40, got {:?}",
+            all.rows[0][0]
+        );
+
+        let q_distinct = "PREFIX ex: <http://ex/> PREFIX agg: <http://ex/agg#> \
+                          SELECT (agg:sum(DISTINCT ?n) AS ?s) WHERE { ?x ex:grp ?g ; ex:n ?n } GROUP BY ?g";
+        let distinct = query_with_aggregates(&graph, q_distinct, &reg).unwrap();
+        assert!(
+            distinct.rows[0][0].as_ref().unwrap().to_string().contains("\"30\""),
+            "with DISTINCT sum should de-dup the repeated 10 -> 10+20=30, got {:?}",
+            distinct.rows[0][0]
+        );
     }
 }

--- a/vendor/spargebra/Cargo.toml
+++ b/vendor/spargebra/Cargo.toml
@@ -57,6 +57,14 @@ path = "src/lib.rs"
 name = "recursion_depth"
 path = "tests/recursion_depth.rs"
 
+# [OPUS-4.8] Regression test for the custom-aggregate DISTINCT parse fix
+# (SPARQ-PATCHES.md §9, bead sq-fldo). Declared explicitly for the same
+# `autotests = false` reason as the recursion-depth target above. Not an
+# upstream change.
+[[test]]
+name = "custom_aggregate_distinct"
+path = "tests/custom_aggregate_distinct.rs"
+
 [dependencies.oxilangtag]
 version = "0.1"
 

--- a/vendor/spargebra/SPARQ-PATCHES.md
+++ b/vendor/spargebra/SPARQ-PATCHES.md
@@ -214,3 +214,42 @@ this vendored tree once the fixes land in a released spargebra.
 > crate ships no `tests/` dir), so this patch also adds an explicit `[[test]]`
 > target entry for `tests/recursion_depth.rs`. Like the `[workspace]` table and
 > the `rand` pin (§7), that is a vendoring artifact, not an upstream change.
+
+## 9. Custom-aggregate `DISTINCT` is unreachable in `iriOrFunction` [OPUS-4.8]
+
+- **Spec / intent**: SPARQL 1.1 §11.6 makes custom aggregates an extension point
+  (`Aggregate ::= … | FunctionCall`). spargebra goes a step further and already
+  has an `Aggregate` grammar alternative for `<agg>(DISTINCT expr)` over a
+  *registered* custom-aggregate IRI (`parser.rs`, the `name:iri() "(" DISTINCT
+  Expression ")"` arm) — so the DISTINCT modifier on a custom aggregate is an
+  intended, supported form. It just never parsed.
+- **Bug**: in `PrimaryExpression`, `iriOrFunction()` is tried *before*
+  `BuiltInCall()` (which owns `Aggregate()`). `iriOrFunction = iri() ArgList()?`
+  has an OPTIONAL argument list. For `<agg>(DISTINCT ?x)` the regular `ArgList`
+  cannot parse `(DISTINCT ?x)` (DISTINCT is not an `Expression`), so `ArgList()?`
+  matches `None` and the rule greedily succeeds treating the bare IRI as a
+  standalone term. Because `iriOrFunction` already succeeded, PEG never
+  backtracks into the `Aggregate` rule, and the parse then fails downstream at
+  the unexpected `(` with a misleading `expected ENCODE_FOR_URI`. The
+  DISTINCT-free form (`<agg>(?x)`) was unaffected: there the regular `ArgList`
+  *does* parse, `iriOrFunction` errors ("…is an aggregate function and not a
+  regular function"), and PEG backtracks into `Aggregate` as designed.
+- **Fix**: in `iriOrFunction`'s `else` branch (no `ArgList` parsed), reject a
+  bare IRI that is a *registered custom aggregate* with the same
+  "…is an aggregate function and not a regular function" error the with-args
+  branch uses. That failure makes PEG backtrack into `BuiltInCall → Aggregate`,
+  whose custom-IRI arms then parse both `(DISTINCT expr)` and `(expr)`. A bare
+  aggregate IRI used as a standalone term is not valid SPARQL, so the rejection
+  removes nothing legitimate; non-aggregate IRIs are untouched.
+- **Tests**: `vendor/spargebra/tests/custom_aggregate_distinct.rs` — the
+  prefixed-name and full-IRI DISTINCT forms must parse, the DISTINCT-free form
+  must still parse, the `DISTINCT` flag must survive into the algebra
+  (`Display`), and DISTINCT in a call to an *undeclared* (regular) IRI must
+  remain an error. Engine-level WITH/WITHOUT-DISTINCT evaluation coverage lives
+  in `crates/sparq-engine/src/aggregate.rs` (bead sq-fldo).
+- **Upstream**: candidate for oxigraph/oxigraph — the `Aggregate` rule's intent
+  is plainly to support `<agg>(DISTINCT …)`, which the rule-ordering defeats.
+
+> Manifest note: as in §8, `autotests = false` means the new
+> `tests/custom_aggregate_distinct.rs` target is declared explicitly in
+> `Cargo.toml`. A vendoring artifact, not an upstream change.

--- a/vendor/spargebra/src/parser.rs
+++ b/vendor/spargebra/src/parser.rs
@@ -2619,6 +2619,18 @@ parser! {
                 } else {
                     Ok(Expression::FunctionCall(Function::Custom(i), a))
                 }
+            } else if state.custom_aggregate_functions.contains(&i) {
+                // [OPUS-4.8] (sq-fldo) A registered custom-aggregate IRI whose argument
+                // list the regular `ArgList` could not parse — notably the extension
+                // form `<agg>(DISTINCT ?x)`, where `DISTINCT` is not a valid `Expression`
+                // so `ArgList()?` matched `None`. Without this guard the rule greedily
+                // succeeds treating the bare IRI as a standalone term, so PEG never
+                // backtracks into the `Aggregate` rule that owns the `(DISTINCT expr)`
+                // form — and the DISTINCT modifier silently fails to parse. Rejecting
+                // here forces that backtrack so a custom aggregate honours DISTINCT
+                // exactly as the builtins do. A bare aggregate IRI used as a plain term
+                // is not valid SPARQL, so this rejection loses nothing legitimate.
+                Err("This custom function is an aggregate function and not a regular function")
             } else {
                 Ok(i.into())
             }

--- a/vendor/spargebra/tests/custom_aggregate_distinct.rs
+++ b/vendor/spargebra/tests/custom_aggregate_distinct.rs
@@ -1,0 +1,88 @@
+// [OPUS-4.8] The vendored crate's `[lints.clippy]` table is pedantic and aimed
+// at library code; this is an integration-test crate, so a couple of those lints
+// are inappropriate here and are relaxed file-wide:
+//   - tests_outside_test_module: an integration test crate IS the test module;
+//     there is no library code to separate the tests from.
+//   - expect_used: panicking on the unexpected is exactly what a test wants.
+//   - assertions_on_result_states: `assert!(... .is_err())` is the clearest way
+//     to state "this query must be rejected" and is the whole point of the test.
+// (None of these gate in the real build: the project lints spargebra as a
+//  `[patch.crates-io]` dependency, and clippy does not lint dependency targets.)
+#![allow(
+    clippy::tests_outside_test_module,
+    clippy::expect_used,
+    clippy::assertions_on_result_states
+)]
+
+// [OPUS-4.8] Regression tests for the custom-aggregate DISTINCT parse fix
+// (bead sq-fldo, SPARQ-PATCHES.md §9).
+//
+// spargebra's `Aggregate` grammar already had a `<agg>(DISTINCT expr)`
+// alternative for a registered custom-aggregate IRI, but `iriOrFunction` was
+// tried first in `PrimaryExpression` and greedily accepted the bare IRI when its
+// optional `ArgList` failed to parse the `(DISTINCT ?x)` argument list (DISTINCT
+// is not a valid `Expression`). PEG therefore never backtracked into the
+// `Aggregate` rule, so `<agg>(DISTINCT ?x)` failed to parse with a misleading
+// "expected ENCODE_FOR_URI" error. The fix makes `iriOrFunction` reject a bare
+// registered-aggregate IRI so the parser falls through to the `Aggregate` rule.
+
+use oxrdf::NamedNode;
+use spargebra::SparqlParser;
+
+fn parser() -> SparqlParser {
+    SparqlParser::new().with_custom_aggregate_function(
+        NamedNode::new("http://example.com/agg#x").expect("valid IRI"),
+    )
+}
+
+const PREFIXED_NO_DISTINCT: &str = "PREFIX agg: <http://example.com/agg#> \
+     SELECT (agg:x(?v) AS ?r) WHERE { ?s ?p ?v } GROUP BY ?s";
+const PREFIXED_DISTINCT: &str = "PREFIX agg: <http://example.com/agg#> \
+     SELECT (agg:x(DISTINCT ?v) AS ?r) WHERE { ?s ?p ?v } GROUP BY ?s";
+const FULL_IRI_DISTINCT: &str = "SELECT (<http://example.com/agg#x>(DISTINCT ?v) AS ?r) \
+     WHERE { ?s ?p ?v } GROUP BY ?s";
+
+/// The pre-fix regression: a registered custom aggregate called WITH DISTINCT
+/// (both the prefixed-name and the full-IRI spelling) must parse, not error.
+#[test]
+fn custom_aggregate_with_distinct_parses() {
+    assert!(
+        parser().parse_query(PREFIXED_DISTINCT).is_ok(),
+        "prefixed custom aggregate with DISTINCT must parse"
+    );
+    assert!(
+        parser().parse_query(FULL_IRI_DISTINCT).is_ok(),
+        "full-IRI custom aggregate with DISTINCT must parse"
+    );
+}
+
+/// The fix must not regress the already-working DISTINCT-free form.
+#[test]
+fn custom_aggregate_without_distinct_still_parses() {
+    assert!(
+        parser().parse_query(PREFIXED_NO_DISTINCT).is_ok(),
+        "custom aggregate without DISTINCT must still parse"
+    );
+}
+
+/// The parsed DISTINCT and non-DISTINCT forms must carry the distinct flag
+/// through to the algebra so the evaluator can act on it: the displayed query
+/// retains `DISTINCT` for the DISTINCT form and omits it otherwise.
+#[test]
+fn distinct_flag_survives_to_algebra() {
+    let distinct = parser().parse_query(PREFIXED_DISTINCT).expect("parses").to_string();
+    assert!(distinct.contains("DISTINCT"), "DISTINCT must survive into the algebra: {distinct}");
+
+    let plain = parser().parse_query(PREFIXED_NO_DISTINCT).expect("parses").to_string();
+    assert!(!plain.contains("DISTINCT"), "no DISTINCT expected: {plain}");
+}
+
+/// An IRI that was NOT declared a custom aggregate is still a regular function
+/// call, and `f(DISTINCT ?x)` for such an IRI remains a parse error — the fix
+/// only changes behaviour for DECLARED aggregate IRIs.
+#[test]
+fn undeclared_iri_with_distinct_is_still_an_error() {
+    let p = SparqlParser::new(); // no custom aggregate declared
+    let q = "SELECT (<http://example.com/agg#x>(DISTINCT ?v) AS ?r) WHERE { ?s ?p ?v } GROUP BY ?s";
+    assert!(p.parse_query(q).is_err(), "DISTINCT in a regular function call is not legal SPARQL");
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead **sq-fldo** (DISTINCT for custom SPARQL aggregates) in `sparq-engine`.

## Honest assessment first

The custom-aggregate **evaluator** in `crates/sparq-engine/src/exec.rs` (`eval_custom_aggregate`, behind the opt-in `window-functions` feature) **already** de-duplicated the materialised member multiset when `distinct` was set — by `Option<Term>` equality, matching the built-in `COUNT(DISTINCT ?x)` / `SUM(DISTINCT ?x)` discipline. So the de-dup logic was not a no-op gap.

**But** `<agg>(DISTINCT ?x)` never **parsed**, so that flag could never reach the evaluator. Root cause was a vendored-`spargebra` rule-ordering bug, not the engine: in `PrimaryExpression`, `iriOrFunction()` is tried before `BuiltInCall()` (which owns `Aggregate()`). `iriOrFunction = iri() ArgList()?` has an **optional** arg list; for `<agg>(DISTINCT ?x)` the regular `ArgList` cannot parse `(DISTINCT ?x)` (`DISTINCT` is not an `Expression`), so `ArgList()?` matched `None` and the rule greedily succeeded treating the bare IRI as a standalone term. PEG therefore never backtracked into the `Aggregate` rule that **already had** a `<agg>(DISTINCT expr)` alternative — the parse then failed downstream with a misleading `expected ENCODE_FOR_URI`. The DISTINCT-free form `<agg>(?x)` was unaffected (there the regular `ArgList` parses, `iriOrFunction` errors, and PEG backtracks into `Aggregate` as designed).

## What changed

- **`vendor/spargebra/src/parser.rs`** — `iriOrFunction` now rejects a **bare** IRI that is a *registered custom aggregate* (the same error the with-args branch already raises), forcing PEG to backtrack into `BuiltInCall → Aggregate`, whose custom-IRI arm parses both `(DISTINCT expr)` and `(expr)`. Narrow: only **declared** aggregate IRIs change behaviour; non-aggregate IRIs and the W3C suite (which registers none) are untouched. A bare aggregate IRI as a standalone term is not valid SPARQL, so nothing legitimate is lost.
- **`vendor/spargebra/SPARQ-PATCHES.md`** — documented as patch §9 (spec/intent, bug, fix, tests, upstream note), per the vendored-patch discipline.
- **`vendor/spargebra/tests/custom_aggregate_distinct.rs`** + `Cargo.toml` `[[test]]` target — parser regression tests: prefixed + full-IRI DISTINCT parse, DISTINCT-free still parses, DISTINCT flag survives into the algebra (`Display`), and DISTINCT in a call to an *undeclared* IRI is still an error.
- **`crates/sparq-engine/src/aggregate.rs`** — engine tests for a custom aggregate **WITH and WITHOUT DISTINCT**:
  - count-style aggregate: 3 members without DISTINCT vs 2 with DISTINCT (duplicate `"x","x","y"`);
  - sum-style aggregate over `{10,10,20}`: 40 without DISTINCT vs 30 with.
  Plus a `register()` doc note clarifying DISTINCT is honoured by the engine, not the closure.

## Gate (all green)

- `cargo build` + `cargo clippy --all-targets -- -D warnings` clean for `sparq-engine` in **both** the default and `window-functions` feature states.
- `cargo test -p sparq-engine` passes in both states (193 default / 215 with feature, incl. the 2 new DISTINCT tests).
- `cargo test -p spargebra` (suite + doctests) green incl. the 4 new regression tests; `sparq-conformance` green.
- `scripts/check-privacy-claims.sh` clean.

No auto-merge enabled — orchestrator arms after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
