### PR TITLE
docs(sparq-mpc): fix broken intra-doc links + gate rustdoc -D warnings (sq-h1w2) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,6 +543,24 @@ jobs:
         run: cargo doc -p sparq-solid --no-deps --features odrl-bridge
         env:
           RUSTDOCFLAGS: "-D warnings"
+      # [OPUS-4.8] sq-h1w2: rustdoc -D warnings, scoped to sparq-mpc. Same rationale as
+      # the sparq-solid gate above — a public MPC item linking to a crate-private helper
+      # (e.g. the `pub(crate)` `mac_shares`/`verify_sum_in_range` internals, or a wrong
+      # `ShamirBackend::run_secure` path that should be the `MpcBackend` trait method) is
+      # a rustdoc warning that slips past clippy/build. This crate's intra-doc backlog is
+      # now cleared, so we GATE it so a public item can never again link to a
+      # private/unresolved one. Both feature states: default and the off-by-default
+      # `insecure-test-rng` (its only feature; `--all-features` == that one feature).
+      # Still per-crate, not `--workspace`: the rest of the workspace carries a separate
+      # pre-existing rustdoc-warning backlog (own beads) a workspace-wide gate would fail.
+      - name: rustdoc (deny warnings, sparq-mpc — default features)
+        run: cargo doc -p sparq-mpc --no-deps
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+      - name: rustdoc (deny warnings, sparq-mpc — insecure-test-rng)
+        run: cargo doc -p sparq-mpc --no-deps --features insecure-test-rng
+        env:
+          RUSTDOCFLAGS: "-D warnings"
       # Informational until the deferred `cargo fmt --all` reformat lands (see rustfmt.toml).
       - name: rustfmt (informational)
         run: cargo fmt --all --check

--- a/crates/sparq-mpc/src/auth_compare.rs
+++ b/crates/sparq-mpc/src/auth_compare.rs
@@ -178,7 +178,7 @@ fn auth_greater_than_bits(
 /// ## Pipeline
 ///
 /// 1. Bit-decompose both operands into [`COMPARE_BITS`] authenticated bits.
-/// 2. Run the authenticated MSB-first comparator ([`auth_greater_than_bits`]) — every
+/// 2. Run the authenticated MSB-first comparator (`auth_greater_than_bits`) — every
 ///    gate a [`MacSession::auth_mul`].
 /// 3. **MAC-check the verdict** ([`MacSession::mac_check`]) BEFORE opening it — a
 ///    tamper in any gate of step 2 (a forged share, a wrong `degree_reduce`

--- a/crates/sparq-mpc/src/auth_disclose.rs
+++ b/crates/sparq-mpc/src/auth_disclose.rs
@@ -13,7 +13,7 @@
 //! MAC-checks the verdict. But the FEDERATION path —
 //! [`crate::compare::disclose_threshold_verdict`], which runs over an EXISTING
 //! degree-`t` sharing `[sum]` (e.g. the cumulative aggregate from
-//! [`crate::shamir::ShamirBackend::run_secure`]) — uses a *masked-open*
+//! [`crate::backend::MpcBackend::run_secure`]) — uses a *masked-open*
 //! bit-decomposition (Damgård et al. TCC'06), not cleartext bit-sharing. That path
 //! has **three distinct opens**, every one of them semi-honest (no integrity check)
 //! on `origin/main`:
@@ -69,10 +69,10 @@
 //! sq-nx0s) — clause (1) recompose `sum == Σ b_k·2^k` and clause (2) high-part
 //! `Σ_{k≥value_bits} b_k·2^k == 0`, each a secret zero-test of a `v·r` masked product
 //! — was, on `sq-6fv7`, still reused VERBATIM from the SEMI-HONEST
-//! [`crate::compare::verify_sum_in_range`]: a tampered open of either `v·r` product
+//! `crate::compare::verify_sum_in_range`: a tampered open of either `v·r` product
 //! (a wrong re-sharing producing a consistent codeword of the wrong value) could flip
 //! "was it zero?" and let an out-of-range / field-wrapping sum masquerade as in-range,
-//! defeating the fail-closed guard. [`auth_verify_sum_in_range`] closes that residual:
+//! defeating the fail-closed guard. `auth_verify_sum_in_range` closes that residual:
 //! the range proof now runs over the AUTHENTICATED sum and bits, the recompose-diff and
 //! high-part are FREE authenticated linear combinations, and each zero-test multiplies
 //! by a fresh nonzero AUTHENTICATED mask via [`crate::shamir::MacSession::auth_mul`] and
@@ -104,7 +104,7 @@ use crate::shamir::{MacSession, ShamirBackend, Share};
 /// `public_threshold` is the public bar (e.g. £100k). `public_threshold` must be
 /// `< 2^`[`DECOMP_VALUE_BITS`] (fail-closed up front); the SUM is range-checked
 /// in-protocol after its bit-decomposition by the MAC-checked sq-nx0s range proof
-/// ([`auth_verify_sum_in_range`], whose zero-test `v·r` opens are MAC-checked too —
+/// (`auth_verify_sum_in_range`, whose zero-test `v·r` opens are MAC-checked too —
 /// sq-m4zi/sq-e7ma). On any tampered open the function ABORTS with
 /// [`MpcError::MacCheckFailed`] (or the fail-closed non-boolean-verdict guard) rather
 /// than returning a wrong verdict.

--- a/crates/sparq-mpc/src/authenticated.rs
+++ b/crates/sparq-mpc/src/authenticated.rs
@@ -264,7 +264,7 @@ impl MacKey {
 /// itself, and *any* `t+1` of them reconstruct `α`; for general `x`, `α = (α·x)/x`
 /// whenever `x` is known and invertible. So a stray `{:?}` (a log line, a panic
 /// message, an `assert_eq!` failure) would exfiltrate the MAC shares and back-door
-/// the `pub(crate)` restriction on [`Self::mac_shares`], undermining the "α is never
+/// the `pub(crate)` restriction on `Self::mac_shares`, undermining the "α is never
 /// reconstructable" guarantee. Instead [`AuthenticatedShare`] has a MANUAL [`Debug`]
 /// that surfaces the openable value sharing `[x]` (already public via
 /// [`Self::value_shares`]) but REDACTS the MAC shares. `[OPUS-4.8]`

--- a/crates/sparq-mpc/src/batched.rs
+++ b/crates/sparq-mpc/src/batched.rs
@@ -12,7 +12,7 @@
 //!
 //! ## The gap this closes
 //!
-//! [`crate::shamir::ShamirBackend::share_private_input`] caps a holder's secure
+//! [`crate::backend::MpcBackend::share_private_input`] caps a holder's secure
 //! contribution to ONE scalar (one row, one column — its single salary). The
 //! four-flatmates aggregate works because each flatmate has exactly one private
 //! salary; but the moment a holder has a *column* of private values (per-row
@@ -29,7 +29,7 @@
 //!
 //! - [`RowBinding::Positional`] — element `i` is row `i`. Two holders' batches
 //!   correlate by INDEX. This is sound only when both holders impose the SAME
-//!   deterministic order on their rows; [`crate::shamir::ShamirBackend::share_private_inputs`]
+//!   deterministic order on their rows; [`crate::backend::MpcBackend::share_private_inputs`]
 //!   enforces this by value-sorting before sharing, so positional batches from
 //!   different holders line up regardless of local row order. Use for a per-row
 //!   secure aggregate where row `i` of holder A pairs with row `i` of holder B
@@ -71,7 +71,7 @@ use crate::shamir::{add_shares, ShamirBackend, ShareVec};
 pub enum RowBinding {
     /// Element `i` is row `i`; holders correlate by INDEX. Sound only when every
     /// holder imposes the same deterministic row order (the value-sort in
-    /// [`ShamirBackend::share_private_inputs`] guarantees this).
+    /// [`crate::backend::MpcBackend::share_private_inputs`] guarantees this).
     Positional,
     /// Element `i` is bound to the DISCLOSED public row key `keys[i]` (a global
     /// IRI / row id rendered to a `String`); holders correlate by KEY. The key

--- a/crates/sparq-mpc/src/compare.rs
+++ b/crates/sparq-mpc/src/compare.rs
@@ -18,7 +18,7 @@
 //! ## The gap this closes (disclosure-minimisation)
 //!
 //! Before this, the only way to answer `sum > £100k` was
-//! [`crate::shamir::ShamirBackend::reconstruct_disclosed`] — which OPENS the exact
+//! [`crate::backend::MpcBackend::reconstruct_disclosed`] — which OPENS the exact
 //! integer sum, so a verifier recomputing the threshold over a DISCLOSED aggregate
 //! learns the precise total (violates disclosure-minimisation, §2 convention #4
 //! read as "the minimal answer"). The missing piece is a secret-shared comparison
@@ -838,8 +838,8 @@ pub fn secure_threshold(
 /// `secure_greater_than` does — the dealer holds the cleartext only to deal the
 /// bit shares, exactly like [`ShamirDealer::share`]). Then
 /// `[a == b] = ∏_k [a_k == b_k]`, where each `[a_k == b_k] = 1 − (a_k − b_k)^2` is
-/// one secure multiplication ([`secret_bit_eq`]) and the product is a balanced
-/// AND-tree of [`secret_and`] (each one mul + degree-reduce). The ONLY value this
+/// one secure multiplication (`secret_bit_eq`) and the product is a balanced
+/// AND-tree of `secret_and` (each one mul + degree-reduce). The ONLY value this
 /// path ever opens is nothing — the result sharing is returned for the caller to
 /// consume secret-shared (e.g. as an oblivious-select control bit). To learn the
 /// verdict (NOT what the oblivious join does) use [`open_verdict`].
@@ -929,12 +929,12 @@ pub fn open_verdict(backend: &ShamirBackend, verdict: &[Share]) -> Result<bool, 
 /// Surface the £100k flatmate verdict as a disclosed [`PartialResult`] carrying
 /// ONLY the boolean `sum > threshold` — never the exact sum. This is the
 /// disclosure-minimising counterpart to
-/// [`crate::shamir::ShamirBackend::reconstruct_disclosed`] (which opens the
+/// [`crate::backend::MpcBackend::reconstruct_disclosed`] (which opens the
 /// integer): here the secure comparison runs over the secret-shared sum, and only
 /// the 1-bit verdict is reconstructed.
 ///
 /// `sum_shares` is the degree-`t` sharing of the cumulative aggregate (e.g. from
-/// [`crate::shamir::ShamirBackend::run_secure`]); `public_threshold` is the public
+/// [`crate::backend::MpcBackend::run_secure`]); `public_threshold` is the public
 /// bar (e.g. £100k). Only the 1-bit verdict ever leaves the computation.
 ///
 /// ## [OPUS-4.8] sq-g7t5 — the sum is bit-decomposed IN-MPC, never reconstructed
@@ -942,13 +942,13 @@ pub fn open_verdict(backend: &ShamirBackend, verdict: &[Share]) -> Result<bool, 
 /// This NO LONGER reconstructs the sum locally. The previous implementation called
 /// `backend.reconstruct(sum_shares)` to obtain the cleartext total and re-deal its
 /// bits — an in-process-simulation shortcut. That shortcut is GONE. The sum is now
-/// bit-decomposed via [`secure_bit_decompose`] (masked-open bit-decomposition,
+/// bit-decomposed via `secure_bit_decompose` (masked-open bit-decomposition,
 /// Damgård et al. TCC'06): a fresh dealer-random mask `[r]` is added to `[sum]` and
 /// ONLY `c = sum + r` is opened (statistically hiding the sum, `2^{−κ}` advantage,
 /// `κ = `[`DECOMP_STAT_SECURITY_BITS`]); the sum's bits are then recovered by a
 /// secret-shared bitwise subtraction `c ⊖ [r]`. **The sum's shares are never all
 /// brought together; `reconstruct(sum_shares)` is never called.** The recovered
-/// shared bits feed [`greater_than_public_bits`], and only the final verdict bit is
+/// shared bits feed `greater_than_public_bits`, and only the final verdict bit is
 /// opened ([`open_verdict`]).
 ///
 /// ## Security tier — honest-majority, semi-honest (NOT malicious)
@@ -972,7 +972,7 @@ pub fn open_verdict(backend: &ShamirBackend, verdict: &[Share]) -> Result<bool, 
 /// Previously the sum bound was a CALLER PRECONDITION (documented, not enforced):
 /// an out-of-range sum silently produced a WRONG verdict because the magnitude of a
 /// SHARING cannot be read off the shares. That seam is now CLOSED. After the in-MPC
-/// bit-decomposition, [`verify_sum_in_range`] PROVES — without reconstructing the
+/// bit-decomposition, `verify_sum_in_range` PROVES — without reconstructing the
 /// sum — that `sum ∈ [0, 2^DECOMP_VALUE_BITS)`, via two secret zero-tests over the
 /// recovered shared bits:
 /// 1. `sum == Σ b_k·2^k` (the bits faithfully recompose the sum: no field wrap, no
@@ -982,7 +982,7 @@ pub fn open_verdict(backend: &ShamirBackend, verdict: &[Share]) -> Result<bool, 
 ///
 /// Clause (1) is what makes this SOUND against field wraparound — a magnitude-only
 /// check would wrongly accept large wrapping sums whose recovered low bits look
-/// small (see [`verify_sum_in_range`]). On violation the function returns a
+/// small (see `verify_sum_in_range`). On violation the function returns a
 /// fail-closed [`MpcError::Protocol`] (abort) — the verdict is **rejected, not
 /// returned wrong**. Each zero-test opens ONLY a uniform `v·r` mask product (zero
 /// in range, uniform-nonzero otherwise), so the sum is STILL never reconstructed.

--- a/crates/sparq-mpc/src/field.rs
+++ b/crates/sparq-mpc/src/field.rs
@@ -176,7 +176,7 @@ impl Fp {
     ///
     /// [OPUS-4.8] sq-7ltf: a square-and-multiply that runs a **fixed 64
     /// iterations** (one per `u64` exponent bit) and selects the conditional
-    /// multiply with [`subtle::ConditionalSelect`] instead of an `if`. There is no
+    /// multiply with [`subtle::ConditionallySelectable`] instead of an `if`. There is no
     /// data-dependent branch on the base value, so the routine is **constant-time
     /// in the base `self`** — closing the latent `Fp::pow` hazard for any caller
     /// that exponentiates a secret-bearing field element. It is **not** asserted

--- a/crates/sparq-mpc/src/join.rs
+++ b/crates/sparq-mpc/src/join.rs
@@ -526,7 +526,7 @@ impl HiddenValueJoin {
 /// parties' shares of the whole key column are jointly independent of every key
 /// (the batched-Shamir hiding property). This is the structural reason the keys
 /// never leak: the cleartext keys are used ONLY as the local inputs to Shamir
-/// sharing and to the secure-equality test ([`HiddenValueJoin::secure_equal_shared`]),
+/// sharing and to the secure-equality test (`HiddenValueJoin::secure_equal_shared`),
 /// and are NEVER reconstructed from shares — exactly as the four-flatmates aggregate
 /// uses its salary column. The DISCLOSED payload columns ride alongside in the clear
 /// (disclosure-minimisation, convention #4 — only the *key* is hidden).
@@ -619,7 +619,7 @@ impl HiddenValueJoin {
     ///      are disclosed (convention #4); the VALUE stays hidden. Correlation is by
     ///      key, not index, so the orders need not match.
     /// 3. For each candidate pair the match is decided by the existing
-    ///    [`Self::secure_equal`] over the secret-shared keys — the join key/value is
+    ///    `Self::secure_equal` over the secret-shared keys — the join key/value is
     ///    NEVER opened; only the match bit is (see the honesty note).
     /// 4. The candidates feed [`crate::oblivious_join::oblivious_join_output`] with
     ///    [`MatchBit::Public`] bits and the public bound `B`: non-matches become

--- a/crates/sparq-mpc/src/metrics.rs
+++ b/crates/sparq-mpc/src/metrics.rs
@@ -229,7 +229,7 @@ impl CommCounter {
     /// total the field elements that cross the boundary and divide by the party
     /// count to get a symmetric per-party figure — the cross-`N`-comparable cost.
     ///
-    /// The on-wire traffic is [`Self::wire_field_elements`]`× FIELD_BYTES`; the
+    /// The on-wire traffic is `Self::wire_field_elements` × [`FIELD_BYTES`]; the
     /// per-party share is that divided by `parties` (each party sends/receives an
     /// equal slice in a symmetric protocol). For one open at `n` parties this is
     /// `(1·n)·8 / n = 8` — the per-open-per-party figure the design record fixes

--- a/crates/sparq-mpc/src/oblivious_join.rs
+++ b/crates/sparq-mpc/src/oblivious_join.rs
@@ -46,7 +46,7 @@
 //!   Shamir multiplication ([`crate::shamir::mul_shares_raw`]) plus local adds: no
 //!   multiplication CHAIN, so it needs **no degree reduction** and is buildable on
 //!   the single-product backend — exactly like
-//!   [`crate::join::HiddenValueJoin::secure_equal`]. The shuffle is the sound
+//!   `crate::join::HiddenValueJoin::secure_equal`. The shuffle is the sound
 //!   substrate; the padded-prefix reveal is a degree-`2t` open of `B` slots. This
 //!   is the structural obliviousness the bead asks for, and it holds at the
 //!   honest-majority Shamir layer.

--- a/crates/sparq-mpc/src/shamir.rs
+++ b/crates/sparq-mpc/src/shamir.rs
@@ -934,7 +934,7 @@ impl MacSession<'_> {
 
     /// [OPUS-4.8] sq-ka8m — a degree-`t` AUTHENTICATED sharing of a PUBLIC constant
     /// `c`: value sharing `[c]` (the trivial constant sharing on `x = 1..=n`) paired
-    /// with the MAC `[α·c]` (= `c·[α]` via [`crate::authenticated::MacKey::scaled_constant_mac`]).
+    /// with the MAC `[α·c]` (= `c·[α]` via `crate::authenticated::MacKey::scaled_constant_mac`).
     /// This is the authenticated analogue of `const_sharing` — it lets the
     /// comparison chain seed its `[0]`/`[1]` accumulators (`gt`, `eq`) as authenticated
     /// values so the WHOLE chain is MAC-carried. `α·c` is the MAC of a PUBLIC value
@@ -1380,11 +1380,11 @@ impl MpcBackend for ShamirBackend {
     /// private contribution. The holder evaluates `fragment` (which MUST project
     /// exactly one integer-valued column) over its OWN data and we share EVERY row
     /// it returns — generalising [`Self::share_private_input`] (the single-row
-    /// special case using the fixed [`PRIVATE_SALARY_FRAGMENT`]) to a per-row
+    /// special case using the fixed `PRIVATE_SALARY_FRAGMENT`) to a per-row
     /// hidden-value / salary vector / per-graph commitment column.
     ///
     /// **Row-binding (POSITIONAL, value-sorted).** The values are extracted and
-    /// then sorted ascending ([`extract_integer_vector`] returns them in the
+    /// then sorted ascending (`extract_integer_vector` returns them in the
     /// holder's local row order; we sort here) so two holders running the same
     /// fragment produce batches whose index `i` refers to the same logical row
     /// position regardless of each holder's local row ordering — exactly the


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. @jeswr runs multiple agents on this account; this PR is from the sparq-mpc rustdoc-hygiene worktree (bead **sq-h1w2**).

## What

`sparq-mpc` carried a pre-existing rustdoc-warning backlog that **`cargo doc -D warnings` failed on**, but no CI lane gated it (the `lint` job only gated `sparq-solid`). This clears the backlog and gates the crate so it can't regress.

Two warning classes were present:

**1. `broken-intra-doc-links` (real bugs — links that resolved to nothing):**
- `crate::shamir::ShamirBackend::{share_private_input, share_private_inputs, run_secure, reconstruct_disclosed}` — these are **trait methods** on `MpcBackend`, not inherent methods on the `ShamirBackend` impl type, so rustdoc could not resolve them through the concrete type. Repointed to `crate::backend::MpcBackend::*` (the declaring trait).
- `subtle::ConditionalSelect` — a typo for the real `subtle` trait `ConditionallySelectable` (the one `Fp` actually implements and `conditional_select` comes from).

**2. `private-intra-doc-links` (public docs linking to deliberately `pub(crate)` internals):**
e.g. `AuthenticatedShare::mac_shares`, `verify_sum_in_range`, `secret_bit_eq`, `secret_and`, `secure_bit_decompose`, `greater_than_public_bits`, `auth_greater_than_bits`, `auth_verify_sum_in_range`, `wire_field_elements`, `scaled_constant_mac`, `PRIVATE_SALARY_FRAGMENT`, `extract_integer_vector`, `HiddenValueJoin::{secure_equal, secure_equal_shared}`.

These items are **intentionally private** — this is a security crate that keeps protocol internals crate-private on purpose (several doc lines explicitly explain *why* a thing is `pub(crate)`). So the fix demotes the `[`...`]` intra-doc link to a plain `` `code span` ``: the prose is preserved verbatim, only the link form is dropped. No item visibility changed.

## Honesty / scope

- **Doc-comment text only.** No protocol, algorithm, wire-format, public-signature, or privacy-claim semantics change. The `verify_sum_in_range` / `disclose_threshold_verdict` soundness wording is byte-for-byte the same minus the link brackets.
- `cargo doc -D warnings` is now **clean for `sparq-mpc` in BOTH feature states** (default + `insecure-test-rng`).

## Gating rustdoc (the "consider gating" half of the bead)

Extended `ci.yml`'s `lint` job with per-crate `cargo doc -p sparq-mpc --no-deps` under `RUSTDOCFLAGS=-D warnings` in both feature states, mirroring the existing `sparq-solid` rustdoc gate immediately above it. Kept **per-crate, not `--workspace`** — the rest of the workspace still carries its own separate rustdoc backlog (own beads) that a workspace-wide gate would fail on today.

## Gate run (this worktree)

- `cargo build -p sparq-mpc` — ok
- `cargo clippy -p sparq-mpc --all-targets -- -D warnings` — ok (default + `insecure-test-rng`)
- `cargo test -p sparq-mpc` — 330 passed, 0 failed (default + `insecure-test-rng`)
- `RUSTDOCFLAGS=-D warnings cargo doc -p sparq-mpc --no-deps` — 0 warnings (default + `insecure-test-rng`)
- `scripts/check-privacy-claims.sh` — OK (no unqualified ZK/MPC privacy/soundness claim; predicate-form included)

Closes sq-h1w2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
