### PR TITLE
feat(site): /surface/genai tier-e captured NL→SPARQL loop + real result tables (sq-3was) [OPUS-4.8]

### DIFF
--- a/site/src/app/surface/[slug]/page.tsx
+++ b/site/src/app/surface/[slug]/page.tsx
@@ -19,6 +19,7 @@ const BUILT_SURFACES = new Set([
   "streaming-rsp",
   "full-text",
   "http-server",
+  "genai",
 ]);
 const PLACEHOLDER_SURFACES = ALL_SURFACES.filter(
   (s) =>

--- a/site/src/app/surface/genai/page.tsx
+++ b/site/src/app/surface/genai/page.tsx
@@ -1,0 +1,148 @@
+import type { Metadata } from "next";
+import { Sparkles } from "lucide-react";
+
+import { SurfaceContent } from "@/components/surface-content";
+import { GenaiWalkthrough } from "@/components/genai-walkthrough";
+
+export const metadata: Metadata = {
+  title: "GenAI / NLQ",
+  description:
+    "sparq-nlq — natural-language questions → SPARQL, grounded in a real schema card, validated by spargebra, executed under a query budget, with a bounded repair loop. This page replays REAL captured engine output over the 1.78M-triple Olympics dataset; the model step is a recorded fixture, not a live LLM.",
+};
+
+export default function GenaiSurfacePage() {
+  return (
+    <SurfaceContent
+      icon={Sparkles}
+      title="GenAI / NLQ"
+      statement="Natural-language → SPARQL: schema-card grounding, spargebra validation, budgeted execution, and a bounded repair loop."
+      tier="walkthrough"
+      extraBadge="Opt-in crate · captured output"
+      intro={
+        <>
+          <p>
+            <code className="font-mono text-foreground">sparq-nlq</code> turns a
+            natural-language question into a SPARQL query over a{" "}
+            <code className="font-mono">sparq_core::Graph</code>. It is a deliberately{" "}
+            <strong className="text-foreground">lean loop</strong> (retrieve + repair, not
+            a sprawling agent):{" "}
+            <strong className="text-foreground">ground</strong> the prompt with{" "}
+            <code className="font-mono">sparq-introspect</code>&rsquo;s token-budgeted
+            schema card → <strong className="text-foreground">generate</strong> a query →{" "}
+            <strong className="text-foreground">validate</strong> it with the real{" "}
+            <code className="font-mono">spargebra</code> parser → on a parse/exec error{" "}
+            <strong className="text-foreground">repair</strong> (the error fed back, a few
+            rounds) → <strong className="text-foreground">execute</strong> under a{" "}
+            <code className="font-mono">QueryBudget</code> (LLM output is untrusted input).
+          </p>
+          <p>
+            It is an <strong className="text-foreground">opt-in crate</strong>: nothing in
+            the workspace depends on it, the default build does not compile it, and the
+            engine carries zero GenAI code. The model sits behind a small{" "}
+            <code className="font-mono">Llm</code> trait with{" "}
+            <strong className="text-foreground">record / replay</strong> fixtures, so CI is
+            fully offline; a thin Anthropic Messages-API client lives behind a non-default{" "}
+            <code className="font-mono">live</code> feature.
+          </p>
+          <p>
+            This static Pages site has no backend and the crate is native-only — so,
+            honestly, this is a <strong className="text-foreground">captured-output
+            walkthrough</strong>. Two halves, labelled distinctly:{" "}
+            <strong className="text-foreground">(1)</strong> the schema card and{" "}
+            <strong className="text-foreground">every result table</strong> are{" "}
+            <em>real, verbatim engine output</em> — produced by running the real loop with
+            the committed replay fixture against the real 1.78M-triple Olympics dataset
+            (term serialization intact, datatypes and language tags preserved).{" "}
+            <strong className="text-foreground">(2)</strong> the{" "}
+            <em>NL→SPARQL generation step itself is a recorded fixture, not a live model
+            call here</em> — the queries are realistic, schema-grounded answers a competent
+            model would write, with one deliberately malformed to exercise the repair path.
+            We do not claim the query text is &ldquo;what an LLM said&rdquo;; we claim the
+            loop&rsquo;s plumbing and the executed results are real.
+          </p>
+        </>
+      }
+      capabilities={[
+        {
+          title: "Schema-card grounding (real introspection)",
+          body: "sparq-introspect's to_text_summary builds a token-budgeted deck — exact class/predicate counts, datatype ranges, characteristic sets — from the store's indexes, not guesses.",
+        },
+        {
+          title: "Validate before execute",
+          body: "The extracted query is parsed with the real spargebra parser before the engine sees it, so a malformed query becomes a concrete repair signal rather than a silent failure.",
+        },
+        {
+          title: "Bounded repair loop",
+          body: "Parse and execution errors (unsupported forms, budget trips) are fed back with the failed query; a capped number of rounds, then the loop gives up honestly.",
+        },
+        {
+          title: "Budgeted execution",
+          body: "LLM-generated queries are untrusted input — every query runs under a QueryBudget (default 10 s wall clock, 1M materialised rows); opting out is explicit.",
+        },
+        {
+          title: "Record / replay — offline CI",
+          body: "The Llm trait records (prompt, completion) pairs to a fixture and replays them by exact-prompt match, so the whole loop is deterministic and network-free in tests.",
+        },
+        {
+          title: "Index-grounded entity linking (opt-in)",
+          body: "Optionally resolve a question's proper nouns to concrete IRIs in this store (label index + sparq-sim structural siblings) and surface them in the prompt — off by default.",
+        },
+      ]}
+      runsNote={
+        <>
+          <p>
+            <strong className="text-foreground">Captured-output replay.</strong> The schema
+            card is the verbatim <code className="font-mono">to_text_summary(4000)</code>{" "}
+            deck; every result table is the verbatim output of the real loop (replay
+            fixture) executed by the sparq engine over the real Olympics dataset. The
+            row counts and the one repair round are cross-checked, offline and
+            deterministically, by the crate&rsquo;s CI test (
+            <code className="font-mono">olympics_eval.rs</code>). To run it live:
+          </p>
+          <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12px] leading-relaxed">
+            {`cargo add sparq-nlq --features live
+export ANTHROPIC_API_KEY=sk-ant-...
+# then: Nlq::new(&graph, Box::new(AnthropicLlm::from_env()?)).ask("...")`}
+          </pre>
+        </>
+      }
+      caveat={
+        <>
+          <p>
+            <strong className="text-foreground">The model step here is not live.</strong>{" "}
+            The generation step on this page is a <em>recorded fixture</em>, not a real LLM
+            call, so the SPARQL text is &ldquo;what a competent model would write&rdquo;,
+            not a measured model output.{" "}
+            <strong className="text-foreground">
+              Live-model exec-accuracy numbers are not measured here
+            </strong>{" "}
+            — that needs an API key and a canonical host (open work in the crate).
+          </p>
+          <p>
+            <strong className="text-foreground">Exec-accuracy is not correctness.</strong>{" "}
+            A query can parse, execute and return rows while answering the{" "}
+            <em>wrong</em> question — passing the loop is not a guarantee the SPARQL
+            faithfully captures the intent. Strict logit-level grammar-constrained{" "}
+            <em>decoding</em> is not implementable against the Anthropic Messages API (no
+            logit/grammar parameter); the dictionary-grounded check on this surface is the
+            design&rsquo;s API-backend fallback, and it is opt-in.
+          </p>
+        </>
+      }
+      links={[
+        {
+          href: "https://github.com/jeswr/sparq/tree/main/crates/sparq-nlq",
+          label: "sparq-nlq crate",
+          external: true,
+        },
+        {
+          href: "https://github.com/jeswr/sparq/tree/main/crates/sparq-introspect",
+          label: "sparq-introspect crate",
+          external: true,
+        },
+      ]}
+    >
+      <GenaiWalkthrough />
+    </SurfaceContent>
+  );
+}

--- a/site/src/components/genai-walkthrough.tsx
+++ b/site/src/components/genai-walkthrough.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+// [OPUS-4.8] sq-3was — the /surface/genai (GenAI / NLQ) walkthrough (tier-e).
+// sparq-nlq is an opt-in NATIVE crate (it can pull a model behind a trait) and is NOT
+// in the lean wasm bundle, and the static Pages site has no backend — so, per the
+// feature-showcase design's honest tier-e fallback, this REPLAYS captured output
+// rather than calling a model live:
+//
+//   1. SCHEMA CARD — the verbatim `to_text_summary(4000)` introspection deck the loop
+//      grounds the model with (pure index introspection — no model). GENUINELY REAL.
+//   2. NL → SPARQL LOOP — pick a question, step the loop (ground → generate → validate
+//      → execute), and see the generated SPARQL plus the REAL executed result table.
+//      One question takes the REPAIR path (a malformed first query, the parser error
+//      fed back, a fixed second query).
+//
+// HONESTY (see src/lib/genai.ts): the RESULT ROWS, row counts, repair counts and the
+// schema card are real captured engine output (verbatim oxrdf Term serialization). The
+// natural-language → SPARQL *generation step* is a SCRIPTED fixture, NOT a live model
+// call (IS_LIVE_LLM === false), so the query text is "a realistic, schema-grounded
+// query a competent model would write", not "what an LLM said here". The page labels
+// both halves. All data is in src/lib/genai.ts (framework-free, unit-tested).
+
+import * as React from "react";
+import {
+  Sparkles,
+  FileSearch,
+  Wand2,
+  CheckCircle2,
+  Play,
+  Database,
+  AlertTriangle,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  DATASET,
+  IS_LIVE_LLM,
+  QUESTIONS,
+  SCHEMA_SUMMARY,
+  type Question,
+} from "@/lib/genai";
+
+const fmt = new Intl.NumberFormat("en-US");
+
+/** A result cell: render `null` (unbound) explicitly, else verbatim. */
+function Cell({ value }: { value: string | null }) {
+  if (value === null) {
+    return <span className="text-muted-foreground/60 italic">unbound</span>;
+  }
+  return <span className="break-all">{value}</span>;
+}
+
+function ResultTable({ q }: { q: Question }) {
+  if (q.isAsk) {
+    // ASK: zero variables, one unit row iff true.
+    const isTrue = q.headRows.length > 0;
+    return (
+      <div className="rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px]">
+        ASK →{" "}
+        <span className={cn("font-semibold", isTrue ? "text-[var(--success)]" : "text-[var(--warning)]")}>
+          {isTrue ? "true" : "false"}
+        </span>
+        <span className="ml-1 text-muted-foreground">
+          (unit-row encoding: {q.vars.length} variables, one empty row iff satisfiable)
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <table className="w-full border-collapse font-mono text-[12px]">
+        <thead>
+          <tr className="border-b bg-muted/60">
+            {q.vars.map((v) => (
+              <th key={v} className="px-3 py-1.5 text-left font-semibold">
+                ?{v}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {q.headRows.map((row, i) => (
+            <tr key={i} className="border-b last:border-0">
+              {row.map((cell, j) => (
+                <td key={j} className="px-3 py-1.5 align-top">
+                  <Cell value={cell} />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function StepBadge({
+  icon: Icon,
+  label,
+  done,
+}: {
+  icon: typeof FileSearch;
+  label: string;
+  done: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium ring-1 transition-colors",
+        done
+          ? "bg-[color-mix(in_oklch,var(--success)_12%,transparent)] text-[var(--success)] ring-[var(--success)]/30"
+          : "bg-muted/50 text-muted-foreground ring-foreground/10",
+      )}
+    >
+      <Icon className="size-3.5" aria-hidden="true" />
+      {label}
+    </div>
+  );
+}
+
+export function GenaiWalkthrough() {
+  const [selected, setSelected] = React.useState(0);
+  // step = how far through the loop the user has stepped (0 … STEPS.length).
+  const [step, setStep] = React.useState(0);
+
+  const q = QUESTIONS[selected];
+  const hasRepair = q.repairs > 0;
+  // Loop stages revealed in order. The repair stage only appears for the repair case.
+  const stages = React.useMemo(
+    () => [
+      { key: "ground", label: "Ground", icon: FileSearch },
+      { key: "generate", label: "Generate", icon: Wand2 },
+      { key: "validate", label: "Validate", icon: CheckCircle2 },
+      ...(hasRepair ? [{ key: "repair", label: "Repair", icon: AlertTriangle }] : []),
+      { key: "execute", label: "Execute", icon: Database },
+    ],
+    [hasRepair],
+  );
+
+  function pick(i: number) {
+    setSelected(i);
+    setStep(0);
+  }
+  const maxStep = stages.length;
+  const done = step >= maxStep;
+
+  return (
+    <div className="space-y-10">
+      {/* ── The schema card — genuinely real introspection grounding ──────────── */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <FileSearch className="size-5 text-primary" aria-hidden="true" />
+          <h2 className="text-xl font-semibold">Schema card — what grounds the model</h2>
+          <Badge variant="success" className="text-[10px] uppercase">
+            real introspection
+          </Badge>
+        </div>
+        <p className="measure text-sm text-muted-foreground">
+          Before any model sees the question, sparq builds a token-budgeted{" "}
+          <strong className="text-foreground">schema summary</strong> straight from the
+          store&rsquo;s permutation indexes — classes &amp; predicates with{" "}
+          <em>exact</em> counts, datatype ranges, characteristic predicate sets and a
+          prefix glossary. This is the verbatim{" "}
+          <code className="font-mono">to_text_summary(4000)</code> output over the{" "}
+          {fmt.format(DATASET.triples)}-triple{" "}
+          <a
+            href={DATASET.source}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2"
+          >
+            {DATASET.name}
+          </a>{" "}
+          dataset — no model, no guessing. The trailing{" "}
+          <code className="font-mono">…</code> markers are its own budget truncation.
+        </p>
+        <pre className="max-h-80 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-[11.5px] leading-relaxed">
+          {SCHEMA_SUMMARY}
+        </pre>
+      </section>
+
+      {/* ── The NL → SPARQL loop ───────────────────────────────────────────────── */}
+      <section className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Sparkles className="size-5 text-primary" aria-hidden="true" />
+          <h2 className="text-xl font-semibold">Ask in English — replay the loop</h2>
+        </div>
+        <p className="measure text-sm text-muted-foreground">
+          Pick a question, then <strong className="text-foreground">Step</strong> through
+          the loop: <em>ground</em> with the schema card, <em>generate</em> a query,{" "}
+          <em>validate</em> it with the real <code className="font-mono">spargebra</code>{" "}
+          parser, and <em>execute</em> it under a query budget. The last question takes
+          the <strong className="text-foreground">repair</strong> path — a malformed first
+          query, the parser error fed back, a fixed second query.
+        </p>
+
+        {/* Question chips. */}
+        <div className="flex flex-wrap gap-2">
+          {QUESTIONS.map((item, i) => (
+            <button
+              key={item.question}
+              type="button"
+              onClick={() => pick(i)}
+              className={cn(
+                "rounded-full px-3 py-1.5 text-left text-[12.5px] ring-1 transition-colors",
+                i === selected
+                  ? "bg-primary/10 text-primary ring-primary/30"
+                  : "bg-muted/40 text-muted-foreground ring-foreground/10 hover:bg-muted",
+              )}
+            >
+              {item.question}
+              {item.repairs > 0 && (
+                <Badge variant="warning" className="ml-2 text-[10px] uppercase">
+                  repair
+                </Badge>
+              )}
+            </button>
+          ))}
+        </div>
+
+        <Card>
+          <CardHeader className="space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <CardTitle className="text-base">
+                <span className="text-muted-foreground">Q:</span> {q.question}
+              </CardTitle>
+              <div className="flex gap-2">
+                <Button size="sm" onClick={() => setStep((s) => Math.min(s + 1, maxStep))} disabled={done}>
+                  <Play className="size-4" aria-hidden="true" />
+                  {step === 0 ? "Step" : done ? "Done" : "Next step"}
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => setStep(0)} disabled={step === 0}>
+                  Reset
+                </Button>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {stages.map((s, i) => (
+                <StepBadge key={s.key} icon={s.icon} label={s.label} done={i < step} />
+              ))}
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {/* Ground */}
+            {step >= 1 && (
+              <div className="space-y-1.5">
+                <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                  <FileSearch className="size-3.5" aria-hidden="true" />
+                  ground — the schema card above is prepended to the prompt
+                </div>
+              </div>
+            )}
+
+            {/* Generate */}
+            {step >= 2 && (
+              <div className="space-y-1.5">
+                <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                  <Wand2 className="size-3.5" aria-hidden="true" />
+                  generate
+                  <Badge variant="muted" className="text-[10px] uppercase">
+                    scripted fixture · not a live model
+                  </Badge>
+                </div>
+                <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed">
+                  {hasRepair ? firstAttempt(q) : q.sparql}
+                </pre>
+              </div>
+            )}
+
+            {/* Validate (and repair) */}
+            {step >= 3 && (
+              <div className="space-y-1.5">
+                <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                  <CheckCircle2 className="size-3.5" aria-hidden="true" />
+                  validate — spargebra parse
+                </div>
+                {hasRepair ? (
+                  <div className="rounded-lg border border-[var(--warning)]/30 bg-[var(--warning)]/5 p-3 font-mono text-[12px] text-[color-mix(in_oklch,var(--warning)_80%,var(--foreground))]">
+                    parse error → the failed query + the parser message are sent back to
+                    the model (repair round 1)
+                  </div>
+                ) : (
+                  <div className="rounded-lg border bg-muted/40 p-3 font-mono text-[12px] text-[var(--success)]">
+                    parsed OK
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Repair (repair case only) — shows the fixed query. */}
+            {hasRepair && step >= 4 && (
+              <div className="space-y-1.5">
+                <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                  <AlertTriangle className="size-3.5" aria-hidden="true" />
+                  repair — second completion (parses)
+                  <Badge variant="muted" className="text-[10px] uppercase">
+                    scripted fixture
+                  </Badge>
+                </div>
+                <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed">
+                  {q.sparql}
+                </pre>
+              </div>
+            )}
+
+            {/* Execute — REAL captured rows. */}
+            {done && (
+              <div className="space-y-1.5">
+                <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                  <Database className="size-3.5" aria-hidden="true" />
+                  execute
+                  <Badge variant="success" className="text-[10px] uppercase">
+                    real engine output
+                  </Badge>
+                </div>
+                <ResultTable q={q} />
+                <p className="text-xs text-muted-foreground">
+                  {q.isAsk ? (
+                    <>Real result, executed by the sparq engine over the full dataset.</>
+                  ) : (
+                    <>
+                      Showing the first {q.headRows.length} of{" "}
+                      <strong className="text-foreground">{fmt.format(q.totalRows)}</strong>{" "}
+                      row{q.totalRows === 1 ? "" : "s"} — real, executed by the sparq engine
+                      over the full {fmt.format(DATASET.triples)}-triple dataset (term
+                      serialization verbatim, datatypes &amp; language tags intact).
+                    </>
+                  )}{" "}
+                  {!IS_LIVE_LLM && (
+                    <em>
+                      The query came from the recorded fixture, not a live model call.
+                    </em>
+                  )}
+                </p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}
+
+// The repair case's deliberately-malformed first attempt (mirrors the fixture's first
+// completion: the aggregate alias loses its closing paren). Shown only for the repair
+// question so the "Generate → Validate → Repair" arc is legible; the fixed query is
+// `q.sparql`. Kept here (not in the data module) because it is the loop's INPUT, not a
+// captured result, and exists for exactly one question.
+function firstAttempt(q: Question): string {
+  return q.sparql
+    .replace("SELECT ?sport (COUNT(?event) AS ?count)", "SELECT ?sport (COUNT(?event) AS ?count")
+    .replace("\nORDER BY DESC(?count)", "");
+}

--- a/site/src/data/surfaces.ts
+++ b/site/src/data/surfaces.ts
@@ -194,8 +194,14 @@ export const GROUPS: SurfaceGroup[] = [
         href: "/surface/genai",
         title: "GenAI / NLQ",
         blurb: "Schema-card / VoID introspection + natural-language → SPARQL loop.",
-        tier: "hosted",
+        // [OPUS-4.8] sq-3was: tier-e. sparq-nlq is an opt-in native crate (it can pull a
+        // model behind a trait), not in the lean wasm bundle, and the static Pages site
+        // has no backend — so the honest surface is a captured-output walkthrough (real
+        // schema card + real executed result tables, scripted-fixture model step), not a
+        // live hosted endpoint.
+        tier: "walkthrough",
         icon: Sparkles,
+        built: true,
       },
     ],
   },

--- a/site/src/lib/genai.ts
+++ b/site/src/lib/genai.ts
@@ -1,0 +1,198 @@
+// [OPUS-4.8] sq-3was — pure, framework-free data + helpers for the /surface/genai
+// (GenAI / NLQ) walkthrough. sparq-nlq is an OPT-IN native crate (it pulls a model
+// behind a trait), it is NOT in the lean wasm bundle, and the static GitHub-Pages
+// site has no backend, so this surface is the honest "captured-output walkthrough"
+// fallback the feature-showcase design names for tier-e
+// (research/feature-showcase-site-design.md §0, surface (e)).
+//
+// =====================================================================================
+// HONESTY CONTRACT — read before editing. A sibling page (sq-rnwc) was caught
+// fabricating "captured" output (dropped datatypes, invented triples). To make that
+// impossible here, EVERYTHING on this page is split into two clearly-labelled halves,
+// and the test (site/test/genai.test.mjs) pins the serialization of both:
+//
+//   (A) GENUINELY LIVE-CAPTURED — `SCHEMA_SUMMARY`, every `Question.sparql`,
+//       `Question.vars`, `Question.headRows`, `Question.totalRows`, `Question.repairs`
+//       and `Question.turnOutcomes`. These were produced by running the REAL
+//       sparq-nlq loop (ground → generate → validate → execute → repair) with the
+//       COMMITTED `ReplayLlm` fixture (crates/sparq-nlq/tests/fixtures/
+//       olympics_replay.json) against the REAL 1,781,625-triple Olympics dataset
+//       (github.com/wallscope/olympics-rdf), and PASTED VERBATIM. The schema summary
+//       is the exact `Introspection::to_text_summary(4000)` grounding deck (pure
+//       index introspection, no model). The result rows are the exact
+//       `oxrdf::Term::Display` (N-Triples) serialization the engine emits — datatypes
+//       and language tags INTACT (`xsd:integer` for COUNT, `xsd:int` for the source
+//       `dbp:year`, `xsd:decimal` for AVG, `@en` langStrings for labels). This is
+//       cross-checked offline+deterministically by the CI test
+//       crates/sparq-nlq/tests/olympics_eval.rs (row counts, the one repair round).
+//
+//   (B) HONESTLY ILLUSTRATIVE — the *natural-language → SPARQL generation step* is
+//       NOT a live model here. The committed fixture's completions are SCRIPTED:
+//       realistic, schema-grounded queries a competent model would emit for this
+//       prompt (one is deliberately malformed first to exercise the repair path),
+//       NOT a real LLM call. So we DO NOT claim the *query text* is "what GPT/Claude
+//       said"; we claim the loop's PLUMBING (grounding, extraction, spargebra
+//       validation, budgeted execution, repair) and the EXECUTED RESULTS are real.
+//       Live-model exec-accuracy NUMBERS are explicitly NOT measured here (open work,
+//       sparq-nlq bead sq-g0lw; needs a key + a canonical host). `IS_LIVE_LLM = false`.
+//
+// NLQ exec-accuracy is NOT a correctness guarantee: a query can parse, execute and
+// return rows while answering the wrong question. The page says so.
+//
+// Grounded in crates/sparq-nlq (README + src/lib.rs + the eval harness) and
+// crates/sparq-introspect (to_text_summary).
+
+/** Whether the NL→SPARQL generation step on this page was a LIVE model call. */
+export const IS_LIVE_LLM = false as const;
+
+/** The dataset the captured loop ran against. */
+export const DATASET = {
+  name: "Olympics (120 years)",
+  source: "https://github.com/wallscope/olympics-rdf",
+  triples: 1781625,
+} as const;
+
+/**
+ * The verbatim grounding deck handed to the model: the exact output of
+ * `sparq_introspect::Introspection::to_text_summary(4000)` over the dataset — schema
+ * card / VoID-style introspection (class & predicate counts, characteristic sets,
+ * prefix glossary) computed from the store's permutation indexes, NOT guessed. The
+ * trailing `…` markers are the introspect crate's own budget-truncation at the 4000
+ * char limit; this string IS the prompt the loop built.
+ */
+export const SCHEMA_SUMMARY =
+  "# Schema summary — 1781625 triples, 406700 subjects, 8 classes, 16 predicates, 15 entity patterns\n## Prefixes\nfoaf: http://xmlns.com/foaf/0.1/ — FOAF (people & agents)\ndbo: http://dbpedia.org/ontology/ — DBpedia ontology\nns1: http://wallscope.co.uk/resource/olympics/team/ (1184 terms)\nrdf: http://www.w3.org/1999/02/22-rdf-syntax-ns# — RDF\nrdfs: http://www.w3.org/2000/01/rdf-schema# — RDF Schema\nskos: http://www.w3.org/2004/02/skos/core# — SKOS\nns2: http://wallscope.co.uk/resource/olympics/gender/\nxsd: http://www.w3.org/2001/XMLSchema# — XML Schema datatypes\nns3: http://wallscope.co.uk/resource/olympics/sport/\nns4: http://wallscope.co.uk/resource/olympics/city/\ndbp: http://dbpedia.org/property/ — DBpedia properties\nns5: http://wallscope.co.uk/resource/olympics/season/\nns6: http://wallscope.co.uk/ontology/olympics/\nns7: http://wallscope.co.uk/resource/olympics/athlete/ (134730 terms)\nns8: http://wallscope.co.uk/resource/olympics/event/ (765 terms)\nns9: http://wallscope.co.uk/resource/olympics/games/1896/\nns10: http://wallscope.co.uk/resource/olympics/medal/\n## Classes (by instance count)\n### foaf:Person — 134730 instances\n- dbo:team — 134730/134730 subjects (100%) → dbo:SportsTeam, e.g. ns1:30Februar\n- rdfs:label — 134730/134730 subjects (100%) → rdf:langString, e.g. \"  Gabrielle Marie \"Gabby\" Adcock (White-)\"@en\n- foaf:gender — 134730/134730 subjects (100%) → skos:Concept, e.g. ns2:F\n- foaf:age — 128429/134730 subjects (95%, avg 1.4/subj) → xsd:int, e.g. \"10\"\n- dbo:height — 101099/134730 subjects (75%) → xsd:int, e.g. \"127\"\n- dbo:weight — 100127/134730 subjects (74%) → xsd:double, e.g. \"100\"\n### dbo:SportsTeam — 1184 instances\n- rdfs:label — 1184/1184 subjects (100%) → rdf:langString, e.g. \"  Gabrielle Marie \"Gabby\" Adcock (White-)\"@en\n### dbo:SportsEvent — 765 instances\n- rdfs:label — 765/765 subjects (100%) → rdf:langString, e.g. \"  Gabrielle Marie \"Gabby\" Adcock (White-)\"@en\n- rdfs:subClassOf — 765/765 subjects (100%) → dbo:Sport, e.g. ns3:Aeronautics\n### dbo:Sport — 66 instances\n- rdfs:label — 66/66 subjects (100%) → rdf:langString, e.g. \"  Gabrielle Marie \"Gabby\" Adcock (White-)\"@en\n### dbo:Olympics — 51 instances\n- dbp:location — 51/51 subjects (100%) → dbo:City, e.g. ns4:Albertville\n- dbp:year — 51/51 subjects (100%) → xsd:int, e.g. \"1896\"\n- ns6:season — 51/51 subjects (100%) → dbo:TimePeriod, e.g. ns5:Summer\n### dbo:City — 42 instances\n- rdfs:label — 42/42 subjects (100%) → rdf:langString, e.g. \"  Gabrielle Marie \"Gabby\" Adcock (White-)\"@en\n### dbo:TimePeriod — 2 instances\n- rdfs:label — 2/2 subjects (100%) → rdf:langString, e.g. \"  Gabrielle Marie \"Gabby\" Adcock (White-)\"@en\n### skos:Concept — 2 instances\n- rdfs:label — 2/2 subjects (100%) → rdf:langString, e.g. \"  Gabrielle Marie \"Gabby\" Adcock (White-)\"@en\n## Entity patterns (characteristic predicate sets)\n- {ns6:athlete, ns6:event, ns6:games} × 229879 subjects\n- {dbo:height, dbo:team, dbo:weight, rdf:type, rdfs:label, foaf:age, foaf:gender} × 98547 subjects — mostly foaf:Person\n- {ns6:athlete, ns6:event, ns6:games, ns6:medal} × 39746 subjects\n- {dbo:team, rdf:type, rdfs:label, foaf:age, foaf:gender} × 27023 subjects — mostly foaf:Person\n- {dbo:team, rdf:type, rdfs:label, foaf:gender} × 5522 subjects — mostly foaf:Person\n- {dbo:height, dbo:team, rdf:type, rdfs:label, foaf:age, foaf:gender} × 1924 subjects — mostly foaf:Person\n- {rdf:type, rdfs:label} × 1296 subjects — mostly dbo:SportsTeam\n- {dbo:team, dbo:weight, rdf:type, rdfs:label, foaf:age, foaf:gender} × 935 subjects — mostly foaf:Person\n- {rdf:type, rdfs:label, rdfs:subClassOf} × 765 subjects — mostly dbo:SportsEvent\n- {dbo:height, dbo:team, dbo:weight, rdf:type, rdfs:label, foaf:gender} × 494 subjects — mostly foaf:Person\n- {dbo:ground, rdfs:label} × 230 subjects\n- {dbo:team, dbo:weight, rdf:type, rdfs:label, foaf:gender} × 151 subjects — mostly foaf:Person\n… and 3 rarer patterns\n## Predicates (global)\n- ns6:athlete — 269625 triples, 269625 subj, 134730 obj (IRIs, e.g. ns7:AAananthaS…)\n…\n";
+
+/** One question's captured run through the real NL→SPARQL loop. */
+export interface Question {
+  /** The natural-language question. */
+  question: string;
+  /** The final SPARQL the loop executed (post-repair if any) — from the fixture. */
+  sparql: string;
+  /** Result variable names, in order ([] for an ASK). */
+  vars: string[];
+  /**
+   * First few result rows, VERBATIM. Each cell is the engine's `oxrdf::Term::Display`
+   * (N-Triples) string, or `null` for an unbound variable. An ASK's single unit row
+   * is `[]` (zero variables, one empty row iff true).
+   */
+  headRows: (string | null)[][];
+  /** Total rows the query returned over the full dataset. */
+  totalRows: number;
+  /** Repair rounds the loop needed (0 = the first completion parsed + executed). */
+  repairs: number;
+  /** Per-turn outcome tags, e.g. ["ParseError","Ok"] for the repair case. */
+  turnOutcomes: string[];
+  /** ASK query (unit-row encoding)? */
+  isAsk: boolean;
+}
+
+// ── (A) GENUINELY LIVE-CAPTURED ─────────────────────────────────────────────────────
+// Produced by the real sparq-nlq loop + ReplayLlm fixture over the real dataset, pasted
+// verbatim. Re-capture (NOT hand-edit) if the prompt template, default NlqConfig, or
+// dataset changes — see crates/sparq-nlq/examples/record_olympics.rs for the recorder.
+export const QUESTIONS: Question[] = [
+  {
+    question: "How many athletes are on each team?",
+    sparql: "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX foaf: <http://xmlns.com/foaf/0.1/>\nPREFIX dbo: <http://dbpedia.org/ontology/>\nSELECT ?team (COUNT(?athlete) AS ?count)\nWHERE {\n  ?athlete rdf:type foaf:Person ;\n           dbo:team ?team .\n}\nGROUP BY ?team\nORDER BY DESC(?count)",
+    vars: ["team", "count"],
+    headRows: [["<http://wallscope.co.uk/resource/olympics/team/UnitedStates>", "\"9114\"^^<http://www.w3.org/2001/XMLSchema#integer>"], ["<http://wallscope.co.uk/resource/olympics/team/France>", "\"5777\"^^<http://www.w3.org/2001/XMLSchema#integer>"], ["<http://wallscope.co.uk/resource/olympics/team/GreatBritain>", "\"5758\"^^<http://www.w3.org/2001/XMLSchema#integer>"], ["<http://wallscope.co.uk/resource/olympics/team/Italy>", "\"4688\"^^<http://www.w3.org/2001/XMLSchema#integer>"], ["<http://wallscope.co.uk/resource/olympics/team/Germany>", "\"4569\"^^<http://www.w3.org/2001/XMLSchema#integer>"]],
+    totalRows: 1184,
+    repairs: 0,
+    turnOutcomes: ["Ok"],
+    isAsk: false,
+  },
+  {
+    question: "How many athletes are in the dataset?",
+    sparql: "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX foaf: <http://xmlns.com/foaf/0.1/>\nSELECT (COUNT(?athlete) AS ?count)\nWHERE { ?athlete rdf:type foaf:Person }",
+    vars: ["count"],
+    headRows: [["\"134730\"^^<http://www.w3.org/2001/XMLSchema#integer>"]],
+    totalRows: 1,
+    repairs: 0,
+    turnOutcomes: ["Ok"],
+    isAsk: false,
+  },
+  {
+    question: "List the year and host city of every Olympic games.",
+    sparql: "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX dbo: <http://dbpedia.org/ontology/>\nPREFIX dbp: <http://dbpedia.org/property/>\nSELECT ?games ?year ?city\nWHERE {\n  ?games rdf:type dbo:Olympics ;\n         dbp:year ?year ;\n         dbp:location ?city .\n}\nORDER BY ?year",
+    vars: ["games", "year", "city"],
+    headRows: [["<http://wallscope.co.uk/resource/olympics/games/1896/Summer>", "\"1896\"^^<http://www.w3.org/2001/XMLSchema#int>", "<http://wallscope.co.uk/resource/olympics/city/Athina>"], ["<http://wallscope.co.uk/resource/olympics/games/1900/Summer>", "\"1900\"^^<http://www.w3.org/2001/XMLSchema#int>", "<http://wallscope.co.uk/resource/olympics/city/Paris>"], ["<http://wallscope.co.uk/resource/olympics/games/1904/Summer>", "\"1904\"^^<http://www.w3.org/2001/XMLSchema#int>", "<http://wallscope.co.uk/resource/olympics/city/StLouis>"], ["<http://wallscope.co.uk/resource/olympics/games/1906/Summer>", "\"1906\"^^<http://www.w3.org/2001/XMLSchema#int>", "<http://wallscope.co.uk/resource/olympics/city/Athina>"], ["<http://wallscope.co.uk/resource/olympics/games/1908/Summer>", "\"1908\"^^<http://www.w3.org/2001/XMLSchema#int>", "<http://wallscope.co.uk/resource/olympics/city/London>"]],
+    totalRows: 52,
+    repairs: 0,
+    turnOutcomes: ["Ok"],
+    isAsk: false,
+  },
+  {
+    question: "How many medals of each type were awarded?",
+    sparql: "PREFIX ns6: <http://wallscope.co.uk/ontology/olympics/>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nSELECT ?medal (COUNT(?participation) AS ?count)\nWHERE {\n  ?participation ns6:medal ?m .\n  ?m rdfs:label ?medal .\n}\nGROUP BY ?medal\nORDER BY DESC(?count)",
+    vars: ["medal", "count"],
+    headRows: [["\"Gold\"@en", "\"13369\"^^<http://www.w3.org/2001/XMLSchema#integer>"], ["\"Bronze\"@en", "\"13293\"^^<http://www.w3.org/2001/XMLSchema#integer>"], ["\"Silver\"@en", "\"13106\"^^<http://www.w3.org/2001/XMLSchema#integer>"]],
+    totalRows: 3,
+    repairs: 0,
+    turnOutcomes: ["Ok"],
+    isAsk: false,
+  },
+  {
+    question: "What is the average height of the athletes?",
+    sparql: "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX foaf: <http://xmlns.com/foaf/0.1/>\nPREFIX dbo: <http://dbpedia.org/ontology/>\nSELECT (AVG(?height) AS ?avgHeight)\nWHERE { ?athlete rdf:type foaf:Person ; dbo:height ?height }",
+    vars: ["avgHeight"],
+    headRows: [["\"176.316366892317380353\"^^<http://www.w3.org/2001/XMLSchema#decimal>"]],
+    totalRows: 1,
+    repairs: 0,
+    turnOutcomes: ["Ok"],
+    isAsk: false,
+  },
+  {
+    question: "Which team has the most athletes?",
+    sparql: "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX foaf: <http://xmlns.com/foaf/0.1/>\nPREFIX dbo: <http://dbpedia.org/ontology/>\nSELECT ?team (COUNT(?athlete) AS ?count)\nWHERE { ?athlete rdf:type foaf:Person ; dbo:team ?team }\nGROUP BY ?team\nORDER BY DESC(?count)\nLIMIT 1",
+    vars: ["team", "count"],
+    headRows: [["<http://wallscope.co.uk/resource/olympics/team/UnitedStates>", "\"9114\"^^<http://www.w3.org/2001/XMLSchema#integer>"]],
+    totalRows: 1,
+    repairs: 0,
+    turnOutcomes: ["Ok"],
+    isAsk: false,
+  },
+  {
+    question: "List all sports with their labels.",
+    sparql: "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nPREFIX dbo: <http://dbpedia.org/ontology/>\nSELECT ?sport ?label\nWHERE { ?sport rdf:type dbo:Sport ; rdfs:label ?label }\nORDER BY ?label",
+    vars: ["sport", "label"],
+    headRows: [["<http://wallscope.co.uk/resource/olympics/sport/Aeronautics>", "\"Aeronautics\"@en"], ["<http://wallscope.co.uk/resource/olympics/sport/AlpineSkiing>", "\"Alpine Skiing\"@en"], ["<http://wallscope.co.uk/resource/olympics/sport/Alpinism>", "\"Alpinism\"@en"], ["<http://wallscope.co.uk/resource/olympics/sport/Archery>", "\"Archery\"@en"], ["<http://wallscope.co.uk/resource/olympics/sport/ArtCompetitions>", "\"Art Competitions\"@en"]],
+    totalRows: 66,
+    repairs: 0,
+    turnOutcomes: ["Ok"],
+    isAsk: false,
+  },
+  {
+    // THE REPAIR CASE: the fixture's first completion drops the aggregate alias's
+    // closing paren; spargebra rejects it, the loop feeds the parser error back, the
+    // second completion parses and executes — turnOutcomes ["ParseError","Ok"].
+    question: "How many events does each sport have?",
+    sparql: "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nPREFIX dbo: <http://dbpedia.org/ontology/>\nSELECT ?sport (COUNT(?event) AS ?count)\nWHERE { ?event rdf:type dbo:SportsEvent ; rdfs:subClassOf ?sport }\nGROUP BY ?sport\nORDER BY DESC(?count)",
+    vars: ["sport", "count"],
+    headRows: [["<http://wallscope.co.uk/resource/olympics/sport/Athletics>", "\"83\"^^<http://www.w3.org/2001/XMLSchema#integer>"], ["<http://wallscope.co.uk/resource/olympics/sport/Shooting>", "\"83\"^^<http://www.w3.org/2001/XMLSchema#integer>"], ["<http://wallscope.co.uk/resource/olympics/sport/Swimming>", "\"55\"^^<http://www.w3.org/2001/XMLSchema#integer>"], ["<http://wallscope.co.uk/resource/olympics/sport/Cycling>", "\"44\"^^<http://www.w3.org/2001/XMLSchema#integer>"], ["<http://wallscope.co.uk/resource/olympics/sport/Sailing>", "\"38\"^^<http://www.w3.org/2001/XMLSchema#integer>"]],
+    totalRows: 66,
+    repairs: 1,
+    turnOutcomes: ["ParseError", "Ok"],
+    isAsk: false,
+  },
+  {
+    question: "Are there any athletes taller than 200 centimetres?",
+    sparql: "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX foaf: <http://xmlns.com/foaf/0.1/>\nPREFIX dbo: <http://dbpedia.org/ontology/>\nASK {\n  ?athlete rdf:type foaf:Person ;\n           dbo:height ?height .\n  FILTER(?height > 200)\n}",
+    vars: [],
+    headRows: [[]],
+    totalRows: 1,
+    repairs: 0,
+    turnOutcomes: ["Ok"],
+    isAsk: true,
+  },
+];
+
+/** Lookup by question text (the page's selection key). */
+export function questionByText(text: string): Question | undefined {
+  return QUESTIONS.find((q) => q.question === text);
+}
+
+/** The total repair rounds across the eval set — exactly one (the fixture exercises it). */
+export function totalRepairs(): number {
+  return QUESTIONS.reduce((n, q) => n + q.repairs, 0);
+}

--- a/site/test/genai.test.mjs
+++ b/site/test/genai.test.mjs
@@ -1,0 +1,178 @@
+// [OPUS-4.8] sq-3was — unit tests for the /surface/genai (GenAI / NLQ) walkthrough.
+// This surface is tier-e (no backend behind the static site) so it replays REAL captured
+// output from the sparq-nlq loop (ReplayLlm fixture + the real engine) over the real
+// 1.78M-triple Olympics dataset. These tests pin the captured data's SHAPE *and
+// SERIALIZATION* so the page can never silently drift into a fabrication — the exact
+// failure mode the sibling http-server page was caught in (dropped datatypes, invented
+// rows). In particular: every literal result cell carries its datatype / language tag
+// EXACTLY as oxrdf::Term::Display emits it; the captured row counts match the crate's
+// own CI cross-check (crates/sparq-nlq/tests/olympics_eval.rs); the one repair case has
+// the ["ParseError","Ok"] transcript; and the ASK is the unit-row encoding. Run via
+// `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  QUESTIONS,
+  SCHEMA_SUMMARY,
+  DATASET,
+  IS_LIVE_LLM,
+  questionByText,
+  totalRepairs,
+} from "../src/lib/genai.ts";
+
+test("the model step is honestly flagged as NOT a live LLM call", () => {
+  // The page MUST NOT claim the NL→SPARQL generation is a live model. This flag drives
+  // the page's "scripted fixture · not a live model" labelling; if it ever flips to true
+  // the page would need a real live capture (and this guard forces that decision).
+  assert.equal(IS_LIVE_LLM, false);
+});
+
+test("the schema card is the real introspection deck over the real dataset", () => {
+  // Pure index introspection (to_text_summary), no model — pin the headline counts it
+  // reports so a hand-edit can't quietly swap in invented numbers.
+  assert.equal(DATASET.triples, 1781625);
+  assert.match(SCHEMA_SUMMARY, /^# Schema summary — 1781625 triples, 406700 subjects/);
+  assert.match(SCHEMA_SUMMARY, /### foaf:Person — 134730 instances/);
+  assert.match(SCHEMA_SUMMARY, /### dbo:Sport — 66 instances/);
+  // The budget-truncation markers the crate itself emits at 4000 chars.
+  assert.ok(SCHEMA_SUMMARY.includes("…"), "schema card must show the real budget truncation");
+  assert.ok(SCHEMA_SUMMARY.length <= 4000, "schema card respects the 4000-char budget");
+});
+
+test("the question set matches the crate's olympics eval, with the captured row counts", () => {
+  // Cross-check against the EXACT (question → total rows, repairs) the crate's CI test
+  // crates/sparq-nlq/tests/olympics_eval.rs asserts against the real engine + dataset.
+  // If a hand-edit invents a different count, this fails.
+  const expected = new Map([
+    ["How many athletes are on each team?", { rows: 1184, repairs: 0 }],
+    ["How many athletes are in the dataset?", { rows: 1, repairs: 0 }],
+    ["List the year and host city of every Olympic games.", { rows: 52, repairs: 0 }],
+    ["How many medals of each type were awarded?", { rows: 3, repairs: 0 }],
+    ["What is the average height of the athletes?", { rows: 1, repairs: 0 }],
+    ["Which team has the most athletes?", { rows: 1, repairs: 0 }],
+    ["List all sports with their labels.", { rows: 66, repairs: 0 }],
+    ["How many events does each sport have?", { rows: 66, repairs: 1 }],
+    ["Are there any athletes taller than 200 centimetres?", { rows: 1, repairs: 0 }],
+  ]);
+  assert.equal(QUESTIONS.length, expected.size);
+  for (const q of QUESTIONS) {
+    const want = expected.get(q.question);
+    assert.ok(want, `unexpected question: ${q.question}`);
+    assert.equal(q.totalRows, want.rows, `${q.question}: row count`);
+    assert.equal(q.repairs, want.repairs, `${q.question}: repair rounds`);
+  }
+  // Exactly one repair round across the set — the fixture exercises the repair path once.
+  assert.equal(totalRepairs(), 1);
+});
+
+test("every captured query is a SELECT or ASK with declared prefixes", () => {
+  for (const q of QUESTIONS) {
+    assert.ok(/\bSELECT\b|\bASK\b/.test(q.sparql), `${q.question}: not a SELECT/ASK`);
+    // Each query declares its prefixes (the grounding prompt requires it).
+    assert.ok(/PREFIX /.test(q.sparql), `${q.question}: no PREFIX declarations`);
+  }
+});
+
+// ── The honesty-regression guard: term serialization is VERBATIM oxrdf Display. ─────────
+// The sibling page dropped literal datatypes when a "captured" payload was hand-edited.
+// Pin every literal cell to its EXACT N-Triples serialization so a bare value can never
+// sneak in: a typed literal is `"lex"^^<datatype-iri>`, a language literal is `"lex"@tag`.
+test("every literal result cell carries its datatype or language tag verbatim", () => {
+  // A non-empty result cell is either an IRI (`<...>`), a typed literal
+  // (`"..."^^<...>`), a language literal (`"..."@tag`), or null. NOTHING else — in
+  // particular, NO bare `"value"` literal without a type/lang (the fabrication shape).
+  const IRI = /^<[^>]+>$/;
+  const TYPED = /^".*"\^\^<[^>]+>$/s;
+  const LANG = /^".*"@[a-zA-Z-]+$/s;
+  for (const q of QUESTIONS) {
+    for (const row of q.headRows) {
+      for (const cell of row) {
+        if (cell === null) continue;
+        const ok = IRI.test(cell) || TYPED.test(cell) || LANG.test(cell);
+        assert.ok(
+          ok,
+          `${q.question}: cell is not a verbatim IRI/typed-literal/lang-literal: ${cell}`,
+        );
+        // A literal (starts with a quote) MUST carry a datatype or a language tag.
+        if (cell.startsWith('"')) {
+          assert.ok(
+            cell.includes("^^<") || /@[a-zA-Z-]+$/.test(cell),
+            `${q.question}: literal cell missing datatype/lang tag (the fabrication shape): ${cell}`,
+          );
+        }
+      }
+    }
+  }
+});
+
+test("aggregate COUNTs serialize as xsd:integer and AVG as xsd:decimal", () => {
+  // COUNT(...) → xsd:integer (the engine's aggregate type), verbatim.
+  const teams = questionByText("How many athletes are on each team?");
+  assert.equal(
+    teams.headRows[0][1],
+    '"9114"^^<http://www.w3.org/2001/XMLSchema#integer>',
+    "COUNT must be a verbatim xsd:integer",
+  );
+  // AVG(...) → xsd:decimal with the engine's full precision, verbatim (NOT rounded).
+  const avg = questionByText("What is the average height of the athletes?");
+  assert.equal(
+    avg.headRows[0][0],
+    '"176.316366892317380353"^^<http://www.w3.org/2001/XMLSchema#decimal>',
+    "AVG must be the verbatim full-precision xsd:decimal",
+  );
+});
+
+test("the source xsd:int datatype is preserved (not coerced to xsd:integer)", () => {
+  // dbp:year literals are typed xsd:int in the source data; the engine preserves that
+  // exact datatype on projection — a coercion to xsd:integer would be a serialization
+  // drift. This pins the distinction the http-server fabrication blurred.
+  const games = questionByText("List the year and host city of every Olympic games.");
+  assert.equal(
+    games.headRows[0][1],
+    '"1896"^^<http://www.w3.org/2001/XMLSchema#int>',
+    "dbp:year must keep its source xsd:int datatype",
+  );
+});
+
+test("language-tagged labels keep their @en tag verbatim", () => {
+  const medals = questionByText("How many medals of each type were awarded?");
+  assert.equal(medals.headRows[0][0], '"Gold"@en');
+  const sports = questionByText("List all sports with their labels.");
+  assert.equal(sports.headRows[1][1], '"Alpine Skiing"@en');
+});
+
+test("the repair case has the malformed-then-fixed transcript", () => {
+  const repair = questionByText("How many events does each sport have?");
+  assert.deepEqual(repair.turnOutcomes, ["ParseError", "Ok"]);
+  assert.equal(repair.repairs, 1);
+  // The FINAL (post-repair) query is well-formed: the aggregate alias paren is closed.
+  assert.match(repair.sparql, /\(COUNT\(\?event\) AS \?count\)/);
+  assert.ok(!repair.isAsk);
+});
+
+test("the ASK case is the unit-row encoding (zero vars, one empty row iff true)", () => {
+  const ask = questionByText("Are there any athletes taller than 200 centimetres?");
+  assert.equal(ask.isAsk, true);
+  assert.deepEqual(ask.vars, []);
+  assert.match(ask.sparql, /^[\s\S]*\bASK\b/);
+  // A satisfied ASK encodes as one row with zero cells.
+  assert.equal(ask.headRows.length, 1);
+  assert.deepEqual(ask.headRows[0], []);
+  assert.equal(ask.totalRows, 1);
+});
+
+test("head rows never exceed the total, and var counts line up with cells", () => {
+  for (const q of QUESTIONS) {
+    assert.ok(q.headRows.length <= q.totalRows, `${q.question}: more head rows than total`);
+    if (!q.isAsk) {
+      for (const row of q.headRows) {
+        assert.equal(row.length, q.vars.length, `${q.question}: row arity != var count`);
+      }
+    }
+  }
+});
+
+test("questionByText returns undefined for an unknown question", () => {
+  assert.equal(questionByText("does not exist"), undefined);
+});


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements bead **sq-3was** — the `/surface/genai` (GenAI / NLQ) showcase page, following the merged `/surface/http-server` (sq-rnwc, #698) tier-e pattern and the surface-shell foundation (sq-8thu).

## What the page shows

`sparq-nlq` is an **opt-in native crate** (the model sits behind an `Llm` trait), it is **not** in the lean wasm bundle, and the static Pages site has no backend — so this is an honest **captured-output walkthrough**, split into two clearly-labelled halves:

1. **Schema card** — the verbatim `Introspection::to_text_summary(4000)` grounding deck (pure index introspection: exact class/predicate counts, datatype ranges, characteristic sets, prefix glossary). Labelled "real introspection".
2. **NL → SPARQL loop** — pick a question, step the loop (ground → generate → validate → execute, with a repair branch), see the generated SPARQL and the **real executed result table**.

## Honesty — exactly what is live-captured vs illustrative

**(A) Genuinely live-captured** (verbatim, pinned by tests): the schema card, and for every question the executed **result rows**, row counts, repair counts and turn outcomes.

- **Capture method:** built `sparq-nlq` (release), downloaded the real **1,781,625-triple Olympics dataset** (`github.com/wallscope/olympics-rdf`), and ran the **real loop** (ground → generate → validate → execute → repair) with the **committed `ReplayLlm` fixture** (`crates/sparq-nlq/tests/fixtures/olympics_replay.json`) against it, then pasted the output verbatim into `site/src/lib/genai.ts`. Term serialization is byte-for-byte `oxrdf::Term::Display` — **datatypes and language tags intact**: `xsd:integer` for COUNT, `xsd:int` preserved from the source `dbp:year`, `xsd:decimal` for AVG (`176.316366892317380353`, full precision, not rounded), `@en` langStrings for labels.
- **Cross-check:** the row counts and the single repair round are verified offline + deterministically by the crate's existing CI test `crates/sparq-nlq/tests/olympics_eval.rs` (which I ran green against the real dataset).
- **Drift guard:** `site/test/genai.test.mjs` pins the serialization — every literal cell must carry its datatype/lang tag verbatim (the exact `"value"`-without-datatype shape the sibling http-server page was caught fabricating), COUNT→`xsd:integer` / AVG→`xsd:decimal` / year→`xsd:int`, `@en` tags, the `["ParseError","Ok"]` repair transcript, and the ASK unit-row encoding.

**(B) Honestly illustrative:** the **NL → SPARQL generation step is NOT a live model call here** (`IS_LIVE_LLM === false`). The committed fixture's completions are **scripted** — realistic, schema-grounded queries a competent model would write (one deliberately malformed to exercise the repair path). The page badges this "scripted fixture · not a live model" and does **not** claim the query text is "what an LLM said". Live-model exec-accuracy **numbers are explicitly not measured here** (open work, sparq-nlq bead `sq-g0lw`). The caveat also states **exec-accuracy is not correctness** (a query can parse + execute + return rows while answering the wrong question).

## Files / routes

- `site/src/app/surface/genai/page.tsx` — the page (tier `walkthrough`, `SurfaceContent` pattern)
- `site/src/components/genai-walkthrough.tsx` — schema card + steppable loop + result tables (client)
- `site/src/lib/genai.ts` — framework-free captured data + helpers (the verbatim capture)
- `site/test/genai.test.mjs` — serialization-pinning unit tests (12, all green)
- `site/src/app/surface/[slug]/page.tsx` — `genai` added to `BUILT_SURFACES` (static route wins over the placeholder)
- `site/src/data/surfaces.ts` — `genai` flipped to `built: true`, tier `walkthrough`

## Gate

- **WASM prereq:** built `js/npm run build:wasm` first (the site build hard-fails without the bundle) — build artifact only, no `crates/` changes.
- `npm install` / `npm run lint` (clean) / `npx tsc --noEmit` (clean) / `npm run build` all green; **`/surface/genai` emits** to `out/surface/genai/index.html` with `basePath /sparq` applied; existing routes intact.
- `npm run test:unit`: **82/82 pass** (12 new genai tests).
- lychee `--offline` link-check over the built HTML: **0 errors**.
- No new dependencies. No hard-coded perf numbers. Privacy-claims gate N/A (no ZK/MPC copy); NLQ is not overclaimed as a correctness guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
