### PR TITLE
feat(site): REPL preserves named graphs (GRAPH) on dataset upload (sq-17nw)

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -12,7 +12,8 @@
     "prebuild": "node scripts/sync-wasm.mjs && node scripts/sync-benchmarks.mjs && node scripts/build-papers.mjs",
     "build": "next build",
     "start": "npx --yes serve out",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:unit": "node --import ./test-support/register-ts.mjs --test test/"
   },
   "dependencies": {
     "@aztec/bb.js": "5.0.0-nightly.20260324",

--- a/site/src/components/repl-datasets.tsx
+++ b/site/src/components/repl-datasets.tsx
@@ -28,6 +28,7 @@ import {
   type SparqlResults,
   type WasmStore,
 } from "@/lib/sparq-wasm";
+import { ALL_QUADS_BODY } from "@/lib/repl-dataset";
 import { BUILTIN_DATASETS } from "@/data/sample-graph";
 
 /** What's currently loaded into the REPL store, for the viewer's heading. */
@@ -36,8 +37,9 @@ export interface ActiveDataset {
   description: string;
 }
 
-const ALL_TRIPLES_QUERY =
-  "SELECT ?s ?p ?o WHERE { ?s ?p ?o } ORDER BY ?s ?p ?o";
+// [OPUS-4.8] sq-17nw — enumerate the WHOLE dataset (default graph + every named graph)
+// so the viewer shows named-graph content too; default-graph rows leave ?g unbound.
+const ALL_QUADS_QUERY = `SELECT ?s ?p ?o ?g WHERE { ${ALL_QUADS_BODY} } ORDER BY ?g ?s ?p ?o`;
 
 // Formats the wasm engine's `load`/`loadDataset` accept, keyed by the file extension
 // or user choice. The engine takes a single format string per the lib.rs docs.
@@ -352,11 +354,11 @@ export function DatasetViewer({
   );
   const [error, setError] = React.useState<string | null>(null);
 
-  // Re-read the triples whenever the dialog opens against the current store.
+  // Re-read the quads whenever the dialog opens against the current store.
   React.useEffect(() => {
     if (!open || !store) return;
     try {
-      const parsed = JSON.parse(store.query(ALL_TRIPLES_QUERY)) as SparqlResults;
+      const parsed = JSON.parse(store.query(ALL_QUADS_QUERY)) as SparqlResults;
       setRows(parsed.results.bindings);
       setError(null);
     } catch (e) {
@@ -365,13 +367,18 @@ export function DatasetViewer({
     }
   }, [open, store]);
 
-  const ntriples = React.useMemo(
+  // Whether ANY row is in a named graph — drives the optional "graph" column / the
+  // N-Quads (vs N-Triples) text view, so a plain triple dataset stays unchanged.
+  const hasGraphs = React.useMemo(() => rows.some((r) => r.g), [rows]);
+
+  // Default-graph rows render as triples; named-graph rows render as quads.
+  const serialised = React.useMemo(
     () =>
       rows
-        .map(
-          (r) =>
-            `${formatTerm(r.s)} ${formatTerm(r.p)} ${formatTerm(r.o)} .`,
-        )
+        .map((r) => {
+          const spo = `${formatTerm(r.s)} ${formatTerm(r.p)} ${formatTerm(r.o)}`;
+          return r.g ? `${spo} ${formatTerm(r.g)} .` : `${spo} .`;
+        })
         .join("\n"),
     [rows],
   );
@@ -402,7 +409,8 @@ export function DatasetViewer({
             size="sm"
             onClick={() => setView("ntriples")}
           >
-            <FileText className="size-3.5" /> N-Triples
+            <FileText className="size-3.5" />{" "}
+            {hasGraphs ? "N-Quads" : "N-Triples"}
           </Button>
         </div>
 
@@ -422,6 +430,9 @@ export function DatasetViewer({
                       {h}
                     </th>
                   ))}
+                  {hasGraphs && (
+                    <th className="px-3 py-2 font-medium">graph</th>
+                  )}
                 </tr>
               </thead>
               <tbody>
@@ -438,13 +449,19 @@ export function DatasetViewer({
                         {formatTerm(r[k])}
                       </td>
                     ))}
+                    {hasGraphs && (
+                      <td className="px-3 py-1.5 font-mono text-[12px] break-all text-muted-foreground">
+                        {/* Default-graph rows leave ?g unbound — show a dash. */}
+                        {r.g ? formatTerm(r.g) : "—"}
+                      </td>
+                    )}
                   </tr>
                 ))}
               </tbody>
             </table>
           ) : (
             <pre className="overflow-x-auto p-3 font-mono text-[12px] leading-relaxed">
-              {ntriples}
+              {serialised}
             </pre>
           )}
         </div>

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -15,8 +15,10 @@ import {
 import { cn } from "@/lib/utils";
 import {
   loadSparq,
+  loadIntoStore,
   prewarmSparq,
-  storeToNTriples,
+  storeToNQuads,
+  datasetSize,
   formatTerm,
   type SparqlResults,
   type WasmStore,
@@ -61,9 +63,13 @@ export function Repl() {
   const buildStore = React.useCallback(
     async (text: string, format: string): Promise<WasmStore> => {
       const Store = await loadSparq();
-      const store = Store.load(text, format);
+      // [OPUS-4.8] sq-17nw — route quad formats through loadDataset so uploaded
+      // N-Quads / TriG keep their named graphs (GRAPH ?g) instead of being folded
+      // into the default graph. The badge counts the WHOLE dataset (the wasm
+      // `size` getter counts the default graph only).
+      const store = loadIntoStore(Store, text, format);
       storeRef.current = store;
-      setSize(store.size);
+      setSize(datasetSize(store));
       return store;
     },
     [],
@@ -158,20 +164,21 @@ export function Repl() {
       try {
         const Store = await loadSparq();
         // Parse the incoming doc first so a parse error aborts BEFORE mutating state.
-        const incoming = Store.load(text, format);
+        // [OPUS-4.8] sq-17nw — loadIntoStore keeps named graphs for quad formats.
+        const incoming = loadIntoStore(Store, text, format);
         if (mode === "add" && storeRef.current) {
+          // Merge as N-Quads (default graph + every named graph) and re-load with
+          // loadDataset, so the named graphs of BOTH stores survive the merge.
           const merged =
-            storeToNTriples(storeRef.current) +
-            "\n" +
-            storeToNTriples(incoming);
-          await buildStore(merged, "ntriples");
+            storeToNQuads(storeRef.current) + "\n" + storeToNQuads(incoming);
+          await buildStore(merged, "nquads");
           setActive((a) => ({
             label: `${a.label} + ${label}`,
-            description: `Merged graph (${size ?? 0} + new triples).`,
+            description: `Merged dataset (${size ?? 0} + new triples).`,
           }));
         } else {
           storeRef.current = incoming;
-          setSize(incoming.size);
+          setSize(datasetSize(incoming));
           setActive({
             label,
             description: `Custom ${format} dataset loaded in your tab.`,
@@ -180,7 +187,8 @@ export function Repl() {
         setActiveBuiltinId(null);
         setState({ kind: "idle" });
         toast.success("Dataset loaded", {
-          description: `${label} — ${storeRef.current.size} triples`,
+          // Count the WHOLE dataset (default + named graphs), not just the default.
+          description: `${label} — ${datasetSize(storeRef.current)} triples`,
         });
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e);

--- a/site/src/lib/repl-dataset.ts
+++ b/site/src/lib/repl-dataset.ts
@@ -1,0 +1,97 @@
+// [OPUS-4.8] sq-17nw — pure dataset helpers for the live SPARQL REPL.
+//
+// The REPL used to load EVERY uploaded document with `Store.load(text, format)`,
+// which folds the named graphs of N-Quads / TriG into the default graph — so a
+// `GRAPH <iri> { … }` query against an uploaded dataset returned nothing. These
+// helpers let the REPL instead:
+//   • pick the named-graph-preserving `Store.loadDataset` for the quad formats
+//     (`isDatasetFormat`), and
+//   • serialise a *whole* loaded dataset (default graph + every named graph) back
+//     to N-Quads (`ALL_QUADS_QUERY` + `rowsToNQuads`) so the format-agnostic
+//     "add to current" merge re-loads through `loadDataset` without losing graphs.
+//
+// They are framework-free and side-effect-free (no React, no DOM, no wasm) so they
+// unit-test directly under `node --test`; the engine-level named-graph behaviour is
+// covered by the Rust tests + js/test/store.test.mjs.
+
+import type { SparqlTerm } from "./sparq-wasm";
+
+/** Formats whose payload can carry named graphs (and so need `loadDataset`). */
+const DATASET_FORMATS = new Set(["nquads", "trig"]);
+
+/**
+ * True for the quad-bearing RDF formats (`nquads` / `trig`). Triple-only formats
+ * (`turtle` / `ntriples`) have no named graphs, so the cheaper `Store.load` is both
+ * correct and slightly faster for them.
+ */
+export function isDatasetFormat(format: string): boolean {
+  return DATASET_FORMATS.has(format);
+}
+
+/**
+ * The graph-pattern that matches the WHOLE dataset: the default graph
+ * (`{ ?s ?p ?o }`) UNION every named graph (`GRAPH ?g { ?s ?p ?o }`). Named-graph
+ * solutions additionally bind `?g`; default-graph solutions leave it unbound.
+ * Folding-only `{ ?s ?p ?o }` would miss the named graphs entirely — the bug this
+ * fixes. Reused by the row enumeration and the COUNT-based total-size query.
+ */
+export const ALL_QUADS_BODY = "{ ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } }";
+
+/** A SELECT that enumerates the whole dataset (see {@link ALL_QUADS_BODY}). */
+export const ALL_QUADS_QUERY = `SELECT ?s ?p ?o ?g WHERE { ${ALL_QUADS_BODY} }`;
+
+/** Escapes a literal's lexical form for an N-Quads quoted string (matches the
+ * engine's own serialiser: backslash, double-quote, LF, CR — a raw tab is legal). */
+function escapeLiteral(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r");
+}
+
+const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
+
+/** Serialises one SPARQL-JSON term to its N-Triples / N-Quads token. */
+function termToNT(term: SparqlTerm): string {
+  switch (term.type) {
+    case "uri":
+      return `<${term.value}>`;
+    case "bnode":
+      return `_:${term.value}`;
+    case "literal": {
+      const quoted = `"${escapeLiteral(term.value)}"`;
+      const lang = term["xml:lang"];
+      if (lang) return `${quoted}@${lang}`;
+      if (term.datatype && term.datatype !== XSD_STRING) {
+        return `${quoted}^^<${term.datatype}>`;
+      }
+      return quoted;
+    }
+  }
+}
+
+/** One solution row from {@link ALL_QUADS_QUERY}: bound `s`/`p`/`o`, optional `g`. */
+type QuadRow = {
+  s?: SparqlTerm;
+  p?: SparqlTerm;
+  o?: SparqlTerm;
+  g?: SparqlTerm;
+};
+
+/**
+ * Serialises {@link ALL_QUADS_QUERY} solution rows to an N-Quads document: a triple
+ * line (`s p o .`) when `?g` is unbound (default graph), a quad line
+ * (`s p o g .`) when `?g` is bound (a named graph). Re-loading the result with
+ * `Store.loadDataset(_, "nquads")` reconstructs the dataset with its named graphs
+ * intact. Rows missing any of `s`/`p`/`o` are skipped defensively.
+ */
+export function rowsToNQuads(rows: QuadRow[]): string {
+  const lines: string[] = [];
+  for (const row of rows) {
+    if (!row.s || !row.p || !row.o) continue;
+    const spo = `${termToNT(row.s)} ${termToNT(row.p)} ${termToNT(row.o)}`;
+    lines.push(row.g ? `${spo} ${termToNT(row.g)} .` : `${spo} .`);
+  }
+  return lines.join("\n");
+}

--- a/site/src/lib/sparq-wasm.ts
+++ b/site/src/lib/sparq-wasm.ts
@@ -8,6 +8,13 @@
 // the wasm bytes' URL explicitly, prefixed with the Pages basePath. This is genuinely
 // live: every query runs the real Rust engine compiled to wasm, in your tab.
 
+import {
+  ALL_QUADS_BODY,
+  ALL_QUADS_QUERY,
+  isDatasetFormat,
+  rowsToNQuads,
+} from "./repl-dataset";
+
 export interface WasmStore {
   readonly size: number;
   query(sparql: string): string; // SPARQL 1.1 JSON results document
@@ -17,18 +24,63 @@ export interface WasmStore {
 interface WasmModule {
   default: (opts?: { module_or_path: string | URL }) => Promise<unknown>;
   Store: {
+    /** Loads RDF, FOLDING any named graphs into the default graph. */
     load(text: string, format: string): WasmStore;
+    /** Loads RDF, PRESERVING named graphs (N-Quads / TriG) as separate graphs. */
     loadDataset(text: string, format: string): WasmStore;
   };
 }
 
 /**
- * [OPUS-4.8] Serialises a store's whole default graph to N-Triples (a valid Turtle
- * subset) via a CONSTRUCT. Used to merge two graphs format-agnostically when the user
- * chooses "add to current": concatenate both stores' N-Triples and re-load as ntriples.
+ * [OPUS-4.8] sq-17nw — parses RDF into a store, PRESERVING named graphs for the
+ * quad-bearing formats (N-Quads / TriG) by routing them through `loadDataset` instead
+ * of `load` (which folds every named graph into the default graph). Triple-only formats
+ * (`turtle` / `ntriples`) carry no named graphs, so the cheaper `load` is used. This is
+ * the single load entry point the REPL uses for every source (default, picker, upload,
+ * URL, and the re-load step of a merge).
  */
-export function storeToNTriples(store: WasmStore): string {
-  return store.queryQuads("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }");
+export function loadIntoStore(
+  Store: WasmModule["Store"],
+  text: string,
+  format: string,
+): WasmStore {
+  return isDatasetFormat(format)
+    ? Store.loadDataset(text, format)
+    : Store.load(text, format);
+}
+
+/**
+ * [OPUS-4.8] sq-17nw — serialises a store's WHOLE dataset (default graph PLUS every
+ * named graph) to N-Quads, by selecting {@link ALL_QUADS_QUERY} and emitting one
+ * triple/quad line per solution. Used to merge two stores format-agnostically when the
+ * user chooses "add to current": concatenate both stores' N-Quads and re-load with
+ * `Store.loadDataset(_, "nquads")` so the named graphs survive the round-trip. (The
+ * previous `CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }` saw only the default graph, so
+ * merging silently dropped every named graph — the folding bug this fixes.)
+ */
+export function storeToNQuads(store: WasmStore): string {
+  const json = store.query(ALL_QUADS_QUERY);
+  const parsed = JSON.parse(json) as SparqlResults;
+  return rowsToNQuads(parsed.results.bindings);
+}
+
+/**
+ * [OPUS-4.8] sq-17nw — the TOTAL number of triples in a store across the default graph
+ * and all named graphs. The wasm `store.size` getter counts the DEFAULT graph only
+ * (see `loadDataset`'s doc), so it under-reports a dataset; this counts the whole thing
+ * via {@link ALL_QUADS_QUERY} for an accurate "N triples" badge. Falls back to
+ * `store.size` if the count query fails for any reason.
+ */
+export function datasetSize(store: WasmStore): number {
+  try {
+    const json = store.query(`SELECT (COUNT(*) AS ?n) WHERE { ${ALL_QUADS_BODY} }`);
+    const parsed = JSON.parse(json) as SparqlResults;
+    const n = parsed.results.bindings[0]?.n?.value;
+    const parsedN = n != null ? Number.parseInt(n, 10) : NaN;
+    return Number.isFinite(parsedN) ? parsedN : store.size;
+  } catch {
+    return store.size;
+  }
 }
 
 let modulePromise: Promise<WasmModule> | null = null;

--- a/site/test-support/register-ts.mjs
+++ b/site/test-support/register-ts.mjs
@@ -1,0 +1,8 @@
+// [OPUS-4.8] sq-17nw — registers the on-the-fly TypeScript ESM loader (ts-loader.mjs)
+// so `node --test` can import the site's `.ts` helper modules directly. Used by the
+// `test:unit` npm script; keeps the unit-test path build-free (no vitest/jest, no
+// separate tsc emit) — type-CHECKING remains the job of `next build`.
+import { register } from "node:module";
+import { pathToFileURL } from "node:url";
+
+register("./ts-loader.mjs", pathToFileURL(`${import.meta.dirname}/`));

--- a/site/test-support/ts-loader.mjs
+++ b/site/test-support/ts-loader.mjs
@@ -1,0 +1,25 @@
+// [OPUS-4.8] sq-17nw — a minimal ESM hook that transpiles the site's `.ts`
+// modules on the fly with the already-installed `typescript` devDependency, so
+// `node --test` can import and unit-test pure helpers WITHOUT pulling in a heavy
+// test runner (vitest/jest) or a separate build step. Type-erasure only; no
+// type-checking (that is the job of `next build`).
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+export async function load(url, context, next) {
+  if (url.endsWith('.ts') && !url.endsWith('.d.ts')) {
+    const source = await readFile(fileURLToPath(url), 'utf8');
+    const { outputText } = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        isolatedModules: true,
+        verbatimModuleSyntax: false,
+      },
+      fileName: fileURLToPath(url),
+    });
+    return { format: 'module', source: outputText, shortCircuit: true };
+  }
+  return next(url, context);
+}

--- a/site/test/repl-dataset.test.mjs
+++ b/site/test/repl-dataset.test.mjs
@@ -1,0 +1,123 @@
+// [OPUS-4.8] sq-17nw — unit tests for the REPL dataset helpers that make the live
+// SPARQL REPL PRESERVE named graphs (GRAPH) on upload instead of folding everything
+// into the default graph. These cover the pure, framework-free decision + serialisation
+// logic; the engine-level named-graph behaviour is already proven by the Rust tests and
+// js/test/store.test.mjs (loadDataset). Run via `npm run test:unit` (a node:test process
+// with the in-repo TypeScript ESM loader).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isDatasetFormat,
+  ALL_QUADS_QUERY,
+  rowsToNQuads,
+} from "../src/lib/repl-dataset.ts";
+
+test("isDatasetFormat is true exactly for the quad-bearing formats", () => {
+  // Quad formats carry named graphs and must be loaded with loadDataset.
+  assert.equal(isDatasetFormat("nquads"), true);
+  assert.equal(isDatasetFormat("trig"), true);
+  // Triple-only formats have no named graphs; load() is correct (and cheaper).
+  assert.equal(isDatasetFormat("turtle"), false);
+  assert.equal(isDatasetFormat("ntriples"), false);
+  // Unknown / empty defaults to the non-dataset path.
+  assert.equal(isDatasetFormat("nt"), false);
+  assert.equal(isDatasetFormat(""), false);
+});
+
+test("ALL_QUADS_QUERY spans the default graph AND every named graph", () => {
+  // A UNION of the default-graph pattern and the GRAPH ?g pattern: the only way to
+  // enumerate the WHOLE dataset (the default-graph-only `{ ?s ?p ?o }` misses named
+  // graphs, which is exactly the folding bug this bead fixes).
+  assert.match(ALL_QUADS_QUERY, /GRAPH \?g/);
+  assert.match(ALL_QUADS_QUERY, /UNION/);
+});
+
+test("rowsToNQuads emits a triple line for default-graph rows (no ?g)", () => {
+  const rows = [
+    {
+      s: { type: "uri", value: "http://ex/a" },
+      p: { type: "uri", value: "http://ex/p" },
+      o: { type: "literal", value: "default" },
+    },
+  ];
+  assert.equal(
+    rowsToNQuads(rows),
+    '<http://ex/a> <http://ex/p> "default" .',
+  );
+});
+
+test("rowsToNQuads emits a quad line (with the graph) for named-graph rows", () => {
+  const rows = [
+    {
+      s: { type: "uri", value: "http://ex/a" },
+      p: { type: "uri", value: "http://ex/p" },
+      o: { type: "literal", value: "in-g1" },
+      g: { type: "uri", value: "http://ex/g1" },
+    },
+  ];
+  assert.equal(
+    rowsToNQuads(rows),
+    '<http://ex/a> <http://ex/p> "in-g1" <http://ex/g1> .',
+  );
+});
+
+test("rowsToNQuads round-trips a mixed dataset, preserving the named graph", () => {
+  const rows = [
+    {
+      s: { type: "uri", value: "http://ex/d" },
+      p: { type: "uri", value: "http://ex/p" },
+      o: { type: "literal", value: "default" },
+    },
+    {
+      s: { type: "uri", value: "http://ex/a" },
+      p: { type: "uri", value: "http://ex/p" },
+      o: { type: "literal", value: "in-g1" },
+      g: { type: "uri", value: "http://ex/g1" },
+    },
+  ];
+  const nq = rowsToNQuads(rows);
+  // The default-graph triple stays a triple; the named-graph triple keeps <g1>.
+  assert.equal(
+    nq,
+    '<http://ex/d> <http://ex/p> "default" .\n' +
+      '<http://ex/a> <http://ex/p> "in-g1" <http://ex/g1> .',
+  );
+});
+
+test("rowsToNQuads encodes term kinds (IRI / bnode / literal w/ datatype & lang)", () => {
+  const rows = [
+    {
+      s: { type: "bnode", value: "b0" },
+      p: { type: "uri", value: "http://ex/n" },
+      o: { type: "literal", value: "42", datatype: "http://www.w3.org/2001/XMLSchema#integer" },
+    },
+    {
+      s: { type: "uri", value: "http://ex/x" },
+      p: { type: "uri", value: "http://ex/label" },
+      o: { type: "literal", value: "hi", "xml:lang": "en" },
+    },
+  ];
+  assert.equal(
+    rowsToNQuads(rows),
+    '_:b0 <http://ex/n> "42"^^<http://www.w3.org/2001/XMLSchema#integer> .\n' +
+      '<http://ex/x> <http://ex/label> "hi"@en .',
+  );
+});
+
+test("rowsToNQuads escapes backslash, quote, CR and LF in literals", () => {
+  // Mirrors the engine's own N-Triples escaping (js/src/sparql.ts escapeLiteral):
+  // backslash, double-quote, LF and CR. A raw tab is legal inside a quoted literal
+  // and is left as-is, so the re-parse is byte-faithful.
+  const rows = [
+    {
+      s: { type: "uri", value: "http://ex/x" },
+      p: { type: "uri", value: "http://ex/p" },
+      o: { type: "literal", value: 'a "q"\nlf\r cr \\ bs' },
+    },
+  ];
+  assert.equal(
+    rowsToNQuads(rows),
+    '<http://ex/x> <http://ex/p> "a \\"q\\"\\nlf\\r cr \\\\ bs" .',
+  );
+});


### PR DESCRIPTION
> 🤖 SPARQ agent — automated change. @jeswr runs several agents on this account; this PR is from the agent working bead **sq-17nw**.

## What & why

The live SPARQL REPL on the site loaded **every** uploaded document with `Store.load(text, format)`, which **folds the named graphs** of N-Quads / TriG into the default graph. So a `GRAPH <iri> { … }` / `GRAPH ?g { … }` query against an uploaded dataset matched **nothing** — directly contradicting the data-formats surface copy that already promised *"named-graph preservation for the quad formats"*.

This routes the quad-bearing formats (`nquads` / `trig`) through the engine's existing `Store.loadDataset`, which keeps each named graph as its own sub-graph. Triple-only formats (`turtle` / `ntriples`) keep the cheaper `load` (they carry no named graphs).

## Changes

- **`src/lib/repl-dataset.ts`** (new) — pure, framework-free helpers: `isDatasetFormat`, `ALL_QUADS_BODY` / `ALL_QUADS_QUERY` (default graph `UNION` every `GRAPH ?g`), and `rowsToNQuads` (SPARQL-JSON solution rows → N-Quads, matching the engine's own escaping).
- **`src/lib/sparq-wasm.ts`** — `loadIntoStore` (the single load entry point; dispatches `load` vs `loadDataset` by format), `storeToNQuads` (serialises the **whole** dataset, default + named, replacing the default-graph-only `CONSTRUCT { ?s ?p ?o }`), and `datasetSize` (total triple count via `COUNT(*)` over default+named — the wasm `size` getter reports the default graph only).
- **`src/components/repl.tsx`** — `buildStore` / `loadText` use the new helpers; **"add to current"** now merges via N-Quads and re-loads with `loadDataset`, so **both** stores' named graphs survive; the triple-count badge / load toast count the whole dataset.
- **`src/components/repl-datasets.tsx`** — the dataset viewer enumerates the whole dataset and shows an optional **graph** column + an **N-Quads** text view when named graphs are present (a plain triple dataset renders unchanged as N-Triples).

## Tests & gate

- New `node --test` unit suite (`test/repl-dataset.test.mjs`) for the pure helpers, run **build-free** via an on-the-fly TypeScript ESM loader (`npm run test:unit`). The engine-level named-graph behaviour is already covered by the Rust tests + `js/test/store.test.mjs`.
- Gated: `npm run test:unit` (7/7) + `tsc --noEmit` + `next lint` (clean) + full `next build` (static export OK) + the repo privacy-claims gate (OK).
- **End-to-end verified against the real wasm engine**: `loadDataset` preserves named graphs; the old `load` path folds them (confirming the bug); the N-Quads merge round-trips **both** stores' named graphs; plain Turtle is unchanged.

## Scope / honesty

Site-only change. No published library public API changed — `loadDataset` already existed and is already documented in `skills/javascript-wasm/SKILL.md` and `skills/data-formats/SKILL.md`; this only makes the **site REPL** consume it for quad formats, so no SKILL edit is required (G2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
