### PR TITLE
ci(flow-on): proactive merge-gate G6 new-config/flag→docs (sq-ncvq.9)

### DIFF
--- a/.github/workflows/flow-on-gates.yml
+++ b/.github/workflows/flow-on-gates.yml
@@ -1,6 +1,6 @@
-# [OPUS-4.8] Proactive maintenance merge-gates G1/G2/G3 (beads sq-ncvq.4 +
-# sq-ncvq.5 + sq-ncvq.6, epic sq-ncvq). Authored by Opus 4.8 (Fable unavailable;
-# flag for re-review when Fable returns).
+# [OPUS-4.8] Proactive maintenance merge-gates G1/G2/G3/G6 (beads sq-ncvq.4 +
+# sq-ncvq.5 + sq-ncvq.6 + sq-ncvq.9, epic sq-ncvq). Authored by Opus 4.8 (Fable
+# unavailable; flag for re-review when Fable returns).
 #
 # This is the PROACTIVE / merge-time half of the maintenance flow-on system
 # (research/maintenance-flow-on-automation-design.md §2.1). It is the COMPLEMENT of
@@ -17,8 +17,10 @@
 # reported but never blocks. There is NO branch-protection edit and NO
 # ci.yml/ci-summary.yml edit needed — the aggregator discovers gates by sibling
 # name on the head commit.
-#   - G1 + G2 run HARD (no "advisory" token, scripts run without --advisory):
-#     the back-catalogue is already clean (verified against current HEAD).
+#   - G1 + G2 + G6 run HARD (no "advisory" token, scripts run without --advisory):
+#     the back-catalogue is already clean (verified against current HEAD — every
+#     existing sparq-cli/sparq-server flag + SPARQ_* env var is already documented
+#     in a crate README or a SKILL.md).
 #   - G3 (new-bench->registry+dashboard) SOFT-LAUNCHES advisory, per design §2.1
 #     ("G1/G3 are heuristic and intentionally start advisory — a false positive
 #     is a nag, not a block, until tuned"). Its job name carries "(advisory)" AND
@@ -143,3 +145,61 @@ jobs:
           # 'refs/heads/main' ref — the scripts normalize the refs/heads/ prefix).
           GATE_BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}
         run: python3 scripts/check-new-bench-registered.py --base "$GATE_BASE_REF" --advisory
+
+  config-documented:
+    # [OPUS-4.8] sq-ncvq.9 — G6 new-config/flag→docs, runs HARD. Like G2 it reads
+    # the PR labels (for the `config-internal` escape hatch), so it mirrors G2's
+    # label-resolution (incl. the merge_group path where the PR number is resolved
+    # from the head commit's associated PR).
+    name: config-documented (G6)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for the merge-base diff)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Self-test the proactive merge-gates (G1/G2/G3/G6)
+        # Runs the hermetic gate unit tests so a regression in any gate script is
+        # caught at PR time (the suite is stdlib-only; no git/network).
+        run: python3 scripts/tests/test_gates.py
+      - name: Read PR labels (for the config-internal escape hatch)
+        id: labels
+        # [OPUS-4.8] Mirror G2: run on BOTH pull_request AND merge_group so the
+        # escape-hatch label is honoured in the merge queue too. On merge_group the
+        # PR number is not in the event payload, so resolve it from the head
+        # commit's associated PR.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_SHA: ${{ github.event.merge_group.head_sha }}
+        run: |
+          set -euo pipefail
+          : > pr-labels.txt
+          num="${PR_NUMBER:-}"
+          if [ -z "$num" ] && [ -n "${MERGE_SHA:-}" ]; then
+            num="$(gh api "repos/${{ github.repository }}/commits/${MERGE_SHA}/pulls" \
+                     --jq '.[0].number' 2>/dev/null || true)"
+          fi
+          if [ -n "$num" ]; then
+            gh pr view "$num" \
+              --repo "${{ github.repository }}" \
+              --json labels --jq '.labels[].name' > pr-labels.txt || : > pr-labels.txt
+          fi
+          echo "have_labels=1" >> "$GITHUB_OUTPUT"
+      - name: G6 — new CLI flag / SPARQ_* env var must be documented
+        env:
+          # On pull_request github.base_ref is the bare target branch ('main'); on
+          # merge_group it is empty, so fall back to merge_group.base_ref (a full
+          # 'refs/heads/main' ref — the scripts normalize the refs/heads/ prefix).
+          GATE_BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}
+        run: |
+          set -euo pipefail
+          if [ -f pr-labels.txt ]; then
+            python3 scripts/check-config-documented.py --base "$GATE_BASE_REF" --labels-file pr-labels.txt
+          else
+            python3 scripts/check-config-documented.py --base "$GATE_BASE_REF"
+          fi

--- a/scripts/check-config-documented.py
+++ b/scripts/check-config-documented.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Gate G6 — new-config/flag→docs (bead sq-ncvq.9, epic sq-ncvq).
+# Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# PROACTIVE / merge-time half of the maintenance flow-on system
+# (research/maintenance-flow-on-automation-design.md §2.1, gate G6). It is a SUBSET
+# of G2 (scripts/gate-api-skill.py) but covers CONFIG rather than `pub` items: a new
+# `sparq-cli` / `sparq-server` CLI flag or `SPARQ_*` env var must be DOCUMENTED in
+# the same change. G2 only sees `pub`-item signatures, so a flag added inside a
+# hand-rolled arg-parser match arm (a string literal, not a `pub` symbol) slips
+# right past it — that is exactly the gap G6 closes.
+#
+# RULE (G6): when a PR ADDS a new public config knob — a CLI flag literal
+# (`"--flag"`) or a `SPARQ_*` environment variable token — to a sparq-cli /
+# sparq-server `src/**` file, FAIL unless that knob is DOCUMENTED:
+#   * it appears as ADDED text in a docs surface in the SAME diff (the crate's
+#     own README.md, the sibling binding crate's README.md, or ANY
+#     skills/**/SKILL.md), OR
+#   * it is ALREADY documented on disk in one of those surfaces (a knob renamed or
+#     rewired in code whose name was previously written down stays covered), OR
+#   * the PR carries the `config-internal` escape-hatch label (design §2.1).
+#
+# WHY "added token", not "any src change" — mirrors G2's net-diff discipline
+# (gate-api-skill.py): we read the per-file unified diff and keep only knob tokens
+# that are NET-added (added and not also removed). A pure relocation of an existing
+# flag/env handler within a file (the same `"--flag"` line removed once and added
+# once) cancels out and never trips the gate; a comment that merely MENTIONS an
+# existing flag is inert because that flag is already documented. Only a genuinely
+# NEW knob — one whose token is not already in the docs and is freshly added in code
+# — can fail.
+#
+# WHAT COUNTS AS A KNOB TOKEN:
+#   * a long CLI flag: a double-quoted `"--xxx"` literal (lower-kebab), matching the
+#     hand-rolled arg matchers in crates/sparq-{cli,server}/src/main.rs. Short flags
+#     (`-h`) and the universal `--help` are NOT user config and are ignored.
+#   * an environment variable: a `SPARQ_[A-Z0-9_]+` token.
+# Both forms are extracted identically from code-diff lines and from docs (so the
+# "documented?" test is a pure token-membership check — no format coupling).
+#
+# SCOPE: only crates/sparq-cli/src/** and crates/sparq-server/src/** are config
+# surfaces (per the design's "(sparq-cli, sparq-server)"). A new flag/env added in
+# any OTHER crate, a test, or a non-src file never reaches the knob check, so such a
+# PR always passes — a CI-only / library-internal PR can never trip G6.
+#
+# DOCS SURFACES (where a knob is considered "documented"):
+#   * crates/sparq-cli/README.md, crates/sparq-server/README.md
+#   * any skills/**/SKILL.md
+# These are exactly the surfaces the design names ("the matching SKILL.md / crate
+# README documents it").
+#
+# DIFF SOURCE: git diff --name-status origin/<base>...HEAD (CI) to find changed +
+# added files, plus the per-file unified diff (git diff origin/<base>...HEAD -- f)
+# for the net-added knob tokens; or a fixture (--changed-files, one status-prefixed
+# path per line) + injected diffs (in hermetic tests) so no live git is needed.
+#
+# EXIT: 0 when no new knob is added, or every new knob is documented, or the
+# `config-internal` label is present; 1 (with a per-knob message) otherwise.
+#
+# Usage:
+#   check-config-documented.py                          # CI: diff vs origin/<base>
+#   check-config-documented.py --base main
+#   check-config-documented.py --advisory               # warn-only soft-launch
+#   check-config-documented.py --dry-run --changed-files files.txt [--labels-file l]
+#
+# stdlib-only.
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Config surfaces: only these crates' src/** define user-facing knobs (design §2.1).
+CONFIG_SRC_RE = re.compile(r"^crates/(sparq-cli|sparq-server)/src/.+")
+
+# Docs surfaces where a knob counts as "documented".
+DOC_READMES = (
+    "crates/sparq-cli/README.md",
+    "crates/sparq-server/README.md",
+)
+SKILL_PREFIX = "skills/"
+SKILL_SUFFIX = "SKILL.md"
+
+# Escape-hatch label (design §2.1).
+CONFIG_INTERNAL_LABEL = "config-internal"
+
+# A long CLI flag literal: a double-quoted "--lower-kebab" token. The hand-rolled
+# matchers in main.rs compare argv against exactly these literals.
+_FLAG_RE = re.compile(r'"(--[a-z][a-z0-9-]*)"')
+# An environment variable: SPARQ_ + uppercase/underscore/digits.
+_ENV_RE = re.compile(r"\bSPARQ_[A-Z0-9_]+\b")
+
+# Flags that are NOT user config knobs (universal help; short -h handled elsewhere).
+_FLAG_IGNORE = {"--help"}
+
+_STATUS_RE = re.compile(r"^([A-Z])\d*\t(.*)$")
+
+
+def parse_status_lines(lines: list[str]) -> tuple[list[str], list[str]]:
+    """Split a `git diff --name-status`-style list into (all_changed, added).
+
+    Each line is "<STATUS>\t<path>" (or "<STATUS>\t<old>\t<new>" for renames/
+    copies) or a bare path (a generic change, not provably added). Returns
+    (changed, added) where `added` holds A/C destination paths."""
+    changed: list[str] = []
+    added: list[str] = []
+    for raw in lines:
+        line = raw.rstrip("\n")
+        if not line.strip():
+            continue
+        m = _STATUS_RE.match(line)
+        if m:
+            status, rest = m.group(1), m.group(2)
+            path = rest.split("\t")[-1]
+            changed.append(path)
+            if status in ("A", "C"):
+                added.append(path)
+        else:
+            changed.append(line)
+    return changed, added
+
+
+def _normalize_base(base: str) -> str:
+    """Accept a bare branch ('main') or a full ref ('refs/heads/main', as the
+    merge_group event supplies) and return the remote-tracking ref ('origin/main')."""
+    base = base.strip()
+    if base.startswith("refs/heads/"):
+        base = base[len("refs/heads/") :]
+    if base.startswith("origin/") or base == "HEAD":
+        return base
+    return f"origin/{base}"
+
+
+def git_diff(base: str) -> tuple[list[str], list[str]]:
+    """Return (changed, added) from git vs the base ref using a 3-dot diff."""
+    ref = _normalize_base(base)
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-status", f"{ref}...HEAD"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except subprocess.CalledProcessError as e:  # pragma: no cover - CI-only
+        sys.stderr.write(f"error: git diff failed: {e.stderr}\n")
+        sys.exit(2)
+    return parse_status_lines(out.splitlines())
+
+
+def knob_tokens(text: str) -> set[str]:
+    """Extract every config-knob token (CLI flags + SPARQ_* env vars) from `text`.
+
+    Used both on code-diff lines (to find what a PR introduces) and on docs (to
+    test whether a knob is documented) — one extractor, so the membership test is
+    format-agnostic."""
+    flags = {f for f in _FLAG_RE.findall(text) if f not in _FLAG_IGNORE}
+    envs = set(_ENV_RE.findall(text))
+    return flags | envs
+
+
+def scan_added_knobs(diff_lines: list[str]) -> set[str]:
+    """Return knob tokens NET-added by a unified diff: present on an added (`+`)
+    line and NOT on any removed (`-`) line. A pure relocation (same token removed
+    once, added once) cancels; a comment that only mentions an unchanged flag is
+    inert (no +/- line). File headers ('+++ '/'--- ') are skipped so a path is
+    never mistaken for content."""
+    added: set[str] = set()
+    removed: set[str] = set()
+    for line in diff_lines:
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            added |= knob_tokens(line[1:])
+        elif line.startswith("-"):
+            removed |= knob_tokens(line[1:])
+    return added - removed
+
+
+def git_added_knobs(path: str, base: str) -> set[str]:
+    """Net-added knob tokens for `path` read from git. Conservative on error
+    (returns empty set — never a CI-only crash)."""
+    ref = _normalize_base(base)
+    try:
+        out = subprocess.run(
+            ["git", "diff", f"{ref}...HEAD", "--", path],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except subprocess.CalledProcessError:  # pragma: no cover - CI-only
+        return set()
+    return scan_added_knobs(out.splitlines())
+
+
+def documented_on_disk() -> set[str]:
+    """Every knob token already written down in a docs surface in the worktree
+    (the crate READMEs + all SKILL.md). A knob whose name is already here stays
+    covered even when the PR only rewires it in code."""
+    tokens: set[str] = set()
+    for rel in DOC_READMES:
+        p = REPO_ROOT / rel
+        try:
+            tokens |= knob_tokens(p.read_text(encoding="utf-8", errors="ignore"))
+        except OSError:
+            continue
+    for sk in REPO_ROOT.glob("skills/**/SKILL.md"):
+        try:
+            tokens |= knob_tokens(sk.read_text(encoding="utf-8", errors="ignore"))
+        except OSError:
+            continue
+    return tokens
+
+
+def git_doc_added_knobs(changed: list[str], base: str) -> set[str]:
+    """Knob tokens ADDED to any docs surface in this diff (so a knob documented in
+    the SAME PR counts even if the README/SKILL did not exist before)."""
+    docs = [
+        p
+        for p in changed
+        if p in DOC_READMES
+        or (p.startswith(SKILL_PREFIX) and p.endswith(SKILL_SUFFIX))
+    ]
+    tokens: set[str] = set()
+    for p in docs:
+        tokens |= git_added_knobs(p, base)
+    return tokens
+
+
+def config_src_changes(changed: list[str]) -> list[str]:
+    """Changed paths under a config surface (sparq-cli/sparq-server src/**)."""
+    return [p for p in changed if CONFIG_SRC_RE.match(p)]
+
+
+def evaluate(
+    changed: list[str],
+    labels: list[str],
+    base: str,
+    *,
+    code_knobs: dict[str, set[str]] | None = None,
+    doc_added: set[str] | None = None,
+    doc_disk: set[str] | None = None,
+) -> tuple[bool, list[tuple[str, str]]]:
+    """Return (ok, undocumented) where `undocumented` is [(knob, src_path)].
+
+    ok=True (PASS) when: no new knob was added; OR every new knob is documented
+    (added to docs in this diff OR already documented on disk); OR the
+    `config-internal` label is present.
+
+    The *_overrides let hermetic tests inject every git/disk fact:
+      code_knobs : {src_path -> set(net-added knob tokens)}  (else read from git)
+      doc_added  : knob tokens added to docs in this diff      (else read from git)
+      doc_disk   : knob tokens already documented on disk       (else read disk)
+    """
+    src_paths = config_src_changes(changed)
+
+    # Map each net-added knob to a source file that introduced it (for messaging).
+    new_knobs: dict[str, str] = {}
+    for p in src_paths:
+        toks = (
+            code_knobs[p]
+            if code_knobs is not None and p in code_knobs
+            else git_added_knobs(p, base)
+        )
+        for t in toks:
+            new_knobs.setdefault(t, p)
+
+    if not new_knobs:
+        return True, []
+
+    if CONFIG_INTERNAL_LABEL in labels:
+        return True, []
+
+    documented: set[str] = set()
+    documented |= (
+        doc_added if doc_added is not None else git_doc_added_knobs(changed, base)
+    )
+    documented |= doc_disk if doc_disk is not None else documented_on_disk()
+
+    undocumented = sorted(
+        (knob, src) for knob, src in new_knobs.items() if knob not in documented
+    )
+    return (not undocumented), undocumented
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="G6 new-config/flag→docs gate (sq-ncvq.9)."
+    )
+    ap.add_argument(
+        "--base",
+        default=os.environ.get("GATE_BASE_REF", "main"),
+        help="base ref to diff against (origin/<base>); default 'main'.",
+    )
+    ap.add_argument(
+        "--changed-files",
+        help="hermetic input: a file of diff lines (status-prefixed or bare paths).",
+    )
+    ap.add_argument(
+        "--labels-file",
+        help="hermetic input: file of PR labels, one per line (for the escape hatch).",
+    )
+    ap.add_argument("--dry-run", action="store_true", help="never exit non-zero.")
+    ap.add_argument(
+        "--advisory", action="store_true", help="soft-launch: report but exit 0."
+    )
+    args = ap.parse_args(argv)
+
+    if args.changed_files:
+        lines = Path(args.changed_files).read_text(encoding="utf-8").splitlines()
+        changed, _added = parse_status_lines(lines)
+    else:
+        changed, _added = git_diff(args.base)
+
+    labels: list[str] = []
+    if args.labels_file:
+        labels = [
+            ln.strip()
+            for ln in Path(args.labels_file).read_text(encoding="utf-8").splitlines()
+            if ln.strip()
+        ]
+
+    ok, undocumented = evaluate(changed, labels, args.base)
+
+    if ok:
+        print("G6 new-config/flag→docs: PASS — no undocumented new config knob.")
+        return 0
+
+    print("G6 new-config/flag→docs: FAIL")
+    print("\n  These new config knobs were added in code but are documented in")
+    print("  no crate README and no skills/**/SKILL.md:")
+    for knob, src in undocumented:
+        print(f"    - {knob}   (added in {src})")
+    print(
+        "\nA new public config key / CLI flag / SPARQ_* env var must be documented "
+        "in the SAME change (research/maintenance-flow-on-automation-design.md "
+        "§2.1, gate G6). Document each knob in the relevant crate README "
+        "(crates/sparq-cli/README.md or crates/sparq-server/README.md) or the "
+        "matching skills/<surface>/SKILL.md — or, if it is genuinely internal and "
+        f"not user-facing, add the `{CONFIG_INTERNAL_LABEL}` label with a "
+        "justification in the PR body."
+    )
+
+    if args.advisory or args.dry_run:
+        print("\n(advisory/dry-run: not failing the build)")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_gates.py
+++ b/scripts/tests/test_gates.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
-# [OPUS-4.8] Hermetic tests for the proactive merge-gate scripts G1/G2 (beads
-# sq-ncvq.4 + sq-ncvq.5, epic sq-ncvq). Authored by Opus 4.8 (Fable unavailable;
-# flag for re-review when Fable returns).
+# [OPUS-4.8] Hermetic tests for the proactive merge-gate scripts G1/G2/G6 (beads
+# sq-ncvq.4 + sq-ncvq.5 + sq-ncvq.9, epic sq-ncvq). Authored by Opus 4.8 (Fable
+# unavailable; flag for re-review when Fable returns).
 #
 # Hermetic w.r.t. git/network: imports scripts/gate-new-crate.py +
-# scripts/gate-api-skill.py and drives their pure evaluate()/main() entry points
-# against FIXTURE diff listings. NO live git and NO subprocess — the
-# evaluate()-level tests inject every git/subprocess fact (crate stub status,
-# bench registration, `pub`-diff heuristic) via the *_overrides kwargs, and
-# main() is driven with --changed-files fixtures + --dry-run so it never shells
-# out. [OPUS-4.8] (Caveat: the main() smoke tests call main() WITHOUT overrides,
-# so they may still consult the in-repo bench/benchmarks.toml on disk — that is a
-# committed file, not git/network state, so the runs stay deterministic.)
+# scripts/gate-api-skill.py + scripts/check-config-documented.py and drives their
+# pure evaluate()/main() entry points against FIXTURE diff listings. NO live git
+# and NO subprocess — the evaluate()-level tests inject every git/subprocess fact
+# (crate stub status, bench registration, `pub`-diff heuristic, G6 net-added knob
+# tokens + documented-token sets) via the *_overrides kwargs, and main() is driven
+# with --changed-files fixtures + --dry-run so it never shells out. [OPUS-4.8]
+# (Caveat: the main() smoke tests call main() WITHOUT overrides, so they may still
+# consult the in-repo bench/benchmarks.toml or the crate READMEs/SKILL.md on disk —
+# those are committed files, not git/network state, so the runs stay deterministic.)
 #
 # Run:  python3 scripts/tests/test_gates.py
 # (stdlib only; no pytest required — also discoverable by `pytest`.)
@@ -38,6 +39,7 @@ def _load(name: str, filename: str):
 
 g1 = _load("gate_new_crate", "gate-new-crate.py")
 g2 = _load("gate_api_skill", "gate-api-skill.py")
+g6 = _load("check_config_documented", "check-config-documented.py")
 
 
 def _statused(added: list[str], modified: list[str] | None = None) -> list[str]:
@@ -280,6 +282,163 @@ class G2Test(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------- #
+# G6 — new-config/flag → docs
+# --------------------------------------------------------------------------- #
+class G6Test(unittest.TestCase):
+    # [OPUS-4.8] G6 fires on a NET-added CLI flag literal / SPARQ_* env var in a
+    # sparq-cli|sparq-server src file that no docs surface documents. The
+    # evaluate()-level tests inject the net-added-knob set (code_knobs), the
+    # docs-added set (doc_added) and the on-disk documented set (doc_disk) so they
+    # stay hermetic (no live git, no disk). The token-extraction + net-diff helpers
+    # are exercised directly.
+
+    SERVER_MAIN = "crates/sparq-server/src/main.rs"
+    CLI_MAIN = "crates/sparq-cli/src/main.rs"
+
+    def test_new_flag_without_docs_fails(self):
+        ok, undoc = g6.evaluate(
+            [self.SERVER_MAIN],
+            labels=[],
+            base="main",
+            code_knobs={self.SERVER_MAIN: {"--new-knob"}},
+            doc_added=set(),
+            doc_disk=set(),
+        )
+        self.assertFalse(ok)
+        self.assertEqual([k for k, _ in undoc], ["--new-knob"])
+        self.assertEqual(undoc[0][1], self.SERVER_MAIN)
+
+    def test_new_flag_documented_in_same_diff_passes(self):
+        # The same PR adds the flag to the crate README → documented.
+        ok, undoc = g6.evaluate(
+            [self.SERVER_MAIN, "crates/sparq-server/README.md"],
+            labels=[],
+            base="main",
+            code_knobs={self.SERVER_MAIN: {"--new-knob"}},
+            doc_added={"--new-knob"},
+            doc_disk=set(),
+        )
+        self.assertTrue(ok)
+        self.assertEqual(undoc, [])
+
+    def test_new_flag_documented_in_skill_in_same_diff_passes(self):
+        ok, undoc = g6.evaluate(
+            [self.CLI_MAIN, "skills/cli/SKILL.md"],
+            labels=[],
+            base="main",
+            code_knobs={self.CLI_MAIN: {"--new-knob"}},
+            doc_added={"--new-knob"},
+            doc_disk=set(),
+        )
+        self.assertTrue(ok)
+        self.assertEqual(undoc, [])
+
+    def test_new_env_var_without_docs_fails(self):
+        ok, undoc = g6.evaluate(
+            [self.CLI_MAIN],
+            labels=[],
+            base="main",
+            code_knobs={self.CLI_MAIN: {"SPARQ_NEW_THING"}},
+            doc_added=set(),
+            doc_disk=set(),
+        )
+        self.assertFalse(ok)
+        self.assertEqual([k for k, _ in undoc], ["SPARQ_NEW_THING"])
+
+    def test_knob_already_documented_on_disk_passes(self):
+        # A rewire of an EXISTING flag whose name is already written down on disk
+        # (the README/SKILL was not touched in this PR) is still covered.
+        ok, undoc = g6.evaluate(
+            [self.SERVER_MAIN],
+            labels=[],
+            base="main",
+            code_knobs={self.SERVER_MAIN: {"--audit-log"}},
+            doc_added=set(),
+            doc_disk={"--audit-log"},
+        )
+        self.assertTrue(ok)
+        self.assertEqual(undoc, [])
+
+    def test_config_internal_label_suppresses(self):
+        ok, undoc = g6.evaluate(
+            [self.SERVER_MAIN],
+            labels=["config-internal"],
+            base="main",
+            code_knobs={self.SERVER_MAIN: {"--secret-internal"}},
+            doc_added=set(),
+            doc_disk=set(),
+        )
+        self.assertTrue(ok)
+        self.assertEqual(undoc, [])
+
+    def test_non_config_crate_src_never_trips(self):
+        # A flag literal added in a NON-config crate's src can never reach the knob
+        # check — out of scope. No code_knobs needed: config_src_changes filters it.
+        ok, undoc = g6.evaluate(
+            ["crates/sparq-core/src/store.rs"],
+            labels=[],
+            base="main",
+            doc_added=set(),
+            doc_disk=set(),
+        )
+        self.assertTrue(ok)
+        self.assertEqual(undoc, [])
+
+    def test_ci_only_change_passes(self):
+        # No config src in the diff at all → always passes (mirrors G2).
+        ok, undoc = g6.evaluate(
+            [".github/workflows/ci.yml", "research/notes.md"],
+            labels=[],
+            base="main",
+            doc_added=set(),
+            doc_disk=set(),
+        )
+        self.assertTrue(ok)
+        self.assertEqual(undoc, [])
+
+    def test_knob_token_extraction(self):
+        # Flags + env vars are extracted; --help and short flags are NOT knobs;
+        # restricted/struct-field/non-quoted tokens do not leak in.
+        toks = g6.knob_tokens(
+            '            "--max-results" => { SPARQ_MAX_RESULTS } "--help" "-h"'
+        )
+        self.assertIn("--max-results", toks)
+        self.assertIn("SPARQ_MAX_RESULTS", toks)
+        self.assertNotIn("--help", toks)
+        self.assertNotIn("-h", toks)
+
+    def test_scan_added_knobs_net_diff(self):
+        # A pure relocation (same flag removed once + added once) cancels; a
+        # genuinely new flag is reported; a removed-only flag is not "added".
+        diff = [
+            "--- a/crates/sparq-server/src/main.rs",
+            "+++ b/crates/sparq-server/src/main.rs",
+            '+            "--relocated" => foo,',
+            '-            "--relocated" => foo,',
+            '+            "--brand-new" => bar,',
+            '-            "--deleted" => baz,',
+        ]
+        added = g6.scan_added_knobs(diff)
+        self.assertEqual(added, {"--brand-new"})
+
+    def test_comment_mentioning_existing_flag_is_inert(self):
+        # A doc-comment that merely names an existing flag adds the token, but the
+        # token is already documented on disk → not undocumented. (Models the very
+        # common "//! --audit-log does X" comment edit.)
+        path = self.SERVER_MAIN
+        ok, undoc = g6.evaluate(
+            [path],
+            labels=[],
+            base="main",
+            code_knobs={path: g6.scan_added_knobs(['+    // see --audit-log flag'])},
+            doc_added=set(),
+            doc_disk={"--audit-log"},
+        )
+        self.assertTrue(ok)
+        self.assertEqual(undoc, [])
+
+
+# --------------------------------------------------------------------------- #
 # main() smoke (hermetic, via --changed-files + --dry-run; no git/network)
 # --------------------------------------------------------------------------- #
 class MainSmokeTest(unittest.TestCase):
@@ -295,6 +454,14 @@ class MainSmokeTest(unittest.TestCase):
             tmp = Path(d)
             f = _write(tmp, "diff.txt", ["research/foo.md"])
             rc = g2.main(["--dry-run", "--changed-files", f])
+            self.assertEqual(rc, 0)
+
+    def test_g6_main_dry_run_on_clean_diff_passes(self):
+        # No config-surface src in the diff → no knob check → PASS (exit 0).
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            f = _write(tmp, "diff.txt", _statused([], ["research/foo.md"]))
+            rc = g6.main(["--dry-run", "--changed-files", f])
             self.assertEqual(rc, 0)
 
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change by an agent operating on @jeswr's behalf. Flag anything off and I'll iterate.

## What & why

Implements bead **sq-ncvq.9** — proactive maintenance merge-gate **G6 (new-config/flag→docs)** from `research/maintenance-flow-on-automation-design.md` §2.1, completing the gate family alongside G1/G2/G3.

**Rule:** when a PR adds a new `sparq-cli` / `sparq-server` CLI flag (a `"--flag"` literal) or a `SPARQ_*` env var under `crates/sparq-{cli,server}/src/**`, it must be **documented in the same change** — in a crate `README.md` or any `skills/**/SKILL.md` — otherwise the gate fails. Escape hatch: the per-PR label `config-internal` (justified in the PR body).

**Why a separate gate from G2.** G2 (`gate-api-skill.py`) only fires on net `pub`-item signature changes. The CLI/server arg parsers are hand-rolled `match` arms, so a new flag is a *string literal*, not a `pub` symbol — it sails straight past G2. G6 is the config-knob subset that closes exactly that gap (design §2.1: "subset of G2, but covers config not just `pub`").

## How

- **`scripts/check-config-documented.py`** (new, stdlib-only). Net-diff discipline mirrors G2: reads each changed config-src file's unified diff and keeps only knob tokens that are **NET-added** (added and not also removed). A knob is undocumented only if it appears in **no** docs surface — neither added-to-docs in this diff nor already on disk. Consequences:
  - a pure relocation of a flag handler within a file cancels out (net-zero) → no trip;
  - a comment that merely *mentions* an existing (already-documented) flag is inert;
  - a flag added in any non-`sparq-cli/server` crate, a test, or a CI file is out of scope → always passes.
  - Hermetic `evaluate()` takes `code_knobs` / `doc_added` / `doc_disk` overrides so tests inject every git/disk fact (no live git, no network).
- **`scripts/tests/test_gates.py`** — 12 hermetic G6 tests + a `main()` dry-run smoke (fail/pass paths, env var, README-doc, SKILL-doc, on-disk-documented rewire, `config-internal` label, out-of-scope crate, CI-only diff, token extraction, net-diff, comment-inert).
- **`.github/workflows/flow-on-gates.yml`** — adds the `config-documented (G6)` job. Runs **HARD**: the back-catalogue is already clean — every existing flag + `SPARQ_*` env var is documented in a crate README or a SKILL.md (verified against HEAD). Reads PR labels for the escape hatch, mirroring G2 (including the merge-queue PR-number resolution). Also runs the gate unit suite as a self-test step.

## Verification

- `python3 scripts/tests/test_gates.py` → 31 tests OK (12 new for G6).
- `python3 scripts/check-config-documented.py --base main` → PASS exit 0 (clean back-catalogue) — gate runs HARD.
- **End-to-end against a real git diff:** committing an undocumented `--g6-probe-undocumented` flag → FAIL (exit 1) with a per-knob message; adding the `config-internal` label → PASS (exit 0).
- `bash scripts/check-privacy-claims.sh` → OK (privacy-claims gate, mandatory).
- Workflow YAML parses; Python compiles.

No public Rust API changed (this is a CI/docs gate), so the G2 public-API→SKILL.md rule does not apply here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)