### PR TITLE
test(sparq-server): behavioural tests for lowest-covered modules, ratchet coverage floor 85->86 (sq-4vao)

### DIFF
--- a/bench/coverage-floor.json
+++ b/bench/coverage-floor.json
@@ -55,7 +55,8 @@
       "note": "[OPUS-4.8] sq-fggn: behavioural tests for the lowest-covered modules (footprint commutativity, scheduler public surface, PodId/WriteError display) lifted measured line% 84.82 -> 94.47; floor = floor(measured) - 2 margin."
     },
     "sparq-server": {
-      "floor": 85
+      "floor": 86,
+      "note": "[OPUS-4.8] sq-4vao: behavioural tests for the lowest-covered modules (subscription reevaluate_step/subscribe_init diff + refusal classes, budget->SSE-status + RDF-1.2 triple-term encoding, the json_error/sanitized_error info-leak envelope, the GSP escape_iri/body-decode helpers, and the SPARQL-Protocol dataset-override rewrite) lifted measured line% 86.38 -> 88.14; floor = floor(measured) - 2 margin."
     },
     "sparq-shacl": {
       "floor": 90

--- a/crates/sparq-server/src/graph.rs
+++ b/crates/sparq-server/src/graph.rs
@@ -191,6 +191,17 @@ mod tests {
     }
 
     #[test]
+    fn parse_rdfxml_rejects_an_invalid_base_iri() {
+        // [OPUS-4.8] sq-4vao: the `base` (the GSP graph IRI) is fed to `with_base_iri`; a
+        // syntactically invalid base must fail FAST with a clear message (the caller maps it
+        // to a 400) rather than silently parsing against no base. A bare space is not a valid IRI.
+        let err = parse_rdfxml(b"<?xml version=\"1.0\"?><rdf:RDF/>", Some("not a valid iri"))
+            .expect_err("an invalid base IRI must be rejected");
+        assert!(err.contains("invalid base IRI"), "unexpected message: {err}");
+        assert!(err.contains("not a valid iri"), "message should echo the bad base: {err}");
+    }
+
+    #[test]
     fn parse_then_serialize_roundtrips_through_turtle() {
         // Parse a hand-written RDF/XML doc, re-serialise as prefix Turtle, and confirm the
         // triples survive (value-equal as a set).

--- a/crates/sparq-server/src/health_probe.rs
+++ b/crates/sparq-server/src/health_probe.rs
@@ -154,6 +154,16 @@ mod tests {
     }
 
     #[test]
+    fn non_utf8_status_line_is_unhealthy() {
+        // [OPUS-4.8] sq-4vao: a status line whose bytes are not valid UTF-8 (a hostile or
+        // corrupt peer) must fail closed at the `from_utf8` guard rather than panic — the
+        // `0xFF` byte is an invalid UTF-8 start byte, so the whole line fails to decode.
+        assert!(!probe_healthy(b"\xFF\xFE 200 OK\r\n\r\n"));
+        // Invalid bytes after the protocol token are equally rejected.
+        assert!(!probe_healthy(b"HTTP/1.1 \xFF\xFF\r\n\r\n"));
+    }
+
+    #[test]
     fn status_line_without_trailing_crlf_still_parses() {
         // Defensive: a response truncated to just the status line is still classified.
         assert!(probe_healthy(b"HTTP/1.1 200 OK"));

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -6116,6 +6116,62 @@ mod hardening_unit_tests {
 }
 
 #[cfg(test)]
+mod json_error_tests {
+    //! [OPUS-4.8] sq-4vao: the `{"error":"…"}` envelope every error response carries hand-rolls
+    //! its JSON-string escaping (it is built without `serde_json` to stay dependency-light on the
+    //! hot error path). A message containing a quote / backslash / control character MUST be
+    //! escaped or the envelope is malformed (and an unescaped `"` is a JSON-injection vector that
+    //! lets a reflected error string break out of the `error` value). These pin every escape arm
+    //! and confirm the result re-parses as the intended JSON object.
+    use super::json_error;
+    use axum::http::StatusCode;
+
+    async fn body_of(resp: axum::response::Response) -> String {
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn escapes_quote_backslash_and_control_characters() {
+        // A hostile/reflected message exercising every special arm: `"`, `\`, the named control
+        // escapes (`\n` `\r` `\t`), and an "other" control char () that takes the \u{:04x} arm.
+        let msg = "a\"b\\c\nd\re\tf\u{0001}g";
+        let resp = json_error(StatusCode::BAD_REQUEST, msg);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_of(resp).await;
+        // The raw, unescaped quote must NOT appear inside the value (only the two envelope quotes).
+        assert_eq!(body, "{\"error\":\"a\\\"b\\\\c\\nd\\re\\tf\\u0001g\"}");
+        // And it must round-trip back to the ORIGINAL message through a real JSON parser.
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["error"], msg);
+    }
+
+    #[tokio::test]
+    async fn ordinary_message_is_passed_through_and_is_valid_json() {
+        let resp = json_error(StatusCode::NOT_FOUND, "no such graph");
+        let body = body_of(resp).await;
+        assert_eq!(body, "{\"error\":\"no such graph\"}");
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["error"], "no such graph");
+    }
+
+    #[tokio::test]
+    async fn sanitized_error_withholds_the_sensitive_detail_from_the_body() {
+        // [OPUS-4.8] sq-4vao: the info-leak guard (#241 posture) — the response body MUST carry
+        // ONLY the generic class message, never the `detail` (which may echo caller input, a
+        // loaded-data fragment, or a filesystem path). The detail goes to the server-side log.
+        let detail = "patient_alice_smith is not a valid subject (/srv/data/phi.ttl)";
+        let resp = super::sanitized_error(StatusCode::BAD_REQUEST, "parse_error", "invalid RDF in request body", detail);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_of(resp).await;
+        assert_eq!(body, "{\"error\":\"invalid RDF in request body\"}");
+        // The sensitive fragments must not have leaked into the client-facing body.
+        assert!(!body.contains("alice_smith"), "leaked loaded-data fragment: {body}");
+        assert!(!body.contains("/srv/data"), "leaked filesystem path: {body}");
+    }
+}
+
+#[cfg(test)]
 mod service_allow_config_tests {
     //! The default posture and the ServerConfig <-> engine-entries plumbing. These are
     //! pure (no process-env mutation) so they parallelise; the env-precedence path
@@ -6303,6 +6359,136 @@ mod durable_degrade_tests {
         let cfg = ServerConfig::default();
         let resp = update_rejection_response("some parse error", &cfg);
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}
+
+#[cfg(test)]
+mod gsp_helpers_tests {
+    //! [OPUS-4.8] sq-4vao: the pure Graph-Store-Protocol write helpers that mint the
+    //! server-side SPARQL UPDATE from a request body. These are security-relevant — a graph
+    //! IRI is interpolated into a `<…>` term, so `escape_iri` must neutralise the IRIREF
+    //! delimiters that would otherwise let a crafted graph name inject SPARQL — and the
+    //! body-decode entry point classifies an unsupported media type / non-UTF-8 body. The
+    //! end-to-end GSP behaviour is in tests/protocol.rs; these pin the building blocks.
+    use super::{base_iri, body_to_ntriples, escape_iri, graph_data_block, GraphRef};
+    use axum::body::Bytes;
+    use axum::http::StatusCode;
+
+    #[test]
+    fn escape_iri_percent_encodes_iriref_delimiters_and_controls() {
+        // A benign IRI is unchanged.
+        assert_eq!(escape_iri("http://ex/g"), "http://ex/g");
+        // The IRIREF-forbidden delimiters that would break out of the `<…>` term are
+        // percent-encoded (uppercase hex), so a crafted graph name cannot inject SPARQL.
+        assert_eq!(escape_iri("a>b"), "a%3Eb");
+        assert_eq!(escape_iri("a b"), "a%20b");
+        assert_eq!(escape_iri("a{b}c"), "a%7Bb%7Dc");
+        assert_eq!(escape_iri("a\\b"), "a%5Cb");
+        // A control character (below 0x20) is percent-encoded too.
+        assert_eq!(escape_iri("a\u{0001}b"), "a%01b");
+        // The classic injection attempt — closing the term and appending an op — is neutralised:
+        // the `>` and `{`/`}` and spaces are all encoded, so no second clause can form.
+        let injected = escape_iri("http://ex/g> ;\nDROP ALL ;\n<x");
+        assert!(!injected.contains('>'), "unescaped '>' would close the IRIREF: {injected}");
+        assert!(!injected.contains(' '), "unescaped space is invalid in an IRIREF: {injected}");
+    }
+
+    #[test]
+    fn graph_data_block_wraps_named_graphs_and_passes_default_through() {
+        let nt = "<http://ex/s> <http://ex/p> <http://ex/o> .\n";
+        // The default graph takes the N-Triples bare.
+        assert_eq!(graph_data_block(&GraphRef::Default, nt), nt);
+        // A named graph is wrapped in `GRAPH <iri> { … }`, with the IRI escaped.
+        let block = graph_data_block(&GraphRef::Named("http://ex/g".into()), nt);
+        assert!(block.starts_with("GRAPH <http://ex/g> {\n"), "block: {block}");
+        assert!(block.trim_end().ends_with('}'), "block: {block}");
+        assert!(block.contains(nt), "block must carry the triples: {block}");
+    }
+
+    #[test]
+    fn base_iri_is_the_named_graph_iri_or_none_for_default() {
+        assert_eq!(base_iri(&GraphRef::Default), None);
+        assert_eq!(base_iri(&GraphRef::Named("http://ex/g".into())), Some("http://ex/g"));
+    }
+
+    #[test]
+    fn body_to_ntriples_rejects_an_unsupported_content_type() {
+        // A non-RDF Content-Type → 415 Unsupported Media Type, BEFORE any parse is attempted.
+        let body = Bytes::from_static(b"{}");
+        let resp = body_to_ntriples(&body, "application/json", None).unwrap_err();
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[test]
+    fn body_to_ntriples_rejects_a_non_utf8_text_body() {
+        // A declared text RDF body that is not valid UTF-8 → 400 (the `from_utf8` guard arm).
+        let body = Bytes::from_static(b"\xFF\xFE not utf-8");
+        let resp = body_to_ntriples(&body, "text/turtle", None).unwrap_err();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn body_to_ntriples_roundtrips_valid_turtle_to_canonical_ntriples() {
+        let body = Bytes::from_static(b"@prefix ex: <http://ex/> . ex:a ex:p ex:b .");
+        let nt = body_to_ntriples(&body, "text/turtle", None).expect("valid turtle parses");
+        assert!(nt.contains("<http://ex/a> <http://ex/p> <http://ex/b> ."), "got: {nt}");
+    }
+}
+
+#[cfg(test)]
+mod dataset_override_tests {
+    //! [OPUS-4.8] sq-4vao: the SPARQL 1.1 Protocol §2.1.4 / §2.2 dataset-override parsing
+    //! (`default-graph-uri` / `named-graph-uri` / `using-*`) and the UPDATE rewrite wrapper that
+    //! maps an override failure onto the right HTTP 400. The end-to-end protocol behaviour is in
+    //! tests/protocol.rs; these pin the pure parse + the rewrite-error → Response mapping.
+    use super::{form_decode, query_dataset_override, rewrite_update, update_dataset_override};
+    use axum::http::StatusCode;
+
+    #[test]
+    fn update_and_query_overrides_read_repeated_protocol_params() {
+        // The §2.2 UPDATE override reads the repeated `using-*` params (multi-valued by design).
+        let over = update_dataset_override("using-graph-uri=http://ex/a&using-named-graph-uri=http://ex/n&using-graph-uri=http://ex/b");
+        assert_eq!(over.default, vec!["http://ex/a", "http://ex/b"]);
+        assert_eq!(over.named, vec!["http://ex/n"]);
+        // The §2.1.4 query override reads the `*-graph-uri` family; unrelated params are ignored.
+        let q = query_dataset_override("default-graph-uri=http://ex/d&query=SELECT&named-graph-uri=http://ex/n");
+        assert_eq!(q.default, vec!["http://ex/d"]);
+        assert_eq!(q.named, vec!["http://ex/n"]);
+    }
+
+    #[test]
+    fn rewrite_update_passes_through_when_no_override_is_present() {
+        let over = update_dataset_override(""); // empty => is_empty() => verbatim
+        let rewritten = rewrite_update("INSERT DATA { <http://ex/s> <http://ex/p> <http://ex/o> }", &over).unwrap();
+        assert_eq!(rewritten, "INSERT DATA { <http://ex/s> <http://ex/p> <http://ex/o> }");
+    }
+
+    #[test]
+    fn rewrite_update_rejects_using_param_alongside_in_string_using_clause() {
+        // §2.2 protocol error: the `using-graph-uri` param must not be combined with an in-update
+        // USING clause. The wrapper maps the UsingConflict to a 400 with the explanatory message.
+        let over = update_dataset_override("using-graph-uri=http://ex/a");
+        let update = "DELETE { ?s ?p ?o } USING <http://ex/g> WHERE { ?s ?p ?o }";
+        let resp = rewrite_update(update, &over).unwrap_err();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn rewrite_update_reports_a_malformed_update_as_400() {
+        // A non-empty override forces a parse; a malformed update is a 400 (the Malformed arm),
+        // with the offending detail withheld from the body (sanitized_error).
+        let over = update_dataset_override("using-graph-uri=http://ex/a");
+        let resp = rewrite_update("DELETE WHERE {", &over).unwrap_err();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn form_decode_handles_plus_percent_and_a_malformed_escape() {
+        // `+` decodes to a space, `%XX` to the byte, and a malformed/truncated `%` is kept literal.
+        assert_eq!(form_decode("a+b"), "a b");
+        assert_eq!(form_decode("a%2Fb"), "a/b"); // %2F => '/'
+        assert_eq!(form_decode("a%2fb"), "a/b"); // lowercase hex digits too
+        assert_eq!(form_decode("a%zzb"), "a%zzb"); // not hex => literal '%'
     }
 }
 

--- a/crates/sparq-server/src/results.rs
+++ b/crates/sparq-server/src/results.rs
@@ -372,6 +372,38 @@ mod tests {
     }
 
     #[test]
+    fn xml_text_body_escapes_markup_characters() {
+        // [OPUS-4.8] sq-4vao: a literal value containing XML-significant characters must be
+        // escaped in the `<literal>` text body, NOT emitted verbatim — otherwise a literal like
+        // `<script>` would break the results document (and be an injection vector). Exercises the
+        // `<` and `>` body arms (the `&` arm too) of `xml_text_escape_body`.
+        let g = Graph::load_str(
+            "@prefix ex: <http://ex/> . ex:a ex:v \"a < b & c > d\" .",
+            "turtle",
+        )
+        .unwrap();
+        let r = query(&g, "PREFIX ex: <http://ex/> SELECT ?v WHERE { ?s ex:v ?v }").unwrap();
+        let xml = select_to_xml(&r);
+        assert!(xml.contains("<literal>a &lt; b &amp; c &gt; d</literal>"), "unescaped markup: {xml}");
+        // The raw, unescaped sequence must NOT appear anywhere in the document.
+        assert!(!xml.contains("a < b & c > d"), "literal leaked raw markup: {xml}");
+    }
+
+    #[test]
+    fn xml_triple_term_with_a_blank_node_subject() {
+        // [OPUS-4.8] sq-4vao: a quoted triple whose SUBJECT is a blank node exercises the
+        // `NamedOrBlankNode::BlankNode` subject arm of the `<triple>` XML encoder (the existing
+        // triple-term test only covers a named-node subject). The bnode label is data-dependent,
+        // so assert on the structural `<bnode>` element, not its id.
+        let g = Graph::load_str("PREFIX : <http://ex/>\n<< _:s :b :c >> :certainty 0.9 .", "turtle").unwrap();
+        let r = query(&g, "SELECT ?t WHERE { ?r <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> ?t }").unwrap();
+        let xml = select_to_xml(&r);
+        assert!(xml.contains("<triple><subject><bnode>"), "expected a bnode subject in the triple term: {xml}");
+        assert!(xml.contains("<predicate><uri>http://ex/b</uri></predicate>"), "got: {xml}");
+        assert!(xml.contains("<object><uri>http://ex/c</uri></object>"), "got: {xml}");
+    }
+
+    #[test]
     fn ask_serialisers() {
         assert_eq!(ask_to_json(true), "{\"head\":{},\"boolean\":true}");
         assert_eq!(ask_to_json(false), "{\"head\":{},\"boolean\":false}");

--- a/crates/sparq-server/src/subscriptions.rs
+++ b/crates/sparq-server/src/subscriptions.rs
@@ -942,4 +942,185 @@ mod tests {
         assert_eq!(msg["notification"]["addedResults"]["results"]["bindings"][0], b);
         assert_eq!(msg["notification"]["removedResults"]["results"]["bindings"], json!([]));
     }
+
+    // [OPUS-4.8] sq-4vao: behavioural tests for the lowest-covered subscription pieces — the
+    // budget→status classification, the RDF-1.2 triple-term encoding, the error-frame builder
+    // edges, and the transport-agnostic reevaluate_step / subscribe_init state machine (the
+    // added/removed diff, mid-stream termination, and the refusal classes).
+
+    #[test]
+    fn term_json_encodes_an_rdf12_triple_term() {
+        // The `oxrdf::Term::Triple` arm (the SPARQL 1.2 quoted-triple-term encoding) is the only
+        // term shape the existing tests miss. A solution row whose object is a triple term must
+        // serialise to `{"type":"triple","value":{subject,predicate,object}}`.
+        use oxrdf::{Literal, NamedNode, Term, Triple};
+        let inner = Triple::new(
+            NamedNode::new("http://ex/s").unwrap(),
+            NamedNode::new("http://ex/p").unwrap(),
+            Literal::new_simple_literal("o"),
+        );
+        let v = term_json(&Term::Triple(Box::new(inner)));
+        assert_eq!(v["type"], "triple");
+        assert_eq!(v["value"]["subject"], json!({"type": "uri", "value": "http://ex/s"}));
+        assert_eq!(v["value"]["predicate"], json!({"type": "uri", "value": "http://ex/p"}));
+        assert_eq!(v["value"]["object"], json!({"type": "literal", "value": "o"}));
+    }
+
+    #[test]
+    fn budget_error_classifies_engine_strings_into_sse_statuses() {
+        let cfg = ServerConfig {
+            query_timeout: Some(std::time::Duration::from_secs(7)),
+            max_results: Some(99),
+            ..ServerConfig::default()
+        };
+        // Timeout → 503, and the message names the configured limit in seconds.
+        let timeout = budget_error("query budget exceeded (timeout)", &cfg);
+        assert_eq!(timeout.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(timeout.message.contains("7s"), "msg: {}", timeout.message);
+        // Row cap → 413, and the message names the configured max-results.
+        let rowcap = budget_error("query budget exceeded (max-rows)", &cfg);
+        assert_eq!(rowcap.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert!(rowcap.message.contains("99"), "msg: {}", rowcap.message);
+        // Anything else → 500, message passed through verbatim.
+        let other = budget_error("denied SERVICE host", &cfg);
+        assert_eq!(other.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(other.message, "denied SERVICE host");
+    }
+
+    #[test]
+    fn error_msg_carries_id_and_alias_when_present() {
+        // The id+alias arms (the `Some` branches) are exercised only by a terminating /
+        // unsubscribe-failure frame; assert both members land under the `error` envelope.
+        let with = error_msg("re-evaluation failed", Some(42), Some("watch"));
+        assert_eq!(with["error"]["message"], "re-evaluation failed");
+        assert_eq!(with["error"]["id"], 42);
+        assert_eq!(with["error"]["alias"], "watch");
+        // And that neither is emitted when absent (the `None` arms).
+        let bare = error_msg("bad json", None, None);
+        assert_eq!(bare["error"]["message"], "bad json");
+        assert!(bare["error"].get("id").is_none());
+        assert!(bare["error"].get("alias").is_none());
+    }
+
+    /// A `Subscription` whose diff baseline is the result of `query` over `state` right now,
+    /// leaking its global slot (the test owns the state lifetime and asserts nothing about leaks).
+    async fn seeded_sub(state: &AppState, alias: Option<&str>, query: &str) -> Subscription {
+        let mut slots = ConnSlots::new(state.subs.clone());
+        let new = match subscribe_init(state, &mut slots, 0, query, alias.map(str::to_string)).await {
+            Ok(n) => n,
+            Err(r) => panic!("initial subscribe should succeed, refused with {}", r.status),
+        };
+        std::mem::forget(slots); // hold the acquired slot for the test's lifetime
+        new.subscription
+    }
+
+    #[tokio::test]
+    async fn reevaluate_step_is_unchanged_then_notifies_on_a_real_diff() {
+        let state = AppState::new(graph("@prefix ex: <http://ex/> . ex:a ex:p ex:b ."));
+        let q = "SELECT ?s WHERE { ?s <http://ex/p> ?o }";
+        let mut sub = seeded_sub(&state, Some("w"), q).await;
+
+        // No change to the graph → the diff is empty → Unchanged (emit nothing).
+        assert!(matches!(sub.reevaluate_step(1, &state).await, ReevalStep::Unchanged));
+
+        // Insert a matching triple → re-evaluation yields one added row, no removed rows.
+        state
+            .apply_update("INSERT DATA { <http://ex/c> <http://ex/p> <http://ex/d> }")
+            .unwrap();
+        match sub.reevaluate_step(1, &state).await {
+            ReevalStep::Notify(msg) => {
+                assert_eq!(msg["notification"]["id"], 1);
+                assert_eq!(msg["notification"]["alias"], "w");
+                // sequence advanced from the seeded 0 to 1.
+                assert_eq!(msg["notification"]["sequence"], 1);
+                let added = &msg["notification"]["addedResults"]["results"]["bindings"];
+                assert_eq!(added.as_array().unwrap().len(), 1);
+                assert_eq!(added[0]["s"]["value"], "http://ex/c");
+                assert_eq!(msg["notification"]["removedResults"]["results"]["bindings"], json!([]));
+            }
+            ReevalStep::Unchanged => panic!("expected Notify after an insert, got Unchanged"),
+            ReevalStep::Terminate(msg) => panic!("expected Notify, got Terminate: {msg}"),
+        }
+        // The baseline advanced, so an immediate re-evaluation with no further change is Unchanged.
+        assert!(matches!(sub.reevaluate_step(1, &state).await, ReevalStep::Unchanged));
+    }
+
+    #[tokio::test]
+    async fn reevaluate_step_terminates_when_a_later_result_overflows_the_row_cap() {
+        // Seed under a row cap of 1 with exactly one matching row (initial eval fits), then grow
+        // the graph past the cap so the NEXT re-evaluation overflows → Terminate, carrying the
+        // row-cap message and the subscription id.
+        let cfg = ServerConfig { max_results: Some(1), ..ServerConfig::default() };
+        let state = AppState::with_config(graph("@prefix ex: <http://ex/> . ex:a ex:p ex:b ."), cfg);
+        let q = "SELECT ?s WHERE { ?s <http://ex/p> ?o }";
+        let mut sub = seeded_sub(&state, None, q).await;
+
+        state
+            .apply_update("INSERT DATA { <http://ex/c> <http://ex/p> <http://ex/d> }")
+            .unwrap();
+        match sub.reevaluate_step(5, &state).await {
+            ReevalStep::Terminate(msg) => {
+                assert_eq!(msg["error"]["id"], 5);
+                let m = msg["error"]["message"].as_str().unwrap();
+                assert!(m.contains("re-evaluation failed"), "msg: {m}");
+                assert!(m.contains("max-results"), "msg: {m}");
+            }
+            ReevalStep::Unchanged => panic!("expected Terminate on row-cap overflow, got Unchanged"),
+            ReevalStep::Notify(msg) => panic!("expected Terminate on row-cap overflow, got Notify: {msg}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn subscribe_init_refuses_non_select_and_malformed_queries() {
+        let state = AppState::new(graph("@prefix ex: <http://ex/> . ex:a ex:p ex:b ."));
+        let mut slots = ConnSlots::new(state.subs.clone());
+
+        // A well-formed but non-SELECT query (ASK) is a client error → 400.
+        let ask = subscribe_init(&state, &mut slots, 0, "ASK { ?s ?p ?o }", None)
+            .await
+            .err()
+            .expect("ASK is not subscribable");
+        assert_eq!(ask.status, StatusCode::BAD_REQUEST);
+        assert!(ask.error["error"]["message"].as_str().unwrap().contains("only SELECT"));
+
+        // A malformed query is also a 400, with the parse error surfaced.
+        let bad = subscribe_init(&state, &mut slots, 0, "SELECT ?s WHERE {", None)
+            .await
+            .err()
+            .expect("a malformed query is refused");
+        assert_eq!(bad.status, StatusCode::BAD_REQUEST);
+        assert!(bad.error["error"]["message"].as_str().unwrap().contains("malformed query"));
+
+        // A refusal holds NO global slot.
+        assert_eq!(state.subs.active_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn subscribe_init_enforces_per_connection_and_global_slot_caps() {
+        let cfg = ServerConfig { max_subscriptions_per_conn: 2, max_subscriptions: 1, ..ServerConfig::default() };
+        let state = AppState::with_config(graph("@prefix ex: <http://ex/> . ex:a ex:p ex:b ."), cfg);
+        let q = "SELECT ?s WHERE { ?s <http://ex/p> ?o }";
+
+        let mut slots = ConnSlots::new(state.subs.clone());
+        // current_conn_subs already at the per-conn cap → refuse with 503, no slot taken.
+        let per_conn = subscribe_init(&state, &mut slots, 2, q, None)
+            .await
+            .err()
+            .expect("per-connection cap refuses");
+        assert_eq!(per_conn.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(per_conn.error["error"]["message"].as_str().unwrap().contains("this connection"));
+        assert_eq!(state.subs.active_count(), 0);
+
+        // Take the single global slot, then a second attempt hits the global cap → 503.
+        assert!(subscribe_init(&state, &mut slots, 0, q, None).await.is_ok(), "first global slot should be granted");
+        assert_eq!(state.subs.active_count(), 1);
+        let global = subscribe_init(&state, &mut slots, 0, q, None)
+            .await
+            .err()
+            .expect("global cap refuses");
+        assert_eq!(global.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(global.error["error"]["message"].as_str().unwrap().contains("server-wide"));
+        // The failed global acquire released its provisional slot — still exactly one held.
+        assert_eq!(state.subs.active_count(), 1);
+    }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent — automated PR (one of several agents @jeswr runs on this account).

Implements **sq-4vao** (test-quality epic sq-qcnn): coverage floor-raise for **sparq-server**. Adds REAL behaviour-asserting tests for the crate's least-covered modules, lifting measured line coverage **86.38% → 88.14%** and ratcheting the per-crate floor **85 → 86** in `bench/coverage-floor.json` (floor = `floor(measured) - 2` margin; the sq-hbg7 ratchet).

### What the new tests pin (all observable behaviour, no vacuous line-touchers)

**`subscriptions.rs`** (88.11% → 93.77%)
- The transport-agnostic `Subscription::reevaluate_step` state machine: `Unchanged` (empty diff), `Notify` on a real added/removed diff after an `apply_update`, and `Terminate` when a later result overflows the row cap (baseline not advanced).
- `subscribe_init` refusal classes: non-SELECT + malformed query → **400**; per-connection and server-wide subscription-slot caps → **503** (and a refusal holds **no** global slot).
- `budget_error` → SSE status classification (timeout→503 / row-cap→413 / other→500), the RDF-1.2 triple-term `term_json` encoding, and the `error_msg` id+alias arms.

**`http.rs`** (89.93% → 91.18%)
- The `{"error":"…"}` `json_error` JSON-string escaping (quote / backslash / control chars + `\u`-escape) — re-parses through a real JSON parser back to the original message (JSON-injection prevention).
- The `sanitized_error` info-leak guard (#241 posture): the sensitive detail (loaded-data fragment / filesystem path) is withheld from the client body.
- The GSP write helpers: `escape_iri` IRIREF-injection neutralisation, `graph_data_block` / `base_iri`, and `body_to_ntriples` 415 (unsupported media type) / 400 (non-UTF-8) arms.
- The SPARQL 1.1 Protocol dataset-override parse (`using-*` / `*-graph-uri`), the `rewrite_update` `UsingConflict`/`Malformed` → 400 mapping, and `form_decode` edge cases (`+`, `%XX`, malformed escape).

**`results.rs`** (96.43% → 97.65%): XML text-body escaping of markup chars (XML-injection prevention) and a blank-node-subject RDF-1.2 triple term.
**`graph.rs`** (97.12% → 98.18%): `parse_rdfxml` invalid-base-IRI rejection.
**`health_probe.rs`** (86.02% → 87.63%): a non-UTF-8 HTTP status line fails closed (no panic).

### Scope / honesty
Tests only, plus a reviewed `bench/coverage-floor.json` bump. **No production code or public API changed** (so no SKILL.md / G2 update). The deep async error paths (`run_probe` IO branches, worker timeout/panic, durable-persist failure injection) and `ServerConfig::from_env` (process-global env mutation, forbidden under this crate's `forbid(unsafe_code)`) remain uncovered by design — chasing them would mean brittle or unsound tests for marginal gain.

### Gate (all green)
- `cargo clippy -p sparq-server --all-targets -- -D warnings` (default **and** `--all-features`)
- `cargo test -p sparq-server` (146 lib + all integration suites) — lib also builds `--no-default-features` (serializer-only library)
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sparq-server --no-deps` and again `--all-features`
- `scripts/check-privacy-claims.sh`
- No `unsafe` added (crate is `#![forbid(unsafe_code)]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)