### PR TITLE
test(sparq-gpu): CPU-reference unit tests + randomized GPU-vs-CPU differential oracle (sq-goay)

### DIFF
--- a/crates/sparq-gpu/README.md
+++ b/crates/sparq-gpu/README.md
@@ -37,10 +37,15 @@ The full measured answer, tables, and the recommendation live in
   - `group_aggregate` — COUNT+SUM GROUP BY (keys pre-densified to
     `0..g ≤ 512`) with two-level (workgroup-shared → global) atomics.
 - `src/cpu.rs` — scalar CPU reference implementations: the correctness oracles
-  and the single-thread baselines.
+  and the single-thread baselines. Its `#[cfg(test)]` module pins each
+  reference to an *independent* brute-force oracle (half-open band, IEEE `>`,
+  O(n·m) probe, per-group recount), so the CPU fallback is validated on every
+  `cargo test` even with no GPU present.
 - `tests/correctness.rs` — GPU vs CPU on random data + IEEE-754 edge cases
-  (NaN/±inf/-0.0/subnormals). Skips (passes, with a stderr note) when no
-  adapter exists.
+  (NaN/±inf/-0.0/subnormals), plus a randomized differential sweep that
+  re-seeds across sizes/selectivities/group-counts/probe-domains (sizes
+  straddling the 256-wide workgroup and the 65535×256 2D-dispatch boundary).
+  Skips (passes, with a stderr note) when no adapter exists.
 - `examples/gpu_bench.rs` — the experiment. Interleaved best-of-N over four
   legs per kernel × {1M, 10M, 100M} elements: `cpu1` (scalar), `cpuN`
   (rayon all-cores), `gpu resident` (column already in device memory),

--- a/crates/sparq-gpu/src/cpu.rs
+++ b/crates/sparq-gpu/src/cpu.rs
@@ -86,3 +86,239 @@ pub fn group_aggregate(keys: &[u32], vals: &[u32], groups: u32) -> Vec<(u64, u64
     }
     out
 }
+
+// [OPUS-4.8] sq-goay: unit tests for the CPU reference itself.
+//
+// `tests/correctness.rs` only exercises these functions transitively, *and only
+// when a GPU adapter exists* — on CI (no device) every differential test takes
+// the skip path, so the oracle ships with ~0% real coverage (the audit's "4.1%
+// — only CPU fallback runs" gap). These tests run on every `cargo test`,
+// device or not, and pin the reference to an INDEPENDENT brute-force oracle so
+// "bit-identical CPU fallback" is a guarantee, not an aspiration.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic xorshift64* (same stream the differential tests use).
+    struct Rng(u64);
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            self.0 ^= self.0 << 13;
+            self.0 ^= self.0 >> 7;
+            self.0 ^= self.0 << 17;
+            self.0.wrapping_mul(0x2545_F491_4F6C_DD1D)
+        }
+        fn u32(&mut self) -> u32 {
+            (self.next() >> 32) as u32
+        }
+    }
+
+    // ---- filter_count_u32 -------------------------------------------------
+
+    #[test]
+    fn filter_u32_brute_force_random() {
+        let mut rng = Rng(0xABCD_1234_5678_9F01);
+        let col: Vec<u32> = (0..5_000).map(|_| rng.u32()).collect();
+        for (lo, hi) in [
+            (0u32, u32::MAX),
+            (0, u32::MAX / 8),
+            (5, 5),  // empty range
+            (10, 5), // inverted range => empty
+            (u32::MAX / 2, u32::MAX / 2 + 1_000_000),
+            (u32::MAX, u32::MAX), // empty at the top edge
+        ] {
+            // Independent oracle: filter().count(), not the same loop shape.
+            let want = col.iter().filter(|&&v| v >= lo && v < hi).count() as u64;
+            assert_eq!(filter_count_u32(&col, lo, hi), want, "lo={lo} hi={hi}");
+        }
+    }
+
+    #[test]
+    fn filter_u32_boundary_is_half_open() {
+        // `lo <= v < hi`: lo included, hi excluded.
+        let col = [4u32, 5, 6, 7];
+        assert_eq!(filter_count_u32(&col, 5, 7), 2, "{{5,6}} match, 7 excluded");
+        assert_eq!(filter_count_u32(&[], 0, 10), 0);
+    }
+
+    // ---- filter_count_f64_gt ---------------------------------------------
+
+    #[test]
+    fn filter_f64_gt_brute_force_random() {
+        let mut rng = Rng(0x0F1E_2D3C_4B5A_6978);
+        let col: Vec<f64> = (0..5_000)
+            .map(|_| (rng.u32() as f64 - (u32::MAX / 2) as f64) / 1e3)
+            .collect();
+        for t in [
+            0.0,
+            -0.0,
+            1.5,
+            -123_456.789,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ] {
+            let want = col.iter().filter(|&&v| v > t).count() as u64;
+            assert_eq!(filter_count_f64_gt(&col, t), want, "t={t}");
+        }
+    }
+
+    #[test]
+    fn filter_f64_gt_ieee_edges() {
+        // Every awkward IEEE-754 citizen, asserted against the language's own
+        // `>` so the reference cannot drift from IEEE semantics.
+        let col = [
+            f64::NAN,
+            -f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            0.0,
+            -0.0,
+            f64::MIN_POSITIVE,
+            -f64::MIN_POSITIVE,
+            5e-324,
+            -5e-324,
+            f64::MAX,
+            f64::MIN,
+        ];
+        for t in [
+            f64::NEG_INFINITY,
+            -0.0,
+            0.0,
+            f64::INFINITY,
+            f64::NAN,
+            5e-324,
+        ] {
+            let want = col.iter().filter(|&&v| v > t).count() as u64;
+            assert_eq!(filter_count_f64_gt(&col, t), want, "t={t}");
+        }
+        // v > NaN is false for every v, including NaN itself.
+        assert_eq!(filter_count_f64_gt(&col, f64::NAN), 0);
+        // -0.0 and 0.0 are equal under `>`, so the count must agree.
+        assert_eq!(
+            filter_count_f64_gt(&col, 0.0),
+            filter_count_f64_gt(&col, -0.0),
+            "-0.0 and 0.0 compare equal"
+        );
+    }
+
+    // ---- build_hash_table / hash_probe -----------------------------------
+
+    #[test]
+    fn build_hash_table_invariants() {
+        let mut rng = Rng(0x1357_9BDF_2468_ACE0);
+        let n = 1_000usize;
+        let keys: Vec<u32> = (0..n).map(|_| rng.u32() % (2 * n as u32)).collect();
+        let payloads: Vec<u32> = (0..n).map(|_| rng.u32()).collect();
+        let slots = build_hash_table(&keys, &payloads);
+
+        // capacity = next pow2 >= 2n, load factor <= 0.5.
+        assert!(slots.len().is_power_of_two());
+        assert!(slots.len() >= 2 * n, "load factor must stay <= 0.5");
+
+        // Exactly n occupied slots (duplicates each take a separate slot), and
+        // every (key,payload) pair from the input is present somewhere.
+        let occupied = slots.iter().filter(|s| s[0] != EMPTY_KEY).count();
+        assert_eq!(occupied, n, "1:N join semantics — no de-dup on insert");
+        for (&k, &p) in keys.iter().zip(&payloads) {
+            assert!(
+                slots.contains(&[k, p]),
+                "inserted pair ({k},{p}) missing from the table"
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "EMPTY_KEY is reserved")]
+    fn build_hash_table_rejects_sentinel_key() {
+        build_hash_table(&[EMPTY_KEY], &[0]);
+    }
+
+    #[test]
+    fn hash_probe_brute_force_random() {
+        let mut rng = Rng(0x2468_ACE0_1357_9BDF);
+        let n_build = 800usize;
+        let build_keys: Vec<u32> = (0..n_build)
+            .map(|_| rng.u32() % (2 * n_build as u32))
+            .collect();
+        let payloads: Vec<u32> = (0..n_build).map(|_| rng.u32()).collect();
+        let probe: Vec<u32> = (0..3_000)
+            .map(|_| {
+                let k = rng.u32() % (4 * n_build as u32);
+                if k == EMPTY_KEY {
+                    0
+                } else {
+                    k
+                }
+            })
+            .collect();
+
+        let slots = build_hash_table(&build_keys, &payloads);
+        let (matches, sum) = hash_probe(&slots, &probe);
+
+        // Independent O(n*m) oracle: for each probe key, scan the raw build
+        // arrays (NOT the hash table) and tally matches + summed payloads.
+        let mut want_m = 0u64;
+        let mut want_s = 0u64;
+        for &k in &probe {
+            for (&bk, &bp) in build_keys.iter().zip(&payloads) {
+                if bk == k {
+                    want_m += 1;
+                    want_s += u64::from(bp);
+                }
+            }
+        }
+        assert_eq!(matches, want_m, "match count");
+        assert_eq!(sum, want_s, "payload sum");
+    }
+
+    #[test]
+    fn hash_probe_handles_collisions_and_duplicates() {
+        // Two keys that the table can only separate by linear probing, plus a
+        // duplicate key (two payloads under the same key => fanout 2).
+        let keys = [7u32, 7, 42];
+        let payloads = [10u32, 100, 1];
+        let slots = build_hash_table(&keys, &payloads);
+        // Probing 7 hits both duplicate rows; 42 hits one; 999 misses.
+        let (m, s) = hash_probe(&slots, &[7, 42, 999]);
+        assert_eq!(m, 3, "7 matches twice, 42 once, 999 zero");
+        assert_eq!(s, 10 + 100 + 1);
+    }
+
+    // ---- group_aggregate -------------------------------------------------
+
+    #[test]
+    fn group_aggregate_brute_force_random() {
+        let mut rng = Rng(0x9999_7777_5555_3333);
+        let groups = 37u32;
+        let keys: Vec<u32> = (0..6_000).map(|_| rng.u32() % groups).collect();
+        let vals: Vec<u32> = (0..6_000).map(|_| rng.u32()).collect();
+        let got = group_aggregate(&keys, &vals, groups);
+
+        // Independent oracle, per group.
+        for g in 0..groups {
+            let want_c = keys.iter().filter(|&&k| k == g).count() as u64;
+            let want_s: u64 = keys
+                .iter()
+                .zip(&vals)
+                .filter(|(&k, _)| k == g)
+                .map(|(_, &v)| u64::from(v))
+                .sum();
+            assert_eq!(got[g as usize], (want_c, want_s), "group {g}");
+        }
+        // Conservation: every row lands in exactly one group.
+        assert_eq!(got.iter().map(|(c, _)| c).sum::<u64>(), keys.len() as u64);
+    }
+
+    #[test]
+    fn group_aggregate_sum_exceeds_u32() {
+        // Single group, large values: the u64 accumulator must not wrap where a
+        // u32 would (this is exactly what the GPU's lo/hi carry emulation must
+        // also get right, so the reference has to be unambiguous).
+        let n = 100usize;
+        let keys = vec![0u32; n];
+        let vals = vec![u32::MAX; n];
+        let got = group_aggregate(&keys, &vals, 1);
+        assert_eq!(got[0], (n as u64, n as u64 * u64::from(u32::MAX)));
+        assert!(got[0].1 > u64::from(u32::MAX), "sum overflows u32");
+    }
+}

--- a/crates/sparq-gpu/tests/correctness.rs
+++ b/crates/sparq-gpu/tests/correctness.rs
@@ -20,6 +20,14 @@ impl Rng {
     fn u32(&mut self) -> u32 {
         (self.next() >> 32) as u32
     }
+    /// Uniform in `[0, bound)`; `bound == 0` yields 0.
+    fn below(&mut self, bound: u32) -> u32 {
+        if bound == 0 {
+            0
+        } else {
+            self.u32() % bound
+        }
+    }
 }
 
 /// `Some(gpu)` or skip: prints the reason so a skipped CI run is auditable.
@@ -158,5 +166,108 @@ fn group_aggregate_matches_cpu() {
         assert_eq!(got, expect, "groups={groups}");
         let total: u64 = got.iter().map(|(c, _)| c).sum();
         assert_eq!(total, N as u64, "every row lands in exactly one group");
+    }
+}
+
+/// [OPUS-4.8] sq-goay: randomized differential oracle.
+///
+/// The tests above pin each kernel against the CPU reference on ONE fixed
+/// workload. This sweep re-seeds the generator every iteration and varies size,
+/// selectivity, group count, table load and probe domain, asserting GPU == CPU
+/// across a broad random workload distribution — the "GPU-result == CPU-result
+/// sweep over random workloads" the audit asked for. Still skips cleanly with
+/// no device, so it is a no-op (passing) on CI.
+#[test]
+fn differential_sweep_all_kernels() {
+    let Some(gpu) = gpu_or_skip("differential_sweep") else {
+        return;
+    };
+    // Sizes deliberately straddle the 256-wide workgroup and the 65535×256
+    // 1D-dispatch boundary (so the 2D-tiled dispatch path is exercised too):
+    // 1, a sub-workgroup size, an awkward prime, and one just over 65535*256.
+    // The top size's f64 column is ~128 MiB (8 B/elem) — at or below WebGPU's
+    // default 128 MiB max-storage-binding, so it fits the lowest-common device;
+    // any size whose largest buffer would overflow this adapter is skipped.
+    let sizes = [1usize, 200, 65_537, 16_777_259];
+    for (round, &n) in sizes.iter().enumerate() {
+        // Largest single buffer in a round is the f64 column (8 B/element).
+        if (n as u64) * 8 > gpu.max_storage_bytes {
+            eprintln!("[differential_sweep] n={n} exceeds device storage limit — skipping size");
+            continue;
+        }
+        let mut rng = Rng(0xA5A5_5A5A_0000_0001u64.wrapping_add(round as u64 * 0x9E37_79B9));
+
+        // --- filter_count_u32: random column, random half-open band ---------
+        {
+            let col: Vec<u32> = (0..n).map(|_| rng.u32()).collect();
+            let resident = gpu.upload_u32(&col);
+            for _ in 0..4 {
+                let a = rng.u32();
+                let b = rng.u32();
+                let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+                assert_eq!(
+                    gpu.filter_count_u32(&resident, lo, hi),
+                    cpu::filter_count_u32(&col, lo, hi),
+                    "filter_u32 n={n} lo={lo} hi={hi}"
+                );
+            }
+        }
+
+        // --- filter_count_f64_gt: random column, random thresholds ----------
+        {
+            let col: Vec<f64> = (0..n)
+                .map(|_| (rng.u32() as f64 - (u32::MAX / 2) as f64) / 1e3)
+                .collect();
+            let resident = gpu.upload_f64(&col);
+            for _ in 0..4 {
+                let t = (rng.u32() as f64 - (u32::MAX / 2) as f64) / 1e3;
+                assert_eq!(
+                    gpu.filter_count_f64_gt(&resident, t),
+                    cpu::filter_count_f64_gt(&col, t),
+                    "filter_f64 n={n} t={t}"
+                );
+            }
+        }
+
+        // --- hash_probe: random build (with duplicates) + random probe ------
+        {
+            let n_build = (n / 4).max(1);
+            let build_keys: Vec<u32> = (0..n_build)
+                .map(|_| rng.below(2 * n_build as u32))
+                .collect();
+            let payloads: Vec<u32> = (0..n_build).map(|_| rng.u32()).collect();
+            let probe: Vec<u32> = (0..n)
+                .map(|_| {
+                    let k = rng.below(4 * n_build as u32);
+                    if k == EMPTY_KEY {
+                        0
+                    } else {
+                        k
+                    }
+                })
+                .collect();
+            let slots = cpu::build_hash_table(&build_keys, &payloads);
+            let table = gpu.upload_table(&slots);
+            let probe_col = gpu.upload_u32(&probe);
+            assert_eq!(
+                gpu.hash_probe(&table, &probe_col),
+                cpu::hash_probe(&slots, &probe),
+                "hash_probe n={n}"
+            );
+        }
+
+        // --- group_aggregate: random group count, random keys/values --------
+        {
+            let groups = (rng.below(MAX_GROUPS) + 1).min(MAX_GROUPS);
+            let keys: Vec<u32> = (0..n).map(|_| rng.below(groups)).collect();
+            let vals: Vec<u32> = (0..n).map(|_| rng.u32()).collect();
+            let keys_col = gpu.upload_u32(&keys);
+            let vals_col = gpu.upload_u32(&vals);
+            assert_eq!(
+                gpu.group_aggregate(&keys_col, &vals_col, groups),
+                cpu::group_aggregate(&keys, &vals, groups),
+                "group_aggregate n={n} groups={groups}"
+            );
+        }
     }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-goay** *(Test P3: GPU CPU-vs-GPU differential oracle, skipped when no device)*.

## Problem

The audit scored `sparq-gpu` at **4.1% real coverage — only CPU fallback runs, no GPU-vs-CPU differential**. Two concrete gaps:

1. **`tests/correctness.rs` skips entirely on CI** (no GPU adapter), so the differential tests contribute no coverage there.
2. **`src/cpu.rs` — the correctness oracle itself — had zero unit tests.** When no device is present (the normal CI state), the CPU reference shipped completely unexercised. There was nothing guaranteeing the CPU fallback is bit-identical to spec.

## Change

- **`src/cpu.rs`**: add a `#[cfg(test)]` module that pins each reference to an **independent** brute-force oracle — not the same loop shape:
  - `filter_count_u32`: `filter().count()` over random data + half-open / empty / inverted / top-edge bands.
  - `filter_count_f64_gt`: the language's own `>` over random data **and** every awkward IEEE-754 citizen (NaN/±inf/±0.0/subnormals/MIN/MAX); asserts `v > NaN` is empty and `0.0` ≡ `-0.0`.
  - `build_hash_table`: capacity / load-factor ≤ 0.5 / occupied-slot-count / pair-presence invariants + the `EMPTY_KEY`-sentinel `#[should_panic]`.
  - `hash_probe`: an O(n·m) recount over the raw build arrays, plus a hand-built collision+duplicate (fanout-2) case.
  - `group_aggregate`: per-group recount + conservation + a u32-overflowing sum.

  These run on **every `cargo test`**, device or not — the CPU fallback is now a validated guarantee.

- **`tests/correctness.rs`**: add `differential_sweep_all_kernels` — re-seeds the generator per round and sweeps **size × selectivity × group-count × table-load × probe-domain**, asserting `GPU == CPU` across a broad random workload distribution. Sizes straddle the 256-wide workgroup and the 65535×256 2D-dispatch boundary; rounds whose largest buffer would exceed the adapter's `max_storage_bytes` are skipped. Still skips cleanly (passing, with a stderr note) when no adapter exists.

- **`README.md`**: describe the new CPU-reference coverage and the sweep.

## Gate

- `cargo test -p sparq-gpu` — 10 new CPU-reference unit tests pass on this (no-GPU) box; differential tests skip cleanly.
- `cargo clippy -p sparq-gpu --all-targets -- -D warnings` — clean.
- `cargo fmt -p sparq-gpu -- --check` — clean.
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sparq-gpu --no-deps` — clean.

No public-API change (tests + doc text only), no `unsafe` (crate is `forbid(unsafe_code)`), no privacy predicates — so the SKILL.md/unsafe/privacy gates do not apply. The crate exposes no Cargo features, so there is a single feature state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)