### PR TITLE
fix(sparq-server): gate /metrics under --auth-token-read (sq-9jrx) [OPUS-4.8]

### DIFF
--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -36,6 +36,10 @@ surface** (PSS gh-46), with an **optional read gate**:
 - **`--auth-token-read`** (env `SPARQ_AUTH_TOKEN_READ=1`) — ALSO gate **reads** (SPARQL query,
   GSP `GET`/`HEAD`, AND the subscription read surfaces — see below) with the same token. Off by
   default (QLever-style: writes gated, reads open). Has no effect unless a token is also configured.
+  [OPUS-4.8] (`sq-9jrx`) The Prometheus **`GET /metrics`** exposition is also gated by
+  `--auth-token-read`: its gauges leak the live graph triple count and the active-subscription
+  count, so it is treated as a read (mirrors QLever, which keeps its stats endpoint behind the
+  same token). **`/health` stays ungated** for liveness probes.
 - The 401 is **identical for a missing vs a wrong token**, so an attacker cannot learn whether
   a token was presented.
 - The subscription transports — the **`/subscriptions` WebSocket** and the

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -1968,7 +1968,15 @@ pub fn router(state: AppState) -> Router {
 
 /// `GET /metrics` — Prometheus text exposition (T22). The gauges (graph triple
 /// count, active subscriptions) are read at scrape time from live state.
-async fn metrics_endpoint(State(state): State<AppState>) -> Response {
+///
+/// [OPUS-4.8] sq-9jrx: the exposition leaks the live graph triple count and the
+/// active-subscription count, so it is treated as a READ and gated by
+/// `--auth-token-read` like any other GET (mirrors QLever, which keeps its stats
+/// endpoint behind the same token). `/health` stays ungated for liveness probes.
+async fn metrics_endpoint(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Some(resp) = auth_gate(state.config(), &headers, Operation::Read) {
+        return resp;
+    }
     let triples = state.current().snapshot().len();
     let subs = state.subs.active_count();
     let body = state.metrics().render(subs, triples);

--- a/crates/sparq-server/tests/auth.rs
+++ b/crates/sparq-server/tests/auth.rs
@@ -338,6 +338,88 @@ async fn reads_gated_when_read_gate_on() {
 }
 
 // ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-9jrx: /metrics is a READ (it leaks the live triple count and the
+// active-subscription count), so it is gated by --auth-token-read like any other
+// GET. /health stays ungated for liveness probes.
+// ---------------------------------------------------------------------------
+
+/// With only a write-token, `/metrics` stays OPEN (no Authorization needed) — same
+/// as any other read in write-only mode.
+#[tokio::test]
+async fn metrics_open_when_only_write_token_set() {
+    let base = spawn_with(token_config(false)).await;
+    let cl = client();
+    let r = cl.get(format!("{base}/metrics")).send().await.unwrap();
+    assert_eq!(
+        r.status(),
+        200,
+        "/metrics must be open with only a write-token"
+    );
+    assert!(r.text().await.unwrap().contains("sparq_graph_triples"));
+}
+
+/// With `--auth-token-read` on, `/metrics` is GATED: no token => 401 with
+/// `WWW-Authenticate: Bearer` (and the gauges are NOT disclosed); correct token => 200.
+#[tokio::test]
+async fn metrics_gated_when_read_gate_on() {
+    let base = spawn_with(token_config(true)).await;
+    let cl = client();
+
+    // No header => 401, and the body must NOT contain the leaked gauges.
+    let unauth = cl.get(format!("{base}/metrics")).send().await.unwrap();
+    assert_eq!(
+        unauth.status(),
+        401,
+        "/metrics must be gated with --auth-token-read"
+    );
+    assert_eq!(
+        unauth
+            .headers()
+            .get("www-authenticate")
+            .map(|v| v.to_str().unwrap()),
+        Some("Bearer"),
+        "the /metrics 401 must carry WWW-Authenticate: Bearer"
+    );
+    assert!(
+        !unauth.text().await.unwrap().contains("sparq_graph_triples"),
+        "a gated /metrics must not disclose the triple-count gauge"
+    );
+
+    // Wrong token => still 401.
+    let wrong = cl
+        .get(format!("{base}/metrics"))
+        .header("authorization", "Bearer not-the-token")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(wrong.status(), 401, "wrong token on /metrics => 401");
+
+    // Correct token => 200 and the exposition is served.
+    let authed = cl
+        .get(format!("{base}/metrics"))
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(authed.status(), 200, "correct token => /metrics 200");
+    assert!(authed.text().await.unwrap().contains("sparq_graph_triples"));
+}
+
+/// `/health` stays UNGATED for liveness probes even with `--auth-token-read` on.
+#[tokio::test]
+async fn health_open_even_when_read_gate_on() {
+    let base = spawn_with(token_config(true)).await;
+    let cl = client();
+    let r = cl.get(format!("{base}/health")).send().await.unwrap();
+    assert_eq!(
+        r.status(),
+        200,
+        "/health must stay open for liveness even under --auth-token-read"
+    );
+    assert_eq!(r.text().await.unwrap(), "ok");
+}
+
+// ---------------------------------------------------------------------------
 // Mutation classification (not route): UPDATE via the query path
 // ---------------------------------------------------------------------------
 

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -39,6 +39,9 @@ cargo run -p sparq-server -- --addr 0.0.0.0:8080 --allow-remote --format ntriple
 > too (bead `sq-cxk5`, closing the prior read-auth bypass): the SSE GET takes the
 > `Authorization: Bearer` header; the WS upgrade accepts that header OR (for browsers, which
 > cannot set headers on a WS handshake) a `Sec-WebSocket-Protocol: bearer.<token>` subprotocol.
+> The Prometheus `GET /metrics` endpoint is gated by `--auth-token-read` as well (bead
+> `sq-9jrx`): its gauges leak the live triple count and active-subscription count, so it is a
+> read; `/health` stays ungated for liveness probes.
 > With no read gate, both are open (back-compatible). The server binds **loopback by default** and **refuses a non-loopback
 > bind** (e.g. `0.0.0.0`) unless you set `--allow-remote` (env `SPARQ_ALLOW_REMOTE=1`) OR the
 > whole surface is authenticated (`--auth-token` AND `--auth-token-read`) — a write-token
@@ -330,7 +333,7 @@ curl -X POST 'http://127.0.0.1:3030/sparql/graph?graph=http://ex/g' \
 curl -X DELETE 'http://127.0.0.1:3030/sparql/graph?graph=http://ex/g'
 
 curl http://127.0.0.1:3030/health                               # -> "ok"
-curl http://127.0.0.1:3030/metrics                              # Prometheus text exposition
+curl http://127.0.0.1:3030/metrics                              # Prometheus text exposition (gated by --auth-token-read; sq-9jrx)
 
 # Admin WAL compaction / vacuum for ERASURE-COMPLETENESS (sq-x32t). POST-only; gated by the
 # WRITE token. Physically purges data removed by DELETE / DROP (incl. orphaned literal VALUES) from the


### PR DESCRIPTION
> 🤖 SPARQ agent — automated change for bead `sq-9jrx`.

## What & why

`sq-zcby` added `--auth-token-read` to gate the READ surface (SPARQL query + GSP `GET`/`HEAD`), but `GET /metrics` (the Prometheus exposition) is served **outside** the gated handlers. So under `--auth-token-read` an unauthenticated client could still read the **live graph triple count** and **active-subscription count** via `/metrics` — a minor info disclosure.

This treats `/metrics` as a **READ** and gates it with `auth_gate(Operation::Read)` like any other `GET`, mirroring QLever (which keeps its stats endpoint behind the same token). `/health` stays **ungated** for liveness probes.

## Changes

- **`crates/sparq-server/src/http.rs`** — `metrics_endpoint` now takes `HeaderMap` and runs the read gate first; returns the standard `401` + `WWW-Authenticate: Bearer` when the read gate is on and no/wrong token is presented. No public-API change (the handler is private; `router` signature unchanged).
- **`crates/sparq-server/tests/auth.rs`** — three new integration tests over real HTTP:
  - `/metrics` stays **open** with only a write-token (write-only mode);
  - `/metrics` is **gated** under `--auth-token-read` — no/wrong token => `401` + `WWW-Authenticate: Bearer`, and the body does **not** disclose `sparq_graph_triples`; correct token => `200`;
  - `/health` stays **open** even with the read gate on.
- **`README.md` + `skills/http-server/SKILL.md`** — document that `/metrics` is gated by `--auth-token-read` and `/health` is not.

## Gate

- `cargo build -p sparq-server` ✅
- `cargo clippy -p sparq-server --all-targets -- -D warnings` ✅ (default features)
- `cargo clippy -p sparq-server --all-features --all-targets -- -D warnings` ✅
- `cargo test -p sparq-server` ✅ and `--all-features` ✅ (both feature states, all green)
- privacy-claims gate ✅ · G2 public-api→SKILL gate ✅ (no public surface changed)
- new code is `rustfmt`-clean (workspace fmt is informational pending the deferred one-time reformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
