### PR TITLE
ci(sq-czlh): reuse ci-free-disk.sh in asan/fuzz/coverage heavy lanes

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -104,6 +104,14 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # [OPUS-4.8] sq-czlh: reclaim ~20-30 GB of pre-installed SDKs/toolchains BEFORE the
+      # heavy build. -Zbuild-std recompiles the ENTIRE standard library under ASan
+      # instrumentation into a distinct target tree, on a runner that starts with only
+      # ~14 GB free on `/` — exactly the `No space left on device` profile sq-c76x fixed in
+      # the load-aware test lane. Same in-repo, SHA-pin-free, best-effort step (absent paths
+      # no-op). See scripts/ci-free-disk.sh.
+      - name: Free runner disk before build
+        run: ./scripts/ci-free-disk.sh
       # ASan via -Zsanitizer ships ONLY on nightly. Pin the nightly channel by DATE so the
       # lane is reproducible and a future nightly regression cannot silently break it; bump
       # the date deliberately (same pinned dtolnay action + nightly date as miri.yml /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -799,6 +799,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # [OPUS-4.8] sq-czlh: reclaim ~20-30 GB of pre-installed SDKs/toolchains BEFORE the
+      # instrumented build. cargo-llvm-cov compiles the workspace per-crate with coverage
+      # instrumentation AND writes a `.profraw` per test, on a runner that starts with only
+      # ~14 GB free on `/` — the same `No space left on device` profile sq-c76x fixed in the
+      # load-aware test lane. Same in-repo, SHA-pin-free, best-effort step (absent paths
+      # no-op). See scripts/ci-free-disk.sh.
+      - name: Free runner disk before build + instrumented test
+        run: ./scripts/ci-free-disk.sh
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
@@ -885,6 +893,15 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # [OPUS-4.8] sq-czlh: reclaim ~20-30 GB of pre-installed SDKs/toolchains BEFORE the
+      # FULL-tier instrumented build. This nightly job adds the heavy sparq-vectors 50k
+      # recall/diskann tests on top of the per-crate llvm-cov instrumentation + per-test
+      # `.profraw`, so it is the most disk-hungry coverage run — and the runner still starts
+      # with only ~14 GB free on `/` (the `No space left on device` profile sq-c76x fixed in
+      # the load-aware test lane). Same in-repo, SHA-pin-free, best-effort step (absent paths
+      # no-op). See scripts/ci-free-disk.sh.
+      - name: Free runner disk before build + instrumented test
+        run: ./scripts/ci-free-disk.sh
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -70,6 +70,14 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # [OPUS-4.8] sq-czlh: reclaim ~20-30 GB of pre-installed SDKs/toolchains BEFORE the
+      # cargo-fuzz build. Each libFuzzer/sancov-instrumented target links a sanitizer
+      # runtime + its own `fuzz/target` tree, on a runner that starts with only ~14 GB free
+      # on `/` — the same `No space left on device` profile sq-c76x fixed in the load-aware
+      # test lane. Same in-repo, SHA-pin-free, best-effort step (absent paths no-op). See
+      # scripts/ci-free-disk.sh.
+      - name: Free runner disk before build
+        run: ./scripts/ci-free-disk.sh
       # cargo-fuzz REQUIRES nightly (libFuzzer sancov codegen / `-Zsanitizer`). Pin the
       # nightly channel by date so the lane is reproducible and a future nightly
       # regression cannot silently break it; bump the date deliberately.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Re-review when Fable returns (authored on Opus 4.8 while Fable was unavailable; carries `[OPUS-4.8]` markers).

## What

Implements bead **sq-czlh**: reuse `scripts/ci-free-disk.sh` in the other heavy `ubuntu-latest` lanes that build the full workspace (or an instrumented variant) and can hit `No space left on device`.

`#461` / `sq-c76x` added `scripts/ci-free-disk.sh` to reclaim ~20-30 GB of pre-installed SDKs/toolchains (the stock `ubuntu-latest` runner ships only ~14 GB free on `/`) and **deliberately scoped it to the load-aware test lane only**, to limit blast radius. This PR extends the same reclaim to the remaining heavy lanes:

| Lane | Why it is disk-hungry |
|------|-----------------------|
| `asan.yml` | `-Zbuild-std` recompiles the **entire** standard library under ASan into a distinct instrumented target tree |
| `fuzz.yml` | each `cargo-fuzz` / libFuzzer target links a sanitizer runtime + its own `fuzz/target` tree |
| `ci.yml` → `coverage` | `cargo-llvm-cov` instruments the workspace per-crate and writes a `.profraw` per test |
| `ci.yml` → `coverage-nightly` | the FULL tier additionally runs the heavy `sparq-vectors` 50k recall/diskann suites — the most disk-hungry coverage run |

Each adds the **same** in-repo, SHA-pin-free, best-effort `Free runner disk` step immediately after `checkout` (absent paths no-op; never touches the checkout). `miri.yml` / `kani.yml` are intentionally **out of scope** — the bead names only asan/fuzz/coverage.

## Why this is safe

- No new third-party action, so the SHA-pin / Scorecard posture is unchanged (the reclaim is in-repo and pinned-by-definition).
- The script is `set -uo pipefail` + every removal is `|| true` and existence-guarded, so a runner-image drift can never abort the build.
- **No Rust code, public API, or privacy/ZK surface is touched** — pure CI plumbing, so the G2 public-api→`SKILL.md` rule and the privacy-claims gate are N/A by construction.

## Gate

- YAML parse: `asan.yml`, `fuzz.yml`, `ci.yml` all `yaml.safe_load` clean.
- `shellcheck scripts/ci-free-disk.sh`: clean (script unchanged — reused as-is).
- No Rust crate changed → the cargo build/clippy/test-in-both-feature-states gate does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
