### PR TITLE
feat(sparq-engine): inline OVER() LAG/LEAD/NTILE + named WINDOW clause (sq-hqhc)

### DIFF
--- a/crates/sparq-engine/Cargo.toml
+++ b/crates/sparq-engine/Cargo.toml
@@ -71,8 +71,10 @@ serialize-rdf = []
 #     aggregate IRI — `SparqlParser::with_custom_aggregate_function`); the engine
 #     evaluates `AggregateFunction::Custom` against the installed registry.
 #   * a programmatic window-function pass (`window` module) — ROW_NUMBER / RANK /
-#     DENSE_RANK + a windowed aggregate over a result table, with PARTITION BY +
-#     ORDER BY window specs. These are a NON-STANDARD extension (no W3C-REC SPARQL
+#     DENSE_RANK, the offset/positional LAG / LEAD / NTILE (sq-hqhc), + a windowed
+#     aggregate over a result table, with PARTITION BY + ORDER BY window specs (and a
+#     reusable named WINDOW clause on the inline OVER syntax). These are a
+#     NON-STANDARD extension (no W3C-REC SPARQL
 #     window syntax exists); the surface follows the SQL:2003 OVER (PARTITION BY …
 #     ORDER BY …) window-spec model that Stardog/AnzoGraph expose.
 # When off, ZERO window/custom-aggregate code compiles and the default build is

--- a/crates/sparq-engine/README.md
+++ b/crates/sparq-engine/README.md
@@ -42,16 +42,19 @@ let json = sparq_engine::query_json(&g, "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?
   see [`docs/extension-functions.md`](../../docs/extension-functions.md).
 - **Custom aggregates + window functions** *(opt-in `window-functions` feature, OFF by default)* —
   register a named user aggregate (`CustomAggregateRegistry`) callable from a real SPARQL `GROUP BY`,
-  and a window-function surface (`ROW_NUMBER` / `RANK` / `DENSE_RANK` + the windowed aggregates
-  `COUNT`/`SUM`/`AVG`/`MIN`/`MAX`, with `PARTITION BY` + `ORDER BY` and an optional `ROWS`/`RANGE` frame)
+  and a window-function surface (`ROW_NUMBER` / `RANK` / `DENSE_RANK`, the offset/positional
+  `LAG`/`LEAD`/`NTILE` (sq-hqhc), + the windowed aggregates `COUNT`/`SUM`/`AVG`/`MIN`/`MAX`, with
+  `PARTITION BY` + `ORDER BY` and an optional `ROWS`/`RANGE` frame)
   available two ways: a programmatic pass (`window::apply_window` over a `QueryResult`) and an inline
   `OVER(…)` query syntax (`query_over` — e.g. `(SUM(?x) OVER (ORDER BY ?y ROWS BETWEEN UNBOUNDED
-  PRECEDING AND CURRENT ROW) AS ?run)` in the SELECT). **Window functions are a NON-STANDARD extension**
+  PRECEDING AND CURRENT ROW) AS ?run)` in the SELECT, and a reusable `WINDOW w AS (…)` clause with
+  `OVER w`). **Window functions are a NON-STANDARD extension**
   — SPARQL has no W3C-REC `OVER` syntax. The inline form is a *source rewrite* in front of the engine
   recognised ONLY on `query_over` (it does NOT change the vendored parser), so the standard
   `query`/`ask`/… surface stays exactly SPARQL 1.1 and conformance is unaffected. Inline covers the three
-  ranking functions, the five windowed aggregates, and `ROWS`/`RANGE` frames (sq-imj8); `DISTINCT`/
-  expression aggregate arguments, numeric `RANGE` offsets, and `LAG`/`LEAD`/`NTILE` are inline-deferred
+  ranking functions, the five windowed aggregates, `ROWS`/`RANGE` frames (sq-imj8), the offset/positional
+  `LAG`/`LEAD`/`NTILE` and a named `WINDOW` clause (sq-hqhc); `DISTINCT`/computed-expression function
+  arguments, numeric `RANGE` offsets, and a computed-expression `PARTITION BY` are inline-deferred
   (use the programmatic API). When the feature is off, zero window/aggregate-registry code compiles and
   the default build is byte-identical (no new deps).
 - **`forbid(unsafe_code)`** — the crate contains zero `unsafe`.

--- a/crates/sparq-engine/src/window.rs
+++ b/crates/sparq-engine/src/window.rs
@@ -32,6 +32,16 @@
 //!   partition. With an explicit frame (`ROWS`/`RANGE BETWEEN … AND …`) the
 //!   aggregate is recomputed per row over only the rows in that row's frame, so a
 //!   running total / moving average is expressible (see [`WindowFrame`]).
+//! * [`WindowFunction::Lag`] / [`WindowFunction::Lead`] — `LAG`/`LEAD(?x[, n[,
+//!   default]])`: the value of a column from the row `n` positions BEFORE (`Lag`)
+//!   or AFTER (`Lead`) the current row in the window `ORDER BY` order. `n` defaults
+//!   to `1`; a source row outside the partition yields the supplied `default`
+//!   (unbound when none is given). These are POSITIONAL functions — they ignore any
+//!   [`WindowFrame`]. [OPUS-4.8] (sq-hqhc)
+//! * [`WindowFunction::Ntile`] — `NTILE(n)`: the 1-based bucket number when the
+//!   ordered partition is split into `n` near-equal buckets (the first `size % n`
+//!   buckets take one extra row). `n` must be `>= 1`. Also ignores any frame.
+//!   [OPUS-4.8] (sq-hqhc)
 //!
 //! Each appends one new bound column (`new_var`) to every row; the row order of
 //! the input `QueryResult` is preserved (window functions are computed, not a
@@ -58,8 +68,9 @@
 //!   `Range` is rejected by [`apply_window`].)
 //!
 //! Frames apply ONLY to aggregates; the ranking functions
-//! (`ROW_NUMBER`/`RANK`/`DENSE_RANK`) ignore any frame (SQL forbids a frame on
-//! them, so [`WindowSpec::frame`] is honoured only for [`WindowFunction::Aggregate`]).
+//! (`ROW_NUMBER`/`RANK`/`DENSE_RANK`) and the positional functions
+//! (`LAG`/`LEAD`/`NTILE`) ignore any frame (SQL forbids a frame on them, so
+//! [`WindowSpec::frame`] is honoured only for [`WindowFunction::Aggregate`]).
 //! A frame with no `ORDER BY` degenerates to the whole partition for `RANGE`
 //! (every row is a peer) and is still well-defined for `ROWS` (input order within
 //! the partition).
@@ -126,6 +137,19 @@ pub enum WindowFunction {
     /// A windowed aggregate over the row's FRAME within the partition (the whole
     /// partition when [`WindowSpec::frame`] is `None`), of the given column.
     Aggregate { agg: WindowAggregate, of: Variable },
+    /// `LAG(?of[, offset[, default]])` — the value of column `of` from the row
+    /// `offset` positions BEFORE the current row, in the window `ORDER BY` order.
+    /// `offset` defaults to `1`. When the source row falls outside the partition
+    /// the result is `default` (unbound when no default is given). [OPUS-4.8] (sq-hqhc)
+    Lag { of: Variable, offset: u64, default: Option<Term> },
+    /// `LEAD(?of[, offset[, default]])` — as [`Self::Lag`] but `offset` positions
+    /// AFTER the current row. [OPUS-4.8] (sq-hqhc)
+    Lead { of: Variable, offset: u64, default: Option<Term> },
+    /// `NTILE(n)` — the 1-based bucket number (`1..=n`) when the ordered partition
+    /// is split into `n` buckets as evenly as possible (earlier buckets take the
+    /// extra row when the partition size is not a multiple of `n`). `n` must be
+    /// `>= 1` (a `0` bucket count is rejected by [`apply_window`]). [OPUS-4.8] (sq-hqhc)
+    Ntile { buckets: u64 },
 }
 
 /// The unit of a window [`WindowFrame`]: physical row offsets (`ROWS`) or the
@@ -227,6 +251,16 @@ pub fn apply_window(result: &QueryResult, spec: &WindowSpec) -> Result<QueryResu
         if matches!(spec.function, WindowFunction::Aggregate { .. }) {
             validate_frame(frame)?;
         }
+    }
+    // NTILE(0) is undefined (you cannot split into zero buckets); reject up front.
+    // [OPUS-4.8] (sq-hqhc)
+    if let WindowFunction::Ntile { buckets: 0 } = spec.function {
+        return Err("window: NTILE requires a bucket count >= 1".into());
+    }
+    // The offset / positional functions read the column named by `of`, so validate
+    // it like the aggregate's `of` (a missing column is one clear error).
+    if let WindowFunction::Lag { of, .. } | WindowFunction::Lead { of, .. } = &spec.function {
+        col(of)?;
     }
 
     // Group row indices into partitions by their partition-key tuple, preserving
@@ -344,8 +378,66 @@ fn compute_partition(
                 }
             }
         }
+        // LAG / LEAD: offset the current ordered position by ±`offset`; out of the
+        // partition ⇒ the supplied default (unbound if none). The frame is ignored
+        // (SQL: an offset function takes no frame). [OPUS-4.8] (sq-hqhc)
+        WindowFunction::Lag { of, offset, default } => {
+            eval_offset(result, of, ordered, values, |pos| pos.checked_sub(*offset as i128), default);
+        }
+        WindowFunction::Lead { of, offset, default } => {
+            eval_offset(result, of, ordered, values, |pos| pos.checked_add(*offset as i128), default);
+        }
+        // NTILE(n): split the ordered partition into `n` near-equal buckets; the
+        // first `size % n` buckets get one extra row. The frame is ignored.
+        // [OPUS-4.8] (sq-hqhc)
+        WindowFunction::Ntile { buckets } => {
+            let n = *buckets;
+            // `buckets == 0` is validated away in `apply_window`; guard anyway.
+            if n == 0 {
+                return Err("window: NTILE requires a bucket count >= 1".into());
+            }
+            let total = ordered.len() as u64;
+            let base = total / n; // minimum rows per bucket
+            let extra = total % n; // first `extra` buckets get one more
+            let mut pos: u64 = 0; // 0-based ordered position consumed so far
+            for bucket in 0..n {
+                let this = base + u64::from(bucket < extra);
+                for _ in 0..this {
+                    let ri = ordered[pos as usize];
+                    values[ri] = Some(int_term((bucket + 1) as i64));
+                    pos += 1;
+                }
+            }
+        }
     }
     Ok(())
+}
+
+/// Shared LAG/LEAD body: for each ordered position `pos`, read column `of` from the
+/// row at `src(pos)` (a position-offset closure) and write it into `values` at the
+/// current row's input index; an out-of-partition source yields `default` (which may
+/// be unbound). [OPUS-4.8] (sq-hqhc)
+fn eval_offset(
+    result: &QueryResult,
+    of: &Variable,
+    ordered: &[usize],
+    values: &mut [Option<Term>],
+    src: impl Fn(i128) -> Option<i128>,
+    default: &Option<Term>,
+) {
+    let of_col = result.vars.iter().position(|c| c == of);
+    let n = ordered.len() as i128;
+    for (pos, &ri) in ordered.iter().enumerate() {
+        let value = match src(pos as i128) {
+            Some(j) if j >= 0 && j < n => {
+                let src_ri = ordered[j as usize];
+                of_col.and_then(|c| result.rows[src_ri][c].clone())
+            }
+            // Source row is outside the partition: fall back to the default.
+            _ => default.clone(),
+        };
+        values[ri] = value;
+    }
 }
 
 /// Validates a window frame for an aggregate: well-formedness (a `start` may not
@@ -856,5 +948,172 @@ mod tests {
         let out = apply_window(&seq(), &spec).unwrap();
         assert_eq!(val(&out, 0, 1), int(1).to_string());
         assert_eq!(val(&out, 3, 1), int(4).to_string());
+    }
+
+    // ---- offset / positional functions: LAG / LEAD / NTILE — sq-hqhc [OPUS-4.8] ----
+
+    /// `(?emp ?sales)` in one partition: a=10, b=20, c=30, d=40 in input order.
+    fn seq2() -> QueryResult {
+        QueryResult {
+            vars: vec![var("emp"), var("sales")],
+            rows: vec![
+                vec![Some(iri("http://ex/a")), Some(int(10))],
+                vec![Some(iri("http://ex/b")), Some(int(20))],
+                vec![Some(iri("http://ex/c")), Some(int(30))],
+                vec![Some(iri("http://ex/d")), Some(int(40))],
+            ],
+        }
+    }
+
+    #[test]
+    fn lag_default_offset_one() {
+        // LAG(?sales) over ORDER BY ?sales asc: each row sees the previous row's value;
+        // the first row's predecessor is out of partition → unbound (no default).
+        let spec = WindowSpec {
+            partition_by: vec![],
+            order_by: vec![SortKey::asc(var("sales"))],
+            function: WindowFunction::Lag { of: var("sales"), offset: 1, default: None },
+            frame: None,
+            new_var: var("prev"),
+        };
+        let out = apply_window(&seq2(), &spec).unwrap();
+        // ordered 10,20,30,40 → lag: unbound, 10, 20, 30 (mapped back to input order a,b,c,d).
+        assert!(out.rows[0][2].is_none()); // a: no predecessor
+        assert_eq!(val(&out, 1, 2), int(10).to_string()); // b sees a=10
+        assert_eq!(val(&out, 2, 2), int(20).to_string()); // c sees b=20
+        assert_eq!(val(&out, 3, 2), int(30).to_string()); // d sees c=30
+    }
+
+    #[test]
+    fn lag_with_offset_and_default() {
+        // LAG(?sales, 2, -1): two rows back, default -1 when out of partition.
+        let spec = WindowSpec {
+            partition_by: vec![],
+            order_by: vec![SortKey::asc(var("sales"))],
+            function: WindowFunction::Lag { of: var("sales"), offset: 2, default: Some(int(-1)) },
+            frame: None,
+            new_var: var("prev2"),
+        };
+        let out = apply_window(&seq2(), &spec).unwrap();
+        // ordered 10,20,30,40 → lag2: default(-1), default(-1), 10, 20.
+        assert_eq!(val(&out, 0, 2), int(-1).to_string()); // a: out → default
+        assert_eq!(val(&out, 1, 2), int(-1).to_string()); // b: out → default
+        assert_eq!(val(&out, 2, 2), int(10).to_string()); // c sees a=10
+        assert_eq!(val(&out, 3, 2), int(20).to_string()); // d sees b=20
+    }
+
+    #[test]
+    fn lead_default_offset_one() {
+        // LEAD(?sales): the NEXT row's value; the last row's successor is out → unbound.
+        let spec = WindowSpec {
+            partition_by: vec![],
+            order_by: vec![SortKey::asc(var("sales"))],
+            function: WindowFunction::Lead { of: var("sales"), offset: 1, default: None },
+            frame: None,
+            new_var: var("next"),
+        };
+        let out = apply_window(&seq2(), &spec).unwrap();
+        // ordered 10,20,30,40 → lead: 20, 30, 40, unbound.
+        assert_eq!(val(&out, 0, 2), int(20).to_string()); // a sees b=20
+        assert_eq!(val(&out, 2, 2), int(40).to_string()); // c sees d=40
+        assert!(out.rows[3][2].is_none()); // d: no successor
+    }
+
+    #[test]
+    fn ntile_even_and_uneven() {
+        // NTILE(2) over 4 rows → buckets [1,1,2,2] (even split).
+        let two = WindowSpec {
+            partition_by: vec![],
+            order_by: vec![SortKey::asc(var("sales"))],
+            function: WindowFunction::Ntile { buckets: 2 },
+            frame: None,
+            new_var: var("nt"),
+        };
+        let out = apply_window(&seq2(), &two).unwrap();
+        assert_eq!(val(&out, 0, 2), int(1).to_string()); // a
+        assert_eq!(val(&out, 1, 2), int(1).to_string()); // b
+        assert_eq!(val(&out, 2, 2), int(2).to_string()); // c
+        assert_eq!(val(&out, 3, 2), int(2).to_string()); // d
+
+        // NTILE(3) over 4 rows → the first (4 % 3 = 1) bucket gets the extra row:
+        // bucket sizes 2,1,1 → [1,1,2,3].
+        let three = WindowSpec {
+            partition_by: vec![],
+            order_by: vec![SortKey::asc(var("sales"))],
+            function: WindowFunction::Ntile { buckets: 3 },
+            frame: None,
+            new_var: var("nt3"),
+        };
+        let out3 = apply_window(&seq2(), &three).unwrap();
+        assert_eq!(val(&out3, 0, 2), int(1).to_string());
+        assert_eq!(val(&out3, 1, 2), int(1).to_string());
+        assert_eq!(val(&out3, 2, 2), int(2).to_string());
+        assert_eq!(val(&out3, 3, 2), int(3).to_string());
+    }
+
+    #[test]
+    fn ntile_more_buckets_than_rows() {
+        // NTILE(10) over 4 rows: 4 % 10 = 4 buckets of size 1, the rest empty →
+        // each row in its own bucket 1..=4.
+        let spec = WindowSpec {
+            partition_by: vec![],
+            order_by: vec![SortKey::asc(var("sales"))],
+            function: WindowFunction::Ntile { buckets: 10 },
+            frame: None,
+            new_var: var("nt"),
+        };
+        let out = apply_window(&seq2(), &spec).unwrap();
+        for (i, expect) in [1, 2, 3, 4].into_iter().enumerate() {
+            assert_eq!(val(&out, i, 2), int(expect).to_string());
+        }
+    }
+
+    #[test]
+    fn ntile_zero_is_error() {
+        let spec = WindowSpec {
+            partition_by: vec![],
+            order_by: vec![SortKey::asc(var("sales"))],
+            function: WindowFunction::Ntile { buckets: 0 },
+            frame: None,
+            new_var: var("nt"),
+        };
+        assert!(apply_window(&seq2(), &spec).is_err());
+    }
+
+    #[test]
+    fn lag_lead_respect_partitions() {
+        // LAG must not cross a partition boundary: with PARTITION BY ?dept, the first
+        // row of each dept has no predecessor.
+        let data = QueryResult {
+            vars: vec![var("dept"), var("sales")],
+            rows: vec![
+                vec![Some(iri("http://ex/eng")), Some(int(10))],
+                vec![Some(iri("http://ex/eng")), Some(int(20))],
+                vec![Some(iri("http://ex/sales")), Some(int(30))],
+            ],
+        };
+        let spec = WindowSpec {
+            partition_by: vec![var("dept")],
+            order_by: vec![SortKey::asc(var("sales"))],
+            function: WindowFunction::Lag { of: var("sales"), offset: 1, default: None },
+            frame: None,
+            new_var: var("prev"),
+        };
+        let out = apply_window(&data, &spec).unwrap();
+        assert!(out.rows[0][2].is_none()); // eng/10: first of partition
+        assert_eq!(val(&out, 1, 2), int(10).to_string()); // eng/20 sees eng/10
+        assert!(out.rows[2][2].is_none()); // sales/30: first (and only) of its partition
+    }
+
+    #[test]
+    fn lag_unknown_column_is_error() {
+        let spec = WindowSpec {
+            partition_by: vec![],
+            order_by: vec![SortKey::asc(var("sales"))],
+            function: WindowFunction::Lag { of: var("nope"), offset: 1, default: None },
+            frame: None,
+            new_var: var("prev"),
+        };
+        assert!(apply_window(&seq2(), &spec).is_err());
     }
 }

--- a/crates/sparq-engine/src/window_syntax.rs
+++ b/crates/sparq-engine/src/window_syntax.rs
@@ -26,7 +26,10 @@
 //! where `<FN>` is either a RANKING function — `ROW_NUMBER`, `RANK`, `DENSE_RANK`
 //! (case-insensitive), called with empty `()` — or a windowed AGGREGATE —
 //! `COUNT`, `SUM`, `AVG`, `MIN`, `MAX` (sq-imj8), called with a single `?var`
-//! argument. The `AS ?out` alias is required. An optional `<frame>` (sq-imj8) is
+//! argument — or an OFFSET / POSITIONAL function — `LAG`/`LEAD(?var[, n[, default]])`
+//! and `NTILE(n)` (sq-hqhc). The `OVER` operand may be an inline `( … )` spec OR a
+//! bare NAME bound by a `WINDOW` clause (sq-hqhc, see below). The `AS ?out` alias is
+//! required. An optional `<frame>` (sq-imj8) is
 //! `ROWS`/`RANGE` followed by either `BETWEEN <bound> AND <bound>` or a single
 //! `<bound>` (shorthand for `BETWEEN <bound> AND CURRENT ROW`), where a bound is
 //! `UNBOUNDED PRECEDING`, `n PRECEDING`, `CURRENT ROW`, `n FOLLOWING`, or
@@ -52,11 +55,31 @@
 //! over the whole result; an absent `ORDER BY` makes every row a peer; a frame
 //! requires an `ORDER BY`).
 //!
+//! ## Named `WINDOW` clause (sq-hqhc)
+//!
+//! A window spec can be DEFINED ONCE and REUSED across projection items via a
+//! trailing `WINDOW` clause (placed in the query tail, alongside `ORDER BY` /
+//! `LIMIT`):
+//!
+//! ```text
+//! SELECT ?emp (RANK() OVER w AS ?r) (DENSE_RANK() OVER w AS ?dr)
+//! WHERE { ?emp :dept ?dept ; :sales ?sales }
+//! WINDOW w AS (PARTITION BY ?dept ORDER BY DESC(?sales))
+//! ```
+//!
+//! Each `<name> AS ( … )` definition uses the same `( PARTITION BY … ORDER BY …
+//! [frame] )` grammar as an inline spec. SPARQL has no standard `WINDOW` clause, so
+//! this is a sparq extension scanned and stripped ONLY on `query_over` (the engine
+//! never sees it). `OVER name` with no matching definition is an error.
+//!
 //! ## Covered vs deferred
 //!
 //! * **Covered:** the ranking functions `ROW_NUMBER()`, `RANK()`, `DENSE_RANK()`
-//!   (empty `()`), AND the windowed AGGREGATES `COUNT`/`SUM`/`AVG`/`MIN`/`MAX` of a
-//!   single `?var` (sq-imj8). `PARTITION BY` over one or more variables; `ORDER BY`
+//!   (empty `()`), the windowed AGGREGATES `COUNT`/`SUM`/`AVG`/`MIN`/`MAX` of a
+//!   single `?var` (sq-imj8), AND the offset / positional functions
+//!   `LAG`/`LEAD(?var[, n[, default]])` and `NTILE(n)` (sq-hqhc). A `WINDOW <name>
+//!   AS ( … )` clause reused via `OVER name` (sq-hqhc). `PARTITION BY` over one or
+//!   more variables; `ORDER BY`
 //!   over one or more keys (ASC/DESC, both `DESC(?v)` and `?v DESC` spellings). An
 //!   `ORDER BY` key may be a **computed SPARQL expression** (sq-c1jv) — e.g.
 //!   `ORDER BY (?a + ?b)`, `DESC(?sales + 0)`, or `STRLEN(?s)` — not just a
@@ -71,12 +94,15 @@
 //! * **Deferred (beaded):** a `DISTINCT` windowed aggregate
 //!   (`COUNT(DISTINCT ?x) OVER …`), an aggregate over a computed-expression
 //!   argument (the aggregate arg must be a bare `?var`), numeric `RANGE n PRECEDING`
-//!   offsets, `LAG`/`LEAD`/`NTILE`, a named `WINDOW` clause, and `PARTITION BY` over
-//!   a computed expression (only ORDER BY keys may be expressions). Those remain
-//!   available via the programmatic [`crate::window`] API.
+//!   offsets, and `PARTITION BY` over a computed expression (only ORDER BY keys may
+//!   be expressions). A `LAG`/`LEAD` argument and default likewise must be a bare
+//!   `?var` / a constant term (not a computed expression). Those remain available
+//!   via the programmatic [`crate::window`] API.
 
 use oxrdf::Variable;
 use sparq_core::Graph;
+
+use oxrdf::Term;
 
 use crate::window::{
     apply_window, FrameBound, FrameUnit, SortKey, WindowAggregate, WindowFrame, WindowFunction,
@@ -124,12 +150,19 @@ type OverSpec = (Vec<String>, Vec<OrderKey>, Option<WindowFrame>);
 
 /// The function a window item computes: one of the three RANKING functions (an
 /// empty `FN()` call), or a windowed AGGREGATE over a column (`SUM(?x)` etc. —
-/// sq-imj8). The aggregate variant carries its argument variable name.
+/// sq-imj8), or an OFFSET / POSITIONAL function (`LAG`/`LEAD`/`NTILE` — sq-hqhc).
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum WinFunc {
     Rank(RankFunc),
     /// A windowed aggregate `AGG(?of)`; the `?of` argument is a bare variable name.
     Agg { agg: AggFunc, of: String },
+    /// `LAG(?of[, n[, default]])` / `LEAD(…)` — the `?of` argument is a bare
+    /// variable name, `offset` defaults to `1`, `default` is an optional constant
+    /// RDF term (an unbound result when out of partition and no default is given).
+    /// sq-hqhc.
+    Offset { lead: bool, of: String, offset: u64, default: Option<Term> },
+    /// `NTILE(n)` — split the ordered partition into `n` near-equal buckets. sq-hqhc.
+    Ntile { buckets: u64 },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -219,6 +252,13 @@ pub fn query_over_with_budget(
             WinFunc::Agg { agg, of } => {
                 WindowFunction::Aggregate { agg: agg.to_window_aggregate(), of: var(of)? }
             }
+            WinFunc::Offset { lead: false, of, offset, default } => {
+                WindowFunction::Lag { of: var(of)?, offset: *offset, default: default.clone() }
+            }
+            WinFunc::Offset { lead: true, of, offset, default } => {
+                WindowFunction::Lead { of: var(of)?, offset: *offset, default: default.clone() }
+            }
+            WinFunc::Ntile { buckets } => WindowFunction::Ntile { buckets: *buckets },
         };
         let spec = WindowSpec {
             partition_by: item.partition_by.iter().map(|v| var(v)).collect::<Result<_, _>>()?,
@@ -306,6 +346,12 @@ fn extract_windows(sparql: &str) -> Result<Option<RewritePlan>, String> {
     let projection = &sparql[proj_start..proj_end];
     let items = split_projection_items(projection)?;
 
+    // A named WINDOW clause (sq-hqhc) lives in the query TAIL (after the WHERE block,
+    // alongside GROUP BY / ORDER BY / LIMIT, etc.): `WINDOW w AS ( … )[, x AS ( … )]`.
+    // Extract + strip it so the engine never sees it, and resolve `OVER w` against it.
+    let tail = &sparql[proj_end..];
+    let (tail_no_window, named_windows) = extract_window_clause(tail)?;
+
     let mut windows = Vec::new();
     let mut output_vars = Vec::new();
     let mut helper_vars: Vec<String> = Vec::new();
@@ -324,7 +370,7 @@ fn extract_windows(sparql: &str) -> Result<Option<RewritePlan>, String> {
             select_star = true;
             continue;
         }
-        if let Some(mut win) = parse_window_item(t)? {
+        if let Some(mut win) = parse_window_item(t, &named_windows)? {
             // PARTITION BY vars must survive the inner SELECT so the post-pass can
             // read them; project them through.
             for v in &win.partition_by {
@@ -332,9 +378,10 @@ fn extract_windows(sparql: &str) -> Result<Option<RewritePlan>, String> {
                     helper_vars.push(v.clone());
                 }
             }
-            // A windowed aggregate's argument variable (`SUM(?of)`) must also
-            // survive the inner SELECT so the post-pass can read it. sq-imj8.
-            if let WinFunc::Agg { of, .. } = &win.func {
+            // A windowed aggregate's argument variable (`SUM(?of)`) — and an offset
+            // function's `?of` (`LAG`/`LEAD`) — must also survive the inner SELECT so
+            // the post-pass can read it. sq-imj8 / sq-hqhc.
+            if let WinFunc::Agg { of, .. } | WinFunc::Offset { of, .. } = &win.func {
                 if !helper_vars.contains(of) {
                     helper_vars.push(of.clone());
                 }
@@ -371,6 +418,9 @@ fn extract_windows(sparql: &str) -> Result<Option<RewritePlan>, String> {
     if windows.is_empty() {
         // `OVER` appeared as a token but not as a window clause we recognise
         // (e.g. a variable or IRI containing the letters). Leave the query alone.
+        // (A WINDOW clause with no `OVER w` user is harmless but pointless; we still
+        // bail to the unmodified engine, which will reject the non-standard WINDOW —
+        // honest: a stray WINDOW clause is only meaningful with an `OVER w` reference.)
         return Ok(None);
     }
 
@@ -395,7 +445,9 @@ fn extract_windows(sparql: &str) -> Result<Option<RewritePlan>, String> {
     }
 
     let inner = inner_proj.join(" ");
-    let rewritten = format!("{} {} {}", &sparql[..proj_start], inner, &sparql[proj_end..]);
+    // Build the rewritten query with the (WINDOW-clause-stripped) tail so the engine
+    // never sees the non-standard WINDOW clause.
+    let rewritten = format!("{} {} {}", &sparql[..proj_start], inner, tail_no_window);
     // `select_star` ⇒ keep all produced columns (no explicit reprojection), which
     // also matches `SELECT *` semantics (the window column is appended).
     let output_vars = if select_star { Vec::new() } else { output_vars };
@@ -405,8 +457,10 @@ fn extract_windows(sparql: &str) -> Result<Option<RewritePlan>, String> {
 }
 
 /// Parses one trimmed projection item as a window expression, or `Ok(None)` if it
-/// is not a window item. A `(… OVER …)` shape that fails to parse is an `Err`.
-fn parse_window_item(item: &str) -> Result<Option<WindowItem>, String> {
+/// is not a window item. A `(… OVER …)` shape that fails to parse is an `Err`. The
+/// `OVER` operand may be an inline `( … )` spec OR a bare NAME referring to a
+/// definition in the `named` WINDOW clause (sq-hqhc).
+fn parse_window_item(item: &str, named: &NamedWindows) -> Result<Option<WindowItem>, String> {
     // A window item is parenthesised: `( FN() OVER ( … ) AS ?out )`.
     let inner = match strip_outer_parens(item) {
         Some(i) => i,
@@ -424,15 +478,23 @@ fn parse_window_item(item: &str) -> Result<Option<WindowItem>, String> {
     // function takes empty `()`; a windowed AGGREGATE takes a single `?var`. sq-imj8.
     let func = parse_window_func(head)?;
 
-    // rest := ( PARTITION BY … ORDER BY … [frame] ) AS ?out — split the balanced
-    // `( … )` spec from its trailing `AS ?out` alias.
-    let (spec_body, alias) = split_spec_and_alias(rest.trim())?;
-    let (partition_by, order_by, frame) = parse_over_spec(&spec_body)?;
-    // A frame is only meaningful on an aggregate; reject it on a ranking function so
-    // a typo is a clear error rather than silently ignored.
-    if frame.is_some() && matches!(func, WinFunc::Rank(_)) {
+    // rest := <over-operand> AS ?out, where <over-operand> is either an inline
+    // `( PARTITION BY … ORDER BY … [frame] )` spec, or a bare NAME bound by the
+    // query's WINDOW clause (sq-hqhc). Split off the trailing `AS ?out` alias.
+    let (spec_source, alias) = split_over_operand_and_alias(rest.trim())?;
+    let (partition_by, order_by, frame) = match spec_source {
+        OverOperand::Inline(spec_body) => parse_over_spec(&spec_body)?,
+        OverOperand::Named(name) => named
+            .iter()
+            .find(|(n, _)| *n == name)
+            .map(|(_, spec)| spec.clone())
+            .ok_or_else(|| format!("inline OVER: window name {name:?} is not defined by any WINDOW clause"))?,
+    };
+    // A frame is only meaningful on an aggregate; reject it on a ranking or offset
+    // function so a typo is a clear error rather than silently ignored.
+    if frame.is_some() && !matches!(func, WinFunc::Agg { .. }) {
         return Err(
-            "inline OVER: a window frame (ROWS/RANGE) is only valid on a windowed aggregate, not a ranking function".into(),
+            "inline OVER: a window frame (ROWS/RANGE) is only valid on a windowed aggregate, not a ranking or offset (LAG/LEAD/NTILE) function".into(),
         );
     }
     Ok(Some(WindowItem { func, partition_by, order_by, frame, out: alias }))
@@ -472,22 +534,151 @@ fn parse_window_func(head: &str) -> Result<WinFunc, String> {
         })?;
         return Ok(WinFunc::Agg { agg, of });
     }
+    // Offset functions: LAG / LEAD ( ?var [, n [, default]] ). sq-hqhc.
+    let fup = fname.to_ascii_uppercase();
+    if fup == "LAG" || fup == "LEAD" {
+        return parse_offset_func(fname, fup == "LEAD", args);
+    }
+    // NTILE ( n ): a single positive-integer bucket count. sq-hqhc.
+    if fup == "NTILE" {
+        let arg_inner = strip_outer_parens(args)
+            .ok_or("inline OVER: NTILE needs a parenthesised bucket count '( n )'")?;
+        let n: u64 = arg_inner.trim().parse().map_err(|_| {
+            format!("inline OVER: NTILE takes a single positive-integer bucket count, got {arg_inner:?}")
+        })?;
+        if n == 0 {
+            return Err("inline OVER: NTILE bucket count must be >= 1".into());
+        }
+        return Ok(WinFunc::Ntile { buckets: n });
+    }
     Err(format!(
-        "inline OVER: unsupported window function {fname:?} (ranking: ROW_NUMBER, RANK, DENSE_RANK; aggregates: COUNT, SUM, AVG, MIN, MAX)"
+        "inline OVER: unsupported window function {fname:?} (ranking: ROW_NUMBER, RANK, DENSE_RANK; aggregates: COUNT, SUM, AVG, MIN, MAX; offset: LAG, LEAD, NTILE)"
     ))
 }
 
-/// Splits `( spec ) AS ?out` into (`spec`, `out`). Requires the `AS ?out` alias.
-fn split_spec_and_alias(s: &str) -> Result<(String, String), String> {
-    let s = s.trim();
-    if !s.starts_with('(') {
-        return Err("inline OVER: expected `( … )` after OVER".into());
+/// Parses a `LAG`/`LEAD ( ?var [, n [, default]] )` argument list. The first arg is
+/// a bare `?var`; an optional second arg is a non-negative integer offset (default
+/// `1`); an optional third arg is a constant RDF term used when the source row falls
+/// outside the partition. sq-hqhc. [OPUS-4.8]
+fn parse_offset_func(fname: &str, lead: bool, args: &str) -> Result<WinFunc, String> {
+    let arg_inner = strip_outer_parens(args)
+        .ok_or_else(|| format!("inline OVER: {fname} needs a parenthesised argument list '( ?var[, n[, default]] )'"))?;
+    let pieces: Vec<String> =
+        split_top_level_commas(arg_inner).into_iter().map(|s| s.trim().to_string()).collect();
+    if pieces.is_empty() || pieces[0].is_empty() {
+        return Err(format!("inline OVER: {fname} needs a ?var first argument (got '()')"));
     }
-    // Find the matching close paren for the opening one.
-    let close = matching_paren(s, 0)
-        .ok_or("inline OVER: unbalanced parentheses in OVER ( … )")?;
-    let spec = s[1..close].to_string();
-    let tail = s[close + 1..].trim();
+    if pieces.len() > 3 {
+        return Err(format!("inline OVER: {fname} takes at most 3 args (?var, offset, default), got {}", pieces.len()));
+    }
+    let of = parse_single_var(&pieces[0]).map_err(|_| {
+        format!("inline OVER: {fname}'s first argument must be a single ?var (an expression argument is not supported inline); got {:?}", pieces[0])
+    })?;
+    let offset: u64 = match pieces.get(1) {
+        None => 1,
+        Some(s) => s.parse().map_err(|_| {
+            format!("inline OVER: {fname}'s offset (2nd arg) must be a non-negative integer, got {s:?}")
+        })?,
+    };
+    let default: Option<Term> = match pieces.get(2) {
+        None => None,
+        Some(s) => Some(parse_constant_term(s).map_err(|e| {
+            format!("inline OVER: {fname}'s default (3rd arg) must be a constant RDF term ({e}); got {s:?}")
+        })?),
+    };
+    Ok(WinFunc::Offset { lead, of, offset, default })
+}
+
+/// Parses a constant RDF term literal as it appears in an `OVER(…)` argument: an
+/// integer/decimal/double numeric literal, a `"…"`-quoted string literal (optionally
+/// with a `@lang` or `^^<datatype>`), `true`/`false`, or an `<IRI>`. Used for a
+/// `LAG`/`LEAD` default value. sq-hqhc. [OPUS-4.8]
+fn parse_constant_term(s: &str) -> Result<Term, String> {
+    use oxrdf::{Literal, NamedNode};
+    let s = s.trim();
+    if s.is_empty() {
+        return Err("empty term".into());
+    }
+    // <IRI>
+    if let Some(rest) = s.strip_prefix('<') {
+        let iri = rest.strip_suffix('>').ok_or("unterminated <IRI>")?;
+        let nn = NamedNode::new(iri).map_err(|e| format!("invalid IRI: {e}"))?;
+        return Ok(Term::NamedNode(nn));
+    }
+    // Boolean keywords.
+    match s {
+        "true" => return Ok(Term::Literal(Literal::from(true))),
+        "false" => return Ok(Term::Literal(Literal::from(false))),
+        _ => {}
+    }
+    // A quoted string literal, optionally with @lang or ^^<datatype>.
+    if let Some(after_open) = s.strip_prefix('"') {
+        // Find the closing quote (no escape handling beyond the simple form — a
+        // default value is a constant, not arbitrary user text).
+        let close = after_open.find('"').ok_or("unterminated string literal")?;
+        let value = &after_open[..close];
+        let tail = after_open[close + 1..].trim();
+        if tail.is_empty() {
+            return Ok(Term::Literal(Literal::new_simple_literal(value)));
+        }
+        if let Some(lang) = tail.strip_prefix('@') {
+            return Literal::new_language_tagged_literal(value, lang)
+                .map(Term::Literal)
+                .map_err(|e| format!("invalid language tag: {e}"));
+        }
+        if let Some(dt) = tail.strip_prefix("^^") {
+            let dt = dt.trim();
+            let iri = dt.strip_prefix('<').and_then(|r| r.strip_suffix('>')).ok_or("datatype must be an <IRI>")?;
+            let nn = NamedNode::new(iri).map_err(|e| format!("invalid datatype IRI: {e}"))?;
+            return Ok(Term::Literal(Literal::new_typed_literal(value, nn)));
+        }
+        return Err("trailing text after string literal".into());
+    }
+    // Bare numeric literal (integer / decimal / double).
+    if let Ok(i) = s.parse::<i64>() {
+        return Ok(Term::Literal(Literal::from(i)));
+    }
+    if s.parse::<f64>().is_ok() {
+        let dt = if s.contains(['e', 'E']) {
+            "http://www.w3.org/2001/XMLSchema#double"
+        } else {
+            "http://www.w3.org/2001/XMLSchema#decimal"
+        };
+        return Ok(Term::Literal(Literal::new_typed_literal(s, NamedNode::new_unchecked(dt))));
+    }
+    Err("not a recognised constant (numeric, \"string\"[@lang|^^<dt>], true/false, or <IRI>)".into())
+}
+
+/// The operand of an `OVER`: either an INLINE `( … )` spec body, or a NAMED window
+/// (`OVER w`) defined by a WINDOW clause. sq-hqhc.
+enum OverOperand {
+    /// The interior of an inline `OVER ( … )` spec.
+    Inline(String),
+    /// A bare window NAME referring to a `WINDOW <name> AS ( … )` definition.
+    Named(String),
+}
+
+/// Splits `<operand> AS ?out` into (`operand`, `out`), where `<operand>` is either
+/// an inline `( spec )` or a bare window NAME. Requires the `AS ?out` alias. sq-hqhc.
+fn split_over_operand_and_alias(s: &str) -> Result<(OverOperand, String), String> {
+    let s = s.trim();
+    let (operand, tail) = if s.starts_with('(') {
+        // Inline `( spec )`: split off the balanced spec then the trailing alias.
+        let close = matching_paren(s, 0)
+            .ok_or("inline OVER: unbalanced parentheses in OVER ( … )")?;
+        (OverOperand::Inline(s[1..close].to_string()), s[close + 1..].trim())
+    } else {
+        // Bare window NAME: the name runs up to the first whitespace; the rest is the
+        // `AS ?out` alias.
+        let name_end = s.find(char::is_whitespace).unwrap_or(s.len());
+        let name = &s[..name_end];
+        if name.is_empty() || !name.chars().all(is_varname_char) {
+            return Err(format!(
+                "inline OVER: expected `( … )` or a WINDOW name after OVER, got {s:?}"
+            ));
+        }
+        (OverOperand::Named(name.to_string()), s[name_end..].trim())
+    };
     // tail := AS ?out
     let tail_up = tail.to_ascii_uppercase();
     if !tail_up.starts_with("AS") {
@@ -502,7 +693,121 @@ fn split_spec_and_alias(s: &str) -> Result<(String, String), String> {
     if out.is_empty() || !out.chars().all(is_varname_char) {
         return Err(format!("inline OVER: invalid output variable {after_as:?} after AS"));
     }
-    Ok((spec, out.to_string()))
+    Ok((operand, out.to_string()))
+}
+
+/// A parsed set of named window definitions from a `WINDOW` clause (sq-hqhc), in
+/// source order: `(name, spec)` pairs a `FN() OVER name` item resolves against.
+type NamedWindows = Vec<(String, OverSpec)>;
+
+/// Extracts a `WINDOW <name> AS ( … )[, <name> AS ( … )]*` clause from the query
+/// TAIL (the text after the SELECT projection — the WHERE block and the solution
+/// modifiers). Returns the tail WITH the WINDOW clause REMOVED (so the engine never
+/// sees it) plus the parsed definitions. With no WINDOW clause the tail is returned
+/// unchanged and the definition list is empty. sq-hqhc. [OPUS-4.8]
+///
+/// The clause is located at top level (depth 0 — outside the WHERE `{ … }` group and
+/// any parentheses), and runs to the next top-level solution-modifier keyword
+/// (`GROUP`/`HAVING`/`ORDER`/`LIMIT`/`OFFSET`/`VALUES`) or end of query, whichever is
+/// first. SPARQL has no standard WINDOW clause, so this is a sparq extension scanned
+/// only on the `query_over` entry point.
+fn extract_window_clause(tail: &str) -> Result<(String, NamedWindows), String> {
+    let Some(kw) = find_top_level_keyword(tail, "WINDOW") else {
+        return Ok((tail.to_string(), Vec::new()));
+    };
+    // The clause body runs from after `WINDOW` to the next top-level modifier.
+    let body_start = kw + "WINDOW".len();
+    let mut clause_end = tail.len();
+    for modifier in ["GROUP", "HAVING", "ORDER", "LIMIT", "OFFSET", "VALUES"] {
+        if let Some(rel) = find_top_level_keyword(&tail[body_start..], modifier) {
+            clause_end = clause_end.min(body_start + rel);
+        }
+    }
+    let body = tail[body_start..clause_end].trim();
+    let named = parse_window_definitions(body)?;
+    // Splice the clause out of the tail.
+    let mut tail_no_window = String::with_capacity(tail.len());
+    tail_no_window.push_str(&tail[..kw]);
+    tail_no_window.push(' ');
+    tail_no_window.push_str(&tail[clause_end..]);
+    Ok((tail_no_window, named))
+}
+
+/// Parses the body of a WINDOW clause — `<name> AS ( … )[, <name> AS ( … )]*` — into
+/// `(name, spec)` definitions. Each `( … )` spec follows the same grammar as an
+/// inline `OVER ( … )` operand (`PARTITION BY` / `ORDER BY` / frame). sq-hqhc.
+fn parse_window_definitions(body: &str) -> Result<NamedWindows, String> {
+    let mut out: NamedWindows = Vec::new();
+    for def in split_top_level_commas(body) {
+        let def = def.trim();
+        if def.is_empty() {
+            continue;
+        }
+        // `<name> AS ( … )`.
+        let as_pos = find_keyword(def, "AS")
+            .ok_or_else(|| format!("inline OVER: WINDOW definition must be `<name> AS ( … )`, got {def:?}"))?;
+        let name = def[..as_pos].trim();
+        if name.is_empty() || !name.chars().all(is_varname_char) {
+            return Err(format!("inline OVER: invalid WINDOW name {name:?}"));
+        }
+        if out.iter().any(|(n, _)| n == name) {
+            return Err(format!("inline OVER: WINDOW name {name:?} is defined more than once"));
+        }
+        let after = def[as_pos + 2..].trim();
+        let spec_body = strip_outer_parens(after)
+            .ok_or_else(|| format!("inline OVER: WINDOW {name} definition needs a parenthesised `( … )` spec, got {after:?}"))?;
+        let spec = parse_over_spec(spec_body)?;
+        out.push((name.to_string(), spec));
+    }
+    if out.is_empty() {
+        return Err("inline OVER: empty WINDOW clause (expected `<name> AS ( … )`)".into());
+    }
+    Ok(out)
+}
+
+/// The byte offset of the first whole-word, case-insensitive occurrence of `kw` in
+/// `s` at TOP LEVEL — outside any `{ … }` group, `( … )`, or `<IRI>` / `"string"`.
+/// Used to locate a WINDOW clause and the solution modifiers around it without
+/// tripping on the same letters inside the WHERE block or an inline spec. sq-hqhc.
+fn find_top_level_keyword(s: &str, kw: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let su = s.to_ascii_uppercase();
+    let ku = kw.to_ascii_uppercase();
+    let kb = ku.as_bytes();
+    let mut brace: i32 = 0;
+    let mut paren: i32 = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'{' => brace += 1,
+            b'}' => brace -= 1,
+            b'(' => paren += 1,
+            b')' => paren -= 1,
+            b'<' => {
+                // Skip an IRI ref so its interior is ignored.
+                if let Some(rel) = s[i..].find('>') {
+                    i += rel;
+                }
+            }
+            b'"' => {
+                // Skip a string literal.
+                if let Some(rel) = s[i + 1..].find('"') {
+                    i += rel + 1;
+                }
+            }
+            _ if brace == 0 && paren == 0 && su[i..].starts_with(&ku) => {
+                let before_ok = i == 0 || !is_ident_byte(bytes[i - 1]);
+                let after = i + kb.len();
+                let after_ok = after >= bytes.len() || !is_ident_byte(bytes[after]);
+                if before_ok && after_ok {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
 }
 
 /// Parses the body of an `OVER ( … )` spec into (partition vars, order keys, frame).
@@ -1015,10 +1320,14 @@ mod tests {
     fn expr_key(expr: &str, descending: bool) -> OrderKey {
         OrderKey { sort: Sort::Expr(expr.to_string()), descending }
     }
+    /// `parse_window_item` with no named WINDOW definitions (the common unit-test case).
+    fn pwi(item: &str) -> Result<Option<WindowItem>, String> {
+        parse_window_item(item, &Vec::new())
+    }
 
     #[test]
     fn parses_row_number_item() {
-        let w = parse_window_item("(ROW_NUMBER() OVER (PARTITION BY ?dept ORDER BY DESC(?sales)) AS ?rn)")
+        let w = pwi("(ROW_NUMBER() OVER (PARTITION BY ?dept ORDER BY DESC(?sales)) AS ?rn)")
             .unwrap()
             .unwrap();
         assert_eq!(w.func, WinFunc::Rank(RankFunc::RowNumber));
@@ -1029,7 +1338,7 @@ mod tests {
 
     #[test]
     fn parses_trailing_keyword_order_form() {
-        let w = parse_window_item("(RANK() OVER (PARTITION BY ?dept ORDER BY ?sales DESC) AS ?r)")
+        let w = pwi("(RANK() OVER (PARTITION BY ?dept ORDER BY ?sales DESC) AS ?r)")
             .unwrap()
             .unwrap();
         assert_eq!(w.func, WinFunc::Rank(RankFunc::Rank));
@@ -1040,25 +1349,25 @@ mod tests {
     fn parses_computed_expression_order_key() {
         // sq-c1jv: a parenthesised computed expression as an ORDER BY key. The
         // redundant outer parens are stripped; the key is an Expr (ascending).
-        let w = parse_window_item("(ROW_NUMBER() OVER (ORDER BY (?a + ?b)) AS ?rn)")
+        let w = pwi("(ROW_NUMBER() OVER (ORDER BY (?a + ?b)) AS ?rn)")
             .unwrap()
             .unwrap();
         assert_eq!(w.order_by, vec![expr_key("?a + ?b", false)]);
 
         // `DESC( <expr> )` → an Expr key, descending.
-        let d = parse_window_item("(RANK() OVER (ORDER BY DESC(?sales + 0)) AS ?r)")
+        let d = pwi("(RANK() OVER (ORDER BY DESC(?sales + 0)) AS ?r)")
             .unwrap()
             .unwrap();
         assert_eq!(d.order_by, vec![expr_key("?sales + 0", true)]);
 
         // Trailing-keyword form on a parenthesised expression: `(?a * 2) DESC`.
-        let t = parse_window_item("(RANK() OVER (ORDER BY (?a * 2) DESC) AS ?r)")
+        let t = pwi("(RANK() OVER (ORDER BY (?a * 2) DESC) AS ?r)")
             .unwrap()
             .unwrap();
         assert_eq!(t.order_by, vec![expr_key("?a * 2", true)]);
 
         // A function-call expression key (not a direction keyword): `STRLEN(?s)`.
-        let f = parse_window_item("(ROW_NUMBER() OVER (ORDER BY STRLEN(?s)) AS ?rn)")
+        let f = pwi("(ROW_NUMBER() OVER (ORDER BY STRLEN(?s)) AS ?rn)")
             .unwrap()
             .unwrap();
         assert_eq!(f.order_by, vec![expr_key("STRLEN(?s)", false)]);
@@ -1067,12 +1376,12 @@ mod tests {
     #[test]
     fn direction_keyword_detection_edge_cases() {
         // A variable literally NAMED `desc` is a plain var key, not a direction.
-        let w = parse_window_item("(ROW_NUMBER() OVER (ORDER BY ?desc) AS ?rn)")
+        let w = pwi("(ROW_NUMBER() OVER (ORDER BY ?desc) AS ?rn)")
             .unwrap()
             .unwrap();
         assert_eq!(w.order_by, vec![var_key("desc", false)]);
         // A function call ending in `)` is an expression key, not a trailing keyword.
-        let f = parse_window_item("(RANK() OVER (ORDER BY STRLEN(?desc)) AS ?r)")
+        let f = pwi("(RANK() OVER (ORDER BY STRLEN(?desc)) AS ?r)")
             .unwrap()
             .unwrap();
         assert_eq!(f.order_by, vec![expr_key("STRLEN(?desc)", false)]);
@@ -1081,11 +1390,9 @@ mod tests {
     #[test]
     fn mixed_var_and_expression_order_keys() {
         // A var key and an expr key in one ORDER BY list, with directions.
-        let w = parse_window_item(
-            "(RANK() OVER (ORDER BY ?dept, DESC(?a + ?b)) AS ?r)",
-        )
-        .unwrap()
-        .unwrap();
+        let w = pwi("(RANK() OVER (ORDER BY ?dept, DESC(?a + ?b)) AS ?r)")
+            .unwrap()
+            .unwrap();
         assert_eq!(w.order_by, vec![var_key("dept", false), expr_key("?a + ?b", true)]);
     }
 
@@ -1114,7 +1421,7 @@ mod tests {
     fn parses_windowed_aggregate_item() {
         // sq-imj8: a windowed aggregate `SUM(?sales) OVER (PARTITION BY ?dept)` now
         // parses to a WinFunc::Agg carrying the argument variable.
-        let w = parse_window_item("(SUM(?sales) OVER (PARTITION BY ?dept) AS ?t)").unwrap().unwrap();
+        let w = pwi("(SUM(?sales) OVER (PARTITION BY ?dept) AS ?t)").unwrap().unwrap();
         assert_eq!(w.func, WinFunc::Agg { agg: AggFunc::Sum, of: "sales".to_string() });
         assert_eq!(w.partition_by, vec!["dept".to_string()]);
         assert!(w.frame.is_none());
@@ -1125,7 +1432,7 @@ mod tests {
             ("(MIN(?s) OVER () AS ?m)", AggFunc::Min),
             ("(MAX(?s) OVER () AS ?x)", AggFunc::Max),
         ] {
-            let w = parse_window_item(src).unwrap().unwrap();
+            let w = pwi(src).unwrap().unwrap();
             assert_eq!(w.func, WinFunc::Agg { agg, of: "s".to_string() });
         }
     }
@@ -1133,21 +1440,101 @@ mod tests {
     #[test]
     fn rejects_ranking_function_with_args() {
         // A ranking function called WITH args is rejected (it takes empty `()`).
-        let e = parse_window_item("(RANK(?sales) OVER (PARTITION BY ?dept) AS ?t)").unwrap_err();
+        let e = pwi("(RANK(?sales) OVER (PARTITION BY ?dept) AS ?t)").unwrap_err();
         assert!(e.contains("empty args") && e.contains("RANK"), "{e}");
     }
 
     #[test]
     fn rejects_distinct_windowed_aggregate() {
         // A DISTINCT windowed aggregate is not supported inline (programmatic only).
-        let e = parse_window_item("(COUNT(DISTINCT ?s) OVER () AS ?c)").unwrap_err();
+        let e = pwi("(COUNT(DISTINCT ?s) OVER () AS ?c)").unwrap_err();
         assert!(e.contains("DISTINCT"), "{e}");
     }
 
     #[test]
     fn rejects_unknown_window_function() {
-        let e = parse_window_item("(NTILE() OVER (ORDER BY ?x) AS ?n)").unwrap_err();
+        let e = pwi("(BOGUS() OVER (ORDER BY ?x) AS ?n)").unwrap_err();
         assert!(e.contains("unsupported window function"), "{e}");
+    }
+
+    // ---- offset / positional functions inline (LAG / LEAD / NTILE) — sq-hqhc ----
+
+    #[test]
+    fn parses_lag_lead_ntile_items() {
+        // LAG(?x): default offset 1, no default value.
+        let lag = pwi("(LAG(?sales) OVER (ORDER BY ?sales) AS ?prev)").unwrap().unwrap();
+        assert_eq!(lag.func, WinFunc::Offset { lead: false, of: "sales".into(), offset: 1, default: None });
+        // LEAD(?x, 2): explicit offset, no default.
+        let lead = pwi("(LEAD(?sales, 2) OVER (ORDER BY ?sales) AS ?n)").unwrap().unwrap();
+        assert_eq!(lead.func, WinFunc::Offset { lead: true, of: "sales".into(), offset: 2, default: None });
+        // LAG(?x, 1, 0): a constant integer default.
+        let dflt = pwi("(LAG(?sales, 1, 0) OVER (ORDER BY ?sales) AS ?p)").unwrap().unwrap();
+        assert_eq!(
+            dflt.func,
+            WinFunc::Offset { lead: false, of: "sales".into(), offset: 1, default: Some(Term::Literal(oxrdf::Literal::from(0))) }
+        );
+        // NTILE(4): a bucket count.
+        let nt = pwi("(NTILE(4) OVER (ORDER BY ?sales) AS ?q)").unwrap().unwrap();
+        assert_eq!(nt.func, WinFunc::Ntile { buckets: 4 });
+    }
+
+    #[test]
+    fn rejects_bad_offset_and_ntile_args() {
+        // LAG with no variable.
+        assert!(pwi("(LAG() OVER (ORDER BY ?x) AS ?p)").is_err());
+        // NTILE needs a positive integer.
+        assert!(pwi("(NTILE() OVER (ORDER BY ?x) AS ?q)").is_err());
+        assert!(pwi("(NTILE(0) OVER (ORDER BY ?x) AS ?q)").is_err());
+        assert!(pwi("(NTILE(?x) OVER (ORDER BY ?x) AS ?q)").is_err());
+        // A frame on an offset function is rejected (only valid on an aggregate).
+        assert!(pwi("(LAG(?x) OVER (ORDER BY ?x ROWS 1 PRECEDING) AS ?p)").is_err());
+    }
+
+    #[test]
+    fn parses_lag_string_iri_defaults() {
+        // A quoted-string default.
+        let s = pwi("(LAG(?n, 1, \"none\") OVER (ORDER BY ?n) AS ?p)").unwrap().unwrap();
+        match s.func {
+            WinFunc::Offset { default: Some(Term::Literal(l)), .. } => assert_eq!(l.value(), "none"),
+            other => panic!("{other:?}"),
+        }
+        // An <IRI> default.
+        let i = pwi("(LEAD(?n, 1, <http://ex/x>) OVER (ORDER BY ?n) AS ?p)").unwrap().unwrap();
+        match i.func {
+            WinFunc::Offset { default: Some(Term::NamedNode(n)), .. } => assert_eq!(n.as_str(), "http://ex/x"),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    // ---- named WINDOW clause (sq-hqhc) ----
+
+    #[test]
+    fn named_window_clause_extracted_and_resolved() {
+        // A WINDOW w AS (…) clause defines a reusable spec; `OVER w` resolves to it.
+        let (tail_no_window, named) = extract_window_clause(
+            "WHERE { ?s ?p ?o } WINDOW w AS (PARTITION BY ?dept ORDER BY DESC(?sales)) ORDER BY ?s",
+        )
+        .unwrap();
+        // The WINDOW clause is stripped from the tail the engine sees.
+        assert!(!tail_no_window.to_ascii_uppercase().contains("WINDOW"), "{tail_no_window}");
+        assert!(tail_no_window.contains("ORDER BY ?s"), "ORDER BY kept: {tail_no_window}");
+        assert_eq!(named.len(), 1);
+        assert_eq!(named[0].0, "w");
+        assert_eq!(named[0].1 .0, vec!["dept".to_string()]); // partition_by
+        assert_eq!(named[0].1 .1, vec![var_key("sales", true)]); // order_by
+
+        // `RANK() OVER w` resolves the named window.
+        let w = parse_window_item("(RANK() OVER w AS ?r)", &named).unwrap().unwrap();
+        assert_eq!(w.func, WinFunc::Rank(RankFunc::Rank));
+        assert_eq!(w.partition_by, vec!["dept".to_string()]);
+        assert_eq!(w.order_by, vec![var_key("sales", true)]);
+    }
+
+    #[test]
+    fn over_unknown_window_name_is_error() {
+        // `OVER w` with no matching WINDOW definition is an error.
+        let e = parse_window_item("(RANK() OVER w AS ?r)", &Vec::new()).unwrap_err();
+        assert!(e.contains("not defined"), "{e}");
     }
 
     // ---- end-to-end parse + eval ----

--- a/crates/sparq-engine/tests/window_inline_over.rs
+++ b/crates/sparq-engine/tests/window_inline_over.rs
@@ -223,3 +223,124 @@ fn inline_frame_on_ranking_function_is_rejected() {
         WHERE { ?emp ex:sales ?sales }";
     assert!(query_over(&g(), q).is_err());
 }
+
+// ---- offset / positional functions inline (LAG / LEAD / NTILE) — sq-hqhc [OPUS-4.8] ----
+
+/// Find the value in `col` for the row whose `emp` is `emp`, allowing an unbound cell.
+fn opt_for_emp(r: &QueryResult, emp: &str, col: usize) -> Option<i64> {
+    for row in &r.rows {
+        if name(&row[0]) == emp {
+            return row[col].as_ref().map(|t| match t {
+                Term::Literal(l) => l.value().parse().expect("integer literal"),
+                other => panic!("expected integer, got {other:?}"),
+            });
+        }
+    }
+    panic!("emp {emp} not found");
+}
+
+#[test]
+fn inline_lag_previous_sales() {
+    // LAG(?sales) OVER (ORDER BY ?sales): each row sees the previous-by-sales value.
+    // ordered: d=10, c=20, a=30, b=30, e=40.
+    let q = "PREFIX ex: <http://ex/> \
+        SELECT ?emp ?sales (LAG(?sales) OVER (ORDER BY ?sales) AS ?prev) \
+        WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }";
+    let r = query_over(&g(), q).unwrap();
+    assert_eq!(r.vars.iter().map(|v| v.as_str()).collect::<Vec<_>>(), ["emp", "sales", "prev"]);
+    // d is the smallest → no predecessor (unbound). c sees d=10. e sees the previous
+    // 30 (a or b — both are 30). The first-in-order row's lag is unbound.
+    assert_eq!(opt_for_emp(&r, "d", 2), None);
+    assert_eq!(opt_for_emp(&r, "c", 2), Some(10));
+    assert_eq!(opt_for_emp(&r, "e", 2), Some(30));
+}
+
+#[test]
+fn inline_lag_with_offset_and_default() {
+    // LAG(?sales, 2, 0): two rows back, default 0 when out of partition.
+    let q = "PREFIX ex: <http://ex/> \
+        SELECT ?emp ?sales (LAG(?sales, 2, 0) OVER (ORDER BY ?sales) AS ?prev2) \
+        WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }";
+    let r = query_over(&g(), q).unwrap();
+    // ordered d=10, c=20, a=30, b=30, e=40. The first two (d,c) have no 2-back row → 0.
+    assert_eq!(opt_for_emp(&r, "d", 2), Some(0));
+    assert_eq!(opt_for_emp(&r, "c", 2), Some(0));
+    // a (3rd) sees d=10; e (5th) sees a/b=30.
+    assert_eq!(opt_for_emp(&r, "a", 2), Some(10));
+    assert_eq!(opt_for_emp(&r, "e", 2), Some(30));
+}
+
+#[test]
+fn inline_lead_next_sales() {
+    // LEAD(?sales) OVER (ORDER BY ?sales): each row sees the next-by-sales value.
+    let q = "PREFIX ex: <http://ex/> \
+        SELECT ?emp ?sales (LEAD(?sales) OVER (ORDER BY ?sales) AS ?next) \
+        WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }";
+    let r = query_over(&g(), q).unwrap();
+    // ordered d=10, c=20, a=30, b=30, e=40. d sees c=20; e (last) → unbound.
+    assert_eq!(opt_for_emp(&r, "d", 2), Some(20));
+    assert_eq!(opt_for_emp(&r, "e", 2), None);
+}
+
+#[test]
+fn inline_ntile_buckets() {
+    // NTILE(2) over 5 rows (ordered d,c,a,b,e) → buckets sizes 3,2: [1,1,1,2,2].
+    let q = "PREFIX ex: <http://ex/> \
+        SELECT ?emp ?sales (NTILE(2) OVER (ORDER BY ?sales) AS ?half) \
+        WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }";
+    let r = query_over(&g(), q).unwrap();
+    // 5 % 2 = 1 → first bucket gets the extra row. ordered d,c,a → bucket 1; b,e → 2.
+    assert_eq!(for_emp(&r, "d", 2), 1);
+    assert_eq!(for_emp(&r, "c", 2), 1);
+    assert_eq!(for_emp(&r, "a", 2), 1);
+    assert_eq!(for_emp(&r, "b", 2), 2);
+    assert_eq!(for_emp(&r, "e", 2), 2);
+}
+
+// ---- named WINDOW clause (sq-hqhc) [OPUS-4.8] ----
+
+#[test]
+fn named_window_clause_reused_across_items() {
+    // A WINDOW w AS (…) clause defines one spec reused by two projection items:
+    // RANK() and DENSE_RANK() both OVER w. The WINDOW clause is a sparq extension
+    // recognised only on `query_over`; it is stripped before the engine runs.
+    let q = "PREFIX ex: <http://ex/> \
+        SELECT ?emp \
+            (RANK() OVER w AS ?r) \
+            (DENSE_RANK() OVER w AS ?dr) \
+        WHERE { ?emp ex:dept ?dept ; ex:sales ?sales } \
+        WINDOW w AS (PARTITION BY ?dept ORDER BY DESC(?sales))";
+    let r = query_over(&g(), q).unwrap();
+    assert_eq!(r.vars.iter().map(|v| v.as_str()).collect::<Vec<_>>(), ["emp", "r", "dr"]);
+    // eng (30,30,20): RANK a=1,b=1,c=3 (gap); DENSE_RANK a=1,b=1,c=2 (no gap).
+    assert_eq!(for_emp(&r, "a", 1), 1); // RANK
+    assert_eq!(for_emp(&r, "c", 1), 3);
+    assert_eq!(for_emp(&r, "a", 2), 1); // DENSE_RANK
+    assert_eq!(for_emp(&r, "c", 2), 2);
+    // sales partition (40,10): e=1, d=2 under both.
+    assert_eq!(for_emp(&r, "e", 1), 1);
+    assert_eq!(for_emp(&r, "d", 1), 2);
+}
+
+#[test]
+fn named_window_with_limit_modifier_after() {
+    // The WINDOW clause is correctly bounded by a trailing LIMIT modifier (it must
+    // not swallow it), and `OVER w` still resolves.
+    let q = "PREFIX ex: <http://ex/> \
+        SELECT ?emp (ROW_NUMBER() OVER w AS ?rn) \
+        WHERE { ?emp ex:dept ?dept ; ex:sales ?sales } \
+        WINDOW w AS (PARTITION BY ?dept ORDER BY ?sales) \
+        LIMIT 100";
+    let r = query_over(&g(), q).unwrap();
+    assert_eq!(r.vars.iter().map(|v| v.as_str()).collect::<Vec<_>>(), ["emp", "rn"]);
+    assert_eq!(r.rows.len(), 5);
+}
+
+#[test]
+fn over_undefined_window_name_is_error() {
+    // `OVER w` with no matching WINDOW definition is a clear error.
+    let q = "PREFIX ex: <http://ex/> \
+        SELECT ?emp (RANK() OVER w AS ?r) \
+        WHERE { ?emp ex:sales ?sales }";
+    assert!(query_over(&g(), q).is_err());
+}

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -113,8 +113,9 @@ Extension functions (SPARQL 17.6) and dataset views:
   `window::{WindowSpec, WindowFunction, WindowAggregate, WindowFrame, FrameUnit, FrameBound, SortKey,
   apply_window}` (programmatic pass), or `query_over(&Graph, &str)` (+ `_with_budget`) for the inline
   `OVER(…)` query syntax (a source rewrite over the engine; covers `ROW_NUMBER`/`RANK`/`DENSE_RANK`,
-  the windowed aggregates `COUNT`/`SUM`/`AVG`/`MIN`/`MAX` (sq-imj8), `PARTITION BY`/`ORDER BY`, and
-  `ROWS`/`RANGE` frames).
+  the windowed aggregates `COUNT`/`SUM`/`AVG`/`MIN`/`MAX` (sq-imj8), the offset/positional
+  `LAG`/`LEAD(?x[, n[, default]])` and `NTILE(n)` (sq-hqhc), `PARTITION BY`/`ORDER BY`,
+  `ROWS`/`RANGE` frames, and a reusable named `WINDOW w AS (…)` clause (sq-hqhc)).
 
 Introspection: `explain(&Graph, &str)` (plan-only) and `explain_analyze(&Graph, &str)` (plan + per-
 operator execution trace).
@@ -218,8 +219,9 @@ the SQL:2003 window model (the surface Stardog / AnzoGraph expose) and neither t
 W3C-conformance SPARQL surface.
 
 *(a) Programmatic pass over a `QueryResult`* — the full surface. Run an ordinary SELECT, then apply a
-`WindowSpec` (`ROW_NUMBER` / `RANK` / `DENSE_RANK`, or a windowed aggregate over the whole partition, or
-— sq-imj8 — over an explicit `ROWS`/`RANGE` frame). One column is appended; row order is preserved:
+`WindowSpec` (`ROW_NUMBER` / `RANK` / `DENSE_RANK`; the offset/positional `Lag` / `Lead` / `Ntile`
+(sq-hqhc); or a windowed aggregate over the whole partition, or — sq-imj8 — over an explicit
+`ROWS`/`RANGE` frame). One column is appended; row order is preserved:
 
 ```rust
 use sparq_engine::window::{apply_window, SortKey, WindowFunction, WindowSpec};
@@ -247,8 +249,10 @@ run it with `query_over` / `query_over_with_budget`. This is a **source rewrite 
 (it does NOT change the vendored `spargebra` parser): `query_over` lifts each `(FN() OVER (…) AS ?out)`
 item out of the projection, runs the window-stripped SELECT through the ordinary engine, applies the
 programmatic pass above, then reprojects. **Covered subset:** the ranking functions `ROW_NUMBER()`,
-`RANK()`, `DENSE_RANK()` and the windowed aggregates `COUNT(?x)` / `SUM(?x)` / `AVG(?x)` / `MIN(?x)` /
-`MAX(?x)` (sq-imj8 — single `?var` argument; case-insensitive), `PARTITION BY ?v …`, `ORDER BY` over
+`RANK()`, `DENSE_RANK()`, the windowed aggregates `COUNT(?x)` / `SUM(?x)` / `AVG(?x)` / `MIN(?x)` /
+`MAX(?x)` (sq-imj8 — single `?var` argument; case-insensitive), and the offset/positional functions
+`LAG(?x[, n[, default]])` / `LEAD(…)` / `NTILE(n)` (sq-hqhc). A spec can be reused via a named
+`WINDOW w AS (…)` clause and `OVER w` (sq-hqhc). `PARTITION BY ?v …`, `ORDER BY` over
 projected variables **or computed expressions** (sq-c1jv) — e.g. `ORDER BY (?a + ?b)`, `DESC(?sales + 0)`,
 `STRLEN(?s)`; each expression is bound to a fresh helper var in the rewritten inner SELECT and dropped
 from the output — in both `DESC(…)` and `… DESC` spellings, an explicit `ROWS`/`RANGE` frame on an
@@ -264,16 +268,19 @@ let r = sparq_engine::query_over(&g,
      WHERE { ?emp ex:dept ?dept ; ex:sales ?sales }").unwrap(); // ?rn = per-?dept rank, descending by ?sales
 ```
 
-**Inline-OVER caveats (HONEST):** the `OVER` surface is a sparq extension, not W3C SPARQL, recognised
-ONLY on the `query_over` entry point (a `(… OVER …)` clause is still a parse error on `query`/the
-standard surface). A ranking function call must be empty (`ROW_NUMBER()`); a windowed aggregate takes a
-single `?var` argument (`SUM(?x)`); the `AS ?out` alias is required. `ORDER BY` keys may be projected
-variables OR computed expressions (sq-c1jv) but `PARTITION BY` keys must be projected variables. A
-`ROWS`/`RANGE` frame is valid only on an aggregate (a frame on a ranking function errors), and `RANGE`
-supports only the peer-group bounds (`UNBOUNDED …` / `CURRENT ROW`), not a numeric `RANGE n PRECEDING`
-offset. **Deferred (programmatic API only, beaded):** a `DISTINCT` windowed aggregate
-(`COUNT(DISTINCT ?x) OVER …`), an aggregate over a computed-expression argument, numeric `RANGE` offsets,
-`LAG`/`LEAD`/`NTILE`, a named `WINDOW` clause, and `PARTITION BY` over a computed expression.
+**Inline-OVER caveats (HONEST):** the `OVER` surface (and the `WINDOW` clause) is a sparq extension, not
+W3C SPARQL, recognised ONLY on the `query_over` entry point (a `(… OVER …)` clause / `WINDOW` clause is
+still a parse error on `query`/the standard surface). A ranking function call must be empty
+(`ROW_NUMBER()`); a windowed aggregate takes a single `?var` argument (`SUM(?x)`); `LAG`/`LEAD` take a
+bare `?var` plus an optional integer offset and a constant default, `NTILE` a positive integer; the
+`AS ?out` alias is required. The `OVER` operand is either an inline `(…)` spec or a name bound by a
+trailing `WINDOW name AS (…)` clause. `ORDER BY` keys may be projected variables OR computed expressions
+(sq-c1jv) but `PARTITION BY` keys must be projected variables. A `ROWS`/`RANGE` frame is valid only on an
+aggregate (a frame on a ranking or offset function errors), and `RANGE` supports only the peer-group
+bounds (`UNBOUNDED …` / `CURRENT ROW`), not a numeric `RANGE n PRECEDING` offset. **Deferred
+(programmatic API only, beaded):** a `DISTINCT` windowed aggregate (`COUNT(DISTINCT ?x) OVER …`), an
+aggregate / `LAG`/`LEAD` argument over a computed-expression, numeric `RANGE` offsets, and `PARTITION BY`
+over a computed expression.
 
 **Budgets / timeouts / ASK-style early exit** — a `QueryBudget` is checked cooperatively at coarse
 sites; tripping it fails with `"query budget exceeded (timeout)"` / `"... (max-rows)"` /
@@ -338,15 +345,17 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
 - **Window functions + custom aggregate registry** are the non-default `window-functions` cargo
   feature. **Window functions are a NON-STANDARD extension** — there is no W3C-REC SPARQL `OVER`
   syntax. sparq exposes them as a programmatic pass over a `QueryResult` (the SQL:2003 model
-  Stardog/AnzoGraph expose), `ROW_NUMBER`/`RANK`/`DENSE_RANK` + a windowed aggregate over the whole
-  partition or an explicit `ROWS`/`RANGE` frame (sq-imj8),
+  Stardog/AnzoGraph expose), `ROW_NUMBER`/`RANK`/`DENSE_RANK`, the offset/positional
+  `LAG`/`LEAD`/`NTILE` (sq-hqhc), + a windowed aggregate over the whole partition or an explicit
+  `ROWS`/`RANGE` frame (sq-imj8),
   AND as an inline `OVER(…)` query syntax via the dedicated `query_over` entry point (a *source rewrite*
   in front of the engine — it does NOT change the vendored parser, so the standard `query`/`ask`/… surface
   stays exactly SPARQL 1.1 and conformance is unaffected; `OVER` is a parse error everywhere except
-  `query_over`). The inline syntax covers the three ranking functions AND the windowed aggregates
-  `COUNT`/`SUM`/`AVG`/`MIN`/`MAX` with `PARTITION BY`/`ORDER BY` and `ROWS`/`RANGE` frames (sq-imj8);
-  `DISTINCT`/expression aggregate arguments, numeric `RANGE` offsets, `LAG`/`LEAD`/`NTILE` and a named
-  `WINDOW` clause are inline-deferred (use the programmatic API). The custom-aggregate side DOES ride real SPARQL `GROUP BY` (a declared aggregate
+  `query_over`). The inline syntax covers the three ranking functions, the windowed aggregates
+  `COUNT`/`SUM`/`AVG`/`MIN`/`MAX` with `PARTITION BY`/`ORDER BY` and `ROWS`/`RANGE` frames (sq-imj8), the
+  offset/positional `LAG`/`LEAD`/`NTILE` and a reusable named `WINDOW w AS (…)` clause (sq-hqhc);
+  `DISTINCT`/computed-expression function arguments, numeric `RANGE` offsets and a computed-expression
+  `PARTITION BY` are inline-deferred (use the programmatic API). The custom-aggregate side DOES ride real SPARQL `GROUP BY` (a declared aggregate
   IRI is part of the SPARQL 1.1 extension grammar). When the feature is off, zero window/aggregate-registry
   code compiles and the default build is byte-identical (no new dependencies). See the recipes above.
 - **Default cargo features** (`parallel`, `regex`, `digest`): `regex` powers REGEX/REPLACE; `digest`


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. @jeswr runs multiple agents on this account.

Implements bead **sq-hqhc** (follow-up to sq-h564 / sq-imj8): adds the offset/positional window functions **LAG / LEAD / NTILE** and a reusable **named `WINDOW` clause** to sparq's opt-in `window-functions` surface — on both the programmatic pass and the inline `OVER(…)` source-rewrite syntax. The vendored `spargebra` parser and the W3C-conformance surface are untouched (the `OVER(…)` / `WINDOW` extension is recognised ONLY on the dedicated `query_over` entry point; it is still a parse error on `query`/`ask`/…).

## What's new `[OPUS-4.8]`

**`window.rs` (programmatic):** `WindowFunction::{Lag, Lead, Ntile}` + evaluation.
- `LAG`/`LEAD(?of, offset, default)` — the value of column `of` from the row `offset` positions before/after the current row in window `ORDER BY` order; an out-of-partition source yields `default` (unbound if none). Positional: frames are ignored, partition boundaries honoured.
- `NTILE(n)` — the 1-based bucket of an n-way near-equal split (the first `size % n` buckets take the extra row); `n >= 1` validated up front (`NTILE(0)` is an error).

**`window_syntax.rs` (inline):**
- Parses `LAG`/`LEAD(?var[, n[, default]])` and `NTILE(n)`; a constant-term parser handles the LAG/LEAD default (numeric, `"string"`[`@lang`|`^^<dt>`], `true`/`false`, `<IRI>`).
- A named `WINDOW name AS (…)` clause (top-level, after the WHERE block, alongside `ORDER BY`/`LIMIT`) reused via `OVER name`. The clause is extracted and **stripped before the engine runs**; `OVER name` with no matching definition is a clear error.
- A `ROWS`/`RANGE` frame on an offset/ranking function is rejected (frames are aggregate-only).

**Docs:** SKILL.md / crate README / Cargo feature note / module docs move LAG/LEAD/NTILE + the named WINDOW clause from "deferred" to "covered". Still inline-deferred (programmatic-only): `DISTINCT` aggregates, computed-expression function arguments, numeric `RANGE` offsets, computed-expression `PARTITION BY`.

## Honesty / scope
- Strict superset: a query with no `OVER` is byte-for-byte unchanged through the ordinary engine.
- No privacy/ZK/MPC surface touched; the privacy-claims gate passes unchanged.

## Gate (all green locally)
- `cargo build` + `cargo clippy --all-targets -- -D warnings` in **both** feature states (`window-functions` on and off).
- Full `cargo test -p sparq-engine` in **both** feature states — 0 failures (new: programmatic LAG/LEAD/NTILE offset/default/partition/uneven-NTILE/NTILE(0) tests; inline parse + end-to-end `query_over` for all three + the named WINDOW clause).
- `scripts/check-privacy-claims.sh`: OK. `scripts/gate-api-skill.py`: PASS.
- rustfmt is informational in CI (pending the deferred one-time `cargo fmt --all`); clippy is the hard lint gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)