### PR TITLE
bench(fts): wire BEIR IR-quality axis (Recall@100/nDCG@10) gather step + lucene-anserini BM25 oracle (sq-1fz0)

### DIFF
--- a/bench/competitors.json
+++ b/bench/competitors.json
@@ -225,9 +225,10 @@
       "pinned_version": "anserini (pin the exact release/Maven coordinate + Lucene version at gather time)",
       "version_source": "the Anserini release version + bundled Lucene version, recorded in the gather results file.",
       "install_recipe": "Anserini (Apache-2.0) via its fatjar / pyserini, plus a BEIR cut (SciFact or TREC-COVID + qrels) downloaded at gather time. gather-only — NOT committed; the BEIR corpus is NOT redistributable in-repo (see the text-index-bench BEIR follow-up bead).",
-      "run_recipe": "Anserini's OWN IR harness: index the BEIR corpus, run BM25 retrieval against the qrels, report Recall@100 / nDCG@10 + latency. This is the IR-quality oracle for sparq-text's BEIR axis once that axis is wired (currently gather-only).",
+      "run_recipe": "[OPUS-4.8 sq-1fz0] WIRED: scripts/gather-competitors.sh dispatches kind `python-lib` to scripts/bench-adapters/beir_ir_adapter.py — it downloads a BEIR cut + qrels, BM25-retrieves with Anserini/pyserini (k1=1.2/b=0.75), and scores Recall@100 / nDCG@10 as DEFICITS (G4). Run: `BEIR_CUT=scifact scripts/gather-competitors.sh --run --only lucene-anserini` (set SPARQ_TEXT_BEIR=target/release/examples/beir_text to ALSO score sparq-text on the SAME cut+qrels via the same scorer). The IR-quality oracle for sparq-text's BEIR axis; gather-only (corpus not redistributable in-repo).",
       "adapter": {
-        "kind_note": "Lucene/Anserini is a kernel IR sub-component with its own harness (not the shared http-sparql/report-cli path); its results are the BM25 quality oracle, comparable ONLY on the IR-quality axis (Recall@100/nDCG@10), never as a SPARQL benchmark."
+        "kind_note": "Lucene/Anserini is a kernel IR sub-component with its own harness (scripts/bench-adapters/beir_ir_adapter.py, NOT the shared http-sparql/report-cli/vector-lib path); its results are the BM25 quality oracle, comparable ONLY on the IR-quality axis (Recall@100/nDCG@10), never as a SPARQL benchmark.",
+        "dataset_env": "BEIR_CUT (scifact|trec-covid; default scifact), BEIR_K (top-k, default 100), BEIR_DATA_DIR (download cache, default /tmp/beir-data)"
       },
       "comparable_suites": [
         { "sparq_suite": "text-index-bench", "note": "KERNEL-ONLY, IR-quality axis: compare Recall@100/nDCG@10 on the same BEIR cut + qrels. NOT a SPARQL benchmark (no RDF surface) and NOT on the dashboard. Scope to AND/OR/prefix/phrase/slop + BM25 k1=1.2/b=0.75 to stay fair." }

--- a/bench/fts/README.md
+++ b/bench/fts/README.md
@@ -15,10 +15,11 @@ predicates (`text:matches` AND, `text:matchesAny` OR, prefix `foo*`, `text:phras
    near query latency. Per-commit corpus N=100000 (sub-5s); the design's **1M**-literal
    axis is the heavy/latency tier (`bench/fts/gen.sh 1000000`).
 2. **IR-quality axis (BEIR)** — Recall@100 / nDCG@10 on a small BEIR cut (SciFact /
-   TREC-COVID) loaded as RDF literals vs qrels. **Status: GATHER-ONLY, NOT YET WIRED.** The
-   BEIR corpus is not redistributable in-repo, so it is a download-step (gather /
-   nightly), not a committed per-PR gate. Tracked as a follow-up bead (see below); the
-   per-commit gate is the deterministic latency-axis structure below.
+   TREC-COVID) loaded as RDF literals vs qrels, emitted as **deficits** (`1 - metric`,
+   G4). **Status: WIRED as a GATHER/DOWNLOAD step** (sq-1fz0) — see *BEIR IR-quality
+   axis* below. The BEIR corpus is not redistributable in-repo, so it is a download-step
+   (gather / nightly), **not** a committed per-PR gate. The per-PR gate stays the
+   deterministic latency-axis structure below.
 
 ## Data substrate
 
@@ -108,9 +109,43 @@ proximity/slop, BM25 k1=1.2/b=0.75) or it is unfair. A real
 `bench/competitor-results/`; docker-based competitors are inherently gather-only on a Docker
 EC2 box (no Docker on the dev box), so they add zero recurring CI cost.
 
-## Follow-up
+## BEIR IR-quality axis (gather-only, sq-1fz0)
 
-The BEIR IR-quality axis (Recall@100 / nDCG@10 as deficits, G4) is captured as a bead — it
-needs a download/gather step (corpus not redistributable in-repo) before it can become a
-deterministic gate. Until then the per-commit gate is the deterministic latency-axis
-structure (hit counts + `bytes_per_doc`) above.
+The second design axis — **Recall@100 / nDCG@10** on a small BEIR cut (SciFact / TREC-COVID
++ qrels), emitted as **deficits** (`recall_deficit_milli = round((1 - metric) * 1000)`, the
+smaller-is-better G4 shape) — is wired as a **download/gather step**, not a committed gate
+(the BEIR corpus is not redistributable in-repo). It runs on a gather box via the
+`python-lib` adapter kind:
+
+```sh
+pip install pyserini beir                              # heavy IR deps (gather box only)
+# the kernel BM25 ORACLE (lucene-anserini) on a BEIR cut + qrels:
+BEIR_CUT=scifact scripts/gather-competitors.sh --run --only lucene-anserini
+# ALSO score sparq-text on the SAME cut+qrels (apples-to-apples), via the shared scorer:
+cargo build -p sparq-text --release --example beir_text
+BEIR_CUT=scifact SPARQ_TEXT_BEIR=target/release/examples/beir_text \
+  scripts/gather-competitors.sh --run --only lucene-anserini
+```
+
+Both engines are scored by **one** scorer (`scripts/bench-adapters/beir_ir_adapter.py`)
+against the **same** qrels:
+
+- `lucene-anserini` (the kernel BM25 reference, `dashboard_engine_id: null` = **off** the
+  dashboard — it has no RDF/SPARQL surface) BM25-retrieves with Anserini (k1=1.2/b=0.75,
+  matching sparq-text) → its run is the IR-quality **oracle**.
+- `sparq-text` loads the SAME cut as RDF literals (`crates/sparq-text/examples/beir_text.rs`)
+  and retrieves with `TextIndex::search` → a TREC run scored by the same
+  `--score` path. Comparing sparq-text's deficits to the oracle's tells you the
+  IR-quality gap.
+
+The pure scoring half (TREC qrels/run parsers, `recall_at_k`, `ndcg_at_k`, deficit, and the
+sparq-input converters) is **fixture-unit-tested in CI** without pyserini/beir installed
+(`scripts/bench-adapters/test_adapters.py`, fixtures `beir_qrels.txt` / `beir_run.txt`). Each
+gather run writes a git-ignored `bench/competitor-results/<engine>-beir-ir-<cut>-<ts>.json`
+(deficits + env/version); a maintainer reviews it before any dashboard snapshot — numbers
+never land in git automatically (AGENTS.md: no hard-coded perf). These deficits are NOT a
+committed per-PR ratchet in `bench/perf-baseline.json` because the corpus is not present in
+CI to derive an honest floor.
+
+The per-PR gate remains the deterministic latency-axis structure (hit counts +
+`bytes_per_doc`) above.

--- a/crates/sparq-text/examples/beir_text.rs
+++ b/crates/sparq-text/examples/beir_text.rs
@@ -1,0 +1,112 @@
+//! [OPUS-4.8] (sq-1fz0) sparq-text BEIR retrieval driver — the sparq side of the
+//! full-text-search **IR-quality axis** (design §3.4). It loads a BEIR cut's corpus
+//! (as RDF literals) into a sparq `Graph`, builds a BM25 `TextIndex`, retrieves the
+//! top-k documents for each query, and emits a **TREC run file** on stdout.
+//!
+//! That run is scored — Recall@100 / nDCG@10, emitted as DEFICITS (G4) — by the SAME
+//! engine-agnostic scorer the kernel oracle uses:
+//! `scripts/bench-adapters/beir_ir_adapter.py --score --run <this output> --qrels <qrels>`.
+//! Because both sparq-text AND `lucene-anserini` are scored by that one scorer against
+//! the SAME qrels, the comparison is apples-to-apples (design §3.4 fairness note).
+//!
+//! GATHER-ONLY: the BEIR corpus is not redistributable in-repo, so the inputs are
+//! produced on a gather box by `scripts/gather-competitors.sh --run --only lucene-anserini`
+//! (which downloads the cut and converts it to the plain formats below). This example
+//! takes NO JSON dependency — it reads two plain text inputs:
+//!
+//! ```text
+//! cargo run -p sparq-text --release --example beir_text -- <corpus.nt> <queries.tsv> [k] [tag]
+//! ```
+//!
+//!   <corpus.nt>    N-Triples, one document per `<beir:doc:DOCID> <beir:text> "<text>" .`
+//!                  triple (DOCID is the BEIR document id; the object literal is the
+//!                  searchable text). Any other triples are ignored.
+//!   <queries.tsv>  one `DOCID-free` query per line: `<qid>\t<query text>`.
+//!   [k]            top-k to retrieve per query (default 100 — BEIR's Recall@100 depth).
+//!   [tag]          the TREC run tag (default `sparq-text`).
+//!
+//! Output (stdout): TREC run rows `<qid> Q0 <docid> <rank> <score> <tag>`, rank 1-based,
+//! best-first by BM25 score — exactly the format `beir_ir_adapter.py --score` parses.
+
+use std::collections::HashMap;
+
+use oxrdf::Term;
+use sparq_core::Graph;
+use sparq_text::TextIndex;
+
+/// The corpus predicate + the document-id IRI prefix this driver expects (must match
+/// what the gather harness writes). A document is `<PREFIX{docid}> <PRED> "text" .`.
+const DOC_IRI_PREFIX: &str = "beir:doc:";
+
+fn die(msg: &str) -> ! {
+    eprintln!("beir_text: {msg}");
+    std::process::exit(2);
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let corpus_path = args
+        .next()
+        .unwrap_or_else(|| die("usage: beir_text <corpus.nt> <queries.tsv> [k] [tag]"));
+    let queries_path = args
+        .next()
+        .unwrap_or_else(|| die("usage: beir_text <corpus.nt> <queries.tsv> [k] [tag]"));
+    let k: usize = args.next().and_then(|a| a.parse().ok()).unwrap_or(100);
+    let tag = args.next().unwrap_or_else(|| "sparq-text".to_string());
+
+    // ---- load the corpus, recording each searchable literal id -> BEIR docid --------
+    let nt = std::fs::read_to_string(&corpus_path)
+        .unwrap_or_else(|e| die(&format!("read {corpus_path}: {e}")));
+    let (dict, triples) = Graph::parse_to_triples(&nt, "ntriples")
+        .unwrap_or_else(|e| die(&format!("parse {corpus_path}: {e}")));
+
+    // literal object id -> docid (from the subject IRI's `beir:doc:` suffix). A literal
+    // shared by two documents would be ambiguous; BEIR doc texts are distinct, but if a
+    // collision occurs we keep the FIRST (deterministic) and never silently overwrite.
+    let mut doc_of: HashMap<u32, String> = HashMap::new();
+    for [s, _p, o] in &triples {
+        // object must be a string literal to be a searchable document.
+        if !matches!(dict.term(*o), Term::Literal(_)) {
+            continue;
+        }
+        if let Term::NamedNode(n) = dict.term(*s) {
+            if let Some(docid) = n.as_str().strip_prefix(DOC_IRI_PREFIX) {
+                doc_of.entry(*o).or_insert_with(|| docid.to_string());
+            }
+        }
+    }
+    if doc_of.is_empty() {
+        die("no `<beir:doc:DOCID> <pred> \"text\" .` triples found in the corpus");
+    }
+
+    let graph = Graph::from_parts(dict, triples);
+    let index = TextIndex::build(&graph);
+
+    // ---- retrieve top-k per query, emit a TREC run ----------------------------------
+    let queries = std::fs::read_to_string(&queries_path)
+        .unwrap_or_else(|e| die(&format!("read {queries_path}: {e}")));
+    let mut out = String::new();
+    for line in queries.lines() {
+        let line = line.trim_end_matches(['\r', '\n']);
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let (qid, text) = match line.split_once('\t') {
+            Some((q, t)) => (q, t),
+            None => die(&format!(
+                "bad queries.tsv line (want `<qid>\\t<text>`): {line:?}"
+            )),
+        };
+        let hits = index.search(text);
+        let mut rank = 0usize;
+        for hit in hits.iter().take(k) {
+            // Only hits whose literal maps to a BEIR document are part of the run; a hit
+            // on some other literal in the graph (there should be none) is skipped.
+            if let Some(docid) = doc_of.get(&hit.id) {
+                rank += 1;
+                out.push_str(&format!("{qid} Q0 {docid} {rank} {:.6} {tag}\n", hit.score));
+            }
+        }
+    }
+    print!("{out}");
+}

--- a/scripts/bench-adapters/beir_ir_adapter.py
+++ b/scripts/bench-adapters/beir_ir_adapter.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] sq-1fz0: BEIR IR-quality adapter KIND (`python-lib`). Authored by Opus
+# 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# Wires the SECOND axis of the full-text-search suite (design §3.4): IR-quality on a
+# small BEIR cut (SciFact / TREC-COVID + qrels) loaded as RDF literals -> Recall@100 /
+# nDCG@10, emitted as DEFICITS (G4) so they slot into the smaller-is-better mode:"auto"
+# ratchet with zero perf-gate change. The BM25 quality ORACLE is `lucene-anserini`
+# (the EMBEDDED Lucene library via Anserini/pyserini — NOT Solr/ES the servers), run on
+# the SAME BEIR cut + qrels so its Recall@100/nDCG@10 is directly comparable to
+# sparq-text's. lucene-anserini is registered in bench/competitors.json
+# (kind=python-lib, dashboard_engine_id=null = OFF the dashboard — it has no RDF/SPARQL
+# surface; it is the kernel BM25 reference, "sub-component, not an RDF benchmark").
+#
+# WHY GATHER-ONLY (not a committed per-commit gate): the BEIR corpus is NOT
+# redistributable in-repo, so this is a DOWNLOAD step (scripts/gather-competitors.sh
+# --run --only lucene-anserini), not a committed corpus. The light scoring half below
+# is fixture-unit-tested in CI WITHOUT any heavy dep; the heavy half (download + index +
+# retrieve) runs only on a gather box.
+#
+# TWO pieces, separable so CI tests the light half and the gather box runs the heavy
+# half (mirrors vector_lib_adapter.py exactly):
+#   1. SCORING / ORACLE (pure, stdlib-only, fixture-tested):
+#        parse_qrels(text)             TREC qrels  `<qid> 0 <docid> <rel>`  -> {qid:{docid:rel}}
+#        parse_run(text)               TREC run    `<qid> Q0 <docid> <rank> <score> <tag>`
+#                                                  -> {qid:[docid ranked]}
+#        recall_at_k(run, qrels, k)    mean |retrieved_topk ∩ relevant| / |relevant|
+#        ndcg_at_k(run, qrels, k)      mean DCG@k / IDCG@k with GRADED relevance
+#        deficit_milli(metric)         round((1 - metric) * 1000)  (the G4 shape)
+#   2. HEAVY HARNESS (gather-only; needs pyserini + a downloaded BEIR cut):
+#        run_anserini_beir(dataset, k) download the BEIR cut, BM25-index it with
+#                                      Anserini, retrieve top-k, return a TREC run +
+#                                      the qrels -> scored against the SAME qrels.
+#
+# Output (stdout, the python-lib contract): one line per metric,
+#   `<engine>\t<metric>\t<deficit_milli>`
+# (recall_at_100, ndcg_at_10). --json adds the raw float metrics + k + the BEIR cut id
+# for the results envelope / dashboard snapshot. The dashboard column is OFF (engine
+# id null) — these numbers are the kernel IR oracle, never a SPARQL benchmark.
+import json
+import math
+import sys
+
+
+# --- TREC qrels / run parsers (BEIR + Anserini standard formats) -------------
+def parse_qrels(text):
+    """TREC qrels `<qid> <iter> <docid> <rel>` (whitespace-separated) -> {qid:{docid:rel}}.
+
+    `<iter>` is conventionally `0` and ignored. `<rel>` is the GRADED relevance
+    (>=1 relevant; 0 explicitly non-relevant). Blank lines and `#`-comments skipped.
+    A graded judgement is kept as its integer for nDCG (BEIR SciFact is binary;
+    TREC-COVID is graded 0/1/2). A negative relevance is rejected (malformed qrels)."""
+    out = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) != 4:
+            raise ValueError("bad qrels line (want 4 fields): %r" % line)
+        qid, _iter, docid, rel = parts
+        rel = int(rel)
+        if rel < 0:
+            raise ValueError("negative relevance in qrels: %r" % line)
+        out.setdefault(qid, {})[docid] = rel
+    return out
+
+
+def parse_run(text):
+    """TREC run `<qid> Q0 <docid> <rank> <score> <tag>` -> {qid:[docid ranked best-first]}.
+
+    The canonical Anserini/pyserini output. Rows are SORTED by descending score (then
+    by ascending rank as a deterministic tie-break) per query, so the resulting list is
+    the true ranking regardless of input row order. A docid that appears twice for one
+    query keeps its best (first-seen-after-sort) position. Blank lines / `#`-comments
+    skipped."""
+    scored = {}  # qid -> list of (score, rank, docid)
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) != 6:
+            raise ValueError("bad run line (want 6 TREC fields): %r" % line)
+        qid, _q0, docid, rank, score, _tag = parts
+        scored.setdefault(qid, []).append((float(score), int(rank), docid))
+    out = {}
+    for qid, rows in scored.items():
+        # best-first: higher score first; ties broken by smaller rank then docid so the
+        # ordering is fully deterministic (a stable run regardless of file row order).
+        rows.sort(key=lambda r: (-r[0], r[1], r[2]))
+        seen = set()
+        ranked = []
+        for _score, _rank, docid in rows:
+            if docid in seen:
+                continue
+            seen.add(docid)
+            ranked.append(docid)
+        out[qid] = ranked
+    return out
+
+
+# --- IR metrics (pure; the ORACLE) -------------------------------------------
+def _relevant_docs(qrels_q):
+    """The set of docids judged relevant (rel >= 1) for one query."""
+    return {d for d, r in qrels_q.items() if r >= 1}
+
+
+def recall_at_k(run, qrels, k):
+    """Mean Recall@k of `run` vs `qrels` (BEIR's primary recall metric).
+
+    Recall@k for a query = |retrieved[:k] ∩ relevant| / |relevant|, averaged over the
+    queries that HAVE at least one relevant doc in qrels (a query with no positive
+    judgement has an undefined recall and is skipped — the BEIR convention). Returns
+    (recall: float, n_queries: int). Raises if NO query has a positive judgement (so a
+    mis-aligned qrels/run pair fails loudly, not silently as recall 0)."""
+    qids = [q for q in qrels if _relevant_docs(qrels[q])]
+    if not qids:
+        raise ValueError("no query in qrels has a relevant (rel>=1) judgement")
+    total = 0.0
+    for q in qids:
+        rel = _relevant_docs(qrels[q])
+        topk = run.get(q, [])[:k]
+        total += len(rel.intersection(topk)) / len(rel)
+    return total / len(qids), len(qids)
+
+
+def _dcg(gains):
+    """DCG of an ordered list of gains: sum_i gain_i / log2(i + 2) (0-based i)."""
+    return sum(g / math.log2(i + 2) for i, g in enumerate(gains))
+
+
+def ndcg_at_k(run, qrels, k):
+    """Mean nDCG@k of `run` vs `qrels` with GRADED relevance (the standard BEIR nDCG).
+
+    For each query: DCG@k over the run's top-k (gain = the qrels relevance grade, 0 for
+    an unjudged/non-relevant doc) divided by the IDCG@k (DCG of the top-k highest grades
+    available for that query). Averaged over queries with at least one positive
+    judgement. Returns (ndcg: float, n_queries: int). Raises if no query is judged."""
+    qids = [q for q in qrels if _relevant_docs(qrels[q])]
+    if not qids:
+        raise ValueError("no query in qrels has a relevant (rel>=1) judgement")
+    total = 0.0
+    for q in qids:
+        judged = qrels[q]
+        gains = [judged.get(d, 0) for d in run.get(q, [])[:k]]
+        ideal = sorted((g for g in judged.values() if g >= 1), reverse=True)[:k]
+        idcg = _dcg(ideal)
+        if idcg > 0:
+            total += _dcg(gains) / idcg
+    return total / len(qids), len(qids)
+
+
+def deficit_milli(metric):
+    """(1 - metric) scaled to integer milli-units — the smaller-is-better metric the
+    mode:"auto" ratchet wants (G4). Clamped to [0, 1000] (a metric is in [0,1])."""
+    d = int(round((1.0 - metric) * 1000))
+    return max(0, min(1000, d))
+
+
+# --- sparq-side input conversion (pure; the apples-to-apples bridge) ----------
+# The sparq-text `beir_text` example takes plain inputs (NO JSON dep): an N-Triples
+# corpus `<beir:doc:DOCID> <beir:text> "<text>" .` and a `<qid>\t<text>` queries TSV.
+# These two pure writers convert a BEIR {docid: text} corpus + {qid: text} queries into
+# those formats so sparq-text is retrieved on the SAME cut the Anserini oracle is, and
+# scored by the SAME recall_at_k/ndcg_at_k against the SAME qrels (design §3.4 fairness).
+DOC_IRI_PREFIX = "beir:doc:"
+TEXT_PREDICATE = "beir:text"
+
+
+def escape_nt_literal(s):
+    r"""Escape a string for an N-Triples double-quoted literal (\\, ", \n, \r, \t).
+
+    Per the N-Triples grammar's ECHAR set — enough for arbitrary BEIR document text
+    (which is plain UTF-8; the byte-level parser accepts non-ASCII verbatim)."""
+    return (
+        s.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+
+
+def corpus_to_ntriples(corpus):
+    """A BEIR corpus {docid: text} -> N-Triples lines for the sparq-text beir_text example.
+
+    `text` is the document's searchable body (title + text, joined, as BEIR/Anserini
+    index it). Emits one `<beir:doc:DOCID> <beir:text> "<escaped>" .` line per doc, in
+    sorted docid order for a deterministic file."""
+    lines = []
+    for docid in sorted(corpus):
+        lines.append(
+            '<%s%s> <%s> "%s" .' % (DOC_IRI_PREFIX, docid, TEXT_PREDICATE, escape_nt_literal(corpus[docid]))
+        )
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def queries_to_tsv(queries):
+    """A BEIR queries {qid: text} -> `<qid>\\t<text>` TSV (newlines/tabs in the query
+    text stripped to single spaces so each query stays one line)."""
+    lines = []
+    for qid in sorted(queries):
+        text = " ".join(queries[qid].split())
+        lines.append("%s\t%s" % (qid, text))
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def qrels_to_trec(qrels):
+    """A qrels {qid:{docid:rel}} -> TREC `<qid> 0 <docid> <rel>` lines (sorted), the
+    format parse_qrels reads back and the sparq-text run is scored against."""
+    lines = []
+    for qid in sorted(qrels):
+        for docid in sorted(qrels[qid]):
+            lines.append("%s 0 %s %d" % (qid, docid, int(qrels[qid][docid])))
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+# --- heavy harness (gather-only; needs pyserini + a downloaded BEIR cut) ------
+# BEIR cuts wired (the design's recommended small redistributable-at-gather cuts).
+# pyserini ships pre-built Anserini Lucene indexes for these under `beir-v1.0.0-<id>`,
+# and the BEIR qrels are fetched by the `beir` package at gather time. Both are
+# Apache-2.0 / CC and downloaded ON the gather box (never committed in-repo).
+BEIR_CUTS = {
+    "scifact": "beir-v1.0.0-scifact.flat",
+    "trec-covid": "beir-v1.0.0-trec-covid.flat",
+}
+
+
+def download_beir_cut(dataset):
+    """Download + load a BEIR cut -> (corpus, queries, qrels). Gather-only.
+
+    Lazily imports the `beir` data loader so CI can import this module (and unit-test
+    the pure scorers/converters) WITHOUT the heavy dep. `corpus` is {docid: text} (BEIR's
+    title + text joined — what Anserini indexes), `queries` is {qid: text}, `qrels` is
+    {qid:{docid:rel}}. The download lands under BEIR_DATA_DIR (default /tmp/beir-data),
+    never committed in-repo (the corpus is not redistributable)."""
+    if dataset not in BEIR_CUTS:
+        raise ValueError("unknown BEIR cut %r (have: %s)" % (dataset, ", ".join(sorted(BEIR_CUTS))))
+    import os
+
+    from beir import util
+    from beir.datasets.data_loader import GenericDataLoader
+
+    url = "https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/%s.zip" % dataset
+    out_dir = os.path.join(os.environ.get("BEIR_DATA_DIR", "/tmp/beir-data"), dataset)
+    data_path = util.download_and_unzip(url, out_dir)
+    corpus_raw, queries, qrels_raw = GenericDataLoader(data_folder=data_path).load(split="test")
+    # BEIR corpus values are {"title":..., "text":...}; join them the way Anserini's
+    # default BEIR indexing does so sparq-text indexes the SAME searchable body.
+    corpus = {
+        did: (("%s %s" % (d.get("title", ""), d.get("text", ""))).strip()) for did, d in corpus_raw.items()
+    }
+    qrels = {qid: {d: int(r) for d, r in rels.items()} for qid, rels in qrels_raw.items()}
+    return corpus, queries, qrels
+
+
+def run_anserini_beir(dataset, k=100, bm25_k1=1.2, bm25_b=0.75):
+    """Download a BEIR cut, BM25-retrieve top-k with Anserini, return (run, qrels).
+
+    Gather-only: imports pyserini (the Anserini Python binding) lazily so CI can import
+    this module (and unit-test the scorers above) WITHOUT the heavy dep. BM25 is pinned
+    to k1=1.2 / b=0.75 to match sparq-text (a fair kernel comparison; design §3.4).
+    Returns the run as {qid:[docid ranked]} and the qrels as {qid:{docid:rel}} — both fed
+    straight into recall_at_k / ndcg_at_k against the SAME judgements sparq-text is
+    scored on."""
+    from pyserini.search.lucene import LuceneSearcher
+
+    _corpus, queries, qrels = download_beir_cut(dataset)
+    searcher = LuceneSearcher.from_prebuilt_index(BEIR_CUTS[dataset])
+    searcher.set_bm25(bm25_k1, bm25_b)
+    run = {}
+    for qid, qtext in queries.items():
+        hits = searcher.search(qtext, k=k)
+        run[qid] = [h.docid for h in hits]
+    return run, qrels
+
+
+def prepare_sparq_inputs(dataset, out_dir):
+    """Download a BEIR cut and write the sparq-text `beir_text` example's inputs to
+    `out_dir` (corpus.nt, queries.tsv, qrels.txt) so sparq-text is retrieved + scored on
+    the SAME cut + qrels the Anserini oracle is. Gather-only. Returns the three paths."""
+    import os
+
+    corpus, queries, qrels = download_beir_cut(dataset)
+    os.makedirs(out_dir, exist_ok=True)
+    paths = {
+        "corpus": os.path.join(out_dir, "corpus.nt"),
+        "queries": os.path.join(out_dir, "queries.tsv"),
+        "qrels": os.path.join(out_dir, "qrels.txt"),
+    }
+    with open(paths["corpus"], "w", encoding="utf-8") as fh:
+        fh.write(corpus_to_ntriples(corpus))
+    with open(paths["queries"], "w", encoding="utf-8") as fh:
+        fh.write(queries_to_tsv(queries))
+    with open(paths["qrels"], "w", encoding="utf-8") as fh:
+        fh.write(qrels_to_trec(qrels))
+    return paths
+
+
+def main(argv):
+    """CLI:
+      beir_ir_adapter.py --score --run <trec-run> --qrels <trec-qrels> [--engine N]
+            offline: score a TREC run vs qrels (fixture-testable, NO pyserini/beir).
+            ENGINE-AGNOSTIC: scores any TREC run — the Anserini oracle's OR sparq-text's
+            (from the beir_text example) — against the SAME qrels (apples-to-apples).
+      beir_ir_adapter.py --anserini --dataset scifact [--k 100] [--engine N]
+            heavy (gather-only): download the BEIR cut, Anserini BM25 retrieve, score.
+      beir_ir_adapter.py --prepare-sparq --dataset scifact --out <dir>
+            heavy (gather-only): download the cut, write corpus.nt + queries.tsv +
+            qrels.txt into <dir> for the sparq-text `beir_text` example (same cut/qrels).
+    Score modes emit one line per metric `<engine>\\t<metric>\\t<deficit_milli>`
+    (recall_at_100 + ndcg_at_10); --json adds the raw floats + k + cut id."""
+    mode = None
+    run_f = qrels_f = dataset = out_dir = None
+    k_recall = 100
+    k_ndcg = 10
+    engine = "lucene-anserini"
+    want_json = False
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--score":
+            mode = "score"
+        elif a == "--anserini":
+            mode = "anserini"
+        elif a == "--prepare-sparq":
+            mode = "prepare-sparq"
+        elif a == "--run":
+            i += 1
+            run_f = argv[i]
+        elif a == "--qrels":
+            i += 1
+            qrels_f = argv[i]
+        elif a == "--dataset":
+            i += 1
+            dataset = argv[i]
+        elif a == "--out":
+            i += 1
+            out_dir = argv[i]
+        elif a == "--k":
+            i += 1
+            k_recall = int(argv[i])
+        elif a == "--engine":
+            i += 1
+            engine = argv[i]
+        elif a == "--json":
+            want_json = True
+        else:
+            sys.stderr.write("beir_ir_adapter: unknown arg %s\n" % a)
+            return 2
+        i += 1
+
+    # The prepare-sparq mode writes files and exits (it produces no metric line).
+    if mode == "prepare-sparq":
+        try:
+            if not dataset or not out_dir:
+                raise ValueError("--prepare-sparq needs --dataset <cut> --out <dir>")
+            paths = prepare_sparq_inputs(dataset, out_dir)
+        except Exception as e:  # noqa: BLE001 — adapter boundary
+            sys.stderr.write("beir_ir_adapter: %s\n" % e)
+            return 1
+        sys.stderr.write("wrote %s\n" % json.dumps(paths))
+        return 0
+
+    try:
+        if mode == "score":
+            if not (run_f and qrels_f):
+                raise ValueError("--score needs --run <trec-run> --qrels <trec-qrels>")
+            with open(run_f, encoding="utf-8") as fh:
+                run = parse_run(fh.read())
+            with open(qrels_f, encoding="utf-8") as fh:
+                qrels = parse_qrels(fh.read())
+        elif mode == "anserini":
+            if not dataset:
+                raise ValueError("--anserini needs --dataset <scifact|trec-covid>")
+            run, qrels = run_anserini_beir(dataset, k=k_recall)
+        else:
+            sys.stderr.write("beir_ir_adapter: pick --score, --anserini or --prepare-sparq\n")
+            return 2
+        recall, _nr = recall_at_k(run, qrels, k_recall)
+        ndcg, _nn = ndcg_at_k(run, qrels, k_ndcg)
+    except Exception as e:  # noqa: BLE001 — adapter boundary
+        sys.stderr.write("beir_ir_adapter: %s\n" % e)
+        return 1
+
+    sys.stdout.write("%s\trecall_at_%d\t%d\n" % (engine, k_recall, deficit_milli(recall)))
+    sys.stdout.write("%s\tndcg_at_%d\t%d\n" % (engine, k_ndcg, deficit_milli(ndcg)))
+    if want_json:
+        sys.stderr.write(
+            json.dumps(
+                {
+                    "engine": engine,
+                    "recall_at_k": recall,
+                    "recall_k": k_recall,
+                    "ndcg_at_k": ndcg,
+                    "ndcg_k": k_ndcg,
+                    "beir_cut": dataset,
+                }
+            )
+            + "\n"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/bench-adapters/fixtures/beir_qrels.txt
+++ b/scripts/bench-adapters/fixtures/beir_qrels.txt
@@ -1,0 +1,13 @@
+# [OPUS-4.8] sq-1fz0 BEIR fixture: TREC qrels `<qid> <iter> <docid> <rel>`.
+# Three queries with GRADED judgements (q2 has a grade-2 doc so nDCG exercises the
+# graded path; SciFact is binary but TREC-COVID grades 0/1/2). Pairs with beir_run.txt
+# to give a KNOWN Recall@3 = 0.5 and nDCG@3 = 0.4332715... (see test_adapters.py).
+#   q1 relevant: dA, dB        (dZ explicitly non-relevant, rel 0 — ignored)
+#   q2 relevant: dC (grade 2), dD (grade 1)
+#   q3 relevant: dE
+q1 0 dA 1
+q1 0 dB 1
+q1 0 dZ 0
+q2 0 dC 2
+q2 0 dD 1
+q3 0 dE 1

--- a/scripts/bench-adapters/fixtures/beir_run.txt
+++ b/scripts/bench-adapters/fixtures/beir_run.txt
@@ -1,0 +1,17 @@
+# [OPUS-4.8] sq-1fz0 BEIR fixture: a TREC run `<qid> Q0 <docid> <rank> <score> <tag>`.
+# q1 rows are INTENTIONALLY out of score order to prove parse_run sorts by score
+# (dA 9 > dX 8 > dB 7), not by file row order. Pairs with beir_qrels.txt:
+#   q1 top-3 = dA,dX,dB  -> recall@3 = |{dA,dB}|/2 = 1.0 ; ndcg gains [1,0,1]
+#   q2 top-3 = dD,dY,dZ  -> recall@3 = |{dD}|/2 = 0.5  (dC,grade2, MISSED) ; gains [1,0,0]
+#   q3 top-3 = dW,dV,dU  -> recall@3 = 0/1 = 0.0  ; gains [0,0,0]
+# Mean Recall@3 = (1.0 + 0.5 + 0.0)/3 = 0.5            -> recall_deficit_milli = 500
+# Mean nDCG@3   = 0.4332715...                          -> ndcg_deficit_milli   = 567
+q1 Q0 dB 3 7.0 fix
+q1 Q0 dA 1 9.0 fix
+q1 Q0 dX 2 8.0 fix
+q2 Q0 dD 1 5.0 fix
+q2 Q0 dY 2 4.0 fix
+q2 Q0 dZ 3 3.0 fix
+q3 Q0 dW 1 2.0 fix
+q3 Q0 dV 2 1.0 fix
+q3 Q0 dU 3 0.5 fix

--- a/scripts/bench-adapters/test_adapters.py
+++ b/scripts/bench-adapters/test_adapters.py
@@ -6,6 +6,7 @@
 #   - shacl_report_count : parse a SHACL ValidationReport graph -> (conforms, viol)
 #   - http_sparql_adapter.parse_sparql_json : SELECT / ASK / COUNT(*) reductions
 #   - vector_lib_adapter.recall_at_k + parse_neighbour_tsv : recall scoring + deficit
+#   - beir_ir_adapter : TREC qrels/run parsers + Recall@k / nDCG@k + deficit (sq-1fz0)
 # shacl_report_count's test needs rdflib (the SHACL report parser's only dep); if
 # rdflib is absent that one test SKIPS (the http + vector tests are stdlib-only and
 # always run). Run with the venv that has rdflib for full coverage:
@@ -17,6 +18,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)
 FIX = os.path.join(HERE, "fixtures")
 
+import beir_ir_adapter as beir  # noqa: E402
 import http_sparql_adapter as http  # noqa: E402
 import vector_lib_adapter as vec  # noqa: E402
 
@@ -94,6 +96,76 @@ def test_vector():
         check("vec.disjoint-raises", True, True)
 
 
+# --- BEIR IR scoring (sq-1fz0; stdlib-only, no pyserini/beir) ----------------
+def test_beir():
+    with open(os.path.join(FIX, "beir_qrels.txt")) as f:
+        qrels = beir.parse_qrels(f.read())
+    with open(os.path.join(FIX, "beir_run.txt")) as f:
+        run = beir.parse_run(f.read())
+    # parse: 3 queries; q1 keeps the rel-0 dZ as an explicit non-relevant judgement.
+    check("beir.parse.nqueries", len(qrels), 3)
+    check("beir.parse.q1_judged", sorted(qrels["q1"]), ["dA", "dB", "dZ"])
+    check("beir.parse.q1_relevant", sorted(beir._relevant_docs(qrels["q1"])), ["dA", "dB"])
+    # parse_run sorts by score regardless of file row order: q1 rows are dB,dA,dX in
+    # the file but dA(9)>dX(8)>dB(7) by score.
+    check("beir.parse.q1_ranked", run["q1"], ["dA", "dX", "dB"])
+    # Recall@3 = mean(1.0, 0.5, 0.0) = 0.5  -> deficit 500 (see fixture header).
+    recall, n = beir.recall_at_k(run, qrels, 3)
+    check("beir.recall.nqueries", n, 3)
+    approx("beir.recall@3", recall, 0.5)
+    check("beir.recall_deficit_milli", beir.deficit_milli(recall), 500)
+    # nDCG@3 = 0.4332715... -> deficit 567 (graded q2: dC grade-2 missed).
+    ndcg, nn = beir.ndcg_at_k(run, qrels, 3)
+    check("beir.ndcg.nqueries", nn, 3)
+    approx("beir.ndcg@3", ndcg, 0.4332715186)
+    check("beir.ndcg_deficit_milli", beir.deficit_milli(ndcg), 567)
+    # A run that returns every relevant doc first -> perfect recall + nDCG -> deficit 0.
+    perfect = {q: list(beir._relevant_docs(qrels[q])) for q in qrels}
+    pr, _ = beir.recall_at_k(perfect, qrels, 100)
+    check("beir.recall.perfect_deficit", beir.deficit_milli(pr), 0)
+    # qrels with NO positive judgement must raise (catch a mis-aligned pair loudly).
+    try:
+        beir.recall_at_k({"q1": ["dA"]}, {"q1": {"dA": 0}}, 3)
+        check("beir.no-positive-raises", False, True)
+    except ValueError:
+        check("beir.no-positive-raises", True, True)
+    # malformed qrels (wrong field count) must raise.
+    try:
+        beir.parse_qrels("q1 0 dA")
+        check("beir.bad-qrels-raises", False, True)
+    except ValueError:
+        check("beir.bad-qrels-raises", True, True)
+    # malformed run (wrong field count) must raise.
+    try:
+        beir.parse_run("q1 Q0 dA 1 9.0")
+        check("beir.bad-run-raises", False, True)
+    except ValueError:
+        check("beir.bad-run-raises", True, True)
+    # --- sparq-side input conversion (the apples-to-apples bridge) -----------
+    # corpus -> N-Triples: one `<beir:doc:DOCID> <beir:text> "..." .` per doc, sorted,
+    # with ECHAR escaping of the literal body.
+    nt = beir.corpus_to_ntriples({"d2": 'has "quotes"\nand newline', "d1": "plain text"})
+    check(
+        "beir.corpus_to_ntriples",
+        nt,
+        '<beir:doc:d1> <beir:text> "plain text" .\n'
+        '<beir:doc:d2> <beir:text> "has \\"quotes\\"\\nand newline" .\n',
+    )
+    check("beir.escape_nt_literal", beir.escape_nt_literal('a\\b"c'), 'a\\\\b\\"c')
+    # queries -> TSV: `<qid>\t<text>`, sorted, whitespace collapsed to single spaces.
+    check(
+        "beir.queries_to_tsv",
+        beir.queries_to_tsv({"q2": "two", "q1": "a\tb\n c"}),
+        "q1\ta b c\nq2\ttwo\n",
+    )
+    # qrels round-trips through parse_qrels (write TREC -> parse back -> identical map).
+    qr = {"q1": {"dB": 1, "dA": 2}}
+    check("beir.qrels_to_trec.roundtrip", beir.parse_qrels(beir.qrels_to_trec(qr)), qr)
+    # empty inputs produce empty (not malformed) files.
+    check("beir.corpus_to_ntriples.empty", beir.corpus_to_ntriples({}), "")
+    check("beir.queries_to_tsv.empty", beir.queries_to_tsv({}), "")
+
+
 # --- shacl report-count parser (needs rdflib) --------------------------------
 def test_shacl():
     try:
@@ -129,6 +201,7 @@ def test_shacl():
 def main():
     test_http()
     test_vector()
+    test_beir()
     test_shacl()
     print("\n%d passed, %d failed" % (PASS, FAIL))
     return 1 if FAIL else 0

--- a/scripts/gather-competitors.sh
+++ b/scripts/gather-competitors.sh
@@ -15,12 +15,14 @@
 #                          Heavy. Caps dataset size, watches `df`, cleans /tmp.
 #
 # Engines: oxigraph (embedded Rust dep) | qlever (Docker) | eye (N3 binary).
-# Plus four SHARED reusable adapter KINDS (sq-eifd), dispatched off competitors.json
-# `kind` and backed by scripts/bench-adapters/:
+# Plus five SHARED reusable adapter KINDS (sq-eifd / sq-1fz0), dispatched off
+# competitors.json `kind` and backed by scripts/bench-adapters/:
 #   report-cli  : file-in/SHACL-report-out CLI (pySHACL, Jena `shacl validate`)
 #   js-lib      : in-process Node/RDF-JS SHACL (rdf-validate-shacl, sparq's own WASM)
 #   http-sparql : POST query -> parse SPARQL-JSON -> count (Fuseki, Virtuoso, QLever)
 #   vector-lib  : in-process Python ANN -> recall@k vs exact-kNN (FAISS, hnswlib)
+#   python-lib  : in-process IR kernel -> Recall@100/nDCG@10 deficits on a BEIR cut
+#                 (lucene-anserini, the FTS IR-quality oracle; sq-1fz0)
 # Select with --only <id[,id...]>; default is all engines in dry-run, but --run
 # requires you to NAME the engines (no accidental "run everything heavy").
 #
@@ -537,9 +539,67 @@ run_vector_lib_engine() { # <id>
   fi
 }
 
+# beir_deficits_json <tsv> — fold the adapter's `<engine>\t<metric>\t<deficit_milli>`
+# lines (recall_at_100, ndcg_at_10) into ONE `{engine, deficits_milli:{metric:val}}`
+# JSON object, so each engine's results envelope is a single comparable record (the
+# same deficit shape the vector-lib path emits).
+beir_deficits_json() {
+  printf '%s' "$1" | python3 -c 'import json,sys
+m={}; e=None
+for ln in sys.stdin.read().splitlines():
+    if not ln.strip(): continue
+    e,k,v=ln.split("\t"); m[k]=int(v)
+print(json.dumps({"engine":e,"deficits_milli":m}))'
+}
+
+# [OPUS-4.8] sq-1fz0: PYTHON-LIB kind — the BEIR IR-quality axis of the FTS suite
+# (design §3.4). The ONLY python-lib engine is lucene-anserini, the kernel BM25
+# ORACLE: it downloads a small BEIR cut (SciFact / TREC-COVID + qrels), BM25-retrieves
+# with Anserini/pyserini (k1=1.2/b=0.75, matching sparq-text), and scores Recall@100 /
+# nDCG@10, emitted as DEFICITS (G4) on the SAME cut + qrels sparq-text is scored on.
+# GATHER-ONLY: the BEIR corpus is not redistributable in-repo, so this is a download
+# step, never a committed per-PR gate. The scoring half is fixture-unit-tested in
+# scripts/bench-adapters/test_adapters.py WITHOUT pyserini/beir installed.
+run_python_lib_engine() { # <id>
+  local id="$1"
+  hdr "$id (python-lib — BEIR IR-quality oracle)"
+  log "  adapter: $ADAPTERS_DIR/beir_ir_adapter.py (download BEIR cut -> Anserini BM25 retrieve -> Recall@100/nDCG@10 deficits)"
+  log "  scoring half is fixture-unit-tested in $ADAPTERS_DIR/test_adapters.py (no pyserini/beir needed)"
+  log "  PREP (gather box): pip install pyserini beir; set BEIR_CUT (scifact|trec-covid); optional BEIR_DATA_DIR"
+  log "  OPTIONAL apples-to-apples: set SPARQ_TEXT_BEIR=target/release/examples/beir_text to ALSO"
+  log "    score sparq-text on the SAME cut+qrels (cargo build -p sparq-text --release --example beir_text)"
+  log "  OFF the dashboard (no RDF/SPARQL surface) — the kernel BM25 reference, 'sub-component, not an RDF benchmark'"
+  if [ "$DO_RUN" -eq 1 ]; then
+    have python3 || die "python3 needed for the python-lib (BEIR) adapter"
+    python3 -c 'import pyserini, beir' 2>/dev/null || die "python-lib adapter needs pyserini + beir (pip install pyserini beir)"
+    local cut; cut="${BEIR_CUT:-scifact}"
+    # 1. the kernel BM25 ORACLE: Anserini retrieve + score on the cut + qrels.
+    OUT="$(python3 "$ADAPTERS_DIR/beir_ir_adapter.py" --anserini --dataset "$cut" --k "${BEIR_K:-100}" --engine "$id" --json 2>/dev/null)" \
+      || die "python-lib (BEIR) adapter failed for $id (cut '$cut'; pyserini index downloadable?)"
+    PAYLOAD="$(beir_deficits_json "$OUT")"
+    write_result "$id" "beir-ir-${cut}" "$(jq -r --arg id "$id" 'first(.competitors[]|select(.id==$id)).pinned_version//"unknown"' "$REGISTRY")" "$PAYLOAD"
+    # 2. OPTIONAL: score sparq-text on the SAME cut+qrels via the shared scorer, so the
+    #    comparison is apples-to-apples (same scorer, same judgements; design §3.4).
+    if [ -n "${SPARQ_TEXT_BEIR:-}" ]; then
+      [ -x "$SPARQ_TEXT_BEIR" ] || die "SPARQ_TEXT_BEIR='$SPARQ_TEXT_BEIR' is not an executable (build the beir_text example)"
+      local prep; prep="$(mktemp -d)"
+      python3 "$ADAPTERS_DIR/beir_ir_adapter.py" --prepare-sparq --dataset "$cut" --out "$prep" \
+        || { rm -rf "$prep"; die "could not prepare sparq inputs for cut '$cut'"; }
+      "$SPARQ_TEXT_BEIR" "$prep/corpus.nt" "$prep/queries.tsv" "${BEIR_K:-100}" sparq-text > "$prep/run.txt" \
+        || { rm -rf "$prep"; die "sparq-text beir_text retrieval failed for cut '$cut'"; }
+      local SOUT
+      SOUT="$(python3 "$ADAPTERS_DIR/beir_ir_adapter.py" --score --run "$prep/run.txt" --qrels "$prep/qrels.txt" --k "${BEIR_K:-100}" --engine sparq-text 2>/dev/null)" \
+        || { rm -rf "$prep"; die "could not score the sparq-text run for cut '$cut'"; }
+      write_result "sparq-text" "beir-ir-${cut}" "$(git rev-parse --short HEAD 2>/dev/null || echo unknown)" "$(beir_deficits_json "$SOUT")"
+      rm -rf "$prep"
+    fi
+    check_df
+  fi
+}
+
 # Walk every registry engine of a SHARED-ADAPTER kind (skipping the three bespoke
 # kinds handled above) and dispatch. Engines stay empty in git, so this is a no-op
-# until a maintainer adds report-cli/js-lib/http-sparql/vector-lib entries.
+# until a maintainer adds report-cli/js-lib/http-sparql/vector-lib/python-lib entries.
 if have jq; then
   while IFS= read -r aid; do
     [ -n "$aid" ] || continue
@@ -549,8 +609,9 @@ if have jq; then
       js-lib)      run_js_lib_engine      "$aid" ;;
       http-sparql) run_http_sparql_engine "$aid" ;;
       vector-lib)  run_vector_lib_engine  "$aid" ;;
+      python-lib)  run_python_lib_engine  "$aid" ;;
     esac
-  done < <(jq -r '.competitors[] | select(.kind=="report-cli" or .kind=="js-lib" or .kind=="http-sparql" or .kind=="vector-lib") | .id' "$REGISTRY")
+  done < <(jq -r '.competitors[] | select(.kind=="report-cli" or .kind=="js-lib" or .kind=="http-sparql" or .kind=="vector-lib" or .kind=="python-lib") | .id' "$REGISTRY")
 fi
 
 hdr "done"


### PR DESCRIPTION
> 🤖 **SPARQ agent** — wires bead `sq-1fz0`. Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns). `[OPUS-4.8]`

## What & why

The full-text-search suite (`bench/fts/`) shipped only its **deterministic latency axis** (hit counts + index bytes/doc, per-PR-gated). The **second** design axis (`research/capability-benchmark-program.md` §3.4) — **IR-quality** on a small BEIR cut (SciFact / TREC-COVID + qrels) as **Recall@100 / nDCG@10** — was beaded (`sq-1fz0`) but unwired, because the BEIR corpus is **not redistributable in-repo** and so must be a **download/gather step**, not a committed per-PR gate.

This wires it, with the **`lucene-anserini`** competitor (already registered, `dashboard_engine_id: null` = off-dashboard) as the **BM25 quality oracle** on the SAME BEIR cut + qrels.

## How

- **`scripts/bench-adapters/beir_ir_adapter.py`** (new) — the BEIR IR harness, split exactly like `vector_lib_adapter.py`:
  - **Pure scoring/oracle half** (stdlib-only, fixture-unit-tested in CI): TREC qrels/run parsers, `recall_at_k`, `ndcg_at_k` (graded relevance), `deficit_milli = round((1 - metric) * 1000)` (the G4 smaller-is-better shape), plus the sparq-input converters.
  - **Gather-only heavy half**: download a BEIR cut, Anserini/pyserini BM25 retrieve at **k1=1.2 / b=0.75** (matching `sparq-text`), score. The `lucene-anserini` run is the **oracle**.
- **`scripts/gather-competitors.sh`** — dispatch the `python-lib` kind (the `lucene-anserini` entry's `kind`, previously undispatched) to the new adapter. Optionally (set `SPARQ_TEXT_BEIR`) also score **sparq-text** on the **same cut + qrels** via the **same scorer** → apples-to-apples (§3.4 fairness). `lucene-anserini` stays **off the dashboard**.
- **`crates/sparq-text/examples/beir_text.rs`** (new) — the sparq side: loads a BEIR cut as RDF literals, retrieves with `TextIndex::search`, emits a TREC run scored by the same `beir_ir_adapter.py --score` path. **No JSON dependency** (reads plain N-Triples + a TSV the Python harness writes from the downloaded cut).
- **`bench/fts/README.md` + `bench/competitors.json`** — document the now-wired gather step.

## Honesty

The deficits are **gather-only** results (the corpus is not present in CI to derive an honest floor), so this does **NOT** add a fabricated `bench/perf-baseline.json` ratchet — it adds the deficit **computation + emission** (G4 shape) into the gather results, ready for a maintainer-reviewed dashboard snapshot. The per-PR gate stays the deterministic latency-axis structure.

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + `cargo test` for **`sparq-text`** in **BOTH** feature states (default `engine,parallel` and `--no-default-features`) — green.
- 35 adapter unit tests pass (`scripts/bench-adapters/test_adapters.py`), incl. the new BEIR fixtures with hand-verified Recall@3 = 0.5 (deficit 500) / nDCG@3 = 0.4332715 (deficit 567).
- End-to-end smoke verified: Python-written corpus → `beir_text` TREC run → `--score` → deficits (the escaped `"`/`\t` round-trip through sparq's N-Triples parser).
- Privacy-claims gate + G2 public-api→SKILL gate green (no public API changed).
- `cargo fmt` is informational-only on main until the deferred workspace reformat lands; the new example is fmt-clean in isolation and no pre-existing files were reformatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
