### PR TITLE
feat(gui-mvp): basePath env-switch + WasmStore conformance guard + SPARQL query-editor uplift (sq-9vw5, sq-06gq, sq-n5aw) [OPUS-4.8]

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -108,6 +108,21 @@ jobs:
         working-directory: js
         run: npm run build:wasm
 
+      # [OPUS-4.8] sq-06gq — with the wasm-pack GENERATED `sparq_wasm.d.ts` now present in
+      # js/wasm/, run the @sparq/client GENERATED-surface conformance typecheck. It asserts the
+      # package's hand-written WasmStore mirror stays a faithful subset of the generated
+      # `Store`, so any future drift (a renamed/retyped/dropped method) fails CI here. (The
+      # `shared-client` job above runs the package's bare typecheck WITHOUT this artifact, so
+      # this is the only lane that can see the generated d.ts — the design's §4 source of
+      # truth.)
+      - name: Install @sparq/client dependencies
+        working-directory: packages/sparq-client
+        run: npm install
+
+      - name: "@sparq/client generated-surface conformance (vs js/wasm d.ts)"
+        working-directory: packages/sparq-client
+        run: npm run typecheck:conformance
+
       - name: Install site dependencies
         working-directory: site
         run: npm install

--- a/gui/README.md
+++ b/gui/README.md
@@ -49,14 +49,17 @@ the full native store rather than the WASM read-replica. Its `#[cfg(test)]` test
 engine calls **directly** (no Tauri runtime), so they are the locally-runnable proof that the
 command layer is wired to the real engine, even when the full Tauri build is CI-only.
 
-## Frontend reuse + the basePath caveat
+## Frontend reuse + the basePath switch (`sq-9vw5`)
 
 The webview loads the site's static export (`frontendDist: "../../site/out"`). The site
-hardcodes `basePath: "/sparq"` for GitHub Pages, but a Tauri webview serves from the
-`tauri://` root, so the export the GUI consumes **must** be built with
-`NEXT_PUBLIC_BASE_PATH=''` (the `beforeBuildCommand` does this). Wiring the env-switch fully
-into `site/next.config.ts` is tracked as a follow-up bead — `tauri.conf.json` records the
-requirement and is structurally valid today.
+defaults to `basePath: "/sparq"` for GitHub Pages, but a Tauri webview serves from the
+`tauri://` root, so the export the GUI consumes **must** be built root-relative
+(`basePath: ""`). `site/next.config.ts` now **env-switches** `basePath`/`assetPrefix` off
+`NEXT_PUBLIC_BASE_PATH`: the `beforeBuildCommand` passes `NEXT_PUBLIC_BASE_PATH=''`, so the
+GUI's export is root-relative with no extra step. Hand-written absolute asset hrefs (the
+favicon, the COOP/COEP service-worker `<Script src>`, the paper PDF links) read the **same**
+env var via `site/src/lib/base-path.ts`, so they move with the build mode too. See the
+"Build modes" table in [`site/README.md`](../site/README.md).
 
 ## Shared TS client
 

--- a/packages/sparq-client/README.md
+++ b/packages/sparq-client/README.md
@@ -30,7 +30,7 @@ re-exports the surface from here; the (proposed) Tauri 2 GUI consumes the same p
   wasm-pack glue needs at load time (`window.location`, dynamic `import()`), both guarded so
   the module is importable under `tsc` / Node type-checking.
 
-## Consumption today (and the deferred §4 step)
+## Consumption today (and the §4 generated-surface step)
 
 The site imports this package via a **TypeScript path alias** (`@sparq/client` →
 `../packages/sparq-client/src`), not an npm dependency — there is no repo-root `package.json`
@@ -38,10 +38,37 @@ or workspaces field today, and adopting npm/pnpm workspaces is a separate review
 the JS build topology (`research/gui-design.md` §3 "Tooling caveat"). The alias keeps the
 static export building with **no new install and no lockfile change**.
 
+### Generated-surface conformance guard — `sq-06gq`
+
 The design's §4 end-state — re-exporting the **wasm-pack-generated** `sparq_wasm.d.ts`
-directly so the `Store` surface is generated, not hand-mirrored — is **deferred**: it depends
-on the workspaces adoption above. This package collapses today's **two** hand-copies into
-**one**; eliminating the last hand-copy is tracked as follow-up work.
+directly so the `Store` surface is generated, not hand-mirrored — has a hard prerequisite: the
+generated d.ts lives in the **git-ignored** build-artifact tree `js/wasm/` (see
+`js/.gitignore`), so it does not exist until `cd js && npm run build:wasm` runs. A literal
+`import` of it in `src/index.ts` would break the bare-package `tsc` (the `gui.yml`
+`shared-client` job typechecks this package with **no** wasm build).
+
+The CI-safe step taken now is a **compile-time conformance guard** (`src/conformance.ts` +
+`tsconfig.conformance.json`): it imports the generated `Store` type via the
+`#sparq-wasm-generated` path alias and asserts the hand-written surface stays a faithful
+**subset** of the generated `Store`, so any future drift (a renamed/retyped/dropped method)
+becomes a type error. Run it where the artifact exists:
+
+```bash
+(cd ../../js && npm run build:wasm)   # produces js/wasm/sparq_wasm.d.ts
+npm run typecheck:conformance         # asserts WasmStore stays a subset of generated Store
+```
+
+It is wired into the `gui.yml` `site-with-shared-client` job (which builds the bundle) and is
+**excluded** from the bare `npm run typecheck`, so the artifact-free `shared-client` CI job is
+unaffected. The two deliberate divergences are asserted explicitly: `validate` is optional here
+(the lean bundle may omit the `shacl` binding) and `queryCursor` returns the narrowed
+`WasmSolutionCursor` rather than the generated `SolutionCursor`.
+
+This package collapsed today's **two** hand-copies into **one** (consumed by the site and the
+GUI), and the surface is now drift-checked against the generated d.ts. **Eliminating** the last
+hand-copy — re-exporting the generated d.ts as the literal source so the hand mirror can be
+deleted — needs repo-root npm/pnpm workspaces (so the package resolves a *tracked*,
+always-present generated d.ts) and is tracked as a follow-up bead.
 
 ## Honesty
 

--- a/packages/sparq-client/package.json
+++ b/packages/sparq-client/package.json
@@ -19,6 +19,7 @@
   "sideEffects": false,
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "typecheck:conformance": "tsc --noEmit --project tsconfig.conformance.json",
     "build": "tsc"
   },
   "keywords": [

--- a/packages/sparq-client/src/conformance.ts
+++ b/packages/sparq-client/src/conformance.ts
@@ -1,0 +1,95 @@
+// [OPUS-4.8] sq-06gq — compile-time conformance guard against the wasm-pack GENERATED
+// `Store` surface.
+//
+// Design background (`research/gui-design.md` §4): the end-state is to make the package
+// consume the wasm-pack-GENERATED `sparq_wasm.d.ts` so the `Store` surface is generated,
+// not hand-mirrored. The hard constraint that blocks a literal re-export today is that the
+// generated d.ts lives in the **git-ignored** build-artifact tree `js/wasm/` (see
+// `js/.gitignore`) — it does not exist until `cd js && npm run build:wasm` runs. So a plain
+// `import` of it in `src/index.ts` would break the bare-package `tsc` (the `gui.yml`
+// `shared-client` job typechecks the package with NO wasm build).
+//
+// This module is the CI-safe halfway step: it imports the generated types via the
+// `#sparq-wasm-generated` tsconfig path alias and ASSERTS — purely at compile time — that the
+// hand-written surface in `./index.ts` stays a faithful subset of the generated `Store`. It
+// is excluded from the default `tsconfig.json`, so the artifact-free bare typecheck is
+// unaffected; it is compiled by `tsconfig.conformance.json` (the `typecheck:conformance`
+// script) ONLY where the artifact is present — locally after a wasm build, and in the
+// `site-with-shared-client` CI job, which builds the bundle. Any future drift between the
+// hand-mirror and the generated `Store` (a renamed/retyped method, a dropped argument) then
+// becomes a TYPE ERROR there, which is the drift-detection §4 is really after. The remaining
+// work — adopting repo-root workspaces and re-exporting the generated d.ts as the literal
+// source so the hand-mirror can be DELETED — is tracked as a follow-up bead.
+
+import type {
+  Store as GeneratedStore,
+  SolutionCursor as GeneratedSolutionCursor,
+} from "#sparq-wasm-generated";
+
+import type { WasmSolutionCursor, WasmStore, WasmStoreCtor } from "./index.js";
+
+// `Extends<A, B>` is `true` only when `A` is assignable to `B`; `Assert<T>` type-checks only
+// when `T` is exactly `true`. Both are types — nothing is emitted at runtime (this whole
+// module is types-only, never imported by the package's runtime entry point).
+type Extends<A, B> = A extends B ? true : false;
+type Assert<_T extends true> = true;
+
+// --- 1. The PRIMITIVE-returning instance methods must match the generated `Store` exactly.
+// These are the methods whose hand signature must equal the generated one byte-for-byte
+// (same args, same primitive return). A rename, a dropped argument, or a changed return type
+// in a future bundle flips one of these to a type error. `queryCursor` and `validate` are
+// asserted separately below because the hand mirror INTENTIONALLY diverges on those two (see
+// #2 / #3); every other shared method is checked here.
+type SharedPrimitiveMethod =
+  | "query"
+  | "queryQuads"
+  | "updateInPlace"
+  | "explain"
+  | "explainAnalyze"
+  | "count"
+  | "ask"
+  | "applyDelta"
+  | "size";
+type _PrimitiveMethodsConform = Assert<
+  Extends<
+    Pick<WasmStore, SharedPrimitiveMethod>,
+    Pick<GeneratedStore, SharedPrimitiveMethod>
+  >
+>;
+export type { _PrimitiveMethodsConform };
+
+// --- 2. `validate` is OPTIONAL on the hand mirror (the lean bundle may be built without the
+// `shacl` feature, so the binding can be absent) but REQUIRED on the generated `Store`. The
+// honest relationship: when the hand `validate` IS present, its signature must equal the
+// generated one. Compare the required form against the generated required form.
+type _ValidateConforms = Assert<
+  Extends<Required<Pick<WasmStore, "validate">>, Pick<GeneratedStore, "validate">>
+>;
+export type { _ValidateConforms };
+
+// --- 3. The static constructor surface: the generated factories (`load` / `loadDataset`)
+// return a generated `Store`, which the hand `WasmStoreCtor` re-types as `WasmStore`. Assert
+// the hand ctor's factory arity/names match the generated statics (a dropped/renamed factory
+// is caught here), independent of the return-type substitution.
+type CtorFactoryShape = {
+  load: (text: string, format: string) => unknown;
+  loadDataset: (text: string, format: string) => unknown;
+};
+type _GeneratedHasFactories = Assert<
+  Extends<Pick<typeof GeneratedStore, "load" | "loadDataset">, CtorFactoryShape>
+>;
+type _HandCtorHasFactories = Assert<Extends<WasmStoreCtor, CtorFactoryShape>>;
+export type { _GeneratedHasFactories, _HandCtorHasFactories };
+
+// --- 4. The streaming cursor: the hand mirror substitutes its own `WasmSolutionCursor` for
+// the generated `SolutionCursor` (a deliberate divergence — the hand cursor narrows to the
+// four methods `streamQueryRows` uses). Assert that narrowing stays a SUBSET of the generated
+// cursor, so a future rename/retype of a cursor method is caught.
+type CursorSubsetKeys = "next" | "vars" | "rowCount" | "batchSize";
+type _CursorConforms = Assert<
+  Extends<
+    Pick<WasmSolutionCursor, CursorSubsetKeys>,
+    Pick<GeneratedSolutionCursor, CursorSubsetKeys>
+  >
+>;
+export type { _CursorConforms };

--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -347,6 +347,29 @@ export async function sparqShaclValidate(
   return JSON.parse(store.validate(data, shapes, format)) as ShaclReport;
 }
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-n5aw — the framework-agnostic SPARQL EDITOR core (highlighting + prefixes).
+// Re-exported so the site (and the Tauri webview) consume the same dependency-free tokenizer
+// and common-prefix logic. The React overlay editor lives in the site component tree; this is
+// the part that "transfers" to any GUI framework unchanged.
+// ---------------------------------------------------------------------------
+
+export {
+  type SparqlToken,
+  type SparqlTokenType,
+  tokenizeSparql,
+} from "./sparql-highlight.js";
+
+export {
+  type PrefixBinding,
+  COMMON_PREFIXES,
+  declaredPrefixes,
+  usedPrefixes,
+  missingCommonPrefixes,
+  renderPrefixLines,
+  withPrefixes,
+} from "./sparql-prefixes.js";
+
 /** Renders a term for display, with a compact datatype/lang suffix. */
 export function formatTerm(t: SparqlTerm | undefined): string {
   if (!t) return "";

--- a/packages/sparq-client/src/sparql-highlight.ts
+++ b/packages/sparq-client/src/sparql-highlight.ts
@@ -1,0 +1,286 @@
+// [OPUS-4.8] sq-n5aw — a framework-agnostic SPARQL tokenizer for syntax highlighting.
+//
+// This is the highlighting CORE the query-editor uplift (`research/gui-design.md` §2, MVP
+// item 1) is built on. It is deliberately DEPENDENCY-FREE and FRAMEWORK-AGNOSTIC: a pure
+// `tokenizeSparql(text)` over a string, returning a flat, gap-free token list a renderer can
+// wrap in styled spans. No DOM, no React — so the SAME tokenizer serves the Next.js site and
+// the Tauri 2 webview (and is unit-testable in `node:test` with no browser). It is a
+// pragmatic LEXER for highlighting, not a SPARQL parser: it never rejects input and always
+// reproduces the source exactly when the token texts are concatenated (a load-bearing
+// property the overlay editor relies on — the highlight layer must align with the textarea
+// glyph-for-glyph).
+//
+// Scope: the SPARQL 1.1/1.2 surface the lean wasm bundle answers — keywords, prefixed names
+// (`foaf:name`), variables (`?x` / `$x`), IRIs (`<…>`), string literals (single/long/quoted),
+// numbers, comments (`# …`), the `a` keyword, booleans, and punctuation. Unknown text falls
+// through as plain. No performance claim is made here (this repo's work box is non-canonical).
+
+/** The lexical class of a highlighted SPARQL token. */
+export type SparqlTokenType =
+  | "keyword" // SELECT, WHERE, FILTER, PREFIX, …  (and the `a` shorthand, booleans)
+  | "variable" // ?x  $x
+  | "iri" // <http://…>
+  | "prefixed" // foaf:name   ex:alice   rdf:type
+  | "string" // "…"  '…'  """…"""  '''…'''  (with lang/datatype handled as adjacent tokens)
+  | "number" // 42   3.14   1.0e9
+  | "comment" // # … to end of line
+  | "punctuation" // { } ( ) [ ] ; , . ^^ etc.
+  | "plain"; // whitespace and anything unclassified
+
+/** One token: its source `text` and lexical `type`. Concatenating every `text` in order
+ * reproduces the input string exactly. */
+export interface SparqlToken {
+  text: string;
+  type: SparqlTokenType;
+}
+
+// SPARQL 1.1 keywords (case-insensitive in SPARQL). Kept as an uppercase set; the lexer
+// upsuper-cases the candidate before lookup. Includes the SPARQL 1.2 additions the engine
+// accepts and the aggregate / modifier / update keywords. `a` (the rdf:type shorthand) and
+// the boolean literals are highlighted as keywords too (handled in the lexer, not this set).
+const KEYWORDS = new Set<string>([
+  "BASE", "PREFIX", "SELECT", "DISTINCT", "REDUCED", "CONSTRUCT", "DESCRIBE",
+  "ASK", "FROM", "NAMED", "WHERE", "ORDER", "BY", "ASC", "DESC", "LIMIT",
+  "OFFSET", "VALUES", "GROUP", "HAVING", "AS", "BIND", "SERVICE", "OPTIONAL",
+  "UNION", "MINUS", "GRAPH", "FILTER", "EXISTS", "NOT", "IN", "STR", "LANG",
+  "LANGMATCHES", "DATATYPE", "BOUND", "IRI", "URI", "BNODE", "RAND", "ABS",
+  "CEIL", "FLOOR", "ROUND", "CONCAT", "STRLEN", "UCASE", "LCASE",
+  "ENCODE_FOR_URI", "CONTAINS", "STRSTARTS", "STRENDS", "STRBEFORE", "STRAFTER",
+  "YEAR", "MONTH", "DAY", "HOURS", "MINUTES", "SECONDS", "TIMEZONE", "TZ", "NOW",
+  "UUID", "STRUUID", "MD5", "SHA1", "SHA256", "SHA384", "SHA512", "COALESCE",
+  "IF", "STRLANG", "STRDT", "SAMETERM", "ISIRI", "ISURI", "ISBLANK",
+  "ISLITERAL", "ISNUMERIC", "REGEX", "SUBSTR", "REPLACE", "COUNT", "SUM", "MIN",
+  "MAX", "AVG", "SAMPLE", "GROUP_CONCAT", "SEPARATOR",
+  // SPARQL Update
+  "LOAD", "CLEAR", "DROP", "CREATE", "ADD", "MOVE", "COPY", "INSERT", "DELETE",
+  "DATA", "WITH", "USING", "SILENT", "DEFAULT", "ALL", "INTO", "TO",
+  // EXPLAIN introspection forms the engine exposes
+  "EXPLAIN", "ANALYZE",
+]);
+
+const BOOLEANS = new Set<string>(["true", "false"]);
+
+// Character-class helpers (ASCII fast paths; PN_CHARS_BASE/U is approximated for highlighting).
+const isWs = (c: string): boolean => c === " " || c === "\t" || c === "\n" || c === "\r" || c === "\f" || c === "\v";
+const isDigit = (c: string): boolean => c >= "0" && c <= "9";
+const isNameStart = (c: string): boolean =>
+  (c >= "a" && c <= "z") || (c >= "A" && c <= "Z") || c === "_" || c.charCodeAt(0) > 127;
+const isNameChar = (c: string): boolean => isNameStart(c) || isDigit(c) || c === "-" || c === "." || c === "·";
+
+/**
+ * Tokenize a SPARQL string for HIGHLIGHTING. Pure: no side effects, no DOM. The returned
+ * tokens are gap-free and ordered — `tokens.map(t => t.text).join("")` equals the input
+ * exactly (so an overlay renderer aligns with the source). This is a forgiving lexer, not a
+ * validator: malformed input (an unterminated string/IRI, a stray character) is still
+ * tokenized to end-of-input rather than throwing.
+ */
+export function tokenizeSparql(input: string): SparqlToken[] {
+  const tokens: SparqlToken[] = [];
+  const n = input.length;
+  let i = 0;
+  const push = (text: string, type: SparqlTokenType): void => {
+    if (text.length > 0) tokens.push({ text, type });
+  };
+
+  while (i < n) {
+    const c = input[i];
+
+    // Whitespace run.
+    if (isWs(c)) {
+      let j = i + 1;
+      while (j < n && isWs(input[j])) j++;
+      push(input.slice(i, j), "plain");
+      i = j;
+      continue;
+    }
+
+    // Comment: `#` to end of line.
+    if (c === "#") {
+      let j = i + 1;
+      while (j < n && input[j] !== "\n") j++;
+      push(input.slice(i, j), "comment");
+      i = j;
+      continue;
+    }
+
+    // IRI ref: `<` … `>` (no whitespace/`<` inside per the grammar; stop forgivingly at EOL).
+    if (c === "<") {
+      let j = i + 1;
+      while (j < n && input[j] !== ">" && input[j] !== "\n" && input[j] !== "<") j++;
+      if (j < n && input[j] === ">") {
+        push(input.slice(i, j + 1), "iri");
+        i = j + 1;
+        continue;
+      }
+      // Not a closed IRI (e.g. a `<` operator) — emit one punctuation char and continue.
+      push(c, "punctuation");
+      i += 1;
+      continue;
+    }
+
+    // Variable: `?x` or `$x`.
+    if (c === "?" || c === "$") {
+      let j = i + 1;
+      while (j < n && isNameChar(input[j])) j++;
+      // A lone `?` (e.g. a property-path `?`) with no name is punctuation.
+      if (j === i + 1) {
+        push(c, "punctuation");
+        i += 1;
+      } else {
+        push(input.slice(i, j), "variable");
+        i = j;
+      }
+      continue;
+    }
+
+    // String literal: '...', "...", '''...''', """...""" (with \-escapes).
+    if (c === '"' || c === "'") {
+      const j = scanString(input, i, c);
+      push(input.slice(i, j), "string");
+      i = j;
+      continue;
+    }
+
+    // Number: a leading digit, or a `+`/`-`/`.` immediately followed by a digit.
+    if (
+      isDigit(c) ||
+      ((c === "+" || c === "-" || c === ".") && i + 1 < n && isDigit(input[i + 1]))
+    ) {
+      const j = scanNumber(input, i);
+      // A bare `.` (statement terminator) is punctuation, not a number — scanNumber returns
+      // i unchanged in that case (it only advances when it actually consumed digits).
+      if (j > i) {
+        push(input.slice(i, j), "number");
+        i = j;
+        continue;
+      }
+    }
+
+    // Name-like run: a keyword, a prefixed name (`foaf:name`), a bare prefix (`foaf:`), the
+    // `a` shorthand, a boolean, or `PREFIX:local`. Also handles a leading `:local` (empty
+    // prefix) and a leading `_:bnode`.
+    if (isNameStart(c) || c === ":") {
+      const j = scanNameLike(input, i);
+      const text = input.slice(i, j);
+      push(text, classifyNameLike(text));
+      i = j;
+      continue;
+    }
+
+    // `_:bnode` blank-node label.
+    if (c === "_" && i + 1 < n && input[i + 1] === ":") {
+      let j = i + 2;
+      while (j < n && isNameChar(input[j])) j++;
+      push(input.slice(i, j), "prefixed");
+      i = j;
+      continue;
+    }
+
+    // Multi-char punctuation we want as one token: `^^`, `||`, `&&`, `<=`, `>=`, `!=`.
+    const two = input.slice(i, i + 2);
+    if (two === "^^" || two === "||" || two === "&&" || two === "<=" || two === ">=" || two === "!=") {
+      push(two, "punctuation");
+      i += 2;
+      continue;
+    }
+
+    // Single-char punctuation / operators.
+    push(c, "punctuation");
+    i += 1;
+  }
+
+  return tokens;
+}
+
+/** Scan a quoted string starting at `start` (quote char `q`), returning the index PAST the
+ * closing quote (or end of input for an unterminated literal). Handles `'''`/`"""` long
+ * forms and `\`-escapes. */
+function scanString(input: string, start: number, q: string): number {
+  const n = input.length;
+  const isLong = input[start + 1] === q && input[start + 2] === q;
+  if (isLong) {
+    let j = start + 3;
+    while (j < n) {
+      if (input[j] === "\\") {
+        j += 2;
+        continue;
+      }
+      if (input[j] === q && input[j + 1] === q && input[j + 2] === q) return j + 3;
+      j++;
+    }
+    return n;
+  }
+  let j = start + 1;
+  while (j < n) {
+    if (input[j] === "\\") {
+      j += 2;
+      continue;
+    }
+    if (input[j] === q) return j + 1;
+    if (input[j] === "\n") return j; // single-line string ends at a newline (forgiving)
+    j++;
+  }
+  return n;
+}
+
+/** Scan a numeric literal at `start`; returns the index past it, or `start` if no digit was
+ * actually consumed (so a bare `.`/`+`/`-` operator is NOT misread as a number). */
+function scanNumber(input: string, start: number): number {
+  const n = input.length;
+  let j = start;
+  if (input[j] === "+" || input[j] === "-") j++;
+  let sawDigit = false;
+  while (j < n && isDigit(input[j])) {
+    j++;
+    sawDigit = true;
+  }
+  if (j < n && input[j] === ".") {
+    j++;
+    while (j < n && isDigit(input[j])) {
+      j++;
+      sawDigit = true;
+    }
+  }
+  // Exponent.
+  if (sawDigit && j < n && (input[j] === "e" || input[j] === "E")) {
+    let k = j + 1;
+    if (k < n && (input[k] === "+" || input[k] === "-")) k++;
+    if (k < n && isDigit(input[k])) {
+      k++;
+      while (k < n && isDigit(input[k])) k++;
+      j = k;
+    }
+  }
+  return sawDigit ? j : start;
+}
+
+/** Scan a name-like run (keyword / prefixed name / bare prefix / `a` / boolean), including an
+ * optional `:` and a local part. Returns the index past it. */
+function scanNameLike(input: string, start: number): number {
+  const n = input.length;
+  let j = start;
+  // Optional leading prefix label (or empty for `:local`).
+  while (j < n && isNameChar(input[j])) j++;
+  // A `:` makes it a prefixed name — consume the colon and the local part.
+  if (j < n && input[j] === ":") {
+    j++;
+    while (j < n && (isNameChar(input[j]) || input[j] === ":" || input[j] === "%")) j++;
+  }
+  // Trim a trailing `.` that is really a statement terminator (not part of a local name end)
+  // — but only when the run is NOT a prefixed name (a dot inside `ex:a.b` is legal). A bare
+  // keyword/`a` followed by `.` must not swallow the dot.
+  if (input.slice(start, j).indexOf(":") === -1) {
+    while (j > start && input[j - 1] === ".") j--;
+  }
+  return Math.max(j, start + 1);
+}
+
+/** Classify a name-like run already extracted by {@link scanNameLike}. */
+function classifyNameLike(text: string): SparqlTokenType {
+  if (text.indexOf(":") !== -1) return "prefixed"; // foaf:name, ex:alice, :local, rdf:type
+  if (text === "a") return "keyword"; // the rdf:type shorthand
+  const upper = text.toUpperCase();
+  if (KEYWORDS.has(upper)) return "keyword";
+  if (BOOLEANS.has(text.toLowerCase())) return "keyword";
+  return "plain";
+}

--- a/packages/sparq-client/src/sparql-prefixes.ts
+++ b/packages/sparq-client/src/sparql-prefixes.ts
@@ -1,0 +1,95 @@
+// [OPUS-4.8] sq-n5aw — framework-agnostic common-prefix support for the SPARQL editor.
+//
+// The editor uplift (`research/gui-design.md` §2, MVP item 1) calls for "prefix awareness".
+// This module is the dependency-free, DOM-free core of that: a curated registry of well-known
+// RDF vocabulary prefixes, plus pure helpers to (a) find which well-known prefixes a query
+// USES but does not DECLARE, and (b) render the PREFIX lines to prepend. No React, no DOM — so
+// the same logic serves the Next.js site and the Tauri 2 webview, and is unit-testable in
+// `node:test`. It takes no opinion on UI; a component decides how to surface the suggestion.
+
+/** A well-known prefix → namespace IRI binding. */
+export interface PrefixBinding {
+  prefix: string;
+  iri: string;
+}
+
+/**
+ * The curated registry of common RDF vocabulary prefixes the editor can offer. These are the
+ * widely-used, stable namespaces (the same families the site's built-in datasets and example
+ * queries use: `ex:`/`foaf:`/`rdf:`/`rdfs:`/`xsd:`/`dc:`). Ordered roughly by ubiquity so a
+ * "insert all common prefixes" affordance produces a sensible block. Not exhaustive by design
+ * — it is a STARTER set for the playground, not a vocabulary directory.
+ */
+export const COMMON_PREFIXES: readonly PrefixBinding[] = [
+  { prefix: "rdf", iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#" },
+  { prefix: "rdfs", iri: "http://www.w3.org/2000/01/rdf-schema#" },
+  { prefix: "owl", iri: "http://www.w3.org/2002/07/owl#" },
+  { prefix: "xsd", iri: "http://www.w3.org/2001/XMLSchema#" },
+  { prefix: "foaf", iri: "http://xmlns.com/foaf/0.1/" },
+  { prefix: "dc", iri: "http://purl.org/dc/terms/" },
+  { prefix: "dcterms", iri: "http://purl.org/dc/terms/" },
+  { prefix: "skos", iri: "http://www.w3.org/2004/02/skos/core#" },
+  { prefix: "schema", iri: "https://schema.org/" },
+  { prefix: "sh", iri: "http://www.w3.org/ns/shacl#" },
+  { prefix: "prov", iri: "http://www.w3.org/ns/prov#" },
+  { prefix: "geo", iri: "http://www.opengis.net/ont/geosparql#" },
+  { prefix: "void", iri: "http://rdfs.org/ns/void#" },
+  { prefix: "ex", iri: "http://example.org/" },
+];
+
+// `PREFIX foo: <iri>` declaration matcher (case-insensitive `PREFIX`, tolerant of the empty
+// prefix `:`). Used to read which prefixes a query already declares.
+const DECLARED_RE = /(?:^|\s)PREFIX\s+([A-Za-z][\w.-]*)?:\s*<[^>]*>/gi;
+
+// A used prefixed-name's prefix label, e.g. `foaf` in `foaf:name`. Excludes IRIs, variables,
+// and the `_:bnode` form. The label must start a token (preceded by start/whitespace/`{(,;.[`).
+const USED_RE = /(?:^|[\s{(,;.[])([A-Za-z][\w.-]*):[A-Za-z_]/g;
+
+/** The set of prefix labels a query DECLARES (via `PREFIX foo: <…>`). The empty prefix `:`
+ * is represented as the empty string. */
+export function declaredPrefixes(query: string): Set<string> {
+  const out = new Set<string>();
+  for (const m of query.matchAll(DECLARED_RE)) out.add(m[1] ?? "");
+  return out;
+}
+
+/** The set of prefix labels a query USES (a prefixed name `foo:bar`). Best-effort over the
+ * highlight grammar, not a full parse; intended for the "you used `foaf:` but didn't declare
+ * it" hint. */
+export function usedPrefixes(query: string): Set<string> {
+  const out = new Set<string>();
+  for (const m of query.matchAll(USED_RE)) out.add(m[1]);
+  return out;
+}
+
+/**
+ * The well-known prefixes a query USES but has not DECLARED — i.e. the {@link COMMON_PREFIXES}
+ * the editor can offer to insert. Returns them in {@link COMMON_PREFIXES} order. A prefix the
+ * query uses but that is NOT in the common registry is omitted (the editor has no IRI to
+ * suggest for it).
+ */
+export function missingCommonPrefixes(query: string): PrefixBinding[] {
+  const declared = declaredPrefixes(query);
+  const used = usedPrefixes(query);
+  return COMMON_PREFIXES.filter((b) => used.has(b.prefix) && !declared.has(b.prefix));
+}
+
+/** Render `PREFIX foo: <iri>` lines for the given bindings (one per line, no trailing
+ * newline). */
+export function renderPrefixLines(bindings: readonly PrefixBinding[]): string {
+  return bindings.map((b) => `PREFIX ${b.prefix}: <${b.iri}>`).join("\n");
+}
+
+/**
+ * Prepend the given prefix declarations to a query, skipping any the query already declares,
+ * and separating the inserted block from the body with a blank line. Returns the query
+ * unchanged when there is nothing new to add. Pure — does not mutate its input.
+ */
+export function withPrefixes(query: string, bindings: readonly PrefixBinding[]): string {
+  const declared = declaredPrefixes(query);
+  const toAdd = bindings.filter((b) => !declared.has(b.prefix));
+  if (toAdd.length === 0) return query;
+  const block = renderPrefixLines(toAdd);
+  const body = query.replace(/^\s+/, ""); // trim leading whitespace so the block sits flush
+  return body.length > 0 ? `${block}\n\n${body}` : block;
+}

--- a/packages/sparq-client/tsconfig.conformance.json
+++ b/packages/sparq-client/tsconfig.conformance.json
@@ -1,0 +1,18 @@
+{
+  // [OPUS-4.8] sq-06gq — the GENERATED-surface conformance typecheck. Run by
+  // `npm run typecheck:conformance` ONLY where the wasm-pack build artifact is present
+  // (locally after `cd ../../js && npm run build:wasm`, and the `site-with-shared-client`
+  // CI job, which builds the bundle). It maps `#sparq-wasm-generated` to the wasm-pack
+  // GENERATED `sparq_wasm.d.ts` (the git-ignored `js/wasm/` build output) and compiles
+  // `src/conformance.ts`, which asserts the hand-written surface stays a faithful subset of
+  // that generated `Store`. The bare `tsconfig.json` excludes `conformance.ts`, so the
+  // artifact-free `shared-client` CI job is unaffected.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "#sparq-wasm-generated": ["../../js/wasm/sparq_wasm.d.ts"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/sparq-client/tsconfig.json
+++ b/packages/sparq-client/tsconfig.json
@@ -14,5 +14,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/conformance.ts"]
 }

--- a/site/README.md
+++ b/site/README.md
@@ -40,6 +40,24 @@ npm run test:e2e   # Playwright — headless browser smoke tests (see below)
 wasm-pack `--target web` output from `js/wasm/`. The `prebuild` script runs it
 automatically before `next build`.
 
+### Build modes — `basePath` (Pages vs Tauri) — `sq-9vw5`
+
+`next.config.ts` env-switches `basePath`/`assetPrefix` off `NEXT_PUBLIC_BASE_PATH` so the
+**same** `out/` export serves two hosts. The `@sparq/client` wasm loader keys its runtime
+asset URLs off the *same* env var, so the build-time route prefix and the runtime wasm-fetch
+prefix stay in lockstep.
+
+| Host | Command | `basePath` | When |
+|---|---|---|---|
+| **GitHub Pages** (default) | `npm run build` | `/sparq` | served under `https://jeswr.github.io/sparq/` — every asset/route is `/sparq`-prefixed |
+| **Tauri 2 webview** | `NEXT_PUBLIC_BASE_PATH='' npm run build` | `''` (root-relative) | the desktop GUI serves the export from the `tauri://` root, where a `/sparq` prefix would 404 |
+
+The env var is read once in `next.config.ts`: **unset** keeps the historical `/sparq` default
+(no caller change); an explicit **empty string** selects the root-relative export; a malformed
+value falls back to the Pages default. The GUI's `gui/src-tauri/tauri.conf.json`
+`beforeBuildCommand` already passes `NEXT_PUBLIC_BASE_PATH=''`, so a Tauri build gets the
+right export with no extra step.
+
 ### Browser smoke tests (Playwright)
 
 `e2e/` holds headless-browser smoke tests driven by Playwright against a real `next dev`

--- a/site/next.config.ts
+++ b/site/next.config.ts
@@ -5,10 +5,41 @@ import type { NextConfig } from "next";
 // Pages serves this project site under https://jeswr.github.io/sparq/, so every
 // asset + route must be prefixed with `/sparq`. `output: "export"` writes a fully
 // static `out/` tree (no Node server) that the Pages deploy workflow uploads.
+//
+// [OPUS-4.8] sq-9vw5 — env-switch the base path so the SAME export tree serves TWO hosts:
+//
+//   * GitHub Pages (the default): served under `/sparq/`, so basePath/assetPrefix must be
+//     `/sparq`. This is what `npm run build` produces with no env set.
+//   * The Tauri 2 desktop webview: serves the frontend from the `tauri://` root (a local
+//     `frontendDist`), so EVERY asset must be ROOT-relative — a `/sparq` prefix 404s there.
+//     The GUI's `gui/src-tauri/tauri.conf.json` `beforeBuildCommand` builds the site with
+//     `NEXT_PUBLIC_BASE_PATH=''`, so this config reads that env var and emits a root-relative
+//     export (`basePath: ''`, no asset prefix).
+//
+// `NEXT_PUBLIC_BASE_PATH` is the single switch — and the `@sparq/client` wasm loader already
+// keys its RUNTIME asset URLs off the SAME env var, so the build-time route prefix and the
+// runtime wasm-fetch prefix stay in lockstep. Two build modes (also in site/README.md):
+//   * Pages :                      `npm run build`     -> basePath '/sparq'
+//   * Tauri : `NEXT_PUBLIC_BASE_PATH='' npm run build` -> basePath '' (root-relative)
+//
+// An UNSET var keeps the historical `/sparq` default so the Pages build and every existing
+// caller are unchanged; an explicit empty string selects the root-relative (Tauri) export.
+// Next requires basePath to be empty or start with `/` (no trailing slash), so we honour only
+// `''` or a `/`-leading value and otherwise fall back to the Pages default.
+const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH;
+const basePath =
+  rawBasePath === undefined
+    ? "/sparq" // unset -> Pages default (historical behaviour, no caller change)
+    : rawBasePath === "" || rawBasePath.startsWith("/")
+      ? rawBasePath // '' (Tauri root-relative) or an explicit '/prefix'
+      : "/sparq"; // a malformed value falls back to the Pages default
+
 const nextConfig: NextConfig = {
   output: "export",
-  basePath: "/sparq",
-  assetPrefix: "/sparq",
+  // Only emit basePath/assetPrefix when there IS a prefix. An empty basePath must not be
+  // set as `assetPrefix: ""` either — leaving both unset is exactly the root-relative
+  // behaviour the Tauri webview needs.
+  ...(basePath ? { basePath, assetPrefix: basePath } : {}),
   trailingSlash: true,
   // Static export cannot run the Next.js image optimiser.
   images: { unoptimized: true },

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -227,4 +227,33 @@
     background-color: color-mix(in oklch, var(--muted) 60%, transparent);
     font-weight: 600;
   }
+
+  /* [OPUS-4.8] sq-n5aw — SPARQL syntax-highlight token colours for the query editor.
+     One class per `SparqlTokenType` from `@sparq/client`. Colours reuse the existing
+     design-system tokens (`--primary`, `--chart-*`, `--muted-foreground`), which already
+     carry light + dark variants, so highlighting follows the theme automatically and adds no
+     new palette. `plain`/`punctuation` inherit `--foreground` (no class needed). */
+  .sq-tok-keyword {
+    color: var(--primary);
+    font-weight: 600;
+  }
+  .sq-tok-variable {
+    color: var(--chart-5);
+  }
+  .sq-tok-iri {
+    color: var(--chart-1);
+  }
+  .sq-tok-prefixed {
+    color: var(--chart-2);
+  }
+  .sq-tok-string {
+    color: var(--chart-4);
+  }
+  .sq-tok-number {
+    color: var(--chart-3);
+  }
+  .sq-tok-comment {
+    color: var(--muted-foreground);
+    font-style: italic;
+  }
 }

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -7,6 +7,7 @@ import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppShell } from "@/components/layout/app-shell";
+import { withBasePath } from "@/lib/base-path";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -21,7 +22,10 @@ export const metadata: Metadata = {
   },
   description:
     "sparq is a state-of-the-art Rust RDF + SPARQL engine with a browser WASM port. This showcase runs real sparq — SPARQL, ZK proofs, MPC, Solid — live in your tab, honestly labelled where it cannot.",
-  icons: { icon: "/sparq/logo.svg" },
+  // [OPUS-4.8] sq-9vw5 — basePath-switched so the favicon resolves under both the Pages
+  // `/sparq` prefix AND the Tauri root-relative build (a hardcoded `/sparq/…` is NOT
+  // rewritten by Next, so it must read the env-derived base path).
+  icons: { icon: withBasePath("/logo.svg") },
 };
 
 export const viewport: Viewport = {
@@ -40,12 +44,14 @@ export default function RootLayout({
         {/* [OPUS-4.8] coi-serviceworker shim — synthesises COOP/COEP so
             `window.crossOriginIsolated` becomes true on GitHub Pages (which cannot
             set those headers itself). That unlocks SharedArrayBuffer, so @aztec/bb.js
-            can spin worker threads and the in-tab ZK prover multithreads (~4x). Loaded
+            can spin worker threads and the in-tab ZK prover multithreads. Loaded
             beforeInteractive with an absolute, basePath-prefixed src so the service
-            worker registers from /sparq/coi-serviceworker.js with scope /sparq/. It
-            changes only thread count — never what any proof proves or its ZK property. */}
+            worker registers from `${basePath}/coi-serviceworker.js` with that scope.
+            [OPUS-4.8] sq-9vw5 — basePath-switched (was hardcoded `/sparq/…`) so it
+            resolves under both Pages and the Tauri root-relative build. It changes only
+            thread count — never what any proof proves or its ZK property. */}
         <Script
-          src="/sparq/coi-serviceworker.js"
+          src={withBasePath("/coi-serviceworker.js")}
           strategy="beforeInteractive"
         />
       </head>

--- a/site/src/app/papers/[slug]/page.tsx
+++ b/site/src/app/papers/[slug]/page.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/data/papers";
 import { LATEST, GENERATED_AT } from "@/data/benchmarks";
 import evidence from "@/data/paper-evidence.json";
+import { withBasePath } from "@/lib/base-path";
 
 export function generateStaticParams() {
   return PAPERS.map((p) => ({ slug: p.slug }));
@@ -70,9 +71,10 @@ function provenanceFor(): Provenance {
   };
 }
 
-// basePath-aware PDF asset link (served under /sparq on GitHub Pages).
+// basePath-aware PDF asset link. [OPUS-4.8] sq-9vw5 — env-switched (was hardcoded `/sparq`)
+// so the PDF resolves under both the Pages `/sparq` prefix and the Tauri root-relative build.
 function pdfHref(slug: string): string {
-  return `/sparq/papers/${slug}.pdf`;
+  return withBasePath(`/papers/${slug}.pdf`);
 }
 
 export default async function PaperPage({

--- a/site/src/app/papers/page.tsx
+++ b/site/src/app/papers/page.tsx
@@ -20,6 +20,7 @@ import {
   STATUS_VARIANT,
   FAMILY_LABEL,
 } from "@/data/papers";
+import { withBasePath } from "@/lib/base-path";
 
 export const metadata: Metadata = {
   title: "Papers",
@@ -27,9 +28,10 @@ export const metadata: Metadata = {
     "Academic papers generated from sparq contributions — each authored once in Typst, bound to live evidence, and built into both an in-site render and a downloadable PDF. Numbers are gated to deterministic, machine-independent evidence.",
 };
 
-// basePath-aware PDF asset link (the site is served under /sparq on GitHub Pages).
+// basePath-aware PDF asset link. [OPUS-4.8] sq-9vw5 — env-switched (was hardcoded `/sparq`)
+// so the PDF resolves under both the Pages `/sparq` prefix and the Tauri root-relative build.
 function pdfHref(slug: string): string {
-  return `/sparq/papers/${slug}.pdf`;
+  return withBasePath(`/papers/${slug}.pdf`);
 }
 
 export default function PapersIndexPage() {

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -36,6 +36,8 @@ import {
   DatasetViewer,
   type ActiveDataset,
 } from "@/components/repl-datasets";
+// [OPUS-4.8] sq-n5aw — the syntax-highlighting SPARQL editor replaces the plain <textarea>.
+import { SparqlEditor } from "@/components/sparql-editor";
 
 // [OPUS-4.8] sq-vfbm — the REPL now dispatches across the whole lean-bundle query
 // surface, so the result state carries one variant per shape of answer: a solution
@@ -324,13 +326,12 @@ export function Repl() {
         <label htmlFor="repl-query" className="sr-only">
           SPARQL query
         </label>
-        <textarea
+        <SparqlEditor
           id="repl-query"
+          ariaLabel="SPARQL query"
           value={sparql}
-          spellCheck={false}
-          onChange={(e) => setSparql(e.target.value)}
+          onChange={setSparql}
           rows={9}
-          className="w-full resize-y rounded-lg border bg-muted/40 p-3 font-mono text-[13px] leading-relaxed outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
         />
 
         <div className="flex flex-wrap items-center gap-3">

--- a/site/src/components/sparql-editor.tsx
+++ b/site/src/components/sparql-editor.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+// [OPUS-4.8] sq-n5aw — query-editor uplift (MVP). A real SPARQL editor surface that replaces
+// the plain `<textarea>` in the live REPL (`research/gui-design.md` §2, MVP item 1 — the
+// single biggest real UX gap). It gives the playground:
+//   * SPARQL SYNTAX HIGHLIGHTING — a highlighted `<pre>` rendered behind a transparent-text
+//     `<textarea>` (the standard zero-dependency overlay technique). The two layers share
+//     identical font metrics, padding and scroll offset so glyphs align exactly. The
+//     tokenizer is the framework-agnostic `@sparq/client` core (`tokenizeSparql`), so the SAME
+//     highlighting serves the site and the Tauri webview.
+//   * COMMON-PREFIX awareness — when the query uses a well-known prefix it has not declared
+//     (`foaf:`, `rdf:`, …), a one-click affordance prepends the missing `PREFIX` lines
+//     (`missingCommonPrefixes` / `withPrefixes`, also from `@sparq/client`).
+//
+// This is DEPENDENCY-FREE (no CodeMirror / Monaco): no new npm dependency, no bundle-size
+// hit, and static-export-safe (no SSR-incompatible client lib). The trade-off vs a full
+// editor framework is no autocomplete popovers / multi-cursor; for the MVP, highlighting +
+// prefix help is the high-leverage win, and the surface can grow later. Example-query
+// chips stay owned by the REPL (they pick a whole query); this component owns the EDITING.
+
+import * as React from "react";
+import { Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  type SparqlToken,
+  tokenizeSparql,
+  missingCommonPrefixes,
+  withPrefixes,
+} from "@sparq/client";
+
+// The shared text-metrics: the highlight `<pre>` and the `<textarea>` MUST use identical
+// font, size, line-height, padding, tab size and wrapping, or the layers drift. Centralised
+// here so they can never diverge.
+const EDITOR_TEXT_CLASS =
+  "font-mono text-[13px] leading-relaxed whitespace-pre-wrap break-words [tab-size:2]";
+const EDITOR_PAD_CLASS = "p-3";
+
+const TOKEN_CLASS: Record<SparqlToken["type"], string> = {
+  keyword: "sq-tok-keyword",
+  variable: "sq-tok-variable",
+  iri: "sq-tok-iri",
+  prefixed: "sq-tok-prefixed",
+  string: "sq-tok-string",
+  number: "sq-tok-number",
+  comment: "sq-tok-comment",
+  punctuation: "",
+  plain: "",
+};
+
+export interface SparqlEditorProps {
+  /** Current query text (controlled). */
+  value: string;
+  /** Called with the new text on edit (and when a prefix block is inserted). */
+  onChange: (next: string) => void;
+  /** Visible rows (the textarea is resizable vertically from here). */
+  rows?: number;
+  /** Accessible label for the editing surface. */
+  ariaLabel?: string;
+  /** id for the textarea (so an external `<label htmlFor>` can target it). */
+  id?: string;
+  className?: string;
+}
+
+/**
+ * A syntax-highlighting SPARQL editor: a transparent-caret `<textarea>` over a highlighted
+ * `<pre>`. Fully controlled; emits edits (and prefix insertions) through {@link onChange}.
+ */
+export function SparqlEditor({
+  value,
+  onChange,
+  rows = 9,
+  ariaLabel = "SPARQL query",
+  id,
+  className,
+}: SparqlEditorProps) {
+  const preRef = React.useRef<HTMLPreElement>(null);
+
+  // Keep the highlight layer's scroll offset in lockstep with the textarea (long queries that
+  // overflow vertically/horizontally must scroll both layers together).
+  const syncScroll = React.useCallback((el: HTMLTextAreaElement) => {
+    if (preRef.current) {
+      preRef.current.scrollTop = el.scrollTop;
+      preRef.current.scrollLeft = el.scrollLeft;
+    }
+  }, []);
+
+  const tokens = React.useMemo(() => tokenizeSparql(value), [value]);
+
+  // The well-known prefixes the query USES but does not DECLARE — the one-click "add prefixes"
+  // affordance. Empty (hidden) when the query already declares everything it uses.
+  const missing = React.useMemo(() => missingCommonPrefixes(value), [value]);
+
+  const addMissingPrefixes = React.useCallback(() => {
+    if (missing.length === 0) return;
+    onChange(withPrefixes(value, missing));
+  }, [missing, onChange, value]);
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <div className="relative rounded-lg border bg-muted/40">
+        {/* Highlight layer: aria-hidden (the textarea is the accessible control). A trailing
+            newline keeps the last line's height stable while typing at the very end. */}
+        <pre
+          ref={preRef}
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none absolute inset-0 m-0 overflow-auto",
+            EDITOR_PAD_CLASS,
+            EDITOR_TEXT_CLASS,
+          )}
+        >
+          {tokens.map((t, idx) => {
+            const cls = TOKEN_CLASS[t.type];
+            return cls ? (
+              <span key={idx} className={cls}>
+                {t.text}
+              </span>
+            ) : (
+              <React.Fragment key={idx}>{t.text}</React.Fragment>
+            );
+          })}
+          {"\n"}
+        </pre>
+
+        {/* Editing layer: transparent text (so the highlight shows through) but a visible
+            caret. `spellCheck` off — SPARQL is not prose. */}
+        <textarea
+          id={id}
+          aria-label={ariaLabel}
+          value={value}
+          spellCheck={false}
+          autoCapitalize="off"
+          autoCorrect="off"
+          rows={rows}
+          onChange={(e) => onChange(e.target.value)}
+          onScroll={(e) => syncScroll(e.currentTarget)}
+          className={cn(
+            "relative block w-full resize-y bg-transparent text-transparent caret-foreground outline-none",
+            "selection:bg-primary/30 focus-visible:ring-3 focus-visible:ring-ring/40 rounded-lg",
+            EDITOR_PAD_CLASS,
+            EDITOR_TEXT_CLASS,
+          )}
+        />
+      </div>
+
+      {missing.length > 0 && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>
+            Uses{" "}
+            <span className="font-mono text-foreground">
+              {missing.map((b) => `${b.prefix}:`).join(" ")}
+            </span>{" "}
+            without a declaration.
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-6 gap-1 px-2 text-xs"
+            onClick={addMissingPrefixes}
+          >
+            <Sparkles className="size-3" />
+            Add {missing.length === 1 ? "prefix" : `${missing.length} prefixes`}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/site/src/lib/base-path.ts
+++ b/site/src/lib/base-path.ts
@@ -1,0 +1,43 @@
+// [OPUS-4.8] sq-9vw5 — the ONE site-side base-path resolver.
+//
+// The site is served under TWO hosts (see site/next.config.ts):
+//   * GitHub Pages — under `/sparq/`, so static asset hrefs must be `/sparq`-prefixed;
+//   * the Tauri 2 desktop webview — from the `tauri://` root, where a `/sparq` prefix 404s.
+//
+// `next.config.ts` already env-switches `basePath`/`assetPrefix` off `NEXT_PUBLIC_BASE_PATH`,
+// so Next rewrites `_next/*` chunk URLs and `<Link href>` routes automatically. But a HARDCODED
+// absolute asset path written by hand into a component (a `<Script src>`, a favicon, a PDF
+// link) is NOT rewritten by Next — it ships verbatim. Those must read the same env var so they
+// move with the build mode. This module is that single read, mirroring the resolver the wasm
+// loaders already use (`?? "/sparq"`), kept in one place so the rule has one source of truth
+// and one unit test.
+
+/**
+ * The configured base path for hand-written absolute asset URLs, derived from
+ * `NEXT_PUBLIC_BASE_PATH` (the same switch `next.config.ts` and the `@sparq/client` wasm
+ * loader use):
+ *
+ *   * **unset** → `"/sparq"` (the GitHub Pages default; historical behaviour, no change);
+ *   * **`""`** → `""` (the Tauri root-relative export);
+ *   * a leading-`/` value → that value (an explicit deploy prefix);
+ *   * any malformed value → falls back to `"/sparq"`.
+ *
+ * Returns `""` (not `"/"`) for the root, so {@link withBasePath} composes a clean
+ * `${basePath}/foo` without a double slash.
+ */
+export function basePath(): string {
+  const raw = process.env.NEXT_PUBLIC_BASE_PATH;
+  if (raw === undefined) return "/sparq";
+  if (raw === "") return "";
+  if (raw.startsWith("/")) return raw.replace(/\/$/, ""); // strip any trailing slash
+  return "/sparq";
+}
+
+/**
+ * Prefix a root-absolute asset path with the configured {@link basePath}. `path` MUST start
+ * with `/` (it is a root-absolute public asset, e.g. `/logo.svg`). On Pages this yields
+ * `/sparq/logo.svg`; in the Tauri root-relative build it yields `/logo.svg` unchanged.
+ */
+export function withBasePath(path: string): string {
+  return `${basePath()}${path}`;
+}

--- a/site/test/base-path.test.mjs
+++ b/site/test/base-path.test.mjs
@@ -1,0 +1,52 @@
+// [OPUS-4.8] sq-9vw5 — unit tests for the site's base-path resolver, the single switch that
+// lets the SAME static export serve BOTH GitHub Pages (`/sparq` prefix) and the Tauri 2
+// webview (root-relative `''`). `basePath()` / `withBasePath()` read `NEXT_PUBLIC_BASE_PATH`
+// at call time, so each case sets/clears the env var and re-imports nothing (the read is
+// function-scoped, not module-scoped). Mirrors the build-time switch in `next.config.ts` and
+// the runtime wasm-loader switch in `@sparq/client`. Run via `npm run test:unit`.
+import { test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { basePath, withBasePath } from "../src/lib/base-path.ts";
+
+const KEY = "NEXT_PUBLIC_BASE_PATH";
+
+// Restore a pristine env after every case so order can't leak.
+const originalHadKey = Object.prototype.hasOwnProperty.call(process.env, KEY);
+const originalValue = process.env[KEY];
+afterEach(() => {
+  if (originalHadKey) process.env[KEY] = originalValue;
+  else delete process.env[KEY];
+});
+
+test("unset env -> the GitHub Pages default '/sparq' (historical, no caller change)", () => {
+  delete process.env[KEY];
+  assert.equal(basePath(), "/sparq");
+  assert.equal(withBasePath("/logo.svg"), "/sparq/logo.svg");
+});
+
+test("empty string -> root-relative '' (the Tauri webview export)", () => {
+  process.env[KEY] = "";
+  assert.equal(basePath(), "");
+  // Root-relative: the asset path is returned unchanged, with no double slash.
+  assert.equal(withBasePath("/logo.svg"), "/logo.svg");
+  assert.equal(withBasePath("/papers/x.pdf"), "/papers/x.pdf");
+});
+
+test("an explicit '/'-leading prefix is honoured (a custom deploy root)", () => {
+  process.env[KEY] = "/demo";
+  assert.equal(basePath(), "/demo");
+  assert.equal(withBasePath("/coi-serviceworker.js"), "/demo/coi-serviceworker.js");
+});
+
+test("a trailing slash on the prefix is stripped (no double slash on compose)", () => {
+  process.env[KEY] = "/demo/";
+  assert.equal(basePath(), "/demo");
+  assert.equal(withBasePath("/logo.svg"), "/demo/logo.svg");
+});
+
+test("a malformed (non-'/'-leading) value falls back to the Pages default", () => {
+  process.env[KEY] = "sparq"; // missing leading slash
+  assert.equal(basePath(), "/sparq");
+  assert.equal(withBasePath("/logo.svg"), "/sparq/logo.svg");
+});

--- a/site/test/sparql-highlight.test.mjs
+++ b/site/test/sparql-highlight.test.mjs
@@ -1,0 +1,113 @@
+// [OPUS-4.8] sq-n5aw — unit tests for the framework-agnostic SPARQL highlighting tokenizer
+// (packages/sparq-client/src/sparql-highlight.ts), the dependency-free core of the query-editor
+// uplift. The two load-bearing invariants: (1) the tokenizer is LOSSLESS — concatenating every
+// token's text reproduces the input exactly (the overlay editor aligns the highlight layer with
+// the textarea glyph-for-glyph, so any drift would mis-render), and (2) each construct gets the
+// right lexical class. Imported via relative path (the node:test TS loader has no `@sparq/client`
+// alias). Run via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  tokenizeSparql,
+} from "../../packages/sparq-client/src/sparql-highlight.ts";
+
+/** Concatenate token texts — must equal the input for any string (the lossless invariant). */
+function roundtrip(src) {
+  return tokenizeSparql(src)
+    .map((t) => t.text)
+    .join("");
+}
+
+/** The token types covering a given source, in order, dropping pure-whitespace `plain` runs. */
+function typesOf(src) {
+  return tokenizeSparql(src)
+    .filter((t) => !(t.type === "plain" && t.text.trim() === ""))
+    .map((t) => t.type);
+}
+
+/** First token of a given type, or undefined. */
+function firstOfType(src, type) {
+  return tokenizeSparql(src).find((t) => t.type === type)?.text;
+}
+
+test("lossless: concatenating tokens reproduces the input exactly", () => {
+  const samples = [
+    "",
+    "   ",
+    "SELECT * WHERE { ?s ?p ?o }",
+    `PREFIX foaf: <http://xmlns.com/foaf/0.1/>\nSELECT ?name WHERE {\n  ?s foaf:name ?name .\n} ORDER BY ?name`,
+    "ASK { ?s a foaf:Person . FILTER(?age >= 25) } # trailing comment",
+    `CONSTRUCT { ?a ex:friendOf ?b } WHERE { ?a foaf:knows ?b }`,
+    "SELECT (COUNT(?s) AS ?n) WHERE { ?s ex:city ?city } GROUP BY ?city",
+    'SELECT * { ?s ?p "a string with \\" escape" }',
+    "SELECT * { ?s ?p '''long\nstring''' }",
+    "INSERT DATA { ex:erin a foaf:Person ; foaf:age 28 . }",
+    "SELECT * { ?x foaf:knows+ ?y } # path",
+    "weird << >> ?? $$ unmatched < iri",
+  ];
+  for (const s of samples) {
+    assert.equal(roundtrip(s), s, `roundtrip mismatch for: ${JSON.stringify(s)}`);
+  }
+});
+
+test("keywords (case-insensitive) and the `a` shorthand are classified as keyword", () => {
+  assert.equal(firstOfType("SELECT ?x", "keyword"), "SELECT");
+  assert.equal(firstOfType("select ?x", "keyword"), "select");
+  assert.equal(firstOfType("WhErE {}", "keyword"), "WhErE");
+  // `a` (rdf:type shorthand) is a keyword; a longer word containing `a` is not.
+  const toks = tokenizeSparql("?s a foaf:Person");
+  assert.deepEqual(
+    toks.filter((t) => t.text === "a").map((t) => t.type),
+    ["keyword"],
+  );
+});
+
+test("variables: ?x and $x, but a lone ? is punctuation", () => {
+  assert.equal(firstOfType("?name", "variable"), "?name");
+  assert.equal(firstOfType("$age", "variable"), "$age");
+  // A property-path `?` (zero-or-one) after a name is punctuation, not a variable.
+  const toks = tokenizeSparql("foaf:knows?");
+  assert.equal(toks.at(-1).type, "punctuation");
+  assert.equal(toks.at(-1).text, "?");
+});
+
+test("IRIs, prefixed names, strings, numbers, comments each get their class", () => {
+  assert.equal(firstOfType("<http://example.org/a>", "iri"), "<http://example.org/a>");
+  assert.equal(firstOfType("foaf:name", "prefixed"), "foaf:name");
+  assert.equal(firstOfType(":local", "prefixed"), ":local");
+  assert.equal(firstOfType('"hello"', "string"), '"hello"');
+  assert.equal(firstOfType("'hi'", "string"), "'hi'");
+  assert.equal(firstOfType("42", "number"), "42");
+  assert.equal(firstOfType("3.14", "number"), "3.14");
+  assert.equal(firstOfType("1.0e9", "number"), "1.0e9");
+  assert.equal(firstOfType("# a comment\nSELECT", "comment"), "# a comment");
+});
+
+test("a statement-terminating dot is punctuation, not a number or part of the name", () => {
+  // `?o .` — the dot must be its own punctuation token (not swallowed by the var or read as a number).
+  const toks = tokenizeSparql("?o .");
+  const dot = toks.find((t) => t.text === ".");
+  assert.ok(dot, "expected a standalone '.' token");
+  assert.equal(dot.type, "punctuation");
+});
+
+test("a realistic query yields a sensible class sequence", () => {
+  const types = typesOf("PREFIX ex: <http://example.org/> SELECT ?x WHERE { ?x a ex:Thing }");
+  // PREFIX(keyword) ex:(prefixed) <iri> SELECT(keyword) ?x(var) WHERE(keyword) {(punct)
+  assert.equal(types[0], "keyword"); // PREFIX
+  assert.equal(types[1], "prefixed"); // ex:
+  assert.equal(types[2], "iri");
+  assert.equal(types[3], "keyword"); // SELECT
+  assert.equal(types[4], "variable"); // ?x
+  assert.equal(types[5], "keyword"); // WHERE
+  assert.equal(types[6], "punctuation"); // {
+  assert.ok(types.includes("keyword")); // `a`
+});
+
+test("forgiving: an unterminated string/IRI does not throw and stays lossless", () => {
+  const bad = 'SELECT * { ?s ?p "unterminated';
+  assert.equal(roundtrip(bad), bad);
+  const badIri = "SELECT * { ?s <http://no-close";
+  assert.equal(roundtrip(badIri), badIri);
+});

--- a/site/test/sparql-prefixes.test.mjs
+++ b/site/test/sparql-prefixes.test.mjs
@@ -1,0 +1,83 @@
+// [OPUS-4.8] sq-n5aw — unit tests for the framework-agnostic common-prefix helpers
+// (packages/sparq-client/src/sparql-prefixes.ts), the dependency-free "prefix awareness" core
+// of the query-editor uplift. Covers: reading declared/used prefixes, computing the well-known
+// prefixes a query uses but omits, and the pure prepend that adds only the missing ones. Run
+// via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  COMMON_PREFIXES,
+  declaredPrefixes,
+  usedPrefixes,
+  missingCommonPrefixes,
+  renderPrefixLines,
+  withPrefixes,
+} from "../../packages/sparq-client/src/sparql-prefixes.ts";
+
+test("the registry has the core RDF families with absolute IRIs", () => {
+  const byPrefix = Object.fromEntries(COMMON_PREFIXES.map((b) => [b.prefix, b.iri]));
+  for (const p of ["rdf", "rdfs", "owl", "xsd", "foaf", "dc", "ex"]) {
+    assert.ok(byPrefix[p], `expected a common prefix '${p}'`);
+    assert.match(byPrefix[p], /^https?:\/\//, `'${p}' IRI should be absolute`);
+  }
+});
+
+test("declaredPrefixes reads PREFIX declarations (case-insensitive, empty prefix)", () => {
+  const q = `PREFIX foaf: <http://xmlns.com/foaf/0.1/>\nprefix ex: <http://example.org/>\nPREFIX : <http://base/>\nSELECT * {}`;
+  const declared = declaredPrefixes(q);
+  assert.ok(declared.has("foaf"));
+  assert.ok(declared.has("ex"));
+  assert.ok(declared.has("")); // the empty prefix `:`
+  assert.equal(declared.has("rdf"), false);
+});
+
+test("usedPrefixes finds prefixed names but not IRIs or variables", () => {
+  const q = "SELECT ?s { ?s foaf:name ?n ; rdf:type ex:Thing . <http://x/> a owl:Class }";
+  const used = usedPrefixes(q);
+  assert.ok(used.has("foaf"));
+  assert.ok(used.has("rdf"));
+  assert.ok(used.has("ex"));
+  assert.ok(used.has("owl"));
+  // The bare IRI <http://x/> must not register as a prefix, and ?s/?n are variables.
+  assert.equal(used.has("http"), false);
+});
+
+test("missingCommonPrefixes = used well-known prefixes that are not declared", () => {
+  const q = "SELECT ?n WHERE { ?s foaf:name ?n ; rdf:type ?t }";
+  const missing = missingCommonPrefixes(q).map((b) => b.prefix);
+  assert.deepEqual(new Set(missing), new Set(["rdf", "foaf"]));
+  // Once declared, foaf drops out of the missing set.
+  const q2 = "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n" + q;
+  assert.deepEqual(
+    missingCommonPrefixes(q2).map((b) => b.prefix),
+    ["rdf"],
+  );
+  // A used prefix NOT in the registry is not suggested (no IRI to offer).
+  const q3 = "SELECT * { ?s wibble:thing ?o }";
+  assert.deepEqual(missingCommonPrefixes(q3), []);
+});
+
+test("renderPrefixLines emits one PREFIX line per binding", () => {
+  const lines = renderPrefixLines([
+    { prefix: "foaf", iri: "http://xmlns.com/foaf/0.1/" },
+    { prefix: "ex", iri: "http://example.org/" },
+  ]);
+  assert.equal(
+    lines,
+    "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\nPREFIX ex: <http://example.org/>",
+  );
+});
+
+test("withPrefixes prepends only the missing prefixes and is a no-op when none are new", () => {
+  const q = "SELECT ?n WHERE { ?s foaf:name ?n }";
+  const out = withPrefixes(q, missingCommonPrefixes(q));
+  assert.match(out, /^PREFIX foaf: <http:\/\/xmlns\.com\/foaf\/0\.1\/>\n\nSELECT/);
+  // Idempotent: a second pass adds nothing.
+  assert.equal(withPrefixes(out, missingCommonPrefixes(out)), out);
+  // Already-declared prefixes are skipped.
+  assert.equal(
+    withPrefixes(out, [{ prefix: "foaf", iri: "http://xmlns.com/foaf/0.1/" }]),
+    out,
+  );
+});


### PR DESCRIPTION
> 🤖 SPARQ agent

Next GUI MVP increment — three unblocked children of the GUI epic (`sq-ixc3`), all on the site/shared-package surface, per the merged design `research/gui-design.md`. One PR (all GUI/site surface), three separate logical commits.

## 1. `sq-9vw5` — env-switch the site basePath for the Tauri webview
`site/next.config.ts` now reads `NEXT_PUBLIC_BASE_PATH`: **unset → `/sparq`** (Pages, historical default, no caller change), **empty string → `''`** (Tauri root-relative). The `@sparq/client` wasm loader already keys its runtime asset URLs off the same env var, so build-time route prefix and runtime wasm-fetch prefix stay in lockstep.

Next rewrites `_next/*` and `<Link>` routes automatically, but **hand-written absolute asset paths** ship verbatim and were hardcoded `/sparq/…`: the favicon, the COOP/COEP service-worker `<Script src>` (`layout.tsx`), and the paper PDF links. Routed through one new resolver `site/src/lib/base-path.ts`. Verified: default build emits `/sparq/_next` + `/sparq` assets; `NEXT_PUBLIC_BASE_PATH=''` emits root-relative `/_next` with **zero `/sparq` refs** and **zero console errors** in a headless-Chromium load. Two build modes documented in `site/README.md`; `gui/README.md` updated (env-switch now wired, not a follow-up). New unit test (5 cases).

## 2. `sq-06gq` — conformance-check the WasmStore mirror vs the generated d.ts
Design §4 wants `@sparq/client` to consume the wasm-pack **generated** `sparq_wasm.d.ts`. Hard blocker: that d.ts lives in the **git-ignored** build tree `js/wasm/` (absent until `npm run build:wasm`), so a literal import would break the bare-package `tsc` (the `gui.yml` `shared-client` job has no wasm build). CI-safe minimal-correct step: a **compile-time conformance guard** (`src/conformance.ts` + `tsconfig.conformance.json`) that imports the generated `Store` via a `#sparq-wasm-generated` path alias and asserts the hand mirror stays a faithful **subset** of it — so any future drift becomes a type error. Verified **non-vacuous** (injecting a `query(): number` drift fails it). Wired into the `gui.yml` `site-with-shared-client` job (which builds the bundle), excluded from the bare `typecheck`. The two deliberate divergences (`validate?` optional; `queryCursor` returns the narrowed cursor) are asserted explicitly. Full workspace adoption (root `package.json` + a tracked generated d.ts so the hand mirror can be **deleted**) is the genuinely-invasive remainder → follow-up bead `sq-jpki`.

## 3. `sq-n5aw` — query-editor uplift (MVP)
Replaces the live REPL's plain `<textarea>` with a real SPARQL editor (the biggest real UX gap, design §2 MVP item 1):
- **Syntax highlighting** via a new **framework-agnostic** tokenizer in `@sparq/client` (`sparql-highlight.ts`) — a pure, dependency-free, **lossless** lexer (concatenating tokens reproduces the input exactly, so the highlight `<pre>` aligns glyph-for-glyph with the overlaid transparent `<textarea>`).
- **Common-prefix awareness** via `@sparq/client` (`sparql-prefixes.ts`) — detects well-known prefixes the query **uses but never declares**, surfaced as a one-click "Add prefixes" affordance.

Both cores are DOM-free / React-free, so the **same** logic serves the site and the Tauri webview, and are unit-tested (13 cases). The React overlay (`site/src/components/sparql-editor.tsx`) is the zero-dependency highlighted-`<pre>`-behind-transparent-`<textarea>` technique — **no new npm dependency** (no CodeMirror/Monaco), static-export-safe; `/try` First Load JS grows ~2 kB. Token colours reuse the existing `--primary` / `--chart-*` design tokens (light/dark aware). Headless smoke confirms it mounts, highlights, re-tokenizes on input, and shows the add-prefix affordance with zero console errors.

## Gate evidence
- `cd site && npm run build` green in **both** modes (Pages default + `NEXT_PUBLIC_BASE_PATH=''`); WASM prereq already present (lean `shacl,jsonld` bundle).
- `tsc --noEmit` clean (site + `@sparq/client` bare **and** conformance); `npm run lint` clean; `npm run test:unit` green (**126** pass, 18 new).
- `.github/workflows/gui.yml` touched (added the conformance step) — **actionlint-clean**, no new actions (SHA-pin/code-scanning unaffected).
- Honesty: the Tauri desktop app stays a **CI-validated scaffold**, not a shipped app; no perf numbers; privacy-claims gate passes; the typos gate is clean.

## Follow-ups (beaded)
- `sq-jpki` — repo-root workspaces + a tracked generated d.ts to **delete** the hand mirror (the invasive remainder of §4).
- `sq-9zjy` — make the vendored `coi-serviceworker.js` self-registration **fallback** basePath-aware for the Tauri webview (polish; needs the GUI CI matrix `sq-var9`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)