### PR TITLE
feat(site): /try REPL full SPARQL surface (CONSTRUCT/UPDATE/EXPLAIN) + tier-a /surface/sparql (sq-vfbm)

### DIFF
--- a/site/src/app/surface/sparql/page.tsx
+++ b/site/src/app/surface/sparql/page.tsx
@@ -65,8 +65,18 @@ export default function SparqlSurfacePage() {
           <p>
             <strong className="text-foreground">Live in your browser tab.</strong>{" "}
             The lean wasm bundle carries the parser, triplestore and SPARQL engine.
-            The live REPL on this site runs your queries against the sample graph
-            with no network round-trip.
+            The live REPL runs your queries against the sample graph with no network
+            round-trip — SELECT and ASK render a table / boolean, CONSTRUCT and
+            DESCRIBE render the constructed N-Triples, and SPARQL Update
+            (INSERT / DELETE) mutates the in-tab store.
+          </p>
+          <p>
+            The same REPL has an{" "}
+            <code className="font-mono text-foreground">EXPLAIN</code> /{" "}
+            <code className="font-mono text-foreground">EXPLAIN ANALYZE</code> mode:
+            EXPLAIN shows the planner&apos;s join order and cardinality estimates
+            without executing, ANALYZE also runs the query and appends a per-operator
+            row-count trace.
           </p>
         </>
       }
@@ -76,8 +86,10 @@ export default function SparqlSurfacePage() {
             REGEX / REPLACE are compiled out of the lean wasm bundle to keep it
             small; they are available in the native build. The query-budget
             deadline (wall-clock timeout) is native-only — the wasm bundle enforces
-            a row cap instead. <code className="font-mono">EXPLAIN</code> exists in
-            the engine but is not yet a wasm export.
+            a row cap instead. In the wasm build,{" "}
+            <code className="font-mono">EXPLAIN ANALYZE</code> reports exact
+            per-operator row counts but zero wall-times (no monotonic clock under
+            wasm32).
           </p>
         </>
       }

--- a/site/src/app/try/page.tsx
+++ b/site/src/app/try/page.tsx
@@ -17,9 +17,11 @@ export default function TryPage() {
           The shared engine component. Edit the query, pick an example, and run —
           every query executes against the sample graph using the real sparq Rust
           engine compiled to WebAssembly. The lean bundle ships the parser,
-          triplestore and SPARQL 1.1 engine (SELECT / ASK with BGP, FILTER,
-          OPTIONAL, UNION, MINUS, BIND, VALUES, aggregates, property paths,
-          sub-SELECT and RDF-star).
+          triplestore and SPARQL 1.1/1.2 engine: SELECT / ASK / CONSTRUCT / DESCRIBE
+          and SPARQL Update (INSERT / DELETE, mutating the in-tab store), over BGP,
+          FILTER, OPTIONAL, UNION, MINUS, BIND, VALUES, aggregates, property paths,
+          sub-SELECT and RDF-star. Switch to the EXPLAIN / ANALYZE mode to inspect
+          the query plan.
         </p>
       </header>
       <Repl />

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -23,6 +23,7 @@ import {
   type SparqlResults,
   type WasmStore,
 } from "@/lib/sparq-wasm";
+import { classifyQueryForm, isGraphForm } from "@/lib/repl-dataset";
 import { EXAMPLE_QUERIES, BUILTIN_DATASETS } from "@/data/sample-graph";
 import {
   DatasetControls,
@@ -30,12 +31,23 @@ import {
   type ActiveDataset,
 } from "@/components/repl-datasets";
 
+// [OPUS-4.8] sq-vfbm — the REPL now dispatches across the whole lean-bundle query
+// surface, so the result state carries one variant per shape of answer: a solution
+// table (SELECT), a boolean (ASK), a constructed N-Triples graph (CONSTRUCT/DESCRIBE),
+// an Update acknowledgement (mutated the in-tab store), and the EXPLAIN plan text.
 type RunState =
   | { kind: "idle" }
   | { kind: "running" }
   | { kind: "select"; results: SparqlResults; ms: number }
   | { kind: "boolean"; value: boolean; ms: number }
+  | { kind: "graph"; ntriples: string; triples: number; ms: number }
+  | { kind: "update"; sizeBefore: number; sizeAfter: number; ms: number }
+  | { kind: "explain"; plan: string; analyze: boolean; ms: number }
   | { kind: "error"; message: string };
+
+// Run mode: execute the query, or render the planner's EXPLAIN / EXPLAIN ANALYZE
+// plan without (EXPLAIN) or with (ANALYZE) executing it.
+type RunMode = "run" | "explain" | "analyze";
 
 // [OPUS-4.8] Engine warm-up lifecycle, surfaced as a subtle indicator. The wasm fetch +
 // instantiate is kicked off on mount (prewarmSparq) so the first "Run query" is instant.
@@ -45,6 +57,7 @@ const DEFAULT_DATASET = BUILTIN_DATASETS[0];
 
 export function Repl() {
   const [sparql, setSparql] = React.useState(EXAMPLE_QUERIES[0].sparql);
+  const [mode, setMode] = React.useState<RunMode>("run");
   const [state, setState] = React.useState<RunState>({ kind: "idle" });
   const [size, setSize] = React.useState<number | null>(null);
   const [engine, setEngine] = React.useState<EngineState>("cold");
@@ -114,10 +127,47 @@ export function Repl() {
     return store;
   }, [buildStore]);
 
+  // [OPUS-4.8] sq-vfbm — dispatch across the whole lean-bundle query surface. EXPLAIN /
+  // ANALYZE modes render the planner's plan text (every form for EXPLAIN; SELECT/ASK for
+  // ANALYZE). Otherwise we classify the SPARQL form and route to the matching wasm export:
+  // SELECT/ASK -> query (JSON), CONSTRUCT/DESCRIBE -> queryQuads (N-Triples), and an Update
+  // keyword -> updateInPlace (mutates the in-tab store; we re-count the dataset after).
   const run = React.useCallback(async () => {
     try {
       const store = await ensureStore();
+      const form = classifyQueryForm(sparql);
       setState({ kind: "running" });
+
+      if (mode === "explain" || mode === "analyze") {
+        const analyze = mode === "analyze";
+        const t0 = performance.now();
+        const plan = analyze ? store.explainAnalyze(sparql) : store.explain(sparql);
+        const ms = performance.now() - t0;
+        setState({ kind: "explain", plan, analyze, ms });
+        return;
+      }
+
+      if (form === "update") {
+        const sizeBefore = datasetSize(store);
+        const t0 = performance.now();
+        store.updateInPlace(sparql);
+        const ms = performance.now() - t0;
+        const sizeAfter = datasetSize(store);
+        setSize(sizeAfter);
+        setState({ kind: "update", sizeBefore, sizeAfter, ms });
+        return;
+      }
+
+      if (isGraphForm(form)) {
+        const t0 = performance.now();
+        const ntriples = store.queryQuads(sparql);
+        const ms = performance.now() - t0;
+        const trimmed = ntriples.trim();
+        const triples = trimmed === "" ? 0 : trimmed.split("\n").length;
+        setState({ kind: "graph", ntriples: trimmed, triples, ms });
+        return;
+      }
+
       const t0 = performance.now();
       const json = store.query(sparql);
       const ms = performance.now() - t0;
@@ -130,9 +180,11 @@ export function Repl() {
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       setState({ kind: "error", message });
-      toast.error("Query failed", { description: message });
+      toast.error(mode === "run" ? "Query failed" : "EXPLAIN failed", {
+        description: message,
+      });
     }
-  }, [ensureStore, sparql]);
+  }, [ensureStore, sparql, mode]);
 
   // Switch to a built-in dataset: reload the store, reset the count + active descriptor.
   const selectBuiltin = React.useCallback(
@@ -261,20 +313,30 @@ export function Repl() {
           className="w-full resize-y rounded-lg border bg-muted/40 p-3 font-mono text-[13px] leading-relaxed outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
         />
 
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
           <Button onClick={run} disabled={busy}>
             {busy ? (
               <Loader2 className="size-4 animate-spin" />
             ) : (
               <Play className="size-4" />
             )}
-            Run query
+            {mode === "run" ? "Run query" : "Run EXPLAIN"}
           </Button>
+          <ModeTabs mode={mode} onChange={setMode} disabled={busy} />
           <p aria-live="polite" className="text-xs text-muted-foreground">
             {state.kind === "select" &&
               `${state.results.results.bindings.length} rows · ${state.ms.toFixed(1)} ms`}
             {state.kind === "boolean" && `${state.ms.toFixed(1)} ms`}
-            {state.kind === "running" && "Running on the wasm engine…"}
+            {state.kind === "graph" &&
+              `${state.triples} triples · ${state.ms.toFixed(1)} ms`}
+            {state.kind === "update" &&
+              `store ${state.sizeBefore} → ${state.sizeAfter} triples · ${state.ms.toFixed(1)} ms`}
+            {state.kind === "explain" &&
+              `plan ${state.analyze ? "+ trace " : ""}· ${state.ms.toFixed(1)} ms`}
+            {state.kind === "running" &&
+              (mode === "run"
+                ? "Running on the wasm engine…"
+                : "Planning on the wasm engine…")}
             {state.kind === "idle" &&
               engine === "warming" &&
               "Pre-warming the wasm engine…"}
@@ -318,6 +380,59 @@ function EngineIndicator({ engine }: { engine: EngineState }) {
   );
 }
 
+// [OPUS-4.8] sq-vfbm — Run / EXPLAIN / EXPLAIN ANALYZE selector. EXPLAIN is a
+// planning-only dry run (every query form); ANALYZE also executes (SELECT/ASK).
+function ModeTabs({
+  mode,
+  onChange,
+  disabled,
+}: {
+  mode: RunMode;
+  onChange: (m: RunMode) => void;
+  disabled: boolean;
+}) {
+  const tabs: { value: RunMode; label: string; title: string }[] = [
+    { value: "run", label: "Run", title: "Execute the query / update" },
+    {
+      value: "explain",
+      label: "EXPLAIN",
+      title: "Show the query plan without executing it",
+    },
+    {
+      value: "analyze",
+      label: "ANALYZE",
+      title: "Show the plan and execute it with a per-operator trace (SELECT/ASK)",
+    },
+  ];
+  return (
+    <div
+      role="tablist"
+      aria-label="Run mode"
+      className="inline-flex rounded-lg border bg-muted/40 p-0.5"
+    >
+      {tabs.map((t) => (
+        <button
+          key={t.value}
+          type="button"
+          role="tab"
+          aria-selected={mode === t.value}
+          title={t.title}
+          disabled={disabled}
+          onClick={() => onChange(t.value)}
+          className={cn(
+            "rounded-md px-2.5 py-1 text-xs font-medium transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/40 disabled:opacity-50",
+            mode === t.value
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 function ResultPanel({ state }: { state: RunState }) {
   if (state.kind === "error") {
     return (
@@ -338,6 +453,38 @@ function ResultPanel({ state }: { state: RunState }) {
       >
         ASK → {state.value ? "true" : "false"}
       </div>
+    );
+  }
+  if (state.kind === "update") {
+    const delta = state.sizeAfter - state.sizeBefore;
+    const sign = delta > 0 ? "+" : "";
+    return (
+      <div className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+        <span className="font-medium text-foreground">Update applied</span> to the
+        in-tab store — {state.sizeBefore} → {state.sizeAfter} triples ({sign}
+        {delta}). Switch the example to a SELECT and re-run to see the change.
+      </div>
+    );
+  }
+  if (state.kind === "graph") {
+    if (state.triples === 0) {
+      return (
+        <p className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+          Empty graph — the template produced no triples.
+        </p>
+      );
+    }
+    return (
+      <pre className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed">
+        {state.ntriples}
+      </pre>
+    );
+  }
+  if (state.kind === "explain") {
+    return (
+      <pre className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed">
+        {state.plan}
+      </pre>
     );
   }
   if (state.kind !== "select") return null;

--- a/site/src/data/sample-graph.ts
+++ b/site/src/data/sample-graph.ts
@@ -123,7 +123,22 @@ export interface ExampleQuery {
   sparql: string;
 }
 
+// [OPUS-4.8] sq-vfbm — the example gallery now spans every query FORM the lean wasm
+// bundle answers (SELECT / ASK / CONSTRUCT / DESCRIBE / UPDATE) plus property paths,
+// so the live REPL exercises the whole tier-a surface advertised on /surface/sparql.
+// Each query is real and runs against the default social graph (ex:alice & friends).
 export const EXAMPLE_QUERIES: ExampleQuery[] = [
+  {
+    // The prefilled default: a focused look at ex:alice — name, age, and who she knows.
+    label: "ex:alice profile",
+    sparql: `PREFIX ex:   <http://example.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+SELECT ?name ?age ?friend WHERE {
+  ex:alice foaf:name  ?name ;
+           foaf:age   ?age ;
+           foaf:knows ?friend .
+} ORDER BY ?friend`,
+  },
   {
     label: "All people & ages",
     sparql: `PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -156,8 +171,42 @@ SELECT ?city (COUNT(?s) AS ?people) WHERE {
 } GROUP BY ?city ORDER BY DESC(?people)`,
   },
   {
+    // Property path: everyone reachable from ex:alice via one-or-more foaf:knows hops.
+    label: "Reachable from ex:alice (path)",
+    sparql: `PREFIX ex:   <http://example.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+SELECT ?name WHERE {
+  ex:alice foaf:knows+ ?p .
+  ?p foaf:name ?name .
+} ORDER BY ?name`,
+  },
+  {
     label: "ASK: anyone over 40?",
     sparql: `PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 ASK { ?s foaf:age ?age . FILTER(?age > 40) }`,
+  },
+  {
+    // CONSTRUCT: derive a symmetric :friendOf graph from the directed foaf:knows links.
+    label: "CONSTRUCT friend-of graph",
+    sparql: `PREFIX ex:   <http://example.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+CONSTRUCT { ?a ex:friendOf ?b }
+WHERE     { ?a foaf:knows ?b }`,
+  },
+  {
+    label: "DESCRIBE ex:alice",
+    sparql: `PREFIX ex: <http://example.org/>
+DESCRIBE ex:alice`,
+  },
+  {
+    // SPARQL Update: mutate the in-tab store. Re-run the "ex:alice profile" query
+    // afterwards to see Erin appear among the people she knows.
+    label: "UPDATE: alice knows ex:erin",
+    sparql: `PREFIX ex:   <http://example.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+INSERT DATA {
+  ex:erin a foaf:Person ; foaf:name "Erin" ; foaf:age 28 .
+  ex:alice foaf:knows ex:erin .
+}`,
   },
 ];

--- a/site/src/lib/repl-dataset.ts
+++ b/site/src/lib/repl-dataset.ts
@@ -122,6 +122,91 @@ type QuadRow = {
   g?: SparqlTerm;
 };
 
+// [OPUS-4.8] sq-vfbm — query-form classification for the live REPL.
+//
+// The wasm Store exposes a different entry point per SPARQL form: `query` for
+// SELECT/ASK (a solution table / boolean), `queryQuads` for the graph-valued forms
+// CONSTRUCT/DESCRIBE (an N-Triples document), and `updateInPlace` for SPARQL Update
+// (INSERT / DELETE / LOAD / graph management — mutates the store, returns nothing).
+// EXPLAIN/EXPLAIN ANALYZE are a separate mode the user toggles, not a query form.
+// The REPL dispatches on the form, so it must recognise it from the query text
+// BEFORE handing it to the engine. This is a pure, framework-free classifier so it
+// unit-tests directly; the engine itself remains the source of truth (a mis-classed
+// query still surfaces the engine's own error).
+
+export type QueryForm = "select" | "ask" | "construct" | "describe" | "update";
+
+// The SPARQL Update keywords (SPARQL 1.1 §3.1 / §3.2). Any of these as the leading
+// significant token means the request is an Update, not a query.
+const UPDATE_KEYWORDS = [
+  "INSERT",
+  "DELETE",
+  "LOAD",
+  "CLEAR",
+  "CREATE",
+  "DROP",
+  "ADD",
+  "MOVE",
+  "COPY",
+  "WITH",
+];
+
+/**
+ * Strips SPARQL comments (`# … <eol>`) and the leading PREFIX / BASE declarations
+ * so the FIRST significant keyword can be read. Returns the remaining query text
+ * upper-cased for keyword matching. Comments are stripped line-by-line; a `#` inside
+ * an IRI or string literal in the prologue is not a concern because the prologue only
+ * contains PREFIX/BASE declarations whose IRIs are angle-bracketed.
+ */
+function significantHead(sparql: string): string {
+  const noComments = sparql
+    .split("\n")
+    .map((line) => {
+      const hash = line.indexOf("#");
+      return hash === -1 ? line : line.slice(0, hash);
+    })
+    .join("\n");
+  // Drop leading PREFIX / BASE declarations (the prologue) repeatedly.
+  let rest = noComments.trimStart();
+  // PREFIX pfx: <iri>  |  BASE <iri>
+  const prologue = /^(PREFIX\s+[^\s]*\s*<[^>]*>|BASE\s*<[^>]*>)\s*/i;
+  while (prologue.test(rest)) {
+    rest = rest.replace(prologue, "").trimStart();
+  }
+  return rest.toUpperCase();
+}
+
+/**
+ * Classifies a SPARQL request into the engine entry point that handles it
+ * ({@link QueryForm}). SELECT/ASK -> `query`; CONSTRUCT/DESCRIBE -> `queryQuads`;
+ * any Update keyword -> `updateInPlace`. Unknown leading tokens default to `"select"`
+ * so the engine's own parser produces the error, rather than this classifier guessing.
+ */
+export function classifyQueryForm(sparql: string): QueryForm {
+  const head = significantHead(sparql);
+  if (head.startsWith("ASK")) return "ask";
+  if (head.startsWith("CONSTRUCT")) return "construct";
+  if (head.startsWith("DESCRIBE")) return "describe";
+  if (head.startsWith("SELECT")) return "select";
+  for (const kw of UPDATE_KEYWORDS) {
+    // Whole-word match: the keyword followed by whitespace, `{`, or end-of-string.
+    if (
+      head === kw ||
+      head.startsWith(`${kw} `) ||
+      head.startsWith(`${kw}\n`) ||
+      head.startsWith(`${kw}{`)
+    ) {
+      return "update";
+    }
+  }
+  return "select";
+}
+
+/** True for the graph-valued query forms answered by the wasm `queryQuads` export. */
+export function isGraphForm(form: QueryForm): boolean {
+  return form === "construct" || form === "describe";
+}
+
 /**
  * Serialises {@link ALL_QUADS_QUERY} solution rows to an N-Quads document: a triple
  * line (`s p o .`) when `?g` is unbound (default graph), a quad line

--- a/site/src/lib/sparq-wasm.ts
+++ b/site/src/lib/sparq-wasm.ts
@@ -17,8 +17,13 @@ import {
 
 export interface WasmStore {
   readonly size: number;
-  query(sparql: string): string; // SPARQL 1.1 JSON results document
-  queryQuads(sparql: string): string; // CONSTRUCT/DESCRIBE -> N-Triples
+  query(sparql: string): string; // SELECT/ASK -> SPARQL 1.1 JSON results document
+  queryQuads(sparql: string): string; // CONSTRUCT/DESCRIBE -> N-Triples document
+  // [OPUS-4.8] sq-vfbm — the remaining lean-bundle query surface the REPL drives:
+  // SPARQL Update (mutates this store in place) and the EXPLAIN introspection forms.
+  updateInPlace(sparql: string): void; // INSERT/DELETE/LOAD/graph-mgmt -> mutate store
+  explain(sparql: string): string; // planning-only plan text (every query form)
+  explainAnalyze(sparql: string): string; // plan + per-operator trace (SELECT/ASK only)
 }
 
 interface WasmModule {

--- a/site/test/repl-dataset.test.mjs
+++ b/site/test/repl-dataset.test.mjs
@@ -13,6 +13,8 @@ import {
   rowsToNQuads,
   guessFormat,
   formatFromContentType,
+  classifyQueryForm,
+  isGraphForm,
 } from "../src/lib/repl-dataset.ts";
 
 test("isDatasetFormat is true exactly for the quad-bearing formats", () => {
@@ -152,4 +154,75 @@ test("rowsToNQuads escapes backslash, quote, CR and LF in literals", () => {
     rowsToNQuads(rows),
     '<http://ex/x> <http://ex/p> "a \\"q\\"\\nlf\\r cr \\\\ bs" .',
   );
+});
+
+// [OPUS-4.8] sq-vfbm — query-form classification: the REPL routes each form to a
+// different wasm export (query / queryQuads / updateInPlace), so the classifier must
+// read the leading significant keyword past the prologue and comments.
+test("classifyQueryForm recognises the four query forms", () => {
+  assert.equal(classifyQueryForm("SELECT ?s WHERE { ?s ?p ?o }"), "select");
+  assert.equal(classifyQueryForm("ASK { ?s ?p ?o }"), "ask");
+  assert.equal(
+    classifyQueryForm("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }"),
+    "construct",
+  );
+  assert.equal(classifyQueryForm("DESCRIBE <http://ex/a>"), "describe");
+  // Case-insensitive.
+  assert.equal(classifyQueryForm("select ?s where { ?s ?p ?o }"), "select");
+  assert.equal(classifyQueryForm("describe ?x"), "describe");
+});
+
+test("classifyQueryForm recognises every SPARQL Update keyword", () => {
+  for (const kw of [
+    "INSERT DATA { <a> <b> <c> }",
+    "DELETE WHERE { ?s ?p ?o }",
+    "LOAD <http://ex/g>",
+    "CLEAR GRAPH <http://ex/g>",
+    "CREATE GRAPH <http://ex/g>",
+    "DROP GRAPH <http://ex/g>",
+    "ADD <http://ex/a> TO <http://ex/b>",
+    "MOVE <http://ex/a> TO <http://ex/b>",
+    "COPY <http://ex/a> TO <http://ex/b>",
+    "WITH <http://ex/g> DELETE { ?s ?p ?o } WHERE { ?s ?p ?o }",
+  ]) {
+    assert.equal(classifyQueryForm(kw), "update", kw);
+  }
+});
+
+test("classifyQueryForm reads past the prologue (PREFIX / BASE)", () => {
+  const q = `PREFIX ex: <http://example.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+SELECT ?name WHERE { ex:alice foaf:name ?name }`;
+  assert.equal(classifyQueryForm(q), "select");
+
+  const u = `PREFIX ex: <http://example.org/>
+INSERT DATA { ex:alice ex:knows ex:erin }`;
+  assert.equal(classifyQueryForm(u), "update");
+
+  const c = `BASE <http://example.org/>
+CONSTRUCT { ?a <friendOf> ?b } WHERE { ?a <knows> ?b }`;
+  assert.equal(classifyQueryForm(c), "construct");
+});
+
+test("classifyQueryForm skips leading comments", () => {
+  const q = `# a comment line
+# another, with a SELECT keyword that must NOT win
+ASK { ?s ?p ?o }`;
+  assert.equal(classifyQueryForm(q), "ask");
+});
+
+test("classifyQueryForm does not mistake INSERTED-into-a-name etc. for whole words", () => {
+  // A SELECT projecting a variable named like a keyword stays a SELECT; the Update
+  // keywords only match as the leading whole token.
+  assert.equal(classifyQueryForm("SELECT ?insert WHERE { ?insert ?p ?o }"), "select");
+  // Unknown leading token defaults to select so the engine surfaces the parse error.
+  assert.equal(classifyQueryForm("GIBBERISH foo bar"), "select");
+});
+
+test("isGraphForm is true exactly for CONSTRUCT and DESCRIBE", () => {
+  assert.equal(isGraphForm("construct"), true);
+  assert.equal(isGraphForm("describe"), true);
+  assert.equal(isGraphForm("select"), false);
+  assert.equal(isGraphForm("ask"), false);
+  assert.equal(isGraphForm("update"), false);
 });


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-vfbm** — make the `/surface/sparql` page genuinely tier-a *live* and polish the `/try` REPL to cover the whole SPARQL surface the lean wasm bundle already exports.

## Why

The lean wasm `Store` already exports `queryQuads` (CONSTRUCT/DESCRIBE), `updateInPlace` (SPARQL Update) and `explain`/`explainAnalyze`. But the live REPL only drove `query()` (SELECT/ASK), and the `/surface/sparql` caveat *falsely* claimed `EXPLAIN` "exists in the engine but is not yet a wasm export". This wires the existing engine surface through to the UI and corrects the docs.

## What changed (site only)

- **`classifyQueryForm` / `isGraphForm`** (`src/lib/repl-dataset.ts`) — a pure, framework-free classifier that reads the leading significant keyword past the PREFIX/BASE prologue and comments, and routes each request to the matching wasm export. Unit-tested.
- **REPL dispatch** (`src/components/repl.tsx`) — SELECT/ASK → `query` (table / boolean); CONSTRUCT/DESCRIBE → `queryQuads` (rendered N-Triples); `INSERT`/`DELETE`/… → `updateInPlace` (mutates the in-tab store, re-counts the dataset badge); plus a **Run / EXPLAIN / ANALYZE** mode toggle that renders the planner's plan text. New result panels for graph output, an Update acknowledgement, and the EXPLAIN plan.
- **Example gallery** (`src/data/sample-graph.ts`) — an `ex:alice`-centred prefilled default, plus property-path, CONSTRUCT, DESCRIBE and `INSERT DATA` examples, spanning every form the bundle answers.
- **Docs** — corrected the `/surface/sparql` caveat (EXPLAIN **is** a wasm export; the honest wasm32 caveat is zero wall-times in ANALYZE) and refreshed the surface "how this runs" note + the `/try` intro to advertise the full surface.

## Honesty / scope

- The wasm methods already existed and ship in the bundle (verified each path — SELECT/CONSTRUCT/DESCRIBE/UPDATE/EXPLAIN/ANALYZE — against the **real shipped wasm** in node). This PR is purely the site wiring + docs correction, not a no-op: the prior REPL genuinely could not run CONSTRUCT/UPDATE/EXPLAIN.
- No Rust crate or public Rust API changed, so the G2 public-api→SKILL.md rule does not apply. No privacy/soundness claims are made or touched.

## Gate

- `npm run test:unit` — 22 pass (new classifier tests included).
- `npm run lint` — clean.
- `npm run build` — static export builds, all 41 pages (incl. `/surface/sparql`, `/try`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)