### PR TITLE
test(sparq-shacl): wire Node RDF-JS SHACL reference adapter into diff-fuzz (sq-vz2v) [OPUS-4.8]

### DIFF
--- a/.github/workflows/shacl-diff-fuzz.yml
+++ b/.github/workflows/shacl-diff-fuzz.yml
@@ -1,15 +1,19 @@
-# [OPUS-4.8] Differential SHACL fuzz gate (beads sq-55c1 + sq-evws).
+# [OPUS-4.8] Differential SHACL fuzz gate (beads sq-55c1 + sq-evws + sq-vz2v).
 #
 # WHAT: generates random but VALID SHACL shapes + data graphs, validates each
 # through `sparq-shacl` AND through every reference SHACL engine that resolves, and
 # asserts the reports agree on the `sh:conforms` bit and the per-focus-node
-# violated-constraint set. Two references are wired:
+# violated-constraint set. Three reference families are wired:
 #   - pySHACL — the canonical Python reference implementation (sq-55c1).
 #   - Apache Jena SHACL — a second, independent reference (sq-evws), driven via the
 #     Java single-file source launcher over its `org.apache.jena.shacl` validator.
+#   - Node / RDF-JS — a third family (sq-vz2v) driving the Zazuko `shacl-engine`
+#     validator over an RDF-JS dataset, via tests/diff_fuzz/node_shacl_adapter.mjs.
+#     (`rdf-validate-shacl` is the same adapter behind SHACL_DIFF_NODE_ENGINE; the
+#     lane runs shacl-engine, the actively-maintained SHACL-AF one.)
 # A disagreement is a candidate sparq-shacl correctness bug; the harness prints the
-# seed + the reproducing Turtle so it replays deterministically. A second engine
-# catches bugs where sparq and pySHACL happen to agree but are both wrong. See
+# seed + the reproducing Turtle so it replays deterministically. Independent engines
+# catch bugs where sparq and ONE reference happen to agree but are both wrong. See
 # crates/sparq-shacl/tests/diff_fuzz.rs.
 #
 # TRIGGER — NIGHTLY/HEAVY tier ONLY. Deliberately NOT on pull_request / push /
@@ -62,12 +66,12 @@ env:
 
 jobs:
   diff-fuzz:
-    name: SHACL differential fuzz (sparq-shacl vs pySHACL + Jena)
+    name: SHACL differential fuzz (sparq-shacl vs pySHACL + Jena + Node RDF-JS)
     runs-on: ubuntu-latest
     # Generous ceiling: ~thousands of cases × a per-case reference subprocess, now
-    # across two engines (each case spawns a fresh interpreter/JVM). A hung run
-    # fails with a clear timeout rather than running away.
-    timeout-minutes: 90
+    # across three engines (each case spawns a fresh interpreter/JVM/Node). A hung
+    # run fails with a clear timeout rather than running away.
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust (stable)
@@ -85,6 +89,10 @@ jobs:
         with:
           distribution: temurin
           java-version: "21"
+      - name: Set up Node (for the RDF-JS reference engine)
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
       - name: Install pySHACL (reference engine) in a venv
         run: |
           set -euo pipefail
@@ -117,6 +125,29 @@ jobs:
           # The harness derives ${JENA_HOME}/lib/* when JENA_HOME is set.
           echo "JENA_HOME=$dest" >> "$GITHUB_ENV"
           "$dest/bin/shacl" --help >/dev/null 2>&1 && echo "Jena shacl CLI OK ($JENA_VERSION)"
+      # Cache the Node reference adapter's node_modules across runs (keyed on the
+      # committed lockfile) so the nightly lane doesn't reinstall the RDF-JS trees
+      # every day. A cache miss falls through to the `npm ci` step.
+      - name: Cache Node reference adapter node_modules
+        id: node-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: crates/sparq-shacl/tests/diff_fuzz/node_modules
+          key: shacl-node-adapter-${{ hashFiles('crates/sparq-shacl/tests/diff_fuzz/package-lock.json') }}
+      - name: Install the Node / RDF-JS reference engine (pinned via lockfile)
+        run: |
+          set -euo pipefail
+          # `npm ci` installs exactly the committed package-lock.json so the
+          # reference engine is reproducible (a pinned shacl-engine, like the pinned
+          # pySHACL/Jena). The Rust harness auto-resolves this adapter-local
+          # node_modules; SHACL_DIFF_NODE_MODULES makes that explicit + robust.
+          npm ci --prefix crates/sparq-shacl/tests/diff_fuzz
+          node crates/sparq-shacl/tests/diff_fuzz/node_shacl_adapter.mjs --selftest \
+            && echo "Node RDF-JS SHACL adapter selftest OK"
+          echo "SHACL_DIFF_NODE_MODULES=$PWD/crates/sparq-shacl/tests/diff_fuzz/node_modules" >> "$GITHUB_ENV"
+          # Run the default engine (shacl-engine); rdf-validate-shacl is the same
+          # adapter behind the switch and is exercised by the Rust unit selftest.
+          echo "SHACL_DIFF_NODE_ENGINE=shacl-engine" >> "$GITHUB_ENV"
       - name: Pick seed count for this trigger
         id: budget
         run: |

--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -76,14 +76,20 @@ runner's comparison is engine-agnostic:
   launcher (`java -cp <jena-libs> JenaShaclAdapter.java`) so no compile step or
   committed jar is needed. A second independent reference catches bugs where sparq
   and pySHACL happen to agree but are both wrong.
+- **Node / RDF-JS** (`tests/diff_fuzz/node_shacl_adapter.mjs`, bead sq-vz2v) —
+  the Zazuko `shacl-engine` validator (default) or `rdf-validate-shacl` (select via
+  `SHACL_DIFF_NODE_ENGINE`) over an RDF-JS dataset, run directly by Node (no build
+  step); deps are pinned in `tests/diff_fuzz/package.json` + lockfile. Being JS over
+  RDF-JS it is also the on-ramp for a future JS-vs-JS lane against sparq's own
+  `@jeswr/sparq` WASM SHACL.
 
-The differential runs against **every** reference engine that resolves. Other
-engines (rdf-validate-shacl / shacl-engine via Node) are tracked as follow-up
-beads and slot in as further adapters over the same contract.
+The differential runs against **every** reference engine that resolves; adding one
+is just another adapter over the same contract.
 
 It is `#[ignore]`d (off the per-PR fast path) and runs as a **nightly** CI lane
-(`.github/workflows/shacl-diff-fuzz.yml`, which installs both pySHACL and a
-SHA-512-verified apache-jena tarball). Run it locally against either or both:
+(`.github/workflows/shacl-diff-fuzz.yml`, which installs pySHACL, a SHA-512-verified
+apache-jena tarball, and the Node adapter's pinned `node_modules`). Run it locally
+against any of them:
 
 ```sh
 # pySHACL:
@@ -93,11 +99,17 @@ SHACL_DIFF_PYTHON=/tmp/shacl-ref-venv/bin/python SHACL_DIFF_COUNT=2000 \
 # Jena (point at an unpacked apache-jena lib classpath, or set JENA_HOME):
 SHACL_DIFF_JENA_CP="/opt/apache-jena/lib/*" SHACL_DIFF_COUNT=2000 \
   cargo test -p sparq-shacl --test diff_fuzz -- --ignored --nocapture
+# Node (install the pinned deps once; the runner auto-finds the adapter-local
+# node_modules, or point SHACL_DIFF_NODE_MODULES / NODE_PATH at one):
+npm ci --prefix crates/sparq-shacl/tests/diff_fuzz
+SHACL_DIFF_COUNT=2000 \
+  cargo test -p sparq-shacl --test diff_fuzz -- --ignored --nocapture
 ```
 
 When no reference engine resolves, the test skips cleanly (so a fresh checkout
 stays green); each engine is gated independently, so Jena is silently skipped
-without a Java/Jena classpath and the pySHACL lane is unaffected. Fast,
+without a Java/Jena classpath, the Node engine without a `node`/node_modules, and
+the pySHACL lane is unaffected. Fast,
 reference-free self-tests (generator well-formedness + outcome mix,
 key-normalisation consistency, the engine-gating logic) DO run in the per-PR
 path.

--- a/crates/sparq-shacl/tests/diff_fuzz.rs
+++ b/crates/sparq-shacl/tests/diff_fuzz.rs
@@ -30,8 +30,14 @@
 //!     reference catches bugs where sparq and pySHACL happen to agree but are both
 //!     wrong.
 //!
-//! Other engines (rdf-validate-shacl / shacl-engine via Node) remain follow-up
-//! beads; each is another `RefEngine` over the same contract.
+//!   - **Node / RDF-JS** (`tests/diff_fuzz/node_shacl_adapter.mjs`, bead sq-vz2v) —
+//!     a third, independent family driving the Zazuko `shacl-engine` (default) or
+//!     `rdf-validate-shacl` validator (selected by `SHACL_DIFF_NODE_ENGINE`) over an
+//!     RDF-JS dataset. Being JS over RDF-JS it is also the on-ramp for diffing
+//!     sparq's OWN `@jeswr/sparq` WASM SHACL (a future JS-vs-JS lane).
+//!
+//! Each reference is another `RefEngine` over the same report-cli contract; adding
+//! one is just a `resolve_*` returning that struct.
 //!
 //! ## How to run
 //! Off by default (`#[ignore]`) so the per-PR `cargo nextest run` fast path is
@@ -45,12 +51,19 @@
 //! # tarball's `lib`), or set JENA_HOME (its `lib` is derived):
 //! SHACL_DIFF_JENA_CP="/opt/apache-jena/lib/*" \
 //!   cargo test -p sparq-shacl --test diff_fuzz -- --ignored --nocapture
+//! # Node: point at a node_modules with the RDF-JS validator + its deps installed
+//! # (SHACL_DIFF_NODE_MODULES, else NODE_PATH); SHACL_DIFF_NODE_ENGINE picks the
+//! # validator (shacl-engine | rdf-validate-shacl; default shacl-engine):
+//! SHACL_DIFF_NODE_MODULES="$PWD/crates/sparq-shacl/tests/diff_fuzz/node_modules" \
+//!   cargo test -p sparq-shacl --test diff_fuzz -- --ignored --nocapture
 //! # bound the run: SHACL_DIFF_SEED_START / SHACL_DIFF_COUNT (defaults 0 / 200).
 //! ```
 //! When NO reference engine resolves, the test SKIPS (prints why and returns) so
 //! it stays green on a box without any reference toolchain. Each engine is gated
 //! independently — Jena is silently skipped when neither a Jena classpath nor a
-//! working `java` is available, so the existing pySHACL-only lane is unaffected.
+//! working `java` is available, and the Node engine when neither a usable `node`
+//! nor a resolvable node_modules is present, so the existing pySHACL-only lane is
+//! unaffected.
 //!
 //! ## Comparison policy (per bead sq-55c1)
 //! 1. `conforms` bit — exact (cheap, highest signal).
@@ -90,13 +103,18 @@ struct RefViolation {
 }
 
 /// A resolved reference engine: a human name plus the program + leading args to
-/// spawn its report-cli adapter. The (data, shapes) request is always written to
-/// the child's stdin and the normalised JSON report read from stdout, regardless
-/// of engine — so adding an engine is just another `resolve_*` returning this.
+/// spawn its report-cli adapter, and any extra environment to set on the child
+/// (e.g. the Node adapter's `NODE_PATH`/engine switch). The (data, shapes) request
+/// is always written to the child's stdin and the normalised JSON report read from
+/// stdout, regardless of engine — so adding an engine is just another `resolve_*`
+/// returning this.
 struct RefEngine {
     name: String,
     program: String,
     args: Vec<String>,
+    /// Extra `(key, value)` environment overrides for the spawned child; empty for
+    /// engines that need none (pySHACL, Jena).
+    envs: Vec<(String, String)>,
 }
 
 fn adapter_dir() -> std::path::PathBuf {
@@ -125,6 +143,7 @@ fn resolve_pyshacl() -> Option<RefEngine> {
                 name: format!("pySHACL via {py}"),
                 program: py,
                 args: vec![adapter.to_string_lossy().into_owned()],
+                envs: vec![],
             });
         }
     }
@@ -185,13 +204,85 @@ fn resolve_jena() -> Option<RefEngine> {
             classpath,
             adapter.to_string_lossy().into_owned(),
         ],
+        envs: vec![],
+    })
+}
+
+/// Pure node_modules selection (env values passed in, so it is unit-testable
+/// without mutating process-global env in parallel tests): an explicit
+/// `SHACL_DIFF_NODE_MODULES` wins; otherwise the adapter-local `node_modules`
+/// (`tests/diff_fuzz/node_modules`, what the CI lane installs) if it exists;
+/// otherwise `NODE_PATH` if set; otherwise `None` (Node engine skipped). An empty
+/// string is treated as unset so a blank env var does not produce a degenerate
+/// empty path. `local_exists` lets the test decide whether to consider the local
+/// dir without touching the filesystem.
+fn node_modules_path(
+    explicit_env: Option<String>,
+    node_path_env: Option<String>,
+    local_modules: &std::path::Path,
+    local_exists: bool,
+) -> Option<String> {
+    if let Some(p) = explicit_env.filter(|s| !s.is_empty()) {
+        return Some(p);
+    }
+    if local_exists {
+        return Some(local_modules.to_string_lossy().into_owned());
+    }
+    node_path_env.filter(|s| !s.is_empty())
+}
+
+/// Resolves the Node / RDF-JS SHACL engine, or `None` if it cannot be driven (so
+/// it is SKIPPED cleanly — the pySHACL/Jena lanes are unaffected). Needs:
+///   - a `node` launcher: `SHACL_DIFF_NODE` else `node` on PATH (must run), and
+///   - a resolvable `node_modules` with the RDF-JS validator installed:
+///     `SHACL_DIFF_NODE_MODULES` else the adapter-local `node_modules` else
+///     `NODE_PATH`.
+///
+/// The adapter is the single-file `node_shacl_adapter.mjs` run directly by Node
+/// (no build step); `SHACL_DIFF_NODE_ENGINE` (shacl-engine | rdf-validate-shacl)
+/// selects the validator inside the adapter. `NODE_PATH` is set on the child so the
+/// adapter's bare `import`s resolve from the chosen `node_modules`.
+fn resolve_node() -> Option<RefEngine> {
+    let local = adapter_dir().join("node_modules");
+    let modules = node_modules_path(
+        std::env::var("SHACL_DIFF_NODE_MODULES").ok(),
+        std::env::var("NODE_PATH").ok(),
+        &local,
+        local.is_dir(),
+    )?;
+    let node = std::env::var("SHACL_DIFF_NODE").unwrap_or_else(|_| "node".to_string());
+    // `node --version` must actually run — otherwise no usable launcher and we skip
+    // rather than spawn-error every case.
+    let node_ok = Command::new(&node)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !node_ok {
+        return None;
+    }
+    let engine_sel =
+        std::env::var("SHACL_DIFF_NODE_ENGINE").unwrap_or_else(|_| "shacl-engine".to_string());
+    let adapter = adapter_dir().join("node_shacl_adapter.mjs");
+    Some(RefEngine {
+        name: format!("Node RDF-JS SHACL ({engine_sel}) via {node}"),
+        program: node,
+        args: vec![adapter.to_string_lossy().into_owned()],
+        // Bare `import`s in the .mjs adapter resolve from NODE_PATH; pass the engine
+        // selection through so it is honoured even if the parent env differs.
+        envs: vec![
+            ("NODE_PATH".to_string(), modules),
+            ("SHACL_DIFF_NODE_ENGINE".to_string(), engine_sel),
+        ],
     })
 }
 
 /// All reference engines available on this box, in a stable order. The
 /// differential runs against each; an empty list means SKIP the whole test.
 fn resolve_engines() -> Vec<RefEngine> {
-    [resolve_pyshacl(), resolve_jena()]
+    [resolve_pyshacl(), resolve_jena(), resolve_node()]
         .into_iter()
         .flatten()
         .collect()
@@ -204,6 +295,7 @@ fn run_reference(engine: &RefEngine, data: &str, shapes: &str) -> Result<RefRepo
     let req = serde_json::json!({ "data": data, "shapes": shapes }).to_string();
     let mut child = Command::new(&engine.program)
         .args(&engine.args)
+        .envs(engine.envs.iter().map(|(k, v)| (k.as_str(), v.as_str())))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -415,7 +507,7 @@ fn mismatch(engine: &RefEngine, seed: u64, data: &str, shapes: &str, msg: &str) 
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "differential SHACL fuzz — nightly/heavy tier; needs a reference engine (pyshacl / Jena)"]
+#[ignore = "differential SHACL fuzz — nightly/heavy tier; needs a reference engine (pyshacl / Jena / Node RDF-JS)"]
 fn differential_shacl_fuzz() {
     let engines = resolve_engines();
     if engines.is_empty() {
@@ -423,7 +515,8 @@ fn differential_shacl_fuzz() {
             "SKIP: no reference SHACL engine resolved. Install pyshacl+rdflib and set \
              SHACL_DIFF_PYTHON to its interpreter (e.g. a venv's bin/python), and/or point \
              SHACL_DIFF_JENA_CP (or JENA_HOME) at an apache-jena lib classpath for the Jena \
-             reference."
+             reference, and/or install the RDF-JS validator into a node_modules pointed at by \
+             SHACL_DIFF_NODE_MODULES (or NODE_PATH) for the Node reference."
         );
         return;
     }
@@ -745,6 +838,91 @@ fn jena_adapter_excludes_nested_sh_detail() {
     assert!(
         out.status.success(),
         "Jena adapter --selftest failed (exit {:?}) — the sh:detail exclusion \
+         regressed (nested sub-result leaked into the top-level violation set):\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr).trim()
+    );
+}
+
+/// [OPUS-4.8] (sq-vz2v) Node node_modules gating, pure (no filesystem / process
+/// env touched, so it is parallel-safe): an explicit `SHACL_DIFF_NODE_MODULES`
+/// wins; else the adapter-local `node_modules` IF it exists; else `NODE_PATH`;
+/// else `None` (Node engine SKIPPED — the pySHACL/Jena lanes unaffected). Blank
+/// values are treated as unset so a degenerate empty path can't slip through.
+#[test]
+fn node_modules_gating() {
+    let local = std::path::Path::new("/repo/tests/diff_fuzz/node_modules");
+    // Explicit env wins, even when the local dir and NODE_PATH are also present.
+    assert_eq!(
+        node_modules_path(
+            Some("/custom/nm".into()),
+            Some("/ignored/nm".into()),
+            local,
+            true
+        ),
+        Some("/custom/nm".to_string())
+    );
+    // No explicit env, local dir exists → the adapter-local node_modules.
+    assert_eq!(
+        node_modules_path(None, Some("/np".into()), local, true)
+            .as_deref()
+            .map(|s| s.ends_with("node_modules")),
+        Some(true)
+    );
+    // No explicit, no local → fall through to NODE_PATH.
+    assert_eq!(
+        node_modules_path(None, Some("/np".into()), local, false),
+        Some("/np".to_string())
+    );
+    // Nothing set → Node skipped.
+    assert_eq!(node_modules_path(None, None, local, false), None);
+    // Blank values are unset.
+    assert_eq!(
+        node_modules_path(Some(String::new()), None, local, false),
+        None
+    );
+    assert_eq!(
+        node_modules_path(None, Some(String::new()), local, false),
+        None
+    );
+    // Blank explicit falls through to the local dir when it exists.
+    assert_eq!(
+        node_modules_path(Some(String::new()), None, local, true)
+            .as_deref()
+            .map(|s| s.ends_with("node_modules")),
+        Some(true)
+    );
+}
+
+/// [OPUS-4.8] (sq-vz2v) The Node adapter must mirror the pySHACL/Jena adapters'
+/// `sh:detail` exclusion: a nested sub-result that is the object of an `sh:detail`
+/// must NOT appear as a top-level violation (it lives in `ValidationResult::details`
+/// in sparq, and `sh:detail` is non-normative per SHACL §3.6.2 — diffing it would
+/// be a latent over-report, not a real disagreement). The adapter ships a
+/// `--selftest` mode asserting this on a synthetic RDF-JS report dataset (no
+/// validator run, so it is independent of which validator/version is installed);
+/// we drive it here. SKIPPED cleanly when Node + a node_modules don't resolve (the
+/// pySHACL/Jena / no-Node lanes are unaffected) — exactly the diff-fuzz gating.
+#[test]
+fn node_adapter_excludes_nested_sh_detail() {
+    let Some(engine) = resolve_node() else {
+        eprintln!("SKIP node_adapter_excludes_nested_sh_detail: Node engine did not resolve");
+        return;
+    };
+    // engine.args is `[<adapter>.mjs]`; append `--selftest` and carry the resolved
+    // NODE_PATH/engine env so the adapter's bare imports resolve.
+    let mut args = engine.args.clone();
+    args.push("--selftest".to_string());
+    let out = Command::new(&engine.program)
+        .args(&args)
+        .envs(engine.envs.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn Node adapter --selftest");
+    assert!(
+        out.status.success(),
+        "Node adapter --selftest failed (exit {:?}) — the sh:detail exclusion \
          regressed (nested sub-result leaked into the top-level violation set):\n{}",
         out.status.code(),
         String::from_utf8_lossy(&out.stderr).trim()

--- a/crates/sparq-shacl/tests/diff_fuzz/.gitignore
+++ b/crates/sparq-shacl/tests/diff_fuzz/.gitignore
@@ -1,0 +1,4 @@
+# [OPUS-4.8] sq-vz2v — the Node reference adapter's installed deps are not tracked;
+# the differential is nightly-only and the CI lane runs `npm ci` from the committed
+# package.json + lockfile. Keeps the repo lean (these are heavy RDF-JS trees).
+node_modules/

--- a/crates/sparq-shacl/tests/diff_fuzz/node_shacl_adapter.mjs
+++ b/crates/sparq-shacl/tests/diff_fuzz/node_shacl_adapter.mjs
@@ -1,0 +1,281 @@
+// [OPUS-4.8] sq-vz2v: Node / RDF-JS reference-engine adapter for the SHACL
+// differential fuzzer (crates/sparq-shacl/tests/diff_fuzz.rs).
+//
+// A THIRD family of independent references alongside the pySHACL (sq-55c1) and
+// Apache Jena (sq-evws) adapters. It is the SAME "report-cli" contract (bead
+// sq-eifd): JSON request in, normalised JSON report out, so the Rust runner's
+// comparison is engine-agnostic. Two RDF-JS SHACL validators are wired behind one
+// `SHACL_DIFF_NODE_ENGINE` switch — both are Zazuko, MIT-licensed:
+//   - "shacl-engine"        (https://github.com/rdf-ext/shacl-engine)
+//   - "rdf-validate-shacl"  (https://github.com/zazuko/rdf-validate-shacl)
+// A third engine catches bugs where sparq + pySHACL + Jena happen to agree but are
+// all wrong, and — being JS over RDF-JS — it is the same family sparq's own
+// @jeswr/sparq WASM SHACL would slot into (the bonus JS-vs-JS lane noted on the
+// bead), so this harness is the on-ramp for that.
+//
+// WHY .mjs run directly (no build step): Node runs an ES module file directly
+// (`node node_shacl_adapter.mjs`), and both validators + the `n3` Turtle parser
+// are pure JS. So the differential ships ONLY source; the npm packages come from
+// a `node_modules` the CI lane installs and the Rust runner points at via
+// NODE_PATH (mirroring how the Jena adapter is handed a `-cp` classpath).
+//
+// CONTRACT (stdin -> stdout) — identical to tests/diff_fuzz/pyshacl_adapter.py
+// and tests/diff_fuzz/JenaShaclAdapter.java:
+//   stdin  : a JSON object {"data": "<turtle>", "shapes": "<turtle>"}
+//   stdout : {"conforms": bool,
+//             "violations": [{"focus": str|null, "component": str|null,
+//                             "path": str|null}, ...]}
+//            — `focus`/`component` are full IRIs (or "_:bnode" for blank nodes,
+//            which have no cross-graph identity); `path` is the bare predicate IRI
+//            for a simple path, the "_:path" sentinel for any complex/blank-rooted
+//            path, or null when the result carries no path. Exactly the shape the
+//            Rust runner's RefReport deserialises and `ref_keys` normalises.
+//   exit   : 0 on a produced report (even non-conforming); non-zero only on an
+//            adapter/engine ERROR (so the runner distinguishes "engine says X" from
+//            "engine could not run"), with a diagnostic on stderr.
+//
+// Reads ONE request and emits ONE report (one Node process per case, mirroring the
+// pySHACL/Jena adapters' one-runtime-per-case isolation).
+//
+// `--selftest`: exercises the sh:detail exclusion + path/term normalisation on a
+// synthetic RDF-JS validation report (no validator run, so it is independent of
+// which engine/version is installed). Exit 0 on pass, non-zero with a diagnostic
+// on fail. Mirrors the Jena adapter's --selftest and the pyshacl adapter's intent.
+
+// `@zazuko/env-node` is a full RDF-JS environment (data-model + dataset +
+// clownface): the ONE factory that drives BOTH validators — shacl-engine wants a
+// `.literal`/`.namedNode` data factory, rdf-validate-shacl additionally wants
+// `.clownface`. Using one factory keeps the two engines on identical term
+// construction, so a difference can only come from validation logic.
+import rdf from "@zazuko/env-node";
+import { Parser } from "n3";
+
+const SH = "http://www.w3.org/ns/shacl#";
+const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+// Which RDF-JS validator to drive. Default `shacl-engine` (actively maintained,
+// SHACL-AF support); `rdf-validate-shacl` selectable for a second JS opinion.
+function nodeEngineName() {
+  return (process.env.SHACL_DIFF_NODE_ENGINE || "shacl-engine").trim();
+}
+
+function parseTurtle(ttl) {
+  // n3's Parser.parse(string) is synchronous; collect quads into a fresh RDF-JS
+  // dataset that both validators accept.
+  const quads = new Parser({ format: "text/turtle" }).parse(ttl);
+  return rdf.dataset(quads);
+}
+
+// Minimal NamedNode factory for dataset.match() predicates (avoids pulling a
+// second data-factory dependency; n3/@rdfjs terms compare by termType+value).
+function namedNode(iri) {
+  return {
+    termType: "NamedNode",
+    value: iri,
+    equals(o) {
+      return !!o && o.termType === "NamedNode" && o.value === iri;
+    },
+  };
+}
+
+// --- term normalisation: the SAME keys the pySHACL / Jena adapters emit. -------
+
+// A graph-independent key for a term: blank nodes collapse to "_:bnode" (no stable
+// cross-graph identity — the tolerance every adapter + the Rust runner share);
+// named nodes render to their IRI; literals (only used in diagnostics) to a stable
+// label. null/undefined → null (a genuinely-absent field, distinct from a blank
+// node — the Rust `ref_keys` maps it to the `<missing-focus>` sentinel).
+function termKey(term) {
+  if (term == null) return null;
+  switch (term.termType) {
+    case "BlankNode":
+      return "_:bnode";
+    case "NamedNode":
+      return term.value;
+    case "Literal":
+      return `"${term.value}"`;
+    default:
+      return String(term.value);
+  }
+}
+
+// An sh:resultPath term → the comparable string the other adapters emit: the bare
+// predicate IRI for a simple (NamedNode) path, else the "_:path" sentinel for any
+// complex / blank-rooted path (sequence/inverse/alternative/* are blank-node
+// rooted), or null when there is no path.
+function pathKey(term) {
+  if (term == null) return null;
+  if (term.termType === "NamedNode") return term.value;
+  return "_:path";
+}
+
+// --- report normalisation over an RDF-JS validation-report dataset. ------------
+
+// Both validators expose a `.dataset` of the RDF report (rdf-validate-shacl via
+// `report.dataset`; shacl-engine via `report.dataset` too). We normalise straight
+// off the RDF so we depend only on the standard SHACL report vocabulary, not on
+// either library's bespoke JS result objects.
+//
+// [OPUS-4.8] (mirrors sq-0hj7 / sq-vsqr) `sh:detail` exclusion: a sh:ValidationResult
+// reachable only as the OBJECT of an `sh:detail` is a NESTED sub-result for a failed
+// inner constraint (SHACL §3.6.2, non-normative "MAY"). sparq keeps those in
+// `ValidationResult::details`, NOT in the top-level `report.results`. Diffing nested
+// sub-results would compare two engines' OPTIONAL detail policies, not a real
+// disagreement — so we drop any result that is the object of an sh:detail, exactly
+// as the pySHACL and Jena adapters do.
+function normaliseDataset(dataset) {
+  const p = (suffix) => SH + suffix;
+
+  // Nodes that are the object of some sh:detail (to exclude as nested sub-results).
+  const nested = new Set();
+  for (const q of dataset.match(null, namedNode(p("detail")), null)) {
+    nested.add(q.object.value);
+  }
+
+  const firstObject = (subj, predIri) => {
+    for (const q of dataset.match(subj, namedNode(predIri), null)) return q.object;
+    return null;
+  };
+
+  // `sh:conforms` lives on the sh:ValidationReport node; if absent (some engines
+  // omit it) derive it from the presence of any top-level result.
+  let conforms = null;
+  for (const q of dataset.match(null, namedNode(p("conforms")), null)) {
+    conforms = q.object.value === "true";
+  }
+
+  const violations = [];
+  const seenResults = new Set();
+  for (const q of dataset.match(null, namedNode(RDF_TYPE), namedNode(p("ValidationResult")))) {
+    const res = q.subject;
+    if (seenResults.has(res.value)) continue;
+    seenResults.add(res.value);
+    if (nested.has(res.value)) continue; // nested sh:detail sub-result — excluded
+    violations.push({
+      focus: termKey(firstObject(res, p("focusNode"))),
+      component: termKey(firstObject(res, p("sourceConstraintComponent"))),
+      path: pathKey(firstObject(res, p("resultPath"))),
+    });
+  }
+
+  if (conforms == null) conforms = violations.length === 0;
+  return { conforms, violations };
+}
+
+// --- engine drivers. -----------------------------------------------------------
+
+async function validateWithShaclEngine(dataTtl, shapesTtl) {
+  const { Validator } = await import("shacl-engine");
+  const data = parseTurtle(dataTtl);
+  const shapes = parseTurtle(shapesTtl);
+  const validator = new Validator(shapes, { factory: rdf });
+  const report = await validator.validate({ dataset: data });
+  return normaliseDataset(report.dataset);
+}
+
+async function validateWithRdfValidateShacl(dataTtl, shapesTtl) {
+  const mod = await import("rdf-validate-shacl");
+  const SHACLValidator = mod.default || mod;
+  const data = parseTurtle(dataTtl);
+  const shapes = parseTurtle(shapesTtl);
+  const validator = new SHACLValidator(shapes, { factory: rdf });
+  const report = await validator.validate(data);
+  return normaliseDataset(report.dataset);
+}
+
+async function run(dataTtl, shapesTtl) {
+  const engine = nodeEngineName();
+  switch (engine) {
+    case "shacl-engine":
+      return validateWithShaclEngine(dataTtl, shapesTtl);
+    case "rdf-validate-shacl":
+      return validateWithRdfValidateShacl(dataTtl, shapesTtl);
+    default:
+      throw new Error(
+        `unknown SHACL_DIFF_NODE_ENGINE='${engine}' (want shacl-engine | rdf-validate-shacl)`,
+      );
+  }
+}
+
+// --- --selftest: prove the sh:detail exclusion + path/term normalisation. ------
+
+function selfTest() {
+  // Synthetic report dataset: a top-level result carrying a nested sh:detail to an
+  // inner result. normaliseDataset must emit EXACTLY the top-level violation; the
+  // nested sub-result is excluded. A regression that dropped the exclusion would
+  // surface the inner result as a second violation here.
+  const blank = (id) => ({ termType: "BlankNode", value: id });
+  const lit = (v) => ({ termType: "Literal", value: v });
+  const quad = (s, predIri, o) => ({
+    subject: s,
+    predicate: namedNode(predIri),
+    object: o,
+    graph: { termType: "DefaultGraph", value: "" },
+  });
+  const report = blank("report");
+  const top = blank("top");
+  const inner = blank("inner");
+  const fX = namedNode("http://example.org/x");
+  const pP = namedNode("http://example.org/p");
+  const comp = namedNode(SH + "MinCountConstraintComponent");
+  const innerComp = namedNode(SH + "DatatypeConstraintComponent");
+
+  const quads = [
+    quad(report, RDF_TYPE, namedNode(SH + "ValidationReport")),
+    quad(report, SH + "conforms", lit("false")),
+    // top-level result
+    quad(top, RDF_TYPE, namedNode(SH + "ValidationResult")),
+    quad(top, SH + "focusNode", fX),
+    quad(top, SH + "resultPath", pP),
+    quad(top, SH + "sourceConstraintComponent", comp),
+    quad(top, SH + "detail", inner), // nested → must be excluded
+    // nested (detail) result — MUST NOT appear at top level
+    quad(inner, RDF_TYPE, namedNode(SH + "ValidationResult")),
+    quad(inner, SH + "focusNode", fX),
+    quad(inner, SH + "sourceConstraintComponent", innerComp),
+  ];
+
+  const out = normaliseDataset(rdf.dataset(quads));
+  const ok =
+    out.conforms === false &&
+    out.violations.length === 1 &&
+    out.violations[0].focus === "http://example.org/x" &&
+    out.violations[0].path === "http://example.org/p" &&
+    out.violations[0].component === SH + "MinCountConstraintComponent";
+  if (!ok) {
+    process.stderr.write(
+      "node_shacl_adapter selftest FAIL: sh:detail exclusion / normalisation; got " +
+        JSON.stringify(out) +
+        "\n",
+    );
+    return false;
+  }
+  return true;
+}
+
+async function main() {
+  if (process.argv.length === 3 && process.argv[2] === "--selftest") {
+    process.exit(selfTest() ? 0 : 3);
+  }
+  let req;
+  try {
+    const chunks = [];
+    for await (const c of process.stdin) chunks.push(c);
+    req = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch (e) {
+    process.stderr.write(`node_shacl_adapter: bad request JSON: ${e}\n`);
+    process.exit(2);
+  }
+  let out;
+  try {
+    out = await run(req.data, req.shapes);
+  } catch (e) {
+    process.stderr.write(
+      `node_shacl_adapter: engine error (${nodeEngineName()}): ${e && e.stack ? e.stack : e}\n`,
+    );
+    process.exit(1);
+  }
+  process.stdout.write(JSON.stringify(out) + "\n");
+}
+
+main();

--- a/crates/sparq-shacl/tests/diff_fuzz/package-lock.json
+++ b/crates/sparq-shacl/tests/diff_fuzz/package-lock.json
@@ -1,0 +1,6705 @@
+{
+  "name": "sparq-shacl-diff-fuzz-node-adapter",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sparq-shacl-diff-fuzz-node-adapter",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@zazuko/env-node": "2.1.2",
+        "n3": "2.0.4",
+        "rdf-validate-shacl": "0.6.5",
+        "shacl-engine": "1.1.0"
+      }
+    },
+    "node_modules/@bergos/jsonparse": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@bergos/jsonparse/-/jsonparse-1.4.2.tgz",
+      "integrity": "sha512-qUt0QNJjvg4s1zk+AuLM6s/zcsQ8MvGn7+1f0vPuxvpCYa08YtTryuDInngbEyW5fNGGYe2znKt61RMGd5HnXg==",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-mediatyped": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-4.5.0.tgz",
+      "integrity": "sha512-KbLuhbTcfAQHJeLo3CDDdffCZdfA1qDu15XIdW+7P03UpUp9xMw4p1G0kYtoXwj9KzWguY704TUtpJVBO1GOnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-parse": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-4.5.0.tgz",
+      "integrity": "sha512-THNdQsJ58HtkyeW9ghVyLrYEQfSPNfmVAJTDSqOxIujjCdimPbzS2LBXoDdw13GuxWWOATssbm1LwXDlX0xMIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "readable-stream": "^4.5.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-path": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-4.5.0.tgz",
+      "integrity": "sha512-oBm9rqCCNErmn570UjhMKa4XSM4NxQ/HtgGw7P0HTR0jx/LBg5ctkmsp0ewSJSx+OVf2fU4S7hodZgsS7jypLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-bindings-aggregator-factory-average": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-average/-/actor-bindings-aggregator-factory-average-4.5.0.tgz",
+      "integrity": "sha512-QQIVsCMzi+AvaTDegSZVcc2wjBszFAVayUfNEe/OW6xvXMXKmLiEdA+5q5MSJYcfDIciwR0FR3mTFJx34GgSGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-bindings-aggregator-factory-count": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-count/-/actor-bindings-aggregator-factory-count-4.5.0.tgz",
+      "integrity": "sha512-BExT1O1b0oP3DVjArcFPLTjFyycShz3ineh7G4ccZ2D+h1xo3dWbCcCNvnOTBnP6XBRtvpgfHLqz2i9C/Hs8SA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      }
+    },
+    "node_modules/@comunica/actor-bindings-aggregator-factory-group-concat": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-group-concat/-/actor-bindings-aggregator-factory-group-concat-4.5.0.tgz",
+      "integrity": "sha512-Gpm2uLDc7mCiE0xt1KX/bKVRXXGNyclq/jJ3zKx+QPftB4z8IFvsTUzt4WuimBYawU0OvM6CUlr6Y3pdY6k4qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-bindings-aggregator-factory-max": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-max/-/actor-bindings-aggregator-factory-max-4.5.0.tgz",
+      "integrity": "sha512-iJZ/NF8s5UhokHIVOCk4fuu8glWH354Oyg2p/VvtBMAXu3x/U3M5EAofsoIGCjwkqcOrknVqG1VGywHgglIAuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-bindings-aggregator-factory-min": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-min/-/actor-bindings-aggregator-factory-min-4.5.0.tgz",
+      "integrity": "sha512-dHkJvOrTr8fLpu0d1HLsssZQov0PdKlFgZczl5gZ/gpTvKUnpaMcI7uSi/FWkbEyZFtJH+mw2Vb9BmVuSnmzkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-bindings-aggregator-factory-sample": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sample/-/actor-bindings-aggregator-factory-sample-4.5.0.tgz",
+      "integrity": "sha512-4IK9MjfLX0pzB74XxqmSJJIySjB0xr4nId96DkRYrJVvFz7PGdZL5ovr7WJEHrCaFZONUQCcJJdTIMxcazfY/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-bindings-aggregator-factory-sum": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sum/-/actor-bindings-aggregator-factory-sum-4.5.0.tgz",
+      "integrity": "sha512-uw3s58igOuHAFLLXr5mS9nVFfA5V5fWxeyln2o/ggipLyDOVKCtkm0GHtx5oZTBNSdyrN2s7SrATdL9ouLbJMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-bindings-aggregator-factory-wildcard-count": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-wildcard-count/-/actor-bindings-aggregator-factory-wildcard-count-4.5.0.tgz",
+      "integrity": "sha512-2D+uykC2LmwmgjQnDaGM5dOJf7CIAetRHUlL29P6WA5J3iWVuRZurIVajexvi7yufk+emajuTGnGuZIeB00SnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.6.3"
+      }
+    },
+    "node_modules/@comunica/actor-context-preprocess-convert-shortcuts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-convert-shortcuts/-/actor-context-preprocess-convert-shortcuts-4.5.0.tgz",
+      "integrity": "sha512-Uu2buxdBxq/0u6Pr/An4FDdafH1bvDCdImeEBBIVfleeYuUNR4klbXZS0M7YxTpYanpNOw9v/i6nHIfNMgFT7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-context-preprocess": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-context-preprocess-query-source-identify": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-query-source-identify/-/actor-context-preprocess-query-source-identify-4.5.0.tgz",
+      "integrity": "sha512-iabRMWYIvolhN90lREOW/nvHY2JmF+oRrQUsELFjyDQnEirY0IHFl7kUskn8RvGoLmgPCKD9nIB3yNPgL/Ggpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-context-preprocess": "^4.5.0",
+        "@comunica/bus-http-invalidate": "^4.5.0",
+        "@comunica/bus-query-source-identify": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "lru-cache": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-context-preprocess-query-source-identify/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/actor-context-preprocess-query-source-skolemize": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-query-source-skolemize/-/actor-context-preprocess-query-source-skolemize-4.5.0.tgz",
+      "integrity": "sha512-BTzlIXHFcX4+tniNAnnh+whGVy7Cy0Gsj57O3jcPjFYdj1Z0AFRValT28G1sYn0avPYoOE9JDAM5cgZVdxUHHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-context-preprocess": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-data-factory": "^4.0.1",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-context-preprocess-set-defaults": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-set-defaults/-/actor-context-preprocess-set-defaults-4.5.0.tgz",
+      "integrity": "sha512-xEm7KPg9G6IcciLbZ2tJ0v6vrluuy/fCZN2wCOYQ1ba6bgxZm/C15kFTwjm4YSsDhtQDADteiQZa+kzkBkuudQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-context-preprocess": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-context-preprocess-set-defaults/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-context-preprocess-set-defaults/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-context-preprocess-source-to-destination": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-4.5.0.tgz",
+      "integrity": "sha512-ndpws/8GzO8CsOuqYS4f4IJ5DXNaCGjp7LXcabeAGobY8F5B3eQ8zWKHjC3jZEaTt89rCiMzkudY2sNWGM0ZbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-context-preprocess": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-expression-evaluator-factory-default": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-expression-evaluator-factory-default/-/actor-expression-evaluator-factory-default-4.5.0.tgz",
+      "integrity": "sha512-1vXRPmcRBTwowYu9FAjEiHeaQv3m2rzhB2jqh/USoPFm0Zn4oR5Xdclyv3WfuhNJRaJWi2uB6P5ddRzimTuTCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-expression-bnode": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bnode/-/actor-function-factory-expression-bnode-4.5.0.tgz",
+      "integrity": "sha512-wIj6ertjQBSSiV6Kbk0h6AuxjQe/IUVJGGBuZRu+VvCdGTX+I/rY00/LdUzzbdMFJgamEwK5ML/Bwu2tZUFN3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-data-factory": "^4.0.1",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-expression-bound": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bound/-/actor-function-factory-expression-bound-4.5.0.tgz",
+      "integrity": "sha512-aClq0SWhyhL3G9HRlri0yyyVcb/gCdexXi3HHiWhI9udBK+oAZeOR/lM49i7/twS5ujPHE/CzbL6C0gtosZzvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-expression-coalesce": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-coalesce/-/actor-function-factory-expression-coalesce-4.5.0.tgz",
+      "integrity": "sha512-xD8oGIsKkzaEvzb7j2HMXzJfRi1onRCaUXRmVVWhf2sWA2YIoQWoG3nHMOAucMseo2FDcY+vYN2pIiSts+C2ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-expression-concat": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-concat/-/actor-function-factory-expression-concat-4.5.0.tgz",
+      "integrity": "sha512-zaNB23vpQkr+49MfBr2fnjahVEb0jTzUjOKO1Hxrb8geocB0coHAhQljejghATCRwnnsnWwcCeOvVE0bjCoU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-expression-extensions": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-extensions/-/actor-function-factory-expression-extensions-4.5.0.tgz",
+      "integrity": "sha512-wCF5jGU/MtTCL3vO0jImgwzthKDqSjJP8D+kK3Y9Sj4j6xumaF+cttj5EoflzK68uvkhhuMLsZY0PKLGkAnvXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "rdf-data-factory": "^1.1.2"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-expression-extensions/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-expression-extensions/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-expression-if": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-if/-/actor-function-factory-expression-if-4.5.0.tgz",
+      "integrity": "sha512-1nE7bXcMVcesnaMABAX7LKKc8PVNeIrg/TJ+LkbZ4LyV4GjUu0zQspuFRFFp/HMfpYOfO1pmhP3Y+kdVkRuFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-expression-in": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-in/-/actor-function-factory-expression-in-4.5.0.tgz",
+      "integrity": "sha512-ubIy7q0VmO8f/ffuXWPkhjKSI7+r1toltgGonunb9VJVmNe7IbpMKIdSiw0PtAyeZMavp/f5d7uIjYfgYbCsbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-expression-logical-and": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-and/-/actor-function-factory-expression-logical-and-4.5.0.tgz",
+      "integrity": "sha512-8Eawz0jPMmP7JFuhtEPwuSBw3hIVpscAuM/RUTOBfsgecjRZTQGMsRJ7LoDgLJVNlevbXoxtzBjL9COjUFBJ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-expression-logical-or": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-or/-/actor-function-factory-expression-logical-or-4.5.0.tgz",
+      "integrity": "sha512-SMJrSpbmOpP1DaHurnM5qm7oWk+dDNaoQZh+8dDCdxz9shSV7eOO7jhjWKhcuZsW6E94G6JSZFZZJkxtmKMrsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-expression-not-in": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-not-in/-/actor-function-factory-expression-not-in-4.5.0.tgz",
+      "integrity": "sha512-FIJGyTDCXLkz7OmBCB8ed/cCqK2QSmGtwNn/rFh6q9UBrks7A6BzZAH5H/32q6ndcMJwx+6DYb2aQMPlScgRkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-expression-same-term": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-same-term/-/actor-function-factory-expression-same-term-4.5.0.tgz",
+      "integrity": "sha512-uJxyZl9FXFFXN1Be90cPBLSJqXSVSYxVZ9j+rR4A1I47dc+TfAS/jWkoBsxLCtox3igm6ZkPzmMB066rHN/K5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-abs": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-abs/-/actor-function-factory-term-abs-4.5.0.tgz",
+      "integrity": "sha512-bqupPX30zWCJ0nirI3XkO9uzIuUSnw4jaWNQpI4rHXGdMLrjUNrokBXIZ4FfSXAaAnQOUb771st/XrNbEDJ+gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-addition": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-addition/-/actor-function-factory-term-addition-4.5.0.tgz",
+      "integrity": "sha512-pqJIeZFvCas3r4PFy4tGdXFiYR9ds99G87rytAWQkVnoBstOUFKXmc6Oq8dwoKCfAnZdfi/GH++Al8buu2I2Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "bignumber.js": "^9.1.2"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-ceil": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ceil/-/actor-function-factory-term-ceil-4.5.0.tgz",
+      "integrity": "sha512-Gape3scVRZgvY4DKGSFH5PSRB1TgnpcRJRWiGy9abvP1QXye3Ob4NIqEyO4iwPLd6U7zf3nyHYAec+4MgQp0nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-contains": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-contains/-/actor-function-factory-term-contains-4.5.0.tgz",
+      "integrity": "sha512-qUv31t9RJ+n0OaMcQBLLruTj3u8BdWj69Fq/tF01E8vRkaZgNf0WkAVfkJRRaYQxr4fpMtgWxzSCZ3VSaiXFUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-datatype": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-datatype/-/actor-function-factory-term-datatype-4.5.0.tgz",
+      "integrity": "sha512-mjucrTW+MJoyCOsvxKJUBqawbNsSacVCvkazKscEBdk1Gj/b75xWUEi7cJHCd1cD1ESHn4EA5PEqhYXUyDsxzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-day": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-day/-/actor-function-factory-term-day-4.5.0.tgz",
+      "integrity": "sha512-B2f3MniYbd7WR7vo8MJzO9jSBIeVOtXotpg9Mxo73Vyhknh7w6td95MpVxPJT8BXFVzFrkAh/OmU9nDcgcdB+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-division": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-division/-/actor-function-factory-term-division-4.5.0.tgz",
+      "integrity": "sha512-IJ/5INqBDXkxuvESllxYNE7Ted/Y6lRQPDvzu1HDw3T+hj/KtBINEr7zPh9yLuapuTCzapygd+kIGVaoemoSJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "bignumber.js": "^9.1.2"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-encode-for-uri": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-encode-for-uri/-/actor-function-factory-term-encode-for-uri-4.5.0.tgz",
+      "integrity": "sha512-3/8YNcg2gqG/Hc/0e24jTwepJqfU2mqhUG55kXNy5J3hKOyYza1wbNhBQUAQVFQcdpwKA/bzpb/YHwSov429Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-equality": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-equality/-/actor-function-factory-term-equality-4.5.0.tgz",
+      "integrity": "sha512-1q0L42931jvjv1b92nc18B/WAomYYEacg1gFJpUSsfqhGGAulA42+fTR2ngRDT0sQw/J1kT1WgY3fY1rHNADIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-floor": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-floor/-/actor-function-factory-term-floor-4.5.0.tgz",
+      "integrity": "sha512-E4jxcs8M5wLZbPdzlmOuoIAwNtTzu5oVzH3gnZnE9iBE0pfSrN6N6g0sRY7vFXKfMgJQqVMlPiFt+Cda7ZcPHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-greater-than": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than/-/actor-function-factory-term-greater-than-4.5.0.tgz",
+      "integrity": "sha512-4WcYnNaXX6d0gXHHChW7QwmG4Ywq7CRihYC4AAkIqP9e9TX+lqz7cXaMMyGICh0uHY4JwAg33i3Pxv54TdwCog==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-greater-than-equal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than-equal/-/actor-function-factory-term-greater-than-equal-4.5.0.tgz",
+      "integrity": "sha512-vziCkcJNQedtqHC5kxvDMlvkJ+uJzO520q/4QjMMsftxyvDfpbWfX3VKQitJdRlvnAcmdZpWKb8ylltbZ/aT/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-hours": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-hours/-/actor-function-factory-term-hours-4.5.0.tgz",
+      "integrity": "sha512-0GkHX9KnU1N+lHzgmGLKndt8QX+8o5Mb5I+QIZWHgm7tkGHIGOQWtN0eBWhiVnzV8MBz471vyAVPHYB/OKsi5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-inequality": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-inequality/-/actor-function-factory-term-inequality-4.5.0.tgz",
+      "integrity": "sha512-p89dQB30AZsuFnJhFzGczz72wTIsR3nQzROP8NMwDpyic5xMrKEw1QljK+leWugrhlCprBuMQTpWWAFGe9EVfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-iri": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-iri/-/actor-function-factory-term-iri-4.5.0.tgz",
+      "integrity": "sha512-LZ3HHdBiWOmNnulKdu+7XhcJQyysRGwtBvIkW6WFnIvQpapeHC/KZO1gD2gevUDo/VJ3l5Rg6bcPY+InVnPDug==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "relative-to-absolute-iri": "^1.0.7"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-is-blank": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-blank/-/actor-function-factory-term-is-blank-4.5.0.tgz",
+      "integrity": "sha512-hUlXgv+gJn7XyZQn9KPpi9R4ss+cFSMWxVvp02ZsmTZ8FKHYYkVP7CyGT1DqkBi17AjLlB4OcotjxY9qu43bTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-is-iri": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-iri/-/actor-function-factory-term-is-iri-4.5.0.tgz",
+      "integrity": "sha512-OzTNf4Lq+80x4M4rhHrptjJTpdu7Icl2Sk+K8B9v1adAPvinHoOEgiT1leRVqExccSstdtyOwBYCCBsJ/fhXtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-is-literal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-literal/-/actor-function-factory-term-is-literal-4.5.0.tgz",
+      "integrity": "sha512-SagBQvOMHm8BiXLoCM2fhHerDXYlfwgnnWUiVbK3M1y9SDvynItc/Wa/BpDbimS/EMmkJxIGjnVDAEQryX7TMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-is-numeric": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-numeric/-/actor-function-factory-term-is-numeric-4.5.0.tgz",
+      "integrity": "sha512-aqt73wM21ROHUgXsMZKFiJX2johJ7j1SUvnPfdCIIeUYTuxCKSjVR6sXNLH7F+u5kcXGS5hJwaYIvl//u3DqMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-is-triple": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-triple/-/actor-function-factory-term-is-triple-4.5.0.tgz",
+      "integrity": "sha512-0P9zR8o3/zsMYjmPvzX84dHKkQz2ZP5pjfactN57oo+SE5wCX9sb4w4WwN9DZwFifjqzxX3EMMBQR5dR1A7sBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-lang": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lang/-/actor-function-factory-term-lang-4.5.0.tgz",
+      "integrity": "sha512-sS574SUxEtR8WTfM1U9QavjC6+SCRxbgEM9uKxVe7sTu73bs4a+UGM5xSm4GBRSKMi574xcSGDBRF8lZua44sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-langmatches": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langmatches/-/actor-function-factory-term-langmatches-4.5.0.tgz",
+      "integrity": "sha512-VKX0DPiM70rXvtlHGBAiqWtRQbL7X8417+amOr7FV7SicC3vZhlRxQoO8VWMMRPtkJWDVbbzt6DQAMIzVt4JBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-lcase": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lcase/-/actor-function-factory-term-lcase-4.5.0.tgz",
+      "integrity": "sha512-AY8HhhGG7zJayAvRtxq/O31Yzz23lCf5P4Z2vjesEP1c0+fOFQJ7Dc6UkoxYHLmvXLtWHTEyNAv8khtEBTfEMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-lesser-than": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than/-/actor-function-factory-term-lesser-than-4.5.0.tgz",
+      "integrity": "sha512-K423u2M02PQxhfbc8O5mUGfYVwFft4IWgIYmIMs2e0KQc8JPHt8ba665ZWoSykkzTyIoR0bffXx83mjwdMa5mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-lesser-than-equal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than-equal/-/actor-function-factory-term-lesser-than-equal-4.5.0.tgz",
+      "integrity": "sha512-uFT9J4fVwZN6JcCnZrCkWXWkUddrp6amu9gGJrwkV++7pS/CjsDDAXuxYwQqtn+RsOZrsc6kvEX9vptJqdqRag==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-md5": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-md5/-/actor-function-factory-term-md5-4.5.0.tgz",
+      "integrity": "sha512-gzRiaYDyr1+ecJMGteO8/CSylhvRpgLpKBj4pMh4XOe1REpb9ld7rR8Lm3LzSVczr+DMabbXcPwInF77hf+drQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@types/spark-md5": "^3.0.1",
+        "spark-md5": "^3.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-minutes": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-minutes/-/actor-function-factory-term-minutes-4.5.0.tgz",
+      "integrity": "sha512-PJPr11nOfjPu7JiFZPwsAYNDlKP2dVcjPqmyMVYg0phnPS5QMqZqclAKPjZgK/A6ipWyLly5j9+uB1NiPoAaPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-month": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-month/-/actor-function-factory-term-month-4.5.0.tgz",
+      "integrity": "sha512-6HFV7p5rRSg8ZEKeAMeY2rpvO+MBI1aEnWkkm8Eb0n9Y9MID8RBDEoWjtim94L430xN+fzbVf2lnKEK0gG/k5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-multiplication": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-multiplication/-/actor-function-factory-term-multiplication-4.5.0.tgz",
+      "integrity": "sha512-cfSOAl8sKhkuJXRpIgz4Avm9ImjP074D3sjVNkptxoJsk+lMI21tbiaa7Kp6b88RV8xlHSMrzzaViX0SWD/rrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "bignumber.js": "^9.1.2"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-not": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-not/-/actor-function-factory-term-not-4.5.0.tgz",
+      "integrity": "sha512-W9Ux+wt2UnjHJVxyLIprGNCWiPJEGSxKBvldRZq4Yaf3O3ZsAShAP5wLzp4+jyI8IX4IFcEaERg1Mek5trl52A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-now": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-now/-/actor-function-factory-term-now-4.5.0.tgz",
+      "integrity": "sha512-bTnQUTg6tNO2orVMVCwMm+qhP61ye91Deabb5HNiDOaE9s5WVNbyyiWxVRmNx0TobPfveiNE4yRuYpHJNbMRgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-object": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-object/-/actor-function-factory-term-object-4.5.0.tgz",
+      "integrity": "sha512-AkFP8DgitOm94NygOc63Ow10kfU8HgcV0ndUOjwkanBXDsoErwd/cZTu5FSEYUP4XedV+RC7qVKp40m51ENggw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-predicate": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-predicate/-/actor-function-factory-term-predicate-4.5.0.tgz",
+      "integrity": "sha512-ceMRBdVHXwWkwZXhE8LgnzacHy6gnzLp95JW1nnEf9Q+/ADE8tpx5OGE+W1tFrCAJbvfkVCRldz6qOXNCqhTEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-rand": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-rand/-/actor-function-factory-term-rand-4.5.0.tgz",
+      "integrity": "sha512-5ORuC18AVkWtvWYjbFpFtB9Noxcw+rg9EI8KVYmN9oE4zW2s/SV8lz4Ybu4tWU9/IvQmyRSv1gr4MZ1OS+DMxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-regex": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-regex/-/actor-function-factory-term-regex-4.5.0.tgz",
+      "integrity": "sha512-HpUlfaDfOJ4PmaJGr4gUE2cpbFG31wcq9E0DNlDi6OlmMyTv1dYBOA0chiC/3bPUJ4JYADpgePu7kruNtEhgwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-replace": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-replace/-/actor-function-factory-term-replace-4.5.0.tgz",
+      "integrity": "sha512-eK/u8+MUB9miUlbH3ZpzQrLFdiXEZSLszOioumGyMSJSbBlASJs1CekKQ90Ed6o3X1vZ/hVlEW0gJNzW/1TkbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-function-factory-term-regex": "^4.5.0",
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-round": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-round/-/actor-function-factory-term-round-4.5.0.tgz",
+      "integrity": "sha512-6VWjonN/WZiBpxSOKI4NVvOs0H/O4+zTuhv4JtWwHjyKLkT/nhbNi0UtU/bnMKEsuFH0tSdNMJxfbOXaFzqgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-seconds": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-seconds/-/actor-function-factory-term-seconds-4.5.0.tgz",
+      "integrity": "sha512-kR1W9A3rZCnpgE75itDFVuZxejBKVOOxX0j1rVP96/Y1Fmsovm9sPo4pbTFTMTROuesICAWux7TP1N5avBWFaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-sha1": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha1/-/actor-function-factory-term-sha1-4.5.0.tgz",
+      "integrity": "sha512-ydGrQVq46uCHAWYUpA2cKGtYvITxl5MsWlqRnxlfnDHgZZI2SCP+ck+im6xBEvIHpMX9PnOQBWoEe1qAJ5NW8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "hash.js": "^1.1.7"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-sha256": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha256/-/actor-function-factory-term-sha256-4.5.0.tgz",
+      "integrity": "sha512-1fOo26Gc5oBEEJypbashF2KolrQfV7Z8OS6d1/sNA8NA05u1R49OWza3p3w91PAIOToGI5QiiIIgCn1bzpUwmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "hash.js": "^1.1.7"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-sha384": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha384/-/actor-function-factory-term-sha384-4.5.0.tgz",
+      "integrity": "sha512-2n9XIEU3ZjqWOeJHqzMziJdLouz57BXyGKUV44buOM/m9zZjkuO0oP+VI44YxcltUvxzwZnkZE9HpUDz3IgdBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "hash.js": "^1.1.7"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-sha512": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha512/-/actor-function-factory-term-sha512-4.5.0.tgz",
+      "integrity": "sha512-60pOulMI8QmW2KWNfOcfC3LdeqG9RnqMMBV/UGbdDSvQpTWQDxfeGj/qujCTNQz604+NCe9FGn2lz06YIFY2aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "hash.js": "^1.1.7"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-str": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str/-/actor-function-factory-term-str-4.5.0.tgz",
+      "integrity": "sha512-E1vrSf+tIL2GX09+ohqY9rjLidFmN33UnarWWOxxkLJCNt6biKBHR/D2eA8r4yADVSn5Ir6DBplns+xZcPE0jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-str-after": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-after/-/actor-function-factory-term-str-after-4.5.0.tgz",
+      "integrity": "sha512-JnrkLjqr31cF3Cw/ojAcnw0MZrZsLFZR7P6wlWo39DOIYPAvP2ztzaJZYlIeYIJn4+BIqiA5wrOBGGrDhLnwzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-str-before": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-before/-/actor-function-factory-term-str-before-4.5.0.tgz",
+      "integrity": "sha512-Usdx/eZBwzMqVz9EFNFivQDL5s+fS6GkQ6aDL7RunGI0eRaLKYpk2lhCULuauQVgdpg3BniMVW6gnwAqgcoJZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-str-dt": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-dt/-/actor-function-factory-term-str-dt-4.5.0.tgz",
+      "integrity": "sha512-X+hIJ3RgtEnfvYsxVqk1KDanGI6wN/1Y7HVM7TU+ErtXq1zLLA7V44F0kL4l8eH94BHnXONUL2IvBjTcNx3ocA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-str-ends": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-ends/-/actor-function-factory-term-str-ends-4.5.0.tgz",
+      "integrity": "sha512-yH54gsUdIXEEgLL1Q0TF8GXM2l27//TipImXk825yBzpSF+MvS4QlrRQ9lAfJjUFeHrUvqLYrC8mLCtnsbHhdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-str-lang": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-lang/-/actor-function-factory-term-str-lang-4.5.0.tgz",
+      "integrity": "sha512-uupsgyA4NjzO7wYsswfuoSVEqtFJreRk02zjggcISUi7TXfDBKiqyzDELNveiSVK7gDUk4vzbbFuVnT35/fJPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-str-len": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-len/-/actor-function-factory-term-str-len-4.5.0.tgz",
+      "integrity": "sha512-2sr025H9rj7hJIO0evfNYj2Fm6KuaC4PSi2hfIy/DGd7uaWPvf+5d+axfsL/gk48SZPjcGyOgum6tjbm+/iS1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-str-starts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-starts/-/actor-function-factory-term-str-starts-4.5.0.tgz",
+      "integrity": "sha512-Qw4jUMM5SQDcdtTip809CLN2LU9nOlK5QsyN2mG7HTHwf4QjnxDXozq2C4fTbUzgYGMTROgQO/wbTPhzMKdgeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-str-uuid": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-uuid/-/actor-function-factory-term-str-uuid-4.5.0.tgz",
+      "integrity": "sha512-Yj5bsRkQ4omf85L8bMqjRgIa2sd+KVBvMvD04zAie5KcbnH8zMSBG62o4MCteQz5jDGZsyYmX9JeUXhmHA9UZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@types/uuid": "^10.0.0",
+        "uuid": "^11.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-sub-str": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sub-str/-/actor-function-factory-term-sub-str-4.5.0.tgz",
+      "integrity": "sha512-br0Ihpcpi3D71rWOTC4BvLiIMJT2Qtt8wZEJGNEfFsLV9DfQIO3YhpFuMyPxGZoW5vkWuFVXzmqcK0JuwjLXgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-subject": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subject/-/actor-function-factory-term-subject-4.5.0.tgz",
+      "integrity": "sha512-9C7qD7BZ9jj+S//aXGvYqNfA/HCPBAPzWz7bBe+eONLnLE/7GjlNj9wspG51gh/gZnJMlUHVLxrLAMR4AxLaWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-subtraction": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subtraction/-/actor-function-factory-term-subtraction-4.5.0.tgz",
+      "integrity": "sha512-INkhG5dQZekt3W6tUL4JIjO1ZVHV31OQoAWQv4GEs/a19WM1EMp3oHlHqo8yOqZgnWbBMb9oarOjRYINthaLZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "bignumber.js": "^9.1.2"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-timezone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-timezone/-/actor-function-factory-term-timezone-4.5.0.tgz",
+      "integrity": "sha512-N44SF5MfzjFhRNDtjJO+E6lfJBX639Ogb2Oc4x2Qh9aj/OUuHuwONEtCwaoUADIThBdDiTTGhlsfwe0tUY3e7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-triple": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-triple/-/actor-function-factory-term-triple-4.5.0.tgz",
+      "integrity": "sha512-U4yIpuR6n2w9YdRXhrONV34ju8CtVm8jA0pBopnFYK/GwnJqp6YIn00B5AC/WdKDUVZUDgNu9j+XgpwJxsN6pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-tz": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-tz/-/actor-function-factory-term-tz-4.5.0.tgz",
+      "integrity": "sha512-wliS6iY6eDbezKYs6CsVoRqvM6ZVNxKRubEexJYyVPy/DF/KHi2Un0iWQGYu+DM6rRQ5gD/kSjmO5PUjaSvtpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-ucase": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ucase/-/actor-function-factory-term-ucase-4.5.0.tgz",
+      "integrity": "sha512-ygsPFyHpE1vZQvBdLiFsSMrQDw7XVl8KDlWMl0Ntj7w6UZt+DWHAfXzxn94fr2OfBrqguqRc8MLQTsX5IjK+Mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-unary-minus": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-minus/-/actor-function-factory-term-unary-minus-4.5.0.tgz",
+      "integrity": "sha512-f3FsopxQIIIiBQtAHcW4KjW3/RAxAjgNPse2BumY6igUjY8vkYPiqRDMdQkl+iV0tLprGYu0BXyj95F23X/wcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-unary-plus": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-plus/-/actor-function-factory-term-unary-plus-4.5.0.tgz",
+      "integrity": "sha512-CvJhzQE/TyyVgvbkSEyiLX0NWAeiH1cOkpWTCqazpjRoTsyvrmNQnrdO/c8yPOyylRMZ/sA7Glad8KyBVdTXqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-uuid": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-uuid/-/actor-function-factory-term-uuid-4.5.0.tgz",
+      "integrity": "sha512-AHDwJR0DxiQexuYLH6EhOirMYcoOOuGW8KhbmCnBilVsx8juZF42l/xiTPbXXEE7QlHGiJImGxkUZF4mcidX9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@types/uuid": "^10.0.0",
+        "uuid": "^11.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-xsd-to-boolean": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-boolean/-/actor-function-factory-term-xsd-to-boolean-4.5.0.tgz",
+      "integrity": "sha512-W6uIE3lRGwOpeiuxV7DclRMchm4l2Pnjb8AimAkI8DTt1Q/hEsO3MmO06Fx098OZZCpMk5kV89up92VOKaZTaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-xsd-to-date": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-date/-/actor-function-factory-term-xsd-to-date-4.5.0.tgz",
+      "integrity": "sha512-mItiMbvoz63VgmkSYWTvqf9w9OnPXzhpe4WYSV7vKnMTmwPflCAszM6glIiN+UXKNhYFBeqXIxrRZ/fFJPu4Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-xsd-to-datetime": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-datetime/-/actor-function-factory-term-xsd-to-datetime-4.5.0.tgz",
+      "integrity": "sha512-U54xs8vL9lkpHyJBwZA4Ed/zC6twOGPl05ApFomsyw4JYEoF0T9MyGQwJgwrDRz6NLaNdbrjtrC3BN/sk9XIdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-xsd-to-day-time-duration": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-day-time-duration/-/actor-function-factory-term-xsd-to-day-time-duration-4.5.0.tgz",
+      "integrity": "sha512-9LDlkfdjpeLf2sJCCTK4JfPUqAfZ5WC3DDb3JiKeSWn0a63o1bUuvznEZniqZPJ0XPDJ3uYd7oXRlWGHP8TCKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-xsd-to-decimal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-decimal/-/actor-function-factory-term-xsd-to-decimal-4.5.0.tgz",
+      "integrity": "sha512-J4mhhGWpkm7K+vJTzxoG7Skon/PdasA2Tl1OUOYboU1SBgaEsIovoIxsDqdVV6HU7O4mHli0ZXH9HM5KVM+GXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-xsd-to-double": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-double/-/actor-function-factory-term-xsd-to-double-4.5.0.tgz",
+      "integrity": "sha512-CsoZVOz4FqEGlyRvFDwhtFELL8hSRysiDD78b67esqEWMYWVPfS34/SaRjgN335tkIFiCM9xEq0vA0I2kLlsnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-xsd-to-duration": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-duration/-/actor-function-factory-term-xsd-to-duration-4.5.0.tgz",
+      "integrity": "sha512-djMWp2ZXz9ffY3JYivsgCH+tJQLia53P0/sqLXuCeJoPsg3QpKoSpwy9wIBkAcaLatAhn6jQJAZTeEVWPNlY+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-xsd-to-float": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-float/-/actor-function-factory-term-xsd-to-float-4.5.0.tgz",
+      "integrity": "sha512-F/BpWl3AEZeSoTe9TF3xd3sgI8g6F4q6+hekSQcp7LWLChn4ln+Bl4N+ZRocxIFJevFjGMnnjtoOi25iOhVx6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-xsd-to-integer": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-integer/-/actor-function-factory-term-xsd-to-integer-4.5.0.tgz",
+      "integrity": "sha512-diT42cLv4L8ZrlvL5UxQ50EXyZj+Id94RJUZjewmnFb13NWrfwjKKS6bdtFV+rNtiVPsvVOgzXyJEws6tHwjUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-xsd-to-string": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-string/-/actor-function-factory-term-xsd-to-string-4.5.0.tgz",
+      "integrity": "sha512-WMKc1Y+leNhUxUUxlgur+Xbq9oHhqI/VUbkPlqcEYRGHH792d5D652a2yND8SbxpF7gdsPpoFYpBmmAwipsWQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-xsd-to-time": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-time/-/actor-function-factory-term-xsd-to-time-4.5.0.tgz",
+      "integrity": "sha512-5C8e71T6FN0Wt1K0C2P2ooC1uBFid7UBkeGhB+GZvbiGcYe3jRJgTACgCGhONuqgIqNvrRuS0lbS7/eKp1dC+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-xsd-to-year-month-duration": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-year-month-duration/-/actor-function-factory-term-xsd-to-year-month-duration-4.5.0.tgz",
+      "integrity": "sha512-+wKVAq7emP25PgjyDZeBWF5hlOJ3SNOtMRM0lfU3cHgigxKs91BELss0JSdHwz7oxTwuxLMogAeA/sknMIvC7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-function-factory-term-year": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-year/-/actor-function-factory-term-year-4.5.0.tgz",
+      "integrity": "sha512-o5Em71Rj3w+YnDbDE5Rkjzlc/enXPFxnFFesAHx8BXwqTK1Lqr2x2izYI1mZvjsy4czwtY7t3Qa9OKNc/AdJJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-hash-bindings-murmur": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-bindings-murmur/-/actor-hash-bindings-murmur-4.5.0.tgz",
+      "integrity": "sha512-bebfR1rwPT+TPgT07P7cwblDlP8/gVPIALZMIqU0w9IbH54kZcFsnc2OQLUCar1Aq7EZUkny/lY2UjcHagObcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@types/imurmurhash": "^0.1.4",
+        "imurmurhash": "^0.1.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-hash-quads-murmur": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-quads-murmur/-/actor-hash-quads-murmur-4.5.0.tgz",
+      "integrity": "sha512-3A3aNcY23HWKoz+5BFyZXNoLYsuiRh9WGYJ+zzZkMOuNopUr/z5+JoYXbQKbbd8iQeKctdCzi9eE4XMU8emUSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-hash-quads": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@types/imurmurhash": "^0.1.4",
+        "imurmurhash": "^0.1.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-http-fetch": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-4.5.0.tgz",
+      "integrity": "sha512-rhPBWOWe0tGDgwXbRgURwiGcbw1KY58oMByT7MVi5SLMpiK1Tjjb6KoMz5SOkZWsD1z6JY65J/VLxKFSj37ogQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-time": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-http-proxy": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-4.5.0.tgz",
+      "integrity": "sha512-M5UQ+/IqXFNXLu9qSFNeeph/vaP349HQozqZzOY+HTO4TNWSIcB/XO6HgE3SC7r4G+KV+s9WbHwQO/8PxshBPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-time": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-init-query": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-query/-/actor-init-query-4.5.0.tgz",
+      "integrity": "sha512-BC+5k0qRxIyl4j00tbqiwKSoOHBkcApMVvXfzYGnK/KgJC8Xj/cPivf3+64Nn4oMgm5kJbp5VW9v7A4+6PB25w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-http-proxy": "^4.5.0",
+        "@comunica/bus-http-invalidate": "^4.5.0",
+        "@comunica/bus-init": "^4.5.0",
+        "@comunica/bus-query-process": "^4.5.0",
+        "@comunica/bus-query-result-serialize": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/logger-pretty": "^4.5.0",
+        "@comunica/runner": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "negotiate": "^1.0.1",
+        "rdf-quad": "^1.5.0",
+        "readable-stream": "^4.5.2",
+        "sparqlalgebrajs": "^5.0.2",
+        "yargs": "^17.7.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      },
+      "optionalDependencies": {
+        "process": "^0.11.10"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-assign-sources-exhaustive": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-assign-sources-exhaustive/-/actor-optimize-query-operation-assign-sources-exhaustive-4.5.0.tgz",
+      "integrity": "sha512-FPw1xidcpP1b6hVJ2zM3ib6wvHEoVnHEuh59jIgRV6Iz5idraCK3EVagYCxSWo9Xj0NR48/6DUVMjVWl7JMnFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-update-quads": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-bgp-to-join": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-4.5.0.tgz",
+      "integrity": "sha512-1raQz4vjZ8MUCAhh4EYcj+6aLnb292NJoSc+jTBC+u5rtJ4gmFqNDyCJxjoI/QbxU9Ioy2Hlj4WxMq7M6F816g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-construct-distinct": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-construct-distinct/-/actor-optimize-query-operation-construct-distinct-4.5.0.tgz",
+      "integrity": "sha512-1phqt7HRuGMf6DzBYxlwJG8gw0KTyfFomhc4Uvr3QZrzRJ9Z41NgDTkSd+OGhbxwFm+aJ5O51VSi0FRK5K/Rvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-describe-to-constructs-subject": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-describe-to-constructs-subject/-/actor-optimize-query-operation-describe-to-constructs-subject-4.5.0.tgz",
+      "integrity": "sha512-bPN82pm7InpjtNvrehl4qaYAu5G8gz2pCzviPo3rHi3syYKMDDXHSW51IpkE904YAysuKbgX4hPZ17WENh4Wpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-filter-pushdown": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-filter-pushdown/-/actor-optimize-query-operation-filter-pushdown-4.5.0.tgz",
+      "integrity": "sha512-2U2uSbaJPCy8pngkJ/c4QKBHObzulOndFO1c2lrdfeMuyq3usUEcxBvoWufeKWhdit88Re+wHJyPY+ZYw5T7hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-group-sources": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-group-sources/-/actor-optimize-query-operation-group-sources-4.5.0.tgz",
+      "integrity": "sha512-IsRPmnSRzKzW/YnKlRQt06qs+ytn1ML50MYwq1siUS8GpCHlBsb+uhYPDb3+1gr/+TYPZro7PzGS4Gn7pdzfAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-join-bgp": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-4.5.0.tgz",
+      "integrity": "sha512-/rl5ig8O2GVTrH0Ux2CjAjyTvv7XvH4nYOjuQwZx05YmsPb6rEzzE7RAGoln4qZNG9TY4X0cKwxQcXmyTJMDGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-join-connected": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-4.5.0.tgz",
+      "integrity": "sha512-wJ0obFZHNaQSlyJCwWlfm/8OqNvHSLdXWlfAm3ZWeeDg7QGBDMZjdoHG5uNSYRsYzxv5GGMduTs1C2kymgfkqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown/-/actor-optimize-query-operation-leftjoin-expression-pushdown-4.5.0.tgz",
+      "integrity": "sha512-j8aHL24PNXhpdDuLNmxUK5Y2JRZDELKZK12vCosAkh9YBcvKRM6liGm8IErfMWqLIk8W9SGac80MP04CCiaAKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-prune-empty-source-operations": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-prune-empty-source-operations/-/actor-optimize-query-operation-prune-empty-source-operations-4.5.0.tgz",
+      "integrity": "sha512-xyLHO3ZP62QAviQcAuluZuNQThyu0x0qT8uSy3EcwdLAaaAasZFf0TYric+cMMFeVk/lkbi250ksnx8HOLDuQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-rewrite-add": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-add/-/actor-optimize-query-operation-rewrite-add-4.5.0.tgz",
+      "integrity": "sha512-n9MgkIpjQ0OswV7tmaKGPruq/WaeOeHzjPt4uf7zoLBGna5UsUWzuL/hnQyIH69zAEDhzyHy2COCefLMKkIyvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.2",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-rewrite-add/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-rewrite-add/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-rewrite-copy": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-copy/-/actor-optimize-query-operation-rewrite-copy-4.5.0.tgz",
+      "integrity": "sha512-dlzn9XlJmgGS32xKiuP++/9qAEPWgXDZ9j1dOBscIzVfsbcwx6zdHbQ6qB0vFM7Ged88CIGS4waCSE/S3gExdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-rewrite-move": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-move/-/actor-optimize-query-operation-rewrite-move-4.5.0.tgz",
+      "integrity": "sha512-ITtO/5XpTewCvDuCISmtX2NGampMCGpHf6s3ew/g2YBEVSeTDhqgA73isHA847Q8cfxOESwChGFCP4CuiHv91w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-ask": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-4.5.0.tgz",
+      "integrity": "sha512-dqO3ztOtLlxtwuG/cSsFcEb3W0hHR9mzS3MlXb+GH5u8n1Phidk8s1mfMQKoYdyTfTTnxAVSMcolHDN9VOl18g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-bgp-join": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-4.5.0.tgz",
+      "integrity": "sha512-/LR/RjHoBk+YBO/FPx+nd63b6pA9OHEMzrR3U5aejIHZ4X3vCiHxcTiGWLx8LffZVKLamsL1NeWnsAa3g4t5jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-construct": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-4.5.0.tgz",
+      "integrity": "sha512-IIVkna7LL+MDGgQbmCAlXkXDGUu2r+hiuu7nY2RVqA9uNqgos1hHwbK2+UWA3rvyCzI/ECIANXX2PInm3ieXvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-distinct-identity": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-identity/-/actor-query-operation-distinct-identity-4.5.0.tgz",
+      "integrity": "sha512-WRhvsT2UpHcgKWRuiWGeu7wX+ITjpfRw2++pPOizL/Wt4EFQQBQNxrPasrUce33jVws1QxS6zlSY+bGzUmeljw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "rdf-string": "^2.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-distinct-identity/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-extend": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-4.5.0.tgz",
+      "integrity": "sha512-dbpTn3EyTch8Aw57KEKCKHCFMKaSLd+KuakGxrTxSiAjbjBJL/ZL4vhGZDpx0xI1IKA8PVFtgsLuUk7IpnP59Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-filter": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter/-/actor-query-operation-filter-4.5.0.tgz",
+      "integrity": "sha512-4kWfCh+s3X/cab/2z/ZW54ah9gAfUiZAmy+DgXNqtj6ty+zBC5ZFKCFbe+O7orvZOrfDD1kwZmvdAR3GO7RrBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-from-quad": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-4.5.0.tgz",
+      "integrity": "sha512-CGRDCTWYc7hi05/d2GUVTNqF2sekcloTuU+uCrqnPMR9g6//KAq7n7QjBC/OZQj7q3454rjnhUxHf1ahTJZS/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-group": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-4.5.0.tgz",
+      "integrity": "sha512-6OSCo3ssBuri0Euf6E9IFbZH7/DP0RSJre549jruLIEAed+XTreStpI9Unx1IOKAOI2X5Xv2cfLfuGubH3CRBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-join": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-4.5.0.tgz",
+      "integrity": "sha512-q2u/PxmP7LLdqpIv4teKDrxTjcqH89aRf34X63nU++8TvEzml/786/EMLmVYshgrWsNShbw9afrmwB6DWNCcpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "rdf-data-factory": "^1.1.2",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-join/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-join/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-leftjoin": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-4.5.0.tgz",
+      "integrity": "sha512-F240YX+ILF1QFW30oGK7bnapo5gkwHWFPkX6UME9ogjdq6AeosM3boevtwsUVp3ykz3irsExdJDIU24QtvYhuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-minus": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-4.5.0.tgz",
+      "integrity": "sha512-8UqLHadZHp0jr2LujjtlKYFdKGZdG24PoKEJOBZpxAgdOFd6QirBFR5TA5QlIjm1o77yzLzPLSokjvlYswYW6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-nop": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-4.5.0.tgz",
+      "integrity": "sha512-Qh3ZK0YkcH0FcAf8U5U22076ZWDSH37m9vbm1yYPdn/ag+G9TXf63VxcYpLcFQJFB7LM6b+6LNQezMfFXiqoYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-orderby": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby/-/actor-query-operation-orderby-4.5.0.tgz",
+      "integrity": "sha512-s28lZK5M9XewM5wl+RfuqwWwcBYpIMnpEPRD6cco5bbP6m9gXZAo8KHYsDfdfBKiOfWDxIcP3QpDJZajmy5KKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-term-comparator-factory": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-alt": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-4.5.0.tgz",
+      "integrity": "sha512-bgM5/lE6C/no1g5XZZi8CL46SURZtgmernDsd10wQdzXYZzlNcxO8yu1C/HozTyKsIlRpv8FTWgh2a0jbsJlJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/actor-query-operation-union": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-inv": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-4.5.0.tgz",
+      "integrity": "sha512-s30h/6aEzzDxgCjy9fz/RVGakiSAD0+GAGvMmMF3zqhpM70lD6dwaMQSwxAH/7IQiEjR7VlrrYPMTI0ljK+9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-link": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-4.5.0.tgz",
+      "integrity": "sha512-Pyu1KpBOvOPTFD/tQ8JcXNzA+TnJVTggZSIsfCdzXJePx5zVglXT74cHLAMP0MS4QI709JrNYDveUWBYxJrcVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-nps": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-4.5.0.tgz",
+      "integrity": "sha512-gziMhls637aQyt86J0uRfGYZlvRuOH5fPExocoqmALh34bi08/hqGUnuPBRqYX7dBnqgIz5daInqhBGaWpvyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-one-or-more": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-4.5.0.tgz",
+      "integrity": "sha512-4Q/WcptuCR7asWzZShupvzfcR6KPsdISdYdguvDnDC2wkiI8DJKkPxek5fCHth78twWqP93WZnkKto3pfM2Dkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-seq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-4.5.0.tgz",
+      "integrity": "sha512-uzvJZWEQ15VpdiVvhcS4eDmQREHIDnyG4/eBsSsh64d/sBTAlnF+jTh10OF7UIBD1IpGwL3u10DoV8Xz9dhOLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-zero-or-more": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-4.5.0.tgz",
+      "integrity": "sha512-8HIBnqBgDEZTiiok9/Biyka24YWfDVLlJntJRX2i+qm20LLCzKqfqM8LyfmuY9xCxLzRHfZplwUMt9p1FbxcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-zero-or-one": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-4.5.0.tgz",
+      "integrity": "sha512-V22P9WtJDLzLsWot/CLmJc9v566LmCoNApFGxAL9TgZeIKyZsKVESMb/TEI/GkXBuMxjAyCTh2cRm2ORztiH8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-project": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-4.5.0.tgz",
+      "integrity": "sha512-8tFqMnM2gaEzewE25PTm4UQMZ4kUUoOrbFS7OM65Vns3Jvw8cYwYCoYAT98L0gHMGG5z0UTYoOHMc+PdjBRuGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-data-factory": "^4.0.1",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-reduced-hash": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-4.5.0.tgz",
+      "integrity": "sha512-yaA/jF4y2vxzS/mjK8UEGMWZtDx3joPPbbcidVACW02HzpXHpNGYUfb2OZOK1LnnaJayms9lJd2kfU78UThRsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "lru-cache": "^10.0.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-reduced-hash/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/actor-query-operation-service": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-4.5.0.tgz",
+      "integrity": "sha512-YuivydtZj4R+zbzQQgp1NTCLoXgP/sfquIY006LW4pQ8iyuY8nnCgH5lbmizHkuxGSmQn/Ii2HZOTMMaa3W3qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http-invalidate": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-query-source-identify": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-service/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/actor-query-operation-slice": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-4.5.0.tgz",
+      "integrity": "sha512-SWBFYpFwu1Ns53BypSR61YuypYcwifsyxvJ2s4mjg5EHBc+myUXf/eoeXl1TFYKWZsUp6xOvCZCLcxsMMM4OTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-source": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-source/-/actor-query-operation-source-4.5.0.tgz",
+      "integrity": "sha512-N7Ncs92KOYQ0uKBc0P3hZ9/7yHwchnazH+wq/Gufm/WsWPt13YppB43rSJHzo0tBkVMvI8MbZvkLj3t46/wYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-union": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-4.5.0.tgz",
+      "integrity": "sha512-cKBEYMc84lXREjj9ta30idl4wYKQnSXS1P3tpyuUcc0AmGFVWA6+VzJEgKzvH6Mpbe/PGA8nhTqDZJVLi1XRXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-clear": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-4.5.0.tgz",
+      "integrity": "sha512-R6x13rE4JU/QlDoBQXAJadtYePWB82UTGT0r3xgNaXgRaODWgaSPXadPvxRLoI9HSX0DQrJiIXaNXH0EDdGtFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-update-quads": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-compositeupdate": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-4.5.0.tgz",
+      "integrity": "sha512-/7hwBvrHUl9f2arb2Z4KOOyTjFNdSAspLofGmMVeM9f8TkPH96gDMRw1+RM4qcuTLEbdJn+efc7YzVJrVmwSDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-create": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-4.5.0.tgz",
+      "integrity": "sha512-BphWTXX81Bpv8hq74eIkPWOi2K8/45UvM2ayQp3RblSlD1fu0GcWnxcoexLFFw1aM4Xd8sCvgRtq2k0HwhgdoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-update-quads": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-deleteinsert": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-4.5.0.tgz",
+      "integrity": "sha512-spJ3Rpj/FAM8tAo35ggFyFWamOfBfHZBT/eMH3CKLJ5qXEJcB9JvjxD/kmW79aMhsPSqlOqyTQ7p3g7OcQd0Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-query-operation-construct": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-update-quads": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-drop": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-4.5.0.tgz",
+      "integrity": "sha512-jVDTwPANfoH6iUzuO2RvVoDZ0tVpyShWANwEpvvfWRocj/oy55p3tF/1CUj/I/6IVXsiBs32xivnGeP2Aurzkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-update-quads": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-load": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-4.5.0.tgz",
+      "integrity": "sha512-ZNQkrhLwUjjLdrkYE83SafnhtSt0LEiAE+cS+soRZwl9GLoIPqfRyE8+r6hPHVKtBefLkTQC01dBC53vb84cTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-query-source-identify": "^4.5.0",
+        "@comunica/bus-rdf-update-quads": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-values": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-4.5.0.tgz",
+      "integrity": "sha512-3RTTA2drfC3gr4VtomTMhhXuJGjmZW5NiiX/QhKLwkxEzVp8JYDP8KTtaMG+HWvNzoXNnLgFjY+69SCVUNfk8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-parse-sparql": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-4.5.0.tgz",
+      "integrity": "sha512-cteTjZAipUsC44z67yyCWe+4FMxBAFv1tNAe2omaqDMo8nLZJ2qnN9wj4ZqOVQuyHSGLeg5V7umc5O1m4FgFKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-parse": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@types/sparqljs": "^3.1.3",
+        "sparqlalgebrajs": "^5.0.2",
+        "sparqljs": "^3.7.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-process-sequential": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-sequential/-/actor-query-process-sequential-4.5.0.tgz",
+      "integrity": "sha512-3MlrVQfY7iz0V17jnlZzeJLav1AtawnXZTEK3Jvsnl7lQrzYJ0rEvvGCeAJ6LCrhHmE9cMI0KtghQnKO1zxuDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-context-preprocess": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-query-parse": "^4.5.0",
+        "@comunica/bus-query-process": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-source-identify-rdfjs": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-rdfjs/-/actor-query-source-identify-rdfjs-4.5.0.tgz",
+      "integrity": "sha512-OODcg3Sz0TAkClTlhHout6hAgikbtm/19rycJeOo6QbsM2dUohnKrk5pXNvlTfCqIj2qsvqcnD5YTuIRjYhYiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-source-identify": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-entries-sort-cardinality": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-4.5.0.tgz",
+      "integrity": "sha512-Tk4AxcP0BdC9e5LJQqcCx1IvrVeeIbRYlin6u//s70MG4QZesFdFl3kNRPWo7PK2M40XT2yO3j5tSNrkj4TpxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-hash": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-4.5.0.tgz",
+      "integrity": "sha512-goMj2HrfZp2rP30F+Ea/n8E8qYbhPHv+qG335RAX1NB1/QuIzhhKf5BP5fYVfEu55lhFAy2WpNn/eDYfXEj2Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-index": "^4.5.0",
+        "@comunica/utils-iterator": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "asyncjoin": "^1.2.4",
+        "rdf-string": "^1.6.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-bind": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-4.5.0.tgz",
+      "integrity": "sha512-jCJyQ0E8G589V5Is3fK6W4LpPwKdOv3jC7MtAPdbRzq57l9aY7kYc0n0U4lC7mGSjyPMAcvCQJCE8MMqYyFmeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-bind-source": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind-source/-/actor-rdf-join-inner-multi-bind-source-4.5.0.tgz",
+      "integrity": "sha512-pnd/r9YW21yxxmJIq8GEz3AB6Qrmvxj9zh04xOw8407Kicxf9iZ2jFm1z5rtrE3fVX4gh206wwKNo5dopOp9Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-iterator": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-empty": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-4.5.0.tgz",
+      "integrity": "sha512-f9FDa00yqmxIn9n0YSc+JxyJGHR/TKQTlkc4A/lkBbHauD+o0LoryGIm/88mK4ZEDG0ebz2s1znmspCEyhol6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-smallest": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-4.5.0.tgz",
+      "integrity": "sha512-X9cVWpImkX7ovYxaRMS5w/Y6z7izvAvglcl6Rn4qnL/u3tsgFEcvVb+nMkGjH3+Dk5yef+oThCvVhc5nb7t9mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/-/actor-rdf-join-inner-multi-smallest-filter-bindings-4.5.0.tgz",
+      "integrity": "sha512-i04prUsnBsdgPvL847NeZihXiE5Pn5mdcYO4i/LDsPoOoD2vcodm2WvfVl8bFI69FJIIyuf/VlfQOFKNp+9JbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-iterator": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-nestedloop": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-4.5.0.tgz",
+      "integrity": "sha512-+u8peRhrLHmTSyMHkKN4Ky0OmUAVteu9WDHagtflNChhGL1OGMZuO1tw+hu8YCrK0/fWCd3ujgr9i5u4Y49iog==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "asyncjoin": "^1.2.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-none": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-4.5.0.tgz",
+      "integrity": "sha512-PSOkwq2NMvDL6ikcDuPEa1Rp2aqFlmgvAzUk8OhiCDI0kEqlUzWxskrqQIjVneK8PmJiV3CaA+QkfDp/V48h0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-single": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-4.5.0.tgz",
+      "integrity": "sha512-XCSO3ULvMMfpmPduzj06oInkvUyTk/n0/p7ovhC/A/0zUJc6Ml9dPrwJZdCiHWF7zjqd74mDrRmu23ouDmuwow==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-symmetrichash": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-4.5.0.tgz",
+      "integrity": "sha512-TgOoAG/Z7+tgR/vLvym7v3udcIqcD90+w5ttQ+hTa7dfHw/NNhAUALmK6ZMa6uJ6RWeNUu2JZSDDaLFkPDeqDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "asyncjoin": "^1.2.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-minus-hash": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-4.5.0.tgz",
+      "integrity": "sha512-3smcJln7Tr+wNEiRuL4KPO+FodMhqQeIaEdnEcs+gzU6JAE9zlPtJDqlTn2pwmUfUYg4xXcScIQJHJoBuf516A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-bindings-index": "^4.5.0",
+        "@comunica/utils-iterator": "^4.5.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.6.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-optional-bind": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-4.5.0.tgz",
+      "integrity": "sha512-R0XBCZXv3bL0712FIwqZ+2U+P+k9YGgQFLHI2/PtW9sJWi/s79JSYnwnACfEEfMwIdkPHwK0NIuNmnw3BTT+1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-rdf-join-inner-multi-bind": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-optional-hash": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-hash/-/actor-rdf-join-optional-hash-4.5.0.tgz",
+      "integrity": "sha512-ogSoBp2OJGZFlUyu5XnggNKBhhQoYBivf4Avvphnm4xZ+4IQmLfwBuzEXhPTZN5Yyfu7L0hQK6Kykk1YuAZo0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-bindings-index": "^4.5.0",
+        "@comunica/utils-iterator": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "rdf-string": "^1.6.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-optional-nestedloop": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-4.5.0.tgz",
+      "integrity": "sha512-szhKIYdV7r6Sv1+q7WW7831O33dO7yYlgbsTDwPir5hgLYHRprrjDFKhPbyA361waWiR7JLrUfdJaXt6FbSIYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "asyncjoin": "^1.2.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-selectivity-variable-counting": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-4.5.0.tgz",
+      "integrity": "sha512-98plhmPvrnYPXQa5PES6sAeNFB+qrGiZg1bUvAM5Jtg5jQ9BfwH+Bf02yIVAfyACjaLaTNGoOP/qHzb6HrUQdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join-selectivity": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-accuracy": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-cardinality": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-4.5.0.tgz",
+      "integrity": "sha512-fHQAs1dqOGwWrSAyCLMGMU3M1GKbjjvcyKS9cYwN47OiT2rEsbBZ1sGWOcpNgxJa4T59lvO4RlfDuuMpmcYLSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-pagesize": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-4.5.0.tgz",
+      "integrity": "sha512-V3Gci3XEN4gO6w+dSHt9QnzaO1+lhytmYxoHIkkwVcjh4X5WYxM82D2fjFf4dW9xF0Yej009ps8RpuX54YRseQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-requesttime": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-4.5.0.tgz",
+      "integrity": "sha512-Br5hlNujsRFCHJ0g48oW8xBBQvDDT5lNaCuY0ky/sIv/ULk5aT5J/jBIvc5aeIXpA37D3KrvfenXz3ScqvTHSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-4.5.0.tgz",
+      "integrity": "sha512-43PrAVCdHLcbJtPqZOVB9/4Zm5EDwIZrzUJhFPx7y30lzda1LmchL5aPrn5OPyrP3/AxK6U0Y9ISDZOBguOAEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/bus-rdf-parse-html": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "htmlparser2": "^10.0.0",
+        "readable-stream": "^4.5.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-4.5.0.tgz",
+      "integrity": "sha512-wxoXLS0nxV4ZqJEsx+zdZLjkRxZPFo+bXt+0fVEuDdBwL5WaJ6WPEL3fqbiH3QuaTu08k9klnsg2L1ncCeHhGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "microdata-rdf-streaming-parser": "^2.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-4.5.0.tgz",
+      "integrity": "sha512-o39tqHXAvKHnsa82Zm5FIbDRj+CSN46Nxj19TBSpCIsRlv5wJ9NpD6yxd7nGr1ovS5/5Ky7vDSdLcJ0MnJaNSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "rdfa-streaming-parser": "^2.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-4.5.0.tgz",
+      "integrity": "sha512-eobWYbV4w7o/NK+6GMVkcaoGEQbTq2RmDDN63J1I/U0sTSQX0qvtLr0L4buOzGliIUttBbpsYfOc5YtJX6PP0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/bus-rdf-parse-html": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.5.2",
+        "relative-to-absolute-iri": "^1.0.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-4.5.0.tgz",
+      "integrity": "sha512-QuYhMRNH7oc2RjpDCUWNoZiEkwgOGgQvT+GnCZz2pd2kHuTcH3iBo5FvDTLornSVO0RVchcpWGItN9zA2dCNoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^4.5.0",
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@jeswr/stream-to-string": "^2.0.0",
+        "jsonld-context-parser": "^2.2.2",
+        "jsonld-streaming-parser": "^4.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/canonicalize": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
+      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/jsonld-context-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.4.0.tgz",
+      "integrity": "sha512-ZYOfvh525SdPd9ReYY58dxB3E2RUEU4DJ6ZibO8AitcowPeBH4L5rCAitE2om5G1P+HMEgYEYEr4EZKbVN4tpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "cross-fetch": "^3.0.6",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/jsonld-streaming-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-4.0.1.tgz",
+      "integrity": "sha512-6M4y9YGgADk3nXJebbRrxEdMVBJ9bnz+peAvjTXUievopqaE8sg/qml/I6Sp1ln7rpOKffsNZWSre6B7N76szw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.0",
+        "@rdfjs/types": "*",
+        "@types/http-link-header": "^1.0.1",
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^3.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/jsonld-streaming-parser/node_modules/jsonld-context-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-3.1.0.tgz",
+      "integrity": "sha512-BfgNJ/t9jjK7Lun9XRCJM6YeNqDk8B6/lg+KS8rzhXAOtS0FvoClSmtLvF24V1M2CDYRy2LcEBt0ilxqSX93WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-4.5.0.tgz",
+      "integrity": "sha512-rERwWLr+fiFWuzWJe5Zoh0JvlaZn9DkvFGRl/5DntnDuwI91/U/p/atXBKfz/abpPAUs4hRGj5gkqmfdZg/bBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "n3": "^1.26.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3/node_modules/n3": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.26.0.tgz",
+      "integrity": "sha512-SQknS0ua90rN+3RHuk8BeIqeYyqIH/+ecViZxX08jR4j6MugqWRjtONl3uANG/crWXnOM2WIqBJtjIhVYFha+w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-rdfxml": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-4.5.0.tgz",
+      "integrity": "sha512-KDmXZ7w++eMO1HXaKwbkx6o5wKTtSMTCdhMGb/ewHinw4XVwesAy9nu/C5CAhi8LpCjdAxa7kf5POejBXUWd3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "rdfxml-streaming-parser": "^2.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-rdfxml/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-rdfxml/node_modules/@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-rdfxml/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-rdfxml/node_modules/rdfxml-streaming-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.4.0.tgz",
+      "integrity": "sha512-f+tdI1wxOiPzMbFWRtOwinwPsqac0WIN80668yFKcVdFCSTGOWTM70ucQGUSdDZZo7pce/UvZgV0C3LDj0P7tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.4.2",
+        "relative-to-absolute-iri": "^1.0.0",
+        "validate-iri": "^1.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-rdfxml/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/actor-rdf-parse-shaclc": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-4.5.0.tgz",
+      "integrity": "sha512-YFYn9ml/eCfZhBTYeaYJ0Qk6HerBi0H4acZYppcMKdh/GPJklzW9LOLlEfEzYstrqwPIKZzqgoBg5yvVgbmXpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@jeswr/stream-to-string": "^2.0.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "readable-stream": "^4.5.2",
+        "shaclc-parse": "^1.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-4.5.0.tgz",
+      "integrity": "sha512-1uQuq3xsokT0wWf9O6d+SyuNEvGX+bgSSGBCQF9YDjc2RygiZATUdThDmh4VDUYJzUCxHb3YM1XyJ+U2Si6xpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "rdfa-streaming-parser": "^2.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-quads-rdfjs-store": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-4.5.0.tgz",
+      "integrity": "sha512-PsV7Fdm/y0jLfSsByUpU0GkbRIV4d73q7d6Ytl5iWQLwvfYiJ8KE6qQyN0tOvcYO9cCwhMCYusEoy6kep6Ml4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-update-quads": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "event-emitter-promisify": "^1.1.0",
+        "rdf-string": "^1.6.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-term-comparator-factory-expression-evaluator": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-term-comparator-factory-expression-evaluator/-/actor-term-comparator-factory-expression-evaluator-4.5.0.tgz",
+      "integrity": "sha512-sI46VJ80mfgwTDBhSuzPfIzNABOc10du4rE3NPVl9ysXU+mlfy71B1tkOq25wkGc/bKqo3etNURJz790qCD+4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-expression-evaluator-factory-default": "^4.5.0",
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/bus-term-comparator-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-bindings-aggregator-factory": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-bindings-aggregator-factory/-/bus-bindings-aggregator-factory-4.5.0.tgz",
+      "integrity": "sha512-gI8UIgEJwYriQmalmMcA1q5g9cu7EzXLuJELiJZMm03msAoVB+RcZmbRBlYnVfRw/uTShl7IV8k27Hl05AjpCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.6.3",
+        "sparqlalgebrajs": "^5.0.2"
+      }
+    },
+    "node_modules/@comunica/bus-context-preprocess": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-4.5.0.tgz",
+      "integrity": "sha512-PE2aSmzcQsDuIUJGt0Ko6yD8YithHy6XwXKeS8OHaQeI93S+V6DZKaaCE+gCNcDBi8jZ4P4cislay/+8V1ZIPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-expression-evaluator-factory": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-expression-evaluator-factory/-/bus-expression-evaluator-factory-4.5.0.tgz",
+      "integrity": "sha512-QaeEiiXq75fV6+P3DnTKJkrV5p9yv1PqmsSPJ3h66DUManXrQEh9ATnJAwEBoUJlHE4Sy2aqho6Whate1W/orA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      }
+    },
+    "node_modules/@comunica/bus-function-factory": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-function-factory/-/bus-function-factory-4.5.0.tgz",
+      "integrity": "sha512-C/D9hzDWAv0GNDYV547rZrVAvkR7pc5CBeE3f3VOHW1aEBc3cvRFSf6FkrweqtxvywK3gI2V+3OPr4kwmRAGXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      }
+    },
+    "node_modules/@comunica/bus-hash-bindings": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-bindings/-/bus-hash-bindings-4.5.0.tgz",
+      "integrity": "sha512-SV1B83AD1ULprq9Xj/DAConubdOkH7ZYWF5MePolYTE1Wx7BMZv1giGVvR56/tA3/37NZzvffZPfqUc6C8Ip0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-hash-quads": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-quads/-/bus-hash-quads-4.5.0.tgz",
+      "integrity": "sha512-733+aHqi+hnlOY6bKAvy27Py54/IvOeGtehr6De8g6ZswP5UatiL4GURQk+acBK4aYSw9RzeyQhCu/LxO0q//g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "rdf-data-factory": "^1.1.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-hash-quads/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/bus-hash-quads/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/@comunica/bus-http": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-4.5.0.tgz",
+      "integrity": "sha512-wWyPNNOl6shDbtibdBl/pa9OIcoEMemNIo/J4tUViXxYXZ8i1h4FZ6PqaLtAls6O+pV71mR4SKJzKEUuiZiXPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@jeswr/stream-to-string": "^2.0.0",
+        "is-stream": "^2.0.1",
+        "readable-from-web": "^1.0.0",
+        "readable-stream-node-to-web": "^1.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-http-invalidate": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-4.5.0.tgz",
+      "integrity": "sha512-s6BJuWjN4enAqWMk07jVVxCaib9KlMTo/XW+ySM+RAa6KUmiy01ucNcvxaqjrFMdLTAoxl6R+4/XZdTOyH4bJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-http/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@comunica/bus-init": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-4.5.0.tgz",
+      "integrity": "sha512-9TYFLjirHDt7HPXj3eQW9KX3x5T3mZ1G/EKadL1gQxo0FAqs3y8TdicepCLhk3HY/egidlyv9WQYAPvJ+WAmAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "readable-stream": "^4.5.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-merge-bindings-context": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-merge-bindings-context/-/bus-merge-bindings-context-4.5.0.tgz",
+      "integrity": "sha512-btvNISwnA+e7ZEvgD80yWnUc90obUgCVDPTA0mx2s2gpi3rx8JV3RusC1fjw4R6d5s9xc4kGq0BmEP60w1v82Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-optimize-query-operation": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-4.5.0.tgz",
+      "integrity": "sha512-JMSpmIehaIQKDktrI5JKqxjU7M/4PYIGbuNHMYgcauZ2XxhFCbUhthshT+tY7pknmJg38whr9bK0Ziyw233Nvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-query-operation": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-4.5.0.tgz",
+      "integrity": "sha512-5sLmlmF+oBmNep0lEQuz9V291ddYSRzFJXT3nF+kswB6SjHj2FzwQZpjDEBkIhNXy3h5JY6J/3BqO20hR/IK2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-query-parse": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-parse/-/bus-query-parse-4.5.0.tgz",
+      "integrity": "sha512-Zd5uKEAVmVuAC9RQWg4QfVD8qidg7SqUdLA4lDMp6UfRUv+GyGQzTuGIr9DD3xjnxPfeiaO4t7M1CSaMA0kqhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-query-process": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-process/-/bus-query-process-4.5.0.tgz",
+      "integrity": "sha512-GYNGP9bjB8UtHCqQ77RPYaR0Kd58brGjSuA1xFxVCm255r6AmM5o0SwG6hydl4I3scdz+E12h938a1YV+LFL1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-query-result-serialize": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-4.5.0.tgz",
+      "integrity": "sha512-KONwhEtNcoiKsVATz9RikdpWSLlKcxII+Bwh8jT9XogWwFXx0oj0WoqTPl97IwtNN2DNvfnzHqZ06v/nsMXBSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-query-source-identify": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-source-identify/-/bus-query-source-identify-4.5.0.tgz",
+      "integrity": "sha512-snauZ+CF/S8NWm/isIk940qy/5RVhPWAvt2D0cmKpCFZOSnOrHe1zh0mX7mQrH/IA2IQmJloXE2rGugbNm22YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-iterator": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "rdf-string": "^1.6.3",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-4.5.0.tgz",
+      "integrity": "sha512-qvasYM2hfF+nEvAi5N/0KZfqFRrPDxu7xU9Tq9XK+14cQRaxGQ/8Xh+cGRTQvNgdXM6zo5MBmtauDsJ0L85msg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
+        "@comunica/bus-rdf-join-selectivity": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-iterator": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join-entries-sort": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-4.5.0.tgz",
+      "integrity": "sha512-WdAHVpFvDyF3Ale56bxSaAwLhxyE8344B5uOxCGsqrlbh+luVZL4ccyUFPyCyvP24M1YUEyxVzV6hHQu860x8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join-selectivity": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-4.5.0.tgz",
+      "integrity": "sha512-QocxGFR0XPoq7CnvGs3cyh3xYnTVwTHTZHkMksO/GJ6WBeAFo9PYaSdusrfShyNHL3SxrfhGO4vqBfNzvtzHLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-accuracy": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-metadata-accumulate": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-4.5.0.tgz",
+      "integrity": "sha512-rnyo4XNGwRiK4tue0i928LgPt0rTuOCILYL4Qvon5Zj4tHQtV9yKinvnR58NnUqjLmjQLEmPrcpgYTZN4KLzjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-4.5.0.tgz",
+      "integrity": "sha512-TnTS9F2GSbibuCd0Rep20C9WXU0KH0iWl2S2xycefMFrZK7noA8LeT/AHNshQlMPKejKxWME+jNsvcXgC++8zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^4.5.0",
+        "@comunica/actor-abstract-parse": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-4.5.0.tgz",
+      "integrity": "sha512-yKsPuCIOLF5TXqoXXo+utZehG2diTCBnNleXrOI8Utr4Qu5rAU4oQ5+FC0UByMu5hr+g/TGm2A+IHSVzFRCUfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-update-quads": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-4.5.0.tgz",
+      "integrity": "sha512-ZxUzqT+/DSyAMYWP/hSh3VIMErgjrWD73EciNqLg/QL6gjuG3twSbnO9ywSlYe2eKDEu8f4aX8ghGW400gZLPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-context-preprocess-query-source-skolemize": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-term-comparator-factory": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-term-comparator-factory/-/bus-term-comparator-factory-4.5.0.tgz",
+      "integrity": "sha512-UXqoBtF9uPT6V/uUo8byWOssOtHtc5Azrg2sb9cT8AWH2Salt0c/Hd4vWCM602Z1Hs/LxTSDaGEMdpZJin/7Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/config-query-sparql": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-4.4.0.tgz",
+      "integrity": "sha512-ZVK6eqpYLNa3MRLOWjRaudgfSdraJH/oZIkc5S2doJI2ZmnHROqQUtjPs13kwkI3hGZ6MVBtLm55oz+tKj2lKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/context-entries": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-4.5.0.tgz",
+      "integrity": "sha512-mgeSYFBcpMKLq34COpy129LVHigGUgA1uEI66WXmk3mdmlAKRQNe9D/W2Q924w0FZZmIOpeLMo+s358tFsodow==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.2.2",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/context-entries/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@comunica/context-entries/node_modules/jsonld-context-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.4.0.tgz",
+      "integrity": "sha512-ZYOfvh525SdPd9ReYY58dxB3E2RUEU4DJ6ZibO8AitcowPeBH4L5rCAitE2om5G1P+HMEgYEYEr4EZKbVN4tpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "cross-fetch": "^3.0.6",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      }
+    },
+    "node_modules/@comunica/context-entries/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/logger-pretty": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-4.5.0.tgz",
+      "integrity": "sha512-4Fs0FCnHWFO1EHmFTNhd92o9WTVIigesu6kuk2DP+Zwvm6HKTqgMqllovyllE0nIVyL+YcWSAPvkUTWmQybFIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "object-inspect": "^1.12.2",
+        "process": "^0.11.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/logger-void": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-4.5.0.tgz",
+      "integrity": "sha512-qvRxSlD65KLLqIkU7zwnJ/uPMmYTlsI9J4gsYgEi8OOss5YuNSChAbbzZwRCNrAZOnRGjyrPfgN/Cd3NuglGew==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediator-all": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-4.5.0.tgz",
+      "integrity": "sha512-9qX58JgDaC56at0m3FdyYZhXw7kBUPuXihpwYowBwuopdlh0XioJyT/b3g+DC0/kiuSCcx6NhSAWzfNLAqTL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediator-combine-pipeline": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-4.5.0.tgz",
+      "integrity": "sha512-Z4uLxugl+Ls8oAwD0dAIQg+i1rkiXbpiFLhgv5h6nksnz9q6Nv14xItm6baivxAJ9p8XVHCOwPxW46YJBtWIoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediator-combine-union": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-4.5.0.tgz",
+      "integrity": "sha512-aCoO3CiANssR8PEjad2aNuCcfhKdUFZWplTWq77cVUMVc4nsUWNleeEvN6kfOx51qdT8lFpH3b8X+S7bT8CABg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediator-join-coefficients-fixed": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-4.5.0.tgz",
+      "integrity": "sha512-kSK0i5FPOmeUmg6nJcoqOvRE6aCXFYMzCFPiId/k5cCjvpT4Uaod33xHEQ0TnX52uLdjNENIRjH8z3OsnhSd/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediator-number": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-4.5.0.tgz",
+      "integrity": "sha512-fChc4gh+gtwPOS0F5eNeDuU4Kyb2fAuppN28d1/5s+OUr5v+1Wya7yZ1zbPHYxDMWZEpJBR06eX6djcI0gKlkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediator-race": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-4.5.0.tgz",
+      "integrity": "sha512-eAWjQolFMOxKoKuUMmcQzxwf/ZL9ooT0/OUWv1vbVfHIQb/eqDs/h8wDqwXMgEiK5dIF9ZQYaRL2vEaLq+U3Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediatortype-accuracy": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-4.5.0.tgz",
+      "integrity": "sha512-f6OVVGwzf3udDT6x0oP/k76XqBV8ZJFdo5SYGVBR/ebsG81V6LciAHvo8BrihZXgmpo1KTCbIFbRmN++M8b6Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediatortype-join-coefficients": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-4.5.0.tgz",
+      "integrity": "sha512-wLhEdEd7TBF1r5xoShOk42Hh4kH4r7YyoPs4W7k41Q5m5tPdv8iyZojqv/MItDKv7XCiTpZLcIQpfV3RcAewhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-4.5.0.tgz",
+      "integrity": "sha512-HND+om4L0VW3VcQrLHHE4+7Nsg7soC98i7g7UqqzDkJ4fix2FnJs0i9WH4RP+oLcx+bPhBSl5mG1m44A6sV19g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/query-sparql-rdfjs-lite": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/query-sparql-rdfjs-lite/-/query-sparql-rdfjs-lite-4.5.0.tgz",
+      "integrity": "sha512-HBgvhn++QwBb7Q/ImzjjP6esCI126Zux7V4SGEGE+sJfxZrtSX57TIxupP0At9SWYMDg2aDqHJC/b5pDGQOHXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-bindings-aggregator-factory-average": "^4.5.0",
+        "@comunica/actor-bindings-aggregator-factory-count": "^4.5.0",
+        "@comunica/actor-bindings-aggregator-factory-group-concat": "^4.5.0",
+        "@comunica/actor-bindings-aggregator-factory-max": "^4.5.0",
+        "@comunica/actor-bindings-aggregator-factory-min": "^4.5.0",
+        "@comunica/actor-bindings-aggregator-factory-sample": "^4.5.0",
+        "@comunica/actor-bindings-aggregator-factory-sum": "^4.5.0",
+        "@comunica/actor-bindings-aggregator-factory-wildcard-count": "^4.5.0",
+        "@comunica/actor-context-preprocess-convert-shortcuts": "^4.5.0",
+        "@comunica/actor-context-preprocess-query-source-identify": "^4.5.0",
+        "@comunica/actor-context-preprocess-query-source-skolemize": "^4.5.0",
+        "@comunica/actor-context-preprocess-set-defaults": "^4.5.0",
+        "@comunica/actor-context-preprocess-source-to-destination": "^4.5.0",
+        "@comunica/actor-expression-evaluator-factory-default": "^4.5.0",
+        "@comunica/actor-function-factory-expression-bnode": "^4.5.0",
+        "@comunica/actor-function-factory-expression-bound": "^4.5.0",
+        "@comunica/actor-function-factory-expression-coalesce": "^4.5.0",
+        "@comunica/actor-function-factory-expression-concat": "^4.5.0",
+        "@comunica/actor-function-factory-expression-extensions": "^4.5.0",
+        "@comunica/actor-function-factory-expression-if": "^4.5.0",
+        "@comunica/actor-function-factory-expression-in": "^4.5.0",
+        "@comunica/actor-function-factory-expression-logical-and": "^4.5.0",
+        "@comunica/actor-function-factory-expression-logical-or": "^4.5.0",
+        "@comunica/actor-function-factory-expression-not-in": "^4.5.0",
+        "@comunica/actor-function-factory-expression-same-term": "^4.5.0",
+        "@comunica/actor-function-factory-term-abs": "^4.5.0",
+        "@comunica/actor-function-factory-term-addition": "^4.5.0",
+        "@comunica/actor-function-factory-term-ceil": "^4.5.0",
+        "@comunica/actor-function-factory-term-contains": "^4.5.0",
+        "@comunica/actor-function-factory-term-datatype": "^4.5.0",
+        "@comunica/actor-function-factory-term-day": "^4.5.0",
+        "@comunica/actor-function-factory-term-division": "^4.5.0",
+        "@comunica/actor-function-factory-term-encode-for-uri": "^4.5.0",
+        "@comunica/actor-function-factory-term-equality": "^4.5.0",
+        "@comunica/actor-function-factory-term-floor": "^4.5.0",
+        "@comunica/actor-function-factory-term-greater-than": "^4.5.0",
+        "@comunica/actor-function-factory-term-greater-than-equal": "^4.5.0",
+        "@comunica/actor-function-factory-term-hours": "^4.5.0",
+        "@comunica/actor-function-factory-term-inequality": "^4.5.0",
+        "@comunica/actor-function-factory-term-iri": "^4.5.0",
+        "@comunica/actor-function-factory-term-is-blank": "^4.5.0",
+        "@comunica/actor-function-factory-term-is-iri": "^4.5.0",
+        "@comunica/actor-function-factory-term-is-literal": "^4.5.0",
+        "@comunica/actor-function-factory-term-is-numeric": "^4.5.0",
+        "@comunica/actor-function-factory-term-is-triple": "^4.5.0",
+        "@comunica/actor-function-factory-term-lang": "^4.5.0",
+        "@comunica/actor-function-factory-term-langmatches": "^4.5.0",
+        "@comunica/actor-function-factory-term-lcase": "^4.5.0",
+        "@comunica/actor-function-factory-term-lesser-than": "^4.5.0",
+        "@comunica/actor-function-factory-term-lesser-than-equal": "^4.5.0",
+        "@comunica/actor-function-factory-term-md5": "^4.5.0",
+        "@comunica/actor-function-factory-term-minutes": "^4.5.0",
+        "@comunica/actor-function-factory-term-month": "^4.5.0",
+        "@comunica/actor-function-factory-term-multiplication": "^4.5.0",
+        "@comunica/actor-function-factory-term-not": "^4.5.0",
+        "@comunica/actor-function-factory-term-now": "^4.5.0",
+        "@comunica/actor-function-factory-term-object": "^4.5.0",
+        "@comunica/actor-function-factory-term-predicate": "^4.5.0",
+        "@comunica/actor-function-factory-term-rand": "^4.5.0",
+        "@comunica/actor-function-factory-term-regex": "^4.5.0",
+        "@comunica/actor-function-factory-term-replace": "^4.5.0",
+        "@comunica/actor-function-factory-term-round": "^4.5.0",
+        "@comunica/actor-function-factory-term-seconds": "^4.5.0",
+        "@comunica/actor-function-factory-term-sha1": "^4.5.0",
+        "@comunica/actor-function-factory-term-sha256": "^4.5.0",
+        "@comunica/actor-function-factory-term-sha384": "^4.5.0",
+        "@comunica/actor-function-factory-term-sha512": "^4.5.0",
+        "@comunica/actor-function-factory-term-str": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-after": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-before": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-dt": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-ends": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-lang": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-len": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-starts": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-uuid": "^4.5.0",
+        "@comunica/actor-function-factory-term-sub-str": "^4.5.0",
+        "@comunica/actor-function-factory-term-subject": "^4.5.0",
+        "@comunica/actor-function-factory-term-subtraction": "^4.5.0",
+        "@comunica/actor-function-factory-term-timezone": "^4.5.0",
+        "@comunica/actor-function-factory-term-triple": "^4.5.0",
+        "@comunica/actor-function-factory-term-tz": "^4.5.0",
+        "@comunica/actor-function-factory-term-ucase": "^4.5.0",
+        "@comunica/actor-function-factory-term-unary-minus": "^4.5.0",
+        "@comunica/actor-function-factory-term-unary-plus": "^4.5.0",
+        "@comunica/actor-function-factory-term-uuid": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-boolean": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-date": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-datetime": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-day-time-duration": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-decimal": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-double": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-duration": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-float": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-integer": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-string": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-time": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-year-month-duration": "^4.5.0",
+        "@comunica/actor-function-factory-term-year": "^4.5.0",
+        "@comunica/actor-hash-bindings-murmur": "^4.5.0",
+        "@comunica/actor-hash-quads-murmur": "^4.5.0",
+        "@comunica/actor-init-query": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-assign-sources-exhaustive": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-bgp-to-join": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-construct-distinct": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-describe-to-constructs-subject": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-filter-pushdown": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-group-sources": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-join-connected": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-prune-empty-source-operations": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-rewrite-add": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-rewrite-copy": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-rewrite-move": "^4.5.0",
+        "@comunica/actor-query-operation-ask": "^4.5.0",
+        "@comunica/actor-query-operation-bgp-join": "^4.5.0",
+        "@comunica/actor-query-operation-construct": "^4.5.0",
+        "@comunica/actor-query-operation-distinct-identity": "^4.5.0",
+        "@comunica/actor-query-operation-extend": "^4.5.0",
+        "@comunica/actor-query-operation-filter": "^4.5.0",
+        "@comunica/actor-query-operation-from-quad": "^4.5.0",
+        "@comunica/actor-query-operation-group": "^4.5.0",
+        "@comunica/actor-query-operation-join": "^4.5.0",
+        "@comunica/actor-query-operation-leftjoin": "^4.5.0",
+        "@comunica/actor-query-operation-minus": "^4.5.0",
+        "@comunica/actor-query-operation-nop": "^4.5.0",
+        "@comunica/actor-query-operation-orderby": "^4.5.0",
+        "@comunica/actor-query-operation-path-alt": "^4.5.0",
+        "@comunica/actor-query-operation-path-inv": "^4.5.0",
+        "@comunica/actor-query-operation-path-link": "^4.5.0",
+        "@comunica/actor-query-operation-path-nps": "^4.5.0",
+        "@comunica/actor-query-operation-path-one-or-more": "^4.5.0",
+        "@comunica/actor-query-operation-path-seq": "^4.5.0",
+        "@comunica/actor-query-operation-path-zero-or-more": "^4.5.0",
+        "@comunica/actor-query-operation-path-zero-or-one": "^4.5.0",
+        "@comunica/actor-query-operation-project": "^4.5.0",
+        "@comunica/actor-query-operation-reduced-hash": "^4.5.0",
+        "@comunica/actor-query-operation-service": "^4.5.0",
+        "@comunica/actor-query-operation-slice": "^4.5.0",
+        "@comunica/actor-query-operation-source": "^4.5.0",
+        "@comunica/actor-query-operation-union": "^4.5.0",
+        "@comunica/actor-query-operation-update-clear": "^4.5.0",
+        "@comunica/actor-query-operation-update-compositeupdate": "^4.5.0",
+        "@comunica/actor-query-operation-update-create": "^4.5.0",
+        "@comunica/actor-query-operation-update-deleteinsert": "^4.5.0",
+        "@comunica/actor-query-operation-update-drop": "^4.5.0",
+        "@comunica/actor-query-operation-update-load": "^4.5.0",
+        "@comunica/actor-query-operation-values": "^4.5.0",
+        "@comunica/actor-query-parse-sparql": "^4.5.0",
+        "@comunica/actor-query-process-sequential": "^4.5.0",
+        "@comunica/actor-query-source-identify-rdfjs": "^4.5.0",
+        "@comunica/actor-rdf-join-entries-sort-cardinality": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-hash": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-multi-bind": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-multi-bind-source": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-multi-empty": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-multi-smallest": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-nestedloop": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-none": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-single": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-symmetrichash": "^4.5.0",
+        "@comunica/actor-rdf-join-minus-hash": "^4.5.0",
+        "@comunica/actor-rdf-join-optional-bind": "^4.5.0",
+        "@comunica/actor-rdf-join-optional-hash": "^4.5.0",
+        "@comunica/actor-rdf-join-optional-nestedloop": "^4.5.0",
+        "@comunica/actor-rdf-join-selectivity-variable-counting": "^4.5.0",
+        "@comunica/actor-rdf-metadata-accumulate-cardinality": "^4.5.0",
+        "@comunica/actor-rdf-metadata-accumulate-pagesize": "^4.5.0",
+        "@comunica/actor-rdf-metadata-accumulate-requesttime": "^4.5.0",
+        "@comunica/actor-rdf-update-quads-rdfjs-store": "^4.5.0",
+        "@comunica/actor-term-comparator-factory-expression-evaluator": "^4.5.0",
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/bus-http-invalidate": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/config-query-sparql": "^4.4.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/logger-void": "^4.5.0",
+        "@comunica/mediator-all": "^4.5.0",
+        "@comunica/mediator-combine-pipeline": "^4.5.0",
+        "@comunica/mediator-combine-union": "^4.5.0",
+        "@comunica/mediator-join-coefficients-fixed": "^4.5.0",
+        "@comunica/mediator-number": "^4.5.0",
+        "@comunica/mediator-race": "^4.5.0",
+        "@comunica/runner": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/runner": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-4.5.0.tgz",
+      "integrity": "sha512-Xq5HUsuNQ2cKHBqQjJ3Xx1jpcdD9Oi+ef7t6wPeUCR6VzZKCmRNxEcwQ0Cz629KMicrZCyWnIkXoB322GRWMVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-init": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "componentsjs": "^6.2.0",
+        "process": "^0.11.10"
+      },
+      "bin": {
+        "comunica-compile-config": "bin/compile-config"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/types/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/utils-bindings-factory": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-bindings-factory/-/utils-bindings-factory-4.5.0.tgz",
+      "integrity": "sha512-LxwHMoBn8JqeVoGEZVaOne9iaShHmaDwJaCBJH3cQi224bv81ylmEBJgrxfNJt+FAzwBfsRdO4aR8dRX5l7Pdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "immutable": "^5.1.3",
+        "rdf-string": "^1.6.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/utils-bindings-index": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-bindings-index/-/utils-bindings-index-4.5.0.tgz",
+      "integrity": "sha512-vV+POCwgVxR3DqtlAt/+q1EzTTghCTYMkx2yV0PJYWdrjsu/JEfoS4S7B1zgb0DjUS7zq0aoeB7FShBUWz/fuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/utils-data-factory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-data-factory/-/utils-data-factory-4.0.1.tgz",
+      "integrity": "sha512-6FTyTC0dNgXwnZN4/5QSDsfNT7AhWPJUcE3a9aa78kQodaq3LfQNW4fiG4tC2O4tcbSy4Ds7ZG/cflThCHwa2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/utils-expression-evaluator": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-expression-evaluator/-/utils-expression-evaluator-4.5.0.tgz",
+      "integrity": "sha512-i4kek6vg5yx/EqwoEEop7UyNy0aHp7MIMdId98opXa/hU64Z8icIaFD+3+1tv98M1LviuJAIPX6lCJwuB22jqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "lru-cache": "^10.0.0",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-string": "^1.6.3",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/utils-expression-evaluator/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/utils-expression-evaluator/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/utils-expression-evaluator/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/@comunica/utils-iterator": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-iterator/-/utils-iterator-4.5.0.tgz",
+      "integrity": "sha512-Gnn6asz0xILR1f5lQrTjg1BgW5IiSibOETul4iJ+sjYnVncZH1eK5qJNG81f6fX40D3FEHyu+jWQSPNMFqdaoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynciterator": "^3.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/utils-metadata": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-metadata/-/utils-metadata-4.5.0.tgz",
+      "integrity": "sha512-NmWWz9F558NQXR5UOyAIdhLmi4tBMtI0N3kHee/DsPCFaxn0wjQ/ckZGrTVTGeP+sdYzobaYvGcIPpf8MmPALQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/utils-query-operation": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-query-operation/-/utils-query-operation-4.5.0.tgz",
+      "integrity": "sha512-R5j61Awzyz+p0FbvACSxh8GuZ4IiBt824UfNZpgDipwzX0JnSaKP5yFKL2dcmb9LlElN8wmDjzy4o512HLK67w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-string": "^1.6.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/utils-query-operation/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/utils-query-operation/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@digitalbazaar/http-client": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-4.3.0.tgz",
+      "integrity": "sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ky": "^1.14.2",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@jeswr/stream-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jeswr/stream-to-string/-/stream-to-string-2.0.0.tgz",
+      "integrity": "sha512-VmoW6xYRjVzdMr2njBObVSlUc5KCJT+gyuuH+tea9ZLE59XhgfLNc8ufN5Md38STxCyAJUDUVcCBfaOo11BfuA==",
+      "license": "MIT",
+      "dependencies": {
+        "event-emitter-promisify": "^1.1.0"
+      }
+    },
+    "node_modules/@rdfjs/data-model": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.1.1.tgz",
+      "integrity": "sha512-6mcOI4DjIPS6MOZw23H8oAdujHCk5gippVNQ7mKwliYTvTNh+uqRM91B9OLqhoAoNcQ3t49Dx2ooIMRG9/6ooA==",
+      "license": "MIT",
+      "bin": {
+        "rdfjs-data-model-test": "bin/test.js"
+      }
+    },
+    "node_modules/@rdfjs/dataset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-2.0.2.tgz",
+      "integrity": "sha512-6YJx+5n5Uxzq9dd9I0GGcIo6eopZOPfcsAfxSGX5d+YBzDgVa1cbtEBFnaPyPKiQsOm4+Cr3nwypjpg02YKPlA==",
+      "license": "MIT",
+      "bin": {
+        "rdfjs-dataset-test": "bin/test.js"
+      }
+    },
+    "node_modules/@rdfjs/environment": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/environment/-/environment-1.0.0.tgz",
+      "integrity": "sha512-+S5YjSvfoQR5r7YQCRCCVHvIEyrWia7FJv2gqM3s5EDfotoAQmFeBagApa9c/eQFi5EiNhmBECE5nB8LIxTaHg==",
+      "license": "MIT"
+    },
+    "node_modules/@rdfjs/fetch-lite": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-3.3.0.tgz",
+      "integrity": "sha512-K3hZC4+Ch0UmYA1w0Xv/8cCVPD5ulKwRa6A/iTn3BFbZpVAb5KoBfOfnOhe6VJEa50raUvTHR1gp1YdvUnYt9g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^4.0.1",
+        "nodeify-fetch": "^3.1.0",
+        "readable-stream": "^4.5.2"
+      }
+    },
+    "node_modules/@rdfjs/formats": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/formats/-/formats-4.0.1.tgz",
+      "integrity": "sha512-Rg53vP+x1bnGAqJNKgEzJEUPDhj+tCpzb6wdmfLoVFq4XoZ589+cg2ScFDUMMyAVsgKXvSWjDhQ9f9ab254ZxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/parser-jsonld": "^2.1.0",
+        "@rdfjs/parser-n3": "^2.0.1",
+        "@rdfjs/serializer-jsonld": "^2.0.0",
+        "@rdfjs/serializer-jsonld-ext": "^4.0.0",
+        "@rdfjs/serializer-ntriples": "^2.0.0",
+        "@rdfjs/serializer-turtle": "^1.1.1",
+        "@rdfjs/sink-map": "^2.0.0",
+        "rdfxml-streaming-parser": "^3.0.1"
+      }
+    },
+    "node_modules/@rdfjs/namespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-2.0.1.tgz",
+      "integrity": "sha512-U85NWVGnL3gWvOZ4eXwUcv3/bom7PAcutSBQqmVWvOaslPy+kDzAJCH1WYBLpdQd4yMmJ+bpJcDl9rcHtXeixg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.0.1"
+      }
+    },
+    "node_modules/@rdfjs/parser-jsonld": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@rdfjs/parser-jsonld/-/parser-jsonld-2.1.3.tgz",
+      "integrity": "sha512-VYnPEwVdqFAPTo9F8XIN4UpGPdNzhBaCFv5b5OT74pA7H8so4aTno3Yd6M5I9bhTrUoCQjpjgr+ugYlvWxdBIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.0.2",
+        "@rdfjs/sink": "^2.0.1",
+        "duplex-to": "^2.0.0",
+        "jsonld-streaming-parser": "^5.0.0",
+        "readable-stream": "^4.5.2"
+      }
+    },
+    "node_modules/@rdfjs/parser-n3": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/parser-n3/-/parser-n3-2.1.0.tgz",
+      "integrity": "sha512-/DiosB+0vPzgAs1WXcCB8MbA5hqq0fIh9VhMg7fBmoJ/I8Xl6Op/AOxVu9x1XZCHSNwO/VsJT/HYKEctZVRKSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.0.2",
+        "@rdfjs/sink": "^2.0.1",
+        "duplex-to": "^2.0.0",
+        "n3": "^1.17.2",
+        "readable-stream": "^4.5.2"
+      }
+    },
+    "node_modules/@rdfjs/parser-n3/node_modules/n3": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.26.0.tgz",
+      "integrity": "sha512-SQknS0ua90rN+3RHuk8BeIqeYyqIH/+ecViZxX08jR4j6MugqWRjtONl3uANG/crWXnOM2WIqBJtjIhVYFha+w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/@rdfjs/prefix-map": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/prefix-map/-/prefix-map-0.1.2.tgz",
+      "integrity": "sha512-qapFYVPYyYepg0sFy7T512667iZsN9a3RNcyNBTBV+O8wrU3v/URQZOipCTNrEm1BXzZ7KCK1Yi8HrE1y+uRuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.3.0"
+      }
+    },
+    "node_modules/@rdfjs/serializer-jsonld": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/serializer-jsonld/-/serializer-jsonld-2.0.1.tgz",
+      "integrity": "sha512-O8WzdY7THsse/nMsrMLd2e51ADHO2SIUrkiZ9Va/8W3lXeeeiwDRPMppWy/i9yL4q6EM8iMW1riV7E0mK3fsBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/sink": "^2.0.1",
+        "readable-stream": "^4.5.2"
+      }
+    },
+    "node_modules/@rdfjs/serializer-jsonld-ext": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/serializer-jsonld-ext/-/serializer-jsonld-ext-4.0.2.tgz",
+      "integrity": "sha512-l/A6gQgKWYYGOPbcVZWnaamqWPtShL4FDrEqh5F85Fw0PdSca7q0YOBpB8ihxKmiGmfXa+SB4M8l9iyEegcp7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/sink": "^2.0.1",
+        "jsonld": "^9.0.0",
+        "readable-stream": "^4.7.0",
+        "stream-chunks": "^1.0.0"
+      }
+    },
+    "node_modules/@rdfjs/serializer-ntriples": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/serializer-ntriples/-/serializer-ntriples-2.0.1.tgz",
+      "integrity": "sha512-G1ZI0qaN/MUHxeCwr59JscO2LdyIb6MNQdXOv7NFBZuodyHsxxhJRFmMVn+3SEXeNJbVeEEbWBrLglCUgJ8XjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/sink": "^2.0.1",
+        "@rdfjs/to-ntriples": "^3.0.1",
+        "duplex-to": "^2.0.0",
+        "readable-stream": "^4.5.2"
+      }
+    },
+    "node_modules/@rdfjs/serializer-turtle": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rdfjs/serializer-turtle/-/serializer-turtle-1.1.5.tgz",
+      "integrity": "sha512-uvIFUOuMuk8JrJnng/tWKIQ+8XI6YLEms75YdvZ49LtIyyfbDqKz76EybgnD/zZYfMhVVkguKtheBC9h08g1PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.0.1",
+        "@rdfjs/namespace": "^2.0.0",
+        "@rdfjs/prefix-map": "^0.1.1",
+        "@rdfjs/sink": "^2.0.0",
+        "@rdfjs/term-map": "^2.0.0",
+        "@rdfjs/to-ntriples": "^3.0.1",
+        "@rdfjs/tree": "^0.2.1",
+        "readable-stream": "^4.3.0",
+        "stream-chunks": "^1.0.0"
+      }
+    },
+    "node_modules/@rdfjs/sink": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-2.0.1.tgz",
+      "integrity": "sha512-smzIFGF6EH1sLAJR9F3p2wMNrN44JjPeYAoITTJLqtuNC319K7IXaJ+qNLBGTtapZ/jvpx2Tks0TjcH9KrAvEA==",
+      "license": "MIT"
+    },
+    "node_modules/@rdfjs/sink-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/sink-map/-/sink-map-2.0.1.tgz",
+      "integrity": "sha512-BwCTTsMN/tfQl6QzD2oHn9A08e4af+hlzAz/d5XXrlOkYMEDUAqFuh2Odj9EbayhAEeN4wA743Mj2yC0/s69rg==",
+      "license": "MIT"
+    },
+    "node_modules/@rdfjs/term-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/term-map/-/term-map-2.0.2.tgz",
+      "integrity": "sha512-EJ2FmmdEUsSR/tU1nrizRLWzH24YzhuvesrbUWxC3Fs0ilYNdtTbg0RaFJDUnJF3HkbNBQe8Zrt/uvU/hcKnHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/to-ntriples": "^3.0.1"
+      }
+    },
+    "node_modules/@rdfjs/term-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-2.0.3.tgz",
+      "integrity": "sha512-DyXrKWEx+mtAFUZVU7bc3Va6/KZ8PsIp0RVdyWT9jfDgI/HCvNisZaBtAcm+SYTC45o+7WLkbudkk1bfaKVB0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/to-ntriples": "^3.0.1"
+      }
+    },
+    "node_modules/@rdfjs/to-ntriples": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-3.0.1.tgz",
+      "integrity": "sha512-gjoPAvh4j7AbGMjcDn/8R4cW+d/FPtbfbMM0uQXkyfBFtNUW2iVgrqsgJ65roLc54Y9A2TTFaeeTGSvY9a0HCQ==",
+      "license": "MIT"
+    },
+    "node_modules/@rdfjs/traverser": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@rdfjs/traverser/-/traverser-0.1.4.tgz",
+      "integrity": "sha512-53QYlxiQIxH8k4jutjet1EjdZfyKCDSsfqnj2YejAJ1X8mLDMSOsneMM5savBwBR0ROfAhKVtZVb+pego+JLiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/to-ntriples": "^3.0.1"
+      }
+    },
+    "node_modules/@rdfjs/tree": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/tree/-/tree-0.2.1.tgz",
+      "integrity": "sha512-J70CQ7R8Ivfs1FFUxtFN7ADb5wTMgbhn0O558NXSXQHItmSavT6cXmQlIokbmboU+grhu56iR/8Bl9do8LCq+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/namespace": "^2.0.0",
+        "@rdfjs/term-map": "^2.0.0",
+        "@rdfjs/term-set": "^2.0.1"
+      }
+    },
+    "node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@rubensworks/saxes": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@rubensworks/saxes/-/saxes-6.0.1.tgz",
+      "integrity": "sha512-UW4OTIsOtJ5KSXo2Tchi4lhZqu+tlHrOAs4nNti7CrtB53kAZl3/hyrTi6HkMihxdbDM6m2Zc3swc/ZewEe1xw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.12"
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@tpluscode/rdf-ns-builders": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-4.3.0.tgz",
+      "integrity": "sha512-x3uh9mYwAU+PrALaDKhVjml1TCCWWduo6J8rybd9SMEEAoooXq1MYb13MRputjRT/kYaFyCND7LMobzhxZ/+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^2",
+        "@rdfjs/namespace": "^2",
+        "@rdfjs/types": "*",
+        "@types/rdfjs__namespace": "^2.0.2",
+        "@zazuko/prefixes": "^2.0.1"
+      }
+    },
+    "node_modules/@types/clownface": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/clownface/-/clownface-2.0.10.tgz",
+      "integrity": "sha512-Vz48oQux0YArQ66wfRp54NlxvEmpyTqbFIH435AsgN7C+p4MXao/rjXUisULL6436bxjFk4VluZr7J2HQkBHmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": ">=1",
+        "@types/rdfjs__environment": "*"
+      }
+    },
+    "node_modules/@types/http-link-header": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.7.tgz",
+      "integrity": "sha512-snm5oLckop0K3cTDAiBnZDy6ncx9DJ3mCRDvs42C884MbVYPP74Tiq2hFsSDRTyjK6RyDYDIulPiW23ge+g5Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-Zo/QlTiAvOP3pd9nuPOw33k0l/QssLOBrriShWzUE4qhIZByIF3rCoyF8ZTxdyFTUM2mYljYLqMUeLvA3NJUmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/jsonld": {
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.15.tgz",
+      "integrity": "sha512-PlAFPZjL+AuGYmwlqwKEL0IMP8M8RexH0NIPGfCVWSQ041H2rR/8OlyZSD7KsCVoN8vCfWdtWDBxX8yBVP+xow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/rdf-dataset-ext": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/rdf-dataset-ext/-/rdf-dataset-ext-1.0.8.tgz",
+      "integrity": "sha512-ngMGOzAm+yvrfTzFhlmPNa9lfWO72IkdqYRR+HNIPX3x+RPLf6qRpAi8GAZCg0rkpGt2JJqDQF3FgVxE6ykr/w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0",
+        "@types/readable-stream": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__data-model": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__data-model/-/rdfjs__data-model-2.0.9.tgz",
+      "integrity": "sha512-rgQSlM9jr7XMZdC0xUIr0zsxf5FvdB4cxxzv+MlHm6uJGip5qi0q+BluNhakAzaM2I56nKLDqSE3I/XuOaHGnA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__dataset": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-2.0.7.tgz",
+      "integrity": "sha512-+GaYIL9C7N1N0HyH+obU4IXuL7DX+fXuf827aUQ2Vx2UghO47+OTxo2v3seEQj/1YHoHBfQFk5Y4P6Q7Ht4Hqw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__environment": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__environment/-/rdfjs__environment-1.0.0.tgz",
+      "integrity": "sha512-MDcnv3qfJvbHoEpUQXj5muT8g3e+xz1D8sGevrq3+Q4TzeEvQf5ijGX5l8485XFYrN/OBApgzXkHMZC04/kd5w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__fetch-lite": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__fetch-lite/-/rdfjs__fetch-lite-3.0.11.tgz",
+      "integrity": "sha512-1bHxBn62bmTPq/HY9Jr+iKCdBp8RTEJ4WA0ycihghRF8zWQfw6T7E5CqdPi4nncmgF70LOz7jF/4jeLGdb6H2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/node": "*",
+        "@types/rdfjs__formats": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__formats": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__formats/-/rdfjs__formats-4.0.1.tgz",
+      "integrity": "sha512-Zj7hQEn5HeCj+pJCWshY2gqBcdBdwyc2j20Ht3PH91pkdRuG2AlGDD3N9PQ1oZ3+J6Q96rAlhxUbjQUp9+s3FQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0",
+        "@types/node": "*",
+        "@types/rdfjs__parser-jsonld": "*",
+        "@types/rdfjs__parser-n3": "*",
+        "@types/rdfjs__serializer-jsonld": "*",
+        "@types/rdfjs__serializer-jsonld-ext": "*",
+        "@types/rdfjs__serializer-ntriples": "*",
+        "@types/rdfjs__serializer-turtle": "*",
+        "@types/rdfjs__sink-map": "*",
+        "rdfxml-streaming-parser": ">=2"
+      }
+    },
+    "node_modules/@types/rdfjs__namespace": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.10.tgz",
+      "integrity": "sha512-xoVzEIOxcpyteEmzaj94MSBbrBFs+vqv05joMhzLEiPRwsBBDnhkdBCaaDxR1Tf7wOW0kB2R1IYe4C3vEBFPgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__parser-jsonld": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-jsonld/-/rdfjs__parser-jsonld-2.1.7.tgz",
+      "integrity": "sha512-n35K+c1Y95580N202Jxly6xjFE953FF+Y2mwxok6zLfMo4rgIfgMBElnNwpja0IeYXTuzGm1tEz7va3lItGrTg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0",
+        "@types/jsonld": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__parser-n3": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-n3/-/rdfjs__parser-n3-2.0.6.tgz",
+      "integrity": "sha512-VHfdq7BDV6iMCtHkzTFSOuUWnqGlMUmEF0UZyK4+g9SzLWvc6TMcU5TYwQPQIz/e0s7dZ+xomxx6mVtIzsRQ/A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0"
+      }
+    },
+    "node_modules/@types/rdfjs__prefix-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__prefix-map/-/rdfjs__prefix-map-0.1.5.tgz",
+      "integrity": "sha512-RAwyS/2dT9X79QwM0F8KLweTfuBoe6xtiAlU7wKPB+/t/sfk6A50LYtAWaDVP5qBjcu50UkKkZT+VR47CiLkfg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__serializer-jsonld": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-jsonld/-/rdfjs__serializer-jsonld-2.0.5.tgz",
+      "integrity": "sha512-ubdLD9QgZzAt+65NSPzh2qWCPWcGYlHEWgkP6uRwfm7JC48Xh/QjzwOTG13MTomOkQqcN4R7PIG0j3Ca8iyNWQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0"
+      }
+    },
+    "node_modules/@types/rdfjs__serializer-jsonld-ext": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-jsonld-ext/-/rdfjs__serializer-jsonld-ext-4.0.1.tgz",
+      "integrity": "sha512-jgbQ/1kV7nESKG7SY8FJED6K4OFznr6Sz3ybF1ncpBR7TUBTuy3InpZOVRK4Wjpy2zi84iIAzJ1CIIo9NZh2Xw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0",
+        "@types/jsonld": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__serializer-ntriples": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-ntriples/-/rdfjs__serializer-ntriples-2.0.6.tgz",
+      "integrity": "sha512-Nn3e3eyuymLvbI5MFzI7ODD/X6ZGpbB9fLaWOB00RtFHd2vttk3wQL2fzzsZZQPJ/ihC/xlFE4cNQkO6SoHa7w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0"
+      }
+    },
+    "node_modules/@types/rdfjs__serializer-turtle": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-turtle/-/rdfjs__serializer-turtle-1.1.0.tgz",
+      "integrity": "sha512-NGHnbz5985UwS/YS6WL/FkS94B+QiVTdsfvJCqPwLmY3E7UeClw91c2KbiphZUR/uh7uwLwxeKKhV2T1gYgT5Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0",
+        "@types/node": "*",
+        "@types/rdfjs__prefix-map": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__sink-map": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__sink-map/-/rdfjs__sink-map-2.0.5.tgz",
+      "integrity": "sha512-ycUBlOMbp9YpjrBrMwGv3uiqulOWgodess06cinYLxomOTc2ET9rEQklgM5rJqnu5WMsVP8SFG3fFw36/5hADQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__term-map": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__term-map/-/rdfjs__term-map-2.0.10.tgz",
+      "integrity": "sha512-YlpYkya+Xq9fmcw+BMi1SCh+w2sBu7G0/qd2+ZhB4QIK3V1xq2o3EOAZnlahyQdwrW9t5+Ihw8IVVvZsJvDOTA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__term-set": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__term-set/-/rdfjs__term-set-2.0.9.tgz",
+      "integrity": "sha512-RRXs5DwFGanZyT705f7KLSiN68gUVUtGWTp508CXJhLfD7AWmilqc1BLgLUoac48h3pnh9w5lRhwFm6fj1ZE5Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__traverser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__traverser/-/rdfjs__traverser-0.1.5.tgz",
+      "integrity": "sha512-tTpiM6lAddw+bGRDjhzwdpo1EQK73m8gYgMVNfO4OsevnuLZvQJeCJBckpuDC4H5HVAEwCapI0UlH9dVnZ9u5g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
+      "integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/spark-md5": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/spark-md5/-/spark-md5-3.0.5.tgz",
+      "integrity": "sha512-lWf05dnD42DLVKQJZrDHtWFidcLrHuip01CtnC2/S6AMhX4t9ZlEUj4iuRlAnts0PQk7KESOqKxeGE/b6sIPGg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/sparqljs": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.12.tgz",
+      "integrity": "sha512-zg/sdKKtYI0845wKPSuSgunyU1o/+7tRzMw85lHsf4p/0UbA6+65MXAyEtv1nkaqSqrq/bXm7+bqXas+Xo5dpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0"
+      }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "license": "MIT"
+    },
+    "node_modules/@vocabulary/sh": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@vocabulary/sh/-/sh-1.1.6.tgz",
+      "integrity": "sha512-8IfAQoKh57THz8LA2+n1jaY/VC2XaqMNSsJgzBKSSrj20y5PSMAawb6dMsxoLxqDIPBDs1TFRl/9CijUnwbBUA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@rdfjs/types": "^2.0.0"
+      }
+    },
+    "node_modules/@zazuko/env": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@zazuko/env/-/env-2.5.3.tgz",
+      "integrity": "sha512-kivvYoXGFjva1CuXeK/jaaWMy9eXhhFmuSfSJGVW2wH7XbcZehJObjPXEVlZ3kKLCFhuv96j8Ot3SkbYaOtuLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.0.1",
+        "@rdfjs/dataset": "^2.0.1",
+        "@rdfjs/formats": "^4.0.0",
+        "@rdfjs/namespace": "^2.0.0",
+        "@rdfjs/term-map": "^2.0.0",
+        "@rdfjs/term-set": "^2.0.1",
+        "@rdfjs/traverser": "^0.1.2",
+        "@tpluscode/rdf-ns-builders": "^4.1.0",
+        "@zazuko/env-core": "^1.1.2",
+        "@zazuko/prefixes": "^2.1.0",
+        "clownface": "^2.0.2",
+        "get-stream": "^9.0.1",
+        "rdf-dataset-ext": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@rdfjs/types": "^2",
+        "@types/clownface": "^2.0.0",
+        "@types/rdf-dataset-ext": "^1.0.8",
+        "@types/rdfjs__data-model": "^2.0.9",
+        "@types/rdfjs__dataset": "^2.0.7",
+        "@types/rdfjs__environment": "^1.0.0",
+        "@types/rdfjs__formats": "^4.0.1",
+        "@types/rdfjs__namespace": "^2.0.10",
+        "@types/rdfjs__term-map": "^2.0.10",
+        "@types/rdfjs__term-set": "^2.0.9",
+        "@types/rdfjs__traverser": "^0.1.5"
+      }
+    },
+    "node_modules/@zazuko/env-core": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@zazuko/env-core/-/env-core-1.1.2.tgz",
+      "integrity": "sha512-mnLG40utuT7jPBPLs6fJ0puhfagnXSj+S8t9+zUGs3YlrOq/7b2zr64Hi3p3etwDdApaQ0VgQuNIY9doaruS1Q==",
+      "dependencies": {
+        "@rdfjs/environment": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/rdfjs__environment": "^1.0.0"
+      }
+    },
+    "node_modules/@zazuko/env-node": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@zazuko/env-node/-/env-node-2.1.2.tgz",
+      "integrity": "sha512-w3qNtSh5ekm+gthXGPA+vZ6zP49vAHWwT1xaO83vqTNs63CMOsYnV3OtZavuyg882S+SBTj/mu7RNSUb5zO0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/fetch-lite": "^3.2.2",
+        "@rdfjs/formats": "^4.0.0",
+        "@zazuko/env": "^2.1.1",
+        "@zazuko/rdf-utils-fs": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/rdfjs__fetch-lite": "^3.0.6"
+      }
+    },
+    "node_modules/@zazuko/prefixes": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@zazuko/prefixes/-/prefixes-2.6.1.tgz",
+      "integrity": "sha512-fbOadP7twxt0ZYT9mgIC+xQMk6f3pYYLI5a/2UJ/mc/ygqb/NoVv2ryK3lTtoi74xwkdpUeDwIuFQSosowzUgg==",
+      "license": "MIT"
+    },
+    "node_modules/@zazuko/rdf-utils-fs": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@zazuko/rdf-utils-fs/-/rdf-utils-fs-3.3.1.tgz",
+      "integrity": "sha512-4HjTbJUwiCFanMMcaaZkLIkWUdVjXSQstAyxnfzsUOmh8Q43iVBL+mYAl17zoi47III0POL6hitRsN1JJ5tUFg==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": ">=3.6.0"
+      },
+      "peerDependencies": {
+        "@rdfjs/types": "*",
+        "@types/rdfjs__environment": "0 - 1",
+        "@types/rdfjs__formats": "^4"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/asynciterator": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.10.0.tgz",
+      "integrity": "sha512-eDOBoUf2m+4ht0ETVn2SCfuBIZZ6UWyyQbP++LRPKoK7PmrCQq37pJ6vRvyef4o1Pn+CwWnzMlkXxGdh/krVIw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-set-immediate": "^1.0.2"
+      }
+    },
+    "node_modules/asyncjoin": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/asyncjoin/-/asyncjoin-1.2.4.tgz",
+      "integrity": "sha512-7/1g5uV2/iTDQteJ/pxqZq6qkO5406V+vNyOCYtHJ+mo6bmvvQHHrZgd7AtU/rx+cnz08NPWlwk8daW61thnlA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynciterator": "^3.9.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clownface": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/clownface/-/clownface-2.0.3.tgz",
+      "integrity": "sha512-E76TBJ7CgU9+/5paSAvuNdMO+fzFThnvRVtidosktYppYkXM8V7tid8Ezzo8S1OmoWxKUam3yfkZlfCid4OiJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.0.1",
+        "@rdfjs/environment": "0 - 1",
+        "@rdfjs/namespace": "^2.0.0"
+      }
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/componentsjs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-6.4.0.tgz",
+      "integrity": "sha512-H3AmzWARyQB5V/XJ7brjnFVfqywedjVFX3n528GKjEpQvNY4HXu5CBOAWDADjeSC42cufVc7C+J+cGTsgeKRzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/minimist": "^1.2.0",
+        "@types/node": "^18.0.0",
+        "@types/semver": "^7.3.4",
+        "jsonld-context-parser": "^3.0.0",
+        "minimist": "^1.2.0",
+        "rdf-data-factory": "^2.0.2",
+        "rdf-object": "^3.0.0",
+        "rdf-parse": "^4.0.0",
+        "rdf-quad": "^2.0.0",
+        "rdf-string": "^2.0.1",
+        "rdf-terms": "^2.0.0",
+        "semver": "^7.3.2",
+        "winston": "^3.3.3"
+      },
+      "bin": {
+        "componentsjs-compile-config": "bin/compile-config.js"
+      }
+    },
+    "node_modules/componentsjs/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/componentsjs/node_modules/rdf-quad": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-quad/-/rdf-quad-2.0.0.tgz",
+      "integrity": "sha512-wR3x+ypdPh6jlFy+i/+U3jUlr5078GHfBkqf3TPPJa7zJVurkJY0J8ALKPWYd1V4oyYsqJCHr3xNM5RDlvH32A==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.1",
+        "rdf-literal": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      }
+    },
+    "node_modules/componentsjs/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/componentsjs/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/componentsjs/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/duplex-to": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/duplex-to/-/duplex-to-2.0.0.tgz",
+      "integrity": "sha512-f2nMnk11mwDptEFBTv2mcWHpF4ENAbuQ63yTiSy/99rG4Exsxsf0GJhJYq/AHF2cdMYswSx23LPuoijBflpquQ==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/event-emitter-promisify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/event-emitter-promisify/-/event-emitter-promisify-1.1.0.tgz",
+      "integrity": "sha512-uyHG8gjwYGDlKoo0Txtx/u1HI1ubj0FK0rVqI4O0s1EymQm4iAEMbrS5B+XFlSaS8SZ3xzoKX+YHRZk8Nk/bXg==",
+      "license": "MIT"
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/grapoi": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/grapoi/-/grapoi-1.2.0.tgz",
+      "integrity": "sha512-oK+qPeiYugQKEm57IlgmedU6NrZMz0nA5g8MJ6db5afOp//isTC1P0zqwSlwfDJrUt+2TEGIoQlW7C8/a2QalQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/namespace": "^2.0.0",
+        "@rdfjs/term-set": "^2.0.0"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/http-link-header": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
+      "integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/immutable": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
+      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+      "license": "MIT"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jsonld": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-9.0.0.tgz",
+      "integrity": "sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@digitalbazaar/http-client": "^4.2.0",
+        "canonicalize": "^2.1.0",
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsonld-context-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-3.1.0.tgz",
+      "integrity": "sha512-BfgNJ/t9jjK7Lun9XRCJM6YeNqDk8B6/lg+KS8rzhXAOtS0FvoClSmtLvF24V1M2CDYRy2LcEBt0ilxqSX93WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/jsonld-context-parser/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/jsonld-context-parser/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/jsonld-streaming-parser": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-5.0.1.tgz",
+      "integrity": "sha512-Rf230DRAWe5p1H4e7phk1vo4FHEMOmC5xVcIywKJBBcwy6zaJWFcAvPcwngufNTdJs7dpTMbKQDjp4TYDpMKUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.0",
+        "@types/http-link-header": "^1.0.1",
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^3.1.0",
+        "rdf-data-factory": "^2.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/jsonld-streaming-parser/node_modules/canonicalize": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
+      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
+    "node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/microdata-rdf-streaming-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-2.0.1.tgz",
+      "integrity": "sha512-oEEYP3OwPGOtoE4eIyJvX1eJXI7VkGR4gKYqpEufaRXc2ele/Tkid/KMU3Los13wGrOq6woSxLEGOYSHzpRvwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "htmlparser2": "^8.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.1.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "node_modules/microdata-rdf-streaming-parser/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/microdata-rdf-streaming-parser/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/microdata-rdf-streaming-parser/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "node_modules/microdata-rdf-streaming-parser/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/n3": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-2.0.4.tgz",
+      "integrity": "sha512-d2Sr4vvqombySfOARjw5jQky0EYMwkEXuQQjYe2glasDdI3hAT3l00aJZbAmR+AA59eFNjJbDkHCq9l5Dm2DIg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/negotiate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/negotiate/-/negotiate-1.0.1.tgz",
+      "integrity": "sha512-KBCIM4dAIT9j/pSXLHHQbZG74NmKNXTtxU2zHN0HG6uzzuFE01m1UdGoUmVHmACiBuCAOL7KwfqSW1oUQBj/vg=="
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/nodeify-fetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nodeify-fetch/-/nodeify-fetch-3.1.0.tgz",
+      "integrity": "sha512-ZV81vM//sEgTgXwVZlOONzcOCdTGQ53mV65FVSNXgPQHa8oCwRLtLbnGxL/1S/Yw90bcXUDKMz00jEnaeazo+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "node-fetch": "^3.2.10",
+        "readable-stream": "^4.2.0",
+        "stream-chunks": "^1.0.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/promise-polyfill": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+      "integrity": "sha512-7rrONfyLkDEc7OJ5QBkqa4KI4EBhCd340xRuIUPGCfu13znS+vx+VDdrT9ODAJHlXm7w4lbxN3DRjyv58EuzDg==",
+      "license": "MIT"
+    },
+    "node_modules/rdf-canonize": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-5.0.0.tgz",
+      "integrity": "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-dataset-ext": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-dataset-ext/-/rdf-dataset-ext-1.1.0.tgz",
+      "integrity": "sha512-CH85RfRKN9aSlbju8T7aM8hgCSWMBsh2eh/tGxUUtWMN+waxi6iFDt8/r4PAEmKaEA82guimZJ4ISbmJ2rvWQg==",
+      "deprecated": "rdf-dataset-ext is deprecated. Switching to rdf-ext is recommended.",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-canonize": "^3.0.0",
+        "readable-stream": "3 - 4"
+      }
+    },
+    "node_modules/rdf-dataset-ext/node_modules/rdf-canonize": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.4.0.tgz",
+      "integrity": "sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-isomorphic/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-isomorphic/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-literal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-2.0.0.tgz",
+      "integrity": "sha512-jlQ+h7EvnXmncmk8OzOYR8T3gNfd4g0LQXbflHkEkancic8dh0Tdt5RiRq8vUFndjIeNHt1RWeA5TAj6rgrtng==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-object": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-3.0.0.tgz",
+      "integrity": "sha512-qefryIRh1d9gqZUKp2qQwzIWLbmQspsc2bvVoOCCp126MZmKubcUTigHiMlCrUI9g7MDCrdTFAwcAal1lVR09A==",
+      "license": "MIT",
+      "dependencies": {
+        "jsonld-context-parser": "^3.0.0",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-string": "^2.0.0",
+        "streamify-array": "^1.0.1"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-object/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-4.0.0.tgz",
+      "integrity": "sha512-lNVuUKPVAdX9lJYYrJFhdQHFulYjk95BYvuNsE+eUs/M93sdsovH/Ga8bTAxagmpsoQ4LzMPa2YqeHX8ysltOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-http-fetch": "^4.0.1",
+        "@comunica/actor-http-proxy": "^4.0.1",
+        "@comunica/actor-rdf-parse-html": "^4.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^4.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^4.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^4.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^4.0.1",
+        "@comunica/actor-rdf-parse-n3": "^4.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^4.0.1",
+        "@comunica/actor-rdf-parse-shaclc": "^4.0.1",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^4.0.1",
+        "@comunica/bus-http": "^4.0.1",
+        "@comunica/bus-init": "^4.0.1",
+        "@comunica/bus-rdf-parse": "^4.0.1",
+        "@comunica/bus-rdf-parse-html": "^4.0.1",
+        "@comunica/config-query-sparql": "^4.0.1",
+        "@comunica/context-entries": "^4.0.1",
+        "@comunica/core": "^4.0.1",
+        "@comunica/mediator-combine-pipeline": "^4.0.1",
+        "@comunica/mediator-combine-union": "^4.0.1",
+        "@comunica/mediator-number": "^4.0.1",
+        "@comunica/mediator-race": "^4.0.1",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.2",
+        "readable-stream": "^4.5.2",
+        "stream-to-string": "^1.2.1"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/rdf-quad": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/rdf-quad/-/rdf-quad-1.5.0.tgz",
+      "integrity": "sha512-LnCYx8XbRVW1wr6UiZPSy2Tv7bXAtEwuyck/68dANhFu8VMnGS+QfUNP3b9YI6p4Bfd/fyDx5E3x81IxGV6BzA==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^1.0.1",
+        "rdf-literal": "^1.2.0",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "node_modules/rdf-quad/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rdf-quad/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/rdf-quad/node_modules/rdf-literal": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.3.2.tgz",
+      "integrity": "sha512-79Stlu3sXy0kq9/decHFLf3xNPuY6sfhFPhd/diWErgaFr0Ekyg38Vh9bnVcqDYu48CFRi0t+hrFii49n92Hbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/rdf-string": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
+      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/rdf-string/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rdf-string/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/rdf-terms": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.11.0.tgz",
+      "integrity": "sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.6.0"
+      }
+    },
+    "node_modules/rdf-terms/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rdf-terms/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/rdf-validate-datatype": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/rdf-validate-datatype/-/rdf-validate-datatype-0.2.2.tgz",
+      "integrity": "sha512-mH9qL8i0WBbZ6HJCA26BB6V+WV2MraKvitez3SV0QegBWVQ4wYO49CgfFBzoAYg6tlnhFXl9MkrOAQ07X2N1FA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/term-map": "^2.0.0",
+        "@tpluscode/rdf-ns-builders": "3 - 5"
+      }
+    },
+    "node_modules/rdf-validate-shacl": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/rdf-validate-shacl/-/rdf-validate-shacl-0.6.5.tgz",
+      "integrity": "sha512-rwIibopSixDE8ecA9x0c7oTVxdMWxGiJh7h3uJ+WS2h4lq2nx3DZVO7rJvwa5kZpDq9QEFPoyZINAUyfaaoN4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.1.0",
+        "@rdfjs/dataset": "^2.0.2",
+        "@rdfjs/environment": "^1.0.0",
+        "@rdfjs/namespace": "^2.0.1",
+        "@rdfjs/term-set": "^2.0.3",
+        "@rdfjs/types": "1 - 2",
+        "@vocabulary/sh": "^1.1.6",
+        "clownface": "^2.0.3",
+        "debug": "^4.3.2",
+        "rdf-dataset-ext": "^1.1.0",
+        "rdf-literal": "^2.0.0",
+        "rdf-validate-datatype": "^0.2.2"
+      }
+    },
+    "node_modules/rdf-validation": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/rdf-validation/-/rdf-validation-0.1.1.tgz",
+      "integrity": "sha512-z2RbRcsKOM+CWa7qoI4LWCQQTji64eoBNLvbP3++0ZE4pO4EP1xkV5asSH4TULeLfDEuMhzyDXRnAjA+8R2l4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.0.1",
+        "@rdfjs/namespace": "^2.0.0",
+        "@rdfjs/term-map": "^2.0.0",
+        "@rdfjs/to-ntriples": "^3.0.1"
+      }
+    },
+    "node_modules/rdfa-streaming-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-2.0.1.tgz",
+      "integrity": "sha512-7Yyaj030LO7iQ38Wh/RNLVeYrVFJeyx3dpCK7C1nvX55eIN/gE4HWfbg4BYI9X7Bd+eUIUMVeiKYLmYjV6apow==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "htmlparser2": "^8.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "node_modules/rdfa-streaming-parser/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rdfa-streaming-parser/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/rdfa-streaming-parser/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "node_modules/rdfa-streaming-parser/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/rdfxml-streaming-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-3.2.0.tgz",
+      "integrity": "sha512-SgQGK0EkbXd0jQ1PZk7dEpfDxf4CZpezkO6cTuGWesa9twdWaaW5elMoNBcbMT+2tOZC1EYZjs0JaXx0HnifcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^4.0.18",
+        "buffer": "^6.0.3",
+        "rdf-data-factory": "^2.0.2",
+        "readable-stream": "^4.4.2",
+        "relative-to-absolute-iri": "^1.0.0",
+        "validate-iri": "^1.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/readable-from-web": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readable-from-web/-/readable-from-web-1.0.0.tgz",
+      "integrity": "sha512-tei03fQhxqLEklpIvocFUR9hO42hiyYvdhwoNHAjJztPAQ8QS1NqF2AhLwzGxIGidPBJ4MCqB48wn7OAFCfhsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-stream-node-to-web": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz",
+      "integrity": "sha512-OGzi2VKLa8H259kAx7BIwuRrXHGcxeHj4RdASSgEGBP9Q2wowdPvBc65upF4Q9O05qWgKqBw1+9PiLTtObl7uQ==",
+      "license": "MIT"
+    },
+    "node_modules/relative-to-absolute-iri": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.8.tgz",
+      "integrity": "sha512-U1TmhrhCmXKkDL9mI8gBbF5TN6TKcuv28k5+H3gMCAjoz0TyyHAICHlaGDZsTEBSu2Y3HhDKc8e6X9n33qeIqA==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/shacl-engine": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shacl-engine/-/shacl-engine-1.1.0.tgz",
+      "integrity": "sha512-DaLeB33mZdbuAQLKAH+/tOaz58DU8q/LHKVriQQl5ts10gBLFQ3KD1x0GRWi08lKULJSuSatBKq0zB3F/H/vRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/query-sparql-rdfjs-lite": "^4.0.2",
+        "@comunica/utils-bindings-factory": "^4.0.2",
+        "@rdfjs/namespace": "^2.0.0",
+        "@rdfjs/term-map": "^2.0.0",
+        "@rdfjs/term-set": "^2.0.1",
+        "@rdfjs/to-ntriples": "^3.0.1",
+        "grapoi": "^1.1.1",
+        "lodash": "^4.17.21",
+        "rdf-literal": "^2.0.0",
+        "rdf-validation": "^0.1.0",
+        "readable-stream": "^4.5.1"
+      }
+    },
+    "node_modules/shaclc-parse": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/shaclc-parse/-/shaclc-parse-1.4.3.tgz",
+      "integrity": "sha512-MQJWVFjfzzMUvieFO0STWjIo49ywy63UkVSsr0e8+8xHUns6X+i3yWYxNKd+GtSEJjBNZxxrUubog+hnd7PvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0",
+        "n3": "^1.16.3"
+      }
+    },
+    "node_modules/shaclc-parse/node_modules/n3": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.26.0.tgz",
+      "integrity": "sha512-SQknS0ua90rN+3RHuk8BeIqeYyqIH/+ecViZxX08jR4j6MugqWRjtONl3uANG/crWXnOM2WIqBJtjIhVYFha+w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+      }
+    },
+    "node_modules/sparqlalgebrajs/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/sparqlalgebrajs/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/sparqljs": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.4.tgz",
+      "integrity": "sha512-hb4C84gf7KM7vz+iG595mPwvqxOvBJCm9L3dCxtV2zZDht6ZMmMG0tHeeqFeqwb9875yU9U4lhYe4LYRvWj0BQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^1.1.2"
+      },
+      "bin": {
+        "sparqljs": "bin/sparql-to-json"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/sparqljs/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/sparqljs/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stream-chunks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-chunks/-/stream-chunks-1.0.0.tgz",
+      "integrity": "sha512-/G+kinLx3pKXChtuko82taA4gZo56zFG2b2BbhmugmS0TUPBL40c5b2vjonS+gAHYK/cSKM9m0WTvAJYgDUeNw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "string_decoder": "^1.3.0"
+      }
+    },
+    "node_modules/stream-to-string": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.1.tgz",
+      "integrity": "sha512-WsvTDNF8UYs369Yko3pcdTducQtYpzEZeOV7cTuReyFvOoA9S/DLJ6sYK+xPafSPHhUMpaxiljKYnT6JSFztIA==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-polyfill": "^1.1.6"
+      }
+    },
+    "node_modules/streamify-array": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/streamify-array/-/streamify-array-1.0.1.tgz",
+      "integrity": "sha512-ZnswaBcC6B1bhPLSQOlC6CdaDUSzU0wr2lvvHpbHNms8V7+DLd8uEAzDAWpsjxbFkijBHhuObFO/qqu52DZUMA==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-set-immediate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-set-immediate/-/tiny-set-immediate-1.0.2.tgz",
+      "integrity": "sha512-EVbaM4zXFWS4CIqVoPzY7XIioQ5LU1p49AHizwPO1KyFyp/gxy5SA8mDmfDVl/2WLQiHgUL+esO6Ig+KhpUxUw==",
+      "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/validate-iri": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/validate-iri/-/validate-iri-1.0.1.tgz",
+      "integrity": "sha512-gLXi7351CoyVVQw8XE5sgpYawRKatxE7kj/xmCxXOZS1kMdtcqC0ILIqLuVEVnAUQSL/evOGG3eQ+8VgbdnstA==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/crates/sparq-shacl/tests/diff_fuzz/package.json
+++ b/crates/sparq-shacl/tests/diff_fuzz/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sparq-shacl-diff-fuzz-node-adapter",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "[OPUS-4.8] sq-vz2v — Node/RDF-JS reference SHACL adapter for the sparq-shacl differential fuzzer. Pinned reference engines so the differential is reproducible; bump deliberately (mirrors the pinned pySHACL/Jena versions). `npm ci` here, then point the Rust runner at this node_modules via SHACL_DIFF_NODE_MODULES (or NODE_PATH).",
+  "license": "MIT",
+  "dependencies": {
+    "@zazuko/env-node": "2.1.2",
+    "n3": "2.0.4",
+    "rdf-validate-shacl": "0.6.5",
+    "shacl-engine": "1.1.0"
+  }
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — automated change for bead **sq-vz2v**. Identifying as a SPARQ agent (the author runs several agents on one account).

## What

Adds a **third** reference-engine family to the differential SHACL fuzzer
(`crates/sparq-shacl/tests/diff_fuzz.rs`), alongside pySHACL (sq-55c1) and Apache
Jena (sq-evws): a **Node / RDF-JS** adapter driving the Zazuko **`shacl-engine`**
(default) or **`rdf-validate-shacl`** validator, selected by `SHACL_DIFF_NODE_ENGINE`.

It is the same report-cli contract (sq-eifd) — `{data,shapes}` Turtle on stdin,
normalised `{conforms, violations:[{focus,component,path}]}` JSON on stdout — so the
engine-agnostic Rust runner is unchanged apart from a new `resolve_node()` wired into
`resolve_engines()`. Being JS over RDF-JS, this is also the on-ramp for a future
JS-vs-JS lane against sparq's own `@jeswr/sparq` WASM SHACL (the bonus noted on the bead).

## How

- **`tests/diff_fuzz/node_shacl_adapter.mjs`** — parses Turtle (`n3`) into an RDF-JS
  dataset (one `@zazuko/env-node` factory drives **both** validators: `shacl-engine`
  needs a data factory, `rdf-validate-shacl` additionally needs `.clownface`),
  runs the selected validator, and normalises straight off the **standard SHACL report
  vocabulary** (not either lib's bespoke JS objects). Mirrors the pySHACL/Jena
  **`sh:detail` exclusion**: a nested sub-result (object of `sh:detail`) lives in
  sparq's `ValidationResult::details`, not the top-level set, and is non-normative
  (SHACL §3.6.2) — so it is dropped. `--selftest` proves this on a synthetic report,
  independent of the installed validator version.
- **`RefEngine`** grows an `envs` field so the child gets `NODE_PATH` + the engine
  switch; pySHACL/Jena pass empty.
- **`resolve_node()`** gates on a usable `node` + a resolvable `node_modules`
  (`SHACL_DIFF_NODE_MODULES`, else the adapter-local `node_modules`, else `NODE_PATH`);
  skips cleanly otherwise, so the pySHACL/Jena/no-Node lanes are unaffected. Deps are
  pinned in `package.json` + lockfile (`node_modules` is gitignored).
- **Fast per-PR unit tests**: `node_modules_gating` (pure, no FS/env) and
  `node_adapter_excludes_nested_sh_detail` (drives `--selftest`, skips if Node doesn't resolve).
- **`shacl-diff-fuzz.yml`**: `setup-node`, cached `npm ci`, adapter selftest, points
  `SHACL_DIFF_NODE_MODULES`; README documents the third engine and how to run it.

## Verification

- **150/150 agreement** sparq-shacl vs `shacl-engine` **and** vs `rdf-validate-shacl`
  over seeds `0..150` (run locally via the actual Rust differential).
- The `sh:detail` exclusion is **load-bearing**: on an `sh:node` nested shape,
  `rdf-validate-shacl` emits a nested detail result that `shacl-engine` does not — the
  exclusion makes all three engines agree on the single top-level violation.

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` + tests pass in **both**
  feature states (`default` and `shacl-af`).
- `scripts/check-privacy-claims.sh` OK.
- No public Rust API changed (test-only assets + a test binary), so the G2
  public-API→SKILL.md rule does not apply.

Closes sq-vz2v.

🤖 Generated with [Claude Code](https://claude.com/claude-code)