### PR TITLE
test(sparq-solid): behavioural tests for rewrite + provenance, ratchet coverage floor 84->89 (sq-2xdr) [OPUS-4.8]

### DIFF
--- a/bench/coverage-floor.json
+++ b/bench/coverage-floor.json
@@ -1,6 +1,6 @@
 {
   "_comment": [
-    "[OPUS-4.8] COVERAGE RATCHET (sq-hbg7) \u2014 committed per-crate line-coverage FLOOR, reviewed in diffs exactly like the conformance ratchet counts in .github/workflows/ci.yml. scripts/coverage-gate.py --check FAILS CI when a crate's measured line% drops below its floor.",
+    "[OPUS-4.8] COVERAGE RATCHET (sq-hbg7) \u2014 committed per-crate line-coverage FLOOR, reviewed in diffs exactly like the conformance ratchet counts in .github/workflows/ci.yml. CI runs scripts/coverage-gate.py --check-robust (sq-x4jy): it re-measures ONLY the sub-floor crates up to K=3 times and keeps the per-crate MAX (llvm-cov only undercounts), FAILING only if a crate is STILL below its floor after K independent measurements \u2014 a genuine regression.",
     "Floor = floor(measured) - 2 (min 0): a small margin so run-to-run / toolchain noise never trips the gate. The floor only ever RISES (--seed will not lower it without --allow-lower).",
     "Tiering: the FAST/MEDIUM crates are measured + gated PER-COMMIT; the heavy sparq-vectors 50k recall/diskann tests are EXCLUDED per-commit (measured in the NIGHTLY tier \u2014 see the .github/workflows/ci.yml coverage-nightly job and the per-crate notes below). No crate is silently dropped.",
     "Floors with floor:0 are crates whose llvm-cov line% is a known measurement artifact (see each note) \u2014 they are guarded by the test-PRESENCE gate (bench/coverage-presence.json) instead of the % gate.",
@@ -62,7 +62,7 @@
       "floor": 94
     },
     "sparq-solid": {
-      "floor": 84
+      "floor": 89
     },
     "sparq-text": {
       "floor": 84

--- a/crates/sparq-solid/src/provenance.rs
+++ b/crates/sparq-solid/src/provenance.rs
@@ -91,3 +91,91 @@ impl AccessProvenance {
             .map(|(r, p)| (r.as_str(), p.creator.as_deref(), p.owner.as_deref()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    // [OPUS-4.8] sq-2xdr — behaviour tests for the trusted creator/owner channel. The
+    // `iter()` accessor is `pub(crate)` (consumed by the loader), so it can only be
+    // exercised from an in-crate test, not an integration test.
+    use super::*;
+
+    #[test]
+    fn empty_map_knows_no_creator_or_owner() {
+        // `new()` and `default()` must agree: an empty, fail-closed map.
+        let prov = AccessProvenance::new();
+        assert!(prov.is_empty());
+        assert_eq!(prov.creator("r"), None);
+        assert_eq!(prov.owner("r"), None);
+        assert_eq!(prov.iter().count(), 0);
+    }
+
+    #[test]
+    fn set_creator_and_owner_are_independent_per_resource() {
+        let mut prov = AccessProvenance::new();
+        prov.set_creator("r1", "https://alice.ex/#me");
+        // setting only the creator leaves the owner unknown (fail-closed for OwnerAgent)
+        assert_eq!(prov.creator("r1"), Some("https://alice.ex/#me"));
+        assert_eq!(prov.owner("r1"), None);
+        assert!(!prov.is_empty());
+
+        prov.set_owner("r1", "https://bob.ex/#me");
+        // owner is now set WITHOUT disturbing the creator on the same entry
+        assert_eq!(prov.creator("r1"), Some("https://alice.ex/#me"));
+        assert_eq!(prov.owner("r1"), Some("https://bob.ex/#me"));
+
+        // a second resource carrying only an owner is fully independent
+        prov.set_owner("r2", "https://carol.ex/#me");
+        assert_eq!(prov.creator("r2"), None);
+        assert_eq!(prov.owner("r2"), Some("https://carol.ex/#me"));
+    }
+
+    #[test]
+    fn set_replaces_previous_value() {
+        let mut prov = AccessProvenance::new();
+        prov.set_creator("r1", "https://old.ex/#me");
+        prov.set_creator("r1", "https://new.ex/#me");
+        assert_eq!(prov.creator("r1"), Some("https://new.ex/#me"));
+        prov.set_owner("r1", "https://o1.ex/#me");
+        prov.set_owner("r1", "https://o2.ex/#me");
+        assert_eq!(prov.owner("r1"), Some("https://o2.ex/#me"));
+    }
+
+    #[test]
+    fn iter_yields_every_resource_with_its_optional_facts() {
+        let mut prov = AccessProvenance::new();
+        prov.set_creator("r1", "https://alice.ex/#me");
+        prov.set_owner("r1", "https://alice.ex/#me");
+        prov.set_owner("r2", "https://bob.ex/#me"); // creator unknown
+        prov.set_creator("r3", "https://carol.ex/#me"); // owner unknown
+
+        let mut seen: Vec<(String, Option<String>, Option<String>)> = prov
+            .iter()
+            .map(|(r, c, o)| (r.to_owned(), c.map(str::to_owned), o.map(str::to_owned)))
+            .collect();
+        seen.sort();
+        assert_eq!(
+            seen,
+            vec![
+                (
+                    "r1".to_owned(),
+                    Some("https://alice.ex/#me".to_owned()),
+                    Some("https://alice.ex/#me".to_owned())
+                ),
+                ("r2".to_owned(), None, Some("https://bob.ex/#me".to_owned())),
+                (
+                    "r3".to_owned(),
+                    Some("https://carol.ex/#me".to_owned()),
+                    None
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn impl_into_string_accepts_owned_keys_and_values() {
+        // the `impl Into<String>` bounds accept owned String keys/values, not just &str.
+        let mut prov = AccessProvenance::new();
+        prov.set_creator(String::from("r1"), String::from("https://alice.ex/#me"));
+        assert_eq!(prov.creator("r1"), Some("https://alice.ex/#me"));
+    }
+}

--- a/crates/sparq-solid/tests/rewrite_structural.rs
+++ b/crates/sparq-solid/tests/rewrite_structural.rs
@@ -1,0 +1,273 @@
+//! [OPUS-4.8] sq-2xdr — behavioural tests for the query-rewrite path
+//! ([`sparq_solid::rewrite_for`] / [`sparq_solid::wrap_for_view`]).
+//!
+//! These exercise the recursive `wrap_in_graph` / `wrap_expr` walk over the SPARQL
+//! algebra (the lowest-covered module of the crate): every structural operator must
+//! (a) push each default-graph triple/path pattern under its own `GRAPH ?fresh { … }`
+//! scope, (b) leave patterns already inside a `GRAPH`/`SERVICE` scope alone, and
+//! (c) still produce a query that round-trips through the SPARQL parser. The asserts
+//! are behavioural — that the rewrite preserves authorized-graph scoping semantics —
+//! not vacuous line-touchers.
+
+use oxrdf::NamedNode;
+use sparq_solid::{rewrite_for, wrap_for_view};
+
+const G: &str = "https://pod.ex/notes/n1.ttl";
+
+fn allowed() -> [NamedNode; 1] {
+    [NamedNode::new(G).unwrap()]
+}
+
+/// Every wrapped query must remain a parseable SPARQL query.
+fn assert_reparses(q: &str) {
+    assert!(
+        spargebra::SparqlParser::new().parse_query(q).is_ok(),
+        "rewritten query must reparse:\n{q}"
+    );
+}
+
+/// Count the `GRAPH ?__sgN` wraps the rewrite introduced.
+fn count_wraps(q: &str) -> usize {
+    q.matches("GRAPH ?__sg").count()
+}
+
+/// A UNION's two branches each get their default-graph patterns wrapped.
+#[test]
+fn union_wraps_both_branches() {
+    let q = "SELECT * WHERE { { ?a <urn:p> ?b } UNION { ?c <urn:q> ?d } }";
+    let out = wrap_for_view(q).unwrap();
+    assert_eq!(count_wraps(&out), 2, "each UNION branch wrapped: {out}");
+    assert_reparses(&out);
+}
+
+/// OPTIONAL (LeftJoin) wraps both the required and the optional side.
+#[test]
+fn optional_wraps_both_sides() {
+    let q = "SELECT * WHERE { ?s <urn:p> ?o OPTIONAL { ?s <urn:q> ?x } }";
+    let out = wrap_for_view(q).unwrap();
+    assert_eq!(count_wraps(&out), 2, "required + optional wrapped: {out}");
+    assert_reparses(&out);
+}
+
+/// OPTIONAL with a FILTER condition: the LeftJoin's `expression` branch is walked too.
+#[test]
+fn optional_with_filter_condition_wraps_and_reparses() {
+    let q = "SELECT * WHERE { ?s <urn:p> ?o OPTIONAL { ?s <urn:q> ?x . FILTER(?x > 1) } }";
+    let out = wrap_for_view(q).unwrap();
+    // both triple patterns get wrapped; the LeftJoin expression has no nested EXISTS
+    assert_eq!(count_wraps(&out), 2, "{out}");
+    assert_reparses(&out);
+}
+
+/// MINUS wraps both operands.
+#[test]
+fn minus_wraps_both_operands() {
+    let q = "SELECT * WHERE { ?s <urn:p> ?o MINUS { ?s <urn:bad> ?x } }";
+    let out = wrap_for_view(q).unwrap();
+    assert_eq!(count_wraps(&out), 2, "{out}");
+    assert_reparses(&out);
+}
+
+/// A property-path pattern (one that stays a `Path` algebra node, e.g. a `+` closure)
+/// in the default graph is wrapped as a whole `GRAPH` scope.
+#[test]
+fn property_path_is_wrapped() {
+    let q = "SELECT * WHERE { ?s <urn:p>+ ?o }";
+    let out = wrap_for_view(q).unwrap();
+    assert_eq!(count_wraps(&out), 1, "path wrapped once: {out}");
+    assert_reparses(&out);
+}
+
+/// A path pattern ALREADY inside a GRAPH scope is left untouched (in_graph short-circuit).
+#[test]
+fn property_path_inside_graph_is_left_alone() {
+    let q = "SELECT * WHERE { GRAPH ?g { ?s <urn:p>+ ?o } }";
+    let out = wrap_for_view(q).unwrap();
+    assert_eq!(count_wraps(&out), 0, "no extra wrap inside GRAPH: {out}");
+    // the user's own GRAPH var survives
+    assert!(out.contains("GRAPH ?g"), "{out}");
+    assert_reparses(&out);
+}
+
+/// Patterns inside an explicit GRAPH block are not re-wrapped, but sibling default-graph
+/// patterns still are.
+#[test]
+fn explicit_graph_block_not_rewrapped_siblings_are() {
+    let q = "SELECT * WHERE { ?s <urn:p> ?o . GRAPH ?g { ?s <urn:q> ?x } }";
+    let out = wrap_for_view(q).unwrap();
+    // exactly the one default-graph triple gets an __sg wrap; the GRAPH ?g block is intact
+    assert_eq!(count_wraps(&out), 1, "{out}");
+    assert!(out.contains("GRAPH ?g"), "{out}");
+    assert_reparses(&out);
+}
+
+/// SERVICE blocks are treated like GRAPH scopes: their inner patterns are NOT wrapped
+/// (the remote endpoint owns that scope), but the rewrite still descends without panic.
+#[test]
+fn service_inner_patterns_not_wrapped() {
+    let q =
+        "SELECT * WHERE { ?s <urn:p> ?o . SERVICE <https://remote.ex/sparql> { ?s <urn:q> ?x } }";
+    let out = wrap_for_view(q).unwrap();
+    assert_eq!(count_wraps(&out), 1, "only the local triple wrapped: {out}");
+    assert!(out.contains("SERVICE"), "{out}");
+    assert_reparses(&out);
+}
+
+/// FILTER NOT EXISTS { … } carries a nested pattern; the EXISTS sub-pattern is walked
+/// and its default-graph triple is wrapped.
+#[test]
+fn filter_not_exists_nested_pattern_is_wrapped() {
+    let q = "SELECT * WHERE { ?s <urn:p> ?o FILTER NOT EXISTS { ?s <urn:secret> ?z } }";
+    let out = wrap_for_view(q).unwrap();
+    // the main triple + the EXISTS-nested triple are both wrapped
+    assert_eq!(count_wraps(&out), 2, "outer + EXISTS-nested wrapped: {out}");
+    assert_reparses(&out);
+}
+
+/// A FILTER with a boolean/arithmetic expression tree (And/Or/comparisons/arith/IN/
+/// COALESCE/IF/unary/function-call) must be walked without panic and reparse — even
+/// though those leaves carry no nested pattern to wrap.
+#[test]
+fn filter_rich_expression_tree_reparses() {
+    let q = "SELECT * WHERE { \
+        ?s <urn:p> ?o . \
+        FILTER( (?o > 1 && ?o <= 10) || (?o IN (2, 3) && !BOUND(?x)) ) \
+        FILTER( IF(?o = 5, COALESCE(?x, ?o), -?o + 1) = ?o ) \
+        FILTER( STRLEN(STR(?o)) > 0 ) \
+    }";
+    let out = wrap_for_view(q).unwrap();
+    assert_eq!(
+        count_wraps(&out),
+        1,
+        "only the BGP triple is wrapped: {out}"
+    );
+    assert_reparses(&out);
+}
+
+/// A sub-SELECT (Project) with DISTINCT, ORDER BY, GROUP BY, and LIMIT/OFFSET (Slice)
+/// reaches the Extend/OrderBy/Project/Distinct/Group/Slice arms of the walk.
+#[test]
+fn projection_modifiers_chain_is_walked() {
+    let q = "SELECT ?s (COUNT(?o) AS ?n) WHERE { \
+        { SELECT DISTINCT ?s ?o WHERE { ?s <urn:p> ?o } ORDER BY ?o LIMIT 5 OFFSET 1 } \
+    } GROUP BY ?s";
+    let out = wrap_for_view(q).unwrap();
+    assert_eq!(
+        count_wraps(&out),
+        1,
+        "the inner BGP triple is wrapped once: {out}"
+    );
+    assert_reparses(&out);
+}
+
+/// BIND (Extend) and VALUES (Values) arms are reached; VALUES injects no pattern to wrap.
+#[test]
+fn bind_and_values_arms_are_walked() {
+    let q = "SELECT * WHERE { \
+        VALUES ?v { 1 2 3 } \
+        ?s <urn:p> ?o . \
+        BIND(?o + 1 AS ?o2) \
+    }";
+    let out = wrap_for_view(q).unwrap();
+    assert_eq!(
+        count_wraps(&out),
+        1,
+        "only the triple wrapped, not VALUES: {out}"
+    );
+    assert_reparses(&out);
+}
+
+/// An empty WHERE (empty BGP) is a no-op for the wrap (the `patterns.is_empty()` guard)
+/// and must still reparse.
+#[test]
+fn empty_bgp_is_left_alone() {
+    let q = "ASK WHERE { }";
+    let out = wrap_for_view(q).unwrap();
+    assert_eq!(count_wraps(&out), 0, "{out}");
+    assert_reparses(&out);
+}
+
+/// CONSTRUCT and DESCRIBE go through the same `wrap_query` arms as SELECT/ASK.
+#[test]
+fn construct_and_describe_are_wrapped() {
+    let c = wrap_for_view("CONSTRUCT { ?s <urn:p> ?o } WHERE { ?s <urn:p> ?o }").unwrap();
+    assert_eq!(count_wraps(&c), 1, "{c}");
+    assert_reparses(&c);
+
+    let d = wrap_for_view("DESCRIBE ?s WHERE { ?s <urn:p> ?o }").unwrap();
+    assert_eq!(count_wraps(&d), 1, "{d}");
+    assert_reparses(&d);
+}
+
+/// `rewrite_for` intersects a pre-existing FROM NAMED with the allowed set: a graph the
+/// query names but is NOT authorized is dropped; an authorized one is kept.
+#[test]
+fn rewrite_for_intersects_existing_from_named() {
+    let q = format!(
+        "SELECT * FROM NAMED <{G}> FROM NAMED <https://pod.ex/other.ttl> WHERE {{ ?s <urn:p> ?o }}"
+    );
+    let out = rewrite_for(&q, &allowed()).unwrap();
+    assert!(
+        out.contains(&format!("FROM NAMED <{G}>")),
+        "authorized graph kept: {out}"
+    );
+    assert!(
+        !out.contains("https://pod.ex/other.ttl"),
+        "unauthorized named graph dropped: {out}"
+    );
+    assert_reparses(&out);
+}
+
+/// `rewrite_for` with a pre-existing FROM NAMED that has NO overlap with the allowed set
+/// collapses to the absent sentinel graph (fail-closed).
+#[test]
+fn rewrite_for_disjoint_from_named_falls_to_sentinel() {
+    let q = "SELECT * FROM NAMED <https://pod.ex/other.ttl> WHERE { ?s <urn:p> ?o }";
+    let out = rewrite_for(q, &allowed()).unwrap();
+    assert!(out.contains("FROM NAMED <urn:sparq:nothing>"), "{out}");
+    assert!(!out.contains("https://pod.ex/other.ttl"), "{out}");
+    assert_reparses(&out);
+}
+
+/// A bare FROM (default-graph) clause is dropped — pod data never lives in the store
+/// default graph. spargebra parses `FROM <g>` as a dataset with an EMPTY named set, so
+/// after intersection there are no authorized named graphs and the rewrite fails closed
+/// to the sentinel (it does NOT silently promote the default-graph URI into FROM NAMED).
+#[test]
+fn rewrite_for_drops_default_graph_clause() {
+    let q = format!("SELECT * FROM <{G}> WHERE {{ ?s <urn:p> ?o }}");
+    let out = rewrite_for(&q, &allowed()).unwrap();
+    // the default-graph clause does not survive, and nothing was named, so: sentinel
+    assert!(
+        !out.contains(&format!("FROM <{G}>")),
+        "default-graph FROM dropped: {out}"
+    );
+    assert!(
+        out.contains("FROM NAMED <urn:sparq:nothing>"),
+        "fails closed: {out}"
+    );
+    assert_reparses(&out);
+}
+
+/// The graph-variable prefix lengthens until it cannot collide with ANY user variable —
+/// including the lengthened `?__sgx…` forms.
+#[test]
+fn prefix_lengthens_past_nested_collisions() {
+    // user already uses ?__sg AND ?__sgx — the prefix must grow to ?__sgxx
+    let q = "SELECT ?__sg ?__sgx WHERE { ?__sg <urn:p> ?__sgx . ?a <urn:q> ?b }";
+    let out = wrap_for_view(q).unwrap();
+    assert!(
+        out.contains("GRAPH ?__sgxx"),
+        "prefix grew past collisions: {out}"
+    );
+    assert!(!out.contains("GRAPH ?__sg0"), "{out}");
+    assert!(!out.contains("GRAPH ?__sgx0"), "{out}");
+    assert_reparses(&out);
+}
+
+/// An invalid query is a parse error, surfaced as `Err` (the only failure mode).
+#[test]
+fn invalid_query_is_an_error() {
+    assert!(rewrite_for("NOT SPARQL", &allowed()).is_err());
+    assert!(wrap_for_view("SELECT WHERE oops").is_err());
+}


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-2xdr** (part of test-quality epic sq-qcnn): raise the `sparq-solid` line-coverage floor by adding **real behaviour-asserting tests** for its two lowest-covered modules, then ratchet `bench/coverage-floor.json`.

## Why

`cargo llvm-cov --package sparq-solid` showed the gap concentrated in two modules:

| module | before | after |
| --- | --- | --- |
| `rewrite.rs` | 47.10% lines | 91.30% |
| `provenance.rs` | 57.69% lines | 100.00% |
| **crate total** | **87.84%** | **91.72%** |

The `rewrite.rs` gap was the entire recursive `wrap_in_graph` / `wrap_expr` walk over the SPARQL algebra — exactly the security-relevant code that scopes every default-graph pattern under an authorized-graph `GRAPH` wrap. `provenance.rs` (the trusted creator/owner channel) had no direct unit tests.

## What

- **`tests/rewrite_structural.rs`** (new): drives every structural operator through `wrap_for_view` / `rewrite_for` — UNION, OPTIONAL (+ a FILTER condition exercising the LeftJoin `expression` branch), MINUS, property-path, an already-`GRAPH`-scoped pattern (the `in_graph` short-circuit), an explicit GRAPH block with default-graph siblings, SERVICE (treated as a scope), FILTER NOT EXISTS (nested-pattern walk), a rich FILTER expression tree (And/Or/comparisons/arith/IN/COALESCE/IF/unary/function-call), a sub-SELECT modifier chain (Extend/OrderBy/Project/Distinct/Group/Slice), BIND + VALUES, empty BGP, CONSTRUCT + DESCRIBE; plus `rewrite_for`'s dataset-clause restriction — FROM NAMED intersection, disjoint set → sentinel **fail-closed**, bare FROM dropped → fail-closed, prefix lengthening past nested `?__sg` collisions, and the parse-error path. Each test asserts the GRAPH-wrap **count** and round-trip parseability — behaviour, not line-touching.
- **`src/provenance.rs`**: in-crate tests for `AccessProvenance` (`new`/`default` agreement, per-resource creator/owner independence + replacement, the `pub(crate) iter()` the loader consumes, owned-`String` key/value `Into` bounds). In-crate because `iter()` is `pub(crate)`.
- **`bench/coverage-floor.json`**: `sparq-solid` floor `84 → 89` via `scripts/coverage-gate.py --seed` (floor = floor(91.72) − 2). All other crate floors unchanged.

## Gate

- `cargo build` / `cargo clippy --all-targets -- -D warnings` — clean in **both** feature states (default + `--all-features`).
- `cargo test -p sparq-solid` — pass in **both** feature states (new: 19 rewrite + 5 provenance).
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sparq-solid --no-deps` — clean (default **and** `--all-features`).
- No `unsafe` added; no public API changed (tests + an in-module `#[cfg(test)]` mod only) → no SKILL.md / unsafe-register / privacy-gate impact.
- `coverage-gate.py --check` passes against the new floor (sparq-solid 91.72 ≥ 89).

🤖 Generated with [Claude Code](https://claude.com/claude-code)