### PR TITLE
feat(site): /surface/inference tier-b live page (W-reason bundle) (sq-0po6) [OPUS-4.8]

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -106,6 +106,15 @@ jobs:
           npm ci
           npm run build:wasm
 
+      # [OPUS-4.8] sq-0po6 — build the tier-b "W-reason" bundle (crates/sparq-reason-wasm,
+      # with --features explain) that drives the live /surface/inference page. Its
+      # wasm-pack output stays in the crate's pkg/; the site's prebuild sync-wasm step
+      # copies it into public/wasm/reason/. Separate from the lean bundle so the landing
+      # page stays light (the page lazy-loads it on first interaction).
+      - name: Build W-reason wasm bundle
+        working-directory: js
+        run: npm run build:reason-wasm
+
       # [OPUS-4.8] sq-gum8 — install the Typst CLI so the paper-factory build step
       # (site/scripts/build-papers.mjs, run by `prebuild`) can compile site/papers/*.typ
       # into the downloadable PDFs + the in-site HTML renders. Pinned to a release tag +

--- a/js/package.json
+++ b/js/package.json
@@ -36,6 +36,7 @@
     "_copy:wasm": "rm -rf wasm && mkdir wasm && cp ../crates/sparq-wasm/pkg/sparq_wasm.js ../crates/sparq-wasm/pkg/sparq_wasm.d.ts ../crates/sparq-wasm/pkg/sparq_wasm_bg.wasm ../crates/sparq-wasm/pkg/sparq_wasm_bg.wasm.d.ts wasm/",
     "build:wasm": "wasm-pack build ../crates/sparq-wasm --target web --release -- --features shacl,jsonld && npm run _copy:wasm",
     "build:wasm:lean": "wasm-pack build ../crates/sparq-wasm --target web --release && npm run _copy:wasm",
+    "build:reason-wasm": "wasm-pack build ../crates/sparq-reason-wasm --target web --release -- --features explain",
     "build:ts": "tsc",
     "build": "npm run build:wasm && npm run build:ts",
     "test": "node --test \"test/*.test.mjs\"",

--- a/site/scripts/sync-wasm.mjs
+++ b/site/scripts/sync-wasm.mjs
@@ -28,3 +28,34 @@ for (const f of files) {
   await copyFile(join(src, f), join(dest, f));
 }
 console.log(`[sync-wasm] copied ${files.length} files → public/wasm/`);
+
+// [OPUS-4.8] sq-0po6 — also sync the tier-b "W-reason" bundle that drives
+// /surface/inference (crates/sparq-reason-wasm, built with `--features explain` by
+// `js/`'s `build:reason-wasm`). Its wasm-pack output stays in the crate's own pkg/
+// (it is NOT part of the published @jeswr/sparq package), so we copy it from there
+// into public/wasm/reason/. This bundle is OPTIONAL: if it has not been built (e.g. a
+// quick `next dev` that skips it), we WARN and skip rather than fail — the inference
+// page surfaces a clear "bundle failed to load" state at runtime in that case.
+const reasonSrc = join(here, "..", "..", "crates", "sparq-reason-wasm", "pkg");
+const reasonDest = join(dest, "reason");
+const reasonFiles = [
+  "sparq_reason_wasm.js",
+  "sparq_reason_wasm_bg.wasm",
+  "sparq_reason_wasm.d.ts",
+];
+
+try {
+  await access(join(reasonSrc, "sparq_reason_wasm_bg.wasm"));
+  await mkdir(reasonDest, { recursive: true });
+  for (const f of reasonFiles) {
+    await copyFile(join(reasonSrc, f), join(reasonDest, f));
+  }
+  console.log(
+    `[sync-wasm] copied ${reasonFiles.length} files → public/wasm/reason/ (W-reason)`,
+  );
+} catch {
+  console.warn(
+    `[sync-wasm] W-reason bundle not found at ${reasonSrc}; /surface/inference will not\n` +
+      `            run live. Build it:  (cd ../js && npm run build:reason-wasm)`,
+  );
+}

--- a/site/src/app/surface/[slug]/page.tsx
+++ b/site/src/app/surface/[slug]/page.tsx
@@ -13,6 +13,7 @@ const BUILT_SURFACES = new Set([
   "data-formats",
   "javascript-wasm",
   "shacl",
+  "inference",
   "mpc",
   "zk",
 ]);

--- a/site/src/app/surface/inference/page.tsx
+++ b/site/src/app/surface/inference/page.tsx
@@ -1,0 +1,108 @@
+import type { Metadata } from "next";
+import { Brain } from "lucide-react";
+
+import { SurfaceContent } from "@/components/surface-content";
+import { InferencePlayground } from "@/components/inference-playground";
+
+export const metadata: Metadata = {
+  title: "Inference",
+  description:
+    "Forward-chaining RDFS / OWL 2 RL / Notation3 reasoning with the sparq reasoner — base vs entailed triple counts and a why() derivation proof tree, live in your tab via the W-reason wasm bundle.",
+};
+
+export default function InferenceSurfacePage() {
+  return (
+    <SurfaceContent
+      icon={Brain}
+      title="Inference"
+      statement="Forward-chain the RDFS / OWL 2 RL / N3 closure — see what reasoning adds, then ask why."
+      tier="live-new-wasm"
+      intro={
+        <>
+          <p>
+            <code className="font-mono text-foreground">sparq-reason</code> is a
+            forward-chaining reasoner over a{" "}
+            <code className="font-mono">sparq_core::Graph</code>: it materializes
+            the deductive closure of an ontology + facts under{" "}
+            <strong className="text-foreground">RDFS</strong> or{" "}
+            <strong className="text-foreground">OWL 2 RL</strong>, runs{" "}
+            <strong className="text-foreground">Notation3 rules</strong> (
+            <code className="font-mono">{"{ … } => { … }"}</code>), and — uniquely —
+            reconstructs a <code className="font-mono">why()</code>{" "}
+            <strong className="text-foreground">derivation proof tree</strong> for
+            any entailed triple: the chain of inference rules and asserted facts that
+            justify it.
+          </p>
+          <p>
+            Because it is pure Rust over <code className="font-mono">sparq-engine</code>
+            , it compiles to wasm. The playground below loads the tier-b{" "}
+            <strong className="text-foreground">&ldquo;W-reason&rdquo; bundle</strong>{" "}
+            on demand — a separate, lazily-loaded bundle from the lean SPARQL REPL — and
+            runs the reasoner in this tab: paste an ontology, see the base vs entailed
+            triple counts, then click an entailed triple to render its proof. The
+            default is the classic Socrates syllogism.
+          </p>
+        </>
+      }
+      capabilities={[
+        {
+          title: "RDFS closure",
+          body: "subClassOf / subPropertyOf / domain / range entailments, forward-chained to fixpoint.",
+        },
+        {
+          title: "OWL 2 RL closure",
+          body: "Property axioms (inverseOf, symmetric/transitive), class axioms, restrictions — the RL profile (includes RDFS).",
+        },
+        {
+          title: "Notation3 rules",
+          body: "{ … } => { … } rule documents over facts — the Socrates example, run in-tab.",
+        },
+        {
+          title: "Base vs entailed counts",
+          body: "Distinct asserted triples, the closure size, and exactly how many triples reasoning added.",
+        },
+        {
+          title: "why() proof trees",
+          body: "Click an entailed triple for one derivation: a premises-before-conclusion DAG bottoming out in asserted facts.",
+        },
+        {
+          title: "Entailed-only delta",
+          body: "Just the triples reasoning ADDED — the closure minus the asserted base — not the whole closure.",
+        },
+      ]}
+      runsNote={
+        <>
+          <p>
+            <strong className="text-foreground">Live in your browser tab.</strong>{" "}
+            The reasoner is pure Rust over the engine, compiled to wasm in the
+            separate W-reason bundle (
+            <code className="font-mono">sparq-reason-wasm</code>, built with the{" "}
+            <code className="font-mono">explain</code> feature for{" "}
+            <code className="font-mono">why()</code>). The page lazy-loads it on first
+            interaction so the landing page never pays for it, then calls the bundle&rsquo;s{" "}
+            <code className="font-mono text-foreground">Reasoner.materializeStats</code>,{" "}
+            <code className="font-mono">Reasoner.entailed</code> /{" "}
+            <code className="font-mono">Reasoner.reasonN3</code>, and{" "}
+            <code className="font-mono">Reasoner.why</code> bindings — nothing is sent
+            to a server.
+          </p>
+        </>
+      }
+      caveat={
+        <>
+          <p>
+            The reasoner is a forward-chaining materializer sized for the
+            illustrative documents here (tens of triples); it is not a tableau OWL DL
+            reasoner, and the OWL 2 RL profile is the rule-based RL fragment, not full
+            OWL. The N3 mode reasons over the rule document directly, so the{" "}
+            <code className="font-mono">why?</code> proof-tree button is shown for the
+            RDFS / OWL profiles only. Materialize large graphs server-side via{" "}
+            <code className="font-mono">sparq-cli reason</code>.
+          </p>
+        </>
+      }
+    >
+      <InferencePlayground />
+    </SurfaceContent>
+  );
+}

--- a/site/src/components/inference-playground.tsx
+++ b/site/src/components/inference-playground.tsx
@@ -1,0 +1,525 @@
+"use client";
+
+// [OPUS-4.8] sq-0po6 — the live /surface/inference playground: load an ontology + facts
+// (or an N3 rule document), forward-chain the closure in your tab via the tier-b W-reason
+// wasm bundle, see the base-vs-entailed triple counts, then click an entailed triple to
+// render its why() derivation proof tree. The default is the Socrates syllogism. Mirrors
+// the SHACL playground's shape (examples → editor → run → result), but loads the SEPARATE
+// reason bundle (src/lib/reason-wasm.ts) lazily so the landing page never pays for it.
+
+import * as React from "react";
+import {
+  Play,
+  Loader2,
+  Brain,
+  CheckCircle2,
+  Sparkles,
+  HelpCircle,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  loadReasoner,
+  prewarmReason,
+  PROFILE_LABEL,
+  type MaterializeStats,
+  type ProofTree,
+  type ReasoningProfile,
+} from "@/lib/reason-wasm";
+import {
+  formatTriple,
+  parseNTriples,
+  parseProof,
+  parseStats,
+  proofRows,
+  ruleLabel,
+  shortenTerm,
+  type Triple,
+} from "@/lib/inference";
+import {
+  INFERENCE_EXAMPLES,
+  type InferenceMode,
+} from "@/data/inference-examples";
+
+interface ReasonResult {
+  /** Counts (profile mode only; N3 mode has no closure/base split). */
+  stats: MaterializeStats | null;
+  /** The NEWLY-entailed triples (profile mode) or the N3-derived ground triples. */
+  entailed: Triple[];
+  ms: number;
+  mode: InferenceMode;
+  profile: ReasoningProfile;
+  /** The exact document reasoned over (so a why() click reasons the same input). */
+  data: string;
+}
+
+type RunState =
+  | { kind: "idle" }
+  | { kind: "running" }
+  | { kind: "result"; result: ReasonResult }
+  | { kind: "error"; message: string };
+
+type EngineState = "cold" | "warming" | "ready" | "error";
+
+const DEFAULT = INFERENCE_EXAMPLES[0];
+const PROFILES: ReasoningProfile[] = ["rdfs", "owl-rl"];
+
+export function InferencePlayground() {
+  const [data, setData] = React.useState(DEFAULT.data);
+  const [mode, setMode] = React.useState<InferenceMode>(DEFAULT.mode);
+  const [profile, setProfile] = React.useState<ReasoningProfile>(DEFAULT.profile);
+  const [state, setState] = React.useState<RunState>({ kind: "idle" });
+  const [engine, setEngine] = React.useState<EngineState>("cold");
+  const [activeExample, setActiveExample] = React.useState<string>(DEFAULT.id);
+  // The triple whose proof is being shown (and the proof itself / loading flag).
+  const [proof, setProof] = React.useState<{
+    triple: Triple;
+    tree: ProofTree | null;
+    loading: boolean;
+  } | null>(null);
+
+  // Pre-warm the W-reason bundle on mount (off the render path) so the first "Reason"
+  // pays no cold start. A failure resets the indicator; reasoning retries the load.
+  React.useEffect(() => {
+    let cancelled = false;
+    setEngine("warming");
+    prewarmReason()
+      .then(() => {
+        if (!cancelled) setEngine("ready");
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setEngine("error");
+        toast.error("Reasoner failed to load", {
+          description: e instanceof Error ? e.message : String(e),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const run = React.useCallback(async () => {
+    setState({ kind: "running" });
+    setProof(null);
+    try {
+      const Reasoner = await loadReasoner();
+      const t0 = performance.now();
+      let stats: MaterializeStats | null = null;
+      let entailed: Triple[];
+      if (mode === "n3") {
+        entailed = parseNTriples(Reasoner.reasonN3(data));
+      } else {
+        stats = parseStats(Reasoner.materializeStats(data, "turtle", profile));
+        entailed = parseNTriples(Reasoner.entailed(data, "turtle", profile));
+      }
+      const ms = performance.now() - t0;
+      setEngine("ready");
+      setState({
+        kind: "result",
+        result: { stats, entailed, ms, mode, profile, data },
+      });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setState({ kind: "error", message });
+      toast.error("Reasoning failed", { description: message });
+    }
+  }, [data, mode, profile]);
+
+  const explain = React.useCallback(
+    async (triple: Triple, result: ReasonResult) => {
+      // N3 rule reasoning has no profile-based proof tree (why() runs RDFS/OWL closure).
+      if (result.mode === "n3") return;
+      setProof({ triple, tree: null, loading: true });
+      try {
+        const Reasoner = await loadReasoner();
+        if (typeof Reasoner.why !== "function") {
+          throw new Error(
+            "This W-reason bundle was built without the `explain` feature (no why binding).",
+          );
+        }
+        const json = Reasoner.why(
+          result.data,
+          "turtle",
+          result.profile,
+          triple.subject,
+          triple.predicate,
+          triple.object,
+        );
+        setProof({ triple, tree: parseProof(json), loading: false });
+      } catch (e) {
+        setProof(null);
+        toast.error("Proof failed", {
+          description: e instanceof Error ? e.message : String(e),
+        });
+      }
+    },
+    [],
+  );
+
+  const selectExample = React.useCallback((id: string) => {
+    const ex = INFERENCE_EXAMPLES.find((e) => e.id === id);
+    if (!ex) return;
+    setData(ex.data);
+    setMode(ex.mode);
+    setProfile(ex.profile);
+    setActiveExample(id);
+    setState({ kind: "idle" });
+    setProof(null);
+  }, []);
+
+  const busy = state.kind === "running";
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center justify-between gap-2 space-y-0">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Brain className="size-4 text-primary" />
+          Live reasoner
+        </CardTitle>
+        <EngineIndicator engine={engine} />
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap gap-1.5">
+          {INFERENCE_EXAMPLES.map((ex) => (
+            <Button
+              key={ex.id}
+              variant={activeExample === ex.id ? "default" : "outline"}
+              size="sm"
+              onClick={() => selectExample(ex.id)}
+              title={ex.description}
+            >
+              {ex.label}
+            </Button>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <ModeTabs mode={mode} onChange={setMode} />
+          {mode === "profile" && (
+            <div
+              role="radiogroup"
+              aria-label="Reasoning profile"
+              className="inline-flex rounded-lg border bg-muted/40 p-0.5"
+            >
+              {PROFILES.map((p) => (
+                <button
+                  key={p}
+                  type="button"
+                  role="radio"
+                  aria-checked={profile === p}
+                  onClick={() => setProfile(p)}
+                  className={cn(
+                    "rounded-md px-2.5 py-1 text-xs font-medium transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/40",
+                    profile === p
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {PROFILE_LABEL[p]}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <label
+            htmlFor="reason-data"
+            className="text-xs font-medium text-muted-foreground"
+          >
+            {mode === "n3"
+              ? "N3 rules + facts"
+              : "Ontology + facts (Turtle)"}
+          </label>
+          <textarea
+            id="reason-data"
+            value={data}
+            spellCheck={false}
+            onChange={(e) => setData(e.target.value)}
+            rows={12}
+            className="w-full resize-y rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Button onClick={run} disabled={busy}>
+            {busy ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Play className="size-4" />
+            )}
+            Reason
+          </Button>
+          <p aria-live="polite" className="text-xs text-muted-foreground">
+            {state.kind === "result" &&
+              `${state.result.entailed.length} entailed · ${state.result.ms.toFixed(1)} ms`}
+            {state.kind === "running" && "Forward-chaining on the wasm reasoner…"}
+            {state.kind === "idle" &&
+              engine === "warming" &&
+              "Pre-warming the W-reason bundle…"}
+          </p>
+        </div>
+
+        <ResultPanel
+          state={state}
+          proof={proof}
+          onExplain={explain}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function EngineIndicator({ engine }: { engine: EngineState }) {
+  if (engine === "ready") {
+    return (
+      <Badge variant="success" aria-live="polite">
+        <CheckCircle2 className="size-3" /> Reasoner ready
+      </Badge>
+    );
+  }
+  if (engine === "error") {
+    return (
+      <Badge variant="warning" aria-live="polite">
+        Reasoner failed — retries on reason
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="muted" aria-live="polite">
+      <Loader2 className="size-3 animate-spin" /> Bundle loading…
+    </Badge>
+  );
+}
+
+function ModeTabs({
+  mode,
+  onChange,
+}: {
+  mode: InferenceMode;
+  onChange: (m: InferenceMode) => void;
+}) {
+  const tabs: { value: InferenceMode; label: string }[] = [
+    { value: "profile", label: "RDFS / OWL" },
+    { value: "n3", label: "N3 rules" },
+  ];
+  return (
+    <div
+      role="tablist"
+      aria-label="Reasoning mode"
+      className="inline-flex rounded-lg border bg-muted/40 p-0.5"
+    >
+      {tabs.map((t) => (
+        <button
+          key={t.value}
+          type="button"
+          role="tab"
+          aria-selected={mode === t.value}
+          onClick={() => onChange(t.value)}
+          className={cn(
+            "rounded-md px-2.5 py-1 text-xs font-medium transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/40",
+            mode === t.value
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ResultPanel({
+  state,
+  proof,
+  onExplain,
+}: {
+  state: RunState;
+  proof: {
+    triple: Triple;
+    tree: ProofTree | null;
+    loading: boolean;
+  } | null;
+  onExplain: (triple: Triple, result: ReasonResult) => void;
+}) {
+  if (state.kind === "error") {
+    return (
+      <pre className="overflow-x-auto rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+        {state.message}
+      </pre>
+    );
+  }
+  if (state.kind !== "result") return null;
+  const { result } = state;
+
+  return (
+    <div className="space-y-3">
+      {result.stats && <CountSummary stats={result.stats} />}
+      <EntailedList result={result} onExplain={onExplain} />
+      {proof && <ProofView proof={proof} />}
+    </div>
+  );
+}
+
+function CountSummary({ stats }: { stats: MaterializeStats }) {
+  const cells: { label: string; value: number; accent?: boolean }[] = [
+    { label: "asserted (base)", value: stats.baseTriples },
+    { label: "after closure", value: stats.closureTriples },
+    { label: "entailed (added)", value: stats.entailed, accent: true },
+  ];
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      {cells.map((c) => (
+        <div
+          key={c.label}
+          className={cn(
+            "rounded-lg border bg-muted/30 p-3 text-center",
+            c.accent &&
+              "bg-[color-mix(in_oklch,var(--success)_12%,transparent)] ring-1 ring-[var(--success)]/30",
+          )}
+        >
+          <div
+            className={cn(
+              "text-xl font-semibold tabular-nums",
+              c.accent ? "text-[var(--success)]" : "text-foreground",
+            )}
+          >
+            {c.value}
+          </div>
+          <div className="text-[11px] text-muted-foreground">{c.label}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EntailedList({
+  result,
+  onExplain,
+}: {
+  result: ReasonResult;
+  onExplain: (triple: Triple, result: ReasonResult) => void;
+}) {
+  if (result.entailed.length === 0) {
+    return (
+      <p className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+        No new triples were entailed — the document is already deductively closed
+        under {result.mode === "n3" ? "its rules" : PROFILE_LABEL[result.profile]}.
+      </p>
+    );
+  }
+  const canExplain = result.mode === "profile";
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <Sparkles className="size-4 text-[var(--success)]" aria-hidden="true" />
+        Entailed triples
+        <span className="text-xs font-normal text-muted-foreground">
+          {canExplain ? "— click “why?” for the derivation" : ""}
+        </span>
+      </div>
+      <ul className="space-y-1.5">
+        {result.entailed.map((t, i) => (
+          <li
+            key={i}
+            className="flex items-center justify-between gap-3 rounded-lg border bg-muted/30 px-3 py-2"
+          >
+            <code className="break-all font-mono text-[12.5px] text-foreground">
+              {formatTriple(t)}
+            </code>
+            {canExplain && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="shrink-0"
+                onClick={() => onExplain(t, result)}
+              >
+                <HelpCircle className="size-3.5" aria-hidden="true" />
+                why?
+              </Button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ProofView({
+  proof,
+}: {
+  proof: {
+    triple: Triple;
+    tree: ProofTree | null;
+    loading: boolean;
+  };
+}) {
+  return (
+    <div className="space-y-2 rounded-lg border bg-background p-3">
+      <div className="text-sm font-medium">
+        Why{" "}
+        <code className="font-mono text-[12.5px] text-primary">
+          {formatTriple(proof.triple)}
+        </code>
+        ?
+      </div>
+      {proof.loading ? (
+        <p className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="size-3 animate-spin" /> Deriving the proof…
+        </p>
+      ) : proof.tree === null ? (
+        <p className="text-xs text-muted-foreground">
+          That triple is not entailed — no derivation.
+        </p>
+      ) : (
+        <ProofTreeView tree={proof.tree} />
+      )}
+    </div>
+  );
+}
+
+function ProofTreeView({ tree }: { tree: ProofTree }) {
+  const rows = proofRows(tree);
+  return (
+    <ol className="space-y-1">
+      {rows.map((row, i) => {
+        const asserted = row.node.rule === "asserted";
+        return (
+          <li
+            key={i}
+            className="flex flex-wrap items-center gap-2 text-[12.5px]"
+            style={{ paddingLeft: `${row.depth * 1.25}rem` }}
+          >
+            <Badge
+              variant={asserted ? "muted" : "default"}
+              className="font-mono text-[10.5px]"
+            >
+              {ruleLabel(row.node.rule)}
+            </Badge>
+            <code className="break-all font-mono text-foreground">
+              {shortenTerm(row.node.conclusion[0])}{" "}
+              {shortenTerm(row.node.conclusion[1])}{" "}
+              {shortenTerm(row.node.conclusion[2])}
+            </code>
+            {row.repeated && (
+              <span className="text-[11px] text-muted-foreground">
+                (see above)
+              </span>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/site/src/data/inference-examples.ts
+++ b/site/src/data/inference-examples.ts
@@ -1,0 +1,105 @@
+// [OPUS-4.8] sq-0po6 — built-in examples for the live /surface/inference page.
+// The default is the classic Socrates syllogism under RDFS (a subClassOf axiom +
+// an instance entailing `Socrates a Mortal`), the example crates/sparq-reason-wasm
+// itself documents. Two modes:
+//   - "profile": run RDFS / OWL 2 RL forward-chaining over a Turtle document.
+//   - "n3":      run a Notation3 rule document ({ … } => { … } + facts).
+
+import type { ReasoningProfile } from "@/lib/reason-wasm";
+
+export type InferenceMode = "profile" | "n3";
+
+export interface InferenceExample {
+  id: string;
+  label: string;
+  description: string;
+  mode: InferenceMode;
+  /** The reasoning profile (profile mode only; ignored for N3). */
+  profile: ReasoningProfile;
+  /** The RDF / N3 document. */
+  data: string;
+}
+
+const SOCRATES_RDFS = `@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:   <http://ex/> .
+
+# Ontology: every Human is a Mortal.
+ex:Human rdfs:subClassOf ex:Mortal .
+
+# Fact: Socrates is a Human.
+ex:Socrates a ex:Human .
+`;
+
+const SOCRATES_N3 = `@prefix ex: <http://ex/> .
+
+# Rule: anything that is a Human is a Mortal.
+{ ?x a ex:Human } => { ?x a ex:Mortal } .
+
+# Fact: Socrates is a Human.
+ex:Socrates a ex:Human .
+`;
+
+const RDFS_DOMAIN_RANGE = `@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:   <http://ex/> .
+
+# Ontology: knows has domain Person and range Person; Friend is a sub-property of knows.
+ex:knows  rdfs:domain ex:Person ;
+          rdfs:range  ex:Person .
+ex:friend rdfs:subPropertyOf ex:knows .
+
+# Facts: Alice friend Bob.
+ex:Alice ex:friend ex:Bob .
+`;
+
+const OWL_RL_INVERSE = `@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix ex:   <http://ex/> .
+
+# Ontology: parentOf and childOf are inverse properties; siblingOf is symmetric.
+ex:parentOf  owl:inverseOf ex:childOf .
+ex:siblingOf a owl:SymmetricProperty .
+
+# Facts.
+ex:Alice ex:parentOf  ex:Bob .
+ex:Bob   ex:siblingOf ex:Carol .
+`;
+
+export const INFERENCE_EXAMPLES: InferenceExample[] = [
+  {
+    id: "socrates-rdfs",
+    label: "Socrates (RDFS)",
+    description:
+      "The classic syllogism under RDFS: ex:Human rdfs:subClassOf ex:Mortal + ex:Socrates a ex:Human entails ex:Socrates a ex:Mortal.",
+    mode: "profile",
+    profile: "rdfs",
+    data: SOCRATES_RDFS,
+  },
+  {
+    id: "socrates-n3",
+    label: "Socrates (N3 rule)",
+    description:
+      "The same syllogism as a Notation3 rule: { ?x a ex:Human } => { ?x a ex:Mortal } over ex:Socrates a ex:Human.",
+    mode: "n3",
+    profile: "rdfs",
+    data: SOCRATES_N3,
+  },
+  {
+    id: "rdfs-domain-range",
+    label: "Domain / range (RDFS)",
+    description:
+      "rdfs:domain, rdfs:range and rdfs:subPropertyOf entailments: ex:Alice ex:friend ex:Bob types both as ex:Person and infers ex:Alice ex:knows ex:Bob.",
+    mode: "profile",
+    profile: "rdfs",
+    data: RDFS_DOMAIN_RANGE,
+  },
+  {
+    id: "owl-rl-inverse",
+    label: "Inverse / symmetric (OWL 2 RL)",
+    description:
+      "OWL 2 RL property axioms: owl:inverseOf infers ex:Bob ex:childOf ex:Alice, and owl:SymmetricProperty infers ex:Carol ex:siblingOf ex:Bob.",
+    mode: "profile",
+    profile: "owl-rl",
+    data: OWL_RL_INVERSE,
+  },
+];

--- a/site/src/data/surfaces.ts
+++ b/site/src/data/surfaces.ts
@@ -156,6 +156,7 @@ export const GROUPS: SurfaceGroup[] = [
         blurb: "RDFS / OWL 2 RL / N3 closure + proof trees.",
         tier: "live-new-wasm",
         icon: Brain,
+        built: true,
       },
       {
         slug: "shacl",

--- a/site/src/lib/inference.ts
+++ b/site/src/lib/inference.ts
@@ -1,0 +1,200 @@
+// [OPUS-4.8] sq-0po6 — pure, framework-free helpers for the live /surface/inference page:
+// parse the bundle's N-Triples output into clickable triples, parse the stats JSON, and
+// shape a `why()` proof tree for rendering. Kept separate from the React component so they
+// can be unit-tested under node:test without a DOM (test/inference.test.mjs).
+
+import type {
+  MaterializeStats,
+  ProofNode,
+  ProofTree,
+  ReasoningProfile,
+} from "./reason-wasm";
+
+/** A single parsed N-Triples triple: the three term strings exactly as the bundle emits
+ *  them (so they can be fed straight back into `Reasoner.why(s, p, o)`). */
+export interface Triple {
+  subject: string;
+  predicate: string;
+  object: string;
+}
+
+/**
+ * Splits ONE N-Triples line into its three term strings, or `null` if the line is blank, a
+ * comment, or not a well-formed `S P O .` triple. Terms are returned VERBATIM (no
+ * unescaping) so they round-trip back into `Reasoner.why`. Whitespace-tolerant: a term is an
+ * IRI (`<…>`), a blank node (`_:…`), or a literal (`"…"` with optional `^^<dt>` / `@lang`,
+ * honouring `\"` and `\\` escapes inside the quotes).
+ */
+export function parseNTriplesLine(line: string): Triple | null {
+  const trimmed = line.trim();
+  if (trimmed.length === 0 || trimmed.startsWith("#")) return null;
+  // Drop the trailing ` .` statement terminator.
+  if (!trimmed.endsWith(".")) return null;
+  const body = trimmed.slice(0, -1).trim();
+
+  const terms: string[] = [];
+  let i = 0;
+  while (i < body.length && terms.length < 3) {
+    // Skip inter-term whitespace.
+    while (i < body.length && /\s/.test(body[i])) i++;
+    if (i >= body.length) break;
+    const start = i;
+    const c = body[i];
+    if (c === "<") {
+      // IRI: up to the next '>'.
+      const end = body.indexOf(">", i);
+      if (end < 0) return null;
+      i = end + 1;
+    } else if (c === '"') {
+      // Literal: consume the quoted body (honouring escapes), then an optional
+      // datatype (`^^<…>`) or language tag (`@…`).
+      i++;
+      while (i < body.length && body[i] !== '"') {
+        if (body[i] === "\\") i++; // skip the escaped char
+        i++;
+      }
+      if (i >= body.length) return null; // unterminated literal
+      i++; // closing quote
+      if (body.startsWith("^^", i)) {
+        const end = body.indexOf(">", i);
+        if (end < 0) return null;
+        i = end + 1;
+      } else if (body[i] === "@") {
+        i++;
+        while (i < body.length && /[\w-]/.test(body[i])) i++;
+      }
+    } else if (c === "_" && body[i + 1] === ":") {
+      // Blank node: up to whitespace.
+      while (i < body.length && !/\s/.test(body[i])) i++;
+    } else {
+      return null; // unexpected token
+    }
+    terms.push(body.slice(start, i));
+  }
+  // After three terms only trailing whitespace may remain.
+  while (i < body.length && /\s/.test(body[i])) i++;
+  if (terms.length !== 3 || i !== body.length) return null;
+  return { subject: terms[0], predicate: terms[1], object: terms[2] };
+}
+
+/**
+ * Parses a whole N-Triples document (the bundle's `materialize` / `entailed` output) into
+ * its triples, skipping blank/comment lines. Malformed lines are dropped (the bundle emits
+ * canonical N-Triples, so this is robust to a stray blank line, not a lenient parser).
+ */
+export function parseNTriples(nt: string): Triple[] {
+  const out: Triple[] = [];
+  for (const line of nt.split("\n")) {
+    const t = parseNTriplesLine(line);
+    if (t) out.push(t);
+  }
+  return out;
+}
+
+/**
+ * Parses the `Reasoner.materializeStats` JSON, validating the shape. Throws a clear error
+ * if the document is not the expected `{profile, baseTriples, closureTriples, entailed}`.
+ */
+export function parseStats(json: string): MaterializeStats {
+  const v = JSON.parse(json) as unknown;
+  if (
+    typeof v !== "object" ||
+    v === null ||
+    typeof (v as MaterializeStats).baseTriples !== "number" ||
+    typeof (v as MaterializeStats).closureTriples !== "number" ||
+    typeof (v as MaterializeStats).entailed !== "number"
+  ) {
+    throw new Error(`unexpected materializeStats JSON: ${json}`);
+  }
+  return v as MaterializeStats;
+}
+
+/**
+ * Parses the `Reasoner.why` result: a {@link ProofTree} or `null` when the triple is not
+ * entailed (the bundle returns the JSON literal `null`). Throws if the JSON is malformed.
+ */
+export function parseProof(json: string): ProofTree | null {
+  const v = JSON.parse(json) as unknown;
+  if (v === null) return null;
+  if (
+    typeof v !== "object" ||
+    typeof (v as ProofTree).root !== "number" ||
+    !Array.isArray((v as ProofTree).nodes)
+  ) {
+    throw new Error(`unexpected why() JSON: ${json}`);
+  }
+  return v as ProofTree;
+}
+
+// ---- term display ----
+
+const PREFIXES: [string, string][] = [
+  ["http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdf:"],
+  ["http://www.w3.org/2000/01/rdf-schema#", "rdfs:"],
+  ["http://www.w3.org/2002/07/owl#", "owl:"],
+  ["http://www.w3.org/2001/XMLSchema#", "xsd:"],
+  ["http://ex/", "ex:"],
+  ["http://example.org/", "ex:"],
+];
+
+/**
+ * Compacts an N-Triples term for display: an IRI (`<…>`) to a CURIE using the well-known
+ * RDF/RDFS/OWL/XSD/example prefixes (anything else keeps its `<…>`); literals and blank
+ * nodes pass through unchanged.
+ */
+export function shortenTerm(term: string): string {
+  if (term.startsWith("<") && term.endsWith(">")) {
+    const iri = term.slice(1, -1);
+    for (const [ns, prefix] of PREFIXES) {
+      if (iri.startsWith(ns)) return prefix + iri.slice(ns.length);
+    }
+    return term;
+  }
+  return term;
+}
+
+/** A one-line, CURIE-compacted rendering of a triple (`s p o`). */
+export function formatTriple(t: Triple): string {
+  return `${shortenTerm(t.subject)} ${shortenTerm(t.predicate)} ${shortenTerm(t.object)}`;
+}
+
+// ---- proof tree layout ----
+
+/** One row of the rendered proof tree: a node plus its indentation depth (root = 0). */
+export interface ProofRow {
+  node: ProofNode;
+  depth: number;
+  /** True the SECOND+ time a shared sub-proof node is reached (rendered as a back-ref). */
+  repeated: boolean;
+}
+
+/**
+ * Flattens a {@link ProofTree} into an indented, root-first list of rows for rendering —
+ * mirroring `sparq-reason`'s `ProofTree::to_text` traversal: each node prints once with its
+ * premises nested beneath it; a node reached again (a shared sub-proof) is emitted as a
+ * `repeated` back-reference row WITHOUT re-expanding its premises. Robust against a
+ * malformed premise index (out-of-range premises are skipped).
+ */
+export function proofRows(proof: ProofTree): ProofRow[] {
+  const rows: ProofRow[] = [];
+  const expanded = new Set<number>();
+  const walk = (id: number, depth: number): void => {
+    const node = proof.nodes[id];
+    if (!node) return;
+    const repeated = expanded.has(id);
+    rows.push({ node, depth, repeated });
+    if (repeated) return;
+    expanded.add(id);
+    for (const p of node.premises) walk(p, depth + 1);
+  };
+  walk(proof.root, 0);
+  return rows;
+}
+
+/** A human label for a proof-rule identifier (leaf vs derived). */
+export function ruleLabel(rule: string): string {
+  if (rule === "asserted") return "asserted";
+  return rule;
+}
+
+export type { MaterializeStats, ProofNode, ProofTree, ReasoningProfile };

--- a/site/src/lib/reason-wasm.ts
+++ b/site/src/lib/reason-wasm.ts
@@ -1,0 +1,144 @@
+// [OPUS-4.8] sq-0po6 — live loader for the tier-b "W-reason" wasm bundle that drives
+// /surface/inference. This is a SEPARATE, lazy-loaded bundle from the lean sparq-wasm
+// triplestore bundle (crates/sparq-reason-wasm → public/wasm/reason): the reasoner
+// (RDFS / OWL 2 RL / N3 forward-chaining closure) plus the `why()` derivation proof
+// tree, built with `--features explain`. The lean landing page never pays for it; the
+// inference page loads it on first interaction, exactly as the SHACL playground loads
+// the SHACL-enabled engine bundle.
+//
+// As with src/lib/sparq-wasm.ts the wasm-pack glue is imported at RUNTIME with a
+// webpackIgnore dynamic import, so the ~2.5 MB wasm never enters the page bundle and we
+// pass the wasm bytes' URL explicitly (prefixed with the Pages basePath) rather than let
+// the glue's `new URL('…_bg.wasm', import.meta.url)` resolution run.
+
+/**
+ * The JS-facing `Reasoner` surface the W-reason bundle exports (mirrors
+ * crates/sparq-reason-wasm). Every method is a STATELESS one-shot: it parses the supplied
+ * document, runs the closure, and returns a string — so the JS side never holds a
+ * long-lived reasoner handle. `profile` is `"rdfs"` or `"owl-rl"`; document `format` is one
+ * of `"turtle"` | `"ntriples"` | `"nquads"` | `"trig"`.
+ */
+export interface WasmReasoner {
+  /** Full deductive closure (asserted base + every entailed triple) as N-Triples. */
+  materialize(data: string, format: string, profile: string): string;
+  /** Only the NEWLY-entailed triples (closure minus the asserted base) as N-Triples. */
+  entailed(data: string, format: string, profile: string): string;
+  /** `{"profile","baseTriples","closureTriples","entailed"}` JSON — counts only. */
+  materializeStats(data: string, format: string, profile: string): string;
+  /** N3 rule reasoning (`{ … } => { … }` + facts) -> entailed ground triples as N-Triples. */
+  reasonN3(n3: string): string;
+  /**
+   * One derivation of the triple `(s, p, o)` under `profile` as a proof-tree JSON document,
+   * or the JSON literal `null` if the triple is not entailed. `s`/`p`/`o` are N-Triples term
+   * strings. Present only when the bundle is built with the `explain` feature (the site's
+   * default — see scripts/sync-wasm.mjs).
+   */
+  why?: (
+    data: string,
+    format: string,
+    profile: string,
+    s: string,
+    p: string,
+    o: string,
+  ) => string;
+}
+
+interface ReasonModule {
+  default: (opts?: { module_or_path: string | URL }) => Promise<unknown>;
+  Reasoner: WasmReasoner;
+}
+
+let modulePromise: Promise<ReasonModule> | null = null;
+
+function basePath(): string {
+  // next.config.ts sets basePath '/sparq'; mirror it for the runtime asset URLs.
+  return process.env.NEXT_PUBLIC_BASE_PATH ?? "/sparq";
+}
+
+/**
+ * [OPUS-4.8] sq-0po6 — loads + initialises the W-reason bundle once; subsequent calls reuse
+ * it. The fetch + compile + instantiate is the expensive cold start. {@link prewarmReason}
+ * kicks this off eagerly on route mount so the first "Reason" pays no cold start. A failed
+ * load resets the cache so a later call retries.
+ */
+export async function loadReasoner(): Promise<WasmReasoner> {
+  if (!modulePromise) {
+    modulePromise = (async () => {
+      const base = basePath();
+      const gluePath = `${base}/wasm/reason/sparq_reason_wasm.js`;
+      const wasmPath = `${base}/wasm/reason/sparq_reason_wasm_bg.wasm`;
+      const mod = (await import(/* webpackIgnore: true */ gluePath)) as ReasonModule;
+      await mod.default({ module_or_path: new URL(wasmPath, window.location.origin) });
+      return mod;
+    })();
+    modulePromise.catch(() => {
+      modulePromise = null; // allow retry on transient failure
+    });
+  }
+  const mod = await modulePromise;
+  return mod.Reasoner;
+}
+
+/**
+ * [OPUS-4.8] sq-0po6 — eagerly pre-warm the W-reason bundle (fetch + compile + instantiate)
+ * without blocking render. Safe to call on route mount and repeatedly; it shares the single
+ * {@link loadReasoner} promise, so the cold start happens at most once.
+ */
+export function prewarmReason(): Promise<unknown> {
+  return loadReasoner();
+}
+
+// ---- reasoning profiles ----
+
+export type ReasoningProfile = "rdfs" | "owl-rl";
+
+/** Human label for each profile, for the profile selector. */
+export const PROFILE_LABEL: Record<ReasoningProfile, string> = {
+  rdfs: "RDFS",
+  "owl-rl": "OWL 2 RL",
+};
+
+// ---- materialize stats (mirrors Reasoner::materializeStats JSON) ----
+
+/**
+ * [OPUS-4.8] sq-0po6 — the base-vs-entailed triple-count summary the inference page shows:
+ * `baseTriples` distinct asserted triples, `closureTriples` after forward-chaining, and
+ * `entailed` = the number reasoning ADDED (`closureTriples - baseTriples`).
+ */
+export interface MaterializeStats {
+  profile: string;
+  baseTriples: number;
+  closureTriples: number;
+  entailed: number;
+}
+
+// ---- proof tree (mirrors sparq-reason's ProofTree::to_json) ----
+
+/**
+ * [OPUS-4.8] sq-0po6 — one node of a `why()` derivation proof tree. `rule === "asserted"`
+ * marks a LEAF: the conclusion is an explicitly asserted base triple (`premises` empty);
+ * `axiom-*` rules are premise-free tautologies; every other node is an application of the
+ * named inference rule to the `premises` nodes (each an index strictly less than this
+ * node's `id`). `conclusion` is the `[s, p, o]` triple as N-Triples term strings.
+ */
+export interface ProofNode {
+  id: number;
+  conclusion: [string, string, string];
+  rule: string;
+  premises: number[];
+}
+
+/**
+ * [OPUS-4.8] sq-0po6 — a `why()` derivation: a flat, premises-before-conclusion DAG whose
+ * `root` node (always the last) is the explained triple. The JSON shape `Reasoner.why`
+ * returns (or `null` when the triple is not entailed).
+ */
+export interface ProofTree {
+  root: number;
+  nodes: ProofNode[];
+}
+
+/** A leaf node is an asserted base fact (the proof bottoms out here). */
+export function isAsserted(node: ProofNode): boolean {
+  return node.rule === "asserted";
+}

--- a/site/test/inference.test.mjs
+++ b/site/test/inference.test.mjs
@@ -1,0 +1,167 @@
+// [OPUS-4.8] sq-0po6 — unit tests for the pure inference helpers that back the live
+// /surface/inference page: the N-Triples line parser, the materializeStats / why() JSON
+// parsers, the CURIE shortening, and the proof-tree flattening. The wasm `Reasoner`
+// bindings themselves are proven by the Rust tests in crates/sparq-reason-wasm; here we
+// only test the framework-free JS shaping of their string outputs. Run via
+// `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseNTriplesLine,
+  parseNTriples,
+  parseStats,
+  parseProof,
+  shortenTerm,
+  formatTriple,
+  proofRows,
+  ruleLabel,
+} from "../src/lib/inference.ts";
+
+test("parseNTriplesLine: an IRI triple", () => {
+  const t = parseNTriplesLine(
+    "<http://ex/Socrates> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ex/Mortal> .",
+  );
+  assert.deepEqual(t, {
+    subject: "<http://ex/Socrates>",
+    predicate: "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
+    object: "<http://ex/Mortal>",
+  });
+});
+
+test("parseNTriplesLine: a literal with datatype, lang, and escapes", () => {
+  const dt = parseNTriplesLine(
+    '<http://ex/a> <http://ex/age> "30"^^<http://www.w3.org/2001/XMLSchema#integer> .',
+  );
+  assert.equal(dt?.object, '"30"^^<http://www.w3.org/2001/XMLSchema#integer>');
+
+  const lang = parseNTriplesLine('<http://ex/a> <http://ex/n> "hi"@en-GB .');
+  assert.equal(lang?.object, '"hi"@en-GB');
+
+  // A quote and a space inside the literal must NOT split the term early.
+  const esc = parseNTriplesLine('<http://ex/a> <http://ex/n> "a \\"b\\" c" .');
+  assert.equal(esc?.object, '"a \\"b\\" c"');
+});
+
+test("parseNTriplesLine: blank node subject/object", () => {
+  const t = parseNTriplesLine("_:b0 <http://ex/p> _:b1 .");
+  assert.deepEqual(t, {
+    subject: "_:b0",
+    predicate: "<http://ex/p>",
+    object: "_:b1",
+  });
+});
+
+test("parseNTriplesLine: rejects blank, comment, and malformed lines", () => {
+  assert.equal(parseNTriplesLine(""), null);
+  assert.equal(parseNTriplesLine("   "), null);
+  assert.equal(parseNTriplesLine("# a comment"), null);
+  assert.equal(parseNTriplesLine("<a> <b> <c>"), null); // missing terminator
+  assert.equal(parseNTriplesLine("<a> <b> ."), null); // only two terms
+  assert.equal(parseNTriplesLine("<a> <b> <c> <d> ."), null); // four terms
+  assert.equal(parseNTriplesLine('<a> <b> "unterminated .'), null);
+});
+
+test("parseNTriples: parses a document, skipping blanks", () => {
+  const doc = [
+    "<http://ex/Socrates> <http://ex/p> <http://ex/Human> .",
+    "",
+    "# comment",
+    "<http://ex/Socrates> <http://ex/p> <http://ex/Mortal> .",
+  ].join("\n");
+  assert.equal(parseNTriples(doc).length, 2);
+});
+
+test("parseStats: valid and invalid", () => {
+  const s = parseStats(
+    '{"profile":"rdfs","baseTriples":2,"closureTriples":5,"entailed":3}',
+  );
+  assert.deepEqual(s, {
+    profile: "rdfs",
+    baseTriples: 2,
+    closureTriples: 5,
+    entailed: 3,
+  });
+  assert.throws(() => parseStats('{"profile":"rdfs"}'));
+  assert.throws(() => parseStats("null"));
+});
+
+test("parseProof: a tree, the null literal, and a malformed doc", () => {
+  const json =
+    '{"root":2,"nodes":[' +
+    '{"id":0,"conclusion":["<a>","<sco>","<b>"],"rule":"asserted","premises":[]},' +
+    '{"id":1,"conclusion":["<s>","<type>","<a>"],"rule":"asserted","premises":[]},' +
+    '{"id":2,"conclusion":["<s>","<type>","<b>"],"rule":"rdfs9","premises":[0,1]}]}';
+  const tree = parseProof(json);
+  assert.equal(tree?.root, 2);
+  assert.equal(tree?.nodes.length, 3);
+
+  assert.equal(parseProof("null"), null);
+  assert.throws(() => parseProof('{"nodes":[]}')); // no root
+});
+
+test("shortenTerm: well-known prefixes, leaves the rest alone", () => {
+  assert.equal(shortenTerm("<http://ex/Socrates>"), "ex:Socrates");
+  assert.equal(
+    shortenTerm("<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>"),
+    "rdf:type",
+  );
+  assert.equal(
+    shortenTerm("<http://www.w3.org/2002/07/owl#sameAs>"),
+    "owl:sameAs",
+  );
+  assert.equal(shortenTerm("<http://other/X>"), "<http://other/X>");
+  assert.equal(shortenTerm('"a literal"'), '"a literal"'); // untouched
+});
+
+test("formatTriple: CURIE-compacts all three positions", () => {
+  assert.equal(
+    formatTriple({
+      subject: "<http://ex/Socrates>",
+      predicate: "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
+      object: "<http://ex/Mortal>",
+    }),
+    "ex:Socrates rdf:type ex:Mortal",
+  );
+});
+
+test("proofRows: indents premises and back-references shared sub-proofs", () => {
+  // node 0 is a shared premise of both node 1 and node 2 (the root).
+  const tree = {
+    root: 2,
+    nodes: [
+      { id: 0, conclusion: ["<a>", "<p>", "<b>"], rule: "asserted", premises: [] },
+      { id: 1, conclusion: ["<c>", "<p>", "<d>"], rule: "rdfsX", premises: [0] },
+      { id: 2, conclusion: ["<e>", "<p>", "<f>"], rule: "rdfsY", premises: [1, 0] },
+    ],
+  };
+  const rows = proofRows(tree);
+  // Root first (depth 0), then its first premise (depth 1) and ITS premise (depth 2),
+  // then the root's second premise — node 0 again — as a repeated back-ref (depth 1).
+  assert.equal(rows[0].node.id, 2);
+  assert.equal(rows[0].depth, 0);
+  assert.equal(rows.at(-1).node.id, 0);
+  assert.equal(rows.at(-1).repeated, true);
+  // node 0 appears exactly twice: once expanded, once as a back-ref.
+  const zero = rows.filter((r) => r.node.id === 0);
+  assert.equal(zero.length, 2);
+  assert.equal(zero.filter((r) => r.repeated).length, 1);
+});
+
+test("proofRows: tolerates an out-of-range premise index", () => {
+  const tree = {
+    root: 1,
+    nodes: [
+      { id: 0, conclusion: ["<a>", "<p>", "<b>"], rule: "asserted", premises: [] },
+      { id: 1, conclusion: ["<c>", "<p>", "<d>"], rule: "rdfsX", premises: [0, 99] },
+    ],
+  };
+  // The bogus premise 99 is skipped, not a crash.
+  const rows = proofRows(tree);
+  assert.equal(rows.length, 2);
+});
+
+test("ruleLabel: leaf vs derived", () => {
+  assert.equal(ruleLabel("asserted"), "asserted");
+  assert.equal(ruleLabel("rdfs9"), "rdfs9");
+});


### PR DESCRIPTION
> 🤖 SPARQ agent — bead sq-0po6.

## What

Builds the live **/surface/inference** page (tier-b, "Live (new wasm)"). Load an ontology + facts or an N3 rule document, forward-chain the deductive closure **in your tab** via the tier-b "W-reason" wasm bundle (`crates/sparq-reason-wasm`, built `--features explain`), see the **base vs entailed triple counts**, then click an entailed triple to render its **`why()` derivation proof tree**. Default is the classic **Socrates** syllogism — both as an RDFS `subClassOf` axiom and as an N3 rule. Realises P-inference; depends on the now-closed sq-8thu (site shell) and sq-6qw3 (the W-reason bundle).

## How

- **`site/src/lib/reason-wasm.ts`** — lazy runtime loader for the SEPARATE W-reason bundle (`public/wasm/reason/`), mirroring `sparq-wasm.ts`'s webpackIgnore dynamic-import pattern so the ~2.5 MB wasm never enters the page bundle and the landing page never pays for it. Types for the `Reasoner` surface, `MaterializeStats`, and the `ProofTree` JSON shape.
- **`site/src/lib/inference.ts`** — pure, framework-free, unit-tested helpers: an N-Triples line parser (handles IRIs / blank nodes / literals with datatype, lang and escapes), the `materializeStats` / `why()` JSON parsers, CURIE shortening, and the proof-tree flattening (premises-before-conclusion, shared sub-proofs back-referenced).
- **`site/src/components/inference-playground.tsx`** — the live client playground (examples → mode/profile selector → editor → Reason → counts + entailed list + per-triple proof tree), modelled on the SHACL playground.
- **`site/src/data/inference-examples.ts`** — Socrates (RDFS), Socrates (N3 rule), RDFS domain/range, OWL 2 RL inverse/symmetric.
- **`site/src/app/surface/inference/page.tsx`** + `surfaces.ts` `built: true` + `[slug]` exclusion so the static route takes precedence.
- **Build wiring** — `js` `build:reason-wasm` (output stays in the crate `pkg/`, **not** in the published `@jeswr/sparq` package), site `sync-wasm.mjs` copies it into `public/wasm/reason/` (optional: warns + skips if absent, so plain `next dev` still works), and a `pages.yml` CI step builds it before the static export.
- **`site/test/inference.test.mjs`** — unit tests for the pure helpers.

## Gate

- `npm run lint` — clean.
- `npx tsc --noEmit` — clean.
- `npm run test:unit` — 42/42 pass (incl. the new inference helper tests).
- `npm run build` — full static export succeeds; `/surface/inference` exports as its own static route (6.36 kB, separate from the lean landing bundle) and `out/wasm/reason/` ships the bundle.
- The wasm JS API contract (`materializeStats` / `entailed` / `why` / `reasonN3`) is **verified live** against the freshly-built bundle (Socrates → `{baseTriples:2, closureTriples:3, entailed:1}`, `why` → an `rdfs9` proof bottoming out in two `asserted` leaves). The bindings themselves are proven by the Rust tests in `crates/sparq-reason-wasm`.

No Rust source changed (the reason-wasm crate already exists from sq-6qw3), so the rustdoc/clippy/unsafe gates are not in scope; no public Rust API or privacy surface is touched.

## Honest scope

This page mirrors the SHACL tier-b-live precedent: pure helpers are unit-tested and the live API contract is verified, but there is no Playwright e2e (the browser+COI harness is currently geared to the ZK page). A reason-page pre-warm e2e is a reasonable follow-up, not required here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)