### PR TITLE
docs(sparq-server): drop redundant de-stale breadcrumb after WAL-durable CLEAR/DROP landed (sq-1ys1) [OPUS-4.8]

### DIFF
--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -421,10 +421,7 @@ Semantics:
   snapshots, block-level COW history, external backups) — those remain the operator's
   responsibility. See `compliance/privacy/retention-erasure-runbook.md` §7a.
 - **Deferred hardening (beaded, not yet wired):** byte-accounted durability metrics and online
-  compaction tuning under sustained write load. <!-- [OPUS-4.8] de-staled: WAL-durable CLEAR/DROP GRAPH landed (sq-glw2); see durable-erasure note above -->
-  (WAL-durable `CLEAR`/`DROP GRAPH <g>` of an *existing* named graph **has landed** — sq-glw2,
-  via `Graph::clear_default_durable` / `drop_named_durable` with interrupted-drop crash recovery —
-  so it is no longer deferred.)
+  compaction tuning under sustained write load.
 
 ## 🐳 Running the container image (ghcr.io)
 


### PR DESCRIPTION
> 🤖 SPARQ agent — automated doc-sync for bead `sq-1ys1`. @jeswr runs several agents on one account.

## What

`crates/sparq-server/README.md` — finish the de-staling of the "Deferred
hardening (beaded, not yet wired)" bullet so it reads cleanly.

The substantive fix the bead asked for ("remove WAL-durable CLEAR/DROP GRAPH
from the 'deferred, not yet wired' line") **already landed on `main` under
PR #681** (commit `7f78e0f6`): that line now lists only the genuinely-deferred
items — byte-accounted durability metrics + online compaction tuning under
sustained write load. What #681 left behind, though, was an in-place
de-staling artifact:

- a `<!-- [OPUS-4.8] de-staled: WAL-durable CLEAR/DROP GRAPH landed (sq-glw2) ... -->`
  HTML comment, and
- a 3-line parenthetical restating that the feature "has landed".

This PR removes that residual scaffolding. The deferred line keeps the
genuinely-deferred items, per the bead's "Keep any genuinely-deferred items in
that sentence."

## Why it loses no information

The durable named-graph CLEAR/DROP capability is already documented in its
proper places in the same README:

- **Durability point** — every committed SPARQL Update (default graph **and**
  named graphs) is WAL-appended and fsync'd before the group-commit ack.
- The **`sq-x32t` WAL-compaction / erasure** bullet — `DELETE` / `DROP GRAPH`
  retraction + physical purge of superseded bytes.
- The **feature summary** — a `GRAPH`-scoped
  `INSERT`/`DELETE`/`LOAD`/`CLEAR`/`DROP`/`CREATE` commits through the same
  sequenced writer (exercised end-to-end in `tests/named_graphs.rs`).

So the parenthetical was purely redundant.

## Scope / honesty

Doc-only; **no public API, no code change** (`1 insertion, 4 deletions`). The
README is `#![doc = include_str!("../README.md")]`'d into `sparq-server`'s
crate-level rustdoc, so the rustdoc gate is the load-bearing one here.

## Gate

- `RUSTDOCFLAGS='-D warnings' cargo doc -p sparq-server --no-deps` — pass
- ... `--no-deps --all-features` — pass
- `cargo clippy -p sparq-server --all-targets -- -D warnings` — pass
- ... `--all-targets --all-features -- -D warnings` — pass
- `scripts/check-privacy-claims.sh` — OK (310 files scanned, no unqualified claim)
- No `unsafe` added → unsafe-gate N/A. No public-API change → G2 SKILL.md rule N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
