### PR TITLE
ci(rustdoc): widen -D warnings gate to the whole workspace (sq-8gsv)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,46 +559,23 @@ jobs:
       # A new warning — from new code or a Rust-stable bump that adds a lint — fails CI.
       - name: clippy (deny warnings)
         run: cargo clippy --workspace --all-targets -- -D warnings
-      # [OPUS-4.8] sq-z1rm: rustdoc -D warnings, scoped to sparq-solid. A broken/private
-      # intra-doc link (e.g. a public item linking to a crate-private const/fn) is a rustdoc
-      # warning, NOT a clippy/build warning, so it slips past every other gate here and
-      # mis-renders the published docs. This GATES the sparq-solid doc surface so a public
-      # item can never again link to a private/unresolved item. Both feature states: the
-      # `odrl-bridge` module (and its own intra-doc links) only compiles under that feature.
-      # Intentionally per-crate, not `--workspace`: the rest of the workspace still carries a
-      # pre-existing rustdoc-warning backlog (tracked separately) that a workspace-wide
-      # -D warnings would fail on today.
-      - name: rustdoc (deny warnings, sparq-solid — default features)
-        run: cargo doc -p sparq-solid --no-deps
+      # [OPUS-4.8] sq-8gsv: rustdoc -D warnings, WORKSPACE-WIDE. A broken/private intra-doc
+      # link (e.g. a public item linking to a crate-private const/fn, or an unresolved
+      # `[`Foo`]` that renders as literal text) is a rustdoc warning — NOT a clippy/build
+      # warning — so it slips past every other gate here and mis-renders the published docs.
+      # This was previously scoped to sparq-solid (sq-z1rm) and sparq-mpc (sq-h1w2) only,
+      # because the rest of the workspace carried ~174 pre-existing intra-doc-link warnings
+      # across ~20 crates. sq-8gsv cleared that backlog, so the gate now covers the WHOLE
+      # doc surface: any new public item that links to a private/unresolved one fails CI.
+      # Two feature states cover the feature-gated doc surface (e.g. sparq-solid's
+      # `odrl-bridge`/`count-enforcement` modules, sparq-mpc's `insecure-test-rng`,
+      # sparq-prov's `reason` bridge): default features, then `--all-features`.
+      - name: rustdoc (deny warnings, workspace — default features)
+        run: cargo doc --workspace --no-deps
         env:
           RUSTDOCFLAGS: "-D warnings"
-      - name: rustdoc (deny warnings, sparq-solid — odrl-bridge)
-        run: cargo doc -p sparq-solid --no-deps --features odrl-bridge
-        env:
-          RUSTDOCFLAGS: "-D warnings"
-      # [OPUS-4.8] sq-58mh: the STATEFUL `odrl:count` bridge surface (the `count` module +
-      # `materialize_odrl_permission_counted` + the `BridgeOutcome::consumed` doc-link)
-      # only compiles/resolves under `count-enforcement` — gate its doc surface too.
-      - name: rustdoc (deny warnings, sparq-solid — count-enforcement)
-        run: cargo doc -p sparq-solid --no-deps --features count-enforcement
-        env:
-          RUSTDOCFLAGS: "-D warnings"
-      # [OPUS-4.8] sq-h1w2: rustdoc -D warnings, scoped to sparq-mpc. Same rationale as
-      # the sparq-solid gate above — a public MPC item linking to a crate-private helper
-      # (e.g. the `pub(crate)` `mac_shares`/`verify_sum_in_range` internals, or a wrong
-      # `ShamirBackend::run_secure` path that should be the `MpcBackend` trait method) is
-      # a rustdoc warning that slips past clippy/build. This crate's intra-doc backlog is
-      # now cleared, so we GATE it so a public item can never again link to a
-      # private/unresolved one. Both feature states: default and the off-by-default
-      # `insecure-test-rng` (its only feature; `--all-features` == that one feature).
-      # Still per-crate, not `--workspace`: the rest of the workspace carries a separate
-      # pre-existing rustdoc-warning backlog (own beads) a workspace-wide gate would fail.
-      - name: rustdoc (deny warnings, sparq-mpc — default features)
-        run: cargo doc -p sparq-mpc --no-deps
-        env:
-          RUSTDOCFLAGS: "-D warnings"
-      - name: rustdoc (deny warnings, sparq-mpc — insecure-test-rng)
-        run: cargo doc -p sparq-mpc --no-deps --features insecure-test-rng
+      - name: rustdoc (deny warnings, workspace — all features)
+        run: cargo doc --workspace --no-deps --all-features
         env:
           RUSTDOCFLAGS: "-D warnings"
       # Informational until the deferred `cargo fmt --all` reformat lands (see rustfmt.toml).

--- a/crates/sparq-cli/src/main.rs
+++ b/crates/sparq-cli/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
 
 /// Isolated micro-benchmark of the latency-bound dict-remap gather, to measure the per-ISA
 /// software prefetch in isolation (undiluted by parsing) on each hardware target.
-///   sparq-cli bench-remap [n_triples] [dict_size] [iters]
+///   sparq-cli bench-remap n_triples dict_size iters
 /// Run twice — once normally, once with SPARQ_NO_PREFETCH=1 — to get the prefetch delta.
 fn cmd_bench_remap(args: &[String]) {
     let n: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(20_000_000);
@@ -62,7 +62,7 @@ fn cmd_bench_remap(args: &[String]) {
 /// sweeping the thread count in ONE process. Reports best time, speedup vs the smallest pool, and
 /// parallel EFFICIENCY (speedup ÷ thread-ratio; 1.0 = perfectly linear) per subsystem, so you can
 /// see precisely where each part plateaus. On a many-core box pass e.g. `1,2,4,8,16,32,64,128,192`.
-///   sparq-cli scaling <data-file> <format> <queries-dir> [threads=auto] [iters=3]
+///   sparq-cli scaling `<data-file>` `<format>` `<queries-dir>` [threads=auto] [iters=3]
 fn cmd_scaling(args: &[String]) {
     let (path, format, qdir) = match (args.get(2), args.get(3), args.get(4)) {
         (Some(p), Some(f), Some(d)) => (p.clone(), f.clone(), d.clone()),
@@ -1017,7 +1017,7 @@ fn out_format_flag(args: &[String]) -> OutFormat {
     }
 }
 
-/// [OPUS-4.8] (sq-l4ki) Renders a SELECT [`QueryResult`] as a fixed-width ASCII table —
+/// [OPUS-4.8] (sq-l4ki) Renders a SELECT `QueryResult` as a fixed-width ASCII table —
 /// the default human-readable `query` output. Unbound cells render empty; each term uses
 /// its SPARQL/Turtle term syntax (oxrdf's `Display`). Column widths are sized to the
 /// widest cell so columns line up; for a zero-variable result (which only ASK produces,

--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -29,7 +29,7 @@
 //! invert that and couple the SPARQL/inference scoreboard to the SHACL/geo build.
 //! So consolidation happens at the REPORTING layer: the floors live here as the
 //! authoritative list, the runners stay where their dependencies are, and a guard
-//! test ([`tests/scoreboard_floors.rs`]) hermetically reads the crate-local
+//! test (`tests/scoreboard_floors.rs`) hermetically reads the crate-local
 //! sources to prove the centrally-declared floors still match the runner-enforced
 //! ones (so the two can never silently diverge).
 

--- a/crates/sparq-core/src/compress.rs
+++ b/crates/sparq-core/src/compress.rs
@@ -491,7 +491,7 @@ impl CompressedPermWriter {
     /// perm the bytes are identical to `CompressedPerm::encode(all_rows).write_to(out)`.
     ///
     /// EMPTY-PERM POLICY: when no rows were pushed, `out` is written as a ZERO-byte file
-    /// (NOT a bare 32-byte header), matching [`TripleStore::save_compressed`] which leaves an
+    /// (NOT a bare 32-byte header), matching `TripleStore::save_compressed` which leaves an
     /// unbuilt permutation raw-empty so `open` skips it by size. This keeps the streaming
     /// build byte-identical to a raw build followed by `recompress`.
     pub fn finish(mut self, out: &std::path::Path) -> std::io::Result<()> {

--- a/crates/sparq-core/src/dict.rs
+++ b/crates/sparq-core/src/dict.rs
@@ -251,7 +251,7 @@ pub(crate) fn lang_with_dir(l: &Literal) -> Option<std::borrow::Cow<'_, str>> {
     }
 }
 
-/// Inverse of [`lang_with_dir`]: split a STORED language slot back into its BCP47 tag and
+/// Inverse of `lang_with_dir`: split a STORED language slot back into its BCP47 tag and
 /// (optional) RDF 1.2 base direction. A stored slot of `en--ltr` is `("en", Some("ltr"))`;
 /// a plain `en` is `("en", None)`. The returned tag/direction are the spec-distinct
 /// components the SPARQL 1.2 results formats keep apart (`xml:lang` vs `its:dir`) — see the
@@ -290,7 +290,7 @@ pub fn split_lang_dir(slot: &str) -> (&str, Option<&str>) {
 /// and never drift apart:
 /// - stored-slot fast path — [`split_lang_dir`] (splits off the `--dir` suffix, then validates
 ///   it here);
-/// - materialised path — [`reconstruct_ref`] (same split-then-validate of a stored slot);
+/// - materialised path — `reconstruct_ref` (same split-then-validate of a stored slot);
 /// - outbound SPARQL 1.2 results — `sparq-engine`'s `json.rs` (emits the validated direction
 ///   as a separate `its:dir` field);
 /// - inbound SERVICE results parser — `sparq-engine`'s `service.rs` (sq-s955), where `its:dir`
@@ -1399,7 +1399,7 @@ impl Dict {
         self.find_term(hash, term).unwrap_or(NO_ID)
     }
 
-    /// Returns the id for a literal given its components, else `NO_ID` — [`lookup`]
+    /// Returns the id for a literal given its components, else `NO_ID` — `lookup`
     /// without constructing an `oxrdf::Term` (the fast path for resolving computed
     /// BIND/aggregate values against the dictionary). Canonical small `xsd:integer`s
     /// resolve to their inline id, exactly like `lookup`/`intern_lit`.

--- a/crates/sparq-core/src/dictspill.rs
+++ b/crates/sparq-core/src/dictspill.rs
@@ -23,7 +23,7 @@
 //!      groups of equal terms yield the distinct term with its MIN seq
 //!      (= first occurrence) plus a (min_seq, seq) pair per occurrence.
 //!   3. assign    — per shard in order: external sort of the distinct terms by
-//!      min_seq; final id = base[shard] + rank (the sharded path's
+//!      min_seq; final id = baseshard + rank (the sharded path's
 //!      assignment). The dictionary files (`dict-terms/offs/hash/hid/
 //!      meta.bin`) plus `numerics.bin`/`temporals.bin` are STREAM-written
 //!      in final-id order — never resident.

--- a/crates/sparq-core/src/extsort.rs
+++ b/crates/sparq-core/src/extsort.rs
@@ -145,7 +145,7 @@ fn kway_merge_to<S: FnMut([Id; 3]) -> io::Result<()>>(runs: &[PathBuf], mut sink
 }
 
 /// K-way merges sorted run files into a RAW little-endian `[u32;3]` permutation at `out`
-/// (deduplicating consecutive equal triples). See [`kway_merge_to`] for the shared merge
+/// (deduplicating consecutive equal triples). See `kway_merge_to` for the shared merge
 /// machinery.
 pub fn kway_merge(runs: &[PathBuf], out: &Path) -> io::Result<()> {
     let mut w = BufWriter::new(std::fs::File::create(out)?);

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -727,7 +727,7 @@ impl Graph {
     /// Like [`load_str`](Self::load_str) but resolves relative IRIs in the document
     /// against `base` — the entry point for documents that carry no `@base` of their
     /// own (e.g. SHACL shapes graphs addressed by their location, W3C test-suite
-    /// manifests). `format`: as [`load_str`]; the line-based formats ("ntriples" /
+    /// manifests). `format`: as `load_str`; the line-based formats ("ntriples" /
     /// "nquads") only allow absolute IRIs, so `base` has no effect on them.
     pub fn load_str_with_base(text: &str, format: &str, base: &str) -> Result<Graph, String> {
         let (dict, triples) = Self::parse_to_triples_with_base(text, format, base)?;
@@ -1036,7 +1036,7 @@ impl Graph {
 
     /// Builds a graph from an already-interned dictionary + triple set (e.g. after opt-in
     /// reasoning materialized additional triples). Public counterpart of the internal
-    /// [`build`](Self::build).
+    /// `build`.
     pub fn from_parts(dict: Dict, triples: Vec<[Id; 3]>) -> Graph {
         Self::build(dict, triples)
     }
@@ -1185,7 +1185,7 @@ impl Graph {
     /// NEVER materialised in memory — only a few blocks in flight plus the growing
     /// dictionary/triples. (The store itself must fit in RAM; this removes the redundant
     /// full-text copy a read-to-string load would hold alongside it.) For N-Triples; other
-    /// formats defer to the serial streaming [`load_reader`].
+    /// formats defer to the serial streaming `load_reader`.
     ///
     /// The read/decompress runs PIPELINED on its own thread (same 3-stage design as the
     /// external build's `build_external_ntriples_parallel`): stage 1 fills full 32 MiB
@@ -1377,7 +1377,7 @@ impl Graph {
     }
 
     /// Like [`save`](Self::save) but persists the permutation indexes BLOCK-COMPRESSED
-    /// (~3-5x smaller on disk; the dictionary/numerics files are unchanged). [`open`]
+    /// (~3-5x smaller on disk; the dictionary/numerics files are unchanged). `open`
     /// auto-detects the format per file, serving compressed perms by lazy block-wise
     /// decode off the mapped file; call [`decompress_indexes`](Self::decompress_indexes)
     /// after open to trade RAM for exactly-raw query speed instead.
@@ -1965,7 +1965,7 @@ impl Graph {
     /// [OPUS-4.8] (sq-5atq) EXTERNAL-MEMORY build for a DATASET WITH NAMED GRAPHS — the
     /// out-of-core twin of an in-RAM dataset `load_dataset` + [`save`](Self::save). Streams an
     /// N-Quads (`"nquads"`/`"n-quads"`) or TriG (`"trig"`) document and writes the SAME
-    /// on-disk layout [`save_named`](Self::save_named) emits — the default graph in `dir`
+    /// on-disk layout `save_named` emits — the default graph in `dir`
     /// itself plus each named graph under `dir/named/<i>/`, committed by the `dir/named.bin`
     /// manifest — so [`open`](Self::open) reads the whole dataset back LOSSLESSLY (mmap).
     ///
@@ -1990,7 +1990,7 @@ impl Graph {
     /// [`build_external`](Self::build_external)), and an empty default graph still produces a
     /// valid (empty) store in `dir`.
     ///
-    /// `chunk` is the per-graph external-build run size (see [`build_external`]).
+    /// `chunk` is the per-graph external-build run size (see `build_external`).
     #[cfg(feature = "mmap")]
     pub fn build_external_quads<R: std::io::Read>(
         reader: R,
@@ -2648,8 +2648,8 @@ impl Graph {
     /// directory swap, scoped to the `named/` sub-tree: the renumbered survivors are built in a
     /// staging `named.drop-new/`, fsync'd, then swapped in (`named` → `named.drop-old`,
     /// `named.drop-new` → `named`), and only THEN is the shrunk manifest written (the manifest
-    /// rewrite is itself atomic+dir-fsync'd via [`write_named_manifest`]). An interrupted swap
-    /// is completed/rolled back deterministically by [`recover_named_drop`] on the next
+    /// rewrite is itself atomic+dir-fsync'd via `write_named_manifest`). An interrupted swap
+    /// is completed/rolled back deterministically by `recover_named_drop` on the next
     /// [`open`](Self::open). Surviving sub-graphs are re-opened from their new directories so
     /// each re-acquires a correctly-indexed per-graph WAL.
     ///
@@ -2696,7 +2696,7 @@ impl Graph {
     /// graph: each of those rebuilt the ENTIRE surviving named set (renumber + manifest rewrite),
     /// making DROP ALL O(n²) in the number of named graphs. Clearing the whole set is O(n) — one
     /// pass to release every sub-graph's handles, one manifest removal, one sub-tree removal — so
-    /// this routes straight through the no-survivors arm of [`persist_named_after_drop`].
+    /// this routes straight through the no-survivors arm of `persist_named_after_drop`.
     ///
     /// In-memory parent (or a non-`mmap` build): just clears the entries, matching the old
     /// `self.named.clear()`. Idempotent — a no-op when there are no named graphs.
@@ -3038,7 +3038,7 @@ impl Graph {
     ///
     /// The live dataset (default graph + every named graph, recursively) is dumped to `[Term; 3]`
     /// and re-interned into a brand-new [`Graph`] with an empty [`Dict`]; that fresh image is then
-    /// swapped in via the SAME rollback-safe [`persist_swap`](Self::persist_swap) the compaction
+    /// swapped in via the SAME rollback-safe `persist_swap` the compaction
     /// uses (atomic, crash-safe, WAL-truncated). The live triple set is preserved EXACTLY
     /// (round-trip). For an in-memory graph it just replaces the dictionary/store in place.
     ///

--- a/crates/sparq-core/src/store.rs
+++ b/crates/sparq-core/src/store.rs
@@ -40,8 +40,8 @@ pub const BUILT: &[Perm] = &[Perm::Spo, Perm::Pos, Perm::Osp];
 impl Perm {
     pub const ALL: [Perm; 6] = [Perm::Spo, Perm::Sop, Perm::Pso, Perm::Pos, Perm::Osp, Perm::Ops];
 
-    /// The column indices (into a canonical [s,p,o] triple) in this permutation's
-    /// sort order. e.g. POS -> [1,2,0].
+    /// The column indices (into a canonical s,p,o triple) in this permutation's
+    /// sort order. e.g. POS -> 1,2,0.
     #[inline]
     pub fn order(self) -> [usize; 3] {
         match self {
@@ -264,7 +264,7 @@ pub struct TripleStore {
 }
 
 impl TripleStore {
-    /// Builds the [`BUILT`] permutation indexes from canonical [s,p,o] triples (all
+    /// Builds the [`BUILT`] permutation indexes from canonical s,p,o triples (all
     /// six by default; just SPO/POS/OSP under `compact-index`). SPO is sorted (in
     /// parallel) and deduplicated first; the rest are independent and built concurrently.
     pub fn from_triples(triples: Vec<[Id; 3]>) -> Self {
@@ -755,7 +755,7 @@ pub struct Scan<'a> {
 }
 
 impl<'a> Scan<'a> {
-    /// Maps a stored row back to a canonical [s,p,o] triple.
+    /// Maps a stored row back to a canonical s,p,o triple.
     #[inline]
     pub fn to_spo(&self, row: &[Id; 3]) -> [Id; 3] {
         let order = self.perm.order();

--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -78,7 +78,7 @@ pub struct QueryBudget {
     pub max_rows: Option<usize>,
     /// [OPUS-4.8] (sq-s5is) Upper bound, in BYTES, on the estimated working-set size of
     /// any materialised (intermediate or final) result — the byte-accounted twin of
-    /// [`max_rows`]. Where `max_rows` counts ROWS and so misses a query with FEW but very
+    /// `max_rows`. Where `max_rows` counts ROWS and so misses a query with FEW but very
     /// WIDE rows (many projected variables, or huge computed string literals), this bounds
     /// the estimated heap footprint of the id-level working set: `rows × width ×
     /// size_of::<Id>()` for each materialised intermediate, PLUS the bytes of any

--- a/crates/sparq-fedclient/src/adaptive.rs
+++ b/crates/sparq-fedclient/src/adaptive.rs
@@ -138,7 +138,7 @@ impl AdaptiveOutcome {
 /// 2. **Adaptive join-ordering** — walk the plan stage by stage; **at each operator boundary**
 ///    ask the [`AdaptiveExecutor`] whether to re-plan the **unjoined remainder** given the
 ///    observation-corrected statistics, then join the next leaf onto the running prefix with
-///    the materialised [`natural_join`] (the SAME operator the static interpreter uses). A
+///    the materialised `natural_join` (the SAME operator the static interpreter uses). A
 ///    re-plan is **considered at most once per boundary** and adopted only when the new suffix
 ///    beats the current one by the policy's hysteresis margin (anti-thrash).
 ///

--- a/crates/sparq-fedclient/src/operators.rs
+++ b/crates/sparq-fedclient/src/operators.rs
@@ -764,7 +764,7 @@ fn join_out_vars(left: &[String], right: &[String]) -> Vec<String> {
 /// joined solution the moment the **later-arriving** of a matching pair is processed — never
 /// waiting for either input to finish. Because [`StreamJoin`] is proven multiset-equal to a
 /// blocking hash join for ANY interleaving and any spill budget, the streamed result is the
-/// same multiset Phase-3's [`natural_join`] produces — the load-bearing correctness property.
+/// same multiset Phase-3's `natural_join` produces — the load-bearing correctness property.
 ///
 /// Interleaving is *real*: a dedicated feeder thread drains both input streams (pulling from
 /// whichever has an item ready, via two `recv` loops multiplexed by a tiny merge) and pushes
@@ -1028,7 +1028,7 @@ impl Default for StreamOptions {
 /// [`materialize_single_source`] for the same plan and source, for ANY interleaving of leaf
 /// arrivals (the streaming-correctness test). Because each [`StreamingJoin`] reuses the
 /// planner's [`StreamJoin`] — proven multiset-equal to a blocking hash join — and the join
-/// keys / output headers match the Phase-3 [`natural_join`], the streamed bag equals the
+/// keys / output headers match the Phase-3 `natural_join`, the streamed bag equals the
 /// materialised bag.
 ///
 /// The returned stream borrows nothing (it owns its channels + threads), but the leaf fetches

--- a/crates/sparq-fedclient/src/source.rs
+++ b/crates/sparq-fedclient/src/source.rs
@@ -959,7 +959,7 @@ const BRTPF_VALUES_PARAM: &str = "values";
 ///    server returns only triples joining at least one attached mapping (the brTPF bind-join).
 /// 3. **Pagination.** A `page` token is the OPAQUE next-page URL the server published as
 ///    `hydra:next`; the transport GETs it verbatim, so following pagination to exhaustion is
-///    "GET the `hydra:next` link until there is none" — exactly what [`drain_fragment`] drives.
+///    "GET the `hydra:next` link until there is none" — exactly what `drain_fragment` drives.
 /// 4. **Turtle/TriG fragment-body parse.** The response (`Accept: text/turtle, application/trig`)
 ///    is parsed with oxttl's TriG parser (a superset of Turtle — it handles a default-graph
 ///    Turtle body and a named-graph TriG body identically). The parse SPLITS the document into

--- a/crates/sparq-geo/src/gml.rs
+++ b/crates/sparq-geo/src/gml.rs
@@ -12,8 +12,8 @@
 //!    <gml:pos>-83.4 34.3</gml:pos></gml:Point>"^^geo:gmlLiteral
 //! ```
 //!
-//! Output is the SAME [`GeoGeometry`](crate::GeoGeometry) the WKT path produces
-//! (a [`geo_types::Geometry<f64>`] tagged with a [`Crs`](crate::Crs)), so every
+//! Output is the SAME [`GeoGeometry`] the WKT path produces
+//! (a [`geo_types::Geometry<f64>`] tagged with a [`Crs`]), so every
 //! downstream `geof:` function, the [`GeoIndex`](crate::GeoIndex), and the CRS /
 //! axis-order handling work UNCHANGED. As with WKT, coordinates are normalised
 //! to x = longitude / y = latitude: an EPSG:4326 `srsName` (LAT/LONG axis order)

--- a/crates/sparq-hdt/src/decode.rs
+++ b/crates/sparq-hdt/src/decode.rs
@@ -516,7 +516,7 @@ fn decode_dict(
 ///
 ///  * the `dict` stage is broken into its four PFC-section decodes (`dict_shared`,
 ///    `dict_subjects`, `dict_objects`, `dict_predicates` — each the wall of one
-///    [`decode_section`], so in the multi-threaded pool these OVERLAP and need not sum to
+///    `decode_section`, so in the multi-threaded pool these OVERLAP and need not sum to
 ///    `dict`) plus the section-order `merge` (`dict_merge`);
 ///  * the `scan` stage is broken into the triples-section bitmap/sequence READ
 ///    (`scan_read`) and the SPO id-translation adjacency WALK (`scan_walk`).
@@ -534,7 +534,7 @@ pub struct StageTimings {
     pub build: std::time::Duration,
 
     // --- [OPUS-4.8] sq-7ge0 finer split (measurement-only; same decode path) ---
-    /// PFC decode+intern wall of the `shared` section (one [`decode_section`] call).
+    /// PFC decode+intern wall of the `shared` section (one `decode_section` call).
     /// In the multi-threaded pool the four section decodes run concurrently, so these
     /// four per-section walls OVERLAP each other and need not sum to `dict`.
     pub dict_shared: std::time::Duration,
@@ -545,7 +545,7 @@ pub struct StageTimings {
     /// PFC decode+intern wall of the `predicates` section.
     pub dict_predicates: std::time::Duration,
     /// Section-order merge of the four partial dicts into the final dict + the
-    /// per-section local-id remap (the four [`merge_section`] calls). This runs single
+    /// per-section local-id remap (the four `merge_section` calls). This runs single
     /// threaded after the (possibly concurrent) section decodes join.
     pub dict_merge: std::time::Duration,
     /// Triples-section READ: triples control info + the two raw bitmaps + the two

--- a/crates/sparq-hdt/src/lib.rs
+++ b/crates/sparq-hdt/src/lib.rs
@@ -15,7 +15,7 @@
 //! Writing back out (`Graph` -> `.hdt`) is opt-in behind the `write` cargo feature.
 //! It encodes the FourSectDict (Plain Front Coding) + BitmapTriples sections
 //! DIRECTLY from sparq's in-memory dictionary + triples (the inverse of the decoder)
-//! — no temporary N-Triples round-trip — see [`save`] and `src/encode.rs`:
+//! — no temporary N-Triples round-trip — see `save` and `src/encode.rs`:
 //!
 //! ```no_run
 //! # #[cfg(feature = "write")]

--- a/crates/sparq-hdt/src/write.rs
+++ b/crates/sparq-hdt/src/write.rs
@@ -68,7 +68,7 @@ fn out_container(path: &Path) -> OutContainer {
 /// Front Coding + BitmapTriples in SPO order) — the same layout [`crate::load`]
 /// reads, and the one hdt-cpp / hdt-java emit, so the result is interoperable. The
 /// sections are encoded DIRECTLY from sparq's in-memory dictionary + triples (no
-/// temporary N-Triples file, no text re-parse — see [`crate::encode`]). If `path`
+/// temporary N-Triples file, no text re-parse — see `crate::encode`). If `path`
 /// ends in `.gz` / `.zst` / `.bz2` the archive bytes are wrapped in that container
 /// (matching the reader's magic-byte sniffing); any other extension writes a bare
 /// `.hdt`.

--- a/crates/sparq-introspect/src/lib.rs
+++ b/crates/sparq-introspect/src/lib.rs
@@ -1020,12 +1020,12 @@ impl Introspection {
         out
     }
 
-    /// [OPUS-4.8] sq-mr32 (federation A3/Z2): the VoID description ([`to_void`]) **plus**
+    /// [OPUS-4.8] sq-mr32 (federation A3/Z2): the VoID description (`to_void`) **plus**
     /// the characteristic-set source statistics, as one N-Triples document.
     ///
     /// This is the served federation-descriptor surface: it is a strict superset of
-    /// [`to_void`] — every standard VoID triple is emitted unchanged — followed by the
-    /// characteristic-set extension (see [`CS_NS`]). sparq already mines these sets
+    /// `to_void` — every standard VoID triple is emitted unchanged — followed by the
+    /// characteristic-set extension (see `CS_NS`). sparq already mines these sets
     /// (Neumann & Moerkotte's per-entity-type predicate co-occurrence + per-predicate
     /// multiplicity); exposing them lets a remote, CostFed/Odyssey-class source-selector
     /// estimate star- and multi-join cardinalities against this node far more accurately
@@ -1276,7 +1276,7 @@ impl Introspection {
     /// it participates in (as subject or object); a seed naming a **predicate** pulls
     /// that predicate's global profile. Only the matched slice is rendered, under
     /// `budget_chars`, most-relevant-first, with the same prefix glossary discipline as
-    /// [`to_text_summary`].
+    /// `to_text_summary`.
     ///
     /// This is struct-level scoping (it filters the already-mined profiles by IRI);
     /// it does not re-scan the graph, so it cannot expand to neighbours the build did

--- a/crates/sparq-nlq/src/eval.rs
+++ b/crates/sparq-nlq/src/eval.rs
@@ -19,7 +19,7 @@
 //!    grounding prompt) vs [`Linking::Oracle`] (the schema/entity linking is given:
 //!    the harness supplies the correct query directly, isolating the loop's
 //!    *validate → execute → repair* contribution from the model's linking ability).
-//! 2. **Grounding** — grounded ([`NlqConfig::ground`] `true`) vs the ungrounded
+//! 2. **Grounding** — grounded (`NlqConfig::ground` `true`) vs the ungrounded
 //!    baseline (`false`). The headline claim is *grounded end-to-end* F1 **>**
 //!    *ungrounded end-to-end* F1.
 //!
@@ -347,7 +347,7 @@ pub fn run_config(
 
 /// The four-cell comparison the design doc requires: end-to-end and oracle, each
 /// grounded and ungrounded. Returned as a struct so the caller can assert the
-/// load-bearing inequality ([`headline_grounding_pays`]).
+/// load-bearing inequality (`headline_grounding_pays`).
 #[derive(Debug, Clone)]
 pub struct Comparison {
     pub grounded_end_to_end: Report,

--- a/crates/sparq-nlq/src/lib.rs
+++ b/crates/sparq-nlq/src/lib.rs
@@ -32,7 +32,7 @@
 //! The LLM sits behind the [`Llm`] trait. CI never touches the network:
 //! [`ReplayLlm`] serves recorded prompt→completion pairs from a JSON fixture, and
 //! [`RecordingLlm`] wraps any backend to produce such fixtures. A thin Anthropic
-//! Messages-API client ([`AnthropicLlm`](live::AnthropicLlm)) is available behind
+//! Messages-API client (`AnthropicLlm`) is available behind
 //! the non-default `live` feature.
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 

--- a/crates/sparq-policy/src/count.rs
+++ b/crates/sparq-policy/src/count.rs
@@ -128,7 +128,7 @@ pub trait UsageCounterStore {
 
     /// The number of units already consumed for `key` (for audit/inspection), or `None`
     /// if the store cannot be read. Pure read — does NOT consume. Never used to *gate*
-    /// an exercise (that is [`try_consume`]'s atomic job); only to report state.
+    /// an exercise (that is `try_consume`'s atomic job); only to report state.
     fn consumed(&self, key: &CountKey) -> Option<u64>;
 }
 

--- a/crates/sparq-policy/src/count_backend.rs
+++ b/crates/sparq-policy/src/count_backend.rs
@@ -49,8 +49,8 @@
 //! # Fail-closed
 //!
 //! Every backend error ([`BackendError`]) maps to [`ConsumeResult::Unavailable`] — a DENY
-//! upstream, never a silent grant. A read error makes [`consumed`](BackendCounterStore::
-//! consumed) return `None`. We never grant beyond a limit we cannot account for.
+//! upstream, never a silent grant. A read error makes `BackendCounterStore::consumed`
+//! return `None`. We never grant beyond a limit we cannot account for.
 //!
 //! [`evaluate_and_exercise`]: crate::count::evaluate_and_exercise
 

--- a/crates/sparq-policy/src/eval.rs
+++ b/crates/sparq-policy/src/eval.rs
@@ -25,7 +25,7 @@ pub const ODRL_PURPOSE: &str = "http://www.w3.org/ns/odrl/2/purpose";
 
 /// The `odrl:count` left-operand IRI — the dimension a *count constraint* restricts
 /// (the number of times a permission may be exercised, e.g. `odrl:count lteq 5`).
-/// Stateful enforcement of this lives in the opt-in [`crate::count`] module.
+/// Stateful enforcement of this lives in the opt-in `crate::count` module.
 /// [OPUS-4.8] sq-zi5w.
 pub const ODRL_COUNT: &str = "http://www.w3.org/ns/odrl/2/count";
 
@@ -283,7 +283,7 @@ impl Decision {
 
 /// Evaluate `policy` against `request`, returning a fail-closed [`Decision`].
 ///
-/// See the [module docs](self) for the exact semantics. This is the single-node
+/// See the module docs for the exact semantics. This is the single-node
 /// base case of ODRL — it reduces to the same allow/deny shape `sparq-solid`'s
 /// WAC/ACP path produces, with ODRL's richer purpose/recipient/time constraints
 /// and duty obligations layered on top.
@@ -483,7 +483,7 @@ pub enum ProhibitionStatus {
 
 /// The three-valued verdict of a rule's `odrl:purpose` constraints against the
 /// purpose evidence a request carries — a FAITHFUL report of exactly what
-/// [`evaluate`] checks for purpose (it reuses the same [`constraint_status`] the
+/// [`evaluate`] checks for purpose (it reuses the same `constraint_status` the
 /// evaluator's purpose constraints go through). [OPUS-4.8] sq-q56r.
 ///
 /// The honesty contract: this never claims a stronger verdict than the evaluator
@@ -516,7 +516,7 @@ pub enum PurposeMatch {
 /// enforcement. [OPUS-4.8] sq-q56r.
 ///
 /// This does NOT re-implement matching: it runs the request through the SAME
-/// [`constraint_status`] every `odrl:purpose` constraint goes through inside
+/// `constraint_status` every `odrl:purpose` constraint goes through inside
 /// [`evaluate`], so the verdict it reports is exactly what the evaluator acts on —
 /// the whole point of the bead (no claimed enforcement that isn't actually checked).
 ///
@@ -592,7 +592,7 @@ pub fn purpose_status(rule: &Rule, request: &Request) -> PurposeMatch {
 
 /// The three-valued verdict of a rule's `odrl:recipient` constraints against the
 /// recipient evidence a request carries — a FAITHFUL report of exactly what
-/// [`evaluate`] checks for recipient (it reuses the same [`constraint_status`] the
+/// [`evaluate`] checks for recipient (it reuses the same `constraint_status` the
 /// evaluator's recipient constraints go through). [OPUS-4.8] sq-5037.
 ///
 /// The honesty contract mirrors [`PurposeMatch`]: this never claims a stronger verdict
@@ -626,12 +626,12 @@ pub enum RecipientMatch {
 /// `neq` / "everyone-except") enforcement. [OPUS-4.8] sq-5037.
 ///
 /// Like [`purpose_status`], this does NOT re-implement matching: it runs the request
-/// through the SAME [`constraint_status`] every `odrl:recipient` constraint goes
+/// through the SAME `constraint_status` every `odrl:recipient` constraint goes
 /// through inside [`evaluate`], so the verdict it reports is exactly what the
 /// evaluator acts on (no claimed enforcement that isn't actually checked). The
 /// recipient evidence is the explicit `odrl:recipient` context value, or — when none
 /// is set — the requesting [`Request::party`] (the recipient-of-data is who is asking;
-/// see [`resolve_actual`]).
+/// see `resolve_actual`).
 ///
 /// Returns [`RecipientMatch::NotConstrained`] when the rule has no recipient constraint.
 ///
@@ -687,7 +687,7 @@ pub fn recipient_status(rule: &Rule, request: &Request) -> RecipientMatch {
 /// The three-valued verdict of a rule's `odrl:dateTime` (time-window) constraints
 /// against the evaluation-time evidence a request carries — a FAITHFUL report of
 /// exactly what [`evaluate`] checks for the clock (it reuses the same
-/// [`constraint_status`] the evaluator's `odrl:dateTime` constraints go through).
+/// `constraint_status` the evaluator's `odrl:dateTime` constraints go through).
 /// [OPUS-4.8] sq-idnv.
 ///
 /// The honesty contract mirrors [`PurposeMatch`] / [`RecipientMatch`]: this never
@@ -725,7 +725,7 @@ pub enum DateTimeMatch {
 /// temporal enforcement. [OPUS-4.8] sq-idnv.
 ///
 /// Like [`purpose_status`] / [`recipient_status`], this does NOT re-implement
-/// matching: it runs the request through the SAME [`constraint_status`] every
+/// matching: it runs the request through the SAME `constraint_status` every
 /// `odrl:dateTime` constraint goes through inside [`evaluate`], so the verdict it
 /// reports is exactly what the evaluator acts on (no claimed enforcement that isn't
 /// actually checked — the whole point of the bead). The time evidence is the
@@ -783,7 +783,7 @@ pub fn datetime_status(rule: &Rule, request: &Request) -> DateTimeMatch {
 
 /// The three-valued verdict of a rule's `odrl:spatial` constraints against the spatial
 /// (region) evidence a request carries — a FAITHFUL report of exactly what [`evaluate`]
-/// checks for the location (it reuses the same [`constraint_status`] the evaluator's
+/// checks for the location (it reuses the same `constraint_status` the evaluator's
 /// `odrl:spatial` constraints go through). [OPUS-4.8] sq-wukl.
 ///
 /// The honesty contract mirrors [`PurposeMatch`] / [`RecipientMatch`] / [`DateTimeMatch`]:
@@ -823,7 +823,7 @@ pub enum SpatialMatch {
 /// enforcement. [OPUS-4.8] sq-wukl.
 ///
 /// Like [`purpose_status`] / [`recipient_status`] / [`datetime_status`], this does NOT
-/// re-implement matching: it runs the request through the SAME [`constraint_status`]
+/// re-implement matching: it runs the request through the SAME `constraint_status`
 /// every `odrl:spatial` constraint goes through inside [`evaluate`] (including the
 /// transitive `isPartOf` match over the request's supplied subsumption closure — see
 /// [`Request::with_purpose_subsumption`]), so the verdict it reports is exactly what the
@@ -1237,7 +1237,7 @@ fn order(a: &Value, b: &Value) -> Option<std::cmp::Ordering> {
 /// `2026-06-16T12:00:00Z` orders correctly (the offset form is *earlier*).
 ///
 /// Returns `None` when **either** operand is not a parseable instant — an order
-/// comparison against a malformed operand is undefined, and [`compare`] treats
+/// comparison against a malformed operand is undefined, and `compare` treats
 /// `None` as fail-closed (the constraint is not satisfied). This is the sq-qj2q
 /// fix for what was previously a raw `x.cmp(y)` lexical comparison.
 ///

--- a/crates/sparq-policy/src/model.rs
+++ b/crates/sparq-policy/src/model.rs
@@ -20,9 +20,9 @@ pub const ODRL_NS: &str = "http://www.w3.org/ns/odrl/2/";
 
 /// An ODRL policy: a container of deontic rules.
 ///
-/// A policy is evaluated as a whole against a single request: a [`Permission`]
+/// A policy is evaluated as a whole against a single request: a `Permission`
 /// whose action/target/constraints all match the request grants access, and any
-/// matching [`Prohibition`] overrides it (fail-closed — see
+/// matching `Prohibition` overrides it (fail-closed — see
 /// [`crate::evaluate`]).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Policy {

--- a/crates/sparq-prov/README.md
+++ b/crates/sparq-prov/README.md
@@ -65,7 +65,7 @@ let turtle  = d.prov_ntriples();    // …serialised (N-Triples ⊂ Turtle)
   `urn:sparq:prov:` nodes (same derivation ⇒ same IRIs); set `ProvConfig`
   `activity`/`entity`/`used`/`agent` to integrate with an external provenance
   store or named-graph scheme. The clock is injectable for deterministic tests.
-- **Reasoner-materialization lineage** (`reason` feature) — [`prov_from_proof`]
+- **Reasoner-materialization lineage** (`reason` feature) — `prov_from_proof`
   maps a `sparq-reason` `why()` proof tree to PROV-O: one `prov:Entity` per
   inferred fact, one `prov:Activity` per rule firing (labelled `cax-sco` /
   `rdfs9` / `prp-trp` / `n3-rule-i` / …), with `wasGeneratedBy` / `used` /

--- a/crates/sparq-prov/src/lib.rs
+++ b/crates/sparq-prov/src/lib.rs
@@ -31,16 +31,16 @@
 //! matched inputs), the triples it **deletes** are *invalidated*
 //! (`prov:wasInvalidatedBy`). [`derive_update`] applies the update in place, captures
 //! the engine's resolved effect log, and returns an [`UpdateDerivation`] carrying the
-//! inserted + deleted triples and the PROV-O lineage. See the [`update`] module.
+//! inserted + deleted triples and the PROV-O lineage. See the `update` module.
 //!
 //! **Reasoner-materialization** lineage is covered under the (non-default)
-//! `reason` feature: [`prov_from_proof`] maps a `sparq-reason` `why()`
-//! [`ProofTree`](sparq_reason::ProofTree) to PROV-O — one `prov:Entity` per
+//! `reason` feature: `prov_from_proof` maps a `sparq-reason` `why()`
+//! `ProofTree` to PROV-O — one `prov:Entity` per
 //! inferred fact, one `prov:Activity` per rule firing, with
 //! `wasGeneratedBy`/`used`/`wasDerivedFrom` edges. Inference *is* derivation, and
 //! the proof tree is a finer-grained provenance (it names the rule and exact
 //! premises for each fact) than a single CONSTRUCT-style activity. See the
-//! [`reason`] module.
+//! `reason` module.
 //!
 //! **Out of scope for per-triple lineage** (a deliberate honesty boundary, not a TODO):
 //! the structural UPDATE operations `CLEAR` / `DROP` / `CREATE` change a graph's

--- a/crates/sparq-prov/src/reason.rs
+++ b/crates/sparq-prov/src/reason.rs
@@ -14,7 +14,7 @@
 //! *finer-grained* derivation record than a single CONSTRUCT-style PROV activity:
 //! it names the rule that fired and the exact premises for **each** inferred fact.
 //!
-//! This module is the bridge. [`prov_from_proof`] walks one proof tree and emits,
+//! This module is the bridge. `prov_from_proof` walks one proof tree and emits,
 //! for the proof's structure:
 //!
 //! * one [`prov:Entity`] per distinct fact (the node's conclusion), with a stable

--- a/crates/sparq-py/src/lib.rs
+++ b/crates/sparq-py/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! A thin, allocation-conscious wrapper over the workspace's public APIs:
 //!
-//! * [`Graph`] wraps `sparq_core::Graph` (load / save / open / len).
+//! * `Graph` wraps `sparq_core::Graph` (load / save / open / len).
 //! * `Graph.query` / `Graph.query_json` / `Graph.ask` / `Graph.construct` /
 //!   `Graph.describe` call `sparq_engine` (all four query forms are native:
 //!   ASK early-exits, CONSTRUCT/DESCRIBE return term triples).

--- a/crates/sparq-reason/src/n3/mod.rs
+++ b/crates/sparq-reason/src/n3/mod.rs
@@ -22,7 +22,7 @@
 //!     logarithm, atan2 — `atan(x/y)` exactly like eye.pl) is always
 //!     xsd:double, with REVERSE modes (`?y math:sin 0` solves y = asin 0).
 //!   * `string:` concatenation (typed literals coerce to canonical value
-//!     strings, IRIs to their text, like cwm)/length/contains[IgnoringCase]/
+//!     strings, IRIs to their text, like cwm)/length/containsIgnoringCase/
 //!     containsRoughly/startsWith/endsWith/greaterThan/lessThan/notGreaterThan/
 //!     notLessThan/equalIgnoringCase/notEqualIgnoringCase/matches/notMatches/
 //!     replace/lowerCase/upperCase/scrape/format (%s %d %f %% subset — other
@@ -38,7 +38,7 @@
 //!     closure), parsedAsN3, langlit, uri and dtlit (both directions), and —
 //!     ONLY when the caller supplies a [`Resolver`] — semantics/content.
 //!
-//! `log:includes` containment is cwm-faithful ([`formula_containment`]): the
+//! `log:includes` containment is cwm-faithful (`formula_containment`): the
 //! scope is the subject formula (the empty formula includes nothing); pattern
 //! existentials (blanks, `@forSome`) are wildcards, pattern rule-variables
 //! bind, scope-side quantified terms are opaque constants (the
@@ -50,7 +50,7 @@
 //! Backward rules (`<=`, log:isImpliedBy) are GOAL-DIRECTED, matching EYE:
 //! they never fire forward; a forward-rule premise atom resolves against
 //! backward conclusions SLD-style (standardized apart, depth-bounded by
-//! [`BW_DEPTH`]), with structural unification through lists and quoted
+//! `BW_DEPTH`), with structural unification through lists and quoted
 //! formulae on both sides.
 //!
 //! Conclusion blank nodes are EXISTENTIALS instantiated fresh once per

--- a/crates/sparq-rsp/src/eval.rs
+++ b/crates/sparq-rsp/src/eval.rs
@@ -36,7 +36,7 @@ pub enum EvalMode {
     /// bounded amount of post-eviction churn triggers a COMPACTION pass that
     /// rebuilds the dictionary from only the still-live terms and atomically
     /// remaps the live window indexes onto the fresh dense ids (see
-    /// [`WindowEval::compact_dict`]). Bound: the dictionary stays O(distinct
+    /// `WindowEval::compact_dict`). Bound: the dictionary stays O(distinct
     /// terms across the live windows), not O(distinct terms over all time. So a
     /// long-running query over an unbounded vocabulary holds memory proportional
     /// to its window content, not its history.

--- a/crates/sparq-rsp/src/lib.rs
+++ b/crates/sparq-rsp/src/lib.rs
@@ -41,7 +41,7 @@
 //!   `max_ts − max_delay`). The whole pipeline is a pure function of the
 //!   pushed `(triple, ts)` sequence: deterministic, unit-testable, and
 //!   trivially embeddable under tokio / threads / wasm timers *by the caller*.
-//! * **Exact window semantics are documented** in [`window`] (boundary
+//! * **Exact window semantics are documented** in `window` (boundary
 //!   inclusivity, lateness, empty windows, gaps) and pinned by tests.
 //! * **Isolation:** nothing else in the workspace depends on this crate; the
 //!   core engine and the wasm build carry zero streaming code.

--- a/crates/sparq-rsp/src/query.rs
+++ b/crates/sparq-rsp/src/query.rs
@@ -67,7 +67,7 @@ pub enum R2S {
 pub struct WindowResult {
     /// Window bounds, as reported by the window operator: time windows are
     /// half-open `[start, end)`; count windows carry the inclusive
-    /// `[first.ts, last.ts]` of their content (see [`crate::window`]).
+    /// `[first.ts, last.ts]` of their content (see `crate::window`).
     pub start: u64,
     /// See `start`.
     pub end: u64,

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -296,7 +296,7 @@ chain of immutable store snapshots) plus the **single sequenced writer**
   reclaims from) readers; old generations are freed by ordinary `Arc` drop. Reader
   concurrency scales with cores; it is the throughput story (the bulk of real endpoint
   traffic is duplicate, cacheable, read-only queries — Bonifati et al., PVLDB 2017).
-- **Writers** submit through one sequenced [`Writer`]; each group-commit window
+- **Writers** submit through one sequenced `Writer`; each group-commit window
   publishes a batch as ONE new immutable generation. Serialisability is by
   construction (Calvin/Bohm collapsed to one node) — write skew is impossible, no SSI
   needed. `apply_update` blocks until the generation containing the update is

--- a/crates/sparq-server/src/access_audit.rs
+++ b/crates/sparq-server/src/access_audit.rs
@@ -3,11 +3,11 @@
 //! for a security / compliance audit trail. Maps to ASVS V7 (logging) / ISO 27001 A.8.15
 //! (logging) / CDMC CD-2 (access audit).
 //!
-//! This is the heavier sibling of the [`crate::audit`] module (`audit-log`). Where `audit-log`
+//! This is the heavier sibling of the `crate::audit` module (`audit-log`). Where `audit-log`
 //! emits a single flat `tracing` event per request (requester fingerprint, op class, query
 //! fingerprint, decision, status, duration) for operators who route a `tracing` target to a
 //! sink, THIS module emits a **typed, self-describing access RECORD** through a **pluggable
-//! sink trait** ([`AuditSink`]) — capturing more of the access-decision context that a
+//! sink trait** (`AuditSink`) — capturing more of the access-decision context that a
 //! compliance audit trail needs:
 //!
 //!   * **actor** — the authenticated subject (a WebID / agent IRI when known, else a Bearer
@@ -19,7 +19,7 @@
 //!     enforcement reason: the Bearer-auth gate, etc.),
 //!   * **timestamp** — RFC-3339-ish UTC wall-clock, plus a monotonic `duration_us`,
 //!   * a **request fingerprint** — the SAME FNV-1a construction the redaction / `audit-log`
-//!     fingerprints use ([`fingerprint`]), so an operator can correlate this record with the
+//!     fingerprints use (`fingerprint`), so an operator can correlate this record with the
 //!     `audit-log` trail and with redacted error logs.
 //!
 //! ## Opt-in, lean, zero-cost-when-off
@@ -40,7 +40,7 @@
 //! opt-in choice.
 //!
 //! What it **does NOT** record is query **CONTENT**. The query / update text is recorded only
-//! as its non-reversible [`fingerprint`] — never the raw SPARQL — because (per the #241
+//! as its non-reversible `fingerprint` — never the raw SPARQL — because (per the #241
 //! info-leak posture and the sq-toze.34 redaction work) a query body can itself carry PII (a
 //! patient IRI in a `FILTER`, an email literal) or disclose loaded-data fragments. The sink
 //! therefore does **not** double-log the content the redaction work just protected. The
@@ -50,7 +50,7 @@
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
-/// A 64-bit FNV-1a hash, hex-encoded — the SAME construction used by [`crate::audit`] and the
+/// A 64-bit FNV-1a hash, hex-encoded — the SAME construction used by `crate::audit` and the
 /// error-redaction fingerprints, so a fingerprint produced here correlates byte-for-byte with
 /// those trails. Fixed + dependency-free (not [`std::hash::DefaultHasher`], whose output is
 /// unspecified across builds), so the same input yields the same fingerprint in every process

--- a/crates/sparq-server/src/descriptors.rs
+++ b/crates/sparq-server/src/descriptors.rs
@@ -31,7 +31,7 @@
 //! ## Cost
 //!
 //! Generating the VoID/SD scans the snapshot (the same cost as a `?s ?p ?o` dump plus the
-//! per-class/predicate aggregation [`Introspection::build`] already does). It is therefore a
+//! per-class/predicate aggregation `Introspection::build` already does). It is therefore a
 //! request-time scan, not amortised — appropriate for an occasionally-polled discovery
 //! endpoint, and another reason it is opt-in rather than always-on.
 
@@ -264,7 +264,7 @@ pub fn named_graph_descriptions(graph: &Graph) -> Vec<NamedGraphDesc> {
 ///
 /// The SD advertises: the endpoint, `sd:Service` typing, the supported query language(s)
 /// (`sd:SPARQL11Query`, plus `sd:SPARQL11Update` when [`Capabilities::update`]), the supported
-/// result + input RDF formats ([`SD_RESULT_FORMATS`] / [`SD_INPUT_FORMATS`]), the federated-query
+/// result + input RDF formats (`SD_RESULT_FORMATS` / `SD_INPUT_FORMATS`), the federated-query
 /// feature when compiled in, the registered extension functions, and the default dataset — its
 /// default graph (linked to the VoID dataset IRI) plus an `sd:namedGraph` enumeration of every
 /// IRI-named graph.

--- a/crates/sparq-server/src/health_probe.rs
+++ b/crates/sparq-server/src/health_probe.rs
@@ -13,8 +13,8 @@
 //! `net` + `io-util`, already in the `server` feature stack), and it works inside distroless
 //! because the probe *is* the shipped binary.
 //!
-//! The HTTP-response classification ([`probe_healthy`]) is pure and unit-tested; the async
-//! [`run_probe`] is the thin TCP wrapper around it.
+//! The HTTP-response classification (`probe_healthy`) is pure and unit-tested; the async
+//! `run_probe` is the thin TCP wrapper around it.
 
 use std::time::Duration;
 
@@ -36,7 +36,7 @@ pub const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 /// `Content-Length`. `Host` is required by some routers even on 1.0; loopback is fine here.
 ///
 /// Only built when the async probe (`server` feature) is, or under `cfg(test)` for the
-/// request-shape unit test; the pure [`probe_healthy`] classifier needs no request builder.
+/// request-shape unit test; the pure `probe_healthy` classifier needs no request builder.
 #[cfg(any(feature = "server", test))]
 fn probe_request(host: &str) -> String {
     format!("GET /health HTTP/1.0\r\nHost: {host}\r\nConnection: close\r\n\r\n")

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -80,7 +80,7 @@ pub(crate) fn with_extensions<T>(f: impl FnOnce() -> T) -> T {
 /// the SERVICE egress allowlist policy AND the SPARQL extension functions.
 ///
 /// With the `service` cargo feature, this installs
-/// [`sparq_engine::with_service_egress_policy`] in STRICT (allowlist-only) mode for the
+/// `sparq_engine::with_service_egress_policy` in STRICT (allowlist-only) mode for the
 /// config's [`ServerConfig::service_allow`]: SERVICE may reach ONLY allowlisted hosts —
 /// an empty allowlist (the default) refuses ALL federation before any network call.
 /// Every engine entry point that can evaluate a `SERVICE` clause (query, ASK,
@@ -146,14 +146,14 @@ pub struct ServerConfig {
     /// time a freshly-accepted HTTP/1 connection may take to transmit its COMPLETE request-header
     /// block. A client that dribbles headers byte-by-byte (the classic slow-loris) otherwise holds
     /// a connection — and, behind the `concurrency_limit`, a concurrency slot — open indefinitely;
-    /// [`max_concurrent`] such clients starve every legitimate caller. Enforced at hyper's HTTP/1
+    /// `max_concurrent` such clients starve every legitimate caller. Enforced at hyper's HTTP/1
     /// connection layer (`http1().header_read_timeout`), so it fires BEFORE the request ever
-    /// reaches a handler — which is exactly why the existing [`query_timeout`] (a per-request
-    /// engine deadline) and the [`max_body_bytes`] / load-shed guards do NOT cover it: those all
+    /// reaches a handler — which is exactly why the existing `query_timeout` (a per-request
+    /// engine deadline) and the `max_body_bytes` / load-shed guards do NOT cover it: those all
     /// run AFTER the headers are fully parsed. The connection is closed when the deadline elapses.
     ///
     /// `None` disables it (back to the unbounded-header-read behaviour `axum::serve` ships — see
-    /// the rationale on [`serve`]). Default 15s. Distinct from the slower [`query_timeout`] (30s)
+    /// the rationale on [`serve`]). Default 15s. Distinct from the slower `query_timeout` (30s)
     /// because reading a header block is sub-second on any healthy client; 15s is generous
     /// headroom for a slow but honest network without leaving the slot open for minutes.
     pub header_read_timeout: Option<Duration>,
@@ -204,7 +204,7 @@ pub struct ServerConfig {
     /// (the default) disables it. For the byte-accounted companion that DOES price row
     /// width and computed-literal size, see [`max_query_bytes`](Self::max_query_bytes).
     ///
-    /// Distinct from [`max_results`]: this caps the working set on *all* forms, whereas
+    /// Distinct from `max_results`: this caps the working set on *all* forms, whereas
     /// `max_results` is folded into the budget only on the paths that pass
     /// `make_budget(_, true)` — SELECT (the final projection) AND CONSTRUCT/DESCRIBE (their
     /// WHERE-pattern solution count) AND EXPLAIN ANALYZE. It is NOT applied on the
@@ -292,7 +292,7 @@ pub struct ServerConfig {
     /// essentially zero. Set by `--audit-log` / `SPARQ_AUDIT_LOG=1`. Present only with the
     /// `audit-log` cargo feature; without it the field, the flag and every call site are
     /// compiled out, so a request pays EXACTLY zero (byte-identical to before). See
-    /// [`crate::audit`].
+    /// `crate::audit`.
     #[cfg(feature = "audit-log")]
     pub audit_log: bool,
     /// [OPUS-4.8] (sq-gos8, epic sq-toze) **Richer STRUCTURED access-audit sink** target (ASVS
@@ -354,7 +354,7 @@ pub struct ServerConfig {
     /// through the query path — classification there keys on whether the request mutates, not
     /// the route) — and the Graph-Store-Protocol write methods (`PUT`/`POST`/`DELETE`/`PATCH`) on
     /// `/sparql/graph` and `/graphs/{*path}`. The token is compared in **constant time**
-    /// ([`constant_time_eq`]). A missing vs a wrong token produce the *identical* 401, so an
+    /// (`constant_time_eq`). A missing vs a wrong token produce the *identical* 401, so an
     /// attacker cannot learn whether a token was presented. `None` (the default) means **no
     /// write auth** — today's behaviour, preserved exactly. Mirrors QLever's `-a <token>`.
     /// Enforced by the library `router` itself, so an embedder gets the gate for free.
@@ -371,7 +371,7 @@ pub struct ServerConfig {
     /// open. The SSE GET reads the `Authorization: Bearer` header like any other GET; the WS
     /// UPGRADE accepts the token from that header OR (for browsers, which cannot set headers on a
     /// WS handshake) a `Sec-WebSocket-Protocol: bearer.<token>` subprotocol — see
-    /// [`crate::subscriptions::subscriptions_endpoint`] and [`ws_auth_gate`].
+    /// [`crate::subscriptions::subscriptions_endpoint`] and `ws_auth_gate`.
     pub auth_token_read: bool,
     /// [OPUS-4.8] (sq-4w18) SERVICE federation egress allowlist. SPARQL `SERVICE <iri>`
     /// makes attacker-controlled query text trigger an outbound HTTP request from the
@@ -382,7 +382,7 @@ pub struct ServerConfig {
     /// `SPARQ_SERVICE_ALLOW` (see [`crate::ServiceAllowlist`]); only listed hosts (or
     /// `*.suffix` matches) become reachable — even a public host must be listed.
     ///
-    /// Enforced by installing [`sparq_engine::with_service_egress_policy`] (strict =
+    /// Enforced by installing `sparq_engine::with_service_egress_policy` (strict =
     /// allowlist-only) around every engine call. Without the `service` cargo feature
     /// this field is still present (so the config shape is stable) but inert: no
     /// federation code is compiled and a SERVICE clause errors at execution as before.
@@ -1207,7 +1207,7 @@ pub(crate) const TIMEOUT_GRACE: Duration = Duration::from_secs(2);
 /// A request's pinned generation: holding this `Arc` keeps the generation's immutable
 /// snapshot alive no matter how far the writer publishes past it. Pinned ONCE per
 /// request and kept for the lifetime of response production (streamed bodies included —
-/// see [`chunked_response`]), so every response is snapshot-consistent with its start.
+/// see `chunked_response`), so every response is snapshot-consistent with its start.
 pub type PinnedGen = Arc<Generation<Graph>>;
 
 /// The catch-all pod: the visibility scope every query implicitly reads, and the
@@ -1220,7 +1220,7 @@ pub type PinnedGen = Arc<Generation<Graph>>;
 /// statically knowable from the parsed update. A correct cache MUST therefore record
 /// this pod's epoch on every entry, so a global bump invalidates all cached reads. Writes
 /// that DO name a finite set of graphs additionally bump those graphs' per-named-graph
-/// pods (see [`touched_pods`]), so a cache keyed on finer-than-global pods is invalidated
+/// pods (see `touched_pods`), so a cache keyed on finer-than-global pods is invalidated
 /// too — finer scoping is purely additive over this catch-all, never a replacement for it.
 ///
 /// Public so a cache layer (and the update tests) can record/compare this catch-all pod's
@@ -1680,7 +1680,7 @@ impl AppState {
     /// the `graph` seed is SAVED there and then re-opened so it carries a WAL. The ring is then
     /// seeded from the durable graph's snapshot, and the writer's applier mirrors every
     /// committed batch back to the durable graph (WAL-durable before publish — see
-    /// [`ServerApplier::seal`]). With `persist_dir == None` this is exactly the historical
+    /// `ServerApplier::seal`). With `persist_dir == None` this is exactly the historical
     /// in-memory path (the ring is seeded from `graph`; no durable mirror; never errors).
     pub fn try_with_config(graph: Graph, config: ServerConfig) -> Result<Self, String> {
         Self::try_with_config_inner(

--- a/crates/sparq-server/src/metrics.rs
+++ b/crates/sparq-server/src/metrics.rs
@@ -2,7 +2,7 @@
 //! no metrics crate, no extra dependencies.
 //!
 //! Counters are wired in at exactly two points: an outermost middleware
-//! ([`track`], applied *around* the hardening stack so shed/over-limit
+//! (`track`, applied *around* the hardening stack so shed/over-limit
 //! responses are counted with their real status) records per-endpoint/status
 //! request counts and the `/sparql` latency histogram; the update handler bumps
 //! `sparq_updates_total`. The two gauges (graph triples, active subscriptions)

--- a/crates/sparq-server/src/redact.rs
+++ b/crates/sparq-server/src/redact.rs
@@ -13,7 +13,7 @@
 //! a privacy / PII exposure distinct from, and complementary to, the #241 / sq-kfel
 //! *error-body* sanitisation (which governs what a CLIENT sees on an error).
 //!
-//! This is the same lesson the audit log ([`crate::audit`]) already applies to its records: it
+//! This is the same lesson the audit log (`crate::audit`) already applies to its records: it
 //! logs a non-reversible *fingerprint* of the query, never the text. Redaction extends that
 //! discipline to the `--verbose` request log.
 //!
@@ -24,7 +24,7 @@
 //! length and a stable non-reversible fingerprint of the original — `?<redacted len=N
 //! fp=xxxxxxxxxxxxxxxx>` — so logs stay useful for correlation (same query => same `fp`; a size
 //! signal from `len`) **without exposing the content**. The path is left intact (it is a route,
-//! not user content). When redaction is off ([`--log-full-requests`] / `SPARQ_LOG_FULL_REQUESTS`
+//! not user content). When redaction is off (`--log-full-requests` / `SPARQ_LOG_FULL_REQUESTS`
 //! truthy), the URI is logged verbatim, exactly as the bare `TraceLayer` did before — the escape
 //! hatch for operators who deliberately want full request text in a debug session.
 //!
@@ -37,7 +37,7 @@
 //! *this* time, and (via `fp`) that the same query recurred. That is metadata, and it is not
 //! erased here. This is also NOT the ZK/MPC privacy story (which concerns what a *remote party*
 //! can learn from a *computation*); it is purely operator-log hygiene. The fingerprint is the
-//! same FNV-1a construction the audit log uses ([`crate::audit::query_fingerprint`]) — fixed,
+//! same FNV-1a construction the audit log uses (`crate::audit::query_fingerprint`) — fixed,
 //! one-way, dependency-free, stable across builds and restarts.
 
 /// A 64-bit FNV-1a hash, hex-encoded. Kept independent of the (feature-gated) audit module so

--- a/crates/sparq-server/src/service_config.rs
+++ b/crates/sparq-server/src/service_config.rs
@@ -21,7 +21,7 @@
 //! This is STRICTER than the engine's standalone default (which allows public IPs
 //! and only blocks private/internal ones): on the server, a host must be on the
 //! allowlist to be reached *at all*, even a public one. The strictness is wired via
-//! [`sparq_engine::with_service_egress_policy`] with `strict = true`.
+//! `sparq_engine::with_service_egress_policy` with `strict = true`.
 //!
 //! ## Allowlist syntax
 //!
@@ -79,7 +79,7 @@ impl ServiceAllowlist {
     /// apex-and-subdomain suffix wildcard, not arbitrary globs).
     ///
     /// [OPUS-4.8] sq-4w18: exact-host entries are NORMALISED to the bare host the
-    /// engine actually compares against (see [`Self::normalize_host`]), so a copy-
+    /// engine actually compares against (see `Self::normalize_host`), so a copy-
     /// pasted endpoint like `example.org:443` or a bracketed IPv6 `[::1]` matches
     /// instead of silently never matching (which would make the allowlist look
     /// configured but be inert — a fail-open footgun).
@@ -207,7 +207,7 @@ impl ServiceAllowlist {
 
     /// The entries in the engine's allowlist representation: exact hosts verbatim,
     /// suffix wildcards as leading-dot strings (`.example.org`). Fed to
-    /// [`sparq_engine::with_service_egress_policy`].
+    /// `sparq_engine::with_service_egress_policy`.
     pub fn engine_entries(&self) -> Vec<String> {
         self.exact.iter().chain(self.suffix.iter()).cloned().collect()
     }

--- a/crates/sparq-server/src/subscriptions.rs
+++ b/crates/sparq-server/src/subscriptions.rs
@@ -141,7 +141,7 @@ impl Drop for ConnSlots {
 /// `Authorization` header on a WS handshake, the token is accepted from EITHER the
 /// `Authorization: Bearer <token>` header (non-browser clients) OR a
 /// `Sec-WebSocket-Protocol: bearer.<token>` subprotocol (browsers) — see
-/// [`crate::http::ws_auth_gate`]. When a `bearer.<token>` subprotocol is present and accepted, it
+/// `crate::http::ws_auth_gate`. When a `bearer.<token>` subprotocol is present and accepted, it
 /// is echoed back as the selected subprotocol (RFC 6455 requires the server to confirm one of the
 /// client's offered subprotocols, or a browser rejects the handshake). When no read token is
 /// configured the upgrade is unchanged (open access) — back-compatible.
@@ -685,10 +685,10 @@ async fn send(socket: &mut WebSocket, msg: &Value) -> Result<(), axum::Error> {
 
 /// SSE (`text/event-stream`) transport for SPARQL update subscriptions, ALONGSIDE the
 /// WebSocket `/subscriptions` endpoint. Both transports share ONE notification source —
-/// [`subscribe_init`] (register + initial result) and [`Subscription::reevaluate_step`]
+/// `subscribe_init` (register + initial result) and `Subscription::reevaluate_step`
 /// (re-evaluate + diff), driven by the same commit-generation `watch` channel
-/// ([`AppState::subscribe_commits`]) and the same global/per-connection slot accounting
-/// ([`ConnSlots`]). Only the wire framing differs: SSE emits `event:`/`data:`/`id:` frames
+/// (`AppState::subscribe_commits`) and the same global/per-connection slot accounting
+/// (`ConnSlots`). Only the wire framing differs: SSE emits `event:`/`data:`/`id:` frames
 /// instead of WebSocket JSON text frames.
 ///
 /// Because SSE is a one-way GET stream (no client→server channel after the request),
@@ -696,7 +696,7 @@ async fn send(socket: &mut WebSocket, msg: &Value) -> Result<(), axum::Error> {
 /// optional `alias`) query-string parameters — the natural REST shape, versus the WS
 /// path's multiplexed many-subscriptions-per-socket protocol. There is no `unsubscribe`
 /// frame: a client unsubscribes by closing the stream, which drops the per-stream state
-/// (releasing its global slot via [`ConnSlots`]'s `Drop`) with no leak.
+/// (releasing its global slot via `ConnSlots`'s `Drop`) with no leak.
 pub mod sse {
     use std::collections::HashMap;
 
@@ -738,18 +738,18 @@ pub mod sse {
     /// Auth ([OPUS-4.8] sq-cxk5): this is a READ surface (live SELECT diffs), so it mirrors the
     /// WebSocket `/subscriptions` path AND the other `/sparql` GET routes — when
     /// `--auth-token-read` is configured the GET is gated behind the read token via
-    /// [`crate::http::auth_gate`] ([`crate::http::Operation::Read`]) and refused with the SAME
+    /// `crate::http::auth_gate` (`crate::http::Operation::Read`) and refused with the SAME
     /// 401 BEFORE the event-stream opens. As a plain GET, the `Authorization: Bearer <token>`
     /// header is the only auth channel here (no WS subprotocol). When no read token is configured
     /// the GET is unchanged (open access) — back-compatible.
     ///
     /// A registration refusal is returned as a normal JSON HTTP error BEFORE the event-stream
     /// opens — SSE cannot set a status once the stream is flowing — classified to match the
-    /// `/sparql` endpoint ([`crate::http::engine_error_response`]): missing/non-SELECT/malformed
+    /// `/sparql` endpoint (`crate::http::engine_error_response`): missing/non-SELECT/malformed
     /// query → **400**; the initial evaluation over the row cap (`--max-results` /
     /// `--max-query-rows`) → **413**; the initial evaluation timing out, or subscription-slot
     /// exhaustion → **503**; any other engine error → **500**. The status is carried on the
-    /// [`super::Refusal`]. On success the response is `text/event-stream` and the first two
+    /// `super::Refusal`. On success the response is `text/event-stream` and the first two
     /// frames are the `subscribed` ack and the full initial result.
     pub async fn sse_endpoint(State(state): State<AppState>, headers: axum::http::HeaderMap, Query(params): Query<HashMap<String, String>>) -> Response {
         // [OPUS-4.8] sq-cxk5: gate the read surface behind the read token (fail-closed when

--- a/crates/sparq-server/src/tpf.rs
+++ b/crates/sparq-server/src/tpf.rs
@@ -13,7 +13,7 @@
 //! ## What this module is
 //!
 //! A PURE (no async, no HTTP types) builder — like [`crate::graph`] / [`crate::descriptors`] —
-//! that, given a parsed triple pattern, a pinned [`Graph`] snapshot and a page number,
+//! that, given a parsed triple pattern, a pinned `Graph` snapshot and a page number,
 //! produces the response **triples** (the page of data triples + the Hydra metadata/control
 //! triples) ready for the crate's existing graph serialisers ([`crate::graph::triples_to_turtle`]
 //! / [`triples_to_ntriples`](crate::graph::triples_to_ntriples)). The async handler that wires
@@ -26,7 +26,7 @@
 //! The three positions come from the `subject` / `predicate` / `object` query parameters, each
 //! an **N-Triples term** (`<iri>`, `"lit"`, `"lit"@en`, `"lit"^^<dt>`); an absent or empty
 //! parameter is a *variable* (unbound). The pattern resolves through the public
-//! [`Graph::pattern`] dictionary lookup, then:
+//! `Graph::pattern` dictionary lookup, then:
 //!
 //!   * `hydra:totalItems` (and the void:triples count on the metadata node) is the engine's
 //!     **cardinality ESTIMATE** for the pattern ([`sparq_core::store::TripleStore::estimate`]) —
@@ -62,7 +62,7 @@
 //! This mirrors the `federation-descriptors` double-opt-in exactly. A build without the feature
 //! pays ZERO cost — no route, no new dependency, byte-identical to before — and
 //! `sparq-core`/`sparq-engine` are untouched (this reads a pinned `&Graph` snapshot through the
-//! existing public [`Graph::pattern`] / `store.estimate` / `store.scan` / `dict.term` API).
+//! existing public `Graph::pattern` / `store.estimate` / `store.scan` / `dict.term` API).
 //!
 //! It is a **READ-only** source interface — there is no write path.
 
@@ -214,7 +214,7 @@ impl Fragment {
 /// Evaluates `pattern` against the pinned `graph` snapshot, returning the [`Fragment`] for
 /// (zero-based) `page` with `page_size` data triples.
 ///
-/// The cardinality estimate is the cheap index-range count ([`store.estimate`]); the page
+/// The cardinality estimate is the cheap index-range count (`store.estimate`); the page
 /// scans only its `[page*page_size, …)` window and resolves that window's ids back to terms.
 /// A bound term absent from the dictionary makes the pattern unmatchable: estimate 0, empty
 /// page, no index work.

--- a/crates/sparq-shacl/src/model.rs
+++ b/crates/sparq-shacl/src/model.rs
@@ -109,11 +109,11 @@ pub enum Component {
     /// key).
     UniqueValuesFor(Vec<String>),
     /// sh:sparql — a SPARQL-based constraint (SHACL §5.2). The index is into
-    /// [`ShapesModel::sparql`].
+    /// `ShapesModel::sparql`.
     Sparql(usize),
     /// [OPUS-4.8] A SPARQL-based constraint COMPONENT (SHACL §6) that activated on
     /// this shape because the shape uses the component's parameter predicates.
-    /// `component` indexes [`ShapesModel::components`]; `args` are the bound
+    /// `component` indexes `ShapesModel::components`; `args` are the bound
     /// parameter values, parallel to the component's `parameters` (one term each
     /// — the first object found for a mandatory parameter; `None` for an absent
     /// optional one). The validator pre-binds each as `$paramName`.
@@ -124,7 +124,7 @@ pub enum Component {
     /// [OPUS-4.8] (sq-mk9n, `shacl-af`) `sh:expression` — the SHACL-AF
     /// *Expression Constraint* (`sh:ExpressionConstraintComponent`): a value node
     /// `v` is violated when the node expression does NOT evaluate to `{ true }`
-    /// for `v` as focus. The index is into [`ShapesModel::expressions`] (the
+    /// for `v` as focus. The index is into `ShapesModel::expressions` (the
     /// parsed node expression is held there, off the public `Component` enum).
     #[cfg(feature = "shacl-af")]
     Expression(usize),
@@ -134,7 +134,7 @@ pub enum Component {
     /// focus to a set of node-shape terms `s`; `v` is violated when it does NOT
     /// conform to some `s`. (Like `sh:node`, but the shape is computed by the
     /// expression rather than fixed.) The index is into
-    /// [`ShapesModel::expressions`] (shared store with `sh:expression`).
+    /// `ShapesModel::expressions` (shared store with `sh:expression`).
     #[cfg(feature = "shacl-af")]
     NodeByExpression(usize),
 }

--- a/crates/sparq-shacl/src/rules.rs
+++ b/crates/sparq-shacl/src/rules.rs
@@ -25,7 +25,7 @@
 //!
 //! `sh:subject`/`sh:predicate`/`sh:object` (TripleRule) and `sh:values` (value
 //! rule) take **node expressions**, evaluated against a focus node `$this` to a
-//! set of nodes. The full algebra is implemented ([`NodeExpr`]):
+//! set of nodes. The full algebra is implemented (`NodeExpr`):
 //!
 //!   * **focus** — the IRI `sh:this` ⇒ `{ $this }`.
 //!   * **constant** — any other IRI / literal ⇒ `{ term }`.
@@ -534,7 +534,7 @@ pub fn expand(data: &Graph, shapes: &Graph) -> Graph {
 /// not declared in the shapes graph) — the caller can treat that as "skip".
 ///
 /// This is the production public seam onto the implemented algebra
-/// ([focus][sh:this] / constant / path-with-`sh:nodes` / `sh:filterShape` /
+/// (focus / constant / path-with-`sh:nodes` / `sh:filterShape` /
 /// `sh:intersection` / `sh:union`): it is the same `parse_node_expr` →
 /// `NodeExpr::eval` machinery that backs `apply_rules`' `sh:values` rules, and is
 /// exercised by this crate's `#[cfg(test)]` unit tests (via `apply_rules` for the

--- a/crates/sparq-text-wasm/src/lib.rs
+++ b/crates/sparq-text-wasm/src/lib.rs
@@ -8,7 +8,7 @@
 //! BM25-ranked literals; `text:matches` / `text:score` SELECT).
 //!
 //! Every method is a stateless one-shot — it parses the supplied document, builds the
-//! [`TextIndex`](sparq_text::TextIndex) over it, runs the request, and returns a string —
+//! [`TextIndex`] over it, runs the request, and returns a string —
 //! so the JS side never holds a long-lived index handle. The bundle ALWAYS builds the
 //! index with positions ([`TextIndex::build_with_positions`]) so the positional
 //! predicates (`text:phrase` / `text:near`) work alongside the BM25 ones; a tiny demo

--- a/crates/sparq-text/src/index.rs
+++ b/crates/sparq-text/src/index.rs
@@ -40,7 +40,7 @@
 //! positions are stored — every existing caller is byte-for-byte unchanged.
 //! Positions are **opt-in**: [`TextIndex::build_with_positions`] (or
 //! [`TextIndex::with_positions`] for the empty/delta-fed case) turns on a
-//! SEPARATE parallel structure ([`positions`](TextIndex::positions)) recording,
+//! SEPARATE parallel structure (`positions`) recording,
 //! for each (token, doc), the token's 0-based offsets within that document. The
 //! BM25 tables and the single-/multi-term [`search`](TextIndex::search) path are
 //! identical either way; only the extra map is allocated, so the cheap default

--- a/crates/sparq-text/src/lib.rs
+++ b/crates/sparq-text/src/lib.rs
@@ -54,7 +54,7 @@ pub mod vocab {
     pub const MATCHES_ANY: &str = "http://sparq.dev/text#matchesAny";
     /// `?lit text:phrase "foo bar"` — literals where the query's tokens appear
     /// ADJACENT and IN ORDER (a positional phrase match, not a BM25 ranking).
-    /// Requires a positions-enabled index ([`TextIndex::build_with_positions`]);
+    /// Requires a positions-enabled index (`TextIndex::build_with_positions`);
     /// the cheap default index stores no positions and is rejected at rewrite
     /// time. No `text:score` companion (a phrase match is boolean adjacency).
     /// [OPUS-4.8]
@@ -67,7 +67,7 @@ pub mod vocab {
     /// the same subject variable in the same basic graph pattern. Unlike
     /// `text:phrase` (boolean adjacency) it IS scored, so it also takes an
     /// optional `text:score ?s` companion. Requires a positions-enabled index
-    /// ([`TextIndex::build_with_positions`]); `text:near "foo bar"` at slop 0 is
+    /// (`TextIndex::build_with_positions`); `text:near "foo bar"` at slop 0 is
     /// exactly `text:phrase "foo bar"`. [OPUS-4.8]
     pub const NEAR: &str = "http://sparq.dev/text#near";
     /// `?lit text:slop N` — sets the proximity gap budget for the `text:near`

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -131,7 +131,7 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
 
 The default build opens no sockets. To embed against a real OpenAI-compatible
 `/v1/embeddings` endpoint without writing any HTTP glue, enable the **non-default**
-`embeddings` feature (it pulls in a blocking [`reqwest`] client; the default build does not):
+`embeddings` feature (it pulls in a blocking `reqwest` client; the default build does not):
 
 ```toml
 sparq-vectors = { path = "../sparq-vectors", features = ["embeddings"] }

--- a/crates/sparq-vectors/src/ann.rs
+++ b/crates/sparq-vectors/src/ann.rs
@@ -1,5 +1,5 @@
 //! Nearest-neighbour search over a [`VectorStore`]: an exact brute-force baseline and
-//! an HNSW index ([`instant-distance`], pure Rust).
+//! an HNSW index (`instant-distance`, pure Rust).
 //!
 //! Similarity is **cosine** throughout. The HNSW index stores L2-normalized copies of
 //! the vectors and searches with Euclidean distance, which is rank-equivalent to cosine
@@ -13,7 +13,7 @@
 //! throughput table). Out-of-core persistent ANN (DiskANN-style) is the recorded
 //! follow-up for 10M+ stores.
 //!
-//! [OPUS-4.8] (sq-ip3a) **The HNSW index ([`VectorIndex`]) is gated behind the opt-in
+//! [OPUS-4.8] (sq-ip3a) **The HNSW index (`VectorIndex`) is gated behind the opt-in
 //! `approx-ann` feature** — it is the only thing here that pulls the third-party
 //! `instant-distance` crate, so with `approx-ann` OFF the default build carries the exact
 //! brute-force searchers ([`nearest_exact`], [`nearest_term_exact`]) and NO heavy ANN
@@ -62,7 +62,7 @@ pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
 /// baseline the HNSW recall gate measures against, and a fine default below ~10⁵
 /// vectors. Ties break on ascending id, so results are deterministic. An all-zero
 /// `query` has no direction (cosine is undefined), so it returns no results — stored
-/// vectors are never zero ([`VectorStore::put`] rejects them), and [`VectorIndex`]
+/// vectors are never zero ([`VectorStore::put`] rejects them), and `VectorIndex`
 /// treats a zero query the same way, so exact and HNSW agree on the degenerate case.
 pub fn nearest_exact(store: &VectorStore, query: &[f32], k: usize) -> Vec<(Id, f32)> {
     if query.iter().all(|&v| v == 0.0) {

--- a/crates/sparq-vectors/src/backend.rs
+++ b/crates/sparq-vectors/src/backend.rs
@@ -4,7 +4,7 @@
 //! sq-7hx6 ([`crate::cost`]) settled the *exact*-scan filtered story: post-filtering a **complete**
 //! cosine ranking can never under-fill `k` (it sees every admitted vector), so there is no
 //! over-fetch boundary for the exact backend. This module is where the **approximate** backend
-//! bites — and it bites exactly as sq-7hx6's [`overfetch_target`](crate::cost::overfetch_target)
+//! bites — and it bites exactly as sq-7hx6's [`overfetch_target`]
 //! docs warned it would.
 //!
 //! # The backend trait
@@ -12,9 +12,9 @@
 //! [`AnnBackend`] is the seam the filtered path searches *through*: a backend returns a ranked
 //! `(Id, cosine)` candidate list of a requested `fetch` size, best-first. Two impls:
 //!
-//! - **[`ExactBackend`]** (default, no third-party dep) — wraps [`nearest_exact`]. `fetch` ≥ the
+//! - **[`ExactBackend`]** (default, no third-party dep) — wraps `nearest_exact`. `fetch` ≥ the
 //!   store size yields the *complete* ranking, so it is **answer-exact**; recall is `1.0`.
-//! - **[`ApproxBackend`]** (`approx-ann`, wraps the on-disk [`DiskAnnIndex`] Vamana graph; the
+//! - **[`ApproxBackend`]** (`approx-ann`, wraps the on-disk `DiskAnnIndex` Vamana graph; the
 //!   in-RAM HNSW [`VectorIndex`](crate::VectorIndex) is an equally valid impl) — returns a
 //!   *bounded, approximate* candidate list. Recall is **`< 1.0`** by construction: an approximate
 //!   index can miss true neighbours. We never claim exactness for it; the recall floor is a
@@ -24,7 +24,7 @@
 //!
 //! Post-filtering a *bounded* approximate candidate list can **under-fill `k`**: if the top
 //! `fetch` candidates contain fewer than `k` ids the mask admits, the result is short even though
-//! the store holds `≥ k` admitted vectors. [`overfetch_target`](crate::cost::overfetch_target)
+//! the store holds `≥ k` admitted vectors. [`overfetch_target`]
 //! sizes a *first* fetch at `ceil(k / selectivity)` — enough *on average* — but the admitted ids
 //! can cluster *below* that prefix, so a single sized fetch still under-fills (the recall boundary
 //! sq-7hx6 documented).

--- a/crates/sparq-vectors/src/cost.rs
+++ b/crates/sparq-vectors/src/cost.rs
@@ -1,5 +1,5 @@
 //! [OPUS-4.8] (sq-7hx6, epic sq-3183) **Filtered-ANN pre-filter vs post-filter cost model** —
-//! deciding when materialising a transitive [`IdMask`](crate::filter::IdMask) and pre-filtering
+//! deciding when materialising a transitive [`IdMask`] and pre-filtering
 //! the search is worth it, versus running the search unfiltered and dropping the disallowed hits
 //! afterwards.
 //!

--- a/crates/sparq-vectors/src/diskann.rs
+++ b/crates/sparq-vectors/src/diskann.rs
@@ -6,7 +6,7 @@
 //!
 //! # Why a second index
 //!
-//! [`VectorIndex`](crate::ann::VectorIndex) wraps `instant-distance`'s HNSW, which is rebuilt
+//! `VectorIndex` wraps `instant-distance`'s HNSW, which is rebuilt
 //! from the mmap'd store on every open (~33 s release for 50k×32 on an M1 — see the README
 //! throughput table). `instant-distance` is a closed graph: its adjacency is not exposed, so
 //! it cannot be laid out on disk. This index is therefore **self-contained** — we build the
@@ -409,7 +409,7 @@ fn write_graph(b: &Builder, path: &Path, fingerprint: Option<Fingerprint>) -> Re
 // ───────────────────────────── on-disk search ─────────────────────────────
 
 /// A **persistent on-disk Vamana index** opened over a `.spqg` file (memory-mapped) — the
-/// out-of-core counterpart to [`VectorIndex`](crate::ann::VectorIndex). Built once with
+/// out-of-core counterpart to `VectorIndex`. Built once with
 /// [`build`](Self::build) / [`build_with`](Self::build_with), reopened with [`open`](Self::open)
 /// at near-zero cost (mmap + header validation, no rebuild). Search reads node records directly
 /// from the map; see the module docs for the format and the honest scope vs. full DiskANN.
@@ -726,7 +726,7 @@ impl DiskAnnIndex {
     /// a *very selective* mask is served by an exact **pre-filter** scan over just the masked ids
     /// (cheaper and exact than touching the whole graph), a *broad* mask by **filtered traversal**
     /// of the Vamana graph. Both honour the mask; see the [`filter`](crate::filter) module docs and
-    /// `tests/filtered.rs` for the measured recall. Uses [`FilterConfig::default`]; for a custom
+    /// `tests/filtered.rs` for the measured recall. Uses `FilterConfig::default`; for a custom
     /// threshold/beam use [`nearest_filtered_with`](Self::nearest_filtered_with).
     ///
     /// An empty mask returns no results (the BGP matched nothing); an all-zero query returns no
@@ -776,7 +776,7 @@ impl DiskAnnIndex {
 
     /// Approximate top-`k` ids by cosine similarity to `query`, best first. An all-zero
     /// `query` returns no results (same contract as [`nearest_exact`](crate::ann::nearest_exact)
-    /// and [`VectorIndex::nearest`](crate::ann::VectorIndex::nearest)).
+    /// and `VectorIndex::nearest`).
     pub fn nearest(&self, query: &[f32], k: usize) -> Vec<(Id, f32)> {
         assert_eq!(query.len(), self.dim, "query dim {} != index dim {}", query.len(), self.dim);
         let Some(q) = normalized(query) else { return Vec::new() };
@@ -789,7 +789,7 @@ impl DiskAnnIndex {
     /// Approximate top-`k` neighbours of `term`: resolves it through the graph's dictionary,
     /// looks its vector up in `store`, excludes the term itself and maps neighbour ids back to
     /// [`Term`]s. Empty if the term is absent or unembedded. Mirrors
-    /// [`VectorIndex::nearest_term`](crate::ann::VectorIndex::nearest_term).
+    /// `VectorIndex::nearest_term`.
     ///
     /// [OPUS-4.8] (sq-32i5) This does NOT verify the index/store match `graph` — pass a graph
     /// whose ids have shifted since build and the results are silently WRONG. Use

--- a/crates/sparq-vectors/src/fingerprint.rs
+++ b/crates/sparq-vectors/src/fingerprint.rs
@@ -19,7 +19,7 @@
 //!   1. **`dict_len`** — `graph.dict.len()`, the number of real dictionary terms. O(1).
 //!   2. **`triple_count`** — `graph.len()`, the number of triples in the default graph. O(1).
 //!   3. **`content_hash`** — a 64-bit hash that folds, **in ascending id order**, every dictionary
-//!      term's content (its [`TermParts`](sparq_core::dict::TermParts) — IRI prefix+suffix, literal
+//!      term's content (its [`TermParts`] — IRI prefix+suffix, literal
 //!      value+datatype+lang, blank label, or a triple term's three child ids). This directly
 //!      captures the **id → term binding**: if any id maps to a different term (the exact failure
 //!      mode of a dict-id shift), the sequence of folded writes changes and the hash changes. The
@@ -49,7 +49,7 @@ pub const FINGERPRINT_LEN: usize = 24;
 /// id-ordered dictionary terms. See the module docs for the exact inputs and rationale.
 ///
 /// [OPUS-4.8] (sq-36ol) Derives `Hash` so a fingerprint can key a per-graph cache (the
-/// filtered-ANN `IdMask` cache in [`crate::rewrite`]): two graphs with the same fingerprint
+/// filtered-ANN `IdMask` cache in `crate::rewrite`): two graphs with the same fingerprint
 /// are treated as the same graph for caching, and any mutation that could change a derived
 /// mask changes the fingerprint (and thus the key), so a stale mask is never served.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/crates/sparq-vectors/src/fuse.rs
+++ b/crates/sparq-vectors/src/fuse.rs
@@ -3,7 +3,7 @@
 //! similarity — without this crate depending on the other.
 //!
 //! Both helpers take plain ranked `(item, score)` lists (best first), so any producer
-//! works: [`VectorIndex::nearest_term`](crate::VectorIndex::nearest_term) cosine,
+//! works: `VectorIndex::nearest_term` cosine,
 //! `sparq_sim::Sim::most_similar` weighted Jaccard, a lexical/BM25 list, …
 //!
 //! Which to use (industry conventions distilled in
@@ -21,7 +21,7 @@
 //! for [`hybrid_search`], which drives N retriever closures off one query `Term` and
 //! fuses their ranked `Term` lists by [`fuse_rrf`], deduplicating by `Term`:
 //!
-//! [OPUS-4.8] (sq-ip3a) `ignore`d, not `no_run`: it references the HNSW [`VectorIndex`], which is
+//! [OPUS-4.8] (sq-ip3a) `ignore`d, not `no_run`: it references the HNSW `VectorIndex`, which is
 //! gated behind the opt-in `approx-ann` feature, so this illustration must not be compiled in the
 //! default doctest build. The executed RRF example below carries no ANN dependency.
 //!

--- a/crates/sparq-vectors/src/labels.rs
+++ b/crates/sparq-vectors/src/labels.rs
@@ -1,12 +1,12 @@
 //! Label-only embedding — the back-compat special case of the verbalization layer in
-//! [`crate::verbalize`].
+//! [`crate::verbalize()`].
 //!
 //! [`embed_labels`] embeds **one human-readable label per entity** (by predicate
 //! priority) and nothing else. That is enough for lexical lookup, but production KG
 //! systems embed a richer *passage* per entity (label + type + description + selected
 //! literals — see `research/genai-text-embedding-practices.md`); use
-//! [`embed_entities`](crate::embed_entities) with an
-//! [`EntityTextConfig`](crate::EntityTextConfig) for that. Both helpers share the same
+//! [`embed_entities`] with an
+//! [`EntityTextConfig`] for that. Both helpers share the same
 //! engine: predicate index-block scans for candidates (no full-graph scan), batched
 //! embedding, vectors keyed by dictionary id.
 

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -24,7 +24,7 @@ pub mod rewrite;
 pub mod store;
 pub mod verbalize;
 
-/// The `vec:` vocabulary — magic predicates recognised by [`rewrite`]
+/// The `vec:` vocabulary — magic predicates recognised by `rewrite`
 /// (`http://sparq.dev/vec#`, the sparq extension namespace). [OPUS-4.8] (sq-k6ex)
 pub mod vocab {
     /// `vec:` — the sparq vector-search namespace.

--- a/crates/sparq-vectors/src/store.rs
+++ b/crates/sparq-vectors/src/store.rs
@@ -430,7 +430,7 @@ impl VectorStore {
     ///
     /// Call this once after [`open`](Self::open) (it is O(dict_len), not per-query) before issuing
     /// `get`/`nearest_term` against `graph`. The term-by-query entry points
-    /// ([`crate::ann::nearest_term_exact_checked`], [`DiskAnnIndex::nearest_term_checked`]) run it.
+    /// ([`crate::ann::nearest_term_exact_checked`], `DiskAnnIndex::nearest_term_checked`) run it.
     pub fn check_graph(&self, graph: &Graph) -> fingerprint::CheckResult {
         let origin = if self.path.as_os_str().is_empty() {
             "<bytes>".to_string()

--- a/crates/sparq-wasm/src/lib.rs
+++ b/crates/sparq-wasm/src/lib.rs
@@ -150,7 +150,7 @@ impl Store {
     /// separate sub-graphs, so `GRAPH <iri> { … }` / `GRAPH ?g { … }` patterns,
     /// `FROM` / `FROM NAMED` dataset clauses, and SPARQL Updates with `GRAPH`
     /// blocks (including `CLEAR GRAPH` / `DROP GRAPH`) all see the dataset.
-    /// Formats without named graphs ("turtle" / "ntriples") load as [`load`].
+    /// Formats without named graphs ("turtle" / "ntriples") load as [`load`](Self::load).
     /// [`size`](Self::size) / [`heapBytes`](Self::heap_bytes) report the DEFAULT
     /// graph only (count the dataset with `GRAPH ?g` queries).
     #[wasm_bindgen(js_name = loadDataset)]

--- a/crates/sparq-zk-compose/src/derivation.rs
+++ b/crates/sparq-zk-compose/src/derivation.rs
@@ -7,9 +7,9 @@
 //! checked it, so a manifest could claim `Rdfs`/`Owl` while the proof attested only
 //! the asserted triples (`Simple` semantics). A relying party reading the regime
 //! field would believe inference was applied when nothing established it. This
-//! module + the verifier's [`crate::verifier::bind_entailment`] make the regime
+//! module + the verifier's `crate::verifier::bind_entailment` make the regime
 //! ENFORCED:
-//! - the relying party declares which regimes it accepts ([`EntailmentPolicy`]);
+//! - the relying party declares which regimes it accepts (`EntailmentPolicy`);
 //! - a regime the policy does not accept REJECTS (fail-closed);
 //! - a non-`Simple` regime REQUIRES `derivation_steps` that STRUCTURALLY justify
 //!   every derived triple against the regime's rule set, re-checked verifier-side.
@@ -85,7 +85,7 @@ pub fn regime_admits(regime: EntailmentRegime, rule: EntailmentRule) -> bool {
 /// same `FieldHex` the scan sub-proofs disclose), so the verifier can tie an
 /// antecedent to a disclosed scan row by encoding-equality.
 ///
-/// The verifier re-checks (see [`crate::verifier::bind_entailment`]):
+/// The verifier re-checks (see `crate::verifier::bind_entailment`):
 /// 1. the step is well-formed for its rule (arity + the rule's variable-sharing
 ///    shape — [`Self::is_well_formed`]);
 /// 2. its regime admits the rule ([`regime_admits`]);

--- a/crates/sparq-zk-compose/src/lib.rs
+++ b/crates/sparq-zk-compose/src/lib.rs
@@ -7,7 +7,7 @@
 //! query-result proof, and verifies one (plan v3 §S4.E modules ii/iii).
 //!
 //! Pipeline:
-//! 1. [`build`] turns sparq-zk [`GraphCommitment`]s + a BGP pattern into a
+//! 1. [`build`] turns sparq-zk `GraphCommitment`s + a BGP pattern into a
 //!    scan [`ProofInputs`], deriving the (k, n, r) [`CircuitId`] from the data.
 //! 2. [`driver::CircuitProver`] proves it via nargo/bb subprocesses.
 //! 3. A [`ProofManifest`] carries the public inputs + bb proof to the verifier.

--- a/crates/sparq-zk-compose/src/manifest.rs
+++ b/crates/sparq-zk-compose/src/manifest.rs
@@ -92,7 +92,7 @@ pub enum BindingMode {
     /// Holder proof-of-possession (sq-cwq): the holder demonstrates possession of
     /// its holder secret key by signing the verifier's `challenge` (its nonce).
     ///
-    /// # Verifier contract (fail-closed) — see [`crate::verifier::bind_holder_pop`]
+    /// # Verifier contract (fail-closed) — see `crate::verifier::bind_holder_pop`
     /// The verifier requires (a) `holder` to be a member of an EXTERNAL
     /// relying-party holder registry ([`crate::verifier::HolderRegistry`], the
     /// trust anchor — mirrors the issuer key-set `K`), and (b) `pop` to be a valid
@@ -581,7 +581,7 @@ pub enum CircuitId {
     /// witness, and the membership index/path are PRIVATE, so the proof proves
     /// "this commitment was signed by SOME key in K" without disclosing WHICH
     /// issuer. The privacy upgrade over the clear-key
-    /// [`crate::verifier::bind_issuer_attestations`] check.
+    /// `crate::verifier::bind_issuer_attestations` check.
     // [OPUS-4.8] sq-z9l: hidden-issuer-attestation circuit member.
     HiddenIssuer { depth: u32 },
     /// `holder_pok` — in-circuit holder Proof-of-Possession (sq-xqfg, HolderPoP
@@ -591,7 +591,7 @@ pub enum CircuitId {
     /// "I possess the holder secret whose key the issuer bound into this
     /// credential" without disclosing the secret OR the key. The relation is
     /// `hpk = hsk·G` (Baby-JubJub, ONE scalar-mul — cheaper than the
-    /// [`HiddenIssuer`] Schnorr's two) AND
+    /// `HiddenIssuer` Schnorr's two) AND
     /// `Poseidon2([ZKSIG_HK, hpk.x, hpk.y]) == holder_pk_digest`, reusing
     /// `issuer.nr`'s scalar-mul / on-curve / `< L` gadgets verbatim. A single
     /// depth-free member (no Merkle parameterisation — the clear-digest tier).
@@ -610,8 +610,8 @@ pub enum CircuitId {
     /// Poseidon2 Merkle membership of the holder-key DIGEST
     /// `Poseidon2([ZKSIG_HK, hpk.x, hpk.y])`, reusing `holder.nr`'s `holder_pok`
     /// gadgets + `issuer.nr`'s Merkle-fold pattern verbatim. The hidden-holder
-    /// analogue of [`HiddenIssuer`] (which hides WHICH issuer); the privacy upgrade
-    /// over the clear-digest [`HolderPok`] member (which makes `holder_pk_digest`
+    /// analogue of `HiddenIssuer` (which hides WHICH issuer); the privacy upgrade
+    /// over the clear-digest `HolderPok` member (which makes `holder_pk_digest`
     /// public). The verifier gate that binds `holder_set_root` to the relying
     /// party's authoritative holder registry is `bind_holder_set`, SEPARATE from
     /// this member registration.
@@ -691,7 +691,7 @@ pub enum ProofInputs {
         /// Per-graph source attribution (length k): `attribution[g]` is true
         /// iff this pattern's match set draws a triple from committed graph `g`.
         /// Constrained in-circuit (`scan.nr` step 4, audit #8) and byte-bound
-        /// into the bb public inputs by [`crate::verifier::reconstruct_public_inputs`],
+        /// into the bb public inputs by `crate::verifier::reconstruct_public_inputs`,
         /// so it is PROOF-BOUND, not a prover-controlled claim. The verifier
         /// cross-checks it against `manifest.attributions` for the pattern this
         /// scan answers (closes the `[[0],[0]]` collapse-two-graphs forge).
@@ -978,7 +978,7 @@ pub struct ProofManifest {
     pub entailment_regime: EntailmentRegime,
     /// The recorded inference steps that justify any DERIVED triples under a
     /// non-`Simple` `entailment_regime` (sq-314). EMPTY for `Simple` (no
-    /// inference). For `Rdfs`/`Owl` the verifier ([`crate::verifier::bind_entailment`])
+    /// inference). For `Rdfs`/`Owl` the verifier (`crate::verifier::bind_entailment`)
     /// re-checks every step is a well-formed, regime-admitted rule instance whose
     /// antecedents are GROUNDED (chain to an earlier step or to a disclosed scan
     /// row) — so the regime claim is enforced, not free metadata. A non-`Simple`
@@ -1030,21 +1030,21 @@ pub struct ProofManifest {
     /// trust anchor is preserved) and runs `bb verify` — so the holder's list slot
     /// is never disclosed. The clear `RevocationStatus.index`/snapshot path remains
     /// the interim check; this field is the additive privacy layer. See
-    /// [`crate::verifier::bind_hidden_revocation`].
+    /// `crate::verifier::bind_hidden_revocation`.
     // [OPUS-4.8] sq-3e5 + sq-h2v: hidden-index revocation proof (privacy upgrade).
     #[serde(default)]
     pub hidden_revocation: Option<HiddenIndexRevocation>,
     /// OPTIONAL hidden-issuer attestation proofs (sq-z9l): zero-knowledge proofs
     /// that scan-covering commitments were each signed by SOME issuer whose key is
     /// in the committed key set K, WITHOUT disclosing which issuer. The privacy
-    /// upgrade over the clear-key [`crate::verifier::bind_issuer_attestations`]
+    /// upgrade over the clear-key `crate::verifier::bind_issuer_attestations`
     /// check. When the policy enables the path (`KeySet::with_hidden_issuer_depth`)
     /// and an entry is present for a commitment, the verifier checks the proof's
     /// PUBLIC `key_set_root` equals the root it derives from its OWN authoritative
     /// KeySet and `message` equals the recomputed issuer-signed message, then runs
     /// `bb verify` — so WHICH authority vouched for the holder is never disclosed.
     /// The clear-key path remains the interim/always-on check; this is the additive
-    /// privacy layer. See [`crate::verifier::bind_hidden_issuer_attestations`].
+    /// privacy layer. See `crate::verifier::bind_hidden_issuer_attestations`.
     // [OPUS-4.8] sq-z9l: hidden-issuer attestation proofs (privacy upgrade).
     #[serde(default)]
     pub hidden_issuer_attestations: Vec<HiddenIssuerAttestation>,
@@ -1053,7 +1053,7 @@ pub struct ProofManifest {
     /// the holder secret whose public key hashes to the issuer-attested
     /// `holder_pk_digest` of the credential covering [`HolderPokProof::commitment`]
     /// — WITHOUT disclosing the holder key. The verifier
-    /// ([`crate::verifier::bind_holder_pok`]) binds the proof's public digest to the
+    /// (`crate::verifier::bind_holder_pok`) binds the proof's public digest to the
     /// ISSUER-SIGNED digest (the binding edge: the digest must verify under the
     /// external trusted `K` over [`sparq_zk::sig::commitment_message_with_holder`]),
     /// reconstructs the public inputs from its own nonce + that digest, and `bb
@@ -1078,7 +1078,7 @@ pub struct ProofManifest {
     /// holder key OR which holder. The hidden-holder analogue of the clear-digest
     /// [`HolderPokProof`] (which makes `holder_pk_digest` public), the holder twin
     /// of [`HiddenIssuerAttestation`] (which hides WHICH issuer). The verifier
-    /// ([`crate::verifier::bind_holder_set`]) binds the proof's PUBLIC
+    /// (`crate::verifier::bind_holder_set`) binds the proof's PUBLIC
     /// `holder_set_root` to the root it derives from its OWN authoritative holder
     /// registry (the trust anchor; WHICH holder is hidden, the trust source is
     /// not), reconstructs the public inputs from its own nonce + that root, and `bb
@@ -1148,7 +1148,7 @@ pub struct HiddenIndexRevocation {
 /// the relying party's own trust anchor, exactly as the clear-key path is — the
 /// only thing hidden is WHICH key (the deanonymising channel), never the trust
 /// source. The privacy upgrade over the clear-key
-/// [`crate::verifier::bind_issuer_attestations`] check.
+/// `crate::verifier::bind_issuer_attestations` check.
 ///
 /// `m` is the issuer-signed commitment message the proof binds. In v1 this is the
 /// status-bound `commitment_message_with_status(C(G), salt, status_ref)` (the
@@ -1202,13 +1202,13 @@ pub struct HiddenIssuerAttestation {
 /// holder_pk_digest` — WITHOUT disclosing `hsk` OR `hpk` (only the digest is
 /// public). The hidden-key analogue of the clear-key
 /// [`BindingMode::HolderPop`]+[`AttestedHolderBinding`] path
-/// ([`crate::verifier::bind_holder_binding`], T3/sq-z8s7 B1): there the presenter
+/// (`crate::verifier::bind_holder_binding`, T3/sq-z8s7 B1): there the presenter
 /// discloses `hpk` and the verifier recomputes the digest host-side; here `hpk`
 /// stays private and possession is proved in zero knowledge.
 ///
 /// # The binding edge (the load-bearing tie — sq-c2ql)
 /// `holder_pk_digest` is the proof's PUBLIC input, but it is NOT trusted as a
-/// prover claim. The verifier ([`crate::verifier::bind_holder_pok`]) reads the
+/// prover claim. The verifier (`crate::verifier::bind_holder_pok`) reads the
 /// digest from the ISSUER-ATTESTED [`AttestedHolderBinding::holder_pk_digest`] on
 /// the attestation COVERING this credential's scan-referenced `commitment`, and —
 /// crucially — anchors that digest in the issuer's Schnorr signature (it must
@@ -1269,7 +1269,7 @@ pub struct HolderPokProof {
 ///
 /// # Trust anchor (mirrors the hidden-issuer external-K anchor — load-bearing)
 /// `holder_set_root` is a PUBLIC input the prover commits, but it is NOT trusted as
-/// a prover claim: the verifier ([`crate::verifier::bind_holder_set`]) recomputes
+/// a prover claim: the verifier (`crate::verifier::bind_holder_set`) recomputes
 /// the authoritative root from its OWN [`crate::verifier::HolderRegistry`]
 /// (canonical order) at `depth` and rejects unless the proof's public
 /// `holder_set_root` byte-equals it. So the "in the set" fact is bound to the

--- a/crates/sparq-zk-compose/src/revocation.rs
+++ b/crates/sparq-zk-compose/src/revocation.rs
@@ -31,11 +31,11 @@
 //! the tree is dominated by all-ZERO subtrees in the covered region and all-ONE
 //! subtrees in the fail-closed padding region past the bitstring. We cache the
 //! "all-zeros subtree root" and "all-ones subtree root" at every height
-//! ([`SubtreeDefaults`]) and recurse only into the `O(S)` subtrees that actually
+//! (`SubtreeDefaults`) and recurse only into the `O(S)` subtrees that actually
 //! contain a set bit or straddle the covered/padding boundary. Cost is
 //! `O(S * depth + depth)` host work and `O(S * depth)` memory — INDEPENDENT of
 //! `2^depth` — so production depths (StatusList2021 lists are commonly 2^17+) are
-//! supported WITHOUT the old dense `O(2^depth)` full-size builder ([`dense_merkle_root`],
+//! supported WITHOUT the old dense `O(2^depth)` full-size builder (`dense_merkle_root`,
 //! retained only as the cross-check oracle).
 //!
 //! The root is BIT-IDENTICAL to the dense fold (same Poseidon2 `h2`, same leaf
@@ -192,12 +192,12 @@ fn any_bit_set(snapshot: &StatusListSnapshot, lo: u64, hi: u64) -> bool {
 /// (the trust anchor the proof's public root is checked against) and what the
 /// PROVER computes over the list it holds.
 ///
-/// [OPUS-4.8] sq-hwe: computed by the SPARSE builder ([`sparse_subtree_root`]) —
+/// [OPUS-4.8] sq-hwe: computed by the SPARSE builder (`sparse_subtree_root`) —
 /// `O(S * depth + depth)` host work / `O(S * depth)` memory for `S` set bits,
 /// INDEPENDENT of `2^depth`, so production depths (2^17+) are supported without a
 /// dense full-size builder. The result is BIT-IDENTICAL to the dense fold (same
 /// `h2`, same leaf layout, same fail-closed padding); cross-checked against
-/// [`dense_merkle_root`] in the unit tests.
+/// `dense_merkle_root` in the unit tests.
 ///
 /// Returns `None` if `depth` is implausibly large (`> 31`, i.e. more than ~2^31
 /// leaves) — a guard so a hostile/buggy `depth` cannot trigger an astronomical
@@ -257,7 +257,7 @@ pub struct MerkleWitness {
 ///
 /// [OPUS-4.8] sq-hwe: SPARSE. The sibling at level `k` is the root of the
 /// height-`k` subtree hanging off the OTHER side of the path node at that level;
-/// each is computed by [`sparse_subtree_root`] (which short-circuits uniform
+/// each is computed by `sparse_subtree_root` (which short-circuits uniform
 /// subtrees against the precomputed defaults), so the whole authentication path is
 /// `O(depth^2)` worst case but `O(depth)` for the common case where the siblings
 /// are uniform subtrees — and, crucially, NEVER materialises `2^depth` leaves. The

--- a/crates/sparq-zk-compose/src/verifier.rs
+++ b/crates/sparq-zk-compose/src/verifier.rs
@@ -40,7 +40,7 @@
 //!   public-input field vector from the DECLARED [`ProofInputs`] (in `main`
 //!   declaration order) using the verifier's own challenge, serialize to
 //!   bb's byte layout (32-byte BE field elements, no header — see
-//!   [`reconstruct_public_inputs`]), and assert byte-equality with the
+//!   `reconstruct_public_inputs`), and assert byte-equality with the
 //!   prover's `public_inputs` blob. This binds the JSON statement to the
 //!   proof; without it stages 1-2 (JSON) and the proof (a detached crypto
 //!   object) describe potentially different statements.
@@ -78,7 +78,7 @@
 //!    commitment to the index), the clear index is WITHHELD, and liveness is
 //!    checked by the hidden-index proof cross-bound to that commitment (so neither
 //!    the index nor the bit is disclosed). The clear-index path above is unchanged
-//!    for clear references. See [`bind_revocation`] / [`bind_hidden_revocation`].
+//!    for clear references. See `bind_revocation` / `bind_hidden_revocation`.
 //!
 //! 4. **Freshness / single-use (audit #4).** [`verify_manifest`] takes a
 //!    VERIFIER-ISSUED fresh [`VerifierNonce`] (minted out of band, handed to the
@@ -154,7 +154,7 @@ use std::path::Path;
 /// (the structural pre-filter). The accept decision then
 /// depends only on this external set; `manifest.key_set`, if present at all, is
 /// only accepted when it is a SUBSET of this external set (checked, never
-/// trusted as the anchor) — see [`bind_issuer_attestations`].
+/// trusted as the anchor) — see `bind_issuer_attestations`.
 ///
 /// Keys are stored in normalized hex form (no `0x`, lowercase) and validated as
 /// parseable, non-identity Baby-JubJub points at construction (an unparseable or
@@ -291,7 +291,7 @@ impl KeySet {
 /// Membership here means "this holder key is authorised to present" — it does NOT
 /// bind the key to a SPECIFIC credential. Issuer-attested credential↔holder
 /// binding (the issuer signing the holder key into the credential) is deferred;
-/// see [`bind_holder_pop`]. Keys are stored normalized (no `0x`, lowercase) and
+/// see `bind_holder_pop`. Keys are stored normalized (no `0x`, lowercase) and
 /// validated as parseable, non-identity Baby-JubJub points at construction
 /// (unparseable/identity entries dropped fail-closed).
 // [OPUS-4.8] sq-cwq: external holder trust anchor (mirrors KeySet).
@@ -430,11 +430,11 @@ impl HolderRegistry {
 /// # Tiers
 /// - **B1 (clear-key, T3/sq-z8s7):** the presented holder key is DISCLOSED
 ///   ([`BindingMode::HolderPop`]) and the verifier recomputes its digest host-side
-///   ([`bind_holder_binding`]), governed by [`Self::require_binding`].
+///   (`bind_holder_binding`), governed by [`Self::require_binding`].
 /// - **B2 (hidden-key in-circuit PoK, T6/sq-c2ql):** only the issuer-attested
 ///   `holder_pk_digest` is public; the holder proves possession of the matching
 ///   secret IN ZERO KNOWLEDGE ([`crate::manifest::HolderPokProof`], verified by
-///   [`bind_holder_pok`]). Opt in with [`Self::require_in_circuit_pok`]. This is the
+///   `bind_holder_pok`). Opt in with [`Self::require_in_circuit_pok`]. This is the
 ///   NOT-yet-sound (sq-qhy4) hidden-holder tier — see `bind_holder_pok`.
 // [OPUS-4.8] sq-z8s7 (HolderPoP T3 / B1): holder-binding policy (external,
 // fail-closed bearer rejection; default back-compatible). Mirrors RevocationPolicy
@@ -504,7 +504,7 @@ impl HolderBindingPolicy {
 
 /// The relying party's ENTAILMENT-REGIME policy (sq-314): which entailment regimes
 /// it will accept a manifest under. The verifier enforces this fail-closed
-/// ([`bind_entailment`]) so `manifest.entailment_regime` is no longer free
+/// (`bind_entailment`) so `manifest.entailment_regime` is no longer free
 /// metadata.
 ///
 /// # Default = `Simple`-only (fail-closed)
@@ -514,7 +514,7 @@ impl HolderBindingPolicy {
 /// in explicitly with [`EntailmentPolicy::with_rdfs`] / [`EntailmentPolicy::with_owl`];
 /// when it does, the verifier additionally requires the manifest's
 /// `derivation_steps` to STRUCTURALLY ground every derived triple (see
-/// [`bind_entailment`] + the `derivation` module). A regime the policy does not
+/// `bind_entailment` + the `derivation` module). A regime the policy does not
 /// accept REJECTS.
 ///
 /// # Honest scope
@@ -885,7 +885,7 @@ impl SeenNonces for InMemorySeenNonces {
 ///
 /// `flock(LOCK_EX)` serialises step 1–3 across ALL processes that opened the SAME
 /// path on the SAME machine, so two concurrent verifiers cannot both observe one
-/// nonce as fresh (the check-and-append is atomic). An in-process [`Mutex`] also
+/// nonce as fresh (the check-and-append is atomic). An in-process `Mutex` also
 /// guards the fd so threads in one process can't interleave the seek/read/append.
 ///
 /// # Honest scope — reference impl, not a clustered DB

--- a/crates/sparq-zk/src/ingest.rs
+++ b/crates/sparq-zk/src/ingest.rs
@@ -132,7 +132,7 @@ impl SaltMint {
     /// folds them into a field element, and redraws on the (negligible) chance
     /// the same salt was already issued. Fails closed ([`IngestError::SaltExhausted`])
     /// only if the entropy source is broken (no fresh value in
-    /// [`MAX_MINT_REDRAWS`] tries).
+    /// `MAX_MINT_REDRAWS` tries).
     pub fn mint(&mut self) -> Result<Fr, IngestError> {
         for _ in 0..MAX_MINT_REDRAWS {
             let mut bytes = [0u8; 32];

--- a/crates/sparq-zk/src/poseidon2.rs
+++ b/crates/sparq-zk/src/poseidon2.rs
@@ -6,7 +6,7 @@
 //!    `acvm-repo/bn254_blackbox_solver/src/poseidon2.rs` — the solver behind
 //!    Noir's `std::hash::poseidon2_permutation` blackbox (itself matching the
 //!    Barretenberg crypto module). t = 4, R_F = 8, R_P = 56, x^5 S-box;
-//!    constants vendored in [`crate::poseidon2_constants`].
+//!    constants vendored in `crate::poseidon2_constants`.
 //! 2. **Sponge** (`hash`): ported from noir-lang/poseidon `src/poseidon2.nr`
 //!    (`Poseidon2::hash`): rate 3, capacity initialised to
 //!    `len * 2^64`, absorb in chunks of 3, squeeze one element.

--- a/crates/sparq-zk/src/sig.rs
+++ b/crates/sparq-zk/src/sig.rs
@@ -58,7 +58,7 @@
 //! tracked as a follow-up bead.
 //!
 //! What sq-8jv7 *did* change is the secret-dependent control flow **in code we
-//! own**: [`derive_nonce`]'s degenerate-`k` guard is now branchless (always
+//! own**: `derive_nonce`'s degenerate-`k` guard is now branchless (always
 //! computes the re-fold candidate and `subtle`-selects it), so our own emitted
 //! control flow is data-independent of the secret nonce. We do **not** claim
 //! this makes signing constant-time — the arkworks residual dominates.
@@ -349,9 +349,9 @@ fn derive_nonce(sk: &SecretKey, m: &Fr) -> JjScalar {
 }
 
 /// Sign `m` with `sk` using a DETERMINISTIC nonce derived from `(sk, m)` (no
-/// entropy source, no caller seed — see [`derive_nonce`]). This is the
+/// entropy source, no caller seed — see `derive_nonce`). This is the
 /// issuance-side path used by [`SecretKey::sign_commitment`]; a relying party
-/// only ever calls [`verify`]. Equivalent in shape to [`sign`] but with the
+/// only ever calls [`verify`]. Equivalent in shape to `sign` but with the
 /// nonce pinned, so it is replay-stable and seed-reuse-proof.
 //
 // # Constant-time posture (CR-G5 / sq-8jv7) [OPUS-4.8]

--- a/crates/sparq-zk/src/verify.rs
+++ b/crates/sparq-zk/src/verify.rs
@@ -223,7 +223,7 @@ impl FilterCmp {
 /// constant operand parsed from the literal. Only the integer-FILTER fragment
 /// the `filter_int` circuit supports is extracted; any other FILTER shape
 /// (float, string, arithmetic, `?a op ?b`, `IN`, …) makes the query fall
-/// outside the bindable fragment and is rejected by [`collect_filters`].
+/// outside the bindable fragment and is rejected by `collect_filters`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryFilter {
     /// The variable the FILTER constrains (its operand column).


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. I am one of several agents @jeswr runs on this account.

## What

Implements **sq-8gsv**: widens the lint-job rustdoc `-D warnings` gate from the per-crate `sparq-solid` (sq-z1rm) / `sparq-mpc` (sq-h1w2) scope to the **whole workspace**, and clears the ~174 pre-existing rustdoc intra-doc-link warnings across ~20 crates that previously blocked a workspace-wide gate.

A broken/private intra-doc link — a public item linking to a crate-private `const`/`fn`, or an unresolved `` [`Foo`] `` that silently renders as literal text — is a **rustdoc** warning, *not* a clippy/build warning. It slipped past every other gate and mis-rendered the published docs. The widened gate now covers the entire doc surface, in **both feature states** (default and `--all-features`), so any new public item that links to a private/unresolved one fails CI.

## How (all fixes are doc-comment / README only)

- **Unresolved + private-item intra-doc links** → demoted to plain code spans: `` [`X`] `` → `` `X` ``.
- **Redundant explicit link targets** → dropped the explicit path: `` [`X`](crate::mod::X) `` → `` [`X`] ``.
- **CLI-usage angle-bracket tokens** (`<data-file>` etc.) → wrapped in backticks so they aren't parsed as unclosed HTML tags.
- **`crate::verbalize` fn/module ambiguity** → disambiguated to the function form.

Heaviest crates fixed: `sparq-zk-compose` (35), `sparq-server` (24+), `sparq-core` (20), `sparq-vectors` (17), `sparq-policy` (14), plus feature-gated surfaces in `sparq-fedclient`, `sparq-hdt`, `sparq-shacl`, `sparq-prov` (the `reason` bridge), and others.

## Scope / honesty

- **No Rust code, no public API, no test, no privacy/soundness claim changed** — verified every `.rs` hunk touches only doc-comment (`//!` / `///`) lines; ZK/MPC/policy prose and predicate-form descriptions are byte-identical apart from the link brackets. The G2 public-API→SKILL.md rule does not apply.
- The widened gate immediately caught two *new* broken links (`probe_healthy` / `run_probe`) introduced on `main` after this branch forked — fixed here, demonstrating the gate working as intended.

## Verification

Both exit `0` (the exact commands the new CI steps run):

- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`

[OPUS-4.8]

🤖 Generated with [Claude Code](https://claude.com/claude-code)