### PR TITLE
ci(coverage): merge conformance binaries into sparq-core/engine nightly coverage (sq-bjct) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1002,10 +1002,17 @@ jobs:
     # [OPUS-4.8] NIGHTLY heavy-coverage tier (sq-hbg7). Runs the FULL per-crate
     # set INCLUDING the sparq-vectors 50k recall/diskann accuracy tests that the
     # per-commit `coverage` job skips (those run >10 min for that one crate under
-    # llvm-cov instrumentation — too slow for per-commit, hence this split). The
-    # gate is the SAME floor file; --check verifies the nightly numbers still meet
-    # their floors. Triggered by the `schedule:` cron (or manual dispatch), and only
-    # when the nightly-gate says HEAD changed since the last nightly.
+    # llvm-cov instrumentation — too slow for per-commit, hence this split).
+    #
+    # [OPUS-4.8] sq-bjct: this tier ALSO merges the W3C SPARQL + inference conformance
+    # BINARIES (sparq-conformance / sparq-inference-conformance — they run as `cargo
+    # run`, NOT `cargo test`) into the sparq-core / sparq-engine llvm-cov reports
+    # (scripts/coverage.sh measure_merged, auto-enabled for tier!=per-commit). Those two
+    # crates are gated here on their HIGHER `nightly_floor` (bench/coverage-floor.json),
+    # while the per-commit `coverage` job still gates the cheaper test-only `floor`. The
+    # gate driver reads the summary's `tier` and applies nightly_floor automatically.
+    # Triggered by the `schedule:` cron (or manual dispatch), and only when the
+    # nightly-gate says HEAD changed since the last nightly.
     name: coverage (nightly, full incl. heavy vectors)
     needs: nightly-gate
     if: needs.nightly-gate.outputs.fresh == 'true'

--- a/bench/coverage-floor.json
+++ b/bench/coverage-floor.json
@@ -16,10 +16,14 @@
       "note": "test-driver crate: the W3C suites run as the BINARIES (cargo run), so `cargo llvm-cov --package` (which runs cargo test) sees only a few unit tests. Low % is expected; floor 0."
     },
     "sparq-core": {
-      "floor": 90
+      "floor": 90,
+      "nightly_floor": 90,
+      "nightly_note": "[OPUS-4.8] sq-bjct: nightly_floor gates the NIGHTLY tier, whose measurement MERGES the W3C SPARQL + inference conformance BINARIES (they run as `cargo run`, not `cargo test`) into this crate's llvm-cov report — a higher number than the test-only per-commit `floor`. See scripts/coverage.sh measure_merged + the coverage-nightly job. Merged measurement 92.44% (test-only ~91.3%); floor = floor(measured) - 2 margin lands at the base floor here, so the binaries' contribution is documented + gated, not yet a higher number."
     },
     "sparq-engine": {
-      "floor": 83
+      "floor": 83,
+      "nightly_floor": 85,
+      "nightly_note": "[OPUS-4.8] sq-bjct: nightly_floor gates the NIGHTLY tier, whose measurement MERGES the W3C SPARQL + inference conformance BINARIES (they run as `cargo run`, not `cargo test`) into this crate's llvm-cov report — a higher number than the test-only per-commit `floor`. See scripts/coverage.sh measure_merged + the coverage-nightly job. Merged measurement 87.31% lifts the nightly floor to 85 (base test-only floor 83); floor = floor(measured) - 2 margin."
     },
     "sparq-geo": {
       "floor": 87

--- a/scripts/coverage-gate.py
+++ b/scripts/coverage-gate.py
@@ -93,26 +93,67 @@ NIGHTLY_NOTE = {
                      "tier measures the full set.",
 }
 
+# [OPUS-4.8] sq-bjct: crates whose NIGHTLY measurement MERGES the W3C conformance
+# binaries (sparq-conformance / sparq-inference-conformance) into the per-crate
+# report (scripts/coverage.sh measure_merged). Those crates carry a separate, HIGHER
+# `nightly_floor` gated only by the nightly tier; their base `floor` stays the cheaper
+# test-only number gated per-commit. Seeding from a nightly summary RAISES nightly_floor;
+# seeding from a per-commit summary RAISES the base floor — neither touches the other.
+CONFORMANCE_MERGE_CRATES = {"sparq-core", "sparq-engine"}
+CONFORMANCE_MERGE_NOTE = (
+    "[OPUS-4.8] sq-bjct: nightly_floor gates the NIGHTLY tier, whose measurement MERGES "
+    "the W3C SPARQL + inference conformance BINARIES (they run as `cargo run`, not "
+    "`cargo test`) into this crate's llvm-cov report — a higher number than the test-only "
+    "per-commit `floor`. See scripts/coverage.sh measure_merged + the coverage-nightly job."
+)
+
 def load(p):
     with open(p) as f:
         return json.load(f)
 
 def seed(summary_path, floor_path, allow_lower):
     s = load(summary_path)
+    tier = s.get("tier")                       # [OPUS-4.8] sq-bjct
     existing = load(floor_path)["crates"] if os.path.exists(floor_path) else {}
     out = {}
     raised, kept, new, lowered = [], [], [], []
+    # A crate's MERGED nightly measurement seeds `nightly_floor`, NOT the base floor:
+    # only when seeding FROM a nightly summary AND the row actually merged the binaries.
+    def is_merged_row(crate, row):
+        return (crate in CONFORMANCE_MERGE_CRATES and tier and tier != "per-commit"
+                and "conformance-merge" in (row.get("features") or []))
     for crate, row in sorted(s["crates"].items()):
+        prev_entry = dict(existing.get(crate, {}))   # carry forward the WHOLE entry
         if not row.get("measured", False):
             # carry an existing floor forward; never invent one for an unmeasured crate
             if crate in existing:
-                out[crate] = existing[crate]; kept.append(crate)
+                out[crate] = prev_entry; kept.append(crate)
             continue
         if crate in ARTIFACT_ZERO:
-            out[crate] = {"floor": 0, "note": ARTIFACT_ZERO[crate]}
+            entry = {"floor": 0, "note": ARTIFACT_ZERO[crate]}
+            # preserve a previously-seeded nightly_floor (the artifact note is base-only)
+            if prev_entry.get("nightly_floor") is not None:
+                entry["nightly_floor"] = prev_entry["nightly_floor"]
+            out[crate] = entry
             continue
         measured = row["lines_pct"]
         proposed = max(0, math.floor(measured) - MARGIN)
+        if is_merged_row(crate, row):
+            # Ratchet the NIGHTLY floor up; leave the base `floor` (per-commit) untouched.
+            entry = prev_entry if prev_entry else {"floor": 0}
+            prev = entry.get("nightly_floor")
+            label = f"{crate}.nightly_floor"
+            if prev is None:
+                entry["nightly_floor"] = proposed; new.append(f"{label}={proposed}")
+            elif proposed > prev:
+                entry["nightly_floor"] = proposed; raised.append(f"{label} {prev}->{proposed}")
+            elif proposed < prev and allow_lower:
+                entry["nightly_floor"] = proposed; lowered.append(f"{label} {prev}->{proposed}")
+            else:
+                entry["nightly_floor"] = prev; kept.append(label)  # ratchet
+            entry.setdefault("nightly_note", CONFORMANCE_MERGE_NOTE)
+            out[crate] = entry
+            continue
         prev = existing.get(crate, {}).get("floor")
         note = NIGHTLY_NOTE.get(crate)
         if prev is None:
@@ -125,6 +166,11 @@ def seed(summary_path, floor_path, allow_lower):
             chosen = prev; kept.append(crate)  # ratchet: never auto-lower
         entry = {"floor": chosen}
         if note: entry["note"] = note
+        # preserve a previously-seeded nightly_floor when seeding from a per-commit summary
+        if prev_entry.get("nightly_floor") is not None:
+            entry["nightly_floor"] = prev_entry["nightly_floor"]
+            if prev_entry.get("nightly_note"):
+                entry["nightly_note"] = prev_entry["nightly_note"]
         out[crate] = entry
     doc = {
         "_comment": [
@@ -144,8 +190,16 @@ def seed(summary_path, floor_path, allow_lower):
             "Floors with floor:0 are crates whose llvm-cov line% is a known measurement "
             "artifact (see each note) — they are guarded by the test-PRESENCE gate "
             "(bench/coverage-presence.json) instead of the % gate.",
+            "[OPUS-4.8] sq-bjct: a crate with a `nightly_floor` (sparq-core / sparq-engine) "
+            "is gated TWICE: per-commit on the test-only `floor`, and nightly on the higher "
+            "`nightly_floor` — the nightly tier MERGES the W3C SPARQL + inference conformance "
+            "BINARIES (which run as `cargo run`, not `cargo test`) into that crate's llvm-cov "
+            "report. Seeding from a nightly summary raises `nightly_floor`; seeding from a "
+            "per-commit summary raises the base `floor`. Neither seed touches the other.",
             "Regenerate after a deliberate coverage rise: scripts/coverage.sh && "
-            "scripts/coverage-gate.py --seed target/coverage/coverage-summary.json",
+            "scripts/coverage-gate.py --seed target/coverage/coverage-summary.json "
+            "(per-commit -> base floor); COVERAGE_TIER=nightly scripts/coverage.sh && "
+            "scripts/coverage-gate.py --seed ... (nightly -> nightly_floor).",
         ],
         "margin_points": MARGIN,
         "crates": out,
@@ -162,9 +216,10 @@ def seed(summary_path, floor_path, allow_lower):
 def check(summary_path, floor_path, require_all):
     s = load(summary_path); floors = load(floor_path)["crates"]
     measured = s["crates"]
+    tier = s.get("tier")            # [OPUS-4.8] sq-bjct: tier-aware nightly_floor
     fails, missing, oks = [], [], []
     for crate, fentry in sorted(floors.items()):
-        floor = fentry["floor"] if isinstance(fentry, dict) else fentry
+        floor = effective_floor(fentry, tier)
         row = measured.get(crate)
         if row is None or not row.get("measured", False):
             missing.append(crate); continue
@@ -198,6 +253,23 @@ def floor_of(fentry):
     """Floor value from a floor-file entry (a dict {"floor": N} or a bare number)."""
     return fentry["floor"] if isinstance(fentry, dict) else fentry
 
+def effective_floor(fentry, tier):
+    """[OPUS-4.8] sq-bjct: the floor that APPLIES for a given measurement tier.
+
+    A crate whose nightly measurement MERGES the conformance binaries (sparq-core /
+    sparq-engine) carries a HIGHER `nightly_floor` alongside the per-commit `floor`:
+    the per-commit `coverage` job measures test-only (lower) coverage and gates on
+    `floor`; the nightly `coverage-nightly` job measures the suite-MERGED (higher)
+    coverage and gates on `nightly_floor`. Without this split, ratcheting the merge
+    crates to their (higher) nightly number — which sq-bjct asks for — would make the
+    cheaper, test-only per-commit job fail. Any tier other than "per-commit" uses the
+    nightly floor when present; per-commit always uses the base floor."""
+    base = floor_of(fentry)
+    if tier and tier != "per-commit" and isinstance(fentry, dict) \
+       and fentry.get("nightly_floor") is not None:
+        return fentry["nightly_floor"]
+    return base
+
 def sub_floor_crates(summary, floors):
     """Pure: the set of crates that are MEASURED in `summary` AND below their floor.
 
@@ -206,11 +278,12 @@ def sub_floor_crates(summary, floors):
     semantics). This is exactly the set the robust gate re-measures."""
     out = []
     measured = summary.get("crates", {})
+    tier = summary.get("tier")      # [OPUS-4.8] sq-bjct: tier-aware nightly_floor
     for crate, fentry in floors.items():
         row = measured.get(crate)
         if row is None or not row.get("measured", False):
             continue
-        if row["lines_pct"] + 1e-9 < floor_of(fentry):
+        if row["lines_pct"] + 1e-9 < effective_floor(fentry, tier):
             out.append(crate)
     return sorted(out)
 
@@ -222,14 +295,27 @@ def floor_regressions(base_floors, new_floors):
     only in `new_floors` (a newly-added crate) is NOT a regression; a crate only in
     `base_floors` (dropped from the floor file) is reported separately by the caller — it is
     NOT a *floor* lowering but it IS a way to erode the ratchet, so the caller treats a drop
-    as a regression too. Here we report only the floor DECREASES; equal/raised floors pass."""
+    as a regression too. Here we report only the floor DECREASES; equal/raised floors pass.
+
+    [OPUS-4.8] sq-bjct: a crate's `nightly_floor` (the merged-suite gate for
+    sparq-core / sparq-engine) is part of the same ratchet, so LOWERING it — or
+    DROPPING it once present — is reported too (as a "<crate>.nightly_floor" row).
+    A newly-ADDED nightly_floor is not a regression."""
     out = []
     for crate, bentry in sorted(base_floors.items()):
         if crate not in new_floors:
             continue  # dropped-crate handling is the caller's (it is reported, not silent)
-        bf, nf = floor_of(bentry), floor_of(new_floors[crate])
+        nentry = new_floors[crate]
+        bf, nf = floor_of(bentry), floor_of(nentry)
         if nf < bf:
             out.append((crate, bf, nf))
+        # nightly_floor ratchet (only when the base had one — a new one cannot regress).
+        bnf = bentry.get("nightly_floor") if isinstance(bentry, dict) else None
+        if bnf is not None:
+            nnf = nentry.get("nightly_floor") if isinstance(nentry, dict) else None
+            if nnf is None or nnf < bnf:
+                out.append((f"{crate}.nightly_floor", bnf,
+                            nnf if nnf is not None else "DROPPED"))
     return out
 
 
@@ -503,12 +589,30 @@ def self_test():
             r.update(lines_pct=pct, lines_covered=int(pct), lines_total=100, seconds=1)
         return r
 
-    def summ(d):
-        return {"crates": {k: crate(*v) if isinstance(v, tuple) else crate(v)
-                           for k, v in d.items()}}
+    def summ(d, tier=None):
+        s = {"crates": {k: crate(*v) if isinstance(v, tuple) else crate(v)
+                        for k, v in d.items()}}
+        if tier is not None:
+            s["tier"] = tier
+        return s
 
     FLOORS = {"a": {"floor": 80}, "b": {"floor": 83}, "c": {"floor": 90}}
     quiet = lambda *a, **k: None
+
+    # --- effective_floor / tier-aware nightly_floor (sq-bjct) [OPUS-4.8] --------
+    fe = {"floor": 90, "nightly_floor": 94}
+    assert effective_floor(fe, "per-commit") == 90, "per-commit uses base floor"
+    assert effective_floor(fe, "nightly") == 94, "nightly uses nightly_floor"
+    assert effective_floor(fe, "full") == 94, "any non-per-commit tier uses nightly_floor"
+    assert effective_floor(fe, None) == 90, "absent tier defaults to base floor"
+    assert effective_floor({"floor": 90}, "nightly") == 90, "no nightly_floor -> base"
+    assert effective_floor(88, "nightly") == 88, "bare-number entry -> itself"
+    # A merge crate at 92% PASSES per-commit (floor 90) but FAILS nightly (floor 94).
+    FL_M = {"core": {"floor": 90, "nightly_floor": 94}}
+    assert sub_floor_crates(summ({"core": 92.0}, tier="per-commit"), FL_M) == []
+    assert sub_floor_crates(summ({"core": 92.0}, tier="nightly"), FL_M) == ["core"]
+    # ...and a merge crate at 95% passes BOTH tiers.
+    assert sub_floor_crates(summ({"core": 95.0}, tier="nightly"), FL_M) == []
 
     # --- merge_max: per-crate MAX, measured-only, internal consistency ---------
     m = merge_max(summ({"a": 70.0, "b": 90.0}), summ({"a": 95.0, "b": 88.0}))
@@ -607,6 +711,18 @@ def self_test():
     # a brand-new crate present only in `new` is never a regression.
     assert floor_regressions(base, {**base, "z": {"floor": 99}}) == []
     assert dropped_crates(base, {**base, "z": {"floor": 99}}) == []
+
+    # [OPUS-4.8] sq-bjct: nightly_floor is part of the ratchet — lowering or DROPPING
+    # one (once present in base) is a regression; ADDING one is not.
+    bnf = {"core": {"floor": 90, "nightly_floor": 94}}
+    assert floor_regressions(bnf, {"core": {"floor": 90, "nightly_floor": 92}}) \
+        == [("core.nightly_floor", 94, 92)]
+    assert floor_regressions(bnf, {"core": {"floor": 90}}) \
+        == [("core.nightly_floor", 94, "DROPPED")]
+    assert floor_regressions(bnf, {"core": {"floor": 90, "nightly_floor": 95}}) == []  # raised
+    # adding a nightly_floor where base had none is fine; base floor unchanged.
+    assert floor_regressions({"core": {"floor": 90}},
+                             {"core": {"floor": 90, "nightly_floor": 92}}) == []
 
     print("coverage-gate self-test: ALL ASSERTIONS PASSED")
     return 0

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -127,10 +127,20 @@ VECTORS_HEAVY_SKIP="recall_at_10_vs_brute_force_on_50k"   # matches HNSW + DiskA
 #
 # This roughly DOUBLES the core/engine measurement cost (the suites are a second
 # heavy exercise on top of the tests), which is exactly why it is nightly-only —
-# the per-commit tier keeps the cheap test-only measurement unchanged. Both suite
-# binaries skip suites whose fixtures are absent (fetched above), so the step is a
-# graceful no-op-on-X if fixtures could not be fetched (the test-only profraw from
-# (2) still yields a valid, if lower, number — never an empty/failed measurement).
+# the per-commit tier keeps the cheap test-only measurement unchanged.
+#
+# FIXTURE-ABSENCE BEHAVIOUR (NOT a graceful degrade): step (3)'s suite binaries
+# REQUIRE their fixtures. If `<root>/sparql` (sparq-conformance) or the inference
+# RDF-tests dir (sparq-inference-conformance) is absent, that binary prints
+# "test data not found … run scripts/fetch-*.sh first" and `std::process::exit(2)`s
+# (see crates/sparq-conformance/src/main.rs and src/bin/inference.rs) — it does NOT
+# skip-and-continue. A non-zero exit BREAKS measure_merged()'s `&&` chain, so step
+# (4)'s `report` never runs, rc!=0, and the crate is recorded UNMEASURED — the
+# step-2 test-only profraw is DISCARDED for that crate, not reported as a lower
+# number. So fixtures must be present (fetched above) for the merge to produce a
+# number at all; on absence the crate falls through to the unmeasured-row path
+# (which the robust gate then re-measures test-only). This is fail-closed, not a
+# silent lower measurement.
 CONFORMANCE_MERGE_CRATES="sparq-core sparq-engine"
 # Enable the merge only outside the cheap per-commit tier (set to 0 to force-disable).
 CONFORMANCE_MERGE="${CONFORMANCE_MERGE:-auto}"
@@ -177,9 +187,11 @@ want_conformance_merge() {
 # report (nightly tier). Uses cargo-llvm-cov's accumulate-then-report flow — see the
 # CONFORMANCE-BINARY MERGE header block for the full rationale. Emits the SAME JSON row
 # shape as measure(), tagging features += "conformance-merge" so the summary records that
-# this crate's number includes the suite binaries. On any failure to capture the merged
-# profraw it leaves rc!=0, and the caller falls through to the unmeasured-row path (the
-# robust gate then re-measures), so this never silently produces a low number.
+# this crate's number includes the suite binaries. On ANY failure to capture the merged
+# profraw — including fixture-absence, where a suite binary `exit(2)`s and breaks the `&&`
+# chain BEFORE step (4)'s report (see the FIXTURE-ABSENCE note in the header) — it leaves
+# rc!=0 and the caller falls through to the unmeasured-row path (the robust gate then
+# re-measures test-only). It records the crate UNMEASURED rather than a silent low number.
 measure_merged() {
   local crate="$1"
   local -a features=("conformance-merge")

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -101,6 +101,40 @@ NIGHTLY_ONLY_NOTE="sparq-vectors heavy 50k recall/diskann tests run only in nigh
 # DOCUMENTED here so the exclusion is never silent.
 VECTORS_HEAVY_SKIP="recall_at_10_vs_brute_force_on_50k"   # matches HNSW + DiskANN 50k
 
+# ---- conformance-binary merge (sq-bjct, NIGHTLY tier only) [OPUS-4.8] --------
+# The W3C SPARQL + inference suites run as the sparq-conformance /
+# sparq-inference-conformance BINARIES (`cargo run`), NOT as `cargo test`. So a
+# plain `cargo llvm-cov --package sparq-core` (which only runs that crate's
+# `cargo test`) does NOT count the suites' deep exercise of sparq-core /
+# sparq-engine — their per-crate floors otherwise reflect only unit+integration
+# tests.
+#
+# In the nightly/full tiers we MERGE the two conformance binaries' coverage into
+# the sparq-core / sparq-engine reports via cargo-llvm-cov's documented
+# accumulate-then-report flow (profraw is NOT clobbered between `--no-report`
+# invocations; it only resets on `clean`):
+#   1. `cargo llvm-cov clean --workspace`            — empty the profraw dir
+#   2. `cargo llvm-cov test  --no-report -p X ...`   — capture X's unit+integration
+#      tests' profraw (no report yet)
+#   3. `cargo llvm-cov run   --no-report --bin sparq-conformance ...`            \
+#      `cargo llvm-cov run   --no-report --bin sparq-inference-conformance ...`  —
+#      capture each suite binary's profraw ON TOP of (2) without wiping it
+#   4. `cargo llvm-cov report -p X --json --summary-only` — merge ALL accumulated
+#      profraw and emit X's line% over the merged set.
+# Step 4's report for package X therefore includes every X line that any of
+# (2)/(3) executed. We `report -p X` per crate so the number stays attributed to
+# X alone (the binaries themselves stay floor-0 / presence-gated).
+#
+# This roughly DOUBLES the core/engine measurement cost (the suites are a second
+# heavy exercise on top of the tests), which is exactly why it is nightly-only —
+# the per-commit tier keeps the cheap test-only measurement unchanged. Both suite
+# binaries skip suites whose fixtures are absent (fetched above), so the step is a
+# graceful no-op-on-X if fixtures could not be fetched (the test-only profraw from
+# (2) still yields a valid, if lower, number — never an empty/failed measurement).
+CONFORMANCE_MERGE_CRATES="sparq-core sparq-engine"
+# Enable the merge only outside the cheap per-commit tier (set to 0 to force-disable).
+CONFORMANCE_MERGE="${CONFORMANCE_MERGE:-auto}"
+
 # ---- fixtures (idempotent; no-ops when already pinned) ----------------------
 if [ "$FETCH_FIXTURES" = "1" ]; then
   echo "==> Fetching pinned W3C fixtures (idempotent)…"
@@ -123,8 +157,103 @@ trap 'rm -rf "$WORK"' EXIT
 declare -a ROWS=()
 TOTAL_START=$(date +%s)
 
+# [OPUS-4.8] sq-bjct: decide whether THIS crate's measurement should merge the
+# conformance binaries' coverage. Yes only when (a) the crate is one of the
+# CONFORMANCE_MERGE_CRATES, AND (b) the merge is enabled for this tier: "auto"
+# enables it for any tier except per-commit (it ~doubles core/engine cost), and an
+# explicit CONFORMANCE_MERGE=1/0 forces it on/off (1 even lets a `full`-tier ad-hoc
+# run merge; 0 disables for debugging / a fast nightly).
+want_conformance_merge() {
+  local crate="$1"
+  case " $CONFORMANCE_MERGE_CRATES " in *" $crate "*) ;; *) return 1 ;; esac
+  case "$CONFORMANCE_MERGE" in
+    0|false|no) return 1 ;;
+    1|true|yes) return 0 ;;
+    auto|*)     [ "$TIER" != "per-commit" ] && return 0 || return 1 ;;
+  esac
+}
+
+# [OPUS-4.8] sq-bjct: measure ONE crate with the conformance binaries MERGED into its
+# report (nightly tier). Uses cargo-llvm-cov's accumulate-then-report flow — see the
+# CONFORMANCE-BINARY MERGE header block for the full rationale. Emits the SAME JSON row
+# shape as measure(), tagging features += "conformance-merge" so the summary records that
+# this crate's number includes the suite binaries. On any failure to capture the merged
+# profraw it leaves rc!=0, and the caller falls through to the unmeasured-row path (the
+# robust gate then re-measures), so this never silently produces a low number.
+measure_merged() {
+  local crate="$1"
+  local -a features=("conformance-merge")
+  local -a feat_flags=()
+  # sparq-core keeps its mmap,dict-spill security surface (see PER-CRATE QUIRKS).
+  if [ "$crate" = "sparq-core" ]; then
+    feat_flags+=(--features mmap,dict-spill); features+=("mmap" "dict-spill")
+  fi
+  local start end rc=0 json="$WORK/$crate.json" err="$WORK/$crate.err"
+  start=$(date +%s)
+  : > "$err"
+  {
+    # 1. Start from an empty profraw set so ONLY this measurement's runs count.
+    cargo llvm-cov clean --workspace &&
+    # 2. Capture the crate's own unit+integration tests (serial — same profraw-race
+    #    mitigation as measure(); see sq-x4jy). No report yet.
+    cargo llvm-cov test --no-report --package "$crate" "${feat_flags[@]}" \
+      -- --test-threads=1 &&
+    # 3. Capture each suite binary ON TOP of (2) without wiping the profraw. Reports
+    #    are written into $WORK so they never litter the repo root.
+    cargo llvm-cov run --no-report --release -p sparq-conformance \
+      --bin sparq-conformance -- --report "$WORK/conformance-report.md" &&
+    cargo llvm-cov run --no-report --release -p sparq-conformance \
+      --bin sparq-inference-conformance -- --report "$WORK/inference-report.md" &&
+    # 4. Merge ALL accumulated profraw and emit X's line% over the merged set.
+    #    NB: `report` does NOT accept --features (that is a build-time flag, applied
+    #    in steps 2-3 which chose what code was compiled); passing it here errors with
+    #    "invalid option '--features' for subcommand 'report'". The report just
+    #    summarises the accumulated profraw for package X.
+    cargo llvm-cov report --package "$crate" \
+      --summary-only --json --output-path "$json"
+  } >/dev/null 2>>"$err" || rc=$?
+  end=$(date +%s)
+
+  if [ "$rc" -ne 0 ] || [ ! -s "$json" ]; then
+    echo "  !! $crate (conformance-merge) FAILED to measure (rc=$rc) — see error tail:"
+    tail -8 "$err" | sed 's/^/     /'
+    ROWS+=("$(python3 - "$crate" "$((end-start))" <<'PY'
+import json,sys
+print(json.dumps({"crate":sys.argv[1],"seconds":int(sys.argv[2]),"measured":False}))
+PY
+)")
+    return
+  fi
+
+  local feats_json
+  feats_json=$(printf '%s\n' "${features[@]}" | python3 -c 'import sys,json;print(json.dumps([l for l in sys.stdin.read().split("\n") if l]))')
+  local row
+  row=$(python3 - "$crate" "$json" "$((end-start))" "$feats_json" <<'PY'
+import json,sys
+crate,path,secs,feats=sys.argv[1],sys.argv[2],int(sys.argv[3]),json.loads(sys.argv[4])
+d=json.load(open(path))
+t=d["data"][0]["totals"]["lines"]
+print(json.dumps({"crate":crate,"lines_pct":round(t["percent"],2),
+  "lines_covered":t["covered"],"lines_total":t["count"],
+  "seconds":secs,"features":feats,"skipped_tests":[],"measured":True}))
+PY
+)
+  ROWS+=("$row")
+  printf "  %-20s lines=%6s%%  %4ss  feat=%s\n" "$crate" \
+    "$(echo "$row" | python3 -c 'import sys,json;print(json.load(sys.stdin)["lines_pct"])')" \
+    "$((end-start))" "${features[*]}"
+}
+
 measure() {
   local crate="$1"; shift
+  # [OPUS-4.8] sq-bjct: in the nightly/full tiers, sparq-core / sparq-engine are
+  # measured with the W3C conformance binaries MERGED into the report (those suites
+  # run as BINARIES, not `cargo test`, so the plain per-crate measurement misses
+  # their deep exercise of these crates). Per-commit is unchanged.
+  if want_conformance_merge "$crate"; then
+    measure_merged "$crate"
+    return
+  fi
   local features=()           # array of feature names recorded in JSON
   local skips=()              # array of skipped-test substrings recorded in JSON
   local -a cargo_args=(--package "$crate")


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Implements bead **sq-bjct**.

## What

The W3C **SPARQL** + **inference** suites run as the `sparq-conformance` /
`sparq-inference-conformance` **binaries** (`cargo run`), not as `cargo test`. So a
plain `cargo llvm-cov --package sparq-core|sparq-engine` (which runs `cargo test`)
does **not** count the suites' deep exercise of those two crates — their floors
otherwise reflect only unit+integration tests.

This PR teaches the **nightly** coverage tier to **merge** both conformance
binaries' coverage into the `sparq-core` / `sparq-engine` reports, and ratchets a
new, tier-aware floor up to the merged number — **without** breaking the cheaper
per-commit job.

## How

- **`scripts/coverage.sh`** — new `measure_merged()` (auto-used for `sparq-core` /
  `sparq-engine` when `tier != per-commit`). Uses cargo-llvm-cov's documented
  *accumulate-then-report* flow (profraw is not clobbered between `--no-report`
  runs; only `clean` resets it):
  1. `cargo llvm-cov clean --workspace`
  2. `cargo llvm-cov test --no-report -p X` (keeps `mmap,dict-spill` for core)
  3. `cargo llvm-cov run --no-report --bin sparq-conformance` + `--bin sparq-inference-conformance`
  4. `cargo llvm-cov report --package X --summary-only --json`

  (`report` does **not** accept `--features` — that is a build-time flag applied in
  steps 2–3; passing it errors. Documented inline.) Per-commit is unchanged.

- **`scripts/coverage-gate.py`** — tier-aware floors. A merge crate carries a
  separate, higher **`nightly_floor`** alongside the test-only `floor`. New
  `effective_floor(entry, tier)` is threaded through `--check`, `--check-robust`
  (`sub_floor_crates`), and `--seed`: per-commit gates `floor`, nightly gates
  `nightly_floor`. The monotonic ratchet (`floor_regressions`) now also protects
  `nightly_floor` from being lowered or dropped. New `--self-test` assertions cover
  all of this.

- **`bench/coverage-floor.json`** — `sparq-core.nightly_floor = 90`,
  `sparq-engine.nightly_floor = 85` (base `floor` 90/83 untouched), each annotated.

- **`.github/workflows/ci.yml`** — documents the merge in the `coverage-nightly`
  job header (the job already exports `COVERAGE_TIER=nightly`, so the merge + the
  tier-aware gate engage automatically — no new step).

## Fixture-absence behaviour (corrected — fail-closed, NOT a graceful no-op)

An earlier revision of the `measure_merged()` header described fixture-absence as a
"graceful no-op … still yields a valid, if lower, number — never an empty/failed
measurement." **That was false and has been corrected.** The actual behaviour:

- The suite binaries **require** their fixtures. If `<root>/sparql`
  (`sparq-conformance`) or the inference rdf-tests dir
  (`sparq-inference-conformance`) is absent, the binary prints
  `test data not found … run scripts/fetch-*.sh first` and **`std::process::exit(2)`s**
  (`crates/sparq-conformance/src/main.rs`, `src/bin/inference.rs`) — it does **not**
  skip-and-continue.
- A non-zero exit **breaks `measure_merged()`'s `&&` chain** before step (4)'s
  `report`, so `rc != 0` and the crate is recorded **UNMEASURED** — the step-2
  test-only profraw is **discarded** for that crate, not reported as a lower number.
- So this is **fail-closed**, not a silent lower measurement. Fixtures must be
  present (CI fetches them first) for the merge to produce a number; on absence the
  crate falls through to the unmeasured-row path (the robust gate then re-measures
  test-only). The per-suite SKIP that does exist is at a different granularity — the
  optional OWL/N3/turtle **sub-suites** skip per-section when their individual
  fixtures are absent — but the top-level required dirs hard-exit.

## Measured (local, rustc 1.96, full fixtures, EC2 work box)

| crate | merged (nightly) | nightly_floor | floor source |
|---|---|---|---|
| sparq-engine | **87.31%** (re-measured end-to-end this run) | 85 | floor(87.31)−2 = 85 ≤ 87.31 ✓ |
| sparq-core | 92.44% (prior measurement; **not** re-run this round — see honesty note) | 90 | equals the already-green per-commit `floor` 90 |

I **re-ran the full merged measurement for sparq-engine end-to-end** on this box
this round: 87.31% over 553s, and `coverage-gate.py --check` accepts it against
`nightly_floor = 85` (87.31 ≥ 85). I did **not** re-run sparq-core this round (a
second ~9-min merged run exceeded the time budget); its `nightly_floor = 90` is
nonetheless safe because it **equals the base `floor` 90 that already gates the
per-commit lane green** — it can never be tighter than an already-passing floor, so
it documents the merge without raising the bar. The 92.44% core number is carried
from the original measurement and is **not** independently re-verified here.

## Honesty / scope

- No Rust source changed → the Rust build/clippy/rustdoc/test gate is **N/A**; no
  `unsafe` added (unsafe-gate N/A); no public API changed (G2/SKILL.md N/A).
- Gates run: `coverage-gate.py --self-test` (pass), `--check` on the live engine
  summary (pass at `nightly_floor`), `--check-monotonic` vs `main` (pass — `floor`
  preserved, `nightly_floor` newly added so it cannot regress), `bash -n` (pass),
  **privacy-claims gate** (pass), **typos** (pass), YAML valid.
- Floors are conservative (−2 margin where raised; core left at its already-green
  base), so CI's own nightly measurement only needs to meet/exceed them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
