### PR TITLE
docs(openssf): triage residual Scorecard Fuzzing/Maintained/Vulnerabilities alerts (sq-cgzx) [OPUS-4.8]

### DIFF
--- a/compliance/openssf/gap-register.md
+++ b/compliance/openssf/gap-register.md
@@ -29,15 +29,18 @@ remediation lives in the supply-chain / slsa frameworks.
 code-scanning alerts**. `scorecard.yml` previously uploaded its SARIF to the GitHub Security
 tab, which surfaced five Scorecard *scores* as "alerts": `BranchProtection` (high),
 `CodeReview` (high), `Maintained` (high), `VulnerabilitiesID` (high), `CIIBestPractices`
-(low). **None is a code vulnerability** — they are posture scores, and four are inherent to
-this repo's operating model:
+(low). **None is a code vulnerability** — they are posture scores, and the inherent-by-design
+ones (`CodeReview`, `BranchProtection`) cannot be raised by a code change in this repo's
+operating model. The residual-alert triage below also covers `Fuzzing`, named alongside
+`Vulnerabilities` / `Maintained` in the residual-triage bead **sq-cgzx**:
 
 | Scorecard check | Why it scores low (honest) | Disposition |
 |---|---|---|
 | `CodeReviewID` | Scorecard infers review from merged-PR history and discounts self-approval; this is a solo-maintained, agent-driven repo (Copilot + CODEOWNERS ruleset, not a 2-human-reviewer flow). | Inherent-by-design (GX-OSSF-3). Dismissed from code-scanning; not a fixable code issue. |
 | `BranchProtectionID` | The live ruleset (`docs/branch-protection.md`) is ruleset-based, not classic branch-protection; Scorecard scores classic settings (stale-review-dismissal, required approvers) the model intentionally does not use. | Inherent-by-design (GX-OSSF-3). Dismissed. |
-| `MaintainedID` | Scored 0 only because the repo is **<90 days old**; mechanical, self-resolves with age. | Time-based, not fixable now. Dismissed. |
-| `VulnerabilitiesID` | Re-surfaces the **`unmaintained`** RustSec advisory already triaged-with-a-bead in `deny.toml` (RUSTSEC-2025-0134 `rustls-pemfile`/sq-g2xs) + one transitive JS devDep advisory (GHSA-qx2v-qp2m-jg93, PostCSS, site tooling). (RUSTSEC-2024-0436 `paste`/sq-l8bv was dropped: the GPU stack no longer pulls `paste`, so it left the tree and the ignore was removed.) **No fixable security advisory** — the cargo-deny advisory gate (GX-1, #210) is un-degraded and would FAIL on a real one. | Already-accepted informational; no new fix. Dismissed. |
+| `MaintainedID` | Scored low only because the repo is **<90 days old** (Scorecard's `Maintained` check counts recent commits/issue activity over the trailing 90 days); mechanical, self-resolves with age and ongoing commit cadence. | Time-based, not fixable now. Dismissed; residual-triage bead sq-cgzx. |
+| `VulnerabilitiesID` | Re-surfaces the **`unmaintained`** RustSec advisory already triaged-with-a-bead in `deny.toml` (RUSTSEC-2025-0134 `rustls-pemfile`/sq-g2xs) + one transitive JS devDep advisory (GHSA-qx2v-qp2m-jg93, PostCSS, site tooling). (RUSTSEC-2024-0436 `paste`/sq-l8bv was dropped: the GPU stack no longer pulls `paste`, so it left the tree and the ignore was removed.) **No fixable security advisory** — the cargo-deny advisory gate (GX-1, #210) is un-degraded and would FAIL on a real one. | Already-accepted informational; no new fix. Dismissed; residual-triage bead sq-cgzx. |
+| `FuzzingID` | **Now satisfied — no longer the "OSS-Fuzz = future" informational gap the bead anticipated.** Coverage-guided fuzzing is wired: [`fuzz.yml`](../../.github/workflows/fuzz.yml) runs `cargo-fuzz` (PR smoke + daily heavy tier) over the RDF/SPARQL parsers and the mmap store loader, plus the SHACL differential lane [`shacl-diff-fuzz.yml`](../../.github/workflows/shacl-diff-fuzz.yml) (bead **sq-ovnf**, closed). Scorecard's `Fuzzing` check detects the `cargo-fuzz` integration and scores it. OSS-Fuzz onboarding remains an optional future maturity nudge, not a posture failure. | Satisfied by `fuzz.yml`/`shacl-diff-fuzz.yml` (sq-ovnf). No fix needed; residual-triage bead sq-cgzx. |
 | `CIIBestPracticesID` | The OpenSSF Best-Practices badge is not filed (GX-4) — a human-owned external step. | Known gap GX-4 (sq-toze.5). Dismissed; tracked. |
 
 **Decision (option a):** keep Scorecard as the **public score + badge** (`publish_results:
@@ -45,8 +48,10 @@ true` → OpenSSF dashboard) and **stop uploading its SARIF to code-scanning** (
 `upload-sarif` step + the now-unneeded `security-events: write` scope). The full posture
 detail remains on the public dashboard and as the build artifact; it no longer pollutes the
 Security tab. The five pre-existing alerts were dismissed (`won't fix`) with the per-row
-reasons above. This loses no certification evidence — the score/badge is the OpenSSF
-artifact, the Security tab was redundant noise.
+reasons above (and the residual `Vulnerabilities` / `Maintained` / `Fuzzing` triage of
+**sq-cgzx** is recorded in the same table — `Fuzzing` is now satisfied, the other two are
+informational/time-based). This loses no certification evidence — the score/badge is the
+OpenSSF artifact, the Security tab was redundant noise.
 
 ## Closed gaps (cite as evidence, do not re-open)
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Re-review when Fable returns ([OPUS-4.8] marker on the change).

## What

Completes the residual-Scorecard-alert triage tracked by **sq-cgzx** ("Triage residual
Scorecard alerts: VulnerabilitiesID / MaintainedID / FuzzingID"). Docs-only edit to the
code-scanning decision-record table in `compliance/openssf/gap-register.md`.

Before this PR the triage table covered `CodeReviewID` / `BranchProtectionID` /
`MaintainedID` / `VulnerabilitiesID` / `CIIBestPracticesID` but **omitted `FuzzingID`** — the
one of the three bead-named checks with a *changed* disposition.

## Changes

- **`FuzzingID` — now SATISFIED** (added row). It is no longer the "OSS-Fuzz = future"
  informational gap the bead anticipated: coverage-guided `cargo-fuzz` is wired
  (`.github/workflows/fuzz.yml` over the RDF/SPARQL parsers + the mmap store loader, PR smoke
  + daily heavy tier; plus `.github/workflows/shacl-diff-fuzz.yml`), landed under the now-closed
  **sq-ovnf**. Scorecard's `Fuzzing` check detects the integration. OSS-Fuzz onboarding stays
  an optional future maturity nudge, not a posture failure.
- **`MaintainedID`** — clarified the honest reason (Scorecard's trailing-90-day
  commit/issue-activity window on a sub-90-day-old repo); time-based, self-resolves with age.
- **`VulnerabilitiesID`** — already accurate post-#633 (only `rustls-pemfile`/sq-g2xs remains
  ignored in `deny.toml`; `paste`/sq-l8bv left the tree). Tagged with the triage bead so the
  disposition is traceable.

## Honesty

This is a **triage / disposition record**, not a new capability. No code, no public API, no
`unsafe`. `FuzzingID` flips to satisfied because the fuzz harness already exists (sq-ovnf);
`Maintained`/`Vulnerabilities` remain informational/time-based — recorded, not "fixed".

## Gate

Docs-only, so the Rust gate (cargo build/clippy/tests/rustdoc/unsafe) does not apply. Ran the
relevant docs-quality + honesty gates locally on the changed file:
- markdownlint-cli2 0.18.1 — 0 errors
- typos 1.47.2 — clean
- lychee `--offline` — 10/10 internal links OK
- `scripts/check-privacy-claims.sh` — OK

No public API touched, so the G2 public-api→SKILL.md rule does not apply.

Closes sq-cgzx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
