### PR TITLE
feat(sparq-introspect): export characteristic sets as SHACL node shapes (sq-bde)

### DIFF
--- a/crates/sparq-introspect/README.md
+++ b/crates/sparq-introspect/README.md
@@ -26,6 +26,7 @@ ix.to_json()                                  // pretty JSON — the machine sur
 ix.to_text_summary(2500)                      // prompt-ready digest, most-important-first, ≤ N chars
 ix.to_void("http://ex.org/dataset")           // W3C VoID description, as N-Triples (valid Turtle)
 ix.to_void_with_cs("http://ex.org/dataset")   // VoID + characteristic-set source stats (scs: ext)
+ix.to_shacl()                                 // characteristic sets → W3C SHACL node shapes
 ix.schema_summary_for(&seeds, 2500)           // retrieval-mode: schema scoped to seed IRIs
 
 // Persisted *.introspect sidecar — mine once, summarise forever without rescanning:
@@ -71,6 +72,15 @@ let ix = sparq_introspect::Introspection::load("data/g.nt.introspect")?; // O(ou
   that primes a remote CostFed/Odyssey-class source-selector with star/multi-join
   cardinalities. Served at `GET /.well-known/void` behind the opt-in
   `federation-descriptors` feature.
+- **SHACL node-shape export** (`to_shacl`) — each mined characteristic set as a W3C
+  [SHACL](https://www.w3.org/TR/shacl/) `sh:NodeShape` (N-Triples / valid Turtle): a
+  `sh:targetClass` for every class **universal** to the set (so the shape auto-applies
+  only where every instance genuinely has the set's predicates), one `sh:PropertyShape`
+  (`sh:path` + `sh:minCount 1`) per non-type predicate, and `sh:maxCount 1` exactly when
+  that predicate's avg multiplicity is 1. The constraints are mined from what the data
+  asserts, so the graph already validates against them — a data-grounded effective-schema
+  floor, not an aspirational contract. Sets with no universal class yield a reusable but
+  target-less shape.
 - **Vocabulary detection** — namespaces in use (split at the last `#`/`/`, the split the
   dictionary stores) with distinct-term counts, recognised against a bundled offline
   table (rdf/rdfs/owl/xsd/foaf/skos/schema.org/dcterms/wd/dbo/…).
@@ -110,11 +120,11 @@ and the olympics summary names the dataset's actual classes (asserted by
 cargo run -p sparq-introspect --example olympics_introspect --release
 ```
 
-Tests: 20 unit (`src/lib.rs`: characteristic-set exactness, coverage, object
+Tests: 24 unit (`src/lib.rs`: characteristic-set exactness, coverage, object
 kinds/datatypes/samples, observed-vs-declared domain/range, vocabularies, JSON validity,
-text-summary budget, join hints, VoID export, retrieval mode, per-class sample isolation,
-persisted-sidecar round-trip) plus 1 integration (`tests/olympics.rs`, skip-if-absent at
-1.78M scale).
+text-summary budget, join hints, VoID export, SHACL node-shape export, retrieval mode,
+per-class sample isolation, persisted-sidecar round-trip) plus 1 integration
+(`tests/olympics.rs`, skip-if-absent at 1.78M scale).
 
 ## 📚 Learn more
 

--- a/crates/sparq-introspect/README.md
+++ b/crates/sparq-introspect/README.md
@@ -120,7 +120,7 @@ and the olympics summary names the dataset's actual classes (asserted by
 cargo run -p sparq-introspect --example olympics_introspect --release
 ```
 
-Tests: 24 unit (`src/lib.rs`: characteristic-set exactness, coverage, object
+Tests: 22 unit (`src/lib.rs`: characteristic-set exactness, coverage, object
 kinds/datatypes/samples, observed-vs-declared domain/range, vocabularies, JSON validity,
 text-summary budget, join hints, VoID export, SHACL node-shape export, retrieval mode,
 per-class sample isolation, persisted-sidecar round-trip) plus 1 integration

--- a/crates/sparq-introspect/src/lib.rs
+++ b/crates/sparq-introspect/src/lib.rs
@@ -16,6 +16,12 @@ const RDFS_DOMAIN: &str = "http://www.w3.org/2000/01/rdf-schema#domain";
 const RDFS_RANGE: &str = "http://www.w3.org/2000/01/rdf-schema#range";
 const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
 const VOID_NS: &str = "http://rdfs.org/ns/void#";
+/// [OPUS-4.8] sq-bde: the W3C SHACL namespace. [`Introspection::to_shacl`] exports each
+/// mined characteristic set as an `sh:NodeShape` under this namespace — a CS ≈ a node
+/// shape (Neumann & Moerkotte's per-entity-type predicate co-occurrence is exactly the
+/// "what properties does an entity of this kind carry, and how often" question SHACL's
+/// property shapes describe).
+const SHACL_NS: &str = "http://www.w3.org/ns/shacl#";
 /// [OPUS-4.8] sq-mr32 (federation A3/Z2): the **sparq characteristic-set** extension
 /// vocabulary. VoID has no native term for per-entity-type predicate co-occurrence
 /// statistics (the Neumann & Moerkotte characteristic sets sparq mines), so the served
@@ -1148,6 +1154,100 @@ impl Introspection {
         out
     }
 
+    /// [OPUS-4.8] sq-bde: export each mined characteristic set as a W3C **SHACL node
+    /// shape**, returned as one N-Triples document (valid Turtle).
+    ///
+    /// A characteristic set (Neumann & Moerkotte: the exact set of predicates a group of
+    /// subjects emits, with per-predicate multiplicity) maps almost one-to-one onto an
+    /// `sh:NodeShape`: "an entity of this kind carries exactly these properties, this
+    /// many times". The mined statistics are derived **only from what the data actually
+    /// asserts**, so every constraint emitted is one the current graph already satisfies
+    /// — the shapes describe the effective schema, they are not an aspirational contract.
+    /// (A consumer who wants a stricter contract edits the generated shapes; a CS is the
+    /// data-grounded floor.)
+    ///
+    /// Per retained set (`self.characteristic_sets.sets`, already bounded by
+    /// [`BuildOptions::max_char_sets`] and ordered by descending subject count, so the
+    /// document is bounded and deterministic):
+    ///
+    /// ```text
+    /// _:shapeN a sh:NodeShape ;
+    ///     sh:targetClass <C> ;              # one per class universal to the set (see below)
+    ///     scs:subjects "<count(C)>"^^xsd:integer ;   # provenance: how many subjects
+    ///     sh:property _:shapeN_M .
+    /// _:shapeN_M a sh:PropertyShape ;
+    ///     sh:path <predicate> ;
+    ///     sh:minCount 1 ;                   # always: every subject in the set emits it
+    ///     sh:maxCount 1 .                   # ONLY when the set's avg multiplicity is 1
+    /// ```
+    ///
+    /// Soundness of the cardinality constraints (each holds for *every* subject in the
+    /// set, by the definition of a characteristic set):
+    /// - `sh:minCount 1` — a subject is in this set iff it emits **exactly** this
+    ///   predicate set, so each listed predicate occurs at least once on every subject.
+    /// - `sh:maxCount 1` — emitted only when `predicate_triples[i] == subjects`, i.e. the
+    ///   summed occurrence count equals the subject count. Since each subject emits the
+    ///   predicate at least once, an equal sum forces exactly one per subject. Any larger
+    ///   sum (avg multiplicity > 1) means some subject is multi-valued, so no `sh:maxCount`
+    ///   is emitted — never an unsound upper bound.
+    ///
+    /// `sh:targetClass <C>` is emitted only for a class **universal** to the set — one
+    /// whose subject count within the set equals the set's total subject count, so every
+    /// instance the shape would target genuinely has this exact predicate set. (The
+    /// per-set `classes` histogram is bounded by [`BuildOptions::max_classes_per_histogram`];
+    /// a universal class with count == subjects is necessarily retained, as it is the most
+    /// common.) `rdf:type` itself is expressed through targeting, so it is **not** repeated
+    /// as an `sh:property`. A set whose subjects share no universal class (untyped or
+    /// heterogeneous entities) yields a **target-less** node shape — still a valid,
+    /// reusable schema template, just not auto-applied to any class.
+    ///
+    /// The `scs:subjects` provenance triple (see `CS_NS`) records the support behind each
+    /// shape; a SHACL processor that does not know the term simply ignores it.
+    pub fn to_shacl(&self) -> String {
+        use std::fmt::Write as _;
+        let sh = |local: &str| format!("{SHACL_NS}{local}");
+        let cs = |local: &str| format!("{CS_NS}{local}");
+        let iri = |s: &str| NamedNode::new_unchecked(s).to_string();
+        let int = |n: u64| Literal::new_typed_literal(n.to_string(), xsd::INTEGER).to_string();
+
+        let mut out = String::new();
+        for (si, set) in self.characteristic_sets.sets.iter().enumerate() {
+            let snode = format!("_:shape{si}");
+            let _ = writeln!(out, "{snode} <{RDF_TYPE}> <{}> .", sh("NodeShape"));
+            // Provenance: subjects backing this shape (the set's support count).
+            let _ = writeln!(out, "{snode} <{}> {} .", cs("subjects"), int(set.subjects));
+
+            // sh:targetClass for every class UNIVERSAL to the set (count == subjects), so
+            // each targeted instance genuinely carries this exact predicate set.
+            for c in &set.classes {
+                if c.count == set.subjects {
+                    let _ = writeln!(out, "{snode} <{}> {} .", sh("targetClass"), iri(&c.iri));
+                }
+            }
+
+            // One sh:property per predicate (rdf:type is carried by sh:targetClass, not
+            // repeated as a property shape).
+            let mut pi = 0u64;
+            for (pred, &triples) in set.predicates.iter().zip(&set.predicate_triples) {
+                if pred == RDF_TYPE {
+                    continue;
+                }
+                let pnode = format!("_:shape{si}_{pi}");
+                pi += 1;
+                let _ = writeln!(out, "{snode} <{}> {pnode} .", sh("property"));
+                let _ = writeln!(out, "{pnode} <{RDF_TYPE}> <{}> .", sh("PropertyShape"));
+                let _ = writeln!(out, "{pnode} <{}> {} .", sh("path"), iri(pred));
+                // Always: every subject in the set emits this predicate at least once.
+                let _ = writeln!(out, "{pnode} <{}> {} .", sh("minCount"), int(1));
+                // Exactly-one only when the summed occurrences equal the subject count.
+                if triples == set.subjects {
+                    let _ = writeln!(out, "{pnode} <{}> {} .", sh("maxCount"), int(1));
+                }
+            }
+        }
+        out
+    }
+
     /// Renders a compact, prompt-ready text digest under `budget_chars` characters,
     /// most important information first: dataset totals, then a prefix glossary of
     /// exactly the namespaces the summary uses, then classes (with per-class predicate
@@ -2122,6 +2222,148 @@ mod tests {
         assert!(
             withcs.contains("1.0000"),
             "avg multiplicity should render as a fixed-precision decimal: {withcs}"
+        );
+    }
+
+    /// [OPUS-4.8] sq-bde: each characteristic set exports as a SHACL `sh:NodeShape` — a
+    /// universal class becomes `sh:targetClass`, every (non-type) predicate a
+    /// `sh:PropertyShape` with `sh:minCount 1`, and `sh:maxCount 1` exactly when the set's
+    /// avg multiplicity for that predicate is 1. The whole document is valid RDF.
+    #[test]
+    fn shacl_exports_char_sets_as_node_shapes() {
+        // Three characteristic sets:
+        //  - {type, name}          ×2  (alice, bob)   — Person universal, name single
+        //  - {type, name, worksAt} ×1  (carol)        — Person universal, worksAt ×2 multi
+        //  - {label}               ×1  (untyped doc)  — no universal class, single
+        let g = graph(
+            ":alice rdf:type foaf:Person ; foaf:name \"Alice\" .
+             :bob   rdf:type foaf:Person ; foaf:name \"Bob\" .
+             :carol rdf:type foaf:Person ; foaf:name \"Carol\" ; :worksAt :acme , :globex .
+             :doc   rdfs:label \"A note\" .",
+        );
+        let ix = Introspection::build(&g);
+        let shacl = ix.to_shacl();
+
+        // Whole document re-parses as valid N-Triples (hence valid Turtle).
+        let triples: Vec<oxrdf::Triple> = oxttl::NTriplesParser::new()
+            .for_slice(shacl.as_bytes())
+            .map(|t| t.expect("SHACL export is valid N-Triples"))
+            .collect();
+
+        let sh = |l: &str| format!("{SHACL_NS}{l}");
+        let cs = |l: &str| format!("{CS_NS}{l}");
+        let person = "http://xmlns.com/foaf/0.1/Person";
+        let name = "http://xmlns.com/foaf/0.1/name";
+        let works = ex("worksAt");
+        let label = "http://www.w3.org/2000/01/rdf-schema#label";
+        let int1 = oxrdf::Literal::new_typed_literal("1", oxrdf::vocab::xsd::INTEGER).to_string();
+
+        // One sh:NodeShape per retained set (here all three are retained).
+        let node_shapes = triples
+            .iter()
+            .filter(|t| {
+                t.predicate.as_str() == RDF_TYPE
+                    && t.object.to_string() == format!("<{}>", sh("NodeShape"))
+            })
+            .count();
+        assert_eq!(node_shapes, ix.characteristic_sets.sets.len());
+        assert_eq!(node_shapes, 3, "three distinct characteristic sets");
+
+        // sh:targetClass Person is emitted (universal to the two Person sets); a
+        // target-less shape exists for the untyped {label} set (no universal class).
+        let target_person = triples
+            .iter()
+            .filter(|t| {
+                t.predicate.as_str() == sh("targetClass")
+                    && t.object.to_string() == format!("<{person}>")
+            })
+            .count();
+        assert_eq!(target_person, 2, "Person targets the two typed sets");
+        // No targetClass ever points at a class that is only a minority of a set, and the
+        // untyped set yields zero targets total beyond the two Person ones.
+        let total_targets = triples
+            .iter()
+            .filter(|t| t.predicate.as_str() == sh("targetClass"))
+            .count();
+        assert_eq!(total_targets, 2, "only universal classes are targeted");
+
+        // rdf:type is expressed via targeting — never repeated as a property shape path.
+        assert!(
+            !triples.iter().any(|t| t.predicate.as_str() == sh("path")
+                && t.object.to_string() == format!("<{RDF_TYPE}>")),
+            "rdf:type must not appear as an sh:path"
+        );
+
+        // Helper: collect the (path -> set of predicate-IRIs that carry a given sh: term).
+        let paths_with = |term: &str| -> Vec<String> {
+            // pnode -> path
+            let path_of: std::collections::HashMap<String, String> = triples
+                .iter()
+                .filter(|t| t.predicate.as_str() == sh("path"))
+                .map(|t| (t.subject.to_string(), t.object.to_string()))
+                .collect();
+            triples
+                .iter()
+                .filter(|t| {
+                    t.predicate.as_str() == sh(term) && t.object.to_string() == int1
+                })
+                .filter_map(|t| path_of.get(&t.subject.to_string()).cloned())
+                .collect()
+        };
+
+        // Every (non-type) predicate of every set gets sh:minCount 1.
+        let min_paths = paths_with("minCount");
+        for p in [name, &works, label] {
+            assert!(
+                min_paths.contains(&format!("<{p}>")),
+                "sh:minCount 1 for {p}: {shacl}"
+            );
+        }
+
+        // sh:maxCount 1 ONLY for single-valued predicates: name (1 each) and label (1),
+        // never worksAt (carol has 2 → avg multiplicity 2, unsound to bound).
+        let max_paths = paths_with("maxCount");
+        assert!(max_paths.contains(&format!("<{name}>")), "name is single-valued");
+        assert!(max_paths.contains(&format!("<{label}>")), "label is single-valued");
+        assert!(
+            !max_paths.contains(&format!("<{works}>")),
+            "worksAt is multi-valued — no sh:maxCount: {shacl}"
+        );
+
+        // Provenance: each shape carries scs:subjects with its support count, and the
+        // support counts match the mined sets exactly (2 + 1 + 1).
+        let mut supports: Vec<u64> = triples
+            .iter()
+            .filter(|t| t.predicate.as_str() == cs("subjects"))
+            .map(|t| {
+                if let oxrdf::Term::Literal(l) = &t.object {
+                    l.value().parse::<u64>().unwrap()
+                } else {
+                    panic!("scs:subjects must be a literal")
+                }
+            })
+            .collect();
+        supports.sort_unstable();
+        assert_eq!(supports, vec![1, 1, 2]);
+
+        // Property shapes are typed sh:PropertyShape.
+        assert!(triples.iter().any(|t| t.predicate.as_str() == RDF_TYPE
+            && t.object.to_string() == format!("<{}>", sh("PropertyShape"))));
+    }
+
+    /// [OPUS-4.8] sq-bde: the empty graph yields an empty (but valid) SHACL document.
+    #[test]
+    fn shacl_empty_graph_is_empty_and_valid() {
+        let g = graph("");
+        let ix = Introspection::build(&g);
+        let shacl = ix.to_shacl();
+        assert!(shacl.is_empty(), "no sets → no shapes");
+        // Trivially parses.
+        assert_eq!(
+            oxttl::NTriplesParser::new()
+                .for_slice(shacl.as_bytes())
+                .count(),
+            0
         );
     }
 

--- a/crates/sparq-introspect/tests/wasm.rs
+++ b/crates/sparq-introspect/tests/wasm.rs
@@ -122,6 +122,26 @@ fn void_export_runs_on_wasm() {
     assert!(with_cs.contains("http://sparq.dev/ns/cs#CharacteristicSet"));
 }
 
+/// [OPUS-4.8] sq-bde: the SHACL node-shape export (`to_shacl`) runs on wasm and emits a
+/// node shape per characteristic set with property shapes for its predicates.
+#[wasm_bindgen_test]
+fn shacl_export_runs_on_wasm() {
+    let ix = Introspection::build(&graph());
+    let shacl = ix.to_shacl();
+    // One sh:NodeShape per retained characteristic set.
+    let node_shapes = shacl
+        .matches("<http://www.w3.org/ns/shacl#NodeShape>")
+        .count();
+    assert_eq!(node_shapes, ix.characteristic_sets.sets.len());
+    assert!(node_shapes > 0);
+    // foaf:Person is universal to the two-Person set, so it targets at least one shape.
+    assert!(shacl.contains("http://www.w3.org/ns/shacl#targetClass"));
+    assert!(shacl.contains("http://xmlns.com/foaf/0.1/Person"));
+    // Property shapes carry sh:path + sh:minCount for the set's predicates.
+    assert!(shacl.contains("http://www.w3.org/ns/shacl#path"));
+    assert!(shacl.contains("http://www.w3.org/ns/shacl#minCount"));
+}
+
 /// The planner-facing id-space accessor (`characteristic_set_ids`) runs on wasm and its
 /// subject counts agree with the IRI-resolved table's distinct-set count.
 #[wasm_bindgen_test]

--- a/skills/genai-retrieval/SKILL.md
+++ b/skills/genai-retrieval/SKILL.md
@@ -11,8 +11,9 @@ crates that compose:
 - **`sparq-introspect`** — mines the *effective schema* a graph actually uses
   (classes, per-class predicate usage, observed domain/range, characteristic sets,
   cross-class join hints, namespaces) by sorted scans over the store indexes — and
-  renders it as a **token-budgeted text "schema card"**, **VoID** (N-Triples), or
-  full **JSON** for LLM grounding / agent retrieval context.
+  renders it as a **token-budgeted text "schema card"**, **VoID** (N-Triples),
+  **SHACL node shapes** (characteristic sets → `sh:NodeShape`), or full **JSON** for
+  LLM grounding / agent retrieval context.
 - **`sparq-nlq`** — a deliberately lean **NL→SPARQL loop**: ground (with the
   introspect summary) → generate (an `Llm` behind a trait) → validate (`spargebra`
   parse) → execute (`sparq-engine` under a `QueryBudget`) → repair (≤ N rounds). The
@@ -46,6 +47,7 @@ let ix = Introspection::build(&graph);
 let card = ix.to_text_summary(2500);          // prompt-ready schema card, ≤ 2500 chars
 let json = ix.to_json();                       // full machine surface for an agent
 let void = ix.to_void("http://ex.org/dataset");// W3C VoID, as N-Triples
+let shacl = ix.to_shacl();                      // characteristic sets → SHACL node shapes (N-Triples)
 # Ok::<(), String>(())
 ```
 
@@ -82,6 +84,7 @@ Introspection::build_with(graph: &Graph, opts: &BuildOptions) -> Introspection
 Introspection::to_text_summary(&self, budget_chars: usize) -> String   // schema card
 Introspection::to_json(&self) -> String                                // pretty JSON
 Introspection::to_void(&self, dataset_iri: &str) -> String             // VoID N-Triples
+Introspection::to_shacl(&self) -> String                               // CS → SHACL node shapes (N-Triples)
 Introspection::schema_summary_for(&self, seeds: &[&str], budget_chars: usize) -> String
 
 // Persisted *.introspect sidecar (sq-3n4): mine once, summarise forever — reload is
@@ -265,6 +268,19 @@ let void_nt = Introspection::build(&graph).to_void("http://ex.org/dataset");
 // propertyPartition per predicate. NOTE: void:distinctObjects is NOT emitted.
 ```
 
+**4b. Bootstrap SHACL shapes from the effective schema.** Each characteristic set becomes
+an `sh:NodeShape`; output is N-Triples (valid Turtle):
+
+```rust
+let shapes_nt = Introspection::build(&graph).to_shacl();
+// Per characteristic set: a sh:NodeShape with sh:targetClass for every class UNIVERSAL
+// to the set (count == subjects), one sh:PropertyShape (sh:path + sh:minCount 1) per
+// non-type predicate, and sh:maxCount 1 only when that predicate is single-valued across
+// the set (avg multiplicity 1). Constraints are mined from what the data asserts, so the
+// graph already validates against them — a data-grounded floor to edit, not a contract.
+// Sets with no universal class yield a reusable but target-less shape.
+```
+
 **5. Tune the introspection for a huge or noisy KG.** Bound the histograms and tables:
 
 ```rust
@@ -380,4 +396,4 @@ the fixtures encode.)
   `sparql-formal-semantics` — the verifiable/private query estate, orthogonal to this
   retrieval surface.
 </skill_md>
-<parameter name="key_apis">["Introspection::build(graph: &Graph) -> Introspection", "Introspection::build_with(graph: &Graph, opts: &BuildOptions) -> Introspection", "Introspection::to_text_summary(&self, budget_chars: usize) -> String", "Introspection::to_json(&self) -> String", "Introspection::to_void(&self, dataset_iri: &str) -> String", "Introspection::schema_summary_for(&self, seeds: &[&str], budget_chars: usize) -> String", "Introspection::save(&self, path: impl AsRef<Path>) -> io::Result<()>", "Introspection::load(path: impl AsRef<Path>) -> io::Result<Introspection>", "Introspection::from_json(json: &str) -> serde_json::Result<Introspection>", "sparq_introspect::sidecar_path_for(dataset: impl AsRef<Path>) -> PathBuf", "sparq_introspect::SIDECAR_EXTENSION: &str", "ClassPredicate { predicate, subjects, triples, coverage, samples: Vec<String> }  (samples = per-class sample labels, sq-3n4)", "sparq_introspect::characteristic_set_ids(graph: &Graph) -> Vec<CsIdSet>", "trait Llm { fn complete(&self, prompt: &str) -> Result<String, String>; }", "ReplayLlm::from_file / from_json", "RecordingLlm::new(inner) + .save(path)", "live::AnthropicLlm::from_env() / with_model(model)  (feature = \"live\")", "Nlq::new(graph, Box<dyn Llm>) / with_config(graph, llm, NlqConfig)", "Nlq::ask(&self, question: &str) -> Result<Answer, NlqError>", "Nlq::prompt_for / repair_prompt_for (deterministic, for fixtures)", "Answer { sparql, result: QueryResult, repairs, transcript }", "NlqConfig { summary_budget_chars, max_repair_rounds, exec_timeout, max_rows, examples, ground, link_entities, link_expand_k, max_links, check_dictionary }", "sparq_nlq::link::EntityLinker::build(graph: &Graph, expand_k: usize, max_links: usize)", "EntityLinker::link(&self, question: &str) -> Linking", "sparq_nlq::link::Linking { entities: Vec<LinkedEntity>, relations: Vec<LinkedRelation> } ; Linking::to_prompt_section(&self) -> Option<String>", "sparq_nlq::constrain::unknown_terms(graph: &Graph, query: &spargebra::Query) -> Vec<UnknownTerm>", "sparq_nlq::constrain::dictionary_repair_message(unknowns: &[UnknownTerm]) -> String", "sparq_nlq::constrain::UnknownTerm { iri, role: TermRole, suggestions }", "sparq_nlq::eval::EvalCase::new(question, gold_sparql)", "sparq_nlq::eval::run_config(graph, cases, llm, config, Linking) -> Report", "sparq_nlq::eval::run_comparison(graph, cases, base_config, make_llm) -> Comparison", "Comparison::headline_grounding_pays() -> bool / summary() -> String", "F1::score(&AnswerSet, &AnswerSet) -> F1 / is_exact() -> bool ; AnswerSet::from_result(&QueryResult)", "sparq_engine::cs::{CsSet, CsTable}  (sparq-engine feature = \"cs-planner\")"]
+<parameter name="key_apis">["Introspection::build(graph: &Graph) -> Introspection", "Introspection::build_with(graph: &Graph, opts: &BuildOptions) -> Introspection", "Introspection::to_text_summary(&self, budget_chars: usize) -> String", "Introspection::to_json(&self) -> String", "Introspection::to_void(&self, dataset_iri: &str) -> String", "Introspection::to_shacl(&self) -> String  (characteristic sets → W3C SHACL node shapes, N-Triples; sq-bde)", "Introspection::schema_summary_for(&self, seeds: &[&str], budget_chars: usize) -> String", "Introspection::save(&self, path: impl AsRef<Path>) -> io::Result<()>", "Introspection::load(path: impl AsRef<Path>) -> io::Result<Introspection>", "Introspection::from_json(json: &str) -> serde_json::Result<Introspection>", "sparq_introspect::sidecar_path_for(dataset: impl AsRef<Path>) -> PathBuf", "sparq_introspect::SIDECAR_EXTENSION: &str", "ClassPredicate { predicate, subjects, triples, coverage, samples: Vec<String> }  (samples = per-class sample labels, sq-3n4)", "sparq_introspect::characteristic_set_ids(graph: &Graph) -> Vec<CsIdSet>", "trait Llm { fn complete(&self, prompt: &str) -> Result<String, String>; }", "ReplayLlm::from_file / from_json", "RecordingLlm::new(inner) + .save(path)", "live::AnthropicLlm::from_env() / with_model(model)  (feature = \"live\")", "Nlq::new(graph, Box<dyn Llm>) / with_config(graph, llm, NlqConfig)", "Nlq::ask(&self, question: &str) -> Result<Answer, NlqError>", "Nlq::prompt_for / repair_prompt_for (deterministic, for fixtures)", "Answer { sparql, result: QueryResult, repairs, transcript }", "NlqConfig { summary_budget_chars, max_repair_rounds, exec_timeout, max_rows, examples, ground, link_entities, link_expand_k, max_links, check_dictionary }", "sparq_nlq::link::EntityLinker::build(graph: &Graph, expand_k: usize, max_links: usize)", "EntityLinker::link(&self, question: &str) -> Linking", "sparq_nlq::link::Linking { entities: Vec<LinkedEntity>, relations: Vec<LinkedRelation> } ; Linking::to_prompt_section(&self) -> Option<String>", "sparq_nlq::constrain::unknown_terms(graph: &Graph, query: &spargebra::Query) -> Vec<UnknownTerm>", "sparq_nlq::constrain::dictionary_repair_message(unknowns: &[UnknownTerm]) -> String", "sparq_nlq::constrain::UnknownTerm { iri, role: TermRole, suggestions }", "sparq_nlq::eval::EvalCase::new(question, gold_sparql)", "sparq_nlq::eval::run_config(graph, cases, llm, config, Linking) -> Report", "sparq_nlq::eval::run_comparison(graph, cases, base_config, make_llm) -> Comparison", "Comparison::headline_grounding_pays() -> bool / summary() -> String", "F1::score(&AnswerSet, &AnswerSet) -> F1 / is_exact() -> bool ; AnswerSet::from_result(&QueryResult)", "sparq_engine::cs::{CsSet, CsTable}  (sparq-engine feature = \"cs-planner\")"]


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-bde** — *Introspect: export characteristic sets as SHACL node shapes* (the last open `sparq-introspect` schema-export TODO).

## What

Adds `Introspection::to_shacl(&self) -> String`, rendering each mined characteristic set as a W3C [SHACL](https://www.w3.org/TR/shacl/) `sh:NodeShape` (N-Triples, which is valid Turtle — no serializer dependency, same as the existing `to_void` family). A characteristic set (Neumann & Moerkotte: the exact predicate set a group of subjects emits, with per-predicate multiplicity) maps almost one-to-one onto a node shape: *"an entity of this kind carries exactly these properties, this many times."*

## Mapping — and why each constraint is sound

Every constraint holds for **every** subject in the set, by the definition of a characteristic set:

- `sh:targetClass <C>` — emitted only for a class **universal** to the set (its in-set subject count equals the set's total subject count), so the shape auto-applies only where every targeted instance genuinely has this exact predicate set. A set whose subjects share no universal class (untyped / heterogeneous) yields a reusable but **target-less** shape.
- `sh:property` → `sh:PropertyShape` with `sh:path <p>` + `sh:minCount 1` per **non-type** predicate — a subject is in the set iff it emits exactly these predicates, so each occurs at least once.
- `sh:maxCount 1` **only** when `predicate_triples[i] == subjects` (avg multiplicity exactly 1). A larger sum means some subject is multi-valued → no upper bound is emitted (never an unsound constraint).
- `rdf:type` is expressed via `sh:targetClass`, so it is **not** repeated as a property shape.
- `scs:subjects` provenance triple records the support behind each shape.

The constraints are mined purely from what the data asserts, so the current graph already validates against them — a data-grounded **effective-schema floor** to edit, not an aspirational contract.

Example (alice/bob share `{type,name}`; carol adds `worksAt` twice):

```
_:shape0 a sh:NodeShape ; scs:subjects 2 ; sh:targetClass foaf:Person ; sh:property _:shape0_0 .
_:shape0_0 a sh:PropertyShape ; sh:path foaf:name ; sh:minCount 1 ; sh:maxCount 1 .
_:shape1 a sh:NodeShape ; scs:subjects 1 ; sh:targetClass foaf:Person ;
         sh:property [ sh:path :worksAt ; sh:minCount 1 ] ,        # multi-valued → no maxCount
                     [ sh:path foaf:name ; sh:minCount 1 ; sh:maxCount 1 ] .
```

## Tests & gate

- 2 new `src/lib.rs` unit tests: full multi-set mapping (universal-class targeting, no minority targets, `rdf:type` never a path, min/maxCount soundness on single- vs multi-valued predicates, `scs:subjects` provenance, valid-RDF re-parse via `oxttl`) + empty-graph edge case. One wasm32 smoke assertion in `tests/wasm.rs`.
- Gate green: `cargo build` + `clippy --all-targets -D warnings`, full crate tests (22 unit + 1 integration), `wasm32-unknown-unknown` build, both workspace rustdoc gates (`-D warnings`, default **and** `--all-features`), privacy-claims gate, G2 api→SKILL gate, no-perf-numbers + skill-frontmatter checks.
- README + `genai-retrieval` SKILL.md updated for the new public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)