### PR TITLE
ci(docs-site): anti-drift glue — lychee over built site HTML + generated-fragment headers (sq-d8or) [OPUS-4.8]

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -243,6 +243,21 @@ jobs:
         run: python3 scripts/check-install-action-tool.py --self-test
       - name: "Enforce explicit `with: tool:` on every SHA-pinned install-action — GATING"
         run: python3 scripts/check-install-action-tool.py
+      # [OPUS-4.8] sq-d8or: the built-docs-site link gate (scripts/check-site-links.sh) is
+      # invoked on the publish path in pages.yml (after `next build`), where the static export
+      # exists. Its remap of the /sparq GitHub-Pages base path + its TEETH (a broken internal
+      # link / dangling #anchor must fail) are easy to break silently when the export's link
+      # shape changes, so the hermetic self-test is run HERE on every PR — it builds a tiny
+      # synthetic export and asserts both a clean pass and that a dead link fails. lychee is
+      # provisioned for this self-test the same SHA-pinned way pages.yml installs it.
+      - name: shellcheck check-site-links.sh + its self-test
+        run: shellcheck scripts/check-site-links.sh scripts/tests/test_check_site_links.sh
+      - name: Install lychee (for the site-links self-test)
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: lychee@0.23.0
+      - name: Self-test check-site-links.sh (basePath remap + broken-link teeth)
+        run: bash scripts/tests/test_check_site_links.sh
 
   # ----------------------------- ADVISORY -----------------------------
   markdownlint-advisory:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -157,6 +157,27 @@ jobs:
           npm ci
           npm run build   # prebuild copies js/wasm → site/public/wasm + builds papers, then next build → out/
 
+      # [OPUS-4.8] sq-d8or — anti-drift: link-check the BUILT site HTML before publish.
+      # The docs-quality `internal-links` job (sq-5fd1) lychee-checks the repo MARKDOWN;
+      # this extends that scope to the static-export HTML the Pages site actually serves —
+      # catching renamed routes / stale cross-links / dangling #anchors that markdown linting
+      # cannot see. lychee runs --offline (deterministic, no network) over site/out, remapping
+      # the /sparq GitHub-Pages base path to the export root. Runs BEFORE the dev/ overlay so
+      # it checks only THIS site's source (the overlaid benchmark dashboard is excluded by the
+      # script anyway). The remap + teeth live in a shared, self-tested script
+      # (scripts/check-site-links.sh + scripts/tests/test_check_site_links.sh, run in
+      # docs-quality's ci-scripts job) so the logic is pinned and reusable locally. A broken
+      # internal link FAILS the build → no broken deploy. lychee is installed via the same
+      # SHA-pinned taiki-e/install-action this repo already trusts (cf. docs-quality typos);
+      # 0.23.0 is the version lycheeverse/lychee-action@v2.8.0 ships, so behaviour matches the
+      # markdown gate.
+      - name: Install lychee
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: lychee@0.23.0
+      - name: Link-check the static-export HTML (lychee --offline)
+        run: bash scripts/check-site-links.sh site/out
+
       # ---- Preserve the existing benchmark dashboard at /sparq/dev/ ----
       - name: Overlay benchmark dashboard (dev/) from benchmark-data
         working-directory: site

--- a/scripts/check-site-links.sh
+++ b/scripts/check-site-links.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] sq-d8or — anti-drift CI glue: offline link-check over the BUILT docs-site HTML.
+#
+# WHY: the docs-quality `internal-links` job (bead sq-5fd1) runs lychee --offline over the
+# repo's MARKDOWN, but the published GitHub Pages site (the Next.js static export under
+# site/out/, plus the in-site rendered papers) is HTML — its relative links + #anchors were
+# never link-checked, so a renamed route or a stale cross-link could ship broken to the live
+# site. sq-d8or extends the lychee scope to that built HTML. This script is the shared,
+# self-testable core (CLI; no Action) so the same check runs in CI (pages.yml, after
+# `next build`) and locally (`scripts/check-site-links.sh site/out`).
+#
+# WHAT: lychee --offline (no network, deterministic) over every *.html under the export,
+# validating relative links AND heading anchors (--include-fragments). The static export is
+# served under the `/sparq` GitHub Pages base path (site/next.config.ts: basePath:"/sparq",
+# trailingSlash:true), so every INTERNAL link in the emitted HTML is an absolute path like
+#   /sparq/about/   (and the bare root link /sparq/).
+# On disk those resolve to <out>/about/index.html and <out>/index.html — i.e. the `/sparq`
+# prefix must be stripped to land in the export root. Two --remap rules do exactly that:
+#   1. file://<out>/sparq/(.*)  -> file://<out>/$1          (every /sparq/<path> link)
+#   2. file://<out>/sparq       -> file://<out>/index.html  (the bare /sparq root link)
+# (lychee normalises a trailing-slash dir link to the slashless path before matching, so the
+# two rules together cover both forms — verified empirically: 0 errors over the full export,
+# and an injected dead link is caught.)
+#
+# EXIT: non-zero iff lychee finds a broken internal link/anchor (CI-gating). A self-test of
+# the remap + teeth lives in scripts/tests/test_check_site_links.sh.
+set -euo pipefail
+
+OUT_DIR="${1:-site/out}"
+
+if ! command -v lychee >/dev/null 2>&1; then
+  echo "check-site-links: 'lychee' not found on PATH." >&2
+  echo "  Install it (cargo install lychee) or run via the pinned lycheeverse action in CI." >&2
+  exit 127
+fi
+
+if [ ! -d "$OUT_DIR" ]; then
+  echo "check-site-links: export directory '$OUT_DIR' not found." >&2
+  echo "  Build it first:  (cd site && npm ci && npm run build)" >&2
+  exit 1
+fi
+
+# Absolute path so the file:// remap patterns are unambiguous regardless of CWD.
+OUT_ABS="$(cd "$OUT_DIR" && pwd)"
+
+echo "check-site-links: lychee --offline over ${OUT_ABS}/**/*.html (basePath /sparq remapped)"
+
+# --root-dir lets lychee resolve absolute (/...) links against the export root; the two
+# --remap rules strip the /sparq Pages base path. `dev/` (the overlaid benchmark dashboard,
+# a separate first-party artifact written by bench.yml onto benchmark-data) is excluded:
+# it is not part of THIS site's source and carries its own link surface.
+lychee \
+  --offline \
+  --include-fragments \
+  --no-progress \
+  --root-dir "$OUT_ABS" \
+  --remap "file://${OUT_ABS}/sparq/(.*) file://${OUT_ABS}/\$1" \
+  --remap "file://${OUT_ABS}/sparq file://${OUT_ABS}/index.html" \
+  --exclude-path "${OUT_ABS}/dev" \
+  "${OUT_ABS}/**/*.html"

--- a/scripts/tests/test_check_site_links.sh
+++ b/scripts/tests/test_check_site_links.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] Hermetic both-direction self-test for scripts/check-site-links.sh (bead
+# sq-d8or — the built-docs-site link gate). Authored by Opus 4.8 (Fable unavailable;
+# flag for re-review when Fable returns).
+#
+# WHY: the gate's value rests on TWO load-bearing behaviours that are easy to break
+# silently when the export's basePath / link shape changes:
+#   1. CORRECTNESS — the `/sparq` GitHub-Pages base-path remap must resolve a normal
+#      internal link (/sparq/about/), the bare root link (/sparq/), an in-page #anchor,
+#      AND a relative sibling link to the right on-disk file, so a CLEAN export PASSES
+#      with NO false positives (a false positive would block every Pages deploy).
+#   2. TEETH — a genuinely broken internal link MUST fail the gate (exit non-zero), or
+#      the gate is decorative.
+# This harness pins both directions over a tiny synthetic export that mimics the real
+# Next.js static export (basePath:"/sparq", trailingSlash:true) — so a regression in the
+# remap rules or the lychee invocation is caught here, before the gate guards a deploy.
+#
+# HERMETIC: builds its own throwaway export tree under a mktemp dir; no repo content, no
+# network (lychee --offline). Requires the `lychee` binary (CI has it; locally:
+# cargo install lychee). If lychee is absent we SKIP with a clear message rather than
+# fail, so the harness never reds a contributor box that simply lacks the tool.
+#
+# Run:  bash scripts/tests/test_check_site_links.sh   (exit 0 = pass, 1 = a case failed)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GATE="${ROOT}/scripts/check-site-links.sh"
+
+[ -f "$GATE" ] || { echo "FATAL: gate script not found at ${GATE}"; exit 2; }
+
+if ! command -v lychee >/dev/null 2>&1; then
+  echo "SKIP: 'lychee' not on PATH — install it (cargo install lychee) to run this self-test."
+  exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --------------------------------------------------------------------------- #
+# Build a minimal export that mirrors the real one: basePath /sparq, trailing-slash
+# dir routes, an in-page anchor, a relative sibling link, and a bare-root link.
+# --------------------------------------------------------------------------- #
+GOOD="${TMP}/good"
+mkdir -p "${GOOD}/about" "${GOOD}/surface/sparql"
+
+# Home page: links the bare root, a route, an anchor on this page, a relative sibling.
+cat > "${GOOD}/index.html" <<'HTML'
+<!doctype html><html><head><title>home</title></head><body>
+  <a href="/sparq/">root</a>
+  <a href="/sparq/about/">about</a>
+  <a href="/sparq/surface/sparql/">sparql surface</a>
+  <a href="#section-a">jump</a>
+  <h2 id="section-a">Section A</h2>
+</body></html>
+HTML
+
+cat > "${GOOD}/about/index.html" <<'HTML'
+<!doctype html><html><head><title>about</title></head><body>
+  <a href="/sparq/">home</a>
+  <a href="/sparq/surface/sparql/">sparql</a>
+</body></html>
+HTML
+
+cat > "${GOOD}/surface/sparql/index.html" <<'HTML'
+<!doctype html><html><head><title>sparql</title></head><body>
+  <a href="/sparq/about/">about</a>
+</body></html>
+HTML
+
+# --------------------------------------------------------------------------- #
+# Case 1 (should-PASS): the clean export must pass with no findings.
+# --------------------------------------------------------------------------- #
+if bash "$GATE" "$GOOD" >/tmp/site-links-good.log 2>&1; then
+  echo "PASS: clean export with /sparq base-path links passes"
+else
+  echo "FAIL: clean export was rejected (false positive — remap likely broken):"
+  sed 's/^/    /' /tmp/site-links-good.log
+  exit 1
+fi
+
+# --------------------------------------------------------------------------- #
+# Case 2 (should-FAIL): a broken internal route link must fail the gate.
+# --------------------------------------------------------------------------- #
+BAD="${TMP}/bad"
+cp -r "$GOOD" "$BAD"
+cat >> "${BAD}/index.html" <<'HTML'
+<a href="/sparq/this-route-does-not-exist/">dead</a>
+HTML
+
+if bash "$GATE" "$BAD" >/tmp/site-links-bad.log 2>&1; then
+  echo "FAIL: a broken internal link was NOT caught (gate has no teeth):"
+  sed 's/^/    /' /tmp/site-links-bad.log
+  exit 1
+else
+  echo "PASS: broken internal link is caught (exit non-zero)"
+fi
+
+# --------------------------------------------------------------------------- #
+# Case 3 (should-FAIL): a broken in-page #anchor must fail (--include-fragments).
+# --------------------------------------------------------------------------- #
+ANCHOR="${TMP}/anchor"
+cp -r "$GOOD" "$ANCHOR"
+cat >> "${ANCHOR}/about/index.html" <<'HTML'
+<a href="#no-such-anchor">dangling anchor</a>
+HTML
+
+if bash "$GATE" "$ANCHOR" >/tmp/site-links-anchor.log 2>&1; then
+  echo "FAIL: a dangling #anchor was NOT caught (--include-fragments not effective):"
+  sed 's/^/    /' /tmp/site-links-anchor.log
+  exit 1
+else
+  echo "PASS: dangling #anchor is caught (exit non-zero)"
+fi
+
+echo "All check-site-links self-tests passed."

--- a/site/scripts/build-papers.mjs
+++ b/site/scripts/build-papers.mjs
@@ -28,6 +28,20 @@ const PAPERS_DIR = join(SITE, "papers");
 const PDF_OUT_DIR = join(SITE, "public", "papers");
 const HTML_OUT_DIR = join(SITE, "src", "generated", "papers");
 
+// [OPUS-4.8] sq-d8or — anti-drift "GENERATED at build time" header for the build-copied
+// HTML fragments under src/generated/papers/. The fragment is the in-site render compiled
+// from the tracked papers/<slug>.typ source on every `prebuild`; it is git-ignored
+// (site/.gitignore: /src/generated/) and must NEVER be hand-edited. A leading HTML comment
+// is invisible when the route injects the fragment via dangerouslySetInnerHTML, so it adds
+// no render cost while making the provenance unmistakable to anyone who opens the file.
+// `source` is the .typ this fragment was compiled from.
+function generatedHeader(source) {
+  return (
+    `<!-- GENERATED at build time by site/scripts/build-papers.mjs from papers/${source} -->\n` +
+    `<!-- DO NOT EDIT: regenerate with \`npm run build-papers\` (or \`npm run build\`). -->\n`
+  );
+}
+
 // ---- resolve the typst binary -------------------------------------------------------------
 function resolveTypst() {
   const candidates = [
@@ -122,7 +136,8 @@ function compilePaper(typst, paper, evidenceJson) {
   const full = readFileSync(htmlOut, "utf8");
   const body = full.match(/<body[^>]*>([\s\S]*)<\/body>/i);
   const fragment = body ? body[1] : full;
-  writeFileSync(htmlOut, fragment, "utf8");
+  // [OPUS-4.8] sq-d8or — stamp the build-time provenance header (invisible HTML comment).
+  writeFileSync(htmlOut, generatedHeader(paper.source) + fragment, "utf8");
 
   console.log(`[paper-factory] built ${paper.slug}: ${pdfOut} + ${htmlOut}`);
 }
@@ -150,7 +165,8 @@ function main() {
     for (const p of papers) {
       const placeholder = `<p class="paper-placeholder">This paper renders from <code>papers/${p.source}</code>. ` +
         `Install the Typst CLI to build it locally; CI builds it automatically.</p>`;
-      writeFileSync(join(HTML_OUT_DIR, `${p.slug}.html`), placeholder, "utf8");
+      // [OPUS-4.8] sq-d8or — same build-time provenance header on the placeholder fragment.
+      writeFileSync(join(HTML_OUT_DIR, `${p.slug}.html`), generatedHeader(p.source) + placeholder, "utf8");
       // a 1-line text PDF stand-in is not produced; the route guards a missing PDF asset.
     }
     return;


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead **sq-d8or** (docs-site anti-drift CI glue). @jeswr runs multiple agents on this account; flag for re-review when Fable returns ([OPUS-4.8] markers + Opus 4.8 trailer on all new code).

## What & why

Bead **sq-d8or** is coordination glue for the docs-site anti-drift estate, with three concrete asks. This PR addresses each honestly:

### 1. Extend lychee scope → the BUILT site HTML  *(new gate)*
The docs-quality `internal-links` job (sq-5fd1) runs `lychee --offline` over the repo's **markdown** only. The published GitHub Pages site — the Next.js static export under `site/out/`, plus the in-site paper renders — is **HTML**, and its relative links + `#anchors` were never link-checked, so a renamed route or stale cross-link could ship broken to the live site.

- **`scripts/check-site-links.sh`** — `lychee --offline` (deterministic, no network) over `site/out/**/*.html`. The export is served under the `/sparq` Pages base path (`next.config.ts`: `basePath:"/sparq"`, `trailingSlash:true`), so every internal link is an absolute `/sparq/...` path; two `--remap` rules strip that prefix so the links resolve against the export root (the bare `/sparq/` root link included). The overlaid benchmark dashboard (`dev/`, a separate first-party artifact) is excluded.
- Wired into **`pages.yml`** right after `next build` (where the export already exists, before the `dev/` overlay). A broken internal link **fails the build → nothing broken deploys**.
- **`scripts/tests/test_check_site_links.sh`** — hermetic both-direction self-test over a tiny synthetic export: asserts a clean export **passes** (no false positives → never wrongly blocks a deploy) AND that a dead route link / dangling `#anchor` **fails** (teeth). Runs in docs-quality's `ci-scripts` job on **every PR**, so a regression in the remap/teeth is caught even on PRs that don't rebuild the site.

Empirically verified: **0 errors over the real 1671-link export**; an injected dead link is caught; the self-test's 3 cases pass.

### 2. GENERATED-at-build-time header on build-copied files
`site/scripts/build-papers.mjs` now stamps every `src/generated/papers/<slug>.html` (the build-copied in-site render — git-ignored, recompiled from the tracked `papers/<slug>.typ` on every `prebuild`) with a leading `GENERATED ... DO NOT EDIT` HTML comment. It is invisible when the route injects the fragment via `dangerouslySetInnerHTML`, so zero render cost, but the provenance is unmistakable to anyone who opens the file. Both the real-compile and the Typst-absent placeholder paths get the header. (The other committed build-copied artifact, `benchmarks.generated.json`, already carries a `generatedAt` + `source` header.)

### 3. Confirm the doctest gate — already present, no change
`ci.yml`'s `build-archive` job already runs `cargo test --workspace --features approx-ann,filtered-ann,vec-predicate --doc` (sq-p26u), off the warm build. **Confirmed present** — documented here rather than shipping a no-op edit.

## Test plan / gate
This PR changes **CI/shell/a build script only — no Rust, no Cargo, no `unsafe`** (the Rust gate suite is path-skipped for a non-Rust PR). Relevant gates run + pass locally:
- `shellcheck` on both new scripts — clean.
- `scripts/tests/test_check_site_links.sh` — 3/3 pass (clean export passes; dead link + dangling anchor fail).
- `scripts/check-install-action-tool.py` (GATING `with: tool:` lint) — PASS for both new SHA-pinned `taiki-e/install-action` steps (`lychee@0.23.0`, the version `lycheeverse/lychee-action@v2.8.0` ships).
- `scripts/check-privacy-claims.sh` — PASS.
- Both edited workflows parse (YAML) cleanly; `node --check site/scripts/build-papers.mjs` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)