### PR TITLE
feat(bench/dashboard): promote the ZK estate to a FEATURED_SUITES card (sq-5o5.3) [OPUS-4.8]

### DIFF
--- a/bench/dashboard/dashboard.css
+++ b/bench/dashboard/dashboard.css
@@ -177,6 +177,11 @@ table.summary-table { width: 100%; border-collapse: collapse; font-size: 0.92rem
   margin: 0 0 10px; font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.05em;
   color: var(--accent); font-weight: 700;
 }
+/* [OPUS-4.8] sq-5o5.3: per-suite honest framing caption (e.g. the ZK estate's circuit-COST,
+   not-speed, research-grade / not-audited note). Muted + italic, like the scaling/refs captions. */
+.featured-suite-note {
+  font-size: 0.74rem; color: var(--muted); font-style: italic; margin: -4px 0 10px; line-height: 1.5;
+}
 .featured-table th.competitor-col, .featured-table td.competitor-col { color: var(--muted); }
 /* sparq's own column reads slightly stronger than competitor columns so the engine-under-test is
    visually anchored. */

--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -419,6 +419,26 @@
     // like-for-like axis (query-over-HDT is a NON-goal — different data structure); the
     // hdt-cpp competitor (bench/competitors.json) is decode-only, gather-only via docker.
     { key: 'HDT',           title: 'HDT load-and-decode', aliases: ['hdt', 'snikmeta'] },
+    // [OPUS-4.8] sq-5o5.3: PROMOTE the ZK estate to a featured card (the maintainer treats ZK as a
+    // genuine differentiator, unlike the trend-only suites). One card groups the whole estate: the
+    // `zk-compose` circuit-gate counts (zk_compose_<member>_gates) + the `zk` commitment-pipeline
+    // and `zk-trace` overhead criterion means (zk_commit_* / zk_canon_* / zk_poseidon2_* / zk_trace_*).
+    // `key` matches the metric-labels.json suite ("Zero-knowledge"); the aliases also carry the bare
+    // `zk` family token (which clears scripts/drift-scan.py::scan_dashboard_row's `dashboard-row:zk`)
+    // and the per-bench slugs, plus the metric-name prefixes for the structural fallback.
+    //
+    // HONESTY (sq-5o5.3): the headline ZK figures are `bb gates -s ultra_honk` CIRCUIT-SIZE counts
+    // (unit `gates`, from the committed bench/zk-compose/gate_counts_latest.json snapshot) — a
+    // circuit-COST measurement, NOT throughput/speed. The zk_commit_*/zk_trace_* rows are µs
+    // criterion MEANS (NON-canonical trend signals). `note` frames the card as circuit-cost and
+    // states ZK is research-grade / not externally audited, so the card never implies a speed claim
+    // or an audited guarantee. No numbers live here — the rows come from the registered bench feed.
+    { key: 'Zero-knowledge', title: 'Zero-knowledge (commit · trace · circuit)',
+      aliases: ['zero-knowledge', 'zk', 'zk-trace', 'zk-compose', 'zktrace', 'zkcompose'],
+      note: 'Circuit-COST card: the headline figures are bb gates -s ultra_honk circuit-size '
+          + '(gate-count) measurements — NOT speed/throughput. The µs rows are non-canonical '
+          + 'criterion trend means. The ZK estate is research-grade and not externally audited; '
+          + 'smaller circuit size is better.' },
     { key: 'BSBM',          title: 'BSBM',          aliases: ['bsbm'] },
     { key: 'DBPSB',         title: 'DBPSB',         aliases: ['dbpsb', 'dbpedia sparql benchmark'] },
     // [OPUS-4.8] sq-i0nm: the synthetic qlever-style suite carries the one in-repo competitor
@@ -529,6 +549,9 @@
       // the comparison table — never aligned into a same-row competitor cell (those stay n/a unless a
       // same-scale gather fills `values`). A suite with rows but no references just omits the note.
       if (bySuite[f.key]) groups.push({ suite: f.key, title: f.title,
+        // [OPUS-4.8] sq-5o5.3: carry the optional FEATURED_SUITES `note` (the ZK estate's
+        // circuit-cost / research-grade framing) through to renderFeatured's caption.
+        note: f.note,
         rows: sortRows(bySuite[f.key].rows), references: referencesForSuite(competitors, f.key) });
     });
     // [OPUS-4.8] sq-aas7: carry the chosen-tier provenance so renderFeatured can show a tier badge
@@ -959,6 +982,10 @@
       var section = el('section', { 'class': 'featured-suite' }, [
         el('h3', { 'class': 'featured-title', text: g.title })
       ]);
+      // [OPUS-4.8] sq-5o5.3: optional per-suite NOTE — an honest framing caption shown under the
+      // suite title (e.g. the ZK estate's "circuit-COST, not speed; research-grade / not audited"
+      // disclaimer). Pure DOM, only rendered when the FEATURED_SUITES entry carries `note`.
+      if (g.note) section.appendChild(el('p', { 'class': 'featured-suite-note', text: g.note }));
       var table = el('table', { 'class': 'summary-table featured-table' });
       var headCells = [
         // [OPUS-4.8] Header is "Metric" (matching the summary table) — the cell holds a general


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-5o5.3** — promote the ZK estate to a FEATURED dashboard row so it renders as a showcased card and clears the `dashboard-row:zk` drift. After #778 the `zk` family was still the only entry of the dashboard-row drift list the maintainer wants featured (ZK is a genuine differentiator, unlike the trend-only suites that were dispositioned `featured = false`).

## What changed
- **`bench/dashboard/dashboard.js`** — added one `FEATURED_SUITES` entry: `{ key: 'Zero-knowledge', title: 'Zero-knowledge (commit · trace · circuit)', aliases: ['zero-knowledge','zk','zk-trace','zk-compose','zktrace','zkcompose'], note: … }`.
  - `key` matches the `metric-labels.json` suite (`"Zero-knowledge"`), so `suiteFor()`/`featuredSuiteOf()`/`buildFeatured()` group the whole estate into **one card**: the `zk-compose` circuit-gate counts (`zk_compose_<member>_gates`, unit `gates`) **and** the `zk` commitment-pipeline + `zk-trace` overhead criterion means (`zk_commit_*` / `zk_canon_* / zk_poseidon2_* / zk_trace_*`).
  - the bare `zk` alias token is what clears `scripts/drift-scan.py::scan_dashboard_row`'s `dashboard-row:zk` flag.
  - a new optional per-suite **`note`** field (rendered by `renderFeatured`) carries the honest framing caption.
- **`bench/dashboard/dashboard.css`** — `.featured-suite-note` (muted/italic caption, like the scaling/refs notes).

This is the mechanism both consumers use: drift-scan reads the `FEATURED_SUITES` block text; the renderer reads `FEATURED_SUITES` via `featuredSuiteOf`/`buildFeatured`. **No numbers live in the JS** — rows come from the registered bench feed (`scripts/ci-bench.sh`, grounded in the committed `bench/zk-compose/gate_counts_latest.json` snapshot).

## Honesty
The headline ZK figures are **`bb gates -s ultra_honk` circuit-SIZE (gate-count)** measurements — a **circuit-COST** metric, **not** speed/throughput. The card's `note` says exactly that, marks the µs rows as non-canonical criterion trend means, and states the ZK estate is **research-grade / not externally audited** — so the card never implies a speed claim or an audited guarantee. `check-privacy-claims.sh` and `check-no-perf-numbers.py --enforce` both pass over the new prose.

## drift-scan dashboard-row set
- **before:** `{zk, sim, introspect, nlq, mpc, wasm}` (6)
- **after:** `{sim, introspect, nlq, mpc, wasm}` (5) — only `zk` removed, **no other family regressed** (verified by diffing the full `--dry-run` output).

## Gate results (local)
- `node --check bench/dashboard/dashboard.js` — OK
- `node scripts/dashboard-smoke.js` — PASS
- `python3 -m pytest scripts/tests/test_drift_scan.py` — 37 passed
- `python3 scripts/drift-scan.py --root . --dry-run` — drops `dashboard-row:zk`, nothing else regresses
- `bench/benchmarks.toml` parses (tomllib, 65 entries)
- `check-no-perf-numbers.py --enforce` — 0 findings; `check-privacy-claims.sh` — OK
- Local reproduction: a node harness loaded the real `gate_counts_latest.json` + `metric-labels.json` and confirmed `buildFeatured` surfaces the ZK card with **30 real rows** (28 gate-count + commit + trace), unit `gates` on the circuit rows, and the circuit-cost / not-audited `note`; LUBM and the other featured suites are unaffected.

Compliance gap closed: the ZK capability surface is now promoted on the dashboard (honest circuit-cost framing), clearing the §5.D `dashboard-row:zk` drift.