### PR TITLE
docs: #![doc=include_str!(README)] + docs.rs all-features for hdt/rsp/text/nlq/shacl/introspect/sim (sq-jxl0)

### DIFF
--- a/crates/sparq-hdt/Cargo.toml
+++ b/crates/sparq-hdt/Cargo.toml
@@ -17,6 +17,12 @@ keywords.workspace = true
 categories.workspace = true
 readme = "README.md"
 
+# [OPUS-4.8] sq-jxl0: wire docs.rs to build all-features + the `docsrs` cfg so the README
+# front page and every feature-gated item (`write`, `zlib-ng`) render on docs.rs.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 # [OPUS-4.8] sq-2te: HDT WRITE support (`save`: sparq `Graph` -> `.hdt`).
 # Opt-in because the only tractable path on hdt 0.4 is the crate's `Hdt::read_nt`
 # (N-Triples -> FourSectDict PFC + BitmapTriples) + `Hdt::write`, BOTH gated behind

--- a/crates/sparq-hdt/README.md
+++ b/crates/sparq-hdt/README.md
@@ -4,14 +4,19 @@ Opt-in [HDT](https://www.rdfhdt.org/) (Header Dictionary Triples) reader (and,
 behind the `write` feature, writer) for the sparq RDF engine: load `.hdt` archives
 straight into a `sparq_core::Graph`, and save a `Graph` back out.
 
-```rust
+```rust,no_run
+# fn main() -> Result<(), sparq_hdt::Error> {
 let graph = sparq_hdt::load("dataset.hdt")?;   // .hdt.gz sniffed + decompressed too
 let meta  = sparq_hdt::header("dataset.hdt")?; // the HDT header (VoID stats, provenance) as a Graph
 // query them like any other sparq graph
 
 // writing (opt-in `write` feature): Graph -> .hdt (honours .gz/.zst/.bz2 by extension)
 # #[cfg(feature = "write")]
+# {
 sparq_hdt::save(&graph, "out.hdt")?;
+# }
+# let _ = &meta;
+# Ok(()) }
 ```
 
 In sparq-cli (behind the opt-in `hdt` cargo feature —

--- a/crates/sparq-hdt/src/lib.rs
+++ b/crates/sparq-hdt/src/lib.rs
@@ -1,39 +1,7 @@
-//! sparq-hdt: load HDT (Header Dictionary Triples) archives into a sparq [`Graph`].
-//!
-//! HDT (<https://www.rdfhdt.org/>, W3C member submission) is the de-facto binary
-//! archive format for RDF: the dictionary is Plain-Front-Coded and the triples are
-//! a bitmap-compressed adjacency list, so files are a fraction of the size of
-//! (even gzipped) N-Triples and load without text parsing. This crate wraps the
-//! maintained [`hdt`] crate's reader — which supports the standard layout written
-//! by hdt-cpp / hdt-java: FourSectionDictionary (PFC) + BitmapTriples, SPO order —
-//! and streams its dictionary + triples into a sparq graph:
-//!
-//! ```no_run
-//! let graph = sparq_hdt::load("dataset.hdt").unwrap();
-//! ```
-//!
-//! Writing back out (`Graph` -> `.hdt`) is opt-in behind the `write` cargo feature.
-//! It encodes the FourSectDict (Plain Front Coding) + BitmapTriples sections
-//! DIRECTLY from sparq's in-memory dictionary + triples (the inverse of the decoder)
-//! — no temporary N-Triples round-trip — see `save` and `src/encode.rs`:
-//!
-//! ```no_run
-//! # #[cfg(feature = "write")]
-//! # fn demo(graph: &sparq_core::Graph) -> Result<(), sparq_hdt::Error> {
-//! sparq_hdt::save(graph, "out.hdt")?;        // or out.hdt.gz / .hdt.zst / .hdt.bz2
-//! # Ok(()) }
-//! ```
-//!
-//! The translation works at the **id level**: each distinct HDT dictionary id is
-//! decompressed to its term string ONCE, interned into the sparq [`Dict`], and the
-//! mapping memoized in a flat per-section table — so the term set is never
-//! materialized twice and the per-triple work is three array lookups.
-//!
-//! Compressed containers — `.hdt.gz` (gzip), `.hdt.zst` (zstd) and `.hdt.bz2`
-//! (bzip2), as publishers ship them — are detected by MAGIC BYTES (not file name)
-//! and decompressed on the fly, STREAMING (the decompressed `.hdt` is never fully
-//! materialized) by every entry point; [`header`] exposes the archive's metadata
-//! triples (the H in HDT) as a queryable sparq [`Graph`].
+// [OPUS-4.8] sq-jxl0: single-source the crate overview from README.md so crates.io
+// (package.readme) and the docs.rs front page render identical content. The README's
+// quickstart fence is a `no_run` doctest (it opens a `.hdt` file that need not exist).
+#![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 
 use sparq_core::dict::{Dict, Id};

--- a/crates/sparq-introspect/Cargo.toml
+++ b/crates/sparq-introspect/Cargo.toml
@@ -11,6 +11,12 @@ keywords.workspace = true
 categories.workspace = true
 readme = "README.md"
 
+# [OPUS-4.8] sq-jxl0: wire docs.rs to build all-features + the `docsrs` cfg so the README
+# front page and every feature-gated item (`federation-descriptors`) render on docs.rs.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 # Opt-in schema introspection (GenAI phase 2 — see research/genai-design.md and
 # research/genai-ontology-introspection.md). This is a SEPARATE crate so the core
 # engine carries zero introspection code; it consumes only sparq-core's PUBLIC

--- a/crates/sparq-introspect/README.md
+++ b/crates/sparq-introspect/README.md
@@ -10,7 +10,7 @@ a SOTA star-join cardinality estimator).
 
 ## 🚀 Quickstart
 
-```rust
+```rust,ignore
 use sparq_introspect::{Introspection, BuildOptions};
 
 let ix = Introspection::build(&graph);              // or build_with(&graph, &BuildOptions{..})
@@ -70,7 +70,7 @@ ix.schema_summary_for(&seeds, 2500)           // retrieval-mode: schema scoped t
   **single named graph** when you pass that graph's sub-`Graph`. Each named graph of a
   quad dataset (loaded via `Graph::load_dataset` from N-Quads / TriG) is a self-contained
   `Graph`, fetched by name with [`Graph::named_graph(&name)`][named-graph] (sq-quuu):
-  ```rust
+  ```rust,ignore
   let g1 = graph.named_graph(&ex_g1).expect("graph exists");
   let card = sparq_introspect::Introspection::build(g1); // schema card for ex:g1 alone
   ```

--- a/crates/sparq-introspect/src/lib.rs
+++ b/crates/sparq-introspect/src/lib.rs
@@ -1,38 +1,7 @@
-//! sparq-introspect: **ontology/schema introspection** over a [`sparq_core::Graph`] —
-//! the effective schema a knowledge graph *actually uses*, mined from the store's
-//! sorted permutation indexes (GenAI phase 2, see `research/genai-design.md` §2 and
-//! `research/genai-ontology-introspection.md`).
-//!
-//! Everything is a **sorted scan, never a join-engine call**:
-//!
-//! - **Characteristic sets** (Neumann & Moerkotte, ICDE 2011): one SPO scan groups
-//!   subjects by their exact predicate set — subjects are contiguous, predicates within
-//!   a subject run are sorted, so the per-subject predicate list falls out of run
-//!   boundaries. Each distinct set carries its subject count and per-predicate triple
-//!   counts (the paper's structure: `count(C)` + per-predicate multiplicity).
-//! - **Schema summary**: class extents from the `rdf:type` block (one POS range),
-//!   per-class predicate usage with coverage ratios, per-predicate global stats
-//!   (triples, distinct subjects/objects, literal-vs-IRI object split, datatype
-//!   distribution, sample values), and **observed** domain/range histograms — the
-//!   most-common subject/object classes per predicate — alongside any **declared**
-//!   `rdfs:domain`/`rdfs:range` triples present.
-//! - **Vocabulary detection**: namespaces in use (IRIs split at the last `#`/`/`, the
-//!   same split the dictionary itself stores) with distinct-term counts, recognised
-//!   against a bundled table of well-known vocabularies.
-//!
-//! - **Cross-class join hints**: the `(subject_class) --predicate--> (object_class)`
-//!   edge table with per-edge triple counts ([`JoinHints`]), mined in the same SPO
-//!   scan — the join-cardinality signal beyond the per-predicate observed range.
-//!
-//! Outputs: the [`Introspection`] struct tree, [`Introspection::to_json`] (the machine
-//! surface for LLM grounding), [`Introspection::to_text_summary`] (a compact,
-//! most-important-first digest under a character budget — the prompt-ready "schema
-//! card" deck the design doc prescribes), [`Introspection::to_void`] (a W3C VoID
-//! dataset description, as N-Triples), and [`Introspection::schema_summary_for`] (a
-//! retrieval-mode digest scoped to a set of seed IRIs, for large-schema KGs).
-//!
-//! The crate is opt-in and read-only over the public `sparq-core` API; the default
-//! engine build does not include it and carries no introspection code.
+// [OPUS-4.8] sq-jxl0: single-source the crate overview from README.md so crates.io
+// (package.readme) and the docs.rs front page render identical content. The README's
+// rust fences are API-map sketches marked `ignore` (they reference an external graph).
+#![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 
 use oxrdf::vocab::xsd;

--- a/crates/sparq-nlq/Cargo.toml
+++ b/crates/sparq-nlq/Cargo.toml
@@ -20,6 +20,12 @@ keywords.workspace = true
 categories.workspace = true
 readme = "README.md"
 
+# [OPUS-4.8] sq-jxl0: wire docs.rs to build all-features + the `docsrs` cfg so the README
+# front page and the `live`-gated `AnthropicLlm` items render on docs.rs.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 # `live` enables AnthropicLlm (network access to the Anthropic Messages API).
 # OFF by default: CI and the eval harness run entirely on recorded fixtures.

--- a/crates/sparq-nlq/README.md
+++ b/crates/sparq-nlq/README.md
@@ -13,14 +13,18 @@ exec error repair, else return `Answer { sparql, result, repairs, transcript }`.
 
 ## 🚀 Quickstart
 
-```rust
+```rust,no_run
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# use sparq_core::Graph;
 use sparq_nlq::{Nlq, ReplayLlm};
 
+# let graph = Graph::load_str("", "turtle")?;
 // Offline / CI path: serve recorded prompt→completion pairs from a fixture.
 let replay = ReplayLlm::from_file("tests/fixtures/olympics_replay.json")?;
 let nlq = Nlq::new(&graph, Box::new(replay));
 let answer = nlq.ask("How many athletes are on each team?")?;
 println!("{}\n{} rows, {} repair(s)", answer.sparql, answer.result.len(), answer.repairs);
+# Ok(()) }
 ```
 
 ```sh
@@ -29,15 +33,25 @@ cargo add sparq-nlq --features live
 export ANTHROPIC_API_KEY=sk-ant-...
 ```
 
-```rust
+```rust,no_run
+# // `live::AnthropicLlm` needs the non-default `live` feature (network); gated so the
+# // doctest is a no-op under the default build.
+# #[cfg(feature = "live")]
+# fn demo() -> Result<(), Box<dyn std::error::Error>> {
+# use sparq_core::Graph;
 use std::rc::Rc;
 use sparq_nlq::{live::AnthropicLlm, Nlq, NlqConfig, RecordingLlm};
 
+# let graph = Graph::load_str("", "turtle")?;
 let llm = Rc::new(RecordingLlm::new(AnthropicLlm::from_env()?)); // record while you go
 let nlq = Nlq::with_config(&graph, Box::new(Rc::clone(&llm)),
     NlqConfig { max_repair_rounds: 3, ..NlqConfig::default() });
 let answer = nlq.ask("Which team has the most athletes?")?;
 llm.save("my_session.json")?;                   // replayable fixture for later
+# let _ = answer;
+# Ok(())
+# }
+# fn main() {}
 ```
 
 ## ✨ Features

--- a/crates/sparq-nlq/src/lib.rs
+++ b/crates/sparq-nlq/src/lib.rs
@@ -1,39 +1,7 @@
-//! sparq-nlq: natural-language questions over a [`sparq_core::Graph`], answered with
-//! SPARQL (GenAI phase 3 — `research/genai-design.md` §2, `research/genai-nl-to-sparql.md`).
-//!
-//! The loop is deliberately **lean** (the SPARQL-LLM finding: retrieve + repair beats
-//! sprawling agents):
-//!
-//! ```text
-//!            ┌──────────────────────────────────────────────────────┐
-//!            │ GROUND   sparq_introspect::to_text_summary(budget)   │
-//!            │          + few-shot examples + the question          │
-//!            └───────────────────────────┬──────────────────────────┘
-//!                                        ▼
-//!            ┌──────────────────────────────────────────────────────┐
-//!      ┌────▶│ GENERATE Llm::complete(prompt) -> completion         │
-//!      │     └───────────────────────────┬──────────────────────────┘
-//!      │                                 ▼
-//!      │     ┌──────────────────────────────────────────────────────┐
-//!      │     │ VALIDATE extract ```sparql block, spargebra parse    │
-//!      │     └───────────┬──────────────────────────┬───────────────┘
-//!      │           parse error                  parses
-//!      │                 │                          ▼
-//!      │     ┌───────────┴───────────┐  ┌──────────────────────────┐
-//!      └─────┤ REPAIR (≤ N rounds:   │  │ EXECUTE sparq_engine::   │
-//!      ▲     │ error + failed query  │  │ query_with_budget        │
-//!      │     │ back to the LLM)      │  └────────────┬─────────────┘
-//!      │     └───────────────────────┘     exec error│        ok
-//!      └──────────────────────────────────◀──────────┘         ▼
-//!                                              Answer { sparql, result,
-//!                                                       repairs, transcript }
-//! ```
-//!
-//! The LLM sits behind the [`Llm`] trait. CI never touches the network:
-//! [`ReplayLlm`] serves recorded prompt→completion pairs from a JSON fixture, and
-//! [`RecordingLlm`] wraps any backend to produce such fixtures. A thin Anthropic
-//! Messages-API client (`AnthropicLlm`) is available behind
-//! the non-default `live` feature.
+// [OPUS-4.8] sq-jxl0: single-source the crate overview from README.md so crates.io
+// (package.readme) and the docs.rs front page render identical content. The README's
+// quickstart fences are `no_run` doctests (they open a fixture file / the `live` API).
+#![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 
 use std::cell::RefCell;

--- a/crates/sparq-rsp/Cargo.toml
+++ b/crates/sparq-rsp/Cargo.toml
@@ -11,6 +11,12 @@ keywords.workspace = true
 categories.workspace = true
 readme = "README.md"
 
+# [OPUS-4.8] sq-jxl0: wire docs.rs to build all-features + the `docsrs` cfg so the README
+# front page renders on docs.rs (the front page now comes from README.md via include_str!).
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 # Opt-in stream processing (the sparq-reason / sparq-shacl isolation pattern): a
 # SEPARATE crate so the core engine carries zero streaming code, deps, or runtime
 # cost by default — RSP is engaged only by depending on this crate. Nothing in

--- a/crates/sparq-rsp/README.md
+++ b/crates/sparq-rsp/README.md
@@ -5,6 +5,7 @@ windowed **continuous SPARQL queries** over timestamped triple streams, as a
 deterministic **library** — no async runtime, no wall clock, no service.
 
 ```rust
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
 use oxrdf::{Literal, NamedNode, Term};
 use sparq_rsp::{ContinuousQuery, R2S, WindowSpec};
 
@@ -15,10 +16,17 @@ let mut q = ContinuousQuery::register(
 )?
 .with_r2s(R2S::RStream);                          // the default: full result per window
 
+# let triple: [Term; 3] = [
+#     NamedNode::new_unchecked("http://ex/sensor1").into(),
+#     NamedNode::new_unchecked("http://ex/reading").into(),
+#     Literal::from(10).into(),
+# ];
+# let ts: u64 = 0;
 q.push(triple, ts, |result| {                     // fires once per CLOSED window
     println!("[{}, {}): {:?}", result.start, result.end, result.rows);
 })?;
 q.flush(|result| { /* end-of-stream: close everything up to max ts */ })?;
+# Ok(()) }
 ```
 
 The classic RSP-QL pipeline, one type each:
@@ -54,7 +62,9 @@ transformation, with R2S as exact set diffs over the constructed graphs), and
 Beyond the programmatic API above, the crate parses the **RSP-QL textual query
 language** and joins across **multiple named windows**:
 
-```rust
+```rust,no_run
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+use oxrdf::{NamedNode, Term};
 use sparq_rsp::ContinuousMultiQuery;
 
 // Join sensor READINGS (stream :temp, window :w1) with the ROOM each sensor is
@@ -68,7 +78,15 @@ SELECT ?room ?v WHERE {
 FROM NAMED WINDOW <http://ex/w1> ON <http://ex/temp> RANGE 10 STEP 10
 FROM NAMED WINDOW <http://ex/w2> ON <http://ex/meta> RANGE 10 STEP 10")?;
 
+# let meta_stream = NamedNode::new_unchecked("http://ex/meta");
+# let triple: [Term; 3] = [
+#     NamedNode::new_unchecked("http://ex/s").into(),
+#     NamedNode::new_unchecked("http://ex/in").into(),
+#     NamedNode::new_unchecked("http://ex/room1").into(),
+# ];
+# let ts: u64 = 0;
 q.push(&meta_stream, triple, ts, |r| { /* full join result per tick */ })?;
+# Ok(()) }
 ```
 
 - **Parser** (`RspqlQuery::parse`): `REGISTER [STREAM|RSTREAM|ISTREAM|DSTREAM]
@@ -198,7 +216,7 @@ above the saving is within run-to-run noise.
 
 ## Tests
 
-`cargo test -p sparq-rsp` — 33 integration tests + 3 doctests pinning:
+`cargo test -p sparq-rsp` — 33 integration tests plus the README doctests, pinning:
 boundary inclusivity (`[start, end)`), tumbling partition / sliding overlap,
 window origin `t0` (shifted bounds, pre-origin arrivals, anchor far from the
 origin), empty-window reporting, `step > range` gaps, out-of-order within

--- a/crates/sparq-rsp/src/lib.rs
+++ b/crates/sparq-rsp/src/lib.rs
@@ -1,74 +1,7 @@
-//! sparq-rsp: deterministic RSP-QL-style RDF stream processing for the sparq
-//! engine — windowed continuous SPARQL queries as a **library**, not a service.
-//!
-//! The pipeline is the classic RSP-QL trio:
-//!
-//! 1. **S2R** — a [`WindowSpec`] (`RANGE w STEP s` time windows or `ROWS n`
-//!    count windows) turns a [stream](TripleStream) of
-//!    [`TimestampedTriple`]s into a sequence of finite [`Window`]s,
-//!    maintained incrementally by [`WindowedStream`];
-//! 2. **R2R** — each closed window is materialised into a
-//!    [`sparq_core::Graph`] (by the configured [`EvalMode`]: rebuild /
-//!    persistent dictionary / delta — see [`EvalMode`] and the README
-//!    throughput table) and the registered SPARQL query is evaluated by
-//!    `sparq_engine`;
-//! 3. **R2S** — an [`R2S`] operator (RSTREAM / ISTREAM / DSTREAM) maps the
-//!    result back onto the output stream, delivered through a callback as
-//!    [`WindowResult`]s.
-//!
-//! [`ContinuousQuery::register`] wires the three together for SELECT;
-//! [`ContinuousConstruct`] (stream-to-stream transformation: each window's
-//! result is itself a graph, as [`GraphResult`]s) and [`ContinuousAsk`] (one
-//! boolean per window, as [`AskResult`]s) are the CONSTRUCT / ASK forms.
-//!
-//! # RSP-QL surface syntax + multi-window joins ([OPUS-4.8], sq-9u1)
-//!
-//! The above is the *programmatic* API (build a [`WindowSpec`], register plain
-//! SPARQL). [`RspqlQuery::parse`] additionally parses the **RSP-QL textual query
-//! language** — `REGISTER … AS`, `FROM NAMED WINDOW <w> ON <s> [RANGE … STEP …]`,
-//! and `WINDOW <w> { … }` graph patterns — into that representation, reusing
-//! spargebra for the embedded SPARQL. [`ContinuousMultiQuery`] is the front end
-//! for queries that open MORE THAN ONE named window and JOIN across them: each
-//! window keeps its own S2R state over its stream, and at each synchronized tick
-//! the windows are assembled as named graphs and joined by the engine. See
-//! [`RspqlQuery`] and [`ContinuousMultiQuery`] for the supported subset and the
-//! scoped-out constructs.
-//!
-//! # Design constraints (deliberate)
-//!
-//! * **No async runtime, no wall clock.** Timestamps are application-supplied
-//!   `u64`s and time only advances through pushed timestamps (watermark =
-//!   `max_ts − max_delay`). The whole pipeline is a pure function of the
-//!   pushed `(triple, ts)` sequence: deterministic, unit-testable, and
-//!   trivially embeddable under tokio / threads / wasm timers *by the caller*.
-//! * **Exact window semantics are documented** in `window` (boundary
-//!   inclusivity, lateness, empty windows, gaps) and pinned by tests.
-//! * **Isolation:** nothing else in the workspace depends on this crate; the
-//!   core engine and the wasm build carry zero streaming code.
-//!
-//! ```
-//! use oxrdf::{Literal, NamedNode, Term};
-//! use sparq_rsp::{ContinuousQuery, WindowSpec};
-//!
-//! // Tumbling 60-tick windows, average reading per window.
-//! let mut q = ContinuousQuery::register(
-//!     "SELECT (AVG(?v) AS ?avg) WHERE { ?s <http://ex/reading> ?v }",
-//!     WindowSpec::time(60, 60).with_max_delay(5), // tolerate 5 ticks of disorder
-//! ).unwrap();
-//!
-//! let reading = |v: i32| -> [Term; 3] {
-//!     [NamedNode::new_unchecked("http://ex/sensor1").into(),
-//!      NamedNode::new_unchecked("http://ex/reading").into(),
-//!      Literal::from(v).into()]
-//! };
-//! q.push(reading(10), 0, |_| {}).unwrap();
-//! q.push(reading(20), 30, |_| {}).unwrap();
-//! let mut avgs = Vec::new();
-//! q.flush(|r| avgs.push(r.rows[0][0].clone())).unwrap();
-//! // Integer averages come back as xsd:decimal per SPARQL AVG typing.
-//! let avg = Literal::new_typed_literal("15.0", oxrdf::vocab::xsd::DECIMAL);
-//! assert_eq!(avgs, vec![Some(avg.into())]);
-//! ```
+// [OPUS-4.8] sq-jxl0: single-source the crate overview from README.md so crates.io
+// (package.readme) and the docs.rs front page render identical content. The README's
+// quickstart fence is a compiled doctest (hidden `#`-scaffolding for the pushed triple).
+#![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 
 mod eval;

--- a/crates/sparq-shacl/Cargo.toml
+++ b/crates/sparq-shacl/Cargo.toml
@@ -17,6 +17,12 @@ readme = "README.md"
 # the wasm graph ONLY by `sparq-wasm`'s non-default `shacl` feature (sq-yqi1, #162),
 # in which case the wasm32 dep rows below keep the bundle lean (no rayon/regex/digest).
 
+# [OPUS-4.8] sq-jxl0: wire docs.rs to build all-features + the `docsrs` cfg so the README
+# front page and every feature-gated item (e.g. `shacl-af`) render on docs.rs.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io
 # (required to publish — crates.io strips `path`).

--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -255,6 +255,7 @@ undefined).
 ## Usage
 
 ```rust
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
 use sparq_core::Graph;
 
 let data = Graph::load_str(r#"
@@ -283,6 +284,8 @@ if !report.conforms {
 // Severity-aware gating: `conforms` counts EVERY result (the spec's
 // sh:conforms); for CI-style "warnings don't fail the build" use:
 if report.conforms_violations_only() { /* only sh:Warning / sh:Info results */ }
+# assert!(!report.conforms);
+# Ok(()) }
 ```
 
 A CLI-style end-to-end run via the bundled example
@@ -300,10 +303,15 @@ For repeated validation of many data graphs against one shapes graph, parse
 the shapes once:
 
 ```rust
+# use sparq_core::Graph;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let shapes = Graph::load_str("", "turtle")?;
+# let data_graphs: Vec<Graph> = Vec::new();
 let model = sparq_shacl::ShapesModel::parse(&shapes);
 for data in data_graphs {
     let report = sparq_shacl::validate_with_model(&data, &model);
 }
+# Ok(()) }
 ```
 
 ## Scope and non-goals

--- a/crates/sparq-shacl/src/lib.rs
+++ b/crates/sparq-shacl/src/lib.rs
@@ -1,43 +1,7 @@
-//! sparq-shacl: opt-in SHACL Core + SHACL-SPARQL validation over
-//! [`sparq_core::Graph`]s.
-//!
-//! Parse a shapes graph into a shapes model, evaluate every SHACL Core
-//! constraint component against a data graph by direct index-backed scans,
-//! evaluate `sh:sparql` constraints (SHACL §5.2) and SPARQL-based constraint
-//! COMPONENTS (`sh:ConstraintComponent`, SHACL §6) by routing their
-//! `sh:select`/`sh:ask` through `sparq-engine` (with `$this`/`$value`/`$PATH`
-//! and `$paramName` pre-binding), and produce a [`ValidationReport`] (with
-//! Turtle and plain-text renderings of the SHACL report vocabulary).
-//!
-//! This crate follows the `sparq-reason` isolation pattern: it is NOT a
-//! dependency of any other sparq crate by default — the core engine and the
-//! default wasm bundle carry zero SHACL code unless a consumer opts in by
-//! depending on it. (`sparq-engine`, pulled in for `sh:sparql`, does not depend
-//! on this crate, so there is no cycle.) The browser/JS consumer opts in via
-//! `sparq-wasm`'s non-default `shacl` feature (sq-yqi1, #162), which exposes
-//! [`validate`] as a `Store::validate(...)` wasm binding; on that wasm32 build the
-//! `sparq-engine` dependency drops its defaults so rayon never enters the bundle.
-//!
-//! ```
-//! use sparq_core::Graph;
-//!
-//! let data = Graph::load_str(r#"
-//!     @prefix ex: <http://example.org/> .
-//!     ex:alice a ex:Person ; ex:age "thirty" .
-//! "#, "turtle").unwrap();
-//! let shapes = Graph::load_str(r#"
-//!     @prefix sh: <http://www.w3.org/ns/shacl#> .
-//!     @prefix ex: <http://example.org/> .
-//!     @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-//!     ex:PersonShape a sh:NodeShape ;
-//!       sh:targetClass ex:Person ;
-//!       sh:property [ sh:path ex:age ; sh:datatype xsd:integer ] .
-//! "#, "turtle").unwrap();
-//!
-//! let report = sparq_shacl::validate(&data, &shapes);
-//! assert!(!report.conforms);
-//! assert_eq!(report.results.len(), 1);
-//! ```
+// [OPUS-4.8] sq-jxl0: single-source the crate overview from README.md so crates.io
+// (package.readme) and the docs.rs front page render identical content. The README's
+// `## Usage` rust fences are compiled as doctests (hidden `#`-scaffolding inside them).
+#![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 
 mod eval;

--- a/crates/sparq-sim/Cargo.toml
+++ b/crates/sparq-sim/Cargo.toml
@@ -11,6 +11,12 @@ keywords.workspace = true
 categories.workspace = true
 readme = "README.md"
 
+# [OPUS-4.8] sq-jxl0: wire docs.rs to build all-features + the `docsrs` cfg so the README
+# front page renders on docs.rs (the front page now comes from README.md via include_str!).
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 # Opt-in structural similarity (T7, GenAI phase 1 — see research/genai-design.md). This
 # is a SEPARATE crate so the core engine carries zero similarity code; it consumes only
 # sparq-core's PUBLIC read API (dict lookups, permutation-index scans, predicate stats).

--- a/crates/sparq-sim/README.md
+++ b/crates/sparq-sim/README.md
@@ -7,7 +7,7 @@ ARE the feature store, so similarity stays correct under incremental updates for
 
 ## 🚀 Quickstart
 
-```rust
+```rust,ignore
 use sparq_sim::{Sim, SimConfig, SignatureMode, weighted_jaccard};
 
 let sim = Sim::new(&graph);                       // defaults: PredicateNeighbor + IDF
@@ -51,7 +51,7 @@ weighted_jaccard(&sig_a, &sig_b);        // for callers that cache signatures
   [`sparq-vectors`](../sparq-vectors) crate covers the text side and ships dependency-free
   fusion helpers, so the two signals combine without either crate depending on the other:
 
-  ```rust
+  ```rust,ignore
   use sparq_sim::Sim;
   use sparq_vectors::{fuse_rrf, RRF_K};
 
@@ -73,7 +73,7 @@ that graph's sub-`Graph`. On a quad dataset (loaded via `Graph::load_dataset` fr
 N-Quads / TriG) each named graph is a self-contained `Graph`; fetch one by name with
 [`Graph::named_graph(&name)`][named-graph] (sq-quuu) and build a per-graph `Sim` over it:
 
-```rust
+```rust,ignore
 let g1 = graph.named_graph(&ex_g1).expect("graph exists");
 let sim = sparq_sim::Sim::new(g1); // signatures + similarity scoped to ex:g1 alone
 ```

--- a/crates/sparq-sim/src/lib.rs
+++ b/crates/sparq-sim/src/lib.rs
@@ -1,27 +1,8 @@
-//! sparq-sim: **training-free structural entity similarity** over a [`sparq_core::Graph`].
-//!
-//! An entity's **structural signature** is the set of `(direction, predicate, neighbor)`
-//! pairs it participates in: outgoing pairs from an SPO range scan (`(e, p, o)` →
-//! `(Out, p, o)`) and incoming pairs from an OSP/OPS range scan (`(s, p, e)` →
-//! `(In, p, s)`). Both are single contiguous index ranges in the store's existing
-//! permutation indexes, so a signature costs `O(log n + degree(e))` — no embeddings, no
-//! training, no extra state; the indexes ARE the feature store, and stay correct under
-//! incremental updates.
-//!
-//! Similarity is a **weighted Jaccard** over two signatures. With predicate-IDF
-//! weighting (the default) each element `(d, p, n)` weighs `1 + ln(|G| / freq(p))`,
-//! using the per-predicate triple counts the store already keeps for its query planner
-//! ([`sparq_core::store::PredStat`]) — so sharing a rare predicate counts for more than
-//! sharing `rdf:type` with half the graph.
-//!
-//! `most_similar` generates candidates **through the indexes, not a full scan**: every
-//! entity sharing a signature element with the query is found by one range scan per
-//! element (POS for "who else has `(p, n)` outgoing", SPO for incoming). See
-//! [`Sim::most_similar`] for the precise complexity and the (documented) frequency-cap
-//! approximation.
-//!
-//! Everything here is read-only over the public `sparq-core` API; the crate is opt-in
-//! and the default engine build does not include it.
+// [OPUS-4.8] sq-jxl0: single-source the crate overview from README.md so crates.io
+// (package.readme) and the docs.rs front page render identical content. The README's
+// rust fences are API-map sketches marked `ignore` (they reference an external graph and
+// the sibling `sparq-vectors` crate, which is not a dependency of `sparq-sim`).
+#![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 
 use oxrdf::{NamedNode, Term};

--- a/crates/sparq-text/Cargo.toml
+++ b/crates/sparq-text/Cargo.toml
@@ -11,6 +11,12 @@ keywords.workspace = true
 categories.workspace = true
 readme = "README.md"
 
+# [OPUS-4.8] sq-jxl0: wire docs.rs to build all-features + the `docsrs` cfg so the README
+# front page and every feature-gated item (`engine`, `cjk`, …) render on docs.rs.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 # Opt-in full-text search. This is a SEPARATE crate (the sparq-geo shape) so the core
 # engine — and in particular the wasm build — carries zero text-search code or
 # dependencies; full-text support is engaged only by depending on this crate. The

--- a/crates/sparq-text/README.md
+++ b/crates/sparq-text/README.md
@@ -16,18 +16,22 @@ subjects/predicates is the store's ordinary permutation-index work.
 ## Library use
 
 ```rust
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
 use sparq_core::Graph;
 use sparq_text::TextIndex;
 
-let graph = Graph::load_str(ttl, "turtle")?;
-let index = TextIndex::build(&graph);     // one dict scan; rayon-sharded with `parallel`
+# let ttl = r#"<http://ex/a> <http://www.w3.org/2000/01/rdf-schema#label> "the quick brown fox" ."#;
+let mut graph = Graph::load_str(ttl, "turtle")?;
+let mut index = TextIndex::build(&graph); // one dict scan; rayon-sharded with `parallel`
 
 let hits = index.search("quick fox");     // AND of tokens, BM25-ranked best-first
 let any  = index.search_any("fox dog");   // OR
 let auto = index.search("auto*");         // *-suffix = prefix token (autocomplete)
 for hit in &hits {
     let literal = graph.dict.term(hit.id); // hit.id IS the dict id; hit.score is BM25
+#   let _ = literal;
 }
+# let _ = (any, auto);
 
 // Phrase (adjacency) search is OPT-IN: it needs token positions, so build the
 // position-enabled index. The cheap default above stores NO positions.
@@ -36,11 +40,14 @@ let ids  = pidx.phrase("quick brown fox"); // literal ids where the tokens are
                                            // adjacent & in order (ascending ids)
 // Proximity/slop: the ranked, bounded-gap variant over the same positions.
 let near = pidx.phrase_near("quick fox", 2); // Vec<Hit>, best-first; score 1/(1+gap)
-
+# let _ = (ids, near);
 
 // Incremental upkeep, mirroring Graph::apply_delta (the GeoIndex shape):
+# let inserts: Vec<[oxrdf::Term; 3]> = Vec::new();
+# let deletes: Vec<[oxrdf::Term; 3]> = Vec::new();
 graph.apply_delta(&inserts, &deletes)?;
 index.apply_delta(&graph, &inserts, &deletes);
+# Ok(()) }
 ```
 
 ## Running `text:` inside SPARQL (the `engine` feature, default on)
@@ -57,8 +64,16 @@ The magic predicates live under `http://sparq.dev/text#`:
 | `?lit text:score ?s` | binds the relevance score (`xsd:double`) — BM25 for `text:matches`/`text:matchesAny`, proximity (`1/(1+gap)`) for `text:near`; must accompany exactly one such scored match on `?lit` in the same BGP <!-- [OPUS-4.8] --> |
 
 ```rust
+# // The `text:` magic predicates need the default-on `engine` feature; gated so the
+# // doctest is a no-op under `--no-default-features`.
+# #[cfg(feature = "engine")]
+# fn demo() -> Result<(), Box<dyn std::error::Error>> {
+# use sparq_core::Graph;
 use sparq_text::{query_text, TextIndex};
 
+# let graph = Graph::load_str(
+#     r#"<http://ex/p> <http://ex/title> "the quick brown fox" ."#, "turtle")?;
+# let index = TextIndex::build(&graph);
 let r = query_text(&graph, r#"
     PREFIX text: <http://sparq.dev/text#>
     SELECT ?post ?s WHERE {
@@ -66,6 +81,10 @@ let r = query_text(&graph, r#"
       ?title text:matches "fox" .
       ?title text:score ?s .
     } ORDER BY DESC(?s)"#, &index)?;
+# let _ = r;
+# Ok(())
+# }
+# fn main() {}
 ```
 
 `query_text` parses, **rewrites** each magic pattern into an inline `VALUES`

--- a/crates/sparq-text/src/lib.rs
+++ b/crates/sparq-text/src/lib.rs
@@ -1,40 +1,7 @@
-//! sparq-text: **opt-in full-text search over literals** for the sparq RDF engine.
-//!
-//! Three layers, bottom-up:
-//!
-//! 1. [`tokenize`] — the shared tokenizer: UAX #29 Unicode word segmentation
-//!    (`unicode-segmentation`) + Unicode lowercasing. No stemming, no stopword
-//!    list, no diacritic folding — deterministic and language-neutral; query
-//!    tokens may end in `*` for prefix (autocomplete) matching. An opt-in
-//!    [`Analyzer::CjkNgram`] adds character-bigram indexing for unspaced CJK
-//!    text (`東京都` → `東京`,`京都`) so a multi-char CJK term is no longer the
-//!    low-precision AND of its individual ideographs; the default
-//!    [`Analyzer::Unicode`] is byte-for-byte unchanged. [OPUS-4.8] sq-m3ln
-//! 2. [`index`] — [`TextIndex`]: an owned BM25 inverted index over the string
-//!    literals (`xsd:string` + language-tagged) of a sparq
-//!    [`Graph`](sparq_core::Graph)'s dictionary. The dictionary term id of a
-//!    literal IS its document id, so [`TextIndex::search`] /
-//!    [`search_any`](TextIndex::search_any) return literal ids that join back
-//!    to triples through the store's ordinary permutation indexes. Deltas are
-//!    mirrored incrementally via [`TextIndex::apply_delta`] (the
-//!    `GeoIndex::apply_delta` shape).
-//! 3. [`rewrite`] (default-on `engine` feature) — the `text:` magic
-//!    predicates ([`vocab`]): `?lit text:matches "query"` (AND of tokens,
-//!    `*`-suffix prefix tokens), `?lit text:matchesAny "query"` (OR),
-//!    `?lit text:phrase "foo bar"` (adjacent, in-order tokens — needs a
-//!    positions-enabled index), `?lit text:near "foo bar"` (proximity/slop:
-//!    in-order within a bounded gap, relevance-ranked — `text:slop N` sets the
-//!    gap budget), and `?lit text:score ?s` (the relevance score). [OPUS-4.8]
-//!    [`query_text`] rewrites them into
-//!    inline `VALUES` over the index's hits at the spargebra-algebra level and
-//!    executes through sparq-engine's prepared-query seam
-//!    (`PreparedQuery: From<spargebra::Query>`) — the engine itself is
-//!    untouched.
-//!
-//! No existing sparq crate depends on this one (in particular the wasm build
-//! carries zero text-search code); full-text support is engaged only by
-//! depending on `sparq-text` — mirroring how `sparq-geo` and `sparq-vectors`
-//! stay out of the default build.
+// [OPUS-4.8] sq-jxl0: single-source the crate overview from README.md so crates.io
+// (package.readme) and the docs.rs front page render identical content. The README's
+// `## Library use` fence is a compiled doctest; the `query_text` fence is `engine`-gated.
+#![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 
 pub mod index;


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated docs PR. Implements bead **sq-jxl0** (parent: sq-9jw5 documentation overhaul).

## What

Extends the README-as-crate-overview wiring (sq-p26u did the first 8 publish crates) to the remaining **7 publish-intended crates**: `sparq-hdt`, `sparq-rsp`, `sparq-text`, `sparq-nlq`, `sparq-shacl`, `sparq-introspect`, `sparq-sim`.

For each crate:

- Replaced the `lib.rs` `//!` overview with `#![doc = include_str!("../README.md")]` (crate-level attributes preserved after it), so **crates.io** (`package.readme`) and the **docs.rs front page** render the *same* content from one source.
- Added `[package.metadata.docs.rs]` with `all-features = true` + `rustdoc-args = ["--cfg", "docsrs"]`, so feature-gated items render on docs.rs (hdt `write`/`zlib-ng`, text `engine`, nlq `live`, shacl `shacl-af`, introspect `federation-descriptors`).
- Made every README `rust` fence behave under the doctest harness:
  - **Real passing doctests** (hidden `#`-scaffolding) where the example is in-memory and runnable — `shacl`, `text` (`## Library use`), `rsp` quickstart.
  - **`no_run`** where it opens a real file or the live API — `hdt`, `nlq`, `rsp` multi-window.
  - **`engine` / `live`-cfg-gated bodies** so the `--no-default-features` doctest run still compiles.
  - **`rust,ignore`** for the API-map sketches that reference an external graph or a non-dependency crate — `introspect`, `sim` (sim's hybrid example uses `sparq-vectors`, which is *not* a dependency of `sparq-sim`).

No code-logic, public-API, or `unsafe` changes — all 7 crates stay `forbid(unsafe_code)`, so the G2 public-API→SKILL.md rule and the unsafe-register ratchet do not apply.

## Gate (all green locally)

- `cargo build` (default + `--all-features`) for the 7 crates.
- `cargo clippy --all-targets` (default + `--all-features`) `-D warnings`.
- `cargo test --doc` (default + `--no-default-features`) — all pass / `no_run`-compile / `ignore`.
- **Rustdoc gate**: `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` **and** `--all-features` — both fully clean (the #1 silently-missed gate; no private intra-doc links introduced).
- `markdownlint-cli2` (HARD docs-quality config) and the `privacy-claims` honesty gate pass.

## Honest scope notes

- Pre-existing hard-coded perf numbers in `sparq-rsp/README.md` (the AVG-parse-cost paragraph) and README-template deviations (missing `## 📚`/License sections; `nlq`/`sim` slightly over the line cap) are **out of scope** — they belong to sibling beads **sq-puyy** (trim rsp) / **sq-8ic6** (ratchet template to HARD) and the `check-no-perf-numbers`/`check-readme-template` checks run **`--advisory` / `continue-on-error`**, so they never block. `nlq`'s line count rose by the hidden doctest scaffolding this bead explicitly requested.
- Unrelated pre-existing `rustfmt` drift deep in `sparq-introspect/src/lib.rs` (a local toolchain-version mismatch, present on `origin/main`) was **not** touched; my edits at the top of each `lib.rs` are fmt-clean.

Closes sq-jxl0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
