### PR TITLE
feat(site/try): structured SPARQL results panel — table ⇄ raw-JSON toggle + CSV/TSV/JSON export (sq-x0kp) [OPUS-4.8]

### DIFF
--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -370,6 +370,24 @@ export {
   withPrefixes,
 } from "./sparql-prefixes.js";
 
+// [OPUS-4.8] sq-x0kp — the framework-agnostic SPARQL-RESULTS formatting core (table
+// extraction, CSV/TSV export, raw-JSON pretty-print, ASK discrimination). Pure data shaping
+// over the SPARQL-JSON shapes above, re-exported so the site results panel AND the Tauri
+// webview render the same cells from one source.
+export {
+  type ResultTable,
+  resultVars,
+  resultRows,
+  isAskResult,
+  askValue,
+  extractTable,
+  csvCell,
+  tsvCell,
+  resultsToCsv,
+  resultsToTsv,
+  formatSparqlJson,
+} from "./results.js";
+
 /** Renders a term for display, with a compact datatype/lang suffix. */
 export function formatTerm(t: SparqlTerm | undefined): string {
   if (!t) return "";

--- a/packages/sparq-client/src/results.ts
+++ b/packages/sparq-client/src/results.ts
@@ -1,0 +1,165 @@
+// [OPUS-4.8] sq-x0kp — framework-agnostic SPARQL-results formatting for the /try REPL
+// results panel (GUI MVP item 2 in research/gui-design.md §"Phase 1").
+//
+// WHY HERE. The GUI design record's load-bearing property is that the PURE part of the GUI
+// "transfers" to any host (the Next.js site today, the proposed Tauri 2 webview later). The
+// React result panel is host-shaped, but the LOGIC that turns a SPARQL 1.1 JSON results
+// document into a typed table, a CSV/TSV export, or a pretty-printed raw view is pure data
+// shaping with no DOM and no framework — so it lives in this shared `@sparq/client` package
+// (alongside `formatTerm` / `streamQueryRows` / the SPARQL-JSON shapes) and both hosts draw
+// the same cells. This file is the single source of truth for "how a result renders".
+//
+// SCOPE. It shapes the three answer shapes the lean wasm bundle returns through its query
+// surface: a SELECT result (`Store.query` -> SPARQL-JSON with `head.vars` + bindings), an
+// ASK result (the same document carrying a top-level `boolean`), and — for completeness so
+// the panel has one place to ask "what shape is this?" — a discriminator over both. The
+// CONSTRUCT/DESCRIBE (N-Triples) and EXPLAIN (plan text) shapes are already plain strings the
+// engine returns, so they need no shaping here; the panel renders them verbatim.
+//
+// No performance claim is made anywhere here.
+
+import type { SparqlResults, SparqlTerm, SparqlBinding } from "./index.js";
+import { formatTerm } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// Reading a SPARQL-JSON results document.
+// ---------------------------------------------------------------------------
+
+/** The variable names a SELECT result projects (its `head.vars`), in order. */
+export function resultVars(results: SparqlResults): string[] {
+  return results.head?.vars ?? [];
+}
+
+/** The solution rows of a SELECT result (each a var→term binding map), in order. */
+export function resultRows(results: SparqlResults): SparqlBinding[] {
+  return results.results?.bindings ?? [];
+}
+
+/**
+ * Whether a parsed SPARQL-JSON document is an ASK answer — it carries a top-level
+ * `boolean`. (A SELECT document has `head.vars` + `results.bindings` and no `boolean`.)
+ */
+export function isAskResult(results: SparqlResults): boolean {
+  return typeof results.boolean === "boolean";
+}
+
+/** The boolean of an ASK answer, or `null` if the document is not an ASK result. */
+export function askValue(results: SparqlResults): boolean | null {
+  return typeof results.boolean === "boolean" ? results.boolean : null;
+}
+
+// ---------------------------------------------------------------------------
+// The typed TABLE view (columns from the head vars, cells via formatTerm).
+// ---------------------------------------------------------------------------
+
+/** A SELECT result shaped as a table: the column headers plus one string row per solution. */
+export interface ResultTable {
+  /** The column headers — the projection's variable names, in `head.vars` order. */
+  vars: string[];
+  /**
+   * One row per solution. Each row has exactly `vars.length` cells (columns in `vars`
+   * order); an unbound projection variable in a solution renders as the empty string.
+   */
+  rows: string[][];
+}
+
+/**
+ * [OPUS-4.8] sq-x0kp — shape a SELECT result set into a {@link ResultTable}: the columns are
+ * the projected variables (in `head.vars` order) and each cell is the term rendered by the
+ * shared {@link formatTerm} (so a URI shows as `<…>`, a typed literal keeps its `^^xsd:…`
+ * suffix, a lang literal its `@lang`, and an unbound variable is the empty string). This is
+ * the single extraction both the site table and the Tauri webview table draw from.
+ *
+ * Passing an ASK document yields an empty table (`vars: []`, `rows: []`): a table is not the
+ * right view for a boolean, and the caller should branch on {@link isAskResult} first.
+ */
+export function extractTable(results: SparqlResults): ResultTable {
+  if (isAskResult(results)) return { vars: [], rows: [] };
+  const vars = resultVars(results);
+  const rows = resultRows(results).map((binding) =>
+    vars.map((v) => formatTerm(binding[v])),
+  );
+  return { vars, rows };
+}
+
+// ---------------------------------------------------------------------------
+// CSV / TSV export (MVP: "table + raw SPARQL-JSON + N-Triples, plus CSV/TSV export").
+// ---------------------------------------------------------------------------
+
+/**
+ * The RAW lexical value of a term for a data export, WITHOUT the display decoration
+ * {@link formatTerm} adds (no `<>` around a URI, no surrounding quotes / `^^`/`@` on a
+ * literal). A CSV/TSV consumer wants the value itself (`http://ex/a`, `42`, `Alice`), and the
+ * cell-level quoting/escaping is handled by {@link csvCell} / {@link tsvCell}. An unbound
+ * projection variable exports as an empty cell.
+ */
+function exportValue(t: SparqlTerm | undefined): string {
+  return t ? t.value : "";
+}
+
+/**
+ * One CSV cell, quoted per RFC 4180: a field containing a comma, double-quote, CR or LF is
+ * wrapped in double-quotes with each embedded double-quote doubled. Other fields pass through
+ * verbatim. (CRLF is the RFC line terminator; {@link resultsToCsv} joins rows with it.)
+ */
+export function csvCell(value: string): string {
+  return /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+/**
+ * One TSV cell: tab/CR/LF are NOT representable inside a TSV field, so they are replaced with
+ * a single space (the conventional lossless-enough TSV escape — TSV has no quoting). This
+ * keeps every solution on exactly one line with one column per tab.
+ */
+export function tsvCell(value: string): string {
+  return value.replace(/[\t\r\n]+/g, " ");
+}
+
+/**
+ * [OPUS-4.8] sq-x0kp — export a SELECT result as CSV (RFC 4180): a header row of the
+ * projected variable names, then one row per solution of the terms' RAW lexical values
+ * ({@link exportValue}), each cell quoted by {@link csvCell}, rows joined with CRLF. An ASK
+ * document (no projection) exports as the empty string. A result with columns but no
+ * solutions exports just the header row. This is the "Download CSV" payload.
+ */
+export function resultsToCsv(results: SparqlResults): string {
+  if (isAskResult(results)) return "";
+  const vars = resultVars(results);
+  const header = vars.map(csvCell).join(",");
+  const body = resultRows(results).map((binding) =>
+    vars.map((v) => csvCell(exportValue(binding[v]))).join(","),
+  );
+  return [header, ...body].join("\r\n");
+}
+
+/**
+ * [OPUS-4.8] sq-x0kp — export a SELECT result as TSV: a tab-separated header row of the
+ * projected variable names, then one tab-separated row per solution of the terms' RAW
+ * lexical values ({@link exportValue}) sanitised by {@link tsvCell}, rows joined with LF. An
+ * ASK document exports as the empty string; a result with columns but no solutions exports
+ * just the header row. This is the "Download TSV" payload.
+ */
+export function resultsToTsv(results: SparqlResults): string {
+  if (isAskResult(results)) return "";
+  const vars = resultVars(results);
+  const header = vars.map(tsvCell).join("\t");
+  const body = resultRows(results).map((binding) =>
+    vars.map((v) => tsvCell(exportValue(binding[v]))).join("\t"),
+  );
+  return [header, ...body].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// The RAW SPARQL-JSON view (a pretty-printed copy of the engine's document).
+// ---------------------------------------------------------------------------
+
+/**
+ * [OPUS-4.8] sq-x0kp — pretty-print a parsed SPARQL-JSON results document for the raw-JSON
+ * toggle: a stable 2-space-indented re-serialisation of the EXACT document the engine
+ * returned (`head` + `results`/`boolean`). Re-serialising the parsed object (rather than
+ * threading the original string) guarantees the panel shows valid, canonically-indented JSON
+ * regardless of how the engine spaced its output.
+ */
+export function formatSparqlJson(results: SparqlResults): string {
+  return JSON.stringify(results, null, 2);
+}

--- a/site/e2e/repl-results.spec.ts
+++ b/site/e2e/repl-results.spec.ts
@@ -1,0 +1,117 @@
+// [OPUS-4.8] sq-x0kp — headless browser smoke test for the /try REPL results panel.
+//
+// WHAT IT GUARDS. The results panel (src/components/repl.tsx `ResultPanel` / `SelectResult`)
+// renders a SELECT result as a TYPED TABLE and offers a raw-SPARQL-JSON view toggle plus
+// CSV/TSV/JSON exports. This test drives a REAL headless Chromium against the live REPL: it
+// runs the default SELECT example on the wasm engine, asserts the bindings table renders with
+// the projected columns, flips the view to raw JSON and asserts a `head`/`results` document
+// shows, and asserts ZERO console errors across the whole interaction. The DOM anchors are
+// the panel's stable `data-result-kind` / `data-result-view` attributes — no copy-scraping.
+//
+// It is a CORRECTNESS smoke test, not a benchmark: it asserts the panel's DOM, never a
+// wall-clock threshold (timings on a work-box / CI runner are non-canonical).
+//
+// WASM PREREQ. The REPL loads the lean wasm bundle from `public/wasm/` (a gitignored build
+// artifact synced from `js/`'s `build:wasm`). The site-e2e CI lane is deliberately LIGHT (no
+// Rust toolchain), so it does not build that bundle; when the bundle is absent this spec
+// SKIPS (the same "optional wasm — warn and skip" posture sync-wasm.mjs already takes for the
+// reason/rsp/text bundles), keeping the light lane green and fast. Locally — and on any lane
+// that builds the bundle first — it runs in full. Run after `npm run sync-wasm`:
+//   npx playwright install chromium && npm run test:e2e
+import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Relative (no leading slash) so it resolves UNDER the baseURL's `/sparq/` basePath.
+const ROUTE = "try/";
+
+// The lean wasm bundle the REPL loads at runtime. Synced into public/wasm/ by `sync-wasm`
+// from the `js/` build; gitignored, so its presence gates this spec.
+const WASM_BUNDLE = fileURLToPath(
+  new URL("../public/wasm/sparq_wasm_bg.wasm", import.meta.url),
+);
+
+// Skip the whole file when the wasm bundle has not been built/synced — the light CI lane
+// does not produce it, and a REPL that cannot load the engine is not the thing under test.
+test.skip(
+  !existsSync(WASM_BUNDLE),
+  "lean wasm bundle absent (public/wasm/sparq_wasm_bg.wasm) — run `npm run sync-wasm` after `(cd ../js && npm run build:wasm)`",
+);
+
+/** Collect every `console.error` the page emits, so the test can assert there were none. */
+function trackConsoleErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("console", (msg: ConsoleMessage) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+  page.on("pageerror", (err) => errors.push(String(err)));
+  return errors;
+}
+
+/** Navigate to /try and wait for the wasm engine readiness pill to settle to "ready". */
+async function gotoReady(page: Page): Promise<void> {
+  await page.goto(ROUTE, { waitUntil: "domcontentloaded" });
+  // The engine pre-warms on mount; the pill flips to "Engine ready" when the wasm is loaded.
+  await expect(page.getByText("Engine ready")).toBeVisible({ timeout: 90_000 });
+}
+
+test("the results panel renders a SELECT table and toggles to raw JSON", async ({
+  page,
+}) => {
+  const consoleErrors = trackConsoleErrors(page);
+  await gotoReady(page);
+
+  // Run the default example (a SELECT). The button label is "Run query" in run mode.
+  await page.getByRole("button", { name: "Run query" }).click();
+
+  // The SELECT result panel appears with the typed table view.
+  const panel = page.locator('[data-result-kind="select"]');
+  await expect(panel).toBeVisible({ timeout: 30_000 });
+
+  const tableView = panel.locator('[data-result-view="table"]');
+  await expect(tableView).toBeVisible();
+  // It is a real <table> with a header row and at least one body row (the sample graph
+  // binds rows for the default query).
+  const table = tableView.locator("table");
+  await expect(table).toBeVisible();
+  await expect(table.locator("thead th").first()).toBeVisible();
+  expect(await table.locator("tbody tr").count()).toBeGreaterThan(0);
+
+  // Flip to the raw SPARQL-JSON view via the "JSON" tab.
+  await panel.getByRole("tab", { name: "JSON" }).click();
+  const jsonView = panel.locator('[data-result-view="json"]');
+  await expect(jsonView).toBeVisible();
+  // The raw view shows the SPARQL 1.1 JSON document (head + results), pretty-printed.
+  await expect(jsonView).toContainText('"head"');
+  await expect(jsonView).toContainText('"bindings"');
+  // The table view is no longer mounted once JSON is selected.
+  await expect(tableView).toHaveCount(0);
+
+  // Flip back to the table — the toggle is non-destructive.
+  await panel.getByRole("tab", { name: "Table" }).click();
+  await expect(panel.locator('[data-result-view="table"] table')).toBeVisible();
+
+  // The whole interaction produced zero console errors (no wasm/render/runtime faults).
+  expect(consoleErrors, `console errors: ${consoleErrors.join("\n")}`).toEqual([]);
+});
+
+test("an ASK query renders the boolean result, not a table", async ({ page }) => {
+  const consoleErrors = trackConsoleErrors(page);
+  await gotoReady(page);
+
+  // Replace the editor with an ASK query, then run it. The editor (sq-n5aw) is a highlight
+  // overlay over a real <textarea> exposed as the accessible "SPARQL query" textbox, so
+  // `fill` replaces its whole value.
+  await page.getByRole("textbox", { name: "SPARQL query" }).fill("ASK { ?s ?p ?o }");
+
+  await page.getByRole("button", { name: "Run query" }).click();
+
+  const boolPanel = page.locator('[data-result-kind="boolean"]');
+  await expect(boolPanel).toBeVisible({ timeout: 30_000 });
+  // The sample graph is non-empty, so `ASK { ?s ?p ?o }` is true.
+  await expect(boolPanel).toHaveAttribute("data-ask-value", "true");
+  // It is NOT rendered as a SELECT table.
+  await expect(page.locator('[data-result-kind="select"]')).toHaveCount(0);
+
+  expect(consoleErrors, `console errors: ${consoleErrors.join("\n")}`).toEqual([]);
+});

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import * as React from "react";
-import { Play, Loader2, Database, Zap, CheckCircle2 } from "lucide-react";
+import {
+  Play,
+  Loader2,
+  Database,
+  Zap,
+  CheckCircle2,
+  Table2,
+  Braces,
+  Download,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -19,10 +28,14 @@ import {
   prewarmSparq,
   storeToNQuads,
   datasetSize,
-  formatTerm,
+  extractTable,
+  resultsToCsv,
+  resultsToTsv,
+  formatSparqlJson,
   type SparqlResults,
   type WasmStore,
 } from "@/lib/sparq-wasm";
+import { downloadText } from "@/lib/download";
 import {
   classifyQueryForm,
   isGraphForm,
@@ -482,6 +495,8 @@ function ResultPanel({ state }: { state: RunState }) {
   if (state.kind === "boolean") {
     return (
       <div
+        data-result-kind="boolean"
+        data-ask-value={state.value ? "true" : "false"}
         className={cn(
           "rounded-lg p-3 text-sm font-medium",
           state.value
@@ -527,39 +542,178 @@ function ResultPanel({ state }: { state: RunState }) {
   }
   if (state.kind !== "select") return null;
 
-  const { vars } = state.results.head;
-  const rows = state.results.results.bindings;
-  if (rows.length === 0) {
-    return (
-      <p className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
-        No solutions.
-      </p>
-    );
-  }
+  return <SelectResult results={state.results} />;
+}
+
+// [OPUS-4.8] sq-x0kp — the structured SELECT results view (GUI MVP item 2). It carries a
+// TABLE ⇄ raw-SPARQL-JSON view toggle and CSV/TSV/JSON exports. The pure shaping — the typed
+// table, the CSV/TSV documents, the pretty-printed JSON — comes from the framework-agnostic
+// `@sparq/client` helpers, so this component is just the React host that draws them (and the
+// Tauri webview draws the SAME cells from the SAME helpers). The view-mode is local to one
+// result render; switching the view never re-runs the query.
+type ResultView = "table" | "json";
+
+function SelectResult({ results }: { results: SparqlResults }) {
+  const [view, setView] = React.useState<ResultView>("table");
+  // Re-default to the table whenever a NEW result arrives (a re-run yields a fresh `results`
+  // object), so a fresh query always lands on the typed table, not whatever view was last
+  // toggled. `results` identity changes per run.
+  React.useEffect(() => setView("table"), [results]);
+
+  const table = React.useMemo(() => extractTable(results), [results]);
+  const hasRows = table.rows.length > 0;
+
   return (
-    <div className="overflow-x-auto rounded-lg border">
-      <table className="w-full text-left text-sm">
-        <thead className="bg-muted/50">
-          <tr>
-            {vars.map((v) => (
-              <th key={v} className="px-3 py-2 font-medium">
-                ?{v}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row, i) => (
-            <tr key={i} className="border-t">
-              {vars.map((v) => (
-                <td key={v} className="px-3 py-1.5 font-mono text-[12.5px]">
-                  {formatTerm(row[v])}
-                </td>
+    <div className="space-y-2" data-result-kind="select">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <ResultViewTabs view={view} onChange={setView} />
+        {/* Exports operate on the WHOLE result (every solution), independent of the view. */}
+        <div className="flex items-center gap-1.5">
+          <ExportButton
+            label="CSV"
+            onClick={() =>
+              downloadText("sparql-results.csv", resultsToCsv(results), "text/csv")
+            }
+          />
+          <ExportButton
+            label="TSV"
+            onClick={() =>
+              downloadText(
+                "sparql-results.tsv",
+                resultsToTsv(results),
+                "text/tab-separated-values",
+              )
+            }
+          />
+          <ExportButton
+            label="JSON"
+            onClick={() =>
+              downloadText(
+                "sparql-results.json",
+                formatSparqlJson(results),
+                "application/sparql-results+json",
+              )
+            }
+          />
+        </div>
+      </div>
+
+      {view === "json" ? (
+        <pre
+          data-result-view="json"
+          className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed"
+        >
+          {formatSparqlJson(results)}
+        </pre>
+      ) : !hasRows ? (
+        <p
+          data-result-view="table"
+          className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground"
+        >
+          No solutions.
+        </p>
+      ) : (
+        <div
+          data-result-view="table"
+          className="max-h-96 overflow-auto rounded-lg border"
+        >
+          <table className="w-full text-left text-sm">
+            <thead className="sticky top-0 bg-muted/80 backdrop-blur">
+              <tr>
+                {table.vars.map((v) => (
+                  <th key={v} className="px-3 py-2 font-medium">
+                    ?{v}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {table.rows.map((row, i) => (
+                <tr key={i} className="border-t">
+                  {row.map((cell, j) => (
+                    <td
+                      key={table.vars[j]}
+                      className="px-3 py-1.5 font-mono text-[12.5px]"
+                    >
+                      {cell}
+                    </td>
+                  ))}
+                </tr>
               ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
+  );
+}
+
+// [OPUS-4.8] sq-x0kp — the TABLE ⇄ JSON view toggle for a SELECT result. Same `role="tablist"`
+// design-token pattern as the Run/EXPLAIN ModeTabs above, so the two selectors read as one
+// family.
+function ResultViewTabs({
+  view,
+  onChange,
+}: {
+  view: ResultView;
+  onChange: (v: ResultView) => void;
+}) {
+  const tabs: { value: ResultView; label: string; Icon: typeof Table2 }[] = [
+    { value: "table", label: "Table", Icon: Table2 },
+    { value: "json", label: "JSON", Icon: Braces },
+  ];
+  return (
+    <div
+      role="tablist"
+      aria-label="Result view"
+      className="inline-flex rounded-lg border bg-muted/40 p-0.5"
+    >
+      {tabs.map((t) => (
+        <button
+          key={t.value}
+          type="button"
+          role="tab"
+          aria-selected={view === t.value}
+          title={
+            t.value === "table"
+              ? "Show the bindings as a typed table"
+              : "Show the raw SPARQL 1.1 JSON results document"
+          }
+          onClick={() => onChange(t.value)}
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/40",
+            view === t.value
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <t.Icon className="size-3.5" />
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// [OPUS-4.8] sq-x0kp — one export button (CSV / TSV / JSON). Reuses the `outline` Button
+// tokens; the download itself is the site-local `downloadText` DOM helper (the bytes come
+// from the framework-agnostic exporters).
+function ExportButton({
+  label,
+  onClick,
+}: {
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={onClick}
+      title={`Download the result as ${label}`}
+    >
+      <Download className="size-3.5" />
+      {label}
+    </Button>
   );
 }

--- a/site/src/lib/download.ts
+++ b/site/src/lib/download.ts
@@ -1,0 +1,28 @@
+// [OPUS-4.8] sq-x0kp — a tiny DOM helper to download an in-memory string as a file.
+//
+// This is the ONE place in the site that turns a string (a CSV/TSV export the
+// framework-agnostic `@sparq/client` produced) into a browser file download. It is
+// deliberately DOM-coupled, so it stays in the site (NOT in `@sparq/client`, which carries no
+// DOM beyond the wasm loader's two globals): the pure "what bytes to export" lives in the
+// shared package, this is only "hand those bytes to the browser as a file". An object URL is
+// created, a hidden anchor clicked, then the URL revoked so it is not leaked.
+
+/**
+ * Trigger a client-side download of `text` as a file named `filename` with the given MIME
+ * `type`. No network — a `Blob` object URL is created, a synthetic anchor click starts the
+ * save, and the URL is revoked on the next tick. Safe to call from a button handler.
+ */
+export function downloadText(filename: string, text: string, type: string): void {
+  const blob = new Blob([text], { type });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  // Appending is not strictly required in modern browsers, but keeps the click reliable
+  // across them; remove it immediately after.
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Revoke after the click has been dispatched so the navigation has read the URL.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/site/src/lib/sparq-wasm.ts
+++ b/site/src/lib/sparq-wasm.ts
@@ -34,6 +34,7 @@ export {
   type CursorBatch,
   type LoadSparqOptions,
   type MatchTerm,
+  type ResultTable,
   type ShaclReport,
   type ShaclResult,
   type SparqlBinding,
@@ -50,6 +51,16 @@ export {
   prewarmSparq,
   sparqShaclValidate,
   streamQueryRows,
+  // [OPUS-4.8] sq-x0kp — the framework-agnostic results-formatting core (table extraction,
+  // CSV/TSV export, raw-JSON pretty-print, ASK discrimination) the REPL result panel draws.
+  extractTable,
+  resultVars,
+  resultRows,
+  isAskResult,
+  askValue,
+  resultsToCsv,
+  resultsToTsv,
+  formatSparqlJson,
 } from "@sparq/client";
 
 /**

--- a/site/test-support/ts-loader.mjs
+++ b/site/test-support/ts-loader.mjs
@@ -3,9 +3,30 @@
 // `node --test` can import and unit-test pure helpers WITHOUT pulling in a heavy
 // test runner (vitest/jest) or a separate build step. Type-erasure only; no
 // type-checking (that is the job of `next build`).
-import { readFile } from 'node:fs/promises';
+import { access, readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
+
+// [OPUS-4.8] sq-x0kp — rewrite an explicit `.js` import specifier to the sibling `.ts`
+// source when that `.ts` exists. The shared `@sparq/client` package uses the NodeNext
+// `.js`-extension convention on its INTERNAL imports (e.g. `import … from "./index.js"`),
+// which its own `tsc` build needs; but Node's default resolver — which `node --test` uses
+// for these on-the-fly-transpiled modules — would look for a literal `index.js` that does
+// not exist on disk. Mapping `.js` → `.ts` (only when the `.ts` is present, so real `.js`
+// files still resolve normally) lets the unit tests import that package's source unchanged.
+// Pure test-support; it changes nothing the bundler / `tsc` see.
+export async function resolve(specifier, context, next) {
+  if (specifier.endsWith('.js') && (specifier.startsWith('./') || specifier.startsWith('../'))) {
+    try {
+      const tsUrl = new URL(specifier.slice(0, -'.js'.length) + '.ts', context.parentURL);
+      await access(fileURLToPath(tsUrl));
+      return next(tsUrl.href, context);
+    } catch {
+      // No sibling `.ts` — fall through to the default resolution of the real `.js`.
+    }
+  }
+  return next(specifier, context);
+}
 
 export async function load(url, context, next) {
   if (url.endsWith('.ts') && !url.endsWith('.d.ts')) {

--- a/site/test/results-panel.test.mjs
+++ b/site/test/results-panel.test.mjs
@@ -1,0 +1,174 @@
+// [OPUS-4.8] sq-x0kp — unit tests for the framework-agnostic SPARQL-results formatting that
+// backs the /try REPL results panel (packages/sparq-client/src/results.ts). These cover the
+// PURE shaping the panel (and the Tauri webview) draw: table extraction from a SPARQL-1.1-JSON
+// SELECT document, the ASK boolean discrimination, the CSV/TSV exports (incl. RFC-4180 quoting
+// and TSV sanitisation), and the raw-JSON pretty-print. The query SEMANTICS themselves are
+// proven by the Rust engine tests; here we only test the JS render of what the wasm binding
+// returns. Run via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  extractTable,
+  resultVars,
+  resultRows,
+  isAskResult,
+  askValue,
+  resultsToCsv,
+  resultsToTsv,
+  csvCell,
+  tsvCell,
+  formatSparqlJson,
+} from "../../packages/sparq-client/src/results.ts";
+
+// A 2-column SELECT with: a URI + plain literal row, a URI + typed-integer row, and a row
+// with an UNBOUND `name` (the OPTIONAL did not match) — exactly the SPARQL 1.1 JSON shape the
+// lean wasm `Store.query` returns.
+const SELECT_RESULTS = {
+  head: { vars: ["person", "name"] },
+  results: {
+    bindings: [
+      {
+        person: { type: "uri", value: "http://ex/alice" },
+        name: { type: "literal", value: "Alice" },
+      },
+      {
+        person: { type: "uri", value: "http://ex/bob" },
+        name: {
+          type: "literal",
+          value: "42",
+          datatype: "http://www.w3.org/2001/XMLSchema#integer",
+        },
+      },
+      // `name` is unbound in this solution.
+      { person: { type: "uri", value: "http://ex/carol" } },
+    ],
+  },
+};
+
+const ASK_TRUE = { head: { vars: [] }, boolean: true };
+const ASK_FALSE = { head: { vars: [] }, boolean: false };
+
+test("resultVars / resultRows read the projection and the solutions in order", () => {
+  assert.deepEqual(resultVars(SELECT_RESULTS), ["person", "name"]);
+  assert.equal(resultRows(SELECT_RESULTS).length, 3);
+});
+
+test("resultVars / resultRows default to empty on a malformed document", () => {
+  assert.deepEqual(resultVars({}), []);
+  assert.deepEqual(resultRows({ head: { vars: ["x"] } }), []);
+});
+
+test("extractTable: columns from head vars, typed cells, unbound → empty string", () => {
+  const table = extractTable(SELECT_RESULTS);
+  assert.deepEqual(table.vars, ["person", "name"]);
+  assert.deepEqual(table.rows, [
+    ["<http://ex/alice>", '"Alice"'],
+    ["<http://ex/bob>", '"42"^^xsd:integer'],
+    // the unbound `name` cell is the empty string, and the row still has 2 columns
+    ["<http://ex/carol>", ""],
+  ]);
+  // every row has exactly one cell per column
+  for (const row of table.rows) assert.equal(row.length, table.vars.length);
+});
+
+test("extractTable: an empty SELECT keeps its columns and yields zero rows", () => {
+  const empty = { head: { vars: ["s", "p", "o"] }, results: { bindings: [] } };
+  const table = extractTable(empty);
+  assert.deepEqual(table.vars, ["s", "p", "o"]);
+  assert.deepEqual(table.rows, []);
+});
+
+test("isAskResult / askValue discriminate ASK from SELECT", () => {
+  assert.equal(isAskResult(ASK_TRUE), true);
+  assert.equal(isAskResult(ASK_FALSE), true);
+  assert.equal(isAskResult(SELECT_RESULTS), false);
+  assert.equal(askValue(ASK_TRUE), true);
+  assert.equal(askValue(ASK_FALSE), false);
+  assert.equal(askValue(SELECT_RESULTS), null);
+});
+
+test("extractTable on an ASK document yields an empty table (not a row)", () => {
+  // The panel branches on isAskResult first; extractTable must not misrender a boolean.
+  assert.deepEqual(extractTable(ASK_TRUE), { vars: [], rows: [] });
+});
+
+test("resultsToCsv: header + raw lexical values, no display decoration", () => {
+  const csv = resultsToCsv(SELECT_RESULTS);
+  assert.equal(
+    csv,
+    [
+      "person,name",
+      "http://ex/alice,Alice",
+      // the typed integer exports its RAW lexical value (42), NOT "42"^^xsd:integer
+      "http://ex/bob,42",
+      // the unbound name is an empty trailing cell
+      "http://ex/carol,",
+    ].join("\r\n"),
+  );
+});
+
+test("resultsToCsv: an empty SELECT exports just the header row", () => {
+  const empty = { head: { vars: ["a", "b"] }, results: { bindings: [] } };
+  assert.equal(resultsToCsv(empty), "a,b");
+});
+
+test("resultsToCsv: an ASK document exports the empty string (no projection)", () => {
+  assert.equal(resultsToCsv(ASK_TRUE), "");
+});
+
+test("csvCell: RFC-4180 quoting of comma, quote, and newline", () => {
+  assert.equal(csvCell("plain"), "plain");
+  assert.equal(csvCell("a,b"), '"a,b"');
+  assert.equal(csvCell('say "hi"'), '"say ""hi"""');
+  assert.equal(csvCell("line1\nline2"), '"line1\nline2"');
+});
+
+test("resultsToCsv: a value containing a comma is quoted so columns stay aligned", () => {
+  const tricky = {
+    head: { vars: ["label"] },
+    results: {
+      bindings: [{ label: { type: "literal", value: "Doe, John" } }],
+    },
+  };
+  assert.equal(resultsToCsv(tricky), 'label\r\n"Doe, John"');
+});
+
+test("resultsToTsv: tab-separated header + raw values", () => {
+  const tsv = resultsToTsv(SELECT_RESULTS);
+  assert.equal(
+    tsv,
+    [
+      "person\tname",
+      "http://ex/alice\tAlice",
+      "http://ex/bob\t42",
+      "http://ex/carol\t",
+    ].join("\n"),
+  );
+});
+
+test("tsvCell: embedded tab/newline are collapsed to a space (TSV has no quoting)", () => {
+  assert.equal(tsvCell("a\tb"), "a b");
+  assert.equal(tsvCell("line1\nline2"), "line1 line2");
+  assert.equal(tsvCell("clean"), "clean");
+});
+
+test("resultsToTsv: a value with a tab is sanitised so the row stays one column-set", () => {
+  const tricky = {
+    head: { vars: ["x"] },
+    results: { bindings: [{ x: { type: "literal", value: "a\tb" } }] },
+  };
+  // exactly one tab in the data row (the header has none for a single column)
+  const dataRow = resultsToTsv(tricky).split("\n")[1];
+  assert.equal(dataRow, "a b");
+  assert.equal((dataRow.match(/\t/g) ?? []).length, 0);
+});
+
+test("formatSparqlJson: stable 2-space-indented re-serialisation of the document", () => {
+  const pretty = formatSparqlJson(ASK_TRUE);
+  assert.equal(pretty, JSON.stringify(ASK_TRUE, null, 2));
+  // round-trips back to the same object (it is the engine's document, pretty-printed)
+  assert.deepEqual(JSON.parse(pretty), ASK_TRUE);
+  // SELECT documents pretty-print too
+  assert.deepEqual(JSON.parse(formatSparqlJson(SELECT_RESULTS)), SELECT_RESULTS);
+});


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes **sq-x0kp** — RESULTS PANEL. GUI MVP item 2 from `research/gui-design.md` §"Phase 1": improve how the `/try` REPL renders SPARQL query results, building on #760's editor uplift + `@sparq/client`.

## What landed

**Framework-agnostic results formatting in `@sparq/client`** (`packages/sparq-client/src/results.ts`), re-exported from `index.ts` so the site result panel **and** the proposed Tauri webview render the SAME cells from one source (the design record's load-bearing "part (A) transfers" property):
- `extractTable()` — a typed TABLE from a SELECT SPARQL-1.1-JSON document (columns from `head.vars`, cells via the existing shared `formatTerm`, unbound projection variable → empty string).
- `resultsToCsv()` / `resultsToTsv()` — CSV (RFC-4180 quoting) + TSV (tab/newline sanitised) export of the raw lexical values.
- `formatSparqlJson()` — pretty-printed raw SPARQL-JSON view.
- `isAskResult()` / `askValue()` / `resultVars()` / `resultRows()` — pure shape discriminators.

**REPL result panel** (`site/src/components/repl.tsx`): the SELECT view now carries a **Table ⇄ JSON** view toggle (same `role="tablist"` design tokens as the existing Run/EXPLAIN `ModeTabs`) and **CSV / TSV / JSON download** buttons. ASK (boolean), CONSTRUCT/DESCRIBE (N-Triples), Update, EXPLAIN and error states keep their existing handling; the boolean/select panels carry stable `data-*` anchors for the smoke test. The download itself is the site-local DOM helper `site/src/lib/download.ts` (the bytes come from the framework-agnostic exporters).

## Tests
- `site/test/results-panel.test.mjs` — **14 non-vacuous unit tests** over the framework-agnostic formatting: table extraction (typed + unbound cells), ASK discrimination, CSV/TSV quoting + sanitisation, raw-JSON round-trip.
- `site/e2e/repl-results.spec.ts` — headless Chromium smoke: runs a SELECT and asserts the typed table renders, toggles to raw JSON, runs an ASK and asserts the boolean panel, **zero console errors**. It **skips gracefully** when the gitignored lean wasm bundle is absent (the light `site-e2e` lane builds no wasm — same "optional wasm, warn-and-skip" posture `sync-wasm.mjs` already takes), and runs in full locally / on any lane that builds the bundle first.
- `site/test-support/ts-loader.mjs` — a `resolve` hook maps a `.js` import specifier to its sibling `.ts` so `node --test` can import `@sparq/client`'s NodeNext source unchanged (pure test-support; nothing the bundler/`tsc` see changes).

## Gates (all green)
- `@sparq/client` `tsc --noEmit` clean (+ the `typecheck:conformance` the gui lane runs).
- site `tsc --noEmit` clean; `next lint` clean.
- `npm run test:unit` — **141/141** pass (14 new).
- `npm run build` (static export) green end-to-end — `/try` emitted into `out/`, `basePath` `/sparq` correct, wasm in `out/wasm/`.
- `npm run test:e2e` — **4/4** Playwright specs green locally (the 2 new + the existing zk-prewarm); verified the new spec also skips cleanly when wasm is absent.

## Honesty / scope
- **No new npm dependency** (a lightweight `<table>`, not a data-grid lib).
- **No performance numbers** anywhere; **no ZK/MPC copy** added (the panel is engine-neutral). The Tauri app stays a scaffold.
- Stayed strictly in `site/src/components/**`, `site/src/lib/**`, `packages/sparq-client/**`, `site/test*`, `site/e2e/**` — did **not** touch `site/papers/**`, `paper-evidence.json`, or `papers.ts` (the concurrent paper lane).
- WASM bundle built as a prereq for the site build (`js/` `build:wasm` — a build artifact only, no `crates/` changes).

## Covered vs deferred
Covered the MVP item in full: SELECT table, raw-SPARQL-JSON toggle, ASK boolean, CONSTRUCT/DESCRIBE triples, error handling, plus CSV/TSV/JSON export. Deferred (design Phase 3, not this bead): a node-link graph visualisation of CONSTRUCT/DESCRIBE output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)