### PR TITLE
ci: free disk before nextest archive to stop nextest.tar.zst No-space flake (sq-9crx)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,36 @@ jobs:
       # rides these archive features; ANYTHING ELSE must be wired into a feature-matrix.yml leg
       # (read that file's GUARD block). Prove a suite is reached: `cargo nextest list -p <crate>
       # --features <set>` must SHOW its test names.
+      # [OPUS-4.8] sq-9crx: FREE DISK before the archive. The whole-workspace
+      # `--all-targets` build + the self-contained `nextest.tar.zst` it writes are the
+      # disk peak of this job, and on a GitHub-hosted ubuntu-latest runner that peak has
+      # intermittently hit `No space left on device` while WRITING the archive (#442,
+      # AFTER a clean compile — so it is a capacity flake, not a build error). The runner
+      # ships ~30 GB+ of preinstalled SDKs/toolchains this job never touches; reclaim them
+      # first so the build's `target/` + the .tar.zst have headroom. Inline (no new
+      # third-party action to SHA-pin — keeps the supply-chain surface flat), only removes
+      # well-known preinstalled bloat (.NET / Android / Haskell / large /usr/local SDKs)
+      # plus a docker prune, and is `|| true`-guarded per path so a layout change on the
+      # image can never red the job. `df -h` brackets it for diagnosability if the flake
+      # ever recurs despite the reclaim.
+      - name: Free disk space (purge unused preinstalled SDKs + docker)
+        run: |
+          echo "::group::Disk before reclaim"
+          df -h /
+          echo "::endgroup::"
+          # Large preinstalled toolchains this Rust workspace never builds against.
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          sudo rm -rf /usr/local/share/boost || true
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
+          # Cached docker images (none are used by this job) — reclaims several GB.
+          sudo docker image prune --all --force || true
+          echo "::group::Disk after reclaim"
+          df -h /
+          echo "::endgroup::"
       - name: Build + archive test binaries (nextest archive)
         run: cargo nextest archive --workspace --all-targets --features approx-ann,filtered-ann,vec-predicate --archive-file nextest.tar.zst
       # [OPUS-4.8] Upload the archive immediately after the build, BEFORE doctests, so


### PR DESCRIPTION
> 🤖 SPARQ agent — automated change. Please review before merge.

## What

Bead **sq-9crx**. The `build-archive` job's `cargo nextest archive --workspace --all-targets`
build plus the self-contained `nextest.tar.zst` it writes is the disk peak of CI. On a
GitHub-hosted `ubuntu-latest` runner that peak has intermittently hit `No space left on
device` **while writing the archive** (#442) — observed *after* a clean compile, so it is a
capacity flake, not a build error.

This inserts a **free-disk step immediately before** the archive build in `build-archive`
(`.github/workflows/ci.yml`). It purges the runner's large preinstalled SDKs/toolchains this
Rust workspace never builds against (.NET, Android, Haskell/`ghcup`, CodeQL, boost, the hosted
toolcache) and runs a `docker image prune`, reclaiming tens of GB so `target/` + the `.tar.zst`
have headroom.

## Why this shape (smallest correct change)

- **Inline shell, no new action.** Per repo supply-chain policy (SHA-pin all actions, keep
  code-scanning at zero) an inline step adds no third-party action surface to pin/vet. It does
  exactly the bead's suggestion — *purge unused SDKs / docker prune* — and nothing else.
- **Cannot red the job.** Every reclaim path is `|| true`-guarded, so an image-layout change on
  the runner can never fail the build-archive job (the reclaim is best-effort headroom, not a
  gate).
- **Diagnosable.** `df -h /` brackets the reclaim (grouped log lines) so if the flake ever
  recurs *despite* the reclaim, the before/after free space is right there in the log.
- Placed **after** the toolchain/nextest installs and **before** the archive build, so it frees
  only space the build will consume — it touches nothing cargo/nextest need.

## Scope / honesty

- One file changed: `.github/workflows/ci.yml` (+30 lines, all in the `build-archive` job). No
  Rust crate touched.
- A disk-capacity flake on a hosted runner is **not locally reproducible** (the EC2 work box is
  non-canonical and has a different disk profile), so this carries no Rust test — there is no
  meaningful unit test for "the runner has more free space." The change is validated by CI lints
  instead.

## Gate

- `python3 -c "yaml.safe_load(...)"` on `ci.yml` — parses clean.
- **actionlint 1.7.7** on `ci.yml` — clean for this step (the only shellcheck `SC2015` *info*
  notes are on pre-existing, unrelated steps, not the new one).
- **shellcheck** on the new `run:` script in isolation — clean; `bash -n` OK.
- **Privacy-claims gate** (predicate-form soundness included): the diff introduces no privacy /
  zero-knowledge / soundness claims — vacuously passes.
- **G2 public-API → SKILL.md**: no public API changed — N/A.
- Rust build + `clippy --all-targets -D warnings` + two-feature-state tests: **N/A** (no Rust
  code in this change).

[OPUS-4.8]

🤖 Generated with [Claude Code](https://claude.com/claude-code)