### PR TITLE
ci: retry transient crates.io fetch flakes in SBOM + feature-matrix (sq-hxn7, sq-hhxc)

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -358,8 +358,42 @@ jobs:
           # Per-leg cache key so each crate+feature combination keeps its own warm
           # target dir (the feature set changes the compiled artifacts).
           shared-key: feature-matrix-${{ matrix.crate }}-${{ matrix.features }}
+      - name: Fetch dependencies (retry transient crates.io fetch)
+        # [OPUS-4.8] sq-hhxc: these `opt-in <crate>` legs were failing ~8s in with exit 101
+        # — i.e. in EARLY SETUP (registry resolve/fetch), BEFORE any real compile (8s is far
+        # too short to build) — on PRs that don't touch the crate (#721/#724). The transient
+        # crates.io fetch that `cargo build` does up front (before compiling) is the flake.
+        # Pull it out into a dedicated, bounded shell retry so the registry hiccup is
+        # absorbed here and the subsequent build resolves from the warm cache. Fails only if
+        # all 3 attempts fail (a genuine outage). No new GitHub Action dependency.
+        run: |
+          set -euo pipefail
+          n=0
+          until cargo fetch --locked; do
+            n=$((n+1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::cargo fetch failed after $n attempts (registry outage?)" >&2
+              exit 1
+            fi
+            echo "cargo fetch attempt $n failed; retrying in 10s..." >&2
+            sleep 10
+          done
       - name: Build (-p ${{ matrix.crate }} --features ${{ matrix.features }})
-        run: cargo build -p ${{ matrix.crate }} --features ${{ matrix.features }}
+        # [OPUS-4.8] sq-hhxc: bounded shell retry as a safety net — with the cache warmed by
+        # the fetch step above this normally compiles offline, but retry guards any residual
+        # transient network touch during resolution (fail only if all attempts fail).
+        run: |
+          set -euo pipefail
+          n=0
+          until cargo build -p ${{ matrix.crate }} --features ${{ matrix.features }}; do
+            n=$((n+1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::cargo build failed after $n attempts" >&2
+              exit 1
+            fi
+            echo "cargo build attempt $n failed; retrying in 10s..." >&2
+            sleep 10
+          done
       - name: Test (-p ${{ matrix.crate }} --features ${{ matrix.features }})
         if: matrix.test
         run: cargo test -p ${{ matrix.crate }} --features ${{ matrix.features }}

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -219,12 +219,47 @@ jobs:
         uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-cyclonedx
+      - name: Warm registry cache (retry transient crates.io fetch)
+        # [OPUS-4.8] sq-hxn7: `cargo cyclonedx` runs `cargo metadata`, which fetches the
+        # crates.io registry. That fetch is TRANSIENTLY flaky on hosted runners (observed
+        # `curl ... [16] Error in the HTTP2 framing layer` -> `cargo metadata exited with
+        # an error`, which failed this GATING job on unrelated PRs #719/#734/#749).
+        # Warm the registry/source cache up front in a bounded shell retry so the bulk of
+        # the network work — and the H2 framing flake — is absorbed here BEFORE the SBOM
+        # step. Fails only if all 3 attempts fail (a genuine outage). No new action dep.
+        run: |
+          set -euo pipefail
+          n=0
+          until cargo fetch --locked; do
+            n=$((n+1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::cargo fetch failed after $n attempts (registry outage?)" >&2
+              exit 1
+            fi
+            echo "cargo fetch attempt $n failed; retrying in 10s..." >&2
+            sleep 10
+          done
       - name: Generate SBOM (CycloneDX 1.5 JSON, whole workspace)
         # --all emits one SBOM per workspace member + an aggregate; JSON format.
         # [OPUS-4.8] sq-toze.28 (GS-4 / CDX-3): --spec-version 1.5 (cargo-cyclonedx
         # 0.5.9 defaults to 1.3) so the CI SBOM matches the published 1.5 SBOM/VEX;
         # the 1.5 metadata.lifecycles slot is populated by scripts/sbom-normalize.jq.
-        run: cargo cyclonedx --all --format json --spec-version 1.5
+        # [OPUS-4.8] sq-hxn7: wrapped in a bounded shell retry — cargo-cyclonedx's internal
+        # `cargo metadata` can still touch the network even with the cache warmed above, so
+        # retry the transient HTTP2-framing crates.io flake here too (fail only if all
+        # attempts fail). No new GitHub Action dependency (keeps code-scanning posture).
+        run: |
+          set -euo pipefail
+          n=0
+          until cargo cyclonedx --all --format json --spec-version 1.5; do
+            n=$((n+1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::cargo cyclonedx failed after $n attempts" >&2
+              exit 1
+            fi
+            echo "cargo cyclonedx attempt $n failed; retrying in 10s..." >&2
+            sleep 10
+          done
       - name: Normalize SBOM (strip host-revealing absolute build paths)
         # [OPUS-4.8] sq-toze.30 (GS-6 / F-6): cargo-cyclonedx stamps the absolute build dir
         # into every workspace/path-dependency bom-ref + purl, which would leak the CI
@@ -284,10 +319,37 @@ jobs:
         run: python3 scripts/tests/test_sbom_purl_canonical.py
       - name: bom-ref-canonicality check self-test (GS-6)
         run: python3 scripts/tests/test_sbom_bomref_canonical.py
+      - name: Warm registry cache (retry transient crates.io fetch)
+        # [OPUS-4.8] sq-hxn7: same transient `cargo metadata` H2-framing crates.io flake as
+        # the `sbom` job — warm the cache in a bounded shell retry before this GATING SBOM
+        # regeneration so a registry hiccup doesn't fail an unrelated PR.
+        run: |
+          set -euo pipefail
+          n=0
+          until cargo fetch --locked; do
+            n=$((n+1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::cargo fetch failed after $n attempts (registry outage?)" >&2
+              exit 1
+            fi
+            echo "cargo fetch attempt $n failed; retrying in 10s..." >&2
+            sleep 10
+          done
       - name: Generate + normalize SBOM, then assert canonical purls — GATING
         run: |
           set -euo pipefail
-          cargo cyclonedx --all --format json --spec-version 1.5
+          # [OPUS-4.8] sq-hxn7: bounded shell retry around the transient crates.io fetch
+          # inside cargo-cyclonedx's `cargo metadata` (fail only if all attempts fail).
+          n=0
+          until cargo cyclonedx --all --format json --spec-version 1.5; do
+            n=$((n+1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::cargo cyclonedx failed after $n attempts" >&2
+              exit 1
+            fi
+            echo "cargo cyclonedx attempt $n failed; retrying in 10s..." >&2
+            sleep 10
+          done
           # cargo-cyclonedx writes <crate>.cdx.json next to each member's Cargo.toml, so
           # the freshly-generated SBOMs live under crates/. Scope the normalize+assert to
           # those (NOT the committed supply-chain/vex.cdx.json, which is a VEX, carries no
@@ -332,10 +394,37 @@ jobs:
           tool: cargo-cyclonedx
       - name: supplier-name check self-test
         run: python3 scripts/tests/test_sbom_supplier.py
+      - name: Warm registry cache (retry transient crates.io fetch)
+        # [OPUS-4.8] sq-hxn7: same transient `cargo metadata` H2-framing crates.io flake as
+        # the `sbom` job — warm the cache in a bounded shell retry before this GATING SBOM
+        # regeneration so a registry hiccup doesn't fail an unrelated PR.
+        run: |
+          set -euo pipefail
+          n=0
+          until cargo fetch --locked; do
+            n=$((n+1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::cargo fetch failed after $n attempts (registry outage?)" >&2
+              exit 1
+            fi
+            echo "cargo fetch attempt $n failed; retrying in 10s..." >&2
+            sleep 10
+          done
       - name: Generate + normalize SBOM, then assert per-component supplier — GATING
         run: |
           set -euo pipefail
-          cargo cyclonedx --all --format json --spec-version 1.5
+          # [OPUS-4.8] sq-hxn7: bounded shell retry around the transient crates.io fetch
+          # inside cargo-cyclonedx's `cargo metadata` (fail only if all attempts fail).
+          n=0
+          until cargo cyclonedx --all --format json --spec-version 1.5; do
+            n=$((n+1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::cargo cyclonedx failed after $n attempts" >&2
+              exit 1
+            fi
+            echo "cargo cyclonedx attempt $n failed; retrying in 10s..." >&2
+            sleep 10
+          done
           # cargo-cyclonedx writes <crate>.cdx.json next to each member's Cargo.toml; scope
           # the normalize+assert to those generated SBOMs (NOT the committed VEX). Normalize
           # through the SAME transform the publication path uses, then assert every cargo


### PR DESCRIPTION
> 🤖 SPARQ agent

Hardens CI against two recurring **TRANSIENT-infra** flakes that kept failing GATING checks on unrelated PRs and forcing manual rebases. Both are crates.io registry-fetch hiccups (observed `curl ... [16] Error in the HTTP2 framing layer` → `cargo metadata exited with an error`), **not PR defects**. Fix is a bounded **shell retry loop** — no new GitHub Action dependency (keeps code-scanning posture).

## sq-hxn7 — `generate CycloneDX SBOM` (`.github/workflows/supply-chain.yml`)
`cargo cyclonedx` internally runs `cargo metadata`, whose crates.io fetch flaked on #719/#734/#749. In all three SBOM jobs (`sbom`, `sbom-purl-canonical`, `sbom-supplier`) I:
1. added a `cargo fetch --locked` retry step up front (warms the registry/source cache, absorbing the H2-framing flake before the SBOM step), and
2. wrapped the `cargo cyclonedx --all --format json --spec-version 1.5` invocation in the same retry (belt-and-suspenders — cyclonedx's internal `cargo metadata` can still touch the network).

Fails only if all 3 attempts fail (a genuine outage).

## sq-hhxc — `opt-in <crate>` legs (`.github/workflows/feature-matrix.yml`)
Legs failed ~8s in with **exit 101** — i.e. in EARLY SETUP (registry resolve/fetch), **before any real compile** (8s is far too short to build) — on PRs not touching the crate (#721/#724). Pulled the up-front fetch `cargo build` does into a dedicated `cargo fetch --locked` retry step, then wrapped `cargo build` as a thin safety net.

A genuine compile error still fails the leg (exit 1 after 3 attempts) — **no defect masking**; only transient fetches are absorbed.

## Retry mechanism (identical everywhere)
```sh
set -euo pipefail
n=0
until <cmd>; do
  n=$((n+1))
  if [ "$n" -ge 3 ]; then echo "::error::... failed after $n attempts" >&2; exit 1; fi
  echo "... attempt $n failed; retrying in 10s..." >&2
  sleep 10
done
```

## Gate verification
- **actionlint** 1.7.12 clean (exit 0) on both touched workflows.
- Valid YAML (`yaml.safe_load`) on both.
- **No `uses:` line added/removed/changed** → every action remains 40-hex SHA-pinned; no new action introduced (code-scanning posture intact).
- `scripts/check-install-action-tool.py --root .` → **PASS** (sq-ur7o, no regression).
- **`ci-summary` gating set UNCHANGED** — `ci-summary.yml` untouched; no gating job renamed/added/removed; only existing step commands wrapped (new `name:` entries are STEP-level, which the aggregator does not key on).
- Local reproduction: `cargo fetch --locked` → exit 0 warms all workspace deps; a representative opt-in build (`sparq-mpc --features insecure-test-rng`) then resolves/builds fully `--offline` → exit 0, confirming the fetch step neutralises the pre-compile fetch flake.

Typos gate and privacy-claims gate: no offending strings added.

🤖 SPARQ agent