### PR TITLE
ci(unsafe-ratchet): mark geiger gate-promotion follow-up done (sq-4plh) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1189,8 +1189,18 @@ jobs:
     # zero-copy dictionary, SIMD) so a PR that ADDS unsafe is visible in the run summary
     # without blocking. Non-gating by design: every step is `continue-on-error: true`
     # (cargo-geiger fails the run on some dependency-graph shapes, and we never want this
-    # report to break CI). Promote to a gate later only with a checked-in unsafe-count
-    # ratchet (mirroring the coverage/conformance idiom) — out of scope here.
+    # report to break CI).
+    #
+    # [OPUS-4.8] sq-4plh: the "promote to a gate later only with a checked-in unsafe-count
+    # ratchet (mirroring the coverage/conformance idiom)" follow-up this comment used to
+    # anticipate IS NOW DONE — see the `unsafe-register (count ratchet)` job above
+    # (sq-toze.6 / cert gap GX-5, PR #217): it ratchets the first-party `unsafe` count per
+    # crate against the checked-in floor in `bench/unsafe-snapshot.json` (the
+    # `bench/coverage-floor.json` analogue) and FAILS a PR that adds an unsafe site without
+    # a `compliance/memsafety/unsafe-register.md` row + re-seed. That job — not this one —
+    # is the gate; this `geiger` job stays informational (cargo-geiger is too heavy/flaky
+    # for a per-PR gating lane), so the two are complementary: GATE via the source-scan
+    # ratchet, VISIBILITY via cargo-geiger.
     name: unsafe report (cargo-geiger, informational)
     needs: changes
     if: needs.changes.outputs.rust_changed == 'true'


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Re-review when Fable returns ([OPUS-4.8] marker on the touched comment).

## What & why (sq-4plh)

Bead **sq-4plh** asked to *"promote the sq-emay cargo-geiger job to a gate"* by adding a checked-in unsafe-site count floor (mirroring `bench/coverage-floor.json` + the conformance ratchet idiom), so a PR that ADDS new `unsafe` must justify it / bump the floor.

**That deliverable already exists on `main`.** It landed via the parallel certification track (sq-toze.6 / cert gap GX-5, **PR #217**):

- **Gate job** — `unsafe-register (count ratchet)` in `.github/workflows/ci.yml` runs `python3 scripts/unsafe-gate.py --check`. Its name carries **no** `advisory`/`informational` token, so `ci-summary` treats it as a **required gating** check (unlike the still-informational `geiger` job).
- **Checked-in floor** — `bench/unsafe-snapshot.json` (the `coverage-floor.json` analogue): per-crate first-party `unsafe` counts (59 total across 5 crates; the other 30 are `#![forbid(unsafe_code)]`). A PR that raises a crate's count without re-seeding **fails CI**.
- **Justification register** — `compliance/memsafety/unsafe-register.md`, kept at 100% coverage by `clippy::undocumented_unsafe_blocks` + the ratchet + a required `// SAFETY:` comment per site.
- **Source-scan, not cargo-geiger** — geiger cannot run the virtual workspace manifest and is too heavy/flaky for a per-PR gate; the deterministic comment/string-stripping source scan is what is ratcheted.

So the only honest, in-scope work left for sq-4plh is to **retire the now-stale comment**: the `geiger` job's block still said *"Promote to a gate later only with a checked-in unsafe-count ratchet … out of scope here"*, as if the promotion were still pending — when that gate is the `unsafe-register` job sitting directly above it. The next reader would otherwise re-do already-done work.

## Change

**Comment-only** edit to the `geiger` job in `.github/workflows/ci.yml`:
- removes the stale *"out of scope here"* note,
- points at the live `unsafe-register` gate (sq-toze.6 / GX-5 / #217) and `bench/unsafe-snapshot.json`,
- clarifies that `geiger` (informational, cargo-geiger visibility) and `unsafe-register` (gating, source-scan ratchet) are **complementary**.

No behaviour change, no Rust touched, no public API touched, no `unsafe` added.

## Gate

- `python3 -c "import yaml; …"` — `ci.yml` parses; 17 jobs intact; `geiger` + `unsafe-register` job names unchanged.
- `git diff` confirms the change is **comment-only** (no non-`#` line changed).
- `python3 scripts/unsafe-gate.py --check` → **PASS** (live 59 == snapshot 59).
- Rust build/clippy/test/rustdoc gate: **N/A** (no Rust changed). G2 public-api→SKILL: **N/A**. unsafe-gate `--seed`: **N/A** (no new unsafe). Privacy-claims gate: **N/A**.

## Honesty note

This PR does **not** add new gating machinery — that already exists and is sound. It is a small hygiene fix that closes out sq-4plh by making the source reflect reality. If a reviewer prefers to instead close sq-4plh as a duplicate of sq-toze.6 with no code change, that is equally defensible; this PR errs toward leaving an accurate breadcrumb in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)