### PR TITLE
feat(site): /surface/shacl tier-b live SHACL validator (sq-egy6) [OPUS-4.8]

### DIFF
--- a/site/src/app/surface/shacl/page.tsx
+++ b/site/src/app/surface/shacl/page.tsx
@@ -2,11 +2,12 @@ import type { Metadata } from "next";
 import { ShieldCheck } from "lucide-react";
 
 import { SurfaceContent } from "@/components/surface-content";
+import { ShaclPlayground } from "@/components/shacl-playground";
 
 export const metadata: Metadata = {
   title: "SHACL",
   description:
-    "Validate RDF against SHACL shapes with the sparq engine — SHACL Core constraints, SHACL-SPARQL, custom constraint components, and the W3C validation report.",
+    "Validate RDF against SHACL shapes with the sparq engine — SHACL Core constraints, SHACL-SPARQL, custom constraint components, and the W3C validation report, live in your tab.",
 };
 
 export default function ShaclSurfacePage() {
@@ -15,8 +16,7 @@ export default function ShaclSurfacePage() {
       icon={ShieldCheck}
       title="SHACL"
       statement="Validate RDF data against shapes — SHACL Core, SHACL-SPARQL, and the W3C validation report."
-      tier="live-new-wasm"
-      extraBadge="Portability spike first"
+      tier="live"
       intro={
         <>
           <p>
@@ -31,9 +31,11 @@ export default function ShaclSurfacePage() {
           </p>
           <p>
             Because it is pure Rust over <code className="font-mono">sparq-engine</code>
-            , it is wasm-portable: a dedicated{" "}
-            <code className="font-mono text-foreground">sparq-shacl-wasm</code>{" "}
-            bundle can validate data + shapes in-tab, lazy-loaded only on this page.
+            , it is wasm-portable. The SHACL-enabled wasm bundle — the same one the
+            published <code className="font-mono text-foreground">@jeswr/sparq</code>{" "}
+            ships — runs the validator in this tab: paste data + shapes below and the
+            conformance flag and per-violation report come back with no network
+            round-trip.
           </p>
         </>
       }
@@ -66,23 +68,32 @@ export default function ShaclSurfacePage() {
       runsNote={
         <>
           <p>
-            Planned <strong className="text-foreground">live in your tab via a new
-            wasm bundle</strong>. The validator is pure Rust over the engine, so it
-            ports cleanly; the bundle is lazy-loaded on this page only to keep the
-            landing page light.
+            <strong className="text-foreground">Live in your browser tab.</strong>{" "}
+            The validator is pure Rust over the engine, compiled to wasm in the
+            SHACL-enabled bundle (the published{" "}
+            <code className="font-mono">@jeswr/sparq</code> ships it). The playground
+            calls the bundle&rsquo;s{" "}
+            <code className="font-mono text-foreground">Store.validate(data, shapes)</code>{" "}
+            binding, parses the two graphs, and renders the conformance flag plus the
+            per-violation W3C report — nothing is sent to a server.
           </p>
         </>
       }
       caveat={
         <>
           <p>
-            SHACL-SPARQL constraints rely on the engine&rsquo;s REGEX, which is
-            compiled out of the lean bundle — the SHACL bundle must include it (a
-            size trade-off confirmed by a portability spike). Until that bundle
-            ships, this surface is a captured-I/O walkthrough.
+            SHACL-SPARQL constraints rely on the engine&rsquo;s REGEX. The lean SPARQL
+            REPL bundle compiles REGEX out, but the SHACL bundle keeps it, so{" "}
+            <code className="font-mono">sh:sparql</code> constraints validate in-tab
+            too. The in-tab validator is sized for small documents (~10–100 triples);
+            validate large graphs server-side via the{" "}
+            <code className="font-mono">sparq-server</code> HTTP{" "}
+            <code className="font-mono">validate</code> path.
           </p>
         </>
       }
-    />
+    >
+      <ShaclPlayground />
+    </SurfaceContent>
   );
 }

--- a/site/src/components/shacl-playground.tsx
+++ b/site/src/components/shacl-playground.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+// [OPUS-4.8] sq-egy6 — the live /surface/shacl playground: two textareas (data +
+// shapes) -> conformance flag + per-violation W3C report, run entirely in your tab
+// via the shacl-enabled wasm bundle (Store.validate). The default example is the
+// `ex:age "thirty"` datatype violation from skills/shacl-validation/SKILL.md.
+
+import * as React from "react";
+import {
+  Play,
+  Loader2,
+  ShieldCheck,
+  CheckCircle2,
+  XCircle,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  prewarmSparq,
+  sparqShaclValidate,
+  type ShaclReport,
+} from "@/lib/sparq-wasm";
+import {
+  componentName,
+  reportSummary,
+  reportToTurtle,
+  severityName,
+  shortenIri,
+} from "@/lib/shacl-report";
+import { SHACL_EXAMPLES } from "@/data/shacl-examples";
+
+type RunState =
+  | { kind: "idle" }
+  | { kind: "running" }
+  | { kind: "report"; report: ShaclReport; ms: number }
+  | { kind: "error"; message: string };
+
+type EngineState = "cold" | "warming" | "ready" | "error";
+type View = "results" | "turtle";
+
+const DEFAULT = SHACL_EXAMPLES[0];
+
+export function ShaclPlayground() {
+  const [data, setData] = React.useState(DEFAULT.data);
+  const [shapes, setShapes] = React.useState(DEFAULT.shapes);
+  const [state, setState] = React.useState<RunState>({ kind: "idle" });
+  const [engine, setEngine] = React.useState<EngineState>("cold");
+  const [activeExample, setActiveExample] = React.useState<string>(DEFAULT.id);
+  const [view, setView] = React.useState<View>("results");
+
+  // Pre-warm the wasm engine on mount (off the render path) so the first "Validate"
+  // pays no cold start. A failure resets the indicator; validate() retries the load.
+  React.useEffect(() => {
+    let cancelled = false;
+    setEngine("warming");
+    prewarmSparq()
+      .then(() => {
+        if (!cancelled) setEngine("ready");
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setEngine("error");
+        toast.error("Engine failed to load", {
+          description: e instanceof Error ? e.message : String(e),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const run = React.useCallback(async () => {
+    setState({ kind: "running" });
+    try {
+      const t0 = performance.now();
+      const report = await sparqShaclValidate(data, shapes, "turtle");
+      const ms = performance.now() - t0;
+      setEngine("ready");
+      setState({ kind: "report", report, ms });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setState({ kind: "error", message });
+      toast.error("Validation failed", { description: message });
+    }
+  }, [data, shapes]);
+
+  const selectExample = React.useCallback((id: string) => {
+    const ex = SHACL_EXAMPLES.find((e) => e.id === id);
+    if (!ex) return;
+    setData(ex.data);
+    setShapes(ex.shapes);
+    setActiveExample(id);
+    setState({ kind: "idle" });
+  }, []);
+
+  const busy = state.kind === "running";
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center justify-between gap-2 space-y-0">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <ShieldCheck className="size-4 text-primary" />
+          Live SHACL validator
+        </CardTitle>
+        <EngineIndicator engine={engine} />
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap gap-1.5">
+          {SHACL_EXAMPLES.map((ex) => (
+            <Button
+              key={ex.id}
+              variant={activeExample === ex.id ? "default" : "outline"}
+              size="sm"
+              onClick={() => selectExample(ex.id)}
+              title={ex.description}
+            >
+              {ex.label}
+            </Button>
+          ))}
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="space-y-1.5">
+            <label
+              htmlFor="shacl-data"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Data graph (Turtle)
+            </label>
+            <textarea
+              id="shacl-data"
+              value={data}
+              spellCheck={false}
+              onChange={(e) => setData(e.target.value)}
+              rows={12}
+              className="w-full resize-y rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label
+              htmlFor="shacl-shapes"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Shapes graph (Turtle)
+            </label>
+            <textarea
+              id="shacl-shapes"
+              value={shapes}
+              spellCheck={false}
+              onChange={(e) => setShapes(e.target.value)}
+              rows={12}
+              className="w-full resize-y rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Button onClick={run} disabled={busy}>
+            {busy ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Play className="size-4" />
+            )}
+            Validate
+          </Button>
+          {state.kind === "report" && (
+            <ViewTabs view={view} onChange={setView} />
+          )}
+          <p aria-live="polite" className="text-xs text-muted-foreground">
+            {state.kind === "report" &&
+              `${state.report.results.length} result${state.report.results.length === 1 ? "" : "s"} · ${state.ms.toFixed(1)} ms`}
+            {state.kind === "running" && "Validating on the wasm engine…"}
+            {state.kind === "idle" &&
+              engine === "warming" &&
+              "Pre-warming the wasm engine…"}
+          </p>
+        </div>
+
+        <ResultPanel state={state} view={view} />
+      </CardContent>
+    </Card>
+  );
+}
+
+function EngineIndicator({ engine }: { engine: EngineState }) {
+  if (engine === "ready") {
+    return (
+      <Badge variant="success" aria-live="polite">
+        <CheckCircle2 className="size-3" /> Engine ready
+      </Badge>
+    );
+  }
+  if (engine === "error") {
+    return (
+      <Badge variant="warning" aria-live="polite">
+        Engine failed — retries on validate
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="muted" aria-live="polite">
+      <Loader2 className="size-3 animate-spin" /> Engine loading…
+    </Badge>
+  );
+}
+
+function ViewTabs({
+  view,
+  onChange,
+}: {
+  view: View;
+  onChange: (v: View) => void;
+}) {
+  const tabs: { value: View; label: string }[] = [
+    { value: "results", label: "Results" },
+    { value: "turtle", label: "W3C Turtle" },
+  ];
+  return (
+    <div
+      role="tablist"
+      aria-label="Report view"
+      className="inline-flex rounded-lg border bg-muted/40 p-0.5"
+    >
+      {tabs.map((t) => (
+        <button
+          key={t.value}
+          type="button"
+          role="tab"
+          aria-selected={view === t.value}
+          onClick={() => onChange(t.value)}
+          className={cn(
+            "rounded-md px-2.5 py-1 text-xs font-medium transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/40",
+            view === t.value
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ResultPanel({ state, view }: { state: RunState; view: View }) {
+  if (state.kind === "error") {
+    return (
+      <pre className="overflow-x-auto rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+        {state.message}
+      </pre>
+    );
+  }
+  if (state.kind !== "report") return null;
+  const { report } = state;
+
+  return (
+    <div className="space-y-3">
+      <ConformanceBanner conforms={report.conforms} summary={reportSummary(report)} />
+      {view === "turtle" ? (
+        <pre className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed">
+          {reportToTurtle(report)}
+        </pre>
+      ) : (
+        <ResultList report={report} />
+      )}
+    </div>
+  );
+}
+
+function ConformanceBanner({
+  conforms,
+  summary,
+}: {
+  conforms: boolean;
+  summary: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 rounded-lg p-3 text-sm font-medium",
+        conforms
+          ? "bg-[color-mix(in_oklch,var(--success)_15%,transparent)] text-[var(--success)]"
+          : "bg-destructive/10 text-destructive",
+      )}
+    >
+      {conforms ? (
+        <CheckCircle2 className="size-4" aria-hidden="true" />
+      ) : (
+        <XCircle className="size-4" aria-hidden="true" />
+      )}
+      <span>
+        <span className="font-mono">sh:conforms</span> = {conforms ? "true" : "false"}{" "}
+        — {summary}
+      </span>
+    </div>
+  );
+}
+
+function ResultList({ report }: { report: ShaclReport }) {
+  if (report.results.length === 0) {
+    return (
+      <p className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+        No violations — every targeted node satisfies its shape.
+      </p>
+    );
+  }
+  return (
+    <ul className="space-y-2">
+      {report.results.map((r, i) => (
+        <li
+          key={i}
+          className="rounded-lg border bg-muted/30 p-3 text-sm"
+        >
+          <div className="mb-1.5 flex flex-wrap items-center gap-2">
+            <Badge variant="warning" className="font-mono text-[11px]">
+              {componentName(r.sourceConstraintComponent)}
+            </Badge>
+            <Badge variant="muted" className="text-[11px]">
+              {severityName(r.severity)}
+            </Badge>
+          </div>
+          {r.message && (
+            <p className="mb-1.5 text-foreground">{r.message}</p>
+          )}
+          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 font-mono text-[12px] text-muted-foreground">
+            <dt>focus</dt>
+            <dd className="break-all text-foreground">{shortenIri(r.focusNode)}</dd>
+            {r.path && (
+              <>
+                <dt>path</dt>
+                <dd className="break-all text-foreground">{shortenIri(r.path)}</dd>
+              </>
+            )}
+            {r.value && (
+              <>
+                <dt>value</dt>
+                <dd className="break-all text-foreground">{shortenIri(r.value)}</dd>
+              </>
+            )}
+          </dl>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/site/src/data/shacl-examples.ts
+++ b/site/src/data/shacl-examples.ts
@@ -1,0 +1,77 @@
+// [OPUS-4.8] sq-egy6 — built-in examples for the live /surface/shacl playground.
+// The default is the `ex:age "thirty"` datatype-violation walkthrough from
+// skills/shacl-validation/SKILL.md: a string where an xsd:integer is required.
+
+export interface ShaclExample {
+  id: string;
+  label: string;
+  description: string;
+  /** True when this example's data is expected to conform (no violations). */
+  conforms: boolean;
+  data: string;
+  shapes: string;
+}
+
+const PERSON_SHAPE = `@prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix ex:  <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:PersonShape a sh:NodeShape ;
+  sh:targetClass ex:Person ;
+  sh:property [
+    sh:path ex:age ;
+    sh:datatype xsd:integer ;
+    sh:minCount 1 ;
+    sh:message "ex:age must be exactly one xsd:integer" ;
+  ] ;
+  sh:property [
+    sh:path ex:name ;
+    sh:datatype xsd:string ;
+    sh:minCount 1 ;
+  ] .
+`;
+
+export const SHACL_EXAMPLES: ShaclExample[] = [
+  {
+    id: "datatype-violation",
+    label: 'Datatype violation (ex:age "thirty")',
+    description:
+      'ex:alice has ex:age "thirty" — a string where the shape requires an xsd:integer. The report is non-conformant with one DatatypeConstraintComponent result.',
+    conforms: false,
+    data: `@prefix ex: <http://example.org/> .
+
+# age is a string literal, not an integer — this violates sh:datatype xsd:integer.
+ex:alice a ex:Person ;
+  ex:name "Alice" ;
+  ex:age "thirty" .
+`,
+    shapes: PERSON_SHAPE,
+  },
+  {
+    id: "conforms",
+    label: "Conforming data",
+    description:
+      "The same shape, but ex:age is a well-typed integer literal — the report conforms (sh:conforms = true, no results).",
+    conforms: true,
+    data: `@prefix ex: <http://example.org/> .
+
+ex:alice a ex:Person ;
+  ex:name "Alice" ;
+  ex:age 30 .
+`,
+    shapes: PERSON_SHAPE,
+  },
+  {
+    id: "min-count",
+    label: "Missing required property",
+    description:
+      "ex:bob has an integer age but no ex:name — the sh:minCount 1 on ex:name fails, so the report carries a MinCountConstraintComponent result.",
+    conforms: false,
+    data: `@prefix ex: <http://example.org/> .
+
+ex:bob a ex:Person ;
+  ex:age 41 .
+`,
+    shapes: PERSON_SHAPE,
+  },
+];

--- a/site/src/data/surfaces.ts
+++ b/site/src/data/surfaces.ts
@@ -162,7 +162,7 @@ export const GROUPS: SurfaceGroup[] = [
         href: "/surface/shacl",
         title: "SHACL",
         blurb: "SHACL Core + SHACL-SPARQL → W3C validation report.",
-        tier: "live-new-wasm",
+        tier: "live",
         icon: ShieldCheck,
         built: true,
       },

--- a/site/src/lib/shacl-report.ts
+++ b/site/src/lib/shacl-report.ts
@@ -1,0 +1,99 @@
+// [OPUS-4.8] sq-egy6 — pure, framework-free helpers for rendering a SHACL
+// validation report in the live /surface/shacl playground. Kept separate from the
+// React component so they can be unit-tested under node:test without a DOM.
+
+import type { ShaclReport, ShaclResult } from "./sparq-wasm";
+
+const PREFIXES: [string, string][] = [
+  ["http://www.w3.org/ns/shacl#", "sh:"],
+  ["http://www.w3.org/2001/XMLSchema#", "xsd:"],
+  ["http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdf:"],
+  ["http://www.w3.org/2000/01/rdf-schema#", "rdfs:"],
+  ["http://example.org/", "ex:"],
+];
+
+/**
+ * Compacts a full IRI (optionally wrapped in `<>` as a term string) to a CURIE
+ * using the well-known SHACL/XSD/example prefixes. Anything outside those
+ * namespaces is returned unchanged. Blank-node (`_:b0`) and literal term strings
+ * pass through untouched.
+ */
+export function shortenIri(s: string): string {
+  const inner = s.startsWith("<") && s.endsWith(">") ? s.slice(1, -1) : s;
+  for (const [ns, prefix] of PREFIXES) {
+    if (inner.startsWith(ns)) {
+      return prefix + inner.slice(ns.length);
+    }
+  }
+  return s;
+}
+
+/** The bare local name of a SHACL constraint-component IRI, e.g.
+ *  `…#DatatypeConstraintComponent` -> `DatatypeConstraintComponent`. */
+export function componentName(iri: string): string {
+  const hash = iri.lastIndexOf("#");
+  return hash >= 0 ? iri.slice(hash + 1) : iri;
+}
+
+/** The bare local name of a severity IRI, e.g. `…#Violation` -> `Violation`. */
+export function severityName(iri: string): string {
+  return componentName(iri);
+}
+
+/**
+ * A one-line, human summary of the report: either "Conforms" or the violation
+ * count. Mirrors the conformance flag the bead asks the page to surface.
+ */
+export function reportSummary(report: ShaclReport): string {
+  if (report.conforms) return "Conforms — no violations.";
+  const n = report.results.length;
+  return `Does not conform — ${n} ${n === 1 ? "violation" : "violations"}.`;
+}
+
+/** Escapes a string literal for inclusion in a Turtle document (`"` and `\`). */
+function turtleString(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Renders the report as a W3C `sh:ValidationReport` Turtle graph — the per-result
+ * vocabulary (`sh:result`, `sh:focusNode`, `sh:resultPath`, `sh:value`,
+ * `sh:resultSeverity`, `sh:sourceConstraintComponent`, `sh:sourceShape`,
+ * `sh:resultMessage`). This is a faithful client-side serialisation of the JSON the
+ * wasm `validate` binding returns; the canonical Turtle serialiser is in
+ * `sparq-shacl` (`ValidationReport::to_turtle`).
+ */
+export function reportToTurtle(report: ShaclReport): string {
+  const lines: string[] = [
+    "@prefix sh:   <http://www.w3.org/ns/shacl#> .",
+    "@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .",
+    "",
+    "[] a sh:ValidationReport ;",
+    `  sh:conforms ${report.conforms ? "true" : "false"}`,
+  ];
+  if (report.results.length === 0) {
+    lines[lines.length - 1] += " .";
+    return lines.join("\n") + "\n";
+  }
+  lines[lines.length - 1] += " ;";
+  report.results.forEach((r, i) => {
+    const last = i === report.results.length - 1;
+    lines.push("  sh:result [");
+    lines.push("    a sh:ValidationResult ;");
+    lines.push(`    sh:focusNode ${r.focusNode} ;`);
+    if (r.path) lines.push(`    sh:resultPath ${r.path} ;`);
+    if (r.value) lines.push(`    sh:value ${r.value} ;`);
+    lines.push(`    sh:resultSeverity <${r.severity}> ;`);
+    lines.push(
+      `    sh:sourceConstraintComponent <${r.sourceConstraintComponent}> ;`,
+    );
+    lines.push(`    sh:sourceShape ${r.sourceShape} ;`);
+    if (r.message) lines.push(`    sh:resultMessage "${turtleString(r.message)}" ;`);
+    // Trim the trailing ` ;` of the last property inside the blank node.
+    lines[lines.length - 1] = lines[lines.length - 1].replace(/ ;$/, "");
+    lines.push(last ? "  ] ." : "  ] ;");
+  });
+  return lines.join("\n") + "\n";
+}
+
+export type { ShaclReport, ShaclResult };

--- a/site/src/lib/sparq-wasm.ts
+++ b/site/src/lib/sparq-wasm.ts
@@ -24,6 +24,11 @@ export interface WasmStore {
   updateInPlace(sparql: string): void; // INSERT/DELETE/LOAD/graph-mgmt -> mutate store
   explain(sparql: string): string; // planning-only plan text (every query form)
   explainAnalyze(sparql: string): string; // plan + per-operator trace (SELECT/ASK only)
+  // [OPUS-4.8] sq-egy6 — the SHACL `validate` binding. Present only when the bundle
+  // is built with `--features shacl` (the site's default `build:wasm`, and the
+  // published `@jeswr/sparq`, both enable it). Stateless: it does NOT consult the
+  // receiver's stored triples — it parses `data`/`shapes` and validates one-shot.
+  validate?: (data: string, shapes: string, format: string) => string;
 }
 
 interface WasmModule {
@@ -146,6 +151,59 @@ export interface SparqlResults {
   head: { vars: string[] };
   results: { bindings: Record<string, SparqlTerm>[] };
   boolean?: boolean;
+}
+
+// ---- SHACL validation report (mirrors crates/sparq-wasm/src/shacl.rs JSON) ----
+
+/**
+ * [OPUS-4.8] sq-egy6 — one SHACL validation result, the per-violation record the
+ * wasm `Store.validate` binding emits (a drop-in for `rdf-validate-shacl`'s
+ * results). `focusNode`/`value`/`sourceShape` are N-Triples term strings; `path`
+ * is a SHACL Turtle path expression; `sourceConstraintComponent`/`severity` are
+ * full IRIs. `path`/`value`/`message` are `null` when the result carries none.
+ */
+export interface ShaclResult {
+  focusNode: string;
+  path: string | null;
+  value: string | null;
+  sourceShape: string;
+  sourceConstraintComponent: string;
+  severity: string;
+  message: string | null;
+}
+
+/**
+ * [OPUS-4.8] sq-egy6 — a SHACL validation report. `conforms` counts EVERY result
+ * regardless of severity (the W3C-suite notion); `results` is the per-violation list.
+ */
+export interface ShaclReport {
+  conforms: boolean;
+  results: ShaclResult[];
+}
+
+/**
+ * [OPUS-4.8] sq-egy6 — validate an RDF **data** document against a SHACL **shapes**
+ * document, entirely in your tab via the shacl-enabled wasm bundle. Both arguments
+ * use the same syntaxes {@link loadIntoStore} accepts. A clear error is thrown if the
+ * loaded bundle was built without the `shacl` feature (no `validate` binding), so a
+ * caller can distinguish "no SHACL in this bundle" from a parse error.
+ */
+export async function sparqShaclValidate(
+  data: string,
+  shapes: string,
+  format = "turtle",
+): Promise<ShaclReport> {
+  const Store = await loadSparq();
+  // `validate` is a stateless one-shot, but it is exposed as an instance method on
+  // the wasm `Store`, so we need any receiver. An empty store is the cheapest.
+  const store = Store.load("", format);
+  if (typeof store.validate !== "function") {
+    throw new Error(
+      "This wasm bundle was built without the SHACL feature (no validate binding). " +
+        "Rebuild sparq-wasm with --features shacl.",
+    );
+  }
+  return JSON.parse(store.validate(data, shapes, format)) as ShaclReport;
 }
 
 /** Renders a term for display, with a compact datatype/lang suffix. */

--- a/site/test/shacl-report.test.mjs
+++ b/site/test/shacl-report.test.mjs
@@ -1,0 +1,100 @@
+// [OPUS-4.8] sq-egy6 — unit tests for the pure SHACL-report rendering helpers that
+// back the live /surface/shacl playground. These cover the framework-free CURIE
+// shortening, component/severity local names, conformance summary, and the W3C
+// Turtle serialisation. The wasm `Store.validate` binding itself is proven by the
+// Rust tests in crates/sparq-wasm/src/shacl.rs; here we only test the JS rendering
+// of the JSON report it returns. Run via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  shortenIri,
+  componentName,
+  severityName,
+  reportSummary,
+  reportToTurtle,
+} from "../src/lib/shacl-report.ts";
+
+// The `ex:age "thirty"` datatype violation, as the wasm validate binding returns it.
+const DATATYPE_VIOLATION = {
+  conforms: false,
+  results: [
+    {
+      focusNode: "<http://example.org/alice>",
+      path: "<http://example.org/age>",
+      value: '"thirty"',
+      sourceShape: "_:b0",
+      sourceConstraintComponent:
+        "http://www.w3.org/ns/shacl#DatatypeConstraintComponent",
+      severity: "http://www.w3.org/ns/shacl#Violation",
+      message: "ex:age must be exactly one xsd:integer",
+    },
+  ],
+};
+
+const CONFORMS = { conforms: true, results: [] };
+
+test("shortenIri compacts the well-known namespaces and leaves the rest alone", () => {
+  assert.equal(shortenIri("<http://example.org/alice>"), "ex:alice");
+  assert.equal(shortenIri("<http://example.org/age>"), "ex:age");
+  assert.equal(
+    shortenIri("<http://www.w3.org/2001/XMLSchema#integer>"),
+    "xsd:integer",
+  );
+  assert.equal(
+    shortenIri("<http://www.w3.org/ns/shacl#Violation>"),
+    "sh:Violation",
+  );
+  // Literal term strings and blank nodes pass through untouched.
+  assert.equal(shortenIri('"thirty"'), '"thirty"');
+  assert.equal(shortenIri("_:b0"), "_:b0");
+  // An IRI outside the known prefixes is returned unchanged.
+  assert.equal(shortenIri("<http://other.test/x>"), "<http://other.test/x>");
+});
+
+test("componentName / severityName take the local part after the hash", () => {
+  assert.equal(
+    componentName("http://www.w3.org/ns/shacl#DatatypeConstraintComponent"),
+    "DatatypeConstraintComponent",
+  );
+  assert.equal(severityName("http://www.w3.org/ns/shacl#Violation"), "Violation");
+});
+
+test("reportSummary reflects conformance and violation count", () => {
+  assert.equal(reportSummary(CONFORMS), "Conforms — no violations.");
+  assert.equal(
+    reportSummary(DATATYPE_VIOLATION),
+    "Does not conform — 1 violation.",
+  );
+  assert.equal(
+    reportSummary({ conforms: false, results: [{}, {}] }),
+    "Does not conform — 2 violations.",
+  );
+});
+
+test("reportToTurtle emits a conforming sh:ValidationReport with no results", () => {
+  const ttl = reportToTurtle(CONFORMS);
+  assert.match(ttl, /a sh:ValidationReport/);
+  assert.match(ttl, /sh:conforms true \./);
+  assert.ok(!ttl.includes("sh:result"), "no sh:result for a conforming report");
+});
+
+test("reportToTurtle emits the per-violation W3C vocabulary", () => {
+  const ttl = reportToTurtle(DATATYPE_VIOLATION);
+  assert.match(ttl, /sh:conforms false ;/);
+  assert.match(ttl, /sh:result \[/);
+  assert.match(ttl, /a sh:ValidationResult ;/);
+  assert.match(ttl, /sh:focusNode <http:\/\/example\.org\/alice> ;/);
+  assert.match(ttl, /sh:resultPath <http:\/\/example\.org\/age> ;/);
+  assert.match(ttl, /sh:value "thirty" ;/);
+  assert.match(
+    ttl,
+    /sh:sourceConstraintComponent <http:\/\/www\.w3\.org\/ns\/shacl#DatatypeConstraintComponent> ;/,
+  );
+  assert.match(
+    ttl,
+    /sh:resultMessage "ex:age must be exactly one xsd:integer"/,
+  );
+  // The blank-node and the report both terminate correctly.
+  assert.match(ttl, /\] \./);
+});


### PR DESCRIPTION
> 🤖 SPARQ agent — automated PR for bead **sq-egy6** (one of @jeswr's agents on this account).

## What

Turns the `/surface/shacl` page from a captured-I/O walkthrough into a **genuinely live, in-tab SHACL validator** (the bead's tier-b "live" goal).

- Two textareas — **data graph** + **shapes graph** (Turtle) — drive `Store.validate(data, shapes)` on the wasm engine.
- The result is the **conformance flag** (`sh:conforms`) plus a **per-violation W3C validation report**, rendered two ways: a per-violation list (constraint component, severity, focus node, path, value, message) and a `sh:ValidationReport` **Turtle** view.
- The default example is the **`ex:age "thirty"` datatype violation** from `skills/shacl-validation/SKILL.md` (a string where `xsd:integer` is required), plus a conforming variant and a `sh:minCount` missing-property variant.

## How it's live (honesty note)

No new "W-shacl" bundle was needed. The `validate` binding already ships in the **SHACL-enabled wasm bundle** that the site's default `build:wasm` (`--features shacl,jsonld`) and the published `@jeswr/sparq` both produce, and which `scripts/sync-wasm.mjs` copies into `public/wasm/`. The page just exposes it. Validation runs entirely in your tab — nothing is sent to a server.

I verified the live path end-to-end: built the SHACL wasm bundle and confirmed `Store.validate` returns the `DatatypeConstraintComponent` violation for `ex:age "thirty"` (`conforms=false`, focus `ex:alice`, value `"thirty"`, declared message), and that the empty-store receiver path used by the helper works.

## Files

- `site/src/lib/sparq-wasm.ts` — optional `validate` on `WasmStore` + a `sparqShaclValidate()` helper that throws a clear error on a shacl-less bundle.
- `site/src/lib/shacl-report.ts` — pure, unit-tested rendering helpers (CURIE shortening, component/severity local names, conformance summary, W3C Turtle serialisation).
- `site/src/components/shacl-playground.tsx` — the live client playground.
- `site/src/data/shacl-examples.ts` — the three built-in examples.
- `site/src/data/surfaces.ts` + `site/src/app/surface/shacl/page.tsx` — tier flipped `live-new-wasm` → `live`.
- `site/test/shacl-report.test.mjs` — 5 unit tests for the pure helpers.

## Gate

- `eslint` on all changed files: clean
- `tsc --noEmit`: clean
- `next build`: succeeds, `/surface/shacl` statically exported (3.84 kB)
- `npm run test:unit`: 27/27 pass (incl. the 5 new ones)
- `scripts/check-privacy-claims.sh`: OK (290 files scanned, no unqualified privacy/soundness claim)
- G2 public-api→SKILL.md: N/A — no Rust public API changed; the wasm `validate` binding it wraps was already shipped + documented in the shacl-validation / javascript-wasm skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)