### PR TITLE
bench(rsp): RSP-QL deterministic per-window row-count gate + SRBench oracle (sq-b1hn)

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -58,7 +58,7 @@ conventions first, then a per-category map that points at the registry, then a
 
 | category | what it covers | registry ids |
 |---|---|---|
-| **query** | engine compute + differential correctness; aux-index harnesses; well-known suites | `sparq-bench-compare`, `sparq-bench-fuzz`, `sparq-bench-diff`, `cli-bench-suite`, `cli-bench-mmap`, `operator-coverage`, `sp2b`, `dbpsb`, `watdiv`, `bsbm`, `lubm`, `shacl-validate-bench`, `geo-bench`, `selective-bindjoin`, `u64-valueids`, `qlever-olympics`, `qlever-synthetic-10m`, `qlever-synthetic-100m`, `text-index-bench`, `vector-ann-bench`, `geo-index-bench`, `rsp-throughput`, `vectors-throughput`, `gpu-bench`, `sim-olympics-eval`, `introspect-olympics` |
+| **query** | engine compute + differential correctness; aux-index harnesses; well-known suites | `sparq-bench-compare`, `sparq-bench-fuzz`, `sparq-bench-diff`, `cli-bench-suite`, `cli-bench-mmap`, `operator-coverage`, `sp2b`, `dbpsb`, `watdiv`, `bsbm`, `lubm`, `shacl-validate-bench`, `geo-bench`, `selective-bindjoin`, `u64-valueids`, `qlever-olympics`, `qlever-synthetic-10m`, `qlever-synthetic-100m`, `text-index-bench`, `vector-ann-bench`, `geo-index-bench`, `rsp-throughput`, `rsp-ql`, `vectors-throughput`, `gpu-bench`, `sim-olympics-eval`, `introspect-olympics` |
 | **parse** | text-format parse throughput (MB/s) | `parse-baseline` |
 | **ingest** | load + dict + external-memory build throughput | `cli-ingest`, `cli-save-build`, `cli-bench-remap`, `hdt-load-bench`, `hdt-stage-split`, `wikidata-8b` |
 | **compression** | index / result-serialization footprint tradeoffs | `cli-probe-compress`, `cli-compare-compress`, `compress-bench` |
@@ -138,6 +138,20 @@ Notes on a few that need care:
   `fts_bytes_per_doc` also has a `mode:auto` ratchet in `bench/perf-baseline.json`. CI emits
   `text_<workload>_us` + `text_build_s` (trend-only, advisory). Heavy/latency tier: `N=1000000`.
   An IR-quality BEIR axis (Recall@100 / nDCG@10) is gather-only and not yet wired (follow-up bead).
+- **`rsp-ql` is the RSP-QL STREAMING suite** — see [`bench/rsp/README.md`](./rsp/README.md). It
+  exercises `sparq-rsp` (windowed continuous SPARQL: S2R `RANGE/STEP` windows, three `EvalMode`s,
+  RSP-QL multi-window joins). Because `sparq-rsp` is **clock-free** (a window closes on the
+  pushed-timestamp watermark, not a real clock), a fixed `(triple, ts)` replay is a pure function —
+  so the gate is a **DETERMINISTIC per-window result-row count** (a STRONGER gate than any
+  wall-clock RSP benchmark). `run.sh` runs the `rsp_oracle` example (no external tool — the crate
+  is isolated, like FTS's `bench_text`) and asserts every `rsp_<scenario>_<mode>_w<k>_rows`
+  (single-window tumbling/sliding/GROUP-BY × Rebuild/PersistentDict/Delta — the identical expected
+  counts ALSO encode the **three-EvalMode-equivalence**) and `rsp_srbench_<q>_w<k>_rows` (the
+  **SRBench correctness ORACLE**: a multi-window observation⋈station-metadata join) vs
+  `expected.tsv` (exit 1 on drift). CI emits `rsp_persistentdict_triples_per_s` (trend-only,
+  advisory). **NO competitor perf column** — the RSP peers (C-SPARQL / CQELS / RSP4J) are
+  wall-clock service engines, so a throughput head-to-head is apples-to-oranges (different time
+  model); perf comparison is explicitly **out of scope**.
   Competitor honesty: **Solr/ES are NOT SPARQL competitors and stay off the dashboard**; the
   surface peer is Fuseki + `jena-text` (`http-sparql`), the kernel ref is Lucene/Anserini (labelled
   *sub-component, not an RDF benchmark*).
@@ -282,6 +296,7 @@ bench/shacl/run.sh                    # SHACL (javac + rapper): LUBM ABox x 5 sh
 cargo build --release -p sparq-text --example bench_text && bench/fts/run.sh   # Full-text (no external tool): synthetic BM25 corpus + hit-count/bytes-per-doc diff
 cargo build --release -p sparq-vectors --example bench_vectors && bench/vector/run.sh   # Vector/ANN (no external tool): synthetic corpus + recall@10-deficit gate (HNSW/Vamana/PQ)
 bench/geo/run.sh                      # GeoSPARQL (cargo only): fixed ~100k point corpus + within/nearest/geof: result-set-size + compliance-pass diff (counts-not-coords)
+cargo build --release -p sparq-rsp --example rsp_oracle && bench/rsp/run.sh   # RSP-QL (cargo only): clock-free fixed (triple,ts) replay + DETERMINISTIC per-window row-count gate (3 EvalModes) + SRBench correctness oracle
 bench/deep-taxonomy/run.sh            # DeepTaxonomy (python3 only): N3 closure per depth tier + closure-size + query-row gate
 bench/owl-sameas/run.sh               # OWL sameAs (python3 only): OWL-RL closure per size tier + closure-size (K·N·(N+M)) + query-row (K·N) gate
 

--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -657,6 +657,25 @@ pinning     = "in-example generator"
 records_to  = "stdout; sparq-rsp README"
 status      = "ok"
 
+# [OPUS-4.8] sq-b1hn — the RSP-QL capability suite: a DETERMINISTIC per-window
+# result-row-count gate (sparq-rsp is clock-free, so a fixed (triple,ts) replay is
+# a pure function — a STRONGER correctness gate than any wall-clock RSP benchmark)
+# + an SRBench correctness ORACLE (multi-window observation⋈metadata join).
+# Design: research/capability-benchmark-program.md §3.6. NO competitor perf column:
+# the RSP peers (C-SPARQL/CQELS/RSP4J) are wall-clock service engines — a throughput
+# head-to-head is apples-to-oranges (different time model), so perf is OUT OF SCOPE.
+[[benchmark]]
+id          = "rsp-ql"
+name        = "RSP-QL streaming (per-window row-count gate + SRBench oracle)"
+category    = "query"
+measures    = "DETERMINISTIC per-window result-row count over a fixed (triple,ts) replay — single-window tumbling/sliding/GROUP-BY x three EvalModes (encoding the 3-EvalMode-equivalence) + SRBench correctness oracle (multi-window join); advisory rsp_persistentdict_triples_per_s (trend-only, NOT gated)"
+invoke      = "cargo build --release -p sparq-rsp --example rsp_oracle && bench/rsp/run.sh"
+source      = "bench/rsp/run.sh; crates/sparq-rsp/examples/rsp_oracle.rs; gate bench/rsp/expected.tsv"
+dataset     = "fixed (triple,ts) replay scripts pinned in-example (single-window sensor stream + SRBench-shaped LOD-weather observation/metadata streams); no external data"
+pinning     = "scripts + queries hard-coded in rsp_oracle.rs; per-window counts gated in bench/rsp/expected.tsv"
+records_to  = "stdout (run.sh, the canonical self-asserting runner); not baked into docs/tests — correctness lives in expected.tsv"
+status      = "ok"
+
 # [OPUS-4.8] sq-cu8c — vector store/HNSW throughput behind an #[ignore]d test.
 [[benchmark]]
 id          = "vectors-throughput"

--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -356,6 +356,11 @@
     { key: 'GeoSPARQL',     title: 'GeoSPARQL',     aliases: ['geosparql', 'geo'] },
     // [OPUS-4.8] sq-v02y: Vector / ANN suite (HNSW / Vamana / PQ recall@10 deficits vs exact-kNN).
     { key: 'Vector / ANN',  title: 'Vector / ANN', aliases: ['vector / ann', 'vector', 'vectors', 'ann'] },
+    // [OPUS-4.8] sq-b1hn: RSP-QL streaming suite. Metrics are `rsp_*` (per-window row-count gate +
+    // SRBench oracle + advisory rsp_persistentdict_triples_per_s) — the `rsp` alias prefix-matches the
+    // whole family. Correctness/expressivity card; perf head-to-head OUT OF SCOPE (clock-free vs the
+    // wall-clock RSP peers C-SPARQL/CQELS/RSP4J — different time model). No competitor perf column.
+    { key: 'RSP-QL',        title: 'RSP-QL streaming', aliases: ['rsp-ql', 'rsp', 'rspql'] },
     { key: 'BSBM',          title: 'BSBM',          aliases: ['bsbm'] },
     { key: 'DBPSB',         title: 'DBPSB',         aliases: ['dbpsb', 'dbpedia sparql benchmark'] },
     // [OPUS-4.8] sq-i0nm: the synthetic qlever-style suite carries the one in-repo competitor

--- a/bench/rsp/README.md
+++ b/bench/rsp/README.md
@@ -1,0 +1,112 @@
+<!-- [OPUS-4.8] sq-b1hn — RSP-QL streaming benchmark suite. Design: research/capability-benchmark-program.md §3.6. -->
+# RSP-QL streaming suite
+
+The RSP-QL analogue of the LUBM / SHACL / FTS template — but with a deliberately
+**different shape**, because `sparq-rsp` is a **deterministic, clock-free
+library**, not a wall-clock service engine. The suite is therefore built around a
+**correctness gate**, not a throughput head-to-head.
+
+It exercises `sparq-rsp`: windowed continuous SPARQL (S2R `RANGE/STEP` windows →
+R2R per-window materialisation → R2S `RSTREAM`), the three `EvalMode`s (Rebuild /
+PersistentDict / Delta), and the RSP-QL surface syntax + multi-window
+named-graph joins.
+
+## Why no competitor perf column (honest)
+
+The natural RSP peers — **C-SPARQL, CQELS, RSP4J / YASPER** (and the
+**SRBench / CityBench / LSBench / RSPLab** harnesses) — are **service/runtime
+engines with wall-clock windows**: a window closes when *real time* passes.
+`sparq-rsp` is clock-free — a window closes when the *pushed-timestamp watermark*
+passes, so its output is a pure function of the `(triple, ts)` sequence with no
+scheduler, no real clock. **Any throughput head-to-head across the two is
+apples-to-oranges (different time model)** — it is the surface where a competitor
+*perf* column is least meaningful. So this suite has **no competitor perf
+column**. The honest comparison is **correctness / expressivity**, run as the
+SRBench correctness oracle below (the EYE role). Perf head-to-head is explicitly
+**out of scope**.
+
+## The gate: per-window result-row counts (clock-free → deterministic)
+
+Because the pipeline is clock-free, replaying a **fixed `(triple, ts)` script**
+yields a fully **deterministic** per-window result. The gate is a diff of the
+per-window **result-row count** against `expected.tsv` — a **stronger** gate than
+any wall-clock RSP benchmark can offer (no timing flake, no scheduler
+nondeterminism). `run.sh` asserts every metric and exits non-zero on any drift,
+exactly like LUBM's count diff.
+
+Two metric families, both asserted:
+
+| family | what | meaning of the count |
+|---|---|---|
+| `rsp_<scenario>_<mode>_w<k>_rows` | single-window scenario × `EvalMode` × window `k` | result rows that window emitted |
+| `rsp_srbench_<q>_w<k>_rows` | SRBench oracle query × synchronized window `k` | rows the multi-window join produced |
+
+### Single-window scenarios (× three EvalModes)
+
+A fixed 13-element sensor script (multi-sensor, a duplicate triple for set
+semantics, an empty window for the gap case, boundary-internal arrivals) replayed
+through three scenarios:
+
+- **`tumbling_avg`** — `AVG` over `RANGE 10 STEP 10` (one aggregate row per
+  window, including empty windows).
+- **`sliding_sum`** — `SUM` per sensor over `RANGE 20 STEP 10` (50 % overlap; one
+  row per distinct sensor present in each overlapping window).
+- **`tumbling_groupby_join`** — room ⋈ value `GROUP BY` over `RANGE 20 STEP 20`.
+
+Each runs under **all three `EvalMode`s** (Rebuild / PersistentDict / Delta), and
+`expected.tsv` pins them to the **same** per-window counts — so these rows ALSO
+encode the **three-EvalMode-equivalence** assert (a regression in any one mode
+fails the gate). This complements the differential streamed-equals-batch oracle
+already in `crates/sparq-rsp/tests/window_oracle.rs` (which proves each window
+equals the batch query over its tuples); the bench pins the *shape* (window
+count + row count) of a fixed replay so a regression alerts on the dashboard.
+
+### SRBench correctness oracle (the EYE role)
+
+[SRBench](https://link.springer.com/chapter/10.1007/978-3-642-35176-1_40) is the
+canonical RSP correctness/expressivity suite over real LOD **weather** streams:
+sensor **observations** joined to **station metadata**. We reproduce that *shape*
+deterministically — an observations stream (`<station> <value> v`) and a
+station-metadata stream (`<station> <state> <usstate>`, re-announced each window
+the way a metadata stream emits a per-window snapshot), joined per synchronized
+window via `ContinuousMultiQuery` (cross-named-graph join, the RSP-QL `WINDOW
+<w1> { … } WINDOW <w2> { … }` form). Two queries:
+
+- **`srbench_join`** — annotate each observation with its station's US state
+  (the canonical "enrich the stream from the background graph" pattern). An
+  observation from a station with **no metadata** is correctly dropped by the
+  inner join; a station observed twice in a window is deduplicated to set
+  semantics.
+- **`srbench_groupby_state`** — readings per US state per window (the join feeds
+  a `GROUP BY` — aggregate-after-join expressivity).
+
+This is correctness/expressivity coverage only; the time model differs from a
+wall-clock RSP engine, so it carries **no perf comparison**.
+
+## Advisory throughput (trend-only, NOT a gate)
+
+The runner also emits a single `rsp_persistentdict_triples_per_s` line: the
+PersistentDict (default) `EvalMode` throughput pushing 200 k synthetic readings
+through a `RANGE 1000` continuous query. It is **machine-sensitive and trend-only**
+— NOT in the perf gate. The deterministic per-window counts above are the real
+gate. The fuller `EvalMode` head-to-head (1 M readings, all scenarios) lives in
+`crates/sparq-rsp/examples/throughput.rs` (the `rsp-throughput` registry entry).
+
+## Files
+
+| file | role |
+|---|---|
+| `crates/sparq-rsp/examples/rsp_oracle.rs` | the TSV-emitting runner (the crate is isolated — not a `sparq-cli` dependency, so the runner is a crate example, like FTS's `bench_text`) |
+| `expected.tsv` | the deterministic per-window row-count gate (single-window × 3 EvalModes + SRBench oracle) |
+| `run.sh` | self-asserting entry point CI calls: run the example, assert every `*_rows` metric vs `expected.tsv`, forward the 3-column `<metric>\t<value>\t<unit>` hook contract |
+
+## Run it
+
+```sh
+cargo build --release -p sparq-rsp --example rsp_oracle
+bench/rsp/run.sh                       # asserts + prints the metric TSV; exit 1 on any drift
+```
+
+A divergence in `expected.tsv` means the RSP windowing / materialisation /
+eval-mode / multi-window-join semantics changed — regenerate only after confirming
+the change is intended (and update the differential oracle test if so).

--- a/bench/rsp/expected.tsv
+++ b/bench/rsp/expected.tsv
@@ -1,0 +1,82 @@
+# [OPUS-4.8] RSP-QL DETERMINISTIC per-window result-row-count gate (sq-b1hn).
+# Design: research/capability-benchmark-program.md §3.6.
+#
+# sparq-rsp is CLOCK-FREE — the windowed pipeline is a pure function of the pushed
+# (triple, ts) sequence — so replaying the FIXED scripts in
+# crates/sparq-rsp/examples/rsp_oracle.rs yields a fully DETERMINISTIC per-window
+# result. run.sh asserts EVERY metric below against the example's output; any
+# mismatch is an S2R / R2R / eval-mode / multi-window-join regression and fails
+# the run LOUDLY. This is a STRONGER correctness gate than any wall-clock RSP
+# benchmark (no timing flake, no scheduler nondeterminism). The advisory throughput
+# (rsp_persistentdict_triples_per_s) is machine-sensitive and is NOT gated here.
+#
+# Two metric families:
+#   rsp_<scenario>_<mode>_w<k>_rows  — single-window scenario, per closed window k.
+#     The three modes (rebuild / pdict / delta) are pinned to the SAME counts, so
+#     these rows ALSO encode the three-EvalMode equivalence assert.
+#   rsp_srbench_<q>_w<k>_rows        — SRBench correctness ORACLE: a multi-window
+#     JOIN over two LOD-weather streams (observations ⋈ station metadata) per
+#     synchronized window k. Correctness/expressivity only — perf head-to-head vs
+#     C-SPARQL/CQELS/RSP4J is OUT OF SCOPE (different, wall-clock time model).
+#
+# Columns: metric<TAB>expected_rows
+#
+# --- single-window: tumbling AVG (RANGE 10 STEP 10) — 1 row per window (AVG is a
+#     single aggregate group), incl. the empty [10,20) which still yields one AVG row.
+rsp_tumbling_avg_rebuild_w0_rows	1
+rsp_tumbling_avg_rebuild_w1_rows	1
+rsp_tumbling_avg_rebuild_w2_rows	1
+rsp_tumbling_avg_rebuild_w3_rows	1
+rsp_tumbling_avg_rebuild_w4_rows	1
+rsp_tumbling_avg_pdict_w0_rows	1
+rsp_tumbling_avg_pdict_w1_rows	1
+rsp_tumbling_avg_pdict_w2_rows	1
+rsp_tumbling_avg_pdict_w3_rows	1
+rsp_tumbling_avg_pdict_w4_rows	1
+rsp_tumbling_avg_delta_w0_rows	1
+rsp_tumbling_avg_delta_w1_rows	1
+rsp_tumbling_avg_delta_w2_rows	1
+rsp_tumbling_avg_delta_w3_rows	1
+rsp_tumbling_avg_delta_w4_rows	1
+# --- single-window: sliding SUM per sensor (RANGE 20 STEP 10, 50% overlap) — one
+#     row per distinct sensor present in each overlapping window.
+rsp_sliding_sum_rebuild_w0_rows	2
+rsp_sliding_sum_rebuild_w1_rows	1
+rsp_sliding_sum_rebuild_w2_rows	2
+rsp_sliding_sum_rebuild_w3_rows	2
+rsp_sliding_sum_rebuild_w4_rows	1
+rsp_sliding_sum_pdict_w0_rows	2
+rsp_sliding_sum_pdict_w1_rows	1
+rsp_sliding_sum_pdict_w2_rows	2
+rsp_sliding_sum_pdict_w3_rows	2
+rsp_sliding_sum_pdict_w4_rows	1
+rsp_sliding_sum_delta_w0_rows	2
+rsp_sliding_sum_delta_w1_rows	1
+rsp_sliding_sum_delta_w2_rows	2
+rsp_sliding_sum_delta_w3_rows	2
+rsp_sliding_sum_delta_w4_rows	1
+# --- single-window: tumbling GROUP BY join room⋈value (RANGE 20 STEP 20) — one
+#     row per room with readings; [40,60) has values but no room triple → 0 rows.
+rsp_tumbling_groupby_join_rebuild_w0_rows	2
+rsp_tumbling_groupby_join_rebuild_w1_rows	2
+rsp_tumbling_groupby_join_rebuild_w2_rows	0
+rsp_tumbling_groupby_join_pdict_w0_rows	2
+rsp_tumbling_groupby_join_pdict_w1_rows	2
+rsp_tumbling_groupby_join_pdict_w2_rows	0
+rsp_tumbling_groupby_join_delta_w0_rows	2
+rsp_tumbling_groupby_join_delta_w1_rows	2
+rsp_tumbling_groupby_join_delta_w2_rows	0
+# --- SRBench oracle Q1 (join): observation ⋈ station-state per synchronized
+#     window. w0=3 (A,B,C all report+known), w1=2 (only A,C), w2=2 (A dedup'd +
+#     C; the unknown station stZ has NO metadata → inner join drops it), w3=0
+#     (the closing heartbeat's window has no metadata snapshot).
+rsp_srbench_join_w0_rows	3
+rsp_srbench_join_w1_rows	2
+rsp_srbench_join_w2_rows	2
+rsp_srbench_join_w3_rows	0
+# --- SRBench oracle Q2 (aggregate-after-join): readings per US state per window.
+#     w0/w1/w2=2 (NY + CA both present), w3=0.
+rsp_srbench_groupby_state_w0_rows	2
+rsp_srbench_groupby_state_w1_rows	2
+rsp_srbench_groupby_state_w2_rows	2
+rsp_srbench_groupby_state_w3_rows	0

--- a/bench/rsp/run.sh
+++ b/bench/rsp/run.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] (sq-b1hn) RSP-QL per-commit runner — the self-asserting entry point CI calls,
+# mirroring bench/fts/run.sh + bench/deep-taxonomy/run.sh. Self-contained:
+#   1. run the sparq-rsp `rsp_oracle` EXAMPLE (the crate is isolated — not a sparq-cli
+#      dependency, so the runner is a crate example, like bench/fts's bench_text).
+#   2. ASSERT every DETERMINISTIC per-window result-row count vs expected.tsv (exit 1 on
+#      any drift — the HARD correctness gate). sparq-rsp is CLOCK-FREE, so a replay over a
+#      fixed (triple, ts) script is a pure function: the per-window row counts are fully
+#      deterministic, a STRONGER gate than any wall-clock RSP benchmark. This covers the
+#      single-window scenarios (tumbling/sliding/GROUP-BY × three EvalModes — the
+#      three-EvalMode-equivalence is encoded as identical expected counts) AND the SRBench
+#      correctness ORACLE (multi-window observation ⋈ station-metadata join).
+#   3. forward on STDOUT the 3-column `<metric>\t<value>\t<unit>` contract the ci-bench
+#      `rsp` hook consumes: the asserted per-window `*_rows` counts (DETERMINISTIC) plus the
+#      single advisory `rsp_persistentdict_triples_per_s` (trend-only — NOT gated, machine-
+#      sensitive). Correctness lives in expected.tsv, exactly like LUBM / FTS / SHACL.
+#
+# Perf head-to-head vs C-SPARQL / CQELS / RSP4J is explicitly OUT OF SCOPE (they are
+# wall-clock service engines — a different time model; see README.md).
+#
+# Usage: bench/rsp/run.sh   (run from anywhere; honours $RSP_BIN override)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+EXP="$ROOT/bench/rsp/expected.tsv"
+# The G1 TSV-emitting runner: a sparq-rsp example (the crate is isolated — not a sparq-cli
+# dependency). Override with $RSP_BIN for a custom build.
+BIN="${RSP_BIN:-$ROOT/target/release/examples/rsp_oracle}"
+
+if [ ! -x "$BIN" ]; then
+  echo "[rsp] ERROR: rsp_oracle not found at $BIN" >&2
+  echo "[rsp]   build: cargo build --release -p sparq-rsp --example rsp_oracle" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ---- 1. run the oracle (TSV: metric value unit) -----------------------------------------
+"$BIN" > "$TMP/rsp.tsv"
+
+# ---- 2. assert the DETERMINISTIC *_rows metrics vs expected.tsv (exit 1 on any mismatch) -
+# ---- 3. forward the 3-column hook contract on STDOUT (advisory metric passes through) ----
+fail=0
+seen=0
+while IFS=$'\t' read -r metric value unit; do
+  [ -n "$metric" ] || continue
+  case "$metric" in
+    *_rows)
+      exp="$(awk -F'\t' -v k="$metric" '$1==k{print $2}' "$EXP")"
+      if [ -z "$exp" ]; then
+        echo "[rsp] ERROR: $metric has no expected.tsv entry" >&2; fail=1; continue
+      fi
+      if [ "$value" != "$exp" ]; then
+        echo "[rsp] ERROR: $metric rows=$value expected=$exp (RSP correctness regression)" >&2; fail=1
+      fi
+      seen=$((seen+1))
+      ;;
+  esac
+  # Forward EVERY metric (deterministic counts + advisory throughput) to the hook.
+  printf '%s\t%s\t%s\n' "$metric" "$value" "$unit"
+done < "$TMP/rsp.tsv"
+
+# Every expected per-window metric must have been emitted (a vanished window is a regression).
+exp_rows=$(grep -cvE '^#|^$' "$EXP")
+if [ "$seen" != "$exp_rows" ]; then
+  echo "[rsp] ERROR: emitted $seen *_rows metrics, expected $exp_rows (a window/scenario vanished)" >&2; fail=1
+fi
+
+if [ "$fail" = 0 ]; then
+  echo "[rsp] OK: all $seen per-window row counts match expected.tsv (single-window x 3 EvalModes + SRBench oracle)" >&2
+else
+  echo "[rsp] FAILED: one or more per-window row counts diverged from expected.tsv" >&2
+fi
+exit "$fail"

--- a/crates/sparq-rsp/examples/rsp_oracle.rs
+++ b/crates/sparq-rsp/examples/rsp_oracle.rs
@@ -1,0 +1,292 @@
+//! [OPUS-4.8] (sq-b1hn) RSP-QL bench RUNNER — the self-asserting TSV emitter the
+//! `bench/rsp/run.sh` per-commit gate consumes.
+//!
+//! sparq-rsp is **clock-free**: the windowed pipeline is a pure function of the
+//! pushed `(triple, ts)` sequence (see the crate docs / README). That is the
+//! design point this bench exploits: replaying a FIXED script yields a fully
+//! DETERMINISTIC per-window result, so the gate is a diff of per-window
+//! result-row counts against an expected TSV — a *stronger* correctness gate
+//! than any wall-clock RSP benchmark can offer (no timing flake, no scheduler
+//! nondeterminism). Design: research/capability-benchmark-program.md §3.6.
+//!
+//! It emits, on STDOUT, the 3-column contract `<metric>\t<count>\t<unit>` that
+//! the ci-bench `rsp` hook (and `run.sh`) harvest:
+//!
+//!   1. DETERMINISTIC per-window row-count gate (`unit = rows`). For each
+//!      scenario × `EvalMode`, one `rsp_<scenario>_<mode>_w<k>_rows` line per
+//!      closed window. run.sh asserts every one against `bench/rsp/expected.tsv`;
+//!      a divergence is an S2R/R2R/eval-mode regression and fails the run. The
+//!      3-EvalMode equivalence is implicit: Rebuild / PersistentDict / Delta each
+//!      emit their own lines and expected.tsv pins them all to the same counts.
+//!   2. SRBench correctness ORACLE (`unit = rows`): an SRBench-shaped multi-window
+//!      JOIN over two LOD-weather streams (observations ⋈ station metadata),
+//!      `rsp_srbench_<q>_w<k>_rows` per tick. This is the honest comparison
+//!      surface — the natural RSP peers (C-SPARQL / CQELS / RSP4J) are
+//!      wall-clock service engines, so a throughput head-to-head is
+//!      apples-to-oranges (different time model). Correctness/expressivity is the
+//!      meaningful axis; perf head-to-head is OUT OF SCOPE (see README).
+//!   3. ADVISORY throughput (`unit = triples_per_s`): a single
+//!      `rsp_persistentdict_triples_per_s` line — trend-only, NOT a gate (it is
+//!      machine-sensitive, and the deterministic counts above are the real gate).
+//!
+//! Run directly:  cargo run --release -p sparq-rsp --example rsp_oracle
+
+use std::time::Instant;
+
+use oxrdf::{Literal, NamedNode, Term};
+use sparq_rsp::{ContinuousMultiQuery, ContinuousQuery, EvalMode, WindowResult, WindowSpec};
+
+// ---------------------------------------------------------------- term helpers
+
+fn iri(s: &str) -> Term {
+    NamedNode::new_unchecked(format!("http://ex/{s}")).into()
+}
+
+fn nn(s: &str) -> NamedNode {
+    NamedNode::new_unchecked(format!("http://ex/{s}"))
+}
+
+/// `<http://ex/{s}> <http://ex/value> "v"^^xsd:integer`
+fn val(s: &str, v: i32) -> [Term; 3] {
+    [iri(s), iri("value"), Literal::from(v).into()]
+}
+
+/// `<http://ex/{s}> <http://ex/{p}> <http://ex/{o}>`
+fn t(s: &str, p: &str, o: &str) -> [Term; 3] {
+    [iri(s), iri(p), iri(o)]
+}
+
+// ----------------------------------------------- the FIXED single-window script
+//
+// One pinned `(triple, ts)` replay sequence shared by every single-window
+// scenario. Hand-built to exercise: a multi-sensor join+aggregate, set semantics
+// (a duplicate triple), an EMPTY window (a gap in the data), a non-zero start,
+// and boundary-internal arrivals. Because the pipeline is clock-free this is a
+// pure input → every closed window's row count is deterministic and diffable.
+fn single_window_script() -> Vec<([Term; 3], u64)> {
+    vec![
+        (t("s1", "in", "kitchen"), 0),
+        (val("s1", 20), 1),
+        (val("s1", 22), 4),
+        (t("s2", "in", "hall"), 5),
+        (val("s2", 30), 6),
+        (val("s2", 30), 8), // duplicate of the previous triple → set semantics
+        // gap: nothing in [10,20) → an EMPTY window
+        (t("s1", "in", "kitchen"), 21),
+        (val("s1", 100), 22),
+        (val("s1", 26), 28), // boundary-internal
+        (t("s3", "in", "hall"), 31),
+        (val("s3", 5), 33),
+        (val("s3", 7), 39),
+        (val("s1", 9), 41), // [40,50) (or its slide) — keeps the slide overlapping
+    ]
+}
+
+/// One single-window scenario: a label, its `WindowSpec`, and the SPARQL.
+struct Scenario {
+    label: &'static str,
+    spec: WindowSpec,
+    sparql: &'static str,
+}
+
+fn scenarios() -> Vec<Scenario> {
+    vec![
+        // Tumbling AVG: one result row per non-empty window, zero for empties.
+        Scenario {
+            label: "tumbling_avg",
+            spec: WindowSpec::time(10, 10),
+            sparql: "SELECT (AVG(?v) AS ?avg) WHERE { ?s <http://ex/value> ?v }",
+        },
+        // Sliding SUM per sensor (RANGE 20 STEP 10 → 50% overlap): one row per
+        // distinct sensor present in each (overlapping) window.
+        Scenario {
+            label: "sliding_sum",
+            spec: WindowSpec::time(20, 10),
+            sparql: "SELECT ?s (SUM(?v) AS ?sum) WHERE { ?s <http://ex/value> ?v } \
+                     GROUP BY ?s ORDER BY ?s",
+        },
+        // Tumbling GROUP BY join: room ⋈ value, one row per room with readings.
+        Scenario {
+            label: "tumbling_groupby_join",
+            spec: WindowSpec::time(20, 20),
+            sparql: "SELECT ?room (AVG(?v) AS ?avg) (COUNT(?v) AS ?n) \
+                     WHERE { ?s <http://ex/in> ?room . ?s <http://ex/value> ?v } \
+                     GROUP BY ?room ORDER BY ?room",
+        },
+    ]
+}
+
+/// Runs one scenario × one `EvalMode` over the fixed script, emitting one
+/// `rsp_<scenario>_<mode>_w<k>_rows<TAB><count><TAB>rows` line per closed window.
+fn run_single_window_gate(sc: &Scenario, mode: EvalMode, script: &[([Term; 3], u64)]) {
+    let mode_tag = match mode {
+        EvalMode::Rebuild => "rebuild",
+        EvalMode::PersistentDict => "pdict",
+        EvalMode::Delta => "delta",
+    };
+    let mut q = ContinuousQuery::register(sc.sparql, sc.spec)
+        .expect("valid query")
+        .with_mode(mode);
+    let mut k = 0u32;
+    let mut emit = |r: WindowResult| {
+        println!("rsp_{}_{}_w{}_rows\t{}\trows", sc.label, mode_tag, k, r.rows.len());
+        k += 1;
+    };
+    for (triple, ts) in script {
+        q.push(triple.clone(), *ts, &mut emit).expect("eval");
+    }
+    q.flush(&mut emit).expect("eval");
+}
+
+// ------------------------------------------------ SRBench correctness ORACLE
+//
+// SRBench (Zhang et al.) is the canonical RSP correctness/expressivity suite over
+// real Linked-Open-Data WEATHER streams: sensor OBSERVATIONS joined against
+// STATION metadata. We reproduce that SHAPE deterministically: an observations
+// stream (a value per station per tick) and a station-metadata stream (each
+// station's US state, re-announced each window the way a metadata stream emits a
+// per-window snapshot), joined per synchronized window. The point is EXPRESSIVITY
+// + CORRECTNESS (cross-window named-graph JOIN + aggregation), not speed — the
+// time model differs from a wall-clock RSP engine, so perf is out of scope.
+// Counts are deterministic, asserted in expected.tsv.
+//
+// Both windows tumble RANGE 10 STEP 10 so they close on the SAME boundaries and
+// the join is evaluated per synchronized window: at each tick the obs window and
+// the meta window each contribute their just-closed content, and the engine's
+// cross-named-graph join binds `?st` between them.
+
+/// A fixed SRBench-shaped script: `(stream, triple, ts)`. Stream `obs` carries
+/// `<station> <value> v`; stream `meta` carries `<station> <state> <usstate>`,
+/// re-announced inside each observation window so the join has metadata to bind.
+fn srbench_script() -> Vec<(NamedNode, [Term; 3], u64)> {
+    let obs = nn("obs");
+    let meta = nn("meta");
+    let mut s: Vec<(NamedNode, [Term; 3], u64)> = Vec::new();
+    // Two stations in NY, one in CA. Metadata snapshot re-announced each window
+    // (a metadata stream emits the current registry per window).
+    let announce_meta = |s: &mut Vec<(NamedNode, [Term; 3], u64)>, base: u64| {
+        s.push((meta.clone(), t("stA", "state", "NY"), base));
+        s.push((meta.clone(), t("stB", "state", "NY"), base));
+        s.push((meta.clone(), t("stC", "state", "CA"), base));
+    };
+    // --- Window 0 = [0,10): A, B, C each report → join yields all three.
+    announce_meta(&mut s, 0);
+    s.push((obs.clone(), val("stA", 12), 1));
+    s.push((obs.clone(), val("stB", 15), 3));
+    s.push((obs.clone(), val("stC", 20), 7));
+    // --- Window 1 = [10,20): only A and C report (B silent) → two joined rows.
+    announce_meta(&mut s, 10);
+    s.push((obs.clone(), val("stA", 11), 12));
+    s.push((obs.clone(), val("stC", 25), 18));
+    // --- Window 2 = [20,30): A reports twice (set semantics on equal triples) +
+    // an UNKNOWN station stZ with NO metadata → it must NOT join (inner join).
+    announce_meta(&mut s, 20);
+    s.push((obs.clone(), val("stA", 9), 21));
+    s.push((obs.clone(), val("stA", 9), 22)); // duplicate value-triple
+    s.push((obs.clone(), val("stZ", 99), 24)); // no metadata for stZ → unjoined
+    s.push((obs.clone(), val("stC", 30), 28));
+    // A heartbeat on obs at ts 35 closes window 2.
+    s.push((obs.clone(), val("stA", 1), 35));
+    s
+}
+
+/// One SRBench query: a label and its RSP-QL multi-window text.
+struct SrbenchQuery {
+    label: &'static str,
+    rspql: &'static str,
+}
+
+fn srbench_queries() -> Vec<SrbenchQuery> {
+    vec![
+        // Q1 (SRBench-style join): every observation joined to its station's
+        // state — the canonical "annotate the stream from the static graph"
+        // pattern. One row per joined observation per window.
+        SrbenchQuery {
+            label: "join",
+            rspql: "\
+REGISTER STREAM <http://ex/out> AS
+SELECT ?st ?state ?v WHERE {
+  WINDOW <http://ex/wo> { ?st <http://ex/value> ?v }
+  WINDOW <http://ex/wm> { ?st <http://ex/state> ?state }
+}
+FROM NAMED WINDOW <http://ex/wo> ON <http://ex/obs> RANGE 10 STEP 10
+FROM NAMED WINDOW <http://ex/wm> ON <http://ex/meta> RANGE 10 STEP 10",
+        },
+        // Q2 (SRBench-style aggregate-after-join): readings per US state per
+        // window — the join feeds a GROUP BY. One row per distinct joined state.
+        SrbenchQuery {
+            label: "groupby_state",
+            rspql: "\
+REGISTER STREAM <http://ex/out> AS
+SELECT ?state (COUNT(?v) AS ?n) WHERE {
+  WINDOW <http://ex/wo> { ?st <http://ex/value> ?v }
+  WINDOW <http://ex/wm> { ?st <http://ex/state> ?state }
+}
+GROUP BY ?state ORDER BY ?state
+FROM NAMED WINDOW <http://ex/wo> ON <http://ex/obs> RANGE 10 STEP 10
+FROM NAMED WINDOW <http://ex/wm> ON <http://ex/meta> RANGE 10 STEP 10",
+        },
+    ]
+}
+
+/// Runs one SRBench query over the fixed script, emitting one
+/// `rsp_srbench_<q>_w<k>_rows` line per join evaluation tick.
+fn run_srbench_oracle(sq: &SrbenchQuery, script: &[(NamedNode, [Term; 3], u64)]) {
+    let mut q = ContinuousMultiQuery::register(sq.rspql).expect("valid RSP-QL");
+    let mut k = 0u32;
+    let mut emit = |r: WindowResult| {
+        println!("rsp_srbench_{}_w{}_rows\t{}\trows", sq.label, k, r.rows.len());
+        k += 1;
+    };
+    for (stream, triple, ts) in script {
+        q.push(stream, triple.clone(), *ts, &mut emit).expect("eval");
+    }
+    q.flush(&mut emit).expect("eval");
+}
+
+// ----------------------------------------------------- ADVISORY throughput
+//
+// Trend-only `rsp_persistentdict_triples_per_s` — NOT a gate (machine-sensitive).
+// The deterministic per-window counts above are the gate.
+
+const N_THROUGHPUT_TRIPLES: u64 = 200_000;
+const N_SENSORS: u64 = 100;
+
+fn run_throughput() {
+    let sparql = "SELECT (AVG(?v) AS ?avg) WHERE { ?s <http://ex/value> ?v }";
+    let mut q = ContinuousQuery::register(sparql, WindowSpec::time(1_000, 1_000))
+        .expect("valid query")
+        .with_mode(EvalMode::PersistentDict);
+    let start = Instant::now();
+    for ts in 0..N_THROUGHPUT_TRIPLES {
+        let s = format!("sensor/{}", ts % N_SENSORS);
+        q.push(val(&s, (ts % 50) as i32), ts, |_| {}).expect("eval");
+    }
+    q.flush(|_| {}).expect("eval");
+    let dt = start.elapsed().as_secs_f64();
+    let tps = if dt > 0.0 {
+        (N_THROUGHPUT_TRIPLES as f64 / dt).round() as u64
+    } else {
+        0
+    };
+    println!("rsp_persistentdict_triples_per_s\t{tps}\ttriples_per_s");
+}
+
+fn main() {
+    // 1. DETERMINISTIC per-window row-count gate: every scenario × every EvalMode.
+    let script = single_window_script();
+    for sc in scenarios() {
+        for mode in [EvalMode::Rebuild, EvalMode::PersistentDict, EvalMode::Delta] {
+            run_single_window_gate(&sc, mode, &script);
+        }
+    }
+
+    // 2. SRBench correctness oracle (the EYE role; correctness/expressivity only).
+    let sr_script = srbench_script();
+    for sq in srbench_queries() {
+        run_srbench_oracle(&sq, &sr_script);
+    }
+
+    // 3. ADVISORY throughput (trend-only).
+    run_throughput();
+}

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -145,6 +145,17 @@ VECTOR_RUN=bench/vector/run.sh
 # DEFICIT geo_compliance_deficit (mode:auto in bench/perf-baseline.json). Registry:
 # bench/benchmarks.toml (geo-bench); details: bench/geo/README.md.
 GEO_RUN=bench/geo/run.sh
+# [OPUS-4.8] RSP-QL streaming suite (sq-b1hn, design §3.6). sparq-rsp is a CLOCK-FREE library, so a
+# fixed (triple,ts) replay is a pure function — the gate is a DETERMINISTIC per-window result-row
+# count (single-window tumbling/sliding/GROUP-BY x three EvalModes, encoding the 3-EvalMode
+# equivalence) + an SRBench correctness ORACLE (multi-window observation⋈metadata join). Like FTS
+# the runner is a crate EXAMPLE (sparq-rsp is isolated, not a sparq-cli dependency). run.sh is the
+# self-asserting entry point: it asserts every `rsp_*_rows` metric vs bench/rsp/expected.tsv (exit 1
+# on drift) and prints the `<metric>\t<value>\t<unit>` contract; the rows are the HARD gate (in
+# run.sh), the single rsp_persistentdict_triples_per_s is ADVISORY (trend-only, NOT in
+# scripts/perf-gate.py). NO competitor perf column — the RSP peers are wall-clock service engines
+# (apples-to-oranges). Registry: bench/benchmarks.toml (rsp-ql); details: bench/rsp/README.md.
+RSP_RUN=bench/rsp/run.sh
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 RES="$TMP/res.tsv"; : > "$RES"
 add() { printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$RES"; }
@@ -685,6 +696,43 @@ elif command -v cargo >/dev/null 2>&1 && [ -x "$VECTOR_RUN" ]; then
   fi
 else
   echo "note: vector skipped (cargo not on PATH or $VECTOR_RUN missing)" >&2
+fi
+
+# [OPUS-4.8] RSP-QL streaming per-commit hook (sq-b1hn). Like FTS/vector the runner is a crate
+# EXAMPLE (rsp_oracle) that only needs `cargo`, so to match the main-only-toolchain skip the
+# LUBM/SHACL hooks get for free — and keep the example build off per-PR CI — we PIN this hook to the
+# MAIN/local tier: it runs on push-to-main (GITHUB_REF=refs/heads/main) and on a LOCAL run
+# (GITHUB_REF unset, so devs/bench/rsp/run.sh still work), but is SKIPPED on the PR tier. The
+# DETERMINISTIC per-window row-count gate therefore runs once per merge to main. run.sh asserts every
+# `rsp_*_rows` vs expected.tsv internally (exit 1 on drift), failing the whole ci-bench run on a
+# regression exactly like LUBM/FTS. We harvest run.sh's `<metric>\t<value>\t<unit>` stdout:
+# `*_rows` are DETERMINISTIC per-window counts (emitted for the dashboard's RSP-QL card; correctness
+# is the run.sh internal gate, so these are trend rows not perf-gate ratchets), and the single
+# `rsp_persistentdict_triples_per_s` is ADVISORY throughput (trend-only, NOT in scripts/perf-gate.py).
+RSP_BIN=target/release/examples/rsp_oracle
+RSP_REF="${GITHUB_REF:-}"
+if [ -n "$RSP_REF" ] && [ "$RSP_REF" != "refs/heads/main" ]; then
+  echo "note: rsp skipped (PR tier — RSP-QL example build/run is main-only, like the javac/rapper suites)" >&2
+elif command -v cargo >/dev/null 2>&1 && [ -x "$RSP_RUN" ]; then
+  # Always (re)build: rust-cache restores target/, so a file-exists check can run a STALE binary.
+  if ! cargo build --release -q -p sparq-rsp --example rsp_oracle; then
+    echo "ERROR: rsp_oracle example failed to build" >&2
+    exit 1
+  fi
+  if RSP_BIN="$RSP_BIN" bash "$RSP_RUN" > "$TMP/rsp.tsv" 2>"$TMP/rsp.err"; then
+    while IFS=$'\t' read -r metric value unit; do
+      [ -n "${metric:-}" ] && [ -n "${value:-}" ] || continue
+      # DETERMINISTIC per-window counts + the advisory throughput: forward the metric verbatim
+      # (run.sh has already asserted the *_rows correctness gate, so these are trend rows).
+      add "$metric" "${unit:-rows}" "$value"
+    done < "$TMP/rsp.tsv"
+  else
+    echo "ERROR: rsp run.sh failed (per-window row-count regression)" >&2
+    cat "$TMP/rsp.err" >&2 || true
+    exit 1
+  fi
+else
+  echo "note: rsp skipped (cargo not on PATH or $RSP_RUN missing)" >&2
 fi
 
 # [OPUS-4.8] ZERO-KNOWLEDGE family (sq dashboard-data-feed) — feeds the dashboard's


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. I am one of several agents @jeswr runs on this account.

Implements **sq-b1hn** (design `research/capability-benchmark-program.md` §3.6): the RSP-QL streaming **capability suite** under `bench/rsp/`.

## Why this shape (honest)
`sparq-rsp` is a **clock-free library** — a window closes on the pushed-timestamp watermark, not a real clock — so the windowed pipeline is a **pure function of the pushed `(triple, ts)` sequence**. The natural RSP peers (C-SPARQL / CQELS / RSP4J + SRBench/CityBench/LSBench/RSPLab) are **wall-clock service engines**: any throughput head-to-head is **apples-to-oranges (different time model)**. So this suite has **no competitor perf column** — perf comparison is explicitly **out of scope**. The honest comparison surface is **correctness/expressivity** (the SRBench oracle, the EYE role).

## What it adds
- **`crates/sparq-rsp/examples/rsp_oracle.rs`** — the TSV-emitting runner (a crate example, like FTS's `bench_text`; `sparq-rsp` is isolated, not a `sparq-cli` dependency). It emits:
  1. **Deterministic per-window row-count gate** — `rsp_<scenario>_<mode>_w<k>_rows` over a fixed replay script, for three single-window scenarios (tumbling AVG / sliding SUM / tumbling GROUP-BY join) × **three EvalModes** (Rebuild / PersistentDict / Delta). The identical expected counts also encode the **three-EvalMode-equivalence** assert.
  2. **SRBench correctness ORACLE** — `rsp_srbench_<q>_w<k>_rows`: a multi-window **observation ⋈ station-metadata** join (LOD-weather shape), exercising the inner-join drop of an unjoinable station and set semantics.
  3. **Advisory throughput** — a single `rsp_persistentdict_triples_per_s` (trend-only, **NOT** gated; machine-sensitive).
- **`bench/rsp/{run.sh,expected.tsv,README.md}`** — the self-asserting runner (exit 1 on any per-window count drift, like LUBM/FTS), the deterministic gate, and docs.
- Registered in `bench/benchmarks.toml` (`rsp-ql`), featured an **RSP-QL** dashboard row, added the `bench/CATALOG.md` entry + run command, and wired the **main-tier** `ci-bench` `rsp` hook.

This complements the existing differential streamed-equals-batch oracle in `crates/sparq-rsp/tests/window_oracle.rs` (which proves each window equals the batch query over its tuples); the bench pins the *shape* of a fixed replay so a regression alerts on the dashboard. It is a **stronger** gate than any wall-clock RSP benchmark (no timing flake, no scheduler nondeterminism).

## Gate (all green locally)
- `cargo build` + `clippy --all-targets -- -D warnings` + `cargo test -p sparq-rsp` (default **and** `--no-default-features`) — pass.
- `bench/rsp/run.sh` — green (47 per-window counts asserted) + a **negative test** (a tampered `expected.tsv` fails the run, then restored).
- **G3 new-bench → registry+dashboard** gate — PASS (against `origin/main`); its 24 unit tests pass.
- **privacy-claims** gate — OK (no ZK/MPC claims in a streaming-correctness suite).
- No public API changed → **G2** N/A.

> Note: the local `rustfmt` (1.9.0) disagrees with the workspace's CI rustfmt — it flags `origin/main`'s own unchanged `sparq-rsp` files. The new example follows the established compact style of the sibling `examples/throughput.rs` (all lines ≤ 100 cols); CI's `fmt` is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)