### PR TITLE
docs(sparq-mpc): cross-link deferred malicious-security seams to successor beads (sq-6d6g) [OPUS-4.8]

### DIFF
--- a/crates/sparq-mpc/PLAN.md
+++ b/crates/sparq-mpc/PLAN.md
@@ -227,6 +227,13 @@ not a silent hole (architecture §4.2 guarantee (D), §5.2 Q2; sq-uu0u DESIGN
    / `reconstruct_disclosed` SIGNATURES and all callers stay put (`backend.rs`).
    REJECTED for *this* increment: it needs preprocessing + a fresh soundness
    argument and is a whole backend, not a Shamir-layer change.
+   *Tracked by:* `sq-j5ok` (the dishonest-majority SPDZ/MASCOT/Overdrive backend
+   design record — MASCOT-OT vs Overdrive-AHE triples, what it adds vs Shamir,
+   the `BackendInfo` preprocessing/PQ/trusted-setup fields), `sq-km34` (the IT-MAC
+   on the degree-`2t` equality/mult open at the minimal `n = 2t+1`, promoting
+   `secure_equal` `SemiHonestOnly → Abort`), and `sq-4i39` (the
+   `BackendInfo.requires_preprocessing` offline-cost field). Design record:
+   `research/mpc-malicious-security-design.md`.
 
 2. **Poseidon2 / Schnorr share-commitments for the M4 attestation layer.**
    Binding a *reconstructed* (or shared) value to an issuer-signed commitment
@@ -238,10 +245,20 @@ not a silent hole (architecture §4.2 guarantee (D), §5.2 Q2; sq-uu0u DESIGN
    gated on Q1 + the ZK-foundation remediation), which is a separate milestone.
    REJECTED for this increment: wrong field, would drag a heavy dependency into a
    crate that is intentionally dependency-light and wasm-excluded.
+   *Tracked by:* `sq-bjl` (the M4 collaborative-proof + distributed-attestation
+   SPIKE — the Q1 research risk), `sq-f7bu` (the buildable M4-v1: verifier-side
+   authenticated-input attestation gate, Dutta/Artemis commit-and-prove anchor),
+   and `sq-34ml` (the M4-v1 freshness/replay binding + federated
+   `reconstruct_public_inputs` layout prerequisites). Feasibility record (the
+   EdDSA-Poseidon / Schnorr-Baby-JubJub constraint sizing):
+   `research/mpc-m4-distributed-sig-feasibility.md`.
 
 Neither seam is on the v1 critical path: v1 is honest-majority, and the RS path
-already delivers (D) there. Both are tracked as beads (sq-6d6g) and named at
-their call sites so the deferral is auditable.
+already delivers (D) there. This subsection (bead `sq-6d6g`, the WI-4 doc-only
+deliverable) is the durable record of the boundary; the *implementation* of each
+seam is tracked by its successor beads named above (SPDZ → `sq-j5ok` / `sq-km34`
+/ `sq-4i39`; M4 attestation → `sq-bjl` / `sq-f7bu` / `sq-34ml`) and named at the
+call sites, so the deferral is auditable.
 
 ### M4 — Collaborative proof + distributed attestation  ⚠️ THE HARD PROBLEM (SPIKE)
 The contribution AND the principal research risk (architecture §5.2 Q1, §3.4).


### PR DESCRIPTION
> 🤖 SPARQ agent (jeswr/sparq RDF/SPARQL engine). Filed by the SPARQ agent (not PSS). [OPUS-4.8]

## What & why (bead sq-6d6g — MPC WI-4, doc-only chore)

sq-6d6g is the WI-4 doc-only deliverable of sq-uu0u: *document the deferred malicious-security seams* — the SPDZ IT-MAC dishonest-majority backend (incl. the `n=2t+1` equality gap) and the Poseidon2/Schnorr share-commitments for the M4 attestation layer — in `PLAN.md` plus beads.

**Honest status:** the bulk of this bead was already satisfied. `crates/sparq-mpc/PLAN.md` already carries a full **"Deferred malicious-security seams (sq-uu0u WI-4, bead sq-6d6g)"** subsection documenting *both* seams in detail (fields, where the no-redundancy points are, why each is rejected for the increment), and the successor beads already exist (`sq-j5ok`, `sq-km34`, `sq-4i39`, `sq-bjl`, `sq-f7bu`, `sq-34ml`) plus the two research design records. I did **not** ship a no-op: the one genuine accuracy gap was that the subsection pointed only at the generic doc bead `sq-6d6g`, not at the real **implementation/design successor beads** — so the deferral was not as auditable as the bead intends.

## Change (single markdown file, +19/−2)

Cross-link each seam to its real successor beads + design record:

- **SPDZ-style IT-MAC backend** (dishonest-majority + the no-redundancy points, incl. the degree-`2t` equality open at `n=2t+1`) → `sq-j5ok` (SPDZ/MASCOT/Overdrive backend design record), `sq-km34` (IT-MAC promoting `secure_equal` `SemiHonestOnly→Abort` at minimal N), `sq-4i39` (`BackendInfo.requires_preprocessing`); `research/mpc-malicious-security-design.md`.
- **Poseidon2/Schnorr share-commitments (M4 attestation)** → `sq-bjl` (M4 collaborative-proof + distributed-attestation SPIKE), `sq-f7bu` (M4-v1 verifier-side authenticated-input attestation), `sq-34ml` (M4-v1 freshness/replay + federated `reconstruct_public_inputs` prereqs); `research/mpc-m4-distributed-sig-feasibility.md`.
- Closing paragraph now distinguishes `sq-6d6g` (the doc record) from the implementation successor beads.

All six linked beads were verified to exist with matching titles/scope. No new security claims were introduced — only cross-references and faithful restatements.

## Gate

Doc-only: one markdown file, **no Rust code / public API / unsafe / SKILL.md surface** change. `PLAN.md` is referenced only as plain backtick text in `lib.rs`/`proof.rs` doc-comments and is **not** `include_str!`-ed into rustdoc, so the build / clippy / test / rustdoc gates are unaffected by this content. Privacy-claims gate: no overclaim (no new claim added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)