### PR TITLE
docs(bench/zk-compose): de-stale catalog README after /benchmarks/zk landed (sq-1s2.1.3/#777) [OPUS-4.8]

### DIFF
--- a/bench/zk-compose/README.md
+++ b/bench/zk-compose/README.md
@@ -82,9 +82,12 @@ with the snapshot, or if a gap carries a non-null gate number. After an
 **intentional** circuit change, re-run `scripts/gate_counts.sh` (re-baseline the
 snapshot) and then re-run the catalog generator to re-join the new numbers.
 
-> The website surface that renders this catalog (a `/benchmarks` or `/papers`
-> gate-cost / coverage table) is a separate follow-on bead (sq-1s2.1.3) — this is
-> the DATA layer only.
+> This file is the **DATA layer**. The website surface that renders it (the
+> SPARQL → ZK coverage + gate-cost table on `/benchmarks/zk`) landed in sq-1s2.1.3
+> (#777): `site/scripts/sync-zk-catalog.mjs` copies this JSON into
+> `site/src/data/zk-sparql-catalog.generated.json`, which the
+> `ZkSparqlCatalog` component (`site/src/components/benchmarks/zk-sparql-catalog.tsx`)
+> renders — so the rendered numbers always trace back to this snapshot-joined data.
 
 ## sq-pn2: full-family prove/verify cost curve
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Periodic repository-hygiene sweep (the recurring "repeated tasks identified in AGENTS.md" job). **DOC-ONLY** — no `crates/`, `zk/`, or bench-config (`benchmarks.toml`/`dashboard.js`) source; no `.beads/`. Review-queue PR (no auto-merge).

## Standing honesty/hygiene gates — all GREEN on this branch

| gate | result |
|---|---|
| `check-readme-template.py` | 0 deviations across 35 READMEs |
| `check-no-perf-numbers.py --enforce` | 0 findings across 171 files |
| `check-privacy-claims.sh` | OK — 349 files, no unqualified ZK/MPC claim |
| `check-skill-frontmatter.py` | 36/36 SKILL.md valid |
| `typos` (CI doc surface + changed file) | 0 |
| markdownlint (changed file) | 0 errors |

## The one doc fix

**`bench/zk-compose/README.md`** — the catalog blockquote said the website surface "is a separate follow-on bead (sq-1s2.1.3)". But **#777 LANDED that exact surface** — the SPARQL → ZK gate-cost / coverage table on `/benchmarks/zk`. That is a doc describing **shipped code as future work** (a docs-currency violation per AGENTS.md *Documents must stay current*).

- **before:** "The website surface that renders this catalog … is a separate follow-on bead (sq-1s2.1.3) — this is the DATA layer only."
- **after:** records the landed render path — `site/scripts/sync-zk-catalog.mjs` → `site/src/data/zk-sparql-catalog.generated.json` → the `ZkSparqlCatalog` component — while still labelling this file as the DATA layer.
- **evidence:** `gh pr view 777` = MERGED; `site/src/app/benchmarks/[type]/page.tsx` renders `<ZkSparqlCatalog />` for `family.key === "zk"`, fed from the generated JSON synced from `bench/zk-compose/sparql_feature_catalog.json`.

## Focus areas verified — no other drift

- **ZK gate-cost benchmark (#770/#777):** `crates/sparq-zk-compose/README.md` already points to `bench/zk-compose/` for benchmarks (now covers the catalog); `skills/zk-query-proofs/SKILL.md` cross-references it. No surface claims "no gate benchmark". No edit needed.
- **Coverage gates (#775):** **#775 is still OPEN, not merged** — the 7 new crates (fedclient/fedplan/prov + 4 wasm) are NOT in `bench/coverage-floor.json` (23 crates). No coverage doc statement is stale. No action.
- **CR-G8 (#772):** the three pointers (`compliance/cryptoreview/gap-register.md` authoritative entry; short forward refs in `crates/sparq-zk/README.md` + `skills/zk-query-proofs/SKILL.md`, each with a `privacy-claims-allow` marker) are consistent and non-duplicative; the "NOT established / OPEN external-audit obligation" caveats are preserved.
- **agent-telemetry (#767) + GUI CI matrix (#764):** doc references are internally consistent (`scripts/agent-telemetry/README.md` path correct; `gui/README.md` + `packages/sparq-client/README.md` reference `gui.yml`, which exists with the per-platform Tauri matrix). No drift.

## Caveat preservation

No unqualified ZK/MPC privacy/soundness claim introduced (privacy-claims gate green). The sparq-zk-compose NOT-yet-sound caveat and CR-G8 OPEN-obligation hedges are untouched.

## from-pss re-confirmation (#47-56/#162)

Re-verified — disposition **unchanged from the last sweep**: 9 CLOSED, 2 legitimately OPEN — #53 (`@jeswr/sparq` npm publish — confirmed still 404 / unpublished) and #55 (sparq-solid research track, no cutover landed). Nothing regressed.

🤖 SPARQ agent