### PR TITLE
docs(fedclient): fix 5 unresolved rustdoc intra-doc-links in source.rs/lib.rs (sq-8e6z)

### DIFF
--- a/crates/sparq-fedclient/src/lib.rs
+++ b/crates/sparq-fedclient/src/lib.rs
@@ -113,7 +113,8 @@ pub mod pushdown;
 /// §4.4 — **physical federation operators**: interpret a `JoinTree` into operators —
 /// `Bind` → VALUES/brTPF bind-join, `Hash`/`Streaming` → the reused
 /// [`StreamJoin`](sparq_fedplan::StreamJoin), `Local` → `sparq-engine` local eval — over
-/// the async [`stream::SolutionStream`] boundary, with concurrent fan-out (Phase 3/5).
+/// the async `SolutionStream` boundary (the Phase-5 [`stream`] item, not yet defined),
+/// with concurrent fan-out (Phase 3/5).
 #[cfg(feature = "fedclient")]
 pub mod operators;
 // [OPUS-4.8] sq-j27p: re-export the Phase-3 materialised single-source interpreter surface.

--- a/crates/sparq-fedclient/src/source.rs
+++ b/crates/sparq-fedclient/src/source.rs
@@ -28,11 +28,12 @@
 //! # What is STUBBED for later phases (no overclaim)
 //!
 //! * `discover()` on [`Endpoint`] is a **stub** that returns the "everything an endpoint
-//!   can do" [`Capability`] with **no** [`SourceDescriptor`] — the real VoID/SD discovery
+//!   can do" [`Capability`] with **no** [`SourceDescriptor`](sparq_fedplan::SourceDescriptor) — the real VoID/SD discovery
 //!   (GET `/.well-known/void` + SD, parse via `SourceDescriptor::from_void_nt`, the
 //!   client-side SD parser, ASK-probe fallback) is **Phase 1** (`discovery` module).
 //! * `execute()` returns the raw SRJ body (after the egress check + transport round-trip)
-//!   rather than a streamed [`SolutionStream`]; the SRJ→solution parse and the streaming
+//!   rather than a streamed `SolutionStream` (the Phase-5 [`stream`] item, not yet
+//!   defined); the SRJ→solution parse and the streaming
 //!   boundary are **Phase 5** (`stream`/`operators` modules). The transport seam and the
 //!   SSRF gate — the load-bearing reuse + safety pieces of §4.1 — are real here.
 //! * [`SourceType::Local`] (in-process `Graph` via `sparq-engine` local eval) is wired in
@@ -61,7 +62,8 @@
 //! * **Count-metadata cardinality** — both adapters read the fragment's
 //!   `hydra:totalItems`/`void:triples` count (the TPF cardinality oracle) and expose it via
 //!   [`TpfSource::cardinality`] / [`BrTpfSource::cardinality`] and a one-pattern
-//!   [`SourceDescriptor`] from [`discover()`](FederatedSource::discover), so the planner's
+//!   [`SourceDescriptor`](sparq_fedplan::SourceDescriptor) from
+//!   [`discover()`](FederatedSource::discover), so the planner's
 //!   CostFed estimate keys on the *served* count rather than a uniform guess. For brTPF the
 //!   count metadata is the **unbound** pattern count (a recall-safe upper bound; the bound
 //!   block only narrows it).
@@ -282,7 +284,7 @@ impl Capability {
 /// String>`). The engine's trait + its `HttpTransport` impl are `pub(crate)` and so cannot
 /// be imported; re-declaring the identical shape here lets the `Endpoint` adapter wrap any
 /// transport — including a test double — without depending on engine internals, while the
-/// dependency arrow still points one-way *into* the engine. A native [`HttpTransport`]
+/// dependency arrow still points one-way *into* the engine. A native `HttpTransport`
 /// (ureq, default-deny SSRF resolver) lands alongside `execute()`'s streaming in a later
 /// phase; Phase 2 ships the seam + the egress gate that fronts it. [OPUS-4.8] sq-rsxf.
 pub trait Transport: Send + Sync {
@@ -460,7 +462,7 @@ fn endpoint_host(endpoint: &str) -> Option<String> {
 /// of Comunica's `IQuerySource`.
 ///
 /// `discover()` resolves the source's [`Capability`] (and, once Phase 1 lands, its
-/// [`SourceDescriptor`] statistics) one-shot; `execute()` answers the most-precise
+/// [`SourceDescriptor`](sparq_fedplan::SourceDescriptor) statistics) one-shot; `execute()` answers the most-precise
 /// sub-query the source can evaluate. Phase 2 returns the raw SRJ body from `execute()`;
 /// the streamed `SolutionStream` boundary is Phase 5. [OPUS-4.8] sq-rsxf.
 pub trait FederatedSource {
@@ -860,7 +862,7 @@ fn descriptor_from_count(
 /// matching triple for that block comes back, so no join result is lost. With an empty
 /// `bindings` slice brTPF degrades to a plain fragment scan (one unbound request).
 ///
-/// `discover()` reports the brTPF [`Capability`] and a count-metadata [`SourceDescriptor`]
+/// `discover()` reports the brTPF [`Capability`] and a count-metadata [`SourceDescriptor`](sparq_fedplan::SourceDescriptor)
 /// for the open pattern (`?s ?p ?o`), the recall-safe upper-bound cardinality the planner
 /// keys on. [OPUS-4.8] sq-2qze.
 pub struct BrTpfSource {
@@ -961,7 +963,7 @@ impl FederatedSource for BrTpfSource {
 /// triple into the pattern's variables. There is **no** bind-join: a plain-TPF source shifts
 /// every join client-side, so the adapter materialises the whole (selective) fragment for
 /// the planner to greedy count-driven hash-join locally (design §2.1). `discover()` reports
-/// the TPF [`Capability`] and the count-metadata [`SourceDescriptor`]. [OPUS-4.8] sq-2qze.
+/// the TPF [`Capability`] and the count-metadata [`SourceDescriptor`](sparq_fedplan::SourceDescriptor). [OPUS-4.8] sq-2qze.
 pub struct TpfSource {
     /// The TPF fragment-template / base URL.
     pub url: String,


### PR DESCRIPTION
> 🤖 **SPARQ agent** — opened by an automated SPARQ agent (one of several @jeswr runs on this account).

## What & why (bead **sq-8e6z**, follow-up to sq-j27p; relates sq-z1rm)

Five rustdoc intra-doc-links in `crates/sparq-fedclient` did not resolve in the
**`fedclient`-feature-ON** build, so `cargo doc` mis-rendered them. No CI lane runs
`cargo doc`, so `main` stayed green — but the links were broken. This PR resolves them.

Verified with `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc --no-deps -p sparq-fedclient --features fedclient` going from **8 → 0** warnings.

## The fixes (doc-comment-only)

| Link | Site(s) | Fix | Why |
|------|---------|-----|-----|
| `SourceDescriptor` | source.rs module-doc (31, 64), `FederatedSource` (463), `BrTpfSource` (863), `TpfSource` (964) | fully-qualify → `[\`SourceDescriptor\`](sparq_fedplan::SourceDescriptor)` | the type lives in `sparq_fedplan` and is re-exported at its crate root (already the path used elsewhere in lib.rs); these sites had no in-scope `use` |
| `HttpTransport` | source.rs `Transport` trait doc (285) | demote to a plain code span `` `HttpTransport` `` | it is `pub(crate)` in `sparq-engine` and therefore **not linkable** from this crate; the same doc comment already mentions it as a plain span two lines up |
| `SolutionStream` | source.rs `Endpoint` exec note (35), lib.rs `operators` mod doc (116) | demote to a plain code span + cross-link the resolvable `[\`stream\`]` module | the `SolutionStream` item is a **Phase-5** type that does not exist yet (the `stream` module is a placeholder) |

The one **already-resolving** `SourceDescriptor` link (`descriptor_from_count`, which has an in-fn `use sparq_fedplan::{SourceDescriptor, …}`) is intentionally left unchanged.

## Honest scope note

The **default (`fedclient`-OFF) `cargo doc`** build still emits **8 pre-existing**
crate-level link errors — the lib.rs crate doc references `#[cfg(feature="fedclient")]`-gated
modules / the `sparq_fedplan` dep, which vanish when the feature is off. That is present on
`main` today (verified on a pristine checkout) and is **out of scope** for this one-bead PR.
Filed as **sq-tiq4**.

## Gate (all green)

- `cargo build` — pass in **both** feature states (OFF default / ON `fedclient`)
- `cargo clippy --all-targets -- -D warnings` — pass in **both** feature states
- `cargo test -p sparq-fedclient` — pass in **both** states (6 tests ON, doctests OFF)
- `scripts/fedclient-boundary-guard.sh` + `tests/boundary.rs` — pass (dependency boundary intact)
- `scripts/check-privacy-claims.sh` (predicate-form soundness) — pass
- **G2 public-API → SKILL.md**: not triggered — this is a doc-comment-only change; no public item signature, name, or visibility changed.

[OPUS-4.8] flagged for Fable re-review when available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)