### PR TITLE
feat(bench-dashboard): surface LUBM regime + result-mode as per-metric badges (sq-19z8) [OPUS-4.8]

### DIFF
--- a/bench/dashboard/dashboard.css
+++ b/bench/dashboard/dashboard.css
@@ -4,6 +4,10 @@
   --bg: #f6f8fa; --card: #ffffff; --fg: #1f2328; --muted: #586069; --line: #d8dee4;
   --accent: #2563eb; --zebra: #fafbfc; --head: #f0f3f6;
   --best-bg: #dcfce7; --best-fg: #166534; --worse-bg: #fee2e2; --worse-fg: #991b1b; --na: #e5e7eb;
+  /* [OPUS-4.8] sq-19z8: per-metric semantic badges (regime + result-mode), muted by design. */
+  --badge-entailed-bg: #ede9fe; --badge-entailed-fg: #5b21b6;
+  --badge-extensional-bg: #e0f2fe; --badge-extensional-fg: #075985;
+  --badge-mode-bg: #eef0f3; --badge-mode-fg: #586069;
   --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
 }
@@ -12,6 +16,10 @@
     --bg: #0d1117; --card: #161b22; --fg: #e6edf3; --muted: #9aa4b2; --line: #30363d;
     --accent: #58a6ff; --zebra: #11161d; --head: #1b222c;
     --best-bg: #0f3d24; --best-fg: #4ade80; --worse-bg: #4a1d1d; --worse-fg: #f87171; --na: #30363d;
+    /* [OPUS-4.8] sq-19z8 dark-mode semantic-badge palette. */
+    --badge-entailed-bg: #2e1065; --badge-entailed-fg: #c4b5fd;
+    --badge-extensional-bg: #0c2a3e; --badge-extensional-fg: #7dd3fc;
+    --badge-mode-bg: #21262d; --badge-mode-fg: #9aa4b2;
   }
 }
 
@@ -74,6 +82,19 @@ table.summary-table { width: 100%; border-collapse: collapse; font-size: 0.92rem
 .pill-best { background: var(--best-bg); color: var(--best-fg); }
 .pill-worse { background: var(--worse-bg); color: var(--worse-fg); }
 .pill-na { background: var(--na); color: var(--muted); }
+
+/* [OPUS-4.8] sq-19z8: per-metric SEMANTIC badges (LUBM regime + result mode), shown next to the
+   metric label. Smaller + lighter-weight than the Δ pill so they READ as metadata, not a verdict;
+   the regime/mode value previously lived only in the cell's title-attr tooltip. */
+.metric-badges { margin-left: 7px; white-space: nowrap; }
+.metric-badge {
+  min-width: 0; padding: 1px 7px; margin-left: 4px; font-size: 0.68rem; font-weight: 600;
+  letter-spacing: 0.01em; vertical-align: middle; cursor: help;
+}
+.metric-badge:first-child { margin-left: 0; }
+.badge-entailed { background: var(--badge-entailed-bg); color: var(--badge-entailed-fg); }
+.badge-extensional { background: var(--badge-extensional-bg); color: var(--badge-extensional-fg); }
+.badge-mode { background: var(--badge-mode-bg); color: var(--badge-mode-fg); }
 
 .chart-group { margin-bottom: 26px; }
 .chart-group h3 {

--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -214,6 +214,45 @@
     return parts.join('\n');
   }
 
+  // [OPUS-4.8] sq-19z8: per-metric SEMANTIC badges derived from the label record (sq-ocuf already
+  // emits `regime` for LUBM — extensional vs entailed OWL-RL closure — and `mode` for the result
+  // shape — count/materialize/json/…). These two fields previously surfaced ONLY in the title-attr
+  // tooltip; this returns small badge descriptors so the renderer can show them as muted pills next
+  // to the metric label, making the reasoning delta + serialization mode visible at a glance.
+  //
+  // Returns an ordered array of { kind, text, title } (empty when the metric has neither field, e.g.
+  // a load/store/dict metric, so most rows stay badge-free). `kind` is a CSS-class suffix:
+  //   - regime -> 'badge-entailed' (LUBM reasoning, OWL-RL closure) or 'badge-extensional' (asserted
+  //     triples only, no entailment). The entailed/extensional split is the reasoning delta.
+  //   - mode   -> 'badge-mode' (count / materialize / json / closure / validate / …), the result
+  //     serialization/consumption mode the latency was measured under.
+  // Pure + node-testable. We DO NOT invent badges for unlabelled metrics (lookup() returns null ->
+  // []), so the structural-fallback path never sprouts a misleading pill.
+  function semanticBadges(name) {
+    var rec = lookup(name);
+    if (!rec) return [];
+    var out = [];
+    if (rec.regime) {
+      var entailed = rec.regime === 'entailed';
+      out.push({
+        kind: entailed ? 'badge-entailed' : 'badge-extensional',
+        text: rec.regime,
+        title: entailed
+          ? 'entailed — measured over the OWL-RL closure (materialised entailments), so this is the reasoning-on path'
+          : 'extensional — measured over the asserted triples only (no entailment / closure)'
+      });
+    }
+    if (rec.mode) {
+      out.push({
+        kind: 'badge-mode',
+        text: rec.mode,
+        title: 'result mode: ' + rec.mode +
+          ' — the serialization/consumption mode this latency was measured under'
+      });
+    }
+    return out;
+  }
+
   // The suite a metric belongs to (drives table sections + chart groups). Falls back to the old
   // structural classifier so an unlabelled metric is grouped, never orphaned.
   function suiteFor(name) {
@@ -685,7 +724,7 @@
                        trendPoints: trendPoints, GROUP_ORDER: GROUP_ORDER,
                        labelFor: labelFor, labelForBare: labelForBare,
                        suiteFor: suiteFor, titleFor: titleFor,
-                       lookup: lookup,
+                       lookup: lookup, semanticBadges: semanticBadges,
                        // sq-xvow (featured well-known suites + competitor seam)
                        FEATURED_SUITES: FEATURED_SUITES, featuredSuiteOf: featuredSuiteOf,
                        buildFeatured: buildFeatured, competitorsFor: competitorsFor,
@@ -718,6 +757,20 @@
     return el('span', { 'class': 'pill pill-worse',
       text: '+' + (Math.round(delta.pct * 10) / 10).toFixed(1) + '%',
       title: 'vs all-time best' });
+  }
+
+  // [OPUS-4.8] sq-19z8: render the per-metric semantic badges (regime + mode) as muted .pill spans,
+  // wrapped in a .metric-badges inline row. Returns null when a metric has no badges (most rows), so
+  // the caller can skip appending. Reuses the .pill base class; the kind-specific class (sq-19z8
+  // CSS) gives each its muted colour.
+  function badges(name) {
+    var bs = semanticBadges(name);
+    if (!bs.length) return null;
+    var wrap = el('span', { 'class': 'metric-badges' });
+    bs.forEach(function (b) {
+      wrap.appendChild(el('span', { 'class': 'pill metric-badge ' + b.kind, text: b.text, title: b.title }));
+    });
+    return wrap;
   }
 
   var PALETTE = ['#2563eb', '#16a34a', '#dc2626', '#9333ea', '#ea580c', '#0891b2', '#ca8a04', '#db2777'];
@@ -843,8 +896,12 @@
       table.appendChild(el('thead', null, [el('tr', null, headCells)]));
       var tbody = el('tbody');
       g.rows.forEach(function (r) {
+        // [OPUS-4.8] sq-19z8: label-line carries any regime/mode semantic badges inline.
+        var labelLine = el('span', { 'class': 'metric-label', text: r.label });
+        var bdg = badges(r.name);
+        if (bdg) labelLine.appendChild(bdg);
         var metricCell = el('td', { 'class': 'metric', title: r.title }, [
-          el('span', { 'class': 'metric-label', text: r.label }),
+          labelLine,
           el('code', { 'class': 'metric-stem', text: r.name })
         ]);
         var cells = [
@@ -1108,8 +1165,12 @@
       ])]));
       var tbody = el('tbody');
       fam.rows.forEach(function (r) {
+        // [OPUS-4.8] sq-19z8: label-line carries any regime/mode semantic badges inline.
+        var labelLine = el('span', { 'class': 'metric-label', text: r.label });
+        var bdg = badges(r.name);
+        if (bdg) labelLine.appendChild(bdg);
         var metricCell = el('td', { 'class': 'metric', title: r.title }, [
-          el('span', { 'class': 'metric-label', text: r.label }),
+          labelLine,
           el('code', { 'class': 'metric-stem', text: r.name })
         ]);
         var tr = el('tr', null, [

--- a/scripts/dashboard-smoke.js
+++ b/scripts/dashboard-smoke.js
@@ -107,6 +107,39 @@ summary.groups.forEach(function (g) {
 ok(sawWatdivRow, 'watdiv row present in summary');
 
 // ============================================================================================
+// [OPUS-4.8] sq-19z8 — per-metric SEMANTIC badges (LUBM regime + result mode).
+// semanticBadges() surfaces the label record's `regime` (extensional vs entailed OWL-RL closure)
+// and `mode` (count/materialize/json/…) fields — which previously lived ONLY in the title tooltip —
+// as small badge descriptors the DOM renders as muted .pill spans next to the metric label.
+// ============================================================================================
+ok(typeof D.semanticBadges === 'function', 'dashboard.js exports semanticBadges');
+
+// LUBM entailed query (regime=entailed, mode=count): two badges, regime FIRST then mode.
+const entBadges = D.semanticBadges('lubm_q04_count_us');
+eq(entBadges.length, 2, 'entailed LUBM query -> two badges (regime + mode)');
+eq(entBadges[0].kind, 'badge-entailed', 'first badge is the entailed-regime kind');
+eq(entBadges[0].text, 'entailed', 'entailed-regime badge text');
+ok(/OWL-RL closure|reasoning/i.test(entBadges[0].title), 'entailed badge title explains the reasoning regime');
+eq(entBadges[1].kind, 'badge-mode', 'second badge is the result-mode kind');
+eq(entBadges[1].text, 'count', 'mode badge text is the result mode');
+
+// LUBM extensional query (regime=extensional): muted extensional kind, distinct from entailed.
+const extBadges = D.semanticBadges('lubm_q01_count_us');
+eq(extBadges[0].kind, 'badge-extensional', 'extensional LUBM query -> extensional-regime badge');
+eq(extBadges[0].text, 'extensional', 'extensional-regime badge text');
+ok(/asserted|no entailment|closure/i.test(extBadges[0].title), 'extensional badge title explains no-closure');
+
+// A metric with a mode but NO regime (e.g. BSBM) -> exactly one mode badge, no regime badge.
+const modeOnly = D.semanticBadges('bsbm_query01_count_us');
+eq(modeOnly.length, 1, 'mode-only metric -> a single (mode) badge');
+eq(modeOnly[0].kind, 'badge-mode', 'mode-only metric badge is the mode kind');
+
+// A metric with NEITHER field (load/store/dict) -> no badges (rows stay clean).
+eq(D.semanticBadges('load_s').length, 0, 'load_s has no semantic badges');
+// An UNLABELLED metric -> no badges (never sprout a misleading pill on the fallback path).
+eq(D.semanticBadges('totally_new_metric_count_us').length, 0, 'unlabelled metric has no semantic badges');
+
+// ============================================================================================
 // [OPUS-4.8] sq-xvow — featured well-known suites at the TOP (+ competitor seam for sq-t0c3).
 // ============================================================================================
 ok(typeof D.featuredSuiteOf === 'function', 'dashboard.js exports featuredSuiteOf');
@@ -555,6 +588,17 @@ ok(!undefThrew, 'buildFamilies(undefined) does not throw either');
   const sparqlSec = famSections.filter(function (s) { return s.attributes.id === 'fam-sparql'; })[0];
   const sparqlTable = sparqlSec && sparqlSec.children.filter(function (c) { return c.tagName === 'table'; })[0];
   ok(sparqlTable, 'DOM: SPARQL family renders a summary table synchronously (first paint)');
+  // [OPUS-4.8] sq-19z8: the LUBM row (lubm_q06_count_us — entailed OWL-RL closure, mode=count)
+  // carries its semantic badges as .metric-badge pills next to the label, not just in the tooltip.
+  const sparqlBadges = sparqlSec ? sparqlSec.querySelectorAll('span.metric-badge') : [];
+  ok(sparqlBadges.length > 0, 'DOM: SPARQL family rows render .metric-badge pills (sq-19z8)');
+  ok(sparqlBadges.some(function (b) { return classList(b).indexOf('badge-entailed') !== -1; }),
+     'DOM: the entailed LUBM row shows a .badge-entailed regime pill');
+  ok(sparqlBadges.some(function (b) { return classList(b).indexOf('badge-mode') !== -1 && b.textContent === 'count'; }),
+     'DOM: the LUBM row shows a .badge-mode "count" result-mode pill');
+  // every semantic badge reuses the .pill base class (sq-19z8 reuses the Δ-pill styling).
+  ok(sparqlBadges.every(function (b) { return classList(b).indexOf('pill') !== -1; }),
+     'DOM: semantic badges reuse the .pill base class');
   // first paint must NOT have built any chart: the trend grid lives inside a <details> and is empty
   // until expanded. Confirm the details/summary disclosure exists with an EMPTY chart-grid.
   const sparqlDetails = sparqlSec && sparqlSec.children.filter(function (c) { return c.tagName === 'details'; })[0];


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-19z8**.

## What

`metric-labels.json` (sq-ocuf) already emits a `regime` field for LUBM (extensional vs entailed OWL-RL closure) and a `mode` field (count/materialize/json/…) on every query metric — but they only surfaced in the metric cell's `title`-attr tooltip. This renders them as small **muted badges** next to the metric label, so the reasoning delta (entailed vs extensional) and the result-mode are visible at a glance.

## How

- **`dashboard.js`** — new pure, node-testable `semanticBadges(name)`: reads the label record (`lookup()`) and returns ordered `{kind,text,title}` descriptors — a regime badge (`badge-entailed` / `badge-extensional`) and a result-mode badge (`badge-mode`). Returns `[]` when the metric has neither field (load/store/dict rows stay clean) or is unlabelled (the structural-fallback path never sprouts a misleading pill). A `badges()` DOM helper renders them as `.pill .metric-badge` spans; wired into the families summary table **and** the featured-suite table metric cells. Exported for the smoke test.
- **`dashboard.css`** — muted entailed / extensional / mode badge palette (light + dark mode), reusing the existing `.pill` base class per the bead.
- **`scripts/dashboard-smoke.js`** — pure-fn assertions (entailed → 2 badges regime+mode; extensional kind; mode-only single badge; neither/unlabelled → `[]`) plus a DOM assertion that the LUBM row renders `.metric-badge` pills reusing `.pill`.

## Gate

Pure JS/CSS change (no Rust crate, no public API, no unsafe, no privacy claims). The dashboard CI gate runs:

- `node --check bench/dashboard/dashboard.js` — passes
- `node scripts/dashboard-smoke.js` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)