### PR TITLE
feat(sparq-server): opt-in first-party CORS origin allowlist (sq-o7o0, ASVS V14.5.3) [OPUS-4.8]

### DIFF
--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -101,14 +101,53 @@ hardening header set (ASVS V14.4 / ASVS-G1; beads `sq-cmvh`, `sq-2bhm`), stamped
 Each header is only added when absent, so a handler may override a specific one.
 **Deliberately omitted:** `Strict-Transport-Security` (this origin serves plain HTTP — HSTS
 belongs on the fronting TLS proxy, setting it here is meaningless or wrongly pins a host);
-`X-XSS-Protection` (deprecated, a no-op/harmful in modern browsers, superseded by CSP); and CORS
-/ `Cross-Origin-*` / `Permissions-Policy` (browser-document policies with no meaning for a
-no-CORS data API — adding CORS would *widen* the surface). No *blanket* `Cache-Control: no-store`
+`X-XSS-Protection` (deprecated, a no-op/harmful in modern browsers, superseded by CSP); and
+`Cross-Origin-*` / `Permissions-Policy` (browser-document policies with no meaning for a data
+API). **CORS** is OFF by default (no `Access-Control-*` header is emitted — a cross-origin
+browser read is blocked, which is the safe posture for a public data API) but is an explicit
+**opt-in first-party allowlist** — see the next section. No *blanket* `Cache-Control: no-store`
 is forced: query results are uncached by default (no `ETag` / `Cache-Control: public` is ever
 set), so there is nothing to tighten, and a blanket value would wrongly override `/health` and
 `/metrics`. **The one targeted exception (`sq-2bhm`):** the sensitive auth-refusal — the `401`
 from a gated request without a valid Bearer token — carries `Cache-Control: no-store` so a
 shared cache / proxy never retains it.
+
+### CORS — off by default; opt-in first-party origin allowlist (ASVS V14.5.3; bead `sq-o7o0`)
+
+`sparq-server` is a SPARQL **data API**, so by default it emits **no CORS headers at all**. A
+response with no `Access-Control-Allow-Origin` is, by the browser Same-Origin Policy, unreadable
+to a cross-origin script — exactly the right (and historical) posture for a public, possibly
+unauthenticated endpoint. **Do nothing and you keep that safe default** (no CORS code path even
+runs).
+
+If you serve a **first-party browser app** (a dashboard / query UI) from a *different* origin
+than the endpoint and need it to read responses from `fetch`, allowlist that origin explicitly:
+
+```sh
+# allow one origin (repeatable)
+cargo run -p sparq-server -- --cors-allow-origin https://app.example.org data.ttl
+# or from a file (one origin per line; '#' comments) / the env var (comma- or ws-separated)
+cargo run -p sparq-server -- --cors-allow-origin-file ./cors-origins.txt data.ttl
+SPARQ_CORS_ALLOW_ORIGIN='https://app.example.org, http://localhost:5173' cargo run -p sparq-server -- data.ttl
+```
+
+Each entry is one RFC 6454 origin `scheme://host[:port]` (e.g. `https://app.example.org`,
+`http://localhost:5173`). Sources union additively (env baseline + file + CLI), matching the
+SERVICE allowlist's precedence. When the allowlist is non-empty, a small middleware in
+`harden()`:
+
+- reflects an **allowlisted** request `Origin` into `Access-Control-Allow-Origin` (plus
+  `Vary: Origin`) on every response; an **un-listed** origin gets **no** CORS header (so the
+  browser still blocks it);
+- answers the **`OPTIONS` preflight** (when it carries `Access-Control-Request-Method`) with the
+  allowed methods, the requested/`content-type, authorization` headers, and a `Max-Age`, for an
+  allowlisted origin only.
+
+Deliberately conservative: it **never** emits `Access-Control-Allow-Origin: *` (only an exact
+listed origin is reflected) and **never** sets `Access-Control-Allow-Credentials` (this is for
+reading public query results). A `*` entry is rejected at startup. **CORS is a browser-read gate
+only** — it does *not* relax the Bearer-token auth gate, the bind posture, the body limits, the
+SERVICE egress allowlist, or the row caps; an allowlisted browser still needs the token to write.
 
 ### Error responses do not leak internals (ASVS V7 / ASVS-G3)
 

--- a/crates/sparq-server/src/cors_config.rs
+++ b/crates/sparq-server/src/cors_config.rs
@@ -1,0 +1,337 @@
+//! First-party CORS origin allowlist — server configuration. [OPUS-4.8] (sq-o7o0)
+//!
+//! ASVS V14.5.3 wants a deliberate, documented CORS decision. `sparq-server` is a
+//! SPARQL *data API* (it serves SPARQL-results JSON/XML/CSV/TSV and RDF, never an
+//! HTML document it asks a browser to render), so its **safe default is to emit NO
+//! CORS headers at all** — a response with no `Access-Control-Allow-Origin` is, by
+//! the Same-Origin Policy, unreadable to a cross-origin browser script. That default
+//! is exactly the historical behaviour and is the correct posture for a public,
+//! unauthenticated endpoint: adding a permissive CORS header would *widen* the
+//! browser-reachable surface, the opposite of hardening.
+//!
+//! ## Why an opt-in allowlist at all
+//!
+//! Some operators run a **first-party browser app** (a dashboard, a query UI) on a
+//! different origin from the endpoint and legitimately need that one origin to read
+//! responses from a browser `fetch`. For them — and ONLY them — this provides an
+//! explicit allowlist: list the exact origins your own front-end is served from, and
+//! the server reflects each listed `Origin` back in `Access-Control-Allow-Origin`
+//! (plus `Vary: Origin`) and answers the `OPTIONS` preflight. Empty (the default)
+//! means **no CORS headers** — unchanged from before this option existed.
+//!
+//! ## Deliberately conservative
+//!
+//!   * **No `*` wildcard origin.** We never emit `Access-Control-Allow-Origin: *`.
+//!     Only an exact origin from the allowlist is reflected; an un-listed origin gets
+//!     no CORS header at all (the browser then blocks the cross-origin read). This
+//!     keeps the allowlist a true first-party list, not an open door.
+//!   * **No `Access-Control-Allow-Credentials`.** The combination of credentialed
+//!     CORS with a reflected origin is a classic footgun; this layer is for a
+//!     first-party app reading PUBLIC query results, so credentials are never opted
+//!     in. (The endpoint's own Bearer-token gate is orthogonal and unaffected — a
+//!     browser still sends/omits it per its own `fetch` options; we simply never set
+//!     `Allow-Credentials`, so the browser will not expose a credentialed response.)
+//!   * **Allowlisting an origin does NOT relax any other guard.** Auth, the bind
+//!     posture, body limits, the SERVICE egress allowlist and the row caps all still
+//!     apply to a CORS request exactly as to any other.
+//!
+//! ## Origin syntax
+//!
+//! Each entry is one **origin** in the RFC 6454 serialization the browser sends in
+//! the `Origin` header: `scheme "://" host [ ":" port ]`, e.g.
+//! `https://app.example.org`, `http://localhost:8080`. The match is **exact** (the
+//! reflected value is byte-for-byte the request `Origin`), case-folded only on the
+//! scheme + host (per RFC 6454 origins are compared case-insensitively on those, but
+//! a browser already lower-cases them, so in practice the entries are compared
+//! verbatim against the header). A default port is NOT inferred: list
+//! `https://app.example.org` and `https://app.example.org:443` separately if you
+//! somehow receive both (browsers omit the default port, so the bare form is the one
+//! you want).
+//!
+//! Entries come from (union of all three, deduplicated):
+//!   * the repeatable `--cors-allow-origin <origin>` CLI flag;
+//!   * `--cors-allow-origin-file <path>` (one entry per line; `#` comments + blanks
+//!     ignored);
+//!   * the `SPARQ_CORS_ALLOW_ORIGIN` env var (comma- and/or whitespace-separated).
+//!
+//! Precedence mirrors the SERVICE allowlist: env establishes a baseline, the file +
+//! CLI flags ADD to it (the union — an allowlist is additive, so the CLI only ever
+//! widens what env granted, never silently removes an origin).
+
+use std::collections::BTreeSet;
+
+/// The configured first-party CORS origin allowlist. Empty = emit NO CORS headers
+/// (the default — historical behaviour).
+///
+/// Stored as a normalised, deduplicated, sorted set so two configs built from the
+/// same inputs in any order compare equal (handy for tests) and the startup log is
+/// deterministic. Each stored entry is already validated as a well-formed origin.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CorsAllowlist {
+    /// Allowed origins in their `scheme://host[:port]` serialization (scheme + host
+    /// lower-cased; no trailing slash).
+    origins: BTreeSet<String>,
+}
+
+impl CorsAllowlist {
+    /// True when no origin is allowlisted — i.e. NO CORS headers are emitted (the
+    /// default; a cross-origin browser read is blocked by the Same-Origin Policy).
+    pub fn is_empty(&self) -> bool {
+        self.origins.is_empty()
+    }
+
+    /// Number of distinct allowlisted origins.
+    pub fn len(&self) -> usize {
+        self.origins.len()
+    }
+
+    /// Whether the given request `Origin` header value is allowlisted (and therefore
+    /// safe to reflect into `Access-Control-Allow-Origin`). The comparison is exact
+    /// against a normalised origin: the input is normalised (scheme + host
+    /// lower-cased, trailing slash stripped) and looked up. Returns `false` for an
+    /// un-listed origin, for a malformed `Origin`, and always for the literal `null`
+    /// origin (sandboxed/`file:`/redirected contexts — we never reflect `null`).
+    pub fn allows(&self, origin: &str) -> bool {
+        match Self::normalize_origin(origin) {
+            Some(o) => self.origins.contains(&o),
+            None => false,
+        }
+    }
+
+    /// Adds one raw entry (CLI flag value, file line, or env token). Returns an error
+    /// string for a malformed origin so the caller can fail fast at startup rather
+    /// than silently dropping an origin the operator meant to allow (a fail-closed
+    /// CORS list that *looks* configured but never matches would be a confusing
+    /// footgun).
+    ///
+    /// Accepted form: a single RFC 6454 origin `scheme://host[:port]`. A `*` (the
+    /// wildcard origin) is REJECTED on purpose — this is a first-party allowlist, not
+    /// an open-CORS switch; reflecting only exact listed origins is the whole point.
+    pub fn add(&mut self, raw: &str) -> Result<(), String> {
+        let e = raw.trim();
+        if e.is_empty() {
+            return Ok(()); // blank line / empty token — nothing to add
+        }
+        if e == "*" || e.contains('*') {
+            return Err(format!(
+                "invalid CORS origin {raw:?}: a '*' wildcard origin is not supported \
+                 (list each exact first-party origin instead — we never emit \
+                 'Access-Control-Allow-Origin: *')"
+            ));
+        }
+        match Self::normalize_origin(e) {
+            Some(o) => {
+                self.origins.insert(o);
+                Ok(())
+            }
+            None => Err(format!(
+                "invalid CORS origin {raw:?}: expected an origin 'scheme://host[:port]' \
+                 (e.g. https://app.example.org)"
+            )),
+        }
+    }
+
+    /// Adds every comma- and/or whitespace-separated token in `s` (the
+    /// `SPARQ_CORS_ALLOW_ORIGIN` env-var grammar).
+    pub fn add_many(&mut self, s: &str) -> Result<(), String> {
+        for tok in s.split([',', ' ', '\t', '\n', '\r']) {
+            self.add(tok)?;
+        }
+        Ok(())
+    }
+
+    /// Validate + normalise an origin string to the canonical `scheme://host[:port]`
+    /// form we store and compare against. Returns `None` for anything that is not a
+    /// well-formed origin (so a malformed `Origin` header can never match, and a
+    /// malformed config entry is rejected at startup).
+    ///
+    /// Normalisation: trim; strip a single trailing `/`; lower-case the scheme and
+    /// host (RFC 6454 §4 — origins are scheme/host case-insensitive); keep the port
+    /// verbatim. We require an explicit scheme and a non-empty host, reject any path
+    /// / query / fragment / userinfo (an origin has none), and reject the `null`
+    /// keyword (we never reflect `null`).
+    fn normalize_origin(raw: &str) -> Option<String> {
+        let s = raw.trim().strip_suffix('/').unwrap_or(raw.trim());
+        if s.is_empty() || s.eq_ignore_ascii_case("null") {
+            return None;
+        }
+        let (scheme, rest) = s.split_once("://")?;
+        if scheme.is_empty()
+            || !scheme
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'+' || b == b'-' || b == b'.')
+            || !scheme.as_bytes()[0].is_ascii_alphabetic()
+        {
+            return None;
+        }
+        // `rest` must be exactly the authority: host[:port]. No path/query/fragment,
+        // no userinfo (`@`), no embedded slash, no whitespace.
+        if rest.is_empty()
+            || rest.contains('/')
+            || rest.contains('?')
+            || rest.contains('#')
+            || rest.contains('@')
+            || rest.contains(char::is_whitespace)
+        {
+            return None;
+        }
+        let scheme_lc = scheme.to_ascii_lowercase();
+        // Split off an optional :port. Bracketed IPv6 (`[::1]` / `[::1]:8080`) is
+        // handled so the colon inside the address is not mistaken for the port sep.
+        let (host, port) = if let Some(after_bracket) = rest.strip_prefix('[') {
+            let (inner, tail) = after_bracket.split_once(']')?;
+            if inner.is_empty() {
+                return None;
+            }
+            let port = match tail {
+                "" => None,
+                t => Some(t.strip_prefix(':')?),
+            };
+            (format!("[{}]", inner.to_ascii_lowercase()), port)
+        } else if let Some((h, p)) = rest.rsplit_once(':') {
+            // Only treat the trailing colon group as a port when it is all digits;
+            // otherwise it is part of an (unbracketed, so invalid) IPv6 literal, which
+            // the host check below rejects via its stray-colon test.
+            if !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()) {
+                (h.to_ascii_lowercase(), Some(p))
+            } else {
+                (rest.to_ascii_lowercase(), None)
+            }
+        } else {
+            (rest.to_ascii_lowercase(), None)
+        };
+        // Host must be non-empty and must not itself contain a stray colon (a bare,
+        // unbracketed IPv6 literal is not a valid Origin authority).
+        if host.is_empty() || (!host.starts_with('[') && host.contains(':')) {
+            return None;
+        }
+        match port {
+            Some(p) => Some(format!("{scheme_lc}://{host}:{p}")),
+            None => Some(format!("{scheme_lc}://{host}")),
+        }
+    }
+
+    /// A stable, human-readable rendering for the startup log.
+    pub fn display(&self) -> String {
+        if self.is_empty() {
+            return "off (no CORS headers emitted)".to_string();
+        }
+        self.origins.iter().cloned().collect::<Vec<_>>().join(", ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_is_no_cors() {
+        let a = CorsAllowlist::default();
+        assert!(a.is_empty());
+        assert_eq!(a.len(), 0);
+        assert!(!a.allows("https://app.example.org"));
+        assert_eq!(a.display(), "off (no CORS headers emitted)");
+    }
+
+    #[test]
+    fn exact_origin_allowed_others_not() {
+        let mut a = CorsAllowlist::default();
+        a.add("https://app.example.org").unwrap();
+        assert!(a.allows("https://app.example.org"));
+        // Different scheme / host / port are all distinct origins.
+        assert!(!a.allows("http://app.example.org"));
+        assert!(!a.allows("https://evil.example.org"));
+        assert!(!a.allows("https://app.example.org:8443"));
+    }
+
+    #[test]
+    fn scheme_and_host_lowercased_trailing_slash_stripped() {
+        let mut a = CorsAllowlist::default();
+        a.add("HTTPS://App.Example.ORG/").unwrap();
+        assert_eq!(a.len(), 1);
+        // A browser always sends the lower-cased, slash-free origin.
+        assert!(a.allows("https://app.example.org"));
+        assert!(a.allows("HTTPS://APP.EXAMPLE.ORG")); // normalised on lookup too
+    }
+
+    #[test]
+    fn port_preserved_and_distinct() {
+        let mut a = CorsAllowlist::default();
+        a.add("http://localhost:8080").unwrap();
+        assert!(a.allows("http://localhost:8080"));
+        assert!(!a.allows("http://localhost")); // no default-port inference
+        assert!(!a.allows("http://localhost:8081"));
+    }
+
+    #[test]
+    fn ipv6_origin_supported() {
+        let mut a = CorsAllowlist::default();
+        a.add("http://[::1]:3000").unwrap();
+        assert!(a.allows("http://[::1]:3000"));
+        assert!(!a.allows("http://[::1]"));
+        let mut b = CorsAllowlist::default();
+        b.add("http://[::1]").unwrap();
+        assert!(b.allows("http://[::1]"));
+    }
+
+    #[test]
+    fn wildcard_rejected() {
+        let mut a = CorsAllowlist::default();
+        assert!(a.add("*").is_err());
+        assert!(a.add("https://*.example.org").is_err());
+        assert!(a.is_empty());
+    }
+
+    #[test]
+    fn null_origin_never_allowed() {
+        let mut a = CorsAllowlist::default();
+        // "null" is not a valid allowlist entry...
+        assert!(a.add("null").is_err());
+        // ...and even a lookup of `null` against a configured list is refused.
+        a.add("https://app.example.org").unwrap();
+        assert!(!a.allows("null"));
+        assert!(!a.allows("NULL"));
+    }
+
+    #[test]
+    fn malformed_origins_rejected() {
+        let mut a = CorsAllowlist::default();
+        assert!(a.add("app.example.org").is_err()); // no scheme
+        assert!(a.add("https://").is_err()); // no host
+        assert!(a.add("https://app.example.org/path").is_err()); // has a path
+        assert!(a.add("https://app.example.org?x=1").is_err()); // has a query
+        assert!(a.add("https://user@app.example.org").is_err()); // userinfo
+        assert!(a.add("https://app.example.org:notaport").is_err()); // bad port
+        assert!(a.add("ht tps://app.example.org").is_err()); // space in scheme
+        assert!(a.is_empty());
+    }
+
+    #[test]
+    fn blank_entries_ignored() {
+        let mut a = CorsAllowlist::default();
+        a.add("   ").unwrap();
+        a.add("").unwrap();
+        assert!(a.is_empty());
+    }
+
+    #[test]
+    fn add_many_splits_and_dedups() {
+        let mut a = CorsAllowlist::default();
+        a.add_many(
+            "https://a.example.org, https://b.example.org  https://a.example.org\nhttps://c.example.org",
+        )
+        .unwrap();
+        assert_eq!(a.len(), 3); // a, b, c — the duplicate a is collapsed
+        assert!(a.allows("https://a.example.org"));
+        assert!(a.allows("https://b.example.org"));
+        assert!(a.allows("https://c.example.org"));
+    }
+
+    #[test]
+    fn display_is_sorted_and_stable() {
+        let mut a = CorsAllowlist::default();
+        a.add("https://b.example.org").unwrap();
+        a.add("https://a.example.org").unwrap();
+        assert_eq!(a.display(), "https://a.example.org, https://b.example.org");
+    }
+}

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -368,6 +368,22 @@ pub struct ServerConfig {
     /// this field is still present (so the config shape is stable) but inert: no
     /// federation code is compiled and a SERVICE clause errors at execution as before.
     pub service_allow: crate::service_config::ServiceAllowlist,
+    /// [OPUS-4.8] (sq-o7o0, ASVS V14.5.3) First-party CORS origin allowlist. `sparq-server`
+    /// is a SPARQL DATA API, so its safe default is to emit **no CORS headers** — a
+    /// cross-origin browser `fetch` cannot read a response with no
+    /// `Access-Control-Allow-Origin`, which is exactly the historical behaviour and the
+    /// right posture for a public endpoint. EMPTY (the default) keeps that: no CORS code
+    /// path runs and a response is byte-identical to before this option existed.
+    ///
+    /// An operator running a FIRST-PARTY browser app on a different origin opts that one
+    /// origin in via `--cors-allow-origin` / `--cors-allow-origin-file` /
+    /// `SPARQ_CORS_ALLOW_ORIGIN` (see [`crate::CorsAllowlist`]). When non-empty, the
+    /// [`harden`] middleware reflects an allowlisted request `Origin` into
+    /// `Access-Control-Allow-Origin` (never `*`, never with credentials) + `Vary: Origin`,
+    /// and answers the `OPTIONS` preflight. An un-listed origin still gets no CORS header.
+    /// This is a browser-read gate ONLY: it does not relax auth, the bind posture, body
+    /// limits, the SERVICE egress allowlist, or the row caps.
+    pub cors_allow: crate::cors_config::CorsAllowlist,
     /// [OPUS-4.8] (sq-7cxr, gh-44) DURABLE PERSISTENCE directory — the QLever `--persist-updates`
     /// equivalent. When `Some(dir)`, the server treats the on-disk index at `dir` as the durable,
     /// rebuildable source of truth: at startup it opens the existing store there (replaying its
@@ -500,6 +516,9 @@ impl Default for ServerConfig {
             auth_token_read: false,
             // [OPUS-4.8] sq-4w18: safe default — empty allowlist = deny ALL SERVICE.
             service_allow: crate::service_config::ServiceAllowlist::default(),
+            // [OPUS-4.8] sq-o7o0: safe default — empty allowlist = NO CORS headers (a
+            // cross-origin browser read is blocked, the historical posture for a data API).
+            cors_allow: crate::cors_config::CorsAllowlist::default(),
             // [OPUS-4.8] sq-7cxr: safe default — no persistence dir = in-memory (back-compat).
             persist_dir: None,
             // [OPUS-4.8] sq-d3d8: safe default — federation discovery descriptors OFF even
@@ -660,6 +679,17 @@ impl ServerConfig {
             cfg.service_allow
                 .add_many(&v)
                 .map_err(|e| format!("SPARQ_SERVICE_ALLOW: {e}"))?;
+        }
+        // [OPUS-4.8] sq-o7o0: first-party CORS origin allowlist baseline from
+        // SPARQ_CORS_ALLOW_ORIGIN (comma/whitespace-separated). The binary then ADDS any
+        // `--cors-allow-origin` / `--cors-allow-origin-file` entries (the union — CLI only
+        // ever widens). A malformed env origin is a hard startup error (propagated, not
+        // panicked) rather than a silently-dropped origin, so the operator's allowlist is
+        // never quietly narrower than written. Unset/empty => no CORS headers (the default).
+        if let Ok(v) = std::env::var("SPARQ_CORS_ALLOW_ORIGIN") {
+            cfg.cors_allow
+                .add_many(&v)
+                .map_err(|e| format!("SPARQ_CORS_ALLOW_ORIGIN: {e}"))?;
         }
         // [OPUS-4.8] sq-7cxr: SPARQ_PERSIST_DIR enables durable persistence at the given
         // directory (the binary's --persist flag overrides it). An empty value is "unset".
@@ -2568,6 +2598,25 @@ pub fn harden(routes: Router, config: &ServerConfig) -> Router {
             .layer(axum::middleware::map_response(json_error_bodies))
             .layer(DefaultBodyLimit::max(config.max_body_bytes)),
     );
+    // [OPUS-4.8] sq-o7o0 (ASVS V14.5.3): OPT-IN first-party CORS. When the allowlist is
+    // EMPTY (the default) this layer is NOT added at all — the stack is byte-identical to
+    // before and NO CORS headers are emitted (a cross-origin browser read stays blocked).
+    // When configured, the layer wraps the WHOLE hardened stack so a preflight `OPTIONS`
+    // is answered before the body-limit/concurrency layers, and the CORS response headers
+    // land on every response — success, 429-shed, 413, and panic alike. The middleware
+    // reflects ONLY an allowlisted `Origin` (never `*`, never with credentials). See
+    // [`cors_layer`] / [`crate::cors_config`].
+    let routes = if config.cors_allow.is_empty() {
+        routes
+    } else {
+        let allow = config.cors_allow.clone();
+        routes.layer(axum::middleware::from_fn(
+            move |req: axum::extract::Request, next: axum::middleware::Next| {
+                let allow = allow.clone();
+                async move { cors_layer(allow, req, next).await }
+            },
+        ))
+    };
     if config.verbose {
         // [OPUS-4.8] sq-toze.34: with redaction ON (the default), swap tower-http's
         // `DefaultMakeSpan` (which records the RAW request URI — and so the full
@@ -4917,6 +4966,130 @@ async fn security_headers(mut resp: Response) -> Response {
         if !headers.contains_key(name) {
             headers.insert(name, header::HeaderValue::from_static(value));
         }
+    }
+    resp
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-o7o0 (ASVS V14.5.3) — OPT-IN first-party CORS
+//
+// sparq-server is a SPARQL DATA API and its DEFAULT is to emit NO CORS headers (an
+// empty [`CorsAllowlist`] => this middleware is not even installed; see `harden`). The
+// option exists only so an operator can let a FIRST-PARTY browser app on a different
+// origin read responses. The policy is deliberately conservative:
+//
+//   * reflect ONLY an exact allowlisted `Origin` into `Access-Control-Allow-Origin`;
+//     an un-listed origin gets NO CORS header (browser blocks the read). Never `*`.
+//   * always `Vary: Origin` so a shared cache never serves an origin-specific
+//     `Access-Control-Allow-Origin` to a different origin.
+//   * NEVER `Access-Control-Allow-Credentials` — this is for reading PUBLIC results;
+//     the endpoint's own Bearer gate is orthogonal and unchanged.
+//   * answer the `OPTIONS` preflight (when it carries `Access-Control-Request-Method`)
+//     with the allowed methods/headers + a `Max-Age`, for an allowlisted origin only.
+// ---------------------------------------------------------------------------
+
+/// The methods advertised in a CORS preflight response. The HTTP surface accepts GET /
+/// HEAD / POST (SPARQL query + the GSP read/write verbs) plus OPTIONS itself; PUT /
+/// DELETE are the GSP write verbs. A browser's actual request is still subject to every
+/// other guard (auth, body limit, …) — advertising a method here does not bypass them.
+const CORS_ALLOW_METHODS: &str = "GET, HEAD, POST, PUT, DELETE, OPTIONS";
+
+/// The request headers advertised as allowed in a preflight when the browser does not
+/// send its own `Access-Control-Request-Headers` (we otherwise reflect that list). Covers
+/// the headers a SPARQL browser client sends: `Content-Type` (the POST forms) and
+/// `Authorization` (the optional Bearer gate).
+const CORS_ALLOW_HEADERS_DEFAULT: &str = "content-type, authorization";
+
+/// Preflight cache lifetime (`Access-Control-Max-Age`, seconds) — 10 minutes, a modest
+/// value so a policy change is picked up reasonably soon without re-preflighting every
+/// request.
+const CORS_MAX_AGE: &str = "600";
+
+/// [OPUS-4.8] sq-o7o0: the opt-in first-party CORS middleware (installed by [`harden`]
+/// only when [`ServerConfig::cors_allow`] is non-empty).
+///
+/// Reads the request `Origin`; if it is allowlisted (exact match, never `*`), reflects it
+/// into `Access-Control-Allow-Origin` (+ `Vary: Origin`). A CORS *preflight* (an `OPTIONS`
+/// carrying `Access-Control-Request-Method`) from an allowlisted origin is answered here
+/// with a `204` + the allowed methods/headers/max-age, WITHOUT running the inner stack.
+/// Any other request runs the inner stack normally and the actual-request CORS headers are
+/// stamped onto its response. A request with no `Origin`, or with an un-listed `Origin`,
+/// passes through completely untouched (no CORS header at all).
+async fn cors_layer(
+    allow: crate::cors_config::CorsAllowlist,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    // The browser's Origin (RFC 6454 serialization). Absent ⇒ not a CORS request.
+    let origin_allowed = req
+        .headers()
+        .get(header::ORIGIN)
+        .and_then(|v| v.to_str().ok())
+        .filter(|o| allow.allows(o))
+        .map(str::to_owned);
+
+    // A preflight is an OPTIONS that carries Access-Control-Request-Method. Answer it
+    // here for an allowlisted origin (204, no inner work). A bare OPTIONS without the
+    // request-method header is NOT a preflight — let it fall through (it 405s) and get
+    // the actual-request CORS header below.
+    let is_preflight = req.method() == Method::OPTIONS
+        && req
+            .headers()
+            .contains_key(header::ACCESS_CONTROL_REQUEST_METHOD);
+
+    if is_preflight {
+        return match &origin_allowed {
+            Some(origin) => {
+                // Echo the requested headers if the browser listed them, else a sane default.
+                let allow_headers = req
+                    .headers()
+                    .get(header::ACCESS_CONTROL_REQUEST_HEADERS)
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|s| header::HeaderValue::from_str(s).ok())
+                    .unwrap_or_else(|| {
+                        header::HeaderValue::from_static(CORS_ALLOW_HEADERS_DEFAULT)
+                    });
+                let mut resp = Response::builder()
+                    .status(StatusCode::NO_CONTENT)
+                    .body(axum::body::Body::empty())
+                    .expect("static preflight response is always valid");
+                let h = resp.headers_mut();
+                // `origin` came from the request header (valid HeaderValue bytes) and is
+                // allowlisted, so the conversion cannot fail.
+                if let Ok(v) = header::HeaderValue::from_str(origin) {
+                    h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, v);
+                }
+                h.insert(
+                    header::ACCESS_CONTROL_ALLOW_METHODS,
+                    header::HeaderValue::from_static(CORS_ALLOW_METHODS),
+                );
+                h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, allow_headers);
+                h.insert(
+                    header::ACCESS_CONTROL_MAX_AGE,
+                    header::HeaderValue::from_static(CORS_MAX_AGE),
+                );
+                h.insert(header::VARY, header::HeaderValue::from_static("Origin"));
+                resp
+            }
+            // Preflight from a NON-allowlisted origin: no CORS headers; a 204 with no
+            // Allow-Origin makes the browser fail the preflight (the desired refusal).
+            None => Response::builder()
+                .status(StatusCode::NO_CONTENT)
+                .body(axum::body::Body::empty())
+                .expect("static preflight response is always valid"),
+        };
+    }
+
+    // Actual (non-preflight) request: run the inner stack, then stamp the CORS
+    // response headers for an allowlisted origin. `Vary: Origin` is APPENDED (not
+    // inserted) so we never clobber a `Vary` a handler already set.
+    let mut resp = next.run(req).await;
+    if let Some(origin) = origin_allowed {
+        let h = resp.headers_mut();
+        if let Ok(v) = header::HeaderValue::from_str(&origin) {
+            h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, v);
+        }
+        h.append(header::VARY, header::HeaderValue::from_static("Origin"));
     }
     resp
 }

--- a/crates/sparq-server/src/lib.rs
+++ b/crates/sparq-server/src/lib.rs
@@ -17,6 +17,15 @@ pub mod results;
 /// posture and rationale.
 pub mod service_config;
 
+/// [OPUS-4.8] (sq-o7o0, ASVS V14.5.3) **First-party CORS origin allowlist** — the
+/// [`cors_config::CorsAllowlist`] config type (parse `--cors-allow-origin` /
+/// `--cors-allow-origin-file` / `SPARQ_CORS_ALLOW_ORIGIN`, exact-origin matcher). Pure
+/// (no async), always compiled + unit-tested. EMPTY by default = NO CORS headers (the
+/// historical, safe posture for a data API); an operator opts specific first-party
+/// browser origins back in. Enforced by the [`http::harden`] middleware. See the module
+/// docs for the deliberately-conservative policy (no `*`, no credentials).
+pub mod cors_config;
+
 /// [OPUS-4.8] (sq-toze.34, epic sq-toze) **Request-log redaction** — keeps SPARQL query / update
 /// text out of the `--verbose` request log (a PII/privacy exposure: `GET /sparql?query=…` puts
 /// the full query in the logged URI). On by default ([`ServerConfig::redact_logs`]); opt out with
@@ -91,6 +100,10 @@ pub use http::{
 /// [OPUS-4.8] (sq-4w18) The SERVICE egress allowlist config type, re-exported at the
 /// crate root next to [`ServerConfig`].
 pub use service_config::ServiceAllowlist;
+
+/// [OPUS-4.8] (sq-o7o0, ASVS V14.5.3) The first-party CORS origin allowlist config type,
+/// re-exported at the crate root next to [`ServerConfig`].
+pub use cors_config::CorsAllowlist;
 
 /// [OPUS-4.8] (sq-uqh, Wave B) Re-exported for consumers (and tests) that introspect a
 /// pinned generation's per-pod epoch vector — the cache-invalidation hook the server's

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -9,6 +9,7 @@
 //!                [--max-results N] [--max-query-rows N] [--max-decompress-ratio N]
 //!                [--max-subscriptions N] [--max-subscriptions-per-conn N]
 //!                [--service-allow HOST|*.SUFFIX]... [--service-allow-file PATH]
+//!                [--cors-allow-origin ORIGIN]... [--cors-allow-origin-file PATH]
 //!                [--verbose] [DATA_FILE]
 //!
 //! DURABLE PERSISTENCE (`--persist DIR`, env `SPARQ_PERSIST_DIR`; QLever's `--persist-updates`
@@ -27,6 +28,16 @@
 //! `SPARQ_SERVICE_ALLOW` env var (comma/whitespace-separated). This is an SSRF guard: a
 //! `SERVICE` clause turns attacker-controlled query text into an outbound request from this
 //! host. See crates/sparq-server/README.md -> "SERVICE federation (egress allowlist)". [OPUS-4.8]
+//!
+//! CORS (sq-o7o0, ASVS V14.5.3): by default the server emits NO CORS headers — it is a SPARQL
+//! DATA API, so a cross-origin browser `fetch` simply cannot read its responses (the safe
+//! posture). For a FIRST-PARTY browser app on a different origin, allowlist that origin via
+//! `--cors-allow-origin <ORIGIN>` (repeatable; exact `scheme://host[:port]`),
+//! `--cors-allow-origin-file PATH` (one origin per line) or `SPARQ_CORS_ALLOW_ORIGIN`
+//! (comma/whitespace-separated). Only a listed `Origin` is reflected into
+//! `Access-Control-Allow-Origin` (never `*`, never with credentials) and the preflight
+//! `OPTIONS` is answered for it; an un-listed origin still gets no CORS header. See
+//! crates/sparq-server/README.md -> "Security posture" (CORS). [OPUS-4.8]
 //!
 //! SECURITY (auth): by default the server has NO authentication on any endpoint (query, the
 //! `application/sparql-update` mutation path, the `/subscriptions` WebSocket). [OPUS-4.8]
@@ -156,6 +167,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // the CLI only ever widens what env granted (never silently narrows it).
     let mut service_allow_cli: Vec<String> = Vec::new();
     let mut service_allow_file: Option<String> = None;
+    // [OPUS-4.8] sq-o7o0: collect first-party CORS origin allowlist entries from the CLI;
+    // UNIONed with the SPARQ_CORS_ALLOW_ORIGIN env baseline + an optional
+    // --cors-allow-origin-file, after the arg loop (additive — CLI only widens).
+    let mut cors_allow_cli: Vec<String> = Vec::new();
+    let mut cors_allow_file: Option<String> = None;
 
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
@@ -328,6 +344,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 service_allow_file =
                     Some(args.next().ok_or("--service-allow-file requires a path")?);
             }
+            // [OPUS-4.8] sq-o7o0 (ASVS V14.5.3): first-party CORS origin allowlist. Repeatable:
+            // each value adds one exact origin (`https://app.example.org`). With NO allowlist
+            // (the default) NO CORS headers are emitted (a cross-origin browser read is blocked).
+            "--cors-allow-origin" => {
+                cors_allow_cli.push(
+                    args.next()
+                        .ok_or("--cors-allow-origin requires an origin (scheme://host[:port])")?,
+                );
+            }
+            "--cors-allow-origin-file" => {
+                cors_allow_file =
+                    Some(args.next().ok_or("--cors-allow-origin-file requires a path")?);
+            }
             "-h" | "--help" => {
                 let time_travel = if cfg!(feature = "time-travel") {
                     " [--time-travel-generations N] [--time-travel-max-age SECS]"
@@ -358,7 +387,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                      [--max-body-bytes N] [--max-concurrent N] \
                      [--max-results N] [--max-query-rows N] [--max-query-bytes N] [--max-decompress-ratio N] \
                      [--max-subscriptions N] \
-                     [--max-subscriptions-per-conn N]{time_travel}{service}{brtpf}{shacl} [--verbose] \
+                     [--max-subscriptions-per-conn N]{time_travel}{service}{brtpf}{shacl} \
+                     [--cors-allow-origin ORIGIN]... [--cors-allow-origin-file PATH] [--verbose] \
                      [--log-full-requests] [DATA_FILE]\n\n  \
                      PERSIST: --persist DIR (env SPARQ_PERSIST_DIR) makes the on-disk index at \
                      DIR the durable source of truth (QLever --persist-updates): every committed \
@@ -379,7 +409,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                      SERVICE federation (the `service` build feature) is DENY-ALL by default: \
                      SERVICE <iri> reaches NOTHING unless the host is allowlisted via \
                      --service-allow / --service-allow-file / SPARQ_SERVICE_ALLOW \
-                     (exact host or *.suffix wildcard) — an SSRF guard."
+                     (exact host or *.suffix wildcard) — an SSRF guard.\n  \
+                     CORS: NO CORS headers by default (a cross-origin browser fetch cannot read \
+                     responses). For a FIRST-PARTY browser app on another origin, allowlist its \
+                     exact origin(s) via --cors-allow-origin ORIGIN (repeatable) / \
+                     --cors-allow-origin-file PATH / SPARQ_CORS_ALLOW_ORIGIN \
+                     (scheme://host[:port]); only a listed Origin is reflected (never '*', never \
+                     with credentials), and preflight OPTIONS is answered for it."
                 );
                 return Ok(());
             }
@@ -401,6 +437,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     for entry in &service_allow_cli {
         config.service_allow.add(entry)?;
+    }
+
+    // [OPUS-4.8] sq-o7o0: merge the --cors-allow-origin-file + --cors-allow-origin CLI
+    // entries INTO the SPARQ_CORS_ALLOW_ORIGIN env baseline already in config.cors_allow
+    // (union — additive). A malformed origin or unreadable file is a hard startup error:
+    // refuse to boot rather than silently run with a narrower-than-written allowlist.
+    if let Some(path) = &cors_allow_file {
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| format!("--cors-allow-origin-file {path}: {e}"))?;
+        for line in text.lines() {
+            let line = line.split('#').next().unwrap_or("").trim();
+            config.cors_allow.add(line)?;
+        }
+    }
+    for entry in &cors_allow_cli {
+        config.cors_allow.add(entry)?;
     }
 
     // [OPUS-4.8] sq-0bxp: the per-query access audit log emits via `tracing`, so it needs a
@@ -526,6 +578,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "SERVICE egress allowlist: {}",
         config.service_allow.display()
     );
+    // [OPUS-4.8] sq-o7o0: surface the CORS posture at startup. Empty (the default) = no CORS
+    // headers; configured = the exact first-party origins a browser may read responses from.
+    eprintln!("CORS first-party origin allowlist: {}", config.cors_allow.display());
     #[cfg(feature = "time-travel")]
     eprintln!(
         "time travel: ?generation=N enabled — generations={} max-age={} (each retained generation is a full graph)",

--- a/crates/sparq-server/tests/cors.rs
+++ b/crates/sparq-server/tests/cors.rs
@@ -1,0 +1,244 @@
+//! [OPUS-4.8] sq-o7o0 (ASVS V14.5.3) — first-party CORS origin allowlist, integration.
+//!
+//! Boots the real hardened router and asserts the END-TO-END CORS contract:
+//!   * DEFAULT (empty allowlist) emits NO CORS headers — the historical, safe posture for
+//!     a data API (a cross-origin browser read is blocked by the Same-Origin Policy);
+//!   * a configured first-party origin is REFLECTED into `Access-Control-Allow-Origin`
+//!     (never `*`, never `Access-Control-Allow-Credentials`) with `Vary: Origin`;
+//!   * an UN-listed origin gets NO CORS header (so the browser still blocks it);
+//!   * the `OPTIONS` preflight is answered (`204` + methods/headers/max-age) for an
+//!     allowlisted origin only;
+//!   * allowlisting an origin does NOT relax the existing auth gate.
+
+use sparq_core::Graph;
+use sparq_server::{router, AppState, CorsAllowlist, ServerConfig};
+use tokio::net::TcpListener;
+
+const DATA: &str = r#"
+    @prefix ex: <http://ex/> .
+    ex:alice ex:knows ex:bob .
+"#;
+
+const APP_ORIGIN: &str = "https://app.example.org";
+const EVIL_ORIGIN: &str = "https://evil.example.org";
+
+async fn serve(app: axum::Router) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+async fn spawn_with(config: ServerConfig) -> String {
+    let graph = Graph::load_str(DATA, "turtle").unwrap();
+    serve(router(AppState::with_config(graph, config))).await
+}
+
+fn cors_config(origins: &[&str]) -> ServerConfig {
+    let mut cors = CorsAllowlist::default();
+    for o in origins {
+        cors.add(o).unwrap();
+    }
+    ServerConfig { cors_allow: cors, ..ServerConfig::default() }
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+const ACAO: &str = "access-control-allow-origin";
+const ACAC: &str = "access-control-allow-credentials";
+
+// ---------------------------------------------------------------------------
+// (1) DEFAULT: no allowlist => no CORS headers (back-compat / safe default).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn default_emits_no_cors_headers_even_with_origin() {
+    let base = spawn_with(ServerConfig::default()).await;
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "SELECT * WHERE { ?s ?p ?o }")])
+        .header("origin", APP_ORIGIN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    // The whole point of the safe default: a browser cross-origin read is blocked because
+    // there is NO Access-Control-Allow-Origin header.
+    assert!(resp.headers().get(ACAO).is_none(), "default must emit no ACAO header");
+    assert!(resp.headers().get(ACAC).is_none());
+}
+
+#[tokio::test]
+async fn default_preflight_options_has_no_cors_headers() {
+    // With no allowlist the CORS layer is not installed; an OPTIONS just 405s (the
+    // /sparql route allows GET/HEAD/POST) and carries no CORS headers.
+    let base = spawn_with(ServerConfig::default()).await;
+    let resp = client()
+        .request(reqwest::Method::OPTIONS, format!("{base}/sparql"))
+        .header("origin", APP_ORIGIN)
+        .header("access-control-request-method", "POST")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.headers().get(ACAO).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// (2) Allowlisted origin is reflected (never *), with Vary: Origin, no credentials.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn allowlisted_origin_is_reflected_on_actual_request() {
+    let base = spawn_with(cors_config(&[APP_ORIGIN])).await;
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "SELECT * WHERE { ?s ?p ?o }")])
+        .header("origin", APP_ORIGIN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let acao = resp.headers().get(ACAO).expect("ACAO present for allowlisted origin");
+    // Exact reflection — never the wildcard `*`.
+    assert_eq!(acao.to_str().unwrap(), APP_ORIGIN);
+    assert_ne!(acao.to_str().unwrap(), "*");
+    // Never opt into credentialed CORS.
+    assert!(resp.headers().get(ACAC).is_none());
+    // Vary: Origin so a shared cache keys on the origin.
+    let vary = resp
+        .headers()
+        .get_all("vary")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .any(|v| v.eq_ignore_ascii_case("origin"));
+    assert!(vary, "Vary: Origin must be present");
+}
+
+// ---------------------------------------------------------------------------
+// (3) Un-listed origin gets NO CORS header (browser blocks the read).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn unlisted_origin_gets_no_cors_header() {
+    let base = spawn_with(cors_config(&[APP_ORIGIN])).await;
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "SELECT * WHERE { ?s ?p ?o }")])
+        .header("origin", EVIL_ORIGIN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200); // the request itself succeeds...
+    // ...but the browser cannot read it: no ACAO header at all.
+    assert!(resp.headers().get(ACAO).is_none(), "un-listed origin must get no ACAO");
+}
+
+#[tokio::test]
+async fn no_origin_header_means_no_cors_header() {
+    let base = spawn_with(cors_config(&[APP_ORIGIN])).await;
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "SELECT * WHERE { ?s ?p ?o }")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert!(resp.headers().get(ACAO).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// (4) Preflight OPTIONS — answered for an allowlisted origin only.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn preflight_answered_for_allowlisted_origin() {
+    let base = spawn_with(cors_config(&[APP_ORIGIN])).await;
+    let resp = client()
+        .request(reqwest::Method::OPTIONS, format!("{base}/sparql"))
+        .header("origin", APP_ORIGIN)
+        .header("access-control-request-method", "POST")
+        .header("access-control-request-headers", "content-type")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 204);
+    assert_eq!(resp.headers().get(ACAO).unwrap().to_str().unwrap(), APP_ORIGIN);
+    let methods = resp
+        .headers()
+        .get("access-control-allow-methods")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(methods.contains("POST"), "preflight advertises POST: {methods}");
+    assert!(methods.contains("GET"), "preflight advertises GET: {methods}");
+    // The requested headers are echoed.
+    let allow_headers = resp
+        .headers()
+        .get("access-control-allow-headers")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(allow_headers.to_ascii_lowercase().contains("content-type"));
+    assert!(resp.headers().get("access-control-max-age").is_some());
+    assert!(resp.headers().get(ACAC).is_none());
+}
+
+#[tokio::test]
+async fn preflight_for_unlisted_origin_has_no_allow_origin() {
+    let base = spawn_with(cors_config(&[APP_ORIGIN])).await;
+    let resp = client()
+        .request(reqwest::Method::OPTIONS, format!("{base}/sparql"))
+        .header("origin", EVIL_ORIGIN)
+        .header("access-control-request-method", "POST")
+        .send()
+        .await
+        .unwrap();
+    // A 204 with NO Access-Control-Allow-Origin makes the browser fail the preflight.
+    assert!(resp.headers().get(ACAO).is_none());
+}
+
+#[tokio::test]
+async fn second_origin_in_list_also_allowed() {
+    let other = "http://localhost:5173";
+    let base = spawn_with(cors_config(&[APP_ORIGIN, other])).await;
+    for origin in [APP_ORIGIN, other] {
+        let resp = client()
+            .get(format!("{base}/sparql"))
+            .query(&[("query", "SELECT * WHERE { ?s ?p ?o }")])
+            .header("origin", origin)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.headers().get(ACAO).unwrap().to_str().unwrap(), origin);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (5) CORS does NOT relax auth — an allowlisted browser still needs the token.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn cors_does_not_bypass_write_auth() {
+    let mut config = cors_config(&[APP_ORIGIN]);
+    config.auth_token = Some("s3cret".to_string());
+    let base = spawn_with(config).await;
+
+    // An UPDATE from the allowlisted origin WITHOUT the token is still refused 401 —
+    // CORS is a browser-read gate, not an authorization bypass.
+    let resp = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .header("origin", APP_ORIGIN)
+        .body("INSERT DATA { <http://ex/x> <http://ex/p> <http://ex/o> }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401, "CORS must not relax the write-auth gate");
+    // The CORS header is still stamped on the 401 (it is a response like any other),
+    // so a browser can read the 401 — but the write did not happen.
+    assert_eq!(resp.headers().get(ACAO).unwrap().to_str().unwrap(), APP_ORIGIN);
+}

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -65,9 +65,11 @@ cargo run -p sparq-server -- --addr 0.0.0.0:8080 --allow-remote --format ntriple
 > + `X-Frame-Options: DENY` say it is never meant to be framed. Each header is only added when
 > absent, so a custom handler can override one. **Deliberately omitted:** `Strict-Transport-
 > Security` (the origin serves plain HTTP — HSTS belongs on the fronting TLS proxy);
-> `X-XSS-Protection` (deprecated, superseded by CSP); CORS / `Cross-Origin-*` / `Permissions-
-> Policy` (browser-app document policies, meaningless for a no-CORS data API — adding CORS would
-> *widen* the surface). No *blanket* `Cache-Control: no-store` is forced: results are uncached by
+> `X-XSS-Protection` (deprecated, superseded by CSP); `Cross-Origin-*` / `Permissions-Policy`
+> (browser-app document policies, meaningless for a data API). **CORS is OFF by default** (no
+> `Access-Control-*` header — a cross-origin browser read is blocked, the safe posture) but is an
+> opt-in **first-party origin allowlist** (`sq-o7o0`; see "CORS" below). No *blanket*
+> `Cache-Control: no-store` is forced: results are uncached by
 > default (no `ETag`/`Cache-Control: public` is ever set), so there is nothing to tighten, and a
 > blanket value would wrongly override `/health` / `/metrics` — but the sensitive auth-refusal
 > (`401` from `unauthorized()`) **does** carry `Cache-Control: no-store` so a shared cache never
@@ -597,6 +599,8 @@ env overrides the default.
 | `--allow-remote` | `SPARQ_ALLOW_REMOTE` | off | opt in to a non-loopback bind; without it a non-loopback `--addr` is **refused** unless the surface is fully authenticated (`--auth-token` AND `--auth-token-read`), with it it warns and proceeds |
 | `--service-allow HOST\|*.SUFFIX` (repeatable) | `SPARQ_SERVICE_ALLOW` (comma/ws-sep) | empty = **deny ALL SERVICE** | (feature `service`) allowlist a SERVICE egress host (exact or `*.suffix` wildcard); CLI + file + env are all merged (combined additively) |
 | `--service-allow-file PATH` | — | — | (feature `service`) load allowlist entries, one per line (`#` comments + blanks ignored) |
+| `--cors-allow-origin ORIGIN` (repeatable) | `SPARQ_CORS_ALLOW_ORIGIN` (comma/ws-sep) | empty = **no CORS headers** | allowlist a first-party browser origin (`scheme://host[:port]`); a listed `Origin` is reflected into `Access-Control-Allow-Origin` (never `*`, never credentials) + `Vary: Origin`, preflight `OPTIONS` answered; CLI + file + env merged additively — see "CORS" |
+| `--cors-allow-origin-file PATH` | — | — | load CORS origins, one per line (`#` comments + blanks ignored) |
 | `--time-travel-generations N` | `SPARQ_TIME_TRAVEL_GENERATIONS` | `16` | (feature) retained generations |
 | `--time-travel-max-age SECS` | `SPARQ_TIME_TRAVEL_MAX_AGE` | off | (feature) age-out window |
 | `--federation-descriptors` | `SPARQ_FEDERATION_DESCRIPTORS` | off | (feature `federation-descriptors`) serve a VoID at `/.well-known/void` + a SPARQL Service Description on `GET /sparql` with no query — see "Federation discovery" |
@@ -695,6 +699,30 @@ Library callers set these on `ServerConfig` (`query_timeout`, `max_query_rows`,
 directly thread a `sparq_engine::QueryBudget { deadline, max_rows, max_bytes }` into
 `*_with_budget` query entry points and `update_in_place_with_budget`, and wrap calls in
 `sparq_engine::with_service_egress_policy(strict, [host], || …)`.
+
+### CORS — off by default; opt-in first-party origin allowlist (`sq-o7o0`, ASVS V14.5.3)
+
+`sparq-server` is a SPARQL **data API**, so by default it emits **no CORS headers** — a
+cross-origin browser `fetch` cannot read its responses (the safe posture). Do nothing and you
+keep that. For a **first-party** browser app on another origin, allowlist its exact origin(s):
+
+```sh
+cargo run -p sparq-server -- --cors-allow-origin https://app.example.org data.ttl
+SPARQ_CORS_ALLOW_ORIGIN='https://app.example.org, http://localhost:5173' \
+  cargo run -p sparq-server -- data.ttl
+# or one origin per line: --cors-allow-origin-file ./cors-origins.txt
+```
+
+Each entry is an RFC 6454 origin `scheme://host[:port]`. CLI + `--cors-allow-origin-file` + env
+merge additively (same precedence as the SERVICE allowlist). When non-empty, a middleware in
+`harden()` reflects an **allowlisted** request `Origin` into `Access-Control-Allow-Origin` (+
+`Vary: Origin`) and answers the `OPTIONS` preflight for it; an **un-listed** origin gets **no**
+CORS header (browser blocks it). Deliberately conservative: **never** `Access-Control-Allow-
+Origin: *`, **never** `Access-Control-Allow-Credentials`, a `*` entry is rejected at startup. It
+is a **browser-read gate only** — it does *not* relax the Bearer-token auth gate, the bind
+posture, the body limit, the SERVICE allowlist, or the row caps (an allowlisted browser still
+needs the token to write). Library callers set `ServerConfig.cors_allow: CorsAllowlist`
+(re-exported at the crate root).
 
 ### Access audit log — opt-in per-query audit trail (`sq-0bxp`, CDMC CD-2)
 


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-o7o0** (`ASVS-G2: document/first-party CORS allowlist option`). @jeswr runs multiple agents on this account.

## What & why

ASVS V14.5.3 (cert remediation #237 / sq-toze) wants a **deliberate, documented CORS decision**. `sparq-server` is a SPARQL **data API**, so its safe default stays **"emit NO CORS headers"** — a cross-origin browser `fetch` cannot read a response with no `Access-Control-Allow-Origin`, which is exactly the historical behaviour and the right posture for a public, possibly-unauthenticated endpoint. This bead documents that decision **and** adds an explicit **opt-in first-party origin allowlist** for operators who run a browser app on a different origin and need it to read query results.

## Change

- **New `cors_config::CorsAllowlist`** (modelled on the proven `ServiceAllowlist`): exact-origin matcher, `scheme://host[:port]` normalisation (scheme/host lower-cased, trailing slash stripped, IPv6-bracket aware), **rejects `*` and `null`**. Re-exported at the crate root next to `ServiceAllowlist`.
- **`ServerConfig.cors_allow`** — **EMPTY by default** (no CORS; byte-identical to before, the CORS code path does not even run).
- **`harden()` installs a CORS middleware ONLY when the allowlist is non-empty**: reflects an **allowlisted** `Origin` into `Access-Control-Allow-Origin` (**never `*`**, **never `Access-Control-Allow-Credentials`**) + `Vary: Origin`, and answers the `OPTIONS` preflight (methods/headers/max-age). An **un-listed** origin gets no CORS header. **CORS is a browser-read gate only** — it does not relax auth, the bind posture, body limits, the SERVICE egress allowlist, or the row caps.
- **CLI/env:** `--cors-allow-origin <ORIGIN>` (repeatable), `--cors-allow-origin-file <PATH>`, `SPARQ_CORS_ALLOW_ORIGIN` (additive union, same precedence as the SERVICE allowlist); `--help` synopsis + explanation; a startup-log posture line.
- **Docs (public-API → SKILL.md rule):** README "Security posture" gets a dedicated CORS subsection (the old "CORS deliberately omitted" note now points at the opt-in); `skills/http-server/SKILL.md` gets the flag-table rows + a "CORS" subsection.

## Tests
- **11 unit** (`cors_config`): empty = no CORS; exact match; scheme/host case-fold + trailing-slash strip; port distinctness; IPv6; `*` rejected; `null` never allowed; malformed rejected; `add_many` split/dedup; stable display.
- **9 integration** (`tests/cors.rs`, real hardened router over HTTP): default emits no CORS even with an `Origin`; allowlisted origin reflected (never `*`, no credentials, `Vary: Origin`); un-listed / no-origin → no header; preflight answered for allowlisted only; multi-origin; **CORS does not bypass the write-auth gate**.

## Gate (run in-worktree)
- `cargo build -p sparq-server` ✅
- `cargo clippy -p sparq-server --all-targets -- -D warnings` ✅ **and** `--all-features --all-targets -- -D warnings` ✅
- `cargo test -p sparq-server` ✅ + `--all-features` cors/cors_config ✅ + regression (hardening / auth / status_contract) ✅
- privacy-claims gate ✅ (`check-privacy-claims: OK`)
- e2e binary smoke (live reflection / un-listed / preflight / startup log) ✅

> `cargo fmt --all --check` is **informational** in CI (clippy is the hard gate; the one-time workspace reformat is deferred per `rustfmt.toml`). The new `cors_config.rs` is rustfmt-clean; the only fmt diffs are the same deferred struct-literal-wrapping noise present across pre-existing test files.

[OPUS-4.8] markers on all new code; Opus 4.8 `Co-Authored-By` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
