### PR TITLE
ci(supply-chain): make cargo-vet GATING leg deterministic (--frozen, no remote re-fetch)

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -137,9 +137,27 @@ jobs:
         uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
         with:
           tool: cargo-vet
-      # `--locked` so vet evaluates the committed Cargo.lock, not a freshly-resolved tree.
+      # [OPUS-4.8] Populate the cargo cache so the subsequent `--frozen` vet can run
+      # fully offline (its precondition is "the cargo cache is populated or deps are
+      # vendored"). `--locked` keeps it to the committed Cargo.lock.
+      - name: Populate cargo cache (for offline vet)
+        run: cargo fetch --locked
+      # [OPUS-4.8] `--locked --frozen`: verify EVERY crate against the COMMITTED
+      # supply-chain/imports.lock + config.toml exemptions WITHOUT re-fetching the
+      # remote `[imports.*]` audit aggregations at run time. Plain `cargo vet --locked`
+      # still re-pulls those 6 upstream audit sets (Mozilla/Google/Bytecode-Alliance/
+      # ISRG/Embark/Zcash) and re-aggregates them in memory on every run; a transient
+      # bad/partial upstream response (observed: a `publisher.wasm-encoder` block fetched
+      # without its `user-id` field -> "missing field `user-id`" toml parse error) then
+      # reds this GATING leg and the whole ci-summary gate on an unrelated PR — while a
+      # concurrent run on `main` that sampled good data passes (seen on PRs #693/#704,
+      # bead sq-miwt). `--frozen` makes the attestation deterministic: it proves the
+      # ratchet against the checked-in evidence, and a genuinely-new/unaudited crate
+      # still FAILS (the committed imports.lock won't cover it). Imports are refreshed
+      # deliberately by re-running `cargo vet` (without `--frozen`) when updating the
+      # checked-in supply-chain/ evidence, not implicitly inside the gate.
       - name: cargo-vet check — GATING
-        run: cargo vet --locked
+        run: cargo vet --locked --frozen
 
   # ---- VEX ↔ deny.toml drift gate ----
   # [OPUS-4.8] sq-toze.29 (GS-5): the published VEX (supply-chain/vex.cdx.json) and the


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

Makes the `cargo-vet (… GATING)` leg of `supply-chain.yml` **deterministic** by
verifying against the **committed** `supply-chain/imports.lock` instead of
re-fetching the remote audit aggregations on every run.

Before: `cargo vet --locked` — still re-pulls the 6 upstream `[imports.*]` audit
sets (Mozilla / Google / Bytecode-Alliance / ISRG / Embark / Zcash) and
re-aggregates them in memory each run.

After: `cargo fetch --locked` (populate the cargo cache) then
`cargo vet --locked --frozen` — `--frozen` (`Avoid the network entirely,
requiring … the cargo cache is populated …`) verifies the **checked-in** evidence
with no run-time remote re-fetch.

## Why (root cause from real logs)

During triage of PRs #693/#704 the cargo-vet leg failed with:

```
ERROR × Failed to parse toml file
  ╰─▶ missing field `user-id` for key `publisher.wasm-encoder` at line 2352
```

The **committed** `imports.lock` is valid and byte-identical between `main` and
the PR branch (its `publisher.wasm-encoder` is at line 59 and well-formed). The
error points at a *runtime-regenerated* lock (line ~2352) — i.e. cargo-vet
re-fetched a transiently malformed `publisher.wasm-encoder` block (no `user-id`)
from upstream. #704 (a no-op `taiki-e/install-action` SHA bump that touches no
`Cargo.lock`) hit this **4 consecutive runs** while a concurrent `main`
supply-chain run was **green on the identical tree**. Same cargo-vet 0.10.0,
same committed evidence — a live-network flake on a **GATING** check. Tracked as
bead `sq-miwt`.

## Honesty / scope

- The attestation is **not weakened**: a genuinely new/unaudited crate still
  FAILS (the committed `imports.lock` won't cover it); the ratchet is unchanged.
- Imports are refreshed **deliberately** (re-run `cargo vet` without `--frozen`)
  when updating the checked-in `supply-chain/` evidence — not implicitly inside
  the gate.

## Validation

- Reproduced locally (cargo-vet 0.10.2):
  `cargo fetch --locked && cargo vet --locked --frozen` on a **fresh** vet cache
  → `Vetting Succeeded`, exit 0.
- YAML valid (`yaml.safe_load`); `actionlint 1.7.12` clean.
- Gate leg name unchanged (no `advisory`/`informational` word) → `ci-summary`
  still treats it as GATING; the aggregator is intact.

Closes the recurring cargo-vet gate flake; unblocks PRs #693 (already merged
post-fix-of-a-different-leg) / #700 / #704.
