### PR TITLE
feat(sparq-engine): opt-in MVCC / ACID transaction isolation (sq-it1x) [OPUS-4.8]

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -177,6 +177,22 @@ jobs:
             crate: sparq-engine
             features: window-functions
             test: true
+          # [OPUS-4.8] sq-it1x: opt-in MVCC / ACID transaction isolation. The whole `txn`
+          # module (`src/txn.rs`, gated `pub mod txn` in lib.rs) and its in-src unit tests
+          # (`txn::tests::*`, 3) plus the whole-file `tests/mvcc_txn.rs` suite (13;
+          # `#![cfg(feature = "txn")]`) are all `#[cfg(feature = "txn")]`, so the default
+          # build (and ci.yml's `--workspace --all-targets` archive, which passes NO
+          # `--features`) compiled them EMPTY and ran ZERO of the 16 tests — the silent
+          # "compiled EMPTY ... tests never ran" gap this lane exists to close. No new dep
+          # (`txn = []`, reuses the existing snapshot/delta-overlay substrate) and no
+          # `not(feature)` divergence, so a single isolated leg (matching the per-feature
+          # engine legs above) covers it; verified `cargo test -p sparq-engine --features
+          # txn` runs all 16 tests and `cargo clippy -p sparq-engine --features txn
+          # --all-targets -- -D warnings` is clean.
+          - name: sparq-engine (txn)
+            crate: sparq-engine
+            features: txn
+            test: true
           # sparq-cli: the `dump` re-serializer (forwards sparq-engine/serialize-rdf).
           - name: sparq-cli (serialize-rdf)
             crate: sparq-cli

--- a/crates/sparq-engine/Cargo.toml
+++ b/crates/sparq-engine/Cargo.toml
@@ -99,6 +99,20 @@ vectorized = []
 # caller bumps the version on every mutation, and non-deterministic queries (NOW/RAND/
 # UUID/SERVICE/custom fns, detected by `cache::is_cacheable`) are never stored.
 result-cache = []
+# [OPUS-4.8] (sq-it1x) MVCC / ACID multi-statement transaction isolation. A
+# `txn::TransactionManager` providing SNAPSHOT-ISOLATION read transactions (a cheap
+# `GraphSnapshot` of the current committed generation) and serialized write transactions
+# with FIRST-COMMITTER-WINS write-write conflict detection (optimistic concurrency
+# control), all built on the existing copy-on-write delta-overlay substrate
+# (`Graph::fork`/`snapshot`/`apply_delta`). Per the design record
+# (research/concurrent-serving-litreview-A-mvcc-benchmarks.md §A.1), a single-writer
+# store with snapshot reads is trivially serializable (SI = serializability); the OCC
+# conflict check additionally serializes concurrent writers safely. OPT-IN and OFF by
+# default — when off, zero txn code compiles and the default native + wasm builds are
+# byte-identical. Pulls in ZERO new dependencies (std `Mutex`/`Arc` + the crate's own
+# `update_in_place_capturing` write-set capture; oxrdf/rustc-hash are already direct deps)
+# and contains no `unsafe`.
+txn = []
 
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io

--- a/crates/sparq-engine/README.md
+++ b/crates/sparq-engine/README.md
@@ -68,6 +68,22 @@ let json = sparq_engine::query_json(&g, "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?
   fresh. Keying on the parsed algebra makes the cache insensitive to whitespace / comments / prefix
   spelling. When the feature is off, zero cache code compiles, the default build is byte-identical,
   and no new dependencies are added (std `HashMap`/`Mutex`/`Arc` only).
+- **MVCC / ACID transaction isolation** *(opt-in `txn` feature, OFF by default)* —
+  a `txn::TransactionManager` over a single logical `Graph` giving **snapshot-isolation** read
+  transactions (`begin_read` → a cheap point-in-time `GraphSnapshot`, immune to later commits) and
+  serialized **write** transactions (`begin_write` → a private copy-on-write fork) with
+  **first-committer-wins** write-write conflict detection (optimistic concurrency control). A
+  `WriteTxn` has read-your-own-writes, applies SPARQL `UPDATE`s to its fork, and on `commit` either
+  publishes a new committed generation (advancing a `u64` version) or returns
+  `CommitError::Conflict` if a concurrent writer published an overlapping write set since it began —
+  in which case the whole body is discarded (atomic rollback). A stale but *non*-conflicting writer
+  has its resolved delta replayed onto the current generation (no lost update). For a *single
+  writer* the conflict check never fires, so SI is serializability (see
+  `research/concurrent-serving-litreview-A-mvcc-benchmarks.md` §A.1); durability is inherited from a
+  directory-backed `Graph`'s WAL. Built entirely on the existing COW delta-overlay substrate
+  (`Graph::fork`/`snapshot`/`apply_delta` + `update_in_place_capturing`/`apply_effects`); when the
+  feature is off, zero transaction code compiles, the default build is byte-identical, and no new
+  dependencies are added.
 - **`forbid(unsafe_code)`** — the crate contains zero `unsafe`.
 
 ## 📚 Learn more

--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -56,6 +56,12 @@ pub use construct::{
     construct_with_budget, describe, describe_prepared, describe_prepared_with_budget,
     describe_with_budget, triples_to_ntriples,
 };
+// [OPUS-4.8] (sq-it1x) Opt-in MVCC / ACID transaction isolation. NON-DEFAULT `txn`
+// feature — when off, zero transaction code compiles and the default native + wasm builds
+// are byte-identical (no new deps). Built on the COW delta-overlay substrate
+// (`Graph::fork`/`snapshot`/`apply_delta`).
+#[cfg(feature = "txn")]
+pub mod txn;
 #[cfg(feature = "cs-planner")]
 pub use cs::{with_cs_table, CsSet, CsTable};
 pub use explain::{explain, explain_analyze, explain_analyze_with_budget};

--- a/crates/sparq-engine/src/txn.rs
+++ b/crates/sparq-engine/src/txn.rs
@@ -1,0 +1,525 @@
+//! [OPUS-4.8] (sq-it1x) MVCC / ACID multi-statement transaction isolation — OPT-IN
+//! (`txn` feature), built on the engine's existing copy-on-write delta-overlay substrate.
+//!
+//! # Model
+//!
+//! This is **snapshot isolation (SI)** with **first-committer-wins** write-write conflict
+//! detection (optimistic concurrency control), exactly the design the project's literature
+//! review records (`research/concurrent-serving-litreview-A-mvcc-benchmarks.md` §A.1):
+//!
+//! * A [`TransactionManager`] owns the current **committed generation** — an immutable
+//!   [`Graph`] published behind a lock, tagged with a monotonically increasing `u64`
+//!   commit version.
+//! * A **read transaction** ([`ReadTxn`], from [`TransactionManager::begin_read`]) holds a
+//!   cheap point-in-time [`GraphSnapshot`] of the generation that was committed when it
+//!   began. It reads a consistent state and is *immune to any later commit* — that is the
+//!   isolation guarantee. Snapshots are `O(pending delta)` (the immutable indexes / frozen
+//!   dictionary are `Arc`-shared by [`Graph::fork`]), never `O(triples)`.
+//! * A **write transaction** ([`WriteTxn`], from [`TransactionManager::begin_write`]) forks
+//!   the committed generation into a *private working copy*, captures the base version, and
+//!   applies SPARQL `UPDATE` statements to that fork — so it has read-your-own-writes while
+//!   staying invisible to everyone else. [`WriteTxn::commit`] then, under the manager lock,
+//!   checks the **first-committer-wins** rule: if any *other* writer has committed since this
+//!   txn began *and its write set overlaps this txn's write set*, the commit is rejected with
+//!   [`CommitError::Conflict`] and the whole body is discarded (atomic rollback). Otherwise the
+//!   working copy becomes the new committed generation and the version advances.
+//!
+//! # ACID
+//!
+//! * **Atomicity** — a `WriteTxn` body is applied to a private fork and only swapped into the
+//!   committed slot on success; on conflict (or `rollback`/drop) nothing is published.
+//! * **Consistency** — every transaction reads one committed snapshot; a writer evaluates its
+//!   `WHERE` clauses against (and only against) its own fork of that snapshot.
+//! * **Isolation** — snapshot isolation: readers never block writers or vice versa, and a
+//!   reader's view never changes underneath it.
+//! * **Durability** — inherited from the underlying [`Graph`]: a directory-backed graph
+//!   committed into the manager carries its WAL, so the published generation's deltas are
+//!   fsync'd by [`Graph::apply_delta`] as the working copy is built. (The in-memory manager is
+//!   non-durable by construction — like the rest of the in-memory engine.)
+//!
+//! # When SI is enough
+//!
+//! For a *single-writer* store (one in-flight `WriteTxn` at a time — the common SPARQL-endpoint
+//! shape) snapshot isolation **is** serializability, so the conflict check never fires and the
+//! cost is one fork + one swap per commit. The OCC check exists to keep *concurrent* writers
+//! safe: it rejects the classic lost-update / write-write race rather than silently dropping one
+//! writer's effect. SI's residual anomaly (write skew) requires two concurrent read-*write*
+//! transactions whose write sets are disjoint but whose invariants overlap; this module does not
+//! add the full SSI apparatus (it is dead weight for the single-writer case the design targets).
+
+use crate::update::UpdateEffect;
+use crate::QueryBudget;
+use oxrdf::Term;
+use rustc_hash::FxHashSet;
+use sparq_core::{Graph, GraphSnapshot};
+use spargebra::algebra::GraphTarget;
+use std::sync::{Arc, Mutex};
+
+/// A coarse, sound write-set key: the graph slot a write touched plus, for triple-level
+/// operations, the exact triple. `None` slot = the default graph; `Some(name)` = a named graph.
+///
+/// `Clear`/`Drop` of a whole graph (and `Drop` of *all* named graphs) cannot be enumerated to
+/// individual triples without scanning, so they record a *slot-level* key
+/// ([`WriteKey::Slot`] / [`WriteKey::AllNamed`] / [`WriteKey::Default`]) that conflicts with ANY
+/// other write touching the same slot. This over-approximates conflicts (it may reject two
+/// writers that a triple-exact analysis would have let through) but is never *unsound* — it can
+/// only refuse, never silently merge incompatible writes.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum WriteKey {
+    /// A single (slot, triple) touched by an insert or delete.
+    Triple(Option<Term>, [Term; 3]),
+    /// The entire default graph was rewritten wholesale (`CLEAR DEFAULT` / `DROP DEFAULT`).
+    Default,
+    /// One named graph was rewritten wholesale (`CLEAR GRAPH g` / `DROP GRAPH g`).
+    Slot(Term),
+    /// Every named graph was rewritten wholesale (`CLEAR NAMED` / `DROP NAMED`).
+    AllNamed,
+    /// The whole dataset was rewritten wholesale (`CLEAR ALL` / `DROP ALL`).
+    All,
+}
+
+impl WriteKey {
+    /// Whether two write keys conflict (touch overlapping data). Slot-level keys conflict with
+    /// any triple/slot key on the same slot; [`WriteKey::All`] conflicts with everything.
+    fn conflicts(&self, other: &WriteKey) -> bool {
+        use WriteKey::*;
+        match (self, other) {
+            // Anything touching the whole dataset conflicts with any other write.
+            (All, _) | (_, All) => true,
+            // Triple-vs-triple: an exact match.
+            (Triple(s1, t1), Triple(s2, t2)) => s1 == s2 && t1 == t2,
+            // A default-graph triple vs a default-graph wholesale rewrite.
+            (Triple(None, _), Default) | (Default, Triple(None, _)) | (Default, Default) => true,
+            // A named-graph triple vs that named graph's wholesale rewrite.
+            (Triple(Some(n1), _), Slot(n2)) | (Slot(n2), Triple(Some(n1), _)) => n1 == n2,
+            (Slot(n1), Slot(n2)) => n1 == n2,
+            // A named write of any kind vs an all-named wholesale rewrite.
+            (Triple(Some(_), _), AllNamed) | (AllNamed, Triple(Some(_), _)) => true,
+            (Slot(_), AllNamed) | (AllNamed, Slot(_)) | (AllNamed, AllNamed) => true,
+            // Default-graph and named-graph writes never collide; AllNamed never touches default.
+            _ => false,
+        }
+    }
+}
+
+/// The set of write keys one transaction touched. Conflict detection is the membership /
+/// overlap test between two such sets.
+#[derive(Debug, Clone, Default)]
+struct WriteSet {
+    triples: FxHashSet<(Option<Term>, [Term; 3])>,
+    slots: FxHashSet<WriteKey>,
+}
+
+impl WriteSet {
+    fn is_empty(&self) -> bool {
+        self.triples.is_empty() && self.slots.is_empty()
+    }
+
+    /// Folds one captured update's [`UpdateEffect`]s into the write set.
+    fn record(&mut self, effects: &[UpdateEffect]) {
+        for e in effects {
+            match e {
+                UpdateEffect::Delta { slot, inserts, deletes } => {
+                    for t in inserts.iter().chain(deletes.iter()) {
+                        self.triples.insert((slot.clone(), t.clone()));
+                    }
+                }
+                UpdateEffect::Clear(target) | UpdateEffect::Drop(target) => {
+                    self.slots.insert(target_key(target));
+                }
+                // CREATE of an empty graph touches no data — it cannot lose-update anyone.
+                UpdateEffect::Create(_) => {}
+            }
+        }
+    }
+
+    /// Whether this write set conflicts with `other` (any overlapping write key).
+    fn conflicts(&self, other: &WriteSet) -> bool {
+        // Fast path: two pure triple-level sets — hash-set intersection.
+        if !self.triples.is_empty() && !other.triples.is_empty() {
+            let (small, big) = if self.triples.len() <= other.triples.len() {
+                (&self.triples, &other.triples)
+            } else {
+                (&other.triples, &self.triples)
+            };
+            if small.iter().any(|k| big.contains(k)) {
+                return true;
+            }
+        }
+        // Slot-level keys conflict against the OTHER side's triples and slots (and vice versa).
+        for s in self.slots.iter().chain(other.slots.iter()) {
+            // Slot vs the opposite side's triples.
+            let side_triples = if self.slots.contains(s) { &other.triples } else { &self.triples };
+            if side_triples
+                .iter()
+                .any(|(slot, t)| s.conflicts(&WriteKey::Triple(slot.clone(), t.clone())))
+            {
+                return true;
+            }
+        }
+        // Slot vs slot (both directions).
+        self.slots.iter().any(|a| other.slots.iter().any(|b| a.conflicts(b)))
+    }
+}
+
+/// The slot-level write key a `CLEAR`/`DROP` target denotes.
+fn target_key(target: &GraphTarget) -> WriteKey {
+    match target {
+        GraphTarget::DefaultGraph => WriteKey::Default,
+        GraphTarget::NamedNode(n) => WriteKey::Slot(Term::NamedNode(n.clone())),
+        GraphTarget::NamedGraphs => WriteKey::AllNamed,
+        GraphTarget::AllGraphs => WriteKey::All,
+    }
+}
+
+/// One past commit, retained so a still-open writer that began before it can test for a
+/// write-write conflict at its own commit time.
+struct Committed {
+    version: u64,
+    write_set: WriteSet,
+}
+
+/// The manager's mutable state: the current committed generation, its version, and the log of
+/// recent commits (for conflict detection by stale writers).
+struct State {
+    graph: Arc<Graph>,
+    version: u64,
+    /// Commits in version order. Pruned to the oldest still-open writer's base version, so it
+    /// never grows unboundedly while writers are short-lived. `Default` (the empty manager) and
+    /// every commit append here; entries below the oldest open base are dropped on commit.
+    log: Vec<Committed>,
+    /// The lowest base version any currently-open write transaction is reading from — the
+    /// watermark below which the commit log can be pruned. `u64::MAX` when no writer is open.
+    oldest_open_base: u64,
+    /// Count of open write transactions (to maintain `oldest_open_base`).
+    open_writers: u64,
+}
+
+/// An MVCC transaction manager over a single logical [`Graph`].
+///
+/// Cheap to share across threads (`Arc<Mutex<…>>` internally); clone the [`Arc`] you wrap it in,
+/// or pass `&TransactionManager`. See the [module docs](self) for the isolation model.
+pub struct TransactionManager {
+    state: Mutex<State>,
+}
+
+impl TransactionManager {
+    /// Creates a manager whose initial committed generation is `graph` (committed version 0).
+    ///
+    /// The graph is taken by value and becomes the immutable base of generation 0; readers and
+    /// writers fork/snapshot it copy-on-write. For DURABILITY, pass a directory-backed graph
+    /// (opened from disk, under sparq-core's `mmap` feature) — its WAL travels with the published
+    /// generations.
+    pub fn new(graph: Graph) -> TransactionManager {
+        TransactionManager {
+            state: Mutex::new(State {
+                graph: Arc::new(graph),
+                version: 0,
+                log: Vec::new(),
+                oldest_open_base: u64::MAX,
+                open_writers: 0,
+            }),
+        }
+    }
+
+    /// The current committed version (advances by 1 on every successful [`WriteTxn::commit`]
+    /// that published a change; an empty/no-op commit does not advance it).
+    pub fn committed_version(&self) -> u64 {
+        self.lock().version
+    }
+
+    /// A read-only, point-in-time snapshot of the *current* committed generation — the same
+    /// state a [`begin_read`](Self::begin_read) transaction would see, without the version
+    /// bookkeeping. Immutable and immune to later commits.
+    pub fn snapshot(&self) -> GraphSnapshot {
+        self.lock().graph.snapshot()
+    }
+
+    /// Begins a snapshot-isolation **read** transaction over the current committed generation.
+    /// Its view is fixed at begin time and unaffected by any later commit.
+    pub fn begin_read(&self) -> ReadTxn {
+        let st = self.lock();
+        ReadTxn { snapshot: st.graph.snapshot(), version: st.version }
+    }
+
+    /// Begins a **write** transaction: forks the current committed generation into a private
+    /// working copy and records the base version. Apply statements with [`WriteTxn::update`],
+    /// then [`WriteTxn::commit`] (first-committer-wins) or [`WriteTxn::rollback`] (discard).
+    pub fn begin_write(&self) -> WriteTxn<'_> {
+        let mut st = self.lock();
+        let base_version = st.version;
+        let working = st.graph.fork();
+        st.open_writers += 1;
+        st.oldest_open_base = st.oldest_open_base.min(base_version);
+        WriteTxn {
+            manager: self,
+            working: Some(working),
+            base_version,
+            write_set: WriteSet::default(),
+            effects: Vec::new(),
+            finished: false,
+        }
+    }
+
+    /// Consumes the manager, returning the current committed generation as an owned [`Graph`].
+    ///
+    /// Any outstanding [`ReadTxn`]/[`WriteTxn`] borrow `&self`, so they must have ended (or never
+    /// existed) for this to be callable. If another `Arc` clone of the committed generation is
+    /// still alive (e.g. a leaked snapshot), the graph is cloned out via a fork.
+    pub fn into_inner(self) -> Graph {
+        let state = self.state.into_inner().unwrap_or_else(|e| e.into_inner());
+        Arc::try_unwrap(state.graph).unwrap_or_else(|arc| arc.fork())
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, State> {
+        self.state.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// A writer ended (committed or rolled back): decrement the open-writer count and, when the
+    /// last one closes, reset the prune watermark.
+    fn writer_closed(st: &mut State) {
+        st.open_writers = st.open_writers.saturating_sub(1);
+        if st.open_writers == 0 {
+            st.oldest_open_base = u64::MAX;
+            st.log.clear(); // no open writer can need the conflict history any more
+        }
+    }
+}
+
+/// A snapshot-isolation read transaction. Derefs to [`&Graph`](Graph), so it is queryable with
+/// every read entry point ([`crate::query`], [`crate::ask`], [`crate::count`], …). Its view is
+/// fixed at [`begin_read`](TransactionManager::begin_read) time.
+pub struct ReadTxn {
+    snapshot: GraphSnapshot,
+    version: u64,
+}
+
+impl ReadTxn {
+    /// The committed version this read transaction is observing.
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+
+    /// The point-in-time graph (also reachable via the [`Deref`](std::ops::Deref) impl).
+    pub fn graph(&self) -> &Graph {
+        &self.snapshot
+    }
+}
+
+impl std::ops::Deref for ReadTxn {
+    type Target = Graph;
+    fn deref(&self) -> &Graph {
+        &self.snapshot
+    }
+}
+
+/// A write transaction over a private working copy of a committed generation.
+///
+/// Apply SPARQL `UPDATE` statements with [`update`](Self::update) (each is request-atomic against
+/// the working copy), read its in-progress state with [`graph`](Self::graph) (read-your-own-
+/// writes), then [`commit`](Self::commit) (first-committer-wins) or [`rollback`](Self::rollback).
+/// Dropping a `WriteTxn` without committing rolls it back.
+pub struct WriteTxn<'m> {
+    manager: &'m TransactionManager,
+    /// The private fork. `Some` until the txn finishes (commit/rollback takes it).
+    working: Option<Graph>,
+    base_version: u64,
+    write_set: WriteSet,
+    /// The ordered, RESOLVED effect log of every statement applied — replayed onto the
+    /// *current* committed generation at commit time so a stale-but-non-conflicting writer
+    /// re-applies its delta rather than publishing its (now out-of-date) private fork wholesale
+    /// (which would lose-update the intervening committer). Deterministic by construction (it
+    /// carries resolved triples), so replay reproduces exactly what the working copy committed.
+    effects: Vec<UpdateEffect>,
+    finished: bool,
+}
+
+impl WriteTxn<'_> {
+    /// The base committed version this transaction forked from.
+    pub fn base_version(&self) -> u64 {
+        self.base_version
+    }
+
+    /// The private working copy, reflecting every [`update`](Self::update) applied so far. Read
+    /// it with any read entry point for read-your-own-writes inside the transaction.
+    pub fn graph(&self) -> &Graph {
+        self.working.as_ref().expect("write txn already finished")
+    }
+
+    /// Applies one SPARQL `UPDATE` request to the working copy (request-atomic: a parse error or
+    /// failing operation leaves the working copy unchanged), recording the *resolved* write set
+    /// for commit-time conflict detection.
+    ///
+    /// The whole request body is applied through the engine's request-atomic in-place path, so a
+    /// later operation that fails rolls THIS statement back without affecting earlier committed
+    /// statements in the same transaction.
+    pub fn update(&mut self, sparql: &str) -> Result<(), String> {
+        self.update_with_budget(sparql, &QueryBudget::unlimited())
+    }
+
+    /// [`update`](Self::update) under a cooperative [`QueryBudget`] (bounds a `DELETE/INSERT …
+    /// WHERE` exactly as the budgeted engine entry points do).
+    pub fn update_with_budget(&mut self, sparql: &str, budget: &QueryBudget) -> Result<(), String> {
+        let working = self.working.as_mut().expect("write txn already finished");
+        // Apply to a throwaway fork first so a failure leaves the working copy untouched
+        // (request-atomicity across the txn's statements), capturing the resolved write set.
+        let mut staged = working.fork();
+        let effects = crate::update::update_in_place_capturing(&mut staged, sparql, budget)?;
+        // Success: adopt the staged state, fold the write set in, and keep the resolved effect
+        // log so a stale-but-non-conflicting commit can replay this delta onto the current
+        // committed generation rather than publishing the (then out-of-date) private fork.
+        *working = staged;
+        self.write_set.record(&effects);
+        self.effects.extend(effects);
+        Ok(())
+    }
+
+    /// Commits the transaction (first-committer-wins). Returns the new committed version on
+    /// success, or [`CommitError::Conflict`] if a concurrent writer committed an overlapping
+    /// write set since this transaction began (in which case the whole body is discarded).
+    ///
+    /// An *empty* write set (no data-touching statement) always commits and never conflicts; if
+    /// nothing was published the version is unchanged.
+    pub fn commit(mut self) -> Result<u64, CommitError> {
+        let working = self.working.take().expect("write txn already finished");
+        self.finished = true;
+        let mut st = self.manager.lock();
+
+        let stale = st.version != self.base_version;
+
+        // First-committer-wins: if other writers committed since our base, conflict iff any of
+        // their write sets overlaps ours. An empty write set can never overlap, so it is exempt.
+        if stale && !self.write_set.is_empty() {
+            let conflict = st
+                .log
+                .iter()
+                .filter(|c| c.version > self.base_version)
+                .any(|c| c.write_set.conflicts(&self.write_set));
+            if conflict {
+                let current = st.version;
+                TransactionManager::writer_closed(&mut st);
+                return Err(CommitError::Conflict { base: self.base_version, current });
+            }
+        }
+
+        // No conflict: publish. An empty write set publishes nothing (version unchanged), so a
+        // read-only "transaction" committed for symmetry costs nothing.
+        if self.write_set.is_empty() {
+            TransactionManager::writer_closed(&mut st);
+            return Ok(st.version);
+        }
+
+        // The published generation. When we are up to date (base == current) the private fork
+        // already reflects exactly the right state, so publish it directly. When we are
+        // stale-but-non-conflicting, the private fork is built atop an OLD base and would
+        // lose-update the intervening committer if published wholesale; instead REPLAY this
+        // txn's resolved effect log onto a fork of the CURRENT committed generation. Replay is
+        // deterministic (the effects carry resolved triples), and disjointness was just proven,
+        // so the result is the merge of both writers' deltas.
+        let published = if stale {
+            let mut merged = st.graph.fork();
+            crate::update::apply_effects(&mut merged, &self.effects)
+                .map_err(|_| CommitError::Conflict { base: self.base_version, current: st.version })?;
+            merged
+        } else {
+            working
+        };
+
+        let new_version = st.version + 1;
+        st.graph = Arc::new(published);
+        st.version = new_version;
+        st.log.push(Committed { version: new_version, write_set: std::mem::take(&mut self.write_set) });
+        TransactionManager::writer_closed(&mut st);
+        // Prune commit history below the oldest still-open writer's base — those entries can no
+        // longer be needed by any open transaction's conflict check.
+        let watermark = st.oldest_open_base;
+        st.log.retain(|c| c.version > watermark);
+        Ok(new_version)
+    }
+
+    /// Discards the transaction's working copy without publishing anything. (Dropping the
+    /// `WriteTxn` does the same — this is the explicit, intention-revealing form.)
+    pub fn rollback(mut self) {
+        self.working.take();
+        self.finished = true;
+        let mut st = self.manager.lock();
+        TransactionManager::writer_closed(&mut st);
+    }
+}
+
+impl Drop for WriteTxn<'_> {
+    fn drop(&mut self) {
+        // A txn dropped without commit/rollback (e.g. on a `?` early-return) must still release
+        // its open-writer slot so the conflict log can be pruned.
+        if !self.finished {
+            let mut st = self.manager.lock();
+            TransactionManager::writer_closed(&mut st);
+        }
+    }
+}
+
+/// Why a [`WriteTxn::commit`] failed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommitError {
+    /// A concurrent writer committed an overlapping write set since this transaction began
+    /// (first-committer-wins). The transaction's body has been fully discarded; the caller may
+    /// retry against the new committed state. `base` is the version this txn forked from;
+    /// `current` is the committed version it lost the race to.
+    Conflict { base: u64, current: u64 },
+}
+
+impl std::fmt::Display for CommitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CommitError::Conflict { base, current } => write!(
+                f,
+                "transaction commit conflict: forked from version {base} but the committed version is now {current} with an overlapping write set (first-committer-wins; retry)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CommitError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn g(src: &str) -> Graph {
+        Graph::load_str(src, "turtle").unwrap()
+    }
+
+    #[test]
+    fn write_key_default_vs_named_disjoint() {
+        let nn = |s: &str| Term::NamedNode(oxrdf::NamedNode::new(s).unwrap());
+        let t = [nn("http://x/s"), nn("http://x/p"), nn("http://x/o")];
+        let def = WriteKey::Triple(None, t.clone());
+        let named = WriteKey::Triple(Some(nn("http://x/g")), t.clone());
+        assert!(!def.conflicts(&named), "default-graph and named-graph triples must be disjoint");
+        assert!(def.conflicts(&WriteKey::Default));
+        assert!(named.conflicts(&WriteKey::Slot(nn("http://x/g"))));
+        assert!(!named.conflicts(&WriteKey::Slot(nn("http://x/other"))));
+        assert!(WriteKey::All.conflicts(&named));
+    }
+
+    #[test]
+    fn empty_writeset_never_conflicts() {
+        let nn = |s: &str| Term::NamedNode(oxrdf::NamedNode::new(s).unwrap());
+        let mut a = WriteSet::default();
+        a.triples.insert((None, [nn("http://x/s"), nn("http://x/p"), nn("http://x/o")]));
+        assert!(!a.conflicts(&WriteSet::default()));
+        assert!(!WriteSet::default().conflicts(&a));
+    }
+
+    #[test]
+    fn manager_round_trips_a_simple_commit() {
+        let m = TransactionManager::new(g("@prefix : <http://ex/> . :a :p :b ."));
+        assert_eq!(m.committed_version(), 0);
+        let mut w = m.begin_write();
+        w.update("PREFIX : <http://ex/> INSERT DATA { :x :p :y }").unwrap();
+        let v = w.commit().unwrap();
+        assert_eq!(v, 1);
+        let r = m.begin_read();
+        assert_eq!(crate::count(&r, "SELECT * WHERE { ?s ?p ?o }").unwrap(), 2);
+    }
+}

--- a/crates/sparq-engine/tests/mvcc_txn.rs
+++ b/crates/sparq-engine/tests/mvcc_txn.rs
@@ -1,0 +1,253 @@
+//! [OPUS-4.8] (sq-it1x) MVCC / ACID transaction-isolation tests.
+//!
+//! Snapshot isolation over the COW delta-overlay substrate (`Graph::fork`/`snapshot`/
+//! `apply_delta`) with first-committer-wins write-write conflict detection — the
+//! ACID contract these tests pin:
+//!   * Isolation  — a read txn sees a stable point-in-time, immune to later commits.
+//!   * Atomicity  — a write txn's body publishes all-or-nothing; rollback shows nothing.
+//!   * Consistency — read-your-own-writes within a write txn.
+//!   * Concurrency — first-committer-wins: a stale, conflicting writer is rejected; a
+//!     stale, NON-conflicting (disjoint write set) writer still commits.
+//!
+//! Only compiled under the opt-in `txn` feature.
+#![cfg(feature = "txn")]
+
+use sparq_core::Graph;
+use sparq_engine::txn::{CommitError, TransactionManager};
+
+const SRC: &str = "@prefix : <http://ex/> . :a :p :b . :b :p :c .";
+
+fn mgr() -> TransactionManager {
+    TransactionManager::new(Graph::load_str(SRC, "turtle").unwrap())
+}
+
+fn ask(g: &Graph, q: &str) -> bool {
+    sparq_engine::ask(g, &format!("PREFIX : <http://ex/> {q}")).unwrap()
+}
+
+fn count_all(g: &Graph) -> usize {
+    sparq_engine::count(g, "SELECT * WHERE { ?s ?p ?o }").unwrap()
+}
+
+#[test]
+fn read_txn_is_isolated_from_later_commits() {
+    let m = mgr();
+    let snap = m.begin_read();
+    assert_eq!(count_all(&snap), 2);
+
+    // A writer commits AFTER the read txn began.
+    let mut w = m.begin_write();
+    w.update("PREFIX : <http://ex/> INSERT DATA { :x :p :y }").unwrap();
+    w.commit().unwrap();
+
+    // The read txn STILL sees its point-in-time state (snapshot isolation).
+    assert_eq!(count_all(&snap), 2, "read txn must not observe the later commit");
+    // A fresh read sees the new state.
+    assert_eq!(count_all(&m.begin_read()), 3);
+}
+
+#[test]
+fn write_txn_reads_its_own_writes_but_others_dont_until_commit() {
+    let m = mgr();
+    let mut w = m.begin_write();
+    w.update("PREFIX : <http://ex/> INSERT DATA { :x :p :y }").unwrap();
+
+    // Read-your-own-writes inside the txn.
+    assert!(ask(w.graph(), "ASK { :x :p :y }"));
+    // But the uncommitted write is invisible to a concurrent read txn.
+    assert!(!ask(&m.begin_read(), "ASK { :x :p :y }"), "uncommitted write must be invisible");
+
+    let v = w.commit().unwrap();
+    assert!(v >= 1);
+    // After commit, a new read txn sees it.
+    assert!(ask(&m.begin_read(), "ASK { :x :p :y }"));
+}
+
+#[test]
+fn rollback_discards_the_whole_body() {
+    let m = mgr();
+    let mut w = m.begin_write();
+    w.update("PREFIX : <http://ex/> INSERT DATA { :x :p :y }").unwrap();
+    w.update("PREFIX : <http://ex/> DELETE DATA { :a :p :b }").unwrap();
+    w.rollback(); // drop without commit
+
+    let r = m.begin_read();
+    assert!(!ask(&r, "ASK { :x :p :y }"), "rolled-back insert must not persist");
+    assert!(ask(&r, "ASK { :a :p :b }"), "rolled-back delete must not persist");
+    assert_eq!(count_all(&r), 2);
+}
+
+#[test]
+fn first_committer_wins_on_conflicting_write_set() {
+    let m = mgr();
+    // Two writers both begin against the SAME base version.
+    let mut w1 = m.begin_write();
+    let mut w2 = m.begin_write();
+
+    // They write OVERLAPPING triples (both touch :a :p :b).
+    w1.update("PREFIX : <http://ex/> DELETE DATA { :a :p :b }").unwrap();
+    w2.update("PREFIX : <http://ex/> DELETE DATA { :a :p :b } ; INSERT DATA { :a :p :z }").unwrap();
+
+    // First committer wins.
+    w1.commit().unwrap();
+    // Second committer is stale AND conflicting -> rejected.
+    let err = w2.commit().unwrap_err();
+    assert!(matches!(err, CommitError::Conflict { .. }), "expected a write-write conflict, got {err:?}");
+
+    // The store reflects ONLY w1's effect.
+    let r = m.begin_read();
+    assert!(!ask(&r, "ASK { :a :p :b }"));
+    assert!(!ask(&r, "ASK { :a :p :z }"), "w2 must have been fully rolled back");
+}
+
+#[test]
+fn stale_but_disjoint_writer_still_commits() {
+    let m = mgr();
+    let mut w1 = m.begin_write();
+    let mut w2 = m.begin_write();
+
+    // DISJOINT write sets (different triples).
+    w1.update("PREFIX : <http://ex/> INSERT DATA { :x :p :y }").unwrap();
+    w2.update("PREFIX : <http://ex/> INSERT DATA { :u :p :v }").unwrap();
+
+    w1.commit().unwrap();
+    // w2 is stale but does not conflict -> first-committer-wins lets it through.
+    w2.commit().expect("a disjoint stale writer must still commit under SI");
+
+    let r = m.begin_read();
+    assert!(ask(&r, "ASK { :x :p :y }"));
+    assert!(ask(&r, "ASK { :u :p :v }"));
+    assert_eq!(count_all(&r), 4);
+}
+
+#[test]
+fn committed_version_advances_monotonically() {
+    let m = mgr();
+    let v0 = m.committed_version();
+    let mut w = m.begin_write();
+    w.update("PREFIX : <http://ex/> INSERT DATA { :x :p :y }").unwrap();
+    let v1 = w.commit().unwrap();
+    assert!(v1 > v0, "commit must advance the version");
+    assert_eq!(m.committed_version(), v1);
+}
+
+#[test]
+fn empty_write_txn_commit_is_a_noop_and_never_conflicts() {
+    let m = mgr();
+    let v0 = m.committed_version();
+    // Two empty writers: neither has a write set, so neither can conflict.
+    let w1 = m.begin_write();
+    let mut w2 = m.begin_write();
+    w2.update("PREFIX : <http://ex/> INSERT DATA { :x :p :y }").unwrap();
+    w2.commit().unwrap();
+    // The empty writer commits fine even though it is now stale.
+    w1.commit().expect("an empty txn never conflicts");
+    assert!(m.committed_version() > v0);
+    assert_eq!(count_all(&m.begin_read()), 3);
+}
+
+#[test]
+fn delete_insert_where_write_set_participates_in_conflict_detection() {
+    let m = mgr();
+    let mut w1 = m.begin_write();
+    let mut w2 = m.begin_write();
+
+    // w1 rewrites :a :p :b -> :a :p :rewritten via DELETE/INSERT WHERE.
+    w1.update(
+        "PREFIX : <http://ex/> DELETE { :a :p ?o } INSERT { :a :p :rewritten } WHERE { :a :p ?o }",
+    )
+    .unwrap();
+    // w2 also deletes the same triple.
+    w2.update("PREFIX : <http://ex/> DELETE DATA { :a :p :b }").unwrap();
+
+    w1.commit().unwrap();
+    let err = w2.commit().unwrap_err();
+    assert!(matches!(err, CommitError::Conflict { .. }));
+
+    let r = m.begin_read();
+    assert!(ask(&r, "ASK { :a :p :rewritten }"));
+}
+
+#[test]
+fn into_inner_returns_the_committed_graph() {
+    let m = mgr();
+    let mut w = m.begin_write();
+    w.update("PREFIX : <http://ex/> INSERT DATA { :x :p :y }").unwrap();
+    w.commit().unwrap();
+    let g = m.into_inner();
+    assert!(ask(&g, "ASK { :x :p :y }"));
+}
+
+#[test]
+fn named_graph_writes_conflict_only_within_the_same_graph() {
+    let m = mgr();
+    let mut w1 = m.begin_write();
+    let mut w2 = m.begin_write();
+
+    // Same triple shape, but in DIFFERENT named graphs -> disjoint slots, no conflict.
+    w1.update("PREFIX : <http://ex/> INSERT DATA { GRAPH :g1 { :s :p :o } }").unwrap();
+    w2.update("PREFIX : <http://ex/> INSERT DATA { GRAPH :g2 { :s :p :o } }").unwrap();
+    w1.commit().unwrap();
+    w2.commit().expect("writes to different named graphs do not conflict");
+
+    // But same triple in the SAME named graph DOES conflict.
+    let mut w3 = m.begin_write();
+    let mut w4 = m.begin_write();
+    w3.update("PREFIX : <http://ex/> DELETE DATA { GRAPH :g1 { :s :p :o } }").unwrap();
+    w4.update("PREFIX : <http://ex/> DELETE DATA { GRAPH :g1 { :s :p :o } }").unwrap();
+    w3.commit().unwrap();
+    assert!(matches!(w4.commit().unwrap_err(), CommitError::Conflict { .. }));
+}
+
+#[test]
+fn stale_disjoint_commit_preserves_both_writers_data() {
+    // The lost-update guard: a stale-but-disjoint writer must MERGE its delta onto the
+    // intervening commit, not publish its own out-of-date fork wholesale.
+    let m = mgr();
+    let mut w1 = m.begin_write();
+    let mut w2 = m.begin_write();
+    w1.update("PREFIX : <http://ex/> DELETE DATA { :a :p :b } ; INSERT DATA { :w1 :p :one }").unwrap();
+    w2.update("PREFIX : <http://ex/> INSERT DATA { :w2 :p :two }").unwrap();
+    w1.commit().unwrap();
+    w2.commit().unwrap();
+
+    let r = m.begin_read();
+    // w1's delete + insert survived w2's later commit; w2's insert is also present.
+    assert!(!ask(&r, "ASK { :a :p :b }"), "w1's delete must survive w2's stale commit");
+    assert!(ask(&r, "ASK { :w1 :p :one }"));
+    assert!(ask(&r, "ASK { :w2 :p :two }"));
+}
+
+#[test]
+fn concurrent_writers_are_serialized_one_wins_on_conflict() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let m = Arc::new(mgr());
+    let mut handles = Vec::new();
+    // Many threads racing to delete the SAME triple: under first-committer-wins exactly one
+    // succeeds; the rest get a Conflict (or commit a no-op if they began after the winner).
+    for _ in 0..8 {
+        let m = Arc::clone(&m);
+        handles.push(thread::spawn(move || {
+            let mut w = m.begin_write();
+            w.update("PREFIX : <http://ex/> DELETE DATA { :a :p :b }").unwrap();
+            w.commit().is_ok()
+        }));
+    }
+    let oks = handles.into_iter().map(|h| h.join().unwrap()).filter(|&ok| ok).count();
+    assert!(oks >= 1, "at least one writer must commit");
+    // The store is consistent: the triple is gone exactly once, no panic / no torn state.
+    assert!(!ask(&m.begin_read(), "ASK { :a :p :b }"));
+}
+
+#[test]
+fn parse_error_in_update_is_reported_and_txn_stays_usable() {
+    let m = mgr();
+    let mut w = m.begin_write();
+    assert!(w.update("NOT VALID SPARQL").is_err());
+    // The txn is still usable after a rejected statement (its working copy is unchanged).
+    w.update("PREFIX : <http://ex/> INSERT DATA { :x :p :y }").unwrap();
+    w.commit().unwrap();
+    assert!(ask(&m.begin_read(), "ASK { :x :p :y }"));
+}

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -402,6 +402,35 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   let r3 = cache.get_or_eval(&graph, &q, version, &QueryBudget::unlimited())?; // miss (fresh)
   # Ok::<(), String>(())
   ```
+- **MVCC / ACID transaction isolation** is the non-default `txn` cargo feature (bead `sq-it1x`):
+  `txn::TransactionManager::new(graph)` owns one logical graph and hands out **snapshot-isolation**
+  read transactions (`begin_read()` → a cheap point-in-time view that derefs to `&Graph`, immune to
+  later commits) and serialized **write** transactions (`begin_write()` → a copy-on-write fork).
+  `WriteTxn::update(sparql)` applies SPARQL `UPDATE`s to the private fork (read-your-own-writes via
+  `w.graph()`); `commit()` returns the new `u64` version, or `CommitError::Conflict` under
+  **first-committer-wins** if a concurrent writer published an overlapping write set since the txn
+  began (the whole body is then discarded — atomic rollback). A stale but *non*-conflicting writer's
+  resolved delta is replayed onto the current generation, so no commit is lost. For a single writer
+  the conflict check never fires (SI = serializability); durability is inherited from a directory-
+  backed graph's WAL. Built on the COW delta-overlay substrate; when off, zero txn code compiles and
+  the default build is byte-identical (no new deps).
+
+  ```rust
+  // Cargo.toml: sparq-engine = { version = "0.1", features = ["txn"] }
+  use sparq_engine::txn::{CommitError, TransactionManager};
+  let m = TransactionManager::new(graph);
+  // Snapshot-isolation read: this view never changes underneath us.
+  let snap = m.begin_read();
+  let _n = sparq_engine::count(&snap, "SELECT * WHERE { ?s ?p ?o }")?;
+  // Write txn: fork, mutate the private copy, commit (first-committer-wins).
+  let mut w = m.begin_write();
+  w.update("INSERT DATA { <http://ex/s> <http://ex/p> <http://ex/o> }")?;
+  match w.commit() {
+      Ok(version) => println!("committed as v{version}"),
+      Err(CommitError::Conflict { .. }) => { /* retry against the new state */ }
+  }
+  # Ok::<(), String>(())
+  ```
 - **Default cargo features** (`parallel`, `regex`, `digest`): `regex` powers REGEX/REPLACE; `digest`
   powers MD5/SHA*; `parallel` enables rayon scan/join/sort/aggregate. The **wasm** crate
   (`sparq-wasm`) disables defaults, so on `wasm32-unknown-unknown` REGEX/hash builtins and


### PR DESCRIPTION
> 🤖 SPARQ agent — automated change by an AI agent operating on @jeswr's behalf. Reply here and I'll pick it up.

Implements **sq-it1x** — MVCC / ACID multi-statement transaction isolation for `sparq-engine`, **opt-in** (non-default `txn` cargo feature), reusing the existing copy-on-write **snapshot / delta-overlay** substrate. Core stays lean: when the feature is off, zero txn code compiles and the default native + wasm builds are byte-identical (no new dependencies).

## What it adds

A `txn::TransactionManager` over a single logical `Graph`:

- **`begin_read()` → `ReadTxn`** — snapshot isolation. Holds a cheap point-in-time `GraphSnapshot` (`O(pending delta)`, never `O(triples)`); derefs to `&Graph` so it queries with every read entry point. Its view is fixed at begin time and **immune to any later commit**.
- **`begin_write()` → `WriteTxn`** — forks the committed generation into a private working copy. `update(sparql)` applies SPARQL `UPDATE`s to the fork (read-your-own-writes via `w.graph()`); `commit()` returns the new `u64` version or `CommitError::Conflict`; `rollback()` / drop discards.
- **`committed_version()`**, **`snapshot()`**, **`into_inner()`**.

## Isolation / conflict model

**Snapshot isolation + first-committer-wins** (optimistic concurrency control), per the project's design record (`research/concurrent-serving-litreview-A-mvcc-benchmarks.md` §A.1):

- For a **single writer**, SI = serializability — the conflict check never fires; cost is one fork + one swap per commit.
- For **concurrent writers**, a writer that became stale **and** whose write set overlaps an intervening commit is rejected with `CommitError::Conflict` (whole body discarded — atomic rollback). A stale **but disjoint** writer has its *resolved* delta replayed onto the current generation via `apply_effects`, so **no commit is lost**.
- Write keys are triple-exact per graph slot; `CLEAR`/`DROP` record slot-level keys (a sound over-approximation — it can only refuse, never silently merge incompatible writes).

## ACID

- **Atomicity** — body applies to a private fork, swapped in only on success.
- **Consistency** — each txn reads one committed snapshot; a writer's `WHERE` runs against its own fork.
- **Isolation** — readers never block writers or vice versa; a reader's view never changes underneath it.
- **Durability** — inherited from the underlying `Graph`'s WAL when directory-backed.

## Tests

`tests/mvcc_txn.rs` (13) + module unit tests (3) = **16**: read isolation vs later commits, read-your-own-writes, atomic rollback, first-committer-wins on conflict, **stale-disjoint commit preserving both writers' data** (lost-update guard), monotonic version, empty-txn no-op, `DELETE/INSERT … WHERE` write sets in conflict detection, named-graph slot disjointness, and a multi-threaded race. Written test-first (red → green).

All 16 are behind `#[cfg(feature = "txn")]` / `#![cfg(feature = "txn")]`, so the default-feature build (and `ci.yml`'s `--workspace --all-targets` archive, which passes no `--features`) compiled them EMPTY — they **never ran in CI**. Fixed in this PR: a **`sparq-engine (txn)` leg** in `.github/workflows/feature-matrix.yml` now runs `cargo build/test/clippy -p sparq-engine --features txn`, so all 16 tests are exercised and the module is clippy-gated on every PR/merge. The leg name carries neither "advisory" nor "informational", so the required `ci-summary / gate` aggregator discovers it as a REQUIRED check. Verified locally: `cargo test -p sparq-engine --features txn` → 3 `txn::tests::*` + 13 `mvcc_txn` = 16 passing; `cargo clippy -p sparq-engine --features txn --all-targets -- -D warnings` clean.

## Gate

Built/clippy/tested in **both** feature states (default + `txn`); rustdoc gate (`RUSTDOCFLAGS='-D warnings'`) clean for `--features txn` and `--all-features`; privacy-claims gate OK; `forbid(unsafe_code)` (no unsafe added). README + `skills/sparql-query/SKILL.md` document the new surface (G2).

**rustfmt (correction):** an earlier version of this PR text claimed `cargo fmt -p sparq-engine --check` showed no diffs in the new files — that was wrong. `cargo fmt --check` does report wrap diffs in `txn.rs`/`mvcc_txn.rs` (e.g. long `.update(…).unwrap()` chains and struct destructuring that default rustfmt would re-wrap below `max_width`). This is **the same pre-existing wrap style as the rest of the crate** — `cargo fmt -p sparq-engine --check` reports diffs in ~30 engine files (`exec.rs`, `update.rs`, `lib.rs`, `aggregate.rs`, …), not just the new ones — and rustfmt is **informational / `continue-on-error`** in this workspace (`ci.yml`'s `rustfmt (informational)` step, pending the deferred one-time `cargo fmt --all` reformat noted in `rustfmt.toml`). The new files intentionally match the crate's current style rather than pre-empting that workspace-wide reformat, so fmt does not (and should not) block this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
