### PR TITLE
fix(ci): sparq-site.md YAML colon + extend skill-frontmatter gate to .claude/agents (sq-tstv)

### DIFF
--- a/.claude/agents/sparq-site.md
+++ b/.claude/agents/sparq-site.md
@@ -1,6 +1,6 @@
 ---
 name: sparq-site
-description: Implements front-end work in the sparq Next.js site (site/) — the statically-exported GitHub Pages app: benchmarks UI, /papers, the /try SPARQL playground, surface/showcase pages. Use for any site/ task. Gates on a green static export + lint + typecheck.
+description: "Implements front-end work in the sparq Next.js site (site/) — the statically-exported GitHub Pages app: benchmarks UI, /papers, the /try SPARQL playground, surface/showcase pages. Use for any site/ task. Gates on a green static export + lint + typecheck."
 model: opus
 ---
 

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -134,13 +134,14 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   skill-frontmatter:
-    # [OPUS-4.8] HARD gate (bead sq-56im): every skills/**/SKILL.md must have YAML
-    # frontmatter that actually parses (yaml.safe_load) and carries non-empty string
-    # `name` + `description`. Catches the GitHub "mapping values are not allowed in
-    # this context" render error caused by an UNQUOTED colon in a description value
-    # (reported on full-text-search/SKILL.md). The validation itself is deterministic
-    # (no network); the one network touch is the version-pinned `pip install` of PyYAML
-    # below. Still a HARD gate. [OPUS-4.8]
+    # [OPUS-4.8] HARD gate (beads sq-56im + sq-tstv): every skills/**/SKILL.md AND
+    # every .claude/agents/*.md must have YAML frontmatter that actually parses
+    # (yaml.safe_load) and carries non-empty string `name` + `description`. Catches the
+    # GitHub "mapping values are not allowed in this context" render error caused by an
+    # UNQUOTED colon in a description value (reported on full-text-search/SKILL.md, and
+    # later on the sparq-site.md agent's "GitHub Pages app: …" — hence the agent-file
+    # coverage). The validation itself is deterministic (no network); the one network
+    # touch is the version-pinned `pip install` of PyYAML below. Still a HARD gate. [OPUS-4.8]
     name: skill-frontmatter (Agent-Skills YAML)
     runs-on: ubuntu-latest
     steps:
@@ -156,8 +157,14 @@ jobs:
         # sha256 against .github/requirements/docs-quality.txt before use. PyYAML has no
         # runtime deps, so that file is the full closure. See its header to bump/regenerate.
         run: pip install --require-hashes -r .github/requirements/docs-quality.txt
-      - name: Validate SKILL.md frontmatter
+      - name: Validate SKILL.md + .claude/agents frontmatter
         run: python3 scripts/check-skill-frontmatter.py
+      # [OPUS-4.8] sq-tstv: hermetic self-test of the gate's classification — an
+      # unquoted-colon agent description must FAIL, a quoted one must PASS, and the
+      # default glob must cover both the skills/ and .claude/agents/ families. Runs in
+      # this same HARD job so a coverage regression also fails the ci-summary gate.
+      - name: Self-test the skill-frontmatter gate
+        run: python3 scripts/tests/test_skill_frontmatter.py
 
   privacy-claims:
     # [OPUS-4.8] HARD gate (bead sq-toze.35 + sq-qhy4): the empirical-honesty mandate

--- a/scripts/check-skill-frontmatter.py
+++ b/scripts/check-skill-frontmatter.py
@@ -110,19 +110,46 @@ def check_file(path: str) -> tuple[list[str], list[str]]:
             warnings.append(
                 f"name '{name}' is not lowercase-hyphen (Agent-Skills convention)"
             )
-        # The repo root skills/SKILL.md is an index, not a surface skill, so its
-        # directory is `skills` rather than the skill name — only check nested ones.
+        # Where `name` is expected to live differs by family:
+        #   * skills/<surface>/SKILL.md — `name` should equal the parent directory
+        #     (<surface>). The repo-root skills/SKILL.md is an index whose directory
+        #     is `skills`, so it's exempt.
+        #   * .claude/agents/<role>.md — these all sit in one `agents/` directory, so
+        #     `name` should equal the FILE stem (<role>), not the directory.
         parent = os.path.basename(os.path.dirname(os.path.abspath(path)))
-        if parent != "skills" and name != parent:
+        if parent == "agents":
+            stem = os.path.splitext(os.path.basename(path))[0]
+            if name != stem:
+                warnings.append(f"name '{name}' != file '{stem}'")
+        elif parent != "skills" and name != parent:
             warnings.append(f"name '{name}' != directory '{parent}'")
 
     return errors, warnings
 
 
+def default_paths() -> list[str]:
+    """Every frontmatter surface GitHub renders + parses (bead sq-tstv).
+
+    Two families share the exact same unquoted-colon render hazard:
+      * skills/**/SKILL.md     — the Agent-Skills surface skills.
+      * .claude/agents/*.md    — the role-specific subagent definitions; their
+        YAML frontmatter (name/description/model) is parsed identically, and an
+        unquoted colon in a `description:` value breaks it the same way (this
+        gate was extended after sparq-site.md shipped a `GitHub Pages app: …`
+        colon).
+    """
+    return sorted(
+        glob.glob("skills/**/SKILL.md", recursive=True)
+        + glob.glob(".claude/agents/*.md")
+    )
+
+
 def main() -> int:
-    paths = sys.argv[1:] or sorted(glob.glob("skills/**/SKILL.md", recursive=True))
+    paths = sys.argv[1:] or default_paths()
     if not paths:
-        print("check-skill-frontmatter: no SKILL.md files found under skills/.")
+        print(
+            "check-skill-frontmatter: no SKILL.md / .claude/agents/*.md files found."
+        )
         return 0
 
     n_bad = 0

--- a/scripts/tests/test_skill_frontmatter.py
+++ b/scripts/tests/test_skill_frontmatter.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Hermetic tests for scripts/check-skill-frontmatter.py (bead sq-tstv).
+#
+# Locks in the two things sq-tstv changed:
+#   1. The default glob now covers BOTH skills/**/SKILL.md AND .claude/agents/*.md,
+#      so an unquoted colon in a subagent `description:` value fails the gate the
+#      same way it does for a SKILL.md (the sparq-site.md "GitHub Pages app: …"
+#      render bug that motivated this bead).
+#   2. For .claude/agents/<role>.md the name-match heuristic checks `name` against
+#      the FILE stem (<role>), not the parent directory (which is always `agents`),
+#      so the valid agent files do not emit spurious advisory warnings.
+#
+# Hermetic w.r.t. git/network: drives the script's pure check_file() against
+# FIXTURE files in a tempdir, and exercises default_paths() by chdir-ing into a
+# fixture tree. No subprocess, no live repo state. Requires PyYAML (same dep the
+# gate itself needs).
+#
+# Run:  python3 scripts/tests/test_skill_frontmatter.py
+# (stdlib + PyYAML; also discoverable by `pytest`.)
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / filename)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+fm = _load("check_skill_frontmatter", "check-skill-frontmatter.py")
+
+
+# Frontmatter blocks (without and with the unquoted-colon defect). The colon-space
+# inside an unquoted scalar is exactly what makes PyYAML read a nested mapping key.
+GOOD_AGENT = (
+    "---\n"
+    "name: my-agent\n"
+    'description: "Does the X thing: then the Y thing. Use for X."\n'
+    "model: opus\n"
+    "---\n"
+    "body\n"
+)
+BAD_AGENT_UNQUOTED_COLON = (
+    "---\n"
+    "name: my-agent\n"
+    "description: Does the X thing: then the Y thing. Use for X.\n"
+    "model: opus\n"
+    "---\n"
+    "body\n"
+)
+GOOD_SKILL = "---\nname: foo\ndescription: A foo skill.\n---\nbody\n"
+
+
+def _write(d: Path, rel: str, text: str) -> str:
+    p = d / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return str(p)
+
+
+class CheckFileTest(unittest.TestCase):
+    def test_unquoted_colon_in_agent_description_is_an_error(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t)
+            path = _write(d, ".claude/agents/my-agent.md", BAD_AGENT_UNQUOTED_COLON)
+            errors, _ = fm.check_file(path)
+            self.assertTrue(
+                any("YAML parse error" in e for e in errors),
+                f"expected a YAML parse error, got {errors!r}",
+            )
+
+    def test_quoted_agent_description_is_clean(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t)
+            path = _write(d, ".claude/agents/my-agent.md", GOOD_AGENT)
+            errors, warnings = fm.check_file(path)
+            self.assertEqual(errors, [], f"unexpected errors: {errors!r}")
+            # name == file stem ('my-agent'), so no name-mismatch warning, and the
+            # parent dir 'agents' must NOT trigger the directory-match heuristic.
+            self.assertEqual(warnings, [], f"unexpected warnings: {warnings!r}")
+
+    def test_agent_name_mismatch_warns_against_file_stem_not_directory(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t)
+            # name 'other' != file stem 'my-agent' -> advisory warning (not error),
+            # and it must reference the FILE, not the 'agents' directory.
+            text = GOOD_AGENT.replace("name: my-agent", "name: other")
+            path = _write(d, ".claude/agents/my-agent.md", text)
+            errors, warnings = fm.check_file(path)
+            self.assertEqual(errors, [], f"unexpected errors: {errors!r}")
+            self.assertTrue(
+                any("!= file 'my-agent'" in w for w in warnings),
+                f"expected a file-stem mismatch warning, got {warnings!r}",
+            )
+            self.assertFalse(
+                any("directory" in w for w in warnings),
+                f"agent files must not warn against the directory, got {warnings!r}",
+            )
+
+    def test_skill_directory_match_still_warns(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t)
+            # A nested skill whose name != its surface directory still warns.
+            text = GOOD_SKILL.replace("name: foo", "name: bar")
+            path = _write(d, "skills/foo/SKILL.md", text)
+            _errors, warnings = fm.check_file(path)
+            self.assertTrue(
+                any("!= directory 'foo'" in w for w in warnings),
+                f"expected a directory mismatch warning, got {warnings!r}",
+            )
+
+
+class DefaultPathsTest(unittest.TestCase):
+    def test_default_glob_covers_both_families(self):
+        prev = os.getcwd()
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t)
+            _write(d, "skills/foo/SKILL.md", GOOD_SKILL)
+            _write(d, ".claude/agents/my-agent.md", GOOD_AGENT)
+            # A non-matching .md in agents-adjacent locations must NOT be picked up.
+            _write(d, ".claude/notes.md", "irrelevant\n")
+            try:
+                os.chdir(d)
+                paths = fm.default_paths()
+            finally:
+                os.chdir(prev)
+            self.assertIn("skills/foo/SKILL.md", paths)
+            self.assertIn(".claude/agents/my-agent.md", paths)
+            self.assertNotIn(".claude/notes.md", paths)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-tstv** (`infra/ci`: `.claude/agents` + skill-frontmatter gate).

## Problem
The `sparq-site` subagent definition (`.claude/agents/sparq-site.md`) shipped a `description:` value with an **unquoted colon**:

```yaml
description: Implements front-end work in the sparq Next.js site (site/) — the statically-exported GitHub Pages app: benchmarks UI, …
```

YAML reads the second `: ` as a nested mapping key, so GitHub renders the frontmatter as the **"mapping values are not allowed in this context"** error. The existing `skill-frontmatter` HARD gate only globbed `skills/**/SKILL.md`, so it never inspected the `.claude/agents/*.md` family — despite those files carrying the identical hazard.

## Change
1. **`.claude/agents/sparq-site.md`** — quote the `description` value (the only broken agent file; the rest already parse).
2. **`scripts/check-skill-frontmatter.py`** — extend the default glob to cover **both** `skills/**/SKILL.md` and `.claude/agents/*.md` (new `default_paths()`). The advisory name-match heuristic now knows that for `.claude/agents/<role>.md` the expected `name` is the **file stem** (`<role>`), not the `agents/` directory — so valid agent files emit no spurious warnings.
3. **`.github/workflows/docs-quality.yml`** — rename the validate step, refresh the comment (beads sq-56im + sq-tstv), and add a **hermetic self-test** step in the same HARD job.
4. **`scripts/tests/test_skill_frontmatter.py`** (new) — locks in: an unquoted-colon agent description must FAIL, a quoted one must PASS, the file-stem name heuristic, and that the default glob covers both families.

## Gate (docs/CI — no Rust crate / public API touched)
- `docs-quality.yml` parses as valid YAML.
- `check-skill-frontmatter.py` (default glob): **35/35 valid, 0 broken, 0 warnings** — was 1 broken before this PR.
- Gate self-test: **5/5 pass**.
- `check-privacy-claims.sh` + its self-test (32 cases): **green** (predicate-form soundness coverage holds).
- G2 public-api→SKILL.md rule: **N/A** — no public API changed.

## Honesty
Scoped exactly to the bead: one real YAML defect fixed, the gate's blind spot closed with a regression test. No no-op, no scope creep into the other agent files (they already parse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)