### PR TITLE
ci(G2): normalize line-wrapped pub-item signatures so rustfmt reflow isn't a false public-surface change (sq-5x2i)

### DIFF
--- a/scripts/pub_api_diff.py
+++ b/scripts/pub_api_diff.py
@@ -39,24 +39,114 @@ import re
 # only the eight item forms below count.
 PUB_ITEM_RE = re.compile(r"^[+-]\s*pub\s+(?:fn|struct|enum|trait|const|type|mod|use)\b")
 
+# [OPUS-4.8] The item KIND drives where its signature ends. The brace-bodied kinds
+# (fn/struct/enum/trait) end at the body's opening `{`; the statement kinds
+# (use/mod-decl/const/type and unit/tuple struct) end at `;`. We read the kind
+# off the first line so a group-import brace in `pub use a::{B, C};` is NOT
+# mistaken for a body brace (its real terminator is the trailing `;`).
+_KIND_RE = re.compile(r"\bpub\s+(fn|struct|enum|trait|const|type|mod|use)\b")
+_BRACE_BODIED = frozenset({"fn", "struct", "enum", "trait"})
+
+# [OPUS-4.8] Trailing comma rustfmt INSERTS when it wraps a comma-delimited list
+# (params, generics, tuple-struct fields, where-clause bounds). The single-line
+# form has no trailing comma before its closing delimiter; the wrapped form does.
+# Dropping a comma that immediately precedes a closing delimiter — `)`/`]`/`>`,
+# the closing `}` of a braced form, OR the body-opening `{` (rustfmt's wrapped
+# `where T: Bound,` lands a comma right before `{`) — makes the two canonical
+# forms identical. A comma before `{`/`}` is never meaningful in a real one-line
+# signature, so removing it cannot mask a genuine difference.
+_TRAILING_COMMA_RE = re.compile(r",(?=[)\]>{}])")
+
+
+def normalize_signature(text: str) -> str:
+    """Canonicalise a `pub `-item signature so a rustfmt LINE-WRAP of it compares
+    EQUAL to its single-line form (bead sq-5x2i).
+
+    rustfmt's only *token-level* change when wrapping a signature is the trailing
+    comma it inserts before a closing delimiter; everything else is pure
+    whitespace (newlines + indentation). So we strip ALL whitespace and drop any
+    comma that sits immediately before a closing delimiter. The result is a
+    whitespace- and wrap-invariant key used ONLY for the multiset EQUALITY test —
+    it is never shown to a user, so collapsing `pub fn` → `pubfn` is harmless."""
+    no_ws = "".join(text.split())
+    return _TRAILING_COMMA_RE.sub("", no_ws)
+
+
+def _item_kind(first_line_body: str) -> str:
+    """The item keyword (`fn`/`struct`/…/`use`) of a `pub `-item line, or ``."""
+    m = _KIND_RE.search(first_line_body)
+    return m.group(1) if m else ""
+
+
+def _signature_complete(acc: str, kind: str) -> bool:
+    """True once `acc` (the marker-stripped text gathered so far) contains this
+    item KIND's signature terminator at the OUTERMOST `()`/`[]` nesting level.
+
+    A brace-bodied kind (fn/struct/enum/trait) ends at the first depth-0 `{`
+    (the body open) or `;` (unit/tuple struct, trait-method decl); a statement
+    kind (use/mod/const/type) ends at the first depth-0 `;`. We count only `()`
+    and `[]` toward depth so a body `{` or a group-import `{` is never confused
+    with a parameter-list delimiter, and a `;` inside a default value's `[...]`
+    does not terminate early."""
+    depth = 0
+    for ch in acc:
+        if ch in "([":
+            depth += 1
+        elif ch in ")]":
+            depth = max(0, depth - 1)
+        elif depth == 0:
+            if ch == ";":
+                return True
+            if ch == "{" and kind in _BRACE_BODIED:
+                return True
+    return False
+
 
 def scan_pub_diff(diff_lines: list[str]) -> tuple[list[str], list[str]]:
     """Split unified-diff lines into (added, removed) public-item signatures.
 
-    Each returned string is the diff line with its leading +/- marker stripped and
-    inner whitespace collapsed, so an identical signature that is both added and
-    removed (a pure relocation / re-indentation) compares equal across the two
-    lists. File headers (`+++ b/…`, `--- a/…`) are skipped — they are never item
-    signatures."""
+    [OPUS-4.8] A `pub `-item signature that rustfmt LINE-WRAPS spans several diff
+    lines on one side: the first matches PUB_ITEM_RE, the continuations
+    (`    chunks: &[S],`, `) -> R {`) do not. We REASSEMBLE the wrapped signature
+    by appending same-sign (`+`/`-`) continuation lines until this item KIND's
+    terminator (`{` body for fn/struct/enum/trait, else `;`) is seen at depth 0,
+    then normalise the whole thing (normalize_signature) so
+    it collapses to the SAME key as the unwrapped one-liner. This stops a pure
+    reformat from reading as a public-surface change (false-positive, tripped
+    #469 — bead sq-5x2i).
+
+    Each returned string is the wrap-invariant canonical key, so an identical
+    signature that is both added and removed (a pure relocation / re-indentation /
+    re-wrap) compares equal across the two lists. File headers (`+++ b/…`,
+    `--- a/…`) and the hunk header (`@@ … @@`) are skipped — they are never item
+    signatures, and they also break a wrapped run."""
     added: list[str] = []
     removed: list[str] = []
-    for line in diff_lines:
-        if line.startswith("+++") or line.startswith("---"):
+    i = 0
+    n = len(diff_lines)
+    while i < n:
+        line = diff_lines[i]
+        if (
+            line.startswith("+++")
+            or line.startswith("---")
+            or not PUB_ITEM_RE.match(line)
+        ):
+            i += 1
             continue
-        if not PUB_ITEM_RE.match(line):
-            continue
-        norm = " ".join(line[1:].split())
-        (added if line[0] == "+" else removed).append(norm)
+        sign = line[0]
+        acc = line[1:]
+        kind = _item_kind(acc)
+        i += 1
+        # Gather wrapped continuation lines: same sign, not a header/hunk line,
+        # until the signature is structurally complete (this item KIND's
+        # terminator at depth 0).
+        while not _signature_complete(acc, kind) and i < n:
+            cont = diff_lines[i]
+            if not cont or cont[0] != sign or cont.startswith(("+++", "---")):
+                break
+            acc += " " + cont[1:]
+            i += 1
+        (added if sign == "+" else removed).append(normalize_signature(acc))
     return added, removed
 
 

--- a/scripts/tests/test_gates.py
+++ b/scripts/tests/test_gates.py
@@ -217,6 +217,127 @@ class G2Test(unittest.TestCase):
         added2, removed2 = g2._scan_pub_diff(diff2)
         self.assertNotEqual(sorted(added2), sorted(removed2))
 
+    def test_rustfmt_line_wrap_does_not_trip(self):
+        # [OPUS-4.8] REGRESSION (false-positive, tripped #469 — bead sq-5x2i): a
+        # one-shot `cargo fmt` LINE-WRAPS a long `pub fn` signature. The diff
+        # REMOVES the single-line form and ADDS the multi-line wrapped form (same
+        # tokens, only rustfmt whitespace + an inserted trailing comma). The two
+        # must canonicalise EQUAL so a pure reformat is NOT a public-surface change
+        # — no `skill-not-needed` label needed on fmt-only PRs. This is the exact
+        # `compress_chunks` reflow from #469 (crates/sparq-parse/src/lib.rs).
+        diff = [
+            "--- a/crates/sparq-parse/src/lib.rs",
+            "+++ b/crates/sparq-parse/src/lib.rs",
+            "@@ -40,7 +40,12 @@",
+            "-pub fn compress_chunks<S: AsRef<[u8]> + Sync>(chunks: &[S], codec: "
+            "&Codec, mode: Mode) -> io::Result<Vec<Vec<u8>>> {",
+            "+pub fn compress_chunks<S: AsRef<[u8]> + Sync>(",
+            "+    chunks: &[S],",
+            "+    codec: &Codec,",
+            "+    mode: Mode,",
+            "+) -> io::Result<Vec<Vec<u8>>> {",
+            "     match mode {",
+        ]
+        added, removed = g2._scan_pub_diff(diff)
+        self.assertEqual(sorted(added), sorted(removed))  # reflow cancels out
+        self.assertFalse(g2._pad.diff_has_net_pub_change(diff))
+
+    def test_rustfmt_unwrap_does_not_trip(self):
+        # [OPUS-4.8] The symmetric direction: rustfmt UN-wraps a previously wrapped
+        # signature (removes the multi-line form, adds the one-liner). Same key.
+        diff = [
+            "+++ b/crates/sparq-parse/src/lib.rs",
+            "-pub fn gzip_single_member<S: AsRef<[u8]>>(",
+            "-    chunks: &[S],",
+            "-    level: u32,",
+            "-    mode: Mode,",
+            "-) -> io::Result<Vec<Vec<u8>>> {",
+            "+pub fn gzip_single_member<S: AsRef<[u8]>>(chunks: &[S], level: u32, "
+            "mode: Mode) -> io::Result<Vec<Vec<u8>>> {",
+        ]
+        self.assertFalse(g2._pad.diff_has_net_pub_change(diff))
+
+    def test_real_signature_change_still_trips_after_normalize(self):
+        # [OPUS-4.8] Normalisation must NOT mask a GENUINE signature change: if a
+        # param TYPE actually changes (Mode -> FastMode), the wrapped-added key
+        # differs from the one-line-removed key and the gate still fires.
+        diff = [
+            "+++ b/crates/sparq-parse/src/lib.rs",
+            "-pub fn compress_chunks<S: AsRef<[u8]> + Sync>(chunks: &[S], codec: "
+            "&Codec, mode: Mode) -> io::Result<Vec<Vec<u8>>> {",
+            "+pub fn compress_chunks<S: AsRef<[u8]> + Sync>(",
+            "+    chunks: &[S],",
+            "+    codec: &Codec,",
+            "+    mode: FastMode,",
+            "+) -> io::Result<Vec<Vec<u8>>> {",
+        ]
+        self.assertTrue(g2._pad.diff_has_net_pub_change(diff))
+
+    def test_wrapped_use_and_const_reflow_cancel(self):
+        # [OPUS-4.8] Wrapping is not fn-only: a long `pub use` re-export and a
+        # `pub const` can reflow too. The `;`/`=` terminators must close the
+        # accumulation and the keys must cancel against the one-line forms.
+        use_diff = [
+            "+++ b/crates/sparq-core/src/lib.rs",
+            "-pub use crate::store::{Alpha, Beta, Gamma, Delta, Epsilon, Zeta};",
+            "+pub use crate::store::{",
+            "+    Alpha, Beta, Gamma, Delta, Epsilon, Zeta,",
+            "+};",
+        ]
+        self.assertFalse(g2._pad.diff_has_net_pub_change(use_diff))
+
+    def test_wrapped_where_clause_reflow_cancels(self):
+        # [OPUS-4.8] rustfmt commonly hoists a `where`-clause onto its own lines
+        # and adds a trailing comma after the last bound — which lands right
+        # before the body `{`. The wrapped and one-line forms must canonicalise
+        # equal (trailing comma before `{` dropped), but a GENUINE bound change
+        # (Send -> Sync) must still trip.
+        reflow = [
+            "+++ b/crates/x/src/a.rs",
+            "-pub fn f<T>(x: T) -> T where T: Clone + Send {",
+            "+pub fn f<T>(x: T) -> T",
+            "+where",
+            "+    T: Clone + Send,",
+            "+{",
+        ]
+        self.assertFalse(g2._pad.diff_has_net_pub_change(reflow))
+        changed = [
+            "+++ b/crates/x/src/a.rs",
+            "-pub fn f<T>(x: T) -> T where T: Clone + Send {",
+            "+pub fn f<T>(x: T) -> T",
+            "+where",
+            "+    T: Clone + Sync,",
+            "+{",
+        ]
+        self.assertTrue(g2._pad.diff_has_net_pub_change(changed))
+
+    def test_wrapped_tuple_struct_reflow_cancels(self):
+        # [OPUS-4.8] A long tuple-struct (terminates at `;`, not a body `{`) that
+        # rustfmt wraps one field per line must also cancel against its one-liner.
+        diff = [
+            "+++ b/crates/x/src/a.rs",
+            "-pub struct P(pub u64, pub u64, pub u64, pub u64, pub u64, pub u64);",
+            "+pub struct P(",
+            "+    pub u64,",
+            "+    pub u64,",
+            "+    pub u64,",
+            "+    pub u64,",
+            "+    pub u64,",
+            "+    pub u64,",
+            "+);",
+        ]
+        self.assertFalse(g2._pad.diff_has_net_pub_change(diff))
+
+    def test_normalize_signature_is_wrap_invariant(self):
+        # [OPUS-4.8] Unit-level: the canonical key is identical for the one-line
+        # and wrapped forms (whitespace stripped + trailing comma dropped).
+        one = "pub fn f<T: Clone>(a: T, b: T) -> Vec<T> {"
+        wrapped = "pub fn f<T: Clone>( a: T, b: T, ) -> Vec<T> {"
+        self.assertEqual(
+            g2._pad.normalize_signature(one),
+            g2._pad.normalize_signature(wrapped),
+        )
+
     def test_pub_item_regex_matches_all_item_forms_excludes_restricted(self):
         # [OPUS-4.8] The pub-item pattern must match every exported FORM
         # (fn/struct/enum/trait/const/type/mod/use) but NOT restricted


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Closes bead **sq-5x2i**.

## What

The G2 public-api→SKILL gate (`scripts/gate-api-skill.py`, via the shared `scripts/pub_api_diff.py` that the reactive `scripts/flow-on.py` also imports) was **line-text-based**: each unified-diff line was scanned independently for a `pub `-item signature, normalised with only `" ".join(line.split())`, and the added/removed signature **multisets** were compared.

A one-shot `cargo fmt` that **line-wraps** a long `pub fn` signature REMOVES the single-line form and ADDS the multi-line wrapped form — *same tokens*, only rustfmt whitespace plus an inserted trailing comma:

```
-pub fn compress_chunks<S: AsRef<[u8]> + Sync>(chunks: &[S], codec: &Codec, mode: Mode) -> io::Result<Vec<Vec<u8>>> {
+pub fn compress_chunks<S: AsRef<[u8]> + Sync>(
+    chunks: &[S],
+    codec: &Codec,
+    mode: Mode,
+) -> io::Result<Vec<Vec<u8>>> {
```

The wrapped **first** line matched the pub-item pattern but its **continuation** lines did not, so the removed multiset held the full signature while the added multiset held only `pub fn compress_chunks…(` → the two differed → the reformat read as a **public-surface change**. This is a false positive: it **tripped #469** (the `sparq-serve`/`sparq-parse` one-shot rustfmt) and forced a `skill-not-needed` label on a pure-formatting PR.

## Fix

`scan_pub_diff` now **reassembles** a wrapped signature: when a line matches the pub-item pattern it appends same-sign (`+`/`-`) continuation lines until the item **kind's terminator** is reached at `()`/`[]` depth 0 — the body `{` for `fn`/`struct`/`enum`/`trait`, otherwise `;` (so a `pub use a::{B, C};` group brace is *not* mistaken for a body brace). The reassembled text is canonicalised by `normalize_signature`: strip **all** whitespace and drop any comma immediately before a closing delimiter (`)`/`]`/`>`/`}` and the body-opening `{`, which is where rustfmt's wrapped `where T: Bound,` lands its trailing comma).

rustfmt's *only* token-level change when wrapping is that trailing comma; everything else is pure whitespace. So the wrapped and single-line forms now produce the **identical** multiset key → a pure reformat is net-zero (no skill-not-needed label needed on fmt-only PRs), **while a genuine signature change** (a param/bound/return type that actually differs) still produces a differing key and still trips the gate.

Verified end-to-end against the **real #469 reflow diff** (`git show 2fd582e -- crates/sparq-parse/src/lib.rs`): added and removed keys are identical → `diff_has_net_pub_change == False`.

## Tests

6 new G2 regression cases in `scripts/tests/test_gates.py`:
- `pub fn` wrap (the #469 `compress_chunks` reflow) and the symmetric un-wrap → cancel
- a **real** param-type change amid a reflow (`Mode` → `FastMode`) → still trips
- `where`-clause hoist + trailing comma → cancels; a genuine bound change (`Send` → `Sync`) → trips
- long tuple-struct wrapped one-field-per-line → cancels
- long `pub use` group import wrapped → cancels
- `normalize_signature` wrap-invariance unit check

## Gate (green)

- CI/scripts-only change — no Rust crate, **no public API change**, so the Rust build/clippy/feature-state gate and the G2 SKILL.md author rule do not apply.
- `python3 scripts/tests/test_gates.py` (the exact CI invocation): exit 0.
- Full `scripts/tests/` suite: **157 passing** (incl. `test_flow_on.py`, the reactive consumer of the shared module).
- **Privacy-claims gate** (predicate-form soundness included): 32 passing.

[OPUS-4.8] — authored by Opus 4.8 (Fable unavailable); flagged for re-review when Fable returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)