### PR TITLE
feat(sparq-server): connection header-read timeout closes the slow-loris DoS (sq-2gqr) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3551,6 +3551,8 @@ dependencies = [
  "axum",
  "flate2",
  "futures-util",
+ "hyper",
+ "hyper-util",
  "mimalloc",
  "oxrdf 0.3.3",
  "oxrdfxml",

--- a/crates/sparq-server/Cargo.toml
+++ b/crates/sparq-server/Cargo.toml
@@ -75,7 +75,7 @@ access-audit = ["server"]
 # equivalent. Feature unification means the `sparq-core` `sparq-engine` resolves also gains `mmap`,
 # so the WAL-durable `apply_delta` path is live on the shared graph. Without `--persist` the server
 # is in-memory exactly as before (the flag, not the feature, selects durability).
-server = ["dep:sparq-serve", "dep:axum", "dep:tokio", "dep:tower", "dep:tower-http", "dep:tracing", "dep:tracing-subscriber", "dep:futures-util", "dep:serde_json", "dep:flate2", "sparq-core/mmap"]
+server = ["dep:sparq-serve", "dep:axum", "dep:hyper", "dep:hyper-util", "dep:tokio", "dep:tower", "dep:tower-http", "dep:tracing", "dep:tracing-subscriber", "dep:futures-util", "dep:serde_json", "dep:flate2", "sparq-core/mmap"]
 # [OPUS-4.8] (sq-i3xc, lever H5) `zlib-ng`: opt-in, OFF by default, NATIVE-ONLY faster
 # gzip backend (zlib-ng C library) for the server's `Content-Encoding: gzip` request
 # inflate (MultiGzDecoder) — a measured 1.5–3× at ~zero code change. The weak
@@ -212,6 +212,14 @@ spargebra.workspace = true
 # --- async HTTP stack (feature-gated; native only) ---
 # `ws` powers the /subscriptions endpoint (T23, SEPA-style SPARQL subscriptions).
 axum = { version = "0.8", optional = true, default-features = false, features = ["http1", "tokio", "query", "json", "ws"] }
+# [OPUS-4.8] (sq-2gqr) Slow-loris guard: `axum::serve` builds hyper's connection `Builder`
+# internally and never installs a timer, so hyper's HTTP/1 `header_read_timeout` is inert and a
+# slow client holds a connection (and concurrency slot) open forever. `sparq_server::serve` owns
+# the accept loop on hyper's `http1::Builder` directly (with a `TokioTimer` + `header_read_timeout`).
+# Both are already in axum 0.8's own dependency graph, so this adds NO new transitive code — it
+# only names them as direct deps so we can call `Builder`. http1-only (matches axum's config).
+hyper = { version = "1", optional = true, default-features = false, features = ["http1", "server"] }
+hyper-util = { version = "0.1", optional = true, default-features = false, features = ["server", "tokio", "service"] }
 # `sync` adds the watch channel that carries the commit generation to subscription tasks (T23).
 tokio = { version = "1", optional = true, default-features = false, features = ["rt-multi-thread", "macros", "net", "signal", "time", "sync"] }
 # `limit` + `load-shed` power the max-concurrency guard (T15); `util` for ServiceBuilder combinators.

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -365,7 +365,9 @@ matrix under "Security posture".
   for reads. Off by default (back-compat). See "Security posture".
 - **Hardening flags** — `--query-timeout` / `--update-where-timeout` (separate, typically-shorter
   writer-side WHERE deadline that bounds writer-queue **head-of-line blocking** from a slow
-  UPDATE, `sq-nulp`) / `--max-body-bytes` / `--max-concurrent` /
+  UPDATE, `sq-nulp`) / `--max-body-bytes` / `--max-concurrent` / `--header-read-timeout`
+  (slow-loris guard: caps how long a connection may take to send its complete request-header block,
+  closing it — and freeing the concurrency slot — when exceeded; default 15s, `sq-2gqr`) /
   `--max-results` / `--max-query-rows` (coarse memory cap) / `--max-query-bytes`
   (byte-accounted memory cap, `sq-s5is`) / `--max-decompress-ratio` (zip-bomb guard) /
   `--service-allow*` (SERVICE SSRF egress) / `--max-subscriptions*` / (feature `brtpf`)

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -2582,6 +2582,7 @@ pub async fn serve<F>(
 where
     F: std::future::Future<Output = ()> + Send + 'static,
 {
+    use futures_util::FutureExt;
     use hyper_util::rt::{TokioIo, TokioTimer};
     use hyper_util::service::TowerToHyperService;
 
@@ -2637,7 +2638,14 @@ where
             // WebSocket handshake depends on it.
             let conn = builder.serve_connection(io, hyper_service).with_upgrades();
             let mut conn = std::pin::pin!(conn);
-            let mut signal_closed = std::pin::pin!(signal_tx.closed());
+            // `.fuse()` is load-bearing (mirrors axum's own graceful-shutdown loop): a bare
+            // `watch::Receiver::closed()` future panics with `async fn resumed after completion`
+            // if it is polled again after it has resolved. Once the shutdown signal fires, the
+            // loop keeps running to DRAIN the connection (`conn.as_mut().await`), and `tokio::select!`
+            // would re-poll the already-completed `signal_closed` on the next iteration. Fusing it
+            // makes that branch terminated (`is_terminated()`); `select!` skips it, so the shutdown
+            // path fires `graceful_shutdown()` exactly once and then quietly drains to completion.
+            let mut signal_closed = std::pin::pin!(signal_tx.closed().fuse());
 
             loop {
                 tokio::select! {
@@ -2648,6 +2656,7 @@ where
                         break;
                     }
                     _ = &mut signal_closed => {
+                        tracing::trace!(target: "sparq_server", "shutdown signal in connection task, starting graceful shutdown");
                         conn.as_mut().graceful_shutdown();
                     }
                 }

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -142,6 +142,21 @@ pub struct ServerConfig {
     pub max_body_bytes: usize,
     /// Maximum in-flight requests; excess requests are shed with 429.
     pub max_concurrent: usize,
+    /// [OPUS-4.8] (sq-2gqr) **Slow-loris guard — connection header-read deadline.** The maximum
+    /// time a freshly-accepted HTTP/1 connection may take to transmit its COMPLETE request-header
+    /// block. A client that dribbles headers byte-by-byte (the classic slow-loris) otherwise holds
+    /// a connection — and, behind the `concurrency_limit`, a concurrency slot — open indefinitely;
+    /// [`max_concurrent`] such clients starve every legitimate caller. Enforced at hyper's HTTP/1
+    /// connection layer (`http1().header_read_timeout`), so it fires BEFORE the request ever
+    /// reaches a handler — which is exactly why the existing [`query_timeout`] (a per-request
+    /// engine deadline) and the [`max_body_bytes`] / load-shed guards do NOT cover it: those all
+    /// run AFTER the headers are fully parsed. The connection is closed when the deadline elapses.
+    ///
+    /// `None` disables it (back to the unbounded-header-read behaviour `axum::serve` ships — see
+    /// the rationale on [`serve`]). Default 15s. Distinct from the slower [`query_timeout`] (30s)
+    /// because reading a header block is sub-second on any healthy client; 15s is generous
+    /// headroom for a slow but honest network without leaving the slot open for minutes.
+    pub header_read_timeout: Option<Duration>,
     /// Maximum SELECT result rows. Exceeding it is an honest 413 refusal (the engine
     /// aborts evaluation via the row budget), never a silent truncation.
     pub max_results: Option<usize>,
@@ -411,6 +426,13 @@ impl Default for ServerConfig {
             update_where_timeout: None,
             max_body_bytes: 1024 * 1024, // 1 MiB
             max_concurrent: 32,
+            // [OPUS-4.8] sq-2gqr: a 15s header-read deadline closes the slow-loris hole ON by
+            // default. `axum::serve` configures hyper's auto-Builder WITHOUT a timer, so hyper's
+            // own 30s header_read_timeout default is inert (it requires a Timer) — meaning the
+            // out-of-the-box stack has NO header deadline at all. `crate::serve` installs a
+            // TokioTimer and wires this value. 0 / env-unset keeps the guard; SPARQ_HEADER_READ_TIMEOUT=0
+            // disables it. See ServerConfig::header_read_timeout.
+            header_read_timeout: Some(Duration::from_secs(15)),
             max_results: None,
             // [OPUS-4.8] sq-ebii: memory cap OFF by default (no surprise refusals on an
             // unconfigured server); an operator exposing the endpoint opts a ceiling in.
@@ -478,7 +500,9 @@ impl ServerConfig {
     /// `SPARQ_UPDATE_WHERE_TIMEOUT` ([OPUS-4.8] sq-nulp: the separate, typically-shorter
     /// writer-side WHERE deadline that bounds writer-queue head-of-line blocking from a slow
     /// UPDATE; seconds, `0`/unset disables — the update WHERE budget is then the plain
-    /// `query_timeout`), `SPARQ_MAX_BODY_BYTES`, `SPARQ_MAX_CONCURRENT`, `SPARQ_MAX_RESULTS`,
+    /// `query_timeout`), `SPARQ_MAX_BODY_BYTES`, `SPARQ_MAX_CONCURRENT`,
+    /// `SPARQ_HEADER_READ_TIMEOUT` ([OPUS-4.8] sq-2gqr: the slow-loris connection header-read
+    /// deadline in seconds; `0` disables, default 15), `SPARQ_MAX_RESULTS`,
     /// `SPARQ_MAX_QUERY_ROWS` ([OPUS-4.8] sq-ebii: the coarse memory cap; `0` disables) and
     /// `SPARQ_MAX_DECOMPRESS_RATIO` ([OPUS-4.8] sq-ebii: the zip-bomb guard; `0` refuses gzip
     /// bodies) environment variables — plus, with the `time-travel` feature,
@@ -510,6 +534,11 @@ impl ServerConfig {
         }
         if let Some(n) = env_parse::<usize>("SPARQ_MAX_CONCURRENT") {
             cfg.max_concurrent = n.max(1);
+        }
+        // [OPUS-4.8] sq-2gqr: slow-loris header-read deadline (seconds); `0` disables it (an
+        // unbounded header read, the pre-fix behaviour), anything else sets the deadline.
+        if let Some(secs) = env_parse::<u64>("SPARQ_HEADER_READ_TIMEOUT") {
+            cfg.header_read_timeout = (secs > 0).then(|| Duration::from_secs(secs));
         }
         if let Some(n) = env_parse::<usize>("SPARQ_MAX_RESULTS") {
             cfg.max_results = (n > 0).then_some(n);
@@ -2514,6 +2543,164 @@ pub fn harden(routes: Router, config: &ServerConfig) -> Router {
         }
     } else {
         routes
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-2gqr) Serve loop with a connection header-read deadline (slow-loris guard)
+// ---------------------------------------------------------------------------
+
+/// Serves `app` on `listener` until `shutdown` resolves, with a hyper HTTP/1
+/// **header-read deadline** ([`ServerConfig::header_read_timeout`]) that closes the
+/// slow-loris DoS.
+///
+/// **Why this exists instead of `axum::serve`.** `axum::serve` builds hyper's connection
+/// `Builder` internally and exposes no hook to configure it, and — critically — it never
+/// installs a [`hyper_util::rt::TokioTimer`]. hyper's HTTP/1 `header_read_timeout` (which
+/// would otherwise default to 30s) is *inert without a timer* and silently does nothing. So
+/// the stock `axum::serve` stack has **no header-read deadline at all**: a client that opens a
+/// connection and then dribbles request-header bytes (or never finishes the header block) holds
+/// the connection — and, behind [`harden`]'s `concurrency_limit`, a concurrency slot — open
+/// indefinitely. [`ServerConfig::max_concurrent`] such clients starve every real caller. None of
+/// the existing guards cover this: the per-request [`ServerConfig::query_timeout`] is an engine
+/// deadline that only starts once a full request has been parsed; `max_body_bytes` and load-shed
+/// likewise act *after* the headers are read.
+///
+/// This loop is a faithful port of `axum::serve`'s own accept + graceful-shutdown loop
+/// (per-connection task, watch-channel drain, `serve_connection(...).with_upgrades()` so the
+/// `/subscriptions` WebSocket upgrade still works) with exactly one behavioural addition: the
+/// connection builder installs a `TokioTimer` and sets `header_read_timeout`. `None` opts back
+/// out to the unbounded behaviour. axum is configured HTTP/1-only (no `http2` feature), so this
+/// uses hyper's `http1::Builder` directly — the smallest builder that carries the knob we need.
+#[cfg(feature = "server")]
+pub async fn serve<F>(
+    listener: tokio::net::TcpListener,
+    app: Router,
+    header_read_timeout: Option<Duration>,
+    shutdown: F,
+) -> std::io::Result<()>
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    use hyper_util::rt::{TokioIo, TokioTimer};
+    use hyper_util::service::TowerToHyperService;
+
+    // `signal_tx`: dropped (closed) once `shutdown` resolves — every connection task watches it
+    // and begins a graceful drain. `close_rx`: each task holds a clone; the loop waits for them
+    // all to drop, which means all connections have finished, before returning.
+    let (signal_tx, signal_rx) = tokio::sync::watch::channel(());
+    tokio::spawn(async move {
+        shutdown.await;
+        tracing::trace!(target: "sparq_server", "shutdown signal received, starting graceful drain");
+        drop(signal_rx);
+    });
+
+    // `close_tx` outlives the loop; each connection task holds a `close_tx.subscribe()` receiver
+    // and drops it when the connection finishes. `close_tx.closed()` then resolves only once every
+    // task's receiver is gone — i.e. all connections have fully drained.
+    let (close_tx, _close_rx) = tokio::sync::watch::channel(());
+    drop(_close_rx); // the loop itself does not hold a connection slot
+
+    loop {
+        let (stream, _remote) = tokio::select! {
+            conn = listener.accept() => match conn {
+                Ok(c) => c,
+                // A transient accept error (e.g. EMFILE / a peer that vanished mid-handshake)
+                // must not kill the server — yield and keep accepting, exactly as axum does.
+                Err(_e) => {
+                    tracing::trace!(target: "sparq_server", error = %_e, "accept error (continuing)");
+                    tokio::task::yield_now().await;
+                    continue;
+                }
+            },
+            _ = signal_tx.closed() => {
+                // Shutdown signalled: stop accepting and let in-flight connections drain.
+                tracing::trace!(target: "sparq_server", "accept loop stopping (graceful shutdown)");
+                break;
+            }
+        };
+
+        let io = TokioIo::new(stream);
+        let hyper_service = TowerToHyperService::new(app.clone());
+        let signal_tx = signal_tx.clone();
+        let close_rx = close_tx.subscribe();
+
+        tokio::spawn(async move {
+            let mut builder = hyper::server::conn::http1::Builder::new();
+            // The header-read deadline is the slow-loris guard. It REQUIRES a timer (hyper panics
+            // otherwise / silently no-ops on the auto builder), which is the bug in the stock
+            // `axum::serve` path this whole function exists to fix.
+            if let Some(t) = header_read_timeout {
+                builder.timer(TokioTimer::new()).header_read_timeout(t);
+            }
+            // `.with_upgrades()` keeps the HTTP/1 `Upgrade` working — the `/subscriptions`
+            // WebSocket handshake depends on it.
+            let conn = builder.serve_connection(io, hyper_service).with_upgrades();
+            let mut conn = std::pin::pin!(conn);
+            let mut signal_closed = std::pin::pin!(signal_tx.closed());
+
+            loop {
+                tokio::select! {
+                    result = conn.as_mut() => {
+                        if let Err(_err) = result {
+                            tracing::trace!(target: "sparq_server", error = %_err, "connection ended with error");
+                        }
+                        break;
+                    }
+                    _ = &mut signal_closed => {
+                        conn.as_mut().graceful_shutdown();
+                    }
+                }
+            }
+            drop(close_rx);
+        });
+    }
+
+    // Drain: `close_tx.closed()` resolves once every connection task's `close_tx.subscribe()`
+    // receiver has dropped — i.e. all in-flight connections have finished (mirrors axum's
+    // own graceful-shutdown drain).
+    tracing::trace!(
+        target: "sparq_server",
+        tasks = close_tx.receiver_count(),
+        "waiting for in-flight connections to drain"
+    );
+    close_tx.closed().await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod header_read_timeout_config_tests {
+    //! [OPUS-4.8] (sq-2gqr) The slow-loris header-read deadline lives in `ServerConfig` so it is
+    //! configurable + testable in isolation; the END-TO-END behaviour (a partial-header socket is
+    //! actually closed by `serve`) is the integration suite in `tests/hardening.rs`. These pin the
+    //! config contract.
+    use super::*;
+
+    #[test]
+    fn slow_loris_guard_is_on_by_default() {
+        // The whole point of sq-2gqr: a fresh, unconfigured server must NOT be vulnerable. A
+        // generous-but-finite 15s deadline ships ON.
+        assert_eq!(
+            ServerConfig::default().header_read_timeout,
+            Some(Duration::from_secs(15)),
+            "header-read deadline must be ON by default (slow-loris guard)"
+        );
+    }
+
+    #[test]
+    fn header_read_timeout_is_independent_of_query_timeout() {
+        // Distinct from the engine's per-request query_timeout (a connection-layer vs evaluation
+        // bound). Setting one must not move the other.
+        let cfg = ServerConfig {
+            header_read_timeout: Some(Duration::from_secs(3)),
+            query_timeout: Some(Duration::from_secs(99)),
+            ..ServerConfig::default()
+        };
+        assert_eq!(cfg.header_read_timeout, Some(Duration::from_secs(3)));
+        assert_eq!(cfg.query_timeout, Some(Duration::from_secs(99)));
+        // It is opt-out-able (an operator who really wants the old unbounded behaviour).
+        let off = ServerConfig { header_read_timeout: None, ..ServerConfig::default() };
+        assert_eq!(off.header_read_timeout, None);
     }
 }
 

--- a/crates/sparq-server/src/lib.rs
+++ b/crates/sparq-server/src/lib.rs
@@ -84,9 +84,9 @@ pub mod subscriptions;
 
 #[cfg(feature = "server")]
 pub use http::{
-    bind_posture, harden, router, AppState, AuthPosture, BindPosture, PinnedGen, ServerConfig,
-    GLOBAL_POD,
-}; // [OPUS-4.8] sq-o4qf: bind_posture / BindPosture for the bind gate; sq-zcby: AuthPosture folds the --auth-token gate into it
+    bind_posture, harden, router, serve, AppState, AuthPosture, BindPosture, PinnedGen,
+    ServerConfig, GLOBAL_POD,
+}; // [OPUS-4.8] sq-o4qf: bind_posture / BindPosture for the bind gate; sq-zcby: AuthPosture folds the --auth-token gate into it; sq-2gqr: serve = the accept loop with the slow-loris header-read deadline
 
 /// [OPUS-4.8] (sq-4w18) The SERVICE egress allowlist config type, re-exported at the
 /// crate root next to [`ServerConfig`].

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -342,7 +342,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 eprintln!(
                     "usage: sparq-server [--addr HOST:PORT] [--allow-remote] [--persist DIR] \
                      [--auth-token TOKEN] [--auth-token-read] [--format FMT] \
-                     [--query-timeout SECS] [--update-where-timeout SECS] [--max-body-bytes N] [--max-concurrent N] \
+                     [--query-timeout SECS] [--update-where-timeout SECS] [--header-read-timeout SECS] \
+                     [--max-body-bytes N] [--max-concurrent N] \
                      [--max-results N] [--max-query-rows N] [--max-query-bytes N] [--max-decompress-ratio N] \
                      [--max-subscriptions N] \
                      [--max-subscriptions-per-conn N]{time_travel}{service}{brtpf}{shacl} [--verbose] \
@@ -449,7 +450,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     eprintln!("loaded {} triples", graph.len());
     eprintln!(
-        "guards: query-timeout={} update-where-timeout={} max-body-bytes={} max-concurrent={} max-results={} \
+        "guards: query-timeout={} update-where-timeout={} header-read-timeout={} max-body-bytes={} max-concurrent={} max-results={} \
          max-query-rows={} max-query-bytes={} max-decompress-ratio={}x max-subscriptions={} \
          max-subscriptions-per-conn={}",
         config
@@ -458,6 +459,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // [OPUS-4.8] sq-nulp: writer-side WHERE deadline bounding head-of-line blocking.
         config
             .update_where_timeout
+            .map_or("off".into(), |t| format!("{}s", t.as_secs())),
+        // [OPUS-4.8] sq-2gqr: connection-layer header-read deadline (slow-loris guard).
+        config
+            .header_read_timeout
             .map_or("off".into(), |t| format!("{}s", t.as_secs())),
         config.max_body_bytes,
         config.max_concurrent,

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -67,6 +67,10 @@
 //!                             [unset, env SPARQ_UPDATE_WHERE_TIMEOUT]
 //!   --max-body-bytes N        maximum request body in bytes              [1048576, env SPARQ_MAX_BODY_BYTES]
 //!   --max-concurrent N        maximum in-flight requests (429 beyond)    [32, env SPARQ_MAX_CONCURRENT]
+//!   --header-read-timeout S   [OPUS-4.8 sq-2gqr] slow-loris guard: max SECONDS a connection may take
+//!                             to send its complete request-header block (closes the connection +
+//!                             frees the concurrency slot if exceeded), 0 disables
+//!                             [15, env SPARQ_HEADER_READ_TIMEOUT]
 //!   --max-results N           maximum SELECT rows (413 beyond), 0 off    [unlimited, env SPARQ_MAX_RESULTS]
 //!   --max-query-rows N        [OPUS-4.8 sq-ebii] coarse MEMORY CAP: working-set row ceiling on EVERY
 //!                             query form (413 beyond), 0 off             [unlimited, env SPARQ_MAX_QUERY_ROWS]
@@ -170,6 +174,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "--max-concurrent" => {
                 let n: usize = parse_flag(&mut args, "--max-concurrent")?;
                 config.max_concurrent = n.max(1);
+            }
+            // [OPUS-4.8] sq-2gqr: slow-loris connection header-read deadline (seconds); 0 disables
+            // it (unbounded header read — the pre-fix behaviour). Default 15s. See
+            // ServerConfig::header_read_timeout.
+            "--header-read-timeout" => {
+                let secs: u64 = parse_flag(&mut args, "--header-read-timeout")?;
+                config.header_read_timeout = (secs > 0).then(|| Duration::from_secs(secs));
             }
             "--max-results" => {
                 let n: usize = parse_flag(&mut args, "--max-results")?;
@@ -536,6 +547,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         BindPosture::RemoteRefused { message } => return Err(message.into()),
     }
 
+    // [OPUS-4.8] sq-2gqr: capture the slow-loris header-read deadline BEFORE `config` is moved
+    // into `AppState` — `sparq_server::serve` (not `axum::serve`) installs it at the hyper
+    // connection layer to close the slow-loris DoS (see ServerConfig::header_read_timeout).
+    let header_read_timeout = config.header_read_timeout;
     // [OPUS-4.8] sq-7cxr: `try_with_config` surfaces a durable-open error (corrupt persist dir,
     // unwritable path) as a clean startup error + non-zero exit, rather than panicking.
     let state = AppState::try_with_config(graph, config)?;
@@ -543,9 +558,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     eprintln!("sparq-server listening on http://{addr}  (SPARQL endpoint: /sparql, subscriptions: ws://{addr}/subscriptions)");
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+    // [OPUS-4.8] sq-2gqr: NOT `axum::serve` — it never installs a timer, so hyper's header-read
+    // deadline is inert there and a slow-loris client holds a connection (and concurrency slot)
+    // open forever. `sparq_server::serve` is the same accept + graceful-drain loop WITH the
+    // header-read deadline wired in.
+    sparq_server::serve(listener, app, header_read_timeout, shutdown_signal()).await?;
     Ok(())
 }
 

--- a/crates/sparq-server/tests/hardening.rs
+++ b/crates/sparq-server/tests/hardening.rs
@@ -931,3 +931,142 @@ async fn security_headers_on_auth_gated_response() {
         "auth-refusal must carry Cache-Control: no-store"
     );
 }
+
+// ---------------------------------------------------------------------------
+// (sq-2gqr) [OPUS-4.8] Slow-loris guard — the connection header-read deadline.
+//
+// `axum::serve` never installs a timer, so hyper's HTTP/1 header_read_timeout is inert and a
+// client that opens a connection then dribbles (or simply never finishes) its request-header
+// block holds the connection — and a concurrency slot — open forever. `sparq_server::serve`
+// fixes this by owning the accept loop and wiring a TokioTimer + header_read_timeout. These
+// tests drive the REAL `serve` loop over a raw TCP socket (reqwest always sends a complete
+// header block, so it cannot exercise this — we have to be the misbehaving client).
+// ---------------------------------------------------------------------------
+
+use std::net::SocketAddr;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// Spawn the real `sparq_server::serve` accept loop (NOT `axum::serve`) with the given
+/// header-read deadline, returning the bound address for a raw-socket client.
+async fn spawn_serve(config: ServerConfig) -> SocketAddr {
+    let header_read_timeout = config.header_read_timeout;
+    let graph = Graph::load_str(DATA, "turtle").unwrap();
+    let app = router(AppState::with_config(graph, config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        sparq_server::serve(listener, app, header_read_timeout, std::future::pending::<()>())
+            .await
+            .unwrap();
+    });
+    addr
+}
+
+/// A slow-loris connection: open a socket, send a partial request line + ONE header, then
+/// never send the terminating blank line. With a short `header_read_timeout` the SERVER must
+/// close the connection (a read returns 0 / a reset) within roughly the deadline. Without the
+/// fix the read would block until the test's own timeout, proving the connection is held open.
+#[tokio::test]
+async fn slow_loris_partial_headers_closed_by_deadline() {
+    let config = ServerConfig {
+        header_read_timeout: Some(Duration::from_millis(400)),
+        ..ServerConfig::default()
+    };
+    let addr = spawn_serve(config).await;
+
+    let mut sock = TcpStream::connect(addr).await.unwrap();
+    // A well-formed request LINE and one header, but NO terminating CRLFCRLF — the header block
+    // is never completed, exactly as a slow-loris client behaves.
+    sock.write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\n")
+        .await
+        .unwrap();
+    sock.flush().await.unwrap();
+
+    // The server's header-read deadline (400ms) must close the connection well within this
+    // generous 5s cap. `read` returning Ok(0) is a clean close; an Err is a reset — both mean
+    // the server let go of the slot. A timeout here means the connection was held open (the bug).
+    let started = std::time::Instant::now();
+    let mut buf = [0u8; 256];
+    let outcome = tokio::time::timeout(Duration::from_secs(5), sock.read(&mut buf)).await;
+    let elapsed = started.elapsed();
+    match outcome {
+        Ok(Ok(0)) | Ok(Err(_)) => {} // connection closed / reset by the server — the guard fired
+        // hyper may emit a 408 Request Timeout status line before closing; that's also a pass —
+        // it still means the server let go rather than holding the slot.
+        Ok(Ok(n)) => {
+            let head = String::from_utf8_lossy(&buf[..n]);
+            assert!(
+                head.contains("408") || head.contains("400"),
+                "server responded but did not signal a header-read timeout: {head:?}"
+            );
+        }
+        Err(_) => panic!(
+            "slow-loris connection was NOT closed within 5s — the header-read deadline did not fire \
+             (connection + concurrency slot held open: the slow-loris DoS)"
+        ),
+    }
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "connection closed but only after {elapsed:?} — far beyond the 400ms deadline"
+    );
+}
+
+/// With the deadline DISABLED (`None`), the partial-header connection is NOT proactively closed
+/// by the server within a short window — proving the guard is what does the closing (and is
+/// genuinely opt-out-able), not some unrelated default. We only assert it stays open briefly
+/// (then we drop it), so the test is fast and not flaky.
+#[tokio::test]
+async fn slow_loris_held_open_when_deadline_disabled() {
+    let config = ServerConfig { header_read_timeout: None, ..ServerConfig::default() };
+    let addr = spawn_serve(config).await;
+
+    let mut sock = TcpStream::connect(addr).await.unwrap();
+    sock.write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\n")
+        .await
+        .unwrap();
+    sock.flush().await.unwrap();
+
+    // Within a short window the server must NOT have closed the (incomplete) connection.
+    let mut buf = [0u8; 64];
+    let outcome = tokio::time::timeout(Duration::from_millis(700), sock.read(&mut buf)).await;
+    assert!(
+        outcome.is_err(),
+        "with header_read_timeout=None the connection should stay open (read blocks), \
+         but the server closed/answered it: {outcome:?}"
+    );
+}
+
+/// Sanity: the new `serve` loop still serves a COMPLETE request normally (it is a faithful port
+/// of axum's accept loop, not just a timeout). Drives a full HTTP/1.1 request over a raw socket
+/// and asserts a 200 with the hardened security headers, so we know nothing regressed.
+#[tokio::test]
+async fn serve_loop_handles_complete_request() {
+    let config = ServerConfig {
+        header_read_timeout: Some(Duration::from_secs(15)),
+        ..ServerConfig::default()
+    };
+    let addr = spawn_serve(config).await;
+
+    let mut sock = TcpStream::connect(addr).await.unwrap();
+    sock.write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .await
+        .unwrap();
+    sock.flush().await.unwrap();
+
+    let mut resp = Vec::new();
+    tokio::time::timeout(Duration::from_secs(5), sock.read_to_end(&mut resp))
+        .await
+        .expect("complete request must be answered promptly")
+        .unwrap();
+    let text = String::from_utf8_lossy(&resp);
+    assert!(
+        text.starts_with("HTTP/1.1 200"),
+        "complete request through sparq_server::serve must return 200: {text:?}"
+    );
+    // The hardened stack still runs on this path — the X-Content-Type-Options header must land.
+    assert!(
+        text.to_ascii_lowercase().contains("x-content-type-options: nosniff"),
+        "security headers must still be stamped by the serve loop: {text:?}"
+    );
+}

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -137,7 +137,7 @@ Library surface re-exported from `sparq_server` (behind the default `server` fea
   (**`time-travel` feature only**).
 - `struct ServerConfig { query_timeout: Option<Duration>, update_where_timeout: Option<Duration>,
   max_body_bytes: usize,
-  max_concurrent: usize, max_results: Option<usize>, max_query_rows: Option<usize>,
+  max_concurrent: usize, header_read_timeout: Option<Duration>, max_results: Option<usize>, max_query_rows: Option<usize>,
   max_query_bytes: Option<usize>,
   max_decompress_ratio: usize, max_subscriptions: usize, max_subscriptions_per_conn: usize,
   verbose: bool, redact_logs: bool, allow_remote: bool, auth_token: Option<String>, auth_token_read: bool,
@@ -147,7 +147,10 @@ Library surface re-exported from `sparq_server` (behind the default `server` fea
   UPDATE that bounds writer-queue **head-of-line blocking** from a slow update — `None` =
   use `query_timeout`, `sq-nulp`; `max_query_rows` = coarse memory cap; `max_query_bytes` =
   byte-accounted memory cap that also prices row WIDTH + computed-literal size — `sq-s5is`;
-  `max_decompress_ratio` = zip-bomb guard — `sq-ebii`.)
+  `max_decompress_ratio` = zip-bomb guard — `sq-ebii`;
+  `header_read_timeout` = **slow-loris guard**: max time a connection may take to send its
+  complete request-header block, enforced at hyper's HTTP/1 connection layer by
+  `sparq_server::serve` — `None` disables; default 15s — `sq-2gqr`.)
   `auth_token` (set: gates the write surface with a Bearer token, constant-time compared;
   `None`: no write auth) and `auth_token_read` (gate reads too) are honoured by the library
   `router` itself — embedders get the gate for free (`sq-zcby`).
@@ -162,6 +165,15 @@ Library surface re-exported from `sparq_server` (behind the default `server` fea
 - `fn harden(routes: axum::Router, config: &ServerConfig) -> axum::Router` — wrap any
   router in the production middleware (panic→500, concurrency-limit→429, body-limit→413,
   JSON error bodies, optional trace).
+- `async fn serve(listener: tokio::net::TcpListener, app: axum::Router, header_read_timeout:
+  Option<Duration>, shutdown: impl Future<Output=()>) -> std::io::Result<()>` — the accept +
+  graceful-drain loop the binary runs **instead of `axum::serve`** (`sq-2gqr`). It is a faithful
+  port of axum's own loop (per-connection task, watch-channel drain, `with_upgrades()` so the
+  `/subscriptions` WebSocket still works) with one addition: it installs a `hyper_util` TokioTimer
+  and hyper's HTTP/1 `header_read_timeout`. **Why:** `axum::serve` never installs a timer, so
+  hyper's header-read deadline is inert there and a slow-loris client holds a connection (and a
+  `concurrency_limit` slot) open indefinitely; this loop closes that hole. Pass `None` to opt back
+  out to the unbounded behaviour.
 - Re-exports for cache layers/tests: `PinnedGen`, `GLOBAL_POD: &str`
   (`"urn:sparq:pod:global"`), and `sparq_serve::{Epoch, PodEpochs, PodId}`.
 - Serializer/negotiation helpers (always compiled, no `server` feature): module
@@ -561,6 +573,7 @@ env overrides the default.
 | `--update-where-timeout SECS` | `SPARQ_UPDATE_WHERE_TIMEOUT` | unset (`0`/unset = use `--query-timeout`) | **separate, typically-SHORTER writer-side WHERE deadline for SPARQL UPDATE** — bounds writer-queue **head-of-line blocking** from a slow update (the single sequenced writer is released within this window instead of holding it for the full read timeout); the update WHERE budget is `min(query_timeout, update_where_timeout)` → slow update `503` (`sq-nulp`) |
 | `--max-body-bytes N` | `SPARQ_MAX_BODY_BYTES` | `1048576` | body cap → `413` |
 | `--max-concurrent N` | `SPARQ_MAX_CONCURRENT` | `32` | in-flight cap, load-shed → `429` |
+| `--header-read-timeout SECS` | `SPARQ_HEADER_READ_TIMEOUT` | `15` (`0`=off) | **slow-loris guard**: max time a connection may take to send its complete request-header block — enforced at hyper's HTTP/1 connection layer by `sparq_server::serve` (NOT `axum::serve`, which never installs a timer so its header deadline is inert), so it fires BEFORE a handler and frees the concurrency slot a dribbling client would otherwise hold forever; connection closed when exceeded (`sq-2gqr`) |
 | `--max-results N` | `SPARQ_MAX_RESULTS` | unlimited (`0`=off) | result/solution cap (SELECT + CONSTRUCT/DESCRIBE WHERE-solutions + EXPLAIN ANALYZE; not ASK/GSP-read/UPDATE) → honest `413` (not truncation) |
 | `--max-query-rows N` | `SPARQ_MAX_QUERY_ROWS` | unlimited (`0`=off) | **memory cap** (coarse): working-set ROW ceiling on **every** form → honest `413` (`sq-ebii`) |
 | `--max-query-bytes N` | `SPARQ_MAX_QUERY_BYTES` | unlimited (`0`=off) | **byte-accounted memory cap**: prices working-set row WIDTH (`rows × vars × id-size`) + computed-literal bytes on **every** form → honest `413` (`sq-s5is`) |


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change by an agent acting for @jeswr. Re-review the [OPUS-4.8] code when Fable is available.

## What & why (sq-2gqr)

`axum::serve` builds hyper's connection `Builder` internally and **never installs a timer**, so hyper's HTTP/1 `header_read_timeout` is *inert* (it requires a `Timer` to take effect — verified against the resolved hyper-util 0.1.20 / hyper 1.10.1 source). The stock stack therefore has **no header-read deadline at all**: a client that opens a connection then dribbles request-header bytes (or simply never finishes the header block) holds the connection — and, behind `harden()`'s `concurrency_limit`, a **concurrency slot** — open indefinitely. `max_concurrent` (default 32) such clients starve every legitimate caller.

None of the existing guards cover this: `query_timeout` is an *engine* deadline that only starts once a full request is parsed; `max_body_bytes` and load-shed likewise act *after* the headers are read. This is the transport-level slow-loris vector the bead calls out as distinct from sq-ebii / sq-s5is.

## The fix

A new `sparq_server::serve` accept loop — a faithful port of axum's own accept + graceful-drain loop (per-connection task, watch-channel drain, `serve_connection(...).with_upgrades()` so the `/subscriptions` WebSocket handshake still works) with **one** behavioural addition: it installs a `hyper_util` `TokioTimer` and sets hyper's `http1` `header_read_timeout`. `main.rs` now calls it instead of `axum::serve`.

- Knob: `ServerConfig::header_read_timeout: Option<Duration>` — **default 15s, ON**.
- `SPARQ_HEADER_READ_TIMEOUT` env (`0` disables) + `--header-read-timeout SECS` flag.
- `None` / `0` opts back out to the prior unbounded behaviour.

axum is configured HTTP/1-only (no `http2` feature), so this uses hyper's `http1::Builder` directly. `hyper` / `hyper-util` are added as **direct** deps (server-feature only) — both already in axum 0.8's dependency graph, so **no new transitive code**.

## Tests

`tests/hardening.rs` (raw TCP, driving the **real** `serve` loop — reqwest always sends a complete header block so it cannot exercise this):
- `slow_loris_partial_headers_closed_by_deadline` — a partial-header socket is closed within the deadline (the fix);
- `slow_loris_held_open_when_deadline_disabled` — with `None` the connection is *not* proactively closed (proves the guard is what closes it, and that it is genuinely opt-out-able);
- `serve_loop_handles_complete_request` — a complete request still returns `200` + the hardened security headers (no regression).

Plus unit tests for the default-ON value and its independence from `query_timeout`.

**Verified live against the binary:** normal query `200`, WebSocket upgrade `HTTP/1.1 101 Switching Protocols`, slow-loris partial-header connection closed at the configured deadline, clean SIGTERM graceful drain.

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` clean — default features AND with all opt-in server features (`audit-log,access-audit,time-travel,service,geo,federation-descriptors,tpf,brtpf`); lib clean in the `--no-default-features` (server-off) state too. (The `--no-default-features --all-targets` test-compile failure is pre-existing on `origin/main` — the integration tests are inherently `server`-feature-only.)
- Full `sparq-server` test suite green (0 failures); workspace builds.
- `rustfmt --check` is *informational* in this repo (pending the deferred one-time `cargo fmt --all`); new code matches surrounding style — not running `cargo fmt` to avoid pulling in the repo-wide reformat.
- Privacy-claims gate: PASS. G2 public-api→SKILL: PASS (README + `skills/http-server/SKILL.md` updated for the new public `serve`, the `ServerConfig` field, and the flag/env).

## Follow-up

Filed **sq-lodb** for the distinct slow-**body**-read vector (a client that completes its headers then dribbles the request body stays under `max_body_bytes` while holding the slot) — not covered by a header-read deadline; complementary, not a replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)