### PR TITLE
docs(sparq-fedclient): fix crate-doc broken intra-doc links in default (fedclient OFF) build (sq-tiq4)

### DIFF
--- a/crates/sparq-fedclient/src/adaptive.rs
+++ b/crates/sparq-fedclient/src/adaptive.rs
@@ -26,7 +26,8 @@
 //! What Phase 7 adds is the **client-side execution loop** that engine drives: it runs the
 //! plan as a sequence of stages, **fetches** each leaf through the real
 //! [`FederatedSource`](crate::FederatedSource) adapter, feeds the *real observed row count*
-//! back into [`RuntimeStats`], asks the executor whether to re-plan the remaining stages, and
+//! back into [`RuntimeStats`](sparq_fedplan::RuntimeStats), asks the executor whether to
+//! re-plan the remaining stages, and
 //! joins the (possibly re-ordered) suffix with the **same** materialised
 //! [`natural_join`](crate::operators) the static interpreter uses. The observed cardinality is
 //! genuine — you cannot know a leaf's true cardinality until you have drained it, which is
@@ -35,7 +36,8 @@
 //! # The load-bearing correctness property (result-equivalence)
 //!
 //! > Re-planning changes the **plan**, never the **answer**. For any divergence, the adaptive
-//! > execution produces the **same solution multiset** as the static [`JoinTree`].
+//! > execution produces the **same solution multiset** as the static
+//! > [`JoinTree`](sparq_fedplan::JoinTree).
 //!
 //! This holds because a BGP's answer is the natural join of its per-pattern solution
 //! multisets, which is **commutative and associative** (proven exhaustively in
@@ -50,13 +52,14 @@
 //! # Honest scope (work-vs-stub split)
 //!
 //! REAL here: the leaf-scan-then-adaptive-join executor, the observed-cardinality capture from
-//! the real adapter, the [`RuntimeStats`] / [`AdaptiveExecutor`] wiring, the
+//! the real adapter, the [`RuntimeStats`](sparq_fedplan::RuntimeStats) /
+//! [`AdaptiveExecutor`](sparq_fedplan::AdaptiveExecutor) wiring, the
 //! at-most-once-per-boundary bound, and the two correctness tests on the real interpreter path
 //! (the in-crate canned-SRJ tests below, plus the end-to-end
 //! `tests/adaptive_result_equals_static.rs` against the REAL engine). The executor is
 //! **single-source** (it shares the Phase-3/5
 //! [`InterpError::MultiSource`](crate::operators::InterpError) guard) and each per-stage join
-//! is the materialised [`natural_join`].
+//! is the materialised [`natural_join`](crate::operators).
 //!
 //! By its nature the observed-cardinality boundary is a **materialisation point** — a leaf must
 //! be drained to be counted — so the adaptive path scans each leaf fully (once) to learn its

--- a/crates/sparq-fedclient/src/lib.rs
+++ b/crates/sparq-fedclient/src/lib.rs
@@ -1,83 +1,124 @@
-//! sparq-fedclient: a **streaming federation CLIENT** over heterogeneous remote RDF
-//! sources — the query *consumer* half of federation (epic **sq-dnko** / **sq-3183**,
-//! Phase 0 bead **sq-s1uy**). See `research/federation-client-design.md` for the full
-//! design (§4 architecture, §6 phased build plan, §7 honest risks).
-//!
-//! Given one SPARQL query and a set of heterogeneous remote sources — full SPARQL
-//! endpoints, bindings-restricted (brTPF) servers, plain TPF servers, and the *local*
-//! sparq engine — this crate (when complete) **discovers** each source's capability,
-//! **plans** a federated execution that pushes the most precise sub-query each source
-//! can answer (REUSING the [`sparq-fedplan`](sparq_fedplan) cost-based planner), and
-//! **streams** results back through non-blocking federation operators.
-//!
-//! # What has landed, and what is still ahead
-//!
-//! The crate began as the **Phase-0 compiling skeleton** (design §6) — the public module
-//! layout the design §4 names ([`source`], [`discovery`], [`planner`], [`pushdown`],
-//! [`operators`], [`stream`]), the **opt-in feature** ([`fedclient`](#opt-in-hard-constraint),
-//! OFF by default), and the **dependency-boundary proof** (below). Landed since, each behind
-//! the same default-OFF `fedclient` feature:
-//!
-//! * **Phase 1 — capability discovery** ([`discovery`], bead `sq-nfxl`): GET the source's
-//!   Service Description + `/.well-known/void`, parse them to a `Capability` +
-//!   `SourceDescriptor`, with a FedX-style ASK-probe fallback, all behind a default-deny
-//!   SSRF-guarded fetch seam.
-//! * **Phase 2 — source-type abstraction + Endpoint adapter** ([`source`], bead `sq-rsxf`):
-//!   [`SourceType`] (`Endpoint | BrTpf | Tpf | Local`), the [`FederatedSource`] trait, the
-//!   fine-grained [`Capability`](source::Capability) descriptor, and the real [`Endpoint`] SRJ
-//!   adapter over a [`Transport`] seam behind a default-deny [`EgressGuard`].
-//! * **Phase 3 — planner bridge + materialised single-source interpreter** ([`planner`] +
-//!   [`operators`], bead `sq-j27p`): [`SourceResolver`] index→adapter resolution + [`lower_leaf`],
-//!   and [`materialize_single_source`] + [`parse_srj`] + [`solutions_equal`].
-//! * **Phase 4 — capability-aware pushdown** ([`pushdown`], bead `sq-7byx`): per leaf / FedX
-//!   exclusive group, build the most precise sub-query a source can answer (projection +
-//!   common-variable-checked filters + ORDER/LIMIT under capability) — [`exclusive_groups`] +
-//!   [`push_group`] + [`render_values_block`], correctness-preservingly NARROWing each source.
-//! * **Phase 5 — streaming operators** ([`operators`] + [`stream`], bead `sq-vtba`): the
-//!   [`SolutionStream`] boundary the client owns, the bounded blocking [`ScatterPool`], the
-//!   `StreamJoin`-feeder [`StreamingJoin`], and the [`stream_single_source`] streaming
-//!   interpreter — backpressured + bounded (Rust ownership + the reused StreamJoin spill).
-//! * **Phase 6 — brTPF + TPF fragment adapters** ([`source`], bead `sq-2qze`): the real
-//!   Triple-Pattern-Fragments adapters ([`TpfSource`] / [`BrTpfSource`]) over a
-//!   [`FragmentTransport`] seam, complete-by-construction with count-metadata cardinality.
-//!
-//! * **Phase 7 — adaptive re-planning** ([`adaptive`], bead `sq-ij5x`, the FINAL phase): the
-//!   opt-in feedback loop that re-invokes [`sparq-fedplan`](sparq_fedplan)'s planner on the
-//!   **unjoined remainder** when observed cardinality diverges from the static estimate,
-//!   bounded to at most once per operator boundary — re-planning changes the plan, never the
-//!   answer ([`execute_adaptive_single_source`]). Behind the extra default-OFF
-//!   `fedclient-adaptive` feature (it pulls `sparq-fedplan/adaptive-replan`).
-//!
-//! With Phase 7 the **8-phase streaming federation client is feature-complete** (Phases 0–7
-//! all landed; epic sq-dnko closed). The public surface and the dependency boundary were made
-//! visible before the logic landed.
-//!
-//! # Opt-in (hard constraint)
-//!
-//! The whole client is behind the **`fedclient` cargo feature, OFF by default**, and the
-//! crate is a standalone workspace member with `publish = false`. `sparq-core` and
-//! `sparq-engine` **never** depend on it — the dependency arrow points one-way *into*
-//! the engine (the client reuses the engine's SERVICE transport + SSRF guard + local
-//! eval), so the default engine build and the WASM artifact are byte-identical with or
-//! without `sparq-fedclient`. A build that does not enable `fedclient` compiles an empty
-//! crate (mirrors [`sparq-fedplan`](sparq_fedplan)'s `fedplan` feature).
-//!
-//! # The dependency boundary (load-bearing, enforced)
-//!
-//! The boundary was **proved before any logic existed** (Phase 0) and is re-checked on every
-//! build. Two complementary checks enforce that neither `sparq-core` nor `sparq-engine` ever
-//! gains a dependency edge *to* `sparq-fedclient`, in both feature states:
-//!
-//! * `scripts/fedclient-boundary-guard.sh` — a CI step (in `feature-matrix.yml`) that
-//!   inverts the dependency graph (`cargo tree -i sparq-fedclient`) and fails if
-//!   `sparq-core` or `sparq-engine` appears as a dependent;
-//! * `tests/boundary.rs` — a hermetic `cargo metadata` test asserting the same invariant
-//!   from inside the test suite, so it gates even off the CI script.
-//!
-//! Both must FAIL if a future edit introduces such an edge.
-//!
-//! [OPUS-4.8] sq-s1uy / sq-73om — flagged for Fable re-review when available.
+// ─── Crate-level documentation ──────────────────────────────────────────────────────
+// [OPUS-4.8] sq-tiq4: the narrative below intra-doc-links the per-phase modules
+// (`source`/`discovery`/`planner`/`pushdown`/`operators`/`stream`/`adaptive`) and the
+// re-exported items — but EVERY one of those is `#[cfg(feature = "fedclient")]`-gated, so in
+// the DEFAULT (fedclient OFF) build none of them are in scope and `cargo doc` under
+// `-D rustdoc::broken_intra_doc_links` failed on ~40 unresolved links. The fix keeps the rich
+// linked narrative for the build where its targets actually exist (`fedclient` ON) and serves
+// a concise, link-free crate doc for the OFF build, so `cargo doc` is clean in BOTH states.
+// `deny(rustdoc::broken_intra_doc_links)` below locks the invariant in (rustdoc-only lint — it
+// fires under `cargo doc`, never under `cargo build`/`clippy`, so the existing gates are
+// unchanged). Mirror this split in any future crate-doc edit.
+#![cfg_attr(
+    feature = "fedclient",
+    doc = r#"sparq-fedclient: a **streaming federation CLIENT** over heterogeneous remote RDF
+sources — the query *consumer* half of federation (epic **sq-dnko** / **sq-3183**,
+Phase 0 bead **sq-s1uy**). See `research/federation-client-design.md` for the full
+design (§4 architecture, §6 phased build plan, §7 honest risks).
+
+Given one SPARQL query and a set of heterogeneous remote sources — full SPARQL
+endpoints, bindings-restricted (brTPF) servers, plain TPF servers, and the *local*
+sparq engine — this crate (when complete) **discovers** each source's capability,
+**plans** a federated execution that pushes the most precise sub-query each source
+can answer (REUSING the [`sparq-fedplan`](sparq_fedplan) cost-based planner), and
+**streams** results back through non-blocking federation operators.
+
+# What has landed, and what is still ahead
+
+The crate began as the **Phase-0 compiling skeleton** (design §6) — the public module
+layout the design §4 names ([`source`], [`discovery`], [`planner`], [`pushdown`],
+[`operators`], [`stream`]), the **opt-in feature** ([`fedclient`](#opt-in-hard-constraint),
+OFF by default), and the **dependency-boundary proof** (below). Landed since, each behind
+the same default-OFF `fedclient` feature:
+
+* **Phase 1 — capability discovery** ([`discovery`], bead `sq-nfxl`): GET the source's
+  Service Description + `/.well-known/void`, parse them to a `Capability` +
+  `SourceDescriptor`, with a FedX-style ASK-probe fallback, all behind a default-deny
+  SSRF-guarded fetch seam.
+* **Phase 2 — source-type abstraction + Endpoint adapter** ([`source`], bead `sq-rsxf`):
+  [`SourceType`] (`Endpoint | BrTpf | Tpf | Local`), the [`FederatedSource`] trait, the
+  fine-grained [`Capability`](source::Capability) descriptor, and the real [`Endpoint`] SRJ
+  adapter over a [`Transport`] seam behind a default-deny [`EgressGuard`].
+* **Phase 3 — planner bridge + materialised single-source interpreter** ([`planner`] +
+  [`operators`], bead `sq-j27p`): [`SourceResolver`] index→adapter resolution + [`lower_leaf`],
+  and [`materialize_single_source`] + [`parse_srj`] + [`solutions_equal`].
+* **Phase 4 — capability-aware pushdown** ([`pushdown`], bead `sq-7byx`): per leaf / FedX
+  exclusive group, build the most precise sub-query a source can answer (projection +
+  common-variable-checked filters + ORDER/LIMIT under capability) — [`exclusive_groups`] +
+  [`push_group`] + [`render_values_block`], correctness-preservingly NARROWing each source.
+* **Phase 5 — streaming operators** ([`operators`] + [`stream`], bead `sq-vtba`): the
+  [`SolutionStream`] boundary the client owns, the bounded blocking [`ScatterPool`], the
+  `StreamJoin`-feeder [`StreamingJoin`], and the [`stream_single_source`] streaming
+  interpreter — backpressured + bounded (Rust ownership + the reused StreamJoin spill).
+* **Phase 6 — brTPF + TPF fragment adapters** ([`source`], bead `sq-2qze`): the real
+  Triple-Pattern-Fragments adapters ([`TpfSource`] / [`BrTpfSource`]) over a
+  [`FragmentTransport`] seam, complete-by-construction with count-metadata cardinality.
+
+* **Phase 7 — adaptive re-planning** (the `adaptive` module, bead `sq-ij5x`, the FINAL
+  phase): the opt-in feedback loop that re-invokes [`sparq-fedplan`](sparq_fedplan)'s planner
+  on the **unjoined remainder** when observed cardinality diverges from the static estimate,
+  bounded to at most once per operator boundary — re-planning changes the plan, never the
+  answer. Behind the extra default-OFF `fedclient-adaptive` feature (it pulls
+  `sparq-fedplan/adaptive-replan`); when that feature is off the `adaptive` module and its
+  `execute_adaptive_single_source` entry point are `#[cfg]`-compiled out.
+
+With Phase 7 the **8-phase streaming federation client is feature-complete** (Phases 0–7
+all landed; epic sq-dnko closed). The public surface and the dependency boundary were made
+visible before the logic landed.
+
+# Opt-in (hard constraint)
+
+The whole client is behind the **`fedclient` cargo feature, OFF by default**, and the
+crate is a standalone workspace member with `publish = false`. `sparq-core` and
+`sparq-engine` **never** depend on it — the dependency arrow points one-way *into*
+the engine (the client reuses the engine's SERVICE transport + SSRF guard + local
+eval), so the default engine build and the WASM artifact are byte-identical with or
+without `sparq-fedclient`. A build that does not enable `fedclient` compiles an empty
+crate (mirrors [`sparq-fedplan`](sparq_fedplan)'s `fedplan` feature).
+
+# The dependency boundary (load-bearing, enforced)
+
+The boundary was **proved before any logic existed** (Phase 0) and is re-checked on every
+build. Two complementary checks enforce that neither `sparq-core` nor `sparq-engine` ever
+gains a dependency edge *to* `sparq-fedclient`, in both feature states:
+
+* `scripts/fedclient-boundary-guard.sh` — a CI step (in `feature-matrix.yml`) that
+  inverts the dependency graph (`cargo tree -i sparq-fedclient`) and fails if
+  `sparq-core` or `sparq-engine` appears as a dependent;
+* `tests/boundary.rs` — a hermetic `cargo metadata` test asserting the same invariant
+  from inside the test suite, so it gates even off the CI script.
+
+Both must FAIL if a future edit introduces such an edge.
+
+[OPUS-4.8] sq-s1uy / sq-73om / sq-tiq4 — flagged for Fable re-review when available."#
+)]
+// Default (fedclient OFF) build: a concise, link-free crate doc. None of the per-phase
+// modules/items linked above exist in this build, so the doc is plain text + code spans
+// (matching `README.md`). [OPUS-4.8] sq-tiq4.
+#![cfg_attr(
+    not(feature = "fedclient"),
+    doc = r#"sparq-fedclient: a **streaming federation CLIENT** over heterogeneous remote RDF
+sources — the query *consumer* half of federation (epic **sq-dnko** / **sq-3183**). See
+`research/federation-client-design.md` for the full design.
+
+**This is the default build with the `fedclient` feature OFF, so the crate is empty** — the
+whole client (the `source` / `discovery` / `planner` / `pushdown` / `operators` / `stream` /
+`adaptive` modules and every re-exported item) is gated behind the **`fedclient` cargo
+feature, OFF by default**. Build the docs with `--features fedclient` to see the federation
+API and the per-phase narrative; this crate is a standalone workspace member with
+`publish = false`, and `sparq-core` / `sparq-engine` **never** depend on it (the dependency
+arrow points one-way *into* the engine), so the default engine build and the WASM artifact
+are byte-identical with or without `sparq-fedclient` (mirrors `sparq-fedplan`'s `fedplan`
+feature).
+
+[OPUS-4.8] sq-s1uy / sq-73om / sq-tiq4 — flagged for Fable re-review when available."#
+)]
 #![forbid(unsafe_code)]
+// [OPUS-4.8] sq-tiq4: lock the fix in. `rustdoc::broken_intra_doc_links` is a rustdoc-only
+// lint — it fires under `cargo doc`, NOT under `cargo build`/`clippy`/`test` — so denying it
+// keeps the existing build/clippy/test gates untouched while making a future broken crate-doc
+// link a hard `cargo doc` error in EITHER feature state.
+#![deny(rustdoc::broken_intra_doc_links)]
 // [OPUS-4.8] sq-s1uy: crate has zero `unsafe`.
 // When `fedclient` is off the crate is intentionally empty. With it on, not every landed item
 // is yet wired into an end-to-end public entry point, so silence the expected dead-code/

--- a/crates/sparq-fedclient/tests/crate_doc_default_build.rs
+++ b/crates/sparq-fedclient/tests/crate_doc_default_build.rs
@@ -1,0 +1,68 @@
+//! Regression guard for bead **sq-tiq4**: the crate-level rustdoc must build cleanly in the
+//! DEFAULT (`fedclient` OFF) build under `-D rustdoc::broken_intra_doc_links`.
+//!
+//! Why this exists: the crate-level narrative in `lib.rs` intra-doc-links the per-phase
+//! modules (`source`/`discovery`/`planner`/`pushdown`/`operators`/`stream`/`adaptive`) and the
+//! re-exported items — but EVERY one of those is `#[cfg(feature = "fedclient")]`-gated, so in
+//! the default build none of them are in scope. Before sq-tiq4, `cargo doc --no-deps -p
+//! sparq-fedclient` (default features) reported ~40 `unresolved link` errors under that lint;
+//! no CI lane builds docs, so `main` stayed green while the default-build docs mis-rendered.
+//! The fix serves a concise, link-free crate doc in the OFF build (and the rich linked one only
+//! when `fedclient` is ON, where the targets exist) and adds
+//! `#![deny(rustdoc::broken_intra_doc_links)]`.
+//!
+//! `broken_intra_doc_links` is a rustdoc-only lint — it fires under `cargo doc`, never under
+//! `cargo build`/`clippy`/`test` — so the crate's `#![deny]` alone is not exercised by the
+//! normal gates. This test shells out to `cargo doc` (mirroring the `cargo metadata` shell-out
+//! in `tests/boundary.rs`) so a regression is caught IN THE TEST SUITE, not silently.
+//!
+//! [OPUS-4.8] sq-tiq4 — flagged for Fable re-review when available.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Build the crate's own docs in the default (fedclient OFF) feature state with the
+/// broken-intra-doc-links lint promoted to an error, and assert it succeeds.
+///
+/// Hermetic notes:
+/// * `--no-deps` documents only this crate, so the run is fast and the assertion is about
+///   THIS crate's doc comments, not a dependency's.
+/// * A dedicated `--target-dir` keeps this nested `cargo doc` off the outer `cargo test`'s
+///   build lock (no deadlock / no contention with the in-flight test build).
+/// * `RUSTDOCFLAGS` carries the deny flag belt-and-braces alongside the crate's own
+///   `#![deny(...)]`, so the test still fails loud even if the inner attribute is ever removed.
+#[test]
+fn crate_doc_builds_clean_in_default_off_build() {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+
+    // Isolate the doc build's target dir under the outer target dir (CARGO_TARGET_DIR /
+    // OUT_DIR-adjacent), falling back to a temp path. This avoids racing the build lock the
+    // outer `cargo test` already holds on the shared target dir.
+    let mut doc_target = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
+    doc_target.push("sq-tiq4-doc-guard");
+
+    let output = Command::new(&cargo)
+        .args([
+            "doc",
+            "--no-deps",
+            "-p",
+            "sparq-fedclient",
+            // DEFAULT features only — this is the build the bug lived in. Do NOT pass
+            // `--features fedclient`.
+            "--target-dir",
+        ])
+        .arg(&doc_target)
+        .env("RUSTDOCFLAGS", "-D rustdoc::broken_intra_doc_links")
+        .output()
+        .expect("failed to spawn `cargo doc`");
+
+    assert!(
+        output.status.success(),
+        "BROKEN CRATE DOC (sq-tiq4 regression): `cargo doc --no-deps -p sparq-fedclient` in the \
+         DEFAULT (fedclient OFF) build failed under `-D rustdoc::broken_intra_doc_links`. The \
+         crate-level doc must not intra-doc-link `#[cfg(feature = \"fedclient\")]`-gated items in \
+         the OFF build — gate the rich linked narrative behind `feature = \"fedclient\"` and keep \
+         the OFF doc link-free.\n--- cargo doc stderr ---\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. @jeswr runs multiple agents on this account; this PR is from the federation-client doc-hygiene agent. Flagged for Fable re-review when available (authored on Opus 4.8).

## What & why (bead `sq-tiq4`)

The crate-level narrative in `crates/sparq-fedclient/src/lib.rs` intra-doc-links the per-phase modules (`source` / `discovery` / `planner` / `pushdown` / `operators` / `stream` / `adaptive`) and the re-exported items — but **every one of those is `#[cfg(feature = "fedclient")]`-gated**, so in the **default (fedclient OFF) build** none of them are in scope. `cargo doc --no-deps -p sparq-fedclient` (default features) reported **~40 `unresolved link` errors** under `-D rustdoc::broken_intra_doc_links`.

Pre-existing on `main`, and independent of `sq-8e6z` (which fixed the fedclient-**ON** intra-doc links). No CI lane builds docs today, so `main` stayed green while the **default** build's docs mis-rendered.

## The fix `[OPUS-4.8]`

- **Split the crate doc** with `#![cfg_attr(feature = "fedclient", doc = ...)]`: the rich linked narrative is served only in the **ON** build (where its link targets exist); a concise, **link-free** doc (matching `README.md`'s prose + code spans) is served in the **OFF** build.
- **`#![deny(rustdoc::broken_intra_doc_links)]`** locks the invariant in. `broken_intra_doc_links` is a **rustdoc-only** lint — it fires under `cargo doc`, never under `cargo build` / `clippy` / `test` — so the existing build/clippy/test gates are **untouched**.
- **Qualified four bare links in `adaptive.rs`** (`RuntimeStats` / `JoinTree` / `AdaptiveExecutor` / `natural_join`) to the paths already `use`-imported in that file, so the `fedclient-adaptive` **ON** build also passes the deny (it surfaced 5 latent errors of the same shape).
- **New `tests/crate_doc_default_build.rs`**: a hermetic guard that shells out to `cargo doc` (mirroring the `cargo metadata` shell-out in `tests/boundary.rs`) and asserts the default-OFF doc builds clean under the deny flag — so a regression is caught **in the test suite** even with no doc CI lane. Verified it **FAILS** on a reintroduced broken link and **PASSES** on the fix.

## Scope / honesty

- **Docs + one test only** — no public API added/removed/renamed, so the G2 public-API → `SKILL.md` rule does not trigger.
- `sparq-fedplan` has the **same latent issue** in its own crate doc (`cargo doc -p sparq-fedplan` default → 13 unresolved links); left out of this PR to keep it one-bead-one-PR — worth a sibling bead.
- This crate is **not** rustfmt-clean on `main` (37 pre-existing `cargo fmt --check` diffs across `adaptive.rs` / `operators.rs` / `pushdown.rs` / `stream.rs`); a separate rustfmt bead owns that. **This PR's own additions are rustfmt-clean** and add no new fmt diffs.

## Gate (all green)

| Check | OFF (default) | `fedclient` | `fedclient-adaptive` |
|---|---|---|---|
| `cargo build` / `clippy --all-targets -D warnings` | ✅ | ✅ | ✅ |
| `cargo test` | ✅ | ✅ | ✅ |
| `cargo doc --no-deps` under `-D rustdoc::broken_intra_doc_links` | ✅ | ✅ | ✅ |

Plus: `scripts/fedclient-boundary-guard.sh` + `tests/boundary.rs` (dependency-boundary) ✅ · `scripts/check-privacy-claims.sh` (predicate-form soundness) ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
