### PR TITLE
test(sparq-serve): behavioural tests for lowest-covered modules, ratchet coverage floor 83->92 (sq-fggn) [OPUS-4.8]

### DIFF
--- a/bench/coverage-floor.json
+++ b/bench/coverage-floor.json
@@ -50,7 +50,8 @@
       "floor": 87
     },
     "sparq-serve": {
-      "floor": 83
+      "floor": 92,
+      "note": "[OPUS-4.8] sq-fggn: behavioural tests for the lowest-covered modules (footprint commutativity, scheduler public surface, PodId/WriteError display) lifted measured line% 84.82 -> 94.47; floor = floor(measured) - 2 margin."
     },
     "sparq-server": {
       "floor": 85

--- a/bench/coverage-presence.json
+++ b/bench/coverage-presence.json
@@ -68,7 +68,7 @@
     },
     "sparq-serve": {
       "had_integration_dir": true,
-      "min_tests": 54
+      "min_tests": 78
     },
     "sparq-server": {
       "had_integration_dir": true,

--- a/crates/sparq-serve/tests/error_display.rs
+++ b/crates/sparq-serve/tests/error_display.rs
@@ -1,0 +1,52 @@
+//! [OPUS-4.8] (sq-fggn) The human-readable / identifier contracts that callers
+//! (sparq-server's HTTP layer, logs, metrics) depend on but that the behavioural
+//! writer/ring tests never invoke: `WriteError`'s `Display`/`Error`, and `PodId`'s
+//! `as_str` round-trip plus its `Display`.
+
+use sparq_serve::{PodId, WriteError};
+
+/// Each `WriteError` variant renders a distinct, non-empty message, and the
+/// retryable `Unavailable` is clearly marked retryable (the 503 contract). The
+/// `Rejected`/`Unavailable` payloads are surfaced in the message.
+#[test]
+fn write_error_display_is_distinct_and_carries_payload() {
+    let rejected = format!("{}", WriteError::Rejected("parse failed at line 2".into()));
+    let shutdown = format!("{}", WriteError::Shutdown);
+    let unavailable = format!("{}", WriteError::Unavailable("ENOSPC".into()));
+
+    assert!(
+        rejected.contains("parse failed at line 2"),
+        "got: {rejected}"
+    );
+    assert!(!shutdown.is_empty());
+    assert!(unavailable.contains("ENOSPC"), "got: {unavailable}");
+    assert!(
+        unavailable.to_lowercase().contains("retry"),
+        "Unavailable must signal retryability: {unavailable}"
+    );
+
+    // All three render differently.
+    assert_ne!(rejected, shutdown);
+    assert_ne!(rejected, unavailable);
+    assert_ne!(shutdown, unavailable);
+
+    // It is a real std::error::Error with no nested source.
+    let err: &dyn std::error::Error = &WriteError::Shutdown;
+    assert!(err.source().is_none());
+    assert!(!err.to_string().is_empty());
+}
+
+/// `PodId` round-trips its identifier through `as_str`, and `Display` prints that
+/// same identifier (used in epoch logging / debug output).
+#[test]
+fn pod_id_as_str_and_display_round_trip() {
+    let id = PodId::from("http://pod/alice");
+    assert_eq!(id.as_str(), "http://pod/alice");
+    assert_eq!(format!("{id}"), "http://pod/alice");
+
+    // The other constructors agree.
+    let from_string = PodId::from(String::from("http://pod/bob"));
+    assert_eq!(from_string.as_str(), "http://pod/bob");
+    let via_new = PodId::new("http://pod/carol");
+    assert_eq!(format!("{via_new}"), via_new.as_str());
+}

--- a/crates/sparq-serve/tests/footprint.rs
+++ b/crates/sparq-serve/tests/footprint.rs
@@ -1,0 +1,172 @@
+//! [OPUS-4.8] (sq-fggn) Behavioural tests for the conservative write-footprint
+//! analysis (`Footprint` / `TargetGraph`) that drives commutativity batching
+//! under [`CommitGranularity::CommuteGroup`](sparq_serve::CommitGranularity).
+//!
+//! These assert the actual COMMUTATIVITY DECISIONS the writer relies on — the
+//! soundness contract of §6.5: two updates may only be grouped (applied in one
+//! generation without ordering them) when [`Footprint::commutes_with`] says so.
+//! A wrong `true` would let the writer reorder conflicting writes, so each case
+//! below is a correctness assertion, not a line-toucher. The production applier's
+//! footprint hook ([`GraphApplier`]) is exercised too, so the text-derived
+//! footprint the writer actually sees is the one under test.
+
+use std::sync::Arc;
+
+use sparq_serve::{ApplyUpdates, Footprint, GraphApplier, TargetGraph};
+
+fn named(iri: &str) -> TargetGraph {
+    TargetGraph::Named(Arc::from(iri))
+}
+
+/// `INSERT DATA` into the default graph yields a `Data` footprint whose insert
+/// set is exactly {Default} and whose delete set is empty.
+#[test]
+fn insert_data_default_graph_is_data_insert_only() {
+    let fp = Footprint::of_sparql("INSERT DATA { <http://ex/s> <http://ex/p> <http://ex/o> }");
+    match &fp {
+        Footprint::Data { inserts, deletes } => {
+            assert!(inserts.contains(&TargetGraph::Default));
+            assert_eq!(inserts.len(), 1);
+            assert!(deletes.is_empty());
+        }
+        Footprint::Barrier => panic!("pure INSERT DATA must be a Data footprint"),
+    }
+    assert!(!fp.is_barrier());
+}
+
+/// `DELETE DATA` from a NAMED graph carries that named-graph slot in its delete
+/// set (exercises the `GraphName::NamedNode` -> `TargetGraph::Named` conversion).
+#[test]
+fn delete_data_named_graph_records_named_target() {
+    let fp = Footprint::of_sparql(
+        "DELETE DATA { GRAPH <http://pod/alice> { <http://ex/s> <http://ex/p> <http://ex/o> } }",
+    );
+    match fp {
+        Footprint::Data { inserts, deletes } => {
+            assert!(inserts.is_empty());
+            assert!(deletes.contains(&named("http://pod/alice")));
+        }
+        Footprint::Barrier => panic!("pure DELETE DATA must be a Data footprint"),
+    }
+}
+
+/// Unparseable text is conservatively a Barrier (never panics, never wrongly
+/// classifies as commutable) — the parse-error arm of `of_sparql`.
+#[test]
+fn garbage_text_is_a_barrier() {
+    let fp = Footprint::of_sparql("this is definitely not sparql");
+    assert_eq!(fp, Footprint::Barrier);
+    assert!(fp.is_barrier());
+}
+
+/// A `WHERE`-driven update (DELETE/INSERT … WHERE) is order-sensitive, so it is
+/// a Barrier even though it parses fine — the catch-all arm of `of_sparql`.
+#[test]
+fn where_driven_update_is_a_barrier() {
+    let fp = Footprint::of_sparql(
+        "DELETE { ?s <http://ex/p> ?o } INSERT { ?s <http://ex/p2> ?o } \
+         WHERE { ?s <http://ex/p> ?o }",
+    );
+    assert!(fp.is_barrier(), "WHERE-driven update must be a barrier");
+}
+
+/// Graph-management operations (DROP/CLEAR) are unanalyzable barriers too.
+#[test]
+fn graph_management_is_a_barrier() {
+    assert!(Footprint::of_sparql("DROP GRAPH <http://pod/alice>").is_barrier());
+    assert!(Footprint::of_sparql("CLEAR DEFAULT").is_barrier());
+}
+
+/// Same-graph SAME-polarity inserts COMMUTE (set union is order-insensitive):
+/// the key license that keeps a bulk-ingest-into-one-pod stream batchable.
+#[test]
+fn same_graph_same_polarity_inserts_commute() {
+    let a = Footprint::of_sparql(
+        "INSERT DATA { GRAPH <http://pod/p> { <http://ex/a> <http://ex/q> <http://ex/1> } }",
+    );
+    let b = Footprint::of_sparql(
+        "INSERT DATA { GRAPH <http://pod/p> { <http://ex/b> <http://ex/q> <http://ex/2> } }",
+    );
+    assert!(
+        a.commutes_with(&b),
+        "same-graph same-polarity inserts commute"
+    );
+    assert!(b.commutes_with(&a), "commutativity is symmetric");
+}
+
+/// Disjoint-graph updates commute regardless of polarity.
+#[test]
+fn disjoint_graph_updates_commute() {
+    let ins = Footprint::of_sparql(
+        "INSERT DATA { GRAPH <http://pod/x> { <http://ex/a> <http://ex/q> <http://ex/1> } }",
+    );
+    let del = Footprint::of_sparql(
+        "DELETE DATA { GRAPH <http://pod/y> { <http://ex/b> <http://ex/q> <http://ex/2> } }",
+    );
+    assert!(
+        ins.commutes_with(&del),
+        "different graphs cannot share a triple"
+    );
+    assert!(del.commutes_with(&ins));
+}
+
+/// Opposite polarity on a SHARED graph does NOT commute — the one graph-level
+/// situation where the same triple could be both inserted and deleted, making
+/// application order observable. A wrong `true` here is a soundness bug.
+#[test]
+fn opposite_polarity_same_graph_does_not_commute() {
+    let ins = Footprint::of_sparql(
+        "INSERT DATA { GRAPH <http://pod/p> { <http://ex/a> <http://ex/q> <http://ex/1> } }",
+    );
+    let del = Footprint::of_sparql(
+        "DELETE DATA { GRAPH <http://pod/p> { <http://ex/a> <http://ex/q> <http://ex/1> } }",
+    );
+    assert!(
+        !ins.commutes_with(&del),
+        "insert+delete on the same graph must NOT commute"
+    );
+    assert!(!del.commutes_with(&ins), "non-commutativity is symmetric");
+}
+
+/// A Barrier commutes with NOTHING — not even another Barrier, and not with a
+/// pure data update.
+#[test]
+fn a_barrier_commutes_with_nothing() {
+    let barrier = Footprint::of_sparql("DROP GRAPH <http://pod/p>");
+    let data = Footprint::of_sparql("INSERT DATA { <http://ex/s> <http://ex/p> <http://ex/o> }");
+    let other_barrier = Footprint::of_sparql("CLEAR ALL");
+    assert!(!barrier.commutes_with(&data));
+    assert!(!data.commutes_with(&barrier));
+    assert!(!barrier.commutes_with(&other_barrier));
+}
+
+/// A multi-operation update that mixes an insert and a delete into the SAME
+/// graph is internally order-sensitive, but `of_sparql` records both graph slots;
+/// it must then NOT commute with itself's mirror (delete-into-the-insert-graph).
+#[test]
+fn mixed_insert_delete_update_tracks_both_graph_sets() {
+    let fp = Footprint::of_sparql(
+        "INSERT DATA { GRAPH <http://pod/p> { <http://ex/a> <http://ex/q> <http://ex/1> } }; \
+         DELETE DATA { GRAPH <http://pod/q> { <http://ex/b> <http://ex/q> <http://ex/2> } }",
+    );
+    match fp {
+        Footprint::Data { inserts, deletes } => {
+            assert!(inserts.contains(&named("http://pod/p")));
+            assert!(deletes.contains(&named("http://pod/q")));
+        }
+        Footprint::Barrier => panic!("multi-op pure-data update must stay Data"),
+    }
+}
+
+/// The production applier's `footprint` hook delegates to `Footprint::of_sparql`,
+/// so the text-derived footprint the writer sees under `CommuteGroup` is the very
+/// one tested above.
+#[test]
+fn graph_applier_footprint_matches_of_sparql() {
+    let applier = GraphApplier::new();
+    let upd = "INSERT DATA { GRAPH <http://pod/p> { <http://ex/s> <http://ex/p> <http://ex/o> } }"
+        .to_string();
+    assert_eq!(applier.footprint(&upd), Footprint::of_sparql(&upd));
+    let barrier = "DROP GRAPH <http://pod/p>".to_string();
+    assert!(applier.footprint(&barrier).is_barrier());
+}

--- a/crates/sparq-serve/tests/scheduler_api.rs
+++ b/crates/sparq-serve/tests/scheduler_api.rs
@@ -1,0 +1,135 @@
+//! [OPUS-4.8] (sq-fggn) Behavioural coverage for the scheduler's public surface
+//! that the existing `scheduler.rs` differential/fairness tests don't reach: the
+//! defaulted construction, the convenience `run`/`with_defaults` entry points, the
+//! non-blocking `try_take` poll, the `submitted`/`completed`/`depth` metrics, and
+//! the `SchedError` display/error contract. Each asserts observable behaviour, not
+//! just that a line ran.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use sparq_serve::{SchedError, Scheduler, SchedulerConfig};
+
+/// `SchedulerConfig::default()` derives a sane shape: >= 2 workers, a heavy cap of
+/// at least 1 but strictly fewer than the worker count (so a cheap job is always
+/// reservable), and the documented default heavy threshold.
+#[test]
+fn default_config_is_well_formed() {
+    let cfg = SchedulerConfig::default();
+    assert!(cfg.workers >= 2, "default must have >= 2 workers");
+    assert_eq!(cfg.heavy_threshold, sparq_serve::DEFAULT_HEAVY_THRESHOLD);
+    assert!(cfg.heavy_concurrency >= 1);
+    // A scheduler built from it runs a job to completion.
+    let sched = Scheduler::<u32>::with_defaults();
+    assert_eq!(sched.workers(), cfg.workers.max(2));
+    assert_eq!(sched.run(1, || 7).unwrap(), 7);
+}
+
+/// `run` is the submit-and-block convenience; it returns the closure's result.
+#[test]
+fn run_blocks_and_returns_the_result() {
+    let sched = Scheduler::<String>::with_defaults();
+    let out = sched.run(1, || "hello".to_string()).unwrap();
+    assert_eq!(out, "hello");
+}
+
+/// `try_take` is non-blocking: `None` while the job is still pending (the ticket
+/// stays usable), then `Some(result)` once it has finished.
+#[test]
+fn try_take_polls_without_consuming_until_done() {
+    let sched = Scheduler::<u32>::with_defaults();
+    // A job that blocks until we release it, so we can observe the pending poll.
+    let gate = Arc::new(std::sync::Barrier::new(2));
+    let g2 = gate.clone();
+    let ticket = sched.submit(1, move || {
+        g2.wait(); // hold here until the test lets it finish
+        42
+    });
+
+    // Still pending: try_take yields None and leaves the ticket usable.
+    assert!(ticket.try_take().is_none(), "job has not finished yet");
+    assert!(
+        ticket.try_take().is_none(),
+        "still pending — ticket not consumed"
+    );
+
+    gate.wait(); // release the job
+
+    // Spin (bounded) for completion, then take the result.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(r) = ticket.try_take() {
+            assert_eq!(r.unwrap(), 42);
+            break;
+        }
+        assert!(Instant::now() < deadline, "job never completed");
+        std::thread::yield_now();
+    }
+}
+
+/// `submitted` and `completed` are monotonic counters that converge once every
+/// ticket has been waited on.
+#[test]
+fn submitted_and_completed_counters_track_jobs() {
+    let sched = Scheduler::<u32>::with_defaults();
+    assert_eq!(sched.submitted(), 0);
+    assert_eq!(sched.completed(), 0);
+
+    let tickets: Vec<_> = (0..8).map(|i| sched.submit(1, move || i)).collect();
+    assert_eq!(sched.submitted(), 8, "every submit counts immediately");
+
+    for (i, t) in tickets.into_iter().enumerate() {
+        assert_eq!(t.wait().unwrap(), i as u32);
+    }
+    assert_eq!(
+        sched.completed(),
+        8,
+        "all jobs completed once every ticket was waited on"
+    );
+}
+
+/// `depth` reports `(cheap_queued, heavy_queued, heavy_running)`; with a single
+/// worker and a flooded queue some jobs are observably still queued.
+#[test]
+fn depth_reports_queue_occupancy() {
+    let sched = Scheduler::<()>::new(SchedulerConfig {
+        workers: 2,
+        heavy_concurrency: 1,
+        heavy_threshold: 100,
+    });
+    let gate = Arc::new(std::sync::Barrier::new(2));
+    let g = gate.clone();
+    // One cheap job parks a worker; queue several more behind it.
+    let parked = sched.submit(1, move || {
+        g.wait();
+    });
+    let _queued: Vec<_> = (0..4).map(|_| sched.submit(1, || {})).collect();
+
+    // Bounded spin until the queue depth is observable (>0 cheap queued).
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let (cheap, heavy, _running) = sched.depth();
+        if cheap > 0 {
+            assert_eq!(heavy, 0, "no heavy jobs were submitted");
+            break;
+        }
+        assert!(Instant::now() < deadline, "queue never showed backlog");
+        std::thread::yield_now();
+    }
+    gate.wait(); // release the parked worker so the pool drains on drop
+    let _ = parked.wait();
+}
+
+/// `SchedError` renders distinct, non-empty human-readable messages (the
+/// `Display`/`Error` contract callers map to 503-class responses).
+#[test]
+fn sched_error_display_is_distinct_and_nonempty() {
+    let shutdown = format!("{}", SchedError::Shutdown);
+    let panicked = format!("{}", SchedError::Panicked);
+    assert!(!shutdown.is_empty());
+    assert!(!panicked.is_empty());
+    assert_ne!(shutdown, panicked);
+    // Error trait object is constructible (source() defaults to None).
+    let err: &dyn std::error::Error = &SchedError::Shutdown;
+    assert!(err.source().is_none());
+}


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes sq-fggn (part of test-quality epic sq-qcnn).

## What

The three lowest-covered `sparq-serve` modules had **real, behaviour-asserting gaps** (not vacuous line-touchers):

| module | before | after | what was missing |
|---|---|---|---|
| `footprint.rs` | 58.8% | **100%** | `Footprint::commutes_with` / `is_barrier`, the parse-error→Barrier and WHERE/DROP→Barrier arms, named-graph target tracking |
| `scheduler.rs` | 79.9% | **97.4%** | `SchedulerConfig::default`, `with_defaults`/`run`, the non-blocking `try_take` poll, `submitted`/`completed`/`depth` metrics, `SchedError` Display/Error |
| `epoch.rs` | 81.8% | **100%** | `PodId::as_str` + `Display`; plus `WriteError` Display/Error (writer.rs) |

Crate line coverage: **84.82% → 94.47%**.

## Tests added (19, all asserting observable behaviour)

- **`tests/footprint.rs`** — the §6.5 commutativity-decision *soundness* contract the sequenced writer relies on: same-polarity inserts commute; disjoint-graph updates commute; **opposite polarity on a shared graph does NOT commute** (a wrong `true` here would let the writer reorder conflicting writes); a barrier commutes with nothing; unparseable / `WHERE`-driven / `DROP`/`CLEAR` text → `Barrier`; named-graph target tracking; and `GraphApplier::footprint` delegating to `Footprint::of_sparql`.
- **`tests/scheduler_api.rs`** — defaulted construction shape, `run`/`with_defaults`, the non-blocking `try_take` (pending→`None` without consuming, then `Some`), the `submitted`/`completed`/`depth` metrics, and the distinct/non-empty `SchedError` display.
- **`tests/error_display.rs`** — `WriteError` renders distinct messages (the retryable `Unavailable` is marked retryable — the 503 contract) and is a real `std::error::Error`; `PodId` round-trips its identifier through `as_str`/`Display` across every constructor.

## Ratchet

- `bench/coverage-floor.json`: sparq-serve **83 → 92** (floor = `floor(measured) − 2` margin, per the file's convention).
- `bench/coverage-presence.json`: sparq-serve test-count floor **54 → 78**.

No production code or public API changed — test-only plus the two ratchet files.

## Gate

- `cargo build -p sparq-serve` ✔
- `cargo clippy -p sparq-serve --all-targets -- -D warnings` ✔
- `cargo test -p sparq-serve` ✔ (78 tests; the crate has **no cargo features**, so no second feature state to vary)
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sparq-serve --no-deps` ✔ (no intra-doc links to private items)
- `cargo fmt -p sparq-serve --check` ✔
- `coverage-gate.py --check` ✔ (94.47% ≥ 92) and `coverage-presence.py --check` ✔ (78 ≥ 78)
- No `unsafe` added; no privacy-claim surface touched; sparq-wasm dependency boundary unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)