### PR TITLE
feat(sparq-shacl): SHACL-1.2 core/node list+ByTypes+disjunctive constraints (sq-vg3y) [OPUS-4.8]

### DIFF
--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -40,16 +40,17 @@ cargo test -p sparq-shacl --test w3c_core -- --nocapture
 ```
 
 A companion harness ([`tests/w3c_core_shacl12.rs`](tests/w3c_core_shacl12.rs),
-sq-yca1) walks the **newer `shacl12-test-suite/tests/core/node`** tree, which
-additionally carries the `nodeByExpression-001` `sht:Validate` entry (covered end
-to end under the `shacl-af` feature) and a set of SHACL-1.2-only constraints this
-crate does not yet implement (`sh:memberShape`, `sh:uniqueMembers`,
+sq-yca1) walks the **newer `shacl12-test-suite/tests/core/node`** tree. The
+SHACL-1.2-only core constraints there — `sh:memberShape`, `sh:uniqueMembers`,
 `sh:{min,max}ListLength`, `sh:uniqueValuesFor`, the `sh:closed sh:ByTypes` mode,
-and the disjunctive list form of `sh:datatype` / `sh:nodeKind`). It is
-**SKIP-tolerant**: an entry is recorded as SKIP — never FAIL — exactly when its
-shapes use a constraint *form* the crate does not implement; every other entry is
-compared strictly, so a regression in an implemented constraint still fails the
-build. The unimplemented forms are tracked in sq-vg3y.
+and the disjunctive list form of `sh:datatype` / `sh:nodeKind` — are now
+**implemented** (sq-vg3y) and pass strictly: 44/45 entries PASS with `shacl-af`
+off (the one SKIP is `nodeByExpression-001`, a `shacl-af` constraint) and 45/45
+with it on. The harness stays **SKIP-tolerant** for any constraint *predicate*
+the build still lacks (after sq-vg3y that is only `sh:nodeByExpression` when
+`shacl-af` is off): such an entry is recorded as SKIP — never FAIL — while every
+other entry is compared strictly, so a regression in an implemented constraint
+still fails the build.
 
 ## Differential fuzzing against reference engines
 
@@ -87,8 +88,10 @@ per-PR path.
 
 ## Supported constraint components
 
-`sh:class`, `sh:datatype` (with XSD lexical-space ill-formedness checks),
-`sh:nodeKind`, `sh:minCount`/`sh:maxCount`,
+`sh:class`, `sh:datatype` (with XSD lexical-space ill-formedness checks; the
+SHACL-1.2 disjunctive list form `sh:datatype ( … )` is accepted),
+`sh:nodeKind` (single IRI or the SHACL-1.2 list form `sh:nodeKind ( … )`),
+`sh:minCount`/`sh:maxCount`,
 `sh:minInclusive`/`sh:minExclusive`/`sh:maxInclusive`/`sh:maxExclusive`
 (numeric, string, boolean and date/time orderings, including the
 timezone-presence comparability rule), `sh:minLength`/`sh:maxLength`,
@@ -96,8 +99,16 @@ timezone-presence comparability rule), `sh:minLength`/`sh:maxLength`,
 `sh:disjoint`, `sh:lessThan`, `sh:lessThanOrEquals`, `sh:not`, `sh:and`,
 `sh:or`, `sh:xone`, `sh:node`, `sh:property`, `sh:qualifiedValueShape`
 (+`sh:qualifiedMinCount`/`sh:qualifiedMaxCount`/
-`sh:qualifiedValueShapesDisjoint`), `sh:closed` (+`sh:ignoredProperties`),
+`sh:qualifiedValueShapesDisjoint`), `sh:closed` (+`sh:ignoredProperties`; the
+SHACL-1.2 `sh:closed sh:ByTypes` close-by-types mode is supported),
 `sh:hasValue`, `sh:in`.
+
+**SHACL-1.2 list constraints (sq-vg3y, Core path):** `sh:memberShape` (every
+member of a SHACL-list value node conforms to a shape), `sh:uniqueMembers`
+(members pairwise distinct), `sh:minListLength`/`sh:maxListLength` (member-count
+bounds), `sh:uniqueValuesFor` (the values of one property — or a SHACL list of
+properties, a composite key — are unique across the shape's target nodes). Each
+also reports when a value node is not a well-formed SHACL list.
 
 **SHACL-SPARQL:** `sh:sparql` (the SPARQL-based constraint component, §5.2) —
 the `sh:select` runs per focus node with `$this` pre-bound (and `$PATH` on

--- a/crates/sparq-shacl/src/eval.rs
+++ b/crates/sparq-shacl/src/eval.rs
@@ -27,6 +27,7 @@ pub(crate) fn validate_graph(data: &Graph, shapes: &ShapesModel) -> Vec<Validati
         memo: vec![FxHashMap::default(); shapes.shapes.len()],
         min_reentry: usize::MAX,
         regexes: FxHashMap::default(),
+        uvf_targets: FxHashMap::default(),
     };
     let mut out = Vec::new();
     for &sid in &shapes.targeted {
@@ -53,6 +54,7 @@ pub(crate) fn conforms_node(data: &Graph, shapes: &ShapesModel, sid: usize, node
         memo: vec![FxHashMap::default(); shapes.shapes.len()],
         min_reentry: usize::MAX,
         regexes: FxHashMap::default(),
+        uvf_targets: FxHashMap::default(),
     };
     v.conforms(node, sid)
 }
@@ -72,6 +74,10 @@ struct Validator<'a> {
     /// memoised only if no re-entry pointed BELOW it.
     min_reentry: usize,
     regexes: FxHashMap<String, Option<regex::Regex>>,
+    /// [OPUS-4.8] (sq-vg3y) Per-shape target-node cache for `sh:uniqueValuesFor`
+    /// (the constraint needs every target node of the shape, but is evaluated once
+    /// per focus node — compute the target scan once).
+    uvf_targets: FxHashMap<usize, Vec<Term>>,
 }
 
 impl<'a> Validator<'a> {
@@ -191,10 +197,15 @@ impl<'a> Validator<'a> {
                     }
                 }
             }
-            Component::Datatype(dt) => {
+            // [OPUS-4.8] (sq-vg3y) A value conforms iff it is a literal whose
+            // (well-formed) datatype is ANY of the allowed datatypes — the single
+            // IRI is a singleton set, the SHACL-1.2 list form is the disjunction.
+            Component::Datatype(dts) => {
                 for v in values {
                     let ok = match v {
-                        Term::Literal(l) => l.datatype().as_str() == dt && well_formed(l),
+                        Term::Literal(l) => {
+                            dts.iter().any(|dt| l.datatype().as_str() == dt) && well_formed(l)
+                        }
                         _ => false,
                     };
                     if !ok {
@@ -203,34 +214,23 @@ impl<'a> Validator<'a> {
                             focus,
                             Some(v.clone()),
                             "DatatypeConstraintComponent",
-                            format!("Value does not have datatype <{dt}>"),
+                            iri_set_message("datatype", dts),
                         ));
                     }
                 }
             }
-            Component::NodeKind(kind) => {
+            // [OPUS-4.8] (sq-vg3y) A value conforms iff its node kind matches ANY of
+            // the allowed kinds (single IRI = singleton; SHACL-1.2 list = disjunction).
+            Component::NodeKind(kinds) => {
                 for v in values {
-                    let local = kind.strip_prefix(crate::model::SH).unwrap_or(kind);
-                    let ok = match v {
-                        Term::NamedNode(_) => {
-                            matches!(local, "IRI" | "BlankNodeOrIRI" | "IRIOrLiteral")
-                        }
-                        Term::BlankNode(_) => {
-                            matches!(local, "BlankNode" | "BlankNodeOrIRI" | "BlankNodeOrLiteral")
-                        }
-                        Term::Literal(_) => {
-                            matches!(local, "Literal" | "BlankNodeOrLiteral" | "IRIOrLiteral")
-                        }
-                        #[allow(unreachable_patterns)]
-                        _ => false,
-                    };
+                    let ok = kinds.iter().any(|kind| node_kind_matches(v, kind));
                     if !ok {
                         out.push(self.result(
                             sid,
                             focus,
                             Some(v.clone()),
                             "NodeKindConstraintComponent",
-                            format!("Value does not have node kind <{kind}>"),
+                            iri_set_message("node kind", kinds),
                         ));
                     }
                 }
@@ -581,21 +581,35 @@ impl<'a> Validator<'a> {
                     }
                 }
             }
-            Component::Closed { ignored } => {
-                let shape = &self.shapes.shapes[sid];
-                let mut allowed: Vec<String> = ignored
+            Component::Closed { ignored, by_types } => {
+                let ignored_preds: Vec<String> = ignored
                     .iter()
                     .filter_map(|t| match t {
                         Term::NamedNode(n) => Some(n.as_str().to_string()),
                         _ => None,
                     })
                     .collect();
-                for &child in &shape.property_children {
-                    if let Some(Path::Predicate(p)) = &self.shapes.shapes[child].path {
-                        allowed.push(p.clone());
+                // `sh:closed true`: the allowed set is fixed (this shape's
+                // sh:property/sh:path predicates), so compute it once. `sh:closed
+                // sh:ByTypes`: the allowed set is recomputed PER value node from its
+                // rdf:type(s) (SHACL-1.2 §4.8.1 collectProperties), so defer it.
+                // [OPUS-4.8] (sq-vg3y) added the ByTypes branch.
+                let fixed_allowed: Option<Vec<String>> = if *by_types {
+                    None
+                } else {
+                    let mut allowed = ignored_preds.clone();
+                    for &child in &self.shapes.shapes[sid].property_children {
+                        if let Some(Path::Predicate(p)) = &self.shapes.shapes[child].path {
+                            allowed.push(p.clone());
+                        }
                     }
-                }
+                    Some(allowed)
+                };
                 for v in values {
+                    let allowed = match &fixed_allowed {
+                        Some(a) => a.clone(),
+                        None => self.close_by_types_allowed(sid, v, &ignored_preds),
+                    };
                     for (p, o) in self.data.predicate_objects(v) {
                         let p_str = match &p {
                             Term::NamedNode(n) => n.as_str().to_string(),
@@ -638,6 +652,101 @@ impl<'a> Validator<'a> {
                         ));
                     }
                 }
+            }
+            // [OPUS-4.8] (sq-vg3y) `sh:memberShape` (SHACL-1.2): each value node must
+            // be a well-formed SHACL list whose members all conform to `member`. A
+            // non-list (or member non-conformance) is ONE top-level result on the
+            // value node (the per-member `sh:detail`s are non-normative; the W3C
+            // suite compares only top-level result fields).
+            Component::MemberShape(member) => {
+                for v in values {
+                    let violates = match self.data.list_strict(v) {
+                        None => true, // not a SHACL list
+                        Some(members) => members.iter().any(|m| !self.conforms(m, *member)),
+                    };
+                    if violates {
+                        out.push(
+                            self.result(
+                                sid,
+                                focus,
+                                Some(v.clone()),
+                                "MemberShapeConstraintComponent",
+                                "List value is not a well-formed SHACL list, or a member \
+                             does not conform to the member shape"
+                                    .into(),
+                            ),
+                        );
+                    }
+                }
+            }
+            // [OPUS-4.8] (sq-vg3y) `sh:uniqueMembers true` (SHACL-1.2): each value
+            // node must be a SHACL list whose members are pairwise distinct. A
+            // non-list, or a list with duplicate members, is one result on v.
+            Component::UniqueMembers => {
+                for v in values {
+                    let violates = match self.data.list_strict(v) {
+                        None => true,
+                        Some(members) => crate::view::dedup(members.clone()).len() != members.len(),
+                    };
+                    if violates {
+                        out.push(
+                            self.result(
+                                sid,
+                                focus,
+                                Some(v.clone()),
+                                "UniqueMembersConstraintComponent",
+                                "List value is not a well-formed SHACL list, or has \
+                             duplicate members"
+                                    .into(),
+                            ),
+                        );
+                    }
+                }
+            }
+            // [OPUS-4.8] (sq-vg3y) `sh:maxListLength` / `sh:minListLength` (SHACL-1.2):
+            // each value node must be a SHACL list with at most / at least N members.
+            Component::MaxListLength(n) => {
+                for v in values {
+                    let violates = match self.data.list_strict(v) {
+                        None => true,
+                        Some(members) => members.len() as u64 > *n,
+                    };
+                    if violates {
+                        out.push(self.result(
+                            sid,
+                            focus,
+                            Some(v.clone()),
+                            "MaxListLengthConstraintComponent",
+                            format!("List value is not a SHACL list with at most {n} members"),
+                        ));
+                    }
+                }
+            }
+            Component::MinListLength(n) => {
+                for v in values {
+                    let violates = match self.data.list_strict(v) {
+                        None => true,
+                        Some(members) => (members.len() as u64) < *n,
+                    };
+                    if violates {
+                        out.push(self.result(
+                            sid,
+                            focus,
+                            Some(v.clone()),
+                            "MinListLengthConstraintComponent",
+                            format!("List value is not a SHACL list with at least {n} members"),
+                        ));
+                    }
+                }
+            }
+            // [OPUS-4.8] (sq-vg3y) `sh:uniqueValuesFor` (SHACL-1.2): the values of the
+            // listed properties of a value node must be unique across ALL target
+            // nodes of the shape. For each value node V that shares the exact same
+            // value-set (for every listed property) with another target node Other,
+            // one result with Other as sh:value. No result if V has no values for
+            // ANY of the properties.
+            Component::UniqueValuesFor(props) => {
+                self.eval_unique_values_for(sid, focus, values, props, out)
             }
             // [OPUS-4.8] sh:sparql — SPARQL-based constraints (SHACL §5.2). The
             // sh:select runs against the data graph with $this pre-bound to the
@@ -875,6 +984,85 @@ impl<'a> Validator<'a> {
         }
     }
 
+    /// [OPUS-4.8] (sq-vg3y) The allowed-predicate set P for `sh:closed sh:ByTypes`
+    /// at value node `v` (SHACL-1.2 §4.8.1 `collectProperties`): the IRI properties
+    /// reachable via `sh:property/sh:path` from every shape that the value node's
+    /// `rdf:type`s pull in — transitively through `rdfs:subClassOf`, inbound
+    /// `sh:targetClass`, and `sh:node` — plus `rdf:type` and the shape's own
+    /// `sh:ignoredProperties`. The shapes-graph traversal is DATA-INDEPENDENT, so
+    /// it is precomputed once per shapes node into [`ShapesModel::by_types_closure`]
+    /// at parse time; here we just union the closures for the shape's own node and
+    /// for each `rdf:type` of the value node (read from the DATA graph).
+    fn close_by_types_allowed(&self, sid: usize, v: &Term, ignored: &[String]) -> Vec<String> {
+        const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+        let mut allowed: rustc_hash::FxHashSet<String> = ignored.iter().cloned().collect();
+        allowed.insert(RDF_TYPE.to_string());
+        let mut add = |node: &Term| {
+            if let Some(props) = self.shapes.by_types_closure(node) {
+                allowed.extend(props.iter().cloned());
+            }
+        };
+        // The shape's own node carries sh:closed and is the rdfs:Class in the
+        // closed-003/004 tests, then every rdf:type of the value node.
+        add(&self.shapes.shapes[sid].node);
+        for ty in self.data.objects(v, RDF_TYPE) {
+            add(&ty);
+        }
+        allowed.into_iter().collect()
+    }
+
+    /// [OPUS-4.8] (sq-vg3y) `sh:uniqueValuesFor` evaluation: for each value node V
+    /// (with at least one value across the listed properties), report each OTHER
+    /// target node of this shape that has the exact same per-property value sets as
+    /// V (with that other node as `sh:value`, V's focus as `sh:focusNode`).
+    fn eval_unique_values_for(
+        &mut self,
+        sid: usize,
+        focus: &Term,
+        values: &[Term],
+        props: &[String],
+        out: &mut Vec<ValidationResult>,
+    ) {
+        // The shape's target nodes (cached once per shape, reused across foci).
+        let targets = self.unique_values_targets(sid);
+        for v in values {
+            let sig_v = value_signature(&self.data, v, props);
+            if sig_v.iter().all(|s| s.is_empty()) {
+                continue; // V has no values for any property — never a violation
+            }
+            for other in &targets {
+                if other == v {
+                    continue;
+                }
+                if value_signature(&self.data, other, props) == sig_v {
+                    out.push(
+                        self.result(
+                            sid,
+                            focus,
+                            Some(other.clone()),
+                            "UniqueValuesForConstraintComponent",
+                            "Another target node has the same values for the unique \
+                         properties"
+                                .into(),
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    /// The (deduplicated) target nodes of shape `sid`, for `sh:uniqueValuesFor`.
+    /// Memoised on first use so a shape's whole-target scan happens once even
+    /// though the constraint is evaluated once per focus node.
+    fn unique_values_targets(&mut self, sid: usize) -> Vec<Term> {
+        if let Some(cached) = self.uvf_targets.get(&sid) {
+            return cached.clone();
+        }
+        let targets = self.focus_nodes(&self.shapes.shapes[sid]);
+        self.uvf_targets.insert(sid, targets.clone());
+        targets
+    }
+
     #[allow(clippy::too_many_arguments)] // one call site per range component; a struct would obscure it
     fn range(
         &mut self,
@@ -923,6 +1111,61 @@ impl<'a> Validator<'a> {
             })
             .clone()
     }
+}
+
+/// [OPUS-4.8] (sq-vg3y) True iff value node `v` matches the single `sh:nodeKind`
+/// IRI `kind` (SHACL §4.6.1): an IRI matches sh:IRI / sh:BlankNodeOrIRI /
+/// sh:IRIOrLiteral; a blank node matches sh:BlankNode / sh:BlankNodeOrIRI /
+/// sh:BlankNodeOrLiteral; a literal matches sh:Literal / sh:BlankNodeOrLiteral /
+/// sh:IRIOrLiteral. A list-form `sh:nodeKind` is the OR over its members.
+fn node_kind_matches(v: &Term, kind: &str) -> bool {
+    let local = kind.strip_prefix(crate::model::SH).unwrap_or(kind);
+    match v {
+        Term::NamedNode(_) => matches!(local, "IRI" | "BlankNodeOrIRI" | "IRIOrLiteral"),
+        Term::BlankNode(_) => {
+            matches!(local, "BlankNode" | "BlankNodeOrIRI" | "BlankNodeOrLiteral")
+        }
+        Term::Literal(_) => matches!(local, "Literal" | "BlankNodeOrLiteral" | "IRIOrLiteral"),
+        #[allow(unreachable_patterns)]
+        _ => false,
+    }
+}
+
+/// [OPUS-4.8] (sq-vg3y) A default message for a set-valued `sh:datatype` /
+/// `sh:nodeKind` constraint (`label` = "datatype" / "node kind"): the single IRI
+/// reads naturally, the list form reads "any of <…> <…>".
+fn iri_set_message(label: &str, iris: &[String]) -> String {
+    match iris {
+        [one] => format!("Value does not have {label} <{one}>"),
+        many => {
+            let joined = many
+                .iter()
+                .map(|i| format!("<{i}>"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            format!("Value does not have any of the allowed {label}s {joined}")
+        }
+    }
+}
+
+/// [OPUS-4.8] (sq-vg3y) The `sh:uniqueValuesFor` signature of a node: for each
+/// listed property (IN ORDER), the SORTED, deduplicated set of its data-graph
+/// values (rendered as terms). Two nodes share a key iff their signatures are
+/// equal — exact term match, so `"04"^^xsd:byte` ≠ `"4"^^xsd:integer`.
+fn value_signature(data: &GraphView, node: &Term, props: &[String]) -> Vec<Vec<String>> {
+    props
+        .iter()
+        .map(|p| {
+            let mut vs: Vec<String> = data
+                .objects(node, p)
+                .iter()
+                .map(|t| t.to_string())
+                .collect();
+            vs.sort();
+            vs.dedup();
+            vs
+        })
+        .collect()
 }
 
 /// The string a value node contributes to sh:minLength/maxLength/pattern:

--- a/crates/sparq-shacl/src/model.rs
+++ b/crates/sparq-shacl/src/model.rs
@@ -33,8 +33,17 @@ pub enum Target {
 #[derive(Debug, Clone)]
 pub enum Component {
     Class(Term),
-    Datatype(String),
-    NodeKind(String),
+    /// `sh:datatype` — the allowed-datatype set (SHACL §4.5.2). A single IRI
+    /// object is a singleton set; the SHACL-1.2 disjunctive list form
+    /// `sh:datatype ( xsd:string rdf:langString )` is the multi-element set. A
+    /// value node conforms iff it is a literal whose (well-formed) datatype is in
+    /// the set. [OPUS-4.8] (sq-vg3y) extended from a single IRI to the set form.
+    Datatype(Vec<String>),
+    /// `sh:nodeKind` — the allowed node-kind set (SHACL §4.6.1). A single IRI is a
+    /// singleton set; the SHACL-1.2 disjunctive list form
+    /// `sh:nodeKind ( sh:BlankNode sh:IRI )` is the multi-element set. A value
+    /// node conforms iff its kind matches ANY listed kind. [OPUS-4.8] (sq-vg3y).
+    NodeKind(Vec<String>),
     MinCount(u64),
     MaxCount(u64),
     MinExclusive(Term),
@@ -70,9 +79,35 @@ pub enum Component {
     },
     Closed {
         ignored: Vec<Term>,
+        /// [OPUS-4.8] (sq-vg3y) SHACL-1.2 "close by types" mode: `sh:closed
+        /// sh:ByTypes`. When `false` (`sh:closed true`), the allowed predicate set
+        /// P is the IRIs reachable from THIS shape via `sh:property/sh:path`. When
+        /// `true`, P is recomputed PER value node from its `rdf:type`s via the
+        /// `collectProperties` algorithm (SHACL §4.8.1), plus `rdf:type`.
+        by_types: bool,
     },
     HasValue(Term),
     In(Vec<Term>),
+    /// [OPUS-4.8] (sq-vg3y) `sh:memberShape` — SHACL-1.2 list-member shape
+    /// (`sh:MemberShapeConstraintComponent`, SHACL §4.x). Each value node must be a
+    /// well-formed SHACL list, and every member of that list must conform to the
+    /// referenced shape. The index is into [`ShapesModel::shapes`].
+    MemberShape(usize),
+    /// [OPUS-4.8] (sq-vg3y) `sh:uniqueMembers true` — value nodes must be SHACL
+    /// lists whose members are pairwise distinct (`sh:UniqueMembersConstraintComponent`).
+    UniqueMembers,
+    /// [OPUS-4.8] (sq-vg3y) `sh:maxListLength` — value nodes must be SHACL lists
+    /// with at most N members (`sh:MaxListLengthConstraintComponent`).
+    MaxListLength(u64),
+    /// [OPUS-4.8] (sq-vg3y) `sh:minListLength` — value nodes must be SHACL lists
+    /// with at least N members (`sh:MinListLengthConstraintComponent`).
+    MinListLength(u64),
+    /// [OPUS-4.8] (sq-vg3y) `sh:uniqueValuesFor` — the values of the listed
+    /// properties of a value node must be unique across all target nodes of the
+    /// shape (`sh:UniqueValuesForConstraintComponent`, SHACL §4.x). One or more
+    /// property IRIs (a single IRI is a singleton; a SHACL list gives a composite
+    /// key).
+    UniqueValuesFor(Vec<String>),
     /// sh:sparql — a SPARQL-based constraint (SHACL §5.2). The index is into
     /// [`ShapesModel::sparql`].
     Sparql(usize),
@@ -212,6 +247,14 @@ pub struct ShapesModel {
     /// [`Component::CustomSparql`]. The registry is keyed (for activation) on the
     /// mandatory parameter predicates each component declares.
     pub(crate) components: Vec<ComponentDef>,
+    /// [OPUS-4.8] (sq-vg3y) Precomputed `sh:closed sh:ByTypes` property closures
+    /// (SHACL-1.2 §4.8.1 `collectProperties`): for each shapes-graph node, the
+    /// IRI properties reachable via `sh:property/sh:path` transitively through
+    /// `rdfs:subClassOf` / inbound `sh:targetClass` / `sh:node`. This
+    /// shapes-graph traversal is data-independent, so it is resolved ONCE here
+    /// (only when at least one ByTypes-closed shape exists) and unioned per value
+    /// node at eval time. Empty when no shape uses `sh:closed sh:ByTypes`.
+    pub(crate) by_types_closures: FxHashMap<Term, Vec<String>>,
     /// [OPUS-4.8] (sq-mk9n, `shacl-af`) Parsed `sh:expression` node expressions,
     /// referenced by [`Component::Expression`]. Kept off the public `Component`
     /// enum so the (crate-private) node-expression type is not exposed.
@@ -228,6 +271,7 @@ impl ShapesModel {
             targeted: Vec::new(),
             sparql: Vec::new(),
             components: Vec::new(),
+            by_types_closures: FxHashMap::default(),
             #[cfg(feature = "shacl-af")]
             expressions: Vec::new(),
         };
@@ -306,11 +350,28 @@ impl ShapesModel {
         #[cfg(feature = "shacl-af")]
         m.parse_expression_constraints(shapes_graph);
 
+        // [OPUS-4.8] (sq-vg3y) Resolve the data-independent `sh:closed sh:ByTypes`
+        // property closures once (only if any shape uses that mode).
+        if m.shapes.iter().any(|s| {
+            s.components
+                .iter()
+                .any(|c| matches!(c, Component::Closed { by_types: true, .. }))
+        }) {
+            m.by_types_closures = compute_by_types_closures(&g);
+        }
+
         // Validation entry points: shapes with targets.
         m.targeted = (0..m.shapes.len())
             .filter(|&i| !m.shapes[i].targets.is_empty())
             .collect();
         m
+    }
+
+    /// [OPUS-4.8] (sq-vg3y) The precomputed `sh:closed sh:ByTypes` property closure
+    /// for a shapes-graph node, or `None` if the node pulls in no properties (e.g.
+    /// a data class with no shapes-graph footprint). See [`Self::by_types_closures`].
+    pub(crate) fn by_types_closure(&self, node: &Term) -> Option<&Vec<String>> {
+        self.by_types_closures.get(node)
     }
 
     /// [OPUS-4.8] (sq-mk9n / sq-3w6n, `shacl-af`) Parses the two SHACL-AF
@@ -486,14 +547,20 @@ impl ShapesModel {
         for o in g.objects(node, &sh("class")) {
             c.push(Component::Class(o));
         }
+        // [OPUS-4.8] (sq-vg3y) `sh:datatype` / `sh:nodeKind` accept either a single
+        // IRI or the SHACL-1.2 disjunctive SHACL-list form (`( a b )`). `iri_set`
+        // returns the IRI set for either spelling; an empty set (e.g. a literal
+        // object, or an ill-formed list) contributes no constraint.
         for o in g.objects(node, &sh("datatype")) {
-            if let Term::NamedNode(n) = o {
-                c.push(Component::Datatype(n.as_str().to_string()));
+            let dts = iri_set(g, &o);
+            if !dts.is_empty() {
+                c.push(Component::Datatype(dts));
             }
         }
         for o in g.objects(node, &sh("nodeKind")) {
-            if let Term::NamedNode(n) = o {
-                c.push(Component::NodeKind(n.as_str().to_string()));
+            let kinds = iri_set(g, &o);
+            if !kinds.is_empty() {
+                c.push(Component::NodeKind(kinds));
             }
         }
         for (pred, ctor) in [
@@ -578,12 +645,64 @@ impl ShapesModel {
             let members = g.list(&o);
             c.push(Component::In(members));
         }
-        if matches!(g.object(node, &sh("closed")), Some(Term::Literal(l)) if l.value() == "true") {
-            let ignored = match g.object(node, &sh("ignoredProperties")) {
-                Some(list) => g.list(&list),
-                None => Vec::new(),
-            };
-            shape.components.push(Component::Closed { ignored });
+        // [OPUS-4.8] (sq-vg3y) `sh:maxListLength` / `sh:minListLength` (SHACL-1.2):
+        // value nodes must be SHACL lists with at most / at least N members.
+        for (pred, ctor) in [
+            (
+                "maxListLength",
+                Component::MaxListLength as fn(u64) -> Component,
+            ),
+            (
+                "minListLength",
+                Component::MinListLength as fn(u64) -> Component,
+            ),
+        ] {
+            for o in g.objects(node, &sh(pred)) {
+                if let Term::Literal(l) = &o {
+                    if let Ok(n) = l.value().parse::<u64>() {
+                        c.push(ctor(n));
+                    }
+                }
+            }
+        }
+        // [OPUS-4.8] (sq-vg3y) `sh:uniqueMembers true` (SHACL-1.2): SHACL-list value
+        // nodes must have pairwise-distinct members.
+        if matches!(g.object(node, &sh("uniqueMembers")), Some(Term::Literal(l)) if l.value() == "true")
+        {
+            c.push(Component::UniqueMembers);
+        }
+        // [OPUS-4.8] (sq-vg3y) `sh:uniqueValuesFor` (SHACL-1.2): one property IRI or
+        // a SHACL list of property IRIs forming a composite uniqueness key.
+        for o in g.objects(node, &sh("uniqueValuesFor")) {
+            let props = iri_set(g, &o);
+            if !props.is_empty() {
+                c.push(Component::UniqueValuesFor(props));
+            }
+        }
+        // `sh:closed`: SHACL-1.0 boolean (`true`) or SHACL-1.2 `sh:ByTypes`
+        // (close-by-types). Any other object (or `false`) is not a closing form.
+        // [OPUS-4.8] (sq-vg3y) added the `sh:ByTypes` spelling.
+        match g.object(node, &sh("closed")) {
+            Some(Term::Literal(l)) if l.value() == "true" => {
+                shape.components.push(Component::Closed {
+                    ignored: closed_ignored(g, node),
+                    by_types: false,
+                });
+            }
+            Some(Term::NamedNode(n)) if n.as_str() == sh("ByTypes") => {
+                shape.components.push(Component::Closed {
+                    ignored: closed_ignored(g, node),
+                    by_types: true,
+                });
+            }
+            _ => {}
+        }
+        // [OPUS-4.8] (sq-vg3y) `sh:memberShape` (SHACL-1.2): each value node must be
+        // a well-formed SHACL list whose members all conform to the referenced
+        // shape. Recursive (the member shape is parsed/interned like sh:node).
+        for o in g.objects(node, &sh("memberShape")) {
+            let id = self.shape_id(g, &o);
+            shape.components.push(Component::MemberShape(id));
         }
 
         // Shape-referencing components (recursive).
@@ -772,6 +891,105 @@ fn collect_prefixes_from(g: &GraphView, prefix_roots: &[Term]) -> String {
 
 fn iri(s: &str) -> Term {
     Term::NamedNode(oxrdf::NamedNode::new_unchecked(s))
+}
+
+/// [OPUS-4.8] (sq-vg3y) The set of IRIs an object denotes when a constraint
+/// parameter accepts "an IRI or a SHACL list of IRIs" (`sh:datatype` /
+/// `sh:nodeKind` / `sh:uniqueValuesFor`, SHACL-1.2). A single IRI → singleton; a
+/// SHACL-list head → its IRI members (non-IRI members dropped). Anything else →
+/// empty (no constraint contributed).
+fn iri_set(g: &GraphView, o: &Term) -> Vec<String> {
+    match o {
+        Term::NamedNode(n) => vec![n.as_str().to_string()],
+        Term::BlankNode(_) => g
+            .list(o)
+            .into_iter()
+            .filter_map(|m| match m {
+                Term::NamedNode(n) => Some(n.as_str().to_string()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// The `sh:ignoredProperties` SHACL list of a (closed) shape node, or empty.
+fn closed_ignored(g: &GraphView, node: &Term) -> Vec<Term> {
+    match g.object(node, &sh("ignoredProperties")) {
+        Some(list) => g.list(&list),
+        None => Vec::new(),
+    }
+}
+
+/// [OPUS-4.8] (sq-vg3y) Precompute the `sh:closed sh:ByTypes` `collectProperties`
+/// closure (SHACL-1.2 §4.8.1) for every node mentioned in the shapes graph. For a
+/// starting node S the closure is the union of the IRI properties reachable via
+/// `sh:property/sh:path` from S and, recursively, from S's `rdfs:subClassOf`
+/// objects, the shapes that target S via `sh:targetClass`, and the node shapes S
+/// references via `sh:node`. The traversal is cycle-guarded (each node expanded at
+/// most once per starting node) and reads ONLY the shapes graph (the per-value
+/// `rdf:type` step happens at eval time). Nodes whose closure is empty are
+/// omitted, so a `get` miss means "no properties".
+fn compute_by_types_closures(g: &GraphView) -> FxHashMap<Term, Vec<String>> {
+    // Candidate starting nodes: every subject and object in the shapes graph (a
+    // data class T is looked up here too, so we must cover object positions).
+    let mut nodes: rustc_hash::FxHashSet<Term> = rustc_hash::FxHashSet::default();
+    for [s, _, o] in g.triples(None, None, None) {
+        if !matches!(s, Term::Literal(_)) {
+            nodes.insert(s);
+        }
+        if !matches!(o, Term::Literal(_)) {
+            nodes.insert(o);
+        }
+    }
+    let mut out: FxHashMap<Term, Vec<String>> = FxHashMap::default();
+    for start in nodes {
+        let mut props: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
+        let mut visited: rustc_hash::FxHashSet<Term> = rustc_hash::FxHashSet::default();
+        let mut stack = vec![start.clone()];
+        while let Some(s) = stack.pop() {
+            if !visited.insert(s.clone()) {
+                continue;
+            }
+            collect_properties(g, &s, &mut props, &mut stack);
+        }
+        if !props.is_empty() {
+            out.insert(start, props.into_iter().collect());
+        }
+    }
+    out
+}
+
+/// One step of the `collectProperties` algorithm (SHACL-1.2 §4.8.1): add the IRI
+/// properties reachable from `s` via `sh:property/sh:path`, and push the nodes the
+/// recursion continues into (`rdfs:subClassOf` objects, inbound `sh:targetClass`
+/// subjects, `sh:node` objects) onto `stack`. Cycle-avoidance is the caller's
+/// `visited` set. Reads only the shapes graph.
+fn collect_properties(
+    g: &GraphView,
+    s: &Term,
+    props: &mut rustc_hash::FxHashSet<String>,
+    stack: &mut Vec<Term>,
+) {
+    const RDFS_SUBCLASS_OF: &str = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
+    // IRI properties reached via sh:property/sh:path.
+    for ps in g.objects(s, &sh("property")) {
+        if let Some(Term::NamedNode(n)) = g.object(&ps, &sh("path")) {
+            props.insert(n.as_str().to_string());
+        }
+    }
+    // rdfs:subClassOf objects (superclasses).
+    for sup in g.objects(s, RDFS_SUBCLASS_OF) {
+        stack.push(sup);
+    }
+    // Shapes that target s via sh:targetClass.
+    for sub in g.subjects(&sh("targetClass"), s) {
+        stack.push(sub);
+    }
+    // Node shapes referenced via sh:node.
+    for n in g.objects(s, &sh("node")) {
+        stack.push(n);
+    }
 }
 
 /// [OPUS-4.8] SHACL §6.2: discover the `sh:ConstraintComponent` declarations in

--- a/crates/sparq-shacl/src/view.rs
+++ b/crates/sparq-shacl/src/view.rs
@@ -153,6 +153,44 @@ impl<'g> GraphView<'g> {
         out
     }
 
+    /// [OPUS-4.8] (sq-vg3y) The members of `head` iff it is a WELL-FORMED SHACL
+    /// list (SHACL §1.4 "SHACL Lists"), else `None`. A SHACL list is `rdf:nil`
+    /// (with no `rdf:first`/`rdf:rest` — empty list), or a node with EXACTLY ONE
+    /// `rdf:first`, EXACTLY ONE `rdf:rest` that is itself a SHACL list, and that
+    /// does not reach itself via `rdf:rest+` (no cycle). A literal head, a missing
+    /// or duplicated `rdf:first`/`rdf:rest`, or a cycle ⇒ NOT a SHACL list. This is
+    /// the strict check `sh:memberShape` / `sh:{min,max}ListLength` /
+    /// `sh:uniqueMembers` need (the lenient [`Self::list`] tolerates malformed
+    /// tails, which would silently truncate those constraints).
+    pub fn list_strict(&self, head: &Term) -> Option<Vec<Term>> {
+        if matches!(head, Term::Literal(_)) {
+            return None; // a literal is never a SHACL list
+        }
+        let mut out = Vec::new();
+        let mut seen: rustc_hash::FxHashSet<Term> = rustc_hash::FxHashSet::default();
+        let mut cur = head.clone();
+        loop {
+            if matches!(&cur, Term::NamedNode(n) if n.as_str() == RDF_NIL) {
+                // rdf:nil must carry no rdf:first/rdf:rest to be the empty list.
+                if self.object(&cur, RDF_FIRST).is_some() || self.object(&cur, RDF_REST).is_some() {
+                    return None;
+                }
+                return Some(out);
+            }
+            if !seen.insert(cur.clone()) {
+                return None; // cycle via rdf:rest+
+            }
+            // Exactly one rdf:first and exactly one rdf:rest.
+            let firsts = self.objects(&cur, RDF_FIRST);
+            let rests = self.objects(&cur, RDF_REST);
+            if firsts.len() != 1 || rests.len() != 1 {
+                return None;
+            }
+            out.push(firsts.into_iter().next().unwrap());
+            cur = rests.into_iter().next().unwrap();
+        }
+    }
+
     /// The SHACL instances of `class`: nodes whose `rdf:type` is `class` or any
     /// `rdfs:subClassOf`-descendant of it (closure computed within this graph).
     pub fn instances_of(&self, class: &Term) -> Vec<Term> {

--- a/crates/sparq-shacl/tests/constraints.rs
+++ b/crates/sparq-shacl/tests/constraints.rs
@@ -564,3 +564,225 @@ fn deactivated_shape_is_skipped() {
         r.to_text()
     );
 }
+
+// ---- [OPUS-4.8] (sq-vg3y) SHACL-1.2 core/node forms ----
+
+// ---- sh:datatype disjunctive (list) form ----
+
+#[test]
+fn datatype_list_form_accepts_any_listed() {
+    // sh:datatype ( xsd:string rdf:langString ): a plain string and a lang-tagged
+    // literal both conform; an integer (neither) violates. Mirrors W3C datatype-003.
+    let shapes = r#"
+        ex:S a sh:NodeShape ;
+          sh:targetNode "plain" ;
+          sh:targetNode "tagged"@en ;
+          sh:targetNode 42 ;
+          sh:datatype ( xsd:string rdf:langString ) .
+    "#;
+    let r = run("", shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(count_component(&r, "DatatypeConstraintComponent"), 1);
+    // The integer is the sole violator.
+    assert!(flagged_values(&r).iter().any(|v| v.contains("42")));
+}
+
+#[test]
+fn datatype_single_iri_still_works() {
+    // Regression: the single-IRI form is the singleton-set case.
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetNode "x" , 1 ;
+          sh:datatype xsd:string .
+    "#;
+    let r = run("", shapes);
+    assert_eq!(count_component(&r, "DatatypeConstraintComponent"), 1);
+}
+
+// ---- sh:nodeKind disjunctive (list) form ----
+
+#[test]
+fn nodekind_list_form_accepts_iri_or_blanknode() {
+    // sh:nodeKind ( sh:BlankNode sh:IRI ): an IRI and a blank node conform; a
+    // literal violates. Mirrors W3C nodeKind-002.
+    let shapes = r#"
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:iri ;
+          sh:targetNode "true"^^xsd:boolean ;
+          sh:nodeKind ( sh:BlankNode sh:IRI ) .
+    "#;
+    let r = run("ex:iri ex:p 0 .", shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(count_component(&r, "NodeKindConstraintComponent"), 1);
+}
+
+// ---- sh:closed sh:ByTypes ----
+
+#[test]
+fn closed_by_types_uses_properties_of_value_node_types() {
+    // closed-003 in miniature: ex:RootClass is closed-by-types and declares
+    // ex:rootClassProperty1; ex:SubClass (subclass) declares ex:subClassProperty1.
+    // An instance of ROOT (not Sub) that uses ex:subClassProperty1 is closed out;
+    // an instance of Sub that uses it is allowed (its type pulls the property in).
+    let shapes = r#"
+        ex:RootClass a rdfs:Class, sh:NodeShape ;
+          sh:property [ sh:path ex:rootClassProperty1 ] ;
+          sh:closed sh:ByTypes .
+        ex:SubClass a rdfs:Class, sh:NodeShape ;
+          rdfs:subClassOf ex:RootClass ;
+          sh:property [ sh:path ex:subClassProperty1 ] ;
+          sh:closed sh:ByTypes .
+    "#;
+    let data = r#"
+        ex:RootInstance a ex:RootClass ; ex:subClassProperty1 1 .
+        ex:SubInstance a ex:SubClass ; ex:rootClassProperty1 1 ; ex:subClassProperty1 3 .
+    "#;
+    let r = run(data, shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    // Exactly one closed violation: ex:RootInstance's ex:subClassProperty1.
+    assert_eq!(count_component(&r, "ClosedConstraintComponent"), 1);
+    let closed: Vec<_> = r
+        .results
+        .iter()
+        .filter(|x| x.source_component.ends_with("ClosedConstraintComponent"))
+        .collect();
+    assert!(closed[0].focus_node.to_string().contains("RootInstance"));
+}
+
+// ---- sh:memberShape ----
+
+#[test]
+fn member_shape_checks_each_list_member() {
+    // sh:memberShape [ sh:nodeKind sh:IRI ]: a list of IRIs conforms; a list with
+    // a literal member, AND a value that is not a SHACL list at all, both violate.
+    let shapes = r#"
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:goodList, ex:badList, ex:notAList ;
+          sh:memberShape [ sh:nodeKind sh:IRI ] .
+    "#;
+    let data = r#"
+        ex:goodList rdf:first ex:a ; rdf:rest ( ex:b ) .
+        ex:badList  rdf:first ex:a ; rdf:rest ( "lit" ) .
+        ex:notAList ex:p 0 .
+    "#;
+    let r = run(data, shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    // One top-level result per violating value node (badList + notAList).
+    assert_eq!(count_component(&r, "MemberShapeConstraintComponent"), 2);
+}
+
+// ---- sh:uniqueMembers ----
+
+#[test]
+fn unique_members_flags_duplicate_and_nonlist() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:uniq, ex:dup, ex:notAList ;
+          sh:uniqueMembers true .
+    "#;
+    let data = r#"
+        ex:uniq rdf:first 1 ; rdf:rest ( 2 3 ) .
+        ex:dup  rdf:first 1 ; rdf:rest ( 2 1 ) .
+        ex:notAList ex:p 0 .
+    "#;
+    let r = run(data, shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    // ex:dup (duplicate 1) + ex:notAList (not a list) -> two results; ex:uniq ok.
+    assert_eq!(count_component(&r, "UniqueMembersConstraintComponent"), 2);
+}
+
+// ---- sh:maxListLength / sh:minListLength ----
+
+#[test]
+fn max_list_length_flags_too_long_and_nonlist() {
+    // Value nodes: ex:ok (2 members, ok), rdf:nil (0, ok), ex:long (3, violates),
+    // ex:notAList (not a list, violates). Mirrors W3C maxListLength-001.
+    let shapes = r#"
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:ok, rdf:nil, ex:long, ex:notAList ;
+          sh:maxListLength 2 .
+    "#;
+    let data = r#"
+        ex:ok   rdf:first 1 ; rdf:rest ( 2 ) .
+        ex:long rdf:first 1 ; rdf:rest ( 2 3 ) .
+        ex:notAList ex:p 0 .
+    "#;
+    let r = run(data, shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(count_component(&r, "MaxListLengthConstraintComponent"), 2);
+}
+
+#[test]
+fn min_list_length_flags_too_short_and_nil() {
+    // rdf:nil is a valid SHACL list of length 0 < 1 -> violates; ex:notAList is
+    // not a list -> violates; ex:ok (length 2) passes. Mirrors W3C minListLength-001.
+    let shapes = r#"
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:ok, rdf:nil, ex:notAList ;
+          sh:minListLength 1 .
+    "#;
+    let data = r#"
+        ex:ok rdf:first 1 ; rdf:rest ( 2 ) .
+        ex:notAList ex:p 0 .
+    "#;
+    let r = run(data, shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(count_component(&r, "MinListLengthConstraintComponent"), 2);
+}
+
+// ---- sh:uniqueValuesFor ----
+
+#[test]
+fn unique_values_for_single_property() {
+    // Two target nodes sharing the same ex:id -> a symmetric pair of results.
+    // A node with no ex:id contributes nothing. Mirrors W3C uniqueValuesFor-001.
+    let shapes = r#"
+        ex:S a sh:NodeShape ;
+          sh:targetClass ex:Thing ;
+          sh:uniqueValuesFor ex:id .
+    "#;
+    let data = r#"
+        ex:a a ex:Thing ; ex:id "001" .
+        ex:b a ex:Thing ; ex:id "002" .
+        ex:dup1 a ex:Thing ; ex:id "DUP" .
+        ex:dup2 a ex:Thing ; ex:id "DUP" .
+        ex:noid a ex:Thing .
+    "#;
+    let r = run(data, shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    // dup1 -> dup2 and dup2 -> dup1: exactly two results.
+    assert_eq!(count_component(&r, "UniqueValuesForConstraintComponent"), 2);
+}
+
+#[test]
+fn unique_values_for_composite_key_and_missing_values() {
+    // Composite key ( ex:notation ex:scheme ): only nodes that agree on BOTH
+    // collide. Mirrors W3C uniqueValuesFor-002.
+    let shapes = r#"
+        ex:S a sh:NodeShape ;
+          sh:targetClass ex:Concept ;
+          sh:uniqueValuesFor ( ex:notation ex:scheme ) .
+    "#;
+    let data = r#"
+        ex:v1 a ex:Concept ; ex:notation "A1" ; ex:scheme ex:S1 .
+        ex:v2 a ex:Concept ; ex:notation "A2" ; ex:scheme ex:S1 .
+        ex:bad1 a ex:Concept ; ex:notation "A1" ; ex:scheme ex:S2 .
+        ex:bad2 a ex:Concept ; ex:notation "A1" ; ex:scheme ex:S2 .
+    "#;
+    let r = run(data, shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    // Only bad1/bad2 agree on both -> two results; v1 (notation A1, scheme S1)
+    // does NOT collide with bad1 (scheme differs).
+    assert_eq!(count_component(&r, "UniqueValuesForConstraintComponent"), 2);
+}
+
+#[test]
+fn unique_values_for_no_values_conforms() {
+    // No instance has the property -> conforms (W3C uniqueValuesFor-004).
+    let shapes = r#"
+        ex:S a sh:NodeShape ;
+          sh:targetClass ex:Thing ;
+          sh:uniqueValuesFor ex:id .
+    "#;
+    let r = run("ex:a a ex:Thing . ex:b a ex:Thing .", shapes);
+    assert!(r.conforms, "{}", r.to_text());
+}

--- a/crates/sparq-shacl/tests/w3c_core_shacl12.rs
+++ b/crates/sparq-shacl/tests/w3c_core_shacl12.rs
@@ -6,38 +6,31 @@
 //! newer `shacl12-test-suite/tests/core/node` tree additionally carries a
 //! `nodeByExpression-001` `sht:Validate` entry (the constant-IRI form of
 //! `sh:nodeByExpression`, implemented under the `shacl-af` feature in sq-3w6n)
-//! **plus** a set of SHACL-1.2-only constraints this crate does not implement
-//! (`sh:memberShape`, `sh:uniqueMembers`, `sh:maxListLength`, `sh:minListLength`,
-//! `sh:uniqueValuesFor`). This harness covers that tree end-to-end with an honest
-//! floor: the SHACL-1.2-only entries are recorded as **SKIP**, never FAIL.
+//! **plus** the SHACL-1.2-only core constraints `sh:memberShape`,
+//! `sh:uniqueMembers`, `sh:{max,min}ListLength`, `sh:uniqueValuesFor`, the
+//! `sh:closed sh:ByTypes` close-by-types mode, and the disjunctive list spellings
+//! of `sh:datatype` / `sh:nodeKind`. [OPUS-4.8] (sq-vg3y) all of those are now
+//! implemented on the Core path and compared strictly; the only thing this
+//! harness still SKIPs is `sh:nodeByExpression` when `shacl-af` is off.
 //!
 //! ## SKIP-tolerance (honest floor)
 //!
 //! An entry is **SKIP**, not FAIL, exactly when its shapes graph uses a
-//! constraint form this crate does not implement. Two kinds:
+//! constraint-component *predicate* with no counterpart in this build
+//! ([`unimplemented`]). After sq-vg3y that is ONLY `sh:nodeByExpression`, and ONLY
+//! when `shacl-af` is off.
 //!
-//!   1. **Unimplemented predicate** — a constraint-component predicate with no
-//!      counterpart in [`sparq_shacl::Component`] (the [`UNIMPLEMENTED_CORE`] set,
-//!      plus `sh:nodeByExpression` when `shacl-af` is off).
-//!   2. **Unimplemented *form* of an implemented predicate** — a SHACL-1.2-only
-//!      spelling of a constraint whose single-valued form *is* implemented:
-//!      `sh:closed` with a non-boolean object (the SHACL-1.2 "close by types"
-//!      mode, e.g. `sh:ByTypes`), and the disjunctive list form of `sh:datatype`
-//!      / `sh:nodeKind` (`( xsd:string rdf:langString )`). The crate models these
-//!      as a single IRI / a boolean flag, so a list / IRI object is a feature it
-//!      does not carry — an absence, not a regression (see [`uses_unimplemented_form`]).
-//!
-//! Any entry whose shapes use **only** implemented constraint forms is compared
+//! Any entry whose shapes use **only** implemented constraints is compared
 //! strictly — a mismatch there is a FAIL, so the harness can never silently mask
 //! a regression in an implemented constraint.
 //!
-//! This is deliberately a *structural* SKIP (vocabulary + object shape) and not an
-//! outcome-driven one: an entry is classed up front by the form it exercises, so a
-//! wrong report on an *implemented* constraint form cannot be laundered into a SKIP.
+//! This is deliberately a *structural* SKIP (vocabulary) and not an
+//! outcome-driven one: an entry is classed up front by the predicates it
+//! exercises, so a wrong report on an *implemented* constraint cannot be laundered
+//! into a SKIP.
 //!
-//! Implementing those SHACL-1.2-only forms (and promoting their entries from SKIP
-//! to PASS) is tracked in **sq-vg3y**; the floor auto-grows as the SKIP list
-//! shrinks (bump [`BASELINE_PASS_CORE`] / [`BASELINE_PASS_AF`] then).
+//! The floor auto-grows as the SKIP list shrinks (bump [`BASELINE_PASS_CORE`] /
+//! [`BASELINE_PASS_AF`] then).
 //!
 //! ## Two gates
 //!
@@ -64,31 +57,21 @@ use std::collections::BTreeMap;
 use std::path::{Path as FsPath, PathBuf};
 
 const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
-const RDF_FIRST: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#first";
 const MF: &str = "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#";
 const SHT: &str = "http://www.w3.org/ns/shacl-test#";
 const SH: &str = "http://www.w3.org/ns/shacl#";
-const XSD_BOOLEAN: &str = "http://www.w3.org/2001/XMLSchema#boolean";
 
 /// Constraint-component *predicates* (relative to `sh:`) this crate does NOT
 /// implement. An entry whose shapes use any of these is recorded as SKIP rather
-/// than FAIL. These are exactly the SHACL-1.2-only core/node constraints with no
-/// counterpart in [`sparq_shacl::Component`]:
+/// than FAIL.
 ///
-///   * `memberShape` — `sh:MemberShapeConstraintComponent` (list-member shape)
-///   * `uniqueMembers` — `sh:UniqueMembersConstraintComponent`
-///   * `maxListLength` / `minListLength` — `sh:{Max,Min}ListLengthConstraintComponent`
-///   * `uniqueValuesFor` — `sh:UniqueValuesForConstraintComponent`
-///
-/// `sh:nodeByExpression` is implemented only under `shacl-af`, so it joins this
-/// set when that feature is OFF (see [`unimplemented`]).
-const UNIMPLEMENTED_CORE: &[&str] = &[
-    "memberShape",
-    "uniqueMembers",
-    "maxListLength",
-    "minListLength",
-    "uniqueValuesFor",
-];
+/// [OPUS-4.8] (sq-vg3y) The SHACL-1.2-only core/node constraints
+/// (`sh:memberShape`, `sh:uniqueMembers`, `sh:{max,min}ListLength`,
+/// `sh:uniqueValuesFor`) are now implemented on the Core path, so this set is
+/// EMPTY. The only feature-dependent absence left is `sh:nodeByExpression`
+/// (implemented under `shacl-af` only) — added to the per-build set in
+/// [`unimplemented`] when that feature is off.
+const UNIMPLEMENTED_CORE: &[&str] = &[];
 
 /// The unimplemented-constraint predicate set for the current build, as full
 /// `sh:`-prefixed IRIs. Feature-dependent: `sh:nodeByExpression` is implemented
@@ -108,7 +91,12 @@ fn unimplemented() -> Vec<String> {
 /// `sht:Validate` entries at the pinned suite commit, excluding
 /// `nodeByExpression-001` (which is then a SKIP). A regression below this fails
 /// the build; raising it is a deliberate bump.
-const BASELINE_PASS_CORE: usize = 32;
+///
+/// [OPUS-4.8] (sq-vg3y) Bumped 32 → 44: the twelve formerly-SKIPed SHACL-1.2-only
+/// core/node entries (`closed-003/004`, `datatype-003`, `nodeKind-002`,
+/// `memberShape-001`, `uniqueMembers-001`, `{max,min}ListLength-001`,
+/// `uniqueValuesFor-001..004`) are now implemented and PASS.
+const BASELINE_PASS_CORE: usize = 44;
 
 /// Pass-floor with the `shacl-af` feature ON: [`BASELINE_PASS_CORE`] plus the
 /// `nodeByExpression-001` entry, which the SHACL-AF `sh:nodeByExpression`
@@ -332,65 +320,23 @@ fn run_entry(
 }
 
 /// The reason (if any) the shapes graph uses a constraint **form** this build
-/// does not implement — identifying an entry to SKIP. Covers two cases:
+/// does not implement — identifying an entry to SKIP.
 ///
-///   1. an unimplemented-constraint *predicate* (the [`unimplemented`] set), and
-///   2. an unimplemented *form* of an implemented predicate:
-///      * `sh:closed` with a non-boolean object (SHACL-1.2 "close by types"), and
-///      * the disjunctive list form of `sh:datatype` / `sh:nodeKind`.
+/// [OPUS-4.8] (sq-vg3y) This now reduces to a single case: an
+/// unimplemented-constraint *predicate* (the [`unimplemented`] set), which after
+/// sq-vg3y contains ONLY `sh:nodeByExpression` and ONLY when `shacl-af` is off.
+/// The previously-SKIPed *forms* of implemented predicates — `sh:closed
+/// sh:ByTypes`, and the disjunctive list spellings of `sh:datatype` /
+/// `sh:nodeKind` — are now implemented on the Core path and so compared strictly.
 ///
 /// Returns `None` when every constraint the shapes use is in a form the crate
 /// implements (so the entry is compared strictly).
 fn unimplemented_form(shapes: &Graph, unimpl: &[String]) -> Option<String> {
     let view = GraphView::new(shapes);
-
-    // (1) Whole-predicate absences.
     if let Some(p) = unimpl.iter().find(|p| !view.subjects_of(p).is_empty()) {
         return Some(format!("shapes use unimplemented constraint <{p}>"));
     }
-
-    // (2a) `sh:closed` with a non-boolean object — the crate fires only on the
-    // literal `true`/`false` form; `sh:ByTypes` (and any other IRI value) is the
-    // unimplemented SHACL-1.2 "close by types" mode.
-    for o in view.objects_of(&format!("{SH}closed")) {
-        let is_boolean_literal =
-            matches!(&o, Term::Literal(l) if l.datatype().as_str() == XSD_BOOLEAN);
-        if !is_boolean_literal {
-            return Some(format!(
-                "shapes use unimplemented sh:closed mode <{}>",
-                term_label(&o)
-            ));
-        }
-    }
-
-    // (2b) Disjunctive (list-valued) `sh:datatype` / `sh:nodeKind` — the crate
-    // models each as a single IRI; a list head (`rdf:first ...`) is the SHACL-1.2
-    // "any of" form it does not implement.
-    for local in ["datatype", "nodeKind"] {
-        for o in view.objects_of(&sh(local)) {
-            if view.object(&o, RDF_FIRST).is_some() {
-                return Some(format!(
-                    "shapes use unimplemented disjunctive sh:{local} (list value)"
-                ));
-            }
-        }
-    }
-
     None
-}
-
-fn sh(local: &str) -> String {
-    format!("{SH}{local}")
-}
-
-fn term_label(t: &Term) -> String {
-    match t {
-        Term::NamedNode(n) => n.as_str().to_string(),
-        Term::Literal(l) => l.value().to_string(),
-        Term::BlankNode(b) => b.as_str().to_string(),
-        #[allow(unreachable_patterns)]
-        _ => t.to_string(),
-    }
 }
 
 fn summarize(rs: &[ValidationResult]) -> String {

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shacl-validation
-description: "Validate RDF data against SHACL shapes with the sparq engine: SHACL Core constraints (class, datatype, cardinality, ranges, paths, logical, node/property, qualified, closed, in/hasValue), SHACL-SPARQL sh:sparql constraints (§5.2), and custom SPARQL-based constraint components (sh:ConstraintComponent, §6) — then read the conformance/violations validation report (W3C report vocabulary as Turtle or human text). Also runs opt-in SHACL Advanced Features (SHACL-AF) rules — sh:rule (sh:TripleRule + sh:SPARQLRule) — to INFER triples (feature `shacl-af`). Use when an agent needs to check whether a sparq_core::Graph conforms to shapes, run shape validation, produce a SHACL validation report, or apply SHACL rules to infer/expand a graph in Rust."
+description: "Validate RDF data against SHACL shapes with the sparq engine: SHACL Core constraints (class, datatype incl. the SHACL-1.2 disjunctive list form, cardinality, ranges, paths, logical, node/property, qualified, closed incl. sh:ByTypes, in/hasValue, and the SHACL-1.2 list constraints sh:memberShape / sh:uniqueMembers / sh:min+maxListLength / sh:uniqueValuesFor), SHACL-SPARQL sh:sparql constraints (§5.2), and custom SPARQL-based constraint components (sh:ConstraintComponent, §6) — then read the conformance/violations validation report (W3C report vocabulary as Turtle or human text). Also runs opt-in SHACL Advanced Features (SHACL-AF) rules — sh:rule (sh:TripleRule + sh:SPARQLRule) — to INFER triples (feature `shacl-af`). Use when an agent needs to check whether a sparq_core::Graph conforms to shapes, run shape validation, produce a SHACL validation report, or apply SHACL rules to infer/expand a graph in Rust."
 ---
 
 # sparq-shacl-validation
@@ -170,6 +170,22 @@ let shapes = Graph::load_str(r#"
 "#, "turtle").unwrap();
 let report = sparq_shacl::validate(&data, &shapes);   // source_component ends with "SPARQLConstraintComponent"
 ```
+
+**SHACL-1.2 core constraints (always on, no feature flag).** The disjunctive
+*set* spellings of `sh:datatype` / `sh:nodeKind` — `sh:datatype ( xsd:string
+rdf:langString )`, `sh:nodeKind ( sh:BlankNode sh:IRI )` — conform a value node
+when it matches ANY listed datatype / kind (the single-IRI form is the singleton
+case). `sh:closed sh:ByTypes` is the "close by types" mode: the allowed-predicate
+set is recomputed per value node from its `rdf:type`s (transitively through
+`rdfs:subClassOf` / inbound `sh:targetClass` / `sh:node`, SHACL §4.8.1), unlike
+`sh:closed true` which fixes it to the shape's own `sh:property` paths. The four
+SHACL list constraints validate that each value node is a well-formed SHACL list:
+`sh:memberShape` (every member conforms to a shape), `sh:uniqueMembers true`
+(members pairwise distinct), `sh:min`/`sh:maxListLength` (member-count bounds),
+and `sh:uniqueValuesFor` (the listed properties' values are unique across the
+shape's target nodes — one IRI, or a SHACL list for a composite key). A value that
+is not a well-formed SHACL list violates the list constraints; a node with no
+values for any `sh:uniqueValuesFor` property is never reported.
 
 **Custom SPARQL-based constraint component (`sh:ConstraintComponent`, §6).** Declare
 the component (parameters + an `sh:ask`/`sh:select` validator) IN THE SHAPES GRAPH; it


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. I am one of several agents @jeswr runs on this account.

Implements **sq-vg3y**: the SHACL-1.2-only core/node constraint forms the gated harness (`tests/w3c_core_shacl12.rs`, sq-yca1) was recording as **SKIP**. All implemented on the **Core path** — no feature flag — since these are SHACL-1.2 *Core* constraints with no SPARQL dependency.

## What

- **Disjunctive list form of `sh:datatype` / `sh:nodeKind`** (`( a b )`): a value conforms when its datatype / node kind matches **any** listed IRI. `Component::Datatype` / `Component::NodeKind` go from a single `String` to `Vec<String>` (a single IRI is the singleton-set case). (datatype-003, nodeKind-002)
- **`sh:closed sh:ByTypes`** (close-by-types, SHACL §4.8.1): the allowed-predicate set is recomputed **per value node** from its `rdf:type`s via the `collectProperties` algorithm — transitively through `rdfs:subClassOf`, inbound `sh:targetClass`, and `sh:node` — plus `rdf:type`. The data-independent shapes-graph traversal is precomputed once at parse time (`ShapesModel::by_types_closures`) and unioned per value node at eval. (closed-003/004)
- **`sh:memberShape`** — each value node must be a well-formed SHACL list whose members all conform to the member shape. (memberShape-001)
- **`sh:uniqueMembers true`** — list members pairwise distinct. (uniqueMembers-001)
- **`sh:minListLength` / `sh:maxListLength`** — list member-count bounds. (min/maxListLength-001)
- **`sh:uniqueValuesFor`** — the values of one property (or a SHACL list of properties, a composite key) are unique across the shape's target nodes; no result when a node has no values for any listed property. (uniqueValuesFor-001..004)

New `GraphView::list_strict` is the strict §1.4 *well-formed SHACL list* check the four list constraints need (the existing lenient `list()` tolerates malformed tails, which would silently truncate these constraints).

## Conformance (W3C SHACL-1.2 core/node `sht:Validate` suite)

| feature `shacl-af` | before | after |
|---|---|---|
| OFF | 32 PASS / 13 SKIP | **44 PASS / 1 SKIP** |
| ON  | 33 PASS / 12 SKIP | **45 PASS / 0 SKIP** |

The one remaining SKIP (af off) is `nodeByExpression-001`, a `shacl-af`-gated constraint. The harness's `UNIMPLEMENTED_CORE` set is now empty and the form-specific SKIP gates (closed mode, disjunctive datatype/nodeKind) are removed, so those **twelve** entries are now compared **strictly** against the suite — a wrong report can no longer be laundered into a SKIP. `BASELINE_PASS_CORE` bumped 32 → 44.

## Tests / docs

- Fixture-free constraint coverage for every new form in `tests/constraints.rs` (single-IRI regression kept).
- Crate `README.md` "Supported constraint components" + status section, and the `shacl-validation` SKILL.md, updated for the new Core surface (G2 public-API rule — `Component` is `pub`).

## Gate (run locally, both feature states)

- `cargo build` / `cargo clippy --all-targets -- -D warnings` — clean, OFF **and** `--features shacl-af`.
- Full `cargo test -p sparq-shacl` — all 13 test binaries pass, OFF and ON.
- `sparq-wasm --features shacl` + `sparq-server` build clean (no downstream break from the `Component` shape change).
- privacy-claims gate (`scripts/check-privacy-claims.sh`) — OK.

## Honest scope note

The `sh:memberShape` / `sh:uniqueMembers` results carry only the **top-level** result (the W3C suite compares only top-level fields); the spec's *non-normative* per-member / per-duplicate `sh:detail` sub-results are not emitted. Worth a follow-up bead (could not create one here — `bd` is not on PATH in this worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)