### PR TITLE
feat(sparq-prov): PROV-O lineage for SPARQL UPDATE (INSERT…WHERE / INSERT DATA / DELETE) (sq-xwdd) [OPUS-4.8]

### DIFF
--- a/crates/sparq-prov/README.md
+++ b/crates/sparq-prov/README.md
@@ -42,6 +42,15 @@ let turtle  = d.prov_ntriples();    // …serialised (N-Triples ⊂ Turtle)
 - **CONSTRUCT/DESCRIBE lineage** — [`derive_construct`] wraps the engine's
   `CONSTRUCT`/`DESCRIBE` evaluation, times it, and returns a [`Derivation`]
   carrying both the derived triples and a PROV-O lineage graph.
+- **SPARQL UPDATE lineage** — [`derive_update`] applies an `INSERT … WHERE` /
+  `INSERT DATA` / `DELETE …` in place, captures the engine's *resolved* effect log,
+  and returns an [`UpdateDerivation`]. The two-sided PROV reading: the **inserted**
+  triples are *generated* (a `prov:Entity` `wasGeneratedBy` the update,
+  `wasDerivedFrom` the matched inputs); the **deleted** triples are *invalidated*
+  (`prov:wasInvalidatedBy`) — retraction is not derivation, so deletes are never
+  claimed as generated/derived. A pure-delete update generates nothing (no result
+  entity). Structural ops (`CLEAR`/`DROP`/`CREATE`) are recorded as an activity kind
+  but carry no per-triple entity (a deliberate honesty boundary — see below).
 - **Standard PROV-O shape** — for result entity `E`, activity `A`, inputs `Iᵢ`:
   `A a prov:Activity` · `E a prov:Entity` ·
   `A prov:startedAtTime/endedAtTime "…"^^xsd:dateTime` ·
@@ -73,13 +82,15 @@ let turtle  = d.prov_ntriples();    // …serialised (N-Triples ⊂ Turtle)
 
 | Derivation path | Status |
 |---|---|
-| `CONSTRUCT` / `DESCRIBE` (query → new graph) | ✅ covered here |
+| `CONSTRUCT` / `DESCRIBE` (query → new graph) | ✅ covered here (`derive_construct`) |
 | Reasoner materialization (RDFS / OWL-RL / N3) | ✅ covered (`reason` feature) — reuses `sparq-reason`'s per-fact `why()` proof trees: a *finer-grained* derivation provenance than PROV-O alone |
-| SPARQL UPDATE (`INSERT … WHERE`, `INSERT DATA`) | ⏳ deferred (follow-up bead) |
+| SPARQL UPDATE data ops (`INSERT … WHERE`, `INSERT DATA`, `DELETE …`, `LOAD`) | ✅ covered here (`derive_update`) — inserts ⇒ generated/derived, deletes ⇒ `wasInvalidatedBy` |
+| SPARQL UPDATE structural ops (`CLEAR` / `DROP` / `CREATE`) | ⛔ no per-triple entity (deliberate boundary — they change graph existence/emptiness, not triples-as-data; recorded only as the activity kind) |
 
 The CONSTRUCT path is the cleanest, best-tested derivation in the engine and the
 natural first PROV-O target; reasoner materialization reuses the existing proof
-trees; the remaining UPDATE path is filed as a bead. [OPUS-4.8] sq-m3i0
+trees; UPDATE lineage reads the engine's resolved effect log so capture is exact
+even for non-deterministic update text. [OPUS-4.8] sq-m3i0, sq-xwdd
 
 ## 📚 Learn more
 

--- a/crates/sparq-prov/src/lib.rs
+++ b/crates/sparq-prov/src/lib.rs
@@ -25,6 +25,14 @@
 //! derivation. [`derive_construct`] runs the query, times it, and returns a
 //! [`Derivation`] carrying both the derived triples and a PROV-O lineage graph.
 //!
+//! The **SPARQL UPDATE** path is covered: an `INSERT … WHERE` / `INSERT DATA` /
+//! `DELETE …` mutation has a two-sided PROV reading — the triples it **inserts** are
+//! *generated* (a `prov:Entity` `wasGeneratedBy` the update, `wasDerivedFrom` the
+//! matched inputs), the triples it **deletes** are *invalidated*
+//! (`prov:wasInvalidatedBy`). [`derive_update`] applies the update in place, captures
+//! the engine's resolved effect log, and returns an [`UpdateDerivation`] carrying the
+//! inserted + deleted triples and the PROV-O lineage. See the [`update`] module.
+//!
 //! **Reasoner-materialization** lineage is covered under the (non-default)
 //! `reason` feature: [`prov_from_proof`] maps a `sparq-reason` `why()`
 //! [`ProofTree`](sparq_reason::ProofTree) to PROV-O — one `prov:Entity` per
@@ -34,8 +42,10 @@
 //! premises for each fact) than a single CONSTRUCT-style activity. See the
 //! [`reason`] module.
 //!
-//! **Deferred** (filed as follow-up beads, see the crate README): SPARQL UPDATE
-//! (`INSERT … WHERE` / `INSERT DATA`) lineage.
+//! **Out of scope for per-triple lineage** (a deliberate honesty boundary, not a TODO):
+//! the structural UPDATE operations `CLEAR` / `DROP` / `CREATE` change a graph's
+//! existence/emptiness rather than its triples-as-data and carry no resolved triple set,
+//! so [`derive_update`] records them as an activity kind but emits no per-triple entity.
 //!
 //! [`prov:Activity`]: https://www.w3.org/TR/prov-o/#Activity
 //! [`prov:Entity`]: https://www.w3.org/TR/prov-o/#Entity
@@ -53,6 +63,11 @@ use sparq_core::Graph;
 use sparq_engine::QueryBudget;
 
 mod datetime;
+// [OPUS-4.8] sq-xwdd: SPARQL UPDATE lineage — capture PROV-O for the data an
+// `INSERT … WHERE` / `INSERT DATA` / `DELETE …` operation changes in a store. Like
+// the CONSTRUCT path it depends only on sparq-core/sparq-engine (no extra feature).
+mod update;
+pub use update::{derive_update, derive_update_with_budget, UpdateDerivation};
 // [OPUS-4.8] sq-m3i0: reasoner-materialization lineage — map a sparq-reason
 // `why()` proof tree → PROV-O RDF. Non-default feature, so the sparq-reason dep
 // is pulled only when asked for.

--- a/crates/sparq-prov/src/update.rs
+++ b/crates/sparq-prov/src/update.rs
@@ -1,0 +1,770 @@
+//! **SPARQL UPDATE lineage** ([OPUS-4.8] sq-xwdd): capture W3C PROV-O provenance for
+//! the data a SPARQL `INSERT … WHERE` / `INSERT DATA` / `DELETE …` operation **changes**
+//! in a store.
+//!
+//! # UPDATE *is* derivation (for the inserts) + invalidation (for the deletes)
+//!
+//! A SPARQL UPDATE mutates a graph in place. The PROV-O reading of that mutation is
+//! two-sided and standard:
+//!
+//! * the triples it **inserts** are *newly generated* data — a [`prov:Entity`] that
+//!   was [`prov:wasGeneratedBy`] the update [`prov:Activity`] and, for an
+//!   `INSERT … WHERE`, [`prov:wasDerivedFrom`] the matched source(s);
+//! * the triples it **deletes** are *retracted* data — a [`prov:Entity`] the activity
+//!   [`prov:wasInvalidatedBy`] (PROV-O's term for "ceased to exist / be valid"). We do
+//!   **not** claim deletes are "derived"; retraction is invalidation, not generation.
+//!
+//! This is the same opt-in, lean-core shape as the CONSTRUCT path (`derive_construct`):
+//! nothing in sparq's default build depends on it, and capture is exact — we read the
+//! engine's **resolved** [`sparq_engine::UpdateEffect`] log (the concrete per-graph
+//! triple delta the update actually committed), so the lineage reflects what happened,
+//! not a re-evaluation of the (possibly non-deterministic) update text.
+//!
+//! # What is and is NOT covered
+//!
+//! Covered: the data-bearing operations — `INSERT DATA`, `DELETE DATA`,
+//! `DELETE/INSERT … WHERE` (incl. `USING`), and `LOAD` (the loaded triples are the
+//! resolved inserts). Structural operations — `CLEAR` / `DROP` / `CREATE` — change a
+//! graph's *existence/emptiness*, not its triples-as-data, and the engine records them
+//! as opaque `UpdateEffect::Clear/Drop/Create` markers without a resolved triple set; we
+//! count them as activity kinds but emit **no** per-triple entity for them (there is no
+//! sound per-triple derivation to assert). A `CLEAR`/`DROP` that retracts existing data
+//! is therefore not enumerated triple-by-triple here — only the explicit `DELETE`
+//! retractions are. (This is a deliberate honesty boundary, not an oversight.)
+//!
+//! [`prov:Entity`]: https://www.w3.org/TR/prov-o/#Entity
+//! [`prov:Activity`]: https://www.w3.org/TR/prov-o/#Activity
+//! [`prov:wasGeneratedBy`]: https://www.w3.org/TR/prov-o/#wasGeneratedBy
+//! [`prov:wasDerivedFrom`]: https://www.w3.org/TR/prov-o/#wasDerivedFrom
+//! [`prov:wasInvalidatedBy`]: https://www.w3.org/TR/prov-o/#wasInvalidatedBy
+
+use std::time::SystemTime;
+
+use oxrdf::vocab::rdf;
+use oxrdf::{Literal, NamedNode, NamedOrBlankNode, Term, Triple};
+use sparq_core::Graph;
+use sparq_engine::{QueryBudget, UpdateEffect};
+
+use crate::{datetime_literal, mint, prov, ProvConfig};
+
+/// A completed SPARQL UPDATE, with its W3C PROV-O lineage.
+///
+/// Produced by [`derive_update`]. The update has **already been applied** to the graph
+/// (it is captured from the resolved effect log of the in-place application). The record
+/// carries the concrete triples the update **inserted** ([`inserted`](Self::inserted) —
+/// the *derived* data) and **deleted** ([`deleted`](Self::deleted) — the *retracted*
+/// data); [`prov_graph`](Self::prov_graph) materialises the lineage as PROV-O RDF.
+#[derive(Clone, Debug)]
+pub struct UpdateDerivation {
+    inserted: Vec<Triple>,
+    deleted: Vec<Triple>,
+    activity: NamedNode,
+    /// The generated-result entity (the inserts). Always minted/configured even when the
+    /// update inserts nothing, so the activity is still a nameable PROV node.
+    entity: NamedNode,
+    used: Vec<NamedNode>,
+    agent: Option<NamedNode>,
+    started: SystemTime,
+    ended: SystemTime,
+    query: String,
+    /// Operation-kind label surfaced on the activity (e.g. `"INSERT DATA"`,
+    /// `"DELETE/INSERT WHERE"`, `"SPARQL UPDATE"` for a mixed/multi-op body).
+    kind: &'static str,
+}
+
+impl UpdateDerivation {
+    /// The triples the update **inserted** — the newly *generated* (derived) data.
+    pub fn inserted(&self) -> &[Triple] {
+        &self.inserted
+    }
+
+    /// The triples the update **deleted** — the *retracted* (invalidated) data.
+    pub fn deleted(&self) -> &[Triple] {
+        &self.deleted
+    }
+
+    /// The activity IRI ([`prov:Activity`](https://www.w3.org/TR/prov-o/#Activity)).
+    pub fn activity(&self) -> &NamedNode {
+        &self.activity
+    }
+
+    /// The generated-result entity IRI ([`prov:Entity`](https://www.w3.org/TR/prov-o/#Entity)),
+    /// naming the set of inserted triples.
+    pub fn entity(&self) -> &NamedNode {
+        &self.entity
+    }
+
+    /// Start/end wall-clock instants of the update activity.
+    pub fn timing(&self) -> (SystemTime, SystemTime) {
+        (self.started, self.ended)
+    }
+
+    /// The PROV-O lineage of this update as an RDF graph (a `Vec<Triple>`).
+    ///
+    /// Emits, for the update activity `A`, the generated entity `E` (the inserts), and
+    /// each configured input `Iᵢ`:
+    ///
+    /// - `A a prov:Activity`, `A rdfs:label "<kind>"`, `A prov:value "<sparql>"`
+    /// - `A prov:startedAtTime "…"^^xsd:dateTime`, `A prov:endedAtTime "…"^^xsd:dateTime`
+    /// - `E a prov:Entity`, `E prov:wasGeneratedBy A` — **only when the update inserted
+    ///   data** (no inserts ⇒ no generated entity, which is the correct PROV reading: a
+    ///   pure-delete update generated nothing)
+    /// - `A prov:used Iᵢ`, `E prov:wasDerivedFrom Iᵢ` (for each input; the
+    ///   `wasDerivedFrom` only when there is an `E`)
+    /// - `A prov:wasAssociatedWith G` (if an agent is configured)
+    /// - for **deletes**: one fresh blank-node `prov:Entity` per retracted triple,
+    ///   `… prov:wasInvalidatedBy A`. Deletes are invalidations, not derivations, so they
+    ///   are never `wasGeneratedBy`/`wasDerivedFrom`.
+    ///
+    /// All IRIs are absolute (deleted-entity nodes are blank), so the graph is valid
+    /// PROV-O and round-trips through any RDF parser.
+    pub fn prov_graph(&self) -> Vec<Triple> {
+        let a = NamedOrBlankNode::NamedNode(self.activity.clone());
+        let e = NamedOrBlankNode::NamedNode(self.entity.clone());
+        let mut out: Vec<Triple> = Vec::new();
+        let mut push = |s: NamedOrBlankNode, p: NamedNode, o: Term| {
+            out.push(Triple {
+                subject: s,
+                predicate: p,
+                object: o,
+            });
+        };
+
+        // Activity: type, kind label, the update recipe, timing.
+        push(
+            a.clone(),
+            NamedNode::from(rdf::TYPE),
+            Term::NamedNode(prov("Activity")),
+        );
+        push(
+            a.clone(),
+            NamedNode::new_unchecked("http://www.w3.org/2000/01/rdf-schema#label"),
+            Term::Literal(Literal::new_simple_literal(self.kind)),
+        );
+        push(
+            a.clone(),
+            prov("value"),
+            Term::Literal(Literal::new_simple_literal(&self.query)),
+        );
+        push(
+            a.clone(),
+            prov("startedAtTime"),
+            Term::Literal(datetime_literal(self.started)),
+        );
+        push(
+            a.clone(),
+            prov("endedAtTime"),
+            Term::Literal(datetime_literal(self.ended)),
+        );
+
+        if let Some(agent) = &self.agent {
+            push(
+                a.clone(),
+                prov("wasAssociatedWith"),
+                Term::NamedNode(agent.clone()),
+            );
+        }
+
+        // Generated entity (the inserts). A pure-delete update generates nothing, so we
+        // only assert the result entity + generation/derivation edges when it inserted.
+        if !self.inserted.is_empty() {
+            push(
+                e.clone(),
+                NamedNode::from(rdf::TYPE),
+                Term::NamedNode(prov("Entity")),
+            );
+            push(
+                e.clone(),
+                prov("wasGeneratedBy"),
+                Term::NamedNode(self.activity.clone()),
+            );
+            for input in &self.used {
+                push(
+                    e.clone(),
+                    prov("wasDerivedFrom"),
+                    Term::NamedNode(input.clone()),
+                );
+            }
+        }
+        // `prov:used` is on the activity regardless of whether anything was inserted — the
+        // activity consulted those inputs (the WHERE/USING dataset) even if no row matched.
+        for input in &self.used {
+            push(a.clone(), prov("used"), Term::NamedNode(input.clone()));
+        }
+
+        // Deleted triples: each retracted triple is an entity the activity invalidated.
+        // (The retracted triple's terms are not re-stated — a deleted triple no longer
+        // exists in the store, so we name it by a fresh blank-node entity, not by value.)
+        for _ in &self.deleted {
+            let de = NamedOrBlankNode::BlankNode(oxrdf::BlankNode::default());
+            push(
+                de.clone(),
+                NamedNode::from(rdf::TYPE),
+                Term::NamedNode(prov("Entity")),
+            );
+            push(
+                de,
+                prov("wasInvalidatedBy"),
+                Term::NamedNode(self.activity.clone()),
+            );
+        }
+        out
+    }
+
+    /// The PROV-O lineage serialised as N-Triples (also a valid Turtle document).
+    pub fn prov_ntriples(&self) -> String {
+        sparq_engine::triples_to_ntriples(&self.prov_graph())
+    }
+}
+
+/// Apply a SPARQL UPDATE to `graph` **in place**, capturing W3C PROV-O lineage for the
+/// data it changes.
+///
+/// The update is evaluated through the engine's effect-capturing in-place path
+/// ([`sparq_engine::update_in_place_capturing`]), so the returned [`UpdateDerivation`]
+/// records the **resolved** triples that were actually inserted (the derived data, a
+/// `prov:Entity` that `wasGeneratedBy` the activity) and deleted (retracted data, each a
+/// `prov:Entity` the activity `wasInvalidatedBy`) — not a re-evaluation of the text.
+///
+/// On a parse error or a failing non-`SILENT` `LOAD`, `graph` is left in whatever
+/// partially-applied state the update reached (identical to
+/// [`sparq_engine::update_in_place`]) and no derivation is returned.
+///
+/// ```
+/// use sparq_core::Graph;
+/// use sparq_prov::{derive_update, ProvConfig};
+/// use oxrdf::NamedNode;
+///
+/// let mut g = Graph::load_str("@prefix ex: <http://ex/> . ex:a ex:age 30 .", "turtle").unwrap();
+/// let cfg = ProvConfig::with_inputs([NamedNode::new_unchecked("http://ex/src")]);
+/// let d = derive_update(
+///     &mut g,
+///     "PREFIX ex: <http://ex/> INSERT { ?s ex:years ?a } WHERE { ?s ex:age ?a }",
+///     cfg,
+/// ).unwrap();
+/// assert_eq!(d.inserted().len(), 1); // ex:a ex:years 30
+/// let lineage = d.prov_graph();      // its PROV-O record
+/// ```
+pub fn derive_update(
+    graph: &mut Graph,
+    sparql: &str,
+    config: ProvConfig,
+) -> Result<UpdateDerivation, String> {
+    derive_update_with_budget(graph, sparql, config, &QueryBudget::unlimited())
+}
+
+/// [`derive_update`] under a cooperative [`QueryBudget`] (bounds a `… WHERE` whose
+/// pattern blows up, exactly as a budgeted `SELECT` is bounded).
+pub fn derive_update_with_budget(
+    graph: &mut Graph,
+    sparql: &str,
+    config: ProvConfig,
+    budget: &QueryBudget,
+) -> Result<UpdateDerivation, String> {
+    let started = (config.clock)();
+    let effects = sparq_engine::update_in_place_capturing(graph, sparql, budget)?;
+    let ended = (config.clock)();
+
+    let kind = kind_label(sparql);
+    let (inserted, deleted) = partition_effects(&effects);
+
+    let activity = config
+        .activity
+        .unwrap_or_else(|| mint("activity", started, ended, sparql));
+    let entity = config
+        .entity
+        .unwrap_or_else(|| mint("entity", started, ended, sparql));
+
+    Ok(UpdateDerivation {
+        inserted,
+        deleted,
+        activity,
+        entity,
+        used: config.used,
+        agent: config.agent,
+        started,
+        ended,
+        query: sparql.to_string(),
+        kind,
+    })
+}
+
+/// Split the resolved effect log into the inserted (derived) and deleted (retracted)
+/// triples, preserving capture order. Structural effects (CLEAR/DROP/CREATE) carry no
+/// resolved triples, so they contribute nothing here (see the module docs).
+fn partition_effects(effects: &[UpdateEffect]) -> (Vec<Triple>, Vec<Triple>) {
+    let mut inserted = Vec::new();
+    let mut deleted = Vec::new();
+    for effect in effects {
+        if let UpdateEffect::Delta {
+            inserts, deletes, ..
+        } = effect
+        {
+            inserted.extend(inserts.iter().filter_map(terms_to_triple));
+            deleted.extend(deletes.iter().filter_map(terms_to_triple));
+        }
+    }
+    (inserted, deleted)
+}
+
+/// A resolved `[subject, predicate, object]` term-triple → an `oxrdf::Triple`.
+///
+/// In well-formed RDF the subject is a NamedNode or BlankNode and the predicate a
+/// NamedNode; the engine only ever produces such triples for the data operations (the
+/// SPARQL grammar forbids a literal/quoted-triple subject or a non-IRI predicate). A
+/// malformed shape is skipped rather than panicking — defensive, never expected.
+fn terms_to_triple(terms: &[Term; 3]) -> Option<Triple> {
+    let subject = match &terms[0] {
+        Term::NamedNode(n) => NamedOrBlankNode::NamedNode(n.clone()),
+        Term::BlankNode(b) => NamedOrBlankNode::BlankNode(b.clone()),
+        _ => return None,
+    };
+    let predicate = match &terms[1] {
+        Term::NamedNode(n) => n.clone(),
+        _ => return None,
+    };
+    Some(Triple {
+        subject,
+        predicate,
+        object: terms[2].clone(),
+    })
+}
+
+/// A coarse, allocation-free operation-kind label for the activity's `rdfs:label`.
+///
+/// Looks at the leading keyword(s) of the (uppercased-insensitive) update text. A
+/// multi-operation body (or one we don't special-case) is labelled `"SPARQL UPDATE"`.
+/// This is a human-facing annotation only — lineage correctness rests on the resolved
+/// effect log, not this string.
+fn kind_label(sparql: &str) -> &'static str {
+    // Strip leading PREFIX/BASE declarations + whitespace to reach the first operation.
+    let body = strip_prologue(sparql);
+    let upper = body.trim_start().to_ascii_uppercase();
+    // Detect a multi-op body conservatively: more than one top-level operation keyword.
+    if is_multi_op(&upper) {
+        return "SPARQL UPDATE";
+    }
+    if upper.starts_with("INSERT DATA") {
+        "INSERT DATA"
+    } else if upper.starts_with("DELETE DATA") {
+        "DELETE DATA"
+    } else if upper.starts_with("INSERT")
+        || upper.starts_with("DELETE")
+        || upper.starts_with("WITH")
+        || upper.starts_with("USING")
+    {
+        // INSERT { } WHERE, DELETE { } WHERE, DELETE WHERE, WITH … DELETE/INSERT, etc.
+        "DELETE/INSERT WHERE"
+    } else if upper.starts_with("LOAD") {
+        "LOAD"
+    } else {
+        // CLEAR / DROP / CREATE / ADD / COPY / MOVE — or anything else.
+        "SPARQL UPDATE"
+    }
+}
+
+/// Drop leading `PREFIX …` / `BASE …` declarations so [`kind_label`] sees the first
+/// operation keyword. Operates line-by-line on a best-effort basis (kind is cosmetic).
+fn strip_prologue(sparql: &str) -> &str {
+    let mut rest = sparql.trim_start();
+    loop {
+        let up = rest.to_ascii_uppercase();
+        let decl = if up.starts_with("PREFIX") {
+            // PREFIX ns: <iri> — skip to past the closing '>'.
+            rest.find('>').map(|i| i + 1)
+        } else if up.starts_with("BASE") {
+            rest.find('>').map(|i| i + 1)
+        } else {
+            None
+        };
+        match decl {
+            Some(i) if i <= rest.len() => rest = rest[i..].trim_start(),
+            _ => return rest,
+        }
+    }
+}
+
+/// True if the update body contains more than one top-level operation, separated by `;`.
+/// A conservative scan that ignores `;` inside `<…>` IRIs and `"…"`/`'…'` string
+/// literals (where a semicolon is data, or a Turtle predicate-list separator inside a
+/// template — which is also not an operation boundary). Cosmetic-only.
+fn is_multi_op(upper: &str) -> bool {
+    // We only need "is there a top-level `;` followed by a non-empty operation?".
+    let bytes = upper.as_bytes();
+    let mut depth_iri = false;
+    let mut in_dq = false;
+    let mut in_sq = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        match c {
+            b'<' if !in_dq && !in_sq => depth_iri = true,
+            b'>' if depth_iri => depth_iri = false,
+            b'"' if !in_sq && !depth_iri => in_dq = !in_dq,
+            b'\'' if !in_dq && !depth_iri => in_sq = !in_sq,
+            b';' if !depth_iri && !in_dq && !in_sq => {
+                // A top-level ';' — is anything non-blank after it?
+                if upper[i + 1..].trim().is_empty() {
+                    return false; // trailing separator only
+                }
+                // A ';' at the top level separates operations ONLY outside a template
+                // `{ … }`. Templates use ';' as Turtle predicate-list shorthand, so a
+                // top-level ';' inside braces is NOT an operation boundary. Track brace
+                // depth to tell them apart.
+                return has_top_level_semicolon(upper);
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Precise check: a `;` at brace-depth 0, outside IRIs/strings, with a following op.
+fn has_top_level_semicolon(upper: &str) -> bool {
+    let bytes = upper.as_bytes();
+    let (mut brace, mut iri, mut dq, mut sq) = (0i32, false, false, false);
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'<' if !dq && !sq => iri = true,
+            b'>' if iri => iri = false,
+            b'"' if !sq && !iri => dq = !dq,
+            b'\'' if !dq && !iri => sq = !sq,
+            b'{' if !iri && !dq && !sq => brace += 1,
+            b'}' if !iri && !dq && !sq => brace -= 1,
+            b';' if brace == 0 && !iri && !dq && !sq && !upper[i + 1..].trim().is_empty() => {
+                return true;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxrdf::vocab::xsd;
+    use std::collections::HashSet;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    const DATA: &str = r#"
+        @prefix ex: <http://ex/> .
+        ex:alice ex:age 30 ; ex:name "Alice" .
+        ex:bob   ex:age 25 ; ex:name "Bob" .
+    "#;
+
+    fn g() -> Graph {
+        Graph::load_str(DATA, "turtle").unwrap()
+    }
+
+    fn fixed_clock() -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(1_700_000_000)
+    }
+
+    fn cfg() -> ProvConfig {
+        ProvConfig {
+            clock: fixed_clock,
+            used: vec![NamedNode::new_unchecked("http://ex/source-graph")],
+            ..ProvConfig::default()
+        }
+    }
+
+    fn line(t: &Triple) -> String {
+        format!("{} {} {} .", t.subject, t.predicate, t.object)
+    }
+
+    fn lines(d: &UpdateDerivation) -> HashSet<String> {
+        d.prov_graph().iter().map(line).collect()
+    }
+
+    #[test]
+    fn insert_where_records_generation_and_derivation() {
+        let mut graph = g();
+        let d = derive_update(
+            &mut graph,
+            "PREFIX ex: <http://ex/> INSERT { ?s ex:years ?a } WHERE { ?s ex:age ?a }",
+            cfg(),
+        )
+        .unwrap();
+
+        // The derived data: one renamed triple per matched subject; nothing retracted.
+        assert_eq!(d.inserted().len(), 2);
+        assert!(d.deleted().is_empty());
+    }
+
+    #[test]
+    fn insert_where_is_applied_in_place() {
+        let mut graph = g();
+        derive_update(
+            &mut graph,
+            "PREFIX ex: <http://ex/> INSERT { ?s ex:years ?a } WHERE { ?s ex:age ?a }",
+            cfg(),
+        )
+        .unwrap();
+        // The store now contains the inserted triples.
+        let n = sparq_engine::construct(
+            &graph,
+            "PREFIX ex: <http://ex/> CONSTRUCT { ?s ex:years ?a } WHERE { ?s ex:years ?a }",
+        )
+        .unwrap();
+        assert_eq!(n.len(), 2);
+    }
+
+    #[test]
+    fn insert_where_emits_core_prov_shape() {
+        let mut graph = g();
+        let d = derive_update(
+            &mut graph,
+            "PREFIX ex: <http://ex/> INSERT { ?s ex:years ?a } WHERE { ?s ex:age ?a }",
+            cfg(),
+        )
+        .unwrap();
+
+        let ls = lines(&d);
+        let a = d.activity().as_str();
+        let e = d.entity().as_str();
+
+        assert!(ls.contains(&format!(
+            "<{a}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Activity> ."
+        )));
+        assert!(ls.contains(&format!(
+            "<{e}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Entity> ."
+        )));
+        assert!(ls.contains(&format!(
+            "<{e}> <http://www.w3.org/ns/prov#wasGeneratedBy> <{a}> ."
+        )));
+        assert!(ls.contains(&format!(
+            "<{a}> <http://www.w3.org/ns/prov#used> <http://ex/source-graph> ."
+        )));
+        assert!(ls.contains(&format!(
+            "<{e}> <http://www.w3.org/ns/prov#wasDerivedFrom> <http://ex/source-graph> ."
+        )));
+        // The activity is labelled with the operation kind.
+        assert!(ls.contains(&format!(
+            "<{a}> <http://www.w3.org/2000/01/rdf-schema#label> \"DELETE/INSERT WHERE\" ."
+        )));
+        // Timing: the fixed clock = 2023-11-14T22:13:20Z, typed xsd:dateTime.
+        assert!(ls.contains(&format!(
+            "<{a}> <http://www.w3.org/ns/prov#startedAtTime> \"2023-11-14T22:13:20Z\"^^<{}> .",
+            xsd::DATE_TIME.as_str()
+        )));
+        assert!(ls.iter().any(|l| l.contains("#endedAtTime>")));
+    }
+
+    #[test]
+    fn insert_data_is_a_generation_with_no_where_match() {
+        let mut graph = g();
+        let d = derive_update(
+            &mut graph,
+            "PREFIX ex: <http://ex/> INSERT DATA { ex:carol ex:age 40 }",
+            cfg(),
+        )
+        .unwrap();
+        assert_eq!(d.inserted().len(), 1);
+        assert!(d.deleted().is_empty());
+        let ls = lines(&d);
+        let a = d.activity().as_str();
+        // The kind label distinguishes INSERT DATA from INSERT...WHERE.
+        assert!(ls.contains(&format!(
+            "<{a}> <http://www.w3.org/2000/01/rdf-schema#label> \"INSERT DATA\" ."
+        )));
+        // Still has a generated entity.
+        assert!(ls.iter().any(|l| l.contains("#wasGeneratedBy>")));
+    }
+
+    #[test]
+    fn delete_insert_where_records_both_sides() {
+        let mut graph = g();
+        let d = derive_update(
+            &mut graph,
+            "PREFIX ex: <http://ex/> \
+             DELETE { ?s ex:age ?a } INSERT { ?s ex:years ?a } WHERE { ?s ex:age ?a }",
+            cfg(),
+        )
+        .unwrap();
+        assert_eq!(d.inserted().len(), 2, "two ex:years inserts");
+        assert_eq!(d.deleted().len(), 2, "two ex:age deletes");
+
+        let ls = lines(&d);
+        let a = d.activity().as_str();
+        // Each delete is an entity the activity INVALIDATED — never generated/derived.
+        let inval: Vec<_> = ls
+            .iter()
+            .filter(|l| l.contains("#wasInvalidatedBy>"))
+            .collect();
+        assert_eq!(inval.len(), 2, "one wasInvalidatedBy per deleted triple");
+        assert!(inval.iter().all(|l| l.ends_with(&format!("<{a}> ."))));
+        // No invalidated entity is also derived-from.
+        assert!(ls
+            .iter()
+            .all(|l| { !(l.contains("#wasInvalidatedBy>") && l.contains("#wasDerivedFrom>")) }));
+    }
+
+    #[test]
+    fn pure_delete_generates_nothing() {
+        let mut graph = g();
+        let d = derive_update(
+            &mut graph,
+            "PREFIX ex: <http://ex/> DELETE { ?s ex:name ?n } WHERE { ?s ex:name ?n }",
+            cfg(),
+        )
+        .unwrap();
+        assert!(d.inserted().is_empty());
+        assert_eq!(d.deleted().len(), 2);
+
+        let ls = lines(&d);
+        // A pure-delete update GENERATED nothing: no result-entity type, no
+        // wasGeneratedBy, no wasDerivedFrom.
+        assert!(ls.iter().all(|l| !l.contains("#wasGeneratedBy>")));
+        assert!(ls.iter().all(|l| !l.contains("#wasDerivedFrom>")));
+        // ...but the activity still records `used` (it consulted the inputs).
+        assert!(ls.iter().any(|l| l.contains("#used>")));
+        // ...and each retracted triple is invalidated.
+        assert_eq!(
+            ls.iter()
+                .filter(|l| l.contains("#wasInvalidatedBy>"))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn prov_graph_is_valid_rdf_and_round_trips() {
+        let mut graph = g();
+        let d = derive_update(
+            &mut graph,
+            "PREFIX ex: <http://ex/> \
+             DELETE { ?s ex:age ?a } INSERT { ?s ex:years ?a } WHERE { ?s ex:age ?a }",
+            cfg(),
+        )
+        .unwrap();
+        let nt = d.prov_ntriples();
+        let reloaded = Graph::load_str(&nt, "turtle").expect("PROV-O output must be valid RDF");
+        assert_eq!(reloaded.len(), d.prov_graph().len());
+
+        use oxttl::NTriplesParser;
+        let parsed: Vec<_> = NTriplesParser::new()
+            .for_reader(nt.as_bytes())
+            .collect::<Result<_, _>>()
+            .expect("emitted lineage must be well-formed N-Triples");
+        assert_eq!(parsed.len(), d.prov_graph().len());
+    }
+
+    #[test]
+    fn explicit_iris_and_agent_are_honoured() {
+        let mut graph = g();
+        let activity = NamedNode::new_unchecked("http://ex/act/1");
+        let entity = NamedNode::new_unchecked("http://ex/result/1");
+        let agent = NamedNode::new_unchecked("http://ex/service");
+        let config = ProvConfig {
+            activity: Some(activity.clone()),
+            entity: Some(entity.clone()),
+            agent: Some(agent.clone()),
+            used: vec![NamedNode::new_unchecked("http://ex/g")],
+            clock: fixed_clock,
+        };
+        let d = derive_update(
+            &mut graph,
+            "PREFIX ex: <http://ex/> INSERT { ?s ex:years ?a } WHERE { ?s ex:age ?a }",
+            config,
+        )
+        .unwrap();
+        assert_eq!(d.activity(), &activity);
+        assert_eq!(d.entity(), &entity);
+        assert!(lines(&d).contains(
+            "<http://ex/act/1> <http://www.w3.org/ns/prov#wasAssociatedWith> <http://ex/service> ."
+        ));
+    }
+
+    #[test]
+    fn minted_iris_are_stable_for_the_same_update() {
+        let q = "PREFIX ex: <http://ex/> INSERT { ?s ex:years ?a } WHERE { ?s ex:age ?a }";
+        let a = derive_update(&mut g(), q, cfg()).unwrap();
+        let b = derive_update(&mut g(), q, cfg()).unwrap();
+        assert_eq!(a.activity(), b.activity());
+        assert_eq!(a.entity(), b.entity());
+        let c = derive_update(
+            &mut g(),
+            "PREFIX ex: <http://ex/> INSERT DATA { <http://ex/x> <http://ex/p> 1 }",
+            cfg(),
+        )
+        .unwrap();
+        assert_ne!(a.activity(), c.activity());
+    }
+
+    #[test]
+    fn rejects_query_text_not_an_update() {
+        // A SELECT is not a valid UPDATE — the engine's parser rejects it.
+        assert!(derive_update(&mut g(), "SELECT * WHERE { ?s ?p ?o }", cfg()).is_err());
+    }
+
+    #[test]
+    fn kind_label_classifies_operations() {
+        assert_eq!(kind_label("INSERT DATA { <a> <b> <c> }"), "INSERT DATA");
+        assert_eq!(kind_label("DELETE DATA { <a> <b> <c> }"), "DELETE DATA");
+        assert_eq!(
+            kind_label("PREFIX ex: <http://ex/> INSERT { ?s ?p ?o } WHERE { ?s ?p ?o }"),
+            "DELETE/INSERT WHERE"
+        );
+        assert_eq!(
+            kind_label("DELETE WHERE { ?s ?p ?o }"),
+            "DELETE/INSERT WHERE"
+        );
+        assert_eq!(
+            kind_label("WITH <http://g/> DELETE { ?s ?p ?o } WHERE { ?s ?p ?o }"),
+            "DELETE/INSERT WHERE"
+        );
+        assert_eq!(kind_label("LOAD <http://ex/doc>"), "LOAD");
+        assert_eq!(kind_label("CLEAR DEFAULT"), "SPARQL UPDATE");
+        // A multi-op body is labelled generically.
+        assert_eq!(
+            kind_label("INSERT DATA { <a> <b> <c> } ; DELETE DATA { <a> <b> <c> }"),
+            "SPARQL UPDATE"
+        );
+    }
+
+    #[test]
+    fn semicolon_inside_template_is_not_a_multi_op() {
+        // Turtle predicate-list ';' inside the INSERT template is NOT an op boundary.
+        assert_eq!(
+            kind_label(
+                "PREFIX ex: <http://ex/> INSERT { ?s ex:a 1 ; ex:b 2 } WHERE { ?s ex:age ?o }"
+            ),
+            "DELETE/INSERT WHERE"
+        );
+        // A ';' inside a string literal is data, not an op boundary.
+        assert_eq!(
+            kind_label("INSERT DATA { <http://ex/s> <http://ex/p> \"a; b\" }"),
+            "INSERT DATA"
+        );
+    }
+
+    #[test]
+    fn empty_inputs_omit_used_and_derived_edges() {
+        let config = ProvConfig {
+            clock: fixed_clock,
+            ..ProvConfig::default()
+        };
+        let mut graph = g();
+        let d = derive_update(
+            &mut graph,
+            "PREFIX ex: <http://ex/> INSERT { ?s ex:years ?a } WHERE { ?s ex:age ?a }",
+            config,
+        )
+        .unwrap();
+        let prov = d.prov_graph();
+        assert!(prov
+            .iter()
+            .all(|t| t.predicate.as_str() != "http://www.w3.org/ns/prov#used"));
+        assert!(prov
+            .iter()
+            .all(|t| t.predicate.as_str() != "http://www.w3.org/ns/prov#wasDerivedFrom"));
+        // The generation edge survives (there were inserts).
+        assert!(prov
+            .iter()
+            .any(|t| t.predicate.as_str() == "http://www.w3.org/ns/prov#wasGeneratedBy"));
+    }
+}

--- a/skills/prov-lineage/SKILL.md
+++ b/skills/prov-lineage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prov-lineage
-description: "Capture W3C PROV-O data lineage for DERIVED RDF — when a CONSTRUCT/DESCRIBE query produces a new graph, OR a reasoner materializes inferred triples (RDFS/OWL-RL/N3), record who/what/when made it (prov:Activity + prov:Entity + wasGeneratedBy/used/wasDerivedFrom) using the opt-in sparq-prov crate. Use when you need machine-readable provenance for derived data — citable lineage for GenAI-grounded answers, audit/compliance (CDMC CD-1) data-lineage capture, attribution of constructed graphs to their source(s), or per-fact inference lineage from a why() proof tree (the `reason` feature). Off by default; does not touch sparq-core/sparq-engine's lean build."
+description: "Capture W3C PROV-O data lineage for DERIVED RDF — when a CONSTRUCT/DESCRIBE query produces a new graph, a SPARQL UPDATE (INSERT…WHERE / INSERT DATA / DELETE) changes a store, OR a reasoner materializes inferred triples (RDFS/OWL-RL/N3), record who/what/when made it (prov:Activity + prov:Entity + wasGeneratedBy/used/wasDerivedFrom; wasInvalidatedBy for deletes) using the opt-in sparq-prov crate. Use when you need machine-readable provenance for derived/mutated data — citable lineage for GenAI-grounded answers, audit/compliance (CDMC CD-1) data-lineage capture, attribution of constructed graphs or UPDATE writes to their source(s), or per-fact inference lineage from a why() proof tree (the `reason` feature). Off by default; does not touch sparq-core/sparq-engine's lean build."
 ---
 
 # sparq-prov — W3C PROV-O lineage for derived data
@@ -69,6 +69,57 @@ A  prov:wasAssociatedWith <agent> .           # if ProvConfig.agent is set
 All IRIs are absolute, so the output is valid PROV-O that round-trips through any
 RDF parser (tested against both `Graph::load_str` and `oxttl::NTriplesParser`).
 
+## Capture lineage for a SPARQL UPDATE
+
+A SPARQL UPDATE mutates a store. `derive_update` applies it **in place** and reads the
+engine's *resolved* effect log, so the lineage reflects the triples actually committed
+(exact even for non-deterministic update text — `NOW()`/`RAND()`/`UUID()`/fresh
+`BNODE()`). The PROV reading is two-sided: **inserts** are *generated/derived*, **deletes**
+are *invalidated*.
+
+```rust
+use sparq_core::Graph;
+use sparq_prov::{derive_update, ProvConfig};
+use oxrdf::NamedNode;
+
+let mut g = Graph::load_str("@prefix ex: <http://ex/> . ex:a ex:age 30 .", "turtle").unwrap();
+let cfg = ProvConfig::with_inputs([NamedNode::new_unchecked("http://ex/src")]);
+let d = derive_update(
+    &mut g,
+    "PREFIX ex: <http://ex/> \
+     DELETE { ?s ex:age ?a } INSERT { ?s ex:years ?a } WHERE { ?s ex:age ?a }",
+    cfg,
+).unwrap();
+
+let inserted = d.inserted();    // the generated (derived) triples
+let deleted  = d.deleted();     // the retracted (invalidated) triples
+let lineage  = d.prov_graph();  // its PROV-O record (Vec<Triple>)
+```
+
+Emitted shape — for update activity `A`, generated entity `E` (the inserts), inputs `Iᵢ`:
+
+```turtle
+A  a                    prov:Activity .
+A  rdfs:label           "DELETE/INSERT WHERE" .   # / "INSERT DATA" / "LOAD" / "SPARQL UPDATE"
+A  prov:value           "<the SPARQL text>" .
+A  prov:startedAtTime   "…Z"^^xsd:dateTime .
+A  prov:endedAtTime     "…Z"^^xsd:dateTime .
+A  prov:used            Iᵢ .                       # one per input
+E  a                    prov:Entity .              # only if the update INSERTED
+E  prov:wasGeneratedBy  A .                         #   "
+E  prov:wasDerivedFrom  Iᵢ .                        #   " (one per input)
+_:d a                   prov:Entity ;               # one fresh blank node per DELETED triple
+    prov:wasInvalidatedBy A .
+```
+
+Honesty boundaries:
+
+- **Deletes are invalidations, not derivations** — a deleted triple is never
+  `wasGeneratedBy`/`wasDerivedFrom`. A pure-delete update generates **no** result entity.
+- **Structural ops** (`CLEAR` / `DROP` / `CREATE`) change a graph's existence/emptiness,
+  not its triples-as-data — they are reflected only in the activity kind label, with **no**
+  per-triple entity (no sound per-triple derivation to assert).
+
 ## Identity & determinism
 
 - IRIs default to stable, content-addressed `urn:sparq:prov:{role}:…` nodes — the
@@ -128,7 +179,8 @@ DAG (the same shared fact names the same entity).
 |---|---|
 | `CONSTRUCT` / `DESCRIBE` | ✅ covered (`derive_construct`) |
 | Reasoner materialization (RDFS / OWL-RL / N3) | ✅ covered (`reason` feature → `prov_from_proof`) |
-| SPARQL UPDATE (`INSERT … WHERE`, `INSERT DATA`) | ⏳ deferred (follow-up bead) |
+| SPARQL UPDATE data ops (`INSERT … WHERE`, `INSERT DATA`, `DELETE …`, `LOAD`) | ✅ covered (`derive_update`) — inserts ⇒ generated/derived, deletes ⇒ `wasInvalidatedBy` |
+| SPARQL UPDATE structural ops (`CLEAR` / `DROP` / `CREATE`) | ⛔ no per-triple entity (deliberate boundary — recorded only as the activity kind) |
 
 For the reasoner's per-fact proof itself (the input to `prov_from_proof`), see the
 [`inference`](../inference/SKILL.md) skill's `explain` feature (`why()` produces


### PR DESCRIPTION
> 🤖 SPARQ agent — automated change. Review before arming auto-merge.

## What & why

Implements bead **sq-xwdd** (CDMC CD-1): extend the opt-in `sparq-prov` crate's
W3C PROV-O lineage capture from `CONSTRUCT`/`DESCRIBE` + reasoner materialization
to the **SPARQL UPDATE** data path — the last derivation surface the crate's scope
table listed as deferred.

A SPARQL UPDATE mutates a store, so it is a PROV event. `derive_update` applies
the update **in place** through the engine's effect-capturing path
(`sparq_engine::update_in_place_capturing`) and reads its **resolved**
`UpdateEffect` log, so the captured lineage reflects the triples actually
committed — exact even for non-deterministic update text (`NOW()`/`RAND()`/
`UUID()`/fresh `BNODE()`), since it never re-evaluates the text.

## The PROV reading (two-sided, honest)

- **Inserts** are *generated* data — a `prov:Entity` `wasGeneratedBy` the update
  `prov:Activity`, `wasDerivedFrom` the configured inputs.
- **Deletes** are *invalidated* data — one fresh blank-node `prov:Entity` per
  retracted triple, `prov:wasInvalidatedBy` the activity. Deletes are **never**
  claimed generated/derived, and a **pure-delete** update emits **no** result
  entity (it generated nothing — the correct PROV reading).

### Deliberate honesty boundary (documented, not a TODO)

Structural ops `CLEAR` / `DROP` / `CREATE` change a graph's existence/emptiness
rather than its triples-as-data, and the engine records them without a resolved
triple set, so they are reflected **only** in the activity's `rdfs:label` kind —
**no** per-triple entity (no sound per-triple derivation to assert).

## Public surface

New (in the `publish = false`, opt-in `sparq-prov` crate; nothing in the default
build or wasm artifact depends on it): `derive_update`,
`derive_update_with_budget`, `UpdateDerivation` (with `inserted`/`deleted`/
`activity`/`entity`/`timing`/`prov_graph`/`prov_ntriples`). **No new
dependencies** — `sparq-core` + `sparq-engine` only, same as the CONSTRUCT path.

## Tests & gates

- 22 unit + doc tests pass: INSERT…WHERE generation/derivation, INSERT DATA,
  DELETE/INSERT WHERE both-sided, pure-delete generates-nothing, PROV-O round-trip
  through `Graph::load_str` + `oxttl::NTriplesParser`, explicit IRIs/agent, minted-IRI
  stability, kind-label classification (incl. `;` inside a template/string literal is
  not a multi-op boundary), empty-inputs edge omission.
- `cargo build` + `clippy --all-targets -- -D warnings` + `cargo test` pass in
  **both feature states** (default and `reason`); `cargo fmt --check` clean.
- **privacy-claims** honesty gate ✅ (PROV-O is plain RDF — no ZK/MPC soundness/
  privacy claim asserted anywhere in the docs).
- **skill-frontmatter** gate ✅, **G2** public-api→SKILL.md gate ✅ (README +
  `skills/prov-lineage/SKILL.md` updated in the same diff).

[OPUS-4.8] — Opus 4.8 (Fable unavailable); flag for re-review when Fable returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
