### PR TITLE
feat(site): hover/focus-intent prefetch warm-up of the in-browser ZK prover [OPUS-4.8]

### DIFF
--- a/site/src/components/layout/sidebar-nav.tsx
+++ b/site/src/components/layout/sidebar-nav.tsx
@@ -8,6 +8,62 @@ import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { FLAGSHIPS, GROUPS, TIER_LABEL, TIER_VARIANT } from "@/data/surfaces";
 
+// [OPUS-4.8] Hover/focus-intent prefetch of the in-browser ZK prover.
+//
+// The prover's cold start (the ~MB @noir-lang/noir_js + @aztec/bb.js WASM glue +
+// the ACIR circuit fetch + the Barretenberg WASM instantiate) is deliberately
+// route-scoped: it warms only after the user lands on a ZK page and the demo
+// component mounts (prewarmProver in src/lib/zk-prover.ts, invoked from the
+// zk-car-hire useEffect). This adds an EARLIER, intent-gated hook so the warm can
+// begin while the pointer is still on the nav link — before navigation, before
+// first paint of the ZK page — without ever pulling those assets onto routes that
+// have nothing to do with ZK (/try, /papers, /benchmarks, …).
+//
+// It is purely an optimisation layered on top of the existing in-route warm-up:
+//   * fire-and-forget — never awaited on any render / interaction path;
+//   * idempotent — `prewarmProver` shares the single module-level promise, so a
+//     hover, a later hover, and the in-route useEffect all reuse ONE cold start;
+//   * one-shot per session — `zkPrefetchScheduled` guards repeat scheduling;
+//   * idle-gated — scheduled via requestIdleCallback (setTimeout fallback) so it
+//     never contends with first paint or an active interaction;
+//   * graceful — failures are swallowed and re-arm the guard; the cold-start cache
+//     self-resets, so the on-demand proving path stays correct even if this never
+//     ran.
+// The dynamic import keeps the bb.js / noir_js chunks out of every other route's
+// bundle, preserving the route-scoping documented in zk-car-hire.tsx.
+const ZK_PREFETCH_HREFS = new Set(["/showcase/zk-car-hire", "/surface/zk"]);
+
+let zkPrefetchScheduled = false;
+
+function prefetchZkProver() {
+  if (typeof window === "undefined" || zkPrefetchScheduled) return;
+  zkPrefetchScheduled = true;
+
+  const warm = () => {
+    // Dynamic import so the bb.js / noir_js chunks never enter non-ZK route bundles.
+    void import("@/lib/zk-prover")
+      .then((m) => m.prewarmProver())
+      .catch(() => {
+        // Optimisation only — if the warm import / instantiate fails, the in-route
+        // useEffect and the proveAgeEligibility safety net still drive a fresh cold
+        // start on demand. Re-arm the guard so a later hover can retry.
+        zkPrefetchScheduled = false;
+      });
+  };
+
+  const ric = (
+    window as Window & {
+      requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+    }
+  ).requestIdleCallback;
+  if (typeof ric === "function") {
+    ric(warm, { timeout: 2000 });
+  } else {
+    // Safari / older browsers lack requestIdleCallback: defer past first paint.
+    window.setTimeout(warm, 200);
+  }
+}
+
 // Shared nav body used by BOTH the persistent desktop sidebar and the mobile Sheet.
 // Every item is a real <a href> (Next Link) per the accessible-html-links rule.
 export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
@@ -103,10 +159,16 @@ function NavLink({
   onNavigate?: () => void;
   children: React.ReactNode;
 }) {
+  // [OPUS-4.8] On ZK nav entries only, hover / focus intent eagerly (idle-gated,
+  // fire-and-forget) warms the in-browser prover before navigation. No-op on every
+  // other link, so non-ZK routes never pull the prover WASM.
+  const onZkIntent = ZK_PREFETCH_HREFS.has(href) ? prefetchZkProver : undefined;
   return (
     <Link
       href={href}
       onClick={onNavigate}
+      onMouseEnter={onZkIntent}
+      onFocus={onZkIntent}
       aria-current={active ? "page" : undefined}
       className={cn(
         "flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors",


### PR DESCRIPTION
> 🤖 SPARQ agent — this PR was prepared by an automated SPARQ agent on @jeswr's behalf.

## What

Background-warm the in-browser ZK proof setup *earlier* than today, gated on **navigation intent** toward the ZK pages — without blocking first paint and without pulling the prover WASM onto non-ZK routes.

The ZK car-hire flagship already warms its prover in the background **on route mount** (`prewarmProver` in `site/src/lib/zk-prover.ts`, kicked off from the `zk-car-hire.tsx` `useEffect`, landed earlier). That warm only begins once the demo component mounts — i.e. after the user has already navigated to the ZK page.

This change adds an **earlier, intent-gated** hook on the ZK navigation entries **only** (`/showcase/zk-car-hire` and `/surface/zk`) in `site/src/components/layout/sidebar-nav.tsx`. On `onMouseEnter` / `onFocus` of those links it fires a fire-and-forget, idle-gated

```ts
void import("@/lib/zk-prover").then((m) => m.prewarmProver());
```

so the prover's cold start — the `@noir-lang/noir_js` + `@aztec/bb.js` WASM glue, the ACIR circuit fetch, and the Barretenberg WASM instantiate — can begin **while the pointer is still on the link**, before navigation and before the ZK page's first paint.

## Properties (this is an optimisation, never a correctness dependency)

- **Does not block first paint** — fire-and-forget, never awaited on any render or interaction path; scheduled via `requestIdleCallback` with a `setTimeout` fallback for Safari / older browsers.
- **Idempotent** — `prewarmProver` shares the single module-level `proverPromise`, so a hover, a later hover, and the in-route `useEffect` all reuse **one** cold start. If the user clicks *Generate ZK proof* before the warm finishes, `proveAgeEligibility` already `await`s that same shared promise rather than starting a second init.
- **One-shot per session** — a module-level guard prevents repeat scheduling; it re-arms if the warm fails.
- **Graceful** — a failed warm is swallowed and the cold-start cache self-resets, so the on-demand proving path stays fully correct even if the prefetch never ran or failed.
- **No bundle leakage** — the dynamic `import()` keeps the `bb.js` / `noir_js` chunks out of every non-ZK route's bundle, preserving the deliberate route-scoping documented in `zk-car-hire.tsx`. Non-ZK nav links get no handler at all.

This mirrors the existing `prewarmSparq()` warm-up pattern proven for the SPARQL REPL.

## Scope

One file: `site/src/components/layout/sidebar-nav.tsx`. No new warm-up mechanism, no changes to `zk-prover.ts` (the existing exported `prewarmProver` / shared-promise contract is reused as-is). No logo/branding assets touched.

## Gate

- `tsc --noEmit` — clean
- `next lint` — no warnings or errors
- `next build` (static export) — clean, 41/41 pages, export 2/2

## Honesty

Effect is described qualitatively only — no speedup figures (this work-box is non-canonical for performance). No soundness/audit claim is made: the broader sparq ZK estate is research-grade and internally reviewed only, not externally audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)