### PR TITLE
ci(release): unify release/dist build matrix via workflow_call; drop dist tags trigger (sq-v286.2) [OPUS-4.8]

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -1,0 +1,148 @@
+# [OPUS-4.8] sq-v286.2: the SINGLE source of truth for the hardware-tiered sparq-cli build
+# matrix. Reusable workflow (`workflow_call`) invoked by release.yml (versioned archives +
+# SHA256SUMS) and dist.yml (bare per-tier binaries for the fat-package launcher). Before this,
+# release.yml#package and dist.yml#build carried two hand-synced copies of the same 10-tier
+# matrix + identical build steps — the duplication the release-CI design record flags to remove
+# (research/release-ci-design.md §5 "Reuse, do not duplicate" and §6 sequencing item 2:
+# "Unify the duplicated build matrix via workflow_call").
+#
+# The matrix (runner labels + target triple + target-cpu + binary extension) and the build
+# steps (checkout -> Rust+target -> cargo-auditable -> `cargo auditable build`) are now defined
+# ONCE here. Each caller selects the artifact SHAPE via the `mode` input:
+#   mode: archive  -> release.yml: tar.gz / zip of binary + README + LICENSE + CHANGELOG,
+#                     uploaded as pkg-<tier>; the release job adds SHA256SUMS over them.
+#   mode: binary   -> dist.yml: bare binary copied to sparq-cli-<tier><ext>, uploaded as
+#                     sparq-cli-<tier>; the launcher's fat package selects from these.
+# Both modes embed the dependency manifest via cargo-auditable (GX-7 / GX-9) and emit an
+# identical SLSA build-provenance attestation over whatever bytes they upload (sq-zqq6).
+#
+# Microarch tier rationale (target-cpu=native is a NO-OP on Apple silicon; the x86-64
+# {,-v2,-v3,-v4} ladder; arm64 neoverse-n1 +lse; win-arm64 cross-linked from the x64 runner)
+# is unchanged - see research/hardware/optimization-findings.md.
+name: build-matrix
+
+on:
+  workflow_call:
+    inputs:
+      mode:
+        description: "Artifact shape: 'archive' (versioned tar.gz/zip + docs, for release.yml) or 'binary' (bare per-tier binary, for dist.yml)."
+        required: true
+        type: string
+
+# Default read-only; the matrix job opts into the OIDC + attestation writes it needs (below).
+# A reusable workflow's effective permissions are the INTERSECTION of this declaration and the
+# permissions the CALLER's invoking job grants - both callers grant id-token+attestations:write.
+permissions:
+  contents: read
+
+jobs:
+  # ---- build + package per hardware tier (THE shared matrix) ----
+  build:
+    name: ${{ inputs.mode == 'archive' && 'package' || 'build' }} ${{ matrix.tier }}
+    runs-on: ${{ matrix.os }}
+    # sq-zqq6 / GX-9: build-provenance attestation over the uploaded bytes needs the OIDC
+    # token + attestation write. Read-only on the repo otherwise.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # ---- Apple ----
+          # Apple silicon (M1-M4): ONE binary, no target-cpu (Darwin baseline already enables
+          # every Apple-silicon feature - measured; see research/hardware/optimization-findings.md).
+          - { tier: arm64-darwin,     os: macos-14,         target: aarch64-apple-darwin,      cpu: "",          ext: "" }
+          # Intel Macs: x86-64-v3 (every Intel Mac since ~2015 / Haswell has AVX2).
+          # macos-*-intel is the supported Intel runner line (the retired macos-13 label is gone).
+          - { tier: x64-darwin,       os: macos-15-intel,   target: x86_64-apple-darwin,       cpu: x86-64-v3,   ext: "" }
+          # ---- x86-64 Linux ----
+          # baseline (SSE2) + v2 (SSE4.2) + v3 (AVX2/BMI2/FMA) + v4 (AVX-512). The launcher
+          # picks the tier by /proc/cpuinfo.
+          - { tier: x64-baseline,     os: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  cpu: x86-64,      ext: "" }
+          - { tier: x64-v2,           os: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  cpu: x86-64-v2,   ext: "" }
+          - { tier: x64-v3,           os: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  cpu: x86-64-v3,   ext: "" }
+          - { tier: x64-v4,           os: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  cpu: x86-64-v4,   ext: "" }
+          # Generic aarch64 Linux (Graviton/Ampere, Raspberry Pi 4+): neoverse-n1 + LSE.
+          - { tier: arm64-linux,      os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu, cpu: neoverse-n1, ext: "" }
+          # ---- Windows ----
+          - { tier: win-x64-baseline, os: windows-latest,   target: x86_64-pc-windows-msvc,    cpu: x86-64,      ext: ".exe" }
+          - { tier: win-x64-v3,       os: windows-latest,   target: x86_64-pc-windows-msvc,    cpu: x86-64-v3,   ext: ".exe" }
+          # Windows on ARM - cross-compiled from the x64 runner (MSVC cross-links; no cross/QEMU).
+          - { tier: win-arm64,        os: windows-latest,   target: aarch64-pc-windows-msvc,   cpu: "",          ext: ".exe" }
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install Rust + target
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup target add ${{ matrix.target }}
+      # GX-7 / GX-9: cargo-auditable embeds the exact dependency manifest (versions + sources)
+      # INTO the released binary, so the shipped artifact is self-describing for post-build audit
+      # (`cargo audit bin <file>` / `auditable info <file>`). Negligible size cost; no runtime overhead.
+      - name: Install cargo-auditable
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: cargo-auditable
+      - name: Build (${{ matrix.cpu || 'default-cpu' }})
+        shell: bash
+        run: |
+          FLAGS=""
+          [ -n "${{ matrix.cpu }}" ] && FLAGS="-Ctarget-cpu=${{ matrix.cpu }}"
+          [ "${{ matrix.tier }}" = "arm64-linux" ] && FLAGS="$FLAGS -Ctarget-feature=+lse"
+          # `cargo auditable build` is a drop-in for `cargo build` that embeds the dep
+          # manifest into the binary (GX-7); `--locked` pins the materials (Cargo.lock).
+          RUSTFLAGS="$FLAGS" cargo auditable build --release --locked -p sparq-cli --target ${{ matrix.target }}
+
+      # ---- archive mode (release.yml): versioned tar.gz/zip + README + LICENSE + CHANGELOG ----
+      - name: Package (binary + README + LICENSE + CHANGELOG)
+        if: inputs.mode == 'archive'
+        shell: bash
+        run: |
+          PKG="sparq-cli-${GITHUB_REF_NAME}-${{ matrix.tier }}"
+          mkdir -p "pkg/$PKG"
+          cp "target/${{ matrix.target }}/release/sparq-cli${{ matrix.ext }}" "pkg/$PKG/"
+          cp README.md "pkg/$PKG/"
+          # LICENSE is copied when present (license = MIT is declared in Cargo.toml; adding
+          # the LICENSE file itself is on the pre-release checklist in docs/release.md).
+          if [ -f LICENSE ]; then cp LICENSE "pkg/$PKG/"; fi
+          if [ -f CHANGELOG.md ]; then cp CHANGELOG.md "pkg/$PKG/"; fi
+          cd pkg
+          case "${{ matrix.tier }}" in
+            win-*) 7z a "$PKG.zip" "$PKG" ;;
+            *)     tar czf "$PKG.tar.gz" "$PKG" ;;
+          esac
+      - name: Attest build provenance (archives)
+        if: inputs.mode == 'archive'
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            pkg/*.tar.gz
+            pkg/*.zip
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: inputs.mode == 'archive'
+        with:
+          name: pkg-${{ matrix.tier }}
+          path: |
+            pkg/*.tar.gz
+            pkg/*.zip
+          if-no-files-found: error
+
+      # ---- binary mode (dist.yml): bare per-tier binary for the launcher fat-package ----
+      - name: Stage dist binary
+        if: inputs.mode == 'binary'
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp "target/${{ matrix.target }}/release/sparq-cli${{ matrix.ext }}" "dist/sparq-cli-${{ matrix.tier }}${{ matrix.ext }}"
+      - name: Attest build provenance (dist binary)
+        if: inputs.mode == 'binary'
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist/sparq-cli-${{ matrix.tier }}${{ matrix.ext }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: inputs.mode == 'binary'
+        with:
+          name: sparq-cli-${{ matrix.tier }}
+          path: dist/sparq-cli-${{ matrix.tier }}${{ matrix.ext }}

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,96 +1,41 @@
-# Build hardware-tiered sparq-cli release binaries on NATIVE runners.
+# Build hardware-tiered sparq-cli binaries on NATIVE runners (the launcher's fat package
+# selects the right tier per host).
+#
+# [OPUS-4.8] sq-v286.2: the per-tier build matrix + build steps + per-tier SLSA attestation
+# are no longer inlined here. They live ONCE in the reusable workflow `build-matrix.yml`,
+# which this workflow invokes with `mode: binary` (bare per-tier binaries uploaded as
+# sparq-cli-<tier>). release.yml calls the same reusable workflow with `mode: archive`.
+#
+# Trigger: manual dispatch ONLY. The `tags: ["v*"]` push trigger has been REMOVED — it
+# double-built the binaries against release.yml (which also fires on `v*`). release.yml is now
+# the single tag-driven release entry point; dist.yml exists for ad-hoc/out-of-band tier
+# builds. This is research/release-ci-design.md §5 ("dist/release double-build ... Drop
+# dist.yml's tags: trigger (keep workflow_dispatch)") and §6 sequencing item 2.
 #
 # Each tier is compiled on a runner of its own architecture (no cross-toolchain needed),
-# which is the robust path: aarch64 builds on macos-14 (Apple silicon), x86-64 tiers on
-# ubuntu. Microarch tiers exist only where they pay off — see
-# research/hardware/optimization-findings.md (target-cpu=native is a NO-OP on Apple
-# silicon, so darwin ships a single binary).
-#
-# Triggers: version tags (v*) and manual dispatch only — never on ordinary pushes.
+# except win-arm64 which cross-links from the x64 Windows runner. Microarch tiers exist only
+# where they pay off - see research/hardware/optimization-findings.md (target-cpu=native is a
+# NO-OP on Apple silicon, so darwin ships a single binary).
 name: dist
 on:
-  push:
-    tags: ["v*"]
   workflow_dispatch:
 
-# [OPUS-4.8] Least-privilege default (Scorecard TokenPermissions): the build matrix only
-# reads the repo and uploads artifacts (artifact upload needs no extra repo-scope token).
+# [OPUS-4.8] Least-privilege default (Scorecard TokenPermissions). The called workflow's
+# matrix job needs the OIDC + attestation writes for SLSA provenance; the calling job below
+# grants them as the ceiling passed down to build-matrix.yml.
 permissions:
   contents: read
 
 jobs:
+  # sq-toze.23 (GX-9): the per-tier dist binaries the launcher's fat-package selects from carry
+  # SLSA build provenance (id-token: write signs the in-toto provenance; attestations: write
+  # pushes it to the GitHub store). Read-only on the repo otherwise (dist uploads workflow
+  # artifacts, it does not create a Release).
   build:
-    name: ${{ matrix.tier }}
-    runs-on: ${{ matrix.os }}
-    # [OPUS-4.8] sq-toze.23 (GX-9): the per-tier dist binaries the launcher's fat-package
-    # selects from must carry SLSA build provenance too — not only the release.yml archives.
-    # The OIDC token (`id-token: write`) is what Sigstore Fulcio signs the in-toto provenance
-    # with; `attestations: write` lets the run push the attestation to the GitHub store.
-    # Still read-only on the repo otherwise (no `contents: write`: dist uploads workflow
-    # artifacts, it does not create a Release).
     permissions:
       contents: read
       id-token: write
       attestations: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # ---- Apple ----
-          # Apple silicon (M1–M4): ONE binary, no target-cpu (Darwin baseline already enables
-          # every Apple-silicon feature; native unlocks zero new instructions — measured).
-          - { tier: arm64-darwin,     os: macos-14,         target: aarch64-apple-darwin,      cpu: "",          ext: "" }
-          # Intel Macs: x86-64-v3 (every Intel Mac since ~2015 / Haswell has AVX2).
-          - { tier: x64-darwin,       os: macos-15-intel,   target: x86_64-apple-darwin,       cpu: x86-64-v3,   ext: "" }
-          # ---- x86-64 Linux (servers + the launcher's fat package) ----
-          # baseline (SSE2, runs anywhere) + v2 (SSE4.2, ~2009+) + v3 (AVX2/BMI2/FMA, common
-          # modern) + v4 (AVX-512, newest). The launcher picks by /proc/cpuinfo.
-          - { tier: x64-baseline,     os: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  cpu: x86-64,      ext: "" }
-          - { tier: x64-v2,           os: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  cpu: x86-64-v2,   ext: "" }
-          - { tier: x64-v3,           os: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  cpu: x86-64-v3,   ext: "" }
-          - { tier: x64-v4,           os: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  cpu: x86-64-v4,   ext: "" }
-          # Generic aarch64 Linux (Graviton/Ampere servers, Raspberry Pi 4+): neoverse-n1 + LSE.
-          - { tier: arm64-linux,      os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu, cpu: neoverse-n1, ext: "" }
-          # ---- Windows (the largest consumer desktop platform) ----
-          - { tier: win-x64-baseline, os: windows-latest,   target: x86_64-pc-windows-msvc,    cpu: x86-64,      ext: ".exe" }
-          - { tier: win-x64-v3,       os: windows-latest,   target: x86_64-pc-windows-msvc,    cpu: x86-64-v3,   ext: ".exe" }
-          # Windows on ARM (Surface Pro X, Snapdragon X Elite) — cross-compiled from the x64 runner.
-          - { tier: win-arm64,        os: windows-latest,   target: aarch64-pc-windows-msvc,   cpu: "",          ext: ".exe" }
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Install Rust + target
-        shell: bash
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup target add ${{ matrix.target }}
-      # [OPUS-4.8] sq-toze.23 (GX-9): mirror release.yml#package — cargo-auditable embeds
-      # the resolved dependency manifest INTO the binary so the dist artifact is self-describing
-      # for post-build audit (`cargo audit bin <file>`), matching the attested release archives.
-      - name: Install cargo-auditable
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
-        with:
-          tool: cargo-auditable
-      - name: Build (${{ matrix.cpu || 'default-cpu' }})
-        shell: bash
-        run: |
-          FLAGS=""
-          [ -n "${{ matrix.cpu }}" ] && FLAGS="-Ctarget-cpu=${{ matrix.cpu }}"
-          [ "${{ matrix.tier }}" = "arm64-linux" ] && FLAGS="$FLAGS -Ctarget-feature=+lse"
-          # `cargo auditable build` is a drop-in for `cargo build`; `--locked` pins the
-          # materials (Cargo.lock) so the build is fully described — same as release.yml.
-          RUSTFLAGS="$FLAGS" cargo auditable build --release --locked -p sparq-cli --target ${{ matrix.target }}
-          mkdir -p dist
-          cp "target/${{ matrix.target }}/release/sparq-cli${{ matrix.ext }}" "dist/sparq-cli-${{ matrix.tier }}${{ matrix.ext }}"
-      # [OPUS-4.8] sq-toze.23 (GX-9): SLSA build provenance over the per-tier dist binary.
-      # Same mechanism as release.yml#package — actions/attest-build-provenance emits a
-      # signed in-toto SLSA provenance predicate binding the binary's digest to this workflow
-      # run (Sigstore Fulcio cert keyed to the GitHub OIDC identity; Rekor inclusion proof).
-      # Verify with: gh attestation verify dist/sparq-cli-<tier> --repo <owner>/sparq
-      - name: Attest build provenance (dist binary)
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: dist/sparq-cli-${{ matrix.tier }}${{ matrix.ext }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: sparq-cli-${{ matrix.tier }}
-          path: dist/sparq-cli-${{ matrix.tier }}${{ matrix.ext }}
+    uses: ./.github/workflows/build-matrix.yml
+    with:
+      mode: binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,17 @@
 # GitHub Release pipeline (T20): tag `vX.Y.Z` -> build, package, checksum, release, docker.
 #
-# DESIGN: this workflow is SELF-CONTAINED — it duplicates dist.yml's build matrix instead of
-# `workflow_call`-ing it, for two reasons:
-#   1. dist.yml has no `workflow_call` trigger and adding one means editing a file another
-#      work-thread owns; a reusable-workflow refactor is a deliberate follow-up, not a hidden
-#      edit. Until then the matrices MUST be kept in sync by hand (both carry this note's
-#      tier table; see dist.yml for the per-tier rationale).
-#   2. Release artifacts have a different shape from dist artifacts: versioned archives
-#      (tar.gz / zip) containing the binary + README + LICENSE + CHANGELOG, plus a SHA256SUMS
-#      manifest — not dist's bare per-tier binaries.
-# Both workflows currently fire on tags; that double-builds the binaries. Harmless but
-# wasteful — once this lands, the maintainer can drop the `tags` trigger from dist.yml
-# (keeping its workflow_dispatch for ad-hoc builds). See docs/release.md.
+# [OPUS-4.8] sq-v286.2: the per-hardware-tier build matrix is no longer inlined here. It is
+# defined ONCE in the reusable workflow `build-matrix.yml` and invoked below with
+# `mode: archive` (the `package` job is a `workflow_call`). release.yml remains THE entry point
+# for cutting a release (it fires on a `v*` tag and is the path the release-plz tag flow will
+# drive — research/release-ci-design.md §6 item 4); dist.yml is now dispatch-only and calls the
+# same reusable matrix with `mode: binary`. This ends the hand-synced double-matrix +
+# double-build the design record flags (§5 "Reuse, do not duplicate"; §6 item 2 "Unify the
+# duplicated build matrix via workflow_call; drop dist.yml's tags trigger").
+#
+# Release artifacts keep their distinct shape vs dist's bare binaries: versioned archives
+# (tar.gz / zip) containing the binary + README + LICENSE + CHANGELOG, plus a SHA256SUMS
+# manifest — produced by the reusable workflow's `archive` mode + the `release` job below.
 #
 # Triggers: version tags only. NO schedule, NO pull_request — releasing is a deliberate act.
 name: release
@@ -25,98 +25,21 @@ permissions:
   contents: read
 
 jobs:
-  # ---- 1. build + package per hardware tier (mirror of dist.yml's matrix) ----
+  # ---- 1. build + package per hardware tier ----
+  # [OPUS-4.8] sq-v286.2: invoke the shared reusable matrix in `archive` mode. The 10-tier
+  # runner-label matrix + build steps + the sq-zqq6 SLSA archive attestation all live in
+  # build-matrix.yml now (single source of truth); this caller only selects the artifact shape.
+  # The reusable workflow's matrix job attests + uploads `pkg-<tier>`; the `release` job below
+  # consumes those artifacts. `permissions:` here is the ceiling passed down to the called
+  # workflow — it must grant the OIDC + attestation writes the attestation step needs.
   package:
-    name: package ${{ matrix.tier }}
-    runs-on: ${{ matrix.os }}
-    # [OPUS-4.8] sq-zqq6: build-provenance attestation over the packaged archives
-    # needs the OIDC token + attestation write. Read-only otherwise.
     permissions:
       contents: read
       id-token: write
       attestations: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # ---- Apple ----
-          # Apple silicon (M1–M4): ONE binary, no target-cpu (Darwin baseline already enables
-          # every Apple-silicon feature — measured; see research/hardware/optimization-findings.md).
-          - { tier: arm64-darwin,     os: macos-14,         target: aarch64-apple-darwin,      cpu: "",          ext: "" }
-          # Intel Macs: x86-64-v3 (every Intel Mac since ~2015 / Haswell has AVX2).
-          # Deliberate divergence from dist.yml: its macos-13 label has been retired by
-          # GitHub; macos-*-intel is the supported Intel runner line (dist.yml needs the
-          # same fix — flagged in docs/release.md, not edited here).
-          - { tier: x64-darwin,       os: macos-15-intel,   target: x86_64-apple-darwin,       cpu: x86-64-v3,   ext: "" }
-          # ---- x86-64 Linux ----
-          # baseline (SSE2) + v2 (SSE4.2) + v3 (AVX2/BMI2/FMA) + v4 (AVX-512).
-          - { tier: x64-baseline,     os: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  cpu: x86-64,      ext: "" }
-          - { tier: x64-v2,           os: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  cpu: x86-64-v2,   ext: "" }
-          - { tier: x64-v3,           os: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  cpu: x86-64-v3,   ext: "" }
-          - { tier: x64-v4,           os: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  cpu: x86-64-v4,   ext: "" }
-          # Generic aarch64 Linux (Graviton/Ampere, Raspberry Pi 4+): neoverse-n1 + LSE.
-          - { tier: arm64-linux,      os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu, cpu: neoverse-n1, ext: "" }
-          # ---- Windows ----
-          - { tier: win-x64-baseline, os: windows-latest,   target: x86_64-pc-windows-msvc,    cpu: x86-64,      ext: ".exe" }
-          - { tier: win-x64-v3,       os: windows-latest,   target: x86_64-pc-windows-msvc,    cpu: x86-64-v3,   ext: ".exe" }
-          # Windows on ARM — cross-compiled from the x64 runner.
-          - { tier: win-arm64,        os: windows-latest,   target: aarch64-pc-windows-msvc,   cpu: "",          ext: ".exe" }
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Install Rust + target
-        shell: bash
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup target add ${{ matrix.target }}
-      # [OPUS-4.8] sq-toze.8 (GX-7): cargo-auditable embeds the exact dependency
-      # manifest (versions + sources) INTO the released binary, so the shipped artifact
-      # is self-describing for post-build audit (`cargo audit bin <file>` / `auditable
-      # info <file>`). Negligible size cost; no runtime overhead.
-      - name: Install cargo-auditable
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
-        with:
-          tool: cargo-auditable
-      - name: Build (${{ matrix.cpu || 'default-cpu' }})
-        shell: bash
-        run: |
-          FLAGS=""
-          [ -n "${{ matrix.cpu }}" ] && FLAGS="-Ctarget-cpu=${{ matrix.cpu }}"
-          [ "${{ matrix.tier }}" = "arm64-linux" ] && FLAGS="$FLAGS -Ctarget-feature=+lse"
-          # `cargo auditable build` is a drop-in for `cargo build` that embeds the dep
-          # manifest into the binary (GX-7); same flags, same output path.
-          RUSTFLAGS="$FLAGS" cargo auditable build --release --locked -p sparq-cli --target ${{ matrix.target }}
-      - name: Package (binary + README + LICENSE + CHANGELOG)
-        shell: bash
-        run: |
-          PKG="sparq-cli-${GITHUB_REF_NAME}-${{ matrix.tier }}"
-          mkdir -p "pkg/$PKG"
-          cp "target/${{ matrix.target }}/release/sparq-cli${{ matrix.ext }}" "pkg/$PKG/"
-          cp README.md "pkg/$PKG/"
-          # LICENSE is copied when present (license = MIT is declared in Cargo.toml; adding
-          # the LICENSE file itself is on the pre-release checklist in docs/release.md).
-          if [ -f LICENSE ]; then cp LICENSE "pkg/$PKG/"; fi
-          if [ -f CHANGELOG.md ]; then cp CHANGELOG.md "pkg/$PKG/"; fi
-          cd pkg
-          case "${{ matrix.tier }}" in
-            win-*) 7z a "$PKG.zip" "$PKG" ;;
-            *)     tar czf "$PKG.tar.gz" "$PKG" ;;
-          esac
-      # [OPUS-4.8] sq-zqq6: SLSA build provenance over the packaged archives.
-      # Generates a signed attestation (Sigstore) binding each archive's digest
-      # to this workflow run; verifiable with `gh attestation verify <file>`.
-      - name: Attest build provenance (archives)
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: |
-            pkg/*.tar.gz
-            pkg/*.zip
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: pkg-${{ matrix.tier }}
-          path: |
-            pkg/*.tar.gz
-            pkg/*.zip
-          if-no-files-found: error
+    uses: ./.github/workflows/build-matrix.yml
+    with:
+      mode: archive
 
   # ---- 1b. per-release CycloneDX SBOM + VEX ----
   # [OPUS-4.8] sq-toze.3 (GX-2): emit a CycloneDX SBOM for each released binary plus a VEX


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-v286.2** (child of the automated-release-CI epic **sq-v286**): *"Unify duplicated release.yml/dist.yml build matrix via workflow_call; drop dist.yml tags trigger."*

## What changed
The 10-tier hardware build matrix — previously **hand-synced** across `release.yml#package` and `dist.yml#build` (identical runner labels + build steps, two copies) — is now defined **ONCE** in a new reusable workflow `.github/workflows/build-matrix.yml` (`workflow_call`), keyed by a required `mode` input that selects the artifact shape:

| mode | caller | artifact |
|------|--------|----------|
| `archive` | `release.yml` | versioned `tar.gz`/`zip` of binary + README + LICENSE + CHANGELOG, uploaded as `pkg-<tier>` (the `release` job adds `SHA256SUMS`) |
| `binary` | `dist.yml` | bare per-tier binary, uploaded as `sparq-cli-<tier>` (the launcher fat-package selects from these) |

Both modes run the identical shared head (checkout → Rust+target → cargo-auditable → `cargo auditable build`) and emit the same SLSA build-provenance attestation over their uploaded bytes.

**Dropped `dist.yml`'s `push: tags: ["v*"]` trigger** (kept `workflow_dispatch`) to end the release/dist double-build. `release.yml` remains the single tag-driven release entry point (the path the future release-plz tag flow drives). Per `research/release-ci-design.md` §5 ("Reuse, do not duplicate"; "dist/release double-build … Drop dist.yml's tags: trigger (keep workflow_dispatch)") and §6 sequencing item 2.

## Runner labels preserved (exact, no drift)
`macos-14` · `macos-15-intel` · `ubuntu-latest` · `ubuntu-24.04-arm` · `windows-latest` — all 10 tiers (target triple + target-cpu + ext) verified byte-for-byte against the originals.

## Verification (release/dist are NOT PR gates — verified by hand)
- **YAML**: all three workflows parse (`python3 yaml.safe_load`).
- **workflow_call wiring**: callee has the required `string` input `mode`; both callers are `uses:` jobs (no `runs-on`/`steps` mixed in) with `with.mode` set and `permissions:` granting `id-token`+`attestations: write` as the ceiling passed to the reusable workflow. `release.yml`'s `release` job still `needs: [package, sbom]` and downloads `pkg-*` (the call job is still named `package`).
- **No residual duplication**: the CLI matrix now appears in exactly one file (the `publish.yml` PyPI-wheel matrix is a separate artifact, out of scope).
- **SHA-pins**: all external actions pinned to 40-hex SHAs with version comments (code-scanning posture intact); the `./.github/workflows/build-matrix.yml` local refs need no pin (resolved at the caller's ref).
- **Gate aggregator**: unchanged — all three workflows are tag/dispatch-triggered and never register on a PR/`merge_group` ref, so `ci-summary / gate` is unaffected; this leg does not gate PRs.
- **Local reproduction**: replayed both `mode` tails — `archive` produced `sparq-cli-vX-<tier>.tar.gz` with binary+README+LICENSE+CHANGELOG; `binary` produced `dist/sparq-cli-<tier>`. The cross-target `cargo auditable build` matrix is the unchanged, already-proven command (not re-run here).

## Compliance impact
No level change — preserves the existing SLSA build-provenance + cargo-auditable posture exactly while removing the duplication maintenance hazard (hand-synced matrices drift). Sets up sq-v286.3/.4 (release-plz) to drive the single `release.yml` entry point.

Note: if early SBOM `GS-*` legs flake at ~9–12s, that's the known transient sq-90ew — re-run.