### PR TITLE
test(sparq-fedclient): correctness suite — pushdown/wire/operators/discovery + error paths (sq-bif.2) [OPUS-4.8]

### DIFF
--- a/crates/sparq-fedclient/README.md
+++ b/crates/sparq-fedclient/README.md
@@ -22,6 +22,34 @@ Design: [`research/federation-client-design.md`](../../research/federation-clien
 Planner it reuses: [`skills/federated-planning/SKILL.md`](../../skills/federated-planning/SKILL.md).
 Contributing: [`AGENTS.md`](../../AGENTS.md).
 
+## Correctness tests
+
+The client's correctness rests on **result-equivalence** — a federated answer equals local
+`sparq-engine` evaluation over the merged data — plus **answer-safety / fail-closed** error
+handling on every untrusted-input boundary (a remote endpoint's body, a fragment server's
+triples, an endpoint IRI's resolved IP). All tests are gated on the `fedclient` feature; the
+default build compiles them to nothing. They run on the REAL path (the canonical answer IS the
+engine), not against a mock that bypasses the logic:
+
+* **Result-equivalence (the load-bearing invariant)** — `planner_result_equals_local_eval`
+  (materialised single-source = local eval), `streaming_result_equals_phase3` (streamed =
+  materialised, for any source-arrival interleaving), `multi_source_union_result_equals_local`
+  (per-leaf UNION fan-out = local eval over the merged graph), and
+  `adaptive_result_equals_static` (a re-plan changes the plan, never the answer).
+* **Wire / error paths** — `srj_parse_correctness` (the SPARQL-Results-JSON decode: every
+  term kind plus the malformed / partial / adversarial-body branches all fail closed),
+  `wire_pushdown_extra` (the brTPF binding-block binary codec rejects truncated / wrong-magic /
+  wrong-version buffers without a panic — the crate is `forbid(unsafe_code)`), and
+  `interpreter_error_paths` (a transport failure, a malformed body, and a plan/resolver
+  mismatch each surface the right `InterpError`, fail-closed).
+* **Discovery + source adapters** — `discovery_error_paths` (the SD / VoID / ASK-probe
+  orchestration: malformed-SD propagation, VoID-without-SD, best-effort VoID, the recall-safe
+  unknown-version capability) and `source_adapter_error_paths` (the SSRF egress guard refuses a
+  host that resolves only to private/internal addresses; a transport / fragment-server error is
+  surfaced as `FedError::Transport`; a runaway paginator is fail-stopped by the page cap).
+* **The dependency boundary** — `boundary` proves `sparq-core` / `sparq-engine` never gain an
+  edge to this crate (the dependency arrow points one way *into* the engine).
+
 ## License
 
 [MIT](../../LICENSE).

--- a/crates/sparq-fedclient/README.md
+++ b/crates/sparq-fedclient/README.md
@@ -22,33 +22,7 @@ Design: [`research/federation-client-design.md`](../../research/federation-clien
 Planner it reuses: [`skills/federated-planning/SKILL.md`](../../skills/federated-planning/SKILL.md).
 Contributing: [`AGENTS.md`](../../AGENTS.md).
 
-## Correctness tests
-
-The client's correctness rests on **result-equivalence** — a federated answer equals local
-`sparq-engine` evaluation over the merged data — plus **answer-safety / fail-closed** error
-handling on every untrusted-input boundary (a remote endpoint's body, a fragment server's
-triples, an endpoint IRI's resolved IP). All tests are gated on the `fedclient` feature; the
-default build compiles them to nothing. They run on the REAL path (the canonical answer IS the
-engine), not against a mock that bypasses the logic:
-
-* **Result-equivalence (the load-bearing invariant)** — `planner_result_equals_local_eval`
-  (materialised single-source = local eval), `streaming_result_equals_phase3` (streamed =
-  materialised, for any source-arrival interleaving), `multi_source_union_result_equals_local`
-  (per-leaf UNION fan-out = local eval over the merged graph), and
-  `adaptive_result_equals_static` (a re-plan changes the plan, never the answer).
-* **Wire / error paths** — `srj_parse_correctness` (the SPARQL-Results-JSON decode: every
-  term kind plus the malformed / partial / adversarial-body branches all fail closed),
-  `wire_pushdown_extra` (the brTPF binding-block binary codec rejects truncated / wrong-magic /
-  wrong-version buffers without a panic — the crate is `forbid(unsafe_code)`), and
-  `interpreter_error_paths` (a transport failure, a malformed body, and a plan/resolver
-  mismatch each surface the right `InterpError`, fail-closed).
-* **Discovery + source adapters** — `discovery_error_paths` (the SD / VoID / ASK-probe
-  orchestration: malformed-SD propagation, VoID-without-SD, best-effort VoID, the recall-safe
-  unknown-version capability) and `source_adapter_error_paths` (the SSRF egress guard refuses a
-  host that resolves only to private/internal addresses; a transport / fragment-server error is
-  surfaced as `FedError::Transport`; a runaway paginator is fail-stopped by the page cap).
-* **The dependency boundary** — `boundary` proves `sparq-core` / `sparq-engine` never gain an
-  edge to this crate (the dependency arrow points one way *into* the engine).
+Correctness suite under `tests/` (gated on the `fedclient` feature; the default build compiles it to nothing) — run on the REAL path, with local `sparq-engine` evaluation as the canonical answer: result-equivalence (planner / streaming / multi-source UNION / adaptive vs. static), fail-closed wire & error paths (SRJ decode, brTPF binary codec, interpreter), discovery + source-adapter error paths (incl. the SSRF egress guard), and the one-way `sparq-core`/`sparq-engine` dependency boundary.
 
 ## License
 

--- a/crates/sparq-fedclient/tests/discovery_error_paths.rs
+++ b/crates/sparq-fedclient/tests/discovery_error_paths.rs
@@ -1,0 +1,287 @@
+//! sq-bif.2 — capability-discovery orchestration error-path + edge-case suite.
+//!
+//! The `discovery` module's inline tests cover the happy SD round-trip, the ASK fallback when
+//! nothing is published, and an unreachable endpoint. This file targets the discovery
+//! ORCHESTRATION branches the inline suite leaves uncovered, driving the public
+//! [`discover`](sparq_fedclient::discovery::discover) against a [`MapFetcher`] double (no
+//! network):
+//!
+//!  * a SD GET that **succeeds but returns malformed N-Triples** (the parse error propagates,
+//!    unlike a transport-failed SD GET which falls through to the ASK probe);
+//!  * the **VoID-without-SD** path: no Service Description, but a served VoID document AND an
+//!    ASK probe — the descriptor is populated from VoID while the capability comes from the
+//!    ASK fallback;
+//!  * an SD whose `sd:Service` carries **no `sd:supportedLanguage`** (the recall-safe
+//!    unknown-version capability);
+//!  * the VoID best-effort branch: a **malformed VoID** is silently ignored (descriptor stays
+//!    `None`), not fatal;
+//!  * [`well_known_void_url`] over query-string / fragment / IPv6-authority / no-path endpoints;
+//!  * the `parse_ask_boolean` behaviour through `discover` (the tolerant scanner accepts a
+//!    `true`/`false` token), and the [`Capability::ask_fallback`] / [`MediaType`] units the
+//!    round-trip exercises only implicitly.
+//!
+//! Gated on `fedclient`; the default build compiles this file to nothing.
+//!
+//! [OPUS-4.8] sq-bif.2 — flagged for Fable re-review when available.
+
+#![cfg(feature = "fedclient")]
+
+use sparq_fedclient::discovery::{
+    discover, parse_service_description, well_known_void_url, Capability, FilterClass, Interface,
+    MapFetcher, MediaType, Provenance, SparqlVersion,
+};
+
+/// `ASK { ?s ?p ?o }` — the FedX reachability probe `discover` issues. The URL form is
+/// `{endpoint}?query={percent-encoded}`; this helper builds the exact key `MapFetcher` matches.
+const ASK_PROBE: &str = "ASK { ?s ?p ?o }";
+fn ask_url(endpoint: &str) -> String {
+    let mut q = String::new();
+    for b in ASK_PROBE.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                q.push(b as char)
+            }
+            _ => q.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    format!("{}?query={}", endpoint, q)
+}
+
+/// A minimal served-shape Service Description naming a SPARQL 1.1 endpoint.
+const SD_SPARQL11: &str = r#"<http://host/sparql> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/sparql-service-description#Service> .
+<http://host/sparql> <http://www.w3.org/ns/sparql-service-description#supportedLanguage> <http://www.w3.org/ns/sparql-service-description#SPARQL11Query> .
+<http://host/sparql> <http://www.w3.org/ns/sparql-service-description#resultFormat> <http://www.w3.org/ns/formats/SPARQL_Results_JSON> .
+"#;
+
+/// A served-shape VoID document (the `from_void_nt` consumer's input).
+const VOID_NT: &str = r#"<http://host/.well-known/void#dataset> <http://rdfs.org/ns/void#triples> "300"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://host/.well-known/void#dataset> <http://rdfs.org/ns/void#propertyPartition> _:p1 .
+_:p1 <http://rdfs.org/ns/void#property> <http://xmlns.com/foaf/0.1/knows> .
+_:p1 <http://rdfs.org/ns/void#triples> "200"^^<http://www.w3.org/2001/XMLSchema#integer> .
+"#;
+
+// ─── discover() orchestration error / edge paths ───────────────────────────────────────
+
+#[test]
+fn discover_propagates_malformed_service_description() {
+    // A SD GET that SUCCEEDS (200) but returns malformed N-Triples: the parse error propagates,
+    // because a successful body that fails to parse is a hard error (distinct from a *transport*
+    // failure on the SD GET, which is non-fatal and falls through to the ASK probe).
+    let endpoint = "http://host/sparql";
+    let fetcher = MapFetcher::new().with(endpoint, "this is not <ntriples at all");
+    let err = discover(endpoint, &fetcher).unwrap_err();
+    assert!(
+        err.contains("service-description") || err.contains("malformed"),
+        "a malformed served SD must surface a parse error, got {}",
+        err
+    );
+}
+
+#[test]
+fn discover_void_without_sd_uses_ask_fallback_but_keeps_descriptor() {
+    // No SD (the endpoint 400s a no-query GET, modelled as an unregistered URL), but a served
+    // VoID AND an ASK probe. The capability is the conservative ASK fallback; the descriptor
+    // IS populated from the served VoID — VoID stats and SD capability are independent.
+    let endpoint = "http://host/sparql";
+    let fetcher = MapFetcher::new()
+        .with("http://host/.well-known/void", VOID_NT)
+        .with(ask_url(endpoint), r#"{"head":{},"boolean":true}"#);
+    let d = discover(endpoint, &fetcher).expect("VoID + reachable ASK ⇒ discovers");
+    assert_eq!(
+        d.provenance,
+        Provenance::AskProbe,
+        "no SD ⇒ the capability comes from the ASK fallback"
+    );
+    // …but the descriptor is the served VoID's statistics, not invented.
+    let desc = d
+        .descriptor
+        .expect("a served VoID ⇒ a descriptor even on the ASK-fallback path");
+    let p = desc
+        .predicate("http://xmlns.com/foaf/0.1/knows")
+        .expect("served property partition");
+    assert_eq!(p.triples, 200);
+}
+
+#[test]
+fn discover_malformed_void_is_silently_ignored() {
+    // A served SD (capability from SD) but a MALFORMED VoID: the VoID fetch is best-effort, so
+    // the descriptor is silently None — discovery still succeeds with the SD capability.
+    let endpoint = "http://host/sparql";
+    let fetcher = MapFetcher::new()
+        .with(endpoint, SD_SPARQL11)
+        .with("http://host/.well-known/void", "garbage <not void");
+    let d = discover(endpoint, &fetcher).expect("SD present ⇒ discovers even with bad VoID");
+    assert_eq!(d.provenance, Provenance::ServiceDescription);
+    assert!(
+        d.descriptor.is_none(),
+        "a malformed VoID must be silently ignored, not fatal, not invented"
+    );
+}
+
+#[test]
+fn discover_sd_present_but_no_void_leaves_descriptor_none() {
+    // A served SD, no VoID registered at all (404). The capability is the SD; the descriptor is
+    // None (no statistics published).
+    let endpoint = "http://host/sparql";
+    let fetcher = MapFetcher::new().with(endpoint, SD_SPARQL11);
+    let d = discover(endpoint, &fetcher).expect("SD-only endpoint discovers");
+    assert_eq!(d.provenance, Provenance::ServiceDescription);
+    assert_eq!(d.capability.sparql_version, Some(SparqlVersion::Sparql11));
+    assert!(d.descriptor.is_none(), "no VoID served ⇒ no descriptor");
+}
+
+#[test]
+fn discover_unreachable_when_nothing_answers() {
+    // No SD, no VoID, no ASK probe registered (every GET 404s) ⇒ not a reachable SPARQL service.
+    let fetcher = MapFetcher::new();
+    assert!(
+        discover("http://dead/sparql", &fetcher).is_err(),
+        "an endpoint that answers nothing must be a discovery error"
+    );
+}
+
+#[test]
+fn discover_ask_false_still_proves_reachability() {
+    // A false ASK answer STILL proves a live SPARQL service (it evaluated the query).
+    let endpoint = "http://empty/sparql";
+    let fetcher = MapFetcher::new().with(ask_url(endpoint), r#"{"boolean": false}"#);
+    let d = discover(endpoint, &fetcher).expect("a false ASK proves reachability");
+    assert_eq!(d.provenance, Provenance::AskProbe);
+}
+
+#[test]
+fn discover_ask_response_without_boolean_is_unreachable() {
+    // An ASK URL that returns a body with NO `boolean` field is not a valid ASK answer, so the
+    // endpoint is treated as unreachable (the parse_ask_boolean failure path through discover).
+    let endpoint = "http://confused/sparql";
+    let fetcher = MapFetcher::new().with(ask_url(endpoint), r#"{"results":{"bindings":[]}}"#);
+    assert!(
+        discover(endpoint, &fetcher).is_err(),
+        "an ASK response with no boolean field ⇒ not a reachable SPARQL endpoint"
+    );
+}
+
+// ─── parse_service_description — partial / unknown-version SD shapes ─────────────────────
+
+#[test]
+fn sd_with_service_but_no_language_is_recall_safe_unknown_version() {
+    // An sd:Service typed node with NO sd:supportedLanguage: version is unknown (None), and the
+    // recall-safe capability keeps FILTER pushable (Full) but does NOT claim aggregate / path /
+    // order-limit push (those are only granted to a declared SPARQL 1.1 service).
+    let nt = "<http://h/s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/sparql-service-description#Service> .\n";
+    let cap = parse_service_description(nt)
+        .expect("well-formed N-Triples")
+        .expect("an sd:Service is present");
+    assert_eq!(cap.interface, Interface::Endpoint);
+    assert_eq!(cap.sparql_version, None, "no supportedLanguage ⇒ unknown version");
+    assert_eq!(cap.pushable_filters, FilterClass::Full);
+    assert!(
+        !cap.aggregates && !cap.property_paths && !cap.order_limit,
+        "unknown version ⇒ no aggregate/path/order-limit push claim (recall-safe)"
+    );
+}
+
+#[test]
+fn sd_with_no_result_formats_does_not_claim_srj() {
+    // An sd:Service with no sd:resultFormat: result_formats is empty, so returns_sparql_results_json
+    // is false (the parser does not fabricate a format the SD did not advertise).
+    let nt = "<http://h/s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/sparql-service-description#Service> .\n";
+    let cap = parse_service_description(nt).unwrap().unwrap();
+    assert!(cap.result_formats.is_empty());
+    assert!(
+        !cap.returns_sparql_results_json(),
+        "no advertised resultFormat ⇒ returns_sparql_results_json is false"
+    );
+}
+
+#[test]
+fn sd_ignores_unknown_feature_iri() {
+    // An unknown sd:feature IRI (neither BasicFederatedQuery nor the PROV lineage feature) is
+    // silently ignored — the recognised flags stay at their recall-safe defaults.
+    let nt = format!(
+        "{SD_SPARQL11}<http://host/sparql> \
+         <http://www.w3.org/ns/sparql-service-description#feature> \
+         <http://example.org/some-unknown-feature> .\n"
+    );
+    let cap = parse_service_description(&nt).unwrap().unwrap();
+    assert!(
+        !cap.federated_query,
+        "an unknown feature IRI must NOT set federated_query"
+    );
+    assert!(
+        !cap.provenance_lineage,
+        "an unknown feature IRI must NOT set provenance_lineage"
+    );
+}
+
+#[test]
+fn parse_sd_over_a_void_document_returns_none() {
+    // A pure VoID document (no sd:Service) is NOT a Service Description ⇒ Ok(None), so the caller
+    // falls back to the ASK probe rather than treating VoID as a capability source.
+    let cap = parse_service_description(VOID_NT).expect("well-formed N-Triples");
+    assert!(cap.is_none(), "no sd:Service ⇒ not an SD ⇒ None");
+}
+
+// ─── well_known_void_url — authority extraction edge cases ──────────────────────────────
+
+#[test]
+fn well_known_void_url_handles_authority_edge_cases() {
+    // Query string and fragment after the path do not pollute the authority.
+    assert_eq!(
+        well_known_void_url("http://host/sparql?default-graph-uri=x").as_deref(),
+        Some("http://host/.well-known/void")
+    );
+    assert_eq!(
+        well_known_void_url("http://host/sparql#frag").as_deref(),
+        Some("http://host/.well-known/void")
+    );
+    // A non-standard port is preserved in the authority.
+    assert_eq!(
+        well_known_void_url("https://host:8080/db/sparql").as_deref(),
+        Some("https://host:8080/.well-known/void")
+    );
+    // An IPv6-literal authority keeps its brackets.
+    assert_eq!(
+        well_known_void_url("http://[::1]/sparql").as_deref(),
+        Some("http://[::1]/.well-known/void")
+    );
+    // An authority with no path still derives the well-known URL.
+    assert_eq!(
+        well_known_void_url("http://host").as_deref(),
+        Some("http://host/.well-known/void")
+    );
+    // No scheme / authority ⇒ None.
+    assert_eq!(well_known_void_url("not-a-url"), None);
+    assert_eq!(well_known_void_url("http:///nohost"), None);
+}
+
+// ─── Capability::ask_fallback + MediaType units ─────────────────────────────────────────
+
+#[test]
+fn ask_fallback_capability_is_conservative() {
+    // The FedX-style fallback: full SPARQL 1.1 + VALUES bind-join + SRJ, but NO aggregate /
+    // path / order-limit / update / federated-query / provenance push claim (recall-safe — an
+    // ASK-only endpoint published no SD).
+    let c = Capability::ask_fallback();
+    assert_eq!(c.interface, Interface::Endpoint);
+    assert_eq!(c.sparql_version, Some(SparqlVersion::Sparql11));
+    assert_eq!(c.pushable_filters, FilterClass::Full);
+    assert!(c.returns_sparql_results_json(), "SRJ is the mandatory format");
+    assert!(
+        !c.aggregates && !c.property_paths && !c.order_limit,
+        "the ASK fallback makes NO push claim beyond core evaluation"
+    );
+    assert!(!c.update && !c.federated_query && !c.provenance_lineage);
+}
+
+#[test]
+fn media_type_recognises_sparql_results_json_only() {
+    let srj = MediaType("http://www.w3.org/ns/formats/SPARQL_Results_JSON".to_string());
+    assert_eq!(srj.iri(), "http://www.w3.org/ns/formats/SPARQL_Results_JSON");
+    assert!(srj.is_sparql_results_json());
+    let turtle = MediaType("http://www.w3.org/ns/formats/Turtle".to_string());
+    assert!(
+        !turtle.is_sparql_results_json(),
+        "a non-SRJ format must not be recognised as SRJ"
+    );
+}

--- a/crates/sparq-fedclient/tests/interpreter_error_paths.rs
+++ b/crates/sparq-fedclient/tests/interpreter_error_paths.rs
@@ -1,0 +1,367 @@
+//! sq-bif.2 — federation OPERATOR-interpreter error-path + edge-case suite.
+//!
+//! The crate's correctness tests (`planner_result_equals_local_eval`,
+//! `streaming_result_equals_phase3`, `multi_source_union_result_equals_local`) drive the
+//! interpreter down the SUCCESS path against an engine-backed transport. They never make the
+//! transport fail, so the interpreter's three error-surfacing branches —
+//! [`InterpError::Source`] (a transport / SSRF / unsupported `FedError`),
+//! [`InterpError::BadSrj`] (a malformed SRJ body), and [`InterpError::Resolve`] (a plan index
+//! out of range) — went untested through the public `materialize_single_source` /
+//! `stream_single_source` entry points. This file drives each through the REAL interpreter
+//! (a controllable [`Transport`] double, no network) and asserts the right variant is
+//! surfaced, fail-closed, for BOTH the materialised and the streaming interpreter.
+//!
+//! It also covers natural-join CORRECTNESS edge cases the success tests do not isolate —
+//! a join whose two leaves never share a binding is empty, a join key that is unbound on one
+//! side never equi-joins, and a fan-out preserves multiplicity — all asserted on the public
+//! interpreter via [`solutions_equal`].
+//!
+//! Gated on `fedclient`; the default build compiles this file to nothing.
+//!
+//! [OPUS-4.8] sq-bif.2 — flagged for Fable re-review when available.
+
+#![cfg(feature = "fedclient")]
+
+use sparq_fedclient::{
+    materialize_single_source, solutions_equal, stream_single_source, Endpoint, FederatedSource,
+    InterpError, Relation, SourceResolver, StreamOptions, Transport,
+};
+use sparq_fedplan::{
+    plan_bgp, select_sources, Bgp, PlanOptions, PredPartition, SourceDescriptor, SourceId, Term,
+    TriplePattern, Var,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn iri(s: &str) -> Term {
+    Term::Iri(s.to_string())
+}
+fn var(s: &str) -> Term {
+    Term::Var(Var::new(s))
+}
+
+/// A transport that always fails with a fixed error string — models a remote endpoint that is
+/// down / returns 5xx. The interpreter must surface this as `InterpError::Source(Transport)`.
+struct FailingTransport(String);
+impl Transport for FailingTransport {
+    fn fetch(&self, _endpoint: &str, _query: &str) -> Result<String, String> {
+        Err(self.0.clone())
+    }
+}
+
+/// A transport that answers each sub-query from a fixed (SPARQL → body) map; an unmapped query
+/// returns the body in `default` (so we can return MALFORMED SRJ for a specific leaf).
+struct MapTransport {
+    answers: HashMap<String, String>,
+    default: String,
+}
+impl Transport for MapTransport {
+    fn fetch(&self, _endpoint: &str, query: &str) -> Result<String, String> {
+        Ok(self
+            .answers
+            .get(query)
+            .cloned()
+            .unwrap_or_else(|| self.default.clone()))
+    }
+}
+
+/// A `Send + Sync` `FederatedSource` wrapper so the streaming interpreter (which needs
+/// `Arc<dyn FederatedSource + Send + Sync>`) can drive the same `Endpoint` adapter.
+struct SyncSource {
+    endpoint: Endpoint,
+}
+impl FederatedSource for SyncSource {
+    fn source_type(&self) -> sparq_fedclient::SourceType<'_> {
+        self.endpoint.source_type()
+    }
+    fn discover(
+        &self,
+    ) -> Result<(sparq_fedclient::Capability, Option<SourceDescriptor>), sparq_fedclient::FedError>
+    {
+        self.endpoint.discover()
+    }
+    fn execute(
+        &self,
+        sub: &sparq_fedclient::SubQuery,
+    ) -> Result<String, sparq_fedclient::FedError> {
+        self.endpoint.execute(sub)
+    }
+}
+
+fn one_pred_descriptor(pred: &str) -> SourceDescriptor {
+    SourceDescriptor::builder(SourceId::new("S"))
+        .total_triples(100)
+        .predicate(PredPartition {
+            predicate: pred.into(),
+            triples: 10,
+            distinct_subjects: 5,
+            distinct_objects: 5,
+        })
+        .build()
+}
+
+/// A one-pattern BGP `?s <pred> ?o` + its plan over the single descriptor.
+fn one_pattern_plan(pred: &str) -> (Bgp, Vec<sparq_fedplan::PatternSources>, sparq_fedplan::JoinTree) {
+    let bgp = Bgp::new(vec![TriplePattern::new(var("s"), iri(pred), var("o"))]);
+    let descriptors = [one_pred_descriptor(pred)];
+    let sel = select_sources(&bgp, &descriptors);
+    let tree = plan_bgp(&bgp, &sel, &descriptors, &PlanOptions::default()).expect("plans");
+    (bgp, sel, tree)
+}
+
+// ─── InterpError::Source — a transport failure is surfaced (both interpreters) ──────────
+
+#[test]
+fn materialise_surfaces_transport_failure_as_source_error() {
+    let (bgp, sel, tree) = one_pattern_plan("http://ex/p");
+    let ep = Endpoint::new(
+        // A public IP literal so the SSRF gate ALLOWS, and the transport — not the gate — is
+        // what fails (we are testing the transport-error branch, not egress refusal).
+        "http://8.8.8.8/sparql",
+        Box::new(FailingTransport("endpoint returned HTTP 503".into())),
+    );
+    let adapters: Vec<&dyn FederatedSource> = vec![&ep];
+    let resolver = SourceResolver::new(&bgp, &adapters);
+    let err = materialize_single_source(&resolver, &sel, &ep, &tree).unwrap_err();
+    match err {
+        InterpError::Source(fe) => assert!(
+            fe.to_string().contains("503"),
+            "the transport error string must be forwarded verbatim, got {}",
+            fe
+        ),
+        other => panic!("expected InterpError::Source, got {:?}", other),
+    }
+}
+
+#[test]
+fn stream_surfaces_transport_failure_as_error_item() {
+    let (bgp, sel, tree) = one_pattern_plan("http://ex/p");
+    let ep = Endpoint::new(
+        "http://8.8.8.8/sparql",
+        Box::new(FailingTransport("connection refused".into())),
+    );
+    let arc: Arc<dyn FederatedSource + Send + Sync> = Arc::new(SyncSource {
+        endpoint: Endpoint::new(
+            "http://8.8.8.8/sparql",
+            Box::new(FailingTransport("connection refused".into())),
+        ),
+    });
+    // The resolver needs an adapter slice for index typing; the streaming interpreter answers
+    // every leaf through `arc`.
+    let adapters: Vec<&dyn FederatedSource> = vec![&ep];
+    let resolver = SourceResolver::new(&bgp, &adapters);
+    let stream = stream_single_source(&resolver, &sel, arc, &tree, &StreamOptions::default())
+        .expect("the stream BUILDS even though the producer will error");
+    // Draining the stream surfaces the producer's error as a terminal error item.
+    let drained = stream.collect_solutions();
+    assert!(
+        drained.is_err(),
+        "a failing transport must surface as a stream error, not silent empty"
+    );
+}
+
+// ─── InterpError::BadSrj — a malformed remote body is surfaced ──────────────────────────
+
+#[test]
+fn materialise_surfaces_malformed_srj_as_bad_srj() {
+    let (bgp, sel, tree) = one_pattern_plan("http://ex/p");
+    // The transport "succeeds" (returns a 200 body) but the body is not valid SRJ.
+    let ep = Endpoint::new(
+        "http://8.8.8.8/sparql",
+        Box::new(MapTransport {
+            answers: HashMap::new(),
+            default: "<html>404 not found</html>".to_string(),
+        }),
+    );
+    let adapters: Vec<&dyn FederatedSource> = vec![&ep];
+    let resolver = SourceResolver::new(&bgp, &adapters);
+    let err = materialize_single_source(&resolver, &sel, &ep, &tree).unwrap_err();
+    assert!(
+        matches!(err, InterpError::BadSrj(_)),
+        "a non-SRJ 200 body must surface as BadSrj, got {:?}",
+        err
+    );
+}
+
+#[test]
+fn materialise_surfaces_ask_boolean_body_as_bad_srj() {
+    // A SELECT leaf answered by an ASK boolean body is a malformed result for the join.
+    let (bgp, sel, tree) = one_pattern_plan("http://ex/p");
+    let ep = Endpoint::new(
+        "http://8.8.8.8/sparql",
+        Box::new(MapTransport {
+            answers: HashMap::new(),
+            default: r#"{"head":{},"boolean":true}"#.to_string(),
+        }),
+    );
+    let adapters: Vec<&dyn FederatedSource> = vec![&ep];
+    let resolver = SourceResolver::new(&bgp, &adapters);
+    let err = materialize_single_source(&resolver, &sel, &ep, &tree).unwrap_err();
+    match err {
+        InterpError::BadSrj(m) => assert!(m.contains("ASK"), "got {}", m),
+        other => panic!("expected BadSrj, got {:?}", other),
+    }
+}
+
+// ─── InterpError::Resolve — a plan/resolver mismatch fails closed ───────────────────────
+
+#[test]
+fn resolver_built_with_empty_bgp_fails_closed_on_pattern_index() {
+    // Plan a 1-pattern BGP, but hand the resolver an EMPTY BGP, so the plan's pattern index 0
+    // is out of range for the resolver — the interpreter must surface Resolve, not panic.
+    let (_planned_bgp, sel, tree) = one_pattern_plan("http://ex/p");
+    let empty_bgp = Bgp::new(vec![]);
+    let ep = Endpoint::new(
+        "http://8.8.8.8/sparql",
+        Box::new(MapTransport {
+            answers: HashMap::new(),
+            default: r#"{"head":{"vars":["s","o"]},"results":{"bindings":[]}}"#.to_string(),
+        }),
+    );
+    let adapters: Vec<&dyn FederatedSource> = vec![&ep];
+    let resolver = SourceResolver::new(&empty_bgp, &adapters);
+    let err = materialize_single_source(&resolver, &sel, &ep, &tree).unwrap_err();
+    assert!(
+        matches!(err, InterpError::Resolve(_)),
+        "an out-of-range plan pattern index must fail closed with Resolve, got {:?}",
+        err
+    );
+}
+
+// ─── Natural-join correctness edge cases (via the public materialised interpreter) ──────
+
+/// SRJ for a two-column leaf `?<va> <pred> ?<vb>`, rows as `(a-iri, b-iri)` pairs. The header
+/// var names MUST match the variables `lower_leaf` projects for the pattern, else the relation's
+/// columns are misnamed and the join key never lines up.
+fn srj_pairs(va: &str, vb: &str, pairs: &[(&str, &str)]) -> String {
+    let mut s = format!(r#"{{"head":{{"vars":["{}","{}"]}},"results":{{"bindings":["#, va, vb);
+    for (i, (a, b)) in pairs.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&format!(
+            r#"{{"{}":{{"type":"uri","value":"{}"}},"{}":{{"type":"uri","value":"{}"}}}}"#,
+            va, a, vb, b
+        ));
+    }
+    s.push_str("]}}");
+    s
+}
+
+#[test]
+fn join_with_no_shared_binding_is_empty() {
+    // ?s :p ?o . ?o :q ?z — a path join on ?o. The :p objects and the :q subjects are disjoint,
+    // so the join is empty (not error, not a spurious row).
+    let bgp = Bgp::new(vec![
+        TriplePattern::new(var("s"), iri("http://ex/p"), var("o")),
+        TriplePattern::new(var("o"), iri("http://ex/q"), var("z")),
+    ]);
+    let descriptors = [SourceDescriptor::builder(SourceId::new("S"))
+        .total_triples(100)
+        .predicate(PredPartition {
+            predicate: "http://ex/p".into(),
+            triples: 10,
+            distinct_subjects: 5,
+            distinct_objects: 5,
+        })
+        .predicate(PredPartition {
+            predicate: "http://ex/q".into(),
+            triples: 10,
+            distinct_subjects: 5,
+            distinct_objects: 5,
+        })
+        .build()];
+    let sel = select_sources(&bgp, &descriptors);
+    let tree = plan_bgp(&bgp, &sel, &descriptors, &PlanOptions::default()).unwrap();
+
+    let mut answers = HashMap::new();
+    // ?s :p ?o → o ∈ {o1, o2}
+    answers.insert(
+        "SELECT ?s ?o WHERE { ?s <http://ex/p> ?o }".to_string(),
+        srj_pairs("s", "o", &[("http://ex/s1", "http://ex/o1"), ("http://ex/s2", "http://ex/o2")]),
+    );
+    // ?o :q ?z → subjects {oX} — DISJOINT from {o1, o2} ⇒ empty join on ?o.
+    answers.insert(
+        "SELECT ?o ?z WHERE { ?o <http://ex/q> ?z }".to_string(),
+        srj_pairs("o", "z", &[("http://ex/oX", "http://ex/zX")]),
+    );
+
+    let ep = Endpoint::new(
+        "http://8.8.8.8/sparql",
+        Box::new(MapTransport {
+            answers,
+            default: r#"{"head":{"vars":["s","o"]},"results":{"bindings":[]}}"#.to_string(),
+        }),
+    );
+    let adapters: Vec<&dyn FederatedSource> = vec![&ep];
+    let resolver = SourceResolver::new(&bgp, &adapters);
+    let rel = materialize_single_source(&resolver, &sel, &ep, &tree).unwrap();
+    assert!(
+        rel.rows.is_empty(),
+        "a join over disjoint join keys must be empty, got {:?}",
+        rel.rows
+    );
+}
+
+#[test]
+fn join_preserves_multiplicity_fan_out() {
+    // ?s :p ?o . ?s :q ?z — a star on ?s where s1 has TWO :q values ⇒ the join fans s1's single
+    // :p row to TWO output rows (bag semantics: multiplicity is preserved, not de-duplicated).
+    let bgp = Bgp::new(vec![
+        TriplePattern::new(var("s"), iri("http://ex/p"), var("o")),
+        TriplePattern::new(var("s"), iri("http://ex/q"), var("z")),
+    ]);
+    let descriptors = [SourceDescriptor::builder(SourceId::new("S"))
+        .total_triples(100)
+        .predicate(PredPartition {
+            predicate: "http://ex/p".into(),
+            triples: 10,
+            distinct_subjects: 5,
+            distinct_objects: 5,
+        })
+        .predicate(PredPartition {
+            predicate: "http://ex/q".into(),
+            triples: 10,
+            distinct_subjects: 5,
+            distinct_objects: 5,
+        })
+        .build()];
+    let sel = select_sources(&bgp, &descriptors);
+    let tree = plan_bgp(&bgp, &sel, &descriptors, &PlanOptions::default()).unwrap();
+
+    let mut answers = HashMap::new();
+    answers.insert(
+        "SELECT ?s ?o WHERE { ?s <http://ex/p> ?o }".to_string(),
+        srj_pairs("s", "o", &[("http://ex/s1", "http://ex/o1")]),
+    );
+    // s1 has two :q values ⇒ two join partners.
+    answers.insert(
+        "SELECT ?s ?z WHERE { ?s <http://ex/q> ?z }".to_string(),
+        srj_pairs("s", "z", &[("http://ex/s1", "http://ex/z1"), ("http://ex/s1", "http://ex/z2")]),
+    );
+
+    let ep = Endpoint::new(
+        "http://8.8.8.8/sparql",
+        Box::new(MapTransport {
+            answers,
+            default: r#"{"head":{"vars":["s","o"]},"results":{"bindings":[]}}"#.to_string(),
+        }),
+    );
+    let adapters: Vec<&dyn FederatedSource> = vec![&ep];
+    let resolver = SourceResolver::new(&bgp, &adapters);
+    let rel: Relation = materialize_single_source(&resolver, &sel, &ep, &tree).unwrap();
+    assert_eq!(rel.rows.len(), 2, "the fan-out must yield two rows (multiplicity preserved)");
+    // Both rows share s1+o1 and differ only in ?z — assert the exact multiset.
+    use oxrdf::NamedNode;
+    let nn = |s: &str| Some(oxrdf::Term::NamedNode(NamedNode::new(s).unwrap()));
+    let expect_vars = vec!["s".to_string(), "o".to_string(), "z".to_string()];
+    let expect = vec![
+        vec![nn("http://ex/s1"), nn("http://ex/o1"), nn("http://ex/z1")],
+        vec![nn("http://ex/s1"), nn("http://ex/o1"), nn("http://ex/z2")],
+    ];
+    assert!(
+        solutions_equal(&rel.vars, &rel.rows, &expect_vars, &expect),
+        "fan-out result multiset mismatch: got {:?}",
+        rel.rows
+    );
+}

--- a/crates/sparq-fedclient/tests/source_adapter_error_paths.rs
+++ b/crates/sparq-fedclient/tests/source_adapter_error_paths.rs
@@ -1,0 +1,265 @@
+//! sq-bif.2 — source-adapter (transport / wire / fragment) error-path suite.
+//!
+//! The inline `source` tests cover the SSRF guard (deny / allow), the happy Endpoint fetch, and
+//! the fragment completeness invariant against an always-succeeding fixture server. This file
+//! targets the ADAPTER-level error and edge branches the inline suite does not:
+//!
+//!  * the [`Endpoint`] adapter forwarding a **transport error** as [`FedError::Transport`]
+//!    (after the SSRF gate ALLOWS — a public IP literal, so the transport, not the gate, fails);
+//!  * the SSRF guard refusing a **DNS name that resolves only to private/internal** addresses
+//!    (`localhost`) and an endpoint **with no host authority** ([`FedError::BadEndpoint`]);
+//!  * a [`FragmentTransport`] that returns an **error** — surfaced as [`FedError::Transport`]
+//!    through both [`TpfSource::solutions`] and [`BrTpfSource::solutions`];
+//!  * a fragment server whose pages **never terminate** (no `hydra:next` end) is fail-stopped by
+//!    the page-cap rather than looping forever;
+//!  * the [`Capability`] per-interface defaults + the brTPF `maxMpR` clamp + `FragPattern::vars`
+//!    repeated-variable de-duplication, units the success path exercises only incidentally.
+//!
+//! All hermetic — a controllable in-memory transport double, no network.
+//!
+//! Gated on `fedclient`; the default build compiles this file to nothing.
+//!
+//! [OPUS-4.8] sq-bif.2 — flagged for Fable re-review when available.
+
+#![cfg(feature = "fedclient")]
+
+use sparq_fedclient::{
+    BindJoin, BrTpfSource, Capability, EgressGuard, Endpoint, FedError, FederatedSource,
+    FragPattern, FragTerm, FragTriple, FragmentPage, FragmentTransport, Interface, PatternTerm,
+    SubQuery, TpfSource, Transport,
+};
+
+// ─── Endpoint adapter: transport error → FedError::Transport (after egress ALLOWS) ──────
+
+/// A transport that always fails with a fixed error string.
+struct FailingTransport(&'static str);
+impl Transport for FailingTransport {
+    fn fetch(&self, _endpoint: &str, _query: &str) -> Result<String, String> {
+        Err(self.0.to_string())
+    }
+}
+
+#[test]
+fn endpoint_forwards_transport_error_verbatim() {
+    // A PUBLIC IP literal so the default-deny guard ALLOWS; the transport then fails, and the
+    // adapter surfaces the transport's error string as FedError::Transport (verbatim).
+    let ep = Endpoint::new(
+        "http://8.8.8.8/sparql",
+        Box::new(FailingTransport("upstream timed out")),
+    );
+    let err = ep.execute(&SubQuery::new("SELECT * WHERE { ?s ?p ?o }")).unwrap_err();
+    match err {
+        FedError::Transport(m) => assert_eq!(m, "upstream timed out"),
+        other => panic!("expected FedError::Transport, got {:?}", other),
+    }
+}
+
+// ─── EgressGuard: DNS-name resolving only to private, and no-host authority ─────────────
+
+#[test]
+fn guard_refuses_localhost_dns_name() {
+    // `localhost` resolves only to loopback (127.0.0.1 / ::1); the default-deny guard must
+    // refuse it on the resolved IP (DNS-rebinding-safe), with EgressRefused.
+    let g = EgressGuard::deny_private();
+    let err = g.check_endpoint("http://localhost:7000/sparql").unwrap_err();
+    assert!(
+        matches!(err, FedError::EgressRefused(_)),
+        "localhost resolves only to loopback ⇒ refused, got {:?}",
+        err
+    );
+}
+
+#[test]
+fn guard_rejects_endpoint_with_no_host() {
+    // An endpoint IRI with no host authority cannot be vetted ⇒ BadEndpoint.
+    let g = EgressGuard::deny_private();
+    let err = g.check_endpoint("http:///no-host/sparql").unwrap_err();
+    assert!(
+        matches!(err, FedError::BadEndpoint(_)),
+        "no host authority ⇒ BadEndpoint, got {:?}",
+        err
+    );
+}
+
+#[test]
+fn endpoint_execute_refuses_private_before_transport() {
+    // A private endpoint must be refused at the SSRF gate BEFORE the transport is reached — the
+    // PanicTransport proves no fetch happens.
+    struct PanicTransport;
+    impl Transport for PanicTransport {
+        fn fetch(&self, _e: &str, _q: &str) -> Result<String, String> {
+            panic!("the transport must not be reached when the egress gate denies");
+        }
+    }
+    let ep = Endpoint::new("http://10.1.2.3/sparql", Box::new(PanicTransport));
+    let err = ep.execute(&SubQuery::new("ASK {}")).unwrap_err();
+    assert!(matches!(err, FedError::EgressRefused(_)), "got {:?}", err);
+}
+
+// ─── Fragment adapters: a transport error → FedError::Transport ─────────────────────────
+
+/// A fragment transport that always fails.
+struct FailingFragments(&'static str);
+impl FragmentTransport for FailingFragments {
+    fn fetch_fragment(
+        &self,
+        _url: &str,
+        _pattern: &FragPattern,
+        _bindings: &[Vec<(String, FragTerm)>],
+        _page: Option<&str>,
+    ) -> Result<FragmentPage, String> {
+        Err(self.0.to_string())
+    }
+}
+
+fn knows_pattern() -> FragPattern {
+    FragPattern::new(
+        PatternTerm::Var("s".into()),
+        PatternTerm::Bound(FragTerm::iri("http://xmlns.com/foaf/0.1/knows")),
+        PatternTerm::Var("o".into()),
+    )
+}
+
+#[test]
+fn tpf_solutions_surfaces_fragment_transport_error() {
+    let tpf = TpfSource::new("http://frag/tpf", Box::new(FailingFragments("502 bad gateway")));
+    let err = tpf.solutions(&knows_pattern()).unwrap_err();
+    match err {
+        FedError::Transport(m) => assert!(m.contains("502"), "got {}", m),
+        other => panic!("expected FedError::Transport, got {:?}", other),
+    }
+}
+
+#[test]
+fn brtpf_solutions_surfaces_fragment_transport_error() {
+    let brtpf = BrTpfSource::new("http://frag/brtpf", 10, Box::new(FailingFragments("dns failure")));
+    // Even with an upstream binding block, the first fetch fails and is surfaced.
+    let bindings = vec![vec![("s".to_string(), FragTerm::iri("http://ex/alice"))]];
+    let err = brtpf.solutions(&knows_pattern(), &bindings).unwrap_err();
+    assert!(matches!(err, FedError::Transport(_)), "got {:?}", err);
+}
+
+#[test]
+fn fragment_execute_routes_to_solutions_not_srj() {
+    // A fragment source's SRJ `execute` is intentionally Unsupported (it speaks triples), and
+    // points the caller at the typed `solutions` method.
+    let tpf = TpfSource::new("http://frag/tpf", Box::new(FailingFragments("x")));
+    let err = tpf.execute(&SubQuery::new("SELECT * WHERE { ?s ?p ?o }")).unwrap_err();
+    assert!(matches!(err, FedError::Unsupported(_)), "got {:?}", err);
+}
+
+// ─── Fragment pagination: a never-terminating server is fail-stopped by the page cap ────
+
+/// A misbehaving fragment server that ALWAYS returns a `next` token (never `None`), so a naive
+/// drainer would loop forever. The adapter's page cap must fail-stop it with a transport error.
+struct InfinitePager;
+impl FragmentTransport for InfinitePager {
+    fn fetch_fragment(
+        &self,
+        _url: &str,
+        pattern: &FragPattern,
+        _bindings: &[Vec<(String, FragTerm)>],
+        page: Option<&str>,
+    ) -> Result<FragmentPage, String> {
+        // Each page returns one matching triple and ALWAYS a next token (monotonic counter).
+        let n: u64 = page
+            .and_then(|t| t.strip_prefix("p:"))
+            .and_then(|n| n.parse().ok())
+            .unwrap_or(0);
+        let triple = FragTriple::new(
+            FragTerm::iri(format!("http://ex/s{}", n)),
+            FragTerm::iri("http://xmlns.com/foaf/0.1/knows"),
+            FragTerm::iri(format!("http://ex/o{}", n)),
+        );
+        // Only emit a data triple that actually matches the requested pattern.
+        let triples = if pattern.predicate
+            == PatternTerm::Bound(FragTerm::iri("http://xmlns.com/foaf/0.1/knows"))
+        {
+            vec![triple]
+        } else {
+            vec![]
+        };
+        Ok(FragmentPage {
+            triples,
+            total_items: u64::MAX,
+            next: Some(format!("p:{}", n + 1)), // NEVER None — runs forever without the cap.
+        })
+    }
+}
+
+#[test]
+fn fragment_pagination_is_fail_stopped_by_page_cap() {
+    // A server that never sets next = None is bounded by the defensive page cap, surfacing a
+    // clean transport error rather than hanging the client. (The cap is ~1e6 pages; this test
+    // proves the cap EXISTS and fail-stops — a real server terminates well within it.)
+    //
+    // NOTE: this drains up to the cap, so it is intentionally a heavier test; it still completes
+    // in well under a second because each fixture page is trivial.
+    let tpf = TpfSource::new("http://frag/runaway", Box::new(InfinitePager));
+    let err = tpf.solutions(&knows_pattern()).unwrap_err();
+    match err {
+        FedError::Transport(m) => assert!(
+            m.contains("pagination") && m.contains("cap"),
+            "the runaway pager must fail-stop with a page-cap transport error, got {}",
+            m
+        ),
+        other => panic!("expected a page-cap Transport error, got {:?}", other),
+    }
+}
+
+// ─── Capability defaults + maxMpR clamp + FragPattern::vars dedup ───────────────────────
+
+#[test]
+fn capability_defaults_match_interface() {
+    let e = Capability::endpoint();
+    assert_eq!(e.interface, Interface::Endpoint);
+    assert_eq!(e.bind_join, BindJoin::Values);
+    assert!(e.aggregates && e.property_paths && e.order_limit);
+
+    let l = Capability::local();
+    assert_eq!(l.interface, Interface::LocalEngine);
+    assert_eq!(l.bind_join, BindJoin::Values, "local engine inherits endpoint caps");
+
+    let b = Capability::brtpf(42);
+    assert_eq!(b.interface, Interface::BrTpf);
+    assert_eq!(b.bind_join, BindJoin::MaxMpR(42));
+    assert!(!b.aggregates && !b.property_paths && !b.order_limit);
+
+    let t = Capability::tpf();
+    assert_eq!(t.interface, Interface::Tpf);
+    assert_eq!(t.bind_join, BindJoin::None);
+}
+
+#[test]
+fn frag_pattern_vars_dedups_repeated_variable() {
+    // ?x knows ?x — the same variable in subject + object position is projected once.
+    let pat = FragPattern::new(
+        PatternTerm::Var("x".into()),
+        PatternTerm::Bound(FragTerm::iri("http://xmlns.com/foaf/0.1/knows")),
+        PatternTerm::Var("x".into()),
+    );
+    assert_eq!(pat.vars(), vec!["x".to_string()]);
+    // A fully-variable pattern projects all three distinct names in subject→predicate→object order.
+    let triple = FragPattern::new(
+        PatternTerm::Var("s".into()),
+        PatternTerm::Var("p".into()),
+        PatternTerm::Var("o".into()),
+    );
+    assert_eq!(
+        triple.vars(),
+        vec!["s".to_string(), "p".to_string(), "o".to_string()]
+    );
+    // A fully-bound pattern projects nothing.
+    let bound = FragPattern::new(
+        PatternTerm::Bound(FragTerm::iri("http://ex/a")),
+        PatternTerm::Bound(FragTerm::iri("http://ex/p")),
+        PatternTerm::Bound(FragTerm::iri("http://ex/b")),
+    );
+    assert!(bound.vars().is_empty());
+}
+
+#[test]
+fn pattern_term_as_var_distinguishes_var_from_bound() {
+    assert_eq!(PatternTerm::Var("s".into()).as_var(), Some("s"));
+    assert_eq!(PatternTerm::Bound(FragTerm::iri("http://ex/a")).as_var(), None);
+}

--- a/crates/sparq-fedclient/tests/srj_parse_correctness.rs
+++ b/crates/sparq-fedclient/tests/srj_parse_correctness.rs
@@ -1,0 +1,331 @@
+//! sq-bif.2 — SPARQL-Results-JSON (SRJ) parser correctness + error-path suite.
+//!
+//! [`parse_srj`](sparq_fedclient::parse_srj) is the load-bearing wire-decode of the federation
+//! interpreter: every endpoint leaf result enters the join through it, so a misbehaving or
+//! adversarial remote endpoint is its threat model. The crate's inline tests cover the happy
+//! `uri`/`literal` round-trip + the ASK-boolean rejection + invalid JSON, but the rich
+//! per-term-kind and structural ERROR branches of `parse_srj` / `srj_term` were untested. This
+//! file targets exactly those uncovered branches against the REAL parser (no mock), asserting
+//! each malformed/partial shape is a clean `Err` (never a panic, never a wrong term) and each
+//! well-formed-but-previously-untested term kind (bnode / typed-literal / language tag /
+//! RDF-1.2 directional literal / RDF-star triple term) decodes to the exact `oxrdf::Term`.
+//!
+//! It also exercises [`solutions_equal`](sparq_fedclient::solutions_equal) on the **negative**
+//! side — distinct multisets, different multiplicities, different bound terms must compare
+//! UNEQUAL — the inline suite only asserted the positive (order-independence) direction.
+//!
+//! Gated on `fedclient`; the default build compiles this file to nothing.
+//!
+//! [OPUS-4.8] sq-bif.2 — flagged for Fable re-review when available.
+
+#![cfg(feature = "fedclient")]
+
+use oxrdf::{BlankNode, Literal, NamedNode, Term};
+use sparq_fedclient::{parse_srj, solutions_equal};
+
+fn nn(s: &str) -> Term {
+    Term::NamedNode(NamedNode::new(s).unwrap())
+}
+
+// ─── Structural error paths (the body shape itself is wrong) ────────────────────────────
+
+#[test]
+fn missing_head_vars_is_clean_error() {
+    // A body with valid results.bindings but NO head.vars — the parser cannot name the columns.
+    let err = parse_srj(r#"{"head":{},"results":{"bindings":[]}}"#).unwrap_err();
+    assert!(err.contains("head.vars"), "got {}", err);
+}
+
+#[test]
+fn missing_results_bindings_is_clean_error() {
+    // Valid head.vars but NO results.bindings array.
+    let err = parse_srj(r#"{"head":{"vars":["x"]},"results":{}}"#).unwrap_err();
+    assert!(err.contains("results.bindings"), "got {}", err);
+}
+
+#[test]
+fn results_bindings_not_array_is_clean_error() {
+    // results.bindings present but the wrong JSON type (an object, not an array).
+    let err = parse_srj(r#"{"head":{"vars":["x"]},"results":{"bindings":{}}}"#).unwrap_err();
+    assert!(err.contains("results.bindings"), "got {}", err);
+}
+
+#[test]
+fn solution_binding_not_object_is_clean_error() {
+    // A binding element that is not a JSON object (an array here) — a misbehaving server.
+    let err = parse_srj(r#"{"head":{"vars":["x"]},"results":{"bindings":[[]]}}"#).unwrap_err();
+    assert!(err.contains("not a JSON object"), "got {}", err);
+}
+
+#[test]
+fn invalid_json_is_clean_error() {
+    // Not JSON at all — surfaced as a parse error, never a panic.
+    assert!(parse_srj("definitely { not json").is_err());
+    assert!(parse_srj("").is_err());
+}
+
+#[test]
+fn ask_boolean_body_is_rejected_for_select() {
+    // An ASK response body has a top-level `boolean`; the SELECT interpreter must refuse it
+    // rather than silently return an empty relation.
+    let err = parse_srj(r#"{"head":{},"boolean":false}"#).unwrap_err();
+    assert!(err.contains("ASK"), "got {}", err);
+}
+
+// ─── Per-cell term-kind error paths (srj_term branches) ─────────────────────────────────
+
+#[test]
+fn uri_cell_missing_value_is_bad_iri() {
+    // A `uri` cell with no `value` defaults to the empty string, which is not a valid IRI.
+    let err = parse_srj(r#"{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"uri"}}]}}"#)
+        .unwrap_err();
+    assert!(err.contains("bad IRI"), "got {}", err);
+}
+
+#[test]
+fn bnode_cell_missing_value_is_bad_bnode() {
+    let err =
+        parse_srj(r#"{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"bnode"}}]}}"#)
+            .unwrap_err();
+    assert!(err.contains("bad bnode"), "got {}", err);
+}
+
+#[test]
+fn literal_cell_missing_value_is_clean_error() {
+    let err =
+        parse_srj(r#"{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"literal"}}]}}"#)
+            .unwrap_err();
+    assert!(err.contains("value"), "got {}", err);
+}
+
+#[test]
+fn typed_literal_bad_datatype_iri_is_clean_error() {
+    // A `datatype` that is not a valid IRI must error, not panic.
+    let err = parse_srj(
+        r#"{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"typed-literal","value":"v","datatype":"not an iri"}}]}}"#,
+    )
+    .unwrap_err();
+    assert!(err.contains("bad datatype"), "got {}", err);
+}
+
+#[test]
+fn literal_bad_language_tag_is_clean_error() {
+    // An invalid BCP47 language tag must error.
+    let err = parse_srj(
+        r#"{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"literal","value":"v","xml:lang":"bad lang!!"}}]}}"#,
+    )
+    .unwrap_err();
+    assert!(err.contains("language tag"), "got {}", err);
+}
+
+#[test]
+fn unknown_binding_type_is_clean_error() {
+    let err = parse_srj(
+        r#"{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"banana","value":"v"}}]}}"#,
+    )
+    .unwrap_err();
+    assert!(err.contains("unknown binding type"), "got {}", err);
+}
+
+// ─── RDF-star triple-term branches (srj_term "triple") ──────────────────────────────────
+
+#[test]
+fn triple_term_round_trips() {
+    // A well-formed SPARQL-1.2 triple term decodes to a Term::Triple with the exact inner terms.
+    let rel = parse_srj(
+        r#"{"head":{"vars":["t"]},"results":{"bindings":[{"t":{"type":"triple","value":{
+            "subject":{"type":"uri","value":"http://ex/s"},
+            "predicate":{"type":"uri","value":"http://ex/p"},
+            "object":{"type":"literal","value":"o"}}}}]}}"#,
+    )
+    .unwrap();
+    assert_eq!(rel.vars, vec!["t"]);
+    assert_eq!(rel.rows.len(), 1);
+    match &rel.rows[0][0] {
+        Some(Term::Triple(t)) => {
+            assert_eq!(t.subject.to_string(), "<http://ex/s>");
+            assert_eq!(t.predicate.as_str(), "http://ex/p");
+            assert_eq!(t.object, Term::Literal(Literal::new_simple_literal("o")));
+        }
+        other => panic!("expected a triple term, got {:?}", other),
+    }
+}
+
+#[test]
+fn triple_term_missing_value_is_clean_error() {
+    let err = parse_srj(
+        r#"{"head":{"vars":["t"]},"results":{"bindings":[{"t":{"type":"triple"}}]}}"#,
+    )
+    .unwrap_err();
+    assert!(err.contains("triple term without value"), "got {}", err);
+}
+
+#[test]
+fn triple_term_missing_component_is_clean_error() {
+    // subject + predicate present but object absent.
+    let err = parse_srj(
+        r#"{"head":{"vars":["t"]},"results":{"bindings":[{"t":{"type":"triple","value":{
+            "subject":{"type":"uri","value":"http://ex/s"},
+            "predicate":{"type":"uri","value":"http://ex/p"}}}}]}}"#,
+    )
+    .unwrap_err();
+    assert!(err.contains("triple term without object"), "got {}", err);
+}
+
+#[test]
+fn triple_term_invalid_predicate_is_clean_error() {
+    // A triple-term predicate that is a blank node (not an IRI) is invalid RDF.
+    let err = parse_srj(
+        r#"{"head":{"vars":["t"]},"results":{"bindings":[{"t":{"type":"triple","value":{
+            "subject":{"type":"uri","value":"http://ex/s"},
+            "predicate":{"type":"bnode","value":"b"},
+            "object":{"type":"literal","value":"o"}}}}]}}"#,
+    )
+    .unwrap_err();
+    assert!(err.contains("invalid triple-term predicate"), "got {}", err);
+}
+
+#[test]
+fn triple_term_invalid_subject_is_clean_error() {
+    // A triple-term subject that is a literal is invalid RDF (subject must be IRI or blank node).
+    let err = parse_srj(
+        r#"{"head":{"vars":["t"]},"results":{"bindings":[{"t":{"type":"triple","value":{
+            "subject":{"type":"literal","value":"oops"},
+            "predicate":{"type":"uri","value":"http://ex/p"},
+            "object":{"type":"literal","value":"o"}}}}]}}"#,
+    )
+    .unwrap_err();
+    assert!(err.contains("invalid triple-term subject"), "got {}", err);
+}
+
+// ─── Well-formed term-kind branches not previously round-tripped ────────────────────────
+
+#[test]
+fn bnode_typed_literal_lang_and_directional_decode_exactly() {
+    // All four kinds the engine emits but the inline suite did not round-trip through parse_srj:
+    // a blank node, a typed (xsd:integer) literal, a plain language-tagged literal, and an
+    // RDF-1.2 base-direction (its:dir) directional literal.
+    let rel = parse_srj(
+        r#"{"head":{"vars":["b","i","l","d"]},"results":{"bindings":[{
+            "b":{"type":"bnode","value":"x1"},
+            "i":{"type":"typed-literal","value":"42","datatype":"http://www.w3.org/2001/XMLSchema#integer"},
+            "l":{"type":"literal","value":"chat","xml:lang":"fr"},
+            "d":{"type":"literal","value":"shalom","xml:lang":"he","its:dir":"rtl"}
+        }]}}"#,
+    )
+    .unwrap();
+    let row = &rel.rows[0];
+    assert_eq!(row[0], Some(Term::BlankNode(BlankNode::new("x1").unwrap())));
+    assert_eq!(
+        row[1],
+        Some(Term::Literal(Literal::new_typed_literal(
+            "42",
+            NamedNode::new("http://www.w3.org/2001/XMLSchema#integer").unwrap()
+        )))
+    );
+    assert_eq!(
+        row[2],
+        Some(Term::Literal(
+            Literal::new_language_tagged_literal("chat", "fr").unwrap()
+        ))
+    );
+    // The directional literal carries the rtl base direction (RDF 1.2 / its:dir).
+    assert_eq!(
+        row[3],
+        Some(Term::Literal(
+            Literal::new_directional_language_tagged_literal(
+                "shalom",
+                "he",
+                oxrdf::BaseDirection::Rtl
+            )
+            .unwrap()
+        ))
+    );
+}
+
+#[test]
+fn invalid_its_dir_degrades_to_plain_language_tag() {
+    // An unrecognised its:dir token must NOT error — the parser degrades to a plain
+    // language-tagged literal (the same recall-safe decision the engine's parser makes), so a
+    // server emitting a junk direction still yields a usable term.
+    let rel = parse_srj(
+        r#"{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"literal","value":"v","xml:lang":"en","its:dir":"sideways"}}]}}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        rel.rows[0][0],
+        Some(Term::Literal(
+            Literal::new_language_tagged_literal("v", "en").unwrap()
+        )),
+        "an unknown its:dir falls back to a plain language-tagged literal, not an error"
+    );
+}
+
+#[test]
+fn type_absent_defaults_to_simple_literal() {
+    // SRJ permits omitting `type` for a plain literal; an object with only `value` is a simple
+    // literal (the `None` arm of the type match).
+    let rel = parse_srj(
+        r#"{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"value":"plain"}}]}}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        rel.rows[0][0],
+        Some(Term::Literal(Literal::new_simple_literal("plain")))
+    );
+}
+
+#[test]
+fn variable_absent_from_a_solution_is_unbound() {
+    // A column listed in head.vars but absent from a solution object is unbound (None) — the
+    // SPARQL semantics of an OPTIONAL-style missing binding.
+    let rel = parse_srj(
+        r#"{"head":{"vars":["s","o"]},"results":{"bindings":[
+            {"s":{"type":"uri","value":"http://ex/a"}}
+        ]}}"#,
+    )
+    .unwrap();
+    assert_eq!(rel.rows[0][0], Some(nn("http://ex/a")));
+    assert_eq!(rel.rows[0][1], None, "?o absent ⇒ unbound");
+}
+
+// ─── solutions_equal — the NEGATIVE direction (must distinguish) ────────────────────────
+
+#[test]
+fn solutions_equal_distinguishes_different_multisets() {
+    let vars = vec!["s".to_string()];
+    let a = vec![vec![Some(nn("http://ex/a"))], vec![Some(nn("http://ex/b"))]];
+    // A different bound term ⇒ unequal.
+    let b = vec![vec![Some(nn("http://ex/a"))], vec![Some(nn("http://ex/c"))]];
+    assert!(
+        !solutions_equal(&vars, &a, &vars, &b),
+        "a different bound term must compare unequal"
+    );
+}
+
+#[test]
+fn solutions_equal_is_multiplicity_sensitive() {
+    // Bag semantics: the same solution at multiplicity 2 differs from multiplicity 1.
+    let vars = vec!["s".to_string()];
+    let once = vec![vec![Some(nn("http://ex/a"))]];
+    let twice = vec![vec![Some(nn("http://ex/a"))], vec![Some(nn("http://ex/a"))]];
+    assert!(
+        !solutions_equal(&vars, &once, &vars, &twice),
+        "differing multiplicity must compare unequal (bag, not set, semantics)"
+    );
+}
+
+#[test]
+fn solutions_equal_ignores_unbound_only_columns_and_order() {
+    // Equal: same bound bindings, even though one side lists the columns in the opposite order
+    // AND carries an extra all-unbound column (an unbound cell is dropped from the bag).
+    let a_vars = vec!["s".to_string(), "o".to_string()];
+    let a = vec![vec![Some(nn("http://ex/a")), Some(nn("http://ex/x"))]];
+    // b: columns reversed, plus a third unbound column ?z.
+    let b_vars = vec!["o".to_string(), "s".to_string(), "z".to_string()];
+    let b = vec![vec![Some(nn("http://ex/x")), Some(nn("http://ex/a")), None]];
+    assert!(
+        solutions_equal(&a_vars, &a, &b_vars, &b),
+        "column order + an unbound-only extra column must not change the solution bag"
+    );
+}

--- a/crates/sparq-fedclient/tests/wire_pushdown_extra.rs
+++ b/crates/sparq-fedclient/tests/wire_pushdown_extra.rs
@@ -1,0 +1,244 @@
+//! sq-bif.2 — brTPF binding-block wire codec + capability-aware pushdown extra branches.
+//!
+//! The `wire` and `pushdown` modules carry strong inline unit tests. This file adds the
+//! adversarial / edge branches the inline suites do not, exercised through the PUBLIC codec +
+//! pushdown surface:
+//!
+//!  * the binary wire round-tripping a mapping that binds **all three** positions (s+p+o) plus
+//!    an EXTRA non-position pair, and a literal carrying its `^^<dt>` decoration verbatim;
+//!  * [`decode_bindings`] rejecting a buffer whose **term length points past the end** and one
+//!    whose **EXTRA name length points past the end** — both clean [`WireError`]s, never a panic
+//!    or out-of-bounds read (this crate is `forbid(unsafe_code)`);
+//!  * the public [`BINARY_VERSION`] / [`BINARY_MAGIC`] contract: a future version byte is a
+//!    clean [`WireError::UnsupportedVersion`], a wrong magic a clean [`WireError::BadMagic`];
+//!  * pushdown's [`group_vars`] / [`common_variable_check`] with an EMPTY group (no group var ⇒
+//!    no var-referencing filter is pushable; a constant-only filter still is), and
+//!    [`push_group`] over a brTPF fragment source whose projection is `SELECT *` when the caller
+//!    requests no narrowing (the empty-output-vars fragment branch);
+//!  * [`bind_block_size`] for `MaxMpR(0)` (clamped to 1) and `BindJoin::None` (0).
+//!
+//! Gated on `fedclient`; the default build compiles this file to nothing.
+//!
+//! [OPUS-4.8] sq-bif.2 — flagged for Fable re-review when available.
+
+#![cfg(feature = "fedclient")]
+
+use sparq_fedclient::{
+    bind_block_size, common_variable_check, decode_bindings, encode_bindings, encode_bindings_text,
+    group_vars, push_group, Capability, ExclusiveGroup, Filter, FilterClass, FragTerm, WireError,
+    BINARY_MAGIC, BINARY_VERSION,
+};
+use sparq_fedplan::{Bgp, Term, TriplePattern, Var};
+
+type FragBinding = Vec<(String, FragTerm)>;
+
+fn iri(s: &str) -> FragTerm {
+    FragTerm::Iri(s.to_string())
+}
+fn lit(s: &str) -> FragTerm {
+    FragTerm::Literal(s.to_string())
+}
+
+// ─── Binary wire: full s+p+o + extra round-trip, decorated literals ─────────────────────
+
+#[test]
+fn binary_round_trips_full_spo_plus_extra_and_typed_literal() {
+    // A mapping that binds ALL THREE canonical positions (each rides a header flag, no name
+    // bytes) PLUS a non-position variable (the EXTRA section), and a typed literal carrying its
+    // ^^<dt> decoration verbatim — the densest mapping shape, exercised end-to-end.
+    let block: Vec<FragBinding> = vec![vec![
+        ("s".to_string(), iri("http://ex/alice")),
+        ("p".to_string(), iri("http://xmlns.com/foaf/0.1/age")),
+        (
+            "o".to_string(),
+            lit(r#""30"^^<http://www.w3.org/2001/XMLSchema#integer>"#),
+        ),
+        ("graph".to_string(), iri("http://ex/g1")),
+    ]];
+    let back = decode_bindings(&encode_bindings(&block)).expect("decode");
+    // Position keys come back canonical s→p→o, then the EXTRA pair in encoded order.
+    assert_eq!(back, block);
+}
+
+#[test]
+fn binary_carries_literal_chars_the_text_wire_cannot() {
+    // A literal with embedded '=', whitespace, and a newline survives the binary wire (the text
+    // wire's one-mapping-per-line `position=term` grammar could not carry it).
+    let nasty: Vec<FragBinding> = vec![vec![("o".to_string(), lit("\"a = b\tc\nd\""))]];
+    assert_eq!(decode_bindings(&encode_bindings(&nasty)).unwrap(), nasty);
+}
+
+// ─── Binary wire: adversarial decode (length fields past the end) ───────────────────────
+
+#[test]
+fn decode_rejects_term_length_past_end() {
+    // Hand-craft: magic + version + count=1 + header(subject) + term-kind(IRI) + a varint length
+    // of 50 but NO payload bytes. The term length points past the buffer ⇒ a clean Truncated.
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&BINARY_MAGIC);
+    bytes.push(BINARY_VERSION);
+    bytes.push(1); // count = 1
+    bytes.push(0b0000_0001); // header: subject present
+    bytes.push(0); // term kind = IRI
+    bytes.push(50); // varint length = 50 (but no bytes follow)
+    let err = decode_bindings(&bytes).unwrap_err();
+    assert_eq!(err, WireError::Truncated, "a length past the end is Truncated");
+}
+
+#[test]
+fn decode_rejects_extra_name_length_past_end() {
+    // magic + version + count=1 + header(HAS_EXTRA only) + nextra=1 + name-length=99 with no
+    // name bytes ⇒ a clean Truncated, never an out-of-bounds read.
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&BINARY_MAGIC);
+    bytes.push(BINARY_VERSION);
+    bytes.push(1); // count = 1
+    bytes.push(0b1000_0000); // header: HAS_EXTRA, no positions
+    bytes.push(1); // nextra = 1
+    bytes.push(99); // name length = 99 (no bytes follow)
+    let err = decode_bindings(&bytes).unwrap_err();
+    assert_eq!(err, WireError::Truncated);
+}
+
+#[test]
+fn decode_version_and_magic_contract() {
+    // The public BINARY_VERSION/BINARY_MAGIC contract: a wrong magic is BadMagic; a future
+    // version byte is UnsupportedVersion (so a peer upgrade is detected, not misparsed).
+    let good = encode_bindings(&[vec![("s".to_string(), iri("http://ex/a"))]]);
+    let mut bad_magic = good.clone();
+    bad_magic[0] ^= 0xff;
+    assert_eq!(decode_bindings(&bad_magic), Err(WireError::BadMagic));
+
+    let mut future = good;
+    future[4] = BINARY_VERSION.wrapping_add(7);
+    assert_eq!(
+        decode_bindings(&future),
+        Err(WireError::UnsupportedVersion(BINARY_VERSION.wrapping_add(7)))
+    );
+}
+
+#[test]
+fn decode_every_truncation_point_is_clean() {
+    // No prefix of a valid block may panic — every cut is a clean error (forbid unsafe).
+    let block: Vec<FragBinding> = vec![
+        vec![
+            ("s".to_string(), iri("http://ex/alice")),
+            ("o".to_string(), lit("\"hi\"@en")),
+        ],
+        vec![("person".to_string(), iri("http://ex/dave"))],
+    ];
+    let bytes = encode_bindings(&block);
+    for cut in 0..bytes.len() {
+        // Must not panic; a partial buffer is always a clean Result.
+        let _ = decode_bindings(&bytes[..cut]);
+    }
+    // The full buffer round-trips.
+    assert_eq!(decode_bindings(&bytes).unwrap(), block);
+}
+
+#[test]
+fn text_wire_drops_non_position_vars_binary_keeps_them() {
+    // A binding over a non-position variable has no brTPF text slot (dropped), but the binary
+    // wire carries it losslessly.
+    let block: Vec<FragBinding> = vec![vec![("person".to_string(), iri("http://ex/dave"))]];
+    assert_eq!(encode_bindings_text(&block), "");
+    assert_eq!(decode_bindings(&encode_bindings(&block)).unwrap(), block);
+}
+
+// ─── Pushdown: empty-group + constant filter + fragment SELECT * ────────────────────────
+
+fn var(s: &str) -> Term {
+    Term::Var(Var::new(s))
+}
+fn tiri(s: &str) -> Term {
+    Term::Iri(s.to_string())
+}
+
+#[test]
+fn common_variable_check_over_empty_group() {
+    // An empty group binds NO variable: a var-referencing filter is not pushable, but a
+    // constant-only conjunct (no vars) trivially is.
+    let none: Vec<String> = Vec::new();
+    let with_var = Filter::new(vec!["x".to_string()], "?x > 1", FilterClass::Full);
+    assert!(
+        !common_variable_check(&with_var, &none),
+        "no group var ⇒ a var-referencing filter is not pushable"
+    );
+    let constant = Filter::new(vec![], "1 = 1", FilterClass::Equality);
+    assert!(
+        common_variable_check(&constant, &none),
+        "a constant-only conjunct is trivially pushable"
+    );
+}
+
+#[test]
+fn group_vars_collects_in_position_order_dedup() {
+    // ?s :p ?o . ?o :q ?z — group vars are s, o, z (de-duplicated, pattern-then-position order).
+    let bgp = Bgp::new(vec![
+        TriplePattern::new(var("s"), tiri("http://ex/p"), var("o")),
+        TriplePattern::new(var("o"), tiri("http://ex/q"), var("z")),
+    ]);
+    let group = ExclusiveGroup {
+        source: 0,
+        patterns: vec![0, 1],
+    };
+    assert_eq!(
+        group_vars(&group, &bgp),
+        vec!["s".to_string(), "o".to_string(), "z".to_string()]
+    );
+}
+
+#[test]
+fn push_group_fragment_with_no_output_vars_is_select_star_first_pattern() {
+    // A brTPF source group of TWO patterns with NO requested output narrowing: pushdown emits
+    // only the FIRST pattern as `SELECT *` (a fragment server answers one pattern; no FILTER /
+    // ORDER / LIMIT), and the rest stays client-side.
+    let bgp = Bgp::new(vec![
+        TriplePattern::new(var("s"), tiri("http://ex/p"), var("o")),
+        TriplePattern::new(var("o"), tiri("http://ex/q"), var("z")),
+    ]);
+    let group = ExclusiveGroup {
+        source: 0,
+        patterns: vec![0, 1],
+    };
+    let cap = Capability::brtpf(20);
+    // Empty output_vars ⇒ "give whatever the group projects"; for a fragment source that is the
+    // first pattern's open SELECT.
+    let pushed = push_group(&group, &bgp, &cap, &[], &[], &[], None).unwrap();
+    assert_eq!(
+        pushed.sub.sparql, "SELECT * WHERE { ?s <http://ex/p> ?o }",
+        "fragment + empty output ⇒ first pattern only, SELECT *"
+    );
+    assert!(pushed.pushed_filters.is_empty());
+}
+
+#[test]
+fn push_group_empty_group_fails_closed() {
+    // A group naming NO patterns is malformed ⇒ push_group returns None (fail closed).
+    let bgp = Bgp::new(vec![TriplePattern::new(
+        var("s"),
+        tiri("http://ex/p"),
+        var("o"),
+    )]);
+    let empty_group = ExclusiveGroup {
+        source: 0,
+        patterns: vec![],
+    };
+    let cap = Capability::endpoint();
+    assert!(push_group(&empty_group, &bgp, &cap, &[], &[], &[], None).is_none());
+}
+
+// ─── Pushdown: bind-block size policy across all bind-join modes ────────────────────────
+
+#[test]
+fn bind_block_size_clamps_and_disables_correctly() {
+    // brTPF maxMpR(0) is clamped to 1 (never a zero-sized block ⇒ no infinite loop), maxMpR(n)
+    // is n, plain TPF (no bind-join) is 0, and a full endpoint is the default block.
+    assert_eq!(bind_block_size(&Capability::brtpf(0)), 1, "maxMpR 0 clamps to 1");
+    assert_eq!(bind_block_size(&Capability::brtpf(7)), 7);
+    assert_eq!(bind_block_size(&Capability::tpf()), 0, "plain TPF has no bind-join");
+    assert!(
+        bind_block_size(&Capability::endpoint()) >= 1,
+        "a full endpoint accepts a non-empty VALUES block"
+    );
+}


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-bif.2** — the sparq-fedclient correctness suite. The crate already had strong coverage (~91%; sq-bif.1 set the floor at 89). This PR ADDS **68 tests** across 5 new feature-gated integration files, targeting the branches the existing suite left uncovered, with a deliberate focus on **ERROR paths**.

### Scope discipline
- Touches ONLY `crates/sparq-fedclient/` (5 new `tests/` files + a README note). No other crate touched.
- Does **not** edit `bench/coverage-floor.json` / `bench/coverage-presence.json` — the new tests raise *actual* coverage above the sq-bif.1 seed (89), which the monotonic ratchet permits without a floor bump (a later PR can ratchet floors up). Leaving the shared coverage JSON untouched keeps this PR non-conflicting with sibling test-suite PRs.
- Lean core / opt-in posture unchanged: every test is `#![cfg(feature = "fedclient")]`-gated (the default build compiles them to nothing) and adds no dependency to `sparq-core` / `sparq-engine`.

### Areas / branches covered (all on the REAL path — the canonical answer IS the engine, no logic-bypassing mock)
- **`srj_parse_correctness.rs` (24)** — `parse_srj` / `srj_term`: every term kind (bnode, typed-literal, language tag, RDF-1.2 directional literal, RDF-star triple term) **plus** the malformed / partial / adversarial-body error branches (missing `head.vars` / `results.bindings`, non-object binding, missing-`value` uri/bnode/literal, bad datatype IRI, bad language tag, unknown `type`, every triple-term structural error). Also `solutions_equal` on the **negative** direction (distinct multisets / multiplicity-sensitive).
- **`interpreter_error_paths.rs` (7)** — `materialize_single_source` / `stream_single_source` surfacing `InterpError::{Source, BadSrj, Resolve}` fail-closed; natural-join correctness edges (disjoint-key ⇒ empty, multiplicity fan-out) via the public interpreter.
- **`discovery_error_paths.rs` (14)** — `discover()` orchestration: malformed-SD propagation, VoID-without-SD, best-effort (silently-ignored) malformed VoID, the recall-safe unknown-version capability, `well_known_void_url` authority edges, `Capability::ask_fallback` / `MediaType` units.
- **`source_adapter_error_paths.rs` (11)** — Endpoint transport error → `FedError::Transport`; the SSRF egress guard refusing a host that resolves only to private/internal addresses + a no-host IRI; fragment transport error surfaced as `FedError::Transport`; a runaway paginator fail-stopped by the page cap; `Capability` defaults + `FragPattern::vars` dedup.
- **`wire_pushdown_extra.rs` (12)** — the brTPF binding-block binary codec rejecting truncated / length-past-end / bad-magic / wrong-version buffers **without a panic** (the crate is `forbid(unsafe_code)`); pushdown's empty-group / constant-filter / fragment `SELECT *` branches + `bind_block_size` clamp.

### Gates (run in BOTH feature states — confirmed GREEN)
| state | `clippy --all-targets -D warnings` | `cargo test` |
|---|---|---|
| **default (feature OFF)** | clean | ok (crate empty; gated tests compile to nothing) |
| **`--features fedclient`** | clean | ok (124 inline + integration) |
| **`--features fedclient,fedclient-adaptive`** | clean | ok (129 inline + integration; 68 new) |

Feature flags exercised: `fedclient`, `fedclient-adaptive` (per the crate's `Cargo.toml`).

No public-API change (tests only) ⇒ no SKILL.md surface to update; the crate README gains a "Correctness tests" section documenting the invariants the suite asserts.

[OPUS-4.8] flagged for Fable re-review when available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)