### PR TITLE
docs: hygiene — de-drift stale ZK gate counts to catalog pointer; fix dangling TODO ref [OPUS-4.8]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,8 +329,8 @@ publish set). The API is unstable; SERVICE federation remains unimplemented — 
   most-selective-first with a `max(4k, 64)` stop. Re-measured on the real
   olympics eval: Sport precision@10 0.000 (0/0) → 1.000 (400/400), City 0.500
   (2/4) → 0.995 (398/400), full 2400/2400 candidate coverage, ~0.3 ms mean
-  latency cost. The per-element IDF hub budget recorded in the TODO is
-  measured-and-rejected (the eval is saturated); numbers in `sparq-sim/TODO.md`.
+  latency cost. The per-element IDF hub budget was investigated and is
+  measured-and-rejected (the eval is saturated).
 
 - **Streaming store builds, weighted RRF, bytes-backed open (`sparq-vectors`)**
   — `StreamingWriter` removes the build-phase RAM ceiling (vectors append

--- a/research/zk-verification-and-costs.md
+++ b/research/zk-verification-and-costs.md
@@ -191,4 +191,4 @@ does not change what is proven or the zero-knowledge (age-hiding) property.**
 - Gate snapshot (authoritative, `sq-pzet`/`sq-mj2z` baseline): `crates/sparq-zk-compose/tests/gate_count_snapshot.json` (mirror: `bench/zk-compose/gate_counts_latest.json`)
 - Cost curve (indicative): `bench/zk-compose/family_cost_curve.json`; browser perf: `research/zk-browser-perf-assessment.md`
 - Per-member machine-readable cost + semantics table: `site/src/data/zk-circuit-costs.json`
-- Soundness status: `research/zk-soundness-audit.md` (`sq-qhy4`/`sq-9hrn`/`sq-1s2`); `zk/compose/STATUS.md` (note: its inventory line cites a stale `revoke_unset_d10 = 822`; the committed snapshot `899` is authoritative)
+- Soundness status: `research/zk-soundness-audit.md` (`sq-qhy4`/`sq-9hrn`/`sq-1s2`); `zk/compose/STATUS.md` (its hard-coded gate-count block has been replaced by a pointer to the authoritative catalog above, so the gate counts here are the single source of truth)

--- a/zk/compose/STATUS.md
+++ b/zk/compose/STATUS.md
@@ -297,22 +297,29 @@ NOT-yet-sound per sq-qhy4). Cross-checked equal to the dense builder for every
 - `bench/zk-compose/`: gate counts (bb gates ultra_honk) + prove/verify
   wall-clock + README + regen scripts.
 
-## Gate counts (ultra_honk circuit_size)
+## Gate counts + prove/verify timing
 
-scan_k1_n16_r4=5958  scan_k2_n16_r8=11011  scan_k2_n64_r8=34379
-filter_int_d{1,2,4}=17416 (blake3-block-bound, d-invariant)  filter_f64=3113
-revoke_unset_d10=822  hidden_issuer_d4=16932 (two ~251-bit BJJ scalar muls; sq-z9l)
+Authoritative figures live in the benchmark catalog — do NOT hard-code them here
+(this avoids the drift that previously left this section citing stale gate counts):
 
-## Prove/verify (small e2e, darwin arm64)
+- gate counts (`bb gates` ultra_honk `circuit_size`), per member:
+  `bench/zk-compose/gate_counts_latest.json` (snapshot test:
+  `crates/sparq-zk-compose/tests/gate_count_snapshot.json`).
+- prove/verify wall-clock + proof size: `bench/zk-compose/prove_verify_timing.json`.
+- family cost curve: `bench/zk-compose/family_cost_curve.json`.
 
-filter_int_d1: prove 1.13s, verify 0.16s, proof 14656 B
-scan_k1_n16_r4: prove 1.62s, verify 0.95s, proof 14656 B
+Regenerate via `bench/zk-compose/scripts/gate_counts.sh` /
+`bench/zk-compose/scripts/prove_verify.sh`. `filter_int_*` is blake3-block-bound
+(d-invariant); `hidden_issuer_d4` is dominated by two ~251-bit BJJ scalar muls
+(sq-z9l). [OPUS-4.8]
 
 ## DONE / verified
 
 - compose_core: 22/22 nargo tests. compose crate: 10/10 + 1 ignored.
 - Poseidon2 + filter_int encoding bit-compatible with sparq-zk (verified).
-- wasm byte gate: see commit (must stay 1,643,095).
+- wasm byte gate: enforced deterministically per-commit by the `wasm_bundle_bytes`
+  benchmark gate (`bench/benchmarks.toml`, CI `bench.yml`) — the authoritative
+  value lives there, not in this doc. [OPUS-4.8]
 
 ### Exact next command (if resuming)
 


### PR DESCRIPTION
> 🤖 SPARQ agent — periodic repo-hygiene + honesty-drift pass. DOC-ONLY (no `crates/` source).

## What this reconciles

**Honesty drift — stale hard-coded ZK gate counts** in `zk/compose/STATUS.md`. The "Gate counts" block cited figures that had drifted from the authoritative committed baseline:

| member | STATUS said | authoritative (`bench/zk-compose/gate_counts_latest.json` + `crates/sparq-zk-compose/tests/gate_count_snapshot.json`) |
|---|---|---|
| `revoke_unset_d10` | 822 | **899** |
| `scan_k1_n16_r4` | 5958 | **5991** |
| `scan_k2_n16_r8` | 11011 | **11261** |
| `scan_k2_n64_r8` | 34379 | **34821** |

Per the no-hard-coded-perf-numbers hygiene rule, rather than re-baking soon-to-be-stale numbers I replaced the hard-coded gate-count + prove/verify-timing block (and the `must stay 1,643,095` wasm byte gate) with pointers to the authoritative catalog / deterministic `wasm_bundle_bytes` CI gate — eliminating the drift surface. Updated the cross-reference note in `research/zk-verification-and-costs.md` (which had already flagged the stale 822). Fixed a dangling `CHANGELOG.md` reference to the removed `sparq-sim/TODO.md`.

**Verification:** authoritative counts read from `bench/zk-compose/gate_counts_latest.json`; `scripts/check-privacy-claims.sh` → OK (no unqualified ZK/MPC claim); `markdownlint-cli2` → 0 errors; all 16 not-yet-sound caveats in STATUS.md preserved.

## Triage (from-pss #55 / #53) — no new beads

- **#55** (sparq-solid write-path enforcement / re-materialization / vocab / WAC-ACP conformance) → already mapped to **sq-3jtd** (external: gh-55, with 9 children). No bead needed.
- **#53** (publish @jeswr/sparq + name/pin + escaper re-prove) → already mapped to **sq-c4ej** (external: gh-53); code-side complete, only the maintainer `npm publish` remains (needs:user). Confirmed not duplicated.

## Not changed (deliberate)

- `bench/wikidata-8b/STATUS.md` — a git-tracked AWS-spend crash-protocol runbook (commit 6a7f5a56, deliberately preserved by prior hygiene cleanup b1ea87c7); its checkboxes are a launch-safety gate and its byte/cost figures are verified dump metadata, not perf claims. Left as-is.

[OPUS-4.8]