### PR TITLE
ci: guard drift-scan/flow-on to refuse minting issues outside CI (sq-z0se)

### DIFF
--- a/research/maintenance-flow-on-automation-design.md
+++ b/research/maintenance-flow-on-automation-design.md
@@ -281,6 +281,15 @@ jobs:
 it never blocks — it only mints follow-on beads. If a created bead must itself
 trigger further automation, swap to a PAT, per the GITHUB_TOKEN loop-guard.)
 
+**CI-only guard (bead sq-z0se).** Both issue-minting tools — `flow-on.py` and the
+periodic `drift-scan.py` — REFUSE to file GitHub issues unless a CI marker
+(`GITHUB_ACTIONS` or `CI`) is set; their `main()` calls `require_ci()` on the
+write path only. This exists because an accidental dev-box run of `drift-scan.py`
+once minted 20 spurious issues (#397-416). `--dry-run` is *never* guarded (it
+makes zero `gh` calls), so local previews and the hermetic test-suite are
+unaffected; a deliberate manual mint can set `DRIFT_SCAN_ALLOW_LOCAL=1` /
+`FLOW_ON_ALLOW_LOCAL=1` as an explicit escape hatch.
+
 ### 2.3 Why this split is the right altitude
 
 - The **gates** stop the gap from ever landing on `main` — the highest leverage,

--- a/scripts/drift-scan.py
+++ b/scripts/drift-scan.py
@@ -479,6 +479,51 @@ def scan_all(root: Path) -> list[DriftItem]:
 
 
 # --------------------------------------------------------------------------- #
+# CI guard (bead sq-z0se)
+# --------------------------------------------------------------------------- #
+# [OPUS-4.8] An accidental dev-box run of this scanner minted 20 spurious GitHub
+# issues (#397-416). This guard makes the ISSUE-MINTING path refuse to run
+# anywhere but CI: it gates on the standard CI markers (`GITHUB_ACTIONS=true`,
+# set by GitHub Actions, or a truthy `CI`). It is checked ONLY on the write path
+# — `--dry-run` (which makes zero `gh` calls) stays runnable anywhere, so local
+# audits and the hermetic test-suite are unaffected. An explicit
+# `DRIFT_SCAN_ALLOW_LOCAL=1` escape hatch exists for the rare deliberate manual
+# mint, so the guard is a guard-rail, not a hard wall.
+CI_ENV_VARS = ("GITHUB_ACTIONS", "CI")
+ALLOW_LOCAL_ENV_VAR = "DRIFT_SCAN_ALLOW_LOCAL"
+
+
+def _is_truthy(val: str | None) -> bool:
+    return val is not None and val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def running_in_ci(env: dict[str, str] | None = None) -> bool:
+    """True iff a recognised CI marker is set (GITHUB_ACTIONS or CI)."""
+    e = os.environ if env is None else env
+    return any(_is_truthy(e.get(v)) for v in CI_ENV_VARS)
+
+
+def require_ci(env: dict[str, str] | None = None) -> None:
+    """Refuse to mint issues outside CI (bead sq-z0se).
+
+    Raises SystemExit(2) with a clear message unless a CI marker is set or the
+    explicit `DRIFT_SCAN_ALLOW_LOCAL` escape hatch is truthy. Only the write
+    path calls this — `--dry-run` never does."""
+    e = os.environ if env is None else env
+    if running_in_ci(e) or _is_truthy(e.get(ALLOW_LOCAL_ENV_VAR)):
+        return
+    print(
+        "drift-scan: refusing to file GitHub issues outside CI "
+        f"(no {' / '.join(CI_ENV_VARS)} env var set). This guard exists because "
+        "an accidental dev-box run minted 20 spurious issues (#397-416, bead "
+        "sq-z0se). Use --dry-run to preview the drift report locally, or set "
+        f"{ALLOW_LOCAL_ENV_VAR}=1 only if you really intend to file issues from here.",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+
+# --------------------------------------------------------------------------- #
 # gh I/O (mirrors flow-on.py exactly so the two halves behave identically)
 # --------------------------------------------------------------------------- #
 def key_marker(dedup_key: str) -> str:
@@ -604,6 +649,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.dry_run:
         return 0
+
+    # Issue-minting path: refuse outside CI (bead sq-z0se).
+    require_ci()
 
     created = 0
     skipped = 0

--- a/scripts/flow-on.py
+++ b/scripts/flow-on.py
@@ -286,6 +286,52 @@ def evaluate(
 
 
 # --------------------------------------------------------------------------- #
+# CI guard (bead sq-z0se)
+# --------------------------------------------------------------------------- #
+# [OPUS-4.8] An accidental dev-box run of the sibling drift scanner minted 20
+# spurious GitHub issues (#397-416). This engine mints issues the same way, so it
+# carries the same guard: the ISSUE-MINTING path refuses to run anywhere but CI.
+# It gates on the standard CI markers (`GITHUB_ACTIONS=true`, set by GitHub
+# Actions, or a truthy `CI`) and is checked ONLY on the write path —
+# `--dry-run` (zero `gh` calls) stays runnable anywhere, so local previews and
+# the hermetic test-suite are unaffected. An explicit `FLOW_ON_ALLOW_LOCAL=1`
+# escape hatch covers a deliberate manual mint.
+CI_ENV_VARS = ("GITHUB_ACTIONS", "CI")
+ALLOW_LOCAL_ENV_VAR = "FLOW_ON_ALLOW_LOCAL"
+
+
+def _is_truthy(val: str | None) -> bool:
+    return val is not None and val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def running_in_ci(env: dict[str, str] | None = None) -> bool:
+    """True iff a recognised CI marker is set (GITHUB_ACTIONS or CI)."""
+    e = os.environ if env is None else env
+    return any(_is_truthy(e.get(v)) for v in CI_ENV_VARS)
+
+
+def require_ci(env: dict[str, str] | None = None) -> None:
+    """Refuse to mint issues outside CI (bead sq-z0se).
+
+    Raises SystemExit(2) with a clear message unless a CI marker is set or the
+    explicit `FLOW_ON_ALLOW_LOCAL` escape hatch is truthy. Only the write path
+    calls this — `--dry-run` never does."""
+    e = os.environ if env is None else env
+    if running_in_ci(e) or _is_truthy(e.get(ALLOW_LOCAL_ENV_VAR)):
+        return
+    print(
+        "flow-on: refusing to file GitHub issues outside CI "
+        f"(no {' / '.join(CI_ENV_VARS)} env var set). This guard exists because "
+        "an accidental dev-box run of the drift scanner minted 20 spurious issues "
+        "(#397-416, bead sq-z0se). Use --dry-run to preview what would be filed, "
+        f"or set {ALLOW_LOCAL_ENV_VAR}=1 only if you really intend to file issues "
+        "from here.",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+
+# --------------------------------------------------------------------------- #
 # gh I/O
 # --------------------------------------------------------------------------- #
 def _gh(args: list[str]) -> str:
@@ -481,6 +527,11 @@ def main(argv: list[str] | None = None) -> int:
     if not follow_ons:
         print(f"flow-on: no rules triggered for PR #{args.pr}.")
         return 0
+
+    # Issue-minting path: refuse outside CI (bead sq-z0se). Only guard the real
+    # write path — a --dry-run preview makes no gh calls and runs anywhere.
+    if not args.dry_run:
+        require_ci()
 
     created = 0
     skipped = 0

--- a/scripts/tests/test_drift_scan.py
+++ b/scripts/tests/test_drift_scan.py
@@ -16,10 +16,11 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import os
 import sys
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -370,6 +371,84 @@ class MainDryRunTest(unittest.TestCase):
             rc = drift_scan.main(["--root", clean.name, "--dry-run"])
         self.assertEqual(0, rc)
         self.assertIn("no drift detected", buf.getvalue())
+
+
+# --------------------------------------------------------------------------- #
+# CI guard (bead sq-z0se) — refuse to MINT issues outside CI
+# --------------------------------------------------------------------------- #
+class CiGuardTest(unittest.TestCase):
+    """The issue-MINTING path must refuse to run outside CI; an accidental
+    dev-box run minted 20 spurious issues (#397-416). --dry-run is NEVER
+    guarded (it makes zero gh calls)."""
+
+    def _drift_fixture(self) -> Path:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        make_crate(root, "sparq-nlq")
+        make_registry(root, sources=["crates/sparq-cli/src/main.rs"])
+        return root
+
+    def _clear_ci_env(self) -> None:
+        backup = {k: os.environ.get(k) for k in ("GITHUB_ACTIONS", "CI",
+                                                 "DRIFT_SCAN_ALLOW_LOCAL")}
+
+        def restore() -> None:
+            for k, v in backup.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+        self.addCleanup(restore)
+        for k in backup:
+            os.environ.pop(k, None)
+
+    def test_running_in_ci_detects_markers(self):
+        self.assertTrue(drift_scan.running_in_ci({"GITHUB_ACTIONS": "true"}))
+        self.assertTrue(drift_scan.running_in_ci({"CI": "true"}))
+        self.assertTrue(drift_scan.running_in_ci({"CI": "1"}))
+
+    def test_running_in_ci_false_when_unset_or_falsey(self):
+        self.assertFalse(drift_scan.running_in_ci({}))
+        self.assertFalse(drift_scan.running_in_ci({"GITHUB_ACTIONS": "false"}))
+        self.assertFalse(drift_scan.running_in_ci({"CI": ""}))
+
+    def test_require_ci_passes_in_ci(self):
+        drift_scan.require_ci({"GITHUB_ACTIONS": "true"})  # no raise
+
+    def test_require_ci_passes_with_escape_hatch(self):
+        drift_scan.require_ci({"DRIFT_SCAN_ALLOW_LOCAL": "1"})  # no raise
+
+    def test_require_ci_refuses_outside_ci(self):
+        err = io.StringIO()
+        with redirect_stderr(err), self.assertRaises(SystemExit) as cm:
+            drift_scan.require_ci({})
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn("refusing to file GitHub issues outside CI", err.getvalue())
+
+    def test_main_mint_path_refuses_outside_ci_before_any_gh_call(self):
+        # End-to-end: a real (non-dry-run) run with drift present must SystemExit
+        # on the guard. If the guard were absent it would instead shell out to
+        # `gh` to mint issues — exactly the #397-416 incident.
+        root = self._drift_fixture()
+        self._clear_ci_env()
+        buf, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(buf), redirect_stderr(err), self.assertRaises(
+            SystemExit
+        ) as cm:
+            drift_scan.main(["--root", str(root)])  # NO --dry-run
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn("refusing to file GitHub issues outside CI", err.getvalue())
+
+    def test_main_dry_run_never_guarded_outside_ci(self):
+        # --dry-run must succeed even with no CI markers (local audits / tests).
+        root = self._drift_fixture()
+        self._clear_ci_env()
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = drift_scan.main(["--root", str(root), "--dry-run"])
+        self.assertEqual(0, rc)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_flow_on.py
+++ b/scripts/tests/test_flow_on.py
@@ -14,9 +14,11 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import os
 import sys
+import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -393,6 +395,84 @@ class DryRunTest(unittest.TestCase):
             out = buf.getvalue()
         self.assertEqual(rc, 0)
         self.assertIn("skill-sync-pr-251", out)
+
+
+# --------------------------------------------------------------------------- #
+# CI guard (bead sq-z0se) — refuse to MINT issues outside CI
+# --------------------------------------------------------------------------- #
+class CiGuardTest(unittest.TestCase):
+    """The issue-MINTING path must refuse to run outside CI; an accidental
+    dev-box run of the sibling drift scanner minted 20 spurious issues
+    (#397-416). --dry-run is NEVER guarded (it makes zero gh calls)."""
+
+    def _clear_ci_env(self) -> None:
+        backup = {k: os.environ.get(k) for k in ("GITHUB_ACTIONS", "CI",
+                                                 "FLOW_ON_ALLOW_LOCAL")}
+
+        def restore() -> None:
+            for k, v in backup.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+        self.addCleanup(restore)
+        for k in backup:
+            os.environ.pop(k, None)
+
+    def _firing_inputs(self, td: str) -> list[str]:
+        # A net pub-API change to a watched surface fires the skill-sync rule, so
+        # `follow_ons` is non-empty and the guard is reached on the write path.
+        changed = Path(td) / "changed.txt"
+        changed.write_text("crates/sparq-cli/src/main.rs\n")
+        pub = Path(td) / "pub.txt"
+        pub.write_text("crates/sparq-cli/src/main.rs\n")
+        return ["--pr", "999", "--changed-files", str(changed),
+                "--pub-diff-file", str(pub), "--title", "add --explain flag"]
+
+    def test_running_in_ci_detects_markers(self):
+        self.assertTrue(flow_on.running_in_ci({"GITHUB_ACTIONS": "true"}))
+        self.assertTrue(flow_on.running_in_ci({"CI": "1"}))
+
+    def test_running_in_ci_false_when_unset_or_falsey(self):
+        self.assertFalse(flow_on.running_in_ci({}))
+        self.assertFalse(flow_on.running_in_ci({"CI": ""}))
+
+    def test_require_ci_passes_in_ci(self):
+        flow_on.require_ci({"GITHUB_ACTIONS": "true"})  # no raise
+
+    def test_require_ci_passes_with_escape_hatch(self):
+        flow_on.require_ci({"FLOW_ON_ALLOW_LOCAL": "1"})  # no raise
+
+    def test_require_ci_refuses_outside_ci(self):
+        err = io.StringIO()
+        with redirect_stderr(err), self.assertRaises(SystemExit) as cm:
+            flow_on.require_ci({})
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn("refusing to file GitHub issues outside CI", err.getvalue())
+
+    def test_main_mint_path_refuses_outside_ci_before_any_gh_call(self):
+        # A real (non-dry-run) run that triggers a rule must SystemExit on the
+        # guard rather than shelling out to `gh` to mint issues.
+        self._clear_ci_env()
+        with tempfile.TemporaryDirectory() as td:
+            buf, err = io.StringIO(), io.StringIO()
+            with redirect_stdout(buf), redirect_stderr(err), self.assertRaises(
+                SystemExit
+            ) as cm:
+                flow_on.main(self._firing_inputs(td))  # NO --dry-run
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn("refusing to file GitHub issues outside CI", err.getvalue())
+
+    def test_main_dry_run_never_guarded_outside_ci(self):
+        # --dry-run must succeed with no CI markers (local previews / tests).
+        self._clear_ci_env()
+        with tempfile.TemporaryDirectory() as td:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = flow_on.main(self._firing_inputs(td) + ["--dry-run"])
+        self.assertEqual(rc, 0)
+        self.assertIn("skill-sync-pr-999", buf.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 SPARQ agent — implements bead **sq-z0se**.

## Why
An accidental dev-box run of `scripts/drift-scan.py` minted **20 spurious GitHub issues (#397-416)**. The two issue-minting CI tools in the repo — the periodic `drift-scan.py` and the merge-triggered `flow-on.py` — file issues via `gh` whenever run, with no environment check. This PR prevents recurrence.

## What
Both tools now **refuse to file GitHub issues unless a CI marker is set** (`GITHUB_ACTIONS` — set by GitHub Actions — or a truthy `CI`):

- A shared-shape `require_ci()` / `running_in_ci()` guard is added to each script. `[OPUS-4.8]`
- The guard is checked **only on the write/minting path**. `--dry-run` (which makes **zero** `gh` calls) stays runnable anywhere, so local audits and the hermetic test-suites are unaffected.
- A deliberate manual mint can opt in with an explicit escape hatch: `DRIFT_SCAN_ALLOW_LOCAL=1` / `FLOW_ON_ALLOW_LOCAL=1`.
- Refusal prints a clear message to **stderr** and exits with code **2**.

The CI workflows (`drift-scan.yml`, `flow-on.yml`) already run on GitHub Actions, where `GITHUB_ACTIONS=true` is always present, so the intended scheduled/merge-triggered runs are unaffected.

## Scope / honesty
- `drift-scan.py` and `flow-on.py` are the **only** two tools in the repo that mint GitHub issues (verified by grepping `scripts/` + `.github/` for `gh issue create` / `"issue", "create"`). No other tool needs the guard.
- This is a CI-tooling change, **not** a Rust crate and **not** a public-API change, so the G2 public-API → `SKILL.md` rule does not apply. The maintenance-flow-on design record (§2.2) is updated to document the guard as durable knowledge.

## Tests (hermetic, stdlib-only)
New `CiGuardTest` class in **both** `scripts/tests/test_drift_scan.py` and `scripts/tests/test_flow_on.py`:
- marker detection (`GITHUB_ACTIONS` / `CI`, truthy vs. falsey/unset);
- the escape-hatch env var passes the guard;
- `require_ci()` refuses outside CI with exit code 2 and the expected stderr message;
- end-to-end: a real (non-`--dry-run`) `main()` run with drift/follow-ons present `SystemExit`s on the guard **before any `gh` call**, while the `--dry-run` path still succeeds.

Local results: `test_drift_scan.py` 30/30 OK, `test_flow_on.py` 27/27 OK. Privacy-claims gate: OK.

## Gate
- Relevant lints for a CI/docs change: `py_compile` clean on all four touched Python files; both hermetic test-suites green in **both** the guarded (no-CI) and CI states.
- Privacy-claims gate (predicate-form soundness included): **OK** — no unqualified ZK/MPC privacy claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
