### PR TITLE
feat(sparq-fedclient): multi-source UNION-per-leaf fan-out (sq-7yf0) [OPUS-4.8]

### DIFF
--- a/crates/sparq-fedclient/README.md
+++ b/crates/sparq-fedclient/README.md
@@ -339,11 +339,27 @@ REAL here: the `SolutionStream` boundary, the bounded blocking thread-pool, the
 `StreamJoin`-feeder streaming join (with spill), the streaming single-source interpreter, the
 lossless `Term ↔ Tuple` bridge, and the streaming-correctness test against the real engine.
 
+### Multi-source UNION-per-leaf fan-out (bead `sq-7yf0`)
+
+Landed since: a leaf the planner retained **more than one source** for is no longer rejected
+with `InterpError::MultiSource` — `materialize_multi_source` / `stream_multi_source` fan it
+out as a **per-source UNION** (the bag-union of every retained source's solutions for that
+pattern, SPARQL UNION's multiset semantics — solution sequences concatenated, no
+de-duplication, multiplicity preserved). The materialised path resolves each candidate
+`source` index to its adapter through the `SourceResolver` and concatenates the per-source
+leaf relations; the streaming path fans each retained source's fetch out onto the same
+`ScatterPool`, all feeding ONE per-leaf `SolutionStream` (a cloned `SolutionSink` per source
+job, so the leaf stream ends once the last source job finishes). Both fold the per-leaf
+unions through the unchanged left-deep `natural_join` / `StreamingJoin`. The single-source
+entry points (`materialize_single_source` / `stream_single_source`) keep the
+`InterpError::MultiSource` fail-closed contract — multi-source is the opt-in entry point.
+`tests/multi_source_union_result_equals_local.rs` proves the materialised AND streamed
+multi-source result equals local `sparq-engine` evaluation over the **union of every source's
+graph**, over disjoint-fragment sources (single leaf, star join, 2-hop path, three sources,
+mixed single+multi-source leaves).
+
 Still a stub / deferred (a clear slice boundary, not a half-done operator):
 
-- **Multi-source UNION-per-leaf fan-out** — a leaf retained by more than one source is still
-  rejected with `InterpError::MultiSource` (the Phase-3 guard), not yet fanned out as a
-  per-source union. The thread-pool and `SolutionStream` are the seam that work builds on.
 - **The pushed-down streaming bind-join** — `JoinAlgo::Bind` is executed with the same
   streaming symmetric hash join (identical result multiset), not yet as a VALUES / `maxMpR`
   block pushed to the source. That pushdown is Phase 4's `pushdown` module + a follow-up
@@ -409,10 +425,12 @@ Phase 2 (source abstraction + Endpoint adapter, `sq-rsxf`), Phase 3 (planner bri
 materialised single-source interpreter, `sq-j27p`), Phase 4 (capability-aware pushdown,
 `sq-7byx`), Phase 5 (streaming operators — `SolutionStream` + thread-pool fan-out +
 `StreamJoin`-feeder join, `sq-vtba`), Phase 6 (brTPF/TPF adapters, `sq-2qze`), Phase 7
-(adaptive re-planning, `sq-ij5x`). Still ahead as future beads under epic **sq-3183**:
-multi-source UNION-per-leaf fan-out + the pushed-down streaming bind-join, and the ANAPSID
-"adaptive operator" refinement. No performance numbers appear here: any "better than Comunica"
-claim in the design record is an *architectural prediction* to be validated head-to-head before
-being asserted as fact.
+(adaptive re-planning, `sq-ij5x`). Landed since under epic **sq-3183**: multi-source
+UNION-per-leaf fan-out (`materialize_multi_source` / `stream_multi_source`, `sq-7yf0`). Still
+ahead as future beads under epic **sq-3183**: the pushed-down streaming bind-join (a VALUES /
+`maxMpR` block pushed to the source vs the current correct streaming hash join) and the
+ANAPSID "adaptive operator" refinement. No performance numbers appear here: any "better than
+Comunica" claim in the design record is an *architectural prediction* to be validated
+head-to-head before being asserted as fact.
 
-[OPUS-4.8] sq-7byx, sq-vtba, sq-ij5x — flagged for Fable re-review.
+[OPUS-4.8] sq-7byx, sq-vtba, sq-ij5x, sq-7yf0 — flagged for Fable re-review.

--- a/crates/sparq-fedclient/src/lib.rs
+++ b/crates/sparq-fedclient/src/lib.rs
@@ -246,6 +246,12 @@ pub use operators::{materialize_single_source, parse_srj, solutions_equal, Inter
 // thread-pool, the `StreamJoin`-feeder streaming join, and the streaming interpreter.
 #[cfg(feature = "fedclient")]
 pub use operators::{stream_single_source, ScatterPool, StreamOptions, StreamingJoin};
+// [OPUS-4.8] sq-7yf0: re-export the multi-source UNION-per-leaf interpreters — a leaf the
+// planner retained >1 source for is fanned out as a per-source bag-union rather than rejected
+// with `InterpError::MultiSource` (the materialised + streaming counterparts of the
+// single-source entry points above).
+#[cfg(feature = "fedclient")]
+pub use operators::{materialize_multi_source, stream_multi_source};
 
 /// §4.4 — the **`SolutionStream`** abstraction the client owns at its boundary (the
 /// engine stays materialised, §7). Backpressured + bounded (Rust ownership + explicit

--- a/crates/sparq-fedclient/src/operators.rs
+++ b/crates/sparq-fedclient/src/operators.rs
@@ -108,8 +108,11 @@ pub enum InterpError {
     Source(FedError),
     /// The SRJ body the adapter returned could not be parsed as SPARQL-Results-JSON.
     BadSrj(String),
-    /// A leaf retained more than one source — Phase-3's interpreter is single-source; the
-    /// multi-source UNION-per-leaf fan-out is Phase 5. Fail closed rather than drop a source.
+    /// A leaf retained more than one source while running through a **single-source** entry
+    /// point ([`materialize_single_source`] / [`stream_single_source`]) — those answer every
+    /// leaf from one explicit `source` and fail closed rather than drop a source. To fan a
+    /// multi-source leaf out as a per-source UNION use [`materialize_multi_source`] /
+    /// [`stream_multi_source`] (bead `sq-7yf0`), which never returns this variant.
     MultiSource { pattern: usize, sources: usize },
 }
 
@@ -175,6 +178,100 @@ pub fn materialize_single_source(
     let project = bgp_vars(resolver);
     rel = rel.project(&project);
     Ok(rel)
+}
+
+/// Materialise a `sparq-fedplan` [`JoinTree`] across **all retained sources per leaf**,
+/// fanning a leaf the planner kept more than one source for out as a **per-source UNION**,
+/// and return the federated solution table. This lifts the single-source restriction the
+/// Phase-3/5/7 [`InterpError::MultiSource`] guard imposed (bead `sq-7yf0`).
+///
+/// Where [`materialize_single_source`] answers every leaf from one explicit `source` (and
+/// rejects a multi-source leaf), this entry point resolves each leaf's retained source
+/// **indices** ([`PatternSources::candidates`](sparq_fedplan::PatternSources)) to adapters
+/// through the `resolver` and answers the leaf as the **bag-union** of every retained
+/// source's relation for that pattern. That is exactly SPARQL UNION semantics over the
+/// per-source solution sequences: the multisets are concatenated, no de-duplication
+/// (SELECT bag semantics), preserving multiplicity. A leaf with a single retained source
+/// degrades to the same fetch the single-source interpreter performs, so for a plan whose
+/// every leaf resolves to one source the two entry points return the identical multiset.
+///
+/// The join order, projection, and the materialised left-deep natural join are
+/// unchanged — only the per-leaf input is now a union over sources rather than one source.
+/// Joining over the *union per leaf* (rather than joining per-source and unioning the
+/// whole BGP) is the correct federated semantics: a leaf's contribution is the union of
+/// what each source holds for that pattern, and the BGP answer is the natural join of those
+/// per-leaf unions, regardless of which source each matching triple came from.
+///
+/// A leaf whose selection retained **no** source is an empty relation over the pattern's
+/// variables (the source-selection layer is the single source of truth; the interpreter
+/// does not silently fall back to "every adapter"). [OPUS-4.8] sq-7yf0.
+pub fn materialize_multi_source(
+    resolver: &SourceResolver<'_>,
+    selection: &[PatternSources],
+    tree: &JoinTree,
+) -> Result<Relation, InterpError> {
+    let mut rel = materialize_node_multi(resolver, selection, &tree.root)?;
+    // Project onto the whole-BGP variable set, matching `materialize_single_source`.
+    let project = bgp_vars(resolver);
+    rel = rel.project(&project);
+    Ok(rel)
+}
+
+/// Recursively materialise one plan node into a [`Relation`], fanning each leaf out across
+/// its retained sources (the multi-source counterpart of [`materialize_node`]). [OPUS-4.8].
+fn materialize_node_multi(
+    resolver: &SourceResolver<'_>,
+    selection: &[PatternSources],
+    node: &JoinNode,
+) -> Result<Relation, InterpError> {
+    match node {
+        JoinNode::Leaf { pattern, .. } => materialize_leaf_multi(resolver, selection, *pattern),
+        JoinNode::Join { left, right, .. } => {
+            let l = materialize_node_multi(resolver, selection, left)?;
+            let r = materialize_leaf_multi(resolver, selection, *right)?;
+            Ok(natural_join(&l, &r))
+        }
+    }
+}
+
+/// Answer ONE leaf pattern as the **bag-union over its retained sources**: fetch the leaf
+/// relation from each candidate adapter (resolved by source index through `resolver`) and
+/// concatenate the rows. The per-source relations share the same variable header (the
+/// pattern's variables in position order), so the union is a plain row concatenation —
+/// SPARQL UNION's multiset semantics, no de-duplication. [OPUS-4.8] sq-7yf0.
+fn materialize_leaf_multi(
+    resolver: &SourceResolver<'_>,
+    selection: &[PatternSources],
+    pattern: usize,
+) -> Result<Relation, InterpError> {
+    let tp = resolver.pattern(pattern)?;
+    let vars = pattern_vars(tp);
+    let mut union = Relation {
+        vars: vars.clone(),
+        rows: Vec::new(),
+    };
+    for idx in leaf_source_indices(selection, pattern) {
+        let source = resolver.source(idx)?;
+        let leaf = fetch_leaf_relation(source, tp)?;
+        // Re-key onto the canonical leaf header so every source's rows union column-aligned
+        // (a source's SRJ header may differ in order from the pattern's variable order).
+        for row in &leaf.rows {
+            union.rows.push(rel_row_project(&leaf.vars, row, &vars));
+        }
+    }
+    Ok(union)
+}
+
+/// The retained source indices for `pattern`, ascending (the deterministic order
+/// [`select_sources`](sparq_fedplan::select_sources) records). A pattern absent from the
+/// selection — or one whose candidate set is empty — contributes no sources, hence an empty
+/// leaf relation. [OPUS-4.8] sq-7yf0.
+fn leaf_source_indices(selection: &[PatternSources], pattern: usize) -> Vec<usize> {
+    selection
+        .iter()
+        .find(|ps| ps.pattern == pattern)
+        .map(|ps| ps.candidates.iter().map(|c| c.source).collect())
+        .unwrap_or_default()
 }
 
 /// All distinct variables of the resolver's BGP, in first-seen order (subject, predicate,
@@ -1151,6 +1248,141 @@ fn stream_leaf(
     Ok(StreamNode { vars, stream })
 }
 
+/// **Stream** a `sparq-fedplan` [`JoinTree`] with **per-leaf multi-source UNION fan-out**,
+/// returning a [`SolutionStream`]. The streaming counterpart of [`materialize_multi_source`]
+/// and the multi-source counterpart of [`stream_single_source`]: it lifts the
+/// [`InterpError::MultiSource`] guard (bead `sq-7yf0`).
+///
+/// `adapters` are the sendable source adapters indexed **the same way** as the resolver's
+/// source indices — `adapters[i]` is descriptor `i` is the adapter `select_sources`'
+/// `candidates[].source` index `i` names (the same contract [`SourceResolver`] enforces for
+/// its borrowed slice; the streaming path needs owned `Arc` adapters to move fetch jobs onto
+/// the [`ScatterPool`], so they are passed directly rather than re-borrowed through the
+/// resolver). A leaf the planner retained N sources for fans **all N** fetches out onto the
+/// pool, each feeding ONE shared per-leaf [`SolutionStream`] (a cloned [`SolutionSink`] per
+/// job) — the channel multiplexes them, so the per-leaf stream is the **bag-union** of every
+/// source's rows and ends only once every source job for that leaf has finished. The leaves
+/// then chain through [`StreamingJoin`]s exactly as the single-source path does.
+///
+/// **Load-bearing invariant:** the streamed multiset equals [`materialize_multi_source`] for
+/// the same plan + adapters, for ANY interleaving of source arrivals — the union is a bag
+/// concatenation (order-independent) and the joins reuse the proven [`StreamJoin`].
+/// [OPUS-4.8] sq-7yf0.
+pub fn stream_multi_source(
+    resolver: &SourceResolver<'_>,
+    selection: &[PatternSources],
+    adapters: &[Arc<dyn FederatedSource + Send + Sync>],
+    tree: &JoinTree,
+    opts: &StreamOptions,
+) -> Result<SolutionStream, InterpError> {
+    // Size the queue to hold every (leaf × retained-source) job at once, so the synchronous
+    // tree walk never blocks submitting (a worker may be blocked on `emit` before the
+    // consumer pulls). The pool still bounds concurrency to `opts.workers`.
+    let job_count: usize = resolver
+        .bgp()
+        .patterns
+        .iter()
+        .enumerate()
+        .map(|(p, _)| leaf_source_indices(selection, p).len())
+        .sum::<usize>()
+        .max(1);
+    let pool = Arc::new(ScatterPool::new(opts.workers, job_count));
+    let node = stream_node_multi(resolver, selection, adapters, &tree.root, &pool, opts)?;
+    let project = bgp_vars(resolver);
+    Ok(project_stream(node.stream, project, opts.channel_cap))
+}
+
+/// Recursively build the streaming pipeline for one node with per-leaf multi-source fan-out
+/// (the multi-source counterpart of [`stream_node`]). [OPUS-4.8] sq-7yf0.
+fn stream_node_multi(
+    resolver: &SourceResolver<'_>,
+    selection: &[PatternSources],
+    adapters: &[Arc<dyn FederatedSource + Send + Sync>],
+    node: &JoinNode,
+    pool: &Arc<ScatterPool>,
+    opts: &StreamOptions,
+) -> Result<StreamNode, InterpError> {
+    match node {
+        JoinNode::Leaf { pattern, .. } => {
+            stream_leaf_multi(resolver, selection, adapters, *pattern, pool, opts)
+        }
+        JoinNode::Join { left, right, .. } => {
+            let l = stream_node_multi(resolver, selection, adapters, left, pool, opts)?;
+            let r = stream_leaf_multi(resolver, selection, adapters, *right, pool, opts)?;
+            let join = StreamingJoin::new(&l.vars, &r.vars, opts.join_opts.clone(), opts.channel_cap);
+            let out_vars = join.out_vars().to_vec();
+            let stream = join.run(l.stream, r.stream);
+            Ok(StreamNode {
+                vars: out_vars,
+                stream,
+            })
+        }
+    }
+}
+
+/// Fan ONE leaf's fetches out across **every retained source** onto the pool, all feeding a
+/// single per-leaf [`SolutionStream`] (a cloned [`SolutionSink`] per source job). The
+/// resulting stream is the bag-union of every source's rows for the pattern; it ends once
+/// the last source job drops its sink. A leaf with no retained source yields an empty stream
+/// (its only sink drops immediately). Each source index is resolved against `adapters`
+/// (range-checked, same as [`SourceResolver::source`]). [OPUS-4.8] sq-7yf0.
+fn stream_leaf_multi(
+    resolver: &SourceResolver<'_>,
+    selection: &[PatternSources],
+    adapters: &[Arc<dyn FederatedSource + Send + Sync>],
+    pattern: usize,
+    pool: &Arc<ScatterPool>,
+    opts: &StreamOptions,
+) -> Result<StreamNode, InterpError> {
+    let tp = resolver.pattern(pattern)?;
+    let vars = pattern_vars(tp);
+    let indices = leaf_source_indices(selection, pattern);
+    // Range-check every source index up front (fail closed before spawning any job) so a
+    // mismatched plan/adapter set surfaces a `ResolveError`, not a silent under-answer.
+    for &idx in &indices {
+        if idx >= adapters.len() {
+            return Err(InterpError::Resolve(
+                crate::planner::ResolveError::SourceOutOfRange {
+                    index: idx,
+                    sources: adapters.len(),
+                },
+            ));
+        }
+    }
+    let (sink, stream) = SolutionStream::bounded(opts.channel_cap);
+    for &idx in &indices {
+        let source = Arc::clone(&adapters[idx]);
+        let tp_owned = tp.clone();
+        let leaf_vars = vars.clone();
+        // Each source job gets its OWN clone of the sink; the per-leaf stream ends only when
+        // the LAST clone drops (every source job finished) — the union over sources.
+        let job_sink = sink.clone();
+        pool.submit(move || {
+            match fetch_leaf_relation(source.as_ref(), &tp_owned) {
+                Ok(rel) => {
+                    for row in rel.rows {
+                        let proj = rel_row_project(&rel.vars, &row, &leaf_vars);
+                        if !job_sink.emit(Solution::new(leaf_vars.clone(), proj)) {
+                            return; // consumer gone.
+                        }
+                    }
+                }
+                Err(InterpError::Source(e)) => {
+                    job_sink.emit_err(e);
+                }
+                Err(other) => {
+                    job_sink.emit_err(FedError::Transport(other.to_string()));
+                }
+            }
+            // `job_sink` drops here → one source job done; the leaf stream ends when all do.
+        });
+    }
+    // Drop our own retained sink so the stream is driven solely by the job clones (and an
+    // empty `indices` immediately closes the stream).
+    drop(sink);
+    Ok(StreamNode { vars, stream })
+}
+
 /// Project one parsed SRJ row from its `src_vars` order onto `keep`'s order (an absent
 /// variable becomes unbound). The streaming analogue of [`Relation::project`] for a single
 /// row. [OPUS-4.8] sq-vtba.
@@ -1974,6 +2206,243 @@ mod tests {
         assert_eq!(
             fragterm_to_oxterm(&FragTerm::Literal("\"hi\"@en".into())),
             Term::Literal(Literal::new_language_tagged_literal("hi", "en").unwrap())
+        );
+    }
+
+    // ─── sq-7yf0: multi-source UNION-per-leaf fan-out ─────────────────────────────────
+
+    /// A single canned answer for one sub-query, as a one-entry map. [OPUS-4.8] sq-7yf0.
+    fn one_answer(sub: &str, body: String) -> StdHashMap<String, String> {
+        let mut m = StdHashMap::new();
+        m.insert(sub.to_string(), body);
+        m
+    }
+
+    /// `materialize_multi_source` fans a leaf retained by TWO sources out as a per-source
+    /// UNION (bag concatenation) instead of returning `MultiSource`. Two distinct endpoints
+    /// answer the SAME leaf sub-query with disjoint rows; the union is their concatenation.
+    /// [OPUS-4.8] sq-7yf0.
+    #[test]
+    fn materialize_multi_source_unions_two_sources() {
+        let bgp = Bgp::new(vec![TriplePattern::new(
+            var("s"),
+            iri("http://ex/p"),
+            var("o"),
+        )]);
+        let mk = |id: &str| {
+            SourceDescriptor::builder(SourceId::new(id))
+                .total_triples(10)
+                .predicate(sparq_fedplan::PredPartition {
+                    predicate: "http://ex/p".into(),
+                    triples: 10,
+                    distinct_subjects: 10,
+                    distinct_objects: 10,
+                })
+                .build()
+        };
+        let descriptors = [mk("A"), mk("B")];
+        let sel = select_sources(&bgp, &descriptors);
+        assert_eq!(sel[0].candidates.len(), 2, "both sources retained");
+        let tree = plan_bgp(&bgp, &sel, &descriptors, &PlanOptions::default()).unwrap();
+
+        let sub = "SELECT ?s ?o WHERE { ?s <http://ex/p> ?o }";
+        // Source A holds {a→o1}, source B holds {b→o2}; the union is both rows.
+        let ep_a = Endpoint::new(
+            "http://8.8.8.8/sparql",
+            Box::new(MapTransport::new(one_answer(
+                sub,
+                srj(&["s", "o"], &[&[("s", "http://ex/a"), ("o", "http://ex/o1")]]),
+            ))),
+        );
+        let ep_b = Endpoint::new(
+            "http://8.8.4.4/sparql",
+            Box::new(MapTransport::new(one_answer(
+                sub,
+                srj(&["s", "o"], &[&[("s", "http://ex/b"), ("o", "http://ex/o2")]]),
+            ))),
+        );
+        // Adapter slice in source-index order: adapters[0]=A, adapters[1]=B.
+        let adapters: Vec<&dyn FederatedSource> = vec![&ep_a, &ep_b];
+        let resolver = SourceResolver::new(&bgp, &adapters);
+
+        let rel = materialize_multi_source(&resolver, &sel, &tree).expect("multi-source unions");
+        assert_eq!(rel.vars, vec!["s".to_string(), "o".to_string()]);
+        // Bag-union: both sources' rows, no de-duplication.
+        let bag = solution_bag(&rel.vars, &rel.rows);
+        assert_eq!(
+            bag,
+            solution_bag(
+                &["s".into(), "o".into()],
+                &[
+                    vec![Some(nn("http://ex/a")), Some(nn("http://ex/o1"))],
+                    vec![Some(nn("http://ex/b")), Some(nn("http://ex/o2"))],
+                ]
+            )
+        );
+    }
+
+    /// The bag-union preserves multiplicity: when two sources return the SAME solution, the
+    /// union carries it TWICE (SELECT bag semantics, no de-dup) — the honest federated
+    /// behaviour over disjoint sources that happen to share a triple. [OPUS-4.8] sq-7yf0.
+    #[test]
+    fn materialize_multi_source_preserves_duplicates() {
+        let bgp = Bgp::new(vec![TriplePattern::new(
+            var("s"),
+            iri("http://ex/p"),
+            var("o"),
+        )]);
+        let mk = |id: &str| {
+            SourceDescriptor::builder(SourceId::new(id))
+                .total_triples(10)
+                .predicate(sparq_fedplan::PredPartition {
+                    predicate: "http://ex/p".into(),
+                    triples: 10,
+                    distinct_subjects: 10,
+                    distinct_objects: 10,
+                })
+                .build()
+        };
+        let descriptors = [mk("A"), mk("B")];
+        let sel = select_sources(&bgp, &descriptors);
+        let tree = plan_bgp(&bgp, &sel, &descriptors, &PlanOptions::default()).unwrap();
+        let sub = "SELECT ?s ?o WHERE { ?s <http://ex/p> ?o }";
+        let body = srj(&["s", "o"], &[&[("s", "http://ex/a"), ("o", "http://ex/o1")]]);
+        let ep_a = Endpoint::new("http://8.8.8.8/sparql", Box::new(MapTransport::new(one_answer(sub, body.clone()))));
+        let ep_b = Endpoint::new("http://8.8.4.4/sparql", Box::new(MapTransport::new(one_answer(sub, body))));
+        let adapters: Vec<&dyn FederatedSource> = vec![&ep_a, &ep_b];
+        let resolver = SourceResolver::new(&bgp, &adapters);
+        let rel = materialize_multi_source(&resolver, &sel, &tree).unwrap();
+        assert_eq!(rel.rows.len(), 2, "the shared solution appears once per source");
+    }
+
+    /// `stream_multi_source` produces the SAME multiset as `materialize_multi_source` for a
+    /// two-source leaf (and proves the guard is lifted on the streaming path too). [OPUS-4.8].
+    #[test]
+    fn stream_multi_source_equals_materialised() {
+        let bgp = Bgp::new(vec![TriplePattern::new(
+            var("s"),
+            iri("http://ex/p"),
+            var("o"),
+        )]);
+        let mk = |id: &str| {
+            SourceDescriptor::builder(SourceId::new(id))
+                .total_triples(10)
+                .predicate(sparq_fedplan::PredPartition {
+                    predicate: "http://ex/p".into(),
+                    triples: 10,
+                    distinct_subjects: 10,
+                    distinct_objects: 10,
+                })
+                .build()
+        };
+        let descriptors = [mk("A"), mk("B")];
+        let sel = select_sources(&bgp, &descriptors);
+        let tree = plan_bgp(&bgp, &sel, &descriptors, &PlanOptions::default()).unwrap();
+        let sub = "SELECT ?s ?o WHERE { ?s <http://ex/p> ?o }";
+        let a_body = srj(&["s", "o"], &[&[("s", "http://ex/a"), ("o", "http://ex/o1")]]);
+        let b_body = srj(&["s", "o"], &[&[("s", "http://ex/b"), ("o", "http://ex/o2")]]);
+
+        // Materialised reference.
+        let ep_a = Endpoint::new("http://8.8.8.8/sparql", Box::new(MapTransport::new(one_answer(sub, a_body.clone()))));
+        let ep_b = Endpoint::new("http://8.8.4.4/sparql", Box::new(MapTransport::new(one_answer(sub, b_body.clone()))));
+        let ref_adapters: Vec<&dyn FederatedSource> = vec![&ep_a, &ep_b];
+        let resolver_ref = SourceResolver::new(&bgp, &ref_adapters);
+        let reference = materialize_multi_source(&resolver_ref, &sel, &tree).unwrap();
+
+        // Streamed: owned Arc adapters, same source-index order.
+        let arc_a: Arc<dyn FederatedSource + Send + Sync> = Arc::new(ArcMapSource::new(one_answer(sub, a_body)));
+        let arc_b: Arc<dyn FederatedSource + Send + Sync> = Arc::new(ArcMapSource::new(one_answer(sub, b_body)));
+        let arc_adapters = vec![arc_a, arc_b];
+        // A stub borrowed slice only for index resolution (pattern lookup); the streaming path
+        // answers through `arc_adapters`, so these are never `execute`d.
+        let stub_a = Endpoint::new("http://8.8.8.8/sparql", Box::new(MapTransport::new(StdHashMap::new())));
+        let stub_b = Endpoint::new("http://8.8.4.4/sparql", Box::new(MapTransport::new(StdHashMap::new())));
+        let stub_adapters: Vec<&dyn FederatedSource> = vec![&stub_a, &stub_b];
+        let resolver = SourceResolver::new(&bgp, &stub_adapters);
+        let stream =
+            stream_multi_source(&resolver, &sel, &arc_adapters, &tree, &StreamOptions::default())
+                .expect("streaming multi-source builds");
+        let got = stream.collect_solutions().unwrap();
+        let got_rows: Vec<Vec<Option<Term>>> = got.iter().map(|s| s.cells.clone()).collect();
+        let got_vars = got
+            .first()
+            .map(|s| s.vars.clone())
+            .unwrap_or_else(|| reference.vars.clone());
+        assert!(
+            solutions_equal(&got_vars, &got_rows, &reference.vars, &reference.rows),
+            "streamed multi-source must equal materialised.\n streamed={:?}\n reference={:?}",
+            got_rows,
+            reference.rows,
+        );
+    }
+
+    /// A leaf the selection retained NO source for is an empty relation (the source-selection
+    /// layer is authoritative — the interpreter never falls back to "every adapter"). Both
+    /// entry points agree. [OPUS-4.8] sq-7yf0.
+    #[test]
+    fn multi_source_leaf_with_no_retained_source_is_empty() {
+        let bgp = Bgp::new(vec![TriplePattern::new(
+            var("s"),
+            iri("http://ex/p"),
+            var("o"),
+        )]);
+        // A descriptor that does NOT declare ex/p ⇒ the source is NOT retained for the leaf.
+        let descriptors = [SourceDescriptor::builder(SourceId::new("A")).total_triples(10).build()];
+        let sel = select_sources(&bgp, &descriptors);
+        assert!(
+            sel.first().map(|ps| ps.candidates.is_empty()).unwrap_or(true),
+            "no source retained for the unmatched predicate"
+        );
+        // With an empty selection there is no plan (no leaf retained any source); exercise the
+        // leaf helper directly to assert the empty-relation contract without a JoinTree.
+        let ep = Endpoint::new("http://8.8.8.8/sparql", Box::new(MapTransport::new(StdHashMap::new())));
+        let adapters: Vec<&dyn FederatedSource> = vec![&ep];
+        let resolver = SourceResolver::new(&bgp, &adapters);
+        let leaf = materialize_leaf_multi(&resolver, &sel, 0).unwrap();
+        assert_eq!(leaf.vars, vec!["s".to_string(), "o".to_string()]);
+        assert!(leaf.rows.is_empty(), "no retained source ⇒ empty leaf relation");
+    }
+
+    /// A retained source index out of range for the streaming adapter slice fails closed with
+    /// a `ResolveError` BEFORE any fetch job is spawned (never a silent under-answer).
+    /// [OPUS-4.8] sq-7yf0.
+    #[test]
+    fn stream_multi_source_range_checks_source_index() {
+        let bgp = Bgp::new(vec![TriplePattern::new(
+            var("s"),
+            iri("http://ex/p"),
+            var("o"),
+        )]);
+        let mk = |id: &str| {
+            SourceDescriptor::builder(SourceId::new(id))
+                .total_triples(10)
+                .predicate(sparq_fedplan::PredPartition {
+                    predicate: "http://ex/p".into(),
+                    triples: 10,
+                    distinct_subjects: 10,
+                    distinct_objects: 10,
+                })
+                .build()
+        };
+        let descriptors = [mk("A"), mk("B")];
+        let sel = select_sources(&bgp, &descriptors);
+        let tree = plan_bgp(&bgp, &sel, &descriptors, &PlanOptions::default()).unwrap();
+        let stub = Endpoint::new("http://8.8.8.8/sparql", Box::new(MapTransport::new(StdHashMap::new())));
+        let stub_adapters: Vec<&dyn FederatedSource> = vec![&stub];
+        let resolver = SourceResolver::new(&bgp, &stub_adapters);
+        // Only ONE Arc adapter supplied, but the selection retained source index 1 ⇒ out of range.
+        let only: Arc<dyn FederatedSource + Send + Sync> = Arc::new(ArcMapSource::new(StdHashMap::new()));
+        let arc_adapters = vec![only];
+        let err = match stream_multi_source(&resolver, &sel, &arc_adapters, &tree, &StreamOptions::default()) {
+            Ok(_) => panic!("an out-of-range source index must fail closed"),
+            Err(e) => e,
+        };
+        assert_eq!(
+            err,
+            InterpError::Resolve(crate::planner::ResolveError::SourceOutOfRange {
+                index: 1,
+                sources: 1,
+            })
         );
     }
 }

--- a/crates/sparq-fedclient/tests/multi_source_union_result_equals_local.rs
+++ b/crates/sparq-fedclient/tests/multi_source_union_result_equals_local.rs
@@ -1,0 +1,290 @@
+//! THE correctness test for multi-source UNION-per-leaf fan-out (bead sq-7yf0, epic
+//! sq-3183): the federated result of a plan whose leaves are retained by **more than one
+//! source** EQUALS local `sparq-engine` evaluation over the **union of every source's
+//! graph**.
+//!
+//! Each "remote endpoint" is a faithful SPARQL endpoint over its OWN graph `G_i` (an
+//! [`EngineTransport`] that runs each leaf sub-query through the real engine on an
+//! in-process `sparq_core::Graph`, serialised to SPARQL-Results-JSON). When the planner
+//! retains several sources for a leaf,
+//! [`materialize_multi_source`](sparq_fedclient::materialize_multi_source) /
+//! [`stream_multi_source`](sparq_fedclient::stream_multi_source) answer that leaf as the
+//! **bag-union** of every retained source's solutions — exactly SPARQL UNION semantics over
+//! the per-source solution sequences. The BGP answer is then the natural join of those
+//! per-leaf unions.
+//!
+//! The canonical answer is `sparq_engine::query(&G_union, Q)` where `G_union` is the single
+//! graph holding the union of every source's triples: for a federation over endpoints that
+//! each hold a fragment of the data, the federated answer must equal evaluating the whole
+//! query over the merged dataset. We assert
+//! [`solutions_equal`](sparq_fedclient::solutions_equal) for BOTH the materialised and the
+//! streaming multi-source interpreters (same multiset, any source-arrival interleaving).
+//!
+//! Gated on `fedclient`; the default build compiles this file to nothing.
+//!
+//! [OPUS-4.8] sq-7yf0 — flagged for Fable re-review when available.
+
+#![cfg(feature = "fedclient")]
+
+use sparq_core::Graph;
+use sparq_engine::json::to_sparql_json;
+use sparq_engine::query;
+use sparq_fedclient::{
+    materialize_multi_source, solutions_equal, stream_multi_source, Endpoint, FederatedSource,
+    Relation, SourceResolver, StreamOptions, Transport,
+};
+use sparq_fedplan::{
+    plan_bgp, select_sources, Bgp, PlanOptions, PredPartition, SourceDescriptor, SourceId, Term,
+    TriplePattern, Var,
+};
+use std::sync::Arc;
+
+/// A transport that answers a sub-query by evaluating it against ONE local engine `Graph` —
+/// a faithful stand-in for a conformant SPARQL endpoint over that graph's fragment of the
+/// federation. No network: the "remote" answer is that source's own engine evaluation.
+struct EngineTransport {
+    graph: Arc<Graph>,
+}
+
+impl Transport for EngineTransport {
+    fn fetch(&self, _endpoint: &str, q: &str) -> Result<String, String> {
+        let res = query(&self.graph, q)?;
+        Ok(to_sparql_json(&res))
+    }
+}
+
+fn iri(s: &str) -> Term {
+    Term::Iri(s.to_string())
+}
+fn var(s: &str) -> Term {
+    Term::Var(Var::new(s))
+}
+
+/// A per-source descriptor declaring `preds` so `select_sources` retains the source for
+/// every pattern it covers. Identical predicate coverage across sources ⇒ a leaf retains
+/// EVERY such source (the multi-source case). [OPUS-4.8] sq-7yf0.
+fn descriptor(id: &str, preds: &[&str]) -> SourceDescriptor {
+    let mut b = SourceDescriptor::builder(SourceId::new(id)).total_triples(1000);
+    for p in preds {
+        b = b.predicate(PredPartition {
+            predicate: (*p).into(),
+            triples: 100,
+            distinct_subjects: 50,
+            distinct_objects: 50,
+        });
+    }
+    b.build()
+}
+
+/// Build the federation harness for `bgp` over the given per-source `(turtle, preds)` set:
+/// returns the descriptors, the per-pattern selection, and the plan. The endpoints are kept
+/// alive by the caller (they borrow their graphs). [OPUS-4.8] sq-7yf0.
+fn plan(
+    bgp: &Bgp,
+    sources: &[(&str, &[&str])],
+) -> (Vec<SourceDescriptor>, Vec<sparq_fedplan::PatternSources>, sparq_fedplan::JoinTree) {
+    let descriptors: Vec<SourceDescriptor> = sources
+        .iter()
+        .enumerate()
+        .map(|(i, (_g, preds))| descriptor(&format!("S{i}"), preds))
+        .collect();
+    let sel = select_sources(bgp, &descriptors);
+    let tree = plan_bgp(bgp, &sel, &descriptors, &PlanOptions::default())
+        .expect("non-empty BGP yields a plan");
+    (descriptors, sel, tree)
+}
+
+/// Assert the multi-source federated result (materialised AND streaming) equals local
+/// evaluation of `whole_query` over the union of every source graph. [OPUS-4.8] sq-7yf0.
+fn assert_multi_source_equals_union(
+    bgp: &Bgp,
+    sources: &[(&str, &[&str])],
+    whole_query: &str,
+) {
+    // Per-source engine graphs + endpoint adapters (index i == descriptor i == source i).
+    let graphs: Vec<Arc<Graph>> = sources
+        .iter()
+        .map(|(g, _)| Arc::new(Graph::load_str(g, "turtle").unwrap()))
+        .collect();
+    let endpoints: Vec<Endpoint> = graphs
+        .iter()
+        .map(|g| {
+            Endpoint::new(
+                "http://example.org/sparql",
+                Box::new(EngineTransport {
+                    graph: Arc::clone(g),
+                }),
+            )
+        })
+        .collect();
+
+    let (_descriptors, sel, tree) = plan(bgp, sources);
+
+    // The borrowed adapter slice for the resolver (range-checked index → adapter).
+    let adapters: Vec<&dyn FederatedSource> = endpoints.iter().map(|e| e as &dyn FederatedSource).collect();
+    let resolver = SourceResolver::new(bgp, &adapters);
+
+    // Materialised multi-source fan-out.
+    let fed: Relation = materialize_multi_source(&resolver, &sel, &tree)
+        .expect("multi-source interpreter succeeds");
+
+    // The canonical answer: query the UNION graph (all sources' triples merged).
+    let union_graph = {
+        let mut all = String::new();
+        for (g, _) in sources {
+            all.push_str(g);
+            all.push('\n');
+        }
+        Arc::new(Graph::load_str(&all, "turtle").unwrap())
+    };
+    let local = query(&union_graph, whole_query).expect("local eval succeeds");
+    let local_vars: Vec<String> = local.vars.iter().map(|v| v.as_str().to_string()).collect();
+
+    assert!(
+        solutions_equal(&fed.vars, &fed.rows, &local_vars, &local.rows),
+        "materialised multi-source result must equal local eval over the union graph.\n  fed = {:?}\n  local vars = {:?} rows = {:?}",
+        fed,
+        local_vars,
+        local.rows,
+    );
+
+    // Streaming multi-source fan-out (owned Arc adapters, indexed the same way).
+    let arc_adapters: Vec<Arc<dyn FederatedSource + Send + Sync>> = graphs
+        .iter()
+        .map(|g| {
+            let ep: Arc<dyn FederatedSource + Send + Sync> = Arc::new(Endpoint::new(
+                "http://example.org/sparql",
+                Box::new(EngineTransport {
+                    graph: Arc::clone(g),
+                }),
+            ));
+            ep
+        })
+        .collect();
+    let stream =
+        stream_multi_source(&resolver, &sel, &arc_adapters, &tree, &StreamOptions::default())
+            .expect("streaming multi-source interpreter builds");
+    let got = stream.collect_solutions().unwrap();
+    let got_rows: Vec<Vec<Option<oxrdf::Term>>> = got.iter().map(|s| s.cells.clone()).collect();
+    let got_vars = got
+        .first()
+        .map(|s| s.vars.clone())
+        .unwrap_or_else(|| fed.vars.clone());
+    assert!(
+        solutions_equal(&got_vars, &got_rows, &local_vars, &local.rows),
+        "streamed multi-source result must equal local eval over the union graph.\n  streamed = {:?}\n  local vars = {:?} rows = {:?}",
+        got_rows,
+        local_vars,
+        local.rows,
+    );
+}
+
+// Two endpoints, each holding a DISJOINT fragment of the same predicate's triples — the
+// canonical multi-source case the bead names. A single leaf `?s ex:knows ?o` retains both
+// sources; the union of their solutions must equal the merged graph's.
+const SRC_A: &str = r#"
+@prefix ex: <http://ex/> .
+ex:alice ex:knows ex:bob .
+ex:alice ex:knows ex:carol .
+ex:alice ex:name "Alice" .
+ex:bob   ex:name "Bob" .
+"#;
+const SRC_B: &str = r#"
+@prefix ex: <http://ex/> .
+ex:carol ex:knows ex:dave .
+ex:bob   ex:knows ex:dave .
+ex:carol ex:name "Carol" .
+ex:dave  ex:name "Dave" .
+"#;
+
+#[test]
+fn single_leaf_two_sources_unions() {
+    // ?s ex:knows ?o — one leaf, BOTH sources hold ex:knows ⇒ a per-source UNION.
+    let bgp = Bgp::new(vec![TriplePattern::new(
+        var("s"),
+        iri("http://ex/knows"),
+        var("o"),
+    )]);
+    assert_multi_source_equals_union(
+        &bgp,
+        &[(SRC_A, &["http://ex/knows"]), (SRC_B, &["http://ex/knows"])],
+        "SELECT ?s ?o WHERE { ?s <http://ex/knows> ?o }",
+    );
+}
+
+#[test]
+fn star_join_with_multi_source_leaves_unions() {
+    // ?s ex:knows ?o . ?s ex:name ?n — a star on ?s where BOTH leaves are multi-source.
+    // The join is over the per-leaf unions: a ?s/?o pair from one source can join a ?s/?n
+    // pair from the OTHER (cross-source join), which only the union-per-leaf semantics
+    // capture (e.g. bob's ex:knows lives in B but his ex:name in A).
+    let bgp = Bgp::new(vec![
+        TriplePattern::new(var("s"), iri("http://ex/knows"), var("o")),
+        TriplePattern::new(var("s"), iri("http://ex/name"), var("n")),
+    ]);
+    assert_multi_source_equals_union(
+        &bgp,
+        &[
+            (SRC_A, &["http://ex/knows", "http://ex/name"]),
+            (SRC_B, &["http://ex/knows", "http://ex/name"]),
+        ],
+        "SELECT ?s ?o ?n WHERE { ?s <http://ex/knows> ?o . ?s <http://ex/name> ?n }",
+    );
+}
+
+#[test]
+fn three_sources_path_join_unions() {
+    // Three sources, a 2-hop path + name lookup; every leaf retains all three sources whose
+    // descriptor covers the predicate. Verifies the fan-out generalises past two sources.
+    const SRC_C: &str = r#"
+@prefix ex: <http://ex/> .
+ex:dave  ex:knows ex:erin .
+ex:erin  ex:name "Erin" .
+"#;
+    let bgp = Bgp::new(vec![
+        TriplePattern::new(var("s"), iri("http://ex/knows"), var("o")),
+        TriplePattern::new(var("o"), iri("http://ex/knows"), var("z")),
+        TriplePattern::new(var("z"), iri("http://ex/name"), var("n")),
+    ]);
+    assert_multi_source_equals_union(
+        &bgp,
+        &[
+            (SRC_A, &["http://ex/knows", "http://ex/name"]),
+            (SRC_B, &["http://ex/knows", "http://ex/name"]),
+            (SRC_C, &["http://ex/knows", "http://ex/name"]),
+        ],
+        "SELECT ?s ?o ?z ?n WHERE { \
+            ?s <http://ex/knows> ?o . \
+            ?o <http://ex/knows> ?z . \
+            ?z <http://ex/name> ?n }",
+    );
+}
+
+#[test]
+fn mixed_single_and_multi_source_leaves_unions() {
+    // One leaf is single-source (only A declares ex:age), the other multi-source (both
+    // declare ex:name) — the interpreter must NOT reject the single-source leaf and must
+    // union the multi-source one.
+    const SRC_AGE: &str = r#"
+@prefix ex: <http://ex/> .
+ex:alice ex:age "30"^^<http://www.w3.org/2001/XMLSchema#integer> .
+ex:alice ex:name "Alice" .
+"#;
+    const SRC_NAME: &str = r#"
+@prefix ex: <http://ex/> .
+ex:alice ex:name "Alice-dup" .
+ex:bob   ex:name "Bob" .
+"#;
+    let bgp = Bgp::new(vec![
+        TriplePattern::new(var("s"), iri("http://ex/age"), var("a")),
+        TriplePattern::new(var("s"), iri("http://ex/name"), var("n")),
+    ]);
+    assert_multi_source_equals_union(
+        &bgp,
+        &[
+            (SRC_AGE, &["http://ex/age", "http://ex/name"]),
+            (SRC_NAME, &["http://ex/name"]),
+        ],
+        "SELECT ?s ?a ?n WHERE { ?s <http://ex/age> ?a . ?s <http://ex/name> ?n }",
+    );
+}

--- a/skills/federated-planning/SKILL.md
+++ b/skills/federated-planning/SKILL.md
@@ -238,9 +238,11 @@ since:
   leaf's SRJ through the Phase-2 adapter, parses it, and natural-joins in the plan's join
   order. The load-bearing property — the materialised federated result **equals** local
   `sparq-engine` evaluation of the same query (`solutions_equal` bag comparison) — is driven
-  end-to-end in `tests/planner_result_equals_local_eval.rs`. The interpreter is single-source
-  + blocking (its streaming counterpart is Phase 5 below); a multi-source leaf fails closed
-  with `InterpError::MultiSource`.
+  end-to-end in `tests/planner_result_equals_local_eval.rs`. `materialize_single_source` is
+  single-source + blocking (its streaming counterpart is Phase 5 below); a leaf the planner
+  retained >1 source for fails closed with `InterpError::MultiSource`. To fan such a leaf out
+  as a per-source UNION use `materialize_multi_source` / `stream_multi_source` (bead `sq-7yf0`,
+  below) — the opt-in multi-source entry points that never return `MultiSource`.
 - **Phase 4 capability-aware pushdown** (`sq-7byx`) — the `pushdown` module decides the most
   precise sub-query each source is asked. `exclusive_groups(selection, bgp)` derives the FedX
   **exclusive groups** (maximal connected sub-patterns whose only retained source is one
@@ -270,9 +272,21 @@ since:
   inputs are exhausted. The load-bearing invariant — the streamed multiset is **multiset-equal**
   to the Phase-3 materialised result for **any** source-arrival interleaving (and both equal
   local eval) — is driven on the real engine path under injected per-leaf delays + a forced spill
-  in `tests/streaming_result_equals_phase3.rs`. Multi-source UNION-per-leaf and the *pushed-down*
-  bind-join (VALUES/`maxMpR`) remain deferred; a bind-classified join runs as the same streaming
-  symmetric hash join (identical result multiset).
+  in `tests/streaming_result_equals_phase3.rs`. The *pushed-down* bind-join (VALUES/`maxMpR`)
+  remains deferred; a bind-classified join runs as the same streaming symmetric hash join
+  (identical result multiset).
+- **Multi-source UNION-per-leaf fan-out** (`sq-7yf0`) — `materialize_multi_source` /
+  `stream_multi_source` lift the single-source `InterpError::MultiSource` guard: a leaf the
+  planner retained >1 source for is answered as the **bag-union** of every retained source's
+  solutions for that pattern (SPARQL UNION's multiset semantics — concatenation, no de-dup,
+  multiplicity preserved), resolving each candidate `source` index to its adapter through the
+  `SourceResolver`. The streaming path fans each retained source's fetch onto the same
+  `ScatterPool`, all feeding ONE per-leaf `SolutionStream` (a cloned `SolutionSink` per source
+  job). Both fold the per-leaf unions through the unchanged left-deep `natural_join` /
+  `StreamingJoin`. `tests/multi_source_union_result_equals_local.rs` proves the materialised
+  AND streamed multi-source result equals local `sparq-engine` evaluation over the union of
+  every source's graph. The single-source entry points keep the fail-closed `MultiSource`
+  contract — multi-source is the opt-in entry point.
 - **Phase 6 the brTPF + TPF fragment adapters** (`sq-2qze`): `source::TpfSource` (plain TPF —
   materialise a fragment to exhaustion, no bind-join) and `source::BrTpfSource`
   (bindings-restricted — push `maxMpR`-bounded binding blocks per request, the standardised
@@ -341,10 +355,11 @@ since:
   interpreter and ground-truth local engine eval across a genuine large-divergence switch.
 
 With Phase 7 the **8-phase streaming federation client is feature-complete** (Phases 0–7 all
-landed; epic **sq-dnko** closed). Still ahead as future beads under epic sq-3183: multi-source
-UNION-per-leaf fan-out, the pushed-down streaming bind-join, and the ANAPSID "adaptive operator"
-refinement (estimate a leaf's cardinality from a prefix of its rows while still streaming it).
-See `crates/sparq-fedclient/README.md`.
+landed; epic **sq-dnko** closed). Multi-source UNION-per-leaf fan-out has since landed under
+epic sq-3183 (`sq-7yf0`, above). Still ahead as future beads under epic sq-3183: the
+pushed-down streaming bind-join, and the ANAPSID "adaptive operator" refinement (estimate a
+leaf's cardinality from a prefix of its rows while still streaming it). See
+`crates/sparq-fedclient/README.md`.
 
 ## Deferred (NOT here)
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements bead **sq-7yf0** — `sparq-fedclient`: multi-source UNION-per-leaf fan-out (the Phase-8 deferred slice under epic `sq-3183`).

## What

A BGP leaf the planner retained **more than one source** for was rejected with `InterpError::MultiSource` (the Phase-3/5/7 single-source guard). This adds the **opt-in multi-source entry points** that fan such a leaf out as a **per-source UNION** instead:

- **`materialize_multi_source`** — resolves each candidate `source` index to its adapter through the `SourceResolver` and answers a leaf as the **bag-union** of every retained source's solutions for that pattern, folding the per-leaf unions through the unchanged left-deep `natural_join`.
- **`stream_multi_source`** — fans each retained source's blocking fetch onto the same `ScatterPool`, all feeding ONE per-leaf `SolutionStream` (a cloned `SolutionSink` per source job, so the leaf stream ends once the last source job finishes), chaining the leaves through the existing `StreamingJoin`.

The union is SPARQL UNION's multiset semantics: per-source solution sequences concatenated, **no de-duplication**, multiplicity preserved.

## Honest scope

- The **single-source** entry points (`materialize_single_source` / `stream_single_source`) keep the fail-closed `InterpError::MultiSource` contract **unchanged** — multi-source is the new *opt-in* entry point, not a behaviour change to the existing one. Their guard tests still pass.
- A leaf with **no** retained source is an empty relation (the source-selection layer is authoritative — the interpreter never falls back to "every adapter").
- A source index out of range for the streaming adapter slice fails closed with a `ResolveError` **before** any fetch job is spawned.
- The streaming path takes owned `Arc<dyn FederatedSource + Send + Sync>` adapters (needed to move fetch jobs onto the pool), indexed the same way as the resolver's source indices — mirroring how `stream_single_source` takes an `Arc`.
- Out of scope (lower-priority refinements in the same README section, still deferred): the pushed-down streaming bind-join (VALUES/`maxMpR`) and the ANAPSID adaptive-operator. Those produce identical results — only request discipline differs.

## Tests

- `tests/multi_source_union_result_equals_local.rs` (NEW) — proves the materialised **and** streamed multi-source result equals local `sparq-engine` evaluation over the **union of every source's graph**, on the real engine path: single leaf / star join (cross-source join) / 2-hop path / three sources / mixed single+multi-source leaves. Uses disjoint-fragment sources so the union-graph oracle is exact.
- In-crate unit tests — two-source bag-union, duplicate-preserving multiplicity, streamed == materialised, the empty-leaf contract, and the streaming range check (out-of-range source index fails closed).

## Gate

- `cargo build` + `clippy --all-targets -- -D warnings` in **fedclient OFF, fedclient ON, and +fedclient-adaptive** — clean.
- `cargo test` in **both feature states** — pass (124 lib unit tests + all integration tests with the feature ON; the new test compiles to nothing with the feature OFF).
- Rustdoc gate `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` **and** `--all-features` — clean (caught + fixed a public-doc intra-doc-link to the private `natural_join`, the #1 silently-missed gate).
- `scripts/fedclient-boundary-guard.sh` + `scripts/check-privacy-claims.sh` — pass.
- No `unsafe` added (crate is `forbid(unsafe_code)`).

## Docs

README + `skills/federated-planning/SKILL.md` updated (multi-source UNION-per-leaf moved from "deferred" to "landed"); the `InterpError::MultiSource` variant doc now points at the opt-in multi-source path.

[OPUS-4.8] — flagged for Fable re-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
