### PR TITLE
test(sparq-shacl): mirror pyshacl sh:detail exclusion in Jena diff-fuzz adapter (sq-vsqr)

### DIFF
--- a/crates/sparq-shacl/tests/diff_fuzz.rs
+++ b/crates/sparq-shacl/tests/diff_fuzz.rs
@@ -717,6 +717,40 @@ fn jena_classpath_gating() {
     );
 }
 
+/// [OPUS-4.8] (sq-vsqr) The Jena adapter must mirror the pySHACL adapter's sq-0hj7
+/// `sh:detail` exclusion: a nested sub-result that is the object of an `sh:detail`
+/// must NOT appear as a top-level violation (it lives in `ValidationResult::details`
+/// in sparq, and `sh:detail` is non-normative per SHACL §3.6.2 — diffing it would
+/// be a latent over-report, not a real disagreement). The adapter ships a
+/// `--selftest` mode that asserts this on a synthetic report graph (no validator
+/// run, so it is independent of whether THIS Jena build emits `sh:detail`); we drive
+/// it here. SKIPPED cleanly when Java + a Jena classpath don't resolve (the
+/// pySHACL-only / no-Jena lanes are unaffected) — exactly the diff-fuzz gating.
+#[test]
+fn jena_adapter_excludes_nested_sh_detail() {
+    let Some(engine) = resolve_jena() else {
+        eprintln!("SKIP jena_adapter_excludes_nested_sh_detail: Jena did not resolve");
+        return;
+    };
+    // engine.args is `[-cp, <classpath>, <adapter>.java]`; append `--selftest` so the
+    // single-file source launcher runs the adapter in self-test mode.
+    let mut args = engine.args.clone();
+    args.push("--selftest".to_string());
+    let out = Command::new(&engine.program)
+        .args(&args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn Jena adapter --selftest");
+    assert!(
+        out.status.success(),
+        "Jena adapter --selftest failed (exit {:?}) — the sh:detail exclusion \
+         regressed (nested sub-result leaked into the top-level violation set):\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr).trim()
+    );
+}
+
 // ---------------------------------------------------------------------------
 // [OPUS-4.8] (sq-0hj7) Guards for the extended generator: logical components,
 // sh:node nested-shape refs, and complex SHAPE paths. These run in the per-PR

--- a/crates/sparq-shacl/tests/diff_fuzz/JenaShaclAdapter.java
+++ b/crates/sparq-shacl/tests/diff_fuzz/JenaShaclAdapter.java
@@ -46,6 +46,14 @@ public final class JenaShaclAdapter {
     static final String SH = "http://www.w3.org/ns/shacl#";
 
     public static void main(String[] args) {
+        // [OPUS-4.8] (sq-vsqr) `--selftest` exercises the sh:detail exclusion on a
+        // synthetic report graph (no validator run): proves a nested sub-result that
+        // is the object of an sh:detail is dropped from the top-level violation set,
+        // independent of whether THIS Jena build emits sh:detail. Exit 0 on pass,
+        // non-zero with a diagnostic on fail. See selfTest().
+        if (args.length == 1 && "--selftest".equals(args[0])) {
+            System.exit(selfTest() ? 0 : 3);
+        }
         try {
             byte[] in = System.in.readAllBytes();
             String req = new String(in, StandardCharsets.UTF_8);
@@ -59,7 +67,7 @@ public final class JenaShaclAdapter {
 
             Shapes sh = Shapes.parse(shapesG);
             ValidationReport report = ShaclValidator.get().validate(sh, dataG);
-            System.out.print(normalise(report));
+            System.out.print(normaliseGraph(report.getGraph(), report.conforms()));
             System.out.print("\n");
             System.exit(0);
         } catch (Throwable t) {
@@ -68,21 +76,79 @@ public final class JenaShaclAdapter {
         }
     }
 
-    static String normalise(ValidationReport report) {
-        Graph g = report.getGraph();
+    // [OPUS-4.8] (sq-vsqr) Build a report graph with ONE top-level result and ONE
+    // nested sh:detail sub-result, then assert normaliseGraph emits exactly the
+    // top-level violation (the detail is excluded). A regression that dropped the
+    // exclusion would surface the nested sub-result as a second violation here.
+    static boolean selfTest() {
+        Graph g = GraphFactory.createDefaultGraph();
+        Node top = org.apache.jena.graph.NodeFactory.createBlankNode("top");
+        Node inner = org.apache.jena.graph.NodeFactory.createBlankNode("inner");
+        Node resultT = NodeFactoryUri(SH + "ValidationResult");
+        Node focusOuter = NodeFactoryUri("http://ex/focus");
+        Node focusInner = NodeFactoryUri("http://ex/value");
+        Node compOuter = NodeFactoryUri(SH + "NodeConstraintComponent");
+        Node compInner = NodeFactoryUri(SH + "MinLengthConstraintComponent");
+        Node pathOuter = NodeFactoryUri("http://ex/p");
+        // Outer (top-level) result, carrying a nested sh:detail to the inner result.
+        g.add(Triple.create(top, RDF.type.asNode(), resultT));
+        g.add(Triple.create(top, NodeFactoryUri(SH + "focusNode"), focusOuter));
+        g.add(Triple.create(top, NodeFactoryUri(SH + "sourceConstraintComponent"), compOuter));
+        g.add(Triple.create(top, NodeFactoryUri(SH + "resultPath"), pathOuter));
+        g.add(Triple.create(top, NodeFactoryUri(SH + "detail"), inner));
+        // Inner (nested) result — must be EXCLUDED from the top-level set.
+        g.add(Triple.create(inner, RDF.type.asNode(), resultT));
+        g.add(Triple.create(inner, NodeFactoryUri(SH + "focusNode"), focusInner));
+        g.add(Triple.create(inner, NodeFactoryUri(SH + "sourceConstraintComponent"), compInner));
+
+        String got = normaliseGraph(g, false);
+        String want = "{\"conforms\":false,\"violations\":["
+            + "{\"focus\":\"http://ex/focus\","
+            + "\"component\":\"http://www.w3.org/ns/shacl#NodeConstraintComponent\","
+            + "\"path\":\"http://ex/p\"}]}";
+        if (!want.equals(got)) {
+            System.err.println("jena_shacl_adapter selftest FAIL: sh:detail exclusion");
+            System.err.println("  want: " + want);
+            System.err.println("  got:  " + got);
+            return false;
+        }
+        return true;
+    }
+
+    static String normaliseGraph(Graph g, boolean conforms) {
         Node pFocus = NodeFactoryUri(SH + "focusNode");
         Node pComp = NodeFactoryUri(SH + "sourceConstraintComponent");
         Node pPath = NodeFactoryUri(SH + "resultPath");
+        Node pDetail = NodeFactoryUri(SH + "detail");
         Node resultT = NodeFactoryUri(SH + "ValidationResult");
 
+        // [OPUS-4.8] (sq-vsqr) Collect only TOP-LEVEL results — mirror of the
+        // pySHACL adapter's sq-0hj7 exclusion. For sh:node / logical components a
+        // reference engine emits an outer result (against the value node, carrying
+        // sh:resultPath) AND an OPTIONAL nested `sh:detail` sub-result for the inner
+        // constraint that failed. `sh:detail` is non-normative (SHACL §3.6.2 "MAY"),
+        // and sparq-shacl keeps inner results off the comparable top-level `results`
+        // list (they live in `ValidationResult::details`). Diffing the nested
+        // sub-results would compare two engines' OPTIONAL detail policies, not a real
+        // disagreement (a latent over-report) — so we exclude any result that is the
+        // object of an sh:detail.
+        java.util.Set<Node> nested = new java.util.HashSet<>();
+        var di = g.find(Node.ANY, pDetail, Node.ANY);
+        while (di.hasNext()) {
+            nested.add(di.next().getObject());
+        }
+
         StringBuilder sb = new StringBuilder();
-        sb.append("{\"conforms\":").append(report.conforms() ? "true" : "false");
+        sb.append("{\"conforms\":").append(conforms ? "true" : "false");
         sb.append(",\"violations\":[");
         boolean first = true;
         var it = g.find(Node.ANY, RDF.type.asNode(), resultT);
         while (it.hasNext()) {
             Triple t = it.next();
             Node res = t.getSubject();
+            if (nested.contains(res)) {
+                continue;
+            }
             Node focus = objectOf(g, res, pFocus);
             Node comp = objectOf(g, res, pComp);
             Node path = objectOf(g, res, pPath);


### PR DESCRIPTION
> 🤖 SPARQ agent — automated change. @jeswr runs several agents on this account; this PR is from the SPARQ agent working bead **sq-vsqr**.

## What

The Apache Jena SHACL reference adapter (`tests/diff_fuzz/JenaShaclAdapter.java`, sq-evws) iterated **every** `sh:ValidationResult` in the report graph — including any nested sub-result that is the object of an `sh:detail`. The pySHACL adapter (sq-0hj7) already excludes those. This mirrors that exclusion in the Jena adapter so both references emit the **same engine-agnostic top-level violation set**.

`sh:detail` is non-normative (SHACL §3.6.2 "MAY"), and sparq-shacl keeps inner results off the comparable top-level `results` list (they live in `ValidationResult::details`). Diffing the nested sub-results would compare two engines' *optional* detail policies, not a real disagreement — a **latent over-report**.

## How

- `JenaShaclAdapter.java`: collect the set of nodes that are objects of `sh:detail`; skip any `ValidationResult` in that set. Production `normalise(report)` refactored to `normaliseGraph(Graph, conforms)` so the exclusion is testable on a synthetic graph (no behaviour change on the validator path).
- New `--selftest` adapter mode: builds a report graph with one top-level result + one nested `sh:detail` sub-result and asserts only the top-level violation is emitted.
- New gated Rust test `jena_adapter_excludes_nested_sh_detail`: drives `--selftest` when Java + a Jena classpath resolve; SKIPPED cleanly otherwise (the pySHACL-only / no-Jena lanes are unaffected — same gating as the rest of diff-fuzz).
- Mutation-checked: removing the `continue` makes the self-test fail (the inner `MinLengthConstraintComponent` leaks as a second violation).

## Honest scope

Apache Jena **5.2.0** (the pinned reference) never writes `sh:detail` into its report graph — `ReportEntry.generate(...)` has no `sh:detail` triple, confirmed against `jena-shacl-5.2.0` sources. So against today's pinned Jena this exclusion does **not yet fire**. This change is **defensive parity** with the pySHACL contract for a future Jena version (or a different engine wired to the same `report-cli` contract) that *does* emit `sh:detail` — exactly the "latent over-report risk" the bead names. The `--selftest` proves the exclusion logic regardless of the live engine's detail policy, so it is a genuine regression guard rather than a no-op.

## Gate

- `cargo build -p sparq-shacl --tests` — green
- `cargo clippy -p sparq-shacl --all-targets -- -D warnings` — clean in **both** feature states (default, `shacl-af`)
- `cargo test -p sparq-shacl --test diff_fuzz` — green in both feature states, with Jena resolved (self-test runs) **and** the no-Jena SKIP path
- 40-seed live diff-fuzz vs Jena: `agree=40 mismatch=0`
- `javac` clean against the Jena classpath; `rustfmt --check` clean on the edited file
- No `src/` / public-API change (G2 N/A); no privacy/ZK/MPC claims introduced (privacy-claims gate N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)