### PR TITLE
feat(js): publish guardrails + git-pin verification for @jeswr/sparq (sq-bkag)

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -38,6 +38,8 @@ jobs:
             target
           key: js-wasm-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
 
+      # wasm-pack BEFORE `npm ci`: the package's `prepare` lifecycle (sq-bkag git-pin
+      # build) runs on `npm ci` and needs wasm-pack on PATH to compile the wasm engine.
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked
 
@@ -50,8 +52,10 @@ jobs:
       - name: Test (node --test)
         run: npm test
 
-      - name: Pack check
-        run: npm pack --dry-run
+      # Publish guardrail + git-pin verification (sq-bkag): `prepare` wired, the
+      # `files` allowlist intact, and the packed tarball actually ships dist/ + wasm/.
+      - name: Package guardrail check
+        run: npm run check:package
 
       - name: Report wasm size
         run: ls -l wasm/sparq_wasm_bg.wasm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,6 +98,11 @@ jobs:
         run: cargo install wasm-pack --locked
       - name: Install npm dependencies
         run: npm ci
+      # Publish guardrail (sq-bkag): refuse to publish a binding that would ship without its
+      # wasm engine, that drops dist/wasm from the `files` allowlist, or that lost the `prepare`
+      # git-pin build hook. Runs BEFORE publish so a broken package fails the job, not the consumer.
+      - name: Package guardrail check
+        run: npm run check:package
       # `prepack` (build:wasm + build:ts + bundle skills) runs automatically on `npm publish`,
       # producing the same tree `npm pack --dry-run` validates in js.yml. We require a modern npm
       # (>=11.5.1 ships with node 22) so --provenance is supported.

--- a/js/README.md
+++ b/js/README.md
@@ -42,6 +42,33 @@ npm run build   # wasm-pack build ../crates/sparq-wasm (--features shacl) + tsc
 npm test        # node --test against the built dist/
 ```
 
+### Pinning a git build (before the npm release)
+
+Until `@jeswr/sparq` is published to npm under its settled name, depend on it by
+**pinning a git build**. The package's `prepare` script compiles the wasm engine
++ TypeScript on install, so a git pin yields a working binding (the registry
+tarball ships those prebuilt). Add to the consumer's `package.json`:
+
+```jsonc
+"dependencies": {
+  // pin an immutable commit; `directory: "js"` is read from this package.json
+  "@jeswr/sparq": "github:jeswr/sparq#<commit-sha>"
+}
+```
+
+A git-pinned install needs the Rust → wasm toolchain on the build machine
+(`rustup target add wasm32-unknown-unknown` + `cargo install wasm-pack`); without
+it `prepare` fails loudly with the install command rather than silently shipping
+an engine-less binding. After install, verify the engine actually landed:
+
+```sh
+node -e "import('@jeswr/sparq').then(m=>m.SparqStore.fromString('<a> <b> <c> .','ntriples')).then(s=>{s.free?.();console.log('ok')})"
+```
+
+Maintainers run the publish guardrail this repo gates on — `npm run
+check:package` — which proves `prepare` is wired, the `files` allowlist is
+intact, and the packed tarball actually ships `dist/` + `wasm/*_bg.wasm`.
+
 The default build (and the published bundle) ships with `--features shacl` so
 `SparqStore.validate` works out of the box. SHACL is not free in the wasm
 binary — it pulls in the SHACL engine + `regex` + the SPARQL query path for

--- a/js/guardrails/check-package.mjs
+++ b/js/guardrails/check-package.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// Publish guardrail + git-pin verification for the `@jeswr/sparq` npm binding.
+// [OPUS-4.8] sq-bkag (follow-up to #623 / sq-c4ej).
+//
+// WHY THIS EXISTS
+// ----------------
+// `@jeswr/sparq` is not yet on npm under its settled name, so the only way a
+// consumer (e.g. PSS) can depend on it today is to PIN A GIT BUILD:
+//
+//     "@jeswr/sparq": "github:jeswr/sparq#<sha>"   # with package.json `directory: "js"`
+//
+// A git-pinned install does NOT ship `dist/` or `wasm/` (both are .gitignored).
+// npm rebuilds them by running the package's `prepare` lifecycle script on
+// install. If `prepare` is missing/broken, or the publish `files` allowlist
+// drops the wasm, the consumer silently gets a binding with no engine — an
+// `import` that throws at runtime, not at install. That is the exact failure
+// mode this guard turns into a hard, pre-publish / pre-pin error.
+//
+// WHAT IT CHECKS (no network, no Rust toolchain required — inspects the tree
+// `npm pack` WOULD ship via `npm pack --dry-run --json`):
+//   1. `prepare` is wired so a git-pinned `npm install` builds the binding.
+//   2. The publish allowlist (`files`) names `dist` and `wasm`.
+//   3. The packed tarball actually contains the JS entrypoint (`main`), the
+//      type entrypoint (`types`), and the wasm artifact (`wasm/*_bg.wasm`).
+//   4. The package self-identifies as `@jeswr/sparq` (settled name guard).
+//
+// USAGE
+//   node guardrails/check-package.mjs           # check the packable tree
+//   npm run check:package                        # same, via package.json
+//
+// As a git-pin verification step a CONSUMER runs (after `npm install` resolves
+// the git pin) to prove the engine landed:
+//   node -e "import('@jeswr/sparq').then(m=>m.SparqStore.fromString('<a> <b> <c> .','ntriples')).then(s=>{s.free?.();console.log('ok')})"
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pkgDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const EXPECTED_NAME = '@jeswr/sparq';
+
+const failures = [];
+const fail = (msg) => failures.push(msg);
+
+const pkg = JSON.parse(readFileSync(resolve(pkgDir, 'package.json'), 'utf8'));
+
+// (4) settled-name guard — a rename must be deliberate, not silent.
+if (pkg.name !== EXPECTED_NAME) {
+  fail(`package name is "${pkg.name}", expected the settled name "${EXPECTED_NAME}"`);
+}
+
+// (1) git-pin install builds the binding: `prepare` runs on `npm install` of a
+//     git dependency. Without it, a git-pinned consumer gets no dist/ or wasm/.
+const scripts = pkg.scripts ?? {};
+if (!scripts.prepare) {
+  fail(
+    'missing `scripts.prepare`: a git-pinned `npm install` will not build dist/ or wasm/ ' +
+      '(both are .gitignored), so consumers pinning a git build get a binding with no engine',
+  );
+} else if (!/build/.test(scripts.prepare)) {
+  fail(`\`scripts.prepare\` ("${scripts.prepare}") does not invoke a build step`);
+}
+
+// (2) publish allowlist names the built outputs.
+const files = pkg.files ?? [];
+for (const required of ['dist', 'wasm']) {
+  if (!files.includes(required)) {
+    fail(`package.json \`files\` allowlist is missing "${required}" — it would be omitted from the published/packed tarball`);
+  }
+}
+
+// (3) the tree `npm pack` would ship actually contains the entrypoints + wasm.
+// `npm pack --dry-run --json` runs `prepack` and reports the resulting file
+// list WITHOUT writing a tarball or touching the network.
+let packed;
+try {
+  const out = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd: pkgDir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+  packed = JSON.parse(out);
+} catch (err) {
+  fail(`\`npm pack --dry-run\` failed (the package is not packable): ${err.message}`);
+}
+
+if (packed) {
+  const entries = (packed[0]?.files ?? []).map((f) => f.path);
+  const has = (pred) => entries.some(pred);
+
+  const main = (pkg.main ?? '').replace(/^\.\//, '');
+  const types = (pkg.types ?? '').replace(/^\.\//, '');
+  if (main && !entries.includes(main)) {
+    fail(`packed tarball is missing the \`main\` entrypoint "${main}"`);
+  }
+  if (types && !entries.includes(types)) {
+    fail(`packed tarball is missing the \`types\` entrypoint "${types}"`);
+  }
+  if (!has((p) => /^wasm\/.*_bg\.wasm$/.test(p))) {
+    fail('packed tarball is missing the wasm artifact (wasm/*_bg.wasm) — the binding would have no engine');
+  }
+  if (!has((p) => /^wasm\/.*\.js$/.test(p))) {
+    fail('packed tarball is missing the wasm JS glue (wasm/*.js)');
+  }
+}
+
+if (failures.length) {
+  console.error(`check-package: ${failures.length} guardrail failure(s) for ${EXPECTED_NAME}:`);
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+
+console.log(`check-package: ${EXPECTED_NAME} is publishable + git-pin-installable (prepare + files + packed dist/wasm verified).`);

--- a/js/guardrails/prepare-build.mjs
+++ b/js/guardrails/prepare-build.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// `prepare` lifecycle for the `@jeswr/sparq` git-pin path. [OPUS-4.8] sq-bkag.
+//
+// npm runs `prepare` (a) when a consumer installs this package from a GIT URL
+// (`github:jeswr/sparq#<sha>` with `directory: "js"`), and (b) on a maintainer's
+// plain `npm install` in a source checkout. It does NOT run when installing the
+// published REGISTRY tarball (that already ships dist/ + wasm/).
+//
+// The git-pin consumer needs dist/ + wasm/ BUILT on install, because both are
+// .gitignored and absent from a git checkout. So here we build — but only when
+// it is both NECESSARY and POSSIBLE, to avoid breaking the maintainer's
+// `npm ci` (which installs wasm-pack AFTER deps, and runs an explicit build):
+//
+//   * Skip when the wasm artifact is already present (already built, or the
+//     maintainer will build explicitly) AND dist/ exists — nothing to do.
+//   * Skip when the Rust source crate is not reachable (e.g. a published tarball
+//     edge case) — there is nothing to build from.
+//   * Skip when wasm-pack is unavailable: emit a LOUD, actionable error telling
+//     the git-pin consumer exactly what to install, and exit non-zero so the
+//     broken-binding state is impossible to miss. (cf. sq-bkag git-pin guard.)
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pkgDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const wasmArtifact = resolve(pkgDir, 'wasm', 'sparq_wasm_bg.wasm');
+const distEntry = resolve(pkgDir, 'dist', 'index.js');
+const sourceCrate = resolve(pkgDir, '..', 'crates', 'sparq-wasm', 'Cargo.toml');
+
+// Already built (or shipping a built tree) — nothing to do.
+if (existsSync(wasmArtifact) && existsSync(distEntry)) {
+  process.exit(0);
+}
+
+// No source crate to build from — not a git/source checkout; leave it be.
+if (!existsSync(sourceCrate)) {
+  process.exit(0);
+}
+
+const hasWasmPack = spawnSync('wasm-pack', ['--version'], { stdio: 'ignore' }).status === 0;
+if (!hasWasmPack) {
+  console.error(
+    [
+      'prepare: @jeswr/sparq is pinned from a git build but cannot build the wasm engine.',
+      'A git-pinned install must compile crates/sparq-wasm to WebAssembly on install, but',
+      '`wasm-pack` was not found on PATH. Install the toolchain, then reinstall:',
+      '',
+      '    rustup target add wasm32-unknown-unknown',
+      '    cargo install wasm-pack --locked',
+      '',
+      'Or depend on the published @jeswr/sparq registry tarball (ships prebuilt dist/ + wasm/).',
+    ].join('\n'),
+  );
+  process.exit(1);
+}
+
+console.log('prepare: building @jeswr/sparq (wasm-pack + tsc) for the git-pin install...');
+execFileSync('npm', ['run', 'build'], { cwd: pkgDir, stdio: 'inherit' });

--- a/js/package.json
+++ b/js/package.json
@@ -40,8 +40,10 @@
     "build": "npm run build:wasm && npm run build:ts",
     "test": "node --test \"test/*.test.mjs\"",
     "bench": "node bench/vs-oxigraph.mjs",
+    "check:package": "node guardrails/check-package.mjs",
     "prepack:skills": "rm -rf skills AGENTS.md && cp -R ../skills skills && cp ../AGENTS.md AGENTS.md",
-    "prepack": "npm run build && npm run prepack:skills"
+    "prepack": "npm run build && npm run prepack:skills",
+    "prepare": "node guardrails/prepare-build.mjs"
   },
   "keywords": [
     "rdf",


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-bkag** (follow-up to #623 / sq-c4ej). [OPUS-4.8]

## What this does

#623 (sq-c4ej) landed the IRIREF percent-encode escaper fix but deferred two sub-tasks. This PR delivers the actionable one: **publish-time guardrails + a git-pin verification step so consumers can pin the binding pre-publish.**

### The gap
`@jeswr/sparq` is not yet on npm under its settled name, so the only way a consumer (e.g. PSS) can depend on it today is to **pin a git build** (`github:jeswr/sparq#<sha>`, `directory: "js"`). But `js/dist` and `js/wasm` are `.gitignored`, and the package had **no `prepare` lifecycle script** — so a git-pinned `npm install` produced a binding with **no wasm engine**: an `import` that throws at runtime, not at install. Nothing gated against that.

### Fix
- **`guardrails/prepare-build.mjs`** + `scripts.prepare` — on a git-pinned (or source) install, compile `crates/sparq-wasm` → wasm + `tsc` so `dist/` + `wasm/` exist. No-ops when already built, or when the source crate is absent (registry-tarball case); fails **loudly** with the exact toolchain install command when `wasm-pack` is missing, instead of silently shipping an engine-less binding.
- **`guardrails/check-package.mjs`** + `scripts.check:package` — publish guardrail asserting (1) `prepare` is wired, (2) the `files` allowlist names `dist`+`wasm`, (3) the packed tarball (`npm pack --dry-run --json`) actually contains the `main`/`types` entrypoints **and** `wasm/*_bg.wasm`, (4) the package self-identifies as `@jeswr/sparq`. No network, no Rust toolchain needed.
- **`js.yml`** — runs `check:package` as the pack-check (wasm-pack is already installed before `npm ci`, which `prepare` needs).
- **`publish.yml`** — runs `check:package` **before** `npm publish`, so a broken package fails the CI job, not the consumer.
- **README** — documents git-pinning + the consumer-side "engine actually landed" verification one-liner.

## Gate
- A clean `npm ci` ran `prepare`, building wasm + dist exactly as a git-pin consumer would.
- `npm run check:package`: **pass**; verified it **FAILS** (exit 1, 4 findings) when `wasm` is dropped from `files` + `prepare` removed — proving it is not a no-op guard.
- `node --test test/`: **66/66 pass**. `tsc --noEmit`: clean. `typos`: clean. Both workflow YAMLs parse.
- JS-only change; **no TS public-API signature change** (so no G2 SKILL.md update), and the Rust unsafe/privacy/rustdoc gates do not apply.

## Honest scope note
The bead's other sub-task — **(a) npm republish under the settled name** — is `needs:user/maintainer` (an npm account action; the `publish.yml` workflow + `NPM_TOKEN` are already wired). It is out of scope for one code PR; sq-bkag/sq-c4ej should stay open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)