### PR TITLE
docs(engine): honest serialise-determinism docs + ORDER-BY-tie clarification (sq-b83e, sq-8qzz, sq-8m65)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,33 @@ spec-justified* reason, record the rationale in the report alongside the diverge
 (don't just drop the count). Raising a floor when coverage genuinely improves is
 encouraged.
 
+<!-- [OPUS-4.8] sq-8qzz: contributor note guarding new golden/snapshot tests against the
+     thread-count-dependent dict-id order. No current test is at risk (the audit verified
+     this) — this is a forward-looking convention, not a fix for a present bug. -->
+### A golden over serialised RDF or an unordered/tied result must canonicalise or pin threads
+
+`sparq-core` assigns dictionary ids in a **thread-count-dependent** order (the parallel
+sharded dict merge, `default_shards = (rayon::current_num_threads()*2).clamp(4,64)`), and
+that id order surfaces — spec-permittedly — in several **observable but unspecified** places:
+RDF serialisation row order (Turtle / TriG / N-Quads / N-Triples / JSON-LD), `SELECT` row
+order without `ORDER BY`, `CONSTRUCT` / `DESCRIBE` triple order, and `ORDER BY`-tie order.
+None is a correctness bug (the SPARQL / RDF specs leave all of them unspecified), and no
+golden/snapshot file in the repo pins any of them today — the conformance harness compares
+unordered results as a **bag (multiset)** and existing snapshot/differential tests sort the
+rendered rows by term before asserting.
+
+So if you add a test that pins one of those outputs **as an exact string / file**, make it
+robust to thread count one of two ways, or it will be host-flaky exactly like the #691
+`label_propagation` test was:
+
+- **Canonicalise** — sort the rendered rows (or compare as a set/multiset of term strings)
+  before asserting. This is the default; it matches every existing test.
+- **Pin threads** — set `RAYON_NUM_THREADS=1` for that test if you genuinely must assert an
+  exact byte sequence (rare; prefer canonicalising). CI does not pin threads on the
+  conformance / bulk shards, and nextest runs shards on differently-sized runners.
+
+Background and the full per-surface analysis: `research/dict-id-order-determinism-audit.md`.
+
 ### Every `unsafe` block needs a `// SAFETY:` comment and a register row
 
 `sparq`'s `unsafe` is confined to five crates (mmap loaders, the zero-copy dictionary,

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -5851,6 +5851,17 @@ fn order_bindings(graph: &Graph, local: &LocalVocab, b: &mut Bindings, exprs: &[
         }
         Ordering::Equal
     };
+    // ORDER BY tie handling [OPUS-4.8]: `cmp` returns `Ordering::Equal` only for rows that
+    // tie on *every* ORDER BY key (no secondary tie-breaker), and SPARQL leaves the relative
+    // order of ORDER BY-tied solutions unspecified, so any tie order is conformant. We still
+    // keep it *deterministic at a fixed thread count*: both branches use a STABLE sort
+    // (`rayon::par_sort_by` is a stable parallel merge sort, same guarantee as `slice::sort_by`),
+    // so ties retain their `b.rows` (scan) input order rather than being shuffled by the
+    // parallel partitioning. The only residual cross-thread-count variation is that `b.rows`
+    // itself is in dict-id (scan) order, which is thread-count-dependent — that is the
+    // umbrella dict-id-order property (research/dict-id-order-determinism-audit.md), not a
+    // tie-break defect in this sort. So no total-order tie-breaker is added: it would cost a
+    // term materialisation per tied row for an order the spec does not constrain.
     #[cfg(feature = "parallel")]
     if keyed.len() >= PAR_THRESHOLD {
         use rayon::prelude::*;

--- a/crates/sparq-engine/src/serialize.rs
+++ b/crates/sparq-engine/src/serialize.rs
@@ -221,9 +221,17 @@ fn write_subject(subj: &NamedOrBlankNode, prefixes: &Prefixes, out: &mut String)
 
 /// Serializes a set of triples as Turtle: a `@prefix` header for every prefix actually
 /// used, then grouped predicate-object lists per subject (`s p1 o1, o2 ; p2 o3 .`), with
-/// `a` standing in for `rdf:type`. Output is deterministic (subjects in first-seen order,
-/// predicates grouped, objects in input order). Only the prefixes that are used appear in
-/// the header.
+/// `a` standing in for `rdf:type`. Only the prefixes that are used appear in the header.
+///
+/// Row order is a faithful, deterministic function *of the input slice*: subjects in
+/// first-seen order, predicates grouped, objects in input order. It is **not** canonicalised
+/// — the writer applies no sort. So when the input slice's own order is unspecified, the
+/// output order is too: the [`graph_to_turtle`] family feeds the store's `iter_ids()`
+/// (dict-id / SPO-index) order, which is thread-count-dependent (`sparq-core`'s parallel
+/// sharded dict merge), so a serialised graph dump can differ across thread counts. That is
+/// spec-permitted (Turtle defines no canonical triple order) and not pinned anywhere
+/// canonical today; see `research/dict-id-order-determinism-audit.md`. A golden over a
+/// serialised graph must canonicalise (sort the rendered rows) or pin `RAYON_NUM_THREADS`.
 pub fn write_turtle(triples: &[Triple], prefixes: &Prefixes) -> String {
     let mut out = String::new();
     write_prefix_header(triples, prefixes, &mut out);
@@ -447,7 +455,11 @@ pub fn write_nquads(graphs: &[NamedGraph<'_>]) -> String {
 // Graph -> bytes convenience wrappers (pull triples out of a live Graph).
 // ---------------------------------------------------------------------------
 
-/// Materializes the default graph's triples in stable store order.
+/// Materializes the default graph's triples in store order: `iter_ids()` walks the SPO
+/// permutation index, i.e. dict-id order. That is stable *for a fixed build/thread count*
+/// but thread-count-dependent across builds (`sparq-core`'s sharded dict merge), so the
+/// downstream writers do not produce a canonical row order — see the [`write_turtle`] doc
+/// and `research/dict-id-order-determinism-audit.md`.
 fn graph_triples(graph: &Graph) -> Vec<Triple> {
     graph
         .iter_ids()
@@ -1057,7 +1069,11 @@ fn write_context(all: &[Triple], prefixes: &Prefixes, out: &mut String) {
 ///   dataset shape), wrapped under `@context` for the compacted form.
 ///
 /// `prefixes` is consulted only for [`JsonLdForm::Compacted`]; the expanded/flattened forms
-/// always emit full IRIs. Output is deterministic (subjects and predicates in first-seen order).
+/// always emit full IRIs. Node and predicate order is a faithful function of the input
+/// slice (subjects and predicates in first-seen order) with no canonicalising sort, so —
+/// as with [`write_turtle`] — the [`graph_to_jsonld`] family inherits the store's
+/// thread-count-dependent row order. JSON-LD specifies no canonical node order; see
+/// `research/dict-id-order-determinism-audit.md`.
 pub fn write_jsonld(graphs: &[NamedGraph<'_>], form: JsonLdForm, prefixes: &Prefixes) -> String {
     let pfx = (form == JsonLdForm::Compacted).then_some(prefixes);
     let mut out = String::new();

--- a/research/dict-id-order-determinism-audit.md
+++ b/research/dict-id-order-determinism-audit.md
@@ -141,7 +141,7 @@ rows faithfully in engine order and add no sort. `GROUP BY` output and `CONSTRUC
 `DESCRIBE` triple order inherit the same scan order transitively. Spec-permitted; not
 pinned canonically.
 
-### ORDER BY tie order — OBSERVABLE (unspecified), with a separate parallel-sort note
+### ORDER BY tie order — OBSERVABLE (unspecified), inherits the dict-id order only
 
 `crates/sparq-engine/src/exec.rs::order_bindings`. The comparator returns
 `Ordering::Equal` for rows that tie on all `ORDER BY` keys (no secondary tie-breaker).
@@ -149,14 +149,21 @@ The serial path uses `sort_by` (a **stable** sort), so ties keep their *input* o
 which is the dict-id-dependent scan order, hence thread-count-dependent. SPARQL leaves the
 relative order of `ORDER BY`-tied solutions unspecified, so this is conformant.
 
-Note (orthogonal, pre-existing): the large-result parallel path uses `par_sort_by`
-(`exec.rs`), which is **not stable**, so for `>= PAR_THRESHOLD` rows the tie order is
-non-deterministic *even at a fixed thread count*. This is a separate determinism wrinkle
-that does not originate from dict-ids; flagged here only because it shares the
-"unspecified-order surface" with the dict-id question. A W3C `ORDER BY` test is normally
-authored so the order is fully determined (no ambiguous ties), so this rarely bites
-conformance — but a future internal golden test over a *tied* `ORDER BY` result would be
-host-flaky.
+**Correction (sq-8m65 follow-up, [OPUS-4.8]):** an earlier revision of this note claimed the
+large-result parallel path uses a *non-stable* sort (`par_sort_by`), making tie order
+non-deterministic *even at a fixed thread count*, as a separate cause from dict-ids. **That
+is wrong.** `keyed.par_sort_by(cmp)` (`exec.rs`) is rayon's **stable** parallel sort —
+rayon's `par_sort_by` is documented as "stable (i.e., does not reorder equal elements)",
+an adaptive parallel merge sort; the *unstable* rayon entry point is `par_sort_unstable_by`,
+which this path does **not** use (it has used `par_sort_by` since the parallel-ORDER-BY
+commit `1ebbf32a`). So the parallel path preserves the `b.rows` input order of tied rows
+exactly like the serial `sort_by`. At a **fixed thread count** the tie order is therefore
+fully deterministic; the only residual variation is that `b.rows` is itself in dict-id /
+scan order, which is thread-count-dependent — i.e. the *same* umbrella dict-id-order
+property as the other surfaces above, **not** a separate parallel-sort defect. There is no
+fixed-thread-count non-determinism to fix here. A future internal golden over a *tied*
+`ORDER BY` result is still host-flaky for the dict-id reason (covered by the
+golden-determinism contributor note), not because of an unstable sort.
 
 ### Vector-store graph fingerprint — WATCH (real robustness sharp edge, fails closed)
 
@@ -222,15 +229,21 @@ but it is worth a fix so the same graph fingerprints identically at any thread c
    identical `content_hash`, plus a test that a real dict shift (added/removed term) still
    changes it. Decide the lexical-fold-cost vs. commutative-collision trade-off with the
    maintainer. (WATCH item above.)
-2. **Bead — golden/snapshot determinism guard.** Add a lightweight test-helper +
-   contributor note (and, if cheap, a CI lint) so that any test pinning serialised RDF or an
-   unordered/tied result either sorts by term first or sets `RAYON_NUM_THREADS`. Codifies the
-   discipline that prevents a #691-style host-flaky golden from being introduced.
-3. **Bead (optional, separate cause) — stabilise large-result `ORDER BY` tie order.**
-   Make the parallel `ORDER BY` path's tie order deterministic at a fixed thread count
-   (stable parallel sort, or a deterministic secondary tie-break key), independent of the
-   dict-id question. Spec-optional, but removes a real intra-host non-determinism on
-   `>= PAR_THRESHOLD` tied results.
+2. **Bead — golden/snapshot determinism guard** (sq-8qzz). **RESOLVED ([OPUS-4.8])** as the
+   contributor-note option: `CONTRIBUTING.md` now carries "A golden over serialised RDF or an
+   unordered/tied result must canonicalise or pin threads", codifying the discipline. No
+   heavy harness/CI-lint was built — the audit verified no current test is at risk, so a
+   forward-looking convention is the honest minimum.
+3. **Bead (separate cause?) — stabilise large-result `ORDER BY` tie order** (sq-8m65).
+   **CLOSED as not-an-issue ([OPUS-4.8]):** the premise was a misreading — `par_sort_by` is
+   already rayon's **stable** sort (see the corrected ORDER-BY-tie section above), so the
+   parallel path's tie order is *already* deterministic at a fixed thread count. There is no
+   separate intra-host non-determinism to remove; adding a total-order tie-breaker would cost
+   a term materialisation per tied row for an order SPARQL leaves unspecified. The sort site
+   now carries a comment recording this.
+
+(Phased item 1 — the `sparq-vectors` fingerprint fix — tracks as sq-xhiv (P2), handled
+separately from this determinism-follow-up batch.)
 4. **Bead (optional, hygiene) — fix the misleading `write_turtle` doc-comment.** Reword
    "Output is deterministic …" to scope the claim to the function's input slice and note that
    `graph_*` serialisers inherit the store's (thread-count-dependent) row order; cross-reference


### PR DESCRIPTION
> 🤖 SPARQ agent

Resolves the three dict-id-order determinism follow-ups surfaced by audit sq-xom2 (`research/dict-id-order-determinism-audit.md`, merged #710). Doc + comment only — no behaviour change.

## sq-b83e (P4) — IMPLEMENTED (doc-only honesty fix)
`crates/sparq-engine/src/serialize.rs`: `write_turtle` and `write_jsonld` said *"Output is deterministic"*. That is true as a pure function of the input slice, but misleading through the `graph_to_*` wrappers, because the input slice is `iter_ids()` = SPO-index = **dict-id order**, which is thread-count-dependent (`sparq-core`'s parallel sharded dict merge). The claim is now scoped to the input slice, with a note that the `graph_*` serialisers inherit the store's thread-count-dependent row order and a cross-reference to the audit. The `graph_triples` *"stable store order"* helper doc is likewise corrected.

## sq-8qzz (P3) — IMPLEMENTED (contributor note, option (a) — the honest minimum)
`CONTRIBUTING.md` gains *"A golden over serialised RDF or an unordered/tied result must canonicalise or pin threads."* The audit verified **no current** golden/snapshot test pins a serialised graph or an unordered/tied result, so this is a forward-looking convention, **not** a harness for a non-existent problem. No CI lint was built.

## sq-8m65 (P3) — CLOSED as not-an-issue (premise was factually wrong)
The bead/audit claimed the parallel `par_sort_by` path is **non-stable**, making `ORDER BY` ties non-deterministic *even at a fixed thread count*, as a separate cause from dict-ids. **That is wrong:** rayon's `par_sort_by` IS a **stable** parallel merge sort (rustdoc: *"This sort is stable (i.e., does not reorder equal elements)"*); the unstable entry point is `par_sort_unstable_by`, which `order_bindings` does **not** use and never has (`par_sort_by` since commit `1ebbf32a`). So the parallel path preserves tied rows' `b.rows` input order exactly like the serial `sort_by` — tie order is already deterministic at a fixed thread count, and the only cross-thread variation is the dict-id order of `b.rows` itself (the umbrella property, covered by sq-8qzz/sq-b83e). A code comment now records this at the sort site, and the audit's now-known-false note is corrected. **No total-order tie-breaker was added** — it would cost a term materialisation per tied row for an order SPARQL leaves unspecified, with no real-world benefit. The bead is closed with this evidence.

## Gates
- `cargo clippy -p sparq-engine --all-targets -- -D warnings` — GREEN in **both** feature states: default (feature OFF) **and** `--features parallel` (the gate that compiles the annotated `par_sort_by` path).
- `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p sparq-engine` — clean (new intra-doc links resolve).
- `markdownlint-cli2` — 0 errors; `scripts/check-privacy-claims.sh` — clean; `typos` introduces no new markdown hit.

Auto-merge intentionally **not** enabled.