### PR TITLE
feat(sparq-shacl): emit sh:detail per-member/per-duplicate sub-results for sh:memberShape/sh:uniqueMembers (sq-f8gu) [OPUS-4.8]

### DIFF
--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -108,7 +108,11 @@ member of a SHACL-list value node conforms to a shape), `sh:uniqueMembers`
 (members pairwise distinct), `sh:minListLength`/`sh:maxListLength` (member-count
 bounds), `sh:uniqueValuesFor` (the values of one property — or a SHACL list of
 properties, a composite key — are unique across the shape's target nodes). Each
-also reports when a value node is not a well-formed SHACL list.
+also reports when a value node is not a well-formed SHACL list. `sh:memberShape`
+and `sh:uniqueMembers` additionally attach non-normative `sh:detail` sub-results
+to the top-level violation (sq-f8gu): one detail per non-conforming member (the
+member-shape results) / per duplicated member. `sh:detail` never affects
+`sh:conforms` (the W3C suite compares only top-level result fields).
 
 **SHACL-SPARQL:** `sh:sparql` (the SPARQL-based constraint component, §5.2) —
 the `sh:select` runs per focus node with `$this` pre-bound (and `$PATH` on

--- a/crates/sparq-shacl/src/eval.rs
+++ b/crates/sparq-shacl/src/eval.rs
@@ -137,6 +137,23 @@ impl<'a> Validator<'a> {
         ok
     }
 
+    /// [OPUS-4.8] (sq-f8gu) Validate `node` against shape `sid` and RETURN the
+    /// results produced (rather than the `conforms` boolean), under the same
+    /// recursion guard. Used to collect `sh:memberShape` per-member `sh:detail`
+    /// sub-results. Re-entry of an in-progress `(node, shape)` pair yields no
+    /// results (the cycle is treated as conforming, exactly as `conforms` does),
+    /// so a cyclic member never recurses unboundedly.
+    fn member_details(&mut self, node: &Term, sid: usize) -> Vec<ValidationResult> {
+        if self.stack.iter().any(|(n, s)| n == node && *s == sid) {
+            return Vec::new();
+        }
+        self.stack.push((node.clone(), sid));
+        let mut tmp = Vec::new();
+        self.validate_shape(sid, node, &mut tmp);
+        self.stack.pop();
+        tmp
+    }
+
     fn validate_shape(&mut self, sid: usize, focus: &Term, out: &mut Vec<ValidationResult>) {
         let shape = &self.shapes.shapes[sid];
         if shape.deactivated {
@@ -171,6 +188,7 @@ impl<'a> Validator<'a> {
             severity: shape.severity.clone(),
             messages: shape.messages.clone(),
             default_message: message,
+            details: Vec::new(),
         }
     }
 
@@ -656,50 +674,81 @@ impl<'a> Validator<'a> {
             // [OPUS-4.8] (sq-vg3y) `sh:memberShape` (SHACL-1.2): each value node must
             // be a well-formed SHACL list whose members all conform to `member`. A
             // non-list (or member non-conformance) is ONE top-level result on the
-            // value node (the per-member `sh:detail`s are non-normative; the W3C
-            // suite compares only top-level result fields).
+            // value node. (sq-f8gu) That top-level result carries one `sh:detail`
+            // sub-result PER non-conforming member — the actual results of
+            // validating that member against the member shape. `sh:detail` is
+            // non-normative (the W3C suite compares only top-level result fields),
+            // so a non-list value (no members to validate) carries no details.
             Component::MemberShape(member) => {
                 for v in values {
-                    let violates = match self.data.list_strict(v) {
-                        None => true, // not a SHACL list
-                        Some(members) => members.iter().any(|m| !self.conforms(m, *member)),
+                    let members = self.data.list_strict(v);
+                    // Collect per-member sub-results before any top-level push, so
+                    // the borrow of `self` for `member_details` is released first.
+                    let details: Vec<ValidationResult> = match &members {
+                        None => Vec::new(), // not a SHACL list — no members
+                        Some(ms) => ms
+                            .iter()
+                            .flat_map(|m| self.member_details(m, *member))
+                            .collect(),
                     };
-                    if violates {
-                        out.push(
-                            self.result(
-                                sid,
-                                focus,
-                                Some(v.clone()),
-                                "MemberShapeConstraintComponent",
-                                "List value is not a well-formed SHACL list, or a member \
+                    // Violation iff the value is not a well-formed list, or any
+                    // member produced a (detail) result.
+                    if members.is_none() || !details.is_empty() {
+                        let mut r = self.result(
+                            sid,
+                            focus,
+                            Some(v.clone()),
+                            "MemberShapeConstraintComponent",
+                            "List value is not a well-formed SHACL list, or a member \
                              does not conform to the member shape"
-                                    .into(),
-                            ),
+                                .into(),
                         );
+                        r.details = details;
+                        out.push(r);
                     }
                 }
             }
             // [OPUS-4.8] (sq-vg3y) `sh:uniqueMembers true` (SHACL-1.2): each value
             // node must be a SHACL list whose members are pairwise distinct. A
             // non-list, or a list with duplicate members, is one result on v.
+            // (sq-f8gu) A duplicate-bearing list carries one `sh:detail` sub-result
+            // per DUPLICATED member (each duplicated value reported once via
+            // `sh:value`); a non-list value carries no details.
             Component::UniqueMembers => {
                 for v in values {
-                    let violates = match self.data.list_strict(v) {
-                        None => true,
-                        Some(members) => crate::view::dedup(members.clone()).len() != members.len(),
+                    let members = self.data.list_strict(v);
+                    let duplicates: Vec<Term> = match &members {
+                        None => Vec::new(),
+                        Some(ms) => duplicate_members(ms),
                     };
-                    if violates {
-                        out.push(
-                            self.result(
-                                sid,
-                                focus,
-                                Some(v.clone()),
-                                "UniqueMembersConstraintComponent",
-                                "List value is not a well-formed SHACL list, or has \
+                    if members.is_none() || !duplicates.is_empty() {
+                        let mut r = self.result(
+                            sid,
+                            focus,
+                            Some(v.clone()),
+                            "UniqueMembersConstraintComponent",
+                            "List value is not a well-formed SHACL list, or has \
                              duplicate members"
-                                    .into(),
-                            ),
+                                .into(),
                         );
+                        r.details = duplicates
+                            .into_iter()
+                            .map(|d| {
+                                let mut detail = self.result(
+                                    sid,
+                                    focus,
+                                    Some(d),
+                                    "UniqueMembersConstraintComponent",
+                                    "List member is not unique".into(),
+                                );
+                                // The detail's path is the member, not the parent
+                                // shape's path — clear it to avoid a misleading
+                                // sh:resultPath on the sub-result.
+                                detail.path = None;
+                                detail
+                            })
+                            .collect();
+                        out.push(r);
                     }
                 }
             }
@@ -870,6 +919,7 @@ impl<'a> Validator<'a> {
                 severity: severity.clone(),
                 messages: shape_messages.clone(),
                 default_message: fields.default_message,
+                details: Vec::new(),
             },
             out,
         );
@@ -952,6 +1002,7 @@ impl<'a> Validator<'a> {
                             severity: severity.clone(),
                             messages: shape_messages.clone(),
                             default_message,
+                            details: Vec::new(),
                         });
                     }
                 }
@@ -977,6 +1028,7 @@ impl<'a> Validator<'a> {
                         severity: severity.clone(),
                         messages: shape_messages.clone(),
                         default_message: fields.default_message,
+                        details: Vec::new(),
                     },
                     out,
                 );
@@ -1111,6 +1163,23 @@ impl<'a> Validator<'a> {
             })
             .clone()
     }
+}
+
+/// [OPUS-4.8] (sq-f8gu) The DISTINCT members of `members` that appear more than
+/// once (each duplicated value listed once, in first-seen order). Uses exact
+/// `Term` equality — the same notion `view::dedup` uses for the `sh:uniqueMembers`
+/// constraint itself — so the per-duplicate `sh:detail` sub-results agree exactly
+/// with the top-level violation decision.
+fn duplicate_members(members: &[Term]) -> Vec<Term> {
+    let mut seen: rustc_hash::FxHashSet<&Term> = rustc_hash::FxHashSet::default();
+    let mut reported: rustc_hash::FxHashSet<&Term> = rustc_hash::FxHashSet::default();
+    let mut out = Vec::new();
+    for m in members {
+        if !seen.insert(m) && reported.insert(m) {
+            out.push(m.clone());
+        }
+    }
+    out
 }
 
 /// [OPUS-4.8] (sq-vg3y) True iff value node `v` matches the single `sh:nodeKind`

--- a/crates/sparq-shacl/src/report.rs
+++ b/crates/sparq-shacl/src/report.rs
@@ -26,6 +26,14 @@ pub struct ValidationResult {
     pub messages: Vec<Term>,
     /// A generated message used when the shape declares none.
     pub default_message: String,
+    /// [OPUS-4.8] (sq-f8gu) Nested `sh:detail` sub-results explaining WHY this
+    /// result fired — currently the per-member (`sh:memberShape`) / per-duplicate
+    /// (`sh:uniqueMembers`) results produced by validating each offending list
+    /// member against the member shape. Empty for every other component. The
+    /// SHACL spec keeps `sh:detail` non-normative (the W3C suite compares only
+    /// top-level result fields), so these are informational and never affect
+    /// `sh:conforms`.
+    pub details: Vec<ValidationResult>,
 }
 
 /// The outcome of validating a data graph against a shapes graph.
@@ -75,27 +83,8 @@ impl ValidationReport {
         let _ = write!(out, "  sh:conforms {}", self.conforms);
         for r in &self.results {
             let _ = writeln!(out, " ;");
-            let _ = writeln!(out, "  sh:result [");
-            let _ = writeln!(out, "    a sh:ValidationResult ;");
-            let _ = writeln!(out, "    sh:focusNode {} ;", r.focus_node);
-            if let Some(p) = &r.path {
-                let _ = writeln!(out, "    sh:resultPath {} ;", p.to_turtle());
-            }
-            if let Some(v) = &r.value {
-                let _ = writeln!(out, "    sh:value {v} ;");
-            }
-            // A blank-node source shape has no graph-independent identity; emit
-            // its label so the report stays self-consistent and parseable.
-            let _ = writeln!(out, "    sh:sourceShape {} ;", r.source_shape);
-            for m in r.effective_messages() {
-                let _ = writeln!(out, "    sh:resultMessage {m} ;");
-            }
-            let _ = writeln!(out, "    sh:resultSeverity <{}> ;", r.severity);
-            let _ = write!(
-                out,
-                "    sh:sourceConstraintComponent <{}> ]",
-                r.source_component
-            );
+            let _ = write!(out, "  sh:result ");
+            write_result_node(&mut out, r);
         }
         let _ = writeln!(out, " .");
         out
@@ -126,9 +115,55 @@ impl ValidationReport {
                 _ => r.default_message.clone(),
             };
             let _ = writeln!(out, "\n    {comp}: {msg}");
+            // [OPUS-4.8] (sq-f8gu) Render nested sh:detail sub-results, indented.
+            for d in &r.details {
+                let dcomp = d
+                    .source_component
+                    .rsplit(['#', '/'])
+                    .next()
+                    .unwrap_or(&d.source_component);
+                let _ = write!(out, "      detail: {dcomp}");
+                if let Some(v) = &d.value {
+                    let _ = write!(out, " | value {v}");
+                }
+                let _ = writeln!(out);
+            }
         }
         out
     }
+}
+
+/// [OPUS-4.8] (sq-f8gu) Writes one `sh:ValidationResult` as an anonymous
+/// blank-node block, recursively nesting `sh:detail` sub-results. Emitted as a
+/// continuation of an already-written predicate (`sh:result ` / `sh:detail `),
+/// and closed with `]` (no trailing `.` — the caller owns statement framing).
+fn write_result_node(out: &mut String, r: &ValidationResult) {
+    let _ = writeln!(out, "[");
+    let _ = writeln!(out, "    a sh:ValidationResult ;");
+    let _ = writeln!(out, "    sh:focusNode {} ;", r.focus_node);
+    if let Some(p) = &r.path {
+        let _ = writeln!(out, "    sh:resultPath {} ;", p.to_turtle());
+    }
+    if let Some(v) = &r.value {
+        let _ = writeln!(out, "    sh:value {v} ;");
+    }
+    // A blank-node source shape has no graph-independent identity; emit its
+    // label so the report stays self-consistent and parseable.
+    let _ = writeln!(out, "    sh:sourceShape {} ;", r.source_shape);
+    for m in r.effective_messages() {
+        let _ = writeln!(out, "    sh:resultMessage {m} ;");
+    }
+    let _ = writeln!(out, "    sh:resultSeverity <{}> ;", r.severity);
+    for d in &r.details {
+        let _ = write!(out, "    sh:detail ");
+        write_result_node(out, d);
+        let _ = writeln!(out, " ;");
+    }
+    let _ = write!(
+        out,
+        "    sh:sourceConstraintComponent <{}> ]",
+        r.source_component
+    );
 }
 
 impl ValidationResult {
@@ -184,6 +219,7 @@ mod tests {
             severity: format!("{SH}{severity}"),
             messages,
             default_message: "generated default".into(),
+            details: Vec::new(),
         }
     }
 
@@ -351,6 +387,68 @@ mod tests {
         let m = with_msg.effective_messages();
         assert_eq!(m.len(), 2);
         assert_eq!(m, vec![lit("m1"), lit("m2")]);
+    }
+
+    // [OPUS-4.8] (sq-f8gu) A result carrying sh:detail sub-results nests each as a
+    // sh:ValidationResult blank node under sh:detail; both Turtle and text render
+    // them, and the Turtle round-trips.
+    #[test]
+    fn turtle_and_text_nest_detail_sub_results() {
+        let mut top = result(
+            iri(&format!("{EX}list")),
+            None,
+            Some(iri(&format!("{EX}list"))),
+            "MemberShapeConstraintComponent",
+            "Violation",
+            vec![],
+        );
+        top.details = vec![
+            result(
+                iri(&format!("{EX}list")),
+                None,
+                Some(lit("bad1")),
+                "NodeKindConstraintComponent",
+                "Violation",
+                vec![],
+            ),
+            result(
+                iri(&format!("{EX}list")),
+                None,
+                Some(lit("bad2")),
+                "NodeKindConstraintComponent",
+                "Violation",
+                vec![],
+            ),
+        ];
+        let r = ValidationReport::new(vec![top]);
+        let ttl = r.to_turtle();
+        assert!(ttl.contains("sh:detail"), "{ttl}");
+        let triples = parse_report(&ttl);
+        // Two sh:detail links, and three sh:ValidationResult nodes (top + 2 details).
+        assert_eq!(
+            triples
+                .iter()
+                .filter(|t| t.predicate.as_str().ends_with("#detail"))
+                .count(),
+            2,
+            "{ttl}"
+        );
+        assert_eq!(
+            triples
+                .iter()
+                .filter(|t| t.predicate.as_str().ends_with("#type")
+                    && t.object.to_string().ends_with("ValidationResult>"))
+                .count(),
+            3,
+            "{ttl}"
+        );
+        // The text rendering surfaces the nested details.
+        let text = r.to_text();
+        assert_eq!(
+            text.matches("detail: NodeKindConstraintComponent").count(),
+            2,
+            "{text}"
+        );
     }
 
     #[test]

--- a/crates/sparq-shacl/tests/constraints.rs
+++ b/crates/sparq-shacl/tests/constraints.rs
@@ -670,6 +670,86 @@ fn member_shape_checks_each_list_member() {
     assert_eq!(count_component(&r, "MemberShapeConstraintComponent"), 2);
 }
 
+// [OPUS-4.8] (sq-f8gu) sh:memberShape emits one sh:detail sub-result per
+// NON-CONFORMING member: the actual validation results of validating that member
+// against the member shape. A non-list value node carries NO details (there are
+// no members to validate against the shape).
+#[test]
+fn member_shape_emits_detail_per_failing_member() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:list, ex:notAList ;
+          sh:memberShape [ sh:nodeKind sh:IRI ] .
+    "#;
+    // ex:list = ( ex:ok "bad1" "bad2" ): one IRI member (ok) and two literal
+    // members (each violates sh:nodeKind sh:IRI).
+    let data = r#"
+        ex:list rdf:first ex:ok ; rdf:rest ( "bad1" "bad2" ) .
+        ex:notAList ex:p 0 .
+    "#;
+    let r = run(data, shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+
+    let top: Vec<_> = r
+        .results
+        .iter()
+        .filter(|x| {
+            x.source_component
+                .ends_with("MemberShapeConstraintComponent")
+        })
+        .collect();
+    assert_eq!(top.len(), 2, "{}", r.to_text());
+
+    // The list result carries two details (one per failing member); each detail
+    // is a NodeKind violation whose sh:value is the offending literal.
+    let list_result = top
+        .iter()
+        .find(|x| {
+            x.value
+                .as_ref()
+                .map(std::string::ToString::to_string)
+                .as_deref()
+                == Some("<http://example.org/list>")
+        })
+        .expect("a result on ex:list");
+    assert_eq!(list_result.details.len(), 2, "{}", r.to_text());
+    assert!(list_result
+        .details
+        .iter()
+        .all(|d| d.source_component.ends_with("NodeKindConstraintComponent")));
+    let mut detail_vals: Vec<String> = list_result
+        .details
+        .iter()
+        .filter_map(|d| d.value.as_ref().map(std::string::ToString::to_string))
+        .collect();
+    detail_vals.sort();
+    assert_eq!(
+        detail_vals,
+        vec![r#""bad1""#.to_string(), r#""bad2""#.to_string()]
+    );
+
+    // The non-list value node carries no details.
+    let notalist = top
+        .iter()
+        .find(|x| {
+            x.value
+                .as_ref()
+                .map(std::string::ToString::to_string)
+                .as_deref()
+                == Some("<http://example.org/notAList>")
+        })
+        .expect("a result on ex:notAList");
+    assert!(notalist.details.is_empty(), "{}", r.to_text());
+
+    // sh:detail must surface in the Turtle report and round-trip as valid Turtle.
+    let ttl = r.to_turtle();
+    assert!(ttl.contains("sh:detail"), "no sh:detail in report: {ttl}");
+    oxttl::TurtleParser::new()
+        .for_slice(ttl.as_bytes())
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap_or_else(|e| panic!("report Turtle does not parse: {e}\n{ttl}"));
+}
+
 // ---- sh:uniqueMembers ----
 
 #[test]
@@ -688,6 +768,69 @@ fn unique_members_flags_duplicate_and_nonlist() {
     assert!(!r.conforms, "{}", r.to_text());
     // ex:dup (duplicate 1) + ex:notAList (not a list) -> two results; ex:uniq ok.
     assert_eq!(count_component(&r, "UniqueMembersConstraintComponent"), 2);
+}
+
+// [OPUS-4.8] (sq-f8gu) sh:uniqueMembers emits one sh:detail sub-result per
+// DUPLICATED member (each duplicated value reported once via sh:value), and a
+// non-list value node carries no details.
+#[test]
+fn unique_members_emits_detail_per_duplicate() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:dup, ex:notAList ;
+          sh:uniqueMembers true .
+    "#;
+    // ex:dup = ( 1 2 1 3 2 ): members 1 and 2 each appear twice -> two duplicates.
+    let data = r#"
+        ex:dup rdf:first 1 ; rdf:rest ( 2 1 3 2 ) .
+        ex:notAList ex:p 0 .
+    "#;
+    let r = run(data, shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+
+    let dup_result = r
+        .results
+        .iter()
+        .find(|x| {
+            x.source_component
+                .ends_with("UniqueMembersConstraintComponent")
+                && x.value
+                    .as_ref()
+                    .map(std::string::ToString::to_string)
+                    .as_deref()
+                    == Some("<http://example.org/dup>")
+        })
+        .expect("a result on ex:dup");
+    // One detail per duplicated value (1 and 2), each carrying that value.
+    assert_eq!(dup_result.details.len(), 2, "{}", r.to_text());
+    let mut detail_vals: Vec<String> = dup_result
+        .details
+        .iter()
+        .filter_map(|d| d.value.as_ref().map(std::string::ToString::to_string))
+        .collect();
+    detail_vals.sort();
+    assert_eq!(
+        detail_vals,
+        vec![
+            r#""1"^^<http://www.w3.org/2001/XMLSchema#integer>"#.to_string(),
+            r#""2"^^<http://www.w3.org/2001/XMLSchema#integer>"#.to_string(),
+        ]
+    );
+
+    let notalist = r
+        .results
+        .iter()
+        .find(|x| {
+            x.source_component
+                .ends_with("UniqueMembersConstraintComponent")
+                && x.value
+                    .as_ref()
+                    .map(std::string::ToString::to_string)
+                    .as_deref()
+                    == Some("<http://example.org/notAList>")
+        })
+        .expect("a result on ex:notAList");
+    assert!(notalist.details.is_empty(), "{}", r.to_text());
 }
 
 // ---- sh:maxListLength / sh:minListLength ----

--- a/crates/sparq-shacl/tests/diff_fuzz.rs
+++ b/crates/sparq-shacl/tests/diff_fuzz.rs
@@ -485,6 +485,7 @@ fn key_normalisation_is_consistent() {
             severity: "http://www.w3.org/ns/shacl#Violation".into(),
             messages: vec![],
             default_message: String::new(),
+            details: vec![],
         }],
     };
     let sk = sparq_keys(&report);

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -107,8 +107,18 @@ pub source_component: String;               // constraint-component IRI, e.g. ".
 pub severity: String;                       // severity IRI (default ".../shacl#Violation")
 pub messages: Vec<oxrdf::Term>;             // sh:message literals
 pub default_message: String;
+pub details: Vec<ValidationResult>;         // nested sh:detail sub-results (see below); empty for most components
 pub fn effective_messages(&self) -> Vec<oxrdf::Term>;   // messages, or a generated default
 ```
+
+`details` carries non-normative `sh:detail` sub-results that explain WHY a result
+fired: a `sh:memberShape` violation lists one sub-result per non-conforming list
+member (the actual results of validating that member against the member shape),
+and a `sh:uniqueMembers` violation lists one sub-result per duplicated member
+(`sh:value` = the duplicated term). `sh:detail` is non-normative — it never
+affects `sh:conforms` and the W3C suite compares only top-level result fields —
+so it is empty for every other component. `to_turtle` nests each detail as a
+`sh:ValidationResult` blank node under `sh:detail`; `to_text` indents them.
 
 `Path` (`sparq_shacl::Path`) — `Predicate | Inverse | Sequence | Alternative |
 ZeroOrMore | OneOrMore | ZeroOrOne`; `path.to_turtle()` gives the Turtle path


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-f8gu** (sq-vg3y follow-up).

## What

`sh:memberShape` and `sh:uniqueMembers` (the SHACL-1.2 list constraints landed in #533 / sq-vg3y) previously reported a single top-level result per offending value node. They now additionally attach **non-normative `sh:detail` sub-results** explaining *why* the value failed:

- **`sh:memberShape`** — one `sh:detail` per **non-conforming member**: the actual validation results of validating that member against the member shape. Runs via a new `Validator::member_details` under the same recursion guard as `conforms()`, so a cyclic member can't recurse unboundedly. A non-list value node carries no details (there are no members to validate).
- **`sh:uniqueMembers`** — one `sh:detail` per **duplicated member** (each duplicated value reported once via `sh:value`), using a new `duplicate_members()` helper with the exact `Term`-equality semantics `view::dedup` uses for the constraint decision itself. A non-list value carries no details.

`ValidationResult` gains a public `details: Vec<ValidationResult>` field. `report.to_turtle()` recursively nests each detail as a `sh:ValidationResult` blank node under `sh:detail` (round-trips as valid Turtle); `to_text()` indents them.

## Why this is sound / in scope

`sh:detail` is **non-normative**: it never affects `sh:conforms`, and the W3C suite compares only top-level result fields. The bead's own title notes "W3C suite only checks top-level so out of v1 scope" — this PR adds the informational sub-results without touching top-level conformance. Verified: the W3C SHACL-1.2 core/node suite is unchanged (**45/45 PASS**, core suite **98/98**), including `memberShape-001` and `uniqueMembers-001`.

## Tests (TDD red→green)

- `tests/constraints.rs`: `member_shape_emits_detail_per_failing_member` and `unique_members_emits_detail_per_duplicate` — assert per-member / per-duplicate detail counts, the offending `sh:value`s, that a non-list value carries no details, and that `sh:detail` surfaces in the Turtle report and round-trips.
- `src/report.rs`: a direct report-serialisation unit test for the nested `sh:detail` blank-node rendering (Turtle + text).

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + `cargo test` — green in **both** feature states (default and `shacl-af`).
- privacy-claims gate (predicate-form soundness): PASS. no-perf-numbers + G2 public-api→SKILL gates: PASS (SKILL.md updated for the new field).

## Docs

Crate README + `skills/shacl-validation/SKILL.md` document the new `details` field and the per-member / per-duplicate behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
