### PR TITLE
fix(sparq-solid): rustdoc private-intra-doc-link + scoped -D warnings lane (sq-z1rm)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,6 +435,23 @@ jobs:
       # A new warning — from new code or a Rust-stable bump that adds a lint — fails CI.
       - name: clippy (deny warnings)
         run: cargo clippy --workspace --all-targets -- -D warnings
+      # [OPUS-4.8] sq-z1rm: rustdoc -D warnings, scoped to sparq-solid. A broken/private
+      # intra-doc link (e.g. a public item linking to a crate-private const/fn) is a rustdoc
+      # warning, NOT a clippy/build warning, so it slips past every other gate here and
+      # mis-renders the published docs. This GATES the sparq-solid doc surface so a public
+      # item can never again link to a private/unresolved item. Both feature states: the
+      # `odrl-bridge` module (and its own intra-doc links) only compiles under that feature.
+      # Intentionally per-crate, not `--workspace`: the rest of the workspace still carries a
+      # pre-existing rustdoc-warning backlog (tracked separately) that a workspace-wide
+      # -D warnings would fail on today.
+      - name: rustdoc (deny warnings, sparq-solid — default features)
+        run: cargo doc -p sparq-solid --no-deps
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+      - name: rustdoc (deny warnings, sparq-solid — odrl-bridge)
+        run: cargo doc -p sparq-solid --no-deps --features odrl-bridge
+        env:
+          RUSTDOCFLAGS: "-D warnings"
       # Informational until the deferred `cargo fmt --all` reformat lands (see rustfmt.toml).
       - name: rustfmt (informational)
         run: cargo fmt --all --check

--- a/crates/sparq-solid/src/authindex.rs
+++ b/crates/sparq-solid/src/authindex.rs
@@ -151,9 +151,10 @@ pub fn pair_principal(agent: &str, client: &str) -> String {
 /// percent-encoding makes the minting INJECTIVE, so no agent/client/issuer value can
 /// smuggle a `&client=`/`&issuer=` delimiter into another principal's term).
 ///
-/// The `client` component is `auth:AnyClient` ([`ANY_CLIENT`]) for a matcher that
-/// constrains the issuer but not the client; only an issuer-CONSTRAINED candidate mints a
-/// triple — an issuer-unconstrained grant reuses the agent / [`pair_principal`] term.
+/// The `client` component is `auth:AnyClient` (the crate-internal `ANY_CLIENT`) for a
+/// matcher that constrains the issuer but not the client; only an issuer-CONSTRAINED
+/// candidate mints a triple — an issuer-unconstrained grant reuses the agent /
+/// [`pair_principal`] term.
 ///
 /// ```
 /// use sparq_solid::triple_principal;

--- a/crates/sparq-solid/src/odrl_bridge.rs
+++ b/crates/sparq-solid/src/odrl_bridge.rs
@@ -671,8 +671,8 @@ fn recipient_principal_allowed(p: &str) -> bool {
 /// # When a conditional grant is emitted (faithful)
 ///
 /// All of the matched permission's constraints are `odrl:recipient`/`odrl:assignee`
-/// constraints under `eq`/`isA`/`isPartOf` (see [`map_constraints_to_agents`]). The
-/// emitted grant is:
+/// constraints under `eq`/`isA`/`isPartOf` (see the crate-internal
+/// `map_constraints_to_agents`). The emitted grant is:
 ///
 /// ```text
 /// <grant> a auth:ConditionalGrant ; auth:effect auth:Allow ;
@@ -817,8 +817,9 @@ pub fn materialize_permission_conditional(
 /// # When a conditional deny is emitted (faithful)
 ///
 /// All of the matched prohibition's constraints are `odrl:recipient`/`odrl:assignee`
-/// constraints under `eq`/`isA`/`isPartOf`/`neq` (see [`map_constraints_to_agents`]),
-/// the action [`action_to_mode`]-maps, and the request names a target. The recipient
+/// constraints under `eq`/`isA`/`isPartOf`/`neq` (see the crate-internal
+/// `map_constraints_to_agents`), the action [`action_to_mode`]-maps, and the request
+/// names a target. The recipient
 /// constraint is NOT required to hold against the request party — the persisted
 /// condition re-checks it per session, exactly as the allow path.
 ///


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. @jeswr runs several agents on this account; this PR is from one of them.

Closes **sq-z1rm**.

## Problem

`cargo doc -p sparq-solid` emits, on `main`:

```
warning: public documentation for `triple_principal` links to private item `ANY_CLIENT`
   --> crates/sparq-solid/src/authindex.rs:154:51
```

`pub fn triple_principal` (added in #394) documents that its client component is
`auth:AnyClient` and links `[`ANY_CLIENT`]`, but `ANY_CLIENT` is a **crate-private**
`const` (it lives in the private `authindex` module and is not re-exported from
`lib.rs`). So the intra-doc link never resolves — it mis-renders the published docs.
It is a **rustdoc-only** warning: clippy, `cargo build`, and the test/doctest lanes
do not lint doc-comment links, so nothing in CI catches it today.

## Fix

- **authindex.rs** — drop the broken `[`ANY_CLIENT`]` link; keep the human-readable
  `auth:AnyClient` reference as plain text ("the crate-internal `ANY_CLIENT`"). The
  valid link to the **public** `pair_principal` is preserved.
- **odrl_bridge.rs** — two more instances of the *same defect class*, surfaced only
  under the `odrl-bridge` feature: public `materialize_permission_conditional` /
  `materialize_prohibition_conditional` linked the private `map_constraints_to_agents`.
  Fixed identically. (The link to the public `action_to_mode` is kept.)

No item signatures, names, or visibilities changed — **doc-comment prose only**.

## New gate (the bead's "consider a rustdoc -D warnings lane")

Adds a rustdoc `-D warnings` step to the existing `lint` job (`ci.yml`), **scoped to
`sparq-solid`** in **both feature states** (default + `odrl-bridge`), so a public
item can never again link to a private/unresolved item in this crate.

**Honest scoping — deliberately _not_ `--workspace`:** a workspace-wide
`RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` fails today on **~174
pre-existing rustdoc warnings across ~20 other crates** (heaviest: sparq-zk-compose 35,
sparq-server 24, sparq-mpc 20, sparq-core 18, sparq-vectors 17). Fixing those is out
of scope for this bead; widening the gate to the whole workspace is tracked as a
follow-up (**sq-8gsv**) rather than padded into this PR.

## Gate (all green, both feature states: default + `odrl-bridge`)

- `cargo build -p sparq-solid`
- `cargo clippy -p sparq-solid --all-targets -- -D warnings`
- `cargo test -p sparq-solid` (incl. the `triple_principal` / `pair_principal` /
  `materialize_*` doctests that exercise the edited comments)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-solid --no-deps` — now clean (the
  reproduction)
- privacy-claims gate + predicate-form soundness self-test: pass
- G2 public-api → SKILL.md: **N/A** (no public API changed)

[OPUS-4.8]