### PR TITLE
docs(sparq-algos): correct test-location claim in README (sq-6c04) [OPUS-4.8]

### DIFF
--- a/crates/sparq-algos/README.md
+++ b/crates/sparq-algos/README.md
@@ -58,7 +58,8 @@ let k    = num_communities(&comm);
 
 - The capability skill: [`skills/graph-analytics/SKILL.md`](../../skills/graph-analytics/SKILL.md).
 - Source: `src/graph.rs` (the view), `src/pagerank.rs`, `src/centrality.rs`,
-  `src/community.rs`. Tests live in each module and in `tests/`.
+  `src/community.rs`. Tests live in `src/lib.rs` under a single `#[cfg(test)]` module
+  (there is no `tests/` directory).
 
 These are **topology** algorithms: edges are unweighted and predicate-erased. To analyse a
 sub-graph (e.g. only `foaf:knows` edges), filter the source graph first; predicate-weighted


### PR DESCRIPTION
> 🤖 SPARQ agent — automated change. Reviewer: please verify the doc claim against the crate source.

## What

`crates/sparq-algos/README.md` (the "📚 Learn more" section) claimed:

> Tests live in each module and in `tests/`.

Both clauses were inaccurate:

- There is **no `tests/` directory** in `crates/sparq-algos/`.
- The tests do **not** live "in each module" — all 22 `#[test]` functions are in a
  single `#[cfg(test)]` module in `src/lib.rs`. (The README's own mutation-testing
  note already references "the `#[test]` module of `src/lib.rs`", so the front matter
  was self-contradictory.)

This fixes the line to state the truth: tests live in `src/lib.rs` under a single
`#[cfg(test)]` module, and there is no `tests/` directory.

## Why

Cosmetic doc-accuracy follow-up from #580 (sq-mqvm) review (bead **sq-6c04**). The README
is rendered as the crate's docs.rs front page via `#![doc = include_str!("../README.md")]`,
so the inaccuracy was user-visible.

## Scope

Doc-only, one line. No code, no public API, no `unsafe`, no privacy/ZK surface — so the
G2 public-api→SKILL.md rule and the privacy-claims gate are N/A.

## Gate

- `cargo build -p sparq-algos` — clean
- `cargo clippy -p sparq-algos --all-targets -- -D warnings` — clean
- `cargo test -p sparq-algos` — 22 passed
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` — clean (exercises the
  README via `include_str!`, the load-bearing gate for this change)
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --all-features` — clean

(The crate has no cargo features — `default = []`, no others — so "both feature states"
is a single state.)

[OPUS-4.8]
