### PR TITLE
feat(bench): register Apache Jena Fuseki+TDB2 http-sparql competitor (sq-gbq0) [OPUS-4.8]

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -67,7 +67,7 @@ conventions first, then a per-category map that points at the registry, then a
 | **zk** | commitment pipeline, trace seam, circuit gates, prove/verify | `zk-commit-throughput`, `zk-trace-overhead`, `zk-compose-gates`, `zk-compose-prove-verify` |
 | **serve** | concurrent-serving + memory-tiering research spikes; PSS write-path parity gate | `serve-spikes`, `memtier-spikes`, `pss-update-parity` |
 | **conformance** | W3C SPARQL + reasoning suites (correctness, not perf) | `sparql-conformance`, `inference-conformance` |
-| **competitors** | versioned external-engine comparison (Oxigraph / QLever / eye) + version+env capture | `competitor-gather` (registry: [`competitors.json`](./competitors.json)) |
+| **competitors** | versioned external-engine comparison (Oxigraph / QLever / Fuseki+TDB2 / eye + the SHACL/geo/FTS/vector peers) + version+env capture | `competitor-gather` (registry: [`competitors.json`](./competitors.json)) |
 
 Notes on a few that need care:
 

--- a/bench/competitors.json
+++ b/bench/competitors.json
@@ -88,6 +88,31 @@
       "dashboard_engine_id": "qlever"
     },
     {
+      "id": "fuseki",
+      "name": "Apache Jena Fuseki + TDB2",
+      "kind": "http-sparql",
+      "role": "[OPUS-4.8 sq-gbq0] Tier-1 SPARQL-1.1 reference SERVER (per research/competitor-benchmark-landscape.md §1): the canonical Jena/TDB2 store reviewers expect as the mainstream baseline + a CORRECTNESS ORACLE (cross-check COUNT/result-size before any timing). NOT the speed target — Fuseki is Java/JVM, single-machine, and lands mid/back-of-pack vs QLever (the speed rival stays QLever). Apache-2.0 -> numbers are publishable (no DeWitt/benchmark-publication clause). Adapter kind `http-sparql` (POST a SELECT/COUNT query -> parse SPARQL-results-JSON -> count) reusing scripts/bench-adapters/http_sparql_adapter.py, the SAME shared unit the QLever path uses and the one the Virtuoso bead (sq-gji9) inherits. tdb2.tdbloader bulk-loads NT/TTL and Fuseki serves SPARQL 1.1, so it runs every existing sparq suite unmodified.",
+      "pinned_version": "apache-jena-fuseki + TDB2 (pin the Fuseki distribution version or the Docker image DIGEST at gather time)",
+      "version_source": "the resolved Docker image DIGEST (`docker inspect --format '{{index .RepoDigests 0}}'`) — this digest IS the recorded version identifier — or, for a from-tarball install, the `fuseki --version` / distribution version. The SPARQL endpoint reports no build string, so the digest/distribution version IS the recorded identifier; recorded in the gather results file at run time.",
+      "install_recipe": "use the first-party jena-fuseki-docker image (Apache-2.0; Dockerfile + compose + helper scripts), OR a community image (stain/jena-fuseki, secoresearch/fuseki), OR download apache-jena-fuseki-<ver>.tar.gz + apache-jena-<ver>.tar.gz (for tdb2.tdbloader) and put bin/ on PATH. Docker-based -> gather-only on a Docker EC2 box (no Docker on the dev box; zero recurring CI cost). gather-only — NOT a committed dependency (engines stay out of git per AGENTS.md).",
+      "run_recipe": "PREP (gather box): bulk-load the suite corpus with `tdb2.tdbloader --loc <DB> <data.nt|.ttl>`, start Fuseki over <DB> (`fuseki-server --loc <DB> /ds` or the Docker image), then for each suite .rq drive the endpoint: `scripts/gather-competitors.sh --run --only fuseki` with SPARQL_ENDPOINT=<http://host:3030/ds/query> SPARQL_QUERY_FILE=<suite>/queries/<q>.rq set; the dispatch calls scripts/bench-adapters/http_sparql_adapter.py (POST query -> parse SPARQL-JSON -> count). COLD + min-of-N; COUNT(*) compute-mode headline. Cross-check the COUNT/result-size against sparq BEFORE trusting any timing.",
+      "adapter": {
+        "endpoint_env": "SPARQL_ENDPOINT",
+        "query_file_env": "SPARQL_QUERY_FILE",
+        "note": "POST each suite query (or its `SELECT (COUNT(*) AS ?n)` compute-mode wrap) to the Fuseki /query endpoint; parse SPARQL-results-JSON, count solutions (or read ?n). Methodology extends bench/CATALOG.md QUIET-BOX: gather ONCE on an otherwise-idle box, same machine+suite+scale back-to-back vs sparq, COLD + min-of-N. Cross-check COUNT/result-size first."
+      },
+      "comparable_suites": [
+        { "sparq_suite": "sp2b",   "note": "SP2Bench corpus; load .nt via tdb2.tdbloader, run queries/*.rq against the endpoint. COUNT(*) compute-mode headline; cross-check result-size vs sparq first." },
+        { "sparq_suite": "watdiv", "note": "WatDiv SF=1 corpus; comparable in count mode (same .rq workload as the QLever/Oxigraph WatDiv comparison)." },
+        { "sparq_suite": "lubm",   "note": "LUBM EXTENSIONAL tier ONLY — Fuseki/TDB2 does not materialize OWL 2 RL by default, so the entailed tier (Q6/Q9/Q11/Q12/Q13) is NOT comparable as-loaded; scope to the extensional queries (like Oxigraph/QLever)." },
+        { "sparq_suite": "bsbm",   "note": "BSBM Explore corpus via the endpoint; CONSTRUCT/DESCRIBE forms compare produced-triple counts." },
+        { "sparq_suite": "dbpsb",  "note": "DBPSB/FEASIBLE DBpedia cut; the suite Jena/Fuseki is most-reported on in the literature." }
+      ],
+      "version_env_metadata": "gather records the Fuseki Docker image DIGEST (or the distribution version / `fuseki --version`) + java -version + the host env block. Results land git-ignored in bench/competitor-results/fuseki-<suite>-<UTC>.json; promote into engines/values only deliberately, reviewed in-diff.",
+      "quiet_box_sensitive": true,
+      "dashboard_engine_id": "fuseki"
+    },
+    {
       "id": "eye",
       "name": "EYE (Euler Yet another proof Engine)",
       "kind": "binary",

--- a/scripts/gather-competitors.sh
+++ b/scripts/gather-competitors.sh
@@ -510,6 +510,13 @@ run_http_sparql_engine() { # <id>
   hdr "$id (http-sparql)"
   log "  adapter: $ADAPTERS_DIR/http_sparql_adapter.py (POST query -> parse SPARQL-JSON -> count)"
   log "  PREP (gather box): start the engine's HTTP endpoint, then set SPARQL_ENDPOINT + SPARQL_QUERY_FILE"
+  # [OPUS-4.8] sq-gbq0: a Docker-backed http-sparql engine (Fuseki, Virtuoso, the
+  # jena-* SAILs) records its IMAGE DIGEST as the version identifier (the endpoint
+  # reports no build string), and tags the result per SUITE so the file lands as
+  # <engine>-<suite>-<UTC>.json per bench/CATALOG.md (e.g. fuseki-sp2b-<UTC>.json).
+  # Both are OPTIONAL env knobs, backward-compatible: default suite stays
+  # "http-sparql" and the version falls back to the registry pinned_version.
+  log "  OPTIONAL: SPARQL_SUITE=<sp2b|watdiv|lubm|bsbm|dbpsb> tags the result file; SPARQL_IMAGE=<image:tag> records the resolved Docker DIGEST as the version"
   if [ "$DO_RUN" -eq 1 ]; then
     have python3 || die "python3 needed for the http-sparql adapter"
     { [ -n "${SPARQL_ENDPOINT:-}" ] && [ -n "${SPARQL_QUERY_FILE:-}" ]; } || die "http-sparql --run needs SPARQL_ENDPOINT + SPARQL_QUERY_FILE"
@@ -517,7 +524,14 @@ run_http_sparql_engine() { # <id>
             --query-file "$SPARQL_QUERY_FILE" --engine "$id" --iters "$ITERS" --json 2>/dev/null)" \
       || die "http-sparql adapter failed for $id (endpoint up?)"
     PAYLOAD="$(printf '%s' "$OUT" | python3 -c 'import json,sys; e,c,u=sys.stdin.read().split(); print(json.dumps({"engine":e,"count":int(c),"query_us":int(u)}))')"
-    write_result "$id" "http-sparql" "$(jq -r --arg id "$id" 'first(.competitors[]|select(.id==$id)).pinned_version//"unknown"' "$REGISTRY")" "$PAYLOAD"
+    # Version: a resolved Docker image DIGEST (SPARQL_IMAGE) IS the version pin for a
+    # Dockerized server; fall back to the registry pinned_version when not Dockerized.
+    local hver=""
+    if [ -n "${SPARQL_IMAGE:-}" ] && have docker; then
+      hver="$(docker inspect --format '{{index .RepoDigests 0}}' "$SPARQL_IMAGE" 2>/dev/null || true)"
+    fi
+    [ -n "$hver" ] || hver="$(jq -r --arg id "$id" 'first(.competitors[]|select(.id==$id)).pinned_version//"unknown"' "$REGISTRY")"
+    write_result "$id" "${SPARQL_SUITE:-http-sparql}" "$hver" "$PAYLOAD"
     check_df
   fi
 }


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-gbq0** (`bench`). Authored on Opus 4.8 (Fable unavailable; `[OPUS-4.8]` markers + Co-Authored-By trailer for re-review when Fable returns).

## What

Registers **Apache Jena Fuseki + TDB2** as a tier-1 competitor in `bench/competitors.json`. Fuseki/TDB2 is the canonical SPARQL-1.1 reference server reviewers expect as the mainstream baseline, and a correctness oracle — **not** the speed target (that stays QLever). Apache-2.0, so its numbers are publishable (no DeWitt/benchmark-publication clause). Per `research/competitor-benchmark-landscape.md` §1, this was the "cheapest high-value add → gather first" and answers @jeswr's "Fuseki?" with yes.

## Scope (and what is deliberately NOT here)

The bead's design has two halves:
1. **Registry entry** (`kind: docker-image` / `http-sparql`) — done here.
2. **Shared HTTP-SPARQL adapter** — *already exists* from sq-eifd (`scripts/bench-adapters/http_sparql_adapter.py` + the `run_http_sparql_engine` dispatch in `scripts/gather-competitors.sh`), the same unit QLever uses and the Virtuoso bead (sq-gji9) inherits. So no new parser was needed; this PR wires Fuseki into it.

The **actual numbers gather** is gather-only on a Docker-equipped EC2 box (Docker is not on the dev box, as the bead notes). Honest: this PR lands the *recipe*, not measured values — `engines`/`values` stay **empty** in git and real gather output lands git-ignored under `bench/competitor-results/`. No hard-coded perf in a tracked file (AGENTS.md).

## Changes

- **`bench/competitors.json`** — new `fuseki` entry: pinned-version/digest recipe, tdb2.tdbloader + endpoint run-recipe, COLD/min-of-N + COUNT(*) methodology, `comparable_suites` = sp2b / watdiv / lubm(extensional-only) / bsbm / dbpsb, `dashboard_engine_id: fuseki`.
- **`scripts/gather-competitors.sh`** — two OPTIONAL, backward-compatible env knobs on the http-sparql gather so a Dockerized server records honest metadata:
  - `SPARQL_SUITE` → tags the result file `<engine>-<suite>-<UTC>.json` (per `bench/CATALOG.md`); default stays `http-sparql`.
  - `SPARQL_IMAGE` → records the resolved Docker image **DIGEST** as the version (the endpoint reports no build string); falls back to the registry `pinned_version`.
  - `geosparql-jena` / `jena-text` (the other http-sparql entries) are unaffected.
- **`bench/CATALOG.md`** — competitors-row engine list refreshed to include Fuseki+TDB2.

## Gate (non-Rust change — no crate / no `unsafe` / no public Rust API)

- `jq .` validates `bench/competitors.json`; 14 competitor ids, all unique.
- `shellcheck scripts/gather-competitors.sh` — clean.
- `python3 scripts/bench-adapters/test_adapters.py` — **46 passed, 0 failed** (http-sparql parser fixtures included).
- `scripts/gather-competitors.sh` full dry-run + `--list` + `--only fuseki` dry-run all exit 0 and show the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
