### PR TITLE
feat(sparq-core): dict-spill external builder supports RDF 1.2 triple terms (sq-jvbr) [OPUS-4.8]

### DIFF
--- a/crates/sparq-core/src/dict.rs
+++ b/crates/sparq-core/src/dict.rs
@@ -222,8 +222,12 @@ fn hash_blank(label: &str) -> u64 {
 /// its components, NOT strings. Unlike the other term kinds this hash is dict-relative
 /// (the ids are), so a `Term::Triple` is hashed only AFTER its children are resolved in
 /// the target dict (`intern`/`lookup` handle this; `hash_term` cannot).
+/// [OPUS-4.8] (sq-jvbr) `pub(crate)` so the dict-spill external builder can content-address
+/// an RDF 1.2 triple term by its components' FINAL dense ids when it assembles the
+/// triple-term dictionary records (the same `(hash, id)` pair `save_mmap`/`into_merged`
+/// produce), keeping `dict-hash.bin`/`dict-hid.bin` consistent for triple terms too.
 #[inline]
-fn hash_triple_ids(ids: [Id; 3]) -> u64 {
+pub(crate) fn hash_triple_ids(ids: [Id; 3]) -> u64 {
     let mut h = rustc_hash::FxHasher::default();
     h.write_u8(3);
     h.write_u32(ids[0]);
@@ -1963,14 +1967,12 @@ impl Dict {
     }
 
     /// [OPUS-4.8] (sq-hxgb) Whether this dict stores any RDF 1.2 triple term
-    /// (`Stored::Triple`), used to GUARD a path that cannot represent them.
+    /// (`Stored::Triple`).
     //
-    // [OPUS-4.8] (sq-87bq) Since the sharded in-RAM/external merge gained structural
-    // triple-term support (sq-t3rt) and the in-memory `merge_partials` serial-fallback guard
-    // was removed, the SOLE remaining caller is the DICT-SPILL external builder's rejection
-    // (`reject_triple_terms_in_external_build`, `#[cfg(feature = "dict-spill")]`), whose
-    // content-only on-disk term records still cannot encode a triple term (tracked as sq-jvbr).
-    // Gated to `dict-spill` so the method is not dead code on the default / wasm builds, which
+    // [OPUS-4.8] (sq-jvbr) The SOLE caller is the DICT-SPILL external builder's
+    // `SpillInterner::intern_batch` (`#[cfg(feature = "dict-spill")]`), which uses it to SKIP
+    // the serial triple-term arena pass on the common triple-term-free hot path. Gated to
+    // `dict-spill` so the method is not dead code on the default / wasm builds, which
     // `clippy -D warnings` (`-D dead-code`) would otherwise reject. (`any_triple_terms`, the
     // implementation, stays ungated — `intern_partials` uses it on every build.)
     #[cfg(feature = "dict-spill")]

--- a/crates/sparq-core/src/dictspill.rs
+++ b/crates/sparq-core/src/dictspill.rs
@@ -206,7 +206,11 @@ fn serialize_termparts(tp: &TermParts, out: &mut Vec<u8>) {
             out.extend_from_slice(b.as_bytes());
         }
         TermParts::Triple(_) => {
-            panic!("RDF-star triple terms are not supported by the spilled-dict bulk interner; use the serial loader")
+            // [OPUS-4.8] (sq-jvbr) Triple terms are NOT routed/spilled as leaf records — their
+            // content is their components' ids (resolvable only after the leaf dedup), so they
+            // take the dedicated in-RAM triple-term arena (`SpillInterner::triples`) and are
+            // finalised in `finalize_triple_terms`. This leaf serializer must never see one.
+            panic!("RDF-star triple terms take the triple-term arena, not the leaf serializer (sq-jvbr)")
         }
     }
 }
@@ -650,11 +654,25 @@ pub(crate) struct SpillInterner {
     staged_path: PathBuf,
     staged_count: u64,
     cache_budget_per_shard: usize,
+    /// [OPUS-4.8] (sq-jvbr) RDF 1.2 triple-term occurrences, in first-occurrence (batch,
+    /// partial, arena) order. Each entry is the triple's three components encoded in the
+    /// SAME staged-id namespace as a triple (inline / leaf `(shard+1)<<32|seq` / nested
+    /// triple-term `TRIPLE_TT_BASE|tt_index`). Triple terms are rare reification metadata,
+    /// so this arena stays in RAM (the sharded path's dedicated triple shard is in-RAM too)
+    /// rather than spilling — bounded by the triple-term count, not the leaf-term count.
+    /// Empty on the common triple-term-free hot path (no allocation, no behaviour change).
+    triples: Vec<[u64; 3]>,
 }
 
-/// Staged-triple encoding: values < 2^32 are pass-through inline ids; otherwise
-/// `(shard+1) << 32 | seq`.
+/// Staged-id encoding: values `< STAGED_DICT_BASE` are pass-through inline ids; a leaf is
+/// `(shard+1) * STAGED_DICT_BASE | seq`; a triple-term reference is `TRIPLE_TT_BASE | tt_index`
+/// (sq-jvbr). `STAGED_DICT_BASE` is `2^32` so a leaf `seq` (a `u32`) occupies the low 32 bits.
 const STAGED_DICT_BASE: u64 = 1 << 32;
+
+/// [OPUS-4.8] (sq-jvbr) Triple-term staged-reference tag, well above any leaf shard band
+/// (`(shard+1) * 2^32`): `default_shards()` is tiny, so this `2^48` base never collides with
+/// a leaf reference. The low bits hold the `tt_index` into `SpillInterner::triples`.
+const TRIPLE_TT_BASE: u64 = 1 << 48;
 
 impl SpillInterner {
     pub(crate) fn new(n: usize, tmp: &Path, cfg: &SpillConfig) -> io::Result<SpillInterner> {
@@ -680,6 +698,7 @@ impl SpillInterner {
             // Ingest phase: the dedup caches get half the budget (the other half is
             // reserved so the consolidation's sort buffers never exceed the same bound).
             cache_budget_per_shard: (cfg.mem_budget / 2 / n).max(1 << 12),
+            triples: Vec::new(),
         })
     }
 
@@ -702,6 +721,12 @@ impl SpillInterner {
                 let mut scratch: Vec<u8> = Vec::new();
                 for i in 1..=pd.len() as Id {
                     let tp = pd.term_parts(i);
+                    // [OPUS-4.8] (sq-jvbr) Triple terms are NOT hash-routed — they take the
+                    // serial triple-term arena pass below (same split as the sharded path's
+                    // `intern_partials`: leaf pass parallel, triple-term pass serial).
+                    if matches!(tp, TermParts::Triple(_)) {
+                        continue;
+                    }
                     let s = (dict::hash_termparts(&tp) % n as u64) as usize;
                     serialize_termparts(&tp, &mut scratch);
                     b[s].push((i, scratch.as_slice().into()));
@@ -745,6 +770,45 @@ impl SpillInterner {
             })
             .map_err(|e| e.to_string())?;
 
+        // [OPUS-4.8] (sq-jvbr) Serial second pass — fill every partial's triple-term remap
+        // slots from the in-RAM arena. Runs AFTER the leaf scatter, so each component's staged
+        // id is already in `remaps` (children precede their triple in a partial's arena —
+        // `nt::parse_chunk` interns s/p/o before the triple). One arena entry per OCCURRENCE,
+        // in (partial, arena) order — final dedup-by-component happens in `finalize_triple_terms`,
+        // exactly as leaves dedup at consolidation, so a per-occurrence arena entry is correct.
+        // Skipped entirely (no per-term walk) unless a partial actually carries a triple term.
+        if partials.iter().any(|(pd, _)| pd.has_triple_terms()) {
+            for (pidx, (pd, _)) in partials.iter().enumerate() {
+                for i in 1..=pd.len() as Id {
+                    if let TermParts::Triple(local_ids) = pd.term_parts(i) {
+                        let rm = &remaps[pidx];
+                        let resolve = |id: Id| -> Result<u64, String> {
+                            if id >= dict::INLINE_BASE {
+                                return Ok(id as u64); // global inline-integer id
+                            }
+                            let v = *rm.get(id as usize).ok_or_else(|| {
+                                format!(
+                                    "dict-spill: malformed triple term in partial {pidx}: component local id {id} out of range (remap len {})",
+                                    rm.len()
+                                )
+                            })?;
+                            if v == 0 {
+                                return Err(format!(
+                                    "dict-spill: malformed triple term in partial {pidx}: component local id {id} references an \
+                                     unpopulated slot (not routed/interned, or violates children-first arena ordering)"
+                                ));
+                            }
+                            Ok(v)
+                        };
+                        let comps = [resolve(local_ids[0])?, resolve(local_ids[1])?, resolve(local_ids[2])?];
+                        let tt_index = self.triples.len() as u64;
+                        self.triples.push(comps);
+                        remaps[pidx][i as usize] = TRIPLE_TT_BASE | tt_index;
+                    }
+                }
+            }
+        }
+
         // Stage the batch's triples (sequential append; 24 B/triple).
         for (pidx, (_, ptriples)) in partials.iter().enumerate() {
             let rm = &remaps[pidx];
@@ -781,6 +845,10 @@ pub(crate) struct RemapPlan {
     staged_path: PathBuf,
     staged_count: u64,
     shards: Vec<ShardRemap>,
+    /// [OPUS-4.8] (sq-jvbr) Final dict id per RDF 1.2 triple-term OCCURRENCE (`tt_finals[tt_index]`),
+    /// used by [`remap_staged`] to resolve a `TRIPLE_TT_BASE | tt_index` staged reference.
+    /// Empty on the common triple-term-free path.
+    tt_finals: Vec<u32>,
 }
 
 struct ShardRemap {
@@ -831,6 +899,9 @@ pub(crate) fn consolidate(mut st: SpillInterner, dir: &Path, tmp: &Path, cfg: &S
         s.cache = FxHashMap::default();
         shard_files.push((s.rec_path, s.seq, s.epochs));
     }
+    // [OPUS-4.8] (sq-jvbr) Move the in-RAM triple-term arena out before dropping the interner;
+    // it is finalised AFTER the leaf consolidation (their final ids follow every leaf's).
+    let staged_triples = std::mem::take(&mut st.triples);
     drop(st);
     ensure_disk(tmp, cfg.disk_floor)?;
 
@@ -968,55 +1039,13 @@ pub(crate) fn consolidate(mut st: SpillInterner, dir: &Path, tmp: &Path, cfg: &S
         debug_assert_eq!(local, counts[s]);
         m2f_w.flush().map_err(io_err)?;
     }
-    terms_w.flush().map_err(io_err)?;
-    offs_w.flush().map_err(io_err)?;
-    numer_w.flush().map_err(io_err)?;
-
-    // temporals.bin layout = all instants then all flags: append the spilled flags.
-    flags_w.flush().map_err(io_err)?;
-    drop(flags_w);
-    {
-        let mut fr = BufReader::new(std::fs::File::open(&flags_path).map_err(io_err)?);
-        std::io::copy(&mut fr, &mut tempi_w).map_err(io_err)?;
-        tempi_w.flush().map_err(io_err)?;
-        std::fs::remove_file(&flags_path).ok();
-    }
-
-    // dict-meta.bin (version header + prefixes + datatypes + term count) — identical bytes to
-    // `save_mmap`. [OPUS-4.8] (review 1409) The version header records the id-space partition.
-    {
-        let mut meta = BufWriter::new(std::fs::File::create(dir.join("dict-meta.bin")).map_err(io_err)?);
-        meta.write_all(&dict::DICT_META_MAGIC.to_le_bytes()).map_err(io_err)?;
-        meta.write_all(&dict::DICT_META_VERSION.to_le_bytes()).map_err(io_err)?;
-        meta.write_all(&dict::INLINE_BASE.to_le_bytes()).map_err(io_err)?;
-        meta.write_all(&(prefixes.names.len() as u32).to_le_bytes()).map_err(io_err)?;
-        for p in &prefixes.names {
-            dict::write_str(&mut meta, p).map_err(io_err)?;
-        }
-        meta.write_all(&(datatypes.names.len() as u32).to_le_bytes()).map_err(io_err)?;
-        for d in &datatypes.names {
-            dict::write_str(&mut meta, d).map_err(io_err)?;
-        }
-        meta.write_all(&total.to_le_bytes()).map_err(io_err)?;
-        meta.flush().map_err(io_err)?;
-    }
-
-    // dict-hash.bin + dict-hid.bin: externally sorted by (hash, id) — the canonical
-    // order `save_mmap` also produces.
-    {
-        let mut hw = BufWriter::new(std::fs::File::create(dir.join("dict-hash.bin")).map_err(io_err)?);
-        let mut iw = BufWriter::new(std::fs::File::create(dir.join("dict-hid.bin")).map_err(io_err)?);
-        let mut merge = hash_sorter.into_merge().map_err(io_err)?;
-        while let Some(p) = merge.next().map_err(io_err)? {
-            hw.write_all(&p.hash.to_le_bytes()).map_err(io_err)?;
-            iw.write_all(&p.id.to_le_bytes()).map_err(io_err)?;
-        }
-        hw.flush().map_err(io_err)?;
-        iw.flush().map_err(io_err)?;
-    }
 
     // Phase 4 — per shard: (seq -> min_seq) ⋈ (min_seq -> final id) -> dense
     // `seq -> final id` remap file (sorted by seq; every seq present exactly once).
+    // [OPUS-4.8] (sq-jvbr) MOVED ahead of the meta/hash finalisation (it used to run last)
+    // so the per-shard `seq -> final id` remaps exist BEFORE triple terms are finalised — a
+    // triple term's leaf components are staged `(shard, seq)` ids that resolve to final ids
+    // through these same remap files.
     let mut shards_out: Vec<ShardRemap> = Vec::with_capacity(n);
     for (s, (_, seq_count, mut epochs)) in shard_files.into_iter().enumerate() {
         ensure_disk(tmp, cfg.disk_floor)?;
@@ -1085,7 +1114,181 @@ pub(crate) fn consolidate(mut st: SpillInterner, dir: &Path, tmp: &Path, cfg: &S
         shards_out.push(ShardRemap { remap_path, epochs });
     }
 
-    Ok(RemapPlan { staged_path, staged_count, shards: shards_out })
+    // [OPUS-4.8] (sq-jvbr) Phase 4b — FINALISE RDF 1.2 triple terms. They are content-
+    // addressed by their components' FINAL dense ids and assigned ids AFTER every leaf
+    // (`total + rank`), exactly as the sharded path's dedicated triple shard sorts LAST. The
+    // arena holds one entry per occurrence in first-occurrence order, so deduping by resolved
+    // components in arena order yields first-occurrence-of-distinct order — the same ranking.
+    // Triple terms are rare reification metadata, so this in-RAM pass mirrors the sharded
+    // path's serial second pass (`intern_triple_terms`) rather than spilling.
+    let tt_finals = finalize_triple_terms(
+        &staged_triples,
+        &shards_out,
+        total,
+        &mut terms_w,
+        &mut offs_w,
+        &mut numer_w,
+        &mut tempi_w,
+        &mut flags_w,
+        &mut hash_sorter,
+        &mut pos,
+        tmp,
+    )?;
+    let total = total + tt_finals.distinct as u64;
+    if total >= dict::INLINE_BASE as u64 {
+        return Err("dict-spill: dictionary exceeded the id capacity (2^31 distinct non-integer terms incl. triple terms); widen Id to u64".into());
+    }
+
+    // Flush the dictionary blobs (leaf records + appended triple-term records).
+    terms_w.flush().map_err(io_err)?;
+    offs_w.flush().map_err(io_err)?;
+    numer_w.flush().map_err(io_err)?;
+
+    // temporals.bin layout = all instants then all flags: append the spilled flags.
+    flags_w.flush().map_err(io_err)?;
+    drop(flags_w);
+    {
+        let mut fr = BufReader::new(std::fs::File::open(&flags_path).map_err(io_err)?);
+        std::io::copy(&mut fr, &mut tempi_w).map_err(io_err)?;
+        tempi_w.flush().map_err(io_err)?;
+        std::fs::remove_file(&flags_path).ok();
+    }
+
+    // dict-meta.bin (version header + prefixes + datatypes + term count) — identical bytes to
+    // `save_mmap`. [OPUS-4.8] (review 1409) The version header records the id-space partition.
+    {
+        let mut meta = BufWriter::new(std::fs::File::create(dir.join("dict-meta.bin")).map_err(io_err)?);
+        meta.write_all(&dict::DICT_META_MAGIC.to_le_bytes()).map_err(io_err)?;
+        meta.write_all(&dict::DICT_META_VERSION.to_le_bytes()).map_err(io_err)?;
+        meta.write_all(&dict::INLINE_BASE.to_le_bytes()).map_err(io_err)?;
+        meta.write_all(&(prefixes.names.len() as u32).to_le_bytes()).map_err(io_err)?;
+        for p in &prefixes.names {
+            dict::write_str(&mut meta, p).map_err(io_err)?;
+        }
+        meta.write_all(&(datatypes.names.len() as u32).to_le_bytes()).map_err(io_err)?;
+        for d in &datatypes.names {
+            dict::write_str(&mut meta, d).map_err(io_err)?;
+        }
+        meta.write_all(&total.to_le_bytes()).map_err(io_err)?;
+        meta.flush().map_err(io_err)?;
+    }
+
+    // dict-hash.bin + dict-hid.bin: externally sorted by (hash, id) — the canonical order
+    // `save_mmap` also produces. Triple-term `(hash, final id)` pairs were pushed into the
+    // SAME sorter during finalisation, so the merged stream stays globally sorted.
+    {
+        let mut hw = BufWriter::new(std::fs::File::create(dir.join("dict-hash.bin")).map_err(io_err)?);
+        let mut iw = BufWriter::new(std::fs::File::create(dir.join("dict-hid.bin")).map_err(io_err)?);
+        let mut merge = hash_sorter.into_merge().map_err(io_err)?;
+        while let Some(p) = merge.next().map_err(io_err)? {
+            hw.write_all(&p.hash.to_le_bytes()).map_err(io_err)?;
+            iw.write_all(&p.id.to_le_bytes()).map_err(io_err)?;
+        }
+        hw.flush().map_err(io_err)?;
+        iw.flush().map_err(io_err)?;
+    }
+
+    Ok(RemapPlan { staged_path, staged_count, shards: shards_out, tt_finals: tt_finals.per_occurrence })
+}
+
+/// [OPUS-4.8] (sq-jvbr) Result of [`finalize_triple_terms`]: the per-OCCURRENCE final dict id
+/// (`per_occurrence[tt_index]`, used by [`remap_staged`] to resolve a `TRIPLE_TT_BASE` staged
+/// reference) and the count of DISTINCT triple terms appended to the dictionary.
+struct TripleTermFinals {
+    per_occurrence: Vec<u32>,
+    distinct: usize,
+}
+
+/// [OPUS-4.8] (sq-jvbr) Resolve, dedup, and stream every RDF 1.2 triple-term occurrence into
+/// the dictionary, appending its records AFTER every leaf (final id = `leaf_total + rank`,
+/// matching the sharded triple shard's LAST-shard position). `staged_triples` holds the
+/// staged-id components in first-occurrence order; a leaf component `(shard, seq)` resolves to
+/// its final id through the per-shard `dsp-remap{s}.bin`, a nested triple-term component (a
+/// `TRIPLE_TT_BASE` ref) through an earlier occurrence's already-assigned final id (children
+/// precede parents in arena order), and an inline-integer component passes through. The
+/// streamed `StoredRef::Triple`/offset/numeric(NaN)/temporal(none)/`(hash, id)` records are
+/// the exact bytes `save_mmap` writes for a triple term, so the read-back path is identical.
+#[allow(clippy::too_many_arguments)]
+fn finalize_triple_terms(
+    staged_triples: &[[u64; 3]],
+    shards_out: &[ShardRemap],
+    leaf_total: u64,
+    terms_w: &mut BufWriter<std::fs::File>,
+    offs_w: &mut BufWriter<std::fs::File>,
+    numer_w: &mut BufWriter<std::fs::File>,
+    tempi_w: &mut BufWriter<std::fs::File>,
+    flags_w: &mut BufWriter<std::fs::File>,
+    hash_sorter: &mut PodSorter<HashPair>,
+    pos: &mut u64,
+    tmp: &Path,
+) -> Result<TripleTermFinals, String> {
+    let io_err = |e: io::Error| e.to_string();
+    if staged_triples.is_empty() {
+        return Ok(TripleTermFinals { per_occurrence: Vec::new(), distinct: 0 });
+    }
+    let _ = tmp; // disk floor already enforced before this phase; no further spill here
+
+    // Random-access reader over a shard's dense `seq -> final id` remap file (4 B/entry).
+    // Triple terms are rare, so per-component seeks are cheap; opened lazily per shard.
+    use std::io::{Seek, SeekFrom};
+    let mut remap_files: Vec<Option<std::fs::File>> = (0..shards_out.len()).map(|_| None).collect();
+    let mut leaf_final = |shard: usize, seq: u32| -> Result<u32, String> {
+        let f = match &mut remap_files[shard] {
+            Some(f) => f,
+            slot @ None => {
+                *slot = Some(std::fs::File::open(&shards_out[shard].remap_path).map_err(io_err)?);
+                slot.as_mut().unwrap()
+            }
+        };
+        f.seek(SeekFrom::Start(seq as u64 * 4)).map_err(io_err)?;
+        let mut b = [0u8; 4];
+        f.read_exact(&mut b).map_err(|_| {
+            format!("dict-spill: triple-term component references leaf seq {seq} outside shard {shard}'s remap")
+        })?;
+        Ok(u32::from_le_bytes(b))
+    };
+
+    // dedup distinct triple terms by their FINAL component ids → final dict id; per-occurrence
+    // final id for the staged-triple remap.
+    let mut dedup: FxHashMap<[u32; 3], u32> = FxHashMap::default();
+    let mut per_occurrence: Vec<u32> = Vec::with_capacity(staged_triples.len());
+    let mut next_rank: u64 = 0;
+    for occ in staged_triples {
+        // Resolve each component to its FINAL dense id.
+        let mut comps = [0u32; 3];
+        for (k, &v) in occ.iter().enumerate() {
+            comps[k] = if v < STAGED_DICT_BASE {
+                v as u32 // inline-integer id (global)
+            } else if v >= TRIPLE_TT_BASE {
+                let nested = (v - TRIPLE_TT_BASE) as usize;
+                *per_occurrence.get(nested).ok_or_else(|| {
+                    "dict-spill: triple-term nested reference precedes its definition (arena order violated)".to_string()
+                })?
+            } else {
+                let shard = (v / STAGED_DICT_BASE) as usize - 1;
+                let seq = (v % STAGED_DICT_BASE) as u32;
+                leaf_final(shard, seq)?
+            };
+        }
+        let id = match dedup.get(&comps) {
+            Some(&id) => id,
+            None => {
+                let id = (leaf_total + 1 + next_rank) as u32; // 1-based dense final id, after all leaves
+                next_rank += 1;
+                dedup.insert(comps, id);
+                // Stream the triple-term dict record + sidecar cells (NaN numeric, no temporal).
+                offs_w.write_all(&pos.to_le_bytes()).map_err(io_err)?;
+                *pos += dict::write_record(terms_w, &dict::StoredRef::Triple(comps)).map_err(io_err)?;
+                hash_sorter.push(HashPair { hash: dict::hash_triple_ids(comps), id }).map_err(io_err)?;
+                numer_w.write_all(&f64::NAN.to_le_bytes()).map_err(io_err)?;
+                tempi_w.write_all(&f64::NAN.to_le_bytes()).map_err(io_err)?;
+                flags_w.write_all(&[0u8]).map_err(io_err)?;
+                id
+            }
+        };
+        per_occurrence.push(id);
+    }
+    Ok(TripleTermFinals { per_occurrence, distinct: next_rank as usize })
 }
 
 /// Per-shard sliding window over a dense remap file, advanced at epoch boundaries —
@@ -1155,6 +1358,13 @@ pub(crate) fn remap_staged(
                 let v = u64::from_le_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]);
                 out[k] = if v < STAGED_DICT_BASE {
                     v as Id // inline-integer id, passed through at ingest
+                } else if v >= TRIPLE_TT_BASE {
+                    // [OPUS-4.8] (sq-jvbr) RDF 1.2 triple-term reference — its final dict id was
+                    // assigned (after every leaf) in `finalize_triple_terms`.
+                    let tt = (v - TRIPLE_TT_BASE) as usize;
+                    *plan.tt_finals.get(tt).ok_or_else(|| {
+                        "dict-spill: staged triple-term reference has no finalised id".to_string()
+                    })?
                 } else {
                     let s = (v / STAGED_DICT_BASE) as usize - 1;
                     windows[s].map(t, (v % STAGED_DICT_BASE) as u32).map_err(io_err)?

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -5248,9 +5248,9 @@ fn build_external_ntriples_dictspill<R: std::io::Read + Send>(
                     continue;
                 }
                 let partials = parse_block(&block)?;
-                // [OPUS-4.8] (sq-hxgb) The sharded/spill consolidation cannot represent
-                // triple terms; fail clearly rather than panic / corrupt (see helper).
-                reject_triple_terms_in_external_build(&partials)?;
+                // [OPUS-4.8] (sq-jvbr) The dict-spill consolidation now interns RDF 1.2 triple
+                // terms structurally (`SpillInterner::intern_batch` → `finalize_triple_terms`),
+                // so no rejection here — like the sharded path (sq-t3rt).
                 if ptx.send(partials).is_err() {
                     return Ok(());
                 }
@@ -5288,28 +5288,6 @@ fn parse_block(bytes: &[u8]) -> Result<ChunkPartials, String> {
         .collect::<Result<Vec<_>, _>>()?;
     build_timing::record(t_parse, &build_timing::PARSE_NS);
     Ok(partials)
-}
-
-/// [OPUS-4.8] (sq-jvbr) The DICT-SPILL external N-Triples builder consolidates partial
-/// dicts through a HASH-SHARDED, disk-staged interner whose on-disk term records are
-/// content-only (`serialize_termparts`) — it has no representation for an RDF 1.2 triple
-/// term `<<( … )>>`, whose content IS its components' ids (resolvable only after the whole
-/// external dedup). So it surfaces a CLEAR error rather than panicking / corrupting.
-///
-/// The SHARDED in-RAM external builder (`build_external_ntriples_sharded`) NO LONGER needs
-/// this: as of sq-t3rt `ShardedDict::intern_partials` interns triple terms structurally into
-/// a dedicated triple shard. Giving the dict-spill staging the same is tracked as sq-jvbr;
-/// until then this guard keeps that path honest.
-#[cfg(feature = "dict-spill")]
-fn reject_triple_terms_in_external_build(partials: &[(Dict, Vec<[Id; 3]>)]) -> Result<(), String> {
-    if partials.iter().any(|(d, _)| d.has_triple_terms()) {
-        return Err("N-Triples: RDF 1.2 triple terms `<<( … )>>` are not yet supported by the \
-                    dict-spill external builder; build with the default sharded path \
-                    (SPARQ_DICT_SPILL unset) or load this document in memory \
-                    (Graph::load_str/load_reader) instead (sq-jvbr)"
-            .to_string());
-    }
-    Ok(())
 }
 
 /// Env-gated (`SPARQ_BUILD_TIMING`) phase-time accumulators for the parallel ingest path,
@@ -7773,9 +7751,11 @@ mod tests {
 
     /// [OPUS-4.8] The spilled external build still supports its mmap'd read-back path, and
     /// it rejects non-N-Triples formats with a clear error (the documented restriction).
-    /// [OPUS-4.8] (sq-jvbr) It also still rejects RDF 1.2 triple terms with a clear error
-    /// (unlike the sharded path, which now handles them — sq-t3rt): the dict-spill staging
-    /// has no representation for a triple term, so the guard must stay live and tested.
+    /// [OPUS-4.8] (sq-jvbr) It now ACCEPTS RDF 1.2 triple terms (previously rejected): the
+    /// `SpillInterner` interns them structurally into an in-RAM triple-term arena finalised
+    /// after the leaf consolidation (`finalize_triple_terms`), so a triple-term document
+    /// builds and opens. Full differential coverage vs the sharded/serial/in-memory paths is
+    /// in `dict_spill_triple_terms_match_in_memory` below; this just checks the smoke path.
     #[cfg(feature = "dict-spill")]
     #[test]
     fn dict_spill_rejects_non_ntriples_and_opens_mmap() {
@@ -7785,14 +7765,20 @@ mod tests {
             .expect_err("spill build must reject non-ntriples");
         assert!(err.contains("N-Triples"), "error must name the restriction: {err}");
 
-        // RDF 1.2 triple terms are rejected by the dict-spill path (sq-jvbr) with an
-        // actionable error that points at the working alternatives.
+        // RDF 1.2 triple terms now build through the dict-spill path (sq-jvbr) and open.
         let tt = "<http://ex/r1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> \
                   <<( <http://ex/a> <http://ex/b> <http://ex/c> )>> .\n";
-        let tt_err = Graph::build_external_spill(tt.as_bytes(), "ntriples", &dir.join("tt"), 64, &cfg)
-            .expect_err("dict-spill build must reject triple terms (sq-jvbr)");
-        assert!(tt_err.contains("triple term"), "error must name triple terms: {tt_err}");
-        assert!(tt_err.contains("sharded") || tt_err.contains("memory"), "error must point at a working path: {tt_err}");
+        let tt_dir = dir.join("tt");
+        Graph::build_external_spill(tt.as_bytes(), "ntriples", &tt_dir, 64, &cfg)
+            .expect("dict-spill build must now accept triple terms (sq-jvbr)");
+        let tg = Graph::open(&tt_dir).unwrap();
+        assert_eq!(tg.len(), 1, "the single reifier statement is materialised");
+        let ttobj = Term::Triple(Box::new(oxrdf::Triple::new(
+            oxrdf::NamedNode::new("http://ex/a").unwrap(),
+            oxrdf::NamedNode::new("http://ex/b").unwrap(),
+            Term::NamedNode(oxrdf::NamedNode::new("http://ex/c").unwrap()),
+        )));
+        assert!(tg.id_of(&ttobj).is_some(), "the triple term `<<( a b c )>>` must be a first-class dict term");
 
         let nt = "<http://ex/a> <http://ex/p> <http://ex/b> .\n\
                   <http://ex/a> <http://ex/p> \"42\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n";
@@ -7802,6 +7788,100 @@ mod tests {
         let g = Graph::open(&ok_dir).unwrap();
         assert_eq!(g.len(), 2);
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [OPUS-4.8] (sq-jvbr) The DICT-SPILL external builder now interns RDF 1.2 triple terms
+    /// `<<( … )>>` structurally: leaf components spill/dedup as usual, while triple-term
+    /// OCCURRENCES go to an in-RAM arena (rare reification metadata, like the sharded path's
+    /// serial second pass) and are finalised — content-addressed by their components' FINAL
+    /// ids, deduped, assigned ids AFTER every leaf — in `finalize_triple_terms`. The built
+    /// store must round-trip identically (term-level, order-independent) to the in-memory
+    /// loader and the serial/sharded external builds. A tiny memory budget forces cache
+    /// eviction/epochs + many sort runs, exercising the staged-id remap windows under spill.
+    ///
+    /// Coverage (mirrors the sharded differential test):
+    /// - a triple term shared by TWO statements (must dedup to ONE id);
+    /// - components in distinct namespaces (route to different leaf shards);
+    /// - a leaf SHARED between a plain triple and a triple-term component;
+    /// - a NESTED triple term (a triple term in another's object slot);
+    /// - a blank-node component;
+    /// - bulk rows so the document spans multiple parse blocks AND triggers epoch resets.
+    #[cfg(feature = "dict-spill")]
+    #[test]
+    fn dict_spill_triple_terms_match_in_memory() {
+        use store::BUILT;
+        let mut nt = String::new();
+        for i in 0..3000u32 {
+            nt.push_str(&format!(
+                "<http://ex/n{}> <http://ex/p{}> \"{}\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
+                i % 211,
+                i % 11,
+                i % 500
+            ));
+            if i % 500 == 0 {
+                // Shared triple term across two statements; cross-namespace components.
+                nt.push_str("<http://ex/r1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( <http://alpha.example/alice> <http://beta.example/age> \"30\"^^<http://www.w3.org/2001/XMLSchema#integer> )>> .\n");
+                nt.push_str("<http://ex/r1b> <http://ex/sameAs> <<( <http://alpha.example/alice> <http://beta.example/age> \"30\"^^<http://www.w3.org/2001/XMLSchema#integer> )>> .\n");
+            }
+        }
+        // A leaf shared between a plain triple and a triple-term component.
+        nt.push_str("<http://ex/knows> <http://ex/about> <http://alpha.example/alice> .\n");
+        // Blank-node component.
+        nt.push_str("<http://ex/r2> <http://ex/about> <<( _:b0 <http://ex/p> \"v\" )>> .\n");
+        // Nested triple term.
+        nt.push_str("<http://ex/r3> <http://ex/nested> <<( <http://gamma.example/x> <http://delta.example/q> <<( <http://eps.example/a> <http://zeta.example/b> <http://eta.example/c> )>> )>> .\n");
+
+        let mem = Graph::load_str(&nt, "ntriples").expect("in-memory loader must accept triple terms");
+
+        let base = std::env::temp_dir().join(format!("sparq_spill_tt_{}", std::process::id()));
+        let spill_dir = base.join("spill");
+        // Tiny budget -> epoch resets + many sort runs (exercises the remap windows).
+        let cfg = dictspill::SpillConfig { mem_budget: 64 << 10, disk_floor: 0 };
+        Graph::build_external_spill(nt.as_bytes(), "ntriples", &spill_dir, 256, &cfg)
+            .expect("dict-spill build must accept triple terms (sq-jvbr)");
+        let sp = Graph::open(&spill_dir).unwrap();
+        assert_eq!(sp.len(), mem.len(), "spill triple count differs from in-memory");
+        assert_eq!(sp.dict.len(), mem.dict.len(), "spill dict size differs from in-memory");
+
+        let dump = |g: &Graph| {
+            let scan = g.store.scan(&[None, None, None]);
+            let mut v: Vec<(String, String, String)> = scan
+                .rows
+                .iter()
+                .map(|r| {
+                    let spo = scan.to_spo(r);
+                    (g.dict.term(spo[0]).to_string(), g.dict.term(spo[1]).to_string(), g.dict.term(spo[2]).to_string())
+                })
+                .collect();
+            v.sort();
+            v
+        };
+        assert_eq!(dump(&sp), dump(&mem), "spill-built store differs from in-memory (triple terms)");
+
+        // The shared triple term must be ONE dict entry referenced by both reifiers.
+        let tt = Term::Triple(Box::new(oxrdf::Triple::new(
+            oxrdf::NamedNode::new("http://alpha.example/alice").unwrap(),
+            oxrdf::NamedNode::new("http://beta.example/age").unwrap(),
+            Term::Literal(Literal::new_typed_literal("30", xsd::INTEGER)),
+        )));
+        let tt_id = sp.id_of(&tt).expect("the shared triple term must be in the spill dict");
+        let r1 = sp.id_of(&Term::NamedNode(oxrdf::NamedNode::new("http://ex/r1").unwrap())).unwrap();
+        let r1b = sp.id_of(&Term::NamedNode(oxrdf::NamedNode::new("http://ex/r1b").unwrap())).unwrap();
+        let obj_of = |s: Id| {
+            let scan = sp.store.scan(&[Some(s), None, None]);
+            assert_eq!(scan.rows.len(), 1, "reifier must have exactly one statement");
+            scan.to_spo(&scan.rows[0])[2]
+        };
+        assert_eq!(obj_of(r1), tt_id, "<r1>'s object is the shared triple term");
+        assert_eq!(obj_of(r1b), tt_id, "<r1b>'s object is the SAME shared triple-term id");
+
+        // Sanity: the triple-term-free permutation/dict bytes are still produced (no perm
+        // file is empty), proving the staged-triple remap fed every triple through.
+        for &perm in BUILT {
+            let f = spill_dir.join(format!("perm{}.bin", perm as usize));
+            assert!(std::fs::metadata(&f).map(|m| m.len() > 0).unwrap_or(false), "perm {f:?} must be non-empty");
+        }
+        std::fs::remove_dir_all(&base).ok();
     }
 
     /// [OPUS-4.8] (sq-t3rt) The SHARDED external builder now handles RDF 1.2 triple terms
@@ -7823,8 +7903,8 @@ mod tests {
     /// - enough bulk rows that the input spans multiple parse blocks/chunks (cross-chunk
     ///   partial merge), with the reification metadata interleaved among them.
     ///
-    /// (The dict-spill path still rejects triple terms — that is bead sq-jvbr, deliberately
-    /// not fixed here to avoid a conflicting edit.)
+    /// (The dict-spill path now also supports triple terms — sq-jvbr; see
+    /// `dict_spill_triple_terms_match_in_memory`.)
     #[cfg(all(feature = "mmap", feature = "parallel"))]
     #[test]
     fn external_build_triple_terms_sharded_matches_serial_and_memory() {

--- a/research/external-dictionary.md
+++ b/research/external-dictionary.md
@@ -115,8 +115,12 @@ in-flight blocks (~3 × 64 MiB + partials), and transient batch overshoot of the
   unset ⇒ exactly the old path.
 - Runtime: `SPARQ_DICT_SPILL=1` routes `Graph::build_external` (N-Triples) through the
   spilled dict; `Graph::build_external_spill(...)` is the explicit API.
-  N-Triples only (same restriction and reason as the sharded path: the byte parser
-  rejects RDF-star; triple terms cannot be sharded/spilled by content hash).
+  N-Triples only (same restriction as the sharded path). RDF 1.2 triple terms (sq-jvbr)
+  ARE supported: leaf components spill/dedup as usual, while triple-term occurrences take an
+  in-RAM arena (rare reification metadata) finalised after the leaf consolidation —
+  content-addressed by their components' FINAL ids and assigned ids after every leaf (the
+  sharded path's dedicated-triple-shard position). They are not hash-routed/spilled because a
+  triple term's content is its components' ids, only resolvable after the leaf dedup.
 - wasm32: the feature is never enabled there (sparq-wasm uses
   `default-features = false`); no detection APIs or libc reach the wasm build. Byte
   count must stay at the 1,643,095 baseline (verified below).

--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -252,11 +252,11 @@ cargo build -p sparq-cli --features serialize-rdf
   a `<<( … )>>` in subject/predicate position is rejected with a precise error). Triple terms
   may nest, take blank-node/literal components, and are content-addressed (an identical triple
   term shares one dict id). They load through **every** path — serial, parallel-chunked,
-  streaming-pipelined, and the sharded external builder — at full parallelism (the in-memory
-  parallel merge no longer drops to a serial fallback when they are present). The **dict-spill**
-  external builder is the one exception: it rejects triple terms with a clear error (its
-  content-only on-disk records can't encode them — bead sq-jvbr); use the default sharded path
-  or an in-memory load for RDF-star + dict-spill datasets. In **Turtle/TriG**, the SPARQL-1.2
+  streaming-pipelined, the sharded external builder, and the **dict-spill** external builder
+  (sq-jvbr: triple-term occurrences take an in-RAM arena finalised after the spilled leaf
+  consolidation, content-addressed by their components' final ids and assigned ids after every
+  leaf) — at full parallelism (the in-memory parallel merge no longer drops to a serial
+  fallback when they are present). In **Turtle/TriG**, the SPARQL-1.2
   reification sugar is supported via the Turtle parser: the reifying triple `<< s p o >>`
   (subject or object position, optionally `<< s p o ~ reifier >>`) and the annotation block
   `s p o {| … |}` desugar to the standard `rdf:reifies <<( s p o )>>` form (the annotation block


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-jvbr**: the disk-spilling external N-Triples builder (`Graph::build_external_spill`, `dict-spill` feature) now supports RDF 1.2 triple terms `<<( s p o )>>`. Previously it returned a clear error because its hash-sharded, content-only on-disk records cannot represent a triple term — a triple term's content *is* its components' ids, resolvable only after the whole external dedup completes.

## Approach (mirrors the sharded in-RAM path, sq-t3rt)

- **Ingest** (`SpillInterner::intern_batch`): leaf components route / spill / dedup exactly as before. Triple-term **occurrences** are *not* hash-routed — they take an in-RAM arena (rare reification metadata; the sharded path's dedicated triple shard is in-RAM too, so RSS stays bounded by triple-term count, not leaf-term count). A statement referencing a triple-term object uses a new `TRIPLE_TT_BASE` staged-id band. Skipped entirely on the common triple-term-free hot path (no allocation, no behaviour change).
- **Consolidate**: Phase 4 (per-shard `seq -> final-id` remaps) is moved ahead of the meta/hash finalisation so triple terms can be resolved against **final** leaf ids. `finalize_triple_terms` resolves each occurrence's components to final ids (leaf via the dense remap, nested triple via an earlier occurrence, inline-integer passthrough), dedups by component final ids, assigns ids **after every leaf** (`total + rank` — the sharded triple shard's last-shard position), and appends the exact `save_mmap` `StoredRef::Triple` records + `(hash, id)` pairs + NaN-numeric / no-temporal sidecar cells. The meta term count and the globally-sorted hash file include them.
- **Phase 5** (`remap_staged`): decodes `TRIPLE_TT_BASE` staged references to their finalised dict id.

`reject_triple_terms_in_external_build` is removed (now unused).

## Correctness

New differential test `dict_spill_triple_terms_match_in_memory` builds a triple-term document (shared cross-statement, cross-namespace/different-shard components, a leaf shared with a plain triple, a nested triple term, a blank-node component, and bulk rows that trigger cache-eviction epochs under a tiny budget) and asserts the spill-built store round-trips identically (term-level, order-independent) to the in-memory loader, plus that the shared triple term is one dict entry referenced by both reifiers. The existing byte-identity-vs-sharded test (triple-term-free) still passes.

## Gate

- `cargo build` + `clippy --all-targets -D warnings` — **default** and **`dict-spill`** feature states ✅
- tests — both feature states ✅
- rustdoc `-D warnings` — `dict-spill` and `--workspace --no-deps --all-features` ✅
- privacy-claims gate ✅; public-API diff: **no public API change** (new items are `pub(crate)`/private) so no SKILL.md G2 update required ✅
- no new `unsafe` (reuses the existing disjoint-`SlotPtr` scatter pattern unchanged)

Docs updated: `skills/data-formats/SKILL.md` and `research/external-dictionary.md` (the dict-spill "rejects triple terms" claims were stale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
