### PR TITLE
docs(sparq-serve): correct false `publish = false` README claim (sq-4kr5)

### DIFF
--- a/crates/sparq-serve/README.md
+++ b/crates/sparq-serve/README.md
@@ -1,4 +1,8 @@
-<!-- [OPUS-4.8] sq-4kr5: internal-stub README for a publish=false crate. -->
+<!-- [OPUS-4.8] sq-4kr5: README for the library-internal serving core. It is
+     PUBLISHABLE (no `publish = false`) only because the published `sparq-server`
+     depends on it — a crates.io crate cannot depend on a `publish = false` crate;
+     it has no standalone public API surface of its own. Keep this in sync with
+     crates/sparq-serve/Cargo.toml. -->
 # sparq-serve
 
 The **concurrent-serving core** of [sparq](../../README.md): a lock-free
@@ -16,8 +20,14 @@ The crate is **sync, runtime-agnostic, and library-first**: it exposes no HTTP
 or async-runtime types (consumers such as `sparq-server` wrap it), and it must
 never enter `sparq-wasm`'s dependency graph.
 
-> **Internal crate — not published** to crates.io (`publish = false`). It is
-> wrapped by `sparq-server`; there is no standalone public API surface.
+> **Library-internal core, not a standalone surface.** It is wrapped by
+> `sparq-server` and has no public API of its own — the [surface map in
+> `AGENTS.md`](../../AGENTS.md) does not list it as a usage entry point. It is
+> nonetheless a *publishable* crate (its `Cargo.toml` does **not** set
+> `publish = false`), and it must stay that way: the published `sparq-server`
+> depends on it, and a crates.io crate cannot depend on a `publish = false`
+> crate. So it ships to crates.io as plumbing for `sparq-server`, not as an
+> independently useful library.
 
 Design: [`research/concurrent-serving.md`](../../research/concurrent-serving.md) §6.
 Contributing: [`AGENTS.md`](../../AGENTS.md).


### PR DESCRIPTION
> 🤖 SPARQ agent

## What & why

#431 (sq-4kr5) landed a factual inaccuracy on `main`: `crates/sparq-serve/README.md` stated *"Internal crate — not published to crates.io (`publish = false`)"*, but `crates/sparq-serve/Cargo.toml` sets **no** `publish` field, so the crate defaults to **publishable**. The README claim was false — confirmed by `cargo metadata` (`sparq-serve -> publish = null`).

## Direction taken: fix the README, NOT add `publish = false`

I confirmed the fix direction with intent + dependency evidence before editing:

**Intent is internal** — `README.md`, `src/lib.rs`, and the `Cargo.toml` header all describe a *library-first, runtime-agnostic serving core* with "no standalone public API surface"; the `AGENTS.md` surface map (~line 9) lists the publishable crates and **omits** `sparq-serve` as a usage entry point.

**But it must stay publishable** — the only crate that depends on `sparq-serve` is `sparq-server` (`crates/sparq-server/Cargo.toml:161`, `{ path, version = "0.1.0", optional = true }`). `sparq-server` is an **intended crates.io surface** (listed in the AGENTS map; crate-local README + `[package.metadata.docs.rs]`; no `publish = false`). A published crate **cannot** depend on a `publish = false` crate.

I verified that cargo behaviour locally rather than reasoning about it: in a minimal workspace, `cargo package` on a publishable crate with an **optional** `publish = false` path-dependency fails with `no matching package … found / location searched: crates.io index` — even though the dep is optional and feature-gated. So adding `publish = false` to `sparq-serve` would have made `sparq-server` silently **unpublishable**, converting a doc-vs-config inconsistency into a worse config-vs-config one.

Per the task's own decision rule (*"If a published crate DOES depend on sparq-serve → fix the README"*), this is the README case. The README now states the honest status: a library-internal core with no public API of its own, but a **publishable** crate that ships to crates.io as plumbing for `sparq-server`. README and Cargo.toml are now **consistent and true**.

## Secondary issue — flagged, not fixed here

`sparq-serve` (and `sparq-parse`) set `readme = "../../README.md"`, so crates.io / docs.rs would surface the **root** sparq README, not this crate-local file. For `sparq-parse` this is harmless (it is `publish = false`). For the publishable `sparq-serve` it means the crate-local README never reaches the registry front page. Flipping to `readme = "README.md"` is **not trivial** — unlike `sparq-server`, `sparq-serve`'s `lib.rs` does not `include_str!` its README, so a flip would diverge the crates.io page from the docs.rs page. Left for a follow-up bead.

## Gates

- **G1 new-crate-completeness** (`scripts/gate-new-crate.py --base main`): **PASS** (no new crate added).
- **Workspace build** (`cargo build -p sparq-serve`): **PASS** (doc-only change; the README is not an `include_str!` compile input).
- **cargo metadata resolve** (`cargo metadata --format-version 1`): **PASS**.
- **typos-gate** (`_typos.toml`): clean; no `DELETEd`/`DROPped`/`invokable`/`ANDed`.
- **privacy-claims gate**: N/A (no ZK/MPC mention in the edit).
- **readme-template** (advisory, exits 0): sparq-serve's pre-existing section deviations are unchanged by this edit.

Doc-only; one file (`crates/sparq-serve/README.md`, +13/-3). Does not touch the gate aggregator or any Rust source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)