### PR TITLE
ci(honesty): scan paper .typ sources in perf-number + privacy-claims gates (sq-mkza)

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -263,6 +263,19 @@ jobs:
           tool: lychee@0.23.0
       - name: Self-test check-site-links.sh (basePath remap + broken-link teeth)
         run: bash scripts/tests/test_check_site_links.sh
+      # [OPUS-4.8] sq-mkza: end-to-end proof that BOTH honesty gates now cover the
+      # paper-factory `.typ` sources (site/papers/**/*.typ) — the highest-stakes
+      # OUTWARD surface. Before sq-mkza a hard-coded "12× faster" or an unqualified
+      # "maliciously secure" typed straight into a paper tripped NEITHER gate. The
+      # harness drives the REAL gate scripts (the perf gate by explicit `.typ` path;
+      # the privacy gate via a throwaway git repo, since it enumerates with
+      # `git ls-files`) and asserts a planted violation FAILS while the accessor /
+      # comment / negator / allow-marker paths PASS. HARD job (no "advisory" token),
+      # so a coverage regression also reds the ci-summary gate.
+      - name: shellcheck the .typ honesty-gate self-test
+        run: shellcheck scripts/tests/test_typ_honesty_gates.sh
+      - name: Self-test the .typ honesty-gate coverage (perf + privacy, both directions)
+        run: bash scripts/tests/test_typ_honesty_gates.sh
 
   # ----------------------------- ADVISORY -----------------------------
   markdownlint-advisory:

--- a/scripts/check-no-perf-numbers.py
+++ b/scripts/check-no-perf-numbers.py
@@ -80,17 +80,40 @@ ALLOW_PATH_PREFIXES = [
     ".github/",
 ]
 
-# Globs of files to scan (markdown only).
-SCAN_GLOBS = ["*.md"]
+# Globs of files to scan. Markdown is the original surface; the published-paper Typst
+# sources (`site/papers/**/*.typ`) are ALSO scanned so a hard-coded perf figure typed
+# directly into a paper — the highest-stakes OUTWARD surface — trips the gate too
+# (bead sq-mkza). The `.typ` glob is git-tracked workspace-wide, so it is narrowed to
+# the paper tree by TYPST_SCAN_PREFIX below; non-paper `.typ` (if any ever appear) are
+# left alone. Result numbers in a paper are meant to flow through the Typst data
+# accessor (`paper-evidence.json` → `#headline(...)` / `#ev(...)`), NOT be typed inline.
+SCAN_GLOBS = ["*.md", "*.typ"]
+
+# Only `.typ` files under this prefix are scanned (the paper-factory sources). The
+# accessor-aware, result-shaped-only `.typ` scan (scan_typst_file) is deliberately
+# NARROWER than the markdown scan — see its docstring and design record
+# research/paper-factory-honesty-gate-coverage.md §7 (Option b: scan for result-shaped
+# numerics only, leave free-typed setup counts — dataset sizes / dimensions / k — alone,
+# for author ergonomics). It catches only the COARSE perf-number class; subtle semantic
+# overclaims remain Stage-5 human review.
+TYPST_SCAN_PREFIX = "site/papers/"
 
 
-def tracked_markdown() -> list[str]:
-    """All git-tracked markdown files (deterministic, no untracked scratch)."""
+def is_typst_paper(path: str) -> bool:
+    return path.endswith(".typ") and path.startswith(TYPST_SCAN_PREFIX)
+
+
+def tracked_sources() -> list[str]:
+    """All git-tracked files in scope (markdown everywhere; `.typ` only under the
+    paper tree). Deterministic, no untracked scratch."""
     out = subprocess.run(
         ["git", "ls-files", *SCAN_GLOBS],
         capture_output=True, text=True, check=True,
     ).stdout
-    return [p for p in out.splitlines() if p]
+    return [
+        p for p in out.splitlines()
+        if p and (p.endswith(".md") or is_typst_paper(p))
+    ]
 
 
 def is_exempt_path(path: str) -> bool:
@@ -138,6 +161,98 @@ def scan_file(path: str) -> list[tuple[int, str, str]]:
     return findings
 
 
+# --- Typst (.typ) paper scan ------------------------------------------------------
+# [OPUS-4.8] bead sq-mkza. The paper-factory rule is: RESULT numbers flow through the
+# Typst data accessor (`paper-evidence.json` → `#headline(key)` / `#ev(key)` /
+# `#provenance(key)`), so the PDF and the in-site HTML cannot disagree and a number
+# auto-updates with the evidence. A result-shaped figure typed DIRECTLY into prose
+# bypasses that single-source discipline — that is what this scan flags. It reuses the
+# SAME result-shaped PERF_PATTERNS as the markdown scan (a number adjacent to a
+# throughput / latency / speed-up / size-per-record unit), so it is NARROW by
+# construction: bare SETUP counts (dataset sizes, dimensions, k, query counts, years,
+# citation numbers) are NOT result-shaped and are left alone (design §7, Option b).
+#
+# Two `.typ`-specific suppressions, so the accessor path and Typst comments never trip:
+#   - ACCESSOR-AWARE: the value a paper is allowed to cite comes IN through an accessor
+#     call whose argument is a string KEY (e.g. `#headline("ann.recall_at_10_floor")`),
+#     never a numeric literal — so we strip accessor-call argument spans before matching.
+#     This makes the legitimate canonical-data path provably unflaggable even if a future
+#     key string happened to contain a unit-like substring.
+#   - COMMENTS: Typst `//` line comments and `/* … */` block comments are author notes,
+#     not published claims — stripped before matching (mirrors the markdown code-fence skip).
+# Honest scope: this catches only the COARSE hard-coded-number class. A subtle semantic
+# overclaim phrased without a result-shaped unit is NOT caught here — that remains
+# Stage-5 human review (and the build-time headline() canonical gate in bench.typ).
+
+# Accessor calls whose (string-key) argument span must be removed before scanning, so a
+# unit-like substring inside a legitimate evidence KEY can never be read as a perf claim.
+TYPST_ACCESSOR_CALL_RE = re.compile(
+    r"#(?:headline|ev|provenance)\s*\([^)]*\)", re.I
+)
+
+
+def _strip_typst_noise(line: str, in_block_comment: bool) -> tuple[str, bool]:
+    """Return (scannable-text, still-in-block-comment) for one Typst source line.
+
+    Removes `/* … */` block-comment spans (possibly multi-line), `//` line comments,
+    and accessor-call argument spans — what's left is the free-typed prose the gate
+    actually judges. Conservative: a `//` or `/*` inside a string literal is rare in
+    these papers and erring toward STRIPPING (a false-negative on a contrived line)
+    is the safe direction for an author-ergonomics gate; the result tables themselves
+    are accessor-driven and unaffected.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(line)
+    while i < n:
+        if in_block_comment:
+            end = line.find("*/", i)
+            if end == -1:
+                return "".join(out), True  # comment continues past EOL
+            i = end + 2
+            in_block_comment = False
+            continue
+        # Start of a block comment?
+        if line.startswith("/*", i):
+            in_block_comment = True
+            i += 2
+            continue
+        # Start of a line comment? (rest of the line is a comment)
+        if line.startswith("//", i):
+            break
+        out.append(line[i])
+        i += 1
+    text = "".join(out)
+    # Remove accessor-call argument spans (the canonical-data path).
+    text = TYPST_ACCESSOR_CALL_RE.sub(" ", text)
+    return text, in_block_comment
+
+
+def scan_typst_file(path: str) -> list[tuple[int, str, str]]:
+    """Accessor-aware, result-shaped-only scan of a paper `.typ` source (bead sq-mkza)."""
+    findings: list[tuple[int, str, str]] = []
+    in_block_comment = False
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for lineno, raw in enumerate(fh, 1):
+                line = raw.rstrip("\n")
+                # The inline allow-substrings (incl. the explicit `perf-ok:` opt-out and
+                # the canonical-home pointers) apply here too, on the RAW line.
+                if any(sub in line for sub in ALLOW_LINE_SUBSTRINGS):
+                    continue
+                scannable, in_block_comment = _strip_typst_noise(line, in_block_comment)
+                if not scannable.strip():
+                    continue
+                for pat, label in PERF_PATTERNS:
+                    m = pat.search(scannable)
+                    if m:
+                        findings.append((lineno, label, m.group(0).strip()))
+                        break  # one finding per line is enough to flag it
+    except (OSError, UnicodeDecodeError) as e:
+        raise FileReadError(f"{path}: could not read: {e}") from e
+    return findings
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
@@ -150,12 +265,13 @@ def main() -> int:
     )
     ap.add_argument(
         "paths", nargs="*",
-        help="optional explicit paths to scan (default: all git-tracked markdown, "
-             "minus the bench/research/changelog allowlisted homes)",
+        help="optional explicit paths to scan (default: all git-tracked markdown + the "
+             "paper-factory .typ sources, minus the bench/research/changelog "
+             "allowlisted homes). A `.typ` path uses the accessor-aware Typst scan.",
     )
     args = ap.parse_args()
 
-    files = args.paths or [p for p in tracked_markdown() if not is_exempt_path(p)]
+    files = args.paths or [p for p in tracked_sources() if not is_exempt_path(p)]
 
     total = 0
     read_errors = 0  # [OPUS-4.8] unreadable files — never silently skipped
@@ -164,7 +280,12 @@ def main() -> int:
         if not args.paths and is_exempt_path(path):
             continue
         try:
-            file_findings = scan_file(path)
+            # [OPUS-4.8] sq-mkza: `.typ` paper sources use the accessor-aware,
+            # result-shaped-only scan; everything else uses the markdown scan.
+            if path.endswith(".typ"):
+                file_findings = scan_typst_file(path)
+            else:
+                file_findings = scan_file(path)
         except FileReadError as e:
             # [OPUS-4.8] Warn on stderr always; in --enforce/non-advisory mode this
             # also counts as a failure below so a hidden file can't pass silently.

--- a/scripts/check-privacy-claims.sh
+++ b/scripts/check-privacy-claims.sh
@@ -105,16 +105,28 @@ SOUNDNESS_CLAIMS=(
 NEGATOR_HEDGE_RE='\bnot\b|\bnever\b|\bno\b|\bn'"'"'t\b|\bun(sound|verified|audited)|not[- ]yet|yet[- ]to|\bopen\b|\bpending\b|\bunverified\b|\bremediat|sound[- ]+as[- ]+landed|sound[- ]+for[- ]+(the[- ]+)?(integrity|threat|assumed|stated)|\bwhether\b|\bquestion\b'
 
 # Path surface to scan = the OUTWARD claim surface (docs/READMEs/skills/site copy /
-# the compliance index). Excludes:
+# the compliance index / the published-paper Typst sources). Excludes:
 #   - research/ + the audit docs : design records that must name the properties to
 #     argue (un)soundness — the honesty source of truth, not a claim surface.
 #   - this script + its CI wiring : they QUOTE the forbidden phrases by definition.
 #   - the privacy/cryptoreview compliance bodies : they exist to discuss the gap and
 #     are line-marked where they legitimately name a phrase.
 #   - .git/target/node_modules/vendor : not authored claim surface.
+#
+# [OPUS-4.8] bead sq-mkza: the paper-factory `.typ` sources (`site/papers/*.typ` +
+# `site/papers/**/*.typ`, i.e. the pilot papers AND `_lib/*.typ`) are added — a `.typ`
+# paper IS a published outward claim, so an unqualified ZK/MPC soundness/privacy claim
+# typed into paper prose must trip the SAME absolute patterns as any README/site copy.
+# The exact inline-allow marker (`privacy-claims-allow: <why>`) and the same-line
+# negator/hedge exemption apply UNCHANGED (the per-line classification below is reused
+# verbatim). Typst `//`/`/* */` comments are NOT stripped here — a forbidden phrase in
+# a paper comment is still authored text, matching this gate's coarse-phrase posture.
+# This catches the COARSE unqualified-claim class; a subtle semantic overclaim phrased
+# around the patterns remains Stage-5 human review.
 mapfile -t FILES < <(
   git ls-files \
     '*.md' '*.mdx' '*.tsx' '*.ts' \
+    'site/papers/*.typ' 'site/papers/**/*.typ' \
     ':!:research/**' \
     ':!:**/*audit*.md' \
     ':!:.claude/agents/**' \

--- a/scripts/tests/test_typ_honesty_gates.sh
+++ b/scripts/tests/test_typ_honesty_gates.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] bead sq-mkza — end-to-end negative-test proof that the two honesty gates
+# actually scan the paper-factory `.typ` sources (`site/papers/**/*.typ`) and catch a
+# planted violation, while leaving the legitimate accessor / comment / negator paths
+# alone. Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# WHY: the highest-stakes OUTWARD surface is a published paper. Before sq-mkza the
+# no-perf-numbers gate scanned only `*.md` and the privacy-claims gate scanned only
+# `*.md *.mdx *.tsx *.ts`, so a hard-coded "12× faster" or an unqualified
+# "maliciously secure" typed straight into a `.typ` paper tripped NEITHER gate. This
+# harness PINS that the coverage now exists and does not silently regress.
+#
+# It runs the REAL gate scripts end-to-end (not a re-derived regex):
+#   1. PERF gate  — driven by explicit `.typ` paths (it dispatches `.typ` → the
+#                   accessor-aware Typst scan). Planted result-number => exit 1;
+#                   comment-only + accessor-driven => exit 0.
+#   2. PRIVACY gate — driven via a throwaway git repo (the gate enumerates its surface
+#                   with `git ls-files`, so the fixture must be TRACKED). A planted
+#                   unqualified claim in `site/papers/planted.typ` => exit 1; the same
+#                   claim hedged / allow-marked => exit 0.
+#
+# HONEST SCOPE: these gates catch only the COARSE hard-coded-number / unqualified-phrase
+# class. A subtle semantic overclaim phrased without a result-shaped unit or a forbidden
+# phrase is NOT caught here — that remains Stage-5 human review (plus the build-time
+# headline() canonical gate in site/papers/_lib/bench.typ).
+#
+# Run:  bash scripts/tests/test_typ_honesty_gates.sh   (exit 0 = all cases pass)
+# Hermetic: no network; the privacy case uses a self-contained `git init` in a tmpdir.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PERF_GATE="${ROOT}/scripts/check-no-perf-numbers.py"
+PRIV_GATE="${ROOT}/scripts/check-privacy-claims.sh"
+
+[ -f "$PERF_GATE" ] || { echo "FATAL: perf gate not found at ${PERF_GATE}"; exit 2; }
+[ -f "$PRIV_GATE" ] || { echo "FATAL: privacy gate not found at ${PRIV_GATE}"; exit 2; }
+
+pass=0
+fail=0
+note() { printf '  %s\n' "$1"; }
+expect_exit() {  # expect_exit <want-code> <label> ; reads actual code from $? via caller
+  local want="$1" label="$2" got="$3"
+  if [ "$got" -eq "$want" ]; then
+    pass=$((pass + 1)); note "PASS  [$label] exit=$got (wanted $want)"
+  else
+    fail=$((fail + 1)); note "FAIL  [$label] exit=$got (wanted $want)"
+  fi
+}
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+echo "== 1. no-perf-numbers gate scans paper .typ sources =="
+
+# 1a. Planted result-shaped number typed into paper PROSE must be caught (exit 1).
+mkdir -p "${TMP}/perf/site/papers"
+cat > "${TMP}/perf/site/papers/planted.typ" <<'TYP'
+== Results
+On WatDiv our engine is 12× faster than the baseline.
+TYP
+set +e
+python3 "$PERF_GATE" --enforce "${TMP}/perf/site/papers/planted.typ" >/dev/null 2>&1
+code=$?
+set -e
+expect_exit 1 "perf: planted '12× faster' in .typ prose => fail" "$code"
+
+# 1b. The SAME number in a Typst comment + an accessor-driven value must NOT trip (exit 0):
+#     this is the narrow/accessor-aware net — results flow through #headline()/#ev().
+cat > "${TMP}/perf/site/papers/clean.typ" <<'TYP'
+// dev note: an earlier draft said 12× faster — do not bake that in.
+The recall floor is #headline("ann.recall_at_10_floor") over 50,000 × 32 vectors.
+The crossover is #ev("filtered_ann.prefilter_crossover") of the store.
+TYP
+set +e
+python3 "$PERF_GATE" --enforce "${TMP}/perf/site/papers/clean.typ" >/dev/null 2>&1
+code=$?
+set -e
+expect_exit 0 "perf: comment + accessor + setup-counts in .typ => clean" "$code"
+
+echo "== 2. check-privacy-claims gate scans paper .typ sources =="
+
+# The privacy gate enumerates its surface with `git ls-files`, so the fixture must be a
+# TRACKED file in a git repo. Build a throwaway repo that mirrors site/papers/ and copy
+# in the REAL gate script so its in-repo `cd $ROOT` + ls-files run against the fixture.
+REPO="${TMP}/repo"
+mkdir -p "${REPO}/scripts" "${REPO}/site/papers"
+cp "$PRIV_GATE" "${REPO}/scripts/check-privacy-claims.sh"
+(
+  cd "$REPO"
+  git init -q
+  git config user.email t@t && git config user.name t
+)
+
+run_priv() {  # run_priv -> echoes exit code of the gate over the current fixture tree
+  (
+    cd "$REPO"
+    git add -A >/dev/null 2>&1
+    set +e
+    bash scripts/check-privacy-claims.sh >/dev/null 2>&1
+    echo $?
+  )
+}
+
+# 2a. Planted unqualified soundness/privacy claim in paper prose must be caught (exit 1).
+cat > "${REPO}/site/papers/planted.typ" <<'TYP'
+== Security
+Our MPC protocol is maliciously secure, and the verifier is sound.
+TYP
+code="$(run_priv)"
+expect_exit 1 "privacy: planted 'maliciously secure' + 'verifier is sound' in .typ => fail" "$code"
+
+# 2b. The same mentions, but HEDGED (negator) and ALLOW-MARKED, must PASS (exit 0) —
+#     proving the existing inline-allow / negator-exemption machinery applies to .typ.
+cat > "${REPO}/site/papers/planted.typ" <<'TYP'
+== Security
+The verifier is NOT yet sound pending external audit.
+We do not claim a privacy-preserving guarantee. // privacy-claims-allow: hedged paper caveat
+TYP
+code="$(run_priv)"
+expect_exit 0 "privacy: hedged + allow-marked claim in .typ => clean" "$code"
+
+echo ""
+echo "test_typ_honesty_gates: ${pass} passed, ${fail} failed."
+[ "$fail" -eq 0 ] || exit 1
+echo "test_typ_honesty_gates: OK — both honesty gates cover site/papers/**/*.typ."


### PR DESCRIPTION
> 🤖 SPARQ agent — bead sq-mkza (honesty-gate hardening, P2).

## What this closes

The two CI honesty gates left the **highest-stakes outward surface ungated**: a hard-coded perf number or an unqualified ZK/MPC soundness/privacy claim typed directly into a published-paper Typst source tripped **neither** gate. `check-no-perf-numbers.py` scanned only `*.md`; `check-privacy-claims.sh` scanned only `*.md`/`*.mdx`/`*.tsx`/`*.ts`. The paper sources are `site/papers/*.typ` + `site/papers/_lib/*.typ`.

Per the merged design record `research/paper-factory-honesty-gate-coverage.md` (Option A coverage; §7 **Option b** — the narrow, result-shaped net for author ergonomics), **both gates now also scan `site/papers/**/*.typ`**.

## Changes

- **`scripts/check-no-perf-numbers.py`** — adds `*.typ` to `SCAN_GLOBS`, narrowed to `site/papers/` via a new **accessor-aware** Typst scan (`scan_typst_file`). It reuses the SAME result-shaped `PERF_PATTERNS`, so only a number adjacent to a throughput / latency / speed-up / size-per-record unit is flagged — bare **setup counts** (dataset sizes, dimensions, k, query/citation/year numbers) are left alone. It strips Typst `//` and `/* */` comments and **accessor-call argument spans** (`#headline()`/`#ev()`/`#provenance()`), so the canonical `paper-evidence.json` data path is provably unflaggable.
- **`scripts/check-privacy-claims.sh`** — adds `site/papers/*.typ` + `site/papers/**/*.typ` to the `git ls-files` surface. The exact inline-allow marker (`privacy-claims-allow: <why>`) and same-line negator/hedge exemption are reused **unchanged** (not weakened).
- **`scripts/tests/test_typ_honesty_gates.sh`** (new) — end-to-end negative test that drives the **real** gate scripts: a planted `12× faster` / `maliciously secure` in a `.typ` **fails**; the comment / accessor / negator / allow-marker paths **pass**. Wired (+ shellchecked) into the **HARD** `ci-scripts` job in `docs-quality.yml`.

## Verification (local reproduction)

- `python3 scripts/check-no-perf-numbers.py --enforce` → **0 findings** (163 files; +3 `.typ` now in scope).
- `bash scripts/check-privacy-claims.sh` → **OK** (330 files; +3 `.typ`).
- The two pilot papers route every result number through the accessor, so **neither trips the new scan — no real paper violation found**.
- `bash scripts/tests/test_typ_honesty_gates.sh` → **4/4 pass**.
- Existing `bash scripts/tests/test_privacy_claims.sh` → still green (machinery reused, not weakened).
- `shellcheck` + `actionlint` on touched files → clean. Valid YAML.

## Honest scope

These gates catch only the **coarse** hard-coded-number / unqualified-phrase class. A subtle semantic overclaim phrased without a result-shaped unit or a forbidden phrase is **not** caught here — that remains Stage-5 human review (plus the build-time `headline()` canonical gate in `site/papers/_lib/bench.typ`).

## Gate aggregator

The new self-test runs inside the existing HARD `ci-scripts` job (no `advisory`/`informational` token in its name), so a coverage regression also reds the `ci-summary / gate` aggregator. No new gating leg or required-check was added; the path filter is untouched.