### PR TITLE
style(sparq-mpc): clear cargo fmt drift in adversarial_tests.rs (sq-f6xs) [OPUS-4.8]

### DIFF
--- a/crates/sparq-mpc/src/adversarial_tests.rs
+++ b/crates/sparq-mpc/src/adversarial_tests.rs
@@ -875,7 +875,11 @@ mod robust_props {
         for &n in &[4usize, 6, 8, 10] {
             let backend = ShamirBackend::new_seeded(n, 0xA17 + n as u64).unwrap();
             let t = backend.threshold();
-            assert_eq!(n - (2 * t + 1), 1, "even honest-majority n: one redundant share");
+            assert_eq!(
+                n - (2 * t + 1),
+                1,
+                "even honest-majority n: one redundant share"
+            );
             for _ in 0..120 {
                 let mut dealer = backend.dealer();
                 // EQUAL keys ⇒ honest m = 0 (a "match"); tampering tries to flip it.
@@ -894,7 +898,8 @@ mod robust_props {
                 }
                 tampered[i].y = tampered[i].y.add(fp(delta));
                 match reconstruct_degree(&tampered, 2 * t) {
-                    Err(MpcError::Tampered { .. }) => { /* detect-and-abort — the honest envelope */ }
+                    Err(MpcError::Tampered { .. }) => { /* detect-and-abort — the honest envelope */
+                    }
                     Ok(v) => panic!(
                         "sq-ji5f: n={n} t={t} has e_max=0, so the equality open must \
                          DETECT-and-ABORT a tampered share, never silently correct it \


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

Clears pre-existing `cargo fmt` drift in `crates/sparq-mpc/src/adversarial_tests.rs` so the workspace-wide CI fmt gate (`cargo fmt --check`) stays green. Two rustfmt wrappings: an `assert_eq!` call and a `match`-arm block comment.

## Why (sq-f6xs)

The bead asked to clear pre-existing fmt drift across the MPC wave. The wave files originally named in the bead (`backend`/`holder`/`join`/`shamir`/`oblivious*`/`proof`/`rng`/`partial`) are already fmt-clean on `origin/main` — that drift was absorbed as the wave merged (each feature PR passed its own fmt gate). The only remaining drift on current `origin/main` is in the `#[cfg(test)]` adversarial-share suite (`adversarial_tests.rs`), which is itself an MPC-wave file and which the workspace fmt gate would flag. This PR is the smallest correct change: a `cargo fmt -p sparq-mpc` over that one file.

## Scope / honesty

- Pure formatting; no behaviour change. The reformatted block lives in the `robust_props` test module (gated APIs behind `insecure-test-rng`).
- No public API change → no SKILL.md / privacy-gate impact. No `unsafe` added.

## Gate

- `cargo build -p sparq-mpc` — pass
- `cargo clippy -p sparq-mpc --all-targets -- -D warnings` — pass (default + `insecure-test-rng`)
- `cargo test -p sparq-mpc` — pass (default + `insecure-test-rng`; the reformatted `robust_props` tests pass)
- `cargo fmt -p sparq-mpc -- --check` — now clean
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sparq-mpc --no-deps` and `--workspace --no-deps --all-features` — pass

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>