### PR TITLE
fix(ci): coverage gate fails on a MEASURE-FAILURE, not just a regression (sq-039g)

### DIFF
--- a/scripts/coverage-gate.py
+++ b/scripts/coverage-gate.py
@@ -214,34 +214,64 @@ def seed(summary_path, floor_path, allow_lower):
     return 0
 
 def check(summary_path, floor_path, require_all):
+    # [OPUS-4.8] sq-039g: distinguish MISSING (a crate entirely ABSENT from this tier's
+    # summary — legitimately not run in this tier, e.g. a nightly-only crate in a
+    # per-commit summary; fatal only with --require-all) from UNMEASURED (a crate that
+    # WAS attempted in this tier but whose coverage step ERRORED — coverage.sh records a
+    # row with "measured": false, e.g. sparq-conformance exit 2 when fixtures are absent,
+    # or — the dangerous case — sparq-core/sparq-engine failing to measure because a
+    # fixture-dependent test aborted). An unmeasured crate WITH A NON-ZERO (effective)
+    # FLOOR is ALWAYS fatal: it is supposed to be gated on its floor, and a failed
+    # measurement would otherwise SILENTLY un-gate it. That was the bug — a measure-
+    # failure was lumped into `missing`, so it was caught ONLY under --require-all, which
+    # the nightly/per-commit --check-robust invocations do NOT pass. An unmeasured crate
+    # with an effective floor of 0 (the ARTIFACT_ZERO crates) is not %-gated anyway, so
+    # its measure-failure is reported but not fatal (the test-presence gate guards it).
     s = load(summary_path); floors = load(floor_path)["crates"]
     measured = s["crates"]
     tier = s.get("tier")            # [OPUS-4.8] sq-bjct: tier-aware nightly_floor
-    fails, missing, oks = [], [], []
+    fails, missing, unmeasured, oks = [], [], [], []
     for crate, fentry in sorted(floors.items()):
         floor = effective_floor(fentry, tier)
         row = measured.get(crate)
-        if row is None or not row.get("measured", False):
-            missing.append(crate); continue
+        if row is None:
+            missing.append((crate, floor)); continue
+        if not row.get("measured", False):
+            unmeasured.append((crate, floor)); continue
         val = row["lines_pct"]
         if val + 1e-9 < floor:
             fails.append((crate, val, floor))
         else:
             oks.append((crate, val, floor))
+    # A crate that failed to MEASURE but carries a real (>0) effective floor is a hard
+    # failure regardless of --require-all; a floor-0 (artifact) crate is not %-gated.
+    unmeasured_gated = [(c, f) for c, f in unmeasured if f > 0]
     for crate, val, floor in oks:
         print(f"  ok   {crate:<20} {val:6.2f}% >= floor {floor}")
-    for crate in missing:
-        flag = "MISSING (not in this tier's summary)"
-        print(f"  --   {crate:<20} {flag}")
+    for crate, floor in missing:
+        print(f"  --   {crate:<20} MISSING (not in this tier's summary)")
+    for crate, floor in unmeasured:
+        if floor > 0:
+            print(f"  FAIL {crate:<20} UNMEASURED (measure step errored) "
+                  f"— floor {floor} NOT enforced")
+        else:
+            print(f"  --   {crate:<20} UNMEASURED (measure step errored) "
+                  f"— floor 0, not %-gated")
     for crate, val, floor in fails:
         print(f"  FAIL {crate:<20} {val:6.2f}% < floor {floor}")
-    bad = bool(fails) or (require_all and bool(missing))
+    bad = bool(fails) or bool(unmeasured_gated) or (require_all and bool(missing))
     if fails:
         print(f"::error::coverage regressed below the floor for {len(fails)} crate(s)")
+    if unmeasured_gated:
+        print(f"::error::{len(unmeasured_gated)} crate(s) FAILED TO MEASURE but have a "
+              f"non-zero floor (would otherwise be SILENTLY un-gated): "
+              f"{', '.join(c for c, _ in unmeasured_gated)}")
     if require_all and missing:
         print(f"::error::{len(missing)} floor crate(s) absent from the summary "
-              f"(--require-all): {', '.join(missing)}")
-    print(f"\ncoverage gate: {len(oks)} ok / {len(fails)} fail / {len(missing)} missing")
+              f"(--require-all): {', '.join(c for c, _ in missing)}")
+    print(f"\ncoverage gate: {len(oks)} ok / {len(fails)} fail / "
+          f"{len(unmeasured)} unmeasured ({len(unmeasured_gated)} gated) / "
+          f"{len(missing)} missing")
     return 1 if bad else 0
 
 # --- pure aggregation primitives (unit-tested by --self-test) -----------------
@@ -723,6 +753,59 @@ def self_test():
     # adding a nightly_floor where base had none is fine; base floor unchanged.
     assert floor_regressions({"core": {"floor": 90}},
                              {"core": {"floor": 90, "nightly_floor": 92}}) == []
+
+    # === UNMEASURED vs MISSING in check() (sq-039g) [OPUS-4.8] ==================
+    # The bug: a crate present in the summary with "measured": false (its coverage step
+    # ERRORED — e.g. conformance fixtures absent -> sparq-conformance exit 2, or a
+    # fixture-dependent sparq-core test aborting) was lumped into `missing`, so it was
+    # fatal ONLY under --require-all. The per-commit / nightly --check-robust gate does
+    # NOT pass --require-all, so such a crate was SILENTLY un-gated instead of gated on
+    # its floor. Fix: an UNMEASURED crate with a non-zero (effective) floor ALWAYS fails;
+    # a genuinely-MISSING crate keeps the --require-all semantics; a floor-0 unmeasured
+    # crate (artifact) is reported but not fatal.
+    import tempfile, contextlib, io
+    def run_check(summary_crates, floor_crates, require_all, tier=None):
+        """Drive the real check() over tempfile summary + floor; return its exit code."""
+        sdoc = {"crates": {k: (crate(*v) if isinstance(v, tuple) else crate(v))
+                           for k, v in summary_crates.items()}}
+        if tier is not None:
+            sdoc["tier"] = tier
+        fdoc = {"crates": floor_crates}
+        with tempfile.NamedTemporaryFile("w", suffix=".sum.json", delete=False) as sf, \
+             tempfile.NamedTemporaryFile("w", suffix=".floor.json", delete=False) as ff:
+            json.dump(sdoc, sf); sp = sf.name
+            json.dump(fdoc, ff); fp = ff.name
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                return check(sp, fp, require_all)
+        finally:
+            os.unlink(sp); os.unlink(fp)
+
+    FL = {"a": {"floor": 80}, "z": {"floor": 0, "note": "artifact"}}
+    # a crate that MEASURED at/above floor + an artifact-zero crate -> PASS.
+    assert run_check({"a": 90.0, "z": (0.0,)}, FL, require_all=False) == 0
+    # UNMEASURED gated crate (a present, measured:false, floor 80) -> FAIL even WITHOUT
+    # --require-all (the core of sq-039g: a measure-failure must not silently un-gate).
+    assert run_check({"a": (0, False), "z": (0.0,)}, FL, require_all=False) == 1, \
+        "unmeasured crate with a non-zero floor MUST fail without --require-all"
+    # ...and it still fails WITH --require-all (regression guard).
+    assert run_check({"a": (0, False), "z": (0.0,)}, FL, require_all=True) == 1
+    # UNMEASURED ARTIFACT crate (z, floor 0) is NOT fatal — not %-gated, presence-gated.
+    assert run_check({"a": 90.0, "z": (0, False)}, FL, require_all=False) == 0, \
+        "an unmeasured floor-0 (artifact) crate must not fail the gate"
+    # genuinely-MISSING crate (absent from summary) keeps the --require-all semantics:
+    #   not fatal without --require-all ...
+    assert run_check({"a": 90.0}, FL, require_all=False) == 0, \
+        "a crate absent from the summary is not fatal without --require-all"
+    #   ... fatal WITH --require-all.
+    assert run_check({"a": 90.0}, FL, require_all=True) == 1, \
+        "an absent crate must fail under --require-all"
+    # The exact sq-039g danger: a conformance-fixture-dependent crate (sparq-core, real
+    # floor) failing to MEASURE under the nightly tier -> FAIL even without --require-all.
+    FLC = {"sparq-core": {"floor": 90, "nightly_floor": 94}}
+    assert run_check({"sparq-core": (0, False)}, FLC, require_all=False,
+                     tier="nightly") == 1, \
+        "sparq-core failing to measure (fixtures absent) must FAIL the nightly gate"
 
     print("coverage-gate self-test: ALL ASSERTIONS PASSED")
     return 0


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

`sq-039g` (ci): the nightly + per-commit coverage gate invokes
`scripts/coverage-gate.py --check-robust` **without** `--require-all`. In
`check()`, a crate that **failed to MEASURE** — `scripts/coverage.sh` records it
as a row with `"measured": false` (e.g. W3C conformance fixtures absent →
`sparq-conformance` exit 2, or a fixture-dependent `sparq-core`/`sparq-engine`
test aborting under `llvm-cov`) — was lumped into the same `missing` bucket as a
crate **legitimately absent** from the tier's summary. Because `missing` is fatal
only under `--require-all`, a crate whose measurement **errored** was **silently
un-gated** instead of being gated on its floor.

This was found during #671 (sq-bjct) verification and is pre-existing (mitigated
today only because CI fetches fixtures before the step — a brittle invariant).

## Fix

Split the two cases in `check()`:

- **MISSING** — row entirely absent from the summary (a crate not run in this
  tier, e.g. a nightly-only crate in a per-commit summary). Fatal only with
  `--require-all` — **unchanged**.
- **UNMEASURED** — row present with `"measured": false` (the measure step
  errored). If the crate's **effective floor** (tier-aware, so `sparq-core` /
  `sparq-engine` use their higher `nightly_floor`) is non-zero, this is **always
  fatal** — a failed measurement must never silently drop a real floor. A
  floor-0 **artifact** crate (`sparq-cli` / `sparq-conformance` / `sparq-gpu`)
  that fails to measure is reported but **not** fatal (it is presence-gated, not
  %-gated, so the bead's literal `sparq-conformance` example stays non-fatal
  while the dangerous fixture-dependent crates are now gated).

No CI-workflow change is needed: the existing `--check-robust` invocations now
fail loudly on a measure-failure of any gated crate.

## Tests

Extends `coverage-gate.py --self-test` (the no-I/O unit harness) with the new
classification, driving the real `check()` over tempfile summary+floor pairs:

- unmeasured-gated crate **fails with and without** `--require-all`;
- unmeasured floor-0 (artifact) crate is reported but **passes**;
- genuinely-missing crate keeps its prior `--require-all` semantics (pass
  without, fail with);
- the exact `sq-039g` danger — `sparq-core` unmeasured under the nightly tier —
  **fails** the gate.

```
$ python3 scripts/coverage-gate.py --self-test
coverage-gate self-test: ALL ASSERTIONS PASSED
```

## Scope / honesty

Single-file change to `scripts/coverage-gate.py` (Python CI tooling). No Rust
sources, no public API, no `unsafe`, no markdown/perf-number changes — so the
Rust crate gate (cargo build/clippy/test/rustdoc), the unsafe ratchet, and the
G2 public-api→SKILL.md rule do not apply. `python3 -m py_compile` is clean; the
repo has no configured Python linter.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
