### PR TITLE
ci(typos): allowlist recurring SPARQL-keyword false-positives (sq-hyzq)

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -108,6 +108,14 @@ jobs:
             ':!:vendor/**' ':!:**/vendor/**' | sort -u > /tmp/doc-md.txt
           echo "Scanning $(wc -l < /tmp/doc-md.txt) markdown file(s) for typos:"
           typos --file-list /tmp/doc-md.txt
+      # [OPUS-4.8] sq-hyzq: both-direction self-test for the _typos.toml allow-list — the
+      # recurring "ALL-CAPS SPARQL keyword + lowercase suffix" false-positives (DELETEd,
+      # INSERTed, "3 OPTIONALs", invokable, …) must stay SUPPRESSED, AND a genuine ALL-CAPS
+      # misspelling + ordinary lowercase typos must STILL fire (so the regex keeps its
+      # teeth). Hermetic (temp fixtures, no repo scan, no network); runs in this same HARD
+      # job so an allow-list over- or under-reach also fails the ci-summary gate.
+      - name: Self-test the typos allow-list (both directions)
+        run: bash scripts/tests/test_typos_allowlist.sh
 
   internal-links:
     name: internal-links (lychee --offline)

--- a/_typos.toml
+++ b/_typos.toml
@@ -30,7 +30,19 @@ extend-exclude = [
 # flags the suffix (e.g. `sq-iy3p` → `iy3p`/`iy`, `sq-1gir` → `gir`). Beads are
 # referenced by the dozen in compliance/research docs, so per-token allowlisting does
 # not scale — match the whole bead-id token shape instead. [OPUS-4.8]
-extend-ignore-re = ["\\bsq-[0-9a-z]{3,}\\b"]
+#
+# [OPUS-4.8] (bead sq-hyzq) Ignore the recurring "ALL-CAPS SPARQL keyword + lowercase
+# English suffix" false-positive family: DELETEd, INSERTed, SELECTed, CONSTRUCTed,
+# DESCRIBEd, CLEARed, LOADed, UNIONed, MATCHed, "3 OPTIONALs", … Authors write these in
+# prose all the time; typos splits at the case boundary and flags the keyword-minus-tail
+# (DELET→DELETE, OPTIONA→OPTIONAL) or the dangling 3-char fragment (Ded/Ned), forcing a
+# pointless reword round-trip on every doc PR. One regex pins the whole shape instead of
+# enumerating dozens of fragments. It is deliberately narrow — it matches ONLY a run of
+# >=3 capitals immediately followed by 1-3 lowercase letters with no break, so a genuine
+# ALL-CAPS misspelling (e.g. `RECIEVE`) and ordinary lowercase typos (`teh`, `hte`) STILL
+# fire and the gate keeps its teeth. Verified across the whole tree: every token this
+# newly silences is a keyword-suffix split, zero real misspellings.
+extend-ignore-re = ["\\bsq-[0-9a-z]{3,}\\b", "\\b[A-Z]{3,}[a-z]{1,3}\\b"]
 
 [default.extend-identifiers]
 iy3p = "iy3p"            # [OPUS-4.8] bead id `sq-iy3p` — typos splits on `-`, flags "iy"->"it"
@@ -66,6 +78,7 @@ Rotat = "Rotat"         # "RotatE" KG-embedding model name (wraps to "Rotat")
 criticals = "criticals"  # audit jargon: "the audit's criticals"
 unparseable = "unparseable" # accepted variant spelling used in skills docs
 unstalled = "unstalled"  # "proceeding unstalled" (= not stalled) — intentional
+invokable = "invokable"  # [OPUS-4.8] (sq-hyzq) accepted variant of "invocable" used in CLI/API docs (e.g. "invokable from the CLI") — recurring typos false-positive
 # --- domain acronyms / dataset + crypto names ---
 SME = "SME"              # [OPUS-4.8] "Subject Matter Expert" — role acronym in CRA incident runbook
 ANE = "ANE"              # Apple Neural Engine

--- a/scripts/tests/test_typos_allowlist.sh
+++ b/scripts/tests/test_typos_allowlist.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] Hermetic both-direction self-tests for the _typos.toml allow-list
+# (bead sq-hyzq — CI hygiene: stop recurring SPARQL-keyword false-positives blocking
+# the docs-quality `typos` gate). Authored by Opus 4.8 (Fable unavailable; flag for
+# re-review when Fable returns).
+#
+# WHY: typos (crate-ci/typos) splits an ALL-CAPS SPARQL keyword written with a lowercase
+# English suffix at the case boundary and flags the keyword-minus-tail or the dangling
+# 3-char fragment — DELETEd->DELET, INSERTed->INSER, "3 OPTIONALs"->OPTIONA, LOADed->Ded.
+# These are not typos; they are how anyone naturally writes SPARQL verbs in prose, so they
+# kept blocking the HARD gate and forcing pointless reword round-trips on doc PRs. The fix
+# adds one narrow `extend-ignore-re` regex (>=3 capitals immediately followed by 1-3
+# lowercase letters) plus an `invokable` word entry. This harness pins BOTH directions so
+# the allow-list can't silently over- or under-reach later:
+#   - should-PASS (SUPPRESSED): the keyword-suffix family + `invokable` must NOT be flagged.
+#   - should-FAIL (STILL FIRES): a genuine ALL-CAPS misspelling and ordinary lowercase
+#                                typos MUST still be caught, so the gate keeps its teeth.
+#
+# HERMETIC w.r.t. repo content/network: every case is a one-line fixture written to a
+# temp file and run through the SHIPPED `typos --config _typos.toml` binary in isolation —
+# no repo scan, no network. It exercises the exact config the gate ships (no duplication).
+#
+# Run:  bash scripts/tests/test_typos_allowlist.sh   (exit 0 = all pass, 1 = a case failed)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONFIG="${ROOT}/_typos.toml"
+
+[ -f "$CONFIG" ] || { echo "FATAL: _typos.toml not found at ${CONFIG}"; exit 2; }
+command -v typos >/dev/null 2>&1 || { echo "FATAL: 'typos' binary not on PATH"; exit 2; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FIX="${TMP}/fixture.md"
+
+# Echo "FAIL" if typos would report >=1 misspelling on this line, "PASS" otherwise.
+# Uses the SHIPPED config; `--isolated` ignores any ambient/parent _typos.toml so only the
+# project config under test applies.
+verdict() {
+  printf '%s\n' "$1" > "$FIX"
+  if typos --isolated --config "$CONFIG" "$FIX" >/dev/null 2>&1; then
+    echo PASS   # exit 0 => no typo found => suppressed/clean
+  else
+    echo FAIL   # non-zero => typo reported
+  fi
+}
+
+pass=0
+fail=0
+check() {  # check <expected FAIL|PASS> <line>
+  local want="$1" line="$2" got
+  got="$(verdict "$line")"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    printf 'CASE FAILED: wanted=%-4s got=%-4s  | %s\n' "$want" "$got" "$line"
+  fi
+}
+
+# --------------------------------------------------------------------------- #
+# Direction A — these MUST be SUPPRESSED (recurring false-positives the bead names).
+# The whole "ALL-CAPS SPARQL keyword + lowercase suffix" family, plus `invokable`.
+# --------------------------------------------------------------------------- #
+check PASS "The triples were DELETEd from the default graph."
+check PASS "We INSERTed three quads and then SELECTed the bindings."
+check PASS "The query CONSTRUCTed a graph and DESCRIBEd the resource."
+check PASS "The named graph was CLEARed and the dump was LOADed."
+check PASS "We UNIONed two patterns and MATCHed the BGP."
+check PASS "Product detail with 3 OPTIONALs and one nested OPTIONALs."
+check PASS "This helper is invokable from the CLI."
+
+# --------------------------------------------------------------------------- #
+# Direction B — these MUST still FIRE (the gate keeps catching real misspellings).
+# --------------------------------------------------------------------------- #
+# A genuine ALL-CAPS misspelling has no lowercase suffix, so the regex does NOT shield it.
+check FAIL "The header says RECIEVE instead of RECEIVE."
+# Ordinary lowercase typos are untouched by the keyword regex.
+check FAIL "Fix teh wording in the paragraph."
+check FAIL "Re-order hte two clauses."
+# A bare keyword with a real lowercase typo glued on a DIFFERENT word must still fire:
+# `seperate` is lowercase, unrelated to the regex, and stays caught.
+check FAIL "Keep the two stores seperate."
+
+# --------------------------------------------------------------------------- #
+echo ""
+echo "test_typos_allowlist: ${pass} passed, ${fail} failed."
+[ "$fail" -eq 0 ] || exit 1
+echo "test_typos_allowlist: OK — keyword-suffix false-positives suppressed, real typos still caught."


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Implements bead **sq-hyzq** (CI hygiene). Authored on Opus 4.8 `[OPUS-4.8]` (Fable unavailable; flag for re-review when Fable returns).

## What & why

The `docs-quality` **`typos` HARD gate** keeps tripping on a recurring class of *false positives*: an ALL-CAPS SPARQL keyword written with a lowercase English suffix. `typos` splits at the case boundary and flags the keyword-minus-tail (or a dangling 3-char fragment):

| Written | typos flags | Reality |
|---|---|---|
| `DELETEd` | `DELET` → `DELETE` | SPARQL UPDATE verb in prose |
| `INSERTed` | `INSER` → `INSERT` | same |
| `SELECTed` | `SELEC` → `SELECT` | query verb |
| `CONSTRUCTed` / `DESCRIBEd` | `CONSTRUC` / `DESCRIB` | query forms |
| `3 OPTIONALs` | `OPTIONA` → `OPTIONAL` | benchmark labels |
| `LOADed` / `BINDed` / `GROUPed` | `Ded` / `Ned` / fragment | camelCase split tail |
| `invokable` | → `invocable` | accepted CLI/API variant |

None are misspellings — they are how SPARQL verbs read in prose — so they kept blocking the gate and forcing pointless reword round-trips on doc PRs (the bead's complaint).

## Fix

- **One narrow `extend-ignore-re`** — `\b[A-Z]{3,}[a-z]{1,3}\b` — pins the whole "keyword + lowercase suffix" family instead of enumerating dozens of fragments.
- **One `extend-words` entry** — `invokable` (accepted variant of *invocable*); it is a standalone word, not a keyword split, so the regex doesn't cover it.

The regex is **deliberately tight**: it matches only a run of ≥3 capitals immediately followed by 1–3 lowercase letters with no break. A genuine ALL-CAPS misspelling (`RECIEVE`) and ordinary lowercase typos (`teh`, `hte`, `seperate`) **still fire** — the gate keeps its teeth.

### Honesty: scope check
I diffed the whole-tree `typos` output before/after the regex. Every token it **newly** silences is a keyword-suffix split (`DELET`, `INSER`, `OPTIONA`, `CLEA`, `UNIO`, `Ded`, `Ned`, …) — **zero** real misspellings. `DROPped` (named in the bead title) was already handled by `typos`; I did **not** add a no-op entry for it.

## Test

New `scripts/tests/test_typos_allowlist.sh` — a hermetic both-direction self-test (temp fixtures, no repo scan, no network) that runs the **shipped** config:
- **Direction A (must stay SUPPRESSED):** the keyword-`-ed` family + `3 OPTIONALs` + `invokable`.
- **Direction B (must STILL fire):** `RECIEVE`, `teh`, `hte`, `seperate`.

Wired into the same HARD `typos` CI job (mirrors `test_privacy_claims.sh`) so an allow-list over/under-reach also fails the `ci-summary` gate. `11 passed, 0 failed` locally; shellcheck clean.

## Gate

- `typos` over the exact HARD CI doc-surface scope: **clean** (143 files).
- `test_typos_allowlist.sh`: **11/11 pass**.
- `scripts/check-privacy-claims.sh` (mandatory): **OK** (268 files, no unqualified ZK/MPC claim).
- Workflow YAML parses; `_typos.toml` parses.
- No Rust crate touched → cargo/clippy/two-feature-state gate **N/A**. No public API changed → G2 public-api→`SKILL.md` rule **N/A**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)