### PR TITLE
feat(sparq-fedclient): native HTTP FragmentTransport + wire TPF/brTPF into interpreter (sq-yzca)

### DIFF
--- a/crates/sparq-fedclient/README.md
+++ b/crates/sparq-fedclient/README.md
@@ -89,9 +89,40 @@ A fragment server speaks triples, not SPARQL-Results-JSON, so the adapters answe
 the typed `solutions(...)` methods; their `FederatedSource::execute` (the SRJ entry point)
 is a deliberate `Unsupported` that points the caller at `solutions` — no lossy SRJ
 re-serialisation, no overclaim. The adapters are tested against an in-memory fixture
-fragment server (real fetch → parse → bind → paginate → bind-join, zero network); the
-native HTTP `FragmentTransport` (ureq + the default-deny SSRF resolver, Hydra URI-template
-serialisation, Turtle/TriG fragment parsing) lands with the streaming phase.
+fragment server (real fetch → parse → bind → paginate → bind-join, zero network).
+
+### Native HTTP `FragmentTransport` + interpreter wiring (`sq-yzca`)
+
+The production `FragmentTransport` is `HttpFragmentTransport` (native-only — ureq + its TLS
+stack never enter the wasm bundle): a blocking GET behind the **same default-deny SSRF
+resolver** as the SRJ `HttpTransport` (the resolved-and-vetted IP is the dialled IP — no
+DNS-rebinding re-resolve window). It does the four pieces a fragment client needs:
+
+- **Hydra URI-template serialisation** — a `FragPattern` becomes the TPF query string the
+  sparq server reads (`?subject=&predicate=&object=`, each bound position percent-encoded as
+  an N-Triples term; a variable position is omitted).
+- **brTPF binding block** — a non-empty binding set rides the `values` parameter using the
+  server's text wire (`wire::encode_bindings_text`), so the server returns only triples that
+  join at least one attached mapping.
+- **Pagination** — the next-page token is the opaque `hydra:next` URL the server published;
+  the transport GETs it verbatim, so following pagination to exhaustion is "GET `hydra:next`
+  until there is none".
+- **Turtle/TriG fragment-body parse** — the response is parsed with oxttl's TriG parser (a
+  Turtle superset), splitting the **control** triples (`hydra:totalItems` / `void:triples` →
+  the count; `hydra:next` → the next-page link) from the **data** triples (kept only when they
+  actually match the requested pattern, so a control triple can never be mistaken for a match,
+  nor a misbehaving server smuggle a non-matching triple). A malformed body is a clean
+  transport-error string, never a panic.
+
+The interpreter (`operators` module) is wired to this: a `JoinTree` leaf that resolves to a
+TPF/brTPF source is **answered** — `fetch_leaf_relation` dispatches on the source's interface,
+routing an endpoint/local leaf to the SRJ `execute` path and a TPF/brTPF leaf to the typed
+`solutions` path (lowered via `lower_leaf_fragment`), converting the `FragBinding` rows back to
+the engine's `oxrdf::Term` model so a fragment leaf equi-joins with an endpoint leaf. (A brTPF
+leaf is currently executed as a complete unbound scan that the interpreter hash-joins locally —
+the same discipline the Phase-3 interpreter applies to a planner `JoinAlgo::Bind`; the streamed
+per-block bind-join feeder is a later phase.) Both the materialised and the streaming
+interpreters share that dispatch.
 
 ### brTPF binding-block wire encodings (`wire` module, `sq-6ihg`)
 
@@ -113,10 +144,12 @@ wire cannot carry on a single line. A 4-byte magic + version header makes a futu
 detectable, and the decoder validates every length so a truncated / corrupt buffer is a clean
 `WireError`, never a panic (the crate is `forbid(unsafe_code)`).
 
-This is a **codec only**: the native HTTP `FragmentTransport` that picks a wire by content
-negotiation and attaches it as the request body / `values` parameter lands with the streaming
-HTTP phase (same as the adapters above). The text form matches the server's `parse_bindings`
-grammar byte-for-byte, so a client emitting either wire is understood by the existing server.
+This `wire` module is a **codec only**. The native HTTP `FragmentTransport`
+(`HttpFragmentTransport`, `sq-yzca`) attaches the **text** form on the `values` query
+parameter (the carrier the sparq server reads on a `GET /tpf`); the compact binary wire here
+is the alternative a body-carrying transport (or a future content-negotiated one) emits. The
+text form matches the server's `parse_bindings` grammar byte-for-byte, so a client emitting
+either wire is understood by the existing server.
 
 ## Capability-aware pushdown (Phase 4, `pushdown` module)
 

--- a/crates/sparq-fedclient/src/lib.rs
+++ b/crates/sparq-fedclient/src/lib.rs
@@ -56,7 +56,14 @@ the same default-OFF `fedclient` feature:
   [`wire`] module (bead `sq-6ihg`) adds the brTPF binding-block transport encodings — a COMPACT
   self-describing BINARY mapping wire ([`encode_bindings`] / [`decode_bindings`]) alongside the
   line-oriented TEXT wire the server parses ([`encode_bindings_text`]), so a large bind-join
-  block travels compactly and losslessly and the client can speak either form.
+  block travels compactly and losslessly and the client can speak either form. The **native
+  HTTP** [`FragmentTransport`](source::FragmentTransport) ([`HttpFragmentTransport`], bead
+  `sq-yzca`) is the production seam — ureq + the same default-deny SSRF resolver, Hydra
+  URI-template serialisation (`?subject=&predicate=&object=` + the brTPF `values` block),
+  `hydra:next` pagination, and a Turtle/TriG fragment-body parse that splits the Hydra/VoID
+  control triples from the data triples — and the [`operators`] interpreter is wired to answer
+  a `JoinTree` leaf resolving to a TPF/brTPF source through its typed `solutions` path (via
+  [`lower_leaf_fragment`]) rather than the SRJ `execute` a fragment server refuses.
 
 * **Phase 7 — adaptive re-planning** (the `adaptive` module, bead `sq-ij5x`, the FINAL
   phase): the opt-in feedback loop that re-invokes [`sparq-fedplan`](sparq_fedplan)'s planner
@@ -159,6 +166,12 @@ pub use source::{
 // the guard-vetted IP IS the dialled IP (no DNS-rebinding re-resolve window).
 #[cfg(all(feature = "fedclient", not(target_arch = "wasm32")))]
 pub use source::HttpTransport;
+// [OPUS-4.8] sq-yzca: re-export the native HTTP FragmentTransport for the TPF/brTPF adapters.
+// Native-only — ureq + the SAME default-deny SSRF resolver, Hydra URI-template serialisation
+// (`?subject=&predicate=&object=` + the brTPF `values` block) and Turtle/TriG fragment-body
+// parse (control/data split, `hydra:totalItems`/`void:triples` count, `hydra:next` pagination).
+#[cfg(all(feature = "fedclient", not(target_arch = "wasm32")))]
+pub use source::HttpFragmentTransport;
 
 /// brTPF binding-block **transport encodings** (bead `sq-6ihg`, follow-up to the server's
 /// `sq-dxhb`): a COMPACT, self-describing BINARY mapping wire ([`wire::encode_bindings`] /
@@ -167,8 +180,9 @@ pub use source::HttpTransport;
 /// N-Triples framing (a one-byte kind tag + length-prefixed bare lexical bytes) so a large
 /// [`FragBinding`] block travels compactly and losslessly; the text form matches the server's
 /// `position=term` grammar so a client can speak either over the same `FragBinding` model. A
-/// codec only — the native HTTP `FragmentTransport` that picks a wire by content negotiation
-/// lands with the streaming HTTP phase.
+/// codec only — the native HTTP [`FragmentTransport`](source::FragmentTransport)
+/// ([`HttpFragmentTransport`], bead `sq-yzca`) attaches the TEXT form on the `values` query
+/// parameter; the binary wire here is the alternative a body-carrying transport emits.
 #[cfg(feature = "fedclient")]
 pub mod wire;
 // [OPUS-4.8] sq-6ihg: re-export the brTPF binding-block wire codec at the crate root.
@@ -194,8 +208,10 @@ pub mod discovery;
 #[cfg(feature = "fedclient")]
 pub mod planner;
 // [OPUS-4.8] sq-j27p: re-export the Phase-3 planner-bridge surface at the crate root.
+// [OPUS-4.8] sq-yzca: `lower_leaf_fragment` lowers a leaf to a `FragPattern` for a TPF/brTPF
+// source (the fragment-source twin of `lower_leaf`'s SPARQL `SubQuery`).
 #[cfg(feature = "fedclient")]
-pub use planner::{lower_leaf, pattern_vars, ResolveError, SourceResolver};
+pub use planner::{lower_leaf, lower_leaf_fragment, pattern_vars, ResolveError, SourceResolver};
 
 /// §4.3 — **capability-aware pushdown**: per leaf / FedX exclusive group, build the
 /// MOST PRECISE sub-query a source can answer (projection + common-variable-checked

--- a/crates/sparq-fedclient/src/operators.rs
+++ b/crates/sparq-fedclient/src/operators.rs
@@ -44,10 +44,10 @@
 // [OPUS-4.8] sq-j27p (epic sq-dnko): Phase-3 materialised single-source interpreter +
 // SRJ parser + result-equivalence invariant. Flagged for Fable re-review when available.
 
-use crate::planner::{lower_leaf, pattern_vars, SourceResolver};
-use crate::source::{FedError, FederatedSource};
+use crate::planner::{lower_leaf, lower_leaf_fragment, pattern_vars, SourceResolver};
+use crate::source::{FedError, FederatedSource, FragBinding, FragPattern, FragTerm, SourceType};
 use oxrdf::{BlankNode, Literal, NamedNode, NamedOrBlankNode, Term, Triple};
-use sparq_fedplan::{JoinNode, JoinTree, PatternSources};
+use sparq_fedplan::{JoinNode, JoinTree, PatternSources, TriplePattern};
 use std::collections::HashMap;
 // [OPUS-4.8] sq-vtba (Phase 5): the streaming-operator surface reuses the planner's proven
 // non-blocking `StreamJoin` + its `Tuple` model, the `SolutionStream` boundary, and `std`
@@ -228,9 +228,101 @@ fn materialize_leaf(
         }
     }
     let tp = resolver.pattern(pattern)?;
-    let sub = lower_leaf(tp);
-    let body = source.execute(&sub)?;
-    parse_srj(&body).map_err(InterpError::BadSrj)
+    fetch_leaf_relation(source, tp)
+}
+
+/// Answer ONE leaf triple pattern against `source`, returning the leaf [`Relation`] —
+/// **dispatching on the source's interface** so a fragment source is answered through its typed
+/// fragment path rather than the SRJ `execute` (which a fragment server refuses, since it speaks
+/// triples, not SPARQL-Results-JSON — bead `sq-2qze`'s `FedError::Unsupported` stub).
+///
+/// * **[`Endpoint`](crate::source::Endpoint) / [`Local`](crate::source::LocalSource)** — lower
+///   to a SPARQL [`SubQuery`](crate::source::SubQuery) ([`lower_leaf`]), `execute` → an SRJ body,
+///   parse → [`Relation`] (the Phase-3 path).
+/// * **[`Tpf`](crate::source::TpfSource)** — lower to a [`FragPattern`] ([`lower_leaf_fragment`]),
+///   call [`solutions`](crate::source::TpfSource::solutions) (the fragment fetched to exhaustion,
+///   complete by construction), and build a [`Relation`] over the pattern's variables.
+/// * **[`BrTpf`](crate::source::BrTpfSource)** — same, calling
+///   [`solutions`](crate::source::BrTpfSource::solutions) with an EMPTY upstream binding block: a
+///   complete unbound fragment scan that the interpreter then hash-joins locally. This mirrors how
+///   the Phase-3 interpreter executes a planner `JoinAlgo::Bind` as a materialised hash join — the
+///   result multiset is identical (the pushed-down brTPF bind-join is a per-block execution
+///   discipline, not a different answer); the streaming bind-join feeder is a later phase.
+///
+/// This is the wiring the bead asks for: a `JoinTree` leaf that resolves to a TPF/brTPF source is
+/// now answered, not rejected with `Unsupported`. The single-source-per-leaf contract is enforced
+/// by the caller. [OPUS-4.8] sq-yzca.
+fn fetch_leaf_relation(
+    source: &dyn FederatedSource,
+    tp: &TriplePattern,
+) -> Result<Relation, InterpError> {
+    match source.source_type() {
+        SourceType::Tpf(tpf) => {
+            let pat = lower_leaf_fragment(tp);
+            let rows = tpf.solutions(&pat)?;
+            Ok(frag_solutions_to_relation(&pat, rows))
+        }
+        SourceType::BrTpf(brtpf) => {
+            let pat = lower_leaf_fragment(tp);
+            // An empty upstream binding block ⇒ a complete unbound fragment scan; the interpreter
+            // hash-joins it locally (semantically identical to the pushed brTPF bind-join).
+            let rows = brtpf.solutions(&pat, &[])?;
+            Ok(frag_solutions_to_relation(&pat, rows))
+        }
+        SourceType::Endpoint(_) | SourceType::Local(_) => {
+            let sub = lower_leaf(tp);
+            let body = source.execute(&sub)?;
+            parse_srj(&body).map_err(InterpError::BadSrj)
+        }
+    }
+}
+
+/// Build a [`Relation`] from a fragment source's typed solution mappings for `pattern`. The
+/// relation's columns are the pattern's variables in position order ([`FragPattern::vars`]); each
+/// [`FragBinding`] row contributes one [`Relation`] row, with each [`FragTerm`] converted back to
+/// the engine's [`oxrdf::Term`] model so the leaf joins against the SAME term type a SPARQL-
+/// endpoint leaf produces (so a federated query mixing endpoint + fragment sources joins
+/// correctly). A binding the fragment did not bind for a column is unbound (`None`). [OPUS-4.8].
+fn frag_solutions_to_relation(pattern: &FragPattern, rows: Vec<FragBinding>) -> Relation {
+    let vars = pattern.vars();
+    let rows = rows
+        .iter()
+        .map(|binding| {
+            vars.iter()
+                .map(|v| {
+                    binding
+                        .iter()
+                        .find(|(name, _)| name == v)
+                        .map(|(_, term)| fragterm_to_oxterm(term))
+                })
+                .collect()
+        })
+        .collect();
+    Relation { vars, rows }
+}
+
+/// Convert one [`FragTerm`] back into the engine's [`oxrdf::Term`] model, preserving the term's
+/// exact lexical identity so it equi-joins with the SAME term parsed from an endpoint's SRJ.
+///
+/// * an IRI / blank node is reconstructed directly; an invalid IRI/label degrades to a simple
+///   literal carrying the raw bytes (never a panic — `forbid(unsafe_code)`, and a malformed term
+///   from a misbehaving server must not crash the join);
+/// * a literal is parsed from its canonical N-Triples lexical form (`"v"`, `"v"@lang`,
+///   `"v"^^<dt>` — the `FragTerm::Literal` model stores exactly that) via `Term::from_str`, the
+///   inverse of the `oxterm_to_fragterm` writer the HTTP transport uses, so the round-trip is
+///   lossless; an unparseable lexical degrades to a simple literal of the raw text. [OPUS-4.8].
+fn fragterm_to_oxterm(term: &FragTerm) -> Term {
+    match term {
+        FragTerm::Iri(s) => NamedNode::new(s)
+            .map(Term::NamedNode)
+            .unwrap_or_else(|_| Term::Literal(Literal::new_simple_literal(s.clone()))),
+        FragTerm::Blank(s) => BlankNode::new(s)
+            .map(Term::BlankNode)
+            .unwrap_or_else(|_| Term::Literal(Literal::new_simple_literal(s.clone()))),
+        FragTerm::Literal(s) => {
+            Term::from_str(s).unwrap_or_else(|_| Term::Literal(Literal::new_simple_literal(s.clone())))
+        }
+    }
 }
 
 /// A materialised **natural (inner) join** of two relations on their shared variables,
@@ -1021,34 +1113,37 @@ fn stream_leaf(
     }
     let tp = resolver.pattern(pattern)?;
     let vars = pattern_vars(tp);
-    let sub = lower_leaf(tp);
+    // Clone the leaf pattern onto the worker (a light fedplan `TriplePattern`) so the blocking
+    // fetch — which dispatches on the source's interface (SRJ endpoint vs TPF/brTPF fragment) —
+    // runs the SAME `fetch_leaf_relation` the materialised interpreter uses. [OPUS-4.8] sq-yzca.
+    let tp_owned = tp.clone();
     let (sink, stream) = SolutionStream::bounded(opts.channel_cap);
     let source = Arc::clone(source);
     let leaf_vars = vars.clone();
     pool.submit(move || {
-        // Blocking fetch + parse on the worker thread. The SSRF gate lives inside `execute`.
-        match source.execute(&sub) {
-            Ok(body) => match parse_srj(&body) {
-                Ok(rel) => {
-                    // Re-key each materialised row onto the leaf's variable header and feed it
-                    // into the stream (the per-leaf "stream" delivers the parsed rows; the
-                    // streaming win is at the JOIN level — a fast leaf feeds the join while a
-                    // slow leaf is still in flight).
-                    for row in rel.rows {
-                        // The SRJ header may differ in order from the pattern's; project onto
-                        // the leaf's variable order so the join keys line up.
-                        let proj = rel_row_project(&rel.vars, &row, &leaf_vars);
-                        if !sink.emit(Solution::new(leaf_vars.clone(), proj)) {
-                            return; // consumer gone.
-                        }
+        // Blocking fetch + parse on the worker thread (the SSRF gate / fragment fetch lives
+        // inside the source adapter). Endpoint/Local answer SRJ; Tpf/BrTpf answer typed
+        // fragment solutions — `fetch_leaf_relation` picks the path by interface.
+        match fetch_leaf_relation(source.as_ref(), &tp_owned) {
+            Ok(rel) => {
+                // Re-key each materialised row onto the leaf's variable header and feed it
+                // into the stream (the per-leaf "stream" delivers the parsed rows; the
+                // streaming win is at the JOIN level — a fast leaf feeds the join while a
+                // slow leaf is still in flight).
+                for row in rel.rows {
+                    // The source header may differ in order from the pattern's; project onto
+                    // the leaf's variable order so the join keys line up.
+                    let proj = rel_row_project(&rel.vars, &row, &leaf_vars);
+                    if !sink.emit(Solution::new(leaf_vars.clone(), proj)) {
+                        return; // consumer gone.
                     }
                 }
-                Err(m) => {
-                    sink.emit_err(FedError::Transport(format!("malformed SRJ: {}", m)));
-                }
-            },
-            Err(e) => {
+            }
+            Err(InterpError::Source(e)) => {
                 sink.emit_err(e);
+            }
+            Err(other) => {
+                sink.emit_err(FedError::Transport(other.to_string()));
             }
         }
         // `sink` drops here → the per-leaf stream ends.
@@ -1502,16 +1597,29 @@ mod tests {
     }
 
     /// A `FederatedSource` whose `execute` answers from a canned map AND can be wrapped in an
-    /// `Arc<dyn FederatedSource + Send + Sync>` for the streaming interpreter. [OPUS-4.8].
+    /// `Arc<dyn FederatedSource + Send + Sync>` for the streaming interpreter. It embeds a real
+    /// `Endpoint` so `source_type()` reports `SourceType::Endpoint` — which the interpreter's
+    /// interface dispatch ([`fetch_leaf_relation`], sq-yzca) now CONSULTS to route an endpoint
+    /// leaf to the SRJ `execute` path (vs the typed fragment path). [OPUS-4.8].
     struct ArcMapSource {
         answers: StdHashMap<String, String>,
+        // A real endpoint so `source_type()` is honest (its inner transport is never reached —
+        // `ArcMapSource::execute` overrides `execute` to answer from the canned map directly).
+        ep: Endpoint,
+    }
+    impl ArcMapSource {
+        fn new(answers: StdHashMap<String, String>) -> Self {
+            ArcMapSource {
+                answers,
+                ep: Endpoint::new("http://8.8.8.8/sparql", Box::new(MapTransport::new(StdHashMap::new()))),
+            }
+        }
     }
     impl FederatedSource for ArcMapSource {
         fn source_type(&self) -> crate::source::SourceType<'_> {
-            // Not consulted by the interpreter; point at a dummy via unreachable is wrong, so
-            // return a real variant by constructing nothing — the interpreter never calls this.
-            // We instead panic to prove it is unused on this path.
-            unreachable!("source_type is not called by the streaming interpreter")
+            // Honest: an endpoint-shaped source reports the Endpoint interface, so the
+            // interpreter's dispatch routes it to the SRJ `execute` path.
+            self.ep.source_type()
         }
         fn discover(
             &self,
@@ -1585,7 +1693,7 @@ mod tests {
         let reference = materialize_single_source(&resolver_ref, &sel, &ep, &tree).unwrap();
 
         // Streamed result via the Phase-5 interpreter.
-        let arc_src: Arc<dyn FederatedSource + Send + Sync> = Arc::new(ArcMapSource { answers });
+        let arc_src: Arc<dyn FederatedSource + Send + Sync> = Arc::new(ArcMapSource::new(answers));
         // The resolver only needs an adapter slice for index resolution; the streaming
         // interpreter answers every leaf through `arc_src`, so a stand-in endpoint adapter in
         // the slice is never `execute`d (it only satisfies `resolver.source_count()`/typing).
@@ -1640,12 +1748,232 @@ mod tests {
         let adapters: Vec<&dyn FederatedSource> = vec![&stub];
         let resolver = SourceResolver::new(&bgp, &adapters);
         let arc_src: Arc<dyn FederatedSource + Send + Sync> =
-            Arc::new(ArcMapSource { answers: StdHashMap::new() });
+            Arc::new(ArcMapSource::new(StdHashMap::new()));
         // `SolutionStream` is not `Debug`, so match the error out by hand (cannot `unwrap_err`).
         let err = match stream_single_source(&resolver, &sel, arc_src, &tree, &StreamOptions::default()) {
             Ok(_) => panic!("multi-source leaf must fail closed"),
             Err(e) => e,
         };
         assert_eq!(err, InterpError::MultiSource { pattern: 0, sources: 2 });
+    }
+
+    // ─── sq-yzca: TPF / brTPF leaves are answered through the interpreter (not Unsupported) ──
+
+    use crate::source::{
+        BrTpfSource, FragBinding, FragPattern, FragTerm, FragTriple, FragmentPage,
+        FragmentTransport, PatternTerm, TpfSource,
+    };
+
+    /// An in-test fragment server (one fixed triple set, paged) so the interpreter exercises a
+    /// TPF/brTPF leaf with NO network — the operators twin of `source`'s `FixtureFragments`.
+    /// [OPUS-4.8] sq-yzca.
+    struct FragFixture {
+        triples: Vec<FragTriple>,
+        page_size: usize,
+    }
+    impl FragFixture {
+        fn matches(pattern: &FragPattern, t: &FragTriple) -> bool {
+            // A position matches iff bound-and-equal, or a variable (with repeated-var consistency
+            // delegated to the adapter's bind_triple — here we just check bound positions).
+            let pos_ok = |p: &PatternTerm, term: &FragTerm| match p {
+                PatternTerm::Bound(b) => b == term,
+                PatternTerm::Var(_) => true,
+            };
+            pos_ok(&pattern.subject, &t.subject)
+                && pos_ok(&pattern.predicate, &t.predicate)
+                && pos_ok(&pattern.object, &t.object)
+        }
+        fn joins(pattern: &FragPattern, t: &FragTriple, bindings: &[FragBinding]) -> bool {
+            if bindings.is_empty() {
+                return true;
+            }
+            // The triple joins a binding iff every var the binding assigns that the pattern also
+            // names binds to the same term in this triple.
+            bindings.iter().any(|b| {
+                b.iter().all(|(name, val)| {
+                    for (p, term) in [
+                        (&pattern.subject, &t.subject),
+                        (&pattern.predicate, &t.predicate),
+                        (&pattern.object, &t.object),
+                    ] {
+                        if p.as_var() == Some(name.as_str()) {
+                            return term == val;
+                        }
+                    }
+                    true
+                })
+            })
+        }
+    }
+    impl FragmentTransport for FragFixture {
+        fn fetch_fragment(
+            &self,
+            _url: &str,
+            pattern: &FragPattern,
+            bindings: &[FragBinding],
+            page: Option<&str>,
+        ) -> Result<FragmentPage, String> {
+            let matched: Vec<&FragTriple> = self
+                .triples
+                .iter()
+                .filter(|t| Self::matches(pattern, t))
+                .filter(|t| Self::joins(pattern, t, bindings))
+                .collect();
+            let total_items = matched.len() as u64;
+            let offset = match page {
+                None => 0,
+                Some(tok) => tok.strip_prefix("offset:").and_then(|n| n.parse().ok()).unwrap_or(0),
+            };
+            let end = (offset + self.page_size.max(1)).min(matched.len());
+            let triples = matched[offset..end].iter().map(|t| (*t).clone()).collect();
+            let next = (end < matched.len()).then(|| format!("offset:{end}"));
+            Ok(FragmentPage { triples, total_items, next })
+        }
+    }
+
+    fn frag_iri(n: &str) -> FragTerm {
+        FragTerm::iri(format!("http://ex/{n}"))
+    }
+    fn knows_triples() -> Vec<FragTriple> {
+        let k = || FragTerm::iri("http://ex/knows");
+        vec![
+            FragTriple::new(frag_iri("alice"), k(), frag_iri("bob")),
+            FragTriple::new(frag_iri("alice"), k(), frag_iri("carol")),
+            FragTriple::new(frag_iri("bob"), k(), frag_iri("dave")),
+        ]
+    }
+
+    /// A `?s :knows ?o` BGP planned over a single TPF source must be ANSWERED by the interpreter
+    /// (the typed `solutions` path), not rejected with `Unsupported` — the wiring the bead asks
+    /// for. The materialised relation is the complete fragment bound into (?s, ?o). [OPUS-4.8].
+    #[test]
+    fn interpreter_answers_tpf_leaf() {
+        let bgp = Bgp::new(vec![TriplePattern::new(
+            var("s"),
+            iri("http://ex/knows"),
+            var("o"),
+        )]);
+        let descriptors = [SourceDescriptor::builder(SourceId::new("T"))
+            .total_triples(3)
+            .build()];
+        let sel = select_sources(&bgp, &descriptors);
+        let tree = plan_bgp(&bgp, &sel, &descriptors, &PlanOptions::default()).unwrap();
+        // page_size 2 forces pagination → exercises hydra:next-to-exhaustion through the adapter.
+        let tpf = TpfSource::new(
+            "http://frag/tpf",
+            Box::new(FragFixture { triples: knows_triples(), page_size: 2 }),
+        );
+        let adapters: Vec<&dyn FederatedSource> = vec![&tpf];
+        let resolver = SourceResolver::new(&bgp, &adapters);
+        let rel = materialize_single_source(&resolver, &sel, &tpf, &tree).unwrap();
+
+        let expect_vars = vec!["s".to_string(), "o".to_string()];
+        let expect_rows = vec![
+            vec![Some(nn("http://ex/alice")), Some(nn("http://ex/bob"))],
+            vec![Some(nn("http://ex/alice")), Some(nn("http://ex/carol"))],
+            vec![Some(nn("http://ex/bob")), Some(nn("http://ex/dave"))],
+        ];
+        assert!(
+            solutions_equal(&rel.vars, &rel.rows, &expect_vars, &expect_rows),
+            "TPF leaf must be materialised completely, got {:?}",
+            rel
+        );
+    }
+
+    /// The SAME single-pattern plan over a brTPF source is answered through the brTPF `solutions`
+    /// path (an unbound scan that the interpreter joins locally). [OPUS-4.8] sq-yzca.
+    #[test]
+    fn interpreter_answers_brtpf_leaf() {
+        let bgp = Bgp::new(vec![TriplePattern::new(
+            var("s"),
+            iri("http://ex/knows"),
+            var("o"),
+        )]);
+        let descriptors = [SourceDescriptor::builder(SourceId::new("B"))
+            .total_triples(3)
+            .build()];
+        let sel = select_sources(&bgp, &descriptors);
+        let tree = plan_bgp(&bgp, &sel, &descriptors, &PlanOptions::default()).unwrap();
+        let brtpf = BrTpfSource::new(
+            "http://frag/brtpf",
+            30,
+            Box::new(FragFixture { triples: knows_triples(), page_size: 100 }),
+        );
+        let adapters: Vec<&dyn FederatedSource> = vec![&brtpf];
+        let resolver = SourceResolver::new(&bgp, &adapters);
+        let rel = materialize_single_source(&resolver, &sel, &brtpf, &tree).unwrap();
+        assert_eq!(rel.rows.len(), 3, "brTPF unbound scan returns the whole fragment");
+    }
+
+    /// The fragment leaf is also answered by the STREAMING interpreter (the dispatch is shared),
+    /// and the streamed multiset equals the materialised one. [OPUS-4.8] sq-yzca.
+    #[test]
+    fn stream_interpreter_answers_tpf_leaf() {
+        let bgp = Bgp::new(vec![TriplePattern::new(
+            var("s"),
+            iri("http://ex/knows"),
+            var("o"),
+        )]);
+        let descriptors = [SourceDescriptor::builder(SourceId::new("T"))
+            .total_triples(3)
+            .build()];
+        let sel = select_sources(&bgp, &descriptors);
+        let tree = plan_bgp(&bgp, &sel, &descriptors, &PlanOptions::default()).unwrap();
+        // Materialised reference.
+        let tpf_ref = TpfSource::new(
+            "http://frag/tpf",
+            Box::new(FragFixture { triples: knows_triples(), page_size: 2 }),
+        );
+        let adapters: Vec<&dyn FederatedSource> = vec![&tpf_ref];
+        let resolver_ref = SourceResolver::new(&bgp, &adapters);
+        let reference = materialize_single_source(&resolver_ref, &sel, &tpf_ref, &tree).unwrap();
+        // Streamed.
+        let arc_src: Arc<dyn FederatedSource + Send + Sync> = Arc::new(TpfSource::new(
+            "http://frag/tpf",
+            Box::new(FragFixture { triples: knows_triples(), page_size: 2 }),
+        ));
+        let resolver = SourceResolver::new(&bgp, &adapters);
+        let stream =
+            stream_single_source(&resolver, &sel, arc_src, &tree, &StreamOptions::default())
+                .expect("stream builds");
+        let got = stream.collect_solutions().unwrap();
+        let got_rows: Vec<Vec<Option<Term>>> = got.iter().map(|s| s.cells.clone()).collect();
+        let got_vars = got
+            .first()
+            .map(|s| s.vars.clone())
+            .unwrap_or_else(|| reference.vars.clone());
+        assert!(
+            solutions_equal(&got_vars, &got_rows, &reference.vars, &reference.rows),
+            "streamed TPF leaf must equal the materialised one"
+        );
+    }
+
+    /// A fragment term round-trips through `fragterm_to_oxterm` so a TPF leaf equi-joins with the
+    /// SAME `oxrdf::Term` an endpoint leaf produces — the cross-interface join correctness check.
+    /// [OPUS-4.8] sq-yzca.
+    #[test]
+    fn fragterm_oxterm_round_trips_every_kind() {
+        assert_eq!(
+            fragterm_to_oxterm(&FragTerm::iri("http://ex/a")),
+            nn("http://ex/a")
+        );
+        assert_eq!(
+            fragterm_to_oxterm(&FragTerm::Blank("b0".into())),
+            Term::BlankNode(BlankNode::new("b0").unwrap())
+        );
+        // A typed/lang literal carried in its N-Triples lexical form parses back exactly.
+        assert_eq!(
+            fragterm_to_oxterm(&FragTerm::Literal(
+                "\"30\"^^<http://www.w3.org/2001/XMLSchema#integer>".into()
+            )),
+            Term::Literal(Literal::new_typed_literal(
+                "30",
+                NamedNode::new("http://www.w3.org/2001/XMLSchema#integer").unwrap()
+            ))
+        );
+        assert_eq!(
+            fragterm_to_oxterm(&FragTerm::Literal("\"hi\"@en".into())),
+            Term::Literal(Literal::new_language_tagged_literal("hi", "en").unwrap())
+        );
     }
 }

--- a/crates/sparq-fedclient/src/planner.rs
+++ b/crates/sparq-fedclient/src/planner.rs
@@ -39,7 +39,7 @@
 // [OPUS-4.8] sq-j27p (epic sq-dnko): Phase-3 planner bridge — index→adapter resolution +
 // per-leaf lowering. Flagged for Fable re-review when available.
 
-use crate::source::{FederatedSource, SubQuery};
+use crate::source::{FederatedSource, FragPattern, FragTerm, PatternTerm, SubQuery};
 use sparq_fedplan::{Bgp, Term, TriplePattern};
 
 /// An error from resolving a plan index — the plan referenced an out-of-range
@@ -189,6 +189,40 @@ pub fn pattern_vars(tp: &TriplePattern) -> Vec<String> {
     out
 }
 
+/// Lower one BGP triple pattern to the [`FragPattern`] a Triple-Pattern-Fragments source
+/// ([`TpfSource`](crate::source::TpfSource) / [`BrTpfSource`](crate::source::BrTpfSource))
+/// answers for that leaf — the TPF/brTPF access unit is exactly one triple pattern.
+///
+/// Each fedplan [`Term`] position maps to a [`PatternTerm`]: a variable becomes
+/// [`PatternTerm::Var`] (the bare name, so it round-trips through the fragment's variable
+/// binding), a bound IRI becomes a [`FragTerm::Iri`], and a bound literal becomes a
+/// [`FragTerm::Literal`] carrying its already-rendered SPARQL/N-Triples lexical form verbatim
+/// (the `Term::Literal` model stores literals already rendered, and the `FragTerm::Literal`
+/// model likewise stores the decorated form — so the lexical identity is preserved end-to-end,
+/// which the fragment server's term parser and the adapter's `bind_triple` both compare on).
+///
+/// This is the fragment-source twin of [`lower_leaf`] (which produces a SPARQL `SubQuery` for an
+/// [`Endpoint`](crate::source::Endpoint)); the interpreter dispatches on the source's interface
+/// to pick which lowering to use. [OPUS-4.8] sq-yzca.
+pub fn lower_leaf_fragment(tp: &TriplePattern) -> FragPattern {
+    FragPattern::new(
+        term_to_pattern_term(&tp.subject),
+        term_to_pattern_term(&tp.predicate),
+        term_to_pattern_term(&tp.object),
+    )
+}
+
+/// Map one fedplan [`Term`] position to a [`PatternTerm`] for a [`FragPattern`]. [OPUS-4.8].
+fn term_to_pattern_term(t: &Term) -> PatternTerm {
+    match t {
+        Term::Var(v) => PatternTerm::Var(v.0.clone()),
+        Term::Iri(iri) => PatternTerm::Bound(FragTerm::Iri(iri.clone())),
+        // A bound literal carries its already-rendered lexical form verbatim (see the doc on
+        // `lower_leaf_fragment` / `FragTerm::Literal`). The fragment server compares on it.
+        Term::Literal(lit) => PatternTerm::Bound(FragTerm::Literal(lit.clone())),
+    }
+}
+
 /// Render a light `sparq-fedplan` [`Term`] as a SPARQL term string. IRIs are wrapped in
 /// `<>`; variables become `?name`; a literal is rendered as a `"…"`-quoted string with the
 /// minimal `"`/`\\`/control escaping, UNLESS it already carries SPARQL literal syntax (a
@@ -322,6 +356,31 @@ mod tests {
         assert_eq!(
             sub.sparql,
             "SELECT * WHERE { <http://ex/a> <http://ex/p> <http://ex/b> } LIMIT 1"
+        );
+    }
+
+    #[test]
+    fn lower_leaf_fragment_maps_positions() {
+        use crate::source::{FragTerm, PatternTerm};
+        // ?s foaf:knows ?o — predicate bound, subject + object variable.
+        let tp = TriplePattern::new(var("s"), iri("http://xmlns.com/foaf/0.1/knows"), var("o"));
+        let pat = lower_leaf_fragment(&tp);
+        assert_eq!(pat.subject, PatternTerm::Var("s".into()));
+        assert_eq!(
+            pat.predicate,
+            PatternTerm::Bound(FragTerm::Iri("http://xmlns.com/foaf/0.1/knows".into()))
+        );
+        assert_eq!(pat.object, PatternTerm::Var("o".into()));
+        assert_eq!(pat.vars(), vec!["s".to_string(), "o".to_string()]);
+        // A bound literal object carries its already-rendered lexical form verbatim.
+        let tp2 = TriplePattern::new(
+            var("s"),
+            iri("http://ex/label"),
+            Term::Literal("\"hi\"@en".to_string()),
+        );
+        assert_eq!(
+            lower_leaf_fragment(&tp2).object,
+            PatternTerm::Bound(FragTerm::Literal("\"hi\"@en".into()))
         );
     }
 

--- a/crates/sparq-fedclient/src/source.rs
+++ b/crates/sparq-fedclient/src/source.rs
@@ -72,20 +72,31 @@
 //! optionally with an attached binding block, → matched triples + the page's count + the
 //! next-page token). It is the TPF analogue of the [`Transport`] SRJ seam and is tested
 //! with an in-memory fixture server ([`source` tests]) so the adapters are exercised on the
-//! REAL fetch→parse→bind→paginate→bind-join path with **zero** network. A native HTTP
-//! `FragmentTransport` (ureq, the same default-deny SSRF resolver) lands with the streaming
-//! phase; Phase 6 ships the adapters + the seam + the completeness invariant.
+//! REAL fetch→parse→bind→paginate→bind-join path with **zero** network.
+//!
+//! The **native HTTP `FragmentTransport`** ([`HttpFragmentTransport`], bead `sq-yzca`) is the
+//! production seam: a blocking ureq GET behind the same default-deny SSRF resolver as
+//! [`HttpTransport`], that serialises a [`FragPattern`] into the Hydra TPF URI template
+//! (`?subject=&predicate=&object=`), attaches a brTPF binding block as the `values` parameter
+//! (the server's text wire), follows the `hydra:next` page link to exhaustion, and parses the
+//! Turtle/TriG fragment body — splitting the Hydra/VoID control triples (the
+//! `hydra:totalItems`/`void:triples` count + the `hydra:next` link) from the data triples
+//! (kept only when they match the requested pattern). Native-only (gated out of wasm).
 //!
 //! `FederatedSource::execute` still returns the SRJ-style `String` body for the
 //! [`Endpoint`] adapter; the TPF adapters answer through the typed
 //! [`TpfSource::solutions`] / [`BrTpfSource::solutions`] methods (a fragment server speaks
 //! triples, not SPARQL-Results-JSON), and their `execute` forwards a clear
 //! [`FedError::Unsupported`] pointing the caller at `solutions` — no overclaim, no lossy
-//! re-serialisation through SRJ.
+//! re-serialisation through SRJ. The interpreter ([`crate::operators`]) bridges this: a
+//! `JoinTree` leaf resolving to a TPF/brTPF source is answered through `solutions` (the typed
+//! fragment path), not through `execute` (bead `sq-yzca`).
 //!
 //! [OPUS-4.8] sq-rsxf (epic sq-dnko / sq-3183): Phase-2 source-type abstraction +
 //! Endpoint adapter + default-deny SSRF guard. [OPUS-4.8] sq-2qze: Phase-6 brTPF + TPF
-//! adapters + count-metadata cardinality. Flagged for Fable re-review when available.
+//! adapters + count-metadata cardinality. [OPUS-4.8] sq-yzca: native HTTP `FragmentTransport`
+//! (ureq + SSRF resolver + Hydra URI-template + Turtle/TriG parse) + interpreter wiring.
+//! Flagged for Fable re-review when available.
 
 use std::collections::HashSet;
 use std::net::IpAddr;
@@ -901,10 +912,10 @@ pub struct FragmentPage {
 /// from a prior [`FragmentPage::next`] (`None` for the first page). The implementation
 /// returns the page's triples + count + next token, or a transport-error string.
 ///
-/// A native HTTP `FragmentTransport` (ureq + the default-deny SSRF resolver, serialising the
-/// pattern into the Hydra URI template + the binding block as the brTPF `values` parameter,
-/// and parsing the Turtle/TriG fragment body) lands with the streaming phase; Phase 6 ships
-/// this seam and exercises the adapters through an in-memory fixture server. [OPUS-4.8].
+/// The native HTTP implementation is [`HttpFragmentTransport`] (bead `sq-yzca`): ureq + the
+/// default-deny SSRF resolver, serialising the pattern into the Hydra URI template + the binding
+/// block as the brTPF `values` parameter, and parsing the Turtle/TriG fragment body. The trait
+/// is also exercised through an in-memory fixture server in the tests (zero network). [OPUS-4.8].
 pub trait FragmentTransport: Send + Sync {
     /// Fetch one fragment page. `bindings` is the brTPF block (empty for plain TPF);
     /// `page` is the next-page token (`None` for the first page).
@@ -915,6 +926,305 @@ pub trait FragmentTransport: Send + Sync {
         bindings: &[FragBinding],
         page: Option<&str>,
     ) -> Result<FragmentPage, String>;
+}
+
+// ─── Native HTTP FragmentTransport (ureq + SSRF resolver + Hydra template + Turtle/TriG) ─
+
+/// The Hydra Core vocabulary namespace (the TPF control vocabulary). [OPUS-4.8] sq-yzca.
+#[cfg(not(target_arch = "wasm32"))]
+const HYDRA_NS: &str = "http://www.w3.org/ns/hydra/core#";
+/// The VoID namespace (`void:triples` — the fragment's match-count estimate). [OPUS-4.8].
+#[cfg(not(target_arch = "wasm32"))]
+const VOID_NS: &str = "http://rdfs.org/ns/void#";
+/// The brTPF `values` control property the sparq server mints (sq-dxhb) — the
+/// `hydra:property` its `{values}` template variable maps to. The native transport attaches
+/// the brTPF binding block under the `values` query parameter (the server's text wire).
+/// [OPUS-4.8] sq-yzca.
+#[cfg(not(target_arch = "wasm32"))]
+const BRTPF_VALUES_PARAM: &str = "values";
+
+/// The production [`FragmentTransport`]: a blocking ureq GET against a Triple-Pattern-Fragments
+/// (TPF) / bindings-restricted-TPF (brTPF) server, behind the **same default-deny SSRF resolver**
+/// as [`HttpTransport`] (the resolved-and-vetted IP is the dialled IP — no DNS-rebinding
+/// re-resolve window).
+///
+/// # What it does (the four pieces the bead names)
+///
+/// 1. **Hydra URI-template serialisation.** A [`FragPattern`] is rendered into the TPF query
+///    string the sparq server reads (`?subject=&predicate=&object=`, each a percent-encoded
+///    N-Triples term; a variable position is omitted). This is the `{subject}`/`{predicate}`/
+///    `{object}` Hydra template the server advertises (`sparq-server`'s `tpf.rs`).
+/// 2. **brTPF binding block.** A non-empty `bindings` slice is attached as the `values` query
+///    parameter using the server's text wire ([`crate::wire::encode_bindings_text`]), so the
+///    server returns only triples joining at least one attached mapping (the brTPF bind-join).
+/// 3. **Pagination.** A `page` token is the OPAQUE next-page URL the server published as
+///    `hydra:next`; the transport GETs it verbatim, so following pagination to exhaustion is
+///    "GET the `hydra:next` link until there is none" — exactly what [`drain_fragment`] drives.
+/// 4. **Turtle/TriG fragment-body parse.** The response (`Accept: text/turtle, application/trig`)
+///    is parsed with oxttl's TriG parser (a superset of Turtle — it handles a default-graph
+///    Turtle body and a named-graph TriG body identically). The parse SPLITS the document into
+///    the **control** triples (`hydra:totalItems` / `void:triples` → the count; `hydra:next` →
+///    the next-page link) and the **data** triples (everything whose predicate is NOT in the
+///    Hydra/VoID control vocabulary), and the data triples are filtered to those that actually
+///    match the requested pattern, so a control triple can never be mistaken for a match.
+///
+/// Native-only (`cfg(not(target_arch = "wasm32"))`): ureq + its TLS stack never enter the wasm
+/// bundle (a wasm federation client would carry a `fetch`-based transport). Construct with
+/// [`HttpFragmentTransport::new`] (strict default-deny) or [`HttpFragmentTransport::from_guard`]
+/// to share an [`EgressGuard`]'s allowlist. [OPUS-4.8] sq-yzca.
+#[cfg(not(target_arch = "wasm32"))]
+pub struct HttpFragmentTransport {
+    timeout: std::time::Duration,
+    /// Hosts (bare authority, lowercased) the SSRF resolver permits even when they resolve
+    /// privately — bridged from an [`EgressGuard`] so the pre-flight check and the socket
+    /// resolver share one allowlist.
+    allow_private: std::sync::Arc<HashSet<String>>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Default for HttpFragmentTransport {
+    fn default() -> Self {
+        HttpFragmentTransport::new()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl HttpFragmentTransport {
+    /// A fragment transport with a finite default timeout and the strict default-deny SSRF
+    /// policy (no private host permitted).
+    pub fn new() -> HttpFragmentTransport {
+        HttpFragmentTransport {
+            timeout: std::time::Duration::from_secs(30),
+            allow_private: std::sync::Arc::new(HashSet::new()),
+        }
+    }
+
+    /// A fragment transport whose SSRF resolver shares `guard`'s allowlist, so a deliberately
+    /// allowlisted private fragment server is reachable (and only such a host is). The IP the
+    /// resolver vets is the IP ureq dials.
+    pub fn from_guard(guard: &EgressGuard) -> HttpFragmentTransport {
+        HttpFragmentTransport {
+            timeout: std::time::Duration::from_secs(30),
+            allow_private: std::sync::Arc::new(guard.allowed_hosts().clone()),
+        }
+    }
+
+    /// Sets the per-request timeout. Chainable.
+    pub fn with_timeout(mut self, timeout: std::time::Duration) -> HttpFragmentTransport {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Build the first-page request URL for `url` + `pattern` (+ optional brTPF `bindings`):
+    /// the Hydra TPF query string with the bound positions percent-encoded as N-Triples terms.
+    fn first_page_url(url: &str, pattern: &FragPattern, bindings: &[FragBinding]) -> String {
+        let mut out = String::with_capacity(url.len() + 64);
+        out.push_str(url);
+        let mut sep = if url.contains('?') { '&' } else { '?' };
+        for (key, pos) in [
+            ("subject", &pattern.subject),
+            ("predicate", &pattern.predicate),
+            ("object", &pattern.object),
+        ] {
+            if let PatternTerm::Bound(term) = pos {
+                out.push(sep);
+                out.push_str(key);
+                out.push('=');
+                out.push_str(&pct_encode(&term_to_ntriples(term)));
+                sep = '&';
+            }
+        }
+        // brTPF binding block (the server's text wire). Empty → plain TPF (no `values` param).
+        if !bindings.is_empty() {
+            let wire = crate::wire::encode_bindings_text(bindings);
+            if !wire.is_empty() {
+                out.push(sep);
+                out.push_str(BRTPF_VALUES_PARAM);
+                out.push('=');
+                out.push_str(&pct_encode(&wire));
+            }
+        }
+        out
+    }
+}
+
+/// Percent-encode a query-parameter VALUE (RFC 3986 unreserved set passes through; everything
+/// else is `%XX`-escaped), so an N-Triples term (`<`, `>`, `"`, spaces, newlines in a brTPF
+/// block) round-trips through the URL back to the same term. Mirrors the sparq server's
+/// `pct_encode` so the link the transport builds is read identically server-side. Hand-rolled
+/// to avoid a `url`-crate dependency (the crate pulls `oxrdf`/`oxttl`, not `url`). [OPUS-4.8].
+#[cfg(not(target_arch = "wasm32"))]
+fn pct_encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for b in value.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+/// Render a [`FragTerm`] in N-Triples lexical form (the TPF query-parameter grammar the server
+/// reads): an IRI is `<…>`-wrapped, a blank node is `_:…`, a literal carries its
+/// `"…"`/`@lang`/`^^<dt>` decoration verbatim (the `FragTerm::Literal` model already stores it).
+/// Identical to `crate::wire`'s private renderer; inlined here so the transport has no cross-
+/// module private dependency. [OPUS-4.8] sq-yzca.
+#[cfg(not(target_arch = "wasm32"))]
+fn term_to_ntriples(term: &FragTerm) -> String {
+    match term {
+        FragTerm::Iri(s) => format!("<{s}>"),
+        FragTerm::Blank(s) => format!("_:{s}"),
+        FragTerm::Literal(s) => s.clone(),
+    }
+}
+
+/// Convert one parsed oxrdf [`oxrdf::Term`] (a triple object) into a [`FragTerm`], preserving the
+/// term's canonical N-Triples lexical identity (so equality against a bound pattern position is
+/// exact). [OPUS-4.8] sq-yzca.
+#[cfg(not(target_arch = "wasm32"))]
+fn oxterm_to_fragterm(term: &oxrdf::Term) -> FragTerm {
+    match term {
+        oxrdf::Term::NamedNode(n) => FragTerm::Iri(n.as_str().to_string()),
+        oxrdf::Term::BlankNode(b) => FragTerm::Blank(b.as_str().to_string()),
+        // A literal's canonical N-Triples form (`"v"`, `"v"@lang`, `"v"^^<dt>`) is its lexical
+        // identity in the `FragTerm::Literal` model — keep it verbatim via `Display`.
+        oxrdf::Term::Literal(l) => FragTerm::Literal(l.to_string()),
+        // SPARQL-1.2 triple terms cannot appear as a TPF fragment data object; carry the
+        // canonical serialisation so a (degenerate) match still compares exactly.
+        other => FragTerm::Literal(other.to_string()),
+    }
+}
+
+/// Convert a parsed oxrdf subject ([`oxrdf::NamedOrBlankNode`]) into a [`FragTerm`]. [OPUS-4.8].
+#[cfg(not(target_arch = "wasm32"))]
+fn oxsubject_to_fragterm(s: &oxrdf::NamedOrBlankNode) -> FragTerm {
+    match s {
+        oxrdf::NamedOrBlankNode::NamedNode(n) => FragTerm::Iri(n.as_str().to_string()),
+        oxrdf::NamedOrBlankNode::BlankNode(b) => FragTerm::Blank(b.as_str().to_string()),
+    }
+}
+
+/// Whether a predicate IRI is a TPF **control** predicate (Hydra / VoID), i.e. metadata about
+/// the fragment rather than a data triple. The native parser uses this to SPLIT the fragment
+/// document: control triples feed the count + next-page link; everything else is candidate
+/// data. [OPUS-4.8] sq-yzca.
+#[cfg(not(target_arch = "wasm32"))]
+fn is_control_predicate(pred: &str) -> bool {
+    pred.starts_with(HYDRA_NS)
+        || pred.starts_with(VOID_NS)
+        // rdf:type triples describe the fragment/dataset/control nodes, never the data.
+        || pred == "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl FragmentTransport for HttpFragmentTransport {
+    fn fetch_fragment(
+        &self,
+        url: &str,
+        pattern: &FragPattern,
+        bindings: &[FragBinding],
+        page: Option<&str>,
+    ) -> Result<FragmentPage, String> {
+        // The next-page token is the OPAQUE `hydra:next` URL (built by the server, self-
+        // contained); the first page is built from the pattern + binding block.
+        let request_url = match page {
+            Some(next) => next.to_string(),
+            None => Self::first_page_url(url, pattern, bindings),
+        };
+        let agent = ureq::AgentBuilder::new()
+            .timeout(self.timeout)
+            .user_agent(concat!("sparq-fedclient/", env!("CARGO_PKG_VERSION")))
+            // Default-deny SSRF egress filter INSIDE ureq's resolver: ureq dials only the
+            // addresses this resolver returns, so the vetted IP IS the dialled IP — no DNS-
+            // rebinding re-resolve window. Same resolver as the SRJ `HttpTransport`. [OPUS-4.8].
+            .resolver(EgressFilterResolver {
+                allow_private: std::sync::Arc::clone(&self.allow_private),
+            })
+            .build();
+        let body = match agent
+            .get(&request_url)
+            // TriG is a Turtle superset; ask for either so a server that serves Turtle (the
+            // conventional TPF serialisation) or TriG (named graphs) both parse.
+            .set("Accept", "application/trig, text/turtle")
+            .call()
+        {
+            Ok(r) => r
+                .into_string()
+                .map_err(|e| format!("fedclient: reading fragment from {request_url}: {e}"))?,
+            Err(ureq::Error::Status(code, _)) => {
+                return Err(format!(
+                    "fedclient: fragment server {request_url} returned HTTP {code}"
+                ))
+            }
+            Err(e) => return Err(format!("fedclient: request to {request_url} failed: {e}")),
+        };
+        parse_fragment_body(&body, pattern)
+    }
+}
+
+/// Parse a Turtle/TriG fragment body into a [`FragmentPage`] (the data triples + the
+/// `hydra:totalItems`/`void:triples` count + the `hydra:next` token).
+///
+/// TriG is parsed (a superset of Turtle: a Turtle body is a TriG document with everything in the
+/// default graph), so a plain-TPF Turtle response and a TriG response are handled identically.
+/// The parse SPLITS each parsed triple into:
+///
+/// * a **control** triple (predicate in the Hydra/VoID vocabulary or `rdf:type`) — from which the
+///   match-count (`hydra:totalItems` / `void:triples`, the max seen) and the next-page link
+///   (`hydra:next`, an IRI object) are read; and
+/// * a candidate **data** triple — kept iff it actually MATCHES the requested `pattern` (the same
+///   consistency [`bind_triple`] enforces downstream), so a control triple never leaks in as a
+///   match and a misbehaving server cannot smuggle a non-matching triple through.
+///
+/// A malformed body (a TriG syntax error) is a clean transport-error string, never a panic — this
+/// crate is `forbid(unsafe_code)`. [OPUS-4.8] sq-yzca.
+#[cfg(not(target_arch = "wasm32"))]
+fn parse_fragment_body(body: &str, pattern: &FragPattern) -> Result<FragmentPage, String> {
+    let mut triples: Vec<FragTriple> = Vec::new();
+    let mut total_items: u64 = 0;
+    let mut next: Option<String> = None;
+    for quad in oxttl::TriGParser::new().for_slice(body.as_bytes()) {
+        let quad = quad.map_err(|e| format!("fedclient: malformed TriG/Turtle fragment: {e}"))?;
+        let pred = quad.predicate.as_str();
+        if is_control_predicate(pred) {
+            // Count metadata: take the largest of any `hydra:totalItems` / `void:triples` literal
+            // (a fragment may carry the count on more than one control node; they agree, and the
+            // max is the recall-safe choice if they ever differ).
+            if pred == format!("{HYDRA_NS}totalItems") || pred == format!("{VOID_NS}triples") {
+                if let oxrdf::Term::Literal(l) = &quad.object {
+                    if let Ok(n) = l.value().parse::<u64>() {
+                        total_items = total_items.max(n);
+                    }
+                }
+            }
+            // The next-page control link (`hydra:next`; legacy `hydra:nextPage` also accepted).
+            if pred == format!("{HYDRA_NS}next") || pred == format!("{HYDRA_NS}nextPage") {
+                if let oxrdf::Term::NamedNode(n) = &quad.object {
+                    next = Some(n.as_str().to_string());
+                }
+            }
+            continue;
+        }
+        // A candidate data triple: keep it only if it matches the requested pattern (the
+        // load-bearing answer-safety filter — a control triple or a non-matching triple cannot
+        // become a match).
+        let triple = FragTriple::new(
+            oxsubject_to_fragterm(&quad.subject),
+            FragTerm::Iri(pred.to_string()),
+            oxterm_to_fragterm(&quad.object),
+        );
+        if bind_triple(pattern, &triple).is_some() {
+            triples.push(triple);
+        }
+    }
+    Ok(FragmentPage {
+        triples,
+        total_items,
+        next,
+    })
 }
 
 // ─── Bind one matched triple back into a pattern's variables ─────────────────────────
@@ -1956,6 +2266,170 @@ mod tests {
         let ep = Endpoint::native("http://127.0.0.1:9999/sparql");
         let err = ep.execute(&SubQuery::new("ASK {}")).unwrap_err();
         assert!(matches!(err, FedError::EgressRefused(_)), "got {err:?}");
+    }
+
+    // ── Native HTTP FragmentTransport: Hydra URI-template + Turtle/TriG parse (sq-yzca) ──
+    //
+    // These prove the four pieces the bead names WITHOUT a network: the Hydra query-string
+    // serialisation, the brTPF `values` text-wire attachment, the Turtle/TriG fragment-body
+    // parse (control/data split + hydra:totalItems + hydra:next extraction), and that a control
+    // triple is never mistaken for a data match. The SSRF resolver itself is the SAME
+    // `EgressFilterResolver` the SRJ transport tests above exercise. [OPUS-4.8] sq-yzca.
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn fragment_first_page_url_serialises_bound_positions() {
+        // ?s foaf:knows ?o — predicate bound, subject + object variable. Only the bound
+        // predicate appears in the query string, percent-encoded as an N-Triples IRI.
+        let url = HttpFragmentTransport::first_page_url("http://frag/tpf", &knows_pattern(), &[]);
+        assert_eq!(
+            url,
+            "http://frag/tpf?predicate=%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2Fknows%3E"
+        );
+        // A fully-bound pattern serialises all three positions; a base URL that already has a
+        // query string gets `&`-joined.
+        let bound = FragPattern::new(
+            PatternTerm::Bound(FragTerm::iri("http://ex/alice")),
+            PatternTerm::Bound(FragTerm::iri("http://xmlns.com/foaf/0.1/knows")),
+            PatternTerm::Bound(FragTerm::iri("http://ex/bob")),
+        );
+        let url2 = HttpFragmentTransport::first_page_url("http://frag/tpf?dataset=x", &bound, &[]);
+        assert!(url2.starts_with("http://frag/tpf?dataset=x&subject="));
+        assert!(url2.contains("&predicate="));
+        assert!(url2.contains("&object="));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn fragment_first_page_url_attaches_brtpf_values_block() {
+        // A non-empty binding block rides the `values` parameter using the server's text wire.
+        let p = |n: &str| FragTerm::iri(format!("http://ex/{n}"));
+        let bindings: Vec<FragBinding> = vec![
+            vec![("s".to_string(), p("alice"))],
+            vec![("s".to_string(), p("bob"))],
+        ];
+        let url =
+            HttpFragmentTransport::first_page_url("http://frag/brtpf", &knows_pattern(), &bindings);
+        assert!(url.contains("predicate="), "the bound predicate is present");
+        assert!(url.contains("&values="), "the brTPF block rides `values`");
+        // The encoded `values` payload decodes back to the server's text wire (s=<…>\ns=<…>).
+        let encoded = url.split("values=").nth(1).unwrap();
+        let decoded = pct_decode_for_test(encoded);
+        assert_eq!(decoded, "s=<http://ex/alice>\ns=<http://ex/bob>");
+    }
+
+    /// Decode a percent-encoded string (test helper — the inverse of `pct_encode`). [OPUS-4.8].
+    #[cfg(not(target_arch = "wasm32"))]
+    fn pct_decode_for_test(s: &str) -> String {
+        let bytes = s.as_bytes();
+        let mut out = Vec::with_capacity(bytes.len());
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'%' && i + 2 < bytes.len() {
+                let hi = (bytes[i + 1] as char).to_digit(16).unwrap();
+                let lo = (bytes[i + 2] as char).to_digit(16).unwrap();
+                out.push((hi * 16 + lo) as u8);
+                i += 3;
+            } else {
+                out.push(bytes[i]);
+                i += 1;
+            }
+        }
+        String::from_utf8(out).unwrap()
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn parse_turtle_fragment_splits_control_from_data() {
+        // A realistic TPF fragment Turtle body: two data triples + the Hydra/VoID control node
+        // (totalItems + next). The parse must return ONLY the data triples that match the
+        // pattern, the count, and the next-page link.
+        let body = r#"
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+<http://ex/alice> foaf:knows <http://ex/bob> .
+<http://ex/alice> foaf:knows <http://ex/carol> .
+<http://frag/tpf?predicate=knows&page=0> void:triples 4 ;
+    hydra:totalItems 4 ;
+    hydra:itemsPerPage 2 ;
+    hydra:next <http://frag/tpf?predicate=knows&page=1> .
+"#;
+        let page = parse_fragment_body(body, &knows_pattern()).unwrap();
+        assert_eq!(page.total_items, 4, "hydra:totalItems / void:triples");
+        assert_eq!(
+            page.next.as_deref(),
+            Some("http://frag/tpf?predicate=knows&page=1"),
+            "hydra:next page link"
+        );
+        // Exactly the two matching knows-triples — the control triples are excluded.
+        assert_eq!(page.triples.len(), 2, "only the data triples survive");
+        let p = |n: &str| FragTerm::iri(format!("http://ex/{n}"));
+        let knows = FragTerm::iri("http://xmlns.com/foaf/0.1/knows");
+        assert!(page
+            .triples
+            .contains(&FragTriple::new(p("alice"), knows.clone(), p("bob"))));
+        assert!(page
+            .triples
+            .contains(&FragTriple::new(p("alice"), knows, p("carol"))));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn parse_trig_fragment_named_graph_body() {
+        // A TriG body wrapping the data + controls in a named graph still parses (TriG superset
+        // of Turtle): the count, next link, and data triples come through identically.
+        let body = r#"
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+<http://frag/g> {
+  <http://ex/bob> foaf:knows <http://ex/carol> .
+  <http://frag/tpf?page=0> hydra:totalItems 1 .
+}
+"#;
+        let page = parse_fragment_body(body, &knows_pattern()).unwrap();
+        assert_eq!(page.total_items, 1);
+        assert!(page.next.is_none(), "no hydra:next ⇒ last page");
+        assert_eq!(page.triples.len(), 1);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn parse_fragment_filters_nonmatching_data_triple() {
+        // A misbehaving server returns a triple that does NOT match the requested pattern (a
+        // different predicate). The match filter drops it — it can never become a binding.
+        let body = r#"
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+<http://ex/alice> foaf:knows <http://ex/bob> .
+<http://ex/alice> foaf:name "Alice" .
+"#;
+        // Pattern is ?s foaf:knows ?o — the foaf:name triple must be filtered out.
+        let page = parse_fragment_body(body, &knows_pattern()).unwrap();
+        assert_eq!(page.triples.len(), 1, "non-matching predicate dropped");
+        assert_eq!(
+            page.triples[0].predicate,
+            FragTerm::iri("http://xmlns.com/foaf/0.1/knows")
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn parse_malformed_fragment_is_clean_error() {
+        // A TriG syntax error is a clean transport-error string (never a panic — forbid unsafe).
+        let err = parse_fragment_body("@prefix x: <broken .", &knows_pattern()).unwrap_err();
+        assert!(err.contains("malformed"), "got {err:?}");
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn http_fragment_transport_from_guard_bridges_allowlist() {
+        // The transport built from a guard shares the guard's allowlist (so the SSRF resolver and
+        // the pre-flight egress check agree — one source of truth, no second unguarded resolve).
+        let guard = EgressGuard::deny_private().allow_host("frag.internal");
+        let t = HttpFragmentTransport::from_guard(&guard);
+        assert!(t.allow_private.contains("frag.internal"));
+        let empty = HttpFragmentTransport::from_guard(&EgressGuard::deny_private());
+        assert!(empty.allow_private.is_empty());
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/crates/sparq-fedclient/src/wire.rs
+++ b/crates/sparq-fedclient/src/wire.rs
@@ -28,9 +28,10 @@
 //!
 //! This module is a **codec only** — it converts a `&[FragBinding]` to/from bytes (binary) and
 //! to a `String` (text). It does NOT issue any request: the native HTTP
-//! [`FragmentTransport`](crate::source::FragmentTransport) (which will pick a wire by content
-//! negotiation and attach it as the request body / `values` parameter) lands with the streaming
-//! HTTP phase, exactly as the Phase-6 module doc states. What is load-bearing and tested here is
+//! [`FragmentTransport`](crate::source::FragmentTransport) (`HttpFragmentTransport`, bead
+//! `sq-yzca`) attaches the **text** form on the `values` query parameter (the carrier the sparq
+//! server reads); this binary wire is the compact alternative a body-carrying transport emits.
+//! What is load-bearing and tested here is
 //! that the binary form is **lossless** (`decode_bindings(encode_bindings(b)) == b` for every
 //! binding set, including literals with embedded `=`, whitespace, and newlines that the text
 //! wire could not carry on a single line) and that the **text form matches the server's parser

--- a/skills/federated-planning/SKILL.md
+++ b/skills/federated-planning/SKILL.md
@@ -282,6 +282,21 @@ since:
   `FragBinding`s via `solutions(...)` (a fragment server speaks triples, not
   SPARQL-Results-JSON, so their `FederatedSource::execute` is a deliberate `Unsupported` that
   points at `solutions`).
+  - **Native HTTP `FragmentTransport` + interpreter wiring** (`sq-yzca`):
+    `source::HttpFragmentTransport` (native-only — ureq behind the SAME default-deny SSRF
+    resolver as the SRJ `HttpTransport`) is the production seam. It serialises a `FragPattern`
+    into the Hydra TPF query string (`?subject=&predicate=&object=`, percent-encoded N-Triples
+    terms), attaches a brTPF binding block as the `values` parameter (the server's text wire),
+    follows the opaque `hydra:next` page URL to exhaustion, and parses the Turtle/TriG body
+    (oxttl `TriGParser`, a Turtle superset) — splitting Hydra/VoID **control** triples
+    (`hydra:totalItems`/`void:triples` → count; `hydra:next` → next link) from **data** triples
+    (kept only when they match the requested pattern). The `operators` interpreter is wired:
+    `fetch_leaf_relation` dispatches on `source_type()`, routing an endpoint/local leaf to the
+    SRJ `execute` path and a TPF/brTPF leaf to the typed `solutions` path (lowered via
+    `planner::lower_leaf_fragment`), converting `FragBinding` rows back to `oxrdf::Term` so a
+    fragment leaf equi-joins with an endpoint leaf. A brTPF leaf currently runs as a complete
+    unbound scan the interpreter hash-joins locally (the same discipline the Phase-3 interpreter
+    applies to `JoinAlgo::Bind`); the streamed per-block bind-join feeder is a later phase.
   - **brTPF binding-block wire codec** (the `wire` module, `sq-6ihg`, follow-up to the
     server's `sq-dxhb`): the brTPF bind-join attaches a SET of upstream solution mappings (a
     `&[FragBinding]` block, at most `maxMpR`) to each fragment request, and that block is
@@ -308,9 +323,9 @@ since:
     canonical `s`→`p`→`o` order, and the empty mapping μ₀ is skipped on encode (it does not
     restrict a fragment) exactly as the server's `parse_bindings` skips an all-blank line.
     **HONEST scope — a codec only:** it converts `&[FragBinding]` ↔ bytes / `String`; it
-    issues no request. The native HTTP `FragmentTransport` that picks a wire by content
-    negotiation and attaches it as the request body / `values` parameter lands with the
-    streaming HTTP phase (same as the Phase-6 adapters above).
+    issues no request. The native HTTP `FragmentTransport` (`HttpFragmentTransport`, `sq-yzca`,
+    above) attaches the **text** form on the `values` query parameter (the carrier the server
+    reads); this binary wire is the compact alternative a body-carrying transport emits.
 - **Phase 7 adaptive re-planning** (`sq-ij5x`, the FINAL phase) — the client-side ANAPSID
   feedback loop, behind the extra default-OFF **`fedclient-adaptive`** feature (which pulls
   this planner's `adaptive-replan`). `adaptive::execute_adaptive_single_source` runs the plan


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements bead **sq-yzca** — the Phase-6 (sq-2qze) follow-up. The brTPF/TPF adapters previously existed only over an in-memory fixture `FragmentTransport`, and the interpreter rejected a `JoinTree` leaf resolving to a fragment source with `FedError::Unsupported`. This PR lands the two missing pieces the bead names, both behind the default-OFF `fedclient` feature.

## 1. Native HTTP `FragmentTransport` (`source::HttpFragmentTransport`, native-only)

A blocking ureq GET behind the **same default-deny SSRF resolver** as the SRJ `HttpTransport` (the resolved-and-vetted IP is the dialled IP — no DNS-rebinding re-resolve window). It performs the four pieces the bead spells out:

- **Hydra URI-template serialisation** — a `FragPattern` → the TPF query string the sparq server reads (`?subject=&predicate=&object=`, each bound position percent-encoded as an N-Triples term; a variable position omitted).
- **brTPF binding block** — a non-empty binding set rides the `values` parameter via the server's text wire (`wire::encode_bindings_text`).
- **Pagination** — the next-page token is the opaque `hydra:next` URL the server published; GET it verbatim to exhaustion.
- **Turtle/TriG fragment-body parse** — oxttl's `TriGParser` (a Turtle superset) splits the Hydra/VoID **control** triples (`hydra:totalItems`/`void:triples` → count; `hydra:next` → next link) from the **data** triples, keeping only data triples that actually match the requested pattern (so a control triple — or a misbehaving server's non-matching triple — can never become a binding). A malformed body is a clean transport-error string, never a panic (`forbid(unsafe_code)`).

## 2. Interpreter wiring (`operators::fetch_leaf_relation`)

Dispatch on `source_type()`: an endpoint/local leaf takes the SRJ `execute` path; a TPF/brTPF leaf takes the typed `solutions` path (lowered via the new `planner::lower_leaf_fragment`), converting the `FragBinding` rows back to the engine's `oxrdf::Term` model so a fragment leaf equi-joins with an endpoint leaf. A brTPF leaf currently runs as a complete unbound scan the interpreter hash-joins locally — the same discipline the Phase-3 interpreter applies to a planner `JoinAlgo::Bind` (identical result multiset; the streamed per-block bind-join feeder is a later phase). Both the materialised and streaming interpreters share the dispatch.

## Honest scope

- The native transport speaks the sparq TPF server's wire (`subject`/`predicate`/`object`/`page`/`values` params, Hydra/VoID control vocab); it is the production seam for that server family. Cross-vendor TPF template discovery (reading an arbitrary server's `hydra:search`/`hydra:template`) is not in scope for this PR.
- The brTPF leaf is executed as an unbound scan + local hash-join, not yet as the pushed-down per-block bind-join — a correctness-equivalent execution, called out in code + docs as a later phase.

## New public surface

`HttpFragmentTransport`, `lower_leaf_fragment` (both re-exported under `fedclient`). README + `skills/federated-planning/SKILL.md` updated.

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + tests pass in **all three feature states** (off / `fedclient` / `fedclient-adaptive`).
- `scripts/fedclient-boundary-guard.sh` OK — neither `sparq-core` nor `sparq-engine` depends on `sparq-fedclient`.
- `scripts/check-privacy-claims.sh` OK; `cargo doc` clean (`deny(rustdoc::broken_intra_doc_links)`).
- fmt: the crate is under the deferred one-time `cargo fmt --all` reformat (CI fmt is informational per `rustfmt.toml`); new code matches the surrounding style.

`[OPUS-4.8]` — flagged for Fable re-review when available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)