### PR TITLE
docs(sparq-gpu): de-perf README — drop baked speedup ratios (sq-p3fk) [OPUS-4.8]

### DIFF
--- a/crates/sparq-gpu/README.md
+++ b/crates/sparq-gpu/README.md
@@ -13,10 +13,13 @@ The full measured answer, tables, and the recommendation live in
 
 > **Parked.** On this M1 (unified memory — the *best possible* transfer
 > economics), the GPU loses or merely ties the 8-core CPU on compute-light
-> scans even when the column is already device-resident, and only wins on the
-> hash-probe shape (~1.7–3× resident, ~1.1× including transfer). One winning
-> kernel class does not pay for a residency cache, scheduler integration, and
-> a second execution backend. Re-open only per the conditions in the verdict.
+> scans even when the column is already device-resident, and wins only on the
+> hash-probe shape — and that win mostly evaporates once the host→device
+> transfer is charged. One winning kernel class does not pay for a residency
+> cache, scheduler integration, and a second execution backend. Re-open only
+> per the conditions in the verdict. The measured ratios live in the verdict
+> and on the [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench),
+> never baked in here.
 
 ## What is here
 


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-p3fk** (`sparq-gpu` docs).

## What

`crates/sparq-gpu/README.md:17` baked in hard-coded speedup ratios
(`~1.7–3× resident, ~1.1× including transfer`), violating the AGENTS.md
**"No hard-coded performance numbers"** house rule.

This replaces them with a **qualitative** statement — the GPU wins only on the
hash-probe shape, and that win mostly evaporates once the host→device transfer
is charged honestly — plus a link to the
[benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench), the single
source of truth. This matches the **sq-q0im** treatment of the
GenAI/wasm/js READMEs.

## Scope

- Only the baked ratios on line 17 are removed; the qualitative verdict
  ("Parked", which shape wins) is preserved.
- Line 42's `{1M, 10M, 100M} elements` is benchmark **input config**, not a
  measured figure — left as-is, per the bead's explicit note.
- The measured numbers continue to live in `research/gpu-verdict.md` (a
  `research/` design record, the correct home for measured tables) and on the
  perf dashboard — the README now points there.

## Gate

Docs-only change (no Rust source, no public API, no `unsafe`). Verified:

- `cargo build` / `clippy --all-targets -- -D warnings` / `cargo test` — pass.
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sparq-gpu --no-deps` (and
  `--all-features`) — pass.
- `scripts/check-no-perf-numbers.py` — no GPU README finding.
- `markdownlint-cli2` (HARD scoped config) — 0 errors.
- `scripts/check-privacy-claims.sh` — OK.
- Relative link `../../research/gpu-verdict.md` target verified to exist.

[OPUS-4.8]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
