### PR TITLE
docs(research): MPC untrusted-planner → routing seam design (sq-pwr) [OPUS-4.8]

### DIFF
--- a/research/mpc-untrusted-planner-routing-design.md
+++ b/research/mpc-untrusted-planner-routing-design.md
@@ -1,0 +1,383 @@
+<!-- [OPUS-4.8] The untrusted-planner → MPC-routing seam: how sparq-fedplan source
+selection + a disclosed/hidden partition feed the sparq-mpc pipeline WITHOUT the
+cryptographic layer trusting the plan for soundness. Design-for-review (no code), Opus 4.8
+(Fable unavailable) — re-review when Fable returns. Date: 2026-06-19. Bead sq-pwr / sq-0jsc. -->
+
+# The untrusted-planner → MPC-routing seam (federated source selection + disclosed/hidden partition)
+
+**Status:** Deep-research design record (no implementation; doc-only — a PROPOSAL for the
+maintainer, not a fait accompli). Author: Opus 4.8 (Fable unavailable — flag for re-review).
+Date: 2026-06-19. Parent epics: **sq-pwr** (MPC over federated SPARQL with ZKP of correctness
++ attested-source derivation), **sq-0jsc** (MPC research track).
+
+**The one-paragraph thesis.** The MPC estate already has a *hand-built* per-query routing
+record — `sparq-mpc::pipeline::FederatedQuery` / `Routing` / `OperatorRouting` — whose own
+docstrings call it *"the (untrusted, §4.1) planner's output, made into typed data."* But there
+is **no planner that produces it**: it is constructed by hand for the four-flatmates demo, and
+the mature cost-based federation planner (`sparq-fedplan`: `select_sources`, `plan_bgp`,
+`SourceDescriptor`) has **zero** knowledge of MPC, while `sparq-mpc` has zero reference to
+`sparq-fedplan`. This record fills the seam between them: an **untrusted** planner that
+(a) selects which sources hold which patterns, and (b) partitions every operator into a
+*disclosed* (recompute-in-the-clear) vs *hidden* (run-in-MPC) route — feeding the existing
+`OperatorRouting` — while the cryptographic layer trusts the plan for **neither soundness nor
+the leakage bound**. It surveys the relational-MPC planning line (Conclave / Senate / SMCQL /
+Secrecy / ORQ) that already solved the cleartext/secure split for SQL, maps it onto sparq's
+RDF-specific conventions (global-IRI join keys, no-proof-of-revealed-properties), and recommends
+a **new opt-in glue crate** `sparq-fedplan-mpc` rather than coupling either existing crate.
+
+---
+
+## 1. Why this is a gap (the inventory, honest)
+
+The MPC/ZK estate under `research/` is large and current. Before proposing anything, the
+relevant existing records and what each *does* cover:
+
+- [`mpc-zkp-research-and-architecture.md`](./mpc-zkp-research-and-architecture.md) — the
+  four-guarantee framing, the six-step protocol flow, and §4.1's explicit decision to treat
+  the **planner / coordinator as UNTRUSTED** ("its plan is an input the cryptographic layer
+  must not have to trust for soundness"). It *names* the stance but does not specify the
+  planning **algorithm**, the source-selection step, or how the untrusted plan is reconciled
+  with leakage.
+- [`mpc-sparql-capability-matrix.md`](./mpc-sparql-capability-matrix.md) — the per-operator ×
+  per-configuration capability tiers and the disclosed/hidden two-regime split (its §1.3). It
+  resolves *what each operator costs* in MPC, not *who decides which regime each operator takes
+  for a given query over a given set of sources*.
+- [`mpc-security-models-and-benchmarks.md`](./mpc-security-models-and-benchmarks.md) — cites
+  the relational-MPC planning line (Conclave hybrid MPC+cleartext, Senate's
+  party-subset decomposition planner, SMCQL split-execution) as **lessons for sparq's
+  planner**, and §6.1 explicitly calls decomposition+planning "directly relevant to sparq's
+  untrusted-planner stance." It catalogues the prior art but stops at "lessons" — it does not
+  turn them into a sparq planning design.
+- [`federation-client-design.md`](./federation-client-design.md) — the full `sparq-fedclient`
+  design (capability discovery, source-type abstraction, cost-based pushdown, streaming
+  operators). Its only mentions of MPC/ZK are a disclaimer (the ZK/MPC estate is "irrelevant"
+  to the federation measurement) and listing `sparq-mpc` as a sibling opt-in crate. **It is
+  deliberately MPC-agnostic.**
+- [`feature-research-federation.md`](./feature-research-federation.md) — flags exactly this
+  seam as undecided: item **Z1** ("privacy-preserving federation — combine the federation
+  client with `sparq-mpc`/`sparq-zk`", impact 5, effort Large, `ambiguous-ask-user`), item
+  **B7** (access-control-aware source skipping, "the natural seam for sparq's ZK/MPC privacy
+  track"), and **Z2** (char-set-driven source selection). All three are marked needing a
+  maintainer decision; **none has a design record.**
+
+**Code ground truth (verified against `main`, 2026-06-19):**
+
+- `sparq-mpc` has **no** dependency on, or reference to, `sparq-fedplan` or `sparq-fedclient`
+  (`grep` for `sparq_fedplan` / `sparq_fedclient` in `crates/sparq-mpc/` returns nothing).
+- `sparq-mpc::pipeline::FederatedQuery` is documented as the untrusted planner's output, but is
+  hand-constructed per call; `Routing { Disclosed | Hidden(OperatorClass) }` and
+  `OperatorRouting { operator, routing }` exist and are surfaced in `FederatedResponse::routing`
+  for auditability — but **the routing is chosen by the caller**, with no algorithm deriving it.
+- `sparq-fedplan` exposes `select_sources(bgp, &[SourceDescriptor]) -> Vec<PatternSources>`,
+  `plan_bgp(...)` (cost-based join-tree planning), and `SourceDescriptor` (predicate/class/
+  char-set partitions, `may_hold_authority`, `star_cardinality`) — a complete classic federated
+  source-selection + join-ordering surface, with **no awareness** that a pattern might be
+  private or that an operator might need to run under MPC.
+
+So the seam is real, code-grounded, and the brief's flagged "federation-pushdown-under-MPC
+question" lands here. **This is a genuine uncovered gap**, not a re-derivation. Everything the
+existing records cover (the operator costs, the security taxonomy, the attestation interim) is
+*downstream* of a routing decision that nothing currently makes.
+
+---
+
+## 2. Problem framing
+
+### 2.1 What the seam must produce
+
+Given a federated SPARQL query `Q`, a fresh verifier challenge `N`, and a set of holder sources
+each with a `SourceDescriptor` plus a *privacy descriptor* (which predicates/columns are
+private), produce a **typed plan** that the existing `sparq-mpc` pipeline can consume:
+
+1. **Source selection** — for each triple pattern, which sources can answer it (the classic
+   `select_sources` job), restricted by what each source is *willing and authorised* to expose.
+2. **A per-operator routing** — the `Vec<OperatorRouting>` the pipeline already accepts: each
+   operator tagged `Disclosed` (verifier/holder recomputes in the clear) or
+   `Hidden(OperatorClass)` (runs under MPC). This is the load-bearing RQ2a "disclosure
+   minimisation" decision (architecture §4.3 step 3), today made by hand.
+3. **A declared leakage envelope** — the set of facts the chosen routing reveals (join keys,
+   result cardinality, which-source-contributed, etc.), so the relying party can *see and
+   accept* the cost-vs-leakage trade before the query runs (the Conclave lesson: a leak-for-
+   speed choice must be a **declared bounded leak**, never an implicit one).
+
+### 2.2 The two hard constraints the planner must respect
+
+- **C-A — the plan is UNTRUSTED for soundness.** The cryptographic layer must verify the result
+  is correct *regardless of whether the plan was honest*. A malicious or buggy planner that
+  drops a source, mis-orders a join, or mis-routes an operator must at worst produce a
+  **wrong-but-rejected** or **less-private-but-still-correct** answer — never a *forged-accepted*
+  one. (Architecture §4.1; the `pipeline` already re-checks the disclosed-key join independently
+  and anchors on a differential-vs-union-store test, so the mechanism exists single-query — the
+  gap is generalising it to arbitrary planner output.)
+- **C-B — the plan is ALSO untrusted for the leakage bound, but here trust is unavoidable in
+  part.** Routing an operator `Disclosed` *reveals* its operands; a dishonest planner can leak
+  more by over-disclosing. Soundness (C-A) is unaffected, but *confidentiality* is. The honest
+  resolution: the **disclosure decision is the holders' / verifier's to make and ratify, not the
+  planner's to impose.** The planner *proposes* a routing + its leakage envelope; each holder
+  **independently re-derives** whether the proposed `Disclosed` route for its own data is
+  consistent with its private-column policy, and **refuses** (fail-closed) if the plan tries to
+  disclose something the holder marked private. The verifier sees the declared envelope and can
+  reject a plan that leaks more than its policy allows.
+
+These two constraints are *the* reason this cannot be folded into `sparq-fedplan` (which assumes
+a trusted local cost model) nor into `sparq-mpc` (which should stay a primitive/protocol crate,
+not a query optimiser). It is genuinely a third concern.
+
+---
+
+## 3. Prior art (what the relational-MPC line already solved)
+
+The cleartext/secure split for *SQL* analytics is a mature line. sparq's contribution is the
+RDF/SPARQL-specific reframing (global-IRI join keys, no-proof-of-revealed-properties,
+attested sources) — **not** the split idea itself, which it should borrow honestly.
+
+- **SMCQL (PVLDB'17)** — the original *split-execution* idea: a query is partitioned into a
+  public slice run in plaintext and a secure slice run in MPC, with a **"split" annotation**
+  deciding the boundary. This is exactly sparq's convention #4 (no-proof-of-revealed-
+  properties) and exactly the `Routing::{Disclosed, Hidden}` enum — but SMCQL's split is
+  schema-annotation-driven and 2-party. The lesson sparq inherits: **the disclosed/hidden
+  boundary is a first-class, declared annotation, not an optimiser side-effect.**
+- **Conclave (EuroSys'19)** — N-party semi-honest *hybrid MPC+cleartext*; its planner inserts
+  **STP (selective trusted party) / hybrid annotations** that trade a *quantified* leak for an
+  order-of-magnitude speedup, and it pushes as much work as possible into cleartext at the
+  edges. The lesson: leakage-for-speed is real and worth it, but **must be a DECLARED bounded
+  leak** the data owners ratify — this is sparq's §2.1(3) leakage envelope.
+- **Senate (USENIX'21)** — N-party *maliciously* secure; its planner **decomposes** the
+  computation so sub-circuits run on **party-subsets in parallel**, and it is the standout
+  evidence that malicious N-party relational analytics is tractable *because of* planning, not
+  despite it. The lesson directly relevant to sparq's untrusted-planner stance: decomposition is
+  the scaling lever, and a *maliciously-secure* protocol tolerates an adversarial planner by
+  construction.
+- **Secrecy (NSDI'23) / ORQ (SOSP'25)** — the oblivious-operator cost model and join-aggregate
+  fusion. ORQ is the honest performance anchor for "even SOTA relational MPC is minutes-to-tens-
+  of-minutes per query on LAN; joins are the cost center." The planner's job is to keep work OUT
+  of MPC precisely because the secure path is this expensive.
+- **Cerebro (USENIX'21)** — contributes *compute/release policies* + cryptographic auditing
+  (accountability) — the model for sparq's **per-holder private-column policy** that gates what
+  a plan is allowed to disclose (the C-B fail-closed check).
+- **Federated-SPARQL planners (non-crypto): FedX, CostFed, ANAPSID, FedUP (WWW'24).** The
+  source-selection + decomposition + join-ordering pipeline sparq's classic planner already
+  implements. FedUP's *result-aware* plans (provenance over quotient summaries) are the lever to
+  **minimise the source-combination blow-up before any MPC is invoked** — the single most
+  valuable pre-MPC optimisation, because every extra source candidate multiplies the secure-join
+  cost.
+
+**Honest gap in the prior art:** all of the above are SQL/relational with a *trusted* query
+compiler. None binds the split decision to (a) RDF global-IRI join keys as the crypto-free join
+substrate, (b) per-source *issuer attestation* of the inputs, or (c) an explicitly **untrusted**
+planner whose output the crypto layer re-validates. That triple is the sparq-specific design
+work below — and it is integration of known parts, **not** a new cryptographic primitive.
+
+---
+
+## 4. Proposed design
+
+### 4.1 A new opt-in glue crate: `sparq-fedplan-mpc`
+
+The seam is its own concern (§2.2), so it gets its own opt-in member rather than coupling the
+two existing crates (consistent with the project's opt-in-feature-architecture rule: core stays
+lean; each new capability is its own crate/feature). It depends on `sparq-fedplan` (for
+`select_sources` / `SourceDescriptor` / `plan_bgp`) and on `sparq-mpc` (for `Routing` /
+`OperatorClass` / `OperatorRouting` / `FederatedQuery`), and produces the typed plan the
+`sparq-mpc::pipeline` already consumes. Neither existing crate gains an MPC↔federation
+dependency; both stay independently usable. The crate is **off by default** (a `fedplan-mpc`
+cargo feature); nothing in the lean core path changes.
+
+**Why not extend `sparq-fedplan`?** Its cost model is local and *trusted*; bolting an untrusted-
+plan-validation and a privacy-policy gate onto it would muddy a clean planner. **Why not extend
+`sparq-mpc`?** That crate is the protocol/primitive layer; a query optimiser does not belong in
+it. The glue is a genuinely separate, smaller concern.
+
+### 4.2 The privacy descriptor (the new input)
+
+`sparq-fedplan::SourceDescriptor` describes a source's *content* (predicates, classes,
+char-sets, authorities). The seam needs an orthogonal **privacy descriptor** per source:
+
+- **Private predicate/column set** — which terms must NEVER leave the source in the clear (the
+  flatmate salary). Default-deny is the safe posture: a term is disclosable only if the source
+  explicitly marks it public (global-IRI facts are public by convention #6).
+- **Attestation key id** — the issuer key the source's graph is signed under, collected into the
+  disclosed key-set `K` (the `Flatmate::issuer_key` field already models this as an opaque id at
+  the current tier; the attestation half stays gated on ZK-remediation #3 and the audits).
+- **Authorisation / willingness** — whether the source will participate at all for this
+  verifier (the B7 access-control-aware-source-skipping hook; SAFE-style). Out of scope to fully
+  design here, but the descriptor reserves the field.
+
+This descriptor is **the source's own declaration** — the planner reads it but the source
+re-enforces it (C-B fail-closed), so a lying planner cannot override it.
+
+### 4.3 The routing algorithm (proposed, three passes)
+
+A planner pass over the SPARQL algebra producing `Vec<OperatorRouting>` + a leakage envelope:
+
+1. **Source selection (reuse).** Run `sparq-fedplan::select_sources` to get per-pattern
+   candidate sources, then prune by the privacy/authorisation descriptor (a source that won't
+   participate, or can't legally answer, drops out). FedUP-style result-aware pruning here is
+   the highest-leverage pre-MPC win (§3) — fewer source combinations, less secure work.
+2. **Disclosed/hidden partition (the core decision).** For each operator, apply convention #4
+   greedily: **route `Disclosed` if every operand is a global IRI or a source-declared-public
+   term** (verifier/holder recomputes in the clear — crypto-free); **route `Hidden(class)`
+   otherwise**, tagging the `OperatorClass` so the pipeline reads off the per-operator security
+   tier. The £100k threshold is the canonical `Hidden(Comparison)`; the membership join on the
+   flat IRI is the canonical `Disclosed`. This is the decision `pipeline.rs` makes by hand
+   today; the pass derives it from the descriptors.
+3. **Leakage-envelope assembly + ratification.** Collect what every `Disclosed` route reveals
+   (operands, cardinalities, source-attribution) into a declared envelope. Each holder
+   **independently re-checks** that the proposed `Disclosed` routes for *its own* data are
+   consistent with its private-column policy and **aborts (fail-closed)** otherwise; the
+   verifier checks the envelope against its acceptance policy. Only a plan that survives both
+   ratifications is executed.
+
+The output is exactly the `FederatedQuery` + `Vec<OperatorRouting>` the pipeline consumes — so
+this design *produces* the structure the pipeline today *receives by hand*, with no change to the
+downstream MPC protocol.
+
+### 4.4 How the two trust constraints are discharged
+
+- **C-A (soundness under an untrusted plan).** Unchanged from the architecture's stance and the
+  pipeline's existing mechanism: the disclosed-key join independently re-checks the join key, and
+  the differential-vs-union-store anchor catches a wrong result. The proposed generalisation: the
+  *eventual* collaborative proof (the gated, audit-pending step — `proof.rs` is honestly a
+  `NotYetImplemented` stub) binds the result to `Eval_PAG(Q, D)` over the *actual* sources, so a
+  plan that drops or mis-routes a source yields a proof that fails to verify, not a forged accept.
+  **Until that proof lands and is audited, the soundness claim is NOT met** — see §6.
+- **C-B (leakage under an untrusted plan).** Discharged by the §4.3-pass-3 dual ratification:
+  the disclosure decision belongs to the data owners and the verifier, not the planner. A
+  dishonest planner can at most propose an over-disclosing route, which a holder's fail-closed
+  policy check rejects before any secret leaves the source.
+
+### 4.5 Worked example (the four-flatmates query, end to end through the seam)
+
+- **Sources:** four holders, each `SourceDescriptor` declaring `ex:memberOf` (public,
+  global-IRI) and a privacy descriptor marking `ex:salary` private.
+- **Pass 1 (selection):** all four answer the `?h ex:memberOf ex:flat` pattern; none is pruned
+  (all participate).
+- **Pass 2 (partition):** the membership join on `ex:flat` (a global IRI) → `Disclosed`; the
+  cumulative-salary `> £100k` comparison (private operands) → `Hidden(Comparison)`.
+- **Pass 3 (envelope + ratify):** the envelope declares "membership multiset disclosed; only the
+  threshold verdict bit disclosed; exact cumulative salary never reconstructed." Each holder
+  confirms `ex:salary` stays in the `Hidden` route (its policy holds → no abort); the verifier
+  accepts the one-bit-output envelope.
+- **Execution:** the produced `FederatedQuery` + routing feeds the existing
+  `sparq-mpc::pipeline` driver unchanged — which is precisely the four-flatmates scenario that
+  driver already runs. **The seam's job is to derive, rather than hand-write, that input.**
+
+---
+
+## 5. Options considered + honest trade-offs
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| **(A) New `sparq-fedplan-mpc` glue crate** (recommended) | clean separation; neither existing crate gains a cross-dependency; opt-in; matches the precedent of standalone opt-in members | one more crate to maintain; the routing pass is genuinely new code | **Recommend** |
+| (B) Extend `sparq-fedplan` with MPC-awareness | reuses the cost model in place | couples a trusted local planner to an untrusted-plan + privacy-policy concern it shouldn't own; bloats the federation planner; breaks the "fedclient is MPC-agnostic" design it already states | Reject |
+| (C) Extend `sparq-mpc::pipeline` to do its own planning | keeps it one crate | puts a query optimiser inside the protocol/primitive crate; pulls `sparq-fedplan` into the crypto crate's dependency graph; conflates concerns | Reject |
+| (D) Do nothing — keep hand-writing `FederatedQuery` per query | zero new code; fine for the single demo | does not scale past the four-flatmates demo; no source selection; no declared leakage envelope; the RQ2a decision stays implicit and un-auditable across queries | Reject for the general case; acceptable ONLY for the existing single demo |
+
+**The honest trade-off on the disclosed/hidden greedy heuristic (§4.3 pass 2):** greedily
+disclosing every global-IRI operand is the *cheapest* route and is correct for the driving use
+case, but a more-private deployment may want to *hide* a global IRI too (e.g. to avoid leaking
+*which* flat). The pass must therefore be **policy-parameterised**, not hard-coded to "disclose
+all IRIs" — the privacy descriptor's default-deny posture (§4.2) supports a strict mode where
+even a public-by-convention term is hidden if the source marks it so. This is a real cost-vs-
+privacy knob, and the leakage envelope makes the chosen point explicit.
+
+---
+
+## 6. Honesty / what this design does NOT claim
+
+This is a **proposal**, and the whole construction sits on top of an estate with explicit,
+load-bearing caveats that this record does not weaken:
+
+- **The collaborative ZK proof that would make the result sound-and-attested under an untrusted
+  plan does NOT exist** — `sparq-mpc::proof` is an honest `NotYetImplemented` stub, and the
+  pipeline today produces a `FederatedResponse` with **no proof**. So C-A's soundness argument
+  (§4.4) is *designed*, not *delivered*: until the proof lands, the seam produces a correct
+  disclosed result with a differential anchor, not a third-party-verifiable one.
+- **The MPC layer is honest-majority, semi-honest only.** Nothing here promotes that; a
+  malicious planner is tolerated for *soundness* only to the extent the (future, audited) proof
+  and the existing differential re-check provide, and the malicious-security work is a separate
+  in-flight line (the IT-MAC beads).
+- **The ZK/MPC estate is NOT externally audited.** The external accredited-cryptographer audit
+  (sq-qhy4, P0) is **pending**, and a fresh coZK soundness re-audit of any collaborative path
+  (sq-9hrn) is required before any soundness/attestation claim. This record makes **no**
+  unqualified privacy, soundness, or security claim, and the routing it designs does not change
+  the estate's audit posture by one inch.
+- **No performance numbers.** The §3 cost framing ("minutes-to-tens-of-minutes", "joins are the
+  cost center") is the *published-literature* anchor (ORQ), cited as such — not a sparq
+  measurement. No work-box timing appears here; sparq's own numbers for any of this do not exist
+  yet and the work-box is non-canonical regardless.
+- **B7 authorisation and Z2 char-set source pruning are reserved, not designed.** The privacy
+  descriptor (§4.2) names the hooks; their full design (SAFE-style WAC/ACP-aware skipping; the
+  char-set miner reuse) is out of scope and stays `ambiguous-ask-user`.
+
+---
+
+## 7. Recommendation
+
+Adopt **Option (A)**: a new opt-in `sparq-fedplan-mpc` glue crate that turns the
+hand-written `FederatedQuery`/`OperatorRouting` into the *output of an untrusted, policy-gated
+routing pass* over `sparq-fedplan` source selection + a per-source privacy descriptor — with the
+disclosed/hidden partition **ratified by the data owners and the verifier**, not imposed by the
+planner. This is integration of known parts (relational-MPC split-execution + sparq's existing
+federation planner + the existing MPC routing enum), not new cryptography. It is **decoupled**
+from, and **does not gate**, the audit-pending crypto: the seam can be built and differentially
+tested today; it simply does not *claim* soundness/attestation until the proof + audits land.
+
+Sequencing intent: build the **descriptor + greedy-partition + envelope** core first (it is
+useful immediately and unblocks the demo's generalisation), defer the **untrusted-plan
+re-validation** until it can ride the collaborative proof, and treat **B7 authorisation** as a
+later, separately-scoped step.
+
+---
+
+## 8. Phased plan (each phase a future bead)
+
+Ordered by leverage / dependency. Each is opt-in (`fedplan-mpc` feature), touches neither the
+lean core nor the audit posture, and is differentially testable against the existing
+four-flatmates pipeline.
+
+1. **Phase 1 — `sparq-fedplan-mpc` crate skeleton + privacy descriptor.** Off-by-default opt-in
+   crate depending on `sparq-fedplan` + `sparq-mpc`; define `SourcePrivacyDescriptor`
+   (private-term set, attestation key id, reserved authorisation field) with default-deny
+   semantics. Dependency-boundary proof (default build pulls neither into the other). *(P2)*
+2. **Phase 2 — source-selection adapter.** Wrap `sparq-fedplan::select_sources` to consume the
+   privacy/authorisation descriptor and prune non-participating / unauthorised sources; surface
+   the candidate set. *(P2, depends Phase 1)*
+3. **Phase 3 — disclosed/hidden routing pass.** The policy-parameterised greedy partition (§4.3
+   pass 2) emitting `Vec<OperatorRouting>` + a `FederatedQuery`; default mode = disclose
+   global-IRI operands, strict mode = honour per-source "hide even public" marks. Differential
+   test: the produced routing reproduces the hand-written four-flatmates routing exactly. *(P2,
+   depends Phase 2)*
+4. **Phase 4 — leakage-envelope assembly + dual ratification.** Compute the declared leakage
+   envelope; each holder's fail-closed private-column re-check; verifier-side envelope acceptance
+   policy. Negative tests: a plan that tries to disclose a private term is rejected by the
+   holder; an over-leaking envelope is rejected by the verifier. *(P2, depends Phase 3)*
+5. **Phase 5 — untrusted-plan soundness re-validation (gated).** Bind the produced plan to the
+   eventual collaborative proof so a dropped/mis-routed source yields a verification failure, not
+   a forged accept. **BLOCKED** on `proof.rs` ceasing to be a stub AND the external audit
+   (sq-qhy4) + collaborative coZK re-audit (sq-9hrn) — do NOT present as sound until then. *(P3,
+   depends Phase 4 + the audit gates)*
+6. **Phase 6 — FedUP-style result-aware source-combination pruning.** Add provenance/quotient-
+   summary pruning to Phase 2 to cut the source-combination blow-up before MPC (the highest-
+   leverage pre-MPC cost win). *(P3, depends Phase 2)*
+7. **Phase 7 — B7 authorisation hook (WAC/ACP-aware source skipping).** Design + wire the
+   reserved authorisation field to SAFE-style per-source access control. Separately scoped;
+   `ambiguous-ask-user`. *(P3, depends Phase 1; needs maintainer decision)*
+
+---
+
+## 9. Open questions for the maintainer
+
+1. **Crate vs feature granularity.** Is a standalone `sparq-fedplan-mpc` member the right shape,
+   or would you prefer a `mpc` feature *inside* `sparq-fedplan` despite the coupling cost? (The
+   recommendation is the standalone crate, per §5, but this is a structural call you own.)
+2. **Default disclosure posture.** Should the routing pass default to *disclose all global IRIs*
+   (cheapest, matches the demo) or to *default-deny even public terms* (most private,
+   `ambiguous-ask-user`)? The leakage envelope makes either explicit, but the default sets the
+   product stance.
+3. **Where does the untrusted-plan re-validation (Phase 5) actually bind?** It depends entirely
+   on the shape the collaborative proof takes when `proof.rs` is built — so Phase 5 is genuinely
+   blocked on a design that does not yet exist, and may need its own record then. Is deferring it
+   the right call, or do you want the binding sketched now so Phases 1–4 are built toward it?
+4. **B7 scope.** Is access-control-aware source skipping in-scope for this track at all, or does
+   it belong with `sparq-solid` (WAC/ACP) and only *reference* this seam?


### PR DESCRIPTION
> 🤖 SPARQ agent — design-for-review (a PROPOSAL for the maintainer, not a fait accompli). Self-ID: SPARQ agent.

## What this is

A focused design record filling a **genuine uncovered gap** on the MPC-over-federated-SPARQL track (epic **sq-pwr** / **sq-0jsc**): the **federation-pushdown-under-MPC seam**.

`research/mpc-untrusted-planner-routing-design.md`

## The gap (verified against `main`)

`sparq-mpc::pipeline` already accepts a hand-written `FederatedQuery` / `Routing` / `OperatorRouting` — its own docstrings call it *"the (untrusted, §4.1) planner's output, made into typed data"* — but **nothing produces it**, the routing is decided by hand for the four-flatmates demo, and the mature cost-based planner `sparq-fedplan` (`select_sources`, `plan_bgp`, `SourceDescriptor`) has **zero** MPC awareness (`sparq-mpc` and `sparq-fedplan` have no cross-reference in code). `feature-research-federation.md` flags exactly this seam (items Z1/B7/Z2) as `ambiguous-ask-user` with **no design record**. The brief's flagged "federation-pushdown-under-MPC question" lands here.

## Thesis

Propose a new **opt-in glue crate** `sparq-fedplan-mpc` that derives the disclosed/hidden partition (the load-bearing RQ2a decision) from `sparq-fedplan` source selection + a per-source privacy descriptor, with the disclosure decision **ratified by the data owners and the verifier** (fail-closed), so the crypto layer trusts the plan for **neither soundness nor the leakage bound**. Integration of known parts (relational-MPC split-execution — SMCQL/Conclave/Senate/Secrecy/ORQ/Cerebro — + the existing federation planner + the existing MPC routing enum), **not** new cryptography.

## Honesty (load-bearing)

- The collaborative ZK proof that would make this sound-and-attested **does NOT exist** (`proof.rs` is an honest `NotYetImplemented` stub; the pipeline produces **no proof** today).
- MPC is **honest-majority, semi-honest only**; the estate is **NOT externally audited** (sq-qhy4 P0 pending; sq-9hrn collaborative coZK re-audit required).
- **No unqualified privacy/soundness/security claim** anywhere; **no performance numbers** (the §3 cost framing is the published ORQ literature anchor, cited as such; work-box is non-canonical).

## Phased plan (each a future bead)

1. sq-2q1x — P1 crate skeleton + `SourcePrivacyDescriptor` (default-deny)
2. sq-fix4 — P2 source-selection adapter (privacy/authorisation pruning)
3. sq-m3sm — P3 disclosed/hidden routing pass → `OperatorRouting`/`FederatedQuery`
4. sq-7ssc — P4 leakage-envelope + dual ratification (holder fail-closed + verifier policy)
5. sq-1fo4 — P5 **GATED** untrusted-plan soundness re-validation (blocked on proof + audits)
6. sq-xkrt — P6 FedUP-style result-aware source-combination pruning
7. sq-lzvl — P7 **needs-user** B7 WAC/ACP-aware source-skipping authorisation hook

## Open questions for the maintainer

Crate-vs-feature granularity; default disclosure posture (disclose-all-IRIs vs default-deny); where Phase 5 binds (depends on the not-yet-existing proof shape); whether B7 belongs here or with `sparq-solid`.

## Gates

markdownlint 0 errors · typos clean · no-perf-numbers 0 findings · privacy-claims OK · all 5 internal links resolve.

Not auto-merged — orchestrator arms after review.