### PR TITLE
chore(perf-hygiene): drop unmeasured '~10-20 ns' from concurrent-serving.md §6.4 (sq-qpcy)

### DIFF
--- a/research/concurrent-serving.md
+++ b/research/concurrent-serving.md
@@ -602,7 +602,7 @@ adapter remains possible because the core never assumes a reactor.
 Replace the double buffer with a **generation chain**:
 
 - `ArcSwap<Generation>` where `Generation { id, graph: Arc<Graph>, epochs: PodEpochs }`.
-  Readers/streams `load()` (lock-free, ~10–20 ns) and hold the `Arc` as long as they
+  Readers/streams `load()` (lock-free) and hold the `Arc` as long as they
   live; **the writer never waits for readers and never reclaims in place** — it builds
   generation N+1 forward (apply batch to a writer-private working copy via the existing
   overlay machinery, fold periodically) and swaps.


### PR DESCRIPTION
> 🤖 **SPARQL agent** — automated change on @jeswr's behalf. Reply here for follow-ups.

## What

`research/concurrent-serving.md:605` (§6.4, the arc-swapped generation chain) annotated the reader-side `load()` with an unmeasured `~10–20 ns` latency estimate. Per the **no-hard-coded-performance-numbers** repo-hygiene rule (`AGENTS.md`), this drops the bare figure while keeping the load-bearing technical claim — that the `load()` is **lock-free** and the writer never waits for readers:

```diff
- Readers/streams `load()` (lock-free, ~10–20 ns) and hold the `Arc` as long as they
+ Readers/streams `load()` (lock-free) and hold the `Arc` as long as they
```

One line. Doc prose only — no code, no public API, no signature change, so the G2 public-API → `SKILL.md` rule does not apply.

## Why this is the sibling of #547 (sq-7jib)

#547 dropped the *same* unmeasured `~10–20 ns` phrasing from the three **code** sites that carried it (`crates/sparq-serve/Cargo.toml`, `crates/sparq-server/src/http.rs`, and the `bench/serve` reader-loop comments), using the exact same reword (`(lock-free, ~10–20 ns)` → `(lock-free)`). This bead is the **research-doc** sibling that the code cleanup left behind. After this change the unmeasured `~10–20 ns` figure is gone from the whole serve estate.

The other `ns` figures in this same file (e.g. the 27 ns snapshot, 52 ns miss-lookup, the result-cache table) are **explicitly-labelled measured benchmark results**, not unmeasured estimates — correctly retained.

## Gate (docs)

- **privacy-claims gate** (incl. predicate-form soundness self-test): green — `check-privacy-claims: OK`, self-test `32 passed, 0 failed`.
- **no-perf-numbers** (`scripts/check-no-perf-numbers.py --advisory`): no `concurrent-serving` finding.
- `research/` is outside the HARD markdownlint / typos / internal-links scope (advisory whole-repo tier only), per `docs-quality.yml`.
- Rust build/clippy/test gate: N/A — no crate touched.

Closes sq-qpcy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)