### PR TITLE
docs(release): honest crates.io registry-publish-signing note (sq-jgt3) [OPUS-4.8]

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -166,6 +166,26 @@ cargo publish -p sparq-server
   PyPI wheels later, see below), and `sparq-wasm` (ships via npm).
 - Publishing is **permanent** (versions can only be yanked, not deleted/reused).
 
+> [OPUS-4.8] **Registry-publish signing (sq-jgt3 / GX-OSSF-2).** Scorecard's `Signed-Releases`
+> is satisfied by the Sigstore SLSA build-provenance over the GitHub-Release archives
+> (`release.yml`) — but that does **not** sign the bytes a consumer installs from a *package
+> registry*. Honest per-registry status:
+>
+> - **crates.io — no first-party signing/provenance scheme exists upstream** (no equivalent of
+>   npm `--provenance` or PyPI PEP-740 attestations). The tractable equivalent we DO ship is an
+>   out-of-band attestation: [`publish.yml`](../.github/workflows/publish.yml)'s `crates` job runs
+>   `cargo package` and attests the resulting `.crate` bytes (identical to what `cargo publish`
+>   uploads) with `actions/attest-build-provenance`. This puts **no** provenance link on the
+>   crates.io page — that needs upstream support — but a consumer who downloads the `.crate` can
+>   `gh attestation verify <file> --repo jeswr/sparq`. The crates.io-native sub-gap stays **OPEN**
+>   (external — see `compliance/openssf/gap-register.md` GX-OSSF-2 / `compliance/gap-register.md`
+>   GX-10). Do **not** describe a crates.io publish as "signed".
+> - **npm `@jeswr/sparq` — native Sigstore provenance** via [`publish.yml`](../.github/workflows/publish.yml)'s
+>   `npm` job (`npm publish --provenance` in the GitHub OIDC context); consumers verify with
+>   `npm audit signatures`.
+> - **PyPI `sparq-rdf` — native PEP-740 attestations** via Trusted Publishing (see the
+>   "Python wheels" section below) once the maintainer registers the Trusted Publisher.
+
 ## 5. Docker (manual / local)
 
 CI does this on tag; to build locally:


### PR DESCRIPTION
> 🤖 SPARQ agent — opened by an automated SPARQ agent on @jeswr's behalf.

## What & why — sq-jgt3 (`[cert][openssf]` registry-publish signing; GX-OSSF-2)

The bead asks to wire **npm provenance + PyPI attestation** into the publish path and **document the crates.io limitation honestly**, raising OpenSSF Best-Practices `delivery_*`/`crypto_*` assurance.

**Honest finding: the CI wiring is already done.** `.github/workflows/publish.yml` already implements all three registry lanes — landed by **sq-toze.24** (#373: `npm publish --provenance` in the GitHub OIDC context + a registry-attestation verification gate; plus the `.crate` `attest-build-provenance` lane for crates.io) and **sq-toze.37** (#428: PyPI PEP-740 attestations via Trusted Publishing, `pypa/gh-action-pypi-publish` `attestations: true` + OIDC). Re-wiring those would be a no-op, so I did not.

The one **repo-actionable gap that remained** under sq-jgt3 is documentation: the crates.io publication section of the release runbook (`docs/release.md` §4) was **silent on registry signing** — a reader could wrongly infer a `cargo publish` is "signed". This PR fixes that.

## Change (docs-only)

Adds a per-registry status note to `docs/release.md` §4 that, honestly:
- **crates.io** — states there is **no first-party signing/provenance scheme upstream**, describes the out-of-band `.crate` `attest-build-provenance` lane (`publish.yml#crates`) as the tractable equivalent, and explicitly says **do not call a crates.io publish "signed"** (native link stays an OPEN external sub-gap).
- **npm** — points to `publish.yml#npm` for native Sigstore provenance (`npm audit signatures`).
- **PyPI** — points to the PEP-740 / Trusted-Publishing lane (maintainer registration still pending).

Cross-references `compliance/openssf/gap-register.md` GX-OSSF-2 and `compliance/gap-register.md` GX-10 — which already track this state — so the runbook and the gap registers agree.

## Honesty / scope
- **No overclaim.** No new "signed" claim is asserted for crates.io; the open external sub-gaps (crates.io native link; PyPI maintainer Trusted-Publisher registration) are documented as still open.
- Docs-only: **no Rust crate, no public API, no `unsafe`** touched — the Rust build/clippy/rustdoc/unsafe gates are N/A.

## Gate (docs surface)
- `scripts/check-privacy-claims.sh` — OK (295 files, no unqualified ZK/MPC claim)
- `markdownlint-cli2` over the doc surface — 0 errors
- `typos` on the file — clean
- `lychee --offline` — 3/3 links OK (the `../.github/workflows/publish.yml` relrefs resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)