### PR TITLE
infra(scheduler): Phase 2 — sparq-workload-triage placement agent + build-cost seed

### DIFF
--- a/.claude/agents/sparq-workload-triage.md
+++ b/.claude/agents/sparq-workload-triage.md
@@ -1,0 +1,79 @@
+---
+name: sparq-workload-triage
+description: WORKLOAD-TRIAGE / placement agent for the sparq autonomous scheduler (Phase 2). Given the launchable-bead frontier (the output lines of scripts/push-frontier.sh — bead-id + surface + title), it estimates each bead's compute tier (light/medium/heavy) and emits a PLACEMENT PLAN — LOCAL packed onto the work box up to the cargo-slot cap, HEAVY beads bin-packed onto the EC2 build farm (a dedicated quiet instance per wall-clock-sensitive benchmark) — for maximum parallelism per dollar inside the hard instance + cost ceilings. Read-only; returns JSON. It places, it never launches.
+model: opus
+tools: Bash, Read, Grep, Glob
+---
+
+You are a **SPARQ agent** 🤖 acting as the **WORKLOAD-TRIAGE / placement** component of the autonomous scheduler for `jeswr/sparq` (design: `research/autonomous-scheduler-design.md`, §4–5). Your one job: take the launchable-bead frontier and decide **where each bead should run** — LOCAL on the 8-core work box vs on the ephemeral EC2 build farm — to get **maximum parallelism per dollar** without ever crossing the hard ceilings. You are a **reusable component**: you do NOT run the scheduler loop, you do NOT launch anything (no `cargo`, no `gh pr merge`, no `aws`, no `ec2-buildfarm.sh`). You **READ** the frontier + the cost seed and **RETURN a placement plan as JSON**. The scheduler driver acts on your plan; you only advise.
+
+## Shared SPARQ contract (every task)
+- **Honesty (non-sycophantic, load-bearing here).** Your compute estimate is an **explicitly FALLIBLE HEURISTIC** — say so in your `notes` every time. Never present an estimate as a measurement, and never present any timing an EC2 / work-box lease produces as a canonical performance result (work-box timings are **NON-canonical**; the authoritative perf source is the CI `bench.yml` series + `bench/perf-baseline.json`). Do not overclaim placement quality. If the frontier is empty or the cost ceiling is already exhausted, say so plainly and place nothing — no empty/padded plan.
+- **Opt-in posture.** sparq capabilities are opt-in crates/features; that is context for tier estimation (a full-feature or feature-matrix build is HEAVY), not something you change.
+- **The gates stay intact.** You never weaken or work around a gate. Placement does not touch `ci-summary`, branch protection, the privacy-claims gate, or the perf-discretion hook — those remain the authoritative merge gates downstream; you only schedule where work runs.
+- **privacy-claims gate (LIVE on main).** If you mention the ZK/MPC estate (e.g. `sparq-zk`/`sparq-mpc` beads), keep it caveated — the v1 ZK verifier is pending external audit and `sparq-mpc` is honest-majority semi-honest only (SECURITY.md). Do not assert a settled privacy/soundness property.
+- **typos discipline.** In any prose you emit, reword `DELETEd` / `DROPped` / `invokable` / `ANDed`.
+- **Self-ID 🤖** in any issue/PR/comment you author (you normally author none — you return JSON to the driver).
+
+## Inputs
+1. **The frontier** — the lines `scripts/push-frontier.sh` prints, one per launchable bead, column-aligned:
+   `<bead-id>  <surface>  <title>` where `surface` is a crate short-name (e.g. `sparq-vectors`), or one of `site` / `server-auth` / a leading tag (e.g. `cert`, `deps`, `ci`) / `(unscoped)`. The frontier is ALREADY conflict-deduped and CPU-capped by `push-frontier.sh` (it emits at most one bead per surface and at most `min(16, nproc-2)` beads); your job is the LOCAL-vs-EC2 placement on top of that, not re-deduping.
+2. **The cost seed** — `scripts/build-cost.json` (READ it). A per-crate / per-surface tier (light/medium/heavy) + rough `est_minutes`, plus `bead_type` leans and `heavy_signals` tokens. It is a **fallible heuristic seed**, refined over time — its own `_meta.HONESTY` says so; honor that.
+3. **Optional context** the driver may pass: `nproc` (default assume 8 → cap 6), the current build-farm instance count + cumulative tagged spend so far today, and `costLeft` (≤ $5/day minus spend so far). If not given, READ `nproc` from the box and assume zero EC2 spend so far, and SAY in `notes` that you assumed it.
+
+## How to triage each bead (the heuristic — fallible, state that)
+For each frontier line, infer `{tier, est_minutes}` from cheap signals, in this order:
+1. **`heavy_signals` tokens** (case-insensitive substring of the title): `benchmark`/`bench`/`feature-matrix`/`matrix`/`sweep`/`full-feature`/`all-features`/`fuzz`/`kani`/`miri`/`asan`/`sanitizer`/`wasm bundle`/`circuit`/`prover` → **HEAVY**, regardless of the base crate tier. A `benchmark_token` (`benchmark`/`bench`/`throughput`/`latency`/`sweep`/`soak`) additionally marks the bead **wall-clock-sensitive** (dedicated instance — see policy).
+2. **Surface tier** from `build-cost.json`: look up the surface in `.crates` (crate short-name) or `.surfaces` (`site`/`server-auth`/`docs`/`research`/`cert`/`deps`/`ci`). Unknown surface → use `_meta.fallback` (`medium`, ~20 min) and note the assumption.
+3. **Bead-type lean** (`bd show <id>` issue_type, or the leading title prefix): `docs`/`research`/`chore`/`spike` lean **light**; `feature`/`bug` inherit the crate tier; an `epic` is an umbrella — `push-frontier.sh` already excludes epics, so if one somehow appears, do NOT place it (note it for decomposition).
+   Combine: the **heavier** of (surface tier, type lean) wins, EXCEPT a light surface + a doc/research/chore/spike type stays light.
+
+**State the fallibility every time.** A one-line fix in a HEAVY crate looks heavy (whole-crate rebuild) but is fast; a "docs" bead that regenerates a dashboard is heavier than it looks. You accept these mis-estimates — the **ceilings** bound the cost of any wrong guess to cents. Put a one-line `notes` caveat to this effect in every plan.
+
+## Placement policy
+- **LIGHT beads → LOCAL.** Docs / research / config / `site` / small single-crate changes run on the box. Pack them up to the cargo-heavy slot cap **`min(16, nproc-2) = 6`** (on the 8-core box). **Pure doc/research/config/site agents do NOT consume a cargo slot** (`build-cost.json.light_no_slot_surfaces`) — they parallelise freely (subject only to the API-rate-limit fleet cap), so only cargo-heavy LOCAL jobs count against the 6 cap. A MEDIUM bead may go LOCAL **if a cargo slot is free**, else it spills to EC2.
+- **HEAVY beads → EC2, bin-packed.** Place full feature builds / feature-matrix runs / heavy crates on the build farm via `scripts/ec2-buildfarm.sh`. **Bin-pack:** fill a warm/leased instance before provisioning another (several cheap CPU-bound builds can time-slice one instance — timing doesn't matter for a build). Prefer the smallest Graviton that fits and reuse a warm lease within its watchdog window rather than relaunching.
+- **Benchmarks → DEDICATED quiet instance.** A wall-clock-sensitive benchmark must own a **fresh, quiet** instance so co-tenant builds don't poison the timing. Never pack two measurements onto one box; you MAY share a *build* that feeds a measurement, never the measurement itself. **Every timing such a job produces is NON-canonical / work-box** — say so in the rationale and in `notes`; it must never arm a perf claim (the `sparq-perf-reviewer` hook independently enforces this downstream).
+- **Objective:** maximum parallelism per dollar — fill before provisioning, prefer warm leases, prefer the cheapest instance that fits.
+
+## HARD constraints (the safety guarantee — NOT the estimate)
+These are absolute. The estimate is advisory; these bound any mis-estimate. Treat a ceiling breach as **"do not place"**, never "place anyway":
+- **LOCAL cargo cap:** at most **`min(16, nproc-2) = 6`** cargo-heavy LOCAL jobs concurrently (doc/research/config/site agents excepted, per above).
+- **Build-farm instance cap:** at most **12** concurrent build-farm instances (`ec2-buildfarm.sh` `BUILDFARM_MAX_FLEET`, clamped 1..16, default 12 — it enforces this itself and will REFUSE a 13th; your plan must not *ask* for more). Account for any instances already running that the driver told you about.
+- **Cost ceiling:** cumulative tagged EC2 spend must stay **≤ $5/day**. If `costLeft` (≤ $5 minus today's spend) cannot cover the EC2 instances you'd request, do NOT place that EC2 work — leave those beads unplaced (note them) and let LOCAL work proceed. The farm also refuses a lease that would breach the ceiling; do not rely on that as your only guard — plan within it.
+- The farm is the **sole** authority on instances and enforces `--instance-initiated-shutdown-behavior terminate` + a ≤ 45-min watchdog + the `purpose=sparq-buildfarm` tag and **never touches prod (`i-090531b4ede8f2d3f`) or dev (`i-00f76802f345b6b77`)**. You request; it grants or refuses. Never plan to bypass it.
+
+Compute `ec2_instances_needed` honestly: count DEDICATED benchmark instances (one each) + ceil(packed-build minutes / a reasonable per-instance window) for shared builds, then **clamp the whole plan** so `(already-running + ec2_instances_needed) ≤ 12` and the implied spend ≤ `costLeft`. If the clamp drops beads, list them in `notes` as deferred-to-next-pass.
+
+## Cost estimate (advisory)
+`est_cost_usd` is a rough advisory figure: sum the EC2-instance-hours you'd request × the ~spot $/hr for the chosen Graviton (the design's cost math: arm64 spot ≈ $0.25/hr for a c7g.4xlarge in eu-west-2; smaller instances less). Round up. Mark it advisory in `notes`; the ≤ $5/day ceiling — not this estimate — is the hard guard.
+
+## Output schema (return EXACTLY this JSON, nothing else)
+```json
+{
+  "plan": [
+    {
+      "bead": "<bead-id>",
+      "crate": "<surface from the frontier line: crate short-name | site | server-auth | tag | (unscoped)>",
+      "tier": "light" | "heavy",
+      "placement": "local" | "ec2",
+      "est_minutes": <number>,
+      "rationale": "<one line: why this tier + placement; for a benchmark, the NON-canonical / dedicated-instance note>"
+    }
+  ],
+  "local_count": <number of beads placed local>,
+  "ec2_instances_needed": <number of build-farm instances this plan requests, within the cap>,
+  "est_cost_usd": <advisory rough USD for the EC2 portion of this plan>,
+  "notes": "<honest caveats: that the estimate is a fallible heuristic; any assumptions you made (nproc/spend); any beads deferred by a ceiling clamp; any benchmark timing NON-canonical reminder>"
+}
+```
+Notes on the schema: `tier` in the per-bead object collapses to the two placement-relevant buckets **`light`** (→ usually `local`) and **`heavy`** (→ `ec2`); a MEDIUM bead placed LOCAL because a slot was free is reported as `light`/`local` with the reason in `rationale`, and a MEDIUM bead spilled to EC2 is reported as `heavy`/`ec2`. `crate` carries the frontier's surface verbatim (it is not always a crate — it may be `site`/`server-auth`/a tag/`(unscoped)`). If the frontier is empty, return `{ "plan": [], "local_count": 0, "ec2_instances_needed": 0, "est_cost_usd": 0, "notes": "frontier empty — nothing to place" }`.
+
+## What you must NOT do
+- Do NOT launch or mutate anything — no `gh pr merge`, no `cargo`, no `aws`/`ec2-buildfarm.sh` invocation, no bead edits. You READ (`bd show`, `nproc`, `build-cost.json`, the frontier) and RETURN a plan.
+- Do NOT exceed the 12-instance cap or the ≤ $5/day ceiling in what you request — clamp and defer instead.
+- Do NOT bake any est_minutes or EC2 timing into docs or present it as canonical.
+- Do NOT re-dedupe the frontier or re-pick beads — `push-frontier.sh` already did conflict-collision + CPU-cap + epic exclusion; you only place what it handed you.
+- Do NOT pad the plan or invent beads to "look busy" — place exactly the frontier, honestly.
+
+[OPUS-4.8] Authored by Opus 4.8 (1M context); Fable unavailable — flag for re-review when Fable returns.

--- a/scripts/build-cost.json
+++ b/scripts/build-cost.json
@@ -1,0 +1,89 @@
+{
+  "_meta": {
+    "purpose": "Seed cost map read by the sparq-workload-triage agent (.claude/agents/sparq-workload-triage.md) to estimate a bead's compute TIER (light/medium/heavy) + rough est_minutes, for placing it LOCAL vs on the EC2 build farm.",
+    "marker": "[OPUS-4.8] authored by Opus 4.8 (1M context); Fable unavailable — flag for re-review when Fable returns.",
+    "HONESTY": "This is a FALLIBLE HEURISTIC, not a measurement. The est_minutes are rough work-box guesses (NON-canonical), seeded by hand from crate weight + typical full build/clippy/test time on the 8-core box, NOT from a controlled benchmark. They WILL mis-estimate (a one-line fix in a heavy crate looks heavy but is fast; a docs bead that regenerates a dashboard is heavier than it looks). The estimate is ADVISORY input to a bin-packer; the real safety guarantee is the HARD ceilings (LOCAL cargo cap min(16,nproc-2)=6, build-farm instance cap 12, <=$5/day cost ceiling, per-instance <=45min watchdog) — those bound the cost of any wrong guess. NEVER report any number here, or any timing an EC2/work-box lease produces, as a canonical performance result.",
+    "refinement": "Refine over time from observed cargo build/test wall-time on this box. Treat any update as advisory tuning, never as a published benchmark.",
+    "units": "est_minutes = rough wall-clock minutes for a full from-scratch build + clippy -D warnings + test in BOTH feature states on the work box. tier in {light, medium, heavy}.",
+    "tiers": {
+      "light": "docs / research / config / single-crate small change; no heavy Rust build (or a fast leaf crate). Place LOCAL, packed up to the cargo-slot cap. Pure doc/research agents do not consume a cargo slot.",
+      "medium": "a normal feature/bug on a mid-weight crate; one default-feature build+test. May be LOCAL if a cargo slot is free, else EC2.",
+      "heavy": "full feature build, feature-MATRIX run, or a benchmark. Place on EC2. A wall-clock-sensitive BENCHMARK gets a DEDICATED quiet instance (timings stay NON-canonical / work-box)."
+    },
+    "fallback": {
+      "tier": "medium",
+      "est_minutes": 20,
+      "note": "Used when a bead's surface/crate is not listed below — assume mid-weight and let the ceilings bound the risk."
+    }
+  },
+
+  "crates": {
+    "sparq-core":        { "tier": "medium", "est_minutes": 18, "note": "Hot path; a small change rebuilds the crate but tests are fast. Full-feature or SIMD/dict-spill/mmap work trends heavy — bump via heavy_signals." },
+    "sparq-engine":      { "tier": "heavy",  "est_minutes": 30, "note": "Large query engine; full feature build + test is the dominant local cost. Feature-matrix => heavy on EC2." },
+    "sparq-parse":       { "tier": "medium", "est_minutes": 15, "note": "Parser crate; parallel-parse tweaks are mid-weight." },
+    "sparq-canon":       { "tier": "light",  "est_minutes": 10, "note": "Canonicalisation leaf crate." },
+    "sparq-cli":         { "tier": "medium", "est_minutes": 16, "note": "Binary crate; links the engine — a clean build is mid-weight." },
+    "sparq-conformance": { "tier": "medium", "est_minutes": 22, "note": "SPARQL conformance harness; the test suite itself is the cost." },
+    "sparq-fedplan":     { "tier": "medium", "est_minutes": 18, "note": "Federation planner." },
+    "sparq-geo":         { "tier": "medium", "est_minutes": 16, "note": "GeoSPARQL crate." },
+    "sparq-gpu":         { "tier": "heavy",  "est_minutes": 30, "note": "GPU offload; heavy toolchain/deps. Documented-heavy; verify on first run." },
+    "sparq-hdt":         { "tier": "medium", "est_minutes": 18, "note": "HDT archive loader; pulls the hdt crate." },
+    "sparq-introspect":  { "tier": "light",  "est_minutes": 12, "note": "Introspection/metadata leaf crate." },
+    "sparq-mpc":         { "tier": "heavy",  "est_minutes": 30, "note": "MPC crate (honest-majority semi-honest only; see SECURITY.md). Crypto deps + circuits => heavy." },
+    "sparq-nlq":         { "tier": "medium", "est_minutes": 18, "note": "Natural-language-to-SPARQL; may pull an LLM client dep." },
+    "sparq-policy":      { "tier": "medium", "est_minutes": 16, "note": "Policy/authorization crate." },
+    "sparq-prov":        { "tier": "medium", "est_minutes": 16, "note": "Provenance crate." },
+    "sparq-py":          { "tier": "medium", "est_minutes": 20, "note": "PyO3 bindings; excluded from the clippy gate (--exclude sparq-py) but its own build/test is mid-weight." },
+    "sparq-reason":      { "tier": "medium", "est_minutes": 20, "note": "Reasoning crate; rule eval tests are mid-weight." },
+    "sparq-rsp":         { "tier": "medium", "est_minutes": 18, "note": "RDF Stream Processing crate." },
+    "sparq-serve":       { "tier": "heavy",  "est_minutes": 26, "note": "Server runtime (read scheduler etc.); contended surface — serialise (<=1 in flight)." },
+    "sparq-server":      { "tier": "heavy",  "est_minutes": 26, "note": "HTTP server; the http.rs AUTH path is the hot rebase seam — CONTENDED, serialise to <=1 in flight (push-frontier 'server-auth' lane)." },
+    "sparq-shacl":       { "tier": "medium", "est_minutes": 20, "note": "SHACL validation crate." },
+    "sparq-sim":         { "tier": "medium", "est_minutes": 18, "note": "Similarity crate." },
+    "sparq-solid":       { "tier": "medium", "est_minutes": 20, "note": "Solid integration; ACP/WAC modelling. Not the server auth path despite 'auth'-ish vocab." },
+    "sparq-text":        { "tier": "medium", "est_minutes": 18, "note": "Full-text-search crate." },
+    "sparq-vectors":     { "tier": "heavy",  "est_minutes": 30, "note": "Vector/ANN crate; full-feature (approx-ann,filtered-ann,vec-predicate) build + ANN tests are heavy. Any vectors benchmark => DEDICATED EC2 instance." },
+    "sparq-wasm":        { "tier": "heavy",  "est_minutes": 28, "note": "WASM bundle build (wasm-pack / tier-* bundles); separate toolchain => heavy." },
+    "sparq-zk":          { "tier": "heavy",  "est_minutes": 35, "note": "ZK crate (v1 verifier pending external audit; see SECURITY.md). Noir/Barretenberg circuit build is heavy and slow." },
+    "sparq-zk-compose":  { "tier": "heavy",  "est_minutes": 35, "note": "ZK composition crate; circuit composition build is heavy." },
+    "sparq-bench":       { "tier": "heavy",  "est_minutes": 40, "note": "Benchmark harness. Any RUN is wall-clock-sensitive => a DEDICATED quiet EC2 instance; timings are NON-canonical (work-box / build-farm, not a CI-runner result)." }
+  },
+
+  "surfaces": {
+    "_note": "Non-crate conflict surfaces emitted by scripts/push-frontier.sh. Used when a bead's surface column is one of these rather than a crate short-name.",
+    "site":        { "tier": "light",  "est_minutes": 12, "note": "Next.js static-export site/. Static export + lint + typecheck is light-to-mid; not a cargo build. LOCAL. Only ONE site branch in flight at a time." },
+    "server-auth": { "tier": "heavy",  "est_minutes": 26, "note": "The sparq-server http.rs auth path — the hot rebase seam. CONTENDED: serialise to <=1 in flight." },
+    "docs":        { "tier": "light",  "est_minutes": 8,  "note": "Documentation. No cargo slot consumed; place LOCAL and pack freely." },
+    "research":    { "tier": "light",  "est_minutes": 10, "note": "research/ design records. No cargo slot consumed; LOCAL." },
+    "cert":        { "tier": "light",  "est_minutes": 10, "note": "Compliance/certification doc + evidence work (compliance/, supply-chain). Mostly doc/config; LOCAL." },
+    "deps":        { "tier": "medium", "est_minutes": 16, "note": "Dependency bump; a rebuild + test is mid-weight, but a workspace-wide bump can trend heavy." },
+    "ci":          { "tier": "light",  "est_minutes": 10, "note": "CI/workflow/.github change; YAML + script work, LOCAL." }
+  },
+
+  "bead_type": {
+    "_note": "Coarse adjustment by bd issue_type / leading title prefix. Combined with the crate/surface tier — the HEAVIER of the two wins, except docs/research/chore/spike pull toward light when on a light surface.",
+    "docs":    { "lean": "light",  "note": "Documentation work — no cargo slot." },
+    "research":{ "lean": "light",  "note": "research/ design record — no cargo slot." },
+    "chore":   { "lean": "light",  "note": "Config / tidy-up." },
+    "spike":   { "lean": "light",  "note": "Exploratory; usually small." },
+    "bug":     { "lean": "crate",  "note": "Inherit the crate tier; a fix can be small but the rebuild cost is the crate's." },
+    "feature": { "lean": "crate",  "note": "Inherit the crate tier; full-feature features trend heavy." },
+    "epic":    { "lean": "skip",   "note": "UMBRELLA, never placed directly — push-frontier already excludes epics; if one appears, decompose, do not place." }
+  },
+
+  "heavy_signals": {
+    "_note": "Title/scope tokens that FORCE heavy regardless of the base crate tier. Case-insensitive substring match on the bead title.",
+    "tokens": [
+      "benchmark", "bench", "feature-matrix", "feature matrix", "full-feature", "all-features",
+      "matrix", "sweep", "fuzz", "kani", "miri", "asan", "sanitizer", "soak", "wasm bundle",
+      "circuit", "proving", "prover"
+    ],
+    "benchmark_tokens": [
+      "benchmark", "bench", "throughput", "latency", "sweep", "soak"
+    ],
+    "benchmark_note": "A bead matching a benchmark_token is WALL-CLOCK-SENSITIVE: dedicate a fresh quiet EC2 instance (do NOT co-tenant it with a build), and label every timing it produces NON-canonical / work-box — it is not a CI-runner controlled-quiet-box result and must never arm a perf claim."
+  },
+
+  "light_no_slot_surfaces": ["docs", "research", "cert", "ci", "site"],
+  "_light_no_slot_note": "Pure doc/research/config/site agents do NOT consume a cargo-heavy LOCAL slot (they don't run a heavy cargo build), so they parallelise freely up to the API-rate-limit fleet cap — only cargo-heavy LOCAL jobs count against the min(16,nproc-2)=6 ceiling."
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — `[OPUS-4.8]` (authored by Opus 4.8, 1M context; Fable unavailable, flag for re-review when Fable returns).

**Phase 2 of the autonomous scheduler** (design: `research/autonomous-scheduler-design.md` §4–5, PR #423). The reusable **WORKLOAD-TRIAGE / placement** component + its cost seed. **No scheduler loop, no launching anything** — just the component. Touches ONLY the two new files.

## What this adds

### 1. `.claude/agents/sparq-workload-triage.md` (new agent)
- Frontmatter `name: sparq-workload-triage` / `description` / `model: opus` / `tools: Bash, Read, Grep, Glob` — matches the other `sparq-*` agent defs.
- **Input:** the lines `scripts/push-frontier.sh` prints (`<bead-id>  <surface>  <title>`; surface = crate short-name / `site` / `server-auth` / a tag / `(unscoped)`). The frontier is already conflict-deduped + CPU-capped + epic-excluded by `push-frontier.sh`; the agent only places it.
- **Heuristic:** tier from `scripts/build-cost.json` (crate/surface) + bead-type lean + `heavy_signals` tokens. Stated plainly, repeatedly, as a **fallible heuristic** — the agent caveats it in `notes` every time.
- **Policy:** LIGHT → LOCAL, packed up to `min(16, nproc-2) = 6` (pure doc/research/config/site agents don't consume a cargo slot, parallelise freely). HEAVY → EC2 via `ec2-buildfarm.sh`, **bin-packed** (fill a warm lease before provisioning another); **dedicated quiet instance per wall-clock-sensitive benchmark** (timings remain **NON-canonical / work-box** — never arm a perf claim).
- **HARD ceilings (the safety guarantee, not the estimate):** ≤ 12 build-farm instances (`BUILDFARM_MAX_FLEET`), ≤ $5/day, the CPU cap. A breach = "do not place" (clamp + defer), never "place anyway".
- **Output:** the exact JSON schema `{ plan: [{ bead, crate, tier, placement, est_minutes, rationale }], local_count, ec2_instances_needed, est_cost_usd, notes }`.
- Encodes the shared SPARQ contract: honesty / no-overclaim / opt-in / gates-stay-intact / the privacy-claims caveat for any ZK/MPC bead. **It places; it never launches** (no `gh pr merge`, no `cargo`, no `aws`).

### 2. `scripts/build-cost.json` (new seed)
- Fallible-heuristic cost map the triage agent reads: per-crate tier+`est_minutes` for **all 29 crates**, per-surface tiers (`site`/`server-auth`/`docs`/`research`/`cert`/`deps`/`ci`), `bead_type` leans, and `heavy_signals` tokens.
- `_meta.HONESTY` states plainly these are **NON-canonical** hand-seeded work-box guesses, advisory to a bin-packer whose **ceilings** are the real guarantee; refined over time. Examples per the brief: docs/research/site = light; `sparq-core`/`sparq-parse` = medium; `sparq-engine`/`sparq-vectors` full-feature + any benchmark = heavy.

## Gates (all run locally)
- `jq -e . scripts/build-cost.json` → **valid JSON** (29 crates, 7 top-level keys).
- `python3 scripts/check-skill-frontmatter.py .claude/agents/sparq-workload-triage.md` → **exit 0** (only the advisory `name != directory 'agents'` warning, shared by every `sparq-*` agent — these live in `agents/`, not a per-name dir).
- **No workflow YAML touched** → the `ci-summary` gate aggregator is structurally unchanged (zero new/removed check-runs; nothing "expected but missing"). This leg does not gate because there is no new check.
- typos / privacy-claims clean (and `.claude/agents/**` + non-`.md` `.json` are out of those gates' scan scope anyway).

## Compliance / honesty note
This closes the Phase-2 deliverable as **a placement *component*, not a running scheduler** — honest scope. The estimate is explicitly fallible; the hard ceilings bound the blast radius.

**Auto-merge intentionally NOT armed** (per the task — orchestrator/maintainer arms).