### PR TITLE
docs(sparq-fedplan): fix crate-doc broken intra-doc links in default (fedplan OFF) build (sq-gxx7)

### DIFF
--- a/crates/sparq-fedplan/src/lib.rs
+++ b/crates/sparq-fedplan/src/lib.rs
@@ -1,83 +1,127 @@
-//! sparq-fedplan: **cost-based federated source selection + bind-vs-hash join
-//! planning** over already-fetched source *descriptors* — the first opt-in slice of
-//! cost-based federation (bead sq-a35t, epic sq-3183).
-//!
-//! This crate plans a federated SPARQL Basic Graph Pattern (BGP) across a set of
-//! remote SPARQL endpoints whose **statistics are already in hand** — each source is
-//! described by a [`SourceDescriptor`] carrying the W3C VoID property/class partitions
-//! (`void:propertyPartition` / `void:classPartition`) that a `sparq-server` already
-//! serves at `/.well-known/void`, *plus* the mined **characteristic sets** the server
-//! also serves under the `scs:` vocab (`http://sparq.dev/ns/cs#`). The planner is:
-//!
-//! * **Pure** — it consumes descriptors, never the network. No I/O, no live `Graph`.
-//!   A caller fetches descriptors once (or builds them programmatically /
-//!   [`SourceDescriptor::from_void_nt`] from the served N-Triples) and hands them in.
-//! * **Deterministic** — same descriptors + same BGP ⇒ same plan, every time. Every
-//!   internal ordering breaks ties on a stable key (source id, then pattern index).
-//!
-//! ## What it produces (this slice)
-//!
-//! 1. [`select_sources`] — **source selection**: for each triple pattern, which
-//!    sources *can* contribute, with a per-(pattern, source) cardinality estimate.
-//!    Two complementary techniques:
-//!    * **HiBISCuS-style authority/prefix pruning** ([`selection`]) — a source is
-//!      pruned for a pattern only when its capability set (the IRI authorities /
-//!      predicates / classes it is known to hold) makes a contribution *impossible*.
-//!      This is **recall-safe**: a source is dropped only on positive evidence of
-//!      non-contribution; *any* uncertainty keeps it. See [`selection`] for the
-//!      invariant and its proof obligations (tested in `selection::tests`).
-//!    * **CostFed-style skew-aware cardinality** — the per-pattern, per-source
-//!      cardinality is estimated from the served per-predicate stats (triples, average
-//!      multiplicity) carried in the characteristic sets, *not* a uniform-distribution
-//!      guess; predicate skew is preserved.
-//! 2. [`plan_bgp`] — a **bind-vs-hash join planner** ([`plan`]): a greedy join-order
-//!    heuristic over the selected sources that, for each join, chooses a **bind join**
-//!    (probe the right side with the left side's bindings — cheap when the left is
-//!    small and the bound variable is selective) or a **hash/symmetric join** (scan
-//!    both sides once — cheap when both sides are large), using characteristic-set
-//!    star-join cardinality to estimate intermediate-result sizes. The output is a
-//!    [`JoinTree`] with per-node estimated cardinality and cost.
-//!
-//! ## Opt-in (hard constraint)
-//!
-//! The whole planner is behind the **`fedplan` cargo feature, OFF by default**, and the
-//! crate is a standalone workspace member with `publish = false` — `sparq-core` /
-//! `sparq-engine` never depend on it, so the default engine and the WASM artifact are
-//! byte-identical with or without it. A build that does not enable `fedplan` compiles
-//! an empty crate.
-//!
-//! ## Streaming execution (sq-vf7q)
-//!
-//! 3. [`StreamJoin`] — an **ANAPSID-style non-blocking streaming join with bounded
-//!    operator spill** ([`stream`]): the execution-side operator the planner's
-//!    [`JoinAlgo::Streaming`] choice corresponds to. It consumes two incrementally-arriving
-//!    tuple streams (federated sub-results returning at different rates), builds *and*
-//!    probes both sides, and emits matches without first materialising either full input.
-//!    Memory is bounded by [`StreamJoinOptions::mem_budget_tuples`]: over-budget join-key
-//!    partitions spill to a backing store (a temp file by default — std only) and are
-//!    reconciled on probe. The load-bearing invariant — proven by tests — is that the
-//!    streamed + spilled result is **multiset-equal** to the equivalent blocking hash join
-//!    ([`blocking_hash_join`]) for any interleaving and any budget.
-//!
-//! ## Live adaptive re-planning (sq-7s4z) — opt-in
-//!
-//! 4. `AdaptiveExecutor` — **mid-execution plan switching** behind the separate
-//!    `adaptive-replan` cargo feature (OFF by default; implies `fedplan`). It captures the
-//!    *observed* runtime statistics (`RuntimeStats`: real per-pattern cardinality +
-//!    per-source latency) as execution proceeds, and at **stage boundaries** — between two
-//!    leaf joins of the left-deep plan — re-invokes the planner on the **remaining** (not-
-//!    yet-executed) patterns when an observation diverges from its estimate past a policy
-//!    factor (`ReplanPolicy::divergence_factor`), adopting the new suffix order only when
-//!    it wins by a hysteresis margin (`ReplanPolicy::improvement_margin`) so stable-but-
-//!    noisy stats never thrash. **Soundness boundary**: re-planning reorders only the
-//!    not-yet-started suffix (never a mid-operator swap); because BGP join is
-//!    commutative/associative, any order over the same patterns yields the *same* result
-//!    multiset — proven by `adaptive::tests::replan_result_equals_static` against an
-//!    order-driven reference executor. Mid-operator adaptivity + live source failover are
-//!    deferred (beaded under epic sq-3183).
-//!
-//! [OPUS-4.8] sq-a35t / sq-vf7q / sq-7s4z — flagged for Fable re-review.
+// ─── Crate-level documentation ──────────────────────────────────────────────────────
+// [OPUS-4.8] sq-gxx7 (sibling of sq-tiq4 / PR #470): the narrative below intra-doc-links
+// items that are EVERY one `#[cfg(feature = "fedplan")]`-gated — the re-exports
+// (`SourceDescriptor`/`select_sources`/`plan_bgp`/`JoinTree`/`StreamJoin`/…) and the private
+// `selection`/`plan`/`stream` modules. In the DEFAULT (fedplan OFF) build none of them are in
+// scope, so `cargo doc` under `-D rustdoc::broken_intra_doc_links` failed on 13 unresolved
+// links. The fix mirrors sq-tiq4: keep the rich linked narrative only for the build where its
+// targets exist (`fedplan` ON) and serve a concise, link-free crate doc for the OFF build, so
+// `cargo doc` is clean in BOTH states. In the ON narrative the links point at PUBLIC re-exported
+// items (never the private `selection`/`plan`/`stream` modules), so the ON doc is also clean
+// under the deny (no `private_intra_doc_links` warning). `deny(rustdoc::broken_intra_doc_links)`
+// below locks the invariant in (rustdoc-only lint — it fires under `cargo doc`, never under
+// `cargo build`/`clippy`/`test`, so the existing gates are unchanged). Mirror this split in any
+// future crate-doc edit.
+#![cfg_attr(
+    feature = "fedplan",
+    doc = r#"sparq-fedplan: **cost-based federated source selection + bind-vs-hash join
+planning** over already-fetched source *descriptors* — the first opt-in slice of
+cost-based federation (bead sq-a35t, epic sq-3183).
+
+This crate plans a federated SPARQL Basic Graph Pattern (BGP) across a set of
+remote SPARQL endpoints whose **statistics are already in hand** — each source is
+described by a [`SourceDescriptor`] carrying the W3C VoID property/class partitions
+(`void:propertyPartition` / `void:classPartition`) that a `sparq-server` already
+serves at `/.well-known/void`, *plus* the mined **characteristic sets** the server
+also serves under the `scs:` vocab (`http://sparq.dev/ns/cs#`). The planner is:
+
+* **Pure** — it consumes descriptors, never the network. No I/O, no live `Graph`.
+  A caller fetches descriptors once (or builds them programmatically /
+  [`SourceDescriptor::from_void_nt`] from the served N-Triples) and hands them in.
+* **Deterministic** — same descriptors + same BGP ⇒ same plan, every time. Every
+  internal ordering breaks ties on a stable key (source id, then pattern index).
+
+## What it produces (this slice)
+
+1. [`select_sources`] — **source selection**: for each triple pattern, which
+   sources *can* contribute, with a per-(pattern, source) cardinality estimate.
+   Two complementary techniques:
+   * **HiBISCuS-style authority/prefix pruning** — a source is
+     pruned for a pattern only when its capability set (the IRI authorities /
+     predicates / classes it is known to hold) makes a contribution *impossible*.
+     This is **recall-safe**: a source is dropped only on positive evidence of
+     non-contribution; *any* uncertainty keeps it. See [`select_sources`] for the
+     invariant and its proof obligations (tested in the `selection::tests` module).
+   * **CostFed-style skew-aware cardinality** — the per-pattern, per-source
+     cardinality is estimated from the served per-predicate stats (triples, average
+     multiplicity) carried in the characteristic sets, *not* a uniform-distribution
+     guess; predicate skew is preserved.
+2. [`plan_bgp`] — a **bind-vs-hash join planner**: a greedy join-order
+   heuristic over the selected sources that, for each join, chooses a **bind join**
+   (probe the right side with the left side's bindings — cheap when the left is
+   small and the bound variable is selective) or a **hash/symmetric join** (scan
+   both sides once — cheap when both sides are large), using characteristic-set
+   star-join cardinality to estimate intermediate-result sizes. The output is a
+   [`JoinTree`] with per-node estimated cardinality and cost.
+
+## Opt-in (hard constraint)
+
+The whole planner is behind the **`fedplan` cargo feature, OFF by default**, and the
+crate is a standalone workspace member with `publish = false` — `sparq-core` /
+`sparq-engine` never depend on it, so the default engine and the WASM artifact are
+byte-identical with or without it. A build that does not enable `fedplan` compiles
+an empty crate.
+
+## Streaming execution (sq-vf7q)
+
+3. [`StreamJoin`] — an **ANAPSID-style non-blocking streaming join with bounded
+   operator spill**: the execution-side operator the planner's
+   [`JoinAlgo::Streaming`] choice corresponds to. It consumes two incrementally-arriving
+   tuple streams (federated sub-results returning at different rates), builds *and*
+   probes both sides, and emits matches without first materialising either full input.
+   Memory is bounded by [`StreamJoinOptions::mem_budget_tuples`]: over-budget join-key
+   partitions spill to a backing store (a temp file by default — std only) and are
+   reconciled on probe. The load-bearing invariant — proven by tests — is that the
+   streamed + spilled result is **multiset-equal** to the equivalent blocking hash join
+   ([`blocking_hash_join`]) for any interleaving and any budget.
+
+## Live adaptive re-planning (sq-7s4z) — opt-in
+
+4. `AdaptiveExecutor` — **mid-execution plan switching** behind the separate
+   `adaptive-replan` cargo feature (OFF by default; implies `fedplan`). It captures the
+   *observed* runtime statistics (`RuntimeStats`: real per-pattern cardinality +
+   per-source latency) as execution proceeds, and at **stage boundaries** — between two
+   leaf joins of the left-deep plan — re-invokes the planner on the **remaining** (not-
+   yet-executed) patterns when an observation diverges from its estimate past a policy
+   factor (`ReplanPolicy::divergence_factor`), adopting the new suffix order only when
+   it wins by a hysteresis margin (`ReplanPolicy::improvement_margin`) so stable-but-
+   noisy stats never thrash. **Soundness boundary**: re-planning reorders only the
+   not-yet-started suffix (never a mid-operator swap); because BGP join is
+   commutative/associative, any order over the same patterns yields the *same* result
+   multiset — proven by `adaptive::tests::replan_result_equals_static` against an
+   order-driven reference executor. Mid-operator adaptivity + live source failover are
+   deferred (beaded under epic sq-3183).
+
+[OPUS-4.8] sq-a35t / sq-vf7q / sq-7s4z / sq-gxx7 — flagged for Fable re-review."#
+)]
+// Default (fedplan OFF) build: a concise, link-free crate doc. None of the per-phase modules /
+// re-exported items linked above exist in this build, so the doc is plain text + code spans
+// (matching `README.md`). [OPUS-4.8] sq-gxx7.
+#![cfg_attr(
+    not(feature = "fedplan"),
+    doc = r#"sparq-fedplan: **cost-based federated source selection + bind-vs-hash join
+planning** over already-fetched source *descriptors* — the first opt-in slice of
+cost-based federation (bead sq-a35t, epic sq-3183). See `README.md` and
+`skills/federated-planning/SKILL.md` for the full design.
+
+**This is the default build with the `fedplan` feature OFF, so the crate is empty** — the
+whole planner (source selection, the bind-vs-hash join planner, the `StreamJoin` streaming
+operator, and the opt-in `AdaptiveExecutor`) and every re-exported item is gated behind the
+**`fedplan` cargo feature, OFF by default**. Build the docs with `--features fedplan` to see the
+planner API and the per-phase narrative; this crate is a standalone workspace member with
+`publish = false`, and `sparq-core` / `sparq-engine` **never** depend on it, so the default
+engine build and the WASM artifact are byte-identical with or without `sparq-fedplan`. Live
+adaptive re-planning (`AdaptiveExecutor`) is behind the further `adaptive-replan` feature
+(which implies `fedplan`).
+
+[OPUS-4.8] sq-a35t / sq-vf7q / sq-7s4z / sq-gxx7 — flagged for Fable re-review."#
+)]
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-a35t: crate has zero `unsafe`.
+// [OPUS-4.8] sq-gxx7: lock the crate-doc fix in. `rustdoc::broken_intra_doc_links` is a
+// rustdoc-only lint — it fires under `cargo doc`, NOT under `cargo build`/`clippy`/`test` — so
+// denying it keeps the existing build/clippy/test gates untouched while making a future broken
+// crate-doc link a hard `cargo doc` error in EITHER feature state.
+#![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(feature = "fedplan"), allow(dead_code, unused_imports))]
 
 // [OPUS-4.8] sq-7s4z: live adaptive mid-execution re-planning. Gated behind the

--- a/crates/sparq-fedplan/tests/crate_doc_default_build.rs
+++ b/crates/sparq-fedplan/tests/crate_doc_default_build.rs
@@ -1,0 +1,69 @@
+//! Regression guard for bead **sq-gxx7** (sibling of sq-tiq4 / PR #470): the crate-level
+//! rustdoc must build cleanly in the DEFAULT (`fedplan` OFF) build under
+//! `-D rustdoc::broken_intra_doc_links`.
+//!
+//! Why this exists: the crate-level narrative in `lib.rs` intra-doc-links items
+//! (`SourceDescriptor` / `select_sources` / `plan_bgp` / `JoinTree` / `StreamJoin` / …) that
+//! are EVERY one `#[cfg(feature = "fedplan")]`-gated, so in the default build none of them are
+//! in scope. Before sq-gxx7, `cargo doc --no-deps -p sparq-fedplan` (default features) reported
+//! 13 `unresolved link` errors under that lint; no CI lane builds docs, so `main` stayed green
+//! while the default-build docs mis-rendered. The fix serves a concise, link-free crate doc in
+//! the OFF build (and the rich linked one only when `fedplan` is ON, where the targets exist,
+//! linking PUBLIC re-exports rather than the private `selection`/`plan`/`stream` modules) and
+//! adds `#![deny(rustdoc::broken_intra_doc_links)]`.
+//!
+//! `broken_intra_doc_links` is a rustdoc-only lint — it fires under `cargo doc`, never under
+//! `cargo build`/`clippy`/`test` — so the crate's `#![deny]` alone is not exercised by the
+//! normal gates. This test shells out to `cargo doc` (the same shell-out style the wider
+//! workspace uses for `cargo metadata`/`cargo` guard tests) so a regression is caught IN THE
+//! TEST SUITE, not silently.
+//!
+//! [OPUS-4.8] sq-gxx7 — flagged for Fable re-review when available.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Build the crate's own docs in the default (fedplan OFF) feature state with the
+/// broken-intra-doc-links lint promoted to an error, and assert it succeeds.
+///
+/// Hermetic notes:
+/// * `--no-deps` documents only this crate, so the run is fast and the assertion is about
+///   THIS crate's doc comments, not a dependency's.
+/// * A dedicated `--target-dir` keeps this nested `cargo doc` off the outer `cargo test`'s
+///   build lock (no deadlock / no contention with the in-flight test build).
+/// * `RUSTDOCFLAGS` carries the deny flag belt-and-braces alongside the crate's own
+///   `#![deny(...)]`, so the test still fails loud even if the inner attribute is ever removed.
+#[test]
+fn crate_doc_builds_clean_in_default_off_build() {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+
+    // Isolate the doc build's target dir under the per-test temp dir so it does not race the
+    // build lock the outer `cargo test` already holds on the shared target dir.
+    let mut doc_target = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
+    doc_target.push("sq-gxx7-doc-guard");
+
+    let output = Command::new(&cargo)
+        .args([
+            "doc",
+            "--no-deps",
+            "-p",
+            "sparq-fedplan",
+            // DEFAULT features only — this is the build the bug lived in. Do NOT pass
+            // `--features fedplan`.
+            "--target-dir",
+        ])
+        .arg(&doc_target)
+        .env("RUSTDOCFLAGS", "-D rustdoc::broken_intra_doc_links")
+        .output()
+        .expect("failed to spawn `cargo doc`");
+
+    assert!(
+        output.status.success(),
+        "BROKEN CRATE DOC (sq-gxx7 regression): `cargo doc --no-deps -p sparq-fedplan` in the \
+         DEFAULT (fedplan OFF) build failed under `-D rustdoc::broken_intra_doc_links`. The \
+         crate-level doc must not intra-doc-link `#[cfg(feature = \"fedplan\")]`-gated items in \
+         the OFF build — gate the rich linked narrative behind `feature = \"fedplan\"` and keep \
+         the OFF doc link-free.\n--- cargo doc stderr ---\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — opened by an automated SPARQ agent (Opus 4.8, Fable unavailable; flag for re-review when Fable returns). @jeswr runs multiple agents on one account.

## sq-gxx7 — sparq-fedplan crate-doc broken intra-doc links in the default (fedplan OFF) build

Sibling of **sq-tiq4** (sparq-fedclient, PR #470, commit `44064ca`): `sparq-fedplan` had the **identical latent crate-doc bug**.

### The bug
The crate-level narrative in `crates/sparq-fedplan/src/lib.rs` intra-doc-links items — `SourceDescriptor`, `SourceDescriptor::from_void_nt`, `select_sources`, `plan_bgp`, `JoinTree`, `JoinAlgo::Streaming`, `StreamJoin`, `StreamJoinOptions::mem_budget_tuples`, `blocking_hash_join` — plus the private `selection` / `plan` / `stream` modules. **Every one is `#[cfg(feature = "fedplan")]`-gated**, so in the **default (fedplan OFF)** build none are in scope:

```
$ RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc --no-deps -p sparq-fedplan
error: unresolved link to `SourceDescriptor`   (… 13 total)
error: could not document `sparq-fedplan`
```

Pre-existing on `main`; **no CI lane builds docs**, so `main` stayed green while the default build's docs mis-rendered.

### The fix (mirrors the sq-tiq4 template)
- **`cfg_attr`-split the crate doc**: `#![cfg_attr(feature = "fedplan", doc = …)]` serves the rich linked narrative only in the ON build (where its targets exist); `#![cfg_attr(not(feature = "fedplan"), doc = …)]` serves a concise, **link-free** doc (matching `README.md` prose + code spans) in the OFF build. `cargo doc` is now clean in **both** states.
- In the ON narrative, the three previously-**private-module** links (`[`selection`]` ×2, `[`plan`]`, `[`stream`]`) now point at the **public re-exports** (`[`select_sources`]`, `[`plan_bgp`]`, `[`StreamJoin`]`), so the ON doc is **also** warning-free (no `private_intra_doc_links` warning from the crate doc).
- **`#![deny(rustdoc::broken_intra_doc_links)]`** locks the invariant in. Rustdoc-only lint — it fires under `cargo doc`, never under `cargo build`/`clippy`/`test`, so the existing build/clippy/test gates are untouched.
- **`tests/crate_doc_default_build.rs`**: a hermetic guard that shells out to `cargo doc --no-deps` in the default OFF state under the deny flag, so a regression is caught **in the test suite** even with no doc CI lane. Verified: **FAILS** on a reintroduced broken link, **PASSES** on the fix.

### Honest scope
One remaining `private_intra_doc_links` warning lives in `descriptor.rs` (`from_void_nt` links the un-re-exported-but-`pub` `SourceDescriptorBuilder`) — a **method doc, not the crate doc**, and **not** promoted by this `deny` (different lint). Left out of this one-bead-one-PR and filed as **sq-zvdc**.

### Gate
- `cargo build` + `cargo clippy --all-targets -- -D warnings` + `cargo test`: green in **OFF**, **`fedplan`**, and **`adaptive-replan`** states.
- `cargo doc` (strict, `-D rustdoc::broken_intra_doc_links`): clean in all three states (OFF went 13 errors → 0).
- Privacy-claims gate (`scripts/check-privacy-claims.sh`): OK.
- **No public API change** (docs + one attribute + one test) → G2 public-api→SKILL.md rule not triggered.

[OPUS-4.8] sq-gxx7 — flag for Fable re-review when available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)