### PR TITLE
ci(typos): correct sq-uiie comment examples (sq-k041) — anchor recovers SEPERATEd/MULTIPLYed/OCURRed, not glued RECIEVEd/ADRESs

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -40,11 +40,16 @@ extend-exclude = [
 #
 # The anchor is a CLOSED alternation of known SPARQL/SQL/RDF-update keyword roots — NOT a
 # blanket `[A-Z]{3,}`. The original sq-hyzq form `\b[A-Z]{3,}[a-z]{1,3}\b` matched ANY run
-# of >=3 capitals plus a 1-3 char lowercase tail, which silently shielded genuine ALL-CAPS
-# misspellings written with a suffix (RECIEVEd, SEPERATEd, ADRESs) — it suppressed the very
-# misspelling class the gate exists to catch. Pinning the prefix to a vetted keyword list
-# closes that hole: a misspelled root is never in the list, so its suffixed form fires
-# again, while every legitimate keyword-suffix split stays clean. (Acronym plurals like
+# of >=3 capitals plus a 1-3 char lowercase tail, which silently shielded genuine misspelled
+# roots written with a suffix (SEPERATEd, MULTIPLYed, OCURRed) — it suppressed the very
+# misspelling class the gate exists to catch. (typos splits at the case boundary, so it sees
+# `SEPERAT`/`MULTIPL`/`OCUR` and flags them against SEPARATE/MULTIPLE/OCCUR; the old regex hid
+# exactly those hits. Note the glued mixed-case forms RECIEVEd/ADRESs are NOT a member of this
+# class — typos never flags them in the first place, with or without the regex; only the bare
+# all-caps RECIEVE/ADRES fire, and the keyword anchor leaves those untouched.) Pinning the
+# prefix to a vetted keyword list closes the hole: a misspelled root is never in the list, so
+# its suffixed form fires again, while every legitimate keyword-suffix split stays clean.
+# (Acronym plurals like
 # IRIs/APIs/SBOMs never needed shielding — typos already treats `<ACRONYM>s` as an acronym
 # plural and does not flag them; verified by a both-config diff over the doc surface.)
 extend-ignore-re = [

--- a/scripts/tests/test_typos_allowlist.sh
+++ b/scripts/tests/test_typos_allowlist.sh
@@ -13,7 +13,11 @@
 # update keyword roots (SELECT|INSERT|DELETE|…) each followed by a 1-3 char lowercase tail,
 # plus an `invokable` word entry. (sq-uiie: the original sq-hyzq form `\b[A-Z]{3,}[a-z]{1,3}\b`
 # was over-broad — it shielded ANY all-caps run with a short lowercase tail, silently hiding
-# genuine misspellings like RECIEVEd/SEPERATEd; the keyword anchor closes that hole.) This
+# genuine misspelled roots whose suffixed form typos DOES flag: SEPERATEd/MULTIPLYed/OCURRed
+# (typos splits at the case boundary -> SEPERAT/MULTIPL/OCUR -> SEPARATE/MULTIPLE/OCCUR). The
+# keyword anchor closes that hole. sq-k041: the glued mixed-case forms RECIEVEd/ADRESs are NOT
+# such a case — typos never flags those, regex or no; only the bare all-caps RECIEVE/ADRES do.)
+# This
 # harness pins BOTH directions so the allow-list can't silently over- or under-reach later:
 #   - should-PASS (SUPPRESSED): the keyword-suffix family + `invokable` must NOT be flagged.
 #   - should-FAIL (STILL FIRES): a genuine ALL-CAPS misspelling (bare OR with a lowercase
@@ -95,6 +99,16 @@ check FAIL "Keep the two stores seperate."
 check FAIL "The bytes were SEPERATEd into two buffers."  # SEPERATE is not a keyword
 check FAIL "Each value was MULTIPLYed by two."            # MULTIPLY+ed, not a SPARQL verb
 check FAIL "The fault OCURRed under load."                # OCURR(ed) is not a keyword
+
+# --------------------------------------------------------------------------- #
+# [OPUS-4.8] Pin (bead sq-k041): the glued mixed-case forms RECIEVEd/ADRESs were cited by the sq-uiie
+# comment as misspellings the new anchor "recovers" — but typos NEVER flags those glued forms
+# (case-boundary split leaves a mixed-case token it won't correct), regex or no. They are NOT
+# the recovered class. These MUST PASS unconditionally — independent of the keyword anchor —
+# so the comment can't drift back to citing them. (The bare all-caps RECIEVE still FAILs above
+# at line ~81, which is the form typos actually catches.)
+check PASS "The handler RECIEVEd the message."           # glued mixed-case — typos-invisible
+check PASS "The ADRESs field was left blank."            # glued mixed-case — typos-invisible
 
 # --------------------------------------------------------------------------- #
 echo ""


### PR DESCRIPTION
> 🤖 **SPARQL agent** — automated change. @jeswr runs several agents on this account; this PR is from one of them.

## What

Corrects a factually-wrong comment introduced in the sq-uiie tightening of `_typos.toml`. Bead **sq-k041** (sq-uiie / #444 follow-up).

The line-44 comment (and the matching self-test header) claimed the new closed-keyword anchor "recovers" misspellings like **RECIEVEd / ADRESs** that the old blanket `\b[A-Z]{3,}[a-z]{1,3}\b` regex had silently shielded. That is wrong.

## Why it was wrong (empirically verified, typos 1.47.2 under the shipped config)

`typos` splits at the case boundary. The behaviour falls into two distinct groups:

| Form | typos verdict | Why |
|---|---|---|
| `RECIEVEd`, `ADRESs` (glued, capital run + lowercase tail) | **never flagged** | the case-split leaves a mixed-case token typos won't correct — regex or no regex |
| `RECIEVE`, `ADRES` (bare all-caps) | flagged → `RECEIVE` / `ADDRESS` | pure all-caps word it recognises |
| `SEPERATEd`, `MULTIPLYed`, `OCURRed` | **flagged** → `SEPERAT`→`SEPARATE`, `MULTIPL`→`MULTIPLE/MULTIPLY`, `OCUR`→`OCCUR` | case-split prefix is a known misspelled root |

So the misspelling class the closed-keyword anchor actually un-shields is **SEPERATEd / MULTIPLYed / OCURRed** (a misspelled root + suffix, which the old blanket regex would have suppressed). The glued mixed-case `RECIEVEd / ADRESs` were never a member of that class — there was nothing to shield.

## Change

- `_typos.toml` (line ~44): comment examples corrected to `SEPERATEd / MULTIPLYed / OCURRed`, with an explicit note that the glued forms are typos-invisible.
- `scripts/tests/test_typos_allowlist.sh`: header comment corrected to match; **two new should-PASS regression pins** (`RECIEVEd`, `ADRESs` must NOT be flagged) so the comment can't drift back to citing them as a recovered class. The existing should-FAIL cases for the bare all-caps `RECIEVE` and the `SEPERATEd/MULTIPLYed/OCURRed` family are unchanged and still pass.

**No regex / no gate behaviour change** — comment + test-doc accuracy only.

## Gate

- `scripts/tests/test_typos_allowlist.sh`: **16 passed, 0 failed** (was 14; +2 sq-k041 pins).
- `shellcheck scripts/tests/test_typos_allowlist.sh`: clean.
- `typos` doc-surface scan (same scope as the `docs-quality` CI gate, 74 md files): clean. (`_typos.toml` and the `.sh` are outside the `.md` doc surface, so the literal misspellings in the corrected comment do not reach the gate — verified.)
- privacy-claims gate (`scripts/check-privacy-claims.sh`): OK (274 files, no unqualified claim).
- No public API touched → G2 SKILL.md rule N/A.

`[OPUS-4.8]`