### PR TITLE
feat(sparq-vectors): wire PQ candidate cache into DiskAnnIndex search path (sq-qamd) [OPUS-4.8]

### DIFF
--- a/crates/sparq-vectors/src/diskann.rs
+++ b/crates/sparq-vectors/src/diskann.rs
@@ -32,7 +32,7 @@
 //! offset 12   degree R    u32   (max out-neighbours)    4 bytes
 //! offset 16   count       u64   (nodes = store vectors) 8 bytes
 //! offset 24   medoid      u32   (entry-point slot)      4 bytes
-//! offset 28   reserved    zero  (encoding tag etc.)     4 bytes
+//! offset 28   enc_tag     u32   (0 = none, 1 = PQ cache) 4 bytes
 //! offset 32   fingerprint graph fingerprint            24 bytes
 //!             (dict_len: u64, triple_count: u64, content_hash: u64)
 //! offset 56   nodes       [count × NODE_RECORD]         count·record bytes
@@ -42,6 +42,13 @@
 //!   degree    u32                  number of valid neighbours (≤ R)
 //!   vector    [dim] f32            the L2-NORMALIZED vector (search reads it here)
 //!   nbrs      [R] u32              neighbour SLOT indices; entries ≥ degree are padding
+//!
+//! [OPUS-4.8] (sq-qamd) the optional PQ_SECTION (present iff enc_tag == 1, appended after nodes):
+//!   magic     b"SPQP"              4 bytes
+//!   cb_len    u64                  length of the codebook block that follows
+//!   codebook  [cb_len] bytes       ProductQuantizer::to_bytes (dim, m, k + centroids)
+//!   stride    u32                  code length M (== codebook M)
+//!   codes     [count × M] bytes    per-slot PQ codes, slot order (== node-record order)
 //! ```
 //!
 //! A node's vector and its adjacency are **co-located in one record** (the DiskANN locality
@@ -51,20 +58,23 @@
 //!
 //! # Honest scope vs. full DiskANN
 //!
-//! This is the **Vamana on-disk graph with full-precision vectors searched from the mmap**.
-//! Full DiskANN additionally keeps a **PQ-compressed** copy of every vector resident in RAM to
-//! rank candidates without touching disk, reading full-precision vectors only to re-rank the
-//! beam. That quantization layer now exists ([OPUS-4.8] sq-nq5,
-//! [`quant`](crate::quant) — [`ProductQuantizer`](crate::quant::ProductQuantizer) +
-//! [`EncodedStore`](crate::quant::EncodedStore) + [`DistanceTable`](crate::quant::DistanceTable))
-//! as a standalone, tested encoder/decoder/distance-estimator, but `search_slots` below is
-//! **unchanged** — it still searches full-precision from the mmap. Wiring the PQ candidate cache
-//! into the greedy search (rank on codes in RAM, re-rank the beam off the mmap) is the recorded
-//! follow-up; see `quant.rs`'s "intended use" note and this crate's open beads
-//! (`bd list -l area:sparq-vectors`). At the scales where the graph
-//! fits in page cache (the regime this unblocks: skip the per-process rebuild) the two are
-//! equivalent; PQ matters only when the vectors themselves exceed RAM. The `.spqg` header
-//! reserves 4 bytes for an encoding tag so a PQ variant lands as a backwards-compatible bump.
+//! The default build is the **Vamana on-disk graph with full-precision vectors searched from the
+//! mmap**. Full DiskANN additionally keeps a **PQ-compressed** copy of every vector resident in RAM
+//! to rank candidates without touching disk, reading full-precision vectors only to re-rank the
+//! beam. That quantization layer ([OPUS-4.8] sq-nq5,
+//! [`quant`](crate::quant) — [`ProductQuantizer`] + [`EncodedStore`] + [`DistanceTable`])
+//! is now **wired into the search path** ([OPUS-4.8] sq-qamd): build with
+//! [`DiskAnnIndex::build_with_pq`] and the greedy search ranks each visited node's neighbours by an
+//! ADC [`DistanceTable`] lookup against the in-RAM codes (no disk), reading the full-precision
+//! vector from the mmap only for the final beam it re-ranks — DiskANN's "search on PQ, re-rank on
+//! disk" loop. Without the PQ section (the plain [`build`](DiskAnnIndex::build) /
+//! [`build_with`](DiskAnnIndex::build_with) path) `search_slots` is unchanged: it computes every
+//! candidate distance from the full-precision mmap, exactly as before. At the scales where the graph
+//! fits in page cache (the regime the plain index unblocks: skip the per-process rebuild) the two
+//! are recall-equivalent up to the PQ approximation; PQ matters most when the vectors themselves
+//! exceed RAM. The `.spqg` header's 4 reserved bytes carry an **encoding tag** (`0` = no cache,
+//! `1` = a trailing PQ section), so the PQ variant is a backwards-compatible addition: a plain
+//! reader sees the tag and a longer file but the node-record layout is byte-identical.
 //!
 //! [OPUS-4.8] (sq-32i5) The header also carries a **graph fingerprint** (offset 32..56) binding
 //! the index to the graph it was built against — see [`crate::fingerprint`] and
@@ -74,6 +84,7 @@
 //! are reported as unverifiable.
 
 use crate::fingerprint::{self, Fingerprint, FINGERPRINT_LEN};
+use crate::quant::{DistanceTable, EncodedStore, PqConfig, ProductQuantizer};
 use crate::store::VectorStore;
 use memmap2::Mmap;
 use oxrdf::Term;
@@ -92,6 +103,15 @@ pub const SPQG_VERSION: u32 = 2;
 const HEADER_LEN_V1: usize = 32;
 /// Header length of the current (version-2) format: the v1 header + the fingerprint block.
 const HEADER_LEN: usize = HEADER_LEN_V1 + FINGERPRINT_LEN;
+/// Byte offset of the encoding tag (the 4 reserved bytes of the v1/v2 header).
+const ENC_TAG_OFFSET: usize = 28;
+/// Encoding tag: no PQ candidate cache — the file ends at the last node record (default).
+const ENC_TAG_NONE: u32 = 0;
+/// [OPUS-4.8] (sq-qamd) Encoding tag: a **PQ candidate-cache section** follows the node records
+/// (codebook + per-slot codes). See `PqSection` for the trailing block's layout.
+const ENC_TAG_PQ: u32 = 1;
+/// First four bytes of the trailing PQ section (a guard against a truncated/garbled tail).
+const PQ_SECTION_MAGIC: [u8; 4] = *b"SPQP";
 
 /// Vamana build/search parameters. Defaults follow the DiskANN paper's small-graph regime
 /// and are tuned to clear [`ann`](crate::ann)'s recall@10 ≥ 0.95 gate on the same synthetic
@@ -357,9 +377,39 @@ const fn record_len(dim: usize, degree: usize) -> usize {
     8 + dim * 4 + degree * 4
 }
 
+/// [OPUS-4.8] (sq-qamd) The trailing PQ candidate-cache section: the fitted quantizer plus every
+/// vector's PQ code, ready to be appended after the node records when the encoding tag is `1`.
+struct PqSection {
+    pq: ProductQuantizer,
+    codes: EncodedStore,
+}
+
+impl PqSection {
+    /// Serializes the section to the on-disk byte layout documented in the module header
+    /// (`SPQP` magic, codebook length + codebook, stride, then the flat per-slot codes).
+    fn to_bytes(&self) -> Vec<u8> {
+        let cb = self.pq.to_bytes();
+        let codes = self.codes.codes();
+        let mut out = Vec::with_capacity(4 + 8 + cb.len() + 4 + codes.len());
+        out.extend_from_slice(&PQ_SECTION_MAGIC);
+        out.extend_from_slice(&(cb.len() as u64).to_le_bytes());
+        out.extend_from_slice(&cb);
+        out.extend_from_slice(&(self.codes.stride() as u32).to_le_bytes());
+        out.extend_from_slice(codes);
+        out
+    }
+}
+
 /// Writes the built graph to `path` as a `.spqg` file (one node record per node). `fingerprint`
 /// (offset 32..56) binds the index to its graph; `None` writes an unverifiable (all-zero) block.
-fn write_graph(b: &Builder, path: &Path, fingerprint: Option<Fingerprint>) -> Result<(), String> {
+/// `pq` (when `Some`) appends a `PqSection` after the node records and sets the encoding tag to
+/// [`ENC_TAG_PQ`]; its `codes` MUST be in the same slot order as the node records.
+fn write_graph(
+    b: &Builder,
+    path: &Path,
+    fingerprint: Option<Fingerprint>,
+    pq: Option<&PqSection>,
+) -> Result<(), String> {
     if cfg!(target_endian = "big") {
         return Err(".spqg is a little-endian format; big-endian targets are unsupported".into());
     }
@@ -372,8 +422,11 @@ fn write_graph(b: &Builder, path: &Path, fingerprint: Option<Fingerprint>) -> Re
     header[12..16].copy_from_slice(&(r as u32).to_le_bytes());
     header[16..24].copy_from_slice(&(count as u64).to_le_bytes());
     header[24..28].copy_from_slice(&b.medoid.to_le_bytes());
-    // [OPUS-4.8] (sq-32i5) Graph fingerprint at offset 32..56 (offset 28..32 stays the reserved
-    // encoding tag). `None` leaves a zeroed block, which `check_graph` treats as unverifiable.
+    // [OPUS-4.8] (sq-qamd) Encoding tag at offset 28..32: `1` when a PQ section is appended below,
+    // else `0`. (sq-32i5) Graph fingerprint at offset 32..56; `None` leaves a zeroed block, which
+    // `check_graph` treats as unverifiable.
+    let enc_tag = if pq.is_some() { ENC_TAG_PQ } else { ENC_TAG_NONE };
+    header[ENC_TAG_OFFSET..ENC_TAG_OFFSET + 4].copy_from_slice(&enc_tag.to_le_bytes());
     if let Some(fp) = fingerprint {
         header[HEADER_LEN_V1..HEADER_LEN].copy_from_slice(&fp.to_bytes());
     }
@@ -401,6 +454,11 @@ fn write_graph(b: &Builder, path: &Path, fingerprint: Option<Fingerprint>) -> Re
         }
         w.write_all(&rec).map_err(|e| format!("write {}: {e}", path.display()))?;
     }
+    // [OPUS-4.8] (sq-qamd) Trailing PQ candidate-cache section (encoding tag == 1).
+    if let Some(section) = pq {
+        w.write_all(&section.to_bytes())
+            .map_err(|e| format!("write {}: {e}", path.display()))?;
+    }
     let f = w.into_inner().map_err(|e| format!("flush {}: {e}", path.display()))?;
     f.sync_all().map_err(|e| format!("fsync {}: {e}", path.display()))?;
     Ok(())
@@ -427,6 +485,18 @@ pub struct DiskAnnIndex {
     /// Byte offset where node records begin: [`HEADER_LEN`] (v2) or [`HEADER_LEN_V1`] (legacy v1).
     /// Every record read keys off this so both versions are read correctly by the same code.
     data_offset: usize,
+    /// [OPUS-4.8] (sq-qamd) The in-RAM PQ candidate cache (codebook + per-slot codes), or `None`
+    /// for a plain index (encoding tag `0`). When present, [`search_slots`](Self::search_slots)
+    /// ranks each visited node's neighbours by an ADC table lookup against these codes and re-ranks
+    /// the final beam off the mmap; when `None` it computes every distance from the mmap as before.
+    pq: Option<PqCache>,
+}
+
+/// [OPUS-4.8] (sq-qamd) The decoded PQ candidate cache: the fitted quantizer and the per-slot
+/// codes (slot order == node-record order, so a graph slot indexes the codes directly).
+struct PqCache {
+    pq: ProductQuantizer,
+    codes: EncodedStore,
 }
 
 impl DiskAnnIndex {
@@ -446,7 +516,7 @@ impl DiskAnnIndex {
         path: P,
         cfg: VamanaConfig,
     ) -> Result<DiskAnnIndex, String> {
-        Self::build_inner(store, path, cfg, None)
+        Self::build_inner(store, path, cfg, None, None)
     }
 
     /// [OPUS-4.8] (sq-32i5) Like [`build`](Self::build) but binds the index to `graph` (embeds its
@@ -469,7 +539,30 @@ impl DiskAnnIndex {
         cfg: VamanaConfig,
         graph: &Graph,
     ) -> Result<DiskAnnIndex, String> {
-        Self::build_inner(store, path, cfg, Some(Fingerprint::of(graph)))
+        Self::build_inner(store, path, cfg, Some(Fingerprint::of(graph)), None)
+    }
+
+    /// [OPUS-4.8] (sq-qamd) Builds the Vamana graph **with a PQ candidate cache**: in addition to
+    /// the full-precision node records, it fits a [`ProductQuantizer`] over `store` (with `pq_cfg`),
+    /// encodes every vector into the in-RAM code cache, and persists both alongside the graph (the
+    /// trailing PQ section, encoding tag `1`). The opened index then searches DiskANN-style: rank
+    /// candidates on the RAM codes (no disk), re-rank the final beam off the mmap. Recall is
+    /// approximate (the PQ approximation) but no disk page is touched until the re-rank, so it scales
+    /// to stores whose full-precision vectors exceed RAM.
+    ///
+    /// Errors if `pq_cfg` is invalid for `store`'s dimension (see [`ProductQuantizer::fit`]) or the
+    /// store is empty (PQ needs at least one training vector — use the plain
+    /// [`build_with`](Self::build_with) for an empty store).
+    pub fn build_with_pq<P: AsRef<Path>>(
+        store: &VectorStore,
+        path: P,
+        cfg: VamanaConfig,
+        pq_cfg: PqConfig,
+    ) -> Result<DiskAnnIndex, String> {
+        let pq = ProductQuantizer::fit(store.dim(), store.iter().map(|(_, v)| v), pq_cfg)?;
+        let codes = pq.encode_store(store)?;
+        let section = PqSection { pq, codes };
+        Self::build_inner(store, path, cfg, None, Some(section))
     }
 
     fn build_inner<P: AsRef<Path>>(
@@ -477,6 +570,7 @@ impl DiskAnnIndex {
         path: P,
         cfg: VamanaConfig,
         fingerprint: Option<Fingerprint>,
+        pq: Option<PqSection>,
     ) -> Result<DiskAnnIndex, String> {
         if cfg.build_beam < cfg.degree {
             return Err(format!(
@@ -485,7 +579,7 @@ impl DiskAnnIndex {
             ));
         }
         let b = build_graph(store, &cfg);
-        write_graph(&b, path.as_ref(), fingerprint)?;
+        write_graph(&b, path.as_ref(), fingerprint, pq.as_ref())?;
         let mut idx = Self::open(path)?;
         idx.search_beam = cfg.search_beam;
         Ok(idx)
@@ -545,18 +639,38 @@ impl DiskAnnIndex {
         }
         let record_len = record_len(dim, degree);
         // Checked size arithmetic — reject a malformed header before it wraps past the bounds check.
-        let expect = count
+        // `nodes_end` is the byte just past the last node record; the file is exactly that long for
+        // a plain index, or longer (a trailing PQ section) when the encoding tag is `1`.
+        let nodes_end = count
             .checked_mul(record_len)
             .and_then(|body| body.checked_add(data_offset))
             .ok_or_else(|| {
                 format!("{origin}: dim={dim} degree={degree} count={count} overflows the file size")
             })?;
-        if map.len() != expect {
-            return Err(format!(
-                "{origin}: file is {} bytes, expected {expect} for dim={dim} degree={degree} count={count}",
-                map.len()
-            ));
-        }
+        // [OPUS-4.8] (sq-qamd) Encoding tag at offset 28..32 (reserved bytes of the header).
+        let enc_tag =
+            u32::from_le_bytes(map[ENC_TAG_OFFSET..ENC_TAG_OFFSET + 4].try_into().unwrap());
+        let pq = match enc_tag {
+            ENC_TAG_NONE => {
+                if map.len() != nodes_end {
+                    return Err(format!(
+                        "{origin}: file is {} bytes, expected {nodes_end} for dim={dim} degree={degree} count={count}",
+                        map.len()
+                    ));
+                }
+                None
+            }
+            ENC_TAG_PQ => {
+                if map.len() < nodes_end {
+                    return Err(format!(
+                        "{origin}: file is {} bytes, shorter than the {nodes_end}-byte node body",
+                        map.len()
+                    ));
+                }
+                Some(Self::parse_pq_section(&map[nodes_end..], count, dim, &origin)?)
+            }
+            t => return Err(format!("{origin}: unsupported encoding tag {t}")),
+        };
         if count > 0 && medoid as usize >= count {
             return Err(format!("{origin}: medoid {medoid} out of range (count {count})"));
         }
@@ -570,7 +684,67 @@ impl DiskAnnIndex {
             search_beam: VamanaConfig::default().search_beam,
             fingerprint,
             data_offset,
+            pq,
         })
+    }
+
+    /// [OPUS-4.8] (sq-qamd) Parses the trailing PQ section (`tail` begins right after the last node
+    /// record). Validates the magic, the codebook (which re-checks its own `dim`/`m`/`k`), that the
+    /// codebook's `dim` matches the graph's, and that exactly `count × M` code bytes are present (no
+    /// trailing slop) so a later code read is always in bounds. Errors are descriptive.
+    fn parse_pq_section(
+        tail: &[u8],
+        count: usize,
+        dim: usize,
+        origin: &str,
+    ) -> Result<PqCache, String> {
+        let hdr = 4 + 8; // magic + codebook length
+        if tail.len() < hdr {
+            return Err(format!("{origin}: truncated PQ section header"));
+        }
+        if tail[0..4] != PQ_SECTION_MAGIC {
+            return Err(format!("{origin}: PQ section has bad magic"));
+        }
+        let cb_len: usize = u64::from_le_bytes(tail[4..12].try_into().unwrap())
+            .try_into()
+            .map_err(|_| format!("{origin}: PQ codebook length exceeds the address space"))?;
+        let cb_end = hdr
+            .checked_add(cb_len)
+            .and_then(|e| e.checked_add(4)) // + stride u32
+            .ok_or_else(|| format!("{origin}: PQ section length overflows"))?;
+        if tail.len() < cb_end {
+            return Err(format!("{origin}: truncated PQ codebook"));
+        }
+        let pq = ProductQuantizer::from_bytes(&tail[hdr..hdr + cb_len])
+            .map_err(|e| format!("{origin}: {e}"))?;
+        if pq.dim() != dim {
+            return Err(format!("{origin}: PQ codebook dim {} != graph dim {dim}", pq.dim()));
+        }
+        let stride = u32::from_le_bytes(tail[hdr + cb_len..cb_end].try_into().unwrap()) as usize;
+        if stride != pq.m() {
+            return Err(format!("{origin}: PQ section stride {stride} != codebook M {}", pq.m()));
+        }
+        let want_codes = count
+            .checked_mul(stride)
+            .ok_or_else(|| format!("{origin}: PQ code array length overflows"))?;
+        if tail.len() != cb_end + want_codes {
+            return Err(format!(
+                "{origin}: PQ code array is {} bytes, expected {want_codes} (count {count} × M {stride})",
+                tail.len() - cb_end
+            ));
+        }
+        let codes =
+            EncodedStore::from_parts((0..count as u32).collect(), tail[cb_end..].to_vec(), stride)
+                .map_err(|e| format!("{origin}: {e}"))?;
+        Ok(PqCache { pq, codes })
+    }
+
+    /// [OPUS-4.8] (sq-qamd) Whether this index carries an in-RAM PQ candidate cache (built via
+    /// [`build_with_pq`](Self::build_with_pq) / persisted as the trailing PQ section). When `true`,
+    /// [`nearest`](Self::nearest) ranks candidates on the codes and re-ranks the beam off the mmap;
+    /// when `false` it searches full-precision throughout.
+    pub fn has_pq_cache(&self) -> bool {
+        self.pq.is_some()
     }
 
     /// The index's vector dimension.
@@ -616,9 +790,18 @@ impl DiskAnnIndex {
     /// Greedy beam search of width `beam` from the medoid toward `query` (already normalized),
     /// returning the `k` best `(slot, cosine)` pairs, best first. Each visited node is one
     /// contiguous record read from the map.
+    ///
+    /// [OPUS-4.8] (sq-qamd) When the index carries a PQ candidate cache (built via
+    /// [`build_with_pq`](Self::build_with_pq)) the beam is driven by RAM-only ADC distance
+    /// estimates against the codes ([`search_slots_pq`](Self::search_slots_pq)) and only the final
+    /// beam is re-ranked off the mmap; otherwise every candidate distance is the exact mmap
+    /// distance, as before.
     fn search_slots(&self, query: &[f32], k: usize, beam: usize) -> Vec<(u32, f32)> {
         if self.count == 0 {
             return Vec::new();
+        }
+        if let Some(cache) = &self.pq {
+            return self.search_slots_pq(cache, query, k, beam);
         }
         let beam = beam.max(k).max(1);
         let mut working: Vec<Cand> = Vec::with_capacity(beam + self.degree);
@@ -649,6 +832,61 @@ impl DiskAnnIndex {
         working.truncate(k);
         // d² over unit vectors → cosine: cos = 1 − d²/2.
         working.into_iter().map(|c| (c.slot, 1.0 - c.dist / 2.0)).collect()
+    }
+
+    /// [OPUS-4.8] (sq-qamd) DiskANN's "search on PQ, re-rank on disk" greedy beam search. The
+    /// frontier `working` holds **PQ-estimated** `d²` (an ADC [`DistanceTable`] lookup against the
+    /// in-RAM codes — no disk touched while traversing), so the beam is ranked from RAM. After the
+    /// walk, the surviving beam is **re-ranked against the full-precision mmap vectors** and the top
+    /// `k` of *those* exact distances are returned, so the reported cosine is exact even though the
+    /// path was guided by the lossy codes. `query` is already L2-normalized (the cosine convention).
+    fn search_slots_pq(
+        &self,
+        cache: &PqCache,
+        query: &[f32],
+        k: usize,
+        beam: usize,
+    ) -> Vec<(u32, f32)> {
+        let beam = beam.max(k).max(1);
+        let table = DistanceTable::new(&cache.pq, query);
+        // PQ-estimated d² for a slot's code (slot order == code order).
+        let pq_dist = |slot: u32| table.distance(cache.codes.code(slot as usize));
+        let mut working: Vec<Cand> = Vec::with_capacity(beam + self.degree);
+        let mut in_working = vec![false; self.count];
+        let mut expanded = vec![false; self.count];
+        let start = self.medoid;
+        working.push(Cand { dist: pq_dist(start), slot: start });
+        in_working[start as usize] = true;
+        loop {
+            let next = working.iter().filter(|c| !expanded[c.slot as usize]).min().copied();
+            let Some(cur) = next else { break };
+            expanded[cur.slot as usize] = true;
+            let neighbours: Vec<u32> = self.node_neighbours(cur.slot).collect();
+            for nbr in neighbours {
+                if in_working[nbr as usize] {
+                    continue;
+                }
+                in_working[nbr as usize] = true;
+                working.push(Cand { dist: pq_dist(nbr), slot: nbr });
+            }
+            if working.len() > beam {
+                working.sort_unstable();
+                working.truncate(beam);
+            }
+        }
+        // Re-rank the surviving beam against full-precision mmap vectors (the only disk reads), then
+        // keep the top `k` by EXACT distance — so the returned cosine matches the full-precision
+        // searchers even though the traversal was PQ-guided.
+        working.sort_unstable();
+        working.truncate(beam);
+        let mut reranked: Vec<Cand> = working
+            .into_iter()
+            .map(|c| Cand { dist: sq_dist(query, self.node_vector(c.slot)), slot: c.slot })
+            .collect();
+        reranked.sort_unstable();
+        reranked.truncate(k);
+        // d² over unit vectors → cosine: cos = 1 − d²/2.
+        reranked.into_iter().map(|c| (c.slot, 1.0 - c.dist / 2.0)).collect()
     }
 
     /// [OPUS-4.8] (sq-1wc1) **Filtered** greedy beam search: traverse the Vamana graph

--- a/crates/sparq-vectors/src/quant.rs
+++ b/crates/sparq-vectors/src/quant.rs
@@ -396,6 +396,67 @@ impl ProductQuantizer {
         out
     }
 
+    /// [OPUS-4.8] (sq-qamd) Serializes the codebook to a self-describing little-endian byte block
+    /// — `dim, m, k` (u32 each) then every centroid value as f32 — so it can be persisted alongside
+    /// the on-disk graph and reloaded with [`from_bytes`](Self::from_bytes). The subspace layout is
+    /// recomputed from `dim`/`m` on load (it is a pure function of the two), so only the learned
+    /// centroids are stored. Round-trips exactly (no lossy step).
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let n_centroid_vals: usize = self.centroids.iter().map(Vec::len).sum();
+        let mut out = Vec::with_capacity(12 + n_centroid_vals * 4);
+        out.extend_from_slice(&(self.dim as u32).to_le_bytes());
+        out.extend_from_slice(&(self.m as u32).to_le_bytes());
+        out.extend_from_slice(&(self.k as u32).to_le_bytes());
+        for sub in &self.centroids {
+            for &val in sub {
+                out.extend_from_slice(&val.to_le_bytes());
+            }
+        }
+        out
+    }
+
+    /// [OPUS-4.8] (sq-qamd) Reconstructs a quantizer from [`to_bytes`](Self::to_bytes). Errors on a
+    /// truncated/over-long block or an invalid header (`m == 0`, `m > dim`, `k == 0`, `k > 256`) —
+    /// the same validity envelope [`fit`](Self::fit) enforces, so a decoded quantizer is always sound.
+    pub fn from_bytes(bytes: &[u8]) -> Result<ProductQuantizer, String> {
+        if bytes.len() < 12 {
+            return Err("PQ codebook block truncated (no header)".into());
+        }
+        let rd = |o: usize| u32::from_le_bytes(bytes[o..o + 4].try_into().unwrap()) as usize;
+        let (dim, m, k) = (rd(0), rd(4), rd(8));
+        if dim == 0 {
+            return Err("PQ codebook dim must be > 0".into());
+        }
+        if m == 0 || m > dim {
+            return Err(format!("PQ codebook M must be in 1..={dim} (got {m})"));
+        }
+        if k == 0 || k > 256 {
+            return Err(format!("PQ codebook K must be in 1..=256 (got {k})"));
+        }
+        let sub_offsets = subspace_offsets(dim, m);
+        let mut centroids: Vec<Vec<f32>> = Vec::with_capacity(m);
+        let mut off = 12;
+        for s in 0..m {
+            let sub_len = sub_offsets[s + 1] - sub_offsets[s];
+            let want = k * sub_len;
+            let need = off + want * 4;
+            if bytes.len() < need {
+                return Err("PQ codebook block truncated (centroids)".into());
+            }
+            let mut sub = Vec::with_capacity(want);
+            for c in 0..want {
+                let p = off + c * 4;
+                sub.push(f32::from_le_bytes(bytes[p..p + 4].try_into().unwrap()));
+            }
+            centroids.push(sub);
+            off = need;
+        }
+        if off != bytes.len() {
+            return Err(format!("PQ codebook block has {} trailing bytes", bytes.len() - off));
+        }
+        Ok(ProductQuantizer { dim, m, k, sub_offsets, centroids })
+    }
+
     /// Encodes every vector in `store` into a flat `count × M`-byte code array (slot order,
     /// matching [`VectorStore::iter`]) plus the slot→id mapping. This is the in-RAM candidate
     /// cache for [`DiskAnnIndex`](crate::diskann::DiskAnnIndex). Errors on a dim mismatch.
@@ -594,6 +655,26 @@ pub struct EncodedStore {
 }
 
 impl EncodedStore {
+    /// [OPUS-4.8] (sq-qamd) Builds an [`EncodedStore`] from a slot→id mapping and the flat
+    /// `len × stride` code array (slot order) — the inverse of the `ids`/`codes` an encoder
+    /// produces, used to reload a persisted candidate cache. Errors if `codes.len()` is not
+    /// `ids.len() × stride` (or `stride == 0` with codes present), so a malformed block can't
+    /// produce out-of-bounds [`code`](Self::code) reads.
+    pub fn from_parts(ids: Vec<Id>, codes: Vec<u8>, stride: usize) -> Result<EncodedStore, String> {
+        if stride == 0 && !codes.is_empty() {
+            return Err("EncodedStore stride must be > 0 when codes are present".into());
+        }
+        let expect = ids.len().checked_mul(stride).ok_or("EncodedStore code length overflow")?;
+        if codes.len() != expect {
+            return Err(format!(
+                "EncodedStore codes len {} != ids {} × stride {stride}",
+                codes.len(),
+                ids.len()
+            ));
+        }
+        Ok(EncodedStore { ids, codes, stride })
+    }
+
     /// Number of encoded vectors.
     pub fn len(&self) -> usize {
         self.ids.len()
@@ -612,6 +693,11 @@ impl EncodedStore {
     /// The code bytes for `slot`.
     pub fn code(&self, slot: usize) -> &[u8] {
         &self.codes[slot * self.stride..(slot + 1) * self.stride]
+    }
+    /// [OPUS-4.8] (sq-qamd) The flat `len × stride` code array (slot order) — for persisting the
+    /// candidate cache; pair with [`from_parts`](Self::from_parts) to reload it.
+    pub fn codes(&self) -> &[u8] {
+        &self.codes
     }
     /// Iterates `(slot, id, code)` in slot order.
     pub fn iter(&self) -> impl Iterator<Item = (usize, Id, &[u8])> + '_ {

--- a/crates/sparq-vectors/tests/diskann.rs
+++ b/crates/sparq-vectors/tests/diskann.rs
@@ -7,7 +7,7 @@
 //! 3. **parity with the in-RAM searchers** on tiny separable clusters, and the degenerate
 //!    all-zero-query contract shared with `nearest_exact` / `VectorIndex`.
 
-use sparq_vectors::{nearest_exact, DiskAnnIndex, VamanaConfig, VectorStore};
+use sparq_vectors::{nearest_exact, DiskAnnIndex, PqConfig, VamanaConfig, VectorStore};
 // [OPUS-4.8] (sq-ip3a) HNSW is the approximate backend — `approx-ann` only (the disk-vs-HNSW
 // parity test below is gated to match).
 #[cfg(feature = "approx-ann")]
@@ -207,6 +207,151 @@ fn empty_and_singleton_graphs_roundtrip() {
     for p in [&store_path, &graph_path, &store_path1, &graph_path1] {
         let _ = std::fs::remove_file(p);
     }
+}
+
+// [OPUS-4.8] (sq-qamd) PQ candidate cache wired into the DiskANN search path: build with a PQ
+// section, confirm it persists + reloads, the codes drive the beam (RAM-only ranking) and the
+// final beam is re-ranked off the mmap so the reported cosine is EXACT, and recall stays high.
+
+#[test]
+fn pq_index_persists_and_reloads_the_candidate_cache() {
+    const N: usize = 2_000;
+    const DIM: usize = 32;
+    let store_path = tmp("diskann-pq-rt.spqv");
+    let graph_path = tmp("diskann-pq-rt.spqg");
+    let mut store = VectorStore::create(&store_path, DIM).unwrap();
+    let mut state = 0xA11CE_u64;
+    for i in 0..N {
+        store.put((i as u32) * 5 + 1, &rand_vec(&mut state, DIM)).unwrap();
+    }
+    store.finalize().unwrap();
+
+    let built = DiskAnnIndex::build_with_pq(
+        &store,
+        &graph_path,
+        VamanaConfig::default(),
+        PqConfig::default(),
+    )
+    .unwrap();
+    assert!(built.has_pq_cache(), "build_with_pq must produce a PQ candidate cache");
+    assert_eq!(built.len(), N);
+
+    // Reopen from the file alone — the PQ section must reload (no rebuild).
+    let reopened = DiskAnnIndex::open(&graph_path).unwrap();
+    assert!(reopened.has_pq_cache(), "reopened index must carry the persisted PQ cache");
+    assert_eq!(reopened.len(), N);
+    assert_eq!(reopened.dim(), DIM);
+
+    let _ = std::fs::remove_file(&store_path);
+    let _ = std::fs::remove_file(&graph_path);
+}
+
+#[test]
+fn pq_returned_cosines_are_exact_after_rerank() {
+    // The re-rank reads full-precision vectors off the mmap, so a returned (id, cosine) must equal
+    // the EXACT cosine of that id to the query — the PQ approximation guides the beam but never
+    // leaks into the reported score.
+    const N: usize = 2_000;
+    const DIM: usize = 32;
+    const K: usize = 10;
+    let store_path = tmp("diskann-pq-exact.spqv");
+    let graph_path = tmp("diskann-pq-exact.spqg");
+    let mut store = VectorStore::create(&store_path, DIM).unwrap();
+    let mut state = 0xBEEF_u64;
+    for i in 0..N {
+        store.put((i as u32) + 1, &rand_vec(&mut state, DIM)).unwrap();
+    }
+    store.finalize().unwrap();
+
+    let idx = DiskAnnIndex::build_with_pq(
+        &store,
+        &graph_path,
+        VamanaConfig::default(),
+        PqConfig::default(),
+    )
+    .unwrap();
+
+    let mut q_state = 0xF00D_u64;
+    for _ in 0..30 {
+        let q = rand_vec(&mut q_state, DIM);
+        let approx = idx.nearest(&q, K);
+        // Returned scores must be sorted best-first and equal the exact cosine for each id.
+        let exact_all = nearest_exact(&store, &q, N);
+        for w in approx.windows(2) {
+            assert!(w[0].1 >= w[1].1 - 1e-6, "results not sorted best-first");
+        }
+        for &(id, cos) in &approx {
+            let exact = exact_all
+                .iter()
+                .find(|&&(eid, _)| eid == id)
+                .map(|&(_, c)| c)
+                .expect("returned id must exist in the store");
+            assert!(
+                (cos - exact).abs() < 1e-5,
+                "re-ranked cosine {cos} for id {id} != exact {exact}"
+            );
+        }
+    }
+
+    let _ = std::fs::remove_file(&store_path);
+    let _ = std::fs::remove_file(&graph_path);
+}
+
+#[test]
+fn pq_recall_at_10_stays_high() {
+    // PQ-guided search is approximate, but with the re-rank it should still recover most of the
+    // true top-K. A gentle gate (≥ 0.80) over a moderate set — well clear of chance.
+    const N: usize = 10_000;
+    const DIM: usize = 32;
+    const K: usize = 10;
+    const QUERIES: usize = 100;
+    let store_path = tmp("diskann-pq-recall.spqv");
+    let graph_path = tmp("diskann-pq-recall.spqg");
+    let mut store = VectorStore::create(&store_path, DIM).unwrap();
+    let mut state = 0xC0FFEE_u64;
+    for i in 0..N {
+        store.put((i as u32) * 7 + 3, &rand_vec(&mut state, DIM)).unwrap();
+    }
+    store.finalize().unwrap();
+
+    // A wider beam compensates for the lossy codes; M=16 gives 2 dims/subspace at DIM=32.
+    let cfg = VamanaConfig { search_beam: 200, ..Default::default() };
+    let idx = DiskAnnIndex::build_with_pq(&store, &graph_path, cfg, PqConfig::default()).unwrap();
+    assert!(idx.has_pq_cache());
+
+    let mut q_state = 0xDECAF_u64;
+    let mut hits = 0usize;
+    for _ in 0..QUERIES {
+        let q = rand_vec(&mut q_state, DIM);
+        let exact: Vec<u32> = nearest_exact(&store, &q, K).into_iter().map(|(id, _)| id).collect();
+        let approx: Vec<u32> = idx.nearest(&q, K).into_iter().map(|(id, _)| id).collect();
+        assert_eq!(approx.len(), K);
+        hits += approx.iter().filter(|id| exact.contains(id)).count();
+    }
+    let recall = hits as f64 / (QUERIES * K) as f64;
+    eprintln!("DiskANN+PQ recall@{K} over {QUERIES} queries on {N}x{DIM}: {recall:.4}");
+    assert!(recall >= 0.80, "PQ recall@{K} gate failed: {recall:.4} < 0.80");
+
+    let _ = std::fs::remove_file(&store_path);
+    let _ = std::fs::remove_file(&graph_path);
+}
+
+#[test]
+fn plain_index_has_no_pq_cache() {
+    let store_path = tmp("diskann-nopq.spqv");
+    let graph_path = tmp("diskann-nopq.spqg");
+    let mut store = VectorStore::create(&store_path, 8).unwrap();
+    let mut state = 1_u64;
+    for i in 0..100 {
+        store.put(i + 1, &rand_vec(&mut state, 8)).unwrap();
+    }
+    store.finalize().unwrap();
+    let idx = DiskAnnIndex::build(&store, &graph_path).unwrap();
+    assert!(!idx.has_pq_cache(), "plain build must not carry a PQ cache");
+    let reopened = DiskAnnIndex::open(&graph_path).unwrap();
+    assert!(!reopened.has_pq_cache());
+    let _ = std::fs::remove_file(&store_path);
+    let _ = std::fs::remove_file(&graph_path);
 }
 
 #[test]

--- a/crates/sparq-vectors/tests/quant.rs
+++ b/crates/sparq-vectors/tests/quant.rs
@@ -10,7 +10,8 @@
 //!    EncodedStore slot→id mapping used as the DiskANN candidate cache.
 
 use sparq_vectors::{
-    cosine, nearest_exact, DistanceTable, PqConfig, ProductQuantizer, ScalarQuantizer, VectorStore,
+    cosine, nearest_exact, DistanceTable, EncodedStore, PqConfig, ProductQuantizer,
+    ScalarQuantizer, VectorStore,
 };
 
 fn splitmix64(state: &mut u64) -> u64 {
@@ -329,5 +330,76 @@ fn pq_ties_break_on_ascending_id() {
     let ranked: Vec<u32> = enc.rank_pq(&table, 3).into_iter().map(|(id, _)| id).collect();
     // The three [1,0,0,0] vectors share a code → ascending id order 5,7,10.
     assert_eq!(ranked, vec![5, 7, 10]);
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+// [OPUS-4.8] (sq-qamd) The PQ codebook round-trips through to_bytes/from_bytes byte-for-byte (so it
+// can be persisted alongside a .spqg graph), and a decoded quantizer produces identical codes and
+// ADC distances.
+fn pq_codebook_serialization_round_trips() {
+    let path = tmp("pq-serde.spqv");
+    let mut cstate = 0x5151_u64;
+    let store = clustered_store(&path, 16, 3, 40, 0.1, &mut cstate);
+    let pq = ProductQuantizer::fit(16, store.iter().map(|(_, v)| v), PqConfig::default()).unwrap();
+
+    let bytes = pq.to_bytes();
+    let decoded = ProductQuantizer::from_bytes(&bytes).unwrap();
+    assert_eq!(decoded.dim(), pq.dim());
+    assert_eq!(decoded.m(), pq.m());
+    assert_eq!(decoded.k(), pq.k());
+    // Re-serializing the decoded quantizer yields the identical bytes.
+    assert_eq!(decoded.to_bytes(), bytes);
+
+    // Codes and ADC distances match the original for every stored vector.
+    let mut state = 0x9999_u64;
+    let q = rand_vec(&mut state, 16);
+    let t0 = DistanceTable::new(&pq, &q);
+    let t1 = DistanceTable::new(&decoded, &q);
+    for (_, v) in store.iter() {
+        assert_eq!(pq.encode(v), decoded.encode(v), "decoded codebook encodes differently");
+        let c = pq.encode(v);
+        assert!((t0.distance(&c) - t1.distance(&c)).abs() < 1e-6, "ADC distance differs");
+    }
+
+    // A truncated / over-long / invalid block is rejected.
+    assert!(ProductQuantizer::from_bytes(&bytes[..bytes.len() - 1]).is_err());
+    let mut extra = bytes.clone();
+    extra.push(0);
+    assert!(ProductQuantizer::from_bytes(&extra).is_err());
+    assert!(ProductQuantizer::from_bytes(b"").is_err());
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+// [OPUS-4.8] (sq-qamd) EncodedStore::from_parts reconstructs the candidate cache from its flat
+// ids/codes/stride and validates the code-array length.
+fn encoded_store_from_parts_round_trips_and_validates() {
+    let path = tmp("pq-fromparts.spqv");
+    let mut cstate = 0x2222_u64;
+    let store = clustered_store(&path, 8, 2, 30, 0.1, &mut cstate);
+    let pq = ProductQuantizer::fit(
+        8,
+        store.iter().map(|(_, v)| v),
+        PqConfig { m: 4, k: 16, iters: 10, seed: 3 },
+    )
+    .unwrap();
+    let enc = pq.encode_store(&store).unwrap();
+
+    let ids: Vec<u32> = enc.iter().map(|(_, id, _)| id).collect();
+    let rebuilt = EncodedStore::from_parts(ids, enc.codes().to_vec(), enc.stride()).unwrap();
+    assert_eq!(rebuilt.len(), enc.len());
+    for slot in 0..enc.len() {
+        assert_eq!(rebuilt.code(slot), enc.code(slot));
+        assert_eq!(rebuilt.id(slot), enc.id(slot));
+    }
+
+    // Wrong length is rejected.
+    assert!(EncodedStore::from_parts(vec![1, 2, 3], vec![0u8; 5], 2).is_err());
+    // stride 0 with codes present is rejected; empty is fine.
+    assert!(EncodedStore::from_parts(vec![1], vec![0u8], 0).is_err());
+    assert!(EncodedStore::from_parts(vec![], vec![], 0).is_ok());
+
     let _ = std::fs::remove_file(&path);
 }

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -111,8 +111,10 @@ impl VectorIndex { fn nearest(&self, query: &[f32], k) -> Vec<(Id, f32)>;
 // --- persistent on-disk ANN (src/diskann.rs) ---
 DiskAnnIndex::build(&VectorStore, path) / ::build_with(&store, path, VamanaConfig{degree, build_beam, search_beam, alpha, seed})
 DiskAnnIndex::build_for(&store, path, &Graph) / ::build_with_for(&store, path, cfg, &Graph)  // embeds the graph fingerprint
-DiskAnnIndex::open(path) -> Result<DiskAnnIndex, String>                        // mmap + header check, NO rebuild
+DiskAnnIndex::build_with_pq(&store, path, cfg, PqConfig) -> Result<..>          // [OPUS-4.8] sq-qamd: + a PQ candidate cache (search on codes, re-rank off mmap); persisted as a trailing .spqg section (encoding tag 1)
+DiskAnnIndex::open(path) -> Result<DiskAnnIndex, String>                        // mmap + header check, NO rebuild (reloads any PQ section)
 impl DiskAnnIndex { fn nearest(&self, &[f32], k) -> Vec<(Id, f32)>; fn nearest_term(..) -> Vec<(Term, f32)>; fn len()/dim();
+                    fn has_pq_cache() -> bool;                                  // [OPUS-4.8] sq-qamd: PQ-guided search when true
                     fn fingerprint() -> Option<Fingerprint>; fn check_graph(&store, &Graph) -> Result<(), String>;
                     fn nearest_term_checked(&Term, &Graph, &store, k) -> Result<Vec<(Term, f32)>, String> }
 sibling_graph_path(&Path) -> PathBuf                                            // foo.spqv -> foo.spqg
@@ -150,10 +152,12 @@ nearest_filtered_overfetch_default(&backend, query, &IdMask, k) -> Vec<(Id, f32)
 // --- quantization for large stores (src/quant.rs) ---
 ScalarQuantizer::fit(dim, vectors: impl IntoIterator<Item=&[f32]>) -> Result<ScalarQuantizer, String>   // f32->u8, 4x
 ProductQuantizer::fit(dim, vectors, PqConfig{m, k, iters, seed}) -> Result<ProductQuantizer, String>    // M bytes/vec, 8-32x
+ProductQuantizer::to_bytes() -> Vec<u8> / ::from_bytes(&[u8]) -> Result<ProductQuantizer, String>       // [OPUS-4.8] sq-qamd: persist/reload the codebook (e.g. in a .spqg PQ section)
 impl {Scalar,Product}Quantizer { fn encode(&self, &[f32]) -> Vec<u8>; fn reconstruct(&self, &[u8]) -> Vec<f32>;
                                   fn encode_store(&self, &VectorStore) -> Result<EncodedStore, String> }
 DistanceTable::new(&ProductQuantizer, query: &[f32]);  fn distance(&self, code)->f32; fn cosine(&self, code)->f32  // ADC
 EncodedStore::rank_pq(&self, &DistanceTable, k) -> Vec<(Id, f32)>;  cosine_from_sq_dist(sq: f32) -> f32
+EncodedStore::from_parts(ids, codes, stride) -> Result<EncodedStore, String> / ::codes() -> &[u8]       // [OPUS-4.8] sq-qamd: reload a persisted candidate cache
 
 // --- hybrid fusion (src/fuse.rs) --- lists are (item, f64) best-first; deterministic ties
 fuse_rrf(lists: &[&[(T, f64)]], k: f64 /*RRF_K=60.0*/, top_k) -> Vec<(T, f64)>
@@ -260,8 +264,20 @@ let hits = index.nearest(query, 10);                    // Vec<(Id, cosine)>, re
 ### 4. Quantize a large store, then PQ-filter + full-precision re-rank (the DiskANN loop)
 
 PQ codes are a coarse RAM-resident *filter*, not a final ranking — re-rank the candidates
-against the full-precision store. (This loop is NOT yet wired into `DiskAnnIndex`; drive it
-yourself.)
+against the full-precision store. [OPUS-4.8] sq-qamd: `DiskAnnIndex::build_with_pq` now drives
+this loop INSIDE the index (rank each visited node's neighbours on the in-RAM codes, re-rank the
+final beam off the mmap — `nearest` reports the exact full-precision cosine), and persists the
+codebook + codes as a trailing `.spqg` section so `open` reloads the cache with no rebuild:
+
+```rust
+use sparq_vectors::{DiskAnnIndex, PqConfig, VamanaConfig, VectorStore};
+let store = VectorStore::open("entities.spqv")?;
+let idx = DiskAnnIndex::build_with_pq(&store, "entities.spqg", VamanaConfig::default(), PqConfig::default())?;
+assert!(idx.has_pq_cache());
+let top10 = idx.nearest(query, 10);                    // PQ-guided traversal, exact re-ranked cosine
+```
+
+To drive the same coarse-filter-then-re-rank loop by hand (e.g. over the exact store with no graph):
 
 ```rust
 use sparq_vectors::{cosine, DistanceTable, ProductQuantizer, PqConfig, VectorStore};


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes the honest scope gap noted in `diskann.rs` (and bead **sq-qamd**): the
`ProductQuantizer`/`EncodedStore`/`DistanceTable` layer (sq-nq5) existed as a
standalone, tested encoder but nothing in the search path used it — `search_slots`
still computed every candidate distance from the full-precision mmap.

## What this does

- **`DiskAnnIndex::build_with_pq(store, path, cfg, PqConfig)`** — in addition to the
  full-precision node records, fits a `ProductQuantizer`, encodes every vector into an
  in-RAM code cache, and persists the codebook + per-slot codes as a **trailing `.spqg`
  section** flagged by the previously-reserved encoding tag (offset 28, `1` = PQ cache).
- **PQ-guided search** — when the cache is present, the greedy beam ranks each visited
  node's neighbours by a RAM-only ADC `DistanceTable` lookup against the codes (no disk),
  then **re-ranks the surviving beam against the full-precision mmap vectors**, returning
  the top-`k` by exact distance. This is DiskANN's "search on PQ, re-rank on disk" loop;
  the reported cosine is exact even though the traversal was PQ-guided.
- **Backwards compatible** — the plain `build`/`build_with` path is byte-identical (encoding
  tag `0`, no trailing section) and `search_slots` is unchanged for it. `open` reloads any
  PQ section with no rebuild; legacy/plain files still open.

## API added

- `ProductQuantizer::to_bytes` / `from_bytes` — codebook serde (validated).
- `EncodedStore::from_parts` / `codes` — reload a persisted candidate cache.
- `DiskAnnIndex::build_with_pq`, `has_pq_cache`.

## Tests (both feature states green)

- persist + reopen the cache (no rebuild); plain index carries no cache.
- **returned cosines are exact after re-rank** (vs `nearest_exact`).
- **recall@10 ≥ 0.80** for PQ-guided search on a 10k×32 synthetic set.
- codebook round-trip is byte-identical; truncated/over-long/invalid blocks rejected;
  `from_parts` length validation.

## Gate

`cargo build`, `clippy --all-targets -D warnings`, full crate tests, and the
`RUSTDOCFLAGS=-D warnings cargo doc` gate all pass in **both** feature states
(default + `--all-features`). Privacy-claims gate passes. SKILL.md updated for the
new public API and the now-false "NOT yet wired into `DiskAnnIndex`" note corrected.
No new `unsafe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)