### PR TITLE
chore(deps): hold dtolnay/rust-toolchain MSRV pin at declared 1.88 floor; ignore version-bumps (sq-sski) [OPUS-4.8]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,24 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # [OPUS-4.8] sq-sski: do NOT let Dependabot version-bump dtolnay/rust-toolchain.
+      # Its release tags are *Rust toolchain versions*, not action releases — the
+      # trailing `# 1.88` comment on the MSRV-check pin in .github/workflows/ci.yml is
+      # the declared workspace floor (root Cargo.toml `[workspace.package]
+      # rust-version = "1.88"`, driven by geo@0.33.1 + the released ox* parser stack).
+      # Bumping that pin to e.g. 1.100 would raise the *tested* floor above the
+      # *declared* floor, so the MSRV job would stop verifying the declared floor —
+      # defeating its purpose. This pin must move only in lockstep with the root
+      # rust-version, by hand. Dependabot grouped PR #26 (actions-minor-patch) kept
+      # proposing 1.88->1.100; ignore minor/major version-updates here so it stops
+      # re-opening. The action stays SHA-pinned and tracked: security-updates are NOT
+      # ignored, and every other action in this ecosystem still gets its grouped
+      # minor/patch bumps.
+      - dependency-name: "dtolnay/rust-toolchain"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
 
   # ---- npm (the @jeswr/sparq wasm package) ----
   - package-ecosystem: npm


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-sski**.

## What & why

Re-evaluation of Dependabot grouped PR **#26** (`actions-minor-patch`), which bundled two bumps:

- `ossf/scorecard-action` 2.4.0 → 2.4.3 — already taken into deps-safe-bumps.
- `dtolnay/rust-toolchain` **1.88 → 1.100** for the CI *"MSRV check (Rust 1.88, declared floor)"* job — **excluded**, this PR records why and stops the re-proposal.

**Verdict: do NOT bump the MSRV pin.** `dtolnay/rust-toolchain`'s release tags are *Rust toolchain versions*, not action releases. The MSRV-check pin in `.github/workflows/ci.yml` (trailing `# 1.88`) is the **declared workspace floor** — root `Cargo.toml` `[workspace.package] rust-version = "1.88"`, driven by `geo@0.33.1` + the released `ox*` parser stack. Raising the pin to 1.100 would lift the *tested* floor above the *declared* floor, so the MSRV job would no longer verify the declared floor and the gate would become meaningless. The pin must move only **in lockstep** with the root `rust-version`, by hand, and only once `geo` + the `ox*` stack actually require a higher `rustc`.

## Change

Add an `ignore` condition to the `github-actions` Dependabot ecosystem in `.github/dependabot.yml` for `dtolnay/rust-toolchain` (`version-update:semver-minor` + `semver-major`) with the full rationale inline. This stops the grouped PR #26 from re-opening, while:

- keeping the action **SHA-pinned and tracked** — `security-updates` are *not* ignored;
- letting **every other action** in the ecosystem still receive its grouped minor/patch bumps.

No `ci.yml` change is needed: the MSRV pin is already at the correct `1.88` floor (PR #26's rust-toolchain bump was never applied), so editing it would be a no-op.

## Scope / honesty

- Config-only change (`.github/dependabot.yml`); no `.rs`, `Cargo.toml`, `Cargo.lock`, or `unsafe` touched — the Rust build/clippy/test/rustdoc and unsafe-register gates do not apply.
- No public API changed → no `SKILL.md` (G2) update required.
- YAML validated; `ignore` block parses and asserts correctly against the Dependabot schema (top-level `ignore` per ecosystem).
- PR #26 is already `CLOSED` and there are no open Dependabot PRs for `rust-toolchain`; this PR makes the exclusion durable so it does not recur.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
