### PR TITLE
feat(sparq-fedclient): Phase 4 capability-aware pushdown (sq-7byx)

### DIFF
--- a/crates/sparq-fedclient/README.md
+++ b/crates/sparq-fedclient/README.md
@@ -34,11 +34,14 @@ since (each behind the same default-OFF `fedclient` feature):
   `planner` module's `SourceResolver` (index → adapter resolution) + `lower_leaf` per-leaf
   lowering, and the `operators` module's `materialize_single_source` interpreter +
   `parse_srj` + `solutions_equal` result-equivalence (see below).
+- **Phase 4 — capability-aware pushdown** (`sq-7byx`): the `pushdown` module — FedX
+  exclusive-group decomposition, the maximal pushable sub-algebra per group, the exact
+  common-variable FILTER check, and the cross-group bind-join block primitive (see below).
 - **Phase 6 — brTPF + TPF fragment adapters** (`sq-2qze`): the real Triple-Pattern-Fragments
   adapters (see below).
 
-Still ahead (future beads under epic sq-dnko): capability-aware pushdown (§4.3), the
-streaming operators (§4.4 / §5), and adaptive re-planning (§7).
+Still ahead (future beads under epic sq-dnko): the streaming operators (§4.4 / §5) and
+adaptive re-planning (§7).
 
 The Phase-3 planner bridge + interpreter is detailed under
 [Phase 3 — lower a plan + interpret it against one source](#phase-3--lower-a-plan--interpret-it-against-one-source);
@@ -74,6 +77,51 @@ fragment server (real fetch → parse → bind → paginate → bind-join, zero 
 native HTTP `FragmentTransport` (ureq + the default-deny SSRF resolver, Hydra URI-template
 serialisation, Turtle/TriG fragment parsing) lands with the streaming phase.
 
+## Capability-aware pushdown (Phase 4, `pushdown` module)
+
+The planner decides *which* source answers *which* pattern and in *what* join order; the
+`pushdown` module decides the **most precise sub-query** each source is asked, so a source
+answers a whole sub-pattern in one request rather than one single-pattern `SELECT` per leaf.
+
+- **`exclusive_groups(selection, bgp)`** — the FedX **exclusive-group decomposition**. From
+  the planner's per-pattern source selection it forms the maximal sets of patterns that each
+  have **exactly one** retained source, the **same** source, and are **connected** by a
+  shared variable (transitively, via union-find). These are the sub-BGPs pushable as one
+  sub-query. A pattern matched by two-or-more sources (a cross-source join) or zero sources
+  is **excluded** from every group — it is handled by the operators phase, never folded into
+  a single-source sub-query.
+- **`push_group(group, bgp, cap, output_vars, filters, order_keys, limit)`** — the **maximal
+  sub-algebra builder**. For one group it builds the most precise `SubQuery` the source's
+  `Capability` can answer: the **projection** trimmed to exactly the join + output variables;
+  the FILTER conjuncts the source's `FilterClass` covers AND that pass the common-variable
+  check; `ORDER BY` / `LIMIT` only when the capability's `order_limit` allows. A full endpoint
+  gets the whole group as one multi-pattern `SELECT`; a fragment source (brTPF / plain TPF)
+  answers **one** triple pattern (its access unit), so a multi-pattern group is *not* collapsed
+  and no filter / order / limit is pushed — honest, not an overclaim that a fragment server
+  evaluates a multi-pattern BGP. The result records which conjuncts were **pushed** and which
+  were kept **local** (the residual the local engine still evaluates).
+- **`common_variable_check(filter, group_vars)`** — the **exact** check Comunica is documented
+  to omit (issues #834/#609): a FILTER conjunct is pushed **only when every variable it
+  references is bound by the group's patterns**. A conjunct over a variable a sibling group
+  binds would evaluate against an *unbound* value remote-side and could drop a solution the
+  local plan keeps, so it is kept local. This is the load-bearing safety invariant — push only
+  the provably-identical sub-algebra.
+- **`render_values_block` / `bind_block_size`** — the cross-group **bind-join block**
+  primitive: a `VALUES` block for a full endpoint (block size `DEFAULT_BIND_BLOCK` ≈ FedX's
+  bound-join batch), a `maxMpR`-bounded block for brTPF, no block for plain TPF. The rendering
+  mirrors `sparq-engine`'s `service.rs::render_values_block` byte-for-byte (that function is
+  `pub(crate)`, so it is re-declared here, exactly as Phase 2 re-declares the `Transport`
+  seam). Phase 4 owns the block *construction*; the operator that gathers upstream bindings,
+  slices them into blocks, and streams the per-block matches is Phase 5.
+
+Pushdown only ever **narrows** what a source returns (a pushed FILTER removes solutions, a
+trimmed projection removes columns, a `VALUES`/`maxMpR` block bounds the rows requested) — it
+never adds an answer the residual local join would not reattach, so it is correctness-preserving
+by construction. The FILTER conjuncts are a **light, pre-parsed model** (`Filter`: variable set +
+rendered expression + required `FilterClass`); wiring the real parsed-query FILTER algebra and
+the disjunctive-filter decomposition is Phase 5's job when the operators consume a whole query
+rather than a bare BGP.
+
 ## Public module layout (design §4)
 
 | Module        | Design  | Status / what it holds                                              |
@@ -81,7 +129,7 @@ serialisation, Turtle/TriG fragment parsing) lands with the streaming phase.
 | `source`      | §4.1    | **Phase 2** — `SourceType` (Endpoint \| BrTpf \| Tpf \| Local) + `FederatedSource` trait + `Endpoint` adapter (SSRF-guarded) |
 | `discovery`   | §4.1    | **Phase 1** — VoID/SD discovery → `Capability`; reuses `from_void_nt`; ASK fallback |
 | `planner`     | §4.2    | **Phase 3** — `SourceResolver` index→adapter resolution + `lower_leaf` per-leaf lowering |
-| `pushdown`    | §4.3    | Phase 4 (stub) — maximal pushable sub-algebra per exclusive group; VALUES bind-join |
+| `pushdown`    | §4.3    | **Phase 4** — FedX exclusive groups + maximal pushable sub-algebra per group + exact common-variable FILTER check + bind-join block primitive |
 | `operators`   | §4.4    | **Phase 3** — `materialize_single_source` interpreter + `parse_srj` + `solutions_equal` result-equivalence |
 | `stream`      | §4.4    | Phase 5 (stub) — the `SolutionStream` boundary the client owns (engine stays materialised) |
 
@@ -154,10 +202,10 @@ rather than under-answered.
 
 Landed: Phase 0 (skeleton + boundary proof, `sq-s1uy`), Phase 1 (discovery, `sq-nfxl`),
 Phase 2 (source abstraction + Endpoint adapter, `sq-rsxf`), Phase 3 (planner bridge +
-materialised single-source interpreter, `sq-j27p`), Phase 6 (brTPF/TPF adapters, `sq-2qze`).
-Still ahead under epic **sq-dnko**: capability-aware pushdown (§4.3), the streaming operators
-(§4.4 / §5), and adaptive re-planning (§7). No performance numbers appear here: any "better
-than Comunica" claim in the design record is an
+materialised single-source interpreter, `sq-j27p`), Phase 4 (capability-aware pushdown,
+`sq-7byx`), Phase 6 (brTPF/TPF adapters, `sq-2qze`). Still ahead under epic **sq-dnko**: the
+streaming operators (§4.4 / §5) and adaptive re-planning (§7). No performance numbers appear
+here: any "better than Comunica" claim in the design record is an
 *architectural prediction* to be validated head-to-head before being asserted as fact.
 
-[OPUS-4.8] sq-j27p — flagged for Fable re-review.
+[OPUS-4.8] sq-7byx — flagged for Fable re-review.

--- a/crates/sparq-fedclient/src/lib.rs
+++ b/crates/sparq-fedclient/src/lib.rs
@@ -109,6 +109,12 @@ pub use planner::{lower_leaf, pattern_vars, ResolveError, SourceResolver};
 /// local (Phase 4). Pushdown only ever NARROWS a source's result — correctness-preserving.
 #[cfg(feature = "fedclient")]
 pub mod pushdown;
+// [OPUS-4.8] sq-7byx: re-export the Phase-4 capability-aware pushdown surface at the crate root.
+#[cfg(feature = "fedclient")]
+pub use pushdown::{
+    bind_block_size, common_variable_check, exclusive_groups, group_vars, push_group,
+    render_values_block, ExclusiveGroup, Filter, PushedGroup, DEFAULT_BIND_BLOCK,
+};
 
 /// §4.4 — **physical federation operators**: interpret a `JoinTree` into operators —
 /// `Bind` → VALUES/brTPF bind-join, `Hash`/`Streaming` → the reused

--- a/crates/sparq-fedclient/src/pushdown.rs
+++ b/crates/sparq-fedclient/src/pushdown.rs
@@ -1,17 +1,957 @@
-//! Capability-aware pushdown (design §4.3).
+//! Capability-aware pushdown (design §4.3) — **Phase 4**.
 //!
-//! Phase 0 PLACEHOLDER — no logic yet. This module will, for each leaf and each FedX
-//! exclusive group, build the MAXIMAL evaluable sub-algebra for that source's
-//! `Capability` and push it: projections (only join + output variables), the FILTER
-//! conjuncts the source's `pushable_filters` cover (pushing a conjunct ONLY when all its
-//! variables are bound in the group — the common-variable check Comunica is documented to
-//! omit), and ORDER/LIMIT when the capability allows. Bind-join across groups reuses the
-//! engine's `render_values_block` + `bind_block_size` (VALUES for endpoints, `maxMpR`
-//! blocks for brTPF). Anything a source cannot evaluate is kept LOCAL.
+//! `sparq-fedplan` decides *which* sources answer *which* patterns and in *what* join
+//! order; it does **not** decide the precise sub-query each source is asked. That is this
+//! module's job: for each **FedX-style exclusive group** — a connected sub-pattern whose
+//! only relevant source is one member — build the **maximal evaluable sub-algebra** for that
+//! source's [`Capability`](crate::source::Capability) and emit it as one
+//! [`SubQuery`](crate::source::SubQuery), so the source answers the most precise query it
+//! can rather than one single-pattern `SELECT` per leaf (the Phase-3 `lower_leaf` shape).
 //!
-//! HONEST EDGE (design §7): push only the sub-algebra whose remote semantics are
-//! provably identical to local evaluation (numeric coercion / collation / language-tag /
-//! datatype / NaN / timezone); when in doubt, keep it local. Pushdown only ever NARROWS
-//! a source's result, so it is correctness-preserving (Phase 4).
+//! # What Phase 4 ships (HONEST scope)
+//!
+//! * [`exclusive_groups`] — the **exclusive-group decomposition**. From the planner's
+//!   per-pattern source selection ([`PatternSources`](sparq_fedplan::PatternSources)) it
+//!   forms the maximal sets of patterns that (a) each have **exactly one** retained source,
+//!   (b) the **same** source, and (c) are **connected** by a shared variable (transitively).
+//!   These are exactly the sub-BGPs FedX pushes as one sub-query. A pattern matched by two
+//!   or more sources is **not** in any exclusive group — it is a cross-source join the
+//!   operators phase fans out (kept out of pushdown, never under-answered).
+//! * [`push_group`] — the **maximal sub-algebra builder**. For one exclusive group it builds
+//!   the most precise [`SubQuery`] the group's source can answer: the projection trimmed to
+//!   exactly the **join + output** variables (everything else is internal to the group), the
+//!   FILTER conjuncts the source's [`FilterClass`](crate::source::FilterClass) covers AND
+//!   that pass the **exact common-variable check** (below), and `ORDER BY` / `LIMIT` only
+//!   when the capability's `order_limit` allows. The shape is chosen by interface:
+//!   - **full endpoint** → a multi-pattern `SELECT … WHERE { tp … FILTER(…) } ORDER/LIMIT`;
+//!   - **brTPF / plain TPF** → a single triple pattern only (a fragment server's access unit
+//!     is one pattern); a group of >1 pattern on a fragment source is *not* collapsed into
+//!     one sub-query — pushdown emits one per pattern and the join stays client-side.
+//! * [`common_variable_check`] — the **exact** check Comunica is documented to omit
+//!   (issues #834/#609): a FILTER conjunct is pushed **only when every variable it
+//!   references is bound by the group's patterns**. A conjunct over a variable the group
+//!   does not produce would change the remote answer (the remote sees an *unbound* variable
+//!   where local evaluation sees it bound by a sibling group), so it is kept local. This is
+//!   the load-bearing safety invariant: push only the provably-identical sub-algebra.
+//! * [`render_values_block`] / [`bind_block_size`] — the **bind-join block** primitive used
+//!   to join *across* groups: a `VALUES` block for a full endpoint (block size
+//!   [`DEFAULT_BIND_BLOCK`]), a `maxMpR`-bounded block for brTPF, no block for plain TPF.
+//!   This mirrors `sparq-engine`'s `service.rs::render_values_block` / `bind_block_size`
+//!   (`pub(crate)`, so re-declared here exactly as Phase 2 re-declares the `Transport` seam).
+//!
+//! # Correctness — pushdown only ever NARROWS
+//!
+//! Every transform here either removes solutions a source would have returned (a pushed
+//! FILTER) or removes columns the caller does not need (a trimmed projection) or bounds the
+//! rows requested (`VALUES`/`maxMpR`) — it never adds an answer the residual local join
+//! would not reattach. The common-variable check is what makes that true for filters: a
+//! conjunct whose variables are all group-bound evaluates identically remote-side and
+//! local-side, so pushing it cannot drop a solution the local plan would keep. Anything a
+//! source cannot evaluate (a filter that fails the class check or the common-variable check,
+//! a cross-source pattern, an `ORDER`/`LIMIT` the capability omits) is left for the local
+//! engine on the residual — pushdown is correctness-preserving by construction.
+//!
+//! # What is STUBBED / deferred (no overclaim)
+//!
+//! * The FILTER conjuncts are a **light, pre-parsed model** ([`Filter`]) — variable set +
+//!   a rendered SPARQL fragment + the class it needs. Wiring the *real* parsed-query FILTER
+//!   algebra (from `spargebra`) into this model, and the disjunctive/combined-filter
+//!   decomposition the design §4.3 names, is Phase 5's job when the operators consume a whole
+//!   query rather than a bare BGP. Phase 4 ships the per-conjunct pushability decision (class
+//!   check + common-variable check) the operators call, tested on the model directly.
+//! * The bind-join block here is the **rendered block + the size policy**; the operator that
+//!   *gathers* upstream bindings, slices them into blocks, and streams the per-block matches
+//!   is the Phase-5 `operators`/`stream` work. Phase 4 owns the block construction the
+//!   operator emits, not the streaming feeder.
+//! * `ORDER BY` is pushed as a passthrough of caller-supplied sort keys; the client does not
+//!   yet parse a query's `ORDER BY` into keys (Phase 5) — `push_group` takes the keys as an
+//!   argument so the lowering is testable now.
 //
-// [OPUS-4.8] sq-s1uy (epic sq-dnko): Phase-0 skeleton module — populated in Phase 4.
+// [OPUS-4.8] sq-7byx (epic sq-dnko): Phase-4 capability-aware pushdown — exclusive-group
+// decomposition + maximal sub-algebra builder + the exact common-variable check + the
+// bind-join block primitive. Phase 4 owns this module; Phase 5 owns operators.rs/stream.rs.
+// Flagged for Fable re-review when available.
+
+use crate::source::{BindJoin, Capability, FilterClass, Interface, SubQuery};
+use sparq_fedplan::{Bgp, PatternSources, Term, TriplePattern};
+
+// ─── Bind-join block size policy (mirrors sparq-engine service.rs, `pub(crate)` there) ──
+
+/// Default `VALUES` bind-join block size for a full endpoint: how many distinct binding
+/// tuples are pushed into one remote request. Mirrors `sparq-engine`'s
+/// `service.rs::DEFAULT_BIND_BLOCK` (`pub(crate)`, not importable) — ~50, FedX's default
+/// bound-join batch: large enough to amortise the round-trip, small enough to keep the
+/// injected query bounded. [OPUS-4.8] sq-7byx.
+pub const DEFAULT_BIND_BLOCK: usize = 50;
+
+/// The bind-join block size a source's [`Capability`] supports — the maximum number of
+/// upstream binding tuples the bind-join operator may push in one request to this source:
+///
+/// * [`BindJoin::Values`] → [`DEFAULT_BIND_BLOCK`] (a full endpoint accepts an arbitrarily
+///   large `VALUES` block; the default bounds the injected query);
+/// * [`BindJoin::MaxMpR(n)`](BindJoin::MaxMpR) → `n` (the brTPF `hydra:maxMpR` ceiling — the
+///   server promises to honour *at most* `n` mappings per request, so the block must not
+///   exceed it), clamped to at least 1 so a tuple is still pushed one-per-request rather than
+///   silently disabling the bind-join;
+/// * [`BindJoin::None`] → `0` (plain TPF has no bind-join — every join is client-side).
+///
+/// [OPUS-4.8] sq-7byx.
+pub fn bind_block_size(cap: &Capability) -> usize {
+    match cap.bind_join {
+        BindJoin::Values => DEFAULT_BIND_BLOCK,
+        BindJoin::MaxMpR(n) => (n as usize).max(1),
+        BindJoin::None => 0,
+    }
+}
+
+/// Render a `VALUES` block binding `vars` to each tuple in `tuples`, in the SPARQL 1.1
+/// syntax accepted inside a group graph pattern — the cross-group bind-join primitive.
+///
+/// Single-variable blocks use the short `VALUES ?v { v1 v2 }` form; multi-variable blocks
+/// use the parenthesised `VALUES (?a ?b) { (a1 b1) (a2 b2) }` form. Each term is the
+/// caller's already-rendered SPARQL term string (an IRI in `<>` or a quoted literal — the
+/// only kinds a join key carries). This mirrors `sparq-engine`'s
+/// `service.rs::render_values_block` byte-for-byte so a pushed block reads identically to the
+/// engine's SERVICE `VALUES` pushdown; the engine's function is `pub(crate)`, hence the
+/// re-declaration. `vars` empty or `tuples` empty yields an empty string (no block to push).
+/// [OPUS-4.8] sq-7byx.
+pub fn render_values_block(vars: &[String], tuples: &[Vec<String>]) -> String {
+    use std::fmt::Write as _;
+    if vars.is_empty() || tuples.is_empty() {
+        return String::new();
+    }
+    let mut s = String::new();
+    if vars.len() == 1 {
+        let _ = write!(s, "VALUES ?{} {{", vars[0]);
+        for t in tuples {
+            let _ = write!(s, " {}", t[0]);
+        }
+        s.push_str(" }");
+    } else {
+        s.push_str("VALUES (");
+        for (i, v) in vars.iter().enumerate() {
+            if i > 0 {
+                s.push(' ');
+            }
+            let _ = write!(s, "?{}", v);
+        }
+        s.push_str(") {");
+        for tuple in tuples {
+            s.push_str(" (");
+            for (i, t) in tuple.iter().enumerate() {
+                if i > 0 {
+                    s.push(' ');
+                }
+                s.push_str(t);
+            }
+            s.push(')');
+        }
+        s.push_str(" }");
+    }
+    s
+}
+
+// ─── A light FILTER-conjunct model (the seam Phase 5 wires the parsed algebra into) ─────
+
+/// One FILTER conjunct as the pushdown layer sees it: the variables it references, a
+/// rendered SPARQL expression fragment, and the [`FilterClass`] a source must support to
+/// evaluate it remotely.
+///
+/// This is the deliberately-light Phase-4 model — the operators phase (Phase 5) lowers the
+/// parsed query's FILTER algebra (and decomposes a conjunction / disjunction) into a slice of
+/// these. Phase 4 owns the **per-conjunct pushability decision** over this model: a conjunct
+/// is pushed only when the source's class covers `needs` AND it passes the common-variable
+/// check ([`common_variable_check`]). [OPUS-4.8] sq-7byx.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Filter {
+    /// The variable names this conjunct references (without the leading `?`). All must be
+    /// bound by the group for the conjunct to be pushable (the common-variable check).
+    pub vars: Vec<String>,
+    /// The rendered SPARQL expression, e.g. `?age > 18` or `?x = <http://ex/a>` — emitted
+    /// verbatim inside the pushed `FILTER(…)`.
+    pub expr: String,
+    /// The [`FilterClass`] the source must support to evaluate this conjunct remotely. A
+    /// simple equality / `IN` needs [`FilterClass::Equality`]; anything richer needs
+    /// [`FilterClass::Full`].
+    pub needs: FilterClass,
+}
+
+impl Filter {
+    /// A conjunct over `vars` with rendered expression `expr` needing class `needs`.
+    pub fn new(vars: Vec<String>, expr: impl Into<String>, needs: FilterClass) -> Filter {
+        Filter {
+            vars,
+            expr: expr.into(),
+            needs,
+        }
+    }
+}
+
+/// Whether a source whose capability advertises `have` can evaluate a conjunct that
+/// `needs` a given class. The order is `None < Equality < Full`: a source covers a conjunct
+/// iff its class is at least the conjunct's. [OPUS-4.8] sq-7byx.
+fn class_covers(have: FilterClass, needs: FilterClass) -> bool {
+    fn rank(c: FilterClass) -> u8 {
+        match c {
+            FilterClass::None => 0,
+            FilterClass::Equality => 1,
+            FilterClass::Full => 2,
+        }
+    }
+    rank(have) >= rank(needs)
+}
+
+// ─── Exclusive groups (FedX) ────────────────────────────────────────────────────────────
+
+/// A FedX **exclusive group**: a connected set of BGP patterns whose only relevant source is
+/// one member. The pushdown layer sends the whole group to that source as one sub-query (for
+/// a full endpoint) — the most precise query the source can answer for that sub-pattern.
+///
+/// `patterns` are BGP pattern indices, ascending (deterministic). `source` is the single
+/// retained source index (into the descriptor / adapter slice). [OPUS-4.8] sq-7byx.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExclusiveGroup {
+    /// The single source index every pattern in this group is exclusively matched by.
+    pub source: usize,
+    /// The BGP pattern indices in this group, ascending.
+    pub patterns: Vec<usize>,
+}
+
+/// Derive the FedX exclusive groups from the planner's per-pattern source selection.
+///
+/// A pattern is **exclusive** when [`select_sources`](sparq_fedplan::select_sources) retained
+/// **exactly one** source for it. Two exclusive patterns are merged into one group when they
+/// share that one source **and** are connected by a shared variable (directly or
+/// transitively, via a union-find over the exclusive patterns). The result is the maximal
+/// set of such groups, each addressed to one source.
+///
+/// Patterns with **zero** retained sources (the planner found no source that can contribute —
+/// the BGP is unsatisfiable against this source set) and patterns with **two or more**
+/// retained sources (a cross-source join) are **excluded** from every group: they are not
+/// pushable as part of a single-source sub-query and are handled by the operators phase
+/// (a multi-source leaf fans out; an empty leaf yields no rows). Pushdown never over-claims
+/// a pattern into a group it does not exclusively belong to.
+///
+/// Determinism: groups are returned sorted by their smallest pattern index, and each group's
+/// `patterns` ascending. [OPUS-4.8] sq-7byx.
+pub fn exclusive_groups(selection: &[PatternSources], bgp: &Bgp) -> Vec<ExclusiveGroup> {
+    // The exclusive patterns and their single source.
+    let mut exclusive: Vec<(usize, usize)> = Vec::new(); // (pattern_index, source_index)
+    for ps in selection {
+        if ps.candidates.len() == 1 {
+            exclusive.push((ps.pattern, ps.candidates[0].source));
+        }
+    }
+    if exclusive.is_empty() {
+        return Vec::new();
+    }
+    exclusive.sort_by_key(|&(p, _)| p);
+
+    // Union-find over the exclusive patterns (indexed by their position in `exclusive`).
+    let n = exclusive.len();
+    let mut parent: Vec<usize> = (0..n).collect();
+    fn find(parent: &mut [usize], mut x: usize) -> usize {
+        while parent[x] != x {
+            parent[x] = parent[parent[x]]; // path-halving
+            x = parent[x];
+        }
+        x
+    }
+    // Merge two exclusive patterns iff SAME source AND they share a variable in the BGP.
+    for i in 0..n {
+        for j in (i + 1)..n {
+            if exclusive[i].1 != exclusive[j].1 {
+                continue; // different source — never the same exclusive group.
+            }
+            if bgp.shares_var(exclusive[i].0, exclusive[j].0) {
+                let (ri, rj) = (find(&mut parent, i), find(&mut parent, j));
+                if ri != rj {
+                    parent[ri] = rj;
+                }
+            }
+        }
+    }
+
+    // Collect components → groups. (The union-find roots are computed by index, so the
+    // component key is the representative index; the per-pattern source + pattern come from
+    // `exclusive[i]`.)
+    use std::collections::BTreeMap;
+    let mut groups: BTreeMap<usize, (usize, Vec<usize>)> = BTreeMap::new();
+    let roots: Vec<usize> = (0..n).map(|i| find(&mut parent, i)).collect();
+    for (i, &(pattern, source)) in exclusive.iter().enumerate() {
+        let entry = groups.entry(roots[i]).or_insert((source, Vec::new()));
+        entry.1.push(pattern);
+    }
+    let mut out: Vec<ExclusiveGroup> = groups
+        .into_values()
+        .map(|(source, mut patterns)| {
+            patterns.sort_unstable();
+            ExclusiveGroup { source, patterns }
+        })
+        .collect();
+    // Deterministic order: by the group's smallest pattern index.
+    out.sort_by_key(|g| g.patterns.first().copied().unwrap_or(usize::MAX));
+    out
+}
+
+/// The variables a group's patterns produce (bound terms in any position), de-duplicated,
+/// in pattern-then-position order. These are the variables a pushed FILTER conjunct may
+/// reference and the maximum a projection can keep. [OPUS-4.8] sq-7byx.
+pub fn group_vars(group: &ExclusiveGroup, bgp: &Bgp) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for &pi in &group.patterns {
+        if let Some(tp) = bgp.patterns.get(pi) {
+            for t in [&tp.subject, &tp.predicate, &tp.object] {
+                if let Term::Var(v) = t {
+                    if !out.iter().any(|n| n == &v.0) {
+                        out.push(v.0.clone());
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+// ─── The exact common-variable check ────────────────────────────────────────────────────
+
+/// The **exact common-variable check** (design §4.3, the check Comunica omits — #834/#609):
+/// a FILTER conjunct may be pushed into a group **only when every variable it references is
+/// bound by the group's patterns**.
+///
+/// If a conjunct references a variable the group does not produce, that variable is *unbound*
+/// from the remote source's perspective but *bound* (by a sibling group) from the whole
+/// query's perspective. Evaluating the conjunct remotely would therefore use a different
+/// (unbound) value than local evaluation and could drop a solution the local plan keeps — so
+/// such a conjunct is **not** pushed; it is kept local on the residual. Returns `true` iff
+/// the conjunct is safe to push by this check alone (the caller separately checks the source
+/// covers the conjunct's [`FilterClass`]). [OPUS-4.8] sq-7byx.
+pub fn common_variable_check(filter: &Filter, group_vars: &[String]) -> bool {
+    filter.vars.iter().all(|v| group_vars.iter().any(|g| g == v))
+}
+
+// ─── The maximal sub-algebra builder ────────────────────────────────────────────────────
+
+/// The outcome of pushing one exclusive group to its source: the [`SubQuery`] to send, plus
+/// the honest record of which FILTER conjuncts were pushed and which were kept local (the
+/// residual the local engine must still evaluate). [OPUS-4.8] sq-7byx.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushedGroup {
+    /// The maximal sub-query the source is asked (projection + pushed filters + order/limit).
+    pub sub: SubQuery,
+    /// Indices (into the `filters` slice passed to [`push_group`]) of the conjuncts pushed
+    /// into `sub` — covered by the source's class AND passing the common-variable check.
+    pub pushed_filters: Vec<usize>,
+    /// Indices of the conjuncts kept **local** (class not covered, or common-variable check
+    /// failed) — the residual the local engine evaluates after the source answers.
+    pub local_filters: Vec<usize>,
+}
+
+/// Build the **maximal evaluable sub-algebra** the group's source can answer (design §4.3).
+///
+/// `output_vars` are the variables the whole query needs out of this group (its projection +
+/// any variable it joins to another group on); the pushed projection is trimmed to exactly
+/// the intersection of those with the group's variables — everything else is internal to the
+/// group and need not come back. `filters` are the query's FILTER conjuncts; each is pushed
+/// **iff** the source's [`Capability::pushable_filters`] class covers it AND it passes
+/// [`common_variable_check`] — otherwise it is recorded in `local_filters` for the residual.
+/// `order_keys` (rendered SPARQL sort keys) and `limit` are pushed only when the capability's
+/// `order_limit` is set.
+///
+/// The pushed shape depends on the interface:
+/// * [`Interface::Endpoint`] / [`Interface::LocalEngine`] → a **multi-pattern** `SELECT
+///   <proj> WHERE { tp … FILTER(<expr>) … } ORDER BY <keys> LIMIT <n>` — the whole group as
+///   one sub-query;
+/// * [`Interface::BrTpf`] / [`Interface::Tpf`] → a fragment server's access unit is **one**
+///   triple pattern, so a multi-pattern group is **not** collapsed: `push_group` emits a
+///   single-pattern `SELECT` for the group's *first* pattern and pushes **no** filter /
+///   order / limit (those capabilities are off for a fragment source); the remaining
+///   patterns and the join stay client-side. (The operators phase issues one fragment fetch
+///   per pattern; `push_group` is the per-group entry the endpoint path uses fully and the
+///   fragment path uses minimally — honest, not an overclaim that a fragment server answers a
+///   multi-pattern BGP.)
+///
+/// Returns `None` only when the group is empty or names a pattern index out of range for the
+/// BGP (a malformed group — fail closed rather than emit a partial query). [OPUS-4.8] sq-7byx.
+pub fn push_group(
+    group: &ExclusiveGroup,
+    bgp: &Bgp,
+    cap: &Capability,
+    output_vars: &[String],
+    filters: &[Filter],
+    order_keys: &[String],
+    limit: Option<u64>,
+) -> Option<PushedGroup> {
+    if group.patterns.is_empty() {
+        return None;
+    }
+    // Resolve the group's patterns up front (fail closed on a bad index).
+    let mut pats: Vec<&TriplePattern> = Vec::with_capacity(group.patterns.len());
+    for &pi in &group.patterns {
+        pats.push(bgp.patterns.get(pi)?);
+    }
+
+    let gvars = group_vars(group, bgp);
+
+    // Fragment sources answer ONE pattern; do not collapse a multi-pattern group, and push
+    // no filter/order/limit (a fragment server evaluates none of them).
+    let fragment = matches!(cap.interface, Interface::BrTpf | Interface::Tpf);
+
+    // --- Projection: keep exactly the group vars the whole query needs out of this group.
+    // For a fragment source the sub-query is the FIRST pattern only, so project that
+    // pattern's vars that are needed (a fragment SELECT still narrows columns).
+    let projectable: Vec<String> = if fragment {
+        pattern_vars(pats[0])
+    } else {
+        gvars.clone()
+    };
+    let project: Vec<String> = projectable
+        .iter()
+        .filter(|v| output_vars.iter().any(|o| o == *v))
+        .cloned()
+        .collect();
+
+    // --- Filters: push a conjunct iff the source's class covers it AND it passes the exact
+    // common-variable check. Fragment sources push none.
+    let mut pushed_filters: Vec<usize> = Vec::new();
+    let mut local_filters: Vec<usize> = Vec::new();
+    for (i, f) in filters.iter().enumerate() {
+        let pushable = !fragment
+            && class_covers(cap.pushable_filters, f.needs)
+            && common_variable_check(f, &gvars);
+        if pushable {
+            pushed_filters.push(i);
+        } else {
+            local_filters.push(i);
+        }
+    }
+
+    // --- Render the pattern block (one pattern for a fragment source, all for an endpoint).
+    let render_pat = |tp: &TriplePattern| -> String {
+        format!(
+            "{} {} {}",
+            render_term(&tp.subject),
+            render_term(&tp.predicate),
+            render_term(&tp.object)
+        )
+    };
+    let body = if fragment {
+        render_pat(pats[0])
+    } else {
+        pats.iter()
+            .map(|tp| render_pat(tp))
+            .collect::<Vec<_>>()
+            .join(" . ")
+    };
+
+    // --- Projection clause: `SELECT ?a ?b` or `SELECT *` when nothing narrower is requested
+    // (an empty `output_vars` means "the caller wants whatever the group projects").
+    let proj_clause = if project.is_empty() && output_vars.is_empty() {
+        "*".to_string()
+    } else if project.is_empty() {
+        // The caller asked for vars, none of which this group produces: a `SELECT *` would
+        // over-return, so project the empty set explicitly as the group's own vars (the
+        // join still reattaches). Keep it precise: project the group's vars.
+        let v = if fragment { pattern_vars(pats[0]) } else { gvars };
+        if v.is_empty() {
+            "*".to_string()
+        } else {
+            v.iter().map(|n| format!("?{}", n)).collect::<Vec<_>>().join(" ")
+        }
+    } else {
+        project.iter().map(|n| format!("?{}", n)).collect::<Vec<_>>().join(" ")
+    };
+
+    // --- FILTER clause(s) for the pushed conjuncts.
+    let mut where_clause = body;
+    for &i in &pushed_filters {
+        where_clause.push_str(&format!(" FILTER({})", filters[i].expr));
+    }
+
+    let mut sparql = format!("SELECT {} WHERE {{ {} }}", proj_clause, where_clause);
+
+    // --- ORDER BY / LIMIT only when the capability covers them (never for a fragment source).
+    if !fragment && cap.order_limit {
+        if !order_keys.is_empty() {
+            sparql.push_str(&format!(" ORDER BY {}", order_keys.join(" ")));
+        }
+        if let Some(n) = limit {
+            sparql.push_str(&format!(" LIMIT {}", n));
+        }
+    }
+
+    Some(PushedGroup {
+        sub: SubQuery {
+            sparql,
+            project: if project.is_empty() && output_vars.is_empty() {
+                // No explicit narrowing requested — let the query's projection stand.
+                Vec::new()
+            } else {
+                project
+            },
+        },
+        pushed_filters,
+        local_filters,
+    })
+}
+
+/// The variables a pattern produces, de-duplicated in subject→predicate→object position
+/// order. (Local copy so pushdown does not reach into the planner module's helper; the
+/// shapes are identical.) [OPUS-4.8] sq-7byx.
+fn pattern_vars(tp: &TriplePattern) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for t in [&tp.subject, &tp.predicate, &tp.object] {
+        if let Term::Var(v) = t {
+            if !out.iter().any(|n| n == &v.0) {
+                out.push(v.0.clone());
+            }
+        }
+    }
+    out
+}
+
+/// Render a light `sparq-fedplan` [`Term`] as a SPARQL term string: a variable as `?name`,
+/// an IRI in `<>`, a literal verbatim if it already carries SPARQL literal syntax (a leading
+/// `"`) else quoted + escaped. Same convention as `planner::render_term`. [OPUS-4.8] sq-7byx.
+fn render_term(t: &Term) -> String {
+    match t {
+        Term::Var(v) => format!("?{}", v.0),
+        Term::Iri(iri) => format!("<{}>", iri),
+        Term::Literal(lit) => {
+            if lit.starts_with('"') {
+                lit.clone()
+            } else {
+                format!("\"{}\"", escape_literal(lit))
+            }
+        }
+    }
+}
+
+/// Minimal SPARQL string-literal escaping for a bare lexical value. [OPUS-4.8] sq-7byx.
+fn escape_literal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sparq_fedplan::{SourceCandidate, Var};
+
+    fn iri(s: &str) -> Term {
+        Term::Iri(s.to_string())
+    }
+    fn var(s: &str) -> Term {
+        Term::Var(Var::new(s))
+    }
+    fn tp(s: Term, p: Term, o: Term) -> TriplePattern {
+        TriplePattern::new(s, p, o)
+    }
+    /// Build a `PatternSources` selection naming, per pattern, the retained source indices.
+    fn sel(per_pattern: &[&[usize]]) -> Vec<PatternSources> {
+        per_pattern
+            .iter()
+            .enumerate()
+            .map(|(pi, srcs)| PatternSources {
+                pattern: pi,
+                candidates: srcs
+                    .iter()
+                    .map(|&s| SourceCandidate {
+                        source: s,
+                        estimated_cardinality: 1.0,
+                    })
+                    .collect(),
+            })
+            .collect()
+    }
+
+    // ─── Exclusive-group derivation ──────────────────────────────────────────────────
+
+    #[test]
+    fn exclusive_group_merges_connected_same_source_patterns() {
+        // ?s :p ?o  and  ?o :q ?z  — both exclusively source 0, share ?o ⇒ one group.
+        let bgp = Bgp::new(vec![
+            tp(var("s"), iri("http://ex/p"), var("o")),
+            tp(var("o"), iri("http://ex/q"), var("z")),
+        ]);
+        let selection = sel(&[&[0], &[0]]);
+        let groups = exclusive_groups(&selection, &bgp);
+        assert_eq!(
+            groups,
+            vec![ExclusiveGroup {
+                source: 0,
+                patterns: vec![0, 1],
+            }]
+        );
+    }
+
+    #[test]
+    fn exclusive_group_splits_different_sources() {
+        // Same shape but pattern 1 is source 1 ⇒ two singleton groups, no merge.
+        let bgp = Bgp::new(vec![
+            tp(var("s"), iri("http://ex/p"), var("o")),
+            tp(var("o"), iri("http://ex/q"), var("z")),
+        ]);
+        let selection = sel(&[&[0], &[1]]);
+        let groups = exclusive_groups(&selection, &bgp);
+        assert_eq!(
+            groups,
+            vec![
+                ExclusiveGroup {
+                    source: 0,
+                    patterns: vec![0],
+                },
+                ExclusiveGroup {
+                    source: 1,
+                    patterns: vec![1],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn exclusive_group_excludes_multi_and_zero_source_patterns() {
+        // p0 exclusive src 0; p1 has TWO sources (cross-source — excluded); p2 zero (excluded).
+        let bgp = Bgp::new(vec![
+            tp(var("s"), iri("http://ex/p"), var("o")),
+            tp(var("o"), iri("http://ex/q"), var("z")),
+            tp(var("z"), iri("http://ex/r"), var("w")),
+        ]);
+        let selection = sel(&[&[0], &[0, 1], &[]]);
+        let groups = exclusive_groups(&selection, &bgp);
+        // Only p0 is exclusive; p1 (multi) and p2 (zero) are not in any group.
+        assert_eq!(
+            groups,
+            vec![ExclusiveGroup {
+                source: 0,
+                patterns: vec![0],
+            }]
+        );
+    }
+
+    #[test]
+    fn exclusive_group_does_not_merge_disconnected_same_source() {
+        // Two patterns, same source 0, but NO shared variable ⇒ two groups (not one).
+        let bgp = Bgp::new(vec![
+            tp(var("a"), iri("http://ex/p"), var("b")),
+            tp(var("c"), iri("http://ex/q"), var("d")),
+        ]);
+        let selection = sel(&[&[0], &[0]]);
+        let groups = exclusive_groups(&selection, &bgp);
+        assert_eq!(
+            groups,
+            vec![
+                ExclusiveGroup {
+                    source: 0,
+                    patterns: vec![0],
+                },
+                ExclusiveGroup {
+                    source: 0,
+                    patterns: vec![1],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn exclusive_group_transitive_chain() {
+        // p0—p1 via ?b, p1—p2 via ?c: a transitive chain ⇒ ONE group of all three.
+        let bgp = Bgp::new(vec![
+            tp(var("a"), iri("http://ex/p"), var("b")),
+            tp(var("b"), iri("http://ex/q"), var("c")),
+            tp(var("c"), iri("http://ex/r"), var("d")),
+        ]);
+        let selection = sel(&[&[2], &[2], &[2]]);
+        let groups = exclusive_groups(&selection, &bgp);
+        assert_eq!(
+            groups,
+            vec![ExclusiveGroup {
+                source: 2,
+                patterns: vec![0, 1, 2],
+            }]
+        );
+    }
+
+    // ─── The exact common-variable check ─────────────────────────────────────────────
+
+    #[test]
+    fn common_variable_check_pushes_only_group_bound_filters() {
+        let group_bound = vec!["s".to_string(), "o".to_string()];
+        // All vars bound by the group ⇒ pushable.
+        let f_ok = Filter::new(vec!["o".to_string()], "?o > 18", FilterClass::Full);
+        assert!(common_variable_check(&f_ok, &group_bound));
+        // A var NOT bound by the group (?z lives in a sibling group) ⇒ NOT pushable.
+        let f_bad = Filter::new(vec!["z".to_string()], "?z > 18", FilterClass::Full);
+        assert!(!common_variable_check(&f_bad, &group_bound));
+        // Mixed: one bound, one not ⇒ NOT pushable (ALL vars must be bound).
+        let f_mixed = Filter::new(
+            vec!["o".to_string(), "z".to_string()],
+            "?o > ?z",
+            FilterClass::Full,
+        );
+        assert!(!common_variable_check(&f_mixed, &group_bound));
+        // A constant-only conjunct (no vars) is trivially pushable.
+        let f_const = Filter::new(vec![], "1 = 1", FilterClass::Equality);
+        assert!(common_variable_check(&f_const, &group_bound));
+    }
+
+    // ─── Maximal sub-algebra builder (the pushed blocks) ─────────────────────────────
+
+    #[test]
+    fn push_group_endpoint_collapses_group_and_pushes_covered_filter() {
+        let bgp = Bgp::new(vec![
+            tp(var("s"), iri("http://ex/age"), var("age")),
+            tp(var("s"), iri("http://ex/name"), var("name")),
+        ]);
+        let group = ExclusiveGroup {
+            source: 0,
+            patterns: vec![0, 1],
+        };
+        let cap = Capability::endpoint();
+        // Output: ?name only (?s is a join var also needed → include it).
+        let output = vec!["s".to_string(), "name".to_string()];
+        let filters = vec![
+            // pushable: ?age is group-bound, Full covers it.
+            Filter::new(vec!["age".to_string()], "?age > 18", FilterClass::Full),
+            // NOT pushable: ?city is not in the group (sibling group var).
+            Filter::new(vec!["city".to_string()], "?city = \"NYC\"", FilterClass::Full),
+        ];
+        let pushed = push_group(&group, &bgp, &cap, &output, &filters, &[], None).unwrap();
+        // The whole group is one sub-query, projecting exactly ?s ?name, pushing FILTER(?age>18).
+        assert_eq!(
+            pushed.sub.sparql,
+            "SELECT ?s ?name WHERE { ?s <http://ex/age> ?age . ?s <http://ex/name> ?name FILTER(?age > 18) }"
+        );
+        assert_eq!(pushed.sub.project, vec!["s".to_string(), "name".to_string()]);
+        assert_eq!(pushed.pushed_filters, vec![0]); // first filter pushed
+        assert_eq!(pushed.local_filters, vec![1]); // second kept local
+    }
+
+    #[test]
+    fn push_group_endpoint_pushes_order_limit_when_capability_allows() {
+        let bgp = Bgp::new(vec![tp(var("s"), iri("http://ex/p"), var("o"))]);
+        let group = ExclusiveGroup {
+            source: 0,
+            patterns: vec![0],
+        };
+        let cap = Capability::endpoint(); // order_limit = true
+        let pushed = push_group(
+            &group,
+            &bgp,
+            &cap,
+            &["s".to_string(), "o".to_string()],
+            &[],
+            &["?o".to_string()],
+            Some(10),
+        )
+        .unwrap();
+        assert_eq!(
+            pushed.sub.sparql,
+            "SELECT ?s ?o WHERE { ?s <http://ex/p> ?o } ORDER BY ?o LIMIT 10"
+        );
+    }
+
+    #[test]
+    fn push_group_does_not_push_order_limit_when_capability_forbids() {
+        // brTPF capability has order_limit = false AND is a fragment source.
+        let bgp = Bgp::new(vec![tp(var("s"), iri("http://ex/p"), var("o"))]);
+        let group = ExclusiveGroup {
+            source: 0,
+            patterns: vec![0],
+        };
+        let cap = Capability::brtpf(20);
+        let pushed = push_group(
+            &group,
+            &bgp,
+            &cap,
+            &["s".to_string(), "o".to_string()],
+            &[],
+            &["?o".to_string()],
+            Some(10),
+        )
+        .unwrap();
+        // No ORDER/LIMIT pushed (capability forbids).
+        assert_eq!(
+            pushed.sub.sparql,
+            "SELECT ?s ?o WHERE { ?s <http://ex/p> ?o }"
+        );
+    }
+
+    #[test]
+    fn push_group_fragment_source_does_not_collapse_or_filter() {
+        // A 2-pattern group on a brTPF source: pushdown emits the FIRST pattern only and
+        // pushes NO filter (a fragment server answers one pattern, evaluates no FILTER).
+        let bgp = Bgp::new(vec![
+            tp(var("s"), iri("http://ex/p"), var("o")),
+            tp(var("o"), iri("http://ex/q"), var("z")),
+        ]);
+        let group = ExclusiveGroup {
+            source: 0,
+            patterns: vec![0, 1],
+        };
+        let cap = Capability::brtpf(20);
+        let filters = vec![Filter::new(
+            vec!["o".to_string()],
+            "?o > 18",
+            FilterClass::Full,
+        )];
+        let pushed = push_group(
+            &group,
+            &bgp,
+            &cap,
+            &["s".to_string(), "o".to_string(), "z".to_string()],
+            &filters,
+            &[],
+            None,
+        )
+        .unwrap();
+        // First pattern only; no FILTER; the filter is recorded local.
+        assert_eq!(
+            pushed.sub.sparql,
+            "SELECT ?s ?o WHERE { ?s <http://ex/p> ?o }"
+        );
+        assert!(pushed.pushed_filters.is_empty());
+        assert_eq!(pushed.local_filters, vec![0]);
+    }
+
+    #[test]
+    fn push_group_filter_kept_local_when_class_not_covered() {
+        // A plain-TPF-like capability with FilterClass::None never pushes a filter even if
+        // its vars are group-bound. (Use an endpoint cap with the filter needing Full but
+        // a cap whose class is only Equality to exercise the class check on a non-fragment.)
+        let bgp = Bgp::new(vec![tp(var("s"), iri("http://ex/age"), var("age"))]);
+        let group = ExclusiveGroup {
+            source: 0,
+            patterns: vec![0],
+        };
+        let mut cap = Capability::endpoint();
+        cap.pushable_filters = FilterClass::Equality; // covers Equality, not Full
+        let filters = vec![
+            // needs Full > Equality ⇒ NOT pushable (class not covered), kept local.
+            Filter::new(vec!["age".to_string()], "?age > 18", FilterClass::Full),
+            // needs Equality ⇒ pushable.
+            Filter::new(
+                vec!["age".to_string()],
+                "?age = 18",
+                FilterClass::Equality,
+            ),
+        ];
+        let pushed = push_group(
+            &group,
+            &bgp,
+            &cap,
+            &["s".to_string(), "age".to_string()],
+            &filters,
+            &[],
+            None,
+        )
+        .unwrap();
+        assert_eq!(pushed.pushed_filters, vec![1]);
+        assert_eq!(pushed.local_filters, vec![0]);
+        assert_eq!(
+            pushed.sub.sparql,
+            "SELECT ?s ?age WHERE { ?s <http://ex/age> ?age FILTER(?age = 18) }"
+        );
+    }
+
+    #[test]
+    fn push_group_trims_projection_to_needed_vars() {
+        // Group produces ?s ?age ?name; the query needs only ?name → projection is just ?name.
+        let bgp = Bgp::new(vec![
+            tp(var("s"), iri("http://ex/age"), var("age")),
+            tp(var("s"), iri("http://ex/name"), var("name")),
+        ]);
+        let group = ExclusiveGroup {
+            source: 0,
+            patterns: vec![0, 1],
+        };
+        let cap = Capability::endpoint();
+        let pushed = push_group(
+            &group,
+            &bgp,
+            &cap,
+            &["name".to_string()],
+            &[],
+            &[],
+            None,
+        )
+        .unwrap();
+        assert_eq!(pushed.sub.project, vec!["name".to_string()]);
+        assert_eq!(
+            pushed.sub.sparql,
+            "SELECT ?name WHERE { ?s <http://ex/age> ?age . ?s <http://ex/name> ?name }"
+        );
+    }
+
+    #[test]
+    fn push_group_empty_output_is_select_star() {
+        let bgp = Bgp::new(vec![tp(var("s"), iri("http://ex/p"), var("o"))]);
+        let group = ExclusiveGroup {
+            source: 0,
+            patterns: vec![0],
+        };
+        let cap = Capability::endpoint();
+        let pushed = push_group(&group, &bgp, &cap, &[], &[], &[], None).unwrap();
+        assert_eq!(
+            pushed.sub.sparql,
+            "SELECT * WHERE { ?s <http://ex/p> ?o }"
+        );
+        assert!(pushed.sub.project.is_empty());
+    }
+
+    #[test]
+    fn push_group_out_of_range_pattern_fails_closed() {
+        let bgp = Bgp::new(vec![tp(var("s"), iri("http://ex/p"), var("o"))]);
+        let group = ExclusiveGroup {
+            source: 0,
+            patterns: vec![9], // out of range
+        };
+        let cap = Capability::endpoint();
+        assert!(push_group(&group, &bgp, &cap, &[], &[], &[], None).is_none());
+    }
+
+    // ─── Bind-join block primitive ───────────────────────────────────────────────────
+
+    #[test]
+    fn bind_block_size_per_capability() {
+        assert_eq!(bind_block_size(&Capability::endpoint()), DEFAULT_BIND_BLOCK);
+        assert_eq!(bind_block_size(&Capability::brtpf(30)), 30);
+        assert_eq!(bind_block_size(&Capability::brtpf(0)), 1); // clamped to >= 1
+        assert_eq!(bind_block_size(&Capability::tpf()), 0); // no bind-join
+    }
+
+    #[test]
+    fn render_values_block_single_and_multi_var() {
+        // Single var → short form.
+        let single = render_values_block(
+            &["j".to_string()],
+            &[vec!["<http://ex/a>".to_string()], vec!["<http://ex/b>".to_string()]],
+        );
+        assert_eq!(single, "VALUES ?j { <http://ex/a> <http://ex/b> }");
+        // Multi var → parenthesised form.
+        let multi = render_values_block(
+            &["a".to_string(), "b".to_string()],
+            &[
+                vec!["<http://ex/a1>".to_string(), "<http://ex/b1>".to_string()],
+                vec!["<http://ex/a2>".to_string(), "<http://ex/b2>".to_string()],
+            ],
+        );
+        assert_eq!(
+            multi,
+            "VALUES (?a ?b) { (<http://ex/a1> <http://ex/b1>) (<http://ex/a2> <http://ex/b2>) }"
+        );
+        // Empty inputs → empty block (nothing to push).
+        assert_eq!(render_values_block(&[], &[]), "");
+        assert_eq!(render_values_block(&["j".to_string()], &[]), "");
+    }
+}

--- a/skills/federated-planning/SKILL.md
+++ b/skills/federated-planning/SKILL.md
@@ -240,6 +240,22 @@ since:
   + blocking; the `StreamJoin` feeder, concurrent fan-out, pushed-down bind-join, and
   multi-source UNION are Phase 5 (a multi-source leaf fails closed with
   `InterpError::MultiSource`).
+- **Phase 4 capability-aware pushdown** (`sq-7byx`) — the `pushdown` module decides the most
+  precise sub-query each source is asked. `exclusive_groups(selection, bgp)` derives the FedX
+  **exclusive groups** (maximal connected sub-patterns whose only retained source is one
+  member — exactly-one-source, same-source, share-a-variable, via union-find); a cross-source
+  or zero-source pattern is excluded. `push_group(...)` builds the **maximal sub-algebra** per
+  group: projection trimmed to the join + output vars, the FILTER conjuncts the source's
+  `FilterClass` covers AND that pass the common-variable check, `ORDER`/`LIMIT` when the
+  capability allows — a full endpoint gets the whole group as one multi-pattern `SELECT`, a
+  fragment source answers one pattern only (no collapse, no filter pushed — honest about a
+  fragment server's access unit). `common_variable_check(filter, group_vars)` is the **exact**
+  check Comunica omits (#834/#609): push a conjunct only when *every* variable it references is
+  bound by the group. `render_values_block` / `bind_block_size` are the cross-group bind-join
+  block primitive (VALUES for endpoints — `DEFAULT_BIND_BLOCK`; `maxMpR` for brTPF; none for
+  plain TPF), mirroring `sparq-engine`'s `pub(crate)` `service.rs` helpers. Pushdown only ever
+  **narrows** a source's result, so it is correctness-preserving; the FILTER model is light
+  (the parsed-query FILTER algebra wiring is Phase 5).
 - **Phase 6 the brTPF + TPF fragment adapters** (`sq-2qze`): `source::TpfSource` (plain TPF —
   materialise a fragment to exhaustion, no bind-join) and `source::BrTpfSource`
   (bindings-restricted — push `maxMpR`-bounded binding blocks per request, the standardised
@@ -250,9 +266,8 @@ since:
   SPARQL-Results-JSON, so their `FederatedSource::execute` is a deliberate `Unsupported` that
   points at `solutions`).
 
-Still to come (future beads under the epic): capability-aware pushdown, the streaming
-operators + multi-source fan-out, and adaptive re-planning. See
-`crates/sparq-fedclient/README.md`.
+Still to come (future beads under the epic): the streaming operators + multi-source fan-out,
+and adaptive re-planning. See `crates/sparq-fedclient/README.md`.
 
 ## Deferred (NOT here)
 
@@ -262,4 +277,4 @@ a replica mid-stage when a source goes dark — observed latency now *biases the
 toward faster sources, but hard failover needs the live multi-source execution layer this pure
 crate does not own) are out of scope. Filed as roadmap beads under epic **sq-3183**.
 
-[OPUS-4.8] sq-a35t / sq-vf7q / sq-7s4z / sq-b51o — flag for Fable re-review.
+[OPUS-4.8] sq-a35t / sq-vf7q / sq-7s4z / sq-b51o / sq-7byx — flag for Fable re-review.


### PR DESCRIPTION
> 🤖 SPARQ agent — Phase 4 of the streaming federation client (epic **sq-dnko** / sq-3183). I am one of multiple agents @jeswr runs; this PR is mine.

## What this implements (bead sq-7byx)

The §4.3 **capability-aware pushdown** layer in `crates/sparq-fedclient/src/pushdown.rs`, behind the default-OFF `fedclient` feature. The planner (Phase 3) decides *which* source answers *which* pattern; this module decides the **most precise sub-query** each source is asked — pushing the maximal evaluable sub-algebra per **FedX exclusive group**, gated by the **exact common-variable check**.

- **`exclusive_groups(selection, bgp)`** — FedX exclusive-group decomposition from the planner's per-pattern source selection (`PatternSources`): the maximal connected sub-patterns that each have **exactly one** retained source, the **same** source, and **share a variable** (transitively, via union-find). A pattern matched by two-or-more sources (cross-source join) or zero sources is **excluded** from every group.
- **`push_group(group, bgp, cap, output_vars, filters, order_keys, limit)`** — the **maximal sub-algebra builder**: projection trimmed to the join + output vars; the FILTER conjuncts the source's `FilterClass` covers AND that pass the common-variable check; `ORDER`/`LIMIT` only when the capability allows. A **full endpoint** gets the whole group as one multi-pattern `SELECT`; a **fragment source** (brTPF / plain TPF) answers **one** pattern (no collapse, no filter pushed — honest about a fragment server's access unit). Records pushed vs **local (residual)** filters.
- **`common_variable_check(filter, group_vars)`** — the **exact** check Comunica is documented to omit (#834/#609): push a conjunct only when **every** variable it references is bound by the group. This is the load-bearing safety invariant — push only the provably-identical sub-algebra.
- **`render_values_block` / `bind_block_size`** — the cross-group **bind-join block** primitive (VALUES for endpoints — `DEFAULT_BIND_BLOCK`; `maxMpR` for brTPF; none for plain TPF), mirroring `sparq-engine`'s `pub(crate)` `service.rs` helpers byte-for-byte.

Pushdown only ever **narrows** what a source returns (pushed FILTER removes solutions, trimmed projection removes columns, `VALUES`/`maxMpR` bounds requested rows), so it is **correctness-preserving** by construction; anything a source cannot evaluate is kept local on the residual.

## Honest work-vs-stub split

**REAL (tested):** the exclusive-group decomposition (union-find, transitive, multi/zero-source exclusion, disconnected-not-merged), the maximal sub-algebra builder (group collapse, projection trimming, pushed-vs-local filter classification, ORDER/LIMIT gating, fragment-source single-pattern shape, fail-closed on a bad pattern index), the exact common-variable check, the class-coverage check, and the bind-join block primitive + size policy. 16 new unit tests assert the **pushed blocks** + the **common-variable check**.

**STUB / Phase 5 (no overclaim):** the FILTER conjuncts are a light pre-parsed model (`Filter` = vars + rendered expr + required class) — wiring the real `spargebra` parsed-query FILTER algebra and the disjunctive-filter decomposition is Phase 5's job when the operators consume a whole query (not a bare BGP). The bind-join block here is the *rendered block + size policy*; the operator that gathers upstream bindings, slices them into blocks, and streams per-block matches is Phase 5 (`operators.rs`/`stream.rs` — owned by the sibling agent, **untouched here**). `ORDER BY` keys are taken as an argument (the query's ORDER parsing is Phase 5).

## Shared-crate discipline

Phase 4 **owns `pushdown.rs`**; Phase 5 owns `operators.rs`/`stream.rs`. `lib.rs` is touched **minimally** — a single re-export block appended right after `pub mod pushdown;` — so the sibling merge stays trivial. `planner.rs` untouched.

## Gates (GREEN in BOTH feature states)

Feature flag: **`fedclient`** (default OFF).

- `cargo build -p sparq-fedclient` (default) + `--features fedclient` ✅
- `cargo clippy -p sparq-fedclient --all-targets -- -D warnings` (default) + `--features fedclient` ✅
- `cargo test -p sparq-fedclient` (default: 0 tests, empty crate) + `--features fedclient` (64 unit incl. 16 new pushdown; 2 boundary; 6 result-equivalence) ✅
- `scripts/fedclient-boundary-guard.sh` → OK (neither `sparq-core` nor `sparq-engine` depends on `sparq-fedclient`) ✅
- Workspace default `cargo build` ✅ (no regression)

Auto-merge **not** enabled (per the bead).

[OPUS-4.8] sq-7byx — flagged for Fable re-review when available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)