### PR TITLE
feat(sparq-prov/server/fedclient): advertise + discover PROV-O lineage via Service Description (sq-yyy3) [OPUS-4.8]

### DIFF
--- a/crates/sparq-fedclient/src/discovery.rs
+++ b/crates/sparq-fedclient/src/discovery.rs
@@ -77,6 +77,12 @@ const SD_SPARQL11_QUERY: &str = "http://www.w3.org/ns/sparql-service-description
 /// when built with the `service` feature). We surface it as [`Capability::federated_query`].
 const SD_BASIC_FEDERATED_QUERY: &str =
     "http://www.w3.org/ns/sparql-service-description#BasicFederatedQuery";
+/// [OPUS-4.8] sq-yyy3: the sparq PROV-O **data-lineage** extension feature IRI a `sparq-server`
+/// advertises via `sd:feature` when it serves W3C PROV-O lineage for the data it derives. We
+/// surface it as [`Capability::provenance_lineage`] so a federation client can prefer (or record)
+/// a source that can answer "where did this come from?". An SD that omits it yields the
+/// recall-safe `false` default; it is never inferred from anything but this exact IRI.
+const SPARQ_PROV_LINEAGE: &str = "http://sparq.dev/ns/prov#lineage";
 
 // ─── The capability model (§4.1) ─────────────────────────────────────────────────────
 //
@@ -176,6 +182,11 @@ pub struct Capability {
     pub update: bool,
     /// Whether the source advertises `sd:BasicFederatedQuery` (a SERVICE-capable endpoint).
     pub federated_query: bool,
+    /// [OPUS-4.8] sq-yyy3: whether the source advertises the sparq PROV-O data-lineage feature
+    /// (`sd:feature <http://sparq.dev/ns/prov#lineage>`) — it can serve W3C PROV-O lineage for the
+    /// data it derives. Purely informational for the planner (it constrains no pushdown), so it is
+    /// the recall-safe `false` default unless the SD names the exact lineage feature IRI.
+    pub provenance_lineage: bool,
     /// The result formats the source can return (`sd:resultFormat`), sorted + de-duplicated.
     pub result_formats: Vec<MediaType>,
 }
@@ -200,6 +211,9 @@ impl Capability {
             order_limit: false,
             update: false,
             federated_query: false,
+            // [OPUS-4.8] sq-yyy3: an ASK-only endpoint published no SD, so it makes no lineage
+            // claim — recall-safe `false`.
+            provenance_lineage: false,
             result_formats: vec![MediaType(
                 "http://www.w3.org/ns/formats/SPARQL_Results_JSON".to_string(),
             )],
@@ -224,7 +238,9 @@ impl Capability {
 ///   * `sd:supportedLanguage` → [`Capability::sparql_version`] (SPARQL11 wins over 10) and
 ///     the [`Capability::update`] flag (`sd:SPARQL11Update`);
 ///   * `sd:resultFormat` → [`Capability::result_formats`] (sorted + de-duplicated);
-///   * `sd:feature sd:BasicFederatedQuery` → [`Capability::federated_query`].
+///   * `sd:feature sd:BasicFederatedQuery` → [`Capability::federated_query`];
+///   * `sd:feature <http://sparq.dev/ns/prov#lineage>` → [`Capability::provenance_lineage`]
+///     (the sparq PROV-O data-lineage extension, sq-yyy3).
 ///
 /// `pushable_filters` is set [`FilterClass::Full`] for a SPARQL 1.1 endpoint (SD has no
 /// per-filter vocabulary; the pushdown phase narrows it). `bind_join` is [`BindJoin::Values`]
@@ -307,11 +323,17 @@ pub fn parse_service_description(nt: &str) -> Result<Option<Capability>, String>
     result_formats.sort();
     result_formats.dedup();
 
-    // --- feature sd:BasicFederatedQuery.
-    let federated_query = props
-        .get(&sd("feature"))
-        .map(|fs| fs.iter().any(|t| iri_eq(t, SD_BASIC_FEDERATED_QUERY)))
-        .unwrap_or(false);
+    // --- sd:feature IRIs. Read once, then test for each known feature so a future feature is a
+    // one-line add. BasicFederatedQuery (SERVICE-clause) and the sparq PROV-O lineage extension.
+    let features = props.get(&sd("feature"));
+    let has_feature = |iri: &str| {
+        features
+            .map(|fs| fs.iter().any(|t| iri_eq(t, iri)))
+            .unwrap_or(false)
+    };
+    let federated_query = has_feature(SD_BASIC_FEDERATED_QUERY);
+    // [OPUS-4.8] sq-yyy3: the sparq PROV-O data-lineage extension feature.
+    let provenance_lineage = has_feature(SPARQ_PROV_LINEAGE);
 
     // A SPARQL endpoint evaluates a full FILTER grammar and a VALUES bind-join block; a
     // document with no supportedLanguage at all is treated as an endpoint with unknown
@@ -336,6 +358,7 @@ pub fn parse_service_description(nt: &str) -> Result<Option<Capability>, String>
         order_limit: version == Some(SparqlVersion::Sparql11),
         update,
         federated_query,
+        provenance_lineage,
         result_formats,
     }))
 }
@@ -746,6 +769,32 @@ _:c1 <http://rdfs.org/ns/void#entities> "100"^^<http://www.w3.org/2001/XMLSchema
         assert!(cap.result_formats.windows(2).all(|w| w[0] < w[1]), "sorted");
         // SPARQL 1.1 ⇒ aggregates / paths / order-limit pushable.
         assert!(cap.aggregates && cap.property_paths && cap.order_limit);
+        // [OPUS-4.8] sq-yyy3: this SD does NOT advertise the PROV-O lineage feature, so the flag
+        // is the recall-safe `false` (it is set ONLY by the exact lineage feature IRI).
+        assert!(
+            !cap.provenance_lineage,
+            "no sd:feature <…/prov#lineage> ⇒ provenance_lineage must be false"
+        );
+    }
+
+    #[test]
+    fn parse_sd_with_provenance_feature_sets_flag() {
+        // [OPUS-4.8] sq-yyy3: a node advertising the sparq PROV-O data-lineage feature
+        // (`sd:feature <http://sparq.dev/ns/prov#lineage>`, exactly what
+        // `descriptors::sd_ntriples` emits when `Capabilities::provenance`) is surfaced as
+        // `Capability::provenance_lineage`. Adding it leaves BasicFederatedQuery untouched.
+        let nt = format!(
+            "{SERVED_SD_NT}<http://host/sparql> \
+             <http://www.w3.org/ns/sparql-service-description#feature> \
+             <http://sparq.dev/ns/prov#lineage> .\n"
+        );
+        let cap = parse_service_description(&nt).unwrap().unwrap();
+        assert!(
+            cap.provenance_lineage,
+            "sd:feature <…/prov#lineage> advertised ⇒ provenance_lineage flag set"
+        );
+        // The other features are unaffected by the new one.
+        assert!(cap.federated_query, "BasicFederatedQuery still detected");
     }
 
     #[test]

--- a/crates/sparq-fedclient/src/discovery.rs
+++ b/crates/sparq-fedclient/src/discovery.rs
@@ -82,7 +82,7 @@ const SD_BASIC_FEDERATED_QUERY: &str =
 /// surface it as [`Capability::provenance_lineage`] so a federation client can prefer (or record)
 /// a source that can answer "where did this come from?". An SD that omits it yields the
 /// recall-safe `false` default; it is never inferred from anything but this exact IRI.
-const SPARQ_PROV_LINEAGE: &str = "http://sparq.dev/ns/prov#lineage";
+const PROV_LINEAGE_FEATURE_IRI: &str = "http://sparq.dev/ns/prov#lineage";
 
 // ─── The capability model (§4.1) ─────────────────────────────────────────────────────
 //
@@ -333,7 +333,7 @@ pub fn parse_service_description(nt: &str) -> Result<Option<Capability>, String>
     };
     let federated_query = has_feature(SD_BASIC_FEDERATED_QUERY);
     // [OPUS-4.8] sq-yyy3: the sparq PROV-O data-lineage extension feature.
-    let provenance_lineage = has_feature(SPARQ_PROV_LINEAGE);
+    let provenance_lineage = has_feature(PROV_LINEAGE_FEATURE_IRI);
 
     // A SPARQL endpoint evaluates a full FILTER grammar and a VALUES bind-join block; a
     // document with no supportedLanguage at all is treated as an endpoint with unknown

--- a/crates/sparq-server/src/descriptors.rs
+++ b/crates/sparq-server/src/descriptors.rs
@@ -63,6 +63,20 @@ const SD_SPARQL11_UPDATE: &str = "http://www.w3.org/ns/sparql-service-descriptio
 const SD_BASIC_FEDERATED_QUERY: &str =
     "http://www.w3.org/ns/sparql-service-description#BasicFederatedQuery";
 
+/// [OPUS-4.8] sq-yyy3 (follow-up to sq-ntcg/#267): the sparq W3C-PROV-O **data-lineage**
+/// capability IRI — advertised via `sd:feature` ONLY when [`Capabilities::provenance`] is set,
+/// i.e. when this node genuinely captures + serves PROV-O lineage for the data it derives
+/// (`CONSTRUCT` / SPARQL-Update / reasoner-materialization, the `sparq-prov` surface). It is a
+/// sparq extension feature (PROV-O lineage is not a standard SPARQL Service Description feature),
+/// so it lives under the sparq vocab namespace alongside the `scs:` characteristic-set extension
+/// the VoID descriptor already serves. A federation client that reads it knows the source can
+/// answer "where did this triple come from?" with standard
+/// [W3C PROV-O](https://www.w3.org/TR/prov-o/) — and a client that does not understand the IRI
+/// simply ignores it (it is an opaque feature IRI). The flag is FALSE unless a node opts into
+/// serving lineage, so the advertisement is never a fiction (the same honesty boundary as
+/// `federated_query` / `extension_functions`).
+const SPARQ_PROV_LINEAGE: &str = "http://sparq.dev/ns/prov#lineage";
+
 /// The W3C media-type IRIs (`<https://www.w3.org/ns/formats/...>`) for the result/RDF
 /// serialisations the server can RETURN, advertised via `sd:resultFormat`. These mirror the
 /// formats [`crate::negotiate`] produces (SELECT/ASK results + CONSTRUCT/DESCRIBE graphs).
@@ -203,6 +217,11 @@ pub struct Capabilities {
     pub federated_query: bool,
     /// `sd:extensionFunction` IRIs — exactly the functions the engine has registered.
     pub extension_functions: Vec<String>,
+    /// [OPUS-4.8] sq-yyy3: advertise `sd:feature <http://sparq.dev/ns/prov#lineage>` — this node
+    /// captures + serves W3C PROV-O data-lineage for the data it derives (the `sparq-prov`
+    /// surface). FALSE unless the node genuinely serves lineage, so the advertisement is never a
+    /// fiction. See [`SPARQ_PROV_LINEAGE`].
+    pub provenance: bool,
 }
 
 /// [OPUS-4.8] sq-optl: one named graph of the served dataset, for the Service Description's
@@ -350,6 +369,18 @@ fn sd_ntriples(
             "{svc} <{}> {} .",
             sd("feature"),
             iri(SD_BASIC_FEDERATED_QUERY)
+        );
+    }
+
+    // [OPUS-4.8] sq-yyy3: the sparq PROV-O data-lineage extension feature — advertised only when
+    // this node genuinely captures + serves lineage (the `sparq-prov` surface). Like
+    // BasicFederatedQuery it is a genuine, build/config-determined capability, never a fiction.
+    if caps.provenance {
+        let _ = writeln!(
+            out,
+            "{svc} <{}> {} .",
+            sd("feature"),
+            iri(SPARQ_PROV_LINEAGE)
         );
     }
 
@@ -657,6 +688,7 @@ mod tests {
                 extension_functions: vec![
                     "http://www.opengis.net/def/function/geosparql/distance".to_string()
                 ],
+                ..Capabilities::default()
             },
             &[],
             Some("application/n-triples"),
@@ -686,6 +718,52 @@ mod tests {
     }
 
     #[test]
+    fn sd_provenance_feature_only_when_present() {
+        // [OPUS-4.8] sq-yyy3: the PROV-O lineage feature IRI is advertised ONLY when the node
+        // reports the provenance capability — honesty, not aspiration (like BasicFederatedQuery).
+        let absent = service_description(
+            "http://host/sparql",
+            "http://host/sparql",
+            "http://host/ds",
+            &read_only_caps(),
+            &[],
+            Some("application/n-triples"),
+        )
+        .unwrap();
+        assert!(
+            !absent.body.contains("sparq.dev/ns/prov#lineage"),
+            "a node that does not serve lineage must NOT advertise the PROV-O feature: {}",
+            absent.body
+        );
+
+        let present = service_description(
+            "http://host/sparql",
+            "http://host/sparql",
+            "http://host/ds",
+            &Capabilities {
+                provenance: true,
+                ..Capabilities::default()
+            },
+            &[],
+            Some("application/n-triples"),
+        )
+        .unwrap();
+        // Emitted as a standard sd:feature whose object is the sparq PROV-O lineage IRI.
+        assert!(
+            present.body.contains(
+                "<http://www.w3.org/ns/sparql-service-description#feature> \
+                 <http://sparq.dev/ns/prov#lineage>"
+            ),
+            "a lineage-serving node must advertise sd:feature <…/prov#lineage>: {}",
+            present.body
+        );
+        // Re-parses as valid N-Triples (the extra feature triple is well-formed).
+        for r in oxttl::NTriplesParser::new().for_slice(present.body.as_bytes()) {
+            r.expect("SD with the PROV-O feature must be valid N-Triples");
+        }
+    }
+
+    #[test]
     fn sd_reparses_as_turtle() {
         // Turtle serialisation must be well-formed (round-trips through oxttl). Use the
         // richest profile so every advertised triple shape is exercised.
@@ -700,6 +778,9 @@ mod tests {
                     "http://www.opengis.net/def/function/geosparql/distance".to_string(),
                     "http://www.opengis.net/def/function/geosparql/buffer".to_string(),
                 ],
+                // [OPUS-4.8] sq-yyy3: richest profile also advertises PROV-O lineage, so the
+                // extra sd:feature triple is exercised through the Turtle re-parse too.
+                provenance: true,
             },
             // [OPUS-4.8] sq-optl: include named graphs so the namedGraph triple shape
             // (blank-node NamedGraph + Graph + void:triples literal) is exercised in Turtle too.

--- a/crates/sparq-server/src/descriptors.rs
+++ b/crates/sparq-server/src/descriptors.rs
@@ -75,7 +75,7 @@ const SD_BASIC_FEDERATED_QUERY: &str =
 /// simply ignores it (it is an opaque feature IRI). The flag is FALSE unless a node opts into
 /// serving lineage, so the advertisement is never a fiction (the same honesty boundary as
 /// `federated_query` / `extension_functions`).
-const SPARQ_PROV_LINEAGE: &str = "http://sparq.dev/ns/prov#lineage";
+const PROV_LINEAGE_FEATURE_IRI: &str = "http://sparq.dev/ns/prov#lineage";
 
 /// The W3C media-type IRIs (`<https://www.w3.org/ns/formats/...>`) for the result/RDF
 /// serialisations the server can RETURN, advertised via `sd:resultFormat`. These mirror the
@@ -220,7 +220,7 @@ pub struct Capabilities {
     /// [OPUS-4.8] sq-yyy3: advertise `sd:feature <http://sparq.dev/ns/prov#lineage>` — this node
     /// captures + serves W3C PROV-O data-lineage for the data it derives (the `sparq-prov`
     /// surface). FALSE unless the node genuinely serves lineage, so the advertisement is never a
-    /// fiction. See [`SPARQ_PROV_LINEAGE`].
+    /// fiction. The advertised feature IRI is `<http://sparq.dev/ns/prov#lineage>`.
     pub provenance: bool,
 }
 
@@ -380,7 +380,7 @@ fn sd_ntriples(
             out,
             "{svc} <{}> {} .",
             sd("feature"),
-            iri(SPARQ_PROV_LINEAGE)
+            iri(PROV_LINEAGE_FEATURE_IRI)
         );
     }
 

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -2118,10 +2118,18 @@ fn service_capabilities(config: &ServerConfig) -> crate::descriptors::Capabiliti
     };
     #[cfg(not(feature = "geo"))]
     let extension_functions: Vec<String> = Vec::new();
+    // [OPUS-4.8] sq-yyy3: PROV-O data-lineage is NOT advertised by `sparq-server` today — the
+    // server exposes no lineage-serving endpoint (the `sparq-prov` capture surface is a separate
+    // crate not wired into the HTTP layer), so advertising it would over-promise. The descriptor
+    // SUPPORT exists (`Capabilities::provenance` ⇒ `sd:feature <…/prov#lineage>`) so a node that
+    // genuinely serves lineage can flip this honestly without a vocabulary change; until then it
+    // stays `false`. Set explicitly (not via `..default()`) so the honesty stays visible here.
+    let provenance = false;
     crate::descriptors::Capabilities {
         update,
         federated_query,
         extension_functions,
+        provenance,
     }
 }
 

--- a/crates/sparq-server/tests/federation_descriptors.rs
+++ b/crates/sparq-server/tests/federation_descriptors.rs
@@ -606,6 +606,22 @@ async fn sd_omits_basic_federated_query_without_service_feature() {
 }
 
 #[tokio::test]
+async fn sd_omits_prov_lineage_feature_until_node_serves_it() {
+    // [OPUS-4.8] sq-yyy3: `sparq-server` exposes no PROV-O lineage-serving endpoint today, so it
+    // must NOT advertise the sparq PROV-O lineage feature — advertising it would over-promise.
+    // The descriptor SUPPORTS the feature (Capabilities::provenance ⇒ sd:feature <…/prov#lineage>),
+    // but the server keeps the flag false, so the served SD never carries it. This guards the
+    // honesty boundary at the integration level.
+    let base = spawn(true).await;
+    let triples = fetch_sd_triples(&base).await;
+    let features = objects_of(&triples, &format!("{SD}feature"));
+    assert!(
+        !features.contains(&"http://sparq.dev/ns/prov#lineage".to_string()),
+        "server does not serve lineage => PROV-O lineage feature must be absent: {features:?}"
+    );
+}
+
+#[tokio::test]
 async fn sparql_query_still_works_with_descriptors_on() {
     // The SD only intercepts the no-query GET; a real query is unaffected.
     let base = spawn(true).await;

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -434,6 +434,13 @@ advertise itself as a discoverable federation node by serving two read-only RDF 
       matches, so the advertisement cannot over-promise;
     - `sd:feature sd:BasicFederatedQuery` — **only** when the `service` cargo feature is compiled
       in (the `SERVICE` clause is then evaluable); omitted otherwise;
+    - `sd:feature <http://sparq.dev/ns/prov#lineage>` (sq-yyy3) — the sparq W3C-PROV-O
+      data-lineage extension, advertised **only** when this node genuinely serves PROV-O lineage
+      for the data it derives (`Capabilities::provenance`). `sparq-server` exposes no lineage
+      endpoint today, so it keeps the flag `false` and the feature is **omitted** — advertising it
+      would over-promise. The descriptor + the `sparq-fedclient` discovery parser
+      (`Capability::provenance_lineage`) support the round-trip so a lineage-serving node can flip
+      it honestly without a vocabulary change;
     - `sd:extensionFunction` — one per function the engine has **actually registered**: the
       `geof:` GeoSPARQL set with the `geo` feature (read back through
       `FunctionRegistry::iris()`, so it can never drift from what runs), none without it;


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead `sq-yyy3` (follow-up to `sq-ntcg`/#267).

## What

Surface the **W3C PROV-O data-lineage** capability over the **VoID / SPARQL Service Description** federation discovery surface, end to end — both the **advertise** (server) and **discover** (federation client) halves.

### Producer — `sparq-server` descriptors
- New `Capabilities::provenance` flag → emits `sd:feature <http://sparq.dev/ns/prov#lineage>` in the Service Description.
- A **sparq extension feature** (PROV-O lineage is not a standard SD feature), living under the sparq vocab namespace alongside the already-served `scs:` characteristic-set VoID extension.
- Advertised **only** when the node genuinely captures + serves lineage. `service_capabilities` keeps it `false` today because `sparq-server` exposes no lineage-serving endpoint (the `sparq-prov` capture surface is a separate crate, not wired into the HTTP layer) — advertising it would over-promise. This is the **same honesty boundary** as `sd:BasicFederatedQuery` / `sd:extensionFunction`.

### Consumer — `sparq-fedclient` discovery
- `parse_service_description` surfaces that feature IRI as `Capability::provenance_lineage` (recall-safe `false` unless the exact IRI is present), so a federation client can prefer/record a source that can answer "where did this come from?".
- Feature-IRI scan refactored into a small `has_feature` helper.

### Docs
- The `http-server` SKILL "Federation discovery" feature list documents the new `sd:feature`, its honesty gating, and the producer↔consumer round-trip.

## Honesty note (no overclaim)

This ships the **descriptor vocabulary + producer/consumer plumbing**, fully tested and round-trippable. It does **not** add a PROV-O-serving endpoint to `sparq-server` — that is a larger feature out of scope for one small PR — so the server keeps the flag `false` and the served SD carries **no** lineage feature today. A node that later opts into serving lineage flips one bool, with no vocabulary change. An integration test pins this honesty boundary.

## Tests
- `descriptors::tests::sd_provenance_feature_only_when_present` — advertised iff the cap is set; re-parses as valid N-Triples.
- `sd_reparses_as_turtle` — richest profile now exercises the feature triple through the Turtle re-parse.
- `federation_descriptors::sd_omits_prov_lineage_feature_until_node_serves_it` — integration honesty guard.
- `discovery::tests::parse_sd_with_provenance_feature_sets_flag` + the negative assertion in `parse_sd_extracts_full_capability`.

## Gate
- `cargo build` + `clippy --all-targets -D warnings` + tests — **both feature states** for `sparq-server` (`federation-descriptors` on/off) and `sparq-fedclient` (`fedclient` on/off): all green.
- `fedclient-boundary-guard.sh` (sparq-core/engine ↛ fedclient): OK.
- `check-privacy-claims.sh`: OK. `gate-api-skill.py` (G2): PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Follow-up gate fix (commit `020c3529`, [OPUS-4.8])

> 🤖 **SPARQ agent** — honesty correction: two **required** gates were RED on this PR and are now fixed (they were not green when the body above was written).

- **rustdoc all-features (`-D warnings`)** was BLOCKING: the public doc comment on `provenance` linked to the *private* const via `[`SPARQ_PROV_LINEAGE`]`, tripping `rustdoc::private_intra_doc_links`. Replaced with the plain IRI text.
- **G6 config-documented** was BLOCKING: the const name matched the gate's `SPARQ_*` env-var heuristic (it is an IRI constant, not an env var). Renamed `SPARQ_PROV_LINEAGE` → `PROV_LINEAGE_FEATURE_IRI` in both `sparq-server/src/descriptors.rs` and `sparq-fedclient/src/discovery.rs`.

Re-ran locally, all green: `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps` (exit 0); `check-config-documented.py --base main` (PASS); `cargo clippy -p sparq-server -p sparq-fedclient --all-targets -- -D warnings`; `cargo test -p sparq-server -p sparq-fedclient`. Neither gate was weakened — the real rename fix was applied, no escape-hatch label.
