### PR TITLE
test(sparq-shacl): wire Apache Jena SHACL reference adapter into diff-fuzz (sq-evws)

### DIFF
--- a/.github/workflows/shacl-diff-fuzz.yml
+++ b/.github/workflows/shacl-diff-fuzz.yml
@@ -1,24 +1,31 @@
-# [OPUS-4.8] Differential SHACL fuzz gate (bead sq-55c1).
+# [OPUS-4.8] Differential SHACL fuzz gate (beads sq-55c1 + sq-evws).
 #
 # WHAT: generates random but VALID SHACL shapes + data graphs, validates each
-# through `sparq-shacl` AND through a reference SHACL engine (pySHACL — the
-# canonical reference implementation), and asserts the reports agree on the
-# `sh:conforms` bit and the per-focus-node violated-constraint set. A disagreement
-# is a candidate sparq-shacl correctness bug; the harness prints the seed + the
-# reproducing Turtle so it replays deterministically. See
+# through `sparq-shacl` AND through every reference SHACL engine that resolves, and
+# asserts the reports agree on the `sh:conforms` bit and the per-focus-node
+# violated-constraint set. Two references are wired:
+#   - pySHACL — the canonical Python reference implementation (sq-55c1).
+#   - Apache Jena SHACL — a second, independent reference (sq-evws), driven via the
+#     Java single-file source launcher over its `org.apache.jena.shacl` validator.
+# A disagreement is a candidate sparq-shacl correctness bug; the harness prints the
+# seed + the reproducing Turtle so it replays deterministically. A second engine
+# catches bugs where sparq and pySHACL happen to agree but are both wrong. See
 # crates/sparq-shacl/tests/diff_fuzz.rs.
 #
 # TRIGGER — NIGHTLY/HEAVY tier ONLY. Deliberately NOT on pull_request / push /
-# merge_group: it installs a Python reference engine and runs thousands of
-# validations, which is too heavy + too slow for the per-PR fast path, and the
-# `#[ignore]`d test is excluded from `cargo nextest run` anyway. Running only on
-# `schedule` + `workflow_dispatch` means this workflow never produces a check-run
-# on a PR head commit, so the `ci-summary / gate` aggregator never sees it and the
-# per-PR gate is unaffected (the intended heavy-lane isolation).
+# merge_group: it installs reference engines and runs thousands of validations,
+# which is too heavy + too slow for the per-PR fast path, and the `#[ignore]`d test
+# is excluded from `cargo nextest run` anyway. Running only on `schedule` +
+# `workflow_dispatch` means this workflow never produces a check-run on a PR head
+# commit, so the `ci-summary / gate` aggregator never sees it and the per-PR gate
+# is unaffected (the intended heavy-lane isolation).
 #
 # Third-party actions are pinned by full commit SHA (supply-chain hardening); the
 # trailing `# vX.Y.Z` comment is what Dependabot follows to bump the pin. The pins
-# here match those already used by .github/workflows/fuzz.yml / ci.yml.
+# here match those already used by .github/workflows/fuzz.yml / ci.yml. The Jena
+# tarball is fetched from the Apache archive and verified against a pinned SHA-512
+# (the published apache-jena-5.2.0 checksum) before use — a tampered or substituted
+# artifact fails the job rather than silently feeding a bad reference engine.
 name: shacl-diff-fuzz
 
 on:
@@ -47,14 +54,20 @@ env:
   # pySHACL change cannot silently break (or silently "fix") the differential; bump
   # deliberately. rdflib comes in as its dependency.
   PYSHACL_VERSION: "0.31.0"
+  # Apache Jena release pinned (binary tarball) with its published SHA-512 so the
+  # second reference engine is reproducible AND the artifact is verified before use;
+  # bump both together (the .sha512 is alongside the tarball on the Apache archive).
+  JENA_VERSION: "5.2.0"
+  JENA_SHA512: "9a66044573ca269c0a9a1191fe7a8e1925f2d77e2e0bdadddd68616a1bafed1d9819c0b2988dd03614ec778a3882ccb091d825976fc0837406916f9f001b701c"
 
 jobs:
   diff-fuzz:
-    name: SHACL differential fuzz (sparq-shacl vs pySHACL)
+    name: SHACL differential fuzz (sparq-shacl vs pySHACL + Jena)
     runs-on: ubuntu-latest
-    # Generous ceiling: ~thousands of cases × a per-case Python subprocess. A hung
-    # run fails with a clear timeout rather than running away.
-    timeout-minutes: 45
+    # Generous ceiling: ~thousands of cases × a per-case reference subprocess, now
+    # across two engines (each case spawns a fresh interpreter/JVM). A hung run
+    # fails with a clear timeout rather than running away.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust (stable)
@@ -67,6 +80,11 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
+      - name: Set up Java (for the Jena reference engine)
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          distribution: temurin
+          java-version: "21"
       - name: Install pySHACL (reference engine) in a venv
         run: |
           set -euo pipefail
@@ -75,6 +93,30 @@ jobs:
           "$RUNNER_TEMP/shacl-ref-venv/bin/pip" install --quiet "pyshacl==${PYSHACL_VERSION}"
           "$RUNNER_TEMP/shacl-ref-venv/bin/python" -c "import pyshacl, rdflib; print('pyshacl', pyshacl.__version__, 'rdflib', rdflib.__version__)"
           echo "SHACL_DIFF_PYTHON=$RUNNER_TEMP/shacl-ref-venv/bin/python" >> "$GITHUB_ENV"
+      # Cache the unpacked Jena dist across runs (keyed on the pinned version) so the
+      # nightly lane does not re-download ~24 MB every day. A cache miss falls
+      # through to the download+verify step below.
+      - name: Cache Apache Jena
+        id: jena-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.temp }}/apache-jena
+          key: apache-jena-${{ env.JENA_VERSION }}
+      - name: Install Apache Jena (reference engine), SHA-512 verified
+        run: |
+          set -euo pipefail
+          dest="$RUNNER_TEMP/apache-jena"
+          if [ ! -x "$dest/bin/shacl" ]; then
+            tarball="$RUNNER_TEMP/apache-jena.tar.gz"
+            url="https://archive.apache.org/dist/jena/binaries/apache-jena-${JENA_VERSION}.tar.gz"
+            curl -fsSL --retry 3 -o "$tarball" "$url"
+            echo "${JENA_SHA512}  ${tarball}" | sha512sum --check --strict -
+            mkdir -p "$dest"
+            tar -xzf "$tarball" -C "$dest" --strip-components=1
+          fi
+          # The harness derives ${JENA_HOME}/lib/* when JENA_HOME is set.
+          echo "JENA_HOME=$dest" >> "$GITHUB_ENV"
+          "$dest/bin/shacl" --help >/dev/null 2>&1 && echo "Jena shacl CLI OK ($JENA_VERSION)"
       - name: Pick seed count for this trigger
         id: budget
         run: |

--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -66,25 +66,41 @@ from its printed seed.
 
 The reference side is a pluggable "report-cli" adapter (bead sq-eifd): a
 subprocess reading `{data, shapes}` Turtle and emitting a normalised JSON
-report. The first wired reference is **pySHACL**
-(`tests/diff_fuzz/pyshacl_adapter.py`); other engines (rdf-validate-shacl /
-shacl-engine via Node, Jena-SHACL via a jar) are tracked as follow-up beads and
-slot in as alternative adapters producing the same JSON shape.
+report. Two references are wired today, each producing the same JSON shape so the
+runner's comparison is engine-agnostic:
+
+- **pySHACL** (`tests/diff_fuzz/pyshacl_adapter.py`, bead sq-55c1) — the canonical
+  Python reference, driven via a Python interpreter with `pyshacl` + `rdflib`.
+- **Apache Jena SHACL** (`tests/diff_fuzz/JenaShaclAdapter.java`, bead sq-evws) —
+  Jena's `org.apache.jena.shacl` validator, driven via the Java single-file source
+  launcher (`java -cp <jena-libs> JenaShaclAdapter.java`) so no compile step or
+  committed jar is needed. A second independent reference catches bugs where sparq
+  and pySHACL happen to agree but are both wrong.
+
+The differential runs against **every** reference engine that resolves. Other
+engines (rdf-validate-shacl / shacl-engine via Node) are tracked as follow-up
+beads and slot in as further adapters over the same contract.
 
 It is `#[ignore]`d (off the per-PR fast path) and runs as a **nightly** CI lane
-(`.github/workflows/shacl-diff-fuzz.yml`). Run it locally against a Python that
-has pySHACL + rdflib installed:
+(`.github/workflows/shacl-diff-fuzz.yml`, which installs both pySHACL and a
+SHA-512-verified apache-jena tarball). Run it locally against either or both:
 
 ```sh
+# pySHACL:
 python3 -m venv /tmp/shacl-ref-venv && /tmp/shacl-ref-venv/bin/pip install pyshacl
 SHACL_DIFF_PYTHON=/tmp/shacl-ref-venv/bin/python SHACL_DIFF_COUNT=2000 \
+  cargo test -p sparq-shacl --test diff_fuzz -- --ignored --nocapture
+# Jena (point at an unpacked apache-jena lib classpath, or set JENA_HOME):
+SHACL_DIFF_JENA_CP="/opt/apache-jena/lib/*" SHACL_DIFF_COUNT=2000 \
   cargo test -p sparq-shacl --test diff_fuzz -- --ignored --nocapture
 ```
 
 When no reference engine resolves, the test skips cleanly (so a fresh checkout
-stays green). Two fast, reference-free self-tests of the generator
-(well-formedness + outcome mix, and key-normalisation consistency) DO run in the
-per-PR path.
+stays green); each engine is gated independently, so Jena is silently skipped
+without a Java/Jena classpath and the pySHACL lane is unaffected. Fast,
+reference-free self-tests (generator well-formedness + outcome mix,
+key-normalisation consistency, the engine-gating logic) DO run in the per-PR
+path.
 
 ## Supported constraint components
 

--- a/crates/sparq-shacl/tests/diff_fuzz.rs
+++ b/crates/sparq-shacl/tests/diff_fuzz.rs
@@ -18,23 +18,39 @@
 //! ## Reference engines (pluggable — sq-eifd report-cli adapters)
 //! The reference side is a "report-cli" adapter (bead sq-eifd): a subprocess that
 //! reads `{data, shapes}` Turtle and emits a normalised JSON report
-//! (`conforms` + a `{focus, component, path}` violation list). The first wired
-//! reference is **pySHACL** (`tests/diff_fuzz/pyshacl_adapter.py`), the canonical
-//! SHACL reference implementation. Other engines (rdf-validate-shacl /
-//! shacl-engine via Node, Jena-SHACL via a jar) are left as TODO beads; each is a
-//! drop-in alternative `RefEngine` that produces the same JSON shape.
+//! (`conforms` + a `{focus, component, path}` violation list). Two references are
+//! wired, each a drop-in `RefEngine` that produces the *same* JSON shape:
+//!   - **pySHACL** (`tests/diff_fuzz/pyshacl_adapter.py`, bead sq-55c1) — the
+//!     canonical Python SHACL reference implementation, driven via a Python
+//!     interpreter that has `pyshacl` + `rdflib` importable.
+//!   - **Apache Jena SHACL** (`tests/diff_fuzz/JenaShaclAdapter.java`, bead
+//!     sq-evws) — Jena's `org.apache.jena.shacl` validator, driven via the Java
+//!     single-file source launcher (`java -cp <jena-libs> JenaShaclAdapter.java`)
+//!     so no compile step / committed jar is needed. A second independent
+//!     reference catches bugs where sparq and pySHACL happen to agree but are both
+//!     wrong.
+//!
+//! Other engines (rdf-validate-shacl / shacl-engine via Node) remain follow-up
+//! beads; each is another `RefEngine` over the same contract.
 //!
 //! ## How to run
 //! Off by default (`#[ignore]`) so the per-PR `cargo nextest run` fast path is
-//! untouched — this is a NIGHTLY/heavy-tier check. Run it explicitly:
+//! untouched — this is a NIGHTLY/heavy-tier check. The differential runs against
+//! EVERY reference engine that resolves; run it explicitly:
 //! ```text
-//! # point at a Python with pyshacl + rdflib installed:
+//! # pySHACL: point at a Python with pyshacl + rdflib installed:
 //! SHACL_DIFF_PYTHON=/path/to/venv/bin/python \
+//!   cargo test -p sparq-shacl --test diff_fuzz -- --ignored --nocapture
+//! # Jena: point at a `*`-globbable classpath of its jars (an unpacked apache-jena
+//! # tarball's `lib`), or set JENA_HOME (its `lib` is derived):
+//! SHACL_DIFF_JENA_CP="/opt/apache-jena/lib/*" \
 //!   cargo test -p sparq-shacl --test diff_fuzz -- --ignored --nocapture
 //! # bound the run: SHACL_DIFF_SEED_START / SHACL_DIFF_COUNT (defaults 0 / 200).
 //! ```
-//! When no reference engine resolves, the test SKIPS (prints why and returns) so
-//! it stays green on a box without the reference toolchain.
+//! When NO reference engine resolves, the test SKIPS (prints why and returns) so
+//! it stays green on a box without any reference toolchain. Each engine is gated
+//! independently — Jena is silently skipped when neither a Jena classpath nor a
+//! working `java` is available, so the existing pySHACL-only lane is unaffected.
 //!
 //! ## Comparison policy (per bead sq-55c1)
 //! 1. `conforms` bit — exact (cheap, highest signal).
@@ -73,10 +89,24 @@ struct RefViolation {
     path: Option<String>,
 }
 
-/// Resolves the Python interpreter to drive the pySHACL adapter, or `None` if
-/// pySHACL is not importable (so the test can SKIP cleanly). Honours
-/// `SHACL_DIFF_PYTHON` (a venv's `python`); otherwise tries `python3`.
-fn resolve_pyshacl() -> Option<String> {
+/// A resolved reference engine: a human name plus the program + leading args to
+/// spawn its report-cli adapter. The (data, shapes) request is always written to
+/// the child's stdin and the normalised JSON report read from stdout, regardless
+/// of engine — so adding an engine is just another `resolve_*` returning this.
+struct RefEngine {
+    name: String,
+    program: String,
+    args: Vec<String>,
+}
+
+fn adapter_dir() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/diff_fuzz")
+}
+
+/// Resolves the pySHACL engine, or `None` if pySHACL is not importable (so it can
+/// be SKIPPED cleanly). Honours `SHACL_DIFF_PYTHON` (a venv's `python`); otherwise
+/// tries `python3` then `python`.
+fn resolve_pyshacl() -> Option<RefEngine> {
     let candidates = std::env::var("SHACL_DIFF_PYTHON")
         .ok()
         .into_iter()
@@ -90,23 +120,90 @@ fn resolve_pyshacl() -> Option<String> {
             .map(|s| s.success())
             .unwrap_or(false);
         if ok {
-            return Some(py);
+            let adapter = adapter_dir().join("pyshacl_adapter.py");
+            return Some(RefEngine {
+                name: format!("pySHACL via {py}"),
+                program: py,
+                args: vec![adapter.to_string_lossy().into_owned()],
+            });
         }
     }
     None
 }
 
-fn adapter_path() -> std::path::PathBuf {
-    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/diff_fuzz/pyshacl_adapter.py")
+/// Pure classpath selection (env values passed in, so it is unit-testable without
+/// mutating process-global env in parallel tests): an explicit `SHACL_DIFF_JENA_CP`
+/// wins; otherwise `${JENA_HOME}/lib/*` if `JENA_HOME` is set; otherwise `None`
+/// (Jena skipped). An empty string is treated as unset so a blank env var does not
+/// produce a degenerate empty classpath.
+fn jena_classpath(cp_env: Option<String>, jena_home_env: Option<String>) -> Option<String> {
+    if let Some(cp) = cp_env.filter(|s| !s.is_empty()) {
+        return Some(cp);
+    }
+    jena_home_env.filter(|s| !s.is_empty()).map(|home| {
+        std::path::Path::new(&home)
+            .join("lib")
+            .join("*")
+            .to_string_lossy()
+            .into_owned()
+    })
 }
 
-/// Runs the reference engine over one (data, shapes) pair. `Err` means the
-/// adapter itself failed (engine error / bad invocation) — distinct from a
-/// produced non-conforming report.
-fn run_reference(python: &str, data: &str, shapes: &str) -> Result<RefReport, String> {
+/// Resolves the Apache Jena SHACL engine, or `None` if Jena cannot be driven (so
+/// it is SKIPPED cleanly — the pySHACL-only lane is unaffected). Needs:
+///   - a `java` launcher: `SHACL_DIFF_JAVA` else `java` on PATH (must run), and
+///   - a Jena classpath: `SHACL_DIFF_JENA_CP` (a `*`-glob over its jars) else
+///     `${JENA_HOME}/lib/*` if `JENA_HOME` is set.
+///
+/// The adapter is the single-file `JenaShaclAdapter.java` run via the Java
+/// single-file source launcher (`java -cp <cp> <file>.java`), so no jar/.class is
+/// committed and there is no separate compile step.
+fn resolve_jena() -> Option<RefEngine> {
+    let classpath = jena_classpath(
+        std::env::var("SHACL_DIFF_JENA_CP").ok(),
+        std::env::var("JENA_HOME").ok(),
+    )?;
+    let java = std::env::var("SHACL_DIFF_JAVA").unwrap_or_else(|_| "java".to_string());
+    // `java -version` must actually run (writes to stderr, exit 0) — otherwise no
+    // usable launcher and we skip rather than spawn-error every case.
+    let java_ok = Command::new(&java)
+        .arg("-version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !java_ok {
+        return None;
+    }
+    let adapter = adapter_dir().join("JenaShaclAdapter.java");
+    Some(RefEngine {
+        name: format!("Apache Jena SHACL via {java} (cp {classpath})"),
+        program: java,
+        args: vec![
+            "-cp".to_string(),
+            classpath,
+            adapter.to_string_lossy().into_owned(),
+        ],
+    })
+}
+
+/// All reference engines available on this box, in a stable order. The
+/// differential runs against each; an empty list means SKIP the whole test.
+fn resolve_engines() -> Vec<RefEngine> {
+    [resolve_pyshacl(), resolve_jena()]
+        .into_iter()
+        .flatten()
+        .collect()
+}
+
+/// Runs one reference engine over one (data, shapes) pair. `Err` means the adapter
+/// itself failed (engine error / bad invocation) — distinct from a produced
+/// non-conforming report.
+fn run_reference(engine: &RefEngine, data: &str, shapes: &str) -> Result<RefReport, String> {
     let req = serde_json::json!({ "data": data, "shapes": shapes }).to_string();
-    let mut child = Command::new(python)
-        .arg(adapter_path())
+    let mut child = Command::new(&engine.program)
+        .args(&engine.args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -225,7 +322,7 @@ enum CaseOutcome {
     Mismatch(String),
 }
 
-fn run_case(python: &str, seed: u64) -> CaseOutcome {
+fn run_case(engine: &RefEngine, seed: u64) -> CaseOutcome {
     let mut rng = Rng::new(seed);
     let scenario = Scenario::generate(&mut rng);
     let data_ttl = scenario.data_turtle();
@@ -237,6 +334,7 @@ fn run_case(python: &str, seed: u64) -> CaseOutcome {
         Ok(g) => g,
         Err(e) => {
             return mismatch(
+                engine,
                 seed,
                 &data_ttl,
                 &shapes_ttl,
@@ -248,6 +346,7 @@ fn run_case(python: &str, seed: u64) -> CaseOutcome {
         Ok(g) => g,
         Err(e) => {
             return mismatch(
+                engine,
                 seed,
                 &data_ttl,
                 &shapes_ttl,
@@ -257,7 +356,7 @@ fn run_case(python: &str, seed: u64) -> CaseOutcome {
     };
     let sparq_report = validate(&data, &shapes);
 
-    let reference = match run_reference(python, &data_ttl, &shapes_ttl) {
+    let reference = match run_reference(engine, &data_ttl, &shapes_ttl) {
         Ok(r) => r,
         Err(e) => return CaseOutcome::Skipped(format!("reference engine error: {e}")),
     };
@@ -265,6 +364,7 @@ fn run_case(python: &str, seed: u64) -> CaseOutcome {
     // 1. conforms bit — exact.
     if sparq_report.conforms != reference.conforms {
         return mismatch(
+            engine,
             seed,
             &data_ttl,
             &shapes_ttl,
@@ -285,6 +385,7 @@ fn run_case(python: &str, seed: u64) -> CaseOutcome {
         let only_sparq: Vec<_> = s.difference(&r).collect();
         let only_ref: Vec<_> = r.difference(&s).collect();
         return mismatch(
+            engine,
             seed,
             &data_ttl,
             &shapes_ttl,
@@ -302,9 +403,10 @@ fn run_case(python: &str, seed: u64) -> CaseOutcome {
     CaseOutcome::Agree
 }
 
-fn mismatch(seed: u64, data: &str, shapes: &str, msg: &str) -> CaseOutcome {
+fn mismatch(engine: &RefEngine, seed: u64, data: &str, shapes: &str, msg: &str) -> CaseOutcome {
     CaseOutcome::Mismatch(format!(
-        "MISMATCH seed={seed}\n{msg}\n--- shapes.ttl ---\n{shapes}\n--- data.ttl ---\n{data}"
+        "MISMATCH seed={seed} reference={}\n{msg}\n--- shapes.ttl ---\n{shapes}\n--- data.ttl ---\n{data}",
+        engine.name,
     ))
 }
 
@@ -313,78 +415,108 @@ fn mismatch(seed: u64, data: &str, shapes: &str, msg: &str) -> CaseOutcome {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "differential SHACL fuzz — nightly/heavy tier; needs a reference engine (pyshacl)"]
+#[ignore = "differential SHACL fuzz — nightly/heavy tier; needs a reference engine (pyshacl / Jena)"]
 fn differential_shacl_fuzz() {
-    let python = match resolve_pyshacl() {
-        Some(p) => p,
-        None => {
-            eprintln!(
-                "SKIP: no reference SHACL engine — install pyshacl+rdflib and set \
-                 SHACL_DIFF_PYTHON to its interpreter (e.g. a venv's bin/python)."
-            );
-            return;
-        }
-    };
-    eprintln!("differential SHACL fuzz: reference = pySHACL via {python}");
+    let engines = resolve_engines();
+    if engines.is_empty() {
+        eprintln!(
+            "SKIP: no reference SHACL engine resolved. Install pyshacl+rdflib and set \
+             SHACL_DIFF_PYTHON to its interpreter (e.g. a venv's bin/python), and/or point \
+             SHACL_DIFF_JENA_CP (or JENA_HOME) at an apache-jena lib classpath for the Jena \
+             reference."
+        );
+        return;
+    }
+    eprintln!(
+        "differential SHACL fuzz: {} reference engine(s):",
+        engines.len()
+    );
+    for e in &engines {
+        eprintln!("  - {}", e.name);
+    }
 
     let seed_start: u64 = env_u64("SHACL_DIFF_SEED_START", 0);
     let count: u64 = env_u64("SHACL_DIFF_COUNT", 200);
 
-    let mut agree = 0u64;
-    let mut skipped = 0u64;
-    let mut mismatches: Vec<String> = Vec::new();
-    let mut skip_examples: Vec<String> = Vec::new();
+    // The differential is run independently against EVERY resolved engine over the
+    // same seed range, so a bug surfaces against whichever reference catches it
+    // (and a sparq-vs-pySHACL agreement that is jointly wrong is still caught if
+    // Jena disagrees). Any per-engine disagreement, or any resolved engine that
+    // compared zero cases, fails the whole test.
+    let mut all_mismatches: Vec<String> = Vec::new();
+    let mut all_skip_examples: Vec<String> = Vec::new();
+    let mut vacuous_engines: Vec<String> = Vec::new();
+    let mut total_mismatch_count = 0u64;
 
-    for seed in seed_start..seed_start + count {
-        match run_case(&python, seed) {
-            CaseOutcome::Agree => agree += 1,
-            CaseOutcome::Skipped(why) => {
-                skipped += 1;
-                if skip_examples.len() < 5 {
-                    skip_examples.push(format!("seed={seed}: {why}"));
+    for engine in &engines {
+        let mut agree = 0u64;
+        let mut skipped = 0u64;
+        let mut mismatches: Vec<String> = Vec::new();
+        let mut skip_examples: Vec<String> = Vec::new();
+
+        for seed in seed_start..seed_start + count {
+            match run_case(engine, seed) {
+                CaseOutcome::Agree => agree += 1,
+                CaseOutcome::Skipped(why) => {
+                    skipped += 1;
+                    if skip_examples.len() < 5 {
+                        skip_examples.push(format!("seed={seed}: {why}"));
+                    }
                 }
-            }
-            CaseOutcome::Mismatch(detail) => {
-                eprintln!("MISMATCH seed={seed}");
-                // Cap stored reproducers so a systematically-wrong run does not
-                // produce megabytes of output; the count is still exact.
-                if mismatches.len() < 10 {
-                    mismatches.push(detail);
+                CaseOutcome::Mismatch(detail) => {
+                    eprintln!("MISMATCH seed={seed} reference={}", engine.name);
+                    // Cap stored reproducers per engine so a systematically-wrong
+                    // run does not produce megabytes of output; counts stay exact.
+                    if mismatches.len() < 10 {
+                        mismatches.push(detail);
+                    }
                 }
             }
         }
-    }
 
-    let total_mismatch = count - agree - skipped;
-    eprintln!(
-        "\nSHACL diff fuzz: seeds {seed_start}..{} — agree={agree} skipped={skipped} mismatch={total_mismatch}",
-        seed_start + count,
-    );
-    for ex in &skip_examples {
-        eprintln!("SKIP example: {ex}");
-    }
-
-    if total_mismatch > 0 {
-        for d in &mismatches {
-            eprintln!("\n{d}");
-        }
-        panic!(
-            "{total_mismatch} disagreement(s) between sparq-shacl and the reference engine \
-             (showing up to {} reproducers above) — file a bead per distinct bug with the seed.",
-            mismatches.len()
+        let engine_mismatch = count - agree - skipped;
+        total_mismatch_count += engine_mismatch;
+        eprintln!(
+            "\nSHACL diff fuzz [{}]: seeds {seed_start}..{} — agree={agree} skipped={skipped} mismatch={engine_mismatch}",
+            engine.name,
+            seed_start + count,
         );
-    }
-
-    // [OPUS-4.8] Guard against a VACUOUS pass. We only reach this point with the
-    // adapter RESOLVED (an absent pySHACL short-circuits via `resolve_pyshacl`
-    // returning `None` above), so the comparison is expected to actually run.
-    // `assess_run` makes "adapter present but compared zero cases" a hard error
-    // instead of a silent agreement; see its doc + the unit test below.
-    if let Err(why) = assess_run(agree, skipped) {
         for ex in &skip_examples {
             eprintln!("SKIP example: {ex}");
         }
-        panic!("{why}");
+        all_mismatches.append(&mut mismatches);
+        all_skip_examples.append(&mut skip_examples);
+
+        // [OPUS-4.8] Guard against a VACUOUS pass for THIS engine. We only resolve
+        // an engine when its toolchain is present, so it is expected to actually
+        // compare. If it compared zero cases (resolved yet errored on every seed —
+        // wrong venv / missing jar / adapter regression) that is a broken setup,
+        // not agreement; record it as a hard failure.
+        if let Err(why) = assess_run(agree, skipped) {
+            vacuous_engines.push(format!("{}: {why}", engine.name));
+        }
+    }
+
+    if total_mismatch_count > 0 {
+        for d in &all_mismatches {
+            eprintln!("\n{d}");
+        }
+        panic!(
+            "{total_mismatch_count} disagreement(s) between sparq-shacl and the reference \
+             engine(s) (showing up to {} reproducers above) — file a bead per distinct bug \
+             with the seed.",
+            all_mismatches.len()
+        );
+    }
+
+    if !vacuous_engines.is_empty() {
+        for ex in &all_skip_examples {
+            eprintln!("SKIP example: {ex}");
+        }
+        panic!(
+            "reference engine(s) compared ZERO cases (resolved yet errored on every seed): {}",
+            vacuous_engines.join("; ")
+        );
     }
 }
 
@@ -549,6 +681,39 @@ fn missing_focus_is_distinct_from_blank_node_focus() {
     assert!(
         !missing.contains(&blank),
         "missing focus collapsed into the blank-node sentinel — masks report-shape bugs"
+    );
+}
+
+/// [OPUS-4.8] (sq-evws) Jena classpath gating: an explicit `SHACL_DIFF_JENA_CP`
+/// wins; else `${JENA_HOME}/lib/*`; else `None` (Jena SKIPPED, pySHACL-only lane
+/// unaffected). A blank value is treated as unset so an empty env var can't yield
+/// a degenerate empty classpath. Pure (env passed in) so it runs in the fast lane
+/// without mutating process-global env across parallel tests.
+#[test]
+fn jena_classpath_gating() {
+    // Explicit classpath wins, even when JENA_HOME is also set.
+    assert_eq!(
+        jena_classpath(Some("/opt/jena/lib/*".into()), Some("/ignored".into())),
+        Some("/opt/jena/lib/*".to_string())
+    );
+    // Derive from JENA_HOME when no explicit classpath.
+    let derived = jena_classpath(None, Some("/opt/apache-jena".into())).unwrap();
+    assert!(
+        derived.starts_with("/opt/apache-jena")
+            && (derived.ends_with("lib/*") || derived.ends_with("lib\\*")),
+        "JENA_HOME-derived classpath should be <home>/lib/*, got {derived}"
+    );
+    // Neither set → Jena is skipped (None), which is the pySHACL-only lane.
+    assert_eq!(jena_classpath(None, None), None);
+    // Blank values are treated as unset (no degenerate empty classpath).
+    assert_eq!(jena_classpath(Some(String::new()), None), None);
+    assert_eq!(jena_classpath(None, Some(String::new())), None);
+    assert_eq!(
+        jena_classpath(Some(String::new()), Some("/opt/apache-jena".into()))
+            .as_deref()
+            .map(|s| s.ends_with("lib/*") || s.ends_with("lib\\*")),
+        Some(true),
+        "blank explicit cp must fall through to JENA_HOME"
     );
 }
 

--- a/crates/sparq-shacl/tests/diff_fuzz/JenaShaclAdapter.java
+++ b/crates/sparq-shacl/tests/diff_fuzz/JenaShaclAdapter.java
@@ -1,0 +1,181 @@
+// [OPUS-4.8] sq-evws: Apache Jena SHACL reference-engine adapter for the SHACL
+// differential fuzzer (crates/sparq-shacl/tests/diff_fuzz.rs).
+//
+// A second, independent reference alongside the pySHACL adapter (sq-55c1). It is
+// the SAME "report-cli" contract (bead sq-eifd): JSON request in, normalised JSON
+// report out, so the Rust runner's comparison is engine-agnostic. A second engine
+// catches bugs where sparq and pySHACL happen to agree but are both wrong.
+//
+// WHY a single .java file (no compile step): Java 11+ runs a source file directly
+// via the single-file source launcher — `java -cp <jena-libs> JenaShaclAdapter.java`.
+// So the differential ships ONLY source, compiled-and-run in one shot per case
+// (the per-case-spawn isolation the pySHACL adapter uses), and no `.class`/jar is
+// committed. The Jena jars come from an unpacked apache-jena tarball cached in CI.
+//
+// CONTRACT (stdin -> stdout) — identical to tests/diff_fuzz/pyshacl_adapter.py:
+//   stdin  : a JSON object {"data": "<turtle>", "shapes": "<turtle>"}
+//   stdout : {"conforms": bool,
+//             "violations": [{"focus": str|null, "component": str|null,
+//                             "path": str|null}, ...]}
+//            — `focus`/`component` are full IRIs (or "_:bnode" for blank nodes,
+//            which have no cross-graph identity); `path` is the bare predicate IRI
+//            for a simple path, the "_:path" sentinel for any complex/blank-rooted
+//            path, or null when the result carries no path. Exactly the shape the
+//            Rust runner's RefReport deserialises and `ref_keys` normalises.
+//   exit   : 0 on a produced report (even non-conforming); non-zero only on an
+//            adapter/engine ERROR (so the runner distinguishes "engine says X" from
+//            "engine could not run"), with a diagnostic on stderr.
+//
+// Reads ONE request and emits ONE report (one JVM per case, mirroring the pySHACL
+// adapter's one-interpreter-per-case isolation).
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.shacl.ShaclValidator;
+import org.apache.jena.shacl.Shapes;
+import org.apache.jena.shacl.ValidationReport;
+import org.apache.jena.sparql.graph.GraphFactory;
+import org.apache.jena.vocabulary.RDF;
+
+public final class JenaShaclAdapter {
+    static final String SH = "http://www.w3.org/ns/shacl#";
+
+    public static void main(String[] args) {
+        try {
+            byte[] in = System.in.readAllBytes();
+            String req = new String(in, StandardCharsets.UTF_8);
+            String data = jsonField(req, "data");
+            String shapes = jsonField(req, "shapes");
+
+            Graph dataG = GraphFactory.createDefaultGraph();
+            RDFParser.create().source(new StringReader(data)).lang(Lang.TURTLE).parse(dataG);
+            Graph shapesG = GraphFactory.createDefaultGraph();
+            RDFParser.create().source(new StringReader(shapes)).lang(Lang.TURTLE).parse(shapesG);
+
+            Shapes sh = Shapes.parse(shapesG);
+            ValidationReport report = ShaclValidator.get().validate(sh, dataG);
+            System.out.print(normalise(report));
+            System.out.print("\n");
+            System.exit(0);
+        } catch (Throwable t) {
+            System.err.println("jena_shacl_adapter: engine error: " + t);
+            System.exit(1);
+        }
+    }
+
+    static String normalise(ValidationReport report) {
+        Graph g = report.getGraph();
+        Node pFocus = NodeFactoryUri(SH + "focusNode");
+        Node pComp = NodeFactoryUri(SH + "sourceConstraintComponent");
+        Node pPath = NodeFactoryUri(SH + "resultPath");
+        Node resultT = NodeFactoryUri(SH + "ValidationResult");
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"conforms\":").append(report.conforms() ? "true" : "false");
+        sb.append(",\"violations\":[");
+        boolean first = true;
+        var it = g.find(Node.ANY, RDF.type.asNode(), resultT);
+        while (it.hasNext()) {
+            Triple t = it.next();
+            Node res = t.getSubject();
+            Node focus = objectOf(g, res, pFocus);
+            Node comp = objectOf(g, res, pComp);
+            Node path = objectOf(g, res, pPath);
+            if (!first) sb.append(",");
+            first = false;
+            sb.append("{\"focus\":").append(termKey(focus));
+            sb.append(",\"component\":").append(termKey(comp));
+            sb.append(",\"path\":").append(pathKey(path));
+            sb.append("}");
+        }
+        sb.append("]}");
+        return sb.toString();
+    }
+
+    static Node NodeFactoryUri(String uri) {
+        return org.apache.jena.graph.NodeFactory.createURI(uri);
+    }
+
+    static Node objectOf(Graph g, Node s, Node p) {
+        var it = g.find(s, p, Node.ANY);
+        if (it.hasNext()) return it.next().getObject();
+        return null;
+    }
+
+    static String termKey(Node n) {
+        if (n == null) return "null";
+        if (n.isBlank()) return jsonStr("_:bnode");
+        if (n.isURI()) return jsonStr(n.getURI());
+        if (n.isLiteral()) return jsonStr(n.getLiteralLexicalForm());
+        return jsonStr(n.toString());
+    }
+
+    static String pathKey(Node n) {
+        if (n == null) return "null";
+        if (n.isURI()) return jsonStr(n.getURI());
+        // Complex / blank-rooted path: same sentinel the pySHACL adapter emits.
+        return jsonStr("_:path");
+    }
+
+    // Minimal JSON string emit (escapes the characters that appear in IRIs/labels).
+    static String jsonStr(String s) {
+        StringBuilder b = new StringBuilder("\"");
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"': b.append("\\\""); break;
+                case '\\': b.append("\\\\"); break;
+                case '\n': b.append("\\n"); break;
+                case '\r': b.append("\\r"); break;
+                case '\t': b.append("\\t"); break;
+                default:
+                    if (c < 0x20) b.append(String.format("\\u%04x", (int) c));
+                    else b.append(c);
+            }
+        }
+        b.append("\"");
+        return b.toString();
+    }
+
+    // Tiny JSON-object field extractor for {"data": "...", "shapes": "..."}.
+    // The request is produced by serde_json with simple string values, so a
+    // dependency-free unescaper suffices (no nested objects/arrays).
+    static String jsonField(String json, String field) {
+        String needle = "\"" + field + "\"";
+        int k = json.indexOf(needle);
+        if (k < 0) throw new IllegalArgumentException("missing field: " + field);
+        int i = json.indexOf('"', k + needle.length());
+        if (i < 0) throw new IllegalArgumentException("no opening quote for: " + field);
+        StringBuilder sb = new StringBuilder();
+        for (int p = i + 1; p < json.length(); p++) {
+            char c = json.charAt(p);
+            if (c == '\\') {
+                char n = json.charAt(++p);
+                switch (n) {
+                    case 'n': sb.append('\n'); break;
+                    case 'r': sb.append('\r'); break;
+                    case 't': sb.append('\t'); break;
+                    case '"': sb.append('"'); break;
+                    case '\\': sb.append('\\'); break;
+                    case '/': sb.append('/'); break;
+                    case 'u':
+                        int cp = Integer.parseInt(json.substring(p + 1, p + 5), 16);
+                        sb.append((char) cp);
+                        p += 4;
+                        break;
+                    default: sb.append(n);
+                }
+            } else if (c == '"') {
+                return sb.toString();
+            } else {
+                sb.append(c);
+            }
+        }
+        throw new IllegalArgumentException("unterminated string for: " + field);
+    }
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-evws** (sparq-shacl): _SHACL diff-fuzz: wire Jena-SHACL reference adapter_.

## What

Adds **Apache Jena SHACL** as a second, independent reference engine for the SHACL differential fuzzer, alongside pySHACL (sq-55c1). A second reference catches bugs where sparq and pySHACL happen to agree but are both wrong.

- **`tests/diff_fuzz/JenaShaclAdapter.java`** — a single-file Java adapter run via the Java 11+ single-file source launcher (`java -cp <jena-libs> JenaShaclAdapter.java`), so **no compile step or committed jar** is needed. It is the same report-cli contract as the pySHACL adapter (sq-eifd): JSON `{data, shapes}` in, normalised JSON `{conforms, violations:[{focus, component, path}]}` out, so the Rust runner's comparison is engine-agnostic. Complex/blank-rooted paths emit the same `_:path` sentinel as pySHACL; blank nodes collapse to `_:bnode`.
- **`tests/diff_fuzz.rs`** — refactor the hardcoded single-engine path into a pluggable `RefEngine` (name + program + args); resolve pySHACL **and** Jena; run the differential **independently against every resolved engine** over the same seed range; aggregate per-engine agree/skip/mismatch and fail on any disagreement or any resolved engine that compared zero cases. Jena is gated on `SHACL_DIFF_JENA_CP` (or `${JENA_HOME}/lib/*`) plus a working `java`, so it is **silently skipped where unavailable** and the existing pySHACL-only lane is unaffected. Adds a fast unit test for the classpath-gating logic (runs in the per-PR path; pure, no Jena needed).
- **`.github/workflows/shacl-diff-fuzz.yml`** — add a Temurin-21 setup and download a **SHA-512-verified** apache-jena tarball (cached across runs, pinned version + checksum = the published `apache-jena-5.2.0` SHA-512), set `JENA_HOME`, and raise the timeout (two per-case-spawn engines). All third-party actions SHA-pinned.
- **`crates/sparq-shacl/README.md`** — document the two wired references and how to run each locally.

## Verification (end-to-end against real Jena 5.2.0)

- Jena-only, 40 seeds: `agree=40 skipped=0 mismatch=0`.
- Both engines, 25 seeds: pySHACL `25/25` agree, Jena `25/25` agree — sparq, pySHACL and Jena all agree on the generated corpus.
- The downloaded tarball's SHA-512 was checked against the official Apache `.sha512` (matches) — that exact checksum is what the workflow pins.

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + tests in **both** feature states (default and `shacl-af`) — green (0 failures).
- `tests/diff_fuzz.rs` passes `rustfmt --check`; pre-existing unformatted sibling files were left untouched (smallest correct change).
- Privacy-claims gate: OK. G2 public-api→SKILL: PASS — **no public API changed** (only a test, a test fixture, a CI workflow, and the README).

## Scope / honesty

This is a test-harness + CI change only — no `src/` or public-API change. It expands differential coverage; it does not by itself assert any new SHACL conformance claim beyond what the corpus exercises. Other reference engines (rdf-validate-shacl / shacl-engine via Node) remain follow-up beads.