### PR TITLE
refactor(sparq-geo): route line∩polygon clip through i_overlay (sq-yt4z) [OPUS-4.8]

### DIFF
--- a/crates/sparq-geo/src/geof.rs
+++ b/crates/sparq-geo/src/geof.rs
@@ -600,8 +600,8 @@ fn intersection_geometry(a: &Geometry<f64>, b: &Geometry<f64>) -> Result<Geometr
         // Line ∩ line.
         (Some(1), Some(1)) => Ok(line_line_intersection(a, b)),
         // Line ∩ polygon (clip the line to the polygon).
-        (Some(1), Some(2)) => Ok(clip_lines_to_polygon(a, &polygonal(b).unwrap())),
-        (Some(2), Some(1)) => Ok(clip_lines_to_polygon(b, &polygonal(a).unwrap())),
+        (Some(1), Some(2)) => Ok(intersect_line_with_polygon(a, &polygonal(b).unwrap())),
+        (Some(2), Some(1)) => Ok(intersect_line_with_polygon(b, &polygonal(a).unwrap())),
         _ => Err(GeoError::Unsupported(format!(
             "geof:intersection does not support {} ∩ {}",
             wkt_type_name(a),
@@ -662,64 +662,33 @@ fn point_on_linestring(c: Coord<f64>, ls: &LineString<f64>) -> bool {
     ls.lines().any(|seg| seg.coordinate_position(&c) != CoordPos::Outside)
 }
 
-/// Clip a 1-D operand to a polygon: the portions of each segment whose
-/// midpoint lies inside-or-on the polygon, after splitting every segment at its
-/// boundary crossings. Returns a (MULTI)LINESTRING (or, when the line only
-/// touches the polygon at isolated points, a MULTIPOINT of those points).
-fn clip_lines_to_polygon(line: &Geometry<f64>, poly: &MultiPolygon<f64>) -> Geometry<f64> {
-    let mut pieces: Vec<LineString<f64>> = Vec::new();
+/// Clip a 1-D operand to a polygon (line ∩ polygon): the portions of the line
+/// lying inside-or-on the polygon. Routed through the same `i_overlay`
+/// string-line clip as line − polygon (`clip_line_by_polygon`) for a single
+/// shared, robustly-noded clipper across both halves of the partition;
+/// `invert == false` keeps the in-polygon portions and `boundary_included ==
+/// true` keeps a span running ALONG the boundary (the polygon is a CLOSED set),
+/// the exact complement of the `(invert: true, boundary_included: true)` rule
+/// used for line − polygon. Returns a (MULTI)LINESTRING, or — when the line
+/// only touches the polygon at isolated points (which `i_overlay` drops as
+/// zero-length pieces) — a MULTIPOINT of those touch points. [OPUS-4.8]
+fn intersect_line_with_polygon(line: &Geometry<f64>, poly: &MultiPolygon<f64>) -> Geometry<f64> {
+    let pieces = clip_line_by_polygon(line, poly, false, true);
+    if !pieces.is_empty() {
+        return collect_lines(pieces);
+    }
+    // No 1-D overlap: the line may still graze the polygon at isolated vertices.
+    // `i_overlay` drops these zero-length pieces, so recover them directly as a
+    // MULTIPOINT (matching the prior hand-rolled fallback).
     let mut touch_points: Vec<Coord<f64>> = Vec::new();
-    // Boundary segments of the polygon, for crossing computation.
-    let boundary: Vec<Line<f64>> = poly
-        .0
-        .iter()
-        .flat_map(|p| {
-            std::iter::once(p.exterior().clone())
-                .chain(p.interiors().iter().cloned())
-                .flat_map(|r| r.lines().collect::<Vec<_>>())
-        })
-        .collect();
     for ls in line_strings(line) {
-        for seg in ls.lines() {
-            // Parametric positions (t in [0,1]) where this segment meets the
-            // polygon boundary, plus the endpoints.
-            let mut ts: Vec<f64> = vec![0.0, 1.0];
-            for bseg in &boundary {
-                if let Some(LineIntersection::SinglePoint { intersection, .. }) =
-                    line_intersection(seg, *bseg)
-                {
-                    ts.push(param_of(seg, intersection));
-                }
-            }
-            ts.retain(|t| t.is_finite() && (0.0..=1.0).contains(t));
-            ts.sort_by(|x, y| x.partial_cmp(y).unwrap());
-            ts.dedup_by(|x, y| (*x - *y).abs() <= 1e-12);
-            // Keep each sub-segment whose midpoint is inside-or-on the polygon.
-            for w in ts.windows(2) {
-                let (t0, t1) = (w[0], w[1]);
-                if t1 - t0 <= 1e-12 {
-                    continue;
-                }
-                let mid = at_param(seg, (t0 + t1) / 2.0);
-                if poly.coordinate_position(&mid) != CoordPos::Outside {
-                    pieces.push(LineString(vec![at_param(seg, t0), at_param(seg, t1)]));
-                }
+        for c in ls.0 {
+            if poly.coordinate_position(&c) != CoordPos::Outside {
+                touch_points.push(c);
             }
         }
     }
-    merge_pieces(&mut pieces);
-    if pieces.is_empty() {
-        // Possibly the line only grazes the polygon at isolated vertices.
-        for ls in line_strings(line) {
-            for c in ls.0 {
-                if poly.coordinate_position(&c) != CoordPos::Outside {
-                    touch_points.push(c);
-                }
-            }
-        }
-        return collect_points(touch_points);
-    }
-    collect_lines(pieces)
+    collect_points(touch_points)
 }
 
 /// The parameter t∈[0,1] of `c` along `seg` (projection onto the longer axis;

--- a/crates/sparq-geo/tests/relations.rs
+++ b/crates/sparq-geo/tests/relations.rs
@@ -453,6 +453,24 @@ fn intersection_polygon_clips_line() {
 }
 
 #[test]
+fn intersection_line_grazing_polygon_vertex_is_a_multipoint() {
+    // A line that only TOUCHES the polygon at an isolated corner vertex (with no
+    // in-polygon span): the intersection is that single point as a MULTIPOINT.
+    // `i_overlay`'s string-line clip drops zero-length pieces, so this exercises
+    // the isolated-touch-point fallback preserved through the migration. [OPUS-4.8]
+    let poly = "POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))";
+    // A line whose ENDPOINT lands on the (0,0) corner, otherwise heading
+    // below-left (outside): no in-polygon span, just the isolated touch vertex.
+    let grazing = lex::intersection("LINESTRING(0 0, -1 -1)", poly).unwrap();
+    assert!(grazing.contains("MULTIPOINT") && grazing.contains('0'), "got {grazing}");
+    let pt = parse_wkt_literal(&grazing).unwrap();
+    assert!(
+        geof::sf_equals(&pt, &parse_wkt_literal("MULTIPOINT(0 0)").unwrap()).unwrap(),
+        "got {grazing}"
+    );
+}
+
+#[test]
 fn intersection_line_crosses_line() {
     // Two crossing diagonals of the unit square meet at the centre (0.5, 0.5).
     let r = parse_wkt_literal(


### PR DESCRIPTION
> 🤖 SPARQ agent

## sq-yt4z — migrate line∩polygon intersection clip to i_overlay

`geof:intersection`'s **line ∩ polygon** case used the hand-rolled
`clip_lines_to_polygon` (geo `line_intersection` boundary splitting +
midpoint-inside tests), while **line − polygon** (sq-fxv3) already routes
through i_overlay's `FloatClip::clip_by`. Two different clippers for the two
halves of the same partition was a maintenance smell — this consolidates both
onto the single robustly-noded string-line clip.

### Change
- Replace `clip_lines_to_polygon` with `intersect_line_with_polygon`, which
  delegates to the existing `clip_line_by_polygon(invert=false,
  boundary_included=true)` helper — the **exact complement** of the
  `(invert=true, boundary_included=true)` rule used for line − polygon, so the
  two operations remain a clean partition (including boundary-tangent and holed
  cases).
- **Preserve** the isolated-touch-point → `MULTIPOINT` fallback: i_overlay
  drops zero-length pieces, so a line vertex merely grazing the polygon (with no
  in-polygon span) is recovered directly as a MULTIPOINT — matching the prior
  hand-rolled behaviour.
- The shared `param_of` / `at_param` / `merge_pieces` helpers stay (still used
  by the line − line subtraction path).

Behaviour-preserving cleanup: no public API change (both functions are
private), so no SKILL.md update is required.

### Tests
- Existing `intersection_polygon_clips_line`, the line∩polygon partition
  assertion in `difference_line_minus_polygon`, and the
  `difference_line_along_polygon_boundary_excludes_the_boundary_span` cases all
  still pass against the new clipper.
- Adds `intersection_line_grazing_polygon_vertex_is_a_multipoint` — a regression
  guard for the grazing-vertex MULTIPOINT fallback (verified identical to the
  pre-migration result).

### Gate
- `cargo build` / `cargo clippy --all-targets -- -D warnings` clean in **all**
  feature states (default `engine`, `--no-default-features`, `reproject`).
- `cargo test -p sparq-geo` green in both default and `--no-default-features`
  (the one `--no-default-features --doc` failure is a pre-existing,
  engine-gated doctest unrelated to this change — confirmed on baseline).
- Privacy-claims gate: OK (no privacy/soundness code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
