### PR TITLE
perf(sparq-core): honest build-timing labels so the rung-5 dict bucket re-measures (sq-3l43) [OPUS-4.8]

### DIFF
--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -5216,7 +5216,13 @@ mod build_timing {
     ///   is the `consolidate` term (`into_merged`/spilled, serial) PLUS whatever intern
     ///   occupancy exceeds the overlapped parse — which is what sq-3l43 confirms at 1 B.
     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-    pub enum PathKind {
+    // [OPUS-4.8 sq-3l43] `build_timing` is a PRIVATE module, so these items are only
+    // crate-reachable regardless of the `pub` keyword. Declare that reachability accurately
+    // with `pub(crate)`: it both reflects the real (crate-internal) surface and keeps the
+    // textual public-API diff gate (G2 / scripts/pub_api_diff.py, a `pub\s+(fn|enum|…)`
+    // regex that does NOT resolve enclosing-module visibility) from tripping on a `pub`
+    // that exports nothing.
+    pub(crate) enum PathKind {
         Serial,
         Pipelined,
     }
@@ -5226,7 +5232,7 @@ mod build_timing {
     /// dict-consolidation step (`into_merged` for sharded, `consolidate` for spilled), folded
     /// in so the FULL dict-consolidation bucket is attributed on one line; pass `None` for the
     /// serial path (whose consolidation is the inline `merge_remap` already in "merge").
-    pub fn format_report(
+    pub(crate) fn format_report(
         stage: &str,
         kind: PathKind,
         consolidate_secs: Option<f64>,
@@ -5255,7 +5261,7 @@ mod build_timing {
         )
     }
 
-    pub fn report(stage: &str, kind: PathKind, consolidate_secs: Option<f64>, secs: f64) {
+    pub(crate) fn report(stage: &str, kind: PathKind, consolidate_secs: Option<f64>, secs: f64) {
         eprintln!("{}", format_report(stage, kind, consolidate_secs, secs));
     }
 

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -1787,6 +1787,11 @@ impl Graph {
             false
         };
         let mut sharded_remap: Option<(Vec<u64>, u32)> = None;
+        // [OPUS-4.8 sq-3l43] Serial dict-consolidation seconds (`into_merged`) on the sharded
+        // default path, folded into the phase report so the FULL dict-consolidation bucket
+        // (the one this rung-5 spike re-measures) appears on one honestly-labelled line.
+        #[cfg(all(feature = "mmap", feature = "parallel"))]
+        let mut cons_secs: Option<f64> = None;
 
         if sharded {
             #[cfg(all(feature = "mmap", feature = "parallel"))]
@@ -1795,8 +1800,10 @@ impl Graph {
                 build_external_ntriples_sharded(reader, &mut sd, &mut buf, &mut runs, &tmp, chunk)?;
                 let t_cons = std::time::Instant::now();
                 let (merged, base, stride) = sd.into_merged();
+                let elapsed = t_cons.elapsed().as_secs_f64();
                 if build_timing::enabled() {
-                    eprintln!("[build-timing] dict consolidate (into_merged): {:.2}s", t_cons.elapsed().as_secs_f64());
+                    eprintln!("[build-timing] dict consolidate (into_merged): {elapsed:.2}s");
+                    cons_secs = Some(elapsed);
                 }
                 dict = merged;
                 sharded_remap = Some((base, stride));
@@ -1840,7 +1847,16 @@ impl Graph {
         buf.shrink_to_fit();
         #[cfg(all(feature = "mmap", feature = "parallel"))]
         if build_timing::enabled() {
-            build_timing::report("parse+intern+spill done", _t_build.elapsed().as_secs_f64());
+            // [OPUS-4.8 sq-3l43] The sharded default path's merge/remap buckets are PIPELINED
+            // (parallel intern + overlapped remap), NOT the additive-serial `merge_remap`/
+            // `triple-remap` of the non-sharded parallel build — label them accordingly so the
+            // dict-consolidation bucket re-measurement reads correctly.
+            let (kind, cons) = if sharded {
+                (build_timing::PathKind::Pipelined, cons_secs)
+            } else {
+                (build_timing::PathKind::Serial, None)
+            };
+            build_timing::report("parse+intern+spill done", kind, cons, _t_build.elapsed().as_secs_f64());
         }
 
         // Merge the SPO runs into the SPO permutation file (deduplicating).
@@ -2242,7 +2258,15 @@ impl Graph {
             dictspill::SpillInterner::new(default_shards(), &tmp, cfg).map_err(|e| e.to_string())?;
         build_external_ntriples_dictspill(reader, &mut interner)?;
         if build_timing::enabled() {
-            build_timing::report("parse+route+stage done", _t_build.elapsed().as_secs_f64());
+            // [OPUS-4.8 sq-3l43] The spill path's "merge" bucket is the bounded PARALLEL
+            // `intern_batch` occupancy (Pipelined), not a serial `merge_remap`. Consolidation
+            // (`consolidate`) is a LATER phase, reported separately below, so `None` here.
+            build_timing::report(
+                "parse+route+stage done",
+                build_timing::PathKind::Pipelined,
+                None,
+                _t_build.elapsed().as_secs_f64(),
+            );
         }
 
         // Phases 2-4: external dedup/rank. The dictionary files and the numeric/temporal
@@ -5173,16 +5197,129 @@ mod build_timing {
             counter.fetch_add(t.elapsed().as_nanos() as u64, std::sync::atomic::Ordering::Relaxed);
         }
     }
-    pub fn report(stage: &str, secs: f64) {
+    /// Which interning topology produced the `MERGE_NS`/`REMAP_NS` buckets — they are NOT
+    /// comparable across paths, so the report MUST label them honestly:
+    ///
+    /// * [`Serial`](PathKind::Serial) — the non-sharded parallel external build
+    ///   (`build_external_ntriples_parallel`): "merge" is the one serial `Dict::merge_remap`
+    ///   global-id re-intern and "remap" is a serial loop. These two buckets ADD into the
+    ///   serial dict-consolidation wall (the measured ~200 s/1 B at engine `ef86e66`).
+    /// * [`Pipelined`](PathKind::Pipelined) — the sharded default
+    ///   (`build_external_ntriples_sharded`) and the dict-spill path: the "merge" bucket is
+    ///   the PARALLEL `intern_partials`/`intern_batch` occupancy and the "remap" bucket runs
+    ///   on its OWN pipeline stage CONCURRENTLY with the next batch's intern. They are
+    ///   per-stage thread-occupancy (inflated by contention), NOT additive serial wall — so
+    ///   labelling them `(serial)` (as this report did before [OPUS-4.8] sq-3l43) made a
+    ///   rung-5 re-measurement of the dict-consolidation bucket UNINTERPRETABLE: a reader
+    ///   would compare pipelined occupancy against the old additive-serial ~200 s/1 B and
+    ///   draw the wrong conclusion. The interpretable dict-consolidation bucket on this path
+    ///   is the `consolidate` term (`into_merged`/spilled, serial) PLUS whatever intern
+    ///   occupancy exceeds the overlapped parse — which is what sq-3l43 confirms at 1 B.
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    pub enum PathKind {
+        Serial,
+        Pipelined,
+    }
+
+    /// Format the per-phase build-timing line for `stage`. Pure (no I/O, no clock) so it is
+    /// unit-testable; `report` prints what this returns. `consolidate_secs` is the serial
+    /// dict-consolidation step (`into_merged` for sharded, `consolidate` for spilled), folded
+    /// in so the FULL dict-consolidation bucket is attributed on one line; pass `None` for the
+    /// serial path (whose consolidation is the inline `merge_remap` already in "merge").
+    pub fn format_report(
+        stage: &str,
+        kind: PathKind,
+        consolidate_secs: Option<f64>,
+        secs: f64,
+    ) -> String {
         use std::sync::atomic::Ordering::Relaxed;
         let (p, m, r) = (
             PARSE_NS.load(Relaxed) as f64 / 1e9,
             MERGE_NS.load(Relaxed) as f64 / 1e9,
             REMAP_NS.load(Relaxed) as f64 / 1e9,
         );
-        eprintln!(
-            "[build-timing] {stage}: parse(parallel) {p:.2}s | merge_remap(serial) {m:.2}s | triple-remap(serial) {r:.2}s | {secs:.2}s wall to here"
-        );
+        // Honest bucket labels: serial buckets ADD to the consolidation wall; pipelined
+        // buckets are overlapped per-stage occupancy (see `PathKind`).
+        let (merge_lbl, remap_lbl) = match kind {
+            PathKind::Serial => ("merge_remap(serial)", "triple-remap(serial)"),
+            PathKind::Pipelined => {
+                ("intern(parallel-occupancy)", "triple-remap(pipelined-occupancy)")
+            }
+        };
+        let cons = match consolidate_secs {
+            Some(c) => format!(" | dict-consolidate(serial) {c:.2}s"),
+            None => String::new(),
+        };
+        format!(
+            "[build-timing] {stage}: parse(parallel) {p:.2}s | {merge_lbl} {m:.2}s | {remap_lbl} {r:.2}s{cons} | {secs:.2}s wall to here"
+        )
+    }
+
+    pub fn report(stage: &str, kind: PathKind, consolidate_secs: Option<f64>, secs: f64) {
+        eprintln!("{}", format_report(stage, kind, consolidate_secs, secs));
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::sync::atomic::Ordering::Relaxed;
+
+        // The phase counters are process-global statics; serialize the few tests that set
+        // them so they don't race each other's `format_report` reads.
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+        // [OPUS-4.8 sq-3l43] The non-sharded parallel build's buckets are the genuine
+        // additive-serial `merge_remap` + `triple-remap` (the measured ~200 s/1 B); they
+        // MUST keep the `(serial)` label and carry NO separate consolidate term.
+        #[test]
+        fn serial_path_labels_buckets_serial_and_has_no_consolidate_term() {
+            let _g = LOCK.lock().unwrap();
+            reset();
+            MERGE_NS.store(137_900_000_000, Relaxed); // 137.9 s
+            REMAP_NS.store(62_200_000_000, Relaxed); //  62.2 s
+            PARSE_NS.store(138_100_000_000, Relaxed); // 138.1 s
+            let line = format_report("parse+intern+spill done", PathKind::Serial, None, 221.2);
+            assert!(line.contains("merge_remap(serial) 137.90s"), "{line}");
+            assert!(line.contains("triple-remap(serial) 62.20s"), "{line}");
+            assert!(!line.contains("dict-consolidate"), "serial path folds consolidation into merge_remap: {line}");
+            assert!(!line.contains("parallel-occupancy"), "{line}");
+        }
+
+        // The sharded DEFAULT (what sq-3l43 re-measures) overlaps a PARALLEL intern with a
+        // pipelined remap — those buckets are per-stage occupancy, NOT additive-serial. They
+        // MUST NOT be labelled `(serial)` (which would make the bucket re-measurement read as
+        // a regression vs the old additive 200 s/1 B), and the serial `into_merged`
+        // consolidation MUST appear as its own honestly-labelled term on the same line.
+        #[test]
+        fn pipelined_path_labels_occupancy_and_surfaces_consolidate_bucket() {
+            let _g = LOCK.lock().unwrap();
+            reset();
+            MERGE_NS.store(40_000_000_000, Relaxed); // 40 s intern occupancy
+            REMAP_NS.store(60_000_000_000, Relaxed); // 60 s remap occupancy
+            PARSE_NS.store(138_000_000_000, Relaxed);
+            let line = format_report("parse+intern+spill done", PathKind::Pipelined, Some(3.5), 150.0);
+            // The whole point of the bead: the dict-consolidation bucket is the small serial
+            // `into_merged` term, distinct from the (overlapped) intern/remap occupancy.
+            assert!(line.contains("dict-consolidate(serial) 3.50s"), "{line}");
+            assert!(line.contains("intern(parallel-occupancy) 40.00s"), "{line}");
+            assert!(line.contains("triple-remap(pipelined-occupancy) 60.00s"), "{line}");
+            // Must NOT mislabel the pipelined buckets as additive-serial.
+            assert!(!line.contains("merge_remap(serial)"), "{line}");
+            assert!(!line.contains("triple-remap(serial)"), "{line}");
+        }
+
+        // Pipelined paths whose consolidation is reported on a SEPARATE later line (dict-spill)
+        // pass `None` and so carry no inline consolidate term, but still drop the serial labels.
+        #[test]
+        fn pipelined_path_without_inline_consolidate_omits_the_term() {
+            let _g = LOCK.lock().unwrap();
+            reset();
+            MERGE_NS.store(10_000_000_000, Relaxed);
+            let line = format_report("parse+route+stage done", PathKind::Pipelined, None, 99.0);
+            assert!(!line.contains("dict-consolidate"), "{line}");
+            assert!(line.contains("intern(parallel-occupancy) 10.00s"), "{line}");
+            assert!(!line.contains("(serial)"), "{line}");
+        }
     }
 }
 

--- a/hwrun/rung5-launch.sh
+++ b/hwrun/rung5-launch.sh
@@ -21,7 +21,11 @@ set -uo pipefail
 
 export AWS_PROFILE=pss
 REGION=eu-west-2
-SHA="${SPARQ_SHA:-ef86e66}"
+# [OPUS-4.8 sq-3l43] Default to current public main, NOT the pre-`dict-consolidation`
+# engine ef86e66 that produced the original ~200 s/1 B SERIAL dict bucket. The whole
+# point of this re-measurement is to exercise the MERGED parallel-intern + pipelined
+# remap + parallel `into_merged` path, so the build MUST be a post-consolidation commit.
+SHA="${SPARQ_SHA:-origin/main}"
 ITYPE=r7i.2xlarge
 DEADMAN=150          # minutes; box self-destructs even if this script dies
 SLICE=1000000000

--- a/hwrun/rung5-remote.sh
+++ b/hwrun/rung5-remote.sh
@@ -12,7 +12,8 @@
 set -u
 SLICE_N="${1:-1000000000}"
 THREADS="${2:-1,2,4,8}"
-SHA="${3:-ef86e66}"
+# [OPUS-4.8 sq-3l43] Post-`dict-consolidation` build by default (see rung5-launch.sh).
+SHA="${3:-origin/main}"
 
 R="$HOME/results"; mkdir -p "$R"
 exec > >(tee -a "$R/onbox.log") 2>&1
@@ -83,6 +84,9 @@ command -v cargo >/dev/null 2>&1 || \
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal >/dev/null 2>&1
 . "$HOME/.cargo/env"
 git clone -q https://github.com/jeswr/sparq.git "$HOME/sparq" && cd "$HOME/sparq" && git checkout -q "$SHA"
+# [OPUS-4.8 sq-3l43] Record the resolved commit so the dict-bucket result is attributable
+# to a specific engine revision (the original ~200 s figure was at ef86e66, PRE-consolidation).
+git rev-parse HEAD | tee "$R/engine-sha.txt"
 t0=$SECONDS
 cargo build --release -q -p sparq-cli -p sparq-bench
 echo "cargo build: $((SECONDS-t0))s"
@@ -145,6 +149,12 @@ if [ -f "$HOME/slice.nt.zst" ] && [ "${SLICE_LINES:-0}" -gt 1000000 ]; then
   BUILD_RC=$?
   kill "$IOSTAT_PID" 2>/dev/null
   tail -30 "$R/t2-build.log"
+  # [OPUS-4.8 sq-3l43] The bead's deliverable: isolate the dict-consolidation bucket from the
+  # phase report. On post-consolidation main these lines read `dict consolidate (into_merged)`
+  # + `dict-consolidate(serial)` + `intern(parallel-occupancy)`/`triple-remap(pipelined-
+  # occupancy)` — NOT the old `merge_remap(serial)`/`triple-remap(serial)` additive ~200 s/1 B.
+  # Compare the `dict-consolidate(serial)` term against the projected single-digit seconds.
+  grep -E '\[build-timing\]' "$R/t2-build.log" | tee "$R/t2-dict-bucket.txt" || true
   df -h / | tail -1; du -sh "$HOME/idx" | tee -a "$R/t2-build.log"
   if [ "$BUILD_RC" = "0" ]; then
     echo "== T2 sanity COUNT queries (mmap) =="

--- a/research/wikidata-ingestion-benchmark.md
+++ b/research/wikidata-ingestion-benchmark.md
@@ -219,3 +219,40 @@ correct COUNTs, out-of-core, 51.5 GB peak RAM, on an 8-vCPU ~$0.61/h box.** The 
 full-truthy target remains neither met nor refuted on real hardware (192-core box still
 quota-blocked), but the path is now quantified: shrink/parallelise the ~200 s/1 B serial
 dict bucket, then re-measure many-core scaling.
+
+## Rung-5 dict-bucket re-measurement (sq-3l43) — instrumentation + re-launch
+
+The ~200 s/1 B SERIAL dict bucket above (`merge_remap(serial)` 137.9 s + `triple-remap
+(serial)` 62.2 s) was measured at engine **`ef86e66`**, which is BEFORE the
+`dict-consolidation` branch landed on main (parallel `intern_partials`, pipelined remap,
+parallel `into_merged`, sharded-default). `research/dict-consolidation-verdict.md` PROJECTS
+that bucket down to single-digit seconds at 1 B — an EXTRAPOLATION from 40 M synthetic on a
+contended M1, never re-measured at 1 B real truthy. sq-3l43 is the cheap precursor to the
+deferred 192-core validation (sq-bj3): one ~$1.50 r7i.2xlarge 1 B build on **current main**
+to confirm or refute the bucket reduction.
+
+Two defeaters in the existing harness made that re-measurement uninterpretable, both fixed
+here (no fabricated numbers — this PR ships the instrumentation + re-launch, the on-box run
+records the result to `hwrun/results/rung5/t2-dict-bucket.txt`):
+
+1. **Stale engine pin.** `hwrun/rung5-launch.sh`/`rung5-remote.sh` defaulted `SHA=ef86e66`
+   — the PRE-consolidation commit. Re-running them would have re-measured the OLD serial
+   path. Default is now `origin/main`; the resolved commit is recorded to `engine-sha.txt`.
+2. **Mislabelled phase report.** On the sharded DEFAULT path, `SPARQ_BUILD_TIMING=1` printed
+   the now-PARALLEL intern / PIPELINED remap occupancy under the labels `merge_remap(serial)`
+   / `triple-remap(serial)` — so a reader would have compared overlapped per-stage occupancy
+   against the old ADDITIVE-serial ~200 s and drawn the wrong conclusion. The report now
+   distinguishes the path (`sparq_core` `build_timing::PathKind`): the sharded/spill paths
+   read `intern(parallel-occupancy)` / `triple-remap(pipelined-occupancy)` and surface the
+   serial consolidation step as its own `dict-consolidate(serial)` term (the `into_merged`
+   bucket — the interpretable dict-consolidation cost on the new path). The non-sharded
+   serial build keeps the honest `merge_remap(serial)` / `triple-remap(serial)` labels.
+
+**Status:** instrumentation + orchestration ready; the 1 B r7i.2xlarge run is launchable
+with `bash hwrun/rung5-launch.sh` (uses `AWS_PROFILE=pss`, self-terminating, tag
+`purpose=sparq-hw-validation`, dead-man `shutdown -h +150`). The on-box clone checks out
+`origin/main`, so the box must be run AFTER this fix merges (otherwise it rebuilds the
+mislabelled report). The dict-consolidation bucket number at 1 B real truthy on
+post-consolidation main is NOT YET recorded — when the box runs, capture `dict consolidate
+(into_merged)` + the `dict-consolidate(serial)` term from `t2-dict-bucket.txt` here and
+compare against the projected single-digit seconds.


### PR DESCRIPTION
> 🤖 SPARQ agent — implements bead **sq-3l43** (sparq-core / bench / perf).

## What the bead asked

Re-measure ONLY the serial dict-consolidation bucket at 1 B on a rung-5-class box, to confirm or refute the `dict-consolidation-verdict.md` projection of the ~200 s/1 B serial dict bucket down to single-digit seconds. The original ~200 s figure (`merge_remap(serial)` 137.9 s + `triple-remap(serial)` 62.2 s, `research/wikidata-ingestion-benchmark.md` "Rung 5 MEASURED") was taken at engine **`ef86e66`** — **before** the `dict-consolidation` branch parallelised the intern, pipelined the remap, and made the sharded dict the default.

## What I found (the load-bearing part)

The rung-5 orchestration *existed* (`hwrun/rung5-launch.sh` + `rung5-remote.sh`, already wired for `SPARQ_BUILD_TIMING=1`), but two defeaters made a re-measurement **uninterpretable** for this bead:

1. **Mislabelled phase report.** On the now-default *sharded* path, `SPARQ_BUILD_TIMING=1` printed the now-**parallel** intern / **pipelined** remap occupancy under the labels `merge_remap(serial)` / `triple-remap(serial)`. A reviewer comparing that overlapped per-stage occupancy against the old **additive-serial** ~200 s would draw the wrong conclusion. The serial `into_merged` consolidation — the interpretable dict-consolidation bucket on the new path — was emitted on a separate line and never folded into the report.
2. **Stale engine pin.** Both scripts defaulted `SHA=ef86e66`, the **pre-consolidation** commit, so a re-run would re-measure the *old* serial path.

## The change (smallest correct)

- `sparq_core` `build_timing::report` now takes a `PathKind`: the sharded default and the dict-spill path read `intern(parallel-occupancy)` / `triple-remap(pipelined-occupancy)` and surface the serial `into_merged` step as its own `dict-consolidate(serial)` term on the same line; the non-sharded serial build keeps the honest `merge_remap(serial)` / `triple-remap(serial)` (those buckets *are* additive-serial there). `report` is split into a pure, unit-tested `format_report`. `build_timing` is a **private** module.
- `hwrun/rung5-launch.sh` + `rung5-remote.sh`: default `SHA=origin/main`, record the resolved commit to `engine-sha.txt`, and extract the `[build-timing]` lines to `t2-dict-bucket.txt` (the bead's deliverable artifact).
- `research/wikidata-ingestion-benchmark.md`: new "Rung-5 dict-bucket re-measurement (sq-3l43)" subsection documenting the methodology + the two defeaters.

End-to-end smoke (built from this branch):
```
sharded:  parse(parallel) | intern(parallel-occupancy) | triple-remap(pipelined-occupancy) | dict-consolidate(serial) | wall
serial:   parse(parallel) | merge_remap(serial)        | triple-remap(serial)             |                          wall
```

## Public-API gate (G2) — corrected framing

**An earlier revision of this PR claimed "G2 N/A / all gates green". That was wrong: `public-api-skill (G2)` was FAILING.** G2 (`scripts/pub_api_diff.py`) is a *purely textual* `^[+-]\s*pub\s+(fn|struct|enum|…)` diff and does NOT resolve enclosing-module visibility, so it tripped on the bare `pub` on `PathKind` / `format_report` / `report` even though `build_timing` is a **private** module and those items export nothing.

Fix (`[OPUS-4.8]` commit `fix(sparq-core): pub(crate) the private build_timing items`):
- Downgraded `PathKind`, `format_report`, and `report` to `pub(crate)` — accurate (a private module makes them crate-reachable at most; grep confirms **nothing outside sparq-core references them**, and a private module cannot re-export them) and `pub(crate)` does not match the G2 `pub\s+` regex.
- The single remaining `pub `-matching diff line is the *net-removal* of the old `pub fn report(stage, secs)` signature, which the textual regex still counts as a public-item change. That is handled with the gate's designed `skill-not-needed` escape-hatch label — justified here because the module is private and **no real public surface changed**, so no `SKILL.md` edit is warranted.

After this, `public-api-skill (G2)` flips FAIL → PASS.

## Honesty / scope

**No fabricated numbers.** This PR ships the *correct, reproducible* instrumentation + re-launch wiring, NOT a measured 1 B figure. The on-box clone checks out `origin/main`, so the actual r7i.2xlarge run (`bash hwrun/rung5-launch.sh`, self-terminating, tag `purpose=sparq-hw-validation`, dead-man `shutdown -h +150`) must run **after** this merges — otherwise it rebuilds the mislabelled report. When it runs, the `dict-consolidate(serial)` term from `t2-dict-bucket.txt` gets recorded in the benchmark doc and compared against the projected single-digit seconds. The full 192-core validation remains the deferred sq-bj3.

## Gate

- `cargo build -p sparq-core` — green (default).
- `cargo clippy -p sparq-core --all-targets -- -D warnings` — green in **default**, **`mmap,dict-spill`**, and **`--no-default-features`**.
- `cargo test -p sparq-core` (default + `mmap,dict-spill`): all green incl. 3 `build_timing` label tests.
- `public-api-skill (G2)`: PASS (via the justified `skill-not-needed` label after the `pub(crate)` downgrade).
- `scripts/check-privacy-claims.sh`: OK.
- `bash -n` on both scripts: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
