### PR TITLE
feat(sparq-server): enrich access-audit Actor::WebId from a trusted front's forwarded session (sq-ljfz) [OPUS-4.8]

### DIFF
--- a/crates/sparq-server/src/access_audit.rs
+++ b/crates/sparq-server/src/access_audit.rs
@@ -137,11 +137,44 @@ pub enum Actor {
 impl Actor {
     /// Derives the actor from a presented Bearer token (the channel available on the plain
     /// HTTP / GSP surface today). `None`/empty => [`Actor::Anonymous`]. A future Solid / ACP
-    /// identity layer constructs [`Actor::WebId`] directly at its enforcement seam.
+    /// identity layer constructs [`Actor::WebId`] directly at its enforcement seam (see
+    /// [`from_session`](Actor::from_session)).
     pub fn from_token(presented: Option<&str>) -> Self {
         match presented {
             Some(t) if !t.is_empty() => Actor::TokenFingerprint(fnv1a_hex(t.as_bytes())),
             _ => Actor::Anonymous,
+        }
+    }
+
+    /// [OPUS-4.8] (sq-ljfz, sq-gos8 follow-up) Derives the actor from the *authenticated
+    /// session* of a fronting authorization layer, falling back to the local Bearer gate.
+    ///
+    /// The deployment pattern this serves is the one the bind-time warnings already name: a
+    /// trusted front — `sparq-solid`, or any Solid/WAC reverse-proxy / identity gateway —
+    /// authenticates the user (resolves their WebID from a WAC/ACP session) and forwards that
+    /// resolved WebID to this upstream server as a request header. When the operator has
+    /// configured the server to trust such a header, the header's value IS the authenticated
+    /// subject, so the audit trail records [`Actor::WebId`] (the actual identity) instead of
+    /// the coarse Bearer-token fingerprint — which is the whole point of the bead: attribute
+    /// access to *who*, not to *which shared secret*.
+    ///
+    /// **Trust precondition (audit-integrity critical).** A forwarded header is
+    /// client-controllable on the wire, so honouring it unconditionally would let any caller
+    /// spoof an arbitrary WebID into the audit trail. The caller therefore passes the
+    /// forwarded value ONLY when the operator has explicitly opted into trusting a named
+    /// header (`--audit-webid-header` / `SPARQ_AUDIT_WEBID_HEADER`), asserting that a trusted
+    /// front sets/overwrites it. With no trusted header configured the caller passes `None`
+    /// here and this is byte-identical to [`from_token`](Actor::from_token).
+    ///
+    /// `forwarded_webid`: the value of the trusted forwarded-identity header (already
+    /// extracted by the caller; `None` when no trusted header is configured or it is absent).
+    /// A present, non-empty, whitespace-trimmed value becomes [`Actor::WebId`]; an empty /
+    /// whitespace-only value is treated as "no identity forwarded" and falls through to the
+    /// Bearer gate, so a front that emits an empty header never silently records a blank WebID.
+    pub fn from_session(forwarded_webid: Option<&str>, bearer: Option<&str>) -> Self {
+        match forwarded_webid.map(str::trim) {
+            Some(w) if !w.is_empty() => Actor::WebId(w.to_string()),
+            _ => Actor::from_token(bearer),
         }
     }
 
@@ -458,6 +491,36 @@ mod tests {
             Actor::WebId("https://alice.example/profile#me".into()).as_field(),
             "webid:https://alice.example/profile#me"
         );
+    }
+
+    #[test]
+    fn from_session_prefers_a_forwarded_webid_else_falls_back_to_the_bearer_gate() {
+        // [OPUS-4.8] sq-ljfz: a trusted front's forwarded WebID becomes Actor::WebId (the
+        // actual subject), recorded verbatim — that is the whole point of the enrichment.
+        let webid = "https://alice.example/profile#me";
+        assert_eq!(
+            Actor::from_session(Some(webid), Some("the-shared-token")),
+            Actor::WebId(webid.to_string()),
+        );
+        // The forwarded value is trimmed (a front may pad the header).
+        assert_eq!(
+            Actor::from_session(Some("  https://bob.example/#me \t"), None),
+            Actor::WebId("https://bob.example/#me".to_string()),
+        );
+        // No forwarded identity (no trusted header configured / header absent) => byte-identical
+        // to the Bearer gate: a present token fingerprints, an absent one is anonymous.
+        assert_eq!(
+            Actor::from_session(None, Some("tok")),
+            Actor::from_token(Some("tok")),
+        );
+        assert_eq!(Actor::from_session(None, None), Actor::Anonymous);
+        // An EMPTY / whitespace-only forwarded value is "no identity forwarded" — it must NOT
+        // record a blank WebID; it falls through to the Bearer gate.
+        assert_eq!(
+            Actor::from_session(Some(""), Some("tok")),
+            Actor::from_token(Some("tok")),
+        );
+        assert_eq!(Actor::from_session(Some("   "), None), Actor::Anonymous);
     }
 
     #[test]

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -308,6 +308,25 @@ pub struct ServerConfig {
     /// compiled out (byte-identical to before). See [`crate::access_audit`].
     #[cfg(feature = "access-audit")]
     pub access_audit: Option<crate::access_audit::SinkTarget>,
+    /// [OPUS-4.8] (sq-ljfz, sq-gos8 follow-up) **Trusted forwarded-identity header** for the
+    /// structured access-audit actor. `Some(name)` tells the audit seam that a fronting
+    /// authorization layer — `sparq-solid`, or any Solid/WAC reverse-proxy / identity gateway,
+    /// the very "reverse proxy / gateway or sparq-solid" the bind warnings name — authenticates
+    /// the user and forwards their resolved WebID in the request header `name`. When set, the
+    /// audit trail records [`Actor::WebId`](crate::access_audit::Actor::WebId) (the real
+    /// authenticated subject from the WAC/ACP session) instead of the coarse Bearer-token
+    /// fingerprint. `None` (the default) trusts no forwarded header, so the actor is derived
+    /// from the local Bearer gate exactly as before (byte-identical).
+    ///
+    /// SECURITY: a forwarded header is client-controllable, so this is honoured ONLY when the
+    /// operator explicitly names a trusted header — the operator thereby asserts that the
+    /// fronting layer sets/overwrites it so a direct client cannot spoof an arbitrary WebID
+    /// into the audit trail. Therefore expose this server ONLY behind that trusted front (not
+    /// directly to untrusted clients) when this is set. Set by `--audit-webid-header <name>` /
+    /// `SPARQ_AUDIT_WEBID_HEADER`. Present only with the `access-audit` cargo feature; without
+    /// it the field + the seam are compiled out (byte-identical to before).
+    #[cfg(feature = "access-audit")]
+    pub audit_webid_header: Option<String>,
     /// [OPUS-4.8] sq-o4qf: explicit opt-in to bind a **non-loopback** address.
     ///
     /// By default the server has **no authentication** on any endpoint — including the
@@ -510,6 +529,11 @@ impl Default for ServerConfig {
             // feature is compiled in (the operator opts in via --access-audit / SPARQ_ACCESS_AUDIT).
             #[cfg(feature = "access-audit")]
             access_audit: None,
+            // [OPUS-4.8] sq-ljfz: trust NO forwarded WebID header by default — the audit actor
+            // is the local Bearer gate unless the operator names a trusted front's header
+            // (--audit-webid-header / SPARQ_AUDIT_WEBID_HEADER).
+            #[cfg(feature = "access-audit")]
+            audit_webid_header: None,
             allow_remote: false, // [OPUS-4.8] sq-o4qf: safe default — refuse non-loopback bind unless opted in
             // [OPUS-4.8] sq-zcby: safe default — no token => no write auth (back-compat).
             auth_token: None,
@@ -653,6 +677,15 @@ impl ServerConfig {
             if !v.is_empty() {
                 cfg.access_audit = Some(crate::access_audit::SinkTarget::parse(v));
             }
+        }
+        // [OPUS-4.8] sq-ljfz: SPARQ_AUDIT_WEBID_HEADER=<header-name> names a TRUSTED forwarded
+        // -identity header — a fronting auth layer (sparq-solid / a Solid-WAC proxy / gateway)
+        // sets it to the authenticated user's WebID, which the audit seam then records as
+        // Actor::WebId. Empty / unset => trust no header (the local Bearer gate, unchanged).
+        #[cfg(feature = "access-audit")]
+        if let Ok(v) = std::env::var("SPARQ_AUDIT_WEBID_HEADER") {
+            let v = v.trim();
+            cfg.audit_webid_header = (!v.is_empty()).then(|| v.to_string());
         }
         // [OPUS-4.8] sq-o4qf: SPARQ_ALLOW_REMOTE truthy ("1"/"true"/"yes"/"on", case-insensitive)
         // opts in to a non-loopback bind. Anything else (incl. unset / "0" / "false") leaves the
@@ -1093,12 +1126,30 @@ fn sparql_action(op: Operation) -> crate::access_audit::Action {
     }
 }
 
-/// [OPUS-4.8] (sq-gos8) Begins a structured access-audit record IFF a sink is installed —
-/// snapshotting the actor (from the presented Bearer token), the action class, the resource and
-/// the (non-reversible) request fingerprint at the enforcement seam. Returns `None` (and builds
-/// nothing) when no sink is configured, so an audit-disabled request pays only the `Option`
-/// check. The returned [`AuditPending`] is `finish`ed once the enforced decision is known and
-/// handed to the sink via [`audit_access_finish`].
+/// [OPUS-4.8] (sq-ljfz) The forwarded WebID a TRUSTED front placed on the request, IFF the
+/// operator named a trusted header ([`ServerConfig::audit_webid_header`]). `None` when no
+/// trusted header is configured (the common case), the header is absent, or its value is not
+/// valid UTF-8 — in every such case the audit actor falls back to the local Bearer gate.
+/// HTTP header names are case-insensitive (`HeaderMap::get` lowercases its key), so the
+/// configured name matches regardless of the front's casing.
+#[cfg(feature = "access-audit")]
+fn forwarded_webid<'a>(config: &ServerConfig, headers: &'a HeaderMap) -> Option<&'a str> {
+    let name = config.audit_webid_header.as_deref()?;
+    headers.get(name)?.to_str().ok()
+}
+
+/// [OPUS-4.8] (sq-gos8; sq-ljfz) Begins a structured access-audit record IFF a sink is installed
+/// — snapshotting the actor, the action class, the resource and the (non-reversible) request
+/// fingerprint at the enforcement seam. Returns `None` (and builds nothing) when no sink is
+/// configured, so an audit-disabled request pays only the `Option` check.
+///
+/// The actor is derived via [`Actor::from_session`](crate::access_audit::Actor::from_session):
+/// when the operator has configured a TRUSTED forwarded-identity header
+/// ([`ServerConfig::audit_webid_header`]) and a fronting auth layer (sparq-solid / a Solid-WAC
+/// proxy / gateway) set it, the record attributes access to that authenticated WebID; otherwise
+/// it falls back to the local Bearer-token fingerprint exactly as before. The returned
+/// [`AuditPending`] is `finish`ed once the enforced decision is known and handed to the sink via
+/// [`audit_access_finish`].
 #[cfg(feature = "access-audit")]
 fn audit_access_begin(
     state: &AppState,
@@ -1108,12 +1159,11 @@ fn audit_access_begin(
     sparql: Option<&str>,
 ) -> Option<crate::access_audit::AuditPending> {
     state.access_audit_sink().map(|_| {
-        crate::access_audit::AuditPending::begin(
-            action,
-            crate::access_audit::Actor::from_token(bearer_token(headers)),
-            resource,
-            sparql,
-        )
+        let actor = crate::access_audit::Actor::from_session(
+            forwarded_webid(state.config(), headers),
+            bearer_token(headers),
+        );
+        crate::access_audit::AuditPending::begin(action, actor, resource, sparql)
     })
 }
 

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -277,6 +277,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 config.access_audit = Some(sparq_server::access_audit::SinkTarget::parse(&target));
             }
+            // [OPUS-4.8] sq-ljfz (sq-gos8 follow-up): trust a fronting auth layer's forwarded
+            // WebID header so the access-audit actor is the real authenticated subject
+            // (Actor::WebId) rather than the coarse Bearer-token fingerprint. NAME the header a
+            // trusted front (sparq-solid / a Solid-WAC proxy / gateway) sets to the user's
+            // WebID. SECURITY: only set this when the server runs BEHIND that trusted front —
+            // a forwarded header is client-spoofable otherwise. Overrides SPARQ_AUDIT_WEBID_HEADER.
+            #[cfg(feature = "access-audit")]
+            "--audit-webid-header" => {
+                let name = args
+                    .next()
+                    .ok_or("--audit-webid-header requires a header name")?;
+                let name = name.trim().to_string();
+                if name.is_empty() {
+                    return Err("--audit-webid-header must not be empty".into());
+                }
+                config.audit_webid_header = Some(name);
+            }
             // [OPUS-4.8] sq-7cxr (PSS gh-44): durable persistence directory (QLever
             // --persist-updates). Updates are WAL-durable to DIR before ack; a restart on the
             // same DIR restores all of them with no rebuild. Overrides SPARQ_PERSIST_DIR.

--- a/crates/sparq-server/tests/access_audit.rs
+++ b/crates/sparq-server/tests/access_audit.rs
@@ -177,3 +177,105 @@ async fn graph_store_write_records_named_graph_resource() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// [OPUS-4.8] sq-ljfz (sq-gos8 follow-up): when the operator configures a TRUSTED forwarded
+/// -identity header, a fronting auth layer's resolved WebID is recorded as the audit actor
+/// (`Actor::WebId`) — the real authenticated subject — instead of the coarse Bearer-token
+/// fingerprint. This is the bead's enrichment, driven end-to-end through the real seam.
+#[tokio::test]
+async fn trusted_forwarded_webid_header_becomes_the_audit_actor() {
+    let dir = std::env::temp_dir().join(format!("sparq-aa-webid-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let audit_path = dir.join("access.jsonl");
+
+    // Trust the front's `X-WebID` header (the deployment names sparq-solid / a Solid-WAC proxy).
+    let config = ServerConfig {
+        access_audit: Some(SinkTarget::File(audit_path.clone())),
+        audit_webid_header: Some("X-WebID".to_string()),
+        ..ServerConfig::default()
+    };
+    let graph =
+        Graph::load_str("<http://ex/s> <http://ex/p> <http://ex/o> .", "ntriples").unwrap();
+    let app = router(AppState::with_config(graph, config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let base = format!("http://{addr}");
+    let cl = reqwest::Client::new();
+
+    let webid = "https://alice.example/profile#me";
+    // Header casing is deliberately different from the configured name to exercise the
+    // case-insensitive HTTP header match.
+    let ok = cl
+        .get(format!("{base}/sparql"))
+        .header("accept", "application/sparql-results+json")
+        .header("x-webid", webid)
+        .query(&[("query", SELECT)])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ok.status(), 200, "unauthed open read should succeed");
+
+    let recs = read_records(&audit_path, 1).await;
+    let rec = recs.iter().find(|r| r["decision"] == "allow").expect("an allow record");
+    assert_eq!(
+        rec["actor"],
+        format!("webid:{webid}"),
+        "the trusted front's WebID is the audit actor",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// [OPUS-4.8] sq-ljfz (audit-integrity / no-spoof): with NO trusted header configured (the
+/// default), a client-supplied identity header is IGNORED — the actor stays the local Bearer
+/// gate (here `anonymous`). This is the guarantee that a direct client cannot spoof an
+/// arbitrary WebID into the audit trail; the WebID is honoured ONLY behind a trusted front the
+/// operator opted into.
+#[tokio::test]
+async fn forwarded_identity_header_is_ignored_unless_a_trusted_header_is_configured() {
+    let dir = std::env::temp_dir().join(format!("sparq-aa-nospoof-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let audit_path = dir.join("access.jsonl");
+
+    // NO audit_webid_header set => trust nothing forwarded.
+    let config = ServerConfig {
+        access_audit: Some(SinkTarget::File(audit_path.clone())),
+        ..ServerConfig::default()
+    };
+    let graph =
+        Graph::load_str("<http://ex/s> <http://ex/p> <http://ex/o> .", "ntriples").unwrap();
+    let app = router(AppState::with_config(graph, config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let base = format!("http://{addr}");
+    let cl = reqwest::Client::new();
+
+    let spoofed = "https://attacker.example/#me";
+    let ok = cl
+        .get(format!("{base}/sparql"))
+        .header("accept", "application/sparql-results+json")
+        // A common forwarded-identity header name — but the operator trusts none, so it is inert.
+        .header("X-WebID", spoofed)
+        .query(&[("query", SELECT)])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ok.status(), 200);
+
+    let recs = read_records(&audit_path, 1).await;
+    let rec = recs.iter().find(|r| r["decision"] == "allow").expect("an allow record");
+    assert_eq!(rec["actor"], "anonymous", "a spoofed header must NOT become the actor");
+    let file = std::fs::read_to_string(&audit_path).unwrap();
+    assert!(
+        !file.contains(spoofed),
+        "an untrusted client-supplied WebID must never reach the audit trail"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -610,6 +610,7 @@ env overrides the default.
 | `--brtpf-max-values-bytes N` | `SPARQ_BRTPF_MAX_VALUES_BYTES` | `1048576` (`0`=off) | (feature `brtpf`) **DoS cap on the raw brTPF `values` payload BYTES** — bounds the GET query-string carrier that `--max-body-bytes` never sees → `413` (`sq-r74h`) |
 | `--audit-log` | `SPARQ_AUDIT_LOG` | off | (feature `audit-log`) per-query **access audit log** — see "Access audit log" |
 | `--access-audit <file\|stderr>` | `SPARQ_ACCESS_AUDIT` | off | (feature `access-audit`) richer **structured access-audit sink** (typed JSON-Lines: actor / action / resource / decision+basis / ts / fingerprint) — see "Structured access-audit sink" |
+| `--audit-webid-header <name>` | `SPARQ_AUDIT_WEBID_HEADER` | off | (feature `access-audit`) **trust a fronting auth layer's forwarded WebID header** so the audit `actor` is the real authenticated subject (`webid:<iri>`) — set ONLY behind a trusted front (spoofable otherwise); see "Structured access-audit sink" |
 
 In a library: `AppState::with_config(graph, ServerConfig { max_concurrent: 64, ..Default::default() })`
 then `router(state)`, or `harden(my_router, &config)`.
@@ -820,6 +821,22 @@ the content the redaction work just protected. One line: **identities + resource
 content stays fingerprinted.** Library callers set `ServerConfig { access_audit:
 Some(SinkTarget::File(path)), .. }` (field present only with the feature). See
 `crates/sparq-server/src/access_audit.rs`.
+
+**Actor enrichment from a trusted front (`sq-ljfz`).** By default the `actor` is derived from the
+local Bearer gate (`token:<fnv1a>` / `anonymous`) — `sparq-server`'s own auth is a single shared
+secret, not per-user. To record the **real authenticated WebID** instead, run the server behind a
+fronting authorization layer — `sparq-solid`, or any Solid/WAC reverse-proxy / identity gateway
+(the "reverse proxy / gateway or sparq-solid" the bind warnings name) — that authenticates the
+user (resolves their WebID from a WAC/ACP session) and forwards it in a request header, then name
+that header with `--audit-webid-header <name>` (env `SPARQ_AUDIT_WEBID_HEADER`, library field
+`ServerConfig { audit_webid_header: Some(name), .. }`). When set, a present non-empty value of that
+header becomes `actor = webid:<iri>` (the audit attributes access to *who*, not to *which shared
+secret*); empty/absent falls back to the Bearer gate, byte-identical to before. **Security:** a
+forwarded header is client-spoofable, so this is honoured ONLY when an operator explicitly names a
+trusted header — set it **only** when the server runs behind that trusted front (never exposed
+directly to untrusted clients), and ensure the front sets/overwrites the header so a direct client
+cannot inject an arbitrary WebID. With no trusted header configured (the default) any such header
+is ignored.
 
 ## Gotchas / feature flags / prerequisites
 


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-ljfz** (sparq-server access-audit). I am an automated agent on @jeswr's account.

## What & why (sq-ljfz, sq-gos8 follow-up)

The structured access-audit (`access-audit` feature) `actor` field has always been the **coarse local Bearer gate** (`token:<fnv1a>` / `anonymous`) because `sparq-server`'s own auth is a *single shared secret*, not per-user. The bead asked to enrich `Actor::WebId` "once sparq-solid fronts the server".

**Honest scoping:** `sparq-solid` does **not** front `sparq-server` today — there is no dependency or wiring between them, and the bind-time warnings reference it only as a *future* external front. So the literal precondition is unmet. But the bead's intent has a real, smallest-correct implementation available **now**: the canonical deployment is to run `sparq-server` **behind a trusted fronting authorization layer** — `sparq-solid`, or any Solid/WAC reverse-proxy / identity gateway (the exact "reverse proxy / gateway or sparq-solid" the warnings name) — that authenticates the user (resolves their WebID from a WAC/ACP session) and **forwards the resolved WebID downstream in a request header**. This PR wires that: the audit trail records `Actor::WebId` (the real authenticated subject) instead of the shared-secret fingerprint.

This is **not** a no-op: `Actor::WebId` already existed and was tested, but nothing ever *produced* it from a live request. Now a trusted front's session does.

## Change (opt-in, default-OFF, audit-integrity safe)

- **`Actor::from_session(forwarded_webid, bearer)`** — a present, non-empty (trimmed) forwarded WebID becomes `Actor::WebId`; empty/absent falls back to `from_token` (byte-identical to before).
- **`ServerConfig::audit_webid_header: Option<String>`** (feature `access-audit`, default `None`) — `--audit-webid-header <name>` / `SPARQ_AUDIT_WEBID_HEADER` names the **trusted** header.
- **Seam:** `audit_access_begin` derives the actor via `from_session`, reading the configured trusted header (HTTP-case-insensitive) from the request.

**Security (no-spoof).** A forwarded header is client-spoofable, so it is honoured **only** when the operator *explicitly names a trusted header* — thereby asserting the front sets/overwrites it. With no trusted header configured (the default), a stray `X-WebID` is **ignored** — a direct client can never inject an arbitrary WebID into the audit trail. This is covered by a dedicated test.

## Tests
- Unit: `from_session` precedence / trim / empty-fallback / anonymous.
- Integration (real axum path): a trusted header ⇒ `actor = webid:<iri>`; an untrusted header is ignored when none is configured (and the spoofed value never reaches the file).

## Docs
- `skills/http-server/SKILL.md`: flags-table row + an "Actor enrichment from a trusted front" subsection (G2 public-API → SKILL sync).

## Gate (all green locally)
- `cargo build` / `clippy --all-targets -- -D warnings` / full `cargo test` in **both** feature states (`access-audit` OFF and ON). With the feature off the field + seam are `#[cfg]`-stripped — byte-identical to before.
- Privacy-claims honesty gate: clean.
- markdownlint: clean. New `typos`: none (pre-existing `optin` test-name hits are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
