### PR TITLE
feat(sparq-core): named-graph scoping for GenAI crates — Graph::named_graph + docs (sq-quuu)

### DIFF
--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -1134,6 +1134,26 @@ impl Graph {
         }
     }
 
+    /// [OPUS-4.8] (sq-quuu) Returns the named graph whose name term is exactly `name`, or
+    /// `None` if this dataset has no such named graph. Each named graph is itself a
+    /// self-contained [`Graph`] (its own dictionary + permutation indexes), so the returned
+    /// `&Graph` can be passed anywhere a `&Graph` is accepted — in particular to the read-only
+    /// GenAI crates (`sparq-introspect`, `sparq-sim`, `sparq-vectors`), which operate over the
+    /// store of whatever `Graph` they are handed. This is the per-name way to scope those crates
+    /// to a single named graph instead of the (default-graph) `self`.
+    ///
+    /// It is the per-name companion to
+    /// [`for_named_graphs_with_prefix`](Self::for_named_graphs_with_prefix) (which is
+    /// prefix-scoped). It is a linear scan over the `named` Vec (a dataset's distinct graphs are
+    /// typically few); for a prefix sweep use the indexed prefix method instead.
+    ///
+    /// The DEFAULT graph is `self` itself — it is not part of `named` and is not returned here;
+    /// pass `&graph` directly to scope introspect/sim/vectors to the default graph.
+    #[inline]
+    pub fn named_graph(&self, name: &Term) -> Option<&Graph> {
+        self.named.iter().find(|(n, _)| n == name).map(|(_, g)| g)
+    }
+
     /// Streaming loader: parses an RDF document incrementally from a reader (so a
     /// gzip / bzip2 decompression stream can be ingested without holding the whole
     /// document in memory). Same formats as [`load_str`](Self::load_str). The
@@ -5523,6 +5543,37 @@ mod tests {
             collect(&g, "http://ex/a/"),
             ["http://ex/a/1", "http://ex/a/10", "http://ex/a/2", "http://ex/a/3"]
         );
+    }
+
+    /// [OPUS-4.8] (sq-quuu) `named_graph(name)` returns the per-name named-graph `&Graph` so the
+    /// read-only GenAI crates can be scoped to one graph of a quad dataset. The returned graph
+    /// holds EXACTLY that graph's triples (not the default graph, not a mixture across graphs),
+    /// and an unknown name yields `None`.
+    #[test]
+    fn named_graph_by_name_scopes_to_one_graph() {
+        let nq = "<http://ex/a> <http://ex/p> <http://ex/x> <http://ex/g1> .\n\
+                  <http://ex/b> <http://ex/p> <http://ex/y> <http://ex/g1> .\n\
+                  <http://ex/c> <http://ex/p> <http://ex/z> <http://ex/g2> .\n\
+                  <http://ex/d> <http://ex/p> <http://ex/w> .\n"; // default graph
+        let g = Graph::load_dataset(nq, "nquads").unwrap();
+        // The default graph (`g` itself) holds only the one default-graph triple.
+        assert_eq!(g.len(), 1);
+
+        let g1 = Term::NamedNode(NamedNode::new("http://ex/g1").unwrap());
+        let g2 = Term::NamedNode(NamedNode::new("http://ex/g2").unwrap());
+        let missing = Term::NamedNode(NamedNode::new("http://ex/none").unwrap());
+
+        let sub1 = g.named_graph(&g1).expect("ex:g1 exists");
+        assert_eq!(sub1.len(), 2, "ex:g1 holds exactly its two triples");
+        let sub2 = g.named_graph(&g2).expect("ex:g2 exists");
+        assert_eq!(sub2.len(), 1, "ex:g2 holds exactly its one triple");
+        assert!(g.named_graph(&missing).is_none(), "unknown name -> None");
+
+        // The scoped sub-graph really is a usable `&Graph`: its own dictionary resolves the
+        // members it contains and NOT a member of a sibling graph.
+        let iri = |s: &str| Term::NamedNode(NamedNode::new(s).unwrap());
+        assert!(sub1.id_of(&iri("http://ex/a")).is_some()); // ex:a is in ex:g1
+        assert!(sub1.id_of(&iri("http://ex/c")).is_none()); // ex:c is NOT in ex:g1
     }
 
     #[cfg(feature = "parallel")]

--- a/crates/sparq-introspect/README.md
+++ b/crates/sparq-introspect/README.md
@@ -65,6 +65,21 @@ ix.schema_summary_for(&seeds, 2500)           // retrieval-mode: schema scoped t
 - **Retrieval-mode summary** (`schema_summary_for(seeds, budget)`) — a seed-scoped digest
   for KGs whose full schema overflows a prompt; filters the already-mined profiles by IRI
   (no re-scan).
+- **Graph scoping** — `Introspection::build(&graph)` introspects the store of whatever
+  `Graph` it is handed: the **default graph** when you pass the top-level `&graph`, and a
+  **single named graph** when you pass that graph's sub-`Graph`. Each named graph of a
+  quad dataset (loaded via `Graph::load_dataset` from N-Quads / TriG) is a self-contained
+  `Graph`, fetched by name with [`Graph::named_graph(&name)`][named-graph] (sq-quuu):
+  ```rust
+  let g1 = graph.named_graph(&ex_g1).expect("graph exists");
+  let card = sparq_introspect::Introspection::build(g1); // schema card for ex:g1 alone
+  ```
+  There is **no cross-graph or union-of-all-graphs** build: a VoID / schema card is always
+  scoped to exactly one graph, so on a multi-graph dataset run it per graph (or over the
+  default graph) rather than expecting it to merge the quads. Default-graph-only crates
+  silently mixing graphs was sq-quuu; this is the documented + supported scope.
+
+  [named-graph]: https://docs.rs/sparq-core/latest/sparq_core/struct.Graph.html#method.named_graph
 - **Cost & zero impact** — `O(|G| + |dict|)` time, output-sized memory plus the
   subject→types map. Separate opt-in crate: no core crate depends on it, the default
   build does not compile it, and it is read-only over `sparq-core`'s public scan surface

--- a/crates/sparq-sim/README.md
+++ b/crates/sparq-sim/README.md
@@ -65,6 +65,25 @@ weighted_jaccard(&sig_a, &sig_b);        // for callers that cache signatures
   Over-fetch each signal (k = 50 for a top-10 fusion) so the fusion has overlap to reward.
   `fuse_scores(&text, &structural, alpha, k)` is the tunable min-max-normalized alternative.
 
+## Graph scoping
+
+`Sim::new(&graph)` operates on the store of whatever `Graph` it is handed — the **default
+graph** when you pass the top-level `&graph`, or a **single named graph** when you pass
+that graph's sub-`Graph`. On a quad dataset (loaded via `Graph::load_dataset` from
+N-Quads / TriG) each named graph is a self-contained `Graph`; fetch one by name with
+[`Graph::named_graph(&name)`][named-graph] (sq-quuu) and build a per-graph `Sim` over it:
+
+```rust
+let g1 = graph.named_graph(&ex_g1).expect("graph exists");
+let sim = sparq_sim::Sim::new(g1); // signatures + similarity scoped to ex:g1 alone
+```
+
+Signatures never reach **across** graphs and there is no union-of-all-graphs mode: a
+similarity query is always scoped to exactly one graph. On a multi-graph dataset choose
+the graph (or the default graph) explicitly rather than expecting the quads to be merged.
+
+[named-graph]: https://docs.rs/sparq-core/latest/sparq_core/struct.Graph.html#method.named_graph
+
 ## Measured results — olympics
 
 `bench/qlever-olympics/olympics.nt` (134,730 foaf:Person + SportsTeam/SportsEvent/

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -111,6 +111,17 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
   is unaffected (still cost-model'd) — the approximate seam swaps only the unfiltered scan.
 - **Verbalization** — `verbalize` / `embed_entities` render `<label>. a <type>. <description>`
   per entity (multilingual, char-budgeted); `embed_labels` is the label-only special case.
+- **Graph scoping** — every `&Graph` entry point (`verbalize`, `embed_entities`,
+  `embed_labels`, `nearest_term*`) reads the store of whatever `Graph` it is handed: the
+  **default graph** for the top-level `&graph`, or a **single named graph** when you pass
+  that graph's sub-`Graph`. On a quad dataset (N-Quads / TriG via `Graph::load_dataset`)
+  each named graph is a self-contained `Graph`; fetch one by name with
+  [`Graph::named_graph(&name)`](https://docs.rs/sparq-core/latest/sparq_core/struct.Graph.html#method.named_graph)
+  (sq-quuu) and embed / verbalize / query that graph alone. Verbalization labels never
+  cross graphs and there is no union-of-all-graphs mode — build a store per graph (or over
+  the default graph) on a multi-graph dataset rather than expecting the quads to be merged.
+  A store's graph **fingerprint** (above) is computed over the exact `Graph` it was built
+  from, so a per-named-graph store and the default-graph store carry distinct fingerprints.
 - **Quantization** — `ScalarQuantizer` (4×) and `ProductQuantizer` (asymmetric distance) for
   large stores; `Embedder` is provider-agnostic.
 - **Live embeddings (opt-in)** — the default build is **socket-free** (no HTTP client). The

--- a/skills/genai-retrieval/SKILL.md
+++ b/skills/genai-retrieval/SKILL.md
@@ -322,6 +322,14 @@ the fixtures encode.)
 - **Cost.** Introspection is `O(|G| + |dict|)` (sorted scans, no GROUP BY); measured
   ~0.1 s build on 1.78M triples. LLM-excluded `ask` latency is the engine's query
   time (p50 ~10 ms at olympics scale) — the LLM round trip dominates wall clock.
+- **Graph scoping (sq-quuu).** `Introspection::build(&graph)` describes the **store of
+  the `Graph` it is handed** — the **default graph** for the top-level `&graph`, or a
+  **single named graph** when you pass that graph's sub-`Graph`. A schema card / VoID is
+  always scoped to exactly one graph; there is **no cross-graph or union-of-all-graphs
+  build**. On a quad dataset (N-Quads / TriG via `Graph::load_dataset`) each named graph
+  is a self-contained `Graph`; fetch one by name with `graph.named_graph(&name)` and
+  introspect it alone — `let card = Introspection::build(graph.named_graph(&g)?);`. Run it
+  per graph (or over the default graph) rather than expecting it to merge the quads.
 
 ## See also
 

--- a/skills/structural-similarity/SKILL.md
+++ b/skills/structural-similarity/SKILL.md
@@ -134,6 +134,13 @@ reward. See the [`vector-search`](../vector-search/SKILL.md) skill for `fuse_sco
 - `max_pair_frequency` is an **approximation knob on candidate generation only** — it
   never changes the exact score of a returned candidate, but a very rare entity reachable
   only through a hub element could be missed at the default cap.
+- **Graph scoping (sq-quuu).** `Sim::new(&graph)` operates on the store of the `Graph`
+  it is handed — the **default graph** for the top-level `&graph`, or a **single named
+  graph** when you pass that graph's sub-`Graph`. On a quad dataset (N-Quads / TriG via
+  `Graph::load_dataset`) each named graph is a self-contained `Graph`; fetch one by name
+  with `graph.named_graph(&name)` and build `Sim::new(graph.named_graph(&g)?)`. Signatures
+  never reach **across** graphs and there is no union-of-all-graphs mode — choose the graph
+  (or the default graph) explicitly; the quads are not merged for you.
 
 _(status: Verified against `crates/sparq-sim/src/lib.rs` + README and the crate's tests
 (13 unit tests in `src/lib.rs`; 1 integration test `tests/olympics.rs` that skips when

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -643,6 +643,17 @@ path (recipe 10), and does **not** transfer to this approximate path. Implement 
 - **Keys are dictionary term ids** (`sparq_core::dict::Id`, a `u32`). Resolve a `Term` with
   `graph.id_of(&term) -> Option<Id>` and an `Id` back with `graph.dict.term(id)`. Coverage
   is **sparse by design** — only entities get vectors, not every literal.
+- **Graph scoping (sq-quuu).** Every `&Graph` entry point (`verbalize`, `embed_entities`,
+  `embed_labels`, `nearest_term*`) reads the store of the `Graph` it is handed — the
+  **default graph** for the top-level `&graph`, or a **single named graph** when you pass
+  that graph's sub-`Graph`. On a quad dataset (N-Quads / TriG via `Graph::load_dataset`)
+  each named graph is a self-contained `Graph`; fetch one by name with
+  `graph.named_graph(&name)` and build a store **per graph** (or over the default graph).
+  Verbalization labels never cross graphs and there is no union-of-all-graphs mode — the
+  quads are not merged for you. Because keys are dict ids and a named graph has its **own**
+  dictionary, a store is bound to **one** `Graph`: the per-named-graph store and the
+  default-graph store carry distinct fingerprints, so `check_graph` catches a cross-graph
+  mix-up.
 - **Dim must match.** `VectorStore::create(path, dim)` fixes `dim`; `embed_*` errors if
   `embedder.dim() != store.dim()`. `embed_labels`/`embed_entities` leave the store
   **unfinalized** — call `store.finalize()` before opening/searching (or before a fresh


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Implements bead **sq-quuu**.

## What & why

The read-only GenAI crates — **sparq-introspect**, **sparq-sim**, **sparq-vectors** — all read `graph.store`, i.e. the store of whatever `&Graph` they are handed. On a quad dataset that is the **default graph only**, with no convenient way to scope to a single named graph and **no documentation** of the limitation. So an introspect schema card / VoID, a sim signature, or a vector store built over a multi-graph (N-Quads / TriG) dataset silently described only the default graph — sq-quuu ("an introspect schema card or VoID over a quad dataset can be quietly wrong").

## Change (smallest correct: support + document)

**Support** — `crates/sparq-core/src/lib.rs`: add `Graph::named_graph(&name) -> Option<&Graph>`, the per-name companion to the existing prefix-scoped `for_named_graphs_with_prefix`. Each named graph is already a self-contained `Graph` (own dictionary + permutation indexes), so this accessor lets a caller pass `graph.named_graph(&name)` to any of the three crates to scope it to exactly that graph. The default graph remains the top-level `&graph`. No new public surface on the GenAI crates — they already accept any `&Graph`; this just makes the per-graph one reachable by name.

**Document** — a "Graph scoping" section in all three crate READMEs and the matching SKILLs (`genai-retrieval`, `structural-similarity`, `vector-search`), each stating: scope is **one graph at a time**, the `named_graph(&name)` recipe, and that there is **no cross-graph / union-of-all-graphs** mode (run per graph, or over the default graph). For sparq-vectors it also notes the per-graph store carries its own fingerprint, so `check_graph` catches a cross-graph mix-up.

**Test** — `named_graph_by_name_scopes_to_one_graph` (sparq-core): the per-name accessor returns exactly that graph's triples (not the default graph, not a cross-graph mix), an unknown name yields `None`, and the scoped sub-graph is a usable `&Graph` with its own dictionary.

## Honest scope

This is a **support + documentation** change, not a federation feature: there is deliberately **no** cross-graph aggregation — the bead asked to document the default-graph-only behaviour and "ideally add a per-named-graph scope option", which is exactly `named_graph`. Union-over-all-graphs introspection would be a separate, larger change (and is called out as out of scope in the docs).

## Gate

- `cargo clippy -p sparq-core --all-targets -- -D warnings` — default **and** `--no-default-features` ✅
- `cargo test -p sparq-core --lib` — default (67) **and** `--no-default-features` (47) ✅
- rustdoc gate: `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` **and** `--all-features` ✅ (added intra-doc links point only at public items)
- `scripts/check-privacy-claims.sh` ✅ · `scripts/gate-api-skill.py --base main` ✅ (SKILLs updated in the same diff)
- sparq-vectors README is `include_str!`-doctested — `--doc` passes default + `--all-features` ✅
- New code is `cargo fmt`-clean (fmt is informational repo-wide pending the deferred reformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)