### PR TITLE
feat(ci): Gate G3 — new bench suite -> registry + dashboard (sq-ncvq.6)

### DIFF
--- a/.github/workflows/flow-on-gates.yml
+++ b/.github/workflows/flow-on-gates.yml
@@ -1,6 +1,6 @@
-# [OPUS-4.8] Proactive maintenance merge-gates G1/G2 (beads sq-ncvq.4 + sq-ncvq.5,
-# epic sq-ncvq). Authored by Opus 4.8 (Fable unavailable; flag for re-review when
-# Fable returns).
+# [OPUS-4.8] Proactive maintenance merge-gates G1/G2/G3 (beads sq-ncvq.4 +
+# sq-ncvq.5 + sq-ncvq.6, epic sq-ncvq). Authored by Opus 4.8 (Fable unavailable;
+# flag for re-review when Fable returns).
 #
 # This is the PROACTIVE / merge-time half of the maintenance flow-on system
 # (research/maintenance-flow-on-automation-design.md §2.1). It is the COMPLEMENT of
@@ -10,16 +10,21 @@
 # consistent — G2's suppression mirrors flow-on.py's SKILL_PATHS exactly, so a PR a
 # gate lets through is also a PR the reactive engine would not re-flag.
 #
-# GATING (not advisory): the job NAMES here contain NO "advisory"/"informational"/
-# "non-blocking" token, so the `ci-summary / gate` aggregator (ci-summary.yml) — the
-# SINGLE required check on `main` — treats them as REQUIRED gating checks and folds
-# their conclusions into the merge verdict. There is NO branch-protection edit and
-# NO ci.yml/ci-summary.yml edit needed: the aggregator discovers every sibling
-# check-run on the head commit by name, so adding this workflow is enough to make
-# the gates required. (A gate that should ever soft-launch would run with the
-# scripts' `--advisory` flag OR be renamed to carry the "advisory" word; these run
-# HARD because the back-catalogue is already clean — verified by running each gate
-# against current HEAD with no violation.)
+# GATING vs ADVISORY: the `ci-summary / gate` aggregator (ci-summary.yml) — the
+# SINGLE required check on `main` — folds in every sibling check-run whose NAME
+# does NOT contain an "advisory"/"informational"/"non-blocking" token. So a job
+# named without that token is a REQUIRED gate; a job named "(advisory …)" is
+# reported but never blocks. There is NO branch-protection edit and NO
+# ci.yml/ci-summary.yml edit needed — the aggregator discovers gates by sibling
+# name on the head commit.
+#   - G1 + G2 run HARD (no "advisory" token, scripts run without --advisory):
+#     the back-catalogue is already clean (verified against current HEAD).
+#   - G3 (new-bench->registry+dashboard) SOFT-LAUNCHES advisory, per design §2.1
+#     ("G1/G3 are heuristic and intentionally start advisory — a false positive
+#     is a nag, not a block, until tuned"). Its job name carries "(advisory)" AND
+#     the script runs with --advisory (belt-and-braces: it never exits non-zero).
+#     Flip to HARD by dropping the "(advisory)" token + the --advisory flag once
+#     the heuristic is proven on real PR traffic (the path G1 took).
 #
 # Each gate reads the PR diff via `git diff --name-only origin/<base>...HEAD` (the
 # scripts derive added vs changed from `--name-status`) and exits non-zero with a
@@ -114,3 +119,27 @@ jobs:
           else
             python3 scripts/gate-api-skill.py --base "$GATE_BASE_REF"
           fi
+
+  new-bench-registry-dashboard:
+    # [OPUS-4.8] sq-ncvq.6 — soft-launch ADVISORY (see the GATING vs ADVISORY note
+    # above): the "(advisory)" token keeps ci-summary from treating it as a
+    # required gate, and --advisory makes the script always exit 0. The verdict is
+    # still visible in the check's logs so authors see the nag before it goes hard.
+    name: new-bench-registry-dashboard (G3, advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for the merge-base diff)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: G3 — new bench suite is registered + featured (or featured=false)
+        env:
+          # On pull_request github.base_ref is the bare target branch ('main'); on
+          # merge_group it is empty, so fall back to merge_group.base_ref (a full
+          # 'refs/heads/main' ref — the scripts normalize the refs/heads/ prefix).
+          GATE_BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}
+        run: python3 scripts/check-new-bench-registered.py --base "$GATE_BASE_REF" --advisory

--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -20,6 +20,16 @@
 #   pinning             SHA/seed/dataset-version that must be fixed, if any
 #   records_to          where results land
 #   status              ok | stale | broken | external-cost | planning
+#   featured            OPTIONAL bool. Set `featured = false` to mark a suite an
+#                       intentionally-UNFEATURED capability suite (internal harness
+#                       / micro-bench / external-cost / spike) so the merge-time
+#                       gate G3 (scripts/check-new-bench-registered.py, soft-launch
+#                       advisory) does NOT require a FEATURED_SUITES row in
+#                       bench/dashboard/dashboard.js for it. Omit it (the default)
+#                       for a capability suite that SHOULD be promoted on the
+#                       dashboard. Non-capability families (cli-*/hw/ci/serve/
+#                       memtier/parse/compress/wikidata/…) are exempt from the
+#                       dashboard requirement without needing this flag. [OPUS-4.8]
 
 # =============================================================================
 # QUERY — engine compute + differential correctness vs reference engines

--- a/scripts/check-new-bench-registered.py
+++ b/scripts/check-new-bench-registered.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Gate G3 — new-bench->registry+dashboard (bead sq-ncvq.6, epic sq-ncvq).
+# Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# The PROACTIVE / merge-time half of the maintenance flow-on system
+# (research/maintenance-flow-on-automation-design.md §2.1, gate G3). Sibling of
+# scripts/gate-new-crate.py (G1) + scripts/gate-api-skill.py (G2). The reactive
+# engine (scripts/flow-on.py, rule `new-bench-dashboard-row`) mints a follow-on
+# ISSUE after a PR merges; THIS gate flags the gap BEFORE merge so a new bench
+# suite never lands invisible to the registry + capability dashboard.
+#
+# RULE (G3): when a PR introduces a NEW bench suite — either
+#   (T1) a NEW `[[benchmark]]` id in bench/benchmarks.toml (an id present at HEAD
+#        but not at the base ref), OR
+#   (T2) a NEW `bench/<suite>/` directory (a file added under a suite dir that did
+#        not exist at the base ref),
+# then that suite must be
+#   (a) REGISTERED in bench/benchmarks.toml — a `[[benchmark]]` entry whose `id`
+#       (T1, registered by construction) or whose `source`/`invoke`/`dataset`
+#       references `bench/<suite>/` (T2); AND
+#   (b) for a CAPABILITY suite, either PROMOTED on the dashboard — its id or family
+#       token appears in the FEATURED_SUITES block of bench/dashboard/dashboard.js —
+#       OR explicitly flagged `featured = false` in its bench/benchmarks.toml entry
+#       (the design's documented escape hatch).
+#
+# ESCAPE HATCH (design §2.1): `featured = false` on the benchmark's TOML entry
+# marks it an intentionally-unfeatured suite (internal harness / micro-bench /
+# external-cost / spike), exempt from the dashboard-row requirement (b). The
+# registry requirement is never waived — a suite must always be catalogued.
+#
+# NON-CAPABILITY FAMILIES are exempt from (b) by default (mirrors
+# scripts/drift-scan.py::DASHBOARD_EXEMPT_FAMILIES + the `sparq-bench` harness
+# prefix): the CLI query-suite runners, the hw/ci probes, the serve/memtier
+# spikes, the external-cost wikidata suites, and the parse/compress micro-benches
+# that feed the ingest harness rather than standing as a capability card. They
+# still must be REGISTERED (a), just not featured.
+#
+# G3 is HEURISTIC (path/id based) and — per design §2.1 — starts ADVISORY: a
+# false positive is a nag, not a block, until tuned. Run with --advisory for the
+# soft-launch (always exit 0, report only).
+#
+# DIFF SOURCE (CI): the PR's changed/added files + the base-ref toml content
+#   git diff --name-status origin/<base>...HEAD     (added bench/<suite>/ dirs)
+#   git show origin/<base>:bench/benchmarks.toml     (base ids, to diff vs HEAD)
+# In tests / --dry-run every git/disk fact is injected via fixtures + overrides,
+# so the evaluate() core is fully hermetic (no live git, no network). stdlib-only.
+#
+# Usage:
+#   check-new-bench-registered.py                     # CI: diff vs origin/<base>
+#   check-new-bench-registered.py --base main         # override base ref
+#   check-new-bench-registered.py --advisory          # soft-launch (never exit 1)
+#   check-new-bench-registered.py --dry-run --changed-files f.txt --base-toml b.toml
+#       # hermetic: added files from f.txt, base registry from b.toml
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BENCH_REGISTRY = REPO_ROOT / "bench" / "benchmarks.toml"
+DASHBOARD_JS = REPO_ROOT / "bench" / "dashboard" / "dashboard.js"
+
+# A line in a status-prefixed diff: "A\tpath", "M\tpath", "R100\told\tnew", etc.
+_STATUS_RE = re.compile(r"^([A-Z])\d*\t(.*)$")
+
+# A bench suite DIR token: a single path component under bench/ — letters,
+# digits, dot, underscore, hyphen (NO spaces/quotes). Used to extract `<suite>`
+# from a `bench/<suite>/` reference that may sit inside a multi-word `invoke`
+# command string, so we never capture trailing shell text.
+_SUITE_TOKEN = r"[A-Za-z0-9._-]+"
+_BENCH_DIR_RE = re.compile(rf"\bbench/({_SUITE_TOKEN})/")
+
+# Bench FAMILIES (the leading `bench/<suite>/` token) that the design (§5.D)
+# accepts as intentionally unfeatured on the capability dashboard — kept in
+# lock-step with scripts/drift-scan.py::DASHBOARD_EXEMPT_FAMILIES. Such a suite
+# must still be REGISTERED, but it is exempt from the dashboard-row requirement
+# (b) WITHOUT needing a `featured = false` flag.
+NONCAPABILITY_SUITE_FAMILIES = frozenset(
+    {
+        "cli",  # CLI query-suite runners (cli-bench-*, cli-ingest, …)
+        "src",  # bench/src — the sparq-bench harness sources, not a suite dir
+        "hw",  # hardware probe (hw-bench)
+        "ci",  # CI harness (ci-bench, ci-bench-ec2)
+        "serve",  # serve spike (research SPIKE, not a maintained suite)
+        "memtier",  # memtier spike
+        "wikidata",  # external-cost suites (wikidata-8b) — acceptably unfeatured
+        "parse",  # parse-baseline micro-bench feeds the ingest harness
+        "compress",  # compression micro-bench, not a capability card
+        "competitor",  # competitor-gather plumbing, not a suite
+        "dashboard",  # the dashboard itself, not a measured suite
+    }
+)
+
+
+# --------------------------------------------------------------------------- #
+# Diff parsing (mirrors gate-new-crate.py exactly so the two gates agree)
+# --------------------------------------------------------------------------- #
+def parse_status_lines(lines: list[str]) -> tuple[list[str], list[str]]:
+    """Split a `git diff --name-status`-style list into (changed, added).
+
+    Each line is either "<STATUS>\t<path>" (or "<STATUS>\t<old>\t<new>" for
+    renames/copies) or a bare path (a generic change, NOT provably added).
+    `A` (added) and `C` (copied) both materialise a NEW destination path."""
+    changed: list[str] = []
+    added: list[str] = []
+    for raw in lines:
+        line = raw.rstrip("\n")
+        if not line.strip():
+            continue
+        m = _STATUS_RE.match(line)
+        if m:
+            status, rest = m.group(1), m.group(2)
+            path = rest.split("\t")[-1]  # rename/copy dest is the last field
+            changed.append(path)
+            if status in ("A", "C"):
+                added.append(path)
+        else:
+            changed.append(line)
+    return changed, added
+
+
+def _normalize_base(base: str) -> str:
+    """Accept a bare branch ('main'), a full ref ('refs/heads/main', as
+    merge_group.base_ref supplies) or an origin/* ref and return the
+    remote-tracking ref to diff against ('origin/main')."""
+    base = base.strip()
+    if base.startswith("refs/heads/"):
+        base = base[len("refs/heads/") :]
+    if base.startswith("origin/") or base == "HEAD":
+        return base
+    return f"origin/{base}"
+
+
+def git_diff(base: str) -> tuple[list[str], list[str]]:
+    """Return (changed, added) from git vs the base ref using a 3-dot diff."""
+    ref = _normalize_base(base)
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-status", f"{ref}...HEAD"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except subprocess.CalledProcessError as e:  # pragma: no cover - CI-only path
+        sys.stderr.write(f"error: git diff failed: {e.stderr}\n")
+        sys.exit(2)
+    return parse_status_lines(out.splitlines())
+
+
+def git_base_toml(base: str) -> str:
+    """The base ref's bench/benchmarks.toml content ('' if it did not exist)."""
+    ref = _normalize_base(base)
+    try:
+        return subprocess.run(
+            ["git", "show", f"{ref}:bench/benchmarks.toml"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except subprocess.CalledProcessError:  # pragma: no cover - CI-only path
+        return ""  # file absent at base => every HEAD id is new
+
+
+def git_base_bench_suites(base: str) -> set[str]:
+    """The set of `bench/<suite>/` dirs that already existed at the base ref.
+
+    Without this, a file merely ADDED inside a PRE-EXISTING suite dir would be
+    mis-read as a brand-new suite (a false positive). We list the base tree under
+    bench/ and collect each immediate child component."""
+    ref = _normalize_base(base)
+    try:
+        out = subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", f"{ref}", "bench/"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except subprocess.CalledProcessError:  # pragma: no cover - CI-only path
+        return set()
+    suites: set[str] = set()
+    for line in out.splitlines():
+        m = re.match(rf"^bench/({_SUITE_TOKEN})/", line)
+        if m:
+            suites.add(m.group(1))
+    return suites
+
+
+# --------------------------------------------------------------------------- #
+# Registry (benchmarks.toml) introspection — textual, mirroring the sibling
+# gates (the registry is hand-authored prose-heavy TOML; a structural array
+# parse is unnecessary and brittle).
+# --------------------------------------------------------------------------- #
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def registry_ids(text: str) -> list[str]:
+    """Every benchmark `id` declared in the registry text, in file order."""
+    return re.findall(r'^\s*id\s*=\s*"([^"]+)"', text, re.MULTILINE)
+
+
+def registry_blocks(text: str) -> list[dict[str, object]]:
+    """Split the registry into per-`[[benchmark]]` blocks, returning for each a
+    dict of the fields we care about: id, the joined text of source/invoke/
+    dataset/records_to (for dir↔entry mapping) and whether `featured = false` is
+    set.
+
+    Keys: {'id': str, 'refs': str, 'featured_false': bool}. Robust to the
+    registry's aligned-`=` formatting and multi-line string values (it slices on
+    the `[[benchmark]]` header, not on field boundaries)."""
+    blocks: list[dict[str, object]] = []
+    # Split on the table-array header; the first chunk is the file preamble.
+    parts = re.split(r"(?m)^\s*\[\[benchmark\]\]\s*$", text)
+    for chunk in parts[1:]:
+        idm = re.search(r'^\s*id\s*=\s*"([^"]+)"', chunk, re.MULTILINE)
+        bid = idm.group(1) if idm else ""
+        # Collect every value text we use to map a bench/<suite>/ dir → entry.
+        refs = " ".join(
+            re.findall(
+                r"^\s*(?:source|invoke|dataset|records_to)\s*=\s*(.*)$",
+                chunk,
+                re.MULTILINE,
+            )
+        )
+        featured_false = (
+            re.search(r"^\s*featured\s*=\s*false\b", chunk, re.MULTILINE) is not None
+        )
+        blocks.append({"id": bid, "refs": refs, "featured_false": featured_false})
+    return blocks
+
+
+def block_for_suite(
+    blocks: list[dict[str, object]], suite: str
+) -> dict[str, object] | None:
+    """The first registry block whose refs reference `bench/<suite>/`, or None."""
+    needle = re.compile(rf"\bbench/{re.escape(suite)}/")
+    for b in blocks:
+        if needle.search(str(b["refs"])):
+            return b
+    return None
+
+
+def suite_for_block(block: dict[str, object]) -> str | None:
+    """The first `bench/<suite>/` dir token a registry block references, or None.
+    Restricted to a valid dir-name token so a multi-word `invoke` command never
+    leaks shell text into the captured suite name."""
+    m = _BENCH_DIR_RE.search(str(block.get("refs", "")))
+    return m.group(1) if m else None
+
+
+def block_for_id(
+    blocks: list[dict[str, object]], bid: str
+) -> dict[str, object] | None:
+    for b in blocks:
+        if b["id"] == bid:
+            return b
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Dashboard (FEATURED_SUITES) introspection.
+# --------------------------------------------------------------------------- #
+def dashboard_featured_text(text: str) -> str:
+    """The FEATURED_SUITES array body, lowercased (matched textually — the file
+    is JS, not data we should eval). '' if the block is absent."""
+    m = re.search(r"FEATURED_SUITES\s*=\s*\[(.*?)\];", text, re.DOTALL)
+    return (m.group(1) if m else "").lower()
+
+
+def is_featured(featured_text: str, bid: str, family: str) -> bool:
+    """True iff the suite's id OR its family token appears in the FEATURED_SUITES
+    block. Loose by design (the JS matcher itself matches on aliases/tokens) —
+    G3 flags whole FAMILIES with no promotion, not the exact JS alias logic."""
+    if not featured_text:
+        return False
+    # Token forms the dashboard aliases use: `deep-taxonomy`, `deeptax`, `deep taxonomy`.
+    candidates = {
+        bid.lower(),
+        family.lower(),
+        family.replace("-", " ").lower(),
+        family.replace("-", "").lower(),
+    }
+    return any(c and c in featured_text for c in candidates)
+
+
+# --------------------------------------------------------------------------- #
+# Suite detection from the diff.
+# --------------------------------------------------------------------------- #
+def suite_family(suite: str) -> str:
+    """The leading slug token of a suite dir name (e.g. `zk` for `zk-compose`,
+    `qlever` for `qlever-100m`) — the unit the dashboard features."""
+    return suite.split("-", 1)[0]
+
+
+def added_bench_suites(added: list[str], base_suites: set[str]) -> list[str]:
+    """Suite dirs introduced by the diff: a file added under `bench/<suite>/`
+    whose `<suite>` dir did not exist at the base ref. Stable, de-duplicated."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for p in added:
+        m = re.match(rf"^bench/({_SUITE_TOKEN})/", p)
+        if not m:
+            continue
+        suite = m.group(1)
+        if suite in base_suites or suite in seen:
+            continue
+        seen.add(suite)
+        out.append(suite)
+    return out
+
+
+def new_registry_ids(head_toml: str, base_toml: str) -> list[str]:
+    """Benchmark ids present at HEAD but not at the base ref (newly registered)."""
+    base = set(registry_ids(base_toml))
+    return [i for i in registry_ids(head_toml) if i not in base]
+
+
+# --------------------------------------------------------------------------- #
+# Core evaluation (pure: every git/disk fact is an argument or override).
+# --------------------------------------------------------------------------- #
+def evaluate(
+    added: list[str],
+    *,
+    head_toml: str,
+    base_toml: str,
+    featured_text: str,
+    base_suites: set[str] | None = None,
+) -> list[tuple[str, list[str]]]:
+    """Return [(suite-or-id, [missing-reasons])] for every new bench suite that
+    violates G3. An empty list means the gate PASSES.
+
+    `added` is the diff's added-file list; `head_toml`/`base_toml` are the
+    registry at HEAD/base; `featured_text` is the lowercased FEATURED_SUITES
+    body; `base_suites` is the set of suite dirs that already existed at base
+    (so a file added to a pre-existing suite is not a 'new suite')."""
+    base_suites = base_suites if base_suites is not None else set()
+    head_blocks = registry_blocks(head_toml)
+    violations: list[tuple[str, list[str]]] = []
+
+    # De-dup so a suite reached via BOTH a new dir and a new id is reported once.
+    seen: set[str] = set()
+
+    def check(
+        label: str,
+        block: dict[str, object] | None,
+        family: str,
+        *,
+        registered: bool,
+    ) -> None:
+        if label in seen:
+            return
+        seen.add(label)
+        missing: list[str] = []
+        if not registered:
+            missing.append(
+                f"a registered [[benchmark]] entry in bench/benchmarks.toml whose "
+                f"source/invoke/dataset references bench/{label}/"
+            )
+        # Dashboard requirement only for capability suites.
+        if family not in NONCAPABILITY_SUITE_FAMILIES:
+            featured_false = bool(block and block.get("featured_false"))
+            bid = str((block or {}).get("id", ""))
+            if not featured_false and not is_featured(featured_text, bid, family):
+                missing.append(
+                    f"a FEATURED_SUITES row in bench/dashboard/dashboard.js for the "
+                    f"`{family}` suite — OR `featured = false` in its "
+                    f"bench/benchmarks.toml entry if it is intentionally unfeatured"
+                )
+        if missing:
+            violations.append((label, missing))
+
+    # (T2) New bench/<suite>/ directories.
+    for suite in added_bench_suites(added, base_suites):
+        block = block_for_suite(head_blocks, suite)
+        check(suite, block, suite_family(suite), registered=block is not None)
+
+    # (T1) New benchmark ids. A new id is registered by construction; we only
+    # check the dashboard requirement. Key the report on the suite dir the id
+    # references (so it de-dups against a T2 hit) when resolvable, else the id.
+    for bid in new_registry_ids(head_toml, base_toml):
+        block = block_for_id(head_blocks, bid)
+        suite = suite_for_block(block) if block else None
+        label = suite or bid
+        family = suite_family(suite) if suite else suite_family(bid)
+        check(label, block, family, registered=True)
+
+    return violations
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="G3 new-bench->registry+dashboard gate (sq-ncvq.6)."
+    )
+    ap.add_argument(
+        "--base",
+        default=os.environ.get("GATE_BASE_REF", "main"),
+        help="base ref to diff against (origin/<base>); default 'main'.",
+    )
+    ap.add_argument(
+        "--changed-files",
+        help="hermetic input: a file of diff lines (status-prefixed or bare paths).",
+    )
+    ap.add_argument(
+        "--base-toml",
+        help="hermetic input: the base ref's bench/benchmarks.toml content.",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="never exit non-zero; print the verdict only (for local/testing).",
+    )
+    ap.add_argument(
+        "--advisory",
+        action="store_true",
+        help="soft-launch: report violations but always exit 0.",
+    )
+    args = ap.parse_args(argv)
+
+    if args.changed_files:
+        lines = Path(args.changed_files).read_text(encoding="utf-8").splitlines()
+        _, added = parse_status_lines(lines)
+        # Hermetic mode: no base tree to list, so a file added under an existing
+        # suite dir cannot be distinguished from a new one. Tests inject
+        # base_suites via evaluate() directly when that distinction matters.
+        base_suites: set[str] = set()
+    else:
+        _, added = git_diff(args.base)
+        base_suites = git_base_bench_suites(args.base)
+
+    head_toml = _read(BENCH_REGISTRY)
+    if args.base_toml is not None:
+        base_toml = Path(args.base_toml).read_text(encoding="utf-8")
+    else:
+        base_toml = git_base_toml(args.base)
+    featured_text = dashboard_featured_text(_read(DASHBOARD_JS))
+
+    violations = evaluate(
+        added,
+        head_toml=head_toml,
+        base_toml=base_toml,
+        featured_text=featured_text,
+        base_suites=base_suites,
+    )
+
+    if not violations:
+        print(
+            "G3 new-bench->registry+dashboard: PASS — no new bench suite missing artifacts."
+        )
+        return 0
+
+    print("G3 new-bench->registry+dashboard: FAIL")
+    for label, missing in violations:
+        print(f"\n  new bench suite `{label}` is missing:")
+        for m in missing:
+            print(f"    - {m}")
+    print(
+        "\nA new bench suite must be REGISTERED in bench/benchmarks.toml and "
+        "(if a capability suite) either added to FEATURED_SUITES in "
+        "bench/dashboard/dashboard.js OR flagged `featured = false` in its toml "
+        "entry (research/maintenance-flow-on-automation-design.md §2.1, gate G3)."
+    )
+
+    if args.advisory or args.dry_run:
+        print("\n(advisory/dry-run: not failing the build)")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_new_bench_registered.py
+++ b/scripts/tests/test_check_new_bench_registered.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Hermetic tests for the proactive merge-gate G3 — new-bench->registry+
+# dashboard (bead sq-ncvq.6, epic sq-ncvq). Authored by Opus 4.8 (Fable
+# unavailable; flag for re-review when Fable returns).
+#
+# Hermetic w.r.t. git/network: imports scripts/check-new-bench-registered.py and
+# drives its pure evaluate() entry point against FIXTURE diff/registry/dashboard
+# strings — NO live git and NO subprocess. main() is exercised only via --dry-run
+# + --changed-files + --base-toml so it never shells out (it does read the
+# committed in-repo bench/benchmarks.toml + dashboard.js, which are deterministic
+# files, not git/network state).
+#
+# Run:  python3 scripts/tests/test_check_new_bench_registered.py
+# (stdlib only; no pytest required — also discoverable by `pytest`.)
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / filename)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+g3 = _load("check_new_bench_registered", "check-new-bench-registered.py")
+
+
+def _added(paths: list[str]) -> list[str]:
+    """A `git diff --name-status` added-files fixture → the parsed added list."""
+    _, added = g3.parse_status_lines([f"A\t{p}" for p in paths])
+    return added
+
+
+def _registry(entries: list[dict]) -> str:
+    """Build a minimal benchmarks.toml from a list of entry dicts.
+
+    Each entry: {id, source?, invoke?, featured_false?}. Mirrors the real
+    registry's aligned-`=` prose-heavy shape closely enough for the textual
+    parser."""
+    out = []
+    for e in entries:
+        out.append("[[benchmark]]")
+        out.append(f'id          = "{e["id"]}"')
+        if "source" in e:
+            out.append(f'source      = "{e["source"]}"')
+        if "invoke" in e:
+            out.append(f'invoke      = "{e["invoke"]}"')
+        if e.get("featured_false"):
+            out.append("featured    = false")
+        out.append("")
+    return "\n".join(out)
+
+
+_DASHBOARD = (
+    "var FEATURED_SUITES = [\n"
+    "  { key: 'WatDiv', title: 'WatDiv', aliases: ['watdiv'] },\n"
+    "  { key: 'GeoSPARQL', title: 'GeoSPARQL', aliases: ['geosparql', 'geo'] },\n"
+    "];\n"
+)
+_FEATURED = g3.dashboard_featured_text(_DASHBOARD)
+
+
+# --------------------------------------------------------------------------- #
+# T2 — a new bench/<suite>/ directory.
+# --------------------------------------------------------------------------- #
+class NewSuiteDirTest(unittest.TestCase):
+    def test_unregistered_unfeatured_capability_suite_fails_both(self):
+        # A brand-new capability suite dir with NO registry entry + NO dashboard
+        # row → both (a) and (b) are missing. Two files under the same suite dir
+        # must still de-dup to ONE detected suite.
+        added = _added(["bench/sparkle/run.sh", "bench/sparkle/queries/q1.rq"])
+        v = g3.evaluate(
+            added, head_toml=_registry([]), base_toml="", featured_text=_FEATURED
+        )
+        self.assertEqual(len(v), 1)
+        label, missing = v[0]
+        self.assertEqual(label, "sparkle")
+        self.assertEqual(len(missing), 2)
+        joined = " ".join(missing)
+        self.assertIn("registered", joined)
+        self.assertIn("FEATURED_SUITES", joined)
+
+    def test_registered_and_featured_passes(self):
+        # Registered (source references bench/sparkle/) AND its family token is
+        # in FEATURED_SUITES → PASS. (We feature it by alias 'geo' here via a
+        # geo-family suite to reuse the fixture dashboard.)
+        added = _added(["bench/geo-extra/run.sh"])
+        reg = _registry([{"id": "geo-extra-bench", "source": "bench/geo-extra/run.sh"}])
+        v = g3.evaluate(added, head_toml=reg, base_toml="", featured_text=_FEATURED)
+        self.assertEqual(v, [])  # 'geo' family token is featured
+
+    def test_registered_but_unfeatured_capability_fails_dashboard_only(self):
+        added = _added(["bench/sparkle/run.sh"])
+        reg = _registry([{"id": "sparkle-bench", "source": "bench/sparkle/run.sh"}])
+        v = g3.evaluate(added, head_toml=reg, base_toml="", featured_text=_FEATURED)
+        self.assertEqual(len(v), 1)
+        _, missing = v[0]
+        self.assertEqual(len(missing), 1)
+        self.assertIn("FEATURED_SUITES", missing[0])
+
+    def test_featured_false_flag_waives_dashboard(self):
+        added = _added(["bench/sparkle/run.sh"])
+        reg = _registry(
+            [
+                {
+                    "id": "sparkle-bench",
+                    "source": "bench/sparkle/run.sh",
+                    "featured_false": True,
+                }
+            ]
+        )
+        v = g3.evaluate(added, head_toml=reg, base_toml="", featured_text=_FEATURED)
+        self.assertEqual(v, [])  # featured=false is the escape hatch
+
+    def test_noncapability_family_exempt_from_dashboard(self):
+        # A new bench/cli-foo/ dir is a non-capability runner family: registered
+        # (to avoid the (a) miss) and NOT featured → still PASS (exempt from b).
+        added = _added(["bench/cli-foo/run.sh"])
+        reg = _registry([{"id": "cli-foo-bench", "source": "bench/cli-foo/run.sh"}])
+        v = g3.evaluate(added, head_toml=reg, base_toml="", featured_text=_FEATURED)
+        self.assertEqual(v, [])
+
+    def test_noncapability_family_still_needs_registry(self):
+        # Even a non-capability family must be REGISTERED.
+        added = _added(["bench/cli-foo/run.sh"])
+        v = g3.evaluate(
+            added, head_toml=_registry([]), base_toml="", featured_text=_FEATURED
+        )
+        self.assertEqual(len(v), 1)
+        _, missing = v[0]
+        self.assertEqual(len(missing), 1)
+        self.assertIn("registered", missing[0])
+
+    def test_preexisting_suite_dir_not_flagged(self):
+        # A file added under an ALREADY-EXISTING suite dir is not a new suite.
+        added = _added(["bench/watdiv/queries/extra.rq"])
+        v = g3.evaluate(
+            added,
+            head_toml=_registry([]),
+            base_toml="",
+            featured_text=_FEATURED,
+            base_suites={"watdiv"},
+        )
+        self.assertEqual(v, [])
+
+    def test_non_bench_paths_ignored(self):
+        added = _added(["crates/sparq-core/src/store.rs", "research/notes.md"])
+        v = g3.evaluate(
+            added, head_toml=_registry([]), base_toml="", featured_text=_FEATURED
+        )
+        self.assertEqual(v, [])
+
+
+# --------------------------------------------------------------------------- #
+# T1 — a new benchmarks.toml id (no new dir).
+# --------------------------------------------------------------------------- #
+class NewRegistryIdTest(unittest.TestCase):
+    def test_new_id_capability_unfeatured_fails(self):
+        # A new id (present at HEAD, absent at base) for a capability family with
+        # no dashboard row → flagged for the dashboard miss (registry is satisfied
+        # by construction).
+        base = _registry([{"id": "old-bench", "source": "bench/old/run.sh"}])
+        head = _registry(
+            [
+                {"id": "old-bench", "source": "bench/old/run.sh"},
+                {"id": "sparkle-bench", "source": "bench/sparkle/run.sh"},
+            ]
+        )
+        # No new DIR added (the dir already existed at base) — only the id is new.
+        v = g3.evaluate(
+            [],
+            head_toml=head,
+            base_toml=base,
+            featured_text=_FEATURED,
+            base_suites={"sparkle", "old"},
+        )
+        self.assertEqual(len(v), 1)
+        label, missing = v[0]
+        self.assertEqual(label, "sparkle")  # keyed on the referenced suite dir
+        self.assertEqual(len(missing), 1)
+        self.assertIn("FEATURED_SUITES", missing[0])
+
+    def test_new_id_featured_passes(self):
+        base = _registry([{"id": "old-bench", "source": "bench/old/run.sh"}])
+        head = _registry(
+            [
+                {"id": "old-bench", "source": "bench/old/run.sh"},
+                {"id": "watdiv-extra", "source": "bench/watdiv/run.sh"},
+            ]
+        )
+        v = g3.evaluate(
+            [],
+            head_toml=head,
+            base_toml=base,
+            featured_text=_FEATURED,
+            base_suites={"watdiv", "old"},
+        )
+        self.assertEqual(v, [])  # watdiv is featured
+
+    def test_new_id_featured_false_passes(self):
+        base = _registry([])
+        head = _registry(
+            [
+                {
+                    "id": "sparkle-bench",
+                    "source": "bench/sparkle/run.sh",
+                    "featured_false": True,
+                }
+            ]
+        )
+        v = g3.evaluate(
+            [],
+            head_toml=head,
+            base_toml=base,
+            featured_text=_FEATURED,
+            base_suites={"sparkle"},
+        )
+        self.assertEqual(v, [])
+
+    def test_dir_and_id_dedup_to_one_violation(self):
+        # A PR that adds bench/sparkle/ AND its new id reports ONE violation, not two.
+        added = _added(["bench/sparkle/run.sh"])
+        head = _registry([{"id": "sparkle-bench", "source": "bench/sparkle/run.sh"}])
+        v = g3.evaluate(added, head_toml=head, base_toml="", featured_text=_FEATURED)
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0][0], "sparkle")
+
+    def test_no_new_id_no_new_dir_passes(self):
+        reg = _registry([{"id": "old-bench", "source": "bench/old/run.sh"}])
+        v = g3.evaluate(
+            [], head_toml=reg, base_toml=reg, featured_text=_FEATURED
+        )
+        self.assertEqual(v, [])
+
+
+# --------------------------------------------------------------------------- #
+# Unit helpers.
+# --------------------------------------------------------------------------- #
+class HelperTest(unittest.TestCase):
+    def test_registry_blocks_parses_featured_false(self):
+        text = _registry(
+            [
+                {"id": "a", "source": "bench/a/x", "featured_false": True},
+                {"id": "b", "source": "bench/b/x"},
+            ]
+        )
+        blocks = g3.registry_blocks(text)
+        self.assertEqual(len(blocks), 2)
+        self.assertTrue(blocks[0]["featured_false"])
+        self.assertFalse(blocks[1]["featured_false"])
+
+    def test_block_for_suite_matches_dir_token(self):
+        text = _registry([{"id": "a", "invoke": "run bench/foo-bar/run.sh now"}])
+        blocks = g3.registry_blocks(text)
+        self.assertIsNotNone(g3.block_for_suite(blocks, "foo-bar"))
+        self.assertIsNone(g3.block_for_suite(blocks, "foo"))  # prefix must not match
+
+    def test_suite_for_block_does_not_leak_shell_text(self):
+        # A multi-word `invoke` that embeds `bench/<suite>/… && cargo bench` must
+        # yield the clean suite token, never the trailing shell text. (Real
+        # registry source/invoke values carry a trailing slash, e.g.
+        # `bench/zk-trace/{Cargo.toml,README.md}`.)
+        text = _registry(
+            [
+                {
+                    "id": "x",
+                    "invoke": "cd bench/zk-trace/ && cargo bench  # then bench/other/y",
+                }
+            ]
+        )
+        block = g3.registry_blocks(text)[0]
+        self.assertEqual(g3.suite_for_block(block), "zk-trace")
+
+    def test_suite_family_strips_variant(self):
+        self.assertEqual(g3.suite_family("zk-compose"), "zk")
+        self.assertEqual(g3.suite_family("qlever-100m"), "qlever")
+        self.assertEqual(g3.suite_family("watdiv"), "watdiv")
+
+    def test_new_registry_ids_diff(self):
+        base = _registry([{"id": "a", "source": "x"}])
+        head = _registry([{"id": "a", "source": "x"}, {"id": "b", "source": "y"}])
+        self.assertEqual(g3.new_registry_ids(head, base), ["b"])
+
+    def test_added_bench_suites_excludes_preexisting_dirs(self):
+        # A file ADDED inside a pre-existing suite dir is not a new suite (this is
+        # what git_base_bench_suites() supplies in the live CI path).
+        self.assertEqual(
+            g3.added_bench_suites(["bench/zk/benches/new.rs"], {"zk", "watdiv"}),
+            [],
+        )
+        # A brand-new suite dir is still detected.
+        self.assertEqual(
+            g3.added_bench_suites(["bench/brandnew/run.sh"], {"zk"}),
+            ["brandnew"],
+        )
+
+    def test_added_bench_suites_token_charset_rejects_garbage(self):
+        # Only valid dir-name components are treated as suite dirs.
+        self.assertEqual(g3.added_bench_suites(["bench/ok-suite/x"], set()), ["ok-suite"])
+        self.assertEqual(g3.added_bench_suites(["bench/benchmarks.toml"], set()), [])
+
+    def test_normalize_base_handles_refs_heads(self):
+        self.assertEqual(g3._normalize_base("refs/heads/main"), "origin/main")
+        self.assertEqual(g3._normalize_base("main"), "origin/main")
+        self.assertEqual(g3._normalize_base("origin/dev"), "origin/dev")
+
+
+# --------------------------------------------------------------------------- #
+# main() smoke — hermetic via --dry-run + --changed-files + --base-toml.
+# --------------------------------------------------------------------------- #
+class MainSmokeTest(unittest.TestCase):
+    def _write(self, tmp: Path, name: str, text: str) -> str:
+        p = tmp / name
+        p.write_text(text, encoding="utf-8")
+        return str(p)
+
+    def test_dry_run_clean_diff_passes(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            cf = self._write(tmp, "diff.txt", "A\tresearch/foo.md\n")
+            bt = self._write(tmp, "base.toml", g3._read(g3.BENCH_REGISTRY))
+            rc = g3.main(["--dry-run", "--changed-files", cf, "--base-toml", bt])
+            self.assertEqual(rc, 0)
+
+    def test_dry_run_reports_violation_but_exits_zero(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            cf = self._write(tmp, "diff.txt", "A\tbench/zzznewsuite/run.sh\n")
+            bt = self._write(tmp, "base.toml", "")  # empty base registry
+            rc = g3.main(["--dry-run", "--changed-files", cf, "--base-toml", bt])
+            self.assertEqual(rc, 0)  # dry-run never fails
+
+
+# --------------------------------------------------------------------------- #
+# Back-catalogue guard: the gate must be GREEN against the current repo state.
+# (A new suite landing later is caught by the diff; the committed registry +
+# dashboard must agree with each other so the gate can ship HARD eventually.)
+# --------------------------------------------------------------------------- #
+class BackCatalogueTest(unittest.TestCase):
+    def test_no_added_files_means_pass_on_current_repo(self):
+        # With an empty added-list and identical base==head registry, the gate is
+        # vacuously green — i.e. merely existing committed state never trips it.
+        reg = g3._read(g3.BENCH_REGISTRY)
+        featured = g3.dashboard_featured_text(g3._read(g3.DASHBOARD_JS))
+        v = g3.evaluate([], head_toml=reg, base_toml=reg, featured_text=featured)
+        self.assertEqual(v, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-ncvq.6** (Gate G3: new-bench->registry+dashboard check). [OPUS-4.8]

## What

Adds `scripts/check-new-bench-registered.py`, the proactive merge-time **gate G3** of the maintenance flow-on system (`research/maintenance-flow-on-automation-design.md` §2.1). It is the sibling of `gate-new-crate.py` (G1) and `gate-api-skill.py` (G2), and the proactive complement of the reactive `drift-scan.py` / `flow-on.py` engines.

## Rule

When a PR introduces a **new bench suite** — either
- **(T1)** a new `[[benchmark]]` id in `bench/benchmarks.toml` (an id at HEAD absent at the base ref), **or**
- **(T2)** a new `bench/<suite>/` directory (a file added under a suite dir that did not exist at the base ref)

then that suite must be
- **(a) registered** in `bench/benchmarks.toml` (an entry whose `source`/`invoke`/`dataset` references `bench/<suite>/`), **and**
- **(b)** for a **capability** suite, either **promoted** on the dashboard (its id / family token appears in `FEATURED_SUITES` in `bench/dashboard/dashboard.js`) **or** flagged **`featured = false`** in its toml entry.

**Escape hatch:** `featured = false` on the benchmark's toml entry (documented in the `benchmarks.toml` field-semantics header). Non-capability families (`cli`/`hw`/`ci`/`serve`/`memtier`/`parse`/`compress`/`wikidata`/…) are registry-only and exempt from the dashboard row — kept in lock-step with `drift-scan.py`'s `DASHBOARD_EXEMPT_FAMILIES`.

## Soft-launch (advisory)

Per design §2.1 (*"G1/G3 are heuristic and intentionally start advisory — a false positive is a nag, not a block"*), the new `flow-on-gates.yml` job is named `new-bench-registry-dashboard (G3, advisory)` so `ci-summary` does **not** treat it as a required gate, and the script runs with `--advisory` (belt-and-braces: never exits non-zero). Flipping it HARD later is a one-line change (drop the `(advisory)` token + the flag), the same path G1 took.

## Design notes

- `evaluate()` is a **pure** core — every git/disk fact is an argument, so the tests are fully hermetic (no live git, no network, stdlib-only).
- The live CI path lists the base tree (`git ls-tree`) so a file added inside an **existing** suite dir is not mis-read as a new suite (false-positive guard); the suite-token charset rejects shell text leaking out of multi-word `invoke` values.
- A suite reached via both a new dir and a new id is reported once.

## Tests / gates

- `scripts/tests/test_check_new_bench_registered.py` — 24 hermetic tests (T1/T2, featured/featured=false/non-capability, dedup, base-suite exclusion, helpers, main() dry-run smoke, back-catalogue guard). All green.
- Sibling suites still green: `test_gates.py` (19), `test_drift_scan.py` (30).
- Privacy-claims gate: OK. `benchmarks.toml` parses (59 benchmarks). Workflow YAML valid.
- **GREEN against `origin/main`** on this PR (modifies `benchmarks.toml` but adds no new id, so no trigger).

Closes the G3 item of epic `sq-ncvq`.