### PR TITLE
docs(sparq-reason-wasm): reproducible bundle-size recipe, drop non-reproducible perf figure (sq-75hm)

### DIFF
--- a/crates/sparq-reason-wasm/README.md
+++ b/crates/sparq-reason-wasm/README.md
@@ -76,6 +76,25 @@ The build is single-threaded (no rayon) and pure-Rust. The reasoner's `regex` de
 are the bundle-size consideration the design flags, which is why this bundle is lazy-loaded
 on its page only and built `-Oz`.
 
+### Measuring the bundle size
+
+<!-- [OPUS-4.8] sq-75hm: replaces the non-reproducible "~2.3 MB pre-gzip" figure that lived
+     in PR #421's body with a reproducible measurement recipe (no hard-coded perf in markdown). -->
+We deliberately do **not** quote a hard-coded byte/MB figure here — bundle size drifts with
+the toolchain (`rustc`, `wasm-bindgen`, `wasm-opt`) and dependency versions, so any number in
+this file would silently rot. To get a reproducible figure for your toolchain, build and
+measure the emitted `.wasm` directly:
+
+```sh
+wasm-pack build crates/sparq-reason-wasm --target web --release   # add `-- --features explain` for the why() variant
+f=crates/sparq-reason-wasm/pkg/sparq_reason_wasm_bg.wasm
+echo "pre-gzip: $(stat -c%s "$f") bytes   gzip -9: $(gzip -9 -c "$f" | wc -c) bytes (this is the over-the-wire transfer size)"
+```
+
+The `regex` automata dominate the binary, which is why the bundle is `-Oz`-optimised and
+lazy-loaded on its page only. The gzip figure — not the pre-gzip one — is what end users
+actually download, since the showcase site serves the `.wasm` gzip-compressed.
+
 ## Status / what remains
 
 This crate delivers the wasm-compatibility changes, the `Reasoner` entry points, the `why()`


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **bead sq-75hm** — `sparq-reason-wasm` PR #421's body cited the lean bundle as **"~2.3 MB pre-gzip"** as a measured figure, but that number is non-reproducible: it lived only in the PR body (immutable GitHub history) and was never carried into any tracked markdown. Markdown hygiene rule: **no hard-coded perf numbers in markdown**.

## What this does (docs-only)

Adds a **"Measuring the bundle size"** section to `crates/sparq-reason-wasm/README.md` that:

- **Declines to bake a fragile byte/MB figure into markdown** — bundle size drifts with the toolchain (`rustc` / `wasm-bindgen` / `wasm-opt`) and dependency versions, so any quoted number silently rots.
- Gives a **copy-paste recipe** to build and measure the emitted `.wasm` **pre-gzip and gzip-9** on demand, and clarifies that the **gzip** figure — not pre-gzip — is the real over-the-wire transfer size (the showcase site serves the `.wasm` gzip-compressed).

The README already described the bundle-size consideration qualitatively ("the regex automata are the bundle-size consideration the design flags"); this makes the size claim **self-service-verifiable** rather than a stale quote.

## Honest re-measurement (not committed to markdown)

I rebuilt the bundle on this worktree's toolchain (wasm-pack 0.13.1, `wasm-opt -Oz`) to verify the PR-body claim:

| variant | pre-gzip | gzip -9 |
| --- | --- | --- |
| lean (default) | 2.27 MiB | ~830 KiB |
| `--features explain` (why() proof trees) | 2.44 MiB | ~882 KiB |

So "~2.3 MB pre-gzip" was **directionally right** but stated without a binary/decimal basis, a build command, or a toolchain pin — i.e. not reproducible from the repo. These numbers are recorded here in the PR for the reviewer; the README deliberately carries the **recipe**, not the figure.

## Scope / honesty

- **Docs-only.** No Rust source or public-API change — G2 (public-api → SKILL.md) not triggered; no `cargo build`/`clippy`/tests required.
- The `~2.3 MB` text in PR #421's body is immutable git/GitHub history and is **not** edited (nor should it be); the fix targets the durable markdown surface.
- **Follow-up (not this PR):** the perf ratchet's `wasm_bundle_bytes` metric (`bench/perf-baseline.json`) tracks only the **lean `sparq-wasm` triplestore bundle**. Adding the `sparq-reason-wasm` bundle to the cross-commit ratchet needs `scripts/ci-bench.sh` / `bench.yml` plumbing and is a separate, larger change.

## Gate (docs/markdown lints + mandatory privacy gate)

- `typos` (changed README) — clean
- `scripts/check-privacy-claims.sh` — OK (277 files scanned; predicate-form soundness included)
- `scripts/check-no-perf-numbers.py --enforce crates/sparq-reason-wasm/README.md` — **0 findings**
- `markdownlint-cli2@0.18.1` (HARD `.markdownlint-cli2.jsonc` config) — **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
