### PR TITLE
docs+bench: N-readers/1-writer serving contract + PSS write-throughput parity (sq-b4lo, gh-52)

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -65,7 +65,7 @@ conventions first, then a per-category map that points at the registry, then a
 | **scaling** | parallel thread sweep + cross-commit/hardware tracking | `cli-scaling`, `ci-bench`, `ci-bench-ec2`, `hw-bench` |
 | **inference** | N3 / RDFS / OWL closure + incremental maintenance | `inference-eye-comparison`, `inference-owl-bench`, `inference-incremental`, `deep-taxonomy`, `owl-sameas`, `solid-wac-bench` |
 | **zk** | commitment pipeline, trace seam, circuit gates, prove/verify | `zk-commit-throughput`, `zk-trace-overhead`, `zk-compose-gates`, `zk-compose-prove-verify` |
-| **serve** | concurrent-serving + memory-tiering research spikes | `serve-spikes`, `memtier-spikes` |
+| **serve** | concurrent-serving + memory-tiering research spikes; PSS write-path parity gate | `serve-spikes`, `memtier-spikes`, `pss-update-parity` |
 | **conformance** | W3C SPARQL + reasoning suites (correctness, not perf) | `sparql-conformance`, `inference-conformance` |
 | **competitors** | versioned external-engine comparison (Oxigraph / QLever / eye) + version+env capture | `competitor-gather` (registry: [`competitors.json`](./competitors.json)) |
 

--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -829,8 +829,8 @@ status      = "ok"
 id          = "serve-spikes"
 name        = "Concurrent-serving research spikes"
 category    = "serve"
-measures    = "HTTP throughput/latency closed+open loop (loadgen); result-cache hit ceiling (cache_spike); point-BGP->JSON ceiling (point_spike); snapshot cost + RSS/generation (snapshot_spike); update-stream latency+RSS stability (update_stream_spike); TTFC streaming (stream_spike); group-commit writer throughput + reader p50/p99 (writer_spike)"
-invoke      = "cd bench/serve && cargo build --release && ./target/release/<bin>   # bins: loadgen cache_spike point_spike snapshot_spike update_stream_spike stream_spike writer_spike"
+measures    = "HTTP throughput/latency closed+open loop (loadgen); result-cache hit ceiling (cache_spike); point-BGP->JSON ceiling (point_spike); snapshot cost + RSS/generation (snapshot_spike); update-stream latency+RSS stability (update_stream_spike); TTFC streaming (stream_spike); group-commit writer throughput + reader p50/p99 (writer_spike); single-writer write-throughput on the PSS update set + reference targets + optional QLever-parity gate (pss_update_throughput, sq-b4lo/gh-52)"
+invoke      = "cd bench/serve && cargo build --release --bin <bin> && ./target/release/<bin>   # bins: loadgen cache_spike point_spike snapshot_spike update_stream_spike stream_spike writer_spike pss_update_throughput   # NOTE (sq-b4lo): some older spikes (snapshot_spike/writer_spike/update_stream_spike) carry AppState API drift — build per-bin; pss_update_throughput is current"
 source      = "bench/serve/{README.md,Cargo.toml}, src/bin/*.rs"
 dataset     = "synthetic, in-spike; writer_spike uses WRITER_UPDATES env (recorded run 30000)"
 quiet_box_sensitive = true  # research spikes, NOT maintained benchmarks; re-run on target hardware before trusting absolutes
@@ -850,6 +850,24 @@ quiet_box_sensitive = true
 pinning     = "standalone cargo project; compact feature = wasm 3-perm {SPO,POS,OSP} config"
 records_to  = "stdout; research/memory-tiering.md"
 status      = "ok"  # research spikes, not a regression gate
+
+# [OPUS-4.8] sq-b4lo / gh-52 — the WRITE-PATH companion to qlever-olympics (READ path):
+# asserts sparq's single sequenced writer is parity-or-better vs QLever-over-HTTP on the
+# PSS interactive LDP-CRUD update set (the documented N-readers/1-writer serving-contract
+# acceptance bar). Differential: fires the SAME updates at both live endpoints on one box.
+[[benchmark]]
+id          = "pss-update-parity"
+name        = "sparq vs QLever — PSS write-path parity (single-writer acceptance bar)"
+category    = "serve"
+measures    = "per-update HTTP commit latency p50/p99/max + sustained writes/s for sparq vs QLever over the SAME PSS LDP-CRUD update set; parity gate exits 1 iff sparq p99 > QLever p99 × tolerance (default 1.0 = parity-or-better, the gh-52 binding criterion)"
+invoke      = "cargo run -p sparq-server --release -- --addr 127.0.0.1:7020   # writable sparq\n              ../../.qlever-venv/bin/qlever start                            # writable QLever on :7019 (see bench/qlever-olympics/README.md)\n              python3 bench/pss-update-set/compare.py 200 --qlever-token <ACCESS_TOKEN>   # the differential gate"
+source      = "bench/pss-update-set/{compare.py,README.md}; update shapes mirror crates/sparq-server/tests/named_graphs.rs (gh-47) + bench/serve/src/bin/pss_update_throughput.rs"
+dataset     = "none — generated interactive LDP-CRUD updates (put_document / set_acl / delete_document), --iters count; NOT bulk ingest"
+quiet_box_sensitive = true
+pinning     = "both engines live on ONE box in ONE run (the only fair way to assert a RELATIVE bar); QLever numbers are machine-specific and intentionally NOT committed (repo hygiene: no hard-coded perf); record the QLever image DIGEST + host env when reporting"
+records_to  = "stdout; the parity verdict is the gate (exit 1 on regression)"
+status      = "ok"  # external-cost (needs a running QLever); the relative gate is the regression check, not a stored number
+featured    = false  # external-cost differential harness, not a dashboard-promoted capability suite
 
 # =============================================================================
 # CI — cross-commit regression tracking (github-action-benchmark)

--- a/bench/pss-update-set/README.md
+++ b/bench/pss-update-set/README.md
@@ -1,0 +1,95 @@
+<!-- [OPUS-4.8] sq-b4lo / gh-52 — re-review when Fable returns. -->
+# sparq vs QLever — PSS write-path parity (the single-writer acceptance bar)
+
+The **write-path** companion to [`bench/qlever-olympics`](../qlever-olympics/) (which
+compares the **read** path). This directory holds the benchmark that backs gh-52's
+Phase-2 acceptance criterion for sparq's documented serving contract — *"N readers
+against 1 sequenced writer + external coordination"*
+(see [`crates/sparq-server/README.md`](../../crates/sparq-server/README.md) →
+**Concurrency contract**).
+
+## The criterion (gh-52, set by the PSS agent)
+
+> **Parity-or-better vs the QLever-over-HTTP write path on PSS's actual update set** —
+> NOT bulk ingest. Reference starting targets (non-gating): single-writer sustained
+> *≥ a few hundred small updates/sec* and *p99 write-commit < ~50 ms*. The **binding**
+> gate is QLever-parity, because a migration acceptance bar is relative, not absolute.
+
+## The update set
+
+The interactive **LDP-CRUD** shapes a Solid pod-server issues — small
+`DELETE … ; INSERT DATA …` per resource + its `.acl` write, plus the heaviest burst
+(pod **provisioning**). These are the exact shapes pinned for *correctness* in
+[`crates/sparq-server/tests/named_graphs.rs`](../../crates/sparq-server/tests/named_graphs.rs)
+(gh-47) — here measured for *throughput/latency*:
+
+| op | shape | PSS operation |
+|---|---|---|
+| `put_document`   | `DELETE WHERE { GRAPH <r> {…} } ; INSERT DATA { GRAPH <r> {…} GRAPH <c> {…ldp:contains…} }` | `putDocument` |
+| `set_acl`        | `DELETE {…} INSERT {…} WHERE { OPTIONAL {…} }` (idempotent single-valued pointer) | `setAclPointer` / `putContainer` |
+| `delete_document`| `DROP SILENT GRAPH <r> ; DELETE WHERE { GRAPH <c> {…ldp:contains…} }` | resource DELETE |
+| `provision`      | one multi-op `INSERT DATA` creating a container + child resources + `.acl`s | pod provisioning burst |
+
+## Two ways to run it
+
+### 1. sparq-only smoke (no QLever) — fast, in-process
+
+The single-writer harness drives sparq's **production** `AppState` writer (the same
+`apply_update` the HTTP `application/sparql-update` path calls) through the update set
+and reports sustained writes/s + commit-latency p50/p99/max. Optionally gate against a
+*recorded* QLever p99:
+
+```sh
+# build JUST this bin (the other bench/serve spikes carry their own API drift):
+( cd bench/serve && cargo build --release --bin pss_update_throughput )
+./bench/serve/target/release/pss_update_throughput --profile crud --updates 20000 --readers 4
+./bench/serve/target/release/pss_update_throughput --profile provision --updates 2000 --children 8
+# parity gate against a recorded QLever p99 (ms); exit 1 on regression:
+./bench/serve/target/release/pss_update_throughput --profile crud --qlever-baseline-ms <recorded> --tolerance 1.0
+```
+
+`--readers N` runs concurrent point-query readers; their query count is reported (not
+gated) — the "readers never block the writer" half of the contract.
+`--base-triples N` sizes the pre-existing working set (default 1M is a large-tenant
+stress case; PSS's real per-pod set is KBs–MBs, e.g. `--base-triples 50000`).
+
+**Read the p99, not the single-client throughput.** `pss_update_throughput` is a SINGLE
+synchronous client (the interactive PSS shape — each LDP request blocks on its own
+commit), so its `updates/s` is bounded by `1/group-commit-window` (≈ 333/s at the 3 ms
+default) *no matter how fast the writer is* — one client never fills a batch window. The
+**binding interactive metric is p99 commit latency** (must sit inside the LDP request
+budget). The writer's true aggregate ceiling under CONCURRENT clients is
+[`writer_spike`](../serve/README.md#writer_spike) (group-commit throughput at
+`max_batch` 1/16/256), not this binary.
+
+### 2. true differential vs a running QLever — the binding gate
+
+`compare.py` fires the **same** updates at BOTH a running sparq-server and a running
+QLever endpoint over HTTP, on one box, in one run, and asserts sparq parity-or-better.
+This is the only fair way to assert the *relative* bar (QLever's write numbers are
+machine-specific and are deliberately **not** committed anywhere — repo hygiene forbids
+hard-coded perf).
+
+```sh
+# sparq (no auth = writable):
+cargo run -p sparq-server --release -- --addr 127.0.0.1:7020
+
+# QLever (see ../qlever-olympics/README.md for the venv + qlever CLI; the Qleverfile
+# must enable updates and an ACCESS_TOKEN):
+../../.qlever-venv/bin/qlever start          # serving on :7019
+
+python3 compare.py 200 --qlever-token <ACCESS_TOKEN>   # 200 interactive updates each
+```
+
+`compare.py` exits 1 if sparq's p99 regresses past `QLever p99 × --tolerance`
+(default 1.0 = exact parity-or-better).
+
+## Why this isn't a horizontal-scale benchmark
+
+gh-52's scope was explicitly locked to **option (a)** — the documented contract +
+this acceptance bar — and **not** a distributed/replicated writer (option (b)), which
+PSS confirmed is over-engineering for the single-instance Phase-2 deployment. The
+single sequenced writer IS the write ceiling by design; this benchmark proves it clears
+the QLever-parity bar PSS needs, it does not try to scale past it. The
+horizontal-scaling design (if/when tenancy demands it) lives in
+[`research/adr-horizontal-scaling.md`](../../research/adr-horizontal-scaling.md).

--- a/bench/pss-update-set/compare.py
+++ b/bench/pss-update-set/compare.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] sq-b4lo / gh-52 — written while Fable 5 unavailable; re-review when Fable returns.
+"""sparq vs QLever — WRITE-PATH parity on the PSS (Solid pod-server) update set.
+
+  compare.py <iters> [--sparq URL] [--qlever URL] [--qlever-token TOK] [--tolerance F]
+
+gh-52 locked sparq's Phase-2 serving contract to "N readers against 1 sequenced
+writer + external coordination" (see crates/sparq-server/README.md → "Concurrency
+contract"). The binding acceptance criterion for that single writer is **parity-or-
+better vs the QLever-over-HTTP write path on PSS's actual update set** — NOT bulk
+ingest. This script is that gate: it fires the SAME interactive SPARQL UPDATEs (the
+PSS LDP-CRUD shapes) at BOTH a running sparq-server and a running QLever endpoint
+over HTTP on one box, measures per-update commit latency on each, and FAILS (exit 1)
+if sparq's p99 regresses past QLever's by more than --tolerance (default 1.0 = exact
+parity-or-better).
+
+This intentionally mirrors `bench/qlever-olympics/compare.py` (the READ-path
+comparison) for the WRITE path. Both engines must be running and writable:
+
+  # sparq (this repo):
+  cargo run -p sparq-server --release -- --addr 127.0.0.1:7020   # no auth = writable
+
+  # QLever (see bench/qlever-olympics/README.md for the venv + qlever CLI):
+  #   the Qleverfile must enable updates; ACCESS_TOKEN gates the update endpoint.
+  ../../.qlever-venv/bin/qlever start    # serving on :7019, writable with the token
+
+  # then, from this directory:
+  python3 compare.py 5 --qlever-token <ACCESS_TOKEN>
+
+Honesty: QLever's write path is an external Docker-on-host process; its numbers are
+machine-specific and are NOT committed anywhere (repo hygiene forbids hard-coded
+perf). This script measures both live, on the same box, in the same run — the only
+fair way to assert a RELATIVE bar. For a sparq-only smoke (no QLever), use the
+`pss_update_throughput` binary in bench/serve with `--qlever-baseline-ms <recorded>`.
+"""
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def parse_args(argv):
+    iters = int(argv[1]) if len(argv) > 1 and not argv[1].startswith("-") else 200
+    opts = {
+        "sparq": "http://127.0.0.1:7020/sparql",
+        "qlever": "http://127.0.0.1:7019",
+        "qlever_token": None,
+        "tolerance": 1.0,
+    }
+    i = 2 if (len(argv) > 1 and not argv[1].startswith("-")) else 1
+    while i < len(argv):
+        a = argv[i]
+        if a == "--sparq":
+            opts["sparq"] = argv[i + 1]; i += 2
+        elif a == "--qlever":
+            opts["qlever"] = argv[i + 1]; i += 2
+        elif a == "--qlever-token":
+            opts["qlever_token"] = argv[i + 1]; i += 2
+        elif a == "--tolerance":
+            opts["tolerance"] = float(argv[i + 1]); i += 2
+        else:
+            sys.exit(f"unknown arg {a}")
+    return iters, opts
+
+
+# --- The PSS update set (mirrors crates/sparq-server/tests/named_graphs.rs and the
+#     bench/serve pss_update_throughput shapes): small interactive LDP-CRUD updates. ---
+
+LDP_CONTAINS = "http://www.w3.org/ns/ldp#contains"
+ACL = "http://www.w3.org/ns/auth/acl#accessControl"
+
+
+def put_document(res, version):
+    r = f"http://pod.ex/p0/r{res}.ttl"
+    c = "http://pod.ex/p0/"
+    return (
+        f"DELETE WHERE {{ GRAPH <{r}> {{ <{r}> ?p ?o }} }} ; "
+        f"INSERT DATA {{ GRAPH <{r}> {{ "
+        f"<{r}> <http://www.w3.org/ns/posix/stat#size> {version} . "
+        f"<{r}> <https://pss.dev/ns#etag> \"e-{res}-{version}\" . }} "
+        f"GRAPH <{c}> {{ <{c}> <{LDP_CONTAINS}> <{r}> . }} }}"
+    )
+
+
+def set_acl(res, version):
+    r = f"http://pod.ex/p0/r{res}.ttl"
+    c = "http://pod.ex/p0/"
+    acl = f"http://pod.ex/p0/v{version}.acl"
+    return (
+        f"DELETE {{ GRAPH <{c}> {{ <{r}> <{ACL}> ?old }} }} "
+        f"INSERT {{ GRAPH <{c}> {{ <{r}> <{ACL}> <{acl}> }} }} "
+        f"WHERE  {{ OPTIONAL {{ GRAPH <{c}> {{ <{r}> <{ACL}> ?old }} }} }}"
+    )
+
+
+def delete_document(res):
+    r = f"http://pod.ex/p0/r{res}.ttl"
+    c = "http://pod.ex/p0/"
+    return (
+        f"DROP SILENT GRAPH <{r}> ; "
+        f"DELETE WHERE {{ GRAPH <{c}> {{ <{c}> <{LDP_CONTAINS}> <{r}> }} }}"
+    )
+
+
+def update_set(iters, resources=200):
+    """The interleaved CRUD stream: cycle put → set_acl → put → delete."""
+    out = []
+    for i in range(iters):
+        res = i % resources
+        version = i // resources + 1
+        m = i % 4
+        if m in (0, 2):
+            out.append(put_document(res, version))
+        elif m == 1:
+            out.append(set_acl(res, version))
+        else:
+            out.append(delete_document(res))
+    return out
+
+
+# --- HTTP update drivers ----------------------------------------------------
+
+def sparq_update(url, sparql):
+    req = urllib.request.Request(
+        url,
+        data=sparql.encode(),
+        headers={"content-type": "application/sparql-update"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        r.read()
+        if r.status not in (200, 204):
+            raise RuntimeError(f"sparq update HTTP {r.status}")
+
+
+def qlever_update(base, token, sparql):
+    data = {"update": sparql}
+    if token:
+        data["access-token"] = token
+    req = urllib.request.Request(base, data=urllib.parse.urlencode(data).encode(), method="POST")
+    with urllib.request.urlopen(req, timeout=60) as r:
+        r.read()
+        if r.status not in (200, 204):
+            raise RuntimeError(f"qlever update HTTP {r.status}")
+
+
+def measure(label, fn, updates):
+    """Returns sorted per-update commit latencies (ms). Fails hard if any update errors."""
+    lat = []
+    for u in updates:
+        t = time.perf_counter()
+        try:
+            fn(u)
+        except urllib.error.URLError as e:
+            sys.exit(f"{label}: update failed ({e}); is the endpoint running and writable?")
+        lat.append((time.perf_counter() - t) * 1000.0)
+    lat.sort()
+    return lat
+
+
+def pct(sorted_ms, p):
+    if not sorted_ms:
+        return float("nan")
+    idx = min(int(len(sorted_ms) * p), len(sorted_ms) - 1)
+    return sorted_ms[idx]
+
+
+def main():
+    iters, opts = parse_args(sys.argv)
+    updates = update_set(iters)
+    print(f"# PSS write-path parity — {len(updates)} interactive LDP-CRUD updates, parity-or-better gate\n")
+
+    sparq = measure("sparq", lambda u: sparq_update(opts["sparq"], u), updates)
+    qlever = measure(
+        "qlever", lambda u: qlever_update(opts["qlever"], opts["qlever_token"], u), updates
+    )
+
+    hdr = f"{'engine':<8} {'p50(ms)':>9} {'p99(ms)':>9} {'max(ms)':>9} {'thr(/s)':>9}"
+    print(hdr)
+    print("-" * len(hdr))
+    for label, lat in (("sparq", sparq), ("qlever", qlever)):
+        total = sum(lat) / 1000.0
+        thr = len(lat) / total if total > 0 else float("nan")
+        print(f"{label:<8} {pct(lat,0.5):>9.2f} {pct(lat,0.99):>9.2f} {lat[-1]:>9.2f} {thr:>9.0f}")
+
+    s99, q99 = pct(sparq, 0.99), pct(qlever, 0.99)
+    bar = q99 * opts["tolerance"]
+    print(f"\n# parity gate: sparq p99 {s99:.2f}ms vs QLever p99 {q99:.2f}ms × tol {opts['tolerance']} = {bar:.2f}ms")
+    if s99 > bar:
+        sys.exit(f"PARITY FAIL: sparq single-writer p99 {s99:.2f}ms regressed past QLever-parity bar {bar:.2f}ms")
+    print("PARITY OK: sparq single-writer is parity-or-better vs QLever on the PSS update set")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/serve/Cargo.lock
+++ b/bench/serve/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,17 +39,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,14 +46,14 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "base64",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -71,12 +66,11 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -87,19 +81,17 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -127,16 +119,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -161,12 +156,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -205,6 +224,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,8 +244,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -249,10 +288,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -315,17 +370,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -355,9 +399,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -365,6 +407,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -416,6 +463,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -531,18 +587,18 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -550,6 +606,15 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mimalloc"
@@ -565,6 +630,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -606,8 +681,21 @@ checksum = "0afd5c28e4a399c57ee2bc3accd40c7b671fdc7b6537499f14e95b265af7d7e0"
 dependencies = [
  "oxilangtag",
  "oxiri",
- "rand 0.9.4",
- "thiserror 2.0.18",
+ "rand",
+ "thiserror",
+]
+
+[[package]]
+name = "oxrdfxml"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd5516ae083d09bc57ec65ed5ee97701481725de6ffaa83d968ab42a96157ba1"
+dependencies = [
+ "oxilangtag",
+ "oxiri",
+ "oxrdf",
+ "quick-xml",
+ "thiserror",
 ]
 
 [[package]]
@@ -620,7 +708,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -691,6 +779,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,33 +810,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -749,16 +825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -927,19 +994,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -966,6 +1044,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -997,15 +1081,17 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "peg",
- "rand 0.9.4",
- "thiserror 2.0.18",
+ "rand",
+ "thiserror",
 ]
 
 [[package]]
 name = "sparq-core"
 version = "0.1.0"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
+ "memchr",
+ "memmap2",
  "oxrdf",
  "oxttl",
  "rayon",
@@ -1022,7 +1108,7 @@ dependencies = [
  "rayon",
  "regex",
  "rustc-hash",
- "sha1",
+ "sha1 0.11.0",
  "sha2",
  "smallvec",
  "spargebra",
@@ -1046,9 +1132,14 @@ name = "sparq-server"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "flate2",
  "futures-util",
+ "hyper",
+ "hyper-util",
  "mimalloc",
  "oxrdf",
+ "oxrdfxml",
+ "oxttl",
  "serde_json",
  "spargebra",
  "sparq-core",
@@ -1057,6 +1148,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "tracing",
  "tracing-subscriber",
 ]
 
@@ -1079,31 +1171,11 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1155,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -1261,20 +1333,18 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.8.6",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
+ "rand",
+ "sha1 0.10.6",
+ "thiserror",
 ]
 
 [[package]]
@@ -1294,12 +1364,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"

--- a/bench/serve/Cargo.toml
+++ b/bench/serve/Cargo.toml
@@ -57,3 +57,9 @@ path = "src/bin/update_stream_spike.rs"
 [[bin]]
 name = "writer_spike"
 path = "src/bin/writer_spike.rs"
+
+# [OPUS-4.8] sq-b4lo / gh-52 — single-writer write-throughput on the PSS update set,
+# with an optional QLever-parity gate (the gh-52 Phase-2 acceptance criterion).
+[[bin]]
+name = "pss_update_throughput"
+path = "src/bin/pss_update_throughput.rs"

--- a/bench/serve/src/bin/pss_update_throughput.rs
+++ b/bench/serve/src/bin/pss_update_throughput.rs
@@ -1,0 +1,405 @@
+// [OPUS-4.8] (sq-b4lo / gh-52) written while Fable 5 unavailable — re-review when Fable returns.
+//! SINGLE-WRITER WRITE-THROUGHPUT BENCHMARK — the PSS (Solid pod-server) update set.
+//!
+//! ## What this measures and why it exists
+//!
+//! gh-52 (the PSS↔SPARQ horizontal-scale thread) locked sparq's Phase-2 serving contract
+//! to **"N readers against 1 sequenced writer + external coordination"** (documented in
+//! `crates/sparq-server/README.md` → "Concurrency contract"). The binding acceptance
+//! criterion the PSS agent set for that single writer is **parity-or-better vs the
+//! QLever-over-HTTP write path on PSS's actual update set** (NOT bulk ingest); the
+//! reference starting targets are *sustained ≥ a few hundred small updates/sec* and
+//! *p99 write-commit < ~50 ms*.
+//!
+//! This harness drives sparq's PRODUCTION single sequenced writer (`AppState`, the same
+//! `apply_update` the HTTP `application/sparql-update` path calls) through the **exact
+//! PSS named-graph update shapes** that `crates/sparq-server/tests/named_graphs.rs`
+//! pins for correctness (gh-47) — so throughput here is measured over the operations PSS
+//! actually issues, not a synthetic stand-in:
+//!
+//! - `put_document` — `DELETE WHERE { GRAPH <r> { <r> ?p ?o } } ; INSERT DATA { GRAPH <r> { … } }`:
+//!   replace a resource's ~8 metadata triples in its own per-resource named graph + the
+//!   parent container's `ldp:contains` link (PSS `putDocument`).
+//! - `set_acl` — `DELETE { … } INSERT { … } WHERE { OPTIONAL { … } }`: idempotently replace a
+//!   single-valued `acl:accessControl` pointer in the container graph (PSS `setAclPointer` /
+//!   `putContainer`, the gh-47 shape (3)).
+//! - `delete_document` — `DROP GRAPH <r> ; DELETE WHERE { GRAPH <parent> { <parent> ldp:contains <r> } }`:
+//!   remove a resource graph and unlink it from its container (PSS DELETE).
+//! - `provision` — the heaviest interactive burst: ONE multi-operation UPDATE that creates a
+//!   pod root container + a handful of child resources + their `.acl` pointers in a single
+//!   sequenced commit (PSS pod provisioning).
+//!
+//! ## Profiles
+//!
+//! - `crud` (default) — a sustained interleaved CRUD stream over a resource pool, round-robin
+//!   so DELETEs really hit (an insert-only overlay would flatter the number). Reports sustained
+//!   writes/s + commit-latency p50/p99/max per 1k window + total + final RSS.
+//! - `provision` — repeated provisioning bursts (the worst-case interactive flow): writes/s and
+//!   per-burst commit latency.
+//!
+//! ## Parity gate (`--qlever-baseline-ms <p99_ms>`)
+//!
+//! The binding criterion is *relative to QLever*, and QLever's write path is an external,
+//! Docker-on-host process; this harness therefore does NOT embed a QLever number (that
+//! would bake a machine-specific absolute into a tracked file — forbidden by repo
+//! hygiene). Instead `bench/pss-update-set/compare.py` runs BOTH engines over the same
+//! update set on one box and asserts parity; for a standalone sparq-only check this binary
+//! accepts a recorded QLever p99 (ms) and FAILS (exit 1) if sparq's p99 regresses past it
+//! by more than the tolerance (`--tolerance`, default 1.0 = exact parity-or-better).
+//! Without the flag it is a pure measurement (exit 0 always) — re-run on the target box.
+//!
+//! Run: `cargo run --release --bin pss_update_throughput` in `bench/serve`.
+//! Flags: `--profile crud|provision`, `--updates N`, `--resources N`, `--readers N`,
+//! `--children N`, `--qlever-baseline-ms F`, `--tolerance F`.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use sparq_core::Graph;
+use sparq_engine::QueryBudget;
+use sparq_server::{AppState, ServerConfig};
+
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+fn rss_mb() -> f64 {
+    let out = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &std::process::id().to_string()])
+        .output()
+        .expect("ps");
+    String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse::<f64>()
+        .unwrap_or(0.0)
+        / 1024.0
+}
+
+// --- PSS update shapes (mirroring crates/sparq-server/tests/named_graphs.rs) --------
+
+const LDP_CONTAINS: &str = "http://www.w3.org/ns/ldp#contains";
+const ACL_ACCESS_CONTROL: &str = "http://www.w3.org/ns/auth/acl#accessControl";
+
+fn resource_iri(pod: usize, res: usize) -> String {
+    format!("http://pod.ex/p{pod}/r{res}.ttl")
+}
+fn container_iri(pod: usize) -> String {
+    format!("http://pod.ex/p{pod}/")
+}
+
+/// PSS `putDocument`: replace the resource's metadata in its OWN named graph + (re)link it
+/// into the parent container graph. `DELETE WHERE` clears the prior version; `INSERT DATA`
+/// writes ~8 fresh triples. Resource and container are distinct named graphs.
+fn put_document(pod: usize, res: usize, version: usize) -> String {
+    let r = resource_iri(pod, res);
+    let c = container_iri(pod);
+    format!(
+        "DELETE WHERE {{ GRAPH <{r}> {{ <{r}> ?p ?o }} }} ; \
+         INSERT DATA {{ \
+           GRAPH <{r}> {{ \
+             <{r}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#Resource> . \
+             <{r}> <https://pss.dev/ns#contentType> \"text/turtle\" . \
+             <{r}> <http://www.w3.org/ns/posix/stat#size> {version} . \
+             <{r}> <http://www.w3.org/ns/posix/stat#mtime> {version} . \
+             <{r}> <http://purl.org/dc/terms/modified> \"2026-06-14T00:00:{ss:02}\" . \
+             <{r}> <https://pss.dev/ns#etag> \"etag-{pod}-{res}-{version}\" . \
+             <{r}> <https://pss.dev/ns#s3Key> \"k/{pod}/{res}/{version}\" . \
+           }} \
+           GRAPH <{c}> {{ <{c}> <{LDP_CONTAINS}> <{r}> . }} \
+         }}",
+        ss = version % 60
+    )
+}
+
+/// PSS `setAclPointer` / `putContainer` (gh-47 shape 3): idempotently replace a
+/// single-valued `acl:accessControl` pointer in the container graph, whether or not one
+/// already exists. `OPTIONAL` binds the prior pointer (if any); `DELETE` clears it; the
+/// `INSERT` sets the new one — exactly one value remains, no accumulation.
+fn set_acl(pod: usize, res: usize, version: usize) -> String {
+    let r = resource_iri(pod, res);
+    let c = container_iri(pod);
+    let acl = format!("http://pod.ex/p{pod}/v{version}.acl");
+    format!(
+        "DELETE {{ GRAPH <{c}> {{ <{r}> <{ACL_ACCESS_CONTROL}> ?old }} }} \
+         INSERT {{ GRAPH <{c}> {{ <{r}> <{ACL_ACCESS_CONTROL}> <{acl}> }} }} \
+         WHERE  {{ OPTIONAL {{ GRAPH <{c}> {{ <{r}> <{ACL_ACCESS_CONTROL}> ?old }} }} }}"
+    )
+}
+
+/// PSS resource DELETE: drop the resource's own graph and unlink it from its container.
+fn delete_document(pod: usize, res: usize) -> String {
+    let r = resource_iri(pod, res);
+    let c = container_iri(pod);
+    format!(
+        "DROP SILENT GRAPH <{r}> ; \
+         DELETE WHERE {{ GRAPH <{c}> {{ <{c}> <{LDP_CONTAINS}> <{r}> }} }}"
+    )
+}
+
+/// PSS pod provisioning — the heaviest interactive burst: ONE multi-operation UPDATE that
+/// creates the pod-root container + `n_children` child resources (each in its own graph,
+/// linked from the container) + an `.acl` pointer for each, all in a single sequenced
+/// commit. This is the "handful of resources + ACLs in one flow" shape gh-52 calls out.
+fn provision(pod: usize, n_children: usize) -> String {
+    let c = container_iri(pod);
+    let mut s = String::new();
+    s.push_str(&format!(
+        "INSERT DATA {{ GRAPH <{c}> {{ <{c}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#Container> ."
+    ));
+    for res in 0..n_children {
+        let r = resource_iri(pod, res);
+        s.push_str(&format!(
+            " <{c}> <{LDP_CONTAINS}> <{r}> . <{r}> <{ACL_ACCESS_CONTROL}> <http://pod.ex/p{pod}/v0.acl> ."
+        ));
+    }
+    s.push_str(" } ");
+    for res in 0..n_children {
+        let r = resource_iri(pod, res);
+        s.push_str(&format!(
+            "GRAPH <{r}> {{ <{r}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#Resource> . \
+             <{r}> <http://www.w3.org/ns/posix/stat#size> 0 . }} "
+        ));
+    }
+    s.push('}');
+    s
+}
+
+// --- metrics ----------------------------------------------------------------
+
+fn pct(sorted_us: &[u64], p: f64) -> u64 {
+    if sorted_us.is_empty() {
+        return 0;
+    }
+    let idx = ((sorted_us.len() as f64 * p) as usize).min(sorted_us.len() - 1);
+    sorted_us[idx]
+}
+
+struct Run {
+    /// all per-update commit latencies (µs), unsorted until summarised in `main`
+    lat_us: Vec<u64>,
+    updates: usize,
+    wall: Duration,
+}
+
+/// CRUD stream: round-robin over a resource pool, cycling put → set_acl → put → delete so
+/// every shape (and a real DELETE) is exercised; latency is the synchronous `apply_update`
+/// commit time (group-commit window + delta apply + publish) on the single writer.
+///
+/// HONESTY — this is a SINGLE synchronous client (one in-flight update at a time), which is
+/// exactly the interactive PSS shape: each LDP request blocks on its own commit. So the
+/// **binding metric is p99 commit latency** (it must sit inside the LDP request budget); the
+/// per-client *throughput* is bounded by `1/group-commit-window` (≈ 333/s at the 3 ms default)
+/// NO MATTER how fast the writer is, because one client never fills a batch window. Aggregate
+/// write throughput rises with CONCURRENT clients filling the window — that ceiling is
+/// `writer_spike` (group-commit throughput at `max_batch` 1/16/256), not this binary. Do NOT
+/// read the single-client `updates/s` here as the writer's capacity.
+fn crud_stream(state: &AppState, updates: usize, resources: usize) -> Run {
+    let pod = 0usize;
+    let mut lat_us = Vec::with_capacity(updates);
+    let window = 1_000usize;
+    let mut window_lat = Vec::with_capacity(window);
+    let start = Instant::now();
+    let mut window_start = Instant::now();
+    for i in 0..updates {
+        let res = i % resources;
+        let version = i / resources + 1;
+        let upd = match i % 4 {
+            0 | 2 => put_document(pod, res, version),
+            1 => set_acl(pod, res, version),
+            _ => delete_document(pod, res),
+        };
+        let t = Instant::now();
+        state.apply_update(&upd).expect("update committed");
+        let us = t.elapsed().as_micros() as u64;
+        lat_us.push(us);
+        window_lat.push(us);
+        if window_lat.len() == window {
+            window_lat.sort_unstable();
+            println!(
+                "updates {:>7}-{:>7}: thr={:>7.0}/s  p50={:>5}us  p99={:>6}us  max={:>8}us  RSS={:>5.0}MB",
+                i + 1 - window,
+                i + 1,
+                window as f64 / window_start.elapsed().as_secs_f64(),
+                window_lat[window / 2],
+                window_lat[window * 99 / 100],
+                window_lat[window - 1],
+                rss_mb()
+            );
+            window_lat.clear();
+            window_start = Instant::now();
+        }
+    }
+    Run {
+        lat_us,
+        updates,
+        wall: start.elapsed(),
+    }
+}
+
+/// Provisioning bursts: one provisioning UPDATE per pod, `updates` pods. Each commit is the
+/// heaviest single interactive write PSS issues.
+fn provision_bursts(state: &AppState, updates: usize, children: usize) -> Run {
+    let mut lat_us = Vec::with_capacity(updates);
+    let start = Instant::now();
+    for pod in 0..updates {
+        let upd = provision(pod, children);
+        let t = Instant::now();
+        state.apply_update(&upd).expect("provision committed");
+        lat_us.push(t.elapsed().as_micros() as u64);
+    }
+    Run {
+        lat_us,
+        updates,
+        wall: start.elapsed(),
+    }
+}
+
+fn main() {
+    let mut profile = String::from("crud");
+    let mut updates = 20_000usize;
+    let mut resources = 2_000usize;
+    let mut readers = 0usize;
+    let mut children = 8usize;
+    // Base graph: the pre-existing working set the writer's delta-overlay folds against. The
+    // 1M default is a STRESS case (a large pod-server tenant) that exercises the periodic
+    // O(graph) compaction; PSS's real per-pod working set is KBs–MBs, so lower it (e.g.
+    // `--base-triples 50000`) to model a realistic interactive tenant.
+    let mut base_triples_target = 1_000_000usize;
+    let mut qlever_baseline_ms: Option<f64> = None;
+    let mut tolerance = 1.0f64;
+    let mut args = std::env::args().skip(1);
+    while let Some(a) = args.next() {
+        let mut next = || args.next().expect("flag value");
+        match a.as_str() {
+            "--profile" => profile = next(),
+            "--updates" => updates = next().parse().expect("number"),
+            "--resources" => resources = next().parse().expect("number"),
+            "--readers" => readers = next().parse().expect("number"),
+            "--children" => children = next().parse().expect("number"),
+            "--base-triples" => base_triples_target = next().parse().expect("number"),
+            "--qlever-baseline-ms" => qlever_baseline_ms = Some(next().parse().expect("float")),
+            "--tolerance" => tolerance = next().parse().expect("float"),
+            other => panic!("unknown arg {other}"),
+        }
+    }
+    // Honest reader count clamp: 0 readers (writer-only ceiling) is the default; readers
+    // exercise the "readers never block the writer" invariant under concurrent write load.
+    resources = resources.max(1);
+
+    // Build the pre-existing working set (`--base-triples`) of unrelated data so the
+    // delta-overlay's periodic O(graph) compaction is exercised against a real graph.
+    let mut nt = String::with_capacity(base_triples_target.saturating_mul(48));
+    let distinct_subjects = (base_triples_target / 5).max(1);
+    for i in 0..base_triples_target {
+        nt.push_str(&format!(
+            "<http://ex/s{}> <http://ex/p{}> \"v{}\" .\n",
+            i % distinct_subjects,
+            i % 50,
+            i
+        ));
+    }
+    let graph = Graph::load_str(&nt, "ntriples").expect("base graph load");
+    let base_triples = graph.len();
+
+    let config = ServerConfig {
+        query_timeout: Some(Duration::from_secs(5)),
+        ..ServerConfig::default()
+    };
+    let state = AppState::with_config(graph, config);
+    let stop = Arc::new(AtomicBool::new(false));
+
+    println!(
+        "# pss_update_throughput — single-writer write-throughput on the PSS update set (gh-52)"
+    );
+    println!(
+        "# profile={profile}  updates={updates}  resources={resources}  readers={readers}  children={children}  base_triples={base_triples_target}"
+    );
+    println!(
+        "# base graph: {base_triples} triples, RSS {:.0}MB\n",
+        rss_mb()
+    );
+
+    // Optional concurrent readers: snapshot + point query in a loop (the N-readers side of
+    // the contract). They must not stall the writer; their throughput is reported, not gated.
+    let state = Arc::new(state);
+    let reader_handles: Vec<_> = (0..readers)
+        .map(|i| {
+            let st = state.clone();
+            let stop = stop.clone();
+            std::thread::spawn(move || {
+                let b = QueryBudget::unlimited();
+                let mut n = 0u64;
+                while !stop.load(Ordering::Relaxed) {
+                    // Pin the current generation (lock-free ~10–20ns); never blocked by the
+                    // writer — the N-readers side of the contract.
+                    let pin = st.current();
+                    let g = pin.snapshot();
+                    let s = (n as usize).wrapping_mul(2654435761).wrapping_add(i) % 200_000;
+                    let q = format!("SELECT ?o WHERE {{ <http://ex/s{s}> ?p ?o }} LIMIT 5");
+                    std::hint::black_box(sparq_engine::query_json_with_budget(g, &q, &b).ok());
+                    n += 1;
+                }
+                n
+            })
+        })
+        .collect();
+
+    let mut run = match profile.as_str() {
+        "crud" => crud_stream(&state, updates, resources),
+        "provision" => provision_bursts(&state, updates, children),
+        other => panic!("unknown profile {other} (use crud|provision)"),
+    };
+
+    stop.store(true, Ordering::Relaxed);
+    let reads: u64 = reader_handles.into_iter().map(|h| h.join().unwrap()).sum();
+
+    run.lat_us.sort_unstable();
+    let thr = run.updates as f64 / run.wall.as_secs_f64();
+    let p50 = pct(&run.lat_us, 0.50) as f64 / 1000.0;
+    let p99 = pct(&run.lat_us, 0.99) as f64 / 1000.0;
+    let max = *run.lat_us.last().unwrap_or(&0) as f64 / 1000.0;
+    let pin = state.current();
+    let g = pin.snapshot();
+    println!(
+        "\nTOTAL: {} commits in {:.2}s = {:.0} updates/s (SINGLE-client, window-bound); p50={:.3}ms p99={:.3}ms max={:.3}ms",
+        run.updates,
+        run.wall.as_secs_f64(),
+        thr,
+        p50,
+        p99,
+        max
+    );
+    println!(
+        "       final graph {} triples (base {base_triples}); concurrent reader queries: {reads}; final RSS {:.0}MB",
+        g.len(),
+        rss_mb()
+    );
+
+    // Reference targets from gh-52 (NOT the gate — the gate is QLever-parity). The BINDING
+    // interactive metric is p99 commit latency (< ~50 ms). Single-client throughput is
+    // ~1/window-bound by design (see crud_stream doc + writer_spike for the concurrent ceiling),
+    // so "below few-hundred/s" here is the single-client window bound, not a writer limit.
+    println!(
+        "# reference (gh-52, non-gating): p99 {} < ~50ms (BINDING interactive metric); single-client thr {:.0}/s is ~1/window-bound (writer_spike = concurrent ceiling)",
+        if p99 < 50.0 { "PASS" } else { "OVER" },
+        thr
+    );
+
+    // Parity gate: only when a recorded QLever p99 is supplied. parity-or-better means
+    // sparq p99 ≤ QLever p99 × tolerance.
+    if let Some(q) = qlever_baseline_ms {
+        let bar = q * tolerance;
+        println!(
+            "# parity gate: sparq p99 {p99:.3}ms vs QLever baseline {q:.3}ms × tol {tolerance} = {bar:.3}ms"
+        );
+        if p99 > bar {
+            eprintln!(
+                "PARITY FAIL: sparq single-writer p99 {p99:.3}ms regressed past QLever-parity bar {bar:.3}ms"
+            );
+            std::process::exit(1);
+        }
+        println!(
+            "PARITY OK: single-writer p99 is parity-or-better vs QLever on the PSS update set"
+        );
+    }
+}

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -231,6 +231,89 @@ cargo run -p sparq-server -- --format turtle data.ttl
 curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=SELECT * WHERE { ?s ?p ?o } LIMIT 5'
 ```
 
+## Concurrency contract — N readers, 1 sequenced writer
+
+<!-- [OPUS-4.8] sq-b4lo / gh-52 — the explicit, PSS-facing serving contract; re-review
+     when Fable returns. -->
+
+sparq-server is a **single-process** SPARQL endpoint with a deliberate, documented
+concurrency shape:
+
+> **N concurrent readers against 1 sequenced writer.** Reads are lock-free and never
+> block; all writes are *serialised* through a single sequenced, group-committing
+> writer. There is **no distributed lock, replication, or consensus**, and the engine
+> is **not sharded per logical dataset** — horizontal scale is an *external*
+> deployment concern, not an in-engine one.
+
+**How it works.** Shared state is a lock-free **generation ring** (an arc-swapped
+chain of immutable store snapshots) plus the **single sequenced writer**
+([`sparq-serve`](../sparq-serve/README.md), design:
+[`research/concurrent-serving.md`](../../research/concurrent-serving.md) §6):
+
+- **Readers** pin the current generation once per request (`AppState::current`, an
+  atomic load — lock-free, never blocked by an in-flight update) and evaluate against
+  that immutable snapshot for the whole response — including streamed bodies. A reader
+  **never** waits for an in-flight update, and an update **never** waits for (or
+  reclaims from) readers; old generations are freed by ordinary `Arc` drop. Reader
+  concurrency scales with cores; it is the throughput story (the bulk of real endpoint
+  traffic is duplicate, cacheable, read-only queries — Bonifati et al., PVLDB 2017).
+- **Writers** submit through one sequenced [`Writer`]; each group-commit window
+  publishes a batch as ONE new immutable generation. Serialisability is by
+  construction (Calvin/Bohm collapsed to one node) — write skew is impossible, no SSI
+  needed. `apply_update` blocks until the generation containing the update is
+  published (the read-your-writes token it returns is the published generation
+  number; clients can pin it with `?generation=N`). A slow `DELETE/INSERT … WHERE`
+  head-of-line-blocks the queue behind it; `--update-where-timeout` bounds that
+  (see `sq-nulp` under "Security posture").
+
+**This single writer IS the write ceiling, by design.** That is a feature for the
+target workload (interactive single-resource writes), not a gap to paper over.
+
+### What scales where, and the explicit non-goal
+
+| Axis | sparq-server | How you scale it |
+| --- | --- | --- |
+| **Reads** | scale with cores in-process; horizontally with an external LB over read replicas | LB / replicas (deployment) |
+| **Writes** | one sequenced writer — the ceiling | **external coordination** (route writes for a logical dataset to its owning instance) |
+| **Whole-dataset HA / sharding** | **not in-engine** | deployment topology |
+
+**Explicit Phase-2 non-goal:** sparq-server does **not** provide an in-engine
+distributed/replicated/sharded writer, and is not planned to for the
+single-instance deployment. If a deployment needs HA or RAM/NIC scale-out, that is an
+*external* topology over single-writer instances — the design (pod-sharded shards,
+each a single writer + 0..N read replicas replaying its deterministic log; staged,
+opt-in, single-node path unchanged) is recorded in
+[`research/adr-horizontal-scaling.md`](../../research/adr-horizontal-scaling.md), but
+**no engine code implements it** and none is required for Phase-2.
+
+### Reconciliation with PSS `decisions/0012-horizontal-scaling.md`
+
+This contract is the SPARQ-side answer to PSS issue **gh-52**. PSS ADR-0012 scaled the
+*application tier* (stateless replicas + shared coordination) and explicitly left the
+*engine* as a single writer with external coordination — sparq fits that seat exactly:
+
+- **Peak concurrent writers per logical dataset = effectively 1** (PSS deploys
+  single-instance; one sequenced writer matches the deployment).
+- **External coordination** (a distributed lock / shared `jti`+cache, ADR-0012's
+  `none`-backend-default discipline) lives in **PSS**, not in sparq — sparq guarantees
+  *per-instance* serialisation, and the deployment guarantees one writer per logical
+  dataset.
+- **Stable write error contract** (for retry classifiers): see "Stable error/status
+  contract" above — a write is `204` (committed), `400` (malformed — permanent), `401`
+  (auth — permanent), `503` (timeout / durable-write refusal — **retryable**, the
+  write did **not** commit), or `429` (shed — never ran, retryable).
+
+### Acceptance bar — parity-or-better vs QLever on the PSS update set
+
+gh-52's binding criterion for the single writer is **parity-or-better vs the
+QLever-over-HTTP write path on PSS's actual update set** (interactive LDP-CRUD — small
+`DELETE … ; INSERT DATA …` per resource + its `.acl`, plus pod provisioning — **not**
+bulk ingest). Reference starting targets (non-gating): sustained *≥ a few hundred small
+updates/sec* and *p99 write-commit < ~50 ms*. The benchmark that asserts this lives in
+[`bench/pss-update-set`](../../bench/pss-update-set/README.md) (a true differential vs
+a running QLever) with a fast in-process single-writer harness in
+[`bench/serve`](../../bench/serve/README.md) (`pss_update_throughput`).
+
 ## Durable persistence (`--persist DIR` — QLever's `--persist-updates`)
 
 By default the server is **in-memory**: updates apply to a `Graph` held only in RAM, so they


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the `jeswr/sparq` RDF/SPARQL engine (Claude Opus 4.8). @jeswr runs multiple agents; this was written by the **SPARQ** agent. The **PSS** agent (`prod-solid-server`) is a separate party in these discussions.

Implements **sq-b4lo** (`from-pss`, gh-52). The PSS↔SPARQ horizontal-scale thread locked Phase-2 scope to **option (a)** — a *documented* "N readers against 1 sequenced writer + external coordination" contract + a single-writer write-throughput acceptance bar — explicitly **not** an in-engine distributed/replicated writer (option (b), which PSS confirmed is over-engineering for the single-instance deployment). This lands both deliverables. **Docs + benchmark only; no workspace crate code changed.**

## 1. Documented serving contract
`crates/sparq-server/README.md` gains a **"Concurrency contract — N readers, 1 sequenced writer"** section:
- the lock-free generation-ring readers + the single sequenced group-commit writer (this single writer **IS** the write ceiling, by design);
- a "what scales where" table + the **explicit Phase-2 non-goal**: no in-engine distribution/replication/sharding — HA/scale-out is an *external* topology over single-writer instances (design recorded in `research/adr-horizontal-scaling.md`, no engine code implements it, none required for Phase-2);
- **reconciliation with PSS `decisions/0012-horizontal-scaling.md`**: writers-per-logical-dataset = effectively 1, external coordination lives in PSS, stable write error contract (`204`/`400`/`401`/`503`-retryable/`429`);
- the **acceptance bar**: parity-or-better vs QLever on the PSS update set, with PSS's reference targets recorded as non-gating.

## 2. Single-writer write-throughput benchmark
- `bench/serve/src/bin/pss_update_throughput.rs` drives sparq's **production `AppState` writer** (the same `apply_update` the HTTP update path calls) through the **exact PSS named-graph LDP-CRUD shapes** that `crates/sparq-server/tests/named_graphs.rs` pins for correctness (gh-47): `put_document`, `set_acl` (DELETE/INSERT…WHERE OPTIONAL), `delete_document`, and the `provision` burst. Reports interactive **p99 commit latency** (the binding metric) + RSS; optional `--qlever-baseline-ms` parity gate (exit 1 on regression). `--base-triples` sizes the working set.
- `bench/pss-update-set/compare.py` is the **true differential**: fires the SAME updates at a live sparq + live QLever on one box and asserts **parity-or-better** (the gh-52 binding criterion). Mirrors `bench/qlever-olympics` (the read-path comparison).
- Registered in `bench/benchmarks.toml` (`serve-spikes` + new `pss-update-parity`) and `bench/CATALOG.md`.

## Honesty
- **Single-client throughput is ~1/group-commit-window-bound by design** (one synchronous client never fills a batch window) — so the **p99 latency** is the binding interactive metric; the concurrent-arrival writer ceiling is `writer_spike`. The harness output and docs say this explicitly so the throughput number isn't misread as the writer's capacity.
- **No QLever numbers are committed** anywhere (repo hygiene forbids hard-coded perf); the parity gate is *relative*, measured live on one box.
- Found + beaded **pre-existing** API drift in three other `bench/serve` spikes (`snapshot_spike`/`writer_spike`/`update_stream_spike` don't build vs current `AppState`/`Writer`) — **sq-i9ck**, out of scope here; the new bin builds clean per-bin.

## Gate
- `bench/serve` (standalone project): `cargo build`/`clippy --bin pss_update_throughput -- -D warnings`/`rustfmt --check` all clean; smoke-ran `crud` + `provision` profiles + parity gate pass/fail.
- G3 new-bench-registry, no-perf-numbers (on changed markdown), G2 api→skill (no public surface changed): all PASS.
- No `crates/` Rust changed → workspace build/test/clippy unaffected.

Closes the gh-52 deliverables. `[OPUS-4.8]` markers throughout (Fable unavailable — flag for re-review when Fable returns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)