### PR TITLE
feat(site): /surface/geosparql tier-e captured geof: + R-tree GeoIndex + map (sq-ndaz) [OPUS-4.8]

### DIFF
--- a/site/src/app/surface/[slug]/page.tsx
+++ b/site/src/app/surface/[slug]/page.tsx
@@ -21,6 +21,7 @@ const BUILT_SURFACES = new Set([
   "http-server",
   "genai",
   "vector",
+  "geosparql",
 ]);
 const PLACEHOLDER_SURFACES = ALL_SURFACES.filter(
   (s) =>

--- a/site/src/app/surface/geosparql/page.tsx
+++ b/site/src/app/surface/geosparql/page.tsx
@@ -1,0 +1,166 @@
+import type { Metadata } from "next";
+import { MapPin } from "lucide-react";
+
+import { SurfaceContent } from "@/components/surface-content";
+import { GeosparqlWalkthrough } from "@/components/geosparql-walkthrough";
+
+export const metadata: Metadata = {
+  title: "GeoSPARQL",
+  description:
+    "sparq-geo — an opt-in GeoSPARQL 1.0/1.1 core: WKT / GML geometry literals, the OGC geof: spatial functions (distance, the sf*/eh*/rcc8* DE-9IM relation families, envelope / buffer / set ops) inside plain SPARQL, the topology-property query-rewrite extension, and an R-tree GeoIndex for nearest / radius / intersects queries. This page replays REAL captured engine output — the London–Paris distance < 400 km query, the within-polygon spatial join, and the GeoIndex metres — byte-for-byte.",
+};
+
+export default function GeosparqlSurfacePage() {
+  return (
+    <SurfaceContent
+      icon={MapPin}
+      title="GeoSPARQL"
+      statement="WKT / GML geometry literals, the OGC geof: spatial functions and the sf*/eh*/rcc8* topology relations inside plain SPARQL, a topology-property query rewrite, and an R-tree GeoIndex for nearest / radius / intersects queries."
+      tier="walkthrough"
+      extraBadge="Opt-in crate · captured output"
+      intro={
+        <>
+          <p>
+            <code className="font-mono text-foreground">sparq-geo</code> is the opt-in
+            GeoSPARQL 1.0/1.1 <strong className="text-foreground">core</strong> for the engine.
+            It parses <code className="font-mono">geo:wktLiteral</code> and{" "}
+            <code className="font-mono">geo:gmlLiteral</code> (the GML Simple-Features profile)
+            geometries, evaluates the OGC <code className="font-mono">geof:</code> spatial
+            functions, packages them as a{" "}
+            <code className="font-mono">sparq_engine::FunctionRegistry</code> so they run inside
+            real SPARQL <code className="font-mono">FILTER</code> /{" "}
+            <code className="font-mono">BIND</code> / <code className="font-mono">SELECT</code>,
+            and builds an <strong className="text-foreground">R-tree GeoIndex</strong> over a
+            graph for distance / nearest / intersection queries.
+          </p>
+          <p>
+            The function surface covers <strong className="text-foreground">distance</strong>{" "}
+            (metric or angular units), the three DE-9IM{" "}
+            <strong className="text-foreground">topology-relation families</strong> —{" "}
+            <code className="font-mono">sf*</code> (Simple Features),{" "}
+            <code className="font-mono">eh*</code> (Egenhofer),{" "}
+            <code className="font-mono">rcc8*</code> (RCC8) — plus a generic 9-character DE-9IM{" "}
+            <code className="font-mono">relate</code>, the geometry-producing functions (
+            <code className="font-mono">envelope</code> / <code className="font-mono">boundary</code>{" "}
+            / <code className="font-mono">convexHull</code> / <code className="font-mono">buffer</code>),
+            and the four set operations (
+            <code className="font-mono">intersection</code> / <code className="font-mono">union</code>{" "}
+            / <code className="font-mono">difference</code> /{" "}
+            <code className="font-mono">symDifference</code>). The RDF-native extra is the{" "}
+            <strong className="text-foreground">topology-property query rewrite</strong>: write a
+            relation as a triple (<code className="font-mono">?a geo:sfWithin ?b</code>) and an
+            opt-in entry point expands it into the geometry-resolution joins plus the matching{" "}
+            <code className="font-mono">geof:</code> FILTER — the engine and wasm bundle are
+            unchanged.
+          </p>
+          <p>
+            It is a <strong className="text-foreground">separate, opt-in crate</strong> so the
+            core engine and the lean wasm bundle carry{" "}
+            <strong className="text-foreground">zero geometry code</strong>; the server exposes
+            it only behind its non-default <code className="font-mono">geo</code> cargo feature.
+            This static Pages site has no backend and the crate is native-only, so &mdash;
+            honestly &mdash; this is a{" "}
+            <strong className="text-foreground">captured-output walkthrough</strong>: the
+            London–Paris distance &lt; 400 km query, the within-polygon spatial join, the{" "}
+            <code className="font-mono">geof:buffer</code> chain, the topology-property rewrite,
+            and the R-tree <code className="font-mono">nearest</code> /{" "}
+            <code className="font-mono">within_distance</code> /{" "}
+            <code className="font-mono">intersects</code> metres are{" "}
+            <em>real, verbatim engine output</em> &mdash; produced by running the real binary
+            over tiny declared fixtures (the same ones the crate&rsquo;s tests use). The small
+            map is a legibility aid drawn from the verbatim WKT coordinates, not captured output.
+          </p>
+        </>
+      }
+      capabilities={[
+        {
+          title: "WKT + GML geometry literals",
+          body: "Parses geo:wktLiteral and geo:gmlLiteral (GML Simple-Features: Point / LineString / Polygon with rings / Multi*), an optional leading CRS IRI, EPSG:4326 axis-swap, and the OGC R9 geo: metadata properties (dimension / isEmpty / isSimple / …).",
+        },
+        {
+          title: "geof: inside plain SPARQL",
+          body: "geof_registry() packages the functions as a sparq-engine FunctionRegistry, so distance / the relation families / envelope / buffer / set ops run inside real FILTER / BIND / SELECT expressions — and chain (geof:buffer feeds straight into geof:sfWithin).",
+        },
+        {
+          title: "Three DE-9IM relation families",
+          body: "sf* (Simple Features), eh* (Egenhofer) and rcc8* (RCC8) topology predicates, plus a generic 9-char DE-9IM relate(). Relations are planar (coordinate-space), not geodesic.",
+        },
+        {
+          title: "Topology-property query rewrite",
+          body: "geosparql_rewrite expands ?a geo:sfWithin ?b triple patterns into (hasDefaultGeometry|hasGeometry)/asWKT resolution joins + the matching geof: FILTER — opt-in, so W3C conformance of the default entry points is unaffected.",
+        },
+        {
+          title: "R-tree GeoIndex (nearest / radius / intersects)",
+          body: "GeoIndex::build scans geo:asWKT / geo:asGML into an rstar R-tree; nearest (k-NN), within_distance (radius) and intersects answer great-circle metre queries, with incremental apply_delta to stay in sync with graph updates.",
+        },
+        {
+          title: "Opt-in everywhere",
+          body: "A separate crate (the core engine + lean wasm carry no geometry code); the server installs geof: only behind its non-default `geo` feature; the `reproject` module (a small curated EPSG table → CRS84) is itself opt-in.",
+        },
+      ]}
+      runsNote={
+        <>
+          <p>
+            <strong className="text-foreground">Captured-output replay.</strong> Every{" "}
+            <code className="font-mono">geof:</code> result table and every R-tree{" "}
+            <code className="font-mono">GeoIndex</code> metre on this page is the verbatim output
+            of the real <code className="font-mono">sparq-geo</code> binary (built with{" "}
+            <code className="font-mono">--features engine</code>) over tiny declared in-memory
+            Turtle fixtures — the <em>same</em> fixtures the crate&rsquo;s own committed tests
+            assert against (<code className="font-mono">tests/registry_sparql.rs</code> /{" "}
+            <code className="font-mono">tests/e2e.rs</code> /{" "}
+            <code className="font-mono">tests/query_rewrite.rs</code>), which corroborate the
+            spatial-join order, the ≈ 343.6 km London–Paris distance and the rewrite / index
+            matches. Everything is deterministic (a fixed fixture, planar DE-9IM, haversine
+            distance), so a re-run yields byte-identical output; a pinning test (
+            <code className="font-mono">site/test/geosparql.test.mjs</code>) asserts the
+            serialization can&rsquo;t drift (datatypes intact, metres pinned). Reproduce the
+            corroborating run yourself:
+          </p>
+          <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12px] leading-relaxed">
+            {`cargo test -p sparq-geo --features engine`}
+          </pre>
+        </>
+      }
+      caveat={
+        <>
+          <p>
+            <strong className="text-foreground">The map is a legibility aid.</strong> The dots
+            and rings are the verbatim WKT longitude/latitude from the fixtures (so they are the
+            real geometry), but the projection and the abstract background are{" "}
+            <em>illustrative chrome</em>, not captured output. No latency or throughput number is
+            shown (hardware-dependent, non-canonical).
+          </p>
+          <p>
+            <strong className="text-foreground">Metric distance is locally exact.</strong>{" "}
+            <code className="font-mono">geof:distance</code> with metric units is exact haversine
+            when an operand is a point, but a{" "}
+            <strong className="text-foreground">local equirectangular approximation</strong>{" "}
+            between two extended geometries (same for <code className="font-mono">geof:buffer</code>{" "}
+            in metres) — accurate locally, distorted at continental scale or near the poles.
+            Topology relations are <strong className="text-foreground">planar</strong> DE-9IM in
+            coordinate space, not geodesic. This is the GeoSPARQL{" "}
+            <em>core</em>: there is no RIF / <code className="font-mono">geor:</code> rule
+            rewriting, and a handful of GML cases (<code className="font-mono">gml:Envelope</code>,
+            arc segments, 3-D) are a clean <code className="font-mono">Unsupported</code> error —
+            see the crate&rsquo;s open beads for the exact boundary.
+          </p>
+        </>
+      }
+      links={[
+        {
+          href: "https://github.com/jeswr/sparq/tree/main/crates/sparq-geo",
+          label: "sparq-geo crate",
+          external: true,
+        },
+        {
+          href: "https://github.com/jeswr/sparq/blob/main/skills/geosparql/SKILL.md",
+          label: "geosparql SKILL.md",
+          external: true,
+        },
+      ]}
+    >
+      <GeosparqlWalkthrough />
+    </SurfaceContent>
+  );
+}

--- a/site/src/components/geosparql-walkthrough.tsx
+++ b/site/src/components/geosparql-walkthrough.tsx
@@ -1,0 +1,498 @@
+"use client";
+
+// [OPUS-4.8] sq-ndaz — the /surface/geosparql (GeoSPARQL) showcase (tier-e). sparq-geo is
+// an OPT-IN native crate (the engine's lean wasm bundle carries ZERO geometry code, and
+// sparq-server exposes geof: only behind its non-default `geo` cargo feature), and the
+// static Pages site has no backend — so, per the feature-showcase design's honest tier-e
+// fallback, this REPLAYS captured output rather than running geof: live:
+//
+//   1. geof: SPARQL — pick a query (geof:distance < 400 km, the geof:sfWithin spatial
+//      join, the geof:buffer chain, or the topology-PROPERTY-form geosparql_rewrite) and
+//      see the REAL executed result table (verbatim oxrdf::Term serialization).
+//   2. R-tree GeoIndex — nearest / within_distance / intersects metres, captured verbatim.
+//   3. A small dependency-free SVG map draws the fixture geometry (the dots ARE the real
+//      WKT lon/lat) so the spatial relations are legible — no Leaflet/MapLibre dep.
+//
+// HONESTY (see src/lib/geosparql.ts): the result rows / distances are REAL captured engine
+// output (answer-exact, verbatim oxrdf serialization; pinned by site/test/geosparql.test.mjs
+// so they cannot drift). The map projection + chrome are an illustrative legibility aid. The
+// metric-distance caveat (haversine for points, local equirectangular for two extended
+// geometries) is real. All data lives in src/lib/geosparql.ts (framework-free, unit-tested).
+
+import * as React from "react";
+import {
+  Database,
+  Globe2,
+  MapPin,
+  Play,
+  Ruler,
+  Search,
+  Shapes,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  CITIES,
+  FEATURES,
+  GEO_QUERIES,
+  INDEX_BUILD,
+  INDEX_CENTER,
+  INDEX_RUNS,
+  RELATION_FAMILIES,
+  type GeoQuery,
+  type IndexRun,
+  type MapFeature,
+  shortIri,
+} from "@/lib/geosparql";
+
+// ── A tiny dependency-free SVG map (no Leaflet/MapLibre dep) ─────────────────────────────
+// An equirectangular projection over the fixture's bounding box: the dots/rings ARE the
+// real WKT lon/lat, so the spatial relations are faithful; the projection + abstract
+// background are an illustrative legibility aid (labelled as such on the page).
+
+const MAP_W = 360;
+const MAP_H = 300;
+const PAD = 22;
+
+function bounds(features: MapFeature[]) {
+  let minLon = Infinity,
+    maxLon = -Infinity,
+    minLat = Infinity,
+    maxLat = -Infinity;
+  for (const f of features) {
+    for (const [lon, lat] of f.coords) {
+      minLon = Math.min(minLon, lon);
+      maxLon = Math.max(maxLon, lon);
+      minLat = Math.min(minLat, lat);
+      maxLat = Math.max(maxLat, lat);
+    }
+  }
+  // Avoid a degenerate span.
+  if (maxLon - minLon < 1e-6) {
+    minLon -= 0.5;
+    maxLon += 0.5;
+  }
+  if (maxLat - minLat < 1e-6) {
+    minLat -= 0.5;
+    maxLat += 0.5;
+  }
+  return { minLon, maxLon, minLat, maxLat };
+}
+
+function makeProject(features: MapFeature[]) {
+  const { minLon, maxLon, minLat, maxLat } = bounds(features);
+  const sx = (MAP_W - 2 * PAD) / (maxLon - minLon);
+  const sy = (MAP_H - 2 * PAD) / (maxLat - minLat);
+  const s = Math.min(sx, sy); // keep aspect ratio
+  return (lon: number, lat: number): [number, number] => {
+    const x = PAD + (lon - minLon) * s;
+    const y = MAP_H - PAD - (lat - minLat) * s; // lat increases upward
+    return [x, y];
+  };
+}
+
+function FixtureMap({
+  features,
+  highlight,
+}: {
+  features: MapFeature[];
+  highlight: Set<string>;
+}) {
+  const project = React.useMemo(() => makeProject(features), [features]);
+  return (
+    <svg
+      viewBox={`0 0 ${MAP_W} ${MAP_H}`}
+      className="w-full rounded-lg border bg-muted/30"
+      role="img"
+      aria-label="Map of the fixture geometry — points and polygons at their verbatim WKT longitude/latitude."
+    >
+      {/* subtle grid background (illustrative chrome, not data) */}
+      {[0.25, 0.5, 0.75].map((t) => (
+        <React.Fragment key={t}>
+          <line
+            x1={PAD + t * (MAP_W - 2 * PAD)}
+            y1={PAD}
+            x2={PAD + t * (MAP_W - 2 * PAD)}
+            y2={MAP_H - PAD}
+            className="stroke-foreground/5"
+            strokeWidth={1}
+          />
+          <line
+            x1={PAD}
+            y1={PAD + t * (MAP_H - 2 * PAD)}
+            x2={MAP_W - PAD}
+            y2={PAD + t * (MAP_H - 2 * PAD)}
+            className="stroke-foreground/5"
+            strokeWidth={1}
+          />
+        </React.Fragment>
+      ))}
+      {/* polygons first (under the points) */}
+      {features
+        .filter((f) => f.kind === "polygon")
+        .map((f) => {
+          const on = highlight.has(f.id);
+          const pts = f.coords.map(([lon, lat]) => project(lon, lat).join(",")).join(" ");
+          return (
+            <polygon
+              key={f.id}
+              points={pts}
+              className={cn(
+                on ? "fill-primary/15 stroke-primary/70" : "fill-foreground/5 stroke-foreground/25",
+              )}
+              strokeWidth={1.5}
+            />
+          );
+        })}
+      {/* points */}
+      {features
+        .filter((f) => f.kind === "point")
+        .map((f) => {
+          const [x, y] = project(f.coords[0][0], f.coords[0][1]);
+          const on = highlight.has(f.id);
+          return (
+            <g key={f.id}>
+              <circle
+                cx={x}
+                cy={y}
+                r={on ? 6 : 4.5}
+                className={cn(on ? "fill-primary stroke-background" : "fill-foreground/40 stroke-background")}
+                strokeWidth={1.5}
+              />
+              <text
+                x={x + 8}
+                y={y + 4}
+                className={cn(
+                  "text-[10px]",
+                  on ? "fill-primary font-semibold" : "fill-muted-foreground",
+                )}
+              >
+                {f.label}
+              </text>
+            </g>
+          );
+        })}
+    </svg>
+  );
+}
+
+// ── result tables ────────────────────────────────────────────────────────────────────────
+
+function ResultTable({ q }: { q: GeoQuery }) {
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <table className="w-full border-collapse font-mono text-[12px]">
+        <thead>
+          <tr className="border-b bg-muted/60">
+            {q.vars.map((v) => (
+              <th key={v} className="px-3 py-1.5 text-left font-semibold">
+                ?{v}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {q.rows.map((row, i) => (
+            <tr key={i} className="border-b last:border-0">
+              {row.map((cell, j) => (
+                <td key={j} className="px-3 py-1.5 align-top break-all">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/** Which fixture features a given query "lights up" on the map. */
+function highlightForQuery(q: GeoQuery): Set<string> {
+  const ids = new Set<string>();
+  for (const row of q.rows) {
+    for (const cell of row) {
+      const id = shortIri(cell);
+      if (CITIES.some((f) => f.id === id)) ids.add(id);
+    }
+  }
+  // Always show London as the anchor for the city-fixture queries.
+  if (!q.rewrite) ids.add("london");
+  return ids;
+}
+
+function highlightForIndex(run: IndexRun): Set<string> {
+  const ids = new Set<string>(run.hits.map((h) => shortIri(h.term)));
+  return ids;
+}
+
+export function GeosparqlWalkthrough() {
+  const [qSel, setQSel] = React.useState(0);
+  const [ran, setRan] = React.useState(false);
+  const [iSel, setISel] = React.useState(0);
+  const q = GEO_QUERIES[qSel];
+  const run = INDEX_RUNS[iSel];
+
+  function pickQuery(i: number) {
+    setQSel(i);
+    setRan(false);
+  }
+
+  // The rewrite query uses the FEATURES fixture; the rest use CITIES.
+  const queryFeatures = q.rewrite ? FEATURES : CITIES;
+  const queryHighlight = ran ? highlightForQuery(q) : new Set<string>();
+
+  return (
+    <div className="space-y-10">
+      {/* ── 1. geof: inside SPARQL ──────────────────────────────────────────────────── */}
+      <section className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Ruler className="size-5 text-primary" aria-hidden="true" />
+          <h2 className="text-xl font-semibold">geof: spatial functions in SPARQL</h2>
+          <Badge variant="success" className="text-[10px] uppercase">
+            real captured output
+          </Badge>
+        </div>
+        <p className="measure text-sm text-muted-foreground">
+          With <code className="font-mono">sparq-geo</code>, the OGC{" "}
+          <code className="font-mono">geof:</code> functions run inside plain SPARQL{" "}
+          <code className="font-mono">FILTER</code> / <code className="font-mono">BIND</code> /{" "}
+          <code className="font-mono">SELECT</code> — distance, the DE-9IM relation families,
+          and the geometry-producing functions (
+          <code className="font-mono">envelope</code> / <code className="font-mono">buffer</code>{" "}
+          /&hellip;) that feed straight back into another <code className="font-mono">geof:</code>{" "}
+          call. The bead&rsquo;s example — cities within{" "}
+          <strong className="text-foreground">400 km of London</strong> — is the first chip.
+          The last chip is the opt-in{" "}
+          <strong className="text-foreground">topology PROPERTY form</strong>: write the
+          relation as a triple (<code className="font-mono">?f geo:sfWithin ?region</code>) and
+          the <code className="font-mono">geosparql_rewrite</code> extension resolves each
+          feature&rsquo;s geometry and applies the matching{" "}
+          <code className="font-mono">geof:</code> — with no asserted topology triple anywhere.
+        </p>
+
+        {/* Query chips. */}
+        <div className="flex flex-wrap gap-2">
+          {GEO_QUERIES.map((item, i) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => pickQuery(i)}
+              className={cn(
+                "rounded-full px-3 py-1.5 text-left text-[12.5px] ring-1 transition-colors",
+                i === qSel
+                  ? "bg-primary/10 text-primary ring-primary/30"
+                  : "bg-muted/40 text-muted-foreground ring-foreground/10 hover:bg-muted",
+              )}
+            >
+              {item.caption}
+            </button>
+          ))}
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          {/* The map. */}
+          <Card>
+            <CardHeader className="flex-row items-center gap-2 space-y-0">
+              <Globe2 className="size-4 text-primary" aria-hidden="true" />
+              <CardTitle className="text-sm">
+                Fixture geometry {q.rewrite ? "(inner-London box + points)" : "(EU cities + boxes)"}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <FixtureMap features={queryFeatures} highlight={queryHighlight} />
+              <p className="text-xs text-muted-foreground">
+                The dots and rings are the verbatim WKT longitude/latitude from the fixture; the
+                projection and background are an illustrative legibility aid (not captured
+                output).{ran ? " Highlighted: the rows the query returned." : ""}
+              </p>
+            </CardContent>
+          </Card>
+
+          {/* The query + result. */}
+          <Card>
+            <CardHeader className="space-y-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <CardTitle className="text-base">{q.caption}</CardTitle>
+                <Button size="sm" onClick={() => setRan(true)} disabled={ran}>
+                  <Play className="size-4" aria-hidden="true" />
+                  {ran ? "Executed" : "Run"}
+                </Button>
+              </div>
+              {q.rewrite && (
+                <Badge variant="muted" className="w-fit text-[10px] uppercase">
+                  opt-in geosparql_rewrite
+                </Badge>
+              )}
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12px] leading-relaxed">
+                {q.sparql}
+              </pre>
+              {ran && (
+                <div className="space-y-1.5">
+                  <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                    <Database className="size-3.5" aria-hidden="true" />
+                    result
+                    <Badge variant="success" className="text-[10px] uppercase">
+                      real engine output
+                    </Badge>
+                  </div>
+                  <ResultTable q={q} />
+                  <p className="text-xs text-muted-foreground">
+                    {q.rows.length} row{q.rows.length === 1 ? "" : "s"}, executed by the sparq
+                    engine over the declared fixture — term serialization verbatim (the
+                    <code className="font-mono"> geof:distance</code> value keeps its{" "}
+                    <code className="font-mono">xsd:double</code> datatype).
+                  </p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      {/* ── 2. R-tree GeoIndex ─────────────────────────────────────────────────────────── */}
+      <section className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Search className="size-5 text-primary" aria-hidden="true" />
+          <h2 className="text-xl font-semibold">R-tree GeoIndex — nearest / radius / intersects</h2>
+          <Badge variant="success" className="text-[10px] uppercase">
+            real captured output
+          </Badge>
+        </div>
+        <p className="measure text-sm text-muted-foreground">
+          <code className="font-mono">GeoIndex::build</code> scans a graph&rsquo;s{" "}
+          <code className="font-mono">geo:asWKT</code> / <code className="font-mono">geo:asGML</code>{" "}
+          serializations (resolving the owning feature through{" "}
+          <code className="font-mono">geo:hasGeometry</code> /{" "}
+          <code className="font-mono">geo:hasDefaultGeometry</code>) into an{" "}
+          <code className="font-mono">rstar</code> R-tree, then answers great-circle{" "}
+          <code className="font-mono">nearest</code> (k-NN),{" "}
+          <code className="font-mono">within_distance</code> (radius) and{" "}
+          <code className="font-mono">intersects</code> queries. This index built{" "}
+          <strong className="text-foreground">{INDEX_BUILD.len} entities, {INDEX_BUILD.skipped}{" "}
+          skipped</strong>, centred on central London ({INDEX_CENTER.lon}, {INDEX_CENTER.lat}).
+        </p>
+
+        {/* Index-run chips. */}
+        <div className="flex flex-wrap gap-2">
+          {INDEX_RUNS.map((item, i) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => setISel(i)}
+              className={cn(
+                "rounded-full px-3 py-1.5 text-left text-[12.5px] ring-1 transition-colors",
+                i === iSel
+                  ? "bg-primary/10 text-primary ring-primary/30"
+                  : "bg-muted/40 text-muted-foreground ring-foreground/10 hover:bg-muted",
+              )}
+            >
+              {item.caption}
+            </button>
+          ))}
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <Card>
+            <CardHeader className="flex-row items-center gap-2 space-y-0">
+              <MapPin className="size-4 text-primary" aria-hidden="true" />
+              <CardTitle className="text-sm">Feature fixture</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <FixtureMap features={FEATURES} highlight={highlightForIndex(run)} />
+              <p className="text-xs text-muted-foreground">
+                Highlighted: the entities this index query returned. Distances are great-circle
+                metres from the index.
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">{run.caption}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12px]">
+                {run.call}
+              </pre>
+              <div className="overflow-x-auto rounded-lg border">
+                <table className="w-full border-collapse font-mono text-[12px]">
+                  <thead>
+                    <tr className="border-b bg-muted/60">
+                      <th className="px-3 py-1.5 text-left font-semibold">entity</th>
+                      <th className="px-3 py-1.5 text-right font-semibold">metres</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {run.hits.map((h) => (
+                      <tr key={h.term} className="border-b last:border-0">
+                        <td className="px-3 py-1.5">{shortIri(h.term)}</td>
+                        <td className="px-3 py-1.5 text-right tabular-nums text-muted-foreground">
+                          {h.metres === null
+                            ? "—"
+                            : h.metres === 0
+                              ? "0"
+                              : h.metres.toLocaleString(undefined, {
+                                  maximumFractionDigits: 1,
+                                })}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {run.hits.length} hit{run.hits.length === 1 ? "" : "s"} — entity terms verbatim,
+                metres the index&rsquo;s exact great-circle f64 (rounded to 1 dp for display).
+                <code className="font-mono"> intersects</code> returns no distance (shown as
+                &ldquo;—&rdquo;).
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      {/* ── 3. Topology relation families (vocabulary) ─────────────────────────────────── */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Shapes className="size-5 text-primary" aria-hidden="true" />
+          <h2 className="text-xl font-semibold">Topology relation families</h2>
+          <Badge variant="muted" className="text-[10px] uppercase">
+            vocabulary
+          </Badge>
+        </div>
+        <p className="measure text-sm text-muted-foreground">
+          Each topology relation comes in three GeoSPARQL families — Simple Features, Egenhofer
+          and RCC8 — every member a planar DE-9IM predicate the crate evaluates (the{" "}
+          <code className="font-mono">geof:sfWithin</code> join above is the captured proof one
+          works). Below are the function names; relations are{" "}
+          <strong className="text-foreground">planar</strong> DE-9IM in coordinate space, not
+          geodesic.
+        </p>
+        <div className="grid gap-3 sm:grid-cols-3">
+          {RELATION_FAMILIES.map((r) => (
+            <div key={r.prefix} className="rounded-xl bg-muted/40 p-4 ring-1 ring-foreground/10">
+              <div className="flex items-baseline gap-2">
+                <span className="font-mono text-sm font-semibold text-primary">{r.prefix}</span>
+                <span className="text-sm font-semibold">{r.name}</span>
+              </div>
+              <div className="mt-1 font-mono text-[11px] leading-relaxed text-muted-foreground">
+                {r.note}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/site/src/data/surfaces.ts
+++ b/site/src/data/surfaces.ts
@@ -219,9 +219,16 @@ export const GROUPS: SurfaceGroup[] = [
         slug: "geosparql",
         href: "/surface/geosparql",
         title: "GeoSPARQL",
-        blurb: "geof: functions + R-tree GeoIndex with a map overlay.",
-        tier: "hosted",
+        blurb: "geof: functions + sf*/eh*/rcc8* + R-tree GeoIndex with a map overlay.",
+        // [OPUS-4.8] sq-ndaz: tier-e. sparq-geo is an opt-in native crate (the core engine
+        // + lean wasm bundle carry zero geometry code; the server exposes geof: only behind
+        // its non-default `geo` feature), and the static Pages site has no backend — so the
+        // honest surface is a captured-output walkthrough (the real London–Paris distance
+        // < 400 km query, within-polygon spatial join, topology-property rewrite, and R-tree
+        // GeoIndex metres, all answer-exact), not a live hosted endpoint.
+        tier: "walkthrough",
         icon: MapPin,
+        built: true,
       },
       {
         slug: "streaming-rsp",

--- a/site/src/lib/geosparql.ts
+++ b/site/src/lib/geosparql.ts
@@ -1,0 +1,352 @@
+// [OPUS-4.8] sq-ndaz — pure, framework-free data + helpers for the /surface/geosparql
+// (GeoSPARQL) showcase. sparq-geo is an OPT-IN native crate: nothing in the engine
+// workspace's lean wasm bundle depends on it (the wasm build carries ZERO geometry
+// code), and `sparq-server` exposes it only behind its non-default `geo` cargo feature.
+// The static GitHub-Pages site has no backend, so this surface is the honest tier-e
+// "captured-output walkthrough" fallback the feature-showcase design names
+// (research/feature-showcase-site-design.md §0, surface (e)).
+//
+// =====================================================================================
+// HONESTY CONTRACT — read before editing. A sibling page (sq-rnwc) was caught fabricating
+// "captured" output (dropped datatypes, invented rows); the fix on the next pages (sq-3was
+// / sq-dwdm) pinned the serialization in a test so drift is impossible. We do the SAME
+// here. Every payload on this page is split into two clearly-labelled halves, and the test
+// (site/test/geosparql.test.mjs) pins the serialization of the live-captured half:
+//
+//   (A) GENUINELY LIVE-CAPTURED — every `GeoQuery` (the geof: SPARQL result tables: FILTER
+//       geof:distance, the geof:sfWithin spatial join, the geof:buffer chain, and the
+//       topology-PROPERTY-form geosparql_rewrite) and every `INDEX_RUN` row (the R-tree
+//       GeoIndex nearest / within_distance / intersects metres). These were produced by
+//       RUNNING THE REAL sparq-geo binary over the tiny DECLARED in-memory Turtle fixtures
+//       below — the SAME fixtures the crate's OWN COMMITTED tests assert against
+//       (crates/sparq-geo/tests/registry_sparql.rs + tests/e2e.rs + tests/query_rewrite.rs,
+//       runnable today with `cargo test -p sparq-geo --features engine`, which corroborate
+//       the spatial-join order, the ≈343.6 km London–Paris distance and the rewrite/index
+//       matches) — and PASTED VERBATIM. The capture was driven by a small `--features
+//       engine` example harness over those fixtures, re-run twice and diffed for byte
+//       stability. The result cells are the engine's
+//       exact `oxrdf::Term::Display` (N-Triples) serialization: an IRI is `<…>`, a typed
+//       literal is `"…"^^<datatype-iri>`. The geof:distance value is bound as an
+//       `xsd:double` literal, datatype INTACT. The GeoIndex distances are the index's exact
+//       great-circle f64 metres (the page rounds them for display, but the captured value
+//       is pinned). Everything in (A) is DETERMINISTIC (a fixed fixture, planar DE-9IM
+//       relations, haversine distance, ties broken by the R-tree order) — the same binary
+//       over the same fixture yields BYTE-IDENTICAL output (verified by re-running the
+//       harness twice and diffing). Re-CAPTURE (do not hand-edit) if a fixture or the
+//       pipeline changes — run the example again and paste.
+//
+//   (B) HONESTLY ILLUSTRATIVE / NON-CANONICAL — the small inline SVG map is a LEGIBILITY
+//       AID, not captured output: the city/region coordinates it draws are exactly the WKT
+//       longitudes/latitudes in the fixtures (so the dots ARE the real geometry), but the
+//       map projection, the coastline-free abstract background, and the "≈ km" annotations
+//       are illustrative chrome. No latency or throughput number is shown (hardware-
+//       dependent, non-canonical). The metric-distance caveat is real: geof:distance with
+//       metric units is exact haversine when an operand is a point, but a local
+//       equirectangular approximation between two extended geometries — accurate locally,
+//       distorted at continental scale or near the poles (see the crate's SKILL.md).
+//
+// Grounded in skills/geosparql/SKILL.md + crates/sparq-geo (README + the committed
+// tests/registry_sparql.rs + tests/e2e.rs + tests/query_rewrite.rs that corroborate every
+// captured value here).
+
+/** Whether the geof: result tables / GeoIndex metres come from the REAL binary (they do —
+ *  captured verbatim from the answer-exact engine over a declared fixture, not illustrative). */
+export const IS_LIVE_CAPTURED = true as const;
+
+/** The `geof:` function vocabulary namespace (OGC GeoSPARQL). */
+export const GEOF_NS = "http://www.opengis.net/def/function/geosparql/" as const;
+
+/** The `geo:` ontology namespace (geometry literals + topology properties). */
+export const GEO_NS = "http://www.opengis.net/ont/geosparql#" as const;
+
+/** The OGC `uom:` unit-of-measure namespace. */
+export const UOM_NS = "http://www.opengis.net/def/uom/OGC/1.0/" as const;
+
+// ── The declared fixtures (the EXACT Turtle the capture harness loaded) ─────────────────
+
+/** A WKT point/polygon feature on the map, keyed by its short fixture name. */
+export interface MapFeature {
+  /** The fixture id (`london`, `france`, …). */
+  id: string;
+  /** A human label for the legend. */
+  label: string;
+  /** "point" | "polygon" — drives the marker shape. */
+  kind: "point" | "polygon";
+  /**
+   * The WKT longitude/latitude coordinates, VERBATIM from the fixture. A point is a
+   * single [lon, lat]; a polygon is its exterior ring as a list of [lon, lat].
+   */
+  coords: [number, number][];
+}
+
+/**
+ * The cities + areas fixture (3 points, 2 polygons) the geof: SPARQL captures ran over.
+ * VERBATIM from crates/sparq-geo/tests/registry_sparql.rs (and the capture harness):
+ * the UK box contains London; the France box contains Paris and Lyon.
+ */
+export const CITIES: MapFeature[] = [
+  { id: "london", label: "London", kind: "point", coords: [[-0.1278, 51.5074]] },
+  { id: "paris", label: "Paris", kind: "point", coords: [[2.3522, 48.8566]] },
+  { id: "lyon", label: "Lyon", kind: "point", coords: [[4.8357, 45.764]] },
+  {
+    id: "uk",
+    label: "UK box",
+    kind: "polygon",
+    coords: [
+      [-6, 50],
+      [2, 50],
+      [2, 59],
+      [-6, 59],
+      [-6, 50],
+    ],
+  },
+  {
+    id: "france",
+    label: "France box",
+    kind: "polygon",
+    coords: [
+      [-1, 42.5],
+      [7, 42.5],
+      [7, 51],
+      [-1, 51],
+      [-1, 42.5],
+    ],
+  },
+];
+
+// ── (A) GENUINELY LIVE-CAPTURED — the geof: SPARQL result tables ─────────────────────────
+
+/** One captured geof: SPARQL run. */
+export interface GeoQuery {
+  /** A short tag for the chip/selector. */
+  id: string;
+  /** A human description of what the query asks. */
+  caption: string;
+  /** The exact SPARQL the harness ran (verbatim, pretty-printed). */
+  sparql: string;
+  /** Projected variable names, in order. */
+  vars: string[];
+  /**
+   * Result rows, VERBATIM. Each cell is the engine's `oxrdf::Term::Display` (N-Triples)
+   * string: an IRI `<…>` or a typed literal `"…"^^<…>`.
+   */
+  rows: string[][];
+  /** Whether this query is driven by the opt-in geosparql_rewrite topology-property form. */
+  rewrite?: boolean;
+}
+
+/**
+ * The captured geof: runs (captured 2026-06-19, byte-identical across re-runs). Each `rows`
+ * array is the VERBATIM engine output. NOTE the honest serialization detail the
+ * fabrication-shape would have blurred: the geof:distance value comes back as a typed
+ * `xsd:double` literal (datatype intact), NOT a bare number; the IRIs are full `<…>` forms.
+ */
+export const GEO_QUERIES: GeoQuery[] = [
+  {
+    id: "distance-400km",
+    caption: "Cities within 400 km of London (geof:distance)",
+    sparql: `PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+PREFIX uom:  <http://www.opengis.net/def/uom/OGC/1.0/>
+PREFIX ex:   <http://ex/>
+SELECT ?city ?km WHERE {
+  ex:london ex:loc ?here . ?city ex:loc ?there .
+  BIND(geof:distance(?here, ?there, uom:kilometre) AS ?km)
+  FILTER(?city != ex:london && ?km < 400)
+} ORDER BY ?km`,
+    vars: ["city", "km"],
+    // London↔Paris ≈ 343.56 km < 400; Lyon (≈ 750 km) excluded. The ?km is an xsd:double.
+    rows: [
+      [
+        "<http://ex/paris>",
+        '"343.55653488088325"^^<http://www.w3.org/2001/XMLSchema#double>',
+      ],
+    ],
+  },
+  {
+    id: "spatial-join",
+    caption: "Which city is within which polygon (geof:sfWithin join)",
+    sparql: `PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+PREFIX ex:   <http://ex/>
+SELECT ?city ?region WHERE {
+  ?city ex:loc ?pt . ?region ex:area ?poly .
+  FILTER(geof:sfWithin(?pt, ?poly))
+} ORDER BY ?city`,
+    vars: ["city", "region"],
+    // The real spatial join over 3 points × 2 polygons: London in the UK box, Paris and
+    // Lyon in the France box.
+    rows: [
+      ["<http://ex/london>", "<http://ex/uk>"],
+      ["<http://ex/lyon>", "<http://ex/france>"],
+      ["<http://ex/paris>", "<http://ex/france>"],
+    ],
+  },
+  {
+    id: "buffer-chain",
+    caption: "Inside a 400 km buffer of London (geof:buffer ∘ geof:sfWithin)",
+    sparql: `PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+PREFIX uom:  <http://www.opengis.net/def/uom/OGC/1.0/>
+PREFIX ex:   <http://ex/>
+SELECT ?city WHERE {
+  ex:london ex:loc ?here . ?city ex:loc ?there .
+  FILTER(?city != ex:london &&
+         geof:sfWithin(?there, geof:buffer(?here, 400, uom:kilometre)))
+} ORDER BY ?city`,
+    vars: ["city"],
+    // geof:buffer returns a geo:wktLiteral that feeds straight into geof:sfWithin in the
+    // same expression: only Paris falls inside the 400 km buffer.
+    rows: [["<http://ex/paris>"]],
+  },
+  {
+    id: "rewrite-sfwithin",
+    caption: "Topology PROPERTY form — ?f geo:sfWithin ex:region (query rewrite)",
+    sparql: `PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX ex:  <http://example.org/>
+SELECT ?f WHERE { ?f geo:sfWithin ex:region } ORDER BY ?f`,
+    vars: ["f"],
+    rewrite: true,
+    // NO asserted geo:sfWithin triple exists. The geosparql_rewrite extension resolves each
+    // feature's (hasDefaultGeometry|hasGeometry)/asWKT geometry and applies geof:sfWithin:
+    // London and Big Ben (inside) match, and the region itself (reflexive under DE-9IM);
+    // Paris (far outside) does not.
+    rows: [
+      ["<http://example.org/bigben>"],
+      ["<http://example.org/london>"],
+      ["<http://example.org/region>"],
+    ],
+  },
+];
+
+// ── (A) GENUINELY LIVE-CAPTURED — the R-tree GeoIndex runs ───────────────────────────────
+
+/** One captured GeoIndex row: (entity term, great-circle metres or null for intersects). */
+export interface IndexHit {
+  /** The entity term, verbatim oxrdf::Term::Display (an `<iri>`). */
+  term: string;
+  /** Exact great-circle metres from the index, pasted verbatim; null for intersects. */
+  metres: number | null;
+}
+
+/** One captured GeoIndex query (nearest / within_distance / intersects). */
+export interface IndexRun {
+  id: string;
+  caption: string;
+  /** The Rust call the harness ran (verbatim). */
+  call: string;
+  hits: IndexHit[];
+}
+
+/**
+ * The features fixture (a region polygon + 3 points) the GeoIndex ran over. VERBATIM from
+ * crates/sparq-geo/tests/query_rewrite.rs — the inner-London box, the London point inside
+ * it, Big Ben just inside, and Paris far outside.
+ */
+export const FEATURES: MapFeature[] = [
+  {
+    id: "region",
+    label: "Inner-London box",
+    kind: "polygon",
+    coords: [
+      [-0.25, 51.45],
+      [0.05, 51.45],
+      [0.05, 51.57],
+      [-0.25, 51.57],
+      [-0.25, 51.45],
+    ],
+  },
+  { id: "london", label: "London", kind: "point", coords: [[-0.13, 51.51]] },
+  { id: "bigben", label: "Big Ben", kind: "point", coords: [[-0.1246, 51.5007]] },
+  { id: "paris", label: "Paris", kind: "point", coords: [[2.3522, 48.8566]] },
+];
+
+/** The R-tree centre the nearest / within_distance queries used (central London). */
+export const INDEX_CENTER = { lon: -0.13, lat: 51.51 } as const;
+
+/**
+ * The captured GeoIndex runs (captured 2026-06-19, byte-identical across re-runs). The
+ * metres are the index's exact great-circle f64 (the page rounds for display). The index
+ * built 4 entities, 0 skipped — entities resolve through hasGeometry/hasDefaultGeometry.
+ */
+export const INDEX_RUNS: IndexRun[] = [
+  {
+    id: "nearest",
+    caption: "k-nearest to central London (R-tree, k = 4)",
+    call: "index.nearest(Point(-0.13, 51.51), 4)",
+    // london + region both contain/sit-on the centre (0 m), then Big Ben (~1.1 km), then
+    // Paris (~344 km) — best-first.
+    hits: [
+      { term: "<http://example.org/london>", metres: 0 },
+      { term: "<http://example.org/region>", metres: 0 },
+      { term: "<http://example.org/bigben>", metres: 1099.5813838365123 },
+      { term: "<http://example.org/paris>", metres: 343882.44355547347 },
+    ],
+  },
+  {
+    id: "within",
+    caption: "Within 5 km of central London (radius query)",
+    call: "index.within_distance(Point(-0.13, 51.51), 5_000.0, None)",
+    // Only the London-area entities; Paris (~344 km) excluded.
+    hits: [
+      { term: "<http://example.org/london>", metres: 0 },
+      { term: "<http://example.org/region>", metres: 0 },
+      { term: "<http://example.org/bigben>", metres: 1099.5813838365123 },
+    ],
+  },
+  {
+    id: "intersects",
+    caption: "Intersects a box over the Channel + Paris",
+    call:
+      'index.intersects_wkt("POLYGON((1 48, 3 48, 3 49.5, 1 49.5, 1 48))")',
+    // The box covers Paris only (no distance is returned by intersects).
+    hits: [{ term: "<http://example.org/paris>", metres: null }],
+  },
+];
+
+/** The index build stats the harness reported (verbatim). */
+export const INDEX_BUILD = { len: 4, skipped: 0 } as const;
+
+// ── (B) HONESTLY ILLUSTRATIVE — the topology-relation families (vocabulary, not captured) ─
+
+/**
+ * The three GeoSPARQL topology-relation families sparq-geo implements, for the capability
+ * note. These are the VOCABULARY (function names), not a captured run — each family is a
+ * set of DE-9IM relations the crate evaluates; the sf* `geof:sfWithin` run above is the
+ * captured proof that the family works.
+ */
+export const RELATION_FAMILIES: { prefix: string; name: string; note: string }[] = [
+  {
+    prefix: "sf*",
+    name: "Simple Features",
+    note: "sfEquals / sfDisjoint / sfIntersects / sfTouches / sfCrosses / sfWithin / sfContains / sfOverlaps",
+  },
+  {
+    prefix: "eh*",
+    name: "Egenhofer",
+    note: "ehEquals / ehDisjoint / ehMeet / ehOverlap / ehCovers / ehCoveredBy / ehInside / ehContains",
+  },
+  {
+    prefix: "rcc8*",
+    name: "RCC8",
+    note: "rcc8eq / rcc8dc / rcc8ec / rcc8po / rcc8tppi / rcc8tpp / rcc8ntpp / rcc8ntppi",
+  },
+];
+
+// ── helpers ──────────────────────────────────────────────────────────────────────────────
+
+/** A short label for an `<iri>` cell — strip the namespace for legibility. */
+export function shortIri(cell: string): string {
+  const m = cell.match(/^<.*[/#]([^/#>]+)>$/);
+  return m ? m[1] : cell;
+}
+
+/** Lookup a captured geof: query by id (the selector key). */
+export function geoQueryById(id: string): GeoQuery | undefined {
+  return GEO_QUERIES.find((q) => q.id === id);
+}
+
+/** Lookup a captured GeoIndex run by id. */
+export function indexRunById(id: string): IndexRun | undefined {
+  return INDEX_RUNS.find((r) => r.id === id);
+}

--- a/site/test/geosparql.test.mjs
+++ b/site/test/geosparql.test.mjs
@@ -1,0 +1,209 @@
+// [OPUS-4.8] sq-ndaz — unit tests for the /surface/geosparql (GeoSPARQL) walkthrough.
+// This surface is tier-e (no backend behind the static site) so it replays REAL captured
+// output from the sparq-geo binary (built with `--features engine`) over tiny declared
+// in-memory Turtle fixtures — the SAME fixtures the crate's own committed tests assert
+// against (crates/sparq-geo/tests/registry_sparql.rs + tests/e2e.rs + tests/query_rewrite.rs,
+// runnable with `cargo test -p sparq-geo --features engine`). These tests pin the captured
+// data's SHAPE *and SERIALIZATION* so the page can
+// never silently drift into a fabrication — the exact failure mode the sibling http-server
+// page (sq-rnwc) was caught in (dropped datatypes, invented rows). In particular: every
+// result cell is the engine's verbatim oxrdf::Term::Display string; the geof:distance value
+// carries its xsd:double datatype EXACTLY; the GeoIndex metres are pinned; and the map
+// coordinates are the verbatim WKT lon/lat from the fixtures. Run via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  CITIES,
+  FEATURES,
+  GEO_NS,
+  GEO_QUERIES,
+  GEOF_NS,
+  INDEX_BUILD,
+  INDEX_CENTER,
+  INDEX_RUNS,
+  IS_LIVE_CAPTURED,
+  RELATION_FAMILIES,
+  UOM_NS,
+  geoQueryById,
+  indexRunById,
+  shortIri,
+} from "../src/lib/geosparql.ts";
+
+test("the captures are flagged as live (real binary), and the namespaces are the OGC ones", () => {
+  assert.equal(IS_LIVE_CAPTURED, true);
+  assert.equal(GEOF_NS, "http://www.opengis.net/def/function/geosparql/");
+  assert.equal(GEO_NS, "http://www.opengis.net/ont/geosparql#");
+  assert.equal(UOM_NS, "http://www.opengis.net/def/uom/OGC/1.0/");
+});
+
+// ── The map fixtures are the verbatim WKT lon/lat ────────────────────────────────────────
+test("every map feature carries WKT lon/lat coordinates (lon in [-180,180], lat in [-90,90])", () => {
+  for (const f of [...CITIES, ...FEATURES]) {
+    assert.ok(f.coords.length >= 1, `${f.id}: no coordinates`);
+    if (f.kind === "point") {
+      assert.equal(f.coords.length, 1, `${f.id}: a point has exactly one coordinate`);
+    } else {
+      // A polygon exterior ring is closed (first == last) and has ≥ 4 vertices.
+      assert.ok(f.coords.length >= 4, `${f.id}: polygon ring too short`);
+      assert.deepEqual(f.coords[0], f.coords[f.coords.length - 1], `${f.id}: ring not closed`);
+    }
+    for (const [lon, lat] of f.coords) {
+      assert.ok(lon >= -180 && lon <= 180, `${f.id}: lon out of range: ${lon}`);
+      assert.ok(lat >= -90 && lat <= 90, `${f.id}: lat out of range: ${lat}`);
+    }
+  }
+});
+
+test("the cities fixture is 3 points + 2 polygons (the geof: capture fixture)", () => {
+  assert.equal(CITIES.filter((f) => f.kind === "point").length, 3);
+  assert.equal(CITIES.filter((f) => f.kind === "polygon").length, 2);
+  // London's coordinate is the verbatim WKT POINT(-0.1278 51.5074).
+  const london = CITIES.find((f) => f.id === "london");
+  assert.deepEqual(london.coords[0], [-0.1278, 51.5074]);
+});
+
+// ── The geof: SPARQL captures ────────────────────────────────────────────────────────────
+test("every captured geof: query is real SPARQL with the geo:/geof: vocabulary", () => {
+  for (const q of GEO_QUERIES) {
+    // Each query references the geo: or geof: vocabulary.
+    assert.match(
+      q.sparql,
+      /(geof:|geo:sf|geo:eh|geo:rcc8)/,
+      `${q.id}: no geof:/geo: topology vocabulary`,
+    );
+    assert.ok(q.vars.length >= 1, `${q.id}: no projected variables`);
+    for (const row of q.rows) {
+      assert.equal(row.length, q.vars.length, `${q.id}: row arity != var count`);
+    }
+  }
+});
+
+// ── The honesty-regression guard: term serialization is VERBATIM oxrdf Display. ─────────
+// The sibling page dropped a literal's datatype when a "captured" payload was hand-edited.
+// Pin every result cell to its EXACT N-Triples serialization so a bare/mistyped value can
+// never sneak in: an IRI is `<...>`, a plain literal is `"..."`, a typed literal is
+// `"..."^^<datatype-iri>`.
+test("every geof: result cell is a verbatim IRI or correctly-serialized literal", () => {
+  const IRI = /^<[^>]+>$/;
+  const PLAIN = /^"[^"]*"$/;
+  const TYPED = /^".*"\^\^<[^>]+>$/s;
+  for (const q of GEO_QUERIES) {
+    for (const row of q.rows) {
+      for (const cell of row) {
+        const ok = IRI.test(cell) || PLAIN.test(cell) || TYPED.test(cell);
+        assert.ok(ok, `${q.id}: cell is not a verbatim IRI/plain/typed literal: ${cell}`);
+      }
+    }
+  }
+});
+
+test("geof:distance binds the distance as a verbatim xsd:double (datatype intact)", () => {
+  const q = geoQueryById("distance-400km");
+  // The exact captured output: Paris at 343.55653488088325 km, as an xsd:double literal.
+  assert.deepEqual(q.rows, [
+    [
+      "<http://ex/paris>",
+      '"343.55653488088325"^^<http://www.w3.org/2001/XMLSchema#double>',
+    ],
+  ]);
+  const scoreCell = q.rows[0][1];
+  assert.ok(
+    scoreCell.endsWith("^^<http://www.w3.org/2001/XMLSchema#double>"),
+    `distance missing xsd:double datatype: ${scoreCell}`,
+  );
+  // The bound value parses to ≈ 343.6 km and is strictly < 400 (the FILTER bound).
+  const km = Number.parseFloat(scoreCell.slice(1));
+  assert.ok(km < 400 && km > 340, `London–Paris ≈ 343.6 km, got ${km}`);
+});
+
+test("the spatial join returns the verbatim (city, region) pairs (pinned)", () => {
+  const q = geoQueryById("spatial-join");
+  assert.deepEqual(q.rows, [
+    ["<http://ex/london>", "<http://ex/uk>"],
+    ["<http://ex/lyon>", "<http://ex/france>"],
+    ["<http://ex/paris>", "<http://ex/france>"],
+  ]);
+});
+
+test("the geof:buffer chain keeps only Paris inside the 400 km buffer (pinned)", () => {
+  const q = geoQueryById("buffer-chain");
+  assert.deepEqual(q.rows, [["<http://ex/paris>"]]);
+});
+
+test("the topology PROPERTY form is the opt-in geosparql_rewrite, with the pinned matches", () => {
+  const q = geoQueryById("rewrite-sfwithin");
+  assert.equal(q.rewrite, true);
+  // The rewrite has NO asserted geo:sfWithin triple — it resolves geometry and FILTERs.
+  assert.match(q.sparql, /\?f geo:sfWithin ex:region/);
+  assert.deepEqual(q.rows, [
+    ["<http://example.org/bigben>"],
+    ["<http://example.org/london>"],
+    ["<http://example.org/region>"],
+  ]);
+});
+
+// ── The R-tree GeoIndex captures ─────────────────────────────────────────────────────────
+test("the GeoIndex built 4 entities, 0 skipped, centred on central London", () => {
+  assert.equal(INDEX_BUILD.len, 4);
+  assert.equal(INDEX_BUILD.skipped, 0);
+  assert.deepEqual(INDEX_CENTER, { lon: -0.13, lat: 51.51 });
+});
+
+test("the GeoIndex metres are verbatim great-circle f64, best-first, pinned", () => {
+  const nearest = indexRunById("nearest");
+  // Pin the EXACT captured output (term + f64 metres) so a hand-edit can't invent a hit.
+  assert.deepEqual(
+    nearest.hits.map((h) => h.term),
+    [
+      "<http://example.org/london>",
+      "<http://example.org/region>",
+      "<http://example.org/bigben>",
+      "<http://example.org/paris>",
+    ],
+  );
+  assert.equal(nearest.hits[2].metres, 1099.5813838365123);
+  assert.equal(nearest.hits[3].metres, 343882.44355547347);
+  // nearest is best-first: metres are non-decreasing, every term is a verbatim IRI.
+  let prev = -Infinity;
+  for (const h of nearest.hits) {
+    assert.match(h.term, /^<[^>]+>$/, `hit is not a verbatim IRI: ${h.term}`);
+    assert.ok(h.metres >= prev, "nearest metres must be non-decreasing (best-first)");
+    prev = h.metres;
+  }
+});
+
+test("within_distance(5 km) drops Paris (~344 km away); intersects returns Paris with no metres", () => {
+  const within = indexRunById("within");
+  // Only the London-area entities are within 5 km; Paris must NOT appear.
+  assert.ok(!within.hits.some((h) => h.term.includes("paris")), "Paris is ~344 km away, not within 5 km");
+  for (const h of within.hits) {
+    assert.ok(h.metres <= 5000, `within-5km hit exceeds radius: ${h.metres}`);
+  }
+  const intersects = indexRunById("intersects");
+  assert.deepEqual(
+    intersects.hits.map((h) => h.term),
+    ["<http://example.org/paris>"],
+  );
+  // intersects returns no distance (metres is null) — the page must not invent one.
+  assert.equal(intersects.hits[0].metres, null);
+});
+
+// ── The illustrative half is honestly labelled vocabulary ────────────────────────────────
+test("the three topology-relation families are the sf*/eh*/rcc8* vocabulary", () => {
+  assert.equal(RELATION_FAMILIES.length, 3);
+  assert.deepEqual(
+    RELATION_FAMILIES.map((r) => r.prefix),
+    ["sf*", "eh*", "rcc8*"],
+  );
+  // The sf* family must name sfWithin (the captured proof above exercises it).
+  const sf = RELATION_FAMILIES.find((r) => r.prefix === "sf*");
+  assert.match(sf.note, /sfWithin/);
+});
+
+test("shortIri strips the namespace; lookups return undefined for unknown ids", () => {
+  assert.equal(shortIri("<http://ex/paris>"), "paris");
+  assert.equal(shortIri("<http://example.org/bigben>"), "bigben");
+  assert.equal(geoQueryById("does-not-exist"), undefined);
+  assert.equal(indexRunById("does-not-exist"), undefined);
+});


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **bead sq-ndaz** — the `/surface/geosparql` showcase, following the exemplary just-landed `/surface/vector` (sq-dwdm) and `/surface/genai` (sq-3was) pages.

## What's live-captured (real engine output, pinned)
Every `geof:` result table and every R-tree `GeoIndex` metre is **REAL, verbatim output** of the `sparq-geo` binary (`--features engine`) run over tiny **declared in-memory Turtle fixtures** — the *same* fixtures the crate's committed tests assert against:

- **`geof:distance` < 400 km** — London↔Paris bound as `"343.55653488088325"^^xsd:double` (datatype **intact**), Lyon (~750 km) excluded.
- **`geof:sfWithin` spatial join** — which city is within which polygon (London→UK, Paris/Lyon→France).
- **`geof:buffer` ∘ `geof:sfWithin` chain** — only Paris inside London's 400 km buffer.
- **Topology PROPERTY form** — `?f geo:sfWithin ex:region` via the opt-in `geosparql_rewrite` (no asserted topology triple): bigben, london, region.
- **R-tree GeoIndex** — `nearest` / `within_distance` / `intersects` great-circle metres (e.g. Big Ben ~1.1 km, Paris ~344 km).

These are pasted **byte-for-byte** (re-run twice + diffed for determinism) and **corroborated by the crate's committed tests** (`tests/registry_sparql.rs` / `tests/e2e.rs` / `tests/query_rewrite.rs`, runnable today with `cargo test -p sparq-geo --features engine`, all green here).

## Honesty (the sq-rnwc fix pattern)
- A **serialization-pinning test** (`site/test/geosparql.test.mjs`, mirroring `vector.test.mjs` / `genai.test.mjs`) pins the `xsd:double` datatype, the verbatim `oxrdf::Term::Display` cells, the GeoIndex metres, and the WKT map coordinates — so the page **cannot drift into a fabrication**.
- The inline-SVG fixture **map** is labelled an **illustrative legibility aid** (the dots ARE the real WKT lon/lat; the projection/background are chrome). **Dependency-free** — no Leaflet/MapLibre (no new dep, no SSR-incompatible lib, no bundle-size hit).
- **No canonical perf numbers**; metric-distance caveat (haversine for points / local equirectangular for two extended geometries; planar DE-9IM) stated.

## Files / routes
- New: `site/src/lib/geosparql.ts`, `site/src/components/geosparql-walkthrough.tsx`, `site/src/app/surface/geosparql/page.tsx`, `site/test/geosparql.test.mjs`.
- Minimal 1-line registrations (kept tiny to make any conflict with #714 a trivial resolve): `site/src/data/surfaces.ts` (`hosted` → `walkthrough`, `built: true`) + `site/src/app/surface/[slug]/page.tsx` (`BUILT_SURFACES`).
- Route emitted: `/surface/geosparql` (7.04 kB); existing routes intact.

## Gate
- `npm run build` static export green end-to-end (`/surface/geosparql` emits to `out/`); WASM prereq satisfied (lean bundle).
- `npm run lint` clean · `tsc --noEmit` clean.
- `npm run test:unit` **96/96** (incl the new pinning test).
- `lychee --offline` 0 errors · `typos` clean · no new markdown.

Staged `site/**` only. Auto-merge **not** enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)