### PR TITLE
feat(sparq-nlq): N2 dictionary-grounded constraint of generated SPARQL (sq-9yjp) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,6 +3438,7 @@ dependencies = [
 name = "sparq-nlq"
 version = "0.1.0"
 dependencies = [
+ "oxrdf 0.3.3",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/sparq-nlq/Cargo.toml
+++ b/crates/sparq-nlq/Cargo.toml
@@ -34,6 +34,10 @@ sparq-introspect = { path = "../sparq-introspect", version = "0.1.0" }
 # Validation: parse the generated query to algebra BEFORE touching the engine, so the
 # repair round gets a real parser error message.
 spargebra.workspace = true
+# N2 dictionary-grounded constraint (`constrain.rs`, sq-9yjp): build oxrdf NamedNode/Term
+# to probe the live dictionary via Graph::id_of. Workspace-pinned so the term type is
+# byte-identical to sparq-core's (id_of takes oxrdf::Term).
+oxrdf.workspace = true
 # Record/replay fixtures (prompt -> completion pairs) are plain JSON.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/sparq-nlq/README.md
+++ b/crates/sparq-nlq/README.md
@@ -48,6 +48,18 @@ llm.save("my_session.json")?;                   // replayable fixture for later
 - **Validate before execute** — parses with `spargebra` *before* the engine sees the
   query, so the repair round gets a real parser error; execution failures (unsupported
   forms, `QueryBudget` trips) are repair signals too.
+- **N2 dictionary constraint** ([`constrain`](src/constrain.rs), bead `sq-9yjp`,
+  **opt-in** via `NlqConfig::check_dictionary`) — once a query parses, walk its algebra
+  and check every predicate / `rdf:type` class IRI against the **live dictionary**
+  (`Graph::id_of`). An ungrounded IRI matches no triple, so it becomes a *targeted*
+  repair signal ("predicate `<…>` not in the dictionary; did you mean `<…>`?") with
+  nearest-namespace edit-distance suggestions pulled from the store itself. This is the
+  design doc's API-backend fallback (`research/genai-nl-to-sparql.md` §6, §11): strict
+  logit-level grammar-constrained *decoding* needs logit/grammar access the Anthropic
+  Messages API does not expose, so it is **only feasible on a local backend** — not
+  implemented here, and not claimed. Off by default because an empty-answer question
+  (a valid-but-absent class) must not be "repaired"; the exec-accuracy harness measures
+  raw model accuracy with it off. <!-- [OPUS-4.8] sq-9yjp -->
 - **Budgeted execution** — LLM-generated queries are untrusted input, so every query runs
   under a [`QueryBudget`]. The default is **bounded** (10 s wall clock, 1M materialised
   rows); opting out requires setting `exec_timeout` / `max_rows` to `None` explicitly.
@@ -83,8 +95,14 @@ llm.save("my_session.json")?;                   // replayable fixture for later
   live path (`live_exec_accuracy`, `#[cfg(feature = "live")]` **and** `#[ignore]`'d) needs a
   real key, the olympics dump, and a **canonical** measurement host (not a CI/sandbox box) —
   open work in bead `sq-g0lw`.
-- **Not yet wired**: entity/relation linking from `sparq-sim` (bead `sq-uw40`) and
-  N2 grammar-constrained decoding against the live dictionary (bead `sq-9yjp`).
+- **Not yet wired**: entity/relation linking from `sparq-sim` (bead `sq-uw40`).
+- **Partial (honest scope)**: N2 against the live dictionary (bead `sq-9yjp`). The
+  **vocabulary** half — predicate / class IRIs checked against the dictionary, with
+  did-you-mean repair — is wired (opt-in `check_dictionary`, see Features). Strict
+  logit-level **grammar-constrained decoding** is *not* implemented: it needs
+  logit/grammar access the Anthropic Messages API does not expose, so it is only
+  feasible on a local/open backend (`research/genai-nl-to-sparql.md` §11). Not claimed.
+  <!-- [OPUS-4.8] sq-9yjp -->
 - `AnthropicLlm` is compile-checked in CI (`--features live`) but never called there; no
   test touches the network. <!-- [OPUS-4.8] sq-05rv sq-g0lw -->
 

--- a/crates/sparq-nlq/src/constrain.rs
+++ b/crates/sparq-nlq/src/constrain.rs
@@ -1,0 +1,469 @@
+//! N2 — dictionary-grounded constraint of generated SPARQL (`sq-9yjp`,
+//! `research/genai-nl-to-sparql.md` §8.1, §6 step 2). [OPUS-4.8]
+//!
+//! Grammar-constrained *decoding* in the strict sense (mask the model's logits at
+//! every step so only grammar-valid tokens are ever emitted) requires **logit
+//! access** and is therefore only feasible on a *local* backend, or on an API that
+//! accepts a supplied grammar (GBNF / structured-output). The crate's only live
+//! backend — `crate::live::AnthropicLlm` — is the Anthropic Messages API, which
+//! exposes **neither** logit bias **nor** a grammar parameter, so the strict variant
+//! is not implementable against it (`research/genai-nl-to-sparql.md` §11: "needs
+//! logit access — only works on local/open backends; API backends … fall back to
+//! post-hoc validation"). Honest scope.
+//!
+//! What *is* both achievable and the part the bead literally names ("against the
+//! **live dictionary**") is the design doc's prescribed fallback (§6 step 2): once a
+//! candidate query parses, walk its algebra, collect every IRI used in **predicate**
+//! or **class** position, and check each against the live dictionary
+//! ([`sparq_core::Graph::id_of`]). An IRI absent from the dictionary cannot match any
+//! triple, so the query is *valid-but-wrong* — it would execute to a silent empty (or
+//! mis-grounded) result. We instead turn it into a **targeted repair signal**: the
+//! unknown IRI plus the nearest known terms from the same namespace ("did you mean
+//! `dbo:director`?"), candidates that are free from the dictionary. This is the
+//! SPARQL-LLM repair pattern, sharpened by the store's own vocabulary.
+//!
+//! The syntactic half of constraint (does it parse at all?) is already covered by the
+//! `spargebra` parse in [`crate::Nlq::ask`]; this module adds the **semantic**
+//! (vocabulary) half.
+
+use oxrdf::{NamedNode, Term};
+use spargebra::algebra::{Expression, GraphPattern, PropertyPathExpression};
+use spargebra::term::{NamedNodePattern, TermPattern, TriplePattern};
+use spargebra::Query;
+use sparq_core::dict::TermParts;
+use sparq_core::Graph;
+
+/// `rdf:type` — the predicate whose *object* is a class IRI, the one object position
+/// we treat as a vocabulary term (every other object is data, not schema).
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+/// How many "did you mean" candidates to surface per unknown term.
+const MAX_SUGGESTIONS: usize = 3;
+
+/// Where in the query an unknown IRI appeared — drives the wording of the repair hint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TermRole {
+    /// Used as a triple/path predicate.
+    Predicate,
+    /// Used as the object of an `rdf:type` triple (a class).
+    Class,
+}
+
+impl TermRole {
+    fn label(self) -> &'static str {
+        match self {
+            TermRole::Predicate => "predicate",
+            TermRole::Class => "class",
+        }
+    }
+}
+
+/// One IRI used in predicate/class position that is **absent from the live
+/// dictionary** — so no triple can match it. Carries up to a few nearest known terms
+/// from the same namespace as repair candidates.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownTerm {
+    /// The offending IRI, exactly as written in the query.
+    pub iri: String,
+    /// Predicate vs class position.
+    pub role: TermRole,
+    /// Nearest known terms (same namespace, smallest edit distance first); possibly
+    /// empty when the namespace itself is unknown to the store.
+    pub suggestions: Vec<String>,
+}
+
+/// Walks the parsed `query` and returns every IRI used as a **predicate** or as an
+/// `rdf:type` **object (class)** that is **not present in `graph`'s dictionary**, each
+/// paired with nearest known terms (see [`UnknownTerm`]). De-duplicated; order is
+/// stable (first appearance). An IRI that *is* in the dictionary is omitted — only the
+/// genuinely-ungrounded vocabulary is reported.
+///
+/// Scope is deliberately predicate and class position: those are the vocabulary terms
+/// a schema-grounded query must get right, and the two the design doc's repair step
+/// targets. Subject/data-object IRIs (specific entities) are left to entity linking
+/// (`sq-uw40`), not this vocabulary constraint.
+pub fn unknown_terms(graph: &Graph, query: &Query) -> Vec<UnknownTerm> {
+    let mut found: Vec<(String, TermRole)> = Vec::new();
+    let mut seen: std::collections::HashSet<(String, TermRole)> = std::collections::HashSet::new();
+    let mut push = |iri: &str, role: TermRole| {
+        let key = (iri.to_string(), role);
+        if seen.insert(key.clone()) {
+            found.push(key);
+        }
+    };
+    match query {
+        Query::Select { pattern, .. }
+        | Query::Ask { pattern, .. }
+        | Query::Describe { pattern, .. } => walk_pattern(pattern, &mut push),
+        Query::Construct {
+            pattern, template, ..
+        } => {
+            walk_pattern(pattern, &mut push);
+            for tp in template {
+                walk_triple(tp, &mut push);
+            }
+        }
+    }
+
+    found
+        .into_iter()
+        .filter(|(iri, _)| !iri_in_dictionary(graph, iri))
+        .map(|(iri, role)| {
+            let suggestions = nearest_known(graph, &iri);
+            UnknownTerm {
+                iri,
+                role,
+                suggestions,
+            }
+        })
+        .collect()
+}
+
+/// Renders the repair message handed back to the model for a non-empty set of unknown
+/// terms — the dictionary-constraint feedback. Stable, deterministic wording (so a
+/// repair prompt is reproducible / replayable).
+pub fn dictionary_repair_message(unknowns: &[UnknownTerm]) -> String {
+    let mut msg = String::from(
+        "the query parses, but these terms are not in the dataset's dictionary, so they \
+         match no triples:",
+    );
+    for u in unknowns {
+        msg.push_str(&format!("\n- {} <{}>", u.role.label(), u.iri));
+        if !u.suggestions.is_empty() {
+            let hints: Vec<String> = u.suggestions.iter().map(|s| format!("<{s}>")).collect();
+            msg.push_str(&format!(" — did you mean {}?", hints.join(", ")));
+        }
+    }
+    msg.push_str("\nUse only predicates and classes that appear in the schema summary above.");
+    msg
+}
+
+/// Is `iri` a term in the live dictionary? Uses the public [`Graph::id_of`] membership
+/// test (absent IRI → no id → cannot match).
+fn iri_in_dictionary(graph: &Graph, iri: &str) -> bool {
+    match NamedNode::new(iri) {
+        Ok(node) => graph.id_of(&Term::NamedNode(node)).is_some(),
+        // A syntactically invalid IRI can never be in the dictionary; spargebra would
+        // not have produced it as a NamedNode, but guard anyway.
+        Err(_) => false,
+    }
+}
+
+/// Nearest known IRIs to `iri` from the same namespace, smallest edit distance first,
+/// capped at [`MAX_SUGGESTIONS`]. A single dictionary scan; only IRI terms sharing the
+/// `iri`'s namespace are considered (suggestions across namespaces are noise) and only
+/// those within edit distance ≤ the local-name length (a larger distance shares almost
+/// nothing — noise too).
+fn nearest_known(graph: &Graph, iri: &str) -> Vec<String> {
+    let Some(split) = iri.rfind(['#', '/']) else {
+        return Vec::new();
+    };
+    let prefix = &iri[..=split];
+    let suffix = &iri[split + 1..];
+    let cap = suffix.chars().count().max(1);
+
+    let mut scored: Vec<(usize, String)> = Vec::new();
+    for (_, parts) in graph.dict.iter() {
+        let TermParts::Iri {
+            prefix: p,
+            suffix: s,
+        } = parts
+        else {
+            continue;
+        };
+        if p != prefix || s == suffix {
+            continue;
+        }
+        let d = edit_distance(suffix, s);
+        if d <= cap {
+            scored.push((d, format!("{p}{s}")));
+        }
+    }
+    scored.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    scored.truncate(MAX_SUGGESTIONS);
+    scored.into_iter().map(|(_, iri)| iri).collect()
+}
+
+/// Levenshtein edit distance (two rolling rows). Local names are short, so the
+/// quadratic cost is trivial; no allocation beyond the two rows.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for (i, &ca) in a.iter().enumerate() {
+        cur[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            cur[j + 1] = (prev[j + 1] + 1).min(cur[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
+// ---------------------------------------------------------------------------
+// Algebra walk
+// ---------------------------------------------------------------------------
+
+fn walk_pattern<F: FnMut(&str, TermRole)>(p: &GraphPattern, f: &mut F) {
+    match p {
+        GraphPattern::Bgp { patterns } => {
+            for tp in patterns {
+                walk_triple(tp, f);
+            }
+        }
+        GraphPattern::Path { path, .. } => walk_path(path, f),
+        GraphPattern::Join { left, right }
+        | GraphPattern::Union { left, right }
+        | GraphPattern::Minus { left, right } => {
+            walk_pattern(left, f);
+            walk_pattern(right, f);
+        }
+        // `sep-0006` (lateral join) is always enabled in this workspace.
+        GraphPattern::Lateral { left, right } => {
+            walk_pattern(left, f);
+            walk_pattern(right, f);
+        }
+        GraphPattern::LeftJoin {
+            left,
+            right,
+            expression,
+        } => {
+            walk_pattern(left, f);
+            walk_pattern(right, f);
+            if let Some(e) = expression {
+                walk_expr(e, f);
+            }
+        }
+        GraphPattern::Filter { expr, inner } => {
+            walk_expr(expr, f);
+            walk_pattern(inner, f);
+        }
+        GraphPattern::Graph { inner, .. }
+        | GraphPattern::Distinct { inner }
+        | GraphPattern::Reduced { inner }
+        | GraphPattern::Slice { inner, .. }
+        | GraphPattern::OrderBy { inner, .. }
+        | GraphPattern::Project { inner, .. }
+        | GraphPattern::Group { inner, .. } => walk_pattern(inner, f),
+        GraphPattern::Extend {
+            inner, expression, ..
+        } => {
+            walk_pattern(inner, f);
+            walk_expr(expression, f);
+        }
+        // A SERVICE block targets a remote endpoint whose dictionary we do not hold;
+        // its vocabulary is out of scope for the local-dictionary check.
+        GraphPattern::Service { .. } => {}
+        GraphPattern::Values { .. } => {}
+    }
+}
+
+fn walk_triple<F: FnMut(&str, TermRole)>(tp: &TriplePattern, f: &mut F) {
+    if let NamedNodePattern::NamedNode(p) = &tp.predicate {
+        let p = p.as_str();
+        f(p, TermRole::Predicate);
+        // An `rdf:type` triple's object, when a fixed IRI, is a class.
+        if p == RDF_TYPE {
+            if let TermPattern::NamedNode(o) = &tp.object {
+                f(o.as_str(), TermRole::Class);
+            }
+        }
+    }
+    // Quoted triple terms (RDF 1.2, `sparql-12`, always enabled here) can nest
+    // predicates/classes; descend.
+    if let TermPattern::Triple(inner) = &tp.subject {
+        walk_triple(inner, f);
+    }
+    if let TermPattern::Triple(inner) = &tp.object {
+        walk_triple(inner, f);
+    }
+}
+
+fn walk_path<F: FnMut(&str, TermRole)>(path: &PropertyPathExpression, f: &mut F) {
+    match path {
+        PropertyPathExpression::NamedNode(n) => f(n.as_str(), TermRole::Predicate),
+        PropertyPathExpression::Reverse(p)
+        | PropertyPathExpression::ZeroOrMore(p)
+        | PropertyPathExpression::OneOrMore(p)
+        | PropertyPathExpression::ZeroOrOne(p) => walk_path(p, f),
+        PropertyPathExpression::Sequence(a, b) | PropertyPathExpression::Alternative(a, b) => {
+            walk_path(a, f);
+            walk_path(b, f);
+        }
+        PropertyPathExpression::NegatedPropertySet(ns) => {
+            for n in ns {
+                f(n.as_str(), TermRole::Predicate);
+            }
+        }
+    }
+}
+
+fn walk_expr<F: FnMut(&str, TermRole)>(e: &Expression, f: &mut F) {
+    match e {
+        Expression::Exists(p) => walk_pattern(p, f),
+        Expression::Or(a, b)
+        | Expression::And(a, b)
+        | Expression::Equal(a, b)
+        | Expression::SameTerm(a, b)
+        | Expression::Greater(a, b)
+        | Expression::GreaterOrEqual(a, b)
+        | Expression::Less(a, b)
+        | Expression::LessOrEqual(a, b)
+        | Expression::Add(a, b)
+        | Expression::Subtract(a, b)
+        | Expression::Multiply(a, b)
+        | Expression::Divide(a, b) => {
+            walk_expr(a, f);
+            walk_expr(b, f);
+        }
+        Expression::In(a, list) => {
+            walk_expr(a, f);
+            for e in list {
+                walk_expr(e, f);
+            }
+        }
+        Expression::UnaryPlus(a) | Expression::UnaryMinus(a) | Expression::Not(a) => {
+            walk_expr(a, f)
+        }
+        Expression::FunctionCall(_, args) => {
+            for a in args {
+                walk_expr(a, f);
+            }
+        }
+        Expression::If(a, b, c) => {
+            walk_expr(a, f);
+            walk_expr(b, f);
+            walk_expr(c, f);
+        }
+        Expression::Coalesce(list) => {
+            for e in list {
+                walk_expr(e, f);
+            }
+        }
+        // A literal/variable/IRI/bound leaf carries no nested schema vocabulary we
+        // check (a bare IRI in expression position is a value, not a predicate/class).
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn graph() -> Graph {
+        let ttl = r#"
+            @prefix ex: <http://example.org/> .
+            @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+            ex:alice a ex:Person ; rdfs:label "Alice" ; ex:knows ex:bob .
+            ex:bob a ex:Person ; rdfs:label "Bob" .
+        "#;
+        Graph::load_str(ttl, "turtle").expect("graph parses")
+    }
+
+    fn parse(q: &str) -> Query {
+        spargebra::SparqlParser::new()
+            .parse_query(q)
+            .expect("query parses")
+    }
+
+    #[test]
+    fn known_predicate_and_class_yield_no_unknowns() {
+        let g = graph();
+        let q = parse(
+            "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n\
+             PREFIX ex: <http://example.org/>\n\
+             SELECT ?s WHERE { ?s rdf:type ex:Person ; ex:knows ?o }",
+        );
+        assert!(unknown_terms(&g, &q).is_empty());
+    }
+
+    #[test]
+    fn unknown_predicate_is_flagged_with_same_namespace_suggestion() {
+        let g = graph();
+        // `ex:know` (typo for `ex:knows`) is absent.
+        let q = parse(
+            "PREFIX ex: <http://example.org/>\n\
+             SELECT ?s WHERE { ?s ex:know ?o }",
+        );
+        let unknowns = unknown_terms(&g, &q);
+        assert_eq!(unknowns.len(), 1);
+        assert_eq!(unknowns[0].iri, "http://example.org/know");
+        assert_eq!(unknowns[0].role, TermRole::Predicate);
+        assert!(
+            unknowns[0]
+                .suggestions
+                .contains(&"http://example.org/knows".to_string()),
+            "expected ex:knows suggested, got {:?}",
+            unknowns[0].suggestions
+        );
+    }
+
+    #[test]
+    fn unknown_class_in_rdf_type_object_is_flagged_as_class() {
+        let g = graph();
+        let q = parse(
+            "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n\
+             PREFIX ex: <http://example.org/>\n\
+             SELECT ?s WHERE { ?s rdf:type ex:Persons }",
+        );
+        let unknowns = unknown_terms(&g, &q);
+        assert_eq!(unknowns.len(), 1);
+        assert_eq!(unknowns[0].iri, "http://example.org/Persons");
+        assert_eq!(unknowns[0].role, TermRole::Class);
+        assert!(unknowns[0]
+            .suggestions
+            .contains(&"http://example.org/Person".to_string()));
+    }
+
+    #[test]
+    fn property_path_predicate_is_checked() {
+        let g = graph();
+        let q = parse(
+            "PREFIX ex: <http://example.org/>\n\
+             SELECT ?s WHERE { ?s ex:knows+ ?o . ?s ex:nope* ?z }",
+        );
+        let unknowns = unknown_terms(&g, &q);
+        assert_eq!(unknowns.len(), 1);
+        assert_eq!(unknowns[0].iri, "http://example.org/nope");
+    }
+
+    #[test]
+    fn unknown_namespace_gives_no_suggestions_but_still_flags() {
+        let g = graph();
+        let q = parse(
+            "PREFIX foo: <http://other.example/>\n\
+             SELECT ?s WHERE { ?s foo:bar ?o }",
+        );
+        let unknowns = unknown_terms(&g, &q);
+        assert_eq!(unknowns.len(), 1);
+        assert!(unknowns[0].suggestions.is_empty());
+    }
+
+    #[test]
+    fn repair_message_lists_terms_and_hints() {
+        let unknowns = vec![UnknownTerm {
+            iri: "http://example.org/know".into(),
+            role: TermRole::Predicate,
+            suggestions: vec!["http://example.org/knows".into()],
+        }];
+        let msg = dictionary_repair_message(&unknowns);
+        assert!(msg.contains("predicate <http://example.org/know>"));
+        assert!(msg.contains("did you mean <http://example.org/knows>?"));
+    }
+
+    #[test]
+    fn edit_distance_basics() {
+        assert_eq!(edit_distance("knows", "know"), 1);
+        assert_eq!(edit_distance("Person", "Persons"), 1);
+        assert_eq!(edit_distance("abc", "abc"), 0);
+        assert_eq!(edit_distance("", "abc"), 3);
+    }
+}

--- a/crates/sparq-nlq/src/lib.rs
+++ b/crates/sparq-nlq/src/lib.rs
@@ -50,6 +50,7 @@ pub use sparq_engine::{QueryBudget, QueryResult};
 #[cfg(feature = "live")]
 pub mod live;
 
+pub mod constrain;
 pub mod eval;
 
 // ---------------------------------------------------------------------------
@@ -227,6 +228,27 @@ pub struct NlqConfig {
     /// is read at prompt time), so one [`Nlq`] can be reconfigured grounded vs
     /// ungrounded; the eval harness drives both off the same graph. [OPUS-4.8] sq-05rv
     pub ground: bool,
+    /// N2 **dictionary-grounded constraint** ([`constrain`], `sq-9yjp`). When `true`,
+    /// a query that parses is additionally checked against the **live dictionary**
+    /// *before* execution: every predicate / `rdf:type` class IRI must be a term the
+    /// store actually holds (via [`sparq_core::Graph::id_of`]). An ungrounded IRI
+    /// matches no triple — a *valid-but-wrong* query — so it becomes a targeted repair
+    /// signal ("predicate X not in the dictionary; did you mean Y?") with
+    /// nearest-namespace candidates pulled from the dictionary, exactly as
+    /// `research/genai-nl-to-sparql.md` §6 prescribes. Strict logit-level
+    /// grammar-constrained *decoding* is not implementable against the Anthropic
+    /// Messages API (no logit/grammar parameter); this is the design doc's API-backend
+    /// fallback (§11).
+    ///
+    /// **Default `false`** — and deliberately so. The check is an *additive* constraint
+    /// with a real false-positive: a query whose answer is legitimately empty (a class
+    /// with no instances, e.g. `SELECT ?r WHERE { ?r a ex:Robot }` over a robot-free
+    /// graph) uses a perfectly valid term that is simply *absent* from the dictionary,
+    /// and must not be "repaired". So it stays opt-in, the same way [`ground`](Self::ground)
+    /// is a knob: the exec-accuracy harness measures raw model accuracy with it off,
+    /// and a caller who wants tighter grounding (accepting that empty-answer questions
+    /// then need it off) sets it `true`. [OPUS-4.8] sq-9yjp
+    pub check_dictionary: bool,
 }
 
 impl Default for NlqConfig {
@@ -256,6 +278,7 @@ impl Default for NlqConfig {
                 },
             ],
             ground: true,
+            check_dictionary: false,
         }
     }
 }
@@ -275,6 +298,11 @@ pub enum TurnOutcome {
     ParseError(String),
     /// The engine rejected or aborted the (syntactically valid) query.
     ExecError(String),
+    /// N2 dictionary constraint (`sq-9yjp`): the query parsed and executed, but used a
+    /// predicate / class IRI absent from the live dictionary (so it matched no
+    /// triples). Carries the ungrounded terms; the repair message lists them with
+    /// nearest-namespace suggestions. [OPUS-4.8]
+    UngroundedTerms(Vec<constrain::UnknownTerm>),
 }
 
 /// One generate→validate(→execute) round, kept verbatim for auditability — the
@@ -476,24 +504,40 @@ impl<'g> Nlq<'g> {
                             let msg = e.to_string();
                             (Some(q), Some((msg.clone(), TurnOutcome::ParseError(msg))))
                         }
-                        // EXECUTE under the budget. Engine-side failures (unsupported
-                        // form, budget trip) are also repairable signals.
-                        Ok(_) => {
-                            match query_with_budget(self.graph, &q, &self.execution_budget()) {
-                                Err(e) => (Some(q), Some((e.clone(), TurnOutcome::ExecError(e)))),
-                                Ok(result) => {
-                                    transcript.push(Turn {
-                                        prompt,
-                                        completion,
-                                        sparql: Some(q.clone()),
-                                        outcome: TurnOutcome::Ok { rows: result.len() },
-                                    });
-                                    return Ok(Answer {
-                                        sparql: q,
-                                        result,
-                                        repairs: round,
-                                        transcript,
-                                    });
+                        Ok(parsed) => {
+                            // N2 dictionary constraint (`sq-9yjp`): a query whose
+                            // predicate/class IRIs are not in the live dictionary
+                            // cannot match — turn it into a targeted repair signal
+                            // BEFORE spending an execution on a guaranteed-empty query.
+                            let unknowns = if self.config.check_dictionary {
+                                constrain::unknown_terms(self.graph, &parsed)
+                            } else {
+                                Vec::new()
+                            };
+                            if !unknowns.is_empty() {
+                                let msg = constrain::dictionary_repair_message(&unknowns);
+                                (Some(q), Some((msg, TurnOutcome::UngroundedTerms(unknowns))))
+                            } else {
+                                // EXECUTE under the budget. Engine-side failures
+                                // (unsupported form, budget trip) are repairable too.
+                                match query_with_budget(self.graph, &q, &self.execution_budget()) {
+                                    Err(e) => {
+                                        (Some(q), Some((e.clone(), TurnOutcome::ExecError(e))))
+                                    }
+                                    Ok(result) => {
+                                        transcript.push(Turn {
+                                            prompt,
+                                            completion,
+                                            sparql: Some(q.clone()),
+                                            outcome: TurnOutcome::Ok { rows: result.len() },
+                                        });
+                                        return Ok(Answer {
+                                            sparql: q,
+                                            result,
+                                            repairs: round,
+                                            transcript,
+                                        });
+                                    }
                                 }
                             }
                         }
@@ -721,5 +765,72 @@ mod tests {
             "expected a budget trip, got {:?}",
             err.transcript[0].outcome
         );
+    }
+
+    /// N2 (`sq-9yjp`): an ungrounded predicate is a repair signal, and the repair
+    /// prompt carries the dictionary feedback + suggestion. The model fixes it and the
+    /// loop succeeds — the dictionary constraint paid for itself.
+    #[test]
+    fn ungrounded_predicate_triggers_dictionary_repair() {
+        let g = tiny_graph();
+        // First completion uses `ex:know` (not in the dictionary); the repair prompt
+        // must surface the dictionary message + the `ex:knows` suggestion; second
+        // completion is grounded.
+        let cfg = NlqConfig {
+            check_dictionary: true,
+            ..NlqConfig::default()
+        };
+        let nlq = Nlq::with_config(
+            &g,
+            Box::new(FnLlm(|prompt| {
+                if prompt.contains("not in the dataset's dictionary") {
+                    assert!(prompt.contains("http://example.org/knows")); // suggestion
+                    Ok("```sparql\nPREFIX ex: <http://example.org/>\n\
+                        SELECT ?s WHERE { ?s ex:knows ?o }\n```"
+                        .to_string())
+                } else {
+                    Ok("```sparql\nPREFIX ex: <http://example.org/>\n\
+                        SELECT ?s WHERE { ?s ex:know ?o }\n```"
+                        .to_string())
+                }
+            })),
+            cfg,
+        );
+        let a = nlq.ask("Who knows whom?").expect("repair succeeds");
+        assert_eq!(a.repairs, 1);
+        assert_eq!(a.transcript.len(), 2);
+        assert!(
+            matches!(&a.transcript[0].outcome, TurnOutcome::UngroundedTerms(u)
+                if u.len() == 1 && u[0].iri == "http://example.org/know"),
+            "got {:?}",
+            a.transcript[0].outcome
+        );
+        assert_eq!(a.transcript[1].outcome, TurnOutcome::Ok { rows: 1 });
+    }
+
+    /// Disabling the constraint accepts the (valid-but-empty) query as-is — the
+    /// pre-N2 behaviour stays available.
+    #[test]
+    fn check_dictionary_false_accepts_ungrounded_query() {
+        let g = tiny_graph();
+        let cfg = NlqConfig {
+            check_dictionary: false,
+            max_repair_rounds: 0,
+            ..NlqConfig::default()
+        };
+        let nlq = Nlq::with_config(
+            &g,
+            Box::new(FnLlm(|_| {
+                Ok("```sparql\nPREFIX ex: <http://example.org/>\n\
+                    SELECT ?s WHERE { ?s ex:know ?o }\n```"
+                    .to_string())
+            })),
+            cfg,
+        );
+        let a = nlq
+            .ask("Who knows whom?")
+            .expect("accepted without the dict check");
+        assert_eq!(a.repairs, 0);
+        assert_eq!(a.result.len(), 0); // ungrounded predicate → empty, but accepted
     }
 }

--- a/skills/genai-retrieval/SKILL.md
+++ b/skills/genai-retrieval/SKILL.md
@@ -128,7 +128,22 @@ Nlq::repair_prompt_for(&self, question, failed_sparql, error) -> String
 (`Some(10s)`, native only), `max_rows` (`Some(1_000_000)`), `examples`
 (two schema-agnostic few-shots), `ground` (`true` — the grounded loop the fixtures
 were recorded under; set `false` for the ungrounded baseline the exec-accuracy
-harness measures grounding against — see below).
+harness measures grounding against — see below), `check_dictionary` (`false` — the
+**N2 dictionary constraint**, bead `sq-9yjp`; see below).
+
+**N2 dictionary constraint** (`sparq_nlq::constrain`, opt-in `check_dictionary`):
+after a query parses, walk its algebra and check every predicate / `rdf:type` class
+IRI against the live dictionary (`Graph::id_of`). An ungrounded IRI matches no triple,
+so it becomes a targeted repair signal (`TurnOutcome::UngroundedTerms`) with
+nearest-namespace did-you-mean suggestions pulled from the store. Off by default: an
+empty-answer question (a valid-but-absent class) must not be "repaired", and the
+exec-accuracy harness measures raw model accuracy with it off. Strict logit-level
+**grammar-constrained decoding** is *not* implemented — it needs logit/grammar access
+the Anthropic Messages API does not expose, so it is only feasible on a local backend
+(`research/genai-nl-to-sparql.md` §11). Public surface:
+`constrain::unknown_terms(graph, &spargebra::Query) -> Vec<UnknownTerm>`,
+`constrain::dictionary_repair_message(&[UnknownTerm]) -> String`,
+`UnknownTerm { iri, role: TermRole, suggestions }`.
 
 `sparq_nlq::eval` — the **exec-accuracy harness** (the design doc's accuracy gate,
 `research/genai-design.md` §4). It grades the *executed* query the QALD way — **answer-set
@@ -340,4 +355,4 @@ the fixtures encode.)
   `sparql-formal-semantics` — the verifiable/private query estate, orthogonal to this
   retrieval surface.
 </skill_md>
-<parameter name="key_apis">["Introspection::build(graph: &Graph) -> Introspection", "Introspection::build_with(graph: &Graph, opts: &BuildOptions) -> Introspection", "Introspection::to_text_summary(&self, budget_chars: usize) -> String", "Introspection::to_json(&self) -> String", "Introspection::to_void(&self, dataset_iri: &str) -> String", "Introspection::schema_summary_for(&self, seeds: &[&str], budget_chars: usize) -> String", "sparq_introspect::characteristic_set_ids(graph: &Graph) -> Vec<CsIdSet>", "trait Llm { fn complete(&self, prompt: &str) -> Result<String, String>; }", "ReplayLlm::from_file / from_json", "RecordingLlm::new(inner) + .save(path)", "live::AnthropicLlm::from_env() / with_model(model)  (feature = \"live\")", "Nlq::new(graph, Box<dyn Llm>) / with_config(graph, llm, NlqConfig)", "Nlq::ask(&self, question: &str) -> Result<Answer, NlqError>", "Nlq::prompt_for / repair_prompt_for (deterministic, for fixtures)", "Answer { sparql, result: QueryResult, repairs, transcript }", "NlqConfig { summary_budget_chars, max_repair_rounds, exec_timeout, max_rows, examples, ground }", "sparq_nlq::eval::EvalCase::new(question, gold_sparql)", "sparq_nlq::eval::run_config(graph, cases, llm, config, Linking) -> Report", "sparq_nlq::eval::run_comparison(graph, cases, base_config, make_llm) -> Comparison", "Comparison::headline_grounding_pays() -> bool / summary() -> String", "F1::score(&AnswerSet, &AnswerSet) -> F1 / is_exact() -> bool ; AnswerSet::from_result(&QueryResult)", "sparq_engine::cs::{CsSet, CsTable}  (sparq-engine feature = \"cs-planner\")"]
+<parameter name="key_apis">["Introspection::build(graph: &Graph) -> Introspection", "Introspection::build_with(graph: &Graph, opts: &BuildOptions) -> Introspection", "Introspection::to_text_summary(&self, budget_chars: usize) -> String", "Introspection::to_json(&self) -> String", "Introspection::to_void(&self, dataset_iri: &str) -> String", "Introspection::schema_summary_for(&self, seeds: &[&str], budget_chars: usize) -> String", "sparq_introspect::characteristic_set_ids(graph: &Graph) -> Vec<CsIdSet>", "trait Llm { fn complete(&self, prompt: &str) -> Result<String, String>; }", "ReplayLlm::from_file / from_json", "RecordingLlm::new(inner) + .save(path)", "live::AnthropicLlm::from_env() / with_model(model)  (feature = \"live\")", "Nlq::new(graph, Box<dyn Llm>) / with_config(graph, llm, NlqConfig)", "Nlq::ask(&self, question: &str) -> Result<Answer, NlqError>", "Nlq::prompt_for / repair_prompt_for (deterministic, for fixtures)", "Answer { sparql, result: QueryResult, repairs, transcript }", "NlqConfig { summary_budget_chars, max_repair_rounds, exec_timeout, max_rows, examples, ground, check_dictionary }", "sparq_nlq::constrain::unknown_terms(graph: &Graph, query: &spargebra::Query) -> Vec<UnknownTerm>", "sparq_nlq::constrain::dictionary_repair_message(unknowns: &[UnknownTerm]) -> String", "sparq_nlq::constrain::UnknownTerm { iri, role: TermRole, suggestions }", "sparq_nlq::eval::EvalCase::new(question, gold_sparql)", "sparq_nlq::eval::run_config(graph, cases, llm, config, Linking) -> Report", "sparq_nlq::eval::run_comparison(graph, cases, base_config, make_llm) -> Comparison", "Comparison::headline_grounding_pays() -> bool / summary() -> String", "F1::score(&AnswerSet, &AnswerSet) -> F1 / is_exact() -> bool ; AnswerSet::from_result(&QueryResult)", "sparq_engine::cs::{CsSet, CsTable}  (sparq-engine feature = \"cs-planner\")"]


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-9yjp** (sparq-nlq: N2 grammar-constrained decoding against the live dictionary).

## What & why

The bead asked for "N2 grammar-constrained decoding against the live dictionary". Strict logit-level grammar-constrained *decoding* (mask the model's logits each step so only grammar-valid tokens are emitted) needs **logit/grammar access**. The crate's only live backend is the Anthropic Messages API, which exposes **neither logit bias nor a grammar parameter** — so the strict variant is **not implementable** here, only on a local/open backend (`research/genai-nl-to-sparql.md` §11). This PR does **not** claim it.

What *is* both achievable and the part the bead literally names — constraining against the **live dictionary** — is the design doc's prescribed API-backend fallback (`research/genai-nl-to-sparql.md` §6): once a candidate query parses, walk its algebra, collect every IRI in **predicate / `rdf:type` class** position, and check each against the live dictionary (`Graph::id_of`). An ungrounded IRI matches no triple — a *valid-but-wrong* query — so it becomes a **targeted repair signal** ("predicate `<…>` not in the dictionary; did you mean `<…>`?") with nearest-namespace edit-distance suggestions pulled from the store itself.

## Changes

- **New `constrain` module** (`crates/sparq-nlq/src/constrain.rs`):
  - `unknown_terms(graph, &spargebra::Query) -> Vec<UnknownTerm>` — algebra walk over BGP / property-path / FILTER-EXISTS / quoted-triple, predicate + `rdf:type`-class positions; de-duplicated, stable order.
  - `dictionary_repair_message(&[UnknownTerm]) -> String` — deterministic repair feedback.
  - `UnknownTerm { iri, role: TermRole, suggestions }`; same-namespace Levenshtein suggestions.
- **Wired into `Nlq::ask`** before execution; new `TurnOutcome::UngroundedTerms(..)` and `NlqConfig::check_dictionary` knob.
- **`check_dictionary` defaults to `false`** — deliberate honesty: a legitimately-empty answer (a valid-but-absent class, e.g. `?r a ex:Robot` over a robot-free graph) must **not** be "repaired"; the exec-accuracy harness measures raw model accuracy with it off. Opt-in, like `ground`.
- Tests (module unit + loop: repair-on-ungrounded-predicate, off-accepts-as-is), README + SKILL updated, honest "Partial (honest scope)" status note replaces the old "not yet wired" line.

## Gate (all green)

- `cargo build` + `clippy --all-targets -- -D warnings` + tests in **both** feature states (default and `--features live`).
- Rustdoc gate: `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` **and** again `--all-features`.
- `scripts/check-privacy-claims.sh`: OK.
- No `unsafe` added (crate is `#![forbid(unsafe_code)]`).
- G2: public API change reflected in `crates/sparq-nlq/README.md` + `skills/genai-retrieval/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)