### PR TITLE
feat(sparq-server): opt-in HTTP SHACL validate endpoint POST /shacl/validate (sq-r868)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3564,6 +3564,7 @@ dependencies = [
  "sparq-geo",
  "sparq-introspect",
  "sparq-serve",
+ "sparq-shacl",
  "tokio",
  "tokio-tungstenite 0.24.0",
  "tower",

--- a/crates/sparq-server/Cargo.toml
+++ b/crates/sparq-server/Cargo.toml
@@ -147,6 +147,24 @@ tpf = ["server"]
 # parameter is just an ignored unknown parameter — plain TPF). STILL governed by the same
 # `--tpf` runtime flag (brTPF is the same endpoint, extended).
 brtpf = ["tpf"]
+# [OPUS-4.8] (sq-r868, from-pss gh-162 follow-up (c)) `shacl` (default OFF) mounts the
+# OPT-IN HTTP SHACL validation endpoint `POST /shacl/validate`: the client POSTs a SHACL
+# shapes graph (RDF, by `Content-Type`) and the server validates its CURRENTLY-LOADED data
+# graph against it, returning a validation report — a JSON projection of
+# `sparq_shacl::ValidationReport` (the same `{ conforms, results: [{ focusNode, path, value,
+# sourceShape, sourceConstraintComponent, severity, message }] }` shape the wasm `shacl`
+# binding (gh-162 part (a)) and the PSS Pod-Manager consume) by default, or the W3C SHACL
+# report-vocabulary Turtle on `Accept: text/turtle`. This is the server-side / large-graph
+# path from gh-162: the store is already in memory (no per-request data parse), and the
+# 100k-node case where the JS `rdf-validate-shacl` OOMs is handled natively. The feature
+# pulls `sparq-shacl` (which transitively pulls sparq-engine for `sh:sparql`); sparq-shacl
+# follows the opt-in isolation pattern, so a build WITHOUT this feature carries ZERO SHACL
+# code — byte-identical to before, and sparq-core/the wasm bundle are untouched either way
+# (sparq-wasm depends on sparq-core/-engine directly, never on sparq-server). STILL OFF AT
+# RUNTIME by default even when compiled in — the operator must additionally set `--shacl` /
+# `SPARQ_SHACL=1` (`ServerConfig::shacl`), mirroring `tpf` / `federation-descriptors`;
+# validation is a READ over the store, so it is gated by the read auth like any GET.
+shacl = ["server", "dep:sparq-shacl"]
 
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io
@@ -167,6 +185,12 @@ sparq-introspect = { path = "../sparq-introspect", version = "0.1.0", optional =
 # Behind the opt-in `geo` feature only (geof_registry; its own default `engine`
 # feature is this same sparq-engine, so the graph gains just the georust stack).
 sparq-geo = { path = "../sparq-geo", version = "0.1.0", optional = true }
+# [OPUS-4.8] (sq-r868) Behind the opt-in `shacl` feature only: SHACL Core + SHACL-SPARQL
+# validation (`sparq_shacl::validate` → `ValidationReport`) for the `POST /shacl/validate`
+# endpoint. It transitively pulls sparq-engine (already a dependency here) for `sh:sparql`;
+# its OWN `oxrdf` is the same workspace 0.3 the server resolves, so terms flow through. OFF
+# by default — a build without the `shacl` feature carries zero SHACL code.
+sparq-shacl = { path = "../sparq-shacl", version = "0.1.0", optional = true }
 oxrdf.workspace = true
 # [OPUS-4.8] sq-rt6v: prefix-compacting Turtle + RDF/XML graph serialisation, and RDF/XML
 # request-body parsing, for the GSP read/write + CONSTRUCT/DESCRIBE surface. Both crates are

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -410,6 +410,20 @@ matrix under "Security posture".
   super-linear in the count) and `--brtpf-max-values-bytes` (raw `values` payload bytes — the GET
   query-string carrier is not covered by `--max-body-bytes`); a breach is a `413`. See the SKILL's
   "Triple Pattern Fragments" section.
+- **SHACL validation endpoint** — opt-in (`shacl` feature + `--shacl` flag, both off by default;
+  read-only): `POST /shacl/validate` validates the server's **currently-loaded data graph**
+  against a SHACL **shapes** graph the client POSTs (RDF body, classified by `Content-Type`,
+  gzip-decoded under the zip-bomb cap). The response is content-negotiated — a JSON projection of
+  the validation report (`{ conforms, results: [{ focusNode, path, value, sourceShape,
+  sourceConstraintComponent, severity, message }] }`, the shape the PSS Pod-Manager + the wasm
+  `shacl` binding consume) by default, or the W3C SHACL report-vocabulary Turtle on
+  `Accept: text/turtle`. Always `200` regardless of conformance (the verdict is in the body); a
+  malformed shapes body is `400`, an unsupported `Content-Type` `415`. Backed by `sparq-shacl`
+  (SHACL Core + SHACL-SPARQL §5.2 + custom SPARQL constraint components §6) — the server-side /
+  large-graph path of [#162](https://github.com/jeswr/sparq/issues/162): the store is already in
+  memory (no per-request data parse) and the 100k-node case where the JS `rdf-validate-shacl` OOMs
+  is handled natively. A build without the `shacl` feature carries zero SHACL code. See the SKILL's
+  "SHACL validation endpoint" section.
 - **Access-audit trails** — opt-in, off by default: `audit-log` (flat `tracing` event per request)
   and `access-audit` (richer typed JSON-Lines records via a pluggable sink — actor / action /
   resource / decision+basis / timestamp / fingerprint, hooked at the real enforcement seam).
@@ -420,6 +434,7 @@ matrix under "Security posture".
   (VoID + Service Description discovery endpoints — see "Federation discovery"), `tpf` (Triple
   Pattern Fragments / LDF source endpoint — see "Triple Pattern Fragments / LDF source"), `brtpf`
   (implies `tpf`; bind-restricted Triple Pattern Fragments — the `values`/POST bindings extension),
+  `shacl` (the `POST /shacl/validate` SHACL validation endpoint — see "SHACL validation endpoint"),
   `audit-log` / `access-audit` (access-audit trails — see "Access-audit trails"), `zlib-ng`
   (native-only faster zlib-ng C backend for `Content-Encoding: gzip` request inflate; off by
   default, pure-Rust `miniz_oxide` otherwise; never in the wasm build).

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -385,6 +385,20 @@ pub struct ServerConfig {
     /// `SPARQ_BRTPF_MAX_VALUES_BYTES`. Present only with the `brtpf` cargo feature.
     #[cfg(feature = "brtpf")]
     pub brtpf_max_values_bytes: usize,
+    /// [OPUS-4.8] (sq-r868, from-pss gh-162 follow-up (c)) OPT-IN HTTP SHACL validation
+    /// endpoint. When `true`, the server serves `POST /shacl/validate`: the client POSTs a
+    /// SHACL shapes graph (RDF, by `Content-Type`) and the server validates its
+    /// CURRENTLY-LOADED data graph against it, returning a validation report — a JSON
+    /// projection of `sparq_shacl::ValidationReport` (the gh-162 / wasm-binding shape) by
+    /// default, or the W3C report-vocabulary Turtle on `Accept: text/turtle`. `false` (the
+    /// default) leaves it off: `/shacl/validate` is `404`.
+    ///
+    /// This field exists only with the `shacl` cargo feature (like
+    /// [`tpf`](Self::tpf) under `tpf`); a build without that feature compiles no SHACL code
+    /// and pays zero cost. Set by the binary's `--shacl` flag / `SPARQ_SHACL=1` env. Validation
+    /// is a READ over the store, so the endpoint is gated by the read auth like any GET.
+    #[cfg(feature = "shacl")]
+    pub shacl: bool,
 }
 
 impl Default for ServerConfig {
@@ -450,6 +464,11 @@ impl Default for ServerConfig {
             brtpf_max_bindings: 1024,
             #[cfg(feature = "brtpf")]
             brtpf_max_values_bytes: 1024 * 1024,
+            // [OPUS-4.8] sq-r868: safe default — the SHACL validate endpoint is OFF even when
+            // the feature is compiled in (the operator opts in deliberately via --shacl /
+            // SPARQ_SHACL=1).
+            #[cfg(feature = "shacl")]
+            shacl: false,
         }
     }
 }
@@ -602,6 +621,12 @@ impl ServerConfig {
             if let Some(n) = env_parse::<usize>("SPARQ_BRTPF_MAX_VALUES_BYTES") {
                 cfg.brtpf_max_values_bytes = n;
             }
+        }
+        // [OPUS-4.8] sq-r868: SPARQ_SHACL truthy ("1"/"true"/"yes"/"on") serves the SHACL
+        // validate endpoint. Off by default. Only present with the `shacl` feature.
+        #[cfg(feature = "shacl")]
+        if let Ok(v) = std::env::var("SPARQ_SHACL") {
+            cfg.shacl = env_truthy(&v);
         }
         Ok(cfg)
     }
@@ -1776,6 +1801,13 @@ pub fn router(state: AppState) -> Router {
         "/tpf",
         get(tpf_endpoint).head(tpf_endpoint).post(tpf_endpoint),
     );
+    // [OPUS-4.8] sq-r868 (from-pss gh-162 follow-up (c)): OPT-IN HTTP SHACL validate endpoint.
+    // Compiled only with the `shacl` feature; even then the handler refuses (404) unless the
+    // config flag is set. POST only — the client sends a shapes graph and the server validates
+    // its loaded data graph (a READ); axum returns a 405 with `Allow: POST` for other methods.
+    // See [`shacl_validate_endpoint`].
+    #[cfg(feature = "shacl")]
+    let routes = routes.route("/shacl/validate", post(shacl_validate_endpoint));
     let routes = routes.with_state(state.clone());
     // The metrics middleware wraps the WHOLE hardened stack so shed requests
     // (429), body-limit rejections (413) and panics (500) are counted with the
@@ -2197,6 +2229,227 @@ async fn tpf_endpoint(
         GraphFormat::RdfXml => crate::graph::triples_to_rdfxml(&triples),
     };
     text_response(StatusCode::OK, fmt.content_type(), body, head_only)
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-r868 (from-pss gh-162 follow-up (c)) — OPT-IN HTTP SHACL validate endpoint
+// ---------------------------------------------------------------------------
+
+/// [OPUS-4.8] sq-r868: `POST /shacl/validate` — validate the server's currently-loaded data
+/// graph against a SHACL shapes graph the client POSTs.
+///
+/// OPT-IN: returns `404` unless [`ServerConfig::shacl`] is set (the route is mounted only with
+/// the `shacl` feature, and the handler refuses unless the operator also turned the flag on).
+///
+/// **Contract.** The request BODY is the SHACL **shapes** graph (RDF — `text/turtle` /
+/// `application/n-triples` / `application/n-quads` / `application/trig` / `application/rdf+xml`,
+/// classified by `Content-Type` exactly like a GSP write body, and gzip-decoded under the same
+/// zip-bomb cap). The **data** graph is the server's CURRENT in-memory store snapshot (pinned
+/// for the request) — the gh-162 server-side / large-graph path: the store is already loaded, so
+/// there is no per-request data parse, and the 100k-node case where the JS `rdf-validate-shacl`
+/// OOMs is handled natively. Validation is a READ; the endpoint is gated by the read auth.
+///
+/// **Response.** Content-negotiated from `Accept`: `text/turtle` yields the W3C SHACL
+/// report-vocabulary graph ([`sparq_shacl::ValidationReport::to_turtle`]); anything else (the
+/// default) yields the JSON projection PSS / the wasm `shacl` binding consume —
+/// `{ "conforms": bool, "results": [{ "focusNode", "path", "value", "sourceShape",
+/// "sourceConstraintComponent", "severity", "message" }] }`. `200` regardless of conformance —
+/// the verdict is in the body (`conforms`), not the HTTP status; a malformed shapes body is a
+/// `400`, an unsupported `Content-Type` a `415`.
+#[cfg(feature = "shacl")]
+async fn shacl_validate_endpoint(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if !state.config().shacl {
+        return json_error(StatusCode::NOT_FOUND, "not found");
+    }
+    // Validation reads the store; gate it like any other read.
+    if let Some(resp) = auth_gate(state.config(), &headers, Operation::Read) {
+        return resp;
+    }
+    // Decode the (possibly gzip'd) body under the shared decompression-ratio cap.
+    let body = match decode_request_body(&body, &headers, state.config()) {
+        Ok(b) => b,
+        Err(e) => return e.into_response(),
+    };
+    // Parse the shapes graph from the body, classified by Content-Type (same matrix as a GSP
+    // write body). A no/relative base is fine — shapes graphs name shapes by absolute IRI.
+    let shapes = match parse_shapes_graph(&body, &content_type(&headers)) {
+        Ok(g) => g,
+        Err(resp) => return resp,
+    };
+    let turtle =
+        negotiate_shacl_report_turtle(headers.get(header::ACCEPT).and_then(|v| v.to_str().ok()));
+    let gen = state.current();
+    // Validation is CPU-bound (index scans over the whole store + any `sh:sparql`), so run it
+    // on the blocking pool under the same wall-clock cap the query paths use.
+    let task = tokio::task::spawn_blocking(move || {
+        let report = sparq_shacl::validate(gen.snapshot(), &shapes);
+        if turtle {
+            text_response(
+                StatusCode::OK,
+                "text/turtle; charset=utf-8",
+                report.to_turtle(),
+                false,
+            )
+        } else {
+            text_response(
+                StatusCode::OK,
+                "application/json; charset=utf-8",
+                shacl_report_to_json(&report),
+                false,
+            )
+        }
+    });
+    await_worker(task, state.config()).await
+}
+
+/// [OPUS-4.8] sq-r868: parse a SHACL shapes graph from a request body classified by its
+/// `Content-Type` (the same media-type matrix as a GSP write body — see [`rdf_format_for`]).
+/// Returns the caller's `415` for an unsupported type, `400` for malformed RDF. The offending
+/// body fragment the parser would echo is withheld from the client and logged server-side, the
+/// same info-leak posture the rest of the surface uses (sq-cz89/sq-j9zs).
+#[cfg(feature = "shacl")]
+#[allow(clippy::result_large_err)]
+fn parse_shapes_graph(body: &Bytes, content_type: &str) -> Result<Graph, Response> {
+    match rdf_format_for(content_type) {
+        Some(BodyFormat::Core(format)) => {
+            let text = std::str::from_utf8(body)
+                .map_err(|_| bad_request("shapes body is not valid UTF-8"))?;
+            Graph::load_str(text, format).map_err(|e| {
+                sanitized_error(
+                    StatusCode::BAD_REQUEST,
+                    "shacl-shapes-parse",
+                    "malformed RDF shapes body",
+                    &e,
+                )
+            })
+        }
+        Some(BodyFormat::RdfXml) => {
+            let triples = crate::graph::parse_rdfxml(body, None).map_err(|e| {
+                sanitized_error(
+                    StatusCode::BAD_REQUEST,
+                    "shacl-shapes-rdfxml-parse",
+                    "malformed RDF/XML shapes body",
+                    &e,
+                )
+            })?;
+            Ok(sparq_shacl::graph_from_triples(triples))
+        }
+        None => Err(json_error(
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "SHACL shapes body must be RDF: Content-Type 'text/turtle', 'application/n-triples', \
+             'application/n-quads', 'application/trig' or 'application/rdf+xml'",
+        )),
+    }
+}
+
+/// [OPUS-4.8] sq-r868: pick the report serialisation from `Accept`. `text/turtle` (the W3C SHACL
+/// report vocabulary) when explicitly requested at non-zero q; otherwise the JSON projection
+/// (the default — the shape PSS / the wasm `shacl` binding consume). q-value aware: an explicit
+/// `text/turtle;q=0` falls back to JSON.
+#[cfg(feature = "shacl")]
+fn negotiate_shacl_report_turtle(accept: Option<&str>) -> bool {
+    let accept = match accept {
+        Some(a) if !a.trim().is_empty() => a,
+        _ => return false,
+    };
+    // Highest-q wins; JSON is the default when nothing (or a wildcard) is preferred over Turtle.
+    let mut turtle_q = f32::NEG_INFINITY;
+    let mut json_q = 0.0f32; // the default floor — JSON is always acceptable
+    for part in accept.split(',') {
+        let mut it = part.split(';');
+        let media = it.next().unwrap_or("").trim().to_ascii_lowercase();
+        let mut q = 1.0f32;
+        for param in it {
+            if let Some(v) = param.trim().strip_prefix("q=") {
+                q = v.parse().unwrap_or(1.0);
+            }
+        }
+        match media.as_str() {
+            "text/turtle" | "application/x-turtle" => turtle_q = turtle_q.max(q),
+            "application/json" | "application/sparql-results+json" => json_q = json_q.max(q),
+            _ => {}
+        }
+    }
+    turtle_q > 0.0 && turtle_q > json_q
+}
+
+/// [OPUS-4.8] sq-r868: serialise a [`sparq_shacl::ValidationReport`] to the JSON projection the
+/// PSS Pod-Manager + the wasm `shacl` binding consume:
+/// `{ "conforms": bool, "results": [{ focusNode, path, value, sourceShape,
+/// sourceConstraintComponent, severity, message }] }`. `path`/`value` are `null` when the result
+/// carries none; `focusNode`/`value`/`sourceShape` are N-Triples term strings; `path` is a SHACL
+/// Turtle path expression; `message` is the first `sh:message` text (or the generated default).
+/// Hand-rolled with the same string escaping as [`json_error`] so the projection stays
+/// byte-compatible with the wasm binding's documented shape.
+#[cfg(feature = "shacl")]
+fn shacl_report_to_json(report: &sparq_shacl::ValidationReport) -> String {
+    use oxrdf::Term;
+
+    fn push_str_lit(out: &mut String, s: &str) {
+        out.push('"');
+        for c in s.chars() {
+            match c {
+                '"' => out.push_str("\\\""),
+                '\\' => out.push_str("\\\\"),
+                '\n' => out.push_str("\\n"),
+                '\r' => out.push_str("\\r"),
+                '\t' => out.push_str("\\t"),
+                c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+                c => out.push(c),
+            }
+        }
+        out.push('"');
+    }
+    fn push_field(out: &mut String, key: &str, val: Option<&str>) {
+        out.push('"');
+        out.push_str(key);
+        out.push_str("\":");
+        match val {
+            Some(v) => push_str_lit(out, v),
+            None => out.push_str("null"),
+        }
+    }
+
+    let mut out = String::from("{\"conforms\":");
+    out.push_str(if report.conforms { "true" } else { "false" });
+    out.push_str(",\"results\":[");
+    for (i, r) in report.results.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('{');
+        push_field(&mut out, "focusNode", Some(&r.focus_node.to_string()));
+        out.push(',');
+        let path = r.path.as_ref().map(|p| p.to_turtle());
+        push_field(&mut out, "path", path.as_deref());
+        out.push(',');
+        let value = r.value.as_ref().map(|v| v.to_string());
+        push_field(&mut out, "value", value.as_deref());
+        out.push(',');
+        push_field(&mut out, "sourceShape", Some(&r.source_shape.to_string()));
+        out.push(',');
+        push_field(
+            &mut out,
+            "sourceConstraintComponent",
+            Some(&r.source_component),
+        );
+        out.push(',');
+        push_field(&mut out, "severity", Some(&r.severity));
+        out.push(',');
+        // The human-readable message: the first sh:message's text, or the generated default.
+        let message = match r.messages.first() {
+            Some(Term::Literal(l)) => l.value().to_string(),
+            _ => r.default_message.clone(),
+        };
+        push_field(&mut out, "message", Some(&message));
+        out.push('}');
+    }
+    out.push_str("]}");
+    out
 }
 
 /// Applies the T15 hardening middleware stack to a router (outermost first):

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -83,6 +83,10 @@
 //!   --brtpf-max-values-bytes N [OPUS-4.8 sq-r74h] (feature `brtpf`) DoS cap on the raw brTPF `values`
 //!                             PAYLOAD BYTES — bounds the GET query-string carrier that --max-body-bytes
 //!                             never sees (413 beyond), 0 off            [1048576, env SPARQ_BRTPF_MAX_VALUES_BYTES]
+//!   --shacl                   [OPUS-4.8 sq-r868] (feature `shacl`) serve the OPT-IN HTTP SHACL validate
+//!                             endpoint `POST /shacl/validate`: POST a shapes graph, the server validates
+//!                             its loaded data graph against it. Read-only. Off by default
+//!                                                                        [off, env SPARQ_SHACL=1]
 //!   --verbose                 per-request logging (TraceLayer)
 //!   --log-full-requests       [OPUS-4.8 sq-toze.34] OPT OUT of request-log redaction: log the
 //!                             raw request URI (incl. the full `?query=` SPARQL text) verbatim.
@@ -283,6 +287,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "--brtpf-max-values-bytes" => {
                 config.brtpf_max_values_bytes = parse_flag(&mut args, "--brtpf-max-values-bytes")?;
             }
+            // [OPUS-4.8] sq-r868 (from-pss gh-162 follow-up (c)): OPT-IN HTTP SHACL validate
+            // endpoint — POST a shapes graph to /shacl/validate and the server validates its
+            // loaded data graph against it. Read-only. Off by default (env SPARQ_SHACL=1).
+            #[cfg(feature = "shacl")]
+            "--shacl" => config.shacl = true,
             // [OPUS-4.8] sq-4w18: SERVICE egress allowlist. Repeatable: each value adds one
             // host (`sparql.example.org`) or suffix wildcard (`*.example.org`). With NO
             // allowlist (the default) every SERVICE clause is refused (default-DENY-all).
@@ -313,13 +322,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 } else {
                     ""
                 };
+                // [OPUS-4.8] sq-r868: surface the SHACL validate endpoint flag (feature shacl).
+                let shacl = if cfg!(feature = "shacl") {
+                    " [--shacl]"
+                } else {
+                    ""
+                };
                 eprintln!(
                     "usage: sparq-server [--addr HOST:PORT] [--allow-remote] [--persist DIR] \
                      [--auth-token TOKEN] [--auth-token-read] [--format FMT] \
                      [--query-timeout SECS] [--update-where-timeout SECS] [--max-body-bytes N] [--max-concurrent N] \
                      [--max-results N] [--max-query-rows N] [--max-query-bytes N] [--max-decompress-ratio N] \
                      [--max-subscriptions N] \
-                     [--max-subscriptions-per-conn N]{time_travel}{service}{brtpf} [--verbose] \
+                     [--max-subscriptions-per-conn N]{time_travel}{service}{brtpf}{shacl} [--verbose] \
                      [--log-full-requests] [DATA_FILE]\n\n  \
                      PERSIST: --persist DIR (env SPARQ_PERSIST_DIR) makes the on-disk index at \
                      DIR the durable source of truth (QLever --persist-updates): every committed \

--- a/crates/sparq-server/tests/shacl_validate.rs
+++ b/crates/sparq-server/tests/shacl_validate.rs
@@ -1,0 +1,229 @@
+//! [OPUS-4.8] sq-r868 (from-pss gh-162 follow-up (c)): e2e integration tests for the
+//! OPT-IN HTTP SHACL validate endpoint (`POST /shacl/validate`).
+//!
+//! These tests run ONLY with the `shacl` cargo feature (the whole file is gated). They spin
+//! the real axum server and assert, over an HTTP request:
+//!   * the OPT-IN posture — `/shacl/validate` is `404` unless the config flag is set;
+//!   * the server's loaded DATA graph is validated against the POSTed SHACL SHAPES graph;
+//!   * a conforming store yields `{ "conforms": true, "results": [] }`;
+//!   * a violating store yields `conforms:false` with the PSS-consumed JSON report shape
+//!     (`focusNode` / `path` / `value` / `sourceShape` / `sourceConstraintComponent` /
+//!     `severity` / `message`);
+//!   * content negotiation — JSON by default, the W3C report Turtle on `Accept: text/turtle`;
+//!   * a malformed shapes body is a 400, an unsupported media type a 415;
+//!   * the wrong HTTP method is a 405;
+//!   * read-auth gating (`--auth-token-read`) — 401 without the bearer token, 200 with it.
+#![cfg(feature = "shacl")]
+
+use sparq_core::Graph;
+use sparq_server::{router, AppState, ServerConfig};
+use tokio::net::TcpListener;
+
+/// A store with one `ex:Person` whose `ex:age` is a string (violates `xsd:integer`).
+const VIOLATING_DATA: &str = r#"
+    @prefix ex: <http://example.org/> .
+    ex:alice a ex:Person ; ex:age "thirty" .
+"#;
+
+/// A store with one `ex:Person` whose `ex:age` is a valid integer.
+const CONFORMING_DATA: &str = r#"
+    @prefix ex: <http://example.org/> .
+    ex:bob a ex:Person ; ex:age 42 .
+"#;
+
+const SHAPES: &str = r#"
+    @prefix sh:  <http://www.w3.org/ns/shacl#> .
+    @prefix ex:  <http://example.org/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    ex:PersonShape a sh:NodeShape ;
+      sh:targetClass ex:Person ;
+      sh:property [ sh:path ex:age ; sh:datatype xsd:integer ; sh:minCount 1 ] .
+"#;
+
+/// Boots a server holding `data` with the SHACL flag set, returns its base URL.
+async fn spawn_with(data: &str, shacl_on: bool, config: ServerConfig) -> String {
+    let graph = Graph::load_str(data, "turtle").unwrap();
+    let config = ServerConfig {
+        shacl: shacl_on,
+        ..config
+    };
+    let app = router(AppState::with_config(graph, config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+async fn spawn(data: &str, shacl_on: bool) -> String {
+    spawn_with(data, shacl_on, ServerConfig::default()).await
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+// ---------------------------------------------------------------------------
+// OPT-IN posture.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn shacl_404_when_flag_off() {
+    let base = spawn(VIOLATING_DATA, false).await;
+    let resp = client()
+        .post(format!("{base}/shacl/validate"))
+        .header("Content-Type", "text/turtle")
+        .body(SHAPES)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}
+
+// ---------------------------------------------------------------------------
+// Validation verdicts (JSON report — the PSS-consumed shape).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn violating_store_reports_violation_json() {
+    let base = spawn(VIOLATING_DATA, true).await;
+    let resp = client()
+        .post(format!("{base}/shacl/validate"))
+        .header("Content-Type", "text/turtle")
+        .body(SHAPES)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers()["content-type"],
+        "application/json; charset=utf-8"
+    );
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("\"conforms\":false"), "{body}");
+    // The PSS-consumed JSON projection fields.
+    assert!(body.contains("\"focusNode\":"), "{body}");
+    assert!(body.contains("\"sourceConstraintComponent\":"), "{body}");
+    assert!(
+        body.contains("DatatypeConstraintComponent"),
+        "expected the datatype violation: {body}"
+    );
+    assert!(body.contains("http://example.org/alice"), "{body}");
+}
+
+#[tokio::test]
+async fn conforming_store_reports_conformance_json() {
+    let base = spawn(CONFORMING_DATA, true).await;
+    let resp = client()
+        .post(format!("{base}/shacl/validate"))
+        .header("Content-Type", "text/turtle")
+        .body(SHAPES)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("\"conforms\":true"), "{body}");
+    assert!(body.contains("\"results\":[]"), "{body}");
+}
+
+// ---------------------------------------------------------------------------
+// Content negotiation — W3C report Turtle.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn turtle_report_on_accept_turtle() {
+    let base = spawn(VIOLATING_DATA, true).await;
+    let resp = client()
+        .post(format!("{base}/shacl/validate"))
+        .header("Content-Type", "text/turtle")
+        .header("Accept", "text/turtle")
+        .body(SHAPES)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.headers()["content-type"], "text/turtle; charset=utf-8");
+    let body = resp.text().await.unwrap();
+    // The W3C SHACL report vocabulary.
+    assert!(body.contains("ValidationReport"), "{body}");
+    assert!(body.contains("conforms"), "{body}");
+    assert!(body.contains("ValidationResult"), "{body}");
+}
+
+// ---------------------------------------------------------------------------
+// Error handling.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn malformed_shapes_body_is_400() {
+    let base = spawn(VIOLATING_DATA, true).await;
+    let resp = client()
+        .post(format!("{base}/shacl/validate"))
+        .header("Content-Type", "text/turtle")
+        .body("this is not valid turtle @@@")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn unsupported_media_type_is_415() {
+    let base = spawn(VIOLATING_DATA, true).await;
+    let resp = client()
+        .post(format!("{base}/shacl/validate"))
+        .header("Content-Type", "application/pdf")
+        .body(SHAPES)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 415);
+}
+
+#[tokio::test]
+async fn get_is_405() {
+    let base = spawn(VIOLATING_DATA, true).await;
+    let resp = client()
+        .get(format!("{base}/shacl/validate"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 405);
+}
+
+// ---------------------------------------------------------------------------
+// Read-auth gating — validation is a READ over the store, gated like any GET.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn read_auth_gates_the_endpoint() {
+    let config = ServerConfig {
+        auth_token: Some("s3cret".to_string()),
+        auth_token_read: true,
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(VIOLATING_DATA, true, config).await;
+
+    // No token → 401.
+    let resp = client()
+        .post(format!("{base}/shacl/validate"))
+        .header("Content-Type", "text/turtle")
+        .body(SHAPES)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+
+    // Correct token → 200.
+    let resp = client()
+        .post(format!("{base}/shacl/validate"))
+        .header("Content-Type", "text/turtle")
+        .header("Authorization", "Bearer s3cret")
+        .body(SHAPES)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -514,6 +514,44 @@ curl -H 'Accept: application/n-triples' \
   'http://127.0.0.1:3030/tpf?subject=%3Chttp%3A%2F%2Fex%2Falice%3E&predicate=%3Chttp%3A%2F%2Fex%2Fknows%3E'
 ```
 
+**5e. SHACL validation endpoint (OPT-IN, `sq-r868`, from-pss gh-162 follow-up; feature
+`shacl`).** Validate the server's **currently-loaded data graph** against a SHACL **shapes**
+graph the client POSTs — the server-side / large-graph path from gh-162 (the store is already in
+memory, so there is no per-request data parse, and the 100k-node case where the JS
+`rdf-validate-shacl` OOMs is handled natively by `sparq-shacl`).
+
+- `POST /shacl/validate` — the request **body** is the SHACL shapes graph (RDF: `text/turtle` /
+  `application/n-triples` / `application/n-quads` / `application/trig` / `application/rdf+xml`,
+  classified by `Content-Type` like a GSP write body, and gzip-decoded under the same zip-bomb
+  cap). The **data** graph is the server's pinned store snapshot.
+- **Response, content-negotiated from `Accept`:** the default is the JSON projection PSS / the
+  wasm `shacl` binding consume — `{ "conforms": bool, "results": [{ "focusNode", "path", "value",
+  "sourceShape", "sourceConstraintComponent", "severity", "message" }] }`; `Accept: text/turtle`
+  yields the W3C SHACL report-vocabulary graph (`sparq_shacl::ValidationReport::to_turtle`).
+- Always `200` regardless of conformance — the verdict is in the body (`conforms`), not the HTTP
+  status. A malformed shapes body is a `400`, an unsupported `Content-Type` a `415`, a non-`POST`
+  method a `405`.
+- Covers SHACL Core + SHACL-SPARQL (`sh:sparql`, §5.2) + custom SPARQL constraint components (§6)
+  — whatever `sparq-shacl::validate` supports (it is the SAME engine the wasm binding and the
+  `sparq-shacl` crate expose; see the `shacl-validation` skill). SHACL-AF `sh:rule` inference is
+  not part of validation and is not run by this endpoint.
+
+```sh
+cargo run -p sparq-server --features shacl -- data.ttl --shacl
+# validate the loaded store against POSTed shapes → JSON report (default)
+curl -X POST -H 'Content-Type: text/turtle' --data-binary @shapes.ttl \
+  http://127.0.0.1:3030/shacl/validate
+# the W3C report vocabulary as Turtle
+curl -X POST -H 'Content-Type: text/turtle' -H 'Accept: text/turtle' --data-binary @shapes.ttl \
+  http://127.0.0.1:3030/shacl/validate
+```
+
+**Double opt-in**, OFF by default and **READ-only** (validation never mutates the store):
+compiled only with the `shacl` cargo feature **and** served only when `--shacl` / `SPARQ_SHACL=1`
+is also set (mirrors `tpf` / `federation-descriptors`). Without the feature, zero cost (no route,
+no SHACL code — `sparq-core`/the wasm bundle are untouched); with the feature but not the flag,
+`/shacl/validate` is `404`. Reads are gated by `--auth-token-read` like any GET.
+
 **6. Hardening — flags / env / library.** Each flag overrides its `SPARQ_*` env var; the
 env overrides the default.
 
@@ -540,6 +578,7 @@ env overrides the default.
 | `--time-travel-max-age SECS` | `SPARQ_TIME_TRAVEL_MAX_AGE` | off | (feature) age-out window |
 | `--federation-descriptors` | `SPARQ_FEDERATION_DESCRIPTORS` | off | (feature `federation-descriptors`) serve a VoID at `/.well-known/void` + a SPARQL Service Description on `GET /sparql` with no query — see "Federation discovery" |
 | `--tpf` | `SPARQ_TPF` | off | (feature `tpf`) serve a Triple Pattern Fragments / LDF source endpoint at `GET /tpf?subject=&predicate=&object=` (paged, full Hydra paging incl. `first`/`last`, read-only); same flag also serves brTPF bind-restricted fragments (`values` param / `POST` body) when built with the `brtpf` feature — see "Triple Pattern Fragments" |
+| `--shacl` | `SPARQ_SHACL` | off | (feature `shacl`) serve the SHACL validate endpoint `POST /shacl/validate` — POST a shapes graph, the server validates its loaded data graph against it; JSON report (default) or W3C report Turtle (`Accept: text/turtle`); read-only — see "SHACL validation endpoint" |
 | `--brtpf-max-bindings N` | `SPARQ_BRTPF_MAX_BINDINGS` | `1024` (`0`=off) | (feature `brtpf`) **DoS cap on the brTPF binding-set mapping COUNT** — one index scan per mapping, so cost is super-linear in the count, not the bytes → `413` (`sq-r74h`) |
 | `--brtpf-max-values-bytes N` | `SPARQ_BRTPF_MAX_VALUES_BYTES` | `1048576` (`0`=off) | (feature `brtpf`) **DoS cap on the raw brTPF `values` payload BYTES** — bounds the GET query-string carrier that `--max-body-bytes` never sees → `413` (`sq-r74h`) |
 | `--audit-log` | `SPARQ_AUDIT_LOG` | off | (feature `audit-log`) per-query **access audit log** — see "Access audit log" |


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the `jeswr/sparq` RDF/SPARQL engine (Claude Opus 4.8). @jeswr runs multiple agents; this was written by the SPARQ agent. The **PSS** agent (`prod-solid-server`) is a separate party.

Implements bead **sq-r868** — the **(c) HTTP `validate` endpoint** follow-up scoped on [#162](https://github.com/jeswr/sparq/issues/162) (the `a + c, not b` agreement; part (a), the WASM binding, already landed in #339/#355).

## What

A new OPT-IN endpoint **`POST /shacl/validate`** on `sparq-server`:

- **Input** — the request **body** is a SHACL **shapes** graph (RDF: `text/turtle` / `application/n-triples` / `application/n-quads` / `application/trig` / `application/rdf+xml`, classified by `Content-Type` exactly like a GSP write body, gzip-decoded under the same zip-bomb cap). The **data** graph is the server's **currently-loaded store snapshot** (pinned for the request) — the gh-162 server-side / large-graph path: the store is already in memory (no per-request data parse), and the 100k-node case where the JS `rdf-validate-shacl` OOMs is handled natively by `sparq-shacl`.
- **Output** — content-negotiated from `Accept`:
  - default: the JSON projection PSS + the wasm `shacl` binding consume — `{ "conforms": bool, "results": [{ focusNode, path, value, sourceShape, sourceConstraintComponent, severity, message }] }`
  - `Accept: text/turtle`: the W3C SHACL report-vocabulary graph (`ValidationReport::to_turtle`)
- Always **`200`** regardless of conformance (the verdict is in the body, `conforms`); malformed shapes → `400`, unsupported media type → `415`, non-`POST` → `405`.
- Backed by `sparq_shacl::validate` (SHACL Core + SHACL-SPARQL §5.2 + custom SPARQL constraint components §6), run on the blocking pool under the same wall-clock cap the query paths use.

## Opt-in posture (mirrors `tpf` / `federation-descriptors`)

**Double opt-in**, OFF by default and **read-only**: compiled only with the new `shacl` cargo feature **and** served only when `--shacl` / `SPARQ_SHACL=1` (`ServerConfig::shacl`) is set. Without the feature, **zero SHACL code** — `sparq-core` / the wasm bundle are untouched (`sparq-wasm` never depends on `sparq-server`); with the feature but not the flag, `/shacl/validate` is `404`. Validation is a READ, so it is gated by `--auth-token-read` like any GET — consistent with the bearer-gating PSS asked for.

## Tests

`crates/sparq-server/tests/shacl_validate.rs` (feature-gated), e2e over the real axum server: 404-when-flag-off; violation + conformance JSON report shapes; W3C Turtle report on `Accept`; 400 / 415 / 405 error paths; read-auth gating (401 without / 200 with the bearer token).

## Gate (all green locally)

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + the **full test suite** in **BOTH feature states** (`--features shacl` and default/off); `--all-features` clippy; doc-tests.
- **wasm boundary guard**: `cargo tree -p sparq-wasm -e normal` shows `sparq-server` and `sparq-serve` counts stay **0**.
- privacy-claims gate, G1 (new-crate) gate, G2 (public-api → SKILL) gate.
- Docs updated proactively: `crates/sparq-server/README.md` (Features + opt-in list), `skills/http-server/SKILL.md` (endpoint section + flag-table row), and `--help`/usage + the module flag doc in `main.rs`.

## Honest scope

This validates the server's **loaded store** against POSTed shapes — the large-graph / whole-container path gh-162 calls out (and the only clean single-body HTTP contract). It does NOT take an arbitrary inline *data* graph in the same request (the body carries the shapes); a future stateless `validate(data, shapes)` HTTP variant, if wanted, is a separate follow-up. SHACL-AF `sh:rule` inference is not run by this endpoint (it is not a validation step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)