### PR TITLE
site(zk): headless Playwright smoke test for ZK prover pre-warm (sq-5q63)

### DIFF
--- a/.github/workflows/site-e2e.yml
+++ b/.github/workflows/site-e2e.yml
@@ -1,0 +1,83 @@
+# [OPUS-4.8] sq-5q63 — site CI lane: lint + unit + the headless Playwright smoke test.
+#
+# WHY: the ZK car-hire prover pre-warms on route mount so the FIRST "Generate ZK proof"
+# pays no cold start (prewarmProver() in site/src/lib/zk-prover.ts). That was previously
+# argued only by code reasoning — no browser driver. site/e2e/zk-prewarm.spec.ts now
+# proves it in a real headless Chromium: it awaits the "Prover ready" pill, then asserts
+# the first proof does NOT re-pay the dynamic-import + Barretenberg.new cold start (the
+# prover's `window.__zkProverColdStarts` counter stays at 1).
+#
+# SCOPE: PRs that touch site/** (or this workflow) — a Rust-/docs-only PR skips this lane
+# (no run, so the required `ci-summary / gate` simply never waits on it). It is path-
+# scoped, not run on `merge_group`, so the heavy browser-download + real-proving cost is
+# paid only on the PRs that actually change the site (matching js.yml / pages.yml, which
+# are likewise not merge-queue lanes). It re-runs on push to main for post-merge cover.
+#
+# The Playwright config drives `next dev` directly (NOT the static export) — the ZK route
+# is fully functional there and needs no wasm-REPL/Typst prebuild artifacts.
+name: site-e2e
+
+on:
+  pull_request:
+    paths:
+      - "site/**"
+      - ".github/workflows/site-e2e.yml"
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/site-e2e.yml"
+
+# Least-privilege default (Scorecard TokenPermissions): read-only; this lane never writes.
+permissions:
+  contents: read
+
+# One in-flight run per PR/branch; cancel a superseded run.
+concurrency:
+  group: site-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  site-e2e:
+    name: lint + unit + zk-prewarm smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests (node --test)
+        run: npm run test:unit
+
+      # Cache the Playwright browser download keyed on the resolved @playwright/test
+      # version, so a browser re-download only happens when the version changes.
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Playwright Chromium (+ OS deps)
+        run: npx playwright install --with-deps chromium
+
+      - name: ZK prover pre-warm smoke test (headless Chromium)
+        run: npm run test:e2e

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -13,3 +13,10 @@ next-env.d.ts
 # wasm bundle; the .typ sources under site/papers/ are the tracked source of truth.
 /public/papers/
 /src/generated/
+
+# [OPUS-4.8] sq-5q63 — Playwright (e2e/) outputs: traces, reports, downloaded browsers.
+# Regenerable test artifacts, never source. The spec + playwright.config.ts are tracked.
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/site/README.md
+++ b/site/README.md
@@ -32,11 +32,33 @@ npm ci
 npm run dev        # sync-wasm → public/wasm, then next dev
 npm run build      # → out/  (static export)
 npm run lint
+npm run test:unit  # node:test — pure helper logic (REPL dataset, …)
+npm run test:e2e   # Playwright — headless browser smoke tests (see below)
 ```
 
 `public/wasm/` is generated (git-ignored): `scripts/sync-wasm.mjs` copies the
 wasm-pack `--target web` output from `js/wasm/`. The `prebuild` script runs it
 automatically before `next build`.
+
+### Browser smoke tests (Playwright)
+
+`e2e/` holds headless-browser smoke tests driven by Playwright against a real `next dev`
+server (config: `playwright.config.ts`). The first time, install the browser:
+
+```bash
+npx playwright install chromium
+npm run test:e2e
+```
+
+The current coverage is the **ZK car-hire prover pre-warm** (`e2e/zk-prewarm.spec.ts`,
+bead sq-5q63): it loads `/showcase/zk-car-hire`, waits for the *Prover ready* pill, and
+asserts the first **Generate ZK proof** click pays no cold start — i.e. it does not
+re-pay the lazy `@noir-lang/noir_js` + `@aztec/bb.js` dynamic-import or the
+`Barretenberg.new` WASM instantiate that `prewarmProver()` already did on route mount.
+That is observed via a test-only cold-start counter the prover mirrors onto
+`window.__zkProverColdStarts` (pure observability; it changes nothing the prover proves).
+CI runs this lane on site-touching PRs (`.github/workflows/site-e2e.yml`); Playwright
+outputs (`test-results/`, `playwright-report/`, the browser cache) are git-ignored.
 
 ## Papers (the academic paper factory)
 

--- a/site/e2e/zk-prewarm.spec.ts
+++ b/site/e2e/zk-prewarm.spec.ts
@@ -1,0 +1,88 @@
+// [OPUS-4.8] sq-5q63 — headless browser smoke test for the ZK car-hire prover pre-warm.
+//
+// WHAT IT GUARDS. The car-hire age-gate prover pre-warms on route mount
+// (`prewarmProver()` in src/lib/zk-prover.ts, kicked off from a useEffect in
+// src/components/zk-car-hire.tsx), so the FIRST "Generate ZK proof" click should pay no
+// cold start: the dynamic-import of @noir-lang/noir_js + @aztec/bb.js and the dominant
+// `Barretenberg.new` WASM instantiate must already be done. Previously that was argued
+// only by code reasoning (no browser driver). This test verifies it with a real run.
+//
+// HOW IT IS OBSERVABLE. `zk-prover.ts` counts every REAL cold start — each time the
+// expensive `loadProver` body actually executes — and mirrors the count onto
+// `window.__zkProverColdStarts` (pure test observability; it changes nothing about what
+// is proved or any security property). A correctly pre-warmed prover leaves the counter
+// at 1 across the first proof; a regression that re-paid the cold start on the click
+// would bump it to 2. The pre-warm pill (`[data-prover="ready"]`) and the proof-result
+// card (`[data-proof-result]`) are the DOM anchors we await — no copy-scraping.
+//
+// THE COI RELOAD. The page ships the coi-serviceworker shim (public/coi-serviceworker.js,
+// registered in app/layout.tsx) so `crossOriginIsolated` becomes true on plain static
+// hosting. On a fresh visit that SW registers and reloads the tab ONCE; the cold-start
+// counter is per-document, so it is the POST-RELOAD load that pre-warms. We therefore
+// wait for the readiness pill to settle (which only happens after the reload) before
+// reading the counter — `gotoSettled` encapsulates that.
+//
+// This is a CORRECTNESS smoke test, not a benchmark: it asserts the cold-start COUNT,
+// never a wall-clock threshold (timings on a work-box / CI runner are non-canonical).
+import { test, expect, type Page } from "@playwright/test";
+
+// Relative (no leading slash) so it resolves UNDER the baseURL's `/sparq/` basePath —
+// a leading slash would target the origin root and miss the basePath entirely.
+const ROUTE = "showcase/zk-car-hire/";
+
+/** Read the test-only cold-start counter the prover mirrors onto `window`. */
+function coldStarts(page: Page): Promise<number> {
+  return page.evaluate(() => window.__zkProverColdStarts ?? 0);
+}
+
+/**
+ * Navigate to the ZK route and wait for the prover to settle to "ready". This absorbs
+ * the one-time coi-serviceworker reload: we wait on the readiness pill (which only the
+ * post-reload document ever shows), so the subsequent counter read is on the live tab.
+ */
+async function gotoReady(page: Page): Promise<void> {
+  await page.goto(ROUTE, { waitUntil: "domcontentloaded" });
+  // The post-reload document pre-warms and flips the pill to ready. If pre-warm failed,
+  // the pill would read [data-prover="error"] instead — fail loudly in that case.
+  await expect(page.locator('[data-prover="error"]')).toHaveCount(0);
+  await page.locator('[data-prover="ready"]').waitFor({ state: "visible", timeout: 90_000 });
+}
+
+test("first ZK proof pays no cold start after pre-warm", async ({ page }) => {
+  await gotoReady(page);
+
+  // The route-mount pre-warm ran the ONE cold start (dynamic import + circuit fetch +
+  // Barretenberg.new) and resolved the readiness pill.
+  expect(await coldStarts(page)).toBe(1);
+
+  // Click "Generate ZK proof" and await the completed-proof card. Because pre-warm
+  // finished, `proveAgeEligibility` awaits the SAME shared prover promise — it must NOT
+  // trigger a second `loadProver` body.
+  await page.getByRole("button", { name: "Generate ZK proof" }).click();
+
+  const resultCard = page.locator("[data-proof-result]");
+  await expect(resultCard).toBeVisible({ timeout: 90_000 });
+
+  // THE ASSERTION: the first proof did not re-pay the cold start. Still exactly one.
+  expect(await coldStarts(page)).toBe(1);
+
+  // The default age (30) is provable and the proof self-verifies in-tab — a sanity check
+  // that we measured a real proof, not an error path that happens to leave the count at 1.
+  await expect(resultCard).toHaveAttribute("data-proof-verified", "true");
+});
+
+test("the cold start happens at most once even across a second proof", async ({ page }) => {
+  // A second proof on the same tab must also reuse the warmed prover — the memoised
+  // `proverPromise` means the cold-start body never runs again for the document's life.
+  await gotoReady(page);
+
+  const generate = page.getByRole("button", { name: "Generate ZK proof" });
+  await generate.click();
+  await expect(page.locator("[data-proof-result]")).toBeVisible({ timeout: 90_000 });
+  expect(await coldStarts(page)).toBe(1);
+
+  // Re-running proves the warm path holds; the count stays pinned at one.
+  await generate.click();
+  await expect(page.locator('[data-proof-verified="true"]')).toBeVisible({ timeout: 90_000 });
+  expect(await coldStarts(page)).toBe(1);
+});

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
+        "@playwright/test": "^1.61.0",
         "@tailwindcss/postcss": "^4.1.0",
         "@types/node": "^22.10.0",
         "@types/react": "^19.0.0",
@@ -1181,6 +1182,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -5080,6 +5097,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6826,6 +6858,38 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -6840,7 +6904,6 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/site/package.json
+++ b/site/package.json
@@ -13,7 +13,8 @@
     "build": "next build",
     "start": "npx --yes serve out",
     "lint": "next lint",
-    "test:unit": "node --import ./test-support/register-ts.mjs --test test/"
+    "test:unit": "node --import ./test-support/register-ts.mjs --test test/",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@aztec/bb.js": "5.0.0-nightly.20260324",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/postcss": "^4.1.0",
     "@types/node": "^22.10.0",
     "@types/react": "^19.0.0",

--- a/site/package.json
+++ b/site/package.json
@@ -13,7 +13,7 @@
     "build": "next build",
     "start": "npx --yes serve out",
     "lint": "next lint",
-    "test:unit": "node --import ./test-support/register-ts.mjs --test test/",
+    "test:unit": "node --import ./test-support/register-ts.mjs --test test/*.test.mjs",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -1,0 +1,56 @@
+// [OPUS-4.8] sq-5q63 — Playwright config for the site's headless browser smoke tests.
+//
+// Scope: the ZK car-hire prover pre-warm smoke test (e2e/zk-prewarm.spec.ts). The test
+// drives a REAL browser against a REAL Next.js server so the "first proof pays no cold
+// start" claim is verified by an automated run, not just by code reasoning.
+//
+// The server is `next dev` (NOT the static export): the ZK route is fully functional in
+// dev — it dynamic-imports @noir-lang/noir_js + @aztec/bb.js (real deps) and fetches the
+// committed circuit from public/zk/, none of which need the wasm-REPL/Typst prebuild
+// artifacts. Driving dev directly keeps the smoke test self-contained and fast.
+//
+// Run locally:  npx playwright install chromium && npm run test:e2e
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = Number(process.env.PORT ?? 3210);
+// basePath "/sparq" (next.config.ts) prefixes every route, so the demo lives under it.
+// Keep the TRAILING SLASH: Playwright resolves a relative `page.goto("showcase/…")`
+// against this baseURL, and only a trailing slash makes the basePath a path *prefix*
+// (without it, the relative segment would replace "/sparq" instead of nesting under it).
+const BASE_URL = `http://127.0.0.1:${PORT}/sparq/`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  // Real ZK proving in a single-thread browser is the slow step; give it room. The
+  // assertion is correctness (cold-start count), never a timing threshold — wall-clock
+  // here is non-canonical (work-box / CI-runner), so we never gate on a duration.
+  timeout: 120_000,
+  expect: { timeout: 90_000 },
+  // A flaky network/instantiate cold start is the prover's documented self-reset path,
+  // not a product bug; one retry absorbs that without masking a real regression (a true
+  // second cold start fails deterministically on every attempt).
+  retries: process.env.CI ? 1 : 0,
+  // Proving is CPU-bound and single-threaded; serial keeps the box quiet + the run honest.
+  workers: 1,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    // The local Next 15 binary serves the dev route under /sparq; bypass the `dev` npm
+    // script (which runs sync-wasm/Typst prebuild steps the ZK route does not need).
+    command: `npx next dev -p ${PORT}`,
+    url: BASE_URL + "showcase/zk-car-hire/",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/site/src/components/zk-car-hire.tsx
+++ b/site/src/components/zk-car-hire.tsx
@@ -278,22 +278,24 @@ export function ZkCarHire() {
 // [OPUS-4.8] Subtle prover-readiness pill. Reuses the badge tokens; never blocks the
 // UI and never alters any security claim — it only reports cold-start progress.
 function ProverIndicator({ prover }: { prover: ProverState }) {
+  // [OPUS-4.8] sq-5q63 — `data-prover` mirrors the lifecycle state for the headless
+  // smoke test to await deterministically (regardless of label text/locale/styling).
   if (prover === "ready") {
     return (
-      <Badge variant="muted" aria-live="polite">
+      <Badge variant="muted" aria-live="polite" data-prover="ready">
         <CircleCheck className="size-3 text-[var(--success)]" /> Prover ready
       </Badge>
     );
   }
   if (prover === "error") {
     return (
-      <Badge variant="warning" aria-live="polite">
+      <Badge variant="warning" aria-live="polite" data-prover="error">
         <CircleAlert className="size-3" /> Prover load failed — retries on proof
       </Badge>
     );
   }
   return (
-    <Badge variant="muted" aria-live="polite">
+    <Badge variant="muted" aria-live="polite" data-prover="warming">
       <Loader2 className="size-3 animate-spin" /> Initializing ZK prover…
     </Badge>
   );
@@ -356,7 +358,9 @@ function VerdictPanel({ phase, age }: { phase: Phase; age: number }) {
   if (phase.kind !== "done") return null;
   const r = phase.result;
   return (
-    <Card>
+    // [OPUS-4.8] sq-5q63 — `data-proof-verified` lets the smoke test await the first
+    // completed proof and assert it verified, without scraping copy.
+    <Card data-proof-result data-proof-verified={r.verified ? "true" : "false"}>
       <CardHeader className="flex-row items-center justify-between gap-2 space-y-0">
         <CardTitle className="flex items-center gap-2 text-base">
           {r.verified ? (

--- a/site/src/lib/zk-prover.ts
+++ b/site/src/lib/zk-prover.ts
@@ -141,9 +141,45 @@ interface ProverContext {
 
 let proverPromise: Promise<ProverContext> | null = null;
 
+/**
+ * [OPUS-4.8] sq-5q63 — observable cold-start counter for the browser smoke test.
+ *
+ * Incremented exactly ONCE per real cold start — i.e. each time the expensive
+ * {@link loadProver} body (dynamic-import of noir_js + bb.js, circuit fetch, and the
+ * dominant `Barretenberg.new` WASM instantiate) actually runs, NOT on the memoised
+ * fast path. Because {@link loadProver} shares one `proverPromise`, a correctly
+ * pre-warmed prover leaves this at 1 across the first {@link proveAgeEligibility}; a
+ * regression that re-paid the cold start on the first proof would bump it to 2.
+ *
+ * Mirrored onto `window.__zkProverColdStarts` purely so a headless Playwright run can
+ * read it without scraping the UI. This is pure test observability: it does not touch
+ * what is proved, the witness, the public inputs, or any security property of the
+ * proof. The counter only ever increases; it is never reset by product code.
+ */
+let coldStarts = 0;
+
+const COLD_START_GLOBAL = "__zkProverColdStarts" as const;
+
+declare global {
+  interface Window {
+    /** @see {@link coldStarts} — test-only cold-start observability hook (sq-5q63). */
+    [COLD_START_GLOBAL]?: number;
+  }
+}
+
+function recordColdStart(): void {
+  coldStarts += 1;
+  if (typeof window !== "undefined") {
+    window[COLD_START_GLOBAL] = coldStarts;
+  }
+}
+
 async function loadProver(): Promise<ProverContext> {
   if (!proverPromise) {
     proverPromise = (async () => {
+      // First (and, when pre-warm works, only) cold start: count it before the heavy
+      // dynamic-import + WASM instantiate so the smoke test can assert it stays at 1.
+      recordColdStart();
       const [{ Noir }, bb, circuit] = await Promise.all([
         import(/* webpackChunkName: "noir-js" */ "@noir-lang/noir_js") as Promise<NoirModule>,
         import(/* webpackChunkName: "bb-js" */ "@aztec/bb.js") as Promise<BbModule>,


### PR DESCRIPTION
> 🤖 SPARQ agent — automated PR. @jeswr runs multiple agents on one account.

Implements bead **sq-5q63**: a headless browser smoke test for the ZK car-hire prover pre-warm.

## Why

The car-hire age-gate prover pre-warms on route mount (`prewarmProver()` in `site/src/lib/zk-prover.ts`, kicked off from a `useEffect` in `site/src/components/zk-car-hire.tsx`), so the **first** "Generate ZK proof" click should pay no cold start. Until now that "first proof pays no cold start" property was verified only by code reasoning + the route-scoped lazy `bb.js` bundle — no browser driver was available for an automated run.

## What

A real **headless-Chromium** smoke test, `site/e2e/zk-prewarm.spec.ts`, that:

1. loads `/showcase/zk-car-hire`,
2. awaits the **Prover ready** pill (`[data-prover="ready"]`), and
3. asserts the first proof completes **without re-paying** the dynamic-import of `@noir-lang/noir_js` + `@aztec/bb.js` or the dominant `Barretenberg.new` WASM instantiate.

### How it's observable

`zk-prover.ts` now counts every **real** cold start (each time the expensive `loadProver` body actually runs) and mirrors the count onto `window.__zkProverColdStarts`. This is **pure test observability** — it changes nothing about what is proved, the witness, the public inputs, or any security property of the proof. A correctly pre-warmed prover leaves the counter at `1` across the first proof; a regression that re-paid the cold start would bump it to `2`.

The pill (`data-prover`) and the proof-result card (`data-proof-result` / `data-proof-verified`) are deterministic DOM anchors, so the test never scrapes copy. The Playwright config drives `next dev` directly (the ZK route is fully functional there — it needs no wasm-REPL/Typst prebuild artifacts) and absorbs the one-time `coi-serviceworker` reload before reading the counter.

### CI

A path-scoped lane, `.github/workflows/site-e2e.yml`, runs `lint` + `test:unit` + this smoke on site-touching PRs (SHA-pinned actions, least-privilege, Playwright-browser caching). Playwright outputs (`test-results/`, `playwright-report/`, browser cache) are git-ignored.

## Gate (all green in-worktree)

- `next lint` (incl. `e2e/` + `playwright.config.ts`) — clean
- `tsc --noEmit` — clean
- `npm run test:unit` — 7/7
- `scripts/check-privacy-claims.sh` (predicate-form soundness included) — clean
- `npm run test:e2e` — **2/2 passed** in a real headless browser
- **Negative validation:** a sabotage run that forces a second cold start makes the assertion fail (`Expected: 1, Received: 2`), confirming the test is load-bearing, not a tautology.

No public Rust API changed (G2 N/A; site is not a published crate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
