### PR TITLE
docs(mpc): drop stale 'matrix still says degree_reduce in-flight #119' cross-ref (sq-aycz)

### DIFF
--- a/research/mpc-bounded-property-path-design.md
+++ b/research/mpc-bounded-property-path-design.md
@@ -21,11 +21,11 @@ the **only tractable family of property paths under MPC over a secret graph**.
 - [`mpc-sparql-capability-matrix.md`](./mpc-sparql-capability-matrix.md) — adopts its
   capability-tier vocabulary (BUILT / KNOWN / OPEN / IMPOSSIBLE), its primitive-class ladder
   (P0–P7), and its two-regime split (DISCLOSED / HIDDEN). This record **resolves its single
-  property-path cell** (matrix §2 row "Property paths", §4.3) into a full operator design. One
-  correction to that record: it still says `degree_reduce` is *"in-flight in PR #119, not yet
-  merged"* (matrix §1.2); **PR #119 has since merged**, so the P4 keystone this operator depends
-  on is now BUILT on `main` ([`shamir.rs:406`](../crates/sparq-mpc/src/shamir.rs)). That is what
-  makes this bead actionable now rather than blocked.
+  property-path cell** (matrix §2 row "Property paths", §4.3) into a full operator design. The P4
+  keystone this operator depends on — `degree_reduce` (BGW reshare-and-recombine, PR #119,
+  `sq-dvuc`) — is **BUILT on `main`** ([`degree_reduce`](../crates/sparq-mpc/src/shamir.rs)); the
+  matrix §1.2 reflects that (its earlier "in-flight in PR #119, not yet merged" draft note was
+  reconciled in `sq-k4of`). That is what makes this bead actionable now rather than blocked.
 - [`mpc-security-models-and-benchmarks.md`](./mpc-security-models-and-benchmarks.md) — the
   3-axis security taxonomy, the seven-channel leakage taxonomy, the honest-envelope framing. §4
   here uses its vocabulary verbatim.


### PR DESCRIPTION
> 🤖 SPARQ agent — automated docs change for bead **sq-aycz**.

## What

bead **sq-aycz** asked: the capability matrix said `degree_reduce` was *"in-flight in PR #119, not yet merged"* but #119 has merged — refresh that line, then re-scan for other now-stale in-flight refs.

**Finding (honest scope):** the capability matrix itself (`research/mpc-sparql-capability-matrix.md` §1.2) was **already reconciled** in `sq-k4of` (#286): it now states "PR #119 has merged / `sq-dvuc` CLOSED" and only quotes the old draft to correct it. So the matrix line the bead literally names is already fixed — shipping a change there would be a no-op.

The re-scan surfaced **one genuinely stale in-flight cross-reference**, which this PR fixes:

- `research/mpc-bounded-property-path-design.md` (Relationship section) asserted the matrix **"still says** `degree_reduce` is in-flight in PR #119, not yet merged"*. That is no longer true — the matrix was reconciled. Reworded to state the P4 keystone is **BUILT on `main`** and that the matrix already reflects it. Also dropped the drifted `shamir.rs:406` line-pin (`degree_reduce` is now at `shamir.rs:474`) in favour of an anchorless symbol link, so it does not re-rot.

No other doc carries a stale *merge-status* in-flight claim (the matrix, this record, the skills and the crate README all correctly state #119 merged / `sq-dvuc` CLOSED). Broader file:line drift across the MPC design records is real but is a separate, larger concern out of scope for this bead.

## Gate (doc-only, no Rust compiled)

- `markdownlint-cli2@0.18.1` (HARD `research/` scope, `sq-rqyo`) — **0 errors**
- `scripts/check-privacy-claims.sh` — **OK**, no unqualified ZK/MPC claim (the edit keeps the semi-honest scope; "BUILT" is a build-status claim, not a security claim)
- relative link target `crates/sparq-mpc/src/shamir.rs` exists; link is anchorless
- no public API touched → no G2 / SKILL.md impact; no `unsafe` added

[OPUS-4.8]

🤖 Generated with [Claude Code](https://claude.com/claude-code)