### PR TITLE
docs(security): FIPS/CMVP posture cross-ref in SECURITY.md (sq-d7kh) [OPUS-4.8]

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -133,6 +133,23 @@ The opt-in capability crates (`sparq-geo`, `sparq-text`, `sparq-vectors`, `sparq
 security boundaries. As with the whole engine at this stage, run untrusted input through
 `sparq` only inside your own sandboxing/resource limits.
 
+<!-- [OPUS-4.8] sq-d7kh / CR-G4 (epic sq-toze) — FIPS posture cross-ref into the
+     governance-owned SECURITY.md, mirroring how the ZK posture cross-ref was handled.
+     Honest negative only: NO FIPS 140-3/CMVP module, NO FIPS claim, NO CMVP claim.
+     Authored by Opus 4.8 while Fable 5 unavailable — re-review when Fable returns. -->
+### FIPS / CMVP posture — no validated module, no claim
+
+`sparq` incorporates **no FIPS 140-2 / 140-3 (CMVP-validated) cryptographic module** and
+makes **no FIPS claim and no CMVP claim**. Its bespoke, research-only ZK/MPC cryptography is
+deliberately built on ZK-friendly, **non-FIPS-approved** primitives (BN254, Poseidon2,
+Schnorr over Baby-JubJub) and must be treated as **out of FIPS scope**; computing a
+FIPS 180-4 algorithm such as the SHA-256 release digests is *not* the same as running it
+inside a validated module. An operator under a FIPS deployment constraint must supply their
+own FIPS-validated module. This is an honest negative posture, not a deficiency to be
+remediated into a positive claim within this project. The full statement — the per-primitive
+breakdown and FIPS-constrained-operator guidance — lives in
+[`compliance/cryptoreview/fips-posture.md`](./compliance/cryptoreview/fips-posture.md) (CR-G4).
+
 ## Hardened-input expectations for the core engine
 
 The parser, query engine, and HTTP server (`sparq-core`, `sparq-engine`, `sparq-server`)

--- a/compliance/cryptoreview/fips-posture.md
+++ b/compliance/cryptoreview/fips-posture.md
@@ -129,10 +129,11 @@ If your deployment is subject to a FIPS 140-2 / 140-3 requirement:
 - It is **not** a FIPS claim, a CMVP claim, or a statement of FIPS-readiness.
 - It is **not** a soundness assertion about the Tier-B crypto (that is `CR-G1`,
   external, open; and `SECURITY.md` is the published posture).
-- It does **not** override `SECURITY.md`. `SECURITY.md` is governance-owned; a
-  cross-reference to this FIPS posture from `SECURITY.md` is deferred to its own
-  bead (mirroring how the SECURITY.md cross-ref for the ZK posture was handled),
-  not made here.
+- It does **not** override `SECURITY.md`. `SECURITY.md` is governance-owned; the
+  one-line FIPS cross-ref into `SECURITY.md` (§"FIPS / CMVP posture — no validated
+  module, no claim") landed under its own bead `sq-d7kh` (mirroring how the SECURITY.md
+  cross-ref for the ZK posture was handled), pointing back at this document as the full
+  statement. <!-- [OPUS-4.8] sq-d7kh: deferral now resolved; reference is bidirectional. -->
 
 ## 7. Disposition
 


### PR DESCRIPTION
> 🤖 SPARQ agent — automated change. @jeswr runs several agents on this account; this PR is from one of them. Please review before arming.

## What

Implements bead **sq-d7kh** (CR-G4, epic sq-toze): add a one-line **FIPS / CMVP posture cross-ref** to the governance-owned `SECURITY.md`, mirroring how the ZK posture cross-ref was handled (sq-zbb5).

The FIPS posture statement already lives at `compliance/cryptoreview/fips-posture.md` (landed in sq-cu32); `SECURITY.md` was deliberately left untouched there because it is governance-owned. This PR surfaces the FIPS scope from the *canonical published posture* doc.

## Changes (docs-only, 2 files)

- **`SECURITY.md`** — new `### FIPS / CMVP posture — no validated module, no claim` subsection in the crypto-scope section. **Honest negative only:** states **no FIPS 140-2/140-3 (CMVP-validated) module, no FIPS claim, no CMVP claim**; the bespoke ZK/MPC crypto (BN254, Poseidon2, Schnorr over Baby-JubJub) is **out of FIPS scope**; computing a FIPS 180-4 algorithm (the SHA-256 release digests) is *not* the same as running it inside a validated module; an operator under a FIPS constraint must supply their own validated module. Links to the full statement at `compliance/cryptoreview/fips-posture.md`.
- **`compliance/cryptoreview/fips-posture.md`** — §6's deferral note (which said the SECURITY.md cross-ref was "deferred to its own bead") is updated to record that the cross-ref **landed under sq-d7kh**, making the reference **bidirectional** and keeping docs current.

**No positive FIPS/CMVP claim is introduced anywhere.** No public API touched → G2 SKILL.md rule N/A.

## Governance sign-off (action for reviewer)

The bead notes: *"`SECURITY.md` is governance-owned. Governance sign-off required before editing `SECURITY.md`."* I am opening this PR rather than merging; **please confirm governance sign-off on the SECURITY.md wording before this is armed.** No FIPS/CMVP claim is made — this is an honest negative cross-ref only.

## Gate

Docs-only; the relevant doc lints were run in-worktree, all green:
- `scripts/check-privacy-claims.sh` — OK (no unqualified ZK/MPC privacy/soundness claim; predicate-form soundness pattern included).
- `markdownlint-cli2@0.18.1` (repo HARD config) — 0 errors.
- `lychee --offline` — 10/10 links OK, 0 errors (both new relative links + the cross-ref anchor resolve).
- `typos` — clean.

Closes bead sq-d7kh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
