### PR TITLE
docs(roadmap): mark T9 named-graph quad store DONE (sq-uls)

### DIFF
--- a/research/roadmap.md
+++ b/research/roadmap.md
@@ -118,7 +118,11 @@ reports into one prioritised design doc.
 instrument T1 and T2 are blind without. Additive — conflicts with nothing.
 
 ## T9 — SPARQL feature gaps
-- **Named graphs / GRAPH** — currently errors (`exec.rs:893`). Needs a quad store or graph-column.
+- **Named graphs / GRAPH — DONE** (sq-uls). The store is now a quad store: TriG / N-Quads /
+  JSON-LD `@graph` named graphs are preserved (`Graph::load_dataset`), `GRAPH <iri> { … }` /
+  `GRAPH ?g { … }`, `FROM` / `FROM NAMED` and `GRAPH`-block / `WITH` / `USING (NAMED)` Updates all
+  scope over them (`exec.rs` `eval_graph_named`; `update.rs`), and the RDF/JS surface exposes a
+  DatasetCore-faithful, graph-aware `match(s,p,o,g)` (JS `options.dataset` → `SparqStore.match`).
 - Property paths (`*`/`+`/`/`), SERVICE federation, remaining aggregates/expressions (the `M2:`
   markers at `exec.rs:2375/2640`). These touch `exec.rs` (conflict with T1).
 


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

`sq-uls` asked for a quad store giving an RDF/JS `DatasetCore`-faithful `match(s,p,o,g)`, because (per the bead) the store was triple-scoped — TriG/N-Quads graphs folded into the default graph, UPDATE rejecting named-graph targets.

**That work is already implemented.** Investigating the bead, the named-graph quad store landed across the stack in prior PRs (#187, #439, #447, #454, #467, #597, #598 + the JS dataset path):

- **core** — `Graph::load_dataset` preserves TriG / N-Quads / JSON-LD `@graph` named graphs; `named_graph(name)`, `for_named_graphs_with_prefix`.
- **engine exec** — `GRAPH <iri> { … }` and `GRAPH ?g { … }` evaluate via `eval_graph_named` (`exec.rs`), plus `FROM` / `FROM NAMED`.
- **UPDATE** — `GRAPH`-block `INSERT DATA` / `DELETE DATA`, `DELETE/INSERT … WHERE` with graph templates (incl. variable graph names), `WITH` / `USING (NAMED)`, `CLEAR`/`DROP GRAPH` (`update.rs`).
- **wasm** — `WasmStore.loadDataset`.
- **RDF/JS surface** — `SparqStore` (`js/src/store.ts`) exposes the DatasetCore-faithful, graph-aware `match(subject, predicate, object, graph)` and `countQuads(…)` behind `options.dataset` (wildcard graph spans default + all named graphs; `DefaultGraph`/`NamedNode`/`BlankNode` graph positions handled), all covered by `js/test/store.test.mjs`.

The bead's `js/TODO.md:20` source line was already stripped during the beads migration. The **one remaining stale artifact** was `research/roadmap.md` T9, which still claimed named graphs "currently error (`exec.rs:893`). Needs a quad store" — false (`exec.rs:893` is now `join_chunks`).

## Change

Doc-currency only: rewrite the T9 named-graph line to **DONE (sq-uls)**, pointing at the landed quad store and the DatasetCore-faithful JS `match`. **No code change** — the feature exists and is tested; shipping code here would be a no-op.

## Honesty

`sq-uls` is **already-done**. This PR closes the documentation loop rather than overclaiming a fresh implementation. The bead can be closed as completed-by-prior-work once this lands.

## Gate

Markdown-only change to a `research/` design record — no Rust code, no public API, no `unsafe`, no perf numbers. The hard `check-no-perf-numbers.py` docs gate passes (0 findings / 160 files). The Rust build/clippy/test/rustdoc gate is N/A (nothing compiles changed).

[OPUS-4.8]

🤖 Generated with [Claude Code](https://claude.com/claude-code)