### PR TITLE
test(sparq-mpc): distinguish sound vs unsound auth_mul MAC-carry by tampering INSIDE degree_reduce (sq-81gd) [OPUS-4.8]

### DIFF
--- a/crates/sparq-mpc/src/auth_compare.rs
+++ b/crates/sparq-mpc/src/auth_compare.rs
@@ -485,9 +485,13 @@ mod tests {
 
     /// ACCEPTANCE: `auth_mul` is correct AND tamper-evident — `a·b·c` chains and a
     /// wrong re-sharing of an intermediate product is caught (design §6 step 3
-    /// acceptance). We can't tamper INSIDE degree_reduce here, but corrupting the
-    /// value sharing of an authenticated product is the same observable deviation
-    /// (a [z] inconsistent with its MAC), so the check catches it.
+    /// acceptance). This test tampers the OUTPUT value sharing of an authenticated
+    /// product (`[z]` inconsistent with its MAC), the same OBSERVABLE deviation a
+    /// wrong re-sharing produces, so the check catches it. It does NOT distinguish a
+    /// SOUND MAC-carry from the (rejected) UNSOUND one, because a post-hoc value
+    /// tamper happens after the MAC is committed either way — that discrimination is
+    /// the dedicated job of [`mac_carry_soundness_distinguished_by_in_reduce_tamper`]
+    /// (sq-81gd), which injects the deviation INSIDE the value degree-reduce.
     #[test]
     fn auth_mul_chain_is_correct_and_tamper_evident() {
         let backend = ShamirBackend::new_seeded(7, 0xABBA).unwrap();
@@ -513,6 +517,143 @@ mod tests {
             session.mac_check(std::slice::from_ref(&tampered)),
             Err(MpcError::MacCheckFailed { .. })
         ));
+    }
+
+    /// [OPUS-4.8] sq-81gd — **THE regression test that distinguishes the SOUND
+    /// MAC-carry from the UNSOUND one by tampering INSIDE the value `degree_reduce`.**
+    ///
+    /// The other tamper tests in this module (and `auth_mul_chain_is_correct_and_
+    /// tamper_evident`) corrupt the OUTPUT value sharing of a completed `auth_mul`.
+    /// That models the *observable* result of a wrong re-sharing, but it CANNOT
+    /// discriminate the production MAC-carry (`[α·z] = reduce([α·x]·[y])`, an
+    /// independent reduce) from the design's REJECTED alternative
+    /// (`[α·z] = reduce([z]·[α])`): a post-hoc value tamper lands AFTER the MAC is
+    /// committed, so BOTH carries would catch it. The genuine "Hole 2" attack — a
+    /// deviating party re-sharing `h_i + δ` INSIDE the BGW reduce — produces a
+    /// *perfectly consistent* degree-`t` `[z]` of a WRONG product, with nothing for
+    /// Reed–Solomon to detect, and ONLY the independence of the two reduces makes the
+    /// MAC catch it. This test injects exactly that, then runs it through BOTH carries
+    /// and asserts they DIVERGE:
+    ///
+    /// - **SOUND** (`MacCarry::SoundIndependentReduce`): the MAC reduce never saw `δ`,
+    ///   so `[α·z]` holds the true `α·z` while `[z]` opens to `z + λδ` →
+    ///   `σ = α·z − (z+λδ)·α = −λδ·α ≠ 0` → `mac_check` ABORTS. Tamper CAUGHT.
+    /// - **UNSOUND** (`MacCarry::UnsoundFromValueTimesAlpha`): `[α·z]` is recomputed
+    ///   as `reduce([z]·[α])` from the tampered `[z]`, so it tracks `α·(z+λδ)` and
+    ///   `σ = 0` → `mac_check` PASSES on a WRONG product. Tamper MISSED.
+    ///
+    /// The divergence is the whole point: it proves the soundness lives in the
+    /// independent MAC reduce, not in any post-hoc consistency / RS check. If a future
+    /// refactor "simplified" `auth_mul` to recompute the MAC from the reduced value,
+    /// the SOUND assertion here would start failing — this is the guard that catches
+    /// that regression. We also sanity-check that the honest run (no `δ`) passes under
+    /// the production `auth_mul`, and that the in-reduce tamper alone (no MAC) leaves
+    /// `[z]` a *consistent* sharing the robust open does NOT flag (so the catch really
+    /// is the MAC, not RS).
+    #[test]
+    fn mac_carry_soundness_distinguished_by_in_reduce_tamper() {
+        use crate::shamir::MacCarry;
+        // n = 5, t = 2 → 2t+1 = 5: the MINIMAL honest-majority count, where the
+        // degree-2t product has ZERO RS redundancy — so RS/robust opens cannot help
+        // and the MAC is the SOLE detector (the regime the MAC was added for).
+        let backend = ShamirBackend::new_seeded(5, 0x81_9D).unwrap();
+        let t = backend.threshold();
+        assert_eq!(t, 2);
+        assert_eq!(
+            backend.parties(),
+            2 * t + 1,
+            "minimal honest-majority count"
+        );
+
+        let x_val = Fp::new(6);
+        let y_val = Fp::new(7);
+        let true_z = x_val.mul(y_val); // 42
+        let delta = Fp::new(123);
+        // Re-sharing party 0 deviates; the reduced secret shifts by λ_0·δ ≠ 0
+        // (λ_0 is the nonzero Lagrange-at-0 weight for the first recombination point).
+        let reshare_party = 0usize;
+
+        // ---- (a) honest production auth_mul passes and is correct (no behaviour
+        //          change on the clean path). ----
+        {
+            let mut dealer = backend.dealer();
+            let mut session = dealer.new_mac_session();
+            let x = session.authenticated_share(x_val);
+            let y = session.authenticated_share(y_val);
+            let z = session.auth_mul(&x, &y).unwrap();
+            session.mac_check(std::slice::from_ref(&z)).unwrap();
+            assert_eq!(backend.reconstruct(z.value_shares()).unwrap(), true_z);
+        }
+
+        // ---- (b) SOUND carry, tamper INSIDE the value reduce → MAC-check ABORTS,
+        //          and the tampered value is a CONSISTENT (undetectable-by-RS)
+        //          sharing of the wrong product. ----
+        {
+            let mut dealer = backend.dealer();
+            let mut session = dealer.new_mac_session();
+            let x = session.authenticated_share(x_val);
+            let y = session.authenticated_share(y_val);
+            let z = session
+                .auth_mul_with_value_reduce_tamper_for_test(
+                    &x,
+                    &y,
+                    reshare_party,
+                    delta,
+                    MacCarry::SoundIndependentReduce,
+                )
+                .unwrap();
+
+            // The value sharing is internally CONSISTENT: the robust degree-t open
+            // succeeds (no RS flag) and yields the WRONG product — exactly the Hole-2
+            // codeword. (If this were an off-curve tamper the open would error.)
+            let opened = backend.reconstruct(z.value_shares()).unwrap();
+            assert_ne!(
+                opened, true_z,
+                "in-reduce δ must shift the reduced product to a wrong value"
+            );
+
+            // The SOUND MAC reduce never saw δ → σ ≠ 0 → ABORT. THIS is the catch
+            // that a post-hoc value tamper test cannot uniquely attribute to the MAC.
+            assert!(
+                matches!(
+                    session.mac_check(std::slice::from_ref(&z)),
+                    Err(MpcError::MacCheckFailed { .. })
+                ),
+                "SOUND independent MAC reduce must catch an in-reduce value tamper"
+            );
+        }
+
+        // ---- (c) UNSOUND carry, SAME tamper → MAC-check PASSES (false negative).
+        //          This is the discriminator: the unsound MAC tracks the tampered
+        //          value, so σ = 0 and a WRONG product would be silently accepted. ----
+        {
+            let mut dealer = backend.dealer();
+            let mut session = dealer.new_mac_session();
+            let x = session.authenticated_share(x_val);
+            let y = session.authenticated_share(y_val);
+            let z = session
+                .auth_mul_with_value_reduce_tamper_for_test(
+                    &x,
+                    &y,
+                    reshare_party,
+                    delta,
+                    MacCarry::UnsoundFromValueTimesAlpha,
+                )
+                .unwrap();
+
+            let opened = backend.reconstruct(z.value_shares()).unwrap();
+            assert_ne!(opened, true_z, "same in-reduce tamper → same wrong value");
+
+            // The UNSOUND recompute `[α·z] = reduce([z]·[α])` makes the MAC track the
+            // tampered z, so the batched check is FOOLED — it passes on a wrong result.
+            // This is the false negative the sound design avoids; the two carries
+            // DIVERGING on the identical in-reduce tamper is the property sq-81gd pins.
+            assert!(
+                session.mac_check(std::slice::from_ref(&z)).is_ok(),
+                "UNSOUND [z]·[α] MAC carry is FOOLED by the in-reduce tamper (σ = 0) — \
+                 this divergence from the sound route is what the test must exhibit"
+            );
+        }
     }
 
     /// `mac_check` of a clean degree-2t-style product (`auth_mul`) on an unequal

--- a/crates/sparq-mpc/src/shamir.rs
+++ b/crates/sparq-mpc/src/shamir.rs
@@ -563,6 +563,85 @@ impl ShamirDealer {
         Ok(reduced)
     }
 
+    /// [OPUS-4.8] sq-81gd — **test-only INSTRUMENTED degree-reduce that injects a
+    /// deviation `δ` INSIDE the BGW re-sharing step.** This reproduces
+    /// [`Self::degree_reduce`] EXACTLY, except the `reshare_party`-th recombination
+    /// party re-shares `h_i + δ` instead of its true sub-share `h_i` — the genuine
+    /// "Hole 2" malicious deviation that a plain post-hoc share tamper cannot model.
+    ///
+    /// ## Why this is a DIFFERENT, harder attack than tampering the output sharing
+    ///
+    /// The honest reduce re-shares each `h_i` under a FRESH degree-`t` polynomial and
+    /// recombines `Σ_i λ_i·[h_i]`. A deviating party who instead re-shares `h_i + δ`
+    /// emits a **perfectly internally-consistent** degree-`t` codeword (`share()`
+    /// always produces a valid sharing) — so the recombined output `[z]` is a *valid*
+    /// degree-`t` sharing whose secret is `z + λ_i·δ`. There is NO off-curve point,
+    /// NO degree inflation, NOTHING for Reed–Solomon / the robust open to detect:
+    /// every party's share lies exactly on a consistent degree-`t` polynomial. This
+    /// is structurally INDISTINGUISHABLE from an honest reduction of a different
+    /// product. A post-hoc tamper that adds a uniform `δ` to every OUTPUT share's `y`
+    /// (e.g. `auth_compare::tests::tamper_value`) reaches the same *observable* `[z]`,
+    /// but it models tampering the RESULT, not a party deviating INSIDE the reduce;
+    /// crucially it cannot be wired to drive a SOUND-vs-UNSOUND `auth_mul`
+    /// discrimination (see [`MacSession::auth_mul_with_value_reduce_tamper_for_test`]),
+    /// which is the property bead sq-81gd pins.
+    ///
+    /// The `secret_shift` out-param receives `λ_{reshare_party}·δ`, the exact amount
+    /// the reduced secret was shifted — the caller uses it to construct the UNSOUND
+    /// (`[z]·[α]`) MAC that would *track* the tampered value, so the regression test
+    /// can show the unsound design fails to catch what the sound one catches.
+    ///
+    /// Only the recombination parties `0..2t+1` re-share, so `reshare_party` must be
+    /// in that range. NOT part of any production path (`#[cfg(test)]`). `[OPUS-4.8]`
+    #[cfg(test)]
+    pub(crate) fn degree_reduce_tamper_inside_reshare_for_test(
+        &mut self,
+        shares_2t: &[Share],
+        reshare_party: usize,
+        delta: Fp,
+        secret_shift: &mut Fp,
+    ) -> Result<Vec<Share>, MpcError> {
+        assert!(
+            reshare_party < 2 * self.t + 1,
+            "only the first 2t+1 recombination parties re-share"
+        );
+        assert_eq!(shares_2t.len(), self.n, "expected the full n-party sharing");
+
+        let recomb_points: Vec<u64> = shares_2t[..2 * self.t + 1].iter().map(|s| s.x).collect();
+        let lambdas = lagrange_zero_weights(&recomb_points);
+
+        // The deviation: the `reshare_party`-th party re-shares `h_i + δ` instead of
+        // `h_i`. `share()` still emits a perfectly consistent degree-t codeword — the
+        // tamper is invisible to any consistency / RS check, exactly the Hole-2 point.
+        let mut resharings: Vec<Vec<Share>> = Vec::with_capacity(2 * self.t + 1);
+        for (i, s) in shares_2t[..2 * self.t + 1].iter().enumerate() {
+            let to_share = if i == reshare_party {
+                s.y.add(delta)
+            } else {
+                s.y
+            };
+            resharings.push(self.share(to_share));
+        }
+
+        // The reduced secret is shifted by exactly λ_{reshare_party}·δ.
+        *secret_shift = lambdas[reshare_party].mul(delta);
+
+        let mut reduced: Vec<Share> = shares_2t
+            .iter()
+            .map(|s| Share {
+                x: s.x,
+                y: Fp::zero(),
+            })
+            .collect();
+        for (i, sub) in resharings.iter().enumerate() {
+            let lambda = lambdas[i];
+            for (out, sub_share) in reduced.iter_mut().zip(sub.iter()) {
+                out.y = out.y.add(lambda.mul(sub_share.y));
+            }
+        }
+        Ok(reduced)
+    }
+
     /// Reconstruct (RNG-free). Like [`ShamirBackend::reconstruct`], this uses the
     /// consistency-checked / robust path (sq-m34i) when redundancy is present.
     pub fn reconstruct(&self, shares: &[Share]) -> Result<Fp, MpcError> {
@@ -600,6 +679,26 @@ impl ShamirDealer {
             key,
         }
     }
+}
+
+/// [OPUS-4.8] sq-81gd — **test-only** selector for how
+/// [`MacSession::auth_mul_with_value_reduce_tamper_for_test`] carries the output MAC.
+/// It exists ONLY so the regression suite can run the SAME in-reduce VALUE tamper
+/// against BOTH the sound and the (rejected) unsound MAC-carry and PROVE they
+/// diverge — the production [`MacSession::auth_mul`] is hard-wired to the sound route
+/// and offers no such toggle. `#[cfg(test)]`.
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MacCarry {
+    /// PRODUCTION route: `[α·z] = reduce([α·x]·[y])` — an INDEPENDENT reduce over the
+    /// input MAC that never saw the VALUE-reduce tamper, so it holds the TRUE `α·z`
+    /// and the batched check fires on a tampered value.
+    SoundIndependentReduce,
+    /// REJECTED route (design §2.4 warning): `[α·z] = reduce([z]·[α])` from the
+    /// just-reduced (tampered) value times `[α]`, so the MAC TRACKS the tampered
+    /// value and the batched check is fooled (`σ = 0`). Used only to demonstrate the
+    /// false-negative the sound route avoids.
+    UnsoundFromValueTimesAlpha,
 }
 
 /// An **IT-MAC authenticated-sharing session** bound to a single session-global,
@@ -774,6 +873,62 @@ impl MacSession<'_> {
         //    bead sq-81gd.
         let mac_2t = mul_shares_raw(x.mac_shares(), y.value_shares())?;
         let mac = self.dealer.degree_reduce(&mac_2t)?;
+        crate::authenticated::AuthenticatedShare::new(z, mac)
+    }
+
+    /// [OPUS-4.8] sq-81gd — **test-only `auth_mul` whose VALUE degree-reduce is
+    /// tampered INSIDE the re-sharing step (the genuine Hole-2 deviation), with a
+    /// SOUND-vs-UNSOUND toggle for how the MAC is carried.** This is the harness the
+    /// production tamper helpers cannot express: it lets the regression test inject
+    /// `δ` into the BGW re-sharing of the VALUE product
+    /// ([`ShamirDealer::degree_reduce_tamper_inside_reshare_for_test`], so `[z]` is a
+    /// *perfectly consistent* degree-`t` sharing of `z + λ·δ`, undetectable by RS),
+    /// then compute the output MAC by one of two routes:
+    ///
+    /// - **`MacCarry::SoundIndependentReduce`** — the PRODUCTION route: `[α·z] =
+    ///   reduce([α·x]·[y])`, an INDEPENDENT reduce over the input MAC `[α·x]` that
+    ///   never saw `δ`. The MAC therefore holds the TRUE `α·z`, so `σ = α·z −
+    ///   (z+λδ)·α = −λδ·α ≠ 0` and [`Self::mac_check`] ABORTS.
+    /// - **`MacCarry::UnsoundFromValueTimesAlpha`** — the REJECTED route the design
+    ///   doc warns against: `[α·z] = reduce([z]·[α])` from the JUST-REDUCED (tampered)
+    ///   value times `[α]`. The MAC then tracks the tampered `z + λδ`, so `σ = 0` and
+    ///   [`Self::mac_check`] PASSES — a SILENT WRONG result.
+    ///
+    /// The two routes diverging on the SAME in-reduce tamper is exactly what the
+    /// current harness cannot show (a post-hoc value tamper happens AFTER the unsound
+    /// `[z]·[α]` recompute too, so even the unsound design would catch it). `[OPUS-4.8]`
+    #[cfg(test)]
+    pub(crate) fn auth_mul_with_value_reduce_tamper_for_test(
+        &mut self,
+        x: &crate::authenticated::AuthenticatedShare,
+        y: &crate::authenticated::AuthenticatedShare,
+        reshare_party: usize,
+        delta: Fp,
+        mac_carry: MacCarry,
+    ) -> Result<crate::authenticated::AuthenticatedShare, MpcError> {
+        // 1. VALUE product reduced with a δ injected INSIDE the re-sharing: [z] is a
+        //    consistent degree-t sharing of (true z) + λ_{reshare_party}·δ.
+        let z_2t = mul_shares_raw(x.value_shares(), y.value_shares())?;
+        let mut secret_shift = Fp::zero();
+        let z = self.dealer.degree_reduce_tamper_inside_reshare_for_test(
+            &z_2t,
+            reshare_party,
+            delta,
+            &mut secret_shift,
+        )?;
+
+        let mac = match mac_carry {
+            // SOUND: independent reduce of [α·x]·[y]; never saw δ → holds true α·z.
+            MacCarry::SoundIndependentReduce => {
+                let mac_2t = mul_shares_raw(x.mac_shares(), y.value_shares())?;
+                self.dealer.degree_reduce(&mac_2t)?
+            }
+            // UNSOUND: [α·z] = reduce([z]·[α]) — tracks whatever (tampered) z carried.
+            MacCarry::UnsoundFromValueTimesAlpha => {
+                let mac_2t = mul_shares_raw(&z, self.key.alpha_shares())?;
+                self.dealer.degree_reduce(&mac_2t)?
+            }
+        };
         crate::authenticated::AuthenticatedShare::new(z, mac)
     }
 


### PR DESCRIPTION
> 🤖 SPARQ agent — this PR was prepared by an automated SPARQ agent (one of several @jeswr runs on this account).

## What & why (bead sq-81gd)

A regression test that **distinguishes the SOUND `auth_mul` MAC-carry from the UNSOUND one by tampering INSIDE `degree_reduce`** — something the current harness cannot do.

The existing `auth_mul` tamper tests (`auth_mul_chain_is_correct_and_tamper_evident`, `tamper_in_the_verdict_is_caught`, …) corrupt the **output** value sharing of a *completed* `auth_mul` by adding a uniform δ to every share. That models the *observable result* of a wrong re-sharing, but it cannot discriminate:

- the **production** MAC-carry — `[α·z] = reduce([α·x]·[y])`, an *independent* reduce over the input MAC — from
- the design's **rejected** alternative — `[α·z] = reduce([z]·[α])`, recomputed from the just-reduced value.

A post-hoc value tamper lands *after* the MAC is committed, so **both** carries would catch it. The genuine "Hole 2" attack is a deviating party re-sharing `h_i + δ` **inside** the BGW reduce: it produces a *perfectly consistent* degree-`t` `[z]` of a wrong product (`z + λ_i·δ`), with nothing for Reed–Solomon to detect — and only the *independence* of the two reduces makes the MAC catch it.

## Change (test-only, no production path or public API change)

- `ShamirDealer::degree_reduce_tamper_inside_reshare_for_test` (`#[cfg(test)]`) — injects δ into one recombination party's re-sharing (the real Hole-2 deviation); reports the resulting `λ·δ` secret shift.
- `MacSession::auth_mul_with_value_reduce_tamper_for_test` + `MacCarry` enum (`#[cfg(test)]`) — runs that in-reduce tamper through either the **sound** independent MAC reduce or the **unsound** `[z]·[α]` recompute.
- `mac_carry_soundness_distinguished_by_in_reduce_tamper` (the regression test) at the minimal `n = 2t+1` (zero RS redundancy, the regime the MAC exists for):
  - **sound** carry → `mac_check` ABORTS (`σ = −λδ·α ≠ 0`); the tampered `[z]` is itself a *consistent* sharing the robust open does **not** flag (proving the catch is the MAC, not RS),
  - **unsound** carry → `mac_check` PASSES (false negative).

The two carries diverging on the *identical* in-reduce tamper is the property the bead pins; it guards against a future refactor recomputing the MAC from the reduced value. Verified the SOUND assertion is load-bearing (flipping it to the unsound carry makes the test fail exactly there).

`degree_reduce`, `auth_mul`, and `mac_check` are unchanged.

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + tests green in **both** feature states (default and `insecure-test-rng`) — 319 tests pass (+1).
- `rustfmt` clean.
- privacy-claims gate OK; **G2** public-api→SKILL PASS (no public surface changed); `sparq-wasm` does not depend on `sparq-mpc` (boundary intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
