### PR TITLE
bench: OWL sameAs equality micro-suite — closure-size self-gate (sq-msl6, A3+A5) [OPUS-4.8]

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -63,7 +63,7 @@ conventions first, then a per-category map that points at the registry, then a
 | **ingest** | load + dict + external-memory build throughput | `cli-ingest`, `cli-save-build`, `cli-bench-remap`, `hdt-load-bench`, `hdt-stage-split`, `wikidata-8b` |
 | **compression** | index / result-serialization footprint tradeoffs | `cli-probe-compress`, `cli-compare-compress`, `compress-bench` |
 | **scaling** | parallel thread sweep + cross-commit/hardware tracking | `cli-scaling`, `ci-bench`, `ci-bench-ec2`, `hw-bench` |
-| **inference** | N3 / RDFS / OWL closure + incremental maintenance | `inference-eye-comparison`, `inference-owl-bench`, `inference-incremental`, `deep-taxonomy`, `solid-wac-bench` |
+| **inference** | N3 / RDFS / OWL closure + incremental maintenance | `inference-eye-comparison`, `inference-owl-bench`, `inference-incremental`, `deep-taxonomy`, `owl-sameas`, `solid-wac-bench` |
 | **zk** | commitment pipeline, trace seam, circuit gates, prove/verify | `zk-commit-throughput`, `zk-trace-overhead`, `zk-compose-gates`, `zk-compose-prove-verify` |
 | **serve** | concurrent-serving + memory-tiering research spikes | `serve-spikes`, `memtier-spikes` |
 | **conformance** | W3C SPARQL + reasoning suites (correctness, not perf) | `sparql-conformance`, `inference-conformance` |
@@ -183,6 +183,21 @@ Notes on a few that need care:
   `deeptax_d<DEPTH>_{closure_s,query_us,closure_triples}` (trend-only). The dashboard features it
   as a scaling suite (depth axis) with EYE external-reference baselines (cited from
   `bench/inference/eye-comparison.md`; dt100k = n/a, EYE not run).
+- **`owl-sameas` is the OWL `sameAs` equality micro-suite** (the EQUALITY analogue of
+  DeepTaxonomy) — see [`bench/owl-sameas/README.md`](./owl-sameas/README.md). `run.sh` is
+  self-asserting: per tier `N` it builds `K=4` independent `owl:sameAs` equivalence classes of `N`
+  members (a STAR of `N-1` edges) + `M=3` anchor data triples (a NEW pure-Python generator
+  `gen_sameas.py`), materializes the **OWL-RL closure** (`sparq-cli reason … owl`), runs a
+  class-membership `query.rq`, and asserts BOTH the closure triple-count (`= K·N·(N+M)`) AND the
+  query rows (`= K·N`) vs `expected.tsv` — a deterministic, load-robust gate on the `owl:sameAs`
+  union-find rewriting + expand-back path that NO other reasoning suite exercises (LUBM is
+  subClassOf/restriction/Transitive/inverseOf; DeepTaxonomy is N3 subclass transitivity). The
+  closure-size assertion is the load-bearing gate: it catches silent UNDER-derivation (a missing
+  `N²` `sameAs` pair) that a correct membership query alone would miss. Needs only `python3` (no
+  g++/javac/Docker), so it runs on the per-commit tier at a SMALL tier pair (N=8+N=32); N=256 is
+  opt-in via `SAMEAS_TIERS` for EC2/nightly. CI emits
+  `sameas_size<N>_{closure_s,query_us,closure_triples}` (trend-only). The dashboard features it as
+  a scaling suite (size axis).
 - **`wikidata-8b` is external-cost and gated.** It builds the full Wikidata
   truthy dump (~8-9.4B triples) on a 16 GB EC2 box (~$5-17). It is **blocked
   until dict-spill merges to public main** — see
@@ -268,6 +283,7 @@ cargo build --release -p sparq-text --example bench_text && bench/fts/run.sh   #
 cargo build --release -p sparq-vectors --example bench_vectors && bench/vector/run.sh   # Vector/ANN (no external tool): synthetic corpus + recall@10-deficit gate (HNSW/Vamana/PQ)
 bench/geo/run.sh                      # GeoSPARQL (cargo only): fixed ~100k point corpus + within/nearest/geof: result-set-size + compliance-pass diff (counts-not-coords)
 bench/deep-taxonomy/run.sh            # DeepTaxonomy (python3 only): N3 closure per depth tier + closure-size + query-row gate
+bench/owl-sameas/run.sh               # OWL sameAs (python3 only): OWL-RL closure per size tier + closure-size (K·N·(N+M)) + query-row (K·N) gate
 
 # --- selective bind-join + u64 value-id probes ---
 python3 bench/selective/gen.py 500000 > bench/selective/selective.nt

--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -228,6 +228,19 @@ records_to  = "stdout (TSV); CI emits deeptax_d<DEPTH>_{closure_s,query_us,closu
 status      = "ok"
 
 [[benchmark]]
+id          = "owl-sameas"
+name        = "OWL sameAs equality micro-suite — equality-reasoning closure correctness"
+category    = "inference"
+measures    = "per tier N (default N=8+N=32 per-commit; N=256 EC2/nightly): OWL-RL closure time (sameas_size<N>_closure_s), a class-membership query over the closure (sameas_size<N>_query_us), and the materialized closure triple-count (sameas_size<N>_closure_triples). run.sh carries a SELF-ASSERTING closure-size gate: closure_triples (= K·N·(N+M), K=4 classes, M=3 data triples) AND query rows (= K·N) are asserted vs expected.tsv (deterministic) so a sparq-reason owl:sameAs regression fails LOUDLY. This is the EQUALITY analogue of deep-taxonomy: it gates the union-find sameAs rewriting + expand-back path that no other reasoning suite touches (LUBM is subClassOf/restriction/Transitive/inverseOf; deep-taxonomy is N3 subclass transitivity)"
+invoke      = "cargo build --release -p sparq-cli && bench/owl-sameas/run.sh   # self-contained: gen_sameas.py builds K owl:sameAs classes of N members per tier, materialize the OWL-RL closure per tier, query.rq over it, assert expected.tsv; CI runs it via scripts/ci-bench.sh -> sameas_size<N>_{closure_s,query_us,closure_triples}. Tiers via SAMEAS_TIERS"
+source      = "bench/owl-sameas/{gen_sameas.py,gen.sh,run.sh,query.rq,expected.tsv,README.md} (gen_sameas.py is a NEW pure-Python deterministic generator, in-repo); scripts/ci-bench.sh (sameas hook); crates/sparq-cli/src/main.rs (cmd_reason owl); crates/sparq-reason/src/owl.rs (owl:sameAs union-find rewriting + expand-back)"
+dataset     = "K=4 independent owl:sameAs equivalence classes, each N individuals (a STAR of N-1 sameAs edges to the class anchor) + M=3 anchor data triples; pure-Python stdlib, NO network/toolchain, byte-deterministic (pure function of K,N,M). Per-commit tiers N=8 + N=32 (OWL-RL closures 352 / 4,480 triples, sub-second total); N=256 (closure 265,216) is opt-in via SAMEAS_TIERS for EC2/nightly. gitignored + regenerable (/tmp/owl-sameas)"
+quiet_box_sensitive = true  # closure_s/query_us wall-clock trend-only, NOT in scripts/perf-gate.py; the closure-triple-count + query-row assertions ARE a hard correctness gate (deterministic, load-robust; catches owl:sameAs reasoner regressions — incl. silent under-derivation a single query misses)
+pinning     = "gen_sameas.py is a deterministic pure function of (K,N,M) (no RNG, byte-identical); expected.tsv pins the closed-form closure sizes (K·N·(N+M)) + query rows (K·N) per tier, each VERIFIED against `sparq-cli reason … owl` (not guessed); metric `n<N>` token is numeric so the dashboard derives the size-scaling axis"
+records_to  = "stdout (TSV); CI emits sameas_size<N>_{closure_s,query_us,closure_triples} into benchmark-data (dev/bench) via scripts/ci-bench.sh; expected sizes in bench/owl-sameas/expected.tsv"
+status      = "ok"
+
+[[benchmark]]
 id          = "selective-bindjoin"
 name        = "Selective (index-nested-loop / bind) join"
 category    = "query"

--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -345,6 +345,9 @@
     { key: 'WatDiv',        title: 'WatDiv',        aliases: ['watdiv'] },
     { key: 'SP2Bench',      title: 'SP2Bench',      aliases: ['sp2bench', 'sp2b'] },
     { key: 'Deep Taxonomy', title: 'Deep Taxonomy', aliases: ['deep taxonomy', 'deeptax', 'deep-taxonomy', 'deeptaxonomy'] },
+    // [OPUS-4.8] sq-msl6: OWL sameAs equality micro-suite (sameas_size<N>_* — the owl:sameAs
+    // closure-correctness analogue of Deep Taxonomy). `sameas` is the metric-name prefix.
+    { key: 'OWL sameAs', title: 'OWL sameAs', aliases: ['owl sameas', 'owl-sameas', 'sameas'] },
     // [OPUS-4.8] sq-7iai: SHACL validation suite (LUBM ABox x 5 hand-authored shape graphs).
     { key: 'SHACL',         title: 'SHACL validation', aliases: ['shacl', 'shacl validation'] },
     // [OPUS-4.8] sq-ustq: Full-text-search suite (synthetic BM25 corpus; text:matches/phrase/near).
@@ -499,8 +502,10 @@
       // likely hook prefixes so they share the Reasoning section if/when they start emitting.
       // NB: `rdfs_infer_s` stays in Core — its label-map suite is "Pipeline" (suiteFor wins over the
       // prefix pass), and we deliberately do NOT claim the bare `rdfs` token here to avoid ambiguity.
-      suites: ['deep taxonomy', 'deeptax', 'deep-taxonomy', 'deeptaxonomy', 'reasoning', 'inference'],
-      prefixes: ['deeptax', 'deep', 'owl', 'infer', 'incremental', 'reason'] },
+      // [OPUS-4.8] sq-msl6: the OWL sameAs equality micro-suite (sameas_size<N>_*) is part of the
+      // reasoning estate — recognise its `sameas` hook prefix so it shares the Reasoning section.
+      suites: ['deep taxonomy', 'deeptax', 'deep-taxonomy', 'deeptaxonomy', 'owl sameas', 'reasoning', 'inference'],
+      prefixes: ['deeptax', 'deep', 'owl', 'sameas', 'infer', 'incremental', 'reason'] },
     // ---- newly-promoted capability families (sq-ncvq.15 / drift-scan §5.D) ------------------------
     // [OPUS-4.8] ZK is the HEADLINE gap: the whole commitment + trace + circuit estate (the zk,
     // zk-trace and zk-compose benchmark suites) had no dashboard presence at all. Prefixes cover the

--- a/bench/owl-sameas/README.md
+++ b/bench/owl-sameas/README.md
@@ -1,0 +1,87 @@
+<!-- [OPUS-4.8] Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns). -->
+# OWL `sameAs` equality micro-suite — equality-reasoning closure correctness
+
+A zero-download, fully-deterministic micro-benchmark that gates the OWL-RL **equality**
+(`owl:sameAs`) machinery of `sparq-reason`. It is the equality analogue of
+[Deep Taxonomy](../deep-taxonomy/README.md) (subclass/transitivity): a structurally-trivial corpus
+whose OWL-RL closure size is a **closed form**, so a single deterministic assertion catches any
+under- or over-derivation in the `sameAs` path. Registry entry: `owl-sameas` in
+[`bench/benchmarks.toml`](../benchmarks.toml).
+
+> **Why a new suite (not a query bolt-on).** No existing reasoning suite exercises `owl:sameAs`
+> equality closure: LUBM's entailed tier is subClassOf / restriction / `TransitiveProperty` /
+> `inverseOf`; Deep Taxonomy is N3 subclass transitivity. `sparq-reason` materialises `sameAs` by
+> **union-find entity rewriting** then expands each class back to the full closure
+> ([`crates/sparq-reason/src/owl.rs`](../../crates/sparq-reason/src/owl.rs)) — a distinct code path
+> with its own regression surface. This suite is its deterministic gate.
+
+## The workload (per tier `N`)
+
+`gen_sameas.py K N M` emits, in N-Triples, **K independent equivalence classes**, each of **N**
+individuals declared equal via a **star** of `N-1` `owl:sameAs` edges to the class anchor, plus
+**M** "data" triples on the anchor only:
+
+```turtle
+# class c (one of K):
+:c{c}_e0 owl:sameAs :c{c}_e1 .   …   :c{c}_e0 owl:sameAs :c{c}_e{N-1} .   # N-1 star edges
+:c{c}_e0 :p0 :v0 .   :c{c}_e1 …            # … M anchor data triples (:p0..:p{M-1})
+```
+
+`gen.sh` fixes `K=4` and `M=3` so a single numeric tier knob (`N`, the per-class size) drives the
+dashboard scaling axis. The star (not a clique) keeps the **input linear in N** while the
+**closure is quadratic in N** — exactly the gap a closure-size gate must defend.
+
+## Closed-form closure size (the gate)
+
+After `sparq-cli reason <corpus> ntriples owl`, the materialised closure is **fully determined** by
+`(K, N, M)` (these are the engine's actual emitted sizes, verified — not assumed):
+
+| quantity | value | why |
+|---|---|---|
+| `closure_triples` | `K·N·(N+M)` | `K·N²` full `sameAs` relation (all ordered pairs **incl. reflexive**) + `K·N·M` eq-rep expansion of each anchor data triple onto every member |
+| `query_rows` (`query.rq`) | `K·N` | every member inherits the anchor's `:p0 :v0` via `sameAs`; raw corpus returns only `K` |
+
+The committed tiers ([`expected.tsv`](./expected.tsv)):
+
+| `N` | `closure_triples` | `query_rows` | tier |
+|----:|------------------:|-------------:|------|
+| 8   | 352               | 32           | per-commit |
+| 32  | 4 480             | 128          | per-commit |
+| 256 | 265 216           | 1 024        | EC2 / nightly (`SAMEAS_TIERS=256`) |
+
+`run.sh` asserts **both** columns; any mismatch is a `sparq-reason` `owl:sameAs` regression and
+fails the run loudly. A correct membership query alone does **not** prove the full `N²` `sameAs`
+relation was materialised — the `closure_triples` assertion is the load-bearing gate (design A5:
+`closure_triples` is the single most valuable reasoner gate, catching silent under-derivation that
+no query touches).
+
+## Layout
+
+```text
+bench/owl-sameas/
+├── gen_sameas.py   pure-Python (stdlib) deterministic generator: K classes × N members × M data
+├── gen.sh          thin cache-backed wrapper around gen_sameas.py; emits an N-Triples corpus per tier
+├── run.sh          self-asserting runner: materialise the OWL-RL closure per tier, query it, assert expected.tsv
+├── query.rq        class-membership probe: SELECT ?x WHERE { ?x :p0 :v0 }  (returns K·N rows)
+└── expected.tsv    DETERMINISTIC per-tier closure_triples (= K·N·(N+M)) + query_rows (= K·N)
+```
+
+## Running
+
+```sh
+cargo build --release -p sparq-cli
+bench/owl-sameas/run.sh                 # per-commit tiers N=8, N=32
+SAMEAS_TIERS="256" bench/owl-sameas/run.sh   # EC2/nightly tier
+```
+
+Honoured env knobs: `SAMEAS_TIERS` (space-separated per-class sizes), `CLI` (sparq-cli path),
+`ITERS` (query bench iterations), `SAMEAS_CACHE` (corpus cache dir, default `/tmp/owl-sameas`,
+gitignored + regenerable per [`bench/CATALOG.md`](../CATALOG.md) disk discipline).
+
+## Hermeticity
+
+No network, no heavyweight toolchain — `python3` only (already required by the bench harness) plus
+the built `sparq-cli`. So, like Deep Taxonomy and unlike LUBM (javac/rapper), this suite runs on the
+**per-commit** tier by default (the `sameas` hook in [`scripts/ci-bench.sh`](../../scripts/ci-bench.sh)).
+The generator is a pure function of `(K, N, M)` — byte-identical every run — so the corpus, and thus
+the closed-form closure size, is reproducible per-commit.

--- a/bench/owl-sameas/expected.tsv
+++ b/bench/owl-sameas/expected.tsv
@@ -1,0 +1,13 @@
+# [OPUS-4.8] OWL sameAs equality micro-suite DETERMINISTIC expected sizes per tier (sq-msl6, A3).
+# run.sh asserts BOTH columns; any mismatch is a sparq-reason owl:sameAs regression and fails the
+# run loudly. These are STRUCTURAL facts of the OWL-RL closure (with K=4 classes, M=3 data triples
+# per class, fixed in gen.sh), NOT perf measurements:
+#   closure_triples = K*N*(N+M) = 4*N*(N+3)   (N^2 full sameAs relation incl. reflexive + N*M eq-rep)
+#   query_rows      = K*N       = 4*N         (every class member inherits the anchor's :p0 :v0)
+# Each value was VERIFIED against `sparq-cli reason … owl` on the pinned generator, not assumed
+# (the engine does union-find sameAs rewriting then expands each class back — owl.rs). The query
+# returns only K=4 on the RAW corpus; the entailment delta to K*N is the point of the suite.
+# Columns: tier(N)<TAB>closure_triples<TAB>query_rows
+8	352	32
+32	4480	128
+256	265216	1024

--- a/bench/owl-sameas/gen.sh
+++ b/bench/owl-sameas/gen.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] OWL sameAs equality micro-suite corpus generator (sq-msl6, design A3). A thin,
+# DETERMINISTIC, cache-backed wrapper around bench/owl-sameas/gen_sameas.py — mirroring
+# bench/deep-taxonomy/gen.sh + bench/lubm/gen.sh as a first-class bench/<suite>/gen.sh entry point.
+#
+#   bench/owl-sameas/gen.sh [tier=8] [out=/tmp/owl-sameas/sameas-<tier>.nt]
+#
+# A TIER is the per-class size N; the suite fixes the class count K and the data-triples-per-class M
+# (see TIER_K / TIER_M below) so a single numeric tier knob drives the dashboard scaling axis. Emits
+# ONE path on stdout: the generated N-Triples corpus for the requested tier:
+#   K independent owl:sameAs equivalence classes, each N individuals (a STAR of N-1 sameAs edges to
+#   the class anchor) + M data triples on the anchor. See gen_sameas.py for the exact shape.
+#
+# run.sh consumes it: materialise the OWL-RL closure with `sparq-cli reason <f> ntriples owl`, run
+# query.rq over the closure, and ASSERT both the closure triple-count (K*N*(N+M)) and the query
+# row-count (K*N) against expected.tsv (deterministic — see run.sh + README.md).
+#
+# HERMETICITY / CI NOTES (identical posture to bench/deep-taxonomy/gen.sh):
+#  - Network: NONE. gen_sameas.py is in-repo pure Python (stdlib only); nothing is fetched.
+#  - Toolchain: python3 ONLY (already required by the bench harness). NO javac/rapper/java guard,
+#    so unlike lubm this suite runs on the per-commit tier by default (scripts/ci-bench.sh sameas hook).
+#  - Output is FULLY DETERMINISTIC (pure function of K,N,M — no RNG, byte-identical every run), so the
+#    corpus — and thus the closed-form closure size — is reproducible per-commit.
+#  - Output cached under $SAMEAS_CACHE (default /tmp/owl-sameas), gitignored + regenerable
+#    (bench/CATALOG.md disk discipline). Caller cleans up.
+#
+# Output is N-Triples; load into sparq with format `ntriples`.
+set -euo pipefail
+
+TIER="${1:-8}"          # per-class size N
+TIER_K=4                # equivalence classes (fixed across tiers)
+TIER_M=3                # data triples per class (fixed across tiers)
+CACHE="${SAMEAS_CACHE:-/tmp/owl-sameas}"
+OUT="${2:-$CACHE/sameas-${TIER}.nt}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GEN="$ROOT/bench/owl-sameas/gen_sameas.py"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[sameas] ERROR: 'python3' not found (needed to run gen_sameas.py)." >&2
+  exit 1
+fi
+if [ ! -f "$GEN" ]; then
+  echo "[sameas] ERROR: generator missing at $GEN" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUT")"
+# Deterministic: same bytes every run for a given (K,N,M). Regenerate only if absent so the cache
+# (like lubm/deep-taxonomy) makes steady-state per-commit runs skip the (cheap) generation step too.
+if [ ! -s "$OUT" ]; then
+  python3 "$GEN" "$TIER_K" "$TIER" "$TIER_M" > "$OUT.tmp"
+  mv "$OUT.tmp" "$OUT"
+fi
+
+echo "$OUT"

--- a/bench/owl-sameas/gen_sameas.py
+++ b/bench/owl-sameas/gen_sameas.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] OWL sameAs equality micro-suite generator (sq-msl6, design A3). Emits, in N-Triples,
+# K INDEPENDENT owl:sameAs equivalence classes, each of N individuals declared equal via a STAR of
+# (N-1) sameAs assertions to the class anchor, plus M shared "data" triples asserted ONLY on the
+# anchor (anchor :p<j> :v<j>). It is a pure function of (K, N, M) — no RNG, byte-identical every
+# run — so the OWL-RL closure size it induces is a CLOSED FORM (see below), making this a
+# zero-download, deterministic hard gate on the reasoner's owl:sameAs equality handling.
+#
+#   python3 gen_sameas.py [K=4] [N=8] [M=3] > sameas.nt
+#
+# CLOSED-FORM CLOSURE SIZE after `sparq-cli reason <f> ntriples owl` (VERIFIED empirically against
+# the engine, not assumed — sparq-reason materialises owl:sameAs by union-find entity rewriting and
+# then EXPANDS each class back to the full closure; crates/sparq-reason/src/owl.rs):
+#   closure_triples = K * N * (N + M)
+#     - sameAs relation per class: the FULL N*N ordered pairs INCLUDING the reflexive pairs
+#       (the engine emits eq-ref restricted to the terms equality touches) -> K * N^2.
+#     - each of the M anchor data triples (anchor :p<j> :v<j>) re-emits for every class member
+#       (eq-rep on the subject; :p<j>/:v<j> are singletons) -> K * N * M.
+#   Total = K*N^2 + K*N*M = K * N * (N + M).
+#
+# The class-membership probe `SELECT ?x WHERE { ?x :p0 :v0 }` (query.rq) returns one row per member
+# of every class, i.e. K * N rows — every member inherits the anchor's data triple via sameAs, the
+# whole point of the suite (returns 0 on the raw data; only correct after reasoning).
+#
+# WHY a STAR (not a clique) of sameAs edges: N-1 edges suffice to merge a class of N (union-find is
+# transitive+symmetric), keeping the INPUT linear in N while the CLOSURE is quadratic in N — the
+# under-derivation a single-query gate would miss is exactly the missing N^2 sameAs pairs, which the
+# closure_triples gate catches deterministically (design A5: closure_triples is the most valuable
+# reasoner gate). Data values :v<j> are shared across classes but are objects (singletons in the
+# eq-rep expansion), so they add no cross-class terms — the closed form is exact.
+import sys
+
+K = int(sys.argv[1]) if len(sys.argv) > 1 else 4
+N = int(sys.argv[2]) if len(sys.argv) > 2 else 8
+M = int(sys.argv[3]) if len(sys.argv) > 3 else 3
+SAME_AS = "http://www.w3.org/2002/07/owl#sameAs"
+
+for c in range(K):
+    anchor = f"http://ex/c{c}_e0"
+    # (N-1) star edges: anchor sameAs every other member of the class.
+    for e in range(1, N):
+        print(f"<{anchor}> <{SAME_AS}> <http://ex/c{c}_e{e}> .")
+    # M shared data triples on the anchor only (inherited by all members via sameAs).
+    for p in range(M):
+        print(f"<{anchor}> <http://ex/p{p}> <http://ex/v{p}> .")

--- a/bench/owl-sameas/query.rq
+++ b/bench/owl-sameas/query.rq
@@ -1,0 +1,6 @@
+# [OPUS-4.8] OWL sameAs equality micro-suite class-membership probe (sq-msl6, design A3).
+# Returns one row per member of EVERY equivalence class — each member inherits the anchor's
+# (:p0 :v0) data triple via owl:sameAs entity rewriting (eq-rep). On the RAW corpus only the K
+# anchors carry :p0, so this returns K; only after the OWL-RL closure does it return K*N (every
+# member). expected.tsv pins K*N per tier. The :p0/:v0 IRIs match gen_sameas.py's first data triple.
+SELECT ?x WHERE { ?x <http://ex/p0> <http://ex/v0> }

--- a/bench/owl-sameas/run.sh
+++ b/bench/owl-sameas/run.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] OWL sameAs equality micro-suite per-commit runner (sq-msl6, design A3 + A5) — a
+# self-contained, self-asserting entry point CI calls (mirrors bench/deep-taxonomy/run.sh and
+# bench/lubm/run.sh). For EACH requested TIER (per-class size N) it:
+#   1. ensures the corpus exists (gen.sh -> gen_sameas.py): K owl:sameAs classes of N members + M
+#      anchor data triples (K=4, M=3 fixed in gen.sh).
+#   2. materialises the OWL-RL closure with `sparq-cli reason <f> ntriples owl <out.nt>` (sparq-reason
+#      owl:sameAs union-find rewriting + expand-back) and records the closure time + closure triple-count.
+#   3. runs query.rq over the closure (count mode, $ITERS iters) and records the query latency.
+#   4. ASSERTS the closure triple-count AND the query row-count against expected.tsv (exit 1 on any
+#      mismatch — a sparq-reason owl:sameAs correctness regression fails the run LOUDLY).
+#
+# The self-asserting closure-size gate is the POINT of the suite (design A5: closure_triples is the
+# single most valuable reasoner gate — it catches silent UNDER-DERIVATION the query alone misses).
+# A correct membership query (K*N rows) does NOT prove the full N^2 sameAs relation was materialised;
+# the closure_triples = K*N*(N+M) assertion does. The closed form is exact + verified — see
+# expected.tsv + README.md.
+#
+# Usage: bench/owl-sameas/run.sh   (run from anywhere; honours these env knobs)
+#   SAMEAS_TIERS="8 32"   space-separated per-class-size tiers (default: the per-commit pair)
+#   CLI=<path>            sparq-cli binary (default: target/release/sparq-cli)
+#   ITERS=<n>             query bench iterations (default 3)
+# stdout: one TSV line per metric:  <metric_name>\t<value>\t<unit>  — harvested by the
+#         scripts/ci-bench.sh sameas hook into github-action-benchmark JSON. Metric names:
+#   sameas_size<TIER>_closure_s        OWL-RL closure wall seconds (engine-internal "in Xs")
+#   sameas_size<TIER>_query_us         query.rq min-of-ITERS latency (µs), count mode
+#   sameas_size<TIER>_closure_triples  materialised closure triple-count (DETERMINISTIC structural)
+# The `size<TIER>` token is the dashboard's existing `_size<digits>` size axis (sizeAxisOf), so the
+# scaling chart works with NO dashboard.js change; the `sameas` prefix routes it to the featured
+# "OWL sameAs" suite (featuredSuiteOf). See README.md.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+CLI="${CLI:-$ROOT/target/release/sparq-cli}"
+ITERS="${ITERS:-3}"
+GEN="$ROOT/bench/owl-sameas/gen.sh"
+QUERY="$ROOT/bench/owl-sameas/query.rq"
+EXP="$ROOT/bench/owl-sameas/expected.tsv"
+CACHE="${SAMEAS_CACHE:-/tmp/owl-sameas}"
+# Default per-commit tiers: N=8 + N=32 (cheap — closures 352 / 4,480 triples, sub-second total).
+# N=256 (closure 265,216) is available via SAMEAS_TIERS for the EC2/nightly tier.
+TIERS="${SAMEAS_TIERS:-8 32}"
+
+if [ ! -x "$CLI" ]; then
+  echo "[sameas] ERROR: sparq-cli not found at $CLI (build: cargo build --release -p sparq-cli)" >&2
+  exit 1
+fi
+
+# query.rq lives in a file but `sparq-cli bench` takes a queries DIRECTORY; stage a dir with just
+# the probe query so the bench runner's TSV reports it under a stable `q` name.
+QDIR="$CACHE/qdir"
+mkdir -p "$QDIR"
+cp "$QUERY" "$QDIR/q_membership.rq"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+expected_for() {  # $1 = tier, $2 = column index (2=closure_triples, 3=query_rows)
+  awk -F'\t' -v t="$1" -v c="$2" '$1==t{print $c}' "$EXP"
+}
+
+for TIER in $TIERS; do
+  echo "[sameas] === tier N=$TIER ===" >&2
+  # ---- 1. ensure corpus -----------------------------------------------------------------
+  CORPUS="$("$GEN" "$TIER")"
+  CLOSURE="$CACHE/sameas-${TIER}-closure.nt"
+
+  # ---- 2. materialise the OWL-RL closure; capture engine time + triple-count ------------
+  # `reason <f> ntriples owl <out.nt>`: stdout carries `<N> triples after owl reasoning` (the
+  # deduplicated closure size); stderr carries the engine-internal `... in <X>s` timer (robust to
+  # machine load). We read the triple-count from stdout and the closure seconds from the stderr timer.
+  "$CLI" reason "$CORPUS" ntriples owl "$CLOSURE" >"$TMP/r.out" 2>"$TMP/r.err"
+  triples="$(grep -oE '[0-9]+ triples after owl reasoning' "$TMP/r.out" | grep -oE '^[0-9]+' | head -1)"
+  closure_s="$(grep -oE 'in [0-9.]+s' "$TMP/r.err" | head -1 | grep -oE '[0-9.]+' | head -1)"
+
+  # ---- 3. run query.rq over the closure (count mode, min-of-ITERS) ----------------------
+  "$CLI" bench "$CLOSURE" ntriples "$QDIR" "$ITERS" count 2>/dev/null > "$TMP/q.tsv" || true
+  IFS=$'\t' read -r _qname qrows qus < "$TMP/q.tsv"
+
+  # ---- emit metric TSV lines (harvested by the ci-bench sameas hook) --------------------
+  [ -n "${closure_s:-}" ] && printf 'sameas_size%s_closure_s\t%s\ts\n'            "$TIER" "$closure_s"
+  [ -n "${qus:-}" ]       && printf 'sameas_size%s_query_us\t%s\tus\n'            "$TIER" "$qus"
+  [ -n "${triples:-}" ]   && printf 'sameas_size%s_closure_triples\t%s\ttriples\n' "$TIER" "$triples"
+
+  # ---- 4. SELF-ASSERTING closure-size + query-row gate (deterministic) ------------------
+  exp_tri="$(expected_for "$TIER" 2)"
+  exp_rows="$(expected_for "$TIER" 3)"
+  if [ -z "$exp_tri" ] || [ -z "$exp_rows" ]; then
+    echo "[sameas] ERROR: tier N=$TIER has no expected.tsv entry (add closure_triples + query_rows)" >&2
+    fail=1; continue
+  fi
+  if [ "${triples:-MISSING}" != "$exp_tri" ]; then
+    echo "[sameas] ERROR: tier N=$TIER closure=${triples:-MISSING} expected=$exp_tri (owl:sameAs regression)" >&2
+    fail=1
+  fi
+  if [ "${qrows:-MISSING}" != "$exp_rows" ]; then
+    echo "[sameas] ERROR: tier N=$TIER query rows=${qrows:-MISSING} expected=$exp_rows (owl:sameAs regression)" >&2
+    fail=1
+  fi
+done
+
+if [ "$fail" = 0 ]; then
+  echo "[sameas] OK: all closure sizes + query rows match expected.tsv ($TIERS)" >&2
+else
+  echo "[sameas] FAILED: closure size or query rows diverged from expected.tsv" >&2
+fi
+exit "$fail"

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -94,6 +94,17 @@ LUBM_RUN=bench/lubm/run.sh
 # (deep-taxonomy); details: bench/deep-taxonomy/README.md. (sq-1hgz)
 DEEPTAX_RUN=bench/deep-taxonomy/run.sh
 DEEPTAX_DEPTHS="${DEEPTAX_DEPTHS:-1000 10000}"
+# [OPUS-4.8] OWL sameAs equality micro-suite (sq-msl6, design A3 + A5) — the EQUALITY reasoning
+# suite (the owl:sameAs analogue of Deep Taxonomy's subclass transitivity). Like LUBM/deep-taxonomy
+# its run.sh is the self-asserting entry point: it builds K owl:sameAs classes of N members per tier
+# (bench/owl-sameas/gen_sameas.py via bench/owl-sameas/gen.sh — pure Python, NO javac/rapper),
+# materializes the OWL-RL closure with `sparq-cli reason … owl`, runs query.rq over the closure, and
+# asserts BOTH the closure triple-count (K·N·(N+M)) AND the query row-count (K·N) vs expected.tsv
+# internally (exit 1 on any mismatch). The hook below invokes run.sh and harvests its metric TSV into
+# `sameas_size<TIER>_{closure_s,query_us,closure_triples}`. Registry: bench/benchmarks.toml (owl-sameas);
+# details: bench/owl-sameas/README.md. (sq-msl6)
+SAMEAS_RUN=bench/owl-sameas/run.sh
+SAMEAS_TIERS="${SAMEAS_TIERS:-8 32}"
 # [OPUS-4.8] SHACL VALIDATION suite (sq-7iai, design §3.1) — the cleanest competitor surface.
 # Reuses the LUBM(1) ABox as its data substrate (so it shares the javac/rapper guard) x the 5
 # committed shape graphs in bench/shacl/shapes/. Like LUBM, run.sh is the self-asserting entry
@@ -458,6 +469,37 @@ if command -v python3 >/dev/null 2>&1 && [ -x "$DEEPTAX_RUN" ]; then
   fi
 else
   echo "note: deep-taxonomy skipped (python3 not on PATH)" >&2
+fi
+
+# [OPUS-4.8] OWL sameAs equality micro-suite per-commit (sq-msl6, design A3 + A5). Exactly the
+# deep-taxonomy hook shape: run.sh is the self-asserting entry point — it reuses
+# bench/owl-sameas/gen_sameas.py (via gen.sh) to build K owl:sameAs equivalence classes of N members
+# per tier, materializes the OWL-RL closure with `sparq-cli reason … owl`, runs query.rq over the
+# closure, and asserts BOTH the closure triple-count (K·N·(N+M)) AND the query row-count (K·N) vs
+# expected.tsv internally (exit 1 on any mismatch). So we invoke run.sh and harvest its metric TSV
+# (it prints `<metric>\t<value>\t<unit>` lines on stdout) into
+# `sameas_size<TIER>_{closure_s,query_us,closure_triples}` (trend-only, NOT in scripts/perf-gate.py;
+# closure_triples is a deterministic structural metric, never an alert source). Like deep-taxonomy
+# this suite needs NO heavyweight toolchain — only python3 (always present) + the built sparq-cli —
+# so it runs on the per-commit tier by default at a SMALL tier pair (N=8 + N=32; closures 352 / 4,480
+# triples, sub-second total). N=256 is opt-in via SAMEAS_TIERS for the EC2/nightly tier. Guarded on
+# python3 + run.sh present (same shape as the deep-taxonomy guard): if python3 is somehow absent it
+# is skipped gracefully so ci-bench still emits valid JSON. run.sh failing (an owl:sameAs reasoner
+# regression) fails the whole ci-bench run.
+if command -v python3 >/dev/null 2>&1 && [ -x "$SAMEAS_RUN" ]; then
+  if CLI="$CLI" ITERS=3 SAMEAS_TIERS="$SAMEAS_TIERS" bash "$SAMEAS_RUN" > "$TMP/sameas.tsv" 2>"$TMP/sameas.err"; then
+    while IFS=$'\t' read -r name value unit; do
+      [ -n "${name:-}" ] && [ -n "${value:-}" ] && add "$name" "${unit:-}" "$value"
+    done < "$TMP/sameas.tsv"
+  else
+    # run.sh exits non-zero ONLY on a hard correctness mismatch (the python3 guard above ensures
+    # the toolchain is present), so surface its diagnostics and fail the run.
+    echo "ERROR: owl-sameas run.sh failed (closure-size regression or owl:sameAs reasoner error)" >&2
+    cat "$TMP/sameas.err" >&2 || true
+    exit 1
+  fi
+else
+  echo "note: owl-sameas skipped (python3 not on PATH)" >&2
 fi
 
 # [OPUS-4.8] SHACL validation suite per-commit (sq-7iai). Reuses the LUBM(1) ABox, so it shares


### PR DESCRIPTION
> 🤖 SPARQ agent — automated change. @jeswr runs multiple agents on one account; this PR is from the SPARQ agent working bead **sq-msl6** (bench: reasoning suite extensions).

## What

Adds `bench/owl-sameas/`, an **OWL `sameAs` equality micro-suite** — the equality analogue of Deep Taxonomy. It implements the cheapest, fully-deterministic, zero-download wins of bead **sq-msl6**: design **A3** (the owl:sameAs equality micro-suite, closure size a closed form → hard gate) and **A5** (a `<suite>_closure_triples` self-gate — the single most valuable reasoner gate, catching silent under-derivation no query touches).

No existing reasoning suite exercises `owl:sameAs` equality closure: LUBM's entailed tier is subClassOf / restriction / `TransitiveProperty` / `inverseOf`; Deep Taxonomy is N3 subclass transitivity. `sparq-reason` materialises `sameAs` by **union-find entity rewriting** then expands each class back to the full closure (`crates/sparq-reason/src/owl.rs`) — a distinct code path with its own regression surface. This suite is its deterministic per-commit gate.

## The workload + closed form

Per tier `N`: **K=4** independent `owl:sameAs` equivalence classes, each `N` members via a **star** of `N-1` edges, plus **M=3** anchor data triples. The star keeps the **input linear in N** while the **closure is quadratic in N** — exactly the under-derivation a closure-size gate must defend. `run.sh` asserts **both** (every expected value VERIFIED against `sparq-cli reason … owl`, not assumed):

| metric | value | why |
|---|---|---|
| `closure_triples` | `K·N·(N+M)` | `K·N²` full sameAs relation (incl. reflexive) + `K·N·M` eq-rep expansion |
| `query_rows` | `K·N` | every member inherits the anchor's `:p0 :v0` via sameAs (raw corpus returns only `K`) |

Tiers `N=8`/`N=32` per-commit (closures 352 / 4 480, sub-second); `N=256` (closure 265 216) opt-in via `SAMEAS_TIERS` for EC2/nightly.

## Wiring (no Rust change — bench shell/python/docs/JS only)

- **`scripts/ci-bench.sh`** — `sameas` hook (python3-only guard, deep-taxonomy hook shape) → `sameas_size<N>_{closure_s,query_us,closure_triples}` (trend-only; `closure_triples` is a deterministic structural metric, never a perf-gate alert source).
- **`bench/benchmarks.toml`** — `owl-sameas` registry entry.
- **`bench/dashboard/dashboard.js`** — "OWL sameAs" featured suite + `sameas` reasoning-family prefix (metric token `_size<N>` reuses the existing dashboard size axis, so **no `SIZE_TOKENS` change**; node-verified that `reason_n3_t` / `incremental_n3_p` / `zk_compose_*_n64_*` are **not** misrouted).
- **`bench/CATALOG.md`** — inference category + suite description + run command.

## Out of scope for this PR (honest)

The bead is multi-part; this lands the cheap deterministic wins as one focused PR. Deliberately **not** included:
- **A1** LUBM scaled tiers `lubm-8`/`lubm-100` — needs the javac/rapper toolchain to regenerate `expected-rows-univ8/100.tsv` deterministically (not a clean in-worktree hard gate).
- **A2/A6** UOBM + OWL2Bench — the bead marks these "later".
- **reasonable / Jena rules / Nemo / VLog** competitor entries — a separable `bench/competitors.json` registry change (no benchmarking), better as its own PR.

These remain open follow-ups under sq-msl6.

## Gate

`bash -n` + `shellcheck` (clean) on the new scripts; `python -m py_compile`; `benchmarks.toml` parses (60 benches, no dup ids); `dashboard.js` node smoke-test (routing + no-misroute); ci-bench `sameas` hook harvest verified; `markdownlint-advisory` clean (0 errors); `check-no-perf-numbers` clean; **privacy-claims gate passes** (277 files, no unqualified ZK/MPC claim). Suite runs green per-commit + nightly; negative test confirms the gate fails loudly on a tampered expected size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)