### PR TITLE
test(sparq-engine): pin bound-endpoint zero-length + NegatedPropertySet full-scan avoidance (sq-5kr) [OPUS-4.8]

### DIFF
--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -9873,6 +9873,41 @@ mod path_pushdown_tests {
         }
     }
 
+    /// [OPUS-4.8] (sq-5kr) Pin the bound-endpoint shortcuts that AVOID the
+    /// full-store scans: `p*`/`p?` over a bound endpoint must emit ITS reflexive
+    /// pair (not the whole `graph_nodes()` domain), and a bound-endpoint `!(...)`
+    /// must return only that node's non-excluded edges from the narrowed scan.
+    /// The load-bearing case is a CONSTANT endpoint absent from the data
+    /// (`:z`, which occurs in no triple): the zero-length rules still bind
+    /// `<z> p* <z>` / `<z> p? <z>`, whereas a reflexive pass over `graph_nodes()`
+    /// would never see `:z` and would WRONGLY drop the solution — so this guards
+    /// against a regression to the old domain-scan reflexive logic.
+    #[test]
+    fn bound_endpoint_zero_length_and_negated_avoid_full_store_scan() {
+        // :a -e-> :b ; :a -f-> :c .  :z occurs in NO triple.
+        let g = Graph::load_str("@prefix : <http://ex/> .\n:a :e :b . :a :f :c .\n", "turtle").unwrap();
+        let rows = |sparql: &str| rowset(&crate::query(&g, &format!("{PFX}{sparql}")).unwrap());
+        let ask = |sparql: &str| !crate::query(&g, &format!("{PFX}{sparql}")).unwrap().rows.is_empty();
+        let want = |items: &[&str]| {
+            let mut v: Vec<String> = items.iter().map(|s| s.to_string()).collect();
+            v.sort();
+            v.dedup();
+            v
+        };
+
+        // Bound-subject `p*`: reflexive self + the one `:e` hop (NOT the node domain).
+        assert_eq!(rows("SELECT ?y WHERE { :a :e* ?y }"), want(&["<http://ex/a>", "<http://ex/b>"]));
+        // Bound-subject `p?`: reflexive self + the one `:e` hop.
+        assert_eq!(rows("SELECT ?y WHERE { :a :e? ?y }"), want(&["<http://ex/a>", "<http://ex/b>"]));
+        // Constant endpoint ABSENT from the data still has its zero-length self-pair.
+        assert_eq!(rows("SELECT ?y WHERE { :z :e* ?y }"), want(&["<http://ex/z>"]));
+        assert!(ask("ASK WHERE { :z :e? :z }"), "absent-term :z must satisfy its own :e? self-pair");
+        // Bound-subject negated set: only :a's non-:e edges (the :f hop), narrowed scan.
+        assert_eq!(rows("SELECT ?y WHERE { :a !:e ?y }"), want(&["<http://ex/c>"]));
+        // Bound-OBJECT negated set: subjects reaching :c via a non-:e predicate (:a -f-> :c).
+        assert_eq!(rows("SELECT ?x WHERE { ?x !:e :c }"), want(&["<http://ex/a>"]));
+    }
+
     /// The row budget must fire INSIDE a single-source traversal (not only
     /// between traversal roots): one long chain, one start node, tiny budget.
     #[test]

--- a/research/property-paths-assessment.md
+++ b/research/property-paths-assessment.md
@@ -1,10 +1,28 @@
 # SPARQL 1.1 property-path support — assessment
 
-Date: 2026-06-12. Scope: `crates/sparq-engine` (algebra from `spargebra`, execution in `exec.rs`). Read-only code review; no builds run.
+Date: 2026-06-12 (original review). Scope: `crates/sparq-engine` (algebra from `spargebra`, execution in `exec.rs`).
+
+> **Update (2026-06-12, commit `47d43294` "perf(engine): push bound endpoints into
+> property-path evaluation"):** the three ranked performance improvements at the end
+> of this document have since LANDED. Bound endpoints are now pushed into a
+> single-source directed traversal (`directed_reach`), `?x p+ ?x` resolves via SCC
+> (`cyclic_nodes`) rather than the all-pairs closure, the budget is checked *inside*
+> the traversal, and the full-store scans for the zero-length node domain /
+> `NegatedPropertySet` are avoided when an endpoint is bound — `p*`/`p?` emit only the
+> bound node's reflexive pair, and `!(...)` skips excluded predicate blocks wholesale
+> on the P-sorted permutation. **Sections 1–4 describe the PRE-optimisation code; their
+> line numbers are stale** and they are retained as the design record. §5 summarises the
+> behaviour as shipped. (sq-5kr, [OPUS-4.8])
 
 ## Verdict
 
-**COMPLETE (semantics) / PARTIAL (performance)** — every SPARQL 1.1 path operator is evaluated natively and the W3C `sparql11/property-path` suite passes 33/33, but evaluation always materialises the path's *entire* (start,end) relation before applying bound endpoints, so bound-endpoint recursive paths (`:alice :knows+ ?x`) cost the same as fully-unbound ones: a whole-graph transitive closure.
+**COMPLETE (semantics) / COMPLETE (bound-endpoint performance, since `47d43294`)** —
+every SPARQL 1.1 path operator is evaluated natively and the W3C
+`sparql11/property-path` suite passes 33/33. At the time of the original review,
+evaluation always materialised the path's *entire* (start,end) relation before
+applying bound endpoints, so bound-endpoint recursive paths (`:alice :knows+ ?x`) cost
+the same as fully-unbound ones: a whole-graph transitive closure. That pathology has
+since been fixed — see the update note above and §5.
 
 ## 1. Per-operator status
 
@@ -52,8 +70,48 @@ For `?x :knows+ ?y` — or, critically, even `:alice :knows+ ?x` — on a graph 
 
 The budget guard (max-rows/deadline) converts the blow-up into an error/truncation when limits are installed, but does not make bound-endpoint queries fast.
 
-## Highest-value improvements (ranked)
+## 5. Current behaviour (as shipped, commit `47d43294`)
 
-1. **Push bound endpoints into a directed traversal** for `+`/`*`/`?` (and recursively through `Reverse`/`Sequence`/`Alternative`): single-source BFS over `[Some(s), Some(pid), None]` range scans (or reverse via OPS for a bound object), with the existing visited-set for cycles. Turns the dominant `:s p+ ?x` case from `O(V·E)` all-pairs into `O(E_reachable)`. The TODO comment at exec.rs:1928–1933 already anticipates this. *Difficulty: medium* — `eval_path` must hand endpoint context into `path_pairs` (signature change + per-operator bound-propagation rules), but the store API already supports the needed scans.
-2. **Lazy/streaming closure with early termination for both-bound and same-variable cases** (`:a p+ :b` as reachability test that stops on hit; `?x p+ ?x` as per-SCC cycle detection) plus per-start budget checks *inside* the BFS loop (currently checked only once per start node at exec.rs:2132, so a single huge BFS can overshoot the budget). *Difficulty: low–medium* — local changes to `transitive_closure_pairs` and the budget placement.
-3. **Avoid full-store scans for the zero-length node domain and NegatedPropertySet**: when an endpoint is bound, `p*`/`p?` need only that node's reflexive pair, not `graph_nodes()` over the whole store; `!(...)` can iterate predicate ranges of the P-sorted permutation and skip excluded predicate blocks wholesale instead of filtering every triple. *Difficulty: low* — both are localised to `path_pairs`/`graph_nodes`, with conformance tests as the safety net.
+All three improvements that the original review ranked below have LANDED; the
+pathology in §4 no longer applies to bound-endpoint queries. Code anchors are
+functions (not line numbers) so they stay valid as the file moves:
+
+- **Bound endpoints pushed into a directed traversal** (was ranked #1). `eval_path`
+  hands a `PathEnds { s, o }` hint into `path_pairs`, which for `+`/`*`/`?` (and,
+  recursively, through `Reverse`/`Sequence`/`Alternative`) runs `directed_reach`: a
+  single-source, budget-checked BFS whose frontier expansion is a sorted range scan
+  (`[Some(s), Some(pid), None]` forward, `[None, Some(pid), Some(o)]` reverse for a
+  bound object). The both-bound case is a reachability TEST that stops on hit. Turns
+  the dominant `:s p+ ?x` case from `O(V·E)` all-pairs into `O(E_reachable)`. The
+  contract on `PathEnds` makes the pushdown a pure optimisation: a sub-evaluation may
+  ignore the hint and return extra pairs, and `eval_path` post-filters as the
+  correctness backstop.
+- **Early termination + per-SCC same-variable case + in-traversal budget** (was
+  ranked #2). `?x p+ ?x` resolves via Kosaraju SCC (`cyclic_nodes`, `O(V+E)`) rather
+  than the all-pairs closure; the zero-length operators' diagonal is exactly the node
+  domain. The row/deadline budget is now checked *inside* `directed_reach` (every 1024
+  pops), so a single runaway traversal respects it promptly — pinned by
+  `budget_fires_inside_directed_traversal`.
+- **No full-store scans for the zero-length node domain / `NegatedPropertySet`** (was
+  ranked #3, this bead — sq-5kr). `path_pairs` emits only the bound node's reflexive
+  pair for `p*`/`p?` (the `graph_nodes()` whole-store scan now runs *only* for a
+  genuinely both-unbound `*`/`?`, where the answer truly IS the whole node domain, and
+  for the `?x p*/p? ?x` diagonal). `negated_property_pairs` narrows to the bound
+  endpoint's triples when one end is bound, and for the both-unbound case walks the
+  P-leading permutation (`scan_sorted(&[None,None,None], 1)`) and skips each excluded
+  predicate's contiguous block wholesale via `partition_point`, instead of a
+  `[None,None,None]` scan that probes the excluded set per triple.
+
+Regression coverage lives in `mod path_pushdown_tests` (and `mod path_tests`) in
+`exec.rs`:
+`pushdown_matches_full_closure_for_all_operators_and_binding_shapes` (every operator,
+incl. `:e*`/`:e?`/`!:e`/`!(:e|:f)`, against the full-closure oracle for subject-bound,
+object-bound, both-bound and same-variable shapes) and
+`negated_property_set_matches_filter_oracle` (the block-skip scan vs a plain
+scan + predicate `FILTER`).
+
+## Remaining (out of scope here)
+
+The both-unbound recursive case is still the spec-correct eager all-pairs closure
+(§4 still applies when NEITHER endpoint is bound) — a streaming/lazy both-unbound
+closure remains a possible future improvement, but is a separate, larger change.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead `sq-5kr` (sparq-engine: avoid full-store scans for the zero-length path domain + NegatedPropertySet). [OPUS-4.8]

## Honest status: the engine change already shipped

The optimisation `sq-5kr` describes — when an endpoint is bound, `p*`/`p?` need only that node's reflexive pair (not a whole-store `graph_nodes()` scan) and `!(...)` can skip excluded-predicate blocks wholesale instead of filtering every triple — **already landed** in commit `47d43294` ("perf(engine): push bound endpoints into property-path evaluation", 2026-06-12), which is an ancestor of `main` and predates this bead's creation (2026-06-13). The bead was filed from a markdown TODO (`research/property-paths-assessment.md`) that was already obsolete.

Concretely, on `main` today:
- `path_pairs` (`crates/sparq-engine/src/exec.rs`) emits only the bound node's reflexive pair for `ZeroOrMore`/`ZeroOrOne`; `graph_nodes()` runs **only** for the genuinely both-unbound `*`/`?` and the `?x p*/p? ?x` diagonal (where the answer truly *is* the node domain).
- `negated_property_pairs` narrows the scan to a bound endpoint's triples when one end is bound, and for the both-unbound case walks the P-leading permutation (`scan_sorted(&[None,None,None], 1)`), skipping each excluded predicate's contiguous block via `partition_point` — no per-triple set probe over the excluded mass.

Shipping a no-op engine change would be dishonest overclaiming, so this PR does **the work that actually remains** and that the bead itself names ("now beaded + to be stripped from the doc"):

## What this PR does

1. **Regression test** `bound_endpoint_zero_length_and_negated_avoid_full_store_scan` (`exec.rs`, `mod path_pushdown_tests`). The load-bearing case is a **constant endpoint absent from the data** (`:z`, in no triple): `<z> p*` / `<z> p?` must still bind `:z` to itself via the zero-length rules, whereas a reflexive pass over `graph_nodes()` would never see `:z` and would wrongly drop the solution — so the test would FAIL if anyone regressed to the old domain-scan reflexive logic. It also pins bound-subject and bound-object `!(...)`. Complements the existing `pushdown_matches_full_closure_for_all_operators_and_binding_shapes` and `negated_property_set_matches_filter_oracle` oracle tests.
2. **Doc reconciliation** (`research/property-paths-assessment.md`): records that the three ranked improvements have landed (a dated update note + a new §5 "Current behaviour as shipped" with function-anchored, line-number-free references), and **strips the now-complete improvement #3**. The pre-optimisation §§1–4 are kept as the design record, flagged as stale-line-numbered. No hard-coded performance numbers.

## Gate

- `cargo clippy -p sparq-engine --all-targets -- -D warnings` — clean in **both** feature states (default + `--no-default-features`).
- `cargo test -p sparq-engine --lib` — **199 passed, 0 failed**; new test passes in both feature states.
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` — clean for **default** and **`--all-features`**.
- No public API changed (private test module + a `research/` doc only) → G2 SKILL.md rule N/A. No `unsafe` added → unsafe-gate N/A. No privacy-claim surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
