### PR TITLE
perf(sparq-core): stream numerics/temporals caches on in-RAM save finalize (sq-7ph8) [OPUS-4.8]

### DIFF
--- a/bench/unsafe-snapshot.json
+++ b/bench/unsafe-snapshot.json
@@ -9,11 +9,11 @@
     "Re-seed (scripts/unsafe-gate.py --seed) ONLY alongside a reviewed register",
     "update \u2014 the diff to this file is the review hook. Smaller is always allowed."
   ],
-  "total": 58,
+  "total": 59,
   "crates": {
     "sparq-bench": 1,
     "sparq-cli": 2,
-    "sparq-core": 44,
+    "sparq-core": 45,
     "sparq-vectors": 9,
     "sparq-zk-compose": 2
   }

--- a/compliance/memsafety/unsafe-register.md
+++ b/compliance/memsafety/unsafe-register.md
@@ -46,7 +46,7 @@ register distinguishes two trust classes of `unsafe`:
 
 ## Register
 
-**58 `unsafe` sites** across 5 crates (the other 30 crates are `#![forbid(unsafe_code)]`).
+**59 `unsafe` sites** across 5 crates (the other 30 crates are `#![forbid(unsafe_code)]`).
 Counts and the file:line list are produced by `scripts/unsafe-gate.py --list` and
 must equal `bench/unsafe-snapshot.json`.
 
@@ -60,7 +60,7 @@ Recurring invariant shorthands used below:
   borrow's duration and is not mutated by us; external concurrent mutation is explicitly
   out of contract (documented stance, same as the rest of the mmap surface).
 
-### `sparq-core` — 44 sites (the unsafe core: mmap loaders, zero-copy dict, parallel build)
+### `sparq-core` — 45 sites (the unsafe core: mmap loaders, zero-copy dict, parallel build)
 
 | File:line | Kind | Invariant relied on | Why sound / how bounded |
 |---|---|---|---|
@@ -68,21 +68,22 @@ Recurring invariant shorthands used below:
 | `src/lib.rs:389` | ptr read | page-align; instant section is `n` f64 at offset 0 | `i < n` checked at the call; f64 at `base+i`. |
 | `src/lib.rs:456` | slice reinterpret (read) | page-align; instants are `n` f64 at offset 0 | `n = mapped_len`; materialises the cells. |
 | `src/lib.rs:577` | slice reinterpret (write) | POD-bytes | reinterpret the f64 column as bytes to write `temporals.bin`. |
-| `src/lib.rs:1546` | slice reinterpret (read) | page-align; `temporals.bin` starts with `len` f64 | `len = mapped_len`; flags read separately after. |
-| `src/lib.rs:1597` | `Mmap::map` | own-for-lifetime | `numerics.bin` opened only if `size == dict.len()*8` (length pre-validated). |
-| `src/lib.rs:1605` | `Mmap::map` | own-for-lifetime | `temporals.bin` opened only if `size == dict.len()*9` (length pre-validated). |
-| `src/lib.rs:1898` | slice reinterpret (read) | page-align; perm0 is whole `[u32;3]` rows | `n` from `map_perm`; map outlives the loop. Written by us above. |
-| `src/lib.rs:2316` | slice reinterpret (read) | page-align; perm0 is whole `[u32;3]` rows | same as 1898 (external-build path). |
-| `src/lib.rs:3741` | slice reinterpret (write) | POD-bytes | reinterpret the f64 numerics cache as bytes to write. |
-| `src/lib.rs:3821` | `_mm_prefetch` (x86_64) | hint-only | prefetch is defined for any address; the hint is dropped on a bad one — cannot fault. |
-| `src/lib.rs:3826` | `prfm` asm (aarch64) | hint-only | `prfm pldl1keep` is a hint; `nostack, preserves_flags`; cannot fault or write memory/regs. |
-| `src/lib.rs:3881` | ptr `add` (prefetch arg) | `id-1 < remap.len()` for every dict id | only computes an address for the hint-only `prefetch_read`; never dereferenced here. |
-| `src/lib.rs:4905` | ptr `add` (prefetch arg) | `id-1 < remap.len()` | same as 3881 (other build path). |
-| `src/lib.rs:5062` | `MmapMut::map_mut` | own-for-lifetime; freshly-written perm file | read-write map of a perm file of whole `[u32;3]` rows we just wrote. |
-| `src/lib.rs:5066` | mut slice reinterpret | page-align; POD-bytes | `len/4` u32; exclusively owned (the `MmapMut`); rayon writes are disjoint by index. |
-| `src/lib.rs:4059` | slice reinterpret (read) | page-align; whole `[u32;3]` rows; map outlives the slice | `compress_perm_file_in_place` (sq-vkz7). `extsort::map_perm` returns `(Mmap, n)` with `n = len/12`, so the `n` `[u32;3]` rows are fully in-bounds and the base is ≥ 4-byte u32-aligned (page-aligned mmap). The raw SPO perm was written by this build (whole rows, sorted+deduped) and is read-only here — the `Mmap` (`map`) is held for the whole row-streaming loop and is not mutated through any other alias for the slice's lifetime; it is `drop`ped only *after* the slice's last use, before the file is renamed. `n==0` (empty perm) returns early without forming the slice. [OPUS-4.8] |
-| `src/lib.rs:7480` | `std::env::set_var` | single-threaded test; var restored before return | TEST-only (`#[test] external_quads_fd_*`): sets `SPARQ_QUADS_SPILL_MAX_OPEN` to exercise the bounded-writer-pool path; no other thread reads the env in the test. Edition-2024 made `set_var` `unsafe`. |
-| `src/lib.rs:7484` | `std::env::remove_var` | same test; restores the env | TEST-only: removes the var set at 7480 before returning so the process env is left clean. Edition-2024 `unsafe`. |
+| `src/lib.rs:1584` | `Mmap::map` | own-for-lifetime | `numerics.bin` opened only if `size == dict.len()*8` (length pre-validated). |
+| `src/lib.rs:1592` | `Mmap::map` | own-for-lifetime | `temporals.bin` opened only if `size == dict.len()*9` (length pre-validated). |
+| `src/lib.rs:1885` | slice reinterpret (read) | page-align; perm0 is whole `[u32;3]` rows | `n` from `map_perm`; map outlives the loop. Written by us above. |
+| `src/lib.rs:2303` | slice reinterpret (read) | page-align; perm0 is whole `[u32;3]` rows | same as 1885 (external-build path). |
+| `src/lib.rs:3728` | slice reinterpret (write) | POD-bytes | reinterpret the f64 numerics cache as bytes to write `numerics.bin`. |
+| `src/lib.rs:3761` | slice reinterpret (write) | POD-bytes | (sq-7ph8) `stream_write_numerics` flush: reinterprets a reusable `Vec<f64>` BLOCK as bytes for `write_all`. (a) `buf` is a live `Vec<f64>` of `buf.len()` elems; `size_of_val(&buf[..]) = len*8` covers the initialised contiguous region exactly. (b) target `u8` has align 1; the f64 source is over-aligned — no misalignment. (c) bytes are only READ (passed to `write_all`), never written through the alias. (d) the `&[u8]` is consumed inside the closure before `buf.clear()`; no provenance/lifetime escape past the source borrow. (e) NATIVE-endian reinterpret, identical to `write_numerics` (3728) it replaces and symmetric with the native-endian READ at `NumData::as_slice` (285): write-native + read-native round-trips on the same arch (the established cache contract; the cache is rebuilt, never shipped cross-arch). Test `streamed_caches_byte_identical_to_dense` asserts byte-identity to the dense write. **GX-5**. [OPUS-4.8] |
+| `src/lib.rs:3805` | slice reinterpret (write) | POD-bytes | (sq-7ph8) `stream_write_temporals` flush_f: reinterprets a reusable `Vec<f64>` instant BLOCK as bytes for `write_all`. Same invariants (a)–(e) as 3761: full-length `len*8` byte view of a live `Vec<f64>`, `u8` align 1, read-only, no escape, native-endian — symmetric with the native-endian temporal read (`temporals.bin` first `n` f64; rows 285/389/456) and byte-identical to `write_temporals` (577). The trailing flag-byte column is written from a `Vec<u8>` (no unsafe). **GX-5**. [OPUS-4.8] |
+| `src/lib.rs:3934` | `_mm_prefetch` (x86_64) | hint-only | prefetch is defined for any address; the hint is dropped on a bad one — cannot fault. |
+| `src/lib.rs:3939` | `prfm` asm (aarch64) | hint-only | `prfm pldl1keep` is a hint; `nostack, preserves_flags`; cannot fault or write memory/regs. |
+| `src/lib.rs:3994` | ptr `add` (prefetch arg) | `id-1 < remap.len()` for every dict id | only computes an address for the hint-only `prefetch_read`; never dereferenced here. |
+| `src/lib.rs:5018` | ptr `add` (prefetch arg) | `id-1 < remap.len()` | same as 3994 (other build path). |
+| `src/lib.rs:5175` | `MmapMut::map_mut` | own-for-lifetime; freshly-written perm file | read-write map of a perm file of whole `[u32;3]` rows we just wrote. |
+| `src/lib.rs:5179` | mut slice reinterpret | page-align; POD-bytes | `len/4` u32; exclusively owned (the `MmapMut`); rayon writes are disjoint by index. |
+| `src/lib.rs:4172` | slice reinterpret (read) | page-align; whole `[u32;3]` rows; map outlives the slice | `compress_perm_file_in_place` (sq-vkz7). `extsort::map_perm` returns `(Mmap, n)` with `n = len/12`, so the `n` `[u32;3]` rows are fully in-bounds and the base is ≥ 4-byte u32-aligned (page-aligned mmap). The raw SPO perm was written by this build (whole rows, sorted+deduped) and is read-only here — the `Mmap` (`map`) is held for the whole row-streaming loop and is not mutated through any other alias for the slice's lifetime; it is `drop`ped only *after* the slice's last use, before the file is renamed. `n==0` (empty perm) returns early without forming the slice. [OPUS-4.8] |
+| `src/lib.rs:7668` | `std::env::set_var` | single-threaded test; var restored before return | TEST-only (`#[test] external_quads_fd_*`): sets `SPARQ_QUADS_SPILL_MAX_OPEN` to exercise the bounded-writer-pool path; no other thread reads the env in the test. Edition-2024 made `set_var` `unsafe`. |
+| `src/lib.rs:7672` | `std::env::remove_var` | same test; restores the env | TEST-only: removes the var set at 7668 before returning so the process env is left clean. Edition-2024 `unsafe`. |
 | `src/store.rs:106` | slice reinterpret (read) | page-align; whole `[u32;3]` triples | `n = len/12`; mmap base ≥ 4-byte u32 align. |
 | `src/store.rs:375` | slice reinterpret (write) | POD-bytes | reinterpret contiguous `[u32;3]` rows as bytes for `std::fs::write`. |
 | `src/store.rs:459` | `Mmap::map` | own-for-lifetime | per-permutation file; empty (size 0) skipped; format auto-detected after. **B5**. |
@@ -145,7 +146,7 @@ Recurring invariant shorthands used below:
 
 ## NEEDS-REVIEW
 
-**None.** Every one of the 58 sites now carries a literal `// SAFETY:` comment
+**None.** Every one of the 59 sites now carries a literal `// SAFETY:` comment
 immediately preceding the `unsafe` block/impl, mechanically enforced by
 `clippy::undocumented_unsafe_blocks` (MS-G2 closed, sq-8wbn, [OPUS-4.8]). The 6 sites that
 previously relied on an adjacent block comment — the two `unsafe impl Send`/`Sync for

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -3746,7 +3746,18 @@ fn stream_write_numerics(path: &std::path::Path, n: usize, num: &NumData) -> std
     const BLOCK: usize = 1 << 16; // ids per flush (512 KiB of f64)
     let mut buf: Vec<f64> = Vec::with_capacity(BLOCK.min(n));
     let flush = |w: &mut std::io::BufWriter<std::fs::File>, buf: &mut Vec<f64>| -> std::io::Result<()> {
-        // SAFETY: reinterpret the contiguous f64 block as bytes for writing.
+        // SAFETY: reinterpret the contiguous f64 block as bytes for writing. (sq-7ph8)
+        // - `buf` is a live `Vec<f64>` of `buf.len()` initialised elements; `size_of_val(&buf[..])`
+        //   = `len * 8` covers exactly that contiguous, fully-initialised region (no over-read).
+        // - target `u8` has alignment 1; the f64 source is over-aligned, so the cast never
+        //   produces a misaligned access.
+        // - the bytes are only READ (passed to `write_all`), never written through the alias.
+        // - the `&[u8]` is consumed within this closure before `buf.clear()`; it never escapes
+        //   the source borrow, so no dangling/provenance issue.
+        // - native-endian reinterpret, identical to `write_numerics` above and symmetric with the
+        //   native-endian read in `NumData::as_slice`: this cache is rebuilt locally, never shipped
+        //   cross-arch, so write-native + read-native round-trips. Byte-identical to the old dense
+        //   write (asserted by `streamed_caches_byte_identical_to_dense`).
         let bytes = unsafe { std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), std::mem::size_of_val(&buf[..])) };
         w.write_all(bytes)?;
         buf.clear();
@@ -3784,7 +3795,13 @@ fn stream_write_temporals(path: &std::path::Path, n: usize, temp: &TempData) -> 
     // "not temporal" decode, so the instant value of a flag-0 cell is irrelevant on read).
     let mut fbuf: Vec<f64> = Vec::with_capacity(BLOCK.min(n));
     let flush_f = |w: &mut std::io::BufWriter<std::fs::File>, buf: &mut Vec<f64>| -> std::io::Result<()> {
-        // SAFETY: reinterpret the contiguous f64 block as bytes for writing.
+        // SAFETY: reinterpret the contiguous f64 instant block as bytes for writing. (sq-7ph8)
+        // Same invariants as `stream_write_numerics::flush`: `size_of_val(&buf[..]) = len*8` views
+        // exactly the live, initialised `Vec<f64>` region; `u8` has align 1 so no misalignment;
+        // the bytes are read-only (fed to `write_all`); the `&[u8]` never escapes this closure
+        // (consumed before `buf.clear()`); native-endian, symmetric with the native-endian temporal
+        // read path and byte-identical to `write_temporals`. The trailing flag column below is a
+        // plain `Vec<u8>` write (no unsafe).
         let bytes = unsafe { std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), std::mem::size_of_val(&buf[..])) };
         w.write_all(bytes)?;
         buf.clear();

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -1417,9 +1417,13 @@ impl Graph {
         std::fs::create_dir_all(dir)?;
         self.store.save(dir)?; // folds any delta-overlay into the persisted permutations
         self.dict.save_mmap(dir)?; // includes appended (delta-overlay) terms
-        write_numerics(&dir.join("numerics.bin"), &self.dense_numerics())?;
-        let (tf, ti) = self.dense_temporals();
-        write_temporals(&dir.join("temporals.bin"), &tf, &ti)?;
+        // [OPUS-4.8] (sq-7ph8) STREAM the numeric/temporal caches block-by-block straight from
+        // the in-RAM cache instead of materialising a whole-dictionary dense intermediate
+        // (`dense_numerics`/`dense_temporals`) first — bounding the finalize RSS peak for a
+        // SPARSE/FORKED cache (the common non-numeric/non-temporal case).
+        let n = self.dict.len();
+        stream_write_numerics(&dir.join("numerics.bin"), n, &self.numerics)?;
+        stream_write_temporals(&dir.join("temporals.bin"), n, &self.temporals)?;
         self.save_named(dir, false)
     }
 
@@ -1433,9 +1437,10 @@ impl Graph {
         std::fs::create_dir_all(dir)?;
         self.store.save_compressed(dir)?; // folds any delta-overlay, like `save`
         self.dict.save_mmap(dir)?;
-        write_numerics(&dir.join("numerics.bin"), &self.dense_numerics())?;
-        let (tf, ti) = self.dense_temporals();
-        write_temporals(&dir.join("temporals.bin"), &tf, &ti)?;
+        // [OPUS-4.8] (sq-7ph8) Stream the caches block-by-block — see `save` for the rationale.
+        let n = self.dict.len();
+        stream_write_numerics(&dir.join("numerics.bin"), n, &self.numerics)?;
+        stream_write_temporals(&dir.join("temporals.bin"), n, &self.temporals)?;
         // [OPUS-4.8] (sq-3ui0) Named graphs are persisted block-compressed too.
         self.save_named(dir, true)
     }
@@ -1538,58 +1543,6 @@ impl Graph {
     /// zero-cost slice borrows, identical to a raw store). No-op on raw/mapped indexes.
     pub fn decompress_indexes(&mut self) {
         self.store.decompress_to_ram();
-    }
-
-    /// The full dense numeric cache (one f64 per dictionary term) for persisting: the
-    /// owned/mmap'd dense backing extended over any APPENDED terms, or recomputed when
-    /// no dense backing covers the dictionary (the sparse browser mode).
-    #[cfg(feature = "mmap")]
-    fn dense_numerics(&self) -> std::borrow::Cow<'_, [f64]> {
-        let n = self.dict.len();
-        match &self.numerics {
-            NumData::Owned(v) if v.len() == n => std::borrow::Cow::Borrowed(v),
-            NumData::Mapped(_, extra) => {
-                let dense = self.numerics.as_slice();
-                if dense.len() == n {
-                    return std::borrow::Cow::Borrowed(dense);
-                }
-                let mut v = dense.to_vec();
-                v.resize(n, f64::NAN);
-                for (&id, &val) in extra {
-                    v[(id - 1) as usize] = val;
-                }
-                std::borrow::Cow::Owned(v)
-            }
-            _ => std::borrow::Cow::Owned(numerics_of(&self.dict)),
-        }
-    }
-
-    /// The full dense temporal cache columns (flag byte + f64 instant per dictionary
-    /// term) for persisting — the temporal twin of [`dense_numerics`](Self::dense_numerics).
-    #[cfg(feature = "mmap")]
-    fn dense_temporals(&self) -> (Vec<u8>, Vec<f64>) {
-        let n = self.dict.len();
-        let split = |cells: &[TempCell]| -> (Vec<u8>, Vec<f64>) {
-            (cells.iter().map(|c| c.flag).collect(), cells.iter().map(|c| c.instant).collect())
-        };
-        match &self.temporals {
-            TempData::Owned(cells) if cells.len() == n => split(cells),
-            TempData::Mapped(m, extra) => {
-                let len = TempData::mapped_len(m);
-                // SAFETY: temporals.bin starts with `len` f64 (page-aligned mmap base).
-                let minst = unsafe { std::slice::from_raw_parts(m.as_ptr().cast::<f64>(), len) };
-                let mut flags = m[len * 8..len * 9].to_vec();
-                let mut instants = minst.to_vec();
-                flags.resize(n, 0);
-                instants.resize(n, f64::NAN);
-                for (&id, &t) in extra {
-                    flags[(id - 1) as usize] = temp_flag(t);
-                    instants[(id - 1) as usize] = t.instant;
-                }
-                (flags, instants)
-            }
-            _ => split(&temporals_of(&self.dict)),
-        }
     }
 
     /// Opens a graph saved by [`save`](Self::save) with its permutation indexes AND
@@ -3774,6 +3727,91 @@ fn write_numerics(path: &std::path::Path, nums: &[f64]) -> std::io::Result<()> {
     // SAFETY: reinterpret the contiguous f64 cache as bytes for writing.
     let bytes = unsafe { std::slice::from_raw_parts(nums.as_ptr().cast::<u8>(), std::mem::size_of_val(nums)) };
     std::fs::write(path, bytes)
+}
+
+/// [OPUS-4.8] (sq-7ph8) STREAM-writes the dense `numerics.bin` (`n` little-endian f64, the
+/// same layout [`write_numerics`] emits and [`Graph::open`] mmaps) DIRECTLY from the cache,
+/// in fixed-size blocks, without first materialising a whole-dictionary dense `Vec<f64>`.
+///
+/// The in-RAM save path used to call `numerics_of`/`dense_numerics`, which for a SPARSE or
+/// FORKED cache rebuilds an O(distinct-terms) dense `Vec` (8 B/term) purely to write it — an
+/// RSS spike on top of the resident dict. Probing the cache per id (`lookup`, O(1)) and
+/// flushing a small reusable block buffer keeps peak resident memory at the block size, the
+/// same bounded-write discipline the dict-spill path (`dictspill.rs`) already uses. The bytes
+/// written are identical: NaN for non-numeric ids, the cached f64 otherwise.
+#[cfg(feature = "mmap")]
+fn stream_write_numerics(path: &std::path::Path, n: usize, num: &NumData) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut w = std::io::BufWriter::new(std::fs::File::create(path)?);
+    const BLOCK: usize = 1 << 16; // ids per flush (512 KiB of f64)
+    let mut buf: Vec<f64> = Vec::with_capacity(BLOCK.min(n));
+    let flush = |w: &mut std::io::BufWriter<std::fs::File>, buf: &mut Vec<f64>| -> std::io::Result<()> {
+        // SAFETY: reinterpret the contiguous f64 block as bytes for writing.
+        let bytes = unsafe { std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), std::mem::size_of_val(&buf[..])) };
+        w.write_all(bytes)?;
+        buf.clear();
+        Ok(())
+    };
+    for id in 1..=n as Id {
+        buf.push(num.lookup(id).unwrap_or(f64::NAN));
+        if buf.len() == BLOCK {
+            flush(&mut w, &mut buf)?;
+        }
+    }
+    if !buf.is_empty() {
+        flush(&mut w, &mut buf)?;
+    }
+    w.flush()
+}
+
+/// [OPUS-4.8] (sq-7ph8) STREAM-writes the dense `temporals.bin` (`n` little-endian f64
+/// instants then `n` flag bytes — the layout [`write_temporals`] emits and
+/// [`TempData::lookup`]/[`Graph::open`] read) DIRECTLY from the cache, without first
+/// materialising the two whole-dictionary dense columns `dense_temporals` builds.
+///
+/// `dense_temporals` always allocated a fresh `(Vec<u8>, Vec<f64>)` (9 B/term) even when the
+/// in-RAM cache is SPARSE (the usual non-temporal case: a tiny map), a transient
+/// O(distinct-terms) RSS spike purely to feed the writer. Here the instants are streamed in
+/// one id pass (probing `lookup`, O(1)) through a small reusable f64 block; the flags follow
+/// in a second pass through a small `u8` block. Peak resident memory is the block size, not
+/// the dictionary — matching the streamed dict-spill write. Output bytes are identical.
+#[cfg(feature = "mmap")]
+fn stream_write_temporals(path: &std::path::Path, n: usize, temp: &TempData) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut w = std::io::BufWriter::new(std::fs::File::create(path)?);
+    const BLOCK: usize = 1 << 16;
+    // Pass 1: the f64 instant column (NaN for non-temporal ids — temp_flag 0 carries the
+    // "not temporal" decode, so the instant value of a flag-0 cell is irrelevant on read).
+    let mut fbuf: Vec<f64> = Vec::with_capacity(BLOCK.min(n));
+    let flush_f = |w: &mut std::io::BufWriter<std::fs::File>, buf: &mut Vec<f64>| -> std::io::Result<()> {
+        // SAFETY: reinterpret the contiguous f64 block as bytes for writing.
+        let bytes = unsafe { std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), std::mem::size_of_val(&buf[..])) };
+        w.write_all(bytes)?;
+        buf.clear();
+        Ok(())
+    };
+    for id in 1..=n as Id {
+        fbuf.push(temp.lookup(id).map(|t| t.instant).unwrap_or(f64::NAN));
+        if fbuf.len() == BLOCK {
+            flush_f(&mut w, &mut fbuf)?;
+        }
+    }
+    if !fbuf.is_empty() {
+        flush_f(&mut w, &mut fbuf)?;
+    }
+    // Pass 2: the flag byte column.
+    let mut gbuf: Vec<u8> = Vec::with_capacity(BLOCK.min(n));
+    for id in 1..=n as Id {
+        gbuf.push(temp.lookup(id).map(temp_flag).unwrap_or(0));
+        if gbuf.len() == BLOCK {
+            w.write_all(&gbuf)?;
+            gbuf.clear();
+        }
+    }
+    if !gbuf.is_empty() {
+        w.write_all(&gbuf)?;
+    }
+    w.flush()
 }
 
 fn subject_term(s: &oxrdf::NamedOrBlankNode) -> Term {
@@ -8983,6 +9021,84 @@ mod tests {
         g.save_compressed(&dir).unwrap();
         assert_eq!(Graph::open(&dir).unwrap().len(), 3);
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (sq-7ph8) The streamed numerics/temporals save must write BYTE-IDENTICAL
+    /// `numerics.bin`/`temporals.bin` to the old dense-materialise path — for a DENSE-owned
+    /// cache, a SPARSE cache (`into_compressed`), AND a graph carrying temporal literals — so
+    /// the bounded-RSS finalize is purely a memory optimisation, never an on-disk format change.
+    /// We prove it by comparing the streamed files against a reference dense computation done
+    /// directly off the dictionary, and by checking the exact on-disk sizes (`n*8`, `n*9`).
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn streamed_caches_byte_identical_to_dense() {
+        // A mix: numeric literals, temporal literals (dateTime + date), and many plain IRIs/
+        // strings so the caches are MOSTLY empty — the case that used to spike a dense buffer.
+        let ttl = "@prefix : <http://ex/> . @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
+             :a :v 1.5 . :b :v 2.5 . :c :n \"42\"^^xsd:integer .\n\
+             :d :t \"2020-01-02T03:04:05Z\"^^xsd:dateTime .\n\
+             :e :t \"2021-06-07\"^^xsd:date .\n\
+             :f :label \"just a string\" . :g :p :a . :h :p :b .";
+
+        // Reference dense bytes computed straight from a dict (the pre-streaming layout):
+        // `n` LE f64 numerics; then `n` LE f64 temporal instants followed by `n` flag bytes.
+        let reference = |dict: &Dict| -> (Vec<u8>, Vec<u8>) {
+            let n = dict.len();
+            let mut num = Vec::new();
+            let mut inst = Vec::new();
+            let mut flags = Vec::new();
+            for id in 1..=n as Id {
+                num.extend_from_slice(&numeric_of(&dict.term(id)).to_le_bytes());
+                match temporal_of_id(dict, id) {
+                    Some(t) => {
+                        inst.extend_from_slice(&t.instant.to_le_bytes());
+                        flags.push(temp_flag(t));
+                    }
+                    None => {
+                        inst.extend_from_slice(&f64::NAN.to_le_bytes());
+                        flags.push(0);
+                    }
+                }
+            }
+            inst.extend_from_slice(&flags); // temporals.bin = instants || flags
+            (num, inst)
+        };
+
+        for sparse in [false, true] {
+            for compressed in [false, true] {
+                let g = {
+                    let g = Graph::load_str(ttl, "turtle").unwrap();
+                    if sparse { g.into_compressed() } else { g }
+                };
+                let (want_num, want_temp) = reference(&g.dict);
+                let dir = std::env::temp_dir()
+                    .join(format!("sparq_stream_caches_{}_{sparse}_{compressed}", std::process::id()));
+                std::fs::remove_dir_all(&dir).ok();
+                if compressed {
+                    g.save_compressed(&dir).unwrap();
+                } else {
+                    g.save(&dir).unwrap();
+                }
+
+                let got_num = std::fs::read(dir.join("numerics.bin")).unwrap();
+                let got_temp = std::fs::read(dir.join("temporals.bin")).unwrap();
+                let n = g.dict.len();
+                assert_eq!(got_num.len(), n * 8, "numerics.bin size (sparse={sparse} compressed={compressed})");
+                assert_eq!(got_temp.len(), n * 9, "temporals.bin size (sparse={sparse} compressed={compressed})");
+                assert_eq!(got_num, want_num, "streamed numerics != dense (sparse={sparse} compressed={compressed})");
+                assert_eq!(got_temp, want_temp, "streamed temporals != dense (sparse={sparse} compressed={compressed})");
+
+                // And the caches still resolve after a re-open (mmap path).
+                let g2 = Graph::open(&dir).unwrap();
+                // 42 is an xsd:integer, inline-encoded into its id (never in numerics.bin); the
+                // decimals 1.5/2.5 are the cache entries that must round-trip.
+                let nums: Vec<f64> = g2.dict.iter().filter_map(|(id, _)| g2.numeric_value(id)).collect();
+                assert!(nums.contains(&1.5) && nums.contains(&2.5), "numerics survive: {nums:?}");
+                let temporal_count = g2.dict.iter().filter(|(id, _)| g2.temporal_value(*id).is_some()).count();
+                assert_eq!(temporal_count, 2, "both temporal literals survive (sparse={sparse} compressed={compressed})");
+                std::fs::remove_dir_all(&dir).ok();
+            }
+        }
     }
 
     /// [OPUS-4.8] (sq-x32t) Recursively reads every regular file under `dir` and returns true iff


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Implements bead **sq-7ph8**.

## What

The in-RAM `save()`/`save_compressed()` finalize built whole-dictionary **dense intermediates** purely to write the `numerics.bin`/`temporals.bin` caches:

- `dense_temporals()` **always** allocated a fresh `(Vec<u8>, Vec<f64>)` (9 B/term) — even when the in-RAM temporal cache is `Sparse` (the usual non-temporal case: a tiny map), the very representation `build()` chooses via `into_sparse_if_worthwhile`.
- `dense_numerics()` rebuilt a dense `Vec<f64>` (8 B/term) for a `Sparse`/`Forked` cache (e.g. after `into_compressed`).

That is an O(distinct-terms) transient RSS spike on top of the resident dict — the finalize peak `research/wikidata-lowresource-stage1.md` flags. The dict-spill path already **stream-writes** these (`dictspill.rs`); the in-memory save path did not.

## How

Replace the dense-materialise + bulk-write with `stream_write_numerics` / `stream_write_temporals`: probe the cache per id (`lookup`, O(1)) and flush a small reusable block buffer (64K ids), keeping peak resident memory at the **block size** rather than the dictionary — the same bounded-write discipline the dict-spill path uses.

The output is **byte-identical** to the old dense write: same on-disk layout (`n` LE f64 numerics; `n` LE f64 temporal instants then `n` flag bytes), `NaN`/flag-0 for non-cached ids. So this is purely a memory optimisation, never a format change — every existing `open` round-trip is unaffected. The now-unused `dense_numerics`/`dense_temporals` helpers are dropped.

No public API change (the `save`/`save_compressed` signatures are unchanged; only private helpers moved), so no SKILL.md/G2 update is required.

## Tests

New `streamed_caches_byte_identical_to_dense` compares the streamed `numerics.bin`/`temporals.bin` against a **reference dense computation** done directly off the dictionary, across `{dense, sparse} × {save, save_compressed}`, asserts the exact on-disk sizes (`n*8`, `n*9`), and re-opens to confirm the mmap caches still resolve (incl. the inline-integer edge: `xsd:integer` 42 is id-encoded, never in `numerics.bin`).

## Unsafe surface — registered + audited [OPUS-4.8]

> **Correction (SPARQ agent):** an earlier revision of this body claimed "Gate clean" but the **unsafe-count ratchet was not run**. `stream_write_numerics` / `stream_write_temporals` each add one `unsafe { std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), size_of_val(&buf[..])) }` (reinterpret a reusable `Vec<f64>` block as bytes for `write_all`), and the commit also **removes** one `unsafe` (the old `dense_temporals` mmap reinterpret) — net **+1** in `sparq-core` (44 → 45), so `scripts/unsafe-gate.py --check` was **RED**. Now fixed.

**Soundness audit (both new `from_raw_parts` reinterprets):** SOUND, unsafe kept.
- (a) `size_of_val(&buf[..]) = len*8` views exactly the live, fully-initialised `Vec<f64>` region — no over-read.
- (b) target `u8` has alignment 1; the f64 source is over-aligned → no misalignment.
- (c) the bytes are only **read** (fed to `write_all`), never written through the alias.
- (d) the `&[u8]` is consumed inside the flush closure before `buf.clear()` → no provenance/lifetime escape.
- (e) **native-endian** reinterpret, identical to the `write_numerics`/`write_temporals` it replaces and symmetric with the native-endian **read** path (`NumData::as_slice`, the temporal mmap reads): write-native + read-native round-trips on the same arch (the established cache contract; the cache is rebuilt locally, never shipped cross-arch). `streamed_caches_byte_identical_to_dense` asserts byte-identity to the dense write. (The doc/register "little-endian" wording is inherited and accurate on the LE targets sparq runs; not a regression.)

Registered: two new rows in `compliance/memsafety/unsafe-register.md` (the removed site's row dropped; drifted lib.rs line refs resynced), each with a precise `// SAFETY:` comment in source (clippy `undocumented_unsafe_blocks` enforces it), and `bench/unsafe-snapshot.json` **re-seeded** for `sparq-core` 44 → 45 (workspace 58 → 59). The ratchet is **not relaxed** — it now passes at the new count because the register documents it (cert gap **GX-5**).

## Gate

- `scripts/unsafe-gate.py --check` — **PASS** (`sparq-core 45 == 45`, total `59 == 59`) ✅
- `cargo build -p sparq-core` — default: clean
- `cargo clippy -p sparq-core --all-targets -- -D warnings` — default **and** `--features mmap,dict-spill` (exercises the new unsafe): clean
- tests — default (68 lib +), `--no-default-features` (48 lib +), `--features mmap,dict-spill` (131 lib incl. `streamed_caches_byte_identical_to_dense`): all pass
- `cargo fmt -p sparq-core --check` — the change is **comments-only**; lib.rs carries no formatting delta (the work-box's local-rustfmt-version crate-wide diff pre-exists this PR, identical with the SAFETY comments stashed)
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` — introduces **no new** errors; the default-feature build still shows exactly the **5 pre-existing** `Self::open`/`Self::save_mmap` intra-doc-link errors (lines 1581/2537/2559/2653/2900, untouched by this PR), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

