### PR TITLE
feat(sparq-solid): library-level ACP conformance harness (sq-3jtd.9)

### DIFF
--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -261,6 +261,47 @@ tracks each bridged grant in a **ledger** and provides a refresh entry point:
   principal+target+mode — correct, because the prohibition is genuinely gone. Static `auth:deny*`
   rules are never in the ledger and so are never retracted.
 
+## ACP conformance harness — [OPUS-4.8] sq-3jtd.9
+
+A library-level **ACP conformance harness** (`sparq_solid::conformance`) exercises this
+crate's ACP authorization engine (`materialize_acp` + `AuthIndex::accessible`) against the
+[Solid ACP specification](https://solidproject.org/TR/acp) at the *library* level. A scenario
+is declared as data — an ACR-document corpus (built with `AcrBuilder`) plus a table of expected
+`(agent, client, mode, resource) → allow | deny` decisions — and the harness asserts the engine
+reproduces every expected decision, reporting all mismatches at once. The scenario corpus lives
+in [`tests/conformance_acp.rs`](tests/conformance_acp.rs); it covers `acp:agent`/`acp:client`
+matchers, `acp:PublicAgent`/`acp:AuthenticatedAgent`, `acp:allOf`/`acp:anyOf`/`acp:noneOf`, the
+native (user, application) pair, deny-overrides, cumulative ancestor inheritance, mode
+independence, and the fail-closed no-policy case.
+
+```rust
+use sparq_solid::conformance::{AcrBuilder, AcpScenario, Decision, Expect};
+use sparq_solid::Mode;
+
+let doc = "https://pod.example/notes/n1";
+let mut acr = AcrBuilder::new();
+acr.access_control(doc, |p| p.allow(Mode::Read).any_of_agent("https://alice.example/card#me"));
+acr.document(doc);
+
+let report = AcpScenario::new("agent-allow")
+    .acr(acr)
+    .expect(Expect::agent("https://alice.example/card#me").read(doc).is(Decision::Allow))
+    .expect(Expect::anonymous().read(doc).is(Decision::Deny))
+    .run().expect("materializes");
+assert!(report.passed());
+```
+
+**Scope decision (honest):** this is the realistic, achievable conformance signal for an
+authorization *oracle*. Driving the Solid Conformance Test Harness (CTH) over HTTP is
+out-of-scope — this crate has no HTTP surface; that belongs to the Solid server,
+conformance-tested *through* it. A differential check against a JS reference evaluator
+(Community Solid Server / Inrupt ESS — same corpus, diff decisions) is the credible *second*
+oracle but is research-open (JS-toolchain cost) and is **not** built here; it is captured as a
+follow-up. See [`research/sparq-solid-scope.md`](../../research/sparq-solid-scope.md) §4 for the
+full rationale. The harness is complementary to `tests/acp.rs` (a hand-derived access matrix
+over one realistic pod) — it gives spec-construct coverage with small, independently-failing
+cases.
+
 ## Security posture — fail-closed
 
 Absence of a grant means a graph is **invisible**, and a non-authorized graph is

--- a/crates/sparq-solid/src/conformance.rs
+++ b/crates/sparq-solid/src/conformance.rs
@@ -1,0 +1,628 @@
+//! [OPUS-4.8] sq-3jtd.9 — a library-level **ACP conformance harness**.
+//!
+//! # What this is (and the decision behind it)
+//!
+//! The conformance surface targeted here is the **Solid Access Control Policy (ACP)
+//! specification** — <https://solidproject.org/TR/acp> — exercised at the *library*
+//! level: a scenario is an ACR-document corpus plus a table of expected
+//! `(agent, client, mode, resource) → allow | deny` decisions, and the harness asserts
+//! that this crate's ACP authorization engine
+//! ([`crate::materialize_acp`] + [`crate::AuthIndex::accessible`]) reproduces every
+//! expected decision (`research/sparq-solid-scope.md` §4).
+//!
+//! This is the **realistic, achievable** conformance signal for an authorization
+//! *oracle*. Two routes were considered and deliberately NOT taken here:
+//!
+//! - **CTH-over-HTTP** (the Solid Conformance Test Harness / `solid/specification-tests`)
+//!   drives a *server* and asserts on HTTP outputs (status codes, `WAC-Allow`). This
+//!   crate has no HTTP surface — that route is out-of-scope (it belongs to the Solid
+//!   server, conformance-tested *through* the server), per the scope record.
+//! - **A differential oracle against a JS reference evaluator** (Community Solid Server /
+//!   Inrupt ESS — same corpus, diff decisions) is the credible *second* oracle, but is
+//!   research-open (JS-toolchain cost) and tracked as a follow-up — it is NOT built here.
+//!
+//! Instead, scenarios are declared as **data** (this module is a builder + runner), and
+//! the expected-decision table is derived from the ACP spec's normative semantics:
+//! matchers (`acp:agent` / `acp:client`, `acp:PublicAgent`, `acp:AuthenticatedAgent`),
+//! policies (`acp:allow` / `acp:deny`, `acp:allOf` / `acp:anyOf` / `acp:noneOf`), and
+//! access control with **cumulative** ancestor inheritance
+//! (`acp:accessControl` / `acp:memberAccessControl`). The corpus that consumes this
+//! harness lives in `tests/conformance_acp.rs`.
+//!
+//! # Relationship to `tests/acp.rs`
+//!
+//! `tests/acp.rs` asserts a hand-derived access *matrix* over the one big synthetic
+//! `acp_fixture()` pod — bespoke, internally authored. This harness is structurally
+//! different: it is **table-driven over independent, minimal scenarios**, each isolating
+//! one ACP construct, with a uniform pass/fail report. The two are complementary: the
+//! matrix exercises depth and interaction on a realistic pod; this harness exercises
+//! spec-construct coverage with small, auditable, independently-failing cases.
+//!
+//! # Example
+//!
+//! ```
+//! use sparq_solid::conformance::{AcrBuilder, AcpScenario, Decision, Expect};
+//! use sparq_solid::Mode;
+//!
+//! let alice = "https://alice.example/card#me";
+//! let bob = "https://bob.example/card#me";
+//! let doc = "https://pod.example/notes/n1";
+//!
+//! // An ACR on the document grants Read to exactly { alice } via an anyOf agent matcher.
+//! let mut acr = AcrBuilder::new();
+//! acr.access_control(doc, |p| p.allow(Mode::Read).any_of_agent(alice));
+//! acr.document(doc); // the protected resource is a (possibly empty) named graph
+//!
+//! let scenario = AcpScenario::new("agent-allow")
+//!     .acr(acr)
+//!     .expect(Expect::agent(alice).read(doc).is(Decision::Allow))
+//!     .expect(Expect::agent(bob).read(doc).is(Decision::Deny))
+//!     .expect(Expect::anonymous().read(doc).is(Decision::Deny));
+//!
+//! let report = scenario.run().expect("materializes");
+//! assert!(report.passed(), "{report}"); // every expected decision reproduced
+//! ```
+
+use crate::{materialize_acp, AuthIndex, Mode, Session};
+use sparq_core::Graph;
+use std::fmt::{self, Write as _};
+
+const ACP: &str = "http://www.w3.org/ns/solid/acp#";
+const ACL: &str = "http://www.w3.org/ns/auth/acl#";
+const EX_PRED: &str = "https://ex.dev/ns#prop";
+
+/// The ACP `acp:PublicAgent` IRI — the matcher that accepts every requestor, including
+/// the anonymous one.
+pub const PUBLIC_AGENT: &str = "http://www.w3.org/ns/solid/acp#PublicAgent";
+/// The ACP `acp:AuthenticatedAgent` IRI — the matcher that accepts any *authenticated*
+/// requestor (an agent is present) but not the anonymous one.
+pub const AUTHENTICATED_AGENT: &str = "http://www.w3.org/ns/solid/acp#AuthenticatedAgent";
+
+/// A single authorization decision: the access is granted (`Allow`) or refused
+/// (`Deny`). This is the binary the harness compares against the engine's verdict
+/// (a graph is in the session's accessible set ⇒ `Allow`, otherwise `Deny`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    /// The access mode is granted on the resource for the requestor.
+    Allow,
+    /// The access mode is refused (no matching grant, or a deny overrides).
+    Deny,
+}
+
+impl fmt::Display for Decision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Decision::Allow => "allow",
+            Decision::Deny => "deny",
+        })
+    }
+}
+
+/// One expected decision in a scenario's table: a `(agent, client, mode, resource)`
+/// request and the decision the ACP spec requires for it.
+///
+/// Build with the fluent helpers: [`Expect::agent`] / [`Expect::anonymous`] /
+/// [`Expect::pair`] pick the requestor, then a mode helper
+/// ([`ExpectBuilder::read`] / [`ExpectBuilder::write`] / [`ExpectBuilder::append`] /
+/// [`ExpectBuilder::control`]) names the resource, then [`ExpectWithMode::is`] fixes the
+/// expected [`Decision`].
+#[derive(Debug, Clone)]
+pub struct Expect {
+    agent: Option<String>,
+    client: Option<String>,
+    mode: Mode,
+    resource: String,
+    decision: Decision,
+}
+
+impl Expect {
+    /// Start an expectation for an authenticated `agent` (no client constraint).
+    pub fn agent(agent: &str) -> ExpectBuilder {
+        ExpectBuilder {
+            agent: Some(agent.to_owned()),
+            client: None,
+        }
+    }
+
+    /// Start an expectation for the **anonymous** requestor (no agent, no client).
+    pub fn anonymous() -> ExpectBuilder {
+        ExpectBuilder {
+            agent: None,
+            client: None,
+        }
+    }
+
+    /// Start an expectation for an `(agent, client)` pair — the native ACP
+    /// (user, application) principal.
+    pub fn pair(agent: &str, client: &str) -> ExpectBuilder {
+        ExpectBuilder {
+            agent: Some(agent.to_owned()),
+            client: Some(client.to_owned()),
+        }
+    }
+
+    /// The decision this expectation asserts the engine must reproduce.
+    pub fn decision(&self) -> Decision {
+        self.decision
+    }
+}
+
+/// Half-built [`Expect`]: requestor chosen, resource + mode + decision still to come.
+#[derive(Debug, Clone)]
+pub struct ExpectBuilder {
+    agent: Option<String>,
+    client: Option<String>,
+}
+
+/// [`Expect`] with the requestor + mode + resource fixed, awaiting the [`Decision`].
+#[derive(Debug, Clone)]
+pub struct ExpectWithMode {
+    agent: Option<String>,
+    client: Option<String>,
+    mode: Mode,
+    resource: String,
+}
+
+impl ExpectBuilder {
+    /// Expect a read decision on `resource`.
+    pub fn read(self, resource: &str) -> ExpectWithMode {
+        self.with_mode(Mode::Read, resource)
+    }
+    /// Expect a write decision on `resource`.
+    pub fn write(self, resource: &str) -> ExpectWithMode {
+        self.with_mode(Mode::Write, resource)
+    }
+    /// Expect an append decision on `resource`.
+    pub fn append(self, resource: &str) -> ExpectWithMode {
+        self.with_mode(Mode::Append, resource)
+    }
+    /// Expect a control decision on `resource` (governs the resource's ACR document).
+    pub fn control(self, resource: &str) -> ExpectWithMode {
+        self.with_mode(Mode::Control, resource)
+    }
+    fn with_mode(self, mode: Mode, resource: &str) -> ExpectWithMode {
+        ExpectWithMode {
+            agent: self.agent,
+            client: self.client,
+            mode,
+            resource: resource.to_owned(),
+        }
+    }
+}
+
+impl ExpectWithMode {
+    /// Fix the expected [`Decision`], completing the [`Expect`].
+    pub fn is(self, decision: Decision) -> Expect {
+        Expect {
+            agent: self.agent,
+            client: self.client,
+            mode: self.mode,
+            resource: self.resource,
+            decision,
+        }
+    }
+}
+
+/// A builder for one ACP access-control resource (ACR) corpus, written as N-Quads (each
+/// ACR into its own named graph `<{resource}.acr>`).
+///
+/// An ACR binds the protected `resource` to one or more **access controls** — either
+/// [`AcrBuilder::access_control`] (`acp:accessControl`, applies to the resource itself)
+/// or [`AcrBuilder::member_access_control`] (`acp:memberAccessControl`, applies to the
+/// resource's members, i.e. descendants). Each carries one or more **policies**, each
+/// declared by a `|policy|` closure over a [`PolicyBuilder`].
+///
+/// To make a resource a concrete protected graph (so an `Allow` is observable as a
+/// non-empty accessible set), register it with [`AcrBuilder::document`].
+///
+/// **Containment is by IRI structure**, not by an `ldp:contains` triple: this crate's
+/// ACP engine derives the ancestry of a resource from its Solid slash path (design doc /
+/// `rules/common.n3`), so a `memberAccessControl` on `https://pod.example/c/` reaches
+/// `https://pod.example/c/d` because the latter is structurally under the former. To
+/// make a container a known ancestor it must be a resource — give it its own ACR (via
+/// `member_access_control`) or register it with [`AcrBuilder::document`]; a structural
+/// prefix of any present graph is also recognised automatically.
+#[derive(Debug, Default, Clone)]
+pub struct AcrBuilder {
+    quads: String,
+    controls: usize,
+}
+
+impl AcrBuilder {
+    /// A new, empty ACR builder.
+    pub fn new() -> AcrBuilder {
+        AcrBuilder::default()
+    }
+
+    /// Add an `acp:accessControl` on `resource` — its policies apply to the resource
+    /// itself. The `build` closure declares the (single) policy attached to it.
+    pub fn access_control(
+        &mut self,
+        resource: &str,
+        build: impl FnOnce(PolicyBuilder<'_>) -> PolicyBuilder<'_>,
+    ) -> &mut AcrBuilder {
+        self.add_control(resource, "accessControl", build)
+    }
+
+    /// Add an `acp:memberAccessControl` on `resource` — its policies apply to the
+    /// resource's **members** (its IRI-structural descendants; containment is by slash
+    /// path, see the type-level docs). ACP inheritance is cumulative: every ancestor's
+    /// member access control applies.
+    pub fn member_access_control(
+        &mut self,
+        resource: &str,
+        build: impl FnOnce(PolicyBuilder<'_>) -> PolicyBuilder<'_>,
+    ) -> &mut AcrBuilder {
+        self.add_control(resource, "memberAccessControl", build)
+    }
+
+    fn add_control(
+        &mut self,
+        resource: &str,
+        pred: &str,
+        build: impl FnOnce(PolicyBuilder<'_>) -> PolicyBuilder<'_>,
+    ) -> &mut AcrBuilder {
+        let g = format!("{resource}.acr");
+        // bind the ACR graph to its resource (ACP `acp:resource`)
+        let _ = writeln!(self.quads, "<{g}> <{ACP}resource> <{resource}> <{g}> .");
+        let ix = self.controls;
+        self.controls += 1;
+        let control = format!("{g}#ctl{ix}");
+        let _ = writeln!(self.quads, "<{g}> <{ACP}{pred}> <{control}> <{g}> .");
+        let pol = format!("{g}#pol{ix}");
+        let _ = writeln!(self.quads, "<{control}> <{ACP}apply> <{pol}> <{g}> .");
+        // `ix` namespaces this policy's matcher IRIs so two policies in the SAME ACR
+        // graph never collide on a matcher node (a collision would silently merge their
+        // matcher attributes — e.g. an allow policy's PublicAgent matcher fusing with a
+        // deny policy's agent matcher).
+        let pb = PolicyBuilder {
+            quads: &mut self.quads,
+            graph: g,
+            control_ix: ix,
+            matchers: 0,
+            policy: pol,
+        };
+        build(pb);
+        self
+    }
+
+    /// Register `resource` as a concrete protected document: emit a placeholder triple
+    /// into `<{resource}>` so that a granted access is observable as a non-empty
+    /// accessible set.
+    pub fn document(&mut self, resource: &str) -> &mut AcrBuilder {
+        let _ = writeln!(
+            self.quads,
+            "<{resource}#it> <{EX_PRED}> \"x\" <{resource}> ."
+        );
+        self
+    }
+
+    /// The accumulated N-Quads of this ACR corpus.
+    pub fn into_nquads(self) -> String {
+        self.quads
+    }
+}
+
+/// A fluent builder for one ACP policy: its `acp:allow` / `acp:deny` modes and its
+/// `acp:allOf` / `acp:anyOf` / `acp:noneOf` matchers.
+///
+/// ACP policy semantics (normative): a policy is **satisfied** for a request when every
+/// `allOf` matcher matches AND at least one `anyOf` matcher matches (a policy with no
+/// `anyOf` matchers requires only the `allOf` set) AND no `noneOf` matcher matches. A
+/// satisfied policy contributes its `acp:allow` modes as grants and its `acp:deny`
+/// modes as denials; **deny overrides** allow for the same `(principal, resource, mode)`.
+#[derive(Debug)]
+pub struct PolicyBuilder<'a> {
+    quads: &'a mut String,
+    graph: String,
+    policy: String,
+    /// Namespaces this policy's matcher IRIs within the shared ACR graph.
+    control_ix: usize,
+    matchers: usize,
+}
+
+impl PolicyBuilder<'_> {
+    fn mode_iri(mode: Mode) -> &'static str {
+        match mode {
+            Mode::Read => "Read",
+            Mode::Write => "Write",
+            Mode::Append => "Append",
+            Mode::Control => "Control",
+        }
+    }
+
+    /// Add an `acp:allow <mode>` to this policy.
+    pub fn allow(self, mode: Mode) -> Self {
+        let m = Self::mode_iri(mode);
+        let _ = writeln!(
+            self.quads,
+            "<{}> <{ACP}allow> <{ACL}{m}> <{}> .",
+            self.policy, self.graph
+        );
+        self
+    }
+
+    /// Add an `acp:deny <mode>` to this policy (deny overrides allow at decision time).
+    pub fn deny(self, mode: Mode) -> Self {
+        let m = Self::mode_iri(mode);
+        let _ = writeln!(
+            self.quads,
+            "<{}> <{ACP}deny> <{ACL}{m}> <{}> .",
+            self.policy, self.graph
+        );
+        self
+    }
+
+    fn matcher(&mut self, combinator: &str) -> String {
+        let m = format!(
+            "{}#m{}-{combinator}{}",
+            self.graph, self.control_ix, self.matchers
+        );
+        self.matchers += 1;
+        let _ = writeln!(
+            self.quads,
+            "<{}> <{ACP}{combinator}> <{m}> <{}> .",
+            self.policy, self.graph
+        );
+        m
+    }
+
+    /// Add an `acp:anyOf` matcher accepting the given `agent` (a WebID, or
+    /// [`PUBLIC_AGENT`] / [`AUTHENTICATED_AGENT`]).
+    pub fn any_of_agent(mut self, agent: &str) -> Self {
+        let m = self.matcher("anyOf");
+        let _ = writeln!(
+            self.quads,
+            "<{m}> <{ACP}agent> <{agent}> <{}> .",
+            self.graph
+        );
+        self
+    }
+
+    /// Add an `acp:allOf` matcher accepting the given `agent`.
+    pub fn all_of_agent(mut self, agent: &str) -> Self {
+        let m = self.matcher("allOf");
+        let _ = writeln!(
+            self.quads,
+            "<{m}> <{ACP}agent> <{agent}> <{}> .",
+            self.graph
+        );
+        self
+    }
+
+    /// Add an `acp:allOf` matcher accepting the given `client` (application id) — the
+    /// other half of the native ACP (user, application) pair.
+    pub fn all_of_client(mut self, client: &str) -> Self {
+        let m = self.matcher("allOf");
+        let _ = writeln!(
+            self.quads,
+            "<{m}> <{ACP}client> <{client}> <{}> .",
+            self.graph
+        );
+        self
+    }
+
+    /// Add an `acp:anyOf` matcher accepting the given `client`.
+    pub fn any_of_client(mut self, client: &str) -> Self {
+        let m = self.matcher("anyOf");
+        let _ = writeln!(
+            self.quads,
+            "<{m}> <{ACP}client> <{client}> <{}> .",
+            self.graph
+        );
+        self
+    }
+
+    /// Add an `acp:noneOf` matcher: the policy is satisfied only when this matcher does
+    /// NOT match (the ACP "except" carve-out). Matches on `agent`.
+    pub fn none_of_agent(mut self, agent: &str) -> Self {
+        let m = self.matcher("noneOf");
+        let _ = writeln!(
+            self.quads,
+            "<{m}> <{ACP}agent> <{agent}> <{}> .",
+            self.graph
+        );
+        self
+    }
+
+    /// Add a single `acp:allOf` matcher requiring BOTH `agent` AND `client` to match —
+    /// the explicit (user, application) pair on one matcher.
+    pub fn all_of_pair(mut self, agent: &str, client: &str) -> Self {
+        let m = self.matcher("allOf");
+        let _ = writeln!(
+            self.quads,
+            "<{m}> <{ACP}agent> <{agent}> <{}> .",
+            self.graph
+        );
+        let _ = writeln!(
+            self.quads,
+            "<{m}> <{ACP}client> <{client}> <{}> .",
+            self.graph
+        );
+        self
+    }
+}
+
+/// One conformance scenario: a named, self-contained ACR corpus plus the table of
+/// expected `(agent, client, mode, resource) → decision` decisions the ACP spec
+/// requires for it.
+///
+/// Build with [`AcpScenario::new`], attach the ACR corpus with [`AcpScenario::acr`]
+/// (or raw N-Quads with [`AcpScenario::nquads`]), add expectations with
+/// [`AcpScenario::expect`], then [`AcpScenario::run`] it through the real ACP engine.
+#[derive(Debug, Clone)]
+pub struct AcpScenario {
+    name: String,
+    nquads: String,
+    expects: Vec<Expect>,
+}
+
+impl AcpScenario {
+    /// A new, empty scenario with the given `name` (used in the failure report).
+    pub fn new(name: &str) -> AcpScenario {
+        AcpScenario {
+            name: name.to_owned(),
+            nquads: String::new(),
+            expects: Vec::new(),
+        }
+    }
+
+    /// Attach an [`AcrBuilder`]'s ACR corpus to this scenario (appended to any N-Quads
+    /// already present).
+    pub fn acr(mut self, acr: AcrBuilder) -> Self {
+        self.nquads.push_str(&acr.into_nquads());
+        self
+    }
+
+    /// Append raw N-Quads (e.g. extra document content) to the scenario corpus.
+    pub fn nquads(mut self, nquads: &str) -> Self {
+        self.nquads.push_str(nquads);
+        self.nquads.push('\n');
+        self
+    }
+
+    /// Add one expected decision to the scenario's table.
+    pub fn expect(mut self, e: Expect) -> Self {
+        self.expects.push(e);
+        self
+    }
+
+    /// Add many expected decisions at once.
+    pub fn expect_all(mut self, es: impl IntoIterator<Item = Expect>) -> Self {
+        self.expects.extend(es);
+        self
+    }
+
+    /// The scenario's name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Materialize the scenario's ACP corpus and check every expected decision against
+    /// the engine's verdict, returning a [`ScenarioReport`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` only if the corpus fails to load or [`materialize_acp`] errors
+    /// (e.g. a reserved-encoding collision). A *wrong decision* is NOT an error — it is
+    /// a recorded mismatch in the returned report (so a whole corpus can be run and all
+    /// mismatches reported at once).
+    pub fn run(&self) -> Result<ScenarioReport, String> {
+        let mut graph = Graph::load_dataset(&self.nquads, "nquads")
+            .map_err(|e| format!("scenario {:?}: load failed: {e}", self.name))?;
+        materialize_acp(&mut graph)
+            .map_err(|e| format!("scenario {:?}: materialize_acp failed: {e}", self.name))?;
+        let index = AuthIndex::from_graph(&graph);
+
+        let mut results = Vec::with_capacity(self.expects.len());
+        for e in &self.expects {
+            let session = Session {
+                agent: e.agent.as_deref(),
+                client: e.client.as_deref(),
+                // [OPUS-4.8] sq-3jtd.9: this harness exercises the agent/client matcher
+                // dimensions; the issuer dimension (sq-3jtd.6, ACP `acp:issuer`) is left
+                // unconstrained (`None` ⇒ AnyIssuer), so issuer-blind decision parity is
+                // unaffected by the (agent, client, issuer) principal model.
+                issuer: None,
+            };
+            let accessible = index.accessible(&session, e.mode);
+            let granted = accessible.iter().any(|g| g.as_str() == e.resource);
+            let actual = if granted {
+                Decision::Allow
+            } else {
+                Decision::Deny
+            };
+            results.push(DecisionResult {
+                expect: e.clone(),
+                actual,
+            });
+        }
+        Ok(ScenarioReport {
+            name: self.name.clone(),
+            results,
+        })
+    }
+}
+
+/// The outcome of checking one expected decision: what was expected vs. what the engine
+/// decided.
+#[derive(Debug, Clone)]
+pub struct DecisionResult {
+    expect: Expect,
+    actual: Decision,
+}
+
+impl DecisionResult {
+    /// `true` iff the engine's decision matched the expectation.
+    pub fn matched(&self) -> bool {
+        self.actual == self.expect.decision
+    }
+}
+
+/// The result of running one [`AcpScenario`]: the per-decision outcomes, with helpers to
+/// assert overall parity.
+#[derive(Debug, Clone)]
+pub struct ScenarioReport {
+    name: String,
+    results: Vec<DecisionResult>,
+}
+
+impl ScenarioReport {
+    /// `true` iff every expected decision was reproduced by the engine.
+    pub fn passed(&self) -> bool {
+        self.results.iter().all(DecisionResult::matched)
+    }
+
+    /// The decisions whose engine verdict did NOT match the expectation.
+    pub fn mismatches(&self) -> impl Iterator<Item = &DecisionResult> {
+        self.results.iter().filter(|r| !r.matched())
+    }
+
+    /// The number of expected decisions checked.
+    pub fn checked(&self) -> usize {
+        self.results.len()
+    }
+
+    /// The scenario name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl fmt::Display for ScenarioReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mismatches = self.results.iter().filter(|r| !r.matched()).count();
+        writeln!(
+            f,
+            "scenario {:?}: {}/{} decisions matched ({mismatches} mismatch(es))",
+            self.name,
+            self.checked() - mismatches,
+            self.checked(),
+        )?;
+        for r in self.results.iter().filter(|r| !r.matched()) {
+            let who = match (&r.expect.agent, &r.expect.client) {
+                (Some(a), Some(c)) => format!("(agent {a}, client {c})"),
+                (Some(a), None) => format!("agent {a}"),
+                (None, _) => "anonymous".to_owned(),
+            };
+            writeln!(
+                f,
+                "  MISMATCH: {who} {:?} {} => expected {}, engine decided {}",
+                r.expect.mode, r.expect.resource, r.expect.decision, r.actual,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+/// Run a whole corpus of scenarios, returning the per-scenario reports. A convenience
+/// for `tests/conformance_acp.rs`: every scenario is run even if an earlier one mismatches,
+/// so a single test surfaces all mismatches at once.
+///
+/// # Errors
+///
+/// Returns `Err` if any scenario fails to materialize (load / reasoner error). Decision
+/// mismatches are not errors — they are in the returned reports.
+pub fn run_corpus(scenarios: &[AcpScenario]) -> Result<Vec<ScenarioReport>, String> {
+    scenarios.iter().map(AcpScenario::run).collect()
+}

--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -2,6 +2,12 @@
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 
 mod authindex;
+// [OPUS-4.8] sq-3jtd.9: library-level ACP conformance harness — a table-driven scenario
+// corpus over the ACP engine (materialize_acp + AuthIndex::accessible), asserting
+// decision parity against the Solid ACP spec semantics. Always compiled (no feature
+// gate): it depends only on the always-present ACP path. The corpus lives in
+// tests/conformance_acp.rs.
+pub mod conformance;
 pub mod fixture;
 mod loader;
 mod materialize;
@@ -13,6 +19,8 @@ mod rewrite;
 mod update; // [OPUS-4.8] sq-xor3: write/update-path enforcement
 
 pub use authindex::{pair_principal, triple_principal, AuthIndex, Mode, Session};
+// [OPUS-4.8] sq-3jtd.9: the ACP conformance harness entry types.
+pub use conformance::{AcpScenario, AcrBuilder, Decision, Expect, ScenarioReport};
 pub use fixture::{acp_fixture, wac_fixture};
 pub use materialize::{materialize_acp, materialize_wac, MaterializeStats};
 #[cfg(feature = "odrl-bridge")]

--- a/crates/sparq-solid/tests/conformance_acp.rs
+++ b/crates/sparq-solid/tests/conformance_acp.rs
@@ -1,0 +1,297 @@
+//! [OPUS-4.8] sq-3jtd.9 — the ACP **conformance corpus**: a table of independent,
+//! minimal scenarios, each isolating one Solid ACP-spec construct, run through this
+//! crate's ACP authorization engine (`materialize_acp` + `AuthIndex::accessible`) with
+//! its expected `(agent, client, mode, resource) → allow | deny` decisions asserted.
+//!
+//! Decision: the conformance surface is the Solid ACP spec
+//! (<https://solidproject.org/TR/acp>) at the library level — see the harness module
+//! `src/conformance.rs` for the full rationale (why CTH-over-HTTP and the JS-reference
+//! differential oracle are out-of-scope / research-open). The harness lets each
+//! scenario fail independently and reports all mismatches at once.
+
+use sparq_solid::conformance::{
+    run_corpus, AcpScenario, AcrBuilder, Decision, Expect, AUTHENTICATED_AGENT, PUBLIC_AGENT,
+};
+use sparq_solid::Mode;
+
+const ALICE: &str = "https://alice.example/card#me";
+const BOB: &str = "https://bob.example/card#me";
+const CAROL: &str = "https://carol.example/card#me";
+const APP: &str = "https://app.example";
+const EVIL: &str = "https://evil.example";
+
+/// ACP §"Matchers" + §"Policies": an `acp:anyOf` agent matcher grants the enumerated
+/// agent and nobody else; the anonymous requestor is refused.
+fn agent_anyof() -> AcpScenario {
+    let doc = "https://pod.example/agent/d1";
+    let mut acr = AcrBuilder::new();
+    acr.access_control(doc, |p| p.allow(Mode::Read).any_of_agent(ALICE));
+    acr.document(doc);
+    AcpScenario::new("agent-anyOf-allow")
+        .acr(acr)
+        .expect(Expect::agent(ALICE).read(doc).is(Decision::Allow))
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Deny))
+        .expect(Expect::anonymous().read(doc).is(Decision::Deny))
+}
+
+/// ACP §"Matchers": `acp:PublicAgent` accepts EVERY requestor, including the anonymous
+/// one and any client.
+fn public_agent() -> AcpScenario {
+    let doc = "https://pod.example/public/d1";
+    let mut acr = AcrBuilder::new();
+    acr.access_control(doc, |p| p.allow(Mode::Read).any_of_agent(PUBLIC_AGENT));
+    acr.document(doc);
+    AcpScenario::new("public-agent")
+        .acr(acr)
+        .expect(Expect::anonymous().read(doc).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).read(doc).is(Decision::Allow))
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Allow))
+        .expect(Expect::pair(BOB, APP).read(doc).is(Decision::Allow))
+}
+
+/// ACP §"Matchers": `acp:AuthenticatedAgent` accepts any authenticated requestor but
+/// NOT the anonymous one.
+fn authenticated_agent() -> AcpScenario {
+    let doc = "https://pod.example/authn/d1";
+    let mut acr = AcrBuilder::new();
+    acr.access_control(doc, |p| {
+        p.allow(Mode::Read).any_of_agent(AUTHENTICATED_AGENT)
+    });
+    acr.document(doc);
+    AcpScenario::new("authenticated-agent")
+        .acr(acr)
+        .expect(Expect::agent(ALICE).read(doc).is(Decision::Allow))
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Allow))
+        .expect(Expect::anonymous().read(doc).is(Decision::Deny))
+}
+
+/// ACP §"Policies" `acp:allOf`: the native (user, application) PAIR — agent BOB AND
+/// client APP must BOTH hold. A right agent with the wrong client (or no client) fails;
+/// a wrong agent with the right client fails.
+fn allof_pair() -> AcpScenario {
+    let doc = "https://pod.example/pair/d1";
+    let mut acr = AcrBuilder::new();
+    acr.access_control(doc, |p| {
+        p.allow(Mode::Read).all_of_agent(BOB).all_of_client(APP)
+    });
+    acr.document(doc);
+    AcpScenario::new("allOf-user-app-pair")
+        .acr(acr)
+        .expect(Expect::pair(BOB, APP).read(doc).is(Decision::Allow))
+        .expect(Expect::pair(BOB, EVIL).read(doc).is(Decision::Deny))
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Deny))
+        .expect(Expect::pair(CAROL, APP).read(doc).is(Decision::Deny))
+        .expect(Expect::anonymous().read(doc).is(Decision::Deny))
+}
+
+/// ACP §"Policies" `acp:allOf` on a single matcher carrying both `acp:agent` and
+/// `acp:client`: same (user, app) pair semantics, one matcher.
+fn allof_single_matcher_pair() -> AcpScenario {
+    let doc = "https://pod.example/pair2/d1";
+    let mut acr = AcrBuilder::new();
+    acr.access_control(doc, |p| p.allow(Mode::Read).all_of_pair(BOB, APP));
+    acr.document(doc);
+    AcpScenario::new("allOf-single-matcher-pair")
+        .acr(acr)
+        .expect(Expect::pair(BOB, APP).read(doc).is(Decision::Allow))
+        .expect(Expect::pair(BOB, EVIL).read(doc).is(Decision::Deny))
+        .expect(Expect::pair(CAROL, APP).read(doc).is(Decision::Deny))
+}
+
+/// ACP §"Access Modes" deny-overrides: a public allow plus a deny for one agent — the
+/// denied agent loses access, everyone else keeps it. (Allow and deny are both
+/// materialized as triples; the session layer computes allow ∖ deny.)
+fn deny_overrides() -> AcpScenario {
+    let doc = "https://pod.example/deny/d1";
+    let mut acr = AcrBuilder::new();
+    acr.access_control(doc, |p| p.allow(Mode::Read).any_of_agent(PUBLIC_AGENT));
+    acr.access_control(doc, |p| p.deny(Mode::Read).any_of_agent(BOB));
+    acr.document(doc);
+    AcpScenario::new("deny-overrides")
+        .acr(acr)
+        .expect(Expect::agent(ALICE).read(doc).is(Decision::Allow))
+        .expect(Expect::anonymous().read(doc).is(Decision::Allow))
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Deny))
+}
+
+/// ACP §"Matchers" `acp:noneOf` (the "except" carve-out): public read EXCEPT carol.
+/// Evaluated per session as a conditional grant.
+fn none_of() -> AcpScenario {
+    let doc = "https://pod.example/except/d1";
+    let mut acr = AcrBuilder::new();
+    acr.access_control(doc, |p| {
+        p.allow(Mode::Read)
+            .any_of_agent(PUBLIC_AGENT)
+            .none_of_agent(CAROL)
+    });
+    acr.document(doc);
+    AcpScenario::new("noneOf-public-except-carol")
+        .acr(acr)
+        .expect(Expect::agent(ALICE).read(doc).is(Decision::Allow))
+        .expect(Expect::anonymous().read(doc).is(Decision::Allow))
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Allow))
+        .expect(Expect::agent(CAROL).read(doc).is(Decision::Deny))
+}
+
+/// ACP §"Effective Policies": `acp:memberAccessControl` on an ancestor applies to its
+/// members (IRI-structural descendants) but NOT to the ancestor resource itself, while
+/// `acp:accessControl` applies to the resource itself only. Here the container grants
+/// alice on members; a deep document inherits it, the container's own resource does not.
+fn member_access_control_inheritance() -> AcpScenario {
+    let container = "https://pod.example/team/";
+    let deep = "https://pod.example/team/sub/d1";
+    let mut acr = AcrBuilder::new();
+    // memberAccessControl on the container: applies to descendants.
+    acr.member_access_control(container, |p| p.allow(Mode::Read).any_of_agent(ALICE));
+    acr.document(deep); // the protected descendant
+    acr.document(container); // make the container a concrete resource too
+    AcpScenario::new("memberAccessControl-inheritance")
+        .acr(acr)
+        // alice reads the descendant (inherited member policy)
+        .expect(Expect::agent(ALICE).read(deep).is(Decision::Allow))
+        .expect(Expect::agent(BOB).read(deep).is(Decision::Deny))
+        // the container resource itself is NOT a member of itself: memberAccessControl
+        // does not grant it (no accessControl present), so alice cannot read it.
+        .expect(Expect::agent(ALICE).read(container).is(Decision::Deny))
+}
+
+/// ACP §"Effective Policies", CUMULATIVE inheritance (the key WAC difference): a deeper
+/// resource accrues EVERY ancestor's memberAccessControl. The root grants alice; a
+/// nested container ALSO grants bob; a deep document under it is readable by BOTH —
+/// the nested ACR does not shadow the root (cumulative, not nearest-wins).
+fn cumulative_inheritance() -> AcpScenario {
+    let root = "https://pod.example/";
+    let mid = "https://pod.example/proj/";
+    let deep = "https://pod.example/proj/c/d1";
+    let mut acr = AcrBuilder::new();
+    acr.member_access_control(root, |p| p.allow(Mode::Read).any_of_agent(ALICE));
+    acr.member_access_control(mid, |p| p.allow(Mode::Read).any_of_agent(BOB));
+    acr.document(deep);
+    AcpScenario::new("cumulative-inheritance")
+        .acr(acr)
+        .expect(Expect::agent(ALICE).read(deep).is(Decision::Allow)) // root, cumulative
+        .expect(Expect::agent(BOB).read(deep).is(Decision::Allow)) // mid, cumulative
+        .expect(Expect::agent(CAROL).read(deep).is(Decision::Deny))
+}
+
+/// ACP §"Access Modes": the four modes are independent. A policy that allows Read+Write
+/// grants both; a Read-only policy denies Write; Control is a separate mode that (per
+/// the rules) governs the ACR document, NOT the resource — so a Control grant does not
+/// by itself make the resource readable.
+fn mode_independence() -> AcpScenario {
+    let rw = "https://pod.example/modes/rw";
+    let ro = "https://pod.example/modes/ro";
+    let mut acr = AcrBuilder::new();
+    acr.access_control(rw, |p| {
+        p.allow(Mode::Read).allow(Mode::Write).any_of_agent(ALICE)
+    });
+    acr.access_control(ro, |p| p.allow(Mode::Read).any_of_agent(ALICE));
+    acr.document(rw);
+    acr.document(ro);
+    AcpScenario::new("mode-independence")
+        .acr(acr)
+        .expect(Expect::agent(ALICE).read(rw).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).write(rw).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).read(ro).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).write(ro).is(Decision::Deny))
+}
+
+/// ACP fail-closed: a resource with NO access control grants nobody (not even the
+/// anonymous requestor, not any authenticated agent). An unprotected resource is
+/// invisible.
+fn fail_closed_no_policy() -> AcpScenario {
+    let doc = "https://pod.example/orphan/d1";
+    let mut acr = AcrBuilder::new();
+    acr.document(doc); // present, but no ACR controls it
+    AcpScenario::new("fail-closed-no-policy")
+        .acr(acr)
+        .expect(Expect::agent(ALICE).read(doc).is(Decision::Deny))
+        .expect(Expect::anonymous().read(doc).is(Decision::Deny))
+}
+
+/// ACP `acp:anyOf` is a disjunction: enumerating two agents grants EITHER, not BOTH-
+/// required. (ACP has no groups, so a group is modelled by enumerating members.)
+fn anyof_disjunction() -> AcpScenario {
+    let doc = "https://pod.example/anyof/d1";
+    let mut acr = AcrBuilder::new();
+    acr.access_control(doc, |p| {
+        p.allow(Mode::Read)
+            .allow(Mode::Write)
+            .any_of_agent(BOB)
+            .any_of_agent(CAROL)
+    });
+    acr.document(doc);
+    AcpScenario::new("anyOf-disjunction")
+        .acr(acr)
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Allow))
+        .expect(Expect::agent(CAROL).write(doc).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).read(doc).is(Decision::Deny))
+}
+
+/// The full corpus.
+fn corpus() -> Vec<AcpScenario> {
+    vec![
+        agent_anyof(),
+        public_agent(),
+        authenticated_agent(),
+        allof_pair(),
+        allof_single_matcher_pair(),
+        deny_overrides(),
+        none_of(),
+        member_access_control_inheritance(),
+        cumulative_inheritance(),
+        mode_independence(),
+        fail_closed_no_policy(),
+        anyof_disjunction(),
+    ]
+}
+
+#[test]
+fn acp_conformance_corpus_decision_parity() {
+    let scenarios = corpus();
+    let reports = run_corpus(&scenarios).expect("every scenario materializes");
+
+    let mut failures = String::new();
+    let mut total_decisions = 0usize;
+    for r in &reports {
+        total_decisions += r.checked();
+        if !r.passed() {
+            failures.push_str(&r.to_string());
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "ACP conformance mismatch(es) across {} scenarios / {total_decisions} decisions:\n{failures}",
+        reports.len(),
+    );
+    // Guard against a corpus that silently checks nothing.
+    assert_eq!(reports.len(), 12, "expected 12 scenarios");
+    assert!(
+        total_decisions >= 35,
+        "expected a substantive decision table, got {total_decisions}"
+    );
+}
+
+/// The harness reports a mismatch (rather than panicking) when an expected decision is
+/// wrong — so a future regression surfaces as a readable diff, not a generic failure.
+/// This NEGATIVE control deliberately states a wrong expectation and asserts the harness
+/// flags it (it does not assert the engine is wrong — it asserts the *reporting* works).
+#[test]
+fn harness_flags_a_wrong_expectation() {
+    let doc = "https://pod.example/neg/d1";
+    let mut acr = AcrBuilder::new();
+    acr.access_control(doc, |p| p.allow(Mode::Read).any_of_agent(ALICE));
+    acr.document(doc);
+    // bob has NO grant; asserting Allow is wrong on purpose.
+    let scenario = AcpScenario::new("negative-control")
+        .acr(acr)
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Allow));
+    let report = scenario.run().expect("materializes");
+    assert!(
+        !report.passed(),
+        "harness must detect the wrong expectation"
+    );
+    assert_eq!(report.mismatches().count(), 1);
+    // the Display form names the mismatch
+    assert!(report.to_string().contains("MISMATCH"));
+}

--- a/research/sparq-solid-scope.md
+++ b/research/sparq-solid-scope.md
@@ -345,9 +345,22 @@ The honest gaps:
 1. **(near-term, feasible — **sq-3jtd.8**)** Vendor/ingest the authorization-relevant WAC
    fixtures from the Solid spec-tests corpus and assert library-level decision parity in
    `tests/conformance_wac.rs`.
-2. **(feasible, after WAC — **sq-3jtd.9**)** Same for ACP (`tests/conformance_acp.rs`).
-3. *(research-open / aspirational)* Differential oracle against CSS (WAC/ACP) — captured here;
-   tracked under sq-3jtd.9's notes, not started until the corpus harness exists.
+2. **(DONE — **sq-3jtd.9** [OPUS-4.8])** ACP harness landed: `sparq_solid::conformance`
+   (`src/conformance.rs`) is a table-driven scenario runner over the ACP engine
+   (`materialize_acp` + `AuthIndex::accessible`), with the scenario corpus in
+   `tests/conformance_acp.rs` (matchers incl. `acp:PublicAgent`/`acp:AuthenticatedAgent`,
+   `acp:allOf`/`acp:anyOf`/`acp:noneOf`, the (user, app) pair, deny-overrides, cumulative
+   ancestor inheritance, mode independence, fail-closed). **Decision recorded:** scenarios are
+   derived from the ACP spec's normative semantics and declared as data (an `AcrBuilder` corpus
+   + an expected-decision table), rather than vendoring the live JS spec-tests/CTH corpus over
+   HTTP — that route has no library entry point here (it asserts on HTTP outputs, PSS's by
+   design). NOTE: the WAC harness (sq-3jtd.8) was still open when this landed, so the ACP harness
+   defines the in-crate pattern rather than mirroring an existing WAC one; the same harness shape
+   transfers to WAC when sq-3jtd.8 is implemented.
+3. *(research-open / aspirational — STILL NOT STARTED)* Differential oracle against CSS (WAC/ACP):
+   run the same corpus through the JS reference evaluator and diff decisions. Deferred for the
+   JS-toolchain cost; the table-driven corpus in `tests/conformance_acp.rs` is the natural input
+   for it. Tracked as a follow-up.
 
 **Verdict: library-level conformance is near-term feasible** (the storage model already matches
 the corpus shape); **CTH-over-HTTP conformance is out-of-scope** for sparq-solid (it is PSS's,

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -177,6 +177,60 @@ pattern: `GRAPH <urn:sparq:auth> { ?who <https://sparq.dev/ns/auth#read> ?doc }`
   Only an issuer-CONSTRAINED grant mints a triple principal; an issuer-unconstrained grant
   (`AnyIssuer`) reuses the agent / pair term, so issuer-blind pods are unaffected.
 
+## ACP conformance harness — [OPUS-4.8] sq-3jtd.9
+
+`sparq_solid::conformance` is a **library-level ACP conformance harness**: a table-driven
+scenario runner over this crate's own ACP engine (`materialize_acp` +
+`AuthIndex::accessible`). A scenario is declared as **data** — an ACR-document corpus plus a
+table of expected `(agent, client, mode, resource) → Allow | Deny` decisions — and the
+harness asserts the engine reproduces every expected decision, reporting **all** mismatches
+at once. The module is **always compiled** (no feature gate; it depends only on the
+always-present ACP path). The scenario corpus that consumes it lives in
+`crates/sparq-solid/tests/conformance_acp.rs` (12 scenarios / 40 decisions, plus a negative
+control asserting a wrong expectation is *reported*, not panicked).
+
+What it is — and is NOT (honest scope, mirrors the module/README/`research/sparq-solid-scope.md` §4):
+
+- It is the **realistic, achievable** conformance signal for an authorization *oracle* —
+  library-level **decision parity** against the [Solid ACP spec](https://solidproject.org/TR/acp)
+  semantics. It is **NOT a normative-CTH pass** and makes no such claim.
+- **CTH-over-HTTP** (the Solid Conformance Test Harness / `solid/specification-tests`, which
+  drives a *server* and asserts on HTTP outputs) is **out-of-scope** — this crate has no HTTP
+  surface; that belongs to a Solid server, conformance-tested *through* it.
+- A **JS-reference differential oracle** (Community Solid Server / Inrupt ESS over the same
+  corpus) is the credible *second* oracle but is research-open (JS-toolchain cost) and is
+  **not** built here — captured as a follow-up.
+- It is a **test/oracle harness over the existing engine** — it does not change authorization
+  behaviour. It is complementary to `tests/acp.rs` (a hand-derived access matrix over one
+  realistic pod): this harness gives spec-construct coverage with small, independently-failing
+  cases.
+- The **WAC** conformance harness (`sq-3jtd.8`) is **still open** — this defines the in-crate
+  harness pattern (the same `AcrBuilder`/`AcpScenario` shape transfers to WAC) rather than
+  mirroring an existing WAC one.
+
+Public surface (`pub mod conformance`, re-exported from the crate root for the entry types):
+
+- `AcrBuilder` — build the ACR-document corpus as N-Quads. `acr.access_control(resource,
+  |p| …)` / `acr.member_access_control(resource, |p| …)` attach a policy (`acp:accessControl`
+  / `acp:memberAccessControl` for cumulative ancestor inheritance); `acr.document(resource)`
+  declares the protected resource graph; `acr.into_nquads()` emits the corpus.
+- `PolicyBuilder<'a>` (the `|p| …` closure argument) — `allow(Mode)` / `deny(Mode)`,
+  `any_of_agent` / `all_of_agent` / `none_of_agent`, `any_of_client` / `all_of_client`,
+  `all_of_pair(agent, client)` — the `acp:allOf` / `acp:anyOf` / `acp:noneOf` combinators over
+  `acp:agent` / `acp:client` matchers, with `PUBLIC_AGENT` / `AUTHENTICATED_AGENT` consts for
+  the `acp:PublicAgent` / `acp:AuthenticatedAgent` matcher IRIs.
+- `AcpScenario` — `new(name)`, `.acr(AcrBuilder)` / `.nquads(&str)` (the corpus),
+  `.expect(Expect)` / `.expect_all(iter)` (the decision table), `.run() ->
+  Result<ScenarioReport, String>` (materializes + checks). `run_corpus(&[AcpScenario])` runs
+  a whole corpus.
+- `Expect` — one expected decision, built fluently: `Expect::agent(webid)` /
+  `Expect::anonymous()` / `Expect::pair(agent, client)`, then `.read/.write/.append/.control(
+  resource)`, then `.is(Decision::Allow | Decision::Deny)`.
+- `ScenarioReport` — `.passed()`, `.checked()`, `.mismatches()` (the failing
+  `DecisionResult`s), `.name()`, and a readable mismatch `Display`. `Decision::{Allow, Deny}`
+  is the binary the harness compares against the engine verdict (graph in the session's
+  accessible set ⇒ `Allow`).
+
 ## Security posture — fail-closed
 
 Absence of a grant means a graph is **invisible**, and a non-authorized graph is


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-3jtd.9** — a library-level **ACP conformance harness** for `sparq-solid`.

## Decision (made first, then implemented)

The conformance surface targeted is the **Solid ACP spec** (<https://solidproject.org/TR/acp>), exercised at the **library** level. A scenario is declared as **data** — an ACR-document corpus (`AcrBuilder`) plus a table of expected `(agent, client, mode, resource) → allow | deny` decisions — and the harness asserts this crate's ACP engine (`materialize_acp` + `AuthIndex::accessible`) reproduces every expected decision, reporting all mismatches at once.

Two routes were considered and **deliberately not taken** (documented in `src/conformance.rs`, the crate README, and `research/sparq-solid-scope.md` §4):
- **CTH-over-HTTP** (Solid Conformance Test Harness / `solid/specification-tests`) drives a *server* and asserts on HTTP outputs — this crate has no HTTP surface, so that route is out-of-scope (it belongs to the Solid server, tested *through* it).
- **A JS-reference differential oracle** (Community Solid Server / Inrupt ESS — same corpus, diff decisions) is the credible *second* oracle but is research-open (JS-toolchain cost); captured as a follow-up, **not** built here.

This matches the scope record's verdict: library-level decision parity is the realistic, achievable conformance signal for an authorization oracle.

## What landed

- **`crates/sparq-solid/src/conformance.rs`** (new module, always compiled): `AcrBuilder` / `PolicyBuilder` (`acp:accessControl` / `memberAccessControl`, `allow` / `deny`, `allOf` / `anyOf` / `noneOf`, `agent` / `client`, `PublicAgent` / `AuthenticatedAgent`), `AcpScenario` + `Expect` decision table, `ScenarioReport` with a readable mismatch `Display`, and `run_corpus`.
- **`crates/sparq-solid/tests/conformance_acp.rs`** (new): a 12-scenario / 40-decision corpus covering agent `anyOf`, `PublicAgent`, `AuthenticatedAgent`, the (user, app) `allOf` pair (two-matcher and single-matcher), deny-overrides, `noneOf` except, `memberAccessControl` inheritance, cumulative ancestor inheritance, mode independence, fail-closed no-policy, and `anyOf` disjunction — plus a negative control asserting the harness *reports* a wrong expectation rather than panicking.
- `src/lib.rs`: `pub mod conformance;` + re-exports. README + scope-doc decision write-up.

This is a **different module** from the just-merged `acp:issuer` principal-model work — none of those files (`authindex.rs`, `loader.rs`, `materialize.rs`, `rules/acp-*.n3`, `tests/acp.rs`) are touched.

## Honest notes

- The harness surfaced a **real builder bug** while authoring the deny-overrides scenario: matcher IRIs were namespaced per-policy, so two policies in the *same* ACR graph collided on a matcher node and silently merged their attributes (an allow policy's `PublicAgent` matcher fused with a deny policy's agent matcher). Fixed by namespacing matcher IRIs with the control index. This is exactly the kind of mistake a conformance harness is meant to catch.
- The bead is sequenced "after WAC" (sq-3jtd.8), but the **WAC harness was never built** (sq-3jtd.8 is still open). So this defines the in-crate harness pattern rather than mirroring an existing WAC one; the same `AcrBuilder`/`AcpScenario` shape transfers to WAC when sq-3jtd.8 is implemented.
- This is a **test/oracle harness over the existing engine** — it does not change authorization behaviour. It is not a normative-CTH pass and makes no such claim.

## Follow-up (captured; `bd` not on PATH in worktrees)

- **sq-3jtd.8** — WAC conformance harness; reuse this harness's `Acl`/scenario pattern.
- **JS-reference differential oracle** (CSS / ESS) over the same corpus — research-open, JS-toolchain cost.

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + tests **PASS** in **both** feature states (default and `odrl-bridge`).
- `rustdoc -D warnings`, the privacy-claims gate, and `typos` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)