### PR TITLE
ci: add coverage/mutation floor files to the 'rust' paths-filter (sq-spfg) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,17 @@ jobs:
               - 'Cargo.lock'
               - 'rust-toolchain*'
               - '.github/workflows/ci.yml'
+              # [OPUS-4.8] sq-spfg: the checked-in coverage/mutation FLOOR files are ratchet
+              # inputs the `coverage` job's --check-monotonic gate validates. Without these,
+              # a PR that lowers ONLY a floor (no .rs/Cargo/ci.yml change) sets
+              # rust_changed=false, SKIPS the coverage job, and bypasses the monotonicity
+              # gate at the PR level (merge_group force-true still catches it in the queue,
+              # but the PR-level gate should fire too). List them so a floor-only PR runs the
+              # gate that guards exactly those files. mutants-baseline.json is included
+              # defensively for when the advisory mutation ratchet is promoted to gating.
+              - 'bench/coverage-floor.json'
+              - 'bench/coverage-presence.json'
+              - 'bench/mutants-baseline.json'
             docker:
               - 'Dockerfile'
               - '**/Dockerfile'


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Implements bead **sq-spfg**.

## What

Add `bench/coverage-floor.json`, `bench/coverage-presence.json`, and `bench/mutants-baseline.json` to the `rust` `dorny/paths-filter` pattern in `.github/workflows/ci.yml`.

## Why

Verification of #665 (sq-neq8) found a residual gap. The `coverage` job runs the `--check-monotonic` ratchet over the checked-in floor files, but it is gated on `needs.changes.outputs.rust_changed`, whose `rust` paths-filter matched `**/*.rs`, `Cargo.toml`/`Cargo.lock`, `rust-toolchain*`, and `ci.yml` — **but not the floor files themselves**.

A PR that lowered **only** a floor file (no `.rs`/`Cargo`/`ci.yml` change) would set `rust_changed=false`, skip the `coverage` job, and bypass the PR-level monotonicity gate. This was mitigated by `merge_group` forcing `rust_changed=true` (so the gate still fires in the merge queue) and by the realistic regression shape always touching code — but the PR-level gate should still fire on a floor-only PR.

## Change

List the three floor/ratchet inputs in the `rust` filter so a floor-only PR runs exactly the gate that guards those files. `bench/mutants-baseline.json` is included defensively — the mutation ratchet is currently advisory + schedule-only, but listing it now means a future promotion to a PR-level gate is already covered.

## Gate

CI-only change: no Rust source, no public API, no `unsafe`. YAML validated as well-formed and parses to the expected filter structure. The standard cargo/clippy/rustdoc/privacy gates do not apply (no Rust touched).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
