### PR TITLE
ci(flow-on): fix G6 asymmetric flag extractor (recognize backtick-documented flags) [OPUS-4.8]

### DIFF
--- a/scripts/check-config-documented.py
+++ b/scripts/check-config-documented.py
@@ -34,8 +34,21 @@
 #     hand-rolled arg matchers in crates/sparq-{cli,server}/src/main.rs. Short flags
 #     (`-h`) and the universal `--help` are NOT user config and are ignored.
 #   * an environment variable: a `SPARQ_[A-Z0-9_]+` token.
-# Both forms are extracted identically from code-diff lines and from docs (so the
-# "documented?" test is a pure token-membership check — no format coupling).
+#
+# CODE-SIDE vs DOC-SIDE extraction (the formats DIFFER, so the extractor MUST too):
+# Rust source writes a flag as a DOUBLE-QUOTED literal (`"--addr"`) — that is what the
+# arg matcher compares against. But the READMEs / SKILL.md document a flag in markdown
+# BACKTICKS (`--addr`) or bare in prose, never in double quotes. A single
+# double-quote-only extractor applied to both sides therefore recognises EVERY
+# code-defined flag and ZERO documented flags, so it false-positives even on its own
+# compliant path (add a flag + document it in backticks → still reported undocumented).
+# Env vars don't have this skew — `SPARQ_*` is written the same way (no quotes) on both
+# sides — so the env half is quote-agnostic on both sides and stays as-is.
+# Fix: code_knob_tokens() recognises double-quoted flags (how code defines them);
+# doc_knob_tokens() recognises backtick-started / double-quoted / bare-prose flags (how
+# docs write them, incl. `--flag <ARG>` / `--flag*` / `--flag N`). Both extract
+# `SPARQ_*` identically. The "documented?" test is then a symmetric token-membership
+# check across the two format conventions.
 #
 # SCOPE: only crates/sparq-cli/src/** and crates/sparq-server/src/** are config
 # surfaces (per the design's "(sparq-cli, sparq-server)"). A new flag/env added in
@@ -89,10 +102,30 @@ SKILL_SUFFIX = "SKILL.md"
 # Escape-hatch label (design §2.1).
 CONFIG_INTERNAL_LABEL = "config-internal"
 
-# A long CLI flag literal: a double-quoted "--lower-kebab" token. The hand-rolled
-# matchers in main.rs compare argv against exactly these literals.
-_FLAG_RE = re.compile(r'"(--[a-z][a-z0-9-]*)"')
-# An environment variable: SPARQ_ + uppercase/underscore/digits.
+# CODE-side long CLI flag literal: a double-quoted "--lower-kebab" token. The
+# hand-rolled matchers in crates/sparq-{cli,server}/src/main.rs compare argv against
+# exactly these double-quoted literals.
+_CODE_FLAG_RE = re.compile(r'"(--[a-z][a-z0-9-]*)"')
+# DOC-side long CLI flag: how a flag is actually WRITTEN DOWN in markdown — at the
+# start of a backtick code span (the dominant convention: `--addr`, but also
+# `--access-audit <file|stderr>` with an arg placeholder, `--max-subscriptions*` with
+# a glob, `--max-subscriptions N` in a SKILL table cell), in double quotes ("--addr"),
+# or bare in prose (--addr at a word boundary). A code-defined flag is "documented" if
+# its token appears in any of these doc forms.
+#   * The backtick arm anchors on the OPENING backtick and captures only the flag
+#     token, NOT the whole span — so `--flag ARG`, `--flag*`, `--flag=VAL` and bare
+#     `--flag` inside a code span all yield the flag. (`[a-z0-9-]*` is greedy but
+#     stops at the first non-kebab char — space, `*`, `=`, `<`, closing backtick.)
+#   * The bare-prose arm requires `--` to start at a non-word, non-`-`, non-quote,
+#     non-backtick boundary, so it never re-matches the backtick/quote forms or a
+#     mid-token `--` fragment.
+_DOC_FLAG_RE = re.compile(
+    r"`(--[a-z][a-z0-9-]*)"  # start of a backtick span: `--addr  / `--access-audit <…>
+    r'|"(--[a-z][a-z0-9-]*)"'  # double-quoted:           "--addr"
+    r'|(?<![\w`"-])(--[a-z][a-z0-9-]*)\b'  # bare in prose: --addr
+)
+# An environment variable: SPARQ_ + uppercase/underscore/digits. Written identically
+# (no quoting) in both code and docs, so this half is shared verbatim by both sides.
 _ENV_RE = re.compile(r"\bSPARQ_[A-Z0-9_]+\b")
 
 # Flags that are NOT user config knobs (universal help; short -h handled elsewhere).
@@ -153,38 +186,63 @@ def git_diff(base: str) -> tuple[list[str], list[str]]:
     return parse_status_lines(out.splitlines())
 
 
-def knob_tokens(text: str) -> set[str]:
-    """Extract every config-knob token (CLI flags + SPARQ_* env vars) from `text`.
-
-    Used both on code-diff lines (to find what a PR introduces) and on docs (to
-    test whether a knob is documented) — one extractor, so the membership test is
-    format-agnostic."""
-    flags = {f for f in _FLAG_RE.findall(text) if f not in _FLAG_IGNORE}
+def code_knob_tokens(text: str) -> set[str]:
+    """Extract config-knob tokens as a PR INTRODUCES them in code: double-quoted
+    `"--flag"` literals (the form the hand-rolled arg matcher compares against) plus
+    `SPARQ_*` env vars. Used on code-diff lines to find what a PR adds."""
+    flags = {f for f in _CODE_FLAG_RE.findall(text) if f not in _FLAG_IGNORE}
     envs = set(_ENV_RE.findall(text))
     return flags | envs
 
 
-def scan_added_knobs(diff_lines: list[str]) -> set[str]:
+def doc_knob_tokens(text: str) -> set[str]:
+    """Extract config-knob tokens as the DOCS write them down: a flag at the start of
+    a markdown backtick span (`--flag`, `--flag <ARG>`, `--flag*`), in double quotes
+    ("--flag"), or bare in prose (--flag), plus `SPARQ_*` env vars. Used on docs
+    (READMEs / SKILL.md) to test whether a knob is documented. Recognising the
+    backtick form — the dominant convention in the docs — is what makes the gate
+    symmetric: a code-defined double-quoted flag and its backtick-documented
+    counterpart map to the same token."""
+    flags: set[str] = set()
+    for backtick, dquote, prose in _DOC_FLAG_RE.findall(text):
+        tok = backtick or dquote or prose
+        if tok and tok not in _FLAG_IGNORE:
+            flags.add(tok)
+    envs = set(_ENV_RE.findall(text))
+    return flags | envs
+
+
+# Back-compat alias: historically a single `knob_tokens()` served both sides. It is the
+# CODE-side extractor (callers that pass code-diff lines must see double-quoted flags).
+knob_tokens = code_knob_tokens
+
+
+def scan_added_knobs(diff_lines: list[str], extractor=code_knob_tokens) -> set[str]:
     """Return knob tokens NET-added by a unified diff: present on an added (`+`)
     line and NOT on any removed (`-`) line. A pure relocation (same token removed
     once, added once) cancels; a comment that only mentions an unchanged flag is
     inert (no +/- line). File headers ('+++ '/'--- ') are skipped so a path is
-    never mistaken for content."""
+    never mistaken for content.
+
+    `extractor` is the token extractor for the diff's side: code_knob_tokens for a
+    src diff (double-quoted flags) or doc_knob_tokens for a docs diff (backtick /
+    quoted / bare-prose flags). Defaults to the code side."""
     added: set[str] = set()
     removed: set[str] = set()
     for line in diff_lines:
         if line.startswith("+++") or line.startswith("---"):
             continue
         if line.startswith("+"):
-            added |= knob_tokens(line[1:])
+            added |= extractor(line[1:])
         elif line.startswith("-"):
-            removed |= knob_tokens(line[1:])
+            removed |= extractor(line[1:])
     return added - removed
 
 
-def git_added_knobs(path: str, base: str) -> set[str]:
-    """Net-added knob tokens for `path` read from git. Conservative on error
-    (returns empty set — never a CI-only crash)."""
+def git_added_knobs(path: str, base: str, extractor=code_knob_tokens) -> set[str]:
+    """Net-added knob tokens for `path` read from git, using `extractor` for the
+    path's side (code vs docs). Conservative on error (returns empty set — never a
+    CI-only crash)."""
     ref = _normalize_base(base)
     try:
         out = subprocess.run(
@@ -196,7 +254,7 @@ def git_added_knobs(path: str, base: str) -> set[str]:
         ).stdout
     except subprocess.CalledProcessError:  # pragma: no cover - CI-only
         return set()
-    return scan_added_knobs(out.splitlines())
+    return scan_added_knobs(out.splitlines(), extractor)
 
 
 def documented_on_disk() -> set[str]:
@@ -207,12 +265,12 @@ def documented_on_disk() -> set[str]:
     for rel in DOC_READMES:
         p = REPO_ROOT / rel
         try:
-            tokens |= knob_tokens(p.read_text(encoding="utf-8", errors="ignore"))
+            tokens |= doc_knob_tokens(p.read_text(encoding="utf-8", errors="ignore"))
         except OSError:
             continue
     for sk in REPO_ROOT.glob("skills/**/SKILL.md"):
         try:
-            tokens |= knob_tokens(sk.read_text(encoding="utf-8", errors="ignore"))
+            tokens |= doc_knob_tokens(sk.read_text(encoding="utf-8", errors="ignore"))
         except OSError:
             continue
     return tokens
@@ -229,7 +287,7 @@ def git_doc_added_knobs(changed: list[str], base: str) -> set[str]:
     ]
     tokens: set[str] = set()
     for p in docs:
-        tokens |= git_added_knobs(p, base)
+        tokens |= git_added_knobs(p, base, doc_knob_tokens)
     return tokens
 
 

--- a/scripts/tests/test_gates.py
+++ b/scripts/tests/test_gates.py
@@ -397,15 +397,95 @@ class G6Test(unittest.TestCase):
         self.assertEqual(undoc, [])
 
     def test_knob_token_extraction(self):
-        # Flags + env vars are extracted; --help and short flags are NOT knobs;
-        # restricted/struct-field/non-quoted tokens do not leak in.
-        toks = g6.knob_tokens(
+        # CODE-side: flags are extracted from DOUBLE-QUOTED literals (how Rust source
+        # writes them) + env vars; --help and short flags are NOT knobs; a
+        # backtick-wrapped / bare flag is NOT a code token (code never writes those).
+        toks = g6.code_knob_tokens(
             '            "--max-results" => { SPARQ_MAX_RESULTS } "--help" "-h"'
         )
         self.assertIn("--max-results", toks)
         self.assertIn("SPARQ_MAX_RESULTS", toks)
         self.assertNotIn("--help", toks)
         self.assertNotIn("-h", toks)
+        # knob_tokens is the back-compat alias for the code extractor.
+        self.assertEqual(g6.knob_tokens('"--addr"'), {"--addr"})
+        self.assertEqual(g6.code_knob_tokens("`--addr`"), set())  # not a code form
+
+    def test_doc_extractor_recognizes_backtick_flags(self):
+        # THE FIX: docs write a flag in markdown BACKTICKS (`--addr`), the dominant
+        # convention — and also `--flag <ARG>` / `--flag*` / `--flag N`, bare in
+        # prose, and double-quoted. The doc extractor recognises ALL of these (so a
+        # code-defined double-quoted flag matches its backtick-documented form),
+        # while a bare `--` dash fragment and short flags are NOT picked up.
+        self.assertEqual(g6.doc_knob_tokens("set `--addr` to bind"), {"--addr"})
+        self.assertEqual(
+            g6.doc_knob_tokens("`--access-audit <file|stderr>` writes audit"),
+            {"--access-audit"},
+        )
+        self.assertEqual(
+            g6.doc_knob_tokens("`--max-subscriptions*` family, `--max-results N`"),
+            {"--max-subscriptions", "--max-results"},
+        )
+        self.assertEqual(g6.doc_knob_tokens("the --reason flag enables"), {"--reason"})
+        self.assertEqual(g6.doc_knob_tokens('use "--proof" here'), {"--proof"})
+        self.assertEqual(g6.doc_knob_tokens("SPARQ_ADDR is the env"), {"SPARQ_ADDR"})
+        self.assertEqual(g6.doc_knob_tokens("a `git -- pathspec` fence"), set())
+        self.assertNotIn("--help", g6.doc_knob_tokens("`--help` prints usage"))
+
+    def test_code_flag_documented_only_in_backticks_passes(self):
+        # END-TO-END through BOTH real extractors: a flag defined in code as a
+        # double-quoted literal and documented ONLY in markdown backticks must be
+        # recognised as documented (the asymmetric-extractor bug: a quote-only doc
+        # extractor saw 0/29 flags and false-positived on the compliant path).
+        src = "crates/sparq-server/src/main.rs"
+        code_added = g6.scan_added_knobs(['+            "--addr" => addr = next(),'])
+        doc_disk = g6.doc_knob_tokens("Bind address: `--addr <HOST:PORT>` (default …).")
+        self.assertEqual(code_added, {"--addr"})
+        self.assertIn("--addr", doc_disk)  # the two forms map to the same token
+        ok, undoc = g6.evaluate(
+            [src],
+            labels=[],
+            base="main",
+            code_knobs={src: code_added},
+            doc_added=set(),
+            doc_disk=doc_disk,
+        )
+        self.assertTrue(ok)  # backtick-documented flag PASSES
+        self.assertEqual(undoc, [])
+
+    def test_code_flag_not_documented_anywhere_fails(self):
+        # Conversely, a flag in code that no doc surface mentions (in ANY form)
+        # FAILS — the gate is not merely permissive after the fix.
+        src = "crates/sparq-cli/src/main.rs"
+        code_added = g6.scan_added_knobs(['+            "--never-documented" => x,'])
+        doc_disk = g6.doc_knob_tokens("Docs that mention `--addr` and `--reason` only.")
+        ok, undoc = g6.evaluate(
+            [src],
+            labels=[],
+            base="main",
+            code_knobs={src: code_added},
+            doc_added=set(),
+            doc_disk=doc_disk,
+        )
+        self.assertFalse(ok)
+        self.assertEqual([k for k, _ in undoc], ["--never-documented"])
+
+    def test_real_repo_backcatalogue_flags_are_documented(self):
+        # Regression guard against the asymmetric extractor on the REAL tree: every
+        # double-quoted flag literal under the config crates' src must be recognised
+        # as documented by the doc extractor reading the actual READMEs/SKILL.md.
+        # (Pre-fix this was 0/29; the gate false-positived on its own clean tree.)
+        flag_re = g6._CODE_FLAG_RE
+        code_flags: set[str] = set()
+        for crate in ("sparq-cli", "sparq-server"):
+            for rs in (REPO_ROOT / "crates" / crate / "src").rglob("*.rs"):
+                for m in flag_re.findall(rs.read_text(encoding="utf-8", errors="ignore")):
+                    code_flags.add(m)
+        code_flags.discard("--help")
+        documented = g6.documented_on_disk()
+        missing = sorted(code_flags - documented)
+        self.assertGreaterEqual(len(code_flags), 20, "expected the back-catalogue flags")
+        self.assertEqual(missing, [], f"undocumented back-catalogue flags: {missing}")
 
     def test_scan_added_knobs_net_diff(self):
         # A pure relocation (same flag removed once + added once) cancels; a


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change by an agent operating on @jeswr's behalf.

## Why a follow-up to #464

PR #464 (bead **sq-ncvq.9**, gate **G6 new-config/flag→docs**) was flagged **honest=FALSE**: the gate is broken by an **asymmetric flag extractor**. It merged with `_FLAG_RE = '"(--[a-z][a-z0-9-]*)"'` — a single extractor requiring **double quotes**, applied to BOTH code and docs. Rust source writes flags as double-quoted literals (correct), but the READMEs/SKILL.md document flags in markdown **backticks** (`` `--addr` ``). Result: **0 of 29** existing CLI flags were recognized as documented — the gate false-positives on its own primary compliant path (add a flag + document it in backticks → still reported undocumented). Only the 26 `SPARQ_*` env vars worked, because the env regex is quote-agnostic/symmetric.

#464 was already merged before this could be pushed to its branch, so this lands the fix as a follow-up to `main`.

## Fix

Split the single extractor into two **format-aware** halves (`scripts/check-config-documented.py`):

- `code_knob_tokens()` — double-quoted `"--flag"` literals (how code defines them) + `SPARQ_*` (code side unchanged).
- `doc_knob_tokens()` — a flag at the **start of a markdown backtick span** (`` `--addr` ``, and also `` `--access-audit <file|stderr>` ``, `` `--max-subscriptions*` ``, `` `--max-results N` `` table cells), in double quotes, or **bare in prose**, + `SPARQ_*`.

The two doc-reading paths (`documented_on_disk`, `git_doc_added_knobs`) now use the doc extractor; the code-diff scan path keeps the code extractor (`scan_added_knobs`/`git_added_knobs` gain an `extractor` param). `knob_tokens` stays as a back-compat alias for the code extractor. **The env-var half is untouched.**

## Verification (real repo)

- Code flags recognized as documented: **0/29 → 29/29**. The 4 that initially still missed (`--access-audit`, `--max-subscriptions`, `--max-subscriptions-per-conn`, `--time-travel-max-age`) are documented as `` `--flag <ARG>` `` / `` `--flag*` `` — the backtick arm anchors on the opening backtick so these now resolve.
- `python3 scripts/check-config-documented.py --base main` → **PASS, exit 0** (clean back-catalogue; gate runs HARD).
- End-to-end FAIL path: an undocumented `--g6-probe-zzz` flag → **exit 1**; the `config-internal` escape hatch still suppresses → PASS.
- Self-tests: **35 OK** (was 31). New: backtick-flag doc recognition; end-to-end backtick-documented-flag PASS; undocumented-flag FAIL; a real-tree regression guard asserting every double-quoted src flag is documented.
- `python3 -m py_compile` clean (Python 3.12, matching CI). No shell files touched. The `config-documented (G6)` CI job and the ci-summary aggregator are unchanged.

Bead: sq-ncvq.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)