### PR TITLE
ci(sbom): retry transient cargo-cyclonedx flake in the GS-* live self-tests (sq-90ew)

### DIFF
--- a/scripts/tests/test_sbom_bomref_canonical.py
+++ b/scripts/tests/test_sbom_bomref_canonical.py
@@ -41,11 +41,48 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 NORMALIZE_JQ = REPO_ROOT / "scripts" / "sbom-normalize.jq"
+
+# [OPUS-4.8] sq-90ew: `cargo cyclonedx` internally runs `cargo metadata`, whose crates.io
+# fetch is TRANSIENTLY flaky on hosted runners (observed `curl ... [16] Error in the HTTP2
+# framing layer` -> non-zero exit at ~9-12s). PR #750 wrapped the cyclonedx invocation in the
+# WORKFLOW STEPS, but this live-SBOM self-test (run in the GATING GS-6/GS-7 job) executes its
+# OWN `cargo cyclonedx` BEFORE those wrapped steps, so the flake could still fail an unrelated
+# PR (same root cause as the supplier/purl self-tests, main run #27810325920, post-#750).
+# Mirror the #750 shell retry here: bounded 3 attempts, fixed 10s sleep, retry ONLY the
+# GENERATION subprocess. This wraps NO assertion — a real GS-6 bom-ref/host-path violation is
+# judged AFTER generation, on the produced files, and still fails. A genuine outage (all 3
+# attempts fail) re-raises -> the test errors.
+_CYCLONEDX_ATTEMPTS = 3
+_CYCLONEDX_RETRY_SLEEP_S = 10
+
+
+def _generate_workspace_sbom() -> None:
+    """Run `cargo cyclonedx --all` (writes <crate>.cdx.json next to each Cargo.toml), with a
+    bounded retry around ONLY the transient crates.io-fetch flake. Re-raises the last
+    CalledProcessError if every attempt fails (a genuine outage / toolchain break)."""
+    last_exc: subprocess.CalledProcessError | None = None
+    for attempt in range(1, _CYCLONEDX_ATTEMPTS + 1):
+        try:
+            subprocess.run(
+                ["cargo", "cyclonedx", "--all", "--format", "json", "--spec-version", "1.5"],
+                cwd=REPO_ROOT, check=True, capture_output=True,
+            )
+            return
+        except subprocess.CalledProcessError as exc:
+            last_exc = exc
+            if attempt >= _CYCLONEDX_ATTEMPTS:
+                break
+            print(f"cargo cyclonedx attempt {attempt} failed; retrying in "
+                  f"{_CYCLONEDX_RETRY_SLEEP_S}s...", file=sys.stderr)
+            time.sleep(_CYCLONEDX_RETRY_SLEEP_S)
+    assert last_exc is not None
+    raise last_exc
 
 # A ref that still embeds a build-machine path. Mirrors gen-sbom-vex.sh's belt-and-braces
 # guard, but we assert it over the parsed ref STRINGS, not a raw grep, so a structurally
@@ -217,12 +254,9 @@ class TestLiveWorkspaceSBOM(unittest.TestCase):
     def test_real_normalized_sbom_has_no_host_path_in_refs(self):
         if not shutil.which("cargo-cyclonedx") or not _jq_available():
             self.skipTest("cargo-cyclonedx / jq not available")
-        subprocess.run(
-            ["cargo", "cyclonedx", "--all", "--format", "json", "--spec-version", "1.5"],
-            cwd=REPO_ROOT,
-            check=True,
-            capture_output=True,
-        )
+        # [OPUS-4.8] sq-90ew: GENERATION only, with the transient-flake retry. The GS-6
+        # host-path / bom-ref assertions below run ONCE on the produced files (NOT retried).
+        _generate_workspace_sbom()
         try:
             judged = 0
             for crate in ("sparq-server", "sparq-cli"):

--- a/scripts/tests/test_sbom_purl_canonical.py
+++ b/scripts/tests/test_sbom_purl_canonical.py
@@ -21,10 +21,47 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# [OPUS-4.8] sq-90ew: `cargo cyclonedx` internally runs `cargo metadata`, whose crates.io
+# fetch is TRANSIENTLY flaky on hosted runners (observed `curl ... [16] Error in the HTTP2
+# framing layer` -> non-zero exit at ~9-12s). PR #750 wrapped the cyclonedx invocation in the
+# WORKFLOW STEPS, but this live-SBOM self-test runs its OWN `cargo cyclonedx` (it executes
+# BEFORE those wrapped steps), so the flake still failed the GATING GS-6/GS-7 job on unrelated
+# PRs (main run #27810325920, post-#750). Mirror the #750 shell retry here: bounded 3
+# attempts, fixed 10s sleep, retry ONLY the GENERATION subprocess. This wraps NO assertion — a
+# real GS-6/GS-7 purl-canonicality violation is judged AFTER generation, on the produced
+# files, and still fails. A genuine outage (all 3 attempts fail) re-raises -> the test errors.
+_CYCLONEDX_ATTEMPTS = 3
+_CYCLONEDX_RETRY_SLEEP_S = 10
+
+
+def _generate_workspace_sbom() -> None:
+    """Run `cargo cyclonedx --all` (writes <crate>.cdx.json next to each Cargo.toml), with a
+    bounded retry around ONLY the transient crates.io-fetch flake. Re-raises the last
+    CalledProcessError if every attempt fails (a genuine outage / toolchain break)."""
+    last_exc: subprocess.CalledProcessError | None = None
+    for attempt in range(1, _CYCLONEDX_ATTEMPTS + 1):
+        try:
+            subprocess.run(
+                ["cargo", "cyclonedx", "--all", "--format", "json",
+                 "--spec-version", "1.5"],
+                cwd=REPO_ROOT, check=True, capture_output=True,
+            )
+            return
+        except subprocess.CalledProcessError as exc:
+            last_exc = exc
+            if attempt >= _CYCLONEDX_ATTEMPTS:
+                break
+            print(f"cargo cyclonedx attempt {attempt} failed; retrying in "
+                  f"{_CYCLONEDX_RETRY_SLEEP_S}s...", file=sys.stderr)
+            time.sleep(_CYCLONEDX_RETRY_SLEEP_S)
+    assert last_exc is not None
+    raise last_exc
 
 
 def _load(name: str, filename: str):
@@ -124,11 +161,9 @@ class TestLiveWorkspaceSBOM(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             # Generate into the repo (cargo-cyclonedx writes next to each Cargo.toml),
             # normalize, copy out, then clean the generated crate SBOMs.
-            subprocess.run(
-                ["cargo", "cyclonedx", "--all", "--format", "json",
-                 "--spec-version", "1.5"],
-                cwd=REPO_ROOT, check=True, capture_output=True,
-            )
+            # [OPUS-4.8] sq-90ew: GENERATION only, with the transient-flake retry. The
+            # GS-6/GS-7 purl assertion below runs ONCE on the produced files (NOT retried).
+            _generate_workspace_sbom()
             try:
                 judged = 0
                 for crate in ("sparq-server", "sparq-cli"):

--- a/scripts/tests/test_sbom_supplier.py
+++ b/scripts/tests/test_sbom_supplier.py
@@ -22,10 +22,47 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# [OPUS-4.8] sq-90ew: `cargo cyclonedx` internally runs `cargo metadata`, whose crates.io
+# fetch is TRANSIENTLY flaky on hosted runners (observed `curl ... [16] Error in the HTTP2
+# framing layer` -> non-zero exit at ~9-12s). PR #750 wrapped the cyclonedx invocation in the
+# WORKFLOW STEPS, but this live-SBOM self-test runs its OWN `cargo cyclonedx` (it executes
+# BEFORE those wrapped steps), so the flake still failed the GATING GS-1 job on unrelated PRs
+# (main runs #27810325920 / #27811535047, post-#750). Mirror the #750 shell retry here:
+# bounded 3 attempts, fixed 10s sleep, retry ONLY the GENERATION subprocess. This wraps NO
+# assertion — a real GS-1 supplier-name violation is judged AFTER generation, on the produced
+# files, and still fails. A genuine outage (all 3 attempts fail) re-raises -> the test errors.
+_CYCLONEDX_ATTEMPTS = 3
+_CYCLONEDX_RETRY_SLEEP_S = 10
+
+
+def _generate_workspace_sbom() -> None:
+    """Run `cargo cyclonedx --all` (writes <crate>.cdx.json next to each Cargo.toml), with a
+    bounded retry around ONLY the transient crates.io-fetch flake. Re-raises the last
+    CalledProcessError if every attempt fails (a genuine outage / toolchain break)."""
+    last_exc: subprocess.CalledProcessError | None = None
+    for attempt in range(1, _CYCLONEDX_ATTEMPTS + 1):
+        try:
+            subprocess.run(
+                ["cargo", "cyclonedx", "--all", "--format", "json",
+                 "--spec-version", "1.5"],
+                cwd=REPO_ROOT, check=True, capture_output=True,
+            )
+            return
+        except subprocess.CalledProcessError as exc:
+            last_exc = exc
+            if attempt >= _CYCLONEDX_ATTEMPTS:
+                break
+            print(f"cargo cyclonedx attempt {attempt} failed; retrying in "
+                  f"{_CYCLONEDX_RETRY_SLEEP_S}s...", file=sys.stderr)
+            time.sleep(_CYCLONEDX_RETRY_SLEEP_S)
+    assert last_exc is not None
+    raise last_exc
 
 
 def _load(name: str, filename: str):
@@ -124,11 +161,9 @@ class TestLiveWorkspaceSBOM(unittest.TestCase):
             self.skipTest("cargo-cyclonedx / jq not available")
         normalize = REPO_ROOT / "scripts" / "sbom-normalize.jq"
         with tempfile.TemporaryDirectory() as d:
-            subprocess.run(
-                ["cargo", "cyclonedx", "--all", "--format", "json",
-                 "--spec-version", "1.5"],
-                cwd=REPO_ROOT, check=True, capture_output=True,
-            )
+            # [OPUS-4.8] sq-90ew: GENERATION only, with the transient-flake retry. The GS-1
+            # supplier assertion below runs ONCE on the produced files (NOT retried).
+            _generate_workspace_sbom()
             try:
                 judged = 0
                 for crate in ("sparq-server", "sparq-cli"):


### PR DESCRIPTION
> 🤖 SPARQ agent

## What this fixes (sq-90ew)

The three **GATING** SBOM jobs in `.github/workflows/supply-chain.yml` —
- `SBOM per-component supplier-name assertion (GS-1) — GATING`
- `SBOM purl-canonicality assertion (GS-6/GS-7) — GATING`

intermittently failed **EARLY (~9-12s)** on PRs that change no dependencies, on a transient crates.io / `cargo metadata` **HTTP2-framing** flake (`curl ... [16] Error in the HTTP2 framing layer` → `cargo metadata exited with an error`). This forced manual re-runs on ~5 PRs.

## Root cause — the gap #750 left

PR #750 (sq-hxn7) wrapped the `cargo cyclonedx` invocation in the **workflow STEPS** (`cargo fetch --locked` warm-cache + a retry around the step's `cargo cyclonedx`). But each of these GATING jobs runs a Python **self-test FIRST**:

| GATING job | self-test step (runs first) | its `TestLiveWorkspaceSBOM` |
|---|---|---|
| GS-1 | `scripts/tests/test_sbom_supplier.py` | shells out to its OWN `cargo cyclonedx` |
| GS-6/GS-7 | `scripts/tests/test_sbom_purl_canonical.py` + `test_sbom_bomref_canonical.py` | same |

Those `TestLiveWorkspaceSBOM` tests call `subprocess.run(["cargo","cyclonedx",...], check=True)` **unwrapped**, and they execute **before** the #750-wrapped steps — so the SAME flake still tripped the gate. Confirmed on two **post-#750** `main` runs:
- GS-6/GS-7: run **27810325920** → `test_real_normalized_sbom_is_canonical` ERROR, `CalledProcessError` on `cargo cyclonedx` at line 127, failed ~5s in.
- GS-1: run **27811535047** → `test_real_normalized_sbom_has_honest_suppliers` ERROR, same `CalledProcessError`, failed ~6s in.

(The bead premise was "#750 didn't cover these legs" — the accurate finding is #750 covered the *steps* but missed the *self-tests the gating jobs run*.)

## The fix — retry scope (PROVING the assertion is NOT inside it)

Each of the three self-tests gains an identical module-level helper mirroring the #750 shell retry (3 attempts, fixed 10s sleep):

```python
def _generate_workspace_sbom() -> None:
    for attempt in range(1, _CYCLONEDX_ATTEMPTS + 1):
        try:
            subprocess.run(["cargo","cyclonedx","--all","--format","json","--spec-version","1.5"],
                           cwd=REPO_ROOT, check=True, capture_output=True)
            return
        except subprocess.CalledProcessError as exc:
            last_exc = exc
            if attempt >= _CYCLONEDX_ATTEMPTS: break
            time.sleep(_CYCLONEDX_RETRY_SLEEP_S)
    raise last_exc
```

The live test now calls `_generate_workspace_sbom()` for **GENERATION ONLY**; the GS-* **assertion** logic (jq-normalize + `chk.evaluate` + honesty checks + `assertTrue`/`assertEqual`) is **unchanged and runs ONCE on the produced files, OUTSIDE the retry**.

## Why a REAL violation still fails (the #748-class guardrail)

- The retry's `try` block contains **only** `subprocess.run([... cargo cyclonedx ...])` — nothing else. The `except` catches **only** `subprocess.CalledProcessError` (no broad `except`, no `|| true`).
- A real GS-1 / GS-6 / GS-7 violation surfaces as an `AssertionError` from the `assert*` calls that run **after** generation, on the generated files — those are never inside the helper, so they are never retried or swallowed.
- A genuine registry outage (all 3 generation attempts fail) **re-raises** → the gating test still ERRORs (no outage-masking).

Proven locally:
- **PROOF(a)** — planted missing-supplier → GS-1 assertion FAILS; planted `?download_url=file://` purl → GS-6/GS-7 assertion FAILS. The existing planted-violation unit tests (`test_missing_supplier_fails`, `test_download_url_qualifier_fails`, `test_src_subpath_fragment_fails`, `test_future_decoration_qualifier_fails`) are untouched and still pass — they ARE the kept planted-violation self-test.
- **PROOF(b)** — 2 transient failures then success → generation retried, total 3 attempts, no raise; persistent failure → re-raised after exactly 3 attempts; helper catches ONLY `CalledProcessError`.

## Gate / posture verification

- **No GS-* job renamed/removed**; no `advisory`/`informational` token added → all three still GATE via the `ci-summary / gate` aggregator.
- **`.github/workflows/` UNCHANGED** (`supply-chain.yml` re-validated `yaml.safe_load` OK) → no `uses:` touched → every action stays 40-hex **SHA-pinned** (code-scanning=0 posture intact); **no new action**.
- Only `scripts/tests/test_sbom_{supplier,purl_canonical,bomref_canonical}.py` changed.
- All three suites green locally (live `TestLiveWorkspaceSBOM` RUN, not skipped; 9/9, 9/9, 8/8).

## Compliance

No certification level changes — this is a CI-reliability fix that keeps the existing NTIA Supplier-Name (GS-1) + purl/bom-ref canonicality (GS-6/GS-7) SBOM backstops gating without spurious flake failures.

NOTE: the SBOM flake this fixes may itself hit this PR's GS-* legs (~9-12s early fail) — if so, re-run; that is exactly the transient this PR neutralises.

🤖 SPARQ agent