### PR TITLE
fix(bench/serve): thread Wave-A4 ring API through the three drifted research spikes (sq-i9ck)

### DIFF
--- a/bench/serve/src/bin/snapshot_spike.rs
+++ b/bench/serve/src/bin/snapshot_spike.rs
@@ -1,23 +1,31 @@
 //! RESEARCH SPIKE — snapshot cost + retention semantics (research/concurrent-serving.md §d.iii).
 //!
-//! Exercises the PRODUCTION snapshot mechanism (`sparq_server::AppState`): readers take
-//! `Arc<Graph>` clones of the published generation; updates go through the
-//! double-buffered writer (in-place delta on the reclaimed spare, atomic publish swap).
+//! Exercises the PRODUCTION snapshot mechanism (`sparq_server::AppState`). As of Wave A4
+//! that mechanism is the [`sparq_serve::GenerationRing`]: readers pin the current
+//! generation via [`AppState::current`] (lock-free `ArcSwap::load_full`) and read its
+//! immutable snapshot; updates group-commit through the single sequenced
+//! [`sparq_serve::Writer`], which publishes each batch as ONE new generation
+//! (structural fork, in-place delta, atomic ring swap). The ring REPLACED the
+//! double-buffered `RwLock<Arc<Graph>>` writer this spike was originally written for —
+//! the part of the design this spike now demonstrates as FIXED is exactly step 3.
 //!
 //! Measures, on a real dataset (pass the .nt path; defaults to a synthetic graph):
-//!   1. snapshot (`Arc` clone) cost — the per-query price of consistency;
+//!   1. snapshot cost — the lock-free `current()` pin, the per-query price of consistency;
 //!   2. steady-state in-place update latency with NO snapshot held;
-//!   3. update latency while a reader HOLDS the previous generation — the writer
-//!      cannot reclaim its spare, waits out `query_timeout + 2s grace`, then falls
-//!      back to the O(graph) rebuild: this is the cost a long-lived STREAM imposes
-//!      on the write path today, the central number for the streaming design;
-//!   4. RSS at each stage (1 generation, 2 generations pinned) — the memory price
-//!      of one retained snapshot generation.
+//!   3. update latency while a reader HOLDS the previous generation. Under the OLD
+//!      double-buffer this stalled the writer (it could not reclaim its pinned spare,
+//!      waited out `query_timeout + 2s grace`, then fell back to an O(graph) rebuild) —
+//!      the §4.3/§4.4 pathology. Under the ring a pinned generation is just one of K
+//!      retained `Arc`s and is NEVER reclaimed by the writer, so the writer publishes a
+//!      fresh generation regardless: this step now measures that the long-lived-stream
+//!      stall is GONE (latency should match step 2), the central result for the design;
+//!   4. RSS at each stage (1 generation, 2 generations pinned) — the memory price of one
+//!      retained snapshot generation (the ring's bounded-retention cost).
 //!
-//! Honest scope: this spike uses a 1s query-timeout so step 3 completes quickly; the
-//! production default is 30s, i.e. the stall is proportionally worse there.
+//! Honest scope: the 1s query-timeout is now immaterial to step 3 (there is no reclaim
+//! wait to bound), kept only so the budget matches the original run; it no longer makes
+//! the stall "proportionally worse" because there is no stall.
 
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use sparq_core::Graph;
@@ -60,19 +68,18 @@ fn main() {
 
     let config = ServerConfig {
         query_timeout: Some(Duration::from_secs(1)), // keeps step 3 short; default is 30s
-        compact_every: 1024,
         ..ServerConfig::default()
     };
     let state = AppState::with_config(graph, config);
 
-    // 1. snapshot cost — the Arc clone under the read lock.
+    // 1. snapshot cost — pinning the current generation (lock-free `ArcSwap::load_full`).
     let iters = 10_000_000u64;
     let t = Instant::now();
     for _ in 0..iters {
-        std::hint::black_box(state.snapshot());
+        std::hint::black_box(state.current());
     }
     println!(
-        "snapshot (RwLock read + Arc clone): {:.1} ns/op — {:.1} M snapshots/s single thread",
+        "snapshot (lock-free current(): ArcSwap load + Arc clone): {:.1} ns/op — {:.1} M snapshots/s single thread",
         t.elapsed().as_nanos() as f64 / iters as f64,
         iters as f64 / t.elapsed().as_secs_f64() / 1e6
     );
@@ -81,8 +88,8 @@ fn main() {
     let upd = |i: usize| format!("INSERT DATA {{ <http://ex/new{i}> <http://ex/p0> \"fresh{i}\" }}");
     let t = Instant::now();
     state.apply_update(&upd(0)).expect("first update");
-    println!("update #1 (first => O(graph) rebuild + buffer materialisation): {:.2}s", t.elapsed().as_secs_f64());
-    println!("RSS after first update (two buffers live): {:.0} MB", rss_mb());
+    println!("update #1 (first => one-time O(graph) dictionary/cache freeze to mint the shared fork base): {:.2}s", t.elapsed().as_secs_f64());
+    println!("RSS after first update (base + first forked generation live): {:.0} MB", rss_mb());
 
     let mut steady = Vec::new();
     for i in 1..21 {
@@ -98,22 +105,26 @@ fn main() {
     );
 
     // 3. update while a reader pins the PREVIOUS generation (a long-lived stream).
-    let pinned: Arc<Graph> = state.snapshot(); // pins the currently-published generation
+    // Under the ring the pinned generation is just one of K retained Arcs — the writer
+    // never has to reclaim it, so neither of these updates stalls (contrast the old
+    // double-buffer, where the writer waited out timeout+grace then rebuilt O(graph)).
+    let pinned = state.current(); // pins the currently-published generation
     let t = Instant::now();
-    state.apply_update(&upd(100)).expect("update; pinned gen becomes spare");
-    println!("update with snapshot pinned, gen N->spare demotion (still in-place): {:.3}s", t.elapsed().as_secs_f64());
+    state.apply_update(&upd(100)).expect("update while previous gen pinned");
+    println!("update #1 with a generation pinned (writer publishes a fresh generation, no reclaim): {:.3}s", t.elapsed().as_secs_f64());
     let t = Instant::now();
-    state.apply_update(&upd(101)).expect("update that needs the pinned spare");
+    state.apply_update(&upd(101)).expect("update while previous gen still pinned");
     println!(
-        "update needing the PINNED spare: {:.3}s  (= reclaim wait [timeout {}s + 2s grace] + O(graph) rebuild)",
-        t.elapsed().as_secs_f64(),
-        1
+        "update #2 with a generation still pinned: {:.3}s  (ring: NO reclaim wait, NO O(graph) rebuild — should match step 2 steady-state)",
+        t.elapsed().as_secs_f64()
     );
-    println!("RSS with one pinned generation + rebuilt published + spare: {:.0} MB", rss_mb());
-    println!("pinned snapshot still answers at its generation: {} triples (published now has more)", pinned.len());
+    println!("RSS with the pinned generation + the newer published generations live: {:.0} MB", rss_mb());
+    println!("pinned snapshot still answers at its generation: {} triples (published now has more)", pinned.snapshot().len());
     drop(pinned);
 
-    // 4. recovery after the stream ends.
+    // 4. after the stream ends: the pinned generation has dropped, so the ring holds one
+    // fewer retained Arc. There is no reclaim path to "recover", so latency is unchanged
+    // from steps 2/3 — recorded here to confirm exactly that (no recovery transient).
     let mut after = Vec::new();
     for i in 200..210 {
         let t = Instant::now();
@@ -121,6 +132,6 @@ fn main() {
         after.push(t.elapsed().as_micros() as u64);
     }
     after.sort_unstable();
-    println!("updates after snapshot dropped: p50={}us max={}us (first may rebuild once)", after[after.len() / 2], after.last().unwrap());
+    println!("updates after snapshot dropped: p50={}us max={}us (no recovery transient under the ring)", after[after.len() / 2], after.last().unwrap());
     println!("final RSS: {:.0} MB", rss_mb());
 }

--- a/bench/serve/src/bin/update_stream_spike.rs
+++ b/bench/serve/src/bin/update_stream_spike.rs
@@ -4,8 +4,9 @@
 //!
 //! This is the direct test of the QLever failure mode prod-solid-server designed around
 //! (qlever#2481: memory climbing under sustained live updates → OOM): does sparq's
-//! double-buffered delta-overlay writer keep BOTH update latency and RSS flat over a
-//! long update stream, including the periodic O(graph) compactions?
+//! generation-ring writer (Wave A4: structural-fork per generation, delta-overlay
+//! `apply`, bounded-K retention, the applier's own periodic O(graph) compaction fold)
+//! keep BOTH update latency and RSS flat over a long update stream?
 //!
 //! Each update models prod-solid-server's `putDocument` shape scaled to the default
 //! graph (the server's published surface today): DELETE the resource's previous ~9
@@ -13,8 +14,9 @@
 //! round-robin over a pool, so deletes really hit (an overlay that only grows by
 //! inserts would flatter the result).
 //!
-//! Optional concurrent readers (`--readers N`) take snapshots and run a point query in
-//! a loop — checking that the reclaim path doesn't degrade under read load.
+//! Optional concurrent readers (`--readers N`) pin the current generation
+//! ([`AppState::current`]) and run a point query in a loop — checking that reads stay
+//! lock-free and never stall the writer under sustained read load.
 //!
 //! Output: update p50/p99/max per 1k-window, RSS per window, total throughput.
 
@@ -60,7 +62,6 @@ fn main() {
     let mut updates = 20_000usize;
     let mut resources = 2_000usize;
     let mut readers = 0usize;
-    let mut compact_every = 1024usize;
     let mut args = std::env::args().skip(1);
     while let Some(a) = args.next() {
         let mut next = || args.next().expect("flag value").parse::<usize>().expect("number");
@@ -68,7 +69,6 @@ fn main() {
             "--updates" => updates = next(),
             "--resources" => resources = next(),
             "--readers" => readers = next(),
-            "--compact-every" => compact_every = next(),
             other => panic!("unknown arg {other}"),
         }
     }
@@ -80,14 +80,18 @@ fn main() {
     }
     let graph = Graph::load_str(&nt, "ntriples").expect("load");
     println!(
-        "base graph: {} triples, RSS {:.0} MB; {updates} updates over {resources} resources, compact_every={compact_every}, readers={readers}",
+        "base graph: {} triples, RSS {:.0} MB; {updates} updates over {resources} resources, readers={readers}",
         graph.len(),
         rss_mb()
     );
 
+    // Compaction is no longer a ServerConfig knob: as of Wave A4 the writer's
+    // GraphApplier folds each generation's pending overlay flat once it reaches its own
+    // compact threshold (DEFAULT_COMPACT_THRESHOLD), entirely inside sparq-serve. This
+    // spike drives the PRODUCTION AppState, so it inherits that default — what the HTTP
+    // server actually does — and no longer overrides the fold cadence.
     let config = ServerConfig {
         query_timeout: Some(Duration::from_secs(5)),
-        compact_every,
         ..ServerConfig::default()
     };
     let state = AppState::with_config(graph, config);
@@ -101,10 +105,13 @@ fn main() {
                 let b = QueryBudget::unlimited();
                 let mut n = 0u64;
                 while !stop.load(Ordering::Relaxed) {
-                    let g = st.snapshot();
+                    // Pin the current generation (lock-free ~10–20ns); never blocked by the
+                    // writer. Hold `pin` for the whole query so its snapshot stays readable.
+                    let pin = st.current();
+                    let g = pin.snapshot();
                     let s = (n as usize).wrapping_mul(2654435761).wrapping_add(i) % 200_000;
                     let q = format!("SELECT ?o WHERE {{ <http://ex/s{s}> ?p ?o }} LIMIT 5");
-                    std::hint::black_box(sparq_engine::query_json_with_budget(&g, &q, &b).ok());
+                    std::hint::black_box(sparq_engine::query_json_with_budget(g, &q, &b).ok());
                     n += 1;
                 }
                 n
@@ -147,6 +154,6 @@ fn main() {
         rss_mb()
     );
     // Final published graph sanity: each resource should have exactly 8 triples + parent containment.
-    let g = state.snapshot();
-    println!("final graph: {} triples", g.len());
+    let pin = state.current();
+    println!("final graph: {} triples", pin.snapshot().len());
 }

--- a/bench/serve/src/bin/writer_spike.rs
+++ b/bench/serve/src/bin/writer_spike.rs
@@ -183,7 +183,10 @@ fn reader_under_writer(max_batch: usize, dur: Duration, mode: Mode) -> Vec<u64> 
                     let base = ring2.current();
                     let mut w = applier.fork(base.snapshot()).unwrap();
                     if applier.apply(&mut w, &update(i)).is_ok() {
-                        let s = applier.seal(w);
+                        // seal now returns Result (the applier's compaction-fold can fail on a
+                        // durable-backed store); this in-memory applier never errs, so a failure
+                        // here is a real bug — surface it rather than skip the publish.
+                        let s = applier.seal(w).expect("in-memory seal never fails");
                         ring2.publish(s, [PodId::from("pod:w")]);
                     }
                     i += 1;


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

Fixes **sq-i9ck**: the standalone `bench/serve` research-spike project no longer compiled against the current `sparq-server` / `sparq-serve` API. The project is a deliberately detached cargo workspace (its own `[workspace]` table) so it is **not gated by root CI** — the breakage was latent and only surfaced when adding `pss_update_throughput` (sq-b4lo).

Three drifted bins, three API renames threaded through:

| bin | drift | fix |
|---|---|---|
| `snapshot_spike.rs` | `ServerConfig.compact_every` removed; `AppState::snapshot()` removed | drop the field; `AppState::current().snapshot()` (pin the generation, borrow its `&Graph`) |
| `update_stream_spike.rs` | same two | same; also dropped the now-dead `--compact-every` flag (it no longer reaches `AppState` — compaction is the writer's `GraphApplier` threshold inside `sparq-serve`) |
| `writer_spike.rs` | `GraphApplier::seal()` now returns `Result<Graph,String>` | A1-baseline publish path unwraps it (in-memory seal never fails) instead of passing the `Result` to `GenerationRing::publish` |

## Honesty note — not a pure rename

`snapshot_spike`'s **step 3** was written to *measure* the pinned-snapshot writer stall of the OLD double-buffered writer (it could not reclaim its pinned spare → waited out `query_timeout + 2s grace` → fell back to an O(graph) rebuild). **Wave A4 removed that pathology by design**: a pinned generation is just one of K retained `Arc`s and is never reclaimed by the writer. A mechanical rename would have left the spike printing a "reclaim wait + rebuild" narrative that no longer happens — a dishonest no-op measurement. So the module docs and step-3/4 strings were reconciled to the generation-ring reality: the step now measures (and the smoke run **confirms**) that the stall is gone — update-with-a-generation-pinned latency equals steady-state (~3ms vs ~3ms).

## Gate

Run against the detached `bench/serve` workspace:

- `cargo build --release` (whole project) — pass
- `cargo clippy --release --bin snapshot_spike --bin writer_spike --bin update_stream_spike -- -D warnings` — pass
- privacy-claims gate (incl. predicate-form soundness) — pass (no ZK/MPC surface touched)
- G2 public-api→SKILL — PASS, no public surface changed (only `bench/serve` consumers)
- runtime smoke of all three bins — all run correctly; A1 baseline (the fixed `seal().expect(...)` path) publishes cleanly; group-commit win visible; readers never stall the writer

No `#[test]`s and no cargo features in this standalone project, so "both feature states" is a single state here; the runtime smoke is the spike's correctness check. No production code or public API changed.

## Discovered (out of scope, tracked)

`cache_spike.rs` (a bin I did **not** touch) trips `clippy::type_complexity` under `--all-targets -D warnings` — a pre-existing latent lint in this ungated project. Filed as **sq-kujq** rather than scope-crept into this PR.

Closes sq-i9ck.