### PR TITLE
docs(bench/serve): drop unmeasured ~10-20ns figure from pss_update_throughput comment (sq-dpcg) [OPUS-4.8]

### DIFF
--- a/bench/serve/src/bin/pss_update_throughput.rs
+++ b/bench/serve/src/bin/pss_update_throughput.rs
@@ -330,7 +330,7 @@ fn main() {
                 let b = QueryBudget::unlimited();
                 let mut n = 0u64;
                 while !stop.load(Ordering::Relaxed) {
-                    // Pin the current generation (lock-free ~10–20ns); never blocked by the
+                    // Pin the current generation (lock-free atomic load); never blocked by the
                     // writer — the N-readers side of the contract.
                     let pin = st.current();
                     let g = pin.snapshot();


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Re-review when Fable returns (authored on Opus 4.8 while Fable 5 unavailable).

## What & why (sq-dpcg)

The concurrent-reader loop in `bench/serve/src/bin/pss_update_throughput.rs` carried an unmeasured performance estimate in a code comment:

```
// Pin the current generation (lock-free ~10–20ns); never blocked by the
// writer — the N-readers side of the contract.
```

The repo's no-perf-numbers hygiene gate **only scans markdown**, so this hard-coded `~10–20ns` figure in a `.rs` comment was never caught automatically — hence the manual bead. Per the no-hard-coded-perf spirit, this drops the invented nanosecond number and keeps only the load-bearing fact:

```
// Pin the current generation (lock-free atomic load); never blocked by the
// writer — the N-readers side of the contract.
```

Comment-only; runtime behaviour is unchanged.

## Scope note (honesty)

The same `~10–20ns` phrasing also appears in `bench/serve/src/bin/update_stream_spike.rs`, `crates/sparq-serve/Cargo.toml`, and `crates/sparq-server/src/http.rs`. Bead **sq-dpcg** is scoped to **this one file** (`pss_update_throughput.rs`), so this PR fixes only that occurrence to keep the change minimal and reviewable. The other sites are left as-is (not in this bead's scope).

## Gate

Standalone `serve-spikes` project (own `[workspace]`, no cargo features → no "both feature states" axis):

- `cargo build --bin pss_update_throughput` — green
- `cargo clippy --bin pss_update_throughput -- -D warnings` — clean
- `cargo test --bin pss_update_throughput` — passes (0 tests; no test regression)
- Privacy-claims gate: N/A — non-ZK benchmark comment, no predicate-form soundness statements touched
- G2 public-API → SKILL.md: N/A — no public API changed

(Pre-existing, unrelated `clippy::type_complexity` error in the sibling `cache_spike.rs` binary is present on clean `origin/main` and is out of scope for this bead.)

Closes sq-dpcg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)