### PR TITLE
docs: sync TOTAL-crate count 25 → 31 (sq-knl8) [OPUS-4.8]

### DIFF
--- a/research/coverage-and-benchmark-plan.md
+++ b/research/coverage-and-benchmark-plan.md
@@ -6,10 +6,14 @@ suites, dashboard, test-coverage llvm-cov, test-gaps). Point-in-time measurement
 the numbers here are an audit snapshot, not a hard-coded perf claim. Work items are tracked
 in **beads** (see `bd list -l area:bench` / `-l area:test`).
 
+<!-- [OPUS-4.8] sq-knl8 (2026-06-17): total-crate count synced 25 → 31 to track the
+     current workspace (`ls crates/`); this is the TOTAL count, distinct from the
+     unsafe-posture forbid/unsafe split tracked separately in the memsafety audit. -->
+
 ## 1. Benchmark coverage
 
 ### 1.1 Package coverage — already strong
-Of 25 crates, ~20 have a perf bench (registered in `bench/benchmarks.toml` or an `examples/`
+Of 31 crates, ~20 have a perf bench (registered in `bench/benchmarks.toml` or an `examples/`
 harness). Genuine gaps / actions:
 
 - **sparq-vectors** — has `tests/throughput.rs` (HNSW build + exact-vs-HNSW query) but it is

--- a/research/task-tracking-best-practices.md
+++ b/research/task-tracking-best-practices.md
@@ -2,11 +2,15 @@
 
 > Operational guide. Researched & **empirically verified on this box** (Linux aarch64, Node 20, npm 10, Go absent) on 2026-06-13. All commands below were run against `@beads/bd` v1.0.5. Forward-looking notes tagged `[OPUS-4.8]`.
 
+<!-- [OPUS-4.8] sq-knl8 (2026-06-17): total-crate count synced 25 → 31 (and the inline
+     `area:<crate>` list refreshed) to track the current workspace (`ls crates/`). This is
+     the TOTAL count only; the unsafe-posture forbid/unsafe split is tracked separately. -->
+
 ## TL;DR (read this)
 
 - **Use beads.** It is the right tool for *this* repo: a dependency graph of issues stored as git-committed JSONL, with `bd ready` computing the unblocked work-set offline in ms. That maps directly onto our merge-queue + roborev-backlog reality where "task X is blocked until PR Y merges" is the dominant relationship — something flat TODO.md and the agent's built-in todo tool cannot express.
 - **Install is trivial here (no Go needed):** the npm package ships a postinstall that downloads the prebuilt Go binary for `linux/arm64`. Verified working: `npx @beads/bd@latest version` → `bd version 1.0.5`. See "Install".
-- **How to adopt:** one `.beads/` DB at repo root, prefix `sq`. Model the 25 crates + cross-cutting concerns as **labels** (`area:sparq-core`, `area:zk`, …), big initiatives (MPC, ZK build-out, serve-wave) as **epics** (`-t epic` + `parent-child`), the merge queue as **`blocks` edges** ("re-run roborev job" `blocked` by "PR merges"), and roborev findings as tasks linked **`discovered-from`** their source. Commit `.beads/issues.jsonl`; the Dolt dir is gitignored.
+- **How to adopt:** one `.beads/` DB at repo root, prefix `sq`. Model the 31 crates + cross-cutting concerns as **labels** (`area:sparq-core`, `area:zk`, …), big initiatives (MPC, ZK build-out, serve-wave) as **epics** (`-t epic` + `parent-child`), the merge queue as **`blocks` edges** ("re-run roborev job" `blocked` by "PR merges"), and roborev findings as tasks linked **`discovered-from`** their source. Commit `.beads/issues.jsonl`; the Dolt dir is gitignored.
 - **One caveat, mandatory:** run `bd init` with `--skip-agents --skip-hooks` so it does **not** overwrite our `CLAUDE.md` or install git hooks (default behavior does both). See "Install step 2".
 - **Honest downside:** beads is young (1.x, "API stability not guaranteed"), the backend is Dolt (an embedded SQL/git database — heavier than a flat file), and a 132 MB binary. If you want zero new infra and never parallelize agents, plain TODO.md is fine. Beads earns its keep the moment you have >1 agent and real cross-task blockers — which we do.
 
@@ -140,8 +144,8 @@ bd gc --dry-run                       # preview decay+compact;  bd gc --older-th
 
 **One DB, prefix `sq`, at repo root.** Commit `.beads/issues.jsonl` + `config.yaml`; never commit `embeddeddolt/`.
 
-**Crates/areas → labels, not epics.** 25 crates is too many for epics. Use a flat label namespace, multi-label as needed:
-- `area:<crate>` — e.g. `area:sparq-core`, `area:sparq-zk`, `area:sparq-mpc`, `area:sparq-hdt`, `area:sparq-serve`. (We have: sparq-bench, -cli, -conformance, -core, -engine, -geo, -gpu, -hdt, -introspect, -mpc, -nlq, -parse, -py, -reason, -rsp, -serve, -server, -shacl, -sim, -solid, -text, -vectors, -wasm, -zk-compose, -zk.)
+**Crates/areas → labels, not epics.** 31 crates is too many for epics. Use a flat label namespace, multi-label as needed:
+- `area:<crate>` — e.g. `area:sparq-core`, `area:sparq-zk`, `area:sparq-mpc`, `area:sparq-hdt`, `area:sparq-serve`. (We have: sparq-bench, -canon, -cli, -conformance, -core, -engine, -fedclient, -fedplan, -geo, -gpu, -hdt, -introspect, -mpc, -nlq, -parse, -policy, -prov, -py, -reason, -reason-wasm, -rsp, -serve, -server, -shacl, -sim, -solid, -text, -vectors, -wasm, -zk-compose, -zk.)
 - `kind:` cross-cutting: `kind:perf`, `kind:correctness`, `kind:docs`.
 - `roborev` for review-backlog items; `quota-failed` for jobs that need re-running after quota reset.
 - `js` for the JS/WASM port side.
@@ -182,7 +186,7 @@ Each agent: `bd ready --assignee <agent> --claim --json` to atomically grab the 
 |---|---|---|
 | **Beads (`bd`)** | Multiple agents, real cross-task blockers, want offline `ready` queries, git-native history, breadcrumb trails. **Our case.** | Young (1.x, no API-stability promise; 67 npm versions); Dolt backend is heavier than a flat file (132 MB binary, an embedded SQL/git DB under `.beads/`); learning curve on edge semantics; default `init` clobbers `CLAUDE.md`+hooks (mitigated by `--skip-*`); no cross-database refs. |
 | **GitHub Issues** | Human collaborators, public visibility, PR auto-linking, mature/stable. | Requires network for *every* readiness query; dependency graph is weak (task-lists, not first-class `blocks`+`ready`); rate limits; agents pay latency; not git-local. Good as a *mirror* (`bd github …` exists) but poor as the agent's live work-graph. |
-| **Plain markdown TODO.md** (what we have) | Zero infra, human-readable, trivially diffable, fine for a single linear worker. | No dependency semantics, no `ready` computation, no atomic claim — two agents collide; "blocked until X" is a prose comment a human must parse; rots fast across 25 crates. We already feel this pain (10+ TODO.md files, no cross-cutting view). |
+| **Plain markdown TODO.md** (what we have) | Zero infra, human-readable, trivially diffable, fine for a single linear worker. | No dependency semantics, no `ready` computation, no atomic claim — two agents collide; "blocked until X" is a prose comment a human must parse; rots fast across 31 crates. We already feel this pain (10+ TODO.md files, no cross-cutting view). |
 | **Agent built-in todo tool** | Single task, single session scratchpad. | Ephemeral — dies with the session; no persistence, no graph, no cross-agent sharing. Wrong layer for a multi-day, multi-agent backlog. Keep it for in-session steps; beads for the durable backlog. |
 
 **Verdict:** adopt beads as the durable, cross-agent backlog + merge-queue graph; keep the agent's built-in todo for in-session steps; optionally mirror selected epics to GitHub Issues for human visibility. Retire per-crate `TODO.md` once migrated (or leave one-line pointers to `bd`). The honest cost is a new young dependency and a Dolt directory; the honest benefit is that "what can an agent work on right now, given everything in flight?" becomes a single `bd ready` call instead of tribal knowledge.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated docs change for bead **sq-knl8**.

## What

Sync the **TOTAL crate count** in two `research/` design records that still asserted **25 crates**; the workspace now has **31** (`ls crates/`):

- `research/coverage-and-benchmark-plan.md` — "Of 25 crates …" → "Of 31 crates …".
- `research/task-tracking-best-practices.md` — three "25 crates" assertions → "31 crates", **and** the inline `area:<crate>` example list refreshed to add the 6 crates created since the doc was written: `canon`, `fedclient`, `fedplan`, `policy`, `prov`, `reason-wasm`.

Each file also gets a dated `[OPUS-4.8] sq-knl8` HTML-comment maintenance note.

## Scope / honesty note

- This is the **TOTAL crate count only**. It is deliberately **distinct from the unsafe-posture forbid/unsafe split** (`20 forbid + 5 unsafe = 25`) recorded as a **point-in-time finding** in `compliance/audit/memsafety-findings-1.md`. That line is a historical audit record (not a stale current-state claim) and is governed by the separate unsafe-count sync (sq-pro0), so it is **left untouched** — matching the bead's "(not unsafe posture)" qualifier.
- A repo-wide grep confirms no other markdown asserts a stale `NN crate` total (`AGENTS.md` / `README.md` carry no crate-count claim).

## Gate (docs)

- **privacy-claims** gate (incl. predicate-form soundness): PASS (`scripts/check-privacy-claims.sh` — 279 files scanned, no unqualified ZK/MPC claim).
- **markdownlint-cli2** (HARD config) on the changed files: 0 errors.
- **typos**: clean on the changed files.
- No public API touched → G2 public-api→SKILL.md rule N/A.

Docs-only; no Rust crate compiled. Auto-merge intentionally **not** enabled — orchestrator arms after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
