### PR TITLE
fix(scripts): drift-scan honors featured=false; mark 7 trend-only suites (sq-5o5.2) [OPUS-4.8]

### DIFF
--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -127,6 +127,9 @@ dataset     = "sparq-bench synthetic dump (deterministic WatDiv-flavoured social
 quiet_box_sensitive = true  # wall-clock latency; trend-only, NOT in the deterministic perf-gate (scripts/perf-gate.py)
 pinning     = "query dir + mode; dataset deterministic; queries pinned to fixed subjects so result counts are scale-stable"
 records_to  = "stdout (TSV); CI emits op_<query>_<mode>_us into benchmark-data (dev/bench) via scripts/ci-bench.sh"
+# [OPUS-4.8] sq-5o5.2: trend-only operator-latency coverage, not a head-to-head competitor
+# card — featured = false is a dashboard DISPOSITION (no perf claim). Promotion deferred to a maintainer.
+featured    = false
 status      = "ok"
 
 # [OPUS-4.8] sq-0jp — SP2Bench (well-known suite) at CI scale; per-commit subset + heavy tier.
@@ -266,6 +269,9 @@ dataset     = "dense follows graph (N nodes x4 edges) + rare premium leaf; gen2.
 quiet_box_sensitive = true
 pinning     = "gen.py seed fixed (random.seed(7)); pin N + fanout"
 records_to  = "stdout; tables in bench/selective/README.md; analysis research/predicate-transfer-measured.md"
+# [OPUS-4.8] sq-5o5.2: trend-only join-strategy characterization, not a head-to-head competitor
+# card — featured = false is a dashboard DISPOSITION (no perf claim). Promotion deferred to a maintainer.
+featured    = false
 status      = "ok"
 
 [[benchmark]]
@@ -279,6 +285,9 @@ dataset     = "literal-heavy synthetic, ~5N triples (int inline / big int / deci
 quiet_box_sensitive = true
 pinning     = "deterministic generator (index-derived values); pin N"
 records_to  = "stdout (TSV)"
+# [OPUS-4.8] sq-5o5.2: trend-only value-path cost probe, not a head-to-head competitor
+# card — featured = false is a dashboard DISPOSITION (no perf claim). Promotion deferred to a maintainer.
+featured    = false
 status      = "ok"
 
 # =============================================================================
@@ -488,6 +497,9 @@ dataset     = "socrates (vendored), DeepTaxonomy dt1k/10k/100k (gen_deeptaxonomy
 quiet_box_sensitive = true
 pinning     = "EYE version (v11.24.4 / SWI-Prolog), pinned generators; use CLI engine-internal 'in Xs' timer for load-robust comparison"
 records_to  = "bench/inference/eye-comparison.md"
+# [OPUS-4.8] sq-5o5.2: trend-only inference-closure coverage, not a head-to-head competitor
+# card — featured = false is a dashboard DISPOSITION (no perf claim). Promotion deferred to a maintainer.
+featured    = false
 status      = "ok"
 
 [[benchmark]]
@@ -501,6 +513,9 @@ dataset     = "synthesized in-script: 100k individuals x depth-20 subClassOf; 2k
 quiet_box_sensitive = true
 pinning     = "in-script generators are deterministic; trans chain capped at 2k (quadratic closure)"
 records_to  = "stdout; bench/inference/eye-comparison.md (RDFS/OWL section)"
+# [OPUS-4.8] sq-5o5.2: trend-only inference-closure coverage, not a head-to-head competitor
+# card — featured = false is a dashboard DISPOSITION (no perf claim). Promotion deferred to a maintainer.
+featured    = false
 status      = "ok"
 
 [[benchmark]]
@@ -514,6 +529,9 @@ dataset     = "bench/qlever-olympics/olympics.nt (1.78M triples, gitignored — 
 quiet_box_sensitive = true  # single-shot timings (not best-of-N); orders of magnitude are stable
 pinning     = "olympics dataset version; synthesized TBox defined in olympics_tbox"
 records_to  = "stdout; bench/inference/incremental-bench.md"
+# [OPUS-4.8] sq-5o5.2: trend-only incremental-maintenance coverage, not a head-to-head competitor
+# card — featured = false is a dashboard DISPOSITION (no perf claim). Promotion deferred to a maintainer.
+featured    = false
 status      = "ok"
 
 [[benchmark]]
@@ -527,6 +545,10 @@ dataset     = "~1.1k-graph WAC fixture (+ ACP variant), built in-crate (sparq_so
 quiet_box_sensitive = true
 pinning     = "in-crate fixture is deterministic"
 records_to  = "stdout; cross-checked in bench/inference/incremental-bench.md (0.84s WAC re-run baseline)"
+# [OPUS-4.8] sq-5o5.2: trend-only Solid WAC/ACP auth-view coverage, not a head-to-head competitor
+# card — featured = false is a dashboard DISPOSITION (no perf claim). Promotion (esp. as a Solid
+# differentiator) deferred to a maintainer.
+featured    = false
 status      = "ok"
 
 # [OPUS-4.8] sq-r06h — ODRL usage-control evaluator (opt-in sparq-policy crate).
@@ -541,6 +563,9 @@ dataset     = "synthetic ODRL Set of N permissions (assignee + target + dateTime
 quiet_box_sensitive = true
 pinning     = "in-example synthetic policy is deterministic; pin N for comparable numbers"
 records_to  = "stdout (us per phase)"
+# [OPUS-4.8] sq-5o5.2: trend-only ODRL policy-eval coverage, not a head-to-head competitor
+# card — featured = false is a dashboard DISPOSITION (no perf claim). Promotion deferred to a maintainer.
+featured    = false
 status      = "ok"
 
 # =============================================================================
@@ -773,6 +798,10 @@ dataset     = "synthetic column data generated in-example"
 quiet_box_sensitive = true
 pinning     = "column sizes fixed; GPU backend availability"
 records_to  = "stdout"
+# [OPUS-4.8] sq-5o5.2: trend-only CPU-vs-GPU kernel experiment, not a head-to-head competitor
+# card — featured = false is a dashboard DISPOSITION (no perf claim). Promotion (esp. as a GPU
+# differentiator) deferred to a maintainer.
+featured    = false
 status      = "ok"
 
 [[benchmark]]
@@ -910,6 +939,9 @@ dataset     = "RDF Semantics rdf-mt / OWL 2 RL / N3 / SPARQL entailment suites, 
 quiet_box_sensitive = false
 pinning     = "fetched suite revisions (see fetch-inference-suites.sh)"
 records_to  = "stdout + inference-conformance-report.md"
+# [OPUS-4.8] sq-5o5.2: conformance scoreboard (correctness, not perf) in the inference family;
+# trend-only — featured = false is a dashboard DISPOSITION (no perf claim). Promotion deferred to a maintainer.
+featured    = false
 status      = "ok"
 
 # =============================================================================

--- a/scripts/drift-scan.py
+++ b/scripts/drift-scan.py
@@ -205,6 +205,36 @@ def registered_bench_ids(root: Path) -> list[str]:
     return ids
 
 
+def featured_false_bench_ids(root: Path) -> set[str]:
+    """[OPUS-4.8] sq-5o5.2 — every benchmark `id` whose `[[benchmark]]` block sets
+    `featured = false` in bench/benchmarks.toml.
+
+    `featured = false` is the design's documented escape hatch (registry schema
+    header; research/maintenance-flow-on-automation-design.md §2.1) for a suite
+    that is intentionally trend-only — catalogued + visible in trend history, but
+    NOT promoted as a head-to-head competitor card on the capability dashboard.
+    It makes NO performance claim; it is purely a dashboard DISPOSITION.
+
+    The merge-time gate G3 (scripts/check-new-bench-registered.py) already accepts
+    this flag as a dashboard disposition; this reactive scanner did NOT, so the two
+    halves of the maintenance-flow-on system could disagree (G3 would pass a
+    suite that drift-scan still flagged). We mirror G3's predicate EXACTLY — split
+    on the `[[benchmark]]` header, then per block test the same
+    `^\\s*featured\\s*=\\s*false\\b` regex G3's registry_blocks() uses — so the two
+    tools share one definition of an intentionally-unfeatured suite and cannot
+    diverge again."""
+    text = bench_registry_sources(root)
+    ids: set[str] = set()
+    # Split on the table-array header; chunk[0] is the file preamble (no id).
+    for chunk in re.split(r"(?m)^\s*\[\[benchmark\]\]\s*$", text)[1:]:
+        idm = re.search(r'^\s*id\s*=\s*"([^"]+)"', chunk, re.MULTILINE)
+        if not idm:
+            continue
+        if re.search(r"^\s*featured\s*=\s*false\b", chunk, re.MULTILINE):
+            ids.add(idm.group(1))
+    return ids
+
+
 def crates_named_in_skills(root: Path) -> set[str]:
     """Every sparq-<x> crate token mentioned in ANY skills/**/SKILL.md.
 
@@ -367,10 +397,22 @@ def scan_dashboard_row(root: Path) -> list[DriftItem]:
     leading token of it) appears in the FEATURED_SUITES block's aliases. This
     is intentionally loose (the dashboard matches on aliases/tokens too) — its
     job is to flag whole FAMILIES with no promotion (e.g. the entire ZK family),
-    not to perfectly mirror the JS alias matcher."""
+    not to perfectly mirror the JS alias matcher.
+
+    A suite also clears the drift if its `[[benchmark]]` entry sets
+    `featured = false` (sq-5o5.2): that is the design's documented trend-only
+    DISPOSITION — catalogued + in trend history but not a head-to-head competitor
+    card — and it makes NO performance claim. Honoring it here keeps this reactive
+    scanner in lock-step with the merge-time gate G3, which already accepts the same
+    flag (scripts/check-new-bench-registered.py)."""
     featured = dashboard_featured_keys(root)
     if not featured:
         return []
+    # [OPUS-4.8] sq-5o5.2: ids explicitly flagged `featured = false` in
+    # bench/benchmarks.toml are an intentional trend-only DISPOSITION (the design's
+    # documented escape hatch, honored by gate G3) — they clear the dashboard-row
+    # drift without a FEATURED_SUITES competitor card and without any perf claim.
+    featured_false = featured_false_bench_ids(root)
     items: list[DriftItem] = []
     seen_families: set[str] = set()
     for bid in registered_bench_ids(root):
@@ -385,6 +427,13 @@ def scan_dashboard_row(root: Path) -> list[DriftItem]:
         if family in DASHBOARD_EXEMPT_FAMILIES or bid.startswith("sparq-bench"):
             continue
         if family in seen_families:
+            continue
+        # An explicit `featured = false` on THIS bench's entry is a dashboard
+        # disposition (trend-only) — it clears the drift like a FEATURED_SUITES
+        # row would, with no perf claim. We do NOT add the family to seen_families
+        # here (matching the featured-row skip below), so a sibling id in the same
+        # family that is NOT dispositioned can still surface the gap.
+        if bid in featured_false:
             continue
         # Featured iff the family token or the full id appears in the block.
         if family in featured or bid in featured:

--- a/scripts/tests/test_drift_scan.py
+++ b/scripts/tests/test_drift_scan.py
@@ -55,16 +55,25 @@ def make_crate(root: Path, name: str, *, public: bool = True) -> None:
     _write(root, f"crates/{name}/Cargo.toml", body)
 
 
-def make_registry(root: Path, sources: list[str], ids: list[str] | None = None) -> None:
+def make_registry(
+    root: Path,
+    sources: list[str],
+    ids: list[str] | None = None,
+    featured_false: set[str] | None = None,
+) -> None:
     """Write a minimal bench/benchmarks.toml with the given `source` lines (and
-    optionally `id` lines for the dashboard scanner)."""
+    optionally `id` lines for the dashboard scanner). Any id in `featured_false`
+    gets a `featured = false` line in its block (sq-5o5.2 dashboard disposition)."""
     ids = ids or []
+    featured_false = featured_false or set()
     lines = []
     n = max(len(sources), len(ids))
     for i in range(n):
         lines.append("[[benchmark]]")
         if i < len(ids):
             lines.append(f'id          = "{ids[i]}"')
+            if ids[i] in featured_false:
+                lines.append("featured    = false")
         if i < len(sources):
             lines.append(f'source      = "{sources[i]}"')
         lines.append("")
@@ -270,6 +279,60 @@ class DashboardRowTest(unittest.TestCase):
         make_dashboard(self.root, featured_tokens=["lubm"])
         items = drift_scan.scan_dashboard_row(self.root)
         self.assertEqual([], items)
+
+    # [OPUS-4.8] sq-5o5.2: a `featured = false` entry is an intentional trend-only
+    # DISPOSITION that clears the dashboard-row drift WITHOUT a FEATURED_SUITES
+    # competitor card and WITHOUT any perf claim. drift-scan must honor it so it
+    # stays in lock-step with the merge-time gate G3 (check-new-bench-registered.py),
+    # which already accepts the same flag.
+    def test_featured_false_clears_drift(self):
+        make_registry(
+            self.root,
+            sources=["s", "s"],
+            ids=["gpu-bench", "lubm"],
+            featured_false={"gpu-bench"},  # gpu marked trend-only
+        )
+        make_dashboard(self.root, featured_tokens=["lubm"])  # gpu NOT in FEATURED_SUITES
+        items = drift_scan.scan_dashboard_row(self.root)
+        keys = {it.dedup_key for it in items}
+        self.assertNotIn("dashboard-row:gpu", keys)
+
+    def test_featured_false_collects_helper_ids(self):
+        # The helper must report exactly the ids whose block carries featured=false.
+        make_registry(
+            self.root,
+            sources=["s", "s", "s"],
+            ids=["gpu-bench", "operator-coverage", "lubm"],
+            featured_false={"gpu-bench", "operator-coverage"},
+        )
+        self.assertEqual(
+            {"gpu-bench", "operator-coverage"},
+            drift_scan.featured_false_bench_ids(self.root),
+        )
+
+    def test_featured_false_clears_multi_id_family(self):
+        # A multi-id family is only cleared when EVERY non-exempt id is
+        # dispositioned (the bead marks all 4 inference ids); marking only one
+        # leaves the sibling to surface the gap, matching the FEATURED_SUITES skip.
+        make_registry(
+            self.root,
+            sources=["s", "s"],
+            ids=["inference-eye-comparison", "inference-owl-bench"],
+            featured_false={"inference-eye-comparison"},  # only ONE of two
+        )
+        make_dashboard(self.root, featured_tokens=["lubm"])
+        keys = {it.dedup_key for it in drift_scan.scan_dashboard_row(self.root)}
+        self.assertIn("dashboard-row:inference", keys)  # sibling still flags it
+        # Now disposition BOTH → family clears.
+        make_registry(
+            self.root,
+            sources=["s", "s"],
+            ids=["inference-eye-comparison", "inference-owl-bench"],
+            featured_false={"inference-eye-comparison", "inference-owl-bench"},
+        )
+        make_dashboard(self.root, featured_tokens=["lubm"])
+        keys = {it.dedup_key for it in drift_scan.scan_dashboard_row(self.root)}
+        self.assertNotIn("dashboard-row:inference", keys)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-5o5.2** — "Resolve dashboard-row drift for non-promotable registered suites via `featured = false`."

## What changed (two parts)

**1. `scripts/drift-scan.py::scan_dashboard_row` now honors `featured = false`.**
The scanner previously decided "has a dashboard row" using ONLY the `FEATURED_SUITES` JS block + the `DASHBOARD_EXEMPT_FAMILIES` list — it never read the registry's `featured` flag. The merge-time gate **G3** (`scripts/check-new-bench-registered.py`) *already* accepts `featured = false` as a dashboard disposition, so the two halves of the maintenance-flow-on system disagreed. Concretely, `pss-update-parity` was already `featured = false` in `main` yet drift-scan still flagged the `pss` family. A new helper `featured_false_bench_ids()` reuses **G3's exact regex** (`^\s*featured\s*=\s*false\b`, block-split on `[[benchmark]]`), so the two tools can't diverge again.

**2. `bench/benchmarks.toml` — mark the 7 non-promotable suites trend-only** (`featured = false`): `operator-coverage`, `selective-bindjoin`, `u64-valueids`, the four `inference-*` ids, `solid-wac-bench`, `policy-odrl-eval`, `gpu-bench`.

`featured = false` is a presentation / dispositioning choice — the suite stays catalogued and appears in trend history, but is **not** promoted as a head-to-head competitor card. **It makes no performance claim.** No FEATURED_SUITES cards added; no numbers fabricated.

## Before / after — `dashboard-row` drift set
`python3 scripts/drift-scan.py --root . --dry-run`

- **Before (14):** operator, selective, u64, inference, solid, policy, **zk, gpu, sim, introspect, nlq, mpc, wasm, pss**
- **After (6):** zk, sim, introspect, nlq, mpc, wasm
- **Cleared:** the 7 targets (operator, selective, u64, inference, solid, policy, gpu) — **plus `pss`**, which was *already* `featured = false` in `main` and only stayed flagged because of the scanner↔G3 inconsistency this PR closes. `pss-update-parity` is untouched by this PR's diff. No suite regressed (nothing in "after" that wasn't in "before").

## Where the flag lives
On each suite's `[[benchmark]]` entry in `bench/benchmarks.toml`, as `featured = false` (the schema's documented OPTIONAL field, header lines 23–32). The scanner reads it via the new `featured_false_bench_ids()` helper in `scripts/drift-scan.py`.

## Deferred maintainer decision (explicit, out of scope here)
Whether any of these — **especially `solid` or `gpu`, which could be genuine differentiators** — should instead be **PROMOTED to a featured competitor card** rather than trend-only is a **maintainer call**. This PR takes the conservative `featured = false` route for all 7 and promotes **none**. Do not promote any without explicit maintainer say-so.

## Gates / validation (local repro)
- `python3 -m pytest scripts/tests/test_drift_scan.py` → **37 passed** (34 existing + 3 new dashboard-row cases: featured=false clears; helper id-collection; multi-id family needs all ids dispositioned).
- `python3 -m pytest scripts/tests/` → **210 passed** (incl. the 24 G3 tests, unaffected).
- `python3 scripts/check-new-bench-registered.py --base main --dry-run` → **PASS**.
- `python3 scripts/check-no-perf-numbers.py --enforce` → **0 findings** (prose is perf-number-free).
- `node scripts/dashboard-smoke.js` → all checks pass; `node --check bench/dashboard/dashboard.js` OK.
- `python3 -c "import tomllib; tomllib.load(open('bench/benchmarks.toml','rb'))"` → parses (65 benchmarks).

No workflow or `crates/` source changes. Note: an early ~9–12s SBOM `GS-*` failure, if it appears, is the known transient flake (sq-90ew) — re-run.
