### PR TITLE
feat(bench): --json <path> emit for 4 example bench harnesses (sq-cxji) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3451,6 +3451,7 @@ dependencies = [
  "flate2",
  "hdt",
  "rayon",
+ "serde_json",
  "sparq-core",
  "tempfile",
  "zstd",
@@ -3571,6 +3572,7 @@ version = "0.1.0"
 dependencies = [
  "oxrdf 0.3.3",
  "rustc-hash 2.1.2",
+ "serde_json",
  "spargebra",
  "sparq-core",
  "sparq-engine",
@@ -3664,6 +3666,7 @@ version = "0.1.0"
 dependencies = [
  "oxrdf 0.3.3",
  "rustc-hash 2.1.2",
+ "serde_json",
  "sparq-core",
 ]
 

--- a/crates/sparq-hdt/Cargo.toml
+++ b/crates/sparq-hdt/Cargo.toml
@@ -94,3 +94,8 @@ hdt = { version = "0.4", features = ["sophia"] }
 # under `cargo test` parallelism. `tempfile::tempdir()` hands each invocation a
 # unique directory (auto-removed on drop), so no two tests can ever collide.
 tempfile = "3"
+# [OPUS-4.8] (sq-cxji) Test-only: PARSE the `examples/bench_load.rs` `--json` emit back
+# to assert it is valid, well-shaped JSON. The emit itself stays serde-free (hand-built
+# `format!`, mirroring `mpc_net_bench::cell_json`); serde_json is a dev-dependency so it
+# never enters the crate's published graph.
+serde_json = "1"

--- a/crates/sparq-hdt/README.md
+++ b/crates/sparq-hdt/README.md
@@ -83,6 +83,9 @@ size on disk, load time, and throughput for each. Run it for the numbers:
 
 ```sh
 cargo run --release -p sparq-hdt --example bench_load
+# add `-- --json <path>` to also write the same measurements as a machine-readable
+# JSON document (STDOUT unchanged; timings are advisory/non-canonical, nothing committed)
+cargo run --release -p sparq-hdt --example bench_load -- --json /tmp/hdt.json
 ```
 
 HDT loads faster than gunzip-and-parse. On synthetic data with mostly unique literal

--- a/crates/sparq-hdt/examples/bench_load.rs
+++ b/crates/sparq-hdt/examples/bench_load.rs
@@ -7,7 +7,18 @@
 //! Usage (generates `crates/sparq-hdt/bench-data/` on first run, gitignored):
 //! ```sh
 //! cargo run --release -p sparq-hdt --example bench_load
+//! # strictly-additive machine-readable emit (STDOUT unchanged):
+//! cargo run --release -p sparq-hdt --example bench_load -- --json /tmp/hdt.json
 //! ```
+//!
+//! [OPUS-4.8] (sq-cxji) `--json <path>` writes the SAME measurements STDOUT prints —
+//! the deterministic file sizes + triple count, plus the advisory best-of-RUNS load
+//! times — as a stable, DEPENDENCY-FREE JSON document, mirroring the `format!`-JSON
+//! convention of `crates/sparq-mpc/examples/mpc_net_bench.rs::cell_json` and
+//! `crates/sparq-text/examples/bench_text.rs`. No serde dep is added (serde_json is a
+//! TEST-only dev-dep used to parse the emit back). STDOUT is byte-for-byte unchanged
+//! whether or not the flag is present; the timings are ADVISORY + NON-CANONICAL (this
+//! dev box) and nothing is committed.
 
 use std::io::Write;
 use std::path::Path;
@@ -16,7 +27,81 @@ use std::time::Instant;
 const N_TRIPLES: usize = 1_000_000;
 const RUNS: usize = 3;
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-cxji) --json <path> machine-readable results emit
+// ---------------------------------------------------------------------------
+
+/// Extracts `--json <path>` (and its value) from argv, returning argv WITHOUT the
+/// flag pair so any positional parsing is unchanged. A bare `--json` is a usage
+/// error (exit 2), mirroring `sparq-cli` / `bench_text`'s identical flag.
+fn take_json_flag(args: Vec<String>) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
+/// Serialises the measured load comparison to stable, dependency-free JSON. The byte
+/// sizes + triple count are DETERMINISTIC (a pure function of the seeded corpus); the
+/// `*_load_secs` / `*_triples_per_s` / `speedup` numbers are best-of-RUNS wall-clock —
+/// ADVISORY + NON-CANONICAL (this dev box), stated in `note`. No serde dependency.
+fn results_json(
+    nt_bytes: u64,
+    gz_bytes: u64,
+    hdt_bytes: u64,
+    triples: usize,
+    hdt_secs: f64,
+    gz_secs: f64,
+) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"sparq-hdt bench_load\",\n");
+    s.push_str(&format!("  \"triples\": {triples},\n"));
+    s.push_str(&format!("  \"runs\": {RUNS},\n"));
+    s.push_str(
+        "  \"note\": \"file `*_bytes` + `triples` are DETERMINISTIC (a pure function of the \
+         seeded synthetic corpus); `*_load_secs`/`*_triples_per_s`/`speedup` are best-of-runs \
+         wall-clock MEASURED on the running host — ADVISORY, NON-CANONICAL (this dev box) — \
+         do not bake into committed files\",\n",
+    );
+    s.push_str(&format!("  \"nt_bytes\": {nt_bytes},\n"));
+    s.push_str(&format!("  \"gz_bytes\": {gz_bytes},\n"));
+    s.push_str(&format!("  \"hdt_bytes\": {hdt_bytes},\n"));
+    s.push_str(&format!("  \"hdt_load_secs\": {hdt_secs:.4},\n"));
+    s.push_str(&format!(
+        "  \"hdt_triples_per_s\": {:.1},\n",
+        triples as f64 / hdt_secs
+    ));
+    s.push_str(&format!("  \"gz_load_secs\": {gz_secs:.4},\n"));
+    s.push_str(&format!(
+        "  \"gz_triples_per_s\": {:.1},\n",
+        triples as f64 / gz_secs
+    ));
+    s.push_str(&format!("  \"speedup\": {:.4}\n", gz_secs / hdt_secs));
+    s.push_str("}\n");
+    s
+}
+
 fn main() {
+    let (_args, json_path) = take_json_flag(std::env::args().collect());
+
     let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("bench-data");
     std::fs::create_dir_all(&dir).unwrap();
     let nt_path = dir.join("bench.nt");
@@ -28,10 +113,11 @@ fn main() {
     }
 
     let size = |p: &Path| std::fs::metadata(p).unwrap().len();
+    let (nt_bytes, gz_bytes, hdt_bytes) = (size(&nt_path), size(&gz_path), size(&hdt_path));
     println!("file sizes:");
-    println!("  bench.nt     {:>10} bytes", size(&nt_path));
-    println!("  bench.nt.gz  {:>10} bytes", size(&gz_path));
-    println!("  bench.hdt    {:>10} bytes", size(&hdt_path));
+    println!("  bench.nt     {nt_bytes:>10} bytes");
+    println!("  bench.nt.gz  {gz_bytes:>10} bytes");
+    println!("  bench.hdt    {hdt_bytes:>10} bytes");
 
     // HDT -> Graph.
     let mut best_hdt = f64::MAX;
@@ -64,6 +150,17 @@ fn main() {
         n as f64 / best_gz
     );
     println!("speedup: {:.2}x", best_gz / best_hdt);
+
+    // [OPUS-4.8] (sq-cxji) Strictly-additive JSON emit: only when `--json <path>` was
+    // given. STDOUT above is the unchanged human table.
+    if let Some(path) = json_path {
+        let doc = results_json(nt_bytes, gz_bytes, hdt_bytes, n, best_hdt, best_gz);
+        if let Err(e) = std::fs::write(&path, doc) {
+            eprintln!("error writing --json results to {path}: {e}");
+            std::process::exit(1);
+        }
+        eprintln!("wrote load comparison to {path}");
+    }
 }
 
 /// Deterministic synthetic graph: clustered subjects, a small predicate set, and a
@@ -115,4 +212,49 @@ fn generate(nt_path: &Path, gz_path: &Path, hdt_path: &Path) {
     let hdt = hdt::Hdt::read_nt(nt_path).unwrap();
     let mut out = std::io::BufWriter::new(std::fs::File::create(hdt_path).unwrap());
     hdt.write(&mut out).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-cxji) --json emit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_flag_extraction() {
+        let argv: Vec<String> = ["bench_load", "--json", "/tmp/o.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (positional, path) = take_json_flag(argv);
+        assert_eq!(positional, vec!["bench_load"]);
+        assert_eq!(path.as_deref(), Some("/tmp/o.json"));
+        // Absent flag -> argv unchanged, no path.
+        let plain: Vec<String> = ["bench_load"].iter().map(|s| s.to_string()).collect();
+        let (p2, none) = take_json_flag(plain.clone());
+        assert_eq!(p2, plain);
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn results_json_shape_and_keys() {
+        let doc = results_json(100_000_000, 20_000_000, 12_000_000, 1_000_000, 0.25, 1.5);
+        // The dependency-free emit must round-trip through a REAL serde_json parse —
+        // this catches a malformed document (e.g. a missing comma).
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+        assert_eq!(v["harness"], "sparq-hdt bench_load");
+        assert_eq!(v["triples"], 1_000_000);
+        assert_eq!(v["runs"], RUNS);
+        assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+        assert_eq!(v["nt_bytes"], 100_000_000u64);
+        assert_eq!(v["gz_bytes"], 20_000_000u64);
+        assert_eq!(v["hdt_bytes"], 12_000_000u64);
+        assert!((v["hdt_load_secs"].as_f64().unwrap() - 0.25).abs() < 1e-9);
+        assert!((v["gz_load_secs"].as_f64().unwrap() - 1.5).abs() < 1e-9);
+        // speedup = gz_secs / hdt_secs = 1.5 / 0.25 = 6.0.
+        assert!((v["speedup"].as_f64().unwrap() - 6.0).abs() < 1e-9);
+        // triples_per_s = triples / secs.
+        assert!((v["hdt_triples_per_s"].as_f64().unwrap() - 4_000_000.0).abs() < 1.0);
+    }
 }

--- a/crates/sparq-introspect/README.md
+++ b/crates/sparq-introspect/README.md
@@ -118,6 +118,9 @@ and the olympics summary names the dataset's actual classes (asserted by
 
 ```sh
 cargo run -p sparq-introspect --example olympics_introspect --release
+# add `-- --json <path>` to also write the same measurements as a machine-readable
+# JSON document (STDOUT unchanged; timings are advisory/non-canonical, nothing committed)
+cargo run -p sparq-introspect --example olympics_introspect --release -- --json /tmp/introspect.json
 ```
 
 Tests: 22 unit (`src/lib.rs`: characteristic-set exactness, coverage, object

--- a/crates/sparq-introspect/examples/olympics_introspect.rs
+++ b/crates/sparq-introspect/examples/olympics_introspect.rs
@@ -10,10 +10,38 @@
 //! `to_text_summary` time and sizes, plus the first part of the text summary.
 //!
 //! Run: `cargo run -p sparq-introspect --example olympics_introspect --release`
+//!
+//! [OPUS-4.8] (sq-cxji) `--json <path>` writes the SAME measurements STDOUT prints —
+//! the deterministic structural counts (triples, subjects, classes, predicates,
+//! characteristic sets, namespaces, byte sizes) plus the advisory build/serialise
+//! timings — as a stable, DEPENDENCY-FREE JSON document, mirroring the `format!`-JSON
+//! convention of `crates/sparq-mpc/examples/mpc_net_bench.rs::cell_json`. (The crate
+//! already depends on serde_json for `Introspection::to_json`, but the bench emit is
+//! deliberately hand-built so the convention matches the other harnesses.) STDOUT is
+//! byte-for-byte unchanged whether or not the flag is present; timings are ADVISORY +
+//! NON-CANONICAL (this dev box) and nothing is committed.
 
 use sparq_core::Graph;
 use sparq_introspect::Introspection;
 use std::time::Instant;
+
+/// One dataset's measured row (the per-dataset emit object).
+struct DatasetResult {
+    name: String,
+    path: String,
+    triples: usize,
+    load_secs: f64,
+    build_secs: f64,
+    subjects: u64,
+    classes: usize,
+    predicates: usize,
+    characteristic_sets: u64,
+    namespaces: u64,
+    json_ms: f64,
+    json_bytes: usize,
+    summary_ms: f64,
+    summary_chars: usize,
+}
 
 fn path_of(env: &str, rel: &str) -> Option<std::path::PathBuf> {
     if let Ok(p) = std::env::var(env) {
@@ -23,23 +51,21 @@ fn path_of(env: &str, rel: &str) -> Option<std::path::PathBuf> {
     p.exists().then_some(p)
 }
 
-fn measure(name: &str, path: &std::path::Path) {
+fn measure(name: &str, path: &std::path::Path) -> DatasetResult {
     println!("==== {name} ({}) ====", path.display());
     let t0 = Instant::now();
     let text = std::fs::read_to_string(path).expect("read dataset");
     let g = Graph::load_str(&text, "ntriples").expect("parse dataset");
     drop(text);
-    println!(
-        "loaded {} triples in {:.2}s",
-        g.len(),
-        t0.elapsed().as_secs_f64()
-    );
+    let load_secs = t0.elapsed().as_secs_f64();
+    let triples = g.len();
+    println!("loaded {triples} triples in {load_secs:.2}s");
 
     let t1 = Instant::now();
     let ix = Introspection::build(&g);
-    let build_s = t1.elapsed().as_secs_f64();
+    let build_secs = t1.elapsed().as_secs_f64();
     println!(
-        "Introspection::build: {build_s:.2}s — {} subjects, {} classes, {} predicates, {} characteristic sets, {} namespaces",
+        "Introspection::build: {build_secs:.2}s — {} subjects, {} classes, {} predicates, {} characteristic sets, {} namespaces",
         ix.subjects,
         ix.classes.len(),
         ix.predicates.len(),
@@ -49,35 +75,240 @@ fn measure(name: &str, path: &std::path::Path) {
 
     let t2 = Instant::now();
     let json = ix.to_json();
-    println!(
-        "to_json: {:.0}ms, {} bytes",
-        t2.elapsed().as_secs_f64() * 1000.0,
-        json.len()
-    );
+    let json_ms = t2.elapsed().as_secs_f64() * 1000.0;
+    let json_bytes = json.len();
+    println!("to_json: {json_ms:.0}ms, {json_bytes} bytes");
 
     let t3 = Instant::now();
     let summary = ix.to_text_summary(2500);
-    println!(
-        "to_text_summary(2500): {:.1}ms, {} chars",
-        t3.elapsed().as_secs_f64() * 1000.0,
-        summary.chars().count()
-    );
+    let summary_ms = t3.elapsed().as_secs_f64() * 1000.0;
+    let summary_chars = summary.chars().count();
+    println!("to_text_summary(2500): {summary_ms:.1}ms, {summary_chars} chars");
     println!("---- text summary (budget 2500) ----\n{summary}");
+
+    DatasetResult {
+        name: name.to_string(),
+        path: path.display().to_string(),
+        triples,
+        load_secs,
+        build_secs,
+        subjects: ix.subjects,
+        classes: ix.classes.len(),
+        predicates: ix.predicates.len(),
+        characteristic_sets: ix.characteristic_sets.distinct,
+        namespaces: ix.vocabularies.distinct,
+        json_ms,
+        json_bytes,
+        summary_ms,
+        summary_chars,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-cxji) --json <path> machine-readable results emit
+// ---------------------------------------------------------------------------
+
+/// Extracts `--json <path>` (and its value) from argv, returning argv WITHOUT the
+/// flag pair so any positional parsing is unchanged. A bare `--json` is a usage
+/// error (exit 2), mirroring `sparq-cli` / `bench_text`'s identical flag.
+fn take_json_flag(args: Vec<String>) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
+/// Minimal JSON string escaper (the dependency-free emit). Dataset names + paths are
+/// ASCII in practice; anything else still yields valid `\uXXXX` escapes.
+fn json_str(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for c in raw.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Serialises the per-dataset measurements to stable, dependency-free JSON. The
+/// structural counts + byte sizes are DETERMINISTIC (pure functions of the dataset);
+/// the `*_secs`/`*_ms` timings are wall-clock — ADVISORY + NON-CANONICAL (this dev
+/// box), stated in `note`.
+fn results_json(rows: &[DatasetResult]) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"sparq-introspect olympics_introspect\",\n");
+    s.push_str(
+        "  \"note\": \"structural counts (`triples`/`subjects`/`classes`/`predicates`/\
+         `characteristic_sets`/`namespaces`) and byte sizes are DETERMINISTIC (pure \
+         functions of the dataset); `*_secs`/`*_ms` are wall-clock MEASURED on the running \
+         host — ADVISORY, NON-CANONICAL (this dev box) — do not bake into committed files\",\n",
+    );
+    s.push_str("  \"datasets\": [\n");
+    for (i, r) in rows.iter().enumerate() {
+        let comma = if i + 1 < rows.len() { "," } else { "" };
+        s.push_str(&format!(
+            "    {{ \"name\": {}, \"path\": {}, \"triples\": {}, \"subjects\": {}, \
+             \"classes\": {}, \"predicates\": {}, \"characteristic_sets\": {}, \
+             \"namespaces\": {}, \"json_bytes\": {}, \"summary_chars\": {}, \
+             \"load_secs\": {:.4}, \"build_secs\": {:.4}, \"json_ms\": {:.2}, \
+             \"summary_ms\": {:.2} }}{comma}\n",
+            json_str(&r.name),
+            json_str(&r.path),
+            r.triples,
+            r.subjects,
+            r.classes,
+            r.predicates,
+            r.characteristic_sets,
+            r.namespaces,
+            r.json_bytes,
+            r.summary_chars,
+            r.load_secs,
+            r.build_secs,
+            r.json_ms,
+            r.summary_ms,
+        ));
+    }
+    s.push_str("  ]\n");
+    s.push_str("}\n");
+    s
 }
 
 fn main() {
+    let (_args, json_path) = take_json_flag(std::env::args().collect());
+
+    let mut rows: Vec<DatasetResult> = Vec::new();
     match path_of(
         "SPARQ_OLYMPICS_NT",
         "../../bench/qlever-olympics/olympics.nt",
     ) {
-        Some(p) => measure("olympics 1.78M", &p),
+        Some(p) => rows.push(measure("olympics 1.78M", &p)),
         None => eprintln!("olympics.nt not found (set SPARQ_OLYMPICS_NT) — skipping"),
     }
     match path_of(
         "SPARQ_SYNTHETIC_NT",
         "../../bench/qlever-synthetic/synthetic.nt",
     ) {
-        Some(p) => measure("qlever-synthetic 8M", &p),
+        Some(p) => rows.push(measure("qlever-synthetic 8M", &p)),
         None => eprintln!("synthetic.nt not found (set SPARQ_SYNTHETIC_NT) — skipping"),
+    }
+
+    // [OPUS-4.8] (sq-cxji) Strictly-additive JSON emit: only when `--json <path>` was
+    // given. STDOUT above is the unchanged human report. An empty `datasets` array
+    // (neither dataset present) is still valid JSON, so the file is always written.
+    if let Some(path) = json_path {
+        let doc = results_json(&rows);
+        if let Err(e) = std::fs::write(&path, doc) {
+            eprintln!("error writing --json results to {path}: {e}");
+            std::process::exit(1);
+        }
+        eprintln!("wrote {} dataset result(s) to {path}", rows.len());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-cxji) --json emit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(name: &str, triples: usize) -> DatasetResult {
+        DatasetResult {
+            name: name.to_string(),
+            path: format!("/data/{name}.nt"),
+            triples,
+            load_secs: 1.25,
+            build_secs: 0.5,
+            subjects: 100,
+            classes: 6,
+            predicates: 40,
+            characteristic_sets: 12,
+            namespaces: 8,
+            json_ms: 3.5,
+            json_bytes: 2048,
+            summary_ms: 0.75,
+            summary_chars: 2400,
+        }
+    }
+
+    #[test]
+    fn json_flag_extraction() {
+        let argv: Vec<String> = ["olympics_introspect", "--json", "/tmp/o.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (positional, path) = take_json_flag(argv);
+        assert_eq!(positional, vec!["olympics_introspect"]);
+        assert_eq!(path.as_deref(), Some("/tmp/o.json"));
+        let plain: Vec<String> = ["olympics_introspect"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (p2, none) = take_json_flag(plain.clone());
+        assert_eq!(p2, plain);
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn json_str_escapes() {
+        assert_eq!(json_str("olympics 1.78M"), "\"olympics 1.78M\"");
+        assert_eq!(json_str("a\"b\\c\n"), "\"a\\\"b\\\\c\\n\"");
+    }
+
+    #[test]
+    fn results_json_shape_and_keys() {
+        let rows = vec![
+            sample("olympics", 1_780_000),
+            sample("synthetic", 8_000_000),
+        ];
+        let doc = results_json(&rows);
+        // The dependency-free emit must round-trip through a REAL serde_json parse —
+        // this catches a malformed document (e.g. a missing inter-row comma).
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+        assert_eq!(v["harness"], "sparq-introspect olympics_introspect");
+        assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+        let arr = v["datasets"].as_array().expect("datasets is an array");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["name"], "olympics");
+        assert_eq!(arr[0]["triples"], 1_780_000);
+        assert_eq!(arr[0]["classes"], 6);
+        assert_eq!(arr[0]["characteristic_sets"], 12);
+        assert!(arr[0]["build_secs"].is_number());
+        assert_eq!(arr[1]["name"], "synthetic");
+        assert_eq!(arr[1]["triples"], 8_000_000);
+    }
+
+    #[test]
+    fn empty_datasets_is_valid_json() {
+        // Neither dataset present -> an empty `datasets` array is still valid JSON.
+        let doc = results_json(&[]);
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+        assert_eq!(v["datasets"].as_array().unwrap().len(), 0);
     }
 }

--- a/crates/sparq-rsp/Cargo.toml
+++ b/crates/sparq-rsp/Cargo.toml
@@ -37,3 +37,10 @@ oxrdf.workspace = true
 spargebra.workspace = true
 # ISTREAM/DSTREAM row-hash diffs (already in the tree via sparq-core).
 rustc-hash.workspace = true
+
+# [OPUS-4.8] (sq-cxji) Test-only: PARSE the `examples/throughput.rs` `--json` emit back
+# to assert it is valid, well-shaped JSON. The emit itself stays serde-free (hand-built
+# `format!`, mirroring `mpc_net_bench::cell_json`); serde_json is a dev-dependency so it
+# never enters the crate's published graph.
+[dev-dependencies]
+serde_json = "1"

--- a/crates/sparq-rsp/README.md
+++ b/crates/sparq-rsp/README.md
@@ -70,7 +70,8 @@ q.flush(|result| { /* end-of-stream: close everything up to max ts */ })?;
 - **API reference** — [docs.rs/sparq-rsp](https://docs.rs/sparq-rsp).
 - **Design** — [`research/ARCHITECTURE.md`](../../research/ARCHITECTURE.md).
 - **Performance** — the `throughput` example
-  (`cargo run --release -p sparq-rsp --example throughput`) and
+  (`cargo run --release -p sparq-rsp --example throughput`; append `-- --json <path>` to
+  also write the same rows as a machine-readable JSON document, STDOUT unchanged) and
   [`bench/rsp/`](../../bench/rsp); the [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench).
 - **Contribute** — [`AGENTS.md`](../../AGENTS.md) and [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 

--- a/crates/sparq-rsp/examples/throughput.rs
+++ b/crates/sparq-rsp/examples/throughput.rs
@@ -7,7 +7,18 @@
 //!
 //! ```sh
 //! cargo run --release -p sparq-rsp --example throughput
+//! # strictly-additive machine-readable emit (STDOUT unchanged):
+//! cargo run --release -p sparq-rsp --example throughput -- --json /tmp/rsp.json
 //! ```
+//!
+//! [OPUS-4.8] (sq-cxji) `--json <path>` writes the SAME rows STDOUT prints — the
+//! deterministic `windows`/`rows` counts plus the advisory throughput timings — as
+//! a stable, DEPENDENCY-FREE JSON document, mirroring the `format!`-JSON convention
+//! of `crates/sparq-mpc/examples/mpc_net_bench.rs::cell_json` and
+//! `crates/sparq-text/examples/bench_text.rs`. No serde dep is added (serde_json is a
+//! TEST-only dev-dep used to parse the emit back). STDOUT is byte-for-byte unchanged
+//! whether or not the flag is present; timings are ADVISORY + NON-CANONICAL (this dev
+//! box) and nothing is committed.
 
 use std::time::Instant;
 
@@ -16,6 +27,19 @@ use sparq_rsp::{ContinuousQuery, EvalMode, WindowSpec, WindowedStream};
 
 const N_TRIPLES: u64 = 1_000_000;
 const N_SENSORS: u64 = 100;
+
+/// One captured measurement row. `windows`/`rows` are DETERMINISTIC (a pure function
+/// of the synthetic stream + window spec — runner-noise-immune); `mtriples_per_s` and
+/// `windows_per_s` are best-effort throughput (ADVISORY, NON-CANONICAL on this box).
+struct Row {
+    label: String,
+    mode: String,
+    mtriples_per_s: f64,
+    windows_per_s: f64,
+    windows: u64,
+    rows: u64,
+    secs: f64,
+}
 
 fn reading(sensor: u64, v: u64) -> [Term; 3] {
     [
@@ -26,7 +50,7 @@ fn reading(sensor: u64, v: u64) -> [Term; 3] {
 }
 
 /// One scenario × one strategy: windows of `range`/`step`, one triple per tick.
-fn run(label: &str, range: u64, step: u64, sparql: &str, mode: EvalMode) {
+fn run(label: &str, range: u64, step: u64, sparql: &str, mode: EvalMode) -> Row {
     let mut q = ContinuousQuery::register(sparql, WindowSpec::time(range, step))
         .expect("valid query")
         .with_mode(mode);
@@ -46,18 +70,31 @@ fn run(label: &str, range: u64, step: u64, sparql: &str, mode: EvalMode) {
     })
     .expect("eval");
     let dt = start.elapsed().as_secs_f64();
+    let mtriples_per_s = N_TRIPLES as f64 / dt / 1e6;
+    let windows_per_s = windows as f64 / dt;
     println!(
-        "{label:<48} {:<16} {:>7.2} Mtriples/s  {:>9.0} windows/s  ({windows} windows, {rows} rows, {dt:.2}s)",
+        "{label:<48} {:<16} {mtriples_per_s:>7.2} Mtriples/s  {windows_per_s:>9.0} windows/s  ({windows} windows, {rows} rows, {dt:.2}s)",
         format!("{mode:?}"),
-        N_TRIPLES as f64 / dt / 1e6,
-        windows as f64 / dt,
     );
+    Row {
+        label: label.to_string(),
+        mode: format!("{mode:?}"),
+        mtriples_per_s,
+        windows_per_s,
+        windows,
+        rows,
+        secs: dt,
+    }
 }
 
-fn run_all_modes(label: &str, range: u64, step: u64, sparql: &str) {
-    for mode in [EvalMode::Rebuild, EvalMode::PersistentDict, EvalMode::Delta, EvalMode::Snapshot]
-    {
-        run(label, range, step, sparql, mode);
+fn run_all_modes(label: &str, range: u64, step: u64, sparql: &str, out: &mut Vec<Row>) {
+    for mode in [
+        EvalMode::Rebuild,
+        EvalMode::PersistentDict,
+        EvalMode::Delta,
+        EvalMode::Snapshot,
+    ] {
+        out.push(run(label, range, step, sparql, mode));
     }
     println!();
 }
@@ -73,11 +110,13 @@ fn run_parse_cost(label: &str, sparql: &str) {
         std::hint::black_box(sparq_engine::PreparedQuery::parse(sparql)).expect("valid query");
     }
     let ns = start.elapsed().as_nanos() as f64 / f64::from(N);
-    println!("parse cost ({label}): {ns:.0} ns/parse — saved per window by parse-once registration\n");
+    println!(
+        "parse cost ({label}): {ns:.0} ns/parse — saved per window by parse-once registration\n"
+    );
 }
 
 /// Windowing only (no query): the bare S2R operator cost.
-fn run_windowing_only(window_ticks: u64) {
+fn run_windowing_only(window_ticks: u64, out: &mut Vec<Row>) {
     let mut ws = WindowedStream::empty(WindowSpec::time(window_ticks, window_ticks));
     let mut windows = 0u64;
     let start = Instant::now();
@@ -87,30 +126,249 @@ fn run_windowing_only(window_ticks: u64) {
     }
     windows += ws.flush().len() as u64;
     let dt = start.elapsed().as_secs_f64();
+    let mtriples_per_s = N_TRIPLES as f64 / dt / 1e6;
+    let windows_per_s = windows as f64 / dt;
+    let label = format!("windowing only (no query), RANGE {window_ticks}");
     println!(
-        "{:<48} {:<16} {:>7.2} Mtriples/s  {:>9.0} windows/s  ({windows} windows, {dt:.2}s)\n",
-        format!("windowing only (no query), RANGE {window_ticks}"),
+        "{label:<48} {:<16} {mtriples_per_s:>7.2} Mtriples/s  {windows_per_s:>9.0} windows/s  ({windows} windows, {dt:.2}s)\n",
         "-",
-        N_TRIPLES as f64 / dt / 1e6,
-        windows as f64 / dt,
     );
+    out.push(Row {
+        label,
+        mode: "-".to_string(),
+        mtriples_per_s,
+        windows_per_s,
+        windows,
+        rows: 0,
+        secs: dt,
+    });
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-cxji) --json <path> machine-readable results emit
+// ---------------------------------------------------------------------------
+
+/// Extracts `--json <path>` (and its value) from argv, returning argv WITHOUT the
+/// flag pair so any positional parsing is unchanged. A bare `--json` is a usage
+/// error (exit 2), mirroring `sparq-cli` / `bench_text`'s identical flag.
+fn take_json_flag(args: Vec<String>) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
+/// Minimal JSON string escaper (the dependency-free emit). Workload labels are static
+/// ASCII, so this covers the realistic input; anything else still yields valid `\uXXXX`.
+fn json_str(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for c in raw.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Serialises the run to stable, dependency-free JSON. Each `rows` object carries the
+/// SAME fields the STDOUT line prints; `windows`/`rows` are the DETERMINISTIC counts,
+/// the throughput numbers are ADVISORY + NON-CANONICAL (stated in `note`).
+fn results_json(rows: &[Row]) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"sparq-rsp throughput\",\n");
+    s.push_str(&format!("  \"n_triples\": {N_TRIPLES},\n"));
+    s.push_str(&format!("  \"n_sensors\": {N_SENSORS},\n"));
+    s.push_str(
+        "  \"note\": \"`windows`/`rows` are DETERMINISTIC (a pure function of the synthetic \
+         stream + window spec); `mtriples_per_s`/`windows_per_s`/`secs` are best-effort \
+         throughput MEASURED on the running host — ADVISORY, NON-CANONICAL (this dev box) — \
+         do not bake into committed files\",\n",
+    );
+    s.push_str("  \"rows\": [\n");
+    for (i, r) in rows.iter().enumerate() {
+        let comma = if i + 1 < rows.len() { "," } else { "" };
+        s.push_str(&format!(
+            "    {{ \"label\": {}, \"mode\": {}, \"windows\": {}, \"rows\": {}, \
+             \"mtriples_per_s\": {:.4}, \"windows_per_s\": {:.1}, \"secs\": {:.4} }}{comma}\n",
+            json_str(&r.label),
+            json_str(&r.mode),
+            r.windows,
+            r.rows,
+            r.mtriples_per_s,
+            r.windows_per_s,
+            r.secs,
+        ));
+    }
+    s.push_str("  ]\n");
+    s.push_str("}\n");
+    s
 }
 
 fn main() {
+    let (_args, json_path) = take_json_flag(std::env::args().collect());
+
     println!("{N_TRIPLES} triples, {N_SENSORS} sensors, 1 triple/tick, time windows\n");
-    run_windowing_only(1_000);
+    let mut rows: Vec<Row> = Vec::new();
+    run_windowing_only(1_000, &mut rows);
     let avg = "SELECT (AVG(?v) AS ?avg) WHERE { ?s <http://ex/value> ?v }";
     run_parse_cost("AVG", avg);
-    run_all_modes("AVG, RANGE 10 STEP 10 (tumbling, parse-sensitive)", 10, 10, avg);
-    run_all_modes("AVG, RANGE 100 STEP 100 (tumbling)", 100, 100, avg);
-    run_all_modes("AVG, RANGE 1000 STEP 1000 (tumbling)", 1_000, 1_000, avg);
-    run_all_modes("AVG, RANGE 10000 STEP 10000 (tumbling)", 10_000, 10_000, avg);
-    run_all_modes("AVG, RANGE 1000 STEP 100 (sliding 10x overlap)", 1_000, 100, avg);
-    run_all_modes("AVG, RANGE 10000 STEP 1000 (sliding 10x overlap)", 10_000, 1_000, avg);
+    run_all_modes(
+        "AVG, RANGE 10 STEP 10 (tumbling, parse-sensitive)",
+        10,
+        10,
+        avg,
+        &mut rows,
+    );
+    run_all_modes(
+        "AVG, RANGE 100 STEP 100 (tumbling)",
+        100,
+        100,
+        avg,
+        &mut rows,
+    );
+    run_all_modes(
+        "AVG, RANGE 1000 STEP 1000 (tumbling)",
+        1_000,
+        1_000,
+        avg,
+        &mut rows,
+    );
+    run_all_modes(
+        "AVG, RANGE 10000 STEP 10000 (tumbling)",
+        10_000,
+        10_000,
+        avg,
+        &mut rows,
+    );
+    run_all_modes(
+        "AVG, RANGE 1000 STEP 100 (sliding 10x overlap)",
+        1_000,
+        100,
+        avg,
+        &mut rows,
+    );
+    run_all_modes(
+        "AVG, RANGE 10000 STEP 1000 (sliding 10x overlap)",
+        10_000,
+        1_000,
+        avg,
+        &mut rows,
+    );
     run_all_modes(
         "AVG per sensor (GROUP BY), RANGE 1000 STEP 1000",
         1_000,
         1_000,
         "SELECT ?s (AVG(?v) AS ?avg) WHERE { ?s <http://ex/value> ?v } GROUP BY ?s",
+        &mut rows,
     );
+
+    // [OPUS-4.8] (sq-cxji) Strictly-additive JSON emit: only when `--json <path>` was
+    // given. STDOUT above is the unchanged human/README table.
+    if let Some(path) = json_path {
+        let doc = results_json(&rows);
+        if let Err(e) = std::fs::write(&path, doc) {
+            eprintln!("error writing --json results to {path}: {e}");
+            std::process::exit(1);
+        }
+        eprintln!("wrote {} result rows to {path}", rows.len());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-cxji) --json emit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_flag_extraction() {
+        let argv: Vec<String> = ["throughput", "--json", "/tmp/o.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (positional, path) = take_json_flag(argv);
+        assert_eq!(positional, vec!["throughput"]);
+        assert_eq!(path.as_deref(), Some("/tmp/o.json"));
+        // Absent flag -> argv unchanged, no path.
+        let plain: Vec<String> = ["throughput"].iter().map(|s| s.to_string()).collect();
+        let (p2, none) = take_json_flag(plain.clone());
+        assert_eq!(p2, plain);
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn json_str_escapes() {
+        assert_eq!(json_str("Rebuild"), "\"Rebuild\"");
+        assert_eq!(json_str("a\"b\\c\n"), "\"a\\\"b\\\\c\\n\"");
+    }
+
+    #[test]
+    fn results_json_shape_and_keys() {
+        let rows = vec![
+            Row {
+                label: "windowing only".into(),
+                mode: "-".into(),
+                mtriples_per_s: 12.5,
+                windows_per_s: 999.0,
+                windows: 1000,
+                rows: 0,
+                secs: 0.08,
+            },
+            Row {
+                label: "AVG tumbling".into(),
+                mode: "Rebuild".into(),
+                mtriples_per_s: 3.25,
+                windows_per_s: 42.0,
+                windows: 100,
+                rows: 100,
+                secs: 0.3,
+            },
+        ];
+        let doc = results_json(&rows);
+        // The dependency-free emit must round-trip through a REAL serde_json parse —
+        // this catches a malformed document (e.g. a missing inter-row comma).
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+        assert_eq!(v["harness"], "sparq-rsp throughput");
+        assert_eq!(v["n_triples"], N_TRIPLES);
+        assert_eq!(v["n_sensors"], N_SENSORS);
+        assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+        let arr = v["rows"].as_array().expect("rows is an array");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["label"], "windowing only");
+        assert_eq!(arr[0]["mode"], "-");
+        assert_eq!(arr[0]["windows"], 1000);
+        assert_eq!(arr[0]["rows"], 0);
+        assert!(arr[0]["mtriples_per_s"].is_number());
+        assert_eq!(arr[1]["label"], "AVG tumbling");
+        assert_eq!(arr[1]["mode"], "Rebuild");
+        assert_eq!(arr[1]["windows"], 100);
+        assert_eq!(arr[1]["rows"], 100);
+    }
 }

--- a/crates/sparq-sim/Cargo.toml
+++ b/crates/sparq-sim/Cargo.toml
@@ -31,3 +31,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 sparq-core = { path = "../sparq-core", version = "0.1.0" }
 oxrdf.workspace = true
 rustc-hash.workspace = true
+
+# [OPUS-4.8] (sq-cxji) Test-only: PARSE the `examples/olympics_eval.rs` `--json` emit
+# back to assert it is valid, well-shaped JSON. The emit itself stays serde-free
+# (hand-built `format!`, mirroring `mpc_net_bench::cell_json`); serde_json is a
+# dev-dependency so it never enters the crate's published graph.
+[dev-dependencies]
+serde_json = "1"

--- a/crates/sparq-sim/README.md
+++ b/crates/sparq-sim/README.md
@@ -95,6 +95,9 @@ perf dashboard.
 
 ```sh
 cargo run -p sparq-sim --example olympics_eval --release
+# add `-- --json <path>` to also write the same accuracy + latency metrics as a
+# machine-readable JSON document (STDOUT unchanged; latency advisory/non-canonical)
+cargo run -p sparq-sim --example olympics_eval --release -- --json /tmp/sim.json
 ```
 
 **The two AUCs.** Pairwise AUC asks "do two random same-class entities score higher than

--- a/crates/sparq-sim/examples/olympics_eval.rs
+++ b/crates/sparq-sim/examples/olympics_eval.rs
@@ -16,6 +16,16 @@
 //!
 //! Run: `cargo run -p sparq-sim --example olympics_eval --release`
 //! Data path: `$SPARQ_OLYMPICS_NT` or `bench/qlever-olympics/olympics.nt` at the repo root.
+//!
+//! [OPUS-4.8] (sq-cxji) `--json <path>` writes the SAME measurements STDOUT prints —
+//! the deterministic accuracy metrics (per-mode AUC, overall precision@10, pair/seed
+//! counts) plus the advisory `most_similar` latency distribution — as a stable,
+//! DEPENDENCY-FREE JSON document, mirroring the `format!`-JSON convention of
+//! `crates/sparq-mpc/examples/mpc_net_bench.rs::cell_json`. No serde dep is added
+//! (serde_json is a TEST-only dev-dep used to parse the emit back). STDOUT is
+//! byte-for-byte unchanged whether or not the flag is present; accuracy metrics are
+//! deterministic, the latency numbers are ADVISORY + NON-CANONICAL (this dev box), and
+//! nothing is committed.
 
 use oxrdf::{NamedNode, Term};
 use sparq_core::dict::Id;
@@ -30,6 +40,26 @@ const PER_CLASS: usize = 40;
 /// Only classes with at least this many members participate (skips the 2-member tails).
 const MIN_CLASS: usize = 40;
 
+/// The captured accuracy + latency metrics for the `--json` emit. Every field here is
+/// printed to STDOUT verbatim; the AUC/precision/count fields are DETERMINISTIC (pure
+/// functions of the dataset + stratified sample), the latency fields are ADVISORY.
+#[derive(Default)]
+struct EvalResult {
+    triples: usize,
+    classes_kept: usize,
+    sample_size: usize,
+    /// (mode-label, auc, n_pos_pairs, n_neg_pairs) per signature mode.
+    auc_by_mode: Vec<(String, f64, usize, usize)>,
+    precision_at_10: f64,
+    precision_hits: usize,
+    precision_scored: usize,
+    latency_calls: usize,
+    latency_mean_ms: f64,
+    latency_p50_ms: f64,
+    latency_p95_ms: f64,
+    latency_max_ms: f64,
+}
+
 fn data_path() -> Option<std::path::PathBuf> {
     if let Ok(p) = std::env::var("SPARQ_OLYMPICS_NT") {
         return Some(p.into());
@@ -39,25 +69,136 @@ fn data_path() -> Option<std::path::PathBuf> {
     p.exists().then_some(p)
 }
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-cxji) --json <path> machine-readable results emit
+// ---------------------------------------------------------------------------
+
+/// Extracts `--json <path>` (and its value) from argv, returning argv WITHOUT the
+/// flag pair so any positional parsing is unchanged. A bare `--json` is a usage
+/// error (exit 2), mirroring `sparq-cli` / `bench_text`'s identical flag.
+fn take_json_flag(args: Vec<String>) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
+/// Minimal JSON string escaper (the dependency-free emit). Mode labels are ASCII;
+/// anything else still yields valid `\uXXXX` escapes.
+fn json_str(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for c in raw.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Serialises the evaluation to stable, dependency-free JSON. The accuracy metrics
+/// (`auc`, `precision_at_10`, all counts) are DETERMINISTIC (pure functions of the
+/// dataset + stratified sample); the `latency_*_ms` numbers are wall-clock — ADVISORY
+/// + NON-CANONICAL (this dev box), stated in `note`.
+fn results_json(r: &EvalResult) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"sparq-sim olympics_eval\",\n");
+    s.push_str(
+        "  \"note\": \"accuracy metrics (`auc`, `precision_at_10`, pair/seed counts) are \
+         DETERMINISTIC (pure functions of the dataset + stratified sample); `latency_*_ms` are \
+         `most_similar` wall-clock MEASURED on the running host — ADVISORY, NON-CANONICAL \
+         (this dev box) — do not bake into committed files\",\n",
+    );
+    s.push_str(&format!("  \"triples\": {},\n", r.triples));
+    s.push_str(&format!("  \"classes_kept\": {},\n", r.classes_kept));
+    s.push_str(&format!("  \"sample_size\": {},\n", r.sample_size));
+    s.push_str("  \"auc_by_mode\": [\n");
+    for (i, (label, auc, pos, neg)) in r.auc_by_mode.iter().enumerate() {
+        let comma = if i + 1 < r.auc_by_mode.len() { "," } else { "" };
+        s.push_str(&format!(
+            "    {{ \"mode\": {}, \"auc\": {auc:.6}, \"pos_pairs\": {pos}, \"neg_pairs\": {neg} }}{comma}\n",
+            json_str(label.trim()),
+        ));
+    }
+    s.push_str("  ],\n");
+    s.push_str(&format!(
+        "  \"precision_at_10\": {:.6},\n",
+        r.precision_at_10
+    ));
+    s.push_str(&format!("  \"precision_hits\": {},\n", r.precision_hits));
+    s.push_str(&format!(
+        "  \"precision_scored\": {},\n",
+        r.precision_scored
+    ));
+    s.push_str(&format!("  \"latency_calls\": {},\n", r.latency_calls));
+    s.push_str(&format!(
+        "  \"latency_mean_ms\": {:.4},\n",
+        r.latency_mean_ms
+    ));
+    s.push_str(&format!("  \"latency_p50_ms\": {:.4},\n", r.latency_p50_ms));
+    s.push_str(&format!("  \"latency_p95_ms\": {:.4},\n", r.latency_p95_ms));
+    s.push_str(&format!("  \"latency_max_ms\": {:.4}\n", r.latency_max_ms));
+    s.push_str("}\n");
+    s
+}
+
 fn main() {
+    let (_args, json_path) = take_json_flag(std::env::args().collect());
+
     let Some(path) = data_path() else {
         eprintln!("olympics.nt not found (set SPARQ_OLYMPICS_NT or place it under bench/qlever-olympics/) — skipping");
         return;
     };
+    let mut metrics = EvalResult::default();
     let t0 = Instant::now();
     let text = std::fs::read_to_string(&path).expect("read olympics.nt");
     let g = Graph::load_str(&text, "ntriples").expect("parse olympics.nt");
     drop(text);
-    println!("loaded {} triples in {:.1}s", g.len(), t0.elapsed().as_secs_f64());
+    metrics.triples = g.len();
+    println!(
+        "loaded {} triples in {:.1}s",
+        g.len(),
+        t0.elapsed().as_secs_f64()
+    );
 
     let rdf_type = NamedNode::new(RDF_TYPE).unwrap();
     let sim = Sim::with_config(
         &g,
-        SimConfig { exclude_predicates: vec![rdf_type.clone()], ..SimConfig::default() },
+        SimConfig {
+            exclude_predicates: vec![rdf_type.clone()],
+            ..SimConfig::default()
+        },
     );
 
     // ---- Ground truth: entity id -> class ids, via one POS scan of the rdf:type block.
-    let type_id = g.id_of(&Term::NamedNode(rdf_type)).expect("rdf:type present");
+    let type_id = g
+        .id_of(&Term::NamedNode(rdf_type))
+        .expect("rdf:type present");
     let scan = g.store.scan(&[None, Some(type_id), None]);
     let mut classes_of: HashMap<Id, Vec<Id>> = HashMap::new();
     let mut members: HashMap<Id, Vec<Id>> = HashMap::new();
@@ -66,9 +207,12 @@ fn main() {
         classes_of.entry(s).or_default().push(o);
         members.entry(o).or_default().push(s);
     }
-    let mut classes: Vec<(Id, Vec<Id>)> =
-        members.into_iter().filter(|(_, m)| m.len() >= MIN_CLASS).collect();
+    let mut classes: Vec<(Id, Vec<Id>)> = members
+        .into_iter()
+        .filter(|(_, m)| m.len() >= MIN_CLASS)
+        .collect();
     classes.sort_by_key(|(c, _)| *c);
+    metrics.classes_kept = classes.len();
     println!("classes with >= {MIN_CLASS} members: {}", classes.len());
 
     // ---- Stratified sample: PER_CLASS entities per class, deterministic stride.
@@ -81,8 +225,13 @@ fn main() {
             sample.push((*e, *c));
         }
         let name = g.dict.term(*c);
-        println!("  class {name}: {} members, sampled {}", m.len(), m.len().div_ceil(stride).min(PER_CLASS));
+        println!(
+            "  class {name}: {} members, sampled {}",
+            m.len(),
+            m.len().div_ceil(stride).min(PER_CLASS)
+        );
     }
+    metrics.sample_size = sample.len();
 
     // ---- AUC over all sampled pairs (signatures cached), in BOTH signature modes:
     // PredicateNeighbor measures shared concrete context (the ranking signal used by
@@ -95,7 +244,10 @@ fn main() {
     };
     let rdf_type_nn = NamedNode::new(RDF_TYPE).unwrap();
     for (label, mode) in [
-        ("predicate+neighbor", sparq_sim::SignatureMode::PredicateNeighbor),
+        (
+            "predicate+neighbor",
+            sparq_sim::SignatureMode::PredicateNeighbor,
+        ),
         ("predicate-profile ", sparq_sim::SignatureMode::Predicates),
     ] {
         let s = Sim::with_config(
@@ -108,7 +260,13 @@ fn main() {
         );
         let sigs: Vec<(Id, sparq_sim::Signature)> = sample
             .iter()
-            .map(|&(e, _)| (e, s.signature(&g.dict.term(e)).expect("sampled entity in dict")))
+            .map(|&(e, _)| {
+                (
+                    e,
+                    s.signature(&g.dict.term(e))
+                        .expect("sampled entity in dict"),
+                )
+            })
             .collect();
         let mut pos: Vec<f64> = Vec::new();
         let mut neg: Vec<f64> = Vec::new();
@@ -123,20 +281,28 @@ fn main() {
                 }
             }
         }
+        let auc_value = auc(&pos, &neg);
         println!(
             "AUC [{label}] (same-class above cross-class): {:.4}   [{} pos / {} neg pairs, {:.1}s]",
-            auc(&pos, &neg),
+            auc_value,
             pos.len(),
             neg.len(),
             t_auc.elapsed().as_secs_f64()
         );
+        metrics
+            .auc_by_mode
+            .push((label.to_string(), auc_value, pos.len(), neg.len()));
     }
 
     // ---- precision@10 + most_similar latency, per class and overall.
     let mut latencies: Vec<f64> = Vec::new();
     let mut overall = (0usize, 0usize); // (hits, scored)
     for (c, _) in &classes {
-        let seeds: Vec<Id> = sample.iter().filter(|(_, sc)| sc == c).map(|(e, _)| *e).collect();
+        let seeds: Vec<Id> = sample
+            .iter()
+            .filter(|(_, sc)| sc == c)
+            .map(|(e, _)| *e)
+            .collect();
         let mut hits = 0;
         let mut scored = 0;
         for &e in &seeds {
@@ -162,6 +328,9 @@ fn main() {
             seeds.len()
         );
     }
+    metrics.precision_at_10 = overall.0 as f64 / overall.1.max(1) as f64;
+    metrics.precision_hits = overall.0;
+    metrics.precision_scored = overall.1;
     println!(
         "precision@10 overall: {:.3}  ({}/{})",
         overall.0 as f64 / overall.1.max(1) as f64,
@@ -171,20 +340,41 @@ fn main() {
 
     latencies.sort_by(f64::total_cmp);
     let pct = |p: f64| latencies[((latencies.len() - 1) as f64 * p) as usize];
+    let mean = latencies.iter().sum::<f64>() / latencies.len() as f64;
     println!(
         "most_similar(k=10) latency over {} calls: mean {:.2} ms, p50 {:.2} ms, p95 {:.2} ms, max {:.2} ms",
         latencies.len(),
-        latencies.iter().sum::<f64>() / latencies.len() as f64,
+        mean,
         pct(0.50),
         pct(0.95),
         latencies.last().unwrap()
     );
+    metrics.latency_calls = latencies.len();
+    metrics.latency_mean_ms = mean;
+    metrics.latency_p50_ms = pct(0.50);
+    metrics.latency_p95_ms = pct(0.95);
+    metrics.latency_max_ms = *latencies.last().unwrap();
+
+    // [OPUS-4.8] (sq-cxji) Strictly-additive JSON emit: only when `--json <path>` was
+    // given. STDOUT above is the unchanged human report.
+    if let Some(path) = json_path {
+        let doc = results_json(&metrics);
+        if let Err(e) = std::fs::write(&path, doc) {
+            eprintln!("error writing --json results to {path}: {e}");
+            std::process::exit(1);
+        }
+        eprintln!("wrote evaluation metrics to {path}");
+    }
 }
 
 /// Exact AUC by pairwise comparison (ties count ½).
 fn auc(pos: &[f64], neg: &[f64]) -> f64 {
     // Rank-sum (Mann-Whitney) over the merged score list — O((P+N) log (P+N)).
-    let mut all: Vec<(f64, bool)> = pos.iter().map(|&s| (s, true)).chain(neg.iter().map(|&s| (s, false))).collect();
+    let mut all: Vec<(f64, bool)> = pos
+        .iter()
+        .map(|&s| (s, true))
+        .chain(neg.iter().map(|&s| (s, false)))
+        .collect();
     all.sort_by(|a, b| a.0.total_cmp(&b.0));
     let mut rank_sum = 0.0;
     let mut i = 0;
@@ -205,4 +395,78 @@ fn auc(pos: &[f64], neg: &[f64]) -> f64 {
     }
     let (p, n) = (pos.len() as f64, neg.len() as f64);
     (rank_sum - p * (p + 1.0) / 2.0) / (p * n)
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-cxji) --json emit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_flag_extraction() {
+        let argv: Vec<String> = ["olympics_eval", "--json", "/tmp/o.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (positional, path) = take_json_flag(argv);
+        assert_eq!(positional, vec!["olympics_eval"]);
+        assert_eq!(path.as_deref(), Some("/tmp/o.json"));
+        let plain: Vec<String> = ["olympics_eval"].iter().map(|s| s.to_string()).collect();
+        let (p2, none) = take_json_flag(plain.clone());
+        assert_eq!(p2, plain);
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn json_str_escapes() {
+        assert_eq!(json_str("predicate+neighbor"), "\"predicate+neighbor\"");
+        assert_eq!(json_str("a\"b\\c\n"), "\"a\\\"b\\\\c\\n\"");
+    }
+
+    #[test]
+    fn results_json_shape_and_keys() {
+        let metrics = EvalResult {
+            triples: 1_780_000,
+            classes_kept: 6,
+            sample_size: 160,
+            // The label intentionally has a trailing space (mirrors the live "predicate-profile ")
+            // to assert the emit trims it.
+            auc_by_mode: vec![
+                ("predicate+neighbor".to_string(), 0.91, 1000, 8000),
+                ("predicate-profile ".to_string(), 0.97, 1000, 8000),
+            ],
+            precision_at_10: 0.85,
+            precision_hits: 136,
+            precision_scored: 160,
+            latency_calls: 160,
+            latency_mean_ms: 0.42,
+            latency_p50_ms: 0.4,
+            latency_p95_ms: 0.8,
+            latency_max_ms: 1.5,
+        };
+        let doc = results_json(&metrics);
+        // The dependency-free emit must round-trip through a REAL serde_json parse —
+        // this catches a malformed document (e.g. a missing inter-row comma).
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+        assert_eq!(v["harness"], "sparq-sim olympics_eval");
+        assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+        assert_eq!(v["triples"], 1_780_000);
+        assert_eq!(v["classes_kept"], 6);
+        assert_eq!(v["sample_size"], 160);
+        let arr = v["auc_by_mode"]
+            .as_array()
+            .expect("auc_by_mode is an array");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["mode"], "predicate+neighbor");
+        assert!((arr[0]["auc"].as_f64().unwrap() - 0.91).abs() < 1e-6);
+        assert_eq!(arr[0]["pos_pairs"], 1000);
+        // The trailing space on the second label must be trimmed in the emit.
+        assert_eq!(arr[1]["mode"], "predicate-profile");
+        assert!((v["precision_at_10"].as_f64().unwrap() - 0.85).abs() < 1e-9);
+        assert_eq!(v["precision_hits"], 136);
+        assert_eq!(v["latency_calls"], 160);
+        assert!(v["latency_p95_ms"].is_number());
+    }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-cxji** (a slice of it — see *Scope & honesty* below): extends the
dependency-free `--json <path>` results-emit to the four **example-based Rust bench
harnesses** that have a natural `fn main` + CLI args.

## What

Each harness still prints its existing human/README table to STDOUT byte-for-byte; a
strictly-additive trailing `--json <path>` ALSO writes the same measurements as a
stable, dependency-free `format!`-JSON document, mirroring the established convention
from `crates/sparq-mpc/examples/mpc_net_bench.rs::cell_json` and
`crates/sparq-text/examples/bench_text.rs::results_json` (sq-d7d/#709, sq-ghjc/#719).

| Harness | Deterministic fields (gate-grade) | Advisory fields |
|---|---|---|
| `sparq-hdt` `bench_load` | file sizes, triple count | HDT-vs-`.nt.gz` load times, speedup |
| `sparq-rsp` `throughput` | `windows`/`rows` per scenario×mode | triples/s, windows/s |
| `sparq-introspect` `olympics_introspect` | subjects/classes/predicates/char-sets/namespaces, byte sizes | load/build/serialise ms |
| `sparq-sim` `olympics_eval` | per-mode AUC, precision@10, pair/seed counts | `most_similar` latency dist |

- **NO serde dep in any binary** — the emit is hand-built `format!`; `serde_json` is a
  **TEST-only dev-dep** (added to sparq-hdt/sparq-rsp/sparq-sim; sparq-introspect
  already had it) used only to parse the emit back.
- The `--json` flag is stripped from argv **before** positional parsing, so STDOUT is
  unchanged when the flag is absent. Verified end-to-end on the rsp harness: 41
  identical lines, deterministic columns match.
- Every harness gained a `#[cfg(test)] mod tests` that round-trips the document through
  a **real `serde_json` parse** (catches a malformed emit, e.g. a missing inter-row
  comma) plus flag-extraction + escaper assertions.
- The emitted `note` states every timing is **ADVISORY + NON-CANONICAL** (this dev
  box); nothing is committed. READMEs gain a one-line `-- --json <path>` note.

## Gate (all green, for the four crates)

- `cargo build` + `cargo clippy --all-targets -- -D warnings`
- tests in **both feature states** (default AND `--all-features`), examples included
- rustdoc gate: `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps` **and** `--all-features`
- privacy-claims gate + no-perf-numbers gate pass
- no `unsafe` added; **no public API changed** (examples are binaries, not lib API), so
  no G2 SKILL.md update needed

## Scope & honesty

sq-cxji's title enumerates more harnesses than this PR. This PR deliberately covers
only the four that are **examples with natural CLI args** — the cleanest, fully-tested
slice. The still-remaining STDOUT-only harnesses are tracked as follow-up bead
**sq-k5qq** and are NOT claimed here:

- `sparq-vectors` `tests/throughput.rs` + `diskann.rs` — run under `cargo test` with
  **no CLI args**, so they need an env-var output path, not a `--json` flag (a
  materially different mechanism).
- `sparq-nlq` `examples/record_olympics.rs`; `sparq-wasm` `test/perf.cjs` + `mem.cjs`
  (JS); `bench/inference` (shell); `bench/serve` writer_spike + spikes.