### PR TITLE
feat(site): MPC £100k flagship — received-view panel + semi-honest/stub bead citations (sq-3hrc) [OPUS-4.8]

### DIFF
--- a/site/src/app/showcase/mpc-100k/page.tsx
+++ b/site/src/app/showcase/mpc-100k/page.tsx
@@ -198,21 +198,27 @@ export default function MpcFlagshipPage() {
               <strong className="text-foreground">no production security claim</strong>.
               It is honest-majority <strong className="text-foreground">semi-honest</strong>{" "}
               only — confidentiality holds against parties that follow the protocol
-              but try to learn more, not against actively-cheating parties in every
-              configuration. The collaborative zero-knowledge{" "}
-              <em>proof of correctness and source-attestation</em> is a stub that
-              returns <code className="font-mono">NotYetImplemented</code>. So this
-              demo does <strong className="text-foreground">not</strong> prove the
-              result is correct, only that the disclosure pattern is minimal.
+              but try to learn more, <strong className="text-foreground">not</strong> against
+              actively-cheating (malicious) parties, and the confidentiality argument
+              assumes an honest majority. The collaborative zero-knowledge{" "}
+              <em>proof of correctness and source-attestation</em> layer is a{" "}
+              <strong className="text-foreground">stub</strong> that returns{" "}
+              <code className="font-mono">NotYetImplemented</code> (tracked as beads{" "}
+              <code className="font-mono">sq-9hrn</code> /{" "}
+              <code className="font-mono">sq-qhy4</code>). So this demo does{" "}
+              <strong className="text-foreground">not</strong> prove the result is
+              correct — there is no soundness guarantee — only that the disclosure
+              pattern is minimal under the semi-honest, honest-majority assumption.
             </p>
             <p>
               No external cryptographer has reviewed sparq&rsquo;s bespoke MPC. Per
               the project&rsquo;s published <code className="font-mono">SECURITY.md</code>{" "}
               posture, treat this as a research / explainer artifact, not a
               certified secure-computation system. The crypto-review readiness doc
-              states it plainly: <code className="font-mono">sparq-mpc</code> carries
-              no confidentiality, correctness, attestation, or malicious-security
-              guarantee today.
+              (<code className="font-mono">compliance/cryptoreview/</code>, gap{" "}
+              <code className="font-mono">CR-G1</code>) states it plainly:{" "}
+              <code className="font-mono">sparq-mpc</code> carries no confidentiality,
+              correctness, attestation, or malicious-security guarantee today.
             </p>
           </CardContent>
         </Card>

--- a/site/src/components/mpc-demo.tsx
+++ b/site/src/components/mpc-demo.tsx
@@ -16,6 +16,8 @@ import {
   EyeOff,
   ShieldCheck,
   ShieldAlert,
+  Inbox,
+  Dice5,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -228,18 +230,21 @@ function MpcResultPanels({
             </table>
           </div>
           <p className="mt-3 text-xs text-muted-foreground">
-            Read a <strong>column</strong> to see what one party receives: a
-            mixture of one share from every party. No column reveals any single
-            input — addition over shares is what produces the answer.
+            Each <strong>column</strong> is what one party receives: a mixture of
+            one share from every party. The next step lays each column out as that
+            party&rsquo;s received view to show no column reveals any single input.
           </p>
         </CardContent>
       </Card>
 
-      {/* 3 · local sums → combine */}
+      {/* 3 · each party's RECEIVED view — what one party actually holds */}
+      <ReceivedViewPanel result={result} revealMatrix={revealMatrix} />
+
+      {/* 4 · local sums → combine */}
       <Card>
         <CardHeader>
           <CardTitle className="text-base">
-            3 · Add over shares (free, zero-round)
+            4 · Add over shares (free, zero-round)
           </CardTitle>
           <CardDescription>
             Each party sums the column of shares it holds. Combining these local
@@ -273,10 +278,10 @@ function MpcResultPanels({
         </CardContent>
       </Card>
 
-      {/* 4 · reveal ONLY the verdict bit — the money shot */}
+      {/* 5 · reveal ONLY the verdict bit — the money shot */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">4 · Reveal only the verdict</CardTitle>
+          <CardTitle className="text-base">5 · Reveal only the verdict</CardTitle>
           <CardDescription>
             The secure comparison opens exactly one bit:{" "}
             <code className="font-mono">total ≥ {gbp(THRESHOLD)}</code>. The exact
@@ -364,5 +369,97 @@ function MpcResultPanels({
         </CardContent>
       </Card>
     </div>
+  );
+}
+
+// [OPUS-4.8] sq-3hrc — each party's RECEIVED VIEW: the single column of shares
+// it ends up holding (one share from every party, including itself). The point
+// the spec calls out: any set of at most `t` shares — and here a party sees
+// exactly one share per other party — is uniform-random and INDEPENDENT of any
+// secret, so a party's whole received view leaks nothing about anyone's value.
+function ReceivedViewPanel({
+  result,
+  revealMatrix,
+}: {
+  result: MpcResult;
+  revealMatrix: boolean;
+}) {
+  const n = result.parties.length;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">
+          3 · What each party actually receives
+        </CardTitle>
+        <CardDescription>
+          Every party ends up holding one column of the matrix: a single share
+          from each of the {n} parties. Each card below is one party&rsquo;s
+          entire <strong>received view</strong> — and it is uniform random.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {result.received.map((column, j) => (
+            <div
+              key={j}
+              className="space-y-2 rounded-xl bg-muted/40 p-3 ring-1 ring-foreground/10"
+            >
+              <div className="flex items-center gap-1.5 text-sm font-medium">
+                <Inbox className="size-3.5 text-primary" aria-hidden="true" />
+                {result.parties[j].name}&rsquo;s view
+              </div>
+              <ul className="space-y-1">
+                {column.map((share, i) => {
+                  const own = i === j;
+                  return (
+                    <li
+                      key={i}
+                      className="flex items-center justify-between gap-2 text-xs"
+                    >
+                      <span className="text-muted-foreground">
+                        {own ? (
+                          <>
+                            own share{" "}
+                            <Badge variant="default" className="ml-0.5">
+                              kept
+                            </Badge>
+                          </>
+                        ) : (
+                          <>from {result.parties[i].name}</>
+                        )}
+                      </span>
+                      <span className="tabular font-mono text-[11px]">
+                        {revealMatrix ? share.toLocaleString() : "••••"}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <p className="flex items-start gap-2 rounded-lg bg-muted/50 p-3 text-xs text-muted-foreground">
+          <Dice5
+            className="mt-0.5 size-4 shrink-0 text-[var(--success)]"
+            aria-hidden="true"
+          />
+          <span>
+            <strong className="text-foreground">
+              Any single column reveals nothing.
+            </strong>{" "}
+            Because every share except the last is sampled uniformly at random,
+            any set of at most the reconstruction threshold{" "}
+            <code className="font-mono">t</code> of them — and a party only ever
+            sees its own column — is uniformly random and{" "}
+            <em>statistically independent</em> of every party&rsquo;s private
+            value. A view is indistinguishable from random noise until the
+            parties <em>jointly</em> open the final result. (This independence
+            is the confidentiality property the protocol relies on under its
+            honest-majority, semi-honest assumption — not a malicious-security
+            guarantee.)
+          </span>
+        </p>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
> 🤖 SPARQ agent

Completes bead **sq-3hrc** (FLAGSHIP 2: MPC £100k secure-threshold simulation page). The FL2 `/showcase/mpc-100k` page + `MpcDemo` + `mpc-sim.ts` already landed in #249 but the bead was left open; this PR closes the two remaining gaps vs. the §4.2 design and the FL1 honesty pattern (#771).

## What changed
- **`site/src/components/mpc-demo.tsx`** — added a dedicated **step 3 "What each party actually receives"** panel. Each party's received column is rendered as its own card (own share `kept` vs. `from <peer>`), gated by the existing reveal/hide toggle. A distinct **"Any single column reveals nothing"** callout makes the design's *"any ≤ t column is uniform-random → statistically independent of every secret"* property explicit — the spec listed the received view as its own visualized element and it was previously folded into a matrix footnote only. Renumbered the reveal step to 5; pointed the matrix footnote at the new panel.
- **`site/src/app/showcase/mpc-100k/page.tsx`** — hardened the honesty panel to **cite the tracking beads `sq-9hrn` / `sq-qhy4`** for the stubbed collaborative-ZK proof-of-correctness layer, and **gap `CR-G1`** in `compliance/cryptoreview/` — matching how FL1 `zk-car-hire` cites `sq-qhy4` / `CR-G1`.

## Honesty framing (load-bearing)
Every security sentence is qualified from the start:
- **Illustration, not the crate:** "client-side illustration of the protocol shape, not the hardened crate" (pre-existing, retained).
- **Semi-honest only / honest-majority:** the new and revised copy states confidentiality holds against semi-honest parties **"not against actively-cheating (malicious) parties"** and **"assumes an honest majority"**; the received-view independence note explicitly ends "*— not a malicious-security guarantee.*"
- **Stub, no proof of correctness:** the collaborative-ZK layer is a `NotYetImplemented` **stub** (sq-9hrn / sq-qhy4); "this demo does **not** prove the result is correct — there is no soundness guarantee."
- No unqualified "sound" / "secure" / "cannot learn" / "zero-knowledge-secure" claims; "secure threshold/comparison" appear only as the protocol's term-of-art name.

## Gates
- `cd site && npm run build` — **static export green**; `/showcase/mpc-100k/index.html` emitted (basePath `/sparq` correct in assets), build typecheck clean.
- `npm run lint` — clean (no ESLint warnings/errors).
- `scripts/check-privacy-claims.sh` — **OK** (349 files, no unqualified claim).
- `scripts/check-no-perf-numbers.py --enforce` — **OK** (0 findings).
- Existing routes intact: `/showcase/zk-car-hire`, `/showcase/solid-pairs`, `/benchmarks/zk`, `/surface/mpc`.
- WASM prereq: reused the prebuilt lean bundle (build artifact only; no `crates/` change). MPC page itself uses no WASM.

> NOTE: if an early ~9–12s SBOM `GS-*` lane fails, that is the known transient flake (sq-90ew) — please re-run.