### PR TITLE
docs: internal-stub READMEs for 5 publish=false crates (sq-4kr5)

### DIFF
--- a/crates/sparq-bench/README.md
+++ b/crates/sparq-bench/README.md
@@ -1,0 +1,24 @@
+<!-- [OPUS-4.8] sq-4kr5: internal-stub README for a publish=false crate. -->
+# sparq-bench
+
+The **benchmark + differential harness** for [sparq](../../README.md): it runs
+the same dataset and queries through `sparq` and through
+[Oxigraph](https://github.com/oxigraph/oxigraph) (a mature, independent Rust
+SPARQL engine), cross-checks that both return the same number of solutions, and
+reports load/query timings and peak memory.
+
+Why it exists: it serves a correctness role as well as a speed one — the
+solution-count cross-check against an independent implementation is a cheap,
+continuous oracle that catches engine regressions, while the timings feed the
+benchmarks dashboard.
+
+> **Internal tooling — not published** to crates.io (`publish = false`). Run it
+> as a workspace binary; it is not a library. Measured numbers belong in the
+> [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench), never baked
+> into docs.
+
+Contributing: [`AGENTS.md`](../../AGENTS.md).
+
+## License
+
+[MIT](../../LICENSE).

--- a/crates/sparq-conformance/README.md
+++ b/crates/sparq-conformance/README.md
@@ -1,0 +1,25 @@
+<!-- [OPUS-4.8] sq-4kr5: internal-stub README for a publish=false crate. -->
+# sparq-conformance
+
+The **W3C conformance harness** for [sparq](../../README.md): it runs the
+official test suites against the engine and reports a per-suite
+pass/fail/skip scoreboard, gated in CI by a pass-count ratchet. Three binaries
+sit on shared manifest-walking / result-comparison machinery:
+
+- `sparq-conformance` — the W3C SPARQL suites (query/update evaluation + syntax).
+- `sparq-inference-conformance` — the reasoning suites (RDF Semantics, OWL 2 RL,
+  N3, SPARQL entailment regimes) run against `sparq-reason`.
+- `sparq-conformance-scoreboard` — the consolidated index of every conformance
+  ratchet across the workspace (SPARQL, inference, W3C SHACL, OGC GeoSPARQL).
+
+Why it exists: it is the regression oracle that turns "is sparq spec-conformant?"
+into a number CI can ratchet upward and never let slip.
+
+> **Internal dev-only harness — not published** to crates.io
+> (`publish = false`). Test data is fetched by `scripts/fetch-conformance.sh`.
+
+Contributing: [`AGENTS.md`](../../AGENTS.md).
+
+## License
+
+[MIT](../../LICENSE).

--- a/crates/sparq-parse/README.md
+++ b/crates/sparq-parse/README.md
@@ -1,0 +1,29 @@
+<!-- [OPUS-4.8] sq-4kr5: internal-stub README for a publish=false crate. -->
+# sparq-parse
+
+**Compressed serialization of query results** for [sparq](../../README.md):
+chunk-at-a-time gzip / zstd encoding of serialized result chunks, built around
+one format property — *multi-member gzip and multi-frame zstd are valid single
+streams*.
+
+Why it exists: each serialized chunk is compressed as an independent gzip member
+/ zstd frame, and the members are concatenated in order. The result decodes as
+**one stream with stock decoders** (browser `Content-Encoding: gzip`,
+`MultiGzDecoder`, `gzip -d`, the `zstd` CLI), so chunks can be compressed in
+parallel as they are produced — compression overlaps serialization instead of
+following it, and the first bytes hit the wire sooner.
+
+Hard constraint: this crate must **not** enter `sparq-wasm`'s dependency graph
+(flate2 / zstd / rayon stay out of the browser bundle).
+
+> **Internal crate — not on crates.io** (`publish = false`). The design is gated
+> on a measured baseline; it is consumed inside the workspace, not as a
+> standalone public API.
+
+Design + baseline:
+[`research/custom-parsers-D4-compressed-serialization.md`](../../research/custom-parsers-D4-compressed-serialization.md).
+Contributing: [`AGENTS.md`](../../AGENTS.md).
+
+## License
+
+[MIT](../../LICENSE).

--- a/crates/sparq-serve/README.md
+++ b/crates/sparq-serve/README.md
@@ -1,0 +1,27 @@
+<!-- [OPUS-4.8] sq-4kr5: internal-stub README for a publish=false crate. -->
+# sparq-serve
+
+The **concurrent-serving core** of [sparq](../../README.md): a lock-free
+*generation ring* — an arc-swapped chain of immutable store snapshots with
+bounded retention and per-pod epoch vectors — plus the single **sequenced
+writer** with group-commit batching that publishes those snapshots.
+
+Why it exists: readers load the current generation in tens of nanoseconds and
+**never block the writer**, and the writer **never waits for readers** or
+reclaims in place — old generations are freed by ordinary `Arc` drop. This
+replaced the double-buffered snapshot scheme whose pinned-snapshot writer stalls
+and reclaim-poll degradation motivated the redesign.
+
+The crate is **sync, runtime-agnostic, and library-first**: it exposes no HTTP
+or async-runtime types (consumers such as `sparq-server` wrap it), and it must
+never enter `sparq-wasm`'s dependency graph.
+
+> **Internal crate — not published** to crates.io (`publish = false`). It is
+> wrapped by `sparq-server`; there is no standalone public API surface.
+
+Design: [`research/concurrent-serving.md`](../../research/concurrent-serving.md) §6.
+Contributing: [`AGENTS.md`](../../AGENTS.md).
+
+## License
+
+[MIT](../../LICENSE).

--- a/crates/sparq-zk/README.md
+++ b/crates/sparq-zk/README.md
@@ -1,0 +1,25 @@
+<!-- [OPUS-4.8] sq-4kr5: internal-stub README for a publish=false crate. -->
+# sparq-zk
+
+The **engine-side ZK foundation** for [sparq](../../README.md): the off-circuit
+**commitment pipeline** and the **zk-trace seam** behind the
+[derived-credentials design](../../research/zkp-query-proofs-plan.md). RDFC10
+canonicalization, Poseidon2-BN254 per-graph commitments, graph-scoped term/triple
+field encoding, issuer signatures, and the `<urn:sparq:zk>` registry plumbing.
+
+Why it exists: everything here is off-circuit Rust whose outputs (BN254 field
+elements, leaf orderings, witness input sets) are exactly what the later Noir
+circuits and proof composition will consume — bit-compatible with
+`noir-lang/poseidon` and validated against the W3C `rdf-canon` test suite.
+
+> **Internal crate — not published** to crates.io (`publish = false`). Circuits
+> and proof composition are later deliverables; **no soundness or privacy claim**
+> is made for this pipeline today (see the ZK verifier soundness status in the
+> repo's security records).
+
+Design: [`research/zkp-query-proofs-plan.md`](../../research/zkp-query-proofs-plan.md).
+Contributing: [`AGENTS.md`](../../AGENTS.md).
+
+## License
+
+[MIT](../../LICENSE).


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Implements bead **sq-4kr5** (child of the docs overhaul **sq-9jw5**): add the short internal-stub README the doc-overhaul design mandates for every `publish = false` crate — *title + what/why + "internal, not published" + AGENTS link, no badges, no perf numbers, <=30 lines*.

## What

Adds five missing stub READMEs:

| Crate | One-liner |
|---|---|
| `sparq-serve` | concurrent-serving core (lock-free generation ring + single sequenced writer) |
| `sparq-parse` | compressed serialization of query results (multi-member gzip / multi-frame zstd) |
| `sparq-zk` | engine-side ZK commitment pipeline + zk-trace seam (off-circuit) |
| `sparq-conformance` | W3C conformance harness + cross-workspace scoreboard |
| `sparq-bench` | benchmark + Oxigraph-differential harness |

## Honesty note — only 5 of the 6 named crates

The bead names six crates (serve/parse/mpc/zk/conformance/bench). **`sparq-mpc` is deliberately left untouched**: it already carries a substantial, load-bearing security-posture README (per-pair leakage tiers, threshold-verdict decomposition, constant-time posture, the `sq-qhy4` not-yet-sound caveats). Replacing that with a 15-line stub would *destroy* auditor-facing content and regress the crate's docs — out of scope for a docs-tidy PR. The other five had no README at all; those are the gap this bead closes.

## Gates run (all green)

- **readme-template** (`scripts/check-readme-template.py`) — all 5 recognized as stubs, ≤30 lines, no section requirement: `0 deviation(s)`.
- **no-perf-numbers** (`scripts/check-no-perf-numbers.py`) — `0 finding(s)` in the new files (pre-existing findings in `sparq-rsp`/`skills/cli` are out of scope, tracked by sibling bead sq-puyy).
- **privacy-claims honesty gate** (`scripts/check-privacy-claims.sh`, predicate-form soundness included) — `OK`. The `sparq-zk` stub explicitly states *no soundness or privacy claim is made* (sq-qhy4 pending).
- **markdownlint-cli2** (repo `.markdownlint-cli2.jsonc`) — `0 error(s)`.

Docs-only: no crate `include_str!`s its README, so there is no Rust API-surface or doctest impact — the cargo build/clippy/test gate is not engaged by this change. G2 (public-api→SKILL.md) N/A (no public API touched).

[OPUS-4.8]

🤖 Generated with [Claude Code](https://claude.com/claude-code)