### PR TITLE
docs(sparq-solid): record ldp:contains/containment-view ownership decision + pin invariant (sq-3jtd.4) [OPUS-4.8]

### DIFF
--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -387,6 +387,22 @@ indistinguishable from an absent one. Before the first `materialize_*` call ever
 at load. See [`SECURITY.md`](../../SECURITY.md) for the project security policy and the
 design doc for the full threat model.
 
+## Containment / `ldp:contains` ownership — PSS-written, not sparq-derived ([OPUS-4.8] sq-3jtd.4)
+
+A container's `ldp:contains` listing is **explicit content written by the storage layer
+(PSS)**, not a sparq-derived or sparq-materialized view. sparq-solid stores `ldp:contains`
+as ordinary triples in the container's named graph and treats them as opaque content: it
+**never** derives `ldp:contains` from IRI structure, mutates or re-derives it on a write,
+or reads it into the reasoner. Containment *ancestry* is derived structurally from IRI
+slash-semantics (`solidx:parent`/`solidx:ancestor`, design doc §3.2) purely to drive ACL
+inheritance — that derivation never surfaces as `ldp:contains`. Keeping containment
+PSS-written avoids re-deriving a view on every write, keeps the §2.4 content/reasoner
+security boundary clean (a derived listing would have to read pod content), and lets the
+engine's atomic multi-op `UPDATE` keep the explicit triples consistent. The decision and
+the conditions under which a structural-only sparq-side derivation would be revisited are
+recorded in the design doc §7 item 7 and `research/sparq-solid-scope.md` area 2. The invariant is
+pinned by `tests/containment_view_ownership.rs`.
+
 ## 📚 Learn more
 
 - **Design + threat model + measured baseline** —

--- a/crates/sparq-solid/tests/containment_view_ownership.rs
+++ b/crates/sparq-solid/tests/containment_view_ownership.rs
@@ -1,0 +1,100 @@
+//! [OPUS-4.8] sq-3jtd.4 — `ldp:contains` / containment-view OWNERSHIP decision guard.
+//!
+//! DECISION (research/solid-access-control-design.md §2.1 / §7.7,
+//! research/sparq-solid-scope.md area 2): a container's `ldp:contains` listing is
+//! **PSS-written explicit content**, NOT a sparq-derived/materialized view. sparq-solid
+//! derives *ancestry* structurally from IRI slash-semantics (`solidx:parent`/
+//! `solidx:ancestor`, §3.2) purely to drive ACL inheritance, and **never**:
+//!   - derives `ldp:contains` from structure,
+//!   - mutates or re-derives `ldp:contains` on a write, or
+//!   - reads `ldp:contains` from pod content into the reasoner.
+//!
+//! These tests pin that boundary so the codebase cannot silently drift toward
+//! sparq-owned containment. If PSS ever asks sparq to own containment derivation it is a
+//! separate, explicitly-scoped structural-only spike (the bead body) — and these tests
+//! would be the thing that has to change deliberately.
+
+use sparq_core::Graph;
+use sparq_engine::query;
+use sparq_solid::{wac_fixture, PodStore, AUTH_GRAPH};
+
+const LDP_CONTAINS: &str = "http://www.w3.org/ns/ldp#contains";
+
+fn rows(g: &Graph, q: &str) -> usize {
+    query(g, q).expect("query ok").rows.len()
+}
+
+/// All `ldp:contains` triples, regardless of named graph, as `(s, o, graph)` strings.
+fn all_contains(g: &Graph) -> Vec<(String, String, String)> {
+    let q = format!(
+        "SELECT ?s ?o ?g WHERE {{ GRAPH ?g {{ ?s <{LDP_CONTAINS}> ?o }} }} ORDER BY ?s ?o ?g"
+    );
+    query(g, &q)
+        .expect("query ok")
+        .rows
+        .iter()
+        .map(|r| {
+            let cell = |i: usize| r[i].as_ref().map(|t| t.to_string()).unwrap_or_default();
+            (cell(0), cell(1), cell(2))
+        })
+        .collect()
+}
+
+/// Materializing the auth view leaves every PSS-written `ldp:contains` triple
+/// byte-identical: the materializer neither derives new containment nor mutates or
+/// drops the explicit ones. (The fixture is the stand-in for a PSS-written pod.)
+#[test]
+fn materialization_preserves_pss_written_contains_verbatim() {
+    let g = Graph::load_dataset(&wac_fixture(), "nquads").expect("fixture loads");
+    let before = all_contains(&g);
+    assert!(
+        !before.is_empty(),
+        "fixture must carry PSS-written ldp:contains so the guard is meaningful"
+    );
+
+    let mut store = PodStore::new(g);
+    store.materialize_wac().expect("wac materializes");
+
+    let after = all_contains(&store.graph);
+    assert_eq!(
+        before, after,
+        "ldp:contains is PSS-written content; materialization must not add, drop, or move any"
+    );
+}
+
+/// sparq does NOT derive a containment view: no `ldp:contains` triple is ever emitted
+/// into the reserved auth graph. Containment ancestry lives only as the internal
+/// `solidx:` ancestry facts that drive inheritance — never re-surfaced as `ldp:contains`.
+#[test]
+fn no_contains_is_derived_into_the_auth_view() {
+    let g = Graph::load_dataset(&wac_fixture(), "nquads").expect("fixture loads");
+    let mut store = PodStore::new(g);
+    store.materialize_wac().expect("wac materializes");
+
+    let derived = rows(
+        &store.graph,
+        &format!("SELECT ?s ?o WHERE {{ GRAPH <{AUTH_GRAPH}> {{ ?s <{LDP_CONTAINS}> ?o }} }}"),
+    );
+    assert_eq!(
+        derived, 0,
+        "the auth view must not own/derive ldp:contains (containment is PSS-written content)"
+    );
+}
+
+/// `ldp:contains` is opaque content to the reasoner: every `ldp:contains` triple that
+/// exists after materialization is exactly one that was supplied in a *content* graph
+/// (the container's own graph), never synthesized into the reserved `urn:sparq:` space.
+#[test]
+fn contains_lives_only_in_pss_content_graphs() {
+    let g = Graph::load_dataset(&wac_fixture(), "nquads").expect("fixture loads");
+    let mut store = PodStore::new(g);
+    store.materialize_wac().expect("wac materializes");
+
+    for (s, _o, graph) in all_contains(&store.graph) {
+        assert!(
+            !graph.contains("urn:sparq:"),
+            "ldp:contains for {s} leaked into a reserved sparq graph ({graph}); \
+             containment must stay PSS-written content"
+        );
+    }
+}

--- a/research/solid-access-control-design.md
+++ b/research/solid-access-control-design.md
@@ -812,4 +812,19 @@ Reading the numbers honestly:
    today): a *precise* per-solution check for variable `GRAPH ?var` template slots (today:
    require write on every store graph), and the `auth:append`-only insert-into-absent-graph
    edge. <!-- [OPUS-4.8] sq-xor3 -->
+7. **Containment / `ldp:contains` view ownership** — **DECIDED: PSS-written, not
+   sparq-derived** (sq-3jtd.4). A container's `ldp:contains` listing is explicit content the
+   storage layer (PSS) writes in its UPDATE bodies; sparq-solid stores it as ordinary triples
+   in the container's named graph (`fixture.rs`) and treats it as opaque content — it never
+   derives `ldp:contains` from IRI structure, mutates/re-derives it on a write, or reads it
+   into the reasoner. Containment *ancestry* is derived structurally (`solidx:parent`/
+   `solidx:ancestor`, §3.2) only to drive ACL inheritance and is never surfaced as
+   `ldp:contains`. Rationale: (i) avoids re-deriving a view on every write; (ii) keeps the
+   §2.4 content/reasoner boundary clean — a derived listing would have to read pod content;
+   (iii) the engine's atomic multi-op UPDATE (sq-ycle) is exactly the mechanism that keeps the
+   PSS-written listing consistent. The invariant is pinned by
+   `tests/containment_view_ownership.rs`. **Revisit only if** PSS asks sparq to own
+   containment; that would be a separate, explicitly-scoped *structural-only* (IRI
+   slash-semantics) derivation spike, never a content-reading one (`research/sparq-solid-scope.md`
+   area 2). <!-- [OPUS-4.8] sq-3jtd.4 -->
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Please review.

## What

Bead **sq-3jtd.4** is a **DECISION / decision-tracking** task: settle who owns the `ldp:contains` / containment view (PSS-written explicit triples vs sparq-derived), and spike a structural-only sparq-side derivation *only if* PSS later wants it.

**Decision recorded: `ldp:contains` is PSS-written content, not a sparq-derived/materialized view.**

sparq-solid stores `ldp:contains` as ordinary triples in the container's named graph and treats them as opaque content. It **never**:
- derives `ldp:contains` from IRI structure,
- mutates or re-derives it on a write, or
- reads it into the reasoner.

Containment *ancestry* is still derived structurally (`solidx:parent`/`solidx:ancestor`, design doc §3.2) purely to drive ACL inheritance — that derivation is never surfaced as `ldp:contains`.

Rationale: (i) avoids re-deriving a view on every write; (ii) keeps the §2.4 content/reasoner security boundary clean — a derived listing would have to read pod content; (iii) the engine's atomic multi-op `UPDATE` (sq-ycle) is exactly what keeps the PSS-written listing consistent. Revisited only if PSS asks sparq to own containment — that would be a separate, explicitly-scoped *structural-only* (IRI slash-semantics) spike, never a content-reading one.

## Changes

- **Durable record** of the decision + revisit conditions in `research/solid-access-control-design.md` (§7 item 7) and `crates/sparq-solid/README.md`.
- **`tests/containment_view_ownership.rs`** pins the invariant so the codebase cannot silently drift toward sparq-owned containment:
  - materialization preserves every PSS-written `ldp:contains` triple **verbatim** (no add/drop/move);
  - **no** `ldp:contains` is derived into the reserved auth graph;
  - `ldp:contains` lives only in PSS content graphs, never synthesized into the reserved `urn:sparq:` space.

No public API change; no new `unsafe`. This is honest scope for a decision bead: it records the decision and guards it, rather than shipping a no-op or a speculative derivation engine.

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` (default **and** `--all-features`) — clean
- `cargo test -p sparq-solid` in **both** feature states — all pass (new tests: 3/3)
- Workspace rustdoc gate `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` and again `--all-features` — clean
- `scripts/check-privacy-claims.sh` — OK
- New test file is `cargo fmt`-clean against the workspace `rustfmt.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)