### PR TITLE
feat(sparq-server): request-body read/idle timeout closes the slow-body DoS (sq-lodb) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3972,6 +3972,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "pin-project-lite",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",

--- a/crates/sparq-server/Cargo.toml
+++ b/crates/sparq-server/Cargo.toml
@@ -225,7 +225,11 @@ tokio = { version = "1", optional = true, default-features = false, features = [
 # `limit` + `load-shed` power the max-concurrency guard (T15); `util` for ServiceBuilder combinators.
 tower = { version = "0.5", optional = true, features = ["limit", "load-shed", "util"] }
 # `catch-panic` turns a handler panic into a 500 instead of a dead connection (T15).
-tower-http = { version = "0.6", optional = true, features = ["trace", "catch-panic"] }
+# [OPUS-4.8] (sq-lodb) `timeout` adds `RequestBodyTimeoutLayer` / `TimeoutBody` — the slow-BODY
+# guard (an idle deadline between consecutive request-body frame polls) that complements
+# sq-2gqr's connection header-read deadline. Pure-Rust; already in tower-http's graph behind the
+# feature, so no new transitive code.
+tower-http = { version = "0.6", optional = true, features = ["trace", "catch-panic", "timeout"] }
 # Emits the TraceLayer request log when the binary runs with --verbose.
 tracing-subscriber = { version = "0.3", optional = true, default-features = false, features = ["fmt", "env-filter"] }
 # [OPUS-4.8] (sq-cz89/sq-j9zs) Detailed error diagnostics (the offending query/RDF/path) are

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -368,6 +368,10 @@ matrix under "Security posture".
   UPDATE, `sq-nulp`) / `--max-body-bytes` / `--max-concurrent` / `--header-read-timeout`
   (slow-loris guard: caps how long a connection may take to send its complete request-header block,
   closing it — and freeing the concurrency slot — when exceeded; default 15s, `sq-2gqr`) /
+  `--body-read-timeout` (slow-**body** guard, the complement to `--header-read-timeout`: an idle
+  deadline between consecutive request-**body** reads — a complete-header client that then dribbles
+  the body one byte at a time, or stalls mid-body, otherwise holds the slot forever; the timer
+  resets after each chunk so an honest large upload is never penalised; default 30s, `sq-lodb`) /
   `--max-results` / `--max-query-rows` (coarse memory cap) / `--max-query-bytes`
   (byte-accounted memory cap, `sq-s5is`) / `--max-decompress-ratio` (zip-bomb guard) /
   `--service-allow*` (SERVICE SSRF egress) / `--max-subscriptions*` / (feature `brtpf`)

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -157,6 +157,31 @@ pub struct ServerConfig {
     /// because reading a header block is sub-second on any healthy client; 15s is generous
     /// headroom for a slow but honest network without leaving the slot open for minutes.
     pub header_read_timeout: Option<Duration>,
+    /// [OPUS-4.8] (sq-lodb) **Slow-body guard — request-body read/idle deadline (complement to
+    /// [`header_read_timeout`](Self::header_read_timeout)).** The maximum time the server will wait
+    /// for the NEXT chunk of a request body once the previous one has arrived — an *idle* deadline
+    /// between consecutive body reads, reset after every chunk. The header-read deadline closes the
+    /// classic slow-loris (dribbled *headers*), but it does NOT cover the body phase: once a client
+    /// has sent a complete, valid header block it can then dribble the request BODY one byte at a
+    /// time (or send a chunk then stall forever) and stay under [`max_body_bytes`](Self::max_body_bytes)
+    /// yet hold the connection — and, behind the `concurrency_limit`, a concurrency slot — open
+    /// indefinitely. hyper's `header_read_timeout` has already elapsed (the headers parsed fine),
+    /// [`query_timeout`](Self::query_timeout) is an engine deadline that only starts once the WHOLE
+    /// request has been read, and [`max_body_bytes`](Self::max_body_bytes) is a SIZE cap that a
+    /// one-byte-at-a-time trickle never trips. So this is a genuinely distinct vector that needs its
+    /// own bound.
+    ///
+    /// Enforced by a `tower_http::timeout::RequestBodyTimeoutLayer` wrapping the request body in a
+    /// `TimeoutBody`: each poll for the next body frame gets a fresh deadline; if that frame does
+    /// not arrive within the window the body read fails and the request is aborted. Because the
+    /// timer RESETS after every received frame, a slow-but-honest large upload (steady chunks just
+    /// under the window apart) is never penalised by total transfer time — only an idle stall is.
+    ///
+    /// `None` disables it (back to the unbounded body-read behaviour — a slow body can hold the
+    /// slot forever). Default 30s. The window is generous (a stall, not a slow link) and matches
+    /// the default [`query_timeout`](Self::query_timeout); an operator behind a flaky network widens
+    /// it, a hostile-input operator tightens it.
+    pub body_read_timeout: Option<Duration>,
     /// Maximum SELECT result rows. Exceeding it is an honest 413 refusal (the engine
     /// aborts evaluation via the row budget), never a silent truncation.
     pub max_results: Option<usize>,
@@ -433,6 +458,13 @@ impl Default for ServerConfig {
             // TokioTimer and wires this value. 0 / env-unset keeps the guard; SPARQ_HEADER_READ_TIMEOUT=0
             // disables it. See ServerConfig::header_read_timeout.
             header_read_timeout: Some(Duration::from_secs(15)),
+            // [OPUS-4.8] sq-lodb: a 30s body read/idle deadline closes the slow-BODY hole ON by
+            // default — the complement to the header-read guard above. A client that finishes its
+            // headers then dribbles the request body (or stalls mid-body) otherwise holds the slot
+            // forever. The timer resets after each received chunk, so an honest large upload is
+            // never penalised by total time. 0 / SPARQ_BODY_READ_TIMEOUT=0 disables it. See
+            // ServerConfig::body_read_timeout.
+            body_read_timeout: Some(Duration::from_secs(30)),
             max_results: None,
             // [OPUS-4.8] sq-ebii: memory cap OFF by default (no surprise refusals on an
             // unconfigured server); an operator exposing the endpoint opts a ceiling in.
@@ -502,7 +534,9 @@ impl ServerConfig {
     /// UPDATE; seconds, `0`/unset disables — the update WHERE budget is then the plain
     /// `query_timeout`), `SPARQ_MAX_BODY_BYTES`, `SPARQ_MAX_CONCURRENT`,
     /// `SPARQ_HEADER_READ_TIMEOUT` ([OPUS-4.8] sq-2gqr: the slow-loris connection header-read
-    /// deadline in seconds; `0` disables, default 15), `SPARQ_MAX_RESULTS`,
+    /// deadline in seconds; `0` disables, default 15),
+    /// `SPARQ_BODY_READ_TIMEOUT` ([OPUS-4.8] sq-lodb: the slow-body request-body read/idle
+    /// deadline in seconds; `0` disables, default 30), `SPARQ_MAX_RESULTS`,
     /// `SPARQ_MAX_QUERY_ROWS` ([OPUS-4.8] sq-ebii: the coarse memory cap; `0` disables) and
     /// `SPARQ_MAX_DECOMPRESS_RATIO` ([OPUS-4.8] sq-ebii: the zip-bomb guard; `0` refuses gzip
     /// bodies) environment variables — plus, with the `time-travel` feature,
@@ -539,6 +573,11 @@ impl ServerConfig {
         // unbounded header read, the pre-fix behaviour), anything else sets the deadline.
         if let Some(secs) = env_parse::<u64>("SPARQ_HEADER_READ_TIMEOUT") {
             cfg.header_read_timeout = (secs > 0).then(|| Duration::from_secs(secs));
+        }
+        // [OPUS-4.8] sq-lodb: slow-body read/idle deadline (seconds); `0` disables it (an
+        // unbounded body read — a slow body can hold the slot forever), anything else sets it.
+        if let Some(secs) = env_parse::<u64>("SPARQ_BODY_READ_TIMEOUT") {
+            cfg.body_read_timeout = (secs > 0).then(|| Duration::from_secs(secs));
         }
         if let Some(n) = env_parse::<usize>("SPARQ_MAX_RESULTS") {
             cfg.max_results = (n > 0).then_some(n);
@@ -2547,12 +2586,14 @@ pub fn harden(routes: Router, config: &ServerConfig) -> Router {
 }
 
 // ---------------------------------------------------------------------------
-// [OPUS-4.8] (sq-2gqr) Serve loop with a connection header-read deadline (slow-loris guard)
+// [OPUS-4.8] (sq-2gqr / sq-lodb) Serve loop with connection-layer slow-client deadlines
+// (slow-loris HEADER guard + slow-BODY guard)
 // ---------------------------------------------------------------------------
 
-/// Serves `app` on `listener` until `shutdown` resolves, with a hyper HTTP/1
-/// **header-read deadline** ([`ServerConfig::header_read_timeout`]) that closes the
-/// slow-loris DoS.
+/// Serves `app` on `listener` until `shutdown` resolves, with two complementary slow-client
+/// deadlines: a hyper HTTP/1 **header-read deadline** ([`ServerConfig::header_read_timeout`],
+/// sq-2gqr) that closes the slow-loris HEADER dribble, and a **request-body read/idle deadline**
+/// ([`ServerConfig::body_read_timeout`], sq-lodb) that closes the slow-BODY dribble.
 ///
 /// **Why this exists instead of `axum::serve`.** `axum::serve` builds hyper's connection
 /// `Builder` internally and exposes no hook to configure it, and — critically — it never
@@ -2566,17 +2607,31 @@ pub fn harden(routes: Router, config: &ServerConfig) -> Router {
 /// deadline that only starts once a full request has been parsed; `max_body_bytes` and load-shed
 /// likewise act *after* the headers are read.
 ///
+/// **The slow-BODY complement (sq-lodb).** hyper's `header_read_timeout` only covers the header
+/// block; once that completes a client can dribble the request BODY one byte at a time (or send a
+/// chunk then stall) and hold the slot forever — under [`ServerConfig::max_body_bytes`] (a SIZE
+/// cap a trickle never trips) and before [`ServerConfig::query_timeout`] starts (an engine
+/// deadline that begins only after the whole request is read). When `body_read_timeout` is set
+/// the incoming request body is wrapped in a `tower_http::timeout::TimeoutBody` (via
+/// [`tower::util::option_layer`] so a `None` is a true no-op `Identity` layer): every poll for the
+/// next body frame gets a fresh deadline, reset after each frame — so an honest large upload is
+/// never penalised by total transfer time, only an idle stall is. The `Router` accepts the
+/// wrapped body natively (`impl<B> Service<Request<B>> for Router` for any `B: Body<Data = Bytes>`),
+/// so no body re-boxing is needed.
+///
 /// This loop is a faithful port of `axum::serve`'s own accept + graceful-shutdown loop
 /// (per-connection task, watch-channel drain, `serve_connection(...).with_upgrades()` so the
-/// `/subscriptions` WebSocket upgrade still works) with exactly one behavioural addition: the
-/// connection builder installs a `TokioTimer` and sets `header_read_timeout`. `None` opts back
-/// out to the unbounded behaviour. axum is configured HTTP/1-only (no `http2` feature), so this
-/// uses hyper's `http1::Builder` directly — the smallest builder that carries the knob we need.
+/// `/subscriptions` WebSocket upgrade still works) with two behavioural additions: the connection
+/// builder installs a `TokioTimer` and sets `header_read_timeout`, and the per-connection service
+/// optionally wraps the body in the `body_read_timeout` layer. `None` on either opts back out to
+/// the unbounded behaviour. axum is configured HTTP/1-only (no `http2` feature), so this uses
+/// hyper's `http1::Builder` directly — the smallest builder that carries the header knob.
 #[cfg(feature = "server")]
 pub async fn serve<F>(
     listener: tokio::net::TcpListener,
     app: Router,
     header_read_timeout: Option<Duration>,
+    body_read_timeout: Option<Duration>,
     shutdown: F,
 ) -> std::io::Result<()>
 where
@@ -2585,6 +2640,15 @@ where
     use futures_util::FutureExt;
     use hyper_util::rt::{TokioIo, TokioTimer};
     use hyper_util::service::TowerToHyperService;
+    use tower::ServiceBuilder;
+    use tower_http::timeout::RequestBodyTimeoutLayer;
+
+    // [OPUS-4.8] sq-lodb: wrap the per-connection service with the slow-body read/idle deadline.
+    // `option_layer` makes a `None` an `Identity` (true no-op) layer, so the disabled path is
+    // byte-for-byte the pre-sq-lodb behaviour. The layer feeds the `Router` a `TimeoutBody`-wrapped
+    // request body, which the `Router`'s body-generic `Service` impl accepts directly.
+    let body_timeout_layer =
+        tower::util::option_layer(body_read_timeout.map(RequestBodyTimeoutLayer::new));
 
     // `signal_tx`: dropped (closed) once `shutdown` resolves — every connection task watches it
     // and begins a graceful drain. `close_rx`: each task holds a clone; the loop waits for them
@@ -2622,7 +2686,12 @@ where
         };
 
         let io = TokioIo::new(stream);
-        let hyper_service = TowerToHyperService::new(app.clone());
+        // [OPUS-4.8] sq-lodb: apply the (optional) slow-body read/idle deadline around this
+        // connection's clone of the router, then hand the composed tower service to hyper.
+        let service = ServiceBuilder::new()
+            .layer(body_timeout_layer.clone())
+            .service(app.clone());
+        let hyper_service = TowerToHyperService::new(service);
         let signal_tx = signal_tx.clone();
         let close_rx = close_tx.subscribe();
 
@@ -2679,10 +2748,11 @@ where
 
 #[cfg(test)]
 mod header_read_timeout_config_tests {
-    //! [OPUS-4.8] (sq-2gqr) The slow-loris header-read deadline lives in `ServerConfig` so it is
-    //! configurable + testable in isolation; the END-TO-END behaviour (a partial-header socket is
-    //! actually closed by `serve`) is the integration suite in `tests/hardening.rs`. These pin the
-    //! config contract.
+    //! [OPUS-4.8] (sq-2gqr / sq-lodb) The slow-loris header-read deadline and the slow-body
+    //! read/idle deadline live in `ServerConfig` so they are configurable + testable in isolation;
+    //! the END-TO-END behaviour (a partial-header socket / a dribbled-body socket is actually
+    //! closed by `serve`) is the integration suite in `tests/hardening.rs`. These pin the config
+    //! contract.
     use super::*;
 
     #[test]
@@ -2710,6 +2780,36 @@ mod header_read_timeout_config_tests {
         // It is opt-out-able (an operator who really wants the old unbounded behaviour).
         let off = ServerConfig { header_read_timeout: None, ..ServerConfig::default() };
         assert_eq!(off.header_read_timeout, None);
+    }
+
+    #[test]
+    fn slow_body_guard_is_on_by_default() {
+        // [OPUS-4.8] sq-lodb: a fresh, unconfigured server must also bound the slow-BODY vector.
+        // A generous-but-finite 30s idle deadline ships ON.
+        assert_eq!(
+            ServerConfig::default().body_read_timeout,
+            Some(Duration::from_secs(30)),
+            "body read/idle deadline must be ON by default (slow-body guard)"
+        );
+    }
+
+    #[test]
+    fn body_read_timeout_is_independent_of_the_header_and_query_deadlines() {
+        // [OPUS-4.8] sq-lodb: three distinct deadlines (body phase / header phase / engine
+        // evaluation). Setting one must not move the others.
+        let cfg = ServerConfig {
+            body_read_timeout: Some(Duration::from_secs(5)),
+            header_read_timeout: Some(Duration::from_secs(3)),
+            query_timeout: Some(Duration::from_secs(99)),
+            ..ServerConfig::default()
+        };
+        assert_eq!(cfg.body_read_timeout, Some(Duration::from_secs(5)));
+        assert_eq!(cfg.header_read_timeout, Some(Duration::from_secs(3)));
+        assert_eq!(cfg.query_timeout, Some(Duration::from_secs(99)));
+        // It is opt-out-able independently of the header guard.
+        let off = ServerConfig { body_read_timeout: None, ..ServerConfig::default() };
+        assert_eq!(off.body_read_timeout, None);
+        assert_eq!(off.header_read_timeout, Some(Duration::from_secs(15))); // header guard untouched
     }
 }
 

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -71,6 +71,11 @@
 //!                             to send its complete request-header block (closes the connection +
 //!                             frees the concurrency slot if exceeded), 0 disables
 //!                             [15, env SPARQ_HEADER_READ_TIMEOUT]
+//!   --body-read-timeout S     [OPUS-4.8 sq-lodb] slow-BODY guard (complement to --header-read-timeout):
+//!                             max SECONDS the server waits for the NEXT request-body chunk (idle deadline
+//!                             between body reads, reset after each chunk — an honest large upload is not
+//!                             penalised, only a stall). Closes the slow-body DoS a complete-header client
+//!                             could otherwise use. 0 disables   [30, env SPARQ_BODY_READ_TIMEOUT]
 //!   --max-results N           maximum SELECT rows (413 beyond), 0 off    [unlimited, env SPARQ_MAX_RESULTS]
 //!   --max-query-rows N        [OPUS-4.8 sq-ebii] coarse MEMORY CAP: working-set row ceiling on EVERY
 //!                             query form (413 beyond), 0 off             [unlimited, env SPARQ_MAX_QUERY_ROWS]
@@ -181,6 +186,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "--header-read-timeout" => {
                 let secs: u64 = parse_flag(&mut args, "--header-read-timeout")?;
                 config.header_read_timeout = (secs > 0).then(|| Duration::from_secs(secs));
+            }
+            // [OPUS-4.8] sq-lodb: slow-body request-body read/idle deadline (seconds); 0 disables
+            // it (unbounded body read — a slow body can hold the slot forever). Default 30s. The
+            // complement to --header-read-timeout. See ServerConfig::body_read_timeout.
+            "--body-read-timeout" => {
+                let secs: u64 = parse_flag(&mut args, "--body-read-timeout")?;
+                config.body_read_timeout = (secs > 0).then(|| Duration::from_secs(secs));
             }
             "--max-results" => {
                 let n: usize = parse_flag(&mut args, "--max-results")?;
@@ -450,7 +462,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     eprintln!("loaded {} triples", graph.len());
     eprintln!(
-        "guards: query-timeout={} update-where-timeout={} header-read-timeout={} max-body-bytes={} max-concurrent={} max-results={} \
+        "guards: query-timeout={} update-where-timeout={} header-read-timeout={} body-read-timeout={} max-body-bytes={} max-concurrent={} max-results={} \
          max-query-rows={} max-query-bytes={} max-decompress-ratio={}x max-subscriptions={} \
          max-subscriptions-per-conn={}",
         config
@@ -463,6 +475,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // [OPUS-4.8] sq-2gqr: connection-layer header-read deadline (slow-loris guard).
         config
             .header_read_timeout
+            .map_or("off".into(), |t| format!("{}s", t.as_secs())),
+        // [OPUS-4.8] sq-lodb: connection-layer body read/idle deadline (slow-body guard).
+        config
+            .body_read_timeout
             .map_or("off".into(), |t| format!("{}s", t.as_secs())),
         config.max_body_bytes,
         config.max_concurrent,
@@ -552,10 +568,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         BindPosture::RemoteRefused { message } => return Err(message.into()),
     }
 
-    // [OPUS-4.8] sq-2gqr: capture the slow-loris header-read deadline BEFORE `config` is moved
-    // into `AppState` — `sparq_server::serve` (not `axum::serve`) installs it at the hyper
-    // connection layer to close the slow-loris DoS (see ServerConfig::header_read_timeout).
+    // [OPUS-4.8] sq-2gqr / sq-lodb: capture the connection-layer slow-client deadlines BEFORE
+    // `config` is moved into `AppState` — `sparq_server::serve` (not `axum::serve`) installs the
+    // header-read deadline (slow-loris HEADER guard, sq-2gqr) and the body read/idle deadline
+    // (slow-BODY guard, sq-lodb). See ServerConfig::header_read_timeout / ::body_read_timeout.
     let header_read_timeout = config.header_read_timeout;
+    let body_read_timeout = config.body_read_timeout;
     // [OPUS-4.8] sq-7cxr: `try_with_config` surfaces a durable-open error (corrupt persist dir,
     // unwritable path) as a clean startup error + non-zero exit, rather than panicking.
     let state = AppState::try_with_config(graph, config)?;
@@ -563,11 +581,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     eprintln!("sparq-server listening on http://{addr}  (SPARQL endpoint: /sparql, subscriptions: ws://{addr}/subscriptions)");
-    // [OPUS-4.8] sq-2gqr: NOT `axum::serve` — it never installs a timer, so hyper's header-read
-    // deadline is inert there and a slow-loris client holds a connection (and concurrency slot)
-    // open forever. `sparq_server::serve` is the same accept + graceful-drain loop WITH the
-    // header-read deadline wired in.
-    sparq_server::serve(listener, app, header_read_timeout, shutdown_signal()).await?;
+    // [OPUS-4.8] sq-2gqr / sq-lodb: NOT `axum::serve` — it never installs a timer, so hyper's
+    // header-read deadline is inert there and a slow-loris client holds a connection (and
+    // concurrency slot) open forever. `sparq_server::serve` is the same accept + graceful-drain
+    // loop WITH the header-read deadline (slow-loris HEADER guard) and the body read/idle deadline
+    // (slow-BODY guard) wired in.
+    sparq_server::serve(
+        listener,
+        app,
+        header_read_timeout,
+        body_read_timeout,
+        shutdown_signal(),
+    )
+    .await?;
     Ok(())
 }
 

--- a/crates/sparq-server/tests/hardening.rs
+++ b/crates/sparq-server/tests/hardening.rs
@@ -948,17 +948,25 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
 /// Spawn the real `sparq_server::serve` accept loop (NOT `axum::serve`) with the given
-/// header-read deadline, returning the bound address for a raw-socket client.
+/// header-read and body read/idle deadlines, returning the bound address for a raw-socket client.
 async fn spawn_serve(config: ServerConfig) -> SocketAddr {
     let header_read_timeout = config.header_read_timeout;
+    // [OPUS-4.8] sq-lodb: also drive the real slow-body read/idle deadline through the serve loop.
+    let body_read_timeout = config.body_read_timeout;
     let graph = Graph::load_str(DATA, "turtle").unwrap();
     let app = router(AppState::with_config(graph, config));
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
-        sparq_server::serve(listener, app, header_read_timeout, std::future::pending::<()>())
-            .await
-            .unwrap();
+        sparq_server::serve(
+            listener,
+            app,
+            header_read_timeout,
+            body_read_timeout,
+            std::future::pending::<()>(),
+        )
+        .await
+        .unwrap();
     });
     addr
 }
@@ -1068,5 +1076,147 @@ async fn serve_loop_handles_complete_request() {
     assert!(
         text.to_ascii_lowercase().contains("x-content-type-options: nosniff"),
         "security headers must still be stamped by the serve loop: {text:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (sq-lodb) [OPUS-4.8] Slow-BODY guard — the request-body read/idle deadline (complement to
+// sq-2gqr's header-read deadline).
+//
+// sq-2gqr's `header_read_timeout` closes the slow-loris HEADER dribble, but once a client has
+// sent a complete, valid header block it can then dribble the BODY — declare a large
+// `Content-Length`, send a few bytes, then stall forever — staying under `max_body_bytes` (a SIZE
+// cap a trickle never trips) and before `query_timeout` starts (an engine deadline that begins
+// only after the whole request is read). `body_read_timeout` wraps the body in a `TimeoutBody`
+// whose per-frame idle deadline aborts that read. These tests drive the REAL `serve` loop over a
+// raw TCP socket (reqwest sends its whole body at once, so it cannot exercise this — we have to be
+// the misbehaving client and stall mid-body).
+// ---------------------------------------------------------------------------
+
+/// Write a complete request head for a POST /sparql whose `Content-Length` PROMISES more body
+/// bytes than we will actually send, then send a partial body and stall. With a short
+/// `body_read_timeout` the SERVER must let go of the connection (close / reset / an error status)
+/// within roughly the deadline, instead of waiting forever for the rest of the body.
+#[tokio::test]
+async fn slow_body_dribble_closed_by_deadline() {
+    let config = ServerConfig {
+        // Short body deadline; keep the header deadline generous so it is unambiguously the BODY
+        // guard that fires, not the header guard.
+        body_read_timeout: Some(Duration::from_millis(400)),
+        header_read_timeout: Some(Duration::from_secs(30)),
+        ..ServerConfig::default()
+    };
+    let addr = spawn_serve(config).await;
+
+    let mut sock = TcpStream::connect(addr).await.unwrap();
+    // A COMPLETE header block (so the header-read deadline is satisfied), promising 4096 body
+    // bytes — but we send only a handful and then never send the rest (the slow-body dribble).
+    sock.write_all(
+        b"POST /sparql HTTP/1.1\r\n\
+          Host: localhost\r\n\
+          Content-Type: application/sparql-query\r\n\
+          Content-Length: 4096\r\n\r\n\
+          SELECT",
+    )
+    .await
+    .unwrap();
+    sock.flush().await.unwrap();
+
+    // The body-read deadline (400ms) must make the server release the connection well within this
+    // generous 5s cap. Ok(0) is a clean close, Err is a reset, and a 400/408 status line before
+    // close all mean the server let go of the slot rather than holding it for the missing body.
+    let started = std::time::Instant::now();
+    let mut buf = [0u8; 256];
+    let outcome = tokio::time::timeout(Duration::from_secs(5), sock.read(&mut buf)).await;
+    let elapsed = started.elapsed();
+    match outcome {
+        Ok(Ok(0)) | Ok(Err(_)) => {} // connection closed / reset by the server — the guard fired
+        Ok(Ok(n)) => {
+            let head = String::from_utf8_lossy(&buf[..n]);
+            assert!(
+                head.contains("400") || head.contains("408") || head.contains("500"),
+                "server responded but did not signal a body-read timeout: {head:?}"
+            );
+        }
+        Err(_) => panic!(
+            "slow-body connection was NOT closed within 5s — the body-read deadline did not fire \
+             (connection + concurrency slot held open for a dribbled body: the slow-body DoS)"
+        ),
+    }
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "connection released but only after {elapsed:?} — far beyond the 400ms body deadline"
+    );
+}
+
+/// With the body deadline DISABLED (`None`) — header guard still on — the same dribbled-body
+/// connection is NOT proactively released within a short window, proving the body guard is what
+/// does the releasing (and is genuinely opt-out-able). We only assert it stays open briefly (then
+/// we drop it), so the test is fast and not flaky.
+#[tokio::test]
+async fn slow_body_held_open_when_deadline_disabled() {
+    let config = ServerConfig {
+        body_read_timeout: None,
+        header_read_timeout: Some(Duration::from_secs(30)),
+        ..ServerConfig::default()
+    };
+    let addr = spawn_serve(config).await;
+
+    let mut sock = TcpStream::connect(addr).await.unwrap();
+    sock.write_all(
+        b"POST /sparql HTTP/1.1\r\n\
+          Host: localhost\r\n\
+          Content-Type: application/sparql-query\r\n\
+          Content-Length: 4096\r\n\r\n\
+          SELECT",
+    )
+    .await
+    .unwrap();
+    sock.flush().await.unwrap();
+
+    // Within a short window the server must NOT have released the (incomplete-body) connection.
+    let mut buf = [0u8; 64];
+    let outcome = tokio::time::timeout(Duration::from_millis(700), sock.read(&mut buf)).await;
+    assert!(
+        outcome.is_err(),
+        "with body_read_timeout=None the connection should stay open (waiting for the rest of the \
+         body), but the server released/answered it: {outcome:?}"
+    );
+}
+
+/// Sanity: with the body deadline ON, a COMPLETE POST /sparql whose body arrives all at once is
+/// still answered normally (the timer resets after the frame and never fires). Proves the guard
+/// does not penalise an honest request that simply carries a body.
+#[tokio::test]
+async fn slow_body_guard_does_not_break_a_complete_post() {
+    let config = ServerConfig {
+        body_read_timeout: Some(Duration::from_millis(500)),
+        ..ServerConfig::default()
+    };
+    let addr = spawn_serve(config).await;
+
+    let body = b"SELECT * WHERE { ?s ?p ?o } LIMIT 1";
+    let req = format!(
+        "POST /sparql HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/sparql-query\r\n\
+         Connection: close\r\n\
+         Content-Length: {}\r\n\r\n",
+        body.len()
+    );
+    let mut sock = TcpStream::connect(addr).await.unwrap();
+    sock.write_all(req.as_bytes()).await.unwrap();
+    sock.write_all(body).await.unwrap(); // whole body in one write — no idle gap
+    sock.flush().await.unwrap();
+
+    let mut resp = Vec::new();
+    tokio::time::timeout(Duration::from_secs(5), sock.read_to_end(&mut resp))
+        .await
+        .expect("a complete POST with a body must be answered promptly under the body deadline")
+        .unwrap();
+    let text = String::from_utf8_lossy(&resp);
+    assert!(
+        text.starts_with("HTTP/1.1 200"),
+        "complete POST /sparql under body_read_timeout must return 200: {text:?}"
     );
 }

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -137,7 +137,7 @@ Library surface re-exported from `sparq_server` (behind the default `server` fea
   (**`time-travel` feature only**).
 - `struct ServerConfig { query_timeout: Option<Duration>, update_where_timeout: Option<Duration>,
   max_body_bytes: usize,
-  max_concurrent: usize, header_read_timeout: Option<Duration>, max_results: Option<usize>, max_query_rows: Option<usize>,
+  max_concurrent: usize, header_read_timeout: Option<Duration>, body_read_timeout: Option<Duration>, max_results: Option<usize>, max_query_rows: Option<usize>,
   max_query_bytes: Option<usize>,
   max_decompress_ratio: usize, max_subscriptions: usize, max_subscriptions_per_conn: usize,
   verbose: bool, redact_logs: bool, allow_remote: bool, auth_token: Option<String>, auth_token_read: bool,
@@ -150,7 +150,12 @@ Library surface re-exported from `sparq_server` (behind the default `server` fea
   `max_decompress_ratio` = zip-bomb guard — `sq-ebii`;
   `header_read_timeout` = **slow-loris guard**: max time a connection may take to send its
   complete request-header block, enforced at hyper's HTTP/1 connection layer by
-  `sparq_server::serve` — `None` disables; default 15s — `sq-2gqr`.)
+  `sparq_server::serve` — `None` disables; default 15s — `sq-2gqr`;
+  `body_read_timeout` = **slow-body guard** (the complement to `header_read_timeout`): an idle
+  deadline between consecutive request-**body** reads, applied by `sparq_server::serve` via a
+  `tower_http` `RequestBodyTimeoutLayer`/`TimeoutBody` (the timer resets after each chunk, so an
+  honest large upload is not penalised — only a stall is) — closes the slow-**body** dribble a
+  complete-header client could otherwise use; `None` disables; default 30s — `sq-lodb`.)
   `auth_token` (set: gates the write surface with a Bearer token, constant-time compared;
   `None`: no write auth) and `auth_token_read` (gate reads too) are honoured by the library
   `router` itself — embedders get the gate for free (`sq-zcby`).
@@ -166,14 +171,18 @@ Library surface re-exported from `sparq_server` (behind the default `server` fea
   router in the production middleware (panic→500, concurrency-limit→429, body-limit→413,
   JSON error bodies, optional trace).
 - `async fn serve(listener: tokio::net::TcpListener, app: axum::Router, header_read_timeout:
-  Option<Duration>, shutdown: impl Future<Output=()>) -> std::io::Result<()>` — the accept +
-  graceful-drain loop the binary runs **instead of `axum::serve`** (`sq-2gqr`). It is a faithful
-  port of axum's own loop (per-connection task, watch-channel drain, `with_upgrades()` so the
-  `/subscriptions` WebSocket still works) with one addition: it installs a `hyper_util` TokioTimer
-  and hyper's HTTP/1 `header_read_timeout`. **Why:** `axum::serve` never installs a timer, so
-  hyper's header-read deadline is inert there and a slow-loris client holds a connection (and a
-  `concurrency_limit` slot) open indefinitely; this loop closes that hole. Pass `None` to opt back
-  out to the unbounded behaviour.
+  Option<Duration>, body_read_timeout: Option<Duration>, shutdown: impl Future<Output=()>) ->
+  std::io::Result<()>` — the accept + graceful-drain loop the binary runs **instead of
+  `axum::serve`** (`sq-2gqr` / `sq-lodb`). It is a faithful port of axum's own loop (per-connection
+  task, watch-channel drain, `with_upgrades()` so the `/subscriptions` WebSocket still works) with
+  two additions: (1) it installs a `hyper_util` TokioTimer and hyper's HTTP/1
+  `header_read_timeout` (the slow-loris HEADER guard); (2) it optionally wraps the request body in a
+  `tower_http` `RequestBodyTimeoutLayer` keyed on `body_read_timeout` (the slow-BODY guard — applied
+  via `tower::util::option_layer`, so `None` is a true no-op `Identity` layer). **Why:** `axum::serve`
+  never installs a timer, so hyper's header-read deadline is inert there and a slow-loris client
+  holds a connection (and a `concurrency_limit` slot) open indefinitely; and even with that fixed, a
+  complete-header client can still dribble the BODY to hold the slot — `body_read_timeout` closes
+  that complementary hole. Pass `None` on either to opt back out of that guard.
 - Re-exports for cache layers/tests: `PinnedGen`, `GLOBAL_POD: &str`
   (`"urn:sparq:pod:global"`), and `sparq_serve::{Epoch, PodEpochs, PodId}`.
 - Serializer/negotiation helpers (always compiled, no `server` feature): module
@@ -574,6 +583,7 @@ env overrides the default.
 | `--max-body-bytes N` | `SPARQ_MAX_BODY_BYTES` | `1048576` | body cap → `413` |
 | `--max-concurrent N` | `SPARQ_MAX_CONCURRENT` | `32` | in-flight cap, load-shed → `429` |
 | `--header-read-timeout SECS` | `SPARQ_HEADER_READ_TIMEOUT` | `15` (`0`=off) | **slow-loris guard**: max time a connection may take to send its complete request-header block — enforced at hyper's HTTP/1 connection layer by `sparq_server::serve` (NOT `axum::serve`, which never installs a timer so its header deadline is inert), so it fires BEFORE a handler and frees the concurrency slot a dribbling client would otherwise hold forever; connection closed when exceeded (`sq-2gqr`) |
+| `--body-read-timeout SECS` | `SPARQ_BODY_READ_TIMEOUT` | `30` (`0`=off) | **slow-body guard** (complement to `--header-read-timeout`): idle deadline between consecutive request-**body** reads — applied by `sparq_server::serve` via a `tower_http` `RequestBodyTimeoutLayer`. Closes the slow-**body** dribble a complete-header client could otherwise use (declare a large `Content-Length`, send a few bytes, stall) to hold the slot under `--max-body-bytes` and before `--query-timeout` starts. The timer RESETS after each received chunk, so an honest large upload is not penalised — only an idle stall is; body read fails → request aborted (`sq-lodb`) |
 | `--max-results N` | `SPARQ_MAX_RESULTS` | unlimited (`0`=off) | result/solution cap (SELECT + CONSTRUCT/DESCRIBE WHERE-solutions + EXPLAIN ANALYZE; not ASK/GSP-read/UPDATE) → honest `413` (not truncation) |
 | `--max-query-rows N` | `SPARQ_MAX_QUERY_ROWS` | unlimited (`0`=off) | **memory cap** (coarse): working-set ROW ceiling on **every** form → honest `413` (`sq-ebii`) |
 | `--max-query-bytes N` | `SPARQ_MAX_QUERY_BYTES` | unlimited (`0`=off) | **byte-accounted memory cap**: prices working-set row WIDTH (`rows × vars × id-size`) + computed-literal bytes on **every** form → honest `413` (`sq-s5is`) |


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. @jeswr runs multiple agents on this account.

## What & why (bead sq-lodb)

`sq-2gqr` (#507) added a hyper http1 `header_read_timeout` — the slow-loris **HEADER**-dribble guard — to `sparq_server::serve`. That closes the header-block vector but **not** a slow-**BODY** dribble: once a client has sent a complete, valid header block it can then dribble the request body one byte at a time (or send a chunk then stall) and hold the connection — and, behind `harden()`'s `concurrency_limit`, a concurrency slot — open indefinitely.

This is a genuinely distinct transport-level vector:
- it stays under `max_body_bytes` (a **size** cap a trickle never trips);
- `header_read_timeout` has already elapsed (the headers parsed fine);
- `query_timeout` is an **engine** deadline that only starts once the *whole* request has been read.

## Fix

A new `ServerConfig::body_read_timeout` (default **30s, ON**) wired through `sparq_server::serve`. The accept loop wraps each connection's request body in a `tower_http::timeout::RequestBodyTimeoutLayer` (`TimeoutBody`) via `tower::util::option_layer`, so:
- `None` is a true no-op `Identity` layer → the disabled path is byte-for-byte the pre-sq-lodb behaviour;
- the per-frame idle deadline **resets after every received chunk**, so an honest large upload is never penalised by total transfer time — only an idle **stall** is;
- the `Router`'s body-generic `Service` impl accepts the wrapped body directly, so no body re-boxing is needed.

This is the bead's **option (1)**: a per-request body-phase guard, **complementary** to sq-2gqr's connection header-phase guard, *not a replacement*.

Configurable via `ServerConfig::body_read_timeout`, `SPARQ_BODY_READ_TIMEOUT`, and `--body-read-timeout` (seconds; `0` disables), mirroring `header_read_timeout` exactly. Surfaced in the startup guard summary.

## Tests (`tests/hardening.rs`, raw-TCP, driving the REAL serve loop)

- `slow_body_dribble_closed_by_deadline` — a complete-header + partial-body socket is released within the deadline (the fix);
- `slow_body_held_open_when_deadline_disabled` — `None` keeps it open (proves the guard is what closes it, and is genuinely opt-out-able, independently of the header guard);
- `slow_body_guard_does_not_break_a_complete_post` — a POST whose body arrives in one write still returns 200 (timer resets, never fires — no regression).

Plus unit tests for the default-ON value + independence from the header/query deadlines.

## Notes

- `tower-http`'s `timeout` feature added (server-feature only) — pure-Rust, already in tower-http's graph behind the feature, so **no new transitive crate**: `Cargo.lock` only records `tokio` (already a workspace dep) on tower-http's edge.
- `README` + `skills/http-server/SKILL.md` updated for the new public `serve` parameter, the `ServerConfig` field, and the flag/env (**G2** public-api → SKILL.md rule).

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + tests pass in **both** feature states (`server` default, and `--no-default-features` lib — the integration tests are `server`-only by the crate's existing layout);
- privacy-claims gate (`scripts/check-privacy-claims.sh`) and wasm-deps guard (`scripts/wasm-deps-guard.sh`) pass;
- net rustdoc intra-doc-link delta is **zero** (qualified my new links).

rustfmt is informational in CI (the workspace-wide reformat is deliberately deferred per `rustfmt.toml`), so I did not run `cargo fmt --all` — that would reformat 20+ untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)