### PR TITLE
feat(sparq-server): apply SPARQL-Protocol dataset-override params (sq-z33x)

### DIFF
--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -342,15 +342,17 @@ matrix under "Security posture".
 ## ✨ Features
 
 - **SPARQL 1.1 Protocol** — `query` (GET / POST direct / POST url-encoded / HEAD) and
-  `update` (`application/sparql-update` → `204`, atomic).
+  `update` (`application/sparql-update` → `204`, atomic). The protocol **dataset-override**
+  parameters are applied, not just accepted: `default-graph-uri` / `named-graph-uri` re-scope a
+  query's active RDF dataset (replacing any in-query `FROM` / `FROM NAMED`, per §2.1.4), and
+  `using-graph-uri` / `using-named-graph-uri` re-scope an update's `WHERE` clause (per §2.2;
+  combining them with an in-update `USING` / `USING NAMED` / `WITH` is a `400`). A graph-URI value
+  that is not a valid absolute IRI is a `400`.
 - **Named graphs / full RDF dataset** — the server serves a complete RDF dataset (a default
   graph **plus** named graphs), so an in-query `GRAPH <iri>` / `GRAPH ?g` pattern, a
   cross-graph join, and a `FROM` / `FROM NAMED` dataset clause all execute, and a
   `GRAPH`-scoped `INSERT`/`DELETE`/`LOAD`/`CLEAR`/`DROP`/`CREATE` commits through the same
   sequenced writer (these are exercised end-to-end over HTTP in `tests/named_graphs.rs`).
-  **Caveat:** the *protocol-level* dataset OVERRIDE parameters (`default-graph-uri` /
-  `named-graph-uri` on `/sparql`) are accepted but not yet applied — address named graphs
-  with an in-query `GRAPH` / `FROM` for now (deferred: bead sq-z33x).
 - **Durable persistence** — `--persist <DIR>` (env `SPARQ_PERSIST_DIR`) makes the on-disk index
   the source of truth: updates are WAL-fsync'd before ack and survive a restart with **no
   rebuild** (QLever's `--persist-updates`). Off by default (in-memory). See "Durable persistence".

--- a/crates/sparq-server/src/exec.rs
+++ b/crates/sparq-server/src/exec.rs
@@ -11,7 +11,9 @@
 //!   `sparq_engine::construct` / `sparq_engine::describe`), serialised as
 //!   N-Triples / Turtle per content negotiation.
 
-use spargebra::{Query, SparqlParser};
+use spargebra::algebra::QueryDataset;
+use spargebra::term::NamedNode;
+use spargebra::{GraphUpdateOperation, Query, SparqlParser, Update};
 
 /// The classified form of a parsed SPARQL query.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,22 +37,91 @@ pub struct Prepared {
 pub enum PrepareError {
     /// The query string did not parse — HTTP 400.
     Malformed(String),
+    /// A SPARQL-Protocol `default-graph-uri` / `named-graph-uri` value was not a valid
+    /// absolute IRI — HTTP 400 (the protocol parameter is caller input). [OPUS-4.8] sq-z33x.
+    BadGraphUri(String),
 }
 
-/// Parses + classifies the query.
+/// [OPUS-4.8] sq-z33x: the SPARQL 1.1 Protocol §2.1.4 dataset-override carried OUT-OF-BAND on
+/// the request (the repeated `default-graph-uri` / `named-graph-uri` parameters), as opposed
+/// to an in-query `FROM` / `FROM NAMED` clause. Per the protocol, when this override is present
+/// it DEFINES the RDF Dataset the query runs against — and if the query string ALSO carries a
+/// `FROM` / `FROM NAMED` clause, "the SPARQL service must execute the query using the RDF Dataset
+/// given in the protocol request" (the override REPLACES, it does not merge with, the in-query
+/// clause). An empty override (both lists empty) is the no-op common case.
+#[derive(Debug, Default, Clone)]
+pub struct DatasetOverride {
+    /// `default-graph-uri` values — the FROM (default-graph) sources of the active dataset.
+    pub default: Vec<String>,
+    /// `named-graph-uri` values — the FROM NAMED sources of the active dataset.
+    pub named: Vec<String>,
+}
+
+impl DatasetOverride {
+    /// True when no override was supplied (the request carried neither parameter): the query
+    /// runs exactly as written, paying nothing for the override path.
+    pub fn is_empty(&self) -> bool {
+        self.default.is_empty() && self.named.is_empty()
+    }
+
+    /// Builds the `spargebra` [`QueryDataset`] this override denotes, validating each IRI.
+    /// `named` is `Some` iff at least one `named-graph-uri` was given: a `default-graph-uri`-only
+    /// override yields `FROM …` with NO named graphs (so `GRAPH ?g` enumerates nothing), and a
+    /// `named-graph-uri`-only override yields `FROM NAMED …` with an EMPTY default graph — exactly
+    /// the engine's dataset-clause semantics (`sparq_engine` `build_active`). [OPUS-4.8] sq-z33x.
+    fn to_query_dataset(&self) -> Result<QueryDataset, PrepareError> {
+        let default = self
+            .default
+            .iter()
+            .map(|i| parse_graph_iri(i))
+            .collect::<Result<Vec<_>, _>>()?;
+        let named = if self.named.is_empty() {
+            None
+        } else {
+            Some(
+                self.named
+                    .iter()
+                    .map(|i| parse_graph_iri(i))
+                    .collect::<Result<Vec<_>, _>>()?,
+            )
+        };
+        Ok(QueryDataset { default, named })
+    }
+}
+
+/// Parses a protocol graph-URI value into a validated absolute-IRI [`NamedNode`].
+fn parse_graph_iri(iri: &str) -> Result<NamedNode, PrepareError> {
+    NamedNode::new(iri.to_string())
+        .map_err(|e| PrepareError::BadGraphUri(format!("invalid graph IRI '{iri}': {e}")))
+}
+
+/// Parses + classifies the query, leaving the query text unchanged. Use
+/// [`prepare_with_dataset`] when a SPARQL-Protocol dataset override may be present.
 ///
 /// Note on datasets / named graphs: the engine DOES support a full RDF dataset — a default
 /// graph plus named graphs — so a `GRAPH <iri>` / `GRAPH ?g` pattern, a cross-graph join,
 /// and an in-query `FROM` / `FROM NAMED` dataset clause all execute correctly (conformance
-/// rounds 3–4; covered end-to-end over HTTP by `tests/named_graphs.rs`, sq-fh4z). What is
-/// NOT yet wired is the *protocol-level* dataset OVERRIDE: the SPARQL-Protocol
-/// `default-graph-uri` / `named-graph-uri` request parameters, which would let a client
-/// re-scope the active dataset for a query that has no in-query `FROM`. The HTTP layer
-/// accepts and records those parameters but does not currently rewrite the query's dataset
-/// around them, so they have no effect — an in-query `FROM` / `GRAPH` is the supported way
-/// to address named graphs today (deferred: bead sq-z33x). See README.
+/// rounds 3–4; covered end-to-end over HTTP by `tests/named_graphs.rs`, sq-fh4z). The
+/// *protocol-level* dataset OVERRIDE — the SPARQL-Protocol `default-graph-uri` /
+/// `named-graph-uri` request parameters — is wired via [`prepare_with_dataset`] (sq-z33x).
 pub fn prepare(sparql: &str) -> Result<Prepared, PrepareError> {
-    let parsed = SparqlParser::new()
+    prepare_with_dataset(sparql, &DatasetOverride::default())
+}
+
+/// Parses + classifies the query, applying any SPARQL 1.1 Protocol dataset override
+/// (`default-graph-uri` / `named-graph-uri`) per §2.1.4.
+///
+/// When `over` is non-empty the parsed query's dataset clause is REPLACED with the dataset the
+/// override denotes (the protocol mandates the protocol-supplied dataset wins over an in-query
+/// `FROM` / `FROM NAMED`), and `runnable` is re-serialised from the rewritten algebra so the
+/// engine — which re-parses `runnable` — sees the synthesized clause. When `over` is empty the
+/// query is returned verbatim (the no-op common path: no rewrite, no re-serialisation).
+/// [OPUS-4.8] sq-z33x.
+pub fn prepare_with_dataset(
+    sparql: &str,
+    over: &DatasetOverride,
+) -> Result<Prepared, PrepareError> {
+    let mut parsed = SparqlParser::new()
         .parse_query(sparql)
         .map_err(|e| PrepareError::Malformed(e.to_string()))?;
     let form = match parsed {
@@ -59,7 +130,117 @@ pub fn prepare(sparql: &str) -> Result<Prepared, PrepareError> {
         Query::Construct { .. } => QueryForm::Construct,
         Query::Describe { .. } => QueryForm::Describe,
     };
-    Ok(Prepared { form, runnable: sparql.to_string() })
+    let runnable = if over.is_empty() {
+        sparql.to_string()
+    } else {
+        set_query_dataset(&mut parsed, over.to_query_dataset()?);
+        // Re-serialise the rewritten algebra: spargebra's `Display` re-emits the FROM / FROM
+        // NAMED clauses, and the engine re-parses this string.
+        parsed.to_string()
+    };
+    Ok(Prepared { form, runnable })
+}
+
+/// Overwrites the dataset specification of a parsed query (every form carries the same
+/// `Option<QueryDataset>` field). [OPUS-4.8] sq-z33x.
+fn set_query_dataset(q: &mut Query, dataset: QueryDataset) {
+    match q {
+        Query::Select { dataset: d, .. }
+        | Query::Construct { dataset: d, .. }
+        | Query::Describe { dataset: d, .. }
+        | Query::Ask { dataset: d, .. } => *d = Some(dataset),
+    }
+}
+
+/// [OPUS-4.8] sq-z33x: the SPARQL 1.1 Protocol §2.2 UPDATE dataset override carried OUT-OF-BAND
+/// (the repeated `using-graph-uri` / `using-named-graph-uri` parameters). Per the protocol these
+/// re-scope the WHERE clause of every operation as if a `USING <g>` / `USING NAMED <g>` clause had
+/// been written — BUT it is an error to supply them alongside an update that already carries an
+/// in-string `USING` / `USING NAMED` / `WITH` clause (the override SUPPLEMENTS, it never overrides).
+#[derive(Debug, Default, Clone)]
+pub struct UsingOverride {
+    /// `using-graph-uri` values — the default-graph (`USING <g>`) sources of the WHERE dataset.
+    pub default: Vec<String>,
+    /// `using-named-graph-uri` values — the `USING NAMED <g>` sources of the WHERE dataset.
+    pub named: Vec<String>,
+}
+
+impl UsingOverride {
+    /// True when no override was supplied (the common in-update / no-dataset case).
+    pub fn is_empty(&self) -> bool {
+        self.default.is_empty() && self.named.is_empty()
+    }
+
+    fn to_query_dataset(&self) -> Result<QueryDataset, UpdateDatasetError> {
+        let map = |list: &[String]| {
+            list.iter()
+                .map(|i| {
+                    NamedNode::new(i.to_string()).map_err(|e| {
+                        UpdateDatasetError::BadGraphUri(format!("invalid graph IRI '{i}': {e}"))
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()
+        };
+        let default = map(&self.default)?;
+        let named = if self.named.is_empty() {
+            None
+        } else {
+            Some(map(&self.named)?)
+        };
+        Ok(QueryDataset { default, named })
+    }
+}
+
+/// A failure applying the UPDATE dataset override — both map to an HTTP 400. [OPUS-4.8] sq-z33x.
+#[derive(Debug)]
+pub enum UpdateDatasetError {
+    /// The update did not parse.
+    Malformed(String),
+    /// A `using-graph-uri` / `using-named-graph-uri` value was not a valid absolute IRI.
+    BadGraphUri(String),
+    /// The protocol `using-*` parameters were supplied alongside an update operation that already
+    /// carries an in-string `USING` / `USING NAMED` / `WITH` clause — a protocol error (§2.2).
+    UsingConflict,
+}
+
+/// Applies a SPARQL 1.1 Protocol §2.2 UPDATE dataset override (`using-graph-uri` /
+/// `using-named-graph-uri`) to an update string, returning the rewritten update the engine runs.
+///
+/// * No override → returns the update verbatim (the common path; no parse, no rewrite).
+/// * Override present, but some operation already carries an in-string `USING`/`USING NAMED`/`WITH`
+///   clause → [`UpdateDatasetError::UsingConflict`] (the protocol error; the HTTP layer answers 400).
+/// * Otherwise the override's `USING`/`USING NAMED` dataset is injected into every `DeleteInsert`
+///   operation (data-only operations — `INSERT DATA`, `LOAD`, `CLEAR`, … — have no WHERE clause to
+///   re-scope and are left untouched), and the rewritten update is re-serialised for the engine.
+///
+/// [OPUS-4.8] sq-z33x.
+pub fn apply_update_dataset(
+    update: &str,
+    over: &UsingOverride,
+) -> Result<String, UpdateDatasetError> {
+    if over.is_empty() {
+        return Ok(update.to_string());
+    }
+    let mut parsed: Update = SparqlParser::new()
+        .parse_update(update)
+        .map_err(|e| UpdateDatasetError::Malformed(e.to_string()))?;
+    // §2.2: it is an error to supply the protocol params when ANY operation already names its WHERE
+    // dataset in-string (USING / USING NAMED / WITH — all encoded as `using: Some(..)`).
+    if parsed.operations.iter().any(|op| {
+        matches!(
+            op,
+            GraphUpdateOperation::DeleteInsert { using: Some(_), .. }
+        )
+    }) {
+        return Err(UpdateDatasetError::UsingConflict);
+    }
+    let dataset = over.to_query_dataset()?;
+    for op in &mut parsed.operations {
+        if let GraphUpdateOperation::DeleteInsert { using, .. } = op {
+            *using = Some(dataset.clone());
+        }
+    }
+    Ok(parsed.to_string())
 }
 
 #[cfg(test)]
@@ -75,18 +256,29 @@ mod tests {
 
     #[test]
     fn classifies_forms() {
-        assert_eq!(prepare("SELECT * WHERE { ?s ?p ?o }").unwrap().form, QueryForm::Select);
+        assert_eq!(
+            prepare("SELECT * WHERE { ?s ?p ?o }").unwrap().form,
+            QueryForm::Select
+        );
         assert_eq!(prepare("ASK { ?s ?p ?o }").unwrap().form, QueryForm::Ask);
         assert_eq!(
-            prepare("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }").unwrap().form,
+            prepare("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }")
+                .unwrap()
+                .form,
             QueryForm::Construct
         );
-        assert_eq!(prepare("DESCRIBE <http://ex/a>").unwrap().form, QueryForm::Describe);
+        assert_eq!(
+            prepare("DESCRIBE <http://ex/a>").unwrap().form,
+            QueryForm::Describe
+        );
     }
 
     #[test]
     fn malformed_is_error() {
-        assert!(matches!(prepare("SELECT WHERE {"), Err(PrepareError::Malformed(_))));
+        assert!(matches!(
+            prepare("SELECT WHERE {"),
+            Err(PrepareError::Malformed(_))
+        ));
     }
 
     #[test]
@@ -103,12 +295,222 @@ mod tests {
 
     #[test]
     fn construct_runs_natively_on_engine() {
-        let p = prepare("PREFIX ex: <http://ex/> CONSTRUCT { ?s ex:q ?o } WHERE { ?s ex:p ?o }").unwrap();
+        let p = prepare("PREFIX ex: <http://ex/> CONSTRUCT { ?s ex:q ?o } WHERE { ?s ex:p ?o }")
+            .unwrap();
         assert_eq!(p.form, QueryForm::Construct);
         assert_eq!(sparq_engine::construct(&g(), &p.runnable).unwrap().len(), 2);
 
         let p = prepare("DESCRIBE <http://ex/a>").unwrap();
         assert_eq!(p.form, QueryForm::Describe);
         assert_eq!(sparq_engine::describe(&g(), &p.runnable).unwrap().len(), 1);
+    }
+
+    // ---------------------------------------------------------------------------
+    // [OPUS-4.8] sq-z33x — SPARQL 1.1 Protocol §2.1.4 dataset override
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn empty_override_leaves_query_verbatim() {
+        let q = "SELECT * WHERE { ?s ?p ?o }";
+        let p = prepare_with_dataset(q, &DatasetOverride::default()).unwrap();
+        assert_eq!(
+            p.runnable, q,
+            "an absent override must not rewrite the query"
+        );
+    }
+
+    #[test]
+    fn default_graph_uri_synthesizes_from_clause() {
+        let over = DatasetOverride {
+            default: vec!["http://ex/g".into()],
+            named: vec![],
+        };
+        let p = prepare_with_dataset("SELECT * WHERE { ?s ?p ?o }", &over).unwrap();
+        // The rewritten runnable carries a FROM clause and re-parses cleanly.
+        assert!(
+            p.runnable.contains("FROM <http://ex/g>"),
+            "runnable: {}",
+            p.runnable
+        );
+        assert!(
+            !p.runnable.contains("FROM NAMED"),
+            "default-only must not emit FROM NAMED"
+        );
+        assert!(SparqlParser::new().parse_query(&p.runnable).is_ok());
+    }
+
+    #[test]
+    fn named_graph_uri_synthesizes_from_named_clause() {
+        let over = DatasetOverride {
+            default: vec![],
+            named: vec!["http://ex/g".into()],
+        };
+        let p = prepare_with_dataset("ASK { ?s ?p ?o }", &over).unwrap();
+        assert!(
+            p.runnable.contains("FROM NAMED <http://ex/g>"),
+            "runnable: {}",
+            p.runnable
+        );
+        assert!(SparqlParser::new().parse_query(&p.runnable).is_ok());
+    }
+
+    #[test]
+    fn override_replaces_in_query_from_clause() {
+        // Per §2.1.4 the protocol dataset REPLACES the in-query clause — the only FROM in the
+        // rewritten query is the override's, never the original `FROM <http://ex/orig>`.
+        let over = DatasetOverride {
+            default: vec!["http://ex/over".into()],
+            named: vec![],
+        };
+        let p = prepare_with_dataset("SELECT * FROM <http://ex/orig> WHERE { ?s ?p ?o }", &over)
+            .unwrap();
+        assert!(
+            p.runnable.contains("FROM <http://ex/over>"),
+            "runnable: {}",
+            p.runnable
+        );
+        assert!(
+            !p.runnable.contains("orig"),
+            "in-query FROM must be replaced: {}",
+            p.runnable
+        );
+    }
+
+    #[test]
+    fn bad_graph_uri_is_error() {
+        let over = DatasetOverride {
+            default: vec!["not a valid iri".into()],
+            named: vec![],
+        };
+        assert!(matches!(
+            prepare_with_dataset("SELECT * WHERE { ?s ?p ?o }", &over),
+            Err(PrepareError::BadGraphUri(_))
+        ));
+    }
+
+    #[test]
+    fn override_re_scopes_active_dataset_on_engine() {
+        // A FROM of a graph the store does not hold ⇒ empty default graph ⇒ zero rows; the same
+        // query without the override sees the store's two triples. End-to-end through the engine.
+        let over = DatasetOverride {
+            default: vec!["http://ex/absent".into()],
+            named: vec![],
+        };
+        let p = prepare_with_dataset("SELECT * WHERE { ?s ?p ?o }", &over).unwrap();
+        let res = sparq_engine::query(&g(), &p.runnable).unwrap();
+        assert_eq!(
+            res.rows.len(),
+            0,
+            "FROM of an absent graph must yield an empty default graph"
+        );
+
+        let plain = prepare("SELECT * WHERE { ?s ?p ?o }").unwrap();
+        assert_eq!(
+            sparq_engine::query(&g(), &plain.runnable)
+                .unwrap()
+                .rows
+                .len(),
+            2
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // [OPUS-4.8] sq-z33x — SPARQL 1.1 Protocol §2.2 UPDATE dataset override
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn empty_using_override_leaves_update_verbatim() {
+        let u = "INSERT DATA { <http://ex/a> <http://ex/p> <http://ex/b> }";
+        assert_eq!(
+            apply_update_dataset(u, &UsingOverride::default()).unwrap(),
+            u
+        );
+    }
+
+    #[test]
+    fn using_override_injects_using_into_delete_insert() {
+        let over = UsingOverride {
+            default: vec!["http://ex/g".into()],
+            named: vec![],
+        };
+        let out = apply_update_dataset(
+            "INSERT { ?s <http://ex/q> ?o } WHERE { ?s <http://ex/p> ?o }",
+            &over,
+        )
+        .unwrap();
+        assert!(out.contains("USING <http://ex/g>"), "out: {out}");
+        // The rewritten update re-parses cleanly.
+        assert!(SparqlParser::new().parse_update(&out).is_ok());
+    }
+
+    #[test]
+    fn using_named_override_injects_using_named() {
+        let over = UsingOverride {
+            default: vec![],
+            named: vec!["http://ex/g".into()],
+        };
+        let out = apply_update_dataset(
+            "DELETE { ?s ?p ?o } WHERE { GRAPH <http://ex/g> { ?s ?p ?o } }",
+            &over,
+        )
+        .unwrap();
+        assert!(out.contains("USING NAMED <http://ex/g>"), "out: {out}");
+        assert!(SparqlParser::new().parse_update(&out).is_ok());
+    }
+
+    #[test]
+    fn using_override_conflicts_with_in_string_using() {
+        // §2.2: supplying the protocol params alongside an in-string USING/WITH is an error.
+        let over = UsingOverride {
+            default: vec!["http://ex/g".into()],
+            named: vec![],
+        };
+        assert!(matches!(
+            apply_update_dataset(
+                "INSERT { ?s <http://ex/q> ?o } USING <http://ex/h> WHERE { ?s <http://ex/p> ?o }",
+                &over,
+            ),
+            Err(UpdateDatasetError::UsingConflict)
+        ));
+        // WITH is encoded the same way — also a conflict.
+        assert!(matches!(
+            apply_update_dataset(
+                "WITH <http://ex/h> DELETE { ?s ?p ?o } WHERE { ?s ?p ?o }",
+                &over,
+            ),
+            Err(UpdateDatasetError::UsingConflict)
+        ));
+    }
+
+    #[test]
+    fn using_override_leaves_data_only_ops_untouched() {
+        // INSERT DATA has no WHERE clause to re-scope: the override applies to no operation, so the
+        // update is structurally unchanged (still parses, still an INSERT DATA).
+        let over = UsingOverride {
+            default: vec!["http://ex/g".into()],
+            named: vec![],
+        };
+        let out = apply_update_dataset(
+            "INSERT DATA { <http://ex/a> <http://ex/p> <http://ex/b> }",
+            &over,
+        )
+        .unwrap();
+        assert!(
+            !out.contains("USING"),
+            "data-only op must not gain a USING: {out}"
+        );
+        assert!(SparqlParser::new().parse_update(&out).is_ok());
+    }
+
+    #[test]
+    fn bad_using_graph_uri_is_error() {
+        let over = UsingOverride {
+            default: vec!["not a valid iri".into()],
+            named: vec![],
+        };
+        assert!(matches!(
+            apply_update_dataset("DELETE { ?s ?p ?o } WHERE { ?s ?p ?o }", &over),
+            Err(UpdateDatasetError::BadGraphUri(_))
+        ));
     }
 }

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -44,7 +44,7 @@ use sparq_serve::{
     ApplyUpdates, Generation, GenerationRing, GraphApplier, PodId, WriteError, Writer, WriterConfig,
 };
 
-use crate::exec::{prepare, PrepareError, QueryForm};
+use crate::exec::{apply_update_dataset, prepare_with_dataset, DatasetOverride, PrepareError, QueryForm, UpdateDatasetError, UsingOverride};
 use crate::negotiate::{negotiate, negotiate_graph, Format, GraphFormat};
 use crate::results;
 
@@ -2326,7 +2326,13 @@ async fn sparql_endpoint(
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
-    let url_params = parse_form(raw_query.as_deref().unwrap_or(""));
+    let raw = raw_query.as_deref().unwrap_or("");
+    let url_params = parse_form(raw);
+    // [OPUS-4.8] sq-z33x: the SPARQL 1.1 Protocol query/update dataset overrides live in the URL
+    // query string for GET and the direct (`application/sparql-query` / `application/sparql-update`)
+    // POSTs; the form-POST path reads them from the request BODY instead (see `handle_post`).
+    let url_dataset = query_dataset_override(raw);
+    let url_using = update_dataset_override(raw);
     match method {
         Method::GET | Method::HEAD => {
             // Query string carries `query=` (+ optional dataset params). Per protocol, a
@@ -2378,7 +2384,7 @@ async fn sparql_endpoint(
                     };
                     let explain = explain_mode(&url_params, None, &headers);
                     let resp =
-                        run_query(&state, q, &headers, method == Method::HEAD, explain, pin).await;
+                        run_query(&state, q, &headers, method == Method::HEAD, explain, pin, &url_dataset).await;
                     #[cfg(feature = "audit-log")]
                     if let Some(a) = audit {
                         a.emit(&resp);
@@ -2401,7 +2407,7 @@ async fn sparql_endpoint(
                 None => bad_request("missing 'query' parameter"),
             }
         }
-        Method::POST => handle_post(&state, &headers, &body, &url_params).await,
+        Method::POST => handle_post(&state, &headers, &body, &url_params, &url_dataset, &url_using).await,
         _ => method_not_allowed(&[Method::GET, Method::HEAD, Method::POST]),
     }
 }
@@ -2411,6 +2417,14 @@ async fn handle_post(
     headers: &HeaderMap,
     body: &Bytes,
     url_params: &HashMap<String, String>,
+    // [OPUS-4.8] sq-z33x: the §2.1.4 query dataset override carried in the URL query string
+    // (applies to the direct `application/sparql-query` POST; the form-POST path overrides it with
+    // the override carried in the form BODY, per the protocol's url-encoded encoding).
+    url_dataset: &DatasetOverride,
+    // [OPUS-4.8] sq-z33x: the §2.2 UPDATE dataset override (`using-*`) carried in the URL query
+    // string (applies to the direct `application/sparql-update` POST; the form-POST `update=` path
+    // reads it from the form BODY).
+    url_using: &UsingOverride,
 ) -> Response {
     let ct = content_type(headers);
     if ct.starts_with(SPARQL_QUERY_CT) {
@@ -2471,7 +2485,7 @@ async fn handle_post(
             }
         };
         let explain = explain_mode(url_params, None, headers);
-        let resp = run_query(state, s, headers, false, explain, pin).await;
+        let resp = run_query(state, s, headers, false, explain, pin, url_dataset).await;
         #[cfg(feature = "audit-log")]
         if let Some(a) = audit {
             a.emit(&resp);
@@ -2557,7 +2571,12 @@ async fn handle_post(
                 audit_access_finish(state, aa, &resp);
                 return resp;
             }
-            let resp = run_update(state, u.clone()).await;
+            // [OPUS-4.8] sq-z33x: §2.2 UPDATE dataset override — for the url-encoded form encoding
+            // the `using-*` params are carried in the FORM BODY (`s`), not the URL query string.
+            let resp = match rewrite_update(u, &update_dataset_override(s)) {
+                Ok(rewritten) => run_update(state, rewritten).await,
+                Err(resp) => resp,
+            };
             #[cfg(feature = "audit-log")]
             if let Some(a) = audit {
                 a.emit(&resp);
@@ -2581,7 +2600,10 @@ async fn handle_post(
                     }
                 };
                 let explain = explain_mode(url_params, Some(&params), headers);
-                run_query(state, q, headers, false, explain, pin).await
+                // [OPUS-4.8] sq-z33x: per the SPARQL 1.1 Protocol url-encoded encoding, the dataset
+                // override (`default-graph-uri` / `named-graph-uri`) is carried in the FORM BODY for
+                // this content type, not the URL query string.
+                run_query(state, q, headers, false, explain, pin, &query_dataset_override(s)).await
             }
             None => bad_request("missing 'query' or 'update' parameter in url-encoded body"),
         };
@@ -2642,7 +2664,12 @@ async fn handle_post(
             return resp;
         }
         let resp = match std::str::from_utf8(body) {
-            Ok(u) => run_update(state, u.to_string()).await,
+            // [OPUS-4.8] sq-z33x: §2.2 UPDATE dataset override — for the `application/sparql-update`
+            // body the `using-*` params are carried in the URL query string (`url_using`).
+            Ok(u) => match rewrite_update(u, url_using) {
+                Ok(rewritten) => run_update(state, rewritten).await,
+                Err(resp) => resp,
+            },
             Err(_) => bad_request("request body is not valid UTF-8"),
         };
         #[cfg(feature = "audit-log")]
@@ -2771,9 +2798,10 @@ async fn run_query(
     head_only: bool,
     explain: ExplainMode,
     gen: PinnedGen,
+    dataset: &DatasetOverride,
 ) -> Response {
     let number = gen.number();
-    let resp = run_query_pinned(state, sparql, headers, head_only, explain, gen).await;
+    let resp = run_query_pinned(state, sparql, headers, head_only, explain, gen, dataset).await;
     with_generation_header(resp, number)
 }
 
@@ -2784,8 +2812,11 @@ async fn run_query_pinned(
     head_only: bool,
     explain: ExplainMode,
     gen: PinnedGen,
+    // [OPUS-4.8] sq-z33x: the SPARQL 1.1 Protocol §2.1.4 dataset override
+    // (`default-graph-uri` / `named-graph-uri`); empty for the common in-query / no-dataset case.
+    dataset: &DatasetOverride,
 ) -> Response {
-    let prepared = match prepare(sparql) {
+    let prepared = match prepare_with_dataset(sparql, dataset) {
         Ok(p) => p,
         // [OPUS-4.8] (sq-cz89/sq-j9zs) The parser echoes the offending query token verbatim;
         // withhold it from the body (it is caller input, but an info-leak contract regardless)
@@ -2798,6 +2829,9 @@ async fn run_query_pinned(
                 &msg,
             )
         }
+        // [OPUS-4.8] sq-z33x: a `default-graph-uri` / `named-graph-uri` value that is not a valid
+        // absolute IRI is a client error (the protocol parameter is caller input).
+        Err(PrepareError::BadGraphUri(msg)) => return bad_request(&msg),
     };
     // The generation was pinned ONCE per request (the caller's `resolve_pin`: the
     // current generation, or — under the `time-travel` feature — the requested
@@ -3772,6 +3806,58 @@ fn parse_form(s: &str) -> HashMap<String, String> {
         map.insert(form_decode(k), form_decode(v));
     }
     map
+}
+
+/// [OPUS-4.8] sq-z33x: collects EVERY value of a repeated `application/x-www-form-urlencoded`
+/// key (in request order). [`parse_form`]'s `HashMap` keeps only the last value, but the SPARQL
+/// 1.1 Protocol dataset parameters (`default-graph-uri` / `named-graph-uri` / `using-*`) are
+/// intrinsically multi-valued — a dataset can name several default and several named graphs — so
+/// they must be read from the raw form/query string, not the collapsed map.
+fn form_values(raw: &str, key: &str) -> Vec<String> {
+    raw.split('&')
+        .filter(|pair| !pair.is_empty())
+        .filter_map(|pair| match pair.split_once('=') {
+            Some((k, v)) => (form_decode(k) == key).then(|| form_decode(v)),
+            None => None,
+        })
+        .collect()
+}
+
+/// [OPUS-4.8] sq-z33x: extracts the SPARQL 1.1 Protocol §2.1.4 query dataset override
+/// (`default-graph-uri` / `named-graph-uri`) from a raw urlencoded string — the request URL query
+/// string for GET / direct-POST, or the form body for an `application/x-www-form-urlencoded` POST.
+fn query_dataset_override(raw: &str) -> DatasetOverride {
+    DatasetOverride {
+        default: form_values(raw, "default-graph-uri"),
+        named: form_values(raw, "named-graph-uri"),
+    }
+}
+
+/// [OPUS-4.8] sq-z33x: extracts the SPARQL 1.1 Protocol §2.2 UPDATE dataset override
+/// (`using-graph-uri` / `using-named-graph-uri`) from a raw urlencoded string.
+fn update_dataset_override(raw: &str) -> UsingOverride {
+    UsingOverride {
+        default: form_values(raw, "using-graph-uri"),
+        named: form_values(raw, "using-named-graph-uri"),
+    }
+}
+
+/// [OPUS-4.8] sq-z33x: applies the UPDATE dataset override to the update string, mapping a rewrite
+/// failure onto the right HTTP 400. Returns the (possibly rewritten) update on success.
+// clippy: Err is axum's `Response` (the idiomatic handler error, as at `resolve_pin`); boxing it
+// would only desync the call sites that already thread `Response` errors.
+#[allow(clippy::result_large_err)]
+fn rewrite_update(update: &str, over: &UsingOverride) -> Result<String, Response> {
+    apply_update_dataset(update, over).map_err(|e| match e {
+        UpdateDatasetError::Malformed(msg) => {
+            sanitized_error(StatusCode::BAD_REQUEST, "update-parse", "malformed update", &msg)
+        }
+        UpdateDatasetError::BadGraphUri(msg) => bad_request(&msg),
+        UpdateDatasetError::UsingConflict => bad_request(
+            "the 'using-graph-uri' / 'using-named-graph-uri' parameters must not be combined with \
+             an in-update USING / USING NAMED / WITH clause (SPARQL 1.1 Protocol §2.2)",
+        ),
+    })
 }
 
 /// Decodes a single `application/x-www-form-urlencoded` component (`+` → space, `%XX`).

--- a/crates/sparq-server/src/subscriptions.rs
+++ b/crates/sparq-server/src/subscriptions.rs
@@ -356,6 +356,9 @@ pub(crate) async fn subscribe_init(
         Ok(p) if p.form == QueryForm::Select => {}
         Ok(_) => return Err(refuse("only SELECT queries can be subscribed".into(), StatusCode::BAD_REQUEST)),
         Err(PrepareError::Malformed(e)) => return Err(refuse(format!("malformed query: {e}"), StatusCode::BAD_REQUEST)),
+        // [OPUS-4.8] sq-z33x: subscriptions carry no SPARQL-Protocol dataset override, so this
+        // arm is unreachable in practice — but a bad graph IRI is a client error regardless.
+        Err(PrepareError::BadGraphUri(e)) => return Err(refuse(e, StatusCode::BAD_REQUEST)),
     }
 
     // Limits: per-connection first (cheap), then the global slot. Both are genuine

--- a/crates/sparq-server/tests/protocol.rs
+++ b/crates/sparq-server/tests/protocol.rs
@@ -735,30 +735,226 @@ async fn gsp_indirect_requires_graph_selector() {
 }
 
 // ---------------------------------------------------------------------------
-// protocol dataset-override params accepted (not yet applied — see exec.rs)
+// [OPUS-4.8] sq-z33x — SPARQL 1.1 Protocol §2.1.4 / §2.2 dataset-override params
+// (`default-graph-uri` / `named-graph-uri`; update `using-graph-uri` / `using-named-graph-uri`)
 // ---------------------------------------------------------------------------
 //
 // [OPUS-4.8] The engine DOES support named graphs — `GRAPH` / `FROM` / `FROM NAMED` and
-// cross-graph joins all execute (see `tests/named_graphs.rs`, sq-fh4z). What is not yet
-// wired is the *protocol-level* dataset override: the `default-graph-uri` /
-// `named-graph-uri` request parameters are accepted and recorded but do not currently
-// re-scope the query's active dataset, so they must not error and (today) have no effect.
+// cross-graph joins all execute (see `tests/named_graphs.rs`, sq-fh4z). On top of that, the
+// *protocol-level* dataset override — the `default-graph-uri` / `named-graph-uri` request
+// parameters (and the update `using-graph-uri` / `using-named-graph-uri` forms) — now
+// re-scopes the active dataset of the query/update per §2.1.4 / §2.2 (sq-z33x), as the
+// tests below assert.
 
+/// An RDF dataset with a default graph plus two named graphs, so the protocol dataset override
+/// has something real to re-scope the active dataset to.
+const NQ_DATASET: &str = r#"
+    <http://ex/d> <http://ex/p> <http://ex/in_default> .
+    <http://ex/a> <http://ex/p> <http://ex/in_g1> <http://ex/g1> .
+    <http://ex/b> <http://ex/p> <http://ex/in_g2> <http://ex/g2> .
+"#;
+
+/// Boots a server over [`NQ_DATASET`] (a default graph + named graphs g1, g2).
+async fn spawn_dataset() -> String {
+    let graph = Graph::load_dataset(NQ_DATASET, "nquads").unwrap();
+    let app = router(AppState::new(graph));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+/// Counts SELECT `?s ?p ?o` solution rows in a SPARQL-JSON body.
+fn json_row_count(body: &str) -> usize {
+    let v: serde_json::Value = serde_json::from_str(body).unwrap();
+    v["results"]["bindings"].as_array().map(|a| a.len()).unwrap_or(0)
+}
+
+/// `default-graph-uri=g1` re-scopes the active default graph to ONLY g1's triple — the store's
+/// own default graph drops out (one row, the g1 triple; not the default-graph one).
 #[tokio::test]
-async fn default_graph_uri_param_is_accepted() {
-    let base = spawn().await;
-    let resp = client()
+async fn default_graph_uri_rescopes_active_dataset() {
+    let base = spawn_dataset().await;
+    let cl = client();
+
+    // Without the override: the store's default graph (1 triple).
+    let plain = cl
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "SELECT ?s ?p ?o WHERE { ?s ?p ?o }")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(plain.status(), 200);
+    assert_eq!(json_row_count(&plain.text().await.unwrap()), 1);
+
+    // With `default-graph-uri=g1`: the active default graph is g1 (still 1 triple, but it is g1's).
+    let resp = cl
         .get(format!("{base}/sparql"))
         .query(&[
-            ("query", "SELECT ?s WHERE { ?s <http://ex/age> ?a }"),
-            ("default-graph-uri", "http://ex/g"),
+            ("query", "SELECT ?s ?p ?o WHERE { ?s ?p ?o }"),
+            ("default-graph-uri", "http://ex/g1"),
         ])
         .send()
         .await
         .unwrap();
-    // Accepted + recorded; the protocol dataset-override is not yet applied, so it has no
-    // effect here — but it must not error. (In-query GRAPH/FROM is the supported path.)
     assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert_eq!(json_row_count(&body), 1);
+    assert!(body.contains("http://ex/in_g1"), "expected g1's triple, got {body}");
+    assert!(!body.contains("in_default"), "store default graph must drop out: {body}");
+}
+
+/// Two `default-graph-uri` values merge into the active default graph (g1 ∪ g2 = 2 triples).
+#[tokio::test]
+async fn multiple_default_graph_uri_merge() {
+    let base = spawn_dataset().await;
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[
+            ("query", "SELECT ?s ?p ?o WHERE { ?s ?p ?o }"),
+            ("default-graph-uri", "http://ex/g1"),
+            ("default-graph-uri", "http://ex/g2"),
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(json_row_count(&resp.text().await.unwrap()), 2);
+}
+
+/// `named-graph-uri=g1` makes g1 the only named graph; the active default graph is empty, so a
+/// `GRAPH ?g` query sees exactly g1's one triple and a default-graph BGP sees nothing.
+#[tokio::test]
+async fn named_graph_uri_rescopes_named_graphs() {
+    let base = spawn_dataset().await;
+    let cl = client();
+
+    let in_graph = cl
+        .get(format!("{base}/sparql"))
+        .query(&[
+            ("query", "SELECT ?s ?p ?o WHERE { GRAPH ?g { ?s ?p ?o } }"),
+            ("named-graph-uri", "http://ex/g1"),
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(in_graph.status(), 200);
+    let body = in_graph.text().await.unwrap();
+    assert_eq!(json_row_count(&body), 1);
+    assert!(body.contains("http://ex/in_g1"), "got {body}");
+
+    // The active default graph is empty under a named-only override.
+    let in_default = cl
+        .get(format!("{base}/sparql"))
+        .query(&[
+            ("query", "SELECT ?s ?p ?o WHERE { ?s ?p ?o }"),
+            ("named-graph-uri", "http://ex/g1"),
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(json_row_count(&in_default.text().await.unwrap()), 0);
+}
+
+/// Per §2.1.4 the protocol dataset REPLACES an in-query `FROM` clause: a query that says
+/// `FROM <g2>` but is sent with `default-graph-uri=g1` runs against g1, not g2.
+#[tokio::test]
+async fn protocol_override_replaces_in_query_from() {
+    let base = spawn_dataset().await;
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[
+            ("query", "SELECT ?s ?p ?o FROM <http://ex/g2> WHERE { ?s ?p ?o }"),
+            ("default-graph-uri", "http://ex/g1"),
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("http://ex/in_g1"), "override (g1) must win over in-query FROM g2: {body}");
+    assert!(!body.contains("in_g2"), "in-query FROM g2 must be replaced: {body}");
+}
+
+/// The override also applies on the url-encoded POST form (body-carried params).
+#[tokio::test]
+async fn default_graph_uri_via_post_form() {
+    let base = spawn_dataset().await;
+    let resp = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body("query=SELECT+%3Fs+%3Fp+%3Fo+WHERE+%7B+%3Fs+%3Fp+%3Fo+%7D&default-graph-uri=http://ex/g1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("http://ex/in_g1"), "POST-form override must re-scope: {body}");
+}
+
+/// A `default-graph-uri` that is not a valid absolute IRI is a 400 (caller-input validation).
+#[tokio::test]
+async fn bad_default_graph_uri_is_400() {
+    let base = spawn_dataset().await;
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[
+            ("query", "SELECT ?s WHERE { ?s ?p ?o }"),
+            ("default-graph-uri", "not a valid iri"),
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+/// `using-graph-uri` re-scopes the WHERE clause of an UPDATE: an `INSERT … WHERE` that reads
+/// from g1 (via the override) copies g1's triple into the default graph.
+#[tokio::test]
+async fn using_graph_uri_rescopes_update_where() {
+    let base = spawn_dataset().await;
+    let cl = client();
+
+    // INSERT a marker into the default graph for every triple visible in the override's default
+    // graph (g1). Without `using-graph-uri` this WHERE would read the store's default graph.
+    let upd = cl
+        .post(format!("{base}/sparql?using-graph-uri=http://ex/g1"))
+        .header("content-type", "application/sparql-update")
+        .body("INSERT { <http://ex/marker> <http://ex/saw> ?o } WHERE { ?s <http://ex/p> ?o }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(upd.status(), 204, "update must succeed");
+
+    // The marker must reference g1's object, proving the WHERE read g1, not the store default.
+    let q = cl
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "SELECT ?o WHERE { <http://ex/marker> <http://ex/saw> ?o }")])
+        .send()
+        .await
+        .unwrap();
+    let body = q.text().await.unwrap();
+    assert!(body.contains("http://ex/in_g1"), "USING g1 must re-scope the WHERE: {body}");
+    assert!(!body.contains("in_default"), "WHERE must NOT read the store default graph: {body}");
+}
+
+/// Per §2.2 it is an error to supply `using-graph-uri` alongside an in-update `USING` clause: 400.
+#[tokio::test]
+async fn using_graph_uri_conflict_with_in_update_using_is_400() {
+    let base = spawn_dataset().await;
+    let resp = client()
+        .post(format!("{base}/sparql?using-graph-uri=http://ex/g1"))
+        .header("content-type", "application/sparql-update")
+        .body(
+            "INSERT { <http://ex/m> <http://ex/p> ?o } USING <http://ex/g2> \
+             WHERE { ?s <http://ex/p> ?o }",
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400, "USING + using-graph-uri must be a protocol error");
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -164,8 +164,12 @@ Library surface re-exported from `sparq_server` (behind the default `server` fea
 - Serializer/negotiation helpers (always compiled, no `server` feature): module
   `sparq_server::negotiate` — `fn negotiate(accept: Option<&str>) -> Format`,
   `fn negotiate_graph(accept: Option<&str>) -> GraphFormat`; module
-  `sparq_server::exec` — `fn prepare(&str) -> Result<Prepared, PrepareError>`,
-  `enum QueryForm { Select, Ask, Construct, Describe }`; module `sparq_server::results`.
+  `sparq_server::exec` — `fn prepare(&str) -> Result<Prepared, PrepareError>` and
+  `fn prepare_with_dataset(&str, &DatasetOverride) -> Result<Prepared, PrepareError>` (applies the
+  SPARQL-Protocol `default-graph-uri`/`named-graph-uri` override, sq-z33x),
+  `fn apply_update_dataset(&str, &UsingOverride) -> Result<String, UpdateDatasetError>` (the
+  update-side `using-*` override), `enum QueryForm { Select, Ask, Construct, Describe }`; module
+  `sparq_server::results`.
 
 ## Common recipes
 
@@ -754,9 +758,13 @@ Some(SinkTarget::File(path)), .. }` (field present only with the feature). See
 - **Named graphs are real (since conformance round 3).** The engine stores the FULL dataset
   — default graph + named graphs — so `GRAPH <g> { … }` / `GRAPH ?g { … }` evaluate, and a
   GSP graph resource (`?graph=<iri>` or the direct request URI) addresses a genuine named
-  graph (no longer a default-graph alias). `FROM`/`FROM NAMED` and the protocol's
-  `default-graph-uri`/`named-graph-uri` params are accepted/threaded. Time-travel pinning is
-  `/sparql` queries only (GSP read/write and subscriptions always operate on current).
+  graph (no longer a default-graph alias). `FROM`/`FROM NAMED` re-scope the active dataset, and
+  the protocol's dataset-override params are **applied** (sq-z33x), not just accepted:
+  `default-graph-uri`/`named-graph-uri` synthesize the query's active dataset (replacing any
+  in-query `FROM`/`FROM NAMED` per §2.1.4), and `using-graph-uri`/`using-named-graph-uri` re-scope
+  an update's `WHERE` (per §2.2; combining with an in-update `USING`/`USING NAMED`/`WITH` is a
+  `400`, as is a non-IRI graph value). Time-travel pinning is `/sparql` queries only (GSP
+  read/write and subscriptions always operate on current).
 - **Update operations.** Engine handles `INSERT DATA`, `DELETE DATA`, `CLEAR`/`DROP`/`CREATE`
   (DEFAULT / named / ALL), `LOAD`, and `DELETE/INSERT … WHERE` — over the default graph AND
   named graphs. A failing operation is refused with `400`, atomically (no partial effect


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated PR by an agent running on @jeswr's account. Re-review tagged for Fable when it returns ([OPUS-4.8] markers + Opus 4.8 trailer).

## What

Implements bead **sq-z33x**: the SPARQL 1.1 Protocol dataset-override parameters were *accepted + recorded* but **not applied** — they did not re-scope the active RDF dataset. This wires them through.

* **Query (§2.1.4)** — `default-graph-uri` / `named-graph-uri` synthesize a `FROM` / `FROM NAMED` dataset clause on the parsed query (re-serialised via spargebra `Display` so the engine, which re-parses, sees it). Per the spec, when the override is present it **replaces** any in-query `FROM` / `FROM NAMED` ("the SPARQL service must execute the query using the RDF Dataset given in the protocol request").
* **Update (§2.2)** — `using-graph-uri` / `using-named-graph-uri` inject a `USING` / `USING NAMED` into every `DELETE/INSERT … WHERE`. Combining them with an in-update `USING` / `USING NAMED` / `WITH` is the protocol error condition → **400**. Data-only ops (`INSERT DATA`, `LOAD`, `CLEAR`, …) have no `WHERE` to re-scope and are left untouched.
* A graph-URI value that is not a valid absolute IRI → **400** (caller input).

The params are intrinsically multi-valued, so they are read from the **raw** query string / form body (`parse_form`'s `HashMap` keeps only the last value of a repeated key). Wired on every transport: GET, direct `application/sparql-query` POST, url-encoded form POST, and the `application/sparql-update` body — with the override taken from the URL query string or the form body per the protocol's encoding for each content type.

## Why this shape

The engine already builds an active dataset from a `FROM` / `FROM NAMED` clause (`sparq_engine` `build_active`), and the server already passes a query **string** to the engine. So the smallest correct change is to rewrite the parsed query/update algebra and re-serialise — no engine API change, no new evaluation path. The override semantics fall straight out of the existing dataset-clause executor (a `FROM` of an absent graph → empty default graph; `named-graph-uri`-only → empty default graph + exactly those named graphs).

## Tests

* `exec.rs` unit tests — query rewrite (default / named / replace-in-query / bad-IRI / empty no-op / end-to-end on the engine) and update rewrite (inject `USING`/`USING NAMED`, conflict → error, data-only untouched, bad-IRI).
* `tests/protocol.rs` — end-to-end over real HTTP against a named-graph dataset: re-scope, multi-value merge, `GRAPH ?g` named-graph scoping, in-query `FROM` replacement, POST-form override, 400 on bad IRI, update `WHERE` re-scope, and the `USING` + `using-graph-uri` conflict → 400.

Updated the stale `default_graph_uri_param_is_accepted` test (which asserted "no effect"), the `crates/sparq-server/README.md` Features note, and `skills/http-server/SKILL.md` (was "accepted/threaded" → now "applied", plus the new `exec` public API).

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + tests on **default** and the **`audit-log,access-audit,time-travel,test-seams`** feature legs — all green.
- privacy-claims gate (predicate-form soundness) — OK.
- G2 public-api → SKILL.md gate — PASS (the new `exec` surface is documented).

Note: `--no-default-features --all-targets` clippy fails on the integration tests both before and after this change (they inherently require the `server` feature); the **library** builds clean with `--no-default-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)