### PR TITLE
fix(js): chunk-safe zstd fixture synthesis (sq-3lh7)

### DIFF
--- a/js/test/helpers/zstd-fixtures.mjs
+++ b/js/test/helpers/zstd-fixtures.mjs
@@ -67,7 +67,17 @@ export function zstdRawFrame(payload, { dictId = 0 } = {}) {
   // Window_Descriptor byte then).
   const fhd = (fcs.flag << 6) | (1 << 5) | did.flag;
 
-  const blocks = [];
+  // The frame is at least one block even for a zero-length payload (an empty
+  // Raw_Block with Last_Block set). Each block contributes a 3-byte header plus
+  // its raw bytes; size the output exactly so we can write it with .set()
+  // rather than spreading chunk bytes as function args — a >=128 KiB chunk
+  // spread into Array.push overflows the call stack (RangeError, bead sq-3lh7).
+  const blockCount = Math.max(1, Math.ceil(data.length / MAX_RAW_BLOCK));
+  const header = [...ZSTD_MAGIC, fhd, ...did.bytes, ...fcs.bytes];
+  const frame = new Uint8Array(header.length + blockCount * 3 + data.length);
+  frame.set(header, 0);
+
+  let pos = header.length;
   let offset = 0;
   do {
     const end = Math.min(offset + MAX_RAW_BLOCK, data.length);
@@ -75,18 +85,31 @@ export function zstdRawFrame(payload, { dictId = 0 } = {}) {
     const lastBlock = end >= data.length ? 1 : 0;
     // Block_Header (3 bytes LE): Block_Size<<3 | Block_Type<<1 | Last_Block.
     // Block_Type 0 = Raw_Block (stored uncompressed).
-    const header = (chunk.length << 3) | (0 << 1) | lastBlock;
-    blocks.push(header & 0xff, (header >> 8) & 0xff, (header >> 16) & 0xff, ...chunk);
+    const bh = (chunk.length << 3) | (0 << 1) | lastBlock;
+    frame[pos] = bh & 0xff;
+    frame[pos + 1] = (bh >> 8) & 0xff;
+    frame[pos + 2] = (bh >> 16) & 0xff;
+    frame.set(chunk, pos + 3);
+    pos += 3 + chunk.length;
     offset = end;
   } while (offset < data.length);
 
-  return Uint8Array.from([...ZSTD_MAGIC, fhd, ...did.bytes, ...fcs.bytes, ...blocks]);
+  return frame;
 }
 
 /** Concatenated independent frames — the RFC 8878 multi-frame wire shape the
  *  `CompressedSink` emits (Node's own `zstdDecompressSync` decodes only the
  *  first; fzstd loops them all). */
 export function zstdMultiFrame(payloads) {
-  const frames = payloads.map(p => [...zstdRawFrame(p)]);
-  return Uint8Array.from(frames.flat());
+  // Copy each frame in with .set() (no spread): frames can each exceed the
+  // safe argument count, so flattening via spread would re-introduce sq-3lh7.
+  const frames = payloads.map(p => zstdRawFrame(p));
+  const total = frames.reduce((n, f) => n + f.length, 0);
+  const out = new Uint8Array(total);
+  let pos = 0;
+  for (const f of frames) {
+    out.set(f, pos);
+    pos += f.length;
+  }
+  return out;
 }

--- a/js/test/zstd-fixtures.test.mjs
+++ b/js/test/zstd-fixtures.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { decompress as fzstdDecompress } from 'fzstd';
+// Unit-tests the pure-JS zstd fixture synthesiser directly (no wasm/dist build
+// needed): the fixtures themselves must survive payloads at and beyond the
+// 128 KiB Raw_Block boundary. Regression for bead sq-3lh7, where a >=128 KiB
+// chunk was spread as `push(...chunk)` args and overflowed the call stack
+// (RangeError) before any frame was produced. [OPUS-4.8]
+import { zstdRawFrame, zstdMultiFrame } from './helpers/zstd-fixtures.mjs';
+
+const MAX_RAW_BLOCK = 128 * 1024;
+
+function ramp(n) {
+  const a = new Uint8Array(n);
+  for (let i = 0; i < n; i++) a[i] = (i * 31 + 7) & 0xff;
+  return a;
+}
+
+// Sizes straddling the single-block boundary: just under, exactly at, just
+// over, several blocks, and a size whose final block is a remainder.
+for (const n of [
+  MAX_RAW_BLOCK - 1,
+  MAX_RAW_BLOCK,
+  MAX_RAW_BLOCK + 1,
+  3 * MAX_RAW_BLOCK,
+  3 * MAX_RAW_BLOCK + 123,
+]) {
+  test(`zstdRawFrame round-trips a ${n}-byte payload through fzstd`, () => {
+    const payload = ramp(n);
+    const frame = zstdRawFrame(payload);
+    const out = fzstdDecompress(frame);
+    assert.deepEqual(Uint8Array.from(out), payload);
+  });
+}
+
+test('zstdRawFrame round-trips an empty payload (single empty Raw_Block)', () => {
+  const out = fzstdDecompress(zstdRawFrame(new Uint8Array(0)));
+  assert.equal(out.length, 0);
+});
+
+test('zstdRawFrame embeds a dictId across the block boundary', () => {
+  const payload = ramp(MAX_RAW_BLOCK + 9);
+  const out = fzstdDecompress(zstdRawFrame(payload, { dictId: 0x1234 }));
+  assert.deepEqual(Uint8Array.from(out), payload);
+});
+
+test('zstdMultiFrame concatenates large independent frames', () => {
+  const parts = [ramp(MAX_RAW_BLOCK + 5), ramp(10), ramp(2 * MAX_RAW_BLOCK)];
+  const frame = zstdMultiFrame(parts);
+  const expected = Uint8Array.from(parts.flatMap(p => [...p]));
+  const out = fzstdDecompress(frame);
+  assert.deepEqual(Uint8Array.from(out), expected);
+});


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

`js/test/helpers/zstd-fixtures.mjs:79` built each `Raw_Block` by spreading the chunk as `push`-arguments:

```js
blocks.push(header & 0xff, (header >> 8) & 0xff, (header >> 16) & 0xff, ...chunk);
```

A chunk is up to `MAX_RAW_BLOCK = 128 * 1024` (131072) bytes, so for any payload `>= 128 KiB` the `...chunk` spread pushes ~131K values as function arguments and overflows the JS call stack — **`RangeError: Maximum call stack size exceeded`** — before any frame is produced. Every compressed/dictionary fixture at or above the single-block boundary was therefore un-buildable. (bead **sq-3lh7**)

Reproduced on Node 20 — payloads of 131071, 131072, 204800, 524288 bytes all threw.

## Fix

Size the output `Uint8Array` exactly (`magic+header + blockCount*3 + payload`) and write each 3-byte block header plus its raw bytes with `frame.set(chunk, …)` instead of spreading. `zstdMultiFrame` likewise concatenates frames with `.set()` rather than `[...frame]`, so a large frame can't re-introduce the same overflow.

- **Byte-identical** to the previous implementation for every sub-128 KiB payload and every dictId (verified by diffing against the old impl), so existing `compressed.test.mjs` / `dictionary.test.mjs` fixtures are unaffected.
- Empty-payload single-block case preserved via `Math.max(1, ceil(len/MAX))`.

## Tests

New standalone `js/test/zstd-fixtures.test.mjs` — imports only the helper + `fzstd` (no wasm/`dist` build needed), so it runs under `node --test "test/*.test.mjs"` directly. Covers round-trips at `MAX_RAW_BLOCK-1 / =MAX / +1`, multi-block (`3×`) and remainder sizes, an empty payload, a dictId across the block boundary, and a large multi-frame stream. All 8 pass; were RED (RangeError) before the fix.

## Gate

- JS-only test-helper change: no Rust crate, no public package API, no SKILL.md surface touched.
- Privacy-claims / predicate-form soundness gate: N/A — synthesises test fixtures only, asserts no privacy property.
- No JS lint/format config in repo; `tsc` scope is `src/**/*.ts` (untouched).

[OPUS-4.8]