### PR TITLE
feat(sparq-engine): add request-atomic update_in_place_atomic wrapper (sq-o1wp)

### DIFF
--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -49,7 +49,8 @@ pub use construct::{
 pub use cs::{with_cs_table, CsSet, CsTable};
 pub use explain::{explain, explain_analyze, explain_analyze_with_budget};
 pub use update::{
-    apply_effects, update, update_in_place, update_in_place_capturing, update_in_place_with_budget,
+    apply_effects, update, update_in_place, update_in_place_atomic,
+    update_in_place_atomic_with_budget, update_in_place_capturing, update_in_place_with_budget,
     with_load_base, UpdateEffect,
 };
 

--- a/crates/sparq-engine/src/update.rs
+++ b/crates/sparq-engine/src/update.rs
@@ -649,6 +649,44 @@ pub fn update_in_place_capturing(
     Ok(effects)
 }
 
+/// [OPUS-4.8] (sq-o1wp) Request-ATOMIC variant of [`update_in_place`]: applies the whole
+/// `;`-separated update request to a private [`fork`](Graph::fork) and only commits it back into
+/// `graph` (by replacing `*graph`) when EVERY operation succeeds. On any error — a parse failure,
+/// a non-SILENT failing `LOAD`, or a budget/WHERE blow-up on operation *K* — the partial fork is
+/// discarded and `graph` is left EXACTLY at its pre-request state (full rollback).
+///
+/// This packages, as a safe public default, the request-level-atomicity pattern the production
+/// serve writer already uses (fork → apply → seal-only-on-`Ok`; see
+/// `fork_and_seal_recovers_request_atomicity`). The bare [`update_in_place`] primitive is, by its
+/// documented contract, NON-atomic on error: a failing later operation leaves the earlier ops'
+/// partial prefix applied (see `in_place_request_is_partial_on_error_by_contract`). That is the
+/// fast path the serve writer wraps; a *direct library consumer* that does not implement its own
+/// fork/seal recovery should reach for THIS function to get SPARQL 1.1's all-or-nothing request
+/// semantics without the footgun.
+///
+/// Cost: one [`fork`](Graph::fork) (O(pending delta), not O(triples)) plus the in-place apply. The
+/// fork carries no WAL/redo-journal, so the committed state inherits `graph`'s durability story
+/// only after the swap — for a directory-backed graph prefer the serve writer path, which seals
+/// through the durable base. Runs under an unlimited [`crate::QueryBudget`]; use
+/// [`update_in_place_atomic_with_budget`] to bound a `DELETE/INSERT … WHERE`.
+pub fn update_in_place_atomic(graph: &mut Graph, sparql: &str) -> Result<(), String> {
+    update_in_place_atomic_with_budget(graph, sparql, &crate::QueryBudget::unlimited())
+}
+
+/// [OPUS-4.8] (sq-o1wp) [`update_in_place_atomic`] under a cooperative [`crate::QueryBudget`] (the
+/// budget bounds a `DELETE/INSERT … WHERE` exactly as in [`update_in_place_with_budget`]). The
+/// fork is applied under the budget; a budget-exceeded error rolls the request back whole.
+pub fn update_in_place_atomic_with_budget(
+    graph: &mut Graph,
+    sparql: &str,
+    budget: &crate::QueryBudget,
+) -> Result<(), String> {
+    let mut working = graph.fork();
+    update_in_place_with_budget(&mut working, sparql, budget)?;
+    *graph = working;
+    Ok(())
+}
+
 /// The shared in-place apply core. When `sink` is `Some`, every operation's RESOLVED effect is
 /// recorded into it so a durable mirror can replay the exact committed delta (see
 /// [`update_in_place_capturing`]); when `None`, capture is fully elided.
@@ -1812,6 +1850,52 @@ mod update_contract {
         assert_eq!(dataset_count(&published), 3, "an all-succeed request seals the fully-applied working copy");
         // The base the fork came from is, throughout, untouched by either request.
         assert_eq!(dump(&base), snapshot, "the published base is never mutated by a working-copy apply");
+    }
+
+    /// [OPUS-4.8] (sq-o1wp) [`update_in_place_atomic`] packages the fork → apply → seal-only-on-`Ok`
+    /// pattern as a safe public default, so a DIRECT library consumer gets SPARQL-1.1 all-or-nothing
+    /// request semantics WITHOUT writing its own recovery. Pins both arms: a failing multi-op request
+    /// leaves `graph` exactly at its pre-request snapshot (full rollback — the hazard the bare
+    /// `update_in_place` leaks per `in_place_request_is_partial_on_error_by_contract`), and an
+    /// all-succeed request commits every operation in place.
+    #[test]
+    fn in_place_atomic_rolls_back_whole_request_on_error() {
+        let mut g = Graph::load_str("@prefix : <http://ex/> . :seed :p :o .", "turtle").unwrap();
+        let snapshot = dump(&g);
+        assert_eq!(dataset_count(&g), 1);
+
+        // A request: a VALID INSERT DATA, then a non-SILENT LOAD that fails (op K = 2).
+        let failing = "PREFIX : <http://ex/> INSERT DATA { :a :p :b } ; LOAD <http://ex/nope.ttl>";
+        let r = update_in_place_atomic(&mut g, failing);
+        assert!(r.is_err(), "the request reports the failure");
+        // Unlike the bare in-place path, the valid INSERT DATA prefix is NOT committed.
+        assert_eq!(dump(&g), snapshot, "atomic in-place rolls the dataset back to its pre-request snapshot");
+        assert_eq!(dataset_count(&g), 1, "the pre-failure prefix must NOT have committed in place");
+
+        // The all-succeed counterpart commits every operation in place.
+        let ok = "PREFIX : <http://ex/> INSERT DATA { :a :p :b } ; INSERT DATA { :c :p :d }";
+        update_in_place_atomic(&mut g, ok).expect("an all-succeed request commits in place");
+        assert_eq!(dataset_count(&g), 3, "an all-succeed request commits every operation in place");
+    }
+
+    /// [OPUS-4.8] (sq-o1wp) A parse error never mutates `graph` under the atomic wrapper (the fork is
+    /// built but `parse_update` fails before any op applies), and the budgeted entry point shares the
+    /// same all-or-nothing contract.
+    #[test]
+    fn in_place_atomic_parse_error_and_budget_entry_point() {
+        let mut g = Graph::load_str("@prefix : <http://ex/> . :seed :p :o .", "turtle").unwrap();
+        let snapshot = dump(&g);
+        assert!(update_in_place_atomic(&mut g, "NOT A VALID UPDATE").is_err(), "parse error is reported");
+        assert_eq!(dump(&g), snapshot, "a parse error leaves the graph untouched");
+
+        // Budgeted entry point: an all-succeed request under an unlimited budget commits.
+        update_in_place_atomic_with_budget(
+            &mut g,
+            "PREFIX : <http://ex/> INSERT DATA { :a :p :b }",
+            &crate::QueryBudget::unlimited(),
+        )
+        .expect("budgeted atomic apply commits an all-succeed request");
+        assert_eq!(dataset_count(&g), 2, "the budgeted atomic apply committed the insert");
     }
 }
 

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -86,7 +86,12 @@ Update (data lives in the default + named graphs):
 
 - `update(&Graph, &str) -> Result<Graph, String>` — returns a NEW graph (O(n) rebuild).
 - `update_in_place(&mut Graph, &str) -> Result<(), String>` — incremental delta-overlay, O(batch);
-  WAL-durable for directory-backed graphs.
+  WAL-durable for directory-backed graphs. NON-atomic on error: a failing op leaves the earlier
+  ops' partial prefix applied (request-level atomicity is the caller's responsibility).
+- `update_in_place_atomic(&mut Graph, &str) -> Result<(), String>` (+ `_with_budget`) — request-ATOMIC
+  delta-overlay: forks, applies, and commits back ONLY if every op succeeds (else `graph` is left at
+  its pre-request state). Use this for SPARQL-1.1 all-or-nothing semantics from a direct library
+  consumer without writing your own fork/seal recovery.
 - `update_in_place_capturing(&mut Graph, &str, &QueryBudget) -> Result<Vec<UpdateEffect>, String>`
   + `apply_effects(&mut Graph, &[UpdateEffect])` — apply once, capturing the RESOLVED delta, then
   replay it onto a second (e.g. durable mirror) graph WITHOUT re-executing the text. Use this when
@@ -320,9 +325,11 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
 - **Only SELECT/ASK** go through `query`/`query_json`/`count`; CONSTRUCT/DESCRIBE have their own
   functions, and a form mismatch is a clean `Err` (e.g. `ask()` on a SELECT).
 - **`SELECT *`** never exposes blank-node "variables" (`_:x` in a pattern is an existential var).
-- **`update` vs `update_in_place`** — `update` returns a fresh `Graph` (input borrowed, untouched);
-  `update_in_place(&mut g, …)` mutates via the delta overlay (call `Graph::compact` periodically).
-  `LOAD` only resolves `file://`; set the base dir with `with_load_base(path, || update(...))`.
+- **`update` vs `update_in_place` vs `update_in_place_atomic`** — `update` returns a fresh `Graph`
+  (input borrowed, untouched, atomic by construction); `update_in_place(&mut g, …)` mutates via the
+  delta overlay (call `Graph::compact` periodically) but is NON-atomic on error; `update_in_place_atomic`
+  forks-and-seals so an in-place mutation is all-or-nothing. `LOAD` only resolves `file://`; set the
+  base dir with `with_load_base(path, || update(...))`.
 - **SPARQL `SERVICE` federation** is the non-default `service` cargo feature (pulls `ureq`; off on
   wasm). When enabled, outbound `SERVICE` fetches go through a **default-deny SSRF egress filter**:
   an endpoint that resolves to a loopback / RFC1918 / link-local (incl. the `169.254.169.254`


### PR DESCRIPTION
> 🤖 SPARQ agent

## What & why (sq-o1wp)

A SPARQL UPDATE *request* is a `;`-separated op sequence and per SPARQL 1.1 should be all-or-nothing. The delta-overlay entry point `update_in_place(&mut Graph, sparql)` applies ops in place and, on op *K* failing, leaves ops `0..K-1` committed (a partial prefix) — pinned by the existing `in_place_request_is_partial_on_error_by_contract`.

This is fine in production: the serve writer already recovers atomicity via fork → apply → seal-only-on-`Ok`, and the rebuild path `update()` is atomic by construction. The gap sq-o1wp identifies is a **library footgun**: any *direct* consumer of `update_in_place` gets silent partial application on error.

This PR takes **option (a)** from the bead — add an atomic wrapper as a safe public default — rather than only documenting the hazard:

- **`update_in_place_atomic(&mut Graph, &str)`** (+ `update_in_place_atomic_with_budget`) forks the graph, applies the whole request to the private fork, and commits it back (`*graph = working`) **only on `Ok`**. On any error (parse failure, non-SILENT failing `LOAD`, or a budget/WHERE blow-up) the partial fork is discarded and `graph` is left **exactly at its pre-request state** (full rollback). Cost is one `Graph::fork()` (O(pending delta), not O(triples)) plus the apply.
- The bare `update_in_place` primitive is **unchanged** (byte-for-byte the previous behaviour) — it stays the fast path the serve writer wraps, and its rustdoc + SKILL.md now flag the non-atomicity explicitly so the choice is informed.

## Tests

Added to the existing `update_contract` module (which already pins the non-atomic contract and the production fork/seal pattern):

- `in_place_atomic_rolls_back_whole_request_on_error` — a multi-op request whose `LOAD` fails leaves the dataset at its pre-request snapshot; the all-succeed counterpart commits every op in place.
- `in_place_atomic_parse_error_and_budget_entry_point` — a parse error never mutates the graph; the budgeted entry point shares the contract.

## Gate

- `cargo build` + `cargo clippy --all-targets -- -D warnings` (the hard gate) green in **both** feature states (default + `--no-default-features`).
- `cargo test -p sparq-engine --lib` green in both feature states (198 / 191 passed).
- Rustdoc gate: `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` and again `--all-features` — both clean. (Doc cross-refs point only at public items / plain code spans for the `#[cfg(test)]` helpers.)
- No `unsafe` added; no privacy-claim / predicate-soundness surface touched.
- G2: public-API change reflected in `skills/sparql-query/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)