### PR TITLE
docs(sparq-rsp): EvalMode doc-comments say 'four' strategies after Snapshot landed (sq-wh42) [OPUS-4.8]

### DIFF
--- a/crates/sparq-rsp/src/eval.rs
+++ b/crates/sparq-rsp/src/eval.rs
@@ -1,6 +1,6 @@
 //! Window materialisation strategies (the R2R step's graph production):
 //! how each closed window becomes the [`sparq_core::Graph`] the engine
-//! evaluates. See [`EvalMode`] for the three strategies and the crate README
+//! evaluates. See [`EvalMode`] for the four strategies and the crate README
 //! for the measured throughput of each.
 
 use oxrdf::Term;
@@ -12,7 +12,7 @@ use crate::window::{Window, WindowSpec, WindowedStream};
 
 /// How each closed window's graph is materialised for evaluation.
 ///
-/// All three modes produce IDENTICAL query results (pinned by tests); they
+/// All four modes produce IDENTICAL query results (pinned by tests); they
 /// differ only in how much per-window work is redone. Numbers below are the
 /// crate benchmark (`examples/throughput.rs`, see README).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/crates/sparq-rsp/tests/rsp.rs
+++ b/crates/sparq-rsp/tests/rsp.rs
@@ -503,7 +503,7 @@ fn t0_on_count_window_panics() {
 
 // ---------------------------------------------------------------- eval modes
 
-/// All three materialisation strategies are OBSERVATIONALLY IDENTICAL: the
+/// All four materialisation strategies are OBSERVATIONALLY IDENTICAL: the
 /// same scripted stream (sliding overlap, duplicate triples across windows,
 /// numeric aggregation, empty windows) produces the same per-window results.
 #[test]

--- a/crates/sparq-rsp/tests/window_oracle.rs
+++ b/crates/sparq-rsp/tests/window_oracle.rs
@@ -693,7 +693,7 @@ impl Rng {
 
 /// Deterministic fuzz: many seeded random IN-ORDER streams (timestamps
 /// non-decreasing, so no tuple is ever late and the naive timestamp oracle is
-/// exact) across tumbling AND sliding specs, several queries, all three eval
+/// exact) across tumbling AND sliding specs, several queries, all four eval
 /// modes — each emitted window must equal the batch over its tuples. This is the
 /// broad differential net: a closure/eviction/materialisation bug on SOME shape
 /// would surface as a streamed-vs-batch divergence on SOME seed.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated doc-staleness fix for bead **sq-wh42**.

## What

PR #725 (sq-j39) extended `EvalMode` from **three** variants to **four**
(`Rebuild` / `PersistentDict` / `Delta` / `Snapshot`), but four mode-count
doc-comments in `sparq-rsp` still read "three". This corrects them:

| Location | Before → After | Why it's now four |
|---|---|---|
| `src/eval.rs:3` | "the **three** strategies" → "four" | refers to the `EvalMode` enum (4 variants) |
| `src/eval.rs:15` | "All **three** modes produce IDENTICAL results" → "four" | covers every variant |
| `tests/rsp.rs:506` | "All **three** materialisation strategies … IDENTICAL" → "four" | `eval_modes_produce_identical_results` now runs all four (asserts `Snapshot` vs the `Rebuild` baseline) |
| `tests/window_oracle.rs:696` | fuzz doc "all **three** eval modes" → "four" | `fuzz_in_order_streams_streamed_equals_batch` now iterates all four modes vs the batch oracle |

## What this does NOT change (honesty)

The other "three" mentions in the crate are **not** mode counts and are left untouched:

- `src/query.rs:19` — the **three R2S operators** (RSTREAM / ISTREAM / DSTREAM).
- `examples/rsp_oracle.rs:129` — the deterministic gate **deliberately keeps the original three golden tags** (`Snapshot` is excluded from the gate's iteration loop, as its inline comment states).
- `examples/rsp_oracle.rs:177` — three stations (A/B/C) reporting.
- `tests/window_oracle.rs:6` — three integration test files.

`README.md` already lists all four modes (updated by #725), so no README change is needed.

## Scope

Doc-comment prose only — **no code, no public-API, no `unsafe` change** (4 word edits across 3 files). The `EvalMode` enum itself is unchanged, so the G2 public-API→SKILL rule and the privacy-claims gate do not apply.

## Gate (all green)

- `cargo build -p sparq-rsp` ✅
- `cargo clippy -p sparq-rsp --all-targets -- -D warnings` ✅
- `cargo test -p sparq-rsp` ✅ (18 integration + 4 doc-tests; the 4-mode equivalence/fuzz/oracle tests pass). The crate has **no `[features]`**, so "both feature states" collapses to the single default state.
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` ✅
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --all-features` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)