### PR TITLE
feat(sparq-engine): opt-in materialised-view / query-result cache (sq-a9cn) [OPUS-4.8]

### DIFF
--- a/crates/sparq-engine/Cargo.toml
+++ b/crates/sparq-engine/Cargo.toml
@@ -89,6 +89,16 @@ window-functions = []
 # Pulls in ZERO new dependencies (sparq-core is already a direct dep) and contains no
 # `unsafe` — the kernels are plain index loops the compiler auto-vectorises.
 vectorized = []
+# [OPUS-4.8] (sq-a9cn) Materialised-view / query-result cache: a bounded, version-aware
+# LRU (`cache::ResultCache`) that stores a SELECT/ASK `QueryResult` keyed by `(parsed
+# query algebra, caller graph-version)`. Vendor-parity operational-perf feature for
+# endpoints that re-serve the same read query against a slowly-changing graph. OPT-IN and
+# OFF by default: when off, zero cache code compiles and the default native + wasm builds
+# are byte-identical. Pulls in ZERO new dependencies (std `HashMap`/`Mutex`/`Arc` only)
+# and contains no `unsafe`. Caching is SOUND only under the documented contract — the
+# caller bumps the version on every mutation, and non-deterministic queries (NOW/RAND/
+# UUID/SERVICE/custom fns, detected by `cache::is_cacheable`) are never stored.
+result-cache = []
 
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io

--- a/crates/sparq-engine/README.md
+++ b/crates/sparq-engine/README.md
@@ -57,6 +57,17 @@ let json = sparq_engine::query_json(&g, "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?
   arguments, numeric `RANGE` offsets, and a computed-expression `PARTITION BY` are inline-deferred
   (use the programmatic API). When the feature is off, zero window/aggregate-registry code compiles and
   the default build is byte-identical (no new deps).
+- **Materialised-view / query-result cache** *(opt-in `result-cache` feature, OFF by default)* —
+  a bounded, version-aware LRU (`cache::ResultCache`) that stores a SELECT/ASK `QueryResult` keyed
+  by `(parsed query algebra, caller graph-version)`, so an endpoint that re-serves the same read
+  query against a slowly-changing graph can replay the materialised result instead of re-executing.
+  **Caching is sound only under a contract**: the caller bumps a `u64` *version* on every mutation
+  (the engine can't observe writes through a borrowed `&Graph`), and the cache **refuses to store
+  non-deterministic queries** — `NOW`/`RAND`/`UUID`/`STRUUID`/`BNODE`, a remote `SERVICE`, or any
+  custom function / aggregate (detected conservatively by `is_cacheable`); those always evaluate
+  fresh. Keying on the parsed algebra makes the cache insensitive to whitespace / comments / prefix
+  spelling. When the feature is off, zero cache code compiles, the default build is byte-identical,
+  and no new dependencies are added (std `HashMap`/`Mutex`/`Arc` only).
 - **`forbid(unsafe_code)`** — the crate contains zero `unsafe`.
 
 ## 📚 Learn more

--- a/crates/sparq-engine/src/cache.rs
+++ b/crates/sparq-engine/src/cache.rs
@@ -1,0 +1,382 @@
+//! [OPUS-4.8] (sq-a9cn) Opt-in materialised-view / query-result cache.
+//!
+//! A SPARQL endpoint that serves the *same* read query repeatedly against a graph
+//! that changes only occasionally (the common operational pattern — dashboards,
+//! popular saved queries, federation sub-queries) can skip re-execution by keeping
+//! the materialised [`QueryResult`] and replaying it. This is the vendor-parity
+//! "query result cache" / "materialised view" feature; it is **OFF by default**
+//! (the `result-cache` Cargo feature) and pulls **zero new dependencies** — when the
+//! feature is off, none of this module compiles and the default build is unchanged.
+//!
+//! # Soundness — the two correctness obligations
+//!
+//! A result cache is only correct if a *hit* is exactly the result a fresh
+//! evaluation would have produced. Two things can break that, and this module
+//! guards both:
+//!
+//! 1. **The graph changed.** The engine evaluates against a borrowed `&Graph` and
+//!    cannot observe mutations through that borrow, so the cache CANNOT detect
+//!    staleness on its own. The caller therefore supplies a monotonically-increasing
+//!    **version token** ([`u64`]) that it bumps on every mutation
+//!    (`apply_delta` / `update` / reload). A cached entry is keyed by
+//!    `(query, version)`; once the version advances, every prior entry is
+//!    unreachable (and reclaimed lazily). This is the standard "the writer owns the
+//!    epoch" contract — the same discipline the snapshot-generation machinery in
+//!    `sparq-core` already uses. A caller that holds an immutable graph snapshot can
+//!    simply pass a constant version for that snapshot's lifetime.
+//!
+//! 2. **The query is non-deterministic.** `NOW()`, `RAND()`, `UUID()`, `STRUUID()`,
+//!    `BNODE()`, a remote `SERVICE`, or any custom (`<iri>`) function / aggregate can
+//!    return a different value on each evaluation *even for an unchanged graph*, so
+//!    caching their result would be observably wrong. The cache refuses to store such
+//!    queries: [`is_cacheable`] walks the algebra and returns `false`, and
+//!    [`ResultCache::get_or_eval`] then always evaluates fresh and never inserts.
+//!    Determinism is conservative — anything the walker is unsure about is treated as
+//!    non-cacheable.
+//!
+//! Only SELECT and ASK forms are cached (the [`QueryResult`]-valued surface);
+//! CONSTRUCT / DESCRIBE go through a different return type and are out of scope here.
+//!
+//! # Eviction
+//!
+//! The cache is a bounded LRU keyed on the parsed [`Query`] algebra (whitespace- and
+//! comment-independent — two textually-different spellings of the same query share an
+//! entry). When it is full, the least-recently-used entry is dropped. Entries from a
+//! superseded version are removed opportunistically on insert, so a long-lived cache
+//! never accumulates stale generations.
+
+use crate::{exec, QueryBudget, QueryResult};
+use spargebra::algebra::{
+    AggregateExpression, AggregateFunction, Expression, Function, GraphPattern, OrderExpression,
+};
+use spargebra::Query;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Whether a query's result may be cached without violating the soundness contract
+/// in the [module docs](self) — i.e. it is **deterministic** for a fixed graph.
+///
+/// Returns `false` (conservatively) when the algebra contains any value-producing
+/// construct that can differ between two evaluations of the same query against the
+/// same data: `NOW`, `RAND`, `UUID`, `STRUUID`, `BNODE`, a remote `SERVICE`, or any
+/// custom function / custom aggregate (whose Rust closure the engine cannot prove
+/// deterministic). Everything else — BGPs, joins, OPTIONAL, UNION, MINUS, FILTER over
+/// the built-in deterministic functions, GROUP BY with the standard aggregates,
+/// ORDER BY, projection, DISTINCT, LIMIT/OFFSET, VALUES — is cacheable.
+///
+/// Only the SELECT / ASK forms are considered; CONSTRUCT / DESCRIBE return `false`
+/// because the cache stores [`QueryResult`], not a triple set.
+pub fn is_cacheable(query: &Query) -> bool {
+    match query {
+        Query::Select { pattern, .. } | Query::Ask { pattern, .. } => {
+            pattern_is_deterministic(pattern)
+        }
+        // Graph-valued forms are not stored by this cache.
+        Query::Construct { .. } | Query::Describe { .. } => false,
+    }
+}
+
+fn pattern_is_deterministic(p: &GraphPattern) -> bool {
+    match p {
+        GraphPattern::Bgp { .. } | GraphPattern::Path { .. } | GraphPattern::Values { .. } => true,
+        // A remote SERVICE is time-varying and outside our data — never cache.
+        GraphPattern::Service { .. } => false,
+        GraphPattern::Join { left, right }
+        | GraphPattern::Union { left, right }
+        | GraphPattern::Minus { left, right } => {
+            pattern_is_deterministic(left) && pattern_is_deterministic(right)
+        }
+        // `Lateral` (SEP-0006) is unconditionally present — the workspace enables
+        // spargebra's `sep-0006`, which is a spargebra feature, not one of ours.
+        GraphPattern::Lateral { left, right } => {
+            pattern_is_deterministic(left) && pattern_is_deterministic(right)
+        }
+        GraphPattern::LeftJoin {
+            left,
+            right,
+            expression,
+        } => {
+            pattern_is_deterministic(left)
+                && pattern_is_deterministic(right)
+                && expression
+                    .as_ref()
+                    .map(expr_is_deterministic)
+                    .unwrap_or(true)
+        }
+        GraphPattern::Filter { expr, inner } => {
+            expr_is_deterministic(expr) && pattern_is_deterministic(inner)
+        }
+        GraphPattern::Graph { inner, .. }
+        | GraphPattern::Distinct { inner }
+        | GraphPattern::Reduced { inner }
+        | GraphPattern::Project { inner, .. }
+        | GraphPattern::Slice { inner, .. } => pattern_is_deterministic(inner),
+        GraphPattern::Extend {
+            inner, expression, ..
+        } => pattern_is_deterministic(inner) && expr_is_deterministic(expression),
+        GraphPattern::OrderBy { inner, expression } => {
+            pattern_is_deterministic(inner)
+                && expression.iter().all(|o| {
+                    let (OrderExpression::Asc(e) | OrderExpression::Desc(e)) = o;
+                    expr_is_deterministic(e)
+                })
+        }
+        GraphPattern::Group {
+            inner, aggregates, ..
+        } => {
+            pattern_is_deterministic(inner)
+                && aggregates
+                    .iter()
+                    .all(|(_, a)| aggregate_is_deterministic(a))
+        }
+    }
+}
+
+fn aggregate_is_deterministic(a: &AggregateExpression) -> bool {
+    match a {
+        AggregateExpression::CountSolutions { .. } => true,
+        AggregateExpression::FunctionCall { name, expr, .. } => {
+            // A custom aggregate's closure is opaque — refuse it. The standard
+            // aggregates (incl. SAMPLE, which is implementation-defined but stable
+            // for a fixed input on a fixed engine) are fine.
+            !matches!(name, AggregateFunction::Custom(_)) && expr_is_deterministic(expr)
+        }
+    }
+}
+
+fn expr_is_deterministic(e: &Expression) -> bool {
+    match e {
+        Expression::NamedNode(_)
+        | Expression::Literal(_)
+        | Expression::Variable(_)
+        | Expression::Bound(_) => true,
+        Expression::Or(a, b)
+        | Expression::And(a, b)
+        | Expression::Equal(a, b)
+        | Expression::SameTerm(a, b)
+        | Expression::Greater(a, b)
+        | Expression::GreaterOrEqual(a, b)
+        | Expression::Less(a, b)
+        | Expression::LessOrEqual(a, b)
+        | Expression::Add(a, b)
+        | Expression::Subtract(a, b)
+        | Expression::Multiply(a, b)
+        | Expression::Divide(a, b) => expr_is_deterministic(a) && expr_is_deterministic(b),
+        Expression::UnaryPlus(a) | Expression::UnaryMinus(a) | Expression::Not(a) => {
+            expr_is_deterministic(a)
+        }
+        Expression::In(a, list) => {
+            expr_is_deterministic(a) && list.iter().all(expr_is_deterministic)
+        }
+        Expression::If(a, b, c) => {
+            expr_is_deterministic(a) && expr_is_deterministic(b) && expr_is_deterministic(c)
+        }
+        Expression::Coalesce(list) => list.iter().all(expr_is_deterministic),
+        // EXISTS evaluates an inner pattern — a SERVICE or non-deterministic call in
+        // there would taint the result, so recurse.
+        Expression::Exists(inner) => pattern_is_deterministic(inner),
+        Expression::FunctionCall(func, args) => {
+            function_is_deterministic(func) && args.iter().all(expr_is_deterministic)
+        }
+    }
+}
+
+fn function_is_deterministic(f: &Function) -> bool {
+    !matches!(
+        f,
+        // Value-producing, evaluation-varying builtins.
+        Function::Now
+            | Function::Rand
+            | Function::Uuid
+            | Function::StrUuid
+            // BNODE() mints a fresh blank node; not safe to replay verbatim.
+            | Function::BNode
+            // A custom (`<iri>`) extension function's closure is opaque to us.
+            | Function::Custom(_)
+    )
+}
+
+/// The cache key: the parsed query algebra paired with the caller's graph version.
+///
+/// Keying on [`Query`] (which is `Eq + Hash`) rather than the raw SPARQL string makes
+/// the cache insensitive to whitespace, comments and prefix spelling — two textual
+/// forms that parse to the same algebra share one entry.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct Key {
+    version: u64,
+    query: Query,
+}
+
+struct Entry {
+    result: Arc<QueryResult>,
+    /// Monotonic access stamp for LRU eviction.
+    last_used: u64,
+}
+
+/// A bounded, version-aware SPARQL result cache (a materialised-view store).
+///
+/// Construct with [`ResultCache::new`], then serve queries through
+/// [`get_or_eval`](ResultCache::get_or_eval), passing the current graph **version**
+/// (see the [soundness contract](self)). The cache is `Send + Sync` (it locks an
+/// internal map) so it can be shared across request threads behind an
+/// [`Arc`].
+pub struct ResultCache {
+    inner: Mutex<Inner>,
+    capacity: usize,
+}
+
+struct Inner {
+    map: HashMap<Key, Entry>,
+    /// Monotonic clock for LRU stamps.
+    clock: u64,
+    hits: u64,
+    misses: u64,
+}
+
+/// A point-in-time snapshot of cache counters, returned by [`ResultCache::stats`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CacheStats {
+    /// Number of [`get_or_eval`](ResultCache::get_or_eval) calls served from a stored entry.
+    pub hits: u64,
+    /// Number of calls that had to evaluate (a miss or a non-cacheable query).
+    pub misses: u64,
+    /// Number of entries currently resident.
+    pub entries: usize,
+}
+
+impl ResultCache {
+    /// A cache holding at most `capacity` distinct cacheable results (LRU eviction).
+    /// A `capacity` of 0 disables storage: every call evaluates fresh (useful to
+    /// keep the call-site uniform while turning the cache off at runtime).
+    pub fn new(capacity: usize) -> Self {
+        ResultCache {
+            inner: Mutex::new(Inner {
+                map: HashMap::new(),
+                clock: 0,
+                hits: 0,
+                misses: 0,
+            }),
+            capacity,
+        }
+    }
+
+    /// Returns the cached result for `query` at `version`, evaluating and storing it
+    /// on a miss. A non-cacheable query (see [`is_cacheable`]) is always evaluated
+    /// fresh and never stored — the result is still returned, so the call-site can
+    /// route every read query through the cache unconditionally.
+    ///
+    /// `version` is the caller's graph epoch (bumped on every mutation); a hit is
+    /// returned only for the *current* version, so a stale generation can never be
+    /// served. The returned [`Arc`] shares the stored result — clone it freely.
+    pub fn get_or_eval(
+        &self,
+        graph: &sparq_core::Graph,
+        query: &Query,
+        version: u64,
+        budget: &QueryBudget,
+    ) -> Result<Arc<QueryResult>, String> {
+        if !is_cacheable(query) || self.capacity == 0 {
+            // Evaluate without touching the store; count it as a miss.
+            let r = eval(graph, query, budget)?;
+            let mut inner = self.inner.lock().expect("result-cache mutex poisoned");
+            inner.misses += 1;
+            return Ok(Arc::new(r));
+        }
+
+        let key = Key {
+            version,
+            query: query.clone(),
+        };
+
+        // Fast path: a hit at the current version.
+        {
+            let mut inner = self.inner.lock().expect("result-cache mutex poisoned");
+            inner.clock += 1;
+            let now = inner.clock;
+            if let Some(e) = inner.map.get_mut(&key) {
+                e.last_used = now;
+                let r = Arc::clone(&e.result);
+                inner.hits += 1;
+                return Ok(r);
+            }
+        }
+
+        // Miss: evaluate OUTSIDE the lock so concurrent queries are not serialised.
+        let result = Arc::new(eval(graph, query, budget)?);
+
+        let mut inner = self.inner.lock().expect("result-cache mutex poisoned");
+        inner.misses += 1;
+        // Drop any entry from a superseded version (the writer advanced the epoch).
+        inner.map.retain(|k, _| k.version == version);
+        inner.clock += 1;
+        let now = inner.clock;
+        // Evict LRU if at capacity (and this is a genuinely new key).
+        if inner.map.len() >= self.capacity && !inner.map.contains_key(&key) {
+            if let Some(lru) = inner
+                .map
+                .iter()
+                .min_by_key(|(_, e)| e.last_used)
+                .map(|(k, _)| k.clone())
+            {
+                inner.map.remove(&lru);
+            }
+        }
+        inner.map.insert(
+            key,
+            Entry {
+                result: Arc::clone(&result),
+                last_used: now,
+            },
+        );
+        Ok(result)
+    }
+
+    /// Drops every stored entry (keeps the configured capacity). A coarse alternative
+    /// to bumping the version when the caller cannot thread an epoch through.
+    pub fn clear(&self) {
+        let mut inner = self.inner.lock().expect("result-cache mutex poisoned");
+        inner.map.clear();
+    }
+
+    /// Hit / miss counters and resident-entry count.
+    pub fn stats(&self) -> CacheStats {
+        let inner = self.inner.lock().expect("result-cache mutex poisoned");
+        CacheStats {
+            hits: inner.hits,
+            misses: inner.misses,
+            entries: inner.map.len(),
+        }
+    }
+
+    /// The configured maximum number of resident entries.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+}
+
+/// Evaluate one SELECT / ASK query to a [`QueryResult`], mirroring
+/// [`crate::query_prepared_with_budget`] (the dataset / base / budget wiring) so a
+/// cached result is identical to the uncached path.
+fn eval(
+    graph: &sparq_core::Graph,
+    query: &Query,
+    budget: &QueryBudget,
+) -> Result<QueryResult, String> {
+    let active = crate::active_dataset(graph, query);
+    let graph = active.as_ref().unwrap_or(graph);
+    let _view_scope = crate::view_scope(&active);
+    let _guard = exec::budget::install(budget);
+    exec::set_query_base(query.base_iri().map(|b| b.as_str()));
+    match query {
+        Query::Select { pattern, .. } => exec::eval_select(graph, pattern),
+        Query::Ask { pattern, .. } => Ok(QueryResult {
+            vars: Vec::new(),
+            rows: if exec::eval_ask(graph, pattern)? {
+                vec![Vec::new()]
+            } else {
+                Vec::new()
+            },
+        }),
+        _ => Err("result cache only stores SELECT and ASK queries".into()),
+    }
+}

--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -1,6 +1,11 @@
 #![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 
+// [OPUS-4.8] (sq-a9cn) Opt-in materialised-view / query-result cache. NON-DEFAULT
+// `result-cache` feature — when off, zero cache code compiles and the default native +
+// wasm builds are byte-identical (no new deps).
+#[cfg(feature = "result-cache")]
+pub mod cache;
 mod construct;
 #[cfg(feature = "cs-planner")]
 pub mod cs;
@@ -205,6 +210,10 @@ pub use aggregate::{
 };
 #[cfg(feature = "window-functions")]
 pub use window_syntax::{query_over, query_over_with_budget};
+// [OPUS-4.8] (sq-a9cn) Materialised-view / query-result cache re-exports (NON-DEFAULT
+// `result-cache` feature).
+#[cfg(feature = "result-cache")]
+pub use cache::{is_cacheable, CacheStats, ResultCache};
 
 // [OPUS-4.8] (sq-hvfe) Vectorized (columnar / vector-at-a-time) execution primitives —
 // the first building block of the M4 plan (research/optimization-techniques.md). NON-DEFAULT
@@ -418,7 +427,7 @@ pub fn ask_view_with_budget(v: &DatasetView, sparql: &str, budget: &QueryBudget)
 /// [`dataset::build_active`]. `None` (the common case) means: evaluate against
 /// the store itself. Every query entry point calls this once after parsing, so
 /// the no-clause path costs exactly one `Option` check.
-fn active_dataset(graph: &Graph, q: &Query) -> Option<Graph> {
+pub(crate) fn active_dataset(graph: &Graph, q: &Query) -> Option<Graph> {
     q.dataset().map(|ds| dataset::build_active(graph, ds))
 }
 

--- a/crates/sparq-engine/tests/result_cache.rs
+++ b/crates/sparq-engine/tests/result_cache.rs
@@ -1,0 +1,233 @@
+//! [OPUS-4.8] (sq-a9cn) Materialised-view / query-result cache tests.
+//!
+//! Only built under the opt-in `result-cache` feature; the whole file is empty
+//! otherwise so the default `cargo test` is unaffected.
+#![cfg(feature = "result-cache")]
+
+use sparq_core::Graph;
+use sparq_engine::PreparedQuery;
+use sparq_engine::{is_cacheable, query, QueryBudget, ResultCache};
+
+const DATA: &str = r#"@prefix ex: <http://ex/> .
+    ex:a ex:p 1 . ex:b ex:p 2 . ex:c ex:p 3 .
+"#;
+
+fn g() -> Graph {
+    Graph::load_str(DATA, "turtle").unwrap()
+}
+
+fn parse(q: &str) -> spargebra::Query {
+    PreparedQuery::parse(q).unwrap().into_query()
+}
+
+/// A hit returns the SAME result a fresh evaluation would, and is counted as a hit.
+#[test]
+fn hit_matches_fresh_eval_and_counts() {
+    let graph = g();
+    let cache = ResultCache::new(16);
+    let q = parse("PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:p ?o } ORDER BY ?o");
+    let budget = QueryBudget::unlimited();
+
+    let fresh = query(
+        &graph,
+        "PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:p ?o } ORDER BY ?o",
+    )
+    .unwrap();
+
+    let first = cache.get_or_eval(&graph, &q, 0, &budget).unwrap();
+    let second = cache.get_or_eval(&graph, &q, 0, &budget).unwrap();
+
+    // Same row count + same bound terms as the uncached path.
+    assert_eq!(first.rows.len(), fresh.rows.len());
+    assert_eq!(first.vars, fresh.vars);
+    for (a, b) in first.rows.iter().zip(fresh.rows.iter()) {
+        assert_eq!(a, b);
+    }
+    // The two cached reads are the SAME Arc (a genuine hit, not a re-eval).
+    assert!(std::sync::Arc::ptr_eq(&first, &second));
+
+    let stats = cache.stats();
+    assert_eq!(stats.misses, 1, "first call is a miss");
+    assert_eq!(stats.hits, 1, "second call is a hit");
+    assert_eq!(stats.entries, 1);
+}
+
+/// Whitespace / comment / prefix-spelling differences collapse to one entry
+/// (keyed on the parsed algebra, not the source string).
+#[test]
+fn textual_variants_share_one_entry() {
+    let graph = g();
+    let cache = ResultCache::new(16);
+    let budget = QueryBudget::unlimited();
+    let a = parse("PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:p ?o }");
+    let b = parse("PREFIX foo: <http://ex/>\n# a comment\nSELECT   ?s WHERE {?s foo:p ?o}");
+
+    cache.get_or_eval(&graph, &a, 0, &budget).unwrap();
+    cache.get_or_eval(&graph, &b, 0, &budget).unwrap();
+
+    let stats = cache.stats();
+    assert_eq!(stats.hits, 1, "the second spelling hits the first's entry");
+    assert_eq!(stats.entries, 1);
+}
+
+/// A version bump invalidates: the new version misses, and the stale generation
+/// is reclaimed (no unbounded growth across epochs).
+#[test]
+fn version_bump_invalidates() {
+    let graph = g();
+    let cache = ResultCache::new(16);
+    let budget = QueryBudget::unlimited();
+    let q = parse("PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:p ?o }");
+
+    cache.get_or_eval(&graph, &q, 0, &budget).unwrap();
+    assert_eq!(cache.stats().entries, 1);
+    // Advance the epoch (as a writer would after a mutation).
+    cache.get_or_eval(&graph, &q, 1, &budget).unwrap();
+    let stats = cache.stats();
+    assert_eq!(stats.misses, 2, "the new version is a miss");
+    assert_eq!(stats.hits, 0);
+    assert_eq!(stats.entries, 1, "the stale v0 entry was reclaimed");
+}
+
+/// A version bump after a real mutation serves the UPDATED result, never the stale one.
+#[test]
+fn updated_graph_after_version_bump_is_fresh() {
+    let mut graph = g();
+    let cache = ResultCache::new(16);
+    let budget = QueryBudget::unlimited();
+    let q = parse("SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?o }");
+
+    let before = cache.get_or_eval(&graph, &q, 0, &budget).unwrap();
+    let n_before = before.rows[0][0].as_ref().unwrap().to_string();
+
+    graph
+        .apply_delta_nquads(
+            "<http://ex/d> <http://ex/p> \"4\"^^<http://www.w3.org/2001/XMLSchema#integer> .",
+            "",
+        )
+        .unwrap();
+
+    // Same version => STALE hit (caller bug we deliberately demonstrate is possible).
+    let stale = cache.get_or_eval(&graph, &q, 0, &budget).unwrap();
+    assert_eq!(stale.rows[0][0].as_ref().unwrap().to_string(), n_before);
+
+    // Bumped version => fresh count.
+    let fresh = cache.get_or_eval(&graph, &q, 1, &budget).unwrap();
+    let n_fresh = fresh.rows[0][0].as_ref().unwrap().to_string();
+    assert_ne!(
+        n_fresh, n_before,
+        "after a mutation + version bump the count changed"
+    );
+}
+
+/// Non-deterministic queries are never cached: each call re-evaluates and the store
+/// stays empty.
+#[test]
+fn non_deterministic_not_cached() {
+    let graph = g();
+    let cache = ResultCache::new(16);
+    let budget = QueryBudget::unlimited();
+
+    for src in [
+        "SELECT (NOW() AS ?x) WHERE {}",
+        "SELECT (RAND() AS ?x) WHERE {}",
+        "SELECT (UUID() AS ?x) WHERE {}",
+        "SELECT (STRUUID() AS ?x) WHERE {}",
+        "SELECT (BNODE() AS ?x) WHERE {}",
+    ] {
+        let q = parse(src);
+        assert!(!is_cacheable(&q), "{src} must be classified non-cacheable");
+        cache.get_or_eval(&graph, &q, 0, &budget).unwrap();
+    }
+    assert_eq!(
+        cache.stats().entries,
+        0,
+        "no non-deterministic query was stored"
+    );
+    assert_eq!(cache.stats().hits, 0);
+}
+
+/// A deterministic query with a non-deterministic sub-expression (e.g. inside a
+/// FILTER) is also refused.
+#[test]
+fn non_determinism_inside_filter_refused() {
+    let q = parse("SELECT ?s WHERE { ?s ?p ?o FILTER(?o > RAND()) }");
+    assert!(!is_cacheable(&q));
+    // A plain deterministic FILTER is fine.
+    let ok = parse("SELECT ?s WHERE { ?s ?p ?o FILTER(?o > 1) }");
+    assert!(is_cacheable(&ok));
+}
+
+/// Standard aggregates, ORDER BY, DISTINCT, UNION, OPTIONAL, VALUES, ASK are cacheable.
+#[test]
+fn standard_forms_are_cacheable() {
+    for src in [
+        "SELECT DISTINCT ?o WHERE { ?s ?p ?o }",
+        "SELECT (SUM(?o) AS ?t) WHERE { ?s ?p ?o }",
+        "SELECT ?s WHERE { { ?s ?p 1 } UNION { ?s ?p 2 } }",
+        "SELECT ?s ?o2 WHERE { ?s ?p ?o OPTIONAL { ?s ?p2 ?o2 } }",
+        "SELECT ?x WHERE { VALUES ?x { 1 2 3 } }",
+        "ASK { ?s ?p ?o }",
+    ] {
+        assert!(is_cacheable(&parse(src)), "{src} should be cacheable");
+    }
+}
+
+/// SERVICE (remote, time-varying) and CONSTRUCT/DESCRIBE are not cacheable.
+#[test]
+fn service_and_graph_forms_refused() {
+    assert!(!is_cacheable(&parse(
+        "SELECT * WHERE { SERVICE <http://example.org/sparql> { ?s ?p ?o } }"
+    )));
+    assert!(!is_cacheable(&parse(
+        "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }"
+    )));
+    assert!(!is_cacheable(&parse("DESCRIBE ?s WHERE { ?s ?p ?o }")));
+}
+
+/// Capacity 0 disables storage; an over-capacity cache evicts the LRU entry.
+#[test]
+fn eviction_and_disabled() {
+    let graph = g();
+    let budget = QueryBudget::unlimited();
+
+    let off = ResultCache::new(0);
+    let q = parse("SELECT ?s WHERE { ?s ?p ?o }");
+    off.get_or_eval(&graph, &q, 0, &budget).unwrap();
+    off.get_or_eval(&graph, &q, 0, &budget).unwrap();
+    assert_eq!(off.stats().entries, 0);
+    assert_eq!(off.stats().hits, 0, "capacity-0 never hits");
+
+    let cache = ResultCache::new(2);
+    let q1 = parse("SELECT ?s WHERE { ?s ?p 1 }");
+    let q2 = parse("SELECT ?s WHERE { ?s ?p 2 }");
+    let q3 = parse("SELECT ?s WHERE { ?s ?p 3 }");
+    cache.get_or_eval(&graph, &q1, 0, &budget).unwrap();
+    cache.get_or_eval(&graph, &q2, 0, &budget).unwrap();
+    // Touch q1 so q2 becomes the LRU.
+    cache.get_or_eval(&graph, &q1, 0, &budget).unwrap();
+    cache.get_or_eval(&graph, &q3, 0, &budget).unwrap(); // evicts q2
+    assert_eq!(cache.stats().entries, 2);
+    // q1 still resident (hit), q2 evicted (miss again).
+    let h0 = cache.stats().hits;
+    cache.get_or_eval(&graph, &q1, 0, &budget).unwrap();
+    assert_eq!(cache.stats().hits, h0 + 1, "q1 survived eviction");
+    let m0 = cache.stats().misses;
+    cache.get_or_eval(&graph, &q2, 0, &budget).unwrap();
+    assert_eq!(cache.stats().misses, m0 + 1, "q2 was evicted, so it misses");
+}
+
+/// `clear` empties the store but keeps capacity.
+#[test]
+fn clear_empties() {
+    let graph = g();
+    let budget = QueryBudget::unlimited();
+    let cache = ResultCache::new(4);
+    cache
+        .get_or_eval(&graph, &parse("SELECT ?s WHERE { ?s ?p ?o }"), 0, &budget)
+        .unwrap();
+    assert_eq!(cache.stats().entries, 1);
+    cache.clear();
+    assert_eq!(cache.stats().entries, 0);
+    assert_eq!(cache.capacity(), 4);
+}

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -375,6 +375,33 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   wired into the query evaluator — `query`/`query_json`/etc. are unchanged whether the feature is on
   or off. When off, zero columnar code compiles and the default native + wasm builds are
   byte-identical (no new dependencies; no `unsafe`).
+- **Materialised-view / query-result cache** is the non-default `result-cache` cargo feature (bead
+  `sq-a9cn`): `ResultCache::new(capacity)` is a bounded, version-aware LRU that stores a SELECT/ASK
+  `QueryResult` keyed by `(parsed query algebra, caller graph-version)`; serve a query through
+  `cache.get_or_eval(&graph, &query, version, &budget)` (returns an `Arc<QueryResult>`). It re-serves
+  the same read query against a slowly-changing graph without re-executing. **Soundness contract**:
+  the engine evaluates against a borrowed `&Graph` and can't see mutations, so the **caller bumps the
+  `u64` version on every mutation** (`apply_delta`/`update`/reload) — a hit is only returned for the
+  current version. **Non-deterministic queries are never stored** — `NOW`/`RAND`/`UUID`/`STRUUID`/
+  `BNODE`, a remote `SERVICE`, or any custom function / aggregate; `is_cacheable(&query)` reports this
+  conservatively, and `get_or_eval` evaluates those fresh every time. Keying on the parsed algebra
+  makes the cache insensitive to whitespace / comments / prefix spelling. `cache.stats()` exposes
+  hit/miss/entry counts; `cache.clear()` drops all entries. When off, zero cache code compiles, the
+  default build is byte-identical, and no new dependencies are added.
+
+  ```rust
+  // Cargo.toml: sparq-engine = { version = "0.1", features = ["result-cache"] }
+  use sparq_engine::{PreparedQuery, QueryBudget, ResultCache};
+  let cache = ResultCache::new(256);          // up to 256 distinct results, LRU
+  let q = PreparedQuery::parse("SELECT ?s WHERE { ?s ?p ?o }")?.into_query();
+  let mut version = 0u64;
+  let r1 = cache.get_or_eval(&graph, &q, version, &QueryBudget::unlimited())?; // miss
+  let r2 = cache.get_or_eval(&graph, &q, version, &QueryBudget::unlimited())?; // hit (same Arc)
+  // ... mutate the graph, then bump the epoch so the next read re-evaluates:
+  version += 1;
+  let r3 = cache.get_or_eval(&graph, &q, version, &QueryBudget::unlimited())?; // miss (fresh)
+  # Ok::<(), String>(())
+  ```
 - **Default cargo features** (`parallel`, `regex`, `digest`): `regex` powers REGEX/REPLACE; `digest`
   powers MD5/SHA*; `parallel` enables rayon scan/join/sort/aggregate. The **wasm** crate
   (`sparq-wasm`) disables defaults, so on `wasm32-unknown-unknown` REGEX/hash builtins and


### PR DESCRIPTION
> 🤖 **SPARQL agent** — automated change by a SPARQL agent on @jeswr's account.

Implements bead **sq-a9cn** — vendor-parity *materialised view / query-result cache*, as an **opt-in** feature (not core).

## What

A new non-default `result-cache` cargo feature adds `cache::ResultCache`: a bounded, version-aware LRU that stores a SELECT/ASK `QueryResult` keyed by `(parsed query algebra, caller graph-version)`. An endpoint re-serving the same read query against a slowly-changing graph can replay the materialised result instead of re-executing it.

- Keying on the parsed `spargebra::Query` (which is `Eq + Hash`) makes the cache insensitive to whitespace / comments / prefix spelling — two textual spellings of the same query share one entry.
- Public surface (feature-gated only): `ResultCache`, `CacheStats`, `is_cacheable`.

## Soundness contract (the load-bearing part)

A result cache is only correct if a *hit* equals a fresh evaluation. Two failure modes, both guarded:

1. **Staleness.** The engine evaluates against a borrowed `&Graph` and *cannot* observe mutations through that borrow. So the caller supplies a monotonic `u64` **version** that it bumps on every mutation (`apply_delta`/`update`/reload); a hit is returned only for the *current* version, and superseded generations are reclaimed on insert (no unbounded growth across epochs). A test exercises a real mutation + bump and asserts the fresh count is served.
2. **Non-determinism.** `cache::is_cacheable` walks the algebra and **conservatively refuses** `NOW`/`RAND`/`UUID`/`STRUUID`/`BNODE`, a remote `SERVICE`, and any custom function / aggregate (whose closure is opaque). Those always evaluate fresh and are never stored — top-level *and* nested (e.g. inside a FILTER or EXISTS).

CONSTRUCT / DESCRIBE are out of scope (different return type) and report non-cacheable.

## Opt-in / zero-cost-when-off

OFF by default. When off: zero cache code compiles, the default native + wasm builds are byte-identical, and **no new dependencies** are added (std `HashMap`/`Mutex`/`Arc` only). No `unsafe` (`forbid(unsafe_code)` is preserved).

## Docs (G2)

Public API change → updated in the same PR: crate `README.md` feature bullet + `skills/sparql-query/SKILL.md` (feature entry with a runnable example and the soundness contract).

## Gate

- `cargo build` / `cargo clippy --all-targets -- -D warnings` — clean in **both** feature states.
- Tests pass in **both** states: default `sparq-engine` suite, and feature-on (198 lib + 10 new `tests/result_cache.rs` integration tests).
- rustdoc gate (`RUSTDOCFLAGS='-D warnings'`): default, `--features result-cache`, and `--workspace --no-deps --all-features` all clean.
- privacy-claims gate + G2 api→skill gate: pass.
- No `unsafe` added, so the unsafe-gate ratchet does not apply.

(rustfmt is informational in this repo per `.github/workflows/ci.yml`; the new files are `rustfmt --check`-clean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)