### PR TITLE
feat(sparq-server): bound writer-queue head-of-line blocking from a slow UPDATE (sq-nulp)

### DIFF
--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -353,7 +353,9 @@ matrix under "Security posture".
 - **Authentication** — optional `--auth-token <TOKEN>` Bearer gate on the write surface
   (constant-time compared; mirrors QLever's `-a`), with an optional `--auth-token-read` gate
   for reads. Off by default (back-compat). See "Security posture".
-- **Hardening flags** — `--query-timeout` / `--max-body-bytes` / `--max-concurrent` /
+- **Hardening flags** — `--query-timeout` / `--update-where-timeout` (separate, typically-shorter
+  writer-side WHERE deadline that bounds writer-queue **head-of-line blocking** from a slow
+  UPDATE, `sq-nulp`) / `--max-body-bytes` / `--max-concurrent` /
   `--max-results` / `--max-query-rows` (coarse memory cap) / `--max-query-bytes`
   (byte-accounted memory cap, `sq-s5is`) / `--max-decompress-ratio` (zip-bomb guard) /
   `--service-allow*` (SERVICE SSRF egress) / `--max-subscriptions*`, each with a `SPARQ_*` env

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -113,6 +113,28 @@ pub struct ServerConfig {
     /// `timeout + TIMEOUT_GRACE` guarantees the HTTP 503 even if the engine is inside
     /// an uninstrumented stretch. `None` disables the timeout.
     pub query_timeout: Option<Duration>,
+    /// [OPUS-4.8] (sq-nulp) **Writer-side WHERE deadline for SPARQL UPDATE — a head-of-line
+    /// blocking bound.** Updates are *sequenced* on a single writer thread (sparq-serve's
+    /// group-commit writer), so while one update runs its `DELETE/INSERT … WHERE` to its
+    /// cooperative stop, every queued update behind it waits. The plain [`query_timeout`](Self::query_timeout)
+    /// already bounds the WHERE evaluation, but it is the *read* timeout (default 30 s) — far
+    /// too long to hold the writer, because it bounds the offending client's own wait, not the
+    /// head-of-line blocking of the whole writer queue.
+    ///
+    /// When set, this is a SEPARATE, typically-shorter cooperative deadline applied ONLY to
+    /// the WHERE phase of an UPDATE on the writer thread: the update's budget deadline becomes
+    /// `min(query_timeout, update_where_timeout)`, so any single update releases the writer
+    /// within this bound and the queue behind it cannot be head-of-line blocked longer than
+    /// that — *no matter how long the read timeout is*. `None` (the default) keeps the
+    /// historical behaviour exactly: the update WHERE budget is the plain [`query_timeout`](Self::query_timeout).
+    ///
+    /// This is a cooperative deadline (checked at the engine's coarse sites — operator entry /
+    /// per outer-loop iteration), so it bounds head-of-line blocking *approximately*, like
+    /// every other [`QueryBudget`] deadline: an uninstrumented stretch can overrun until the
+    /// next check. It is a tunable backstop, not a hard preemption (true preemption of the
+    /// writer is out of scope — see `sparq_serve`'s scheduler docs). Set via
+    /// `--update-where-timeout` / `SPARQ_UPDATE_WHERE_TIMEOUT` (seconds; `0` disables).
+    pub update_where_timeout: Option<Duration>,
     /// Maximum accepted request body, enforced before the handler reads it (413).
     pub max_body_bytes: usize,
     /// Maximum in-flight requests; excess requests are shed with 429.
@@ -344,6 +366,10 @@ impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             query_timeout: Some(Duration::from_secs(30)),
+            // [OPUS-4.8] sq-nulp: no separate writer-side WHERE deadline by default — an
+            // update's WHERE budget is the plain query_timeout, exactly as before. An operator
+            // who wants to bound writer-queue head-of-line blocking opts a shorter one in.
+            update_where_timeout: None,
             max_body_bytes: 1024 * 1024, // 1 MiB
             max_concurrent: 32,
             max_results: None,
@@ -397,7 +423,10 @@ impl Default for ServerConfig {
 
 impl ServerConfig {
     /// Defaults overridden by the `SPARQ_QUERY_TIMEOUT` (seconds; `0` disables),
-    /// `SPARQ_MAX_BODY_BYTES`, `SPARQ_MAX_CONCURRENT`, `SPARQ_MAX_RESULTS`,
+    /// `SPARQ_UPDATE_WHERE_TIMEOUT` ([OPUS-4.8] sq-nulp: the separate, typically-shorter
+    /// writer-side WHERE deadline that bounds writer-queue head-of-line blocking from a slow
+    /// UPDATE; seconds, `0`/unset disables — the update WHERE budget is then the plain
+    /// `query_timeout`), `SPARQ_MAX_BODY_BYTES`, `SPARQ_MAX_CONCURRENT`, `SPARQ_MAX_RESULTS`,
     /// `SPARQ_MAX_QUERY_ROWS` ([OPUS-4.8] sq-ebii: the coarse memory cap; `0` disables) and
     /// `SPARQ_MAX_DECOMPRESS_RATIO` ([OPUS-4.8] sq-ebii: the zip-bomb guard; `0` refuses gzip
     /// bodies) environment variables — plus, with the `time-travel` feature,
@@ -417,6 +446,12 @@ impl ServerConfig {
         let mut cfg = Self::default();
         if let Some(secs) = env_parse::<u64>("SPARQ_QUERY_TIMEOUT") {
             cfg.query_timeout = (secs > 0).then(|| Duration::from_secs(secs));
+        }
+        // [OPUS-4.8] sq-nulp: separate, typically-shorter writer-side WHERE deadline that
+        // bounds writer-queue head-of-line blocking from a slow UPDATE; 0 / unset disables it
+        // (the update WHERE budget is then the plain query_timeout, exactly as before).
+        if let Some(secs) = env_parse::<u64>("SPARQ_UPDATE_WHERE_TIMEOUT") {
+            cfg.update_where_timeout = (secs > 0).then(|| Duration::from_secs(secs));
         }
         if let Some(n) = env_parse::<usize>("SPARQ_MAX_BODY_BYTES") {
             cfg.max_body_bytes = n;
@@ -2929,16 +2964,37 @@ pub(crate) fn make_budget(config: &ServerConfig, apply_max_results: bool) -> Que
 }
 
 /// [OPUS-4.8] (sq-ebii) The per-UPDATE engine budget: the coarse memory cap
-/// (`--max-query-rows`) as the working-set row ceiling, and the query timeout as a
-/// cooperative deadline measured from NOW (the moment the writer starts this update). The
-/// SELECT-projection cap (`--max-results`) does NOT apply to updates — there is no result to
-/// project — but the working-set memory cap and the deadline do.
+/// (`--max-query-rows`) as the working-set row ceiling, and a cooperative deadline measured
+/// from NOW (the moment the writer starts this update). The SELECT-projection cap
+/// (`--max-results`) does NOT apply to updates — there is no result to project — but the
+/// working-set memory cap and the deadline do.
+///
+/// [OPUS-4.8] (sq-nulp) The WHERE deadline is [`update_where_deadline`]: the TIGHTER of the
+/// read [`query_timeout`](ServerConfig::query_timeout) and the optional, typically-shorter
+/// [`update_where_timeout`](ServerConfig::update_where_timeout). Because updates are sequenced
+/// on a single writer thread, this deadline is what BOUNDS writer-queue head-of-line blocking:
+/// a slow update releases the writer within this window, so the queue behind it cannot be held
+/// longer than that (cooperatively — see [`QueryBudget`]'s coarse-check caveat). With
+/// `update_where_timeout` unset (the default) it is exactly `query_timeout`, unchanged.
 fn update_budget(config: &ServerConfig) -> QueryBudget {
     QueryBudget {
-        deadline: config.query_timeout.map(|t| std::time::Instant::now() + t),
+        deadline: update_where_deadline(config).map(|t| std::time::Instant::now() + t),
         max_rows: config.max_query_rows,
         // [OPUS-4.8] (sq-s5is) the byte cap reaches the UPDATE's WHERE evaluation too.
         max_bytes: config.max_query_bytes,
+    }
+}
+
+/// [OPUS-4.8] (sq-nulp) The effective WHERE-phase deadline for a SPARQL UPDATE on the writer
+/// thread: the tighter of the read [`query_timeout`](ServerConfig::query_timeout) and the
+/// opt-in [`update_where_timeout`](ServerConfig::update_where_timeout). `None` (no deadline)
+/// only when BOTH are unset; otherwise the smaller of whichever are present. This is the knob
+/// that bounds writer-queue head-of-line blocking independently of the (usually longer) read
+/// timeout — see [`update_budget`].
+fn update_where_deadline(config: &ServerConfig) -> Option<Duration> {
+    match (config.query_timeout, config.update_where_timeout) {
+        (Some(q), Some(u)) => Some(q.min(u)),
+        (q, u) => q.or(u),
     }
 }
 
@@ -3002,7 +3058,12 @@ pub(crate) enum UpdateOutcome {
 /// result; (2) the non-WHERE operations (INSERT/DELETE DATA, CLEAR/DROP/CREATE/LOAD) do not
 /// consult the budget (they are bounded by operand size, already capped by `--max-body-bytes`);
 /// (3) updates are *sequenced* on a single writer, so a long-running update blocks the queue
-/// behind it until it finishes — this cap bounds the client's wait, not the writer's work.
+/// behind it until it finishes — this *await* cap bounds the client's own wait, not the writer's
+/// work. [OPUS-4.8] (sq-nulp) The writer's work — and hence that head-of-line blocking — is
+/// bounded SEPARATELY by the WHERE-phase deadline ([`update_budget`] / [`update_where_deadline`]):
+/// `--update-where-timeout` sets a typically-shorter cooperative deadline so a slow update
+/// releases the writer within that window instead of holding it for the full (longer) read
+/// timeout, cooperatively per caveat (1).
 async fn await_update_worker(
     task: tokio::task::JoinHandle<Result<u64, String>>,
     config: &ServerConfig,
@@ -4784,9 +4845,10 @@ mod hardening_unit_tests {
     //! [OPUS-4.8] (sq-ebii) Pure-logic units for the memory cap (`tighter`) and the
     //! decompression-ratio cap (`decode_request_body`). The HTTP-level 413/503 wiring is
     //! covered by tests/hardening.rs; these pin the boundary math without a server boot.
-    use super::{decode_request_body, tighter, ServerConfig};
+    use super::{decode_request_body, tighter, update_where_deadline, ServerConfig};
     use axum::body::Bytes;
     use axum::http::{header, HeaderMap, HeaderValue};
+    use std::time::Duration;
 
     #[test]
     fn tighter_takes_the_smaller_present_cap() {
@@ -4795,6 +4857,39 @@ mod hardening_unit_tests {
         assert_eq!(tighter(None, Some(7)), Some(7));
         assert_eq!(tighter(Some(5), Some(7)), Some(5));
         assert_eq!(tighter(Some(9), Some(7)), Some(7));
+    }
+
+    // [OPUS-4.8] (sq-nulp) The writer-side WHERE deadline for an UPDATE is the TIGHTER of the
+    // read query_timeout and the opt-in update_where_timeout — that smaller value is what
+    // bounds writer-queue head-of-line blocking. `None` only when BOTH are unset.
+    #[test]
+    fn update_where_deadline_is_the_tighter_of_query_and_update_timeouts() {
+        let with = |q: Option<u64>, u: Option<u64>| {
+            update_where_deadline(&ServerConfig {
+                query_timeout: q.map(Duration::from_secs),
+                update_where_timeout: u.map(Duration::from_secs),
+                ..ServerConfig::default()
+            })
+        };
+        // Both unset => no deadline at all.
+        assert_eq!(with(None, None), None);
+        // Only one present => that one (whichever it is).
+        assert_eq!(with(Some(30), None), Some(Duration::from_secs(30)));
+        assert_eq!(with(None, Some(2)), Some(Duration::from_secs(2)));
+        // Both present => the SMALLER. The whole point: a short update_where_timeout wins over
+        // a long read query_timeout, so the writer is released sooner (head-of-line bound).
+        assert_eq!(with(Some(30), Some(2)), Some(Duration::from_secs(2)));
+        // ...and an update_where_timeout LARGER than query_timeout never loosens the bound.
+        assert_eq!(with(Some(5), Some(30)), Some(Duration::from_secs(5)));
+    }
+
+    // [OPUS-4.8] (sq-nulp) The DEFAULT config sets no update_where_timeout, so the update WHERE
+    // budget is exactly the plain query_timeout — byte-for-byte the historical behaviour.
+    #[test]
+    fn update_where_deadline_defaults_to_query_timeout_unchanged() {
+        let cfg = ServerConfig::default();
+        assert_eq!(cfg.update_where_timeout, None, "no separate update deadline by default");
+        assert_eq!(update_where_deadline(&cfg), cfg.query_timeout);
     }
 
     fn gz(data: &[u8]) -> Bytes {

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -5,7 +5,7 @@
 //!   sparq-server [--addr 127.0.0.1:3030] [--allow-remote] [--format turtle]
 //!                [--persist DIR]
 //!                [--auth-token TOKEN] [--auth-token-read]
-//!                [--query-timeout SECS] [--max-body-bytes N] [--max-concurrent N]
+//!                [--query-timeout SECS] [--update-where-timeout SECS] [--max-body-bytes N] [--max-concurrent N]
 //!                [--max-results N] [--max-query-rows N] [--max-decompress-ratio N]
 //!                [--max-subscriptions N] [--max-subscriptions-per-conn N]
 //!                [--service-allow HOST|*.SUFFIX]... [--service-allow-file PATH]
@@ -60,6 +60,11 @@
 //! `SPARQ_*` environment variable (see crates/sparq-server/README.md and the four-limit
 //! "Server hardening" section in skills/http-server/SKILL.md):
 //!   --query-timeout SECS      per-request query timeout, 0 disables      [30, env SPARQ_QUERY_TIMEOUT]
+//!   --update-where-timeout S  [OPUS-4.8 sq-nulp] separate, typically-SHORTER writer-side WHERE deadline
+//!                             for SPARQL UPDATE: bounds writer-queue HEAD-OF-LINE blocking from a slow
+//!                             update (a slow update releases the single writer within S instead of
+//!                             holding it for the full --query-timeout). 0/unset = use --query-timeout
+//!                             [unset, env SPARQ_UPDATE_WHERE_TIMEOUT]
 //!   --max-body-bytes N        maximum request body in bytes              [1048576, env SPARQ_MAX_BODY_BYTES]
 //!   --max-concurrent N        maximum in-flight requests (429 beyond)    [32, env SPARQ_MAX_CONCURRENT]
 //!   --max-results N           maximum SELECT rows (413 beyond), 0 off    [unlimited, env SPARQ_MAX_RESULTS]
@@ -140,6 +145,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "--query-timeout" => {
                 let secs: u64 = parse_flag(&mut args, "--query-timeout")?;
                 config.query_timeout = (secs > 0).then(|| Duration::from_secs(secs));
+            }
+            // [OPUS-4.8] sq-nulp: separate, typically-shorter writer-side WHERE deadline that
+            // bounds writer-queue head-of-line blocking from a slow UPDATE; 0 disables it (the
+            // update WHERE budget is then the plain --query-timeout, exactly as before).
+            "--update-where-timeout" => {
+                let secs: u64 = parse_flag(&mut args, "--update-where-timeout")?;
+                config.update_where_timeout = (secs > 0).then(|| Duration::from_secs(secs));
             }
             "--max-body-bytes" => {
                 config.max_body_bytes = parse_flag(&mut args, "--max-body-bytes")?
@@ -278,7 +290,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 eprintln!(
                     "usage: sparq-server [--addr HOST:PORT] [--allow-remote] [--persist DIR] \
                      [--auth-token TOKEN] [--auth-token-read] [--format FMT] \
-                     [--query-timeout SECS] [--max-body-bytes N] [--max-concurrent N] \
+                     [--query-timeout SECS] [--update-where-timeout SECS] [--max-body-bytes N] [--max-concurrent N] \
                      [--max-results N] [--max-query-rows N] [--max-query-bytes N] [--max-decompress-ratio N] \
                      [--max-subscriptions N] \
                      [--max-subscriptions-per-conn N]{time_travel}{service} [--verbose] \
@@ -385,11 +397,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     eprintln!("loaded {} triples", graph.len());
     eprintln!(
-        "guards: query-timeout={} max-body-bytes={} max-concurrent={} max-results={} \
+        "guards: query-timeout={} update-where-timeout={} max-body-bytes={} max-concurrent={} max-results={} \
          max-query-rows={} max-query-bytes={} max-decompress-ratio={}x max-subscriptions={} \
          max-subscriptions-per-conn={}",
         config
             .query_timeout
+            .map_or("off".into(), |t| format!("{}s", t.as_secs())),
+        // [OPUS-4.8] sq-nulp: writer-side WHERE deadline bounding head-of-line blocking.
+        config
+            .update_where_timeout
             .map_or("off".into(), |t| format!("{}s", t.as_secs())),
         config.max_body_bytes,
         config.max_concurrent,

--- a/crates/sparq-server/tests/hardening.rs
+++ b/crates/sparq-server/tests/hardening.rs
@@ -332,6 +332,79 @@ async fn update_path_honours_timeout() {
 }
 
 // ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-nulp) Writer-queue head-of-line blocking bound: a SEPARATE, shorter
+// --update-where-timeout releases the single sequenced writer from a slow UPDATE's WHERE
+// within that window, EVEN when the (read) --query-timeout is much longer. So a slow update
+// (a) returns its 503 bounded by the short writer deadline, not the long read timeout, and
+// (b) does not head-of-line block a fast update queued behind it.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn update_where_timeout_bounds_head_of_line_blocking() {
+    // A GENEROUS read timeout (8 s) — long enough that, without the writer-side WHERE
+    // deadline, a slow update would hold the single writer for the full 8 s + grace and
+    // head-of-line block everything behind it. The separate short WHERE deadline (1 s) is
+    // what actually bounds the writer's work.
+    let config = ServerConfig {
+        query_timeout: Some(Duration::from_secs(8)),
+        update_where_timeout: Some(Duration::from_secs(1)),
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(&dense_graph_ttl(), config).await;
+
+    // The never-finishing 3-way cross-product WHERE, as a DELETE/INSERT update.
+    let slow = "PREFIX ex: <http://ex/> \
+         DELETE { ?a ex:e ?b } INSERT { ?a ex:gone ?b } \
+         WHERE { ?a ex:e ?b . ?c ex:e ?d . ?e ex:e ?f }";
+
+    // Fire the slow update and, concurrently, a trivial fast update. The fast one is queued
+    // behind the slow one on the single writer; if the slow update were NOT cut at the 1 s
+    // writer deadline, the fast one could not be acked until the slow one released the writer.
+    let slow_base = base.clone();
+    let slow_task = tokio::spawn(async move {
+        let started = std::time::Instant::now();
+        let resp = client()
+            .post(format!("{slow_base}/sparql"))
+            .header("content-type", "application/sparql-update")
+            .body(slow)
+            .send()
+            .await
+            .unwrap();
+        (resp.status(), started.elapsed())
+    });
+
+    // Give the slow update a head start so it is the one occupying the writer.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let fast_started = std::time::Instant::now();
+    let fast = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .body("INSERT DATA { <http://ex/x> <http://ex/p> <http://ex/y> }")
+        .send()
+        .await
+        .unwrap();
+    let fast_elapsed = fast_started.elapsed();
+    assert_eq!(fast.status(), 204, "fast queued update must still commit");
+
+    let (slow_status, slow_elapsed) = slow_task.await.unwrap();
+    // The slow update is refused (503): its WHERE hit the writer-side cooperative deadline.
+    assert_eq!(slow_status, 503, "slow update must be cut at the writer WHERE deadline");
+    // Bounded by the SHORT writer deadline (1 s + grace + scheduling slack), NOT the 8 s
+    // read timeout — proving head-of-line blocking is bounded by --update-where-timeout.
+    assert!(
+        slow_elapsed < Duration::from_secs(6),
+        "slow update 503 should be bounded by the 1 s writer deadline, took {slow_elapsed:?}"
+    );
+    // The fast update was not blocked for anything near the 8 s read timeout: it landed once
+    // the writer was released (≈ the 1 s WHERE deadline), well under the read timeout.
+    assert!(
+        fast_elapsed < Duration::from_secs(6),
+        "fast update must not be head-of-line blocked for the full read timeout, took {fast_elapsed:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // [OPUS-4.8] (sq-ebii) Decompression-ratio cap (--max-decompress-ratio): a high-ratio
 // gzip body (a "zip bomb") on the GSP write path is refused with 413 BEFORE the full
 // decompressed image is held; a benign small gzip body within the ratio decodes fine.

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -135,16 +135,19 @@ Library surface re-exported from `sparq_server` (behind the default `server` fea
   off the async workers (`spawn_blocking`).
 - `AppState::at(&self, number: u64) -> Option<PinnedGen>` — pin a retained generation
   (**`time-travel` feature only**).
-- `struct ServerConfig { query_timeout: Option<Duration>, max_body_bytes: usize,
+- `struct ServerConfig { query_timeout: Option<Duration>, update_where_timeout: Option<Duration>,
+  max_body_bytes: usize,
   max_concurrent: usize, max_results: Option<usize>, max_query_rows: Option<usize>,
   max_query_bytes: Option<usize>,
   max_decompress_ratio: usize, max_subscriptions: usize, max_subscriptions_per_conn: usize,
   verbose: bool, redact_logs: bool, allow_remote: bool, auth_token: Option<String>, auth_token_read: bool,
   service_allow: ServiceAllowlist, /* + time_travel_* under feature, + audit_log under audit-log feature */ }` with
   `ServerConfig::default()` and `ServerConfig::from_env()`.
-  (`max_query_rows` = coarse memory cap; `max_query_bytes` = byte-accounted memory cap that
-  also prices row WIDTH + computed-literal size — `sq-s5is`; `max_decompress_ratio` =
-  zip-bomb guard — `sq-ebii`.)
+  (`update_where_timeout` = separate, typically-SHORTER writer-side WHERE deadline for SPARQL
+  UPDATE that bounds writer-queue **head-of-line blocking** from a slow update — `None` =
+  use `query_timeout`, `sq-nulp`; `max_query_rows` = coarse memory cap; `max_query_bytes` =
+  byte-accounted memory cap that also prices row WIDTH + computed-literal size — `sq-s5is`;
+  `max_decompress_ratio` = zip-bomb guard — `sq-ebii`.)
   `auth_token` (set: gates the write surface with a Bearer token, constant-time compared;
   `None`: no write auth) and `auth_token_read` (gate reads too) are honoured by the library
   `router` itself — embedders get the gate for free (`sq-zcby`).
@@ -501,6 +504,7 @@ env overrides the default.
 | Flag | Env | Default | Effect |
 | --- | --- | --- | --- |
 | `--query-timeout SECS` | `SPARQ_QUERY_TIMEOUT` | `30` (`0`=off) | per-request timeout → `503` |
+| `--update-where-timeout SECS` | `SPARQ_UPDATE_WHERE_TIMEOUT` | unset (`0`/unset = use `--query-timeout`) | **separate, typically-SHORTER writer-side WHERE deadline for SPARQL UPDATE** — bounds writer-queue **head-of-line blocking** from a slow update (the single sequenced writer is released within this window instead of holding it for the full read timeout); the update WHERE budget is `min(query_timeout, update_where_timeout)` → slow update `503` (`sq-nulp`) |
 | `--max-body-bytes N` | `SPARQ_MAX_BODY_BYTES` | `1048576` | body cap → `413` |
 | `--max-concurrent N` | `SPARQ_MAX_CONCURRENT` | `32` | in-flight cap, load-shed → `429` |
 | `--max-results N` | `SPARQ_MAX_RESULTS` | unlimited (`0`=off) | result/solution cap (SELECT + CONSTRUCT/DESCRIBE WHERE-solutions + EXPLAIN ANALYZE; not ASK/GSP-read/UPDATE) → honest `413` (not truncation) |
@@ -543,8 +547,19 @@ quota:
    same cooperative budget on the writer thread *and* the same wall-clock await cap on the
    HTTP side. *Bounds:* wall-clock per request, approximately (next-check granularity).
    *Caveat:* updates are sequenced on a single writer, so a long update blocks the queue
-   behind it until it finishes — the cap bounds the **client's wait**, the writer still runs
-   the WHERE to its cooperative stop.
+   behind it until it finishes — this cap bounds the **client's own wait**, while the writer
+   runs the WHERE to its cooperative stop. To bound that **head-of-line blocking** of the
+   queue, set a separate, shorter WHERE deadline — see (1b).
+   - **1b. UPDATE writer-side WHERE deadline / head-of-line bound**
+     (`--update-where-timeout`, `SPARQ_UPDATE_WHERE_TIMEOUT`, default **unset** = use
+     `--query-timeout`; `sq-nulp`). A SEPARATE, typically-shorter cooperative deadline applied
+     ONLY to the WHERE phase of a SPARQL UPDATE on the writer thread: the update's budget
+     deadline becomes `min(query_timeout, update_where_timeout)`, so a slow update releases the
+     single sequenced writer within this window instead of holding it for the full (usually
+     longer) read timeout — bounding how long one slow update can head-of-line block every
+     queued update behind it. Cooperative, like the query timeout (next-check granularity); a
+     tunable backstop, not hard preemption. Unset ⇒ the update WHERE budget is exactly
+     `--query-timeout` (unchanged). The offending update gets a `503`.
 2. **Memory cap** (`--max-query-rows`, `SPARQ_MAX_QUERY_ROWS`, default **off**, `0`=off).
    A coarse OOM circuit-breaker: an upper bound on the **row count** of any *materialised
    intermediate or final* result the engine builds, on **every** form (including


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-nulp** (sparq-server).

## Problem (the residual gap from sq-ebii)

SPARQL UPDATEs are **sequenced on a single group-commit writer** (sparq-serve). While one update runs its `DELETE/INSERT … WHERE` to its cooperative stop, **every queued update behind it waits**. The sq-ebii cooperative `QueryBudget` already bounds the WHERE evaluation, but its deadline is the **read** `query_timeout` (default 30 s) — far too long to hold the single writer. So the timeout bounds the *offending client's own wait*, not the **head-of-line blocking** of the whole writer queue (caveat (3) in `await_update_worker`'s own docs).

## Fix — option (b): a separate, shorter writer-side WHERE deadline `[OPUS-4.8]`

New **opt-in** knob `--update-where-timeout` / `SPARQ_UPDATE_WHERE_TIMEOUT` (`ServerConfig::update_where_timeout: Option<Duration>`). The per-UPDATE budget deadline becomes `min(query_timeout, update_where_timeout)` via the new `update_where_deadline` helper, so **any single update releases the writer within that window** and the queue behind it cannot be head-of-line blocked longer — *independent of the (usually longer) read timeout*. The offending update is refused **503** through the existing `query budget exceeded (timeout)` → `timeout_response` path.

It is **cooperative** (checked at the engine's coarse sites — operator entry / per outer-loop iteration), a tunable backstop, **not hard preemption** (true writer preemption is out of scope). **Default unset ⇒ the update WHERE budget is exactly `query_timeout`, byte-for-byte the prior behaviour.**

### Why not (a) pre-flight cost model / (c) parse-time rejection?
The bead says *measure first*. Both need a WHERE cost estimator and risk **false rejections** of legitimate updates — over-scoped for one PR and not measurement-backed here. Option (b) is the **smallest correct change** that directly bounds the writer's work with an honest, operator-set value.

## Tests
- **Unit** (`http.rs`): `update_where_deadline` takes the tighter of the two timeouts (`min`), is `None` only when both unset, and **defaults to exactly `query_timeout`** when `update_where_timeout` is unset.
- **Integration** (`tests/hardening.rs::update_where_timeout_bounds_head_of_line_blocking`): with a generous 8 s read `query_timeout` but a 1 s `update_where_timeout`, a never-finishing `DELETE/INSERT … WHERE`
  1. returns **503 bounded by the short writer deadline** (well under the 8 s read timeout), and
  2. does **not** head-of-line block a trivial fast update queued behind it — the fast one still commits **204** quickly.

## Docs
- `crates/sparq-server/README.md` hardening-flags bullet.
- `skills/http-server/SKILL.md`: `ServerConfig` listing, flags table row, and "Server hardening" item **1b** (the head-of-line bound), with honest cooperative-bound caveats.
- `main.rs` usage / `--help` / startup-guard line.

## Gate (all green)
- `cargo build` + `clippy --all-targets -- -D warnings` + tests in **default**, **`--all-features`**, and **`--no-default-features`** feature states.
- privacy-claims gate (incl. predicate-form soundness) — OK.
- G2 public-api→SKILL — PASS (`ServerConfig` field documented in SKILL regardless).
- wasm-deps boundary guard — OK (server feature-gated; never in the wasm graph).

Auto-merge intentionally **not** enabled — orchestrator arms after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)