### PR TITLE
ci(release): add release-plz Release-PR + tag workflow → reuse release.yml (sq-v286.4) [OPUS-4.8]

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,127 @@
+# Automated semantic-release driver (release-plz) — epic sq-v286, item sq-v286.4.
+#
+# [OPUS-4.8] 🤖 SPARQ agent. Design record: research/release-ci-design.md
+#   §2  (tool selection: release-plz, release-PR model, git-cliff changelog engine)
+#   §6  item 4 ("Add the release-plz release-pr + release workflow … on merge tags
+#       vX.Y.Z, which fires the EXISTING release.yml unchanged").
+#
+# WHAT THIS DOES — the two-step release-plz flow, anchored on release-plz.toml
+# (#789 / sq-v286.3: the version_group over the 17 publishable crates that keeps the
+# locked single-version model):
+#
+#   1. release-pr  — on every push to main, release-plz reads the conventional-commit
+#                    history (+ cargo-semver-checks API-break detection), computes the
+#                    next single workspace version, and opens/UPDATES one "Release-PR"
+#                    that bumps the version across the version_group + rewrites
+#                    CHANGELOG.md (git-cliff) + updates Cargo.lock. Nothing is released
+#                    yet — a human reviews + merges that PR.
+#
+#   2. release     — when the Release-PR MERGES, its version-bump commit lands on main;
+#                    this push re-runs the workflow and `release-plz release` detects the
+#                    new version is not yet tagged and CREATES the `v<version>` git tag
+#                    (name from release-plz.toml `git_tag_name = "v{{ version }}"`).
+#
+# THE HANDOFF — tag → reuse existing release.yml (the whole point; do NOT duplicate the
+# build matrix here). The EXISTING release.yml triggers on `push: tags: ["v*"]`, so the
+# tag this job creates fires release.yml unchanged → its proven build-matrix.yml archive
+# matrix + CycloneDX SBOM/VEX + SLSA provenance + SHA256SUMS + GitHub Release + ghcr
+# container path all run exactly as today. This workflow adds NO build/package steps.
+#
+# SCOPE / RECONCILIATION (design §6 item 4 "Reconcile the two crates.io paths"):
+#   * GitHub Release ownership — release.yml's `release` job creates the GitHub Release
+#     (archives + SBOM/VEX + SHA256SUMS). release-plz's own GitHub-release creation is
+#     therefore DISABLED (`git_release_enable = false` in release-plz.toml) so the two do
+#     not collide on the same tag. release-plz creates the TAG ONLY; release.yml owns the
+#     Release. This is the "scope release-plz to the tag only" arm of design §6 item 4.
+#   * crates.io publish — kept MANUAL for now (`publish = false` in release-plz.toml):
+#     the `CARGO_REGISTRY_TOKEN` secret does not exist yet (it is the needs:user bead
+#     sq-v286.5 "complete out-of-repo publish prerequisites"). With publish disabled,
+#     `release-plz release` skips `cargo publish` and proceeds straight to tag creation —
+#     without that, cargo-publish-before-tag would fail with no token and the tag (hence
+#     the whole release) would never be cut. Flip to release-plz-driven publish once the
+#     token lands (then publish.yml only ATTESTS .crate bytes — the point of adoption).
+#
+# CARE — this workflow does NOT run on this PR (its triggers are push:main and the
+# Release-PR-merge push, never pull_request / merge_group), so it does NOT register on the
+# `ci-summary / gate` aggregator and cannot block this PR. The trade-off: a defect surfaces
+# only at release time, so trigger keys / action inputs / permissions / the tag→release.yml
+# handoff were hand-verified (see the PR body).
+name: release-plz
+
+on:
+  push:
+    branches: [main]
+
+# Default to no permissions; each job opts into exactly what it needs (least privilege).
+permissions: {}
+
+# Serialize release-plz runs on main so two quick pushes cannot race to open/update the
+# same Release-PR. cancel-in-progress: false — never abort a run that may be cutting a
+# tag/release mid-flight (matches release-plz's documented recommendation).
+concurrency:
+  group: release-plz-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ---- 1. Release-PR: open/update the version-bump + changelog PR on every push to main.
+  release-plz-pr:
+    name: release-plz / Release-PR
+    # Guard against forks: release-plz needs repo write + would open PRs on a fork clone.
+    # Mirrors bench-ec2.yml's `github.repository == 'jeswr/sparq'` guard.
+    if: github.repository == 'jeswr/sparq'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write       # commit the version bump + changelog onto the Release-PR branch
+      pull-requests: write  # open / update the Release-PR
+    steps:
+      - name: Checkout (full history for changelog generation)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # release-plz / git-cliff walk the full commit history to build the changelog.
+          fetch-depth: 0
+          # Do not leave the default GITHUB_TOKEN in the local git config; release-plz uses
+          # its own `token:` input for forge operations (release-plz docs recommendation).
+          persist-credentials: false
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # [OPUS-4.8] sq-v286.4: official release-plz action, SHA-pinned (code-scanning=0;
+      # the repo SHA-pins ALL actions). v0.5.130 — pin verified to peel to this commit via
+      # `gh api repos/release-plz/action/git/tags/<annotated> --jq .object.sha`.
+      - name: Run release-plz (open/update Release-PR)
+        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
+        with:
+          command: release-pr
+        env:
+          # GITHUB_TOKEN is what release-plz uses to open/update the Release-PR.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ---- 2. release: when the Release-PR's version commit is on main, create the v<version>
+  #         git tag. That tag fires the EXISTING release.yml (push: tags: ["v*"]) which does
+  #         all the building/packaging/releasing. No build matrix here by design.
+  release-plz-release:
+    name: release-plz / tag (handoff to release.yml)
+    if: github.repository == 'jeswr/sparq'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create + push the v<version> git tag
+    steps:
+      - name: Checkout (full history for tag detection)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # [OPUS-4.8] sq-v286.4: `release` command. With `publish = false` +
+      # `git_release_enable = false` in release-plz.toml, this creates ONLY the v<version>
+      # git tag — it skips cargo publish (needs:user token, sq-v286.5) and skips its own
+      # GitHub Release (release.yml owns that). The pushed tag then triggers release.yml.
+      - name: Run release-plz (create v<version> tag on version commit)
+        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
+        with:
+          command: release
+        env:
+          # Tagging is a forge operation done with GITHUB_TOKEN. No CARGO_REGISTRY_TOKEN is
+          # passed because crates.io publish is disabled (publish = false) until the
+          # needs:user token lands (sq-v286.5).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,12 +3,13 @@
 # [OPUS-4.8] sq-v286.3 (child of the automated-semantic-release epic sq-v286).
 # Design record: research/release-ci-design.md (§2 tool selection, §5/§6 sequencing).
 #
-# 🤖 SPARQ agent. Honest scope note: this file configures release-plz's
-# version + changelog POLICY only. It deliberately does NOT add the release-plz
-# WORKFLOW (that is the dependent bead sq-v286.4) and does NOT touch
-# release.yml / dist.yml / publish.yml (a sibling bead owns those). The keys
-# below take effect only once a release-plz workflow exists; until then this is
-# inert configuration.
+# 🤖 SPARQ agent. This file configures release-plz's version + changelog POLICY.
+# It was authored under sq-v286.3 as inert configuration; sq-v286.4 then added the
+# release-plz WORKFLOW (.github/workflows/release-plz.yml) that ACTIVATES it, plus the
+# two tag-only handoff keys near the bottom of [workspace] (git_release_enable = false,
+# publish = false) that this file's keys take effect through. It still does NOT touch
+# release.yml / dist.yml / publish.yml (those stay sibling-owned); the handoff is via the
+# `vX.Y.Z` tag only.
 #
 # Why this file exists — the one workspace decision release-plz forces
 # (design §2 "The one workspace decision release-plz forces"):
@@ -38,6 +39,26 @@ semver_check = true
 # locked single-version model. Design §6 step 4: merging the release PR tags
 # `vX.Y.Z`, which fires release.yml unchanged.
 git_tag_name = "v{{ version }}"
+
+# --- Tag-only handoff to release.yml (activated by the release-plz WORKFLOW) -----------
+# [OPUS-4.8] sq-v286.4 (the workflow bead this file's header defers "activation" to;
+# .github/workflows/release-plz.yml). The two keys below are what make the `release-plz
+# release` command create the `vX.Y.Z` tag ONLY, so the tag hands off cleanly to the
+# existing release.yml (design §6 item 4: "scope release-plz to the tag only").
+#
+# git_release_enable = false — release.yml's `release` job already creates the GitHub
+#   Release (archives + CycloneDX SBOM/VEX + SHA256SUMS, via build-matrix.yml). Leaving
+#   release-plz's default `true` would make release-plz ALSO create a GitHub Release for
+#   the same tag → a collision (duplicate/empty release racing release.yml). Disable it:
+#   release-plz creates the tag, release.yml owns the Release.
+git_release_enable = false
+# publish = false — crates.io publish stays MANUAL for now. The `CARGO_REGISTRY_TOKEN`
+#   secret does not exist yet (needs:user bead sq-v286.5). release-plz runs `cargo publish`
+#   BEFORE creating the tag, so with the default `true` and no token the publish step would
+#   fail and the tag would never be cut. Disabling publish lets `release-plz release`
+#   skip straight to tagging. Flip to `true` (release-plz-driven publish, publish.yml then
+#   only attests .crate bytes) once sq-v286.5 provisions the token — "the point of adoption".
+publish = false
 
 # --- The locked version_group: all 17 publishable crates ---------------------
 # These are exactly the crates under crates/* WITHOUT `publish = false`


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-v286.4** — the release-plz two-step flow — child of the maintainer-requested automated semantic-release epic **sq-v286**. Deps merged: `release-plz.toml` (#789) and the unified `release.yml`/`build-matrix.yml` (#790). Design: `research/release-ci-design.md` §2 (tool choice) + §6 item 4 (this item's sequencing).

## What this wires

New `.github/workflows/release-plz.yml`, on `push: branches: [main]`, two jobs:

| job | command | permissions | does |
|---|---|---|---|
| `release-plz / Release-PR` | `release-pr` | `contents: write` + `pull-requests: write` | opens/updates ONE Release-PR: version bump across the 17-crate `version_group` + `CHANGELOG.md` (git-cliff) + `Cargo.lock` |
| `release-plz / tag (handoff to release.yml)` | `release` | `contents: write` | on the merged version commit, creates the `v<version>` git tag |

Both jobs: fork-guarded (`github.repository == 'jeswr/sparq'`, matching `bench-ec2.yml`), top-level `permissions: {}` with per-job least-privilege opt-in, `fetch-depth: 0` + `persist-credentials: false` checkout, `concurrency` group (`cancel-in-progress: false`).

## The Release-PR → tag → release.yml handoff (the whole point)

`release-plz.toml` sets `git_tag_name = "v{{ version }}"`. The `release` job creates the `v<version>` tag; the **existing** `release.yml` (`on: push: tags: ["v*"]`) fires unchanged → its proven `build-matrix.yml` archive matrix + CycloneDX SBOM/VEX + SLSA provenance + SHA256SUMS + GitHub Release + ghcr container all run as today. **No build matrix is duplicated here** (design §6 item 4; `build-matrix.yml` untouched — sibling sq-v286.6 owns it).

## Required reconciliation in `release-plz.toml` (honest cross-bead touch)

`release-plz.toml`'s header explicitly deferred *activation* to this workflow bead. Activating it correctly needs two `[workspace]` keys, or the release-time path is broken:

- **`git_release_enable = false`** — `release.yml` already creates the GitHub Release for the tag. release-plz's default (`true`) would create a **colliding** Release for the same tag. Disabled → release-plz creates the tag, `release.yml` owns the Release.
- **`publish = false`** — crates.io publish stays manual: the `CARGO_REGISTRY_TOKEN` secret does not exist yet (it is **needs:user**, sq-v286.5). release-plz runs `cargo publish` **before** tagging, so with the default `true` and no token the publish would fail and **the tag would never be cut**. Disabled → `release` skips publish and tags directly. Flip to `true` (release-plz-driven publish; `publish.yml` then only attests `.crate` bytes) once sq-v286.5 lands — the chosen "scope release-plz to the tag only" arm of design §6 item 4.

## Verification (release workflows do NOT run on this PR — hand-verified)

- **YAML**: `python3 -c 'import yaml; yaml.safe_load(...)'` → OK. `release-plz.toml` parses; `git_release_enable=false`, `publish=false`, `git_tag_name='v{{ version }}'`, 17 packages.
- **actionlint**: not installed in this env (no Go toolchain); structure hand-verified by parsing the YAML.
- **SHA-pins**: all three `uses:` are exact 40-hex SHAs with version comments. `release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130` — verified via `gh api repos/release-plz/action/git/tags/<annotated-tag>` peeling to that commit. `actions/checkout@…9c091bb # v7.0.0` and `dtolnay/rust-toolchain@…29eef336 # stable` match the repo's canonical pins.
- **Action inputs**: confirmed against `release-plz/action` `action.yml` — `command: release-pr` / `command: release`; `GITHUB_TOKEN` env for forge ops; no `CARGO_REGISTRY_TOKEN` passed (publish disabled).
- **Gate aggregator**: triggers are `push: main` only — **no `pull_request`/`merge_group`**, so this workflow does NOT register on `ci-summary / gate` and cannot block this PR or the merge queue. Confirmed by parsing `on:`.

## Compliance gap closed

Automates the version-decision + changelog + tag steps that `docs/release.md` §1–§2 do by hand today (the stale-`[Unreleased]` problem in design §1), while **reusing** the existing release/SBOM/SLSA estate rather than duplicating it — Conventional-Commits + cargo-semver-checks SemVer inference feeding the proven tag-driven release path.

Files: `.github/workflows/release-plz.yml` (new), `release-plz.toml` (two-key reconciliation).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>