### PR TITLE
test(coverage): seed floors + presence gate for 7 untracked crates (sq-bif.1) [OPUS-4.8]

### DIFF
--- a/bench/coverage-floor.json
+++ b/bench/coverage-floor.json
@@ -25,6 +25,14 @@
       "nightly_floor": 85,
       "nightly_note": "[OPUS-4.8] sq-bjct: nightly_floor gates the NIGHTLY tier, whose measurement MERGES the W3C SPARQL + inference conformance BINARIES (they run as `cargo run`, not `cargo test`) into this crate's llvm-cov report — a higher number than the test-only per-commit `floor`. See scripts/coverage.sh measure_merged + the coverage-nightly job. Merged measurement 87.31% lifts the nightly floor to 85 (base test-only floor 83); floor = floor(measured) - 2 margin."
     },
+    "sparq-fedclient": {
+      "floor": 89,
+      "note": "[OPUS-4.8] sq-bif.1: OPT-IN streaming federation CLIENT. Measured WITH its whole-surface features on (--features fedclient,fedclient-adaptive — see scripts/coverage.sh measure() case; a default-feature build is an empty crate). Measured line% 91.71 (4361/4753); floor = floor(measured) - 2 margin. Conservative seed measured on a non-canonical work box; the floor is the CI-enforced ratchet of record."
+    },
+    "sparq-fedplan": {
+      "floor": 94,
+      "note": "[OPUS-4.8] sq-bif.1: OPT-IN cost-based federated planner. Measured WITH --features fedplan,adaptive-replan (its surface is entirely feature-gated). Measured line% 96.04 (2307/2402); floor = floor(measured) - 2 margin. Conservative work-box seed; CI is the ratchet of record."
+    },
     "sparq-geo": {
       "floor": 87
     },
@@ -48,11 +56,23 @@
     "sparq-parse": {
       "floor": 91
     },
+    "sparq-prov": {
+      "floor": 94,
+      "note": "[OPUS-4.8] sq-bif.1: OPT-IN W3C PROV-O lineage. CONSTRUCT/UPDATE lineage core is default-on; measured WITH --features reason (the sparq-reason proof-tree -> PROV-O bridge module + its tests/reason_prov.rs). Measured line% 96.70 (762/788); floor = floor(measured) - 2 margin. Conservative work-box seed; CI is the ratchet of record."
+    },
     "sparq-reason": {
       "floor": 82
     },
+    "sparq-reason-wasm": {
+      "floor": 0,
+      "note": "[OPUS-4.8] sq-bif.1: tier-b WASM bundle (cdylib+rlib). Its gate-exercising surface is the #[wasm_bindgen] JS API exercised ONLY by `wasm-pack test --node` (tests/web.rs is #[wasm_bindgen_test]); a NATIVE `cargo llvm-cov` runs 0 of those and reports a misleadingly-low ~55% over the rlib helpers alone — a measurement artifact in the same class as sparq-cli (subprocess) / sparq-gpu (device-gated). Floor 0 + PRESENCE-gated (bench/coverage-presence.json) instead of an unenforceable %; not added to scripts/coverage.sh."
+    },
     "sparq-rsp": {
       "floor": 87
+    },
+    "sparq-rsp-wasm": {
+      "floor": 0,
+      "note": "[OPUS-4.8] sq-bif.1: tier-b WASM bundle (cdylib+rlib). #[wasm_bindgen] JS API exercised only by `wasm-pack test --node`; native llvm-cov reports a misleadingly-low ~60% (rlib helpers only) — measurement artifact (cf. sparq-cli). Floor 0 + PRESENCE-gated; not measured by scripts/coverage.sh."
     },
     "sparq-serve": {
       "floor": 92,
@@ -65,6 +85,10 @@
     "sparq-shacl": {
       "floor": 90
     },
+    "sparq-shacl-wasm": {
+      "floor": 0,
+      "note": "[OPUS-4.8] sq-bif.1: tier-b WASM bundle (cdylib+rlib). #[wasm_bindgen] JS API exercised only by `wasm-pack test --node`; native llvm-cov reports a misleadingly-low ~79% (rlib helpers only) — measurement artifact (cf. sparq-cli). Floor 0 + PRESENCE-gated; not measured by scripts/coverage.sh."
+    },
     "sparq-sim": {
       "floor": 94
     },
@@ -73,6 +97,10 @@
     },
     "sparq-text": {
       "floor": 90
+    },
+    "sparq-text-wasm": {
+      "floor": 0,
+      "note": "[OPUS-4.8] sq-bif.1: tier-b WASM bundle (cdylib+rlib). #[wasm_bindgen] JS API exercised only by `wasm-pack test --node`; native llvm-cov reports a misleadingly-low ~80% (rlib helpers only) — measurement artifact (cf. sparq-cli). Floor 0 + PRESENCE-gated; not measured by scripts/coverage.sh."
     },
     "sparq-vectors": {
       "floor": 91,

--- a/bench/coverage-presence.json
+++ b/bench/coverage-presence.json
@@ -25,6 +25,14 @@
       "had_integration_dir": true,
       "min_tests": 238
     },
+    "sparq-fedclient": {
+      "had_integration_dir": true,
+      "min_tests": 150
+    },
+    "sparq-fedplan": {
+      "had_integration_dir": true,
+      "min_tests": 50
+    },
     "sparq-geo": {
       "had_integration_dir": true,
       "min_tests": 85
@@ -53,6 +61,10 @@
       "had_integration_dir": false,
       "min_tests": 13
     },
+    "sparq-prov": {
+      "had_integration_dir": true,
+      "min_tests": 30
+    },
     "sparq-py": {
       "had_integration_dir": true,
       "min_tests": 0,
@@ -62,9 +74,17 @@
       "had_integration_dir": true,
       "min_tests": 127
     },
+    "sparq-reason-wasm": {
+      "had_integration_dir": true,
+      "min_tests": 9
+    },
     "sparq-rsp": {
       "had_integration_dir": true,
       "min_tests": 44
+    },
+    "sparq-rsp-wasm": {
+      "had_integration_dir": true,
+      "min_tests": 5
     },
     "sparq-serve": {
       "had_integration_dir": true,
@@ -78,6 +98,10 @@
       "had_integration_dir": true,
       "min_tests": 103
     },
+    "sparq-shacl-wasm": {
+      "had_integration_dir": true,
+      "min_tests": 6
+    },
     "sparq-sim": {
       "had_integration_dir": true,
       "min_tests": 14
@@ -89,6 +113,10 @@
     "sparq-text": {
       "had_integration_dir": true,
       "min_tests": 37
+    },
+    "sparq-text-wasm": {
+      "had_integration_dir": true,
+      "min_tests": 4
     },
     "sparq-vectors": {
       "had_integration_dir": true,

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -93,6 +93,16 @@ PER_COMMIT_CRATES=(
   sparq-parse sparq-gpu sparq-wasm sparq-zk sparq-zk-compose
   sparq-vectors                # measured with the two 50k tests SKIPPED (see below)
   sparq-conformance            # low %, floor 0 (test driver) — kept for presence
+  # [OPUS-4.8] sq-bif.1: the three OPT-IN native crates that were untracked by BOTH
+  # coverage gates. Their whole surface is feature-gated (fedclient/fedplan empty by
+  # default; prov has a `reason` extra), so they MUST be measured WITH those features
+  # on — the `case` in measure() below names them, or a default-feature build would
+  # report an empty-crate number. The 4 tier-b `-wasm` crates are NOT added here:
+  # their gate-exercising surface is the `#[wasm_bindgen]` JS API that only the
+  # `wasm-pack test --node` runner reaches, so a NATIVE llvm-cov number is a
+  # misleadingly-low artifact (measured 55-79% native; same class as sparq-cli's
+  # subprocess artifact) — they are floor-0 + presence-gated in the JSONs instead.
+  sparq-fedclient sparq-fedplan sparq-prov
 )
 # Crates whose HEAVY tests are only run in the nightly tier.
 NIGHTLY_ONLY_NOTE="sparq-vectors heavy 50k recall/diskann tests run only in nightly tier"
@@ -300,6 +310,25 @@ measure() {
       if [ "$TIER" = "per-commit" ]; then
         subcmd="test"; test_args+=(--skip "$VECTORS_HEAVY_SKIP"); skips+=("$VECTORS_HEAVY_SKIP")
       fi ;;
+    # [OPUS-4.8] sq-bif.1: the opt-in federation/provenance crates are ENTIRELY
+    # feature-gated — a default-feature `cargo llvm-cov -p <crate>` would build an
+    # empty crate and report a meaningless number. Name the features that turn the
+    # whole surface ON so the measured line% reflects the real (feature-on) code the
+    # floor gates. (Mirrors the sparq-core `--features mmap,dict-spill` quirk above.)
+    sparq-fedclient)
+      # `fedclient` enables the module surface + REUSE seams; `fedclient-adaptive`
+      # turns on the Phase-7 adaptive re-planning module (its tests are gated on it).
+      cargo_args+=(--features fedclient,fedclient-adaptive)
+      features+=("fedclient" "fedclient-adaptive") ;;
+    sparq-fedplan)
+      # `fedplan` enables the planner; `adaptive-replan` the live re-planning module.
+      cargo_args+=(--features fedplan,adaptive-replan)
+      features+=("fedplan" "adaptive-replan") ;;
+    sparq-prov)
+      # `reason` turns on the sparq-reason proof-tree -> PROV-O lineage bridge module
+      # (its integration test, tests/reason_prov.rs, is gated on it). The CONSTRUCT/
+      # update lineage core is default-on.
+      cargo_args+=(--features reason); features+=("reason") ;;
   esac
 
   local start end rc=0 json="$WORK/$crate.json"


### PR DESCRIPTION
> 🤖 SPARQ agent — Opus 4.8 (Fable unavailable; flag for re-review when Fable returns). `[OPUS-4.8]`

## sq-bif.1 — seed coverage floors + presence gate for the 7 untracked crates

The opt-in native crates **sparq-fedclient / sparq-fedplan / sparq-prov** and the 4 tier-b WASM binding crates (**sparq-reason-wasm / sparq-rsp-wasm / sparq-shacl-wasm / sparq-text-wasm**) carry real tests but were absent from **both** `bench/coverage-floor.json` and `bench/coverage-presence.json`, so AGENTS.md's "anything merged → coverage ratchet + presence gate" rule was silently un-met for them. (Found by the sq-bif/sq-5o5 audit — `research/coverage-bench-gap-audit.md` #4 flagged `sparq-fedplan`/`sparq-prov` as empty scratch dirs at audit time; they became real crates afterwards. The G1 new-crate gate enforces README/bench/SKILL but **not** the two coverage JSONs, which is how they slipped through.)

### The 7 entries added

| crate | presence `min_tests` | floor | how |
|---|---|---|---|
| sparq-fedclient | 150 (+integ) | **89** | measured 91.71% `--features fedclient,fedclient-adaptive`; floor = ⌊measured⌋−2 |
| sparq-fedplan | 50 (+integ) | **94** | measured 96.04% `--features fedplan,adaptive-replan` |
| sparq-prov | 30 (+integ) | **94** | measured 96.70% `--features reason` |
| sparq-reason-wasm | 9 (+integ) | **0 (presence-only)** | native llvm-cov artifact (see below) |
| sparq-rsp-wasm | 5 (+integ) | **0 (presence-only)** | native llvm-cov artifact |
| sparq-shacl-wasm | 6 (+integ) | **0 (presence-only)** | native llvm-cov artifact |
| sparq-text-wasm | 4 (+integ) | **0 (presence-only)** | native llvm-cov artifact |

### Why the 3 native crates also touch `scripts/coverage.sh`

The floor `--check` only enforces crates that appear in the measured summary. `scripts/coverage.sh`'s `PER_COMMIT_CRATES` list did **not** include these 3, so a floor entry alone would have been a dead `MISSING` row (silently un-gated). I added them to that list **and** taught `measure()` their features — their entire surface is `#[cfg(feature = …)]`-gated, so a default-feature build would report an empty-crate number. Mirrors the existing `sparq-core --features mmap,dict-spill` quirk.

### Why the 4 `-wasm` crates are presence-only (floor 0)

These tier-b bundles are `crate-type = ["cdylib", "rlib"]`; their gate-exercising surface is the `#[wasm_bindgen]` JS API exercised **only** by `wasm-pack test --node` (`tests/web.rs` is `#[wasm_bindgen_test]`). A **native** `cargo llvm-cov` runs **0** of those and reports a misleadingly-low number over the rlib helpers alone — measured **55% / 60% / 79% / 80%** respectively. That is a measurement artifact in the exact same class as `sparq-cli` (subprocess) / `sparq-gpu` (device-gated) / `sparq-conformance` (test-driver), all of which are floor-0 + presence-gated. Setting a real % floor here would gate a non-representative denominator, so I honestly handled them as presence-only per precedent rather than invent an unenforceable floor. They are **not** added to `coverage.sh` (no measurement cost for no gating value); absent floor-0 crates are a non-fatal `MISSING` row under the CI `--check-robust` invocation (which does not pass `--require-all`).

### Honesty

Every % above is a **conservative seed measured on a non-canonical work box**, not a canonical number. The floor is the **CI-enforced ratchet of record** (`coverage-gate.py --check-robust`, max-of-K re-measure); the −2 margin absorbs run-to-run noise.

### Gate results (local)

- `coverage-presence.py --check` → **32 ok / 0 fail** (all 7 new crates ok, +integ)
- `coverage-gate.py --check-monotonic --base-ref origin/main` → **PASS** (every base floor preserved/raised; only additions)
- `coverage-gate.py --self-test` → **ALL ASSERTIONS PASSED**
- `coverage-gate.py --check <measured 3-native-crate summary>` → fedclient 91.71% ≥ 89, fedplan 96.04% ≥ 94, prov 96.70% ≥ 94 (all met with headroom)
- `bash -n scripts/coverage.sh`, `shellcheck -S error`, JSON + ci.yml YAML all valid

No `crates/` source changed; the JSONs stay sorted and valid. The `ci-summary / gate` aggregator is unaffected (this rides the existing `coverage` job; no new gating leg added).

> Note: main has a recurring transient SBOM gating flake (sq-90ew). If an early ~9-12s SBOM `GS-*` leg fails, that is the flake, not this change — please re-run.