### PR TITLE
docs(sparq-fedplan): sweep residual private_intra_doc_links on descriptor.rs:321 (sq-qik4)

### DIFF
--- a/crates/sparq-fedplan/src/descriptor.rs
+++ b/crates/sparq-fedplan/src/descriptor.rs
@@ -494,6 +494,20 @@ fn is_subset(a: &[String], b: &[String]) -> bool {
 mod tests {
     use super::*;
 
+    // [OPUS-4.8] sq-qik4: `SourceDescriptorBuilder` is the return type of the PUBLIC
+    // `SourceDescriptor::builder` and the link target of `from_void_nt`'s doc, so it must be a
+    // nameable crate-level public item. Referencing it through `crate::` (NOT `super::`) makes a
+    // future drop of the re-export a compile error here — not just a residual `cargo doc` warning.
+    #[test]
+    fn builder_type_is_publicly_nameable() {
+        let b: crate::SourceDescriptorBuilder =
+            SourceDescriptor::builder(SourceId::new("http://s/"));
+        // The builder method named in `from_void_nt`'s doc opts the descriptor into complete
+        // authorities; the built descriptor must then report `authorities_complete() == true`.
+        let d = b.authorities_complete().build();
+        assert!(d.authorities_complete());
+    }
+
     #[test]
     fn authority_extraction() {
         assert_eq!(

--- a/crates/sparq-fedplan/src/lib.rs
+++ b/crates/sparq-fedplan/src/lib.rs
@@ -122,6 +122,12 @@ adaptive re-planning (`AdaptiveExecutor`) is behind the further `adaptive-replan
 // denying it keeps the existing build/clippy/test gates untouched while making a future broken
 // crate-doc link a hard `cargo doc` error in EITHER feature state.
 #![deny(rustdoc::broken_intra_doc_links)]
+// [OPUS-4.8] sq-qik4: also lock in the *private*-link invariant. This is a SEPARATE rustdoc lint
+// from `broken_intra_doc_links` (#474) — it fires when a PUBLIC item's doc links to a private
+// item. `from_void_nt`'s doc links to `SourceDescriptorBuilder::authorities_complete`; once the
+// builder is re-exported (above), that target is public, so this deny is clean. Denying it makes a
+// future public→private doc link a hard `cargo doc` error rather than a silently-residual warning.
+#![deny(rustdoc::private_intra_doc_links)]
 #![cfg_attr(not(feature = "fedplan"), allow(dead_code, unused_imports))]
 
 // [OPUS-4.8] sq-7s4z: live adaptive mid-execution re-planning. Gated behind the
@@ -140,9 +146,16 @@ mod selection;
 #[cfg(feature = "fedplan")]
 mod stream;
 
+// [OPUS-4.8] sq-qik4: re-export `SourceDescriptorBuilder` too. It is the return type of the
+// PUBLIC `SourceDescriptor::builder` and the link target of `from_void_nt`'s doc, so leaving it
+// un-exported (a) leaked a public method returning an unnameable type and (b) tripped the residual
+// `rustdoc::private_intra_doc_links` warning (the link resolved to a `pub` item reachable only
+// through the private `descriptor` module). Re-exporting it closes both: the link now points at a
+// genuinely public item. Separate from the #474 `broken_intra_doc_links` gate (a method-doc lint).
 #[cfg(feature = "fedplan")]
 pub use descriptor::{
-    CharSet, ClassPartition, PredPartition, SourceDescriptor, SourceId, CS_NS, VOID_NS,
+    CharSet, ClassPartition, PredPartition, SourceDescriptor, SourceDescriptorBuilder, SourceId,
+    CS_NS, VOID_NS,
 };
 #[cfg(feature = "fedplan")]
 pub use pattern::{Bgp, Term, TriplePattern, Var};

--- a/skills/federated-planning/SKILL.md
+++ b/skills/federated-planning/SKILL.md
@@ -35,7 +35,9 @@ depends on `sparq-fedplan` pays nothing for it unless the feature is enabled.
 Either programmatically via the builder, or by parsing the served N-Triples document.
 
 ```rust
-use sparq_fedplan::{SourceDescriptor, SourceId, PredPartition, ClassPartition};
+// `SourceDescriptorBuilder` is the (public, nameable) return type of `.builder(..)`; you only
+// need to import it if you hold the builder in a `let` rather than chaining straight to `.build()`.
+use sparq_fedplan::{SourceDescriptor, SourceDescriptorBuilder, SourceId, PredPartition, ClassPartition};
 
 // Programmatic (VoID property/class partitions).
 let src = SourceDescriptor::builder(SourceId::new("https://a.example/sparql"))


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Flagged for review.

## What & why (sq-qik4)

`SourceDescriptor::from_void_nt`'s doc (`crates/sparq-fedplan/src/descriptor.rs:321`) links to
`SourceDescriptorBuilder::authorities_complete`. `SourceDescriptorBuilder` is `pub` but lived in
the **private** `mod descriptor` and was **never re-exported**, so it was reachable only through a
private path. rustdoc treated the link target as private and emitted a residual
`rustdoc::private_intra_doc_links` warning (fedplan-ON build only):

```
warning: public documentation for `from_void_nt` links to private item
         `SourceDescriptorBuilder::authorities_complete`
   --> crates/sparq-fedplan/src/descriptor.rs:321:11
```

This is a **method-doc lint, separate from the #474 `broken_intra_doc_links` gate**. It was also a
genuine public-API hole: the PUBLIC `SourceDescriptor::builder` returns `SourceDescriptorBuilder`,
a type callers could not name.

## Fix (smallest correct)

- **Re-export `SourceDescriptorBuilder`** from the crate root (`lib.rs`). The doc-link target is
  now genuinely public and the leaked return type is nameable — closes both issues. Strictly better
  than `#[allow(...)]`, which would suppress the warning but leave the API leak.
- **`#![deny(rustdoc::private_intra_doc_links)]`** alongside the existing broken-link deny. This is
  a rustdoc-only lint (fires under `cargo doc`, never under build/clippy/test), so the existing
  gates are untouched; a future public→private doc link becomes a hard `cargo doc` error rather
  than a silently-residual warning. Verified load-bearing: removing the re-export makes `cargo doc`
  hard-error (rc 101), not just warn.
- **Test `builder_type_is_publicly_nameable`** names the type via `crate::` (not `super::`) so a
  future drop of the re-export is a compile error here, not merely a doc warning.
- **SKILL.md**: noted the now-public builder type (proactive docs; `sparq-fedplan` is
  `publish = false` so the G2 api→SKILL gate does not require it, but the surface is documented).

## Gate

- `cargo doc --no-deps` clean (no warnings/errors) in **all three** feature states: default (OFF),
  `fedplan`, `adaptive-replan`.
- `cargo build` + `cargo clippy --all-targets -- -D warnings` + `cargo test` pass in **all three**
  states (33 lib tests with `fedplan`, 49 with `adaptive-replan`, incl. the new test; 0 with OFF as
  the crate is empty).
- `cargo fmt --check` clean on every touched line. (Pre-existing fmt drift in `adaptive.rs` and on
  `lib.rs`'s `#![forbid(unsafe_code)]` line is on `origin/main` already and untouched here.)
- `scripts/check-privacy-claims.sh`: OK (no privacy/soundness predicate logic changed — the
  recall-safety / pruning-soundness claims are unchanged).
- `scripts/gate-api-skill.py` (G2): PASS.

[OPUS-4.8] sq-qik4 — flagged for Fable re-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)