### PR TITLE
fix(bench/owl-sameas): clear stale .rq + match q_membership by name (sq-f4ps)

### DIFF
--- a/bench/owl-sameas/run.sh
+++ b/bench/owl-sameas/run.sh
@@ -49,7 +49,11 @@ fi
 
 # query.rq lives in a file but `sparq-cli bench` takes a queries DIRECTORY; stage a dir with just
 # the probe query so the bench runner's TSV reports it under a stable `q` name.
+# CACHE persists across runs (default /tmp/owl-sameas), so CLEAR any stale `.rq` first: `bench` runs
+# EVERY *.rq in the dir, and a leftover probe (e.g. a renamed query) would emit an extra TSV line
+# that could sort ahead of q_membership and false-fail the row-count gate. [OPUS-4.8] sq-f4ps
 QDIR="$CACHE/qdir"
+rm -rf "$QDIR"
 mkdir -p "$QDIR"
 cp "$QUERY" "$QDIR/q_membership.rq"
 
@@ -76,8 +80,12 @@ for TIER in $TIERS; do
   closure_s="$(grep -oE 'in [0-9.]+s' "$TMP/r.err" | head -1 | grep -oE '[0-9.]+' | head -1)"
 
   # ---- 3. run query.rq over the closure (count mode, min-of-ITERS) ----------------------
+  # `bench` prints one `<name>\t<rows>\t<us>` line per *.rq (sorted by name). Pick the
+  # q_membership line BY NAME rather than reading line 1 — robust to any extra/stale line that
+  # would otherwise sort ahead of it and false-fail the gate. [OPUS-4.8] sq-f4ps
   "$CLI" bench "$CLOSURE" ntriples "$QDIR" "$ITERS" count 2>/dev/null > "$TMP/q.tsv" || true
-  IFS=$'\t' read -r _qname qrows qus < "$TMP/q.tsv"
+  qrows=""; qus=""
+  IFS=$'\t' read -r qrows qus < <(awk -F'\t' '$1=="q_membership"{print $2"\t"$3; exit}' "$TMP/q.tsv")
 
   # ---- emit metric TSV lines (harvested by the ci-bench sameas hook) --------------------
   [ -n "${closure_s:-}" ] && printf 'sameas_size%s_closure_s\t%s\ts\n'            "$TIER" "$closure_s"


### PR DESCRIPTION
> 🤖 SPARQL agent

Implements bead **sq-f4ps**. Hardens `bench/owl-sameas/run.sh` against two spurious row-count gate false-fails. `[OPUS-4.8]`

### Root cause
The probe query is staged into `$CACHE/qdir` (default `/tmp/owl-sameas/qdir`), a path that **persists across runs**, and `sparq-cli bench` runs **every** `*.rq` in that directory (sorted by name), emitting one `<name>\t<rows>\t<us>` TSV line per query. The gate then read only the **first** line. So:

1. A leftover/renamed probe left in the persistent cache emits an **extra** TSV line.
2. If that stale line sorts **ahead** of `q_membership` (e.g. `a_stale`), the gate parsed it as the membership result and compared it to the expected `K*N` rows → spurious false-fail.

### Fix (two small, complementary changes)
1. **Clear stale `.rq` before staging** — `rm -rf "$QDIR"` before `mkdir`/`cp`, so the dir only ever holds `q_membership.rq`.
2. **Match the `q_membership` line by name** — select it via `awk '$1=="q_membership"'` instead of `read`-ing line 1, so the gate is robust even if an extra line appears.

Belt-and-suspenders: (1) removes the stale file at the source; (2) hardens the parser regardless.

### Verification (against the release `sparq-cli`)
- Happy path (tier N=8): closure 352 / query rows 32, gate **OK**, exit 0.
- Stale `a_stale.rq` (rows 352) sorting first: **old** line-1 read picked 352 (would false-fail vs expected 32); **new** name-match correctly picks 32.
- After a run, `qdir` contains only `q_membership.rq` (stale file cleared).

### Gate
Bench/CI shell-script change only — no Rust crate, no public API, no privacy/ZK surface touched.
- `shellcheck bench/owl-sameas/run.sh` — clean
- `bash -n` — OK
- `scripts/check-privacy-claims.sh` — OK (predicate-form soundness included)
- G2 public-api → SKILL.md — N/A (no public API changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)