### PR TITLE
docs(sparq-serve,sparq-parse): surface crate-local README on crates.io/docs.rs (sq-ieqz)

### DIFF
--- a/crates/sparq-parse/Cargo.toml
+++ b/crates/sparq-parse/Cargo.toml
@@ -9,7 +9,10 @@ repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
-readme = "../../README.md"
+# [OPUS-4.8] sq-ieqz: surface the crate-LOCAL README, not the root one. Harmless here
+# (publish = false, never reaches crates.io) but kept consistent with sparq-serve;
+# lib.rs mirrors it via `#![doc = include_str!("../README.md")]` for rustdoc parity.
+readme = "README.md"
 publish = false
 
 # Codec deps live HERE and nowhere closer to the engine: this crate must never

--- a/crates/sparq-parse/README.md
+++ b/crates/sparq-parse/README.md
@@ -16,6 +16,26 @@ following it, and the first bytes hit the wire sooner.
 Hard constraint: this crate must **not** enter `sparq-wasm`'s dependency graph
 (flate2 / zstd / rayon stay out of the browser bundle).
 
+## API sketch
+
+```rust
+use sparq_parse::{Codec, CompressedSink, Mode, decode_gzip_concat};
+
+let chunks: Vec<String> = vec!["{\"head\":...".into(), "...rest".into()];
+let mut sink = CompressedSink::new(Codec::Gzip { level: 6 }, Mode::Parallel);
+let mut wire = Vec::new();
+for c in &chunks {
+    sink.push(c.as_bytes());
+    for member in sink.try_drain().unwrap() {
+        wire.extend_from_slice(&member); // stream to the client immediately
+    }
+}
+for member in sink.finish().unwrap() {
+    wire.extend_from_slice(&member);
+}
+assert_eq!(decode_gzip_concat(&wire).unwrap(), chunks.concat().into_bytes());
+```
+
 > **Internal crate — not on crates.io** (`publish = false`). The design is gated
 > on a measured baseline; it is consumed inside the workspace, not as a
 > standalone public API.

--- a/crates/sparq-parse/src/lib.rs
+++ b/crates/sparq-parse/src/lib.rs
@@ -1,43 +1,8 @@
-//! sparq-parse: compressed serialization of query results (D4).
-//!
-//! The crate's first real module: chunk-at-a-time compression of serialized
-//! query results, designed around one format property — **multi-member gzip and
-//! multi-frame zstd are valid single streams**. Each serialized chunk (e.g. one
-//! element of `sparq_engine::query_json_chunks_with_budget`'s output) is
-//! compressed as an *independent* gzip member / zstd frame, and the members are
-//! concatenated in order. The concatenation decodes as ONE stream with stock
-//! decoders (`Content-Encoding: gzip` in browsers, `MultiGzDecoder`, `gzip -d`,
-//! Python `gzip`, the `zstd` CLI), so chunks can be compressed in parallel as
-//! they are produced and emitted in order: compression overlaps serialization
-//! instead of following it, and the first bytes hit the wire sooner.
-//!
-//! Measured results + design notes: `research/custom-parsers-D4-compressed-serialization.md`
-//! (benchmarks under `bench/parse/`, `compress-bench` binary). Numbers gate on
-//! the house baseline in `research/custom-parsers-baseline.md`.
-//!
-//! Hard constraint (unchanged from the scaffold): this crate must NOT enter the
-//! wasm dependency graph (`sparq-wasm` must never depend on it, directly or
-//! transitively) — flate2/zstd/rayon stay out of the bundle.
-//!
-//! # API sketch
-//!
-//! ```
-//! use sparq_parse::{Codec, CompressedSink, Mode, decode_gzip_concat};
-//!
-//! let chunks: Vec<String> = vec!["{\"head\":...".into(), "...rest".into()];
-//! let mut sink = CompressedSink::new(Codec::Gzip { level: 6 }, Mode::Parallel);
-//! let mut wire = Vec::new();
-//! for c in &chunks {
-//!     sink.push(c.as_bytes());
-//!     for member in sink.try_drain().unwrap() {
-//!         wire.extend_from_slice(&member); // stream to the client immediately
-//!     }
-//! }
-//! for member in sink.finish().unwrap() {
-//!     wire.extend_from_slice(&member);
-//! }
-//! assert_eq!(decode_gzip_concat(&wire).unwrap(), chunks.concat().into_bytes());
-//! ```
+// [OPUS-4.8] sq-ieqz: rustdoc front page IS the crate-local README
+// (`crates/sparq-parse/README.md`), so the doc surface and the README never drift.
+// The README carries the format rationale (multi-member gzip / multi-frame zstd),
+// the no-wasm-dep guard, and the runnable API-sketch doctest below.
+#![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 
 use std::collections::BTreeMap;

--- a/crates/sparq-serve/Cargo.toml
+++ b/crates/sparq-serve/Cargo.toml
@@ -20,7 +20,10 @@ repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
-readme = "../../README.md"
+# [OPUS-4.8] sq-ieqz: crate-LOCAL README is the crates.io/docs.rs front page (this
+# crate is publishable). lib.rs mirrors it via `#![doc = include_str!("../README.md")]`,
+# so the rustdoc front page == the crates.io README (parity, like sparq-server).
+readme = "README.md"
 
 [dependencies]
 # Lock-free current-generation pointer (§6.4): readers `load()` in ~10-20 ns and

--- a/crates/sparq-serve/src/lib.rs
+++ b/crates/sparq-serve/src/lib.rs
@@ -1,68 +1,9 @@
-//! sparq-serve: the concurrent-serving core (research/concurrent-serving.md §6).
-//!
-//! Wave A deliverable 1 (§8): the **generation ring** — an arc-swapped chain of
-//! immutable store snapshots with a bounded retention ring and per-pod epoch
-//! vectors. This replaces the double-buffered `AppState` snapshot scheme whose two
-//! measured pathologies (§4.3/§4.4: the 5.4 s/32 s pinned-snapshot writer stall and
-//! reclaim-poll degradation under reader churn) motivated the redesign.
-//!
-//! Invariants (load-bearing, tested):
-//! - **Readers never block the writer; the writer never waits for readers** and
-//!   never reclaims in place. Old generations are freed by ordinary `Arc` drop
-//!   when their last holder lets go — there is no reclaim poll, no grace timer.
-//! - **The ring only forgets its own references** beyond the retention bound K;
-//!   it can never invalidate a generation a reader still pins.
-//! - `current()` is lock-free (`ArcSwap::load`, ~10–20 ns); only `publish()` and
-//!   the introspection accessors take the (writer-side) mutex.
-//!
-//! Wave A deliverable 2 (§6.5): the **single sequenced writer** with a
-//! group-commit window — [`Writer`] owns the sole right to publish generations;
-//! updates arriving within a window (default 3 ms / 256 updates) are applied to
-//! one working copy and published as ONE generation, epochs bumped for the union
-//! of touched pods. Sync ([`Writer::submit`], returns the generation number) and
-//! fire-and-forget ([`Writer::submit_detached`]) submission; failed updates are
-//! reported to their submitter and skipped, never poisoning the batch (policy
-//! documented in the `writer` module). [`GraphApplier`] is the production
-//! [`ApplyUpdates`] strategy — the STRUCTURAL FORK (`Graph::fork`, Arc-shared
-//! immutable storage + per-generation delta) makes its fork O(pending delta),
-//! with a threshold compaction policy in `seal` bounding the delta (its module
-//! docs record the design and the measured before/after numbers).
-//!
-//! Opt-in time travel: a retained generation IS a queryable snapshot, so
-//! [`RingConfig::time_travel`] ([`TimeTravelConfig`]) extends retention beyond the
-//! concurrency bound K (count and/or age bounded; K stays the floor) and
-//! [`GenerationRing::at`] / [`GenerationRing::as_of`] resolve a generation number /
-//! "as of T" timestamp to a pinned historical generation ([`Generation::published_at`]
-//! is stamped by the ring's injectable clock). Memory cost is honest and documented on
-//! [`TimeTravelConfig`]: each retained generation is a FULL `Graph` until the
-//! structural-fork follow-up lands; the API is shaped so delta-chain retention can
-//! replace full graphs later without an API change.
-//!
-//! Wave B deliverable (§6.2): the read-side **query [`Scheduler`]** — goal #4
-//! requirements 3 + 4 (cheap-query prioritisation + no head-of-line blocking). A
-//! cost-aware bounded thread pool with two lanes: cheap jobs are prioritised and
-//! always keep a reserved worker (so an expensive-query flood can never block a
-//! cheap query — the structural no-HoL guarantee), while heavy jobs run under a
-//! bounded concurrency cap with SRPT-approx + unbounded-aging ordering
-//! (shortest-estimated-first, starvation-free). Readers still pin a generation on
-//! entry (A1) inside the submitted closure, so snapshot consistency is preserved
-//! and scheduling never changes results. See the `scheduler` module docs for the
-//! Umbra-derived design (litreview-C Topic A) and the empirical-honesty test plan.
-//!
-//! Library-first rule (§6.1): sync, runtime-agnostic, no HTTP and no async-runtime
-//! types anywhere in the API (the writer and scheduler use `std::thread` +
-//! channels/condvars internally). The result cache and stream admission
-//! (`Shed(SnapshotPressure)` at the bound) are LATER waves; this crate ships the
-//! foundation they compose over and exposes the introspection (live-generation
-//! count, oldest retained number, scheduler queue depths) they will need.
-//!
-//! Snapshot integration decision: §6.4 sketches `Generation { id, graph: Arc<Graph>,
-//! epochs }`. The production snapshot mechanism is exactly an `Arc<sparq_core::Graph>`
-//! clone (`AppState::snapshot()`, measured 27 ns in §4.3), which fits behind a plain
-//! type parameter at zero cost — so [`Generation<S>`] is generic over the snapshot
-//! handle instead of introducing a `StoreSnapshot` trait that would carry no methods.
-//! The integration test `tests/real_store.rs` instantiates the ring with the real
-//! `Graph`; unit tests use an instrumented mock to observe drops.
+// [OPUS-4.8] sq-ieqz: the crate's rustdoc front page IS its crate-local README
+// (`crates/sparq-serve/README.md`, the same file crates.io/docs.rs surface), so the
+// two never drift. The Wave A/B design narrative (ring / sequenced writer / scheduler
+// invariants, the time-travel opt-in, the library-first + no-wasm-dep guards) lives in
+// that README; the per-item rustdoc on the re-exports below carries the API detail.
+#![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 
 mod applier;


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated PR. Reviewers: @jeswr runs multiple agents on one account.

Implements **sq-ieqz**.

## Problem

`sparq-serve` is a **publishable** crate, but its `Cargo.toml` set `readme = "../../README.md"` — so crates.io and docs.rs surfaced the **whole-project ROOT README** as this crate's front page, not its own. `sparq-parse` had the same `readme = "../../README.md"` (harmless — it is `publish = false`, never reaches crates.io, but inconsistent).

The crate-local `README.md` files already exist (landed under sq-4kr5); they just weren't wired up as the front page or mirrored into rustdoc.

## Change

For **both** crates:

- Flip `readme = "../../README.md"` → `readme = "README.md"` (the crate-local README).
- Add `#![doc = include_str!("../README.md")]` to `lib.rs` so the **rustdoc front page == the crates.io README** — the same parity `sparq-server`, `sparq-engine`, `sparq-core`, `sparq-reason`, `sparq-vectors`, … already follow.

`cargo package -p sparq-serve --list` now bundles the crate-local `README.md` (verified). `cargo metadata` reports `readme: README.md` for both.

### Doc-content handling (no information lost)

- The old `lib.rs` module docs for `sparq-serve` (the Wave A/B design narrative) are covered by the existing crate README; the deeper per-module detail stays in the `ring` / `writer` / `scheduler` module docs and the per-item rustdoc on the re-exports.
- `sparq-parse`'s runnable **API-sketch doctest** moved into its README, so it still runs as a doctest via the `include_str!` path (`crates/sparq-parse/src/lib.rs - (line 25)` passes in both feature states).
- Side benefit / hygiene: the old `sparq-serve` module docs carried hard-coded perf numbers (`5.4 s` / `32 s` / `27 ns`) that the README does not — folding the front page onto the README drops them from the public doc surface.

## Scope / honesty

- **No public API changed** — only Cargo metadata + crate-level doc attributes; the `pub use` re-exports are untouched. So the G2 public-API → SKILL.md rule does not trigger.
- **Privacy-claims gate:** nothing to evaluate — no privacy / ZK / soundness predicates added or modified (docs-metadata change).
- Pre-existing `rustfmt` debt in these crates' code/test bodies (146 diffs on `origin/main`, all in files I did not touch) is **deliberately left alone** — out of scope for this docs bead, and reformatting it would bury the change.

## Gate (all green)

For `sparq-serve` (no features) and `sparq-parse` (default **and** `zlib-ng`):

- `cargo build`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (incl. the README doctest in `sparq-parse`)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — confirms the `include_str!` switch introduces **no broken intra-doc links**
- wasm-dependency boundary guard: `cargo tree -p sparq-wasm -e normal | grep -cE 'sparq-serve|sparq-parse'` → **0**

[OPUS-4.8]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
