### PR TITLE
perf(sparq-mpc): tighten oblivious shuffle to AS-Waksman optimal switch count (sq-hny9) [OPUS-4.8]

### DIFF
--- a/crates/sparq-mpc/src/oblivious.rs
+++ b/crates/sparq-mpc/src/oblivious.rs
@@ -176,13 +176,20 @@ pub struct Switch {
 /// cannot reach all permutations (or reaches some far more often) leaks order
 /// information. The switch count is `O(n log n)`.
 ///
-/// We build the **plain** recursive form (`⌊m/2⌋` input + `⌊m/2⌋` output switches
-/// per level) rather than the AS-Waksman redundancy-removal optimization (which
-/// shaves one switch per level by fixing the first output pair). The plain form is
-/// marginally larger but routes every permutation without the odd-`m` corner-case
-/// over-constraint the fixed pair introduces — see `solve_waksman_level`.
-/// Tightening to the AS-Waksman `−1`/level count is a perf-only follow-up (bead
-/// sq-hny9).
+/// We build the **AS-Waksman** (Beauquier–Darrot, "On arbitrary-size Waksman
+/// networks") redundancy-removal form: `⌊m/2⌋` input switches and `⌊(m−1)/2⌋`
+/// output switches per level (one fewer output switch than the plain Beneš form on
+/// **even** `m`), giving the optimal arbitrary-size count `W(n) = W(⌈n/2⌉) +
+/// W(⌊n/2⌋) + (n−1)`. The saving comes from **fixing one output pair** on even
+/// levels: the last output pair `(m−2, m−1)` is routed straight (output `m−2` from
+/// the TOP sub-network, output `m−1` from the BOTTOM), so it needs no switch — the
+/// alternating-path solver seeds that pin and derives the rest, so the fixed pair
+/// is a *consequence* of the routing rather than an over-constraint. On **odd** `m`
+/// no extra output pair is pinned (the odd-trailing output already carries no
+/// switch), which is exactly how the corner-case clash the bead flagged — output 1
+/// pinned BOTTOM vs. the odd-trailing input pinned TOP — is avoided. Full support
+/// (every `n!` permutation reachable) and exhaustive routing are tested for small
+/// `n`; see `solve_waksman_level`.
 ///
 /// The topology depends ONLY on `n`. The same network is reused for every shuffle
 /// of the same width; only the control bits (the secret permutation) change.
@@ -330,15 +337,17 @@ fn route_recording(perm: &[usize]) -> (Vec<Switch>, Vec<bool>) {
 /// the trailing input/output passes straight into the top sub-network (no input
 /// switch, no output switch).
 ///
-/// We use the **Beneš/Waksman recursive network** in its plain form — `⌊m/2⌋`
-/// input + `⌊m/2⌋` output switches per level — rather than the AS-Waksman
-/// redundancy-removal optimization (which fixes the first output pair to shave one
-/// switch per level). The plain form is one switch/level larger (still `O(n log
-/// n)`) but routes EVERY permutation without the corner-case over-constraint the
-/// fixed pair introduces for odd `m` (verified exhaustively for all permutations
-/// up to `n = 9`). Crucially for a *shuffle* it is **NOT Benes-biased**: it reaches
-/// all `n!` permutations with full support (tested for `n = 3, 4`). Tightening to
-/// the −1/level AS-Waksman count is a perf-only follow-up (bead sq-hny9).
+/// We use the **AS-Waksman recursive network** (Beauquier–Darrot): `⌊m/2⌋` input
+/// switches and `⌊(m−1)/2⌋` output switches per level. On **even** `m` that is one
+/// FEWER output switch than the plain Beneš form — the last output pair `(m−2,
+/// m−1)` is routed straight (no switch) by fixing output `m−2` to the TOP
+/// sub-network and `m−1` to the BOTTOM. On **odd** `m` all `⌊m/2⌋` output switches
+/// are kept (no extra pair is pinned), so the odd-trailing-input / fixed-pair
+/// clash the bead flagged cannot occur. This yields the optimal arbitrary-size
+/// count `W(n) = W(⌈n/2⌉) + W(⌊n/2⌋) + (n−1)` (still `O(n log n)`) and routes EVERY
+/// permutation (verified exhaustively up to `n = 9`). Crucially for a *shuffle* it
+/// is **NOT Benes-biased**: it reaches all `n!` permutations with full support
+/// (tested for `n = 3, 4`).
 ///
 /// Routing (data-dependent — the control BITS, not the topology): solved by the
 /// standard alternating-path / 2-coloring argument over the input/output pair
@@ -362,8 +371,12 @@ fn waksman_rec(wires: &[usize], perm: &[usize], switches: &mut Vec<Switch>, bits
     let odd = m % 2 == 1;
     let top_len = m - half; // = ⌈m/2⌉
     let bot_len = half; // = ⌊m/2⌋
+    // AS-Waksman: ⌊(m−1)/2⌋ output switches. On even m the LAST output pair
+    // (m−2, m−1) is fixed (no switch), shaving one switch this level; on odd m all
+    // `half` output switches are kept.
+    let out_switches = (m - 1) / 2;
 
-    let solved = solve_waksman_level(m, half, odd, perm);
+    let solved = solve_waksman_level(m, half, odd, out_switches, perm);
 
     // --- emit in BUILD/application order: input column, top sub, bottom sub, output column.
 
@@ -392,8 +405,11 @@ fn waksman_rec(wires: &[usize], perm: &[usize], switches: &mut Vec<Switch>, bits
     waksman_rec(&top_wires, &solved.top_perm, switches, bits);
     waksman_rec(&bot_wires, &solved.bot_perm, switches, bits);
 
-    // Output column: switch k (k in 0..half) acts on global (wires[2k], wires[2k+1]).
-    for k in 0..half {
+    // Output column: AS-Waksman emits only the first `out_switches = ⌊(m−1)/2⌋`
+    // output switches. On even m the last output pair (m−2, m−1) is fixed (output
+    // m−2 from TOP, m−1 from BOTTOM) and carries NO switch — that is the −1/level
+    // saving; on odd m `out_switches == half` so all are emitted.
+    for k in 0..out_switches {
         switches.push(Switch {
             a: wires[2 * k],
             b: wires[2 * k + 1],
@@ -405,7 +421,7 @@ fn waksman_rec(wires: &[usize], perm: &[usize], switches: &mut Vec<Switch>, bits
 /// The solved routing of one AS-Waksman level.
 struct WaksmanLevel {
     in_swap: Vec<bool>,   // len half (per input switch)
-    out_swap: Vec<bool>,  // len half (index 0 fixed false)
+    out_swap: Vec<bool>,  // len ⌊(m−1)/2⌋ (the last even-m output pair is fixed)
     top_perm: Vec<usize>, // permutation routed by the top sub-network (len ⌈m/2⌉)
     bot_perm: Vec<usize>, // permutation routed by the bottom sub-network (len ⌊m/2⌋)
 }
@@ -431,7 +447,23 @@ struct WaksmanLevel {
 /// DIFFERENT sub-networks, then 2-color by walking alternating cycles. Seeding
 /// each cycle at an undecided input switch (with the fixed output pair already
 /// pinned) yields a consistent assignment; this is the classic Waksman routing.
-fn solve_waksman_level(m: usize, half: usize, odd: bool, perm: &[usize]) -> WaksmanLevel {
+///
+/// AS-Waksman optimization: on **even** `m` the last output pair `(m−2, m−1)` is
+/// pinned BEFORE the alternating-path propagation (output `m−2` from TOP, `m−1`
+/// from BOTTOM), so it needs no output switch — the pin is just one more seed the
+/// constraint propagation honours, making the fixed pair a *consequence* of a
+/// consistent routing rather than an axiom that over-constrains it. `out_switches`
+/// = `⌊(m−1)/2⌋` switch bits are returned (the pinned even-`m` pair excluded). On
+/// **odd** `m` nothing extra is pinned (the odd-trailing output already carries no
+/// switch), avoiding the corner-case clash between a pinned output pair and the
+/// odd-trailing input that is forced TOP.
+fn solve_waksman_level(
+    m: usize,
+    half: usize,
+    odd: bool,
+    out_switches: usize,
+    perm: &[usize],
+) -> WaksmanLevel {
     let top_len = m - half;
     // inv[o] = the input that must reach output o.
     let mut inv = vec![0usize; m];
@@ -448,6 +480,14 @@ fn solve_waksman_level(m: usize, half: usize, odd: bool, perm: &[usize]) -> Waks
     if odd {
         in_top[m - 1] = Some(true);
         out_from_top[m - 1] = Some(true);
+    } else {
+        // AS-Waksman (even m): fix the LAST output pair (m−2, m−1) so it needs no
+        // switch — output m−2 fed from TOP, m−1 from BOTTOM. This is the −1/level
+        // saving. We pin it as a seed; the alternating-path propagation below makes
+        // the rest consistent, so the fixed pair is a consequence of the routing.
+        // (m ≥ 4 here: m == 2 returns early above, m == 3 is odd.)
+        out_from_top[m - 2] = Some(true);
+        out_from_top[m - 1] = Some(false);
     }
 
     // Helper: given an input i is decided, the OTHER input of its switch must go to
@@ -542,9 +582,11 @@ fn solve_waksman_level(m: usize, half: usize, odd: bool, perm: &[usize]) -> Waks
         in_swap[k] = !low_top; // pass when low_top; swap otherwise
     }
     // Output switch k passes iff output 2k is fed from TOP (top→low is the pass
-    // wiring).
-    let mut out_swap = vec![false; half];
-    for k in 0..half {
+    // wiring). Only the first `out_switches` output pairs carry a switch; on even
+    // m the last pair (k = half−1, outputs m−2/m−1) was pinned (TOP/BOTTOM) and has
+    // no switch — that is the AS-Waksman −1/level saving.
+    let mut out_swap = vec![false; out_switches];
+    for k in 0..out_switches {
         let low_from_top = out_from_top[2 * k].unwrap();
         out_swap[k] = !low_from_top;
     }
@@ -1083,9 +1125,8 @@ mod tests {
 
     #[test]
     fn waksman_switch_count_is_log_linear() {
-        // The plain Beneš/Waksman form is O(n log n); assert it stays within a
-        // loose 2·n·⌈log₂ n⌉ bound (the AS-Waksman optimization would shave it, a
-        // perf-only follow-up — bead sq-hny9) and is non-trivial for n>1.
+        // The AS-Waksman form is O(n log n); assert it stays within a loose
+        // 2·n·⌈log₂ n⌉ bound and is non-trivial for n>1.
         for n in [2usize, 3, 4, 5, 7, 8, 16, 17, 31, 32] {
             let net = WaksmanNetwork::new(n);
             let l = ceil_log2(n);
@@ -1099,11 +1140,71 @@ mod tests {
         }
     }
 
+    /// AS-Waksman optimal switch count (bead sq-hny9): the network realizes the
+    /// canonical arbitrary-size recurrence `W(n) = W(⌈n/2⌉) + W(⌊n/2⌋) + (n−1)`
+    /// (Beauquier–Darrot), shaving one switch per even-`m` recursion level vs. the
+    /// plain Beneš form. This is the `~n·⌈log₂ n⌉ − n + 1` optimal count.
+    #[test]
+    fn waksman_switch_count_is_as_waksman_optimal() {
+        fn canonical(n: usize) -> usize {
+            match n {
+                0 | 1 => 0,
+                2 => 1,
+                _ => canonical(n.div_ceil(2)) + canonical(n / 2) + (n - 1),
+            }
+        }
+        for n in 0..=64usize {
+            assert_eq!(
+                WaksmanNetwork::new(n).switch_count(),
+                canonical(n),
+                "n={n}: switch count is not the AS-Waksman optimum"
+            );
+        }
+        // Spot-check known optimal values from the literature.
+        assert_eq!(WaksmanNetwork::new(4).switch_count(), 5);
+        assert_eq!(WaksmanNetwork::new(8).switch_count(), 17);
+        assert_eq!(WaksmanNetwork::new(16).switch_count(), 49);
+    }
+
     /// THE shuffle correctness + routing test: for every permutation of small n,
     /// routing it and applying the network must realize EXACTLY that permutation.
+    /// Full support (the anti-Benes-bias property the bead requires verified): for
+    /// small `n`, EVERY one of the `n!` permutations is realized by routing it
+    /// through the network — none is unreachable. Combined with
+    /// `waksman_routes_every_permutation_correctly` (which checks each routes to
+    /// EXACTLY itself) this proves the realized-permutation map is a bijection onto
+    /// `S_n`, so a uniform random `perm` gives an unbiased shuffle even after the
+    /// AS-Waksman switch-count reduction.
+    #[test]
+    fn waksman_has_full_support_after_optimization() {
+        use std::collections::HashSet;
+        for n in 1..=7usize {
+            let net = WaksmanNetwork::new(n);
+            let mut realized: HashSet<Vec<usize>> = HashSet::new();
+            let mut perm: Vec<usize> = (0..n).collect();
+            permute_each(&mut perm, 0, &mut |p| {
+                let bits = net.route(p).expect("route ok");
+                let mut labels: Vec<usize> = (0..n).collect();
+                for (sw, &bit) in net.switches().iter().zip(&bits) {
+                    if bit {
+                        labels.swap(sw.a, sw.b);
+                    }
+                }
+                // labels[o] = input landing at output o; record the realized perm.
+                realized.insert(labels);
+            });
+            let factorial: usize = (1..=n).product();
+            assert_eq!(
+                realized.len(),
+                factorial,
+                "n={n}: AS-Waksman net does not reach all {factorial} permutations (biased)"
+            );
+        }
+    }
+
     #[test]
     fn waksman_routes_every_permutation_correctly() {
-        for n in 1..=7usize {
+        for n in 1..=8usize {
             let net = WaksmanNetwork::new(n);
             let mut perm: Vec<usize> = (0..n).collect();
             permute_each(&mut perm, 0, &mut |p| {

--- a/crates/sparq-mpc/src/oblivious.rs
+++ b/crates/sparq-mpc/src/oblivious.rs
@@ -371,6 +371,7 @@ fn waksman_rec(wires: &[usize], perm: &[usize], switches: &mut Vec<Switch>, bits
     let odd = m % 2 == 1;
     let top_len = m - half; // = ⌈m/2⌉
     let bot_len = half; // = ⌊m/2⌋
+
     // AS-Waksman: ⌊(m−1)/2⌋ output switches. On even m the LAST output pair
     // (m−2, m−1) is fixed (no switch), shaving one switch this level; on odd m all
     // `half` output switches are kept.


### PR DESCRIPTION
> 🤖 SPARQ agent — bead sq-hny9.

## What

Tighten the oblivious-shuffle permutation network (`crates/sparq-mpc/src/oblivious.rs`) from the plain Beneš/Waksman recursive form to the **AS-Waksman** (Beauquier–Darrot, "On arbitrary-size Waksman networks") redundancy-removal form.

- **Before:** `⌊m/2⌋` input + `⌊m/2⌋` output switches per recursion level.
- **After:** `⌊m/2⌋` input + `⌊(m−1)/2⌋` output switches per level — one fewer output switch on **even** `m`.

The saving comes from **fixing one output pair** on even levels: the last pair `(m−2, m−1)` is routed straight (output `m−2` from the TOP sub-network, `m−1` from the BOTTOM), so it carries no switch. This realizes the optimal arbitrary-size count `W(n) = W(⌈n/2⌉) + W(⌊n/2⌋) + (n−1)` (e.g. `n=8 → 17`, `n=16 → 49`, vs. the plain `20`/`56`).

## The odd-`m` corner case the bead flagged

The bead deferred this because naive fixed-pair pinning over-constrains routing for **odd** `m` (output 1 pinned BOTTOM clashes with the odd-trailing input pinned TOP). This PR avoids it by:

1. **Not** pinning any extra output pair on odd `m` — the odd-trailing output already carries no switch, so `⌊(m−1)/2⌋ = ⌊m/2⌋` and all output switches are kept.
2. On even `m`, seeding the fixed pair `out_from_top[m−2]=TOP, out_from_top[m−1]=BOTTOM` **into** the alternating-path solver before propagation, so the fixed pair is a *consequence* of a consistent routing rather than an axiom that over-constrains it.

## Honesty / scope

Perf-only. Obliviousness is **preserved and now explicitly tested**, not merely asserted:

- `waksman_has_full_support_after_optimization` — every one of the `n!` permutations is reachable (the anti-Benes-bias property) for `n = 1..=7`.
- `waksman_routes_every_permutation_correctly` — exhaustive correct routing extended to `n = 8`.
- `waksman_switch_count_is_as_waksman_optimal` — asserts the exact canonical AS-Waksman count for `n = 0..=64` (with literature spot-checks 4→5, 8→17, 16→49).

`ShuffleCost::depth_rounds` is an analytic model derived from `n`, unaffected. **No public API change** (G2 gate confirms).

## Gate

- `cargo build -p sparq-mpc` ✓
- `cargo clippy -p sparq-mpc --all-targets -- -D warnings` ✓ (default) and `--features insecure-test-rng` ✓
- `cargo test -p sparq-mpc` ✓ (332 passed) in **both** feature states
- `cargo fmt -p sparq-mpc --check` ✓
- privacy-claims gate (incl. predicate-form soundness self-test: 32 passed) ✓
- G2 public-api→SKILL.md gate: PASS (no public surface changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)