### PR TITLE
test(sparq-engine): assert SPARQL parse-depth bound at engine seam + 1 MiB body cap (sq-1ukn, ASVS V5.5.2) [OPUS-4.8]

### DIFF
--- a/crates/sparq-engine/tests/parse_recursion_depth.rs
+++ b/crates/sparq-engine/tests/parse_recursion_depth.rs
@@ -1,0 +1,144 @@
+//! [OPUS-4.8] Engine-level regression for the SPARQL parse-depth bound
+//! (bead sq-1ukn, cert gap ASVS-G4 / ASVS V5.5.2; threat-model boundary B2,
+//! T-PARSE-DoS).
+//!
+//! `spargebra` is a `peg` recursive-descent parser: each level of `{ }` / `( )` /
+//! `[ ]` / `<<( )>>` syntactic nesting (group graph patterns, sub-SELECTs,
+//! bracketed/unary expressions, property paths, RDF collections, blank-node
+//! property lists, RDF-1.2 triple terms) maps onto native call-stack frames. The
+//! vendored crate already caps that recursion (`MAX_RECURSION_DEPTH`, bead
+//! sq-v5dg) and `vendor/spargebra/tests/recursion_depth.rs` proves the cap fires
+//! at the `SparqlParser` layer. THIS file pins the same guarantee at the seam the
+//! cert gap actually names — `sparq_engine::PreparedQuery::parse`, through which
+//! every string query entry point (`query` / `ask` / `count` / `construct` / …)
+//! funnels — and at the concrete attack envelope the bead calls out: a request
+//! body filled to the server's default `--max-body-bytes` cap (1 MiB, see
+//! `sparq_server::http` `ServerConfig::default`). Without the depth bound, that
+//! body of nested delimiters would deep-recurse the parser until the native stack
+//! overflows and ABORTS the process — an unauthenticated DoS. With it, the parse
+//! returns a clean `Err` and the body cap is the only thing standing between an
+//! attacker and the parser.
+//!
+//! Each case parses on a deliberately small 2 MiB thread stack — the size of a
+//! tokio worker / blocking-pool thread, where the server actually parses (NOT the
+//! larger main-thread `ulimit -s`). A stack overflow there aborts the whole test
+//! process (SIGABRT), so reaching the `join()` at all is itself part of the
+//! assertion: the parser must have RETURNED, not recursed to death.
+
+use sparq_engine::PreparedQuery;
+
+/// The server's default request-body cap (`sparq_server::http` `ServerConfig`:
+/// `max_body_bytes: 1024 * 1024`). A query string up to this length is exactly
+/// what an unauthenticated client can push at the parser, so the depth guard must
+/// hold for a body of nested delimiters filled right to this cap.
+const BODY_CAP: usize = 1024 * 1024;
+
+/// Run `f` on a 2 MiB stack (tokio's default worker/blocking-pool stack). A stack
+/// overflow there aborts the process, so reaching the `join()` at all proves the
+/// parser returned rather than recursing past the native stack.
+fn on_small_stack<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    std::thread::Builder::new()
+        .stack_size(2 * 1024 * 1024)
+        .spawn(f)
+        .expect("spawn 2 MiB-stack thread")
+        .join()
+        .expect("parser thread must return, not overflow the stack")
+}
+
+/// Build a query whose `WHERE` clause is `open`-then-`close` delimiters nested
+/// `depth` levels deep around `?s ?p ?o`, padded so the whole string is as close
+/// to (but not over) `BODY_CAP` as the delimiter count allows.
+fn deeply_nested_where(open: char, close: char, depth: usize) -> String {
+    let mut q = String::with_capacity(depth * 2 + 32);
+    q.push_str("SELECT * WHERE ");
+    for _ in 0..depth {
+        q.push(open);
+    }
+    q.push_str(" ?s ?p ?o ");
+    for _ in 0..depth {
+        q.push(close);
+    }
+    q
+}
+
+/// A 1 MiB body that is *entirely* nested group graph patterns — the maximal
+/// recursion a default server will admit — must come back as a clean parse `Err`
+/// and must NOT overflow the 2 MiB parse stack. This is the headline cert
+/// assertion: it exercises `PreparedQuery::parse` (the engine seam every string
+/// query funnels through) at the exact `--max-body-bytes` envelope.
+#[test]
+fn body_cap_nested_groups_is_clean_err_not_overflow() {
+    let result = on_small_stack(|| {
+        // Half the budget for '{', half for '}', leaving the "SELECT * WHERE "
+        // prefix and " ?s ?p ?o " infix headroom under the cap.
+        let depth = (BODY_CAP - 32) / 2;
+        let q = deeply_nested_where('{', '}', depth);
+        assert!(
+            q.len() <= BODY_CAP,
+            "test query must fit the body cap (got {} bytes)",
+            q.len()
+        );
+        PreparedQuery::parse(&q).is_err()
+    });
+    assert!(
+        result,
+        "a body-cap-sized stack of nested groups must parse to Err, never Ok"
+    );
+}
+
+/// Same envelope, bracketed-expression nesting (the FILTER expression axis is a
+/// distinct recursive production from group patterns and must be bounded too).
+#[test]
+fn body_cap_nested_expressions_is_clean_err_not_overflow() {
+    let result = on_small_stack(|| {
+        let depth = (BODY_CAP - 32) / 2;
+        let mut q = String::with_capacity(depth * 2 + 32);
+        q.push_str("SELECT * WHERE { FILTER(");
+        for _ in 0..depth {
+            q.push('(');
+        }
+        q.push('1');
+        for _ in 0..depth {
+            q.push(')');
+        }
+        q.push_str(") }");
+        assert!(
+            q.len() <= BODY_CAP + 16,
+            "test query must be near the body cap (got {} bytes)",
+            q.len()
+        );
+        PreparedQuery::parse(&q).is_err()
+    });
+    assert!(
+        result,
+        "a body-cap-sized stack of nested expressions must parse to Err, never Ok"
+    );
+}
+
+/// The depth error must surface as a clean `Err(String)` (the engine maps the
+/// parser's `SparqlSyntaxError` through `to_string()`), never a panic or abort.
+/// A modest-but-past-the-cap depth is enough to assert the wording without paying
+/// for a full 1 MiB allocation, and confirms `PreparedQuery::parse` propagates the
+/// guard's message rather than swallowing it.
+#[test]
+fn past_cap_depth_reports_too_deeply_nested() {
+    let q = deeply_nested_where('{', '}', 4000);
+    let err = PreparedQuery::parse(&q).expect_err("a 4000-deep group query must be rejected");
+    assert!(
+        err.contains("too deeply nested"),
+        "expected the recursion-depth message from the engine parse seam, got: {err}"
+    );
+}
+
+/// Positive control: a legitimately deep query (well under the cap, far deeper
+/// than any real-world or W3C-conformance query) must still parse through the
+/// engine seam. The guard must reject pathological nesting WITHOUT rejecting any
+/// query a real client would send.
+#[test]
+fn legitimately_deep_query_still_parses_through_engine() {
+    let q = deeply_nested_where('{', '}', 64);
+    assert!(
+        PreparedQuery::parse(&q).is_ok(),
+        "a 64-deep group query (within the cap) must still parse through PreparedQuery::parse"
+    );
+}

--- a/research/threat-model.md
+++ b/research/threat-model.md
@@ -283,14 +283,25 @@ with thousands of nested `(` or `{` recurses unbounded and **overflows the stack
 → process abort**. Reachable from the production entry `PreparedQuery::parse`
 (`crates/sparq-engine/src/lib.rs:380`) and hence the unauthenticated `/sparql`
 endpoint.
-*Existing mitigation:* **none in the parser.** A search of the vendored crate for
-`stacker`/`recursion`/`depth`/`set_max` finds no depth cap, no input-length cap,
-no stack-growth guard. The conformance harness wraps each parse in a 20s
-watchdog thread (`crates/sparq-conformance/src/run.rs:170-201`) — but that is
-**test-harness only** and does not protect production callers.
-*GAP:* add a recursion-depth / input-size cap (or `stacker`-style stack-growth
-guard) at the parse entry, and contribute it upstream per the vendoring policy.
-**Bead sq-v5dg** (new).
+*Mitigation (IMPLEMENTED — sq-v5dg):* the vendored parser now caps syntactic
+nesting at `MAX_RECURSION_DEPTH = 128` (`vendor/spargebra/src/parser.rs`):
+recursive productions call `enter_recursion`/`leave_recursion` around every
+nested delimiter (group graph patterns, sub-SELECTs, bracketed/unary
+expressions, property paths, RDF collections, blank-node property lists, RDF-1.2
+triple terms), and exceeding the cap returns a clean `TooDeeplyNested` syntax
+error (`SparqlSyntaxErrorKind::TooDeeplyNested`) instead of recursing until the
+native stack overflows. 128 is ~8× the deepest W3C conformance query yet leaves
+~30% headroom under the debug-build overflow point on the smallest (2 MiB tokio
+worker / blocking-pool) stack the server parses on. The conformance harness's 20s
+parse watchdog (`crates/sparq-conformance/src/run.rs:170-201`) remains as
+defence-in-depth but is no longer the only line.
+*Regression coverage:* `vendor/spargebra/tests/recursion_depth.rs` exercises every
+recursion axis on a 2 MiB stack (overflow there aborts the process, so a passing
+run *proves* graceful rejection); `crates/sparq-engine/tests/parse_recursion_depth.rs`
+pins the same guarantee at the production seam `PreparedQuery::parse` and at the
+default `--max-body-bytes` (1 MiB) request-body envelope (ASVS V5.5.2 / cert gap
+ASVS-G4, **bead sq-1ukn**). Upstreaming the cap to `oxigraph/spargebra` per the
+vendoring policy is tracked separately.
 
 **T-EXEC-DoS — Denial of service (pathological query: unbounded CPU / memory /
 result set).**
@@ -369,8 +380,10 @@ gating it. Beads: **sq-zcby** (write gate, done), **sq-o4qf** (bind posture),
 *GAP:* (i) **no rate limit** — a flood of distinct expensive-but-under-timeout
 queries within the concurrency window is unthrottled; (ii) `max_results`
 **defaults to unlimited**; (iii) **no query-complexity bound**; (iv) the parser
-stack-overflow (T-PARSE-DoS / sq-v5dg) is reachable here. Items (i)–(iii)
-→ **sq-ebii** + **sq-o4qf**; (iv) → **sq-v5dg**.
+stack-overflow (T-PARSE-DoS) was reachable here — now bounded by the
+`MAX_RECURSION_DEPTH` cap (sq-v5dg), with the engine-seam / body-cap assertion
+under sq-1ukn. Items (i)–(iii) → **sq-ebii** + **sq-o4qf**; (iv) → **sq-v5dg**
+(done) + **sq-1ukn** (cert assertion).
 
 **T-HTTP-INFO — Information disclosure (error messages).**
 *Mechanism:* an error response leaking filesystem paths, stack traces, or
@@ -454,7 +467,7 @@ Ordered by severity. Every gap maps to a bead (existing or new).
 | 1 | Non-UTF-8 dictionary blob → `from_utf8_unchecked` → **UB** on a hostile/corrupt store | **Critical** (UB) | B5 | Replace `from_utf8_unchecked` with checked `from_utf8`; validate `dict-offs.bin` length & every offset at open | **sq-znld** (new, P1) |
 | 2 | mmap loader unfuzzed against hostile/truncated files (the whole B5 surface incl. dict-spill & raw-perm sortedness, plus parser-robustness) | **High** | B5 / B1 | Add a fuzz target: corrupt/truncated/hostile store + hostile RDF/SPARQL bytes → must error, never UB/panic-loop; run under `--features dict-spill` | **sq-ky2a** (exists, P2) |
 | 3 | Compressed-perm header arithmetic overflow + unchecked block offsets/varints → panic / OOB-read | **High** | B5 | `checked_mul`/`checked_add` header math; bounds-check directory offsets and varint reads | **sq-ed2i** (new, P2) |
-| 4 | SPARQL parser stack-overflow on deeply-nested query → process abort | **High** | B2 | Recursion-depth / input-size cap (or `stacker`) at parse entry; contribute upstream | **sq-v5dg** (new, P2) |
+| 4 | SPARQL parser stack-overflow on deeply-nested query → process abort | **High** → mitigated | B2 | Recursion-depth cap (`MAX_RECURSION_DEPTH = 128`) at the parse productions returning a clean `TooDeeplyNested` error; engine-seam + 1 MiB body-cap regression assertion; upstream the cap | **sq-v5dg** (cap, done) + **sq-1ukn** (cert assertion, done) |
 | 5 | Server auth: write surface now has a Bearer-token gate (`--auth-token`, sq-zcby) + bind-posture refusal (sq-o4qf); RESIDUAL — `/subscriptions` WS not yet token-gated, no per-user authz, `max-results` unlimited, no rate limit / query-complexity bound | **Medium** (was High) | B3 / B2 | Gate the subscriptions WS (sq-cxk5); default-on rate limit + sensible `max-results`; document gateway expectation | **sq-zcby** (write gate, done) + **sq-o4qf** (bind, done) + **sq-cxk5** (WS, new) + **sq-ebii** (exists, P2) |
 | 6 | No documented/enforced server timeout-memory-decompression-SSRF policy; minor 500-error engine-internal disclosure; reason/SHACL materialization budgets | **Medium** | B3 / B1 | Write+enforce the DoS/SSRF policy doc; redact `{:?}` algebra from 500s; add reasoning/validation budgets when exposed to untrusted input | **sq-ebii** (exists, P2) |
 | 7 | SERVICE federation has zero SSRF egress filtering **if** the `service` feature is enabled | **Medium** (gated off by default) | B4 | Default-deny loopback/RFC1918/link-local/metadata; config allowlist; document the sharp edge | **sq-2v6f** (new, P2) |


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. @jeswr runs several agents on one account; this PR is from one of them.

## What & why

Bead **sq-1ukn** — `[cert][gap ASVS-G4]` *No explicit SPARQL parse-depth bound* (ASVS V5.5.2, recursive/deeply-nested input resistance).

The bead offered two remediation paths: **(a)** add an explicit nesting-depth guard, **OR** **(b)** add a fuzz/regression assertion confirming no stack overflow at the body cap.

Path **(a)** already landed on `main` — the vendored `spargebra` caps syntactic nesting at `MAX_RECURSION_DEPTH = 128` (bead **sq-v5dg**, `vendor/spargebra/src/parser.rs`), with axis-by-axis regression tests at the `SparqlParser` layer (`vendor/spargebra/tests/recursion_depth.rs`). Shipping another guard would be a no-op.

This PR completes path **(b)** at the seam the cert gap actually names — `sparq_engine::PreparedQuery::parse`, the parse-once entry every string query funnels through — and at the concrete attack envelope the bead calls out: a request body filled to the server's **default `--max-body-bytes` cap (1 MiB)**.

## Changes

**`crates/sparq-engine/tests/parse_recursion_depth.rs`** (new) — all cases parse on a deliberately small **2 MiB stack** (tokio worker / blocking-pool size, where the server actually parses; overflow there aborts the process, so reaching `join()` is itself the assertion):
- `body_cap_nested_groups_is_clean_err_not_overflow` — a **full 1 MiB body** of nested group graph patterns → clean `Err`, no overflow (headline cert assertion).
- `body_cap_nested_expressions_is_clean_err_not_overflow` — same envelope, the bracketed-expression recursion axis.
- `past_cap_depth_reports_too_deeply_nested` — the depth error propagates through `PreparedQuery::parse` as a clean `Err(String)` (`"too deeply nested"`).
- `legitimately_deep_query_still_parses_through_engine` — positive control: 64-deep nesting (within the cap) still parses, so the guard rejects no realistic query.

**`research/threat-model.md`** — **T-PARSE-DoS** marked IMPLEMENTED (was an open *GAP* citing sq-v5dg as future work): documents the cap, the regression coverage at both the spargebra and engine seams, and updates risk-register row 4 / the §B2 surface note.

## Honesty note

This is the **assertion / documentation** half of the bead; the runtime guard itself was already implemented by sq-v5dg. I did not re-ship the guard. Empirically verified the guard holds at the full 1 MiB envelope through the engine seam on a 2 MiB stack before writing the test (returns `Err` in ~0.02s, no overflow).

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + full `cargo test -p sparq-engine` — green in **both** feature states (`default` and `--no-default-features`).
- `scripts/check-privacy-claims.sh` — OK (no privacy/ZK surface touched).
- `scripts/gate-api-skill.py` (G2) — PASS, no public API surface changed (test + docs only).
- `rustfmt` clean on the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)