### PR TITLE
feat(bench): --json <path> machine-readable emit for bench/parse + sparq-text bench_text (sq-ghjc) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3688,6 +3688,7 @@ dependencies = [
  "rand 0.10.1",
  "rayon",
  "rustc-hash 2.1.2",
+ "serde_json",
  "spargebra",
  "sparq-core",
  "sparq-engine",

--- a/bench/fts/README.md
+++ b/bench/fts/README.md
@@ -91,6 +91,14 @@ FTS_N=1000000 bench/fts/run.sh
 ci-bench hook consumes (`sparq-text` is the *isolated* FTS crate — not a `sparq-cli`
 dependency — so the runner is a crate `--example`, not a CLI subcommand).
 
+A trailing `--json <path>` additionally writes the same rows (deterministic `count` +
+advisory `us`) as a dependency-free JSON document (sq-ghjc) — STDOUT stays the pure TSV
+`run.sh` parses, so the flag never disturbs the hard count gate:
+
+```sh
+cargo run --release -p sparq-text --example bench_text -- 100000 0 3 --json fts-results.json
+```
+
 ## Competitors
 
 **Be honest: Solr / Elasticsearch are NOT SPARQL competitors** (no RDF/SPARQL surface; RDF4J

--- a/bench/parse/Cargo.lock
+++ b/bench/parse/Cargo.lock
@@ -51,6 +51,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +79,15 @@ checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
 dependencies = [
  "bzip2-sys",
  "libc",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -101,10 +119,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -169,13 +202,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -211,6 +264,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures-core"
@@ -277,9 +336,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -287,6 +344,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hdt"
@@ -309,6 +371,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "id-arena"
@@ -368,6 +439,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,12 +467,12 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -497,13 +574,14 @@ dependencies = [
 name = "parse-baseline"
 version = "0.0.0"
 dependencies = [
- "bzip2",
+ "bzip2 0.4.4",
  "flate2",
  "hdt",
  "mimalloc",
  "oxrdf",
  "oxttl",
  "rayon",
+ "serde_json",
  "sparq-core",
  "sparq-engine",
  "sparq-hdt",
@@ -778,13 +856,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -794,8 +872,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -861,7 +950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83f6facc93703fcb7fa773b0ff71e0ee7d937157c5c22ae2aa6c95b5cf834949"
 dependencies = [
  "log",
- "sha2",
+ "sha2 0.10.9",
  "sophia_api",
  "sophia_iri",
  "thiserror",
@@ -964,7 +1053,7 @@ dependencies = [
 name = "sparq-core"
 version = "0.1.0"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "memchr",
  "oxrdf",
  "oxttl",
@@ -983,7 +1072,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "sha1",
- "sha2",
+ "sha2 0.11.0",
  "smallvec",
  "spargebra",
  "sparq-core",
@@ -994,10 +1083,11 @@ dependencies = [
 name = "sparq-hdt"
 version = "0.1.0"
 dependencies = [
- "bzip2",
+ "bzip2 0.6.1",
  "crc",
  "flate2",
  "hdt",
+ "rayon",
  "sparq-core",
  "zstd",
 ]

--- a/bench/parse/Cargo.toml
+++ b/bench/parse/Cargo.toml
@@ -43,6 +43,13 @@ rayon = "1"
 # Match the production CLI environment: sparq-cli ingest runs under mimalloc.
 mimalloc = "0.1"
 
+[dev-dependencies]
+# [OPUS-4.8] (sq-ghjc) Test-only: PARSE the dependency-free `--json` emit back to
+# assert it is valid JSON with the documented shape. The emit itself stays
+# serde-free (hand-built `format!`, mirroring mpc_net_bench::cell_json); serde_json
+# is a dev-dependency so it never enters the bench binary or the production build.
+serde_json = "1"
+
 [[bin]]
 name = "parse-baseline"
 path = "src/main.rs"

--- a/bench/parse/README.md
+++ b/bench/parse/README.md
@@ -46,6 +46,17 @@ bzcat /path/to/truthy.nt.bz2 | head -n 1500000 > data/wikidata-slice.nt
 Each number is the median of 3 runs, wall clock. MB/s is over the
 *decompressed* input bytes. Run on an otherwise idle machine.
 
+Any subcommand also accepts a trailing `--json <path>` that writes the SAME
+measured rows as a dependency-free JSON document (the machine-readable
+results-emit, sq-ghjc) — STDOUT is the unchanged markdown either way:
+
+```sh
+./target/release/parse-baseline bench-nt data/wikidata-slice.nt --json results.json
+```
+
+The emitted numbers are whatever the running machine measured — non-canonical
+(the `note` field says so); do not commit them.
+
 ## D4: compressed result serialization (`compress-bench`)
 
 Measures `crates/sparq-parse`'s `CompressedSink` (multi-member gzip /

--- a/bench/parse/src/main.rs
+++ b/bench/parse/src/main.rs
@@ -1,7 +1,10 @@
 //! Baseline measurements for the custom-parsers design (one bin, subcommands).
 //! Numbers land in research/custom-parsers-baseline.md.
 //!
-//! Subcommands:
+//! Subcommands (a trailing `--json <path>` on any subcommand also writes the same
+//! measured rows as a dependency-free JSON document — sq-ghjc; STDOUT is unchanged):
+//!
+//! ```text
 //!   gen <entities> <out.nt> <out.ttl>   deterministic synthetic dataset (same
 //!                                       generator as crates/sparq-bench/src/dataset.rs)
 //!   to-ttl <in.nt> <out.ttl>            convert N-Triples to Turtle via the oxttl
@@ -26,6 +29,7 @@
 //!                                       parallel NT path) [sq-q6a1, sq-7ge0].
 //!   bench-hdt-zip <file.hdt>            decompress+parse MB/s of <file.hdt>.{gz,zst,bz2}
 //!                                       via the direct decoder (expects those files)
+//! ```
 
 // Match the production CLI: sparq-cli ingest runs under mimalloc.
 #[global_allocator]
@@ -34,12 +38,186 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use sparq_core::Graph;
 use std::hint::black_box;
 use std::io::{Read, Write};
+use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
 const ITERS: usize = 3;
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-ghjc) --json <path> machine-readable results emit
+// ---------------------------------------------------------------------------
+//
+// The table-printing subcommands (`bench-nt`, `bench-ttl`, `bench-zip`,
+// `ab-ttl-intern`, `bench-hdt`, `bench-hdt-zip`) emit ad-hoc markdown so a doc
+// can `run the harness` rather than restate frozen numbers (sq-5vm). This adds a
+// strictly-additive `--json <path>` that mirrors the SAME measured rows as a
+// stable, DEPENDENCY-FREE JSON document — the hand-built `format!` convention
+// from `crates/sparq-mpc/examples/mpc_net_bench.rs::cell_json` and the
+// `suite_results_json` sq-d7d added to `sparq-cli`. NO serde dep is added.
+//
+// STDOUT is byte-for-byte unchanged whether or not `--json` is present: the
+// collector silently accumulates every `row(..)` call (and the `ab-ttl-intern`
+// special rows) and `main` writes the document at the end only when a path was
+// given. The numbers are whatever THIS machine measured — NON-CANONICAL — so the
+// emitted `note` says so and nothing here is committed.
+
+/// One captured measurement row: an ORDERED list of `(key, raw_json_value)` pairs.
+/// Heterogeneous by design — `row()` pushes the 6-column table shape, while
+/// `ab-ttl-intern` pushes its own `strategy`/`mtriples_s`/`ns_per_triple` shape —
+/// so each subcommand serialises exactly the fields it measured.
+type JsonRow = Vec<(&'static str, String)>;
+
+/// Global, lazily-initialised JSON-emit state. `path` is the `--json <path>`
+/// destination (None disables emit entirely); `subcommand`/`dataset`/`note` label
+/// the run; `rows` accumulates every captured measurement. Behind a `Mutex` only so
+/// the parallel benches (which call `row()` from the main thread, but via rayon
+/// pools that could in principle move it) never race — emit is not on any hot path.
+struct JsonCollector {
+    path: Option<String>,
+    subcommand: String,
+    dataset: String,
+    rows: Vec<JsonRow>,
+}
+
+static JSON: OnceLock<Mutex<JsonCollector>> = OnceLock::new();
+
+fn json_collector() -> &'static Mutex<JsonCollector> {
+    JSON.get_or_init(|| {
+        Mutex::new(JsonCollector {
+            path: None,
+            subcommand: String::new(),
+            dataset: String::new(),
+            rows: Vec::new(),
+        })
+    })
+}
+
+/// Records the run-level labels (subcommand + dataset name) once, at dispatch.
+fn json_init(subcommand: &str, dataset: &str) {
+    let mut c = json_collector().lock().unwrap();
+    c.subcommand = subcommand.to_string();
+    c.dataset = dataset.to_string();
+}
+
+/// Records the `--json <path>` destination (only set when the flag was present).
+fn json_set_path(path: &str) {
+    json_collector().lock().unwrap().path = Some(path.to_string());
+}
+
+/// Appends one captured measurement row.
+fn json_push(row: JsonRow) {
+    json_collector().lock().unwrap().rows.push(row);
+}
+
+/// Extracts a `--json <path>` flag (and its value) from the raw argv, returning the
+/// positional args WITHOUT the flag pair. The subcommands index their operands
+/// positionally (`args[2]`, `args[3]`, ...), so the flag is removed BEFORE dispatch to
+/// keep the historical positional contract intact whether the flag is present or not.
+/// A bare `--json` with no following value is a usage error (exit 2), mirroring
+/// `sparq-cli`'s identical flag.
+fn take_json_flag(args: &[String]) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
+/// Minimal JSON string escaper for the dependency-free emit — escapes the characters
+/// JSON requires (`"`, `\`, the C0 control set incl. the named whitespace escapes).
+/// Task labels are static ASCII and dataset names are file stems, so this covers the
+/// realistic input; anything else still produces valid `\uXXXX` escapes.
+fn json_str(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for c in raw.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Serialises the accumulated rows to the `--json` path, if one was given. Called
+/// once at the end of `main`. The shape mirrors `suite_results_json`: a top-level
+/// object carrying the run labels + an honest non-canonical `note`, and a `rows`
+/// array of one object per captured measurement (each row's keys are exactly the
+/// fields that subcommand measured). Writes nothing (and is a no-op) when `--json`
+/// was absent — STDOUT is the only output in that case.
+fn json_flush() {
+    let c = json_collector().lock().unwrap();
+    let Some(path) = c.path.clone() else {
+        return;
+    };
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"bench/parse parse-baseline\",\n");
+    s.push_str(&format!("  \"subcommand\": {},\n", json_str(&c.subcommand)));
+    s.push_str(&format!("  \"dataset\": {},\n", json_str(&c.dataset)));
+    s.push_str(&format!("  \"iters\": {ITERS},\n"));
+    s.push_str(
+        "  \"note\": \"median/best-of-iters wall-clock MEASURED on the running host; \
+         NON-CANONICAL (whatever this machine measured) — do not bake into committed files\",\n",
+    );
+    s.push_str("  \"rows\": [\n");
+    for (i, row) in c.rows.iter().enumerate() {
+        s.push_str("    {");
+        for (j, (k, v)) in row.iter().enumerate() {
+            if j > 0 {
+                s.push(',');
+            }
+            s.push_str(&format!(" {}: {}", json_str(k), v));
+        }
+        s.push_str(" }");
+        if i + 1 < c.rows.len() {
+            s.push(',');
+        }
+        s.push('\n');
+    }
+    s.push_str("  ]\n");
+    s.push_str("}\n");
+    if let Err(e) = std::fs::write(&path, s) {
+        eprintln!("error writing --json results to {path}: {e}");
+        std::process::exit(1);
+    }
+    eprintln!("wrote {} result rows to {path}", c.rows.len());
+}
+
 fn main() {
-    let args: Vec<String> = std::env::args().collect();
+    let argv: Vec<String> = std::env::args().collect();
+    let (args, json_path) = take_json_flag(&argv);
+    if let Some(p) = &json_path {
+        json_set_path(p);
+    }
+    // Label the run (subcommand + dataset) for the JSON emit, where a dataset path
+    // is the conventional second operand. Harmless when `--json` is absent.
+    if let Some(sub) = args.get(1) {
+        let dataset = args.get(2).map(|p| dataset_name(p)).unwrap_or("");
+        json_init(sub, dataset);
+    }
     match args.get(1).map(String::as_str) {
         Some("gen") => gen(args[2].parse().unwrap(), &args[3], &args[4]),
         Some("to-ttl") => to_ttl(&args[2], &args[3]),
@@ -55,10 +233,12 @@ fn main() {
         // Internal: load ONE path once in a fresh process, print its peak RSS.
         Some("hdt-rss") => hdt_rss(&args[2], &args[3]),
         _ => {
-            eprintln!("usage: parse-baseline gen|to-ttl|compress|bench-nt|bench-ttl|ab-ttl-intern|bench-zip|gen-hdt|bench-hdt|bench-hdt-zip ...");
+            eprintln!("usage: parse-baseline gen|to-ttl|compress|bench-nt|bench-ttl|ab-ttl-intern|bench-zip|gen-hdt|bench-hdt|bench-hdt-zip ... [--json <results.json>]");
             std::process::exit(2);
         }
     }
+    // Strictly-additive: writes the JSON document only when `--json <path>` was given.
+    json_flush();
 }
 
 // ---------------------------------------------------------------------------
@@ -79,10 +259,24 @@ fn median<F: FnMut()>(mut f: F) -> f64 {
 }
 
 /// Prints one markdown row: task, threads, seconds, input MB/s, Mtriples/s.
+///
+/// [OPUS-4.8] (sq-ghjc) Also captures the SAME measured fields for the optional
+/// `--json` emit. The push is unconditional and cheap; `json_flush` only writes a
+/// file when a `--json <path>` was given, so STDOUT is unaffected either way.
 fn row(dataset: &str, task: &str, threads: usize, secs: f64, bytes: usize, triples: usize) {
     let mbs = bytes as f64 / 1e6 / secs;
     let mts = triples as f64 / 1e6 / secs;
     println!("| {dataset} | {task} | {threads} | {secs:.3} | {mbs:.0} | {mts:.2} |");
+    json_push(vec![
+        ("dataset", json_str(dataset)),
+        ("task", json_str(task)),
+        ("threads", threads.to_string()),
+        ("secs", format!("{secs:.6}")),
+        ("bytes", bytes.to_string()),
+        ("triples", triples.to_string()),
+        ("mb_s", format!("{mbs:.3}")),
+        ("mtriples_s", format!("{mts:.3}")),
+    ]);
 }
 
 fn pool(n: usize) -> rayon::ThreadPool {
@@ -110,8 +304,12 @@ fn bench_nt(path: &str) {
     // Triple count (for triples/s) via oxttl, also validates the slice parses.
     let triples = oxttl::NTriplesParser::new()
         .for_slice(bytes)
-        .map(|r| r.expect("dataset must parse"))
-        .count();
+        // [OPUS-4.8] (sq-ghjc) fold-count keeps the parse validation (expect) while
+        // satisfying clippy::suspicious_map (map+count would warn): count + panic on error.
+        .fold(0usize, |acc, r| {
+            r.expect("dataset must parse");
+            acc + 1
+        });
     eprintln!("{name}: {} bytes, {triples} triples", bytes.len());
     println!("| dataset | task | threads | s | MB/s | Mtriples/s |");
     println!("|---|---|---|---|---|---|");
@@ -133,7 +331,7 @@ fn bench_nt(path: &str) {
 
     // oxttl, parse only (discard triples): pure parser cost, no interning/index.
     let secs = median(|| {
-        let n = oxttl::NTriplesParser::new().for_slice(bytes).map(|r| r.unwrap()).count();
+        let n = oxttl::NTriplesParser::new().for_slice(bytes).fold(0usize, |acc, r| { r.unwrap(); acc + 1 });
         black_box(n);
     });
     row(name, "oxttl NT parse-only", 1, secs, bytes.len(), triples);
@@ -281,6 +479,26 @@ fn ab_ttl_intern(path: &str) {
         "| {name} | **ratio old/new** | **{:.3}×** | | |",
         mo / mn
     );
+    // [OPUS-4.8] (sq-ghjc) Capture the intern-A/B shape (distinct from the standard
+    // `row()` columns) for the optional `--json` emit. Same measured numbers as the
+    // markdown rows above; the ratio is recorded as a single labelled row.
+    let intern_row = |strategy: &'static str, median_s: f64| -> JsonRow {
+        vec![
+            ("dataset", json_str(name)),
+            ("strategy", json_str(strategy)),
+            ("rounds", ROUNDS.to_string()),
+            ("median_s", format!("{median_s:.6}")),
+            ("mtriples_s", format!("{:.3}", n as f64 / 1e6 / median_s)),
+            ("ns_per_triple", format!("{:.3}", median_s * 1e9 / n as f64)),
+        ]
+    };
+    json_push(intern_row("OLD owned-Term intern", mo));
+    json_push(intern_row("NEW (T1) borrowed intern", mn));
+    json_push(vec![
+        ("dataset", json_str(name)),
+        ("strategy", json_str("ratio old/new")),
+        ("ratio_old_new", format!("{:.3}", mo / mn)),
+    ]);
     eprintln!(
         "intern-only A/B: OLD {mo:.4}s, NEW {mn:.4}s, speedup {:.3}× ({:.1}% of intern step removed)",
         mo / mn,
@@ -300,15 +518,19 @@ fn bench_ttl(path: &str) {
 
     let triples = oxttl::TurtleParser::new()
         .for_slice(bytes)
-        .map(|r| r.expect("dataset must parse"))
-        .count();
+        // [OPUS-4.8] (sq-ghjc) fold-count keeps the parse validation (expect) while
+        // satisfying clippy::suspicious_map (map+count would warn): count + panic on error.
+        .fold(0usize, |acc, r| {
+            r.expect("dataset must parse");
+            acc + 1
+        });
     eprintln!("{name}: {} bytes, {triples} triples", bytes.len());
     println!("| dataset | task | threads | s | MB/s | Mtriples/s |");
     println!("|---|---|---|---|---|---|");
 
     // oxttl, parse only.
     let secs = median(|| {
-        let n = oxttl::TurtleParser::new().for_slice(bytes).map(|r| r.unwrap()).count();
+        let n = oxttl::TurtleParser::new().for_slice(bytes).fold(0usize, |acc, r| { r.unwrap(); acc + 1 });
         black_box(n);
     });
     row(name, "oxttl Turtle parse-only", 1, secs, bytes.len(), triples);
@@ -359,8 +581,12 @@ fn bench_zip(path: &str) {
 
     let triples = oxttl::NTriplesParser::new()
         .for_slice(&raw)
-        .map(|r| r.expect("dataset must parse"))
-        .count();
+        // [OPUS-4.8] (sq-ghjc) fold-count keeps the parse validation (expect) while
+        // satisfying clippy::suspicious_map (map+count would warn): count + panic on error.
+        .fold(0usize, |acc, r| {
+            r.expect("dataset must parse");
+            acc + 1
+        });
     eprintln!(
         "{name}: raw {} B, gz {} B ({:.2}x), zst {} B ({:.2}x), {triples} triples",
         raw.len(),
@@ -875,5 +1101,89 @@ fn bench_hdt_zip(path: &str) {
             black_box(g.store.len());
         });
         row(name, &format!("{ext} decode+parse (direct, {ratio:.2}x compressed)"), 1, secs, plain.len(), triples);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-ghjc) --json emit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `--json <path>` is stripped from the positional argv (so the subcommands'
+    /// positional indexing is unaffected) and its value is returned; the escaper
+    /// produces RFC-valid JSON strings; and the full emit round-trips through a
+    /// real `serde_json` parse with the documented shape + keys. One test only,
+    /// because the collector is a process-global `OnceLock` (parallel tests would
+    /// race its `rows`); this drives the whole emit path end-to-end in isolation.
+    #[test]
+    fn json_flag_and_emit_round_trip() {
+        // --- flag extraction keeps positional args intact -------------------------
+        let argv: Vec<String> = ["parse-baseline", "bench-nt", "data.nt", "--json", "/tmp/out.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (positional, path) = take_json_flag(&argv);
+        assert_eq!(positional, vec!["parse-baseline", "bench-nt", "data.nt"]);
+        assert_eq!(path.as_deref(), Some("/tmp/out.json"));
+        // Absent flag -> args unchanged, no path.
+        let (p2, none) = take_json_flag(&argv[..3]);
+        assert_eq!(p2, argv[..3]);
+        assert!(none.is_none());
+
+        // --- string escaper produces valid JSON strings ---------------------------
+        assert_eq!(json_str("a\"b\\c\n"), "\"a\\\"b\\\\c\\n\"");
+        assert_eq!(json_str("plain"), "\"plain\"");
+
+        // --- full emit round-trips through serde_json -----------------------------
+        json_init("bench-nt", "data.nt");
+        let tmp = std::env::temp_dir().join(format!("sq-ghjc-emit-{}.json", std::process::id()));
+        json_set_path(tmp.to_str().unwrap());
+        // A standard table row (the `row()` shape) ...
+        json_push(vec![
+            ("dataset", json_str("data.nt")),
+            ("task", json_str("oxttl NT parse-only")),
+            ("threads", 1.to_string()),
+            ("secs", format!("{:.6}", 0.5_f64)),
+            ("bytes", 100usize.to_string()),
+            ("triples", 4usize.to_string()),
+            ("mb_s", format!("{:.3}", 0.2_f64)),
+            ("mtriples_s", format!("{:.3}", 0.008_f64)),
+        ]);
+        // ... and a heterogeneous (intern-A/B) row to prove the shape is per-row.
+        json_push(vec![
+            ("dataset", json_str("data.nt")),
+            ("strategy", json_str("ratio old/new")),
+            ("ratio_old_new", format!("{:.3}", 1.25_f64)),
+        ]);
+        json_flush();
+
+        let doc = std::fs::read_to_string(&tmp).expect("emit file written");
+        let _ = std::fs::remove_file(&tmp);
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+
+        assert_eq!(v["harness"], "bench/parse parse-baseline");
+        assert_eq!(v["subcommand"], "bench-nt");
+        assert_eq!(v["dataset"], "data.nt");
+        assert_eq!(v["iters"], ITERS);
+        assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+
+        let rows = v["rows"].as_array().expect("rows is an array");
+        assert_eq!(rows.len(), 2);
+        // Standard row keys.
+        let r0 = &rows[0];
+        assert_eq!(r0["task"], "oxttl NT parse-only");
+        assert_eq!(r0["threads"], 1);
+        assert_eq!(r0["bytes"], 100);
+        assert_eq!(r0["triples"], 4);
+        assert!(r0["secs"].is_number());
+        assert!(r0["mb_s"].is_number());
+        assert!(r0["mtriples_s"].is_number());
+        // Heterogeneous row keeps its own keys (no leakage from the table shape).
+        let r1 = &rows[1];
+        assert_eq!(r1["strategy"], "ratio old/new");
+        assert!(r1["ratio_old_new"].is_number());
+        assert!(r1.get("threads").is_none());
     }
 }

--- a/crates/sparq-text/Cargo.toml
+++ b/crates/sparq-text/Cargo.toml
@@ -72,3 +72,8 @@ unicode-segmentation = "1"
 # [OPUS-4.8] sq-8xug: rand-ecosystem 0.10. `random_range`/`random` moved from the
 # `Rng` trait to `RngExt` in 0.10, so the test/example imports use the prelude.
 rand = "0.10"
+# [OPUS-4.8] (sq-ghjc) Test-only: PARSE the dependency-free `bench_text --json` emit
+# back to assert it is valid JSON with the documented shape. The emit itself stays
+# serde-free (hand-built `format!`); serde_json is a dev-dependency so it never enters
+# the library, its dependents, or the wasm bundle (`sparq-text-wasm`).
+serde_json = "1"

--- a/crates/sparq-text/examples/bench_text.rs
+++ b/crates/sparq-text/examples/bench_text.rs
@@ -92,10 +92,114 @@ fn fixed_queries(n: usize) -> Vec<(String, String)> {
 /// sub-second; the hit-count SUM over this set is the deterministic gate).
 const QUERIES: usize = 200;
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-ghjc) --json <path> machine-readable results emit
+// ---------------------------------------------------------------------------
+//
+// Strictly-additive: a trailing `--json <path>` writes the SAME `name/count/us`
+// rows (plus the run parameters) as a stable, DEPENDENCY-FREE JSON document — the
+// hand-built `format!` convention from `crates/sparq-mpc/examples/mpc_net_bench.rs`
+// (no serde dep). STDOUT stays byte-for-byte the pure TSV the `bench/fts/run.sh`
+// gate parses whether or not the flag is present; the flag is stripped from argv
+// BEFORE the positional `[N] [seed] [iters]` parse so the gate's positional call
+// (`bench_text <N> <seed> <iters>`, no flag) is wholly unaffected.
+
+/// Extracts `--json <path>` (and its value) from argv, returning argv WITHOUT the
+/// flag pair so the positional `[N] [seed] [iters]` indexing is unchanged. A bare
+/// `--json` is a usage error (exit 2), mirroring `sparq-cli`'s identical flag.
+fn take_json_flag(args: Vec<String>) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
+/// Minimal JSON string escaper (the dependency-free emit). Workload names are static
+/// ASCII identifiers, so this covers the realistic input; anything else still yields
+/// valid `\uXXXX` escapes.
+fn json_str(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for c in raw.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Serialises the run to stable, dependency-free JSON. The `rows` array carries one
+/// object per workload with the SAME `name`/`count`/`us` fields the TSV prints; the
+/// `count` column is the DETERMINISTIC gate value (corpus-stable), while `us`/`build_us`
+/// are best-of-iters timings — ADVISORY and NON-CANONICAL (this dev box), stated in
+/// `note`. `n`/`seed`/`iters` record the corpus the document describes.
+fn results_json(
+    n: usize,
+    seed: u64,
+    iters: usize,
+    rows: &[(String, usize, f64)],
+    bytes_per_doc: usize,
+    build_us: f64,
+) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"sparq-text bench_text\",\n");
+    s.push_str(&format!("  \"n\": {n},\n"));
+    s.push_str(&format!("  \"seed\": {seed},\n"));
+    s.push_str(&format!("  \"iters\": {iters},\n"));
+    s.push_str(
+        "  \"note\": \"`count` columns are DETERMINISTIC (the bench/fts/expected.tsv gate); \
+         `us`/`build_us` are best-of-iters wall-clock MEASURED on the running host — ADVISORY, \
+         NON-CANONICAL (this dev box) — do not bake into committed files\",\n",
+    );
+    s.push_str("  \"rows\": [\n");
+    for (name, count, us) in rows.iter() {
+        // Every workload row is ALWAYS followed by the bytes_per_doc gate row below,
+        // so each gets a trailing comma; only the gate row (last) omits it.
+        s.push_str(&format!(
+            "    {{ \"name\": {}, \"count\": {count}, \"us\": {us:.1} }},\n",
+            json_str(name)
+        ));
+    }
+    // The deterministic index-footprint gate row (count = integer B/doc; us = advisory build µs).
+    // This is the LAST element of `rows`, hence no trailing comma.
+    s.push_str(&format!(
+        "    {{ \"name\": \"bytes_per_doc\", \"count\": {bytes_per_doc}, \"us\": {build_us:.1} }}\n"
+    ));
+    s.push_str("  ]\n");
+    s.push_str("}\n");
+    s
+}
+
 fn main() {
-    let n: usize = std::env::args().nth(1).and_then(|a| a.parse().ok()).unwrap_or(CORPUS_N);
-    let seed: u64 = std::env::args().nth(2).and_then(|a| a.parse().ok()).unwrap_or(CORPUS_SEED);
-    let iters: usize = std::env::args().nth(3).and_then(|a| a.parse().ok()).unwrap_or(3);
+    let (args, json_path) = take_json_flag(std::env::args().collect());
+    let n: usize = args.get(1).and_then(|a| a.parse().ok()).unwrap_or(CORPUS_N);
+    let seed: u64 = args.get(2).and_then(|a| a.parse().ok()).unwrap_or(CORPUS_SEED);
+    let iters: usize = args.get(3).and_then(|a| a.parse().ok()).unwrap_or(3);
     let iters = iters.max(1);
 
     // ---- data generation + graph load ------------------------------------------------
@@ -215,4 +319,75 @@ fn main() {
     }
     // The deterministic index-footprint gate (count = integer B/doc; us = advisory build time).
     println!("bytes_per_doc\t{bytes_per_doc}\t{build_us:.1}");
+
+    // [OPUS-4.8] (sq-ghjc) Strictly-additive JSON emit: only when `--json <path>` was
+    // given. STDOUT above is the unchanged TSV the bench/fts gate parses.
+    if let Some(path) = json_path {
+        let doc = results_json(n, seed, iters, &rows, bytes_per_doc, build_us);
+        if let Err(e) = std::fs::write(&path, doc) {
+            eprintln!("error writing --json results to {path}: {e}");
+            std::process::exit(1);
+        }
+        eprintln!("wrote {} result rows to {path}", rows.len() + 1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-ghjc) --json emit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_flag_extraction() {
+        let argv: Vec<String> = ["bench_text", "100", "0", "3", "--json", "/tmp/o.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (positional, path) = take_json_flag(argv);
+        // The positional `[N] [seed] [iters]` contract the fts gate relies on is intact.
+        assert_eq!(positional, vec!["bench_text", "100", "0", "3"]);
+        assert_eq!(path.as_deref(), Some("/tmp/o.json"));
+        // Absent flag -> argv unchanged, no path.
+        let plain: Vec<String> = ["bench_text", "100"].iter().map(|s| s.to_string()).collect();
+        let (p2, none) = take_json_flag(plain.clone());
+        assert_eq!(p2, plain);
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn json_str_escapes() {
+        assert_eq!(json_str("and_terms"), "\"and_terms\"");
+        assert_eq!(json_str("a\"b\\c\n"), "\"a\\\"b\\\\c\\n\"");
+    }
+
+    #[test]
+    fn results_json_shape_and_keys() {
+        let rows = vec![
+            ("and_terms".to_string(), 42usize, 1.5f64),
+            ("or_terms".to_string(), 99usize, 2.25f64),
+        ];
+        let doc = results_json(100, 0, 3, &rows, 64, 12.5);
+        // The dependency-free emit must round-trip through a REAL serde_json parse — this
+        // is what catches a malformed document (e.g. a missing inter-row comma).
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+        assert_eq!(v["harness"], "sparq-text bench_text");
+        assert_eq!(v["n"], 100);
+        assert_eq!(v["seed"], 0);
+        assert_eq!(v["iters"], 3);
+        assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+        let arr = v["rows"].as_array().expect("rows is an array");
+        // 2 workloads + the deterministic bytes_per_doc gate row.
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0]["name"], "and_terms");
+        assert_eq!(arr[0]["count"], 42);
+        assert!(arr[0]["us"].is_number());
+        assert_eq!(arr[1]["name"], "or_terms");
+        assert_eq!(arr[1]["count"], 99);
+        // The gate row is last and carries the integer footprint + advisory build µs.
+        assert_eq!(arr[2]["name"], "bytes_per_doc");
+        assert_eq!(arr[2]["count"], 64);
+        assert!((arr[2]["us"].as_f64().unwrap() - 12.5).abs() < 1e-9);
+    }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-ghjc** — extends the dependency-free `--json <path>` machine-readable results-emit (sq-d7d/#709 did the `sparq-cli bench`/`bench-mmap` slice) to two more STDOUT-only benchmark harnesses. Mirrors the hand-built `format!`-JSON convention from `crates/sparq-mpc/examples/mpc_net_bench.rs::cell_json` and the `suite_results_json` sq-d7d added — **no `serde` dependency enters any binary** (`serde_json` is a TEST-only dev-dep, used to parse the emit back and assert validity).

### Harnesses wired (verified on origin/main that neither had `--json`)
- **`bench/parse` (`parse-baseline`)** — every table-emitting subcommand (`bench-nt`, `bench-ttl`, `bench-zip`, `ab-ttl-intern`, `bench-hdt`, `bench-hdt-zip`) now accepts a trailing `--json <path>`. A process-global collector captures the exact rows `row()` prints (and the heterogeneous `ab-ttl-intern` shape — `strategy`/`mtriples_s`/`ns_per_triple`/`ratio_old_new`) and writes one JSON document at end of `main`.
- **`crates/sparq-text/examples/bench_text.rs`** — `--json <path>` writes the same `name`/`count`/`us` rows (the `count` column is the deterministic `bench/fts` gate value; `us`/`build_us` are advisory) plus the `n`/`seed`/`iters` run params and the `bytes_per_doc` gate row.

### JSON shape (dependency-free, NON-CANONICAL note)
Top-level object: `harness`, run labels (`subcommand`/`dataset`/`iters` for parse; `n`/`seed`/`iters` for text), an honest `note` stating the numbers are MEASURED on the running host and NON-CANONICAL, and a `rows`/`queries` array of one object per measurement. Numbers are never committed.

### STDOUT unchanged
The `--json` flag is stripped from argv **before** positional parsing, so STDOUT is byte-for-byte the same when the flag is absent. The `bench/fts/run.sh` count gate is therefore untouched — **verified: all 6 workloads still match `expected.tsv` (exit 0)**.

### Gate (all green, locally reproduced)
- `cargo build` + `cargo clippy --all-targets -D warnings` for both crates, **both feature states** for `sparq-text` (default + `--no-default-features`). Also fixed the **5 pre-existing `clippy::suspicious_map` errors** that kept `bench/parse` off `-D warnings` on `main` (no behaviour change — `fold`-count keeps the same parse-validation panic + count).
- A test per crate asserting `--json` writes valid, **`serde_json`-parseable** JSON with the documented keys (a round-trip guard against shape/serialisation regressions in the net-new emit).
- `cargo rustdoc -D warnings` clean. Privacy-claims gate: clean. No new `unsafe`.

### Compliance gap closed
Two more STDOUT-only harnesses now have a persisted, structured JSON artifact a doc can link to instead of restating frozen numbers (the sq-5vm docs-hygiene "reference the harness" convention).

### Remaining work
The other ~7 crate harnesses (`sparq-vectors` tests, `sparq-hdt`/`introspect`/`sim`/`nlq`/`rsp` examples, `sparq-wasm` perf cjs) + `bench/inference` + `bench/serve` are tracked in **sq-cxji** — deliberately deferred to keep this PR clean (the vectors ones are `cargo test` harnesses with no natural CLI args, needing a different emit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


> 🤖 SPARQ agent — note: corrected two over-stated claims from an earlier draft of this description (there were no pre-existing rustdoc `invalid_html_tags` fixes, and the round-trip test is a guard on net-new code, not a caught bug). The substantive change — additive `--json`, the 5 real `suspicious_map` fixes, dev-only `serde_json` — is unchanged and independently verified.
