### PR TITLE
docs: SERVICE ?var doc-currency (#739/sq-d4p) + fix stale 58→59 unsafe-site count [OPUS-4.8]

### DIFF
--- a/compliance/memsafety/audit-log.md
+++ b/compliance/memsafety/audit-log.md
@@ -12,8 +12,9 @@ roles adversarially against the *actual repo*, not the docs.
 > `#![forbid(unsafe_code)]` crates / 25 total, 56-site register, MS-G2 then OPEN) and are
 > preserved as the historical record — **do not rewrite them**. The workspace has since grown:
 > the *current* figures are **30 `#![forbid(unsafe_code)]` crates of 35 total**, with the
-> unsafe surface still confined to the same 5 crates and the register now at **58 sites**
-> (sparq-core 44 after sq-vkz7). **MS-G2 (the first-party clippy `undocumented_unsafe_blocks`
+> unsafe surface still confined to the same 5 crates and the register now at **59 sites**
+> (sparq-core 45; per the current `bench/unsafe-snapshot.json` / `unsafe-gate.py --list`).
+> **MS-G2 (the first-party clippy `undocumented_unsafe_blocks`
 > lint) and MS-G3 (standalone ASan) have since CLOSED** (sq-8wbn / sq-hybl); the
 > round-2 verdict's "PASS-with-caveat MS-5/MS-9" reflects the *audit-time* state and is left
 > as history. The live count + current control status live in `unsafe-register.md` /

--- a/compliance/memsafety/evidence.md
+++ b/compliance/memsafety/evidence.md
@@ -25,23 +25,24 @@ Accounting: **30 forbid + 5 with unsafe (sparq-core, sparq-vectors, sparq-cli,
 sparq-zk-compose, sparq-bench) = 35.** No crate is unaccounted-for. <!-- [OPUS-4.8] sq-toze.16:
 count re-verified on this branch — 35 workspace crates, 30 `#![forbid(unsafe_code)]` roots,
 5 unsafe-bearing (sq-algos + the 3 *-wasm split crates joined the forbid set since the
-sq-pro0 26/31 snapshot). The 58-site / per-crate figures (MS-2) reflect sq-vkz7. -->
+sq-pro0 26/31 snapshot). The 59-site / per-crate figures (MS-2) reflect the current
+`bench/unsafe-snapshot.json` (`total=59`, sparq-core 45). -->
 
-## MS-2 — 58-site register, count-verified
+## MS-2 — 59-site register, count-verified
 
 ```sh
-python3 scripts/unsafe-gate.py --list | tail -1     # → TOTAL=58
+python3 scripts/unsafe-gate.py --list | tail -1     # → TOTAL=59
 ```
 Per-crate (from `--check`, matching `bench/unsafe-snapshot.json` and the register §headers):
 
 | crate | snapshot | live | register rows |
 |---|---:|---:|---:|
-| sparq-core | 44 | 44 | 44 |
+| sparq-core | 45 | 45 | 45 |
 | sparq-vectors | 9 | 9 | 9 |
 | sparq-cli | 2 | 2 | 2 |
 | sparq-zk-compose | 2 | 2 | 2 |
 | sparq-bench | 1 | 1 | 1 |
-| **total** | **58** | **58** | **58** |
+| **total** | **59** | **59** | **59** |
 
 Every row carries the site kind, the invariant relied on, and how it is bounded — see
 [`unsafe-register.md`](./unsafe-register.md).

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -347,11 +347,23 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   the rows the endpoint returns and the data transferred. It is **on by default** — a
   correctness-preserving optimisation of the existing `SERVICE` path (the answer is identical to the
   unbound-then-local-join path; `SILENT`, `OPTIONAL`/left-join, multi-var and empty-binding edge cases
-  are all preserved) — and **falls back to the verbatim forward** when it can't apply (variable
-  endpoint, no bound join var, a join key bound to a blank node). The only tuning knob is the block
+  are all preserved) — and **falls back to the verbatim forward** when it can't apply (no bound join
+  var, a join key bound to a blank node). The only tuning knob is the block
   size (distinct binding tuples per remote request): **opt-in** via
   `with_service_bound_join_block_size(n, || query(&g, q))` or the `SPARQ_SERVICE_BIND_BLOCK` env var
   (default ~50). The knob never changes results — only the remote-request count vs per-request size.
+- **`SERVICE ?ep` variable endpoint** (`sq-d4p`) — a `SERVICE ?ep { P }` whose endpoint variable is
+  bound by the surrounding query is evaluated per SPARQL 1.1: the bind-join path partitions the
+  already-bound left rows by their `?ep` value and dispatches one bind-join **per distinct endpoint
+  IRI**, tagging each remote row with `?ep = <that endpoint>` so the surrounding join re-attaches it
+  to exactly the left rows that named that endpoint. A left row whose `?ep` is unbound or not an IRI
+  names no valid endpoint and contributes no federated answer. A **top-level** `SERVICE ?ep` with
+  nothing to bind it still errors (or, under `SILENT`, yields the join identity). (No new public API —
+  this is a behavioural addition on the `service` feature.)
+- **Per-query `SERVICE` timeout** (`sq-d4p`) — the SERVICE HTTP transport's socket timeout is now
+  bounded by the active `QueryBudget` deadline (it caps at `min(remaining-until-deadline, default)`
+  with a small non-zero floor), so a `SERVICE` fetch under a tight `deadline` no longer blocks for the
+  full default on an unresponsive endpoint.
 - **Window functions + custom aggregate registry** are the non-default `window-functions` cargo
   feature. **Window functions are a NON-STANDARD extension** — there is no W3C-REC SPARQL `OVER`
   syntax. sparq exposes them as a programmatic pass over a `QueryResult` (the SQL:2003 model


### PR DESCRIPTION
> 🤖 SPARQ agent — periodic repo-hygiene + drift sweep (AGENTS.md standing maintenance). DOC-ONLY; no `crates/` source changed.

## What this reconciles

Two real doc-drift findings from the sweep, both collision-free (no open PR touches these files):

### 1. `skills/sparql-query/SKILL.md` — SERVICE doc-currency for #739 (`sq-d4p`)

PR #739 added (a) variable-endpoint `SERVICE ?ep` dispatch and (b) a `QueryBudget`-bounded SERVICE timeout. The SKILL still listed **variable endpoint** as a verbatim-forward *fallback* of the bind-join — now stale, since `SERVICE ?ep` is actively dispatched **per distinct endpoint IRI** via the bind-join path. Fixed the fallback wording and added two bullets documenting the user-observable behaviour (variable-endpoint dispatch + budget-bounded timeout).

- **No public-API change** (the #739 commit states "No new public API"; G2 gate confirms PASS — no public surface changed). This is a behavioural addition on the opt-in `service` feature, so the update is to the SPARQL skill prose, not an API signature.

### 2. `compliance/memsafety/{evidence.md,audit-log.md}` — stale unsafe-site count

§MS-2 claimed a **58-site / sparq-core-44** register and quoted `unsafe-gate.py --list → TOTAL=58`. The canonical snapshot (`bench/unsafe-snapshot.json`), `unsafe-register.md`, and the live gate all say **59 / sparq-core 45**. Corrected to the verified truth; the deliberately-preserved *historical* audit-round counts (20/25, 56-site) are left untouched.

**Verification command (reproducible):**
```sh
python3 scripts/unsafe-gate.py --list | grep TOTAL   # → TOTAL=59
python3 scripts/unsafe-gate.py --check               # → sparq-core 45, live total = 59
```

## Honesty

- No ZK/MPC privacy/soundness caveat touched; privacy-claims gate **OK** (330 files). The "ZK NOT externally audited" (`sq-qhy4` pending), MPC semi-honest-only, and original-unsoundness-audit (`sq-1s2`/`sq-gbp4`) caveats are all intact and were verified present this sweep.
- No unqualified ZK/MPC claim introduced. No hard-coded perf numbers (perf-numbers gate clean).

## Gates
markdownlint **0 errors** · typos **clean** · privacy-claims **OK** · G2 public-api→skill **PASS** · perf-numbers **clean**.

Not in this PR (beaded instead): `sq-j174` — consolidate sparq-solid WAC/ACP conformance ratchets into the central sparq-conformance scoreboard (drift-scan `conformance-split` finding).
