### PR TITLE
bench(hdt): HDT load-and-decode suite — count gate + load_s/ratio advisory + hdt-cpp competitor (sq-lrp9)

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -60,7 +60,7 @@ conventions first, then a per-category map that points at the registry, then a
 |---|---|---|
 | **query** | engine compute + differential correctness; aux-index harnesses; well-known suites | `sparq-bench-compare`, `sparq-bench-fuzz`, `sparq-bench-diff`, `cli-bench-suite`, `cli-bench-mmap`, `operator-coverage`, `sp2b`, `dbpsb`, `watdiv`, `bsbm`, `lubm`, `shacl-validate-bench`, `geo-bench`, `selective-bindjoin`, `u64-valueids`, `qlever-olympics`, `qlever-synthetic-10m`, `qlever-synthetic-100m`, `text-index-bench`, `vector-ann-bench`, `geo-index-bench`, `rsp-throughput`, `rsp-ql`, `vectors-throughput`, `gpu-bench`, `sim-olympics-eval`, `introspect-olympics` |
 | **parse** | text-format parse throughput (MB/s) | `parse-baseline` |
-| **ingest** | load + dict + external-memory build throughput | `cli-ingest`, `cli-save-build`, `cli-bench-remap`, `hdt-load-bench`, `hdt-stage-split`, `wikidata-8b` |
+| **ingest** | load + dict + external-memory build throughput | `cli-ingest`, `cli-save-build`, `cli-bench-remap`, `hdt-load-bench`, `hdt-stage-split`, `hdt-suite`, `wikidata-8b` |
 | **compression** | index / result-serialization footprint tradeoffs | `cli-probe-compress`, `cli-compare-compress`, `compress-bench` |
 | **scaling** | parallel thread sweep + cross-commit/hardware tracking | `cli-scaling`, `ci-bench`, `ci-bench-ec2`, `hw-bench` |
 | **inference** | N3 / RDFS / OWL closure + incremental maintenance | `inference-eye-comparison`, `inference-owl-bench`, `inference-incremental`, `deep-taxonomy`, `owl-sameas`, `solid-wac-bench` |
@@ -155,6 +155,25 @@ Notes on a few that need care:
   Competitor honesty: **Solr/ES are NOT SPARQL competitors and stay off the dashboard**; the
   surface peer is Fuseki + `jena-text` (`http-sparql`), the kernel ref is Lucene/Anserini (labelled
   *sub-component, not an RDF benchmark*).
+- **`hdt-suite` is the HDT LOAD-AND-DECODE suite** — see [`bench/hdt/README.md`](./hdt/README.md).
+  It exercises `sparq-hdt` loading the **vendored real-world `snikmeta.hdt`** (a hdt-cpp/java-shaped
+  FourSectDict+BitmapTriples archive, 328 triples) straight into a native sparq `Graph`. Like
+  FTS/RSP the runner is a crate **example** (`bench_oracle` — `sparq-hdt` is isolated, not a
+  `sparq-cli` dependency, and is behind the `hdt` cargo feature). `run.sh` is self-asserting: it
+  gates the **load-and-decode counts** (`snikmeta_triples` / `snikmeta_terms`), **triple-pattern
+  resolution** over the decoded graph (`snikmeta_distinct_predicates` / `snikmeta_rdf_type_triples`)
+  and the **id-translation oracle** (`snikmeta_direct_eq_upstream` = direct decoder vs the
+  upstream-backed `Hdt::read` path on the same bytes) vs `expected.tsv` (exit 1 on drift),
+  complementing the differential + rejection oracles in `crates/sparq-hdt/tests/roundtrip.rs`. CI
+  emits `hdt_load_s` (advisory wall-clock) + `hdt_vs_ntgz_load_s` (an advisory **ratio** — survives
+  box contention; trend-only). **CRITICAL honest caveat:** load-and-decode-to-native is the **ONLY**
+  like-for-like axis vs **hdt-cpp / hdt-java** — `sparq-hdt` decodes HDT into sparq's own
+  `Dict`/`Graph` then queries its **own** indexes, whereas hdt-cpp/java query the compressed
+  BitmapTriples **in place**; so a **query-over-HDT head-to-head is NOT like-for-like and is OUT OF
+  SCOPE**. The `hdt-cpp` competitor (`bench/competitors.json`) is **decode-only**, gather-only via
+  docker (zero recurring CI cost). The write-side **bytes-on-disk** gate is deferred until the
+  in-memory PFC+BitmapTriples encoder (`sq-ashy`) is the production write path (encode-perf parity
+  is a non-goal today).
 - **`vector-ann-bench` is the VECTOR / ANN suite** — see
   [`bench/vector/README.md`](./vector/README.md). It exercises `sparq-vectors` (mmap'd `.spqv`
   vector store + HNSW / Vamana / PQ ANN) over a **synthetic** corpus generated **in-process** (no

--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -644,6 +644,29 @@ pinning     = "dataset slice size; mimalloc + fat LTO build to match shipped ing
 records_to  = "stdout (canonical runner); not baked into docs/tests"
 status      = "ok"
 
+# [OPUS-4.8] sq-lrp9 — the HDT capability suite: a DETERMINISTIC LOAD-AND-DECODE
+# count gate (triples/terms/distinct-predicates/rdf:type-resolution of the vendored
+# real-world snikmeta.hdt + a direct-vs-upstream id-translation oracle) + advisory
+# load timing (hdt_load_s + the contention-robust hdt_vs_ntgz_load_s RATIO).
+# Design: research/capability-benchmark-program.md §3.7. CRITICAL honest caveat:
+# load-and-decode-to-native is the ONLY like-for-like axis vs hdt-cpp/java —
+# sparq-hdt decodes HDT into sparq's own Dict/Graph then queries its own indexes,
+# whereas hdt-cpp/java query the compressed BitmapTriples in place — so a
+# "query over HDT" head-to-head is NOT like-for-like and is OUT OF SCOPE. The
+# hdt-cpp competitor (bench/competitors.json) is decode-only, gather-only via docker.
+[[benchmark]]
+id          = "hdt-suite"
+name        = "HDT load-and-decode (count gate + direct==upstream oracle)"
+category    = "ingest"
+measures    = "DETERMINISTIC load-and-decode counts on the vendored snikmeta.hdt — stored triples (328) / distinct dictionary terms / distinct predicates + rdf:type triple-pattern resolution over the decoded graph + the direct-vs-upstream id-translation oracle (all unit count, the HARD gate); advisory hdt_load_s + hdt_vs_ntgz_load_s ratio (trend-only, NOT gated)"
+invoke      = "cargo build --release -p sparq-hdt --example bench_oracle && bench/hdt/run.sh"
+source      = "bench/hdt/run.sh; crates/sparq-hdt/examples/bench_oracle.rs; gate bench/hdt/expected.tsv"
+dataset     = "vendored real-world snikmeta.hdt (crates/sparq-hdt/tests/fixtures; hdt-cpp/java-shaped, 328 triples) for the gate; deterministic ~250k-triple synthetic archive (HDT_BENCH_N) for the advisory timing"
+quiet_box_sensitive = true
+pinning     = "fixture is byte-fixed in-repo; counts gated in bench/hdt/expected.tsv; synthetic generator is seeded (xorshift) — only the advisory timing depends on N (HDT_BENCH_N)"
+records_to  = "stdout (run.sh, the canonical self-asserting runner); not baked into docs/tests — correctness lives in expected.tsv"
+status      = "ok"
+
 [[benchmark]]
 id          = "rsp-throughput"
 name        = "sparq-rsp continuous-query throughput"

--- a/bench/competitors.json
+++ b/bench/competitors.json
@@ -274,6 +274,29 @@
       "version_env_metadata": "gather records each DB image digest + the host env block.",
       "quiet_box_sensitive": true,
       "dashboard_engine_id": null
+    },
+    {
+      "id": "hdt-cpp",
+      "name": "hdt-cpp (rdfhdt reference C++ tools)",
+      "kind": "report-cli",
+      "role": "[OPUS-4.8 sq-lrp9] The HDT reference implementation: the rdfhdt C++ tools (core LGPL, tools Apache-2.0). The ONLY like-for-like axis vs sparq-hdt is LOAD-AND-DECODE — sparq-hdt decodes HDT into sparq's OWN Dict/Graph (HDT as an ingest format) then queries its own permutation indexes, whereas hdt-cpp/java query the compressed BitmapTriples IN PLACE (HDT as a queryable store). So we compare DECODE only: `hdt2rdf <in.hdt> <out.nt>` (decode the same archive to N-Triples) is the structural analogue of sparq-hdt's load+decode-to-native. A query-over-HDT head-to-head (hdtSearch / triple-pattern over the compressed bitmap) is NOT like-for-like and is OUT OF SCOPE (different data structure, different work). hdt-java is the JVM sibling, same caveat. Adapter kind `report-cli` (file-in / N-Triples-out), Docker-based -> gather-only on a Docker EC2 box (no Docker on the dev box; zero recurring CI cost), behind the `hdt` cargo feature.",
+      "pinned_version": "rdfhdt/hdt-cpp (pin the rdfhdt/hdt-cpp Docker image DIGEST at gather time)",
+      "version_source": "the rdfhdt/hdt-cpp Docker image DIGEST (or the built tag of a from-source build), recorded in the gather results file.",
+      "install_recipe": "use the `rdfhdt/hdt-cpp` Docker image (core LGPL / tools Apache-2.0), OR build from source (autotools: `./autogen.sh && ./configure && make`). Docker-based -> gather-only on a Docker EC2 box, like QLever; zero recurring CI cost. gather-only — NOT a committed dependency (engines stay out of git per AGENTS.md).",
+      "run_recipe": "scripts/gather-competitors.sh --run --only hdt-cpp with HDT_ARCHIVE=<in.hdt> set; the dispatch calls scripts/bench-adapters/report_cli_adapter.py with the `adapter` recipe below (hdt2rdf decodes the SAME archive sparq-hdt loads, to N-Triples on stdout — the load+decode-to-native analogue). Cross-check the decoded TRIPLE COUNT against sparq-hdt's store.len() before trusting any timing. Match the regime: hdt-cpp `mapHDT` (mmap) vs `loadHDT` (in-RAM) — compare in-RAM vs in-RAM.",
+      "adapter": {
+        "cmd": ["hdt2rdf", "{archive}"],
+        "report_format": "ntriples",
+        "report_to": "stdout",
+        "version_cmd": ["hdt2rdf", "--version"],
+        "kind_note": "DECODE-ONLY. The report is the decoded N-Triples; the comparable signal is decode wall-clock + the decoded triple count (cross-check vs sparq-hdt store.len()). A query-over-HDT (hdtSearch) head-to-head is deliberately NOT wired — it is not like-for-like (sparq-hdt re-indexes; hdt-cpp queries the compressed bitmap in place)."
+      },
+      "comparable_suites": [
+        { "sparq_suite": "hdt-suite", "note": "DECODE-ONLY: hdt2rdf decodes the SAME .hdt sparq-hdt loads; cross-check the decoded triple count (== sparq-hdt store.len(), 328 for snikmeta) before trusting any decode timing. Query-over-HDT is OUT OF SCOPE — not like-for-like (sparq-hdt re-indexes into its own Dict/Graph; hdt-cpp queries the compressed BitmapTriples in place)." }
+      ],
+      "version_env_metadata": "gather records the hdt-cpp Docker image digest (or source tag) + the host env block.",
+      "quiet_box_sensitive": true,
+      "dashboard_engine_id": "hdt-cpp"
     }
   ],
 

--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -361,6 +361,12 @@
     // whole family. Correctness/expressivity card; perf head-to-head OUT OF SCOPE (clock-free vs the
     // wall-clock RSP peers C-SPARQL/CQELS/RSP4J — different time model). No competitor perf column.
     { key: 'RSP-QL',        title: 'RSP-QL streaming', aliases: ['rsp-ql', 'rsp', 'rspql'] },
+    // [OPUS-4.8] sq-lrp9: HDT load-and-decode suite. Metrics are the deterministic snikmeta_*
+    // counts (load-and-decode gate) + advisory hdt_load_s / hdt_vs_ntgz_load_s. The `hdt` /
+    // `snikmeta` aliases prefix-match the whole family. Load-decode-vs-hdt-cpp is the ONLY
+    // like-for-like axis (query-over-HDT is a NON-goal — different data structure); the
+    // hdt-cpp competitor (bench/competitors.json) is decode-only, gather-only via docker.
+    { key: 'HDT',           title: 'HDT load-and-decode', aliases: ['hdt', 'snikmeta'] },
     { key: 'BSBM',          title: 'BSBM',          aliases: ['bsbm'] },
     { key: 'DBPSB',         title: 'DBPSB',         aliases: ['dbpsb', 'dbpedia sparql benchmark'] },
     // [OPUS-4.8] sq-i0nm: the synthetic qlever-style suite carries the one in-repo competitor

--- a/bench/dashboard/metric-labels.json
+++ b/bench/dashboard/metric-labels.json
@@ -820,6 +820,22 @@
       "mode": "query",
       "unit": "µs"
     },
+    "hdt_load_s": {
+      "label": "HDT — load+decode .hdt to a native Graph (advisory)",
+      "suite": "HDT",
+      "dataset": "vendored real-world snikmeta.hdt (hdt-cpp/java-shaped FourSectDict+BitmapTriples; 328 triples) for the gate; deterministic ~250k-triple synthetic archive for the advisory timing (HDT_BENCH_N)",
+      "query": "wall-clock load+decode of the synthetic .hdt (trend-only; machine-sensitive)",
+      "mode": "load",
+      "unit": "s"
+    },
+    "hdt_vs_ntgz_load_s": {
+      "label": "HDT — gzipped-N-Triples / HDT load-time ratio (advisory)",
+      "suite": "HDT",
+      "dataset": "vendored real-world snikmeta.hdt (hdt-cpp/java-shaped FourSectDict+BitmapTriples; 328 triples) for the gate; deterministic ~250k-triple synthetic archive for the advisory timing (HDT_BENCH_N)",
+      "query": "ntgz_load_s / hdt_load_s on the same triples (ratio survives contention; trend-only)",
+      "mode": "ratio",
+      "unit": "ratio"
+    },
     "load_s": {
       "label": "Load — parse + index build (synthetic)",
       "suite": "Pipeline",
@@ -1822,6 +1838,46 @@
       "query": "sh:sparql (SHACL §5.2) routed through sparq-engine",
       "mode": "validate",
       "unit": "µs"
+    },
+    "snikmeta_direct_eq_upstream": {
+      "label": "HDT direct_eq_upstream — load-and-decode gate",
+      "suite": "HDT",
+      "dataset": "vendored real-world snikmeta.hdt (hdt-cpp/java-shaped FourSectDict+BitmapTriples; 328 triples) for the gate; deterministic ~250k-triple synthetic archive for the advisory timing (HDT_BENCH_N)",
+      "query": "1 iff direct decoder == upstream-backed path on the same bytes (oracle)",
+      "mode": "count",
+      "unit": "count"
+    },
+    "snikmeta_distinct_predicates": {
+      "label": "HDT distinct_predicates — load-and-decode gate",
+      "suite": "HDT",
+      "dataset": "vendored real-world snikmeta.hdt (hdt-cpp/java-shaped FourSectDict+BitmapTriples; 328 triples) for the gate; deterministic ~250k-triple synthetic archive for the advisory timing (HDT_BENCH_N)",
+      "query": "distinct predicates via a full SPO scan (triple-pattern resolution)",
+      "mode": "count",
+      "unit": "count"
+    },
+    "snikmeta_rdf_type_triples": {
+      "label": "HDT rdf_type_triples — load-and-decode gate",
+      "suite": "HDT",
+      "dataset": "vendored real-world snikmeta.hdt (hdt-cpp/java-shaped FourSectDict+BitmapTriples; 328 triples) for the gate; deterministic ~250k-triple synthetic archive for the advisory timing (HDT_BENCH_N)",
+      "query": "bound-predicate triple-pattern resolution (rdf:type triples)",
+      "mode": "count",
+      "unit": "count"
+    },
+    "snikmeta_terms": {
+      "label": "HDT terms — load-and-decode gate",
+      "suite": "HDT",
+      "dataset": "vendored real-world snikmeta.hdt (hdt-cpp/java-shaped FourSectDict+BitmapTriples; 328 triples) for the gate; deterministic ~250k-triple synthetic archive for the advisory timing (HDT_BENCH_N)",
+      "query": "distinct dictionary terms interned into sparq's Dict (id-translation)",
+      "mode": "count",
+      "unit": "count"
+    },
+    "snikmeta_triples": {
+      "label": "HDT triples — load-and-decode gate",
+      "suite": "HDT",
+      "dataset": "vendored real-world snikmeta.hdt (hdt-cpp/java-shaped FourSectDict+BitmapTriples; 328 triples) for the gate; deterministic ~250k-triple synthetic archive for the advisory timing (HDT_BENCH_N)",
+      "query": "stored triples of the decoded graph (load-and-decode-to-native)",
+      "mode": "count",
+      "unit": "count"
     },
     "sp2b_q01_count": {
       "label": "SP2Bench q01 — single journal's issue year (selective lookup), count",

--- a/bench/hdt/README.md
+++ b/bench/hdt/README.md
@@ -1,0 +1,110 @@
+<!-- [OPUS-4.8] sq-lrp9 — HDT load-and-decode suite. Design: research/capability-benchmark-program.md §3.7. -->
+# HDT load-and-decode suite
+
+The HDT analogue of the LUBM / SHACL / FTS / RSP template: a self-asserting
+per-commit runner over a **fixed `.hdt` archive**, built around a
+**load-and-decode correctness gate** with **advisory** load timing on the side.
+
+It exercises [`sparq-hdt`](../../crates/sparq-hdt): loading an HDT
+(Header-Dictionary-Triples) archive — the de-facto binary RDF archive format
+(FourSectionDictionary with Plain Front Coding + BitmapTriples, SPO order, as
+written by hdt-cpp / hdt-java) — straight into a sparq `Graph` and resolving
+triple patterns over the decoded graph's own index.
+
+## The like-for-like axis is LOAD-AND-DECODE only (honest)
+
+**Critical caveat (design §3.7):** `sparq-hdt` **decodes HDT into sparq's own
+`Dict`/`Graph`** — it treats HDT as an *ingest format*, then queries its own
+permutation indexes. The reference engines **hdt-cpp / hdt-java query the
+compressed BitmapTriples in place** — they treat HDT as a *queryable store*. So
+**load-and-decode-to-native is the ONLY like-for-like comparison**; a "query over
+HDT" head-to-head is **NOT** like-for-like (different data structure, different
+work) and is an explicit **NON-goal**. This suite gates and compares **load +
+decode** only. (On the honesty ladder in §4.2, HDT load-decode-vs-hdt-cpp is a
+*fair* comparison; query-over-HDT is not.)
+
+## The gate: load-and-decode counts (deterministic)
+
+The runner loads the **vendored real-world `snikmeta.hdt`**
+([`crates/sparq-hdt/tests/fixtures/snikmeta.hdt`](../../crates/sparq-hdt/tests/fixtures/snikmeta.hdt)
+— a hdt-cpp/java-shaped archive, **NOT** produced by sparq's writer; the `hdt`
+crate's own tests assert its 328 triples) and asserts every `count`-unit metric
+against [`expected.tsv`](./expected.tsv). `run.sh` exits non-zero on any drift —
+exactly like LUBM's count diff. Five metrics, all asserted:
+
+| metric | what | meaning |
+|---|---|---|
+| `snikmeta_triples` | stored triples of the decoded graph | the HDT `expected-rows.tsv` (328) |
+| `snikmeta_terms` | distinct dictionary terms interned into sparq's `Dict` | the id-translation produced exactly this many terms |
+| `snikmeta_distinct_predicates` | distinct predicates via a full SPO scan | triple-pattern resolution over the decoded graph's index |
+| `snikmeta_rdf_type_triples` | a single bound-predicate triple-pattern resolution | count of `rdf:type` triples |
+| `snikmeta_direct_eq_upstream` | `1` iff the direct decoder == the upstream-backed path on the SAME bytes | the id-translation **oracle** (the exhaustive form is in `tests/roundtrip.rs`) |
+
+The first two (`_triples` / `_terms`) are the **load-and-decode-to-native** gate;
+`_distinct_predicates` / `_rdf_type_triples` add **triple-pattern resolution on
+the same archive** (design §3.7(a)); `_direct_eq_upstream` pins the
+`.hdt` → sparq `Dict` id-translation against the wrapped `hdt` crate's own
+`Hdt::read` + per-id `id_to_string` path. These complement the differential +
+rejection oracles already in
+[`crates/sparq-hdt/tests/roundtrip.rs`](../../crates/sparq-hdt/tests/roundtrip.rs)
+(triple-for-triple HDT-vs-N-Triples equality, multi-codec decode, truncation /
+byte-flip rejection); the bench pins the *shape* of a fixed load so a regression
+alerts on the dashboard.
+
+> **Write-path note.** Optionally the **bytes-on-disk of a `save`-produced
+> archive** could become a gate once the in-memory PFC+BitmapTriples encoder
+> (bead `sq-ashy`) is the production write path; until then write still goes
+> through a temp-NT round-trip, so **encode-perf parity is an explicit non-goal**
+> and no write metric is gated here.
+
+## Advisory timing (trend-only, NOT a gate)
+
+The runner also emits two advisory rows on a deterministic **synthetic** archive
+(default ~250k triples; override with `$HDT_BENCH_N`):
+
+- `hdt_load_s` — wall-clock to load+decode the `.hdt` to a native `Graph`
+  (seconds, **machine-sensitive**, trend-only).
+- `hdt_vs_ntgz_load_s` — the **ratio** of gzipped-N-Triples load time to HDT
+  load time on the *same* triples. A unitless ratio **survives box contention**
+  (per [`bench/CATALOG.md`](../CATALOG.md)), so it is the more trustworthy
+  advisory signal — but it is **NEVER** asserted; the deterministic counts above
+  are the real gate.
+
+The fuller perf sketches — the ~1M-triple HDT-vs-`.nt.gz` headline and the
+direct-vs-upstream-decoder A/B — live in
+[`crates/sparq-hdt/examples/bench_load.rs`](../../crates/sparq-hdt/examples/bench_load.rs)
+and `examples/bench_direct_vs_upstream.rs` (the `hdt-load-bench` / `hdt-stage-split`
+registry entries).
+
+## Competitor: hdt-cpp (decode-only)
+
+The natural HDT peers are the **rdfhdt reference implementations** — **hdt-cpp**
+and **hdt-java** (core LGPL, tools Apache; the `rdfhdt/hdt-cpp` Docker image
+exists; tools `rdf2hdt` / `hdt2rdf` / `hdtSearch`). The **fair** benchmark is
+**load time + memory + triple-pattern resolution on the same `.hdt`**, matching
+the mapped (`mapHDT` / mmap) vs loaded (`loadHDT` / in-RAM) regimes — and **only**
+that axis (query-over-HDT is not like-for-like, see above). The competitor is
+registered in [`bench/competitors.json`](../competitors.json) (`hdt-cpp`) as a
+**docker / `report-cli`** adapter, gather-only (Docker is not on the dev box;
+zero recurring CI cost), behind the `hdt` cargo feature. Numbers ship **empty**
+in git and are populated only by a real measured gather run.
+
+## Files
+
+| file | role |
+|---|---|
+| `crates/sparq-hdt/examples/bench_oracle.rs` | the TSV-emitting runner (the crate is isolated — not a `sparq-cli` dependency, so the runner is a crate example, like FTS's `bench_text` / RSP's `rsp_oracle`) |
+| `expected.tsv` | the deterministic load-and-decode gate (snikmeta triples / terms / predicates + the direct==upstream id-translation oracle) |
+| `run.sh` | self-asserting entry point CI calls: run the example, assert every `count`-unit metric vs `expected.tsv`, forward the 3-column `<metric>\t<value>\t<unit>` hook contract |
+
+## Run it
+
+```sh
+cargo build --release -p sparq-hdt --example bench_oracle
+bench/hdt/run.sh                       # asserts + prints the metric TSV; exit 1 on any drift
+HDT_BENCH_N=1000000 bench/hdt/run.sh   # bigger synthetic archive for the advisory timing
+```
+
+A divergence in `expected.tsv` means the HDT decode / id-translation /
+triple-pattern resolution changed — regenerate only after confirming the change
+is intended (and update the differential oracle in `tests/roundtrip.rs` if so).

--- a/bench/hdt/expected.tsv
+++ b/bench/hdt/expected.tsv
@@ -1,0 +1,31 @@
+# [OPUS-4.8] (sq-lrp9) HDT suite DETERMINISTIC golden values for the vendored
+# real-world snikmeta.hdt fixture (crates/sparq-hdt/tests/fixtures/snikmeta.hdt — a
+# hdt-cpp/java-shaped FourSectDict+BitmapTriples archive, NOT produced by this code
+# path; the `hdt` crate's own tests assert its 328 triples). Format: <metric>\t<count>.
+#
+# These are the LOAD-AND-DECODE-TO-NATIVE + triple-pattern-resolution gate (design
+# §3.7(a/b)) — the ONLY like-for-like axis vs hdt-cpp/java (query-over-HDT is a NON-goal;
+# see README.md). They are DERIVED by RUNNING examples/bench_oracle on the fixture (not
+# guessed); run.sh re-runs it every commit and exits 1 on any drift, exactly like LUBM's
+# row-count diff / FTS's hit-count diff. The advisory hdt_load_s / hdt_vs_ntgz_load_s rows
+# bench_oracle also emits are wall-clock (non-canonical dev box) and are NEVER asserted.
+#
+#   snikmeta_triples             stored triple count of the decoded graph (HDT's
+#                                expected-rows.tsv; the same 328 the round-trip + the hdt
+#                                crate's own tests assert).
+#   snikmeta_terms               distinct dictionary terms interned into sparq's Dict
+#                                (the id-translation produced exactly this many terms).
+#   snikmeta_distinct_predicates distinct predicates via a full SPO scan (triple-pattern
+#                                resolution over the decoded graph's own index).
+#   snikmeta_rdf_type_triples    a single bound-predicate triple-pattern resolution
+#                                (count of rdf:type triples).
+#   snikmeta_direct_eq_upstream  1 iff the default direct decoder (H1–H4) and the
+#                                upstream-backed path (Hdt::read + per-id id_to_string)
+#                                decode the SAME bytes to byte-identical graphs (the
+#                                id-translation oracle; the exhaustive form is in
+#                                crates/sparq-hdt/tests/roundtrip.rs). Anything but 1 fails.
+snikmeta_triples	328
+snikmeta_terms	205
+snikmeta_distinct_predicates	23
+snikmeta_rdf_type_triples	49
+snikmeta_direct_eq_upstream	1

--- a/bench/hdt/run.sh
+++ b/bench/hdt/run.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] (sq-lrp9) HDT per-commit runner — the self-asserting entry point CI calls,
+# mirroring bench/fts/run.sh + bench/rsp/run.sh. Self-contained:
+#   1. run the sparq-hdt `bench_oracle` EXAMPLE (the crate is isolated — not a sparq-cli
+#      dependency, so the runner is a crate example, like FTS's bench_text / RSP's
+#      rsp_oracle). It loads the VENDORED real-world snikmeta.hdt and decodes it to a
+#      native sparq Graph, then resolves triple patterns over that graph.
+#   2. ASSERT every DETERMINISTIC `count`-unit metric vs expected.tsv (exit 1 on any drift
+#      — the HARD correctness gate). This is the LOAD-AND-DECODE-TO-NATIVE + triple-pattern
+#      -resolution gate (design §3.7) plus the direct-vs-upstream id-translation oracle.
+#   3. forward on STDOUT the 3-column `<metric>\t<value>\t<unit>` contract the ci-bench
+#      `hdt` hook consumes: the asserted DETERMINISTIC counts plus the advisory
+#      hdt_load_s / hdt_vs_ntgz_load_s (trend-only — NOT gated, machine-sensitive; the
+#      RATIO survives box contention per bench/CATALOG.md). Correctness lives in
+#      expected.tsv, exactly like LUBM / FTS / SHACL / RSP.
+#
+# Load-and-decode-to-native is the ONLY like-for-like axis vs hdt-cpp / hdt-java
+# (sparq-hdt decodes HDT into sparq's own Dict/Graph then queries its own indexes;
+# hdt-cpp/java query the compressed BitmapTriples in place — different model). A
+# "query over HDT" head-to-head is explicitly OUT OF SCOPE (see README.md).
+#
+# Usage: bench/hdt/run.sh   (run from anywhere; honours $HDT_BIN / $HDT_BENCH_N overrides)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+EXP="$ROOT/bench/hdt/expected.tsv"
+# The G1 TSV-emitting runner: a sparq-hdt example (the crate is isolated — not a sparq-cli
+# dependency). Override with $HDT_BIN for a custom build.
+BIN="${HDT_BIN:-$ROOT/target/release/examples/bench_oracle}"
+
+if [ ! -x "$BIN" ]; then
+  echo "[hdt] ERROR: bench_oracle not found at $BIN" >&2
+  echo "[hdt]   build: cargo build --release -p sparq-hdt --example bench_oracle" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ---- 1. run the oracle (TSV: metric value unit) -----------------------------------------
+"$BIN" > "$TMP/hdt.tsv"
+
+# ---- 2. assert the DETERMINISTIC count-unit metrics vs expected.tsv (exit 1 on mismatch) -
+# ---- 3. forward the 3-column hook contract on STDOUT (advisory rows pass through) --------
+fail=0
+seen=0
+while IFS=$'\t' read -r metric value unit; do
+  [ -n "$metric" ] || continue
+  case "$unit" in
+    count)
+      exp="$(awk -F'\t' -v k="$metric" '$1==k{print $2}' "$EXP")"
+      if [ -z "$exp" ]; then
+        echo "[hdt] ERROR: $metric has no expected.tsv entry" >&2; fail=1; continue
+      fi
+      if [ "$value" != "$exp" ]; then
+        echo "[hdt] ERROR: $metric=$value expected=$exp (HDT load-decode correctness regression)" >&2; fail=1
+      fi
+      seen=$((seen+1))
+      ;;
+  esac
+  # Forward EVERY metric (deterministic counts + advisory timings) to the hook.
+  printf '%s\t%s\t%s\n' "$metric" "$value" "$unit"
+done < "$TMP/hdt.tsv"
+
+# Every expected metric must have been emitted (a vanished gate metric is a regression).
+exp_rows=$(grep -cvE '^#|^$' "$EXP")
+if [ "$seen" != "$exp_rows" ]; then
+  echo "[hdt] ERROR: emitted $seen count metrics, expected $exp_rows (a gate metric vanished)" >&2; fail=1
+fi
+
+if [ "$fail" = 0 ]; then
+  echo "[hdt] OK: all $seen load-and-decode counts match expected.tsv (snikmeta triples/terms/predicates + direct==upstream oracle)" >&2
+else
+  echo "[hdt] FAILED: one or more load-and-decode counts diverged from expected.tsv" >&2
+fi
+exit "$fail"

--- a/crates/sparq-hdt/examples/bench_oracle.rs
+++ b/crates/sparq-hdt/examples/bench_oracle.rs
@@ -1,0 +1,272 @@
+//! [OPUS-4.8] (sq-lrp9) HDT benchmark ORACLE — the self-asserting TSV-emitting
+//! runner `bench/hdt/run.sh` calls (the sparq-hdt analogue of FTS's `bench_text`
+//! and RSP's `rsp_oracle`; the crate is isolated — not a `sparq-cli` dependency —
+//! so the runner is a crate EXAMPLE).
+//!
+//! Design: `research/capability-benchmark-program.md` §3.7. The suite compares
+//! **LOAD-AND-DECODE-TO-NATIVE + triple-pattern resolution** on a FIXED `.hdt`
+//! archive. That is the ONLY like-for-like axis vs hdt-cpp / hdt-java:
+//! `sparq-hdt` decodes HDT into sparq's own `Dict`/`Graph` (HDT as an *ingest
+//! format*) then queries its own permutation indexes, whereas hdt-cpp/java query
+//! the compressed BitmapTriples in place (HDT as a *queryable store*) — so a
+//! "query over HDT" head-to-head is NOT like-for-like and is an explicit NON-goal
+//! (see README.md). We gate/compare LOAD+DECODE only.
+//!
+//! Two metric families, emitted as `<metric>\t<value>\t<unit>`:
+//!
+//!   * DETERMINISTIC gate (`*_count` / `*_triples` / `*_terms` / `*_predicates`,
+//!     unit `count`) — asserted by `run.sh` against `bench/hdt/expected.tsv` (exit
+//!     1 on any drift). Box-contention-immune, the REAL gate. Derived from the
+//!     vendored real-world `snikmeta.hdt` (NOT produced by this code path; the
+//!     `hdt` crate's own tests assert its 328 triples), plus a direct-vs-upstream
+//!     decode-agreement check on the SAME bytes (the id-translation oracle).
+//!
+//!   * Advisory timing (`hdt_load_s` seconds; `hdt_vs_ntgz_load_s` a unitless
+//!     RATIO — survives box contention per `bench/CATALOG.md`) — trend-only, NEVER
+//!     asserted. Measured on a synthetic archive (default ~250k triples; override
+//!     with `$HDT_BENCH_N`). The full ~1M perf sketch + the direct-vs-upstream A/B
+//!     live in `examples/bench_load.rs` / `examples/bench_direct_vs_upstream.rs`.
+//!
+//! Usage: `cargo run --release -p sparq-hdt --example bench_oracle`
+//!        (honours `$HDT_BENCH_N` for the synthetic advisory archive size).
+
+use std::fmt::Write as _;
+use std::io::Write as _;
+use std::path::Path;
+use std::time::Instant;
+
+use sparq_core::Graph;
+
+/// Default synthetic-archive size for the ADVISORY timing rows. Small enough to
+/// keep the per-commit hook quick; the headline ~1M sketch is `bench_load`.
+const DEFAULT_SYNTH_N: usize = 250_000;
+/// Min-of-N for the advisory timings (ratios survive contention; min-of-N firms it).
+const RUNS: usize = 3;
+
+fn main() {
+    // ---- 1. DETERMINISTIC gate: the vendored real-world snikmeta.hdt ---------------------
+    // A real archive (NOT produced by our writer) so the gate pins the decode of a
+    // hdt-cpp/java-shaped FourSectDict+BitmapTriples layout, not just a round-trip.
+    let hdt_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/snikmeta.hdt");
+    if !hdt_path.exists() {
+        eprintln!("[hdt] ERROR: fixture {} absent", hdt_path.display());
+        std::process::exit(1);
+    }
+
+    let g = sparq_hdt::load(&hdt_path).expect("loading snikmeta.hdt");
+
+    // (a) load-and-decode-to-native: stored triple count + distinct dictionary terms.
+    let triples = g.store.len();
+    let terms = g.dict.len();
+
+    // (b) triple-pattern RESOLUTION on the decoded graph (the design's §3.7(a) "+
+    //     triple-pattern resolution on the same archive"): both prove the decoded
+    //     graph is queryable through sparq's own index, deterministically.
+    //   * distinct predicates: a full SPO scan grouped by predicate.
+    //   * rdf:type triples: a single bound-predicate triple-pattern resolution.
+    let distinct_predicates = distinct_predicate_count(&g);
+    let rdf_type_triples =
+        bound_predicate_count(&g, "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>");
+
+    // (c) the id-translation ORACLE: the default direct decoder (H1–H4) and the
+    //     upstream-backed path (`Hdt::read` + per-id `id_to_string`) must decode the
+    //     SAME bytes to byte-identical graphs. Emitted as a gate metric (1 == agree)
+    //     so a translation regression that still round-trips through one path fails
+    //     the suite. (The exhaustive form lives in `tests/roundtrip.rs`.)
+    let bytes = std::fs::read(&hdt_path).expect("reading snikmeta.hdt bytes");
+    let upstream = sparq_hdt::load_reader_via_upstream(std::io::Cursor::new(bytes.clone()))
+        .expect("upstream-oracle load");
+    let direct_eq_upstream = (triple_set(&g) == triple_set(&upstream)
+        && g.store.len() == upstream.store.len()
+        && g.dict.len() == upstream.dict.len()) as u64;
+
+    // DETERMINISTIC rows (unit `count`) — the HARD gate in run.sh.
+    let mut out = String::new();
+    let _ = writeln!(out, "snikmeta_triples\t{triples}\tcount");
+    let _ = writeln!(out, "snikmeta_terms\t{terms}\tcount");
+    let _ = writeln!(
+        out,
+        "snikmeta_distinct_predicates\t{distinct_predicates}\tcount"
+    );
+    let _ = writeln!(out, "snikmeta_rdf_type_triples\t{rdf_type_triples}\tcount");
+    let _ = writeln!(
+        out,
+        "snikmeta_direct_eq_upstream\t{direct_eq_upstream}\tcount"
+    );
+
+    // ---- 2. ADVISORY timing: synthetic archive load + the ntgz RATIO ---------------------
+    // A unitless RATIO (hdt_vs_ntgz_load_s) survives box contention (CATALOG); the
+    // absolute hdt_load_s is trend-only. Both are NEVER asserted in run.sh.
+    let n: usize = std::env::var("HDT_BENCH_N")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_SYNTH_N);
+    if let Some((hdt_s, ntgz_s, synth_triples)) = synthetic_timing(n) {
+        let ratio = if hdt_s > 0.0 { ntgz_s / hdt_s } else { 0.0 };
+        let _ = writeln!(out, "hdt_load_s\t{hdt_s:.6}\ts");
+        let _ = writeln!(out, "hdt_vs_ntgz_load_s\t{ratio:.4}\tratio");
+        eprintln!(
+            "[hdt] advisory (CONTENDED — orchestrator re-measures on a quiet box): \
+             synthetic {synth_triples} triples, hdt_load_s={hdt_s:.4} ntgz_load_s={ntgz_s:.4} \
+             ratio={ratio:.2}x"
+        );
+    } else {
+        eprintln!("[hdt] note: synthetic advisory timing skipped (HDT writer unavailable)");
+    }
+
+    print!("{out}");
+}
+
+/// A full SPO scan grouped by predicate -> number of DISTINCT predicates.
+fn distinct_predicate_count(g: &Graph) -> usize {
+    use std::collections::BTreeSet;
+    let scan = g.store.scan(&[None, None, None]);
+    let mut preds: BTreeSet<u32> = BTreeSet::new();
+    for r in scan.rows.iter() {
+        let [_, pid, _] = scan.to_spo(r);
+        preds.insert(pid);
+    }
+    preds.len()
+}
+
+/// A single bound-predicate triple-pattern resolution: count of triples whose
+/// predicate term is `pred_str` (returns 0 if that predicate is absent).
+fn bound_predicate_count(g: &Graph, pred_str: &str) -> usize {
+    let scan = g.store.scan(&[None, None, None]);
+    scan.rows
+        .iter()
+        .filter(|r| {
+            let [_, pid, _] = scan.to_spo(r);
+            g.dict.term(pid).to_string() == pred_str
+        })
+        .count()
+}
+
+/// A canonical, comparable triple set (N-Triples term rendering) for the
+/// direct-vs-upstream decode-agreement oracle.
+fn triple_set(g: &Graph) -> std::collections::BTreeSet<[String; 3]> {
+    let scan = g.store.scan(&[None, None, None]);
+    scan.rows
+        .iter()
+        .map(|r| {
+            let [s, p, o] = scan.to_spo(r);
+            [
+                g.dict.term(s).to_string(),
+                g.dict.term(p).to_string(),
+                g.dict.term(o).to_string(),
+            ]
+        })
+        .collect()
+}
+
+/// Builds a deterministic synthetic graph (same shape as `bench_load.rs`:
+/// clustered subjects, a small predicate set, a mix of shared-section IRI objects
+/// and literal kinds) as BOTH a `.hdt` archive and a gzipped N-Triples file, then
+/// returns `(best_hdt_load_s, best_ntgz_load_s, triples)` — min-of-`RUNS`.
+///
+/// The `.hdt` is built via the `hdt` crate's experimental N-Triples writer
+/// (`read_nt`, the dev-dependency `sophia` feature) — the same build path the
+/// round-trip tests + `bench_load` use. Returns `None` if that writer is
+/// unavailable, so the advisory rows are skipped rather than failing the suite.
+fn synthetic_timing(n: usize) -> Option<(f64, f64, usize)> {
+    let nt = generate_nt(n);
+
+    // Scratch in a UNIQUE auto-removed temp dir (disk discipline; CATALOG).
+    let dir = std::env::temp_dir().join(format!("sparq-hdt-bench-oracle-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).ok()?;
+    let nt_path = dir.join("synth.nt");
+    let gz_path = dir.join("synth.nt.gz");
+    let hdt_path = dir.join("synth.hdt");
+    std::fs::write(&nt_path, &nt).ok()?;
+
+    // gzip the N-Triples (the .nt.gz competitor ingest path).
+    let gz_file = std::fs::File::create(&gz_path).ok()?;
+    let mut enc = flate2::write::GzEncoder::new(
+        std::io::BufWriter::new(gz_file),
+        flate2::Compression::default(),
+    );
+    enc.write_all(nt.as_bytes()).ok()?;
+    enc.finish().ok()?.flush().ok()?;
+
+    // N-Triples -> HDT archive (FourSectDict PFC + BitmapTriples).
+    let hdt = hdt::Hdt::read_nt(&nt_path).ok()?;
+    {
+        let mut w = std::io::BufWriter::new(std::fs::File::create(&hdt_path).ok()?);
+        hdt.write(&mut w).ok()?;
+    }
+
+    let mut best_hdt = f64::MAX;
+    let mut triples = 0usize;
+    for _ in 0..RUNS {
+        let t = Instant::now();
+        let g = sparq_hdt::load(&hdt_path).ok()?;
+        best_hdt = best_hdt.min(t.elapsed().as_secs_f64());
+        triples = g.store.len();
+    }
+
+    let mut best_ntgz = f64::MAX;
+    for _ in 0..RUNS {
+        let t = Instant::now();
+        let f = std::fs::File::open(&gz_path).ok()?;
+        let g = Graph::load_reader(flate2::read::GzDecoder::new(f), "ntriples").ok()?;
+        best_ntgz = best_ntgz.min(t.elapsed().as_secs_f64());
+        // Both ingest paths must agree on the stored triple count (a cheap sanity
+        // cross-check; the HARD correctness gate is the snikmeta block above).
+        debug_assert_eq!(g.store.len(), triples);
+    }
+
+    // Clean the scratch dir (disk discipline; bench data is regenerable).
+    let _ = std::fs::remove_dir_all(&dir);
+    Some((best_hdt, best_ntgz, triples))
+}
+
+/// Deterministic synthetic N-Triples (SplitMix-free xorshift, fixed seed): clustered
+/// subjects, a small predicate set, shared-section IRI objects + a literal zoo —
+/// mirroring `bench_load.rs` so the dictionary has realistic term reuse across PFC
+/// blocks.
+fn generate_nt(n: usize) -> String {
+    let mut nt = String::with_capacity(n * 100);
+    let mut st = 0x243f_6a88u64;
+    let mut rng = || {
+        st ^= st << 13;
+        st ^= st >> 7;
+        st ^= st << 17;
+        st
+    };
+    for _ in 0..n {
+        let s = rng() % 100_000;
+        let p = rng() % 50;
+        let _ = write!(
+            nt,
+            "<http://bench.example/e{s}> <http://bench.example/vocab/p{p}> "
+        );
+        match rng() % 5 {
+            0 => {
+                let _ = write!(nt, "<http://bench.example/e{}>", rng() % 100_000);
+            }
+            1 => {
+                let _ = write!(nt, "\"label {}\"", rng() % 1_000_000);
+            }
+            2 => {
+                let _ = write!(nt, "\"etikett {}\"@de", rng() % 1_000_000);
+            }
+            3 => {
+                let _ = write!(
+                    nt,
+                    "\"{}\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+                    rng() % 100_000
+                );
+            }
+            _ => {
+                let _ = write!(
+                    nt,
+                    "\"{}.{:02}\"^^<http://www.w3.org/2001/XMLSchema#decimal>",
+                    rng() % 1000,
+                    rng() % 100
+                );
+            }
+        }
+        nt.push_str(" .\n");
+    }
+    nt
+}

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -156,6 +156,16 @@ GEO_RUN=bench/geo/run.sh
 # scripts/perf-gate.py). NO competitor perf column — the RSP peers are wall-clock service engines
 # (apples-to-oranges). Registry: bench/benchmarks.toml (rsp-ql); details: bench/rsp/README.md.
 RSP_RUN=bench/rsp/run.sh
+# [OPUS-4.8] HDT load-and-decode suite (sq-lrp9, design §3.7). Like FTS/RSP the runner is a crate
+# EXAMPLE (bench_oracle) that only needs `cargo` (sparq-hdt is isolated, not a sparq-cli dependency,
+# and is behind the `hdt` cargo feature). run.sh is the self-asserting entry point: it loads the
+# VENDORED snikmeta.hdt, decodes it to a native sparq Graph, resolves triple patterns, and asserts
+# every DETERMINISTIC `count`-unit metric vs bench/hdt/expected.tsv (exit 1 on drift) — the
+# load-and-decode-to-native + triple-pattern-resolution gate (the ONLY like-for-like axis vs
+# hdt-cpp/java; query-over-HDT is OUT OF SCOPE). The advisory hdt_load_s / hdt_vs_ntgz_load_s
+# (a contention-robust RATIO) are trend-only (NOT in scripts/perf-gate.py). Registry:
+# bench/benchmarks.toml (hdt-suite); details: bench/hdt/README.md.
+HDT_RUN=bench/hdt/run.sh
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 RES="$TMP/res.tsv"; : > "$RES"
 add() { printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$RES"; }
@@ -733,6 +743,44 @@ elif command -v cargo >/dev/null 2>&1 && [ -x "$RSP_RUN" ]; then
   fi
 else
   echo "note: rsp skipped (cargo not on PATH or $RSP_RUN missing)" >&2
+fi
+
+# [OPUS-4.8] HDT load-and-decode per-commit hook (sq-lrp9). Like RSP/FTS the runner is a crate
+# EXAMPLE (bench_oracle) that only needs `cargo`, so — to match the main-only-toolchain skip the
+# LUBM/SHACL hooks get for free and keep the example build off per-PR CI — we PIN this hook to the
+# MAIN/local tier: it runs on push-to-main (GITHUB_REF=refs/heads/main) and on a LOCAL run
+# (GITHUB_REF unset, so dev `bench/hdt/run.sh` still works), but is SKIPPED on the PR tier. The
+# DETERMINISTIC load-and-decode count gate therefore runs once per merge to main. run.sh asserts
+# every `count`-unit metric vs expected.tsv internally (exit 1 on drift), failing the whole ci-bench
+# run on a regression exactly like LUBM/FTS/RSP. We harvest run.sh's `<metric>\t<value>\t<unit>`
+# stdout: the `snikmeta_*` counts are DETERMINISTIC (emitted for the dashboard's HDT card; correctness
+# is the run.sh internal gate, so trend rows not perf-gate ratchets), and hdt_load_s /
+# hdt_vs_ntgz_load_s are ADVISORY (trend-only, NOT in scripts/perf-gate.py). A small HDT_BENCH_N keeps
+# the advisory synthetic-archive build quick; the deterministic gate is on the fixture, not N.
+HDT_BIN=target/release/examples/bench_oracle
+HDT_REF="${GITHUB_REF:-}"
+if [ -n "$HDT_REF" ] && [ "$HDT_REF" != "refs/heads/main" ]; then
+  echo "note: hdt skipped (PR tier — HDT example build/run is main-only, like the javac/rapper suites)" >&2
+elif command -v cargo >/dev/null 2>&1 && [ -x "$HDT_RUN" ]; then
+  # Always (re)build: rust-cache restores target/, so a file-exists check can run a STALE binary.
+  if ! cargo build --release -q -p sparq-hdt --example bench_oracle; then
+    echo "ERROR: bench_oracle example failed to build" >&2
+    exit 1
+  fi
+  if HDT_BIN="$HDT_BIN" HDT_BENCH_N="${HDT_BENCH_N:-100000}" bash "$HDT_RUN" > "$TMP/hdt.tsv" 2>"$TMP/hdt.err"; then
+    while IFS=$'\t' read -r metric value unit; do
+      [ -n "${metric:-}" ] && [ -n "${value:-}" ] || continue
+      # DETERMINISTIC load-and-decode counts + the advisory load/ratio rows: forward verbatim
+      # (run.sh has already asserted the count gate, so these are trend rows).
+      add "$metric" "${unit:-count}" "$value"
+    done < "$TMP/hdt.tsv"
+  else
+    echo "ERROR: hdt run.sh failed (load-and-decode count regression)" >&2
+    cat "$TMP/hdt.err" >&2 || true
+    exit 1
+  fi
+else
+  echo "note: hdt skipped (cargo not on PATH or $HDT_RUN missing)" >&2
 fi
 
 # [OPUS-4.8] ZERO-KNOWLEDGE family (sq dashboard-data-feed) — feeds the dashboard's

--- a/scripts/gen-metric-labels.py
+++ b/scripts/gen-metric-labels.py
@@ -529,6 +529,42 @@ def build():
         "mode": "deficit", "unit": "fixtures",
     }
 
+    # 13.5) HDT load-and-decode suite (sq-lrp9, design §3.7). The ci-bench hook emits the
+    # DETERMINISTIC load-and-decode counts (snikmeta_* , unit count — the HARD gate in
+    # bench/hdt/run.sh's self-assertion) plus two ADVISORY rows: hdt_load_s (wall-clock, trend)
+    # and hdt_vs_ntgz_load_s (a RATIO that survives box contention; trend, NEVER asserted).
+    # Load-and-decode-to-native is the ONLY like-for-like axis vs hdt-cpp/java (query-over-HDT is
+    # a NON-goal); the deterministic counts ARE the gate, not the dashboard. The `hdt` alias in the
+    # dashboard's FEATURED_SUITES routes these metrics to the HDT card via name-token match.
+    HDT_DATASET = ("vendored real-world snikmeta.hdt (hdt-cpp/java-shaped FourSectDict+BitmapTriples; "
+                   "328 triples) for the gate; deterministic ~250k-triple synthetic archive for the "
+                   "advisory timing (HDT_BENCH_N)")
+    HDT_GATE = {
+        "snikmeta_triples": "stored triples of the decoded graph (load-and-decode-to-native)",
+        "snikmeta_terms": "distinct dictionary terms interned into sparq's Dict (id-translation)",
+        "snikmeta_distinct_predicates": "distinct predicates via a full SPO scan (triple-pattern resolution)",
+        "snikmeta_rdf_type_triples": "bound-predicate triple-pattern resolution (rdf:type triples)",
+        "snikmeta_direct_eq_upstream": "1 iff direct decoder == upstream-backed path on the same bytes (oracle)",
+    }
+    for name, desc in HDT_GATE.items():
+        labels[name] = {
+            "label": "HDT %s — load-and-decode gate" % name.replace("snikmeta_", ""),
+            "suite": "HDT", "dataset": HDT_DATASET,
+            "query": desc, "mode": "count", "unit": "count",
+        }
+    labels["hdt_load_s"] = {
+        "label": "HDT — load+decode .hdt to a native Graph (advisory)",
+        "suite": "HDT", "dataset": HDT_DATASET,
+        "query": "wall-clock load+decode of the synthetic .hdt (trend-only; machine-sensitive)",
+        "mode": "load", "unit": "s",
+    }
+    labels["hdt_vs_ntgz_load_s"] = {
+        "label": "HDT — gzipped-N-Triples / HDT load-time ratio (advisory)",
+        "suite": "HDT", "dataset": HDT_DATASET,
+        "query": "ntgz_load_s / hdt_load_s on the same triples (ratio survives contention; trend-only)",
+        "mode": "ratio", "unit": "ratio",
+    }
+
     # 14) ZERO-KNOWLEDGE family (sq dashboard-data-feed; ci-bench ZK hooks). EVERY ZK metric
     # name leads with the token `zk` so the dashboard's Zero-knowledge family prefix routing
     # buckets it. Three feeds, each grounded in an EXISTING bench (bench/benchmarks.toml zk-*):


### PR DESCRIPTION
> 🤖 SPARQ agent — automated change. @jeswr runs multiple agents on this account; this PR is from the HDT benchmark-suite worktree. Authored by Opus 4.8 (Fable unavailable; `[OPUS-4.8]` markers + Opus Co-Authored-By trailer flag it for re-review when Fable returns).

Implements bead **sq-lrp9** — the HDT capability-benchmark suite from `research/capability-benchmark-program.md` §3.7, mirroring the FTS / RSP / SHACL template: a self-asserting per-commit runner over a **fixed `.hdt` archive**, built around a **deterministic load-and-decode correctness gate** with advisory load timing on the side.

## What this adds

- **`crates/sparq-hdt/examples/bench_oracle.rs`** — the TSV-emitting runner. The crate is isolated (not a `sparq-cli` dependency, and behind the `hdt` cargo feature), so the runner is a crate **example**, like FTS's `bench_text` / RSP's `rsp_oracle`. It loads the **vendored real-world `snikmeta.hdt`** (a hdt-cpp/java-shaped FourSectDict+BitmapTriples archive, 328 triples, **not** produced by sparq's writer), decodes it to a native sparq `Graph`, and resolves triple patterns over that graph.
- **`bench/hdt/{expected.tsv, run.sh, README.md}`** — the **DETERMINISTIC gate** (`snikmeta_triples` / `snikmeta_terms` / `snikmeta_distinct_predicates` / `snikmeta_rdf_type_triples` + the `snikmeta_direct_eq_upstream` id-translation oracle, all unit `count`), asserted by `run.sh` against `expected.tsv` (exit 1 on any drift — exactly like LUBM's count diff). The advisory `hdt_load_s` + `hdt_vs_ntgz_load_s` (a contention-robust **ratio**) are trend-only and **never** asserted.
- **`bench/competitors.json`** — the **`hdt-cpp`** competitor (rdfhdt reference), **decode-only** (`hdt2rdf`), `report-cli` / docker, gather-only behind the `hdt` feature (zero recurring CI cost). Numbers ship empty.
- **`bench/dashboard/{dashboard.js, metric-labels.json}` + `scripts/gen-metric-labels.py`** — HDT featured-suite card + metric labels (drift gate green).
- **`scripts/ci-bench.sh` + `bench/{benchmarks.toml, CATALOG.md}`** — a main-tier harvest hook (like RSP — the example build stays off the per-PR path) + the `hdt-suite` registry entry + the catalog note.

## Honest caveat (carried through every doc)

**Load-and-decode-to-native is the ONLY like-for-like axis** vs hdt-cpp / hdt-java: `sparq-hdt` decodes HDT into sparq's **own** `Dict`/`Graph` (HDT as an *ingest format*) then queries its own permutation indexes, whereas hdt-cpp/java query the compressed BitmapTriples **in place** (HDT as a *queryable store*). A **query-over-HDT head-to-head is NOT like-for-like and is an explicit NON-goal** — the suite gates and compares load+decode only. The write-side **bytes-on-disk** gate is deferred until the in-memory PFC+BitmapTriples encoder (`sq-ashy`) is the production write path (encode-perf parity is a non-goal today).

## Gate (run locally, all green)

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + `cargo test` — **all green in BOTH feature states** (default + `write`).
- `bench/hdt/run.sh` passes; drift + vanished-metric failure paths both exit non-zero (verified).
- `rustfmt`-clean (the new example; rustfmt is informational per `rustfmt.toml`, but the new file is clean).
- **Privacy-claims gate** (predicate-form soundness included), **no-perf-numbers**, **new-bench-registered** (G3), and **metric-labels drift** gates all pass; dashboard node `--check` + smoke test pass.
- **No public API changed** (example + bench harness only), so the G2 public-API → `SKILL.md` rule does not apply.

Closes sq-lrp9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)