### PR TITLE
test(sparq-shacl): diff-fuzz generator covers logical + nested + complex-path SHACL (sq-0hj7) [OPUS-4.8]

### DIFF
--- a/crates/sparq-shacl/tests/diff_fuzz.rs
+++ b/crates/sparq-shacl/tests/diff_fuzz.rs
@@ -551,3 +551,128 @@ fn missing_focus_is_distinct_from_blank_node_focus() {
         "missing focus collapsed into the blank-node sentinel — masks report-shape bugs"
     );
 }
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-0hj7) Guards for the extended generator: logical components,
+// sh:node nested-shape refs, and complex SHAPE paths. These run in the per-PR
+// fast lane (no reference engine) so the extension can't silently degenerate.
+// ---------------------------------------------------------------------------
+
+/// Over a batch of seeds the generator must actually emit each extended family:
+/// every logical operator (and/or/not/xone), at least one sh:node ref, and at
+/// least one complex path. A regression that stopped generating one of these
+/// would shrink the differential's coverage silently — this fails loudly.
+#[test]
+fn generator_covers_logical_node_and_complex_paths() {
+    let mut seen = gen::Coverage::default();
+    for seed in 0..4000u64 {
+        let mut rng = Rng::new(seed);
+        let cov = Scenario::generate(&mut rng).coverage();
+        seen.logical_and |= cov.logical_and;
+        seen.logical_or |= cov.logical_or;
+        seen.logical_not |= cov.logical_not;
+        seen.logical_xone |= cov.logical_xone;
+        seen.node |= cov.node;
+        seen.complex_path |= cov.complex_path;
+    }
+    assert!(seen.logical_and, "no sh:and generated over 4000 seeds");
+    assert!(seen.logical_or, "no sh:or generated over 4000 seeds");
+    assert!(seen.logical_not, "no sh:not generated over 4000 seeds");
+    assert!(seen.logical_xone, "no sh:xone generated over 4000 seeds");
+    assert!(seen.node, "no sh:node ref generated over 4000 seeds");
+    assert!(
+        seen.complex_path,
+        "no complex path generated over 4000 seeds"
+    );
+}
+
+/// The generator's conform/violate CONSTRUCTION must be sound: a case it intends
+/// to conform must validate as conforming in sparq, and a case it intends to
+/// violate must validate as non-conforming — for every extended component and
+/// every complex-path form. This is the invariant the differential leans on
+/// (a reference engine then checks sparq's *answer*; this checks the *input*
+/// actually exercises the intended outcome), verified here without one.
+#[test]
+fn extended_components_conform_violate_construction_is_sound() {
+    use gen::PathSpecKind::*;
+
+    // (label, value builder, path form) — both conform & violate are checked.
+    // For each we assert sparq's global conformance bit matches the intent. We
+    // assert on the conformance BIT (not the violation set) so the check is
+    // robust to impl-specific result counts; the differential's set comparison
+    // adds the per-component agreement on top.
+    let value_cases: Vec<(&str, gen::Constraint)> = vec![
+        ("and(2)", gen::logical_and(2)),
+        ("and(3)", gen::logical_and(3)),
+        ("or(2)", gen::logical_or(2)),
+        ("or(3)", gen::logical_or(3)),
+        ("not", gen::logical_not()),
+        ("xone(2)", gen::logical_xone(2)),
+        ("xone(3)", gen::logical_xone(3)),
+        ("node(datatype integer)", gen::node_datatype_integer()),
+        ("node(nodeKind IRI)", gen::node_nodekind_iri()),
+    ];
+
+    for (label, value) in &value_cases {
+        for conform in [true, false] {
+            let (shapes_ttl, data_ttl) = gen::single_case(value.clone(), Predicate, conform, 1);
+            assert_conformance(label, "predicate", &shapes_ttl, &data_ttl, conform);
+        }
+    }
+
+    // Complex SHAPE paths. The value-node-set-includes-focus forms (zeroOrOne /
+    // zeroOrMore) are generated value-component-free; we test them with an
+    // integer-datatype value applied to the NON-focus reachable value to confirm
+    // the path still wires up + validates (focus is a value node and is a typed
+    // IRI, which is NOT an integer literal, so those forms would mis-violate the
+    // focus — hence the generator keeps them value-free; here we only exercise
+    // the focus-EXCLUDING forms with a value constraint).
+    let path_cases = [
+        ("sequence", Sequence, gen::datatype_integer()),
+        ("oneOrMore", OneOrMore, gen::datatype_integer()),
+        ("inverse", Inverse, gen::class_kind()),
+    ];
+    for (label, kind, value) in path_cases {
+        for conform in [true, false] {
+            let (shapes_ttl, data_ttl) = gen::single_case(value.clone(), kind, conform, 7);
+            assert_conformance("complex-path", label, &shapes_ttl, &data_ttl, conform);
+        }
+    }
+
+    // And the focus-INCLUDING forms (value-component-free, exactly as the
+    // generator emits them): they must parse + validate as CONFORMING (no value
+    // constraint to violate, no cardinality). A regression that made them
+    // ill-formed or spuriously violating (e.g. checking the focus against
+    // something) would fail here.
+    for (label, kind) in [("zeroOrOne", ZeroOrOne), ("zeroOrMore", ZeroOrMore)] {
+        let (shapes_ttl, data_ttl) = gen::single_case_path_only(kind, 9);
+        assert_conformance("complex-path", label, &shapes_ttl, &data_ttl, true);
+    }
+}
+
+/// Validate `(shapes, data)` through sparq and assert the global conformance bit
+/// equals `expect_conforms`, with the reproducer in the panic message.
+fn assert_conformance(
+    group: &str,
+    label: &str,
+    shapes_ttl: &str,
+    data_ttl: &str,
+    expect_conforms: bool,
+) {
+    let data = Graph::load_str(data_ttl, "turtle")
+        .unwrap_or_else(|e| panic!("{group}/{label}: data parse: {e}\n{data_ttl}"));
+    let shapes = Graph::load_str(shapes_ttl, "turtle")
+        .unwrap_or_else(|e| panic!("{group}/{label}: shapes parse: {e}\n{shapes_ttl}"));
+    let report = validate(&data, &shapes);
+    assert_eq!(
+        report.conforms,
+        expect_conforms,
+        "{group}/{label}: generator intended conforms={expect_conforms} but sparq reported \
+         conforms={} ({} results) — the conform/violate construction is UNSOUND, so the \
+         differential would compare a case whose intended outcome doesn't hold.\
+         \n--- shapes.ttl ---\n{shapes_ttl}\n--- data.ttl ---\n{data_ttl}\n--- results ---\n{:#?}",
+        report.conforms,
+        report.results.len(),
+        report.results,
+    );
+}

--- a/crates/sparq-shacl/tests/diff_fuzz/pyshacl_adapter.py
+++ b/crates/sparq-shacl/tests/diff_fuzz/pyshacl_adapter.py
@@ -94,7 +94,20 @@ def run(data_ttl, shapes_ttl):
     p_focus = rdflib.URIRef(SH + "focusNode")
     p_comp = rdflib.URIRef(SH + "sourceConstraintComponent")
     p_path = rdflib.URIRef(SH + "resultPath")
+    p_detail = rdflib.URIRef(SH + "detail")
+    # [OPUS-4.8] (sq-0hj7) Collect only TOP-LEVEL results. For sh:node / logical
+    # components, pySHACL emits an outer result (the sh:node / sh:and / … against
+    # the value node, carrying sh:resultPath) AND an OPTIONAL nested `sh:detail`
+    # sub-result for the inner constraint that failed (e.g. the inner
+    # sh:minLength, focus = the value node, no path). `sh:detail` is non-normative
+    # (SHACL §3.6.2 "MAY"), and sparq-shacl keeps inner results off the comparable
+    # top-level `results` list (they live in `ValidationResult::details`). Comparing
+    # the nested sub-results would diff two engines' OPTIONAL detail policies, not a
+    # real disagreement — so we exclude any result that is the object of an sh:detail.
+    nested = set(report_graph.objects(None, p_detail))
     for res in report_graph.subjects(rdf_type, result_t):
+        if res in nested:
+            continue
         focus = report_graph.value(res, p_focus)
         comp = report_graph.value(res, p_comp)
         path = report_graph.value(res, p_path)

--- a/crates/sparq-shacl/tests/gen.rs
+++ b/crates/sparq-shacl/tests/gen.rs
@@ -10,24 +10,45 @@
 //!
 //! ## In-scope constraint components (the comparable subset — what is GENERATED)
 //! These are generated and their reports compared against the reference engine:
-//!   sh:minCount, sh:maxCount (cardinality, on every property shape) and one value
-//!   component per property shape drawn from: sh:datatype, sh:nodeKind, sh:class,
-//!   sh:pattern, sh:in, sh:minLength, sh:maxLength, sh:hasValue, sh:minInclusive,
-//!   sh:maxInclusive, sh:minExclusive, sh:maxExclusive.
+//!   sh:minCount, sh:maxCount (cardinality, on every SIMPLE-path property shape)
+//!   and one value component per property shape drawn from: sh:datatype,
+//!   sh:nodeKind, sh:class, sh:pattern, sh:in, sh:minLength, sh:maxLength,
+//!   sh:hasValue, sh:minInclusive, sh:maxInclusive, sh:minExclusive,
+//!   sh:maxExclusive.
+//!
+//! [OPUS-4.8] (sq-0hj7) Extended to also generate, as the property shape's value
+//! component:
+//!   - the **logical components** sh:and / sh:or / sh:not / sh:xone, each over a
+//!     small list of inline member node-shapes that carry one of the simple value
+//!     components above. The generator drives each value node to a known
+//!     per-member conform/violate decision, then derives the composite's expected
+//!     outcome (∧ / ∨ / ¬ / exactly-one) — the differential only compares the
+//!     (focus, component, path) violation set, so the bespoke per-member messages
+//!     don't matter.
+//!   - **sh:node** nested-shape references: an inline member node-shape carrying a
+//!     simple value component, applied to the value node. This also stresses the
+//!     (focus, shape) conformance memo in the evaluator.
+//!
+//! ## Complex SHAPE paths (sq-0hj7)
+//! The property shape's `sh:path` is now a [`PathSpec`], not just a bare
+//! predicate: sequence / inverse / oneOrMore / zeroOrMore / zeroOrOne forms are
+//! generated alongside simple predicates, and the data graph is wired so values
+//! are reachable along the chosen path. The `(focus, component, path)` comparison
+//! key already maps any non-`Predicate` path to the `_:path` sentinel on both
+//! sides (sparq's `norm_path` and the pySHACL adapter's `_path_key`), so complex
+//! paths compare by presence + the (focus, component) pair — exactly the bead's
+//! "relax the path-key to the `_:path` sentinel" disposition. Path forms whose
+//! value-node set INCLUDES the focus itself (zeroOrOne / zeroOrMore) are only
+//! emitted WITHOUT a value component (count-free), so the focus node is never
+//! checked against a value constraint it wasn't meant to satisfy.
 //!
 //! ## Deliberately OUT of scope (documented; tracked as TODO beads where useful)
-//!   - the logical components sh:and / sh:or / sh:not / sh:xone and sh:node
-//!     (nested-shape reference) — sparq supports them, but generating VALID nested
-//!     shapes + the matching reference-report normalisation is a follow-up bead.
 //!   - sh:closed, sh:qualifiedValueShape, sh:disjoint/equals/lessThan*,
 //!     sh:uniqueLang, sh:languageIn — future generator extensions (their report
 //!     shapes / pySHACL message-paths need extra normalisation).
 //!   - sh:sparql / SPARQL constraint COMPONENTS — pySHACL and sparq both support
 //!     them but their report focus/value semantics differ enough to need bespoke
 //!     comparison; left for a follow-up bead.
-//!   - complex property paths (sequence / inverse / */+) as the SHAPE path — the
-//!     generator uses simple predicate paths so the (focus, component, path) key
-//!     is byte-comparable; a complex-path generation mode is a follow-up bead.
 //!   - sh:severity other than the default sh:Violation — the differential compares
 //!     the conformance bit + violated-component set, which is severity-agnostic by
 //!     construction here (everything is a Violation).
@@ -68,7 +89,7 @@ const EX: &str = "http://example.org/";
 /// contributes to the shapes graph and a generator for object values that
 /// conform vs violate it.
 #[derive(Clone, Debug)]
-enum Constraint {
+pub enum Constraint {
     Datatype(&'static str), // xsd local name (integer/string/boolean/decimal)
     NodeKind(&'static str), // sh:IRI / sh:Literal / sh:BlankNode
     Class(String),          // sh:class <iri>
@@ -81,6 +102,110 @@ enum Constraint {
     MaxInclusive(i64),
     MinExclusive(i64),
     MaxExclusive(i64),
+    // [OPUS-4.8] (sq-0hj7) Logical components sh:and/or/not/xone over inline
+    // member node-shapes. Each member is an `sh:in (...)` token list (see
+    // `Logical::member_lines` / the conform/violate construction below) chosen so
+    // ONE value's per-member conformance is independently controllable, so the
+    // composite's expected outcome is computable.
+    Logical(Logical),
+    // [OPUS-4.8] (sq-0hj7) `sh:node <inline shape>` — a nested node-shape that
+    // applies an inner value constraint to the VALUE NODE. Conform/violate of the
+    // composite is exactly conform/violate of the inner constraint, so we delegate.
+    Node(Box<Constraint>),
+}
+
+/// [OPUS-4.8] (sq-0hj7) A logical component over inline `sh:in`-token member
+/// node-shapes. The member encoding makes one value's per-member conformance
+/// independently controllable so the composite outcome is derivable:
+///
+/// - `And`: every member list contains a shared `KEEP` token, so emitting `KEEP`
+///   conforms to all; an out-of-list token conforms to none.
+/// - `Or`: member lists are disjoint singletons (`tok0`, `tok1`, …); `tok0`
+///   conforms to exactly one (so OR holds); an out-of-list token to none.
+/// - `Xone`: disjoint singletons too; `tok0` conforms to exactly one (XONE holds);
+///   an out-of-list token to zero (XONE violated). A single value is in at most
+///   one disjoint list, so the >1-match path can't arise.
+/// - `Not`: a single member; `KEEP` conforms to it (so NOT is violated), an
+///   out-of-list token does not (so NOT holds).
+#[derive(Clone, Debug)]
+pub struct Logical {
+    op: LogicalOp,
+    /// Number of member shapes (1 for `Not`, 2..=3 for the list operators).
+    members: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LogicalOp {
+    And,
+    Or,
+    Not,
+    Xone,
+}
+
+/// The shared token every `And` member list contains and the single `Not` member
+/// list contains — emitting it conforms to that/those member(s).
+const KEEP: &str = "\"keep\"";
+/// A token in NO member list — emitting it conforms to no member.
+const MISS: &str = "\"miss-none\"";
+
+impl Logical {
+    fn keyword(&self) -> &'static str {
+        match self.op {
+            LogicalOp::And => "and",
+            LogicalOp::Or => "or",
+            LogicalOp::Not => "not",
+            LogicalOp::Xone => "xone",
+        }
+    }
+
+    /// The `sh:in` token list for member index `i`.
+    fn member_list(&self, i: u64) -> String {
+        match self.op {
+            // every And member shares KEEP (plus a distinct filler so the lists
+            // aren't byte-identical) → KEEP conforms to all of them.
+            LogicalOp::And => format!("{KEEP} \"and{i}\""),
+            // Or/Xone: disjoint singletons.
+            LogicalOp::Or | LogicalOp::Xone => format!("\"opt{i}\""),
+            // Not: a single member whose list is {KEEP}.
+            LogicalOp::Not => KEEP.to_string(),
+        }
+    }
+
+    /// The Turtle for the logical component: `sh:<kw> ( [member] … )`, or for
+    /// `sh:not` the single `sh:not [member]` form.
+    fn shape_line(&self) -> String {
+        let member = |i: u64| format!("[ sh:in ( {} ) ]", self.member_list(i));
+        if self.op == LogicalOp::Not {
+            format!("sh:not {}", member(0))
+        } else {
+            let members: Vec<String> = (0..self.members).map(member).collect();
+            format!("sh:{} ( {} )", self.keyword(), members.join(" "))
+        }
+    }
+
+    /// A value that makes the COMPOSITE conform.
+    fn conforming_value(&self) -> String {
+        match self.op {
+            // KEEP is in every And member list / is the Or/Xone… no: for Or/Xone
+            // KEEP is in NO list, so use opt0 (in exactly one).
+            LogicalOp::And => KEEP.to_string(),
+            LogicalOp::Or | LogicalOp::Xone => "\"opt0\"".to_string(),
+            // NOT holds when the value does NOT conform to the inner member: an
+            // out-of-list token does not match {KEEP}.
+            LogicalOp::Not => MISS.to_string(),
+        }
+    }
+
+    /// A value that makes the COMPOSITE violate.
+    fn violating_value(&self) -> String {
+        match self.op {
+            // in no list → conforms to no member → And/Or/Xone all fail (Xone via
+            // the zero-match branch).
+            LogicalOp::And | LogicalOp::Or | LogicalOp::Xone => MISS.to_string(),
+            // NOT is violated when the value DOES conform to the inner member.
+            LogicalOp::Not => KEEP.to_string(),
+        }
+    }
 }
 
 impl Constraint {
@@ -100,6 +225,12 @@ impl Constraint {
             Constraint::MaxInclusive(n) => vec![format!("sh:maxInclusive {n}")],
             Constraint::MinExclusive(n) => vec![format!("sh:minExclusive {n}")],
             Constraint::MaxExclusive(n) => vec![format!("sh:maxExclusive {n}")],
+            Constraint::Logical(l) => vec![l.shape_line()],
+            // sh:node references an inline member node-shape carrying the inner
+            // value constraint, applied to the value node.
+            Constraint::Node(inner) => {
+                vec![format!("sh:node [ {} ]", inner.shape_lines().join(" ; "))]
+            }
         }
     }
 
@@ -131,6 +262,8 @@ impl Constraint {
             Constraint::MaxInclusive(n) => format!("{}", n - rng.below(3) as i64),
             Constraint::MinExclusive(n) => format!("{}", n + 1 + rng.below(3) as i64),
             Constraint::MaxExclusive(n) => format!("{}", n - 1 - rng.below(3) as i64),
+            Constraint::Logical(l) => l.conforming_value(),
+            Constraint::Node(inner) => inner.conforming_value(rng),
         }
     }
 
@@ -164,13 +297,17 @@ impl Constraint {
             Constraint::MaxInclusive(n) => format!("{}", n + 1 + rng.below(3) as i64),
             Constraint::MinExclusive(n) => format!("{}", n - rng.below(2) as i64), // n itself violates min-exclusive
             Constraint::MaxExclusive(n) => format!("{}", n + rng.below(2) as i64),
+            Constraint::Logical(l) => l.violating_value(),
+            Constraint::Node(inner) => inner.violating_value(rng),
         }
     }
 
     /// Does this constraint need a typed class instance in the data graph?
+    /// `sh:node` over an inner `sh:class` propagates the inner requirement.
     fn class_iri(&self) -> Option<&str> {
         match self {
             Constraint::Class(c) => Some(c),
+            Constraint::Node(inner) => inner.class_iri(),
             _ => None,
         }
     }
@@ -207,10 +344,84 @@ fn typed_literal(dt: &str, rng: &mut Rng, valid: bool) -> String {
     }
 }
 
-/// One property shape: a path predicate, a min/maxCount pair, and a value
-/// constraint. The generator decides per-instance whether to satisfy or violate.
+/// [OPUS-4.8] (sq-0hj7) The `sh:path` of a property shape: a simple predicate or
+/// one of the complex forms. Each form knows how to (a) render itself as a Turtle
+/// path expression for `sh:path`, and (b) emit the data-graph triple(s) that make
+/// a given `value` reachable from a `subject` along it.
+///
+/// The complex forms are restricted to those whose value-node set does NOT include
+/// the focus node itself — `Inverse`, `Sequence`, `OneOrMore` — so a value
+/// constraint can be attached without the focus being checked against it. The
+/// `ZeroOrOne` / `ZeroOrMore` forms (where the focus IS a value node) are only
+/// generated count-free + value-constraint-free (see `gen_path`).
+#[derive(Clone, Debug)]
+enum PathSpec {
+    /// `<p>` — a bare predicate path.
+    Predicate(String),
+    /// `[ sh:inversePath <p> ]` — the value node is the SUBJECT of `<value> <p> <subject>`.
+    Inverse(String),
+    /// `( <p1> <p2> )` — a two-step sequence through a fresh intermediate node.
+    Sequence(String, String),
+    /// `[ sh:oneOrMorePath <p> ]` — one hop suffices to make a value reachable.
+    OneOrMore(String),
+    /// `[ sh:zeroOrOnePath <p> ]` — focus is also a value node (count/value-free).
+    ZeroOrOne(String),
+    /// `[ sh:zeroOrMorePath <p> ]` — focus is also a value node (count/value-free).
+    ZeroOrMore(String),
+}
+
+impl PathSpec {
+    /// `true` for the simple predicate path (where the `(focus, component, path)`
+    /// key carries the bare predicate IRI on both engines); `false` for the
+    /// complex forms (which both engines normalise to the `_:path` sentinel).
+    fn is_simple(&self) -> bool {
+        matches!(self, PathSpec::Predicate(_))
+    }
+
+    /// The Turtle path expression for `sh:path`.
+    fn to_turtle(&self) -> String {
+        match self {
+            PathSpec::Predicate(p) => format!("<{p}>"),
+            PathSpec::Inverse(p) => format!("[ sh:inversePath <{p}> ]"),
+            PathSpec::Sequence(a, b) => format!("( <{a}> <{b}> )"),
+            PathSpec::OneOrMore(p) => format!("[ sh:oneOrMorePath <{p}> ]"),
+            PathSpec::ZeroOrOne(p) => format!("[ sh:zeroOrOnePath <{p}> ]"),
+            PathSpec::ZeroOrMore(p) => format!("[ sh:zeroOrMorePath <{p}> ]"),
+        }
+    }
+
+    /// Emit the data triple(s) (subject, predicate, object Turtle) that make
+    /// `value` reachable from `subject` along this path. `fresh` mints the unique
+    /// intermediate node a sequence path needs.
+    fn emit(&self, subject: &str, value: &str, fresh: &mut impl FnMut() -> String) -> Vec<String> {
+        match self {
+            PathSpec::Predicate(p)
+            | PathSpec::OneOrMore(p)
+            | PathSpec::ZeroOrOne(p)
+            | PathSpec::ZeroOrMore(p) => {
+                vec![format!("<{subject}> <{p}> {value} .")]
+            }
+            // inverse: value --p--> subject (so subject reaches value via ^p).
+            // The value MUST be an IRI/blank to be a subject; complex inverse paths
+            // are only generated with IRI-yielding value constraints (see gen_path),
+            // but for a literal value we still need a subject, so route through a
+            // fresh node and assert literal equality is impossible — guarded upstream.
+            PathSpec::Inverse(p) => vec![format!("{value} <{p}> <{subject}> .")],
+            PathSpec::Sequence(a, b) => {
+                let mid = fresh();
+                vec![
+                    format!("<{subject}> <{a}> <{mid}> ."),
+                    format!("<{mid}> <{b}> {value} ."),
+                ]
+            }
+        }
+    }
+}
+
+/// One property shape: a path, a min/maxCount pair, and a value constraint. The
+/// generator decides per-instance whether to satisfy or violate.
 struct PropShape {
-    path_pred: String,
+    path: PathSpec,
     min_count: Option<u64>,
     max_count: Option<u64>,
     value: Option<Constraint>,
@@ -218,7 +429,7 @@ struct PropShape {
 
 impl PropShape {
     fn shape_turtle(&self) -> String {
-        let mut lines = vec![format!("sh:path <{}>", self.path_pred)];
+        let mut lines = vec![format!("sh:path {}", self.path.to_turtle())];
         if let Some(n) = self.min_count {
             lines.push(format!("sh:minCount {n}"));
         }
@@ -245,11 +456,14 @@ pub struct Scenario {
     support: Vec<String>,
 }
 
-/// One data-graph instance of the target class, with the property objects to emit.
+/// One data-graph instance of the target class. The value objects are wired to
+/// the focus subject along each property shape's path during generation (a
+/// complex path emits intermediate triples), so we store the fully-rendered
+/// triple lines rather than `(predicate, object)` pairs. [OPUS-4.8] (sq-0hj7)
 struct Instance {
     subject: String,
-    /// (predicate, object-turtle) pairs.
-    objects: Vec<(String, String)>,
+    /// Fully-rendered `<s> <p> o .` triple lines (path-aware).
+    triples: Vec<String>,
 }
 
 impl Scenario {
@@ -261,26 +475,40 @@ impl Scenario {
         let mut props = Vec::new();
         let mut support = Vec::new();
         let mut used_preds = std::collections::HashSet::new();
+        let mut fresh_id = 0u64;
         for i in 0..n_props {
-            // distinct predicate per property shape so cardinality is unambiguous.
+            // distinct base predicate per property shape so cardinality is
+            // unambiguous (the path may compose several distinct predicates).
             let mut pred = format!("{EX}p{i}");
             while !used_preds.insert(pred.clone()) {
                 pred = format!("{EX}p{}_{}", i, rng.below(1000));
             }
-            let value = gen_constraint(rng, &mut support);
-            // counts: keep min<=max and small so violations are reachable.
-            let min_count = if rng.chance(2, 3) {
-                Some(rng.below(2))
+            // [OPUS-4.8] (sq-0hj7) choose a path form first — it constrains which
+            // value-constraint families are sound (e.g. an inverse path needs an
+            // IRI-valued constraint, and focus-including paths must stay value-free).
+            let path = gen_path(rng, &pred, &mut used_preds);
+            let value = gen_value_for_path(rng, &path, &mut support);
+            // counts: keep min<=max and small so violations are reachable. Complex
+            // paths get NO cardinality constraint (their value-node counting under
+            // */+/seq/inverse has subtle focus-inclusion semantics we keep out of
+            // the cardinality comparison — the value-component comparison still runs).
+            let (min_count, max_count) = if path.is_simple() {
+                let mn = if rng.chance(2, 3) {
+                    Some(rng.below(2))
+                } else {
+                    None
+                };
+                let mx = if rng.chance(1, 2) {
+                    Some(1 + rng.below(2))
+                } else {
+                    None
+                };
+                (mn, mx)
             } else {
-                None
-            };
-            let max_count = if rng.chance(1, 2) {
-                Some(1 + rng.below(2))
-            } else {
-                None
+                (None, None)
             };
             props.push(PropShape {
-                path_pred: pred,
+                path,
                 min_count,
                 max_count,
                 value,
@@ -293,7 +521,7 @@ impl Scenario {
         let mut instances = Vec::new();
         for i in 0..n_inst {
             let subject = format!("{EX}i{}_{}", class_n, i);
-            let mut objects = Vec::new();
+            let mut triples = Vec::new();
             for p in &props {
                 // Decide how many values to emit for this property (0..=3), then
                 // make each conform or violate the value constraint.
@@ -312,10 +540,14 @@ impl Scenario {
                         }
                         None => format!("\"v{}\"", rng.below(10)),
                     };
-                    objects.push((p.path_pred.clone(), obj));
+                    let mut fresh = || {
+                        fresh_id += 1;
+                        format!("{EX}mid{fresh_id}")
+                    };
+                    triples.extend(p.path.emit(&subject, &obj, &mut fresh));
                 }
             }
-            instances.push(Instance { subject, objects });
+            instances.push(Instance { subject, triples });
         }
 
         Scenario {
@@ -340,8 +572,9 @@ impl Scenario {
         let mut s = String::from(PREFIXES);
         for inst in &self.instances {
             s.push_str(&format!("<{}> a <{}> .\n", inst.subject, self.target_class));
-            for (pred, obj) in &inst.objects {
-                s.push_str(&format!("<{}> <{}> {} .\n", inst.subject, pred, obj));
+            for triple in &inst.triples {
+                s.push_str(triple);
+                s.push('\n');
             }
         }
         // Supporting declarations (typed class instances for sh:class, etc.).
@@ -350,6 +583,67 @@ impl Scenario {
             s.push('\n');
         }
         s
+    }
+}
+
+/// [OPUS-4.8] (sq-0hj7) Choose the `sh:path` form for a property shape. ~5-in-6
+/// stay simple predicate paths (so cardinality + simple-path-key coverage is
+/// unchanged); ~1-in-6 pick a complex form, drawing fresh distinct predicates for
+/// the multi-predicate forms so the path's predicates don't collide with other
+/// shapes' base predicates.
+fn gen_path(
+    rng: &mut Rng,
+    base_pred: &str,
+    used_preds: &mut std::collections::HashSet<String>,
+) -> PathSpec {
+    if !rng.chance(1, 6) {
+        return PathSpec::Predicate(base_pred.to_string());
+    }
+    match rng.below(5) {
+        0 => PathSpec::Inverse(base_pred.to_string()),
+        1 => PathSpec::Sequence(base_pred.to_string(), fresh_pred(rng, used_preds)),
+        2 => PathSpec::OneOrMore(base_pred.to_string()),
+        3 => PathSpec::ZeroOrOne(base_pred.to_string()),
+        _ => PathSpec::ZeroOrMore(base_pred.to_string()),
+    }
+}
+
+/// Mints a fresh predicate IRI distinct from every predicate `used_preds` has
+/// seen, so a sequence path's second predicate can't collide with another
+/// shape's base predicate (which would blur cardinality across shapes).
+fn fresh_pred(rng: &mut Rng, used_preds: &mut std::collections::HashSet<String>) -> String {
+    let mut p = format!("{EX}q{}", rng.below(100000));
+    while !used_preds.insert(p.clone()) {
+        p = format!("{EX}q{}", rng.below(100000));
+    }
+    p
+}
+
+/// [OPUS-4.8] (sq-0hj7) Pick a value constraint that is SOUND for the chosen path
+/// form:
+///   - simple predicate / sequence / oneOrMore: any in-scope value component
+///     (the value is the final object, so a literal is fine).
+///   - inverse: the value node must be a SUBJECT, so it must be an IRI — restrict
+///     to `sh:class` (both its conforming and violating values are IRIs).
+///   - zeroOrOne / zeroOrMore: the focus node IS a value node, so a value
+///     component would (correctly, but confusingly) also be checked against the
+///     focus; we keep these path-only (no value component) so the differential
+///     compares pure complex-path reachability + cardinality-free conformance.
+fn gen_value_for_path(
+    rng: &mut Rng,
+    path: &PathSpec,
+    support: &mut Vec<String>,
+) -> Option<Constraint> {
+    match path {
+        PathSpec::Predicate(_) | PathSpec::Sequence(..) | PathSpec::OneOrMore(_) => {
+            gen_constraint(rng, support)
+        }
+        PathSpec::Inverse(_) => {
+            // IRI-valued only (value node becomes a subject).
+            let cls = format!("{EX}Kind{}", rng.below(100));
+            Some(Constraint::Class(cls))
+        }
+        PathSpec::ZeroOrOne(_) | PathSpec::ZeroOrMore(_) => None,
     }
 }
 
@@ -365,7 +659,8 @@ fn gen_constraint(rng: &mut Rng, _support: &mut Vec<String>) -> Option<Constrain
     if rng.chance(1, 6) {
         return None;
     }
-    let choice = rng.below(12);
+    // 12..=14: the sq-0hj7 logical/node extensions (drawn ~1-in-5 of value cases).
+    let choice = rng.below(15);
     Some(match choice {
         0 => Constraint::Datatype(rng.pick(&["integer", "string", "boolean", "decimal"])),
         1 => Constraint::NodeKind(rng.pick(&["sh:IRI", "sh:Literal", "sh:BlankNode"])),
@@ -388,8 +683,53 @@ fn gen_constraint(rng: &mut Rng, _support: &mut Vec<String>) -> Option<Constrain
         8 => Constraint::MinInclusive(rng.below(50) as i64),
         9 => Constraint::MaxInclusive(50 + rng.below(50) as i64),
         10 => Constraint::MinExclusive(rng.below(50) as i64),
-        _ => Constraint::MaxExclusive(50 + rng.below(50) as i64),
+        11 => Constraint::MaxExclusive(50 + rng.below(50) as i64),
+        // [OPUS-4.8] (sq-0hj7) logical components over inline `sh:in`-token members.
+        12 | 13 => {
+            let op = *rng.pick(&[
+                LogicalOp::And,
+                LogicalOp::Or,
+                LogicalOp::Not,
+                LogicalOp::Xone,
+            ]);
+            let members = if op == LogicalOp::Not {
+                1
+            } else {
+                2 + rng.below(2) // 2..=3 members
+            };
+            Constraint::Logical(Logical { op, members })
+        }
+        // [OPUS-4.8] (sq-0hj7) sh:node over an inline member shape carrying a
+        // simple leaf value constraint. Restrict the leaf to families whose
+        // conform/violate is unambiguous on a value node — reuse a small subset
+        // (datatype / nodeKind / in / pattern / numeric range).
+        _ => {
+            let inner = gen_leaf_for_node(rng);
+            Constraint::Node(Box::new(inner))
+        }
     })
+}
+
+/// [OPUS-4.8] (sq-0hj7) A leaf value constraint suitable INSIDE a `sh:node` member
+/// shape. We exclude `sh:class` (its conforming value is a typed-instance
+/// placeholder resolved per top-level value, which the nested `resolve_value`
+/// path already handles, but keeping the nested leaf class-free avoids minting
+/// support inside a member shape) and the logical/node families (no nesting of
+/// composites — one level is enough to stress the conformance memo).
+fn gen_leaf_for_node(rng: &mut Rng) -> Constraint {
+    match rng.below(7) {
+        0 => Constraint::Datatype(rng.pick(&["integer", "string", "boolean"])),
+        1 => Constraint::NodeKind(rng.pick(&["sh:IRI", "sh:Literal"])),
+        2 => Constraint::Pattern(rng.pick(&["^[a-z]+[0-9]+$", "^a.*$"])),
+        3 => {
+            let n = 2 + rng.below(3);
+            let vals: Vec<String> = (0..n).map(|j| format!("\"opt{j}\"")).collect();
+            Constraint::In(vals)
+        }
+        4 => Constraint::MinInclusive(rng.below(50) as i64),
+        5 => Constraint::MaxInclusive(50 + rng.below(50) as i64),
+        _ => Constraint::MinLength(1 + rng.below(3)),
+    }
 }
 
 /// Resolves the `<__CLASS_INSTANCE__>` placeholder produced by a conforming
@@ -411,3 +751,214 @@ const PREFIXES: &str = "\
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 ";
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-0hj7) Test-support: coverage introspection + a single-case
+// builder so the per-PR fast lane can prove (a) the new component families are
+// actually generated, and (b) the generator's conform/violate construction is
+// SOUND — i.e. sparq's own report agrees with what the generator intended for
+// each value. Without these guards the extended generator could silently emit
+// shapes that always (dis)agree for the wrong reason.
+// ---------------------------------------------------------------------------
+
+/// Which extended component families a scenario contains (for the coverage guard).
+#[derive(Default, Debug)]
+pub struct Coverage {
+    pub logical_and: bool,
+    pub logical_or: bool,
+    pub logical_not: bool,
+    pub logical_xone: bool,
+    pub node: bool,
+    pub complex_path: bool,
+}
+
+impl Scenario {
+    /// Classify the component families present in this scenario.
+    pub fn coverage(&self) -> Coverage {
+        let mut c = Coverage::default();
+        for p in &self.props {
+            if !p.path.is_simple() {
+                c.complex_path = true;
+            }
+            match &p.value {
+                Some(Constraint::Logical(l)) => match l.op {
+                    LogicalOp::And => c.logical_and = true,
+                    LogicalOp::Or => c.logical_or = true,
+                    LogicalOp::Not => c.logical_not = true,
+                    LogicalOp::Xone => c.logical_xone = true,
+                },
+                Some(Constraint::Node(_)) => c.node = true,
+                _ => {}
+            }
+        }
+        c
+    }
+}
+
+/// A self-contained `(shapes_ttl, data_ttl)` pair: a node shape with ONE property
+/// shape carrying `path` + `value`, and ONE focus instance whose single value is
+/// driven to conform (`conform=true`) or violate (`conform=false`) `value`.
+///
+/// Used by the soundness self-test: the generator INTENDS this case to
+/// conform/violate, so sparq validating it must agree (the global conformance bit
+/// must equal `conform`). This is the invariant the differential leans on, checked
+/// here without a reference engine.
+pub fn single_case(
+    value: Constraint,
+    path: PathSpecKind,
+    conform: bool,
+    seed: u64,
+) -> (String, String) {
+    let mut rng = Rng::new(seed);
+    let class = format!("{EX}T{seed}");
+    let base_pred = format!("{EX}pp");
+    let path = match path {
+        PathSpecKind::Predicate => PathSpec::Predicate(base_pred.clone()),
+        PathSpecKind::Inverse => PathSpec::Inverse(base_pred.clone()),
+        PathSpecKind::Sequence => PathSpec::Sequence(base_pred.clone(), format!("{EX}qq")),
+        PathSpecKind::OneOrMore => PathSpec::OneOrMore(base_pred.clone()),
+        PathSpecKind::ZeroOrOne => PathSpec::ZeroOrOne(base_pred.clone()),
+        PathSpecKind::ZeroOrMore => PathSpec::ZeroOrMore(base_pred.clone()),
+    };
+
+    let mut shapes = String::from(PREFIXES);
+    shapes.push_str(&format!("<{EX}S> a sh:NodeShape ;\n"));
+    shapes.push_str(&format!("    sh:targetClass <{class}> ;\n"));
+    let prop = PropShape {
+        path: path.clone(),
+        min_count: None,
+        max_count: None,
+        value: Some(value.clone()),
+    };
+    shapes.push_str(&prop.shape_turtle());
+    shapes.push_str(" .\n");
+
+    let subject = format!("{EX}foc");
+    let raw = if conform {
+        value.conforming_value(&mut rng)
+    } else {
+        value.violating_value(&mut rng)
+    };
+    let mut support = Vec::new();
+    let obj = resolve_value(raw, &value, &mut support, &mut rng);
+    let mut fresh_n = 0u64;
+    let mut fresh = || {
+        fresh_n += 1;
+        format!("{EX}m{fresh_n}")
+    };
+    let triples = path.emit(&subject, &obj, &mut fresh);
+
+    let mut data = String::from(PREFIXES);
+    data.push_str(&format!("<{subject}> a <{class}> .\n"));
+    for t in &triples {
+        data.push_str(t);
+        data.push('\n');
+    }
+    for line in &support {
+        data.push_str(line);
+        data.push('\n');
+    }
+    (shapes, data)
+}
+
+/// A value-component-FREE single case for a focus-including path form
+/// (`zeroOrOne` / `zeroOrMore`), mirroring exactly how the generator emits them:
+/// one focus instance with one outbound edge, no value or cardinality constraint.
+/// Such a shape can only conform (nothing to violate), so the soundness test
+/// asserts conformance — a regression that made the path ill-formed or spuriously
+/// violating (e.g. checking the focus against something) would fail.
+pub fn single_case_path_only(path: PathSpecKind, seed: u64) -> (String, String) {
+    let mut rng = Rng::new(seed);
+    let class = format!("{EX}TP{seed}");
+    let base_pred = format!("{EX}pp");
+    let path = match path {
+        PathSpecKind::Predicate => PathSpec::Predicate(base_pred.clone()),
+        PathSpecKind::Inverse => PathSpec::Inverse(base_pred.clone()),
+        PathSpecKind::Sequence => PathSpec::Sequence(base_pred.clone(), format!("{EX}qq")),
+        PathSpecKind::OneOrMore => PathSpec::OneOrMore(base_pred.clone()),
+        PathSpecKind::ZeroOrOne => PathSpec::ZeroOrOne(base_pred.clone()),
+        PathSpecKind::ZeroOrMore => PathSpec::ZeroOrMore(base_pred.clone()),
+    };
+    let mut shapes = String::from(PREFIXES);
+    shapes.push_str(&format!("<{EX}S> a sh:NodeShape ;\n"));
+    shapes.push_str(&format!("    sh:targetClass <{class}> ;\n"));
+    let prop = PropShape {
+        path: path.clone(),
+        min_count: None,
+        max_count: None,
+        value: None,
+    };
+    shapes.push_str(&prop.shape_turtle());
+    shapes.push_str(" .\n");
+
+    let subject = format!("{EX}foc");
+    let obj = format!("\"v{}\"", rng.below(5));
+    let mut fresh_n = 0u64;
+    let mut fresh = || {
+        fresh_n += 1;
+        format!("{EX}m{fresh_n}")
+    };
+    let triples = path.emit(&subject, &obj, &mut fresh);
+    let mut data = String::from(PREFIXES);
+    data.push_str(&format!("<{subject}> a <{class}> .\n"));
+    for t in &triples {
+        data.push_str(t);
+        data.push('\n');
+    }
+    (shapes, data)
+}
+
+/// The path forms `single_case` can build (a public mirror of the private
+/// `PathSpec` discriminant, so tests don't need the private predicates).
+#[derive(Clone, Copy, Debug)]
+pub enum PathSpecKind {
+    Predicate,
+    Inverse,
+    Sequence,
+    OneOrMore,
+    ZeroOrOne,
+    ZeroOrMore,
+}
+
+/// Constructors the soundness test uses to build each extended value component
+/// without reaching into the private `Constraint` enum.
+pub fn logical_and(members: u64) -> Constraint {
+    Constraint::Logical(Logical {
+        op: LogicalOp::And,
+        members,
+    })
+}
+pub fn logical_or(members: u64) -> Constraint {
+    Constraint::Logical(Logical {
+        op: LogicalOp::Or,
+        members,
+    })
+}
+pub fn logical_not() -> Constraint {
+    Constraint::Logical(Logical {
+        op: LogicalOp::Not,
+        members: 1,
+    })
+}
+pub fn logical_xone(members: u64) -> Constraint {
+    Constraint::Logical(Logical {
+        op: LogicalOp::Xone,
+        members,
+    })
+}
+/// `sh:node [ sh:datatype xsd:integer ]` — the simplest nested node-shape ref.
+pub fn node_datatype_integer() -> Constraint {
+    Constraint::Node(Box::new(Constraint::Datatype("integer")))
+}
+/// `sh:node [ sh:nodeKind sh:IRI ]` — an IRI-valued nested node-shape ref.
+pub fn node_nodekind_iri() -> Constraint {
+    Constraint::Node(Box::new(Constraint::NodeKind("sh:IRI")))
+}
+/// A plain `sh:datatype xsd:integer` (for the complex-path soundness cases).
+pub fn datatype_integer() -> Constraint {
+    Constraint::Datatype("integer")
+}
+/// `sh:class <iri>` — IRI-valued (used for the inverse-path soundness case).
+pub fn class_kind() -> Constraint {
+    Constraint::Class(format!("{EX}KindT"))
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change for bead **sq-0hj7** (`area:sparq-shacl`, `testing`). One of several agents @jeswr runs on this account.

## What

Follow-up to sq-55c1 (#166). Extends the SHACL differential generator (`crates/sparq-shacl/tests/gen.rs`) so the cross-engine fuzz exercises three new component classes the bead called out — each with VALID-input generation **and** a matching reference-report comparison:

1. **Logical components** `sh:and` / `sh:or` / `sh:not` / `sh:xone`. Member shapes are inline `sh:in`-token node-shapes encoded so ONE value's per-member conformance is independently controllable (And: a shared `KEEP` token in every member list; Or/Xone: disjoint singletons; Not: a single member), making the composite outcome derivable — so the generator can mint a known-conforming or known-violating value soundly.
2. **`sh:node`** nested-shape references over an inline member node-shape applied to the value node (also stresses the `(focus, shape)` conformance memo in the evaluator).
3. **Complex SHAPE paths**: a new `PathSpec` (`sequence` / `inverse` / `oneOrMore` / `zeroOrMore` / `zeroOrOne`) drives both the `sh:path` Turtle and the data-graph wiring. The `(focus, component, path)` key already maps any non-predicate path to the `_:path` sentinel on both engines (sparq's `norm_path` + the adapter's `_path_key`), so complex paths compare by presence + the `(focus, component)` pair — exactly the bead's path-key relaxation. Cardinality is dropped for complex paths, and the focus-including forms (`zeroOrOne` / `zeroOrMore`) stay value-component-free so the focus is never checked against a value constraint it wasn't meant to satisfy.

## pySHACL adapter fix

The adapter now collects only **top-level** results, excluding `sh:detail`-nested sub-results. pySHACL emits an outer `sh:node`/logical result PLUS an *optional* nested `sh:detail` sub-result for the inner failing constraint; `sh:detail` is non-normative (SHACL §3.6.2 "MAY") and sparq keeps inner results off its comparable top-level list. Comparing the nested details would diff two engines' optional-detail policies, not a real disagreement — this surfaced as a false mismatch during validation and the fix makes the comparison apples-to-apples.

## Guards (run in the per-PR fast lane, no reference engine needed)

- `generator_covers_logical_node_and_complex_paths` — asserts every new family is actually generated across seeds (coverage can't silently regress).
- `extended_components_conform_violate_construction_is_sound` — asserts sparq's own conformance bit matches the generator's INTENT for each logical operator, `sh:node` ref, and complex-path form. This guards the invariant the differential leans on (the input actually exercises the intended outcome). It already caught one unsound test case during TDD.

## Validation

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + `cargo test` — all green in **both** feature states (default and `shacl-af`).
- End-to-end against **pySHACL 0.31.0 / rdflib 7.6.0** locally: **800 seeds (0..800), zero mismatches, zero skips.**

Test-only change: no `src/` or public-API surface touched, so the privacy-claims gate is n/a (no claims) and the G2 public-API → `SKILL.md` rule does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)