### PR TITLE
feat(sparq-solid): precise variable-GRAPH write check under USING/WITH (sq-cnor) [OPUS-4.8]

### DIFF
--- a/crates/sparq-solid/src/update.rs
+++ b/crates/sparq-solid/src/update.rs
@@ -270,13 +270,22 @@ fn analyze(upd: &Update) -> WriteReqs {
 /// - `None` (the parser's encoding of `WITH`, which re-scopes only the default graph):
 ///   `build_using` keeps ALL the store's named graphs, but a query's empty `FROM NAMED`
 ///   keeps NONE. We therefore materialize `named` as an explicit `FROM NAMED` of every
-///   store named graph (excluding the reserved auth view, which the apply never exposes to
-///   the WHERE either) so the query keeps the same set.
+///   store named graph — **including the reserved [`AUTH_GRAPH`](crate::AUTH_GRAPH) view**.
+///   This is load-bearing for soundness ([OPUS-4.8] sq-cnor): `build_using(named: None)`
+///   keeps the auth view in the active dataset, so `GRAPH ?g` CAN bind to it and the engine
+///   CAN record a Delta to it. If we excluded the auth view here the precise resolved set
+///   would *under-count* the engine write set — a binding to the auth view would escape the
+///   per-graph check and let a `WITH … DELETE/INSERT { GRAPH ?g … }` transiently mutate the
+///   authorization view. Including it means a binding to the auth view appears in the precise
+///   set, and since no session is ever granted write/append on the auth view itself,
+///   [`allowed`] denies — fail-closed. (Contrast [`store_named_graphs`], used by the
+///   conservative *wildcard* path, which deliberately excludes the auth view.)
 fn rescope_dataset(graph: &sparq_core::Graph, u: &QueryDataset) -> QueryDataset {
     let named = match &u.named {
         Some(list) => list.clone(),
-        // WITH: make the implicit "all store named graphs" explicit for the query side.
-        None => store_named_graphs(graph),
+        // WITH: make the implicit "all store named graphs" explicit for the query side —
+        // the SAME set `build_using(named: None)` keeps, auth view included.
+        None => engine_using_named_graphs(graph),
     };
     QueryDataset { default: u.default.clone(), named: Some(named) }
 }
@@ -321,6 +330,14 @@ fn rescope_dataset(graph: &sparq_core::Graph, u: &QueryDataset) -> QueryDataset 
 /// write-check path — `check` calls the full-store `query`, not `query_view`). The
 /// enumerated bindings therefore equal the engine's, so the resolution stays precise even
 /// under `USING`/`WITH`.
+///
+/// The `WITH` named set explicitly INCLUDES the reserved [`AUTH_GRAPH`](crate::AUTH_GRAPH)
+/// view, because `build_using(named: None)` does: `GRAPH ?g` can therefore bind to the auth
+/// view and the engine can record a write to it. That binding shows up in the precise set
+/// here, and since no session is granted write/append on the auth view, [`allowed`] denies —
+/// fail-closed. (Were the auth view dropped from the materialized set the precise resolution
+/// would under-count the engine write set and a `WITH … { GRAPH ?g … }` could transiently
+/// mutate the authorization view; that hole is closed by [`engine_using_named_graphs`].)
 ///
 /// Fail-closed cases that still fall back to the wildcard (rather than risk a hole):
 ///
@@ -394,13 +411,39 @@ fn allowed(auth: &AuthIndex, s: &Session, g: &NamedNode, need: Need) -> bool {
     }
 }
 
-/// Every named graph currently in the store except the reserved auth view.
+/// Every named graph currently in the store except the reserved auth view. Used by the
+/// conservative *wildcard* check (CLEAR/DROP ALL|NAMED, or a var-graph op that bailed): the
+/// actor must hold write on every *user* graph, and the auth view is never user-writable, so
+/// excluding it here is correct — the auth view is protected by re-materialization, not by a
+/// write grant.
 fn store_named_graphs(graph: &sparq_core::Graph) -> Vec<NamedNode> {
     graph
         .named
         .iter()
         .filter_map(|(n, _)| match n {
             Term::NamedNode(nn) if nn.as_str() != crate::AUTH_GRAPH => Some(nn.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Every named-node graph the engine's `Dataset::build_using(named: None)` keeps in the
+/// active dataset for a `WITH` re-scope — i.e. EVERY store named graph, **including the
+/// reserved [`AUTH_GRAPH`](crate::AUTH_GRAPH) view** (and any future reserved view). This is
+/// the set [`rescope_dataset`] must hand the binding SELECT so the precise resolved
+/// var-graph set EQUALS the engine write set under `WITH`; see that function for why the auth
+/// view must be present (fail-closed deny, not a silent under-count). [OPUS-4.8] sq-cnor.
+///
+/// (Blank-node graph names cannot be expressed in a `FROM NAMED` clause and contribute no
+/// binding the actor could ever be authorized for, so they are excluded here exactly as the
+/// query-side dataset builder excludes them; a var-graph slot that binds to a blank-node
+/// graph is independently caught fail-closed by [`resolve_var_graphs`].)
+fn engine_using_named_graphs(graph: &sparq_core::Graph) -> Vec<NamedNode> {
+    graph
+        .named
+        .iter()
+        .filter_map(|(n, _)| match n {
+            Term::NamedNode(nn) => Some(nn.clone()),
             _ => None,
         })
         .collect()
@@ -536,15 +579,28 @@ mod differential_writeset_tests {
     /// `r1` ALSO holds the optional `aclPointer` triple that PSS's `setAclPointer` keys its
     /// OPTIONAL off. A third graph `r3` holds an unrelated triple (no title) so a title-keyed
     /// WHERE never binds it — present to prove the resolver does not over-count the store.
+    ///
+    /// CRITICAL ([OPUS-4.8] sq-cnor): the fixture ALSO seeds a `title` triple in the reserved
+    /// [`crate::AUTH_GRAPH`] view. `Dataset::build_using(named: None)` (the `WITH` re-scope)
+    /// keeps the auth view, so a title-keyed `GRAPH ?g` WHERE makes `?g` bind to it and the
+    /// engine records a write there. The guard tests therefore expect the engine write set to
+    /// INCLUDE the auth view, and the WITH guard catches the original under-count: the prior
+    /// `rescope_dataset` dropped the auth view from the materialized `FROM NAMED` set, so the
+    /// precise resolved set MISSED it while the engine wrote it — `precise != written`. With
+    /// the auth view restored to the materialized set the two are equal again (and the
+    /// production `check` path then DENIES, since no session is write-granted on the auth view).
     fn pss_dataset() -> Graph {
         let nq = "\
 <https://pod.ex/r1#it> <https://ex.dev/ns#title> \"r1\" <https://pod.ex/r1> .
 <https://pod.ex/r1#it> <https://ex.dev/ns#aclPointer> <https://pod.ex/r1.acl> <https://pod.ex/r1> .
 <https://pod.ex/r2#it> <https://ex.dev/ns#title> \"r2\" <https://pod.ex/r2> .
 <https://pod.ex/r3#it> <https://ex.dev/ns#other> \"r3\" <https://pod.ex/r3> .
+<https://sparq.dev/auth#it> <https://ex.dev/ns#title> \"auth\" <urn:sparq:auth> .
 ";
         Graph::load_dataset(nq, "nquads").expect("fixture loads")
     }
+
+    const AUTH: &str = crate::AUTH_GRAPH;
 
     /// The set of named graphs `sparq_engine::update_in_place` ACTUALLY writes for `sparql`,
     /// observed via the engine's own resolved effect log (`UpdateEffect::Delta { slot, … }`
@@ -631,17 +687,21 @@ mod differential_writeset_tests {
         assert!(!default, "no default-graph write in this shape");
 
         // The DELETE half only produces a quad for r1 (where OPTIONAL bound `?p`); the INSERT
-        // half produces a quad for r1 AND r2 (both have a title). The engine writes r1 and r2.
-        // resolve_var_graphs must enumerate EXACTLY {r1, r2} — never r3 (no title), never the
+        // half produces a quad for every graph with a title — r1, r2 AND the seeded auth view
+        // (a plain no-USING update runs over the full store, which build_using also keeps).
+        // resolve_var_graphs must enumerate EXACTLY that set — never r3 (no title), never the
         // whole store.
         assert_eq!(
             precise, written,
             "precise resolve_var_graphs set must EQUAL the engine's actual write set"
         );
-        let expect: BTreeSet<String> = ["https://pod.ex/r1", "https://pod.ex/r2"]
+        let expect: BTreeSet<String> = ["https://pod.ex/r1", "https://pod.ex/r2", AUTH]
             .map(String::from)
             .into();
-        assert_eq!(written, expect, "engine wrote exactly r1+r2");
+        assert_eq!(
+            written, expect,
+            "engine wrote exactly r1+r2+auth (every titled graph)"
+        );
     }
 
     /// CASE 2 — OPTIONAL that does NOT bind for some rows: the precise set must still equal the
@@ -667,18 +727,21 @@ mod differential_writeset_tests {
         let (written, default) = engine_write_set(&mut applied, upd);
         assert!(!default);
 
-        // `?g` binds to r1 and r2 (both have a title). The engine writes both — r1 via
-        // delete+insert, r2 via insert only (its DELETE quad is dropped, `?p` unbound). r3 is
-        // never bound. The precise set must be exactly that, with NO phantom r3 and NO
-        // escalation to all-store.
+        // `?g` binds to every titled graph — r1, r2 and the auth view. The engine writes all
+        // of them — r1 via delete+insert, r2/auth via insert only (their DELETE quad is
+        // dropped, `?p` unbound). r3 is never bound. The precise set must be exactly that, with
+        // NO phantom r3 and NO escalation to all-store.
         assert_eq!(
             precise, written,
             "OPTIONAL-unbound: precise set must EQUAL the engine write set"
         );
-        let expect: BTreeSet<String> = ["https://pod.ex/r1", "https://pod.ex/r2"]
+        let expect: BTreeSet<String> = ["https://pod.ex/r1", "https://pod.ex/r2", AUTH]
             .map(String::from)
             .into();
-        assert_eq!(written, expect, "engine wrote exactly r1+r2 (r3 unbound)");
+        assert_eq!(
+            written, expect,
+            "engine wrote exactly r1+r2+auth (r3 unbound)"
+        );
     }
 
     /// CASE 3 — an OPTIONAL whose WHERE key is ABSENT everywhere, so `?g` binds to NOTHING:
@@ -713,6 +776,15 @@ mod differential_writeset_tests {
     /// (`rescope_dataset` re-expresses `WITH`'s implicit "all store named graphs" as an explicit
     /// `FROM NAMED` list), so it enumerates the SAME `GRAPH ?g` bindings the engine writes. The
     /// precise set must now EQUAL the engine write set — no longer the conservative wildcard.
+    ///
+    /// SOUNDNESS GUARD ([OPUS-4.8] sq-cnor): the fixture seeds a `title` triple in the auth
+    /// view, which `build_using(named: None)` keeps, so the engine's write set INCLUDES the
+    /// auth view. The earlier `rescope_dataset` excluded the auth view from the materialized
+    /// `FROM NAMED` list, so the precise resolved set MISSED it — `precise != written` — an
+    /// under-count that let a `WITH … { GRAPH ?g … }` slip a write to the authorization view
+    /// past the per-graph check. This assertion FAILS on that prior code and PASSES once the
+    /// auth view is restored to the materialized set; the production `check` then DENIES the
+    /// op fail-closed (no session is write-granted on the auth view).
     #[test]
     fn with_clause_resolves_precisely_to_engine_write_set() {
         // WITH re-scopes the operation's DEFAULT graph to r1; the GRAPH ?g slot still ranges
@@ -741,16 +813,25 @@ mod differential_writeset_tests {
              template quad is explicitly GRAPH ?g-scoped"
         );
 
-        // The precise set now EQUALS the engine's actual write set (exactly r1+r2) — the sq-cnor
-        // gap is closed; no escalation to the all-store wildcard.
+        // The precise set now EQUALS the engine's actual write set — exactly r1+r2 AND the auth
+        // view (every titled graph build_using keeps). The sq-cnor under-count is closed; no
+        // escalation to the all-store wildcard, and crucially the auth view is no longer missed.
         assert_eq!(
             precise, written,
             "WITH: precise resolve_var_graphs set must EQUAL the engine's actual write set"
         );
-        let expect: BTreeSet<String> = ["https://pod.ex/r1", "https://pod.ex/r2"]
+        assert!(
+            written.contains(AUTH),
+            "the engine's WITH write set includes the auth view (build_using keeps it) — the \
+             precise set must too, or a write to the auth view escapes the per-graph check"
+        );
+        let expect: BTreeSet<String> = ["https://pod.ex/r1", "https://pod.ex/r2", AUTH]
             .map(String::from)
             .into();
-        assert_eq!(written, expect, "engine wrote exactly r1+r2 under WITH");
+        assert_eq!(
+            written, expect,
+            "engine wrote exactly r1+r2+auth under WITH"
+        );
     }
 
     /// CASE 5 — `USING NAMED` restricts the GRAPH ?g range to the listed graphs only ([OPUS-4.8]

--- a/crates/sparq-solid/src/update.rs
+++ b/crates/sparq-solid/src/update.rs
@@ -24,16 +24,19 @@
 //! - a write to a graph the actor cannot write in the required mode is denied and the
 //!   store is **not** mutated (the check runs entirely before [`update_in_place`]);
 //! - a `DELETE/INSERT … WHERE` template with a `GRAPH ?var` slot is resolved
-//!   *precisely* ([OPUS-4.8] sq-biss): the operation's WHERE pattern is evaluated to
-//!   enumerate the CONCRETE graphs `?var` actually binds to, and write is required only
-//!   on THOSE graphs (per the read path's per-graph model) — not on every store graph.
-//!   This stays fail-closed: the WHERE is evaluated against **exactly the dataset the
-//!   engine will instantiate the templates over** (the full store, re-scoped by `USING`
-//!   — see the soundness note on [`resolve_var_graphs`]), so the graphs checked are
-//!   exactly the graphs the apply could touch; if any binding is not a writable named
-//!   graph the update is denied, and any binding that cannot be reduced to a concrete
-//!   named graph (a blank-node graph name, or a WHERE the analysis cannot evaluate)
-//!   falls back to the conservative all-graphs check below (never a hole);
+//!   *precisely* ([OPUS-4.8] sq-biss, extended to `USING`/`WITH` by sq-cnor): the
+//!   operation's WHERE pattern is evaluated to enumerate the CONCRETE graphs `?var`
+//!   actually binds to, and write is required only on THOSE graphs (per the read path's
+//!   per-graph model) — not on every store graph. This stays fail-closed: the WHERE is
+//!   evaluated against **exactly the dataset the engine will instantiate the templates
+//!   over** — the full store, or, when the operation carries a `USING (NAMED)` / `WITH`
+//!   clause, the same active dataset the engine's `build_using` assembles, re-expressed
+//!   as an explicit `FROM`/`FROM NAMED` clause (see the soundness note on
+//!   [`resolve_var_graphs`]) — so the graphs checked are exactly the graphs the apply
+//!   could touch; if any binding is not a writable named graph the update is denied, and
+//!   any binding that cannot be reduced to a concrete named graph (a blank-node graph
+//!   name, or a WHERE the analysis cannot evaluate) falls back to the conservative
+//!   all-graphs check below (never a hole);
 //! - a target whose graph name cannot be determined statically by the above — a
 //!   `CLEAR`/`DROP` of `ALL`/`NAMED` graphs, or a `GRAPH ?var` slot that fell back —
 //!   is treated *conservatively*: the actor must be able to write **every** named graph
@@ -253,6 +256,31 @@ fn analyze(upd: &Update) -> WriteReqs {
     reqs
 }
 
+/// Re-express an update's `USING (NAMED)` / `WITH` re-scope as a query `FROM`/`FROM NAMED`
+/// dataset clause that makes the query side's [`sparq_engine::query`] assemble the SAME
+/// active dataset the engine's apply builds via `Dataset::build_using`. [OPUS-4.8] sq-cnor.
+///
+/// `build_using` and the query-side `build_active` treat the `default` (FROM) graphs
+/// identically (merge the listed store graphs; an absent one contributes nothing). They
+/// diverge only on `named`:
+///
+/// - `Some(list)` (explicit `USING NAMED`): both keep exactly `list`. We pass it through
+///   unchanged — an absent name denotes the empty graph on the query side and contributes
+///   no binding under `build_using` either, so the `GRAPH ?g` enumeration is identical.
+/// - `None` (the parser's encoding of `WITH`, which re-scopes only the default graph):
+///   `build_using` keeps ALL the store's named graphs, but a query's empty `FROM NAMED`
+///   keeps NONE. We therefore materialize `named` as an explicit `FROM NAMED` of every
+///   store named graph (excluding the reserved auth view, which the apply never exposes to
+///   the WHERE either) so the query keeps the same set.
+fn rescope_dataset(graph: &sparq_core::Graph, u: &QueryDataset) -> QueryDataset {
+    let named = match &u.named {
+        Some(list) => list.clone(),
+        // WITH: make the implicit "all store named graphs" explicit for the query side.
+        None => store_named_graphs(graph),
+    };
+    QueryDataset { default: u.default.clone(), named: Some(named) }
+}
+
 /// Resolve a `DELETE/INSERT … WHERE` operation's `GRAPH ?var` template slots into the
 /// concrete (named-graph, need) requirements its solutions actually produce.
 /// [OPUS-4.8] sq-biss.
@@ -275,15 +303,27 @@ fn analyze(upd: &Update) -> WriteReqs {
 /// wildcard already computed, only tightened to the graphs that genuinely appear as
 /// targets.
 ///
-/// Fail-closed cases that fall back to the wildcard (rather than risk a hole):
+/// # `USING`/`WITH` re-scope ([OPUS-4.8] sq-cnor)
 ///
-/// - the operation carries a `USING`/`WITH` clause: the apply re-scopes the WHERE through
-///   `Dataset::build_using`, whose `named: None` (the parser's encoding of `WITH`) keeps
-///   ALL store named graphs — but a plain query's `FROM`/`FROM NAMED` (`build_active`)
-///   treats `named: None` as the EMPTY named set, so a serialized SELECT would
-///   *under-count* the `GRAPH ?g` bindings. Rather than reproduce the update-side dataset
-///   semantics (private to the engine), we stay conservative whenever a re-scope is
-///   present — `Err(need)`;
+/// When the operation carries a `USING (NAMED)` / `WITH` clause the apply re-scopes the
+/// WHERE through `Dataset::build_using`, which a *plain* SELECT (`dataset: None`) does NOT
+/// reproduce: `build_using`'s `named: None` (the parser's encoding of `WITH`, which only
+/// re-scopes the DEFAULT graph) keeps ALL the store's named graphs, whereas a query whose
+/// `FROM NAMED` list is empty keeps NONE — so a naive serialized SELECT would *under-count*
+/// the `GRAPH ?g` bindings and open a hole. We close the gap by handing the binding SELECT
+/// the EXACT same active dataset the engine builds, re-expressed as a query dataset clause
+/// ([`rescope_dataset`]): the `USING` default graphs become `FROM`, and the named set is
+/// either the explicit `USING NAMED` list or — for `WITH` (`named: None`) — an explicit
+/// `FROM NAMED` of every store named graph (the set `build_using` keeps). The query side's
+/// [`sparq_engine::query`] then assembles the identical active dataset
+/// (`dataset::build_active` with `default`/`named` matching `build_using` graph-for-graph;
+/// the two diverge only on a view intersection, and no dataset view is installed on the
+/// write-check path — `check` calls the full-store `query`, not `query_view`). The
+/// enumerated bindings therefore equal the engine's, so the resolution stays precise even
+/// under `USING`/`WITH`.
+///
+/// Fail-closed cases that still fall back to the wildcard (rather than risk a hole):
+///
 /// - the WHERE cannot be evaluated (parse/serialize/engine error) — `Err(need)`;
 /// - a slot binds to a **blank-node** graph name: the engine *would* write to it
 ///   ([`gnp_subst`] accepts blank nodes), but the auth view only ever grants write on
@@ -300,16 +340,14 @@ fn resolve_var_graphs(
     // every slot.
     let fallback = r.slots.iter().map(|(_, n)| *n).fold(Need::WriteOrAppend, strongest);
 
-    // USING/WITH re-scopes the WHERE in a way a plain query cannot faithfully reproduce
-    // (see the doc note) — fail closed to the conservative all-graphs check.
-    if r.using.is_some() {
-        return Err(fallback);
-    }
-
     // Build `SELECT ?v… { WHERE }` and evaluate it exactly as the engine instantiates the
-    // templates: the full store, no dataset re-scope (the USING/WITH case bailed above).
+    // templates. With no `USING`/`WITH` the active dataset is the full store
+    // (`dataset: None`); with a re-scope we re-express the engine's `build_using` active
+    // dataset as an explicit FROM/FROM NAMED clause so the SELECT enumerates the SAME
+    // bindings the apply will ([OPUS-4.8] sq-cnor).
+    let dataset = r.using.as_ref().map(|u| rescope_dataset(graph, u));
     let select = Query::Select {
-        dataset: None,
+        dataset,
         pattern: GraphPattern::Project {
             inner: Box::new(r.pattern.clone()),
             variables: r.slots.iter().map(|(v, _)| v.clone()).collect(),
@@ -669,20 +707,17 @@ mod differential_writeset_tests {
         );
     }
 
-    /// CASE 4 — the WITH-clause variant (PSS shapes can carry `WITH`). `resolve_var_graphs`
-    /// DELIBERATELY bails to the conservative all-graphs wildcard whenever a USING/WITH
-    /// re-scope is present (`update.rs` ~line 305; root-caused in sq-cnor): a plain serialized
-    /// SELECT cannot reproduce the apply's `build_using` dataset (`WITH` keeps ALL store named
-    /// graphs, a query's `FROM NAMED` of `named: None` keeps NONE), so a precise resolution
-    /// could UNDER-count and open a hole. We therefore verify the SECURITY property directly:
-    /// the conservative target (every store named graph) is a SUPERSET of what the engine
-    /// actually writes. A superset can only DENY (never leak) — sound, the invariant holds in
-    /// the safe direction. (When sq-cnor tightens this to a precise set, this test's superset
-    /// check still holds and the equality below documents the tightening target.)
+    /// CASE 4 — the WITH-clause variant (PSS shapes can carry `WITH`). [OPUS-4.8] sq-cnor
+    /// tightened `resolve_var_graphs` so a `USING`/`WITH` re-scope is now resolved PRECISELY:
+    /// the binding SELECT is handed the same active dataset the apply's `build_using` builds
+    /// (`rescope_dataset` re-expresses `WITH`'s implicit "all store named graphs" as an explicit
+    /// `FROM NAMED` list), so it enumerates the SAME `GRAPH ?g` bindings the engine writes. The
+    /// precise set must now EQUAL the engine write set — no longer the conservative wildcard.
     #[test]
-    fn with_clause_falls_back_to_sound_over_approximation() {
+    fn with_clause_resolves_precisely_to_engine_write_set() {
         // WITH re-scopes the operation's DEFAULT graph to r1; the GRAPH ?g slot still ranges
-        // over named graphs. The resolver sees a re-scope and bails (USING is Some).
+        // over named graphs. The resolver re-expresses the re-scope as a FROM NAMED clause and
+        // resolves precisely.
         let upd = "\
             WITH <https://pod.ex/r1> \
             DELETE { GRAPH ?g { ?s <https://ex.dev/ns#aclPointer> ?p } } \
@@ -691,53 +726,64 @@ mod differential_writeset_tests {
                                 OPTIONAL { ?s <https://ex.dev/ns#aclPointer> ?p } } }";
 
         let graph = pss_dataset();
-        // resolve_var_graphs returns Err(_) -> the precise set is undefined; PodStore falls
-        // back to the all-graphs wildcard.
-        assert!(
-            resolve_var_graph_set(&graph, upd).is_none(),
-            "WITH/USING re-scope must trigger the conservative wildcard fallback"
-        );
-
-        // The conservative target set is EVERY named graph in the store.
-        let conservative: BTreeSet<String> = store_named_graphs(&graph)
-            .iter()
-            .map(|n| n.as_str().to_owned())
-            .collect();
+        let precise =
+            resolve_var_graph_set(&graph, upd).expect("WITH re-scope now resolves precisely (sq-cnor)");
 
         let mut applied = pss_dataset();
         let (written, default) = engine_write_set(&mut applied, upd);
 
         // WITH re-scopes the operation's DEFAULT graph, but EVERY quad pattern in the DELETE,
         // INSERT and WHERE templates here is explicitly `GRAPH ?g { … }`-scoped, so no triple
-        // lands in (or is read from) the default graph: the WITH target is never written. Assert
-        // that signal rather than dropping it — a regression that started routing writes to the
-        // WITH default graph would otherwise pass the subset check below unnoticed.
+        // lands in (or is read from) the default graph: the WITH target is never written.
         assert!(
             !default,
             "WITH default-graph re-scope must NOT produce a default-graph write when every \
              template quad is explicitly GRAPH ?g-scoped"
         );
 
-        // SECURITY invariant in the safe direction: the authorization target (all store
-        // graphs) is a SUPERSET of the engine's actual write set — never an under-approximation
-        // (which would let a write escape auth). Over-approximation is sound; it only denies.
-        assert!(
-            written.is_subset(&conservative),
-            "fallback wildcard must COVER every graph the engine writes (no under-approx hole): \
-             engine wrote {written:?}, wildcard covers {conservative:?}"
+        // The precise set now EQUALS the engine's actual write set (exactly r1+r2) — the sq-cnor
+        // gap is closed; no escalation to the all-store wildcard.
+        assert_eq!(
+            precise, written,
+            "WITH: precise resolve_var_graphs set must EQUAL the engine's actual write set"
         );
-        // Document the precision gap (sq-cnor): the engine actually writes only r1+r2, but the
-        // wildcard demands write on the whole store -> the fallback is a strict over-approx here.
-        let real: BTreeSet<String> = ["https://pod.ex/r1", "https://pod.ex/r2"]
+        let expect: BTreeSet<String> = ["https://pod.ex/r1", "https://pod.ex/r2"]
             .map(String::from)
             .into();
+        assert_eq!(written, expect, "engine wrote exactly r1+r2 under WITH");
+    }
+
+    /// CASE 5 — `USING NAMED` restricts the GRAPH ?g range to the listed graphs only ([OPUS-4.8]
+    /// sq-cnor). The binding SELECT must mirror `build_using`'s explicit named set: `?g` binds
+    /// only within the `USING NAMED` graphs, so a resource with a title that is NOT named in the
+    /// USING clause must NOT appear in the precise set (and the engine does not write it). This
+    /// proves the re-scope is honoured precisely, not just passed through as the whole store.
+    #[test]
+    fn using_named_restricts_precise_set_to_listed_graphs() {
+        // Only r1 is in USING NAMED; r2 has a title too but is excluded. `?g` can bind ONLY r1.
+        let upd = "\
+            DELETE { GRAPH ?g { ?s <https://ex.dev/ns#aclPointer> ?p } } \
+            INSERT { GRAPH ?g { ?s <https://ex.dev/ns#aclPointer> <https://pod.ex/new.acl> } } \
+            USING NAMED <https://pod.ex/r1> \
+            WHERE  { GRAPH ?g { ?s <https://ex.dev/ns#title> ?t . \
+                                OPTIONAL { ?s <https://ex.dev/ns#aclPointer> ?p } } }";
+
+        let graph = pss_dataset();
+        let precise =
+            resolve_var_graph_set(&graph, upd).expect("USING NAMED resolves precisely (sq-cnor)");
+
+        let mut applied = pss_dataset();
+        let (written, default) = engine_write_set(&mut applied, upd);
+        assert!(!default, "no default-graph write in this shape");
+
         assert_eq!(
-            written, real,
-            "engine's real WITH write set is exactly r1+r2"
+            precise, written,
+            "USING NAMED: precise set must EQUAL the engine write set (only the listed graph)"
         );
-        assert!(
-            real.is_subset(&conservative) && conservative.len() > real.len(),
-            "wildcard is a STRICT over-approximation of the engine write set (the sq-cnor gap)"
+        let expect: BTreeSet<String> = ["https://pod.ex/r1"].map(String::from).into();
+        assert_eq!(
+            written, expect,
+            "USING NAMED <r1> restricts the write set to r1 (r2 excluded despite its title)"
         );
     }
 }

--- a/crates/sparq-solid/tests/update.rs
+++ b/crates/sparq-solid/tests/update.rs
@@ -381,6 +381,35 @@ fn var_graph_with_clause_precise_still_denies_unwritable_binding() {
     assert_eq!(graph_len(&s, MIXED4_DOC), before, "denied WITH variable-graph delete changed nothing");
 }
 
+#[test]
+fn var_graph_with_clause_denies_binding_to_auth_view() {
+    // [OPUS-4.8] sq-cnor — the AUTH_GRAPH under-count regression guard at the PRODUCTION
+    // `check` boundary. `Dataset::build_using(named: None)` (the `WITH` re-scope) keeps EVERY
+    // store named graph in the active dataset, INCLUDING the reserved `urn:sparq:auth` view.
+    // So a `WITH … DELETE { GRAPH ?g { … } } WHERE { GRAPH ?g { ?s <auth#read> ?o } }` makes
+    // `?g` bind to the auth view and the engine WOULD write it. The prior `rescope_dataset`
+    // dropped the auth view from the materialized `FROM NAMED` set, so the precise resolver
+    // MISSED that binding — the op could be (wrongly) PERMITTED and transiently mutate the
+    // authorization view. With the auth view restored to the materialized set the binding is
+    // resolved, and since no session is ever write-granted on the auth view the op is DENIED
+    // fail-closed. The auth view must be untouched.
+    let mut s = wac_store();
+    let auth = "urn:sparq:auth";
+    let before = graph_len(&s, auth);
+    assert!(before > 0, "materialized auth view holds the WAC grant triples");
+    // `auth#read` triples exist ONLY in the auth view, so `?g` binds exactly {urn:sparq:auth}.
+    let upd = "WITH <https://pod.ex/team2/c3/g0/d0.ttl> \
+               DELETE { GRAPH ?g { ?s ?p ?o } } \
+               WHERE  { GRAPH ?g { ?s <https://sparq.dev/ns/auth#read> ?o . ?s ?p ?o } }";
+    let r = s.update_as(&sess(Some(CAROL)), upd);
+    assert!(
+        r.is_err(),
+        "a WITH var-graph op whose ?g binds to the auth view must be DENIED (no write grant on \
+         the auth view); was: {r:?}"
+    );
+    assert_eq!(graph_len(&s, auth), before, "denied op left the auth view untouched");
+}
+
 // --- [OPUS-4.8] sq-3jtd.2: fail-closed-BEFORE-apply — a DENIED update mutates NOTHING ---
 //
 // The tests above assert per-graph triple COUNTS are unchanged on a deny. This block

--- a/crates/sparq-solid/tests/update.rs
+++ b/crates/sparq-solid/tests/update.rs
@@ -340,24 +340,45 @@ fn var_graph_empty_binding_is_a_permitted_noop() {
 }
 
 #[test]
-fn var_graph_with_using_clause_falls_back_to_conservative() {
-    // A USING/WITH re-scope on a variable-GRAPH op cannot be faithfully reproduced by a
-    // plain SELECT (the apply's `build_using` keeps all store named graphs for `WITH`,
-    // while a query's FROM-only dataset has an EMPTY named set), so precise resolution
-    // would UNDER-count the bound graphs. The check fails closed to the all-graphs
-    // wildcard: CAROL — who could write this exact team2-bounded delete WITHOUT the WITH
-    // clause (var_graph_precise_allows_authorized_subset) — is now denied, because she
-    // cannot write every store graph.
+fn var_graph_with_clause_resolves_precisely() {
+    // [OPUS-4.8] sq-cnor: a `WITH`/`USING` re-scope on a variable-GRAPH op is now resolved
+    // PRECISELY (no longer the conservative all-graphs fallback). The binding SELECT is handed
+    // the same active dataset the apply's `build_using` builds — for `WITH` (which re-scopes
+    // only the DEFAULT graph), `named: None` keeps all store named graphs, re-expressed as an
+    // explicit `FROM NAMED` of every store named graph. Every quad here is `GRAPH ?g`-scoped,
+    // so the `WITH` default graph never participates; `?g` resolves to exactly the team2
+    // content graphs CAROL owns — so she is now PERMITTED, just as without the WITH clause
+    // (var_graph_precise_allows_authorized_subset).
     let mut s = wac_store();
     let before = graph_len(&s, TEAM2_DOC);
+    assert!(before > 0, "team2 doc has a title triple to delete");
     let upd = format!(
         "WITH <{TEAM2_DOC}> \
          DELETE {{ GRAPH ?g {{ ?s <{TITLE}> ?o }} }} \
          WHERE  {{ GRAPH ?g {{ ?s <{TITLE}> ?o }} FILTER(STRSTARTS(STR(?g), \"https://pod.ex/team2/\")) }}"
     );
+    s.update_as(&sess(Some(CAROL)), &upd)
+        .expect("precise WITH-clause resolution: carol may delete titles across team2 she owns");
+    assert_eq!(graph_len(&s, TEAM2_DOC), before - 1, "title deleted from a bound team2 graph");
+}
+
+#[test]
+fn var_graph_with_clause_precise_still_denies_unwritable_binding() {
+    // The precise WITH/USING resolution must NOT confuse the re-scope with a free pass: CAROL
+    // can READ mixed4 but WRITE none of it. A `WITH`-carrying variable-GRAPH delete whose `?g`
+    // binds to the (readable, unwritable) mixed4 graphs is still DENIED, store untouched —
+    // exactly as the no-WITH precise path denies (var_graph_precise_denies_readable_but_unwritable_binding).
+    let mut s = wac_store();
+    let before = graph_len(&s, MIXED4_DOC);
+    assert!(before > 0, "mixed4 doc non-empty");
+    let upd = format!(
+        "WITH <{MIXED4_DOC}> \
+         DELETE {{ GRAPH ?g {{ ?s <{TITLE}> ?o }} }} \
+         WHERE  {{ GRAPH ?g {{ ?s <{TITLE}> ?o }} FILTER(STRSTARTS(STR(?g), \"https://pod.ex/mixed4/\")) }}"
+    );
     let r = s.update_as(&sess(Some(CAROL)), &upd);
-    assert!(r.is_err(), "USING/WITH variable-graph op falls back to conservative deny: {r:?}");
-    assert_eq!(graph_len(&s, TEAM2_DOC), before, "conservative fallback applied nothing");
+    assert!(r.is_err(), "WITH does not waive write-auth: carol may read but not write mixed4 -> denied: {r:?}");
+    assert_eq!(graph_len(&s, MIXED4_DOC), before, "denied WITH variable-graph delete changed nothing");
 }
 
 // --- [OPUS-4.8] sq-3jtd.2: fail-closed-BEFORE-apply — a DENIED update mutates NOTHING ---


### PR DESCRIPTION
> 🤖 SPARQ agent

## sq-cnor — precise variable-GRAPH write check under USING/WITH (with AUTH_GRAPH soundness fix)

`sq-biss` made `GRAPH ?var` write-permission checks precise (enumerate the concrete bound graphs, check write only on those). This PR extends that to `DELETE/INSERT…WHERE` carrying a `USING`/`WITH` clause, which previously fell back to the conservative all-graphs wildcard because a plain serialized `SELECT` (`dataset: None`) cannot reproduce the apply's `Dataset::build_using` re-scope.

### ⚠️ Soundness hole found in the first revision (now fixed)

Adversarial review **disproved** the original PR's "precise resolved set EQUALS the engine write set" invariant. The first revision's `rescope_dataset` materialized the `WITH` (`named: None`) `FROM NAMED` set from `store_named_graphs`, which **deliberately excludes** the reserved `urn:sparq:auth` (AUTH_GRAPH) view. But the engine's `Dataset::build_using(named: None)` keeps **all** store named graphs **including** the auth view.

So for `WITH <r1> DELETE { GRAPH ?g {…} } WHERE { GRAPH ?g {…} }` over a store with a triple matching the WHERE in **both** `r1` and `urn:sparq:auth`:

- the first revision's precise resolved set = `{r1}` (auth view dropped),
- the engine's actual write set = `{r1, urn:sparq:auth}`.

That is an **under-count**: `?g` binds to `urn:sparq:auth`, a Delta is recorded to it, and the op could be wrongly **PERMITTED** — transiently mutating the authorization view. (End-to-end this was masked only by the incidental `.acl`/`.acr` re-materialization self-heal — safety must rest on the invariant, not on that.) The original doc claim that the apply "never exposes the auth view to the WHERE either" was therefore **false**, and the differential guard was blind to it because its fixture had no auth-view triple.

### Fix (true-invariant option)

New `engine_using_named_graphs` returns **exactly** what `build_using(named: None)` keeps — every store named graph, **auth view included** — and the `WITH` rescope path uses it. The precise resolved set now genuinely **EQUALS** the engine write set. A binding to the auth view is now enumerated, and since no session is ever write/append-granted on the auth view, `check` **DENIES fail-closed**. (`store_named_graphs`, used by the conservative *wildcard* path, keeps its intentional auth-view exclusion — the wildcard protects the auth view by re-materialization, not by a write grant.)

The previously-false doc comments were corrected: `rescope_dataset` / `resolve_var_graphs` now state the auth view **is** in the active dataset and is protected by a fail-closed deny, not by being hidden from the WHERE.

`USING NAMED` and the no-rescope (full-store) paths are unchanged. Fail-closed cases unchanged: a blank-node graph-name binding or an un-evaluable WHERE still falls back to the conservative wildcard. No `unsafe`, no public-API change.

### Tests — the strengthened guard demonstrably catches the original drift

- `pss_dataset` now seeds a `title` triple in `urn:sparq:auth`, so the engine write set includes the auth view. The differential guard `with_clause_resolves_precisely_to_engine_write_set` **FAILS on the old code** (`precise {r1,r2}` != `written {r1,r2,urn:sparq:auth}`) and **PASSES on the fix**.
- New production-boundary test `var_graph_with_clause_denies_binding_to_auth_view`: a `WITH` var-GRAPH op whose `?g` binds to the auth view was wrongly `Ok(())` on the old code; it is now **denied** with the auth view untouched.
- Kept the `USING NAMED` restriction test and all prior cases.

### Gate

- `cargo build` + `cargo clippy -p sparq-solid --all-targets -- -D warnings` — clean **default** and **`--features count-enforcement`**.
- `cargo test -p sparq-solid` — green **both** feature states, including the strengthened guard.
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sparq-solid --no-deps` — clean.
- Privacy-claims gate — OK (no unqualified auth-soundness claim; fail-closed deny is stated as the mechanism).
- fmt is informational repo-wide (deferred reformat); new lines match the surrounding committed style; no net fmt drift in `src/update.rs`.

Closes sq-cnor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)