### PR TITLE
docs(sparq-introspect/nlq/sim): concise-README rewrite to the template (sq-lsxd) [OPUS-4.8]

### DIFF
--- a/crates/sparq-introspect/README.md
+++ b/crates/sparq-introspect/README.md
@@ -1,167 +1,101 @@
 # sparq-introspect
 
-**Ontology / schema introspection** for the sparq RDF engine — an opt-in crate
-(GenAI phase 2, see [`research/genai-design.md`](../../research/genai-design.md) and
-[`research/genai-ontology-introspection.md`](../../research/genai-ontology-introspection.md))
-that mines the *effective schema* a knowledge graph actually uses, straight from the
-store's sorted permutation indexes. No models, no network, no extra state — and
-**no GROUP BY**: every statistic is a sorted scan over indexes the store already keeps.
+**Ontology / schema introspection** for the sparq RDF engine — an **opt-in** crate
+(GenAI phase 2) that mines the *effective schema* a knowledge graph actually uses,
+straight from the store's sorted permutation indexes. No models, no network, no extra
+state, and **no GROUP BY**: every statistic is a sorted scan over indexes the store
+already keeps. The output grounds NL→SPARQL prompts (budgeted text summaries; full JSON
+for machines) and doubles as planner-grade statistics (the characteristic-set table is
+a SOTA star-join cardinality estimator).
 
-The output grounds NL→SPARQL prompts (compact, budgeted text summaries; full JSON for
-machine consumption) and doubles as planner-grade statistics (the characteristic-set
-table is the SOTA star-join cardinality estimator — see the open beads for this crate, `bd list -l area:sparq-introspect`, for the wiring).
-
-## What it computes
-
-- **Characteristic sets** (Neumann & Moerkotte, ICDE 2011): one SPO scan groups
-  subjects by their *exact* predicate set — subjects are contiguous and predicates
-  sorted within each subject run, so the per-subject predicate list falls out of run
-  boundaries. Each distinct set carries its subject count, per-predicate triple counts
-  (avg multiplicity = `predicate_triples[i] / subjects`), and the `rdf:type` histogram
-  of its subjects (the declared classes behind the emergent entity type).
-- **Schema summary**:
-  - classes (`rdf:type` objects) with instance counts;
-  - per-class predicate usage: which predicates appear on instances of each class,
-    with subject/triple counts and **coverage ratios**;
-  - per-predicate global stats: triples, distinct subjects/objects, literal-vs-IRI
-    object split, datatype distribution, deterministic sample values (the first sample
-    is the predicate's *minimum* object value — sorted indexes give min/max for free);
-  - **observed domain/range**: the most-common subject/object classes per predicate,
-    inferred from usage, alongside any **declared** `rdfs:domain`/`rdfs:range` present
-    (real KGs are under-declared and mis-typed; usage wins, both are reported).
-- **Vocabulary detection**: namespaces in use (IRIs split at the last `#`/`/` — the
-  split the dictionary itself stores) with distinct-term counts, recognised against a
-  bundled offline table of well-known vocabularies (rdf/rdfs/owl/xsd/foaf/skos/
-  schema.org/dcterms/wd/dbo/…).
-
-## API
+## 🚀 Quickstart
 
 ```rust
 use sparq_introspect::{Introspection, BuildOptions};
 
 let ix = Introspection::build(&graph);              // or build_with(&graph, &BuildOptions{..})
 
-ix.classes        // Vec<ClassProfile>      — by instance count, with per-class usage
-ix.predicates     // Vec<PredicateProfile>  — global stats + observed/declared domain/range
-ix.characteristic_sets  // CharacteristicSets — top sets + exact tail aggregates
-ix.join_hints     // JoinHints              — cross-class (C, p, D) edges + triple counts
-ix.entities       // u64                    — distinct typed subjects (the void:entities count)
-ix.vocabularies   // Vocabularies           — namespaces + well-known recognition
+ix.classes              // Vec<ClassProfile>      — by instance count, with per-class usage
+ix.predicates           // Vec<PredicateProfile>  — global stats + observed/declared domain/range
+ix.characteristic_sets  // CharacteristicSets     — top sets + exact tail aggregates
+ix.join_hints           // JoinHints              — cross-class (C, p, D) edges + triple counts
+ix.entities             // u64                    — distinct typed subjects (void:entities)
+ix.vocabularies         // Vocabularies           — namespaces + well-known recognition
 
-ix.to_json()                          // pretty JSON — the machine surface for LLM grounding
-ix.to_text_summary(2500)              // prompt-ready digest, most-important-first, ≤ 2500 chars
-ix.to_void("http://ex.org/dataset")   // W3C VoID description, as N-Triples (valid Turtle)
-ix.to_void_with_cs("http://ex.org/dataset") // VoID + characteristic-set source stats (scs: ext)
-ix.schema_summary_for(&seeds, 2500)   // retrieval-mode: schema scoped to seed class/predicate IRIs
+ix.to_json()                                  // pretty JSON — the machine surface for LLMs
+ix.to_text_summary(2500)                      // prompt-ready digest, most-important-first, ≤ N chars
+ix.to_void("http://ex.org/dataset")           // W3C VoID description, as N-Triples (valid Turtle)
+ix.to_void_with_cs("http://ex.org/dataset")   // VoID + characteristic-set source stats (scs: ext)
+ix.schema_summary_for(&seeds, 2500)           // retrieval-mode: schema scoped to seed IRIs
 ```
 
-`to_text_summary(budget_chars)` renders: header totals → prefix glossary (exactly the
-namespaces the body uses; well-known prefixes, `nsN` otherwise, assigned in first-use
-order) → classes with per-class coverage + range hints + samples → characteristic-set
-patterns → global predicate stats. Lines are dropped greedily at the budget; a final
-`…` marks elision. Range/sample hints in the class section come from the predicate's
-*global* profile (the per-class numbers are exact; hints are hints).
+## ✨ Features
 
-**VoID export** (`to_void(dataset_iri)`): a [W3C VoID](https://www.w3.org/TR/void/)
-description as N-Triples (a subset of Turtle, so it parses as either — no serializer
-dependency). The `void:Dataset` carries `void:triples`, `void:entities` (distinct typed
-subjects), `void:distinctSubjects`, `void:classes`, `void:properties` (all exact), plus
-a `void:classPartition` per class (`void:class` + `void:entities`) and a
-`void:propertyPartition` per predicate (`void:property` + `void:triples` +
-`void:distinctSubjects`). `void:distinctObjects` is **not** emitted — the crate tracks
-distinct objects only per-predicate (mixed IRI/literal), never a global de-duplicated
-count, so a faithful figure would need an extra pass; omitted rather than misleading.
-
-**VoID + characteristic-set source stats** (`to_void_with_cs(dataset_iri)`, sq-mr32,
-federation A3/Z2): a strict superset of `to_void` — every standard VoID triple unchanged —
-followed by the mined characteristic sets, expressed under a documented sparq extension
-vocab `scs:` (`<http://sparq.dev/ns/cs#>`). VoID has no native term for per-entity-type
-predicate co-occurrence, so this is the served federation-descriptor surface that primes a
-remote CostFed/Odyssey-class source-selector with star/multi-join cardinalities the bare
-property-partition counts cannot give. Per retained set: `scs:characteristicSet` links the
-dataset to a typed `scs:CharacteristicSet` node carrying `scs:subjects` (`count(C)`) and one
-`scs:predicateStat` per predicate (reusing `void:property`/`void:triples`, plus
-`scs:avgMultiplicity` = `predicate_triples / subjects`); the EXACT distinct-set count rides
-on `scs:distinctCharacteristicSets`. The sparq HTTP server serves this at
-`GET /.well-known/void` behind the OPT-IN `federation-descriptors` feature + flag.
-
-**Cross-class join hints** (`ix.join_hints`): the `(subject_class) --predicate-->
-(object_class)` edge table with per-edge triple counts, mined in the *same* SPO scan as
-the characteristic sets (one object-type lookup per triple; only typed-subject→typed-
-object triples contribute). Top edges by triple count, capped at
-`BuildOptions::max_join_hints` with exact tail aggregates — the join-cardinality signal
-beyond the per-predicate global observed range.
-
-**Retrieval-mode summary** (`schema_summary_for(seeds, budget)`): a seed-scoped digest
-for KGs whose full schema overflows a prompt (the 10k-property-KG path). Each seed IRI
-is matched against the mined schema — a **class** seed pulls its per-predicate profile
-plus the cross-class join edges it touches; a **predicate** seed pulls its global
-profile — and only that slice is rendered under the budget. Struct-level scoping (it
-filters the already-mined profiles by IRI, no re-scan), so it does not chase the
-*instances* of a seed entity.
-
-## Cost model
-
-One full SPO scan (characteristic sets, per-class usage, observed domains), one pass
-over every predicate's POS block (object kinds, datatypes, samples, observed ranges —
-type lookups once per *distinct* object), two range scans for declared domain/range,
-one dictionary pass (vocabularies). `O(|G| + |dict|)` time, output-sized memory plus
-the subject→types map.
+- **Characteristic sets** (Neumann & Moerkotte, ICDE 2011) — one SPO scan groups
+  subjects by their *exact* predicate set; each distinct set carries its subject count,
+  per-predicate triple counts (avg multiplicity = `predicate_triples[i] / subjects`),
+  and the `rdf:type` histogram of its subjects. Top sets retained, exact tail aggregates.
+- **Schema summary** — classes with instance counts; per-class predicate usage with
+  subject/triple counts and **coverage ratios**; per-predicate global stats (triples,
+  distinct subjects/objects, literal-vs-IRI split, datatype distribution, deterministic
+  sample values); and **observed domain/range** (most-common subject/object classes,
+  inferred from usage) alongside any **declared** `rdfs:domain`/`rdfs:range` — real KGs
+  are under-declared and mis-typed, so usage wins and both are reported.
+- **Cross-class join hints** — the `(subject_class) --predicate--> (object_class)` edge
+  table with per-edge triple counts, mined in the *same* SPO scan as the characteristic
+  sets; top edges by triple count, capped with exact tail aggregates.
+- **Text summary** (`to_text_summary(budget_chars)`) — header totals → prefix glossary
+  (only the namespaces the body uses; well-known prefixes, `nsN` otherwise) → classes
+  with coverage + range hints + samples → characteristic-set patterns → predicate stats.
+  Lines drop greedily at the budget; a final `…` marks elision.
+- **VoID export** (`to_void`) — a [W3C VoID](https://www.w3.org/TR/void/) description as
+  N-Triples (parses as Turtle too — no serializer dep), with exact `void:triples`,
+  `void:entities`, `void:distinctSubjects`, `void:classes`, `void:properties`, plus a
+  `void:classPartition` and `void:propertyPartition` each. `void:distinctObjects` is
+  **not** emitted — omitted rather than misleading (no global de-duplicated count kept).
+- **VoID + characteristic-set source stats** (`to_void_with_cs`, federation A3/Z2) — a
+  strict superset of `to_void`, then the mined sets under a documented sparq extension
+  vocab `scs:` (`<http://sparq.dev/ns/cs#>`); the served federation-descriptor surface
+  that primes a remote CostFed/Odyssey-class source-selector with star/multi-join
+  cardinalities. Served at `GET /.well-known/void` behind the opt-in
+  `federation-descriptors` feature.
+- **Vocabulary detection** — namespaces in use (split at the last `#`/`/`, the split the
+  dictionary stores) with distinct-term counts, recognised against a bundled offline
+  table (rdf/rdfs/owl/xsd/foaf/skos/schema.org/dcterms/wd/dbo/…).
+- **Retrieval-mode summary** (`schema_summary_for(seeds, budget)`) — a seed-scoped digest
+  for KGs whose full schema overflows a prompt; filters the already-mined profiles by IRI
+  (no re-scan).
+- **Cost & zero impact** — `O(|G| + |dict|)` time, output-sized memory plus the
+  subject→types map. Separate opt-in crate: no core crate depends on it, the default
+  build does not compile it, and it is read-only over `sparq-core`'s public scan surface
+  (works against raw, mmap'd, and compressed storage).
 
 ## Measured results
 
-The `olympics_introspect` example reports load / `Introspection::build` / `to_json` /
-`to_text_summary` time over the olympics (1.78M triples) and qlever-synthetic (10M)
-fixtures. Run it for the numbers (fixture paths via `SPARQ_OLYMPICS_NT` /
-`SPARQ_SYNTHETIC_NT`) — the tracked figures live on the perf dashboard
-(<https://jeswr.github.io/sparq/dev/bench>):
+The `olympics_introspect` example reports load / build / `to_json` / `to_text_summary`
+time over the olympics (1.78M triples) and qlever-synthetic (10M) fixtures (paths via
+`SPARQ_OLYMPICS_NT` / `SPARQ_SYNTHETIC_NT`). The design-doc §4 gates: the introspection
+scan stays within dataset load time; summary generation is quick relative to that load;
+and the olympics summary names the dataset's actual classes (asserted by
+`tests/olympics.rs`). Tracked figures live on the perf dashboard.
 
 ```sh
 cargo run -p sparq-introspect --example olympics_introspect --release
 ```
 
-The design-doc §4 gates it enforces: the full introspection scan stays within dataset
-load time; summary generation is quick relative to that load (see the perf dashboard for timings); and the olympics text
-summary names the dataset's actual classes (foaf:Person, dbo:SportsEvent,
-dbo:SportsTeam, dbo:Olympics, …) — asserted by `tests/olympics.rs`.
+Tests: 14 unit (`src/lib.rs`: characteristic-set exactness, coverage, object
+kinds/datatypes/samples, observed-vs-declared domain/range, vocabularies, JSON validity,
+text-summary budget, join hints, VoID export, retrieval mode) plus 1 integration
+(`tests/olympics.rs`, skip-if-absent at 1.78M scale).
 
-Olympics summary excerpt (budget 2500):
+## 📚 Learn more
 
-```text
-# Schema summary — 1781625 triples, 406700 subjects, 8 classes, 16 predicates, 15 entity patterns
-## Prefixes
-foaf: http://xmlns.com/foaf/0.1/ — FOAF (people & agents) (3 terms)
-dbo: http://dbpedia.org/ontology/ — DBpedia ontology (10 terms)
-ns1: http://wallscope.co.uk/resource/olympics/team/ (1184 terms)
-…
-## Classes (by instance count)
-### foaf:Person — 134730 instances
-- dbo:team — 134730/134730 subjects (100%) → dbo:SportsTeam, e.g. ns1:Malaysia
-- rdfs:label — 134730/134730 subjects (100%) → rdf:langString, e.g. "A. Aanantha Sambu Mayavo"@en
-- foaf:age — 128429/134730 subjects (95%, avg 1.4/subj) → xsd:int, e.g. "26"
-…
-### dbo:SportsEvent — 765 instances
-- rdfs:subClassOf — 765/765 subjects (100%) → dbo:Sport, e.g. ns3:Aeronautics
-…
-```
+- Design records: [`research/genai-design.md`](../../research/genai-design.md),
+  [`research/genai-ontology-introspection.md`](../../research/genai-ontology-introspection.md)
+- W3C VoID: <https://www.w3.org/TR/void/>
+- Perf dashboard: <https://jeswr.github.io/sparq/dev/bench>
+- Open work for this crate: `bd list -l area:sparq-introspect`
 
-## Tests
+## License
 
-- 14 unit tests (`src/lib.rs`): characteristic-set exactness (counts, multiplicities,
-  partition of subjects, cap aggregation), class instance counts + coverage, object
-  kinds/datatypes/samples (incl. inline integers and language tags), observed-vs-
-  declared domain/range, vocabulary counts + well-known recognition, JSON validity,
-  text-summary budget/truncation/content, empty + typeless graphs, cross-class join
-  hints (exact edge counts + cap aggregation), VoID export (exact counts + re-parses as
-  N-Triples), and the retrieval-mode seed-scoped summary (matched/unmatched seeds,
-  budget).
-- 1 integration test (`tests/olympics.rs`): the design-doc gate at 1.78M-triple scale —
-  skips (passes with a note) when the fixture is absent; override the path with
-  `SPARQ_OLYMPICS_NT`.
-
-## Zero impact
-
-Separate opt-in crate: no core crate depends on it, the default build does not compile
-it, and it is read-only over `sparq-core`'s public API (`Graph::id_of`, `store.scan`/
-`scan_sorted`, `dict.term_parts`). Works against every storage mode (raw, mmap'd,
-compressed) because it only uses the public scan surface.
+MIT. [OPUS-4.8] sq-lsxd

--- a/crates/sparq-nlq/README.md
+++ b/crates/sparq-nlq/README.md
@@ -1,81 +1,31 @@
 # sparq-nlq
 
-**Natural-language questions → SPARQL** over a sparq graph — an opt-in crate (GenAI
-phase 3, see [`research/genai-design.md`](../../research/genai-design.md)) built as a
-deliberately **lean loop** (the SPARQL-LLM research finding the design adopts:
-retrieve + repair beats sprawling agents). Nothing in the workspace depends on this
-crate; the default build does not compile it, and the engine carries zero GenAI code.
+**Natural-language questions → SPARQL** over a sparq graph — an **opt-in** crate
+(GenAI phase 3) built as a deliberately **lean loop** (retrieve + repair beats sprawling
+agents). Nothing in the workspace depends on it; the default build does not compile it,
+and the engine carries zero GenAI code.
 
-## The loop
+The loop: **GROUND** (`sparq_introspect::to_text_summary(budget)` + few-shot examples +
+the question) → **GENERATE** (`Llm::complete`) → **VALIDATE** (extract the ` ```sparql `
+block, `spargebra` parse) → on parse error **REPAIR** (error + failed query back to the
+LLM, ≤ N rounds) → on parse success **EXECUTE** (`sparq_engine::query_with_budget`) → on
+exec error repair, else return `Answer { sparql, result, repairs, transcript }`.
 
-```text
-         ┌──────────────────────────────────────────────────────┐
-         │ GROUND   sparq_introspect::to_text_summary(budget)   │
-         │          + few-shot examples + the question          │
-         └───────────────────────────┬──────────────────────────┘
-                                     ▼
-         ┌──────────────────────────────────────────────────────┐
-   ┌────▶│ GENERATE Llm::complete(prompt) -> completion         │
-   │     └───────────────────────────┬──────────────────────────┘
-   │                                 ▼
-   │     ┌──────────────────────────────────────────────────────┐
-   │     │ VALIDATE extract ```sparql block, spargebra parse    │
-   │     └───────────┬──────────────────────────┬───────────────┘
-   │           parse error                  parses
-   │                 │                          ▼
-   │     ┌───────────┴───────────┐  ┌──────────────────────────┐
-   └─────┤ REPAIR (≤ N rounds:   │  │ EXECUTE sparq_engine::   │
-   ▲     │ error + failed query  │  │ query_with_budget        │
-   │     │ back to the LLM)      │  └────────────┬─────────────┘
-   │     └───────────────────────┘     exec error│        ok
-   └──────────────────────────────────◀──────────┘         ▼
-                                           Answer { sparql, result,
-                                                    repairs, transcript }
-```
-
-- **Grounding** is the introspect crate's token-budgeted schema summary — exact
-  counts mined from the store's permutation indexes, not guesses — plus two
-  schema-agnostic few-shot examples.
-- **Validation** parses with `spargebra` *before* the engine sees the query, so the
-  repair round gets a real parser error message. Execution failures (unsupported
-  forms, `QueryBudget` trips) are repair signals too.
-- **Execution** always runs under a [`QueryBudget`] — LLM-generated queries are
-  untrusted input. The default is **bounded** (10 s wall clock, 1M materialised
-  rows); opting out requires setting `exec_timeout` / `max_rows` to `None`
-  explicitly.
-- The returned `Answer` carries the final query, the materialised result, the repair
-  count and the **full transcript** (every prompt/completion with its outcome) — the
-  transcript is the provenance of the answer.
-
-## The `Llm` trait — record/replay, offline CI
-
-```rust
-pub trait Llm {
-    fn complete(&self, prompt: &str) -> Result<String, String>;
-}
-```
-
-| Impl | Role |
-|---|---|
-| `ReplayLlm` | Serves recorded prompt→completion pairs from a JSON fixture — **the CI path**. Exact-prompt match (prompts are deterministic); misses produce a diagnosable error. |
-| `RecordingLlm<L>` | Wraps any backend, records every exchange, `save()`s the fixture. |
-| `AnthropicLlm` | Thin blocking client for the Anthropic Messages API (`POST /v1/messages`), behind the **non-default `live` feature**. Model id is configurable, default `claude-sonnet-4-6`; key from `ANTHROPIC_API_KEY`. |
-
-## Usage — replay (offline, what the tests do)
+## 🚀 Quickstart
 
 ```rust
 use sparq_nlq::{Nlq, ReplayLlm};
 
+// Offline / CI path: serve recorded prompt→completion pairs from a fixture.
 let replay = ReplayLlm::from_file("tests/fixtures/olympics_replay.json")?;
 let nlq = Nlq::new(&graph, Box::new(replay));
 let answer = nlq.ask("How many athletes are on each team?")?;
 println!("{}\n{} rows, {} repair(s)", answer.sparql, answer.result.len(), answer.repairs);
 ```
 
-## Usage — live (opt-in, network)
-
 ```sh
-cargo add sparq-nlq --features live   # or: features = ["live"] in Cargo.toml
+# Live path (opt-in, network): the non-default `live` feature + an API key.
+cargo add sparq-nlq --features live
 export ANTHROPIC_API_KEY=sk-ant-...
 ```
 
@@ -84,103 +34,80 @@ use std::rc::Rc;
 use sparq_nlq::{live::AnthropicLlm, Nlq, NlqConfig, RecordingLlm};
 
 let llm = Rc::new(RecordingLlm::new(AnthropicLlm::from_env()?)); // record while you go
-let nlq = Nlq::with_config(&graph, Box::new(Rc::clone(&llm)), NlqConfig {
-    max_repair_rounds: 3,                       // design-doc cap for live runs
-    ..NlqConfig::default()
-});
+let nlq = Nlq::with_config(&graph, Box::new(Rc::clone(&llm)),
+    NlqConfig { max_repair_rounds: 3, ..NlqConfig::default() });
 let answer = nlq.ask("Which team has the most athletes?")?;
 llm.save("my_session.json")?;                   // replayable fixture for later
 ```
 
-`Nlq::prompt_for` / `repair_prompt_for` are public and deterministic, so fixtures can
-be constructed and inspected outside the loop.
+## ✨ Features
 
-## Eval harness — measured results
+- **Grounded generation** — the introspect crate's token-budgeted schema summary (exact
+  counts from the store's permutation indexes, not guesses) plus two schema-agnostic
+  few-shot examples.
+- **Validate before execute** — parses with `spargebra` *before* the engine sees the
+  query, so the repair round gets a real parser error; execution failures (unsupported
+  forms, `QueryBudget` trips) are repair signals too.
+- **Budgeted execution** — LLM-generated queries are untrusted input, so every query runs
+  under a [`QueryBudget`]. The default is **bounded** (10 s wall clock, 1M materialised
+  rows); opting out requires setting `exec_timeout` / `max_rows` to `None` explicitly.
+- **Full provenance** — the returned `Answer` carries the final query, the materialised
+  result, the repair count, and the **full transcript** (every prompt/completion with its
+  outcome). `Nlq::prompt_for` / `repair_prompt_for` are public and deterministic, so
+  fixtures can be built and inspected outside the loop.
+- **`Llm` trait — record/replay, offline CI** — `fn complete(&self, prompt: &str) ->
+  Result<String, String>`. `ReplayLlm` serves recorded pairs (exact-prompt match — the CI
+  path); `RecordingLlm<L>` wraps any backend and `save()`s the fixture; `AnthropicLlm` is
+  a thin blocking client for the Messages API behind the non-default `live` feature
+  (model id configurable, default `claude-sonnet-4-6`; key from `ANTHROPIC_API_KEY`).
+- **Exec-accuracy harness** ([`eval`](src/eval.rs)) — grades the executed SPARQL the QALD
+  way (**answer-set F1**, not query-string equality) by running candidate and a **gold**
+  query on the *same* graph; the gold answer is recomputed live (no checked-in answer blob
+  to drift). Reports two axes separately: **linking** (oracle vs end-to-end) and
+  **grounding** (grounded vs ungrounded baseline). `Comparison::headline_grounding_pays()`
+  is the load-bearing check: grounded end-to-end macro-F1 **>** the *same LLM* ungrounded.
 
-`tests/olympics_eval.rs` is the design doc's accuracy-gate scaffold: it drives the
-full loop against the real olympics dataset (1.78M triples,
-`bench/qlever-olympics/olympics.nt`, skip-if-absent) with `ReplayLlm` serving the
-committed fixture — 9 hand-written NL→SPARQL pairs over the olympics schema,
-realistic completions (only vocabulary visible in the grounding prompt), including
-**one deliberate parse failure that exercises the repair round**.
+## Honest status — what is and is not measured
 
-What the harness measures and gates (run it, or see the perf dashboard at
-<https://jeswr.github.io/sparq/dev/bench>, for the absolute figures):
+- **Validated offline (the CI gate)**: the engine-side loop — grounding, extraction,
+  `spargebra` validation, budgeted execution, repair plumbing, record/replay — end-to-end
+  against real data; **and** the exec-accuracy harness itself (answer-F1 scoring,
+  oracle-vs-end-to-end / grounded-vs-ungrounded reporting, the "grounding pays" inequality),
+  proven deterministically on an in-memory graph with scripted backends and on the olympics
+  dataset when present (committed grounded fixture). The record→`save`→`from_file`→
+  identical-scores round-trip is itself CI-gated, so a committed live session is guaranteed
+  replayable.
+- **NOT yet measured against a real model**: live-model exec-accuracy *numbers*. The
+  in-memory and olympics scores use scripted / recorded completions — they demonstrate the
+  *harness* and the *mechanism* of the headline claim, **not** a real model's accuracy. The
+  live path (`live_exec_accuracy`, `#[cfg(feature = "live")]` **and** `#[ignore]`'d) needs a
+  real key, the olympics dump, and a **canonical** measurement host (not a CI/sandbox box) —
+  open work in bead `sq-g0lw`.
+- **Not yet wired**: entity/relation linking from `sparq-sim` (bead `sq-uw40`) and
+  N2 grammar-constrained decoding against the live dictionary (bead `sq-9yjp`).
+- `AnthropicLlm` is compile-checked in CI (`--features live`) but never called there; no
+  test touches the network. <!-- [OPUS-4.8] sq-05rv sq-g0lw -->
 
-| Metric | What it checks |
-|---|---|
-| Parse success (after ≤1 repair) | every fixture pair parses |
-| Execution success | every fixture pair executes |
-| Result sanity | non-empty + exact row counts + spot-checked values |
-| Repair rounds used | the one scripted malformed query exercises a repair |
-| LLM-excluded `ask()` latency | gated low (the recorded p50/max print from the example below) |
+## Measured results
 
-Re-record the fixture whenever the prompt template, default `NlqConfig`, or dataset
-changes:
-
-```sh
-cargo run -p sparq-nlq --example record_olympics --release
-```
-
-## Exec-accuracy harness — answer-F1, oracle vs end-to-end, grounded vs not
-
-The [`eval`](src/eval.rs) module (`tests/exec_accuracy.rs`) is the design doc's
-accuracy gate (`research/genai-design.md` §4, `sparq-nlq` row): it grades the executed
-SPARQL the QALD way — **answer-set F1**, not query-string equality — by executing both
-the candidate query and a **gold query** on the *same* graph and comparing the
-resulting bind-row sets (`AnswerSet`). The gold answer is recomputed live from the gold
-query, so there is no checked-in answer blob to drift
-(`research/genai-nl-to-sparql.md` §4.3).
-
-It reports the two axes the design doc requires **separately**:
-
-| Axis | Values |
-|---|---|
-| Linking | **oracle** (the correct query is given — isolates the engine-side validate→execute→repair loop) vs **end-to-end** (the model writes the query) |
-| Grounding | **grounded** (`NlqConfig::ground = true`, the schema deck in the prompt) vs the **ungrounded baseline** (`false`, no deck) |
-
-`Comparison::headline_grounding_pays()` is the load-bearing check: grounded end-to-end
-macro-F1 **>** the *same LLM* ungrounded ("the grounding must pay for itself").
-
-Four layers, the first three run in CI with **no network**:
-
-| Layer | What | Runs in CI? |
-|---|---|---|
-| `harness_demonstrates_grounding_pays_in_memory` | tiny in-memory graph + scripted backends (a grounded model that answers from the deck; an ungrounded one that hallucinates a predicate) — proves the harness and the headline inequality | yes, always |
-| `recorded_session_saves_and_replays_as_regression_set` | the **regression-set round-trip**: record a session, `RecordingLlm::save` it to disk in the `live_session_*.json` format, reload via `ReplayLlm::from_file`, re-score through `run_config` — and assert the scores are identical. Proves a saved live session replays faithfully (so "commit the recorded session as the regression set" is sound) | yes, always |
-| `olympics_exec_accuracy_replay` | answer-F1 on the real 1.78M-triple olympics dataset via the committed `ReplayLlm` fixture + oracle linking | yes, **skip-if-absent** dataset |
-| `live_exec_accuracy` | the real measurement: a live model via `--features live` + `RecordingLlm`, records replay fixtures, asserts the inequality | **no** — `#[cfg(feature = "live")]` **and** `#[ignore]`'d |
-
-Run the live measurement explicitly (network + key + dataset):
+The eval harnesses run in CI with no network and gate parse/execution success, result
+sanity, repair-round use, and LLM-excluded `ask()` latency. Re-record fixtures whenever the
+prompt template, default `NlqConfig`, or dataset changes; run the live measurement
+explicitly with a key + dataset. Tracked figures live on the perf dashboard.
 
 ```sh
-ANTHROPIC_API_KEY=sk-ant-... SPARQ_OLYMPICS_NT=/path/olympics.nt \
-  cargo test -p sparq-nlq --features live --release -- --ignored live_exec_accuracy
+cargo run  -p sparq-nlq --example record_olympics --release
+cargo test -p sparq-nlq --features live --release -- --ignored live_exec_accuracy  # network + key
 ```
 
-## Honest status
+## 📚 Learn more
 
-- **What is validated offline (the CI gate)**: the engine-side loop — grounding,
-  extraction, spargebra validation, budgeted execution, repair plumbing, record/replay
-  — end-to-end against real data; **and** the exec-accuracy harness itself: answer-F1
-  scoring, oracle-vs-end-to-end and grounded-vs-ungrounded reporting, and the
-  "grounding pays for itself" inequality, proven deterministically on an in-memory
-  graph with scripted backends (and on the olympics dataset when present, via the
-  committed grounded fixture).
-- **What is NOT yet measured against a real model**: live-model exec-accuracy
-  *numbers*. The in-memory and olympics scores use scripted / recorded completions, so
-  they demonstrate the *harness* and the *mechanism* of the headline claim, **not** a
-  real model's accuracy. The live measurement runs through the same harness with
-  `--features live` + `RecordingLlm` (`live_exec_accuracy`, `#[ignore]`'d); after a
-  live run the recorded sessions become the offline regression set — and that
-  record→`save`→`from_file`→identical-scores round-trip is itself CI-gated by
-  `recorded_session_saves_and_replays_as_regression_set`, so a committed live session
-  is guaranteed replayable. Producing the live *numbers* needs a real key, the olympics
-  dump, and a **canonical** measurement host (not a CI/sandbox box); that run remains
-  the open work of bead `sq-g0lw`. <!-- [OPUS-4.8] sq-05rv sq-g0lw -->
-- **Not yet wired**: entity/relation linking from `sparq-sim` (design §2 phase 3
-  lists it as input to grounding; the schema summary alone is enough for the
-  olympics-scale schema) — bead `sq-uw40`; and N2 grammar-constrained decoding
-  against the live dictionary — bead `sq-9yjp`. <!-- [OPUS-4.8] -->
-- `AnthropicLlm` is compile-checked in CI (`--features live`) but never called there;
-  no test touches the network.
+- Design records: [`research/genai-design.md`](../../research/genai-design.md) (§4),
+  [`research/genai-nl-to-sparql.md`](../../research/genai-nl-to-sparql.md) (§4.3)
+- Schema grounding: [`sparq-introspect`](../sparq-introspect)
+- Perf dashboard: <https://jeswr.github.io/sparq/dev/bench>
+- Open work for this crate: `bd list -l area:sparq-nlq`
+
+## License
+
+MIT. [OPUS-4.8] sq-lsxd

--- a/crates/sparq-sim/README.md
+++ b/crates/sparq-sim/README.md
@@ -1,29 +1,11 @@
 # sparq-sim
 
-**Training-free structural entity similarity** for the sparq RDF engine — an opt-in
-crate (GenAI phase 1, see [`research/genai-design.md`](../../research/genai-design.md))
-that computes similarity straight from the store's existing permutation indexes. No
-embeddings, no models, no network, no extra state: the indexes ARE the feature store,
-so similarity stays correct under incremental updates for free.
+**Training-free structural entity similarity** for the sparq RDF engine — an **opt-in**
+crate (GenAI phase 1) that computes similarity straight from the store's existing
+permutation indexes. No embeddings, no models, no network, no extra state: the indexes
+ARE the feature store, so similarity stays correct under incremental updates for free.
 
-## How it works
-
-- **Signature**: an entity's structural signature is its set of
-  `(direction, predicate, neighbor)` pairs — outgoing from one SPO range scan,
-  incoming from one OSP/OPS range scan. Cost `O(log n + degree)`.
-- **Similarity**: predicate-IDF-weighted Jaccard over two signatures
-  (`w(e) = 1 + ln(|G| / freq(pred))`, frequencies from the store's existing planner
-  stats) — sharing a rare predicate counts for more than sharing `rdf:type`.
-- **`most_similar(a, k)`**: candidate generation through the indexes, **not a full
-  scan** — each signature element's co-owners are one contiguous index range (POS for
-  outgoing `(p, n)`, SPO for incoming). Candidates accumulate shared-element weight
-  (an intersection upper bound); the top `max(4k, 64)` are re-scored exactly.
-  Complexity `O(Σ_e min(freq(e), F))` for generation plus `O(M·(log n + d̄))` for
-  re-scoring. Elements matched by more than `F = max_pair_frequency` triples (hubs —
-  the lowest-IDF, least informative) are skipped during *generation only*; re-scoring
-  is always exact. Set the cap to `usize::MAX` for exact-but-slower generation.
-
-## API
+## 🚀 Quickstart
 
 ```rust
 use sparq_sim::{Sim, SimConfig, SignatureMode, weighted_jaccard};
@@ -43,83 +25,78 @@ sim.similar_by_signature(&sig, 10);      // probe with an arbitrary signature
 weighted_jaccard(&sig_a, &sig_b);        // for callers that cache signatures
 ```
 
-Two signature modes, two notions of similarity:
+## ✨ Features
 
-- `PredicateNeighbor` (default): similar = **shares concrete context** (same team,
-  same games, same birthplace). This is the mode `most_similar`'s index-driven
-  candidate generation is built around.
-- `Predicates`: similar = **used the same way** (predicate profile / role similarity —
-  two Sports share no concrete neighbor, but their profiles are near-identical).
+- **Structural signature** — an entity's signature is its set of
+  `(direction, predicate, neighbor)` pairs (outgoing from one SPO range scan, incoming
+  from one OSP/OPS scan), cost `O(log n + degree)`.
+- **IDF-weighted Jaccard** — `w(e) = 1 + ln(|G| / freq(pred))`, frequencies from the
+  store's existing planner stats, so sharing a rare predicate counts for more than
+  sharing `rdf:type`.
+- **Index-driven `most_similar(a, k)`** — candidate generation through the indexes, **not
+  a full scan**: each signature element's co-owners are one contiguous index range.
+  Candidates accumulate a shared-element weight (intersection upper bound); the top
+  `max(4k, 64)` are re-scored exactly. Generation skips hub elements matched by more than
+  `F = max_pair_frequency` triples (the lowest-IDF, least informative); re-scoring is
+  always exact. Set the cap to `usize::MAX` for exact-but-slower generation.
+- **Two signature modes** — `PredicateNeighbor` (default): similar = **shares concrete
+  context** (same team, same games), the mode candidate generation is built around.
+  `Predicates`: similar = **used the same way** (predicate profile / role similarity).
+- **Neighbor-sparse profile fallback** (`SimConfig::profile_fallback`, default on) — for
+  classes where every entity names a unique neighbor (no two share concrete context), the
+  fallback fills starved slots with role-profile matches, recovering near-full precision
+  for a small per-query latency cost.
+- **Hybrid search with text vectors** — structural similarity knows how entities are
+  *connected*, not what their labels *mean*. The opt-in
+  [`sparq-vectors`](../sparq-vectors) crate covers the text side and ships dependency-free
+  fusion helpers, so the two signals combine without either crate depending on the other:
 
-## How to: hybrid search with text vectors
+  ```rust
+  use sparq_sim::Sim;
+  use sparq_vectors::{fuse_rrf, RRF_K};
 
-Structural similarity knows how entities are *connected*; it knows nothing about
-what their labels and descriptions *mean* (two differently-modeled descriptions of
-the same person share no structure). The opt-in [`sparq-vectors`](../sparq-vectors)
-crate covers the text side — `embed_entities` embeds a passage per entity
-(label + type + description, configurable) — and ships dependency-free fusion
-helpers, so the two signals combine without either crate depending on the other:
+  let structural = Sim::new(&graph).most_similar(&query, 50);
+  let text: Vec<(_, f64)> = index.nearest_term(&query, &graph, &store, 50)
+      .into_iter().map(|(t, s)| (t, s as f64)).collect();
+  // Reciprocal Rank Fusion: rank-based, no score normalization needed.
+  let hybrid = fuse_rrf(&[&text, &structural], RRF_K, 10);
+  ```
 
-```rust
-use sparq_sim::Sim;
-use sparq_vectors::{fuse_rrf, RRF_K};
-
-let structural: Vec<(Term, f64)> = Sim::new(&graph).most_similar(&query, 50);
-let text: Vec<(Term, f64)> = index // sparq_vectors::VectorIndex
-    .nearest_term(&query, &graph, &store, 50)
-    .into_iter().map(|(t, s)| (t, s as f64)).collect();
-
-// Reciprocal Rank Fusion: rank-based, no score normalization needed
-// (weighted Jaccard in [0,1] and cosine in [-1,1] fuse as-is).
-let hybrid = fuse_rrf(&[&text, &structural], RRF_K, 10);
-```
-
-Over-fetch each signal (k = 50 for a top-10 fusion) so the fusion has overlap to
-reward. `fuse_scores(&text, &structural, alpha, k)` is the tunable alternative
-(min-max normalized alpha-blend). Full recipe + the research behind it:
-[`sparq-vectors` README](../sparq-vectors/README.md) and
-[`research/genai-text-embedding-practices.md`](../../research/genai-text-embedding-practices.md).
+  Over-fetch each signal (k = 50 for a top-10 fusion) so the fusion has overlap to reward.
+  `fuse_scores(&text, &structural, alpha, k)` is the tunable min-max-normalized alternative.
 
 ## Measured results — olympics
 
 `bench/qlever-olympics/olympics.nt` (134,730 foaf:Person + SportsTeam/SportsEvent/
-Olympics/Sport/City), ground truth = `rdf:type`, **type triples excluded from
-signatures** (leakage rule, design doc §5.5). Stratified per-class sampling (40 per
-class — the data is 98% Person).
-
-The `olympics_eval` example reports the quality + latency metrics and checks them
-against their gates (same-class precision@10; `Predicates`-mode class-separation AUC;
-`most_similar(k=10)` latency). Run it for the numbers — and see the perf dashboard
-(<https://jeswr.github.io/sparq/dev/bench>) for the tracked figures:
+Olympics/Sport/City), ground truth = `rdf:type`, **type triples excluded** (leakage rule,
+design doc §5.5), stratified per-class sampling. The `olympics_eval` example reports
+quality + latency and checks the gates (same-class precision@10; `Predicates`-mode
+class-separation AUC; `most_similar(k=10)` latency); the absolute figures live on the
+perf dashboard.
 
 ```sh
 cargo run -p sparq-sim --example olympics_eval --release
 ```
 
-The gates it enforces, and the two AUC interpretations below, are the load-bearing
-part — the absolute figures print from the example.
+**The two AUCs.** Pairwise AUC asks "do two random same-class entities score higher than
+two cross-class ones?". In `PredicateNeighbor` mode most same-class pairs share *no*
+concrete neighbor and tie at 0 — by design: that mode measures shared context, not class
+membership. Role similarity is the `Predicates` mode's job (near-perfect separation). The
+ranking task the crate is built for — `most_similar` retrieving same-class entities — is
+measured by precision@10, high across every class.
 
-**Note on the two AUCs.** Pairwise AUC asks "do two random same-class entities score
-higher than two cross-class ones?". In `PredicateNeighbor` mode most same-class pairs
-(two arbitrary athletes) share *no concrete neighbor* and tie with cross-class pairs
-at 0 — by design: that mode measures shared context, not class membership. Role
-similarity is the `Predicates` mode's job, where class separation is near-perfect.
-The ranking task the crate is built for — `most_similar` retrieving same-class
-entities — is measured by precision@10, which is high across every class.
+Tests: 13 unit (`src/lib.rs`: Jaccard math, symmetry, direction, IDF ordering, exclusions,
+mode semantics, hub-cap behaviour, neighbor-sparse fallback, AUC gate) plus 1 integration
+(`tests/olympics.rs`, skip-if-absent at 1.78M scale).
 
-Sport and City are served by the **neighbor-sparse profile fallback**
-(`SimConfig::profile_fallback`, default on): v1 returned almost no candidates for them
-(every event names exactly one sport, so no two sports share a concrete neighbor); the
-fallback fills starved slots with role-profile matches, taking those classes to near-full
-precision for a small per-query latency cost.
+## 📚 Learn more
 
-## Tests
+- Design record: [`research/genai-design.md`](../../research/genai-design.md)
+- Text embeddings: [`sparq-vectors` README](../sparq-vectors/README.md),
+  [`research/genai-text-embedding-practices.md`](../../research/genai-text-embedding-practices.md)
+- Skill: `skills/structural-similarity/SKILL.md`
+- Perf dashboard: <https://jeswr.github.io/sparq/dev/bench>
 
-- 13 unit tests (`src/lib.rs`): Jaccard math hand-checks, symmetry, direction,
-  IDF ordering, exclusions, mode semantics, hub-cap behaviour (with and without the
-  fallback), neighbor-sparse fallback semantics (starved star topology, exact-first
-  ranking, no fallback when generation suffices), and a generated-taxonomy
-  AUC gate (a deterministic threshold the synthetic data must clear).
-- 1 integration test (`tests/olympics.rs`): API sanity at 1.78M-triple scale —
-  skips (passes with a note) when the fixture is absent; override the path with
-  `SPARQ_OLYMPICS_NT`.
+## License
+
+MIT. [OPUS-4.8] sq-lsxd


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-lsxd** (docs), a follow-up to sq-avp7.

## What

The three GenAI-crate READMEs (`sparq-introspect`, `sparq-nlq`, `sparq-sim`) were
algorithm-manuals that ran over the 120-line cap and lacked the template's required
sections. The advisory `scripts/check-readme-template.py` flagged each for length plus
all three emoji section markers and the License line.

This rewrites all three to the concise crate-README template (sq-9jw5):

- **≤ 120 lines** with the three section markers — `## 🚀 Quickstart`, `## ✨ Features`,
  `## 📚 Learn more` — plus a `## License` section.
- Algorithm-manual prose condensed into Features bullets; API listings folded into
  Quickstart.
- **Load-bearing content preserved**: the `sparq-nlq` honest-status section
  (validated-offline vs not-yet-measured-against-a-real-model, with the open beads
  `sq-g0lw`/`sq-uw40`/`sq-9yjp`) and the `sparq-sim` two-AUCs interpretation note are
  kept intact — these are the non-overclaim guardrails for the GenAI crates.

No code or public API changed (docs-only), so the G2 public-api→SKILL.md rule does not
apply.

## Result

| Crate | Lines before → after |
|---|---|
| `sparq-introspect` | 167 → 101 |
| `sparq-nlq` | 186 → 113 |
| `sparq-sim` | 125 → 102 |

## Gates

- `check-readme-template.py` on the three files: **0 deviations** (was 15).
- `check-no-perf-numbers.py`: **0 findings** (no hard-coded perf numbers; dataset
  triple-counts retained as dataset facts, same as before).
- `check-privacy-claims.sh`: **OK**, no unqualified ZK/MPC privacy/soundness claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)