### PR TITLE
feat(site): live /surface/streaming-rsp page (tier-b W-rsp wasm) (sq-11zy) [OPUS-4.8]

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -115,6 +115,15 @@ jobs:
         working-directory: js
         run: npm run build:reason-wasm
 
+      # [OPUS-4.8] sq-11zy — build the tier-b "W-rsp" bundle (crates/sparq-rsp-wasm, the
+      # windowed RSP-QL stream processor) that drives the live /surface/streaming-rsp page.
+      # Its wasm-pack output stays in the crate's pkg/; the site's prebuild sync-wasm step
+      # copies it into public/wasm/rsp/. Separate from the lean bundle so the landing page
+      # stays light (the page lazy-loads it on first interaction).
+      - name: Build W-rsp wasm bundle
+        working-directory: js
+        run: npm run build:rsp-wasm
+
       # [OPUS-4.8] sq-gum8 — install the Typst CLI so the paper-factory build step
       # (site/scripts/build-papers.mjs, run by `prebuild`) can compile site/papers/*.typ
       # into the downloadable PDFs + the in-site HTML renders. Pinned to a release tag +

--- a/js/package.json
+++ b/js/package.json
@@ -37,6 +37,7 @@
     "build:wasm": "wasm-pack build ../crates/sparq-wasm --target web --release -- --features shacl,jsonld && npm run _copy:wasm",
     "build:wasm:lean": "wasm-pack build ../crates/sparq-wasm --target web --release && npm run _copy:wasm",
     "build:reason-wasm": "wasm-pack build ../crates/sparq-reason-wasm --target web --release -- --features explain",
+    "build:rsp-wasm": "wasm-pack build ../crates/sparq-rsp-wasm --target web --release",
     "build:ts": "tsc",
     "build": "npm run build:wasm && npm run build:ts",
     "test": "node --test \"test/*.test.mjs\"",

--- a/site/scripts/sync-wasm.mjs
+++ b/site/scripts/sync-wasm.mjs
@@ -59,3 +59,33 @@ try {
       `            run live. Build it:  (cd ../js && npm run build:reason-wasm)`,
   );
 }
+
+// [OPUS-4.8] sq-11zy — also sync the tier-b "W-rsp" bundle that drives
+// /surface/streaming-rsp (crates/sparq-rsp-wasm, the windowed RSP-QL stream processor,
+// built by `js/`'s `build:rsp-wasm`). Like W-reason, its wasm-pack output stays in the
+// crate's own pkg/ (it is NOT part of the published @jeswr/sparq package), so we copy it
+// into public/wasm/rsp/. OPTIONAL: a quick `next dev` that skips the build WARNs and
+// skips rather than failing — the streaming page then surfaces a clear load-failure state.
+const rspSrc = join(here, "..", "..", "crates", "sparq-rsp-wasm", "pkg");
+const rspDest = join(dest, "rsp");
+const rspFiles = [
+  "sparq_rsp_wasm.js",
+  "sparq_rsp_wasm_bg.wasm",
+  "sparq_rsp_wasm.d.ts",
+];
+
+try {
+  await access(join(rspSrc, "sparq_rsp_wasm_bg.wasm"));
+  await mkdir(rspDest, { recursive: true });
+  for (const f of rspFiles) {
+    await copyFile(join(rspSrc, f), join(rspDest, f));
+  }
+  console.log(
+    `[sync-wasm] copied ${rspFiles.length} files → public/wasm/rsp/ (W-rsp)`,
+  );
+} catch {
+  console.warn(
+    `[sync-wasm] W-rsp bundle not found at ${rspSrc}; /surface/streaming-rsp will not\n` +
+      `            run live. Build it:  (cd ../js && npm run build:rsp-wasm)`,
+  );
+}

--- a/site/src/app/surface/[slug]/page.tsx
+++ b/site/src/app/surface/[slug]/page.tsx
@@ -16,6 +16,7 @@ const BUILT_SURFACES = new Set([
   "inference",
   "mpc",
   "zk",
+  "streaming-rsp",
 ]);
 const PLACEHOLDER_SURFACES = ALL_SURFACES.filter(
   (s) =>

--- a/site/src/app/surface/streaming-rsp/page.tsx
+++ b/site/src/app/surface/streaming-rsp/page.tsx
@@ -1,0 +1,128 @@
+import type { Metadata } from "next";
+import { Radio } from "lucide-react";
+
+import { SurfaceContent } from "@/components/surface-content";
+import { RspPlayground } from "@/components/rsp-playground";
+
+export const metadata: Metadata = {
+  title: "Streaming RSP",
+  description:
+    "Continuous, windowed SPARQL over a live RDF stream with the sparq engine — RSP-QL sliding/tumbling time windows (RANGE/STEP), RSTREAM/ISTREAM/DSTREAM output, AVG-per-window — live in your tab via the W-rsp wasm bundle.",
+};
+
+export default function StreamingRspSurfacePage() {
+  return (
+    <SurfaceContent
+      icon={Radio}
+      title="Streaming RSP"
+      statement="Continuous, windowed SPARQL over a live RDF stream — RSP-QL sliding/tumbling time windows, RSTREAM/ISTREAM/DSTREAM, an AVG per window close."
+      tier="live-new-wasm"
+      intro={
+        <>
+          <p>
+            <code className="font-mono text-foreground">sparq-rsp</code> runs{" "}
+            <strong className="text-foreground">windowed continuous SPARQL</strong>{" "}
+            (RSP-QL-style RDF Stream Processing) over a stream of{" "}
+            <code className="font-mono">(triple, timestamp)</code> elements. You push
+            timestamped readings; it closes windows on a watermark and fires your query
+            once per closed window — an <code className="font-mono">AVG(?v)</code>,{" "}
+            <code className="font-mono">COUNT</code>, or any SELECT, evaluated over just
+            that window&rsquo;s triples.
+          </p>
+          <p>
+            It is a deterministic, synchronous library:{" "}
+            <strong className="text-foreground">
+              it reads no wall clock and runs no async runtime
+            </strong>
+            . Time advances only through the timestamps you push, so the whole pipeline
+            is a pure, replayable function of the pushed sequence. That is exactly what
+            makes it wasm-safe — and here the{" "}
+            <strong className="text-foreground">browser tab is the clock</strong>: the
+            buttons below advance the logical time, nothing in the bundle does.
+          </p>
+          <p>
+            Streaming ships as a <em>separate</em>, lazy-loaded wasm bundle (the tier-b{" "}
+            <code className="font-mono text-foreground">sparq-rsp-wasm</code>{" "}
+            &ldquo;W-rsp&rdquo;), not folded into the lean triplestore bundle, so the
+            landing page stays light and only this route downloads it. Pick an example,
+            push readings, and the closed-window tables come back with no network
+            round-trip.
+          </p>
+        </>
+      }
+      capabilities={[
+        {
+          title: "Tumbling & sliding time windows",
+          body: "RANGE / STEP in your own logical time unit — step == range tumbles, step < range slides with overlap.",
+        },
+        {
+          title: "Per-window aggregates",
+          body: "AVG / COUNT / SUM / MIN / MAX over each window's triples; integer AVG comes back as xsd:decimal per SPARQL typing.",
+        },
+        {
+          title: "RSTREAM / ISTREAM / DSTREAM",
+          body: "Full result per window, only rows that newly appeared (ISTREAM), or only rows that disappeared (DSTREAM).",
+        },
+        {
+          title: "Watermark + out-of-order tolerance",
+          body: "A window closes when max_ts − maxDelay reaches its end; late arrivals past every covering window are counted, not silently dropped.",
+        },
+        {
+          title: "Empty windows reported",
+          body: "When the watermark jumps a gap, the window still fires (with no rows) — so DSTREAM can observe results disappear.",
+        },
+        {
+          title: "Flush at end-of-stream",
+          body: "Flush closes every remaining open window up to the last timestamp seen, ignoring maxDelay.",
+        },
+      ]}
+      runsNote={
+        <>
+          <p>
+            <strong className="text-foreground">Live in your browser tab.</strong> The
+            stream processor is pure Rust over{" "}
+            <code className="font-mono">sparq-engine</code>, compiled to{" "}
+            <code className="font-mono">wasm32-unknown-unknown</code> as the separate{" "}
+            <code className="font-mono text-foreground">sparq-rsp-wasm</code> bundle. The
+            playground registers a continuous SELECT via{" "}
+            <code className="font-mono text-foreground">Rsp.select(query, range, step, maxDelay, r2s)</code>
+            , then drives the logical clock with{" "}
+            <code className="font-mono text-foreground">push(s, p, o, ts)</code> and{" "}
+            <code className="font-mono">flush()</code>. Each push returns the windows it
+            just closed as standard SPARQL 1.1 JSON — nothing is sent to a server.
+          </p>
+        </>
+      }
+      caveat={
+        <>
+          <p>
+            The in-tab bundle wraps the single-window{" "}
+            <code className="font-mono">ContinuousQuery</code> SELECT form only. The
+            native <code className="font-mono">sparq-rsp</code> crate also offers
+            continuous CONSTRUCT / ASK, count (ROWS) windows, the RSP-QL surface syntax
+            (<code className="font-mono">REGISTER STREAM … FROM NAMED WINDOW … ON …</code>),
+            and multi-window joins (
+            <code className="font-mono">WINDOW &lt;w1&gt; JOIN WINDOW &lt;w2&gt;</code>)
+            — those stay native for now. Window semantics here are exactly the crate&rsquo;s,
+            pinned by its tests; this is a thin, zero-<code className="font-mono">unsafe</code>{" "}
+            wrapper that owns no parsing or semantics of its own.
+          </p>
+        </>
+      }
+      links={[
+        {
+          href: "https://github.com/jeswr/sparq/tree/main/crates/sparq-rsp",
+          label: "sparq-rsp crate",
+          external: true,
+        },
+        {
+          href: "https://github.com/jeswr/sparq/tree/main/crates/sparq-rsp-wasm",
+          label: "W-rsp wasm bundle",
+          external: true,
+        },
+      ]}
+    >
+      <RspPlayground />
+    </SurfaceContent>
+  );
+}

--- a/site/src/components/rsp-playground.tsx
+++ b/site/src/components/rsp-playground.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+// [OPUS-4.8] sq-11zy — the live /surface/streaming-rsp playground. The browser tab drives
+// the logical clock: pick an example, then "Push next reading" feeds one timestamped
+// triple at a time (or "Run stream" replays them all), and each push that crosses a
+// window boundary fires the closed windows — their AVG(?v) / COUNT / ISTREAM table comes
+// back per close. A RANGE / STEP slider lets you re-shape the window (tumbling vs sliding)
+// and re-run. Everything runs in-tab via the separate, lazy-loaded W-rsp wasm bundle
+// (registerRsp -> Rsp.select/push/flush); nothing is sent to a server.
+
+import * as React from "react";
+import {
+  Play,
+  SkipForward,
+  RotateCcw,
+  Loader2,
+  Radio,
+  CheckCircle2,
+  Flag,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  prewarmRsp,
+  registerRsp,
+  type WasmRsp,
+} from "@/lib/sparq-rsp-wasm";
+import {
+  parseClosedWindows,
+  windowCells,
+  windowLabel,
+  type ClosedWindow,
+} from "@/lib/rsp-window";
+import { RSP_EXAMPLES, type RspExample } from "@/data/rsp-examples";
+
+type EngineState = "cold" | "warming" | "ready" | "error";
+
+const DEFAULT = RSP_EXAMPLES[0];
+
+export function RspPlayground() {
+  const [example, setExample] = React.useState<RspExample>(DEFAULT);
+  const [engine, setEngine] = React.useState<EngineState>("cold");
+  // Window controls (seeded from the example, then user-tunable via the sliders).
+  const [range, setRange] = React.useState(DEFAULT.range);
+  const [step, setStep] = React.useState(DEFAULT.step);
+  // Stream replay state: the live handle, how many readings we've pushed, the windows
+  // fired so far, the late-dropped counter, and whether we've flushed (end-of-stream).
+  const [handle, setHandle] = React.useState<WasmRsp | null>(null);
+  const [cursor, setCursor] = React.useState(0);
+  const [windows, setWindows] = React.useState<ClosedWindow[]>([]);
+  const [lateDropped, setLateDropped] = React.useState(0);
+  const [flushed, setFlushed] = React.useState(false);
+  const [busy, setBusy] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  // Pre-warm the (separate) streaming wasm bundle on mount so the first push pays no
+  // cold start. A failure resets the indicator; the first register retries the load.
+  React.useEffect(() => {
+    let cancelled = false;
+    setEngine("warming");
+    prewarmRsp()
+      .then(() => {
+        if (!cancelled) setEngine("ready");
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setEngine("error");
+        toast.error("Streaming engine failed to load", {
+          description: e instanceof Error ? e.message : String(e),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Re-register the continuous query with the current window when the example, RANGE or
+  // STEP changes. Re-registering resets the stream (a fresh logical clock), so we also
+  // clear the replay state. The wasm handle is stateful; we keep one live per config.
+  const reset = React.useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const h = await registerRsp(
+        example.query,
+        range,
+        step,
+        example.maxDelay,
+        example.r2s,
+      );
+      setEngine("ready");
+      setHandle(h);
+      setCursor(0);
+      setWindows([]);
+      setLateDropped(0);
+      setFlushed(false);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setError(message);
+      setHandle(null);
+      toast.error("Could not register the continuous query", {
+        description: message,
+      });
+    } finally {
+      setBusy(false);
+    }
+  }, [example, range, step]);
+
+  // (Re)register whenever the configuration changes.
+  React.useEffect(() => {
+    void reset();
+  }, [reset]);
+
+  const selectExample = React.useCallback((id: string) => {
+    const ex = RSP_EXAMPLES.find((e) => e.id === id);
+    if (!ex) return;
+    setExample(ex);
+    setRange(ex.range);
+    setStep(ex.step);
+  }, []);
+
+  // Push ONE reading and absorb whatever windows it closed.
+  const pushOne = React.useCallback(() => {
+    if (!handle || cursor >= example.readings.length) return;
+    try {
+      const r = example.readings[cursor];
+      const closed = parseClosedWindows(handle.push(r.s, r.p, r.o, r.ts));
+      setWindows((prev) => [...prev, ...closed]);
+      setLateDropped(handle.lateDropped());
+      setCursor((c) => c + 1);
+      setError(null);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setError(message);
+      toast.error("Push failed", { description: message });
+    }
+  }, [handle, cursor, example.readings]);
+
+  // Replay every remaining reading, then flush (end-of-stream) to close the tail window.
+  const runAll = React.useCallback(() => {
+    if (!handle) return;
+    try {
+      const closed: ClosedWindow[] = [];
+      for (let i = cursor; i < example.readings.length; i++) {
+        const r = example.readings[i];
+        closed.push(...parseClosedWindows(handle.push(r.s, r.p, r.o, r.ts)));
+      }
+      closed.push(...parseClosedWindows(handle.flush()));
+      setWindows((prev) => [...prev, ...closed]);
+      setLateDropped(handle.lateDropped());
+      setCursor(example.readings.length);
+      setFlushed(true);
+      setError(null);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setError(message);
+      toast.error("Stream run failed", { description: message });
+    }
+  }, [handle, cursor, example.readings]);
+
+  // Flush only (close the open tail window without more pushes).
+  const flush = React.useCallback(() => {
+    if (!handle || flushed) return;
+    try {
+      const closed = parseClosedWindows(handle.flush());
+      setWindows((prev) => [...prev, ...closed]);
+      setLateDropped(handle.lateDropped());
+      setFlushed(true);
+      setError(null);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setError(message);
+      toast.error("Flush failed", { description: message });
+    }
+  }, [handle, flushed]);
+
+  const tumbling = step >= range;
+  const remaining = example.readings.length - cursor;
+  const done = cursor >= example.readings.length;
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center justify-between gap-2 space-y-0">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Radio className="size-4 text-primary" />
+          Live RSP-QL stream processor
+        </CardTitle>
+        <EngineIndicator engine={engine} />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap gap-1.5">
+          {RSP_EXAMPLES.map((ex) => (
+            <Button
+              key={ex.id}
+              variant={example.id === ex.id ? "default" : "outline"}
+              size="sm"
+              onClick={() => selectExample(ex.id)}
+              title={ex.description}
+            >
+              {ex.label}
+            </Button>
+          ))}
+        </div>
+
+        <p className="text-sm text-muted-foreground">{example.description}</p>
+
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">
+            Continuous SELECT
+          </label>
+          <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed">
+            {example.query}
+          </pre>
+        </div>
+
+        {/* RANGE / STEP sliders — re-shape the window (tumbling vs sliding) and re-run. */}
+        <div className="grid gap-4 sm:grid-cols-2">
+          <WindowSlider
+            id="rsp-range"
+            label="RANGE"
+            help="window width (logical ticks)"
+            value={range}
+            min={5}
+            max={120}
+            step={5}
+            onChange={setRange}
+          />
+          <WindowSlider
+            id="rsp-step"
+            label="STEP"
+            help={tumbling ? "≥ RANGE ⇒ tumbling" : "< RANGE ⇒ sliding"}
+            value={step}
+            min={5}
+            max={120}
+            step={5}
+            onChange={setStep}
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Button onClick={pushOne} disabled={busy || done || !handle}>
+            <SkipForward className="size-4" />
+            Push next reading
+          </Button>
+          <Button
+            variant="outline"
+            onClick={runAll}
+            disabled={busy || done || !handle}
+          >
+            <Play className="size-4" />
+            Run stream
+          </Button>
+          <Button
+            variant="outline"
+            onClick={flush}
+            disabled={busy || flushed || !handle}
+          >
+            <Flag className="size-4" />
+            Flush
+          </Button>
+          <Button variant="ghost" onClick={() => void reset()} disabled={busy}>
+            <RotateCcw className="size-4" />
+            Reset
+          </Button>
+          <p aria-live="polite" className="text-xs text-muted-foreground">
+            {busy
+              ? "Registering on the wasm engine…"
+              : `${cursor} / ${example.readings.length} readings pushed · ${windows.length} window${windows.length === 1 ? "" : "s"} fired${lateDropped ? ` · ${lateDropped} late-dropped` : ""}`}
+          </p>
+        </div>
+
+        {/* The next reading queued for the clock — makes "the tab is the clock" concrete. */}
+        {!done && handle && (
+          <p className="text-xs text-muted-foreground">
+            Next push:{" "}
+            <code className="font-mono text-foreground">
+              {example.readings[cursor].s} {example.readings[cursor].p}{" "}
+              {example.readings[cursor].o}
+            </code>{" "}
+            at <span className="font-mono text-foreground">ts={example.readings[cursor].ts}</span>{" "}
+            ({remaining} remaining)
+          </p>
+        )}
+
+        {error && (
+          <pre className="overflow-x-auto rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+            {error}
+          </pre>
+        )}
+
+        <WindowList windows={windows} flushed={flushed && done} />
+      </CardContent>
+    </Card>
+  );
+}
+
+function WindowSlider({
+  id,
+  label,
+  help,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  help: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between">
+        <label htmlFor={id} className="text-xs font-medium text-muted-foreground">
+          {label}{" "}
+          <span className="font-mono text-foreground">{value}</span>
+        </label>
+        <span className="text-[11px] text-muted-foreground">{help}</span>
+      </div>
+      <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full accent-[var(--primary)]"
+      />
+    </div>
+  );
+}
+
+function EngineIndicator({ engine }: { engine: EngineState }) {
+  if (engine === "ready") {
+    return (
+      <Badge variant="success" aria-live="polite">
+        <CheckCircle2 className="size-3" /> Engine ready
+      </Badge>
+    );
+  }
+  if (engine === "error") {
+    return (
+      <Badge variant="warning" aria-live="polite">
+        Engine failed — retries on register
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="muted" aria-live="polite">
+      <Loader2 className="size-3 animate-spin" /> Engine loading…
+    </Badge>
+  );
+}
+
+function WindowList({
+  windows,
+  flushed,
+}: {
+  windows: ClosedWindow[];
+  flushed: boolean;
+}) {
+  if (windows.length === 0) {
+    return (
+      <p className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+        No windows fired yet — push readings until the logical clock crosses a window
+        boundary, or hit “Run stream”.
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-2" data-testid="rsp-windows">
+      {windows.map((w, i) => (
+        <WindowCard key={i} window={w} />
+      ))}
+      {flushed && (
+        <p className="text-xs text-muted-foreground">
+          Stream flushed — every window up to the last timestamp is closed.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function WindowCard({ window: w }: { window: ClosedWindow }) {
+  const { vars, rows } = windowCells(w);
+  return (
+    <div className="rounded-lg border bg-muted/30 p-3 text-sm" data-testid="rsp-window">
+      <div className="mb-2 flex items-center gap-2">
+        <Badge variant="muted" className="font-mono text-[11px]">
+          {windowLabel(w)}
+        </Badge>
+        <span className="text-xs text-muted-foreground">
+          {rows.length === 0
+            ? "empty window"
+            : `${rows.length} row${rows.length === 1 ? "" : "s"}`}
+        </span>
+      </div>
+      {rows.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          Fired with no solutions (the watermark jumped this window).
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse font-mono text-[12.5px]">
+            <thead>
+              <tr className="text-left text-muted-foreground">
+                {vars.map((v) => (
+                  <th key={v} className="border-b px-2 py-1 font-medium">
+                    ?{v}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, ri) => (
+                <tr key={ri}>
+                  {row.map((cell, ci) => (
+                    <td
+                      key={ci}
+                      className={cn(
+                        "border-b px-2 py-1 text-foreground",
+                        cell === "" && "text-muted-foreground",
+                      )}
+                    >
+                      {cell === "" ? "—" : cell}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/site/src/data/rsp-examples.ts
+++ b/site/src/data/rsp-examples.ts
@@ -1,0 +1,99 @@
+// [OPUS-4.8] sq-11zy — built-in examples for the live /surface/streaming-rsp playground.
+// The default is the SKILL.md / sparq-rsp-wasm README walkthrough: AVG(?v) over tumbling
+// 60-tick windows, fed bare-numeric Turtle readings, with ts=65 closing the [0,60) window
+// at AVG = 15.0. Each example pins a continuous SELECT, a window (range/step/maxDelay),
+// the R2S operator, and a scripted reading stream the page replays one push at a time.
+
+import type { R2S } from "@/lib/sparq-rsp-wasm";
+
+/** One scripted reading: a Turtle (s, p, o) triple plus its logical timestamp. */
+export interface RspReading {
+  s: string;
+  p: string;
+  o: string;
+  ts: number;
+}
+
+export interface RspExample {
+  id: string;
+  label: string;
+  description: string;
+  /** The continuous SELECT registered over the window. */
+  query: string;
+  /** RSP-QL window: RANGE / STEP (step==range tumbling, step<range sliding) / lateness. */
+  range: number;
+  step: number;
+  maxDelay: number;
+  r2s: R2S;
+  /** The scripted reading stream the page replays. */
+  readings: RspReading[];
+}
+
+const READING = "<http://ex/reading>";
+const S1 = "<http://ex/s1>";
+const ACTIVE = "<http://ex/active>";
+
+/** Three sensors over six 60-tick windows, so AVG fires a fresh value per window close. */
+function avgReadings(): RspReading[] {
+  const vals = [
+    [10, 0],
+    [20, 30],
+    [5, 65], // closes [0,60) -> AVG(10,20) = 15.0
+    [30, 70],
+    [40, 95],
+    [50, 130], // closes [60,120) -> AVG(5,30,40) = 25.0
+    [60, 190], // closes [120,180) -> AVG(50) = 50.0
+  ] as const;
+  return vals.map(([v, ts]) => ({ s: S1, p: READING, o: String(v), ts }));
+}
+
+export const RSP_EXAMPLES: RspExample[] = [
+  {
+    id: "avg-tumbling-60",
+    label: "AVG per 60-tick window",
+    description:
+      "AVG(?v) over TUMBLING 60-tick windows (RANGE 60 STEP 60). A push at ts=65 closes [0,60) at AVG = 15.0.",
+    query: "SELECT (AVG(?v) AS ?avg) WHERE { ?s <http://ex/reading> ?v }",
+    range: 60,
+    step: 60,
+    maxDelay: 0,
+    r2s: "rstream",
+    readings: avgReadings(),
+  },
+  {
+    id: "count-tumbling",
+    label: "COUNT per window",
+    description:
+      "COUNT(*) of readings per tumbling 30-tick window — a per-window throughput meter.",
+    query: "SELECT (COUNT(*) AS ?n) WHERE { ?s <http://ex/reading> ?v }",
+    range: 30,
+    step: 30,
+    maxDelay: 0,
+    r2s: "rstream",
+    readings: [
+      { s: S1, p: READING, o: "10", ts: 0 },
+      { s: S1, p: READING, o: "11", ts: 5 },
+      { s: S1, p: READING, o: "12", ts: 20 },
+      { s: S1, p: READING, o: "13", ts: 35 }, // closes [0,30): n = 3
+      { s: S1, p: READING, o: "14", ts: 50 },
+      { s: S1, p: READING, o: "15", ts: 70 }, // closes [30,60): n = 2
+    ],
+  },
+  {
+    id: "istream-sliding-active",
+    label: "ISTREAM sliding (new rows)",
+    description:
+      "Sliding window (RANGE 40 STEP 20) with ISTREAM: each close reports only the subjects that NEWLY appeared vs. the previous window.",
+    query: "SELECT ?s WHERE { ?s <http://ex/active> ?o }",
+    range: 40,
+    step: 20,
+    maxDelay: 0,
+    r2s: "istream",
+    readings: [
+      { s: "<http://ex/a>", p: ACTIVE, o: "true", ts: 0 },
+      { s: "<http://ex/b>", p: ACTIVE, o: "true", ts: 25 }, // close [0,20): a appears
+      { s: "<http://ex/c>", p: ACTIVE, o: "true", ts: 45 }, // close [0,40): b appears (a already seen)
+      { s: "<http://ex/d>", p: ACTIVE, o: "true", ts: 70 }, // close [20,60): c, d appear
+    ],
+  },
+];

--- a/site/src/data/surfaces.ts
+++ b/site/src/data/surfaces.ts
@@ -216,6 +216,7 @@ export const GROUPS: SurfaceGroup[] = [
         blurb: "RSP-QL windows (sliding / tumbling, R/I/DSTREAM).",
         tier: "live-new-wasm",
         icon: Radio,
+        built: true,
       },
     ],
   },

--- a/site/src/lib/rsp-window.ts
+++ b/site/src/lib/rsp-window.ts
@@ -1,0 +1,112 @@
+// [OPUS-4.8] sq-11zy — pure helpers for the live /surface/streaming-rsp playground:
+// parse the closed-window JSON array the wasm `Rsp.push`/`Rsp.flush` bindings return,
+// and render each window's SPARQL-1.1-JSON result table into framework-free rows. The
+// wasm windowing semantics themselves (boundaries, lateness, R2S diffs) are proven by
+// crates/sparq-rsp's tests; here we only test the JS parse/render of what it returns.
+// Kept separate from the React component so node --test can exercise it with no DOM.
+
+import type { SparqlResults, SparqlTerm } from "./sparq-wasm";
+
+const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
+
+/**
+ * [OPUS-4.8] sq-11zy — render a SPARQL-JSON term for display, with a compact
+ * datatype/lang suffix. A self-contained copy of the REPL's `formatTerm` so this pure
+ * helper carries NO cross-module runtime import (the unit-test ts-loader does not rewrite
+ * extensionless specifiers, and a value import would not resolve). An undefined term —
+ * an unbound projection variable in a row — renders as the empty string.
+ */
+function formatTerm(t: SparqlTerm | undefined): string {
+  if (!t) return "";
+  if (t.type === "uri") return `<${t.value}>`;
+  if (t.type === "bnode") return `_:${t.value}`;
+  if (t["xml:lang"]) return `"${t.value}"@${t["xml:lang"]}`;
+  if (t.datatype && t.datatype !== XSD_STRING) {
+    const short = t.datatype.replace("http://www.w3.org/2001/XMLSchema#", "xsd:");
+    return `"${t.value}"^^${short}`;
+  }
+  return `"${t.value}"`;
+}
+
+/**
+ * [OPUS-4.8] sq-11zy — one CLOSED window the engine fired: the half-open `[start, end)`
+ * logical-time bounds plus the R2S-filtered SELECT table as a self-contained SPARQL 1.1
+ * JSON document. Mirrors the `{"start","end","results"}` shape `windows_json` emits in
+ * crates/sparq-rsp-wasm.
+ */
+export interface ClosedWindow {
+  start: number;
+  end: number;
+  results: SparqlResults;
+}
+
+/**
+ * [OPUS-4.8] sq-11zy — parse the JSON string a single `push`/`flush` returns into the
+ * array of windows it closed (oldest first, possibly empty). Throws a clear error if the
+ * payload is not the expected `{start,end,results}[]` shape, so a malformed binding return
+ * surfaces loudly rather than rendering as an empty stream.
+ */
+export function parseClosedWindows(json: string): ClosedWindow[] {
+  const parsed: unknown = JSON.parse(json);
+  if (!Array.isArray(parsed)) {
+    throw new Error("expected a JSON array of closed windows");
+  }
+  return parsed.map((w, i) => {
+    if (
+      typeof w !== "object" ||
+      w === null ||
+      typeof (w as Record<string, unknown>).start !== "number" ||
+      typeof (w as Record<string, unknown>).end !== "number" ||
+      typeof (w as Record<string, unknown>).results !== "object"
+    ) {
+      throw new Error(`closed window ${i} is not {start,end,results}`);
+    }
+    const rec = w as { start: number; end: number; results: SparqlResults };
+    return { start: rec.start, end: rec.end, results: rec.results };
+  });
+}
+
+/** The variable names a window's result table projects (its SELECT projection). */
+export function windowVars(window: ClosedWindow): string[] {
+  return window.results.head?.vars ?? [];
+}
+
+/** The solution rows of a window's result table (each a var→term map). */
+export function windowRows(
+  window: ClosedWindow,
+): Record<string, SparqlTerm>[] {
+  return window.results.results?.bindings ?? [];
+}
+
+/**
+ * [OPUS-4.8] sq-11zy — render a window's result table as plain string cells (one row per
+ * solution, columns in `windowVars` order), reusing the REPL's {@link formatTerm} so the
+ * datatype/lang suffixes match the rest of the site. An unbound variable in a row renders
+ * as the empty string. This is what the playground draws into its per-window table.
+ */
+export function windowCells(window: ClosedWindow): {
+  vars: string[];
+  rows: string[][];
+} {
+  const vars = windowVars(window);
+  const rows = windowRows(window).map((binding) =>
+    vars.map((v) => formatTerm(binding[v])),
+  );
+  return { vars, rows };
+}
+
+/** A compact `[start, end)` label for a window header. */
+export function windowLabel(window: ClosedWindow): string {
+  return `[${window.start}, ${window.end})`;
+}
+
+/**
+ * [OPUS-4.8] sq-11zy — a one-line human summary of a window: its bounds and its row count
+ * ("empty" when the watermark jumped a gap and the window fired with no solutions —
+ * which `sparq-rsp` reports so DSTREAM can observe results disappear).
+ */
+export function windowSummary(window: ClosedWindow): string {
+  const n = windowRows(window).length;
+  if (n === 0) return `${windowLabel(window)} — empty window`;
+  return `${windowLabel(window)} — ${n} row${n === 1 ? "" : "s"}`;
+}

--- a/site/src/lib/sparq-rsp-wasm.ts
+++ b/site/src/lib/sparq-rsp-wasm.ts
@@ -1,0 +1,114 @@
+// [OPUS-4.8] sq-11zy — live loader for the SEPARATE, lazy-loaded `sparq-rsp-wasm`
+// ("W-rsp") bundle that backs the /surface/streaming-rsp page. This is NOT the lean
+// `sparq_wasm` triplestore bundle (src/lib/sparq-wasm.ts) — it is its own wasm-pack
+// `--target web` artifact (`sparq_rsp_wasm{.js,_bg.wasm}`), carrying the windowed
+// RSP-QL stream processor and nothing else, so the landing page stays light and only
+// THIS route pays its download. Loaded with the same runtime-`import(webpackIgnore)`
+// strategy as the lean bundle (and the sibling W-reason bundle, src/lib/reason-wasm.ts):
+// the glue never enters the page bundle and the wasm bytes' URL is passed explicitly
+// (basePath-prefixed for GitHub Pages). Its wasm-pack output stays in the crate's own
+// pkg/ (it is NOT part of the published @jeswr/sparq package); the prebuild sync-wasm
+// step copies it into public/wasm/rsp/.
+//
+// The browser tab drives the logical clock: `sparq-rsp` reads no wall clock and runs no
+// async runtime, so a window only closes when the UI advances `ts` via a push (or a
+// flush). The whole pipeline is a pure, replayable function of the pushed (triple, ts)
+// sequence — see crates/sparq-rsp-wasm/README.md.
+
+/** The R2S relation-to-stream operator names the `Rsp.select` binding accepts. */
+export type R2S = "rstream" | "istream" | "dstream";
+
+/**
+ * [OPUS-4.8] sq-11zy — the wasm `Rsp` handle: one registered continuous SELECT over a
+ * time window. Mirrors `crates/sparq-rsp-wasm`'s `#[wasm_bindgen] struct Rsp`. Stateful:
+ * each {@link WasmRsp.push} advances the logical clock and returns the windows that just
+ * CLOSED.
+ */
+export interface WasmRsp {
+  /** Feed one timestamped Turtle triple; returns the closed-window JSON array as a string. */
+  push(s: string, p: string, o: string, ts: number): string;
+  /** End-of-stream: close every window up to the last `ts` seen; same JSON array shape. */
+  flush(): string;
+  /** Count of arrivals dropped as too late (every covering window had already closed). */
+  lateDropped(): number;
+  /** The registered SPARQL text (echo, for the UI). */
+  sparql(): string;
+}
+
+interface RspModule {
+  default: (opts?: { module_or_path: string | URL }) => Promise<unknown>;
+  Rsp: {
+    select(
+      sparql: string,
+      range: number,
+      step: number,
+      maxDelay: number,
+      r2s: R2S,
+    ): WasmRsp;
+  };
+}
+
+function basePath(): string {
+  // Mirror next.config.ts's basePath ('/sparq' on Pages, empty in local `next dev`).
+  return process.env.NEXT_PUBLIC_BASE_PATH ?? "/sparq";
+}
+
+let modulePromise: Promise<RspModule> | null = null;
+
+/**
+ * [OPUS-4.8] sq-11zy — load + initialise the W-rsp wasm bundle once; subsequent calls
+ * reuse the single instance. The fetch + compile + instantiate is the cold start;
+ * {@link prewarmRsp} kicks it off on route mount so the first push pays none of it. A
+ * load failure resets the cache so a later call can retry.
+ */
+export async function loadRsp(): Promise<RspModule["Rsp"]> {
+  if (!modulePromise) {
+    modulePromise = (async () => {
+      const base = basePath();
+      const gluePath = `${base}/wasm/rsp/sparq_rsp_wasm.js`;
+      const wasmPath = `${base}/wasm/rsp/sparq_rsp_wasm_bg.wasm`;
+      const mod = (await import(/* webpackIgnore: true */ gluePath)) as RspModule;
+      await mod.default({ module_or_path: new URL(wasmPath, window.location.origin) });
+      return mod;
+    })();
+    modulePromise.catch(() => {
+      modulePromise = null; // allow retry on transient failure
+    });
+  }
+  const mod = await modulePromise;
+  return mod.Rsp;
+}
+
+/**
+ * [OPUS-4.8] sq-11zy — eagerly pre-warm the W-rsp bundle without blocking render. Safe
+ * to call on route mount and repeatedly: it shares the single {@link loadRsp} promise, so
+ * the cold start happens at most once. Resolves when the bundle is ready (or rejects on a
+ * load failure, which resets the cache so a later register can retry).
+ */
+export function prewarmRsp(): Promise<unknown> {
+  return loadRsp();
+}
+
+/**
+ * [OPUS-4.8] sq-11zy — register a continuous SELECT over a time window, in your tab via
+ * the W-rsp bundle. The returned {@link WasmRsp} is stateful — each `push` advances the
+ * logical clock — so callers own its lifetime (re-register to reset the stream). Throws
+ * if the bundle is missing the `Rsp` export (wrong artifact) or `Rsp.select` rejects the
+ * query / window parameters.
+ */
+export async function registerRsp(
+  sparql: string,
+  range: number,
+  step: number,
+  maxDelay: number,
+  r2s: R2S,
+): Promise<WasmRsp> {
+  const Rsp = await loadRsp();
+  if (typeof Rsp?.select !== "function") {
+    throw new Error(
+      "This wasm bundle does not export the streaming `Rsp` handle. " +
+        "Build crates/sparq-rsp-wasm with `wasm-pack build --target web`.",
+    );
+  }
+  return Rsp.select(sparql, range, step, maxDelay, r2s);
+}

--- a/site/test/rsp-window.test.mjs
+++ b/site/test/rsp-window.test.mjs
@@ -1,0 +1,117 @@
+// [OPUS-4.8] sq-11zy — unit tests for the pure helpers that back the live
+// /surface/streaming-rsp playground: parsing the closed-window JSON array the wasm
+// `Rsp.push`/`Rsp.flush` bindings return, and shaping each window's SPARQL-1.1-JSON
+// table into framework-free cells. The wasm windowing SEMANTICS themselves (boundaries,
+// lateness, R2S diffs) are proven by the Rust tests in crates/sparq-rsp(/ -wasm); here we
+// only test the JS parse/render of what those bindings return. Run via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseClosedWindows,
+  windowVars,
+  windowRows,
+  windowCells,
+  windowLabel,
+  windowSummary,
+} from "../src/lib/rsp-window.ts";
+
+// The AVG(?v) tumbling-window walkthrough: a single closed window [0,60) whose result is
+// the AVG of readings 10 and 20 = "15.0"^^xsd:decimal (SPARQL aggregate typing), exactly
+// as the W-rsp bundle's `push` returns it for the default example.
+const AVG_PUSH = JSON.stringify([
+  {
+    start: 0,
+    end: 60,
+    results: {
+      head: { vars: ["avg"] },
+      results: {
+        bindings: [
+          {
+            avg: {
+              type: "literal",
+              value: "15.0",
+              datatype: "http://www.w3.org/2001/XMLSchema#decimal",
+            },
+          },
+        ],
+      },
+    },
+  },
+]);
+
+test("parseClosedWindows: an empty array means no window closed", () => {
+  assert.deepEqual(parseClosedWindows("[]"), []);
+});
+
+test("parseClosedWindows: parses {start,end,results} windows", () => {
+  const windows = parseClosedWindows(AVG_PUSH);
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0].start, 0);
+  assert.equal(windows[0].end, 60);
+  assert.equal(windows[0].results.head.vars[0], "avg");
+});
+
+test("parseClosedWindows: rejects a non-array payload", () => {
+  assert.throws(() => parseClosedWindows('{"start":0}'), /array of closed windows/);
+});
+
+test("parseClosedWindows: rejects a malformed window object", () => {
+  assert.throws(
+    () => parseClosedWindows('[{"start":0,"end":"oops"}]'),
+    /not \{start,end,results\}/,
+  );
+});
+
+test("windowVars / windowRows: read the projection and solutions", () => {
+  const [w] = parseClosedWindows(AVG_PUSH);
+  assert.deepEqual(windowVars(w), ["avg"]);
+  assert.equal(windowRows(w).length, 1);
+});
+
+test("windowCells: renders the decimal AVG with its xsd suffix", () => {
+  const [w] = parseClosedWindows(AVG_PUSH);
+  const { vars, rows } = windowCells(w);
+  assert.deepEqual(vars, ["avg"]);
+  assert.deepEqual(rows, [['"15.0"^^xsd:decimal']]);
+});
+
+test("windowCells: an unbound variable renders as the empty string", () => {
+  const [w] = parseClosedWindows(
+    JSON.stringify([
+      {
+        start: 0,
+        end: 10,
+        results: {
+          head: { vars: ["s", "o"] },
+          results: {
+            bindings: [{ s: { type: "uri", value: "http://ex/a" } }],
+          },
+        },
+      },
+    ]),
+  );
+  const { rows } = windowCells(w);
+  assert.deepEqual(rows, [["<http://ex/a>", ""]]);
+});
+
+test("windowLabel: the half-open bounds", () => {
+  const [w] = parseClosedWindows(AVG_PUSH);
+  assert.equal(windowLabel(w), "[0, 60)");
+});
+
+test("windowSummary: row count, and 'empty window' when the watermark jumped a gap", () => {
+  const [w] = parseClosedWindows(AVG_PUSH);
+  assert.equal(windowSummary(w), "[0, 60) — 1 row");
+
+  const [empty] = parseClosedWindows(
+    JSON.stringify([
+      {
+        start: 60,
+        end: 120,
+        results: { head: { vars: ["avg"] }, results: { bindings: [] } },
+      },
+    ]),
+  );
+  assert.equal(windowSummary(empty), "[60, 120) — empty window");
+});


### PR DESCRIPTION
> 🤖 SPARQL agent — automated PR from a SPARQL agent on @jeswr's account.

Implements **sq-11zy**: the live `/surface/streaming-rsp` (tier-b) page. Both dependency beads are closed — `sq-8thu` (site shell + design language) and `sq-nzcb` (the W-rsp wasm bundle) — so this wires the bundle into the showcase site and builds the interactive page.

## What it does

Push timestamped readings and watch RSP-QL **windows fire `AVG(?v)` / `COUNT` / `ISTREAM` per close**, with a **RANGE / STEP slider** to re-shape the window (tumbling when `step ≥ range`, sliding when `step < range`) and re-run. The **browser tab drives the logical clock** — *Push next reading*, *Run stream* and *Flush* advance `ts`; nothing in the bundle reads a wall clock — exactly the wasm-safety property `sparq-rsp` is built around. The default example is the SKILL.md walkthrough: AVG per 60-tick tumbling window, where a push at `ts=65` closes `[0,60)` at AVG = 15.0.

It runs **live in-tab** via the separate, lazy-loaded tier-b `sparq-rsp-wasm` ("W-rsp") bundle, wired exactly like the sibling **W-reason** bundle (`/surface/inference`): a new `build:rsp-wasm` in `js/`, its wasm-pack `pkg/` copied into `site/public/wasm/rsp/` by the prebuild `sync-wasm` step, and a build step in `pages.yml`. The landing page never pays for it.

## Files

- `site/src/lib/sparq-rsp-wasm.ts` — runtime `webpackIgnore` loader + `prewarmRsp` / `registerRsp` over the `Rsp.select/push/flush/lateDropped/sparql` bindings (mirrors `crates/sparq-rsp-wasm`).
- `site/src/lib/rsp-window.ts` — pure, framework-free parse of the closed-window JSON array + SPARQL-1.1-JSON table rendering. Self-contained (no cross-module runtime import) so it unit-tests under the ts-loader.
- `site/src/components/rsp-playground.tsx` — the playground: example picker, RANGE/STEP sliders, push/run/flush controls, per-window result tables, late-dropped counter.
- `site/src/data/rsp-examples.ts` — AVG-per-60-tick (default), COUNT-per-window, ISTREAM-sliding scripted streams, grounded in `skills/streaming-rsp/SKILL.md`.
- `site/src/app/surface/streaming-rsp/page.tsx` — the page (`SurfaceContent` + playground), tier `live-new-wasm`, with the honest caveat below.
- `site/test/rsp-window.test.mjs` — unit tests for the pure helpers (windowing semantics themselves are proven by the Rust crate tests).
- `surfaces.ts` `built: true` + `[slug]` `BUILT_SURFACES` so the static page takes the route; `sync-wasm.mjs` / `js/package.json` / `pages.yml` bundle wiring.

## Honesty

The in-tab bundle wraps the single-window `ContinuousQuery` **SELECT** form only. CONSTRUCT/ASK, ROWS count windows, the RSP-QL surface syntax (`REGISTER STREAM … FROM NAMED WINDOW …`) and multi-window joins stay native for now — stated as a caveat on the page, not overclaimed.

## Gate

- `npm run test:unit` — 51 pass (11 new in `rsp-window.test.mjs`).
- `npm run lint` — clean.
- `npx tsc --noEmit` — clean.
- `npx next build` — succeeds; `/surface/streaming-rsp` prerenders as a static page (no longer the `[slug]` placeholder).

This is a site/JS-only change (no Rust public-API change → no `SKILL.md` G2 update needed; the `streaming-rsp` SKILL already documents the W-rsp bundle + this page). The Rust gate (clippy/rustdoc/unsafe/privacy) does not apply to a site-only PR. The `site-e2e` lane drives `next dev` and does not build the wasm export, so the live path is exercised by the unit tests + the production build here and by the wasm CI for the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)