### PR TITLE
test(js): Node-version-independent compressed/dictionary zstd fixtures (sq-fz8s)

### DIFF
--- a/js/test/compressed.test.mjs
+++ b/js/test/compressed.test.mjs
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { gzipSync, zstdCompressSync } from 'node:zlib';
+import { gzipSync } from 'node:zlib';
 import { decompress, decompressToString, sniffCodec, SparqStore } from '../dist/index.js';
+// zstd fixtures are synthesised in pure JS (Raw_Block frames) rather than via
+// node:zlib's native zstdCompressSync, which is absent on Node 20 and
+// experimental/version-coupled thereafter (bead sq-fz8s).
+import { zstdRawFrame, zstdMultiFrame } from './helpers/zstd-fixtures.mjs';
 
 const NT = [
   '<http://ex/a> <http://ex/p> "one" .\n',
@@ -12,7 +16,7 @@ const FULL = NT.join('');
 const bytes = s => new Uint8Array(Buffer.from(s));
 
 test('sniffCodec recognises zstd, skippable-frame zstd, gzip, and rejects junk', () => {
-  assert.equal(sniffCodec(new Uint8Array(zstdCompressSync(bytes(FULL)))), 'zstd');
+  assert.equal(sniffCodec(zstdRawFrame(bytes(FULL))), 'zstd');
   assert.equal(sniffCodec(new Uint8Array(gzipSync(bytes(FULL)))), 'gzip');
   // a skippable frame (magic 0x184D2A50, LE on the wire) may legally lead a stream
   assert.equal(sniffCodec(new Uint8Array([0x50, 0x2a, 0x4d, 0x18, 0, 0, 0, 0])), 'zstd');
@@ -20,16 +24,16 @@ test('sniffCodec recognises zstd, skippable-frame zstd, gzip, and rejects junk',
 });
 
 test('.nt.zst ingest: single zstd frame', async () => {
-  const store = await SparqStore.fromCompressed(new Uint8Array(zstdCompressSync(bytes(FULL))), 'ntriples');
+  const store = await SparqStore.fromCompressed(zstdRawFrame(bytes(FULL)), 'ntriples');
   assert.equal(store.size, 3);
   assert.equal(store.queryBoolean('ASK { <http://ex/b> ?p "two" }'), true);
 });
 
 test('multi-frame zstd (the CompressedSink wire shape) decodes fully', async () => {
   // Independently compressed chunks concatenated in order — RFC 8878 multi-frame.
-  const frames = Buffer.concat(NT.map(line => zstdCompressSync(bytes(line))));
-  assert.equal(await decompressToString(new Uint8Array(frames)), FULL);
-  const store = await SparqStore.fromCompressed(new Uint8Array(frames), 'ntriples');
+  const frames = zstdMultiFrame(NT.map(line => bytes(line)));
+  assert.equal(await decompressToString(frames), FULL);
+  const store = await SparqStore.fromCompressed(frames, 'ntriples');
   assert.equal(store.size, 3); // NOT first-frame-only (Node's own zstd truncates here)
 });
 
@@ -45,7 +49,7 @@ test('.gz ingest (multi-member gzip decodes fully in Node)', async () => {
 
 test('explicit codec, dataset pass-through, and clear junk error', async () => {
   const nq = '<http://ex/s> <http://ex/p> "in-g" <http://ex/g> .\n';
-  const store = await SparqStore.fromCompressed(new Uint8Array(zstdCompressSync(bytes(nq))), 'nquads', {
+  const store = await SparqStore.fromCompressed(zstdRawFrame(bytes(nq)), 'nquads', {
     codec: 'zstd',
     dataset: true,
   });

--- a/js/test/dictionary.test.mjs
+++ b/js/test/dictionary.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { zstdCompressSync, zstdDecompressSync } from 'node:zlib';
+import { decompress as fzstdDecompress } from 'fzstd';
 import {
   dictIdOf,
   parseZstdDictId,
@@ -9,6 +9,12 @@ import {
   SPARQ_DICTIONARY_HEADER,
   verifyDictId,
 } from '../dist/index.js';
+// zstd fixtures are synthesised in pure JS (Raw_Block frames, dictId 0) rather
+// than via node:zlib's native zstdCompressSync, which is absent on Node 20 and
+// experimental/version-coupled thereafter (bead sq-fz8s). The protocol logic is
+// driven by the Sparq-Dictionary response header, not the frame's own bytes, so
+// raw frames exercise both the plain and dictionary-decode paths identically.
+import { zstdRawFrame } from './helpers/zstd-fixtures.mjs';
 
 const enc = new TextEncoder();
 const dec = new TextDecoder();
@@ -19,9 +25,18 @@ const DICT = enc.encode(
 );
 const BODY = '{"head":{"vars":["o"]},"results":{"bindings":[{"o":{"type":"uri","value":"http://example.org/vocab#x"}}]}}';
 
-/** Node-zlib-backed dict-capable decoder (what zstd-wasm provides in browsers). */
-const nodeDictDecoder = (body, dictionary) =>
-  new Uint8Array(zstdDecompressSync(body, { dictionary: Buffer.from(dictionary) }));
+/**
+ * A dict-capable decoder stand-in (what zstd-wasm provides in browsers). The
+ * client routes a response to this hook purely because the `Sparq-Dictionary`
+ * header named a dictionary; the `dictionary` argument is therefore threaded
+ * through (and asserted present) even though our Raw_Block fixtures reference
+ * none — matching the real contract, in which a dict-capable backend is what
+ * makes the dictionary path engage at all.
+ */
+const dictAwareDecoder = (body, dictionary) => {
+  assert.ok(dictionary instanceof Uint8Array && dictionary.length > 0);
+  return fzstdDecompress(body);
+};
 
 /**
  * A mock origin implementing the server side of the protocol: dictionary
@@ -45,10 +60,12 @@ async function mockOrigin({ corruptDictionary = false } = {}) {
     if (held.split(/,\s*/).includes(dictId)) {
       log.push('dict-compressed');
       headers[SPARQ_DICTIONARY_HEADER] = dictId;
-      return new Response(zstdCompressSync(Buffer.from(BODY), { dictionary: Buffer.from(DICT) }), { headers });
+      // The Sparq-Dictionary header — not the frame bytes — drives the client
+      // onto the dict-capable decode hook, so a plain Raw_Block fixture suffices.
+      return new Response(zstdRawFrame(enc.encode(BODY)), { headers });
     }
     log.push('plain');
-    return new Response(zstdCompressSync(Buffer.from(BODY)), { headers });
+    return new Response(zstdRawFrame(enc.encode(BODY)), { headers });
   };
   return { dictId, log, fetchImpl };
 }
@@ -64,7 +81,7 @@ test('content addressing: dictIdOf / truncated verifyDictId', async () => {
 
 test('protocol round-trip: plain first request, warmed-up dictionary on the second', async () => {
   const { dictId, log, fetchImpl } = await mockOrigin();
-  const client = new SparqDictionaryClient({ fetch: fetchImpl, decodeWithDictionary: nodeDictDecoder });
+  const client = new SparqDictionaryClient({ fetch: fetchImpl, decodeWithDictionary: dictAwareDecoder });
 
   // First request: nothing held -> plain zstd, decoded by the bundled fzstd.
   const first = await client.fetch('https://sparq.example/sparql?query=...');
@@ -96,7 +113,7 @@ test('without a dict-capable decoder the client never advertises (stays plain)',
 
 test('a corrupted dictionary fails content verification and is never trusted', async () => {
   const { fetchImpl } = await mockOrigin({ corruptDictionary: true });
-  const client = new SparqDictionaryClient({ fetch: fetchImpl, decodeWithDictionary: nodeDictDecoder });
+  const client = new SparqDictionaryClient({ fetch: fetchImpl, decodeWithDictionary: dictAwareDecoder });
   await client.fetch('https://sparq.example/sparql');
   await client.idle();
   assert.deepEqual(client.dictionaryIds, []); // rejected, not cached
@@ -107,7 +124,7 @@ test('a corrupted dictionary fails content verification and is never trusted', a
 
 test('addDictionary seeds a persisted dictionary (verified against the claimed id)', async () => {
   const { dictId, log, fetchImpl } = await mockOrigin();
-  const client = new SparqDictionaryClient({ fetch: fetchImpl, decodeWithDictionary: nodeDictDecoder });
+  const client = new SparqDictionaryClient({ fetch: fetchImpl, decodeWithDictionary: dictAwareDecoder });
   await client.addDictionary(DICT, dictId);
   const res = await client.fetch('https://sparq.example/sparql');
   assert.equal(res.dictionary, dictId); // dictionary path engaged on the FIRST request
@@ -123,12 +140,12 @@ test('non-compressed and platform-decoded bodies pass through untouched', async 
 });
 
 test('parseZstdDictId reads the frame-header Dictionary_ID', () => {
-  // Node's raw-content dictionary embeds no dictID: 0 (= "names none").
-  assert.equal(parseZstdDictId(new Uint8Array(zstdCompressSync(Buffer.from(BODY)))), 0);
-  assert.equal(
-    parseZstdDictId(new Uint8Array(zstdCompressSync(Buffer.from(BODY), { dictionary: Buffer.from(DICT) }))),
-    0,
-  );
+  // A frame that names no dictionary reads as 0 (= "names none"), like the
+  // raw-content dictionaries this protocol uses.
+  assert.equal(parseZstdDictId(zstdRawFrame(enc.encode(BODY))), 0);
+  // A frame whose header DOES carry a Dictionary_ID reads it back (our helper
+  // emits a single-segment 2-byte DID field for 0xBEEF here).
+  assert.equal(parseZstdDictId(zstdRawFrame(enc.encode(BODY), { dictId: 0xbeef })), 0xbeef);
   // Hand-crafted RFC 8878 header: magic, FHD with DID_Field_Size=2 (0x02),
   // not single-segment -> 1 Window_Descriptor byte, then DID 0xBEEF LE.
   assert.equal(parseZstdDictId(new Uint8Array([0x28, 0xb5, 0x2f, 0xfd, 0x02, 0x00, 0xef, 0xbe])), 0xbeef);

--- a/js/test/helpers/zstd-fixtures.mjs
+++ b/js/test/helpers/zstd-fixtures.mjs
@@ -1,0 +1,92 @@
+/**
+ * Portable zstd fixture helpers — version-independent test fixtures. [OPUS-4.8]
+ *
+ * `node:zlib`'s native `zstdCompressSync` / `zstdDecompressSync` (and the
+ * `{ dictionary }` option) were only added in Node 22.15 / 23.8 and remain
+ * STABILITY-1 EXPERIMENTAL — absent on Node 20 (where the import is
+ * `undefined`, so every fixture call throws `TypeError`) and emitting a
+ * different frame-header shape across Node versions (nodejs/node#58392: sync
+ * frames carry no Content_Size, streaming frames do). Both made the
+ * compressed/dictionary JS tests Node-version-coupled (bead sq-fz8s).
+ *
+ * Instead of compressing through that experimental native API, we synthesise
+ * the zstd frames the tests need directly, using ONLY `Raw_Block`s (stored,
+ * uncompressed payload) per RFC 8878 §3.1. Such frames:
+ *   - are valid zstd that the bundled pure-JS `fzstd` decoder reads (the exact
+ *     decode path the library ships), and that `node:zlib` would also accept;
+ *   - let us embed an arbitrary `Dictionary_ID` in the frame header, exercising
+ *     `parseZstdDictId`; and
+ *   - need NO dictionary to decode (raw blocks reference none), so the
+ *     dictionary-fetch protocol — which keys off the `Sparq-Dictionary`
+ *     response header, not the frame bytes — is exercised identically.
+ *
+ * This keeps full coverage on EVERY supported Node (>=18) with no native zstd
+ * and no extra dependency. gzip fixtures still use `node:zlib` (`gzipSync` is
+ * stable across all supported versions and is not implicated in sq-fz8s).
+ */
+
+const ZSTD_MAGIC = [0x28, 0xb5, 0x2f, 0xfd]; // RFC 8878 §3.1.1 (LE on the wire)
+const MAX_RAW_BLOCK = 128 * 1024; // §3.1.1.2.3 Block_Maximum_Size for our window
+
+/** Encodes `dictId` (a non-negative int) into a header field + its flag (0..3). */
+function dictionaryIdField(dictId) {
+  if (dictId <= 0) return { flag: 0, bytes: [] };
+  if (dictId < 0x100) return { flag: 1, bytes: [dictId & 0xff] };
+  if (dictId < 0x10000) return { flag: 2, bytes: [dictId & 0xff, (dictId >> 8) & 0xff] };
+  return {
+    flag: 3,
+    bytes: [dictId & 0xff, (dictId >> 8) & 0xff, (dictId >> 16) & 0xff, (dictId >>> 24) & 0xff],
+  };
+}
+
+/** Frame_Content_Size field + its FCS_Field_flag (0 ⇒ 1 byte, 2 ⇒ 4 bytes). */
+function contentSizeField(length) {
+  if (length < 0x100) return { flag: 0, bytes: [length & 0xff] };
+  return {
+    flag: 2,
+    bytes: [length & 0xff, (length >> 8) & 0xff, (length >> 16) & 0xff, (length >>> 24) & 0xff],
+  };
+}
+
+/**
+ * A single zstd frame carrying `payload` in `Raw_Block`s, optionally naming a
+ * `dictId` in the frame header. Decodes through fzstd or any conformant zstd
+ * reader without a dictionary.
+ *
+ * @param {Uint8Array | Buffer} payload
+ * @param {{ dictId?: number }} [opts]
+ * @returns {Uint8Array}
+ */
+export function zstdRawFrame(payload, { dictId = 0 } = {}) {
+  const data = Uint8Array.from(payload);
+  const did = dictionaryIdField(dictId);
+  const fcs = contentSizeField(data.length);
+  // Frame_Header_Descriptor: FCS_flag<<6 | Single_Segment<<5 | (unused 0) |
+  // Content_Checksum 0 | Dictionary_ID_flag. Single_Segment=1 keeps the window
+  // implicit and forces the Content_Size field to be present (no separate
+  // Window_Descriptor byte then).
+  const fhd = (fcs.flag << 6) | (1 << 5) | did.flag;
+
+  const blocks = [];
+  let offset = 0;
+  do {
+    const end = Math.min(offset + MAX_RAW_BLOCK, data.length);
+    const chunk = data.subarray(offset, end);
+    const lastBlock = end >= data.length ? 1 : 0;
+    // Block_Header (3 bytes LE): Block_Size<<3 | Block_Type<<1 | Last_Block.
+    // Block_Type 0 = Raw_Block (stored uncompressed).
+    const header = (chunk.length << 3) | (0 << 1) | lastBlock;
+    blocks.push(header & 0xff, (header >> 8) & 0xff, (header >> 16) & 0xff, ...chunk);
+    offset = end;
+  } while (offset < data.length);
+
+  return Uint8Array.from([...ZSTD_MAGIC, fhd, ...did.bytes, ...fcs.bytes, ...blocks]);
+}
+
+/** Concatenated independent frames — the RFC 8878 multi-frame wire shape the
+ *  `CompressedSink` emits (Node's own `zstdDecompressSync` decodes only the
+ *  first; fzstd loops them all). */
+export function zstdMultiFrame(payloads) {
+  const frames = payloads.map(p => [...zstdRawFrame(p)]);
+  return Uint8Array.from(frames.flat());
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. One of several agents @jeswr runs on this account.

## What & why

The `js/` compressed + dictionary tests built their zstd fixtures with `node:zlib`'s native `zstdCompressSync` / `zstdDecompressSync`. Those APIs (and the `{ dictionary }` option) were only added in **Node 22.15 / 23.8** and remain STABILITY-1 **experimental**:

- **Absent on Node 20** — the import resolves to `undefined`, so every fixture call throws `TypeError: zstdCompressSync is not a function`.
- **Version-coupled frame headers** even within Node 22+ — the sync compressor emits a different frame-header shape than streaming ([nodejs/node#58392](https://github.com/nodejs/node/issues/58392): sync frames carry no `Content_Size`, streaming frames do).

CI pins `node-version: 22` (`.github/workflows/js.yml`), so the suite was coupled to whichever 22.x the runner resolved — the failure captured in bead **sq-fz8s**.

Crucially, **the library itself never used native zstd**: it decodes zstd via the pure-JS bundled `fzstd` and gzip via `node:zlib` `gunzipSync`. So this was purely a **test-harness portability** bug — no production code path was affected.

## The fix

A small pure-JS helper, `js/test/helpers/zstd-fixtures.mjs`, synthesises valid zstd frames using only **RFC 8878 `Raw_Block`s** (stored, uncompressed payload). Such frames:

- are real zstd that the shipped `fzstd` decoder reads (the exact decode path the package uses), and that any conformant reader accepts;
- can embed an arbitrary `Dictionary_ID` in the frame header (exercises `parseZstdDictId`); and
- need no dictionary to decode — and the dictionary-fetch protocol keys off the `Sparq-Dictionary` **response header**, not the frame bytes, so raw frames drive both the plain and dictionary-decode paths identically.

The dict-capable decode hook now asserts the dictionary is threaded through and decodes via `fzstd` (standing in for a zstd-wasm backend). `parseZstdDictId` also gains a **non-zero** header-DID round-trip the native path could not produce.

This keeps full coverage on **every** supported Node (>=18) with no native zstd and no new dependency.

## Scope & honesty

- Test-only change. No library/public-API surface touched → no `SKILL.md` (G2) update needed.
- Helper lives under `test/`, excluded from the npm `files` allowlist (not published).
- gzip fixtures still use `node:zlib` `gzipSync` (stable across all supported versions; not implicated in sq-fz8s).

## Gate

- Full `js/` suite **green on Node 20.20.2** (47 tests), the version where the originals threw `TypeError`. Confirmed baseline failure: `zstdCompressSync is not a function` on Node 20.
- `npm pack --dry-run` clean; test helper correctly excluded.
- Privacy-claims gate: OK (275 files scanned, no unqualified ZK/MPC claim).
- No Rust crate changed → Rust build/clippy/test gate N/A.

Closes sq-fz8s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)