### PR TITLE
test(sbom): regression-test the GS-6 bom-ref normalization (sq-9gli)

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -218,8 +218,15 @@ jobs:
   # `^pkg:cargo/[^?#]+@[^?#]+$` (scripts/check-sbom-purl-canonical.py) — so a regression
   # in the normalizer-vs-tool contract FAILS the PR instead of shipping. NOTE: the job name
   # has NO `advisory`/`informational` WHOLE WORD, so the ci-summary aggregator treats it as
-  # GATING (intentional). Also runs the hermetic self-test so a regression in the check
-  # itself is caught.
+  # GATING (intentional). Also runs the hermetic self-tests so a regression in the checks
+  # themselves is caught:
+  #   * test_sbom_purl_canonical.py — the purl half (GS-7).
+  #   * test_sbom_bomref_canonical.py — the bom-ref half (GS-6, sq-9gli): pins that the SBOM
+  #     ROOT COMPONENT's `bom-ref` (and every workspace/path ref + dependency edge) is
+  #     rewritten from the `path+file:///abs/build/dir/...#ver` form to the canonical
+  #     `pkg:cargo/<name>@<version>` identity, so no build-machine path leaks into the
+  #     PUBLISHED SBOM. With the toolchain installed below, its live-workspace assertion runs
+  #     here (not skipped) over the same normalizer the publication path uses.
   sbom-purl-canonical:
     name: SBOM purl-canonicality assertion (GS-6/GS-7) — GATING
     runs-on: ubuntu-latest
@@ -233,6 +240,8 @@ jobs:
           tool: cargo-cyclonedx
       - name: purl-canonicality check self-test
         run: python3 scripts/tests/test_sbom_purl_canonical.py
+      - name: bom-ref-canonicality check self-test (GS-6)
+        run: python3 scripts/tests/test_sbom_bomref_canonical.py
       - name: Generate + normalize SBOM, then assert canonical purls — GATING
         run: |
           set -euo pipefail

--- a/scripts/tests/test_sbom_bomref_canonical.py
+++ b/scripts/tests/test_sbom_bomref_canonical.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] sq-9gli (GS-6 / F-6): hermetic regression test for the BOM-REF half of
+# scripts/sbom-normalize.jq. Authored by Opus 4.8 (Fable unavailable; flag for
+# re-review when Fable returns).
+#
+# WHY THIS, ON TOP OF test_sbom_purl_canonical.py:
+# GS-6 (F-6, sq-toze.30) is specifically that cargo-cyclonedx 0.5.9 stamps the absolute
+# build-machine path into the SBOM ROOT COMPONENT's `bom-ref` (and every workspace/path
+# dependency `bom-ref` + `dependencies[].ref`/`dependsOn[]` edge) as
+#     path+file:///abs/build/dir/crates/<name>#<version>[ <suffix>]
+# which would leak the CI runner's filesystem layout into the PUBLISHED SBOM. The
+# load-bearing control is scripts/sbom-normalize.jq's `canon_ref`, which rewrites every
+# such ref to the canonical, host-independent `pkg:cargo/<name>@<version>[<suffix>]` and
+# rewrites the dependency graph in lock-step.
+#
+# That `bom-ref` rewrite had NO dedicated test: the existing sbom self-test
+# (test_sbom_purl_canonical.py) + its CI backstop (check-sbom-purl-canonical.py) assert
+# only `purl` canonicality, and the only `bom-ref` guard is a coarse
+# `grep -qE 'path+file://|/home/'` tripwire inside gen-sbom-vex.sh / supply-chain.yml.
+# That tripwire would still "pass" if a future cargo-cyclonedx bump caused canon_ref to
+# DROP or MANGLE a ref (no host path present, but the SBOM's internal reference graph
+# silently broken / the root component mis-identified). This test pins the actual
+# contract: the root bom-ref is rewritten to the CORRECT canonical identity, nested
+# build-target suffixes are preserved, every dependency edge is rewritten in lock-step,
+# registry refs are untouched, no host path survives, and the transform is idempotent.
+#
+# Hermetic w.r.t. git/network/cargo: drives the REAL scripts/sbom-normalize.jq (via jq)
+# over an in-tmpdir fixture carrying the exact 0.5.9 `path+file://...#ver` shapes. A final
+# test generates the REAL workspace SBOM and asserts no bom-ref/ref/dependsOn leaks a host
+# path; it is SKIPPED (not failed) if cargo-cyclonedx / jq are unavailable, so the suite
+# stays runnable in a bare environment while still proving the live invariant on CI.
+#
+# Run:  python3 scripts/tests/test_sbom_bomref_canonical.py
+# (stdlib only; no pytest required — also discoverable by `pytest`.)
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+NORMALIZE_JQ = REPO_ROOT / "scripts" / "sbom-normalize.jq"
+
+# A ref that still embeds a build-machine path. Mirrors gen-sbom-vex.sh's belt-and-braces
+# guard, but we assert it over the parsed ref STRINGS, not a raw grep, so a structurally
+# broken (dropped/mangled) ref is also visible to the lock-step / identity assertions.
+HOST_PATH = re.compile(r"path\+file://|download_url=file://|/home/|/Users/|/runner|/builds?/")
+
+# Canonical cargo bom-ref/ref: pkg:cargo/<name>@<version>, optionally with a trailing
+# build-target suffix (e.g. " bin-target-0"). Registry refs keep their own form and are
+# matched separately.
+CANONICAL_REF = re.compile(r"^pkg:cargo/[^@]+@[^?#]+( \S.*)?$")
+REGISTRY_REF = re.compile(r"^registry\+https://")
+
+
+def _jq_available() -> bool:
+    return shutil.which("jq") is not None
+
+
+def _normalize(doc: dict) -> dict:
+    """Run the REAL scripts/sbom-normalize.jq over `doc` via jq and return the result."""
+    out = subprocess.run(
+        ["jq", "-f", str(NORMALIZE_JQ)],
+        input=json.dumps(doc),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return json.loads(out)
+
+
+def _walk_refs(node: object) -> list[str]:
+    """Every bom-ref / dependencies[].ref / dependsOn[] string anywhere in the doc."""
+    out: list[str] = []
+    if isinstance(node, dict):
+        for key in ("bom-ref", "ref"):
+            v = node.get(key)
+            if isinstance(v, str):
+                out.append(v)
+        for v in node.get("dependsOn", []) or []:
+            if isinstance(v, str):
+                out.append(v)
+        for k, v in node.items():
+            if k == "dependsOn":
+                continue
+            out.extend(_walk_refs(v))
+    elif isinstance(node, list):
+        for v in node:
+            out.extend(_walk_refs(v))
+    return out
+
+
+# The exact 0.5.9 shapes (root component + nested build target + workspace member +
+# dependency edges), with a CI-runner absolute build path stamped in.
+def _leaky_sbom() -> dict:
+    abs_cli = "path+file:///home/runner/work/sparq/sparq/crates/sparq-cli#0.1.0"
+    abs_core = "path+file:///home/runner/work/sparq/sparq/crates/sparq-core#0.1.0"
+    reg_serde = "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0"
+    return {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "metadata": {
+            "component": {
+                "type": "application",
+                "name": "sparq-cli",
+                "version": "0.1.0",
+                "bom-ref": abs_cli,
+                "purl": "pkg:cargo/sparq-cli@0.1.0?download_url=file://.",
+                "components": [
+                    {
+                        "type": "application",
+                        "name": "sparq-cli",
+                        "bom-ref": abs_cli + " bin-target-0",
+                        "purl": "pkg:cargo/sparq-cli@0.1.0?download_url=file://.#src/main.rs",
+                    }
+                ],
+            }
+        },
+        "components": [
+            {
+                "type": "library",
+                "name": "sparq-core",
+                "version": "0.1.0",
+                "bom-ref": abs_core,
+                "purl": "pkg:cargo/sparq-core@0.1.0?download_url=file://../sparq-core",
+            },
+            {
+                "type": "library",
+                "name": "serde",
+                "version": "1.0.0",
+                "bom-ref": reg_serde,
+                "purl": "pkg:cargo/serde@1.0.0",
+            },
+        ],
+        "dependencies": [
+            {"ref": abs_cli, "dependsOn": [abs_core, reg_serde]},
+            {"ref": abs_core, "dependsOn": [reg_serde]},
+        ],
+    }
+
+
+@unittest.skipUnless(_jq_available(), "jq not available")
+class TestBomRefNormalization(unittest.TestCase):
+    """Drive the real scripts/sbom-normalize.jq over the leaky fixture and pin the GS-6
+    bom-ref contract."""
+
+    def setUp(self) -> None:
+        self.norm = _normalize(_leaky_sbom())
+
+    def test_no_ref_leaks_a_host_path(self):
+        # The headline GS-6 invariant: no bom-ref / ref / dependsOn carries a build path.
+        leaks = [r for r in _walk_refs(self.norm) if HOST_PATH.search(r)]
+        self.assertEqual(leaks, [], f"host path leaked into ref(s): {leaks}")
+
+    def test_root_component_bomref_is_canonical_identity(self):
+        # The bead's literal subject: the ROOT component ref. It must become the canonical
+        # cargo identity for sparq-cli@0.1.0 — not dropped, not mangled to something else.
+        root = self.norm["metadata"]["component"]["bom-ref"]
+        self.assertEqual(root, "pkg:cargo/sparq-cli@0.1.0")
+
+    def test_nested_build_target_suffix_is_preserved(self):
+        # canon_ref preserves the trailing build-target suffix while stripping the path.
+        sub = self.norm["metadata"]["component"]["components"][0]["bom-ref"]
+        self.assertEqual(sub, "pkg:cargo/sparq-cli@0.1.0 bin-target-0")
+
+    def test_workspace_member_bomref_is_canonical(self):
+        core = next(c for c in self.norm["components"] if c["name"] == "sparq-core")
+        self.assertEqual(core["bom-ref"], "pkg:cargo/sparq-core@0.1.0")
+
+    def test_registry_ref_is_untouched(self):
+        # Registry deps are already host-independent and must pass through verbatim.
+        serde = next(c for c in self.norm["components"] if c["name"] == "serde")
+        self.assertEqual(
+            serde["bom-ref"],
+            "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0",
+        )
+
+    def test_dependency_graph_rewritten_in_lockstep(self):
+        # Every ref/dependsOn edge must be rewritten so the graph still resolves: each
+        # ref is now the canonical cargo form (suffix-free) or an untouched registry ref.
+        deps = {d["ref"]: d.get("dependsOn", []) for d in self.norm["dependencies"]}
+        self.assertIn("pkg:cargo/sparq-cli@0.1.0", deps)
+        self.assertIn("pkg:cargo/sparq-core@0.1.0", deps)
+        self.assertEqual(
+            sorted(deps["pkg:cargo/sparq-cli@0.1.0"]),
+            sorted(
+                [
+                    "pkg:cargo/sparq-core@0.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0",
+                ]
+            ),
+        )
+        for ref in deps:
+            self.assertTrue(
+                CANONICAL_REF.match(ref) or REGISTRY_REF.match(ref),
+                f"dependency ref is neither canonical cargo nor registry: {ref!r}",
+            )
+
+    def test_idempotent(self):
+        # canon_ref's canonical form contains no path+file:// so a second pass is a no-op:
+        # normalizing the already-normalized doc must be byte-identical.
+        once = json.dumps(self.norm, sort_keys=True)
+        twice = json.dumps(_normalize(self.norm), sort_keys=True)
+        self.assertEqual(once, twice)
+
+
+class TestLiveWorkspaceSBOM(unittest.TestCase):
+    """Generate the REAL normalized workspace SBOM and assert no ref leaks a host path —
+    the exact GS-6 invariant the publication path must hold. Skipped if toolchain absent."""
+
+    def test_real_normalized_sbom_has_no_host_path_in_refs(self):
+        if not shutil.which("cargo-cyclonedx") or not _jq_available():
+            self.skipTest("cargo-cyclonedx / jq not available")
+        subprocess.run(
+            ["cargo", "cyclonedx", "--all", "--format", "json", "--spec-version", "1.5"],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+        )
+        try:
+            judged = 0
+            for crate in ("sparq-server", "sparq-cli"):
+                src = REPO_ROOT / "crates" / crate / f"{crate}.cdx.json"
+                if not src.exists():
+                    continue
+                out = subprocess.run(
+                    ["jq", "-f", str(NORMALIZE_JQ), str(src)],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ).stdout
+                refs = _walk_refs(json.loads(out))
+                leaks = [r for r in refs if HOST_PATH.search(r)]
+                self.assertEqual(leaks, [], f"{crate}: host path leaked into ref(s): {leaks}")
+                # The root component ref of the released binary is the canonical cargo id.
+                root = json.loads(out)["metadata"]["component"]["bom-ref"]
+                self.assertTrue(
+                    CANONICAL_REF.match(root),
+                    f"{crate}: root bom-ref not canonical: {root!r}",
+                )
+                judged += 1
+            self.assertGreater(judged, 0, "no released-binary SBOM was generated")
+        finally:
+            for f in REPO_ROOT.glob("crates/**/*.cdx.json"):
+                f.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 SPARQ agent — automated change. Implements bead **sq-9gli** (GS-6, F-6).

## What & why

**GS-6 / F-6** (SBOM cert audit, #229) flagged that the generated CycloneDX SBOM's **root component `bom-ref`** embedded an absolute build-machine path — `path+file:///abs/build/dir/crates/<name>#<version>` — leaking the CI runner's filesystem layout into the published SBOM (information disclosure / non-reproducible).

**The fix itself already landed on `main`** in `#284` (`sq-toze.30`): `scripts/sbom-normalize.jq`'s `canon_ref` rewrites every leaking ref (root `metadata.component.bom-ref`, nested build-target sub-components, workspace/path-dependency refs, and every `dependencies[].ref` / `dependsOn[]` edge) to the canonical, host-independent `pkg:cargo/<name>@<version>` form, and `gen-sbom-vex.sh` + `supply-chain.yml` carry a belt-and-braces grep tripwire. I verified the live generator output: the root ref is `pkg:cargo/sparq-cli@0.1.0` with zero host-path leaks anywhere.

**What was missing — and what this PR adds — is test coverage for the `bom-ref` half of that control.** The existing sbom self-test (`test_sbom_purl_canonical.py`) and its CI backstop (`check-sbom-purl-canonical.py`) assert only `purl` canonicality. The only `bom-ref` guard is a coarse `grep -qE 'path+file://|/home/'` tripwire that would *still pass* if a future `cargo-cyclonedx` bump caused `canon_ref` to **drop or mangle** a ref (no host path present, but the internal reference graph silently broken / the root component mis-identified).

## Change

- **New** `scripts/tests/test_sbom_bomref_canonical.py` — hermetic test that drives the **real** `scripts/sbom-normalize.jq` over a fixture carrying the exact 0.5.9 `path+file://...#ver` shapes and pins the GS-6 contract:
  - root `metadata.component.bom-ref` → correct canonical identity `pkg:cargo/sparq-cli@0.1.0`;
  - nested build-target suffix preserved (`... bin-target-0`);
  - workspace-member refs canonicalised; registry refs untouched;
  - every `dependencies[].ref` / `dependsOn[]` edge rewritten in lock-step (graph still resolves);
  - no host path survives anywhere; transform idempotent.
  - A live-workspace test regenerates the real SBOM and asserts no ref leaks a host path over the **same** normalizer the publication path uses (skipped if `cargo-cyclonedx`/`jq` absent).
- **Wired** into the existing `sbom-purl-canonical` **GATING** job in `.github/workflows/supply-chain.yml` (already installs `jq` + `cargo-cyclonedx`, so the live-workspace assertion runs rather than skips).

This is a **pure test-coverage addition — no production-code change** (`scripts/sbom-normalize.jq` is byte-identical to `main`).

## Verification (TDD)

- **RED:** temporarily neutering `canon_ref` fails **6** of these tests, including the live-workspace assertion, which surfaced the real leaked refs (e.g. `vendor/spargebra#0.4.6`).
- **GREEN:** all 8 pass against the real normalizer.
- Privacy-claims gate: 32 passed, 0 failed. `test_gates.py` G2 (public-api→SKILL) PASS — no public surface changed. Workflow YAML parses; `py_compile` clean.

## Honesty note

The underlying GS-6 leak was already remediated by `#284`; this PR does **not** re-fix it. It closes the remaining gap — a regression test for the `bom-ref` normalization — so a future `cargo-cyclonedx` upgrade that re-introduces a host path (or breaks the ref graph) fails the PR instead of shipping. If the reviewer considers the existing grep tripwire sufficient and does not want the extra coverage, this PR can be closed without loss of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
