### PR TITLE
docs(fast-ingestion): reject radix-sort permutation lever after measurement (sq-56z) [OPUS-4.8]

### DIFF
--- a/research/fast-ingestion.md
+++ b/research/fast-ingestion.md
@@ -22,14 +22,43 @@ dump and the actual sparq release binary (except where marked "est").
 |--|--|--|--|--|
 | **1** | **Fast decompression** — recompress source to **zstd** once (`zstd -9 -T0`, parallel), then `.zst` input decompresses ~12× faster than bzip2 so it stops being the bottleneck (the `lbzip2` alternative needs an install that isn't present) | E2E decompress 147 → ~16 min | Low | **DONE** (commit 4903da1 — `.zst`/`.zstd` input in build/ingest; 10M build from `.zst` 4.6 s vs `.bz2` 10.4 s vs `.nt` 4.4 s — zstd decompress fully hidden under the parse by the #2 overlap pipeline, so compressed ingest now runs at ~uncompressed speed) |
 | **2** | **Overlap decompress with parse** — decompress on its own thread feeding a bounded channel, so it runs concurrently with parse+spill instead of additively | hides the parse under the decompress | Low | **DONE** (commit 48b9c22 — `build_external_ntriples_parallel`; measured ~0.39 → ~0.96 M/s on a `.bz2`, ~2.4×) |
-| **3** | **Radix sort** the permutations (MSD on the leading u32 — ids are dense) instead of serial `sort_unstable` in `build_raw_perms`/`external_sort` | build stage 2–4× | Medium | open (tracked in beads) |
+| **3** | ~~**Radix sort** the permutations (MSD on the leading u32 — ids are dense) instead of `sort_unstable` in `build_raw_perms`/`external_sort`~~ | build stage 2–4× (claimed) | Medium | **REJECTED — measured (sq-56z).** The premise (replace a *serial* sort) is stale: both sites already use `par_sort_unstable` under the default `parallel` feature, against which a best-effort MSD radix is a **regression**. See "Radix-sort verdict (sq-56z)" below. |
 | **4** | **Parallelize `external_sort`** across the 5 sibling permutations (each in its own tmp subdir, sharing the chunk budget) | build stage faster (eff. cores → ~5) | Medium | **DONE** (commit c391dde — external build 10M from `.nt` 6.8s → 4.4s, −35%) |
 
 zstd (#1, now done) is the single biggest win — bzip2 was 70% of E2E wall-time. With #2
 (overlap, done) hiding the now-fast zstd decompress under the parse, compressed ingest runs
-at ~uncompressed speed (measured 4.6 s vs 4.4 s on 10M). #3 (radix) is the only remaining
-open lever (tracked in beads) and is measure-first/questionable on the bandwidth-bound M1;
-# 4 (parallel sibling sorts, done) already removed the build stage as the second wall.
+at ~uncompressed speed (measured 4.6 s vs 4.4 s on 10M). #3 (radix) was the last open lever
+and is now **measured and rejected** (see below); #4 (parallel sibling sorts, done) already
+removed the build stage as the second wall.
+
+### Radix-sort verdict (sq-56z) — REJECTED after measurement
+
+The bead flagged this as "measure-first / questionable on the bandwidth-bound M1", and the
+measurement confirms the doubt. The sort hot paths — `build_raw_perms` (SPO dedup + sibling
+permutations) and the `spill_run` tail under `external_sort` — **already use rayon
+`par_sort_unstable`** under the default `parallel` feature (they did `sort_unstable` when this
+doc was first written; that was changed independently). A direct comparison on synthetic
+`[u32;3]` permutation rows across four distributions (Wikidata-like, dense, small per-run
+chunk, and POS-like low-leading-cardinality) gives, *relative to the real baseline*:
+
+- A serial MSD radix beats the **serial** `sort_unstable` by ~1.3–2.0× — but no hot path
+  uses the serial sort in the shipped (parallel) build, so that win is unreachable.
+- Every parallel MSD radix variant we could write (naive leading-byte partition; and a
+  load-balanced variant that does a parallel chunked histogram and even falls back to
+  `par_sort_unstable` for the big buckets) is **slower than plain `par_sort_unstable`** —
+  roughly **0.5–0.7×** its throughput (i.e. `par_sort_unstable` is ~1.4–1.8× faster), with
+  no distribution where radix wins.
+
+Why: the radix scatter pass is a random-write memory shuffle, which is exactly the
+bandwidth-bound bottleneck the bead named — and rayon's `par_sort_unstable` (a cache-aware
+parallel driftsort) is already very well tuned. The "Sort traffic floor" row above
+(6 perms × 3 passes) is the same memory-traffic ceiling radix would have to beat and cannot.
+(Ratios are relative algorithm comparisons measured on the non-canonical -aws work box; they
+are directional, not the canonical M1 throughput numbers, and so are stated as ratios only.)
+
+**Decision:** keep `par_sort_unstable`; do not add a radix path. Re-open only if a future
+profile shows the index BUILD stage (not decompress/parse) is the binding ingest constraint
+*and* a radix variant is shown by measurement to beat `par_sort_unstable` on real id rows.
 
 **Recipe for the full Wikidata dump:** `zstd -9 -T0` the 42.8 GB `.bz2` → `.zst` once
 (parallel, one-time), then `sparq-cli build dump.nt.zst ntriples out 8` — ingest is now


### PR DESCRIPTION
> 🤖 SPARQ agent

## sq-56z — Ingest: radix-sort permutations in `build_raw_perms`/`external_sort` (measure-first)

**Verdict: REJECTED after measurement.** This is a doc-only change — closing the bead with the empirical result rather than shipping a regression.

### What the bead asked
Radix-sort the permutation rows (MSD on the leading `u32`) "instead of serial `sort_unstable`" in `build_raw_perms`/`external_sort`, claimed build-stage 2-4x. The bead itself flagged it **measure-first / questionable on the bandwidth-bound M1**.

### What measurement found
The premise is stale. Both hot paths already use rayon **`par_sort_unstable`** under the default `parallel` feature (`crates/sparq-core/src/store.rs:301`, `crates/sparq-core/src/extsort.rs:60`), not the serial `sort_unstable` the lever assumed. Against that real baseline, on synthetic `[u32;3]` rows across four distributions (Wikidata-like, dense, small per-run chunk, POS-like low-leading-cardinality):

- A serial MSD radix beats the **serial** `sort_unstable` by ~1.3-2.0x — but **no shipped path uses the serial sort**, so that win is unreachable.
- Every parallel MSD radix variant — naive leading-byte partition, and a load-balanced one with a parallel chunked histogram that even falls back to `par_sort_unstable` for big buckets — runs at **~0.5-0.7x** the throughput of plain `par_sort_unstable` (i.e. `par_sort_unstable` is ~1.4-1.8x faster). **No distribution where radix wins.**

Root cause: the radix scatter pass is a random-write memory shuffle — exactly the bandwidth-bound bottleneck the bead named — and rayon's `par_sort_unstable` (cache-aware parallel driftsort) is already very well tuned. The doc's existing "Sort traffic floor" row is the same memory-traffic ceiling radix would have to beat and cannot.

### Change in this PR
- `research/fast-ingestion.md`: lever #3 marked **REJECTED — measured (sq-56z)** with the rationale; the "open / tracked in beads" framing stripped per the bead's instruction.
- Bead `sq-56z` **closed** with the verdict (not staged here; `.beads` left to the orchestrator).
- **No code change** — adding a radix path would be a net regression.

### Honesty / hygiene notes
- Ratios are **relative algorithm comparisons** measured on the non-canonical `-aws` work box, stated as ratios only — no new hard-coded absolute throughput numbers in markdown (the no-perf-numbers rule).
- Doc-only PR: no Rust source, no public API, no `unsafe` touched → the clippy / tests-both-feature-states / rustdoc / unsafe-register / privacy / G2-SKILL gates have no applicable surface. Markdown table re-validated (6 lever rows intact).
- Re-open only if a future profile shows the index BUILD stage (not decompress/parse) is the binding ingest constraint **and** a radix variant is measured to beat `par_sort_unstable` on real id rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)