### PR TITLE
feat(papers): A3 — opt-in GeoSPARQL layer + cross-family conformance ratchet [OPUS-4.8]

### DIFF
--- a/site/papers/geosparql-optin-crate.typ
+++ b/site/papers/geosparql-optin-crate.typ
@@ -1,0 +1,202 @@
+// [OPUS-4.8] sq-gum8 — Paper A3: a conformant, opt-in GeoSPARQL layer + the cross-family
+// conformance ratchet that backs it.
+// Single-source Typst. Numbers come ONLY from #headline(...) / #ev(...) (paper-evidence.json),
+// never hard-coded. Compiles to BOTH a PDF (the download) and semantic HTML (the in-site page).
+// Framed HONESTLY as a RESOURCES / IN-USE contribution: the evidence is the set of
+// DETERMINISTIC, CI-enforced conformance ratchet floors (machine-independent integers), NOT a
+// performance result and NOT a research-novelty claim about spatial algorithms.
+
+#import "_lib/bench.typ": headline, ev, provenance, authors, anon
+
+#set document(title: "A Conformant, Opt-In GeoSPARQL Layer")
+#set text(size: 11pt)
+#set par(justify: true)
+#set heading(numbering: "1.")
+
+#align(center)[
+  #text(size: 17pt, weight: "bold")[
+    A Conformant, Opt-In GeoSPARQL Layer for a Dictionary-Id RDF Engine,
+    Backed by a Cross-Family Conformance Ratchet
+  ]
+]
+#authors()
+
+#align(center)[#text(style: "italic", size: 0.9em)[
+  A resources / in-use contribution. The evidence is a set of deterministic, CI-enforced
+  conformance ratchet floors (machine-independent integers that may only rise); no wall-clock
+  performance is claimed, and the spatial algorithms are standard pure-Rust prior art, not a
+  novelty.
+]]
+
+== Abstract
+
+Adding GeoSPARQL to an RDF engine usually means coupling a spatial stack into the core, which
+burdens every build — including a WebAssembly target — whether or not spatial queries are ever
+issued. We describe an _opt-in_ GeoSPARQL 1.0/1.1 layer that ships as a separate crate engaged
+only by declaring it as a dependency: no core or wasm build links the spatial stack
+unconditionally. The layer reuses the host engine's generic SPARQL machinery — its
+extension-function registry runs `geof:` functions inside real `FILTER`/`BIND`, and its generic
+RDFS/OWL-RL closure satisfies the GeoSPARQL entailment requirements with no spatial-specific
+reasoner. We make no performance claim. Instead the contribution is _conformance discipline_:
+the spatial layer is one suite in a single cross-family conformance ratchet — a registry of
+every suite the project gates, each with a monotone floor that CI enforces and that a guard
+test proves stays in lock-step with the runner it mirrors. This is a resources / in-use
+contribution; its value is a faithful, decoupled spatial layer with a machine-checkable
+conformance floor, not an algorithmic result.
+
+== Contributions
+
+This paper substantiates the following claims; each is refutable and forward-references its
+evidence. None is a performance or novelty claim about spatial algorithms.
+
+- *An opt-in spatial layer with no core/wasm coupling* (§3) — GeoSPARQL support is a
+  separate crate; nothing in the core engine or the wasm build links the spatial stack unless
+  the crate is added as a dependency. Spatial capability is purely additive.
+- *The host engine's generic machinery is reused, not duplicated* (§3) — `geof:` functions
+  run as host extension functions inside ordinary SPARQL expressions, and the GeoSPARQL
+  RDFS/OWL-RL entailment requirements are met by the engine's _generic_ closure over the
+  GeoSPARQL ontology axioms, with no geometry-specific reasoner.
+- *The spatial layer carries a deterministic, CI-enforced conformance floor* (§4) — OGC
+  GeoSPARQL topology compliance is ratcheted at a floor of
+  #headline("conformance.geosparql_topology_floor") passing assertions that may only rise.
+- *That floor is one row of a single cross-family ratchet* (§5) — the project registers
+  #headline("conformance.suite_count") conformance suites across crates in one central
+  scoreboard with a combined floor of #headline("conformance.cross_family_total"), and a guard
+  test proves each declared floor equals the floor the runner actually enforces.
+
+== The opt-in layer and its reuse of the host engine <layer>
+
+GeoSPARQL is a spatial extension to RDF/SPARQL: WKT and GML geometry literals
+(`geo:wktLiteral`, `geo:gmlLiteral`), the `geof:` spatial functions (distance, the
+simple-features / Egenhofer / RCC8 topological relations via the DE-9IM matrix, set operations,
+constructors), and the class/property entailment requirements. Implementing it faithfully is
+table-stakes parity with established engines; it is _not_ a research novelty, and we do not
+claim one. The geometry parsing and algorithms wrap the standard pure-Rust spatial stack, and
+the spatial index wraps a standard R-tree.
+
+The systems angle is purely _architectural_: the layer is a separate crate, so the spatial
+stack is linked only when the crate is declared as a dependency. No other crate — and in
+particular not the WebAssembly build — depends on it unconditionally. A deployment that never
+issues a spatial query pays nothing for spatial support: no binary-size cost, no extra
+dependency surface, no wasm bloat. Spatial capability is _additive_, engaged by opting in.
+
+Decoupling is not the same as isolation: the layer _reuses_ the host engine rather than
+re-implementing query infrastructure. The `geof:` functions register with the engine's
+extension-function registry, so they evaluate inside real SPARQL `FILTER` and `BIND`
+expressions exactly like any built-in. The GeoSPARQL RDFS/OWL-RL entailment requirements (the
+`geo:Feature` / `geo:Geometry` / `geo:SpatialObject` class hierarchy and the
+`geo:hasGeometry` / `geo:hasDefaultGeometry` property axioms) are satisfied by running the
+engine's _generic_ RDFS / OWL-RL closure over the GeoSPARQL ontology axioms — there is no
+geometry-specific reasoner. The result is a faithful spatial layer that stays decoupled from
+core while inheriting the engine's full query and reasoning machinery.
+
+== Conformance, not performance, is the evidence <conformance>
+
+We make _no_ wall-clock claim. The spatial algorithms are standard, and the canonical
+performance runner this project gates timings on is not yet operational; an honest spatial
+benchmark would need it. What _is_ canonical today is _correctness against the OGC suite_,
+expressed as a ratchet floor: a monotone lower bound on the number of conformance assertions
+that pass, which CI enforces and which may only rise.
+
+#figure(
+  table(
+    columns: 3,
+    align: (left, right, left),
+    table.header[Suite][Ratchet floor][Basis],
+    [OGC GeoSPARQL topology compliance],
+    [#headline("conformance.geosparql_topology_floor")],
+    [hand-curated sf / eh / rcc8 topology + WKT/GML equivalence],
+  ),
+  caption: [
+    The spatial layer's deterministic conformance floor: passing OGC GeoSPARQL topology
+    assertions. A monotone lower bound a CI test enforces — machine-independent (the value of a
+    `const` an assertion checks), not a timing. The floor may only rise.
+  ],
+)
+
+#provenance("conformance.geosparql_topology_floor")
+
+This floor is deterministic and machine-independent: it is the value of a constant the OGC
+compliance test asserts, identical on any host, with no dependence on wall-clock timing. That
+property is exactly why it can back a headline here while a latency number could not.
+
+== One cross-family ratchet, guarded against drift <ratchet>
+
+The spatial floor does not stand alone. The project maintains a _single central scoreboard_:
+a registry of every conformance suite it gates — across crates — each row carrying the spec
+family, the runner that executes it, the CI job that enforces it, and its ratchet floor. The
+scoreboard registers #headline("conformance.suite_count") suites with a combined floor of
+#headline("conformance.cross_family_total") passing assertions:
+
+#figure(
+  table(
+    columns: 3,
+    align: (left, left, right),
+    table.header[Suite][Family][Floor],
+    [W3C SPARQL (query + update + syntax)],
+    [W3C SPARQL],
+    [#headline("conformance.sparql_floor")],
+    [Inference (rdf-mt / OWL 2 RL / N3 / entailment)],
+    [W3C RDF Semantics + OWL + N3],
+    [#headline("conformance.inference_floor")],
+    [W3C SHACL core],
+    [W3C SHACL],
+    [#headline("conformance.shacl_core_floor")],
+    [W3C SHACL-SPARQL],
+    [W3C SHACL],
+    [#headline("conformance.shacl_sparql_floor")],
+    [OGC GeoSPARQL topology],
+    [OGC GeoSPARQL],
+    [#headline("conformance.geosparql_topology_floor")],
+    table.cell(colspan: 2)[*Total (#headline("conformance.suite_count") suites)*],
+    [*#headline("conformance.cross_family_total")*],
+  ),
+  caption: [
+    The cross-family conformance ratchet: every suite the project gates, in one registry, each
+    with a monotone floor. The spatial layer (last row) is one suite among five spanning four
+    spec families. Each floor is a deterministic integer CI enforces and that may only rise.
+  ],
+)
+
+The scoreboard is a _reporting_ registry, not a merged runner: each suite's runner stays in the
+crate where its dependencies live (so the spatial and SHACL ratchets are not pulled into the
+SPARQL/inference harness, and that harness does not depend on the spatial or SHACL crates).
+Consolidation happens at the reporting layer. To keep the central declaration honest, a guard
+test reads each crate-local runner's floor constant _textually_ and asserts it equals the value
+copied into the scoreboard — so the two can never silently diverge: if a runner raises its
+floor, the guard fails until the registry is updated to match. The cross-family total is
+therefore the sum of independently CI-enforced, drift-guarded floors, not a hand-maintained
+number.
+
+== Related work and honest positioning
+
+Faithful GeoSPARQL implementations exist in established stacks (RDF triple stores and spatial
+SPARQL engines); we do not claim a spatial-algorithm advance over them, and the geometry
+algorithms here are standard pure-Rust libraries used as-is. The only mild systems angle is the
+clean opt-in-crate architecture — spatial support that imposes no cost on a core or wasm build
+that never uses it — together with the engine-reuse (extension-function registry, generic
+entailment closure) that avoids duplicating query infrastructure. The conformance ratchet
+methodology is engineering discipline rather than a research result; it is presented here as
+the machine-checkable _evidence_ for the in-use claim, and as the mechanism that lets a spatial
+suite join a cross-family floor without a bespoke harness.
+
+== Conclusion
+
+A spatial layer need not burden the engine that hosts it: shipped as an opt-in crate, GeoSPARQL
+support costs nothing for a build that never issues a spatial query, while still inheriting the
+host engine's SPARQL evaluation and generic entailment. The honest evidence is conformance, not
+speed — an OGC topology floor of #headline("conformance.geosparql_topology_floor") that is one
+row of a single cross-family ratchet totalling #headline("conformance.cross_family_total")
+across #headline("conformance.suite_count") suites, every floor deterministic, CI-enforced,
+monotone, and guarded against drift. We make no wall-clock claim; a spatial performance
+evaluation is deferred to the canonical runner.
+
+#if not anon [
+  #line(length: 100%)
+  #text(size: 0.8em, fill: gray)[
+    sparq project · evidence traces to `crates/sparq-geo/tests`, the cross-family scoreboard in
+    `crates/sparq-conformance/src/scoreboard.rs`, and its drift guard
+    `tests/scoreboard_floors.rs`. Numbers in this document are injected at build time from the
+    paper-bound evidence file; see the provenance stamp on the published page.
+  ]
+]

--- a/site/src/components/papers/paper-provenance.tsx
+++ b/site/src/components/papers/paper-provenance.tsx
@@ -38,7 +38,8 @@ export function PaperProvenance({ prov }: { prov: Provenance }) {
       </div>
       <p>
         Numbers in this paper are injected at build time from the paper-bound evidence file
-        and trace to named tests in <code>crates/sparq-vectors/tests</code>. Of{" "}
+        and trace to named tests and conformance-ratchet constants in the sparq crates (each
+        record names its <code>source</code>). Of{" "}
         {prov.canonical + prov.indicative} evidence records,{" "}
         <strong className="text-foreground">{prov.canonical}</strong> are{" "}
         <strong className="text-foreground">canonical</strong> (deterministic,

--- a/site/src/data/paper-evidence.json
+++ b/site/src/data/paper-evidence.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "[OPUS-4.8] sq-gum8 — paper-bound EVIDENCE for the academic paper factory. Distinct from benchmarks.generated.json (which is per-commit TIMING, all environment=indicative on the dev work-box). Every record here is a DETERMINISTIC, machine-INDEPENDENT metric (recall floor / answer-safety invariant / cost-model crossover) lifted from a real test in crates/sparq-vectors/tests, so environment=canonical. The honesty gate in scripts/build-papers.mjs FAILS the build if a paper-bound headline table references an environment=indicative record. To add a number a paper may cite as a headline, it MUST appear here as environment=canonical and trace to a named test (the `source` field).",
+  "_comment": "[OPUS-4.8] sq-gum8 — paper-bound EVIDENCE for the academic paper factory. Distinct from benchmarks.generated.json (which is per-commit TIMING, all environment=indicative on the dev work-box). Every record here is a DETERMINISTIC, machine-INDEPENDENT metric (recall floor / answer-safety invariant / cost-model crossover / conformance ratchet floor) lifted from a real test or the central conformance scoreboard, so environment=canonical. The honesty gate in scripts/build-papers.mjs FAILS the build if a paper-bound headline table references an environment=indicative record. To add a number a paper may cite as a headline, it MUST appear here as environment=canonical and trace to a named test or const (the `source` field).",
   "schemaVersion": 1,
   "records": {
     "filtered_ann.recall_at_10_floor": {
@@ -59,6 +59,69 @@
       "scatter_penalty": 2.0,
       "source": "crates/sparq-vectors/src/cost.rs::CostModel::decision_crossover_default_penalty (tests/cost_model.rs)",
       "note": "Deterministic decision rule (not a measured latency): pre-filter is chosen iff m*scatter_penalty <= n, i.e. with the default scatter_penalty 2.0, iff the mask admits <= half the store. Whichever branch is picked the returned top-k is identical, so a mis-estimate costs throughput, never correctness."
+    },
+    "conformance.geosparql_topology_floor": {
+      "value": 119,
+      "unit": "passing-assertions",
+      "environment": "canonical",
+      "kind": "conformance-ratchet-floor",
+      "family": "OGC GeoSPARQL",
+      "source": "crates/sparq-geo/tests/ogc_compliance_ratchet.rs::OGC_RATCHET_FLOOR (mirrored in crates/sparq-conformance/src/scoreboard.rs; guarded by tests/scoreboard_floors.rs)",
+      "note": "OGC GeoSPARQL topology compliance ratchet floor: a monotone lower bound on passing sf/eh/rcc8 topology + WKT/GML equivalence assertions that CI enforces and that may only RISE. Deterministic and machine-independent (a const a test asserts), not a timing."
+    },
+    "conformance.sparql_floor": {
+      "value": 1229,
+      "unit": "passing-assertions",
+      "environment": "canonical",
+      "kind": "conformance-ratchet-floor",
+      "family": "W3C SPARQL",
+      "source": "crates/sparq-conformance/src/scoreboard.rs::SUITES (W3C SPARQL row); enforced by ci.yml job conformance (RATCHET=1229)",
+      "note": "W3C SPARQL 1.0/1.1/1.2 query+update+syntax ratchet floor (pass + documented divergence). Deterministic; CI-enforced; may only rise."
+    },
+    "conformance.inference_floor": {
+      "value": 1967,
+      "unit": "passing-assertions",
+      "environment": "canonical",
+      "kind": "conformance-ratchet-floor",
+      "family": "W3C RDF Semantics + OWL + N3",
+      "source": "crates/sparq-conformance/src/scoreboard.rs::SUITES (inference row); enforced by ci.yml job inference-conformance (RATCHET=1967)",
+      "note": "Inference (rdf-mt / OWL 2 RL / N3 / entailment / rdf-turtle) ratchet floor (pass + documented divergence). Deterministic; CI-enforced; may only rise."
+    },
+    "conformance.shacl_core_floor": {
+      "value": 98,
+      "unit": "passing-assertions",
+      "environment": "canonical",
+      "kind": "conformance-ratchet-floor",
+      "family": "W3C SHACL",
+      "source": "crates/sparq-shacl/tests/w3c_core.rs::BASELINE_PASS (mirrored in scoreboard.rs; guarded by tests/scoreboard_floors.rs)",
+      "note": "W3C SHACL core (data-shapes sht:Validate) ratchet floor. Deterministic; CI-enforced; may only rise."
+    },
+    "conformance.shacl_sparql_floor": {
+      "value": 5,
+      "unit": "passing-assertions",
+      "environment": "canonical",
+      "kind": "conformance-ratchet-floor",
+      "family": "W3C SHACL",
+      "source": "crates/sparq-shacl/tests/w3c_sparql.rs::SHACL_SPARQL_FLOOR (mirrored in scoreboard.rs; guarded by tests/scoreboard_floors.rs)",
+      "note": "W3C SHACL-SPARQL (sh:sparql node + property constraint sub-suites) ratchet floor. Deterministic; CI-enforced; may only rise."
+    },
+    "conformance.cross_family_total": {
+      "value": 3418,
+      "unit": "passing-assertions",
+      "environment": "canonical",
+      "kind": "conformance-ratchet-floor",
+      "family": "cross-family (5 suites)",
+      "source": "crates/sparq-conformance/src/scoreboard.rs::SUITES (sum of all ratchet_floor; rendered by render_scoreboard as the total row)",
+      "note": "Sum of the five cross-family conformance ratchet floors (SPARQL 1229 + inference 1967 + SHACL core 98 + SHACL-SPARQL 5 + GeoSPARQL 119). A single deterministic, CI-enforced, monotone index across crates. If any individual floor rises this total must be updated in lock-step (the same scoreboard const is the source)."
+    },
+    "conformance.suite_count": {
+      "value": 5,
+      "unit": "suites",
+      "environment": "canonical",
+      "kind": "conformance-ratchet-floor",
+      "family": "cross-family",
+      "source": "crates/sparq-conformance/src/scoreboard.rs::SUITES.len()",
+      "note": "Number of distinct conformance suites the central scoreboard registers and ratchets across crates (W3C SPARQL, inference, SHACL core, SHACL-SPARQL, OGC GeoSPARQL)."
     }
   }
 }

--- a/site/src/data/papers.ts
+++ b/site/src/data/papers.ts
@@ -81,6 +81,20 @@ export const PAPERS: Paper[] = [
     evidence:
       "Methodology contribution — reports no performance number as evidence; demonstrates the canonical/indicative honesty gate this factory enforces.",
   },
+  {
+    slug: "geosparql-optin-crate",
+    source: "geosparql-optin-crate.typ",
+    title:
+      "A Conformant, Opt-In GeoSPARQL Layer for a Dictionary-Id RDF Engine, Backed by a Cross-Family Conformance Ratchet",
+    blurb:
+      "An opt-in GeoSPARQL 1.0/1.1 layer that imposes no cost on a core or wasm build that never uses it, reusing the host engine's extension-function registry and generic entailment. The honest evidence is conformance, not speed: an OGC topology floor that is one row of a single cross-family, CI-enforced, drift-guarded ratchet.",
+    authors: "Jesse Wright · the sparq project",
+    venue: "ISWC resources / in-use track (or demo)",
+    status: "publishable-now",
+    family: "B",
+    evidence:
+      "Deterministic conformance ratchet floors: OGC GeoSPARQL topology (119) as one row of a 5-suite cross-family scoreboard totalling 3418, each floor CI-enforced, monotone, and guarded against drift. No latency claim; spatial algorithms are standard prior art.",
+  },
 ];
 
 export function paperBySlug(slug: string): Paper | undefined {


### PR DESCRIPTION
> 🤖 **SPARQ agent** — paper-factory epic **sq-gum8**, the next contribution authored.

## What

The **third paper** in the academic paper factory: *"A Conformant, Opt-In GeoSPARQL Layer for a Dictionary-Id RDF Engine, Backed by a Cross-Family Conformance Ratchet."* It is the inventory's **A3** candidate — the next PUBLISHABLE-NOW contribution whose **headline data is already canonical and committed**, with **no work-box / uncanonical measurement** required.

- `site/papers/geosparql-optin-crate.typ` — the single-source Typst paper (compiles to the download PDF **and** the in-site HTML fragment).
- `site/src/data/paper-evidence.json` — **7 new `environment: canonical` records** for the conformance ratchet floors, each `source`-traced to the enforcing test/const.
- `site/src/data/papers.ts` — registers the paper (index / route / nav / build are data-driven off this).
- `site/src/components/papers/paper-provenance.tsx` — generalised the footer wording (it hard-coded the vectors test path) so the provenance stays accurate across **all** papers.

## Honest framing (non-sycophantic)

This is a **resources / in-use** contribution, **not** a research novelty — exactly as `research/paper-contributions-inventory.md` (A3) classifies it. The spatial algorithms are standard pure-Rust prior art; the only systems angle is the **opt-in-crate architecture** (no core/wasm coupling) plus **engine reuse** (the `geof:` extension-function registry and the generic RDFS/OWL-RL entailment closure). The paper makes **no wall-clock claim** — the canonical performance runner is not yet operational, so the evidence is **deterministic, machine-independent, CI-enforced conformance floors** only.

## Canonical data, routed through the accessor

Every number flows through the Typst data accessor (`#headline(...)` / `#ev(...)`) over the new canonical records — **none is typed inline**. The source of truth is the committed conformance scoreboard (`crates/sparq-conformance/src/scoreboard.rs`), guard-tested against the crate-local enforcers (`tests/scoreboard_floors.rs`):

| Metric | Value | Source const |
| --- | ---: | --- |
| OGC GeoSPARQL topology floor | 119 | `OGC_RATCHET_FLOOR` |
| Cross-family scoreboard total (5 suites) | 3418 | `SUITES` (1229 + 1967 + 98 + 5 + 119) |

These are monotone (may only rise) and CI-enforced; a guard test proves each declared floor equals the floor its runner enforces, so the cross-family total can never silently drift.

## ZK/MPC

Not a C-family paper. No security/privacy/integrity/attestation property is asserted; the ZK/MPC estate remains caveated (not externally audited — sq-qhy4).

## Verification

- `npm run build-papers` → 3 papers, **13 canonical / 0 indicative** evidence records (gate passed).
- `npm run build` (full Next build) → **42 static pages exported**; the new paper's PDF + HTML fragment both carry the numbers; the per-paper route is statically generated.
- `npm run test:unit` → **108 / 108 pass**.
- `python3 scripts/check-no-perf-numbers.py --enforce` → **PASS** (0 findings).
- `bash scripts/check-privacy-claims.sh` → **PASS** (no unqualified ZK/MPC claim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)