### PR TITLE
test(sparq-nlq): CI-gate the live-session regression-set round-trip (sq-g0lw)

### DIFF
--- a/crates/sparq-nlq/README.md
+++ b/crates/sparq-nlq/README.md
@@ -142,11 +142,12 @@ It reports the two axes the design doc requires **separately**:
 `Comparison::headline_grounding_pays()` is the load-bearing check: grounded end-to-end
 macro-F1 **>** the *same LLM* ungrounded ("the grounding must pay for itself").
 
-Three layers, the first two run in CI with **no network**:
+Four layers, the first three run in CI with **no network**:
 
 | Layer | What | Runs in CI? |
 |---|---|---|
 | `harness_demonstrates_grounding_pays_in_memory` | tiny in-memory graph + scripted backends (a grounded model that answers from the deck; an ungrounded one that hallucinates a predicate) — proves the harness and the headline inequality | yes, always |
+| `recorded_session_saves_and_replays_as_regression_set` | the **regression-set round-trip**: record a session, `RecordingLlm::save` it to disk in the `live_session_*.json` format, reload via `ReplayLlm::from_file`, re-score through `run_config` — and assert the scores are identical. Proves a saved live session replays faithfully (so "commit the recorded session as the regression set" is sound) | yes, always |
 | `olympics_exec_accuracy_replay` | answer-F1 on the real 1.78M-triple olympics dataset via the committed `ReplayLlm` fixture + oracle linking | yes, **skip-if-absent** dataset |
 | `live_exec_accuracy` | the real measurement: a live model via `--features live` + `RecordingLlm`, records replay fixtures, asserts the inequality | **no** — `#[cfg(feature = "live")]` **and** `#[ignore]`'d |
 
@@ -171,7 +172,12 @@ ANTHROPIC_API_KEY=sk-ant-... SPARQ_OLYMPICS_NT=/path/olympics.nt \
   they demonstrate the *harness* and the *mechanism* of the headline claim, **not** a
   real model's accuracy. The live measurement runs through the same harness with
   `--features live` + `RecordingLlm` (`live_exec_accuracy`, `#[ignore]`'d); after a
-  live run the recorded fixtures become the offline regression set. <!-- [OPUS-4.8] sq-05rv -->
+  live run the recorded sessions become the offline regression set — and that
+  record→`save`→`from_file`→identical-scores round-trip is itself CI-gated by
+  `recorded_session_saves_and_replays_as_regression_set`, so a committed live session
+  is guaranteed replayable. Producing the live *numbers* needs a real key, the olympics
+  dump, and a **canonical** measurement host (not a CI/sandbox box); that run remains
+  the open work of bead `sq-g0lw`. <!-- [OPUS-4.8] sq-05rv sq-g0lw -->
 - **Not yet wired**: entity/relation linking from `sparq-sim` (design §2 phase 3
   lists it as input to grounding; the schema summary alone is enough for the
   olympics-scale schema) — bead `sq-uw40`; and N2 grammar-constrained decoding

--- a/crates/sparq-nlq/tests/exec_accuracy.rs
+++ b/crates/sparq-nlq/tests/exec_accuracy.rs
@@ -27,7 +27,7 @@
 
 use sparq_core::Graph;
 use sparq_nlq::eval::{run_comparison, run_config, EvalCase, Linking};
-use sparq_nlq::{Llm, NlqConfig};
+use sparq_nlq::{Llm, NlqConfig, RecordingLlm, ReplayLlm};
 
 // ---------------------------------------------------------------------------
 // Layer 1 — the offline CI gate: a tiny in-memory graph, scripted backends.
@@ -165,6 +165,109 @@ fn empty_gold_is_a_true_negative() {
     );
     assert_eq!(report.macro_f1, 1.0, "empty==empty is a true negative");
     assert_eq!(report.exact_match, 1.0);
+}
+
+/// The **regression-set contract** the live run depends on (bead sq-g0lw, follow-up
+/// to sq-05rv): a recorded session, once written to disk in the on-disk fixture format
+/// `live_exec_accuracy` uses (`RecordingLlm::save` → `tests/fixtures/live_session_
+/// {i}.json`), must reload via `ReplayLlm::from_file` and re-score **identically**
+/// through the very same exec-accuracy harness (`run_config`). That round-trip is what
+/// makes "commit the recorded session as the regression set" honest — without it, a
+/// live run could write a fixture the offline gate cannot faithfully replay.
+///
+/// Proven OFFLINE. The live measurement itself needs `ANTHROPIC_API_KEY` + network +
+/// the 1.78M-triple olympics dump (none of which CI has), and per project policy a
+/// live run from a non-canonical box must NOT bake numbers into committed fixtures. So
+/// the live API is substituted by the same deterministic grounded backend the CI gate
+/// already uses; what is exercised is the *mechanism* (record → save-to-disk → reload
+/// → identical harness scores), not a real model's accuracy.
+#[test]
+fn recorded_session_saves_and_replays_as_regression_set() {
+    use std::rc::Rc;
+
+    let g = tiny_graph();
+    let cases = cases();
+    let cfg = NlqConfig::default();
+
+    // 1. Record a grounded session through the SAME `run_config` harness the live run
+    //    drives — the recorder wraps the deterministic backend exactly as
+    //    `RecordingLlm<AnthropicLlm>` wraps the live client. `Rc` keeps a handle to the
+    //    recorder after `run_config` takes ownership of its `Box<dyn Llm>` (an `Rc<L>`
+    //    is itself `Llm`), mirroring `live_exec_accuracy`'s recorder bookkeeping.
+    let recorder = Rc::new(RecordingLlm::new(FnLlm(|prompt: &str| {
+        grounded_completion(prompt)
+            .ok_or_else(|| format!("no scripted grounded answer for {prompt:?}"))
+    })));
+    let recorded_report = run_config(
+        &g,
+        &cases,
+        Box::new(Rc::clone(&recorder)),
+        cfg.clone(),
+        Linking::EndToEnd,
+    );
+    assert_eq!(
+        recorded_report.macro_f1, 1.0,
+        "the recorded grounded session answers all tiny-graph cases"
+    );
+    assert!(
+        !recorder.exchanges().is_empty(),
+        "the session recorded at least one (prompt, completion) pair"
+    );
+
+    // 2. Persist it exactly as `live_exec_accuracy` does — to disk, in the committed
+    //    `Exchange[]` JSON format — then reload through the public file API.
+    let path = std::env::temp_dir().join(format!(
+        "sparq_nlq_live_session_{}_{}.json",
+        std::process::id(),
+        // distinguish concurrent test binaries sharing the temp dir.
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    ));
+    recorder.save(&path).expect("save the recorded session");
+
+    // The on-disk shape IS the committed fixture format (a JSON array of
+    // {prompt, completion}) — same contract as `olympics_replay.json`.
+    let on_disk = std::fs::read_to_string(&path).expect("read back the saved session");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&on_disk).expect("saved session is valid JSON");
+    assert!(parsed.is_array(), "fixture is a JSON array of exchanges");
+    assert!(
+        parsed[0].get("prompt").is_some() && parsed[0].get("completion").is_some(),
+        "each exchange carries a prompt and a completion"
+    );
+
+    let reloaded = ReplayLlm::from_file(&path).expect("saved session reloads as a fixture");
+    assert_eq!(
+        reloaded.len(),
+        recorder.exchanges().len(),
+        "every recorded exchange survives the disk round-trip"
+    );
+
+    // 3. Re-score the SAME cases through the SAME `run_config` harness, now driven by
+    //    the reloaded fixture. The regression set is faithful iff the scores match.
+    let replay_report = run_config(
+        &g,
+        &cases,
+        Box::new(reloaded),
+        cfg.clone(),
+        Linking::EndToEnd,
+    );
+    assert_eq!(
+        replay_report.macro_f1, recorded_report.macro_f1,
+        "replayed regression set must reproduce the recorded macro-F1"
+    );
+    assert_eq!(
+        replay_report.exact_match, recorded_report.exact_match,
+        "replayed regression set must reproduce the recorded exact-match"
+    );
+    assert_eq!(
+        replay_report.validity, recorded_report.validity,
+        "replayed regression set must reproduce the recorded validity"
+    );
+
+    let _ = std::fs::remove_file(&path); // hygiene: leave no scratch fixture behind.
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/genai-retrieval/SKILL.md
+++ b/skills/genai-retrieval/SKILL.md
@@ -277,8 +277,11 @@ oracle-vs-end-to-end and grounded-vs-ungrounded reporting, the inequality — **
 real model's accuracy numbers. Those come from a `live_exec_accuracy` run (`--features
 live` + `RecordingLlm`, which needs a key + network + dataset); that test is `#[ignore]`'d
 and feature-gated **OFF**, so a model or network outage can never red the build. After a
-live run the recorded fixtures become the offline regression set. (No claim is made here
-about NL→SPARQL quality beyond what the fixtures encode.)
+live run the recorded sessions become the offline regression set — and the
+record→`save`→`from_file`→identical-scores round-trip that makes them a *faithful*
+regression set is itself CI-gated (`recorded_session_saves_and_replays_as_regression_set`
+in `tests/exec_accuracy.rs`). (No claim is made here about NL→SPARQL quality beyond what
+the fixtures encode.)
 
 ## Gotchas / feature flags / prerequisites
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change for bead **sq-g0lw**. @jeswr runs multiple agents on one account; this is one of them.

## What & why

Bead **sq-g0lw** (follow-up to **sq-05rv**) asks for two things: run the real-model `live_exec_accuracy` harness, **and** commit the recorded sessions as the regression set.

**Honest scope split.** The live *numbers* cannot be produced here:
- no `ANTHROPIC_API_KEY` (env unset; the API returns `401`),
- no olympics dataset present (git-ignored ~1.78M-triple downloaded fixture),
- and per project policy this work box yields **non-canonical** measurements that must **not** be baked into committed fixtures.

Fabricating or committing "live" fixtures from this box would be an overclaim, so that half is tracked as a follow-up bead (**sq-qidj**: run it on a canonical host with a real key + the pinned dump).

**What this PR ships** is the part the live run silently depends on but was never tested: the **regression-set round-trip**. The `live_exec_accuracy` test does `RecordingLlm::save(...) → tests/fixtures/live_session_{i}.json`, and the offline gate later expects `ReplayLlm::from_file(...)` to replay those. Nothing proved that round-trip is faithful — i.e. that a saved session re-scores identically through the harness. Without it, *"commit the recorded session as the regression set"* is unsound.

## Change

- **`crates/sparq-nlq/tests/exec_accuracy.rs`** — new offline test `recorded_session_saves_and_replays_as_regression_set`: records a grounded session through the **same `run_config` harness** the live run drives (recorder wrapped in `Rc`, mirroring `live_exec_accuracy`'s `RecordingLlm<AnthropicLlm>`), `save`s it to a temp `live_session_*.json`, asserts the on-disk shape is the committed `Exchange[]` format, reloads via `ReplayLlm::from_file`, and asserts **macro-F1 / exact-match / validity are bit-identical**. Deterministic, no key, no dataset; cleans up its scratch file (repo's `temp_dir()` convention — no `tempfile` dep).
- **`README.md` / `skills/genai-retrieval/SKILL.md`** — document the now-CI-gated round-trip; keep the honest status explicit: live-model *numbers* remain unmeasured (open work, sq-qidj); only the harness/mechanism is validated.

No production code changed — this is a test + docs PR that locks the regression-set contract.

## Gate

- `cargo fmt -p sparq-nlq --check` ✓
- `cargo clippy -p sparq-nlq --all-targets -- -D warnings` ✓ (default) and `--features live` ✓
- `cargo test -p sparq-nlq` ✓ in **both** feature states; `live_exec_accuracy` stays `#[cfg(feature="live")]` + `#[ignore]`'d (never calls the network in CI)
- No public-API change → G2 SKILL rule n/a (SKILL doc refreshed anyway for currency)
- No privacy/soundness predicate surface touched → privacy-claims gate vacuously satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)