### PR TITLE
test(sparq-shacl): wire Node RDF-JS reference adapters into SHACL diff-fuzz (sq-vz2v) [OPUS-4.8]

### DIFF
--- a/.github/workflows/shacl-diff-fuzz.yml
+++ b/.github/workflows/shacl-diff-fuzz.yml
@@ -3,14 +3,17 @@
 # WHAT: generates random but VALID SHACL shapes + data graphs, validates each
 # through `sparq-shacl` AND through every reference SHACL engine that resolves, and
 # asserts the reports agree on the `sh:conforms` bit and the per-focus-node
-# violated-constraint set. Two references are wired:
+# violated-constraint set. Three reference families are wired:
 #   - pySHACL — the canonical Python reference implementation (sq-55c1).
 #   - Apache Jena SHACL — a second, independent reference (sq-evws), driven via the
 #     Java single-file source launcher over its `org.apache.jena.shacl` validator.
+#   - RDF-JS SHACL — the Zazuko `rdf-validate-shacl` + `shacl-engine` validators
+#     (sq-vz2v), driven via a Node adapter (one JS engine selected per run by
+#     SHACL_DIFF_NODE_ENGINE; both are exercised across two run passes below).
 # A disagreement is a candidate sparq-shacl correctness bug; the harness prints the
-# seed + the reproducing Turtle so it replays deterministically. A second engine
-# catches bugs where sparq and pySHACL happen to agree but are both wrong. See
-# crates/sparq-shacl/tests/diff_fuzz.rs.
+# seed + the reproducing Turtle so it replays deterministically. Each extra engine
+# catches bugs where sparq and another reference happen to agree but are both
+# wrong. See crates/sparq-shacl/tests/diff_fuzz.rs.
 #
 # TRIGGER — NIGHTLY/HEAVY tier ONLY. Deliberately NOT on pull_request / push /
 # merge_group: it installs reference engines and runs thousands of validations,
@@ -59,6 +62,22 @@ env:
   # bump both together (the .sha512 is alongside the tarball on the Apache archive).
   JENA_VERSION: "5.2.0"
   JENA_SHA512: "9a66044573ca269c0a9a1191fe7a8e1925f2d77e2e0bdadddd68616a1bafed1d9819c0b2988dd03614ec778a3882ccb091d825976fc0837406916f9f001b701c"
+  # JS / RDF-JS reference engines (sq-vz2v): the Zazuko SHACL validators + the
+  # RDF/JS factory pieces the Node adapter composes. Versions are pinned so the
+  # third reference family is reproducible and a future npm release cannot silently
+  # break (or silently "fix") the differential; bump deliberately. These are
+  # `npm i`-ed into a scratch dir and are NOT committed (AGENTS.md: reference
+  # engines stay out of git). `--ignore-scripts` since none need a build step.
+  NODE_SHACL_PACKAGES: >-
+    rdf-validate-shacl@0.5.5
+    shacl-engine@1.0.2
+    @rdfjs/environment@1.0.0
+    @rdfjs/data-model@2.0.2
+    @rdfjs/dataset@2.0.2
+    @rdfjs/term-map@2.0.1
+    @rdfjs/namespace@2.0.1
+    @rdfjs/parser-n3@2.0.2
+    clownface@2.0.3
 
 jobs:
   diff-fuzz:
@@ -85,6 +104,10 @@ jobs:
         with:
           distribution: temurin
           java-version: "21"
+      - name: Set up Node (for the RDF-JS reference engines)
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
       - name: Install pySHACL (reference engine) in a venv
         run: |
           set -euo pipefail
@@ -117,6 +140,19 @@ jobs:
           # The harness derives ${JENA_HOME}/lib/* when JENA_HOME is set.
           echo "JENA_HOME=$dest" >> "$GITHUB_ENV"
           "$dest/bin/shacl" --help >/dev/null 2>&1 && echo "Jena shacl CLI OK ($JENA_VERSION)"
+      - name: Install RDF-JS SHACL engines (reference engines) into a scratch dir
+        run: |
+          set -euo pipefail
+          dest="$RUNNER_TEMP/shacl-node-modules"
+          mkdir -p "$dest"
+          # A minimal package.json so `node`'s createRequire resolves from here.
+          echo '{"name":"shacl-diff-node-refs","private":true,"version":"0.0.0"}' > "$dest/package.json"
+          # Pinned, scripts disabled (none of these need a build step), no audit/fund noise.
+          (cd "$dest" && npm install --no-audit --no-fund --ignore-scripts ${NODE_SHACL_PACKAGES})
+          node -e "const r=require('node:module').createRequire('$dest/package.json'); \
+                   r('rdf-validate-shacl'); r('shacl-engine'); r('@rdfjs/parser-n3'); \
+                   console.log('RDF-JS SHACL engines OK');"
+          echo "SHACL_DIFF_NODE_MODULES=$dest" >> "$GITHUB_ENV"
       - name: Pick seed count for this trigger
         id: budget
         run: |
@@ -130,9 +166,23 @@ jobs:
       # fuzzing disagreement.
       - name: Build the differential test
         run: cargo build -p sparq-shacl --test diff_fuzz
-      - name: Run the differential fuzz (bounded; fails on any disagreement)
+      # First pass resolves pySHACL + Jena + the Node `rdf-validate-shacl` engine
+      # (SHACL_DIFF_NODE_ENGINE defaults to it), all over the same seed range.
+      - name: Run the differential fuzz — pySHACL + Jena + rdf-validate-shacl
         env:
           SHACL_DIFF_SEED_START: "0"
           SHACL_DIFF_COUNT: ${{ steps.budget.outputs.count }}
+          SHACL_DIFF_NODE_ENGINE: "rdf-validate-shacl"
+        run: |
+          cargo test -p sparq-shacl --test diff_fuzz -- --ignored --nocapture
+      # Second pass drives the OTHER Node JS engine (shacl-engine). The runner
+      # resolves one JS engine per run (selected by SHACL_DIFF_NODE_ENGINE), so a
+      # dedicated pass exercises shacl-engine too. pySHACL + Jena re-run here is
+      # cheap relative to the JS engine and keeps the lane a single job.
+      - name: Run the differential fuzz — shacl-engine (the other RDF-JS engine)
+        env:
+          SHACL_DIFF_SEED_START: "0"
+          SHACL_DIFF_COUNT: ${{ steps.budget.outputs.count }}
+          SHACL_DIFF_NODE_ENGINE: "shacl-engine"
         run: |
           cargo test -p sparq-shacl --test diff_fuzz -- --ignored --nocapture

--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -76,14 +76,20 @@ runner's comparison is engine-agnostic:
   launcher (`java -cp <jena-libs> JenaShaclAdapter.java`) so no compile step or
   committed jar is needed. A second independent reference catches bugs where sparq
   and pySHACL happen to agree but are both wrong.
+- **RDF-JS SHACL** (`tests/diff_fuzz/node_shacl_adapter.mjs`, bead sq-vz2v) — the
+  JS-ecosystem validators **Zazuko `rdf-validate-shacl`** and **`shacl-engine`**, a
+  Node "js-lib" adapter. The JS engine is selected by `SHACL_DIFF_NODE_ENGINE`
+  (default `rdf-validate-shacl`); the engines are `npm i`-ed into a scratch dir the
+  runner points at with `SHACL_DIFF_NODE_MODULES` (they are not committed deps). A
+  third independent engine family further hardens the cross-check.
 
-The differential runs against **every** reference engine that resolves. Other
-engines (rdf-validate-shacl / shacl-engine via Node) are tracked as follow-up
-beads and slot in as further adapters over the same contract.
+The differential runs against **every** reference engine that resolves; each is a
+drop-in adapter over the same contract.
 
 It is `#[ignore]`d (off the per-PR fast path) and runs as a **nightly** CI lane
-(`.github/workflows/shacl-diff-fuzz.yml`, which installs both pySHACL and a
-SHA-512-verified apache-jena tarball). Run it locally against either or both:
+(`.github/workflows/shacl-diff-fuzz.yml`, which installs pySHACL, a SHA-512-verified
+apache-jena tarball, and the pinned RDF-JS engines). Run it locally against any
+subset:
 
 ```sh
 # pySHACL:
@@ -93,11 +99,16 @@ SHACL_DIFF_PYTHON=/tmp/shacl-ref-venv/bin/python SHACL_DIFF_COUNT=2000 \
 # Jena (point at an unpacked apache-jena lib classpath, or set JENA_HOME):
 SHACL_DIFF_JENA_CP="/opt/apache-jena/lib/*" SHACL_DIFF_COUNT=2000 \
   cargo test -p sparq-shacl --test diff_fuzz -- --ignored --nocapture
+# RDF-JS (npm i rdf-validate-shacl / shacl-engine + the @rdfjs/* factory pieces
+# into a dir, then point the runner at it and pick the JS engine):
+SHACL_DIFF_NODE_MODULES=/tmp/shacl-node-refs SHACL_DIFF_NODE_ENGINE=rdf-validate-shacl \
+  SHACL_DIFF_COUNT=2000 cargo test -p sparq-shacl --test diff_fuzz -- --ignored --nocapture
 ```
 
 When no reference engine resolves, the test skips cleanly (so a fresh checkout
 stays green); each engine is gated independently, so Jena is silently skipped
-without a Java/Jena classpath and the pySHACL lane is unaffected. Fast,
+without a Java/Jena classpath, Node is skipped without `node` + a module dir, and
+the pySHACL lane is unaffected. Fast,
 reference-free self-tests (generator well-formedness + outcome mix,
 key-normalisation consistency, the engine-gating logic) DO run in the per-PR
 path.

--- a/crates/sparq-shacl/tests/diff_fuzz.rs
+++ b/crates/sparq-shacl/tests/diff_fuzz.rs
@@ -30,8 +30,17 @@
 //!     reference catches bugs where sparq and pySHACL happen to agree but are both
 //!     wrong.
 //!
-//! Other engines (rdf-validate-shacl / shacl-engine via Node) remain follow-up
-//! beads; each is another `RefEngine` over the same contract.
+//!   - **Node / RDF-JS** (`tests/diff_fuzz/node_shacl_adapter.mjs`, bead sq-vz2v)
+//!     — the JS-ecosystem SHACL validators (Zazuko `rdf-validate-shacl` and
+//!     `shacl-engine`), a NODE "js-lib" adapter (sq-eifd kind) driven via `node`.
+//!     The JS engine is selected by `SHACL_DIFF_NODE_ENGINE` (default
+//!     `rdf-validate-shacl`); the engines are `npm i`-ed into a scratch dir the
+//!     runner points at with `SHACL_DIFF_NODE_MODULES`. A third independent engine
+//!     family catches bugs where sparq and the Python/Java references agree but are
+//!     jointly wrong, and (bonus) the same harness can drive sparq's own
+//!     `@jeswr/sparq` WASM SHACL JS-vs-JS in a follow-up.
+//!
+//! Each reference is another `RefEngine` over the same contract.
 //!
 //! ## How to run
 //! Off by default (`#[ignore]`) so the per-PR `cargo nextest run` fast path is
@@ -45,12 +54,18 @@
 //! # tarball's `lib`), or set JENA_HOME (its `lib` is derived):
 //! SHACL_DIFF_JENA_CP="/opt/apache-jena/lib/*" \
 //!   cargo test -p sparq-shacl --test diff_fuzz -- --ignored --nocapture
+//! # Node: point at a dir where `rdf-validate-shacl` / `shacl-engine` + the RDF/JS
+//! # factory pieces were `npm i`-ed, and pick which JS engine to drive:
+//! SHACL_DIFF_NODE_MODULES=/path/to/scratch SHACL_DIFF_NODE_ENGINE=rdf-validate-shacl \
+//!   cargo test -p sparq-shacl --test diff_fuzz -- --ignored --nocapture
 //! # bound the run: SHACL_DIFF_SEED_START / SHACL_DIFF_COUNT (defaults 0 / 200).
 //! ```
 //! When NO reference engine resolves, the test SKIPS (prints why and returns) so
 //! it stays green on a box without any reference toolchain. Each engine is gated
 //! independently — Jena is silently skipped when neither a Jena classpath nor a
-//! working `java` is available, so the existing pySHACL-only lane is unaffected.
+//! working `java` is available, and Node is silently skipped when `node` or a
+//! module dir with the JS engines is unavailable, so the existing pySHACL-only
+//! lane is unaffected.
 //!
 //! ## Comparison policy (per bead sq-55c1)
 //! 1. `conforms` bit — exact (cheap, highest signal).
@@ -97,6 +112,10 @@ struct RefEngine {
     name: String,
     program: String,
     args: Vec<String>,
+    /// Extra environment variables to set on the spawned adapter (e.g. the Node
+    /// adapter's `SHACL_DIFF_NODE_ENGINE` / `SHACL_DIFF_NODE_MODULES`). Empty for
+    /// engines that take all their config via args (pySHACL / Jena).
+    env: Vec<(String, String)>,
 }
 
 fn adapter_dir() -> std::path::PathBuf {
@@ -125,6 +144,7 @@ fn resolve_pyshacl() -> Option<RefEngine> {
                 name: format!("pySHACL via {py}"),
                 program: py,
                 args: vec![adapter.to_string_lossy().into_owned()],
+                env: vec![],
             });
         }
     }
@@ -185,13 +205,69 @@ fn resolve_jena() -> Option<RefEngine> {
             classpath,
             adapter.to_string_lossy().into_owned(),
         ],
+        env: vec![],
+    })
+}
+
+/// Pure selection of the Node JS engine name (env passed in, so it is
+/// unit-testable without mutating process-global env). A blank or absent
+/// `SHACL_DIFF_NODE_ENGINE` defaults to `rdf-validate-shacl`; only the two wired
+/// engine names are accepted (anything else returns `None`, so a typo SKIPS Node
+/// rather than spawning an adapter that errors on every case). The returned name
+/// is the value passed straight through to the adapter's `SHACL_DIFF_NODE_ENGINE`.
+fn node_engine_name(engine_env: Option<String>) -> Option<&'static str> {
+    match engine_env.as_deref().filter(|s| !s.is_empty()) {
+        None | Some("rdf-validate-shacl") => Some("rdf-validate-shacl"),
+        Some("shacl-engine") => Some("shacl-engine"),
+        Some(_) => None,
+    }
+}
+
+/// Resolves the Node / RDF-JS SHACL engine, or `None` if it cannot be driven (so
+/// it is SKIPPED cleanly — the pySHACL/Jena lanes are unaffected). Needs:
+///   - a `node` launcher: `SHACL_DIFF_NODE` else `node` on PATH (must run), and
+///   - a modules dir with the JS engines `npm i`-ed: `SHACL_DIFF_NODE_MODULES`.
+///     We require this rather than guessing, because without the engines the
+///     adapter would error on every case (a vacuous run); demanding the env var
+///     means an unconfigured box SKIPS instead of looking like agreement.
+///   - a wired JS engine name (`SHACL_DIFF_NODE_ENGINE`, default
+///     `rdf-validate-shacl`); an unknown name SKIPS.
+///
+/// The selected JS engine is passed to the adapter via the child's
+/// `SHACL_DIFF_NODE_ENGINE` env (set on the spawn in `run_reference`), and the
+/// modules dir via `SHACL_DIFF_NODE_MODULES`.
+fn resolve_node() -> Option<RefEngine> {
+    let modules = std::env::var("SHACL_DIFF_NODE_MODULES")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    let engine = node_engine_name(std::env::var("SHACL_DIFF_NODE_ENGINE").ok())?;
+    let node = std::env::var("SHACL_DIFF_NODE").unwrap_or_else(|_| "node".to_string());
+    let node_ok = Command::new(&node)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !node_ok {
+        return None;
+    }
+    let adapter = adapter_dir().join("node_shacl_adapter.mjs");
+    Some(RefEngine {
+        name: format!("Node {engine} via {node} (modules {modules})"),
+        program: node,
+        args: vec![adapter.to_string_lossy().into_owned()],
+        env: vec![
+            ("SHACL_DIFF_NODE_ENGINE".to_string(), engine.to_string()),
+            ("SHACL_DIFF_NODE_MODULES".to_string(), modules),
+        ],
     })
 }
 
 /// All reference engines available on this box, in a stable order. The
 /// differential runs against each; an empty list means SKIP the whole test.
 fn resolve_engines() -> Vec<RefEngine> {
-    [resolve_pyshacl(), resolve_jena()]
+    [resolve_pyshacl(), resolve_jena(), resolve_node()]
         .into_iter()
         .flatten()
         .collect()
@@ -204,6 +280,7 @@ fn run_reference(engine: &RefEngine, data: &str, shapes: &str) -> Result<RefRepo
     let req = serde_json::json!({ "data": data, "shapes": shapes }).to_string();
     let mut child = Command::new(&engine.program)
         .args(&engine.args)
+        .envs(engine.env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -745,6 +822,67 @@ fn jena_adapter_excludes_nested_sh_detail() {
     assert!(
         out.status.success(),
         "Jena adapter --selftest failed (exit {:?}) — the sh:detail exclusion \
+         regressed (nested sub-result leaked into the top-level violation set):\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr).trim()
+    );
+}
+
+/// [OPUS-4.8] (sq-vz2v) Node JS-engine selection: blank/absent defaults to
+/// `rdf-validate-shacl`; `shacl-engine` is accepted; any unknown name returns
+/// `None` so a typo SKIPS Node rather than spawning an always-erroring adapter.
+/// Pure (env passed in) so it runs in the fast lane without mutating process env.
+#[test]
+fn node_engine_name_selection() {
+    assert_eq!(node_engine_name(None), Some("rdf-validate-shacl"));
+    assert_eq!(
+        node_engine_name(Some(String::new())),
+        Some("rdf-validate-shacl")
+    );
+    assert_eq!(
+        node_engine_name(Some("rdf-validate-shacl".into())),
+        Some("rdf-validate-shacl")
+    );
+    assert_eq!(
+        node_engine_name(Some("shacl-engine".into())),
+        Some("shacl-engine")
+    );
+    assert_eq!(node_engine_name(Some("not-an-engine".into())), None);
+}
+
+/// [OPUS-4.8] (sq-vz2v) The Node adapter must mirror the pySHACL/Jena adapters'
+/// sq-0hj7 `sh:detail` exclusion: a nested sub-result that is the object of an
+/// `sh:detail` must NOT appear as a top-level violation. The adapter ships a
+/// `--selftest` mode asserting this on a synthetic report dataset (no engine /
+/// npm dep, so it is independent of whether an engine build emits `sh:detail`);
+/// we drive it here. SKIPPED cleanly when `node` is unavailable (the no-Node lane
+/// is unaffected), and it needs NO `SHACL_DIFF_NODE_MODULES` (the self-test runs
+/// the adapter's pure normaliser, not a validator).
+#[test]
+fn node_adapter_excludes_nested_sh_detail() {
+    let node = std::env::var("SHACL_DIFF_NODE").unwrap_or_else(|_| "node".to_string());
+    let node_ok = Command::new(&node)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !node_ok {
+        eprintln!("SKIP node_adapter_excludes_nested_sh_detail: `node` did not resolve");
+        return;
+    }
+    let adapter = adapter_dir().join("node_shacl_adapter.mjs");
+    let out = Command::new(&node)
+        .arg(&adapter)
+        .arg("--selftest")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn Node adapter --selftest");
+    assert!(
+        out.status.success(),
+        "Node adapter --selftest failed (exit {:?}) — the sh:detail exclusion \
          regressed (nested sub-result leaked into the top-level violation set):\n{}",
         out.status.code(),
         String::from_utf8_lossy(&out.stderr).trim()

--- a/crates/sparq-shacl/tests/diff_fuzz/node_shacl_adapter.mjs
+++ b/crates/sparq-shacl/tests/diff_fuzz/node_shacl_adapter.mjs
@@ -1,0 +1,292 @@
+// [OPUS-4.8] sq-vz2v: Node / RDF-JS reference-engine adapter for the SHACL
+// differential fuzzer (crates/sparq-shacl/tests/diff_fuzz.rs).
+//
+// A third class of reference alongside pySHACL (sq-55c1) and Apache Jena
+// (sq-evws): the JS / RDF-JS ecosystem SHACL engines, as a NODE "js-lib" adapter
+// (bead sq-eifd's js-lib KIND). It is the SAME "report-cli" contract — JSON
+// request in, normalised JSON report out — so the Rust runner's comparison stays
+// engine-agnostic (resolve_pyshacl / resolve_jena / resolve_node all yield the
+// same RefEngine). Two engines are wired, selected by SHACL_DIFF_NODE_ENGINE:
+//   - Zazuko `rdf-validate-shacl`   (engine=rdf-validate-shacl)  [default]
+//   - Zazuko `shacl-engine`         (engine=shacl-engine)
+// Both are MIT and the de-facto JS SHACL validators; a third independent family
+// catches bugs where sparq and the Python/Java references happen to agree but are
+// jointly wrong.
+//
+// CONTRACT (stdin -> stdout) — identical to tests/diff_fuzz/pyshacl_adapter.py
+// and JenaShaclAdapter.java:
+//   stdin  : a JSON object {"data": "<turtle>", "shapes": "<turtle>"}
+//   stdout : {"conforms": bool,
+//             "violations": [{"focus": str|null, "component": str|null,
+//                             "path": str|null}, ...]}
+//            — `focus`/`component` are full IRIs (or "_:bnode" for blank nodes,
+//            which have no cross-graph identity); `path` is the bare predicate IRI
+//            for a simple path, the "_:path" sentinel for any complex/blank-rooted
+//            path, or null when the result carries no path. Exactly the shape the
+//            Rust runner's RefReport deserialises and `ref_keys` normalises.
+//   exit   : 0 on a produced report (even non-conforming); non-zero only on an
+//            adapter/engine ERROR (so the runner distinguishes "engine says X"
+//            from "engine could not run"), with a diagnostic on stderr.
+//
+// We read the report from the report DATASET (the RDF/JS graph), NOT from the
+// engine's structured `report.results` JS objects, so the normalisation is the
+// IDENTICAL reduction the pySHACL and Jena adapters perform over the report graph
+// (collect sh:ValidationResult subjects; read sh:focusNode / sh:resultPath /
+// sh:sourceConstraintComponent; EXCLUDE any result that is the object of an
+// sh:detail — sh:detail is non-normative, SHACL §3.6.2, and sparq keeps nested
+// sub-results off the comparable top-level set).
+//
+// Reads ONE request and emits ONE report (one Node process per case, mirroring the
+// pySHACL/Jena adapters' per-case isolation).
+//
+// The JS engines are NOT a committed dependency (AGENTS.md: reference engines stay
+// out of git). The CI lane `npm i`s them into a scratch dir and points the runner
+// at it via SHACL_DIFF_NODE_MODULES. When neither resolves, the Rust runner SKIPS
+// the Node engine cleanly.
+
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { Readable } from 'node:stream';
+
+const SH = 'http://www.w3.org/ns/shacl#';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+// Resolve the gather-only JS engines + RDF/JS factory pieces from a modules dir
+// (SHACL_DIFF_NODE_MODULES) or cwd. Mirrors the bench adapter's importer so both
+// find the same `npm i`-installed engines.
+function makeImporter(modulesDir) {
+  const base = modulesDir
+    ? pathToFileURL(modulesDir.replace(/\/?$/, '/') + 'package.json')
+    : pathToFileURL(process.cwd() + '/package.json');
+  const req = createRequire(base);
+  return { require: (id) => req(id) };
+}
+
+// Build the RDF/JS environment rdf-validate-shacl / shacl-engine consume
+// (data-model + dataset + term-map + namespace + clownface), composed through
+// @rdfjs/environment — exactly how @zazuko/env builds its env, without taking the
+// heavier bundle as a dependency. `.default` unwraps transpiled-ESM CJS entries.
+function makeFactory(imp) {
+  const Environment = imp.require('@rdfjs/environment').default || imp.require('@rdfjs/environment');
+  const def = (id, sub) => {
+    const m = imp.require(sub ? `${id}/${sub}` : id);
+    return m.default || m;
+  };
+  const DataFactory = def('@rdfjs/data-model', 'Factory.js');
+  const DatasetFactory = def('@rdfjs/dataset', 'Factory.js');
+  const TermMapFactory = def('@rdfjs/term-map', 'Factory.js');
+  const NamespaceFactory = def('@rdfjs/namespace', 'Factory.js');
+  const ClownfaceFactory = def('clownface', 'Factory.js');
+  return new Environment([
+    DataFactory, DatasetFactory, TermMapFactory, NamespaceFactory, ClownfaceFactory,
+  ]);
+}
+
+async function parseTurtleToDataset(imp, factory, text, baseIRI) {
+  const ParserN3mod = imp.require('@rdfjs/parser-n3');
+  const ParserN3 = ParserN3mod.default || ParserN3mod;
+  const parser = new ParserN3({ factory, baseIRI });
+  const stream = parser.import(Readable.from([text]));
+  const ds = factory.dataset();
+  for await (const quad of stream) ds.add(quad);
+  return ds;
+}
+
+// Engine adapters: each returns the report's RDF/JS dataset (the report GRAPH),
+// which we then normalise the same way as the Python/Java references.
+async function runRdfValidateShacl(imp, factory, dataDs, shapesDs) {
+  const SHACLValidator = imp.require('rdf-validate-shacl').default || imp.require('rdf-validate-shacl');
+  const validator = new SHACLValidator(shapesDs, { factory });
+  const report = await validator.validate(dataDs);
+  return { conforms: report.conforms, dataset: report.dataset };
+}
+
+async function runShaclEngine(imp, factory, dataDs, shapesDs) {
+  const mod = imp.require('shacl-engine');
+  const Validator = mod.Validator || mod.default;
+  const validator = new Validator(shapesDs, { factory });
+  const report = await validator.validate({ dataset: dataDs });
+  return { conforms: report.conforms, dataset: report.dataset || null };
+}
+
+const ENGINES = {
+  'rdf-validate-shacl': runRdfValidateShacl,
+  'shacl-engine': runShaclEngine,
+};
+
+// A graph-independent term key: blank nodes collapse to '_:bnode' (no stable
+// cross-graph identity — the same tolerance the Python/Java references and the
+// Rust runner's norm_term use); named nodes render to the bare IRI.
+function termKey(term) {
+  if (!term) return null;
+  if (term.termType === 'BlankNode') return '_:bnode';
+  if (term.termType === 'NamedNode') return term.value;
+  if (term.termType === 'Literal') return `"${term.value}"`;
+  return String(term.value);
+}
+
+// An sh:resultPath rendered as a comparable string: a simple predicate path is a
+// NamedNode and renders to the bare IRI (the same string sparq emits for
+// Path::Predicate); any complex / blank-rooted path renders to the "_:path"
+// sentinel — we do NOT byte-match the impl-specific Turtle serialisation, the
+// (focus, component) pair + path-presence carry the signal. Null when absent.
+function pathKey(term) {
+  if (!term) return null;
+  if (term.termType === 'NamedNode') return term.value;
+  return '_:path';
+}
+
+// Identity key preserving blank-node distinctness (NOT the comparison-tolerant
+// "_:bnode" collapse): used only to test result-node membership against the
+// sh:detail object set, so distinct blank nodes don't all collide.
+function nodeId(term) {
+  return term.termType === 'BlankNode' ? `bnode:${term.value}` : `iri:${term.value}`;
+}
+
+// Reduce the report GRAPH to the normalised violation set. Reads the same way as
+// pyshacl_adapter.run / JenaShaclAdapter.normaliseGraph:
+//   - subjects of (?s rdf:type sh:ValidationResult) are the results;
+//   - EXCLUDE any result that is the object of an sh:detail (nested sub-result of
+//     an sh:node / logical component — non-normative, kept off sparq's top-level
+//     set), so we never diff two engines' OPTIONAL detail policies;
+//   - per top-level result read sh:focusNode / sh:sourceConstraintComponent /
+//     sh:resultPath.
+function normaliseReport(dataset, conforms) {
+  // First pass: index by subject + collect nested (sh:detail object) node ids.
+  const bySubject = new Map(); // nodeId -> { focus, comp, path, isResult }
+  const nested = new Set();
+  for (const q of dataset) {
+    const sid = nodeId(q.subject);
+    let rec = bySubject.get(sid);
+    if (!rec) {
+      rec = { focus: null, comp: null, path: null, isResult: false };
+      bySubject.set(sid, rec);
+    }
+    const p = q.predicate.value;
+    if (p === RDF_TYPE && q.object.value === SH + 'ValidationResult') rec.isResult = true;
+    else if (p === SH + 'focusNode') rec.focus = q.object;
+    else if (p === SH + 'sourceConstraintComponent') rec.comp = q.object;
+    else if (p === SH + 'resultPath') rec.path = q.object;
+    else if (p === SH + 'detail') nested.add(nodeId(q.object));
+  }
+  const violations = [];
+  for (const [sid, rec] of bySubject) {
+    if (!rec.isResult) continue;
+    if (nested.has(sid)) continue; // nested sub-result — excluded.
+    violations.push({
+      focus: termKey(rec.focus),
+      component: termKey(rec.comp),
+      path: pathKey(rec.path),
+    });
+  }
+  return { conforms: Boolean(conforms), violations };
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const c of process.stdin) chunks.push(c);
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+async function main() {
+  const engineName = process.env.SHACL_DIFF_NODE_ENGINE || 'rdf-validate-shacl';
+  const runner = ENGINES[engineName];
+  if (!runner) {
+    process.stderr.write(
+      `node_shacl_adapter: unknown engine '${engineName}' (have: ${Object.keys(ENGINES).join(', ')})\n`,
+    );
+    process.exit(2);
+  }
+
+  let req;
+  try {
+    req = JSON.parse(await readStdin());
+  } catch (e) {
+    process.stderr.write(`node_shacl_adapter: bad request JSON: ${e}\n`);
+    process.exit(2);
+  }
+
+  const imp = makeImporter(process.env.SHACL_DIFF_NODE_MODULES);
+  let factory;
+  try {
+    factory = makeFactory(imp);
+  } catch (e) {
+    process.stderr.write(
+      `node_shacl_adapter: cannot load RDF/JS factory (npm i in SHACL_DIFF_NODE_MODULES?): ${e}\n`,
+    );
+    process.exit(1);
+  }
+
+  let out;
+  try {
+    const dataDs = await parseTurtleToDataset(imp, factory, req.data, 'http://ex/');
+    const shapesDs = await parseTurtleToDataset(imp, factory, req.shapes, 'http://ex/');
+    const { conforms, dataset } = await runner(imp, factory, dataDs, shapesDs);
+    out = dataset
+      ? normaliseReport(dataset, conforms)
+      : { conforms: Boolean(conforms), violations: [] };
+  } catch (e) {
+    process.stderr.write(
+      `node_shacl_adapter: engine error (${engineName}): ${e && e.stack ? e.stack : e}\n`,
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write(JSON.stringify(out) + '\n');
+}
+
+// [OPUS-4.8] Self-test mode (`--selftest`): exercise the sh:detail exclusion on a
+// synthetic report dataset (no engine / npm dep needed), mirroring the Jena
+// adapter's --selftest. Proves a nested sub-result that is the object of an
+// sh:detail is dropped from the top-level violation set, independent of whether an
+// engine build emits sh:detail. The Rust runner drives this in the fast lane when
+// `node` resolves. Exit 0 on pass, non-zero with a diagnostic on fail.
+function selfTest() {
+  // Minimal in-memory dataset over plain term objects so the self-test needs no
+  // npm dependency. It is iterable (the normaliser only iterates and reads
+  // predicate/object .value), with terms exposing { termType, value }.
+  const nn = (v) => ({ termType: 'NamedNode', value: v });
+  const bn = (v) => ({ termType: 'BlankNode', value: v });
+  const top = bn('top');
+  const inner = bn('inner');
+  const quads = [
+    [top, nn(RDF_TYPE), nn(SH + 'ValidationResult')],
+    [top, nn(SH + 'focusNode'), nn('http://ex/focus')],
+    [top, nn(SH + 'sourceConstraintComponent'), nn(SH + 'NodeConstraintComponent')],
+    [top, nn(SH + 'resultPath'), nn('http://ex/p')],
+    [top, nn(SH + 'detail'), inner],
+    [inner, nn(RDF_TYPE), nn(SH + 'ValidationResult')],
+    [inner, nn(SH + 'focusNode'), nn('http://ex/value')],
+    [inner, nn(SH + 'sourceConstraintComponent'), nn(SH + 'MinLengthConstraintComponent')],
+  ].map(([subject, predicate, object]) => ({ subject, predicate, object }));
+  const dataset = quads; // an Array is iterable, which is all normaliseReport needs.
+  const got = normaliseReport(dataset, false);
+  const want = {
+    conforms: false,
+    violations: [
+      {
+        focus: 'http://ex/focus',
+        component: SH + 'NodeConstraintComponent',
+        path: 'http://ex/p',
+      },
+    ],
+  };
+  const gotJson = JSON.stringify(got);
+  const wantJson = JSON.stringify(want);
+  if (gotJson !== wantJson) {
+    process.stderr.write('node_shacl_adapter selftest FAIL: sh:detail exclusion\n');
+    process.stderr.write(`  want: ${wantJson}\n`);
+    process.stderr.write(`  got:  ${gotJson}\n`);
+    return false;
+  }
+  return true;
+}
+
+if (process.argv.includes('--selftest')) {
+  process.exit(selfTest() ? 0 : 3);
+} else {
+  main().catch((e) => {
+    process.stderr.write(`node_shacl_adapter: fatal: ${e && e.stack ? e.stack : e}\n`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-vz2v** (follow-up to sq-55c1 / sq-evws). Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).

## What

Adds a **third reference-engine family** to the differential SHACL fuzzer
(`crates/sparq-shacl/tests/diff_fuzz.rs`): the JS / RDF-JS validators **Zazuko
`rdf-validate-shacl`** and **`shacl-engine`** (MIT), wired as a Node "js-lib"
adapter (bead sq-eifd kind). Previously only pySHACL (sq-55c1) and Apache Jena
(sq-evws) were wired; the bead asked for the Node references over the same
contract.

## How

- **`tests/diff_fuzz/node_shacl_adapter.mjs`** (new): reads the SAME
  `{data, shapes}` JSON request on stdin, parses to an RDF/JS dataset (the
  `@rdfjs/*` factory composed via `@rdfjs/environment`, same as the existing bench
  adapter), runs the selected JS validator, and emits the SAME normalised
  `{conforms, violations:[{focus, component, path}]}` JSON the pySHACL/Jena adapters
  emit. The reduction runs over the report **graph** (collect
  `sh:ValidationResult` subjects; **exclude** nested `sh:detail` sub-results,
  matching the sq-0hj7 policy) — identical to the Python/Java references, not the
  engines' structured JS objects. Ships a dependency-free `--selftest` proving the
  `sh:detail` exclusion, mirroring `JenaShaclAdapter --selftest`.
- **`diff_fuzz.rs`**: the engine-agnostic runner gains `resolve_node` + a
  `RefEngine.env` field so the adapter's `SHACL_DIFF_NODE_ENGINE` /
  `SHACL_DIFF_NODE_MODULES` are set on the spawn. The JS engine is selected by
  `SHACL_DIFF_NODE_ENGINE` (default `rdf-validate-shacl`). Node resolves **only**
  when `node` runs AND `SHACL_DIFF_NODE_MODULES` is set — no module dir ⇒ SKIP, so
  an unconfigured box never produces a vacuous all-erroring run. New fast-lane
  tests: `node_engine_name_selection` (pure) and
  `node_adapter_excludes_nested_sh_detail` (drives the adapter `--selftest`).
- **`.github/workflows/shacl-diff-fuzz.yml`**: set up Node, `npm i` the pinned
  RDF-JS engines into a scratch dir, and run two extra passes
  (`rdf-validate-shacl` + `shacl-engine`) behind the engine switch. The existing
  pySHACL + Jena lanes are unaffected.
- **README**: documents the third reference family + local-run recipe.

## Honesty / scope

This is a **test-harness + CI** change only — no `sparq-shacl` public API changed,
so the G2 SKILL.md rule does not apply. The "bonus" of driving sparq's own
`@jeswr/sparq` WASM SHACL JS-vs-JS is left as a follow-up to keep this PR minimal;
the harness is structured so it slots in as another engine.

## Verification (local)

- Installed the pinned engines into a scratch dir and ran the differential:
  **60/60 seed agreement** against `rdf-validate-shacl` and **60/60** against
  `shacl-engine`.
- Fast-lane self-tests pass (`cargo test -p sparq-shacl --test diff_fuzz`, 10
  passed / 1 ignored).
- `cargo build` + `cargo clippy --all-targets -- -D warnings` + tests green in
  **both** feature states (default + `shacl-af`); `rustfmt --check` clean on the
  edited file; `scripts/check-privacy-claims.sh` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)