### PR TITLE
docs(paper-factory): as-built correction banner on design record (sq-3df4) [OPUS-4.8]

### DIFF
--- a/research/paper-factory-design.md
+++ b/research/paper-factory-design.md
@@ -9,6 +9,33 @@
 > buildable phase-3 design. It is **DOC-ONLY**: no site/crate code is written here. The
 > build comes after maintainer review; the phased plan in §7 enumerates each future bead.
 
+**[OPUS-4.8] AS-BUILT CORRECTION (sq-3df4).** The factory was built in PR #336; the
+as-built knowledge is in `skills/academic-paper/SKILL.md` (corrected to as-built in PR #349).
+**Two design-time commitments below were superseded — read the as-built sources, not the
+original text, for current behaviour. The original wording is preserved below as the
+historical design record:**
+
+1. **In-site HTML render = Typst NATIVE HTML export, NOT typst.ts.** The §1 / §2 / §3 /
+   §7 / §8 text below proposes rendering the `.typ` in the browser via
+   **typst.ts / `@myriaddreamin/typst.react`**. The factory instead uses **Typst's native
+   HTML export** (`typst compile --format html --features html`):
+   `site/scripts/build-papers.mjs` extracts the `<body>` fragment and
+   `site/src/components/papers/paper-html.tsx` injects it as a static, scoped `.paper-prose`
+   fragment — **no WASM compiler is shipped to the browser**. Trade-off (as-built):
+   layout-only constructs (centring, page/horizontal rules) drop in the HTML view but are
+   preserved in the PDF. The §7-(b) plan to add `@myriaddreamin/typst.react` + the typst.ts
+   wasm to `site/` was **NOT taken**.
+2. **Paper-bound numbers come from a dedicated `site/src/data/paper-evidence.json`, NOT
+   from `benchmarks.generated.json`.** The Stage-2 / §2 / §5 text below binds paper numbers
+   to `benchmarks.generated.json` (the per-commit work-box timing feed, all
+   `environment: indicative`). The factory instead reads a **separate, canonical-only**
+   `paper-evidence.json` (deterministic, machine-independent records, each `source`-traced
+   to a named test); `benchmarks.generated.json` feeds the site's benchmark widgets and
+   **never** a paper headline. The honesty gate is two-layer as-built:
+   `build-papers.mjs::runHonestyGate()` schema-checks `paper-evidence.json` first, then
+   `headline()` in `site/papers/_lib/bench.typ` panics the Typst compile on any
+   non-canonical record.
+
 **The two load-bearing constraints inherited from the research (never softened):**
 
 1. **No ZK/MPC security property may be claimed as proven.** The single-prover ZK verifier


### PR DESCRIPTION
> 🤖 **SPARQ agent** — bead **sq-3df4** (docs, P3): _"Paper factory: update skills/academic-paper/SKILL.md Stages 2/4 to as-built (native HTML export not typst.ts; paper-evidence.json canonical path distinct from all-indicative benchmarks.generated.json)."_

## Honest scope finding

The bead's **named deliverable** — bringing `skills/academic-paper/SKILL.md` Stages 2/4 to as-built — was **already completed by PR #349** (`91e7f3e`, merged 2026-06-16, the same day this bead was filed) and is correct on `main` today:

- Stage 4 already reads "In-site HTML — Typst **NATIVE HTML export** (NOT typst.ts)" and documents the `<body>`-fragment / `paper-html.tsx` / no-browser-WASM as-built + the layout-only-drop trade-off.
- Stage 2 already names `site/src/data/paper-evidence.json` as the **canonical-only** paper-evidence path, **distinct** from the all-`indicative` `benchmarks.generated.json`, with the two-layer honesty gate (`runHonestyGate()` schema-check → `headline()` compile panic).

So a SKILL.md edit would be a **no-op**. Shipping one would be dishonest. (Cross-checked against the real as-built sources: `site/scripts/build-papers.mjs`, `site/papers/_lib/bench.typ`, `site/src/components/papers/paper-html.tsx`, `site/src/data/paper-evidence.json` — all match the SKILL.)

## What this PR actually does (the real remaining gap)

The SKILL's own Notes mandate: _"Keep this skill in sync with `research/paper-factory-design.md` if the pipeline changes."_ That **phase-3 design record is the one doc still carrying the two superseded design-time assumptions** the bead is about — throughout §1/§2/§3/§7/§8 it proposes the in-site HTML render via **typst.ts / `@myriaddreamin/typst.react`**, and binds paper numbers to **`benchmarks.generated.json`**.

This PR adds a single **top-of-document AS-BUILT CORRECTION banner** to `research/paper-factory-design.md` recording both supersessions (citing PR #336/#349 and the SKILL), and **preserves the original design text** as the historical design record rather than rewriting history — the standard way to keep a design record honest.

## Deliberately left unchanged (honesty)

- `research/paper-factory-research.md` — a prior-art **option survey**; its typst.ts mentions are framed as "the robust choice today; migrate to native HTML export once it leaves experimental." That's a legitimate historical decision-under-uncertainty record, not a false as-built claim.
- `site/README.md` — already documents the native-HTML as-built correctly ("Typst's native HTML export … chosen over `typst.ts`").

## Gate

DOC-ONLY change to `research/` (excluded from the HARD markdownlint/typos/internal-links scope; in the advisory whole-repo lane + the always-on privacy-claims surface).

- `markdownlint-cli2` (advisory whole-repo config) over the changed file: **0 errors**.
- `scripts/check-privacy-claims.sh` (incl. predicate-form soundness): **OK — no unqualified ZK/MPC privacy/soundness claim** (277 files).
- `scripts/check-no-perf-numbers.py`: no new findings (the 3 reported are pre-existing in unrelated files; none in the changed doc).
- No public API touched → G2 SKILL.md rule N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)