### PR TITLE
feat(site): gray EXPLAIN/ANALYZE mode toggle for SPARQL Update examples (sq-xe4f)

### DIFF
--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -23,7 +23,13 @@ import {
   type SparqlResults,
   type WasmStore,
 } from "@/lib/sparq-wasm";
-import { classifyQueryForm, isGraphForm } from "@/lib/repl-dataset";
+import {
+  classifyQueryForm,
+  isGraphForm,
+  modeSupportsForm,
+  type QueryForm,
+  type RunMode,
+} from "@/lib/repl-dataset";
 import { EXAMPLE_QUERIES, BUILTIN_DATASETS } from "@/data/sample-graph";
 import {
   DatasetControls,
@@ -46,8 +52,9 @@ type RunState =
   | { kind: "error"; message: string };
 
 // Run mode: execute the query, or render the planner's EXPLAIN / EXPLAIN ANALYZE
-// plan without (EXPLAIN) or with (ANALYZE) executing it.
-type RunMode = "run" | "explain" | "analyze";
+// plan without (EXPLAIN) or with (ANALYZE) executing it. The RunMode union now lives
+// alongside the form classifier in repl-dataset so the per-form mode-support rule
+// (modeSupportsForm) is a single pure, unit-tested source of truth.
 
 // [OPUS-4.8] Engine warm-up lifecycle, surfaced as a subtle indicator. The wasm fetch +
 // instantiate is kicked off on mount (prewarmSparq) so the first "Run query" is instant.
@@ -254,6 +261,19 @@ export function Repl() {
   const busy = state.kind === "running";
   const controlsDisabled = engine === "warming" || engine === "cold";
 
+  // [OPUS-4.8] sq-xe4f — classify the current editor text so the mode toggle can gray
+  // out EXPLAIN / ANALYZE for SPARQL Update forms (the query planner those modes drive
+  // rejects Update). If the user had EXPLAIN/ANALYZE selected and then loads an Update
+  // example, snap the mode back to "run" so the next click runs the Update instead of
+  // hitting an engine parse error.
+  const form: QueryForm = React.useMemo(
+    () => classifyQueryForm(sparql),
+    [sparql],
+  );
+  React.useEffect(() => {
+    if (!modeSupportsForm(mode, form)) setMode("run");
+  }, [mode, form]);
+
   return (
     <Card>
       <CardHeader className="flex-row items-center justify-between gap-2 space-y-0">
@@ -322,7 +342,7 @@ export function Repl() {
             )}
             {mode === "run" ? "Run query" : "Run EXPLAIN"}
           </Button>
-          <ModeTabs mode={mode} onChange={setMode} disabled={busy} />
+          <ModeTabs mode={mode} onChange={setMode} disabled={busy} form={form} />
           <p aria-live="polite" className="text-xs text-muted-foreground">
             {state.kind === "select" &&
               `${state.results.results.bindings.length} rows · ${state.ms.toFixed(1)} ms`}
@@ -382,14 +402,19 @@ function EngineIndicator({ engine }: { engine: EngineState }) {
 
 // [OPUS-4.8] sq-vfbm — Run / EXPLAIN / EXPLAIN ANALYZE selector. EXPLAIN is a
 // planning-only dry run (every query form); ANALYZE also executes (SELECT/ASK).
+// [OPUS-4.8] sq-xe4f — EXPLAIN / ANALYZE drive the query planner, which rejects SPARQL
+// Update forms, so those tabs are grayed (disabled + aria-disabled) when the editor
+// holds an Update example. The decision is the pure `modeSupportsForm` predicate.
 function ModeTabs({
   mode,
   onChange,
   disabled,
+  form,
 }: {
   mode: RunMode;
   onChange: (m: RunMode) => void;
   disabled: boolean;
+  form: QueryForm;
 }) {
   const tabs: { value: RunMode; label: string; title: string }[] = [
     { value: "run", label: "Run", title: "Execute the query / update" },
@@ -410,25 +435,37 @@ function ModeTabs({
       aria-label="Run mode"
       className="inline-flex rounded-lg border bg-muted/40 p-0.5"
     >
-      {tabs.map((t) => (
-        <button
-          key={t.value}
-          type="button"
-          role="tab"
-          aria-selected={mode === t.value}
-          title={t.title}
-          disabled={disabled}
-          onClick={() => onChange(t.value)}
-          className={cn(
-            "rounded-md px-2.5 py-1 text-xs font-medium transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/40 disabled:opacity-50",
-            mode === t.value
-              ? "bg-background text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground",
-          )}
-        >
-          {t.label}
-        </button>
-      ))}
+      {tabs.map((t) => {
+        // Gray out a mode the current query form cannot use (EXPLAIN/ANALYZE on an
+        // Update). The engine still validates — this only stops the user picking a
+        // mode that would parse-error.
+        const unsupported = !modeSupportsForm(t.value, form);
+        const tabDisabled = disabled || unsupported;
+        return (
+          <button
+            key={t.value}
+            type="button"
+            role="tab"
+            aria-selected={mode === t.value}
+            aria-disabled={unsupported}
+            title={
+              unsupported
+                ? `${t.label} is unavailable for SPARQL Update — it plans a query`
+                : t.title
+            }
+            disabled={tabDisabled}
+            onClick={() => onChange(t.value)}
+            className={cn(
+              "rounded-md px-2.5 py-1 text-xs font-medium transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/40 disabled:opacity-50 disabled:cursor-not-allowed",
+              mode === t.value
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {t.label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/site/src/lib/repl-dataset.ts
+++ b/site/src/lib/repl-dataset.ts
@@ -207,6 +207,28 @@ export function isGraphForm(form: QueryForm): boolean {
   return form === "construct" || form === "describe";
 }
 
+// [OPUS-4.8] sq-xe4f — EXPLAIN / EXPLAIN ANALYZE support per query form.
+//
+// EXPLAIN/ANALYZE drive the *query* planner (`store.explain` / `store.explainAnalyze`),
+// which only accept query forms — handing it a SPARQL Update yields an engine parse
+// error ("expected CONSTRUCT"). So the REPL must NOT offer EXPLAIN/ANALYZE for an Update
+// example. This pure predicate lets the ModeTabs component gray those tabs out (and lets
+// `Repl` snap the mode back to "run" when an Update is loaded) instead of only degrading
+// via the error panel after the fact. The engine stays the source of truth — a
+// mis-classified query still surfaces the engine's own error.
+export type RunMode = "run" | "explain" | "analyze";
+
+/**
+ * True when {@link mode} is a usable choice for {@link form}. `"run"` always is.
+ * EXPLAIN / ANALYZE plan a *query* and reject SPARQL Update forms, so they are
+ * unavailable for `"update"`.
+ */
+export function modeSupportsForm(mode: RunMode, form: QueryForm): boolean {
+  if (mode === "run") return true;
+  // EXPLAIN / EXPLAIN ANALYZE plan a *query*; SPARQL Update is not a query form.
+  return form !== "update";
+}
+
 /**
  * Serialises {@link ALL_QUADS_QUERY} solution rows to an N-Quads document: a triple
  * line (`s p o .`) when `?g` is unbound (default graph), a quad line

--- a/site/test/repl-dataset.test.mjs
+++ b/site/test/repl-dataset.test.mjs
@@ -15,6 +15,7 @@ import {
   formatFromContentType,
   classifyQueryForm,
   isGraphForm,
+  modeSupportsForm,
 } from "../src/lib/repl-dataset.ts";
 
 test("isDatasetFormat is true exactly for the quad-bearing formats", () => {
@@ -225,4 +226,29 @@ test("isGraphForm is true exactly for CONSTRUCT and DESCRIBE", () => {
   assert.equal(isGraphForm("select"), false);
   assert.equal(isGraphForm("ask"), false);
   assert.equal(isGraphForm("update"), false);
+});
+
+// [OPUS-4.8] sq-xe4f — EXPLAIN / ANALYZE drive the query planner, which rejects SPARQL
+// Update forms; the REPL grays those mode tabs out for Update examples. The decision is
+// this pure predicate, so the table-of-cases test guards the gating rule directly.
+test("modeSupportsForm: Run is available for every form", () => {
+  for (const form of ["select", "ask", "construct", "describe", "update"]) {
+    assert.equal(modeSupportsForm("run", form), true, form);
+  }
+});
+
+test("modeSupportsForm: EXPLAIN / ANALYZE are available for the query forms", () => {
+  for (const form of ["select", "ask", "construct", "describe"]) {
+    assert.equal(modeSupportsForm("explain", form), true, `explain/${form}`);
+    assert.equal(modeSupportsForm("analyze", form), true, `analyze/${form}`);
+  }
+});
+
+test("modeSupportsForm: EXPLAIN / ANALYZE are UNavailable for SPARQL Update", () => {
+  // The bead (sq-xe4f): selecting EXPLAIN or ANALYZE on an Update example yields an
+  // engine parse error, so the toggle must gray those modes out for "update".
+  assert.equal(modeSupportsForm("explain", "update"), false);
+  assert.equal(modeSupportsForm("analyze", "update"), false);
+  // Run still works — the Update can still be executed.
+  assert.equal(modeSupportsForm("run", "update"), true);
 });


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements bead **sq-xe4f** — follow-up from #579 (sq-vfbm) adversarial review.

## Problem
The `/try` REPL's Run / EXPLAIN / ANALYZE mode toggle let the user select EXPLAIN or ANALYZE while a **SPARQL Update** example (e.g. `INSERT DATA`) was loaded. Those modes drive the *query* planner (`store.explain` / `store.explainAnalyze`), which rejects Update forms with an engine parse error (`expected CONSTRUCT`). It degraded gracefully (error panel + toast, no crash) but offered a mode that could only fail.

## Change
- **`repl-dataset.ts`**: new pure, framework-free predicate `modeSupportsForm(mode, form)` — the single source of truth that EXPLAIN/ANALYZE are unavailable for the `"update"` form (`"run"` is always available). The `RunMode` union moves here next to the existing `classifyQueryForm` / `isGraphForm` classifiers.
- **`ModeTabs`** (`repl.tsx`): grays out (disabled + `aria-disabled` + not-allowed cursor + explanatory `title`) any mode the current query form cannot use, instead of only degrading after a failed run.
- **`Repl`** (`repl.tsx`): classifies the editor text (memoised) and, if the selected mode stops being supported when an Update is loaded, snaps the mode back to `"run"` so the next click executes the Update rather than parse-erroring.

## Tests / gate
- `npm run test:unit` — **25 pass** (3 new table-of-cases tests for `modeSupportsForm`: Run always; EXPLAIN/ANALYZE for every query form; neither for Update).
- `next lint` clean · `tsc --noEmit` clean · static export builds (41 pages).

No public Rust API changed (site only) — G2 SKILL.md rule not triggered. No privacy claims touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)