### PR TITLE
bench(rung5): SPARQ_SPOT spot-launch path + record the on-demand/IAM blocker for the 1B dict-bucket re-measure (sq-3l43) [OPUS-4.8]

### DIFF
--- a/hwrun/rung5-launch.sh
+++ b/hwrun/rung5-launch.sh
@@ -98,19 +98,37 @@ SG_ID=$(aws ec2 create-security-group --region "$REGION" --group-name "$KEY_NAME
   --query 'GroupId' --output text)
 aws ec2 authorize-security-group-ingress --region "$REGION" --group-id "$SG_ID" --protocol tcp --port 22 --cidr "${MYIP}/32" >/dev/null
 
-echo "== RUNG 5: launch on-demand $ITYPE (deadman +${DEADMAN}m, 400 GB gp3) =="
+# [OPUS-4.8 sq-3l43] MARKET selection. The original 2026-06-11 run launched ON-DEMAND
+# and fit the 16-vCPU L-1216C47A Standard bucket because only the 2-vCPU prod t3.large
+# was running. Since 2026-06-13 the 8-vCPU r7g.2xlarge agent dev box (`sparq-dev-claude`,
+# the box this orchestrator itself runs on — NEVER terminate it) also occupies that
+# bucket: 2 + 8 = 10 used, so a fresh 8-vCPU r7i.2xlarge (=18) trips VcpuLimitExceeded.
+# SPOT requests draw on a SEPARATE quota bucket (L-34B43A08 "All Standard Spot Instance
+# Requests"), so SPARQ_SPOT=1 unblocks the re-measurement without any on-demand quota
+# bump and at ~$0.21/h (cheaper than the ~$0.61/h on-demand). The 12-min build tolerates
+# the low spot-interruption risk; one-time + interrupt=terminate keeps it self-cleaning,
+# and the dead-man `shutdown -h +DEADMAN` + cleanup trap still apply unchanged.
+MARKET="${SPARQ_SPOT:+spot}"; MARKET="${MARKET:-on-demand}"
+echo "== RUNG 5: launch $MARKET $ITYPE (deadman +${DEADMAN}m, 400 GB gp3) =="
 # plain text: AWS CLI v2 base64-encodes --user-data itself
 printf '#!/bin/bash\nshutdown -h +%s\n' "$DEADMAN" > "$WORK/udata.txt"
+MARKET_OPTS=()
+if [ "$MARKET" = "spot" ]; then
+  # one-time spot, terminate (not stop/hibernate) on interruption so the cleanup contract
+  # — and the gp3 DeleteOnTermination — hold even if AWS reclaims the box mid-build.
+  MARKET_OPTS=(--instance-market-options '{"MarketType":"spot","SpotOptions":{"SpotInstanceType":"one-time","InstanceInterruptionBehavior":"terminate"}}')
+fi
 INSTANCE_ID=$(aws ec2 run-instances --region "$REGION" --image-id "$AMI" --instance-type "$ITYPE" \
   --key-name "$KEY_NAME" --security-group-ids "$SG_ID" --subnet-id "$SUBNET1" --associate-public-ip-address \
   --user-data "file://$WORK/udata.txt" \
   --instance-initiated-shutdown-behavior terminate \
+  "${MARKET_OPTS[@]}" \
   --block-device-mappings '[{"DeviceName":"/dev/sda1","Ebs":{"VolumeSize":400,"VolumeType":"gp3","Throughput":500,"Iops":6000,"DeleteOnTermination":true}}]' \
   --tag-specifications 'ResourceType=instance,Tags=[{Key=purpose,Value=sparq-hw-validation},{Key=Name,Value=sparq-hw-validation-rung5}]' \
   --query 'Instances[0].InstanceId' --output text 2>"$WORK/err.txt")
 if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "None" ] || [[ "$INSTANCE_ID" != i-* ]]; then
   INSTANCE_ID=""
-  { echo "--- RUNG 5 (on-demand $ITYPE) FAILED $(date -u +%FT%TZ) ---"; cat "$WORK/err.txt"; } | tee -a "$ERRLOG"
+  { echo "--- RUNG 5 ($MARKET $ITYPE) FAILED $(date -u +%FT%TZ) ---"; cat "$WORK/err.txt"; } | tee -a "$ERRLOG"
   exit 1
 fi
 LAUNCH_EPOCH=$(date +%s)
@@ -119,7 +137,7 @@ echo "RUNG 5 SUCCEEDED: $INSTANCE_ID" | tee -a "$ERRLOG"
 aws ec2 wait instance-running --region "$REGION" --instance-ids "$INSTANCE_ID"
 IP=$(aws ec2 describe-instances --region "$REGION" --instance-ids "$INSTANCE_ID" \
   --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
-echo "instance $INSTANCE_ID ($ITYPE, on-demand) ip=$IP launched $(date -u +%FT%TZ)" | tee -a "$OUT/rung5-cost.txt"
+echo "instance $INSTANCE_ID ($ITYPE, $MARKET) ip=$IP launched $(date -u +%FT%TZ)" | tee -a "$OUT/rung5-cost.txt"
 
 echo "== wait for sshd =="
 UP=""

--- a/research/wikidata-ingestion-benchmark.md
+++ b/research/wikidata-ingestion-benchmark.md
@@ -256,3 +256,36 @@ mislabelled report). The dict-consolidation bucket number at 1 B real truthy on
 post-consolidation main is NOT YET recorded — when the box runs, capture `dict consolidate
 (into_merged)` + the `dict-consolidate(serial)` term from `t2-dict-bucket.txt` here and
 compare against the projected single-digit seconds.
+
+### 2026-06-17 launch attempt — BLOCKED by the account envelope (NOT yet measured) [OPUS-4.8]
+
+The post-`#570` run was attempted on 2026-06-17 against `origin/main`. It is currently
+**blocked by the AWS account quota/IAM envelope this work box runs under — no `dict-
+consolidate(serial)` figure was produced, and none is recorded here (no fabrication).**
+Both launch paths fail at `RunInstances`:
+
+1. **On-demand `VcpuLimitExceeded`.** The original 2026-06-11 run fit the 16-vCPU Standard
+   on-demand bucket (`L-1216C47A`) because only the 2-vCPU prod `t3.large` was running
+   (14-vCPU headroom). Since **2026-06-13** the 8-vCPU `r7g.2xlarge` agent dev box
+   `sparq-dev-claude` — *the box this orchestrator itself runs on*, which must never be
+   terminated — also occupies that bucket. Standard usage is now 2 + 8 = 10 vCPU, so a
+   fresh 8-vCPU `r7i.2xlarge` (→ 18) trips the limit. The 1 B build needs ≥64 GB RAM
+   (51.5 GB peak RSS measured), and the smallest 64 GB box is an `x.2xlarge` (8 vCPU), so
+   the 6-vCPU on-demand headroom cannot host it. The prod box and the dev box are both
+   off-limits, so on-demand cannot proceed without a quota increase.
+2. **Spot `AuthFailure.ServiceLinkedRoleCreationNotPermitted`.** Spot draws on a *separate*
+   quota bucket (`L-34B43A08`), and a spot `--dry-run` reports "would have succeeded", so
+   spot is this bead's natural unblock (also cheaper: ~$0.21/h vs ~$0.61/h on-demand).
+   `hwrun/rung5-launch.sh` now takes `SPARQ_SPOT=1` to launch one-time spot (interrupt =
+   terminate, so the self-cleaning + dead-man contract holds). But the real spot
+   `RunInstances` is refused: the scoped SSO deploy role (`AWSReservedSSO_PSSSingleInstance
+   Deploy`) lacks permission to create the one-time `AWSServiceRoleForEC2Spot`
+   service-linked role (and cannot even `iam:GetRole` to check whether it exists).
+
+**Unblock — one of:** (a) a privileged principal creates the `AWSServiceRoleForEC2Spot`
+SLR once (`aws iam create-service-linked-role --aws-service-name spot.amazonaws.com`),
+after which `SPARQ_SPOT=1 bash hwrun/rung5-launch.sh` runs end-to-end under the separate
+spot quota; or (b) a Standard on-demand vCPU limit bump to ≥24 (then plain `bash
+hwrun/rung5-launch.sh`); or (c) run it from a session that is NOT on the 8-vCPU dev box so
+the on-demand headroom is free again. Tracked on sq-3l43; the deferred 192-core full
+validation is sq-bj3.


### PR DESCRIPTION
> 🤖 SPARQ agent — opening on behalf of @jeswr. One of several agents on this account.

## What & why (sq-3l43)

sq-3l43 asks to **re-measure ONLY the serial dict-consolidation bucket at 1 B on a rung-5-class box** (an `r7i.2xlarge`, 8-vCPU/64 GB) on **post-`#570` `origin/main`, to confirm/refute the `dict-consolidation-verdict.md` projection that the ~200 s/1 B serial bucket falls to single-digit seconds. The instrumentation precursor (#570, honest `build_timing` labels + `dict-consolidate(serial)` term) is already merged.

I attempted the actual run on 2026-06-17. **It is currently blocked by the AWS account quota/IAM envelope this work box runs under, so no `dict-consolidate(serial)` figure was produced — and none is recorded (no fabrication).** This PR ships the smallest correct change toward the bead and records the blocker precisely.

### Why the run can't proceed right now

- **on-demand `RunInstances` → `VcpuLimitExceeded`.** The original 2026-06-11 run fit the 16-vCPU Standard on-demand bucket (`L-1216C47A`) because only the 2-vCPU prod `t3.large` was running. Since **2026-06-13** the 8-vCPU `r7g.2xlarge` agent dev box `sparq-dev-claude` — **the box this orchestrator itself runs on, which must never be terminated** — also occupies that bucket (10 vCPU used). A fresh 8-vCPU `r7i.2xlarge` (→ 18) trips the limit, and the 6-vCPU headroom can't host a ≥64 GB box (51.5 GB peak RSS measured; smallest 64 GB box is an 8-vCPU `x.2xlarge`).
- **spot `RunInstances` → `AuthFailure.ServiceLinkedRoleCreationNotPermitted`.** Spot draws on a **separate** quota bucket (`L-34B43A08`; a spot `--dry-run` reports "would have succeeded"), so spot is the natural unblock — and cheaper (~\$0.21/h vs ~\$0.61/h). But the scoped SSO deploy role can't create the one-time `AWSServiceRoleForEC2Spot` service-linked role.

## Change

- `hwrun/rung5-launch.sh`: `SPARQ_SPOT=1` switches the launch to **one-time spot** (`InstanceInterruptionBehavior=terminate`, so the dead-man `shutdown -h +150` + cleanup-trap + `DeleteOnTermination` self-clean contract still holds). Removes the on-demand-quota collision once the spot SLR is provisioned. Default behaviour (on-demand) is unchanged.
- `research/wikidata-ingestion-benchmark.md`: records the 2026-06-17 blocker and the three unblock options (provision the spot SLR once → `SPARQ_SPOT=1 …`; bump Standard on-demand vCPU ≥24; or run from a session not co-resident with the 8-vCPU dev box).

## Honesty

This **does not** record a measurement — the measurement stays open on sq-3l43. It removes the on-demand-quota dependency and captures the exact remaining blocker so the run is a single privileged action away.

## Gate

- `bash -n hwrun/rung5-launch.sh` clean; `shellcheck -S warning` clean except the pre-existing SC2034 (`for i` counter, untouched by this PR).
- Doc surface: `research/` is the advisory (not hard-gated) markdownlint surface; the changed section has no trailing whitespace, correct ATX spacing, final newline.
- No Rust crate / no public API touched → no `cargo`/clippy and no G2 SKILL.md rule applies.
- **Privacy-claims gate** (incl. predicate-form soundness): N/A — the diff is EC2 orchestration + a benchmark research record; it touches no privacy/ZK/MPC claim or predicate-form code.
- No orphan EC2 resources: both failed launches self-cleaned via the trap; tag query shows zero `purpose=sparq-hw-validation` instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)