### PR TITLE
fix(ci): restore coverage gate — pin explicit tool for cargo-llvm-cov install-action [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -921,7 +921,12 @@ jobs:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-llvm-cov
+        # [OPUS-4.8] sq-tool-pin: taiki-e/install-action picks the tool from its @<tool> ref;
+        # SHA-pinning (our code-scanning=0 policy) drops that ref, so an explicit `with: tool:`
+        # is MANDATORY — without it install-action installs NOTHING and `cargo llvm-cov` ENOENTs.
         uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # cargo-llvm-cov
+        with:
+          tool: cargo-llvm-cov
       - name: Test-presence gate (fast, no compile)
         run: python3 scripts/coverage-presence.py --check
       - name: Coverage-floor MONOTONICITY gate (ratchet only rises, fast, no compile)
@@ -1034,7 +1039,12 @@ jobs:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-llvm-cov
+        # [OPUS-4.8] sq-tool-pin: explicit `with: tool:` is MANDATORY when SHA-pinning
+        # install-action — the @<tool> ref is dropped by the SHA pin, so without this the
+        # tool is silently NOT installed and `cargo llvm-cov` ENOENTs (see per-commit job).
         uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # cargo-llvm-cov
+        with:
+          tool: cargo-llvm-cov
       - name: Test-presence gate
         run: python3 scripts/coverage-presence.py --check
       - name: Measure + enforce per-crate coverage (FULL tier, max-remeasure gate)

--- a/crates/sparq-geo/src/lib.rs
+++ b/crates/sparq-geo/src/lib.rs
@@ -102,3 +102,32 @@ impl std::fmt::Display for GeoError {
 }
 
 impl std::error::Error for GeoError {}
+
+#[cfg(test)]
+mod error_display_tests {
+    // [OPUS-4.8] sq-9g58 coverage: every GeoError Display arm renders its
+    // payload. These arms (CrsMismatch / NonGeographicCrs / UnknownUnit) were
+    // unexercised — Parse / Unsupported are hit by the parser/eval tests.
+    use super::GeoError;
+
+    #[test]
+    fn each_variant_renders_its_payload() {
+        let parse = GeoError::Parse("bad wkt".to_string()).to_string();
+        assert!(parse.contains("bad wkt"), "{parse}");
+
+        let crs = GeoError::CrsMismatch("urn:a".to_string(), "urn:b".to_string()).to_string();
+        assert!(crs.contains("urn:a") && crs.contains("urn:b"), "{crs}");
+
+        let non_geo = GeoError::NonGeographicCrs("urn:proj".to_string()).to_string();
+        assert!(non_geo.contains("urn:proj") && non_geo.contains("geographic"), "{non_geo}");
+
+        let unit = GeoError::UnknownUnit("urn:furlong".to_string()).to_string();
+        assert!(unit.contains("urn:furlong") && unit.contains("unit"), "{unit}");
+
+        let unsup = GeoError::Unsupported("no can do".to_string()).to_string();
+        assert!(unsup.contains("no can do"), "{unsup}");
+
+        // The error implements std::error::Error (trait-object usable).
+        let _: &dyn std::error::Error = &GeoError::Parse("x".to_string());
+    }
+}

--- a/crates/sparq-geo/src/metadata.rs
+++ b/crates/sparq-geo/src/metadata.rs
@@ -370,4 +370,35 @@ mod tests {
             Some(0)
         );
     }
+
+    #[test]
+    fn lex_metadata_aggregate_returns_all_values() {
+        // [OPUS-4.8] sq-9g58 coverage: the aggregate `lex::metadata` helper (the
+        // single-call form a materialising loader uses) — distinct from the
+        // per-property `lex::dimension` etc. that the test above drives.
+        use crate::vocab::WKT_LITERAL;
+        let m = lex::metadata("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", WKT_LITERAL).unwrap();
+        assert_eq!(m.dimension, Some(2));
+        assert_eq!(m.coordinate_dimension, Some(2));
+        assert_eq!(m.spatial_dimension, Some(2));
+        assert!(!m.is_empty);
+        assert!(m.is_simple);
+        assert!(m.has_serialization.contains("POLYGON"));
+    }
+
+    #[test]
+    fn degenerate_linestring_is_simple() {
+        // [OPUS-4.8] sq-9g58 coverage: linestring_is_simple's `< 2 points`
+        // early-return arm. An EMPTY linestring has no vertices and is simple.
+        assert!(meta("LINESTRING EMPTY").is_simple);
+    }
+
+    #[test]
+    fn collinear_self_overlapping_linestring_is_not_simple() {
+        // [OPUS-4.8] sq-9g58 coverage: linestring_is_simple's COLLINEAR
+        // intersection arm — a curve whose segments overlap along a shared line
+        // (it doubles back over itself) is NOT simple.
+        // (0 0)->(3 0)->(1 0): the second segment lies ON the first.
+        assert!(!meta("LINESTRING(0 0, 3 0, 1 0)").is_simple);
+    }
 }

--- a/crates/sparq-geo/src/provider.rs
+++ b/crates/sparq-geo/src/provider.rs
@@ -115,3 +115,138 @@ impl SpatialProvider for GeoIndexProvider {
         self.indexed.contains(term)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    // [OPUS-4.8] sq-9g58 coverage: the provider's decline paths — the cases
+    // where the index CANNOT serve a candidate superset and must hand the query
+    // back to the exact post-hoc `geof:` FILTER (returning `None`). These are
+    // load-bearing for ANSWER-SAFETY: a wrong (non-`None`) answer here would
+    // silently drop matches. The happy pushdown paths are covered by
+    // `tests/pushdown.rs`; these cover the guards.
+    use super::*;
+    use crate::GeoIndex;
+    use sparq_core::Graph;
+
+    fn index() -> GeoIndex {
+        let g = Graph::load_str(
+            r#"@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+               <http://ex/a> geo:asWKT "POINT(0 0)"^^geo:wktLiteral ."#,
+            "turtle",
+        )
+        .unwrap();
+        GeoIndex::build(&g)
+    }
+
+    const DEG: &str = "http://www.opengis.net/def/uom/OGC/1.0/degree";
+    const KM: &str = "http://www.opengis.net/def/uom/OGC/1.0/kilometre";
+
+    #[test]
+    fn index_accessor_borrows_the_inner_index() {
+        let p = GeoIndexProvider::new(index());
+        // The accessor returns a usable index: the one literal we loaded is
+        // present in its entries.
+        assert_eq!(p.index().entries().count(), 1);
+    }
+
+    #[test]
+    fn distance_in_angular_unit_is_declined() {
+        // A DEGREE-unit distance is euclidean coordinate distance, NOT the
+        // index's great-circle metre metric: the provider declines (None) so
+        // the exact FILTER runs. (meters_scale() is None for angular units.)
+        let p = GeoIndexProvider::new(index());
+        let q = SpatialQuery::DistanceWithin {
+            point_wkt: "POINT(0 0)",
+            radius: 1.0,
+            unit_iri: DEG,
+            inclusive: true,
+        };
+        assert!(p.candidates(&q).is_none(), "angular-unit distance must decline");
+    }
+
+    #[test]
+    fn distance_from_non_geographic_constant_is_declined() {
+        // A projected (non-geographic) centre shares no metric with the
+        // geographic index entries: center_point returns None -> decline.
+        let p = GeoIndexProvider::new(index());
+        let q = SpatialQuery::DistanceWithin {
+            // A point in EPSG:3857 (Web Mercator), a projected CRS.
+            point_wkt: "<http://www.opengis.net/def/crs/EPSG/0/3857> POINT(0 0)",
+            radius: 1.0,
+            unit_iri: KM,
+            inclusive: true,
+        };
+        assert!(p.candidates(&q).is_none(), "non-geographic centre must decline");
+    }
+
+    #[test]
+    fn distance_from_non_point_constant_is_declined() {
+        // The index's within-distance scan accepts only a single POINT centre;
+        // a polygon constant declines.
+        let p = GeoIndexProvider::new(index());
+        let q = SpatialQuery::DistanceWithin {
+            point_wkt: "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
+            radius: 1.0,
+            unit_iri: KM,
+            inclusive: true,
+        };
+        assert!(p.candidates(&q).is_none(), "non-point centre must decline");
+    }
+
+    #[test]
+    fn metric_distance_from_geographic_point_is_served() {
+        // The positive case: a metric unit + geographic POINT centre is served
+        // (Some candidate set) — contrasts the decline paths above.
+        let p = GeoIndexProvider::new(index());
+        let q = SpatialQuery::DistanceWithin {
+            point_wkt: "POINT(0 0)",
+            radius: 1.0,
+            unit_iri: KM,
+            inclusive: true,
+        };
+        let got = p.candidates(&q).expect("metric+geographic must be served");
+        assert_eq!(got.len(), 1, "the one entry is within 1 km of itself");
+    }
+
+    #[test]
+    fn bbox_with_non_geographic_constant_is_declined() {
+        // A non-geographic bbox constant shares no metric with the index:
+        // decline (None) rather than wrongly drop same-CRS matches.
+        let p = GeoIndexProvider::new(index());
+        let q = SpatialQuery::BboxIntersects {
+            arg_wkt: "<http://www.opengis.net/def/crs/EPSG/0/3857> POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
+        };
+        assert!(p.candidates(&q).is_none(), "non-geographic bbox must decline");
+    }
+
+    #[test]
+    fn bbox_with_geographic_constant_is_served() {
+        let p = GeoIndexProvider::new(index());
+        let q = SpatialQuery::BboxIntersects {
+            arg_wkt: "POLYGON((-1 -1, 1 -1, 1 1, -1 1, -1 -1))",
+        };
+        let got = p.candidates(&q).expect("geographic bbox must be served");
+        assert_eq!(got.len(), 1);
+    }
+
+    #[test]
+    fn is_indexed_distinguishes_known_from_unknown_literals() {
+        let p = GeoIndexProvider::new(index());
+        // The literal Term the index actually holds is reported indexed; a
+        // literal it never saw is not.
+        let known: Term = p
+            .index()
+            .entries()
+            .next()
+            .expect("one entry")
+            .literal
+            .clone();
+        assert!(p.is_indexed(&known), "the indexed literal is reported indexed");
+
+        let other = Term::Literal(oxrdf::Literal::new_typed_literal(
+            "POINT(99 99)",
+            oxrdf::NamedNode::new_unchecked(crate::vocab::WKT_LITERAL),
+        ));
+        assert!(!p.is_indexed(&other), "an unseen literal is not indexed");
+    }
+}

--- a/crates/sparq-geo/src/rewrite.rs
+++ b/crates/sparq-geo/src/rewrite.rs
@@ -517,4 +517,231 @@ mod tests {
         );
         assert!(s.contains("asWKT"), "no geometry resolution in {s}");
     }
+
+    // -----------------------------------------------------------------------
+    // [OPUS-4.8] sq-9g58 coverage: the rewrite must recurse through EVERY
+    // GraphPattern variant the engine's `spargebra` algebra exposes, expanding
+    // a topology triple nested arbitrarily deep. Each query below places a
+    // `geo:sfWithin` triple inside exactly one structural node so that the
+    // corresponding `rewrite_pattern` arm is exercised AND we assert the
+    // topology predicate was expanded (the `geof:` call appears, the bare
+    // `geo:sfWithin` predicate does not survive as an asserted edge). A bare
+    // SERPENT (`SERVICE`) and `VALUES` are also driven so the leaf arms run.
+    // -----------------------------------------------------------------------
+
+    /// Parse, rewrite, and stringify a query.
+    fn rw(q: &str) -> String {
+        let parsed = sparq_engine::PreparedQuery::parse(q).unwrap().into_query();
+        rewrite_query(parsed).to_string()
+    }
+
+    /// The rewrite expanded a topology triple: the `geof:` call and the
+    /// `asWKT` resolution edge appear in the rewritten algebra.
+    fn assert_expanded(s: &str) {
+        assert!(s.contains("function/geosparql/sfWithin"), "not expanded: {s}");
+        assert!(s.contains("asWKT"), "no resolution path: {s}");
+    }
+
+    const GEO_P: &str = "PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+                         PREFIX ex:  <http://example.org/>";
+
+    #[test]
+    fn recurses_through_optional_left_join() {
+        // The topology triple sits in an OPTIONAL (LeftJoin) block.
+        let s = rw(&format!(
+            "{GEO_P} SELECT ?a ?b WHERE {{ ?a ex:p ?x OPTIONAL {{ ?a geo:sfWithin ?b }} }}"
+        ));
+        assert_expanded(&s);
+    }
+
+    #[test]
+    fn recurses_through_optional_left_join_with_filter_expression() {
+        // OPTIONAL ... FILTER(EXISTS { topology triple }) — drives both the
+        // LeftJoin `expression` map AND `rewrite_expression`'s Exists arm.
+        let s = rw(&format!(
+            "{GEO_P} SELECT ?a WHERE {{ ?a ex:p ?x \
+             OPTIONAL {{ ?a ex:q ?y FILTER( EXISTS {{ ?a geo:sfWithin ?b }} ) }} }}"
+        ));
+        assert_expanded(&s);
+    }
+
+    #[test]
+    fn recurses_through_lateral() {
+        // LATERAL (SEP-0006) join: the right side is rewritten (Lateral arm).
+        let s = rw(&format!(
+            "{GEO_P} SELECT ?a ?b WHERE {{ ?a ex:p ?x LATERAL {{ ?a geo:sfWithin ?b }} }}"
+        ));
+        assert_expanded(&s);
+    }
+
+    #[test]
+    fn recurses_through_union() {
+        let s = rw(&format!(
+            "{GEO_P} SELECT ?a WHERE {{ {{ ?a ex:p ?x }} UNION {{ ?a geo:sfWithin ?b }} }}"
+        ));
+        assert_expanded(&s);
+    }
+
+    #[test]
+    fn recurses_through_named_graph() {
+        let s = rw(&format!(
+            "{GEO_P} SELECT ?a WHERE {{ GRAPH ?g {{ ?a geo:sfWithin ?b }} }}"
+        ));
+        assert_expanded(&s);
+    }
+
+    #[test]
+    fn recurses_through_minus() {
+        let s = rw(&format!(
+            "{GEO_P} SELECT ?a WHERE {{ ?a ex:p ?x MINUS {{ ?a geo:sfWithin ?b }} }}"
+        ));
+        assert_expanded(&s);
+    }
+
+    #[test]
+    fn recurses_through_bind_extend_and_order_distinct_slice() {
+        // BIND => Extend; ORDER BY => OrderBy; DISTINCT => Distinct;
+        // LIMIT/OFFSET => Slice; the projection => Project. A single query that
+        // stacks all of them above the topology triple.
+        let s = rw(&format!(
+            "{GEO_P} SELECT DISTINCT ?a ?label WHERE {{ \
+             ?a geo:sfWithin ?b . BIND(STR(?a) AS ?label) }} \
+             ORDER BY ?label LIMIT 5 OFFSET 1"
+        ));
+        assert_expanded(&s);
+    }
+
+    #[test]
+    fn recurses_through_group_by_aggregate() {
+        // GROUP BY => Group. The topology triple feeds the grouped pattern.
+        let s = rw(&format!(
+            "{GEO_P} SELECT ?b (COUNT(?a) AS ?n) WHERE {{ ?a geo:sfWithin ?b }} GROUP BY ?b"
+        ));
+        assert_expanded(&s);
+    }
+
+    #[test]
+    fn recurses_through_subselect_reduced() {
+        // A sub-SELECT with REDUCED => Project over Reduced, nested under the
+        // outer Project. The topology triple lives in the inner select.
+        let s = rw(&format!(
+            "{GEO_P} SELECT ?a WHERE {{ \
+             {{ SELECT REDUCED ?a WHERE {{ ?a geo:sfWithin ?b }} }} }}"
+        ));
+        assert_expanded(&s);
+    }
+
+    #[test]
+    fn recurses_through_service() {
+        // SERVICE block: the inner pattern is still rewritten (Service arm).
+        let s = rw(&format!(
+            "{GEO_P} SELECT ?a WHERE {{ SERVICE ?svc {{ ?a geo:sfWithin ?b }} }}"
+        ));
+        assert_expanded(&s);
+    }
+
+    #[test]
+    fn topology_as_single_predicate_path_is_expanded() {
+        // `?a geo:sfWithin+ ?b` parses as a `Path`; a one-hop path predicate is
+        // recognised and expanded by the `Path` arm's NamedNode branch.
+        // (`geo:sfWithin` alone is a Bgp triple, so use a property-path operator
+        // to force the `Path` node, then assert the leaf NamedNode of that path
+        // is still handled — here a plain `Path` with a single NamedNode is
+        // produced by an inverse path `^geo:sfContains`-style shape; we use a
+        // sequence-free single hop expressed via a path to keep it a `Path`.)
+        let q = format!(
+            "{GEO_P} SELECT ?a ?b WHERE {{ ?a (geo:sfWithin) ?b }}"
+        );
+        // Whether spargebra lowers `(geo:sfWithin)` to a Bgp or a Path, the
+        // rewrite must still expand it.
+        let s = rw(&q);
+        assert_expanded(&s);
+    }
+
+    #[test]
+    fn values_leaf_is_left_untouched() {
+        // A standalone VALUES block has no nested pattern; the Values arm
+        // returns it unchanged (no topology triple to expand). The query is a
+        // structural no-op for the rewrite.
+        let q = format!(
+            "{GEO_P} SELECT ?a WHERE {{ VALUES ?a {{ ex:x ex:y }} }}"
+        );
+        let before = sparq_engine::PreparedQuery::parse(&q).unwrap().into_query();
+        let after = rewrite_query(before.clone());
+        assert_eq!(before.to_string(), after.to_string());
+    }
+
+    #[test]
+    fn rewrite_expression_recurses_through_boolean_and_if() {
+        // FILTER( !EXISTS{...} && (EXISTS{...} || IF(EXISTS{...}, true, false)) )
+        // drives the Not / And / Or / If arms of rewrite_expression, each
+        // wrapping an Exists whose inner pattern holds a topology triple.
+        let s = rw(&format!(
+            "{GEO_P} SELECT ?a WHERE {{ ?a ex:p ?x FILTER( \
+               !EXISTS {{ ?a geo:sfWithin ?b }} && \
+               ( EXISTS {{ ?a geo:sfContains ?c }} || \
+                 IF(EXISTS {{ ?a geo:sfEquals ?d }}, true, false) ) ) }}"
+        ));
+        // Three distinct topology predicates expanded inside the expression.
+        assert!(s.contains("function/geosparql/sfWithin"), "{s}");
+        assert!(s.contains("function/geosparql/sfContains"), "{s}");
+        assert!(s.contains("function/geosparql/sfEquals"), "{s}");
+    }
+
+    #[test]
+    fn construct_describe_ask_query_forms_are_rewritten() {
+        // The non-SELECT query forms each route their pattern through
+        // rewrite_pattern (the Construct / Describe / Ask arms of rewrite_query).
+        let construct = rw(&format!(
+            "{GEO_P} CONSTRUCT {{ ?a ex:near ?b }} WHERE {{ ?a geo:sfWithin ?b }}"
+        ));
+        assert_expanded(&construct);
+
+        let describe = rw(&format!(
+            "{GEO_P} DESCRIBE ?a WHERE {{ ?a geo:sfWithin ?b }}"
+        ));
+        assert_expanded(&describe);
+
+        let ask = rw(&format!(
+            "{GEO_P} ASK WHERE {{ ?a geo:sfWithin ?b }}"
+        ));
+        assert_expanded(&ask);
+    }
+
+    #[test]
+    fn bgp_with_mixed_topology_and_plain_triples_keeps_the_plain_remainder() {
+        // A BGP holding BOTH a plain triple and TWO topology triples: the plain
+        // remainder is kept as a Bgp and conjoined with each expansion (the
+        // `plain` + multi-`expanded` Join-fold in rewrite_bgp).
+        let s = rw(&format!(
+            "{GEO_P} SELECT ?a ?b ?c WHERE {{ \
+             ?a ex:p ?x . ?a geo:sfWithin ?b . ?a geo:sfContains ?c }}"
+        ));
+        assert!(s.contains("function/geosparql/sfWithin"), "{s}");
+        assert!(s.contains("function/geosparql/sfContains"), "{s}");
+        // The plain edge survives in the rewritten algebra.
+        assert!(s.contains("example.org/p"), "plain triple lost: {s}");
+    }
+
+    #[test]
+    fn bgp_of_only_topology_triples_has_no_plain_remainder() {
+        // Two topology triples, NO plain triple: the `plain.is_empty()` branch
+        // of rewrite_bgp (acc starts `None`, first expansion seeds it).
+        let s = rw(&format!(
+            "{GEO_P} SELECT ?a ?b ?c WHERE {{ ?a geo:sfWithin ?b . ?b geo:sfContains ?c }}"
+        ));
+        assert!(s.contains("function/geosparql/sfWithin"), "{s}");
+        assert!(s.contains("function/geosparql/sfContains"), "{s}");
+    }
+
+    #[test]
+    fn variable_predicate_bgp_is_not_rewritten() {
+        // A triple with a VARIABLE predicate is never a topology property; the
+        // BGP has no topology triple so rewrite_bgp returns None and the BGP is
+        // kept verbatim.
+        let q = format!("{GEO_P} SELECT ?a ?p ?b WHERE {{ ?a ?p ?b }}");
+        let before = sparq_engine::PreparedQuery::parse(&q).unwrap().into_query();
+        let after = rewrite_query(before.clone());
+        assert_eq!(before.to_string(), after.to_string());
+    }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent

## Root cause: dropped tool ref on a SHA-pinned `taiki-e/install-action`

`taiki-e/install-action` selects which tool to install from its **`@<tool>` git ref**. Our code-scanning=0 posture **SHA-pins every action**, which replaces that `@<tool>` ref with a commit SHA — so the tool name is lost. Without an explicit `with: tool:` input, install-action installs **nothing**, and the very next step (`cargo llvm-cov ...`) fails with `error: no such command: llvm-cov` → every crate is **UNMEASURED**.

`sq-039g` recently made a measure-failure **FATAL**. Before that the per-commit coverage gate silently swallowed the missing-tool failure and was **effectively vacuous** (measuring nothing). After sq-039g, the `coverage ratchet + test-presence gate (per-crate)` job went **RED on main** (run 27783630399, sha 181577b0) and on every open PR — blocking the merge train.

The CI log symptom: `install-action: no tool specified; this could be caused by a dependabot bug where @<tool_name> tags ... are replaced by @<version> tags`.

## Fix

Add the explicit `with: tool: cargo-llvm-cov` input to both `Install cargo-llvm-cov` steps in `.github/workflows/ci.yml` (per-commit `coverage` job and the FULL/nightly coverage job). **The SHA pin is kept** — `SHA pin + with: tool:` is the correct pattern. This also **restores real per-commit coverage enforcement** (the gate now actually measures).

## Audit of all `taiki-e/install-action` uses

Audited all **18** uses across `.github/workflows/*.yml`:

| File | Step | Status |
|---|---|---|
| ci.yml:924 | Install cargo-llvm-cov (per-commit `coverage`) | **FIXED** — was missing `tool:` |
| ci.yml:1037 | Install cargo-llvm-cov (FULL/nightly) | **FIXED** — was missing `tool:` |
| ci.yml:162, 315 | nextest | already correct (`tool: nextest`) |
| ci.yml:1100 | cargo-mutants | already correct (`tool: cargo-mutants@25.3.1`) |
| ci.yml:1190 | cargo-geiger | already correct |
| supply-chain.yml ×5 | cargo-deny / cargo-vet / cargo-cyclonedx ×3 | already correct |
| dist.yml, release.yml:76 | cargo-auditable | already correct |
| release.yml:139 | cargo-cyclonedx | already correct |
| dependency-monitoring.yml | cargo-deny | already correct |
| fuzz.yml | cargo-fuzz | already correct |
| docs-quality.yml | typos@1.47.2 | already correct |

Only the two `cargo-llvm-cov` steps were broken.

## Verification

- YAML valid: `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` → OK.
- Programmatic scan confirms **zero** install-action steps now lack `with: tool:`.
- All actions remain SHA-pinned (no floating tags introduced) — code-scanning=0 stays 0.
- `gate` aggregator structure unchanged (only the two install steps touched).
- Local reproduction: `cargo llvm-cov --version` → `cargo-llvm-cov 0.8.7`; `cargo llvm-cov --help` resolves. The lane's command is valid once the tool is present — the only failure was install-action not installing it.
- actionlint: only pre-existing `info`-level shellcheck notes elsewhere; no errors at the touched lines.

The cleanest proof is this PR's own `coverage` job (it edits ci.yml, so its CI exercises the fix). I have **not** yet observed it green — see CI status on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)