### PR TITLE
feat(sparq-solid): library-level WAC conformance harness (sq-3jtd.8) [OPUS-4.8]

### DIFF
--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -278,6 +278,49 @@ tracks each bridged grant in a **ledger** and provides a refresh entry point:
   principal+target+mode — correct, because the prohibition is genuinely gone. Static `auth:deny*`
   rules are never in the ledger and so are never retracted.
 
+## WAC conformance harness — [OPUS-4.8] sq-3jtd.8
+
+A library-level **WAC conformance harness** (`sparq_solid::wac_conformance`) exercises this
+crate's WAC authorization engine (`materialize_wac` + `AuthIndex::accessible`) against the
+[Solid Web Access Control specification](https://solidproject.org/TR/wac) at the *library*
+level. A scenario is declared as data — an `.acl`-document corpus (built with `AclBuilder`)
+plus a table of expected `(agent, client, mode, resource) → allow | deny` decisions — and the
+harness asserts the engine reproduces every expected decision, reporting all mismatches at
+once. The scenario corpus lives in [`tests/conformance_wac.rs`](tests/conformance_wac.rs); it
+isolates each WAC construct: `acl:agent` on the resource's own ACL (`acl:accessTo`),
+`acl:agentClass foaf:Agent` (public) / `acl:AuthenticatedAgent`, `acl:agentGroup` via
+`vcard:hasMember`, `acl:default` inheritance vs `acl:accessTo`, **nearest-ACL shadowing** (the
+key WAC difference from ACP's cumulative inheritance — a closer ACL replaces, not adds to, the
+ancestors'), resource-specific override, the `acl:origin` (user, application) pair, mode
+independence, `acl:Control` governing the resource's `.acl` document, the fail-closed no-ACL
+case, and the multi-agent union.
+
+```rust
+use sparq_solid::wac_conformance::{AclBuilder, WacScenario};
+use sparq_solid::conformance::{Decision, Expect};
+use sparq_solid::Mode;
+
+let doc = "https://pod.example/notes/n1";
+let mut acl = AclBuilder::new();
+acl.access_to(doc, |a| a.agent("https://alice.example/card#me").mode(Mode::Read));
+acl.document(doc);
+
+let report = WacScenario::new("agent-allow")
+    .acl(acl)
+    .expect(Expect::agent("https://alice.example/card#me").read(doc).is(Decision::Allow))
+    .expect(Expect::anonymous().read(doc).is(Decision::Deny))
+    .run().expect("materializes");
+assert!(report.passed());
+```
+
+The decision/expectation/report vocabulary (`conformance::{Decision, Expect, ScenarioReport}`)
+is **shared** with the ACP harness below — both compare the same allow/deny binary against the
+same `AuthIndex::accessible` verdict; only the corpus shape differs. A `run_via_podstore` twin
+additionally proves the public `PodStore` method-form path (the one a PSS integration uses, with
+the per-session cache) reproduces the same decisions. The **scope decision is identical to ACP's**
+(below): library-level decision parity, not CTH-over-HTTP (PSS's), with the CSS differential
+oracle research-open. The table-driven corpus is the natural input for that future oracle.
+
 ## ACP conformance harness — [OPUS-4.8] sq-3jtd.9
 
 A library-level **ACP conformance harness** (`sparq_solid::conformance`) exercises this

--- a/crates/sparq-solid/src/conformance.rs
+++ b/crates/sparq-solid/src/conformance.rs
@@ -145,6 +145,29 @@ impl Expect {
     pub fn decision(&self) -> Decision {
         self.decision
     }
+
+    /// The requestor's agent WebID (`None` = anonymous). [OPUS-4.8] sq-3jtd.8 — exposed so
+    /// the sibling WAC harness ([`crate::wac_conformance`]) can build a [`crate::Session`]
+    /// from a shared [`Expect`]. (Named `req_*` so it does not shadow the [`Expect::agent`]
+    /// *constructor*.)
+    pub fn req_agent(&self) -> Option<&str> {
+        self.agent.as_deref()
+    }
+
+    /// The requestor's client identifier (`None` = any client). [OPUS-4.8] sq-3jtd.8.
+    pub fn req_client(&self) -> Option<&str> {
+        self.client.as_deref()
+    }
+
+    /// The access mode this expectation is about. [OPUS-4.8] sq-3jtd.8.
+    pub fn req_mode(&self) -> Mode {
+        self.mode
+    }
+
+    /// The resource (named graph) this expectation is about. [OPUS-4.8] sq-3jtd.8.
+    pub fn req_resource(&self) -> &str {
+        &self.resource
+    }
 }
 
 /// Half-built [`Expect`]: requestor chosen, resource + mode + decision still to come.
@@ -513,33 +536,20 @@ impl AcpScenario {
         materialize_acp(&mut graph)
             .map_err(|e| format!("scenario {:?}: materialize_acp failed: {e}", self.name))?;
         let index = AuthIndex::from_graph(&graph);
-
-        let mut results = Vec::with_capacity(self.expects.len());
-        for e in &self.expects {
+        ScenarioReport::build(&self.name, &self.expects, |e| {
             let session = Session {
-                agent: e.agent.as_deref(),
-                client: e.client.as_deref(),
+                agent: e.req_agent(),
+                client: e.req_client(),
                 // [OPUS-4.8] sq-3jtd.9: this harness exercises the agent/client matcher
                 // dimensions; the issuer dimension (sq-3jtd.6, ACP `acp:issuer`) is left
                 // unconstrained (`None` ⇒ AnyIssuer), so issuer-blind decision parity is
                 // unaffected by the (agent, client, issuer) principal model.
                 issuer: None,
             };
-            let accessible = index.accessible(&session, e.mode);
-            let granted = accessible.iter().any(|g| g.as_str() == e.resource);
-            let actual = if granted {
-                Decision::Allow
-            } else {
-                Decision::Deny
-            };
-            results.push(DecisionResult {
-                expect: e.clone(),
-                actual,
-            });
-        }
-        Ok(ScenarioReport {
-            name: self.name.clone(),
-            results,
+            index
+                .accessible(&session, e.req_mode())
+                .iter()
+                .any(|g| g.as_str() == e.req_resource())
         })
     }
 }
@@ -568,6 +578,47 @@ pub struct ScenarioReport {
 }
 
 impl ScenarioReport {
+    /// Build a report by asking `granted` whether the engine grants each expectation's
+    /// `(agent, client, mode, resource)` request, comparing it to the expected [`Decision`].
+    ///
+    /// [OPUS-4.8] sq-3jtd.8 — the shared comparison/reporting core for both the ACP harness
+    /// ([`AcpScenario::run`]) and the WAC harness ([`crate::wac_conformance::WacScenario::run`]):
+    /// only the *engine* differs (which auth view `granted` consults), not the
+    /// decision-parity machinery. `granted` returns `true` when the resource is in the
+    /// session's accessible set for the mode (⇒ [`Decision::Allow`]), `false` otherwise
+    /// (⇒ [`Decision::Deny`]). It is `FnMut` so callers may consult a `&mut` engine handle
+    /// (e.g. [`crate::PodStore`], whose `accessible` memoizes per session).
+    ///
+    /// # Errors
+    ///
+    /// Never — this is infallible (it records mismatches in the report rather than
+    /// erroring). It returns `Result` only so callers can `?`-chain it after a fallible
+    /// materialization step.
+    pub fn build(
+        name: &str,
+        expects: &[Expect],
+        mut granted: impl FnMut(&Expect) -> bool,
+    ) -> Result<ScenarioReport, String> {
+        let results = expects
+            .iter()
+            .map(|e| {
+                let actual = if granted(e) {
+                    Decision::Allow
+                } else {
+                    Decision::Deny
+                };
+                DecisionResult {
+                    expect: e.clone(),
+                    actual,
+                }
+            })
+            .collect();
+        Ok(ScenarioReport {
+            name: name.to_owned(),
+            results,
+        })
+    }
+
     /// `true` iff every expected decision was reproduced by the engine.
     pub fn passed(&self) -> bool {
         self.results.iter().all(DecisionResult::matched)

--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -20,10 +20,19 @@ mod provenance;
 pub mod odrl_bridge;
 mod rewrite;
 mod update; // [OPUS-4.8] sq-xor3: write/update-path enforcement
+// [OPUS-4.8] sq-3jtd.8: library-level WAC conformance harness — the table-driven
+// scenario sibling of `conformance` (ACP), over the WAC engine (materialize_wac +
+// AuthIndex::accessible). Shares the decision/expectation/report vocabulary with
+// `conformance`; adds the WAC `.acl`-corpus builder (`AclBuilder`) and runner
+// (`WacScenario`). Always compiled (no feature gate). Corpus in tests/conformance_wac.rs.
+pub mod wac_conformance;
 
 pub use authindex::{pair_principal, triple_principal, AuthIndex, Mode, Session};
 // [OPUS-4.8] sq-3jtd.9: the ACP conformance harness entry types.
 pub use conformance::{AcpScenario, AcrBuilder, Decision, Expect, ScenarioReport};
+// [OPUS-4.8] sq-3jtd.8: the WAC conformance harness entry types (the decision/expectation
+// /report vocabulary is the shared `conformance::{Decision, Expect, ScenarioReport}`).
+pub use wac_conformance::{AclBuilder, AuthBuilder, WacScenario};
 pub use fixture::{acp_fixture, wac_fixture};
 pub use materialize::{materialize_acp, materialize_acp_with, materialize_wac, MaterializeStats};
 pub use provenance::AccessProvenance;

--- a/crates/sparq-solid/src/wac_conformance.rs
+++ b/crates/sparq-solid/src/wac_conformance.rs
@@ -1,0 +1,443 @@
+//! [OPUS-4.8] sq-3jtd.8 — a library-level **WAC conformance harness**.
+//!
+//! # What this is (and the decision behind it)
+//!
+//! The conformance surface targeted here is the **Solid Web Access Control (WAC)
+//! specification** — <https://solidproject.org/TR/wac> — exercised at the *library*
+//! level: a scenario is an `.acl`-document corpus plus a table of expected
+//! `(agent, client, mode, resource) → allow | deny` decisions, and the harness asserts
+//! that this crate's WAC authorization engine
+//! ([`crate::materialize_wac`] + [`crate::AuthIndex::accessible`]) reproduces every
+//! expected decision (`research/sparq-solid-scope.md` §4).
+//!
+//! This is the **realistic, achievable** conformance signal for an authorization
+//! *oracle*. Two routes were considered and deliberately NOT taken here (identical
+//! reasoning to the ACP harness in [`crate::conformance`] — kept in sync):
+//!
+//! - **CTH-over-HTTP** (the Solid Conformance Test Harness / `solid/specification-tests`)
+//!   drives a *server* and asserts on HTTP outputs (status codes, the `WAC-Allow`
+//!   header). This crate has no HTTP surface — that route is out-of-scope (it belongs
+//!   to the Solid server, conformance-tested *through* the server), per the scope record.
+//! - **A differential oracle against a JS reference evaluator** (Community Solid Server —
+//!   same corpus, diff decisions) is the credible *second* oracle, but is research-open
+//!   (JS-toolchain cost) and tracked as a follow-up — it is NOT built here.
+//!
+//! Instead, scenarios are declared as **data** (this module is a builder + runner), and
+//! the expected-decision table is derived from the WAC spec's normative semantics:
+//! ACL resolution (`acl:accessTo` on the resource's own ACL vs. `acl:default` on the
+//! **nearest** ancestor with an ACL — nearest-wins, NOT cumulative), access subjects
+//! (`acl:agent` / `acl:agentClass` `foaf:Agent` (public) / `acl:AuthenticatedAgent` /
+//! `acl:agentGroup` via `vcard:hasMember` / `acl:origin` minting an (agent, client) pair),
+//! and access modes (`acl:Read`/`Write`/`Append`/`Control`, where `Control` governs the
+//! **ACL document** of the resource, not the resource). The corpus that consumes this
+//! harness lives in `tests/conformance_wac.rs`.
+//!
+//! # Relationship to the ACP harness and to `tests/wac.rs`
+//!
+//! The decision/expectation/report vocabulary ([`Decision`](crate::conformance::Decision),
+//! [`Expect`], [`ScenarioReport`]) is **shared** with the ACP harness
+//! ([`crate::conformance`]) — both compare the same
+//! `(agent, client, mode, resource) → allow | deny` binary against the same
+//! [`AuthIndex::accessible`] verdict; only the *corpus shape* differs (`.acl`
+//! authorizations here, `.acr` policies there). This module adds the WAC-specific corpus
+//! builder ([`AclBuilder`]) and runner ([`WacScenario`]).
+//!
+//! `tests/wac.rs` asserts a hand-derived access *matrix* over the one big synthetic
+//! `wac_fixture()` pod — bespoke, internally authored, depth-4. This harness is
+//! structurally different: it is **table-driven over independent, minimal scenarios**,
+//! each isolating one WAC construct, with a uniform pass/fail report. The two are
+//! complementary: the matrix exercises depth and interaction on a realistic pod; this
+//! harness exercises spec-construct coverage with small, auditable, independently-failing
+//! cases (the natural input for the aspirational CSS differential oracle).
+//!
+//! # Example
+//!
+//! ```
+//! use sparq_solid::wac_conformance::{AclBuilder, WacScenario};
+//! use sparq_solid::conformance::{Decision, Expect};
+//! use sparq_solid::Mode;
+//!
+//! let alice = "https://alice.example/card#me";
+//! let bob = "https://bob.example/card#me";
+//! let doc = "https://pod.example/notes/n1";
+//!
+//! // An ACL on the document grants Read to exactly { alice } via `acl:accessTo`.
+//! let mut acl = AclBuilder::new();
+//! acl.access_to(doc, |a| a.agent(alice).mode(Mode::Read));
+//! acl.document(doc); // the protected resource is a (possibly empty) named graph
+//!
+//! let scenario = WacScenario::new("agent-allow")
+//!     .acl(acl)
+//!     .expect(Expect::agent(alice).read(doc).is(Decision::Allow))
+//!     .expect(Expect::agent(bob).read(doc).is(Decision::Deny))
+//!     .expect(Expect::anonymous().read(doc).is(Decision::Deny));
+//!
+//! let report = scenario.run().expect("materializes");
+//! assert!(report.passed(), "{report}"); // every expected decision reproduced
+//! ```
+
+use crate::conformance::{Expect, ScenarioReport};
+use crate::{materialize_wac, AuthIndex, Mode, PodStore, Session};
+use sparq_core::Graph;
+use std::fmt::Write as _;
+
+const ACL: &str = "http://www.w3.org/ns/auth/acl#";
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const FOAF_AGENT: &str = "http://xmlns.com/foaf/0.1/Agent";
+const VCARD_MEMBER: &str = "http://www.w3.org/2006/vcard/ns#hasMember";
+const EX_PRED: &str = "https://ex.dev/ns#prop";
+
+/// The WAC `acl:AuthenticatedAgent` class IRI — the matcher that accepts any
+/// *authenticated* requestor (an agent is present) but not the anonymous one.
+pub const AUTHENTICATED_AGENT: &str = "http://www.w3.org/ns/auth/acl#AuthenticatedAgent";
+/// The `foaf:Agent` class IRI — WAC's "public" matcher, accepting every requestor
+/// including the anonymous one.
+pub const PUBLIC_AGENT: &str = FOAF_AGENT;
+
+/// A builder for one WAC ACL-document corpus, written as N-Quads (each `acl:Authorization`
+/// into the `<{resource}.acl>` graph named by Solid's `R` → `R.acl` convention, the same
+/// linkage [`crate::materialize_wac`]'s loader resolves).
+///
+/// An `acl:Authorization` binds the protected `resource` either via
+/// [`AclBuilder::access_to`] (`acl:accessTo`, applies to the resource named by the ACL —
+/// the resource's own ACL) or [`AclBuilder::default_for`] (`acl:default`, applies to the
+/// resource's **members** by *inheritance from the nearest ancestor* — WAC inheritance is
+/// **nearest-wins**, NOT cumulative: a resource is governed by exactly the ACL of the
+/// closest ancestor (or itself) that has one, and a closer ACL fully shadows the rest).
+/// Each authorization carries access subjects and modes declared by an [`AuthBuilder`]
+/// closure.
+///
+/// To make a resource a concrete protected graph (so an `Allow` is observable as a
+/// non-empty accessible set, and so the resource exists as an inheritance anchor),
+/// register it with [`AclBuilder::document`]. Group documents for `acl:agentGroup` are
+/// emitted automatically by [`AuthBuilder::agent_group`].
+///
+/// **Containment is by IRI structure**, not by an `ldp:contains` triple: this crate's WAC
+/// engine derives ancestry from the Solid slash path (`rules/common.n3`), so an
+/// `acl:default` on `https://pod.example/c/` reaches `https://pod.example/c/d` because the
+/// latter is structurally under the former — provided the container `…/c/` is a known
+/// resource (give it its own ACL, or register it with [`AclBuilder::document`]; a
+/// structural prefix of any present graph is also recognised automatically).
+#[derive(Debug, Default, Clone)]
+pub struct AclBuilder {
+    quads: String,
+    auths: usize,
+}
+
+impl AclBuilder {
+    /// A new, empty ACL builder.
+    pub fn new() -> AclBuilder {
+        AclBuilder::default()
+    }
+
+    /// Add an `acl:Authorization` with `acl:accessTo <resource>` — it applies to the
+    /// resource itself (the resource's own ACL). The `build` closure declares the
+    /// authorization's access subjects and modes.
+    pub fn access_to(
+        &mut self,
+        resource: &str,
+        build: impl FnOnce(AuthBuilder<'_>) -> AuthBuilder<'_>,
+    ) -> &mut AclBuilder {
+        self.add_auth(resource, true, false, build)
+    }
+
+    /// Add an `acl:Authorization` with `acl:default <resource>` — it applies to the
+    /// resource's **members** (its IRI-structural descendants) by nearest-ancestor
+    /// inheritance, but NOT to the resource itself.
+    pub fn default_for(
+        &mut self,
+        resource: &str,
+        build: impl FnOnce(AuthBuilder<'_>) -> AuthBuilder<'_>,
+    ) -> &mut AclBuilder {
+        self.add_auth(resource, false, true, build)
+    }
+
+    /// Add an `acl:Authorization` with BOTH `acl:accessTo` and `acl:default <resource>` —
+    /// it applies to the resource itself AND its members (the common "owns this container
+    /// and everything under it" shape).
+    pub fn access_to_and_default(
+        &mut self,
+        resource: &str,
+        build: impl FnOnce(AuthBuilder<'_>) -> AuthBuilder<'_>,
+    ) -> &mut AclBuilder {
+        self.add_auth(resource, true, true, build)
+    }
+
+    fn add_auth(
+        &mut self,
+        resource: &str,
+        access_to: bool,
+        default: bool,
+        build: impl FnOnce(AuthBuilder<'_>) -> AuthBuilder<'_>,
+    ) -> &mut AclBuilder {
+        let g = format!("{resource}.acl");
+        let ix = self.auths;
+        self.auths += 1;
+        let auth = format!("{g}#auth{ix}");
+        let _ = writeln!(
+            self.quads,
+            "<{auth}> <{RDF_TYPE}> <{ACL}Authorization> <{g}> ."
+        );
+        if access_to {
+            let _ = writeln!(self.quads, "<{auth}> <{ACL}accessTo> <{resource}> <{g}> .");
+        }
+        if default {
+            let _ = writeln!(self.quads, "<{auth}> <{ACL}default> <{resource}> <{g}> .");
+        }
+        let ab = AuthBuilder {
+            quads: &mut self.quads,
+            graph: g,
+            auth,
+        };
+        build(ab);
+        self
+    }
+
+    /// Register `resource` as a concrete protected document: emit a placeholder triple
+    /// into `<{resource}>` so that a granted access is observable as a non-empty
+    /// accessible set (and so the resource is a known inheritance anchor).
+    pub fn document(&mut self, resource: &str) -> &mut AclBuilder {
+        let _ = writeln!(
+            self.quads,
+            "<{resource}#it> <{EX_PRED}> \"x\" <{resource}> ."
+        );
+        self
+    }
+
+    /// The accumulated N-Quads of this ACL corpus.
+    pub fn into_nquads(self) -> String {
+        self.quads
+    }
+}
+
+/// A fluent builder for one WAC `acl:Authorization`: its access subjects
+/// (`acl:agent` / `acl:agentClass` / `acl:agentGroup` / `acl:origin`) and its `acl:mode`s.
+///
+/// WAC authorization semantics (normative): an authorization that *applies to* a resource
+/// (by `acl:accessTo` on its own ACL, or by `acl:default` on the resource's nearest
+/// ancestor ACL) grants its `acl:mode`s to every requestor matched by ANY of its access
+/// subjects. There is no deny in core WAC — access is the union of all applicable grants;
+/// the nearest-ACL resolution is the only "narrowing" (a closer ACL replaces, rather than
+/// adds to, the ancestor's). An `acl:origin` makes the grant a (user, application) pair:
+/// the agent matches only through that client/origin.
+#[derive(Debug)]
+pub struct AuthBuilder<'a> {
+    quads: &'a mut String,
+    graph: String,
+    auth: String,
+}
+
+impl AuthBuilder<'_> {
+    fn mode_iri(mode: Mode) -> &'static str {
+        match mode {
+            Mode::Read => "Read",
+            Mode::Write => "Write",
+            Mode::Append => "Append",
+            Mode::Control => "Control",
+        }
+    }
+
+    /// Add an `acl:mode <mode>` to this authorization.
+    pub fn mode(self, mode: Mode) -> Self {
+        let m = Self::mode_iri(mode);
+        let _ = writeln!(
+            self.quads,
+            "<{}> <{ACL}mode> <{ACL}{m}> <{}> .",
+            self.auth, self.graph
+        );
+        self
+    }
+
+    /// Add an `acl:agent <webid>` subject — the named WebID is granted.
+    pub fn agent(self, webid: &str) -> Self {
+        let _ = writeln!(
+            self.quads,
+            "<{}> <{ACL}agent> <{webid}> <{}> .",
+            self.auth, self.graph
+        );
+        self
+    }
+
+    /// Add an `acl:agentClass foaf:Agent` subject — the **public** class, granting every
+    /// requestor including the anonymous one. (Convenience for `agent_class(PUBLIC_AGENT)`.)
+    pub fn public(self) -> Self {
+        self.agent_class(PUBLIC_AGENT)
+    }
+
+    /// Add an `acl:agentClass acl:AuthenticatedAgent` subject — granting any *authenticated*
+    /// requestor but not the anonymous one. (Convenience for
+    /// `agent_class(AUTHENTICATED_AGENT)`.)
+    pub fn authenticated(self) -> Self {
+        self.agent_class(AUTHENTICATED_AGENT)
+    }
+
+    /// Add an `acl:agentClass <class>` subject (use [`PUBLIC_AGENT`] / [`AUTHENTICATED_AGENT`];
+    /// any other class is inert — the WAC rules only recognise those two).
+    pub fn agent_class(self, class: &str) -> Self {
+        let _ = writeln!(
+            self.quads,
+            "<{}> <{ACL}agentClass> <{class}> <{}> .",
+            self.auth, self.graph
+        );
+        self
+    }
+
+    /// Add an `acl:agentGroup <group>` subject AND emit the group document
+    /// (`<group> vcard:hasMember <member>` for each member into the fragment-stripped
+    /// group-document graph), granting every group member. The WAC loader resolves the
+    /// group document by stripping the fragment from the group IRI, so `group` should be
+    /// a fragment IRI like `https://pod.example/groups/team#g`.
+    pub fn agent_group(self, group: &str, members: &[&str]) -> Self {
+        let _ = writeln!(
+            self.quads,
+            "<{}> <{ACL}agentGroup> <{group}> <{}> .",
+            self.auth, self.graph
+        );
+        // The group document is the group IRI without its fragment (loader convention).
+        let doc = group.split('#').next().unwrap_or(group);
+        for m in members {
+            let _ = writeln!(self.quads, "<{group}> <{VCARD_MEMBER}> <{m}> <{doc}> .");
+        }
+        self
+    }
+
+    /// Add an `acl:origin <client>` to this authorization — the grant becomes a
+    /// (user, application) pair: a matched agent is granted only when the session presents
+    /// this client/origin. (An authorization with an `acl:origin` and no `acl:agent` grants
+    /// nobody — the agent half is required.)
+    pub fn origin(self, client: &str) -> Self {
+        let _ = writeln!(
+            self.quads,
+            "<{}> <{ACL}origin> <{client}> <{}> .",
+            self.auth, self.graph
+        );
+        self
+    }
+}
+
+/// One WAC conformance scenario: a named, self-contained `.acl` corpus plus the table of
+/// expected `(agent, client, mode, resource) → decision` decisions the WAC spec requires
+/// for it.
+///
+/// Build with [`WacScenario::new`], attach the ACL corpus with [`WacScenario::acl`] (or
+/// raw N-Quads with [`WacScenario::nquads`]), add expectations with [`WacScenario::expect`]
+/// (the shared [`Expect`] builder from [`crate::conformance`]), then [`WacScenario::run`]
+/// it through the real WAC engine.
+#[derive(Debug, Clone)]
+pub struct WacScenario {
+    name: String,
+    nquads: String,
+    expects: Vec<Expect>,
+}
+
+impl WacScenario {
+    /// A new, empty scenario with the given `name` (used in the failure report).
+    pub fn new(name: &str) -> WacScenario {
+        WacScenario {
+            name: name.to_owned(),
+            nquads: String::new(),
+            expects: Vec::new(),
+        }
+    }
+
+    /// Attach an [`AclBuilder`]'s ACL corpus to this scenario (appended to any N-Quads
+    /// already present).
+    pub fn acl(mut self, acl: AclBuilder) -> Self {
+        self.nquads.push_str(&acl.into_nquads());
+        self
+    }
+
+    /// Append raw N-Quads (e.g. extra document content) to the scenario corpus.
+    pub fn nquads(mut self, nquads: &str) -> Self {
+        self.nquads.push_str(nquads);
+        self.nquads.push('\n');
+        self
+    }
+
+    /// Add one expected decision to the scenario's table.
+    pub fn expect(mut self, e: Expect) -> Self {
+        self.expects.push(e);
+        self
+    }
+
+    /// Add many expected decisions at once.
+    pub fn expect_all(mut self, es: impl IntoIterator<Item = Expect>) -> Self {
+        self.expects.extend(es);
+        self
+    }
+
+    /// The scenario's name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Materialize the scenario's WAC corpus and check every expected decision against the
+    /// engine's verdict, returning a [`ScenarioReport`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` only if the corpus fails to load or [`materialize_wac`] errors (e.g. a
+    /// reserved-encoding collision). A *wrong decision* is NOT an error — it is a recorded
+    /// mismatch in the returned report (so a whole corpus can be run and all mismatches
+    /// reported at once).
+    pub fn run(&self) -> Result<ScenarioReport, String> {
+        let mut graph = Graph::load_dataset(&self.nquads, "nquads")
+            .map_err(|e| format!("scenario {:?}: load failed: {e}", self.name))?;
+        materialize_wac(&mut graph)
+            .map_err(|e| format!("scenario {:?}: materialize_wac failed: {e}", self.name))?;
+        let index = AuthIndex::from_graph(&graph);
+        ScenarioReport::build(&self.name, &self.expects, |e| {
+            // WAC has no issuer dimension; the session's issuer stays None (an absent
+            // `acl:issuer` notion — see authindex::Session). [OPUS-4.8] sq-3jtd.8
+            let session = Session {
+                agent: e.req_agent(),
+                client: e.req_client(),
+                issuer: None,
+            };
+            index
+                .accessible(&session, e.req_mode())
+                .iter()
+                .any(|g| g.as_str() == e.req_resource())
+        })
+    }
+
+    /// Materialize the scenario through a full [`PodStore`] (the method form of the engine,
+    /// with the per-session cache) and check decision parity. Equivalent verdict to
+    /// [`WacScenario::run`]; this form additionally proves the public `PodStore` surface
+    /// reproduces the same decisions (the path a PSS integration actually uses).
+    ///
+    /// # Errors
+    ///
+    /// As [`WacScenario::run`].
+    pub fn run_via_podstore(&self) -> Result<ScenarioReport, String> {
+        let graph = Graph::load_dataset(&self.nquads, "nquads")
+            .map_err(|e| format!("scenario {:?}: load failed: {e}", self.name))?;
+        let mut store = PodStore::new(graph);
+        store
+            .materialize_wac()
+            .map_err(|e| format!("scenario {:?}: materialize_wac failed: {e}", self.name))?;
+        ScenarioReport::build(&self.name, &self.expects, |e| {
+            let session = Session {
+                agent: e.req_agent(),
+                client: e.req_client(),
+                issuer: None,
+            };
+            store
+                .accessible(&session, e.req_mode())
+                .iter()
+                .any(|g| g.as_str() == e.req_resource())
+        })
+    }
+}
+
+/// Run a whole corpus of WAC scenarios, returning the per-scenario reports. A convenience
+/// for `tests/conformance_wac.rs`: every scenario is run even if an earlier one mismatches,
+/// so a single test surfaces all mismatches at once.
+///
+/// # Errors
+///
+/// Returns `Err` if any scenario fails to materialize (load / reasoner error). Decision
+/// mismatches are not errors — they are in the returned reports.
+pub fn run_corpus(scenarios: &[WacScenario]) -> Result<Vec<ScenarioReport>, String> {
+    scenarios.iter().map(WacScenario::run).collect()
+}

--- a/crates/sparq-solid/tests/conformance_wac.rs
+++ b/crates/sparq-solid/tests/conformance_wac.rs
@@ -1,0 +1,352 @@
+//! [OPUS-4.8] sq-3jtd.8 — the WAC **conformance corpus**: a table of independent, minimal
+//! scenarios, each isolating one Solid WAC-spec construct, run through this crate's WAC
+//! authorization engine (`materialize_wac` + `AuthIndex::accessible`) with its expected
+//! `(agent, client, mode, resource) → allow | deny` decisions asserted.
+//!
+//! Decision: the conformance surface is the Solid WAC spec
+//! (<https://solidproject.org/TR/wac>) at the library level — see the harness module
+//! `src/wac_conformance.rs` for the full rationale (why CTH-over-HTTP and the JS-reference
+//! differential oracle are out-of-scope / research-open). This is the near-term-feasible
+//! conformance signal called for in `research/sparq-solid-scope.md` §4. The harness lets
+//! each scenario fail independently and reports all mismatches at once.
+//!
+//! The scenarios are derived from the WAC spec's normative semantics, NOT vendored over
+//! HTTP from the live `solid/specification-tests` / CTH corpus — that corpus asserts on
+//! HTTP-shaped outputs (status codes, the `WAC-Allow` header) which have no library entry
+//! point here (they are PSS's by design, gh-55). The decision table below is the
+//! authorization *content* of those tests (the `.acl` shapes and their expected
+//! allow/deny per principal), which is exactly what an authorization oracle can reproduce.
+
+use sparq_solid::conformance::{Decision, Expect};
+use sparq_solid::wac_conformance::{
+    run_corpus, AclBuilder, WacScenario, AUTHENTICATED_AGENT, PUBLIC_AGENT,
+};
+use sparq_solid::Mode;
+
+const ALICE: &str = "https://alice.example/card#me";
+const BOB: &str = "https://bob.example/card#me";
+const CAROL: &str = "https://carol.example/card#me";
+const DAVE: &str = "https://dave.example/card#me";
+const APP: &str = "https://app.example";
+const EVIL: &str = "https://evil.example";
+
+/// WAC §"Access subjects" `acl:agent` + §"Access modes" `acl:accessTo`: an authorization
+/// on the resource's own ACL grants the named agent and nobody else; the anonymous
+/// requestor is refused (fail-closed).
+fn agent_access_to() -> WacScenario {
+    let doc = "https://pod.example/agent/d1";
+    let mut acl = AclBuilder::new();
+    acl.access_to(doc, |a| a.agent(ALICE).mode(Mode::Read));
+    acl.document(doc);
+    WacScenario::new("agent-accessTo")
+        .acl(acl)
+        .expect(Expect::agent(ALICE).read(doc).is(Decision::Allow))
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Deny))
+        .expect(Expect::anonymous().read(doc).is(Decision::Deny))
+}
+
+/// WAC §"Access subjects" `acl:agentClass foaf:Agent` (the public class): grants EVERY
+/// requestor including the anonymous one and any client.
+fn public_agent_class() -> WacScenario {
+    let doc = "https://pod.example/public/d1";
+    let mut acl = AclBuilder::new();
+    acl.access_to(doc, |a| a.public().mode(Mode::Read));
+    acl.document(doc);
+    WacScenario::new("agentClass-foaf-Agent-public")
+        .acl(acl)
+        .expect(Expect::anonymous().read(doc).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).read(doc).is(Decision::Allow))
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Allow))
+        .expect(Expect::pair(BOB, APP).read(doc).is(Decision::Allow))
+        // sanity: the `PUBLIC_AGENT` constant is `foaf:Agent`.
+        .expect(
+            Expect::agent(CAROL)
+                .read(doc)
+                .is(if PUBLIC_AGENT == "http://xmlns.com/foaf/0.1/Agent" {
+                    Decision::Allow
+                } else {
+                    Decision::Deny
+                }),
+        )
+}
+
+/// WAC §"Access subjects" `acl:agentClass acl:AuthenticatedAgent`: grants any *authenticated*
+/// requestor but NOT the anonymous one.
+fn authenticated_agent_class() -> WacScenario {
+    let doc = "https://pod.example/authn/d1";
+    let mut acl = AclBuilder::new();
+    acl.access_to(doc, |a| {
+        a.agent_class(AUTHENTICATED_AGENT).mode(Mode::Read)
+    });
+    acl.document(doc);
+    WacScenario::new("agentClass-AuthenticatedAgent")
+        .acl(acl)
+        .expect(Expect::agent(ALICE).read(doc).is(Decision::Allow))
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Allow))
+        .expect(Expect::anonymous().read(doc).is(Decision::Deny))
+}
+
+/// WAC §"Access subjects" `acl:agentGroup` + `vcard:hasMember`: every group member is
+/// granted; a non-member is not. (The group document is the group IRI with the fragment
+/// stripped — the loader's resolution convention.)
+fn agent_group() -> WacScenario {
+    let doc = "https://pod.example/team/d1";
+    let group = "https://pod.example/groups/team#g";
+    let mut acl = AclBuilder::new();
+    acl.access_to(doc, |a| {
+        a.agent_group(group, &[BOB, CAROL])
+            .mode(Mode::Read)
+            .mode(Mode::Write)
+    });
+    acl.document(doc);
+    WacScenario::new("agentGroup-vcard-members")
+        .acl(acl)
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Allow))
+        .expect(Expect::agent(CAROL).read(doc).is(Decision::Allow))
+        // group grant carries Write too (independent mode).
+        .expect(Expect::agent(BOB).write(doc).is(Decision::Allow))
+        .expect(Expect::agent(DAVE).read(doc).is(Decision::Deny))
+        .expect(Expect::anonymous().read(doc).is(Decision::Deny))
+}
+
+/// WAC §"ACL resolution": `acl:default` on a container inherits to its members (its
+/// IRI-structural descendants) but NOT to the container resource itself, while
+/// `acl:accessTo` applies to the resource named by the ACL only. Here a container's ACL
+/// grants alice on members via `acl:default`; a deep document inherits it, the container's
+/// own resource does not.
+fn default_inheritance_vs_access_to() -> WacScenario {
+    let container = "https://pod.example/c/";
+    let deep = "https://pod.example/c/sub/d1";
+    let mut acl = AclBuilder::new();
+    // acl:default on the container: inherited by descendants, not the container itself.
+    acl.default_for(container, |a| a.agent(ALICE).mode(Mode::Read));
+    acl.document(deep); // the protected descendant
+    acl.document(container); // make the container a concrete resource + inheritance anchor
+    WacScenario::new("default-inheritance-vs-accessTo")
+        .acl(acl)
+        // alice reads the descendant (inherited acl:default)
+        .expect(Expect::agent(ALICE).read(deep).is(Decision::Allow))
+        .expect(Expect::agent(BOB).read(deep).is(Decision::Deny))
+        // the container resource itself is not a member of itself: acl:default does not
+        // grant it (no acl:accessTo present), so alice cannot read the container.
+        .expect(Expect::agent(ALICE).read(container).is(Decision::Deny))
+}
+
+/// WAC §"ACL resolution" NEAREST-ACL (the key WAC difference from ACP's cumulative
+/// inheritance): a resource is governed by exactly the **nearest** ancestor that has an
+/// ACL — a closer ACL fully SHADOWS the ancestors above it. Root grants alice on all
+/// members; a nested container restates an ACL granting only bob; a deep document under
+/// the nested container is readable by BOB ONLY — alice's root grant is shadowed (NOT
+/// cumulative).
+fn nearest_acl_shadows() -> WacScenario {
+    let root = "https://pod.example/";
+    let mid = "https://pod.example/proj/";
+    let deep = "https://pod.example/proj/c/d1";
+    let mut acl = AclBuilder::new();
+    acl.default_for(root, |a| a.agent(ALICE).mode(Mode::Read));
+    acl.default_for(mid, |a| a.agent(BOB).mode(Mode::Read));
+    acl.document(deep);
+    WacScenario::new("nearest-acl-shadows-ancestor")
+        .acl(acl)
+        // bob via the NEAREST acl (mid)
+        .expect(Expect::agent(BOB).read(deep).is(Decision::Allow))
+        // alice's root grant is SHADOWED by the closer mid ACL — denied.
+        .expect(Expect::agent(ALICE).read(deep).is(Decision::Deny))
+        .expect(Expect::agent(CAROL).read(deep).is(Decision::Deny))
+}
+
+/// WAC §"ACL resolution": a resource-specific own ACL (`acl:accessTo` on the document
+/// itself) overrides the container's `acl:default` for THAT document only — a sibling
+/// without its own ACL still inherits the container default.
+fn resource_specific_override() -> WacScenario {
+    let container = "https://pod.example/docs/";
+    let overridden = "https://pod.example/docs/d0";
+    let sibling = "https://pod.example/docs/d1";
+    let mut acl = AclBuilder::new();
+    // container default: alice on members
+    acl.default_for(container, |a| a.agent(ALICE).mode(Mode::Read));
+    acl.document(container);
+    // overridden document has its OWN acl granting bob (shadows the container default)
+    acl.access_to(overridden, |a| a.agent(BOB).mode(Mode::Read));
+    acl.document(overridden);
+    acl.document(sibling); // no own acl -> inherits the container default
+    WacScenario::new("resource-specific-override")
+        .acl(acl)
+        // the overridden doc: bob only (its own ACL shadows the container default)
+        .expect(Expect::agent(BOB).read(overridden).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).read(overridden).is(Decision::Deny))
+        // the sibling still inherits the container default: alice only
+        .expect(Expect::agent(ALICE).read(sibling).is(Decision::Allow))
+        .expect(Expect::agent(BOB).read(sibling).is(Decision::Deny))
+}
+
+/// WAC §"Access subjects" `acl:origin`: the grant is a (user, application) PAIR — the agent
+/// is granted only when the session presents that origin/client. The right agent with the
+/// wrong client (or no client) is refused; a wrong agent with the right client is refused.
+fn origin_user_app_pair() -> WacScenario {
+    let doc = "https://pod.example/origin/d1";
+    let mut acl = AclBuilder::new();
+    acl.access_to(doc, |a| a.agent(BOB).origin(APP).mode(Mode::Read));
+    acl.document(doc);
+    WacScenario::new("origin-user-app-pair")
+        .acl(acl)
+        .expect(Expect::pair(BOB, APP).read(doc).is(Decision::Allow))
+        .expect(Expect::pair(BOB, EVIL).read(doc).is(Decision::Deny))
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Deny)) // no client
+        .expect(Expect::pair(CAROL, APP).read(doc).is(Decision::Deny)) // wrong agent
+        .expect(Expect::anonymous().read(doc).is(Decision::Deny))
+}
+
+/// WAC §"Access modes": the four modes are independent. An authorization that names
+/// Read+Write grants both; a Read-only authorization denies Write/Append.
+fn mode_independence() -> WacScenario {
+    let rw = "https://pod.example/modes/rw";
+    let ro = "https://pod.example/modes/ro";
+    let mut acl = AclBuilder::new();
+    acl.access_to(rw, |a| a.agent(ALICE).mode(Mode::Read).mode(Mode::Write));
+    acl.access_to(ro, |a| a.agent(ALICE).mode(Mode::Read));
+    acl.document(rw);
+    acl.document(ro);
+    WacScenario::new("mode-independence")
+        .acl(acl)
+        .expect(Expect::agent(ALICE).read(rw).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).write(rw).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).read(ro).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).write(ro).is(Decision::Deny))
+        .expect(Expect::agent(ALICE).append(ro).is(Decision::Deny))
+}
+
+/// WAC §"Access modes" `acl:Control`: Control governs the resource's **ACL document**, not
+/// the resource. A Control grant on the resource makes the holder Read+Write the
+/// `<resource>.acl` graph (and Control on the resource itself), but does NOT by itself make
+/// the resource readable. Here alice has Read+Control on the doc; she can Read the doc (via
+/// Read) and Write its `.acl` (via Control), while bob — with neither — can do neither.
+fn control_governs_acl_document() -> WacScenario {
+    let doc = "https://pod.example/ctl/d1";
+    let acl_doc = "https://pod.example/ctl/d1.acl";
+    let mut acl = AclBuilder::new();
+    acl.access_to(doc, |a| a.agent(ALICE).mode(Mode::Read).mode(Mode::Control));
+    acl.document(doc);
+    WacScenario::new("control-governs-acl-document")
+        .acl(acl)
+        .expect(Expect::agent(ALICE).read(doc).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).control(doc).is(Decision::Allow))
+        // Control -> Read+Write of the .acl graph
+        .expect(Expect::agent(ALICE).read(acl_doc).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).write(acl_doc).is(Decision::Allow))
+        // bob holds nothing
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Deny))
+        .expect(Expect::agent(BOB).read(acl_doc).is(Decision::Deny))
+}
+
+/// WAC fail-closed: a resource with NO applicable ACL (no own ACL, no ancestor ACL) grants
+/// nobody — not the anonymous requestor, not any authenticated agent. An unprotected
+/// resource is invisible.
+fn fail_closed_no_acl() -> WacScenario {
+    let doc = "https://pod.example/orphan/d1";
+    let mut acl = AclBuilder::new();
+    acl.document(doc); // present, but no ACL controls it (and no ancestor ACL)
+    WacScenario::new("fail-closed-no-acl")
+        .acl(acl)
+        .expect(Expect::agent(ALICE).read(doc).is(Decision::Deny))
+        .expect(Expect::anonymous().read(doc).is(Decision::Deny))
+}
+
+/// WAC: multiple `acl:agent`s in one authorization is a disjunction — EITHER named agent is
+/// granted (the grant is the union of its access subjects). Two authorizations in one ACL
+/// likewise union.
+fn multi_agent_union() -> WacScenario {
+    let doc = "https://pod.example/multi/d1";
+    let mut acl = AclBuilder::new();
+    // one authorization, two agents
+    acl.access_to(doc, |a| {
+        a.agent(BOB).agent(CAROL).mode(Mode::Read).mode(Mode::Write)
+    });
+    acl.document(doc);
+    WacScenario::new("multi-agent-union")
+        .acl(acl)
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Allow))
+        .expect(Expect::agent(CAROL).write(doc).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).read(doc).is(Decision::Deny))
+}
+
+/// The full corpus.
+fn corpus() -> Vec<WacScenario> {
+    vec![
+        agent_access_to(),
+        public_agent_class(),
+        authenticated_agent_class(),
+        agent_group(),
+        default_inheritance_vs_access_to(),
+        nearest_acl_shadows(),
+        resource_specific_override(),
+        origin_user_app_pair(),
+        mode_independence(),
+        control_governs_acl_document(),
+        fail_closed_no_acl(),
+        multi_agent_union(),
+    ]
+}
+
+#[test]
+fn wac_conformance_corpus_decision_parity() {
+    let scenarios = corpus();
+    let reports = run_corpus(&scenarios).expect("every scenario materializes");
+
+    let mut failures = String::new();
+    let mut total_decisions = 0usize;
+    for r in &reports {
+        total_decisions += r.checked();
+        if !r.passed() {
+            failures.push_str(&r.to_string());
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "WAC conformance mismatch(es) across {} scenarios / {total_decisions} decisions:\n{failures}",
+        reports.len(),
+    );
+    // Guard against a corpus that silently checks nothing.
+    assert_eq!(reports.len(), 12, "expected 12 scenarios");
+    assert!(
+        total_decisions >= 40,
+        "expected a substantive decision table, got {total_decisions}"
+    );
+}
+
+/// The `PodStore` method form (the path a PSS integration uses, with the per-session cache)
+/// reproduces the same decisions as the free-function `AuthIndex` path. Run the whole
+/// corpus through `run_via_podstore` and assert parity.
+#[test]
+fn wac_conformance_via_podstore_matches() {
+    for scenario in corpus() {
+        let report = scenario
+            .run_via_podstore()
+            .unwrap_or_else(|e| panic!("podstore run failed: {e}"));
+        assert!(report.passed(), "{report}");
+    }
+}
+
+/// The harness reports a mismatch (rather than panicking) when an expected decision is
+/// wrong — so a future regression surfaces as a readable diff, not a generic failure. This
+/// NEGATIVE control deliberately states a wrong expectation and asserts the harness flags it
+/// (it does not assert the engine is wrong — it asserts the *reporting* works).
+#[test]
+fn harness_flags_a_wrong_expectation() {
+    let doc = "https://pod.example/neg/d1";
+    let mut acl = AclBuilder::new();
+    acl.access_to(doc, |a| a.agent(ALICE).mode(Mode::Read));
+    acl.document(doc);
+    // bob has NO grant; asserting Allow is wrong on purpose.
+    let scenario = WacScenario::new("negative-control")
+        .acl(acl)
+        .expect(Expect::agent(BOB).read(doc).is(Decision::Allow));
+    let report = scenario.run().expect("materializes");
+    assert!(
+        !report.passed(),
+        "harness must detect the wrong expectation"
+    );
+    assert_eq!(report.mismatches().count(), 1);
+    // the Display form names the mismatch
+    assert!(report.to_string().contains("MISMATCH"));
+}

--- a/research/sparq-solid-scope.md
+++ b/research/sparq-solid-scope.md
@@ -342,9 +342,23 @@ The honest gaps:
 
 ### Sequenced tasks
 
-1. **(near-term, feasible — **sq-3jtd.8**)** Vendor/ingest the authorization-relevant WAC
-   fixtures from the Solid spec-tests corpus and assert library-level decision parity in
-   `tests/conformance_wac.rs`.
+1. **(DONE — **sq-3jtd.8** [OPUS-4.8])** WAC harness landed: `sparq_solid::wac_conformance`
+   (`src/wac_conformance.rs`) is a table-driven scenario runner over the WAC engine
+   (`materialize_wac` + `AuthIndex::accessible`, with a `run_via_podstore` twin proving the
+   `PodStore` method-form path), sharing the decision/expectation/report vocabulary
+   (`conformance::{Decision, Expect, ScenarioReport}`) with the ACP harness. The scenario
+   corpus in `tests/conformance_wac.rs` isolates each WAC construct: `acl:agent` on the
+   resource's own ACL (`acl:accessTo`), `acl:agentClass foaf:Agent` (public) /
+   `acl:AuthenticatedAgent`, `acl:agentGroup` via `vcard:hasMember`, `acl:default`
+   inheritance vs `acl:accessTo`, **nearest-ACL shadowing** (the key WAC difference from
+   ACP's cumulative inheritance), resource-specific override, the `acl:origin` (user, app)
+   pair, mode independence, `acl:Control` governing the `.acl` document, fail-closed, and
+   the multi-agent union. **Decision recorded (same as ACP):** scenarios are derived from
+   the WAC spec's normative semantics and declared as data (an `AclBuilder` corpus + an
+   expected-decision table), rather than vendoring the live JS spec-tests/CTH corpus over
+   HTTP — that route has no library entry point here (it asserts on HTTP outputs, PSS's by
+   design). The table-driven corpus is the natural input for the aspirational CSS
+   differential oracle (item 3).
 2. **(DONE — **sq-3jtd.9** [OPUS-4.8])** ACP harness landed: `sparq_solid::conformance`
    (`src/conformance.rs`) is a table-driven scenario runner over the ACP engine
    (`materialize_acp` + `AuthIndex::accessible`), with the scenario corpus in
@@ -354,9 +368,10 @@ The honest gaps:
    derived from the ACP spec's normative semantics and declared as data (an `AcrBuilder` corpus
    + an expected-decision table), rather than vendoring the live JS spec-tests/CTH corpus over
    HTTP — that route has no library entry point here (it asserts on HTTP outputs, PSS's by
-   design). NOTE: the WAC harness (sq-3jtd.8) was still open when this landed, so the ACP harness
-   defines the in-crate pattern rather than mirroring an existing WAC one; the same harness shape
-   transfers to WAC when sq-3jtd.8 is implemented.
+   design). The ACP harness defined the in-crate pattern; the WAC harness (sq-3jtd.8, item 1
+   above) now mirrors it, sharing the `conformance::{Decision, Expect, ScenarioReport}`
+   vocabulary (the `ScenarioReport::build` core takes a `FnMut` "granted?" oracle, so both
+   harnesses differ only in which auth view they consult).
 3. *(research-open / aspirational — STILL NOT STARTED)* Differential oracle against CSS (WAC/ACP):
    run the same corpus through the JS reference evaluator and diff decisions. Deferred for the
    JS-toolchain cost; the table-driven corpus in `tests/conformance_acp.rs` is the natural input

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -220,9 +220,9 @@ What it is — and is NOT (honest scope, mirrors the module/README/`research/spa
   behaviour. It is complementary to `tests/acp.rs` (a hand-derived access matrix over one
   realistic pod): this harness gives spec-construct coverage with small, independently-failing
   cases.
-- The **WAC** conformance harness (`sq-3jtd.8`) is **still open** — this defines the in-crate
-  harness pattern (the same `AcrBuilder`/`AcpScenario` shape transfers to WAC) rather than
-  mirroring an existing WAC one.
+- The **WAC** conformance harness (`sq-3jtd.8`, `sparq_solid::wac_conformance`) mirrors this
+  one — the same harness shape with a WAC `.acl` corpus builder; see its section below. The
+  two share the `conformance::{Decision, Expect, ScenarioReport}` vocabulary.
 
 Public surface (`pub mod conformance`, re-exported from the crate root for the entry types):
 
@@ -246,6 +246,43 @@ Public surface (`pub mod conformance`, re-exported from the crate root for the e
   `DecisionResult`s), `.name()`, and a readable mismatch `Display`. `Decision::{Allow, Deny}`
   is the binary the harness compares against the engine verdict (graph in the session's
   accessible set ⇒ `Allow`).
+
+## WAC conformance harness — [OPUS-4.8] sq-3jtd.8
+
+`sparq_solid::wac_conformance` is the **WAC sibling** of the ACP harness above: the same
+table-driven scenario runner, but over this crate's **WAC** engine (`materialize_wac` +
+`AuthIndex::accessible`) against the [Solid WAC spec](https://solidproject.org/TR/wac)
+semantics. A scenario is an `.acl`-document corpus (`AclBuilder`) plus a table of expected
+`(agent, client, mode, resource) → Allow | Deny` decisions; the harness asserts the engine
+reproduces every one, reporting all mismatches at once. Always compiled (no feature gate).
+The corpus lives in `crates/sparq-solid/tests/conformance_wac.rs` (12 scenarios / 40+
+decisions, a `run_via_podstore` parity test over the full `PodStore` method-form path, and a
+negative control). The honest-scope caveats are **identical** to the ACP harness's (library
+decision parity, NOT a normative-CTH pass; CTH-over-HTTP out-of-scope; CSS differential oracle
+research-open).
+
+Public surface (`pub mod wac_conformance`, re-exported from the crate root for the entry types;
+the decision/expectation/report types are the **shared** `conformance::{Decision, Expect,
+ScenarioReport}`):
+
+- `AclBuilder` — build the `.acl` corpus as N-Quads. `acl.access_to(resource, |a| …)` /
+  `acl.default_for(resource, |a| …)` / `acl.access_to_and_default(resource, |a| …)` attach an
+  `acl:Authorization` (`acl:accessTo` on the resource's own ACL / `acl:default` for
+  **nearest-ancestor** inheritance over members / both); `acl.document(resource)` declares the
+  protected resource graph + inheritance anchor; `acl.into_nquads()` emits the corpus.
+- `AuthBuilder<'a>` (the `|a| …` closure argument) — `mode(Mode)`, `agent(webid)`,
+  `public()` / `authenticated()` / `agent_class(class)` (`acl:agentClass foaf:Agent` /
+  `acl:AuthenticatedAgent`), `agent_group(group, &[members])` (emits the `vcard:hasMember`
+  group document), `origin(client)` (the `acl:origin` (user, app) pair). `PUBLIC_AGENT`
+  (`foaf:Agent`) / `AUTHENTICATED_AGENT` consts name the two recognised classes.
+- `WacScenario` — `new(name)`, `.acl(AclBuilder)` / `.nquads(&str)`, `.expect(Expect)` /
+  `.expect_all(iter)`, `.run() -> Result<ScenarioReport, String>` (materializes via the free
+  `AuthIndex` path + checks), and `.run_via_podstore()` (the same check through the full
+  `PodStore` method form — proves the path a PSS integration uses). `run_corpus(&[WacScenario])`
+  runs a whole corpus.
+- The `Expect` builder, `Decision`, and `ScenarioReport` are the same shared types as the ACP
+  harness — `Expect::agent(webid)` / `Expect::anonymous()` / `Expect::pair(agent, client)`,
+  `.read/.write/.append/.control(resource)`, `.is(Decision::Allow | Deny)`.
 
 ## Security posture — fail-closed
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change by an agent run by @jeswr. Implements bead **sq-3jtd.8**.

## What

A library-level **WAC conformance harness** (`sparq_solid::wac_conformance`) — the WAC sibling of the ACP harness (sq-3jtd.9, #420). A scenario is declared as **data**: an `.acl`-document corpus (`AclBuilder`) plus a table of expected `(agent, client, mode, resource) → Allow | Deny` decisions, and the harness asserts this crate's WAC engine (`materialize_wac` + `AuthIndex::accessible`) reproduces every one, reporting all mismatches at once. `research/sparq-solid-scope.md` §4 area 4.

## Files

- **`src/wac_conformance.rs`** — `AclBuilder` / `AuthBuilder` (`acl:Authorization` with `acl:accessTo` / `acl:default` / both; `acl:agent` / `acl:agentClass foaf:Agent` (public) / `acl:AuthenticatedAgent` / `acl:agentGroup`+`vcard:hasMember` / `acl:origin`; `acl:mode`), `WacScenario` + a `run_via_podstore` twin (the full `PodStore` method-form path a PSS integration uses), `run_corpus`. Always compiled (no feature gate).
- **Shared vocabulary** — the decision/expectation/report types stay in `conformance::{Decision, Expect, ScenarioReport}`; this PR adds `req_*` accessors on `Expect` and a `ScenarioReport::build(name, expects, FnMut "granted?" oracle)` core that **both** harnesses route through. `AcpScenario::run` is refactored onto it with **no behaviour change** (its 12-scenario corpus still passes). The two harnesses differ only in which auth view the oracle consults.
- **`tests/conformance_wac.rs`** — a 12-scenario / 40+-decision corpus + a `PodStore`-parity test + a negative control (the harness *reports* a wrong expectation, never panics). Covers `acl:agent` on the own ACL (`accessTo`), `foaf:Agent`/`AuthenticatedAgent`, `agentGroup`, `acl:default`-vs-`accessTo`, **nearest-ACL shadowing** (the key WAC difference from ACP's cumulative inheritance), resource-specific override, the `acl:origin` (user, app) pair, mode independence, `acl:Control` gating the `.acl` document, fail-closed no-ACL, multi-agent union.
- **Docs** — `README.md` + `skills/access-control/SKILL.md` (G2 public-api→SKILL.md gate) document the harness with the same honest scope as ACP; `research/sparq-solid-scope.md` §4 marks sq-3jtd.8 done.

## Scope (honest — no overclaim)

This is the **realistic, achievable** signal for an authorization *oracle*: library-level **decision parity** against the [Solid WAC spec](https://solidproject.org/TR/wac) semantics. It is **NOT a normative-CTH pass** and makes no such claim. CTH-over-HTTP is **out-of-scope** (this crate has no HTTP surface; the CTH asserts on HTTP outputs that are PSS's by design). A JS-reference differential oracle (CSS) is the credible second oracle but is **research-open** (JS-toolchain cost) and captured as a follow-up — the table-driven corpus is its natural input.

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + tests (incl doctests): **PASS in BOTH feature states** (default and `odrl-bridge`).
- `rustdoc -D warnings`: clean. Privacy-claims gate: clean. SKILL frontmatter: valid. G2 public-api→SKILL.md: satisfied (SKILL.md updated in the same change).
- Staged explicit paths only (no `-A`, no `.beads`). Pre-existing fmt drift in `examples/bench.rs` + `authindex.rs` is untouched (not in scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)