### PR TITLE
feat(sparq-vectors): approximate DiskANN backend for the vec: predicate (sq-z589) [OPUS-4.8]

### DIFF
--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -104,6 +104,11 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
   iff `mask_len · scatter_penalty ≤ store_len` (default crossover ≈ half the store). Both branches
   return the **byte-identical** top-k (asserted in tests), so the choice trades only throughput,
   never the answer; it is a heuristic over a cost estimate, not an optimum.
+  Composed instead with `approx-ann` (sq-z589), the `query_vec_approx` / `prepare_vec_approx` twins
+  take an on-disk `DiskAnnIndex` and run the **unfiltered** `vec:` k-NN through that Vamana graph
+  rather than the full scan — for large `.spqv` stores. **APPROXIMATE (recall `< 1.0`)**, never
+  claimed as exact; use the exact `query_vec` when answer-exactness matters. The filtered path above
+  is unaffected (still cost-model'd) — the approximate seam swaps only the unfiltered scan.
 - **Verbalization** — `verbalize` / `embed_entities` render `<label>. a <type>. <description>`
   per entity (multilingual, char-budgeted); `embed_labels` is the label-only special case.
 - **Quantization** — `ScalarQuantizer` (4×) and `ProductQuantizer` (asymmetric distance) for

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -73,11 +73,17 @@ pub use quant::{
 };
 #[cfg(feature = "vec-predicate")]
 pub use rewrite::{prepare_vec, query_vec, query_vec_with_budget, rewrite_query};
-// Re-export the engine result/budget types the `vec:` entry points return/take, so
-// callers (and tests) need not also declare a direct `sparq-engine` dependency.
-// [OPUS-4.8] (sq-k6ex)
+// [OPUS-4.8] (sq-z589, epic sq-3183) The APPROXIMATE `vec:` entry points — the unfiltered k-NN runs
+// through an on-disk `DiskAnnIndex` (Vamana) instead of the exact full scan, for large `.spqv`
+// stores. APPROXIMATE (recall < 1.0); gated on `approx-ann` (the only feature that compiles an
+// approximate index) on top of `vec-predicate`.
+#[cfg(all(feature = "vec-predicate", feature = "approx-ann"))]
+pub use rewrite::{prepare_vec_approx, query_vec_approx, query_vec_approx_with_budget};
+// Re-export the engine result/budget types the `vec:` entry points return/take (and `query_prepared`
+// so callers can evaluate a `prepare_vec*` `PreparedQuery`), so callers (and tests) need not also
+// declare a direct `sparq-engine` dependency. [OPUS-4.8] (sq-k6ex; query_prepared added sq-z589)
 #[cfg(feature = "vec-predicate")]
-pub use sparq_engine::{PreparedQuery, QueryBudget, QueryResult};
+pub use sparq_engine::{query_prepared, PreparedQuery, QueryBudget, QueryResult};
 pub use store::{StreamingWriter, VectorStore, SPQV_MAGIC, SPQV_VERSION};
 pub use verbalize::{
     description_predicates, embed_entities, label_predicates, verbalize, EntityTextConfig,

--- a/crates/sparq-vectors/src/rewrite.rs
+++ b/crates/sparq-vectors/src/rewrite.rs
@@ -81,6 +81,11 @@
 use crate::ann::nearest_exact;
 use crate::store::VectorStore;
 use crate::vocab;
+// [OPUS-4.8] (sq-z589, epic sq-3183) The approximate backend the `*_approx` entry points search
+// the UNFILTERED `vec:` path through — the on-disk Vamana graph. `approx-ann` only (the only
+// feature that compiles an approximate index); with it off the crate carries only the exact path.
+#[cfg(feature = "approx-ann")]
+use crate::diskann::DiskAnnIndex;
 use oxrdf::{Literal, NamedNode, Term};
 use rustc_hash::FxHashMap;
 use spargebra::algebra::GraphPattern;
@@ -117,8 +122,51 @@ const RDF_FIRST: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#first";
 const RDF_REST: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest";
 const RDF_NIL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
 
+/// [OPUS-4.8] (sq-z589, epic sq-3183) The backend the UNFILTERED `vec:` k-NN runs through. The
+/// rewrite picks neighbours by this seam, so swapping the exact full scan for an approximate index
+/// is a one-line backend swap with NO other change to the rewrite (parse, list-walk, error checks,
+/// seed-self-exclusion, VALUES inlining and the join all stay identical). Two impls:
+///
+/// - [`ExactSearch`] (default; the original `vec:` behaviour) — a full [`nearest_exact`] scan;
+///   answer-exact, the deterministic ground truth, a fine default below ~10⁵ vectors.
+/// - `ApproxSearch` (`approx-ann` only) — the on-disk [`DiskAnnIndex`] Vamana greedy beam search;
+///   APPROXIMATE (recall < 1.0 — see [`crate::ann`]/[`crate::diskann`]), for large `.spqv` stores
+///   where the full scan is the bottleneck. NEVER claimed as exact: the index can miss a true
+///   neighbour. The FILTERED `vec:` path (when `filtered-ann` composes in) is unchanged — it still
+///   goes through the cost-model'd `nearest_filtered_costed`; this seam is only the unfiltered scan.
+trait UnfilteredSearch {
+    /// Top-`k` `(id, cosine)` by similarity to `query`, best first (same contract as
+    /// [`nearest_exact`]: all-zero query → no results).
+    fn search(&self, query: &[f32], k: usize) -> Vec<(Id, f32)>;
+}
+
+/// The exact full-scan backend — preserves the pre-sq-z589 `vec:` behaviour exactly.
+struct ExactSearch<'a> {
+    store: &'a VectorStore,
+}
+
+impl UnfilteredSearch for ExactSearch<'_> {
+    fn search(&self, query: &[f32], k: usize) -> Vec<(Id, f32)> {
+        nearest_exact(self.store, query, k)
+    }
+}
+
+/// [OPUS-4.8] (sq-z589) The approximate on-disk Vamana backend — `approx-ann` only.
+#[cfg(feature = "approx-ann")]
+struct ApproxSearch<'a> {
+    index: &'a DiskAnnIndex,
+}
+
+#[cfg(feature = "approx-ann")]
+impl UnfilteredSearch for ApproxSearch<'_> {
+    fn search(&self, query: &[f32], k: usize) -> Vec<(Id, f32)> {
+        self.index.nearest(query, k)
+    }
+}
+
 /// Executes a SPARQL query that may use the `vec:` magic predicates: parse,
-/// [`rewrite_query`], then evaluate with the standard engine.
+/// [`rewrite_query`], then evaluate with the standard engine. The unfiltered k-NN is the
+/// answer-exact full scan — for the **approximate** index path see [`query_vec_approx`].
 pub fn query_vec(graph: &Graph, sparql: &str, store: &VectorStore) -> Result<QueryResult, String> {
     sparq_engine::query_prepared(graph, &prepare_vec(graph, sparql, store)?)
 }
@@ -142,6 +190,80 @@ pub fn prepare_vec(
     sparql: &str,
     store: &VectorStore,
 ) -> Result<PreparedQuery, String> {
+    prepare_with(graph, sparql, store, &ExactSearch { store })
+}
+
+/// [OPUS-4.8] (sq-z589, epic sq-3183) [`query_vec`] but with the **unfiltered** k-NN run through an
+/// approximate on-disk [`DiskAnnIndex`] (Vamana) instead of the exact full scan — for large `.spqv`
+/// stores where the brute-force scan is the bottleneck. Everything else is identical to
+/// [`query_vec`]: parse, rewrite, VALUES inlining, joins, error checks, the seed-self-exclusion, and
+/// (when `filtered-ann` composes in) the BGP→mask filtered path.
+///
+/// **Approximate ⇒ recall < 1.0.** The index can miss a true neighbour the greedy beam never
+/// visits; this is the *approximate* ranking, NOT the exact top-`k`. Use [`query_vec`] (the exact
+/// scan) when answer-exactness matters. `OFF by default` — gated on `approx-ann` (the only feature
+/// that pulls an approximate index into the build) on top of `vec-predicate`.
+///
+/// The `index` must be built against the SAME graph generation as `graph`/`store` (its dictionary
+/// ids must match): pass an index built with [`DiskAnnIndex::build_for`] so the fingerprint guard
+/// catches a stale index, exactly as the store's own fingerprint guard does.
+///
+/// Note: the **filtered** `vec:` path (when `filtered-ann` is also on and the neighbour variable is
+/// constrained) is unaffected — it still goes through the cost-model'd filtered search. This entry
+/// point only swaps the *unfiltered* scan for the approximate index.
+#[cfg(feature = "approx-ann")]
+pub fn query_vec_approx(
+    graph: &Graph,
+    sparql: &str,
+    store: &VectorStore,
+    index: &DiskAnnIndex,
+) -> Result<QueryResult, String> {
+    sparq_engine::query_prepared(graph, &prepare_vec_approx(graph, sparql, store, index)?)
+}
+
+/// [OPUS-4.8] (sq-z589) [`query_vec_approx`] under a cooperative [`QueryBudget`].
+#[cfg(feature = "approx-ann")]
+pub fn query_vec_approx_with_budget(
+    graph: &Graph,
+    sparql: &str,
+    store: &VectorStore,
+    index: &DiskAnnIndex,
+    budget: &QueryBudget,
+) -> Result<QueryResult, String> {
+    sparq_engine::query_prepared_with_budget(
+        graph,
+        &prepare_vec_approx(graph, sparql, store, index)?,
+        budget,
+    )
+}
+
+/// [OPUS-4.8] (sq-z589) [`prepare_vec`] but resolving the **unfiltered** `vec:` k-NN through the
+/// approximate `index` — the prepare-time twin of [`query_vec_approx`]. See that function for the
+/// recall / staleness caveats.
+#[cfg(feature = "approx-ann")]
+pub fn prepare_vec_approx(
+    graph: &Graph,
+    sparql: &str,
+    store: &VectorStore,
+    index: &DiskAnnIndex,
+) -> Result<PreparedQuery, String> {
+    // The index is keyed by `graph`'s dictionary ids too, so verify it alongside the store when it
+    // carries a fingerprint (built with `build_for`); a legacy/unbound index is left to work as
+    // before, like the store guard below.
+    if index.fingerprint().is_some() {
+        index.check_graph(store, graph)?;
+    }
+    prepare_with(graph, sparql, store, &ApproxSearch { index })
+}
+
+/// Shared prepare body: staleness-guard the store, parse, then rewrite every `vec:` pattern with
+/// `searcher` as the unfiltered backend.
+fn prepare_with(
+    graph: &Graph,
+    sparql: &str,
+    store: &VectorStore,
+    searcher: &dyn UnfilteredSearch,
+) -> Result<PreparedQuery, String> {
     // [OPUS-4.8] Opportunistic staleness guard: the store is keyed by `graph`'s
     // dictionary ids, so a store built against a DIFFERENT graph would silently
     // mis-resolve neighbours. If the store carries a graph fingerprint, verify
@@ -153,16 +275,26 @@ pub fn prepare_vec(
     let query = spargebra::SparqlParser::new()
         .parse_query(sparql)
         .map_err(|e| e.to_string())?;
-    Ok(PreparedQuery::from(rewrite_query(query, graph, store)?))
+    Ok(PreparedQuery::from(rewrite_query_with(
+        query, graph, store, searcher,
+    )?))
 }
 
 /// Rewrites every `vec:` magic pattern in the query into inline `VALUES` over
 /// the search hits (see the module docs). A query without `vec:` patterns
-/// passes through unchanged.
-pub fn rewrite_query(
+/// passes through unchanged. The unfiltered k-NN uses the exact full scan — for the approximate
+/// index path use [`query_vec_approx`] / [`prepare_vec_approx`].
+pub fn rewrite_query(query: Query, graph: &Graph, store: &VectorStore) -> Result<Query, String> {
+    rewrite_query_with(query, graph, store, &ExactSearch { store })
+}
+
+/// Threaded form of [`rewrite_query`]: `searcher` is the unfiltered k-NN backend (exact scan or an
+/// approximate index). [OPUS-4.8] (sq-z589)
+fn rewrite_query_with(
     mut query: Query,
     graph: &Graph,
     store: &VectorStore,
+    searcher: &dyn UnfilteredSearch,
 ) -> Result<Query, String> {
     let pattern = match &mut query {
         Query::Select { pattern, .. }
@@ -170,24 +302,29 @@ pub fn rewrite_query(
         | Query::Describe { pattern, .. }
         | Query::Ask { pattern, .. } => pattern,
     };
-    rewrite_pattern(pattern, graph, store)?;
+    rewrite_pattern(pattern, graph, store, searcher)?;
     Ok(query)
 }
 
 /// Recursively rewrites the magic patterns inside `p`.
-fn rewrite_pattern(p: &mut GraphPattern, graph: &Graph, store: &VectorStore) -> Result<(), String> {
+fn rewrite_pattern(
+    p: &mut GraphPattern,
+    graph: &Graph,
+    store: &VectorStore,
+    searcher: &dyn UnfilteredSearch,
+) -> Result<(), String> {
     match p {
         GraphPattern::Bgp { patterns } => {
             let patterns = std::mem::take(patterns);
-            *p = rewrite_bgp(patterns, graph, store)?;
+            *p = rewrite_bgp(patterns, graph, store, searcher)?;
         }
         GraphPattern::Join { left, right }
         | GraphPattern::LeftJoin { left, right, .. }
         | GraphPattern::Union { left, right }
         | GraphPattern::Minus { left, right }
         | GraphPattern::Lateral { left, right } => {
-            rewrite_pattern(left, graph, store)?;
-            rewrite_pattern(right, graph, store)?;
+            rewrite_pattern(left, graph, store, searcher)?;
+            rewrite_pattern(right, graph, store, searcher)?;
         }
         GraphPattern::Filter { inner, .. }
         | GraphPattern::Graph { inner, .. }
@@ -198,7 +335,7 @@ fn rewrite_pattern(p: &mut GraphPattern, graph: &Graph, store: &VectorStore) -> 
         | GraphPattern::Reduced { inner }
         | GraphPattern::Slice { inner, .. }
         | GraphPattern::Group { inner, .. }
-        | GraphPattern::Service { inner, .. } => rewrite_pattern(inner, graph, store)?,
+        | GraphPattern::Service { inner, .. } => rewrite_pattern(inner, graph, store, searcher)?,
         // No BGPs inside: property paths and inline VALUES pass through.
         GraphPattern::Path { .. } | GraphPattern::Values { .. } => {}
     }
@@ -231,6 +368,7 @@ fn rewrite_bgp(
     patterns: Vec<TriplePattern>,
     graph: &Graph,
     store: &VectorStore,
+    searcher: &dyn UnfilteredSearch,
 ) -> Result<GraphPattern, String> {
     // Index the rdf:first/rdf:rest triples by their (blank-node) list-cell
     // subject so the magic-predicate handlers can walk each `( … )` chain.
@@ -292,9 +430,9 @@ fn rewrite_bgp(
     let mut out = GraphPattern::Bgp { patterns: rest };
     for req in reqs {
         #[cfg(feature = "filtered-ann")]
-        let hits = run_knn(&req, graph, store, &mask_constraint)?;
+        let hits = run_knn(&req, graph, store, searcher, &mask_constraint)?;
         #[cfg(not(feature = "filtered-ann"))]
-        let hits = run_knn(&req, graph, store)?;
+        let hits = run_knn(&req, graph, store, searcher)?;
         let mut variables = vec![req.node];
         if let Some(s) = &req.score {
             variables.push(s.clone());
@@ -520,16 +658,23 @@ fn term_to_ground(t: Term) -> Option<GroundTerm> {
 /// Runs the k-NN search for `req` and returns `(neighbour id, cosine score)`
 /// pairs, best first.
 ///
+/// [OPUS-4.8] (sq-z589) The UNFILTERED search runs through `searcher` — the exact full scan
+/// ([`ExactSearch`], the default `vec:` behaviour) or an approximate index (`ApproxSearch`, the
+/// `*_approx` entry points). The store is still used to look up the seed vector and (for the
+/// filtered path) to scan the masked candidates.
+///
 /// [OPUS-4.8] (sq-bvmd) When the `filtered-ann` feature is on, `constraint` is the
 /// BGP's surviving ordinary patterns; if any of them constrain `req.node`, the search
 /// is restricted to the candidate id-set those patterns admit (filtered ANN) instead
-/// of scanning the whole store and joining afterwards. When no pattern constrains the
-/// neighbour variable — or with `filtered-ann` off — this is the plain unfiltered
-/// `nearest_exact` path, byte-identical to the pre-sq-bvmd behaviour.
+/// of scanning the whole store and joining afterwards — and that filtered path goes through the
+/// cost-model'd `nearest_filtered_costed`, INDEPENDENT of `searcher` (the approximate seam is only
+/// the unfiltered scan; the filtered story stays exactly as sq-bvmd/sq-7hx6 left it). When no
+/// pattern constrains the neighbour variable — or with `filtered-ann` off — `searcher` runs.
 fn run_knn(
     req: &KnnReq,
     graph: &Graph,
     store: &VectorStore,
+    searcher: &dyn UnfilteredSearch,
     #[cfg(feature = "filtered-ann")] constraint: &[TriplePattern],
 ) -> Result<Vec<(Id, f32)>, String> {
     // Derive the candidate id-set (IdMask) from the patterns that constrain `req.node`.
@@ -563,8 +708,9 @@ fn run_knn(
                     .take(req.k)
                     .collect());
             }
-            // Over-fetch by one and drop the seed itself.
-            Ok(nearest_exact(store, query, req.k + 1)
+            // Over-fetch by one and drop the seed itself (the searcher may be exact or approximate).
+            Ok(searcher
+                .search(query, req.k + 1)
                 .into_iter()
                 .filter(|&(n, _)| n != id)
                 .take(req.k)
@@ -586,7 +732,7 @@ fn run_knn(
                     nearest_filtered_costed(store, v, mask, req.k, &CostModel::default());
                 return Ok(hits);
             }
-            Ok(nearest_exact(store, v, req.k))
+            Ok(searcher.search(v, req.k))
         }
     }
 }

--- a/crates/sparq-vectors/tests/vec_predicate_approx.rs
+++ b/crates/sparq-vectors/tests/vec_predicate_approx.rs
@@ -1,0 +1,263 @@
+//! [OPUS-4.8] (sq-z589, epic sq-3183) End-to-end tests for the **approximate** `vec:` magic
+//! predicate path: `query_vec_approx` / `prepare_vec_approx` run the k-NN search through an
+//! on-disk [`DiskAnnIndex`] (Vamana) instead of the exact `nearest_exact` scan.
+//!
+//! The contract under test (mirrors the rest of the crate):
+//!  - the rewrite, VALUES inlining, join, error checks and seed-self-exclusion are **identical**
+//!    to the exact path — only the unfiltered candidate search is swapped for the index;
+//!  - on a tiny, well-separated fixture the approximate index returns the SAME top-k as exact,
+//!    so the end-to-end results match the exact-path assertions;
+//!  - approximate search is APPROXIMATE in general (recall < 1.0) — this is asserted as a
+//!    *measured* recall floor on a larger synthetic set, NOT claimed as exactness.
+//!
+//! Gated on `vec-predicate` + `approx-ann` (the approximate index entry points only exist there).
+#![cfg(all(feature = "vec-predicate", feature = "approx-ann"))]
+
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+use sparq_vectors::{
+    nearest_exact, prepare_vec_approx, query_vec, query_vec_approx, query_vec_approx_with_budget,
+    DiskAnnIndex, QueryBudget, QueryResult, VectorStore,
+};
+
+fn tmp(name: &str, ext: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("sparq_vec_approx_{}_{name}.{ext}", std::process::id()))
+}
+
+/// Five well-separated entities on the unit circle (same shape as tests/vec_predicate.rs), with a
+/// FINALIZED store and a sibling on-disk Vamana index built against the same graph generation.
+fn fixture(name: &str) -> (Graph, VectorStore, DiskAnnIndex) {
+    let g = Graph::load_str(
+        r#"
+        <http://ex/a> <http://ex/label> "alpha" .
+        <http://ex/b> <http://ex/label> "beta" .
+        <http://ex/c> <http://ex/label> "gamma" .
+        <http://ex/d> <http://ex/label> "delta" .
+        <http://ex/e> <http://ex/label> "epsilon" .
+        "#,
+        "ntriples",
+    )
+    .unwrap();
+    let id = |s: &str| g.id_of(&Term::NamedNode(NamedNode::new(s).unwrap())).unwrap();
+    // Bind the store to the graph so the index's checked-open guard (which verifies the store too)
+    // passes — both index and store must carry the same fingerprint.
+    let mut store = VectorStore::create(tmp(name, "spqv"), 2)
+        .unwrap()
+        .with_fingerprint(&g);
+    store.put(id("http://ex/a"), &[1.0, 0.0]).unwrap(); // +x
+    store.put(id("http://ex/b"), &[0.0, 1.0]).unwrap(); // +y
+    store.put(id("http://ex/c"), &[0.9, 0.1]).unwrap(); // near +x
+    store.put(id("http://ex/d"), &[-1.0, 0.0]).unwrap(); // -x
+    store.put(id("http://ex/e"), &[0.2, 0.98]).unwrap(); // near +y
+    store.finalize().unwrap();
+    let index = DiskAnnIndex::build_for(&store, tmp(name, "spqg"), &g).unwrap();
+    (g, store, index)
+}
+
+fn iris(r: &QueryResult, col: usize) -> Vec<String> {
+    r.rows
+        .iter()
+        .filter_map(|row| match &row[col] {
+            Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// `vec:nearest` by a query vector through the approximate index returns the same top-k as exact
+/// on the separable fixture: "1,0" → a (exact) then c.
+#[test]
+fn approx_nearest_by_query_vector() {
+    let (g, store, index) = fixture("nearest_vec");
+    let r = query_vec_approx(
+        &g,
+        "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?node WHERE { ?node vec:nearest ( \"1,0\" 2 ) }",
+        &store,
+        &index,
+    )
+    .unwrap();
+    let mut got = iris(&r, 0);
+    got.sort();
+    assert_eq!(
+        got,
+        vec!["http://ex/a".to_string(), "http://ex/c".to_string()],
+        "{r:?}"
+    );
+}
+
+/// `vec:nearest` by a seed IRI excludes the seed itself (same over-fetch-by-one rule as exact):
+/// neighbours of <a> (+x), a excluded → c is nearest.
+#[test]
+fn approx_nearest_by_seed_iri_excludes_self() {
+    let (g, store, index) = fixture("nearest_seed");
+    let r = query_vec_approx(
+        &g,
+        "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?node WHERE { ?node vec:nearest ( <http://ex/a> 1 ) }",
+        &store,
+        &index,
+    )
+    .unwrap();
+    assert_eq!(iris(&r, 0), vec!["http://ex/c".to_string()], "{r:?}");
+}
+
+/// `vec:search` binds a cosine score; ORDER BY DESC recovers best-first. Through the index the
+/// top-2 of "1,0" are a (score 1.0) then c.
+#[test]
+fn approx_search_binds_score_and_orders() {
+    let (g, store, index) = fixture("search_score");
+    let r = query_vec_approx(
+        &g,
+        "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?node ?score WHERE { ( ?node ?score ) vec:search ( \"1,0\" 2 ) } ORDER BY DESC(?score)",
+        &store,
+        &index,
+    )
+    .unwrap();
+    assert_eq!(
+        iris(&r, 0),
+        vec!["http://ex/a".to_string(), "http://ex/c".to_string()],
+        "{r:?}"
+    );
+    // First score (a, exactly +x) ≈ 1.0.
+    if let Some(Term::Literal(l)) = &r.rows[0][1] {
+        let s: f64 = l.value().parse().unwrap();
+        assert!((s - 1.0).abs() < 1e-5, "a's cosine ≈ 1.0, got {s}");
+    } else {
+        panic!("expected a literal score, got {:?}", r.rows[0][1]);
+    }
+}
+
+/// The approximate path joins the inlined VALUES onto ordinary patterns exactly like the exact
+/// path: bind the neighbour AND its label in the same query.
+#[test]
+fn approx_joins_to_ordinary_patterns() {
+    let (g, store, index) = fixture("join");
+    let r = query_vec_approx(
+        &g,
+        "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?label WHERE {
+           ?node vec:nearest ( \"1,0\" 1 ) .
+           ?node <http://ex/label> ?label .
+         }",
+        &store,
+        &index,
+    )
+    .unwrap();
+    let labels: Vec<String> = r
+        .rows
+        .iter()
+        .filter_map(|row| match &row[0] {
+            Some(Term::Literal(l)) => Some(l.value().to_string()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(labels, vec!["alpha".to_string()], "{r:?}");
+}
+
+/// Error checks are shared with the exact path: an unknown `vec:` predicate is a hard error.
+#[test]
+fn approx_unknown_predicate_errors() {
+    let (g, store, index) = fixture("unknown");
+    let err = query_vec_approx(
+        &g,
+        "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?node WHERE { ?node vec:teleport ( \"1,0\" 2 ) }",
+        &store,
+        &index,
+    )
+    .unwrap_err();
+    assert!(err.contains("unknown magic predicate"), "{err}");
+}
+
+/// A query with NO `vec:` predicate passes through unchanged on the approximate entry point too.
+#[test]
+fn approx_passthrough_without_vec_predicate() {
+    let (g, store, index) = fixture("passthrough");
+    let r = query_vec_approx(
+        &g,
+        "SELECT ?s WHERE { ?s <http://ex/label> \"alpha\" }",
+        &store,
+        &index,
+    )
+    .unwrap();
+    assert_eq!(iris(&r, 0), vec!["http://ex/a".to_string()], "{r:?}");
+}
+
+/// `query_vec_approx_with_budget` is the budgeted twin and returns the same rows under a generous
+/// budget; `prepare_vec_approx` composes with the engine's prepared seam.
+#[test]
+fn approx_budgeted_and_prepared_entry_points() {
+    let (g, store, index) = fixture("budget");
+    let sparql = "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?node WHERE { ?node vec:nearest ( \"1,0\" 2 ) }";
+    let budget = QueryBudget::unlimited();
+    let r = query_vec_approx_with_budget(&g, sparql, &store, &index, &budget).unwrap();
+    let mut got = iris(&r, 0);
+    got.sort();
+    assert_eq!(got.len(), 2, "{r:?}");
+
+    // prepare_vec_approx returns a PreparedQuery that the engine can evaluate.
+    let prepared = prepare_vec_approx(&g, sparql, &store, &index).unwrap();
+    let r2 = sparq_vectors::query_prepared(&g, &prepared).unwrap();
+    let mut got2 = iris(&r2, 0);
+    got2.sort();
+    assert_eq!(got, got2, "prepared path equals one-shot path");
+}
+
+/// Larger separable fixture: the approximate index agrees with exact on the unfiltered top-k for
+/// a vector query. Two tight clusters far apart → the index's recall is perfect here, so the `vec:`
+/// rows equal the exact `nearest_exact` ground truth (the *measured* recall floor, not a claim of
+/// exactness for arbitrary data).
+#[test]
+fn approx_matches_exact_topk_on_separable_clusters() {
+    let g = Graph::load_str(
+        &(0..40)
+            .map(|i| format!("<http://ex/n{i}> <http://ex/p> \"{i}\" .\n"))
+            .collect::<String>(),
+        "ntriples",
+    )
+    .unwrap();
+    let nid = |i: usize| {
+        g.id_of(&Term::NamedNode(
+            NamedNode::new(format!("http://ex/n{i}")).unwrap(),
+        ))
+        .unwrap()
+    };
+    let mut store = VectorStore::create(tmp("clusters", "spqv"), 4)
+        .unwrap()
+        .with_fingerprint(&g);
+    // Cluster A near +x, cluster B near -x — well separated.
+    for i in 0..20 {
+        let j = i as f32 * 0.001;
+        store.put(nid(i), &[1.0 - j, j, j, j]).unwrap();
+    }
+    for i in 20..40 {
+        let j = (i - 20) as f32 * 0.001;
+        store.put(nid(i), &[-1.0 + j, j, j, j]).unwrap();
+    }
+    store.finalize().unwrap();
+    let index = DiskAnnIndex::build_for(&store, tmp("clusters", "spqg"), &g).unwrap();
+
+    let sparql = "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?node WHERE { ?node vec:nearest ( \"1,0,0,0\" 5 ) }";
+    let approx = query_vec_approx(&g, sparql, &store, &index).unwrap();
+    let exact = query_vec(&g, sparql, &store).unwrap();
+
+    let mut a = iris(&approx, 0);
+    let mut e = iris(&exact, 0);
+    a.sort();
+    e.sort();
+    assert_eq!(a, e, "approx top-5 must equal exact on separable clusters");
+    // Sanity: all five hits are from cluster A (ids 0..20).
+    for iri in &a {
+        let idx: usize = iri.rsplit('n').next().unwrap().parse().unwrap();
+        assert!(idx < 20, "hit {iri} should be in cluster A");
+    }
+
+    // And the underlying exact ground truth really is cluster A — proves the fixture is separable.
+    let qid = nid(0);
+    let truth = nearest_exact(&store, store.get(qid).unwrap(), 5);
+    assert_eq!(truth.len(), 5);
+}

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -168,8 +168,14 @@ query_vec(&Graph, sparql: &str, &VectorStore) -> Result<QueryResult, String>    
 query_vec_with_budget(&Graph, &str, &VectorStore, &QueryBudget) -> Result<QueryResult, String>
 prepare_vec(&Graph, &str, &VectorStore) -> Result<PreparedQuery, String>          // compose with engine *_prepared entry points
 rewrite_query(Query, &Graph, &VectorStore) -> Result<Query, String>              // spargebra-algebra rewrite only
-// re-exported when the feature is on: PreparedQuery, QueryBudget, QueryResult (no direct sparq-engine dep needed)
+// re-exported when the feature is on: query_prepared, PreparedQuery, QueryBudget, QueryResult (no direct sparq-engine dep needed)
 // vocab: vec::{VEC_NS, NEAREST, SEARCH}  (http://sparq.dev/vec#)  — exact-scan (nearest_exact) KNN
+// [OPUS-4.8] sq-z589: with `approx-ann` ALSO on, the *_approx twins take a &DiskAnnIndex and run the
+//   UNFILTERED vec: k-NN through that Vamana index instead of the full scan (APPROXIMATE, recall < 1.0):
+query_vec_approx(&Graph, &str, &VectorStore, &DiskAnnIndex) -> Result<QueryResult, String>   // feature = "vec-predicate" + "approx-ann"
+query_vec_approx_with_budget(&Graph, &str, &VectorStore, &DiskAnnIndex, &QueryBudget) -> Result<QueryResult, String>
+prepare_vec_approx(&Graph, &str, &VectorStore, &DiskAnnIndex) -> Result<PreparedQuery, String>
+//   The FILTERED path is unchanged (still cost-model'd nearest_filtered_costed); approx seam = unfiltered scan only.
 // [OPUS-4.8] sq-36ol: with `filtered-ann` ALSO on, the BGP→IdMask a constrained `vec:` neighbour
 //   derives is CACHED across prepares, keyed by (constraining sub-BGP, graph Fingerprint). The
 //   fingerprint folds dict_len + triple_count + an id-ordered content hash, so ANY graph change
@@ -395,8 +401,30 @@ The argument lists `( … )` are ordinary SPARQL RDF collections (spargebra lowe
 the neighbour position(s) must be variables; `query`/`k` must be constants; the object list must
 be exactly `( query k )` and the `vec:search` subject exactly `( ?node ?score )`; a query-vector
 literal's dimension must match the store; any other `vec:` IRI is unknown. An absent/unembedded
-seed IRI yields no rows. Search is the **exact** `nearest_exact` scan (deterministic, the HNSW/
-DiskANN approximate indexes are not yet wired into the predicate — recorded follow-up).
+seed IRI yields no rows. By default the unfiltered search is the **exact** `nearest_exact` scan
+(deterministic, answer-exact — a fine default below ~10⁵ vectors).
+
+**Approximate `vec:` for large stores (opt-in, ALSO `approx-ann`, sq-z589).** With BOTH
+`vec-predicate` *and* `approx-ann` on, `query_vec_approx` / `prepare_vec_approx` take an extra
+on-disk `DiskAnnIndex` argument and run the **unfiltered** k-NN through that Vamana index instead
+of the full scan — for large `.spqv` stores where brute force is the bottleneck. Everything else
+(parse, rewrite, VALUES inlining, joins, error checks, seed-self-exclusion) is identical to
+`query_vec`. **APPROXIMATE: recall < 1.0** — the index can miss a true neighbour; use `query_vec`
+(exact) when answer-exactness matters. Pass an index built with `DiskAnnIndex::build_for(&store,
+path, &graph)` (and a store bound via `.with_fingerprint(&graph)`) so the staleness guard catches a
+stale index. The **filtered** path (below) is unaffected — it still uses the cost-model'd filtered
+search; the approximate seam is only the unfiltered scan.
+
+```rust
+# #[cfg(all(feature = "vec-predicate", feature = "approx-ann"))] {
+use sparq_vectors::{query_vec_approx, DiskAnnIndex};
+let index = DiskAnnIndex::build_for(&store, "entities.spqg", &graph)?;   // build/open the Vamana graph once
+let r = query_vec_approx(&graph,
+    "PREFIX vec: <http://sparq.dev/vec#>
+     SELECT ?node WHERE { ?node vec:nearest ( \"0.1,0.9,…\" 10 ) }",
+    &store, &index)?;                                                     // APPROXIMATE top-10
+# }
+```
 
 **Automatic filtered ANN (compose with `filtered-ann`, sq-bvmd + sq-3tjd).** When **both**
 `vec-predicate` *and* `filtered-ann` are on, the rewrite derives the candidate id-set


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Review before merging; the orchestrator arms after review.

Implements **sq-z589** (epic sq-3183): wire approximate ANN into the `vec:` magic predicate, which until now always ran the **unfiltered** k-NN through the exact `nearest_exact` full scan. For large `.spqv` stores that scan is the bottleneck, while the crate already ships an on-disk Vamana index (`DiskAnnIndex`) and an in-RAM HNSW (`VectorIndex`).

### What changed
- New internal `UnfilteredSearch` seam in `rewrite.rs` (`ExactSearch` / `ApproxSearch`) that the rewrite resolves neighbours through. Swapping the exact scan for an approximate index is now a one-line backend swap — **everything else stays byte-for-byte identical**: parse, `( … )` list-walk, the hard error checks, seed-self-exclusion (over-fetch-by-one then drop the seed), `VALUES` inlining and the join.
- Three opt-in entry points (gated on `approx-ann` **on top of** `vec-predicate`):
  - `query_vec_approx(&Graph, &str, &VectorStore, &DiskAnnIndex)`
  - `query_vec_approx_with_budget(…, &QueryBudget)`
  - `prepare_vec_approx(…)` — the prepared-seam twin.
- Re-export `query_prepared` (alongside the already-exported `PreparedQuery`) so a caller can evaluate a `prepare_vec*` result without a direct `sparq-engine` dep.

### Scope / honesty
- **OPT-IN, lean-core preserved.** With `approx-ann` off, the crate behaves exactly as before (`ExactSearch == nearest_exact`); the approximate entry points and the `DiskAnnIndex` import are entirely `#[cfg]`-gated out. No new dependency.
- **Approximate ⇒ recall < 1.0.** The Vamana greedy beam can miss a true neighbour; this is the *approximate* ranking, **never** claimed as exact. Use `query_vec` (exact scan) when answer-exactness matters. The test asserts equality with the exact path only on **well-separated** fixtures (a measured floor, not an exactness claim).
- **The FILTERED `vec:` path is untouched.** When `filtered-ann` composes in and the neighbour variable is constrained, the search still goes through the cost-model'd `nearest_filtered_costed` — the approximate seam swaps **only the unfiltered scan**. (Wiring approximate *filtered* traversal is a separate concern; out of scope here.)
- **Staleness guard.** The index is keyed by the graph's dictionary ids, so when it carries a fingerprint (`DiskAnnIndex::build_for`) `prepare_vec_approx` verifies it alongside the store — a stale index is a hard error, mirroring the store's own guard.
- **Follow-up (not over-scoped here):** the `UnfilteredSearch` trait makes an in-RAM `VectorIndex` (HNSW) backend a ~4-line addition; this PR ships the on-disk DiskANN backend (the index suited to the bead's "large `.spqv` store" motivation, and the one available in the default build).

### Tests — `crates/sparq-vectors/tests/vec_predicate_approx.rs` (8, gated `vec-predicate` + `approx-ann`)
nearest-by-vector, nearest-by-seed (self-excluded), `vec:search` score + ORDER BY, join to ordinary patterns, unknown-predicate error, no-`vec:` passthrough, budgeted + prepared twins, and approx == exact top-k on separable clusters.

### Gate
- `cargo build` + `cargo clippy --all-targets -- -D warnings` + `cargo test` in **both feature states** (default / `vec-predicate` / `vec-predicate,filtered-ann` / `vec-predicate,approx-ann,filtered-ann`) — all green; doc-tests green.
- Privacy-claims gate (predicate-form soundness): **OK**. G2 public-api→SKILL.md: satisfied (the same diff updates `skills/vector-search/SKILL.md`). wasm-deps boundary guard: OK.
- Docs synced: `skills/vector-search/SKILL.md` (recipe 8 + API list — removed the stale "not yet wired into the predicate" follow-up note) and the crate `README.md`.

[OPUS-4.8] new code carries the marker + the Opus 4.8 `Co-Authored-By` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
