### PR TITLE
ci(mutants): seed bench/mutants-baseline.json for sparq-algos (sq-ep3f) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1076,10 +1076,14 @@ jobs:
     # (drop "advisory") + flipping the step to fail on a regression, once broadly seeded.
     # Until then `continue-on-error: true` keeps the run green while it seeds.
     #
-    # SEEDED SO FAR (honest): sparq-canon and sparq-parse carry a real committed ceiling in
-    # bench/mutants-baseline.json from a local cargo-mutants run; every other crate is
-    # measured + reported here and gets its ceiling seeded on its first nightly run. The
-    # baseline's absence of a crate is NOT a claim that it has zero surviving mutants.
+    # SEEDED SO FAR (honest): the crates listed in bench/mutants-baseline.json carry a real
+    # committed ceiling from an actual cargo-mutants run (sparq-canon, sparq-parse from the
+    # original local run; sparq-algos added locally under sq-ep3f). Every OTHER crate in
+    # CRATES below is measured + reported here and gets its ceiling seeded on its first
+    # nightly run (download the mutants-outcomes-nightly artifact, run
+    # scripts/mutants-gate.py --seed on each outcomes.json, commit — sq-ep3f). The
+    # baseline's absence of a crate is NOT a claim that it has zero surviving mutants — it
+    # just has not been measured yet.
     name: mutation ratchet (cargo-mutants, advisory)
     needs: nightly-gate
     if: needs.nightly-gate.outputs.fresh == 'true'

--- a/bench/mutants-baseline.json
+++ b/bench/mutants-baseline.json
@@ -8,6 +8,14 @@
     "Regenerate after tests improve: cargo mutants -p <crate> -o target/mutants/<crate> && scripts/mutants-gate.py --seed target/mutants/<crate>/outcomes.json"
   ],
   "crates": {
+    "sparq-algos": {
+      "caught": 110,
+      "caught_pct": 84.09,
+      "ceiling": 23,
+      "measured_surviving": 21,
+      "timeout": 1,
+      "unviable": 3
+    },
     "sparq-canon": {
       "caught": 28,
       "caught_pct": 80.0,


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

Partial increment of **sq-ep3f** (*Seed bench/mutants-baseline.json for the remaining workspace crates + promote mutants lane to gating*).

- **Seed `sparq-algos`** into `bench/mutants-baseline.json` from a real, fully-completed local `cargo mutants -p sparq-algos` run (135 mutants): **21 surviving / 110 caught / 1 timeout / 3 unviable**, caught 84.09%. Ceiling = `measured_surviving + margin(2)` = **23**, exactly per `scripts/mutants-gate.py`.
- **Correct the "SEEDED SO FAR (honest)" note** on the `mutants-nightly-advisory` job (`.github/workflows/ci.yml`) to list the crates that actually carry a committed ceiling (canon, parse, algos) and to spell out the artifact-driven seeding path for the rest.

## Honest scope — what this PR does NOT do

This is **not** the whole bead. I am calling that out rather than shipping an overclaim:

1. **The other 23 crates in the lane's `CRATES` list are not seeded.** The `mutants-nightly-advisory` lane (added in #649) has **never run on a scheduled nightly** — #649 merged `2026-06-18 14:15Z`, *after* that day's `04:54Z` nightly, so there are zero real measured outcomes for those crates yet. The bead's step 1 explicitly anticipates seeding them from the `mutants-outcomes-nightly` artifact. cargo-mutants re-copies the ~14 GB workspace tree once per crate, so measuring the heavy crates locally was out of this session's budget; I measured the smallest crate end-to-end and seeded it honestly. (I attempted `sparq-prov`/`sparq-introspect` too but they did not finish, so they are deliberately **not** committed — a partial outcomes.json would be a dishonest ceiling.)
2. **The lane is NOT promoted to gating.** It stays advisory + `continue-on-error: true`. The bead gates promotion on the baseline being "broadly seeded and stable across nightly runs", which has not happened.

## Follow-up (for the orchestrator to file as beads — `bd` is not on PATH in the worktree)

- **Triage `sparq-algos` 21 survivors** (a real test-quality gap): clustered in `pagerank.rs` (damping/convergence arithmetic — `+=`/`-`/`<`/`/` at lines 76/84/87 run but not asserted on exact scores), `community.rs` (`UnionFind::union` `<` + rank `+=` at 55/59; `label_propagation` `+=`/`!=` at 133/136/147/152), `centrality.rs` (`degree_centrality_normalized` `<` at 42). Add behaviour-asserting tests (exact pagerank scores on a known graph, union-by-rank structure, label-propagation fixed points, exact normalized centrality) that kill these, then re-seed to LOWER the ceiling.
- **Seed the remaining crates from the first nightly artifact** (the bead's intended path) and only then promote the lane to gating.

## Verification

- `scripts/mutants-gate.py --self-test` → ALL ASSERTIONS PASSED
- `scripts/mutants-gate.py --check <algos outcomes>` → `ok sparq-algos surviving 21 <= ceiling 23`, exit 0
- `bench/mutants-baseline.json` is valid JSON; `.github/workflows/ci.yml` is valid YAML

No Rust public API changed (JSON + workflow comment only), so the G2 SKILL.md rule and the rustdoc/clippy gates are not engaged by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)