### PR TITLE
sparq-server(brtpf): DoS cap the binding set — mapping count + values payload bytes (sq-r74h)

### DIFF
--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -368,9 +368,11 @@ matrix under "Security posture".
   UPDATE, `sq-nulp`) / `--max-body-bytes` / `--max-concurrent` /
   `--max-results` / `--max-query-rows` (coarse memory cap) / `--max-query-bytes`
   (byte-accounted memory cap, `sq-s5is`) / `--max-decompress-ratio` (zip-bomb guard) /
-  `--service-allow*` (SERVICE SSRF egress) / `--max-subscriptions*`, each with a `SPARQ_*` env
-  override. The DoS/SSRF limits are documented together (with their honest semantics) in the
-  SKILL's "Server hardening" section.
+  `--service-allow*` (SERVICE SSRF egress) / `--max-subscriptions*` / (feature `brtpf`)
+  `--brtpf-max-bindings` + `--brtpf-max-values-bytes` (DoS caps on the brTPF binding set — mapping
+  count + `values` payload bytes, `sq-r74h`), each with a `SPARQ_*` env override. The DoS/SSRF
+  limits are documented together (with their honest semantics) in the SKILL's "Server hardening"
+  section.
 - **EXPLAIN / EXPLAIN ANALYZE**, Prometheus **`/metrics`**, and SEPA-style **WebSocket
   subscriptions** (live SELECT diffs).
 - **Federation discovery** — opt-in (`federation-descriptors` feature + `--federation-descriptors`
@@ -403,7 +405,11 @@ matrix under "Security posture".
   fragment advertises the restriction through an extra `hydra:mapping` for the `values` variable,
   and `hydra:totalItems` reflects the bindings-restricted result (not the unrestricted pattern). A
   `tpf`-only build is byte-identical to before (a stray `values` parameter is just an ignored
-  unknown parameter — plain TPF). See the SKILL's "Triple Pattern Fragments" section.
+  unknown parameter — plain TPF). The binding set is bounded by two ON-by-default DoS caps
+  (`sq-r74h`): `--brtpf-max-bindings` (mapping count — one index scan runs per mapping, so cost is
+  super-linear in the count) and `--brtpf-max-values-bytes` (raw `values` payload bytes — the GET
+  query-string carrier is not covered by `--max-body-bytes`); a breach is a `413`. See the SKILL's
+  "Triple Pattern Fragments" section.
 - **Access-audit trails** — opt-in, off by default: `audit-log` (flat `tracing` event per request)
   and `access-audit` (richer typed JSON-Lines records via a pluggable sink — actor / action /
   resource / decision+basis / timestamp / fingerprint, hooked at the real enforcement seam).

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -44,7 +44,10 @@ use sparq_serve::{
     ApplyUpdates, Generation, GenerationRing, GraphApplier, PodId, WriteError, Writer, WriterConfig,
 };
 
-use crate::exec::{apply_update_dataset, prepare_with_dataset, DatasetOverride, PrepareError, QueryForm, UpdateDatasetError, UsingOverride};
+use crate::exec::{
+    apply_update_dataset, prepare_with_dataset, DatasetOverride, PrepareError, QueryForm,
+    UpdateDatasetError, UsingOverride,
+};
 use crate::negotiate::{negotiate, negotiate_graph, Format, GraphFormat};
 use crate::results;
 
@@ -360,6 +363,28 @@ pub struct ServerConfig {
     /// zero cost. Set by the binary's `--tpf` flag / `SPARQ_TPF=1` env.
     #[cfg(feature = "tpf")]
     pub tpf: bool,
+    /// [OPUS-4.8] (sq-r74h, follow-up to sq-dxhb) **brTPF binding-set DoS cap — maximum number of
+    /// solution mappings** accepted on a `GET /tpf?values=…` / `POST /tpf` brTPF request. A brTPF
+    /// fragment runs ONE index scan per attached mapping (see [`crate::tpf::evaluate_brtpf`]), so
+    /// the per-request cost is super-linear in the mapping *count*, not the payload *bytes* — and
+    /// `--max-body-bytes` (a body-byte limit, and one that the `values` *query-string* carrier
+    /// never even sees) bounds the count only transitively and far too loosely. This caps the
+    /// fan-out directly: a request whose binding set exceeds it is refused `413` BEFORE any index
+    /// work. `0` disables the count cap. Default `1024`. Set by `--brtpf-max-bindings` /
+    /// `SPARQ_BRTPF_MAX_BINDINGS`. Present only with the `brtpf` cargo feature.
+    #[cfg(feature = "brtpf")]
+    pub brtpf_max_bindings: usize,
+    /// [OPUS-4.8] (sq-r74h, follow-up to sq-dxhb) **brTPF binding-set DoS cap — maximum `values`
+    /// payload bytes.** The companion byte cap to [`brtpf_max_bindings`](Self::brtpf_max_bindings),
+    /// enforced on the raw binding-set payload BEFORE it is parsed (`413` on breach). It exists
+    /// because the brTPF `values` binding set can ride the **query string** of a `GET /tpf`, which
+    /// the server's `--max-body-bytes` HTTP *body* limit does not cover at all — so without this,
+    /// the GET carrier is unbounded. On a `POST` body the body limit also applies; the effective
+    /// bound is then the tighter of the two. `0` disables the byte cap. Default `1048576` (1 MiB,
+    /// matching the `--max-body-bytes` default). Set by `--brtpf-max-values-bytes` /
+    /// `SPARQ_BRTPF_MAX_VALUES_BYTES`. Present only with the `brtpf` cargo feature.
+    #[cfg(feature = "brtpf")]
+    pub brtpf_max_values_bytes: usize,
 }
 
 impl Default for ServerConfig {
@@ -417,6 +442,14 @@ impl Default for ServerConfig {
             // the feature is compiled in (the operator opts in deliberately via --tpf / SPARQ_TPF=1).
             #[cfg(feature = "tpf")]
             tpf: false,
+            // [OPUS-4.8] sq-r74h: brTPF binding-set DoS caps — ON by default (a public source
+            // endpoint should be bounded out of the box). 1024 mappings and a 1 MiB payload mirror
+            // the conservative LDF page size and the --max-body-bytes default; an operator widens
+            // (or, with 0, disables) either via the flags.
+            #[cfg(feature = "brtpf")]
+            brtpf_max_bindings: 1024,
+            #[cfg(feature = "brtpf")]
+            brtpf_max_values_bytes: 1024 * 1024,
         }
     }
 }
@@ -558,6 +591,17 @@ impl ServerConfig {
         #[cfg(feature = "tpf")]
         if let Ok(v) = std::env::var("SPARQ_TPF") {
             cfg.tpf = env_truthy(&v);
+        }
+        // [OPUS-4.8] sq-r74h: brTPF binding-set DoS caps (mapping count + payload bytes); 0
+        // disables that cap. Only present with the `brtpf` feature.
+        #[cfg(feature = "brtpf")]
+        {
+            if let Some(n) = env_parse::<usize>("SPARQ_BRTPF_MAX_BINDINGS") {
+                cfg.brtpf_max_bindings = n;
+            }
+            if let Some(n) = env_parse::<usize>("SPARQ_BRTPF_MAX_VALUES_BYTES") {
+                cfg.brtpf_max_values_bytes = n;
+            }
         }
         Ok(cfg)
     }
@@ -2077,15 +2121,30 @@ async fn tpf_endpoint(
         } else {
             std::borrow::Cow::Borrowed(params.get("values").map(String::as_str).unwrap_or(""))
         };
-        match crate::tpf::parse_bindings(&raw_values) {
+        // [OPUS-4.8] sq-r74h: enforce the binding-set DoS caps (mapping count + payload bytes)
+        // BEFORE parsing/evaluation. These bound the brTPF fan-out independently of
+        // `--max-body-bytes` — which does not cover the `values` query-string carrier at all, and
+        // bounds the per-mapping index-scan cost only transitively. A too-large set is a `413`
+        // (the same refusal class as the body limit); a malformed set stays a `400`.
+        let limits = crate::tpf::BindingLimits {
+            max_mappings: state.config().brtpf_max_bindings,
+            max_payload_bytes: state.config().brtpf_max_values_bytes,
+        };
+        match crate::tpf::parse_bindings_capped(&raw_values, limits) {
             Ok(b) => b,
-            Err(e) => {
+            Err(crate::tpf::BindingError::Malformed(e)) => {
                 return sanitized_error(
                     StatusCode::BAD_REQUEST,
                     "brtpf-bindings-parse",
                     "malformed brTPF binding set",
                     &e.to_string(),
                 )
+            }
+            Err(crate::tpf::BindingError::TooLarge(m)) => {
+                // The cap message names only the limit (never a caller-supplied term), so it is
+                // safe to return to the client — it tells them which knob to lower / which the
+                // operator set, exactly like the `--max-body-bytes` 413.
+                return json_error(StatusCode::PAYLOAD_TOO_LARGE, &m);
             }
         }
     };
@@ -2418,8 +2477,16 @@ async fn sparql_endpoint(
                         }
                     };
                     let explain = explain_mode(&url_params, None, &headers);
-                    let resp =
-                        run_query(&state, q, &headers, method == Method::HEAD, explain, pin, &url_dataset).await;
+                    let resp = run_query(
+                        &state,
+                        q,
+                        &headers,
+                        method == Method::HEAD,
+                        explain,
+                        pin,
+                        &url_dataset,
+                    )
+                    .await;
                     #[cfg(feature = "audit-log")]
                     if let Some(a) = audit {
                         a.emit(&resp);
@@ -2442,7 +2509,17 @@ async fn sparql_endpoint(
                 None => bad_request("missing 'query' parameter"),
             }
         }
-        Method::POST => handle_post(&state, &headers, &body, &url_params, &url_dataset, &url_using).await,
+        Method::POST => {
+            handle_post(
+                &state,
+                &headers,
+                &body,
+                &url_params,
+                &url_dataset,
+                &url_using,
+            )
+            .await
+        }
         _ => method_not_allowed(&[Method::GET, Method::HEAD, Method::POST]),
     }
 }
@@ -2638,7 +2715,16 @@ async fn handle_post(
                 // [OPUS-4.8] sq-z33x: per the SPARQL 1.1 Protocol url-encoded encoding, the dataset
                 // override (`default-graph-uri` / `named-graph-uri`) is carried in the FORM BODY for
                 // this content type, not the URL query string.
-                run_query(state, q, headers, false, explain, pin, &query_dataset_override(s)).await
+                run_query(
+                    state,
+                    q,
+                    headers,
+                    false,
+                    explain,
+                    pin,
+                    &query_dataset_override(s),
+                )
+                .await
             }
             None => bad_request("missing 'query' or 'update' parameter in url-encoded body"),
         };
@@ -3910,9 +3996,12 @@ fn update_dataset_override(raw: &str) -> UsingOverride {
 #[allow(clippy::result_large_err)]
 fn rewrite_update(update: &str, over: &UsingOverride) -> Result<String, Response> {
     apply_update_dataset(update, over).map_err(|e| match e {
-        UpdateDatasetError::Malformed(msg) => {
-            sanitized_error(StatusCode::BAD_REQUEST, "update-parse", "malformed update", &msg)
-        }
+        UpdateDatasetError::Malformed(msg) => sanitized_error(
+            StatusCode::BAD_REQUEST,
+            "update-parse",
+            "malformed update",
+            &msg,
+        ),
         UpdateDatasetError::BadGraphUri(msg) => bad_request(&msg),
         UpdateDatasetError::UsingConflict => bad_request(
             "the 'using-graph-uri' / 'using-named-graph-uri' parameters must not be combined with \
@@ -4974,7 +5063,10 @@ mod hardening_unit_tests {
     #[test]
     fn update_where_deadline_defaults_to_query_timeout_unchanged() {
         let cfg = ServerConfig::default();
-        assert_eq!(cfg.update_where_timeout, None, "no separate update deadline by default");
+        assert_eq!(
+            cfg.update_where_timeout, None,
+            "no separate update deadline by default"
+        );
         assert_eq!(update_where_deadline(&cfg), cfg.query_timeout);
     }
 

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -76,6 +76,13 @@
 //!   --max-decompress-ratio N  [OPUS-4.8 sq-ebii] DECOMPRESSION-RATIO cap for a `Content-Encoding: gzip`
 //!                             request body (zip-bomb guard; 413), 0 = refuse gzip bodies
 //!                                                                        [20, env SPARQ_MAX_DECOMPRESS_RATIO]
+//!   --brtpf-max-bindings N    [OPUS-4.8 sq-r74h] (feature `brtpf`) DoS cap on the brTPF binding-set
+//!                             MAPPING COUNT — one index scan runs per mapping, so cost is super-linear
+//!                             in the count, not the bytes (413 beyond), 0 off
+//!                                                                        [1024, env SPARQ_BRTPF_MAX_BINDINGS]
+//!   --brtpf-max-values-bytes N [OPUS-4.8 sq-r74h] (feature `brtpf`) DoS cap on the raw brTPF `values`
+//!                             PAYLOAD BYTES — bounds the GET query-string carrier that --max-body-bytes
+//!                             never sees (413 beyond), 0 off            [1048576, env SPARQ_BRTPF_MAX_VALUES_BYTES]
 //!   --verbose                 per-request logging (TraceLayer)
 //!   --log-full-requests       [OPUS-4.8 sq-toze.34] OPT OUT of request-log redaction: log the
 //!                             raw request URI (incl. the full `?query=` SPARQL text) verbatim.
@@ -263,6 +270,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // controls. Read-only. Off by default (env SPARQ_TPF=1).
             #[cfg(feature = "tpf")]
             "--tpf" => config.tpf = true,
+            // [OPUS-4.8] sq-r74h (follow-up to sq-dxhb): brTPF binding-set DoS caps. A brTPF
+            // request runs ONE index scan per attached solution mapping, so the cost is
+            // super-linear in the mapping COUNT — which `--max-body-bytes` bounds only loosely,
+            // and not at all for the `values` query-string carrier. These cap the mapping count
+            // and the raw `values` payload bytes (413 on breach); 0 disables that cap.
+            #[cfg(feature = "brtpf")]
+            "--brtpf-max-bindings" => {
+                config.brtpf_max_bindings = parse_flag(&mut args, "--brtpf-max-bindings")?;
+            }
+            #[cfg(feature = "brtpf")]
+            "--brtpf-max-values-bytes" => {
+                config.brtpf_max_values_bytes = parse_flag(&mut args, "--brtpf-max-values-bytes")?;
+            }
             // [OPUS-4.8] sq-4w18: SERVICE egress allowlist. Repeatable: each value adds one
             // host (`sparql.example.org`) or suffix wildcard (`*.example.org`). With NO
             // allowlist (the default) every SERVICE clause is refused (default-DENY-all).
@@ -287,13 +307,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 } else {
                     ""
                 };
+                // [OPUS-4.8] sq-r74h: surface the brTPF binding-set DoS caps in --help (feature brtpf).
+                let brtpf = if cfg!(feature = "brtpf") {
+                    " [--brtpf-max-bindings N] [--brtpf-max-values-bytes N]"
+                } else {
+                    ""
+                };
                 eprintln!(
                     "usage: sparq-server [--addr HOST:PORT] [--allow-remote] [--persist DIR] \
                      [--auth-token TOKEN] [--auth-token-read] [--format FMT] \
                      [--query-timeout SECS] [--update-where-timeout SECS] [--max-body-bytes N] [--max-concurrent N] \
                      [--max-results N] [--max-query-rows N] [--max-query-bytes N] [--max-decompress-ratio N] \
                      [--max-subscriptions N] \
-                     [--max-subscriptions-per-conn N]{time_travel}{service} [--verbose] \
+                     [--max-subscriptions-per-conn N]{time_travel}{service}{brtpf} [--verbose] \
                      [--log-full-requests] [DATA_FILE]\n\n  \
                      PERSIST: --persist DIR (env SPARQ_PERSIST_DIR) makes the on-disk index at \
                      DIR the durable source of truth (QLever --persist-updates): every committed \
@@ -421,6 +447,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.max_subscriptions,
         config.max_subscriptions_per_conn,
     );
+    // [OPUS-4.8] sq-r74h: surface the brTPF binding-set DoS caps at startup (feature `brtpf`).
+    #[cfg(feature = "brtpf")]
+    {
+        let fmt0 = |n: usize| {
+            if n == 0 {
+                "off".to_string()
+            } else {
+                n.to_string()
+            }
+        };
+        eprintln!(
+            "guards (brtpf): brtpf-max-bindings={} brtpf-max-values-bytes={}",
+            fmt0(config.brtpf_max_bindings),
+            fmt0(config.brtpf_max_values_bytes),
+        );
+    }
     // [OPUS-4.8] sq-7cxr: surface the durable-persistence posture at startup.
     match &config.persist_dir {
         Some(dir) => eprintln!(

--- a/crates/sparq-server/src/tpf.rs
+++ b/crates/sparq-server/src/tpf.rs
@@ -295,6 +295,73 @@ impl Binding {
     }
 }
 
+/// [OPUS-4.8] sq-r74h: the DoS caps on a brTPF binding set, enforced by [`parse_bindings_capped`]
+/// BEFORE the (potentially large) payload is fully parsed and BEFORE any index work. `0` on either
+/// field disables that cap (the historical uncapped behaviour). These bound the binding set
+/// *independently of* the server's `--max-body-bytes` body limit, for two reasons the body limit
+/// does not cover:
+///
+///   * **The `values` query-string transport is NOT a body** — a `GET /tpf?values=…` carries the
+///     binding set in the URL, which `--max-body-bytes` (an HTTP *body* limit) never sees. So a
+///     payload-byte cap is the only bound on the query-string carrier.
+///   * **Cost is super-linear in the mapping COUNT, not the bytes** — [`evaluate_brtpf`] runs ONE
+///     index scan per mapping and unions the rows into a `BTreeSet`, so N tiny mappings (each a
+///     handful of bytes, so well under any byte limit) still cost N scans + an O(result) set. A
+///     mapping-COUNT cap bounds that fan-out directly; a byte limit only bounds it transitively
+///     and far too loosely (a 1 MiB body of `s=<a>\n`-sized mappings is ~150k scans).
+///
+/// Compiled only with the `brtpf` feature.
+#[cfg(feature = "brtpf")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BindingLimits {
+    /// Maximum number of (non-empty) solution mappings accepted. `0` disables the count cap.
+    pub max_mappings: usize,
+    /// Maximum size, in bytes, of the raw `values` payload accepted. `0` disables the byte cap.
+    pub max_payload_bytes: usize,
+}
+
+#[cfg(feature = "brtpf")]
+impl BindingLimits {
+    /// No caps — the historical uncapped behaviour (used by [`parse_bindings`]).
+    pub const UNLIMITED: BindingLimits = BindingLimits {
+        max_mappings: 0,
+        max_payload_bytes: 0,
+    };
+}
+
+/// [OPUS-4.8] sq-r74h: a brTPF binding-set parse outcome that DISTINGUISHES a malformed payload
+/// (the client sent garbage → `400`) from a payload that exceeds a DoS cap (the client sent a
+/// well-formed but too-large set → `413`, the same refusal class as `--max-body-bytes`). The HTTP
+/// layer maps the two variants to those two distinct statuses.
+///
+/// Compiled only with the `brtpf` feature.
+#[cfg(feature = "brtpf")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BindingError {
+    /// The payload was malformed (a bad `position=term` pair, a non-IRI predicate, …) → `400`.
+    Malformed(ParseError),
+    /// The payload was well-formed but exceeded a [`BindingLimits`] DoS cap → `413`. The message
+    /// names which cap and its limit (NOT any caller-supplied term — no info-leak / no echo).
+    TooLarge(String),
+}
+
+#[cfg(feature = "brtpf")]
+impl std::fmt::Display for BindingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BindingError::Malformed(e) => write!(f, "{e}"),
+            BindingError::TooLarge(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+#[cfg(feature = "brtpf")]
+impl From<ParseError> for BindingError {
+    fn from(e: ParseError) -> Self {
+        BindingError::Malformed(e)
+    }
+}
+
 /// [OPUS-4.8] sq-dxhb: parses a brTPF `values` payload into the set of solution mappings.
 ///
 /// The wire format is one mapping per line; within a line, whitespace-separated
@@ -306,6 +373,12 @@ impl Binding {
 /// pairs is the empty mapping μ₀ (compatible with everything) and is skipped (it would defeat
 /// the restriction). The predicate position must be an IRI (same rule as the pattern).
 ///
+/// This is the UNCAPPED parse — for the DoS-capped form a public server should use, see
+/// [`parse_bindings_capped`] (sq-r74h). This entrypoint is retained for callers that have already
+/// bounded the input (e.g. unit tests) and is equivalent to
+/// `parse_bindings_capped(payload, BindingLimits::UNLIMITED)` with the error re-narrowed to
+/// [`ParseError`] (it can only fail malformed when uncapped).
+///
 /// Example payload (URL-decoded), restricting `?s foaf:knows ?o` to two `?s` values:
 ///
 /// ```text
@@ -314,6 +387,44 @@ impl Binding {
 /// ```
 #[cfg(feature = "brtpf")]
 pub fn parse_bindings(payload: &str) -> Result<Vec<Binding>, ParseError> {
+    match parse_bindings_capped(payload, BindingLimits::UNLIMITED) {
+        Ok(b) => Ok(b),
+        // UNLIMITED can never produce a TooLarge; only Malformed is reachable here.
+        Err(BindingError::Malformed(e)) => Err(e),
+        Err(BindingError::TooLarge(m)) => {
+            unreachable!("BindingLimits::UNLIMITED never trips a cap: {m}")
+        }
+    }
+}
+
+/// [OPUS-4.8] sq-r74h: [`parse_bindings`] with the DoS caps in [`BindingLimits`] enforced.
+///
+/// Enforces, in this order:
+///   1. **The payload-byte cap** (`limits.max_payload_bytes`) — checked FIRST, on the raw byte
+///      length, BEFORE any line scanning, so an oversized payload is rejected without parsing it.
+///      This is the bound on the `values` *query-string* carrier, which `--max-body-bytes` (a
+///      *body* limit) never sees.
+///   2. **The mapping-count cap** (`limits.max_mappings`) — checked as non-empty mappings
+///      accumulate, so parsing stops at the limit + 1th mapping rather than building the whole
+///      vector first. This bounds [`evaluate_brtpf`]'s per-mapping index-scan fan-out directly.
+///
+/// A `0` limit disables that cap. A cap breach returns [`BindingError::TooLarge`] (the HTTP layer
+/// → `413`); a malformed payload returns [`BindingError::Malformed`] (→ `400`). The byte cap is
+/// checked before the malformed check, so a payload that is BOTH oversized and malformed is
+/// reported as too-large (the cheaper, earlier refusal — we never parse an over-cap payload).
+#[cfg(feature = "brtpf")]
+pub fn parse_bindings_capped(
+    payload: &str,
+    limits: BindingLimits,
+) -> Result<Vec<Binding>, BindingError> {
+    // 1. Payload-byte cap — rejected on raw length before any parse work. NB: the message names
+    // only the limit, never the payload, so an over-cap request leaks nothing back to the client.
+    if limits.max_payload_bytes != 0 && payload.len() > limits.max_payload_bytes {
+        return Err(BindingError::TooLarge(format!(
+            "brTPF binding payload exceeds the {}-byte cap (--brtpf-max-values-bytes)",
+            limits.max_payload_bytes
+        )));
+    }
     let mut out = Vec::new();
     for line in payload.lines() {
         let line = line.trim();
@@ -332,15 +443,23 @@ pub fn parse_bindings(payload: &str) -> Result<Vec<Binding>, ParseError> {
                 "predicate" | "p" => b.predicate = parse_predicate(Some(term))?,
                 "object" | "o" => b.object = parse_term(Some(term), "object")?,
                 other => {
-                    return Err(ParseError(format!(
+                    return Err(BindingError::Malformed(ParseError(format!(
                         "brTPF binding position must be subject/predicate/object (s/p/o), got '{other}'"
-                    )))
+                    ))))
                 }
             }
         }
         // A mapping that constrains nothing (an all-blank μ₀) does not restrict the fragment;
         // drop it rather than let it widen the result to the whole pattern.
         if !b.is_empty() {
+            // 2. Mapping-count cap — checked as each non-empty mapping is accepted, so we stop at
+            // the (limit+1)th rather than materialising the whole set first.
+            if limits.max_mappings != 0 && out.len() == limits.max_mappings {
+                return Err(BindingError::TooLarge(format!(
+                    "brTPF binding set exceeds the {}-mapping cap (--brtpf-max-bindings)",
+                    limits.max_mappings
+                )));
+            }
             out.push(b);
         }
     }
@@ -1113,6 +1232,102 @@ mod tests {
             // {alice,bob} → alice knows bob (1). {knows} → alice→bob, carol→alice (2). Union = 2.
             assert_eq!(f.total_estimate, 2);
             assert_eq!(f.triples.len(), 2);
+        }
+
+        // ---- sq-r74h: DoS caps on the binding set (count + payload bytes) ----------------
+
+        #[test]
+        fn capped_unlimited_matches_uncapped() {
+            // UNLIMITED trips no cap — identical to the uncapped parse_bindings.
+            let payload = "s=<http://ex/alice>\ns=<http://ex/carol>";
+            let capped = parse_bindings_capped(payload, BindingLimits::UNLIMITED).unwrap();
+            let plain = parse_bindings(payload).unwrap();
+            assert_eq!(capped, plain);
+            assert_eq!(capped.len(), 2);
+        }
+
+        #[test]
+        fn mapping_count_cap_rejects_excess_as_too_large() {
+            // 3 mappings, cap of 2 → TooLarge (413), naming the count cap, not the payload.
+            let payload = "s=<http://ex/a>\ns=<http://ex/b>\ns=<http://ex/c>";
+            let limits = BindingLimits {
+                max_mappings: 2,
+                max_payload_bytes: 0,
+            };
+            let err = parse_bindings_capped(payload, limits).unwrap_err();
+            assert!(matches!(err, BindingError::TooLarge(_)), "{err:?}");
+            assert!(err.to_string().contains("brtpf-max-bindings"), "{err}");
+            // Exactly at the cap is accepted (boundary: count == cap is OK, cap+1 is not).
+            let at_cap = "s=<http://ex/a>\ns=<http://ex/b>";
+            assert_eq!(parse_bindings_capped(at_cap, limits).unwrap().len(), 2);
+        }
+
+        #[test]
+        fn empty_mappings_do_not_count_toward_the_cap() {
+            // Blank lines + an all-blank μ₀ line are dropped, so they don't consume the count cap:
+            // 2 real mappings interleaved with skipped lines is fine under a cap of 2.
+            let payload = "\ns=<http://ex/a>\n   \ns=<http://ex/b>\n";
+            let limits = BindingLimits {
+                max_mappings: 2,
+                max_payload_bytes: 0,
+            };
+            assert_eq!(parse_bindings_capped(payload, limits).unwrap().len(), 2);
+        }
+
+        #[test]
+        fn payload_byte_cap_rejects_oversize_as_too_large() {
+            let payload = "s=<http://ex/alice>"; // 19 bytes
+            let limits = BindingLimits {
+                max_mappings: 0,
+                max_payload_bytes: 10,
+            };
+            let err = parse_bindings_capped(payload, limits).unwrap_err();
+            assert!(matches!(err, BindingError::TooLarge(_)), "{err:?}");
+            assert!(err.to_string().contains("brtpf-max-values-bytes"), "{err}");
+            // A payload exactly at the byte cap is accepted.
+            let ok = BindingLimits {
+                max_mappings: 0,
+                max_payload_bytes: payload.len(),
+            };
+            assert_eq!(parse_bindings_capped(payload, ok).unwrap().len(), 1);
+        }
+
+        #[test]
+        fn byte_cap_is_checked_before_parsing_so_oversize_garbage_is_413_not_400() {
+            // A payload that is BOTH oversize AND malformed is reported as 413 (TooLarge), because
+            // the byte cap is enforced before any line is parsed — we never parse over-cap input.
+            let garbage = "this is not a valid binding payload at all";
+            let limits = BindingLimits {
+                max_mappings: 0,
+                max_payload_bytes: 5,
+            };
+            let err = parse_bindings_capped(garbage, limits).unwrap_err();
+            assert!(matches!(err, BindingError::TooLarge(_)), "{err:?}");
+        }
+
+        #[test]
+        fn malformed_under_caps_is_still_malformed_not_too_large() {
+            // Within both caps, a malformed pair is Malformed (→ 400), not TooLarge (→ 413).
+            let limits = BindingLimits {
+                max_mappings: 100,
+                max_payload_bytes: 1024,
+            };
+            let err = parse_bindings_capped("bogus=<http://ex/x>", limits).unwrap_err();
+            assert!(matches!(err, BindingError::Malformed(_)), "{err:?}");
+        }
+
+        #[test]
+        fn too_large_message_does_not_echo_the_payload() {
+            // The TooLarge message must not leak any caller-supplied term (same no-echo posture as
+            // the malformed-term path) — it names only the cap.
+            const SENTINEL: &str = "brtpf_secret_sentinel";
+            let payload = format!("s=<http://ex/{SENTINEL}>");
+            let limits = BindingLimits {
+                max_mappings: 0,
+                max_payload_bytes: 5,
+            };
+            let err = parse_bindings_capped(&payload, limits).unwrap_err();
+            assert!(!err.to_string().contains(SENTINEL), "leaked payload: {err}");
         }
     }
 }

--- a/crates/sparq-server/tests/tpf.rs
+++ b/crates/sparq-server/tests/tpf.rs
@@ -245,7 +245,10 @@ async fn malformed_term_does_not_echo_input() {
         .unwrap();
     assert_eq!(resp.status(), 400);
     let body = resp.text().await.unwrap();
-    assert!(body.starts_with("{\"error\":"), "structured JSON error, got: {body}");
+    assert!(
+        body.starts_with("{\"error\":"),
+        "structured JSON error, got: {body}"
+    );
     assert!(
         !body.contains(SENTINEL),
         "TPF term parse error echoed caller input: {body}"
@@ -278,7 +281,10 @@ async fn fragment_carries_first_and_last_paging_controls() {
         "fragment must link hydra:last: {body}"
     );
     // first → page 0; with 7 triples in one default page, last is also page 0.
-    assert!(body.contains("page=0"), "first/last should reference page 0: {body}");
+    assert!(
+        body.contains("page=0"),
+        "first/last should reference page 0: {body}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -359,7 +365,10 @@ async fn brtpf_empty_values_is_plain_tpf() {
         .unwrap();
     assert_eq!(resp.status(), 200);
     let body = resp.text().await.unwrap();
-    assert!(body.contains("totalItems> \"2\""), "unrestricted count: {body}");
+    assert!(
+        body.contains("totalItems> \"2\""),
+        "unrestricted count: {body}"
+    );
 }
 
 #[cfg(feature = "brtpf")]
@@ -377,9 +386,135 @@ async fn brtpf_malformed_bindings_is_400_and_no_echo() {
         .unwrap();
     assert_eq!(resp.status(), 400);
     let body = resp.text().await.unwrap();
-    assert!(body.starts_with("{\"error\":"), "structured JSON error: {body}");
+    assert!(
+        body.starts_with("{\"error\":"),
+        "structured JSON error: {body}"
+    );
     assert!(
         !body.contains(SENTINEL),
         "brTPF binding parse error echoed caller input: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-r74h — brTPF binding-set DoS caps (mapping count + payload bytes), enforced
+// independently of --max-body-bytes and refusing 413 (not 400) so a client can distinguish
+// "too large" from "malformed". Only with the `brtpf` feature.
+// ---------------------------------------------------------------------------
+
+/// Boots a TPF-on server with explicit brTPF binding-set caps (0 = disabled).
+#[cfg(feature = "brtpf")]
+async fn spawn_with_caps(max_bindings: usize, max_values_bytes: usize) -> String {
+    let graph = Graph::load_str(DATA, "turtle").unwrap();
+    let config = ServerConfig {
+        tpf: true,
+        brtpf_max_bindings: max_bindings,
+        brtpf_max_values_bytes: max_values_bytes,
+        ..ServerConfig::default()
+    };
+    let app = router(AppState::with_config(graph, config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+#[cfg(feature = "brtpf")]
+#[tokio::test]
+async fn brtpf_too_many_mappings_is_413() {
+    // Cap of 2 mappings; POST 3 → 413 (not 400 — the set is well-formed, just too large).
+    let base = spawn_with_caps(2, 0).await;
+    let resp = client()
+        .post(format!("{base}/tpf"))
+        .query(&[("predicate", "<http://ex/knows>")])
+        .body("s=<http://ex/a>\ns=<http://ex/b>\ns=<http://ex/c>")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 413);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.starts_with("{\"error\":"),
+        "structured JSON error: {body}"
+    );
+    // The 413 message names the cap knob, so a client/operator knows what to change.
+    assert!(body.contains("brtpf-max-bindings"), "{body}");
+}
+
+#[cfg(feature = "brtpf")]
+#[tokio::test]
+async fn brtpf_mappings_at_the_cap_succeed() {
+    // Exactly at the cap is accepted (boundary): 2 mappings under a cap of 2 → 200.
+    let base = spawn_with_caps(2, 0).await;
+    let resp = client()
+        .post(format!("{base}/tpf"))
+        .query(&[("predicate", "<http://ex/knows>")])
+        .header("Accept", "application/n-triples")
+        .body("s=<http://ex/alice>\ns=<http://ex/carol>")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("totalItems> \"2\""), "{body}");
+}
+
+#[cfg(feature = "brtpf")]
+#[tokio::test]
+async fn brtpf_values_query_string_payload_byte_cap_is_413() {
+    // The `values` query-string carrier is NOT a body, so --max-body-bytes never bounds it; only
+    // --brtpf-max-values-bytes does. A 10-byte payload cap rejects a longer GET `values`.
+    let base = spawn_with_caps(0, 10).await;
+    let resp = client()
+        .get(format!("{base}/tpf"))
+        .query(&[
+            ("predicate", "<http://ex/knows>"),
+            ("values", "s=<http://ex/carol>"), // > 10 bytes
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 413);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("brtpf-max-values-bytes"), "{body}");
+}
+
+#[cfg(feature = "brtpf")]
+#[tokio::test]
+async fn brtpf_caps_disabled_with_zero_allow_a_large_set() {
+    // 0 on both caps disables them — a set larger than the production defaults is accepted.
+    let base = spawn_with_caps(0, 0).await;
+    let resp = client()
+        .post(format!("{base}/tpf"))
+        .query(&[("predicate", "<http://ex/knows>")])
+        .header("Accept", "application/n-triples")
+        .body("s=<http://ex/alice>\ns=<http://ex/carol>")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("totalItems> \"2\""), "{body}");
+}
+
+#[cfg(feature = "brtpf")]
+#[tokio::test]
+async fn brtpf_413_payload_message_does_not_echo_input() {
+    // The 413 body names only the cap, never the caller's payload (no info-leak / no echo).
+    const SENTINEL: &str = "brtpf_dos_secret_sentinel";
+    let base = spawn_with_caps(0, 5).await;
+    let resp = client()
+        .post(format!("{base}/tpf"))
+        .body(format!("s=<http://ex/{SENTINEL}>"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 413);
+    let body = resp.text().await.unwrap();
+    assert!(
+        !body.contains(SENTINEL),
+        "413 cap message echoed caller input: {body}"
     );
 }

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -475,6 +475,18 @@ re-fetching the whole pattern once per binding.
   `#[cfg]`-stripped, so a stray `values` parameter is just an ignored unknown parameter (plain
   TPF). Still governed by the same `--tpf` runtime flag and read-auth (`POST /tpf` is a READ — it
   returns a fragment, it never writes).
+- **DoS caps on the binding set (`sq-r74h`).** The brTPF fragment runs ONE index scan per
+  attached mapping (`tpf::evaluate_brtpf`), so the per-request cost is super-linear in the mapping
+  **count**, not the payload **bytes** — and `--max-body-bytes` bounds the count only transitively
+  (a 1 MiB body of `s=<a>`-sized mappings is ~150k scans) and does NOT cover the `values`
+  **query-string** carrier of a `GET /tpf` at all (it is a body limit). Two dedicated, ON-by-default
+  caps close that: `--brtpf-max-bindings` (default `1024`) bounds the mapping count, and
+  `--brtpf-max-values-bytes` (default `1 MiB`) bounds the raw `values` payload bytes — enforced
+  BEFORE any parse/index work. A breach is a `413` (the same refusal class as `--max-body-bytes`,
+  distinct from the malformed-payload `400`); the message names the cap, never the caller's input
+  (no echo). `0` disables either cap. The pure parser is `tpf::parse_bindings_capped(payload,
+  tpf::BindingLimits { max_mappings, max_payload_bytes })`, returning `tpf::BindingError::{Malformed
+  → 400, TooLarge → 413}`.
 
 ```sh
 cargo run -p sparq-server --features brtpf -- data.ttl --tpf
@@ -528,6 +540,8 @@ env overrides the default.
 | `--time-travel-max-age SECS` | `SPARQ_TIME_TRAVEL_MAX_AGE` | off | (feature) age-out window |
 | `--federation-descriptors` | `SPARQ_FEDERATION_DESCRIPTORS` | off | (feature `federation-descriptors`) serve a VoID at `/.well-known/void` + a SPARQL Service Description on `GET /sparql` with no query — see "Federation discovery" |
 | `--tpf` | `SPARQ_TPF` | off | (feature `tpf`) serve a Triple Pattern Fragments / LDF source endpoint at `GET /tpf?subject=&predicate=&object=` (paged, full Hydra paging incl. `first`/`last`, read-only); same flag also serves brTPF bind-restricted fragments (`values` param / `POST` body) when built with the `brtpf` feature — see "Triple Pattern Fragments" |
+| `--brtpf-max-bindings N` | `SPARQ_BRTPF_MAX_BINDINGS` | `1024` (`0`=off) | (feature `brtpf`) **DoS cap on the brTPF binding-set mapping COUNT** — one index scan per mapping, so cost is super-linear in the count, not the bytes → `413` (`sq-r74h`) |
+| `--brtpf-max-values-bytes N` | `SPARQ_BRTPF_MAX_VALUES_BYTES` | `1048576` (`0`=off) | (feature `brtpf`) **DoS cap on the raw brTPF `values` payload BYTES** — bounds the GET query-string carrier that `--max-body-bytes` never sees → `413` (`sq-r74h`) |
 | `--audit-log` | `SPARQ_AUDIT_LOG` | off | (feature `audit-log`) per-query **access audit log** — see "Access audit log" |
 | `--access-audit <file\|stderr>` | `SPARQ_ACCESS_AUDIT` | off | (feature `access-audit`) richer **structured access-audit sink** (typed JSON-Lines: actor / action / resource / decision+basis / ts / fingerprint) — see "Structured access-audit sink" |
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change by an agent operated by @jeswr. Implements bead **sq-r74h** (a `sq-dxhb` follow-up). Marked `[OPUS-4.8]` for re-review when Fable returns.

## Why

`--max-body-bytes` (the HTTP body limit) does **not** adequately bound a brTPF binding set:

- **The `values` carrier is not always a body.** A `GET /tpf?values=…` carries the binding set in the **query string**, which a body limit never sees — so on the GET path the set is effectively unbounded.
- **Cost is super-linear in the mapping COUNT, not the bytes.** `tpf::evaluate_brtpf` runs **one index scan per attached mapping** and unions the rows into a `BTreeSet`. N tiny mappings (each a handful of bytes, well under any byte limit) still cost N scans + an O(result) set — a 1 MiB POST body of `s=<a>`-sized mappings is ~150k scans. A byte limit bounds that only transitively and far too loosely.

## What

Two dedicated, **ON-by-default** DoS caps on the brTPF binding set, enforced **before any parse/index work**:

| Flag | Env | Default | Effect |
| --- | --- | --- | --- |
| `--brtpf-max-bindings N` | `SPARQ_BRTPF_MAX_BINDINGS` | `1024` (`0`=off) | cap on the mapping **count** → `413` |
| `--brtpf-max-values-bytes N` | `SPARQ_BRTPF_MAX_VALUES_BYTES` | `1048576` (`0`=off) | cap on the raw `values` payload **bytes** → `413` |

- A breach is a **`413`** (the same refusal class as `--max-body-bytes`), kept **distinct from** the malformed-payload **`400`** so a client can tell "too large" from "garbage". The 413 message names the cap knob, **never** the caller's input (same no-echo / info-leak posture as the existing term-parse path).
- The byte cap is checked **first**, on the raw length, before any line is parsed — so an over-cap payload is rejected without parsing it (an oversize-and-malformed payload reports as `413`, the cheaper earlier refusal).
- New pure surface in the **public `tpf` module**: `parse_bindings_capped(payload, BindingLimits { max_mappings, max_payload_bytes })` → `Result<Vec<Binding>, BindingError::{Malformed → 400, TooLarge → 413}>`. `parse_bindings` now delegates to it with `BindingLimits::UNLIMITED` (back-compat, can only fail `Malformed`).

## Scope / safety

- **Fully `brtpf`-feature-gated.** Config fields, env, CLI flags, the startup-log line and the handler wiring are all `#[cfg(feature = "brtpf")]`; a `tpf`-only or featureless build is **byte-identical** to before. `sparq-core` / `sparq-engine` are untouched.
- `0` on either cap disables it (the historical uncapped behaviour, for an operator who wants it).

## Tests

- **Unit** (`tpf.rs`): count + byte boundary (exactly-at-cap accepted, cap+1 refused), empty-μ₀ mappings don't consume the count cap, `413`-before-`400` ordering, malformed-under-caps stays `Malformed`, and the `TooLarge` message does not echo a sentinel payload.
- **e2e** (`tests/tpf.rs`): `POST` over-count → `413`, at-cap → `200`, the **GET `values` query-string** byte cap → `413` (the carrier `--max-body-bytes` cannot see), `0`-disables, and a no-echo `413` check.

## Gate

`cargo build` + `clippy --all-targets -D warnings` + tests all pass in **three** feature states (default / `tpf` / `brtpf`); `rustfmt --check` on the changed files; privacy-claims gate OK; G2 public-api→SKILL.md updated (README + `http-server` SKILL flag table + brTPF section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)