### PR TITLE
test(sparq-core): N-Quads graphLabel IRI/blank-only coverage (sq-cpm) [OPUS-4.8]

### DIFF
--- a/crates/sparq-core/src/nt.rs
+++ b/crates/sparq-core/src/nt.rs
@@ -35,7 +35,7 @@ const MAX_TRIPLE_TERM_DEPTH: usize = 128;
 /// `oxrdf::Term` stored in the parent graph's `named` vec. `Ord`/`Hash` give a deterministic
 /// per-graph grouping independent of parse order.
 #[cfg(feature = "parallel")]
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum GraphKey {
     Iri(String),
     Blank(String),
@@ -700,6 +700,82 @@ mod tests {
         assert!(
             e.contains("nested more than") && e.contains("levels deep"),
             "must be the depth-limit error, got: {e}"
+        );
+    }
+
+    // [OPUS-4.8] (sq-cpm) The N-Quads 4th field is an OPTIONAL `graphLabel`, and the RDF 1.2
+    // N-Quads grammar restricts it to `IRIREF | BLANK_NODE_LABEL` (prod. `graphLabel`) — a
+    // literal or a triple term in graph position is a syntax error, not a fourth quad component.
+    // `parse_quads_chunk` resolves the graph bucket via `graph_key` (IRI/blank only) and
+    // `span_term` (object-only triple-term rule), so these cases must be rejected; an absent 4th
+    // field routes to the default (`None`) graph.
+    // `parse_quads_chunk` returns `Dict` (no `Debug`/`PartialEq`), so these helpers pull just the
+    // graph-key column and the per-graph triple counts out of the bucket vec for assertions.
+    #[cfg(feature = "parallel")]
+    fn quad_graph_keys(line: &[u8]) -> Result<Vec<(Option<GraphKey>, usize)>, String> {
+        parse_quads_chunk(line).map(|buckets| {
+            buckets.into_iter().map(|(g, _dict, triples)| (g, triples.len())).collect()
+        })
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn nquads_graph_label_accepts_iri_and_blank_only() {
+        // IRI graph label: routes the triple into a named-graph bucket keyed by that IRI.
+        let iri_g = b"<http://ex/s> <http://ex/p> <http://ex/o> <http://ex/g> .\n";
+        assert_eq!(
+            quad_graph_keys(iri_g).expect("IRI graph label must parse"),
+            vec![(Some(GraphKey::Iri("http://ex/g".to_owned())), 1)],
+            "the triple lands in the IRI-keyed graph"
+        );
+
+        // Blank-node graph label.
+        let blank_g = b"<http://ex/s> <http://ex/p> <http://ex/o> _:g0 .\n";
+        assert_eq!(
+            quad_graph_keys(blank_g).expect("blank-node graph label must parse"),
+            vec![(Some(GraphKey::Blank("g0".to_owned())), 1)],
+            "blank-node graph label key"
+        );
+
+        // No 4th field: the triple is in the default graph (`None`).
+        let default_g = b"<http://ex/s> <http://ex/p> <http://ex/o> .\n";
+        assert_eq!(
+            quad_graph_keys(default_g).expect("triple with no graph label must parse"),
+            vec![(None, 1)],
+            "absent graph label is the default graph"
+        );
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn nquads_graph_label_rejects_literal() {
+        // A literal in the 4th position is not a valid `graphLabel`.
+        let lit_g = b"<http://ex/s> <http://ex/p> <http://ex/o> \"g\" .\n";
+        let e = quad_graph_keys(lit_g).expect_err("a literal graph label must be rejected");
+        assert!(
+            e.contains("graph name must be an IRI or blank node"),
+            "message must explain the IRI/blank-only rule, got: {e}"
+        );
+
+        // A typed literal likewise.
+        let typed_g = b"<http://ex/s> <http://ex/p> <http://ex/o> \"5\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n";
+        assert!(
+            quad_graph_keys(typed_g).is_err(),
+            "a typed-literal graph label must be rejected"
+        );
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn nquads_graph_label_rejects_triple_term() {
+        // A triple term `<<( … )>>` is OBJECT-ONLY; it is not a valid `graphLabel`. The span walk
+        // (`span_term`) reaches the `<<(` opener in graph position and rejects it with the
+        // position-aware message.
+        let tt_g = b"<http://ex/s> <http://ex/p> <http://ex/o> <<( <http://ex/a> <http://ex/b> <http://ex/c> )>> .\n";
+        let e = quad_graph_keys(tt_g).expect_err("a triple-term graph label must be rejected");
+        assert!(
+            e.contains("only valid in OBJECT position"),
+            "message must explain the object-only rule, got: {e}"
         );
     }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent

## sq-cpm: RDF 1.2 N-Triples/N-Quads tripleTerm object + graphLabel

### Honest status of the bead

The bead's two requirements were **already implemented** before this PR:

1. **tripleTerm in OBJECT position only, right-branching nesting, depth guard** — landed across sq-hxgb (`<<( s p o )>>` object parsing, structural interning), sq-87bq (position-aware rejection of triple terms in subject/predicate/graph), and sq-53s1 (`MAX_TRIPLE_TERM_DEPTH` bound on both the interning and the no-intern span paths). Covered by existing tests in `crates/sparq-core/src/nt.rs`.
2. **N-Quads optional 4th `graphLabel`** — landed in sq-25r3: `parse_quads_chunk` resolves the optional graph field via `graph_key` (IRI/blank only) and routes each triple to a per-graph bucket.

The **one explicit requirement with no asserting test** was the `graphLabel ::= IRIREF | BLANK_NODE_LABEL` restriction. This PR closes that gap rather than shipping a no-op, and strips no design-reference text (the lines at `research/rdf12-parser.md:348-349` are the doc's intentional spec digest — "kept here as design reference (not a task list)" — not a checkbox TODO; the bead's `from-md-todo` provenance is already captured).

### Change

`crates/sparq-core/src/nt.rs` — three `#[cfg(feature = "parallel")]` tests over `parse_quads_chunk`:
- accepts IRI and blank-node graph labels (routing the triple into that graph) and treats an absent 4th field as the default (`None`) graph;
- rejects a simple **and** typed literal in graph position with the IRI/blank-only message;
- rejects a **triple term** in graph position (object-only rule, enforced by `span_term`).

Plus a `#[derive(Debug)]` on the public `GraphKey` enum so the keys can be asserted (purely additive).

### Gate

- `cargo build` / `clippy --all-targets -D warnings` / `cargo test` — all green in **both** feature states (default `parallel`, and `--no-default-features`).
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` and again `--all-features` — both clean (this is what CI runs; an isolated `-p sparq-core` default-feature doc surfaces a *pre-existing* `Self::open` intra-doc link gated behind `mmap`, unrelated to this PR and not present in the workspace gate).
- privacy-claims gate: OK. unsafe-count ratchet: PASS (no `unsafe` added).
- rustfmt is informational in CI (deferred one-time reformat); not reformatting the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)