### PR TITLE
ci: run the bench/dict (dict-baseline) selftest from a CI lane (sq-hqmm) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,6 +636,22 @@ jobs:
         run: cargo doc --workspace --no-deps --all-features
         env:
           RUSTDOCFLAGS: "-D warnings"
+      # [OPUS-4.8] sq-hqmm: invoke the standalone bench/dict (dict-baseline) selftest from a CI
+      # lane. bench/dict carries its OWN `[workspace]` table (the same isolation pattern as
+      # bench/parse and bench/serve), so the `cargo clippy --workspace` + the workspace nextest
+      # archive above NEVER reach it — its structural invariants (every dictionary term classified
+      # exactly once, `Dict::into_blob` preserving the term count, positive footprints) live ONLY in
+      # its `selftest` subcommand and were unchecked by any lane. This step clippy-gates the crate
+      # (under -D warnings, since the workspace clippy can't) and runs `dict-baseline selftest` so a
+      # harness regression (a composition miscount, an into_blob that drops terms) fails CI. It is
+      # in-process + dataset-free + makes no wall-clock claim, so it is deterministic in CI (the
+      # README documents `selftest` as the CI-runnable check; this is the lane that runs it). It is a
+      # SEPARATE workspace (own target dir), so sparq-core compiles once more here in debug — but the
+      # registry/git deps come warm from rust-cache, and a debug build keeps the added cost small.
+      - name: bench/dict standalone selftest (clippy + invariant checks)
+        run: |
+          cargo clippy --manifest-path bench/dict/Cargo.toml --all-targets -- -D warnings
+          cargo run --manifest-path bench/dict/Cargo.toml -- selftest
       # Informational until the deferred `cargo fmt --all` reformat lands (see rustfmt.toml).
       - name: rustfmt (informational)
         run: cargo fmt --all --check

--- a/bench/dict/README.md
+++ b/bench/dict/README.md
@@ -81,3 +81,11 @@ Each prints a markdown block; numbers + analysis are recorded in
 In-process invariant checks — every term is classified exactly once, `into_blob`
 preserves the term count, footprints are positive. Not a performance claim; purely
 structural, so it runs deterministically in CI without a dataset or a quiet box.
+
+Because this is a standalone cargo project (own `[workspace]` table), the root
+workspace's `cargo clippy --workspace` + nextest lanes never reach it. The CI
+`clippy (gate) + fmt` job (`.github/workflows/ci.yml`) therefore clippy-gates this
+crate and runs `dict-baseline selftest` directly (`--manifest-path
+bench/dict/Cargo.toml`), so a harness regression — a composition miscount, an
+`into_blob` that drops terms — fails CI rather than passing unobserved (bead
+**sq-hqmm**).


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

Wire the standalone `bench/dict` (`dict-baseline`) **`selftest`** subcommand into a CI lane (bead **sq-hqmm**, from the #689 / sq-9w0t verification follow-up).

`bench/dict` is a standalone cargo project with its **own `[workspace]` table** (the same isolation pattern as `bench/parse` and `bench/serve`), so the workspace `cargo clippy --workspace` and the `cargo nextest` archive in `ci.yml` **never reach it**. The crate has no `#[test]` functions; its structural invariants live only in the `selftest` subcommand — and although the README already advertised `selftest` as "CI-runnable", **no lane actually ran it**, so a harness regression (a composition miscount, an `into_blob` that drops terms) would land unobserved.

## Change

- `.github/workflows/ci.yml` — add one step to the existing **`clippy (gate) + fmt`** job (job key `lint`), which already provisions the Rust toolchain + `rust-cache` and runs whenever `rust_changed`:
  - `cargo clippy --manifest-path bench/dict/Cargo.toml --all-targets -- -D warnings` (the workspace clippy can't reach this crate), then
  - `cargo run --manifest-path bench/dict/Cargo.toml -- selftest`.

  Both are **GATING** (the step has no `continue-on-error`). The selftest is in-process, dataset-free, and makes no wall-clock claim, so it is deterministic in CI — no quiet box needed.
- `bench/dict/README.md` — the "Selftest (CI-runnable)" section now names the lane that runs it, so the doc claim is accurate and durable.

## Why this lane

The selftest needs a Rust toolchain, so the Python-only `flow-on-gates.yml` (G1/G2/G3/G6) is the wrong home; G3 (`check-new-bench-registered.py`) is about registry/dashboard registration, not running a harness. The `lint` job is the cheapest correct fit — toolchain + warm dep cache already present, and it is a required gate via `ci-summary`.

## Honesty / scope notes

- `bench/dict` is a separate workspace (own `target/`), so `sparq-core` recompiles once more here in **debug**; the registry/git deps come warm from `rust-cache`, so the added cost is small. The CI comment states this plainly rather than claiming a free reuse.
- A pre-existing benign `cargo` warning (`patch spargebra ... was not used in the crate graph`) is emitted by the `bench/dict` manifest — it is **not** a build/clippy error, does not fail the step, and predates this PR (it shipped with #689). Left untouched to keep this the smallest correct change; orthogonal to the CI-wiring this bead asks for.
- No Rust source, no public API, no `unsafe`, no privacy-claim surface touched.

## Verification

- `cargo clippy --manifest-path bench/dict/Cargo.toml --all-targets -- -D warnings` — clean locally.
- `cargo run --manifest-path bench/dict/Cargo.toml -- selftest` — `selftest OK: 10 terms, 6 IRIs, 3 literals (1 lang), 1 blanks…`.
- The CI path filter includes `.github/workflows/ci.yml`, so this PR **runs the new lane on itself**.

[OPUS-4.8]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
