### PR TITLE
test(sparq-core): behavioural extsort tests + raise coverage floor 78→90 (sq-j67o) [OPUS-4.8]

### DIFF
--- a/bench/coverage-floor.json
+++ b/bench/coverage-floor.json
@@ -16,7 +16,7 @@
       "note": "test-driver crate: the W3C suites run as the BINARIES (cargo run), so `cargo llvm-cov --package` (which runs cargo test) sees only a few unit tests. Low % is expected; floor 0."
     },
     "sparq-core": {
-      "floor": 78
+      "floor": 90
     },
     "sparq-engine": {
       "floor": 83

--- a/crates/sparq-core/src/extsort.rs
+++ b/crates/sparq-core/src/extsort.rs
@@ -237,3 +237,210 @@ pub fn map_perm(path: &Path) -> io::Result<(memmap2::Mmap, usize)> {
     let n = m.len() / TRIPLE_BYTES;
     Ok((m, n))
 }
+
+#[cfg(test)]
+mod tests {
+    // [OPUS-4.8] sq-j67o — behavioural tests for the out-of-core index build
+    // (spill -> k-way merge -> raw/compressed write). These assert OBSERVABLE
+    // behaviour: that the on-disk permutation is sorted in the requested column
+    // order, that consecutive-equal triples are deduplicated, that the input is
+    // physically split across multiple runs (so the MERGE path — not a single
+    // in-RAM sort — is exercised), that the run files are cleaned up afterwards,
+    // and that the compressed merge tail emits the canonical block archive. Before
+    // this, extsort.rs was only touched transitively by the build pipeline and
+    // sat at the crate's lowest line coverage.
+    use super::*;
+
+    /// A unique scratch directory under the system temp dir; removed on drop so a
+    /// failing assertion does not leak run files. Follows the crate's existing
+    /// `temp_dir().join(pid)` test convention (no extra dev-dependency).
+    struct Scratch(PathBuf);
+    impl Scratch {
+        fn new(tag: &str) -> Self {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static SEQ: AtomicU64 = AtomicU64::new(0);
+            let n = SEQ.fetch_add(1, Ordering::Relaxed);
+            let p = std::env::temp_dir()
+                .join(format!("sparq_extsort_{tag}_{}_{n}", std::process::id()));
+            std::fs::create_dir_all(&p).unwrap();
+            Scratch(p)
+        }
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            std::fs::remove_dir_all(&self.0).ok();
+        }
+    }
+
+    /// Reads a RAW little-endian `[u32;3]` permutation file back into a `Vec`.
+    /// Reads the bytes (no mmap / no `unsafe`) and decodes each 12-byte triple.
+    fn read_raw_perm(path: &Path) -> Vec<[Id; 3]> {
+        let bytes = std::fs::read(path).unwrap();
+        assert_eq!(
+            bytes.len() % TRIPLE_BYTES,
+            0,
+            "perm file is not a whole number of triples"
+        );
+        bytes
+            .chunks_exact(TRIPLE_BYTES)
+            .map(|c| {
+                [
+                    Id::from_le_bytes(c[0..4].try_into().unwrap()),
+                    Id::from_le_bytes(c[4..8].try_into().unwrap()),
+                    Id::from_le_bytes(c[8..12].try_into().unwrap()),
+                ]
+            })
+            .collect()
+    }
+
+    #[test]
+    fn spill_run_on_empty_buffer_is_a_noop() {
+        let tmp = Scratch::new("spill_empty");
+        let mut buf: Vec<[Id; 3]> = Vec::new();
+        let mut runs: Vec<PathBuf> = Vec::new();
+        spill_run(&mut buf, &mut runs, tmp.path()).unwrap();
+        // No run file is created for an empty buffer.
+        assert!(runs.is_empty());
+    }
+
+    #[test]
+    fn spill_run_sorts_and_writes_one_run_then_clears_buffer() {
+        let tmp = Scratch::new("spill_sort");
+        let mut buf: Vec<[Id; 3]> = vec![[3, 0, 0], [1, 0, 0], [2, 0, 0]];
+        let mut runs: Vec<PathBuf> = Vec::new();
+        spill_run(&mut buf, &mut runs, tmp.path()).unwrap();
+        // Buffer is drained, exactly one run file exists, and it is sorted.
+        assert!(buf.is_empty());
+        assert_eq!(runs.len(), 1);
+        assert!(runs[0].exists());
+        assert_eq!(
+            read_raw_perm(&runs[0]),
+            vec![[1, 0, 0], [2, 0, 0], [3, 0, 0]]
+        );
+    }
+
+    #[test]
+    fn external_sort_reorders_into_requested_column_order_and_dedups() {
+        let tmp = Scratch::new("ext_reorder");
+        let out = tmp.path().join("perm.bin");
+        // Triples in SPO terms. Includes an exact duplicate ([5,1,9] twice) and
+        // rows that only sort correctly under the POS order [1,2,0].
+        let input = [
+            [5u32, 1, 9],
+            [1, 3, 2],
+            [5, 1, 9], // dup of row 0
+            [4, 1, 0],
+            [2, 3, 1],
+        ];
+        // Sort by predicate, then object, then subject: order = [1,2,0].
+        let order = [1usize, 2, 0];
+        // chunk = 2 forces 3 runs => the k-way MERGE path (not a single sort) runs.
+        external_sort(input.iter().copied(), order, &out, tmp.path(), 2).unwrap();
+
+        let got = read_raw_perm(&out);
+
+        // Expected: each triple permuted into `order`, deduplicated, fully sorted.
+        let mut expected: Vec<[Id; 3]> = input
+            .iter()
+            .map(|t| [t[order[0]], t[order[1]], t[order[2]]])
+            .collect();
+        expected.sort_unstable();
+        expected.dedup();
+        assert_eq!(got, expected);
+        // Sanity: the duplicate collapsed (5 inputs, 1 dup => 4 rows).
+        assert_eq!(got.len(), 4);
+
+        // Run files were cleaned up — only `out` remains in tmp.
+        let leftover_runs: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with("run"))
+            .collect();
+        assert!(leftover_runs.is_empty(), "run files were not removed");
+    }
+
+    #[test]
+    fn external_sort_on_empty_input_writes_empty_perm() {
+        let tmp = Scratch::new("ext_empty");
+        let out = tmp.path().join("empty.bin");
+        external_sort(std::iter::empty(), [0, 1, 2], &out, tmp.path(), 8).unwrap();
+        assert_eq!(read_raw_perm(&out), Vec::<[Id; 3]>::new());
+    }
+
+    #[test]
+    fn compressed_external_sort_matches_canonical_block_encoding() {
+        let tmp = Scratch::new("ext_cmp");
+        // A larger, repetitive input so the FoR+varint block encoder is exercised
+        // across more than one block and dedup actually fires.
+        let mut input: Vec<[Id; 3]> = Vec::new();
+        for s in 0..40u32 {
+            for p in 0..3u32 {
+                input.push([s, p, s * 7 + p]);
+                input.push([s, p, s * 7 + p]); // every triple duplicated
+            }
+        }
+        let order = [0usize, 1, 2];
+
+        let raw_out = tmp.path().join("raw.bin");
+        let cmp_out = tmp.path().join("cmp.bin");
+        external_sort(input.iter().copied(), order, &raw_out, tmp.path(), 16).unwrap();
+        external_sort_compressed(input.iter().copied(), order, &cmp_out, tmp.path(), 16).unwrap();
+
+        // The raw tail is the ground truth: fully sorted + deduplicated.
+        let raw = read_raw_perm(&raw_out);
+        let mut expected = input.clone();
+        expected.sort_unstable();
+        expected.dedup();
+        assert_eq!(raw, expected);
+        // Every triple was duplicated, so the result is exactly half the input size.
+        assert_eq!(raw.len(), input.len() / 2);
+
+        // The COMPRESSED tail must be byte-identical to encoding those same sorted,
+        // deduplicated rows through the canonical in-RAM `CompressedPerm` encoder —
+        // i.e. the streaming merge-write produced exactly the standard archive, so a
+        // later `from_mmap` would decode it back to `expected`. (Asserting the bytes
+        // avoids re-mapping the file here.)
+        let cmp_bytes = std::fs::read(&cmp_out).unwrap();
+        let mut canonical = Vec::new();
+        crate::compress::CompressedPerm::encode(&expected)
+            .write_to(&mut canonical)
+            .unwrap();
+        assert_eq!(
+            cmp_bytes, canonical,
+            "compressed tail must equal the canonical block encoding"
+        );
+    }
+
+    #[test]
+    fn kway_merge_combines_multiple_presorted_runs() {
+        let tmp = Scratch::new("kway");
+        let mut runs: Vec<PathBuf> = Vec::new();
+        // Two runs whose sorted order interleaves, with a cross-run duplicate.
+        let mut a: Vec<[Id; 3]> = vec![[1, 0, 0], [4, 0, 0], [7, 0, 0]];
+        let mut b: Vec<[Id; 3]> = vec![[2, 0, 0], [4, 0, 0], [9, 0, 0]];
+        spill_run(&mut a, &mut runs, tmp.path()).unwrap();
+        spill_run(&mut b, &mut runs, tmp.path()).unwrap();
+        assert_eq!(runs.len(), 2);
+
+        let out = tmp.path().join("merged.bin");
+        kway_merge(&runs, &out).unwrap();
+        // Interleaved, with the cross-run [4,0,0] duplicate collapsed to one.
+        assert_eq!(
+            read_raw_perm(&out),
+            vec![[1, 0, 0], [2, 0, 0], [4, 0, 0], [7, 0, 0], [9, 0, 0]]
+        );
+    }
+
+    #[test]
+    fn map_perm_reports_the_triple_count() {
+        let tmp = Scratch::new("map_count");
+        let out = tmp.path().join("count.bin");
+        let input = [[1u32, 2, 3], [4, 5, 6], [7, 8, 9]];
+        external_sort(input.iter().copied(), [0, 1, 2], &out, tmp.path(), 8).unwrap();
+        let (_map, n) = map_perm(&out).unwrap();
+        assert_eq!(n, 3);
+    }
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — coverage floor-raise for `sparq-core` (bead **sq-j67o**, part of the test-quality epic). [OPUS-4.8]

## What

`crates/sparq-core/src/extsort.rs` — the out-of-core index BUILD (spill → k-way merge → raw/compressed write) — was the lowest-covered module in `sparq-core` (**68.15% line**) with **no dedicated tests**; it was exercised only transitively by the build pipeline.

This PR adds a behavioural test module that drives the **public** API directly and asserts **observable behaviour** (not vacuous line-touchers, which the adversarial-verify rejects):

- **`spill_run`** — empty buffer is a no-op (no run file); a non-empty buffer is sorted, spilled to one run file, and the buffer is drained.
- **`external_sort`** — triples are permuted into the requested column `order`, fully sorted and consecutive-duplicate-collapsed; a small `chunk` forces **multiple runs** so the k-way **merge** path (not a single in-RAM sort) runs; run files are cleaned up afterwards.
- **`external_sort`** on empty input writes an empty perm.
- **`external_sort_compressed`** — the streaming merge tail is **byte-identical** to the canonical in-RAM `CompressedPerm` block encoding of the same sorted/deduped rows.
- **`kway_merge`** — interleaves multiple presorted runs and collapses a cross-run duplicate.
- **`map_perm`** — reports the triple count of a written perm.

Then ratchets the floor: `bench/coverage-floor.json` `sparq-core` **78 → 90** (`floor = floor(measured) − margin(2)`).

## Measured

| | line % |
|---|---|
| `extsort.rs` | 68.15% → **94.40%** |
| `sparq-core` total | 91.98% → **92.37%** |

(measured `cargo llvm-cov --package sparq-core --features mmap,dict-spill`, the per-commit tier for this crate.)

## Notes / honesty

- **Test-only** change — no public API touched, so no SKILL.md / G2 impact.
- The read helpers parse perm bytes directly (no new `unsafe`), so the **unsafe-count ratchet stays at 45**. A `Scratch` RAII temp dir (no new dev-dependency) follows the crate's existing `temp_dir()+pid` convention.
- The pre-existing `Graph::open` intra-doc-link only resolves under feature-unification; the **CI rustdoc gate** (`cargo doc --workspace --no-deps` and `--all-features`) passes — unchanged by this PR.

## Gate (all pass)

- `cargo build` + `cargo clippy --all-targets -- -D warnings` in **both** feature states (default; `mmap,dict-spill`)
- `cargo test` in **both** feature states (new module: 7/7 pass)
- rustdoc gate: `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` **and** `--all-features`
- `scripts/unsafe-gate.py --check` (45 = snapshot, no rise)
- `scripts/check-privacy-claims.sh` OK
- `scripts/coverage-gate.py --check` passes `sparq-core` at floor 90 vs measured 92.37%

🤖 Generated with [Claude Code](https://claude.com/claude-code)