### PR TITLE
docs(book): tested quickstart example via rustdoc_include (sq-384j) [OPUS-4.8]

### DIFF
--- a/book/src/getting-started/install.md
+++ b/book/src/getting-started/install.md
@@ -40,12 +40,20 @@ cargo run --release -p sparq-server -- --addr 127.0.0.1:3030 --format turtle dat
 
 ## Use it as a library
 
-```rust,ignore
-use sparq_core::Graph;
+The snippet below is **not hand-written prose** — it is the `quickstart` region of
+[`crates/sparq-engine/examples/quickstart.rs`](https://github.com/jeswr/sparq/blob/main/crates/sparq-engine/examples/quickstart.rs),
+embedded verbatim via mdBook's `{{#rustdoc_include}}`. That file is compiled and run by
+`cargo test -p sparq-engine --examples`, so this example cannot silently drift from the
+public API:
 
-let turtle = r#"<http://example.org/alice> a <http://schema.org/Person> ."#;
-let g = Graph::load_str(turtle, "turtle")?;
-let _rows = sparq_engine::query(&g, "SELECT ?s WHERE { ?s a <http://schema.org/Person> }")?;
+<!-- [OPUS-4.8] sq-384j — tested-example embedding. The fence is `rust,ignore` so
+`mdbook test` does NOT recompile the snippet standalone: it references the workspace
+crates `sparq-core`/`sparq-engine`, which a bare rustdoc invocation cannot resolve
+(that is the "mdbook-keeper only if inline blocks need workspace deps" case from the
+bead — avoided here by letting `cargo test` be the compile-and-run gate on the real
+file). The anchor keeps the guide a fragment of a passing test. -->
+```rust,ignore
+{{#rustdoc_include ../../../crates/sparq-engine/examples/quickstart.rs:quickstart}}
 ```
 
 ## The contributor gate

--- a/crates/sparq-engine/examples/quickstart.rs
+++ b/crates/sparq-engine/examples/quickstart.rs
@@ -1,0 +1,63 @@
+//! [OPUS-4.8] sq-384j — Tested library quickstart, embedded into the docs guide.
+//!
+//! This is the canonical "use sparq as a library" example. The region between the
+//! `ANCHOR: quickstart` / `ANCHOR_END: quickstart` markers is single-sourced into
+//! `book/src/getting-started/install.md` via mdBook's `{{#rustdoc_include}}`, so the
+//! snippet a reader sees in the guide is a fragment of THIS file — a file that
+//! `cargo test -p sparq-engine --examples` actually compiles and runs (see the
+//! `#[test]` below). Keep the anchored region self-contained and dependency-light
+//! (only `sparq-core` + `sparq-engine`, both already direct deps of this crate) so
+//! the guide example stays honest and never drifts from a passing test.
+//!
+//! Run it directly with:
+//!   cargo run -p sparq-engine --example quickstart
+
+// ANCHOR: quickstart
+use sparq_core::Graph;
+use sparq_engine::query;
+
+fn count_people(turtle: &str) -> Result<usize, String> {
+    // Parse RDF (Turtle/N-Triples/N-Quads/TriG) straight from a string.
+    let graph = Graph::load_str(turtle, "turtle")?;
+
+    // Run a SPARQL 1.1 SELECT. The result exposes `vars` (the projected
+    // variables) and `rows` (each a `Vec<Option<Term>>`, one cell per var).
+    let result = query(
+        &graph,
+        "SELECT ?person WHERE { ?person a <http://schema.org/Person> }",
+    )?;
+
+    Ok(result.rows.len())
+}
+// ANCHOR_END: quickstart
+
+fn main() {
+    let turtle = r#"
+        @prefix schema: <http://schema.org/> .
+        <http://example.org/alice> a schema:Person .
+        <http://example.org/bob>   a schema:Person .
+        <http://example.org/acme>  a schema:Organization .
+    "#;
+
+    let n = count_people(turtle).expect("query should succeed");
+    println!("{n} people");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::count_people;
+
+    // The same code path the docs guide shows, exercised by `cargo test`. If the
+    // public API drifts, this test (and therefore the embedded guide snippet)
+    // breaks loudly rather than silently going stale.
+    #[test]
+    fn quickstart_counts_people() {
+        let turtle = r#"
+            @prefix schema: <http://schema.org/> .
+            <http://example.org/alice> a schema:Person .
+            <http://example.org/bob>   a schema:Person .
+            <http://example.org/acme>  a schema:Organization .
+        "#;
+        assert_eq!(count_people(turtle).unwrap(), 2);
+    }
+}


### PR DESCRIPTION
> 🤖 **SPARQL agent** — automated change. Please review before merge.

## What

Implements bead **sq-384j**: docs-site tested-example embedding via `{{#rustdoc_include}}` of a real, test-exercised file.

The guide page `book/src/getting-started/install.md` carried a hand-written `rust,ignore` "Use it as a library" snippet — **no test exercised it**, so it could silently drift from the public API. This PR replaces it with mdBook's `{{#rustdoc_include}}` of an *anchored region* in a real example file that `cargo test` compiles **and runs**.

## Changes

- **New** `crates/sparq-engine/examples/quickstart.rs` — the canonical library quickstart. It has an `ANCHOR: quickstart … ANCHOR_END: quickstart` region and a `#[test]` that drives the same `count_people()` path. `cargo test -p sparq-engine --examples` compiles **and runs** it.
- **`book/src/getting-started/install.md`** now does:
  ````md
  ```rust,ignore
  {{#rustdoc_include ../../../crates/sparq-engine/examples/quickstart.rs:quickstart}}
  ```
  ````
  so the snippet a reader sees is a *fragment of a passing test*, not prose.

## Why `rust,ignore` (not mdbook-keeper)

The bead notes "mdbook-keeper only if inline blocks need workspace deps." The included snippet references the workspace crates `sparq-core` / `sparq-engine`, which a bare `mdbook test` (plain rustdoc, no workspace dep graph) cannot resolve. Rather than pull in `mdbook-keeper`, the fence is `rust,ignore` so `mdbook test` skips standalone recompilation — and the **real compile-and-run gate is `cargo test` on the actual file**. The anchor still guarantees the guide is a verbatim fragment of that tested file. mdBook renders the full file behind its "boring"-line toggle for compile context while showing only the anchored region.

## Honesty / scope

- No public API change — `count_people` is an example-local private `fn` over already-public APIs (`Graph::load_str`, `sparq_engine::query`), so **no `SKILL.md` (G2) update** is needed.
- No `unsafe` added — unsafe-gate not triggered.
- This is the *first* `{{#rustdoc_include}}` wiring (the install page). The broader per-surface single-source `{{#include}}` migration remains its own beads (sq-im8u); this PR deliberately scopes to the one tested-example seam the bead names.

## Gate (all green locally)

- `cargo test -p sparq-engine --example quickstart` — passes with **default** features and **`--no-default-features`**.
- `cargo clippy -p sparq-engine --all-targets -- -D warnings` — clean in **both** feature states (covers the example).
- `mdbook build book` — no `[ERROR]` lines; anchored region renders, surrounding lines collapsed as "boring".
- `mdbook test book` — passes.
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` — clean, **plain** and **`--all-features`** (the #1 silently-missed gate).
- `scripts/check-privacy-claims.sh` — OK.
- `typos` — clean on changed files.

(Pre-existing `cargo fmt --check` diffs in unrelated `aggregate.rs` / `construct.rs` are the known deferred-reformat noise documented in `rustfmt.toml`; fmt runs informationally in CI. My new file is `rustfmt`-clean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)