### PR TITLE
feat(site): live /surface/data-formats — format picker + gzip ingest demo (sq-j50v)

### DIFF
--- a/site/src/app/surface/data-formats/page.tsx
+++ b/site/src/app/surface/data-formats/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Database } from "lucide-react";
 
 import { SurfaceContent } from "@/components/surface-content";
+import { DataFormatsDemo } from "@/components/data-formats-demo";
 
 export const metadata: Metadata = {
   title: "Data formats",
@@ -47,7 +48,7 @@ export default function DataFormatsSurfacePage() {
         },
         {
           title: "Compressed ingest",
-          body: "gzip / zstd RDF dumps decode-and-load; in the browser via SparqStore.fromCompressed().",
+          body: "gzip / zstd / bzip2 RDF dumps decode-and-load natively (fused decompress + parallel parse); gzip also decodes live in the browser.",
         },
         {
           title: "Streaming & parallel loaders",
@@ -70,21 +71,32 @@ export default function DataFormatsSurfacePage() {
         <>
           <p>
             <strong className="text-foreground">Live in your tab</strong> for the
-            four text formats and gzip/zstd-compressed ingest — the same loaders
-            that ship in <code className="font-mono">@jeswr/sparq</code>.
+            four text formats — the demo above runs the same{" "}
+            <code className="font-mono">Store.load</code> /{" "}
+            <code className="font-mono">loadDataset</code> loaders that ship in{" "}
+            <code className="font-mono">@jeswr/sparq</code>, compiled to wasm. The
+            gzip-ingest panel decodes with the browser&apos;s native{" "}
+            <code className="font-mono">DecompressionStream</code> before parsing —
+            no codec library, no server.
           </p>
         </>
       }
       caveat={
         <>
           <p>
-            HDT loading, the mmap / external-memory ingest path, and the
-            fully-parallel fast loaders are <strong className="text-foreground">native-only</strong>
-            ; in the browser they fall back to the in-memory streaming loader.
+            Only <strong className="text-foreground">gzip</strong> decodes in the
+            browser (via <code className="font-mono">DecompressionStream</code>);{" "}
+            <strong className="text-foreground">zstd</strong> and{" "}
+            <strong className="text-foreground">bzip2</strong> ingest, HDT loading,
+            the mmap / external-memory path, and the fully-parallel fast loaders are{" "}
+            <strong className="text-foreground">native-only</strong> — in the
+            browser the in-memory streaming loader is used.
           </p>
         </>
       }
-      links={[{ href: "/try", label: "Load data in the REPL" }]}
-    />
+      links={[{ href: "/try", label: "Open the full SPARQL REPL" }]}
+    >
+      <DataFormatsDemo />
+    </SurfaceContent>
   );
 }

--- a/site/src/components/data-formats-demo.tsx
+++ b/site/src/components/data-formats-demo.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+// [OPUS-4.8] sq-j50v — the LIVE /surface/data-formats demo. Two real, in-tab panels, both
+// driven by the shipped lean wasm Store (no mocks, no server):
+//
+//   1. FORMAT PICKER — pick Turtle / N-Triples / N-Quads / TriG, paste (or edit the seeded
+//      sample), Parse → the engine's triple count + a sample of the parsed triples. Quad
+//      formats route through `loadDataset` so the named graph survives and shows as a ?g
+//      column; the TriG / N-Quads samples include a named-graph example.
+//   2. GZIP INGEST — gzip the current document in-tab via the native `CompressionStream`,
+//      show the size + ratio, then gunzip it back with `DecompressionStream` and parse the
+//      decoded text → triple count. gzip is the one codec the browser decodes natively;
+//      zstd / bzip2 ingest is native-only (see the page's honest caveat).
+
+import * as React from "react";
+import { Loader2, Play, FileArchive, Database, CheckCircle2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  loadSparq,
+  loadIntoStore,
+  prewarmSparq,
+  datasetSize,
+  formatTerm,
+  type SparqlResults,
+  type WasmStore,
+} from "@/lib/sparq-wasm";
+import {
+  FORMAT_SAMPLES,
+  sampleFor,
+  gzipString,
+  gunzipToString,
+  formatBytes,
+  type DataFormat,
+} from "@/lib/data-formats";
+
+// The whole-dataset enumeration: default graph UNION every named graph, so a sample of an
+// N-Quads / TriG document shows its named-graph rows too (?g bound). Same shape the REPL uses.
+const SAMPLE_QUERY =
+  "SELECT ?s ?p ?o ?g WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } } LIMIT 8";
+
+type EngineState = "cold" | "warming" | "ready" | "error";
+
+type ParseState =
+  | { kind: "idle" }
+  | { kind: "running" }
+  | { kind: "ok"; count: number; rows: SparqlResults["results"]["bindings"]; ms: number }
+  | { kind: "error"; message: string };
+
+type GzipState =
+  | { kind: "idle" }
+  | { kind: "running" }
+  | {
+      kind: "ok";
+      rawBytes: number;
+      gzBytes: number;
+      count: number;
+      ms: number;
+    }
+  | { kind: "error"; message: string };
+
+export function DataFormatsDemo() {
+  const [format, setFormat] = React.useState<DataFormat>("turtle");
+  const [text, setText] = React.useState(sampleFor("turtle")?.sample ?? "");
+  const [engine, setEngine] = React.useState<EngineState>("cold");
+  const [parse, setParse] = React.useState<ParseState>({ kind: "idle" });
+  const [gzip, setGzip] = React.useState<GzipState>({ kind: "idle" });
+
+  // Pre-warm the wasm engine on mount so the first Parse pays no cold start. Shares the
+  // single loadSparq promise with the rest of the site.
+  React.useEffect(() => {
+    let cancelled = false;
+    setEngine("warming");
+    prewarmSparq()
+      .then(() => {
+        if (!cancelled) setEngine("ready");
+      })
+      .catch(() => {
+        if (!cancelled) setEngine("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Switch the picked format AND reseed the textarea with that format's sample, so the
+  // chosen syntax always matches the document. (Editing the textarea then keeps the edit.)
+  const pickFormat = React.useCallback((f: DataFormat) => {
+    setFormat(f);
+    setText(sampleFor(f)?.sample ?? "");
+    setParse({ kind: "idle" });
+    setGzip({ kind: "idle" });
+  }, []);
+
+  // Parse the current text in the chosen format and read back the engine's triple count +
+  // a small sample. loadIntoStore routes quad formats through loadDataset (named graphs).
+  const runParse = React.useCallback(async () => {
+    setParse({ kind: "running" });
+    try {
+      const Store = await loadSparq();
+      setEngine("ready");
+      const t0 = performance.now();
+      const store: WasmStore = loadIntoStore(Store, text, format);
+      const count = datasetSize(store);
+      const rows = (
+        JSON.parse(store.query(SAMPLE_QUERY)) as SparqlResults
+      ).results.bindings;
+      const ms = performance.now() - t0;
+      setParse({ kind: "ok", count, rows, ms });
+    } catch (e) {
+      setParse({
+        kind: "error",
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }, [text, format]);
+
+  // The gzip ingest path: gzip the current document in-tab, then gunzip it back and parse
+  // the decoded text — the same JS-side decode a real `.ttl.gz` upload would take.
+  const runGzip = React.useCallback(async () => {
+    setGzip({ kind: "running" });
+    try {
+      const rawBytes = new TextEncoder().encode(text).byteLength;
+      const gz = await gzipString(text);
+      const decoded = await gunzipToString(gz);
+      const Store = await loadSparq();
+      setEngine("ready");
+      const t0 = performance.now();
+      const store = loadIntoStore(Store, decoded, format);
+      const count = datasetSize(store);
+      const ms = performance.now() - t0;
+      setGzip({ kind: "ok", rawBytes, gzBytes: gz.byteLength, count, ms });
+    } catch (e) {
+      setGzip({
+        kind: "error",
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }, [text, format]);
+
+  const busy = parse.kind === "running" || gzip.kind === "running";
+  const disabled = engine === "cold" || engine === "warming";
+
+  return (
+    <section className="space-y-4" aria-labelledby="data-formats-demo-heading">
+      <h2 id="data-formats-demo-heading" className="text-xl font-semibold">
+        Try it: parse RDF in your tab
+      </h2>
+
+      <Card>
+        <CardHeader className="flex-row items-center justify-between gap-2 space-y-0">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Database className="size-4 text-primary" aria-hidden="true" />
+            Format picker
+          </CardTitle>
+          <EngineIndicator engine={engine} />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div
+            role="tablist"
+            aria-label="RDF text format"
+            className="flex flex-wrap gap-1.5"
+          >
+            {FORMAT_SAMPLES.map((f) => (
+              <Button
+                key={f.format}
+                role="tab"
+                aria-selected={format === f.format}
+                variant={format === f.format ? "default" : "outline"}
+                size="sm"
+                onClick={() => pickFormat(f.format)}
+              >
+                {f.label}
+                <span className="ml-1 font-mono text-[11px] opacity-70">
+                  {f.ext}
+                </span>
+              </Button>
+            ))}
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            {sampleFor(format)?.blurb}
+          </p>
+
+          <label htmlFor="data-formats-input" className="sr-only">
+            RDF document to parse
+          </label>
+          <textarea
+            id="data-formats-input"
+            value={text}
+            spellCheck={false}
+            onChange={(e) => setText(e.target.value)}
+            rows={10}
+            className="w-full resize-y rounded-lg border bg-muted/40 p-3 font-mono text-[13px] leading-relaxed outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+          />
+
+          <div className="flex items-center gap-3">
+            <Button onClick={runParse} disabled={busy || disabled}>
+              {parse.kind === "running" ? (
+                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <Play className="size-4" aria-hidden="true" />
+              )}
+              Parse
+            </Button>
+            <p aria-live="polite" className="text-xs text-muted-foreground">
+              {parse.kind === "ok" &&
+                `${parse.count} triples · parsed in ${parse.ms.toFixed(1)} ms`}
+              {parse.kind === "running" && "Parsing on the wasm engine…"}
+              {parse.kind === "idle" &&
+                engine === "warming" &&
+                "Pre-warming the wasm engine…"}
+            </p>
+          </div>
+
+          <ParseResult state={parse} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex-row items-center gap-2 space-y-0">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <FileArchive className="size-4 text-primary" aria-hidden="true" />
+            Compressed (gzip) ingest
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            gzip the document above entirely in your tab (the browser&apos;s native{" "}
+            <code className="font-mono text-foreground">CompressionStream</code>),
+            then decode it back with{" "}
+            <code className="font-mono text-foreground">DecompressionStream</code>{" "}
+            and parse the decoded text — the same JS-side decode a{" "}
+            <code className="font-mono">.ttl.gz</code> upload takes before reaching{" "}
+            <code className="font-mono">Store.load</code>.
+          </p>
+
+          <div className="flex items-center gap-3">
+            <Button
+              variant="outline"
+              onClick={runGzip}
+              disabled={busy || disabled}
+            >
+              {gzip.kind === "running" ? (
+                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <FileArchive className="size-4" aria-hidden="true" />
+              )}
+              gzip → decode → parse
+            </Button>
+            <p aria-live="polite" className="text-xs text-muted-foreground">
+              {gzip.kind === "running" && "Compressing & decoding in your tab…"}
+            </p>
+          </div>
+
+          <GzipResult state={gzip} />
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
+// Subtle engine-readiness pill, mirroring the REPL's indicator.
+function EngineIndicator({ engine }: { engine: EngineState }) {
+  if (engine === "ready") {
+    return (
+      <Badge variant="success" aria-live="polite">
+        <CheckCircle2 className="size-3" aria-hidden="true" /> Engine ready
+      </Badge>
+    );
+  }
+  if (engine === "error") {
+    return (
+      <Badge variant="warning" aria-live="polite">
+        Engine failed — retries on parse
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="muted" aria-live="polite">
+      <Loader2 className="size-3 animate-spin" aria-hidden="true" /> Engine
+      loading…
+    </Badge>
+  );
+}
+
+function ParseResult({ state }: { state: ParseState }) {
+  if (state.kind === "error") {
+    return (
+      <pre className="overflow-x-auto rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+        {state.message}
+      </pre>
+    );
+  }
+  if (state.kind !== "ok") return null;
+
+  const hasGraphs = state.rows.some((r) => r.g);
+  return (
+    <div className="space-y-2">
+      <Badge variant="muted" className="tabular">
+        <Database className="size-3" aria-hidden="true" /> {state.count} triples
+      </Badge>
+      {state.rows.length === 0 ? (
+        <p className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+          Parsed, but the document has no triples.
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-muted/50">
+              <tr>
+                {["subject", "predicate", "object"].map((h) => (
+                  <th key={h} className="px-3 py-2 font-medium">
+                    {h}
+                  </th>
+                ))}
+                {hasGraphs && (
+                  <th className="px-3 py-2 font-medium">graph</th>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {state.rows.map((r, i) => (
+                <tr key={i} className="border-t">
+                  {(["s", "p", "o"] as const).map((k) => (
+                    <td
+                      key={k}
+                      className={cn(
+                        "px-3 py-1.5 font-mono text-[12px]",
+                        k === "o" && "break-all",
+                      )}
+                    >
+                      {formatTerm(r[k])}
+                    </td>
+                  ))}
+                  {hasGraphs && (
+                    <td className="px-3 py-1.5 font-mono text-[12px] break-all text-muted-foreground">
+                      {r.g ? formatTerm(r.g) : "—"}
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      <p className="text-xs text-muted-foreground">
+        A sample of up to 8 triples, read straight out of the live store.
+      </p>
+    </div>
+  );
+}
+
+function GzipResult({ state }: { state: GzipState }) {
+  if (state.kind === "error") {
+    return (
+      <pre className="overflow-x-auto rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+        {state.message}
+      </pre>
+    );
+  }
+  if (state.kind !== "ok") return null;
+
+  const ratio = state.gzBytes > 0 ? state.rawBytes / state.gzBytes : 0;
+  return (
+    <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+      <Stat label="Original" value={formatBytes(state.rawBytes)} />
+      <Stat label="gzipped" value={formatBytes(state.gzBytes)} />
+      <Stat label="Ratio" value={`${ratio.toFixed(1)}×`} />
+      <Stat label="Decoded → parsed" value={`${state.count} triples`} />
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg bg-muted/40 p-3 ring-1 ring-foreground/10">
+      <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className="tabular text-sm font-semibold">{value}</div>
+    </div>
+  );
+}

--- a/site/src/lib/data-formats.ts
+++ b/site/src/lib/data-formats.ts
@@ -1,0 +1,178 @@
+// [OPUS-4.8] sq-j50v — pure, framework-free helpers for the live /surface/data-formats
+// demo: the four-format sample catalogue (including a TriG named-graph example) and the
+// in-tab gzip round-trip (compress a UTF-8 string with the browser's native
+// `CompressionStream("gzip")`, decode it back with `DecompressionStream("gzip")`).
+//
+// WHY THESE LIVE HERE (and are framework-free). The demo's parse step runs the real wasm
+// Store (no mocks); but the *gzip ingest* path is plain Web-platform code: gzip is the one
+// codec the browser decompresses natively (zstd / bzip2 are NOT — see the page's honest
+// caveat), so the compressed-ingest demo is `gunzip(bytes)` -> `Store.load(text, fmt)`.
+// Keeping the codec round-trip + the sample catalogue here (no React, no wasm) lets them
+// unit-test directly under `node --test` (the Web Streams API is in Node ≥ 18).
+
+/** The engine format string each picker entry loads through. */
+export type DataFormat = "turtle" | "ntriples" | "nquads" | "trig";
+
+export interface FormatSample {
+  /** Engine format string for `Store.load` / `Store.loadDataset`. */
+  format: DataFormat;
+  /** Human label shown in the picker. */
+  label: string;
+  /** Canonical file extension, for display. */
+  ext: string;
+  /** One-line description of the format. */
+  blurb: string;
+  /** A small, self-contained sample document in this exact format. */
+  sample: string;
+}
+
+// N-Triples / N-Quads share the same four triples so the "same data, four syntaxes" point
+// is visible; the quad formats add a named graph so the named-graph-preserving load path
+// (loadDataset) is exercised. All four parse with the lean wasm bundle.
+
+const TURTLE_SAMPLE = `@prefix ex:   <http://example.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+ex:alice a foaf:Person ;
+  foaf:name "Alice" ;
+  foaf:knows ex:bob .
+
+ex:bob a foaf:Person ;
+  foaf:name "Bob"@en .
+`;
+
+const NTRIPLES_SAMPLE = `<http://example.org/alice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
+<http://example.org/alice> <http://xmlns.com/foaf/0.1/name> "Alice" .
+<http://example.org/alice> <http://xmlns.com/foaf/0.1/knows> <http://example.org/bob> .
+<http://example.org/bob> <http://xmlns.com/foaf/0.1/name> "Bob"@en .
+`;
+
+// N-Quads: the same triples, but two are placed in a named graph (4th term) — so a
+// GRAPH ?g query against the loaded dataset returns them (loadDataset preserves graphs).
+const NQUADS_SAMPLE = `<http://example.org/alice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
+<http://example.org/alice> <http://xmlns.com/foaf/0.1/name> "Alice" .
+<http://example.org/alice> <http://xmlns.com/foaf/0.1/knows> <http://example.org/bob> <http://example.org/social> .
+<http://example.org/bob> <http://xmlns.com/foaf/0.1/name> "Bob"@en <http://example.org/social> .
+`;
+
+// TriG: Turtle-with-named-graphs. The default graph holds the type assertions; the
+// `ex:social` named graph holds the social links — the named-graph example the bead asks for.
+const TRIG_SAMPLE = `@prefix ex:   <http://example.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+ex:alice a foaf:Person .
+ex:bob   a foaf:Person .
+
+ex:social {
+  ex:alice foaf:name "Alice" ;
+    foaf:knows ex:bob .
+  ex:bob foaf:name "Bob"@en .
+}
+`;
+
+/** The four text formats, each with a live sample the picker seeds the textarea with. */
+export const FORMAT_SAMPLES: FormatSample[] = [
+  {
+    format: "turtle",
+    label: "Turtle",
+    ext: ".ttl",
+    blurb: "Prefixed, compact triple syntax — the most human-readable.",
+    sample: TURTLE_SAMPLE,
+  },
+  {
+    format: "ntriples",
+    label: "N-Triples",
+    ext: ".nt",
+    blurb: "One fully-expanded triple per line — the line-parallel bulk format.",
+    sample: NTRIPLES_SAMPLE,
+  },
+  {
+    format: "nquads",
+    label: "N-Quads",
+    ext: ".nq",
+    blurb: "N-Triples plus a 4th graph term — carries named graphs.",
+    sample: NQUADS_SAMPLE,
+  },
+  {
+    format: "trig",
+    label: "TriG",
+    ext: ".trig",
+    blurb: "Turtle plus { … } named-graph blocks.",
+    sample: TRIG_SAMPLE,
+  },
+];
+
+/** Whether a format carries named graphs (so the REPL must use `loadDataset`). */
+const DATASET_FORMATS = new Set<DataFormat>(["nquads", "trig"]);
+
+/** True for the quad-bearing formats (`nquads` / `trig`). */
+export function isDatasetFormat(format: DataFormat): boolean {
+  return DATASET_FORMATS.has(format);
+}
+
+/** The sample for a format, or `undefined` for an unknown format string. */
+export function sampleFor(format: DataFormat): FormatSample | undefined {
+  return FORMAT_SAMPLES.find((f) => f.format === format);
+}
+
+// ---------------------------------------------------------------------------
+// gzip round-trip — the live compressed-ingest path (gzip is the one codec the
+// browser decompresses natively; zstd / bzip2 are native-only, see the page caveat).
+// ---------------------------------------------------------------------------
+
+// All byte buffers here are backed by a plain `ArrayBuffer` (never `SharedArrayBuffer`),
+// so they satisfy `BlobPart` under TS 5.7's typed-array generics — hence the explicit
+// `Uint8Array<ArrayBuffer>` annotation rather than the bare `Uint8Array` alias.
+
+/** Drains a ReadableStream of Uint8Array chunks into one contiguous ArrayBuffer-backed buffer. */
+async function collect(
+  stream: ReadableStream<Uint8Array>,
+): Promise<Uint8Array<ArrayBuffer>> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    total += value.byteLength;
+  }
+  const out = new Uint8Array(new ArrayBuffer(total));
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.byteLength;
+  }
+  return out;
+}
+
+/**
+ * Gzip-compresses a UTF-8 string entirely in-tab via the native `CompressionStream`.
+ * Used by the demo to MANUFACTURE a `.ttl.gz`-style payload from the sample text so the
+ * decode side is a real gzip stream, not a canned blob.
+ */
+export async function gzipString(text: string): Promise<Uint8Array<ArrayBuffer>> {
+  const cs = new CompressionStream("gzip");
+  const stream = new Blob([text]).stream().pipeThrough(cs);
+  return collect(stream as ReadableStream<Uint8Array>);
+}
+
+/**
+ * Gunzips a gzip byte buffer back to a UTF-8 string via the native `DecompressionStream`.
+ * This is the exact JS-side decode the compressed-ingest path performs before handing the
+ * text to `Store.load` — gzip is decoded by the browser, no wasm/JS codec dependency.
+ */
+export async function gunzipToString(
+  bytes: Uint8Array<ArrayBuffer>,
+): Promise<string> {
+  const ds = new DecompressionStream("gzip");
+  const stream = new Blob([bytes]).stream().pipeThrough(ds);
+  const out = await collect(stream as ReadableStream<Uint8Array>);
+  return new TextDecoder().decode(out);
+}
+
+/** Formats a byte count compactly (B / KB) for the compression-ratio readout. */
+export function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  return `${(n / 1024).toFixed(1)} KB`;
+}

--- a/site/test/data-formats.test.mjs
+++ b/site/test/data-formats.test.mjs
@@ -1,0 +1,67 @@
+// [OPUS-4.8] sq-j50v — unit tests for the /surface/data-formats demo helpers: the
+// four-format sample catalogue and the in-tab gzip round-trip. These cover the pure,
+// framework-free logic (no React, no wasm); the engine-level parse of each sample is
+// covered by the Rust tests + js/test/store.test.mjs. Run via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  FORMAT_SAMPLES,
+  isDatasetFormat,
+  sampleFor,
+  gzipString,
+  gunzipToString,
+  formatBytes,
+} from "../src/lib/data-formats.ts";
+
+test("the catalogue covers exactly the four text formats", () => {
+  assert.deepEqual(
+    FORMAT_SAMPLES.map((f) => f.format),
+    ["turtle", "ntriples", "nquads", "trig"],
+  );
+});
+
+test("every sample is non-empty and carries the right named-graph syntax", () => {
+  for (const f of FORMAT_SAMPLES) {
+    assert.ok(f.sample.trim().length > 0, `${f.format} sample is empty`);
+  }
+  // The quad-bearing formats include the named graph the bead asks for.
+  assert.match(sampleFor("nquads").sample, /<http:\/\/example\.org\/social>/);
+  assert.match(sampleFor("trig").sample, /ex:social\s*\{/);
+  // The triple-only formats do NOT (no 4th term / no graph block).
+  assert.doesNotMatch(sampleFor("turtle").sample, /\{/);
+});
+
+test("isDatasetFormat is true exactly for the quad-bearing formats", () => {
+  assert.equal(isDatasetFormat("nquads"), true);
+  assert.equal(isDatasetFormat("trig"), true);
+  assert.equal(isDatasetFormat("turtle"), false);
+  assert.equal(isDatasetFormat("ntriples"), false);
+});
+
+test("sampleFor returns undefined for an unknown format", () => {
+  // @ts-expect-error — deliberately probing the not-a-format branch.
+  assert.equal(sampleFor("hdt"), undefined);
+});
+
+test("gzip round-trips every sample byte-for-byte through the native codec", async () => {
+  // The live compressed-ingest path is gunzip(gzip(text)) === text — proving the demo's
+  // decode side is a REAL gzip stream (CompressionStream -> DecompressionStream), not a
+  // canned blob. gzip is the one codec the browser decodes natively.
+  for (const f of FORMAT_SAMPLES) {
+    const gz = await gzipString(f.sample);
+    assert.ok(gz instanceof Uint8Array && gz.byteLength > 0);
+    const back = await gunzipToString(gz);
+    assert.equal(back, f.sample, `${f.format} did not gzip round-trip`);
+  }
+});
+
+test("gunzipToString rejects on non-gzip bytes", async () => {
+  await assert.rejects(() => gunzipToString(new Uint8Array([1, 2, 3, 4])));
+});
+
+test("formatBytes renders B under 1 KiB and KB above", () => {
+  assert.equal(formatBytes(0), "0 B");
+  assert.equal(formatBytes(512), "512 B");
+  assert.equal(formatBytes(2048), "2.0 KB");
+});


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change by an AI agent working on behalf of @jeswr.

## What & why (sq-j50v)

Turns `/surface/data-formats` from a static placeholder (which only linked to `/try`) into a **tier-a LIVE** page, driven by the shipped lean wasm `Store` — no mocks, no server, the real Rust engine compiled to wasm in your tab.

### Two interactive panels

1. **Format picker** — pick Turtle / N-Triples / N-Quads / TriG, paste (or edit the seeded sample), **Parse** → the engine's triple count + a sample of the parsed triples. Quad formats route through `loadDataset`, so the named graph survives and renders as a `?g` column; the N-Quads / TriG samples include a named-graph example (the bead's "TriG named-graph example").
2. **gzip ingest** — gzip the current document entirely in-tab via the browser's native `CompressionStream`, show the size + compression ratio, then decode it back with `DecompressionStream` and parse the decoded text → triple count. This is the exact JS-side decode a `.ttl.gz` upload takes before reaching `Store.load`.

### Honesty fixes to the page copy
- Dropped the `SparqStore.fromCompressed()` claim — **no such method exists** in the lean wasm bundle. (`loadCompressed` is an unrelated *index*-block-compression variant, not a gzip/zstd input decoder.)
- Scoped the in-browser codec to **gzip only**: `DecompressionStream` supports gzip/deflate, **not** zstd. zstd/bzip2 ingest, HDT, mmap/external-memory, and the parallel fast loaders are **native-only** (the page caveat says so).

## Tests & verification
- 7 new unit tests (`test/data-formats.test.mjs`) over the pure, framework-free helpers (sample catalogue invariants + gzip round-trip via the Web Streams API). `npm run test:unit` → 14/14 pass.
- End-to-end verified against the **real wasm engine**: all four samples parse to correct counts (Turtle 5, N-Triples 4, N-Quads 4, TriG 5) and each gzip round-trip re-parses to an identical count.

## Gate
- `next lint` (whole project): no warnings/errors.
- `tsc --noEmit`: clean.
- `next build` (production static export): succeeds; `/surface/data-formats` builds as a static page (6.03 kB / 195 kB First Load JS) and correctly takes precedence over the `[slug]` placeholder route.
- Privacy-claims gate: N/A — no privacy/ZK/MPC predicate or security claims in this change.
- G2 public-API → SKILL.md: N/A — no public API changed (consumes existing `Store.load`/`loadDataset` via existing site helpers only).

## Files
- `site/src/lib/data-formats.ts` — pure helpers (format sample catalogue + gzip round-trip).
- `site/src/components/data-formats-demo.tsx` — the `"use client"` interactive demo.
- `site/src/app/surface/data-formats/page.tsx` — render the demo as `children`; honesty copy fixes.
- `site/test/data-formats.test.mjs` — unit tests.

[OPUS-4.8]

🤖 Generated with [Claude Code](https://claude.com/claude-code)