### PR TITLE
docs(sparq-rsp-wasm): README push() term-syntax is Turtle, not N-Triples (sq-k2wy) [OPUS-4.8]

### DIFF
--- a/crates/sparq-rsp-wasm/README.md
+++ b/crates/sparq-rsp-wasm/README.md
@@ -54,7 +54,7 @@ window. Then:
 
 | method | returns | role |
 |---|---|---|
-| `push(s, p, o, ts)` | JSON array of closed-window `{start,end,results}` objects | feeds one timestamped triple; the terms are N-Triples syntax (`<iri>`, `"lit"`, `"3.0"^^<…#decimal>`, `"hi"@en`, `_:b`) |
+| `push(s, p, o, ts)` | JSON array of closed-window `{start,end,results}` objects | feeds one timestamped triple; the terms are Turtle syntax (`<iri>`, the numeric shorthand `10` / `10.5`, `"lit"`, `"3.0"^^<…#decimal>`, `"hi"@en`, `_:b`) |
 | `flush()` | same JSON array | end-of-stream: close every window up to the last `ts` seen (ignoring `maxDelay`) |
 | `lateDropped()` | `number` | arrivals dropped as too late (every covering window already closed) |
 | `sparql()` | `string` | the registered query text (echo, for the UI) |
@@ -65,8 +65,9 @@ JSON form (so the page hands `.results` to any SPARQL-JSON renderer). The window
 boundary inclusivity, sliding overlap, lateness, empty-window reporting, the R2S multiset
 diffs — are exactly [`sparq-rsp`'s](../sparq-rsp/README.md), pinned by that crate's tests;
 this bundle is a thin, zero-`unsafe` JS wrapper that owns no parsing or semantics of its own
-(triples are parsed via the engine's N-Triples path; results via the engine's SPARQL-JSON
-serialiser — the bundle carries no serde).
+(triples are parsed via the engine's Turtle path — chosen over N-Triples so the streaming demo
+can push the bare numeric shorthand `10` / `10.5` rather than the verbose `"10"^^<…#integer>`;
+results via the engine's SPARQL-JSON serialiser — the bundle carries no serde).
 
 This bundle exposes the single-window `ContinuousQuery` SELECT form (the streaming-rsp
 showcase). CONSTRUCT/ASK forms and multi-window joins (`ContinuousMultiQuery`) stay in the


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change for bead `sq-k2wy` (follow-up to `sq-nzcb`).

## What

The `sparq-rsp-wasm` README described `push(s, p, o, ts)` terms as **N-Triples** syntax in two places (the API table and the closing parenthetical), but the code parses **Turtle**:

```rust
// crates/sparq-rsp-wasm/src/lib.rs — parse_triple()
let (dict, triples) = Graph::parse_to_triples(&line, "turtle")
```

Turtle is chosen deliberately so the streaming demo can push the bare numeric shorthand `10` / `10.5` (parsed as `xsd:integer` / `xsd:decimal`). That is exactly the form the AVG quick-start earlier in the same README pushes — `q.push("<http://ex/s1>", "<http://ex/reading>", "10", 0)` — which would be **ill-formed under N-Triples** (N-Triples would require the verbose `"10"^^<…#integer>`). So the prose contradicted both the code and its own example.

## Change

Docs-only. Two README lines updated to say Turtle (matching the crate-level rustdoc and the `push()` rustdoc, which already said Turtle), and the numeric-shorthand rationale made explicit.

## Gate

- Docs-only change to `crates/sparq-rsp-wasm/README.md`; no Rust source, no public API, no privacy claims touched. README is not compiled.
- No predicate-form / soundness surface affected (no privacy-claim text changed).
- No G2 public-api → SKILL.md impact (no API change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)