### PR TITLE
feat(sparq-py): add Graph.copy() over the core snapshot API (sq-6h8) [OPUS-4.8]

### DIFF
--- a/crates/sparq-py/README.md
+++ b/crates/sparq-py/README.md
@@ -104,6 +104,11 @@ g.query_text("""
     } ORDER BY DESC(?score)
 """)                                  # text: magic predicates inside plain SPARQL
 
+# A cheap, logically-independent copy (Arc-shared structural snapshot: O(pending
+# delta), not O(triples)). The original and the copy mutate separately.
+c = g.copy()
+c.update('INSERT DATA { <http://ex/dave> <http://ex/age> 40 }')   # only c changes
+
 # Persist / reopen with memory-mapped indexes (out-of-core path).
 g.save("./mydb")
 g4 = sparq.Graph.open("./mydb")
@@ -132,4 +137,8 @@ g4 = sparq.Graph.open("./mydb")
   `text:matchesAny` an OR, `*`-suffixed tokens match as prefixes, and
   `text:score` binds the BM25 score. Hits are frozen per call: the cached index
   is invalidated by every mutating call and lazily rebuilt.
+- `copy()` returns a logically-independent graph over the core's Arc-shared
+  structural snapshot (O(pending delta), not O(triples)); mutating either the
+  original or the copy leaves the other unchanged. Named graphs are copied; the
+  copy starts with no full-text index and lazily rebuilds its own.
 - Long-running calls (load, query, update, reason, text search) release the GIL.

--- a/crates/sparq-py/src/lib.rs
+++ b/crates/sparq-py/src/lib.rs
@@ -2,7 +2,9 @@
 //!
 //! A thin, allocation-conscious wrapper over the workspace's public APIs:
 //!
-//! * `Graph` wraps `sparq_core::Graph` (load / save / open / len).
+//! * `Graph` wraps `sparq_core::Graph` (load / save / open / len). `Graph.copy`
+//!   returns a cheap, logically-independent copy over the core's structural
+//!   snapshot (Arc-shared immutable base) — O(pending delta), not O(triples).
 //! * `Graph.query` / `Graph.query_json` / `Graph.ask` / `Graph.construct` /
 //!   `Graph.describe` call `sparq_engine` (all four query forms are native:
 //!   ASK early-exits, CONSTRUCT/DESCRIBE return term triples).
@@ -610,6 +612,31 @@ impl Graph {
     fn inconsistencies(&self, py: Python<'_>) -> PyResult<Vec<String>> {
         let inner = &self.inner;
         Ok(py.detach(|| sparq_reason::inconsistencies(&inner.dict, &all_triples(inner))))
+    }
+
+    /// A cheap, logically-INDEPENDENT copy of this graph that can then be
+    /// mutated separately — `update` / `reason` / `reason_n3_with` on either the
+    /// original or the copy leave the other untouched.
+    ///
+    /// Built on the core's structural snapshot (`sparq_core::Graph::snapshot`):
+    /// the immutable base storage (the six permutation indexes, the frozen
+    /// dictionary base, the numeric caches) is `Arc`-shared, so this is
+    /// O(pending delta), NEVER O(triples) — it duplicates neither the indexes nor
+    /// the dictionary arena. (The first copy of a freshly-loaded graph pays a
+    /// one-time O(n) freeze to mint the shareable base; subsequent copies of the
+    /// frozen lineage are cheap.) Named graphs are copied too.
+    ///
+    /// The cached full-text index is NOT carried over: the copy starts without
+    /// one and lazily rebuilds on its first `text_search` / `query_text`, exactly
+    /// as a freshly loaded graph would (the same lazy-rebuild policy a mutating
+    /// swap uses). [OPUS-4.8] sq-6h8
+    fn copy(&self, py: Python<'_>) -> Graph {
+        let inner = &self.inner;
+        // `snapshot()` yields an immutable point-in-time view; `into_graph()`
+        // drops the read-only wrapper, leaving an independently-mutable `Graph`
+        // that already owns its own Arc-shared base + per-generation delta.
+        let copied = py.detach(|| inner.snapshot().into_graph());
+        Graph { inner: copied, text: None }
     }
 
     /// Number of triples in the default graph.

--- a/crates/sparq-py/tests/test_basic.py
+++ b/crates/sparq-py/tests/test_basic.py
@@ -458,5 +458,53 @@ def test_open_missing_dir(tmp_path):
         sparq.Graph.open(tmp_path / "nope")
 
 
+# --- copy -------------------------------------------------------------------
+
+
+def test_copy_is_equal_but_independent():
+    graph = g()
+    c = graph.copy()
+    assert len(c) == len(graph) == 7
+    q = "PREFIX ex: <http://ex/> SELECT ?s ?a WHERE { ?s ex:age ?a } ORDER BY ?a"
+    assert c.query_json(q) == graph.query_json(q)
+    # Mutating the copy does NOT touch the original ...
+    c.update("INSERT DATA { <http://ex/dave> <http://ex/age> 40 }")
+    assert len(c) == 8 and len(graph) == 7
+    assert not graph.ask("PREFIX ex: <http://ex/> ASK { ex:dave ex:age 40 }")
+    # ... and mutating the original after copying does NOT touch the copy.
+    graph.update("INSERT DATA { <http://ex/erin> <http://ex/age> 50 }")
+    assert len(graph) == 8 and len(c) == 8
+    assert not c.ask("PREFIX ex: <http://ex/> ASK { ex:erin ex:age 50 }")
+
+
+def test_copy_reason_independent():
+    graph = sparq.Graph.load(RDFS_DATA)
+    c = graph.copy()
+    c.reason("rdfs")
+    q = "PREFIX ex: <http://ex/> ASK { ex:rex a ex:Animal }"
+    assert c.ask(q)          # entailment materialised on the copy
+    assert not graph.ask(q)  # original untouched by the copy's reasoning
+
+
+def test_copy_preserves_named_graphs():
+    nq = (
+        "<http://ex/a> <http://ex/p> <http://ex/b> .\n"
+        "<http://ex/c> <http://ex/p> <http://ex/d> <http://ex/g1> .\n"
+    )
+    graph = sparq.Graph.load(nq, format="nquads")
+    c = graph.copy()
+    assert len(c) == 1  # default graph
+    assert c.ask("ASK { GRAPH <http://ex/g1> { <http://ex/c> <http://ex/p> <http://ex/d> } }")
+
+
+def test_copy_has_fresh_text_index():
+    graph = g()
+    graph.build_text_index()           # force the original's index to exist
+    c = graph.copy()
+    # The copy lazily builds its own index; text search works on it independently.
+    hits = c.text_search("alic*")
+    assert any(h[0].value == "Alice" for h in hits)
+
+
 def test_version():
     assert isinstance(sparq.__version__, str) and sparq.__version__

--- a/skills/python/SKILL.md
+++ b/skills/python/SKILL.md
@@ -61,6 +61,7 @@ All on the `sparq.Graph` class (the only entry point). Constructors are static m
 - `g.text_search(query, any=False, limit=None) -> list[(Term, float)]` — BM25 search over the default graph's string literals; best-first `(literal Term, score)`. AND of tokens by default; `any=True` is OR; `*`-suffix token = prefix match; `limit` keeps top-n.
 - `g.query_text(sparql) -> QueryResult` — SELECT that may use `text:` magic predicates (see recipe below).
 - `g.build_text_index() -> int` / `g.drop_text_index() -> None` — eagerly build (returns indexed-literal count) / free the cached full-text index.
+- `g.copy() -> Graph` — a cheap, logically-independent copy (over the core's Arc-shared structural snapshot, O(pending delta), not O(triples)); the original and the copy can then be mutated separately (`update`/`reason`/`reason_n3_with` on one leaves the other untouched). Named graphs are copied; the copy lazily rebuilds its own full-text index.
 - `len(g)` — default-graph triple count; `repr(g)` → `"Graph(N triples)"`.
 
 `QueryResult`: `.vars: list[str]`, `.rows: list[dict[str, Term]]`, plus `len(res)`, `res[i]` (negative indices/slices ok), and iteration.


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

Adds `sparq.Graph.copy()` to the Python bindings — a cheap, logically-independent copy of a `Graph`, closing **sq-6h8**.

`Dict`/`Graph` are not `Clone`, so a naive deep copy is O(n). The designed fix was the cheap-snapshot core API (**sq-3p1**, now closed). `Graph.copy()` is built on it:

```python
c = g.copy()
c.update('INSERT DATA { <http://ex/dave> <http://ex/age> 40 }')   # only c changes; g is untouched
```

## How

`copy()` calls `sparq_core::Graph::snapshot().into_graph()`:

- The immutable base storage (the six permutation indexes, the frozen dictionary base, the numeric caches) is **`Arc`-shared**, so the copy is **O(pending delta), never O(triples)** — it duplicates neither the indexes nor the dictionary arena. (The first copy of a freshly-loaded graph pays a one-time O(n) freeze to mint the shareable base; later copies of the frozen lineage are cheap.)
- The original and the copy then mutate **independently** — `update` / `reason` / `reason_n3_with` on one leaves the other untouched.
- **Named graphs** are copied. The copy starts with **no full-text index** and lazily rebuilds its own on first `text_search` / `query_text`, matching the existing mutating-swap invalidation policy.
- The snapshot runs under `py.detach` (GIL released).

## Tests

`crates/sparq-py/tests/test_basic.py` (4 new):

- `test_copy_is_equal_but_independent` — copy is value-equal; mutating either the copy or the original after copying leaves the other unchanged.
- `test_copy_reason_independent` — reasoning on the copy entails on the copy but not on the original.
- `test_copy_preserves_named_graphs` — named graphs survive the copy.
- `test_copy_has_fresh_text_index` — the copy builds its own full-text index.

All 84 Python tests pass (`test_basic.py` + `test_parity.py` + `test_text.py`), built via `maturin develop`.

## Gate

- `cargo build -p sparq-py` — clean
- `cargo clippy -p sparq-py --all-targets -- -D warnings` — clean
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` — clean (and again with `--all-features`)
- G2 public-api→SKILL (`gate-api-skill.py`) — PASS; README + `skills/python/SKILL.md` updated for the maintenance rule
- privacy-claims (`check-privacy-claims.sh`) — OK
- The crate has no Cargo features and no `unsafe` (`#![forbid(unsafe_code)]`), so the both-feature-states / unsafe-register gates are N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)