### PR TITLE
style(sparq-serve,sparq-parse): one-shot rustfmt to clear 146 pre-existing diffs (sq-g47l)

### DIFF
--- a/crates/sparq-parse/src/lib.rs
+++ b/crates/sparq-parse/src/lib.rs
@@ -148,7 +148,10 @@ impl CompressedSink {
         CompressedSink {
             codec,
             mode,
-            shared: Arc::new(Shared { ready: Mutex::new(BTreeMap::new()), cv: Condvar::new() }),
+            shared: Arc::new(Shared {
+                ready: Mutex::new(BTreeMap::new()),
+                cv: Condvar::new(),
+            }),
             next_in: 0,
             next_out: 0,
         }
@@ -233,12 +236,22 @@ impl CompressedSink {
 
 /// One-shot convenience: compress a batch of chunks into ordered members/frames.
 /// [`Mode::Parallel`] uses the rayon pool; order is preserved by construction.
-pub fn compress_chunks<S: AsRef<[u8]> + Sync>(chunks: &[S], codec: &Codec, mode: Mode) -> io::Result<Vec<Vec<u8>>> {
+pub fn compress_chunks<S: AsRef<[u8]> + Sync>(
+    chunks: &[S],
+    codec: &Codec,
+    mode: Mode,
+) -> io::Result<Vec<Vec<u8>>> {
     match mode {
-        Mode::Serial => chunks.iter().map(|c| compress_member(codec, c.as_ref())).collect(),
+        Mode::Serial => chunks
+            .iter()
+            .map(|c| compress_member(codec, c.as_ref()))
+            .collect(),
         Mode::Parallel => {
             use rayon::prelude::*;
-            chunks.par_iter().map(|c| compress_member(codec, c.as_ref())).collect()
+            chunks
+                .par_iter()
+                .map(|c| compress_member(codec, c.as_ref()))
+                .collect()
         }
     }
 }
@@ -260,11 +273,19 @@ fn deflate_segment(level: u32, chunk: &[u8], finish: bool) -> io::Result<Vec<u8>
         if out.capacity() == out.len() {
             out.reserve(16 * 1024);
         }
-        c.compress_vec(&chunk[c.total_in() as usize..], &mut out, FlushCompress::None)?;
+        c.compress_vec(
+            &chunk[c.total_in() as usize..],
+            &mut out,
+            FlushCompress::None,
+        )?;
     }
     // Phase 2: flush. Per the zlib contract a flush is complete once deflate
     // returns with output space still available; until then keep growing.
-    let flush = if finish { FlushCompress::Finish } else { FlushCompress::Full };
+    let flush = if finish {
+        FlushCompress::Finish
+    } else {
+        FlushCompress::Full
+    };
     loop {
         if out.capacity() == out.len() {
             out.reserve(16 * 1024);
@@ -325,7 +346,10 @@ impl SingleMemberGzipSink {
         SingleMemberGzipSink {
             level,
             mode,
-            shared: Arc::new(GzShared { ready: Mutex::new(BTreeMap::new()), cv: Condvar::new() }),
+            shared: Arc::new(GzShared {
+                ready: Mutex::new(BTreeMap::new()),
+                cv: Condvar::new(),
+            }),
             next_in: 0,
             next_out: 0,
             crc: flate2::Crc::new(),
@@ -365,7 +389,11 @@ impl SingleMemberGzipSink {
         }
     }
 
-    fn take(&mut self, piece: io::Result<(Vec<u8>, flate2::Crc)>, out: &mut Vec<Vec<u8>>) -> io::Result<()> {
+    fn take(
+        &mut self,
+        piece: io::Result<(Vec<u8>, flate2::Crc)>,
+        out: &mut Vec<Vec<u8>>,
+    ) -> io::Result<()> {
         // [OPUS-4.8] Advance the emission cursor BEFORE propagating a compression
         // error. The caller (`try_drain`/`finish`) has already removed this index
         // from the ready map; if we returned `Err` without advancing `next_out`,
@@ -446,7 +474,11 @@ impl SingleMemberGzipSink {
 
 /// One-shot convenience over [`SingleMemberGzipSink`]: ordered wire pieces
 /// whose concatenation is ONE browser-decodable gzip member.
-pub fn gzip_single_member<S: AsRef<[u8]>>(chunks: &[S], level: u32, mode: Mode) -> io::Result<Vec<Vec<u8>>> {
+pub fn gzip_single_member<S: AsRef<[u8]>>(
+    chunks: &[S],
+    level: u32,
+    mode: Mode,
+) -> io::Result<Vec<Vec<u8>>> {
     let mut sink = SingleMemberGzipSink::new(level, mode);
     for c in chunks {
         sink.push(c.as_ref());
@@ -488,7 +520,8 @@ mod tests {
     /// fragments with repeated structure but distinct values (so members differ
     /// and ordering bugs cannot cancel out).
     fn json_chunks(n: usize) -> Vec<Vec<u8>> {
-        let mut chunks = vec![br#"{"head":{"vars":["s","p","o"]},"results":{"bindings":["#.to_vec()];
+        let mut chunks =
+            vec![br#"{"head":{"vars":["s","p","o"]},"results":{"bindings":["#.to_vec()];
         for i in 0..n {
             let mut c = Vec::new();
             for j in 0..200 {
@@ -525,8 +558,16 @@ mod tests {
         let chunks = json_chunks(20);
         for mode in [Mode::Serial, Mode::Parallel] {
             let members = run_sink(&chunks, Codec::Gzip { level: 6 }, mode);
-            assert_eq!(members.len(), chunks.len(), "one member per chunk ({mode:?})");
-            assert_eq!(decode_gzip_concat(&concat(&members)).unwrap(), concat(&chunks), "{mode:?}");
+            assert_eq!(
+                members.len(),
+                chunks.len(),
+                "one member per chunk ({mode:?})"
+            );
+            assert_eq!(
+                decode_gzip_concat(&concat(&members)).unwrap(),
+                concat(&chunks),
+                "{mode:?}"
+            );
         }
     }
 
@@ -535,8 +576,16 @@ mod tests {
         let chunks = json_chunks(20);
         for mode in [Mode::Serial, Mode::Parallel] {
             let members = run_sink(&chunks, Codec::Zstd { level: 3 }, mode);
-            assert_eq!(members.len(), chunks.len(), "one frame per chunk ({mode:?})");
-            assert_eq!(decode_zstd_concat(&concat(&members)).unwrap(), concat(&chunks), "{mode:?}");
+            assert_eq!(
+                members.len(),
+                chunks.len(),
+                "one frame per chunk ({mode:?})"
+            );
+            assert_eq!(
+                decode_zstd_concat(&concat(&members)).unwrap(),
+                concat(&chunks),
+                "{mode:?}"
+            );
         }
     }
 
@@ -567,7 +616,9 @@ mod tests {
         let chunks = vec![b"".to_vec(), b"x".to_vec(), b"".to_vec()];
         let members = run_sink(&chunks, Codec::Gzip { level: 6 }, Mode::Parallel);
         assert_eq!(decode_gzip_concat(&concat(&members)).unwrap(), b"x");
-        let none = CompressedSink::new(Codec::Zstd { level: 3 }, Mode::Parallel).finish().unwrap();
+        let none = CompressedSink::new(Codec::Zstd { level: 3 }, Mode::Parallel)
+            .finish()
+            .unwrap();
         assert!(none.is_empty());
     }
 
@@ -596,20 +647,31 @@ mod tests {
         let stream = concat(&frames);
 
         // Decodes with the dictionary — as one multi-frame stream and per frame.
-        assert_eq!(decode_zstd_concat_with_dict(&stream, &dict).unwrap(), concat(&responses));
+        assert_eq!(
+            decode_zstd_concat_with_dict(&stream, &dict).unwrap(),
+            concat(&responses)
+        );
         let mut d = zstd::bulk::Decompressor::with_prepared_dictionary(prepared.decoder()).unwrap();
         for (frame, want) in frames.iter().zip(&responses) {
             assert_eq!(&d.decompress(frame, want.len() + 1).unwrap(), want);
         }
 
         // And does NOT decode without it (proves the dictionary is load-bearing).
-        assert!(decode_zstd_concat(&stream).is_err(), "dict frames must not decode dict-less");
+        assert!(
+            decode_zstd_concat(&stream).is_err(),
+            "dict frames must not decode dict-less"
+        );
 
         // Dictionary actually helps on these sizes: strictly smaller than plain zstd.
         let plain = compress_chunks(&responses, &Codec::Zstd { level: 3 }, Mode::Serial).unwrap();
-        let (with, without): (usize, usize) =
-            (frames.iter().map(Vec::len).sum(), plain.iter().map(Vec::len).sum());
-        assert!(with < without, "dict {with} B should beat plain {without} B on small responses");
+        let (with, without): (usize, usize) = (
+            frames.iter().map(Vec::len).sum(),
+            plain.iter().map(Vec::len).sum(),
+        );
+        assert!(
+            with < without,
+            "dict {with} B should beat plain {without} B on small responses"
+        );
     }
 
     /// Decodes with flate2's SINGLE-member `GzDecoder` — the strict stand-in for
@@ -622,7 +684,10 @@ mod tests {
         // The whole input must be consumed by the ONE member (no ignored tail).
         let mut rest = Vec::new();
         d.into_inner().read_to_end(&mut rest).unwrap();
-        assert!(rest.is_empty(), "single-member stream must leave no trailing bytes");
+        assert!(
+            rest.is_empty(),
+            "single-member stream must leave no trailing bytes"
+        );
         out
     }
 
@@ -638,9 +703,17 @@ mod tests {
                     pieces.extend(sink.try_drain().unwrap());
                 }
                 pieces.extend(sink.finish().unwrap());
-                assert_eq!(pieces.len(), chunks.len() + 1, "chunks + trailer piece ({mode:?})");
+                assert_eq!(
+                    pieces.len(),
+                    chunks.len() + 1,
+                    "chunks + trailer piece ({mode:?})"
+                );
                 let wire = concat(&pieces);
-                assert_eq!(decode_single_member(&wire), concat(&chunks), "level {level} {mode:?}");
+                assert_eq!(
+                    decode_single_member(&wire),
+                    concat(&chunks),
+                    "level {level} {mode:?}"
+                );
                 // MultiGzDecoder agrees (it sees one member).
                 assert_eq!(decode_gzip_concat(&wire).unwrap(), concat(&chunks));
             }
@@ -658,7 +731,9 @@ mod tests {
     #[test]
     fn single_member_gzip_empty_and_empty_chunks() {
         // No pushes: a valid empty gzip member.
-        let pieces = SingleMemberGzipSink::new(6, Mode::Parallel).finish().unwrap();
+        let pieces = SingleMemberGzipSink::new(6, Mode::Parallel)
+            .finish()
+            .unwrap();
         assert_eq!(decode_single_member(&concat(&pieces)), b"");
         // Empty chunks interleaved.
         let chunks = vec![b"".to_vec(), b"abc".to_vec(), b"".to_vec(), b"def".to_vec()];
@@ -682,7 +757,10 @@ mod tests {
         }
         members.extend(sink.finish().unwrap());
         assert_eq!(members.len(), chunks.len());
-        assert_eq!(decode_zstd_concat(&concat(&members)).unwrap(), concat(&chunks));
+        assert_eq!(
+            decode_zstd_concat(&concat(&members)).unwrap(),
+            concat(&chunks)
+        );
         // Not asserted as a hard invariant (scheduling), but record the intent:
         // on any real machine some members are ready before the last push.
         if !drained_early {
@@ -700,7 +778,10 @@ mod tests {
         use std::sync::atomic::{AtomicBool, Ordering};
 
         let chunks = json_chunks(16);
-        let pool = rayon::ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap();
         let done = Arc::new(AtomicBool::new(false));
 
         // Watchdog: if `pool.install` has not finished in 30 s it has deadlocked.
@@ -720,10 +801,16 @@ mod tests {
             // CompressedSink (gzip + zstd) round-trips inside the constrained pool.
             let members = run_sink(&chunks, Codec::Gzip { level: 6 }, Mode::Parallel);
             assert_eq!(members.len(), chunks.len());
-            assert_eq!(decode_gzip_concat(&concat(&members)).unwrap(), concat(&chunks));
+            assert_eq!(
+                decode_gzip_concat(&concat(&members)).unwrap(),
+                concat(&chunks)
+            );
 
             let members = run_sink(&chunks, Codec::Zstd { level: 1 }, Mode::Parallel);
-            assert_eq!(decode_zstd_concat(&concat(&members)).unwrap(), concat(&chunks));
+            assert_eq!(
+                decode_zstd_concat(&concat(&members)).unwrap(),
+                concat(&chunks)
+            );
 
             // SingleMemberGzipSink round-trips inside the constrained pool.
             let pieces = gzip_single_member(&chunks, 6, Mode::Parallel).unwrap();
@@ -761,7 +848,10 @@ mod tests {
         rayon::scope(|s| {
             s.spawn(|_| {
                 let members = run_sink(&chunks, Codec::Zstd { level: 1 }, Mode::Parallel);
-                assert_eq!(decode_zstd_concat(&concat(&members)).unwrap(), concat(&chunks));
+                assert_eq!(
+                    decode_zstd_concat(&concat(&members)).unwrap(),
+                    concat(&chunks)
+                );
                 let pieces = gzip_single_member(&chunks, 6, Mode::Parallel).unwrap();
                 assert_eq!(decode_single_member(&concat(&pieces)), concat(&chunks));
             });
@@ -792,6 +882,10 @@ mod tests {
         assert_eq!(err.to_string(), "boom");
         // Cursor advanced past the failed (and already-removed) index; the entry
         // is gone, so a re-check must not block on it.
-        assert_eq!(sink.next_out, next_out_before + 1, "cursor must advance past the error");
+        assert_eq!(
+            sink.next_out,
+            next_out_before + 1,
+            "cursor must advance past the error"
+        );
     }
 }

--- a/crates/sparq-serve/src/applier.rs
+++ b/crates/sparq-serve/src/applier.rs
@@ -65,7 +65,9 @@ pub struct GraphApplier {
 
 impl Default for GraphApplier {
     fn default() -> Self {
-        GraphApplier { compact_threshold: DEFAULT_COMPACT_THRESHOLD }
+        GraphApplier {
+            compact_threshold: DEFAULT_COMPACT_THRESHOLD,
+        }
     }
 }
 
@@ -78,7 +80,9 @@ impl GraphApplier {
     /// An applier compacting once the pending delta reaches `threshold` entries
     /// (values below 1 are treated as 1 — compact after every batch).
     pub fn with_compact_threshold(threshold: usize) -> Self {
-        GraphApplier { compact_threshold: threshold.max(1) }
+        GraphApplier {
+            compact_threshold: threshold.max(1),
+        }
     }
 }
 

--- a/crates/sparq-serve/src/footprint.rs
+++ b/crates/sparq-serve/src/footprint.rs
@@ -100,8 +100,14 @@ impl Footprint {
     pub fn commutes_with(&self, other: &Footprint) -> bool {
         match (self, other) {
             (
-                Footprint::Data { inserts: i1, deletes: d1 },
-                Footprint::Data { inserts: i2, deletes: d2 },
+                Footprint::Data {
+                    inserts: i1,
+                    deletes: d1,
+                },
+                Footprint::Data {
+                    inserts: i2,
+                    deletes: d2,
+                },
             ) => i1.is_disjoint(d2) && d1.is_disjoint(i2),
             _ => false,
         }

--- a/crates/sparq-serve/src/ring.rs
+++ b/crates/sparq-serve/src/ring.rs
@@ -63,7 +63,10 @@ pub struct TimeTravelConfig {
 
 impl Default for TimeTravelConfig {
     fn default() -> Self {
-        TimeTravelConfig { max_generations: 16, max_age: None }
+        TimeTravelConfig {
+            max_generations: 16,
+            max_age: None,
+        }
     }
 }
 
@@ -87,7 +90,11 @@ pub struct RingConfig {
 
 impl Default for RingConfig {
     fn default() -> Self {
-        RingConfig { retain: DEFAULT_RETAIN, time_travel: None, clock: SystemTime::now }
+        RingConfig {
+            retain: DEFAULT_RETAIN,
+            time_travel: None,
+            clock: SystemTime::now,
+        }
     }
 }
 
@@ -282,7 +289,8 @@ impl<S> GenerationRing<S> {
                         // A clock that stepped backwards makes the front look
                         // future-published; keep it (conservative, never lies
                         // about retention it still holds).
-                        now.duration_since(front.published_at).map_or(true, |age| age <= max)
+                        now.duration_since(front.published_at)
+                            .map_or(true, |age| age <= max)
                     })
             });
             if keep_for_time_travel {
@@ -322,7 +330,12 @@ impl<S> GenerationRing<S> {
     /// generation (O(retained) scan — robust to non-monotonic clocks).
     pub fn as_of(&self, t: SystemTime) -> Option<Arc<Generation<S>>> {
         let inner = self.inner.lock().expect("generation ring poisoned");
-        inner.retained.iter().rev().find(|g| g.published_at <= t).cloned()
+        inner
+            .retained
+            .iter()
+            .rev()
+            .find(|g| g.published_at <= t)
+            .cloned()
     }
 
     /// How many generations are still alive anywhere — retained by the ring *or*

--- a/crates/sparq-serve/src/scheduler.rs
+++ b/crates/sparq-serve/src/scheduler.rs
@@ -117,7 +117,10 @@ pub const DEFAULT_HEAVY_THRESHOLD: Cost = 4_096;
 
 impl Default for SchedulerConfig {
     fn default() -> Self {
-        let workers = thread::available_parallelism().map(|n| n.get()).unwrap_or(8).max(2);
+        let workers = thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(8)
+            .max(2);
         SchedulerConfig {
             workers,
             heavy_concurrency: (workers / 2).max(1),
@@ -130,7 +133,8 @@ impl SchedulerConfig {
     /// Resolved heavy-concurrency cap, clamped to `1..=workers-1` so at least one
     /// worker is always reservable for cheap jobs.
     fn heavy_cap(&self) -> usize {
-        self.heavy_concurrency.clamp(1, self.workers.saturating_sub(1).max(1))
+        self.heavy_concurrency
+            .clamp(1, self.workers.saturating_sub(1).max(1))
     }
 }
 
@@ -261,7 +265,10 @@ enum SlotState<T> {
 
 impl<T> Slot<T> {
     fn new() -> Arc<Self> {
-        Arc::new(Slot { state: Mutex::new(SlotState::Pending), ready: Condvar::new() })
+        Arc::new(Slot {
+            state: Mutex::new(SlotState::Pending),
+            ready: Condvar::new(),
+        })
     }
 
     fn deliver(&self, outcome: Result<T, SchedError>) {
@@ -335,7 +342,10 @@ impl<T: Send + 'static> Scheduler<T> {
             );
         }
         Arc::new(Scheduler {
-            cfg: SchedulerConfig { workers: workers_n, ..cfg },
+            cfg: SchedulerConfig {
+                workers: workers_n,
+                ..cfg
+            },
             heavy_cap,
             queues,
             seq: AtomicU64::new(0),
@@ -363,7 +373,11 @@ impl<T: Send + 'static> Scheduler<T> {
         F: FnOnce() -> T + Send + 'static,
     {
         let slot = Slot::new();
-        let lane = if cost >= self.cfg.heavy_threshold { Lane::Heavy } else { Lane::Cheap };
+        let lane = if cost >= self.cfg.heavy_threshold {
+            Lane::Heavy
+        } else {
+            Lane::Cheap
+        };
         let seq = self.seq.fetch_add(1, Ordering::Relaxed);
         let job = Job {
             seq,
@@ -402,7 +416,11 @@ impl<T: Send + 'static> Scheduler<T> {
     /// The lane a given cost maps to under this scheduler's config (exposed for
     /// callers/metrics that classify before submitting).
     pub fn lane_of(&self, cost: Cost) -> Lane {
-        if cost >= self.cfg.heavy_threshold { Lane::Heavy } else { Lane::Cheap }
+        if cost >= self.cfg.heavy_threshold {
+            Lane::Heavy
+        } else {
+            Lane::Cheap
+        }
     }
 
     /// Total jobs submitted since construction.
@@ -560,7 +578,10 @@ fn pick_heavy<T>(heavy: &mut Vec<Job<T>>) -> Job<T> {
 }
 
 fn heavy_key<T>(job: &Job<T>) -> HeavyKey {
-    HeavyKey { cost: job.cost, enqueued: job.enqueued }
+    HeavyKey {
+        cost: job.cost,
+        enqueued: job.enqueued,
+    }
 }
 
 /// Runs `work`, catching a panic and reporting it as [`SchedError::Panicked`]

--- a/crates/sparq-serve/src/writer.rs
+++ b/crates/sparq-serve/src/writer.rs
@@ -247,7 +247,9 @@ impl std::fmt::Display for WriteError {
         match self {
             WriteError::Rejected(e) => write!(f, "update rejected: {e}"),
             WriteError::Shutdown => f.write_str("writer has shut down"),
-            WriteError::Unavailable(e) => write!(f, "update not durably committed (retryable): {e}"),
+            WriteError::Unavailable(e) => {
+                write!(f, "update not durably committed (retryable): {e}")
+            }
         }
     }
 }
@@ -294,7 +296,11 @@ pub struct Writer<U: Send + 'static> {
 impl<U: Send + 'static> Writer<U> {
     /// Spawns the writer thread over `ring`, owning `applier` as its snapshot
     /// production strategy.
-    pub fn spawn<A>(ring: Arc<GenerationRing<A::Snapshot>>, applier: A, config: WriterConfig) -> Self
+    pub fn spawn<A>(
+        ring: Arc<GenerationRing<A::Snapshot>>,
+        applier: A,
+        config: WriterConfig,
+    ) -> Self
     where
         A: ApplyUpdates<Update = U>,
     {
@@ -303,7 +309,10 @@ impl<U: Send + 'static> Writer<U> {
             .name("sparq-serve-writer".into())
             .spawn(move || run(ring, applier, config, rx))
             .expect("spawn writer thread");
-        Writer { tx: Some(tx), thread: Some(thread) }
+        Writer {
+            tx: Some(tx),
+            thread: Some(thread),
+        }
     }
 
     /// Submits an update and **blocks until the generation containing it is
@@ -327,7 +336,11 @@ impl<U: Send + 'static> Writer<U> {
         touched: impl IntoIterator<Item = PodId>,
     ) -> Result<u64, WriteError> {
         let (ack_tx, ack_rx) = mpsc::sync_channel(1);
-        self.send(Msg { update, touched: touched.into_iter().collect(), ack: Some(ack_tx) })?;
+        self.send(Msg {
+            update,
+            touched: touched.into_iter().collect(),
+            ack: Some(ack_tx),
+        })?;
         // A dropped ack sender means the writer thread died mid-batch.
         ack_rx.recv().map_err(|_| WriteError::Shutdown)?
     }
@@ -361,7 +374,11 @@ impl<U: Send + 'static> Writer<U> {
         update: U,
         touched: impl IntoIterator<Item = PodId>,
     ) -> Result<(), WriteError> {
-        self.send(Msg { update, touched: touched.into_iter().collect(), ack: None })
+        self.send(Msg {
+            update,
+            touched: touched.into_iter().collect(),
+            ack: None,
+        })
     }
 
     fn send(&self, msg: Msg<U>) -> Result<(), WriteError> {
@@ -567,7 +584,9 @@ fn commit<A: ApplyUpdates>(
         Ok(s) => s,
         Err(e) => return fail_batch_after_seal_error(batch, errs, &e),
     };
-    let touched = applied.iter().flat_map(|&i| batch[i].touched.iter().cloned());
+    let touched = applied
+        .iter()
+        .flat_map(|&i| batch[i].touched.iter().cloned());
     let number = ring.publish(snapshot, touched).number();
     for (i, msg) in batch.into_iter().enumerate() {
         if let Some(ack) = msg.ack {

--- a/crates/sparq-serve/tests/batch_atomicity.rs
+++ b/crates/sparq-serve/tests/batch_atomicity.rs
@@ -45,7 +45,11 @@ fn reader_sees_zero_or_all_of_a_bulk_update() {
     let writer = Arc::new(Writer::spawn(
         ring.clone(),
         GraphApplier::new(),
-        WriterConfig { window: Duration::from_millis(1), max_batch: 256, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(1),
+            max_batch: 256,
+            ..WriterConfig::default()
+        },
     ));
 
     let stop = Arc::new(AtomicBool::new(false));
@@ -79,9 +83,15 @@ fn reader_sees_zero_or_all_of_a_bulk_update() {
     let before = ring.current();
     assert_eq!(before.snapshot().len(), BASE);
 
-    let gen = writer.submit(bulk_insert(), [PodId::from("pod:bulk")]).unwrap();
+    let gen = writer
+        .submit(bulk_insert(), [PodId::from("pod:bulk")])
+        .unwrap();
     assert_eq!(gen, 1, "the bulk update is one generation");
-    assert_eq!(ring.current().snapshot().len(), BASE + BULK, "all 50k applied atomically");
+    assert_eq!(
+        ring.current().snapshot().len(),
+        BASE + BULK,
+        "all 50k applied atomically"
+    );
 
     // Keep sampling briefly after the commit so the sampler observes the new gen.
     std::thread::sleep(Duration::from_millis(20));
@@ -114,7 +124,11 @@ fn pinned_generation_survives_sustained_writes() {
     let writer = Writer::spawn(
         ring.clone(),
         GraphApplier::new(),
-        WriterConfig { window: Duration::from_millis(1), max_batch: 64, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(1),
+            max_batch: 64,
+            ..WriterConfig::default()
+        },
     );
 
     let pinned = ring.current(); // generation 0, BASE triples

--- a/crates/sparq-serve/tests/commute.rs
+++ b/crates/sparq-serve/tests/commute.rs
@@ -18,9 +18,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use sparq_core::Graph;
-use sparq_serve::{
-    CommitGranularity, GenerationRing, GraphApplier, PodId, Writer, WriterConfig,
-};
+use sparq_serve::{CommitGranularity, GenerationRing, GraphApplier, PodId, Writer, WriterConfig};
 
 fn empty_graph() -> Graph {
     Graph::load_str("", "ntriples").expect("empty graph")
@@ -50,15 +48,23 @@ fn run_stream(granularity: CommitGranularity, updates: &[(&str, &str)]) -> (usiz
         GraphApplier::new(),
         // Wide window + large max_batch so every update joins ONE window; the
         // granularity then decides how many generations that window publishes.
-        WriterConfig { window: Duration::from_millis(120), max_batch: 4096, granularity },
+        WriterConfig {
+            window: Duration::from_millis(120),
+            max_batch: 4096,
+            granularity,
+        },
     );
     // Submit all but the last detached, then a sync submit to force the window to
     // have opened and collected everyone before we read.
     for (upd, pod) in &updates[..updates.len() - 1] {
-        writer.submit_detached((*upd).to_string(), [PodId::from(*pod)]).unwrap();
+        writer
+            .submit_detached((*upd).to_string(), [PodId::from(*pod)])
+            .unwrap();
     }
     let (last_upd, last_pod) = updates[updates.len() - 1];
-    writer.submit(last_upd.to_string(), [PodId::from(last_pod)]).unwrap();
+    writer
+        .submit(last_upd.to_string(), [PodId::from(last_pod)])
+        .unwrap();
     drop(writer); // drain any straggler
     let current = ring.current();
     (total_quads(current.snapshot()), current.number())
@@ -114,14 +120,23 @@ fn same_graph_opposite_polarity_splits_but_result_identical() {
     // INS_A0 then DEL_A0 (deletes what was inserted) then INS_A1.
     let stream = [(INS_A0, "a"), (DEL_A0, "a"), (INS_A1, "a")];
     let serial = serial_result(&stream);
-    assert_eq!(serial, 1, "insert s0, delete s0, insert s1 → only s1 remains");
+    assert_eq!(
+        serial, 1,
+        "insert s0, delete s0, insert s1 → only s1 remains"
+    );
 
     let (win_len, win_gen) = run_stream(CommitGranularity::Window, &stream);
     let (cg_len, cg_gen) = run_stream(CommitGranularity::CommuteGroup, &stream);
 
     assert_eq!(win_len, serial);
-    assert_eq!(cg_len, serial, "CommuteGroup result == serial despite group splits");
-    assert_eq!(win_gen, 1, "Window collapses the whole window into one generation");
+    assert_eq!(
+        cg_len, serial,
+        "CommuteGroup result == serial despite group splits"
+    );
+    assert_eq!(
+        win_gen, 1,
+        "Window collapses the whole window into one generation"
+    );
     assert!(
         cg_gen > 1,
         "CommuteGroup splits at the insert/delete polarity conflict (got {cg_gen} generations)"
@@ -132,8 +147,7 @@ fn same_graph_opposite_polarity_splits_but_result_identical() {
 /// singleton generation, but the final result is still serial-identical.
 #[test]
 fn where_update_is_a_barrier_result_identical() {
-    let where_upd =
-        "INSERT { GRAPH <http://ex/a> { ?s <http://ex/q> \"copy\" } } \
+    let where_upd = "INSERT { GRAPH <http://ex/a> { ?s <http://ex/q> \"copy\" } } \
          WHERE { GRAPH <http://ex/a> { ?s <http://ex/p> \"v\" } }";
     let stream = [(INS_A0, "a"), (where_upd, "a"), (INS_B0, "b")];
     let serial = serial_result(&stream);
@@ -141,8 +155,14 @@ fn where_update_is_a_barrier_result_identical() {
     assert_eq!(serial, 3);
 
     let (cg_len, cg_gen) = run_stream(CommitGranularity::CommuteGroup, &stream);
-    assert_eq!(cg_len, serial, "barrier update still produces the serial result");
-    assert!(cg_gen >= 2, "the WHERE barrier forces at least one extra generation (got {cg_gen})");
+    assert_eq!(
+        cg_len, serial,
+        "barrier update still produces the serial result"
+    );
+    assert!(
+        cg_gen >= 2,
+        "the WHERE barrier forces at least one extra generation (got {cg_gen})"
+    );
 }
 
 /// Pseudo-random differential fuzz: many mixed inserts/deletes across a small set
@@ -152,7 +172,9 @@ fn fuzz_differential_window_vs_commute_vs_serial() {
     // A deterministic LCG so the stream is reproducible.
     let mut state: u64 = 0x9E3779B97F4A7C15;
     let mut next = || {
-        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
         state >> 33
     };
     let graphs = ["http://ex/g0", "http://ex/g1", "http://ex/g2"];
@@ -162,9 +184,8 @@ fn fuzz_differential_window_vs_commute_vs_serial() {
         let subj = next() % 20;
         let del = next() % 2 == 0;
         let op = if del { "DELETE" } else { "INSERT" };
-        let upd = format!(
-            "{op} DATA {{ GRAPH <{g}> {{ <http://ex/s{subj}> <http://ex/p> \"v\" }} }}"
-        );
+        let upd =
+            format!("{op} DATA {{ GRAPH <{g}> {{ <http://ex/s{subj}> <http://ex/p> \"v\" }} }}");
         let pod = g.rsplit('/').next().unwrap();
         owned.push((upd, pod));
     }

--- a/crates/sparq-serve/tests/real_store.rs
+++ b/crates/sparq-serve/tests/real_store.rs
@@ -20,7 +20,13 @@ fn graph_with(n: usize) -> Graph {
 
 #[test]
 fn ring_serves_real_graph_snapshots_consistently() {
-    let ring = GenerationRing::with_config(graph_with(2), RingConfig { retain: 2, ..RingConfig::default() });
+    let ring = GenerationRing::with_config(
+        graph_with(2),
+        RingConfig {
+            retain: 2,
+            ..RingConfig::default()
+        },
+    );
 
     let gen0 = ring.current();
     assert_eq!(gen0.snapshot().len(), 2);
@@ -34,7 +40,11 @@ fn ring_serves_real_graph_snapshots_consistently() {
     // The pinned generation still answers at its own state — snapshot-consistent
     // streaming is free by construction (§6.6).
     assert_eq!(gen0.number(), 0);
-    assert_eq!(gen0.snapshot().len(), 2, "pinned graph unchanged after 6 publishes");
+    assert_eq!(
+        gen0.snapshot().len(),
+        2,
+        "pinned graph unchanged after 6 publishes"
+    );
     let current = ring.current();
     assert_eq!(current.number(), 6);
     assert_eq!(current.snapshot().len(), 8);

--- a/crates/sparq-serve/tests/ring.rs
+++ b/crates/sparq-serve/tests/ring.rs
@@ -17,7 +17,10 @@ struct MockSnapshot {
 impl MockSnapshot {
     fn new(value: u64, live: &Arc<AtomicUsize>) -> Self {
         live.fetch_add(1, Ordering::SeqCst);
-        MockSnapshot { value, live: live.clone() }
+        MockSnapshot {
+            value,
+            live: live.clone(),
+        }
     }
 }
 
@@ -46,7 +49,13 @@ fn initial_state_is_generation_zero() {
 #[test]
 fn readers_pin_old_generations_while_writer_publishes_past() {
     let live = Arc::new(AtomicUsize::new(0));
-    let ring = GenerationRing::with_config(MockSnapshot::new(0, &live), RingConfig { retain: 2, ..RingConfig::default() });
+    let ring = GenerationRing::with_config(
+        MockSnapshot::new(0, &live),
+        RingConfig {
+            retain: 2,
+            ..RingConfig::default()
+        },
+    );
 
     // A reader pins generation 0 (e.g. a long-lived stream).
     let pinned = ring.current();
@@ -76,13 +85,23 @@ fn readers_pin_old_generations_while_writer_publishes_past() {
 #[test]
 fn retention_bound_drops_ring_references_but_not_reader_pins() {
     let live = Arc::new(AtomicUsize::new(0));
-    let ring = GenerationRing::with_config(MockSnapshot::new(0, &live), RingConfig { retain: 3, ..RingConfig::default() });
+    let ring = GenerationRing::with_config(
+        MockSnapshot::new(0, &live),
+        RingConfig {
+            retain: 3,
+            ..RingConfig::default()
+        },
+    );
 
     // No readers: beyond current + K, forgotten generations are freed promptly.
     for i in 1..=10u64 {
         ring.publish(MockSnapshot::new(i, &live), std::iter::empty());
     }
-    assert_eq!(live.load(Ordering::SeqCst), 4, "ring retains current + K = 4");
+    assert_eq!(
+        live.load(Ordering::SeqCst),
+        4,
+        "ring retains current + K = 4"
+    );
     assert_eq!(ring.live_generations(), 4);
     assert_eq!(ring.oldest_retained(), 7);
 
@@ -92,7 +111,11 @@ fn retention_bound_drops_ring_references_but_not_reader_pins() {
     for i in 11..=20u64 {
         ring.publish(MockSnapshot::new(i, &live), std::iter::empty());
     }
-    assert_eq!(ring.oldest_retained(), 17, "ring's own refs moved past the pin");
+    assert_eq!(
+        ring.oldest_retained(),
+        17,
+        "ring's own refs moved past the pin"
+    );
     // current+K from the ring, plus the externally pinned gen 10.
     assert_eq!(live.load(Ordering::SeqCst), 5);
     assert_eq!(ring.live_generations(), 5);
@@ -109,7 +132,11 @@ fn retention_bound_drops_ring_references_but_not_reader_pins() {
 fn epoch_bumps_only_for_touched_pods() {
     let live = Arc::new(AtomicUsize::new(0));
     let ring = GenerationRing::new(MockSnapshot::new(0, &live));
-    let (a, b, c) = (PodId::from("pod:a"), PodId::from("pod:b"), PodId::from("pod:c"));
+    let (a, b, c) = (
+        PodId::from("pod:a"),
+        PodId::from("pod:b"),
+        PodId::from("pod:c"),
+    );
 
     let g1 = ring.publish(MockSnapshot::new(1, &live), pods(&["pod:a", "pod:b"]));
     assert_eq!(g1.epochs().epoch(&a), 1);
@@ -118,7 +145,11 @@ fn epoch_bumps_only_for_touched_pods() {
     assert_eq!(g1.epochs().len(), 2);
 
     let g2 = ring.publish(MockSnapshot::new(2, &live), pods(&["pod:b"]));
-    assert_eq!(g2.epochs().epoch(&a), 1, "untouched pod's epoch carried unchanged");
+    assert_eq!(
+        g2.epochs().epoch(&a),
+        1,
+        "untouched pod's epoch carried unchanged"
+    );
     assert_eq!(g2.epochs().epoch(&b), 2);
     assert_eq!(g2.epochs().epoch(&c), 0);
 
@@ -126,7 +157,10 @@ fn epoch_bumps_only_for_touched_pods() {
     assert_eq!(g1.epochs().epoch(&b), 1);
 
     // Duplicate mentions within one publish bump once.
-    let g3 = ring.publish(MockSnapshot::new(3, &live), pods(&["pod:c", "pod:c", "pod:c"]));
+    let g3 = ring.publish(
+        MockSnapshot::new(3, &live),
+        pods(&["pod:c", "pod:c", "pod:c"]),
+    );
     assert_eq!(g3.epochs().epoch(&c), 1);
     assert_eq!(g3.epochs().epoch(&a), 1);
     assert_eq!(g3.epochs().epoch(&b), 2);
@@ -148,7 +182,13 @@ fn publish_with_no_touched_pods_keeps_epochs() {
 #[test]
 fn retain_zero_keeps_only_current() {
     let live = Arc::new(AtomicUsize::new(0));
-    let ring = GenerationRing::with_config(MockSnapshot::new(0, &live), RingConfig { retain: 0, ..RingConfig::default() });
+    let ring = GenerationRing::with_config(
+        MockSnapshot::new(0, &live),
+        RingConfig {
+            retain: 0,
+            ..RingConfig::default()
+        },
+    );
     for i in 1..=5u64 {
         ring.publish(MockSnapshot::new(i, &live), std::iter::empty());
     }

--- a/crates/sparq-serve/tests/scheduler.rs
+++ b/crates/sparq-serve/tests/scheduler.rs
@@ -28,7 +28,11 @@ use sparq_serve::{Lane, SchedError, Scheduler, SchedulerConfig};
 /// A scheduler config with a known worker count and a low heavy threshold, so
 /// tests are deterministic about lane assignment and reserved capacity.
 fn cfg(workers: usize, heavy_concurrency: usize, heavy_threshold: u64) -> SchedulerConfig {
-    SchedulerConfig { workers, heavy_concurrency, heavy_threshold }
+    SchedulerConfig {
+        workers,
+        heavy_concurrency,
+        heavy_threshold,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -56,7 +60,10 @@ fn scheduling_does_not_change_results_differential() {
     for (i, t) in tickets {
         let got = t.wait().expect("job completed");
         let expected = (0..=i as u64).sum::<u64>().wrapping_mul(2654435761);
-        assert_eq!(got, expected, "scheduled result must equal direct computation for job {i}");
+        assert_eq!(
+            got, expected,
+            "scheduled result must equal direct computation for job {i}"
+        );
     }
 }
 
@@ -78,7 +85,10 @@ fn heavy_cap_always_reserves_a_cheap_worker() {
     // Even if a deployment misconfigures heavy_concurrency == workers, the cap is
     // clamped so at least one worker stays free for cheap jobs.
     let sched: Arc<Scheduler<()>> = Scheduler::new(cfg(4, 4, 1_000));
-    assert!(sched.heavy_cap() < sched.workers(), "a cheap worker must always be reserved");
+    assert!(
+        sched.heavy_cap() < sched.workers(),
+        "a cheap worker must always be reserved"
+    );
     assert!(sched.heavy_cap() >= 1);
 }
 
@@ -218,7 +228,8 @@ fn head_of_line_cheap_p99_bounded_under_expensive_query() {
         load_p99 < base_p99 + Duration::from_millis(60),
         "lane-split cheap p99 went from {:?} (unloaded) to {:?} under expensive queries — \
          reserved capacity is not containing head-of-line blocking",
-        base_p99, load_p99
+        base_p99,
+        load_p99
     );
     // The contrast must be real, asserted two ways so neither a noisy denominator
     // nor a light workload can make it pass vacuously (empirical honesty):
@@ -237,7 +248,8 @@ fn head_of_line_cheap_p99_bounded_under_expensive_query() {
         fifo_p99 > load_p99 * 3,
         "FIFO single-lane p99 ({:?}) was not dramatically worse than lane-split p99 ({:?}) — \
          the scheduler's lane split is not earning its keep in this measurement",
-        fifo_p99, load_p99
+        fifo_p99,
+        load_p99
     );
     // And lane-split cheap p99 must stay well under a single scan's duration (a
     // 200ms scan must NOT appear in cheap p99).
@@ -286,7 +298,11 @@ fn heavy_query_not_starved_under_cheap_flood() {
         cheap_tickets.len(),
         t0.elapsed()
     );
-    assert_eq!(heavy_done.load(Ordering::SeqCst), 1, "heavy job must have run to completion");
+    assert_eq!(
+        heavy_done.load(Ordering::SeqCst),
+        1,
+        "heavy job must have run to completion"
+    );
     for t in cheap_tickets {
         t.wait().expect("cheap job completed");
     }
@@ -462,7 +478,11 @@ fn no_regression_all_cheap_workload() {
 
 /// A minimal "unscheduled" baseline: a fixed pool of `width` threads pulling from
 /// one mpsc queue, no lanes, no cost, no aging — the simplest correct dispatcher.
-fn run_plain_pool(width: usize, n: usize, work: impl Fn() + Send + Sync + 'static + Clone) -> Duration {
+fn run_plain_pool(
+    width: usize,
+    n: usize,
+    work: impl Fn() + Send + Sync + 'static + Clone,
+) -> Duration {
     use std::sync::mpsc;
     let (tx, rx) = mpsc::channel::<Box<dyn FnOnce() + Send>>();
     let rx = Arc::new(std::sync::Mutex::new(rx));
@@ -555,7 +575,11 @@ fn queued_jobs_shed_on_shutdown() {
 fn panicking_job_is_isolated() {
     let sched = Scheduler::new(cfg(2, 1, 1_000));
     let bad = sched.submit(1, || -> u32 { panic!("boom") });
-    assert_eq!(bad.wait(), Err(SchedError::Panicked), "a panicking job is surfaced, not silent");
+    assert_eq!(
+        bad.wait(),
+        Err(SchedError::Panicked),
+        "a panicking job is surfaced, not silent"
+    );
     // The pool survives: a following job still runs.
     let good = sched.submit(1, || 42u32);
     assert_eq!(good.wait(), Ok(42), "pool must survive a panicking job");

--- a/crates/sparq-serve/tests/scheduler_real_store.rs
+++ b/crates/sparq-serve/tests/scheduler_real_store.rs
@@ -37,7 +37,11 @@ fn direct(graph: &Graph) -> String {
 #[test]
 fn scheduled_query_matches_direct_execution_on_pinned_generation() {
     let ring = Arc::new(GenerationRing::new(graph_with(100)));
-    let sched = Scheduler::new(SchedulerConfig { workers: 4, heavy_concurrency: 2, heavy_threshold: 10_000 });
+    let sched = Scheduler::new(SchedulerConfig {
+        workers: 4,
+        heavy_concurrency: 2,
+        heavy_threshold: 10_000,
+    });
 
     // Submit many queries; each pins the CURRENT generation inside the closure and
     // runs the engine. We compare to a direct run on a generation pinned now.
@@ -58,7 +62,10 @@ fn scheduled_query_matches_direct_execution_on_pinned_generation() {
     for t in tickets {
         let (num, got) = t.wait().expect("scheduled query ok");
         assert_eq!(num, 0, "no writes happened, all reads see generation 0");
-        assert_eq!(got, expected, "scheduled result must equal direct execution");
+        assert_eq!(
+            got, expected,
+            "scheduled result must equal direct execution"
+        );
     }
 }
 
@@ -67,7 +74,11 @@ fn snapshot_consistency_preserved_under_concurrent_writes() {
     // A reader scheduled at generation G must see exactly G's state even as the
     // writer publishes past it — the scheduler must not perturb the A1 pin.
     let ring = Arc::new(GenerationRing::new(graph_with(50)));
-    let sched = Scheduler::new(SchedulerConfig { workers: 4, heavy_concurrency: 2, heavy_threshold: 10_000 });
+    let sched = Scheduler::new(SchedulerConfig {
+        workers: 4,
+        heavy_concurrency: 2,
+        heavy_threshold: 10_000,
+    });
 
     // Pin generation 0 BEFORE any writes; schedule a job that reads it but is held
     // until after the writer has advanced the ring. The job captures the pinned
@@ -82,7 +93,9 @@ fn snapshot_consistency_preserved_under_concurrent_writes() {
         let upd = format!(
             "INSERT DATA {{ GRAPH <http://pod/{i}> {{ <http://ex/s{i}> <http://ex/p> \"new{i}\" }} }}"
         );
-        writer.submit(upd, [PodId::from(format!("http://pod/{i}").as_str())]).expect("write ok");
+        writer
+            .submit(upd, [PodId::from(format!("http://pod/{i}").as_str())])
+            .expect("write ok");
     }
 
     // The job that pinned generation 0 must still report generation-0 state.
@@ -92,14 +105,20 @@ fn snapshot_consistency_preserved_under_concurrent_writes() {
     let exp0 = expected0.clone();
     let held = sched.submit(1, move || {
         let got = direct(p0.snapshot());
-        assert_eq!(got, exp0, "pinned generation-0 read must be unchanged by concurrent writes");
+        assert_eq!(
+            got, exp0,
+            "pinned generation-0 read must be unchanged by concurrent writes"
+        );
         let count = sparq_engine::count(p0.snapshot(), "SELECT * WHERE { GRAPH ?gr { ?s ?p ?o } }")
             .unwrap_or(0);
         (p0.number(), count)
     });
     let (num, held_named_count) = held.wait().expect("held read ok");
     assert_eq!(num, 0, "the held read stayed on generation 0");
-    assert_eq!(held_named_count, 0, "generation 0 has no named-graph triples — the writes are invisible to it");
+    assert_eq!(
+        held_named_count, 0,
+        "generation 0 has no named-graph triples — the writes are invisible to it"
+    );
 
     // A fresh read scheduled now sees the advanced state (more triples, higher gen).
     let ring2 = ring.clone();
@@ -110,8 +129,14 @@ fn snapshot_consistency_preserved_under_concurrent_writes() {
         (g.number(), count)
     });
     let (fresh_num, fresh_named_count) = fresh.wait().expect("fresh read ok");
-    assert!(fresh_num >= 1, "fresh read should see at least one published generation, saw {fresh_num}");
-    assert_eq!(fresh_named_count, 20, "the 20 named-graph inserts are visible to a fresh read");
+    assert!(
+        fresh_num >= 1,
+        "fresh read should see at least one published generation, saw {fresh_num}"
+    );
+    assert_eq!(
+        fresh_named_count, 20,
+        "the 20 named-graph inserts are visible to a fresh read"
+    );
 
     // Clean shutdown.
     drop(writer);

--- a/crates/sparq-serve/tests/stress.rs
+++ b/crates/sparq-serve/tests/stress.rs
@@ -24,7 +24,10 @@ struct MockSnapshot {
 impl MockSnapshot {
     fn new(value: u64, live: &Arc<AtomicUsize>) -> Self {
         live.fetch_add(1, Ordering::SeqCst);
-        MockSnapshot { value, live: live.clone() }
+        MockSnapshot {
+            value,
+            live: live.clone(),
+        }
     }
 }
 
@@ -57,7 +60,10 @@ fn concurrent_readers_pin_across_many_publishes_without_torn_reads() {
     let live = Arc::new(AtomicUsize::new(0));
     let ring = Arc::new(GenerationRing::with_config(
         MockSnapshot::new(0, &live),
-        RingConfig { retain: 4, ..RingConfig::default() },
+        RingConfig {
+            retain: 4,
+            ..RingConfig::default()
+        },
     ));
     let done = Arc::new(AtomicBool::new(false));
 
@@ -105,7 +111,11 @@ fn concurrent_readers_pin_across_many_publishes_without_torn_reads() {
     for i in 1..=PUBLISHES {
         let pod = PodId::new(format!("pod:{}", i % POD_FANOUT));
         let gen = ring.publish(MockSnapshot::new(i, &live), [pod]);
-        assert_eq!(gen.number(), i, "single writer must observe dense numbering");
+        assert_eq!(
+            gen.number(),
+            i,
+            "single writer must observe dense numbering"
+        );
         published += 1;
     }
     done.store(true, Ordering::Release);
@@ -127,5 +137,8 @@ fn concurrent_readers_pin_across_many_publishes_without_torn_reads() {
     drop(final_gen);
     assert_eq!(ring.live_generations(), ring.retain_bound() + 1);
     assert_eq!(live.load(Ordering::SeqCst), ring.retain_bound() + 1);
-    assert_eq!(ring.oldest_retained(), PUBLISHES - ring.retain_bound() as u64);
+    assert_eq!(
+        ring.oldest_retained(),
+        PUBLISHES - ring.retain_bound() as u64
+    );
 }

--- a/crates/sparq-serve/tests/time_travel.rs
+++ b/crates/sparq-serve/tests/time_travel.rs
@@ -16,7 +16,14 @@ use sparq_serve::{GenerationRing, RingConfig, TimeTravelConfig};
 /// Snapshots are plain u64 payloads here: time travel is about *which* generation
 /// is served, not about drop instrumentation (tests/ring.rs covers reclamation).
 fn ring(retain: usize, tt: Option<TimeTravelConfig>) -> GenerationRing<u64> {
-    GenerationRing::with_config(0, RingConfig { retain, time_travel: tt, ..RingConfig::default() })
+    GenerationRing::with_config(
+        0,
+        RingConfig {
+            retain,
+            time_travel: tt,
+            ..RingConfig::default()
+        },
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -25,7 +32,13 @@ fn ring(retain: usize, tt: Option<TimeTravelConfig>) -> GenerationRing<u64> {
 
 #[test]
 fn at_hits_every_retained_generation_and_misses_the_rest() {
-    let ring = ring(2, Some(TimeTravelConfig { max_generations: 8, max_age: None }));
+    let ring = ring(
+        2,
+        Some(TimeTravelConfig {
+            max_generations: 8,
+            max_age: None,
+        }),
+    );
     for i in 1..=10u64 {
         ring.publish(i, std::iter::empty());
     }
@@ -34,7 +47,9 @@ fn at_hits_every_retained_generation_and_misses_the_rest() {
 
     // Hit: every retained generation, including current, served with its own data.
     for n in 2..=10u64 {
-        let g = ring.at(n).unwrap_or_else(|| panic!("generation {n} should be retained"));
+        let g = ring
+            .at(n)
+            .unwrap_or_else(|| panic!("generation {n} should be retained"));
         assert_eq!(g.number(), n);
         assert_eq!(*g.snapshot(), n);
     }
@@ -42,7 +57,10 @@ fn at_hits_every_retained_generation_and_misses_the_rest() {
     assert!(ring.at(1).is_none(), "generation 1 aged out of the window");
     assert!(ring.at(0).is_none(), "generation 0 aged out of the window");
     // Miss: never published.
-    assert!(ring.at(11).is_none(), "generation 11 has not been published");
+    assert!(
+        ring.at(11).is_none(),
+        "generation 11 has not been published"
+    );
     assert!(ring.at(u64::MAX).is_none());
 }
 
@@ -55,7 +73,10 @@ fn at_without_time_travel_serves_exactly_the_k_window() {
         ring.publish(i, std::iter::empty());
     }
     assert_eq!(ring.oldest_retained(), 7);
-    assert!(ring.at(6).is_none(), "beyond K with no time travel: aged out");
+    assert!(
+        ring.at(6).is_none(),
+        "beyond K with no time travel: aged out"
+    );
     assert_eq!(*ring.at(7).expect("inside K").snapshot(), 7);
     assert_eq!(*ring.at(10).expect("current").snapshot(), 10);
 }
@@ -70,7 +91,11 @@ fn at_returns_none_for_a_generation_only_a_reader_still_pins() {
         ring.publish(i, std::iter::empty());
     }
     assert_eq!(pinned.number(), 0);
-    assert_eq!(*pinned.snapshot(), 0, "the pin itself still serves old data");
+    assert_eq!(
+        *pinned.snapshot(),
+        0,
+        "the pin itself still serves old data"
+    );
     assert!(ring.at(0).is_none(), "ring no longer owns generation 0");
 }
 
@@ -82,21 +107,41 @@ fn at_returns_none_for_a_generation_only_a_reader_still_pins() {
 fn k_floor_wins_when_time_travel_bound_is_smaller() {
     // time-travel max_generations < K: the concurrency floor wins — time travel
     // can extend retention, never shrink it below K.
-    let ring = ring(4, Some(TimeTravelConfig { max_generations: 1, max_age: None }));
+    let ring = ring(
+        4,
+        Some(TimeTravelConfig {
+            max_generations: 1,
+            max_age: None,
+        }),
+    );
     for i in 1..=10u64 {
         ring.publish(i, std::iter::empty());
     }
-    assert_eq!(ring.oldest_retained(), 6, "K=4 older generations kept despite max_generations=1");
+    assert_eq!(
+        ring.oldest_retained(),
+        6,
+        "K=4 older generations kept despite max_generations=1"
+    );
     assert_eq!(ring.live_generations(), 5);
 }
 
 #[test]
 fn time_travel_bound_wins_when_larger_than_k() {
-    let ring = ring(2, Some(TimeTravelConfig { max_generations: 6, max_age: None }));
+    let ring = ring(
+        2,
+        Some(TimeTravelConfig {
+            max_generations: 6,
+            max_age: None,
+        }),
+    );
     for i in 1..=10u64 {
         ring.publish(i, std::iter::empty());
     }
-    assert_eq!(ring.oldest_retained(), 4, "max_generations=6 older generations kept, K=2 floor inactive");
+    assert_eq!(
+        ring.oldest_retained(),
+        4,
+        "max_generations=6 older generations kept, K=2 floor inactive"
+    );
     assert_eq!(ring.live_generations(), 7);
 }
 
@@ -137,7 +182,11 @@ fn max_age_evicts_only_beyond_the_k_floor_and_only_on_publish() {
     // and 3 (1030) are over-age too. But gen 4 sits inside the K=1 floor, which
     // age NEVER evicts.
     ring.publish(5, std::iter::empty());
-    assert_eq!(ring.oldest_retained(), 4, "over-age extension evicted, K floor kept");
+    assert_eq!(
+        ring.oldest_retained(),
+        4,
+        "over-age extension evicted, K floor kept"
+    );
     assert!(ring.at(3).is_none(), "aged out by max_age");
     assert_eq!(*ring.at(4).expect("K floor survives any age").snapshot(), 4);
     assert_eq!(*ring.at(5).expect("current").snapshot(), 5);
@@ -160,7 +209,10 @@ fn as_of_resolves_timestamps_to_the_generation_current_at_that_time() {
         0u64,
         RingConfig {
             retain: 0,
-            time_travel: Some(TimeTravelConfig { max_generations: 2, max_age: None }),
+            time_travel: Some(TimeTravelConfig {
+                max_generations: 2,
+                max_age: None,
+            }),
             clock,
         },
     );
@@ -170,7 +222,11 @@ fn as_of_resolves_timestamps_to_the_generation_current_at_that_time() {
     CLOCK_SECS.store(300, Ordering::SeqCst);
     ring.publish(2, std::iter::empty());
 
-    assert_eq!(ring.at(1).unwrap().published_at(), at(200), "publish stamps the injected clock");
+    assert_eq!(
+        ring.at(1).unwrap().published_at(),
+        at(200),
+        "publish stamps the injected clock"
+    );
 
     // Exact hits and in-between times resolve to the generation current THEN.
     assert_eq!(ring.as_of(at(100)).unwrap().number(), 0);
@@ -188,6 +244,13 @@ fn as_of_resolves_timestamps_to_the_generation_current_at_that_time() {
     CLOCK_SECS.store(400, Ordering::SeqCst);
     ring.publish(3, std::iter::empty());
     assert!(ring.at(0).is_none());
-    assert!(ring.as_of(at(150)).is_none(), "the generation covering t=150 aged out");
-    assert_eq!(ring.as_of(at(200)).unwrap().number(), 1, "still-retained history resolves");
+    assert!(
+        ring.as_of(at(150)).is_none(),
+        "the generation covering t=150 aged out"
+    );
+    assert_eq!(
+        ring.as_of(at(200)).unwrap().number(),
+        1,
+        "still-retained history resolves"
+    );
 }

--- a/crates/sparq-serve/tests/tokens.rs
+++ b/crates/sparq-serve/tests/tokens.rs
@@ -17,9 +17,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use sparq_serve::{
-    ApplyUpdates, GenerationRing, PodId, Writer, WriterConfig,
-};
+use sparq_serve::{ApplyUpdates, GenerationRing, PodId, Writer, WriterConfig};
 
 /// Snapshot = applied-update log (mirrors tests/writer.rs).
 type Log = Vec<String>;
@@ -56,7 +54,11 @@ fn token_is_satisfied_immediately_on_the_acking_ring() {
     let writer = Writer::spawn(
         ring.clone(),
         LogApplier,
-        WriterConfig { window: Duration::from_millis(1), max_batch: 256, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(1),
+            max_batch: 256,
+            ..WriterConfig::default()
+        },
     );
 
     for expect in 1..=5u64 {
@@ -79,7 +81,11 @@ fn read_your_writes_boundary() {
     let writer = Writer::spawn(
         ring.clone(),
         LogApplier,
-        WriterConfig { window: Duration::from_millis(1), max_batch: 256, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(1),
+            max_batch: 256,
+            ..WriterConfig::default()
+        },
     );
     let token = writer.submit("only".into(), pod("p")).unwrap();
     assert_eq!(token, 1);
@@ -109,7 +115,11 @@ fn lagging_replica_refuses_then_accepts_token() {
     let lw = Writer::spawn(
         leader.clone(),
         LogApplier,
-        WriterConfig { window: Duration::from_millis(1), max_batch: 256, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(1),
+            max_batch: 256,
+            ..WriterConfig::default()
+        },
     );
 
     // Leader applies three updates; replica is still at generation 0.
@@ -134,7 +144,11 @@ fn lagging_replica_refuses_then_accepts_token() {
     let rw = Writer::spawn(
         replica.clone(),
         LogApplier,
-        WriterConfig { window: Duration::from_millis(1), max_batch: 256, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(1),
+            max_batch: 256,
+            ..WriterConfig::default()
+        },
     );
     for i in 0..3 {
         rw.submit(format!("u{i}"), pod("p")).unwrap();
@@ -157,7 +171,11 @@ fn satisfied_token_pin_never_regresses_under_concurrent_writes() {
     let writer = Arc::new(Writer::spawn(
         ring.clone(),
         LogApplier,
-        WriterConfig { window: Duration::from_millis(1), max_batch: 16, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(1),
+            max_batch: 16,
+            ..WriterConfig::default()
+        },
     ));
 
     // Establish a token at generation 1.
@@ -182,7 +200,10 @@ fn satisfied_token_pin_never_regresses_under_concurrent_writes() {
     // Reader: every satisfied pin reflects at least the token.
     for _ in 0..50_000 {
         if let Some(g) = ring.read_your_writes(token) {
-            assert!(g.number() >= token, "a satisfied RYW pin never regresses below its token");
+            assert!(
+                g.number() >= token,
+                "a satisfied RYW pin never regresses below its token"
+            );
         }
     }
     // The feeder ran concurrently throughout the reader spin, but on a contended CPU
@@ -197,5 +218,8 @@ fn satisfied_token_pin_never_regresses_under_concurrent_writes() {
     }
     stop.store(true, Ordering::Relaxed);
     feeder.join().unwrap();
-    assert!(ring.current().number() > 1, "writer advanced past the anchor");
+    assert!(
+        ring.current().number() > 1,
+        "writer advanced past the anchor"
+    );
 }

--- a/crates/sparq-serve/tests/writer.rs
+++ b/crates/sparq-serve/tests/writer.rs
@@ -9,9 +9,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use sparq_serve::{
-    ApplyUpdates, GenerationRing, PodId, WriteError, Writer, WriterConfig,
-};
+use sparq_serve::{ApplyUpdates, GenerationRing, PodId, WriteError, Writer, WriterConfig};
 
 /// Snapshot = the log of applied updates, in application order.
 type Log = Vec<String>;
@@ -162,7 +160,11 @@ fn one_window_one_generation_epochs_union() {
     let writer = Writer::spawn(
         ring.clone(),
         MockApplier::new(&forks),
-        WriterConfig { window: Duration::from_millis(250), max_batch: 64, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(250),
+            max_batch: 64,
+            ..WriterConfig::default()
+        },
     );
 
     // 7 fire-and-forget + 1 sync, all queued well inside the 250 ms window the
@@ -172,20 +174,33 @@ fn one_window_one_generation_epochs_union() {
             .submit_detached(format!("u{i}"), pods(&[&format!("pod:{i}"), "pod:shared"]))
             .unwrap();
     }
-    let generation = writer.submit("u7".to_string(), pods(&["pod:7", "pod:shared"])).unwrap();
+    let generation = writer
+        .submit("u7".to_string(), pods(&["pod:7", "pod:shared"]))
+        .unwrap();
 
-    assert_eq!(generation, 1, "all 8 updates collapse into the single generation 1");
+    assert_eq!(
+        generation, 1,
+        "all 8 updates collapse into the single generation 1"
+    );
     let current = ring.current();
     assert_eq!(current.number(), 1);
     let expected: Log = (0..8).map(|i| format!("u{i}")).collect();
-    assert_eq!(*current.snapshot(), expected, "strict FIFO submission order");
+    assert_eq!(
+        *current.snapshot(),
+        expected,
+        "strict FIFO submission order"
+    );
     // Union of touched pods, each bumped ONCE per publish (dedup across updates).
     for i in 0..8 {
         assert_eq!(current.epochs().epoch(&PodId::from(format!("pod:{i}"))), 1);
     }
     assert_eq!(current.epochs().epoch(&PodId::from("pod:shared")), 1);
     assert_eq!(current.epochs().len(), 9);
-    assert_eq!(forks.load(Ordering::SeqCst), 1, "one working copy for the whole batch");
+    assert_eq!(
+        forks.load(Ordering::SeqCst),
+        1,
+        "one working copy for the whole batch"
+    );
 }
 
 /// Sequential sync submits land in consecutive generations and each ack carries
@@ -197,7 +212,11 @@ fn sync_submit_returns_its_generation_number() {
     let writer = Writer::spawn(
         ring.clone(),
         MockApplier::new(&forks),
-        WriterConfig { window: Duration::from_millis(1), max_batch: 256, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(1),
+            max_batch: 256,
+            ..WriterConfig::default()
+        },
     );
 
     // Each submit blocks until publish, so the next opens a fresh window.
@@ -207,7 +226,10 @@ fn sync_submit_returns_its_generation_number() {
 
     let current = ring.current();
     assert_eq!(current.number(), 3);
-    assert_eq!(*current.snapshot(), vec!["a".to_string(), "b".into(), "c".into()]);
+    assert_eq!(
+        *current.snapshot(),
+        vec!["a".to_string(), "b".into(), "c".into()]
+    );
     assert_eq!(current.epochs().epoch(&PodId::from("p")), 2);
     assert_eq!(current.epochs().epoch(&PodId::from("q")), 1);
 }
@@ -223,7 +245,11 @@ fn failed_update_is_isolated_and_recovered() {
     let writer = Arc::new(Writer::spawn(
         ring.clone(),
         MockApplier::new(&forks),
-        WriterConfig { window: Duration::from_millis(300), max_batch: 64, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(300),
+            max_batch: 64,
+            ..WriterConfig::default()
+        },
     ));
 
     // Deterministic in-window order via staggered sync submitters: a (t≈0),
@@ -247,15 +273,35 @@ fn failed_update_is_isolated_and_recovered() {
         WriteError::Rejected("boom".into()),
         "the failed update's submitter gets ITS error"
     );
-    assert_eq!(c.join().unwrap().unwrap(), 1, "the batch survivor publishes in the same generation");
+    assert_eq!(
+        c.join().unwrap().unwrap(),
+        1,
+        "the batch survivor publishes in the same generation"
+    );
 
     let current = ring.current();
-    assert_eq!(current.number(), 1, "one generation despite the mid-batch failure");
-    assert_eq!(*current.snapshot(), vec!["a".to_string(), "c".into()], "no POISON, order kept");
+    assert_eq!(
+        current.number(),
+        1,
+        "one generation despite the mid-batch failure"
+    );
+    assert_eq!(
+        *current.snapshot(),
+        vec!["a".to_string(), "c".into()],
+        "no POISON, order kept"
+    );
     assert_eq!(current.epochs().epoch(&PodId::from("pod:a")), 1);
     assert_eq!(current.epochs().epoch(&PodId::from("pod:c")), 1);
-    assert_eq!(current.epochs().epoch(&PodId::from("pod:bad")), 0, "skipped update bumps nothing");
-    assert_eq!(forks.load(Ordering::SeqCst), 2, "initial fork + one recovery re-fork");
+    assert_eq!(
+        current.epochs().epoch(&PodId::from("pod:bad")),
+        0,
+        "skipped update bumps nothing"
+    );
+    assert_eq!(
+        forks.load(Ordering::SeqCst),
+        2,
+        "initial fork + one recovery re-fork"
+    );
 }
 
 /// A batch in which EVERY update fails publishes nothing — the generation
@@ -267,12 +313,22 @@ fn all_failed_batch_publishes_no_generation() {
     let writer = Writer::spawn(
         ring.clone(),
         MockApplier::new(&forks),
-        WriterConfig { window: Duration::from_millis(1), max_batch: 8, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(1),
+            max_batch: 8,
+            ..WriterConfig::default()
+        },
     );
 
-    let err = writer.submit("fail:nope".into(), pods(&["pod:x"])).unwrap_err();
+    let err = writer
+        .submit("fail:nope".into(), pods(&["pod:x"]))
+        .unwrap_err();
     assert_eq!(err, WriteError::Rejected("nope".into()));
-    assert_eq!(ring.current().number(), 0, "nothing changed, nothing published");
+    assert_eq!(
+        ring.current().number(),
+        0,
+        "nothing changed, nothing published"
+    );
     assert!(ring.current().epochs().is_empty());
 
     // The writer is still healthy afterwards.
@@ -288,7 +344,11 @@ fn window_closes_early_on_max_batch() {
     let writer = Arc::new(Writer::spawn(
         ring.clone(),
         MockApplier::new(&forks),
-        WriterConfig { window: Duration::from_secs(10), max_batch: 2, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_secs(10),
+            max_batch: 2,
+            ..WriterConfig::default()
+        },
     ));
 
     let started = Instant::now();
@@ -300,7 +360,11 @@ fn window_closes_early_on_max_batch() {
     let g1 = t.join().unwrap().unwrap();
     let elapsed = started.elapsed();
 
-    assert_eq!((g1, g2), (1, 1), "both updates in the one max_batch-closed generation");
+    assert_eq!(
+        (g1, g2),
+        (1, 1),
+        "both updates in the one max_batch-closed generation"
+    );
     assert!(
         elapsed < Duration::from_secs(5),
         "max_batch must close the 10 s window early (took {elapsed:?})"
@@ -317,7 +381,11 @@ fn window_timing_approximately_honored() {
     let writer = Writer::spawn(
         ring.clone(),
         MockApplier::new(&forks),
-        WriterConfig { window: Duration::from_millis(80), max_batch: 256, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(80),
+            max_batch: 256,
+            ..WriterConfig::default()
+        },
     );
 
     let started = Instant::now();
@@ -343,14 +411,21 @@ fn drop_drains_pending_batch() {
     let writer = Writer::spawn(
         ring.clone(),
         MockApplier::new(&forks),
-        WriterConfig { window: Duration::from_secs(10), max_batch: 256, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_secs(10),
+            max_batch: 256,
+            ..WriterConfig::default()
+        },
     );
 
     writer.submit_detached("a".into(), pods(&["p"])).unwrap();
     writer.submit_detached("b".into(), pods(&["q"])).unwrap();
     let started = Instant::now();
     drop(writer); // closes the queue; the open window ends early; batch commits
-    assert!(started.elapsed() < Duration::from_secs(5), "drop does not wait out the window");
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "drop does not wait out the window"
+    );
 
     let current = ring.current();
     assert_eq!(current.number(), 1);
@@ -367,13 +442,23 @@ fn applier_panic_reports_shutdown() {
     let writer = Writer::spawn(
         ring.clone(),
         MockApplier::new(&forks),
-        WriterConfig { window: Duration::from_millis(1), max_batch: 8, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(1),
+            max_batch: 8,
+            ..WriterConfig::default()
+        },
     );
 
-    assert_eq!(writer.submit("panic".into(), pods(&["p"])).unwrap_err(), WriteError::Shutdown);
+    assert_eq!(
+        writer.submit("panic".into(), pods(&["p"])).unwrap_err(),
+        WriteError::Shutdown
+    );
     // The thread is gone (the receiver dropped with it): later submissions fail
     // fast instead of queueing forever.
-    assert_eq!(writer.submit("a".into(), pods(&["p"])).unwrap_err(), WriteError::Shutdown);
+    assert_eq!(
+        writer.submit("a".into(), pods(&["p"])).unwrap_err(),
+        WriteError::Shutdown
+    );
     assert_eq!(ring.current().number(), 0);
 }
 
@@ -396,7 +481,11 @@ fn readers_never_stall_while_writer_commits() {
             maintain_fails: Arc::new(AtomicUsize::new(0)),
             committed: 0,
         },
-        WriterConfig { window: Duration::from_millis(1), max_batch: 64, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(1),
+            max_batch: 64,
+            ..WriterConfig::default()
+        },
     ));
 
     let stop = Arc::new(AtomicBool::new(false));
@@ -408,7 +497,10 @@ fn readers_never_stall_while_writer_commits() {
         std::thread::spawn(move || {
             let mut i = 0u64;
             while !stop.load(Ordering::Relaxed) {
-                if writer.submit_detached(format!("u{i}"), [PodId::from("pod:w")]).is_err() {
+                if writer
+                    .submit_detached(format!("u{i}"), [PodId::from("pod:w")])
+                    .is_err()
+                {
                     break;
                 }
                 i += 1;
@@ -440,17 +532,27 @@ fn readers_never_stall_while_writer_commits() {
     feeder.join().unwrap();
 
     let committed = ring.current().number();
-    assert!(committed > 50, "writer must have committed continuously (got {committed})");
+    assert!(
+        committed > 50,
+        "writer must have committed continuously (got {committed})"
+    );
 
     for r in readers {
         let mut lat = r.join().unwrap();
-        assert!(lat.len() > 10_000, "reader must have run hot ({} reads)", lat.len());
+        assert!(
+            lat.len() > 10_000,
+            "reader must have run hot ({} reads)",
+            lat.len()
+        );
         lat.sort_unstable();
         let p99 = lat[lat.len() * 99 / 100];
         // Lock-free load is ~tens of ns; 1 ms is two orders of magnitude of
         // scheduler-noise headroom. A reader blocked behind a 2 ms fork or the
         // writer's batch application would blow straight past this.
-        assert!(p99 < 1_000_000, "reader p99 = {p99} ns — a read blocked on the write path");
+        assert!(
+            p99 < 1_000_000,
+            "reader p99 = {p99} ns — a read blocked on the write path"
+        );
     }
 }
 
@@ -469,7 +571,11 @@ fn transient_seal_failure_refuses_then_recovers() {
         ring.clone(),
         MockApplier::with_seal_control(&forks, &seal_fails, &seals),
         // One update per window so each is its own batch / generation attempt.
-        WriterConfig { window: Duration::from_millis(5), max_batch: 1, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(5),
+            max_batch: 1,
+            ..WriterConfig::default()
+        },
     );
 
     // Baseline: a normal write publishes generation 1.
@@ -500,11 +606,20 @@ fn transient_seal_failure_refuses_then_recovers() {
 
     // The writer thread SURVIVED: a subsequent write after recovery succeeds + publishes.
     let g2 = writer.submit("ok-2".to_string(), pods(&["pod:a"])).unwrap();
-    assert_eq!(g2, 2, "writer must keep running and publish after a transient failure");
-    assert_eq!(ring.current().snapshot(), &vec!["ok-1".to_string(), "ok-2".to_string()]);
+    assert_eq!(
+        g2, 2,
+        "writer must keep running and publish after a transient failure"
+    );
+    assert_eq!(
+        ring.current().snapshot(),
+        &vec!["ok-1".to_string(), "ok-2".to_string()]
+    );
 
     // Sanity: the writer actually re-attempted the seal after the refusal.
-    assert!(seals.load(Ordering::SeqCst) >= 3, "writer must have re-attempted seal after refusal");
+    assert!(
+        seals.load(Ordering::SeqCst) >= 3,
+        "writer must have re-attempted seal after refusal"
+    );
 }
 
 /// [OPUS-4.8] (sq-vpx4) Per-submitter failure semantics when `seal` fails on a MIXED
@@ -522,7 +637,11 @@ fn seal_failure_keeps_apply_rejection_distinct_from_unavailable() {
     let writer = Arc::new(Writer::spawn(
         ring.clone(),
         MockApplier::with_seal_control(&forks, &seal_fails, &seals),
-        WriterConfig { window: Duration::from_millis(300), max_batch: 64, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(300),
+            max_batch: 64,
+            ..WriterConfig::default()
+        },
     ));
 
     // Arm ONE seal failure: it fires when the writer seals this batch.
@@ -554,10 +673,19 @@ fn seal_failure_keeps_apply_rejection_distinct_from_unavailable() {
     );
 
     // FAIL-CLOSED: nothing published; the writer survived and recovers on the next write.
-    assert_eq!(ring.current().number(), 0, "a seal-failed batch must publish no generation");
+    assert_eq!(
+        ring.current().number(),
+        0,
+        "a seal-failed batch must publish no generation"
+    );
     assert!(ring.current().snapshot().is_empty());
-    let g = writer.submit("ok-after".to_string(), pods(&["pod:ok"])).unwrap();
-    assert_eq!(g, 1, "writer must keep running and publish once durability recovers");
+    let g = writer
+        .submit("ok-after".to_string(), pods(&["pod:ok"]))
+        .unwrap();
+    assert_eq!(
+        g, 1,
+        "writer must keep running and publish once durability recovers"
+    );
 }
 
 /// [OPUS-4.8] (sq-vpx4) A PERSISTENT durable-write error → every write is refused with
@@ -573,7 +701,11 @@ fn persistent_seal_failure_refuses_repeatedly_reads_survive() {
     let writer = Writer::spawn(
         ring.clone(),
         MockApplier::with_seal_control(&forks, &seal_fails, &seals),
-        WriterConfig { window: Duration::from_millis(5), max_batch: 1, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(5),
+            max_batch: 1,
+            ..WriterConfig::default()
+        },
     );
 
     // Establish a published snapshot, then jam durability "persistently".
@@ -587,7 +719,11 @@ fn persistent_seal_failure_refuses_repeatedly_reads_survive() {
             "write #{n} under persistent durability failure must be Unavailable, got {r:?}",
         );
         // Reads still served from the last good snapshot throughout the outage.
-        assert_eq!(ring.current().number(), 1, "reads must keep serving generation 1 during the outage");
+        assert_eq!(
+            ring.current().number(),
+            1,
+            "reads must keep serving generation 1 during the outage"
+        );
         assert_eq!(ring.current().snapshot(), &vec!["ok-1".to_string()]);
     }
 
@@ -613,7 +749,11 @@ fn maintain_runs_after_preceding_updates_no_new_generation() {
         ring.clone(),
         MockApplier::with_maintain_control(&forks, &maintains, &maintain_fails),
         // Tiny window so each submit commits as its own generation promptly.
-        WriterConfig { window: Duration::from_millis(5), max_batch: 64, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(5),
+            max_batch: 64,
+            ..WriterConfig::default()
+        },
     );
 
     // Commit three updates (FIFO), each its own generation.
@@ -621,15 +761,31 @@ fn maintain_runs_after_preceding_updates_no_new_generation() {
         writer.submit(format!("u{n}"), pods(&["pod:a"])).unwrap();
     }
     let gen_before = ring.current().number();
-    assert_eq!(ring.current().snapshot().len(), 3, "three updates committed");
+    assert_eq!(
+        ring.current().snapshot().len(),
+        3,
+        "three updates committed"
+    );
 
     // Maintenance: blocks, runs on the writer thread, returns Ok.
     assert_eq!(writer.maintain().unwrap(), Ok(()));
 
     // It observed all three committed updates (ran after them), and published no generation.
-    assert_eq!(*maintains.lock().unwrap(), vec![3], "maintain ran once, after the 3 updates");
-    assert_eq!(ring.current().number(), gen_before, "maintenance must not publish a new generation");
-    assert_eq!(ring.current().snapshot().len(), 3, "the live snapshot is unchanged by maintenance");
+    assert_eq!(
+        *maintains.lock().unwrap(),
+        vec![3],
+        "maintain ran once, after the 3 updates"
+    );
+    assert_eq!(
+        ring.current().number(),
+        gen_before,
+        "maintenance must not publish a new generation"
+    );
+    assert_eq!(
+        ring.current().snapshot().len(),
+        3,
+        "the live snapshot is unchanged by maintenance"
+    );
 }
 
 /// A maintenance FAILURE is reported to the caller (inner `Err`) WITHOUT tearing down the writer:
@@ -643,17 +799,32 @@ fn maintain_failure_keeps_writer_alive() {
     let writer = Writer::spawn(
         ring.clone(),
         MockApplier::with_maintain_control(&forks, &maintains, &maintain_fails),
-        WriterConfig { window: Duration::from_millis(5), max_batch: 64, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(5),
+            max_batch: 64,
+            ..WriterConfig::default()
+        },
     );
 
     writer.submit("u0".to_string(), pods(&["pod:a"])).unwrap();
     // First maintenance fails (inner Err), but the writer thread survives.
     let r = writer.maintain().unwrap();
-    assert!(r.is_err(), "armed maintenance failure must surface as Err, got {r:?}");
+    assert!(
+        r.is_err(),
+        "armed maintenance failure must surface as Err, got {r:?}"
+    );
     // A subsequent write still commits…
     writer.submit("u1".to_string(), pods(&["pod:a"])).unwrap();
-    assert_eq!(ring.current().snapshot().len(), 2, "writes work after a maintenance failure");
+    assert_eq!(
+        ring.current().snapshot().len(),
+        2,
+        "writes work after a maintenance failure"
+    );
     // …and a later maintenance now succeeds.
     assert_eq!(writer.maintain().unwrap(), Ok(()));
-    assert_eq!(maintains.lock().unwrap().len(), 2, "both maintenance attempts ran");
+    assert_eq!(
+        maintains.lock().unwrap().len(),
+        2,
+        "both maintenance attempts ran"
+    );
 }

--- a/crates/sparq-serve/tests/writer_graph.rs
+++ b/crates/sparq-serve/tests/writer_graph.rs
@@ -30,12 +30,18 @@ fn sparql_batch_publishes_one_generation() {
     let writer = Writer::spawn(
         ring.clone(),
         GraphApplier::new(),
-        WriterConfig { window: Duration::from_millis(200), max_batch: 64, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(200),
+            max_batch: 64,
+            ..WriterConfig::default()
+        },
     );
 
     let before = ring.current(); // pinned across the commit
     for i in 0..3 {
-        writer.submit_detached(insert(i), [PodId::from("pod:alice")]).unwrap();
+        writer
+            .submit_detached(insert(i), [PodId::from("pod:alice")])
+            .unwrap();
     }
     let generation = writer
         .submit(
@@ -44,7 +50,10 @@ fn sparql_batch_publishes_one_generation() {
         )
         .unwrap();
 
-    assert_eq!(generation, 1, "3 inserts + 1 delete in one window = one generation");
+    assert_eq!(
+        generation, 1,
+        "3 inserts + 1 delete in one window = one generation"
+    );
     let current = ring.current();
     assert_eq!(current.number(), 1);
     assert_eq!(current.snapshot().len(), 12, "10 + 3 inserts - 1 delete");
@@ -61,10 +70,16 @@ fn bad_sparql_is_isolated_from_its_batch() {
     let writer = Arc::new(Writer::spawn(
         ring.clone(),
         GraphApplier::new(),
-        WriterConfig { window: Duration::from_millis(300), max_batch: 64, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(300),
+            max_batch: 64,
+            ..WriterConfig::default()
+        },
     ));
 
-    writer.submit_detached(insert(0), [PodId::from("pod:a")]).unwrap();
+    writer
+        .submit_detached(insert(0), [PodId::from("pod:a")])
+        .unwrap();
     let bad = {
         let writer = writer.clone();
         std::thread::spawn(move || {
@@ -101,11 +116,17 @@ fn consecutive_windows_consecutive_generations() {
     let writer = Writer::spawn(
         ring.clone(),
         GraphApplier::new(),
-        WriterConfig { window: Duration::from_millis(1), max_batch: 256, ..WriterConfig::default() },
+        WriterConfig {
+            window: Duration::from_millis(1),
+            max_batch: 256,
+            ..WriterConfig::default()
+        },
     );
 
     for expect in 1..=4u64 {
-        let g = writer.submit(insert(expect as usize), [PodId::from("pod:a")]).unwrap();
+        let g = writer
+            .submit(insert(expect as usize), [PodId::from("pod:a")])
+            .unwrap();
         assert_eq!(g, expect);
     }
     assert_eq!(ring.current().snapshot().len(), 6);
@@ -146,7 +167,9 @@ fn fork_cost_measurement() {
             best = best.min(t.elapsed());
             assert_eq!(f.len(), n);
         }
-        println!("fork of {n} triples: first (freeze) {first_cost:?}, steady-state {best:?} (best of 5)");
+        println!(
+            "fork of {n} triples: first (freeze) {first_cost:?}, steady-state {best:?} (best of 5)"
+        );
 
         // Full commit cycle: fork + 10-triple INSERT DATA + seal, chained like the
         // writer (each commit forks the previous sealed generation). 2000 commits
@@ -207,7 +230,10 @@ fn pending_delta_stays_bounded_under_sustained_updates() {
         max_pending < threshold + 5,
         "pending delta must stay bounded by threshold + one batch (saw {max_pending})"
     );
-    assert!(compactions >= 5, "compaction must keep firing (saw {compactions})");
+    assert!(
+        compactions >= 5,
+        "compaction must keep firing (saw {compactions})"
+    );
     assert_eq!(base.len(), 200 + 200 * 2);
     // And the final generation still answers correctly after many fold cycles.
     assert_eq!(


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Closes bead **sq-g47l**.

## What

One-shot `cargo fmt -p sparq-serve -p sparq-parse` to clear **146** pre-existing rustfmt diffs (124 in `sparq-serve` src/tests, 22 in `sparq-parse/src/lib.rs`) that predate the deferred workspace-wide reformat (see `rustfmt.toml`).

This is a **pure formatting change** — no token content changed, only rustfmt's canonical line-wrapping and trailing commas. `cargo fmt -p sparq-serve -p sparq-parse -- --check` now reports **0 diffs** (was 146).

## Why this scope

The bead (discovered during sq-ieqz) names exactly these two crates. The rest of the workspace fmt debt is intentionally **left untouched** so the CI `cargo fmt --all --check` lane stays *informational* (per the deferral note in `rustfmt.toml`) until the full reformat lands. This change reduces the informational diff count; it does not flip fmt to a hard gate.

## Gate (green)

- `cargo build` — clean for both crates
- `cargo clippy --all-targets -- -D warnings` — clean for both crates
- `cargo test` — all pass for both crates
- **Both feature states**: `sparq-parse` tested with default features **and** `--features zlib-ng` (pulls the `libz-ng-sys` C backend) — 13 unit + 1 doc-test pass in each; `sparq-serve` has no cargo features (single state, all integration tests pass).
- **Public API**: no signature *content* changed — rustfmt only line-wrapped two long `pub fn` signatures in `sparq-parse` (`compress_chunks`, `gzip_single_member`). Names/params/types/returns identical, so no `SKILL.md` update is required (G2).
- **Privacy gate**: N/A — no privacy/ZK/predicate-soundness code is touched; `sparq-serve` is the write-scheduler/generation-ring crate and `sparq-parse` is result compression.

[OPUS-4.8] — flagged for re-review when Fable returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)