### PR TITLE
docs(sparq-mpc): equality/mult open is DETECT-only, never CORRECTS under honest majority (sq-ji5f)

### DIFF
--- a/crates/sparq-mpc/src/adversarial_tests.rs
+++ b/crates/sparq-mpc/src/adversarial_tests.rs
@@ -812,6 +812,99 @@ mod robust_props {
             }
         }
     }
+
+    /// PROPERTY (bead **sq-ji5f**, decision: the honest envelope is DETECT-only).
+    /// The honest-majority constructor fixes `t = ⌊(n−1)/2⌋`, so the equality /
+    /// mult open at degree `2t` has correction budget
+    /// `e_max = ⌊(n − (2t+1))/2⌋`. We sweep EVERY honest-majority party count the
+    /// constructor will build and assert `e_max == 0` for all of them — odd `n`
+    /// (`n = 2t+1`, zero redundancy → no detection) AND even `n` (`n = 2t+2`,
+    /// exactly one redundant share → detect-and-abort). So the production
+    /// equality primitive can at best DETECT (even `n`) and NEVER auto-CORRECTS a
+    /// cheater: a flipped verdict is never silently repaired into the honest one.
+    /// Robust correction (`e_max ≥ 1`) at degree `2t` would need `n ≥ 2t+3`, which
+    /// the constructor never provisions for the equality open (see the
+    /// `…_corrects_…_when_overprovisioned` prop, which builds the degree-`2t`
+    /// sharing DIRECTLY at `n ≥ 2t+3` — no honest-majority `secure_equal` path
+    /// reaches it).
+    #[test]
+    fn honest_majority_equality_open_has_zero_correction_budget() {
+        for n in 2usize..=24 {
+            let backend = ShamirBackend::new_seeded(n, 0xC0DE + n as u64).unwrap();
+            let t = backend.threshold();
+            assert_eq!(t, (n - 1) / 2, "honest-majority t = ⌊(n−1)/2⌋");
+            // One multiplication needs the 2t+1 <= n headroom.
+            assert!(n > 2 * t, "n={n} t={t}: equality open needs n >= 2t+1");
+            let degree = 2 * t;
+            // Redundant shares at the product degree, and the RS correction budget.
+            let redundancy = n - (degree + 1);
+            let e_max = redundancy / 2;
+            assert_eq!(
+                e_max, 0,
+                "sq-ji5f: honest-majority n={n} (t={t}) must give ZERO correction \
+                 budget at degree 2t (got e_max={e_max}); the equality open DETECTS \
+                 at most, never auto-corrects"
+            );
+            // Cross-check the two reachable regimes the constructor produces.
+            if n % 2 == 1 {
+                assert_eq!(
+                    redundancy, 0,
+                    "odd honest-majority n={n}: n = 2t+1, zero redundancy at degree 2t \
+                     (tampering undetectable — MAC is the deferred WI-4 fix, sq-6d6g)"
+                );
+            } else {
+                assert_eq!(
+                    redundancy, 1,
+                    "even honest-majority n={n}: n = 2t+2, exactly one redundant share \
+                     at degree 2t (detect-and-abort only, e_max=0)"
+                );
+            }
+        }
+    }
+
+    /// PROPERTY (bead **sq-ji5f**): the FUNCTIONAL counterpart of the budget
+    /// arithmetic above — on every even honest-majority `n` (the only regime with
+    /// redundancy), a tampered degree-`2t` product share is DETECT-and-ABORT and
+    /// is NEVER silently corrected back to the honest verdict. The reconstruction
+    /// must therefore return `Err(Tampered)`, not `Ok(honest_value)`: with
+    /// `e_max = 0` the RS checker has no correction budget, so "correct the
+    /// cheater away" is provably unreachable on the honest-majority equality path.
+    #[test]
+    fn honest_majority_equality_open_never_corrects_tamper() {
+        let mut rng = Lcg(0x5111_CE5A);
+        for &n in &[4usize, 6, 8, 10] {
+            let backend = ShamirBackend::new_seeded(n, 0xA17 + n as u64).unwrap();
+            let t = backend.threshold();
+            assert_eq!(n - (2 * t + 1), 1, "even honest-majority n: one redundant share");
+            for _ in 0..120 {
+                let mut dealer = backend.dealer();
+                // EQUAL keys ⇒ honest m = 0 (a "match"); tampering tries to flip it.
+                let key = fp(rng.next_fp());
+                let sa = dealer.share(key);
+                let sb = dealer.share(key);
+                let mask = dealer.draw_nonzero_fp();
+                let r = dealer.share(mask);
+                let d = shamir::sub_shares(&sa, &sb).unwrap();
+                let m_shares = mul_shares_raw(&d, &r).unwrap();
+                let mut tampered = m_shares.clone();
+                let i = rng.next_in(n);
+                let mut delta = rng.next_fp();
+                if delta == 0 {
+                    delta = 1;
+                }
+                tampered[i].y = tampered[i].y.add(fp(delta));
+                match reconstruct_degree(&tampered, 2 * t) {
+                    Err(MpcError::Tampered { .. }) => { /* detect-and-abort — the honest envelope */ }
+                    Ok(v) => panic!(
+                        "sq-ji5f: n={n} t={t} has e_max=0, so the equality open must \
+                         DETECT-and-ABORT a tampered share, never silently correct it \
+                         (got Ok({v:?}))"
+                    ),
+                    Err(other) => panic!("n={n}: must be Tampered (detect-only), got {other:?}"),
+                }
+            }
+        }
+    }
 }
 
 // =====================================================================

--- a/crates/sparq-mpc/src/join.rs
+++ b/crates/sparq-mpc/src/join.rs
@@ -440,6 +440,29 @@ impl HiddenValueJoin {
     /// `m = (a - b)·r` is opened at degree `2t`; `m == 0 ⇔ a == b`, and for unequal
     /// keys `m` is uniform nonzero — so ONLY the match bit is revealed, never either
     /// key or their difference.
+    ///
+    /// **Integrity envelope — DETECT-only, never CORRECT (bead sq-ji5f; decision
+    /// = the honest envelope).** The degree-`2t` open routes through
+    /// [`shamir::reconstruct_degree`] → the WI-1 Reed–Solomon checker, but the
+    /// honest-majority constructor fixes `t = ⌊(n−1)/2⌋`, so the equality open's
+    /// correction budget at degree `2t` is `e_max = ⌊(n − (2t+1))/2⌋ = 0` for
+    /// EVERY party count the constructor builds:
+    ///
+    /// - **odd `n`** (`n = 2t+1`): zero RS redundancy at degree `2t` ⇒ tampering
+    ///   is information-theoretically undetectable (a MAC is the deferred WI-4
+    ///   fix, bead sq-6d6g) — NOT claimed otherwise;
+    /// - **even `n`** (`n = 2t+2`): exactly one redundant share ⇒ a tampered
+    ///   product share is DETECTED and the open aborts with [`MpcError::Tampered`].
+    ///
+    /// So this primitive can at best **detect-and-abort** under an honest majority
+    /// and NEVER auto-corrects a cheater. Robust correction (`e_max ≥ 1`) at
+    /// degree `2t` would need `n ≥ 2t+3`, which is deliberately NOT provisioned
+    /// here: the bead weighed (a) over-provisioning the party set, (b) a
+    /// BGW/DN degree-reduction round before the open, and (c) leaving
+    /// detect-and-abort as the honest envelope, and chose (c) — robustness is out
+    /// of scope for the honest-majority equality test and would change the trust
+    /// model. The arithmetic and behaviour are pinned by the `sq-ji5f` properties
+    /// in `adversarial_tests` (`honest_majority_equality_open_*`).
     fn secure_equal_shared(
         &self,
         dealer: &mut ShamirDealer,


### PR DESCRIPTION
> 🤖 SPARQ agent

Resolves bead **sq-ji5f** — *MPC: equality/mult open only DETECTS, never CORRECTS, under the honest-majority party count*.

## What the bead asked

Discovered during WI-2 (sq-7q9i): the degree-`2t` equality/mult open routes through the WI-1 Reed–Solomon checker ([`shamir::reconstruct_degree`] → `robust::reconstruct_robust`), but the honest-majority constructor fixes `t = ⌊(n−1)/2⌋`, so the open's RS correction budget at degree `2t` is `e_max = ⌊(n − (2t+1))/2⌋ = 0` for **every** party count the constructor builds. The bead asked to decide among: (a) over-provision the party set (`n ≥ 2t+3`) for robustness, (b) a BGW/DN degree-reduction round before the open, or (c) leave detect-and-abort as the honest envelope and document it — then implement/document.

## Decision: (c), the honest envelope

`secure_equal` can at best **detect-and-abort** under an honest majority and **never auto-corrects** a cheater:

- **odd `n`** (`n = 2t+1`): zero RS redundancy at degree `2t` ⇒ tampering is information-theoretically undetectable (a MAC is the deferred WI-4 fix, sq-6d6g);
- **even `n`** (`n = 2t+2`): exactly one redundant share ⇒ a tampered product share is **detected** and the open aborts with `MpcError::Tampered`.

Robust correction (`e_max ≥ 1`) at degree `2t` would need `n ≥ 2t+3`, which is deliberately **not** provisioned for the equality primitive — that would change the trust model and is out of scope for the honest-majority equality test.

## Change (doc + tests only; no public-API change)

- `HiddenValueJoin::secure_equal_shared` now records the decision and the `e_max = 0` envelope explicitly in its doc.
- Two new `sq-ji5f` properties in `adversarial_tests`:
  - `honest_majority_equality_open_has_zero_correction_budget` — pins the `e_max = 0` arithmetic across the full honest-majority sweep (`n = 2..=24`), cross-checking the odd (zero-redundancy) and even (one-redundant-share) regimes;
  - `honest_majority_equality_open_never_corrects_tamper` — functional: across even `n ∈ {4,6,8,10}`, a tampered degree-`2t` product share **aborts** (`Tampered`), never silently corrects back to the honest verdict.

The existing `degree_2t_open_corrects_*_when_overprovisioned` property still exercises the checker's correction arm by building a degree-`2t` sharing **directly** at `n ≥ 2t+3` — confirming no honest-majority `secure_equal` path reaches correction.

## Honesty

This is the documentation/decision deliverable the bead requested, not a new capability. No `secure_equal` behaviour changed; the work makes the previously-implicit detect-only envelope an explicit, decision-of-record + property-pinned guarantee.

## Gate

- `cargo build -p sparq-mpc`
- `cargo clippy -p sparq-mpc --all-targets` (default + `--all-features`) with `-D warnings`
- `cargo test -p sparq-mpc` (default + `--all-features`) — 395 passing
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` (default + `--all-features`)
- privacy-claims gate + G2 public-api→SKILL gate

No `unsafe` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)