### PR TITLE
docs(bench): re-confirm rung-5 1B dict-bucket EC2 run STILL blocked (sq-3l43) [OPUS-4.8]

### DIFF
--- a/research/wikidata-ingestion-benchmark.md
+++ b/research/wikidata-ingestion-benchmark.md
@@ -289,3 +289,35 @@ spot quota; or (b) a Standard on-demand vCPU limit bump to ≥24 (then plain `ba
 hwrun/rung5-launch.sh`); or (c) run it from a session that is NOT on the 8-vCPU dev box so
 the on-demand headroom is free again. Tracked on sq-3l43; the deferred 192-core full
 validation is sq-bj3.
+
+### 2026-06-18 re-confirmation — BOTH paths STILL blocked (no change, no fabrication) [OPUS-4.8]
+
+Re-probed live from the same work-box session before re-attempting; the account envelope
+is unchanged from the 2026-06-17 attempt above, so **the `dict-consolidate(serial)` figure
+at 1 B is still NOT produced and none is recorded here.** Evidence captured this session:
+
+- Running instances unchanged: prod `t3.large` (2 vCPU) + dev `r7g.2xlarge`
+  `sparq-dev-claude` (8 vCPU) = 10 vCPU Standard on-demand. No `purpose=sparq-hw-validation`
+  instances exist (orphan-clean before and after).
+- **On-demand still `VcpuLimitExceeded`.** The sanctioned self-terminating launch
+  (`bash hwrun/rung5-launch.sh`, `--instance-initiated-shutdown-behavior terminate` +
+  dead-man `shutdown -h +150` + cleanup trap) aborted at `RunInstances`: *"requested more
+  vCPU capacity than your current vCPU limit of 16 … for the instance bucket"* (10 used + 8
+  for a fresh `r7i.2xlarge` = 18 > 16). The pre-flight + cleanup trap left no instance,
+  keypair, or SG behind. NB: a bare `--dry-run` RunInstances misleadingly reports "would
+  have succeeded" because dry-run does NOT evaluate the per-bucket vCPU quota — only a real
+  `RunInstances` surfaces the limit, so the dry-run cannot be used as the go/no-go signal.
+- **Spot still `AuthFailure.ServiceLinkedRoleCreationNotPermitted`.** A real spot
+  `RunInstances` probe is refused: the scoped SSO deploy role
+  (`AWSReservedSSO_PSSSingleInstanceDeploy`) cannot create the one-time
+  `AWSServiceRoleForEC2Spot` service-linked role, and cannot `iam:GetRole` to check whether
+  it already exists. `servicequotas:GetServiceQuota` is likewise denied, so the limits
+  cannot be read from this principal — only inferred from the live `RunInstances` verdicts.
+
+Not run in-place on the dev box instead: it is **aarch64 (Neoverse-V1)**, not the x86-64
+(Xeon Platinum 8488C) of the rung-5 baseline, so a figure from it would not be comparable
+to the 137.9 s + 62.2 s x86 split this re-measurement compares against; it is also the
+shared agent box (a ~12-min full-core 1 B build would contend with other agents, and the
+~84 GB index would crowd the shared root volume). The bead scopes a dedicated,
+self-terminating r7i.2xlarge precisely to avoid both. Unblock paths (a)/(b)/(c) above are
+unchanged; producing the figure remains the responsibility of whoever satisfies one of them.


### PR DESCRIPTION
> 🤖 SPARQ agent

## sq-3l43 — re-measure the serial dict-consolidation bucket at 1 B (rung-5 precursor)

**Honest status: the bead's measurement is BLOCKED, not done.** This PR ships a dated,
live-verified re-confirmation of that block to `research/wikidata-ingestion-benchmark.md`.
It deliberately ships **no fabricated `dict-consolidate(serial)` figure** — none could be
produced, so none is recorded. [OPUS-4.8]

### What the bead asks for

A single `~$1.50` self-terminating **r7i.2xlarge** (8 vCPU / 64 GB, x86) 1 B-triple
Wikidata build with `SPARQ_BUILD_TIMING=1`, to confirm/refute that the post-`dict-
consolidation` engine drops the old `~200 s/1 B` additive-serial dict bucket
(`merge_remap(serial)` 137.9 s + `triple-remap(serial)` 62.2 s, measured at `ef86e66`)
down to the projected single-digit seconds (`research/dict-consolidation-verdict.md`).

### What is already done (prior work, NOT this PR)

- **#570 (merged)** shipped the instrumentation + orchestration: `build_timing::PathKind`
  honestly labels the sharded path's `intern(parallel-occupancy)` /
  `triple-remap(pipelined-occupancy)` and surfaces the serial `into_merged` as its own
  `dict-consolidate(serial)` term; `hwrun/rung5-launch.sh`/`rung5-remote.sh` default to
  `origin/main` and extract `t2-dict-bucket.txt`.
- The benchmark doc already records a **2026-06-17** launch attempt that hit the account
  envelope.

### What this PR adds

A **2026-06-18 re-confirmation**, re-probed live from this session before re-attempting:

| path | live verdict (this session) |
|---|---|
| on-demand `RunInstances` | `VcpuLimitExceeded` — prod `t3.large` 2 + dev `r7g.2xlarge` 8 + fresh `r7i.2xlarge` 8 = **18 > 16** limit |
| spot `RunInstances` | `AuthFailure.ServiceLinkedRoleCreationNotPermitted` — the scoped SSO deploy role cannot create the `AWSServiceRoleForEC2Spot` SLR (and cannot `iam:GetRole`/`servicequotas:GetServiceQuota` to check) |

The sanctioned self-terminating launch (`bash hwrun/rung5-launch.sh`,
`--instance-initiated-shutdown-behavior terminate` + dead-man `shutdown -h +150` +
cleanup trap) aborted at `RunInstances`; pre-flight + cleanup left **no instance,
keypair, or SG behind** (orphan-clean, verified before and after). A bare `--dry-run`
misleadingly reports "would have succeeded" because it does not evaluate the per-bucket
vCPU quota — only a real `RunInstances` surfaces the limit, so dry-run is **not** a valid
go/no-go signal.

**Why not run it in-place on the dev box:** that box is **aarch64 (Neoverse-V1)**, not the
x86-64 (Xeon Platinum 8488C) rung-5 baseline, so a number from it would not be comparable
to the `137.9 s + 62.2 s` x86 split this re-measurement targets; it is also the shared
agent box (a ~12-min full-core 1 B build would contend with other agents, and the ~84 GB
index would crowd the shared root volume).

### Unblock — one of

- a privileged principal creates the spot SLR once
  (`aws iam create-service-linked-role --aws-service-name spot.amazonaws.com`), then
  `SPARQ_SPOT=1 bash hwrun/rung5-launch.sh`; **or**
- a Standard on-demand vCPU limit bump to ≥24, then plain `bash hwrun/rung5-launch.sh`; **or**
- run it from a session not on the 8-vCPU dev box (frees the on-demand headroom).

The bead stays open; the deferred 192-core full validation is `sq-bj3`.

### Gate

Docs-only change to a `research/` design record (no Rust, no public API, no `unsafe`, no
SKILL surface). Ran the applicable doc gates locally on the worktree: **markdownlint-cli2
0.18.1** (HARD config) 0 errors, **typos** 0, **privacy-claims** OK, **no-perf-numbers**
(advisory) clean. The pre-existing `137.9 / 62.2` figures are unchanged context, not new
baked-in numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
