### PR TITLE
docs(federated-planning): document the sparq-fedclient brTPF wire codec (sq-9wqw) [OPUS-4.8]

### DIFF
--- a/skills/federated-planning/SKILL.md
+++ b/skills/federated-planning/SKILL.md
@@ -282,6 +282,35 @@ since:
   `FragBinding`s via `solutions(...)` (a fragment server speaks triples, not
   SPARQL-Results-JSON, so their `FederatedSource::execute` is a deliberate `Unsupported` that
   points at `solutions`).
+  - **brTPF binding-block wire codec** (the `wire` module, `sq-6ihg`, follow-up to the
+    server's `sq-dxhb`): the brTPF bind-join attaches a SET of upstream solution mappings (a
+    `&[FragBinding]` block, at most `maxMpR`) to each fragment request, and that block is
+    re-sent on every request of a bind nested-loop join. The sparq server parses it from a
+    **line-oriented TEXT wire** — one mapping per line, space-separated `position=term` pairs,
+    each term fully N-Triples-decorated — which is readable but verbose: it repeats the
+    `s=`/`p=`/`o=` key and the `<…>`/`"…"`/`^^<…>` framing on every term. The `wire` module
+    adds the **compact, self-describing BINARY mapping wire** the bead asks for
+    (`encode_bindings` / `decode_bindings`) the client can emit instead, plus the text-wire
+    writer (`encode_bindings_text`) so a client can speak EITHER form over the same
+    `FragBinding` model (the server already parses the text one). The binary form's twofold
+    compactness win: a 1-byte per-mapping header bitmask records which of `s`/`p`/`o` the
+    mapping binds, so a position term carries **no** name bytes (the header bit IS the name),
+    and a 1-byte kind tag distinguishes IRI / blank / literal so the bare lexical bytes follow
+    length-prefixed with **no** `<>`/`""` framing. A binding over an arbitrary (non-position)
+    variable name still round-trips losslessly via an overflow EXTRA section, and the binary
+    wire carries literals with embedded `=`, whitespace, or newlines that the one-mapping-
+    per-line text wire cannot represent (the text writer drops a non-position variable — it
+    has no brTPF slot). The container leads with a 4-byte magic (`BINARY_MAGIC`, ASCII `bTPF`)
+    + a 1-byte `BINARY_VERSION` so a future revision is detectable, and `decode_bindings`
+    validates every length against the remaining input, so a truncated / bad-magic / bad-
+    version / bad-kind / varint-overflow buffer is a clean `WireError`, never a panic or OOB
+    read (the crate is `forbid(unsafe_code)`). Position keys decode in a deterministic
+    canonical `s`→`p`→`o` order, and the empty mapping μ₀ is skipped on encode (it does not
+    restrict a fragment) exactly as the server's `parse_bindings` skips an all-blank line.
+    **HONEST scope — a codec only:** it converts `&[FragBinding]` ↔ bytes / `String`; it
+    issues no request. The native HTTP `FragmentTransport` that picks a wire by content
+    negotiation and attaches it as the request body / `values` parameter lands with the
+    streaming HTTP phase (same as the Phase-6 adapters above).
 - **Phase 7 adaptive re-planning** (`sq-ij5x`, the FINAL phase) — the client-side ANAPSID
   feedback loop, behind the extra default-OFF **`fedclient-adaptive`** feature (which pulls
   this planner's `adaptive-replan`). `adaptive::execute_adaptive_single_source` runs the plan


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Docs-only; flagged for review before arming.

## What

Documents the new `sparq-fedclient` **brTPF binding-block wire codec** (`encode_bindings` / `decode_bindings`) — landed in **PR #517** (bead `sq-6ihg`) — in `skills/federated-planning/SKILL.md`, the matching public-surface skill.

Bead **sq-9wqw**. PR #517 made the `wire` module and its items (`encode_bindings`, `decode_bindings`, `encode_bindings_text`, `WireError`, `BINARY_MAGIC`, `BINARY_VERSION`) `pub` and re-exported them at the crate root. The crate README got a section; the SKILL.md did not — so the **G2 public-API → SKILL.md** rule was unmet for that surface. This PR closes that gap.

## The change (docs-only, no Rust touched)

A sub-bullet under the existing **Phase-6 brTPF/TPF fragment-adapter** entry (the wire is a direct follow-up to those adapters), covering, all grounded in `crates/sparq-fedclient/src/wire.rs`:

- the **two wires** and why the binary one exists — the verbose line-oriented `position=term` TEXT wire (which the server's `parse_bindings` reads) repeats the `s=`/`p=`/`o=` key and the `<…>`/`"…"`/`^^<…>` framing on every term of a `maxMpR` block re-sent per request;
- the **twofold compactness win** — a 1-byte header bitmask makes the position term carry no name bytes (the bit IS the name), and a 1-byte kind tag (IRI / blank / literal) replaces the N-Triples framing with bare length-prefixed lexical bytes;
- **lossless** round-trip of arbitrary (non-position) variable names (overflow EXTRA section) and of literals with embedded `=` / whitespace / newline that the single-line text wire cannot carry;
- the **`BINARY_MAGIC` (`bTPF`) + `BINARY_VERSION`** container and every-length-validated **clean `WireError`** decode (no panic / OOB; crate is `forbid(unsafe_code)`); canonical `s`→`p`→`o` decode order; μ₀ skip;
- the **HONEST codec-only scope** — it issues no request; the content-negotiating native HTTP `FragmentTransport` lands with the streaming HTTP phase (same caveat as the Phase-6 adapters and the crate README).

## Gate (docs/CI lints)

- `scripts/check-privacy-claims.sh` — OK (incl. predicate-form soundness; 279 files scanned, no unqualified ZK/MPC privacy/soundness claim).
- `scripts/check-skill-frontmatter.py` — 35/35 SKILL.md valid.
- `scripts/gate-api-skill.py --base main` — PASS (no public surface changed in this diff; the SKILL.md is the catch-up the G2 rule wants).

No Rust source changed, so the crate build/clippy/test matrix is not exercised by this PR.

[OPUS-4.8] `sq-9wqw` (epic `sq-dnko` / `sq-3183`). Flagged for Fable re-review when available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
