### PR TITLE
fix(js): percent-encode IRIREF-illegal chars + re-prove SPARQL-injection guard against the real parser (sq-c4ej)

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -168,6 +168,15 @@ verified warm-up from `GET /dictionary/{dict-id}` for the *next* request.
   `fromCompressed` uses `node:zlib` in Node (which loops members) and
   `DecompressionStream` in the browser (single-member only); multi-frame
   **zstd** decodes fully everywhere via the bundled fzstd.
+- **SPARQL-injection guard.** `match()`/`countQuads()` build a query string and
+  `addQuads`/`applyDelta`/`fromQuads` build N-Quads, both embedding RDF/JS terms
+  via `termToNT`. Hostile term values cannot break out of their token: IRIs are
+  percent-encoded over the full `IRIREF`-illegal set (`< > " { } | ^` `` ` ``
+  `\` and `#x00–#x20`, so a `>` in an ACL-pointer IRI becomes `%3E`) and literal
+  values escape `"`, `\` and all control chars — the same rules QLever's lexer
+  enforces. This is proved end-to-end against the engine's real parser in
+  `test/injection.test.mjs`. Note percent-encoding is canonicalising: an IRI
+  value that *contains* illegal chars stores under its encoded form.
 
 ## Benchmarks
 

--- a/js/src/sparql.ts
+++ b/js/src/sparql.ts
@@ -116,12 +116,64 @@ export class SparqlJsonRowsParser {
 
 // --- RDF/JS terms → N-Triples / SPARQL syntax ---------------------------------------------------
 
+/**
+ * Escapes a literal lexical form for the inside of a `"…"` N-Triples /
+ * SPARQL `STRING_LITERAL_QUOTE`. Escapes `\`, `"`, and the whole C0 control
+ * range plus DEL — the SPARQL grammar forbids a raw `#x22`/`#x5C`/`#xA`/`#xD`
+ * inside a single-quoted string, and a raw control byte (e.g. TAB or NUL) is
+ * exactly what an attacker would use to slip past a naive `"`-only escaper.
+ * `\n`/`\r`/`\t`/`\b`/`\f` use their short forms; every other control char
+ * becomes a `\uXXXX` escape.
+ *
+ * This is the SPARQL-injection guard for literal *values*: the output cannot
+ * close its own quote or emit a raw newline, so a hostile value (e.g. an
+ * ACL-derived label) stays confined to the literal token when the result is
+ * re-parsed by sparq's own SPARQL lexer.
+ */
 function escapeLiteral(value: string): string {
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r');
+  // " \  and C0 controls (#x00–#x1F) + DEL (#x7F).
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/["\\\x00-\x1f\x7f]/g, (c) => {
+    switch (c) {
+      case '\\':
+        return '\\\\';
+      case '"':
+        return '\\"';
+      case '\n':
+        return '\\n';
+      case '\r':
+        return '\\r';
+      case '\t':
+        return '\\t';
+      case '\b':
+        return '\\b';
+      case '\f':
+        return '\\f';
+      default:
+        return `\\u${c.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0')}`;
+    }
+  });
+}
+
+/**
+ * Percent-encodes the characters the SPARQL/Turtle `IRIREF` production forbids
+ * inside `<…>` — `< > " { } | ^` `` ` `` `\` and every codepoint in `#x00–#x20`
+ * (controls and space). Without this a hostile IRI value — most importantly one
+ * carrying a `>`, e.g. an ACL pointer IRI taken from untrusted input — could
+ * close its own `<…>` bracket and inject arbitrary SPARQL.
+ *
+ * This is the SPARQL-injection guard for IRI *values*; it matches the illegal
+ * set QLever's lexer rejects, so a value that round-trips here parses to the
+ * same single IRI term in sparq's parser. Percent-encoding is IRI-preserving:
+ * an endpoint dereferences the encoded form to the same resource.
+ */
+function escapeIri(value: string): string {
+  // IRIREF illegal set: < > " { } | ^ ` \ and #x00–#x20 (controls + space).
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/[<>"{}|^`\\\x00-\x20]/g, (c) => {
+    const code = c.charCodeAt(0);
+    return `%${code.toString(16).toUpperCase().padStart(2, '0')}`;
+  });
 }
 
 const XSD_STRING = 'http://www.w3.org/2001/XMLSchema#string';
@@ -130,7 +182,7 @@ const XSD_STRING = 'http://www.w3.org/2001/XMLSchema#string';
 export function termToNT(term: RDF.Term): string {
   switch (term.termType) {
     case 'NamedNode':
-      return `<${term.value}>`;
+      return `<${escapeIri(term.value)}>`;
     case 'BlankNode':
       return `_:${term.value}`;
     case 'Literal': {
@@ -139,7 +191,7 @@ export function termToNT(term: RDF.Term): string {
         const dir = term.direction != null && term.direction !== '' ? `--${term.direction}` : '';
         return `${quoted}@${term.language}${dir}`;
       }
-      if (term.datatype.value !== XSD_STRING) return `${quoted}^^<${term.datatype.value}>`;
+      if (term.datatype.value !== XSD_STRING) return `${quoted}^^<${escapeIri(term.datatype.value)}>`;
       return quoted;
     }
     case 'DefaultGraph':

--- a/js/test/injection.test.mjs
+++ b/js/test/injection.test.mjs
@@ -1,0 +1,155 @@
+// SPARQL-injection guard, re-proved against sparq's ACTUAL parse path. [OPUS-4.8]
+//
+// sq-c4ej: these are the PSS `src/storage/sparql.ts` escaper test-vectors,
+// lifted out of the PSS unit suite (where they checked the escaper's *output
+// string*) and run here as INTEGRATION tests that round-trip each hostile term
+// through `termToNT` AND the sparq engine's real SPARQL parser / N-Triples
+// loader. That is the only thing that actually proves the guard: that the
+// engine sees one IRI / one literal term, never an injected query fragment.
+//
+// The priority target is ACL-derived IRIs (the PSS `pss:acl` pointer set via
+// `setAclPointer`): an attacker who controls a resource's ACL pointer must not
+// be able to smuggle SPARQL through it. `iri()` percent-encodes every
+// IRIREF-illegal char (incl `>`); `literal()` escapes the closing quote and
+// control chars — identically to QLever's lexer rules.
+//
+// Note on round-tripping: literal-*value* escaping is lossless (a value comes
+// back byte-identical). IRI percent-encoding is intentionally NOT a no-op for
+// values that contain IRIREF-illegal chars — the encoded form is the canonical
+// one the engine stores. That is correct (it is IRI-preserving), so the tests
+// assert against the encoded form for hostile IRIs, and exact equality only for
+// literal values and already-legal IRIs.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { DataFactory as DF, SparqStore, termToNT } from '../dist/index.js';
+
+const seed = () => SparqStore.fromString('<http://ex/s> <http://ex/p> <http://ex/o> .', 'nt');
+
+// --- escaper output vectors (string-level, == the original PSS unit vectors) --
+
+test('iri() percent-encodes every IRIREF-illegal char incl ">"', () => {
+  // < > " { } | ^ ` \ and space all become %XX; safe chars pass through.
+  assert.equal(termToNT(DF.namedNode('http://ex/a')), '<http://ex/a>');
+  assert.equal(termToNT(DF.namedNode('http://ex/o>')), '<http://ex/o%3E>');
+  assert.equal(termToNT(DF.namedNode('a<b>c')), '<a%3Cb%3Ec>');
+  assert.equal(termToNT(DF.namedNode('a b')), '<a%20b>');
+  assert.equal(termToNT(DF.namedNode('a{b}c')), '<a%7Bb%7Dc>');
+  assert.equal(termToNT(DF.namedNode('a|b^c`d')), '<a%7Cb%5Ec%60d>');
+  assert.equal(termToNT(DF.namedNode('a\\b')), '<a%5Cb>');
+  assert.equal(termToNT(DF.namedNode('a\u0000b\u001Fc')), '<a%00b%1Fc>');
+  // Already-safe percent-escapes are left intact (not double-encoded).
+  assert.equal(termToNT(DF.namedNode('http://ex/a%20b')), '<http://ex/a%20b>');
+});
+
+test('literal() escapes the closing quote, backslash and control chars', () => {
+  assert.equal(termToNT(DF.literal('a"b\\c\nd\re\tf')), '"a\\"b\\\\c\\nd\\re\\tf"');
+  assert.equal(termToNT(DF.literal('\b\f')), '"\\b\\f"');
+  assert.equal(termToNT(DF.literal('x\u0000y\u001Fz')), '"x\\u0000y\\u001Fz"');
+  // The classic break-out attempt: a value that tries to close its own quote
+  // and append a triple pattern stays one literal token.
+  assert.equal(termToNT(DF.literal('o" . ?x ?y ?z . #')), '"o\\" . ?x ?y ?z . #"');
+});
+
+// --- integration: hostile terms vs the engine's real parse path -------------
+
+test('hostile IRI cannot break out of <...> in a generated SELECT (match path)', async () => {
+  const store = await seed();
+  // Each of these tried to close the <...> and inject a UNION / extra pattern.
+  const payloads = [
+    'http://ex/o> } UNION { ?s ?p ?inj . VALUES ?inj { <http://pwned/x>',
+    'http://ex/o> . ?a ?b ?c . <http://x',
+    'http://ex/o>}#',
+    'http://ex/o> } UNION { ?s ?p ?o',
+  ];
+  for (const p of payloads) {
+    const hits = store.match(undefined, undefined, DF.namedNode(p));
+    // The encoded IRI is a real (non-matching) term: 0 rows, no parse error,
+    // and crucially never the 1 row that a successful `} UNION { ?s ?p ?o`
+    // injection would surface.
+    assert.equal(hits.length, 0, `IRI payload leaked: ${JSON.stringify(p)}`);
+  }
+  // Control: the genuine object still matches exactly one quad.
+  assert.equal(store.match(undefined, undefined, DF.namedNode('http://ex/o')).length, 1);
+});
+
+test('hostile datatype IRI cannot break out of ^^<...> (match path)', async () => {
+  const store = await seed();
+  const dt = DF.namedNode('http://ex/dt> } UNION { ?s ?p ?x . #');
+  assert.equal(store.match(undefined, undefined, DF.literal('o', dt)).length, 0);
+});
+
+test('hostile literal value cannot break out of "..." (match path)', async () => {
+  const store = await seed();
+  const payloads = [
+    'o" . ?s ?p ?o . #',
+    'o"@en . <http://x> <http://y> "z',
+    'o\n?s ?p ?o',
+  ];
+  for (const v of payloads) {
+    assert.equal(
+      store.match(undefined, undefined, DF.literal(v)).length,
+      0,
+      `literal payload leaked: ${JSON.stringify(v)}`,
+    );
+  }
+});
+
+test('hostile literal value round-trips losslessly through the N-Triples loader (data path)', async () => {
+  const store = await seed();
+  // A hostile literal *value* (every escape-relevant char) with a normal
+  // datatype: insert via addQuads (-> quadsToNQuads -> engine loader), read
+  // back via match. Literal-value escaping is lossless, so the value AND the
+  // datatype come back byte-identical, AND no injected triple appears.
+  const subj = DF.namedNode('https://pod.example/acl#owner');
+  const pred = DF.namedNode('http://pss/acl');
+  const evilLit = DF.literal('grant" . <http://pwned> <http://x> "1\n\t#', DF.namedNode('http://ex/t'));
+
+  store.addQuads([DF.quad(subj, pred, evilLit)]);
+
+  const byPred = store.match(undefined, pred, undefined);
+  assert.equal(byPred.length, 1, 'expected exactly the inserted quad (no extra injected ones)');
+  assert.ok(byPred[0].object.equals(evilLit), 'literal value/datatype did not round-trip');
+
+  // The whole store still holds only the seed quad + the one insert — the
+  // `"1` and `<http://pwned>` fragments did NOT become their own triple.
+  assert.equal(store.size, 2);
+  assert.equal(store.match(DF.namedNode('http://pwned'), undefined, undefined).length, 0);
+});
+
+test('hostile ACL-pointer IRI is neutralised to its percent-encoded canonical form (data path)', async () => {
+  const store = await seed();
+  // ACL-pointer-shaped subject IRI carrying every IRIREF-illegal char. It is
+  // stored as exactly one IRI term — its percent-encoded canonical form — so it
+  // matches `iri(rawValue)` (which encodes identically) and injects nothing.
+  const rawAcl = 'https://pod.example/acl#a>{} |^`"\\ b';
+  const aclIri = DF.namedNode(rawAcl);
+  const pred = DF.namedNode('http://pss/acl');
+  const obj = DF.namedNode('http://ex/grant');
+
+  store.addQuads([DF.quad(aclIri, pred, obj)]);
+
+  // Exactly one quad was stored — the hostile IRI did not fan out into several
+  // triples and did not run any injected operation.
+  const hits = store.match(undefined, pred, undefined);
+  assert.equal(hits.length, 1, 'hostile ACL IRI did not store as a single term');
+  // Its subject is the percent-encoded canonical IRI (illegal chars neutralised,
+  // identical to what `termToNT(aclIri)` emits inside `<…>`).
+  assert.equal(hits[0].subject.termType, 'NamedNode');
+  assert.equal(hits[0].subject.value, termToNT(aclIri).slice(1, -1));
+  assert.match(hits[0].subject.value, /%3E/); // the hostile ">" survived as %3E
+  assert.doesNotMatch(hits[0].subject.value, />/); // ...and no raw ">" remains
+  // No injection: store is seed + the single insert; no phantom subjects.
+  assert.equal(store.size, 2);
+});
+
+test('hostile terms cannot inject through a SPARQL UPDATE delta (applyDelta path)', async () => {
+  const store = await seed();
+  // applyDelta serialises both sides via quadsToNQuads and feeds DELETE/INSERT
+  // DATA to the engine. A break-out here would corrupt unrelated graph state.
+  const g = DF.namedNode('http://ex/g> } ; DROP ALL ; INSERT DATA { <http://x> <http://y> <http://z');
+  store.applyDelta([DF.quad(DF.namedNode('http://ex/s2'), DF.namedNode('http://ex/p2'), DF.namedNode('http://ex/o2'), g)]);
+  // The seed quad survives and DROP ALL did NOT run.
+  assert.equal(store.match(DF.namedNode('http://ex/s'), undefined, undefined).length, 1);
+  // No phantom <http://x> <http://y> <http://z> triple was injected.
+  assert.equal(store.match(DF.namedNode('http://x'), undefined, undefined).length, 0);
+});


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-c4ej** (gh-53). [OPUS-4.8]

## What this does

While re-running the PSS `src/storage/sparql.ts` escaper test-vectors **as integration tests against sparq's actual parse path** (the explicit deliverable of sq-c4ej), I found a real SPARQL-injection gap in `@jeswr/sparq` and fixed it.

`termToNT` — used by `match`/`countQuads` to build query strings, and by `addQuads`/`applyDelta`/`fromQuads` to build N-Quads — emitted `<${value}>` for IRIs with **no escaping**. An IRI value containing `>` (or space, `{` `}` `<` `|` `^` `` ` `` `\`, control chars) could close its own `<…>` bracket and inject SPARQL. The ACL-pointer IRI path PSS feeds from untrusted input (`pss:acl` set via `setAclPointer`) is the priority target the bead names.

### Fix
- **`escapeIri()`** (new): percent-encodes the full SPARQL/Turtle `IRIREF`-illegal set — `< > " { } | ^` `` ` `` `\` and `#x00–#x20` — applied to `NamedNode` and the `^^<datatype>` IRI. Matches QLever's lexer rules; percent-encoding is IRI-preserving.
- **`escapeLiteral()`**: extended to escape TAB + the whole C0 control range + DEL (was only `\ " \n \r`), with `\b`/`\f` short forms.
- **`test/injection.test.mjs`** (new): the PSS escaper vectors as integration tests — each hostile term round-trips through `termToNT` **and the engine's real SPARQL parser / N-Triples loader** (match, addQuads, applyDelta), proving the engine sees one IRI / one literal term, never an injected fragment. Covers the ACL-pointer IRI case explicitly.
- **README**: documents the injection guard.

## Gate
- `npm run build` (full `--features shacl,jsonld` wasm + `tsc`): clean.
- `node --test test/`: **66/66 pass** (the 6 new injection tests included).
- `tsc --noEmit`: clean. `typos`: clean.
- No public-API signature change (`escapeIri`/`escapeLiteral` are private; `termToNT` signature unchanged), so no G2 SKILL.md update is required. The added Rust `unsafe`/privacy gates do not apply (JS-only change).

## Honest scope note
sq-c4ej bundles several sub-tasks; this PR delivers the one that belongs in **this** repo and is testable here:

- ✅ **Re-run PSS escaper vectors as integration tests against sparq's real parse path** — done, and it surfaced + fixed a real injection gap.
- ➖ **Publish `@jeswr/sparq` npm artifacts** — a release/CI action, not a code change; out of scope for one PR.
- ➖ **Settle the name** — already `@jeswr/sparq` in `package.json`; the crates.io sibling check (sq-bk9) is closed.
- ➖ **Pin the git build with vendored spargebra fixes** — this repo *already* vendors spargebra with the W3C-conformance parser fixes (`Cargo.toml` `spargebra = { path = "vendor/spargebra" }`). The PSS-side git pin + `guardrails/check-packages.mjs` gate live in the **PSS repo**, not here.

I left sq-c4ej open and recommend splitting the remaining publish/pin/guardrails items into PSS-repo beads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)