### PR TITLE
ci(release): Trivy scan the released container image before push (sq-p9xq)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,10 @@ jobs:
       # pushed image; the OIDC token is what signs the provenance attestation.
       id-token: write
       attestations: write
+      # [OPUS-4.8] sq-p9xq: upload the released image's Trivy SARIF to the
+      # code-scanning dashboard (Security tab) so a vuln in the published artifact
+      # is visible there, not just in the run log.
+      security-events: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -246,6 +250,49 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Smoke test the image (docker run + /health + ASK query)
         run: scripts/docker-smoke.sh sparq-server:smoke 3030
+      # [OPUS-4.8] sq-p9xq: SCAN BEFORE PUSH. cargo-deny gates the Rust dependency tree, but
+      # the distroless base layer (glibc / libgcc / CA certs) is outside that scope — a CVE
+      # disclosed there would ship in the released image unscanned. Trivy scans the exact
+      # `sparq-server:smoke` artifact built above (same bytes that get pushed) for OS-package
+      # AND library vulns, and FAILS the release on a FIXABLE HIGH/CRITICAL so a vulnerable
+      # image never reaches ghcr.io. `container-scan.yml` runs the same scan on PRs/main/weekly
+      # against the Dockerfile; this is the release-gate copy that scans the published bytes.
+      #   exit-code: 1   => fail the step (and the release) on a non-ignored match.
+      #   ignore-unfixed => only FIXABLE vulns gate; a CVE with no upstream fix yet cannot
+      #                     block a release (it is still surfaced in the SARIF pass below).
+      #   trivyignores   => the shared .trivyignore allowlist for triaged/accepted CVEs.
+      - name: Trivy scan released image (fail on fixable HIGH/CRITICAL)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: sparq-server:smoke
+          scan-type: image
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+          vuln-type: os,library
+          trivyignores: .trivyignore
+      # Second pass: SARIF for the code-scanning dashboard. exit-code 0 (the gating decision
+      # is the table pass above) and includes unfixed findings so the Security tab shows the
+      # full picture of the released image for triage.
+      - name: Trivy scan released image (SARIF for code-scanning)
+        if: always()
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: sparq-server:smoke
+          scan-type: image
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: "0"
+          severity: HIGH,CRITICAL
+          vuln-type: os,library
+          trivyignores: .trivyignore
+      - name: Upload Trivy SARIF to code-scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-release-image
       - name: Build and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-p9xq** (area:release / ci / security). [OPUS-4.8] authored while Fable is unavailable; re-review when Fable returns.

## What

`release.yml`'s `docker` job builds the distroless `sparq-server` image and pushes it to `ghcr.io` on every `v*` tag, with **no image vulnerability scan in the release path**. `cargo-deny` gates the Rust dependency tree, but the distroless base layer (glibc / libgcc / CA certs) is outside its scope — a CVE disclosed there would ship in the released artifact unscanned. The SBOM records the layer; it doesn't gate on it.

This adds a **Trivy scan of the exact bytes being released**, gating the release on a fixable HIGH/CRITICAL.

## How

The `docker` job already builds the image **locally** as `sparq-server:smoke` (`load: true`) for the pre-push smoke test — the same bytes the subsequent push step ships (push is a GHA cache hit, not a rebuild). The new steps slot in **after the smoke test, before the push**:

1. **Gating pass** (`format: table`, `exit-code: 1`) — fails the release on a **fixable** HIGH/CRITICAL OS-package or library vuln, so a vulnerable image never reaches ghcr.io.
2. **SARIF pass** (`exit-code: 0`, `if: always()`, includes unfixed) — uploads to the code-scanning dashboard under category `trivy-release-image` for triage.

Config mirrors the already-proven `container-scan.yml` lane: `--ignore-unfixed` (a CVE with no upstream fix can't wedge a release), `HIGH,CRITICAL`, `os,library`, and the **shared `.trivyignore`** allowlist. Third-party actions are pinned to the **same commit SHAs** already vetted in `container-scan.yml` (`trivy-action` v0.36.0, `codeql-action/upload-sarif` v4.36.2). The job gains `security-events: write` for the SARIF upload.

## Why a release-path copy when container-scan.yml exists

`container-scan.yml` scans the image built from the Dockerfile on PRs / push-to-main / weekly — it proves the *recipe* is clean between releases. This PR scans the *published artifact* at release time (distinct SARIF category), so the gate sits on the actual bytes that go to ghcr.io. The bead asks for exactly this: scan the **released** image in `release.yml`.

## Gate

CI/YAML-only change — no Rust crate touched, so the Rust build/clippy/test/rustdoc gate does not apply; no public API changed, so no SKILL.md update. `release.yml` validates as YAML; the new steps are structurally identical to the working `container-scan.yml` `trivy` job. The scan only runs on tag pushes (release pipeline), so it cannot be exercised on this PR — verifiable on the next `v*` tag.

Closes sq-p9xq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)