### PR TITLE
docs/ci: finish crate-README template + promote readme-template to a HARD gate (sq-4lvq, sq-ixsf, sq-8ic6) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -35,8 +35,9 @@
 #   • "markdownlint-advisory (whole repo)"            (docs-quality.yml)
 #   • "external-links (lychee online, advisory)"      (docs-quality.yml)
 #   • "vale (prose, advisory)"                        (docs-quality.yml)
-#   • "readme-template (template, advisory)"          (docs-quality.yml; sq-8ic6 split
-#                                                      no-perf-numbers off to a HARD gate)
+# ([OPUS-4.8] sq-8ic6: "readme-template (template, advisory)" was PROMOTED to the HARD
+#  gate "readme-template (template)" — no advisory token, so it now GATES — once the
+#  sq-9jw5 README-overhaul backlog cleared and sq-ixsf tightened the stub classifier.)
 # REQUIRED checks (gate / build+test / clippy / coverage / the conformance + perf
 # ratchets / wasm / MSRV / supply-chain / …) do NOT contain those words, so they
 # still gate normally. Rationale: an advisory job that concludes `failure` (e.g.

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -23,6 +23,15 @@
 #                       from advisory to HARD by sq-8ic6 once the backlog cleared (the last
 #                       stray, skills/cli/SKILL.md's inline ratio, was reworded to cite the
 #                       canonical measured source). Deterministic, grep-only, no network.
+#     • readme-template — crate-README length cap + 🚀/✨/📚 sections + License
+#                       (scripts/check-readme-template.py --enforce). PROMOTED from advisory
+#                       to HARD by sq-8ic6's deferred half once the sq-9jw5 README-overhaul
+#                       epic cleared the backlog (sq-inzv brought 20 publish=true crate
+#                       READMEs to the template; sq-4lvq finished the 3 deferred crates) and
+#                       sq-ixsf tightened the stub classifier (an explicit `internal-stub`
+#                       HTML-comment directive is now required). 0 deviations across all 35
+#                       READMEs. Deterministic (line-count/grep), no network; carries a
+#                       hermetic --self-test step.
 #
 #   ADVISORY (continue-on-error / --advisory exit-0 → reported, never block a merge):
 #     • markdownlint-advisory — same rules over the WHOLE repo MINUS the HARD-gated dirs
@@ -30,13 +39,11 @@
 #                       not-yet-clean dirs (bench/, .claude/) so any backlog stays visible.
 #     • vale          — prose hygiene: weasel words, wordy phrases, adjective puffery.
 #     • external-links — lychee online: dead http(s) links (network-flaky → advisory).
-#     • readme-template — crate-README length cap + required sections (pairs w/ sq-9jw5).
-#                       Still advisory: 67-deviation backlog owned by the sq-9jw5 epic.
 #
-# WHY this split: markdownlint/typos/internal-links/no-perf-numbers are deterministic and
-# already pass on the scoped doc surface, so they gate. Vale/external-links/readme-template
-# either carry a large pre-existing backlog or depend on network/another in-flight bead
-# (sq-9jw5), so they advise until their scope is clean, then flip to HARD.
+# WHY this split: markdownlint/typos/internal-links/no-perf-numbers/readme-template are
+# deterministic and now pass on the scoped doc surface, so they gate. Vale/external-links
+# carry a network dependency or a pre-existing prose-style backlog, so they advise until
+# their scope is clean, then flip to HARD.
 #
 # ci-summary aggregation: it polls every check-run on the head commit and fails iff one
 # concluded failure. So every ADVISORY job must CONCLUDE SUCCESS or it would block the
@@ -400,18 +407,20 @@ jobs:
       - name: No hard-coded performance numbers in user-facing docs — GATING
         run: python3 scripts/check-no-perf-numbers.py --enforce
 
-  # [OPUS-4.8] Still ADVISORY (bead sq-8ic6 left this leg un-promoted, honestly): the crate-
-  # README template (length cap + required sections) has a 67-deviation backlog across 35
-  # READMEs, owned by the sq-9jw5 README-overhaul epic (sq-puyy/sq-my8/…). Promoting it now
-  # would red docs-quality on main + every PR. Flip to --enforce + drop continue-on-error
-  # (and rename out of the "advisory" exclusion) once that scope is clean. The check runs
-  # in --advisory mode (reports findings but always exits 0) so the job concludes SUCCESS;
-  # the job-level continue-on-error is defence-in-depth and the "advisory" token in the NAME
-  # is a third belt — the ci-summary aggregator excludes it either way. [OPUS-4.8]
+  # [OPUS-4.8] sq-8ic6 (deferred half): PROMOTED to a HARD gate. The README-overhaul epic
+  # (sq-9jw5) cleared the backlog — sq-inzv (#751) brought 20 publish=true crate READMEs to
+  # the template and sq-4lvq finished the 3 deferred crates (sparq-hdt/introspect/sim), so
+  # `scripts/check-readme-template.py --enforce` is now GREEN across ALL 35 READMEs (0
+  # deviations). sq-ixsf tightened the stub classifier first (an EXPLICIT `internal-stub`
+  # HTML-comment directive is now required, instead of a body-prose substring match that
+  # could silently exempt a real deviation). So the crate-README template (length cap +
+  # 🚀/✨/📚 + License) now FAILS the build instead of advising — same promotion pattern as
+  # no-perf-numbers (sq-8ic6, above). Deterministic (grep/line-count only, no network). The
+  # job NAME carries no "advisory"/"informational" token, so the ci-summary aggregator gates
+  # on it. The self-test step pins the checker's own stub-classification logic. [OPUS-4.8]
   readme-template:
-    name: readme-template (template, advisory)
+    name: readme-template (template)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -419,5 +428,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
-      - name: Crate-README length cap + required sections (template, sq-9jw5)
-        run: python3 scripts/check-readme-template.py --advisory
+      # [OPUS-4.8] sq-ixsf: hermetic self-test of the stub-classification + section/cap
+      # logic — a re-broadening back to a prose substring match (which would let real
+      # deviations through) fails the gate HERE. Mirrors the coverage-gate.py / perf-gate.py
+      # --self-test pattern; runs in this same HARD job so a regression also reds ci-summary.
+      - name: Self-test the readme-template stub classifier (pure logic)
+        run: python3 scripts/check-readme-template.py --self-test
+      - name: Crate-README length cap + required sections (template, sq-9jw5) — GATING
+        run: python3 scripts/check-readme-template.py --enforce

--- a/crates/sparq-hdt/README.md
+++ b/crates/sparq-hdt/README.md
@@ -1,8 +1,13 @@
+<!-- [OPUS-4.8] sq-4lvq: README brought to template (deferred from sq-inzv). -->
 # sparq-hdt
 
 Opt-in [HDT](https://www.rdfhdt.org/) (Header Dictionary Triples) reader (and,
 behind the `write` feature, writer) for the sparq RDF engine: load `.hdt` archives
-straight into a `sparq_core::Graph`, and save a `Graph` back out.
+straight into a `sparq_core::Graph`, and save a `Graph` back out. This is a separate
+crate so the core engine — and in particular the wasm build — carries zero HDT code
+or dependencies. Native-only by design.
+
+## 🚀 Quickstart
 
 ```rust,no_run
 # fn main() -> Result<(), sparq_hdt::Error> {
@@ -23,10 +28,7 @@ In sparq-cli (behind the opt-in `hdt` cargo feature —
 `cargo build -p sparq-cli --features hdt`), the `hdt` format argument or a
 `.hdt`/`.hdt.gz` file extension routes loading through this crate.
 
-This is a separate crate so the core engine — and in particular the wasm build —
-carries zero HDT code or dependencies. Native-only by design.
-
-## What it does
+## ✨ Features
 
 - Wraps the maintained [`hdt`](https://crates.io/crates/hdt) crate
   (KonradHoeffner/hdt, MIT) for the binary decode rather than reimplementing the
@@ -52,68 +54,51 @@ carries zero HDT code or dependencies. Native-only by design.
 - **Header access**: `header()` / `header_reader()` decode just the dataset
   metadata triples (the "H" in HDT) into a queryable `Graph` without touching
   the dictionary/triples sections.
+- **Writing** (opt-in `write` feature): `save(&graph, path)` serialises a `Graph` to a
+  standard-layout `.hdt` (or `.hdt.gz`/`.hdt.zst`/`.hdt.bz2`, chosen by the output
+  extension), encoding the HDT sections **directly** from sparq's in-memory dictionary +
+  triple ids (`src/encode.rs`) — no temporary N-Triples file, no text re-parse. The bytes
+  are interoperable standard HDT v1.0; the PFC dictionary and the BitmapTriples payload are
+  byte-for-byte identical to the upstream builder's output (proven in
+  `tests/write_roundtrip.rs`). HDT carries a single default graph, so named graphs are
+  ignored; an RDF 1.2 quoted-triple term cannot be written (standard HDT has no
+  representation for it) and `save` returns `Error::Term`.
 
 ## Validation
 
-`tests/roundtrip.rs`:
-
-- `snikmeta.hdt` — a real-world archive vendored from the `hdt` crate's test suite
-  (i.e. not produced by this code path) — must load to exactly the same 328-triple
-  set as its N-Triples rendering loaded through sparq's own parser.
-- A term-zoo N-Triples document round-tripped through a generated HDT archive
-  (unicode, lang tags, datatypes, blank nodes, shared subject/object terms,
-  inline-integer literals) must match sparq's direct N-Triples load.
-
-`tests/write_roundtrip.rs` (the `write` feature): a `Graph` saved with `save` and
-reloaded with `load` must equal the original term set — over the term zoo, a
-multi-block graph, the empty graph, all three compression containers, and the
-upstream-oracle load path (so the bytes `save` writes are spec-conformant, not just
-something our own decoder accepts). One test goes further still: the direct
-encoder's **FourSectDict PFC bytes and BitmapTriples payload are byte-for-byte
-identical** to the upstream builder's output (`Hdt::read_nt` + `Hdt::write`) for the
-same graph (only the triples control-info preamble's property order differs — an
-upstream `HashMap` ordering both encoders share). The direct path also writes no
-temporary scratch file.
+`tests/roundtrip.rs`: `snikmeta.hdt` — a real-world archive vendored from the `hdt` crate's
+test suite (not produced by this code path) — must load to exactly the same triple set as
+its N-Triples rendering loaded through sparq's own parser; and a term-zoo N-Triples document
+(unicode, lang tags, datatypes, blank nodes, shared subject/object terms, inline-integer
+literals) round-tripped through a generated HDT archive must match sparq's direct N-Triples
+load. `tests/write_roundtrip.rs` (the `write` feature): a saved-then-reloaded `Graph` must
+equal the original term set over the term zoo, a multi-block graph, the empty graph, all
+three compression containers, and the upstream-oracle load path — and one test asserts the
+encoder's FourSectDict PFC bytes and BitmapTriples payload are byte-for-byte identical to the
+upstream builder's output (`Hdt::read_nt` + `Hdt::write`).
 
 ## Load throughput
 
-The `bench_load` example loads ~1M synthetic triples (100k subjects, 50 predicates,
-mixed IRI/literal objects) from a `.hdt` archive vs the equivalent `.nt.gz`, reporting
-size on disk, load time, and throughput for each. Run it for the numbers:
+The `bench_load` example loads ~1M synthetic triples from a `.hdt` archive vs the equivalent
+`.nt.gz`, reporting size, load time, and throughput. HDT loads faster than gunzip-and-parse;
+on real corpora with heavier term reuse HDT archives are typically several times smaller than
+gzipped N-Triples, which is the format's main draw alongside no-text-parse loading. Run it for
+the numbers (tracked figures live on the perf dashboard):
 
 ```sh
 cargo run --release -p sparq-hdt --example bench_load
-# add `-- --json <path>` to also write the same measurements as a machine-readable
-# JSON document (STDOUT unchanged; timings are advisory/non-canonical, nothing committed)
+# add `-- --json <path>` to also write the measurements as machine-readable JSON
+# (STDOUT unchanged; timings are advisory/non-canonical, nothing committed)
 cargo run --release -p sparq-hdt --example bench_load -- --json /tmp/hdt.json
 ```
 
-HDT loads faster than gunzip-and-parse. On synthetic data with mostly unique literal
-objects the HDT file is about the size of the `.nt.gz`; on real corpora with heavier
-term reuse HDT archives are typically several times smaller than gzipped N-Triples,
-which is the format's main draw alongside no-text-parse loading.
+## 📚 Learn more
 
-## Writing (opt-in `write` feature)
+- Skill: `skills/hdt-format/SKILL.md`
+- Perf dashboard: <https://jeswr.github.io/sparq/dev/bench>
+- Not yet supported / open work: `bd list -l area:sparq-hdt` (the decode-only ingest fast
+  path; upstream notes in `UPSTREAM.md`).
 
-`save(&graph, path)` serialises a `Graph` to a standard-layout `.hdt` (or
-`.hdt.gz` / `.hdt.zst` / `.hdt.bz2`, chosen by the output extension). HDT carries a
-single default graph, so named graphs are ignored.
+## License
 
-**How.** `save` encodes the HDT sections **directly** from sparq's in-memory
-dictionary + triple ids (`src/encode.rs`, the inverse of `src/decode.rs`) — **no
-temporary N-Triples file, no text re-parse**. It feeds the wrapped crate's public
-section builders/writers (`DictSectPFC::compress` for the four PFC sections,
-`TriplesBitmap::from_triples` for the SPO BitmapTriples) and replays
-`Hdt::write`'s section order (global control info → header → `FourSectDict` →
-`TriplesBitmap`). The bytes are interoperable standard HDT v1.0; the PFC dictionary
-and the BitmapTriples payload are byte-for-byte identical to the upstream builder's
-output (proven in `tests/write_roundtrip.rs`). Enable with `--features write`.
-
-A graph containing an RDF 1.2 quoted-triple term cannot be written (standard HDT
-has no representation for it); `save` returns `Error::Term` in that case.
-
-## Not (yet) supported
-
-See the open beads for this crate (`bd list -l area:sparq-hdt`): the decode-only
-ingest fast path (we already roll our own in `decode.rs`; upstream builds
-pattern-query indexes ingest never uses — queued in `UPSTREAM.md`).
+MIT. [OPUS-4.8] sq-4lvq

--- a/crates/sparq-introspect/README.md
+++ b/crates/sparq-introspect/README.md
@@ -1,3 +1,4 @@
+<!-- [OPUS-4.8] sq-4lvq: README brought to template (deferred from sq-inzv). -->
 # sparq-introspect
 
 **Ontology / schema introspection** for the sparq RDF engine — an **opt-in** crate
@@ -37,97 +38,73 @@ let ix = sparq_introspect::Introspection::load("data/g.nt.introspect")?; // O(ou
 ## ✨ Features
 
 - **Characteristic sets** (Neumann & Moerkotte, ICDE 2011) — one SPO scan groups
-  subjects by their *exact* predicate set; each distinct set carries its subject count,
-  per-predicate triple counts (avg multiplicity = `predicate_triples[i] / subjects`),
-  and the `rdf:type` histogram of its subjects. Top sets retained, exact tail aggregates.
+  subjects by their *exact* predicate set; each set carries its subject count,
+  per-predicate triple counts (avg multiplicity), and the `rdf:type` histogram of its
+  subjects. Top sets retained, exact tail aggregates.
 - **Schema summary** — classes with instance counts; per-class predicate usage with
   subject/triple counts, **coverage ratios**, and **per-class sample object labels**
-  (`ClassPredicate::samples` — drawn only from *this* class's triples, so a minority
-  class shows its OWN representative values instead of the predicate's global minimum,
-  which may belong entirely to a larger class); per-predicate global stats (triples,
-  distinct subjects/objects, literal-vs-IRI split, datatype distribution, deterministic
-  sample values); and **observed domain/range** (most-common subject/object classes,
-  inferred from usage) alongside any **declared** `rdfs:domain`/`rdfs:range` — real KGs
-  are under-declared and mis-typed, so usage wins and both are reported.
+  (`ClassPredicate::samples`, drawn only from *this* class's triples, so a minority class
+  shows its OWN representative values rather than the predicate's global minimum); plus
+  **observed domain/range** (most-common subject/object classes, inferred from usage)
+  alongside any **declared** `rdfs:domain`/`rdfs:range` — real KGs are under-declared and
+  mis-typed, so usage wins and both are reported.
 - **Persisted `*.introspect` sidecar** (`save` / `load` / `from_json`,
-  [`sidecar_path_for`]) — write the mined schema as JSON next to the dataset, then
-  reload it `O(output)` instead of re-mining the graph (`O(|G| + |dict|)`); the format is
-  exactly `to_json`'s, so a sidecar is also a plain JSON document. Every export
-  (`to_text_summary`, `schema_summary_for`, `to_void`, …) runs off the loaded struct.
-- **Cross-class join hints** — the `(subject_class) --predicate--> (object_class)` edge
-  table with per-edge triple counts, mined in the *same* SPO scan as the characteristic
-  sets; top edges by triple count, capped with exact tail aggregates.
-- **Text summary** (`to_text_summary(budget_chars)`) — header totals → prefix glossary
-  (only the namespaces the body uses; well-known prefixes, `nsN` otherwise) → classes
-  with coverage + range hints + samples → characteristic-set patterns → predicate stats.
-  Lines drop greedily at the budget; a final `…` marks elision.
+  [`sidecar_path_for`]) — write the mined schema as JSON next to the dataset, then reload it
+  `O(output)` instead of re-mining `O(|G| + |dict|)`; the format is exactly `to_json`'s, so a
+  sidecar is also a plain JSON document. Every export runs off the loaded struct.
+- **Cross-class join hints** — the `(subject_class) --predicate--> (object_class)` edge table
+  with per-edge triple counts, mined in the *same* SPO scan as the characteristic sets.
+- **Text summary** (`to_text_summary(budget_chars)`) — header totals → prefix glossary →
+  classes with coverage + range hints + samples → characteristic-set patterns → predicate
+  stats. Lines drop greedily at the budget; a final `…` marks elision.
 - **VoID export** (`to_void`) — a [W3C VoID](https://www.w3.org/TR/void/) description as
   N-Triples (parses as Turtle too — no serializer dep), with exact `void:triples`,
-  `void:entities`, `void:distinctSubjects`, `void:classes`, `void:properties`, plus a
-  `void:classPartition` and `void:propertyPartition` each. `void:distinctObjects` is
-  **not** emitted — omitted rather than misleading (no global de-duplicated count kept).
-- **VoID + characteristic-set source stats** (`to_void_with_cs`, federation A3/Z2) — a
-  strict superset of `to_void`, then the mined sets under a documented sparq extension
-  vocab `scs:` (`<http://sparq.dev/ns/cs#>`); the served federation-descriptor surface
-  that primes a remote CostFed/Odyssey-class source-selector with star/multi-join
-  cardinalities. Served at `GET /.well-known/void` behind the opt-in
-  `federation-descriptors` feature.
+  `void:entities`, `void:distinctSubjects`, `void:classes`, `void:properties`, and a
+  `void:classPartition`/`void:propertyPartition` each. `void:distinctObjects` is **not**
+  emitted — omitted rather than misleading (no global de-duplicated count kept).
+- **VoID + characteristic-set source stats** (`to_void_with_cs`, federation A3/Z2) — a strict
+  superset of `to_void` plus the mined sets under a documented sparq extension vocab `scs:`
+  (`<http://sparq.dev/ns/cs#>`); the served federation-descriptor surface that primes a remote
+  CostFed/Odyssey-class source-selector with star/multi-join cardinalities. Served at
+  `GET /.well-known/void` behind the opt-in `federation-descriptors` feature.
 - **SHACL node-shape export** (`to_shacl`) — each mined characteristic set as a W3C
-  [SHACL](https://www.w3.org/TR/shacl/) `sh:NodeShape` (N-Triples / valid Turtle): a
-  `sh:targetClass` for every class **universal** to the set (so the shape auto-applies
-  only where every instance genuinely has the set's predicates), one `sh:PropertyShape`
-  (`sh:path` + `sh:minCount 1`) per non-type predicate, and `sh:maxCount 1` exactly when
-  that predicate's avg multiplicity is 1. The constraints are mined from what the data
-  asserts, so the graph already validates against them — a data-grounded effective-schema
-  floor, not an aspirational contract. Sets with no universal class yield a reusable but
-  target-less shape.
-- **Vocabulary detection** — namespaces in use (split at the last `#`/`/`, the split the
-  dictionary stores) with distinct-term counts, recognised against a bundled offline
-  table (rdf/rdfs/owl/xsd/foaf/skos/schema.org/dcterms/wd/dbo/…).
-- **Retrieval-mode summary** (`schema_summary_for(seeds, budget)`) — a seed-scoped digest
-  for KGs whose full schema overflows a prompt; filters the already-mined profiles by IRI
-  (no re-scan).
+  [SHACL](https://www.w3.org/TR/shacl/) `sh:NodeShape`: a `sh:targetClass` for every class
+  **universal** to the set (so the shape auto-applies only where every instance genuinely has
+  the predicates), one `sh:PropertyShape` (`sh:path` + `sh:minCount 1`) per non-type
+  predicate, and `sh:maxCount 1` exactly when avg multiplicity is 1. Constraints are mined
+  from what the data asserts — a data-grounded effective-schema floor, not an aspirational
+  contract. Sets with no universal class yield a reusable but target-less shape.
+- **Vocabulary detection** — namespaces in use (split at the last `#`/`/`) with distinct-term
+  counts, recognised against a bundled offline table (rdf/rdfs/owl/xsd/foaf/skos/schema.org/
+  dcterms/wd/dbo/…).
+- **Retrieval-mode summary** (`schema_summary_for(seeds, budget)`) — a seed-scoped digest for
+  KGs whose full schema overflows a prompt; filters the already-mined profiles by IRI (no
+  re-scan).
 - **Graph scoping** — `Introspection::build(&graph)` introspects the store of whatever
-  `Graph` it is handed: the **default graph** when you pass the top-level `&graph`, and a
-  **single named graph** when you pass that graph's sub-`Graph`. Each named graph of a
-  quad dataset (loaded via `Graph::load_dataset` from N-Quads / TriG) is a self-contained
-  `Graph`, fetched by name with [`Graph::named_graph(&name)`][named-graph] (sq-quuu):
-  ```rust,ignore
-  let g1 = graph.named_graph(&ex_g1).expect("graph exists");
-  let card = sparq_introspect::Introspection::build(g1); // schema card for ex:g1 alone
-  ```
-  There is **no cross-graph or union-of-all-graphs** build: a VoID / schema card is always
-  scoped to exactly one graph, so on a multi-graph dataset run it per graph (or over the
-  default graph) rather than expecting it to merge the quads. Default-graph-only crates
-  silently mixing graphs was sq-quuu; this is the documented + supported scope.
+  `Graph` it is handed: the **default graph** for the top-level `&graph`, a **single named
+  graph** for that graph's sub-`Graph` (fetch by name with
+  [`Graph::named_graph(&name)`][named-graph], sq-quuu). There is **no cross-graph or
+  union-of-all-graphs** build: a VoID / schema card is always scoped to exactly one graph, so
+  on a multi-graph dataset run it per graph rather than expecting it to merge the quads.
 
   [named-graph]: https://docs.rs/sparq-core/latest/sparq_core/struct.Graph.html#method.named_graph
-- **Cost & zero impact** — `O(|G| + |dict|)` time, output-sized memory plus the
-  subject→types map. Separate opt-in crate: no core crate depends on it, the default
-  build does not compile it, and it is read-only over `sparq-core`'s public scan surface
-  (works against raw, mmap'd, and compressed storage).
+- **Cost & zero impact** — `O(|G| + |dict|)` time, output-sized memory plus the subject→types
+  map. Separate opt-in crate: no core crate depends on it, the default build does not compile
+  it, and it is read-only over `sparq-core`'s public scan surface.
 
 ## Measured results
 
-The `olympics_introspect` example reports load / build / `to_json` / `to_text_summary`
-time over the olympics (1.78M triples) and qlever-synthetic (10M) fixtures (paths via
-`SPARQ_OLYMPICS_NT` / `SPARQ_SYNTHETIC_NT`). The design-doc §4 gates: the introspection
-scan stays within dataset load time; summary generation is quick relative to that load;
-and the olympics summary names the dataset's actual classes (asserted by
-`tests/olympics.rs`). Tracked figures live on the perf dashboard.
+The `olympics_introspect` example reports load / build / `to_json` / `to_text_summary` time
+over the olympics (1.78M triples) and qlever-synthetic (10M) fixtures (paths via
+`SPARQ_OLYMPICS_NT` / `SPARQ_SYNTHETIC_NT`); the design-doc §4 gates (scan stays within load
+time; summary fast relative to load; the olympics summary names the dataset's actual classes,
+asserted by `tests/olympics.rs`). Tracked figures live on the perf dashboard.
 
 ```sh
 cargo run -p sparq-introspect --example olympics_introspect --release
-# add `-- --json <path>` to also write the same measurements as a machine-readable
-# JSON document (STDOUT unchanged; timings are advisory/non-canonical, nothing committed)
-cargo run -p sparq-introspect --example olympics_introspect --release -- --json /tmp/introspect.json
+# add `-- --json <path>` to also write the measurements as machine-readable JSON
+# (STDOUT unchanged; timings are advisory/non-canonical, nothing committed)
 ```
-
-Tests: 22 unit (`src/lib.rs`: characteristic-set exactness, coverage, object
-kinds/datatypes/samples, observed-vs-declared domain/range, vocabularies, JSON validity,
-text-summary budget, join hints, VoID export, SHACL node-shape export, retrieval mode,
-per-class sample isolation, persisted-sidecar round-trip) plus 1 integration
-(`tests/olympics.rs`, skip-if-absent at 1.78M scale).
 
 ## 📚 Learn more
 
@@ -139,4 +116,4 @@ per-class sample isolation, persisted-sidecar round-trip) plus 1 integration
 
 ## License
 
-MIT. [OPUS-4.8] sq-lsxd
+MIT. [OPUS-4.8] sq-4lvq

--- a/crates/sparq-sim/README.md
+++ b/crates/sparq-sim/README.md
@@ -1,3 +1,4 @@
+<!-- [OPUS-4.8] sq-4lvq: README brought to template (deferred from sq-inzv). -->
 # sparq-sim
 
 **Training-free structural entity similarity** for the sparq RDF engine — an **opt-in**
@@ -52,14 +53,11 @@ weighted_jaccard(&sig_a, &sig_b);        // for callers that cache signatures
   fusion helpers, so the two signals combine without either crate depending on the other:
 
   ```rust,ignore
-  use sparq_sim::Sim;
-  use sparq_vectors::{fuse_rrf, RRF_K};
-
   let structural = Sim::new(&graph).most_similar(&query, 50);
   let text: Vec<(_, f64)> = index.nearest_term(&query, &graph, &store, 50)
       .into_iter().map(|(t, s)| (t, s as f64)).collect();
   // Reciprocal Rank Fusion: rank-based, no score normalization needed.
-  let hybrid = fuse_rrf(&[&text, &structural], RRF_K, 10);
+  let hybrid = sparq_vectors::fuse_rrf(&[&text, &structural], sparq_vectors::RRF_K, 10);
   ```
 
   Over-fetch each signal (k = 50 for a top-10 fusion) so the fusion has overlap to reward.
@@ -68,10 +66,9 @@ weighted_jaccard(&sig_a, &sig_b);        // for callers that cache signatures
 ## Graph scoping
 
 `Sim::new(&graph)` operates on the store of whatever `Graph` it is handed — the **default
-graph** when you pass the top-level `&graph`, or a **single named graph** when you pass
-that graph's sub-`Graph`. On a quad dataset (loaded via `Graph::load_dataset` from
-N-Quads / TriG) each named graph is a self-contained `Graph`; fetch one by name with
-[`Graph::named_graph(&name)`][named-graph] (sq-quuu) and build a per-graph `Sim` over it:
+graph** for the top-level `&graph`, or a **single named graph** for that graph's
+sub-`Graph`. On a quad dataset each named graph is a self-contained `Graph`; fetch one by
+name with [`Graph::named_graph(&name)`][named-graph] (sq-quuu) and build a per-graph `Sim`:
 
 ```rust,ignore
 let g1 = graph.named_graph(&ex_g1).expect("graph exists");
@@ -90,14 +87,13 @@ the graph (or the default graph) explicitly rather than expecting the quads to b
 Olympics/Sport/City), ground truth = `rdf:type`, **type triples excluded** (leakage rule,
 design doc §5.5), stratified per-class sampling. The `olympics_eval` example reports
 quality + latency and checks the gates (same-class precision@10; `Predicates`-mode
-class-separation AUC; `most_similar(k=10)` latency); the absolute figures live on the
-perf dashboard.
+class-separation AUC; `most_similar(k=10)` latency); absolute figures live on the perf
+dashboard.
 
 ```sh
 cargo run -p sparq-sim --example olympics_eval --release
-# add `-- --json <path>` to also write the same accuracy + latency metrics as a
-# machine-readable JSON document (STDOUT unchanged; latency advisory/non-canonical)
-cargo run -p sparq-sim --example olympics_eval --release -- --json /tmp/sim.json
+# add `-- --json <path>` to also write accuracy + latency as machine-readable JSON
+# (STDOUT unchanged; latency advisory/non-canonical)
 ```
 
 **The two AUCs.** Pairwise AUC asks "do two random same-class entities score higher than
@@ -107,8 +103,8 @@ membership. Role similarity is the `Predicates` mode's job (near-perfect separat
 ranking task the crate is built for — `most_similar` retrieving same-class entities — is
 measured by precision@10, high across every class.
 
-Tests: 13 unit (`src/lib.rs`: Jaccard math, symmetry, direction, IDF ordering, exclusions,
-mode semantics, hub-cap behaviour, neighbor-sparse fallback, AUC gate) plus 1 integration
+Tests: 13 unit (Jaccard math, symmetry, direction, IDF ordering, exclusions, mode
+semantics, hub-cap, neighbor-sparse fallback, AUC gate) plus 1 integration
 (`tests/olympics.rs`, skip-if-absent at 1.78M scale).
 
 ## 📚 Learn more

--- a/scripts/check-readme-template.py
+++ b/scripts/check-readme-template.py
@@ -37,22 +37,31 @@ LICENSE_RE = re.compile(
     r"|License\s*(?:[:—-]|$))",                # one-line section: "License:" / "License —"
     re.M | re.I,
 )
-# A README that openly declares itself an internal/unpublished stub is exempt from the
-# section requirement (the template allows a 15-line stub for publish=false crates).
-STUB_MARKERS = ("not published", "internal, not published", "internal crate", "not on crates.io")
+# [OPUS-4.8] sq-ixsf: A README is exempt from the section requirement ONLY when it carries
+# an EXPLICIT internal-stub directive — the HTML comment the README-overhaul (sq-9jw5/sq-inzv)
+# stamps on every publish=false stub, e.g.
+#   <!-- [OPUS-4.8] sq-4kr5: internal-stub README for a publish=false crate. -->
+# The previous heuristic substring-matched body PROSE ("not published", "internal crate", …),
+# so a FULL-TEMPLATE README that merely *mentioned* those words anywhere was mis-classified as
+# a <=30-line stub and silently exempted from the cap + the 🚀/✨/📚 + License requirements —
+# letting real template deviations through. Before the --enforce flip that broad match would
+# be a hole in the gate, so the directive is now required to be an EXPLICIT `internal-stub`
+# token INSIDE an HTML comment (`<!-- … internal-stub … -->`), which cannot appear by accident
+# in rendered prose.
+STUB_DIRECTIVE_RE = re.compile(r"<!--[^>]*\binternal-stub\b[^>]*-->", re.I | re.S)
 
 
-def check_readme(path: str) -> list[str]:
+def is_stub_readme(text: str) -> bool:
+    """True iff the README carries the explicit `internal-stub` HTML-comment directive."""
+    return STUB_DIRECTIVE_RE.search(text) is not None
+
+
+def check_readme_text(text: str) -> list[str]:
+    """Template-conformance issues for README *content* (filesystem-free; testable)."""
     issues: list[str] = []
-    try:
-        text = open(path, encoding="utf-8").read()
-    except OSError as e:
-        return [f"could not read: {e}"]
     n_lines = text.count("\n") + (0 if text.endswith("\n") else 1)
 
-    is_stub = any(m in text.lower() for m in STUB_MARKERS)
-
-    if is_stub:
+    if is_stub_readme(text):
         if n_lines > 30:
             issues.append(f"declared a stub but {n_lines} lines (stub target: <=30)")
         return issues
@@ -67,15 +76,91 @@ def check_readme(path: str) -> list[str]:
     return issues
 
 
+def check_readme(path: str) -> list[str]:
+    try:
+        text = open(path, encoding="utf-8").read()
+    except OSError as e:
+        return [f"could not read: {e}"]
+    return check_readme_text(text)
+
+
+# [OPUS-4.8] sq-ixsf: hermetic self-test of the stub-classification + section/cap logic.
+# No filesystem, no network — pins the gate's OWN behaviour so a future regression in the
+# stub narrowing (or a re-broadening back to a prose substring match) fails CI here. Mirrors
+# the perf-gate.py --self-test / coverage-gate.py --self-test pattern.
+def _self_test() -> int:
+    failures: list[str] = []
+
+    def expect(name: str, cond: bool) -> None:
+        if not cond:
+            failures.append(name)
+
+    # A FULL-TEMPLATE, over-cap README that merely MENTIONS "not published" / "internal
+    # crate" in prose must NOT be exempted as a stub (the sq-ixsf false-positive). It has
+    # no 🚀/✨/📚 sections, so with the old broad match it would have wrongly passed.
+    full_mentions_stub_words = (
+        "# sparq-foo\n\n"
+        "This crate is internal, not published to crates.io in the usual sense, but it "
+        "is documented in full here.\n\n"
+        "## Overview\n\n" + ("filler line\n" * 200)
+    )
+    expect("prose-mention is NOT a stub", not is_stub_readme(full_mentions_stub_words))
+    issues = check_readme_text(full_mentions_stub_words)
+    expect("prose-mention README is flagged (cap + missing sections)",
+           any("template cap" in i for i in issues)
+           and any("missing '## 🚀" in i for i in issues))
+
+    # An EXPLICIT internal-stub directive (HTML comment) IS a stub → exempt from sections,
+    # passing while <=30 lines.
+    stub_ok = (
+        "<!-- [OPUS-4.8] sq-4kr5: internal-stub README for a publish=false crate. -->\n"
+        "# sparq-bar\n\nInternal crate; see the design record.\n\n## License\n\nMIT.\n"
+    )
+    expect("explicit directive IS a stub", is_stub_readme(stub_ok))
+    expect("short stub passes", check_readme_text(stub_ok) == [])
+
+    # A stub directive but OVER the 30-line stub budget must still be flagged.
+    stub_too_long = stub_ok + ("\nextra line\n" * 40)
+    expect("over-long stub flagged",
+           any("stub but" in i for i in check_readme_text(stub_too_long)))
+
+    # A conformant full-template README (all sections + License, under cap) passes.
+    good = (
+        "# sparq-good\n\nA real crate.\n\n"
+        "## 🚀 Quickstart\n\n`cargo add sparq-good`\n\n"
+        "## ✨ Features\n\n- does things\n\n"
+        "## 📚 Learn more\n\n- docs\n\n"
+        "## License\n\nMIT.\n"
+    )
+    expect("conformant full template passes", check_readme_text(good) == [])
+
+    # The directive must be inside an HTML comment — a bare word in prose is not enough.
+    expect("bare 'internal-stub' word in prose is NOT a directive",
+           not is_stub_readme("# x\n\nthis is an internal-stub of a sentence\n"))
+
+    if failures:
+        for f in failures:
+            print(f"SELF-TEST FAIL: {f}")
+        print(f"\ncheck-readme-template self-test: {len(failures)} failure(s).")
+        return 1
+    print("check-readme-template self-test: all cases pass ✅")
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--advisory", action="store_true",
                     help="report only, always exit 0 (default while sq-9jw5 lands)")
     ap.add_argument("--enforce", action="store_true",
                     help="exit non-zero on any template deviation (ratchet to HARD)")
+    ap.add_argument("--self-test", action="store_true",
+                    help="run the hermetic stub-classification self-test and exit")
     ap.add_argument("paths", nargs="*",
                     help="explicit README paths (default: crates/*/README.md)")
     args = ap.parse_args()
+
+    if args.self_test:
+        return _self_test()
 
     paths = args.paths or sorted(glob.glob("crates/*/README.md"))
     total = 0


### PR DESCRIPTION
> 🤖 SPARQ agent

Finishes the crate-README-template program — the deferred half left open after sq-inzv (#751). Promotes the `readme-template` lane from advisory to a HARD gate now that deviations are **0 across all 35 crate READMEs**.

## What this does (3 linked beads, in order)

**1. sq-4lvq — bring the 3 deferred crate READMEs to template conformance**
`sparq-hdt`, `sparq-introspect`, `sparq-sim` (all `publish = true`, all wired to render their README on docs.rs via `include_str!`) get the same full-template treatment #751 applied to the other 20: `<= 120` lines, the `🚀 Quickstart` / `✨ Features` / `📚 Learn more` sections, and a License line. Every caveat is preserved in substance — no laundering, no fabricated content:
- **hdt**: exotic non-mainstream layouts rejected; RDF 1.2 quoted-triple write returns `Error::Term`; byte-for-byte upstream-identical encode.
- **introspect**: `void:distinctObjects` deliberately omitted; observed-vs-declared domain/range; per-class sample isolation; no cross-graph build.
- **sim**: the two-AUC explanation (PredicateNeighbor ties at 0 by design) kept intact.

Perf figures already point at the dashboard (no baked-in numbers).

**2. sq-ixsf — narrow the checker's stub detection (done BEFORE the --enforce flip)**
`scripts/check-readme-template.py` previously substring-matched body prose (`"not published"`, `"internal crate"`, …) to classify a README as a `<= 30`-line stub — so a **full-template** README that merely *mentioned* those words would be silently exempted from the cap + section + License checks, a hole that would let real deviations through under `--enforce`. Now an **explicit `internal-stub` HTML-comment directive** is required (the marker the overhaul stamps on every `publish = false` stub). Adds a hermetic `--self-test` covering the false-positive case.

**3. sq-8ic6 (deferred half) — promote readme-template to a HARD gate**
In `.github/workflows/docs-quality.yml`, mirror the no-perf-numbers promotion: rename out of the advisory exclusion (`readme-template (template)`), drop `continue-on-error`, run `--enforce` (GATING), and add the `--self-test` step. The new job name carries no `advisory`/`informational` token, so the `ci-summary` aggregator now gates on it. `ci-summary.yml`'s advisory-jobs documentation comment is updated to match (comment-only; the name-rule itself is dynamic).

## Verification (local)
- `check-readme-template.py --enforce`: **0 deviations across all 35 READMEs**, exit 0.
- Planted a `> 120`-line deviation → `--enforce` exits **1** with `::error::`; restored cleanly.
- `--self-test`: all cases pass (incl. the prose-mention false-positive).
- `actionlint` clean on `docs-quality.yml` + `ci-summary.yml`; all `uses:` SHA-pinned.
- markdownlint (0 errors) + typos (0) clean on the changed READMEs; privacy-claims + no-perf-numbers gates green.

## Compliance gap closed
The crate-README house rule (AGENTS.md: concise per-crate README) is now **enforced** in CI rather than advisory — deviations can no longer drift back in. Honest level: a deterministic line-count + required-section + License gate over `crates/*/README.md`, with the stub exemption narrowed to an explicit directive.

Deviations **68 → 0**. Auto-merge intentionally **not** enabled.
