### PR TITLE
docs(release): reconcile publishable-crate count 16 → 17; add sparq-algos to publish DAG (sq-v286.1)

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -20,9 +20,10 @@ here for the runbook:
 ## 0a. Crate-name availability
 
 Availability snapshot as of **2026-06-14** (crates.io API: a 404 / "does not exist" =
-available; a 200 = taken). All 16 publishable crates plus the top-level `sparq` name were
-checked; the npm and PyPI surface names are included for completeness. Re-run before the
-first publish — registries change.
+available; a 200 = taken). The original snapshot covered 16 publishable crates plus the
+top-level `sparq` name; the npm and PyPI surface names are included for completeness. The
+publishable set is **17** (sparq-algos was missed in the 2026-06-14 snapshot — see the row
+flagged *not yet re-checked* below). Re-run before the first publish — registries change.
 
 For the **PyPI** row, that re-run is one command (`scripts/check-pypi-name.py --check`,
 sq-ed5): it reads the distribution name from `crates/sparq-py/pyproject.toml` (`sparq-rdf`)
@@ -52,11 +53,14 @@ taken name itself.
 | `sparq-rsp` | crates.io | available |
 | `sparq-solid` | crates.io | available |
 | `sparq-nlq` | crates.io | available |
+| `sparq-algos` | crates.io | not yet re-checked (added to the publishable set after the 2026-06-14 snapshot — sq-v286.1) |
 | `@jeswr/sparq` | npm | available |
 | `sparq` | PyPI | **taken** — unrelated `shiventi/sparq` (SJSU degree-planning API client, latest 0.2.6) |
 | `sparq-rdf` | PyPI | chosen distribution name (owner-approved; `pip install sparq-rdf`, `import sparq`) |
 
-**Conclusion:** all crates.io names and the npm scope are clear to publish as-is. The PyPI
+**Conclusion:** every crates.io name checked in the 2026-06-14 snapshot and the npm scope are
+clear to publish as-is; `sparq-algos` (the 17th publishable crate) still needs its one-off
+availability check before the first publish (the re-run noted above covers it). The PyPI
 **distribution** name `sparq` is taken by a real, unrelated, actively-maintained package, so
 the Python wheel ships as **`sparq-rdf`** (owner-approved; `sq-8slf`). This is the only name
 that changed — the **import** name stays `sparq` (`import sparq`), and no crates.io / npm
@@ -116,17 +120,22 @@ in sync until they're unified. (The retired `macos-13` runner label has been rep
 
 ## 4. crates.io publication
 
-**16 crates publish.** The publish order follows the dependency DAG, leaf-first (a crate's
+<!-- [OPUS-4.8] sq-v286.1: reconciled 16 → 17 publishable crates. sparq-algos has full
+crates.io metadata and no `publish = false`, so publish.yml's `crates` job already packages
++ attests it; it is added below as a core-only leaf (depends on sparq-core only — verified
+in crates/sparq-algos/Cargo.toml — and nothing in the workspace depends on it). -->
+**17 crates publish.** The publish order follows the dependency DAG, leaf-first (a crate's
 deps must exist on crates.io before it can be verified):
 
 ```text
 sparq-core                      # no internal deps — first
   ├── sparq-introspect          # core only                ┐
   ├── sparq-reason              # core only                │ order among these
-  ├── sparq-hdt                 # core only                │ six doesn't matter
+  ├── sparq-hdt                 # core only                │ seven doesn't matter
   ├── sparq-shacl               # core only                │
   ├── sparq-sim                 # core only                │
-  └── sparq-vectors             # core only                ┘
+  ├── sparq-vectors             # core only                │
+  └── sparq-algos               # core only                ┘
 sparq-engine                    # core + introspect — after both
   ├── sparq-geo                 # core + engine            ┐
   ├── sparq-serve               # core + engine            │ order among these
@@ -148,6 +157,7 @@ cargo publish -p sparq-hdt
 cargo publish -p sparq-shacl
 cargo publish -p sparq-sim
 cargo publish -p sparq-vectors
+cargo publish -p sparq-algos        # [OPUS-4.8] sq-v286.1 — core-only leaf (17th publishable crate)
 
 # CHECKPOINT before sparq-engine: the crates.io package resolves UPSTREAM spargebra 0.4.6,
 # not the vendored copy (the [patch]/path override is stripped on publish). Dry-run it


### PR DESCRIPTION
> 🤖 SPARQ agent

## sq-v286.1 — Reconcile publishable-crate drift: 17 not 16; add `sparq-algos` to the publish DAG

A **factual doc reconcile**: the runbook was stale, the workflow was right. `crates/sparq-algos/Cargo.toml` carries full crates.io metadata and **no** `publish = false`, so `publish.yml`'s `crates` job (which globs `crates/*/Cargo.toml` and skips only `publish = false`) **already** packages + attests it. The real publishable count is **17**, not 16, and `docs/release.md` omitted `sparq-algos` from the publish-order DAG.

### Verified facts (this checkout)
- Enumerating `crates/*/Cargo.toml` without `publish = false` ⇒ **17** publishable crates (was documented as 16). The 17: `sparq-algos`, `-cli`, `-core`, `-engine`, `-geo`, `-hdt`, `-introspect`, `-nlq`, `-reason`, `-rsp`, `-serve`, `-server`, `-shacl`, `-sim`, `-solid`, `-text`, `-vectors`.
- `sparq-algos` is a **core-only leaf**: its only internal dep is `sparq-core` (`crates/sparq-algos/Cargo.toml`), and **nothing** in the workspace depends on it ⇒ it sits in the same DAG tier as `-introspect`/`-reason`/`-hdt`/`-shacl`/`-sim`/`-vectors`.

### Changes (`docs/release.md` only)
- §4 count line `16 → 17`; added `sparq-algos` as the 7th core-only-leaf branch in the publish-order DAG (`six → seven doesn't matter`) and a `cargo publish -p sparq-algos` line to the exact-commands block, in dependency order.
- §0a count prose `16 → 17`; added a `sparq-algos` row to the availability table marked **not yet re-checked** (a `403` from crates.io in this sandbox is indeterminate under the doc's own 404-available/200-taken convention — no availability is fabricated) and adjusted the §0a conclusion accordingly.

`research/release-ci-design.md` §5 already records this drift correctly ("17 publishable crates, not 16") as item #1 of its sequencing — left as-is (a historical design record; now satisfied).

### Gates (all run locally)
- `scripts/check-no-perf-numbers.py --enforce` → **PASS** (0 findings, 171 files)
- `scripts/gate-new-crate.py --base main` → **PASS** (no new crate added)
- `markdownlint-cli2@0.18.1` (CI version + `.markdownlint-cli2.jsonc`) → **0 errors** (207 files)
- `scripts/check-privacy-claims.sh` → **OK**
- No README touched (readme-template N/A); no workflow touched (YAML/actionlint N/A); typos gate — none of `DELETEd`/`DROPped`/`invokable`/`ANDed` present.

No auto-merge (review-queue PR). If an early ~9-12s SBOM `GS-*` leg fails, that is the known transient SBOM flake (sq-90ew) — re-run.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>