### PR TITLE
docs(bench): reconcile Wikidata-8B runbook against merged dict-spill (sq-1q3) [OPUS-4.8]

### DIFF
--- a/bench/wikidata-8b/RUNBOOK.md
+++ b/bench/wikidata-8b/RUNBOOK.md
@@ -12,21 +12,25 @@ footprint via swap, and the dict extrapolates to ~280–330 GiB at full truthy.
 
 **This run is infeasible without dictionary spill-to-disk.** Without it, the dict
 alone is ~18–21× this box's RAM and the build would be effectively all-swap
-(stage-1 measured 4.8× per-triple slowdown at just 2.2× RAM). The dict-spill
-branch (`../sparq-dictspill`, currently @ 5069b33, feature `dict-spill`) is IN
-FLIGHT. Before launching:
+(stage-1 measured 4.8× per-triple slowdown at just 2.2× RAM). dict-spill is now
+**MERGED** to public main (`crates/sparq-core/src/dictspill.rs`; PRs #29/#582/#670).
+Before launching:
 
-1. dict-spill must be **merged to public main**; set `SPARQ_SHA` in
-   `scripts/config.sh` to a post-merge commit.
-2. Resolve the dict-spill flag/feature placeholders in `scripts/config.sh` and
-   `scripts/remote-8b.sh` (tracked in bead sq-1q3). Candidate names from the
-   in-flight branch (VERIFY against the merged impl — they may change):
-   - env: `SPARQ_DICT_SPILL=1|on|auto`, `SPARQ_DICT_SPILL_BUDGET_MB`,
-     `SPARQ_DICT_SPILL_DISK_FLOOR_MB`
-   - cargo: feature `dict-spill` exists on **sparq-core only**; sparq-cli does
-     not yet re-export it, so the build command is currently
-     `cargo build --release -p sparq-cli --features sparq-core/dict-spill`
-     (verify the merge's final plumbing).
+1. Set `SPARQ_SHA` in `scripts/config.sh` to a public-main commit at or after the
+   dict-spill merge (the module + the sparq-cli default feature must be present).
+2. dict-spill flags/feature RECONCILED against the merged impl (sq-1q3):
+   - env gate (`SpillConfig::from_lookup`): `SPARQ_DICT_SPILL=1|on|auto`
+     (`0`/`off`/unset keeps the in-RAM consolidation), `SPARQ_DICT_SPILL_BUDGET_MB`,
+     `SPARQ_DICT_SPILL_DISK_FLOOR_MB` (default floor 1024). The BUDGET governs the
+     dedup caches + external-sort run buffers ONLY — it does NOT count the
+     `chunk`×12 B triple-run buffer or the ~0.5–1 GiB parse pipeline, so real peak
+     RSS ≈ budget + that floor (8192 MB ⇒ ~9–10 GiB on the 15 GiB box).
+   - cargo: feature `dict-spill` is now a **DEFAULT** feature of sparq-cli
+     (`crates/sparq-cli/Cargo.toml`: `default = ["mmap","mimalloc","dict-spill"]`,
+     forwarding `sparq-core/dict-spill`), so the build command is simply
+     `cargo build --release -p sparq-cli` — no `--features` needed. (`CARGO_FEATURES`
+     in `config.sh` is therefore empty by default; the old
+     `--features sparq-core/dict-spill` was redundant and reached into the sub-crate.)
 3. Budget ledger check: ≤ $0.78 of the $30 cap spent; no live
    `purpose=sparq-hw-validation` instances; **NEVER touch i-090531b4ede8f2d3f**.
 4. Re-verify the dump headers (`curl -sI`, §3) — the dump rolls weekly and the
@@ -62,13 +66,27 @@ flagged estimate):
 | dump .gz (deleted after recompress) | 71 GB | 71 GB | verified Content-Length |
 | recompressed .zst | 56 GB | 66 GB | ~7.0 GB/B-triples (measured @1B: 6.99 GB) |
 | extsort temp runs (peak, upper bound) | 675 GB | 790 GB | ≤0.94× index (1B write-amplification) |
-| dict spill working set | ~150 GB | ~250 GB | ESTIMATE: ~69 B/term (measured @100M) at extrapolated term counts; refine from merged impl (sq-1q3) |
+| dict spill transient (staged + remap) | ~210 GB | ~250 GB | staged `[u64;3]` triples 24 B/triple (192/226 GB) + per-shard `seq→id` remap files (~8 B/distinct-term); deleted at remap end. NOT 69 B/term — that was the in-RAM dict @100M which spill REMOVES (sq-1q3) |
+| dict record files + sort runs (transient) | ~150 GB | ~180 GB | serialized distinct-term bytes + dedup/assign external-sort runs; ≈ on-disk dict (~38.4 B/distinct-term measured @100M, research/external-dictionary.md), deleted as consumed. Partly overlaps the final dict already in "final index" |
 | swapfile | 64 GB | 64 GB | fixed |
 | OS + rust + sparq build | 15 GB | 15 GB | stage-1 observed |
-| **peak total** | **~1,750 GB** | **~2,100 GB** | gz deleted before build (mandatory step) |
+| **peak total (remap phase)** | **~1,800 GB** | **~2,150 GB** | gz deleted before build; see phase note below — the two dict transient rows do NOT both co-peak |
 
-2,200 GB leaves ~5–25 % headroom. The remote driver samples `df` every 30 s and
-kills the build if free space drops below 50 GB (collect partials, terminate).
+The dict-spill transients are PHASE-DISJOINT from each other, so the rows do **not**
+all sum at once. The heaviest moment is the **remap phase**: final index (growing) +
+extsort temp runs + staged `[u64;3]` triples + .zst input + swap + OS. The dict
+**record files + dedup/assign sort runs** are freed BEFORE remap starts feeding
+extsort, so they peak earlier and separately (their phase total stays well under the
+remap peak). Peak total above is the remap co-peak: final index + extsort runs +
+staged triples + .zst + swap + OS ≈ 717 + 675 + 192 + 56 + 64 + 15 = ~1,720 GB @8B
+(round up to ~1,800 for transient-file slack), ~2,150 GB @9.4 B. The staged-triple file is
+the one dict-spill transient that overlaps the extsort-runs peak; it is the +24 B/triple
+the OLD budget's 69-B/term row mis-estimated.
+
+2,200 GB leaves ~2–18 % headroom (tighter at 9.4 B than the pre-reconcile estimate —
+the staged triples are real co-peak bytes). The remote driver samples `df` every 30 s
+and kills the build if free space drops below 50 GB (collect partials, terminate). If
+the 9.4-B case runs hot, raise `VOL_GB` to 2,400 (cost: +$0.025/h).
 
 ## 2. Cost model
 
@@ -161,7 +179,9 @@ instances — never double-launch.
 Executed by `remote-8b.sh`:
 
 ```sh
-# NOTE: verify these flag names + cli feature plumbing against the merged impl (sq-1q3).
+# Flag names + cli feature plumbing RECONCILED against the merged impl (sq-1q3):
+# dict-spill is a default sparq-cli feature, so the plain release binary has the spill
+# path; the env vars below are the merged SpillConfig::from_lookup gate.
 SPARQ_SHARDED_DICT=1 SPARQ_BUILD_TIMING=1 \
 SPARQ_DICT_SPILL=1 SPARQ_DICT_SPILL_BUDGET_MB=8192 \
 timeout 86400 /usr/bin/time -v \
@@ -169,10 +189,16 @@ timeout 86400 /usr/bin/time -v \
 ```
 
 - `32` = 32 M-triple chunks, same as stage 1 (~0.5 GB triple-sort cap).
-- Budget 8,192 MB ≈ half of RAM for the dict, leaving room for chunk buffers +
-  page cache on a 15 GiB-usable box. Tune against the merged implementation's
-  accounting (sq-1q3) — if the budget excludes overheads, go lower.
+- Budget 8,192 MB. The merged `SpillConfig` accounts ONLY the dedup caches + the
+  external-sort run buffers under this budget; it EXCLUDES the `chunk`×12 B triple-run
+  buffer (32M×12 B ≈ 384 MB at chunk=32) and the ~0.5–1 GiB parse pipeline. So expected
+  peak RSS ≈ 8,192 MB + ~1 GiB floor ≈ 9–10 GiB on the 15 GiB-usable box — headroom for
+  page cache. This confirms 8,192 MB is safe; it need NOT be lowered for overhead (the
+  overhead is already outside the budget). The watchdog still aborts on sustained swap
+  >24 GiB as the backstop.
 - `timeout 86400` (24 h) is the build-phase hard stop.
+- The build emits the `parse+intern+spill done` phase marker (verified against the
+  merged `build_timing::report`); the §9 throughput-floor checkpoint greps for it.
 
 ## 5. Monitoring
 

--- a/bench/wikidata-8b/STATUS.md
+++ b/bench/wikidata-8b/STATUS.md
@@ -16,6 +16,21 @@ instances first.
   candidate flags `SPARQ_DICT_SPILL`, `SPARQ_DICT_SPILL_BUDGET_MB`,
   `SPARQ_DICT_SPILL_DISK_FLOOR_MB`; cargo feature `dict-spill` (sparq-core only,
   NOT yet plumbed into sparq-cli's features) — reconcile against merged impl (sq-1q3).
+- [x] dict-spill MERGED to public main (`crates/sparq-core/src/dictspill.rs`;
+  PRs #29/#582/#670). sq-1q3 reconciliation vs the merged impl:
+  - env gate CONFIRMED unchanged (`SpillConfig::from_lookup`): `SPARQ_DICT_SPILL=1|on|auto`,
+    `SPARQ_DICT_SPILL_BUDGET_MB`, `SPARQ_DICT_SPILL_DISK_FLOOR_MB` (default floor 1024 MiB).
+  - cargo feature NOW plumbed: `dict-spill` is a DEFAULT feature of sparq-cli
+    (forwards `sparq-core/dict-spill`), so a plain `cargo build --release -p sparq-cli`
+    compiles the spill path; `CARGO_FEATURES` is now empty (the old
+    `--features sparq-core/dict-spill` was redundant + reached into the sub-crate).
+  - budget accounts dedup caches + sort-run buffers ONLY (EXCLUDES the chunk×12 B
+    triple-run buffer + ~0.5–1 GiB parse pipeline) ⇒ peak RSS ≈ budget + ~1 GiB floor;
+    8,192 MB ⇒ ~9–10 GiB on the 15 GiB box, so the budget need NOT be lowered for overhead.
+  - working-set estimate refined: the dict-spill DISK transient is the staged `[u64;3]`
+    triples (24 B/triple ⇒ ~192/226 GB @8/9.4 B) + remap files, NOT the OLD 69 B/term
+    (that was the in-RAM dict @100M which spill REMOVES); on-disk dict ≈ 38.4 B/distinct-term.
+  - `parse+intern+spill done` phase marker verified present (the §9 abort-checkpoint grep).
 - [x] RUNBOOK.md written (spec, cost model, duration estimates, abort criteria)
 - [x] scripts/ written (config/launch/run/collect/terminate/remote-8b/mem-sampler),
   all default to DRY-RUN; `EXECUTE=1` required for any AWS mutation
@@ -24,9 +39,10 @@ instances first.
 ## Phase: EXECUTION (NOT STARTED — blocked)
 
 Launch gate (ALL must hold before `EXECUTE=1`):
-- [ ] dict-spill merged to public main; `SPARQ_SHA` set to a post-merge commit
-- [ ] dict-spill flag/feature placeholders in `scripts/config.sh` + `scripts/remote-8b.sh`
-      reconciled against the merged flag names / cli feature plumbing (sq-1q3)
+- [x] dict-spill merged to public main (PRs #29/#582/#670)
+- [ ] `SPARQ_SHA` set to a public-main commit at/after the dict-spill merge (operator step)
+- [x] dict-spill flag/feature reconciled against the merged impl (sq-1q3): env gate
+      unchanged, cargo feature now a default sparq-cli feature, working-set refined
 - [ ] budget re-checked: ledger shows ≤ $0.78 spent of $30 cap
 - [ ] no live `purpose=sparq-hw-validation` instances; i-090531b4ede8f2d3f untouched
 

--- a/bench/wikidata-8b/scripts/config.sh
+++ b/bench/wikidata-8b/scripts/config.sh
@@ -16,13 +16,21 @@ DEADMAN_MIN="${DEADMAN_MIN:-2400}"        # 40 h hard cost ceiling ($17.04)
 # MUST be a public-main commit WITH dict-spill merged. Empty = refuse to launch.
 SPARQ_SHA="${SPARQ_SHA:-}"
 CHUNK_MILLIONS="${CHUNK_MILLIONS:-32}"
-# TODO(dict-spill): verify env names + values against the merged implementation.
-# Candidates from in-flight branch ../sparq-dictspill @ 5069b33:
-#   SPARQ_DICT_SPILL=1|on|auto, SPARQ_DICT_SPILL_BUDGET_MB, SPARQ_DICT_SPILL_DISK_FLOOR_MB
+# dict-spill is MERGED (sparq-core/dictspill.rs; PRs #29/#582/#670). Env gate confirmed
+# against the merged impl (SpillConfig::from_lookup):
+#   SPARQ_DICT_SPILL=1|on|auto  — 0/off/unset keeps the in-RAM consolidation
+#   SPARQ_DICT_SPILL_BUDGET_MB  — dedup-cache + sort-run budget (default: 1/4 of RAM)
+#   SPARQ_DICT_SPILL_DISK_FLOOR_MB — abort-before-fill floor (default 1024)
+# NOTE: the budget governs the dedup caches + external-sort run buffers ONLY; it does
+# NOT count the chunk×12 B triple-run buffer or the ~0.5–1 GiB parse pipeline, so the
+# real peak RSS is budget + that floor. 8192 MB ⇒ ~9–10 GiB peak on the 15 GiB box.
 DICT_SPILL_ENV="${DICT_SPILL_ENV:-SPARQ_DICT_SPILL=1 SPARQ_DICT_SPILL_BUDGET_MB=8192}"
-# TODO(dict-spill): verify cargo feature plumbing — on the in-flight branch the
-# feature lives on sparq-core only (sparq-cli does not re-export it).
-CARGO_FEATURES="${CARGO_FEATURES:---features sparq-core/dict-spill}"
+# Cargo feature plumbing CONFIRMED post-merge: `dict-spill` is a DEFAULT feature of
+# sparq-cli (crates/sparq-cli/Cargo.toml: default = ["mmap","mimalloc","dict-spill"]),
+# so a plain `cargo build --release -p sparq-cli` already compiles the spill path —
+# no extra --features needed. Left empty by default; the old `--features
+# sparq-core/dict-spill` is redundant and references a sub-crate feature directly.
+CARGO_FEATURES="${CARGO_FEATURES:-}"
 
 # --- data ------------------------------------------------------------------
 DUMP_URL="${DUMP_URL:-https://dumps.wikimedia.org/wikidatawiki/entities/latest-truthy.nt.gz}"

--- a/bench/wikidata-8b/scripts/remote-8b.sh
+++ b/bench/wikidata-8b/scripts/remote-8b.sh
@@ -14,8 +14,8 @@ BUILD_TIMEOUT_S="${4:-86400}"; SWAP_ABORT_MIB="${5:-24576}"; DISK_ABORT_FREE_GB=
 PARSE_CHECKPOINT_S="${7:-18000}"
 DUMP_URL="${8:-https://dumps.wikimedia.org/wikidatawiki/entities/latest-truthy.nt.gz}"
 DL_WORKERS="${9:-4}"
-DICT_SPILL_ENV="${10:-SPARQ_DICT_SPILL=1 SPARQ_DICT_SPILL_BUDGET_MB=8192}"  # TODO(dict-spill): verify at merge
-CARGO_FEATURES="${11:---features sparq-core/dict-spill}"                    # TODO(dict-spill): verify at merge
+DICT_SPILL_ENV="${10:-SPARQ_DICT_SPILL=1 SPARQ_DICT_SPILL_BUDGET_MB=8192}"  # merged env gate (SpillConfig::from_lookup)
+CARGO_FEATURES="${11:-}"  # dict-spill is a DEFAULT sparq-cli feature post-merge; no extra --features needed
 
 DRY="${DRY_RUN:-0}"
 X() { if [ "$DRY" = 1 ]; then echo "DRY+ $*"; else eval "$*"; fi; }
@@ -78,7 +78,8 @@ X "command -v cargo >/dev/null || curl --proto '=https' --tlsv1.2 -sSf https://s
 X ". '$HOME/.cargo/env'"
 X "git clone -q https://github.com/jeswr/sparq.git '$HOME/sparq'"
 X "cd '$HOME/sparq' && git checkout -q '$SHA_PIN' && git rev-parse HEAD > '$R/sha.txt'"
-# TODO(dict-spill): confirm feature plumbing post-merge (sparq-cli may re-export it).
+# dict-spill is a DEFAULT sparq-cli feature post-merge, so the plain build compiles the
+# spill path; $CARGO_FEATURES is empty unless an A/B run overrides it (e.g. to add a feature).
 X "cd '$HOME/sparq' && cargo build --release -q -p sparq-cli $CARGO_FEATURES 2> '$R/cargo-build.log'"
 CLI="$HOME/sparq/target/release/sparq-cli"
 X "'$CLI' --help > '$R/cli-help.txt' 2>&1 || true"


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes the bead **sq-1q3** — *Wikidata-8B runbook: reconcile dict-spill flags/feature + refine working-set estimate against merged impl*.

dict-spill is now merged to main (`crates/sparq-core/src/dictspill.rs`; PRs #29/#582/#670). This reconciles the stage-2 runbook + on-box scripts against the **merged** implementation so they carry no stale `TODO(dict-spill)` markers, and corrects a working-set basis error.

### What changed (docs + bench-script only — no Rust source / public API / unsafe)

1. **Flags reconciled** (`config.sh`, `remote-8b.sh`, RUNBOOK §0/§4). `SPARQ_DICT_SPILL=1|on|auto`, `SPARQ_DICT_SPILL_BUDGET_MB`, `SPARQ_DICT_SPILL_DISK_FLOOR_MB` confirmed **unchanged** against the merged `SpillConfig::from_lookup`. Documented the load-bearing detail that the **budget governs the dedup caches + external-sort run buffers ONLY** — it excludes the `chunk`×12 B triple-run buffer and the ~0.5–1 GiB parse pipeline — so peak RSS ≈ budget + ~1 GiB floor. 8,192 MB ⇒ ~9–10 GiB on the 15 GiB box, so the budget need **not** be lowered for overhead (the old note said "if the budget excludes overheads, go lower"; it does exclude them, but the floor is small enough that 8,192 MB is already safe).

2. **Feature plumbing confirmed.** At branch-inspection time `dict-spill` was sparq-core-only; in the merged tree it is a **DEFAULT feature of sparq-cli** (`default = ["mmap","mimalloc","dict-spill"]`, forwarding `sparq-core/dict-spill`). So a plain `cargo build --release -p sparq-cli` compiles the spill path — the old `--features sparq-core/dict-spill` is redundant and reached into the sub-crate. `CARGO_FEATURES` now defaults **empty** in both scripts.

3. **Working-set estimate refined** (RUNBOOK §1 disk budget). The old row used **~69 B/term**, which was actually the *in-RAM* dict footprint @100M — the very thing dict-spill **removes** — so it was the wrong basis. Against the merged impl the dict-spill **disk transient** is:
   - staged `[u64;3]` triples = **24 B/triple** ⇒ ~192/226 GB @8/9.4 B (verified in `dictspill.rs`), which co-exists with the extsort runs during remap;
   - per-shard `seq → final-id` remap files = **8 B/distinct-term** (`(u32,u32)`, verified);
   - dict record files + dedup/assign sort runs ≈ on-disk dict (**~38.4 B/distinct-term** measured @100M, `research/external-dictionary.md`), freed *before* remap.
   The disk budget is now split into **phase-disjoint** rows with an explicit "do not sum all rows" note; the peak total is the **remap co-peak** (~1,800/~2,150 GB). The 2,200 GB volume still fits (~2–18 % headroom), with a note to bump `VOL_GB` to 2,400 if the 9.4 B case runs hot.

4. **Phase marker verified.** Confirmed the `parse+intern+spill done` marker (the §9 throughput-floor abort checkpoint the watchdog greps for) is emitted by the merged `build_timing::report` — so the abort logic is correct against the merged build.

5. **STATUS.md** prep + launch-gate checklist updated to reflect the merge + this reconciliation (no raw TODO markers remain).

### Gate
- Pure docs (`.md`) + bench shell scripts; zero `.rs` / `Cargo.toml` / public-API / `unsafe` change, so the Rust crate build/clippy/test/rustdoc gate is not triggered by this diff.
- `bash -n` clean on both edited scripts; the empty-`CARGO_FEATURES` expansion is a no-op in the build command. (Pre-existing shellcheck SC2034/SC2164 on untouched lines left alone.)
- Privacy-claims honesty gate: `scripts/check-privacy-claims.sh` → OK (and `bench/` is out of its scanned surface anyway).
- All factual claims cross-checked directly against the merged source (`dictspill.rs`, `lib.rs`, `sparq-cli/Cargo.toml`) and `research/external-dictionary.md`.

Honest scope note: this is a runbook/script reconciliation, not a benchmark run — the 8 B EXECUTE step stays gated on the operator setting `SPARQ_SHA` and the budget/instance checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)