### PR TITLE
feat(sparq-policy): odrl:spatial dimension + region isPartOf trees (sq-wukl) [OPUS-4.8]

### DIFF
--- a/crates/sparq-policy/README.md
+++ b/crates/sparq-policy/README.md
@@ -78,10 +78,33 @@ assert!(!evaluate(&policy, &outside).allow);
   so access is never restored on missing evidence (`matched_prohibition().is_none()`
   alone conflates the two, which would be fail-OPEN for a deny).
 - **Constraint operators** — `eq`, `neq`, `lt`, `lteq`, `gt`, `gteq`,
-  `isPartOf` (set membership), `isA`. Numeric (`xsd:integer`/`decimal`/…) and
+  `isPartOf` (set membership **or**, for the taxonomic dimensions `purpose`/`spatial`,
+  a transitive subsumption match — see below), `isA`. Numeric (`xsd:integer`/`decimal`/…) and
   `xsd:dateTime`/`date` operands compare by magnitude/instant; everything else
   by IRI/string value. Constraints over `purpose` / `recipient` / `dateTime` /
   `count` / `spatial` left-operands are all supported.
+- **`odrl:spatial` region enforcement + region `isPartOf` trees** — [OPUS-4.8] sq-wukl.
+  A `spatial` constraint gates a rule to a **geographic region** (`spatial isPartOf
+  <country/EU>`, "anywhere in the EU"). A request supplies its region as `odrl:spatial`
+  evidence (`.with(ODRL_SPATIAL, ..)`), gated through the **same** `evaluate` constraint
+  path as every other dimension.
+  - **Region `isPartOf` tree (subsumption).** The spatial dimension is taxonomic, so it
+    reuses the **same** caller-supplied subsumption closure the DPV purpose taxonomy uses
+    (`Request::with_purpose_subsumption(narrower, broader)` / `with_purpose_taxonomy(edges)`
+    — there is *no* separate spatial evidence channel). A `spatial isPartOf <EU>`
+    constraint is then satisfied by a request whose stated region is the EU **or
+    transitively part-of** it — `Berlin ⊑ DEU ⊑ EU`. **Honesty / fail-closed:** the tree is
+    *the requester's asserted subsumption*, never invented — with **no** edge supplied
+    `spatial` matching is exact membership (fully backward compatible), and a sub-region
+    does **not** grant a broad-region permission unless the request asserts the edge (a
+    missing edge fails closed, like a missing context value). Cycle-safe (the closure
+    tolerates a malformed `A ⊑ B ⊑ A`).
+  - `spatial_status(&rule, &request) -> SpatialMatch` reports exactly what the evaluator
+    checks for a rule's spatial constraints — `Satisfied` / `DefinitelyUnsatisfied` /
+    `Unprovable` / `NotConstrained` — the spatial twin of `purpose_status` (it runs the
+    same subsumption-aware path `evaluate` does). (Through the `sparq-solid` bridge
+    `purpose`/`spatial` stay **one-shot** — ACP has no purpose/region dimension to
+    re-check; see the mapping table.)
 - **`odrl:purpose` enforcement (faithful, fail-closed)** — [OPUS-4.8] sq-q56r. A
   purpose constraint restricts a rule to a stated *purpose of use*. A request carries
   its purpose evidence via `Request::for_purpose(Value)` (sugar over
@@ -108,7 +131,9 @@ assert!(!evaluate(&policy, &outside).allow);
     it is *never* inferred from IRI string structure — so with no taxonomy supplied
     matching is byte-for-byte the exact-IRI base case, the broader-under-narrower
     direction never matches, and access is never widened on an unproven relation. The
-    edges form the closure incrementally (order-independent).
+    edges form the closure incrementally (order-independent). The **same** closure also
+    drives the `odrl:spatial` region tree (see the spatial bullet above) — one subsumption
+    evidence channel for both taxonomic dimensions.
   - `purpose_status(&rule, &request) -> PurposeMatch` reports exactly what the evaluator
     checks for a rule's purpose constraints — `Satisfied` / `DefinitelyUnsatisfied` /
     `Unprovable` / `NotConstrained` — the auditable surface of this enforcement (it runs
@@ -208,11 +233,13 @@ Single-node only. The headline **federated-disclosure** / ODRL→MPC composition
 (per-node ODRL drives the `sparq-mpc` disclosed-vs-hidden split; ODRL `Duty` →
 ZK proof obligation) is **deferred** — it inherits the MPC honest-majority/LAN
 envelope and the open ZK-soundness remediation. `dateTime` ordering normalizes
-mixed timezone offsets to the UTC instant before comparing ([OPUS-4.8] sq-qj2q);
-DPV `purpose`-taxonomy subsumption is supported when the request supplies the
-taxonomy edges ([OPUS-4.8] sq-z3ve — `Request::with_purpose_subsumption` /
-`with_purpose_taxonomy`); `Duty → proof-manifest` discharge is tracked as a
-follow-on bead. See `research/feature-research-odrl-policy.md`.
+mixed timezone offsets to the UTC instant before comparing ([OPUS-4.8] sq-qj2q).
+DPV-`purpose`-taxonomy subsumption ([OPUS-4.8] sq-z3ve — `Request::with_purpose_subsumption`
+/ `with_purpose_taxonomy`) and the `odrl:spatial` region `isPartOf` tree ([OPUS-4.8]
+sq-wukl — the same caller-supplied closure) are both evaluated at request time when the
+request supplies the edges. The *static* (request-free) `contains` refinement over
+`isPartOf` set-subset, and `Duty → proof-manifest` discharge, remain follow-on beads.
+See `research/feature-research-odrl-policy.md`.
 
 **Constraint persistence vs. one-shot** (sq-hiz4 / sq-5037, in `sparq-solid`'s opt-in
 bridge): `materialize_odrl_permission_conditional` persists a
@@ -220,8 +247,8 @@ bridge): `materialize_odrl_permission_conditional` persists a
 `auth:ConditionalGrant` — `eq`/`isA`/`isPartOf` as an agent matcher, and **`neq`
 ("everyone EXCEPT X") as an ACP `noneOf` exception** (a public grant + an
 `auth:exceptMatcher` carving out `X`). These are the only constraints with a faithful
-stateless `(agent, client)` analogue. `odrl:purpose`/`dateTime`/`count` have no
-*stateless* ACP analogue and stay
+stateless `(agent, client)` analogue. `odrl:purpose`/`spatial`/`dateTime`/`count` have no
+*stateless* ACP analogue (ACP carries no purpose/region/clock dimension) and stay
 **one-shot** in the bridge (checked once at materialization). Stateful `odrl:count`
 enforcement itself (the usage counter) lives in this crate's `count-enforcement`
 feature (`evaluate_and_exercise` + `UsageCounterStore`); wiring it *through* the

--- a/crates/sparq-policy/src/eval.rs
+++ b/crates/sparq-policy/src/eval.rs
@@ -37,6 +37,16 @@ pub const ODRL_COUNT: &str = "http://www.w3.org/ns/odrl/2/count";
 /// [`recipient_status`]). [OPUS-4.8] sq-5037.
 pub const ODRL_RECIPIENT: &str = "http://www.w3.org/ns/odrl/2/recipient";
 
+/// The `odrl:spatial` left-operand IRI — the dimension a *spatial constraint*
+/// restricts (the geographic region a permission/prohibition is gated on, e.g.
+/// `odrl:spatial isPartOf <country/EU>`, "anywhere in the EU"). A request supplies its
+/// region as `odrl:spatial` evidence; an `isPartOf` spatial constraint matches a
+/// sub-region the request declares part-of the named region by supplying the region
+/// `isPartOf` tree as subsumption evidence via [`Request::with_purpose_subsumption`] /
+/// [`Request::with_purpose_taxonomy`] (`DEU ⊑ EU` — the same caller-supplied closure the
+/// DPV purpose taxonomy uses; see [`spatial_status`]). [OPUS-4.8] sq-wukl.
+pub const ODRL_SPATIAL: &str = "http://www.w3.org/ns/odrl/2/spatial";
+
 /// The `odrl:dateTime` left-operand IRI — the dimension a *temporal constraint*
 /// restricts (the instant a permission/prohibition is gated on, e.g.
 /// `odrl:dateTime lteq "2026-12-31T23:59:59Z"`, the upper edge of a validity
@@ -75,18 +85,20 @@ pub struct Request {
     /// (e.g. `odrl:anonymize`, a custom `proveAttestation`). A permission with an
     /// undischarged duty is denied.
     pub discharged_duties: BTreeSet<String>,
-    /// The **purpose subsumption** evidence the request supplies: the *transitive
-    /// closure* of `(narrower, broader)` purpose pairs — `narrower ⊑ broader`, i.e.
-    /// the stated purpose `narrower` IS-A / is-part-of the broader purpose. Sourced
-    /// from a DPV/purpose-taxonomy (`skos:broader` / `rdfs:subClassOf` /
-    /// `dpv:isSubTypeOf` edges), supplied via [`Request::with_purpose_subsumption`]
-    /// / [`Request::with_purpose_taxonomy`]. Internal — populated only through those
-    /// builders, which maintain the closure so a lookup is a single membership test.
+    /// The **subsumption** evidence the request supplies: the *transitive closure* of
+    /// `(narrower, broader)` pairs — `narrower ⊑ broader`, i.e. the stated value
+    /// `narrower` IS-A / is-part-of the broader value. Used for the two taxonomic
+    /// dimensions — `odrl:purpose` (a DPV/purpose taxonomy, `skos:broader` /
+    /// `rdfs:subClassOf` / `dpv:isSubTypeOf` edges) and `odrl:spatial` (a region
+    /// `isPartOf` tree, e.g. `DEU ⊑ EU`). Supplied via
+    /// [`Request::with_purpose_subsumption`] / [`Request::with_purpose_taxonomy`].
+    /// Internal — populated only through those builders, which maintain the closure so
+    /// a lookup is a single membership test.
     ///
-    /// **Soundness:** subsumption matching for `odrl:purpose` constraints draws ONLY
-    /// on this caller-supplied closure (never inferred from IRI string structure), so
-    /// with an empty closure matching is byte-for-byte the exact-IRI base case and
-    /// access is never widened on an unproven relation. [OPUS-4.8] sq-z3ve.
+    /// **Soundness:** subsumption matching draws ONLY on this caller-supplied closure
+    /// (never inferred from IRI string structure), so with an empty closure matching is
+    /// byte-for-byte the exact-IRI base case and access is never widened on an unproven
+    /// relation. [OPUS-4.8] sq-z3ve / sq-wukl.
     pub(crate) purpose_subsumes: BTreeSet<(String, String)>,
 }
 
@@ -769,6 +781,105 @@ pub fn datetime_status(rule: &Rule, request: &Request) -> DateTimeMatch {
     }
 }
 
+/// The three-valued verdict of a rule's `odrl:spatial` constraints against the spatial
+/// (region) evidence a request carries — a FAITHFUL report of exactly what [`evaluate`]
+/// checks for the location (it reuses the same [`constraint_status`] the evaluator's
+/// `odrl:spatial` constraints go through). [OPUS-4.8] sq-wukl.
+///
+/// The honesty contract mirrors [`PurposeMatch`] / [`RecipientMatch`] / [`DateTimeMatch`]:
+/// it never claims a stronger verdict than the evaluator acts on. `Satisfied` is the ONLY
+/// verdict under which a spatially-gated permission grants; anything other than
+/// `DefinitelyUnsatisfied` (i.e. `Satisfied` OR `Unprovable`) keeps a spatially-gated
+/// prohibition in force.
+///
+/// **The spatial-tree / `isPartOf` shape:** a `spatial isPartOf <Region>` constraint is
+/// `Satisfied` when the request's stated region IS the named region or is **transitively
+/// part-of** it under the region `isPartOf` tree the request supplies as subsumption
+/// evidence (via [`Request::with_purpose_subsumption`] / [`Request::with_purpose_taxonomy`]
+/// — e.g. `Berlin ⊑ DEU ⊑ EU` for a `spatial isPartOf EU` rule, the SAME caller-supplied
+/// closure the DPV purpose taxonomy uses), `DefinitelyUnsatisfied` when the stated region
+/// is provably outside the named region (no edge path reaches it), and `Unprovable` when
+/// the request supplies no region at all — fail-closed. **No invented subsumption:** a
+/// sub-region grants only when the request asserts the `isPartOf` edge; a missing edge
+/// fails closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpatialMatch {
+    /// The rule has no `odrl:spatial` constraint — location places no restriction on it.
+    NotConstrained,
+    /// The rule constrains location AND the request's region **meets** every spatial
+    /// constraint (the named region, or part-of it under the supplied tree).
+    Satisfied,
+    /// The rule constrains location but the request carries **no** region evidence —
+    /// *unprovable*. Fail-closed: a permission does NOT grant; a prohibition is NOT
+    /// withdrawn. (Never silently read as "anywhere allowed".)
+    Unprovable,
+    /// The rule constrains location and the request's region **fails** the constraint —
+    /// a definite no (outside the named region; no `isPartOf` path reaches it).
+    DefinitelyUnsatisfied,
+}
+
+/// Report how `rule`'s `odrl:spatial` constraint(s) stand against the region evidence
+/// `request` carries — the auditable surface of faithful spatial (incl. `isPartOf`-tree)
+/// enforcement. [OPUS-4.8] sq-wukl.
+///
+/// Like [`purpose_status`] / [`recipient_status`] / [`datetime_status`], this does NOT
+/// re-implement matching: it runs the request through the SAME [`constraint_status`]
+/// every `odrl:spatial` constraint goes through inside [`evaluate`] (including the
+/// transitive `isPartOf` match over the request's supplied subsumption closure — see
+/// [`Request::with_purpose_subsumption`]), so the verdict it reports is exactly what the
+/// evaluator acts on — no claimed enforcement that isn't actually checked.
+///
+/// Returns [`SpatialMatch::NotConstrained`] when the rule has no spatial constraint.
+///
+/// # Examples
+///
+/// ```
+/// use sparq_policy::{spatial_status, SpatialMatch, parse_policy_str, Request, Value, ODRL_SPATIAL};
+/// // "may distribute to anywhere in the EU" — spatial isPartOf EU.
+/// let pol = parse_policy_str(r#"
+/// @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+/// <urn:pol/geo> a odrl:Set ; odrl:permission [
+///     odrl:action odrl:distribute ; odrl:target <urn:asset/x> ;
+///     odrl:constraint [ odrl:leftOperand odrl:spatial ; odrl:operator odrl:isPartOf ;
+///                       odrl:rightOperand <urn:country/EU> ] ] .
+/// "#, "turtle").unwrap();
+/// let rule = &pol.permissions[0];
+/// let base = Request::new("http://www.w3.org/ns/odrl/2/distribute").on("urn:asset/x");
+///
+/// // Germany part-of EU (edge supplied) → Satisfied.
+/// let de = base.clone()
+///     .with(ODRL_SPATIAL, Value::Iri("urn:country/DEU".into()))
+///     .with_purpose_subsumption("urn:country/DEU", "urn:country/EU");
+/// assert_eq!(spatial_status(rule, &de), SpatialMatch::Satisfied);
+/// // A region outside EU → DefinitelyUnsatisfied.
+/// let us = base.clone().with(ODRL_SPATIAL, Value::Iri("urn:country/USA".into()));
+/// assert_eq!(spatial_status(rule, &us), SpatialMatch::DefinitelyUnsatisfied);
+/// // No region at all → Unprovable (fail-closed; not "anywhere").
+/// assert_eq!(spatial_status(rule, &base), SpatialMatch::Unprovable);
+/// ```
+pub fn spatial_status(rule: &Rule, request: &Request) -> SpatialMatch {
+    let mut constrained = false;
+    let mut any_unprovable = false;
+    for c in &rule.constraints {
+        if c.left != ODRL_SPATIAL {
+            continue;
+        }
+        constrained = true;
+        match constraint_status(c, request) {
+            ConstraintStatus::Satisfied => {}
+            ConstraintStatus::DefinitelyUnsatisfied => return SpatialMatch::DefinitelyUnsatisfied,
+            ConstraintStatus::Unprovable => any_unprovable = true,
+        }
+    }
+    if !constrained {
+        SpatialMatch::NotConstrained
+    } else if any_unprovable {
+        SpatialMatch::Unprovable
+    } else {
+        SpatialMatch::Satisfied
+    }
+}
+
 /// How one prohibition rule re-evaluates against a request, distinguishing a
 /// *definite* non-match from an *unprovable* one (missing-evidence constraint).
 /// [OPUS-4.8] sq-2pcf.
@@ -845,31 +956,45 @@ fn constraint_status(c: &Constraint, request: &Request) -> ConstraintStatus {
     }
 }
 
+/// Whether a constraint's `leftOperand` is a **taxonomic** dimension that subsumption
+/// (the request's supplied `narrower ⊑ broader` closure) applies to — `odrl:purpose`
+/// (a DPV/purpose taxonomy — [OPUS-4.8] sq-z3ve) and `odrl:spatial` (a region
+/// `isPartOf` tree — [OPUS-4.8] sq-wukl). Every other dimension matches by exact
+/// value / magnitude only.
+fn is_subsumable_dimension(left: &str) -> bool {
+    left == ODRL_PURPOSE || left == ODRL_SPATIAL
+}
+
 /// Compare a constraint's `actual` request value against its bound, applying
-/// **purpose subsumption** for `odrl:purpose` constraints (the stated purpose is
-/// matched against the constraint purpose *and every broader purpose* the request's
-/// supplied taxonomy proves it falls under — see [`Request::with_purpose_subsumption`]);
-/// every other dimension is the plain [`compare`]. One source of truth for both
-/// [`constraint_status`] and [`constraint_satisfied`]. [OPUS-4.8] sq-z3ve.
+/// **subsumption** for the taxonomic dimensions — `odrl:purpose` (a DPV/purpose
+/// taxonomy) and `odrl:spatial` (a region `isPartOf` tree). The stated value is
+/// matched against the constraint value *and every broader value* the request's
+/// supplied subsumption closure proves it falls under (see
+/// [`Request::with_purpose_subsumption`]); every other dimension is the plain
+/// [`compare`]. One source of truth for both [`constraint_status`] and
+/// [`constraint_satisfied`]. [OPUS-4.8] sq-z3ve / sq-wukl.
 fn compare_constraint(c: &Constraint, actual: &Value, request: &Request) -> bool {
-    if c.left == ODRL_PURPOSE && !request.purpose_subsumes.is_empty() {
-        return compare_purpose(actual, c.operator, &c.right, request);
+    if is_subsumable_dimension(&c.left) && !request.purpose_subsumes.is_empty() {
+        return compare_subsumed(actual, c.operator, &c.right, request);
     }
     compare(actual, c.operator, &c.right)
 }
 
-/// Subsumption-aware comparison for an `odrl:purpose` constraint. The stated
-/// purpose `actual` matches the named purpose `bound` when it equals it OR is a
-/// transitively-narrower purpose under the request's supplied taxonomy
-/// (`actual ⊑ bound`). [OPUS-4.8] sq-z3ve.
+/// Subsumption-aware comparison for a taxonomic constraint (`odrl:purpose`,
+/// `odrl:spatial`). The stated value `actual` matches the named value `bound` when it
+/// equals it OR is a transitively-narrower value under the request's supplied closure
+/// (`actual ⊑ bound`) — `clinical ⊑ research` for purpose, `DEU ⊑ EU` for spatial.
+/// [OPUS-4.8] sq-z3ve / sq-wukl.
 ///
 /// - `eq`/`isA`: `actual ⊑ bound`.
-/// - `neq`: NOT `actual ⊑ bound` — a sub-purpose of the excluded purpose is also
-///   excluded (a sub-purpose IS that purpose), so the carve-out is not widened away.
-/// - `isPartOf`: `actual ⊑ some member` of the named set.
-/// - order operators (`lt`/`lteq`/`gt`/`gteq`): purpose is not orderable, so these
-///   delegate to the plain [`compare`] (which already fail-closes on non-orderable).
-fn compare_purpose(actual: &Value, op: Operator, bound: &Value, request: &Request) -> bool {
+/// - `neq`: NOT `actual ⊑ bound` — a sub-value of the excluded value is also excluded
+///   (a sub-purpose IS that purpose; a sub-region IS in that region), so the carve-out
+///   is not widened away.
+/// - `isPartOf`: `actual ⊑ some member` of the named set (the spatial `isPartOf EU`
+///   region-tree case, and the purpose-set-with-hierarchy case).
+/// - order operators (`lt`/`lteq`/`gt`/`gteq`): a taxonomic value is not orderable, so
+///   these delegate to the plain [`compare`] (which already fail-closes on non-orderable).
+fn compare_subsumed(actual: &Value, op: Operator, bound: &Value, request: &Request) -> bool {
     let a = actual.as_str();
     match op {
         Operator::Eq | Operator::IsA => request.purpose_subsumed_by(a, bound.as_str()),
@@ -994,6 +1119,10 @@ fn constraint_satisfied(c: &Constraint, request: &Request) -> bool {
 /// operator. Numeric and dateTime operands compare by magnitude; everything
 /// else compares by string/IRI value. An order comparison (`lt`/`gt`/…) on
 /// non-orderable values is **false** (fail-closed).
+///
+/// This is the **exact / flat** base case (no subsumption). The taxonomic dimensions
+/// (`odrl:purpose`, `odrl:spatial`) route through [`compare_subsumed`] instead when the
+/// request supplies a subsumption closure — see [`compare_constraint`].
 fn compare(actual: &Value, op: Operator, bound: &Value) -> bool {
     match op {
         Operator::Eq | Operator::IsA => value_eq(actual, bound),
@@ -1067,6 +1196,10 @@ fn value_eq(a: &Value, b: &Value) -> bool {
 /// `isPartOf` / set membership: the right operand is a `|`-or-space-separated
 /// set (the common compact encoding) OR a single IRI/string the actual must
 /// equal. We treat the right operand's string as a set: actual ∈ set.
+///
+/// This is the **flat** base case. Transitive `isPartOf` over a taxonomy (a DPV
+/// purpose subtree, a spatial region tree) is handled by [`compare_subsumed`] using the
+/// request's caller-supplied subsumption closure — see [`Request::with_purpose_subsumption`].
 fn is_part_of(actual: &Value, bound: &Value) -> bool {
     let a = actual.as_str();
     bound

--- a/crates/sparq-policy/src/lib.rs
+++ b/crates/sparq-policy/src/lib.rs
@@ -17,8 +17,9 @@ mod parse;
 pub use compare::{contains, detect_conflicts, Conflict, Containment, Overlap};
 pub use eval::{
     datetime_status, evaluate, matched_prohibition, prohibition_status, purpose_status,
-    recipient_status, DateTimeMatch, Decision, ProhibitionStatus, PurposeMatch, RecipientMatch,
-    Request, ODRL_COUNT, ODRL_DATETIME, ODRL_PURPOSE, ODRL_RECIPIENT,
+    recipient_status, spatial_status, DateTimeMatch, Decision, ProhibitionStatus, PurposeMatch,
+    RecipientMatch, Request, SpatialMatch, ODRL_COUNT, ODRL_DATETIME, ODRL_PURPOSE, ODRL_RECIPIENT,
+    ODRL_SPATIAL,
 };
 pub use model::{Action, Constraint, Duty, Operator, Policy, Rule, Value, ODRL_NS};
 pub use parse::{parse_policy, parse_policy_str};

--- a/crates/sparq-policy/src/model.rs
+++ b/crates/sparq-policy/src/model.rs
@@ -124,7 +124,10 @@ pub enum Operator {
     /// `odrl:gteq` — greater than or equal.
     Gteq,
     /// `odrl:isPartOf` — the request value is a member of / part of the
-    /// right-operand set or hierarchy (set membership in this base case).
+    /// right-operand set, OR — for the taxonomic dimensions `odrl:purpose` and
+    /// `odrl:spatial` — **transitively part-of** a named value under the subsumption
+    /// closure the request supplies (the DPV-purpose taxonomy / spatial region *tree*
+    /// case — see `Request::with_purpose_subsumption`). [OPUS-4.8] sq-z3ve / sq-wukl.
     IsPartOf,
     /// `odrl:isA` — the request value IS the right operand (a type/identity
     /// membership check, treated as equality here).

--- a/crates/sparq-policy/tests/odrl_hierarchy.rs
+++ b/crates/sparq-policy/tests/odrl_hierarchy.rs
@@ -1,0 +1,281 @@
+//! [OPUS-4.8] sq-wukl — the `odrl:spatial` dimension + region `isPartOf` trees.
+//!
+//! This is the SPATIAL twin of the DPV/purpose-taxonomy subsumption that landed in
+//! sq-z3ve (#503, `tests/odrl_eval.rs`). A `spatial isPartOf <Region>` constraint is
+//! satisfied when the request's stated region IS the named region OR is **transitively
+//! part-of** it under the region `isPartOf` tree the request supplies as subsumption
+//! evidence — the SAME caller-supplied closure the purpose taxonomy uses
+//! ([`Request::with_purpose_subsumption`] / [`Request::with_purpose_taxonomy`]). There
+//! is no separate spatial evidence channel: spatial reuses the merged subsumption code
+//! path, so all of the soundness/fail-closed properties of sq-z3ve carry over verbatim.
+//!
+//! The honesty contract (mirrors purpose/recipient/dateTime, sq-q56r/sq-5037/sq-idnv):
+//! the tree is **evidence the request supplies**, never invented. No tree supplied ⇒
+//! exact membership (fully backward compatible), and matching never widens access on an
+//! edge the request did not assert — a missing edge is fail-closed.
+
+use sparq_policy::{
+    evaluate, parse_policy_str, prohibition_status, spatial_status, ProhibitionStatus, Request,
+    SpatialMatch, Value, ODRL_SPATIAL,
+};
+
+const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
+
+fn left(local: &str) -> String {
+    format!("{ODRL}{local}")
+}
+
+// ---------------------------------------------------------------------------
+// Spatial hierarchy: a permission gated on a region grants a request from a
+// sub-region declared isPartOf it (the spatial dual of purpose subsumption).
+// ---------------------------------------------------------------------------
+const EU: &str = "http://publications.europa.eu/resource/authority/country/EU";
+const DE: &str = "http://publications.europa.eu/resource/authority/country/DEU";
+const BERLIN: &str = "https://sws.geonames.org/2950159/"; // Berlin
+const USA: &str = "http://publications.europa.eu/resource/authority/country/USA";
+
+/// "MAY distribute asset-X to recipients in the EU region" — spatial isPartOf EU.
+fn eu_region_permission() -> sparq_policy::Policy {
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/geo> a odrl:Set ; odrl:permission [
+    odrl:action odrl:distribute ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:spatial ; odrl:operator odrl:isPartOf ;
+                      odrl:rightOperand <{EU}> ] ] .
+"#
+    );
+    parse_policy_str(&ttl, "turtle").unwrap()
+}
+
+#[test]
+fn spatial_subregion_is_part_of_region_grants() {
+    let p = eu_region_permission();
+    let base = Request::new(left("distribute")).on("urn:asset/x");
+
+    // Germany isPartOf EU → a sub-region under the named region → ALLOW.
+    let germany = base
+        .clone()
+        .with(ODRL_SPATIAL, Value::Iri(DE.into()))
+        .with_purpose_subsumption(DE, EU);
+    assert!(
+        evaluate(&p, &germany).allow,
+        "a sub-region declared part-of the named region grants"
+    );
+    assert_eq!(
+        spatial_status(&p.permissions[0], &germany),
+        SpatialMatch::Satisfied
+    );
+}
+
+#[test]
+fn spatial_transitive_city_grants() {
+    let p = eu_region_permission();
+    let base = Request::new(left("distribute")).on("urn:asset/x");
+
+    // Berlin isPartOf Germany isPartOf EU — transitive region tree (two hops).
+    let berlin = base
+        .clone()
+        .with(ODRL_SPATIAL, Value::Iri(BERLIN.into()))
+        .with_purpose_subsumption(BERLIN, DE)
+        .with_purpose_subsumption(DE, EU);
+    assert!(
+        evaluate(&p, &berlin).allow,
+        "transitive spatial isPartOf (city in country in region) grants"
+    );
+    assert_eq!(
+        spatial_status(&p.permissions[0], &berlin),
+        SpatialMatch::Satisfied
+    );
+}
+
+#[test]
+fn spatial_bulk_taxonomy_builder_grants() {
+    // The bulk `with_purpose_taxonomy` builder also feeds the spatial dimension —
+    // order-independent closure over a whole region tree at once.
+    let p = eu_region_permission();
+    let req = Request::new(left("distribute"))
+        .on("urn:asset/x")
+        .with(ODRL_SPATIAL, Value::Iri(BERLIN.into()))
+        .with_purpose_taxonomy([(DE, EU), (BERLIN, DE)]);
+    assert!(
+        evaluate(&p, &req).allow,
+        "a bulk-supplied region tree drives the transitive spatial match"
+    );
+}
+
+#[test]
+fn spatial_outside_region_denied() {
+    let p = eu_region_permission();
+    let base = Request::new(left("distribute")).on("urn:asset/x");
+
+    // A region not under EU (no edge reaches it) → definite no.
+    let outside = base
+        .clone()
+        .with(ODRL_SPATIAL, Value::Iri(USA.into()))
+        .with_purpose_subsumption(DE, EU); // an edge, but not for the USA
+    assert!(
+        !evaluate(&p, &outside).allow,
+        "a region outside the named one is denied"
+    );
+    assert_eq!(
+        spatial_status(&p.permissions[0], &outside),
+        SpatialMatch::DefinitelyUnsatisfied
+    );
+}
+
+#[test]
+fn spatial_hierarchy_without_edge_fails_closed() {
+    // THE honesty test: a sub-region is NOT subsumed unless the request actually
+    // supplies the isPartOf edge. No invented subsumption — a missing edge is
+    // fail-closed (and the stated region is then provably != the named one → denied).
+    let p = eu_region_permission();
+    let no_edge = Request::new(left("distribute"))
+        .on("urn:asset/x")
+        .with(ODRL_SPATIAL, Value::Iri(DE.into())); // Germany, but NO isPartOf edge
+    assert!(
+        !evaluate(&p, &no_edge).allow,
+        "without a supplied isPartOf edge a sub-region does NOT grant (no invented subsumption)"
+    );
+    assert_eq!(
+        spatial_status(&p.permissions[0], &no_edge),
+        SpatialMatch::DefinitelyUnsatisfied
+    );
+}
+
+#[test]
+fn spatial_exact_region_still_matches_with_or_without_tree() {
+    // Backward compatibility: the exact named region matches, tree or no tree.
+    let p = eu_region_permission();
+    let base = Request::new(left("distribute")).on("urn:asset/x");
+
+    let exact = base.clone().with(ODRL_SPATIAL, Value::Iri(EU.into()));
+    assert!(evaluate(&p, &exact).allow, "the exact named region matches");
+
+    let exact_with_unrelated_tree = base
+        .with(ODRL_SPATIAL, Value::Iri(EU.into()))
+        .with_purpose_subsumption(BERLIN, DE);
+    assert!(
+        evaluate(&p, &exact_with_unrelated_tree).allow,
+        "an unrelated tree does not break the exact match"
+    );
+}
+
+#[test]
+fn spatial_missing_evidence_unprovable() {
+    let p = eu_region_permission();
+    // No spatial evidence at all → Unprovable → fail-closed.
+    let none = Request::new(left("distribute")).on("urn:asset/x");
+    assert!(
+        !evaluate(&p, &none).allow,
+        "missing spatial evidence fails closed"
+    );
+    assert_eq!(
+        spatial_status(&p.permissions[0], &none),
+        SpatialMatch::Unprovable
+    );
+}
+
+#[test]
+fn spatial_not_constrained_when_absent() {
+    let ttl = format!(
+        r#"@prefix odrl: <{ODRL}> . <urn:pol/ns> a odrl:Set ; odrl:permission [
+           odrl:action odrl:distribute ; odrl:target <urn:asset/x> ] ."#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let req = Request::new(left("distribute"))
+        .on("urn:asset/x")
+        .with(ODRL_SPATIAL, Value::Iri(DE.into()));
+    assert_eq!(
+        spatial_status(&p.permissions[0], &req),
+        SpatialMatch::NotConstrained
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Prohibition dual: a carve-out gated on a spatial region carves out a sub-region
+// declared part-of it; an unrelated region is Withdrawn; missing evidence Ambiguous.
+// ---------------------------------------------------------------------------
+#[test]
+fn spatial_prohibition_dual() {
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/pgeo> a odrl:Set ; odrl:prohibition [
+    odrl:action odrl:distribute ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:spatial ; odrl:operator odrl:isPartOf ;
+                      odrl:rightOperand <{EU}> ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let base = Request::new(left("distribute")).on("urn:asset/x");
+
+    // Germany part-of EU → the carve-out applies (a sub-region IS in the region).
+    let germany = base
+        .clone()
+        .with(ODRL_SPATIAL, Value::Iri(DE.into()))
+        .with_purpose_subsumption(DE, EU);
+    assert_eq!(prohibition_status(&p, &germany), ProhibitionStatus::Applies);
+
+    // A region outside EU → definitely not carved out → Withdrawn.
+    let outside = base
+        .clone()
+        .with(ODRL_SPATIAL, Value::Iri(USA.into()))
+        .with_purpose_subsumption(DE, EU);
+    assert_eq!(
+        prohibition_status(&p, &outside),
+        ProhibitionStatus::Withdrawn
+    );
+
+    // No spatial evidence → unprovable → Ambiguous (deny kept, fail-closed).
+    assert_eq!(prohibition_status(&p, &base), ProhibitionStatus::Ambiguous);
+}
+
+// ---------------------------------------------------------------------------
+// The region tree applies to an explicit isPartOf SET right-operand too.
+// ---------------------------------------------------------------------------
+#[test]
+fn spatial_is_part_of_set_with_hierarchy() {
+    // A constraint naming a SET {EU|USA}; a request stating a narrower region under EU
+    // (via an edge) matches the EU member of the set.
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+<urn:pol/set> a odrl:Set ; odrl:permission [
+    odrl:action odrl:distribute ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:spatial ; odrl:operator odrl:isPartOf ;
+                      odrl:rightOperand "{EU}|{USA}" ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    let germany = Request::new(left("distribute"))
+        .on("urn:asset/x")
+        .with(ODRL_SPATIAL, Value::Str(DE.into()))
+        .with_purpose_subsumption(DE, EU);
+    assert!(
+        evaluate(&p, &germany).allow,
+        "a sub-region under one named set member matches"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cycle-safety: a malformed region tree with a cycle must terminate (and not match
+// a value outside the named region). The closure maintenance in sq-z3ve already
+// tolerates cycles; this pins it at the public spatial-API boundary.
+// ---------------------------------------------------------------------------
+#[test]
+fn spatial_cycle_terminates_and_is_fail_closed() {
+    let p = eu_region_permission(); // gated on EU
+    let base = Request::new(left("distribute")).on("urn:asset/x");
+
+    // A → B → A is a cycle that does NOT reach EU. Must terminate, not match.
+    let cyclic = base
+        .clone()
+        .with(ODRL_SPATIAL, Value::Iri("urn:region/A".into()))
+        .with_purpose_subsumption("urn:region/A", "urn:region/B")
+        .with_purpose_subsumption("urn:region/B", "urn:region/A");
+    assert!(
+        !evaluate(&p, &cyclic).allow,
+        "a cyclic region tree not reaching the named region must terminate and deny"
+    );
+}

--- a/skills/usage-control-policy/SKILL.md
+++ b/skills/usage-control-policy/SKILL.md
@@ -70,11 +70,29 @@ assert_eq!(d.matched_rules.len(), 1);  // the granting permission, for audit
 
 ## Constraint operators
 
-`eq`, `neq`, `lt`, `lteq`, `gt`, `gteq`, `isPartOf` (set membership: `right` is a `|`/space/comma-separated set), `isA` (identity, ≈ `eq`). Numeric (`xsd:integer`/`decimal`/`double`/…) and `xsd:dateTime`/`date` operands compare by magnitude/instant; everything else by IRI/string value. Order comparison on non-orderable values is `false` (fail-closed). `dateTime` ordering compares the lexical form — mixed-offset normalization is a deferred bead.
+`eq`, `neq`, `lt`, `lteq`, `gt`, `gteq`, `isPartOf` (set membership: `right` is a `|`/space/comma-separated set — **or**, for the taxonomic dimensions `purpose`/`spatial`, a transitive subsumption match over a request-supplied closure, see below), `isA` (identity, ≈ `eq`). Numeric (`xsd:integer`/`decimal`/`double`/…) and `xsd:dateTime`/`date` operands compare by magnitude/instant; everything else by IRI/string value. Order comparison on non-orderable values is `false` (fail-closed). `dateTime` ordering compares the lexical form — mixed-offset normalization is a deferred bead.
+
+## `odrl:spatial` region enforcement + region `isPartOf` trees — [OPUS-4.8] sq-wukl
+
+A `spatial` constraint gates a rule to a **geographic region** (`spatial isPartOf <country/EU>`, "anywhere in the EU"). The new left-operand IRI is `ODRL_SPATIAL` (`odrl:spatial`); supply the request's region with `.with(ODRL_SPATIAL, Value::Iri(region))`, gated through the **same** `evaluate` constraint path as every other dimension.
+
+The spatial dimension is **taxonomic**, so it reuses the **same** caller-supplied subsumption closure the DPV purpose taxonomy uses — there is *no* separate spatial evidence channel. Declare the region `isPartOf` tree with `.with_purpose_subsumption(narrower, broader)` (one edge) or `.with_purpose_taxonomy([(n, b), …])` (bulk), and a `spatial isPartOf <EU>` constraint is then satisfied by a request whose stated region is the EU **or transitively part-of** it — `Berlin ⊑ DEU ⊑ EU`.
+
+- **Honesty / fail-closed:** the tree is *the requester's asserted subsumption*, never invented. With **no** edge supplied, `spatial` matching is exact membership (fully backward compatible) and a sub-region does **not** grant a broad-region permission — a missing edge fails closed, like a missing context value. Cycle-safe (the closure tolerates a malformed `A ⊑ B ⊑ A`).
+- **Audit:** `spatial_status(&rule, &request) -> SpatialMatch` (`Satisfied`/`DefinitelyUnsatisfied`/`Unprovable`/`NotConstrained`) is the spatial twin of `purpose_status` — it runs the same subsumption-aware path `evaluate` does.
+
+```rust,ignore
+use sparq_policy::{evaluate, Request, Value, ODRL_SPATIAL};
+// policy: distribute spatial isPartOf <country/EU>
+let req = Request::new("http://www.w3.org/ns/odrl/2/distribute").on("urn:asset/x")
+    .with(ODRL_SPATIAL, Value::Iri("urn:country/DEU".into()))
+    .with_purpose_subsumption("urn:country/DEU", "urn:country/EU"); // DEU ⊑ EU
+assert!(evaluate(&policy, &req).allow); // a sub-region of the named region grants
+```
 
 ## Building the request
 
-`Request::new(action_iri)` then chain `.on(target)`, `.by(party)`, `.with(left_operand_iri, Value)` for each context dimension (`dateTime`, `purpose`, `recipient`, `count`, `spatial`, …), and `.discharge(duty_action_iri)` per discharged duty. `Value` is `Iri` | `Str` | `Num(f64)` | `DateTime(String)`. For purpose specifically, prefer the first-class `.for_purpose(Value)` (sugar over `.with(ODRL_PURPOSE, ..)`; read it back via `req.purpose()`); for the evaluation time prefer `.at(instant)` (sugar over `.with(ODRL_DATETIME, Value::DateTime(..))`; read it back via `req.request_time()`).
+`Request::new(action_iri)` then chain `.on(target)`, `.by(party)`, `.with(left_operand_iri, Value)` for each context dimension (`dateTime`, `purpose`, `recipient`, `count`, `spatial`, …), `.with_purpose_subsumption(narrower, broader)` / `.with_purpose_taxonomy([(n, b), …])` per asserted subsumption edge (the DPV-purpose taxonomy / spatial region trees, above — one closure for both taxonomic dimensions), and `.discharge(duty_action_iri)` per discharged duty. `Value` is `Iri` | `Str` | `Num(f64)` | `DateTime(String)`. For purpose specifically, prefer the first-class `.for_purpose(Value)` (sugar over `.with(ODRL_PURPOSE, ..)`; read it back via `req.purpose()`); for the evaluation time prefer `.at(instant)` (sugar over `.with(ODRL_DATETIME, Value::DateTime(..))`; read it back via `req.request_time()`).
 
 ## `odrl:purpose` enforcement (faithful, fail-closed) — [OPUS-4.8] sq-q56r
 
@@ -82,7 +100,7 @@ A purpose constraint restricts a rule to a stated *purpose of use*. The request 
 
 - **Match → grant; mismatch → deny; missing purpose → fail-closed.** A request stating **no** purpose is *unprovable*: a purpose-gated permission does **not** grant, and a purpose-gated prohibition is **not** withdrawn. "No purpose stated" is **never** treated as "any purpose allowed".
 - **Match semantics (the boundary — do not over-claim):** **exact** IRI/string equality (`eq`/`isA`), or membership in the explicit `isPartOf` purpose *set* the constraint names, or `neq` (≠ the named one; still requires a stated purpose).
-- **DPV / purpose-taxonomy subsumption — [OPUS-4.8] sq-z3ve.** Supply the request a purpose taxonomy with `.with_purpose_subsumption(narrower, broader)` (one `skos:broader`/`rdfs:subClassOf`/`dpv:isSubTypeOf` edge) or the bulk `.with_purpose_taxonomy([(n, b), …])`, and a purpose constraint naming `B` is also satisfied by a stated purpose `P` that is **transitively narrower** than `B` (`P ⊑ B`) — a `research` permission covers `clinical-research`, and a `neq research` carve-out *also* excludes that sub-purpose. **Sound, never over-claimed:** the `⊑` relation is the **caller-supplied transitive closure only** (never inferred from IRI string structure); with no taxonomy supplied it is byte-for-byte the exact-IRI base case, the broader-under-narrower direction never matches, and access is never widened on an unproven relation.
+- **DPV / purpose-taxonomy subsumption — [OPUS-4.8] sq-z3ve.** Supply the request a purpose taxonomy with `.with_purpose_subsumption(narrower, broader)` (one `skos:broader`/`rdfs:subClassOf`/`dpv:isSubTypeOf` edge) or the bulk `.with_purpose_taxonomy([(n, b), …])`, and a purpose constraint naming `B` is also satisfied by a stated purpose `P` that is **transitively narrower** than `B` (`P ⊑ B`) — a `research` permission covers `clinical-research`, and a `neq research` carve-out *also* excludes that sub-purpose. **Sound, never over-claimed:** the `⊑` relation is the **caller-supplied transitive closure only** (never inferred from IRI string structure); with no taxonomy supplied it is byte-for-byte the exact-IRI base case, the broader-under-narrower direction never matches, and access is never widened on an unproven relation. The **same** closure also drives the `odrl:spatial` region tree (above) — one subsumption evidence channel for both taxonomic dimensions.
 - **Audit:** `purpose_status(&rule, &request) -> PurposeMatch` reports exactly what the evaluator checks — `Satisfied` / `DefinitelyUnsatisfied` / `Unprovable` / `NotConstrained` (it runs the same subsumption-aware path `evaluate` does).
 - Through the bridge, purpose stays **one-shot** (checked once at materialization; see the mapping table below) — it has no re-checked-condition analogue, so a changed purpose is re-evaluated on the next `refresh_odrl_grant`.
 
@@ -205,7 +223,8 @@ store.materialize_odrl_permission_conditional(&policy, &req); // policy: recipie
 | `odrl:recipient` / `odrl:assignee` | `isPartOf` (static set) | one `auth:agent` head per member (OR) | ✅ set membership = agent ∈ set | **persisted** (one grant/member) |
 | `odrl:recipient` / `odrl:assignee` | `neq` ("everyone EXCEPT X") | `auth:Public` `ConditionalGrant` + `auth:exceptMatcher` carving out `X` (ACP `noneOf`) | ✅ everyone-except is exactly the ACP `noneOf` shape | **persisted, re-checked per session** ([OPUS-4.8] sq-5037) |
 | `odrl:recipient` / `odrl:assignee` | order (`lt`/`gt`/…) | (none — not meaningful on a recipient) | ❌ | **one-shot** (frozen) |
-| `odrl:purpose` | any | (none — a client app ≠ a purpose-of-use) | ❌ ACP session carries no purpose dimension; client-matcher would over-grant | **one-shot** (frozen) |
+| `odrl:purpose` | any (incl. `isPartOf` DPV hierarchy) | (none — a client app ≠ a purpose-of-use) | ❌ ACP session carries no purpose dimension; client-matcher would over-grant | **one-shot** (frozen) |
+| `odrl:spatial` | any (incl. `isPartOf` region hierarchy) | (none — ACP session carries no region) | ❌ no spatial dimension to re-check | **one-shot** (frozen) ([OPUS-4.8] sq-wukl) |
 | `odrl:dateTime` / time window | `lteq` / `lt` / `gteq` / `gt` | (none — matcher accept-sets are static; no "now") | ❌ ACP has no clock dimension to re-check | **one-shot** (frozen) |
 | `odrl:count` | any | (none — ACP is stateless; no per-session usage counter) | ❌ in the bridge | **one-shot** (frozen) in the bridge — stateful enforcement lives in `sparq-policy`'s `count-enforcement` feature (`evaluate_and_exercise`), not yet wired through ACP |
 | any unrecognised left-operand | any | (none) | ❌ | **one-shot** (frozen) |


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. I am one of several agents @jeswr runs on this account.

## What & why (bead sq-wukl)

Adds the **`odrl:spatial`** region dimension to `sparq-policy` — a `spatial isPartOf <Region>` constraint that gates a permission/prohibition to a geographic region, satisfied when the request's stated region IS the named region OR is **transitively part-of** it (`Berlin ⊑ DEU ⊑ EU`).

### Relationship to #503 (sq-z3ve) — disclosed

This branch was opened before #503 (sq-z3ve) merged. **#503 landed the DPV/purpose-taxonomy subsumption on the same `isPartOf` constraint path** (`Request::with_purpose_subsumption` / `with_purpose_taxonomy`, a transitive-closure `purpose_subsumes` set, dispatched via `compare_constraint`). This PR was therefore **rebased onto current main and de-duplicated down to the genuinely-new spatial dimension**:

- **DROPPED** (now redundant with #503): the duplicate purpose-hierarchy mechanism this branch had added — the `part_of` `child→{parents}` field, the `with_part_of` / `part_of_edges` builders, and the cycle-safe-BFS `is_part_of` rewrite. None of that is reintroduced.
- **KEPT / UNIFIED**: the `ODRL_SPATIAL` left-operand, the `spatial_status` / `SpatialMatch` audit helper, and the spatial subsumption capability — riding on **#503's merged closure**, not a parallel one. The spatial dimension is taxonomic, so it reuses the SAME caller-supplied `purpose_subsumes` closure and the same `with_purpose_subsumption` / `with_purpose_taxonomy` builders (there is **no separate spatial evidence channel**). `compare_constraint` now routes both `odrl:purpose` and `odrl:spatial` through the subsumption-aware `compare_subsumed` (renamed from #503's `compare_purpose`); an `is_subsumable_dimension` helper names the two taxonomic dimensions.

Net diff over main: **spatial-only** — 6 files (`sparq-policy` src/model/lib + README + new `tests/odrl_hierarchy.rs` + the SKILL), no duplicated purpose logic, no leftover conflict markers.

## How (spatial)

- New **`ODRL_SPATIAL`** left-operand IRI; supply the request's region with `.with(ODRL_SPATIAL, Value::Iri(region))`.
- Declare the region `isPartOf` tree with the merged **`.with_purpose_subsumption(narrower, broader)`** (one edge) or **`.with_purpose_taxonomy([(n, b), …])`** (bulk closure). A `spatial isPartOf <EU>` rule is then satisfied by `DEU ⊑ EU` / `Berlin ⊑ DEU ⊑ EU`. Covers permission grants AND the prohibition deny-retraction dual (`prohibition_status`).
- New **`spatial_status(&rule, &request) -> SpatialMatch`** audit helper — the spatial twin of `purpose_status`; it runs the request through the SAME `constraint_status` the evaluator acts on (no claimed-but-unchecked enforcement).

## Honesty / fail-closed (the load-bearing property)

The tree is **the requester's asserted subsumption, never invented** (mirrors purpose/recipient/dateTime, sq-q56r/sq-5037/sq-idnv):

- **No edge supplied ⇒ `spatial` is exact membership** — fully backward compatible.
- A sub-region does **NOT** grant a broad-region permission unless the request **asserts the edge** — a missing edge fails closed, like a missing context value.
- Cycle-safe (the closure tolerates a malformed `A ⊑ B ⊑ A`).
- The audit helper runs the **same** subsumption-aware path the evaluator does.

## Tests

New `tests/odrl_hierarchy.rs` is now **spatial-focused** (11 tests): sub-region grants, transitive city (two hops), bulk-taxonomy builder, outside-region denied, **missing-edge-fails-closed** (the honesty test), exact-region-still-matches, missing-evidence Unprovable, not-constrained, the spatial prohibition dual, `isPartOf`-set-with-hierarchy, and **cycle-termination**. The purpose-taxonomy behaviour is already covered by #503's `tests/odrl_eval.rs` (not duplicated here).

## Scope boundary (honest)

Request-evaluation path only. `compare.rs`'s *static* (request-free) `isPartOf`-subset containment refinement stays a follow-on bead; through the `sparq-solid` ACP bridge `purpose`/`spatial` stay one-shot (ACP carries no purpose/region dimension) — documented in the mapping table.

## Docs (G2)

The crate README, `model`/`eval` rustdoc, and `skills/usage-control-policy/SKILL.md` now describe **both** the merged DPV purpose subsumption **and** the new spatial dimension coherently — as **one** subsumption evidence channel for both taxonomic dimensions. The earlier "README/SKILL tracked this as a deferred bead" claim is removed (it is false on current main — #503 already landed the purpose half).

## Gate

- `cargo build` + `clippy --all-targets -- -D warnings` + tests + doctests **GREEN in BOTH feature states** (default + `count-enforcement`).
- `sparq-solid --features odrl-bridge` clippy clean (consumes the `Request` API; the new field is `pub(crate)` with a `Default`, no external-construction break).
- `scripts/check-privacy-claims.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
