### PR TITLE
feat(bench/dashboard): prefer EC2/nightly series in featured block + tier badge (sq-aas7) [OPUS-4.8]

### DIFF
--- a/bench/dashboard/dashboard.css
+++ b/bench/dashboard/dashboard.css
@@ -96,6 +96,15 @@ table.summary-table { width: 100%; border-collapse: collapse; font-size: 0.92rem
 .badge-extensional { background: var(--badge-extensional-bg); color: var(--badge-extensional-fg); }
 .badge-mode { background: var(--badge-mode-bg); color: var(--badge-mode-fg); }
 
+/* [OPUS-4.8] sq-aas7: FEATURED-tier provenance badge. Shows whether the featured numbers came from
+   the EC2/nightly series (preferred when present) or the per-commit gh-runner band. Reuses the
+   .pill base; nightly is the "best/promoted" colour, per-commit a muted neutral. */
+.featured-tier { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; margin-bottom: 14px; }
+.tier-badge { min-width: 0; cursor: help; }
+.tier-nightly { background: var(--best-bg); color: var(--best-fg); }
+.tier-per-commit { background: var(--na); color: var(--muted); }
+.featured-tier-note { font-size: 0.82rem; color: var(--muted); }
+
 .chart-group { margin-bottom: 26px; }
 .chart-group h3 {
   margin: 0 0 12px; font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.05em;

--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -21,6 +21,15 @@
   'use strict';
 
   var SERIES = 'sparq engine';
+  // [OPUS-4.8] sq-aas7 (design sq-i0nm §E): the EC2/nightly heavy-benchmark series. github-action-
+  // benchmark writes it to a SEPARATE data dir (dev/bench-ec2/data.js) under the series NAME below
+  // (see .github/workflows/bench-ec2.yml `name: sparq engine (EC2)`). The per-commit gh-runner
+  // series (SERIES) is the dense history that drives the trend/family/scaling views; the EC2 series
+  // is a quieter, full-scale, higher-fidelity tier. When it is present we PREFER it for the FEATURED
+  // block (the at-a-glance public-suite comparison) because it is env-matched to the same-box
+  // competitor gathers, and we tag the chosen tier so the reader sees the provenance. Graceful: when
+  // the EC2 series is absent (not yet live), everything falls back to the per-commit series.
+  var EC2_SERIES = 'sparq engine (EC2)';
 
   // ---- competitor reference data (sq-i0nm parent) --------------------------
   // [OPUS-4.8] Versioned STATIC competitor data, EMBEDDED so the live GitHub Pages page renders it
@@ -447,7 +456,48 @@
   //   { engines:[{id,label,version,env}], values:{ "<metric stem or name>": { "<engineId>": <µs> } } }
   // We match on the raw metric NAME first, then the stem (name minus _us), so the competitor file
   // can key either way. We never invent numbers — a missing key is simply absent.
-  function buildFeatured(entries, competitors) {
+  // [OPUS-4.8] sq-aas7 (design sq-i0nm §E): choose which series feeds the FEATURED block, PREFERRING
+  // the EC2/nightly tier when it is present + non-empty, else falling back to the per-commit
+  // gh-runner tier. Returns { tier, seriesName, entries, hasEc2 }:
+  //   - tier        — 'nightly' (EC2, env-matched to the same-box competitor gathers) or 'per-commit'
+  //                   (gh-runner CI band — noisier, cross-env vs the gathered competitor numbers).
+  //   - seriesName  — the github-action-benchmark series name actually used.
+  //   - entries     — that series' chronological entries array (>= 1 element when non-empty).
+  //   - hasEc2      — whether an EC2/nightly series with data was available at all (drives the
+  //                   "EC2 absent" graceful note in the renderer).
+  // `data` is the merged BENCHMARK_DATA shape ({ entries: { "<series>": [...] } }). Pure +
+  // node-testable; tolerant of a missing data / entries object (-> per-commit, empty).
+  function pickFeaturedSeries(data) {
+    var allEntries = (data && data.entries) || {};
+    var ec2 = allEntries[EC2_SERIES];
+    var commit = allEntries[SERIES];
+    var hasEc2 = Array.isArray(ec2) && ec2.length > 0;
+    if (hasEc2) {
+      return { tier: 'nightly', seriesName: EC2_SERIES, entries: ec2, hasEc2: true };
+    }
+    return {
+      tier: 'per-commit', seriesName: SERIES,
+      entries: Array.isArray(commit) ? commit : [], hasEc2: false
+    };
+  }
+
+  // [OPUS-4.8] sq-aas7: a display descriptor for a featured tier — { kind, text, title }. `kind` is a
+  // CSS-class suffix (tier-nightly / tier-per-commit). Pure + node-testable; the renderer turns it
+  // into a .pill tier badge in the featured header. The nightly tier is env-matched to the same-box
+  // competitor gathers (ephemeral EC2); the per-commit tier is the noisier gh-runner CI band.
+  function tierDescriptor(tier) {
+    if (tier === 'nightly') {
+      return { kind: 'tier-nightly', text: 'nightly · EC2',
+        title: 'featured numbers are from the weekly EC2/nightly heavy-benchmark series '
+             + '(sparq engine (EC2)) — a quiet, full-scale, env-matched tier, preferred over the '
+             + 'per-commit gh-runner band when present' };
+    }
+    return { kind: 'tier-per-commit', text: 'per-commit · gh-runner',
+      title: 'featured numbers are from the per-commit gh-runner CI series (sparq engine) — the '
+           + 'EC2/nightly series is not present yet, so this noisier CI band is shown' };
+  }
+
+  function buildFeatured(entries, competitors, opts) {
     var latest = entries[entries.length - 1];
     var bySuite = {};
     latest.benches.forEach(function (b) {
@@ -473,8 +523,15 @@
       if (bySuite[f.key]) groups.push({ suite: f.key, title: f.title,
         rows: sortRows(bySuite[f.key].rows), references: referencesForSuite(competitors, f.key) });
     });
+    // [OPUS-4.8] sq-aas7: carry the chosen-tier provenance so renderFeatured can show a tier badge
+    // and an env-match note. `opts` is { tier, seriesName, hasEc2 } from pickFeaturedSeries(); when
+    // omitted (legacy callers / tests passing only entries) it defaults to the per-commit tier so the
+    // existing behaviour is unchanged.
+    var tier = (opts && opts.tier) || 'per-commit';
     return { commit: latest.commit, date: latest.date, groups: groups,
-             competitorEngines: competitorEngines(competitors) };
+             competitorEngines: competitorEngines(competitors),
+             tier: tier, seriesName: (opts && opts.seriesName) || SERIES,
+             hasEc2: !!(opts && opts.hasEc2) };
   }
 
   // SEAM helper (sq-t0c3): read the per-engine competitor numbers for one metric, or {} when the
@@ -729,6 +786,9 @@
                        FEATURED_SUITES: FEATURED_SUITES, featuredSuiteOf: featuredSuiteOf,
                        buildFeatured: buildFeatured, competitorsFor: competitorsFor,
                        competitorEngines: competitorEngines,
+                       // sq-aas7 (nightly-priority featured tier + tier badge)
+                       SERIES: SERIES, EC2_SERIES: EC2_SERIES,
+                       pickFeaturedSeries: pickFeaturedSeries, tierDescriptor: tierDescriptor,
                        // sq-rltn (top-level capability families + summary-first family view)
                        FAMILIES: FAMILIES, familyOf: familyOf, buildFamilies: buildFamilies,
                        // sq-i0nm (embedded versioned competitor data + per-suite references)
@@ -867,6 +927,22 @@
         text: 'No recognised public-suite metrics in the latest commit yet.' }));
       return;
     }
+    // [OPUS-4.8] sq-aas7: TIER BADGE — show which series these featured numbers came from (the
+    // EC2/nightly tier when present, else the per-commit gh-runner band) so the provenance is
+    // visible at a glance. The competitor cells (gathered on ephemeral EC2) are env-matched to the
+    // nightly tier; when we fell back to the per-commit band they are cross-env, so the note says so.
+    var td = tierDescriptor(featured.tier);
+    var tierRow = el('div', { 'class': 'featured-tier' }, [
+      el('span', { 'class': 'pill tier-badge ' + td.kind, text: td.text, title: td.title })
+    ]);
+    tierRow.appendChild(el('span', { 'class': 'featured-tier-note',
+      text: featured.tier === 'nightly'
+        ? 'EC2/nightly heavy-benchmark series (env-matched to the same-box competitor gathers).'
+        : (featured.hasEc2
+            ? 'per-commit gh-runner CI band.'
+            : 'per-commit gh-runner CI band — the EC2/nightly series is not present yet, so '
+              + 'competitor numbers below were gathered on a different (EC2) box.') }));
+    host.appendChild(tierRow);
     var engines = featured.competitorEngines; // [] until sq-t0c3 lands
     featured.groups.forEach(function (g) {
       var section = el('section', { 'class': 'featured-suite' }, [
@@ -1254,7 +1330,13 @@
   // so they can render once competitors.json resolves, without re-blocking the summary first paint.
   function paintFeaturedAndScaling(entries, competitors) {
     if (!entries) return;
-    renderFeatured(buildFeatured(entries, competitors));  // sq-xvow
+    // [OPUS-4.8] sq-aas7: the FEATURED block prefers the EC2/nightly series when present (env-matched
+    // to the competitor gathers); the families/scaling views below keep using the dense per-commit
+    // history (`entries`). pickFeaturedSeries() reads the merged BENCHMARK_DATA so it sees the EC2
+    // series merged in by boot()'s fetch; graceful fall-back to per-commit when EC2 is absent.
+    var picked = pickFeaturedSeries(typeof window !== 'undefined' ? window.BENCHMARK_DATA : null);
+    var featEntries = picked.entries.length ? picked.entries : entries;
+    renderFeatured(buildFeatured(featEntries, competitors, picked));  // sq-xvow + sq-aas7 tier
     renderSameBox(competitors);                           // sq-ays7 (same-box SPARQL comparison)
     renderScaling(buildScalingFamilies(entries));         // sq-viby
   }
@@ -1269,6 +1351,28 @@
   //       PREFERRED source); fall back to the embedded COMPETITORS_DATA if the fetch fails. Then
   //       render the featured-suites + scaling cards. Keeps the embedded copy ONLY as a fallback so
   //       the live Pages page still works if the JSON is not served.
+  // [OPUS-4.8] sq-aas7: fetch + extract the EC2/nightly series from the sibling dev/bench-ec2/data.js.
+  // That file is a github-action-benchmark `data.js` that does `window.BENCHMARK_DATA = {…}`; we run
+  // it in a SHADOWED scope with a throwaway `window` so it cannot clobber the page's real global,
+  // then read the EC2 series out of the captured object. Returns a Promise<entries[]|null>; resolves
+  // null on ANY failure (no EC2 data dir yet, fetch/CORS error, parse/shape error) so the caller
+  // degrades to the per-commit series. The path is RELATIVE to dev/bench/ (where the dashboard is
+  // served), so `../bench-ec2/data.js` reaches the EC2 dir on the published Pages site.
+  function fetchEc2Series() {
+    return window.fetch('../bench-ec2/data.js', { cache: 'no-cache' })
+      .then(function (r) { return r.ok ? r.text() : null; })
+      .then(function (src) {
+        if (!src) return null;
+        var sandbox = { BENCHMARK_DATA: null };
+        // eslint-disable-next-line no-new-func
+        (new Function('window', src))(sandbox);
+        var data = sandbox.BENCHMARK_DATA;
+        var ec2 = data && data.entries && data.entries[EC2_SERIES];
+        return (Array.isArray(ec2) && ec2.length) ? ec2 : null;
+      })
+      .catch(function () { return null; });
+  }
+
   function boot() {
     var entries = paintSummary();                        // (1) instant first paint
 
@@ -1283,6 +1387,23 @@
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (json) { if (json) { window.METRIC_LABELS = json; paintSummary(); } })
       .catch(function () { /* graceful: keep structural labels */ });
+
+    // [OPUS-4.8] sq-aas7 (design sq-i0nm §E): pull the EC2/nightly series so the featured block can
+    // PREFER it. github-action-benchmark writes that series to a SIBLING data dir
+    // (dev/bench-ec2/data.js) whose script REASSIGNS window.BENCHMARK_DATA — so we cannot simply
+    // <script src> it (it would clobber the per-commit series). Instead fetch it as TEXT and run it
+    // with a captured global, then merge ONLY its `sparq engine (EC2)` entry back into the live
+    // BENCHMARK_DATA. GRACEFUL on every failure (404 when EC2 not live, file:// CORS, parse error):
+    // we keep the per-commit series and the featured block falls back to it. The featured repaint in
+    // (3)'s competitor handler runs AFTER this resolves only by luck of ordering, so we ALSO repaint
+    // featured here once the merge lands (idempotent — renderFeatured wipes its host first).
+    fetchEc2Series().then(function (ec2Entries) {
+      if (ec2Entries && ec2Entries.length && window.BENCHMARK_DATA && window.BENCHMARK_DATA.entries) {
+        window.BENCHMARK_DATA.entries[EC2_SERIES] = ec2Entries;
+        // repaint featured with whatever competitor data is currently resolved (embedded or fetched).
+        paintFeaturedAndScaling(entries, window.COMPETITORS || COMPETITORS_DATA);
+      }
+    });
 
     // (3) competitors — fetch competitors.json (single sink), fall back to the embedded mirror.
     window.fetch('competitors.json', { cache: 'no-cache' })

--- a/bench/dashboard/index.html
+++ b/bench/dashboard/index.html
@@ -46,7 +46,9 @@
          commit — from <code>bench/dashboard/competitors.json</code>. A cell shows <code>n/a</code>
          where no competitor number was gathered at this scale (no fabricated numbers); real cited
          numbers at their own scale/machine appear as <em>external reference baselines</em> beneath
-         each suite.</p>
+         each suite. A <strong>tier badge</strong> shows whether these sparq numbers come from the
+         weekly <em>EC2/nightly</em> heavy-benchmark series (preferred when present) or the noisier
+         <em>per-commit</em> gh-runner band.</p>
       <div id="featured">loading…</div>
     </section>
 

--- a/scripts/dashboard-smoke.js
+++ b/scripts/dashboard-smoke.js
@@ -214,6 +214,55 @@ eq(lubmComp && lubmComp.oxigraph, 200, 'competitor matched by canonical stem (na
 ok(watdivComp && watdivComp.oxigraph === undefined, 'unmatched competitor cell stays absent (renders —)');
 
 // ============================================================================================
+// [OPUS-4.8] sq-aas7 — nightly-priority featured tier: pickFeaturedSeries / tierDescriptor and the
+// buildFeatured `tier` carry. The featured block PREFERS the EC2/nightly series when present, falls
+// back to the per-commit gh-runner series otherwise (graceful when EC2 absent).
+// ============================================================================================
+ok(typeof D.pickFeaturedSeries === 'function', 'dashboard.js exports pickFeaturedSeries');
+ok(typeof D.tierDescriptor === 'function', 'dashboard.js exports tierDescriptor');
+eq(D.SERIES, 'sparq engine', 'SERIES constant is the per-commit series name');
+eq(D.EC2_SERIES, 'sparq engine (EC2)', 'EC2_SERIES constant matches bench-ec2.yml');
+
+// EC2 present + non-empty -> nightly tier chosen, with the EC2 entries.
+const ec2Entry = [{ commit: { id: 'ec2', message: 'n', url: '#' }, date: 1,
+  benches: [{ name: 'lubm_q06_count_us', value: 80, unit: 'µs' }] }];
+const commitEntry = [{ commit: { id: 'cc', message: 'c', url: '#' }, date: 2,
+  benches: [{ name: 'lubm_q06_count_us', value: 99, unit: 'µs' }] }];
+const pickedNightly = D.pickFeaturedSeries({ entries: { 'sparq engine': commitEntry, 'sparq engine (EC2)': ec2Entry } });
+eq(pickedNightly.tier, 'nightly', 'pickFeaturedSeries prefers EC2/nightly when present');
+eq(pickedNightly.seriesName, 'sparq engine (EC2)', 'nightly pick reports the EC2 series name');
+ok(pickedNightly.hasEc2 === true, 'nightly pick flags hasEc2');
+eq(pickedNightly.entries, ec2Entry, 'nightly pick returns the EC2 entries');
+
+// EC2 absent -> graceful fall-back to per-commit.
+const pickedCommit = D.pickFeaturedSeries({ entries: { 'sparq engine': commitEntry } });
+eq(pickedCommit.tier, 'per-commit', 'pickFeaturedSeries falls back to per-commit when EC2 absent');
+ok(pickedCommit.hasEc2 === false, 'per-commit pick flags hasEc2 false (EC2 absent -> graceful)');
+eq(pickedCommit.entries, commitEntry, 'per-commit pick returns the per-commit entries');
+// EC2 present but EMPTY -> still per-commit (an empty nightly series must not win).
+const pickedEmptyEc2 = D.pickFeaturedSeries({ entries: { 'sparq engine': commitEntry, 'sparq engine (EC2)': [] } });
+eq(pickedEmptyEc2.tier, 'per-commit', 'an EMPTY EC2 series does not override per-commit');
+// missing data object -> per-commit + empty (no throw).
+let pickThrew = false; let pickedNone = null;
+try { pickedNone = D.pickFeaturedSeries(undefined); } catch (e) { pickThrew = true; }
+ok(!pickThrew, 'pickFeaturedSeries(undefined) does not throw');
+ok(pickedNone && pickedNone.tier === 'per-commit' && pickedNone.entries.length === 0,
+   'pickFeaturedSeries(undefined) -> per-commit, empty entries');
+
+// tierDescriptor: distinct kinds + non-empty text/title.
+const tdN = D.tierDescriptor('nightly'); const tdC = D.tierDescriptor('per-commit');
+eq(tdN.kind, 'tier-nightly', 'tierDescriptor(nightly) kind');
+eq(tdC.kind, 'tier-per-commit', 'tierDescriptor(per-commit) kind');
+ok(tdN.text && tdN.title && tdC.text && tdC.title, 'tier descriptors carry text + title');
+
+// buildFeatured carries the chosen tier through to the view (and defaults to per-commit).
+const featNightly = D.buildFeatured(ec2Entry, null, pickedNightly);
+eq(featNightly.tier, 'nightly', 'buildFeatured carries the nightly tier from opts');
+ok(featNightly.hasEc2 === true, 'buildFeatured carries hasEc2');
+const featDefault = D.buildFeatured(commitEntry, null);
+eq(featDefault.tier, 'per-commit', 'buildFeatured defaults to per-commit when no opts (legacy callers)');
+
+// ============================================================================================
 // [OPUS-4.8] sq-viby — scaling comparison: size/depth axis derived from the metric NAME.
 // ============================================================================================
 ok(typeof D.sizeAxisOf === 'function', 'dashboard.js exports sizeAxisOf');
@@ -613,8 +662,18 @@ ok(!undefThrew, 'buildFamilies(undefined) does not throw either');
   ok(vecSec && vecSec.children.some(function (c) {
     return (c.attributes['class'] || '').indexOf('family-empty') !== -1;
   }), 'DOM: an empty family (Vector/ANN) renders a "not yet reported" placeholder (honest coverage)');
-  // featured host should contain at least one suite section with a table.
-  const featuredSection = hosts.featured.children[0];
+  // [OPUS-4.8] sq-aas7: the featured host opens with a TIER badge row (the shim has no fetch, so the
+  // EC2 series is absent -> the per-commit tier badge), then the suite sections.
+  const tierRow = hosts.featured.children.filter(function (c) {
+    return (c.attributes['class'] || '').indexOf('featured-tier') === 0;
+  })[0];
+  ok(tierRow, 'DOM: featured host renders a tier badge row (sq-aas7)');
+  const tierPill = tierRow && tierRow.querySelectorAll('span.tier-badge')[0];
+  ok(tierPill && classList(tierPill).indexOf('tier-per-commit') !== -1,
+     'DOM: tier badge is per-commit (EC2 series absent in the shim -> graceful fall-back)');
+  ok(tierPill && classList(tierPill).indexOf('pill') !== -1, 'DOM: tier badge reuses the .pill base class');
+  // featured host should contain at least one suite section with a table (after the tier row).
+  const featuredSection = hosts.featured.children.filter(function (c) { return c.tagName === 'section'; })[0];
   ok(featuredSection && featuredSection.tagName === 'section', 'DOM: featured host holds suite sections');
   // #1 — the featured table's first column header is "Metric" (not "Query"): the cell may hold
   // non-query metrics. Walk section -> table -> thead -> tr -> first th.


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-aas7** (dashboard nightly-priority display). [OPUS-4.8]

## What

The benchmark dashboard now treats the weekly **EC2/nightly** heavy-benchmark series as a first-class, *preferred* source for the at-a-glance **featured public-suite** block — while keeping the dense per-commit gh-runner history for the trend / family / scaling views.

Per design **sq-i0nm §E**: *"Load both per-commit + EC2 series, tag tier, prefer nightly in featured + env-match competitors; graceful when EC2 absent."*

## How

- **Two series.** github-action-benchmark writes the per-commit series `"sparq engine"` to `dev/bench/data.js` (loaded by `index.html`) and the EC2 series `"sparq engine (EC2)"` to the sibling `dev/bench-ec2/data.js` (`bench-ec2.yml`). `boot()` now fetches `../bench-ec2/data.js` as **text** and extracts its series in a *shadowed* `window` scope (via `new Function`) so the EC2 `data.js`'s `window.BENCHMARK_DATA = …` assignment cannot clobber the page global, then merges the EC2 entry into the live `BENCHMARK_DATA.entries` and repaints the featured block.
- **Tier selection (pure).** `pickFeaturedSeries(data)` prefers the EC2/nightly series when present + non-empty, else falls back to per-commit. `tierDescriptor(tier)` yields the badge descriptor. `buildFeatured(entries, competitors, opts)` carries the chosen tier into the view (defaults to per-commit, so legacy callers are unchanged).
- **Tier badge.** `renderFeatured` shows a `.pill .tier-badge` (nightly · EC2 / per-commit · gh-runner) plus an env-match note — nightly is env-matched to the ephemeral-EC2 same-box competitor gathers; the per-commit fallback says so honestly.
- **Graceful.** A 404 (EC2 not live yet), `file://` CORS, parse error, or an *empty* EC2 series all degrade to the per-commit tier with no throw.

## Honesty

- No competitor numbers are moved/fabricated. The competitor cells stay exactly as gathered (ephemeral EC2); the tier note only states whether the displayed sparq numbers are env-matched to them.
- No Rust code, no `unsafe`, no public Rust API change → no SKILL.md/SBOM/Miri impact. No hard-coded perf numbers.

## Gate

- `node --check bench/dashboard/dashboard.js` — clean (the CI dashboard syntax gate).
- `node scripts/dashboard-smoke.js` — **203 ok / 0 FAIL**, including new pure-fn tests (`pickFeaturedSeries` nightly/per-commit/empty-EC2/undefined; `tierDescriptor`; `buildFeatured` tier carry) and DOM assertions (tier badge renders, reuses `.pill`, per-commit fall-back in the no-fetch shim).
- `scripts/check-privacy-claims.sh` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
