### PR TITLE
ci(typos): anchor caps-suffix allowlist to known keywords (sq-uiie)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -31,18 +31,26 @@ extend-exclude = [
 # referenced by the dozen in compliance/research docs, so per-token allowlisting does
 # not scale — match the whole bead-id token shape instead. [OPUS-4.8]
 #
-# [OPUS-4.8] (bead sq-hyzq) Ignore the recurring "ALL-CAPS SPARQL keyword + lowercase
-# English suffix" false-positive family: DELETEd, INSERTed, SELECTed, CONSTRUCTed,
-# DESCRIBEd, CLEARed, LOADed, UNIONed, MATCHed, "3 OPTIONALs", … Authors write these in
-# prose all the time; typos splits at the case boundary and flags the keyword-minus-tail
-# (DELET→DELETE, OPTIONA→OPTIONAL) or the dangling 3-char fragment (Ded/Ned), forcing a
-# pointless reword round-trip on every doc PR. One regex pins the whole shape instead of
-# enumerating dozens of fragments. It is deliberately narrow — it matches ONLY a run of
-# >=3 capitals immediately followed by 1-3 lowercase letters with no break, so a genuine
-# ALL-CAPS misspelling (e.g. `RECIEVE`) and ordinary lowercase typos (`teh`, `hte`) STILL
-# fire and the gate keeps its teeth. Verified across the whole tree: every token this
-# newly silences is a keyword-suffix split, zero real misspellings.
-extend-ignore-re = ["\\bsq-[0-9a-z]{3,}\\b", "\\b[A-Z]{3,}[a-z]{1,3}\\b"]
+# [OPUS-4.8] (bead sq-hyzq, tightened in sq-uiie) Ignore the recurring "ALL-CAPS SPARQL
+# keyword + lowercase English suffix" false-positive family: DELETEd, INSERTed, SELECTed,
+# CONSTRUCTed, DESCRIBEd, CLEARed, LOADed, UNIONed, MATCHed, "3 OPTIONALs", … Authors write
+# these in prose all the time; typos splits at the case boundary and flags the keyword-
+# minus-tail (DELET→DELETE, OPTIONA→OPTIONAL) or the dangling 3-char fragment (Ded/Ned),
+# forcing a pointless reword round-trip on every doc PR.
+#
+# The anchor is a CLOSED alternation of known SPARQL/SQL/RDF-update keyword roots — NOT a
+# blanket `[A-Z]{3,}`. The original sq-hyzq form `\b[A-Z]{3,}[a-z]{1,3}\b` matched ANY run
+# of >=3 capitals plus a 1-3 char lowercase tail, which silently shielded genuine ALL-CAPS
+# misspellings written with a suffix (RECIEVEd, SEPERATEd, ADRESs) — it suppressed the very
+# misspelling class the gate exists to catch. Pinning the prefix to a vetted keyword list
+# closes that hole: a misspelled root is never in the list, so its suffixed form fires
+# again, while every legitimate keyword-suffix split stays clean. (Acronym plurals like
+# IRIs/APIs/SBOMs never needed shielding — typos already treats `<ACRONYM>s` as an acronym
+# plural and does not flag them; verified by a both-config diff over the doc surface.)
+extend-ignore-re = [
+  "\\bsq-[0-9a-z]{3,}\\b",
+  "\\b(?:SELECT|CONSTRUCT|DESCRIBE|ASK|INSERT|DELETE|LOAD|CLEAR|CREATE|DROP|COPY|MOVE|ADD|UNION|OPTIONAL|MINUS|GRAPH|SERVICE|BIND|FILTER|VALUES|GROUP|ORDER|HAVING|MATCH|JOIN|PROJECT|AND|OR|XOR|UPDATE|WHERE)[a-z]{1,3}\\b",
+]
 
 [default.extend-identifiers]
 iy3p = "iy3p"            # [OPUS-4.8] bead id `sq-iy3p` — typos splits on `-`, flags "iy"->"it"

--- a/scripts/tests/test_typos_allowlist.sh
+++ b/scripts/tests/test_typos_allowlist.sh
@@ -1,20 +1,24 @@
 #!/usr/bin/env bash
 # [OPUS-4.8] Hermetic both-direction self-tests for the _typos.toml allow-list
-# (bead sq-hyzq — CI hygiene: stop recurring SPARQL-keyword false-positives blocking
-# the docs-quality `typos` gate). Authored by Opus 4.8 (Fable unavailable; flag for
-# re-review when Fable returns).
+# (bead sq-hyzq, tightened in sq-uiie — CI hygiene: stop recurring SPARQL-keyword false-
+# positives blocking the docs-quality `typos` gate). Authored by Opus 4.8 (Fable unavailable;
+# flag for re-review when Fable returns).
 #
 # WHY: typos (crate-ci/typos) splits an ALL-CAPS SPARQL keyword written with a lowercase
 # English suffix at the case boundary and flags the keyword-minus-tail or the dangling
 # 3-char fragment — DELETEd->DELET, INSERTed->INSER, "3 OPTIONALs"->OPTIONA, LOADed->Ded.
 # These are not typos; they are how anyone naturally writes SPARQL verbs in prose, so they
 # kept blocking the HARD gate and forcing pointless reword round-trips on doc PRs. The fix
-# adds one narrow `extend-ignore-re` regex (>=3 capitals immediately followed by 1-3
-# lowercase letters) plus an `invokable` word entry. This harness pins BOTH directions so
-# the allow-list can't silently over- or under-reach later:
+# is an `extend-ignore-re` regex anchored to a CLOSED alternation of known SPARQL/SQL/RDF-
+# update keyword roots (SELECT|INSERT|DELETE|…) each followed by a 1-3 char lowercase tail,
+# plus an `invokable` word entry. (sq-uiie: the original sq-hyzq form `\b[A-Z]{3,}[a-z]{1,3}\b`
+# was over-broad — it shielded ANY all-caps run with a short lowercase tail, silently hiding
+# genuine misspellings like RECIEVEd/SEPERATEd; the keyword anchor closes that hole.) This
+# harness pins BOTH directions so the allow-list can't silently over- or under-reach later:
 #   - should-PASS (SUPPRESSED): the keyword-suffix family + `invokable` must NOT be flagged.
-#   - should-FAIL (STILL FIRES): a genuine ALL-CAPS misspelling and ordinary lowercase
-#                                typos MUST still be caught, so the gate keeps its teeth.
+#   - should-FAIL (STILL FIRES): a genuine ALL-CAPS misspelling (bare OR with a lowercase
+#                                suffix) and ordinary lowercase typos MUST still be caught,
+#                                so the gate keeps its teeth.
 #
 # HERMETIC w.r.t. repo content/network: every case is a one-line fixture written to a
 # temp file and run through the SHIPPED `typos --config _typos.toml` binary in isolation —
@@ -81,6 +85,16 @@ check FAIL "Re-order hte two clauses."
 # A bare keyword with a real lowercase typo glued on a DIFFERENT word must still fire:
 # `seperate` is lowercase, unrelated to the regex, and stays caught.
 check FAIL "Keep the two stores seperate."
+# --------------------------------------------------------------------------- #
+# Direction B (regression — bead sq-uiie). The sq-hyzq form `\b[A-Z]{3,}[a-z]{1,3}\b`
+# was over-broad: it matched ANY >=3-capital run plus a 1-3 char lowercase tail, so a
+# genuine ALL-CAPS misspelling written WITH such a suffix was silently suppressed. Anchoring
+# the prefix to a closed keyword list closes that hole — a misspelled root is not in the
+# list, so its suffixed form fires again. These MUST FIRE (would have been WRONGLY PASSed by
+# the old blanket regex):
+check FAIL "The bytes were SEPERATEd into two buffers."  # SEPERATE is not a keyword
+check FAIL "Each value was MULTIPLYed by two."            # MULTIPLY+ed, not a SPARQL verb
+check FAIL "The fault OCURRed under load."                # OCURR(ed) is not a keyword
 
 # --------------------------------------------------------------------------- #
 echo ""


### PR DESCRIPTION
> 🤖 SPARQ agent — opened by an automated SPARQ agent (one of several @jeswr runs on this account).

Implements bead **sq-uiie** (infra/ci): tighten the `_typos.toml` caps-suffix allowlist so it stops silently suppressing all-caps misspellings that carry a 1-3 char lowercase suffix. Follow-up to **sq-hyzq** (#432).

## The hole

sq-hyzq added `\b[A-Z]{3,}[a-z]{1,3}\b` to `extend-ignore-re` to silence the recurring "ALL-CAPS SPARQL keyword + lowercase English suffix" false-positive family (`DELETEd`, `INSERTed`, `"3 OPTIONALs"`, …). But that pattern matches **any** run of ≥3 capitals plus a short lowercase tail — so a genuine all-caps misspelling written with such a suffix was silently shielded:

| token | old blanket regex | this PR |
|---|---|---|
| `SEPERATEd` | suppressed (wrong) | **fires** |
| `MULTIPLYed` | suppressed (wrong) | **fires** |
| `OCURRed` | suppressed (wrong) | **fires** |
| `DELETEd`, `INSERTed`, `OPTIONALs` | suppressed | suppressed (unchanged) |

The `typos` HARD gate exists to catch exactly that misspelling class, so the blanket regex was blunting its teeth.

## The fix

Replace the blanket caps-run with a **closed alternation over known SPARQL/SQL/RDF-update keyword roots**, each followed by `[a-z]{1,3}`:

```
\b(?:SELECT|CONSTRUCT|DESCRIBE|ASK|INSERT|DELETE|LOAD|CLEAR|CREATE|DROP|COPY|MOVE|ADD|UNION|OPTIONAL|MINUS|GRAPH|SERVICE|BIND|FILTER|VALUES|GROUP|ORDER|HAVING|MATCH|JOIN|PROJECT|AND|OR|XOR|UPDATE|WHERE)[a-z]{1,3}\b
```

A misspelled root is never in the list, so its suffixed form fires again; every legitimate keyword-suffix split stays clean.

The blanket form was also unnecessary: a both-config diff over the gate's doc surface shows `typos` already lets acronym plurals (`IRIs`, `APIs`, `SBOMs`, `WALs`, …) through on its own — only the SPARQL-verb-suffix family ever needed an allowlist entry. Enumerating which tokens actually fire without any caps regex returns exactly the keyword family (`DELETEd`, `INSERTed`, `CONSTRUCTed`, `DESCRIBEd`, `CLEARed`, `LOADed`, `UNIONed`, `MATCHed`, `OPTIONALs`, `ANDed`).

## Verification

- **CI-neutral on real docs**: the scoped doc-surface `typos` scan is byte-identical between the old and new config — this change only removes the *over*-suppression, it adds zero new flags on the existing tree.
- **Both-direction self-test** (`scripts/tests/test_typos_allowlist.sh`, runs in the same HARD CI job): extended with regression cases asserting an all-caps misspelling **with** a lowercase suffix now fires (`SEPERATEd`, `MULTIPLYed`, `OCURRed`). **14/14 pass.**
- HARD `typos` doc-surface gate: green (exit 0). privacy-claims gate: green. shellcheck on the test: clean.

No Rust crate touched (cargo/clippy/feature-state matrix N/A); no public API changed (G2 N/A).

[OPUS-4.8]

🤖 Generated with [Claude Code](https://claude.com/claude-code)