### PR TITLE
docs: reword stale roadmap T9 line — property paths + SERVICE federation are DONE (sq-d751) [OPUS-4.8]

### DIFF
--- a/research/roadmap.md
+++ b/research/roadmap.md
@@ -123,8 +123,14 @@ instrument T1 and T2 are blind without. Additive — conflicts with nothing.
   `GRAPH ?g { … }`, `FROM` / `FROM NAMED` and `GRAPH`-block / `WITH` / `USING (NAMED)` Updates all
   scope over them (`exec.rs` `eval_graph_named`; `update.rs`), and the RDF/JS surface exposes a
   DatasetCore-faithful, graph-aware `match(s,p,o,g)` (JS `options.dataset` → `SparqStore.match`).
-- Property paths (`*`/`+`/`/`), SERVICE federation, remaining aggregates/expressions (the `M2:`
-  markers at `exec.rs:2375/2640`). These touch `exec.rs` (conflict with T1).
+- **Property paths — DONE** (`*`/`+`/`?`/`/`/`|`/`^`/`!`): `exec.rs` `eval_path`.
+- **SERVICE federation — DONE** (sq-6gob): SPARQL 1.1 `SERVICE` ships behind the opt-in `service`
+  cargo feature (off in the default build), in-`exec.rs` SERVICE-algebra (`eval_service`) plus a
+  bound-join pushdown (`try_bound_join_service`); default-DENY-all egress, allowlisted per host as
+  an SSRF guard (see [`crates/sparq-server/README.md`](../crates/sparq-server/README.md)).
+- Remaining aggregates/expressions: the standard-aggregate fallthrough (`M2: unsupported aggregate`
+  in `exec.rs`'s `eval_aggregate`) and a few unsupported SPARQL functions. These touch `exec.rs`
+  (conflict with T1).
 
 ## T10 — SPARQL 1.1/1.2 Update  *(store mutation; core cluster)*
 The store is currently **immutable** (built once, queried). Update needs incremental insert/delete:


### PR DESCRIPTION
> 🤖 SPARQ agent — automated docs PR. @jeswr runs multiple agents on this account.

## What

`research/roadmap.md` T9 ("SPARQL feature gaps") listed **property paths** and
**SERVICE federation** among the `exec.rs` M2 gaps, and cited `M2:` markers at
`exec.rs:2375/2640`. That bullet is stale on three counts:

- **Property paths are implemented** — `exec.rs` `eval_path`
  (`*`/`+`/`?`/`/`/`|`/`^`/`!`).
- **SERVICE federation is implemented** (sq-6gob) — behind the opt-in `service`
  cargo feature (off in the default build): in-`exec.rs` SERVICE-algebra
  (`eval_service`) plus a bound-join pushdown (`try_bound_join_service`);
  default-DENY-all egress with a per-host SSRF allowlist
  (`crates/sparq-server/README.md`).
- The cited `exec.rs:2375/2640` `M2:` line numbers **no longer exist** — the only
  remaining `M2:` marker in the engine `exec.rs` is the standard-aggregate
  fallthrough (`M2: unsupported aggregate`) in `eval_aggregate`.

## Change

Reword that single T9 bullet so property paths and SERVICE both read **DONE**
and point at the live function names, and restate the one genuine remaining gap
(the `eval_aggregate` fallthrough + a few unsupported SPARQL functions) with the
current marker text instead of stale line numbers.

This is distinct from the README/book **status banner** already reworded by #728
(sq-6gob): that fixed the outward-facing banner; this fixes the internal roadmap
gaps list. The T9 conflict-map cell (line ~265, "GRAPH, paths, SERVICE") is left
intact — it describes the *code surface* T9 touches (for the serialise-vs-parallel
map), not a gaps-remaining claim.

## Scope / honesty

- **Docs-only.** Single file (`research/roadmap.md`), 8 insertions / 2 deletions.
- No public API, no `.rs`, no SKILL surface, no Cargo feature change.
- No new perf numbers; no ZK/MPC claims.

## Gate

Rust build/clippy/test/rustdoc + unsafe-gate are **N/A** (no Rust touched).
Applicable docs-quality gates run locally and pass:

- markdownlint-cli2 (HARD config incl. `research/`): 0 errors
- privacy-claims (ZK/MPC honesty): OK
- no-perf-numbers: 0 findings (`research/` is allowlisted regardless)
- internal-links (lychee --offline): the new relative link to
  `crates/sparq-server/README.md` resolves — 1 OK / 0 errors

Closes sq-d751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
