### PR TITLE
feat(sparq-server): classify blocked SERVICE egress as 403, not 500 (sq-iu0c) [OPUS-4.8]

### DIFF
--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -19,6 +19,12 @@ mod service;
 // (threat-model B4 / sq-2v6f). [OPUS-4.8]
 #[cfg(feature = "service")]
 pub use service::with_service_egress_allow;
+// [OPUS-4.8] (sq-iu0c) Stable marker substring in every SERVICE egress-refusal engine
+// error, so a network-exposed host (sparq-server) can classify a blocked SERVICE as a
+// policy refusal (403-style) rather than a server fault (500), mirroring the existing
+// `"query budget exceeded (timeout)"` → 503 pattern.
+#[cfg(feature = "service")]
+pub use service::SERVICE_EGRESS_REFUSED_MARKER;
 // Strict allowlist-only egress policy: only listed hosts reachable (even public ones
 // off the list are refused). The network-exposed server wires this to --service-allow
 // so federation is restricted to operator-configured endpoints. [OPUS-4.8] (sq-4w18)

--- a/crates/sparq-engine/src/service.rs
+++ b/crates/sparq-engine/src/service.rs
@@ -692,6 +692,18 @@ pub(crate) fn parse_srx(text: &str) -> Result<ServiceRelation, String> {
 // ---------------------------------------------------------------------------
 // SSRF egress policy (default-deny private / internal ranges) [OPUS-4.8]
 // ---------------------------------------------------------------------------
+
+/// [OPUS-4.8] (sq-iu0c) Stable marker substring embedded in EVERY engine error string
+/// for a SERVICE egress refusal (a host blocked by the allowlist / default-deny SSRF
+/// policy). It survives the transport-error wrapping in `HttpTransport::fetch`, so a
+/// network-exposed host (e.g. `sparq-server`) can `contains()`-classify the refusal as a
+/// **policy** decision — an honest `403`-style status — rather than a server-fault `500`.
+/// This mirrors the existing `"query budget exceeded (timeout)"` → `503` marker pattern.
+///
+/// The marker is deliberately generic (it names no host) so it is safe to surface; the
+/// host detail still travels in the surrounding (server-log-only) error text.
+pub const SERVICE_EGRESS_REFUSED_MARKER: &str = "SERVICE egress refused";
+
 //
 // The `SERVICE` clause turns an attacker-controlled SPARQL string into an
 // outbound HTTP request from the engine host (threat-model B4 / T-SERVICE-SSRF,
@@ -977,7 +989,7 @@ impl ureq::Resolver for EgressFilterResolver {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
                 format!(
-                    "SERVICE egress refused: host {host:?} is not on the SERVICE allowlist \
+                    "{SERVICE_EGRESS_REFUSED_MARKER}: host {host:?} is not on the SERVICE allowlist \
                      (strict allowlist-only policy; add it via --service-allow / SPARQ_SERVICE_ALLOW \
                      on the server, or with_service_egress_policy in an embedder)"
                 ),
@@ -992,7 +1004,7 @@ impl ureq::Resolver for EgressFilterResolver {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
                 format!(
-                    "SERVICE egress refused: {netloc} resolves only to private/internal addresses \
+                    "{SERVICE_EGRESS_REFUSED_MARKER}: {netloc} resolves only to private/internal addresses \
                      (default-deny SSRF policy; allowlist the host via with_service_egress_allow)"
                 ),
             ));

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -3955,6 +3955,17 @@ fn engine_error_response(e: &str, config: &ServerConfig, apply_max_results: bool
             &format!("result exceeds the server's working-set byte limit ({max} bytes, --max-query-bytes (memory cap)); narrow the query (e.g. project fewer variables, add LIMIT) or raise the limit"),
         );
     }
+    // [OPUS-4.8] (sq-iu0c) A SERVICE to a host the egress allowlist / default-deny SSRF
+    // policy blocked is a POLICY decision, not a server fault — surface it as an honest 403
+    // (Forbidden), distinct from the generic 500 below, so clients and alerting can tell a
+    // refused federation target apart from a real execution failure. The engine marks every
+    // such refusal with `SERVICE_EGRESS_REFUSED_MARKER`, which survives the transport-error
+    // wrapping. Gated on the `service` feature: with it off, no SERVICE clause can run, so
+    // the marker can never appear.
+    #[cfg(feature = "service")]
+    if e.contains(sparq_engine::SERVICE_EGRESS_REFUSED_MARKER) {
+        return forbidden_egress(e);
+    }
     execution_error(e)
 }
 
@@ -5190,6 +5201,20 @@ fn sanitized_error(status: StatusCode, class: &str, safe_msg: &str, detail: &str
     json_error(status, safe_msg)
 }
 
+/// [OPUS-4.8] (sq-iu0c) A SERVICE egress refusal → HTTP 403 (Forbidden). The engine `msg`
+/// names the refused host (an info-leak / SSRF-probe oracle), so it is SANITIZED: the client
+/// gets only a stable, generic policy-refusal class message; the host detail goes to the
+/// server log via [`sanitized_error`], the same posture as [`execution_error`].
+#[cfg(feature = "service")]
+fn forbidden_egress(msg: &str) -> Response {
+    sanitized_error(
+        StatusCode::FORBIDDEN,
+        "service-egress-refused",
+        "SERVICE federation refused: the requested endpoint is not permitted by the server's egress allowlist",
+        msg,
+    )
+}
+
 fn execution_error(msg: &str) -> Response {
     // Engine error strings can embed term text drawn from the loaded graph — withhold them
     // from the client; the operator sees the full message in the server log.
@@ -6028,5 +6053,58 @@ mod durable_degrade_tests {
         let cfg = ServerConfig::default();
         let resp = update_rejection_response("some parse error", &cfg);
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}
+
+/// [OPUS-4.8] (sq-iu0c) The HTTP status CONTRACT for a SERVICE egress refusal: a blocked
+/// SERVICE (host not on the allowlist / default-deny SSRF policy) is an authorization
+/// POLICY decision, not a server fault — it maps to HTTP 403 (Forbidden), NOT the 500 the
+/// generic execution-error path would give. The host-naming engine detail is still
+/// withheld from the client body (sanitized to the server log).
+#[cfg(all(test, feature = "service"))]
+mod egress_refusal_status_tests {
+    use super::{engine_error_response, ServerConfig};
+    use axum::http::StatusCode;
+    use sparq_engine::SERVICE_EGRESS_REFUSED_MARKER;
+
+    #[tokio::test]
+    async fn blocked_service_maps_to_403_and_hides_host_detail() {
+        let cfg = ServerConfig::default();
+        // Mirror the engine's full refusal string, which embeds the marker AND the refused
+        // host — exactly what the engine surfaces through the transport-error wrapping.
+        let engine_err = format!(
+            "SERVICE: request to http://internal.example/ failed: {SERVICE_EGRESS_REFUSED_MARKER}: \
+             host \"internal.example\" is not on the SERVICE allowlist (strict allowlist-only policy)"
+        );
+        let resp = engine_error_response(&engine_err, &cfg, true);
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "a blocked SERVICE is a policy refusal (403), not a server fault (500)",
+        );
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+        // The host (an info-leak / SSRF-probe oracle) must NOT reach the client.
+        assert!(
+            !body.contains("internal.example"),
+            "the refused host must NOT reach the client body: {body:?}",
+        );
+        // The client still learns it was a policy refusal it can act on.
+        assert!(
+            body.to_lowercase().contains("service") && body.to_lowercase().contains("refus"),
+            "the client must get a stable egress-refusal class message: {body:?}",
+        );
+    }
+
+    #[test]
+    fn unrelated_execution_error_still_500() {
+        // A genuine execution error (not an egress refusal) keeps its 500 — the 403 sniff
+        // must not hijack the generic execution-error path.
+        let cfg = ServerConfig::default();
+        let resp = engine_error_response("some evaluation blew up", &cfg, true);
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/crates/sparq-server/src/status_contract.rs
+++ b/crates/sparq-server/src/status_contract.rs
@@ -44,6 +44,7 @@
 //! | `204 No Content` | SPARQL Update / GSP write committed (durable once acked, if `--persist`) | -- | success |
 //! | `400 Bad Request` | malformed query / malformed UPDATE / malformed RDF body / malformed TPF pattern / `GET /sparql` with no `query` / unparsable `?generation` / not-yet-published generation | **permanent** | fix the request; do **not** retry as-is |
 //! | `401 Unauthorized` | a write (or, with `--auth-token-read`, a read) without a valid Bearer token; carries `WWW-Authenticate: Bearer` + `Cache-Control: no-store`; **byte-identical for a missing vs a wrong token** | **permanent** | obtain/correct the token; do **not** retry as-is |
+//! | `403 Forbidden` | (`service` feature) a non-`SILENT` `SERVICE` to a host the egress **allowlist** / default-deny SSRF policy refused (`--service-allow` / `SPARQ_SERVICE_ALLOW`, `sq-4w18`/`sq-iu0c`) -- a **policy** refusal, NOT a server fault | **permanent** | the endpoint is off the server's egress allowlist; do **not** retry -- ask the operator to allowlist it (or use `SERVICE SILENT` to tolerate the refusal) |
 //! | `404 Not Found` | unknown route / GSP `GET` of a named graph that does not exist | **permanent** | -- |
 //! | `405 Method Not Allowed` | method not allowed on the route; carries `Allow` | **permanent** | use a listed method |
 //! | `410 Gone` | (`time-travel` feature) `?generation=N` aged out of the retention window | **permanent** | the snapshot is gone; do not retry that pin |
@@ -63,7 +64,11 @@
 //!     retry once durability recovers is safe and will not double-apply), and a subscription
 //!     **capacity** refusal.
 //! - **Permanent (retrying the identical request cannot help):** everything else --
-//!   `400` / `401` / `404` / `405` / `410` / `413` / `415`.
+//!   `400` / `401` / `403` / `404` / `405` / `410` / `413` / `415`.
+//!   - **`403` is a policy refusal, not a fault.** A blocked `SERVICE` (egress allowlist) is a
+//!     deliberate authorization decision; the same query against the same server config is
+//!     refused every time. Retrying does not help -- the host must be allowlisted (or the
+//!     query must use `SERVICE SILENT`, which swallows the refusal to the empty relation).
 //!   - **`413` is the load-bearing one a `5xx`-only classifier gets wrong.** A result-cap
 //!     `413` is an **honest refusal**, not a truncation and not a transient load signal: the
 //!     same query against the same data crosses the same cap every time. The correct action is

--- a/crates/sparq-server/tests/service_allowlist.rs
+++ b/crates/sparq-server/tests/service_allowlist.rs
@@ -103,17 +103,29 @@ async fn empty_allowlist_refuses_service_before_any_network_call() {
         .send()
         .await
         .unwrap();
-    // A non-SILENT SERVICE that is refused fails the query — the server maps an engine
-    // execution error to a non-2xx (500 here). The egress/allowlist detail names the
-    // refused host, so the server SANITIZES it (see `sanitized_error`/`execution_error`
-    // in http.rs, #241): the body carries only the stable generic class, and the host
-    // detail goes to the server log. The non-2xx status plus the "no socket dialled"
-    // assertion below are the load-bearing proof of the strict pre-DNS refusal.
-    assert!(!resp.status().is_success(), "blocked SERVICE must not 200; got {}", resp.status());
+    // [OPUS-4.8] (sq-iu0c) A non-SILENT SERVICE blocked by the egress allowlist is a POLICY
+    // refusal, not a server fault — the server maps the engine's egress-refusal marker to an
+    // honest 403 (Forbidden), distinct from the 500 a genuine execution error gives. The
+    // egress/allowlist detail names the refused host, so the server SANITIZES it (see
+    // `forbidden_egress`/`sanitized_error` in http.rs): the body carries only the stable
+    // generic policy-refusal class, and the host detail goes to the server log. The 403 plus
+    // the "no socket dialled" assertion below are the load-bearing proof of the strict
+    // pre-DNS refusal.
+    assert_eq!(
+        resp.status(),
+        403,
+        "blocked SERVICE must be a 403 policy refusal, got {}",
+        resp.status(),
+    );
     let body = resp.text().await.unwrap().to_lowercase();
     assert!(
-        body.contains("query execution error"),
-        "expected the sanitized engine-error class in the body, got: {body}"
+        body.contains("service") && body.contains("refus") && body.contains("egress allowlist"),
+        "expected the sanitized egress-refusal class in the body, got: {body}"
+    );
+    // The refused host must NOT leak into the client body (info-leak / SSRF-probe oracle).
+    assert!(
+        !body.contains(&host.to_lowercase()),
+        "the refused host must not reach the client body, got: {body}"
     );
     // The query has already returned; give any in-flight dial a brief window, then assert
     // the live listener accepted NOTHING — i.e. the refusal happened before any socket

--- a/crates/sparq-server/tests/status_contract.rs
+++ b/crates/sparq-server/tests/status_contract.rs
@@ -463,3 +463,46 @@ async fn all_error_bodies_are_sanitized_json() {
         "error body must not echo the caller's input: {body}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-iu0c) PERMANENT-but-distinct class: a blocked SERVICE egress is a 403
+// POLICY refusal, NOT the 500 a server-fault execution error gives. A retry classifier must
+// see a permanent 403 (ask the operator to allowlist the host), never a transient 5xx.
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "service")]
+#[tokio::test]
+async fn blocked_service_egress_is_permanent_403() {
+    // Default config => empty egress allowlist + default-deny SSRF: a non-SILENT SERVICE to a
+    // loopback endpoint is refused before any network call. A short query timeout bounds any
+    // regression that would dial. (127.0.0.1 is a private address, so the default-deny SSRF
+    // branch refuses it even without the strict allowlist-only `serve()` wiring.)
+    let config = ServerConfig {
+        query_timeout: Some(Duration::from_secs(2)),
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(DATA, config).await;
+    let q = "PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:age ?a . \
+             SERVICE <http://127.0.0.1:9/> { ?s ex:name ?name } }";
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", q)])
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    assert_eq!(status, 403, "a blocked SERVICE egress is a 403 policy refusal");
+    assert!(!is_transient(status), "403 must classify as PERMANENT (allowlist the host)");
+    let body = resp.text().await.unwrap();
+    assert_structured_error(&body);
+    // The refused host detail is sanitized out of the body (classify on status, not text).
+    assert!(
+        !body.contains("127.0.0.1"),
+        "the refused host must not reach the client body: {body}"
+    );
+    // The stable generic class names the egress allowlist so a consumer can act.
+    assert!(
+        body.to_lowercase().contains("egress allowlist"),
+        "403 body carries the documented generic egress-refusal sentinel: {body}"
+    );
+}

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -894,8 +894,13 @@ is ignored.
   host must be on the allowlist. The allowlist applies uniformly to queries, ASK,
   CONSTRUCT/DESCRIBE, subscriptions and federated `INSERT … WHERE` updates, and is enforced
   before any socket is opened (DNS-rebinding-safe, on the *resolved* IP). The startup log
-  prints the effective allowlist. Beads `sq-4w18` (this wiring), `sq-2v6f` (the engine SSRF
-  filter). Embedders that drive the engine directly use
+  prints the effective allowlist. A non-`SILENT` `SERVICE` that is refused is an honest
+  **`403 Forbidden`** (`sq-iu0c`) — a *policy* refusal, distinct from the `500` an
+  unclassified execution error gives, so clients and alerting can tell a blocked egress
+  target apart from a real server fault (the refused host is sanitized out of the body and
+  goes only to the server log). `SERVICE SILENT` still swallows the refusal to the empty
+  relation (no `403`). Beads `sq-4w18` (this wiring), `sq-2v6f` (the engine SSRF
+  filter), `sq-iu0c` (the `403` classification). Embedders that drive the engine directly use
   `sparq_engine::with_service_egress_policy(strict, [host], || …)` /
   `with_service_egress_allow([host], || …)`.
 - **Feature flags.** `server` (default-on) pulls axum/tokio/tower — the binary needs it

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -336,7 +336,10 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   cloud-metadata IP) / unique-local / unspecified address is refused (checked on the *resolved* IP,
   so DNS rebinding can't bypass it). To federate to a trusted internal endpoint, allowlist its host
   for the scope: `with_service_egress_allow([host.to_string()], || query(&g, q))`. Public endpoints
-  need no opt-in.
+  need no opt-in. Every egress-refusal error string carries the stable
+  `sparq_engine::SERVICE_EGRESS_REFUSED_MARKER` substring (`sq-iu0c`), so a network-exposed host can
+  `contains()`-classify a blocked `SERVICE` as an authorization-policy refusal (e.g. HTTP `403`)
+  rather than a server fault — `sparq-server` does exactly this.
 - **`SERVICE` bind-join (`VALUES` pushdown)** — when a `SERVICE` sub-query is the right side of a
   join (or `OPTIONAL`) whose join variables are already bound by the left side, sparq pushes a
   *block* of those bindings into the remote query as a `VALUES` clause (the brTPF/FedX "bound join")


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change by an agent operating on @jeswr's behalf.

Implements **sq-iu0c** (`area:sparq-server`, `security`): surface a **403-style refusal distinct from 500** for a blocked SERVICE egress.

## Problem
When a non-`SILENT` `SERVICE` to a host the egress allowlist / default-deny SSRF policy refuses, the engine returns an execution-error string that `http.rs::engine_error_response` mapped to **HTTP 500** — indistinguishable from a genuine server fault, and awkward to alert on. A blocked SERVICE is a *policy* decision, not a server bug.

## Change
- **Engine** (`sparq-engine`): a stable `pub const SERVICE_EGRESS_REFUSED_MARKER` substring is now stamped into *every* egress-refusal error string (both the strict-allowlist and the default-deny-private branches). It survives the `ureq` transport-error wrapping in `HttpTransport::fetch`, exactly like the existing `"query budget exceeded (timeout)"` → 503 marker. Both refusal `format!`s are bound to the const so they cannot drift from the marker.
- **Server** (`sparq-server`): `engine_error_response` matches the marker (gated on the `service` feature — with it off, no SERVICE can run) and routes the refusal through a new `forbidden_egress` helper → **HTTP 403 (Forbidden)**. The host-naming detail is sanitized out of the body (no info-leak / SSRF-probe oracle) and logged server-side, the same posture as `execution_error`. `SERVICE SILENT` is unchanged (still swallows the refusal to the empty relation, no 403).
- **Status contract** (`src/status_contract.rs`): documented the new `403` row (permanent, policy refusal) and the permanent-class note.
- **Tests**: new unit tests (`engine_error_response` 403 + still-500 for an unrelated error), a new `status_contract.rs` integration test (403 / permanent / sanitized body), and updated the existing `service_allowlist.rs` test that asserted the old 500 / `"query execution error"`.
- **Docs**: `skills/http-server/SKILL.md` and `skills/sparql-query/SKILL.md`.

## Gate (all green)
- `cargo build` — `sparq-engine` + `sparq-server`, default and `service` feature states.
- `cargo clippy --all-targets -- -D warnings` — both crates, both feature states.
- `cargo test` — `sparq-server` (default + `service`) and `sparq-engine` (`service`): all pass, 0 failed.
- Rustdoc gate: `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` AND `--all-features` — both clean.
- Privacy-claims gate, G2 public-api→SKILL gate — both pass. No new `unsafe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
