### PR TITLE
ci(sq-c76x): free runner disk + step-retry to stop load-aware shard flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # [OPUS-4.8] sq-c76x: reclaim ~20-30 GB of pre-installed SDKs/toolchains BEFORE the
+      # build + `nextest archive` write. The stock ubuntu-latest runner ships ~14 GB free
+      # on `/`; the archive (.tar.zst of every workspace test binary) plus the warm
+      # `target/` were exhausting it (`No space left on device`). In-repo shell, no
+      # third-party action to SHA-pin. Best-effort + guarded — absent paths no-op. See
+      # scripts/ci-free-disk.sh.
+      - name: Free runner disk before build + archive
+        run: ./scripts/ci-free-disk.sh
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Cache cargo + target
@@ -254,11 +262,25 @@ jobs:
       matrix:
         include:
           # Dedicated shard for the 108.7s diskann recall test (the long pole).
+          # [OPUS-4.8] sq-c76x: rayon_threads=1 makes the recall metric BIT-DETERMINISTIC.
+          # The data/query gen + HNSW level-RNG are already seeded, but the HNSW graph is
+          # built rayon-PARALLEL inside instant-distance (ann.rs build), so thread
+          # scheduling perturbs neighbour selection and HNSW recall varied run-to-run
+          # (MEASURED 0.9980<->1.0000 across runs; ~5pt above the 0.95 floor — safe, but
+          # not reproducible). Pinning ONE rayon thread removes that scheduling variance
+          # (MEASURED: HNSW becomes bit-identical) at ZERO cost here — these are accuracy
+          # gates, not throughput benches, and run alone on their shard. DiskANN is already
+          # bit-identical (MEASURED 0.9660 every run); pinning it too is harmless + uniform.
+          # Floors are UNCHANGED (HNSW >= 0.95, DiskANN >= 0.90) — this removes variance, it
+          # does not move the bar. Only the heavy shards set this; the bulk shards keep
+          # default parallelism (their ~1827 tiny tests want the threads).
           - name: heavy-diskann
             filter: "test(=diskann_recall_at_10_vs_brute_force_on_50k)"
+            rayon_threads: "1"
           # Dedicated shard for the 61.2s hnsw recall test — SPLIT from diskann.
           - name: heavy-hnsw
             filter: "test(=hnsw_recall_at_10_vs_brute_force_on_50k)"
+            rayon_threads: "1"
           # The uniform remainder (~222s), evenly count-partitioned 3 ways.
           - name: bulk 1/3
             partition: "count:1/3"
@@ -268,6 +290,14 @@ jobs:
             partition: "count:3/3"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # [OPUS-4.8] sq-c76x: reclaim ~20-30 GB BEFORE downloading/extracting the nextest
+      # archive and running the shard. This is the PRIMARY site of the `No space left on
+      # device` bulk-shard failures: the bulk shards `--extract-to .` the archived
+      # `target/` INTO the checkout (to rebuild the baked CARGO_BIN_EXE path — see the run
+      # step below) and write per-test diagnostics, on a runner that starts with only
+      # ~14 GB free. Same in-repo, SHA-pin-free, best-effort step as build-archive.
+      - name: Free runner disk before download + test
+        run: ./scripts/ci-free-disk.sh
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install cargo-nextest
@@ -308,23 +338,68 @@ jobs:
       # locally (nextest 0.9.137): clean checkout + extract-to . -> all 4 CLI-spawn tests
       # PASS; without it they reproduce the exact NotFound panic. (Touching ONLY this
       # run-step keeps it on the build-once archive path — sq-vyxy stays closed.)
+      # [OPUS-4.8] sq-c76x: TWO retry layers, each fixing a DIFFERENT failure class —
+      #   1. `--retries 2` (kept, unchanged): nextest's PER-TEST retry. A single flaky
+      #      test process re-runs in-place; the test passes iff any attempt passes. This
+      #      is the residual-variance / transient-binary-race self-heal (sq-x4jy).
+      #   2. The `for attempt` STEP-LEVEL retry below (new): re-invokes the WHOLE
+      #      `cargo nextest run` up to MAX_ATTEMPTS times. This catches failures that a
+      #      per-test retry CANNOT — a transient archive-extraction error, residual disk
+      #      pressure on the first attempt, or a runner hiccup that fails the invocation
+      #      before/around the test run. Without it, ONE such transient sinks the whole
+      #      shard, the ci-summary gate then concludes failure, and an otherwise-mergeable
+      #      PR is blocked (the exact merge-train stall this bead fixes). With it, a single
+      #      transient self-heals on the retry. A GENUINE failure still fails every attempt
+      #      and correctly reds the shard (and the gate) — the floor is never weakened.
+      # The matrix branch (heavy vs bulk) only changes the nextest ARGS; the retry wrapper
+      # is identical for both, so we build the arg list once then loop.
       - name: Test (nextest, shard ${{ matrix.name }})
+        # [OPUS-4.8] sq-c76x: pin rayon to one thread ONLY on the heavy recall shards
+        # (matrix.rayon_threads is "1" there, empty on the bulk shards) so the HNSW
+        # parallel-build recall metric is reproducible — see the matrix comment. An empty
+        # value leaves RAYON_NUM_THREADS unset, so the bulk shards keep default parallelism.
+        env:
+          RAYON_NUM_THREADS: ${{ matrix.rayon_threads }}
         run: |
           set -euo pipefail
+          common=(--archive-file nextest.tar.zst --workspace-remap . \
+                  --extract-to . --extract-overwrite --retries 2)
           if [ -n "${{ matrix.filter }}" ]; then
             # Dedicated heavy shard: intersect HEAVY with this shard's single test so
             # the shard's set is provably a SUBSET of HEAVY (belt-and-braces: if the
             # test is ever renamed in only one place, the shard runs empty rather than
             # silently re-including it in bulk).
-            cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
-              --extract-to . --extract-overwrite \
-              --retries 2 -E '( ${{ env.HEAVY }} ) & ( ${{ matrix.filter }} )'
+            args=("${common[@]}" -E '( ${{ env.HEAVY }} ) & ( ${{ matrix.filter }} )')
           else
             # Bulk shard: everything that is NOT a known-heavy test, count-partitioned.
-            cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
-              --extract-to . --extract-overwrite \
-              --retries 2 --partition ${{ matrix.partition }} -E 'not ( ${{ env.HEAVY }} )'
+            args=("${common[@]}" --partition ${{ matrix.partition }} -E 'not ( ${{ env.HEAVY }} )')
           fi
+          MAX_ATTEMPTS=2
+          attempt=1
+          while true; do
+            echo "::group::nextest shard '${{ matrix.name }}' — attempt $attempt/$MAX_ATTEMPTS"
+            # Capture the exit code EXPLICITLY. `cargo … || rc=$?` is `set -e`-safe (the
+            # `||` makes the failure non-fatal) AND captures nextest's REAL exit code —
+            # unlike `if cargo …; then`, where `$?` after the `if` is the `if` statement's
+            # own status (always 0) and a genuine failure would silently exit 0, wrongly
+            # passing the gate. `rc` is reset to 0 each attempt before the run.
+            rc=0
+            cargo nextest run "${args[@]}" || rc=$?
+            echo "::endgroup::"
+            if [ "$rc" -eq 0 ]; then
+              echo "shard '${{ matrix.name }}' passed on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+              echo "::error::shard '${{ matrix.name }}' failed after $attempt attempt(s) (exit $rc) — genuine failure, not a single transient."
+              exit "$rc"
+            fi
+            echo "::warning::shard '${{ matrix.name }}' attempt $attempt failed (exit $rc) — reclaiming disk and retrying once (sq-c76x transient self-heal)."
+            # Reclaim disk again in case the first attempt was a `No space left` race
+            # that left partial extraction/diagnostics behind; the script is best-effort.
+            ./scripts/ci-free-disk.sh || true
+            attempt=$((attempt + 1))
+          done
 
   wasm:
     name: wasm build (sparq-wasm + sparq-reason-wasm)

--- a/scripts/ci-free-disk.sh
+++ b/scripts/ci-free-disk.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] Reclaim disk on a GitHub-hosted ubuntu runner before the heavy
+# build / nextest-archive / sharded-test steps (bead sq-c76x).
+#
+# WHY: the load-aware test shards were recurringly failing with
+# `No space left on device` while writing the nextest archive (.tar.zst) or the
+# bulk-shard `target/` extraction + per-test diagnostics. A stock ubuntu-latest
+# runner ships only ~14 GB free on `/`, most of it consumed by pre-installed
+# toolchains/SDKs this Rust workspace never uses (.NET, GHC/Haskell, the Android
+# SDK, the bundled CodeQL bundle, and a large Docker image cache). Purging those
+# reclaims ~20-30 GB, which is the PRIMARY fix for the disk-exhaustion shard
+# failures — NOT a weakening of any test or gate.
+#
+# DESIGN NOTES:
+#   • Pure shell + `sudo rm` / `docker image prune` / `apt-get clean` — NO
+#     third-party action, so there is nothing new to SHA-pin or vet (keeps the
+#     repo's SHA-pin / Scorecard posture intact). An equivalent maintained action
+#     (jlumbroso/free-disk-space) exists; we deliberately keep it in-repo so the
+#     reclaim is auditable and pinned-by-definition.
+#   • Each removal is best-effort: a path that is absent on a given runner image
+#     must NOT fail the step (the runner image contents drift). So we DO NOT
+#     `set -e` on the removals — every `rm` is `|| true` and we never abort the
+#     build just because a SDK we wanted gone was already gone.
+#   • We print `df -h /` before and after so the reclaimed amount is visible in
+#     the job log (and so a future regression in runner free-space is diagnosable
+#     from the log alone).
+#   • Safe to run locally / on a non-GitHub host: every target path is guarded by
+#     existence and the whole thing is best-effort, so on a dev box where these
+#     paths do not exist it simply reports "nothing to reclaim" and exits 0.
+#     It NEVER touches the repo checkout or any tracked file.
+set -uo pipefail
+
+echo "::group::Free runner disk — before"
+df -h / || true
+echo "::endgroup::"
+
+# Large pre-installed toolchains/SDKs this Rust workspace never builds against.
+# Order: biggest reclaim first. `sudo` because they live under system prefixes on
+# the hosted image; on a non-root dev box without these paths the rm is a no-op.
+PURGE_PATHS=(
+  /usr/share/dotnet           # .NET SDK + runtimes (~20+ GB on some images)
+  /usr/local/lib/android      # Android SDK/NDK (~8+ GB)
+  /opt/ghc                    # Haskell GHC
+  /usr/local/.ghcup           # Haskell ghcup toolchains
+  /opt/hostedtoolcache/CodeQL # bundled CodeQL pack (we run CodeQL in codeql.yml, not here)
+  /usr/local/share/powershell # PowerShell
+  /usr/share/swift            # Swift toolchain
+)
+
+for p in "${PURGE_PATHS[@]}"; do
+  if [ -e "$p" ]; then
+    echo "removing $p"
+    sudo rm -rf "$p" || true
+  fi
+done
+
+# Reclaim the Docker image cache (the hosted image preloads several GB of images
+# this lane does not use). Best-effort: `docker` may be absent in some contexts.
+if command -v docker >/dev/null 2>&1; then
+  echo "pruning docker images"
+  sudo docker image prune -af || true
+fi
+
+# Drop the apt package cache.
+if command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get clean || true
+fi
+
+echo "::group::Free runner disk — after"
+df -h / || true
+echo "::endgroup::"


### PR DESCRIPTION
> 🤖 SPARQ agent

## Why (bead sq-c76x)
The load-aware test shards in `ci.yml` recurringly fail and stall the merge train via the single required `ci-summary / gate` aggregator. Two observed failure modes:

- **(a) `No space left on device`** on the `bulk N/3` shards. A stock `ubuntu-latest` runner ships only ~14 GB free on `/`; the build job writes the nextest archive (`.tar.zst` of every workspace test binary) and each bulk shard `--extract-to .`'s the archived `target/` into the checkout + writes per-test diagnostics — exhausting the disk.
- **(b) a single transient** (cancellation / residual disk pressure / archive-extraction hiccup) sinks a whole shard, which reds the one-shot gate and blocks otherwise-mergeable PRs.

## What changed (no test floor weakened; gate semantics unchanged)

**1. `scripts/ci-free-disk.sh` — reclaim ~20-30 GB before the heavy steps.**
Purges unused pre-installed SDKs/toolchains (`/usr/share/dotnet`, `/usr/local/lib/android`, `/opt/ghc`, `/usr/local/.ghcup`, `/opt/hostedtoolcache/CodeQL`, PowerShell, Swift) + `docker image prune -af` + `apt-get clean`. In-repo shell — **no third-party action to SHA-pin** (keeps the Scorecard/pin posture intact). Best-effort + existence-guarded so absent paths no-op (safe on any host; never touches the checkout or tracked files). Wired in **before the archive write** (`build-archive`) and **before the archive download/extract + test** (every `test` shard). PRIMARY fix for (a).

**2. Step-level retry in the test shard.** Re-invokes the whole `cargo nextest run` up to 2 attempts (reclaiming disk between), on top of the existing per-test `--retries 2`. A single transient self-heals; a **genuine** failure still fails every attempt and correctly reds the shard. The exit code is captured **explicitly** (`cargo … || rc=$?`), NOT via `if cargo; then` — the latter would swallow nextest's real exit and wrongly pass the gate (a gate-weakening bug I caught + avoided in review).

**3. Deterministic recall shards — `RAYON_NUM_THREADS=1` on the two heavy shards only.**
Empirically measured: the test data/query generation **and** the HNSW level-assignment RNG are already seeded — but HNSW recall **still varied run-to-run** (`0.9980 ↔ 1.0000`, ~5pt above the 0.95 floor). Root cause isolated: `instant-distance` builds the HNSW graph **rayon-parallel**, so thread scheduling perturbs neighbour selection (proven: `RAYON_NUM_THREADS=1` makes it bit-identical). DiskANN was already bit-identical (`0.9660`). Pinning one rayon thread on the heavy shards removes the variance at zero cost (these are accuracy gates that run alone on their shard, not throughput benches). **Floors unchanged** (HNSW `>= 0.95`, DiskANN `>= 0.90`) — this removes variance, it does not move the bar. The bulk shards keep default parallelism (`RAYON_NUM_THREADS` is empty there → rayon's documented invalid-value fallback = default thread count).

### Empirical recall data (measured locally)
| test | recall (default, multi-thread) | recall (`RAYON_NUM_THREADS=1`) | floor | margin |
|---|---|---|---|---|
| `hnsw_recall_at_10_…_50k` | 0.9980 ↔ 1.0000 (varies) | bit-identical | 0.95 | ≥ +0.048 |
| `diskann_recall_at_10_…_50k` | 0.9660 (already identical) | 0.9660 | 0.90 | +0.066 |

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` → ci.yml valid YAML.
- `bash -n` on `ci-free-disk.sh` and on both matrix branches of the test run-step → clean; `shellcheck` clean on the script.
- Retry control-flow validated with a real external-command mock: pass→1 attempt/exit 0; transient-then-pass→2 attempts/exit 0; **genuine failure→exit 4 (propagated, shard reds)**.
- `RAYON_NUM_THREADS=1` HNSW recall verified bit-identical across runs; rayon's empty-value → default-threads fallback confirmed in `rayon-core` source (`usize::from_str("")` → `None` → default).
- `ci-free-disk.sh` executed end-to-end locally (exit 0; absent paths no-op'd — proven not to delete anything outside the runner image).
- **Gate aggregator intact**: `ci-summary.yml` untouched, required check `ci-summary / gate` unchanged, the `test (load-aware shard …)` job name unchanged (same 5 gating check-runs; no leg added/removed), and no new step name contains `advisory`/`informational`.

> Note: this PR's OWN CI may flake (chicken-and-egg — it can't benefit from its own fix until merged). Re-run as needed.