### PR TITLE
docs(sparq-vectors): document the id-keyed .spqv/.spqg staleness contract (sq-wlzi) [OPUS-4.8]

### DIFF
--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -105,6 +105,15 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 # only and never enters the published dependency graph.
 [dev-dependencies]
 sparq-sim = { path = "../sparq-sim" }
+# [OPUS-4.8] sq-wlzi: DEV-only. The id-keyed-staleness-contract test (tests/staleness_contract.rs)
+# demonstrates the SOUND serving path — persist the build graph with `Graph::save`, reopen it with
+# `Graph::open` (which mmaps the FROZEN dict id order), and query the id-keyed store against THAT —
+# vs the re-parse trap (`Graph::load_str` at a different RAYON_NUM_THREADS reshuffles the dict ids,
+# so the store serves the WRONG vectors). `Graph::save`/`open` are gated behind sparq-core's `mmap`
+# feature, so we enable it for the test build ONLY. This does NOT change the published default build:
+# a dev-dependency feature is local to this crate's test/example/bench targets and never propagates
+# to downstream consumers of `sparq-vectors`.
+sparq-core = { path = "../sparq-core", version = "0.1.0", features = ["mmap"] }
 # [OPUS-4.8] sq-xhiv: DEV-only. The fingerprint thread-count-stability regression tests drive the
 # SAME parallel sharded dict merge the loader uses at two explicit thread counts via a scoped rayon
 # pool (`RAYON_NUM_THREADS` is read once per process, so it cannot be varied mid-test). rayon is NOT

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -63,6 +63,13 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
   which assigns dict ids in a thread-count-dependent order — fingerprints **identically** and does
   not spuriously mismatch, while a genuine term add / remove / edit still changes it. (It is an
   integrity check for accidental staleness, not a security/tamper primitive — see the module docs.)
+  **Id-keyed staleness contract (sq-wlzi):** because the store is keyed by raw dict id, a passing
+  `check_graph` is **necessary but not sufficient** — the thread-count-stable fingerprint also passes
+  a re-parse of the same RDF whose ids merely *permuted*, which then serves the **wrong** vector. So
+  to serve a persisted store/index, persist its graph (`Graph::save`) and reopen **that** graph
+  (`Graph::open`, which mmaps the frozen id order) to resolve query terms — **never** re-parse the
+  source RDF (`Graph::load_str` etc.). The round-trip vs the re-parse trap is pinned in
+  `tests/staleness_contract.rs`.
 - **`StreamingWriter`** — build stores bigger than RAM with O(1) build-phase memory;
   byte-identical output to the in-RAM builder.
 - **Search** — `nearest_exact` (answer-exact ground-truth baseline) and the persistent on-disk

--- a/crates/sparq-vectors/src/diskann.rs
+++ b/crates/sparq-vectors/src/diskann.rs
@@ -82,6 +82,17 @@
 //! so an index built against a different graph generation would silently mis-resolve; the checked
 //! query entry points reject that. Version-1 files (no fingerprint, 32-byte header) still open but
 //! are reported as unverifiable.
+//!
+//! [OPUS-4.8] (sq-wlzi) **ID-KEYED STALENESS CONTRACT.** Each node record stores its term's
+//! build-time dictionary id, and neighbour entries are stored slots — so this index, like the
+//! [`VectorStore`] under it, is valid ONLY against the **exact graph generation it was built
+//! against**. To serve it, persist that graph (`Graph::save`) and reopen THAT graph (`Graph::open`,
+//! which mmaps the **frozen** dict id order — both gated by `sparq-core`'s `mmap` feature) to resolve
+//! query terms — **never re-parse the source RDF** (`Graph::load_str` et al.): sparq-core's parallel
+//! sharded dict merge assigns thread-count-dependent ids, so a re-parse gives a *different*
+//! `id → term` binding and `nearest_term` mis-resolves. `check_graph` is a
+//! backstop, **not** a sufficient guard — the sq-xhiv fingerprint is thread-count-stable, so it PASSES
+//! a re-parse of the same RDF whose ids permuted. See [`crate::fingerprint`] for the full rationale.
 
 use crate::fingerprint::{self, Fingerprint, FINGERPRINT_LEN};
 use crate::quant::{DistanceTable, EncodedStore, PqConfig, ProductQuantizer};

--- a/crates/sparq-vectors/src/fingerprint.rs
+++ b/crates/sparq-vectors/src/fingerprint.rs
@@ -57,6 +57,37 @@
 //! graph (it makes no integrity, soundness, or tamper-resistance claim against a motivated party).
 //! dict_len + triple_count are folded alongside it precisely so the common shift cases
 //! (terms added/removed, triples added/removed) are caught structurally even before the hash.
+//!
+//! # [OPUS-4.8] (sq-wlzi) The id-keyed STALENESS CONTRACT — serve via `Graph::open`, never a re-parse
+//!
+//! A passing [`check_against`] is **necessary but NOT sufficient** for a correct query, and the
+//! sq-xhiv thread-count-stability above is exactly why. The store/index are keyed by **raw dict id**;
+//! the fingerprint deliberately folds only the term *set*, so it is **blind to a pure id permutation
+//! of an unchanged term set**. That blindness is the right call for the fingerprint's job (catch a
+//! genuine term change, ignore a thread-count reshuffle), but it means the fingerprint **cannot** tell
+//! a graph with the build-time `id → term` binding apart from the *same* graph re-parsed at a different
+//! `RAYON_NUM_THREADS` (whose ids permuted). Both fingerprint identically, so `check_against` passes
+//! BOTH — yet only the first resolves the id-keyed store correctly; the re-parse serves a **different,
+//! real term's vector** under the queried term's id (a plausible-looking but WRONG neighbour, no error).
+//!
+//! The CONTRACT that closes this gap is a **usage discipline**, not a code check:
+//!
+//! > To serve a persisted `.spqv` / `.spqg`, **persist the graph it was built against**
+//! > (`Graph::save`) and **reopen THAT graph** (`Graph::open`, which mmaps the **frozen** dict id
+//! > order) to resolve query terms. **NEVER re-parse the source RDF** (`Graph::load_str` /
+//! > `load_reader` / `load_dataset`): the parallel sharded dict merge assigns thread-count-dependent
+//! > ids, so a re-parse yields a different `id → term` binding than the store was keyed against. (The
+//! > `mmap` feature on `sparq-core` gates `Graph::save`/`Graph::open`.)
+//!
+//! An id-keyed store/index is valid ONLY against the **exact graph generation it was built against**.
+//! The persisted dict is the only thread-count-independent id binding sparq-core exposes, so reopening
+//! it is the only sound way to recover that generation. `check_against` remains a worthwhile guard for
+//! the cases it *can* catch (a term added/removed/edited ⇒ a changed term set ⇒ a changed fingerprint),
+//! but it is a backstop, not the primary safety mechanism — the discipline above is. The round-trip
+//! and the re-parse trap are pinned end-to-end in `tests/staleness_contract.rs`. A larger, optional
+//! redesign that would make a *logically*-identical graph queryable at any thread count — re-resolving
+//! neighbours by **term** rather than raw id (a term-keyed store/index/mask) — is tracked as a separate
+//! follow-up (it changes the on-disk format and the `IdMask` mask-cache key; not a doc change).
 
 use sparq_core::dict::{is_inline, Dict, Id, TermParts, INLINE_BASE};
 use sparq_core::Graph;

--- a/crates/sparq-vectors/src/store.rs
+++ b/crates/sparq-vectors/src/store.rs
@@ -23,6 +23,18 @@
 //! but `check_graph` reports them as unverifiable — see [`VectorStore::open`] and the back-compat
 //! note there.
 //!
+//! [OPUS-4.8] (sq-wlzi) **ID-KEYED STALENESS CONTRACT.** Because every embedding is keyed by the
+//! build-time dictionary id, a store is valid ONLY against the **exact graph generation it was built
+//! against**. To serve it, persist that graph (`Graph::save`) and reopen THAT graph (`Graph::open`,
+//! which mmaps the **frozen** dict id order — both gated by `sparq-core`'s `mmap` feature) to resolve
+//! query terms — **never re-parse the source RDF** (`Graph::load_str` et al.): sparq-core's parallel
+//! sharded dict merge assigns thread-count-dependent ids, so a re-parse produces a *different*
+//! `id → term` binding and `get`/`nearest_term` mis-resolve. `check_graph` is a
+//! backstop, **not** a sufficient guard for this case — the sq-xhiv fingerprint folds the term *set*
+//! and is thread-count-stable, so it PASSES a re-parse of the same RDF even though the ids permuted.
+//! See [`crate::fingerprint`] for the full rationale and `tests/staleness_contract.rs` for the
+//! round-trip-vs-trap demonstration.
+//!
 //! Coverage is **sparse by design**: in an RDF graph only entities get embeddings, not
 //! every literal, so vectors are stored densely in *insertion* slots and the trailing
 //! sorted `(id, slot)` index maps dictionary ids to slots — `get` on an mmap'd store is

--- a/crates/sparq-vectors/tests/staleness_contract.rs
+++ b/crates/sparq-vectors/tests/staleness_contract.rs
@@ -1,0 +1,211 @@
+//! [OPUS-4.8] (sq-wlzi) The **id-keyed staleness contract** for `.spqv` / `.spqg`, demonstrated
+//! end-to-end. A [`VectorStore`] (and the `DiskAnnIndex` over it) is keyed by **raw dictionary term
+//! id**: a query resolves `graph.id_of(term) -> id` and looks `id` up in the store. The store is
+//! therefore valid ONLY against a graph whose `id -> term` binding equals the build-time binding.
+//!
+//! sparq-core assigns dictionary ids in a **thread-count-dependent** order (the parallel sharded
+//! dict merge sizes its shard count from `rayon::current_num_threads()`), so the *same source RDF*
+//! re-parsed at a different `RAYON_NUM_THREADS` gets a DIFFERENT id binding. Since sq-xhiv the graph
+//! fingerprint is dict-id-order-INDEPENDENT (it folds the term SET), so that re-parsed graph
+//! fingerprints IDENTICALLY and `check_graph` PASSES it — yet the raw id of a given term may now
+//! denote a different term, so the store serves the WRONG vector. The fingerprint cannot catch this
+//! case; the **usage discipline is the safety net**: to serve a persisted store, REOPEN the
+//! persisted graph with `Graph::open` (which mmaps the FROZEN id order), NEVER re-parse the
+//! source RDF.
+//!
+//! These two tests pin both halves of that contract:
+//!   * [`sound_path_save_then_graph_open_serves_correct_vectors`] — the SOUND round-trip.
+//!   * [`reparse_trap_passes_the_check_but_serves_the_wrong_vector`] — why the discipline is
+//!     load-bearing: a re-parse at a different thread count passes `check_graph` yet mis-resolves.
+
+use oxrdf::{NamedNode, Term};
+use sparq_core::dict::Id;
+use sparq_core::Graph;
+use sparq_vectors::VectorStore;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// A unique scratch path under the temp dir, tagged and pid/seq-stamped so parallel test
+/// binaries never collide.
+fn scratch(tag: &str) -> PathBuf {
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("sparq_wlzi_{tag}_{}_{n}", std::process::id()))
+}
+
+fn iri(s: &str) -> Term {
+    Term::NamedNode(NamedNode::new(s).unwrap())
+}
+
+/// Load `nt` (N-Triples) inside a rayon pool of exactly `threads` workers, so the parallel sharded
+/// dict merge runs at a known shard count. `RAYON_NUM_THREADS` is read once per process for the
+/// GLOBAL pool, so a scoped pool is the only way to vary the thread count within one test.
+fn load_in_pool(nt: &str, threads: usize) -> Graph {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .build()
+        .unwrap()
+        .install(|| Graph::load_str(nt, "ntriples").expect("load ntriples"))
+}
+
+/// A multi-namespace N-Triples document large enough that the sharded merge ACTUALLY shards (the
+/// shard count is `(threads*2).clamp(4,64)`, so e.g. 2 vs 8 threads → 4 vs 16 shards → a different
+/// id assignment). Subjects span seven namespaces so the merge interleaves them across shards.
+fn corpus() -> String {
+    let mut nt = String::new();
+    for i in 0..3000u32 {
+        nt.push_str(&format!(
+            "<http://ns{}.example/s{}> <http://ns{}.example/p{}> <http://ns{}.example/o{}> .\n",
+            i % 7,
+            i,
+            i % 5,
+            i % 11,
+            i % 9,
+            i
+        ));
+    }
+    nt
+}
+
+/// A distinctive 4-d vector for a term, derived from its id so each stored term has its own unique
+/// vector (collision-free over the id range we use). Lets a test assert "the vector served for this
+/// id is exactly the one stored for that term" at the byte level — deterministic, no ranking.
+fn vec_for(id: Id) -> [f32; 4] {
+    [id as f32, (id as f32) * 0.5, 7.0, -3.0]
+}
+
+/// Build a store over `g` (bound to `g`, so it carries `g`'s fingerprint), giving every subject
+/// `s{i}` for `i` in `0..n` a distinctive id-derived vector. Returns the store path.
+fn build_store(g: &Graph, path: &std::path::Path, n: u32) {
+    let mut s = VectorStore::create(path, 4).unwrap().with_fingerprint(g);
+    for i in 0..n {
+        let t = iri(&format!("http://ns{}.example/s{}", i % 7, i));
+        let id = g.id_of(&t).expect("subject present in dict");
+        s.put(id, &vec_for(id)).unwrap();
+    }
+    s.finalize().unwrap();
+}
+
+/// THE SOUND PATH. Build a store against a graph, `Graph::save` that graph, then reopen it with
+/// `Graph::open` (which mmaps the frozen dict id order) and query the id-keyed store against the
+/// reopened graph: the staleness check passes AND every term resolves to the vector that was stored
+/// for it. The persisted dict pins the exact `id -> term` binding the store was keyed against.
+#[test]
+fn sound_path_save_then_graph_open_serves_correct_vectors() {
+    let nt = corpus();
+    let n = 64u32; // embed the first 64 subjects
+
+    // Build the graph at one thread count; persist BOTH the graph and a store bound to it.
+    let g_build = load_in_pool(&nt, 8);
+    let store_path = scratch("sound").with_extension("spqv");
+    build_store(&g_build, &store_path, n);
+    let graph_dir = scratch("sound_graph");
+    g_build.save(&graph_dir).expect("persist the build graph");
+
+    // SERVE: reopen the PERSISTED graph (frozen id order), not a re-parse of the source RDF.
+    let g_served = Graph::open(&graph_dir).expect("reopen the persisted graph");
+    let store = VectorStore::open(&store_path).unwrap();
+
+    // The checked query path certifies the store against the reopened graph...
+    assert!(
+        store.check_graph(&g_served).is_ok(),
+        "a store served against its OWN persisted graph (reopened via Graph::open) must verify"
+    );
+    // ...and EVERY embedded term resolves to the exact vector stored for it. `Graph::open` preserves
+    // the build-time `id -> term` binding, so the id-keyed lookup is correct for every term.
+    for i in 0..n {
+        let t = iri(&format!("http://ns{}.example/s{}", i % 7, i));
+        let id = g_served.id_of(&t).expect("subject present after reopen");
+        let served = store.get(id).expect("served vector present");
+        assert_eq!(
+            served,
+            &vec_for(id),
+            "the reopened persisted graph must resolve term {t:?} to ITS OWN stored vector"
+        );
+    }
+
+    std::fs::remove_file(&store_path).ok();
+    std::fs::remove_dir_all(&graph_dir).ok();
+}
+
+/// THE RE-PARSE TRAP — why the `Graph::open` discipline is load-bearing. Re-parse the SAME source
+/// RDF at a DIFFERENT thread count than the build. The dict ids genuinely permute, so:
+///   * `check_graph` PASSES (the sq-xhiv fingerprint folds the term SET and is thread-count-stable,
+///     so the re-parsed graph fingerprints identically) — the fingerprint CANNOT catch this; and
+///   * the id-keyed lookup therefore mis-resolves: a term's id in the re-parsed graph denotes a
+///     DIFFERENT term in the store, so the served vector is WRONG.
+///
+/// This is the foot-gun sq-wlzi documents: a passing `check_graph` is NECESSARY but NOT SUFFICIENT;
+/// only reopening the persisted graph (the test above) is sound.
+#[test]
+fn reparse_trap_passes_the_check_but_serves_the_wrong_vector() {
+    let nt = corpus();
+    let n = 3000u32; // embed every subject, so a permuted id is guaranteed to land on an embedded one
+
+    // Build against the graph parsed at 8 threads.
+    let g_build = load_in_pool(&nt, 8);
+    let store_path = scratch("trap").with_extension("spqv");
+    build_store(&g_build, &store_path, n);
+    let store = VectorStore::open(&store_path).unwrap();
+
+    // RE-PARSE the SAME RDF at a different thread count (the trap: NOT Graph::open).
+    let g_reparsed = load_in_pool(&nt, 2);
+    assert_eq!(
+        g_build.dict.len(),
+        g_reparsed.dict.len(),
+        "same term set, just permuted"
+    );
+
+    // (1) The staleness fingerprint does NOT catch the re-parse: it folds the term SET and is
+    // thread-count-stable (sq-xhiv), so the re-parsed graph fingerprints identically and the check
+    // PASSES. This is exactly why the fingerprint alone is not a sufficient guard.
+    assert!(
+        store.check_graph(&g_reparsed).is_ok(),
+        "sq-xhiv: the dict-id-order-independent fingerprint matches a re-parse of the same RDF, so \
+         check_graph cannot reject the re-parse trap — the Graph::open discipline is the safety net"
+    );
+
+    // (2) ...yet the id-keyed lookup mis-resolves for at least one term: find a subject whose id
+    // GENUINELY permuted between the two bindings (the sharded merge guarantees some do). For such a
+    // term, the store — keyed by the BUILD-time id — returns the vector stored for the term that the
+    // BUILD graph placed at the re-parsed id, which is NOT this term's vector. That is the silently
+    // wrong serving the contract warns against.
+    let mut found_permuted = false;
+    for i in 0..n {
+        let t = iri(&format!("http://ns{}.example/s{}", i % 7, i));
+        let id_build = g_build.id_of(&t).unwrap();
+        let id_reparsed = g_reparsed.id_of(&t).unwrap();
+        if id_build == id_reparsed {
+            continue; // this term happened to keep its id; not the witness we need
+        }
+        found_permuted = true;
+        // What the store serves when the query resolves the term through the RE-PARSED graph.
+        let served_via_reparse = store.get(id_reparsed).expect("embedded id has a vector");
+        // The term's OWN vector (what a correct serving must return).
+        let correct = vec_for(id_build);
+        assert_ne!(
+            served_via_reparse,
+            &correct,
+            "term {t:?} permuted (build id {id_build} != reparse id {id_reparsed}); querying the \
+             id-keyed store through the re-parsed graph serves the WRONG vector even though \
+             check_graph passed — the trap sq-wlzi documents. Reopen the persisted graph instead."
+        );
+        // The served vector is, concretely, the BUILD graph's term-at-id_reparsed vector — i.e. a
+        // different, real term's embedding presented as if it were `t`'s. Pin that mis-attribution.
+        assert_eq!(
+            served_via_reparse,
+            &vec_for(id_reparsed),
+            "the mis-served vector is precisely the one the BUILD graph stored at the re-parsed id \
+             (a different term's embedding) — a plausible-looking but wrong neighbour"
+        );
+        break;
+    }
+    assert!(
+        found_permuted,
+        "expected the parallel sharded merge to permute at least one subject's id at 8 vs 2 \
+         threads; if this fails the test no longer exercises the re-parse trap"
+    );
+
+    std::fs::remove_file(&store_path).ok();
+}

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -97,6 +97,11 @@ store.fingerprint() -> Option<Fingerprint>;  store.check_graph(&Graph) -> Result
 // fingerprint = dict_len + triple_count + content_hash over the dict term SET in a dict-id-order-INDEPENDENT (sorted) order
 //   (sq-xhiv: stable across RAYON_NUM_THREADS, so re-loading the same RDF at a different thread count does NOT spuriously
 //   mismatch; a genuine term add/remove/edit still does); legacy v1 files open but check_graph errs
+// ID-KEYED STALENESS CONTRACT (sq-wlzi): the store is keyed by RAW dict id, so a passing check_graph is NECESSARY but NOT
+//   SUFFICIENT -- the thread-count-stable fingerprint ALSO passes a re-parse of the same RDF whose ids merely permuted, which
+//   then serves the WRONG vector. To SERVE a persisted .spqv/.spqg: persist its graph (Graph::save) and reopen THAT graph
+//   (Graph::open -- mmaps the FROZEN id order) to resolve query terms; NEVER re-parse the source RDF (Graph::load_str etc.).
+//   (Graph::save/open need sparq-core's `mmap` feature.) Round-trip vs re-parse trap pinned in tests/staleness_contract.rs.
 
 // --- search (src/ann.rs) --- all return cosine in [-1,1], best first; zero query -> empty
 nearest_exact(&VectorStore, query: &[f32], k) -> Vec<(Id, f32)>                 // ground-truth full scan


### PR DESCRIPTION
> 🤖 SPARQ agent — automated PR by an agent operating on @jeswr's account.

## What & why (sq-wlzi)

A `VectorStore` (`.spqv`) / `DiskAnnIndex` (`.spqg`) is keyed by **raw dictionary term id**, so it is valid ONLY against the **exact graph generation it was built against**. Since **sq-xhiv** the graph fingerprint folds the dictionary **term SET** and is **dict-id-order-INDEPENDENT** (thread-count stable). That makes `check_against` / `check_graph` **necessary but NOT sufficient**:

- the *same* source RDF re-parsed at a different `RAYON_NUM_THREADS` fingerprints **identically** (its ids merely permuted), so the check **passes**;
- but the store, keyed by the build-time id, then serves a **different, real term's vector** under the queried term's id — a plausible-looking but **wrong** neighbour, with no error.

The fingerprint cannot catch this case, so the **usage discipline is load-bearing**. This PR documents the sound contract (the in-scope remedy sq-xhiv pointed to) and pins it with a test. It does **not** change the fingerprint (that would re-introduce the unsoundness sq-xhiv was closed to avoid) and is **not** the larger term-keyed redesign (a separate follow-up).

## The contract (now documented in the module docs, README, and SKILL)

> To serve a persisted `.spqv` / `.spqg`, persist its graph (`Graph::save`) and **reopen THAT graph** (`Graph::open`, which mmaps the **frozen** dict id order) to resolve query terms — **NEVER** re-parse the source RDF (`Graph::load_str` et al.): sparq-core's parallel sharded dict merge assigns thread-count-dependent ids, so a re-parse yields a different `id → term` binding than the store was keyed against.

## Changes (docs + test only — no public API change)

- `src/fingerprint.rs`, `src/store.rs`, `src/diskann.rs` — new **id-keyed staleness contract** section in each module doc (fingerprint carries the full rationale; store/diskann cross-reference it).
- `README.md` + `skills/vector-search/SKILL.md` — the one-line contract + the necessary-but-not-sufficient caveat.
- `tests/staleness_contract.rs` — pins both halves end-to-end:
  - **sound path**: `Graph::save` → `Graph::open` → every embedded term resolves to **its own** stored vector;
  - **re-parse trap**: re-parse at a different thread count **passes** `check_graph` yet serves the **wrong** vector (precisely the build graph's term-at-permuted-id embedding).
- `Cargo.toml` — enable sparq-core's `mmap` feature as a **dev-dependency feature only** (so the test can call `Graph::save`/`open`); this does **not** change the published default build.

## Gate (all green)

- `cargo build` / `clippy --all-targets -- -D warnings` — both default **and** `--all-features`.
- `cargo test -p sparq-vectors` — both feature states (incl. the new test, both states).
- Rustdoc gate `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps` — both default and `--all-features` (caught + fixed intra-doc links to the `mmap`-gated `Graph::save`/`open`, now plain code spans).
- `scripts/check-privacy-claims.sh` — clean (no ZK/MPC privacy/soundness claim touched).
- No `unsafe` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)