### PR TITLE
chore(bench): attribute existing ZK benches to sparq-zk / sparq-zk-compose in the registry (sq-5o5.1)

### DIFF
--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -547,13 +547,19 @@ status      = "ok"
 # ZK — commitment pipeline, trace seam, circuit gate counts, prove/verify
 # =============================================================================
 
+# [OPUS-4.8] sq-5o5.1 — the `source` names crates/sparq-zk/ explicitly because this
+# standalone criterion project links it as a path dependency (bench/zk/Cargo.toml:
+# `sparq-zk = { path = "../../crates/sparq-zk" }`) and measures its commitment
+# pipeline. That crate-under-test path is what makes this bench COUNT as sparq-zk's
+# registered coverage (drift-scan.py::crate_has_registered_bench / gate-new-crate G1
+# match `source = … crates/<crate>/`); without it sparq-zk false-flagged bench-missing.
 [[benchmark]]
 id          = "zk-commit-throughput"
 name        = "sparq-zk commitment-pipeline criterion bench"
 category    = "zk"
 measures    = "triples/s + mean time: RDFC10 canon (iri/bnode x 64/256/1024), end-to-end commit, leaves+fold, Poseidon2 permutation + hash40"
 invoke      = "cd bench/zk && cargo bench"
-source      = "bench/zk/{Cargo.toml,README.md}, benches/zk_throughput.rs (groups: canon, commit, poseidon2)"
+source      = "bench/zk/{Cargo.toml,README.md}, benches/zk_throughput.rs (groups: canon, commit, poseidon2); crate under test crates/sparq-zk/ (linked via bench/zk/Cargo.toml path dep)"
 dataset     = "synthetic graph shapes generated in-bench (iri = all-ground; bnode = bnode chain)"
 quiet_box_sensitive = true
 pinning     = "standalone cargo project (own workspace), fat LTO release profile; baseline recorded 2026-06-13 fanless M1"
@@ -573,13 +579,21 @@ pinning     = "standalone cargo project; sparq-engine built WITH the non-default
 records_to  = "criterion output; baseline table in bench/zk-trace/README.md"
 status      = "ok"
 
+# [OPUS-4.8] sq-5o5.1 — the `source` names crates/sparq-zk-compose/ explicitly: the
+# member set this bench gates is READ from that crate's regression snapshot
+# (gate_counts.sh derives MEMBERS from crates/sparq-zk-compose/tests/gate_count_snapshot.json,
+# the same source the in-crate gate_count_regression test baselines against), so this
+# bench is the registered gate-count coverage for the sparq-zk-compose prover crate.
+# That crate-under-test path is what makes it COUNT as sparq-zk-compose's coverage
+# (drift-scan.py::crate_has_registered_bench / gate-new-crate G1 match
+# `source = … crates/<crate>/`); without it sparq-zk-compose false-flagged bench-missing.
 [[benchmark]]
 id          = "zk-compose-gates"
 name        = "zk/compose circuit gate counts (bb gates)"
 category    = "zk"
 measures    = "ultra_honk circuit_size (gate count) per circuit-family member; ground-truth per noir-optimisation skill"
 invoke      = "bench/zk-compose/scripts/gate_counts.sh > bench/zk-compose/gate_counts_latest.json"
-source      = "bench/zk-compose/scripts/gate_counts.sh, README.md; circuits in zk/compose/"
+source      = "bench/zk-compose/scripts/gate_counts.sh, README.md; circuits in zk/compose/; member set read from crates/sparq-zk-compose/tests/gate_count_snapshot.json (crate under test)"
 dataset     = "compiled Noir circuits (nargo compile --workspace); no external data"
 quiet_box_sensitive = false  # gate counts are deterministic given toolchain
 pinning     = "nargo 1.0.0-beta.21, bb 5.0.0-nightly.20260324; members list fixed in script"


### PR DESCRIPTION
> 🤖 SPARQ agent

## What & why (sq-5o5.1)

`sparq-zk` and `sparq-zk-compose` were flagging as **`bench-missing`** in `scripts/drift-scan.py::scan_bench_missing` even though their benchmarks already exist — the entries in `bench/benchmarks.toml` named only `bench/…` `source` paths, so the bench-coverage predicate (`crate_has_registered_bench`, which matches `source = … crates/<crate>/`) never saw the crate-under-test. This is an **attribution** fix, not a missing benchmark.

## Change (registry-only)

Two `source` lines in `bench/benchmarks.toml`, each naming the genuine crate-under-test path, plus `[OPUS-4.8]` explanatory comments:

- **`zk-commit-throughput` → `crates/sparq-zk/`** — the standalone criterion project links it as a path dep (`bench/zk/Cargo.toml`: `sparq-zk = { path = "../../crates/sparq-zk" }`) and measures its commitment pipeline.
- **`zk-compose-gates` → `crates/sparq-zk-compose/`** — `gate_counts.sh` derives its member set from `crates/sparq-zk-compose/tests/gate_count_snapshot.json` (the same source the in-crate `gate_count_regression` test baselines against).

No new benchmarks, no fabricated numbers. Work-box bench numbers stay **non-canonical**.

## Verification (local)

- `python3 -c "import tomllib; tomllib.load(open('bench/benchmarks.toml','rb'))"` → valid (65 entries).
- **drift-scan before/after** (run with `--root .`):
  - `bench-missing` **9 → 7**.
  - **Resolved by this PR:** `bench-missing:sparq-zk`, `bench-missing:sparq-zk-compose` (exactly the two targeted).
  - **Newly introduced:** none — `sparq-fedclient/fedplan/prov` + the 5 `*-wasm` crates are unchanged; `dashboard-row` class unchanged (14→14, incl. the separate `dashboard-row:zk` item, out of scope here).
- `scripts/tests/test_drift_scan.py` + `scripts/tests/test_gates.py` → **72/72 pass**.
- `scripts/check-new-bench-registered.py` (G3) on the diff → **PASS** (no new bench suite added → no dashboard-row requirement triggered).
- `scripts/check-privacy-claims.sh` → clean (additions are crate-name/path identifiers only, no ZK/MPC privacy or soundness claims).

## Notes

- No auto-merge enabled (review-queue PR).
- main has a known transient SBOM gating flake (sq-90ew): an early ~9–12s `GS-*` SBOM failure on this PR is that flake, not this change — please re-run.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>