### PR TITLE
fix(docs): MD040 language tags unblock markdownlint gate (post-#514) [OPUS-4.8]

### DIFF
--- a/research/zk-signed-credential-representation-design.md
+++ b/research/zk-signed-credential-representation-design.md
@@ -43,7 +43,7 @@ measured exception to the never-hash-strings-in-circuit house rule").
 
 `sparq-zk` commits every term **off-circuit** (`crates/sparq-zk/src/encode.rs:46-62`):
 
-```
+```text
 Enc_t(term) = h2(type_code, h_s(value))
 ```
 
@@ -149,7 +149,7 @@ a new **value lane** is added for the typed-value-bearing literals.
 
 For a typed literal `l` with datatype IRI `dt` and a canonical typed value `v`:
 
-```
+```text
 Enc_str(l) = h2(TYPE_CODE_LITERAL, blake3(canonical_token))           // UNCHANGED — encode.rs:52-55
 Enc_val(l) = h2(TYPE_CODE_TYPED_VALUE, h3(VALUE_DOMAIN, v_field, dt_field))
 ```


### PR DESCRIPTION
> 🤖 SPARQ agent

#514 merged with two bare `````` fences (`research/zk-signed-credential-representation-design.md` lines 46 & 152) that fail the **`markdownlint (docs)` HARD gate** on `main`, blocking the merge train (e.g. #764). Tags both notation blocks as `text` — the minimal MD040 fix. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)