### PR TITLE
feat(sparq-policy): ODRL static conflict + containment detection (sq-zabv) [OPUS-4.8]

### DIFF
--- a/crates/sparq-policy/README.md
+++ b/crates/sparq-policy/README.md
@@ -167,6 +167,24 @@ assert!(!evaluate(&policy, &outside).allow);
     this stateful path — a bridged ACP grant does not self-retract on count exhaustion;
     the bridge keeps `odrl:count` one-shot/unmappable. This crate provides the
     evaluator + store seam such a bridge would build on.
+- **Static conflict + containment analysis (request-free, sound)** — [OPUS-4.8]
+  sq-zabv. Two policy-vs-policy lints on the query-containment comparison semantics,
+  always compiled (no feature, no deps):
+  - `detect_conflicts(&policy) -> Vec<Conflict>` flags every
+    permission/prohibition pair whose request footprints overlap (a prohibition
+    carves the permission out — deny-overrides). `Overlap::Certain` when the
+    prohibition carves out the **whole** permission (structural overlap + it adds no
+    constraint the permission lacks), else `Overlap::Possible`; a pair that
+    *provably never* overlaps is omitted.
+  - `contains(outer, inner) -> Containment` answers *"does `outer` permit everything
+    `inner` permits?"* (refinement / requester-vs-provider containment):
+    `Contains` / `NotContained` / `Unknown`.
+  - **Sound, never over-claimed.** Constraint satisfiability / query containment is
+    undecidable in general, so this decides only what it can *prove* (identical
+    constraints, `eq` admitted by an outer bound, a tighter same-direction order
+    bound implying a looser one); everything else degrades to `Possible` / `Unknown`
+    — it never reports `Certain` / `Contains` it cannot prove (the fail-OPEN failure
+    mode). DPV/`isPartOf` set-subset refinement is a deferred bead.
 - **Duties as obligations** — a permission's `odrl:duty` must appear in the
   request's discharged-duty set, or the permission is denied (the usage-control
   kernel pure access control lacks).

--- a/crates/sparq-policy/src/compare.rs
+++ b/crates/sparq-policy/src/compare.rs
@@ -1,0 +1,516 @@
+//! Static (policy-vs-policy) ODRL analysis: **conflict** and **containment**
+//! detection. [OPUS-4.8] sq-zabv.
+//!
+//! Where [`crate::evaluate`] answers *"may THIS request go through?"* against one
+//! policy, this module answers two **request-free** questions about the policies
+//! themselves — candidate #7 of `research/feature-research-odrl-policy.md`, on the
+//! query-containment comparison semantics ([arXiv 2509.05139
+//! §comparison](https://arxiv.org/html/2509.05139v1)):
+//!
+//! 1. **Conflict** — [`detect_conflicts`]: which permission/prohibition pairs
+//!    *overlap* (a request could satisfy both)? Because a matching prohibition
+//!    carves out a permission (deny-overrides — see [`crate::evaluate`]), an
+//!    overlapping pair is exactly a request set the permission *appears* to grant
+//!    but the prohibition forbids. This is the ODRL author's "did I prohibit
+//!    something I also permitted?" lint.
+//! 2. **Containment** — [`contains`]: does policy `outer` permit *everything*
+//!    policy `inner` permits (query containment / refinement)? The
+//!    requester-vs-provider check candidate #7 names: a requester's ask is
+//!    acceptable iff the provider's offer **contains** it.
+//!
+//! ## Soundness contract (the honesty gate)
+//!
+//! Both verdicts are **sound, never over-claimed**. Constraint satisfiability and
+//! query containment are undecidable in the general ODRL constraint language, so
+//! this module reasons only about what it can *prove* from the rule structure and a
+//! conservative, per-dimension constraint comparison:
+//!
+//! - A conflict is [`Overlap::Certain`] **only** when the structural attributes
+//!   (action / target / assignee) prove an overlap AND the prohibition adds **no**
+//!   constraint the permission lacks (so for every request the permission grants,
+//!   the prohibition also fires). Otherwise it degrades to [`Overlap::Possible`]
+//!   (the rules *might* overlap for some request, but we cannot prove they always
+//!   do). A pair that provably never overlaps yields **no** conflict at all.
+//! - Containment is [`Containment::Contains`] **only** when every `inner`
+//!   permission is provably subsumed by some `outer` permission AND no `outer`
+//!   prohibition could carve into that subsumption. A provable witness to
+//!   non-containment yields [`Containment::NotContained`]; anything in between is
+//!   [`Containment::Unknown`] — we **never** report `Contains` we cannot prove
+//!   (that would be the fail-OPEN failure mode: claiming an ask is covered when it
+//!   is not).
+
+use crate::model::{Action, Constraint, Operator, Policy, Rule, Value};
+
+/// How strongly two rules overlap — the three-valued result of the conflict test.
+/// [OPUS-4.8] sq-zabv.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Overlap {
+    /// The rules provably overlap for **every** request the permission grants: the
+    /// structural attributes agree (or the prohibition is broader) AND the
+    /// prohibition adds no constraint the permission lacks. The prohibition carves
+    /// out the **whole** permission — a definite conflict the author should resolve.
+    Certain,
+    /// The rules *may* overlap for *some* request, but we cannot prove they always
+    /// do (the prohibition carries a constraint whose joint satisfiability with the
+    /// permission we do not decide). Reported so the conflict is not silently
+    /// dropped — but honestly flagged as not-proven-total.
+    Possible,
+}
+
+/// A detected permission/prohibition conflict: a permission whose granted requests
+/// a prohibition (wholly or partly) carves out. [OPUS-4.8] sq-zabv.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Conflict {
+    /// The conflicting permission's [`Rule::id`].
+    pub permission_id: String,
+    /// The conflicting prohibition's [`Rule::id`].
+    pub prohibition_id: String,
+    /// How strongly they overlap (see [`Overlap`]).
+    pub overlap: Overlap,
+    /// The action IRI the two rules overlap on — the prohibition's action when it
+    /// subsumes (e.g. the `odrl:use` umbrella), else the shared action. `None` only
+    /// if neither rule names an action (degenerate).
+    pub action: Option<String>,
+    /// The concrete target the conflict is about, when both rules pin (or the
+    /// prohibition leaves open and the permission pins) one; `None` for an
+    /// all-targets overlap.
+    pub target: Option<String>,
+}
+
+/// Whether `outer` permits everything `inner` permits — the three-valued
+/// containment / refinement verdict. [OPUS-4.8] sq-zabv.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Containment {
+    /// Proven: every request `inner` permits, `outer` also permits (and no `outer`
+    /// prohibition could carve into that). `inner` is a refinement of `outer`.
+    Contains,
+    /// Proven NOT contained: `inner` has a permission that grants a request `outer`
+    /// provably does not — a definite witness (different concrete target/action, or
+    /// a strictly looser inner constraint dimension).
+    NotContained,
+    /// Neither could be proven — undecidable under the conservative comparison
+    /// (e.g. an `outer` prohibition that *might* carve in, or constraints whose
+    /// implication we do not decide). **Never** silently read as `Contains`.
+    Unknown,
+}
+
+/// Detect every permission/prohibition pair in `policy` that overlaps — the ODRL
+/// conflict lint. [OPUS-4.8] sq-zabv. See the module-level docs for the soundness
+/// contract.
+///
+/// A pair is reported when the permission and prohibition *could* both apply to
+/// some request (their actions are compatible AND their targets/assignees are
+/// compatible). The [`Conflict::overlap`] is [`Overlap::Certain`] when the
+/// prohibition carves out the **whole** permission (it adds no constraint the
+/// permission lacks), else [`Overlap::Possible`]. Pairs that provably never overlap
+/// are omitted. Conflict is strictly across the permission/prohibition divide — two
+/// permissions (or two prohibitions) never conflict.
+///
+/// # Examples
+///
+/// ```
+/// use sparq_policy::{detect_conflicts, parse_policy_str, Overlap};
+/// let p = parse_policy_str(r#"
+/// @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+/// <urn:pol/p> a odrl:Set ;
+///   odrl:permission  [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] ;
+///   odrl:prohibition [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+/// "#, "turtle").unwrap();
+/// let conflicts = detect_conflicts(&p);
+/// assert_eq!(conflicts.len(), 1);
+/// assert_eq!(conflicts[0].overlap, Overlap::Certain);
+/// ```
+pub fn detect_conflicts(policy: &Policy) -> Vec<Conflict> {
+    let mut out = Vec::new();
+    for perm in &policy.permissions {
+        for proh in &policy.prohibitions {
+            if let Some(overlap) = rule_overlap(perm, proh) {
+                out.push(Conflict {
+                    permission_id: perm.id.clone(),
+                    prohibition_id: proh.id.clone(),
+                    overlap,
+                    action: overlap_action(perm, proh),
+                    target: perm.target.clone().or_else(|| proh.target.clone()),
+                });
+            }
+        }
+    }
+    out
+}
+
+/// Does `outer` permit everything `inner` permits? See the module-level docs for
+/// the soundness contract. [OPUS-4.8] sq-zabv.
+///
+/// Returns [`Containment::Contains`] only when **every** `inner` permission is
+/// provably subsumed by some `outer` permission AND no `outer` prohibition could
+/// carve into the subsuming permission; [`Containment::NotContained`] when an
+/// `inner` permission provably grants a request `outer` does not; and
+/// [`Containment::Unknown`] when neither is provable (e.g. an `outer` prohibition
+/// might carve in). An `inner` with no permissions permits nothing and is contained
+/// vacuously.
+///
+/// # Examples
+///
+/// ```
+/// use sparq_policy::{contains, parse_policy_str, Containment};
+/// let broad = parse_policy_str(r#"
+/// @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+/// <urn:pol/b> a odrl:Set ; odrl:permission [ odrl:action odrl:use ] .
+/// "#, "turtle").unwrap();
+/// let narrow = parse_policy_str(r#"
+/// @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+/// <urn:pol/n> a odrl:Set ;
+///   odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+/// "#, "turtle").unwrap();
+/// assert_eq!(contains(&broad, &narrow), Containment::Contains);
+/// assert_eq!(contains(&narrow, &broad), Containment::NotContained);
+/// ```
+pub fn contains(outer: &Policy, inner: &Policy) -> Containment {
+    let mut any_unknown = false;
+    for inner_perm in &inner.permissions {
+        match best_subsumption(outer, inner_perm) {
+            Subsumption::Subsumed => {}
+            Subsumption::NotSubsumed => return Containment::NotContained,
+            Subsumption::Unknown => any_unknown = true,
+        }
+    }
+    if any_unknown {
+        Containment::Unknown
+    } else {
+        Containment::Contains
+    }
+}
+
+/// Per-inner-permission subsumption verdict against the whole `outer` policy.
+enum Subsumption {
+    /// Some `outer` permission provably subsumes the inner one AND no `outer`
+    /// prohibition could carve into it.
+    Subsumed,
+    /// No `outer` permission can subsume the inner one — a definite witness.
+    NotSubsumed,
+    /// An `outer` permission subsumes, but an `outer` prohibition might carve in
+    /// (cannot prove it does not) — undecidable.
+    Unknown,
+}
+
+/// The three-valued verdict for whether ONE outer permission subsumes ONE inner
+/// permission. The distinction between `No` (a *proven* structural witness of
+/// non-subsumption) and `Indeterminate` (compatible footprint, undecided constraint
+/// refinement) is the load-bearing soundness boundary — see [`best_subsumption`].
+enum SubsumeOne {
+    /// Proven: every request `ip` grants, `op` grants.
+    Yes,
+    /// Proven NOT: a structural witness shows `op` denies a request `ip` grants
+    /// (disjoint concrete action/target/assignee, or `op` pins an attribute `ip`
+    /// leaves open).
+    No,
+    /// Compatible footprint but an undecided constraint — cannot prove either way.
+    Indeterminate,
+}
+
+/// Find `outer`'s strongest verdict for one inner permission. Sound aggregation:
+/// * if ANY outer permission **proves** subsumption ([`SubsumeOne::Yes`]) and no
+///   outer prohibition could carve in → [`Subsumption::Subsumed`];
+/// * else, if EVERY outer permission **proves** non-subsumption ([`SubsumeOne::No`])
+///   → [`Subsumption::NotSubsumed`] (a real witness — the inner ask is reachable by
+///   none of outer's permissions);
+/// * else → [`Subsumption::Unknown`] (at least one outer permission is
+///   `Indeterminate`, or a prohibition might carve in). We **never** report
+///   `NotSubsumed` on a merely-undecided permission — that would over-claim
+///   non-containment.
+fn best_subsumption(outer: &Policy, inner_perm: &Rule) -> Subsumption {
+    let mut any_indeterminate = false;
+    let mut any_yes = false;
+    for op in &outer.permissions {
+        match permission_subsumes(op, inner_perm) {
+            SubsumeOne::Yes => {
+                any_yes = true;
+                break;
+            }
+            SubsumeOne::Indeterminate => any_indeterminate = true,
+            SubsumeOne::No => {}
+        }
+    }
+    if any_yes {
+        // A subsuming permission exists. If any outer prohibition could fire on a
+        // request the inner permission grants, we cannot prove containment (the deny
+        // would carve out part of what we just claimed to contain) → Unknown.
+        if outer
+            .prohibitions
+            .iter()
+            .any(|proh| prohibition_can_carve(proh, inner_perm))
+        {
+            return Subsumption::Unknown;
+        }
+        return Subsumption::Subsumed;
+    }
+    // No outer permission proved subsumption. NotSubsumed is only sound when EVERY
+    // outer permission *proved* non-subsumption (no `Indeterminate` left over) — an
+    // empty `outer.permissions` vacuously qualifies (nothing can subsume).
+    if any_indeterminate {
+        Subsumption::Unknown
+    } else {
+        Subsumption::NotSubsumed
+    }
+}
+
+/// Does outer permission `op` subsume inner permission `ip` — i.e. is every request
+/// `ip` grants also granted by `op`? Three-valued and **sound**: `Yes`/`No` are only
+/// returned when *proven*; everything undecided is `Indeterminate`.
+///
+/// `op` ⊇ `ip` requires, on each axis, that `op` is **no narrower** than `ip`:
+/// * action: `op` permits every action `ip` permits (equal IRIs, or `op` is the
+///   `use` umbrella) — else a **proven** `No` (disjoint concrete actions, or `op`
+///   non-`use` against a `use` `ip`);
+/// * target / assignee: `op` is unrefined (`None`, = any) OR pins the same value
+///   `ip` pins — else a **proven** `No` (`op` pins one and `ip` pins another, or `op`
+///   pins one and `ip` leaves it open so `ip` reaches values `op` denies);
+/// * constraints: every constraint `op` carries must be **implied** by some
+///   constraint `ip` carries (so `ip` is at-least-as-restricted on that dimension).
+///   An `op` constraint with no implying `ip` constraint means `op` *may* be
+///   narrower, but we cannot prove `ip` actually reaches outside it →
+///   `Indeterminate` (not `No`).
+fn permission_subsumes(op: &Rule, ip: &Rule) -> SubsumeOne {
+    // Structural axes give *proven* witnesses of non-subsumption.
+    if !action_at_least_as_broad(&op.action, &ip.action) {
+        return SubsumeOne::No;
+    }
+    if !attr_at_least_as_broad(op.target.as_deref(), ip.target.as_deref()) {
+        return SubsumeOne::No;
+    }
+    if !attr_at_least_as_broad(op.assignee.as_deref(), ip.assignee.as_deref()) {
+        return SubsumeOne::No;
+    }
+    // Structurally `op ⊇ ip`. Now the constraints, per `op` constraint `oc`:
+    //  * some `ip` constraint **implies** `oc` (ip no looser on that dimension) → OK;
+    //  * `ip` carries **no** constraint on `oc`'s dimension at all → `ip` is
+    //    *unconstrained* there, so it provably reaches values outside `oc`'s bound
+    //    (every ODRL constraint dimension admits >1 value) → a proven `No`;
+    //  * `ip` constrains the dimension but we cannot prove implication → undecided
+    //    (`ip` might still be a subset under a relation we do not model) →
+    //    `Indeterminate`.
+    let mut any_indeterminate = false;
+    for oc in &op.constraints {
+        if ip.constraints.iter().any(|ic| constraint_implies(ic, oc)) {
+            continue; // ip refines this dimension at least as tightly.
+        }
+        if ip.constraints.iter().any(|ic| ic.left == oc.left) {
+            // ip constrains the dimension but not provably within oc's bound.
+            any_indeterminate = true;
+        } else {
+            // ip leaves this dimension wide open while op restricts it → ip reaches
+            // outside op. Proven non-subsumption.
+            return SubsumeOne::No;
+        }
+    }
+    if any_indeterminate {
+        SubsumeOne::Indeterminate
+    } else {
+        SubsumeOne::Yes
+    }
+}
+
+/// Is action `a` at least as broad as `b` — does `a` permit every action `b` does?
+/// `use` permits everything, so `use ⊇ anything`; a specific action subsumes only
+/// itself, and crucially does NOT subsume the `use` umbrella.
+fn action_at_least_as_broad(a: &Action, b: &Action) -> bool {
+    if is_use(a) {
+        return true; // use permits everything b could.
+    }
+    if is_use(b) {
+        return false; // b is the umbrella; a (non-use) cannot cover all of it.
+    }
+    a == b
+}
+
+fn is_use(a: &Action) -> bool {
+    a == &Action::use_()
+}
+
+/// Is the structural attribute `outer` (target or assignee) at least as broad as
+/// `inner`? `None` (= any) is broadest; otherwise both must pin the same value.
+fn attr_at_least_as_broad(outer: Option<&str>, inner: Option<&str>) -> bool {
+    match (outer, inner) {
+        (None, _) => true,            // outer = any ⊇ anything inner pins (or any)
+        (Some(_), None) => false,     // outer pins one, inner = any → outer narrower
+        (Some(o), Some(i)) => o == i, // both pin → must be identical
+    }
+}
+
+/// Does constraint `ic` (from the inner/narrower rule) **imply** constraint `oc`
+/// (from the outer/broader rule)? Sound (conservative): true only when proven.
+///
+/// We decide this only when the two constrain the **same** `leftOperand`. The cases
+/// we can prove:
+/// * identical constraint → implies itself;
+/// * `ic`'s bound is a *subset* of `oc`'s under compatible order operators (e.g.
+///   inner `lt 2026-01-01` implies outer `lt 2027-01-01`; inner `eq v` implies
+///   outer `lteq`/`gteq`/`isPartOf` that admit `v`).
+///
+/// Anything we do not decide returns `false` — so [`permission_subsumes`] treats an
+/// un-implied outer constraint as "outer is (possibly) narrower" and does not claim
+/// subsumption. Fail-safe.
+fn constraint_implies(ic: &Constraint, oc: &Constraint) -> bool {
+    if ic.left != oc.left {
+        return false; // different dimensions — cannot relate.
+    }
+    // Identical (same op + same right value) always implies.
+    if ic.operator == oc.operator && ic.right == oc.right {
+        return true;
+    }
+    // A few sound, common refinements. `eq v` (inner) implies an outer bound that
+    // admits v.
+    if ic.operator == Operator::Eq || ic.operator == Operator::IsA {
+        return outer_admits_value(&ic.right, oc);
+    }
+    // Same order operator, tighter inner bound implies looser outer bound.
+    match (ic.operator, oc.operator) {
+        // inner lt/lteq B1 implies outer lt/lteq B2 when B1 <= B2.
+        (Operator::Lt | Operator::Lteq, Operator::Lt | Operator::Lteq) => {
+            le_bound(&ic.right, &oc.right)
+        }
+        // inner gt/gteq B1 implies outer gt/gteq B2 when B1 >= B2.
+        (Operator::Gt | Operator::Gteq, Operator::Gt | Operator::Gteq) => {
+            le_bound(&oc.right, &ic.right)
+        }
+        _ => false,
+    }
+}
+
+/// Does the outer constraint `oc` admit the single value `v` (an inner `eq v`)?
+fn outer_admits_value(v: &Value, oc: &Constraint) -> bool {
+    match oc.operator {
+        Operator::Eq | Operator::IsA => value_eq(v, &oc.right),
+        Operator::Neq => !value_eq(v, &oc.right),
+        Operator::IsPartOf => is_part_of(v, &oc.right),
+        Operator::Lt => order_lt(v, &oc.right),
+        Operator::Lteq => order_le(v, &oc.right),
+        Operator::Gt => order_lt(&oc.right, v),
+        Operator::Gteq => order_le(&oc.right, v),
+    }
+}
+
+/// `a <= b` for two bound values (numeric / dateTime); `false` if incomparable.
+fn le_bound(a: &Value, b: &Value) -> bool {
+    order_le(a, b)
+}
+
+/// Can prohibition `proh` carve out any request inner permission `ip` grants?
+/// Sound *over*-approximation (we say "can" unless we can prove it cannot), because
+/// a missed carve-out would be the fail-OPEN error: claiming containment a deny
+/// breaks. We can prove it CANNOT carve only when the structural attributes are
+/// disjoint (different concrete action, target, or assignee).
+fn prohibition_can_carve(proh: &Rule, ip: &Rule) -> bool {
+    // Disjoint action (both concrete and different, neither the umbrella) → cannot.
+    if actions_disjoint(&proh.action, &ip.action) {
+        return false;
+    }
+    // Disjoint concrete target → cannot.
+    if attrs_disjoint(proh.target.as_deref(), ip.target.as_deref()) {
+        return false;
+    }
+    // Disjoint concrete assignee → cannot.
+    if attrs_disjoint(proh.assignee.as_deref(), ip.assignee.as_deref()) {
+        return false;
+    }
+    // Otherwise the structural footprints intersect — conservatively, it can carve
+    // (we do not try to prove a constraint makes the prohibition vacuous).
+    true
+}
+
+/// Two actions are provably disjoint iff both are concrete (non-`use`) and unequal.
+fn actions_disjoint(a: &Action, b: &Action) -> bool {
+    !is_use(a) && !is_use(b) && a != b
+}
+
+/// Two structural attributes are provably disjoint iff both pin a value and differ.
+/// A `None` (= any) overlaps with anything.
+fn attrs_disjoint(a: Option<&str>, b: Option<&str>) -> bool {
+    matches!((a, b), (Some(x), Some(y)) if x != y)
+}
+
+/// Compute the action IRI a conflict overlaps on (the prohibition's when it is the
+/// broader/umbrella action, else the shared action).
+fn overlap_action(perm: &Rule, proh: &Rule) -> Option<String> {
+    if is_use(&proh.action) {
+        Some(proh.action.0.clone())
+    } else {
+        Some(perm.action.0.clone())
+    }
+}
+
+/// The conflict test for one permission/prohibition pair. Returns `None` if they
+/// provably never overlap; else the [`Overlap`] strength. [OPUS-4.8] sq-zabv.
+fn rule_overlap(perm: &Rule, proh: &Rule) -> Option<Overlap> {
+    // Provably-disjoint structural footprints → no conflict at all.
+    if actions_disjoint(&perm.action, &proh.action)
+        || attrs_disjoint(perm.target.as_deref(), proh.target.as_deref())
+        || attrs_disjoint(perm.assignee.as_deref(), proh.assignee.as_deref())
+    {
+        return None;
+    }
+    // The footprints intersect. The carve-out is CERTAIN (covers the whole
+    // permission) iff the prohibition adds no constraint the permission lacks — then
+    // for every request the permission grants, the prohibition also fires. (Each
+    // prohibition constraint must be implied by some permission constraint, OR the
+    // permission is unconstrained on a dimension the prohibition restricts, in which
+    // case we cannot prove the prohibition always fires → Possible.)
+    let certain = proh
+        .constraints
+        .iter()
+        .all(|pc| perm.constraints.iter().any(|qc| constraint_implies(qc, pc)));
+    Some(if certain {
+        Overlap::Certain
+    } else {
+        Overlap::Possible
+    })
+}
+
+// --- value comparison helpers (mirror eval.rs's semantics, kept module-local so
+// the comparison surface stays a sound subset; eval.rs's `compare`/`order` are
+// private). [OPUS-4.8] sq-zabv. ---
+
+fn value_eq(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Num(x), Value::Num(y)) => x == y,
+        _ => a.as_str() == b.as_str(),
+    }
+}
+
+fn is_part_of(actual: &Value, bound: &Value) -> bool {
+    let a = actual.as_str();
+    bound
+        .as_str()
+        .split(['|', ' ', ','])
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .any(|member| member == a)
+}
+
+/// Numeric / dateTime order, `None` if incomparable. Mirrors eval.rs but kept local.
+fn order(a: &Value, b: &Value) -> Option<std::cmp::Ordering> {
+    match (a, b) {
+        (Value::Num(x), Value::Num(y)) => x.partial_cmp(y),
+        (Value::DateTime(x), Value::DateTime(y)) => crate::eval::cmp_datetime_pub(x, y),
+        _ => {
+            let (Ok(x), Ok(y)) = (
+                a.as_str().trim().parse::<f64>(),
+                b.as_str().trim().parse::<f64>(),
+            ) else {
+                return None;
+            };
+            x.partial_cmp(&y)
+        }
+    }
+}
+
+fn order_lt(a: &Value, b: &Value) -> bool {
+    order(a, b) == Some(std::cmp::Ordering::Less)
+}
+
+fn order_le(a: &Value, b: &Value) -> bool {
+    matches!(
+        order(a, b),
+        Some(std::cmp::Ordering::Less | std::cmp::Ordering::Equal)
+    )
+}

--- a/crates/sparq-policy/src/eval.rs
+++ b/crates/sparq-policy/src/eval.rs
@@ -955,6 +955,14 @@ fn cmp_datetime(x: &str, y: &str) -> Option<std::cmp::Ordering> {
     Some(parse_instant(x)?.cmp(&parse_instant(y)?))
 }
 
+/// Crate-internal accessor for [`cmp_datetime`] so [`crate::compare`]'s static
+/// containment analysis orders dateTime bounds by the **same** instant normalizer
+/// the evaluator uses (one source of truth — no duplicated xsd:dateTime parser).
+/// [OPUS-4.8] sq-zabv.
+pub(crate) fn cmp_datetime_pub(x: &str, y: &str) -> Option<std::cmp::Ordering> {
+    cmp_datetime(x, y)
+}
+
 /// A point on the UTC timeline, as `(days-since-epoch, nanoseconds-into-day)`
 /// after applying the lexical form's timezone offset. Comparable and equatable
 /// by derive — that is exactly instant ordering / instant equality.

--- a/crates/sparq-policy/src/lib.rs
+++ b/crates/sparq-policy/src/lib.rs
@@ -6,10 +6,15 @@
 #[cfg(feature = "count-enforcement")]
 pub mod count;
 
+// [OPUS-4.8] sq-zabv: static (request-free) policy analysis — permission/prohibition
+// conflict + policy containment/refinement, on the query-containment comparison
+// semantics. Always compiled (no feature gate); it adds no deps and no core cost.
+mod compare;
 mod eval;
 pub mod model;
 mod parse;
 
+pub use compare::{contains, detect_conflicts, Conflict, Containment, Overlap};
 pub use eval::{
     datetime_status, evaluate, matched_prohibition, prohibition_status, purpose_status,
     recipient_status, DateTimeMatch, Decision, ProhibitionStatus, PurposeMatch, RecipientMatch,

--- a/crates/sparq-policy/tests/odrl_compare.rs
+++ b/crates/sparq-policy/tests/odrl_compare.rs
@@ -1,0 +1,458 @@
+//! ODRL static policy analysis: conflict + containment detection. [OPUS-4.8] sq-zabv.
+//!
+//! Candidate #7 (research/feature-research-odrl-policy.md): detect
+//! permission/prohibition **conflicts** (a permission a prohibition carves out)
+//! and **containment** between two policies (does one permit everything the other
+//! does — query-containment refinement). Both are *static* (policy-vs-policy, no
+//! Request), and both are **sound / fail-closed**: a `Certain` conflict or a
+//! `Contains` verdict is only reported when it can be *proven*; everything not
+//! provable degrades to `Possible` / `Unknown` (never over-claimed).
+
+use sparq_policy::{contains, detect_conflicts, parse_policy_str, Containment, Overlap};
+
+const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
+
+fn left(local: &str) -> String {
+    format!("{ODRL}{local}")
+}
+
+// ---------------------------------------------------------------------------
+// CONFLICT DETECTION
+// ---------------------------------------------------------------------------
+
+/// A permission and a prohibition on the SAME action/target/assignee certainly
+/// conflict — the prohibition carves the permission out for every matching request.
+#[test]
+fn permission_and_prohibition_same_target_conflict() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/p> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+                    odrl:assignee <https://alice.ex/me> ] ;
+  odrl:prohibition [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+                     odrl:assignee <https://alice.ex/me> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let conflicts = detect_conflicts(&p);
+    assert_eq!(conflicts.len(), 1, "{conflicts:?}");
+    assert_eq!(conflicts[0].overlap, Overlap::Certain);
+}
+
+/// A permission and a prohibition on DIFFERENT targets never overlap — no conflict.
+#[test]
+fn different_targets_no_conflict() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/p> a odrl:Set ;
+  odrl:permission  [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] ;
+  odrl:prohibition [ odrl:action odrl:read ; odrl:target <urn:asset/y> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    assert!(detect_conflicts(&p).is_empty());
+}
+
+/// A permission and a prohibition on different ACTIONS (read vs write) never
+/// overlap — no conflict.
+#[test]
+fn different_actions_no_conflict() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/p> a odrl:Set ;
+  odrl:permission  [ odrl:action odrl:read  ; odrl:target <urn:asset/x> ] ;
+  odrl:prohibition [ odrl:action odrl:write ; odrl:target <urn:asset/x> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    assert!(detect_conflicts(&p).is_empty());
+}
+
+/// The `odrl:use` umbrella prohibition subsumes a `read` permission (use ⊇ read),
+/// so they conflict.
+#[test]
+fn use_umbrella_prohibition_conflicts_with_read_permission() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/p> a odrl:Set ;
+  odrl:permission  [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] ;
+  odrl:prohibition [ odrl:action odrl:use  ; odrl:target <urn:asset/x> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let conflicts = detect_conflicts(&p);
+    assert_eq!(conflicts.len(), 1, "{conflicts:?}");
+    assert_eq!(conflicts[0].overlap, Overlap::Certain);
+}
+
+/// An unrefined prohibition (no target) carves into a targeted permission — a
+/// certain overlap (the prohibition applies to *every* target including this one).
+#[test]
+fn unrefined_prohibition_conflicts_with_targeted_permission() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/p> a odrl:Set ;
+  odrl:permission  [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] ;
+  odrl:prohibition [ odrl:action odrl:read ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let conflicts = detect_conflicts(&p);
+    assert_eq!(conflicts.len(), 1, "{conflicts:?}");
+    assert_eq!(conflicts[0].overlap, Overlap::Certain);
+    // The conflict names the two rules.
+    assert_eq!(conflicts[0].permission_id, p.permissions[0].id);
+    assert_eq!(conflicts[0].prohibition_id, p.prohibitions[0].id);
+}
+
+/// When the prohibition adds a CONSTRAINT the permission does not, the two only
+/// *possibly* overlap (the constraint may or may not hold for a given request) —
+/// we cannot prove a certain carve-out, so the verdict is `Possible`, not `Certain`.
+#[test]
+fn constrained_prohibition_only_possibly_conflicts() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/p> a odrl:Set ;
+  odrl:permission  [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] ;
+  odrl:prohibition [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+                     odrl:constraint [ odrl:leftOperand odrl:dateTime ;
+                       odrl:operator odrl:lt ;
+                       odrl:rightOperand "2026-01-01T00:00:00Z"^^xsd:dateTime ] ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let conflicts = detect_conflicts(&p);
+    assert_eq!(conflicts.len(), 1, "{conflicts:?}");
+    assert_eq!(conflicts[0].overlap, Overlap::Possible);
+}
+
+/// Two permissions, or two prohibitions, never conflict with each other — conflict
+/// is strictly across the permission/prohibition divide.
+#[test]
+fn same_kind_rules_never_conflict() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/p> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    assert!(detect_conflicts(&p).is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// CONTAINMENT  (does `outer` permit everything `inner` permits?)
+// ---------------------------------------------------------------------------
+
+/// A policy contains itself (reflexivity) — a clean `Contains`.
+#[test]
+fn policy_contains_itself() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/p> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+                    odrl:assignee <https://alice.ex/me> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    assert_eq!(contains(&p, &p), Containment::Contains);
+}
+
+/// A broad `use` permission with no target/assignee contains a narrow `read`
+/// permission on a specific target/assignee (the broad rule subsumes the narrow).
+#[test]
+fn broad_use_contains_narrow_read() {
+    let broad = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/broad> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:use ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let narrow = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/narrow> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+                    odrl:assignee <https://alice.ex/me> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    assert_eq!(contains(&broad, &narrow), Containment::Contains);
+    // Not symmetric: the narrow policy does NOT contain the broad one.
+    assert_eq!(contains(&narrow, &broad), Containment::NotContained);
+}
+
+/// A narrower outer constraint does NOT contain a broader inner permission: the
+/// outer only permits `purpose = research`, the inner permits any purpose, so the
+/// inner has requests (any non-research purpose) the outer denies → `NotContained`.
+#[test]
+fn constrained_outer_does_not_contain_unconstrained_inner() {
+    let outer = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/outer> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;
+      odrl:rightOperand <urn:purpose/research> ] ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let inner = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/inner> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    assert_eq!(contains(&outer, &inner), Containment::NotContained);
+}
+
+/// An unconstrained outer permission DOES contain a more-constrained inner one of
+/// the same action/target: every request the (extra-)constrained inner permits is
+/// also permitted by the looser outer.
+#[test]
+fn unconstrained_outer_contains_constrained_inner() {
+    let outer = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/outer> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let inner = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/inner> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;
+      odrl:rightOperand <urn:purpose/research> ] ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    assert_eq!(contains(&outer, &inner), Containment::Contains);
+}
+
+/// Containment is fail-safe on the prohibitions of `outer`: if `outer` carries a
+/// prohibition that could carve into a permission it would otherwise contain, we
+/// cannot prove containment → `Unknown` (never claim a containment a deny-overrides
+/// prohibition might break).
+#[test]
+fn outer_prohibition_blocks_certain_containment() {
+    let outer = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/outer> a odrl:Set ;
+  odrl:permission  [ odrl:action odrl:use ] ;
+  odrl:prohibition [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let inner = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/inner> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    // The outer `use` permission subsumes the inner `read`, BUT outer's prohibition
+    // carves exactly that request out — so containment is NOT certain.
+    assert_eq!(contains(&outer, &inner), Containment::Unknown);
+}
+
+/// An empty inner policy (permits nothing) is contained by anything — vacuous truth.
+#[test]
+fn empty_inner_is_contained() {
+    let outer = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/outer> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let inner = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/inner> a odrl:Set .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    assert_eq!(contains(&outer, &inner), Containment::Contains);
+}
+
+/// A `neq` constraint on the inner is NOT something we can prove is refined by a
+/// bare outer of the same dimension — but an *unconstrained* outer (no constraint
+/// at all on that dimension) still contains it. Pin that the `left` IRI is what we
+/// key on, not the operator.
+#[test]
+fn unconstrained_outer_contains_neq_constrained_inner() {
+    let outer = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/outer> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let inner = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/inner> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:recipient ; odrl:operator odrl:neq ;
+      odrl:rightOperand <https://bob.ex/me> ] ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    assert_eq!(contains(&outer, &inner), Containment::Contains);
+}
+
+/// Same dimension, IDENTICAL constraint on both → still contained (the inner is no
+/// broader than the outer on that dimension).
+#[test]
+fn identical_constraint_is_contained() {
+    let same = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/X> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;
+      odrl:rightOperand <urn:purpose/research> ] ] .
+"#;
+    let outer = parse_policy_str(same, "turtle").unwrap();
+    let inner = parse_policy_str(same, "turtle").unwrap();
+    assert_eq!(contains(&outer, &inner), Containment::Contains);
+}
+
+/// When the inner permits a target the outer's permissions cannot reach (a
+/// different concrete target), it is provably NOT contained.
+#[test]
+fn inner_with_unreachable_target_not_contained() {
+    let outer = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/outer> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let inner = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/inner> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/y> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    assert_eq!(contains(&outer, &inner), Containment::NotContained);
+}
+
+/// Helper: the conflict carries the action/target it overlaps on (left() smoke).
+#[test]
+fn conflict_reports_overlapping_action() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/p> a odrl:Set ;
+  odrl:permission  [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] ;
+  odrl:prohibition [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let c = &detect_conflicts(&p)[0];
+    assert_eq!(c.action.as_deref(), Some(left("read").as_str()));
+    assert_eq!(c.target.as_deref(), Some("urn:asset/x"));
+}
+
+/// A CONSTRAINED permission vs an UNCONSTRAINED prohibition on the same footprint
+/// is a *certain* conflict: the prohibition (no constraints) fires on every request,
+/// including the constrained subset the permission grants. (Asymmetric to the
+/// constrained-prohibition case, which is only `Possible`.)
+#[test]
+fn constrained_permission_vs_unconstrained_prohibition_is_certain() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/p> a odrl:Set ;
+  odrl:permission  [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;
+      odrl:rightOperand <urn:purpose/research> ] ] ;
+  odrl:prohibition [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let conflicts = detect_conflicts(&p);
+    assert_eq!(conflicts.len(), 1, "{conflicts:?}");
+    assert_eq!(conflicts[0].overlap, Overlap::Certain);
+}
+
+/// Containment short-circuits to `NotContained` as soon as ANY inner permission is
+/// not subsumed, even if others are — `outer` must cover *every* inner ask.
+#[test]
+fn one_unsubsumed_inner_permission_breaks_containment() {
+    let outer = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/outer> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let inner = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/inner> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ] ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/y> ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    // x is covered but y is not → not contained.
+    assert_eq!(contains(&outer, &inner), Containment::NotContained);
+}
+
+/// A NUMERIC range refinement is decided soundly: inner `count lteq 3` implies outer
+/// `count lteq 5` (3 ≤ 5), so the inner is contained.
+#[test]
+fn tighter_numeric_bound_is_contained() {
+    let outer = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/outer> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:count ; odrl:operator odrl:lteq ;
+      odrl:rightOperand 5 ] ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    let inner = parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/inner> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:count ; odrl:operator odrl:lteq ;
+      odrl:rightOperand 3 ] ] .
+"#,
+        "turtle",
+    )
+    .unwrap();
+    assert_eq!(contains(&outer, &inner), Containment::Contains);
+    // The reverse (outer `lteq 3`, inner `lteq 5`) is *genuinely* not contained
+    // (inner permits count=4,5 the outer denies), but proving it needs reasoning
+    // that the looser inner bound reaches above the tighter outer one — which the
+    // conservative analysis does not attempt. It honestly degrades to `Unknown`
+    // (sound: it never *claims* containment it cannot prove) rather than
+    // over-claiming `NotContained`. (See the module soundness contract.)
+    assert_eq!(contains(&inner, &outer), Containment::Unknown);
+}

--- a/skills/usage-control-policy/SKILL.md
+++ b/skills/usage-control-policy/SKILL.md
@@ -123,6 +123,28 @@ assert!(!evaluate_and_exercise(&policy, &req, &store).allow); // 4th: limit reac
 - **Fail-closed.** `ConsumeResult::Unavailable` (store outage / poisoned lock) or a malformed limit → **DENY** — never silently "unlimited". `count_status(&rule, &request, &store) -> CountStatus` is the side-effect-free audit surface (`Satisfied{consumed,limit}` / `DefinitelyUnsatisfied{..}` / `Unprovable` / `NotConstrained`), the count dual of `purpose_status`.
 - **Deferred (honest).** The stateless ODRL→ACP **bridge does NOT wire this stateful path** — a bridged ACP grant does not self-retract on count exhaustion (ACP has no usage counter; the bridge keeps `odrl:count` one-shot/unmappable, see the mapping table). This feature is the evaluator + store seam such a bridge would build on.
 
+## Static conflict + containment analysis (request-free) — [OPUS-4.8] sq-zabv
+
+Where `evaluate` answers *"may THIS request go through?"*, two **request-free** functions answer questions about the policies themselves (the query-containment comparison semantics, [arXiv 2509.05139 §comparison](https://arxiv.org/html/2509.05139v1)). Both are always compiled (no feature, no deps) and both are **sound / fail-closed — never over-claimed**.
+
+```rust,ignore
+use sparq_policy::{contains, detect_conflicts, Containment, Overlap};
+// Lint a policy for permission/prohibition conflicts.
+for c in detect_conflicts(&policy) {
+    // c.permission_id is (wholly, if c.overlap == Overlap::Certain) carved out by c.prohibition_id
+}
+// Does the provider's offer permit everything the requester asks?
+match contains(&provider_policy, &request_policy) {
+    Containment::Contains => { /* every ask is covered */ }
+    Containment::NotContained => { /* a witness ask the offer denies */ }
+    Containment::Unknown => { /* undecidable under the conservative comparison */ }
+}
+```
+
+- **`detect_conflicts(&policy) -> Vec<Conflict>`** — every permission/prohibition pair whose request footprints overlap (a prohibition carves the permission out — deny-overrides). `Conflict { permission_id, prohibition_id, overlap, action, target }`. `overlap` is `Overlap::Certain` **only** when the structural attributes (action / target / assignee) prove an overlap AND the prohibition adds **no** constraint the permission lacks (so the carve-out covers the *whole* permission); otherwise `Overlap::Possible` (the rules *might* overlap but we cannot prove they always do). A pair that **provably never** overlaps (disjoint concrete action / target / assignee) is omitted. Conflict is strictly across the permission/prohibition divide — two permissions never conflict.
+- **`contains(outer, inner) -> Containment`** — does `outer` permit everything `inner` permits (refinement / requester-vs-provider containment)? `Containment::Contains` **only** when every `inner` permission is *provably* subsumed by some `outer` permission AND no `outer` prohibition could carve into it; `Containment::NotContained` when an `inner` permission *provably* grants a request `outer` denies (disjoint concrete target/action, or `inner` leaves a dimension `outer` restricts wide open); `Containment::Unknown` otherwise. An `inner` with no permissions is contained vacuously.
+- **Soundness boundary (honest).** Constraint satisfiability / query containment is undecidable in the general ODRL constraint language. This module decides only what it can *prove* from rule structure plus a conservative per-dimension constraint comparison (identical constraints; `eq v` admitted by an `outer` bound; a *tighter* same-direction order bound — `lt`/`lteq`, `gt`/`gteq` — implying a looser one). Everything else degrades to `Possible` / `Unknown` — it **never** reports `Certain` / `Contains` it cannot prove (that is the fail-OPEN failure mode: claiming an ask is covered when it is not). It also does not (yet) prove `NotContained` from a *looser* inner numeric bound reaching above a tighter outer one — that case honestly returns `Unknown`. DPV/`isPartOf` set-subset refinement is a deferred bead.
+
 ## Bridge to WAC/ACP enforcement (opt-in `odrl-bridge`) — [OPUS-4.8] sq-h3uk
 
 `sparq-solid` can **materialize** a matched ODRL permission into its `<urn:sparq:auth>` AUTH_GRAPH so the existing graph-level WAC/ACP enforcement applies it — **no new enforcement engine**. Behind the off-by-default `odrl-bridge` cargo feature on `sparq-solid` (it pulls in `sparq-policy` only when enabled; the default solid build stays ODRL-free). This is the **single-node** bridge of epic sq-3183, **research-track**, NOT the (gated) federated/ZK-disclosure path.


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-zabv** (candidate #7 of the ODRL usage-control epic sq-3183). @jeswr runs multiple agents on one account; this is one of them.

## What

Two **request-free**, **sound**, **fail-closed** static analyses over the typed ODRL model in `sparq-policy`, on the query-containment comparison semantics ([arXiv 2509.05139 §comparison](https://arxiv.org/html/2509.05139v1)) — the bead's "detect conflicts (permission vs prohibition on same action/target) + containment between ODRL policies".

- **`detect_conflicts(&policy) -> Vec<Conflict>`** — every permission/prohibition pair whose request footprints overlap (a prohibition carves the permission out — deny-overrides). `Conflict { permission_id, prohibition_id, overlap, action, target }`. `Overlap::Certain` **only** when the structural attributes (action/target/assignee) prove the overlap **and** the prohibition adds no constraint the permission lacks (whole-permission carve-out); else `Overlap::Possible`. A *provably-disjoint* pair is omitted. Conflict is strictly across the permission/prohibition divide.
- **`contains(outer, inner) -> Containment`** — does `outer` permit everything `inner` permits (refinement / requester-vs-provider containment)? `Contains` only when every `inner` permission is *provably* subsumed by some `outer` permission **and** no `outer` prohibition could carve in; `NotContained` on a provable witness; `Unknown` otherwise. Empty `inner` is contained vacuously.

## Soundness (the honesty gate — no over-claim)

Constraint satisfiability / query containment is **undecidable** in the general ODRL constraint language. The module decides only what it can *prove* — identical constraints, an `eq v` admitted by an outer bound, a *tighter* same-direction order bound (`lt`/`lteq`, `gt`/`gteq`) implying a looser one, and an inner dimension left wide-open while the outer restricts it (a proven non-subsumption). Everything else degrades to `Possible` / `Unknown`. It **never** reports `Certain` / `Contains` / `NotContained` it cannot prove (that would be the fail-OPEN failure mode: claiming an ask is covered when it is not). Per-permission subsumption is deliberately three-valued (`Yes`/`No`/`Indeterminate`) so a merely-undecided pair is never mislabelled non-containment. Honestly documented limits: a *looser* inner numeric bound reaching above a tighter outer one returns `Unknown` (not `NotContained`); DPV/`isPartOf` set-subset refinement is a deferred bead.

## Design notes

- New `compare` module, **always compiled** — no cargo feature, **zero new deps**, **zero core cost** (`cargo tree -p sparq-core` does not show `sparq-policy`).
- dateTime bound ordering reuses eval.rs's instant normalizer through a `pub(crate)` accessor — one source of truth, no duplicated `xsd:dateTime` parser.
- `sparq-policy` is `publish = false`, so the G2 public-api→SKILL gate does not block it; the README + `skills/usage-control-policy/SKILL.md` are updated anyway per the AGENTS.md maintenance rule.

## Gate (all green, run in the worktree)

- `cargo clippy -p sparq-policy --all-targets -- -D warnings` — **both** feature states (default + `count-enforcement`).
- `cargo test -p sparq-policy` — **both** feature states: 20 new tests in `tests/odrl_compare.rs` + 2 doctests, plus the existing suite.
- `rustfmt --check` on the new files; markdownlint on the changed docs; `check-privacy-claims.sh` OK; `sparq-solid --features odrl-bridge` still builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
