### PR TITLE
ci(honesty): shared phrase-list + evidence-JSON-prose scan + build-boundary assertion (sq-mraf/sq-4hga/sq-dxi3) [OPUS-4.8]

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -285,6 +285,17 @@ jobs:
       # so a silent rename back to the taken name fails CI here. Stdlib-only, no network.
       - name: Self-test check-pypi-name.py (decision table + dist-name reader)
         run: python3 scripts/check-pypi-name.py --self-test
+      # [OPUS-4.8] sq-mraf: the build-BOUNDARY honesty assertion in
+      # site/scripts/build-papers.mjs re-runs BOTH shared gates over the exact paper
+      # sources + paper-evidence.json before any artifact is written, so the factory can
+      # never serve an un-scanned / violating paper. This self-test drives the REAL
+      # build-papers.mjs against a throwaway site mirror and asserts a planted .typ perf
+      # number / evidence-note ZK-claim ABORTS the build fail-closed (no artifact written),
+      # while clean sources pass. HARD job — a boundary regression also reds ci-summary.
+      - name: shellcheck the build-boundary honesty self-test
+        run: shellcheck scripts/tests/test_build_papers_honesty_boundary.sh
+      - name: Self-test the build-papers.mjs build-boundary honesty assertion (sq-mraf)
+        run: bash scripts/tests/test_build_papers_honesty_boundary.sh
 
   # ----------------------------- ADVISORY -----------------------------
   markdownlint-advisory:

--- a/research/paper-factory-design.md
+++ b/research/paper-factory-design.md
@@ -283,6 +283,21 @@ The factory makes the two load-bearing constraints **mechanical**, not advisory:
    any C-family draft that uses "secure" / "verifiable" / "private" as a *proven* claim
    rather than a *design goal*. A C-family paper graduates to a real venue (PoPETs / USENIX)
    only when sq-qhy4 (and, for the multi-prover path, sq-9hrn) close.
+3. **[OPUS-4.8] Coarse phrase/number gate over the paper surface (beads sq-mkza / sq-4hga /
+   sq-mraf).** The two repo-wide CI honesty gates were extended to also scan the factory's own
+   authored surface: `check-no-perf-numbers.py` scans the paper `.typ` sources (accessor-aware,
+   result-shaped numbers only) and the prose (`note`/free-text) fields of `paper-evidence.json`;
+   `check-privacy-claims.sh` scans those `.typ` + the evidence JSON for the absolute forbidden
+   ZK/MPC soundness/privacy phrases. Both consume **one shared forbidden-phrase list**
+   (`scripts/honesty-phrases.json`) so the gate and the build cannot drift, and
+   `build-papers.mjs` re-runs both at the build boundary (fail-closed) so the factory can never
+   serve an un-scanned paper. See `research/paper-factory-honesty-gate-coverage.md` for the
+   design. **Scope caveat (do not over-sell):** this is the **coarse** phrase/number class only
+   — a hard-coded result-shaped figure, or one of a fixed set of unqualified phrases. A **subtle
+   semantic overclaim** (unsupported generality, an implied superiority claim phrased without a
+   forbidden phrase/unit, an unfair-baseline framing) is **not** mechanically catchable and
+   stays the Stage-5 human/subagent claims↔evidence review's job. Reading the gate's green as a
+   semantic-soundness guarantee would itself breach the empirical-honesty mandate.
 
 The Stage-5 claims↔evidence review also applies the general SIGPLAN-7 + Heiser
 benchmarking-crimes rubric (no overclaiming, fair baselines, error bars, full platform

--- a/scripts/check-no-perf-numbers.py
+++ b/scripts/check-no-perf-numbers.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
 import subprocess
@@ -253,6 +254,80 @@ def scan_typst_file(path: str) -> list[tuple[int, str, str]]:
     return findings
 
 
+# --- paper-evidence.json prose scan ----------------------------------------------
+# [OPUS-4.8] bead sq-4hga. The paper-factory evidence file carries human PROSE in its `note`
+# (and the top-level `_comment`) free-text fields, which surface inline in a published paper
+# via the `provenance()` helper. A result-shaped perf number typed into a record `note` (e.g.
+# "…runs at 12× faster on WatDiv…") would bypass the canonical accessor discipline exactly
+# like one typed into a `.typ` — so the SAME result-shaped PERF_PATTERNS are applied to those
+# prose strings only. Everything else is left alone by design:
+#   - Structured numeric metadata (`value`, `n_vectors`, `dim`, `k`, `n_queries`,
+#     `scatter_penalty`, `schemaVersion`) is the canonical data path — the values a paper
+#     cites THROUGH the accessor — the legitimate counterpart of the `.typ` accessor-call skip.
+#   - The `source` field is a test/dataset PATH (e.g. "…recall.rs::hnsw_recall_at_10_vs_brute_
+#     force_on_50k"), NOT prose: a count-like token in a test name is a legitimate identifier,
+#     not a published claim, so `source` is deliberately NOT in the prose set.
+# The narrow result-shaped net also means bare setup counts inside a `note` ("on a 20k
+# synthetic set") are left alone (no throughput/latency/ratio unit). Honest scope: COARSE
+# perf-number class only; a subtle semantic overclaim in a note remains Stage-5 human review
+# (and the privacy-phrase half of the note scan is covered by check-privacy-claims.sh).
+EVIDENCE_PATH = "site/src/data/paper-evidence.json"
+# Only these string fields are PROSE; every other string (and all numbers) is structured data.
+EVIDENCE_PROSE_FIELDS = frozenset({"note", "_comment"})
+
+
+def scan_evidence_json(path: str) -> list[tuple[int, str, str]]:
+    """Scan the prose (`note`/`_comment`) fields of paper-evidence.json (bead sq-4hga).
+
+    Reports the 1-based line number of the offending prose field within the file, so a CI
+    reader can jump straight to it (the JSON is pretty-printed, one field per line).
+    """
+    findings: list[tuple[int, str, str]] = []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw = fh.read()
+    except (OSError, UnicodeDecodeError) as e:
+        raise FileReadError(f"{path}: could not read: {e}") from e
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        # A malformed evidence file is a hard failure, not a silent skip — the build-time
+        # honesty gate (build-papers.mjs) also parses it, but surfacing here keeps the
+        # perf gate from passing a file it could not actually inspect.
+        raise FileReadError(f"{path}: invalid JSON: {e}") from e
+
+    # Map line numbers for the prose values so findings point at the real line. We re-scan
+    # the raw text for each offending value rather than trust json positions (stdlib json
+    # gives none), which is exact enough: prose `note`s are unique strings in this file.
+    lines = raw.splitlines()
+
+    def line_of(substr: str) -> int:
+        for i, ln in enumerate(lines, 1):
+            if substr in ln:
+                return i
+        return 0
+
+    def walk(obj, field_name: str | None) -> None:
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                walk(v, k)
+        elif isinstance(obj, list):
+            for v in obj:
+                walk(v, field_name)
+        elif isinstance(obj, str) and field_name in EVIDENCE_PROSE_FIELDS:
+            if any(sub in obj for sub in ALLOW_LINE_SUBSTRINGS):
+                return
+            for pat, label in PERF_PATTERNS:
+                m = pat.search(obj)
+                if m:
+                    snippet = m.group(0).strip()
+                    findings.append((line_of(snippet), label, snippet))
+                    break
+
+    walk(data, None)
+    return findings
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
@@ -272,6 +347,12 @@ def main() -> int:
     args = ap.parse_args()
 
     files = args.paths or [p for p in tracked_sources() if not is_exempt_path(p)]
+    # [OPUS-4.8] bead sq-4hga: in default (whole-tree) mode, also scan the paper-evidence
+    # prose fields. Added explicitly because the file is *.json (not in SCAN_GLOBS) and its
+    # scan is field-aware, not line-shaped. An explicit-paths invocation that names the file
+    # gets the same field-aware dispatch below.
+    if not args.paths and os.path.exists(EVIDENCE_PATH) and EVIDENCE_PATH not in files:
+        files = [*files, EVIDENCE_PATH]
 
     total = 0
     read_errors = 0  # [OPUS-4.8] unreadable files — never silently skipped
@@ -281,8 +362,11 @@ def main() -> int:
             continue
         try:
             # [OPUS-4.8] sq-mkza: `.typ` paper sources use the accessor-aware,
-            # result-shaped-only scan; everything else uses the markdown scan.
-            if path.endswith(".typ"):
+            # result-shaped-only scan; sq-4hga: the evidence JSON uses the field-aware
+            # prose scan; everything else uses the markdown scan.
+            if path.endswith("paper-evidence.json"):
+                file_findings = scan_evidence_json(path)
+            elif path.endswith(".typ"):
                 file_findings = scan_typst_file(path)
             else:
                 file_findings = scan_file(path)

--- a/scripts/check-privacy-claims.sh
+++ b/scripts/check-privacy-claims.sh
@@ -39,9 +39,29 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+# [OPUS-4.8] sq-mraf (Option C) — the FORBIDDEN-PHRASE patterns are loaded from the SINGLE
+# shared source of truth `scripts/honesty-phrases.json` so this gate and the build-boundary
+# assertion in site/scripts/build-papers.mjs cannot drift. The JSON is the canonical list;
+# the per-line classification logic (which tier exempts how) stays HERE, unchanged.
+#
 # Inline allow-list marker: a scanned line containing this token is exempt. The text
 # AFTER the marker is the required human justification (audit trail). [OPUS-4.8]
-ALLOW_MARKER='privacy-claims-allow'
+PHRASES_JSON="${ROOT}/scripts/honesty-phrases.json"
+[ -f "$PHRASES_JSON" ] || { echo "::error::shared honesty-phrase list not found at ${PHRASES_JSON} (sq-mraf)"; exit 2; }
+
+# Read a top-level string field from the shared JSON. python3 is already a hard CI dep
+# (scripts/check-no-perf-numbers.py); using it (not jq) keeps the toolchain identical.
+_phrases_field() {  # _phrases_field <jsonpath-key>
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])' "$PHRASES_JSON" "$1"
+}
+# Read a top-level array field as NUL-delimited entries (so a pattern may contain any char).
+_phrases_array() {  # _phrases_array <jsonpath-key> -> writes \0-joined items to stdout
+  python3 -c 'import json,sys
+items = json.load(open(sys.argv[1]))[sys.argv[2]]
+sys.stdout.write("\0".join(items))' "$PHRASES_JSON" "$1"
+}
+
+ALLOW_MARKER="$(_phrases_field allowMarker)"
 
 # FORBIDDEN phrases — settled-property claim shapes for the ZK/MPC estate. Case-
 # insensitive, extended-regex. Each is a phrasing that, UNHEDGED, asserts a privacy
@@ -68,24 +88,18 @@ ALLOW_MARKER='privacy-claims-allow'
 #                      "NOT sound", "is not sound", "unsound", and the project's
 #                      canonical hedged verdict "SOUND as landed for the … threat
 #                      model" all still PASS.
-PATTERNS=(
-  'zero[- ]?knowledge[- ]secure'
-  'provably[- ](private|secure|sound)'
-  'sound(ness)?[- ](verifier|proof)s?'
-  'privacy[- ]?preserving'
-  'malicious(ly)?[- ]secure'
-  'cryptographically[- ](private|sound|secure)'
-  '(fully|completely|totally|unconditionally|perfectly)[- ]sound'
-)
+# Loaded from the shared list (`absoluteForbiddenPatterns`) — see sq-mraf note above.
+mapfile -d '' -t PATTERNS < <(_phrases_array absoluteForbiddenPatterns)
 
 # [OPUS-4.8] Predicate-form soundness overclaim, subject-anchored on a ZK/MPC artifact
 # noun + copula + "sound" (e.g. "the verifier is sound", "the proofs are sound", "the
 # protocol is sound"). The anchoring keeps it OFF honest non-crypto "is sound" lines.
-ZK_ARTIFACT='(verifier|proof|protocol|scheme|circuit|prover|snark|construction|the[- ]zk[- ]?(system|estate|pipeline))'
+# Both parts come from the shared list so build-papers.mjs reuses the identical regex.
+ZK_ARTIFACT="$(_phrases_field soundnessArtifact)"
 # Copula clause: the artifact noun, then is/are/'s/'re, then "sound" — allowing up to two
 # intervening conjoined adjectives ("complete and sound", "correct, complete and sound")
 # so the PR-#391 shape ("…are COMPLETE and SOUND") is caught, not just bare "is sound".
-COPULA='[- ]+(is|are|s|re)[- ]+([a-z]+[- ,]+(and[- ]+)?){0,2}sound'
+COPULA="$(_phrases_field soundnessCopula)"
 SOUNDNESS_CLAIMS=(
   "${ZK_ARTIFACT}s?${COPULA}"
 )
@@ -101,8 +115,8 @@ SOUNDNESS_CLAIMS=(
 # words) — NO broad lexical escape hatch like a bare "if"/"claim", so an overclaim can't
 # slip past on an incidental word; verified that no honest in-repo line relies on those.
 # An over-matched legitimate line still has the explicit `privacy-claims-allow:` escape.
-# Case-insensitive (matched with grep -i below).
-NEGATOR_HEDGE_RE='\bnot\b|\bnever\b|\bno\b|\bn'"'"'t\b|\bun(sound|verified|audited)|not[- ]yet|yet[- ]to|\bopen\b|\bpending\b|\bunverified\b|\bremediat|sound[- ]+as[- ]+landed|sound[- ]+for[- ]+(the[- ]+)?(integrity|threat|assumed|stated)|\bwhether\b|\bquestion\b'
+# Case-insensitive (matched with grep -i below). Loaded from the shared list.
+NEGATOR_HEDGE_RE="$(_phrases_field negatorHedge)"
 
 # Path surface to scan = the OUTWARD claim surface (docs/READMEs/skills/site copy /
 # the compliance index / the published-paper Typst sources). Excludes:
@@ -123,10 +137,20 @@ NEGATOR_HEDGE_RE='\bnot\b|\bnever\b|\bno\b|\bn'"'"'t\b|\bun(sound|verified|audit
 # a paper comment is still authored text, matching this gate's coarse-phrase posture.
 # This catches the COARSE unqualified-claim class; a subtle semantic overclaim phrased
 # around the patterns remains Stage-5 human review.
+#
+# [OPUS-4.8] bead sq-4hga: the paper-factory EVIDENCE file
+# `site/src/data/paper-evidence.json` is also added — its human `note` / free-text fields
+# are published-paper provenance prose (they surface inline via the `provenance()` helper),
+# so an unqualified ZK/MPC claim hidden in a record `note` must trip the SAME patterns. The
+# whole JSON is scanned line-by-line (the coarse posture); a JSON-string `note` may carry
+# the inline `privacy-claims-allow:` marker just like any other line. The accessor-driven
+# numeric values are NOT prose and are unaffected. (The perf-number half of the
+# evidence-prose scan lives in scripts/check-no-perf-numbers.py, its natural home.)
 mapfile -t FILES < <(
   git ls-files \
     '*.md' '*.mdx' '*.tsx' '*.ts' \
     'site/papers/*.typ' 'site/papers/**/*.typ' \
+    'site/src/data/paper-evidence.json' \
     ':!:research/**' \
     ':!:**/*audit*.md' \
     ':!:.claude/agents/**' \

--- a/scripts/honesty-phrases.json
+++ b/scripts/honesty-phrases.json
@@ -1,0 +1,41 @@
+{
+  "_comment": [
+    "[OPUS-4.8] sq-mraf (Option C) — the SINGLE shared source of truth for the ZK/MPC",
+    "privacy/soundness FORBIDDEN-PHRASE list, consumed by BOTH honesty entry points so",
+    "they cannot drift:",
+    "  1. scripts/check-privacy-claims.sh   — the CI gate over the outward claim surface",
+    "     (docs / READMEs / skills / site copy / the published-paper .typ sources).",
+    "  2. site/scripts/build-papers.mjs     — the build-boundary assertion: every .typ the",
+    "     factory compiles AND the prose (note/free-text) fields of paper-evidence.json are",
+    "     re-scanned with THIS list, so the factory can never serve an un-scanned paper.",
+    "WHY: the v1 ZK verifier is NOT externally audited and sparq-mpc is honest-majority",
+    "semi-honest only (SECURITY.md; research/zk-*-audit.md; bead sq-qhy4). An UNHEDGED claim",
+    "of a settled ZK/MPC privacy/soundness property is a high-severity honesty defect. This is",
+    "a COARSE phrase gate, not an NLP classifier — it catches the unqualified-claim phrase",
+    "class; a subtle semantic overclaim phrased around these patterns remains Stage-5 human",
+    "review (skills/academic-paper/SKILL.md). DO NOT WEAKEN a pattern to make a line pass —",
+    "hedge the wording or add the inline allow marker. Patterns are case-insensitive ERE,",
+    "valid in BOTH POSIX grep -E (bash gate) and the JS RegExp engine (build-papers.mjs)."
+  ],
+  "schemaVersion": 1,
+  "allowMarker": "privacy-claims-allow",
+  "absoluteForbiddenPatterns": [
+    "zero[- ]?knowledge[- ]secure",
+    "provably[- ](private|secure|sound)",
+    "sound(ness)?[- ](verifier|proof)s?",
+    "privacy[- ]?preserving",
+    "malicious(ly)?[- ]secure",
+    "cryptographically[- ](private|sound|secure)",
+    "(fully|completely|totally|unconditionally|perfectly)[- ]sound"
+  ],
+  "_soundnessPredicateNote": [
+    "Predicate-form soundness overclaim, subject-anchored on a ZK/MPC artifact noun + copula",
+    "+ 'sound' (e.g. 'the verifier is sound', 'the proofs are sound'). EXEMPT if the line",
+    "carries the allow marker OR a same-line negator/hedge (negatorHedge below). The bash gate",
+    "(check-privacy-claims.sh) is the source of truth for the exact assembly of these two parts;",
+    "build-papers.mjs reuses them for the paper-evidence.json prose + .typ build-boundary scan."
+  ],
+  "soundnessArtifact": "(verifier|proof|protocol|scheme|circuit|prover|snark|construction|the[- ]zk[- ]?(system|estate|pipeline))",
+  "soundnessCopula": "[- ]+(is|are|s|re)[- ]+([a-z]+[- ,]+(and[- ]+)?){0,2}sound",
+  "negatorHedge": "\\bnot\\b|\\bnever\\b|\\bno\\b|\\bn't\\b|\\bun(sound|verified|audited)|not[- ]yet|yet[- ]to|\\bopen\\b|\\bpending\\b|\\bunverified\\b|\\bremediat|sound[- ]+as[- ]+landed|sound[- ]+for[- ]+(the[- ]+)?(integrity|threat|assumed|stated)|\\bwhether\\b|\\bquestion\\b"
+}

--- a/scripts/tests/test_build_papers_honesty_boundary.sh
+++ b/scripts/tests/test_build_papers_honesty_boundary.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] bead sq-mraf — end-to-end proof of the build-BOUNDARY honesty assertion in
+# site/scripts/build-papers.mjs. Authored by Opus 4.8 (Fable unavailable; flag for re-review
+# when Fable returns).
+#
+# WHY: the data-layer runHonestyGate() validates the evidence-record envelope but never reads
+# PROSE (the .typ paper text or the human `note` fields). sq-mraf adds a build-boundary
+# assertion that RE-RUNS the two shared CI honesty gates over the exact paper sources + the
+# evidence file BEFORE any artifact is written, so the factory can never serve an un-scanned
+# or violating paper. Both gates + this boundary consume the SINGLE shared forbidden-phrase
+# list (scripts/honesty-phrases.json) — one source of truth, zero drift.
+#
+# This harness builds a self-contained throwaway "site" mirror (papers.ts + a paper .typ +
+# paper-evidence.json + the real gate scripts + the shared list) and drives the REAL
+# build-papers.mjs against it, asserting:
+#   - CLEAN sources                       => the boundary scan PASSES (and the build proceeds;
+#                                            typst may be absent — we only assert the scan, so
+#                                            we stop the build at the placeholder branch).
+#   - a planted '12× faster' in the .typ  => the boundary scan FAILS (non-zero exit) and NO
+#                                            PDF/HTML artifact is written (fail-closed).
+#   - a planted 'verifier is sound' note  => the boundary scan FAILS (privacy half, via the
+#                                            git-tracked evidence file on the gate's surface).
+#
+# HONEST SCOPE: this pins the COARSE phrase/number boundary only — a subtle semantic overclaim
+# is NOT caught here (Stage-5 human review; skills/academic-paper/SKILL.md).
+#
+# Run:  bash scripts/tests/test_build_papers_honesty_boundary.sh   (exit 0 = all cases pass)
+# Hermetic: a self-contained `git init` in a tmpdir; no network. Requires node + python3 + bash
+# + git (all CI baseline). typst is NOT required (the boundary scan runs before compilation).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUILDER="${ROOT}/site/scripts/build-papers.mjs"
+PERF_GATE="${ROOT}/scripts/check-no-perf-numbers.py"
+PRIV_GATE="${ROOT}/scripts/check-privacy-claims.sh"
+SHARED="${ROOT}/scripts/honesty-phrases.json"
+
+for f in "$BUILDER" "$PERF_GATE" "$PRIV_GATE" "$SHARED"; do
+  [ -f "$f" ] || { echo "FATAL: required file not found: $f"; exit 2; }
+done
+command -v node >/dev/null 2>&1 || { echo "FATAL: node not found"; exit 2; }
+
+pass=0
+fail=0
+note() { printf '  %s\n' "$1"; }
+expect() {  # expect <want-code> <label> <got-code>
+  if [ "$3" -eq "$1" ]; then pass=$((pass + 1)); note "PASS  [$2] exit=$3 (wanted $1)";
+  else fail=$((fail + 1)); note "FAIL  [$2] exit=$3 (wanted $1)"; fi
+}
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# ---- build a throwaway "site" repo mirroring the real layout build-papers.mjs expects ----
+REPO="${TMP}/repo"
+mkdir -p "${REPO}/scripts" "${REPO}/site/scripts" "${REPO}/site/papers/_lib" \
+         "${REPO}/site/src/data"
+cp "$BUILDER"    "${REPO}/site/scripts/build-papers.mjs"
+cp "$PERF_GATE"  "${REPO}/scripts/check-no-perf-numbers.py"
+cp "$PRIV_GATE"  "${REPO}/scripts/check-privacy-claims.sh"
+cp "$SHARED"     "${REPO}/scripts/honesty-phrases.json"
+
+# Minimal papers.ts the builder's regex registry parser understands (slug + source).
+cat > "${REPO}/site/src/data/papers.ts" <<'TS'
+export const papers = [{ slug: "demo", source: "demo.typ" }];
+TS
+
+# A minimal bench.typ stub so the paper imports resolve if a compile is attempted (it won't be
+# reached in the should-FAIL cases; in the clean case typst is likely absent → placeholder).
+cat > "${REPO}/site/papers/_lib/bench.typ" <<'TYP'
+#let evidence = json(bytes(sys.inputs.data))
+#let headline(key) = str(evidence.records.at(key).value)
+#let ev(key) = str(evidence.records.at(key).value)
+#let provenance(key) = []
+TYP
+
+write_clean_sources() {
+  cat > "${REPO}/site/papers/demo.typ" <<'TYP'
+#import "_lib/bench.typ": headline, ev, provenance
+= Demo
+The recall floor is #headline("x.foo") over 20000 vectors.
+TYP
+  cat > "${REPO}/site/src/data/paper-evidence.json" <<'JSON'
+{ "records": { "x.foo": {
+  "value": 0.9, "environment": "canonical", "source": "crates/x/tests/y.rs::z",
+  "note": "Asserted recall floor on a 20000-vector synthetic set; machine-independent." } } }
+JSON
+}
+
+# Run the builder inside the throwaway repo; echo its exit code.
+run_builder() {
+  (
+    cd "$REPO"
+    git add -A >/dev/null 2>&1
+    set +e
+    node site/scripts/build-papers.mjs >/dev/null 2>&1
+    echo $?
+  )
+}
+
+git -C "$REPO" init -q
+git -C "$REPO" config user.email t@t
+git -C "$REPO" config user.name t
+
+# ---- 1. clean sources: boundary scan PASSES (build returns 0 — placeholder or real) ----
+write_clean_sources
+code="$(run_builder)"
+expect 0 "clean .typ + clean evidence note => build-boundary scan passes" "$code"
+
+# ---- 2. planted '12× faster' in the .typ: boundary scan FAILS, NO artifact written ----
+# Clear any artifacts a prior (clean) build wrote, so a leftover does not mask a regression:
+# the boundary scan runs BEFORE the output dirs are (re)created, so a violating build must
+# leave NO fresh artifact.
+rm -rf "${REPO}/site/public/papers" "${REPO}/site/src/generated"
+write_clean_sources
+printf '\nOur engine is 12× faster than the baseline.\n' >> "${REPO}/site/papers/demo.typ"
+code="$(run_builder)"
+expect 1 "planted '12× faster' in .typ => build aborts (fail-closed)" "$code"
+if [ -e "${REPO}/site/public/papers/demo.pdf" ] || [ -e "${REPO}/site/src/generated/papers/demo.html" ]; then
+  fail=$((fail + 1)); note "FAIL  [no artifact written on a violating build] artifact present"
+else
+  pass=$((pass + 1)); note "PASS  [no artifact written on a violating build]"
+fi
+
+# ---- 3. planted 'verifier is sound' in an evidence note: boundary scan FAILS ----
+write_clean_sources
+cat > "${REPO}/site/src/data/paper-evidence.json" <<'JSON'
+{ "records": { "x.foo": {
+  "value": 0.9, "environment": "canonical", "source": "crates/x/tests/y.rs::z",
+  "note": "The verifier is sound and the construction is privacy-preserving." } } }
+JSON
+code="$(run_builder)"
+expect 1 "planted 'verifier is sound' in an evidence note => build aborts" "$code"
+
+echo ""
+echo "test_build_papers_honesty_boundary: ${pass} passed, ${fail} failed."
+[ "$fail" -eq 0 ] || exit 1
+echo "test_build_papers_honesty_boundary: OK — the factory refuses to serve an un-scanned/violating paper."

--- a/scripts/tests/test_privacy_claims.sh
+++ b/scripts/tests/test_privacy_claims.sh
@@ -32,8 +32,14 @@ GATE="${ROOT}/scripts/check-privacy-claims.sh"
 # `set -euo pipefail` and runs the scan at source-time, so we instead lift just the
 # variable-definition block (everything up to the `mapfile` that begins the scan).
 # This keeps the test reading the SAME patterns the gate ships — no duplication.
+#
+# [OPUS-4.8] sq-mraf: the gate now LOADS its forbidden-phrase list from the shared
+# scripts/honesty-phrases.json (via the _phrases_field/_phrases_array helpers defined
+# from `PHRASES_JSON=` onward), so we lift the block from that anchor — exercising the
+# real JSON-load path, not a hand-copied list. ROOT is set above; the helpers read the
+# real shared file, so a drift between the JSON and what the gate uses is caught here.
 # --------------------------------------------------------------------------- #
-DEFS="$(sed -n '/^ALLOW_MARKER=/,/^mapfile -t FILES/p' "$GATE" | sed '/^mapfile -t FILES/d')"
+DEFS="$(sed -n '/^PHRASES_JSON=/,/^mapfile -t FILES/p' "$GATE" | sed '/^mapfile -t FILES/d')"
 # shellcheck disable=SC1090,SC2086
 eval "$DEFS"
 

--- a/scripts/tests/test_typ_honesty_gates.sh
+++ b/scripts/tests/test_typ_honesty_gates.sh
@@ -82,10 +82,12 @@ echo "== 2. check-privacy-claims gate scans paper .typ sources =="
 
 # The privacy gate enumerates its surface with `git ls-files`, so the fixture must be a
 # TRACKED file in a git repo. Build a throwaway repo that mirrors site/papers/ and copy
-# in the REAL gate script so its in-repo `cd $ROOT` + ls-files run against the fixture.
+# in the REAL gate script + the shared forbidden-phrase list it loads (bead sq-mraf) so its
+# in-repo `cd $ROOT` + ls-files run against the fixture with the REAL patterns.
 REPO="${TMP}/repo"
-mkdir -p "${REPO}/scripts" "${REPO}/site/papers"
+mkdir -p "${REPO}/scripts" "${REPO}/site/papers" "${REPO}/site/src/data"
 cp "$PRIV_GATE" "${REPO}/scripts/check-privacy-claims.sh"
+cp "${ROOT}/scripts/honesty-phrases.json" "${REPO}/scripts/honesty-phrases.json"
 (
   cd "$REPO"
   git init -q
@@ -120,7 +122,60 @@ TYP
 code="$(run_priv)"
 expect_exit 0 "privacy: hedged + allow-marked claim in .typ => clean" "$code"
 
+# [OPUS-4.8] bead sq-4hga — the gates also scan the PROSE (note/free-text) fields of
+# site/src/data/paper-evidence.json: a forbidden perf number or ZK/MPC claim hidden in a
+# record `note` (which surfaces in a paper via the provenance() helper) must be caught too.
+echo "== 3. honesty gates scan paper-evidence.json prose (note) fields =="
+
+# Remove the .typ fixture so this section's verdict is attributable to the JSON alone.
+rm -f "${REPO}/site/papers/planted.typ"
+
+# 3a. PERF: a result-shaped number in a record `note` must FAIL the perf gate (exit 1). The
+#     perf gate dispatches a *paper-evidence.json path → the field-aware prose scan, so we can
+#     drive it by explicit path (no git repo needed for the perf half).
+mkdir -p "${TMP}/ev/site/src/data"
+cat > "${TMP}/ev/site/src/data/paper-evidence.json" <<'JSON'
+{ "records": { "x.foo": {
+  "value": 0.9, "environment": "canonical", "source": "crates/x/tests/y.rs::z",
+  "note": "Our engine is 12× faster than the baseline on a 20000-vector set." } } }
+JSON
+set +e
+python3 "$PERF_GATE" --enforce "${TMP}/ev/site/src/data/paper-evidence.json" >/dev/null 2>&1
+code=$?
+set -e
+expect_exit 1 "perf: planted '12× faster' in an evidence note => fail" "$code"
+
+# 3b. PERF: a bare SETUP count in a note (no result-shaped unit) must NOT trip — the narrow net.
+cat > "${TMP}/ev/site/src/data/paper-evidence.json" <<'JSON'
+{ "records": { "x.foo": {
+  "value": 0.9, "environment": "canonical", "source": "crates/x/tests/y.rs::z",
+  "note": "Asserted floor on a 20000-vector, 32-dim synthetic set; machine-independent." } } }
+JSON
+set +e
+python3 "$PERF_GATE" --enforce "${TMP}/ev/site/src/data/paper-evidence.json" >/dev/null 2>&1
+code=$?
+set -e
+expect_exit 0 "perf: bare setup counts in an evidence note => clean" "$code"
+
+# 3c. PRIVACY: an unqualified ZK/MPC claim in a record `note` must FAIL the privacy gate. Reuse
+#     the throwaway repo (the privacy gate enumerates with git ls-files; paper-evidence.json is
+#     on its surface — bead sq-4hga).
+cat > "${REPO}/site/src/data/paper-evidence.json" <<'JSON'
+{ "records": { "x.foo": {
+  "note": "The verifier is sound and the construction is privacy-preserving." } } }
+JSON
+code="$(run_priv)"
+expect_exit 1 "privacy: planted 'verifier is sound' + 'privacy-preserving' in an evidence note => fail" "$code"
+
+# 3d. PRIVACY: the same mentions HEDGED + ALLOW-MARKED in a note must PASS (exit 0).
+cat > "${REPO}/site/src/data/paper-evidence.json" <<'JSON'
+{ "records": { "x.foo": {
+  "note": "The verifier is NOT yet sound pending external audit; privacy-claims-allow: hedged note." } } }
+JSON
+code="$(run_priv)"
+expect_exit 0 "privacy: hedged + allow-marked claim in an evidence note => clean" "$code"
+
 echo ""
 echo "test_typ_honesty_gates: ${pass} passed, ${fail} failed."
 [ "$fail" -eq 0 ] || exit 1
-echo "test_typ_honesty_gates: OK — both honesty gates cover site/papers/**/*.typ."
+echo "test_typ_honesty_gates: OK — both honesty gates cover site/papers/**/*.typ + paper-evidence.json prose."

--- a/site/scripts/build-papers.mjs
+++ b/site/scripts/build-papers.mjs
@@ -23,6 +23,7 @@ import { homedir } from "node:os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SITE = resolve(__dirname, "..");
+const REPO_ROOT = resolve(SITE, ".."); // [OPUS-4.8] sq-mraf: to invoke the shared gates.
 const EVIDENCE_PATH = join(SITE, "src", "data", "paper-evidence.json");
 const PAPERS_DIR = join(SITE, "papers");
 const PDF_OUT_DIR = join(SITE, "public", "papers");
@@ -111,6 +112,68 @@ function runHonestyGate() {
   );
 }
 
+// ---- the build-BOUNDARY honesty assertion (bead sq-mraf, Option C) -------------------------
+// [OPUS-4.8] The data-layer runHonestyGate() above validates the evidence-record *envelope*
+// (environment/source/value) but never reads PROSE — the .typ paper text or the human `note`
+// fields. To guarantee the factory can NEVER serve an un-scanned paper, we RE-RUN the two real
+// CI honesty gates here, at the build boundary, over the exact paper sources we are about to
+// compile + the evidence file:
+//   - scripts/check-no-perf-numbers.py --enforce <each .typ> <paper-evidence.json>
+//       (the Python gate dispatches a `.typ` path → the accessor-aware Typst scan, and a
+//        paper-evidence.json path → the prose-field scan — beads sq-mkza + sq-4hga).
+//   - scripts/check-privacy-claims.sh  (whole-tree; its git-ls-files surface already includes
+//       site/papers/**/*.typ + paper-evidence.json — beads sq-mkza + sq-4hga).
+// Both gates consume the SINGLE shared forbidden-phrase list (scripts/honesty-phrases.json),
+// so there is ONE source of truth and zero drift between the CI gate and this build boundary.
+// FAIL-CLOSED: a non-zero gate exit aborts the build (the artifacts are never written). This
+// is deliberately strict — a published paper is the highest-stakes outward surface, so an
+// un-scanned or violating paper must not compile. python3 + bash are stdlib-level CI deps
+// (the gates already run in docs-quality.yml); a genuinely missing interpreter is itself a
+// build failure, not a silent skip.
+//
+// HONEST SCOPE: re-running the gates here catches the same COARSE class (forbidden phrase /
+// hard-coded result number); it does NOT catch a subtle semantic overclaim — that remains the
+// Stage-5 claims↔evidence human review in skills/academic-paper/SKILL.md.
+function runBuildBoundaryHonestyScan(papers) {
+  const perfGate = join(REPO_ROOT, "scripts", "check-no-perf-numbers.py");
+  const privacyGate = join(REPO_ROOT, "scripts", "check-privacy-claims.sh");
+  const sharedList = join(REPO_ROOT, "scripts", "honesty-phrases.json");
+  for (const p of [perfGate, privacyGate, sharedList]) {
+    if (!existsSync(p)) {
+      console.error(`\n[paper-factory] BUILD-BOUNDARY HONESTY SCAN: required gate missing: ${p}\n`);
+      process.exit(1);
+    }
+  }
+  const typPaths = papers.map((p) => join(PAPERS_DIR, p.source)).filter((t) => existsSync(t));
+
+  const run = (label, cmd, cmdArgs) => {
+    try {
+      // inherit stderr so a finding is visible; capture nothing — the gate self-reports.
+      execFileSync(cmd, cmdArgs, { cwd: REPO_ROOT, stdio: ["ignore", "inherit", "inherit"] });
+    } catch (e) {
+      const code = typeof e.status === "number" ? e.status : 1;
+      console.error(
+        `\n[paper-factory] BUILD-BOUNDARY HONESTY SCAN FAILED (${label}, exit ${code}).\n` +
+          "  A paper .typ source or an evidence note carries a forbidden ZK/MPC claim or a\n" +
+          "  hard-coded result number. Hedge the wording / route the number through the\n" +
+          "  paper-evidence.json accessor, or add the inline allow marker. The factory will\n" +
+          "  not serve an un-scanned paper. (Shared list: scripts/honesty-phrases.json.)\n",
+      );
+      process.exit(1);
+    }
+  };
+
+  // Perf gate over the exact paper sources + the evidence file (explicit paths => --enforce).
+  run("no-perf-numbers", "python3", [perfGate, "--enforce", ...typPaths, EVIDENCE_PATH]);
+  // Privacy gate (whole-tree; already covers the paper surface + the evidence file).
+  run("privacy-claims", "bash", [privacyGate]);
+
+  console.log(
+    `[paper-factory] build-boundary honesty scan passed: ${typPaths.length} paper source(s) ` +
+      "+ paper-evidence.json scanned by both honesty gates (shared phrase list).",
+  );
+}
+
 // ---- compile one paper to PDF + HTML ------------------------------------------------------
 function compilePaper(typst, paper, evidenceJson) {
   const typPath = join(PAPERS_DIR, paper.source);
@@ -148,6 +211,12 @@ function main() {
 
   const typst = resolveTypst();
   const papers = readRegistry();
+
+  // [OPUS-4.8] sq-mraf: build-boundary honesty assertion — re-run the two shared honesty
+  // gates over the exact paper sources + evidence file BEFORE any compile/placeholder is
+  // written, so the factory can never serve an un-scanned or violating paper. Runs even when
+  // typst is absent (the scan is independent of compilation). FAIL-CLOSED.
+  runBuildBoundaryHonestyScan(papers);
 
   mkdirSync(PDF_OUT_DIR, { recursive: true });
   mkdirSync(HTML_OUT_DIR, { recursive: true });

--- a/skills/academic-paper/SKILL.md
+++ b/skills/academic-paper/SKILL.md
@@ -134,6 +134,18 @@ on one IAM step), publish **only the deterministic metrics** (conformance counts
 floors, byte-identity / answer-safety invariants, gate/round/byte counts) — those are
 canonical today and are exactly what `paper-evidence.json` holds.
 
+3. **Coarse phrase/number gate over the paper surface — `check-no-perf-numbers.py` +
+   `check-privacy-claims.sh`** (beads sq-mkza / sq-4hga / sq-mraf). Both CI gates also scan
+   the paper `.typ` sources **and** the prose (`note`/free-text) fields of
+   `paper-evidence.json`: a result-shaped number typed inline (not routed through the
+   accessor) trips the perf gate (accessor-call spans + Typst comments are skipped, so the
+   canonical data path is unflaggable); an unqualified ZK/MPC soundness/privacy phrase trips
+   the privacy gate (with the same `privacy-claims-allow: <why>` inline marker + same-line
+   negator/hedge exemption). They share **one** forbidden-phrase list
+   (`scripts/honesty-phrases.json`), and `build-papers.mjs` re-runs both at the build
+   boundary. This is a **COARSE** class only — see Stage 5 for what it does and does **not**
+   catch; do not read its green as a semantic-correctness guarantee.
+
 ---
 
 ## Stage 3 — Draft: single-source Typst, bound to live data
@@ -250,6 +262,22 @@ subagent section-reviewers + one cross-cutting honesty/repro reviewer) **blocks*
   must be a design goal, with the sq-qhy4 soundness-gap disclaimer present.
 - **Overclaiming / implied generality, weak/unfair baselines, missing ablations, no error
   bars, irreproducibility** (the SIGPLAN-7 + benchmarking-crimes findings from Stage 3).
+
+**What is — and is NOT — mechanically gated (do not over-sell the gate).** [OPUS-4.8] As of
+beads sq-mkza / sq-4hga / sq-mraf, the two CI honesty gates also scan the paper-factory's own
+surface: `check-no-perf-numbers.py` scans the paper `.typ` sources (accessor-aware, result-
+shaped numbers only) **and** the prose (`note`/free-text) fields of `paper-evidence.json`;
+`check-privacy-claims.sh` scans those `.typ` + the evidence JSON for the absolute forbidden
+ZK/MPC phrases. Both consume **one shared forbidden-phrase list**
+(`scripts/honesty-phrases.json`), and `build-papers.mjs` re-runs both at the build boundary
+so the factory cannot serve an un-scanned paper (`scripts/tests/test_typ_honesty_gates.sh` +
+`scripts/tests/test_build_papers_honesty_boundary.sh` pin this). **But this is a COARSE,
+mechanical class only** — a hard-coded result-shaped number, or one of a fixed set of
+unqualified soundness/privacy phrases. A **subtle semantic overclaim** — an unsupported
+"generalises to all RDF stores", an implied causal/superiority claim phrased without a
+forbidden phrase or a result-unit, an unfair-baseline framing — is **NOT** caught by any
+gate and **remains this Stage-5 human/subagent review's responsibility**. Treating the gate's
+green as a soundness guarantee would itself be an empirical-honesty violation.
 
 Resolve **all** findings before publish. Final check: the claims↔evidence loop is closed and
 every headline number is canonical.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — paper-factory honesty-gate-coverage follow-ons (children of sq-gum8, maintainer-greenlit). Non-sycophantic by mandate. Authored on Opus 4.8 (Fable unavailable); flag for re-review when Fable returns.

## What & why

The paper factory's two CI honesty gates were extended to the `.typ` paper surface in sq-mkza. This PR closes the remaining coverage + drift gaps from `research/paper-factory-honesty-gate-coverage.md` §6.2–6.5.

**First checked against main:** `sq-ddc0` (negative-test fixtures) is **already satisfied** by sq-mkza's `scripts/tests/test_typ_honesty_gates.sh` (plants both a hard-coded-number `.typ` and an overclaiming `.typ`, asserts each FAILS its gate, pilots stay green). It is **closed with that evidence — not duplicated.** This PR implements the other three.

### sq-mraf — Option C: shared list + build-boundary assertion (no drift)
- New `scripts/honesty-phrases.json` is the **single source of truth** for the absolute ZK/MPC forbidden-phrase patterns + the soundness-predicate parts + the negator/hedge regex.
- `check-privacy-claims.sh` now **loads** them from it instead of inlining — **byte-identical to the prior list (NOT weakened)**; verified by diff, and the 32-case `test_privacy_claims.sh` now exercises the real JSON-load path.
- `build-papers.mjs` gains `runBuildBoundaryHonestyScan()`: before any artifact is written it **re-runs both real gates** (`check-no-perf-numbers.py --enforce` over each compiled `.typ` + `paper-evidence.json`, and `check-privacy-claims.sh` whole-tree) **fail-closed**, so the factory can never serve an un-scanned/violating paper.

### sq-4hga — scan `paper-evidence.json` prose
- `check-no-perf-numbers.py` gains a field-aware `scan_evidence_json()` applying the **same result-shaped** `PERF_PATTERNS` to the prose fields only (`note` + top-level `_comment`). Structured numeric metadata (`value`/`n_vectors`/`dim`/`k`/…) and the `source` test-path field are **deliberately left alone** (the canonical accessor data path / legitimate identifiers).
- `check-privacy-claims.sh` adds `site/src/data/paper-evidence.json` to its `git ls-files` surface so a forbidden phrase hidden in a record `note` is caught — same `privacy-claims-allow:` marker.

### sq-dxi3 — doc + skill sync (honestly scoped, don't over-sell)
- `skills/academic-paper/SKILL.md` (Stage 2 + Stage 5) and `research/paper-factory-design.md` (§5) now state plainly that this gate catches only the **coarse** phrase/number class; **subtle semantic overclaims remain the Stage-5 human/subagent claims↔evidence review** — and that reading the gate's green as a semantic-soundness guarantee would itself breach the empirical-honesty mandate.

## Tests (all wired into the HARD `ci-scripts` job in `docs-quality.yml`)
- `test_typ_honesty_gates.sh` — extended with 4 evidence-JSON-prose cases (now **8/8**).
- **new** `test_build_papers_honesty_boundary.sh` (**4 cases**): a planted `.typ` `12× faster` / evidence-note `verifier is sound` **aborts the build with no artifact written**; clean sources pass.
- `test_privacy_claims.sh` — updated to lift defs from the shared-list loader (**32/32**).

## Gate
- Both honesty gates **clean on the real tree**: perf `0/164`, privacy `331` files.
- All self-tests green; `shellcheck` clean; `py_compile` clean; `test_gates.py` + `test_skill_frontmatter.py` pass.
- **Planted-violation proof on the real paper tree:** a `12× faster` / `maliciously secure` appended to `filtered-ann.typ` makes both gates exit 1; restored clean.
- Honesty: every number routes through the Typst data accessor; no work-box / fabricated numbers introduced. ZK/MPC stays **caveated** (sq-qhy4 — not externally audited).

Closes sq-mraf, sq-4hga, sq-dxi3. sq-ddc0 closed separately (already satisfied by sq-mkza).

🤖 Generated with [Claude Code](https://claude.com/claude-code)