### PR TITLE
feat(site): /surface/vector tier-e captured vec: k-NN + Bolt embedding run (sq-dwdm) [OPUS-4.8]

### DIFF
--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -113,6 +113,16 @@ sparq-sim = { path = "../sparq-sim" }
 name = "bench_vectors"
 required-features = ["approx-ann"]
 
+# [OPUS-4.8] sq-dwdm: the site /surface/vector capture harness exercises the `vec:`
+# magic predicate (query_vec), so it needs `vec-predicate`. Registering the requirement
+# keeps `cargo build --all-targets` (default features) green when the feature is out of
+# the build — the example body is `#![cfg(feature = "vec-predicate")]`, so without the
+# requirement a default-feature build would strip even `main` (E0601). The file is a
+# build-and-run capture harness only — no library code, no new dependency.
+[[example]]
+name = "capture_surface_vector"
+required-features = ["vec-predicate"]
+
 # [OPUS-4.8] sq-hkud (epic sq-toze, gap MS-G4) — register the `kani` cfg so the
 # `#[cfg(kani)]` bounded-proof harness in `store.rs` does not trip `-D warnings`
 # (unexpected_cfgs) on the NORMAL build. `cargo kani` sets this cfg itself when it

--- a/crates/sparq-vectors/examples/capture_surface_vector.rs
+++ b/crates/sparq-vectors/examples/capture_surface_vector.rs
@@ -1,0 +1,156 @@
+//! [OPUS-4.8] sq-dwdm — capture harness for the /surface/vector site page.
+//!
+//! Prints the EXACT, deterministic output of the real sparq-vectors pipeline so the
+//! site page (site/src/lib/vector.ts) can paste it BYTE-FOR-BYTE rather than fabricate
+//! it (the sq-rnwc lesson). Everything here is the answer-EXACT backend over a tiny,
+//! declared, in-memory fixture — reproducible on any machine, no downloaded data, no
+//! model, no index build. Run with:
+//!
+//!   cargo run -p sparq-vectors --features vec-predicate --example capture_surface_vector
+//!
+//! Two captures:
+//!   1. Usain Bolt label-embedding nearest-neighbour (deterministic HashEmbedder,
+//!      `embed_labels` + `nearest_term_exact`) — the bead's requested example.
+//!   2. The `vec:nearest` / `vec:search` magic predicates as REAL SPARQL over a
+//!      5-entity unit-circle store, printing the engine's verbatim term serialization.
+#![cfg(feature = "vec-predicate")]
+
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+use sparq_vectors::{
+    embed_labels, nearest_term_exact, query_vec, HashEmbedder, QueryResult, VectorStore,
+};
+
+fn term(iri: &str) -> Term {
+    Term::NamedNode(NamedNode::new(iri).unwrap())
+}
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "sparq-vectors-capture-{}-{}.spqv",
+        std::process::id(),
+        name
+    ))
+}
+
+/// Render a QueryResult exactly as the engine emits each cell (oxrdf::Term::Display =
+/// N-Triples), one row per line, tab-separated, `UNBOUND` for an unbound cell.
+fn render(r: &QueryResult) {
+    let header: Vec<String> = r.vars.iter().map(|v| format!("?{}", v.as_str())).collect();
+    println!("VARS\t{}", header.join("\t"));
+    for row in &r.rows {
+        let cells: Vec<String> = row
+            .iter()
+            .map(|c| match c {
+                Some(t) => t.to_string(),
+                None => "UNBOUND".to_string(),
+            })
+            .collect();
+        println!("ROW\t{}", cells.join("\t"));
+    }
+    println!("NROWS\t{}", r.rows.len());
+}
+
+fn capture_bolt() {
+    // The bead's example: rdfs:label embeddings with the DETERMINISTIC HashEmbedder
+    // (lexical n-gram hashing, fixed — no model, no randomness), then exact cosine
+    // nearest-neighbour by term. "Usain Bolt"'s nearest LABELED neighbour is
+    // "Usain Bolt Junior" (shared n-grams); the seed is excluded.
+    let ttl = r#"
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ex:   <http://example.org/> .
+
+ex:bolt      rdfs:label "Usain Bolt" ; a ex:Athlete .
+ex:bolt2     rdfs:label "Usain Bolt Junior" ; a ex:Athlete .
+ex:blake     rdfs:label "Yohan Blake" ; a ex:Athlete .
+ex:powell    rdfs:label "Asafa Powell" ; a ex:Athlete .
+ex:coubertin skos:prefLabel "Pierre de Coubertin" ; a ex:Founder .
+"#;
+    let g = Graph::load_str(ttl, "turtle").unwrap();
+    let path = tmp("bolt");
+    let embedder = HashEmbedder::new(64); // deterministic, test-only lexical embedder
+    let mut store = VectorStore::create(&path, 64).unwrap();
+    let n = embed_labels(&g, &mut store, &embedder).unwrap();
+    store.finalize().unwrap();
+
+    println!("=== BOLT-CAPTURE-BEGIN ===");
+    println!("EMBEDDED\t{}", n);
+    let bolt = term("http://example.org/bolt");
+    let neighbours = nearest_term_exact(&store, &g, &bolt, 4);
+    println!("SEED\t{}", bolt);
+    for (t, score) in &neighbours {
+        // f32 cosine printed with full default precision; the site rounds for display
+        // but the captured value is the engine's exact f32.
+        println!("NEIGHBOUR\t{}\t{}", t, score);
+    }
+    println!("=== BOLT-CAPTURE-END ===");
+    let _ = std::fs::remove_file(&path);
+}
+
+fn unit_circle_store(name: &str) -> (Graph, VectorStore) {
+    // Five entities on the unit circle (mirrors tests/vec_predicate.rs::fixture): a-style
+    // +x, b-style +y, c near +x, d -x, e near +y. dim=2 so the geometry is legible.
+    let g = Graph::load_str(
+        r#"
+        <http://ex/a> <http://ex/label> "alpha" .
+        <http://ex/b> <http://ex/label> "beta" .
+        <http://ex/c> <http://ex/label> "gamma" .
+        <http://ex/d> <http://ex/label> "delta" .
+        <http://ex/e> <http://ex/label> "epsilon" .
+        "#,
+        "ntriples",
+    )
+    .unwrap();
+    let id = |s: &str| g.id_of(&term(s)).unwrap();
+    let mut store = VectorStore::create(tmp(name), 2).unwrap();
+    store.put(id("http://ex/a"), &[1.0, 0.0]).unwrap(); // +x
+    store.put(id("http://ex/b"), &[0.0, 1.0]).unwrap(); // +y
+    store.put(id("http://ex/c"), &[0.9, 0.1]).unwrap(); // near +x
+    store.put(id("http://ex/d"), &[-1.0, 0.0]).unwrap(); // -x
+    store.put(id("http://ex/e"), &[0.2, 0.98]).unwrap(); // near +y
+    (g, store)
+}
+
+fn capture_query(title: &str, name: &str, sparql: &str) {
+    let (g, store) = unit_circle_store(name);
+    println!("=== QUERY-CAPTURE-BEGIN\t{} ===", title);
+    println!("SPARQL-BEGIN");
+    print!("{}", sparql);
+    println!("\nSPARQL-END");
+    let r = query_vec(&g, sparql, &store).unwrap();
+    render(&r);
+    println!("=== QUERY-CAPTURE-END ===");
+}
+
+fn main() {
+    capture_bolt();
+
+    // (a) vec:nearest by query vector "1,0" → the two most +x-aligned: a then c.
+    capture_query(
+        "nearest-by-vector",
+        "nearest_vec",
+        "PREFIX vec: <http://sparq.dev/vec#>\nSELECT ?node WHERE { ?node vec:nearest ( \"1,0\" 2 ) }",
+    );
+
+    // (b) vec:nearest by SEED IRI <a> (+x); a itself is excluded → c is nearest.
+    capture_query(
+        "nearest-by-seed",
+        "nearest_seed",
+        "PREFIX vec: <http://sparq.dev/vec#>\nSELECT ?node WHERE { ?node vec:nearest ( <http://ex/a> 1 ) }",
+    );
+
+    // (c) vec:nearest joined to ordinary triples — neighbours' labels for "0,1".
+    capture_query(
+        "nearest-joined-to-bgp",
+        "nearest_join",
+        "PREFIX vec: <http://sparq.dev/vec#>\nSELECT ?label WHERE {\n  ?node vec:nearest ( \"0,1\" 2 ) .\n  ?node <http://ex/label> ?label .\n}",
+    );
+
+    // (d) vec:search binds the cosine score; ORDER BY DESC recovers best-first.
+    capture_query(
+        "search-binds-score",
+        "search_score",
+        "PREFIX vec: <http://sparq.dev/vec#>\nSELECT ?node ?score WHERE {\n  ( ?node ?score ) vec:search ( \"1,0\" 3 )\n} ORDER BY DESC(?score)",
+    );
+}

--- a/site/src/app/surface/[slug]/page.tsx
+++ b/site/src/app/surface/[slug]/page.tsx
@@ -20,6 +20,7 @@ const BUILT_SURFACES = new Set([
   "full-text",
   "http-server",
   "genai",
+  "vector",
 ]);
 const PLACEHOLDER_SURFACES = ALL_SURFACES.filter(
   (s) =>

--- a/site/src/app/surface/vector/page.tsx
+++ b/site/src/app/surface/vector/page.tsx
@@ -1,0 +1,160 @@
+import type { Metadata } from "next";
+import { Binary } from "lucide-react";
+
+import { SurfaceContent } from "@/components/surface-content";
+import { VectorWalkthrough } from "@/components/vector-walkthrough";
+
+export const metadata: Metadata = {
+  title: "Vector / ANN",
+  description:
+    "sparq-vectors — an opt-in memory-mapped per-term-id embedding store (.spqv) with exact cosine top-k, on-disk DiskANN/Vamana and in-RAM HNSW nearest-neighbour search, predicate-constrained (filtered) ANN, hybrid RRF fusion, and k-NN inside plain SPARQL via the vec: magic predicates. This page replays REAL captured engine output: the Usain Bolt label-embedding run and the vec:nearest / vec:search results, byte-for-byte.",
+};
+
+export default function VectorSurfacePage() {
+  return (
+    <SurfaceContent
+      icon={Binary}
+      title="Vector / ANN"
+      statement="A memory-mapped per-term-id embedding store with exact + approximate (HNSW / DiskANN) nearest-neighbour search, predicate-constrained ANN, hybrid fusion, and k-NN inside plain SPARQL."
+      tier="walkthrough"
+      extraBadge="Opt-in crate · captured output"
+      intro={
+        <>
+          <p>
+            <code className="font-mono text-foreground">sparq-vectors</code> adds embedding
+            storage + nearest-neighbour (ANN) search to the engine. It stores{" "}
+            <strong className="text-foreground">one f32 vector per dictionary term id</strong>{" "}
+            in a flat memory-mapped <code className="font-mono">.spqv</code> file (sparse by
+            design — entities, not every literal), then queries top-
+            <code className="font-mono">k</code> by{" "}
+            <strong className="text-foreground">cosine</strong>: an exact brute-force scan,
+            a persistent on-disk <strong className="text-foreground">DiskANN / Vamana</strong>{" "}
+            graph (<code className="font-mono">.spqg</code>), or an in-RAM{" "}
+            <strong className="text-foreground">HNSW</strong> index behind the opt-in{" "}
+            <code className="font-mono">approx-ann</code> feature. Embeddings are produced{" "}
+            <em>out of process</em> — the crate verbalizes entities to text and embeds via a
+            provider-agnostic trait; it never runs a model itself.
+          </p>
+          <p>
+            The RDF-native differentiators: <strong className="text-foreground">k-NN
+            inside plain SPARQL</strong> via the <code className="font-mono">vec:nearest</code>{" "}
+            / <code className="font-mono">vec:search</code> magic predicates (a
+            spargebra-algebra rewrite — the engine and wasm bundle are unchanged),{" "}
+            <strong className="text-foreground">predicate-constrained (filtered) ANN</strong>{" "}
+            that searches only the graph nodes a BGP admits, and{" "}
+            <strong className="text-foreground">hybrid fusion</strong> (RRF / score blend)
+            with another ranked signal.
+          </p>
+          <p>
+            It is an <strong className="text-foreground">opt-in crate</strong>: nothing in
+            the workspace (or the lean wasm bundle) depends on it, the default build does not
+            compile it, and the <code className="font-mono">vec:</code> predicate sits behind
+            the non-default <code className="font-mono">vec-predicate</code> feature. This
+            static Pages site has no backend and the crate is native-only, so &mdash;
+            honestly &mdash; this is a{" "}
+            <strong className="text-foreground">captured-output walkthrough</strong>:{" "}
+            <strong className="text-foreground">(1)</strong> the Usain Bolt
+            label-embedding run and <strong className="text-foreground">(2)</strong> every{" "}
+            <code className="font-mono">vec:</code> result table are{" "}
+            <em>real, verbatim engine output</em> &mdash; produced by running the real
+            binary over a tiny declared fixture with the answer-exact backend (term
+            serialization, datatypes intact). The cosines are the engine&rsquo;s exact f32.
+            The embeddings come from the deterministic{" "}
+            <strong className="text-foreground">test-only</strong>{" "}
+            <code className="font-mono">HashEmbedder</code> (lexical hashing, no semantics),
+            so they demonstrate the <em>pipeline and the exact geometry</em>, not the
+            retrieval quality of a real model.
+          </p>
+        </>
+      }
+      capabilities={[
+        {
+          title: "Memory-mapped per-term-id store (.spqv)",
+          body: "One f32 vector per dictionary id; get is one binary search + a contiguous slice. Sparse by design, corrupt files rejected up front, build bigger than RAM with StreamingWriter.",
+        },
+        {
+          title: "Exact + approximate search",
+          body: "nearest_exact is the answer-exact ground truth; the on-disk DiskANN/Vamana graph (build once, reopen with no rebuild) and the opt-in in-RAM HNSW trade recall (< 1.0) for speed at scale.",
+        },
+        {
+          title: "k-NN inside plain SPARQL (opt-in vec-predicate)",
+          body: "vec:nearest / vec:search run vector k-NN via a spargebra-algebra rewrite that inlines the hits as a VALUES table — the engine, planner and wasm bundle are unchanged.",
+        },
+        {
+          title: "Predicate-constrained (filtered) ANN (opt-in filtered-ann)",
+          body: "Restrict the search to the graph nodes a SPARQL BGP admits — the join-connected sub-BGP of the neighbour variable derives the candidate mask; a cost model picks pre- vs post-filter, both byte-identical.",
+        },
+        {
+          title: "Hybrid fusion + quantization",
+          body: "fuse_rrf / fuse_scores combine text vectors with another ranked signal (e.g. structural similarity); ScalarQuantizer (4×) and ProductQuantizer (8–32×) shrink large stores.",
+        },
+        {
+          title: "Bring-your-own embeddings",
+          body: "Embeddings are out-of-process: import a matrix computed elsewhere (NumPy .npy / flat f32 dump) keyed by dict id, or wire a real OpenAI-compatible endpoint behind the opt-in embeddings feature. The default build opens no sockets.",
+        },
+      ]}
+      runsNote={
+        <>
+          <p>
+            <strong className="text-foreground">Captured-output replay.</strong> The Bolt
+            neighbour list and every <code className="font-mono">vec:</code> result table are
+            the verbatim output of the real <code className="font-mono">sparq-vectors</code>{" "}
+            binary (the capture harness{" "}
+            <code className="font-mono">examples/capture_surface_vector.rs</code>, built with{" "}
+            <code className="font-mono">--features vec-predicate</code>) over a tiny declared
+            in-memory fixture, using the <strong className="text-foreground">answer-exact</strong>{" "}
+            scan — no index build, no model, no downloaded data. Everything is deterministic
+            (fixed lexical embedder, exact backend, id-ascending ties), so re-running the
+            harness yields byte-identical output; a pinning test (
+            <code className="font-mono">site/test/vector.test.mjs</code>) asserts the
+            serialization can&rsquo;t drift. To run it for yourself:
+          </p>
+          <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12px] leading-relaxed">
+            {`cargo run -p sparq-vectors --features vec-predicate \\
+  --example capture_surface_vector`}
+          </pre>
+        </>
+      }
+      caveat={
+        <>
+          <p>
+            <strong className="text-foreground">HashEmbedder is test-only.</strong> The
+            captured embeddings come from a deterministic lexical n-gram hash with{" "}
+            <em>no semantics</em> (&ldquo;car&rdquo; and &ldquo;automobile&rdquo; are
+            unrelated) — the neighbours are real and reproducible, but they show the
+            store / search / SPARQL-rewrite <em>pipeline</em> and the exact geometry, not
+            the retrieval quality of a real embedding model (a deployment supplies its own{" "}
+            <code className="font-mono">Embedder</code>).
+          </p>
+          <p>
+            <strong className="text-foreground">
+              Approximate search is approximate; recall &lt; 1.0.
+            </strong>{" "}
+            Only the exact scan and these captured runs are answer-exact. The HNSW / DiskANN
+            recall figures referenced here are the crate&rsquo;s own{" "}
+            <code className="font-mono">cargo test</code> gates &mdash;{" "}
+            <strong className="text-foreground">representative, not canonical</strong> and not
+            measured on this page; run the tests for the numbers. No latency figure is shown
+            (hardware-dependent). The <code className="font-mono">vec:</code> predicate,
+            filtered ANN, HNSW and live embeddings are all <em>opt-in</em> cargo features,
+            off in the default build.
+          </p>
+        </>
+      }
+      links={[
+        {
+          href: "https://github.com/jeswr/sparq/tree/main/crates/sparq-vectors",
+          label: "sparq-vectors crate",
+          external: true,
+        },
+        {
+          href: "https://github.com/jeswr/sparq/blob/main/skills/vector-search/SKILL.md",
+          label: "vector-search SKILL.md",
+          external: true,
+        },
+      ]}
+    >
+      <VectorWalkthrough />
+    </SurfaceContent>
+  );
+}

--- a/site/src/components/vector-walkthrough.tsx
+++ b/site/src/components/vector-walkthrough.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+// [OPUS-4.8] sq-dwdm — the /surface/vector (Vector / ANN) showcase (tier-e). sparq-vectors
+// is an OPT-IN native crate (nothing in the workspace or the lean wasm bundle depends on
+// it, and the `vec:` magic predicate sits behind the non-default `vec-predicate` feature),
+// and the static Pages site has no backend — so, per the feature-showcase design's honest
+// tier-e fallback, this REPLAYS captured output rather than building an index live:
+//
+//   1. EMBED & SEARCH BY TERM — the Usain Bolt example: embed entity labels with the
+//      deterministic HashEmbedder, then exact cosine nearest-neighbour by term. REAL
+//      captured output (the cosines are the engine's exact f32). Lexical, NOT semantic.
+//   2. k-NN INSIDE SPARQL — pick a `vec:nearest` / `vec:search` query and see the REAL
+//      executed result table over a tiny unit-circle store (verbatim term serialization).
+//
+// HONESTY (see src/lib/vector.ts): the result rows / cosines are real captured engine
+// output (answer-exact backend, verbatim oxrdf Term serialization). The HashEmbedder is
+// TEST-ONLY (lexical n-gram hashing, no semantics — IS_SEMANTIC_EMBEDDER === false), so the
+// neighbours demonstrate the PIPELINE + the exact geometry, not embedding quality. ANN
+// recall/latency are NOT captured here and are non-canonical. All data is in
+// src/lib/vector.ts (framework-free, unit-tested).
+
+import * as React from "react";
+import {
+  Binary,
+  Crosshair,
+  Database,
+  FileSearch,
+  Play,
+  Search,
+  Tag,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  BOLT,
+  IS_SEMANTIC_EMBEDDER,
+  RECALL_NOTES,
+  UNIT_CIRCLE,
+  VEC_QUERIES,
+  type VecQuery,
+} from "@/lib/vector";
+
+/** A short label for an `<iri>` cell — strip the namespace for legibility. */
+function shortIri(cell: string): string {
+  const m = cell.match(/^<.*[/#]([^/#>]+)>$/);
+  return m ? m[1] : cell;
+}
+
+function ResultTable({ q }: { q: VecQuery }) {
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <table className="w-full border-collapse font-mono text-[12px]">
+        <thead>
+          <tr className="border-b bg-muted/60">
+            {q.vars.map((v) => (
+              <th key={v} className="px-3 py-1.5 text-left font-semibold">
+                ?{v}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {q.rows.map((row, i) => (
+            <tr key={i} className="border-b last:border-0">
+              {row.map((cell, j) => (
+                <td key={j} className="px-3 py-1.5 align-top break-all">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function VectorWalkthrough() {
+  const [selected, setSelected] = React.useState(0);
+  const [ran, setRan] = React.useState(false);
+  const q = VEC_QUERIES[selected];
+
+  function pick(i: number) {
+    setSelected(i);
+    setRan(false);
+  }
+
+  return (
+    <div className="space-y-10">
+      {/* ── 1. Embed labels + exact nearest-neighbour by term (the Bolt example) ──── */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Tag className="size-5 text-primary" aria-hidden="true" />
+          <h2 className="text-xl font-semibold">
+            Embed labels, then search by term
+          </h2>
+          <Badge variant="success" className="text-[10px] uppercase">
+            real captured output
+          </Badge>
+        </div>
+        <p className="measure text-sm text-muted-foreground">
+          <code className="font-mono">embed_labels</code> stores one f32 vector per labeled
+          entity (keyed by its dictionary id), then{" "}
+          <code className="font-mono">nearest_term_exact</code> returns the cosine-closest
+          neighbours of a term — the seed excluded, best first. This run embeds five athlete
+          labels and queries the neighbours of{" "}
+          <strong className="text-foreground">Usain Bolt</strong>. The vectors come from the{" "}
+          <strong className="text-foreground">deterministic, test-only</strong>{" "}
+          <code className="font-mono">HashEmbedder</code> (lexical n-gram hashing), so the
+          nearest neighbour is{" "}
+          <em>&ldquo;Usain Bolt Junior&rdquo;</em> because the strings overlap — this shows
+          the pipeline and the exact geometry, <strong className="text-foreground">not</strong>{" "}
+          semantic quality (a real deployment supplies its own embedder).
+        </p>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {/* The fixture. */}
+          <Card>
+            <CardHeader className="flex-row items-center gap-2 space-y-0">
+              <FileSearch className="size-4 text-muted-foreground" aria-hidden="true" />
+              <CardTitle className="text-sm">
+                Fixture — {BOLT.embedded} labeled entities embedded
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-1.5 font-mono text-[12px]">
+              {BOLT.fixture.map((e) => (
+                <div key={e.iri} className="flex items-center gap-2">
+                  <Binary className="size-3 shrink-0 text-primary/60" aria-hidden="true" />
+                  <span className="text-muted-foreground">{shortIri(`<${e.iri}>`)}</span>
+                  <span className="break-all">&ldquo;{e.label}&rdquo;</span>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          {/* The captured neighbours. */}
+          <Card>
+            <CardHeader className="flex-row items-center gap-2 space-y-0">
+              <Crosshair className="size-4 text-primary" aria-hidden="true" />
+              <CardTitle className="text-sm">
+                nearest_term_exact( {shortIri(BOLT.seed)}, 4 )
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="overflow-x-auto rounded-lg border">
+                <table className="w-full border-collapse font-mono text-[12px]">
+                  <thead>
+                    <tr className="border-b bg-muted/60">
+                      <th className="px-3 py-1.5 text-left font-semibold">neighbour</th>
+                      <th className="px-3 py-1.5 text-right font-semibold">cosine</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {BOLT.neighbours.map((n) => (
+                      <tr key={n.term} className="border-b last:border-0">
+                        <td className="px-3 py-1.5">{shortIri(n.term)}</td>
+                        <td
+                          className={cn(
+                            "px-3 py-1.5 text-right tabular-nums",
+                            n.cosine >= 0
+                              ? "text-[var(--success)]"
+                              : "text-muted-foreground",
+                          )}
+                        >
+                          {n.cosine.toFixed(4)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                The seed {shortIri(BOLT.seed)} is excluded. Cosines are the engine&rsquo;s
+                exact f32, captured verbatim (shown to 4 dp).
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      {/* ── 2. k-NN inside SPARQL — the vec: magic predicate ──────────────────────── */}
+      <section className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Search className="size-5 text-primary" aria-hidden="true" />
+          <h2 className="text-xl font-semibold">k-NN inside SPARQL — the vec: predicate</h2>
+          <Badge variant="success" className="text-[10px] uppercase">
+            real captured output
+          </Badge>
+        </div>
+        <p className="measure text-sm text-muted-foreground">
+          With the opt-in <code className="font-mono">vec-predicate</code> feature, vector
+          k-NN is expressed in <strong className="text-foreground">plain SPARQL</strong> via
+          the <code className="font-mono">vec:nearest</code> /{" "}
+          <code className="font-mono">vec:search</code> magic predicates — a
+          spargebra-algebra rewrite that inlines the hits as a{" "}
+          <code className="font-mono">VALUES</code> table, so the engine, planner and wasm
+          bundle are unchanged. These run over a tiny{" "}
+          <strong className="text-foreground">unit-circle store</strong> (5 entities, dim 2)
+          so the geometry is legible:
+        </p>
+
+        {/* The unit-circle store. */}
+        <div className="flex flex-wrap gap-2 font-mono text-[12px]">
+          {UNIT_CIRCLE.map((e) => (
+            <span
+              key={e.iri}
+              className="inline-flex items-center gap-1.5 rounded-full bg-muted/40 px-2.5 py-1 ring-1 ring-foreground/10"
+            >
+              <span className="text-primary">{shortIri(`<${e.iri}>`)}</span>
+              <span className="text-muted-foreground">
+                [{e.vec[0]}, {e.vec[1]}]
+              </span>
+            </span>
+          ))}
+        </div>
+
+        {/* Query chips. */}
+        <div className="flex flex-wrap gap-2">
+          {VEC_QUERIES.map((item, i) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => pick(i)}
+              className={cn(
+                "rounded-full px-3 py-1.5 text-left text-[12.5px] ring-1 transition-colors",
+                i === selected
+                  ? "bg-primary/10 text-primary ring-primary/30"
+                  : "bg-muted/40 text-muted-foreground ring-foreground/10 hover:bg-muted",
+              )}
+            >
+              {item.caption}
+            </button>
+          ))}
+        </div>
+
+        <Card>
+          <CardHeader className="space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <CardTitle className="text-base">{q.caption}</CardTitle>
+              <Button size="sm" onClick={() => setRan(true)} disabled={ran}>
+                <Play className="size-4" aria-hidden="true" />
+                {ran ? "Executed" : "Run"}
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed">
+              {q.sparql}
+            </pre>
+            {ran && (
+              <div className="space-y-1.5">
+                <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                  <Database className="size-3.5" aria-hidden="true" />
+                  result
+                  <Badge variant="success" className="text-[10px] uppercase">
+                    real engine output
+                  </Badge>
+                </div>
+                <ResultTable q={q} />
+                <p className="text-xs text-muted-foreground">
+                  {q.rows.length} row{q.rows.length === 1 ? "" : "s"}, executed by the sparq
+                  engine over the unit-circle store with the answer-exact scan — term
+                  serialization verbatim (datatypes intact).
+                </p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+
+      {/* ── Exact vs approximate — honest, non-canonical ──────────────────────────── */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Binary className="size-5 text-primary" aria-hidden="true" />
+          <h2 className="text-xl font-semibold">Exact vs approximate — the trade-off</h2>
+          <Badge variant="muted" className="text-[10px] uppercase">
+            non-canonical
+          </Badge>
+        </div>
+        <p className="measure text-sm text-muted-foreground">
+          The captures above use the <strong className="text-foreground">exact</strong>{" "}
+          brute-force scan (answer-exact, the right default below ~10
+          <sup>5</sup> vectors). At scale you trade some recall for speed with an approximate
+          index. Approximate search is <strong className="text-foreground">approximate</strong>{" "}
+          &mdash; recall <code className="font-mono">&lt; 1.0</code>. The figures below are{" "}
+          <strong className="text-foreground">the crate&rsquo;s own test gates, not
+          canonical</strong> and not measured here &mdash; run the tests for the numbers; we
+          show no latency (hardware-dependent).
+        </p>
+        <div className="grid gap-3 sm:grid-cols-3">
+          {RECALL_NOTES.map((r) => (
+            <div
+              key={r.backend}
+              className="rounded-xl bg-muted/40 p-4 ring-1 ring-foreground/10"
+            >
+              <div className="text-sm font-semibold">{r.backend}</div>
+              <div className="mt-1 text-xs text-muted-foreground">{r.note}</div>
+              <div className="mt-2 font-mono text-[11px] text-muted-foreground/80">
+                {r.test}
+              </div>
+            </div>
+          ))}
+        </div>
+        {!IS_SEMANTIC_EMBEDDER && (
+          <p className="text-xs text-muted-foreground">
+            Note: the captured embeddings come from the test-only{" "}
+            <code className="font-mono">HashEmbedder</code> (lexical, no semantics). They
+            demonstrate the store / search / SPARQL-rewrite pipeline and the exact geometry,
+            not the retrieval quality of a real embedding model.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/site/src/data/surfaces.ts
+++ b/site/src/data/surfaces.ts
@@ -185,9 +185,16 @@ export const GROUPS: SurfaceGroup[] = [
         slug: "vector",
         href: "/surface/vector",
         title: "Vector",
-        blurb: "Embedding store + cosine top-k (HNSW / DiskANN) + hybrid fusion.",
-        tier: "hosted",
+        blurb: "Embedding store + cosine top-k (HNSW / DiskANN) + k-NN inside SPARQL.",
+        // [OPUS-4.8] sq-dwdm: tier-e. sparq-vectors is an opt-in native crate (nothing in
+        // the workspace or the lean wasm bundle depends on it, and the vec: magic predicate
+        // sits behind the non-default vec-predicate feature), and the static Pages site has
+        // no backend — so the honest surface is a captured-output walkthrough (the real
+        // Usain Bolt label-embedding run + real vec:nearest / vec:search result tables,
+        // answer-exact backend), not a live hosted endpoint.
+        tier: "walkthrough",
         icon: Binary,
+        built: true,
       },
       {
         slug: "genai",

--- a/site/src/lib/vector.ts
+++ b/site/src/lib/vector.ts
@@ -1,0 +1,217 @@
+// [OPUS-4.8] sq-dwdm — pure, framework-free data + helpers for the /surface/vector
+// (Vector / ANN) showcase. sparq-vectors is an OPT-IN native crate: nothing in the
+// workspace (or the lean wasm bundle) depends on it, the default engine build does not
+// even compile it, and the `vec:` magic-predicate integration sits behind the non-default
+// `vec-predicate` feature. The static GitHub-Pages site has no backend, so this surface is
+// the honest tier-e "captured-output walkthrough" fallback the feature-showcase design
+// names (research/feature-showcase-site-design.md §0, surface (e)).
+//
+// =====================================================================================
+// HONESTY CONTRACT — read before editing. A sibling page (sq-rnwc) was caught fabricating
+// "captured" output (dropped datatypes, invented rows); the fix on the next page (sq-3was)
+// pinned the serialization in a test so drift is impossible. We do the SAME here. Every
+// payload on this page is split into two clearly-labelled halves, and the test
+// (site/test/vector.test.mjs) pins the serialization of the live-captured half:
+//
+//   (A) GENUINELY LIVE-CAPTURED — `BOLT` (the embed_labels + nearest_term_exact run) and
+//       every `VecQuery` (the `vec:nearest` / `vec:search` SPARQL results). These were
+//       produced by RUNNING THE REAL sparq-vectors binary
+//       (crates/sparq-vectors/examples/capture_surface_vector.rs, built with
+//       `--features vec-predicate`) over a tiny DECLARED in-memory fixture, with the
+//       answer-EXACT backend (`nearest_exact` brute-force — no index build, no model), and
+//       PASTED VERBATIM. The result cells are the engine's exact `oxrdf::Term::Display`
+//       (N-Triples) serialization: an IRI is `<…>`, a plain literal is `"…"`, a typed
+//       literal is `"…"^^<datatype-iri>`. The `vec:search` cosine score is bound by the
+//       engine as an `xsd:double` literal, datatype INTACT. The Bolt cosines are the
+//       engine's exact f32 (the page rounds them for display but the captured value is
+//       pinned). Re-CAPTURE (do not hand-edit) if the fixture or pipeline changes — run the
+//       example again and paste. Everything in (A) is DETERMINISTIC: the HashEmbedder is a
+//       fixed lexical hash, the exact backend is answer-exact, ties break on ascending id —
+//       so the same binary over the same fixture yields byte-identical output (verified by
+//       re-running the harness).
+//
+//   (B) HONESTLY ILLUSTRATIVE / NON-CANONICAL — the ANN recall and latency characteristics
+//       (HNSW / DiskANN / PQ) are NOT captured here and are NOT canonical. They are the
+//       crate's own `cargo test` gates (tests/recall.rs, tests/diskann.rs, tests/quant.rs,
+//       tests/throughput.rs) — run them yourself for the figures. We cite a couple of the
+//       crate's documented recall FLOORS as representative, clearly labelled "measured by
+//       the crate's tests, recall < 1.0, not a canonical guarantee", and we present NO
+//       latency number. Approximate search is APPROXIMATE: recall < 1.0; only the exact
+//       scan (`nearest_exact`) and the captured runs above are answer-exact. `HashEmbedder`
+//       is TEST-ONLY (lexical n-gram hashing, no semantics — "car" and "automobile" are
+//       unrelated); a real deployment supplies its own `Embedder`. We do NOT claim semantic
+//       quality from these captures — they demonstrate the PIPELINE and the exact geometry,
+//       not embedding quality.
+//
+// Grounded in crates/sparq-vectors (README + SKILL.md + src/rewrite.rs + tests/labels.rs +
+// tests/vec_predicate.rs) and the capture harness examples/capture_surface_vector.rs.
+
+/** Whether the embeddings on this page come from a REAL semantic model. They do NOT —
+ *  the captures use the deterministic, test-only `HashEmbedder` (lexical, no semantics). */
+export const IS_SEMANTIC_EMBEDDER = false as const;
+
+/** Whether the captured search used the answer-EXACT backend (vs an approximate index). */
+export const IS_EXACT_BACKEND = true as const;
+
+/** The `vec:` predicate vocabulary namespace (crates/sparq-vectors/src/rewrite.rs). */
+export const VEC_NS = "http://sparq.dev/vec#" as const;
+
+// ── (A) GENUINELY LIVE-CAPTURED ─────────────────────────────────────────────────────────
+
+/** One neighbour from the captured `nearest_term_exact` run: (term, exact f32 cosine). */
+export interface Neighbour {
+  /** The neighbour's term, verbatim oxrdf::Term::Display (here always an `<iri>`). */
+  term: string;
+  /** The engine's exact f32 cosine, pasted verbatim (the page rounds for display). */
+  cosine: number;
+}
+
+/**
+ * The Usain Bolt label-embedding nearest-neighbour run (the bead's requested example).
+ * Captured VERBATIM from `embed_labels` (deterministic `HashEmbedder::new(64)`) +
+ * `nearest_term_exact(store, graph, <bolt>, 4)` over a 5-entity in-memory graph. The seed
+ * `<bolt>` is excluded; neighbours are best-first by cosine. HashEmbedder similarity is
+ * LEXICAL (shared n-grams), not semantic — "Usain Bolt" is nearest "Usain Bolt Junior"
+ * because the strings overlap, NOT because the model knows they are sprinters.
+ */
+export const BOLT = {
+  /** The five rdfs:label / skos:prefLabel entities the fixture declares. */
+  fixture: [
+    { iri: "http://example.org/bolt", label: "Usain Bolt" },
+    { iri: "http://example.org/bolt2", label: "Usain Bolt Junior" },
+    { iri: "http://example.org/blake", label: "Yohan Blake" },
+    { iri: "http://example.org/powell", label: "Asafa Powell" },
+    { iri: "http://example.org/coubertin", label: "Pierre de Coubertin" },
+  ],
+  /** Entities embedded by `embed_labels` (all five carry a label literal). */
+  embedded: 5,
+  /** The query seed, excluded from its own neighbour list. */
+  seed: "<http://example.org/bolt>",
+  /** Verbatim captured neighbours, best-first (captured 2026-06-19). */
+  neighbours: [
+    { term: "<http://example.org/bolt2>", cosine: 0.8762895 },
+    { term: "<http://example.org/blake>", cosine: 0.12010295 },
+    { term: "<http://example.org/powell>", cosine: -0.022044001 },
+    { term: "<http://example.org/coubertin>", cosine: -0.08783152 },
+  ] as Neighbour[],
+} as const;
+
+/** One captured `vec:nearest` / `vec:search` SPARQL run over the unit-circle store. */
+export interface VecQuery {
+  /** A short tag for the chip/selector. */
+  id: string;
+  /** A human description of what the query asks. */
+  caption: string;
+  /** The exact SPARQL the harness ran (verbatim). */
+  sparql: string;
+  /** Projected variable names, in order. */
+  vars: string[];
+  /**
+   * Result rows, VERBATIM. Each cell is the engine's `oxrdf::Term::Display` (N-Triples)
+   * string: an IRI `<…>`, a plain literal `"…"`, or a typed literal `"…"^^<…>`.
+   */
+  rows: string[][];
+}
+
+/**
+ * The unit-circle vector store the `vec:` captures run over (5 entities, dim 2). The
+ * geometry is legible: `a` points along +x, `b` along +y, `c` near +x, `d` along −x,
+ * `e` near +y. Same fixture as crates/sparq-vectors/tests/vec_predicate.rs.
+ */
+export const UNIT_CIRCLE = [
+  { iri: "http://ex/a", label: "alpha", vec: [1.0, 0.0] },
+  { iri: "http://ex/b", label: "beta", vec: [0.0, 1.0] },
+  { iri: "http://ex/c", label: "gamma", vec: [0.9, 0.1] },
+  { iri: "http://ex/d", label: "delta", vec: [-1.0, 0.0] },
+  { iri: "http://ex/e", label: "epsilon", vec: [0.2, 0.98] },
+] as const;
+
+/**
+ * The captured `vec:` magic-predicate runs (captured 2026-06-19). Each `rows` array is the
+ * VERBATIM engine output from `query_vec`. NOTE the honest serialization detail the
+ * fabrication-shape would have blurred: the BGP-joined labels come back as PLAIN string
+ * literals (`"epsilon"`) because that is exactly how they are stored — no invented
+ * datatype — and the cosine scores from `vec:search` carry their `xsd:double` datatype.
+ */
+export const VEC_QUERIES: VecQuery[] = [
+  {
+    id: "nearest-by-vector",
+    caption: "Nearest neighbours of a query vector",
+    sparql:
+      'PREFIX vec: <http://sparq.dev/vec#>\nSELECT ?node WHERE { ?node vec:nearest ( "1,0" 2 ) }',
+    vars: ["node"],
+    // "1,0" → the two most +x-aligned entities: a (exact +x) then c (near +x).
+    rows: [["<http://ex/a>"], ["<http://ex/c>"]],
+  },
+  {
+    id: "nearest-by-seed",
+    caption: "Nearest neighbour of a seed IRI (seed excluded)",
+    sparql:
+      "PREFIX vec: <http://sparq.dev/vec#>\nSELECT ?node WHERE { ?node vec:nearest ( <http://ex/a> 1 ) }",
+    vars: ["node"],
+    // Neighbours of <a> (its stored +x vector); a itself is excluded → c is nearest.
+    rows: [["<http://ex/c>"]],
+  },
+  {
+    id: "nearest-joined",
+    caption: "Neighbours joined to ordinary triples (their labels)",
+    sparql:
+      'PREFIX vec: <http://sparq.dev/vec#>\nSELECT ?label WHERE {\n  ?node vec:nearest ( "0,1" 2 ) .\n  ?node <http://ex/label> ?label .\n}',
+    vars: ["label"],
+    // "0,1" → b (+y) and e (near +y); their labels, joined through the plain triple
+    // pattern. Plain string literals — verbatim, no invented datatype.
+    rows: [['"epsilon"'], ['"beta"']],
+  },
+  {
+    id: "search-score",
+    caption: "vec:search binds the cosine score (ORDER BY DESC)",
+    sparql:
+      'PREFIX vec: <http://sparq.dev/vec#>\nSELECT ?node ?score WHERE {\n  ( ?node ?score ) vec:search ( "1,0" 3 )\n} ORDER BY DESC(?score)',
+    vars: ["node", "score"],
+    // a (cosine 1.0) > c (~0.994) > e (~0.200); the score is an xsd:double literal,
+    // datatype intact, ORDER BY DESC recovers best-first over the unordered VALUES table.
+    rows: [
+      ["<http://ex/a>", '"1"^^<http://www.w3.org/2001/XMLSchema#double>'],
+      [
+        "<http://ex/c>",
+        '"0.9938837289810181"^^<http://www.w3.org/2001/XMLSchema#double>',
+      ],
+      [
+        "<http://ex/e>",
+        '"0.19996000826358795"^^<http://www.w3.org/2001/XMLSchema#double>',
+      ],
+    ],
+  },
+];
+
+// ── (B) HONESTLY ILLUSTRATIVE / NON-CANONICAL ───────────────────────────────────────────
+
+/**
+ * Representative recall FLOORS the crate's own `cargo test`s assert (NOT canonical, NOT
+ * measured on this box). Approximate search is APPROXIMATE — recall < 1.0; only the exact
+ * scan is answer-exact. These are shown only to be honest about the exact-vs-approximate
+ * trade-off, with the "run the test yourself" pointer. We present NO latency number (it is
+ * hardware-dependent and non-canonical).
+ */
+export const RECALL_NOTES: { backend: string; note: string; test: string }[] = [
+  {
+    backend: "Exact brute-force scan",
+    note: "answer-exact (recall 1.0) — the ground-truth baseline, no third-party ANN dependency",
+    test: "the default; nearest_exact",
+  },
+  {
+    backend: "On-disk DiskANN / Vamana",
+    note: "approximate; the crate documents recall@10 ≈ 0.966 — representative, < 1.0, not canonical",
+    test: "tests/diskann.rs",
+  },
+  {
+    backend: "In-RAM HNSW (opt-in approx-ann)",
+    note: "approximate; recall < 1.0 — the only third-party ANN dependency, off by default",
+    test: "tests/recall.rs",
+  },
+];
+
+/** Lookup a captured vec: query by id (the selector key). */
+export function vecQueryById(id: string): VecQuery | undefined {
+  return VEC_QUERIES.find((q) => q.id === id);
+}

--- a/site/test/vector.test.mjs
+++ b/site/test/vector.test.mjs
@@ -1,0 +1,177 @@
+// [OPUS-4.8] sq-dwdm — unit tests for the /surface/vector (Vector / ANN) walkthrough.
+// This surface is tier-e (no backend behind the static site) so it replays REAL captured
+// output from the sparq-vectors binary (the capture harness
+// crates/sparq-vectors/examples/capture_surface_vector.rs, built with `--features
+// vec-predicate`) over a tiny declared in-memory fixture, with the answer-EXACT backend.
+// These tests pin the captured data's SHAPE *and SERIALIZATION* so the page can never
+// silently drift into a fabrication — the exact failure mode the sibling http-server page
+// (sq-rnwc) was caught in (dropped datatypes, invented rows). In particular: every result
+// cell is the engine's verbatim oxrdf::Term::Display string; the vec:search cosine carries
+// its xsd:double datatype EXACTLY; the BGP-joined labels are PLAIN string literals (no
+// invented datatype); and the captured Bolt cosines are pinned. Run via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  BOLT,
+  IS_EXACT_BACKEND,
+  IS_SEMANTIC_EMBEDDER,
+  RECALL_NOTES,
+  UNIT_CIRCLE,
+  VEC_NS,
+  VEC_QUERIES,
+  vecQueryById,
+} from "../src/lib/vector.ts";
+
+test("the embedder is honestly flagged as NOT a semantic model, backend is exact", () => {
+  // The page MUST NOT claim the captures show semantic retrieval quality. The HashEmbedder
+  // is a deterministic lexical hash; the captured search is the answer-exact scan. If
+  // either flag ever flips, the page would need a real re-capture (this forces the choice).
+  assert.equal(IS_SEMANTIC_EMBEDDER, false);
+  assert.equal(IS_EXACT_BACKEND, true);
+});
+
+test("the vec: namespace matches the crate's vocabulary", () => {
+  assert.equal(VEC_NS, "http://sparq.dev/vec#");
+});
+
+// ── The Usain Bolt label-embedding capture ──────────────────────────────────────────────
+test("the Bolt run embeds all five labeled entities and excludes the seed", () => {
+  assert.equal(BOLT.fixture.length, 5);
+  assert.equal(BOLT.embedded, 5);
+  assert.equal(BOLT.seed, "<http://example.org/bolt>");
+  // The seed must NOT appear among its own neighbours (self-exclusion is real, not faked).
+  for (const n of BOLT.neighbours) {
+    assert.notEqual(n.term, BOLT.seed, "seed must be excluded from its neighbours");
+  }
+});
+
+test("the captured Bolt neighbours are verbatim, best-first, with pinned cosines", () => {
+  // Pin the EXACT captured output (term + f32 cosine) so a hand-edit can't invent a
+  // neighbour or a score. Captured from the real binary 2026-06-19.
+  assert.deepEqual(
+    BOLT.neighbours.map((n) => n.term),
+    [
+      "<http://example.org/bolt2>",
+      "<http://example.org/blake>",
+      "<http://example.org/powell>",
+      "<http://example.org/coubertin>",
+    ],
+  );
+  // bolt2 (shared n-grams) is the nearest; cosine pinned to the engine's exact f32.
+  assert.equal(BOLT.neighbours[0].cosine, 0.8762895);
+  // Cosines are in [-1, 1] and strictly non-increasing (best-first).
+  let prev = Infinity;
+  for (const n of BOLT.neighbours) {
+    assert.ok(n.cosine >= -1.0001 && n.cosine <= 1.0001, `cosine out of range: ${n.cosine}`);
+    assert.ok(n.cosine <= prev, "cosines must be non-increasing (best-first)");
+    prev = n.cosine;
+    // Every neighbour term is a verbatim IRI (<...>), not a bare value.
+    assert.match(n.term, /^<[^>]+>$/, `neighbour is not a verbatim IRI: ${n.term}`);
+  }
+});
+
+// ── The vec: magic-predicate captures ───────────────────────────────────────────────────
+test("the unit-circle store is the dim-2 fixture the captures ran over", () => {
+  assert.equal(UNIT_CIRCLE.length, 5);
+  for (const e of UNIT_CIRCLE) {
+    assert.equal(e.vec.length, 2, `${e.iri}: expected a dim-2 vector`);
+  }
+});
+
+test("every captured vec: query is real SPARQL with the vec: prefix", () => {
+  for (const q of VEC_QUERIES) {
+    assert.match(q.sparql, /PREFIX vec: <http:\/\/sparq\.dev\/vec#>/, `${q.id}: no vec: prefix`);
+    assert.match(q.sparql, /vec:(nearest|search)/, `${q.id}: no vec: predicate`);
+    assert.ok(q.vars.length >= 1, `${q.id}: no projected variables`);
+    // Head rows never exceed what a query of this shape returns; arity lines up.
+    for (const row of q.rows) {
+      assert.equal(row.length, q.vars.length, `${q.id}: row arity != var count`);
+    }
+  }
+});
+
+// ── The honesty-regression guard: term serialization is VERBATIM oxrdf Display. ─────────
+// The sibling page dropped a literal's datatype when a "captured" payload was hand-edited.
+// Pin every result cell to its EXACT N-Triples serialization so a bare/mistyped value can
+// never sneak in: an IRI is `<...>`, a plain literal is `"..."`, a typed literal is
+// `"..."^^<datatype-iri>`.
+test("every vec: result cell is a verbatim IRI or correctly-serialized literal", () => {
+  const IRI = /^<[^>]+>$/;
+  const PLAIN = /^"[^"]*"$/;
+  const TYPED = /^".*"\^\^<[^>]+>$/s;
+  for (const q of VEC_QUERIES) {
+    for (const row of q.rows) {
+      for (const cell of row) {
+        const ok = IRI.test(cell) || PLAIN.test(cell) || TYPED.test(cell);
+        assert.ok(ok, `${q.id}: cell is not a verbatim IRI/plain-literal/typed-literal: ${cell}`);
+      }
+    }
+  }
+});
+
+test("vec:nearest returns the correct verbatim IRIs (pinned)", () => {
+  // "1,0" → the two most +x-aligned: a (exact) then c (near +x).
+  const byVec = vecQueryById("nearest-by-vector");
+  assert.deepEqual(byVec.rows, [["<http://ex/a>"], ["<http://ex/c>"]]);
+  // Neighbours of <a>; a itself excluded → c is nearest.
+  const bySeed = vecQueryById("nearest-by-seed");
+  assert.deepEqual(bySeed.rows, [["<http://ex/c>"]]);
+});
+
+test("BGP-joined labels are PLAIN string literals — verbatim, no invented datatype", () => {
+  // The fabrication shape would coerce or strip these; the real engine emits plain string
+  // literals because that is exactly how `<http://ex/label>` objects are stored.
+  const joined = vecQueryById("nearest-joined");
+  assert.deepEqual(joined.rows, [['"epsilon"'], ['"beta"']]);
+  for (const row of joined.rows) {
+    for (const cell of row) {
+      assert.match(cell, /^"[^"]*"$/, `expected a plain string literal, got: ${cell}`);
+      assert.ok(!cell.includes("^^"), `joined label must NOT carry a datatype: ${cell}`);
+    }
+  }
+});
+
+test("vec:search binds the cosine as a verbatim xsd:double, ordered best-first", () => {
+  const search = vecQueryById("search-score");
+  // The exact captured output: a (1.0) > c (~0.994) > e (~0.200), each an xsd:double.
+  assert.deepEqual(search.rows, [
+    ["<http://ex/a>", '"1"^^<http://www.w3.org/2001/XMLSchema#double>'],
+    ["<http://ex/c>", '"0.9938837289810181"^^<http://www.w3.org/2001/XMLSchema#double>'],
+    ["<http://ex/e>", '"0.19996000826358795"^^<http://www.w3.org/2001/XMLSchema#double>'],
+  ]);
+  // Every score cell carries the xsd:double datatype verbatim (the serialization the
+  // fabrication blurred), and the parsed scores are non-increasing (ORDER BY DESC).
+  const DOUBLE = "^^<http://www.w3.org/2001/XMLSchema#double>";
+  let prev = Infinity;
+  for (const row of search.rows) {
+    const scoreCell = row[1];
+    assert.ok(scoreCell.endsWith(DOUBLE), `score missing xsd:double datatype: ${scoreCell}`);
+    const val = Number.parseFloat(scoreCell.slice(1));
+    assert.ok(val <= prev + 1e-9, "scores must be non-increasing (ORDER BY DESC)");
+    prev = val;
+  }
+});
+
+// ── The illustrative half is honestly labelled. ─────────────────────────────────────────
+test("the recall notes are labelled approximate (< 1.0) and point at a test", () => {
+  assert.ok(RECALL_NOTES.length >= 2);
+  // The exact backend is named as the answer-exact ground truth.
+  assert.ok(
+    RECALL_NOTES.some((r) => /exact/i.test(r.backend) && /recall 1\.0/.test(r.note)),
+    "an exact, answer-exact backend must be listed",
+  );
+  // Approximate backends must NOT be claimed as exact — each says recall < 1.0 / approximate.
+  for (const r of RECALL_NOTES) {
+    if (/exact/i.test(r.backend)) continue;
+    assert.match(
+      r.note,
+      /approximate|< 1\.0/,
+      `approximate backend "${r.backend}" must be labelled approximate`,
+    );
+  }
+});
+
+test("vecQueryById returns undefined for an unknown id", () => {
+  assert.equal(vecQueryById("does-not-exist"), undefined);
+});


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements bead **sq-dwdm** — the `/surface/vector` showcase page for **sparq-vectors** (the opt-in embedding store + ANN crate): memory-mapped `.spqv` store, exact + approximate (HNSW / DiskANN) cosine top-k, predicate-constrained (filtered) ANN, hybrid RRF fusion, and **k-NN inside plain SPARQL** via the `vec:nearest` / `vec:search` magic predicates.

## What the page shows
- **Embed labels, then search by term** — the bead's **Usain Bolt** example: `embed_labels` (deterministic `HashEmbedder`) + `nearest_term_exact`, with the captured neighbour list and exact f32 cosines.
- **k-NN inside SPARQL** — a selector of `vec:nearest` / `vec:search` queries over a tiny unit-circle store, each with its real executed result table.
- **Exact vs approximate** — an honestly-labelled, non-canonical trade-off panel (recall < 1.0; figures are the crate's own test gates, no latency shown).

## Honesty (the sq-rnwc lesson)
A sibling page (sq-rnwc) was caught fabricating "captured" output; the fix on sq-3was added a serialization-pinning test. This page does the same:

- **Genuinely live-captured:** the Bolt neighbour list and every `vec:` result table are produced by a real capture harness — `crates/sparq-vectors/examples/capture_surface_vector.rs`, built with `--features vec-predicate` — running the **real binary** over a tiny declared in-memory fixture with the **answer-exact** backend (no index build, no model, no downloaded data). Pasted **byte-for-byte**: cells are the engine's verbatim `oxrdf::Term::Display` (N-Triples); the `vec:search` cosine carries its `xsd:double` datatype; the BGP-joined labels are plain string literals (no invented datatype). Deterministic — re-running the harness yields byte-identical output.
- **Pinning test:** `site/test/vector.test.mjs` (12 tests) asserts that serialization can't drift, mirroring `site/test/genai.test.mjs`.
- **Honestly illustrative:** `HashEmbedder` is test-only (lexical, **no semantics**) — the captures show the **pipeline + exact geometry**, not retrieval quality. ANN recall figures are the crate's `cargo test` gates — **representative, recall < 1.0, NOT canonical**; no latency figure shown. No ZK/MPC privacy claims (gate N/A).

## Files / routes
- New route `/surface/vector` (`site/src/app/surface/vector/page.tsx`), component `site/src/components/vector-walkthrough.tsx`, data module `site/src/lib/vector.ts`, pinning test `site/test/vector.test.mjs`.
- Registered in `site/src/data/surfaces.ts` (tier-e walkthrough, `built: true`) and the `[slug]` `BUILT_SURFACES` set.
- Capture harness `crates/sparq-vectors/examples/capture_surface_vector.rs` + `Cargo.toml` `required-features = ["vec-predicate"]` (a build artifact; no library/crates source change, no new dependency).

## Gates
- `npm run build` static export green — `/surface/vector` emits (5.83 kB), `/sparq` basePath correct, existing routes intact. WASM prereq (`js && npm run build:wasm`) built for the export.
- `npm run lint` clean · `tsc --noEmit` clean · `npm run test:unit` **94/94** (incl. the 12 new pinning tests).
- `lychee --offline` 0 errors · `typos` clean · typos-gate banned words absent.
- Capture example: `clippy -D warnings` clean with the feature; default `--all-targets` build skips it (no `main` E0601).

Do not enable auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)