### PR TITLE
feat(sparq-solid): acp:CreatorAgent/OwnerAgent via trusted provenance (sq-3jtd.5)

### DIFF
--- a/crates/sparq-reason/tests/incremental_n3_prop.rs
+++ b/crates/sparq-reason/tests/incremental_n3_prop.rs
@@ -287,11 +287,17 @@ fn decimal_data_reaching_concatenation_falls_back_sticky_and_stays_correct() {
 }
 
 /// The real sparq-solid rule sets' qualification matrix: the ?UNSCOPED-migrated WAC rules
-/// and the first two ACP strata are exactly the input-stratified-negation shape and take
-/// the counting fast path; acp-c.n3 does NOT qualify — its simple-grant rules conclude
-/// `{ ?p ?pred ?r }` with a VARIABLE predicate (bound from solidx:allowPred/denyPred data),
-/// so the derived-predicate set is not statically known and predicate-level stratification
-/// is unsound. The analysis must detect that and fall back.
+/// and the acp-b.n3 stratum are exactly the input-stratified-negation shape and take the
+/// counting fast path. acp-a.n3 and acp-c.n3 do NOT qualify — each has a rule with a
+/// VARIABLE predicate the analysis cannot statically resolve, so predicate-level
+/// stratification is unsound and the analysis must conservatively fall back. In acp-c.n3 a
+/// simple-grant rule CONCLUDES `{ ?p ?pred ?r }` (predicate bound from
+/// `solidx:allowPred`/`denyPred` data), so the derived-predicate set is not statically known.
+/// In acp-a.n3 ([OPUS-4.8] sq-3jtd.5) the CreatorAgent/OwnerAgent candidate rule has a
+/// variable-predicate PREMISE `?r ?kind ?w` (`?kind` bound to `solidx:creator`/`owner` from
+/// `solidx:provMatcher`), likewise outside the statically-stratifiable whitelist. Both
+/// fallbacks are SOUND (the engine path is always correct); they only forgo the counting
+/// fast path. This asserts the analysis classifies each stratum correctly.
 #[test]
 fn sparq_solid_wac_and_acp_rules_qualification_matrix() {
     let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../sparq-solid/rules");
@@ -299,7 +305,7 @@ fn sparq_solid_wac_and_acp_rules_qualification_matrix() {
     let common = read("common.n3");
     for (stratum, expect) in [
         ("wac.n3", N3Mode::Counting),
-        ("acp-a.n3", N3Mode::Counting),
+        ("acp-a.n3", N3Mode::Fallback), // variable PREMISE predicate (?r ?kind ?w), sq-3jtd.5
         ("acp-b.n3", N3Mode::Counting),
         ("acp-c.n3", N3Mode::Fallback), // variable conclusion predicate (?p ?pred ?r)
     ] {

--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -43,8 +43,17 @@ let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len(
   inheritance, agent classes, groups, the `allOf`/`anyOf`/`noneOf` combinators, the ACP
   matcher's `acp:agent` / `acp:client` / `acp:issuer` attributes (the three-dimensional
   `(agent, client, issuer)` principal — a Matcher can gate on the OIDC issuer that vouched
-  for the requester, not just the WebID), and normative deny-overrides. The full support
-  matrix is in the design doc (linked below).
+  for the requester, not just the WebID), the `acp:CreatorAgent` / `acp:OwnerAgent` matchers
+  (the context agent must be the resource's creator / owner), and normative deny-overrides.
+  The full support matrix is in the design doc (linked below).
+- **Trusted creator/owner provenance** — `acp:CreatorAgent` / `acp:OwnerAgent` matchers
+  resolve against per-resource creator/owner WebIDs the storage layer supplies through the
+  trusted [`AccessProvenance`] channel and `PodStore::materialize_acp_with`. These facts are
+  asserted by the caller (who minted the resource) and are **never** read from the resource
+  graph — a writer who embeds `<r> solidx:creator <self>` in a document they control cannot
+  thereby grant themselves access (design doc §2.4). Each grant is resource-scoped: the
+  creator of `R1` is never granted `R2`. With no provenance supplied, no such matcher grants
+  (fail-closed). [OPUS-4.8] sq-3jtd.5.
 - **Triples-native** — pods, ACL/ACR documents, and the materialized authorization view are
   all ordinary named graphs; "who can read G?" is one SPARQL pattern.
 - **Zero-copy enforcement** — the default query path evaluates through the engine's zero-copy

--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -49,10 +49,13 @@ let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len(
 - **Trusted creator/owner provenance** — `acp:CreatorAgent` / `acp:OwnerAgent` matchers
   resolve against per-resource creator/owner WebIDs the storage layer supplies through the
   trusted [`AccessProvenance`] channel and `PodStore::materialize_acp_with`. These facts are
-  asserted by the caller (who minted the resource) and are **never** read from the resource
-  graph — a writer who embeds `<r> solidx:creator <self>` in a document they control cannot
-  thereby grant themselves access (design doc §2.4). Each grant is resource-scoped: the
-  creator of `R1` is never granted `R2`. With no provenance supplied, no such matcher grants
+  asserted by the caller (who minted the resource); they come from that channel **only** and
+  never from graph content. The loader hard-rejects any control-document triple whose
+  predicate is in the derivation-internal `solidx:` namespace, so a writer can embed
+  `<r> solidx:creator <self>` in neither a content document NOR the `.acr` they control and
+  thereby grant themselves access (design doc §2.4) — this also closes forged
+  `solidx:appliesToResource` policy-redirection. Each grant is resource-scoped: the creator
+  of `R1` is never granted `R2`. With no provenance supplied, no such matcher grants
   (fail-closed). [OPUS-4.8] sq-3jtd.5.
 - **Triples-native** — pods, ACL/ACR documents, and the materialized authorization view are
   all ordinary named graphs; "who can read G?" is one SPARQL pattern.

--- a/crates/sparq-solid/rules/acp-a.n3
+++ b/crates/sparq-solid/rules/acp-a.n3
@@ -42,6 +42,14 @@
 => { ?m solidx:agentValP ?a . } .
 { ?m acp:agent acp:PublicAgent . }        => { ?m solidx:agentValP auth:Public . } .
 { ?m acp:agent acp:AuthenticatedAgent . } => { ?m solidx:agentValP auth:Authenticated . } .
+# [OPUS-4.8] sq-3jtd.5: acp:CreatorAgent / acp:OwnerAgent — the context agent must be the
+# resource's CREATOR / OWNER. That fact (<r> solidx:creator|owner <w>) is loader-synthesized
+# ONLY from the TRUSTED provenance channel (never pod content — design doc §2.4). It is
+# resource-coupled, so it is NOT mapped to a plain agentValP (which would grant the creator
+# on EVERY resource the policy reaches); a CreatorAgent matcher is flagged provMatcher, and
+# the resource-scoped grant in acp-c.n3 joins it back to the specific (resource, creator).
+{ ?m solidx:isMatcher true . ?m acp:agent acp:CreatorAgent . } => { ?m solidx:provMatcher solidx:creator . } .
+{ ?m solidx:isMatcher true . ?m acp:agent acp:OwnerAgent . }   => { ?m solidx:provMatcher solidx:owner . } .
 { ?m solidx:isMatcher true . ?m acp:client ?c . ?c log:notEqualTo acp:PublicClient . }
 => { ?m solidx:clientValP ?c . } .
 { ?m acp:client acp:PublicClient . }      => { ?m solidx:clientValP auth:AnyClient . } .
@@ -60,6 +68,11 @@
 => { ?m solidx:acceptsAgentP auth:Authenticated . } .
 { ?m solidx:acceptsAgentP auth:Authenticated . ?a solidx:isCandAgent true . }
 => { ?m solidx:acceptsAgentP ?a . } .
+# [OPUS-4.8] sq-3jtd.5: a provenance matcher accepts its provenance agent (the creator/owner)
+# in the agent dimension, so the resource-scoped provenance candidate is not allOf-rejected
+# by its own matcher in stratum B. Resource-scoping is enforced separately by the grant's
+# provForResource join — this accept-set fact is agent-only and carries no resource binding.
+{ ?m solidx:provMatcher ?kind . ?m solidx:provAgent ?w . } => { ?m solidx:acceptsAgentP ?w . } .
 
 { ?m solidx:clientValP ?c . } => { ?m solidx:acceptsClientP ?c . } .
 { ?m solidx:isMatcher true . ?UNSCOPED log:notIncludes { ?m acp:client ?x . } . }
@@ -85,6 +98,47 @@
 { ?pol solidx:candAgent ?a . ?a solidx:isWebId true . }       => { ?a solidx:isCandAgent true . } .
 { ?pol solidx:candClient ?c . ?c log:notEqualTo auth:AnyClient . } => { ?c solidx:isCandClient true . } .
 { ?pol solidx:candIssuer ?i . ?i log:notEqualTo auth:AnyIssuer . } => { ?i solidx:isCandIssuer true . } .
+
+# ── [OPUS-4.8] sq-3jtd.5: provenance (CreatorAgent/OwnerAgent) candidate generation ─────
+# A provenance matcher M (kind K) in policy P, applied to resource R whose trusted K-fact
+# is W, yields a RESOURCE-SCOPED candidate: the agent is the creator/owner W, the client /
+# issuer dimensions come from M's OWN constraints (its clientValP/issuerValP, or the dim
+# tops when M is unconstrained there). We tag the candidate with its resource R so the
+# acp-c.n3 grant fires ONLY on R — W (creator of R1) never reaches R2. The candidate IRI
+# embeds the resource alongside the usual (pol, agent, client, issuer), all percent-encoded,
+# so distinct (pol, W, client, issuer, R) tuples stay injective.
+# ?kind is the creator/owner predicate IRI itself (solidx:creator / solidx:owner), so the
+# loader fact `?r ?kind ?w` matches directly with ?kind in predicate position. The (w, r)
+# pair stays COUPLED here so a creator of R1 never picks up R2; ?w becomes a candidate
+# agent (the matcher accepts it — see acceptsAgentP rule above) and feeds isCandAgent.
+{ ?pol solidx:hasMatcher ?m . ?m solidx:provMatcher ?kind .
+  ?pol solidx:appliesToResource ?r . ?r ?kind ?w . ?w solidx:isWebId true . }
+=> { ?m solidx:provAgent ?w . ?w solidx:isCandAgent true . } .
+# the provenance matcher's client/issuer values: M's own, defaulting to the dim tops.
+{ ?m solidx:provMatcher ?kind . ?m solidx:clientValP ?c . } => { ?m solidx:provClient ?c . } .
+{ ?m solidx:provMatcher ?kind . ?UNSCOPED log:notIncludes { ?m acp:client ?x . } . }
+=> { ?m solidx:provClient auth:AnyClient . } .
+{ ?m solidx:provMatcher ?kind . ?m solidx:issuerValP ?i . } => { ?m solidx:provIssuer ?i . } .
+{ ?m solidx:provMatcher ?kind . ?UNSCOPED log:notIncludes { ?m acp:issuer ?x . } . }
+=> { ?m solidx:provIssuer auth:AnyIssuer . } .
+
+# mint the provenance candidate triple, resource-tagged. The creator/owner (?w, ?r) pair is
+# re-derived COUPLED here (?r ?kind ?w), and ?r is in the key + carried as provForResource,
+# so two resources sharing a creator get distinct candidates and distinct resource-scoped
+# grants. Components percent-encoded -> injective minting.
+{ ?pol solidx:hasMatcher ?m . ?m solidx:provMatcher ?kind .
+  ?pol solidx:appliesToResource ?r . ?r ?kind ?pa . ?pa solidx:isWebId true .
+  ?m solidx:provClient ?pc . ?m solidx:provIssuer ?pi .
+  ?pol log:uri ?pols . ?m log:uri ?ms . ?pa log:uri ?pas . ?pc log:uri ?pcs .
+  ?pi log:uri ?pis . ?r log:uri ?rs .
+  ?pols string:encodeForUri ?pole . ?ms string:encodeForUri ?me . ?pas string:encodeForUri ?pae .
+  ?pcs string:encodeForUri ?pce . ?pis string:encodeForUri ?pie . ?rs string:encodeForUri ?re .
+  ("urn:sparq:provcand?pol=" ?pole "&m=" ?me "&agent=" ?pae "&client=" ?pce "&issuer=" ?pie "&res=" ?re)
+      string:concatenation ?ks .
+  ?k log:uri ?ks . }
+=> { ?pol solidx:candTriple ?k . ?pol solidx:provTriple ?k .
+     ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc . ?k solidx:pairIssuer ?pi .
+     ?k solidx:provForResource ?r . } .
 
 # ── candidate (agent, client, issuer) triples, minted deterministically ────────────────
 # (components percent-encoded — string:encodeForUri — so distinct (pol, agent, client,

--- a/crates/sparq-solid/rules/acp-c.n3
+++ b/crates/sparq-solid/rules/acp-c.n3
@@ -57,12 +57,29 @@ acl:Control solidx:allowPred auth:control ; solidx:denyPred auth:denyControl .
 => { ?k solidx:principal ?p . } .
 
 # ── SIMPLE grants (policy has no noneOf) ───────────────────────────────────────────────
+# [OPUS-4.8] sq-3jtd.5: a PROVENANCE candidate (CreatorAgent/OwnerAgent) is excluded here —
+# it grants ONLY on its bound resource (solidx:provForResource), never on every
+# appliesToResource, so the creator of R1 is never granted R2. Its scoped grant is below.
 { ?pol solidx:candTriple ?k . ?k solidx:satisfied true . ?k solidx:principal ?p .
   ?pol solidx:appliesToResource ?r . ?pol acp:allow ?mode . ?mode solidx:allowPred ?pred .
-  ?UNSCOPED log:notIncludes { ?pol acp:noneOf ?nm . } . }
+  ?UNSCOPED log:notIncludes { ?pol acp:noneOf ?nm . } .
+  ?UNSCOPED log:notIncludes { ?pol solidx:provTriple ?k . } . }
 => { ?p ?pred ?r . } .
 { ?pol solidx:candTriple ?k . ?k solidx:satisfied true . ?k solidx:principal ?p .
   ?pol solidx:appliesToResource ?r . ?pol acp:deny ?mode . ?mode solidx:denyPred ?pred .
+  ?UNSCOPED log:notIncludes { ?pol acp:noneOf ?nm . } .
+  ?UNSCOPED log:notIncludes { ?pol solidx:provTriple ?k . } . }
+=> { ?p ?pred ?r . } .
+
+# ── [OPUS-4.8] sq-3jtd.5: RESOURCE-SCOPED provenance grants (policy has no noneOf) ──────
+# The candidate is satisfied (its client/issuer dimensions, and the creator/owner agent,
+# all accepted) and it is bound to resource ?r via provForResource — grant ONLY on ?r.
+{ ?pol solidx:provTriple ?k . ?k solidx:satisfied true . ?k solidx:principal ?p .
+  ?k solidx:provForResource ?r . ?pol acp:allow ?mode . ?mode solidx:allowPred ?pred .
+  ?UNSCOPED log:notIncludes { ?pol acp:noneOf ?nm . } . }
+=> { ?p ?pred ?r . } .
+{ ?pol solidx:provTriple ?k . ?k solidx:satisfied true . ?k solidx:principal ?p .
+  ?k solidx:provForResource ?r . ?pol acp:deny ?mode . ?mode solidx:denyPred ?pred .
   ?UNSCOPED log:notIncludes { ?pol acp:noneOf ?nm . } . }
 => { ?p ?pred ?r . } .
 
@@ -71,9 +88,13 @@ acl:Control solidx:allowPred auth:control ; solidx:denyPred auth:denyControl .
 #  No encoding needed here for injectivity: ?ks is a minted cand IRI whose components
 #  are already percent-encoded (acp-a.n3) — it cannot contain a raw "&mode=" — ?modes
 #  is one of four fixed acl: IRIs, and ?rs is the final component.)
+# [OPUS-4.8] sq-3jtd.5: provenance candidates are excluded here (they range over their
+# bound provForResource, not appliesToResource) and handled by the scoped conditional
+# rules that follow.
 { ?pol solidx:candTriple ?k . ?k solidx:satisfied true .
   ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc . ?k solidx:pairIssuer ?pi .
   ?pol solidx:appliesToResource ?r . ?pol acp:allow ?mode . ?pol acp:noneOf ?nm .
+  ?UNSCOPED log:notIncludes { ?pol solidx:provTriple ?k . } .
   ?k log:uri ?ks . ?mode log:uri ?modes . ?r log:uri ?rs .
   ("urn:sparq:grant?cand=" ?ks "&mode=" ?modes "&effect=allow&graph=" ?rs)
       string:concatenation ?gs .
@@ -84,6 +105,29 @@ acl:Control solidx:allowPred auth:control ; solidx:denyPred auth:denyControl .
 { ?pol solidx:candTriple ?k . ?k solidx:satisfied true .
   ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc . ?k solidx:pairIssuer ?pi .
   ?pol solidx:appliesToResource ?r . ?pol acp:deny ?mode . ?pol acp:noneOf ?nm .
+  ?UNSCOPED log:notIncludes { ?pol solidx:provTriple ?k . } .
+  ?k log:uri ?ks . ?mode log:uri ?modes . ?r log:uri ?rs .
+  ("urn:sparq:grant?cand=" ?ks "&mode=" ?modes "&effect=deny&graph=" ?rs)
+      string:concatenation ?gs .
+  ?g log:uri ?gs . }
+=> { ?g a auth:ConditionalGrant . ?g auth:effect auth:Deny .
+     ?g auth:agent ?pa . ?g auth:client ?pc . ?g auth:issuer ?pi .
+     ?g auth:mode ?mode . ?g auth:graph ?r . ?g auth:exceptMatcher ?nm . } .
+
+# ── [OPUS-4.8] sq-3jtd.5: RESOURCE-SCOPED provenance conditional grants (noneOf present) ──
+{ ?pol solidx:provTriple ?k . ?k solidx:satisfied true .
+  ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc . ?k solidx:pairIssuer ?pi .
+  ?k solidx:provForResource ?r . ?pol acp:allow ?mode . ?pol acp:noneOf ?nm .
+  ?k log:uri ?ks . ?mode log:uri ?modes . ?r log:uri ?rs .
+  ("urn:sparq:grant?cand=" ?ks "&mode=" ?modes "&effect=allow&graph=" ?rs)
+      string:concatenation ?gs .
+  ?g log:uri ?gs . }
+=> { ?g a auth:ConditionalGrant . ?g auth:effect auth:Allow .
+     ?g auth:agent ?pa . ?g auth:client ?pc . ?g auth:issuer ?pi .
+     ?g auth:mode ?mode . ?g auth:graph ?r . ?g auth:exceptMatcher ?nm . } .
+{ ?pol solidx:provTriple ?k . ?k solidx:satisfied true .
+  ?k solidx:pairAgent ?pa . ?k solidx:pairClient ?pc . ?k solidx:pairIssuer ?pi .
+  ?k solidx:provForResource ?r . ?pol acp:deny ?mode . ?pol acp:noneOf ?nm .
   ?k log:uri ?ks . ?mode log:uri ?modes . ?r log:uri ?rs .
   ("urn:sparq:grant?cand=" ?ks "&mode=" ?modes "&effect=deny&graph=" ?rs)
       string:concatenation ?gs .

--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -11,6 +11,9 @@ pub mod conformance;
 pub mod fixture;
 mod loader;
 mod materialize;
+// [OPUS-4.8] sq-3jtd.5: TRUSTED per-resource creator/owner provenance — the channel by
+// which the storage layer (PSS) supplies the `acp:CreatorAgent`/`acp:OwnerAgent` facts.
+mod provenance;
 // [OPUS-4.8] sq-h3uk: ODRL→AUTH_GRAPH bridge — opt-in (`odrl-bridge` feature), OFF by
 // default, so the core sparq-solid build carries zero ODRL/sparq-policy code.
 #[cfg(feature = "odrl-bridge")]
@@ -22,7 +25,8 @@ pub use authindex::{pair_principal, triple_principal, AuthIndex, Mode, Session};
 // [OPUS-4.8] sq-3jtd.9: the ACP conformance harness entry types.
 pub use conformance::{AcpScenario, AcrBuilder, Decision, Expect, ScenarioReport};
 pub use fixture::{acp_fixture, wac_fixture};
-pub use materialize::{materialize_acp, materialize_wac, MaterializeStats};
+pub use materialize::{materialize_acp, materialize_acp_with, materialize_wac, MaterializeStats};
+pub use provenance::AccessProvenance;
 #[cfg(feature = "odrl-bridge")]
 pub use odrl_bridge::{
     action_to_mode, materialize_permission, materialize_permission_conditional, materialize_policy,
@@ -241,7 +245,58 @@ impl PodStore {
     /// As [`PodStore::materialize_wac`] (reserved-encoding collisions in
     /// agent/client IRIs; reasoner failure).
     pub fn materialize_acp(&mut self) -> Result<MaterializeStats, String> {
-        let stats = materialize_acp(&mut self.graph)?;
+        self.materialize_acp_with(&AccessProvenance::new())
+    }
+
+    /// (Re-)materialize the ACP auth view using TRUSTED per-resource creator/owner facts,
+    /// resolving `acp:CreatorAgent` / `acp:OwnerAgent` matchers ([OPUS-4.8] sq-3jtd.5).
+    ///
+    /// Identical to [`PodStore::materialize_acp`], but `provenance` supplies "who
+    /// created/owns `<r>`" for the resources whose ACP policies use a `CreatorAgent` /
+    /// `OwnerAgent` matcher. `provenance` is the **trusted channel** for those facts: they
+    /// are asserted by the caller (the storage layer that minted the resource) and are
+    /// **never** read from the resource graph — a writer who embeds `<r> solidx:creator
+    /// <self>` in a document they control cannot thereby grant themselves access (design
+    /// doc §2.4). `materialize_acp()` is exactly `materialize_acp_with(&AccessProvenance::new())`.
+    ///
+    /// # Errors
+    ///
+    /// As [`PodStore::materialize_acp`], plus an `Err` if a creator/owner WebID collides
+    /// with the reserved principal encoding (starts with `urn:sparq:` or contains the
+    /// literal `&client=`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sparq_solid::{AccessProvenance, Mode, PodStore, Session};
+    ///
+    /// // A policy on /docs/ grants Read to the resource's CREATOR.
+    /// let acp = "http://www.w3.org/ns/solid/acp#";
+    /// let nquads = format!(
+    ///     "<https://pod.ex/docs/d0.ttl#it> <https://ex.dev/ns#k> \"v\" <https://pod.ex/docs/d0.ttl> .\n\
+    ///      <https://pod.ex/docs/.acr> <{acp}memberAccessControl> <https://pod.ex/docs/.acr#c> <https://pod.ex/docs/.acr> .\n\
+    ///      <https://pod.ex/docs/.acr#c> <{acp}apply> <https://pod.ex/docs/.acr#pol> <https://pod.ex/docs/.acr> .\n\
+    ///      <https://pod.ex/docs/.acr#pol> <{acp}allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/docs/.acr> .\n\
+    ///      <https://pod.ex/docs/.acr#pol> <{acp}allOf> <https://pod.ex/docs/.acr#m> <https://pod.ex/docs/.acr> .\n\
+    ///      <https://pod.ex/docs/.acr#m> <{acp}agent> <{acp}CreatorAgent> <https://pod.ex/docs/.acr> .\n");
+    /// let mut store = PodStore::new(sparq_core::Graph::load_dataset(&nquads, "nquads")?);
+    ///
+    /// // The trusted storage layer says alice created d0.
+    /// let mut prov = AccessProvenance::new();
+    /// prov.set_creator("https://pod.ex/docs/d0.ttl", "https://alice.ex/card#me");
+    /// store.materialize_acp_with(&prov)?;
+    ///
+    /// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None };
+    /// let bob = Session { agent: Some("https://bob.ex/card#me"), client: None, issuer: None };
+    /// assert_eq!(store.accessible(&alice, Mode::Read).len(), 1); // d0 (her creation)
+    /// assert_eq!(store.accessible(&bob, Mode::Read).len(), 0);   // not the creator
+    /// # Ok::<(), String>(())
+    /// ```
+    pub fn materialize_acp_with(
+        &mut self,
+        provenance: &AccessProvenance,
+    ) -> Result<MaterializeStats, String> {
+        let stats = materialize_acp_with(&mut self.graph, provenance)?;
         self.reconcile_bridged_after_static();
         self.reindex();
         Ok(stats)

--- a/crates/sparq-solid/src/loader.rs
+++ b/crates/sparq-solid/src/loader.rs
@@ -7,7 +7,7 @@
 //! documents referenced via `acl:agentGroup` (fragment stripped), and the synthesized
 //! structural facts below.
 
-use crate::{AUTH_GRAPH, SOLIDX_NS};
+use crate::{AccessProvenance, AUTH_GRAPH, SOLIDX_NS};
 use oxrdf::Term;
 use rustc_hash::FxHashSet;
 use sparq_core::Graph;
@@ -123,10 +123,20 @@ fn subject_repr(t: &Term, gix: usize) -> String {
     s
 }
 
-/// Assemble the full facts source: structural facts + the access-control graphs.
-/// Errors if any agent/client/origin value collides with the reserved principal
-/// encoding (see [`validate_principal_iri`]).
-pub(crate) fn assemble_input(graph: &Graph, system: System) -> Result<String, String> {
+/// Assemble the full facts source: structural facts + the access-control graphs +
+/// (ACP only) the TRUSTED per-resource creator/owner facts from `provenance`.
+/// Errors if any agent/client/origin/creator/owner value collides with the reserved
+/// principal encoding (see [`validate_principal_iri`]).
+///
+/// [OPUS-4.8] sq-3jtd.5: `provenance` is the trusted channel for `acp:CreatorAgent` /
+/// `acp:OwnerAgent`. Its `<r> solidx:creator|owner <webid>` facts are synthesized HERE,
+/// from the caller-supplied map ONLY — never read from the resource graphs (design doc
+/// §2.4). For WAC (no creator/owner vocabulary) `provenance` is ignored.
+pub(crate) fn assemble_input(
+    graph: &Graph,
+    system: System,
+    provenance: &AccessProvenance,
+) -> Result<String, String> {
     let mut out = String::new();
     let suffix = if system == System::Wac { ACL_SUFFIX } else { ACR_SUFFIX };
     let own_pred = if system == System::Wac { "ownAcl" } else { "ownAcr" };
@@ -212,6 +222,25 @@ pub(crate) fn assemble_input(graph: &Graph, system: System) -> Result<String, St
     }
     for iri in &principal_iris {
         validate_principal_iri(iri)?;
+    }
+    // [OPUS-4.8] sq-3jtd.5: TRUSTED creator/owner facts (ACP only). Emitted ONLY from the
+    // caller-supplied provenance map — never from pod content (design doc §2.4). The
+    // WebIDs go through the SAME reserved-encoding validation as agents/clients/issuers
+    // (they become candidate agents in the rules) and are marked isWebId so the
+    // candidate-generation lattice picks them up.
+    if system == System::Acp {
+        for (resource, creator, owner) in provenance.iter() {
+            if let Some(c) = creator {
+                validate_principal_iri(c)?;
+                webids.insert(c.to_owned());
+                let _ = writeln!(out, "<{resource}> <{SOLIDX_NS}creator> <{c}> .");
+            }
+            if let Some(o) = owner {
+                validate_principal_iri(o)?;
+                webids.insert(o.to_owned());
+                let _ = writeln!(out, "<{resource}> <{SOLIDX_NS}owner> <{o}> .");
+            }
+        }
     }
     for a in &webids {
         let _ = writeln!(out, "<{a}> <{SOLIDX_NS}isWebId> true .");

--- a/crates/sparq-solid/src/loader.rs
+++ b/crates/sparq-solid/src/loader.rs
@@ -6,6 +6,16 @@
 //! triples granting themselves access. The inputs are: `.acl`/`.acr` graphs, group
 //! documents referenced via `acl:agentGroup` (fragment stripped), and the synthesized
 //! structural facts below.
+//!
+//! [OPUS-4.8] sq-3jtd.5: the `.acl`/`.acr`/group graphs ARE emitted verbatim, so they are a
+//! second smuggling surface. The reasoner's derivation-internal vocabulary — the `solidx:`
+//! namespace (`solidx:creator|owner|appliesToResource|isResource|isWebId|…`) — must only be
+//! produced by THIS loader (from trusted structural metadata + the caller-supplied
+//! `AccessProvenance`) or derived by the rules; a forged `solidx:` fact inside a control
+//! document would otherwise grant access (cross-resource privilege escalation / policy
+//! redirection). So [`is_reserved_derivation_predicate`] hard-rejects any control-graph or
+//! group-document triple whose predicate is in `solidx:` space — the analogue of the
+//! `urn:sparq:` reserved-principal guard ([`validate_principal_iri`]).
 
 use crate::{AccessProvenance, AUTH_GRAPH, SOLIDX_NS};
 use oxrdf::Term;
@@ -47,6 +57,25 @@ fn validate_principal_iri(iri: &str) -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+/// [OPUS-4.8] sq-3jtd.5: Predicates in the `solidx:` namespace are the reasoner's
+/// DERIVATION-INTERNAL vocabulary (`solidx:creator`, `solidx:owner`,
+/// `solidx:appliesToResource`, `solidx:isResource`, `solidx:inDoc`, `solidx:isWebId`,
+/// `solidx:provForResource`, …). Those facts are synthesized by THIS loader from
+/// trusted inputs (structural metadata + the caller-supplied [`AccessProvenance`]) or
+/// derived by the N3 rules — they must NEVER originate from access-control-document
+/// content. A writer who can place a triple inside an `.acr`/`.acl` they control could
+/// otherwise smuggle a forged `<r> solidx:creator <self>` (cross-resource privilege
+/// escalation) or `<pol> solidx:appliesToResource <secret>` (policy redirection) that
+/// the rules cannot distinguish from a loader-synthesized trusted fact.
+///
+/// So any control-graph (or group-document) triple whose PREDICATE is in `solidx:`
+/// space is DROPPED before it reaches the reasoner — the direct analogue of the
+/// `urn:sparq:` reserved-principal guard in [`validate_principal_iri`]. The trusted
+/// channel for creator/owner facts is [`AccessProvenance`] and nothing else.
+fn is_reserved_derivation_predicate(t: &[Term; 3]) -> bool {
+    matches!(&t[1], Term::NamedNode(n) if n.as_str().starts_with(SOLIDX_NS))
 }
 
 /// Drop ALL named graphs in the reserved IRI space — including a pre-existing
@@ -185,6 +214,12 @@ pub(crate) fn assemble_input(
     for (gix, iri, sub) in &control_graphs {
         let mut in_doc: FxHashSet<String> = FxHashSet::default();
         for t in graph_triples(sub) {
+            // [OPUS-4.8] sq-3jtd.5: hard-reject any forged derivation-internal fact
+            // (`solidx:creator|owner|appliesToResource|…`) smuggled into the control
+            // document — only the loader/rules may produce `solidx:` facts.
+            if is_reserved_derivation_predicate(&t) {
+                continue;
+            }
             write_term(&mut out, &t[0], *gix);
             out.push(' ');
             write_term(&mut out, &t[1], *gix);
@@ -205,6 +240,11 @@ pub(crate) fn assemble_input(
                 continue;
             }
             for t in graph_triples(sub) {
+                // [OPUS-4.8] sq-3jtd.5: same derivation-internal guard for group
+                // documents — a forged `solidx:` fact here would feed the reasoner too.
+                if is_reserved_derivation_predicate(&t) {
+                    continue;
+                }
                 write_term(&mut out, &t[0], gix);
                 out.push(' ');
                 write_term(&mut out, &t[1], gix);

--- a/crates/sparq-solid/src/materialize.rs
+++ b/crates/sparq-solid/src/materialize.rs
@@ -7,7 +7,7 @@
 //! each seeded with the previous closure.
 
 use crate::loader::{assemble_input, strip_reserved_graphs, System};
-use crate::{AUTH_GRAPH, AUTH_NS};
+use crate::{AccessProvenance, AUTH_GRAPH, AUTH_NS};
 use oxrdf::{NamedNode, Term};
 use rustc_hash::FxHashSet;
 use sparq_core::dict::Dict;
@@ -98,7 +98,8 @@ pub struct MaterializeStats {
 pub fn materialize_wac(graph: &mut Graph) -> Result<MaterializeStats, String> {
     let t0 = Instant::now();
     strip_reserved_graphs(graph);
-    let input = assemble_input(graph, System::Wac)?;
+    // WAC has no creator/owner vocabulary; provenance is ignored (the loader skips it).
+    let input = assemble_input(graph, System::Wac, &AccessProvenance::new())?;
     let src = format!("{input}\n{COMMON_RULES}\n{WAC_RULES}");
     let mut dict = Dict::new();
     let closure = reason_n3(&mut dict, &src)?;
@@ -143,9 +144,35 @@ pub fn materialize_wac(graph: &mut Graph) -> Result<MaterializeStats, String> {
 /// # Ok::<(), String>(())
 /// ```
 pub fn materialize_acp(graph: &mut Graph) -> Result<MaterializeStats, String> {
+    materialize_acp_with(graph, &AccessProvenance::new())
+}
+
+/// Materialize the ACP auth view from the `.acr` graphs PLUS the TRUSTED per-resource
+/// creator/owner facts in `provenance`, resolving `acp:CreatorAgent` / `acp:OwnerAgent`
+/// matchers ([OPUS-4.8] sq-3jtd.5).
+///
+/// The free-function form of [`crate::PodStore::materialize_acp_with`]. Identical to
+/// [`materialize_acp`] (three stratified `reason_n3` calls) except the loader also
+/// synthesizes `<r> solidx:creator|owner <webid>` facts from `provenance` — the trusted
+/// channel for "who created/owns `<r>`". These facts are **never** read from the resource
+/// graphs (design doc §2.4): a writer cannot self-grant via a forged `solidx:creator`
+/// triple in a document they control.
+///
+/// `materialize_acp(graph)` is exactly `materialize_acp_with(graph, &AccessProvenance::new())`
+/// — with no provenance, no `CreatorAgent`/`OwnerAgent` matcher ever grants (fail-closed).
+///
+/// # Errors
+///
+/// As [`materialize_acp`], and additionally if a creator/owner WebID collides with the
+/// reserved principal encoding (starts with `urn:sparq:` or contains the literal
+/// `&client=`).
+pub fn materialize_acp_with(
+    graph: &mut Graph,
+    provenance: &AccessProvenance,
+) -> Result<MaterializeStats, String> {
     let t0 = Instant::now();
     strip_reserved_graphs(graph);
-    let input = assemble_input(graph, System::Acp)?;
+    let input = assemble_input(graph, System::Acp, provenance)?;
     let mut strata_facts = Vec::new();
 
     let mut dict = Dict::new();

--- a/crates/sparq-solid/src/provenance.rs
+++ b/crates/sparq-solid/src/provenance.rs
@@ -1,0 +1,93 @@
+//! [OPUS-4.8] sq-3jtd.5 — TRUSTED per-resource creator/owner provenance.
+//!
+//! `acp:CreatorAgent` / `acp:OwnerAgent` matchers grant the *creator* / *owner* of the
+//! resource being accessed. "Who created `<r>`" is structural storage metadata the
+//! storage layer (PSS) knows when it mints the resource — it is **not** in the pod or the
+//! ACR. This type is the TRUSTED CHANNEL by which that caller supplies the facts.
+//!
+//! # Security boundary (design doc §2.4)
+//!
+//! The creator/owner fact MUST arrive here, from the trusted caller — it is **never**
+//! read from the resource graph. A writer who can put `<r> solidx:creator <self>` in a
+//! document they control must not thereby grant themselves access; the loader only ever
+//! synthesizes `solidx:creator`/`solidx:owner` facts from THIS map, never from pod
+//! content. Supplying a value through this API is an assertion of trust by the caller.
+
+use rustc_hash::FxHashMap;
+
+/// The trusted creator and owner WebID of one resource. `None` = unknown to the caller
+/// (so no `CreatorAgent`/`OwnerAgent` grant can ever fire on that resource — fail-closed).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ResourceProvenance {
+    creator: Option<String>,
+    owner: Option<String>,
+}
+
+/// Caller-supplied (TRUSTED) per-resource creator/owner WebIDs, the input to
+/// `acp:CreatorAgent` / `acp:OwnerAgent` matcher resolution. Built by the storage layer
+/// and passed to [`crate::PodStore::materialize_acp_with`] /
+/// [`crate::materialize_acp_with`]; an empty map (the default) means no creator/owner is
+/// known, so no `CreatorAgent`/`OwnerAgent` matcher ever grants — fully fail-closed.
+///
+/// These facts are asserted by the caller and are **never** read from the resource graph —
+/// see the type-level docs above for the full trust boundary.
+///
+/// # Examples
+///
+/// ```
+/// use sparq_solid::AccessProvenance;
+///
+/// let mut prov = AccessProvenance::default();
+/// prov.set_creator("https://pod.ex/notes/n1.ttl", "https://alice.ex/card#me");
+/// prov.set_owner("https://pod.ex/notes/n1.ttl", "https://alice.ex/card#me");
+/// assert_eq!(prov.creator("https://pod.ex/notes/n1.ttl"), Some("https://alice.ex/card#me"));
+/// assert_eq!(prov.creator("https://pod.ex/notes/n2.ttl"), None); // unknown -> fail-closed
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct AccessProvenance {
+    by_resource: FxHashMap<String, ResourceProvenance>,
+}
+
+impl AccessProvenance {
+    /// An empty provenance map (no creator/owner known for any resource).
+    pub fn new() -> AccessProvenance {
+        AccessProvenance::default()
+    }
+
+    /// Assert (TRUSTED) that `creator` is the creator WebID of `resource`. Replaces any
+    /// previous creator for that resource. The value is taken on trust from the caller —
+    /// see the [`AccessProvenance`] type docs for the security boundary.
+    pub fn set_creator(&mut self, resource: impl Into<String>, creator: impl Into<String>) {
+        self.by_resource.entry(resource.into()).or_default().creator = Some(creator.into());
+    }
+
+    /// Assert (TRUSTED) that `owner` is the owner WebID of `resource`. Replaces any
+    /// previous owner for that resource.
+    pub fn set_owner(&mut self, resource: impl Into<String>, owner: impl Into<String>) {
+        self.by_resource.entry(resource.into()).or_default().owner = Some(owner.into());
+    }
+
+    /// The trusted creator WebID of `resource`, if the caller supplied one.
+    pub fn creator(&self, resource: &str) -> Option<&str> {
+        self.by_resource.get(resource).and_then(|p| p.creator.as_deref())
+    }
+
+    /// The trusted owner WebID of `resource`, if the caller supplied one.
+    pub fn owner(&self, resource: &str) -> Option<&str> {
+        self.by_resource.get(resource).and_then(|p| p.owner.as_deref())
+    }
+
+    /// Whether any creator or owner fact was supplied (an empty map materializes no
+    /// `CreatorAgent`/`OwnerAgent` grants).
+    pub fn is_empty(&self) -> bool {
+        self.by_resource.is_empty()
+    }
+
+    /// Iterate `(resource, creator?, owner?)` for every resource with a fact. Internal —
+    /// used by the loader to synthesize `solidx:creator`/`solidx:owner` reasoning facts.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&str, Option<&str>, Option<&str>)> {
+        self.by_resource
+            .iter()
+            .map(|(r, p)| (r.as_str(), p.creator.as_deref(), p.owner.as_deref()))
+    }
+}

--- a/crates/sparq-solid/tests/acp.rs
+++ b/crates/sparq-solid/tests/acp.rs
@@ -3,7 +3,7 @@
 
 use sparq_core::Graph;
 use sparq_solid::fixture::{acp_fixture, ALICE, APP, BOB, CAROL, DAVE};
-use sparq_solid::{Mode, PodStore, Session};
+use sparq_solid::{AccessProvenance, Mode, PodStore, Session};
 
 fn store() -> PodStore {
     let g = Graph::load_dataset(&acp_fixture(), "nquads").expect("fixture loads");
@@ -282,4 +282,283 @@ fn acp_issuer_reserved_encoding_rejected() {
     let g = Graph::load_dataset(&acr, "nquads").expect("loads");
     let mut s = PodStore::new(g);
     assert!(s.materialize_acp().is_err(), "reserved-space issuer IRI rejected at materialization");
+}
+
+// ── [OPUS-4.8] sq-3jtd.5: acp:CreatorAgent / acp:OwnerAgent support ───────────────────
+//
+// An ACP Matcher can constrain on `acp:agent acp:CreatorAgent` / `acp:OwnerAgent`: it
+// accepts the context agent iff that agent is the *creator* (resp. *owner*) of the
+// resource being accessed. That per-resource fact ("who created <r>") is NOT in the pod
+// or the ACR — it is structural storage metadata the TRUSTED caller (PSS, which created
+// the resource) supplies through [`AccessProvenance`]. Crucially it is NEVER read from
+// the resource graph: a writer who could embed `<r> solidx:creator <self>` in their own
+// document must not thereby grant themselves access (design doc §2.4). These tests build
+// small inline ACP pods so the matrix is hand-verifiable, and exercise BOTH outcomes —
+// allow when the session agent is the trusted creator/owner, deny otherwise — plus the
+// resource-scoping and trust-boundary invariants.
+
+const CRE_DOC: &str = "https://pod.ex/cre/d0.ttl";
+const CRE_ACR: &str = "https://pod.ex/cre/.acr";
+const CRE_DOC2: &str = "https://pod.ex/cre/d1.ttl";
+
+/// One inline ACP pod: documents under `cre/` whose containing `cre/` ACR carries
+/// `policy_body` under `acp:memberAccessControl`, materialized with the trusted
+/// `provenance` (per-resource creator/owner WebIDs).
+fn cre_store(policy_body: &str, provenance: &AccessProvenance) -> PodStore {
+    let acr = format!(
+        "<{CRE_DOC}#it> <https://ex.dev/ns#title> \"d0\" <{CRE_DOC}> .\n\
+         <{CRE_DOC2}#it> <https://ex.dev/ns#title> \"d1\" <{CRE_DOC2}> .\n\
+         <{CRE_ACR}> <http://www.w3.org/ns/solid/acp#memberAccessControl> <{CRE_ACR}#ctl> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#ctl> <http://www.w3.org/ns/solid/acp#apply> <{CRE_ACR}#pol> <{CRE_ACR}> .\n\
+         {policy_body}"
+    );
+    let g = Graph::load_dataset(&acr, "nquads").expect("inline acp pod loads");
+    let mut s = PodStore::new(g);
+    s.materialize_acp_with(provenance).expect("acp materializes with provenance");
+    s
+}
+
+/// allOf { acp:agent acp:CreatorAgent }: the resource's trusted creator is granted Read;
+/// everyone else (including another WebID, or the SAME WebID when no creator fact is
+/// supplied for that resource) is denied. Allow AND deny are decided by the creator fact.
+#[test]
+fn acp_creator_agent_allow_and_deny() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let body = format!(
+        "<{CRE_ACR}#pol> <{acp}allow> <{acl}Read> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#pol> <{acp}allOf> <{CRE_ACR}#m> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#m> <{acp}agent> <{acp}CreatorAgent> <{CRE_ACR}> .\n"
+    );
+    let mut prov = AccessProvenance::default();
+    prov.set_creator(CRE_DOC, BOB); // PSS: bob created d0
+    let mut s = cre_store(&body, &prov);
+    let r = Mode::Read;
+
+    // ALLOW: bob is the trusted creator of d0.
+    assert!(can(&mut s, Some(BOB), None, r, CRE_DOC), "bob (creator) reads d0");
+    // DENY decided by the creator fact: carol is not the creator of d0.
+    assert!(!can(&mut s, Some(CAROL), None, r, CRE_DOC), "carol (non-creator) denied d0");
+    // DENY: anonymous has no WebID, so cannot be a creator.
+    assert!(!can(&mut s, None, None, r, CRE_DOC), "anonymous denied d0");
+    // DENY fail-closed: NO creator fact for d1, so even bob is denied there.
+    assert!(!can(&mut s, Some(BOB), None, r, CRE_DOC2), "no creator fact for d1 -> bob denied d1");
+}
+
+/// Resource-scoping: a CreatorAgent grant is per-resource. bob is the creator of d0 and
+/// carol of d1; the SINGLE shared CreatorAgent matcher grants each ONLY their own
+/// resource, never the other's.
+#[test]
+fn acp_creator_agent_is_resource_scoped() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let body = format!(
+        "<{CRE_ACR}#pol> <{acp}allow> <{acl}Read> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#pol> <{acp}allOf> <{CRE_ACR}#m> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#m> <{acp}agent> <{acp}CreatorAgent> <{CRE_ACR}> .\n"
+    );
+    let mut prov = AccessProvenance::default();
+    prov.set_creator(CRE_DOC, BOB);
+    prov.set_creator(CRE_DOC2, CAROL);
+    let mut s = cre_store(&body, &prov);
+    let r = Mode::Read;
+
+    assert!(can(&mut s, Some(BOB), None, r, CRE_DOC), "bob reads d0 (his)");
+    assert!(can(&mut s, Some(CAROL), None, r, CRE_DOC2), "carol reads d1 (hers)");
+    // the load-bearing soundness check: creator of d0 is NOT granted d1, and vice-versa.
+    assert!(!can(&mut s, Some(BOB), None, r, CRE_DOC2), "bob NOT granted d1 (carol's)");
+    assert!(!can(&mut s, Some(CAROL), None, r, CRE_DOC), "carol NOT granted d0 (bob's)");
+}
+
+/// acp:OwnerAgent is the twin of acp:CreatorAgent over the trusted owner fact.
+#[test]
+fn acp_owner_agent_allow_and_deny() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let body = format!(
+        "<{CRE_ACR}#pol> <{acp}allow> <{acl}Write> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#pol> <{acp}allOf> <{CRE_ACR}#m> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#m> <{acp}agent> <{acp}OwnerAgent> <{CRE_ACR}> .\n"
+    );
+    let mut prov = AccessProvenance::default();
+    prov.set_owner(CRE_DOC, ALICE); // PSS: alice owns d0
+    let mut s = cre_store(&body, &prov);
+    let w = Mode::Write;
+
+    assert!(can(&mut s, Some(ALICE), None, w, CRE_DOC), "alice (owner) writes d0");
+    assert!(!can(&mut s, Some(BOB), None, w, CRE_DOC), "bob (non-owner) denied write on d0");
+    // a creator fact does NOT satisfy an OwnerAgent matcher (distinct dimensions).
+    let mut prov2 = AccessProvenance::default();
+    prov2.set_creator(CRE_DOC, BOB);
+    let mut s2 = cre_store(&body, &prov2);
+    assert!(!can(&mut s2, Some(BOB), None, w, CRE_DOC), "creator is not owner -> denied");
+}
+
+/// Deny-overrides with a CreatorAgent matcher: a public-Read policy plus a
+/// `acp:deny Read` policy whose matcher is `acp:agent acp:CreatorAgent` carves the creator
+/// out — everyone reads EXCEPT the resource's creator, and the deny is resource-scoped
+/// (it only carves the creator out of THEIR resource).
+#[test]
+fn acp_creator_agent_deny_overrides() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    // pol-pub: public Read.  pol-deny: deny Read to the resource's creator.
+    let body = format!(
+        "<{CRE_ACR}#pol> <{acp}allow> <{acl}Read> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#pol> <{acp}anyOf> <{CRE_ACR}#mpub> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#mpub> <{acp}agent> <{acp}PublicAgent> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#ctl> <{acp}apply> <{CRE_ACR}#poldeny> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#poldeny> <{acp}deny> <{acl}Read> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#poldeny> <{acp}allOf> <{CRE_ACR}#mcre> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#mcre> <{acp}agent> <{acp}CreatorAgent> <{CRE_ACR}> .\n"
+    );
+    let mut prov = AccessProvenance::default();
+    prov.set_creator(CRE_DOC, BOB); // bob created d0
+    prov.set_creator(CRE_DOC2, CAROL); // carol created d1
+    let mut s = cre_store(&body, &prov);
+    let r = Mode::Read;
+
+    // public reads both docs…
+    assert!(can(&mut s, Some(CAROL), None, r, CRE_DOC), "carol reads d0 (public, not its creator)");
+    assert!(can(&mut s, Some(BOB), None, r, CRE_DOC2), "bob reads d1 (public, not its creator)");
+    assert!(can(&mut s, None, None, r, CRE_DOC), "anonymous reads d0");
+    // …EXCEPT each doc's own creator is denied on THAT doc (deny-overrides, resource-scoped).
+    assert!(!can(&mut s, Some(BOB), None, r, CRE_DOC), "bob (creator of d0) denied on d0");
+    assert!(!can(&mut s, Some(CAROL), None, r, CRE_DOC2), "carol (creator of d1) denied on d1");
+}
+
+/// TRUST BOUNDARY (design doc §2.4): a `solidx:creator` triple embedded in the RESOURCE
+/// graph (pod content the writer controls) must NEVER grant access — only the trusted
+/// [`AccessProvenance`] channel does. mallory writes `<d0> solidx:creator <mallory>` into
+/// her own document; with NO provenance supplied she is still denied.
+#[test]
+fn acp_creator_fact_from_resource_graph_is_ignored() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let solidx = "https://sparq.dev/ns/solidx#";
+    let mallory = "https://mallory.ex/card#me";
+    let body = format!(
+        "<{CRE_ACR}#pol> <{acp}allow> <{acl}Read> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#pol> <{acp}allOf> <{CRE_ACR}#m> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#m> <{acp}agent> <{acp}CreatorAgent> <{CRE_ACR}> .\n"
+    );
+    // mallory embeds a forged creator fact in her OWN resource document.
+    let acr = format!(
+        "<{CRE_DOC}#it> <https://ex.dev/ns#title> \"d0\" <{CRE_DOC}> .\n\
+         <{CRE_DOC}> <{solidx}creator> <{mallory}> <{CRE_DOC}> .\n\
+         <{CRE_ACR}> <{acp}memberAccessControl> <{CRE_ACR}#ctl> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#ctl> <{acp}apply> <{CRE_ACR}#pol> <{CRE_ACR}> .\n\
+         {body}"
+    );
+    let g = Graph::load_dataset(&acr, "nquads").expect("loads");
+    let mut s = PodStore::new(g);
+    // NO provenance supplied — the resource-graph forgery must not grant.
+    s.materialize_acp().expect("materializes");
+    assert!(
+        !can(&mut s, Some(mallory), None, Mode::Read, CRE_DOC),
+        "forged solidx:creator in pod content must NOT grant access"
+    );
+}
+
+/// A creator fact is INERT without a CreatorAgent/OwnerAgent matcher: supplying provenance
+/// for a resource whose policy uses a plain concrete-WebID matcher grants nothing extra —
+/// the creator is granted access ONLY if they also match the explicit policy.
+#[test]
+fn acp_creator_fact_without_creator_matcher_is_inert() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    // policy grants Read to CAROL by concrete WebID — no CreatorAgent matcher at all.
+    let body = format!(
+        "<{CRE_ACR}#pol> <{acp}allow> <{acl}Read> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#pol> <{acp}allOf> <{CRE_ACR}#m> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#m> <{acp}agent> <{CAROL}> <{CRE_ACR}> .\n"
+    );
+    let mut prov = AccessProvenance::default();
+    prov.set_creator(CRE_DOC, BOB); // bob is the creator, but the policy never asks
+    let mut s = cre_store(&body, &prov);
+    let r = Mode::Read;
+    assert!(can(&mut s, Some(CAROL), None, r, CRE_DOC), "carol granted by explicit WebID");
+    assert!(!can(&mut s, Some(BOB), None, r, CRE_DOC), "bob (creator) NOT granted — no CreatorAgent matcher");
+}
+
+/// anyOf { acp:agent acp:CreatorAgent }: the creator alone satisfies the policy. Same
+/// outcome as the allOf-sole-matcher case, exercising the anyOf path.
+#[test]
+fn acp_creator_agent_anyof() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let body = format!(
+        "<{CRE_ACR}#pol> <{acp}allow> <{acl}Read> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#pol> <{acp}anyOf> <{CRE_ACR}#m> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#m> <{acp}agent> <{acp}CreatorAgent> <{CRE_ACR}> .\n"
+    );
+    let mut prov = AccessProvenance::default();
+    prov.set_creator(CRE_DOC, BOB);
+    let mut s = cre_store(&body, &prov);
+    assert!(can(&mut s, Some(BOB), None, Mode::Read, CRE_DOC), "bob (creator) reads d0 via anyOf");
+    assert!(!can(&mut s, Some(CAROL), None, Mode::Read, CRE_DOC), "carol denied");
+}
+
+/// allOf { acp:agent acp:CreatorAgent ; acp:client APP }: the creator-AND-client pair on
+/// ONE matcher — the resource's creator is granted ONLY through the named app, composing
+/// the provenance agent dimension with the client dimension.
+#[test]
+fn acp_creator_agent_with_client_constraint() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let body = format!(
+        "<{CRE_ACR}#pol> <{acp}allow> <{acl}Read> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#pol> <{acp}allOf> <{CRE_ACR}#m> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#m> <{acp}agent> <{acp}CreatorAgent> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#m> <{acp}client> <{APP}> <{CRE_ACR}> .\n"
+    );
+    let mut prov = AccessProvenance::default();
+    prov.set_creator(CRE_DOC, BOB);
+    let mut s = cre_store(&body, &prov);
+    let r = Mode::Read;
+
+    // ALLOW: bob (creator) through the named app.
+    assert!(
+        s.accessible(&Session { agent: Some(BOB), client: Some(APP), issuer: None }, r)
+            .iter()
+            .any(|g| g.as_str() == CRE_DOC),
+        "bob (creator) + app reads d0"
+    );
+    // DENY: creator without the named client (the client dimension is constrained).
+    assert!(!can(&mut s, Some(BOB), None, r, CRE_DOC), "bob (creator) w/o app denied");
+    // DENY: named client but not the creator.
+    assert!(
+        !s.accessible(&Session { agent: Some(CAROL), client: Some(APP), issuer: None }, r)
+            .iter()
+            .any(|g| g.as_str() == CRE_DOC),
+        "carol (non-creator) + app denied"
+    );
+}
+
+/// Fail-closed: a malicious creator/owner WebID inside the reserved `urn:sparq:` space is
+/// rejected at materialization, exactly like a malicious agent/client/issuer value — it
+/// cannot smuggle a forged principal into the auth view.
+#[test]
+fn acp_creator_reserved_encoding_rejected() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let body = format!(
+        "<{CRE_ACR}#pol> <{acp}allow> <{acl}Read> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#pol> <{acp}allOf> <{CRE_ACR}#m> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#m> <{acp}agent> <{acp}CreatorAgent> <{CRE_ACR}> .\n"
+    );
+    let acr = format!(
+        "<{CRE_DOC}#it> <https://ex.dev/ns#title> \"d0\" <{CRE_DOC}> .\n\
+         <{CRE_ACR}> <{acp}accessControl> <{CRE_ACR}#ctl> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#ctl> <{acp}apply> <{CRE_ACR}#pol> <{CRE_ACR}> .\n\
+         {body}"
+    );
+    let g = Graph::load_dataset(&acr, "nquads").expect("loads");
+    let mut s = PodStore::new(g);
+    let mut prov = AccessProvenance::default();
+    prov.set_creator(CRE_DOC, "urn:sparq:pair?agent=x&client=y");
+    assert!(
+        s.materialize_acp_with(&prov).is_err(),
+        "reserved-space creator WebID rejected at materialization"
+    );
 }

--- a/crates/sparq-solid/tests/acp.rs
+++ b/crates/sparq-solid/tests/acp.rs
@@ -431,6 +431,12 @@ fn acp_creator_agent_deny_overrides() {
 /// graph (pod content the writer controls) must NEVER grant access — only the trusted
 /// [`AccessProvenance`] channel does. mallory writes `<d0> solidx:creator <mallory>` into
 /// her own document; with NO provenance supplied she is still denied.
+///
+/// NOTE: this only covers the *resource-graph* vector (content graphs are never fed to the
+/// reasoner). The strictly harder vector — a forged `solidx:` fact placed inside the `.acr`
+/// CONTROL document, which IS fed verbatim — is covered by the `acp_forged_*_in_acr_document`
+/// tests below ([OPUS-4.8] sq-3jtd.5), which need the `is_reserved_derivation_predicate`
+/// filter; this test alone passes even without it.
 #[test]
 fn acp_creator_fact_from_resource_graph_is_ignored() {
     let acl = "http://www.w3.org/ns/auth/acl#";
@@ -560,5 +566,153 @@ fn acp_creator_reserved_encoding_rejected() {
     assert!(
         s.materialize_acp_with(&prov).is_err(),
         "reserved-space creator WebID rejected at materialization"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-3jtd.5 — ADVERSARIAL: forged derivation-internal `solidx:` facts
+// smuggled INSIDE the `.acr` access-control document (not the resource graph) must
+// NEVER reach the reasoner. These exploit the real attack surface that
+// `acp_creator_fact_from_resource_graph_is_ignored` does NOT cover: that test placed
+// the forged triple in a *resource* graph (`<CRE_DOC>`), whose triples the loader never
+// feeds to the reasoner anyway. The `.acr` graph's triples ARE emitted verbatim — so
+// without the `is_reserved_derivation_predicate` filter each of these GRANTS access
+// (cross-resource privilege escalation). Each test FAILS pre-filter, PASSES post-filter.
+// ---------------------------------------------------------------------------
+
+/// Builds an inline ACP pod where the `.acr` for `cre/` carries (a) a CreatorAgent (resp.
+/// OwnerAgent) matcher under `prov_pol` granting `prov_mode`, and (b) a SEPARATE matcher
+/// listing `mallory` as a concrete `acp:agent` on a DIFFERENT mode (`alt_mode`) — that
+/// concrete reference is what legitimately makes `mallory solidx:isWebId true`, exactly
+/// as it would for any agent named anywhere in the ACR. Then `forged_fact` smuggles
+/// `<d0> solidx:creator|owner <mallory>` directly into the `.acr`. NO trusted provenance.
+/// Without the `solidx:`-predicate filter, the forged fact + the legitimate `isWebId`
+/// together mint a provenance candidate and escalate mallory from `alt_mode` to
+/// `prov_mode` on d0. With the filter, the forged fact never reaches the reasoner.
+fn forged_prov_store(prov_pol_body: &str, alt_pol_body: &str, forged_fact: &str) -> PodStore {
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let acr = format!(
+        "<{CRE_DOC}#it> <https://ex.dev/ns#title> \"d0\" <{CRE_DOC}> .\n\
+         <{CRE_ACR}> <{acp}memberAccessControl> <{CRE_ACR}#ctl> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#ctl> <{acp}apply> <{CRE_ACR}#pol> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#ctl> <{acp}apply> <{CRE_ACR}#altpol> <{CRE_ACR}> .\n\
+         {forged_fact}\
+         {prov_pol_body}\
+         {alt_pol_body}"
+    );
+    let g = Graph::load_dataset(&acr, "nquads").expect("forged inline acp pod loads");
+    let mut s = PodStore::new(g);
+    // NO provenance — the ONLY creator/owner facts are the forged ones inside the .acr.
+    s.materialize_acp().expect("acp materializes (forged facts must be filtered, not error)");
+    s
+}
+
+/// EXPLOIT 1: forged `<R> solidx:creator <mallory>` inside the `.acr`, against a Read
+/// `CreatorAgent` matcher. Mallory is legitimately known (`isWebId`) because a separate
+/// matcher grants her Write by concrete WebID — but she has NO legitimate Read. The
+/// forged creator fact, if it reached the reasoner, would escalate her to Read on d0.
+#[test]
+fn acp_forged_creator_in_acr_document_does_not_grant() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let solidx = "https://sparq.dev/ns/solidx#";
+    let mallory = "https://mallory.ex/card#me";
+    // #pol: Read to the (forged) CreatorAgent.
+    let prov_pol = format!(
+        "<{CRE_ACR}#pol> <{acp}allow> <{acl}Read> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#pol> <{acp}allOf> <{CRE_ACR}#m> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#m> <{acp}agent> <{acp}CreatorAgent> <{CRE_ACR}> .\n"
+    );
+    // #altpol: Write to mallory by concrete WebID — gives her isWebId (and a Write grant),
+    // but NOT Read.
+    let alt_pol = format!(
+        "<{CRE_ACR}#altpol> <{acp}allow> <{acl}Write> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#altpol> <{acp}allOf> <{CRE_ACR}#altm> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#altm> <{acp}agent> <{mallory}> <{CRE_ACR}> .\n"
+    );
+    let forged = format!("<{CRE_DOC}> <{solidx}creator> <{mallory}> <{CRE_ACR}> .\n");
+    let mut s = forged_prov_store(&prov_pol, &alt_pol, &forged);
+    // Baseline: her LEGITIMATE Write grant is intact (the filter does not over-block).
+    assert!(can(&mut s, Some(mallory), None, Mode::Write, CRE_DOC), "mallory keeps her legit Write");
+    // The exploit: the forged creator fact must NOT escalate her to Read.
+    assert!(
+        !can(&mut s, Some(mallory), None, Mode::Read, CRE_DOC),
+        "forged `solidx:creator` inside the .acr must NOT self-grant Read (privilege escalation)"
+    );
+}
+
+/// EXPLOIT 2: forged `<R> solidx:owner <mallory>` inside the `.acr`, against a Write
+/// `OwnerAgent` matcher — the OwnerAgent twin of EXPLOIT 1. Mallory legitimately has
+/// only Read (concrete WebID on `#altpol`); the forged owner fact must not escalate her
+/// to Write on d0.
+#[test]
+fn acp_forged_owner_in_acr_document_does_not_grant() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let solidx = "https://sparq.dev/ns/solidx#";
+    let mallory = "https://mallory.ex/card#me";
+    let prov_pol = format!(
+        "<{CRE_ACR}#pol> <{acp}allow> <{acl}Write> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#pol> <{acp}allOf> <{CRE_ACR}#m> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#m> <{acp}agent> <{acp}OwnerAgent> <{CRE_ACR}> .\n"
+    );
+    let alt_pol = format!(
+        "<{CRE_ACR}#altpol> <{acp}allow> <{acl}Read> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#altpol> <{acp}allOf> <{CRE_ACR}#altm> <{CRE_ACR}> .\n\
+         <{CRE_ACR}#altm> <{acp}agent> <{mallory}> <{CRE_ACR}> .\n"
+    );
+    let forged = format!("<{CRE_DOC}> <{solidx}owner> <{mallory}> <{CRE_ACR}> .\n");
+    let mut s = forged_prov_store(&prov_pol, &alt_pol, &forged);
+    assert!(can(&mut s, Some(mallory), None, Mode::Read, CRE_DOC), "mallory keeps her legit Read");
+    assert!(
+        !can(&mut s, Some(mallory), None, Mode::Write, CRE_DOC),
+        "forged `solidx:owner` inside the .acr must NOT self-grant Write (privilege escalation)"
+    );
+}
+
+/// EXPLOIT 3 (the broader pre-existing class — also affects origin/main): forged
+/// `<pol> solidx:appliesToResource <secret>` inside the `.acr`. `appliesToResource` is
+/// derived in stratum A from the `acp:accessControl`/`memberAccessControl` chain; if a
+/// writer can smuggle it directly, a policy that legitimately grants them on THEIR OWN
+/// container is redirected to apply to a resource in a DIFFERENT container that they do
+/// not control. Two isolated containers prove this cleanly. `forge/.acr`
+/// `memberAccessControl` → `#pol` grants mallory Read, so she legitimately reads
+/// `forge/d0.ttl` (a member of `forge/`). `secret/s.ttl` lives in a SEPARATE container
+/// with no policy of its own (private by default) and is NOT a member of `forge/`, so
+/// `#pol` does not legitimately reach it. The forged
+/// `<#pol> solidx:appliesToResource <secret/s.ttl>` inside `forge/.acr` is the ONLY path
+/// that could extend the grant onto the secret resource — it must be filtered.
+#[test]
+fn acp_forged_applies_to_resource_in_acr_document_does_not_grant() {
+    let acl = "http://www.w3.org/ns/auth/acl#";
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let solidx = "https://sparq.dev/ns/solidx#";
+    let mallory = "https://mallory.ex/card#me";
+    let forge_acr = "https://pod.ex/forge/.acr";
+    let forge_doc = "https://pod.ex/forge/d0.ttl";
+    let secret_doc = "https://pod.ex/secret/s.ttl";
+
+    // forge/.acr: memberAccessControl → #pol allow Read to mallory (concrete agent).
+    // Plus the forged appliesToResource redirecting #pol onto the unrelated secret_doc.
+    let acr = format!(
+        "<{forge_doc}#it> <https://ex.dev/ns#title> \"d0\" <{forge_doc}> .\n\
+         <{secret_doc}#it> <https://ex.dev/ns#secret> \"top\" <{secret_doc}> .\n\
+         <{forge_acr}> <{acp}memberAccessControl> <{forge_acr}#ctl> <{forge_acr}> .\n\
+         <{forge_acr}#ctl> <{acp}apply> <{forge_acr}#pol> <{forge_acr}> .\n\
+         <{forge_acr}#pol> <{acp}allow> <{acl}Read> <{forge_acr}> .\n\
+         <{forge_acr}#pol> <{acp}allOf> <{forge_acr}#m> <{forge_acr}> .\n\
+         <{forge_acr}#m> <{acp}agent> <{mallory}> <{forge_acr}> .\n\
+         <{forge_acr}#pol> <{solidx}appliesToResource> <{secret_doc}> <{forge_acr}> .\n"
+    );
+    let g = Graph::load_dataset(&acr, "nquads").expect("loads");
+    let mut s = PodStore::new(g);
+    s.materialize_acp().expect("materializes (forged appliesToResource filtered, not error)");
+
+    // Sanity: the policy is live — mallory legitimately reads forge/d0.ttl.
+    assert!(can(&mut s, Some(mallory), None, Mode::Read, forge_doc), "mallory reads forge/d0.ttl (legit)");
+    // The exploit: the forged appliesToResource must NOT leak the grant onto secret/s.ttl.
+    assert!(
+        !can(&mut s, Some(mallory), None, Mode::Read, secret_doc),
+        "forged `solidx:appliesToResource` inside the .acr must NOT redirect a policy onto a secret resource in another container"
     );
 }

--- a/research/solid-access-control-design.md
+++ b/research/solid-access-control-design.md
@@ -446,8 +446,21 @@ a three-component `urn:sparq:triple?agent=A&client=C&issuer=I` principal (an unc
 issuer keeps the agent / `urn:sparq:pair?…` term byte-identical), the candidate enumeration
 gains an `issuer × {matcher values, auth:AnyIssuer top}` factor (still bounded as the client
 dimension is), and the session expands to ≤12 lookups (the pre-issuer ≤6 doubled).
-Not covered (documented gaps, §7): `acp:vc`, `acp:CreatorAgent`/`OwnerAgent` (need
-per-resource creator facts from the storage layer), `acl:accessToClass`, custom ACP modes
+`acp:CreatorAgent`/`acp:OwnerAgent` ([OPUS-4.8] sq-3jtd.5): the context agent must be the
+resource's creator / owner. "Who created/owns `<r>`" is structural storage metadata the
+trusted caller (PSS) supplies through the `AccessProvenance` channel and
+`materialize_acp_with` — the loader synthesizes `<r> solidx:creator|owner <w>` facts from
+THAT map ONLY, never from the resource graph (§2.4): a writer cannot self-grant via a forged
+`solidx:creator` triple. The grant is RESOURCE-SCOPED — a resource-tagged
+`urn:sparq:provcand?…&res=R` candidate mints per (policy, creator/owner, resource), so the
+creator of `R1` is never granted `R2`; the creator/owner agent composes with the matcher's
+own `acp:client`/`acp:issuer` constraints (minting the same pair/triple principal). With no
+provenance supplied, no `CreatorAgent`/`OwnerAgent` matcher grants (fail-closed). Documented
+bound: a provenance matcher composes with client/issuer constraints on itself and with
+`anyOf`/`noneOf`/the policy's other allOf matchers' client/issuer dimensions, but combining a
+`CreatorAgent`/`OwnerAgent` matcher under `allOf` with a SECOND, independent concrete-agent
+matcher (a contradictory shape) is out of scope.
+Not covered (documented gaps, §7): `acp:vc`, `acl:accessToClass`, custom ACP modes
 (design supports any mode IRI; prototype maps the 4 standard ones).
 
 ## 4. L3 — the `sparq-solid` crate

--- a/research/solid-access-control-design.md
+++ b/research/solid-access-control-design.md
@@ -255,6 +255,27 @@ structural facts. Pod *content* graphs are **excluded** — otherwise any agent 
 a document could embed `acl:` triples and grant themselves access. Writing `.acl`/`.acr`
 graphs is what `acl:Control` (WAC) / ACR write (ACP) gates.
 
+That excludes pod *content*, but the `.acl`/`.acr`/group graphs are themselves emitted to
+the reasoner **verbatim**, so there is a SECOND smuggling surface: the reasoner's own
+**derivation-internal vocabulary** is the `solidx:` namespace (`solidx:creator`,
+`solidx:owner`, `solidx:appliesToResource`, `solidx:isResource`, `solidx:isWebId`,
+`solidx:provForResource`, …). Those facts are meant to be produced ONLY by the loader (from
+trusted structural metadata + the caller-supplied `AccessProvenance`) or derived by the
+rules. A writer who controls an `.acr` could otherwise place a forged
+`<r> solidx:creator <self>` (cross-resource privilege escalation) or
+`<pol> solidx:appliesToResource <secret>` (policy redirection onto a resource they do not
+control) directly into the control document — and the rules cannot distinguish it from a
+loader-synthesized trusted fact. **[OPUS-4.8] sq-3jtd.5:** the loader therefore HARD-REJECTS
+(`is_reserved_derivation_predicate`) any control-graph or group-document triple whose
+predicate is in `solidx:` space before it reaches the reasoner — the direct analogue of the
+`urn:sparq:` reserved-principal guard (`validate_principal_iri`). The trusted channel for
+creator/owner facts is `AccessProvenance` and **nothing else**. *Until that filter was in
+place this boundary was NOT airtight: the original forgery test only covered a forged fact
+in a **resource** graph (never fed to the reasoner anyway); a forged fact placed inside the
+`.acr` itself escalated. The filter, the `acp:CreatorAgent`/`acp:OwnerAgent` resource-scoping
+AND the `solidx:appliesToResource` redirection class are now closed — see tests
+`acp_forged_{creator,owner,applies_to_resource}_in_acr_document_does_not_grant`.*
+
 ## 3. L2 — the rule sets (`crates/sparq-solid/rules/*.n3`)
 
 Vocabulary: `auth:` = `https://sparq.dev/ns/auth#` (public view), `solidx:` =
@@ -450,8 +471,11 @@ dimension is), and the session expands to ≤12 lookups (the pre-issuer ≤6 dou
 resource's creator / owner. "Who created/owns `<r>`" is structural storage metadata the
 trusted caller (PSS) supplies through the `AccessProvenance` channel and
 `materialize_acp_with` — the loader synthesizes `<r> solidx:creator|owner <w>` facts from
-THAT map ONLY, never from the resource graph (§2.4): a writer cannot self-grant via a forged
-`solidx:creator` triple. The grant is RESOURCE-SCOPED — a resource-tagged
+THAT map ONLY. Neither pod content NOR the `.acr` document itself can supply them: the
+loader hard-rejects any control-graph triple whose predicate is in `solidx:` space (§2.4),
+so a writer cannot self-grant via a forged `solidx:creator` triple smuggled into the `.acr`
+(tests `acp_forged_{creator,owner,applies_to_resource}_in_acr_document_does_not_grant`).
+The grant is RESOURCE-SCOPED — a resource-tagged
 `urn:sparq:provcand?…&res=R` candidate mints per (policy, creator/owner, resource), so the
 creator of `R1` is never granted `R2`; the creator/owner agent composes with the matcher's
 own `acp:client`/`acp:issuer` constraints (minting the same pair/triple principal). With no

--- a/research/sparq-solid-scope.md
+++ b/research/sparq-solid-scope.md
@@ -239,7 +239,7 @@ Documented in design doc §3.6 / §7 item 4 and gh-55, all currently **missing**
 | Vocabulary term | Spec | Status | Shape of the work |
 |---|---|---|---|
 | `acl:accessToClass` | WAC (extension) | missing | needs a class-membership join over pod content — crosses the §2.4 reasoner/content boundary; non-trivial |
-| `acp:CreatorAgent` / `acp:OwnerAgent` | ACP | missing | needs *per-resource creator/owner facts* from the storage layer (who created `<r>`) — a loader-synthesized fact PSS would have to supply; recognized in `loader.rs` `SPECIAL_AGENTS` but not granted |
+| `acp:CreatorAgent` / `acp:OwnerAgent` | ACP | **done ([OPUS-4.8] sq-3jtd.5)** | per-resource creator/owner WebIDs the trusted caller supplies via `AccessProvenance` + `materialize_acp_with`; loader synthesizes `<r> solidx:creator\|owner <w>` from THAT map only (never pod content, §2.4); resource-scoped grant (`urn:sparq:provcand?…&res=R`) so a creator of `R1` is never granted `R2` |
 | `acp:issuer` | ACP | missing | "same shape as `acp:client`" (design doc §3.6) — extend the principal from a pair to a triple `(agent, client, issuer)`, combinatorial blow-up noted |
 | `acp:vc` | ACP | missing | Verifiable-Credential-gated matcher — needs VC verification, genuinely large; ties to the sparq ZK/VC estate |
 | custom ACP mode IRIs | ACP | partial | the design supports *any* mode IRI; the prototype maps only the 4 standard ones — the auth-view predicate space is fixed to read/write/append/control |

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -92,9 +92,11 @@ Materialize the authorization view from the access-control documents, then enfor
   `acp:OwnerAgent` matchers against per-resource creator/owner WebIDs supplied by the
   TRUSTED caller. `AccessProvenance::set_creator(resource, webid)` /
   `set_owner(resource, webid)` build the map; the loader synthesizes
-  `<r> solidx:creator|owner <w>` facts from THAT map ONLY — **never** from the resource
-  graph (§2.4), so a writer who embeds `<r> solidx:creator <self>` in a document they
-  control cannot self-grant. Each grant is RESOURCE-SCOPED (the creator of `R1` is never
+  `<r> solidx:creator|owner <w>` facts from THAT map ONLY. The loader hard-rejects any
+  control-document triple whose predicate is in the derivation-internal `solidx:` namespace
+  (§2.4), so a writer who embeds `<r> solidx:creator <self>` in a content document OR in the
+  `.acr` they control cannot self-grant (this also blocks forged `solidx:appliesToResource`
+  policy redirection). Each grant is RESOURCE-SCOPED (the creator of `R1` is never
   granted `R2`) and composes with the matcher's own `acp:client`/`acp:issuer` constraints.
   `materialize_acp()` is `materialize_acp_with(&AccessProvenance::new())` — no provenance ⇒
   no `CreatorAgent`/`OwnerAgent` grant (fail-closed).

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -87,6 +87,17 @@ Materialize the authorization view from the access-control documents, then enfor
   `materialize_*` call **every** session (including the owner) sees nothing.
 - `store.materialize_wac()` / `store.materialize_acp() -> Result<MaterializeStats, _>` —
   run the N3 rules to (re)install `<urn:sparq:auth>`.
+- `store.materialize_acp_with(&AccessProvenance) -> Result<MaterializeStats, _>` —
+  ([OPUS-4.8] sq-3jtd.5) ACP materialization that ALSO resolves `acp:CreatorAgent` /
+  `acp:OwnerAgent` matchers against per-resource creator/owner WebIDs supplied by the
+  TRUSTED caller. `AccessProvenance::set_creator(resource, webid)` /
+  `set_owner(resource, webid)` build the map; the loader synthesizes
+  `<r> solidx:creator|owner <w>` facts from THAT map ONLY — **never** from the resource
+  graph (§2.4), so a writer who embeds `<r> solidx:creator <self>` in a document they
+  control cannot self-grant. Each grant is RESOURCE-SCOPED (the creator of `R1` is never
+  granted `R2`) and composes with the matcher's own `acp:client`/`acp:issuer` constraints.
+  `materialize_acp()` is `materialize_acp_with(&AccessProvenance::new())` — no provenance ⇒
+  no `CreatorAgent`/`OwnerAgent` grant (fail-closed).
 - `store.query_as(&Session, Mode, sparql)` → `QueryResult` (`.rows`);
   `store.query_json_as(...)` → JSON string; `store.ask_as(...)` → `bool`. These evaluate
   through the engine's **zero-copy `DatasetView`** filtered to the session's authorized
@@ -167,7 +178,10 @@ pattern: `GRAPH <urn:sparq:auth> { ?who <https://sparq.dev/ns/auth#read> ?doc }`
 - **ACP** (`.acr`) — policies / matchers with the `allOf` / `anyOf` / `noneOf`
   combinators and normative **deny-overrides**. [OPUS-4.8] sq-3jtd.6: matchers may now
   also constrain on `acp:issuer` (the caller-asserted OIDC issuer), the third principal
-  dimension.
+  dimension. [OPUS-4.8] sq-3jtd.5: matchers may also use `acp:agent acp:CreatorAgent` /
+  `acp:OwnerAgent` — the context agent must be the resource's creator / owner, resolved
+  against the TRUSTED per-resource provenance supplied via `materialize_acp_with` (above),
+  resource-scoped and fail-closed.
 - Principal lattice — three independent dimensions (agent, client, issuer):
   `Public ⊒ Authenticated ⊒ concrete-WebID`, `AnyClient ⊒ concrete-client`, and
   ([OPUS-4.8] sq-3jtd.6) `AnyIssuer ⊒ concrete-issuer`. A session expands to the agent


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. @jeswr runs multiple agents on this account; this PR is from the sparq-solid feature agent working bead **sq-3jtd.5**.

## What

Implements `acp:CreatorAgent` / `acp:OwnerAgent` ACP matchers ([OPUS-4.8] **sq-3jtd.5**). These were recognized in `loader.rs` `SPECIAL_AGENTS` but never granted. A matcher with `acp:agent acp:CreatorAgent` (resp. `acp:OwnerAgent`) now accepts the context agent iff that agent is the **creator** (resp. **owner**) of the resource being accessed.

The only missing piece was a per-resource creator/owner fact (*who created `<r>`*). That is structural storage metadata, supplied by the **TRUSTED** caller (PSS, which minted the resource) through a new channel — never read from the resource graph.

## Public API (new)

- `AccessProvenance` — caller-built map of per-resource creator/owner WebIDs (`set_creator` / `set_owner`).
- `PodStore::materialize_acp_with(&AccessProvenance)` and the free `materialize_acp_with(graph, &prov)`. `materialize_acp()` is exactly `materialize_acp_with(&AccessProvenance::new())`.

## Security boundary (design doc §2.4) — load-bearing

- The loader synthesizes `<r> solidx:creator|owner <w>` facts **only** from the caller-supplied `AccessProvenance` — **never** from pod content. A writer who embeds `<r> solidx:creator <self>` in a document they control **cannot** self-grant. *(test: `acp_creator_fact_from_resource_graph_is_ignored`)*
- Creator/owner WebIDs go through the **same reserved-encoding validation** as agents/clients/issuers; a `urn:sparq:`-space value is **rejected** at materialization. *(test: `acp_creator_reserved_encoding_rejected`)*
- **Resource-scoped** grants: a resource-tagged `urn:sparq:provcand?…&res=R` candidate is minted per `(policy, creator/owner, resource)` and grants **only** on its bound resource (`solidx:provForResource`). The creator of `R1` is never granted `R2` — verified for both allow *(`acp_creator_agent_is_resource_scoped`)* and **deny-overrides** *(`acp_creator_agent_deny_overrides`: each doc's creator is carved out of THAT doc only)*.
- **Fail-closed**: with no provenance supplied, no `CreatorAgent`/`OwnerAgent` matcher grants; a creator fact without a matching matcher is inert *(`acp_creator_fact_without_creator_matcher_is_inert`)*.
- **Stratification preserved**: the generic simple/conditional grant paths exclude provenance candidates via NAF over the input-only `solidx:provTriple` (produced in stratum A, complete before stratum C).

The creator/owner agent **composes** with the matcher's own `acp:client` / `acp:issuer` constraints (same pair/triple principal) and with `anyOf` / `noneOf` / deny-overrides. **Documented bound:** a `CreatorAgent`/`OwnerAgent` matcher under `allOf` alongside a *second, independent* concrete-agent matcher (a contradictory shape) is out of scope — captured as a follow-up bead.

## Tests — TDD (red first, then green)

17 ACP tests: allow + deny, resource-scoping, `OwnerAgent` (incl. creator≠owner), `anyOf`, client-constraint composition, deny-overrides carve-out, resource-graph forgery ignored, inert-without-matcher, reserved-encoding rejected. Plus a new doctest for `materialize_acp_with` / `AccessProvenance`.

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + full `sparq-solid` test suite **GREEN in BOTH feature states** (default and `odrl-bridge`).
- **Privacy-claims gate** (`scripts/check-privacy-claims.sh`) clean; rustdoc clean.
- **G2**: public-API change mirrored to `skills/access-control/SKILL.md` in the same PR. Design doc §3.6 and the scope-doc vocab table moved from "missing" → implemented.
- Opt-in posture unchanged: all changes are inside the opt-in `sparq-solid` crate; core engine untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)