### PR TITLE
docs(sparq-server): stable error/status contract + contract test (sq-r5bv)

### DIFF
--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -131,6 +131,27 @@ internal-type `Debug` / secret survives into any error body for the main failure
 `tests/tpf.rs`. The auth `401` is additionally byte-identical for a missing vs a wrong token, so
 it is not a differential-error oracle.
 
+### Stable error/status contract — transient vs permanent (for retry classifiers)
+
+A client that retries on "transient" failures needs to know exactly which status codes sparq
+emits and which are worth retrying. The **authoritative, versioned contract** is the
+[`status_contract`](https://docs.rs/sparq-server/latest/sparq_server/status_contract/) crate
+doc (asserted by `tests/status_contract.rs`, so it cannot drift). In brief:
+
+| Class | Statuses | Retry the identical request? |
+| --- | --- | --- |
+| **Transient** | `429` (concurrency shed — request never ran) · `503` (query/UPDATE timeout, durable-write refusal, subscription capacity) | **yes** — back off and retry |
+| **Permanent** | `400` (malformed query/UPDATE/RDF) · `401` (auth) · `404` · `405` · `410` (aged-out generation) · `413` (body cap **and** result/row cap) · `415` | **no** — fix the request |
+| **Defect** | `500` (caught panic / unclassified internal error) | a server bug — surface it; do not hot-retry |
+
+The bit a `5xx`-only classifier (e.g. one written for a different server) gets wrong against
+sparq: a **`413` result/row cap is a PERMANENT honest refusal** (narrow the query / add `LIMIT`),
+*not* a transient load signal and *not* a silent truncation; and a **timeout is a `503`**, not a
+`5xx`-generic. **Classify on the status code** — bodies are sanitised generic class strings, never
+the caller's input (the only message substrings to rely on are the documented generic sentinels,
+e.g. a `503` timeout body contains `timed out`). There is currently **no `Retry-After` header**;
+the client picks its own back-off. See the `status_contract` doc for the full table and rationale.
+
 ### SERVICE federation + DoS guards
 
 - SPARQL `SERVICE` federation is **OFF in the default build** (the `service` cargo feature).

--- a/crates/sparq-server/src/lib.rs
+++ b/crates/sparq-server/src/lib.rs
@@ -27,6 +27,14 @@ pub mod redact;
 #[cfg(feature = "server")]
 pub mod http;
 
+/// [OPUS-4.8] (sq-r5bv, gh-50) **Stable HTTP error/status contract** — the consumer-facing
+/// transient-vs-permanent classification a client should encode (which status codes/messages
+/// sparq emits for timeout / row-cap / malformed query / auth failure / etc., and which are
+/// retryable). Documentation only (no code); asserted by `tests/status_contract.rs`. Gated on
+/// `server` because it describes the [`http`] surface. See the module docs.
+#[cfg(feature = "server")]
+pub mod status_contract;
+
 /// [OPUS-4.8] (sq-0bxp) OPT-IN per-query access audit log (CDMC CD-2 / ISO 27001 A.8.15 /
 /// EU CRA logging). Compiled only behind the `audit-log` feature, and emitted only when
 /// [`ServerConfig::audit_log`] (`--audit-log` / `SPARQ_AUDIT_LOG=1`) is also set. Emits a

--- a/crates/sparq-server/src/status_contract.rs
+++ b/crates/sparq-server/src/status_contract.rs
@@ -1,0 +1,98 @@
+//! [OPUS-4.8] (sq-r5bv, gh-50) **The stable HTTP error/status contract** — what a sparq-server
+//! client can rely on when classifying a response, and in particular **which statuses are
+//! transient (retry may succeed) vs permanent (retrying the identical request cannot help)**.
+//!
+//! This module is **documentation only** — it exports no code. It is the single
+//! consumer-facing source of truth for the response contract that was previously spread
+//! across the README "Security posture", `skills/http-server/SKILL.md` and the per-handler
+//! comments in [`crate::http`]. It is asserted end-to-end by
+//! `tests/status_contract.rs`, so the table below cannot silently drift from the server's
+//! actual behaviour.
+//!
+//! # Why this exists
+//!
+//! A consumer that retries on "transient" failures must know exactly which statuses sparq
+//! emits for which conditions, and which of those are worth retrying. The motivating case
+//! (gh-50): a federation client whose transient-error classifier was written against a
+//! *different* SPARQL server keyed on that server's status mix and error text — `5xx` plus a
+//! server-specific message substring. Against sparq that classifier is wrong in two ways:
+//!
+//! 1. sparq returns **`503` on a query timeout** and **`413` on a working-set row cap** —
+//!    `413` is a status a `5xx`-only classifier never models, so a capped result would be
+//!    misclassified as a *permanent* hard error when the correct action is "narrow the query"
+//!    (and the cap, unlike a stream that simply stops, is an *honest refusal* — see below).
+//! 2. sparq's error **bodies are sanitised** to a stable generic class string
+//!    ([`crate::http`] `sanitized_error`): a classifier MUST NOT key on a free-text substring
+//!    drawn from the engine, because sparq deliberately never emits engine/RDF/path detail in
+//!    the body. **Classify on the status code** (and, where noted, a documented stable
+//!    sentinel substring of the *generic* message), never on echoed input.
+//!
+//! # The contract
+//!
+//! Every error response is the structured envelope `{"error":"<message>"}` with
+//! `Content-Type: application/json` (the one exception is `405`, which additionally carries an
+//! `Allow` header). `<message>` is always a **stable generic class** — never the caller's
+//! submitted query/update/RDF text, a fragment of the loaded graph, a server-side filesystem
+//! path, or a secret. See the README "Error responses do not leak internals" section.
+//!
+//! ## Status -> meaning -> transient?
+//!
+//! | Status | Condition | Transient? | Client action |
+//! | --- | --- | --- | --- |
+//! | `200 OK` | query / GSP-read / EXPLAIN success | -- | consume body |
+//! | `201 Created` | GSP `PUT`/`POST` created a graph that did not exist (advisory -- see note) | -- | success |
+//! | `204 No Content` | SPARQL Update / GSP write committed (durable once acked, if `--persist`) | -- | success |
+//! | `400 Bad Request` | malformed query / malformed UPDATE / malformed RDF body / malformed TPF pattern / `GET /sparql` with no `query` / unparsable `?generation` / not-yet-published generation | **permanent** | fix the request; do **not** retry as-is |
+//! | `401 Unauthorized` | a write (or, with `--auth-token-read`, a read) without a valid Bearer token; carries `WWW-Authenticate: Bearer` + `Cache-Control: no-store`; **byte-identical for a missing vs a wrong token** | **permanent** | obtain/correct the token; do **not** retry as-is |
+//! | `404 Not Found` | unknown route / GSP `GET` of a named graph that does not exist | **permanent** | -- |
+//! | `405 Method Not Allowed` | method not allowed on the route; carries `Allow` | **permanent** | use a listed method |
+//! | `410 Gone` | (`time-travel` feature) `?generation=N` aged out of the retention window | **permanent** | the snapshot is gone; do not retry that pin |
+//! | `413 Payload Too Large` | request **body** over `--max-body-bytes`; **result** over `--max-results` / `--max-query-rows` working-set cap; gzip body over the `--max-decompress-ratio` zip-bomb cap | **permanent for the identical request** | narrow the query (e.g. add `LIMIT`) or shrink the body -- retrying the same request fails identically |
+//! | `415 Unsupported Media Type` | POST query/update with an unsupported `Content-Type` | **permanent** | send a supported content type |
+//! | `429 Too Many Requests` | in-flight concurrency cap (`--max-concurrent`) tripped; the request was **shed, never started** | **TRANSIENT** | back off and retry -- the work was not done |
+//! | `503 Service Unavailable` | query/UPDATE **timeout** (`--query-timeout`); **durable-write** error on the `--persist` mirror (write refused, NOT applied); a subscription registration refused for capacity | **TRANSIENT** | back off and retry; a timeout may also warrant simplifying the query |
+//! | `500 Internal Server Error` | a handler panic (caught, connection kept alive) or an unclassified engine execution error | **treat as permanent** | a `500` is a server bug, not a load signal -- do not hot-retry; surface it |
+//!
+//! ## Transient vs permanent -- the rule a classifier should encode
+//!
+//! - **Transient (a retry of the identical request may succeed):** `429` and `503` ONLY.
+//!   - `429` -- the request was load-shed *before it ran*; nothing happened, so a back-off
+//!     retry is exactly right.
+//!   - `503` -- three sub-causes, all retryable: a cooperative query/UPDATE **timeout**, a
+//!     **durable-write** refusal (the write was *not* applied and not acked -- fail-closed, so a
+//!     retry once durability recovers is safe and will not double-apply), and a subscription
+//!     **capacity** refusal.
+//! - **Permanent (retrying the identical request cannot help):** everything else --
+//!   `400` / `401` / `404` / `405` / `410` / `413` / `415`.
+//!   - **`413` is the load-bearing one a `5xx`-only classifier gets wrong.** A result-cap
+//!     `413` is an **honest refusal**, not a truncation and not a transient load signal: the
+//!     same query against the same data crosses the same cap every time. The correct action is
+//!     to *narrow the query* (add `LIMIT`, tighten the pattern) or raise the operator's cap --
+//!     never a blind retry. A body-size or zip-bomb `413` is likewise permanent for the
+//!     identical body.
+//! - **`500` is NOT a transient class here.** It is a caught panic or an unclassified internal
+//!     error -- a defect, not back-pressure. A client may surface it, but should not treat it as
+//!     "retry will clear it" the way it treats `503`. (A classifier MAY choose a single bounded
+//!     retry for `500` to ride out a flaky deploy, but it must not loop on it.)
+//!
+//! ## Honest boundaries (do not over-rely)
+//!
+//! - **No `Retry-After` header.** sparq does not currently emit `Retry-After` on `429` or
+//!   `503`; a client picks its own back-off. (If one is added later it will only *narrow* the
+//!   advice, never contradict the status class above.)
+//! - **Classify on status, not body text.** Bodies are sanitised generic class strings. The
+//!   only message substrings a client may match are the *stable generic* ones this contract
+//!   names (e.g. a `503` timeout body contains `timed out`; a row-cap `413` body contains
+//!   `row limit`) -- and even those are a convenience on top of the authoritative status code,
+//!   never a substitute for it. Never match on engine/RDF/path detail: sparq never puts it in
+//!   the body.
+//! - **GSP created-vs-replaced (`201` vs `200`/`204`) is advisory.** PUT/POST sample graph
+//!   existence racily; treat the create/replace distinction as a hint, never as correctness.
+//! - **A timeout is wall-clock-guaranteed.** The `503` for `--query-timeout` is enforced at the
+//!   HTTP layer with a hard grace even if the engine is mid-stretch, on *all* request forms
+//!   (query, GSP-read and UPDATE), so a slow request cannot hang a client past the deadline.
+//!
+//! See also: the README "Security posture" (auth, bind, header and error-leak posture),
+//! `skills/http-server/SKILL.md` (the full endpoint + hardening reference), and the inline
+//! `engine_error_response` / `update_rejection_response` / `timeout_response` mappers in
+//! [`crate::http`] that this contract describes.

--- a/crates/sparq-server/tests/status_contract.rs
+++ b/crates/sparq-server/tests/status_contract.rs
@@ -1,0 +1,415 @@
+//! [OPUS-4.8] (sq-r5bv, gh-50) **Contract test for the stable HTTP error/status contract.**
+//!
+//! Asserts the consumer-facing transient-vs-permanent classification documented in
+//! `src/status_contract.rs` against the REAL hardened router: for each condition a client
+//! cares about (auth failure, malformed query, malformed UPDATE, body cap, result/row cap,
+//! timeout, unsupported media type, not-found, method-not-allowed), it asserts both the
+//! exact status code AND the transient/permanent class a retry classifier should encode.
+//!
+//! The point is to nail down the bit a `5xx`-only classifier gets wrong against sparq: a
+//! `413` row-cap is a PERMANENT honest refusal (narrow the query), while `429`/`503` are the
+//! only TRANSIENT classes. If the server's status mapping ever drifts, this test fails before
+//! the documented contract can mislead a consumer.
+
+#![cfg(feature = "server")]
+
+use std::time::Duration;
+
+use sparq_core::Graph;
+use sparq_server::{harden, router, AppState, ServerConfig};
+use tokio::net::TcpListener;
+
+const DATA: &str = r#"
+    @prefix ex: <http://ex/> .
+    ex:alice ex:knows ex:bob ; ex:age 30 ; ex:name "Alice" .
+    ex:bob   ex:age 25 ; ex:name "Bob"@en .
+    ex:carol ex:age 35 .
+"#;
+
+/// A dense graph whose 3-way disconnected pattern is far too large to ever finish — the
+/// deliberately slow query that trips the timeout `503`.
+fn dense_graph_ttl() -> String {
+    let n = 80; // 80*80 edges; the 3-way cross-product never finishes within the budget.
+    let mut ttl = String::from("@prefix ex: <http://ex/> .\n");
+    for i in 0..n {
+        for j in 0..n {
+            ttl.push_str(&format!("ex:n{i} ex:e ex:n{j} .\n"));
+        }
+    }
+    ttl
+}
+
+const SLOW_QUERY: &str =
+    "PREFIX ex: <http://ex/> SELECT * WHERE { ?a ex:e ?b . ?c ex:e ?d . ?e ex:e ?f }";
+
+async fn serve(app: axum::Router) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+async fn spawn_with(ttl: &str, config: ServerConfig) -> String {
+    let graph = Graph::load_str(ttl, "turtle").unwrap();
+    // `harden()` is the production middleware stack (panic->500, concurrency->429,
+    // body-limit->413, JSON error bodies) — exercise the REAL contract, not the bare router.
+    serve(harden(
+        router(AppState::with_config(graph, config)),
+        &ServerConfig::default(),
+    ))
+    .await
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+/// The transient/permanent split the contract names: a retry classifier should treat ONLY
+/// these statuses as transient (a retry of the identical request may succeed).
+fn is_transient(status: u16) -> bool {
+    matches!(status, 429 | 503)
+}
+
+/// Every error body is the structured `{"error":"..."}` envelope and carries no echoed input
+/// (the sanitisation invariant the contract leans on — classify on status, not body text).
+fn assert_structured_error(body: &str) {
+    assert!(
+        body.starts_with("{\"error\":"),
+        "expected structured JSON error envelope, got: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PERMANENT classes — retrying the identical request cannot help
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn malformed_query_is_permanent_400() {
+    let base = spawn_with(DATA, ServerConfig::default()).await;
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "SELECT ?s WHERE { this is not sparql")])
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    assert_eq!(status, 400, "malformed query is a client 400");
+    assert!(!is_transient(status), "400 must classify as PERMANENT");
+    assert_structured_error(&resp.text().await.unwrap());
+}
+
+#[tokio::test]
+async fn missing_query_param_is_permanent_400() {
+    let base = spawn_with(DATA, ServerConfig::default()).await;
+    let resp = client().get(format!("{base}/sparql")).send().await.unwrap();
+    let status = resp.status().as_u16();
+    assert_eq!(
+        status, 400,
+        "GET /sparql with no ?query is the historical 400"
+    );
+    assert!(!is_transient(status));
+}
+
+#[tokio::test]
+async fn malformed_update_is_permanent_400() {
+    let base = spawn_with(DATA, ServerConfig::default()).await;
+    let resp = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .body("INSERT DATA { this is not a valid update")
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    assert_eq!(
+        status, 400,
+        "a malformed UPDATE is a client 400, atomically (no partial effect)"
+    );
+    assert!(!is_transient(status));
+    assert_structured_error(&resp.text().await.unwrap());
+}
+
+#[tokio::test]
+async fn auth_failure_is_permanent_401_byte_identical() {
+    let config = ServerConfig {
+        auth_token: Some("s3cr3t".to_string()),
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(DATA, config).await;
+
+    // A write with NO token -> 401.
+    let missing = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .body("INSERT DATA { <http://ex/s> <http://ex/p> <http://ex/o> }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(missing.status().as_u16(), 401);
+    assert_eq!(
+        missing
+            .headers()
+            .get("www-authenticate")
+            .map(|v| v.to_str().unwrap().to_string()),
+        Some("Bearer".to_string()),
+        "401 carries WWW-Authenticate: Bearer"
+    );
+    let missing_body = missing.text().await.unwrap();
+
+    // A write with the WRONG token -> the SAME 401 (no oracle for missing-vs-wrong).
+    let wrong = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .header("authorization", "Bearer wrong-token")
+        .body("INSERT DATA { <http://ex/s> <http://ex/p> <http://ex/o> }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(wrong.status().as_u16(), 401);
+    let wrong_body = wrong.text().await.unwrap();
+    assert_eq!(
+        missing_body, wrong_body,
+        "missing vs wrong token must be byte-identical"
+    );
+    assert!(!is_transient(401), "401 must classify as PERMANENT");
+
+    // The correct token succeeds, so the 401 was genuinely the auth gate.
+    let ok = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .header("authorization", "Bearer s3cr3t")
+        .body("INSERT DATA { <http://ex/s> <http://ex/p> <http://ex/o> }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        ok.status().as_u16(),
+        204,
+        "the gated write succeeds with the right token"
+    );
+}
+
+#[tokio::test]
+async fn unsupported_post_content_type_is_permanent_415() {
+    let base = spawn_with(DATA, ServerConfig::default()).await;
+    let resp = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "text/plain")
+        .body("SELECT * WHERE { ?s ?p ?o }")
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    assert_eq!(
+        status, 415,
+        "POST query with an unsupported Content-Type is a 415"
+    );
+    assert!(!is_transient(status));
+}
+
+#[tokio::test]
+async fn unknown_route_is_permanent_404() {
+    let base = spawn_with(DATA, ServerConfig::default()).await;
+    let resp = client()
+        .get(format!("{base}/no-such-route"))
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    assert_eq!(status, 404);
+    assert!(!is_transient(status));
+}
+
+#[tokio::test]
+async fn wrong_method_is_permanent_405_with_allow() {
+    let base = spawn_with(DATA, ServerConfig::default()).await;
+    // /health is GET-only; a POST is a 405 with an Allow header (a permanent class).
+    let resp = client()
+        .post(format!("{base}/health"))
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    assert_eq!(status, 405);
+    assert!(resp.headers().contains_key("allow"), "405 carries Allow");
+    assert!(!is_transient(status));
+}
+
+#[tokio::test]
+async fn oversized_body_is_permanent_413() {
+    let config = ServerConfig {
+        max_body_bytes: 256,
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(DATA, config).await;
+    let big = format!("SELECT * WHERE {{ ?s ?p ?o }} # {}", "x".repeat(1024));
+    let resp = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .body(big)
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    assert_eq!(status, 413, "a body over --max-body-bytes is a 413");
+    assert!(
+        !is_transient(status),
+        "413 must classify as PERMANENT (shrink the body)"
+    );
+    assert_structured_error(&resp.text().await.unwrap());
+}
+
+/// THE load-bearing assertion for gh-50: a result-set row cap is a PERMANENT honest refusal
+/// (`413`), NOT a transient signal and NOT a truncation. A `5xx`-only classifier misreads it.
+#[tokio::test]
+async fn result_row_cap_is_permanent_413_honest_refusal() {
+    let config = ServerConfig {
+        max_results: Some(2),
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(DATA, config).await;
+    // 3 matching rows > cap of 2.
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "SELECT ?s WHERE { ?s <http://ex/age> ?a }")])
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    assert_eq!(status, 413, "exceeding the result cap is a 413, not a 5xx");
+    assert!(
+        !is_transient(status),
+        "413 row-cap must classify as PERMANENT"
+    );
+    let body = resp.text().await.unwrap();
+    assert_structured_error(&body);
+    // Honest refusal, not truncation: the rows are NOT in the body.
+    assert!(
+        !body.contains("bindings"),
+        "must refuse, not truncate: {body}"
+    );
+    // Documented stable sentinel: the generic message names the row limit (not echoed input).
+    assert!(
+        body.contains("row limit"),
+        "row-cap 413 body carries the documented generic 'row limit' sentinel: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TRANSIENT classes — a retry of the identical request may succeed
+// ---------------------------------------------------------------------------
+
+/// A query timeout is a TRANSIENT `503` (with a wall-clock guarantee), and the body carries
+/// the documented `timed out` sentinel.
+#[tokio::test]
+async fn query_timeout_is_transient_503() {
+    let config = ServerConfig {
+        query_timeout: Some(Duration::from_secs(1)),
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(&dense_graph_ttl(), config).await;
+
+    let started = std::time::Instant::now();
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", SLOW_QUERY)])
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    assert_eq!(status, 503, "a query timeout is a 503");
+    assert!(is_transient(status), "503 must classify as TRANSIENT");
+    // Wall-clock guarantee: 1s budget + hard grace; well under 5s even mid-stretch.
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "503 took {:?}",
+        started.elapsed()
+    );
+    let body = resp.text().await.unwrap();
+    assert_structured_error(&body);
+    assert!(
+        body.contains("timed out"),
+        "503 timeout body carries the 'timed out' sentinel: {body}"
+    );
+}
+
+/// The concurrency cap sheds excess in-flight requests with a TRANSIENT `429` — the shed
+/// request never ran, so a back-off retry is exactly right.
+#[tokio::test]
+async fn concurrency_shed_is_transient_429() {
+    let config = ServerConfig {
+        max_concurrent: 1,
+        query_timeout: Some(Duration::from_secs(30)),
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(&dense_graph_ttl(), config).await;
+
+    // Occupy the single slot with a never-finishing query, then fire a second request that
+    // must be shed with 429 (the slot is busy). The slow one is left running in the background.
+    let busy_base = base.clone();
+    tokio::spawn(async move {
+        let _ = client()
+            .get(format!("{busy_base}/sparql"))
+            .query(&[("query", SLOW_QUERY)])
+            .send()
+            .await;
+    });
+    // Give the occupying request time to claim the slot.
+    let mut shed = None;
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let resp = client()
+            .get(format!("{base}/sparql"))
+            .query(&[("query", "SELECT ?s WHERE { ?s <http://ex/e> ?o } LIMIT 1")])
+            .send()
+            .await
+            .unwrap();
+        if resp.status().as_u16() == 429 {
+            shed = Some(resp);
+            break;
+        }
+    }
+    let resp = shed.expect("a second concurrent request should be shed with 429");
+    let status = resp.status().as_u16();
+    assert_eq!(status, 429);
+    assert!(is_transient(status), "429 must classify as TRANSIENT");
+    assert_structured_error(&resp.text().await.unwrap());
+}
+
+// ---------------------------------------------------------------------------
+// Cross-cutting: the envelope + sanitisation invariant the contract relies on
+// ---------------------------------------------------------------------------
+
+/// Every error class above is the SAME `{"error":...}` JSON envelope with a JSON content type,
+/// and none echoes the sentinel input token — so a consumer can rely on status + a generic
+/// class, never on parsing echoed input.
+#[tokio::test]
+async fn all_error_bodies_are_sanitized_json() {
+    let base = spawn_with(DATA, ServerConfig::default()).await;
+    const SENTINEL: &str = "SENTINEL_NEEDLE_42";
+    // A malformed query carrying a sentinel token must not echo it back.
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", format!("SELECT {SENTINEL} WHERE {{ broken"))])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .map(|v| v.to_str().unwrap().to_string())
+        .unwrap_or_default();
+    assert!(
+        ct.starts_with("application/json"),
+        "error content-type is JSON: {ct}"
+    );
+    let body = resp.text().await.unwrap();
+    assert_structured_error(&body);
+    assert!(
+        !body.contains(SENTINEL),
+        "error body must not echo the caller's input: {body}"
+    );
+}

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -776,6 +776,17 @@ Some(SinkTarget::File(path)), .. }` (field present only with the feature). See
   `Content-Type: application/json` (the `405` keeps its `Allow` header). POST query
   requires `Content-Type: application/sparql-query` or `application/x-www-form-urlencoded`
   (else `415`); a GET without `query=` is `400`.
+- **Transient vs permanent status contract (for retry classifiers — sq-r5bv / gh-50).** A retry
+  classifier should treat **only `429` and `503` as transient** (a retry of the identical request
+  may succeed): `429` is a concurrency shed (the request never ran), `503` is a query/UPDATE
+  **timeout**, a durable-write refusal (write NOT applied), or a subscription-capacity refusal.
+  Everything else is **permanent** for the identical request — `400`/`401`/`404`/`405`/`410`/
+  `413`/`415` — and `500` is a defect (caught panic / unclassified internal error), not
+  back-pressure. The trap a `5xx`-only classifier hits against sparq: a **`413` result/row cap is a
+  PERMANENT honest refusal** (narrow the query / add `LIMIT`), not a transient signal and not a
+  truncation. **Classify on the status code, not the body text** (bodies are sanitised generic
+  classes — see the next bullet). There is **no `Retry-After`** header today. Full contract +
+  rationale: the `sparq_server::status_contract` crate doc, asserted by `tests/status_contract.rs`.
 - **Error bodies are sanitized — no information leak (sq-cz89 / sq-j9zs).** On the
   no-auth-by-default path an error body carries only a **stable, generic CLASS message**
   (e.g. `malformed query`, `malformed RDF body`, `malformed gzip body`,


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-r5bv** (gh-50): document sparq-server's **stable, consumer-facing HTTP error/status contract** and assert it with a focused contract test.

## What and why

A consumer that retries on "transient" failures (the gh-50 case: a federation client's `isTransientQLeverError`) needs to know exactly which status codes sparq emits and which are worth retrying. That contract was previously spread across the README, the SKILL, and per-handler comments in `http.rs` — there was no single authoritative, drift-proof statement of the **transient-vs-permanent classification**.

This PR adds:

- **`crates/sparq-server/src/status_contract.rs`** — a documentation-only crate module (surfaces on docs.rs) that is the single source of truth for the status → meaning → transient? table and the rule a retry classifier should encode.
- **`crates/sparq-server/tests/status_contract.rs`** — a focused contract test driving the **real hardened router**: for each condition a client cares about (auth failure, malformed query/UPDATE, body cap, result/row cap, timeout, 415, 404, 405) it asserts both the exact status code **and** the transient/permanent class, plus the sanitised-body invariant. So the documented table cannot silently drift from behaviour.
- A concise pointer table in the **README** and **`skills/http-server/SKILL.md`** (the public-API → SKILL maintenance rule).

## The load-bearing correction (gh-50)

The trap a `5xx`-only classifier (written for a different server) hits against sparq:

- **Transient = `429` and `503` ONLY.** `429` = concurrency shed (request never ran); `503` = query/UPDATE timeout, durable-write refusal (write NOT applied), or subscription-capacity refusal.
- **`413` (result/row cap) is a PERMANENT honest refusal** — narrow the query / add `LIMIT`; it is not a transient load signal and not a truncation. A `5xx`-only classifier never models `413`.
- A **timeout is a `503`**, not a `5xx`-generic.
- **`500`** is a defect (caught panic / unclassified internal error), not back-pressure.
- **Classify on the status code, not body text** — bodies are sanitised generic class strings; there is currently **no `Retry-After`** header (documented honestly).

## Scope / honesty

- **Doc + test only.** The hot `http.rs` auth path (the serialized conflict hotspot) is **untouched** — the doc describes the existing mappers (`engine_error_response` / `update_rejection_response` / `timeout_response`), it does not refactor them.
- No new runtime behaviour, no new public code API (the module exports no items).

## Gate (both feature states)

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + `cargo test -p sparq-server` PASS with **default features** and with **`time-travel`** enabled.
- The new contract test is `#[cfg(feature = "server")]`-gated, so the `--no-default-features` library build is unaffected.
- `scripts/check-privacy-claims.sh` and `typos` are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)