### PR TITLE
fix(bench/serve): factor cache_spike shard-map into type aliases (sq-kujq) [OPUS-4.8]

### DIFF
--- a/bench/serve/src/bin/cache_spike.rs
+++ b/bench/serve/src/bin/cache_spike.rs
@@ -27,6 +27,13 @@ const KEYS: usize = 10_000;
 const RESPONSE_BYTES: usize = 1024;
 const ZIPF_S: f64 = 1.0;
 
+/// query string → pre-serialized response bytes (the cache's value is a shared blob).
+type ResponseCache = HashMap<String, Arc<Vec<u8>>>;
+/// the sharded read-mostly map: one `RwLock`-guarded `ResponseCache` per shard.
+/// [OPUS-4.8] sq-kujq — factored out to satisfy `clippy::type_complexity` under
+/// `--all-targets -D warnings` (this standalone spike workspace is not gated by root CI).
+type ShardedCache = Arc<Vec<RwLock<ResponseCache>>>;
+
 fn main() {
     let threads: usize = std::env::args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(8);
 
@@ -46,7 +53,7 @@ fn main() {
         .map(|i| format!("SELECT ?n WHERE {{ <http://example.org/person/{i}> <http://xmlns.com/foaf/0.1/name> ?n }}"))
         .collect();
     let blob: Arc<Vec<u8>> = Arc::new(vec![b'x'; RESPONSE_BYTES]);
-    let mut map: HashMap<String, Arc<Vec<u8>>> = HashMap::with_capacity(KEYS * 2);
+    let mut map: ResponseCache = HashMap::with_capacity(KEYS * 2);
     for s in &queries {
         map.insert(s.clone(), blob.clone());
     }
@@ -82,12 +89,11 @@ fn main() {
 
     // --- multi-thread hit path: sharded maps (no writer contention modelled) ------
     const SHARDS: usize = 64;
-    let mut shards: Vec<HashMap<String, Arc<Vec<u8>>>> = (0..SHARDS).map(|_| HashMap::new()).collect();
+    let mut shards: Vec<ResponseCache> = (0..SHARDS).map(|_| HashMap::new()).collect();
     for s in &queries {
         shards[shard_of(s, SHARDS)].insert(s.clone(), blob.clone());
     }
-    let shards: Arc<Vec<RwLock<HashMap<String, Arc<Vec<u8>>>>>> =
-        Arc::new(shards.into_iter().map(RwLock::new).collect());
+    let shards: ShardedCache = Arc::new(shards.into_iter().map(RwLock::new).collect());
     bench_threads("sharded(64) RwLock", threads, &queries, &cdf, {
         let shards = shards.clone();
         move |k| {
@@ -99,7 +105,7 @@ fn main() {
     // --- multi-thread: lock-free reads via an immutable Arc-swapped map ----------
     // Models the "generation cache": readers clone an Arc to the whole map (as the
     // server already does for the graph) and look up with zero locking.
-    let frozen: Arc<HashMap<String, Arc<Vec<u8>>>> = Arc::new(cache.read().unwrap().clone());
+    let frozen: Arc<ResponseCache> = Arc::new(cache.read().unwrap().clone());
     bench_threads("Arc-swapped immutable map", threads, &queries, &cdf, {
         let frozen = frozen.clone();
         move |k| frozen.get(k).map(|v| v.len()).unwrap_or(0)


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

`bench/serve/src/bin/cache_spike.rs` declared the sharded cache inline as
`Arc<Vec<RwLock<HashMap<String, Arc<Vec<u8>>>>>>`, which trips
`clippy::type_complexity`. The lint fires only under
`cargo clippy --all-targets -- -D warnings` — the plain build path does not lint it —
and `bench/serve` is a **standalone cargo workspace** (its own `[workspace]` table),
so it is not gated by root CI and the breakage was latent. (Discovered while fixing
sq-i9ck.)

## Fix

Factor the shape into two named `type` aliases at the top of the bin and apply them
at every binding site that previously spelled the type out:

- `type ResponseCache = HashMap<String, Arc<Vec<u8>>>;` — the query-string → shared
  pre-serialized response blob map.
- `type ShardedCache = Arc<Vec<RwLock<ResponseCache>>>;` — the per-shard RwLock vector
  whose declaration tripped the lint.

This satisfies the lint without an `#[allow(...)]` and makes the types self-documenting.
Pure bench-spike refactor: **no behaviour change, no public API, no privacy surface.**

## Out of scope (sq-i9ck)

The sibling drifted bins `snapshot_spike` / `writer_spike` / `update_stream_spike`
still fail `--all-targets` against the current `sparq-server` API (`AppState::snapshot`,
`ServerConfig::compact_every`). Those are explicitly scoped to sq-i9ck, not this bead.

## Gate

- `cargo build --bin cache_spike` — clean, **no warnings** (the previously-emitted
  `dead_code` on the aliases is gone now that they are used).
- `cargo clippy --bin cache_spike -- -D warnings` (dev + `--profile test`) — clean;
  the `type_complexity` error is resolved.
- Bin runs to completion and produces the same measurement series as before.
- rustfmt: my added lines are already canonical; I deliberately did **not** reformat
  the rest of the file (pre-existing drift in this non-fmt-gated detached workspace is
  out of scope for this bead).
- Privacy-claims gate: N/A — no privacy/predicate-form/soundness surface touched.
- G2 public-API → SKILL.md: N/A — this is a `[[bin]]` research spike, no library API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)