### PR TITLE
feat(bench/cli): --json <path> results emit for bench / bench-mmap (sq-d7d) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3329,6 +3329,7 @@ dependencies = [
  "oxrdf 0.3.3",
  "oxttl 0.2.3",
  "rayon",
+ "serde_json",
  "spargebra",
  "sparq-core",
  "sparq-engine",

--- a/bench/qlever-baselines.md
+++ b/bench/qlever-baselines.md
@@ -47,6 +47,12 @@ Run sparq alone (background):
      bench/qlever-100m/queries <iters> count`
 then read each query's µs from stdout and divide the QLever ms above by it.
 
+For a machine-readable run, append `--json <path>` (e.g. `… count --json /tmp/run.json`):
+the STDOUT TSV is unchanged and the same measured fields (`name` / `rows` / `min_micros`,
+min-of-iters) are ALSO written to `<path>` as a JSON document — the structured-benchmark-catalog
+shape. `bench-mmap` takes the same flag. The emitted numbers are whatever the running host
+measured (NON-CANONICAL); never commit them.
+
 ## sparq vs QLever — compute-only comparison (2026-06-09, native QLever 0.5.47 reproduced)
 
 Re-ran QLever natively (Homebrew `qlever-server`, SYSTEM=native, cold/cache-cleared) — numbers

--- a/crates/sparq-cli/Cargo.toml
+++ b/crates/sparq-cli/Cargo.toml
@@ -98,3 +98,9 @@ memmap2 = { workspace = true }
 flate2 = "1"
 bzip2 = "0.5"
 zstd = "0.13"
+# [OPUS-4.8] (sq-d7d) `bench`/`bench-mmap` emit a dependency-free JSON results document via
+# `--json <path>` (the runtime CLI adds NO serde dep — it hand-builds the JSON like
+# mpc_net_bench::cell_json). serde_json is a TEST-ONLY dep so cli_contract.rs can prove the
+# emitted document is genuinely valid, parseable JSON with the expected keys (a stronger
+# assertion than substring checks). Dev-deps never enter the shipped binary or its MSRV.
+serde_json = "1"

--- a/crates/sparq-cli/README.md
+++ b/crates/sparq-cli/README.md
@@ -34,7 +34,11 @@ cargo run --release -p sparq-cli -- query data.ttl turtle 'SELECT * WHERE { ?s ?
   json (`--format`), CONSTRUCT/DESCRIBE as N-Triples.
 - **`build` / `query-mmap`** — build an on-disk index once, then query it memory-mapped
   without loading the dataset into RAM.
-- **`bench`** — run a directory of `*.rq` queries N times each, one TSV timing line per query.
+- **`bench` / `bench-mmap`** — run a directory of `*.rq` queries N times each, one TSV timing
+  line per query. Pass `--json <path>` to ALSO write the per-query results (`name` / `rows` /
+  `min_micros`, min-of-iters) to `<path>` as a machine-readable JSON document (the
+  structured-benchmark-catalog shape); the STDOUT TSV is unchanged. Measured numbers are
+  whatever the running host reports and are non-canonical — never commit them.
 - **`--reason <rdfs|owl-rl|n3>`** — opt-in forward-chaining materialization before query.
 - **Transparent decompression** — `.gz` / `.bz2` / `.zst` inputs detected by content.
   The gzip path defaults to the pure-Rust `miniz_oxide` backend; the opt-in, native-only

--- a/crates/sparq-cli/src/main.rs
+++ b/crates/sparq-cli/src/main.rs
@@ -1190,11 +1190,42 @@ fn die_query(e: String) -> ! {
     std::process::exit(1);
 }
 
+/// [OPUS-4.8] (sq-d7d) Extract a `--json <path>` results-emit flag (and its value) from the
+/// positional argument vector, returning `(positional_args_without_the_flag, Option<path>)`.
+/// `bench` / `bench-mmap` index their other arguments positionally (`args.get(N)`), so the
+/// flag+value pair is removed BEFORE positional parsing rather than handled inline — this keeps
+/// the historical positional contract intact whether the flag is present or absent. A bare
+/// `--json` with no following value is a usage error (exit 2), mirroring the rest of the CLI.
+fn take_json_flag(args: &[String]) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
 fn cmd_bench(args: &[String]) {
+    let (args, json_path) = take_json_flag(args);
     let (path, format, dir) = match (args.get(2), args.get(3), args.get(4)) {
         (Some(p), Some(f), Some(d)) => (p, f, d),
         _ => {
-            eprintln!("usage: sparq-cli bench <data-file> <format> <queries-dir> [iters]");
+            eprintln!("usage: sparq-cli bench <data-file> <format> <queries-dir> [iters] [count|materialize|json] [--json <results.json>]");
             std::process::exit(2);
         }
     };
@@ -1205,7 +1236,7 @@ fn cmd_bench(args: &[String]) {
         std::process::exit(2);
     }
     let g = load(path, format);
-    run_query_suite(&g, dir, iters, mode);
+    run_query_suite(&g, dir, iters, mode, json_path.as_deref());
 }
 
 /// `bench-mmap <dir> <queries-dir> [iters] [count|materialize|json]` — same as `bench`
@@ -1213,10 +1244,11 @@ fn cmd_bench(args: &[String]) {
 /// be measured without loading it into RAM. Used to compare sparq's compute against the
 /// stored QLever baselines at 100M+ on a 16 GB machine.
 fn cmd_bench_mmap(args: &[String]) {
+    let (args, json_path) = take_json_flag(args);
     let (dir, qdir) = match (args.get(2), args.get(3)) {
         (Some(d), Some(q)) => (d.as_str(), q.as_str()),
         _ => {
-            eprintln!("usage: sparq-cli bench-mmap <index-dir> <queries-dir> [iters] [count|materialize|json] [decompress]");
+            eprintln!("usage: sparq-cli bench-mmap <index-dir> <queries-dir> [iters] [count|materialize|json] [decompress] [--json <results.json>]");
             std::process::exit(2);
         }
     };
@@ -1234,12 +1266,26 @@ fn cmd_bench_mmap(args: &[String]) {
         g.decompress_indexes();
         eprintln!("decompressed indexes to RAM in {:.3}s | committed heap ~{:.3} GB", t.elapsed().as_secs_f64(), g.heap_bytes() as f64 / 1e9);
     }
-    run_query_suite(&g, qdir, iters, mode);
+    run_query_suite(&g, qdir, iters, mode, json_path.as_deref());
+}
+
+/// One measured row of the query suite — the same fields the TSV reports
+/// (`name`, `rows`, `min_micros`), captured so they can be serialised to JSON.
+/// [OPUS-4.8] (sq-d7d)
+struct SuiteRow {
+    name: String,
+    /// `Ok(min_micros)` for a successful query (with `rows`), or `Err(message)` if it failed.
+    outcome: Result<(usize, f64), String>,
 }
 
 /// Runs every `*.rq` in `dir` (sorted) `iters` times in `mode`, printing one TSV line
 /// per query: `<name>\t<rows>\t<min_micros>`.
-fn run_query_suite(g: &sparq_core::Graph, dir: &str, iters: usize, mode: &str) {
+///
+/// [OPUS-4.8] (sq-d7d) When `json_path` is `Some`, the SAME measured fields are ALSO written
+/// to that path as a machine-readable JSON document (the structured-benchmark-catalog pattern,
+/// mirroring `bench/memtier` / `mpc_net_bench`'s dependency-free emit). STDOUT is byte-for-byte
+/// unchanged whether or not the flag is present — JSON is strictly additive.
+fn run_query_suite(g: &sparq_core::Graph, dir: &str, iters: usize, mode: &str, json_path: Option<&str>) {
     let mut entries: Vec<_> = std::fs::read_dir(dir)
         .unwrap_or_else(|e| {
             eprintln!("error reading {dir}: {e}");
@@ -1251,6 +1297,7 @@ fn run_query_suite(g: &sparq_core::Graph, dir: &str, iters: usize, mode: &str) {
         .collect();
     entries.sort();
 
+    let mut results: Vec<SuiteRow> = Vec::with_capacity(entries.len());
     for path in entries {
         let name = path.file_stem().unwrap().to_string_lossy().to_string();
         let sparql = std::fs::read_to_string(&path).unwrap();
@@ -1288,9 +1335,85 @@ fn run_query_suite(g: &sparq_core::Graph, dir: &str, iters: usize, mode: &str) {
                 }
             }
         }
-        match err {
+        match &err {
             None => println!("{name}\t{rows}\t{best:.1}"),
             Some(e) => println!("{name}\tERROR\t{e}"),
         }
+        let outcome = match err {
+            None => Ok((rows, best)),
+            Some(e) => Err(e),
+        };
+        results.push(SuiteRow { name, outcome });
     }
+
+    if let Some(p) = json_path {
+        let doc = suite_results_json(mode, iters, &results);
+        if let Err(e) = std::fs::write(p, doc) {
+            eprintln!("error writing --json results to {p}: {e}");
+            std::process::exit(1);
+        }
+        eprintln!("wrote {} query results to {p}", results.len());
+    }
+}
+
+/// [OPUS-4.8] (sq-d7d) Serialise a query-suite run to stable, dependency-free JSON — the same
+/// hand-built `format!` convention as `mpc_net_bench::cell_json` (no serde_json dep added to the
+/// CLI). The shape mirrors the catalog pattern: a top-level object carrying the run parameters +
+/// an honest `note` (these are the numbers THIS machine measured — non-canonical), and a
+/// `queries` array of one object per `*.rq`, each with the SAME fields the TSV prints
+/// (`name`, `rows`, `min_micros`) or an `error` string when the query failed.
+fn suite_results_json(mode: &str, iters: usize, rows: &[SuiteRow]) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"sparq-cli bench\",\n");
+    s.push_str(&format!("  \"mode\": {},\n", json_str(mode)));
+    s.push_str(&format!("  \"iters\": {iters},\n"));
+    s.push_str(
+        "  \"note\": \"min-of-iters wall-clock MEASURED on the running host; \
+         NON-CANONICAL (whatever this machine measured) — do not bake into committed files\",\n",
+    );
+    s.push_str("  \"queries\": [\n");
+    for (i, r) in rows.iter().enumerate() {
+        s.push_str("    {\n");
+        s.push_str(&format!("      \"name\": {}", json_str(&r.name)));
+        match &r.outcome {
+            Ok((rows, micros)) => {
+                s.push_str(&format!(",\n      \"rows\": {rows}"));
+                s.push_str(&format!(",\n      \"min_micros\": {micros:.1}\n"));
+            }
+            Err(e) => {
+                s.push_str(&format!(",\n      \"error\": {}\n", json_str(e)));
+            }
+        }
+        s.push_str("    }");
+        if i + 1 < rows.len() {
+            s.push(',');
+        }
+        s.push('\n');
+    }
+    s.push_str("  ]\n");
+    s.push_str("}\n");
+    s
+}
+
+/// [OPUS-4.8] (sq-d7d) Minimal JSON string escaper for the dependency-free emit — escapes the
+/// characters JSON requires (`"`, `\`, and the C0 control set incl. the named whitespace
+/// escapes). Query names are file stems and error strings are engine messages, so this covers
+/// the realistic input; anything else still produces valid `\uXXXX` escapes.
+fn json_str(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for c in raw.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }

--- a/crates/sparq-cli/tests/cli_contract.rs
+++ b/crates/sparq-cli/tests/cli_contract.rs
@@ -611,6 +611,69 @@ fn bench_emits_one_tsv_line_per_query_including_construct() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// [OPUS-4.8] (sq-d7d) `bench --json <path>` writes a machine-readable results document
+/// ALONGSIDE the unchanged STDOUT TSV. Asserts: (a) STDOUT is still exactly one TSV line per
+/// query (JSON is additive, not a replacement); (b) the file is genuinely VALID, parseable JSON
+/// (parsed with serde_json, not substring-matched); (c) it carries the expected top-level keys +
+/// a `queries` array whose entries mirror the TSV fields (`name`, `rows`, `min_micros`).
+#[test]
+fn bench_json_flag_writes_parseable_results_with_expected_keys() {
+    let dir = scratch("bench-json");
+    let data = write(&dir, "data.nt", NT);
+    let qd = dir.join("q");
+    std::fs::create_dir_all(&qd).unwrap();
+    write(&qd, "a_all.rq", "SELECT ?s ?p ?o WHERE { ?s ?p ?o }");
+    write(&qd, "b_ask.rq", "ASK { ?s <http://ex/knows> ?o }");
+    let out = dir.join("results.json");
+
+    let (code, stdout, stderr) =
+        run3(&["bench", s(&data), "ntriples", s(&qd), "1", "count", "--json", s(&out)]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+
+    // (a) STDOUT TSV is unchanged — still one line per query, byte-for-byte the historical shape.
+    let lines: Vec<&str> = stdout.lines().filter(|l| l.contains('\t')).collect();
+    assert_eq!(lines.len(), 2, "expected 2 TSV lines on STDOUT, got: {stdout}");
+    assert!(lines[0].starts_with("a_all\t3\t"), "line0: {}", lines[0]);
+    assert!(lines[1].starts_with("b_ask\t1\t"), "line1: {}", lines[1]);
+
+    // (b) The file exists and is VALID, parseable JSON.
+    let raw = std::fs::read_to_string(&out).expect("--json results file should exist");
+    let doc: serde_json::Value = serde_json::from_str(&raw).expect("results file must be valid JSON");
+
+    // (c) Expected top-level keys + run parameters.
+    assert_eq!(doc["harness"], "sparq-cli bench", "harness key: {raw}");
+    assert_eq!(doc["mode"], "count", "mode key: {raw}");
+    assert_eq!(doc["iters"], 1, "iters key: {raw}");
+    assert!(doc["note"].is_string(), "note caveat present: {raw}");
+
+    // The `queries` array mirrors the TSV: one entry per *.rq, sorted by name, each carrying
+    // the SAME measured fields (name / rows / min_micros).
+    let queries = doc["queries"].as_array().expect("queries must be an array");
+    assert_eq!(queries.len(), 2, "one entry per query: {raw}");
+    assert_eq!(queries[0]["name"], "a_all", "first query name: {raw}");
+    assert_eq!(queries[0]["rows"], 3, "first query rows: {raw}");
+    assert!(queries[0]["min_micros"].is_number(), "min_micros numeric: {raw}");
+    assert_eq!(queries[1]["name"], "b_ask", "second query name: {raw}");
+    assert_eq!(queries[1]["rows"], 1, "second query rows (ASK): {raw}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// [OPUS-4.8] (sq-d7d) A bare `--json` with no path is a usage error (exit 2), mirroring the
+/// rest of the CLI's value-flag contract.
+#[test]
+fn bench_json_flag_requires_a_path() {
+    let dir = scratch("bench-json-nopath");
+    let data = write(&dir, "data.nt", NT);
+    let qd = dir.join("q");
+    std::fs::create_dir_all(&qd).unwrap();
+    write(&qd, "a_all.rq", "SELECT ?s ?p ?o WHERE { ?s ?p ?o }");
+
+    let (code, _stdout, stderr) = run3(&["bench", s(&data), "ntriples", s(&qd), "1", "--json"]);
+    assert_eq!(code, 2, "bare --json is a usage error; stderr: {stderr}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn compare_compress_reports_footprint() {
     let dir = scratch("compare-compress");


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-d7d**: give the STDOUT-only `sparq-cli bench` / `bench-mmap` benchmark harnesses a `--json <path>` machine-readable results emit (the structured-benchmark-catalog pattern), so a run can be consumed by docs/CI instead of scraped from TSV.

## What changed
- `crates/sparq-cli/src/main.rs` — `cmd_bench` + `cmd_bench_mmap` accept `--json <path>` (extracted before positional parsing so the historical positional arg contract is untouched). Both funnel through `run_query_suite`, which now ALSO writes the same measured fields to the path when the flag is present. STDOUT TSV is **byte-for-byte unchanged** whether the flag is present or not — JSON is strictly additive. A bare `--json` (no path) is a usage error (exit 2).
- `crates/sparq-cli/tests/cli_contract.rs` — new tests: one asserts the file is **genuinely valid, parseable JSON** (parsed with `serde_json`, not substring-matched) with the expected top-level keys + a `queries` array mirroring the TSV (`name`/`rows`/`min_micros`), and that STDOUT is unchanged; one asserts the bare-`--json` usage error.
- `crates/sparq-cli/Cargo.toml` / `Cargo.lock` — `serde_json` added as a **TEST-ONLY dev-dep** (proves parseability). The runtime CLI adds **no serde dep** — the JSON is hand-built with `format!`, mirroring `mpc_net_bench::cell_json`'s dependency-free convention.
- `bench/qlever-baselines.md` — documents the new flag where the `bench` invocation is shown.

## JSON shape (mirrors the dependency-free catalog convention)
Top-level object: `harness`, `mode`, `iters`, an honest `note` (numbers are whatever the host measured — NON-CANONICAL), and a `queries` array — one object per `*.rq` with `name` + `rows` + `min_micros`, or `name` + `error` when the query failed.

## Scope honesty
The bead's summary said `bench/memtier` already has a `--json <path>` template — **it does not**. The actual repo convention is `crates/sparq-mpc/examples/mpc_net_bench.rs`'s `--json` (dependency-free `cell_json` to stdout); I mirrored its shape/conventions. I scoped this PR to the cli `bench`/`bench-mmap` path (one `run_query_suite`, uniform per-query schema). **Not in scope** (separate beads — each subcommand emits heterogeneous ad-hoc output with no shared schema, so JSON-wiring is per-subcommand work): `bench/parse`, `bench/inference`, `bench/serve` spikes, and the per-crate example/test harnesses.

## Gate (run locally)
- `cargo clippy -p sparq-cli --all-targets -D warnings` — clean in BOTH feature states (default; `--no-default-features --features mmap`).
- `cargo test -p sparq-cli` — 41 pass (incl. the 2 new + the unchanged-STDOUT regression on the existing bench test).
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-cli --no-deps` — clean.
- `scripts/check-privacy-claims.sh` — OK. typos-gate — clean. No new `unsafe`.
- End-to-end reproduced: `sparq-cli bench … count --json /tmp/run.json` writes valid JSON (verified with `python3 -m json.tool` + the error-path entry); TSV STDOUT identical to before.

[OPUS-4.8]