### PR TITLE
sparq-prov(reason): PROV-O lineage for reasoner materialization via why() proof trees (sq-m3i0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3482,6 +3482,7 @@ dependencies = [
  "oxttl 0.2.3",
  "sparq-core",
  "sparq-engine",
+ "sparq-reason",
 ]
 
 [[package]]

--- a/crates/sparq-prov/Cargo.toml
+++ b/crates/sparq-prov/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
-description = "W3C PROV-O data-lineage records for data DERIVED by a sparq operation (CONSTRUCT today) — a small, opt-in public API over sparq's term model"
+description = "W3C PROV-O data-lineage records for data DERIVED by a sparq operation (CONSTRUCT, reasoner materialization) — a small, opt-in public API over sparq's term model"
 publish = false
 
 # OPT-IN, lean core. NOTHING in the workspace's default build depends on this
@@ -19,12 +19,25 @@ publish = false
 # OFF BY DEFAULT at the dependency level — the leanest possible gating, with zero
 # core overhead when absent. [OPUS-4.8] sq-ntcg, branch feat-prov-lineage.
 
+# [OPUS-4.8] sq-m3i0: the reasoner-materialization lineage bridge is itself a
+# *non-default* feature, so even consumers who pull sparq-prov for CONSTRUCT
+# lineage pay nothing (no sparq-reason dep) unless they ask for `reason`.
+[features]
+default = []
+# Map a sparq-reason `why()` proof tree → PROV-O RDF (the `reason` module). Pulls
+# sparq-reason with its `explain` feature (the `ProofTree`/`ProofNode` surface).
+reason = ["dep:sparq-reason"]
+
 [dependencies]
 # sparq term model (oxrdf 0.3 re-export) + store Graph.
 sparq-core = { path = "../sparq-core" }
 # The CONSTRUCT derivation we wrap (and, by extension, DESCRIBE).
 sparq-engine = { path = "../sparq-engine" }
 oxrdf = { workspace = true }
+# Reasoner proof trees (`why()`), only under the `reason` feature. `explain` is the
+# sparq-reason feature that exposes ProofTree/ProofNode; default-features stay on
+# (parallel materialization) — sparq-prov never enters the wasm graph.
+sparq-reason = { path = "../sparq-reason", features = ["explain"], optional = true }
 
 [dev-dependencies]
 # Round-trip the emitted PROV-O graph back through the loader to prove it is

--- a/crates/sparq-prov/README.md
+++ b/crates/sparq-prov/README.md
@@ -56,6 +56,15 @@ let turtle  = d.prov_ntriples();    // …serialised (N-Triples ⊂ Turtle)
   `urn:sparq:prov:` nodes (same derivation ⇒ same IRIs); set `ProvConfig`
   `activity`/`entity`/`used`/`agent` to integrate with an external provenance
   store or named-graph scheme. The clock is injectable for deterministic tests.
+- **Reasoner-materialization lineage** (`reason` feature) — [`prov_from_proof`]
+  maps a `sparq-reason` `why()` proof tree to PROV-O: one `prov:Entity` per
+  inferred fact, one `prov:Activity` per rule firing (labelled `cax-sco` /
+  `rdfs9` / `prp-trp` / `n3-rule-i` / …), with `wasGeneratedBy` / `used` /
+  `wasDerivedFrom` edges. Inference *is* derivation, and the proof tree is a
+  *finer-grained* provenance than a single CONSTRUCT activity (it names the rule
+  and exact premises for each fact). Entity/activity IRIs are content-addressed,
+  so lineage from overlapping proofs **stitches** into one DAG. Non-default
+  feature: the `sparq-reason` dep is pulled only when you ask for `reason`.
 - **Dependency-light** — `xsd:dateTime` is formatted in-crate (no `chrono`/
   `time` dep); the formatter is the inverse of `sparq-core`'s dateTime parser,
   so a recorded timestamp parses back to the same instant (tested).
@@ -65,11 +74,12 @@ let turtle  = d.prov_ntriples();    // …serialised (N-Triples ⊂ Turtle)
 | Derivation path | Status |
 |---|---|
 | `CONSTRUCT` / `DESCRIBE` (query → new graph) | ✅ covered here |
+| Reasoner materialization (RDFS / OWL-RL / N3) | ✅ covered (`reason` feature) — reuses `sparq-reason`'s per-fact `why()` proof trees: a *finer-grained* derivation provenance than PROV-O alone |
 | SPARQL UPDATE (`INSERT … WHERE`, `INSERT DATA`) | ⏳ deferred (follow-up bead) |
-| Reasoner materialization (RDFS / OWL-RL / N3) | ⏳ deferred — would reuse `sparq-reason`'s per-triple `why()` proof trees, a *finer-grained* derivation provenance than PROV-O alone (follow-up bead) |
 
 The CONSTRUCT path is the cleanest, best-tested derivation in the engine and the
-natural first PROV-O target; the deferred paths are filed as beads.
+natural first PROV-O target; reasoner materialization reuses the existing proof
+trees; the remaining UPDATE path is filed as a bead. [OPUS-4.8] sq-m3i0
 
 ## 📚 Learn more
 

--- a/crates/sparq-prov/src/lib.rs
+++ b/crates/sparq-prov/src/lib.rs
@@ -25,10 +25,17 @@
 //! derivation. [`derive_construct`] runs the query, times it, and returns a
 //! [`Derivation`] carrying both the derived triples and a PROV-O lineage graph.
 //!
+//! **Reasoner-materialization** lineage is covered under the (non-default)
+//! `reason` feature: [`prov_from_proof`] maps a `sparq-reason` `why()`
+//! [`ProofTree`](sparq_reason::ProofTree) to PROV-O — one `prov:Entity` per
+//! inferred fact, one `prov:Activity` per rule firing, with
+//! `wasGeneratedBy`/`used`/`wasDerivedFrom` edges. Inference *is* derivation, and
+//! the proof tree is a finer-grained provenance (it names the rule and exact
+//! premises for each fact) than a single CONSTRUCT-style activity. See the
+//! [`reason`] module.
+//!
 //! **Deferred** (filed as follow-up beads, see the crate README): SPARQL UPDATE
-//! (`INSERT … WHERE` / `INSERT DATA`) lineage, and reasoner-materialization
-//! lineage (which would reuse `sparq-reason`'s per-triple `why()` proof trees —
-//! already a finer-grained derivation provenance than PROV-O alone).
+//! (`INSERT … WHERE` / `INSERT DATA`) lineage.
 //!
 //! [`prov:Activity`]: https://www.w3.org/TR/prov-o/#Activity
 //! [`prov:Entity`]: https://www.w3.org/TR/prov-o/#Entity
@@ -46,6 +53,13 @@ use sparq_core::Graph;
 use sparq_engine::QueryBudget;
 
 mod datetime;
+// [OPUS-4.8] sq-m3i0: reasoner-materialization lineage — map a sparq-reason
+// `why()` proof tree → PROV-O RDF. Non-default feature, so the sparq-reason dep
+// is pulled only when asked for.
+#[cfg(feature = "reason")]
+pub mod reason;
+#[cfg(feature = "reason")]
+pub use reason::{prov_from_proof, ProvProofConfig};
 
 // ── PROV-O vocabulary IRIs ─────────────────────────────────────────────────
 const PROV: &str = "http://www.w3.org/ns/prov#";

--- a/crates/sparq-prov/src/reason.rs
+++ b/crates/sparq-prov/src/reason.rs
@@ -1,0 +1,247 @@
+//! **Reasoner-materialization lineage** (`reason` feature): turn a
+//! [`sparq-reason`](https://docs.rs/sparq-reason) `why()` **proof tree** into W3C
+//! PROV-O RDF.
+//!
+//! # Inference *is* derivation
+//!
+//! When a reasoner materializes a triple, that triple is *derived* — exactly the
+//! relationship PROV-O exists to record. `sparq-reason` already computes, per
+//! materialized triple, a [`sparq_reason::ProofTree`]: a flat DAG of
+//! [`sparq_reason::ProofNode`]s where every node carries a `conclusion`
+//! (the fact), a `rule` id (`"asserted"` for a base fact, `axiom-*` for a
+//! tautology, a W3C/engine rule id otherwise — `cax-sco`, `rdfs9`, `prp-trp`,
+//! `n3-rule-<i>`, …), and the indices of its `premises`. That proof tree is a
+//! *finer-grained* derivation record than a single CONSTRUCT-style PROV activity:
+//! it names the rule that fired and the exact premises for **each** inferred fact.
+//!
+//! This module is the bridge. [`prov_from_proof`] walks one proof tree and emits,
+//! for the proof's structure:
+//!
+//! * one [`prov:Entity`] per distinct fact (the node's conclusion), with a stable
+//!   content-addressed IRI so the same fact names the same entity across proofs;
+//! * one [`prov:Activity`] per rule application (a non-leaf node), labelled with
+//!   the rule id ([`rdfs:label`]) and time-stamped if a clock is configured;
+//! * the lineage edges: `entity` [`prov:wasGeneratedBy`] `activity`, and for each
+//!   premise `activity` [`prov:used`] `premiseEntity` + `entity`
+//!   [`prov:wasDerivedFrom`] `premiseEntity`.
+//!
+//! Asserted leaves and `axiom-*` tautologies are entities with no generating
+//! activity (they were not *derived* — they are the inputs the derivation rests on),
+//! which is the correct PROV reading: a leaf is the boundary of the lineage.
+//!
+//! # Why content-addressed IRIs
+//!
+//! A proof's `conclusion` strings are self-contained N-Triples-style term strings
+//! (no engine ids leak — see the `sparq-reason::explain` module docs), so the same
+//! fact stringifies identically everywhere. Hashing that string into the entity IRI
+//! makes the lineage **stitchable**: emit PROV for two overlapping proofs and the
+//! shared sub-facts coincide, so `wasDerivedFrom` chains join up into one DAG
+//! instead of two disconnected trees. Activities are addressed by `(rule,
+//! conclusion)` for the same reason (one activity per distinct rule firing).
+//!
+//! [`prov:Entity`]: https://www.w3.org/TR/prov-o/#Entity
+//! [`prov:Activity`]: https://www.w3.org/TR/prov-o/#Activity
+//! [`prov:wasGeneratedBy`]: https://www.w3.org/TR/prov-o/#wasGeneratedBy
+//! [`prov:used`]: https://www.w3.org/TR/prov-o/#used
+//! [`prov:wasDerivedFrom`]: https://www.w3.org/TR/prov-o/#wasDerivedFrom
+//! [`rdfs:label`]: http://www.w3.org/2000/01/rdf-schema#label
+
+use std::time::SystemTime;
+
+use oxrdf::vocab::rdf;
+use oxrdf::{Literal, NamedNode, NamedOrBlankNode, Term, Triple};
+use sparq_reason::ProofTree;
+
+use crate::{datetime_literal, fnv1a, prov, SPARQ_PROV_NS};
+
+/// The `rule` id a leaf [`ProofNode`](sparq_reason::ProofNode) carries when it is an
+/// explicitly asserted base triple (the proof's boundary — no generating activity).
+const ASSERTED: &str = "asserted";
+/// Prefix of the `rule` id for the few premise-free tautology nodes (the XSD
+/// numeric-tower `rdfs:subClassOf` axioms, etc.). Treated like [`ASSERTED`]: an
+/// entity boundary, but labelled with the axiom name for traceability.
+const AXIOM_PREFIX: &str = "axiom-";
+
+const RDFS_LABEL: &str = "http://www.w3.org/2000/01/rdf-schema#label";
+
+/// How reasoner-materialization lineage is identified and time-stamped.
+///
+/// Unlike [`ProvConfig`](crate::ProvConfig) (which names *one* activity/entity for
+/// a whole CONSTRUCT), a proof tree has *many* facts and rule firings, so the IRIs
+/// here are minted **per node** (content-addressed; see the module docs). What the
+/// caller controls is the namespace, the optional clock, and the optional agent.
+#[derive(Clone, Debug)]
+pub struct ProvProofConfig {
+    /// IRI prefix the per-fact entities and per-rule activities are minted under.
+    /// Defaults to [`SPARQ_PROV_NS`]. Set it to integrate with an external store.
+    pub namespace: String,
+    /// Optional wall clock: when `Some`, every rule-application activity is
+    /// time-stamped with `prov:generatedAtTime` (a single instant — the moment
+    /// lineage was captured, not a per-rule duration, which a finished proof no
+    /// longer has). `None` ⇒ no timestamps (fully deterministic output).
+    pub clock: Option<fn() -> SystemTime>,
+    /// Optional [`prov:Agent`](https://www.w3.org/TR/prov-o/#Agent) every rule
+    /// activity is [`prov:wasAssociatedWith`](https://www.w3.org/TR/prov-o/#wasAssociatedWith)
+    /// (e.g. the reasoner profile / service identity).
+    pub agent: Option<NamedNode>,
+}
+
+impl Default for ProvProofConfig {
+    fn default() -> Self {
+        ProvProofConfig {
+            namespace: SPARQ_PROV_NS.to_string(),
+            clock: None,
+            agent: None,
+        }
+    }
+}
+
+impl ProvProofConfig {
+    /// A config minting under the default [`SPARQ_PROV_NS`] namespace, time-stamping
+    /// activities with the given clock (so `prov:generatedAtTime` is recorded).
+    pub fn with_clock(clock: fn() -> SystemTime) -> Self {
+        ProvProofConfig {
+            clock: Some(clock),
+            ..Self::default()
+        }
+    }
+}
+
+/// Emit W3C PROV-O lineage RDF for one [`ProofTree`] (a `sparq-reason` `why()`
+/// result) — see the module docs for the shape.
+///
+/// Returns the lineage as a `Vec<Triple>` (a valid RDF graph that round-trips
+/// through any parser). The proof's *conclusion* (root) is the explained,
+/// materialized fact; its leaves are the asserted facts / axioms the derivation
+/// rests on; every internal node becomes a rule-application activity.
+///
+/// Deterministic for a given proof + config (modulo the optional clock): node
+/// order follows the proof's premises-before-conclusion order, and all IRIs are
+/// content-addressed.
+pub fn prov_from_proof(proof: &ProofTree, config: &ProvProofConfig) -> Vec<Triple> {
+    let now = config.clock.map(|c| datetime_literal(c()));
+    let mut out: Vec<Triple> = Vec::new();
+    let mut push = |s: NamedOrBlankNode, p: NamedNode, o: Term| {
+        out.push(Triple {
+            subject: s,
+            predicate: p,
+            object: o,
+        });
+    };
+
+    // First pass: a stable entity IRI per node (content-addressed by conclusion).
+    let entity_iris: Vec<NamedNode> = proof
+        .nodes()
+        .iter()
+        .map(|n| fact_entity(&config.namespace, &n.conclusion))
+        .collect();
+
+    for (i, node) in proof.nodes().iter().enumerate() {
+        let entity = NamedOrBlankNode::NamedNode(entity_iris[i].clone());
+
+        // Every node is a prov:Entity (the fact it concludes).
+        push(
+            entity.clone(),
+            NamedNode::from(rdf::TYPE),
+            Term::NamedNode(prov("Entity")),
+        );
+
+        // A leaf (asserted base fact / axiom tautology) is the boundary of the
+        // lineage: it has no generating activity. Axioms keep a label so the
+        // tautology is still traceable.
+        let is_asserted = node.rule == ASSERTED;
+        let is_axiom = node.rule.starts_with(AXIOM_PREFIX);
+        if is_asserted || is_axiom {
+            if is_axiom {
+                push(
+                    entity.clone(),
+                    NamedNode::new_unchecked(RDFS_LABEL),
+                    Term::Literal(Literal::new_simple_literal(&node.rule)),
+                );
+            }
+            continue;
+        }
+
+        // An internal node: the rule fired to GENERATE this fact from its premises.
+        let activity_iri = rule_activity(&config.namespace, &node.rule, &node.conclusion);
+        let activity = NamedOrBlankNode::NamedNode(activity_iri.clone());
+        push(
+            activity.clone(),
+            NamedNode::from(rdf::TYPE),
+            Term::NamedNode(prov("Activity")),
+        );
+        // The rule id (cax-sco / rdfs9 / n3-rule-i / …) as an rdfs:label.
+        push(
+            activity.clone(),
+            NamedNode::new_unchecked(RDFS_LABEL),
+            Term::Literal(Literal::new_simple_literal(&node.rule)),
+        );
+        if let Some(ref lit) = now {
+            push(
+                activity.clone(),
+                prov("generatedAtTime"),
+                Term::Literal(lit.clone()),
+            );
+        }
+        if let Some(agent) = &config.agent {
+            push(
+                activity.clone(),
+                prov("wasAssociatedWith"),
+                Term::NamedNode(agent.clone()),
+            );
+        }
+        // Generation: the derived fact was generated by this rule application.
+        push(
+            entity.clone(),
+            prov("wasGeneratedBy"),
+            Term::NamedNode(activity_iri.clone()),
+        );
+        // Lineage to each premise: the activity used it, the fact derives from it.
+        for &p in &node.premises {
+            let prem = &entity_iris[p as usize];
+            push(
+                activity.clone(),
+                prov("used"),
+                Term::NamedNode(prem.clone()),
+            );
+            push(
+                entity.clone(),
+                prov("wasDerivedFrom"),
+                Term::NamedNode(prem.clone()),
+            );
+        }
+    }
+    out
+}
+
+/// Mint a stable `…fact:<hash>` entity IRI from a fact's term strings. The
+/// conclusion strings are canonical (one rendering per term), so the same fact
+/// always names the same entity — letting lineage from different proofs stitch.
+fn fact_entity(ns: &str, conclusion: &[String; 3]) -> NamedNode {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for part in conclusion {
+        h = mix(h, fnv1a(part.as_bytes()));
+    }
+    NamedNode::new_unchecked(format!("{ns}fact:{h:016x}"))
+}
+
+/// Mint a stable `…rule:<hash>` activity IRI for one rule firing — addressed by
+/// `(rule, conclusion)` so one activity exists per distinct rule application.
+fn rule_activity(ns: &str, rule: &str, conclusion: &[String; 3]) -> NamedNode {
+    let mut h = fnv1a(rule.as_bytes());
+    for part in conclusion {
+        h = mix(h, fnv1a(part.as_bytes()));
+    }
+    NamedNode::new_unchecked(format!("{ns}rule:{h:016x}"))
+}
+
+/// Order-sensitive 64-bit mix of two hashes (so `(a,b,c)` and a permutation differ).
+fn mix(acc: u64, x: u64) -> u64 {
+    // FNV-1a-style fold of `x` into `acc`, byte by byte (keeps it dependency-free).
+    let mut h = acc;
+    for b in x.to_le_bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}

--- a/crates/sparq-prov/tests/reason_prov.rs
+++ b/crates/sparq-prov/tests/reason_prov.rs
@@ -1,0 +1,307 @@
+//! End-to-end: sparq-reason `why()` proof tree → PROV-O lineage RDF.
+//! [OPUS-4.8] sq-m3i0 — reasoner-materialization lineage.
+#![cfg(feature = "reason")]
+
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use oxrdf::vocab::xsd;
+use oxrdf::Triple;
+use sparq_core::dict::{Dict, Id};
+use sparq_prov::{prov_from_proof, ProvProofConfig};
+use sparq_reason::n3::Term as N3Term;
+use sparq_reason::{MaterializedGraph, MaterializedN3Graph};
+
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const RDFS_SUBCLASS: &str = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
+const PROV: &str = "http://www.w3.org/ns/prov#";
+const RDFS_LABEL: &str = "http://www.w3.org/2000/01/rdf-schema#label";
+
+/// Build an RDFS graph over `(rex a Dog), (Dog ⊑ Animal)` and return the graph,
+/// the dict, and the id of the inferred fact `(rex a Animal)` (via cax-sco/rdfs9).
+fn dog_setup() -> (MaterializedGraph, Dict, [Id; 3]) {
+    let mut dict = Dict::default();
+    let i = |d: &mut Dict, s: &str| d.intern_iri(s);
+    let rex = i(&mut dict, "http://ex/rex");
+    let dog = i(&mut dict, "http://ex/Dog");
+    let animal = i(&mut dict, "http://ex/Animal");
+    let ty = i(&mut dict, RDF_TYPE);
+    let sc = i(&mut dict, RDFS_SUBCLASS);
+    let base = vec![[rex, ty, dog], [dog, sc, animal]];
+    let g = MaterializedGraph::new(&mut dict, &base);
+    (g, dict, [rex, ty, animal])
+}
+
+/// All distinct predicate IRIs in a graph.
+fn preds(g: &[Triple]) -> HashSet<String> {
+    g.iter().map(|t| t.predicate.as_str().to_string()).collect()
+}
+
+/// Map subject IRI -> set of (predicate, object-IRI-or-literal-lexical) for assertions.
+fn lines(g: &[Triple]) -> HashSet<String> {
+    g.iter()
+        .map(|t| format!("{} {} {}", t.subject, t.predicate, t.object))
+        .collect()
+}
+
+#[test]
+fn derived_fact_proof_emits_entity_activity_and_lineage() {
+    let (g, dict, fact) = dog_setup();
+    let proof = g.why(&dict, fact).expect("inferred fact has a proof");
+    // The proof: root (rex a Animal) ← rule(rdfs9/cax-sco) ← 2 asserted leaves.
+    assert!(
+        proof.nodes().len() >= 3,
+        "expected a multi-node proof, got {}",
+        proof.nodes().len()
+    );
+
+    let prov = prov_from_proof(&proof, &ProvProofConfig::default());
+    let p = preds(&prov);
+    // Core PROV-O lineage predicates are present.
+    assert!(
+        p.contains(&format!("{PROV}wasGeneratedBy")),
+        "missing wasGeneratedBy: {p:?}"
+    );
+    assert!(p.contains(&format!("{PROV}used")), "missing used");
+    assert!(
+        p.contains(&format!("{PROV}wasDerivedFrom")),
+        "missing wasDerivedFrom"
+    );
+
+    // Exactly one prov:Activity per non-leaf node; here the single rule firing.
+    let activities: Vec<&Triple> = prov
+        .iter()
+        .filter(|t| {
+            t.predicate.as_str() == RDF_TYPE && t.object.to_string() == format!("<{PROV}Activity>")
+        })
+        .collect();
+    assert_eq!(activities.len(), 1, "one rule firing ⇒ one Activity");
+
+    // Every premise that the activity `used` is also `wasDerivedFrom` by the result.
+    let used: HashSet<String> = prov
+        .iter()
+        .filter(|t| t.predicate.as_str() == format!("{PROV}used"))
+        .map(|t| t.object.to_string())
+        .collect();
+    let derived_from: HashSet<String> = prov
+        .iter()
+        .filter(|t| t.predicate.as_str() == format!("{PROV}wasDerivedFrom"))
+        .map(|t| t.object.to_string())
+        .collect();
+    assert_eq!(used, derived_from, "used inputs == wasDerivedFrom inputs");
+    assert_eq!(
+        used.len(),
+        2,
+        "rdfs9 has two premises (typing + subClassOf)"
+    );
+
+    // The activity carries the rule id as an rdfs:label (cax-sco / rdfs9).
+    let label = prov
+        .iter()
+        .find(|t| t.predicate.as_str() == RDFS_LABEL && t.subject.to_string().contains(":rule:"))
+        .map(|t| t.object.to_string())
+        .expect("rule activity has a label");
+    assert!(
+        label.contains("rdfs9") || label.contains("cax-sco"),
+        "unexpected rule label: {label}"
+    );
+}
+
+#[test]
+fn asserted_leaves_are_entities_without_a_generating_activity() {
+    let (g, dict, fact) = dog_setup();
+    let proof = g.why(&dict, fact).unwrap();
+    let prov = prov_from_proof(&proof, &ProvProofConfig::default());
+
+    // Subjects that wasGeneratedBy something = derived entities.
+    let generated: HashSet<String> = prov
+        .iter()
+        .filter(|t| t.predicate.as_str() == format!("{PROV}wasGeneratedBy"))
+        .map(|t| t.subject.to_string())
+        .collect();
+    // Every fact node is typed prov:Entity.
+    let entities: HashSet<String> = prov
+        .iter()
+        .filter(|t| {
+            t.predicate.as_str() == RDF_TYPE && t.object.to_string() == format!("<{PROV}Entity>")
+        })
+        .map(|t| t.subject.to_string())
+        .collect();
+    // 3 distinct facts (2 leaves + 1 root) ⇒ 3 entities; exactly 1 is generated.
+    assert_eq!(entities.len(), 3);
+    assert_eq!(generated.len(), 1);
+    assert!(generated.is_subset(&entities));
+    // The two leaves have no generating activity.
+    assert_eq!(entities.difference(&generated).count(), 2);
+}
+
+#[test]
+fn lineage_is_valid_rdf_and_round_trips() {
+    let (g, dict, fact) = dog_setup();
+    let proof = g.why(&dict, fact).unwrap();
+    let prov = prov_from_proof(&proof, &ProvProofConfig::default());
+    let nt = sparq_engine::triples_to_ntriples(&prov);
+
+    let reloaded = sparq_core::Graph::load_str(&nt, "turtle").expect("PROV-O must be valid RDF");
+    assert_eq!(reloaded.len(), prov.len());
+
+    use oxttl::NTriplesParser;
+    let parsed: Vec<_> = NTriplesParser::new()
+        .for_reader(nt.as_bytes())
+        .collect::<Result<_, _>>()
+        .expect("emitted lineage must be well-formed N-Triples");
+    assert_eq!(parsed.len(), prov.len());
+}
+
+#[test]
+fn deterministic_and_content_addressed() {
+    let (g, dict, fact) = dog_setup();
+    let proof = g.why(&dict, fact).unwrap();
+    let a = prov_from_proof(&proof, &ProvProofConfig::default());
+    let b = prov_from_proof(&proof, &ProvProofConfig::default());
+    assert_eq!(
+        lines(&a),
+        lines(&b),
+        "same proof + config ⇒ identical lineage"
+    );
+    // The minted entity/activity IRIs sit under the default namespace.
+    assert!(a
+        .iter()
+        .any(|t| t.subject.to_string().contains("urn:sparq:prov:fact:")));
+    assert!(a
+        .iter()
+        .any(|t| t.subject.to_string().contains("urn:sparq:prov:rule:")));
+}
+
+#[test]
+fn shared_subfacts_stitch_across_proofs() {
+    // Two derived facts that share the asserted typing premise (rex a Dog) must
+    // name the SAME entity IRI for that shared fact, so lineage DAGs join up.
+    let mut dict = Dict::default();
+    let i = |d: &mut Dict, s: &str| d.intern_iri(s);
+    let rex = i(&mut dict, "http://ex/rex");
+    let dog = i(&mut dict, "http://ex/Dog");
+    let animal = i(&mut dict, "http://ex/Animal");
+    let mammal = i(&mut dict, "http://ex/Mammal");
+    let ty = i(&mut dict, RDF_TYPE);
+    let sc = i(&mut dict, RDFS_SUBCLASS);
+    // Dog ⊑ Mammal ⊑ Animal, rex a Dog ⇒ rex a Mammal and rex a Animal.
+    let base = vec![[rex, ty, dog], [dog, sc, mammal], [mammal, sc, animal]];
+    let g = MaterializedGraph::new(&mut dict, &base);
+
+    let cfg = ProvProofConfig::default();
+    let p1 = prov_from_proof(&g.why(&dict, [rex, ty, mammal]).unwrap(), &cfg);
+    let p2 = prov_from_proof(&g.why(&dict, [rex, ty, animal]).unwrap(), &cfg);
+
+    // Both proofs share the asserted leaf (rex a Dog), and the SAME fact must mint
+    // the SAME content-addressed entity IRI — so the lineage DAGs join up.
+    let ents1: HashSet<String> = p1
+        .iter()
+        .filter(|t| {
+            t.predicate.as_str() == RDF_TYPE && t.object.to_string() == format!("<{PROV}Entity>")
+        })
+        .map(|t| t.subject.to_string())
+        .collect();
+    let ents2: HashSet<String> = p2
+        .iter()
+        .filter(|t| {
+            t.predicate.as_str() == RDF_TYPE && t.object.to_string() == format!("<{PROV}Entity>")
+        })
+        .map(|t| t.subject.to_string())
+        .collect();
+    // At least one shared entity (the (rex a Dog) leaf) appears in both.
+    assert!(
+        ents1.intersection(&ents2).next().is_some(),
+        "overlapping proofs must share at least the (rex a Dog) leaf entity"
+    );
+}
+
+#[test]
+fn clock_and_agent_are_recorded_on_activities() {
+    let (g, dict, fact) = dog_setup();
+    let proof = g.why(&dict, fact).unwrap();
+
+    fn fixed() -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(1_700_000_000)
+    }
+    let cfg = ProvProofConfig {
+        agent: Some(oxrdf::NamedNode::new_unchecked("http://ex/rdfs-reasoner")),
+        ..ProvProofConfig::with_clock(fixed)
+    };
+    let prov = prov_from_proof(&proof, &cfg);
+
+    // generatedAtTime on the activity, typed xsd:dateTime = 2023-11-14T22:13:20Z.
+    let ts = prov
+        .iter()
+        .find(|t| t.predicate.as_str() == format!("{PROV}generatedAtTime"))
+        .map(|t| t.object.to_string())
+        .expect("activity is time-stamped");
+    assert!(ts.contains("2023-11-14T22:13:20Z"), "got {ts}");
+    assert!(ts.contains(xsd::DATE_TIME.as_str()));
+
+    // wasAssociatedWith the configured agent.
+    assert!(prov.iter().any(
+        |t| t.predicate.as_str() == format!("{PROV}wasAssociatedWith")
+            && t.object.to_string() == "<http://ex/rdfs-reasoner>"
+    ));
+}
+
+#[test]
+fn n3_rule_proof_emits_lineage_with_n3_rule_label() {
+    // The same bridge works on N3 proofs (the bead is RDFS/OWL-RL/N3): a forward
+    // rule firing becomes a prov:Activity labelled `n3-rule-<i>`.
+    let ex = |l: &str| N3Term::Iri(format!("http://ex/{l}"));
+    let rules = r#"
+        @prefix : <http://ex/> .
+        { ?x :parent ?y } => { ?x :ancestor ?y } .
+    "#;
+    let base = vec![[ex("a"), ex("parent"), ex("b")]];
+    let g = MaterializedN3Graph::new(rules, &base).expect("rules parse");
+    let fact = [ex("a"), ex("ancestor"), ex("b")];
+    assert!(g.contains(&fact));
+    let proof = g.why(&fact).expect("derived N3 fact explains");
+
+    let prov = prov_from_proof(&proof, &ProvProofConfig::default());
+    // The rule firing is a labelled Activity.
+    let label = prov
+        .iter()
+        .find(|t| t.predicate.as_str() == RDFS_LABEL && t.subject.to_string().contains(":rule:"))
+        .map(|t| t.object.to_string())
+        .expect("rule activity has a label");
+    assert!(
+        label.contains("n3-rule-0"),
+        "unexpected N3 rule label: {label}"
+    );
+    // wasGeneratedBy + a single used/wasDerivedFrom premise (the asserted parent edge).
+    assert!(preds(&prov).contains(&format!("{PROV}wasGeneratedBy")));
+    let used = prov
+        .iter()
+        .filter(|t| t.predicate.as_str() == format!("{PROV}used"))
+        .count();
+    assert_eq!(used, 1, "one premise: a :parent b");
+    // Valid RDF.
+    let nt = sparq_engine::triples_to_ntriples(&prov);
+    assert!(sparq_core::Graph::load_str(&nt, "turtle").is_ok());
+}
+
+#[test]
+fn asserted_fact_proof_is_a_lone_entity() {
+    // why() on a base triple returns a single asserted leaf ⇒ one Entity, no Activity.
+    let (g, dict, _) = dog_setup();
+    let mut dict2 = dict;
+    let rex = dict2.intern_iri("http://ex/rex");
+    let dog = dict2.intern_iri("http://ex/Dog");
+    let ty = dict2.intern_iri(RDF_TYPE);
+    let proof = g
+        .why(&dict2, [rex, ty, dog])
+        .expect("asserted fact explains");
+    assert_eq!(proof.nodes().len(), 1);
+    let prov = prov_from_proof(&proof, &ProvProofConfig::default());
+    // One Entity typing triple, nothing else (no activity, no edges).
+    let mut by_pred: HashMap<String, usize> = HashMap::new();
+    for t in &prov {
+        *by_pred.entry(t.predicate.as_str().to_string()).or_default() += 1;
+    }
+    assert_eq!(by_pred.get(RDF_TYPE), Some(&1));
+    assert!(!by_pred.contains_key(&format!("{PROV}wasGeneratedBy")));
+}

--- a/skills/prov-lineage/SKILL.md
+++ b/skills/prov-lineage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prov-lineage
-description: "Capture W3C PROV-O data lineage for DERIVED RDF — when a CONSTRUCT/DESCRIBE query produces a new graph, record who/what/when made it (prov:Activity + prov:Entity + wasGeneratedBy/used/wasDerivedFrom) using the opt-in sparq-prov crate. Use when you need machine-readable provenance for derived data — citable lineage for GenAI-grounded answers, audit/compliance (CDMC CD-1) data-lineage capture, or attribution of constructed graphs to their source(s). Off by default; does not touch sparq-core/sparq-engine's lean build."
+description: "Capture W3C PROV-O data lineage for DERIVED RDF — when a CONSTRUCT/DESCRIBE query produces a new graph, OR a reasoner materializes inferred triples (RDFS/OWL-RL/N3), record who/what/when made it (prov:Activity + prov:Entity + wasGeneratedBy/used/wasDerivedFrom) using the opt-in sparq-prov crate. Use when you need machine-readable provenance for derived data — citable lineage for GenAI-grounded answers, audit/compliance (CDMC CD-1) data-lineage capture, attribution of constructed graphs to their source(s), or per-fact inference lineage from a why() proof tree (the `reason` feature). Off by default; does not touch sparq-core/sparq-engine's lean build."
 ---
 
 # sparq-prov — W3C PROV-O lineage for derived data
@@ -80,17 +80,59 @@ RDF parser (tested against both `Graph::load_str` and `oxttl::NTriplesParser`).
 - `ProvConfig.used` lists the input-source IRIs (typically the dataset / named
   graph the CONSTRUCT ran against); `ProvConfig.agent` names the running service.
 
+## Reasoner-materialization lineage (`reason` feature)
+
+Inference *is* derivation: when a reasoner materializes a triple, that triple is
+`wasDerivedFrom` the premises the rule fired on. The `reason` feature turns a
+`sparq-reason` `why()` proof tree (the `explain` feature there) straight into
+PROV-O — a *finer-grained* provenance than a single CONSTRUCT activity, because
+it names the rule and exact premises for **each** inferred fact.
+
+```toml
+[dependencies]
+sparq-prov   = { path = "crates/sparq-prov", features = ["reason"] }
+sparq-reason = { path = "crates/sparq-reason", features = ["explain"] }
+```
+
+```rust
+use sparq_prov::{prov_from_proof, ProvProofConfig};
+
+// g: a sparq_reason::MaterializedGraph / MaterializedOwlGraph / MaterializedN3Graph.
+let proof   = g.why(&dict, inferred_fact).expect("fact is in the closure");
+let lineage = prov_from_proof(&proof, &ProvProofConfig::default());  // Vec<Triple>
+```
+
+Emitted shape — for each proof node (fact) `F` and the rule firing `R` that
+generated a non-leaf `F` from premises `Pᵢ`:
+
+```turtle
+F  a                   prov:Entity .
+R  a                   prov:Activity .
+R  rdfs:label          "cax-sco" .          # rdfs9 / prp-trp / n3-rule-0 / …
+F  prov:wasGeneratedBy R .
+R  prov:used           Pᵢ .                  # one per premise
+F  prov:wasDerivedFrom Pᵢ .
+R  prov:generatedAtTime "…Z"^^xsd:dateTime . # iff ProvProofConfig.clock is set
+R  prov:wasAssociatedWith <agent> .          # iff ProvProofConfig.agent is set
+```
+
+Asserted leaves and `axiom-*` tautologies are entities with **no** generating
+activity — they are the boundary the derivation rests on. Entity/activity IRIs
+are content-addressed (`urn:sparq:prov:fact:…` / `:rule:…`) from the proof's
+canonical term strings, so lineage from overlapping proofs **stitches** into one
+DAG (the same shared fact names the same entity).
+
 ## Scope — covered vs deferred
 
 | Derivation path | Status |
 |---|---|
 | `CONSTRUCT` / `DESCRIBE` | ✅ covered (`derive_construct`) |
+| Reasoner materialization (RDFS / OWL-RL / N3) | ✅ covered (`reason` feature → `prov_from_proof`) |
 | SPARQL UPDATE (`INSERT … WHERE`, `INSERT DATA`) | ⏳ deferred (follow-up bead) |
-| Reasoner materialization (RDFS / OWL-RL / N3) | ⏳ deferred — reuses `sparq-reason`'s `why()` proof trees, a finer-grained per-triple derivation provenance (follow-up bead) |
 
-For the reasoner's *inference* provenance today, see the
+For the reasoner's per-fact proof itself (the input to `prov_from_proof`), see the
 [`inference`](../inference/SKILL.md) skill's `explain` feature (`why()` produces
-an N3 proof tree — derivation provenance at the rule/premise level).
+a proof tree — derivation provenance at the rule/premise level).
 
 ## See also
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — opening this PR on @jeswr's behalf. Do not enable auto-merge; the orchestrator arms it after review.

## What

Implements **sq-m3i0** (CDMC CD-1): emit **W3C PROV-O lineage for reasoner materialization** (RDFS / OWL-RL / N3), **reusing `sparq-reason`'s `why()` proof trees**. This closes the derivation path `sparq-prov` had explicitly filed as *deferred* in its own README/lib docs.

**Inference *is* derivation.** A new, non-default `reason` feature adds `prov_from_proof(&ProofTree, &ProvProofConfig) -> Vec<Triple>`, which walks one proof tree and emits:

- one `prov:Entity` per distinct fact (the node's conclusion),
- one `prov:Activity` per **rule firing** (a non-leaf node), labelled with the rule id (`cax-sco` / `rdfs9` / `prp-trp` / `n3-rule-i` / …) via `rdfs:label`,
- the lineage edges `entity prov:wasGeneratedBy activity`, and per premise `activity prov:used premise` + `entity prov:wasDerivedFrom premise`,
- optional `prov:generatedAtTime` (injectable clock) and `prov:wasAssociatedWith <agent>`.

This is a **finer-grained** provenance than a single CONSTRUCT-style activity: it names the rule and the exact premises for *each* inferred fact. Asserted leaves and `axiom-*` tautologies are entities with **no** generating activity — the boundary the derivation rests on.

Entity/activity IRIs are **content-addressed** from the proof's canonical N-Triples-style term strings, so lineage from overlapping proofs **stitches** into one DAG (the same shared fact names the same entity).

## Opt-in by construction

The `reason` feature is **non-default**, and the `sparq-reason` dependency (with its `explain` feature) is pulled in *only* under `reason`. So:
- the workspace default build and the wasm artifact are byte-identical (sparq-prov is already a standalone, non-default member),
- even consumers who pull sparq-prov for CONSTRUCT lineage pay nothing extra unless they ask for `reason`.

## Tests (`tests/reason_prov.rs`, gated on `reason`)

End-to-end through real RDFS (`MaterializedGraph`) and N3 (`MaterializedN3Graph`) `why()`:
- derived-fact proof → correct entity/activity/`used`==`wasDerivedFrom`/rule-label shape;
- asserted leaves are entities **without** a generating activity;
- emitted lineage is valid RDF (round-trips via `Graph::load_str` **and** `oxttl::NTriplesParser`);
- deterministic + content-addressed IRIs under `urn:sparq:prov:`;
- shared sub-facts across overlapping proofs **stitch** (same entity IRI);
- N3 rule firing → `n3-rule-0`-labelled activity;
- clock + agent recorded on activities (`generatedAtTime` typed `xsd:dateTime`).

## Gate (all green)

- `cargo fmt -p sparq-prov --check`
- `cargo clippy -p sparq-prov --all-targets -- -D warnings` — **both** feature states (default, `--features reason`)
- `cargo test -p sparq-prov` — **both** feature states (default: 9 unit + 1 doctest; `reason`: + 8 integration)
- `RUSTDOCFLAGS=-D warnings cargo doc -p sparq-prov --features reason`
- `scripts/check-privacy-claims.sh` — OK (no privacy/soundness claims; this is provenance, not a privacy mechanism)
- G2 public-API → SKILL: `prov-lineage/SKILL.md` updated for the new public surface (`prov_from_proof`, `ProvProofConfig`)
- `cargo check --workspace` clean

## Docs

- `crates/sparq-prov/README.md` + lib.rs: scope table flips reasoner-materialization from *deferred* → *covered*; UPDATE remains the one deferred path.
- `skills/prov-lineage/SKILL.md`: new "Reasoner-materialization lineage" section with the emitted shape, plus updated description + scope.

[OPUS-4.8] markers on all new code/notes; Opus 4.8 `Co-Authored-By` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)