### PR TITLE
feat(site): live /surface/full-text page (tier-b W-text wasm) (sq-xoxu) [OPUS-4.8]

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -124,6 +124,15 @@ jobs:
         working-directory: js
         run: npm run build:rsp-wasm
 
+      # [OPUS-4.8] sq-xoxu — build the tier-b "W-text" bundle (crates/sparq-text-wasm, the
+      # BM25 inverted index + `text:` magic predicates) that drives the live
+      # /surface/full-text page. Its wasm-pack output stays in the crate's pkg/; the site's
+      # prebuild sync-wasm step copies it into public/wasm/text/. Separate from the lean
+      # bundle so the landing page stays light (the page lazy-loads it on first interaction).
+      - name: Build W-text wasm bundle
+        working-directory: js
+        run: npm run build:text-wasm
+
       # [OPUS-4.8] sq-gum8 — install the Typst CLI so the paper-factory build step
       # (site/scripts/build-papers.mjs, run by `prebuild`) can compile site/papers/*.typ
       # into the downloadable PDFs + the in-site HTML renders. Pinned to a release tag +

--- a/js/package.json
+++ b/js/package.json
@@ -38,6 +38,7 @@
     "build:wasm:lean": "wasm-pack build ../crates/sparq-wasm --target web --release && npm run _copy:wasm",
     "build:reason-wasm": "wasm-pack build ../crates/sparq-reason-wasm --target web --release -- --features explain",
     "build:rsp-wasm": "wasm-pack build ../crates/sparq-rsp-wasm --target web --release",
+    "build:text-wasm": "wasm-pack build ../crates/sparq-text-wasm --target web --release",
     "build:ts": "tsc",
     "build": "npm run build:wasm && npm run build:ts",
     "test": "node --test \"test/*.test.mjs\"",

--- a/site/scripts/sync-wasm.mjs
+++ b/site/scripts/sync-wasm.mjs
@@ -89,3 +89,34 @@ try {
       `            run live. Build it:  (cd ../js && npm run build:rsp-wasm)`,
   );
 }
+
+// [OPUS-4.8] sq-xoxu — also sync the tier-b "W-text" bundle that drives
+// /surface/full-text (crates/sparq-text-wasm, the BM25 inverted index + `text:` magic
+// predicates, built by `js/`'s `build:text-wasm`). Like W-reason / W-rsp, its wasm-pack
+// output stays in the crate's own pkg/ (it is NOT part of the published @jeswr/sparq
+// package), so we copy it into public/wasm/text/. OPTIONAL: a quick `next dev` that skips
+// the build WARNs and skips rather than failing — the full-text page then surfaces a clear
+// load-failure state.
+const textSrc = join(here, "..", "..", "crates", "sparq-text-wasm", "pkg");
+const textDest = join(dest, "text");
+const textFiles = [
+  "sparq_text_wasm.js",
+  "sparq_text_wasm_bg.wasm",
+  "sparq_text_wasm.d.ts",
+];
+
+try {
+  await access(join(textSrc, "sparq_text_wasm_bg.wasm"));
+  await mkdir(textDest, { recursive: true });
+  for (const f of textFiles) {
+    await copyFile(join(textSrc, f), join(textDest, f));
+  }
+  console.log(
+    `[sync-wasm] copied ${textFiles.length} files → public/wasm/text/ (W-text)`,
+  );
+} catch {
+  console.warn(
+    `[sync-wasm] W-text bundle not found at ${textSrc}; /surface/full-text will not\n` +
+      `            run live. Build it:  (cd ../js && npm run build:text-wasm)`,
+  );
+}

--- a/site/src/app/surface/[slug]/page.tsx
+++ b/site/src/app/surface/[slug]/page.tsx
@@ -17,6 +17,7 @@ const BUILT_SURFACES = new Set([
   "mpc",
   "zk",
   "streaming-rsp",
+  "full-text",
 ]);
 const PLACEHOLDER_SURFACES = ALL_SURFACES.filter(
   (s) =>

--- a/site/src/app/surface/full-text/page.tsx
+++ b/site/src/app/surface/full-text/page.tsx
@@ -1,0 +1,125 @@
+import type { Metadata } from "next";
+import { Search } from "lucide-react";
+
+import { SurfaceContent } from "@/components/surface-content";
+import { TextPlayground } from "@/components/text-playground";
+
+export const metadata: Metadata = {
+  title: "Full-text",
+  description:
+    "BM25 full-text search over RDF string literals with the sparq engine — text: magic predicates (matches / matchesAny / phrase / near / slop / score) inside plain SPARQL, the quick-brown-fox example, live in your tab via the W-text wasm bundle.",
+};
+
+export default function FullTextSurfacePage() {
+  return (
+    <SurfaceContent
+      icon={Search}
+      title="Full-text"
+      statement="Keyword, prefix, phrase and proximity search over RDF literals — BM25-ranked, expressed as text: magic predicates inside ordinary SPARQL."
+      tier="live-new-wasm"
+      intro={
+        <>
+          <p>
+            <code className="font-mono text-foreground">sparq-text</code> builds an{" "}
+            owned <strong className="text-foreground">BM25 inverted index</strong> over
+            the string literals of a{" "}
+            <code className="font-mono">sparq_core::Graph</code> and exposes it through{" "}
+            <strong className="text-foreground">
+              <code className="font-mono">text:</code> magic predicates
+            </strong>{" "}
+            (<code className="font-mono">http://sparq.dev/text#</code>) that you write
+            inside ordinary SPARQL. A keyword search becomes{" "}
+            <code className="font-mono">?lit text:matches &quot;quick fox&quot;</code>;
+            the relevance score binds with{" "}
+            <code className="font-mono">text:score ?s</code>. The rewrite splices the
+            index hits into the query as inline{" "}
+            <code className="font-mono">VALUES</code> — the SPARQL engine itself is
+            unaware of text search.
+          </p>
+          <p>
+            Because it is pure Rust over{" "}
+            <code className="font-mono">sparq-engine</code>, it compiles to wasm. The
+            playground below loads the tier-b{" "}
+            <strong className="text-foreground">&ldquo;W-text&rdquo; bundle</strong> on
+            demand — a separate, lazily-loaded bundle from the lean SPARQL REPL — and
+            runs the indexer + query in this tab: edit the tiny corpus, run a{" "}
+            <code className="font-mono">text:</code> query, see the BM25-ranked literals.
+            The default is the classic quick-brown-fox example.
+          </p>
+        </>
+      }
+      capabilities={[
+        {
+          title: "text:matches (AND) + BM25 score",
+          body: "Keyword search: literals containing every token, ranked by BM25 relevance bound with text:score.",
+        },
+        {
+          title: "text:matchesAny (OR)",
+          body: "Literals containing at least one token — the inclusive variant, also BM25-ranked.",
+        },
+        {
+          title: "Prefix tokens (foo*)",
+          body: "A token ending in '*' is a prefix query: 'fox*' matches 'fox' and 'foxes' — autocomplete-style.",
+        },
+        {
+          title: "text:phrase (adjacent, in order)",
+          body: "Exact phrase match over the positions-enabled index this bundle always builds; order is significant.",
+        },
+        {
+          title: "text:near + text:slop (proximity)",
+          body: "Bounded-gap, in-order proximity match, ranked tightest-first (score = 1/(1+gap)); slop sets the gap budget.",
+        },
+        {
+          title: "Index footprint reported",
+          body: "Indexed-literal and distinct-token counts plus an in-memory heap estimate — the index-build-memory surface, shown per run.",
+        },
+      ]}
+      runsNote={
+        <>
+          <p>
+            <strong className="text-foreground">Live in your browser tab.</strong> The
+            BM25 index + the <code className="font-mono">text:</code> rewrite are pure
+            Rust over the engine, compiled to wasm in the separate W-text bundle (
+            <code className="font-mono">sparq-text-wasm</code>). The page lazy-loads it on
+            first interaction so the landing page never pays for it, then calls the
+            bundle&rsquo;s stateless{" "}
+            <code className="font-mono text-foreground">TextSearch.query</code> and{" "}
+            <code className="font-mono">TextSearch.indexStats</code> bindings — each parses
+            the corpus, builds a positions-enabled index, and returns canonical SPARQL 1.1
+            JSON (or the footprint summary). Nothing is sent to a server.
+          </p>
+        </>
+      }
+      caveat={
+        <>
+          <p>
+            Each search is a stateless one-shot: the bundle rebuilds the index from the
+            corpus it is given every call, which keeps the JS side from holding a
+            long-lived handle but means it is sized for the illustrative corpora here
+            (tens of literals), not a large persistent index. The tokenizer is UAX&nbsp;#29
+            word segmentation + Unicode lowercasing — no stemming, no stopword list, no
+            diacritic folding (<code className="font-mono">café</code> ≠{" "}
+            <code className="font-mono">cafe</code>). Build a real index over a large graph
+            natively via <code className="font-mono">sparq-cli</code>, and persist /
+            incrementally update it with the native crate&rsquo;s{" "}
+            <code className="font-mono">apply_delta</code> / reconcile paths.
+          </p>
+        </>
+      }
+      links={[
+        {
+          href: "https://github.com/jeswr/sparq/tree/main/crates/sparq-text",
+          label: "sparq-text crate",
+          external: true,
+        },
+        {
+          href: "https://github.com/jeswr/sparq/tree/main/crates/sparq-text-wasm",
+          label: "W-text wasm bundle",
+          external: true,
+        },
+      ]}
+    >
+      <TextPlayground />
+    </SurfaceContent>
+  );
+}

--- a/site/src/components/text-playground.tsx
+++ b/site/src/components/text-playground.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+// [OPUS-4.8] sq-xoxu — the live /surface/full-text playground: a tiny RDF corpus + a
+// `text:`-predicate SELECT (both editable) → BM25-ranked literal hits, run entirely in your
+// tab via the separate, lazy-loaded W-text wasm bundle (TextSearch.query / .indexStats).
+// The default is the classic "quick brown fox" example from skills/full-text-search/SKILL.md.
+// Nothing is sent to a server.
+
+import * as React from "react";
+import { Play, Loader2, Search, CheckCircle2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  prewarmText,
+  sparqTextQuery,
+  sparqTextIndexStats,
+  type TextIndexStats,
+} from "@/lib/sparq-text-wasm";
+import { resultCells } from "@/lib/text-results";
+import type { SparqlResults } from "@/lib/sparq-wasm";
+import { TEXT_EXAMPLES, type TextExample } from "@/data/text-examples";
+
+type EngineState = "cold" | "warming" | "ready" | "error";
+
+type RunState =
+  | { kind: "idle" }
+  | { kind: "running" }
+  | { kind: "results"; results: SparqlResults; stats: TextIndexStats; ms: number }
+  | { kind: "error"; message: string };
+
+const DEFAULT = TEXT_EXAMPLES[0];
+
+export function TextPlayground() {
+  const [example, setExample] = React.useState<TextExample>(DEFAULT);
+  const [data, setData] = React.useState(DEFAULT.data);
+  const [query, setQuery] = React.useState(DEFAULT.query);
+  const [engine, setEngine] = React.useState<EngineState>("cold");
+  const [state, setState] = React.useState<RunState>({ kind: "idle" });
+
+  // Pre-warm the (separate) full-text wasm bundle on mount so the first "Search" pays no
+  // cold start. A failure flips the indicator; the first query retries the load.
+  React.useEffect(() => {
+    let cancelled = false;
+    setEngine("warming");
+    prewarmText()
+      .then(() => {
+        if (!cancelled) setEngine("ready");
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setEngine("error");
+        toast.error("Full-text engine failed to load", {
+          description: e instanceof Error ? e.message : String(e),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const selectExample = React.useCallback((id: string) => {
+    const ex = TEXT_EXAMPLES.find((e) => e.id === id);
+    if (!ex) return;
+    setExample(ex);
+    setData(ex.data);
+    setQuery(ex.query);
+    setState({ kind: "idle" });
+  }, []);
+
+  const run = React.useCallback(async () => {
+    setState({ kind: "running" });
+    const t0 = performance.now();
+    try {
+      // Index footprint + the ranked hits, both over the current corpus. indexStats is the
+      // bundle's index-build-memory surface (the risk the bead flags); we show it alongside.
+      const [stats, results] = await Promise.all([
+        sparqTextIndexStats(data, example.format),
+        sparqTextQuery(data, query, example.format),
+      ]);
+      setEngine("ready");
+      setState({
+        kind: "results",
+        results,
+        stats,
+        ms: Math.round(performance.now() - t0),
+      });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setState({ kind: "error", message });
+      toast.error("Full-text query failed", { description: message });
+    }
+  }, [data, query, example.format]);
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center justify-between gap-2 space-y-0">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Search className="size-4 text-primary" />
+          Live BM25 full-text search
+        </CardTitle>
+        <EngineIndicator engine={engine} />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap gap-1.5">
+          {TEXT_EXAMPLES.map((ex) => (
+            <Button
+              key={ex.id}
+              variant={example.id === ex.id ? "default" : "outline"}
+              size="sm"
+              onClick={() => selectExample(ex.id)}
+              title={ex.description}
+            >
+              {ex.label}
+            </Button>
+          ))}
+        </div>
+
+        <p className="text-sm text-muted-foreground">{example.description}</p>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <Field
+            id="text-corpus"
+            label="Corpus (RDF)"
+            help={`format: ${example.format}`}
+            value={data}
+            onChange={setData}
+            rows={7}
+          />
+          <Field
+            id="text-query"
+            label="text: SPARQL query"
+            help="text:matches / matchesAny / phrase / near / slop / score"
+            value={query}
+            onChange={setQuery}
+            rows={7}
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            onClick={() => void run()}
+            disabled={state.kind === "running"}
+          >
+            {state.kind === "running" ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Play className="size-4" />
+            )}
+            Search
+          </Button>
+          <p aria-live="polite" className="text-xs text-muted-foreground">
+            {state.kind === "running"
+              ? "Indexing + querying on the wasm engine…"
+              : state.kind === "results"
+                ? `${state.results.results.bindings.length} hit${state.results.results.bindings.length === 1 ? "" : "s"} · ${state.ms} ms`
+                : "Edit the corpus or query, then Search."}
+          </p>
+        </div>
+
+        {state.kind === "error" && (
+          <pre className="overflow-x-auto rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+            {state.message}
+          </pre>
+        )}
+
+        {state.kind === "results" && (
+          <>
+            <IndexStats stats={state.stats} />
+            <ResultsTable results={state.results} />
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Field({
+  id,
+  label,
+  help,
+  value,
+  onChange,
+  rows,
+}: {
+  id: string;
+  label: string;
+  help: string;
+  value: string;
+  onChange: (v: string) => void;
+  rows: number;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between">
+        <label htmlFor={id} className="text-xs font-medium text-muted-foreground">
+          {label}
+        </label>
+        <span className="text-[11px] text-muted-foreground">{help}</span>
+      </div>
+      <textarea
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={rows}
+        spellCheck={false}
+        className="w-full resize-y rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+      />
+    </div>
+  );
+}
+
+function IndexStats({ stats }: { stats: TextIndexStats }) {
+  const kib = (stats.heapBytes / 1024).toFixed(1);
+  return (
+    <div className="flex flex-wrap gap-2" data-testid="text-index-stats">
+      <Badge variant="muted" className="font-mono text-[11px]">
+        {stats.docs} indexed literal{stats.docs === 1 ? "" : "s"}
+      </Badge>
+      <Badge variant="muted" className="font-mono text-[11px]">
+        {stats.tokens} distinct token{stats.tokens === 1 ? "" : "s"}
+      </Badge>
+      <Badge variant="muted" className="font-mono text-[11px]">
+        ≈ {kib} KiB heap
+      </Badge>
+      {stats.hasPositions && (
+        <Badge variant="muted" className="font-mono text-[11px]">
+          positions on
+        </Badge>
+      )}
+    </div>
+  );
+}
+
+function ResultsTable({ results }: { results: SparqlResults }) {
+  const { vars, rows } = resultCells(results);
+  if (rows.length === 0) {
+    return (
+      <p className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+        No literals matched — every term filters the set to empty (an empty result is not an
+        error: a query whose tokens match nothing yields zero rows).
+      </p>
+    );
+  }
+  return (
+    <div className="overflow-x-auto rounded-lg border" data-testid="text-results">
+      <table className="w-full border-collapse font-mono text-[12.5px]">
+        <thead>
+          <tr className="bg-muted/40 text-left text-muted-foreground">
+            {vars.map((v) => (
+              <th key={v} className="border-b px-3 py-1.5 font-medium">
+                ?{v}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, ri) => (
+            <tr key={ri}>
+              {row.map((cell, ci) => (
+                <td
+                  key={ci}
+                  className={cn(
+                    "border-b px-3 py-1.5 text-foreground",
+                    cell === "" && "text-muted-foreground",
+                  )}
+                >
+                  {cell === "" ? "—" : cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function EngineIndicator({ engine }: { engine: EngineState }) {
+  if (engine === "ready") {
+    return (
+      <Badge variant="success" aria-live="polite">
+        <CheckCircle2 className="size-3" /> Engine ready
+      </Badge>
+    );
+  }
+  if (engine === "error") {
+    return (
+      <Badge variant="warning" aria-live="polite">
+        Engine failed — retries on search
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="muted" aria-live="polite">
+      <Loader2 className="size-3 animate-spin" /> Engine loading…
+    </Badge>
+  );
+}

--- a/site/src/data/surfaces.ts
+++ b/site/src/data/surfaces.ts
@@ -179,6 +179,7 @@ export const GROUPS: SurfaceGroup[] = [
         blurb: "BM25 text search via magic predicates.",
         tier: "live-new-wasm",
         icon: Search,
+        built: true,
       },
       {
         slug: "vector",

--- a/site/src/data/text-examples.ts
+++ b/site/src/data/text-examples.ts
@@ -1,0 +1,101 @@
+// [OPUS-4.8] sq-xoxu — built-in examples for the live /surface/full-text playground. The
+// default is the classic "quick brown fox" walkthrough from skills/full-text-search/SKILL.md
+// + the sparq-text-wasm README: a tiny N-Triples corpus of comment literals, queried with
+// `text:matches` (AND of tokens) + `text:score` (BM25), ranked. Each example pins the corpus
+// (one small document so the positional index stays bounded), the document format, and a
+// `text:`-predicate SELECT the page runs as a stateless one-shot.
+
+export interface TextExample {
+  id: string;
+  label: string;
+  description: string;
+  /** The RDF corpus to index (kept tiny so the positions-enabled index stays bounded). */
+  data: string;
+  /** Document syntax: "turtle" | "ntriples" | "nquads" | "trig". */
+  format: string;
+  /** The `text:`-predicate SELECT to run over the corpus. */
+  query: string;
+}
+
+// The quick-brown-fox corpus the SKILL.md / README walkthrough uses, extended to a handful
+// of short literals so BM25 ranking and matchesAny / phrase / near have something to rank.
+const FOX_CORPUS = `<http://ex/a> <http://ex/comment> "The quick brown fox jumps over the lazy dog" .
+<http://ex/b> <http://ex/comment> "A quick red fox" .
+<http://ex/c> <http://ex/comment> "The lazy brown dog sleeps" .
+<http://ex/d> <http://ex/comment> "Foxes are quick and clever animals" .
+<http://ex/e> <http://ex/comment> "Slow and steady wins the race" .`;
+
+const TEXT_PREFIX = "PREFIX text: <http://sparq.dev/text#>";
+
+export const TEXT_EXAMPLES: TextExample[] = [
+  {
+    id: "matches-score",
+    label: "BM25-ranked matches",
+    description:
+      "text:matches (AND of tokens) + text:score — keyword → BM25-ranked literals. Only literals containing BOTH 'quick' and 'fox' match; ranked by relevance.",
+    data: FOX_CORPUS,
+    format: "ntriples",
+    query: `${TEXT_PREFIX}
+SELECT ?s ?lit ?score WHERE {
+  ?s <http://ex/comment> ?lit .
+  ?lit text:matches "quick fox" ;
+       text:score   ?score .
+} ORDER BY DESC(?score)`,
+  },
+  {
+    id: "matches-any",
+    label: "matchesAny (OR)",
+    description:
+      "text:matchesAny — literals containing AT LEAST ONE token, BM25-ranked. 'fox dog' matches every literal mentioning either word.",
+    data: FOX_CORPUS,
+    format: "ntriples",
+    query: `${TEXT_PREFIX}
+SELECT ?s ?lit ?score WHERE {
+  ?s <http://ex/comment> ?lit .
+  ?lit text:matchesAny "fox dog" ;
+       text:score      ?score .
+} ORDER BY DESC(?score)`,
+  },
+  {
+    id: "prefix",
+    label: "Prefix token (fox*)",
+    description:
+      "A token ending in '*' is a prefix query: 'fox*' matches 'fox' and 'foxes'. Combined here with 'quick' as an AND.",
+    data: FOX_CORPUS,
+    format: "ntriples",
+    query: `${TEXT_PREFIX}
+SELECT ?s ?lit ?score WHERE {
+  ?s <http://ex/comment> ?lit .
+  ?lit text:matches "quick fox*" ;
+       text:score   ?score .
+} ORDER BY DESC(?score)`,
+  },
+  {
+    id: "phrase",
+    label: "Phrase (adjacent, in order)",
+    description:
+      "text:phrase matches only where the tokens are adjacent and in order — needs the positions-enabled index this bundle always builds. 'quick brown' matches; 'brown quick' would not.",
+    data: FOX_CORPUS,
+    format: "ntriples",
+    query: `${TEXT_PREFIX}
+SELECT ?s ?lit WHERE {
+  ?s <http://ex/comment> ?lit .
+  ?lit text:phrase "quick brown" .
+}`,
+  },
+  {
+    id: "near",
+    label: "Proximity (near + slop)",
+    description:
+      "text:near is the scored, bounded-gap variant of text:phrase: tokens in order within a gap budget (text:slop), ranked tightest-first (score = 1/(1+gap)). 'quick fox' within slop 2.",
+    data: FOX_CORPUS,
+    format: "ntriples",
+    query: `${TEXT_PREFIX}
+SELECT ?s ?lit ?score WHERE {
+  ?s <http://ex/comment> ?lit .
+  ?lit text:near  "quick fox" ;
+       text:slop  2 ;
+       text:score ?score .
+} ORDER BY DESC(?score)`,
+  },
+];

--- a/site/src/lib/sparq-text-wasm.ts
+++ b/site/src/lib/sparq-text-wasm.ts
@@ -1,0 +1,136 @@
+// [OPUS-4.8] sq-xoxu — live loader for the tier-b "W-text" wasm bundle that drives
+// /surface/full-text. This is a SEPARATE, lazy-loaded bundle from the lean sparq-wasm
+// triplestore bundle (crates/sparq-text-wasm → public/wasm/text): the owned BM25 inverted
+// index + the `text:` magic predicates of sparq-text over an RDF document. The lean
+// landing page never pays for it; the full-text page loads it on first interaction,
+// exactly as the inference page loads the W-reason bundle and the streaming page the W-rsp
+// bundle.
+//
+// As with src/lib/reason-wasm.ts the wasm-pack glue is imported at RUNTIME with a
+// webpackIgnore dynamic import, so the wasm never enters the page bundle and we pass the
+// wasm bytes' URL explicitly (prefixed with the Pages basePath) rather than let the glue's
+// `new URL('…_bg.wasm', import.meta.url)` resolution run.
+
+/**
+ * The JS-facing `TextSearch` surface the W-text bundle exports (mirrors
+ * crates/sparq-text-wasm). Every method is a STATELESS one-shot: it parses the supplied
+ * document, builds a positions-enabled BM25 index over it, runs the request, and returns a
+ * string — so the JS side never holds a long-lived index handle. Document `format` is one
+ * of `"turtle"` | `"ntriples"` | `"nquads"` | `"trig"`.
+ */
+export interface WasmTextSearch {
+  /**
+   * Parse `data`, build the index, rewrite the `text:` magic predicates in `sparql` into
+   * plain SPARQL, evaluate, and return a canonical SPARQL 1.1 JSON results document. A
+   * query with no `text:` patterns runs unchanged.
+   */
+  query(data: string, format: string, sparql: string): string;
+  /**
+   * Report the index footprint over `data` as a small JSON object
+   * `{"docs","tokens","heapBytes","hasPositions"}` — the indexed-literal count, the
+   * distinct-token count, the index's estimated in-memory size in bytes, and whether
+   * positions are recorded.
+   */
+  indexStats(data: string, format: string): string;
+}
+
+interface TextModule {
+  default: (opts?: { module_or_path: string | URL }) => Promise<unknown>;
+  TextSearch: WasmTextSearch;
+}
+
+let modulePromise: Promise<TextModule> | null = null;
+
+function basePath(): string {
+  // next.config.ts sets basePath '/sparq'; mirror it for the runtime asset URLs.
+  return process.env.NEXT_PUBLIC_BASE_PATH ?? "/sparq";
+}
+
+/**
+ * [OPUS-4.8] sq-xoxu — loads + initialises the W-text bundle once; subsequent calls reuse
+ * it. The fetch + compile + instantiate is the expensive cold start. {@link prewarmText}
+ * kicks this off eagerly on route mount so the first "Search" pays no cold start. A failed
+ * load resets the cache so a later call retries.
+ */
+export async function loadTextSearch(): Promise<WasmTextSearch> {
+  if (!modulePromise) {
+    modulePromise = (async () => {
+      const base = basePath();
+      const gluePath = `${base}/wasm/text/sparq_text_wasm.js`;
+      const wasmPath = `${base}/wasm/text/sparq_text_wasm_bg.wasm`;
+      const mod = (await import(/* webpackIgnore: true */ gluePath)) as TextModule;
+      await mod.default({ module_or_path: new URL(wasmPath, window.location.origin) });
+      return mod;
+    })();
+    modulePromise.catch(() => {
+      modulePromise = null; // allow retry on transient failure
+    });
+  }
+  const mod = await modulePromise;
+  return mod.TextSearch;
+}
+
+/**
+ * [OPUS-4.8] sq-xoxu — eagerly pre-warm the W-text bundle (fetch + compile + instantiate)
+ * without blocking render. Safe to call on route mount and repeatedly; it shares the single
+ * {@link loadTextSearch} promise, so the cold start happens at most once.
+ */
+export function prewarmText(): Promise<unknown> {
+  return loadTextSearch();
+}
+
+/**
+ * [OPUS-4.8] sq-xoxu — the index footprint the full-text page shows: `docs` indexed string
+ * literals, `tokens` distinct terms across them, `heapBytes` estimated in-memory size, and
+ * whether `hasPositions` (the bundle always builds positions on, so `text:phrase` /
+ * `text:near` are answerable). Mirrors `TextSearch.indexStats`'s JSON.
+ */
+export interface TextIndexStats {
+  docs: number;
+  tokens: number;
+  heapBytes: number;
+  hasPositions: boolean;
+}
+
+/**
+ * [OPUS-4.8] sq-xoxu — run a `text:`-predicate SPARQL query over an RDF document, entirely
+ * in your tab via the W-text bundle. `format` is one of `"turtle"` | `"ntriples"` |
+ * `"nquads"` | `"trig"`. Returns the parsed SPARQL 1.1 JSON results. Throws if the bundle is
+ * missing the `TextSearch` export (wrong artifact), or the document / query fails to parse,
+ * or the query misuses a `text:` predicate.
+ */
+export async function sparqTextQuery(
+  data: string,
+  sparql: string,
+  format = "turtle",
+): Promise<import("./sparq-wasm").SparqlResults> {
+  const TextSearch = await loadTextSearch();
+  if (typeof TextSearch?.query !== "function") {
+    throw new Error(
+      "This wasm bundle does not export the full-text `TextSearch` handle. " +
+        "Build crates/sparq-text-wasm with `wasm-pack build --target web`.",
+    );
+  }
+  return JSON.parse(
+    TextSearch.query(data, format, sparql),
+  ) as import("./sparq-wasm").SparqlResults;
+}
+
+/**
+ * [OPUS-4.8] sq-xoxu — report the BM25 index footprint over an RDF document via the W-text
+ * bundle. Same `format` set as {@link sparqTextQuery}. Throws if the bundle is the wrong
+ * artifact or the document fails to parse.
+ */
+export async function sparqTextIndexStats(
+  data: string,
+  format = "turtle",
+): Promise<TextIndexStats> {
+  const TextSearch = await loadTextSearch();
+  if (typeof TextSearch?.indexStats !== "function") {
+    throw new Error(
+      "This wasm bundle does not export the full-text `TextSearch` handle. " +
+        "Build crates/sparq-text-wasm with `wasm-pack build --target web`.",
+    );
+  }
+  return JSON.parse(TextSearch.indexStats(data, format)) as TextIndexStats;
+}

--- a/site/src/lib/text-results.ts
+++ b/site/src/lib/text-results.ts
@@ -1,0 +1,72 @@
+// [OPUS-4.8] sq-xoxu — pure helpers for the live /surface/full-text playground: shape the
+// SPARQL-1.1-JSON result set the wasm `TextSearch.query` binding returns into framework-free
+// rows for rendering. The BM25 ranking + `text:` rewrite SEMANTICS themselves are proven by
+// crates/sparq-text(/ -wasm)'s tests; here we only test the JS render of what the binding
+// returns. Kept separate from the React component so node --test can exercise it with no DOM.
+
+import type { SparqlResults, SparqlTerm } from "./sparq-wasm";
+
+const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
+
+/**
+ * [OPUS-4.8] sq-xoxu — render a SPARQL-JSON term for display, with a compact datatype/lang
+ * suffix. A self-contained copy of the REPL's `formatTerm` so this pure helper carries NO
+ * cross-module runtime import (the unit-test ts-loader does not rewrite extensionless
+ * specifiers, and a value import would not resolve). An undefined term — an unbound
+ * projection variable in a row — renders as the empty string.
+ */
+export function formatTerm(t: SparqlTerm | undefined): string {
+  if (!t) return "";
+  if (t.type === "uri") return `<${t.value}>`;
+  if (t.type === "bnode") return `_:${t.value}`;
+  if (t["xml:lang"]) return `"${t.value}"@${t["xml:lang"]}`;
+  if (t.datatype && t.datatype !== XSD_STRING) {
+    const short = t.datatype.replace("http://www.w3.org/2001/XMLSchema#", "xsd:");
+    return `"${t.value}"^^${short}`;
+  }
+  return `"${t.value}"`;
+}
+
+/** The variable names the result set projects (its SELECT projection), in order. */
+export function resultVars(results: SparqlResults): string[] {
+  return results.head?.vars ?? [];
+}
+
+/** The solution rows of the result set (each a var→term map). */
+export function resultRows(
+  results: SparqlResults,
+): Record<string, SparqlTerm>[] {
+  return results.results?.bindings ?? [];
+}
+
+/**
+ * [OPUS-4.8] sq-xoxu — render a result set as plain string cells (one row per solution,
+ * columns in {@link resultVars} order), reusing {@link formatTerm} so the datatype/lang
+ * suffixes match the rest of the site. An unbound variable in a row renders as the empty
+ * string. This is what the playground draws into its ranked-hits table.
+ */
+export function resultCells(results: SparqlResults): {
+  vars: string[];
+  rows: string[][];
+} {
+  const vars = resultVars(results);
+  const rows = resultRows(results).map((binding) =>
+    vars.map((v) => formatTerm(binding[v])),
+  );
+  return { vars, rows };
+}
+
+/**
+ * [OPUS-4.8] sq-xoxu — the raw numeric value of a bound variable in a row, or `null` when
+ * it is unbound or not a finite number. Used to read a `text:score` cell for the relevance
+ * bar without re-formatting it (the score binds as an xsd:double in the SPARQL JSON).
+ */
+export function numericValue(
+  binding: Record<string, SparqlTerm> | undefined,
+  variable: string,
+): number | null {
+  const t = binding?.[variable];
+  if (!t || t.type !== "literal") return null;
+  const n = Number(t.value);
+  return Number.isFinite(n) ? n : null;
+}

--- a/site/test/text-results.test.mjs
+++ b/site/test/text-results.test.mjs
@@ -1,0 +1,111 @@
+// [OPUS-4.8] sq-xoxu — unit tests for the pure helpers that back the live /surface/full-text
+// playground: shaping the SPARQL-1.1-JSON result set the wasm `TextSearch.query` binding
+// returns into framework-free cells, and reading a numeric (text:score) cell. The BM25
+// ranking + `text:` rewrite SEMANTICS themselves are proven by the Rust tests in
+// crates/sparq-text(/ -wasm); here we only test the JS render of what that binding returns.
+// Run via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  formatTerm,
+  resultVars,
+  resultRows,
+  resultCells,
+  numericValue,
+} from "../src/lib/text-results.ts";
+
+// The quick-brown-fox walkthrough: `text:matches "quick fox" ; text:score ?score` over the
+// corpus binds only <http://ex/a> (the literal with BOTH tokens), with its BM25 score as an
+// xsd:double — exactly the SPARQL 1.1 JSON shape the W-text bundle's `query` returns.
+const FOX_RESULTS = {
+  head: { vars: ["s", "lit", "score"] },
+  results: {
+    bindings: [
+      {
+        s: { type: "uri", value: "http://ex/a" },
+        lit: {
+          type: "literal",
+          value: "The quick brown fox jumps over the lazy dog",
+        },
+        score: {
+          type: "literal",
+          value: "0.6931472",
+          datatype: "http://www.w3.org/2001/XMLSchema#double",
+        },
+      },
+    ],
+  },
+};
+
+test("formatTerm: uri, plain literal, and a typed score literal", () => {
+  assert.equal(formatTerm({ type: "uri", value: "http://ex/a" }), "<http://ex/a>");
+  assert.equal(formatTerm({ type: "literal", value: "fox" }), '"fox"');
+  assert.equal(
+    formatTerm({
+      type: "literal",
+      value: "0.69",
+      datatype: "http://www.w3.org/2001/XMLSchema#double",
+    }),
+    '"0.69"^^xsd:double',
+  );
+});
+
+test("formatTerm: a plain xsd:string literal drops the redundant datatype suffix", () => {
+  assert.equal(
+    formatTerm({
+      type: "literal",
+      value: "fox",
+      datatype: "http://www.w3.org/2001/XMLSchema#string",
+    }),
+    '"fox"',
+  );
+});
+
+test("formatTerm: an undefined (unbound) term renders as the empty string", () => {
+  assert.equal(formatTerm(undefined), "");
+});
+
+test("resultVars / resultRows: read the projection and the solutions", () => {
+  assert.deepEqual(resultVars(FOX_RESULTS), ["s", "lit", "score"]);
+  assert.equal(resultRows(FOX_RESULTS).length, 1);
+});
+
+test("resultVars: an empty result set has no projection and no rows", () => {
+  const empty = { head: { vars: [] }, results: { bindings: [] } };
+  assert.deepEqual(resultVars(empty), []);
+  assert.deepEqual(resultRows(empty), []);
+});
+
+test("resultCells: renders the ranked fox hit with its xsd:double score suffix", () => {
+  const { vars, rows } = resultCells(FOX_RESULTS);
+  assert.deepEqual(vars, ["s", "lit", "score"]);
+  assert.deepEqual(rows, [
+    [
+      "<http://ex/a>",
+      '"The quick brown fox jumps over the lazy dog"',
+      '"0.6931472"^^xsd:double',
+    ],
+  ]);
+});
+
+test("resultCells: an unbound variable in a row renders as the empty string", () => {
+  const partial = {
+    head: { vars: ["s", "score"] },
+    results: { bindings: [{ s: { type: "uri", value: "http://ex/a" } }] },
+  };
+  const { rows } = resultCells(partial);
+  assert.deepEqual(rows, [["<http://ex/a>", ""]]);
+});
+
+test("numericValue: reads a finite score, null for unbound / non-numeric / uri", () => {
+  const [row] = resultRows(FOX_RESULTS);
+  assert.ok(Math.abs(numericValue(row, "score") - 0.6931472) < 1e-6);
+  assert.equal(numericValue(row, "missing"), null);
+  assert.equal(numericValue(row, "s"), null); // a uri is not a numeric literal
+  assert.equal(
+    numericValue({ x: { type: "literal", value: "not a number" } }, "x"),
+    null,
+  );
+  assert.equal(numericValue(undefined, "score"), null);
+});


### PR DESCRIPTION
> 🤖 SPARQL agent

Implements bead **sq-xoxu** — the live `/surface/full-text` page (tier-b, W-text wasm).

## What this builds

Keyword → BM25-ranked literals via the `text:` magic predicates, **live in your browser tab**. A tiny RDF corpus + a `text:`-predicate SELECT (both editable) → BM25-ranked literal hits, with the index footprint (indexed-literal / distinct-token counts + a heap estimate) shown per run. The default is the classic **quick-brown-fox** example from `skills/full-text-search/SKILL.md`.

Runs in-tab via the separate, lazy-loaded tier-b `sparq-text-wasm` ("W-text") bundle (sq-jbe6, already merged), wired **exactly like the sibling W-reason / W-rsp bundles**:
- `js`'s new `build:text-wasm` script builds the wasm-pack `--target web` bundle;
- the site `prebuild` `sync-wasm` step copies its `pkg/` into `site/public/wasm/text/`;
- `pages.yml` builds it in the Pages deploy.

The page lazy-loads the bundle on mount so the landing page stays light. Each search is a **stateless one-shot** over the bundle's `TextSearch.query` / `TextSearch.indexStats` bindings — nothing is sent to a server.

## Files
- `site/src/lib/sparq-text-wasm.ts` — runtime `webpackIgnore` loader + `prewarm` / `query` / `indexStats` over the `TextSearch` bindings.
- `site/src/lib/text-results.ts` — pure, framework-free SPARQL-1.1-JSON table rendering + numeric (`text:score`) cell read (self-contained; no cross-module runtime import, mirroring `rsp-window.ts`).
- `site/src/components/text-playground.tsx` — example picker, editable corpus + query textareas, run control, index-stats badges + ranked-hits table.
- `site/src/data/text-examples.ts` — `matches`+`score` (default), `matchesAny`, prefix (`fox*`), `phrase`, `near`+`slop` scripted examples (grounded in the SKILL).
- `site/src/app/surface/full-text/page.tsx` — the surface page (capabilities, runs-note, honest caveat, crate links).
- `site/test/text-results.test.mjs` — unit tests for the pure helpers.
- `js/package.json`, `site/scripts/sync-wasm.mjs`, `.github/workflows/pages.yml` — W-text build + sync + Pages wiring.
- `site/src/data/surfaces.ts` (`built: true`) + `site/src/app/surface/[slug]/page.tsx` (`BUILT_SURFACES`) so the static page takes the route.

## Honest scope / caveat
Each search **rebuilds the index from the corpus it is given** (stateless), so it is sized for the illustrative corpora here (tens of literals), not a large persistent index. Tokenizer is UAX #29 + Unicode lowercasing — no stemming/stopwords/diacritic folding. Large / persistent indexes (`apply_delta` / reconcile) stay native via `sparq-cli`. This is a thin wrapper over the existing W-text bundle and owns **no** BM25 / rewrite / serialisation semantics of its own — those are proven by the `sparq-text` crate tests + the bundle's `wasm-pack test --node` suite.

No Rust source changed (the W-text crate was complete from sq-jbe6); this PR is the site page + JS/CI wiring. No `unsafe` added; no public Rust API change.

## Gate (all green locally)
- `site`: `tsc --noEmit` clean, `next lint` clean, `test:unit` 59/59 pass, `next build` succeeds (`/surface/full-text` is its own static route, excluded from `/surface/[slug]`).
- `crates/sparq-text-wasm`: `npm run build:text-wasm` (wasm-pack `--target web`) succeeds; `wasm-pack test --node` 5/5 pass; `clippy --all-targets -D warnings` clean; `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps` clean.
- `sync-wasm` copies the W-text `pkg/` into `public/wasm/text/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)