### PR TITLE
feat(sparq-shacl): SHACL-AF sh:nodeByExpression + gated sht:Validate harness (sq-3w6n) [OPUS-4.8]

### DIFF
--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -150,6 +150,14 @@ value node `v` is a violation when its `sh:expression` node expression does NOT
 evaluate to `{ true }` for `v`. On a node shape `v` is the focus node; on a
 property shape it is each path value node.
 
+**`sh:nodeByExpression` constraint** (`sh:NodeByExpressionConstraintComponent`,
+SHACL-AF) — like `sh:node`, but the node shape is *computed* by a node expression
+rather than fixed. For each value node `v`, the expression is evaluated against
+`v` as focus to a set of node-shape terms; `v` is a violation when it does NOT
+conform to one of them. A constant IRI expression is the `sh:node` special case
+(it evaluates to that one shape); a path-values expression locates the shape(s)
+dynamically. An expression result that names no parsed shape is skipped (lenient).
+
 Rules honour `sh:condition` (fire only for focus nodes conforming to every
 condition shape), `sh:order` (ascending; a rule sees earlier groups' inferences)
 and `sh:deactivated`. The schedule is **iterated to a fixpoint** bounded by
@@ -163,7 +171,11 @@ compiled in. A gated W3C conformance harness
 ([`tests/w3c_node_expr.rs`](tests/w3c_node_expr.rs)) drives the `sht:EvalNodeExpr`
 suite for the implemented forms — all evaluation entries (focus/constant/list/path/
 filter/intersection/union plus the registry's function operators) pass; it
-self-skips when the suite is not fetched.
+self-skips when the suite is not fetched. A companion gated harness
+([`tests/w3c_node_expr_constraints.rs`](tests/w3c_node_expr_constraints.rs)) drives
+the suite's two `sht:Validate` constraint entries (`expression-001`,
+`nodeByExpression-001`) end-to-end through `validate`, comparing the produced
+report to the expected one.
 
 Targets: `sh:targetNode`, `sh:targetClass` (with `rdfs:subClassOf*` closure),
 implicit class targets (a shape that is itself an `rdfs:Class`),

--- a/crates/sparq-shacl/src/eval.rs
+++ b/crates/sparq-shacl/src/eval.rs
@@ -674,6 +674,51 @@ impl<'a> Validator<'a> {
                     }
                 }
             }
+            // [OPUS-4.8] (sq-3w6n, `shacl-af`) `sh:nodeByExpression`
+            // (`sh:NodeByExpressionConstraintComponent`): for each value node `v`,
+            // the node expression is evaluated against `v` as focus to a set of
+            // node-shape terms; `v` is violated when it does NOT conform to one of
+            // them. (Per SHACL-AF, `sh:node` is the special case of a constant IRI
+            // node-shape expression.) Result-set evaluation borrows the model
+            // immutably, so the (value → shape ids) work is collected up front and
+            // the recursion-safe `conforms` (which needs `&mut self`) runs after.
+            #[cfg(feature = "shacl-af")]
+            Component::NodeByExpression(idx) => {
+                let mut checks: Vec<(Term, Vec<usize>)> = Vec::with_capacity(values.len());
+                {
+                    let data = self.data.graph();
+                    let expr = &self.shapes.expressions[*idx];
+                    for v in values {
+                        let shape_terms =
+                            crate::rules::eval_parsed_expr(data, self.shapes, expr, v);
+                        // Resolve each computed shape term to a parsed shape id. An
+                        // unparsed term (no such shape) is skipped — lenient, per
+                        // this crate's policy.
+                        let sids: Vec<usize> = shape_terms
+                            .iter()
+                            .filter_map(|s| self.shapes.by_node(s))
+                            .collect();
+                        checks.push((v.clone(), sids));
+                    }
+                }
+                for (v, sids) in checks {
+                    for s in sids {
+                        if !self.conforms(&v, s) {
+                            out.push(
+                                self.result(
+                                    sid,
+                                    focus,
+                                    Some(v.clone()),
+                                    "NodeByExpressionConstraintComponent",
+                                    "Value does not conform to the node shape computed by \
+                                 sh:nodeByExpression"
+                                        .to_string(),
+                                ),
+                            );
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/crates/sparq-shacl/src/lib.rs
+++ b/crates/sparq-shacl/src/lib.rs
@@ -469,9 +469,11 @@ mod tests {
     }
 }
 
-// [OPUS-4.8] (sq-mk9n, `shacl-af`) The `sh:expression` constraint
-// (`sh:ExpressionConstraintComponent`): a value node violates when the node
-// expression does not evaluate to `{ true }` for that value.
+// [OPUS-4.8] (sq-mk9n / sq-3w6n, `shacl-af`) The two SHACL-AF node-expression
+// constraints: `sh:expression` (`sh:ExpressionConstraintComponent`) — a value
+// node violates when the node expression does not evaluate to `{ true }` — and
+// `sh:nodeByExpression` (`sh:NodeByExpressionConstraintComponent`) — a value node
+// violates when it does not conform to a node shape the expression computes.
 #[cfg(feature = "shacl-af")]
 #[cfg(test)]
 mod expression_tests {
@@ -530,6 +532,88 @@ mod expression_tests {
         assert!(
             r.conforms,
             "age 5 >= 3 => matchAll true => exists true: {}",
+            r.to_text()
+        );
+    }
+
+    // ---- [OPUS-4.8] (sq-3w6n) sh:nodeByExpression ----
+
+    #[test]
+    fn node_by_expression_constant_iri_violates_nonconforming_value() {
+        // The W3C `nodeByExpression-001` shape: a property shape whose value nodes
+        // must conform to the node shape an expression computes. Here the expression
+        // is the constant IRI `ex:AssignedToShape` (per SHACL-AF, an IRI expression
+        // evaluating to { ex:AssignedToShape } — the `sh:node` special case). The
+        // assignee lacks the required `ex:email`, so it does NOT conform => one
+        // violation with the value node and component IRI.
+        let data = g("ex:issue a ex:Issue ; ex:assignedTo ex:anon . ex:anon a ex:Person .");
+        let shapes = g(
+            "ex:AssignedToShape a sh:NodeShape ; \
+               sh:property [ sh:path ex:email ; sh:minCount 1 ] . \
+             ex:Issue a rdfs:Class, sh:NodeShape ; \
+               sh:property [ sh:path ex:assignedTo ; sh:nodeByExpression ex:AssignedToShape ] .",
+        );
+        let r = validate(&data, &shapes);
+        assert!(!r.conforms, "{}", r.to_text());
+        assert!(
+            r.results.iter().any(|res| res
+                .source_component
+                .ends_with("NodeByExpressionConstraintComponent")
+                && res.value.as_ref().map(|v| v.to_string()).as_deref()
+                    == Some("<http://example.org/anon>")),
+            "expected a NodeByExpression violation for ex:anon: {}",
+            r.to_text()
+        );
+    }
+
+    #[test]
+    fn node_by_expression_conforming_value_passes() {
+        // The same constraint, but the assignee carries the required email, so it
+        // conforms to the computed node shape and there is no violation.
+        let data = g(
+            "ex:issue a ex:Issue ; ex:assignedTo ex:jane . \
+             ex:jane a ex:Person ; ex:email \"jane@ex.org\" .",
+        );
+        let shapes = g(
+            "ex:AssignedToShape a sh:NodeShape ; \
+               sh:property [ sh:path ex:email ; sh:minCount 1 ] . \
+             ex:Issue a rdfs:Class, sh:NodeShape ; \
+               sh:property [ sh:path ex:assignedTo ; sh:nodeByExpression ex:AssignedToShape ] .",
+        );
+        let r = validate(&data, &shapes);
+        assert!(
+            r.conforms,
+            "ex:jane has an email => conforms: {}",
+            r.to_text()
+        );
+    }
+
+    #[test]
+    fn node_by_expression_path_computed_shape() {
+        // A dynamically-computed shape: the node expression is a path-values
+        // expression that locates the shape at `ex:hasShape` from the value node.
+        // ex:obs/ex:hasShape => ex:RangeShape (minInclusive 0); ex:obs's measure is
+        // -1, so it must NOT conform => one violation on the value node.
+        let data = g(
+            "ex:obs a ex:Observation ; ex:value -1 ; ex:hasShape ex:RangeShape . \
+             ex:s a ex:DataShape ; ex:item ex:obs .",
+        );
+        let shapes = g(
+            "ex:RangeShape a sh:NodeShape ; \
+               sh:property [ sh:path ex:value ; sh:minInclusive 0 ] . \
+             ex:DataShape a rdfs:Class, sh:NodeShape ; \
+               sh:property [ sh:path ex:item ; \
+                 sh:nodeByExpression [ sh:path ex:hasShape ] ] .",
+        );
+        let r = validate(&data, &shapes);
+        assert!(!r.conforms, "value -1 < 0 must violate: {}", r.to_text());
+        assert!(
+            r.results.iter().any(|res| res
+                .source_component
+                .ends_with("NodeByExpressionConstraintComponent")
+                && res.value.as_ref().map(|v| v.to_string()).as_deref()
+                    == Some("<http://example.org/obs>")),
+            "expected a NodeByExpression violation for ex:obs: {}",
             r.to_text()
         );
     }

--- a/crates/sparq-shacl/src/model.rs
+++ b/crates/sparq-shacl/src/model.rs
@@ -93,6 +93,15 @@ pub enum Component {
     /// parsed node expression is held there, off the public `Component` enum).
     #[cfg(feature = "shacl-af")]
     Expression(usize),
+    /// [OPUS-4.8] (sq-3w6n, `shacl-af`) `sh:nodeByExpression` — the SHACL-AF
+    /// *Node-by-Expression Constraint* (`sh:NodeByExpressionConstraintComponent`):
+    /// for each value node `v`, the node expression is evaluated against `v` as
+    /// focus to a set of node-shape terms `s`; `v` is violated when it does NOT
+    /// conform to some `s`. (Like `sh:node`, but the shape is computed by the
+    /// expression rather than fixed.) The index is into
+    /// [`ShapesModel::expressions`] (shared store with `sh:expression`).
+    #[cfg(feature = "shacl-af")]
+    NodeByExpression(usize),
 }
 
 /// [OPUS-4.8] A declared `sh:parameter` of a SPARQL-based constraint component
@@ -304,37 +313,54 @@ impl ShapesModel {
         m
     }
 
-    /// [OPUS-4.8] (sq-mk9n, `shacl-af`) Parses `sh:expression` on every shape into
-    /// a [`Component::Expression`]. Inline filter shapes used by the expression are
-    /// registered first (so they are conformance-checkable), then the expressions
-    /// are parsed and attached.
+    /// [OPUS-4.8] (sq-mk9n / sq-3w6n, `shacl-af`) Parses the two SHACL-AF
+    /// node-expression constraints — `sh:expression`
+    /// (→ [`Component::Expression`]) and `sh:nodeByExpression`
+    /// (→ [`Component::NodeByExpression`]) — on every shape. Inline filter shapes
+    /// used by the expressions, and the node shapes a `sh:nodeByExpression`
+    /// expression names as a constant, are registered first (so they are
+    /// conformance-checkable), then the expressions are parsed and attached.
     #[cfg(feature = "shacl-af")]
     fn parse_expression_constraints(&mut self, shapes_graph: &Graph) {
         let g = GraphView::new(shapes_graph);
-        // Collect (shape_id, expression_term) for every shape carrying sh:expression.
-        let mut pending: Vec<(usize, Term)> = Vec::new();
+        // Collect (shape_id, expression_term, is_node_by_expr) for every shape
+        // carrying sh:expression or sh:nodeByExpression.
+        let mut pending: Vec<(usize, Term, bool)> = Vec::new();
         for sid in 0..self.shapes.len() {
             let node = self.shapes[sid].node.clone();
             for expr in g.objects(&node, &sh("expression")) {
-                pending.push((sid, expr));
+                pending.push((sid, expr, false));
+            }
+            for expr in g.objects(&node, &sh("nodeByExpression")) {
+                pending.push((sid, expr, true));
             }
         }
         // Register any inline filter shapes the expressions reference (best-effort)
         // so `sh:filterShape` / function filter shapes resolve at eval time.
-        for (_, expr) in &pending {
+        for (_, expr, is_nbe) in &pending {
             self.register_expression_shapes(shapes_graph, expr, 0);
+            // A `sh:nodeByExpression` whose expression names a node shape as a
+            // constant IRI must have that shape parsed so conformance can be
+            // checked at eval time (it may not be a target-bearing root).
+            if *is_nbe && matches!(expr, Term::NamedNode(_)) {
+                self.ensure_shape(shapes_graph, expr);
+            }
         }
         // Parse each expression (immutable borrow) and attach the component.
-        let parsed: Vec<(usize, crate::rules::NodeExpr)> = pending
+        let parsed: Vec<(usize, crate::rules::NodeExpr, bool)> = pending
             .into_iter()
-            .filter_map(|(sid, expr)| {
-                crate::rules::parse_node_expr(&g, self, &expr).map(|ne| (sid, ne))
+            .filter_map(|(sid, expr, is_nbe)| {
+                crate::rules::parse_node_expr(&g, self, &expr).map(|ne| (sid, ne, is_nbe))
             })
             .collect();
-        for (sid, expr) in parsed {
+        for (sid, expr, is_nbe) in parsed {
             let idx = self.expressions.len();
             self.expressions.push(expr);
-            self.shapes[sid].components.push(Component::Expression(idx));
+            self.shapes[sid].components.push(if is_nbe {
+                Component::NodeByExpression(idx)
+            } else {
+                Component::Expression(idx)
+            });
         }
     }
 

--- a/crates/sparq-shacl/tests/w3c_node_expr_constraints.rs
+++ b/crates/sparq-shacl/tests/w3c_node_expr_constraints.rs
@@ -1,0 +1,365 @@
+//! [OPUS-4.8] (sq-3w6n) Manifest-driven runner for the W3C SHACL **node
+//! expression** test suite's `sht:Validate` entries — the `constraints/`
+//! subdirectory of `node-expr` (`expression-001`, `nodeByExpression-001`).
+//!
+//! These are full validation tests (not `sht:EvalNodeExpr` node-expression
+//! evaluations — those are covered by `w3c_node_expr.rs`): a data graph is
+//! validated against a shapes graph and the produced report is compared to the
+//! expected `sh:ValidationReport`. They exercise the SHACL-AF **constraint**
+//! surface — `sh:expression` (`sh:ExpressionConstraintComponent`, sq-mk9n) and
+//! `sh:nodeByExpression` (`sh:NodeByExpressionConstraintComponent`, sq-3w6n) —
+//! end to end through the public `validate` entry point.
+//!
+//! ## Two gates, both opt-in
+//!
+//!   * **Feature gate** — the whole runner is `#[cfg(feature = "shacl-af")]`; the
+//!     two constraint components it exercises are themselves feature-gated, so
+//!     with the feature off the file compiles to nothing.
+//!   * **Suite gate** — the suite is fetched by `./fetch-shacl-tests.sh` into
+//!     `tests/shacl/` (gitignored). When absent the test SKIPS itself so
+//!     `cargo test --workspace` stays green on a fresh checkout.
+//!
+//! The report-comparison policy mirrors `w3c_core.rs`: `sh:conforms` must match,
+//! and the result multisets must correspond 1:1 where each expected result's
+//! stated `sh:focusNode` / `sh:resultPath` / `sh:value` / `sh:resultSeverity` /
+//! `sh:sourceConstraintComponent` / `sh:sourceShape` / `sh:resultMessage` agree
+//! (blank nodes match any blank node). `sh:sourceConstraint` (a SHACL-AF-only
+//! result field this crate does not surface on `ValidationResult`) is not
+//! compared — the constraint-component IRI + source shape already pin the result.
+
+#![cfg(feature = "shacl-af")]
+
+use oxrdf::Term;
+use sparq_core::Graph;
+use sparq_shacl::view::GraphView;
+use sparq_shacl::{validate, Path, ValidationResult};
+use std::collections::BTreeMap;
+use std::path::{Path as FsPath, PathBuf};
+
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const MF: &str = "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#";
+const SHT: &str = "http://www.w3.org/ns/shacl-test#";
+const SH: &str = "http://www.w3.org/ns/shacl#";
+
+/// Pass-rate floor: the two `sht:Validate` entries in `node-expr/constraints/`
+/// (`expression-001`, `nodeByExpression-001`) at the pinned suite commit. A
+/// regression below this fails the build.
+const BASELINE_PASS: usize = 2;
+
+fn suite_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/shacl/data-shapes/shacl12-test-suite/tests/node-expr/constraints")
+}
+
+#[test]
+fn w3c_shacl_node_expr_constraints_suite() {
+    let root = suite_root();
+    if !root.exists() {
+        eprintln!(
+            "SKIP: W3C SHACL node-expr constraints suite not present at {} — run crates/sparq-shacl/fetch-shacl-tests.sh",
+            root.display()
+        );
+        return;
+    }
+    let mut score = Scoreboard::default();
+    walk_manifest(&root.join("manifest.ttl"), &mut score);
+
+    let (mut pass, mut fail, mut skip) = (0, 0, 0);
+    println!("\nW3C SHACL node-expr constraints suite scoreboard");
+    for (id, outcome) in &score.outcomes {
+        match outcome {
+            Outcome::Pass => {
+                pass += 1;
+                println!("  PASS {id}");
+            }
+            Outcome::Fail(why) => {
+                fail += 1;
+                println!("  FAIL {id}: {why}");
+            }
+            Outcome::Skip(why) => {
+                skip += 1;
+                println!("  SKIP {id}: {why}");
+            }
+        }
+    }
+    println!("TOTAL pass {pass} fail {fail} skip {skip}");
+    assert_eq!(
+        fail, 0,
+        "SHACL node-expr constraints: {fail} entries produced the wrong report"
+    );
+    assert!(
+        pass >= BASELINE_PASS,
+        "SHACL node-expr constraints pass count regressed: {pass} < baseline {BASELINE_PASS} (skipped {skip})"
+    );
+}
+
+#[derive(Default)]
+struct Scoreboard {
+    /// id -> outcome, kept in a BTreeMap so the scoreboard is stable.
+    outcomes: BTreeMap<String, Outcome>,
+}
+
+enum Outcome {
+    Pass,
+    Fail(String),
+    Skip(String),
+}
+
+fn file_iri(path: &FsPath) -> String {
+    format!("file://{}", path.display())
+}
+
+fn iri_to_path(iri: &str) -> Option<PathBuf> {
+    iri.strip_prefix("file://").map(PathBuf::from)
+}
+
+fn load(path: &FsPath) -> Result<Graph, String> {
+    let text =
+        std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    sparq_shacl::load_turtle_with_base(&text, &file_iri(path))
+}
+
+/// Recursively walks `mf:include`s; runs every `sht:Validate` entry.
+fn walk_manifest(path: &FsPath, score: &mut Scoreboard) {
+    let path = match path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let g = match load(&path) {
+        Ok(g) => g,
+        Err(e) => {
+            score.outcomes.insert(
+                path.display().to_string(),
+                Outcome::Fail(format!("parse: {e}")),
+            );
+            return;
+        }
+    };
+    let view = GraphView::new(&g);
+    let manifests: Vec<Term> = view
+        .triples(None, Some(RDF_TYPE), Some(&iri(&format!("{MF}Manifest"))))
+        .into_iter()
+        .map(|[s, _, _]| s)
+        .collect();
+    for m in &manifests {
+        for inc in view.objects(m, &format!("{MF}include")) {
+            if let Term::NamedNode(n) = &inc {
+                if let Some(p) = iri_to_path(n.as_str()) {
+                    walk_manifest(&p, score);
+                }
+            }
+        }
+        for head in view.objects(m, &format!("{MF}entries")) {
+            for entry in view.list(&head) {
+                let id = match &entry {
+                    Term::NamedNode(n) => n.as_str().to_string(),
+                    other => other.to_string(),
+                };
+                let outcome = run_entry(&path, &g, &view, &entry)
+                    .unwrap_or_else(|e| Outcome::Fail(format!("harness error: {e}")));
+                score.outcomes.insert(id, outcome);
+            }
+        }
+    }
+}
+
+fn run_entry(file: &FsPath, g: &Graph, view: &GraphView, entry: &Term) -> Result<Outcome, String> {
+    let is_validate = view
+        .objects(entry, RDF_TYPE)
+        .iter()
+        .any(|t| matches!(t, Term::NamedNode(n) if n.as_str() == format!("{SHT}Validate")));
+    if !is_validate {
+        return Ok(Outcome::Skip("not sht:Validate".into()));
+    }
+
+    let action = view
+        .object(entry, &format!("{MF}action"))
+        .ok_or("entry has no mf:action")?;
+    let graph_of = |pred: &str| -> Result<Option<Graph>, String> {
+        match view.object(&action, &format!("{SHT}{pred}")) {
+            Some(Term::NamedNode(n)) => {
+                let p = iri_to_path(n.as_str()).ok_or_else(|| format!("non-file graph IRI {n}"))?;
+                if p == file {
+                    Ok(None) // the test document itself — reuse the loaded graph
+                } else {
+                    load(&p).map(Some)
+                }
+            }
+            other => Err(format!("missing/odd {pred}: {other:?}")),
+        }
+    };
+    let data = graph_of("dataGraph")?;
+    let shapes = graph_of("shapesGraph")?;
+    let report = validate(data.as_ref().unwrap_or(g), shapes.as_ref().unwrap_or(g));
+
+    let exp_node = view
+        .object(entry, &format!("{MF}result"))
+        .ok_or("entry has no mf:result")?;
+    let exp_conforms = matches!(
+        view.object(&exp_node, &format!("{SH}conforms")),
+        Some(Term::Literal(l)) if l.value() == "true"
+    );
+    if exp_conforms != report.conforms {
+        return Ok(Outcome::Fail(format!(
+            "conforms: expected {exp_conforms}, got {} ({} results)",
+            report.conforms,
+            report.results.len()
+        )));
+    }
+    let expected: Vec<Expected> = view
+        .objects(&exp_node, &format!("{SH}result"))
+        .iter()
+        .map(|r| Expected::parse(view, r))
+        .collect::<Result<_, _>>()?;
+    if expected.len() != report.results.len() {
+        return Ok(Outcome::Fail(format!(
+            "result count: expected {}, got {} — {}",
+            expected.len(),
+            report.results.len(),
+            summarize(&report.results)
+        )));
+    }
+    if !bipartite_match(
+        &expected,
+        &report.results,
+        &mut vec![false; expected.len()],
+        0,
+    ) {
+        return Ok(Outcome::Fail(format!(
+            "results do not correspond — got {}",
+            summarize(&report.results)
+        )));
+    }
+    Ok(Outcome::Pass)
+}
+
+fn summarize(rs: &[ValidationResult]) -> String {
+    let items: Vec<String> = rs
+        .iter()
+        .map(|r| {
+            format!(
+                "[focus {} comp {} value {}]",
+                r.focus_node,
+                r.source_component.rsplit('#').next().unwrap_or(""),
+                r.value
+                    .as_ref()
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "-".into())
+            )
+        })
+        .collect();
+    items.join(" ")
+}
+
+/// One expected validation result. Absent properties are left unconstrained.
+struct Expected {
+    focus: Option<Term>,
+    path: Option<Path>,
+    has_path: bool,
+    value: Option<Term>,
+    has_value: bool,
+    severity: Option<String>,
+    component: Option<String>,
+    source_shape: Option<Term>,
+    messages: Vec<Term>,
+}
+
+impl Expected {
+    fn parse(view: &GraphView, node: &Term) -> Result<Expected, String> {
+        let path_term = view.object(node, &format!("{SH}resultPath"));
+        let path = match &path_term {
+            Some(t) => Some(Path::parse(view, t).map_err(|e| format!("expected path: {e}"))?),
+            None => None,
+        };
+        let value = view.object(node, &format!("{SH}value"));
+        Ok(Expected {
+            focus: view.object(node, &format!("{SH}focusNode")),
+            has_path: path_term.is_some(),
+            path,
+            has_value: value.is_some(),
+            value,
+            severity: match view.object(node, &format!("{SH}resultSeverity")) {
+                Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+                _ => None,
+            },
+            component: match view.object(node, &format!("{SH}sourceConstraintComponent")) {
+                Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+                _ => None,
+            },
+            source_shape: view.object(node, &format!("{SH}sourceShape")),
+            messages: view.objects(node, &format!("{SH}resultMessage")),
+        })
+    }
+
+    fn matches(&self, a: &ValidationResult) -> bool {
+        if let Some(f) = &self.focus {
+            if !term_matches(f, &a.focus_node) {
+                return false;
+            }
+        }
+        if self.has_path != a.path.is_some() || (self.has_path && self.path != a.path) {
+            return false;
+        }
+        if self.has_value != a.value.is_some() {
+            return false;
+        }
+        if let (Some(e), Some(av)) = (&self.value, &a.value) {
+            if !term_matches(e, av) {
+                return false;
+            }
+        }
+        if let Some(s) = &self.severity {
+            if s != &a.severity {
+                return false;
+            }
+        }
+        if let Some(c) = &self.component {
+            if c != &a.source_component {
+                return false;
+            }
+        }
+        if let Some(s) = &self.source_shape {
+            if !term_matches(s, &a.source_shape) {
+                return false;
+            }
+        }
+        let actual_messages = a.effective_messages();
+        self.messages.iter().all(|m| actual_messages.contains(m))
+    }
+}
+
+/// Term correspondence across graphs: exact, except blank nodes match any blank
+/// node (they have no stable cross-graph identity).
+fn term_matches(expected: &Term, actual: &Term) -> bool {
+    match (expected, actual) {
+        (Term::BlankNode(_), Term::BlankNode(_)) => true,
+        _ => expected == actual,
+    }
+}
+
+/// Backtracking perfect matching: every expected result claims a distinct actual
+/// result it matches (counts already verified equal).
+fn bipartite_match(
+    expected: &[Expected],
+    actual: &[ValidationResult],
+    used: &mut Vec<bool>,
+    i: usize,
+) -> bool {
+    if i == expected.len() {
+        return true;
+    }
+    for (j, a) in actual.iter().enumerate() {
+        if !used[j] && expected[i].matches(a) {
+            used[j] = true;
+            if bipartite_match(expected, actual, used, i + 1) {
+                return true;
+            }
+            used[j] = false;
+        }
+    }
+    false
+}
+
+fn iri(s: &str) -> Term {
+    Term::NamedNode(oxrdf::NamedNode::new_unchecked(s))
+}

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -270,12 +270,21 @@ parent's focus nodes.
 violates when its `sh:expression` node expression does NOT evaluate to `{ true }`
 (value = focus on a node shape; each path value on a property shape).
 
+**`sh:nodeByExpression` constraint** (`sh:NodeByExpressionConstraintComponent`):
+like `sh:node`, but the node shape is *computed* by a node expression. For each
+value node `v`, the expression is evaluated against `v` as focus to a set of
+node-shape terms; `v` violates when it does NOT conform to one of them. A constant
+IRI expression is the `sh:node` special case; an expression result naming no parsed
+shape is skipped (lenient).
+
 API: `apply_rules(data, shapes)`, `apply_rules_with_model(data, shapes, &model)`
 (amortise shape parsing), `expand(data, shapes) -> Graph`, the node-expression
 seam `eval_node_expression(data, shapes, expr, focus) -> Option<Vec<Term>>`, and
 the conformance primitive `conforms(data, shapes, shape_node) -> ConformanceCheck`
 (call `.holds(node)` per focus). A gated W3C harness (`tests/w3c_node_expr.rs`)
-drives the `sht:EvalNodeExpr` suite — all evaluation entries pass (self-skips when
+drives the `sht:EvalNodeExpr` suite — all evaluation entries pass; a companion
+harness (`tests/w3c_node_expr_constraints.rs`) drives the suite's two `sht:Validate`
+entries (`sh:expression` / `sh:nodeByExpression`) end-to-end (both self-skip when
 the suite is not fetched).
 
 ## Gotchas / feature flags / prerequisites


### PR DESCRIPTION
> 🤖 SPARQ agent — automated change. Please review.

Closes **sq-3w6n** (follow-up to sq-mk9n). OPT-IN behind the `shacl-af` cargo feature; the base SHACL Core + SHACL-SPARQL path is entirely unaffected when the feature is off.

## What

1. **`sh:nodeByExpression`** (`sh:NodeByExpressionConstraintComponent`) — the SHACL-AF node-by-expression constraint. Like `sh:node`, but the node shape is *computed* by a node expression rather than fixed. For each value node `v`, the expression is evaluated against `v` as focus to a set of node-shape terms; `v` is a violation when it does NOT conform to one of them. A constant IRI expression is the `sh:node` special case (per the SHACL-AF spec); a path-values expression resolves the shape dynamically. An expression result that names no parsed shape is skipped (lenient, per crate policy).
   - `model.rs`: new `Component::NodeByExpression(usize)`; the existing `sh:expression` parse pass is extended to also collect `sh:nodeByExpression`, register a constant-IRI shape so conformance is checkable, and attach the right component.
   - `eval.rs`: evaluates the expression per value node (collecting work up front since result evaluation borrows the model immutably), then conformance-checks via the existing recursion-safe `conforms` memo (so cyclic shape references terminate).

2. **Gated `sht:Validate` harness** ([`tests/w3c_node_expr_constraints.rs`](crates/sparq-shacl/tests/w3c_node_expr_constraints.rs)) — a manifest runner over the W3C node-expr suite's `constraints/` subdir, which `w3c_node_expr.rs` deliberately SKIPS (it runs only `sht:EvalNodeExpr`). Validates each `sht:Validate` entry (`expression-001`, `nodeByExpression-001`) end to end through the public `validate` and compares the report (conforms + a bipartite result correspondence on focus/path/value/severity/component/sourceShape/messages), mirroring `w3c_core.rs`. **Feature-gated** (`#[cfg(feature = "shacl-af")]`) and **suite-gated** (self-skips when the fetched suite is absent, so `cargo test --workspace` stays green on a fresh checkout).

`expression-001` already passed with sq-mk9n's `sh:expression`; both entries now pass through the new harness. Unit tests added for the constant-IRI, conforming, and path-computed-shape forms. README + `shacl-validation` SKILL.md updated for the new public `Component` variant.

## Honesty / scope

- The newer `shacl12-test-suite/tests/core/node` tree carries its *own* `nodeByExpression-001` `sht:Validate` entry (constant-IRI form — now passing with this impl) plus many SHACL-1.2-only core constraints no harness walks today. Covering that tree is out of scope for this bead (it needs a SKIP-tolerant harness with its own floor) and is filed as **sq-yca1**.
- No `sh:sourceConstraint` field was added to `ValidationResult` (a SHACL-AF-only result field); the component IRI + source shape already pin every result the suite checks.

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + full `cargo test` — all green in **both** feature states (default and `shacl-af`).
- Privacy-claims gate (predicate-form soundness) and G2 public-api→SKILL gate both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)