### PR TITLE
feat(site): GUI Phase 2 endpoint mode — Connect panel + SPARQL 1.1 Protocol client (sq-2mke) [OPUS-4.8]

### DIFF
--- a/packages/sparq-client/README.md
+++ b/packages/sparq-client/README.md
@@ -19,6 +19,34 @@ re-exports the surface from here; the (proposed) Tauri 2 GUI consumes the same p
   unchanged; a desktop GUI passes its own `tauri://` / `file://` origin).
 - The framework-agnostic query helpers: `matchQuads`, `countQuads`, `streamQueryRows`,
   `sparqShaclValidate`, `formatTerm`.
+- **Endpoint mode** (`src/endpoint.ts`, `sq-2mke`): the SPARQL 1.1 Protocol HTTP client —
+  the companion to the in-tab `WasmStore`. Run the SAME editor against any running
+  `sparq-server` (or any conformant endpoint) over `fetch`. `runEndpointQuery(config, sparql)`
+  classifies the form (`classifyEndpointForm`), builds the request (`buildSparqlRequest`: a
+  direct `application/sparql-query` POST for reads with per-form `Accept`, a direct
+  `application/sparql-update` POST for writes, bearer-auth in the `Authorization` header only),
+  and parses the response per form (SELECT/ASK JSON, CONSTRUCT/DESCRIBE N-Triples, a `204`
+  update ack). `connectionSafetyWarnings(config)` is the pure, honest connection-safety
+  classifier that drives the Connect-panel UX; `wsSubprotocols(token)` derives the
+  `bearer.<token>` subprotocol the server's WS handshake accepts (browsers cannot set an
+  `Authorization` header on a WS upgrade). This client **consumes** the existing server API and
+  **never bypasses a server gate** — it claims no security the server does not provide.
+
+## Endpoint-mode safety posture (honest, never an overclaim)
+
+`connectionSafetyWarnings` mirrors the real `sparq-server` posture (`crates/sparq-server/README.md`)
+and the browser's transport rules, as classified `SafetyWarning`s (each with a stable `code`):
+
+- `invalid-url` / `mixed-content` (**error**, hard block): not a valid http(s) URL; or an HTTPS
+  page cannot `fetch` a plaintext `http:` endpoint (the browser blocks it before any request).
+- `token-over-plaintext` / `non-loopback-no-tls` (**warning**): a bearer token — or the query and
+  results — sent over plaintext `http:` to a **non-loopback** host travel in cleartext. (A token
+  over **loopback** `http:` stays on the machine, so it is only an `info` note.) The server's
+  Bearer gate is one shared secret with no per-user identity.
+- `service-allowlist` / `cors-required` (**info**): a `SERVICE` clause is refused before any
+  socket unless the operator set the egress allowlist (off / default-DENY); and the server emits
+  **no CORS headers** by default, so a cross-origin browser fetch is blocked until an origin is
+  opted in (`--cors-allow-origin`).
 
 ## What's NOT in it (deliberately)
 

--- a/packages/sparq-client/src/endpoint.ts
+++ b/packages/sparq-client/src/endpoint.ts
@@ -1,0 +1,453 @@
+// [OPUS-4.8] sq-2mke — SPARQL 1.1 Protocol HTTP client (endpoint mode).
+//
+// This is the framework-agnostic client that lets the SAME editor run against any
+// running SPARQL 1.1 Protocol endpoint (a `sparq-server`, or any conformant endpoint)
+// instead of the in-tab WASM store. It is the companion to the WASM `Store` surface in
+// `./index.ts`: where that one executes locally with no network, this one speaks the
+// wire protocol over `fetch`.
+//
+// It is built to CONSUME the existing `sparq-server` HTTP API
+// (`crates/sparq-server/src/http.rs`) — it changes nothing server-side and claims no
+// security the server does not provide. It honours the server's security posture
+// (`crates/sparq-server/README.md`) as connection-safety UX: it surfaces honest warnings
+// (a bearer token over plaintext to a non-loopback host is exposed in transit; an empty
+// SERVICE allowlist on the server means federation is refused) but NEVER bypasses any
+// gate. The bearer token is sent ONLY in the `Authorization` header (and, for the WS
+// handshake that browsers cannot set headers on, the `Sec-WebSocket-Protocol:
+// bearer.<token>` subprotocol the server's `ws_auth_gate` validates) — never echoed,
+// never logged.
+//
+// No React, no Next.js, no DOM beyond the `fetch` / `URL` / `WebSocket` web platform
+// globals. No performance claim is made here (this repo's work box is non-canonical).
+
+import type { SparqlResults } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// Content types — exactly what the server's `negotiate.rs` understands.
+// ---------------------------------------------------------------------------
+
+/** SPARQL 1.1 Protocol media types (mirrors `crates/sparq-server/src/negotiate.rs`). */
+export const SPARQL_RESULTS_JSON = "application/sparql-results+json";
+/** RDF graph media type the server returns for CONSTRUCT / DESCRIBE / GSP reads. */
+export const SPARQL_GRAPH_NTRIPLES = "application/n-triples";
+/** Direct-POST query Content-Type (SPARQL 1.1 Protocol §2.1.3). */
+const SPARQL_QUERY_CT = "application/sparql-query";
+/** Direct-POST update Content-Type (SPARQL 1.1 Protocol §2.2.2). */
+const SPARQL_UPDATE_CT = "application/sparql-update";
+
+// ---------------------------------------------------------------------------
+// Connection config + the honest safety classifier.
+// ---------------------------------------------------------------------------
+
+/** A configured connection to a SPARQL 1.1 Protocol endpoint. */
+export interface EndpointConfig {
+  /** The endpoint URL, e.g. `http://127.0.0.1:3030/sparql`. */
+  url: string;
+  /**
+   * Optional Bearer token. The server's write gate (`--auth-token`) and read gate
+   * (`--auth-token-read`) are one shared secret with no per-user identity; this is sent
+   * verbatim as `Authorization: Bearer <token>`. Empty / whitespace-only is treated as
+   * "no token".
+   */
+  token?: string;
+}
+
+/** Severity of a {@link SafetyWarning}: a hard block vs an advisory the user can proceed past. */
+export type SafetyLevel = "error" | "warning" | "info";
+
+/** A stable identifier for each safety finding (so the UI / tests key on it, not prose). */
+export type SafetyCode =
+  | "invalid-url"
+  | "token-over-plaintext"
+  | "mixed-content"
+  | "non-loopback-no-tls"
+  | "service-allowlist"
+  | "cors-required";
+
+/** One honest connection-safety finding surfaced in the Connect panel UI. */
+export interface SafetyWarning {
+  level: SafetyLevel;
+  code: SafetyCode;
+  message: string;
+}
+
+/** Is this hostname a loopback address (the server's safe default bind)? */
+export function isLoopbackHost(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  if (h === "localhost" || h === "127.0.0.1" || h === "::1" || h === "[::1]") {
+    return true;
+  }
+  // 127.0.0.0/8 is entirely loopback.
+  if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(h)) return true;
+  return false;
+}
+
+/** Parse the endpoint URL, or `null` if it is not a valid absolute http(s) URL. */
+export function parseEndpointUrl(url: string): URL | null {
+  const trimmed = url.trim();
+  if (trimmed === "") return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  return parsed;
+}
+
+/**
+ * The current page origin's protocol, if the client runs in a browser (`"https:"` /
+ * `"http:"`), else `undefined` (Node / SSR type-check). Used only to detect the
+ * mixed-content block a browser enforces on an HTTPS page fetching an HTTP endpoint.
+ */
+function pageProtocol(): string | undefined {
+  return typeof window !== "undefined" ? window.location?.protocol : undefined;
+}
+
+/**
+ * [OPUS-4.8] sq-2mke — the honest connection-safety classifier. Pure (no network), so it
+ * is unit-testable and drives the Connect-panel warnings. It NEVER blocks a query by
+ * itself (that is the UI's choice); it returns findings that faithfully describe the
+ * server's posture (`crates/sparq-server/README.md`) and the browser's transport rules:
+ *
+ * - `invalid-url` (error): the URL is not a valid absolute http(s) URL.
+ * - `mixed-content` (error): an HTTPS page cannot `fetch` a plaintext-`http:` endpoint —
+ *   the browser blocks it before any request. A hard block, not advice.
+ * - `token-over-plaintext` (warning): a Bearer token sent over `http:` (not `https:`) to a
+ *   NON-loopback host travels in cleartext and can be intercepted. (Loopback `http:` stays
+ *   on the machine, so a token there is only an info note, below.)
+ * - `non-loopback-no-tls` (warning): talking plaintext `http:` to a non-loopback host at
+ *   all — even without a token the query + results are in cleartext, and the server refuses
+ *   a non-loopback bind unless `--allow-remote` (so reaching it means it was deliberately
+ *   exposed).
+ * - `service-allowlist` (info): a reminder that the server's SERVICE federation is OFF by
+ *   default and, even with `--features service`, default-DENY — a `SERVICE` clause is
+ *   refused before any socket unless the operator set an egress allowlist. We cannot see
+ *   the server's config from the client, so this is surfaced as an honest "may be refused".
+ * - `cors-required` (info): the server emits NO CORS headers by default, so a cross-origin
+ *   browser fetch is blocked until the operator opts an origin in (`--cors-allow-origin`).
+ *   Surfaced when the endpoint origin differs from the page origin.
+ */
+export function connectionSafetyWarnings(config: EndpointConfig): SafetyWarning[] {
+  const warnings: SafetyWarning[] = [];
+  const parsed = parseEndpointUrl(config.url);
+  if (!parsed) {
+    warnings.push({
+      level: "error",
+      code: "invalid-url",
+      message:
+        "Enter a valid absolute endpoint URL (http:// or https://), e.g. http://127.0.0.1:3030/sparql.",
+    });
+    return warnings;
+  }
+
+  const hasToken = (config.token ?? "").trim() !== "";
+  const isTls = parsed.protocol === "https:";
+  const loopback = isLoopbackHost(parsed.hostname);
+  const page = pageProtocol();
+
+  // A browser blocks an HTTPS page from fetching a plaintext http: endpoint outright.
+  if (page === "https:" && parsed.protocol === "http:") {
+    warnings.push({
+      level: "error",
+      code: "mixed-content",
+      message:
+        "This page is served over HTTPS, so the browser will block a request to a plaintext http:// endpoint (mixed content). Serve the endpoint over HTTPS, or open this editor over http (e.g. a local dev server).",
+    });
+  }
+
+  if (!isTls && !loopback) {
+    if (hasToken) {
+      warnings.push({
+        level: "warning",
+        code: "token-over-plaintext",
+        message:
+          "You are sending a Bearer token over plaintext http:// to a non-loopback host — it travels in cleartext and can be intercepted. Use https:// for any remote, authenticated endpoint. The server's Bearer gate is a single shared secret with no per-user identity (sparq-server README, Security posture).",
+      });
+    }
+    warnings.push({
+      level: "warning",
+      code: "non-loopback-no-tls",
+      message:
+        "Plaintext http:// to a non-loopback host: the query and results travel in cleartext. The server refuses a non-loopback bind unless it was started with --allow-remote, so this endpoint was deliberately exposed.",
+    });
+  } else if (!isTls && loopback && hasToken) {
+    // Loopback http: keeps the token on the machine — not a transit risk, just a note.
+    warnings.push({
+      level: "info",
+      code: "token-over-plaintext",
+      message:
+        "Bearer token sent over loopback http:// — it stays on this machine (no transit exposure). The token is sent only in the Authorization header, never logged by this client.",
+    });
+  }
+
+  // Cross-origin browser fetch needs server CORS, which is OFF by default.
+  if (page && typeof window !== "undefined") {
+    const pageOrigin = window.location?.origin;
+    if (pageOrigin && pageOrigin !== parsed.origin) {
+      warnings.push({
+        level: "info",
+        code: "cors-required",
+        message:
+          "The endpoint is a different origin from this page. sparq-server emits NO CORS headers by default, so the browser will block this cross-origin request until the operator opts this origin in (--cors-allow-origin). A same-origin or CORS-enabled endpoint is required.",
+      });
+    }
+  }
+
+  warnings.push({
+    level: "info",
+    code: "service-allowlist",
+    message:
+      "If your query uses SERVICE (federation), note the server's SERVICE egress is OFF by default and, even with the service feature, default-DENY — a SERVICE clause is refused before any network call unless the operator set an egress allowlist (sparq-server README).",
+  });
+
+  return warnings;
+}
+
+/** Does any warning block the request outright (a hard error, not an advisory)? */
+export function hasBlockingWarning(warnings: SafetyWarning[]): boolean {
+  return warnings.some((w) => w.level === "error");
+}
+
+// ---------------------------------------------------------------------------
+// The query form classifier (shared shape with the WASM REPL).
+// ---------------------------------------------------------------------------
+
+/** The SPARQL form the endpoint client dispatches on. */
+export type EndpointForm =
+  | "select"
+  | "ask"
+  | "graph" // CONSTRUCT / DESCRIBE
+  | "update";
+
+/** The result of running a query against the endpoint, tagged by form. */
+export type EndpointResult =
+  | { kind: "select"; results: SparqlResults; status: number }
+  | { kind: "boolean"; value: boolean; status: number }
+  | { kind: "graph"; ntriples: string; status: number }
+  | { kind: "update"; status: number };
+
+/**
+ * Classify a SPARQL string into the protocol operation the endpoint client uses. This
+ * folds to the four wire shapes: a query is a SELECT/ASK (SPARQL-results body), a
+ * CONSTRUCT/DESCRIBE (RDF graph body), or an update (no body, a 204).
+ *
+ * To find the operative keyword past a PREFIX/BASE prologue, the noise that would
+ * otherwise yield spurious word tokens is stripped FIRST — line comments (`#…`), IRIs
+ * (`<…>`), and string literals (`"…"` / `'…'`) — so a `PREFIX ex: <http://example.org/>`
+ * declaration contributes only the `PREFIX` and `ex` tokens, not `http`/`example`/`org`.
+ * A whole `PREFIX <label>` declaration is then skipped. The default is `select` (the
+ * protocol's query operation); the server's parser remains the source of truth on
+ * validity, so an unrecognised lead keyword is treated as a query, never silently an
+ * update (which would mis-route a read to the write path).
+ */
+export function classifyEndpointForm(sparql: string): EndpointForm {
+  const stripped = sparql
+    .replace(/#[^\n]*/g, " ") // line comments
+    .replace(/<[^>]*>/g, " ") // IRIs
+    .replace(/"(?:\\.|[^"\\])*"/g, " ") // double-quoted literals
+    .replace(/'(?:\\.|[^'\\])*'/g, " "); // single-quoted literals
+  const tokens = stripped.match(/[A-Za-z]+/g) ?? [];
+  for (let i = 0; i < tokens.length; i++) {
+    const kw = tokens[i].toUpperCase();
+    if (kw === "PREFIX") {
+      i += 1; // skip the prefix label token (the IRI was stripped above)
+      continue;
+    }
+    if (kw === "BASE") continue;
+    switch (kw) {
+      case "SELECT":
+        return "select";
+      case "ASK":
+        return "ask";
+      case "CONSTRUCT":
+      case "DESCRIBE":
+        return "graph";
+      case "INSERT":
+      case "DELETE":
+      case "LOAD":
+      case "CLEAR":
+      case "CREATE":
+      case "DROP":
+      case "COPY":
+      case "MOVE":
+      case "ADD":
+      case "WITH":
+        return "update";
+      default:
+        return "select";
+    }
+  }
+  return "select";
+}
+
+// ---------------------------------------------------------------------------
+// Request building (pure — so it is unit-testable without a network).
+// ---------------------------------------------------------------------------
+
+/** A prepared `fetch` request: the resolved URL + the RequestInit. */
+export interface PreparedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+/** Add the `Authorization: Bearer <token>` header iff a non-empty token is configured. */
+function withAuth(headers: Record<string, string>, token?: string): Record<string, string> {
+  const t = (token ?? "").trim();
+  if (t !== "") headers["Authorization"] = `Bearer ${t}`;
+  return headers;
+}
+
+/**
+ * Build the `fetch` request for a SPARQL operation against the endpoint. Reads
+ * (SELECT/ASK/CONSTRUCT/DESCRIBE) use a direct `application/sparql-query` POST — the most
+ * robust form (no URL-length limit, no query-string PII), accepted by the server's
+ * `sparql_endpoint` POST path and the wider SPARQL 1.1 Protocol. Updates use a direct
+ * `application/sparql-update` POST (the server's write path, gated by `--auth-token`).
+ * The `Accept` header asks for the precise media type per form so content negotiation is
+ * deterministic.
+ */
+export function buildSparqlRequest(
+  config: EndpointConfig,
+  sparql: string,
+  form: EndpointForm,
+): PreparedRequest {
+  if (form === "update") {
+    return {
+      url: config.url,
+      init: {
+        method: "POST",
+        headers: withAuth({ "Content-Type": SPARQL_UPDATE_CT }, config.token),
+        body: sparql,
+      },
+    };
+  }
+  const accept = form === "graph" ? SPARQL_GRAPH_NTRIPLES : SPARQL_RESULTS_JSON;
+  return {
+    url: config.url,
+    init: {
+      method: "POST",
+      headers: withAuth(
+        { "Content-Type": SPARQL_QUERY_CT, Accept: accept },
+        config.token,
+      ),
+      body: sparql,
+    },
+  };
+}
+
+/**
+ * Build the WebSocket subprotocols for a `/subscriptions` handshake: the
+ * `bearer.<token>` subprotocol the server's `ws_auth_gate` accepts (browsers cannot set
+ * an `Authorization` header on a WS upgrade). Returns `[]` when no token is configured.
+ * This client does not open subscriptions itself (that is the live-subscriptions view,
+ * tracked separately); this helper exists so the same auth posture is reused there
+ * without re-deriving the subprotocol string.
+ */
+export function wsSubprotocols(token?: string): string[] {
+  const t = (token ?? "").trim();
+  return t === "" ? [] : [`bearer.${t}`];
+}
+
+// ---------------------------------------------------------------------------
+// Execution (the single network path).
+// ---------------------------------------------------------------------------
+
+/** A structured failure from an endpoint request (HTTP error, or a transport failure). */
+export class EndpointError extends Error {
+  readonly status: number | null;
+  constructor(message: string, status: number | null) {
+    super(message);
+    this.name = "EndpointError";
+    this.status = status;
+  }
+}
+
+/**
+ * Turn a non-2xx response into an {@link EndpointError} with an honest, classified message
+ * that mirrors the server's status contract (`crates/sparq-server` `status_contract`):
+ * 401 → auth required; 4xx → fix the request; 429/503 → transient, retry; 5xx → server
+ * defect. The server's error body is a generic `{"error":"…"}` class (it never leaks
+ * internals), so we surface the class verbatim when present.
+ */
+async function toEndpointError(resp: Response): Promise<EndpointError> {
+  let detail = "";
+  try {
+    const text = await resp.text();
+    if (text) {
+      try {
+        const parsed = JSON.parse(text) as { error?: string };
+        detail = parsed?.error ?? text;
+      } catch {
+        detail = text;
+      }
+    }
+  } catch {
+    /* body unreadable — fall through to the status-only message */
+  }
+  const prefix =
+    resp.status === 401
+      ? "Authentication required — the server gates this operation behind a Bearer token. Enter a valid token in the Connect panel."
+      : resp.status === 429 || resp.status === 503
+        ? `Server temporarily unavailable (${resp.status}) — transient, safe to retry.`
+        : resp.status >= 500
+          ? `Server error (${resp.status}).`
+          : `Request rejected (${resp.status}).`;
+  const message = detail ? `${prefix} ${detail}` : prefix;
+  return new EndpointError(message, resp.status);
+}
+
+/**
+ * Run a SPARQL operation against the configured endpoint over `fetch`. Classifies the
+ * form, builds the request, sends it, and parses the response per form:
+ * - SELECT → `{ kind: "select", results }` (parses the SPARQL-results JSON; an ASK that
+ *   was classified as SELECT still surfaces as a boolean when the body carries one).
+ * - ASK → `{ kind: "boolean", value }`.
+ * - CONSTRUCT/DESCRIBE → `{ kind: "graph", ntriples }` (the N-Triples body).
+ * - Update → `{ kind: "update" }` on the server's `204`.
+ *
+ * Throws an {@link EndpointError} on any non-2xx (with the server's error class) or a
+ * transport failure (CORS block, DNS, refused connection) with an honest hint. The bearer
+ * token is sent only in the `Authorization` header; it is never logged here.
+ */
+export async function runEndpointQuery(
+  config: EndpointConfig,
+  sparql: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<EndpointResult> {
+  const form = classifyEndpointForm(sparql);
+  const { url, init } = buildSparqlRequest(config, sparql, form);
+
+  let resp: Response;
+  try {
+    resp = await fetchImpl(url, init);
+  } catch (e) {
+    // A browser surfaces a CORS block / network failure as an opaque TypeError; give an
+    // honest hint rather than a bare "Failed to fetch".
+    const base = e instanceof Error ? e.message : String(e);
+    throw new EndpointError(
+      `Could not reach the endpoint (${base}). This is usually a CORS block (the server emits no CORS headers by default — opt this origin in with --cors-allow-origin), a refused connection (is the server running and bound to a reachable address?), or a mixed-content block (HTTPS page → http endpoint).`,
+      null,
+    );
+  }
+
+  if (!resp.ok) {
+    throw await toEndpointError(resp);
+  }
+
+  if (form === "update") {
+    return { kind: "update", status: resp.status };
+  }
+  if (form === "graph") {
+    const ntriples = (await resp.text()).trim();
+    return { kind: "graph", ntriples, status: resp.status };
+  }
+  // SELECT / ASK — a SPARQL-results JSON document.
+  const text = await resp.text();
+  const parsed = JSON.parse(text) as SparqlResults;
+  if (typeof parsed.boolean === "boolean") {
+    return { kind: "boolean", value: parsed.boolean, status: resp.status };
+  }
+  return { kind: "select", results: parsed, status: resp.status };
+}

--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -388,6 +388,35 @@ export {
   formatSparqlJson,
 } from "./results.js";
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-2mke — endpoint mode: the SPARQL 1.1 Protocol HTTP client.
+// The companion to the in-tab WASM `Store` above — run the SAME editor against any
+// running SPARQL 1.1 Protocol endpoint over `fetch`, with bearer-auth and the honest
+// connection-safety classifier. Consumes the existing `sparq-server` API; bypasses no
+// server gate; claims no security the server does not provide.
+// ---------------------------------------------------------------------------
+
+export {
+  type EndpointConfig,
+  type EndpointForm,
+  type EndpointResult,
+  type PreparedRequest,
+  type SafetyCode,
+  type SafetyLevel,
+  type SafetyWarning,
+  EndpointError,
+  SPARQL_GRAPH_NTRIPLES,
+  SPARQL_RESULTS_JSON,
+  buildSparqlRequest,
+  classifyEndpointForm,
+  connectionSafetyWarnings,
+  hasBlockingWarning,
+  isLoopbackHost,
+  parseEndpointUrl,
+  runEndpointQuery,
+  wsSubprotocols,
+} from "./endpoint.js";
+
 /** Renders a term for display, with a compact datatype/lang suffix. */
 export function formatTerm(t: SparqlTerm | undefined): string {
   if (!t) return "";

--- a/site/src/app/try/page.tsx
+++ b/site/src/app/try/page.tsx
@@ -5,7 +5,7 @@ import { Repl } from "@/components/repl";
 export const metadata: Metadata = {
   title: "Live SPARQL REPL",
   description:
-    "Run real SPARQL queries against a sample RDF graph using the sparq engine compiled to WebAssembly — live in your browser tab, nothing sent to a server.",
+    "Run real SPARQL queries with the sparq engine compiled to WebAssembly — live in your browser tab by default — or connect the same editor to a running sparq-server over the SPARQL 1.1 Protocol.",
 };
 
 export default function TryPage() {
@@ -15,13 +15,22 @@ export default function TryPage() {
         <h1 className="text-2xl font-semibold">Live SPARQL REPL</h1>
         <p className="measure text-muted-foreground">
           The shared engine component. Edit the query, pick an example, and run —
-          every query executes against the sample graph using the real sparq Rust
-          engine compiled to WebAssembly. The lean bundle ships the parser,
-          triplestore and SPARQL 1.1/1.2 engine: SELECT / ASK / CONSTRUCT / DESCRIBE
-          and SPARQL Update (INSERT / DELETE, mutating the in-tab store), over BGP,
-          FILTER, OPTIONAL, UNION, MINUS, BIND, VALUES, aggregates, property paths,
-          sub-SELECT and RDF-star. Switch to the EXPLAIN / ANALYZE mode to inspect
-          the query plan.
+          by default every query executes against the sample graph using the real sparq
+          Rust engine compiled to WebAssembly, entirely in your browser tab with nothing
+          sent to a server. The lean bundle ships the parser, triplestore and SPARQL
+          1.1/1.2 engine: SELECT / ASK / CONSTRUCT / DESCRIBE and SPARQL Update
+          (INSERT / DELETE, mutating the in-tab store), over BGP, FILTER, OPTIONAL, UNION,
+          MINUS, BIND, VALUES, aggregates, property paths, sub-SELECT and RDF-star. Switch
+          to the EXPLAIN / ANALYZE mode to inspect the query plan.
+        </p>
+        <p className="measure text-muted-foreground">
+          The <span className="font-medium text-foreground">Connect</span> panel runs the
+          same editor against any running sparq-server over the SPARQL 1.1 Protocol —
+          enter an endpoint URL and an optional bearer token. The token is sent only in the
+          HTTP <code className="font-mono text-[0.9em]">Authorization</code> header; the
+          panel surfaces honest connection-safety warnings (a token over plaintext to a
+          non-loopback host, a cross-origin request the server must opt in via CORS, a
+          SERVICE clause the server refuses by default) and never bypasses a server gate.
         </p>
       </header>
       <Repl />

--- a/site/src/components/connect-panel.tsx
+++ b/site/src/components/connect-panel.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+// [OPUS-4.8] sq-2mke — GUI Phase 2 item 6: the "Connect" panel for endpoint mode.
+//
+// This panel lets the SAME SPARQL editor run against any running SPARQL 1.1 Protocol
+// endpoint (a `sparq-server`, or any conformant endpoint) instead of the in-tab WASM
+// store. It CONSUMES the existing server API (`crates/sparq-server/src/http.rs`) — it
+// changes nothing server-side — and honours the server's security posture
+// (`crates/sparq-server/README.md`) as honest connection-safety UX, never bypassing a
+// gate. The bearer token is sent only in the `Authorization` header by the shared client;
+// this panel never logs it.
+//
+// All wire-protocol + safety logic lives in the framework-agnostic `@sparq/client`
+// endpoint module; this component is just the React host that draws the form, the
+// classified warnings, and the connection-test result.
+
+import * as React from "react";
+import {
+  Loader2,
+  PlugZap,
+  Plug,
+  ShieldAlert,
+  ShieldCheck,
+  Info,
+  CircleCheck,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  type EndpointConfig,
+  type SafetyWarning,
+  connectionSafetyWarnings,
+  hasBlockingWarning,
+  parseEndpointUrl,
+  runEndpointQuery,
+} from "@sparq/client";
+
+/** The connection-test lifecycle, surfaced inline under the form. */
+type TestState =
+  | { kind: "idle" }
+  | { kind: "testing" }
+  | { kind: "ok"; ms: number }
+  | { kind: "fail"; message: string };
+
+export interface ConnectPanelProps {
+  /** The current endpoint config (URL + optional token), lifted into the REPL. */
+  config: EndpointConfig;
+  /** Update the config (controlled by the parent so the REPL can route queries). */
+  onConfigChange: (config: EndpointConfig) => void;
+  /** Whether endpoint mode is currently active (queries route to the endpoint). */
+  active: boolean;
+  /** Toggle endpoint mode on/off. */
+  onActiveChange: (active: boolean) => void;
+}
+
+/**
+ * [OPUS-4.8] sq-2mke — the Connect panel. Renders the endpoint URL + optional bearer
+ * token, the live connection-safety warnings (pure `connectionSafetyWarnings`), an
+ * "endpoint mode" toggle, and a "Test connection" button that runs a trivial `ASK {}`
+ * through the shared client so a misconfig is caught before the user runs a real query.
+ */
+export function ConnectPanel({
+  config,
+  onConfigChange,
+  active,
+  onActiveChange,
+}: ConnectPanelProps) {
+  const [test, setTest] = React.useState<TestState>({ kind: "idle" });
+
+  // The honest safety findings for the current config — recomputed as the user types.
+  // Pure + synchronous (no network), so it is cheap to run on every render.
+  const warnings = React.useMemo(
+    () => connectionSafetyWarnings(config),
+    [config],
+  );
+  const blocked = hasBlockingWarning(warnings);
+  const urlValid = parseEndpointUrl(config.url) !== null;
+
+  // Reset any stale test verdict when the connection details change.
+  React.useEffect(() => {
+    setTest({ kind: "idle" });
+  }, [config.url, config.token]);
+
+  const testConnection = React.useCallback(async () => {
+    setTest({ kind: "testing" });
+    try {
+      // A trivial ASK is the cheapest legal SPARQL read; it exercises the exact request
+      // path (POST application/sparql-query + Accept + bearer) a real query would use, so
+      // a CORS / auth / reachability problem surfaces here, not mid-query.
+      const t0 = performance.now();
+      await runEndpointQuery(config, "ASK { ?s ?p ?o }");
+      const ms = performance.now() - t0;
+      setTest({ kind: "ok", ms });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setTest({ kind: "fail", message });
+    }
+  }, [config]);
+
+  return (
+    <div className="space-y-3 rounded-lg border bg-muted/30 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+          {active ? (
+            <PlugZap className="size-3.5 text-primary" />
+          ) : (
+            <Plug className="size-3.5" />
+          )}
+          Endpoint mode
+          <span className="font-normal text-muted-foreground/80">
+            — run the editor against a running sparq-server (SPARQL 1.1 Protocol)
+          </span>
+        </div>
+        <ModeSwitch active={active} disabled={blocked && !active} onChange={onActiveChange} />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-[1fr_auto]">
+        <div className="space-y-1.5">
+          <label htmlFor="endpoint-url" className="text-xs font-medium">
+            Endpoint URL
+          </label>
+          <input
+            id="endpoint-url"
+            type="url"
+            inputMode="url"
+            value={config.url}
+            placeholder="http://127.0.0.1:3030/sparql"
+            spellCheck={false}
+            autoComplete="off"
+            onChange={(e) => onConfigChange({ ...config, url: e.target.value })}
+            className="w-full rounded-lg border bg-muted/40 px-3 py-2 font-mono text-[13px] outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <label htmlFor="endpoint-token" className="text-xs font-medium">
+            Bearer token{" "}
+            <span className="font-normal text-muted-foreground">(optional)</span>
+          </label>
+          <input
+            id="endpoint-token"
+            type="password"
+            value={config.token ?? ""}
+            placeholder="—"
+            spellCheck={false}
+            autoComplete="off"
+            onChange={(e) => onConfigChange({ ...config, token: e.target.value })}
+            className="w-full rounded-lg border bg-muted/40 px-3 py-2 font-mono text-[13px] outline-none focus-visible:ring-3 focus-visible:ring-ring/40 sm:w-56"
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={testConnection}
+          disabled={!urlValid || test.kind === "testing"}
+          title="Run a trivial ASK against the endpoint to verify reachability + auth"
+        >
+          {test.kind === "testing" ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <PlugZap className="size-3.5" />
+          )}
+          Test connection
+        </Button>
+        <TestResult test={test} />
+      </div>
+
+      <SafetyWarnings warnings={warnings} />
+
+      <p className="text-[11px] leading-relaxed text-muted-foreground">
+        The token is sent only in the{" "}
+        <code className="font-mono">Authorization: Bearer</code> header by the shared
+        client and is never logged. sparq-server has{" "}
+        <span className="font-medium">no auth by default</span> and binds loopback-only;
+        these warnings reflect its real posture (see the sparq-server README) — this
+        editor never bypasses a server gate.
+      </p>
+    </div>
+  );
+}
+
+// [OPUS-4.8] sq-2mke — the WASM ⇄ endpoint switch. A blocking safety error (invalid URL /
+// mixed-content) disables turning endpoint mode ON, but never blocks turning it OFF (so a
+// user can always fall back to the in-tab engine).
+function ModeSwitch({
+  active,
+  disabled,
+  onChange,
+}: {
+  active: boolean;
+  disabled: boolean;
+  onChange: (active: boolean) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Execution target"
+      className="inline-flex rounded-lg border bg-background p-0.5"
+    >
+      <SwitchTab
+        label="In-tab WASM"
+        selected={!active}
+        onClick={() => onChange(false)}
+        title="Execute queries in this tab on the WebAssembly engine (no network)"
+      />
+      <SwitchTab
+        label="Endpoint"
+        selected={active}
+        disabled={disabled}
+        onClick={() => onChange(true)}
+        title={
+          disabled
+            ? "Fix the endpoint URL / transport warning before connecting"
+            : "Route queries to the configured SPARQL 1.1 Protocol endpoint"
+        }
+      />
+    </div>
+  );
+}
+
+function SwitchTab({
+  label,
+  selected,
+  disabled,
+  onClick,
+  title,
+}: {
+  label: string;
+  selected: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  title: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={selected}
+      disabled={disabled}
+      title={title}
+      onClick={onClick}
+      className={cn(
+        "rounded-md px-2.5 py-1 text-xs font-medium transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-50",
+        selected
+          ? "bg-primary text-primary-foreground shadow-sm"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+function TestResult({ test }: { test: TestState }) {
+  if (test.kind === "idle") return null;
+  if (test.kind === "testing") {
+    return (
+      <span className="text-xs text-muted-foreground" aria-live="polite">
+        Sending a trivial ASK…
+      </span>
+    );
+  }
+  if (test.kind === "ok") {
+    return (
+      <span
+        className="inline-flex items-center gap-1.5 text-xs text-[var(--success)]"
+        aria-live="polite"
+      >
+        <CircleCheck className="size-3.5" /> Reachable — ASK answered in{" "}
+        {test.ms.toFixed(1)} ms
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-start gap-1.5 text-xs text-destructive"
+      aria-live="polite"
+    >
+      <ShieldAlert className="mt-0.5 size-3.5 shrink-0" />
+      <span>{test.message}</span>
+    </span>
+  );
+}
+
+// [OPUS-4.8] sq-2mke — render the classified connection-safety findings. `error` findings
+// (invalid URL, mixed content) are hard blocks; `warning` findings (token / query over
+// plaintext to a non-loopback host) are advisory; `info` findings (CORS, SERVICE
+// allowlist, loopback-token note) are honest reminders. Each carries a stable `code` so
+// the rendering keys on it, not on prose.
+function SafetyWarnings({ warnings }: { warnings: SafetyWarning[] }) {
+  if (warnings.length === 0) return null;
+  return (
+    <ul className="space-y-1.5">
+      {warnings.map((w) => (
+        <li
+          key={w.code}
+          data-safety-code={w.code}
+          data-safety-level={w.level}
+          className={cn(
+            "flex items-start gap-2 rounded-md border p-2 text-[11.5px] leading-relaxed",
+            w.level === "error" &&
+              "border-destructive/30 bg-destructive/5 text-destructive",
+            w.level === "warning" &&
+              "border-[color-mix(in_oklch,var(--warning)_35%,transparent)] bg-[color-mix(in_oklch,var(--warning)_10%,transparent)] text-[color-mix(in_oklch,var(--warning)_80%,var(--foreground))]",
+            w.level === "info" && "border-border bg-muted/40 text-muted-foreground",
+          )}
+        >
+          <SafetyIcon level={w.level} />
+          <span>{w.message}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function SafetyIcon({ level }: { level: SafetyWarning["level"] }) {
+  if (level === "error") {
+    return <ShieldAlert className="mt-0.5 size-3.5 shrink-0" />;
+  }
+  if (level === "warning") {
+    return <ShieldCheck className="mt-0.5 size-3.5 shrink-0" />;
+  }
+  return <Info className="mt-0.5 size-3.5 shrink-0" />;
+}

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -10,6 +10,7 @@ import {
   Table2,
   Braces,
   Download,
+  PlugZap,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -51,6 +52,9 @@ import {
 } from "@/components/repl-datasets";
 // [OPUS-4.8] sq-n5aw — the syntax-highlighting SPARQL editor replaces the plain <textarea>.
 import { SparqlEditor } from "@/components/sparql-editor";
+// [OPUS-4.8] sq-2mke — endpoint mode: the Connect panel + the SPARQL 1.1 Protocol client.
+import { ConnectPanel } from "@/components/connect-panel";
+import { type EndpointConfig, runEndpointQuery } from "@sparq/client";
 
 // [OPUS-4.8] sq-vfbm — the REPL now dispatches across the whole lean-bundle query
 // surface, so the result state carries one variant per shape of answer: a solution
@@ -62,7 +66,15 @@ type RunState =
   | { kind: "select"; results: SparqlResults; ms: number }
   | { kind: "boolean"; value: boolean; ms: number }
   | { kind: "graph"; ntriples: string; triples: number; ms: number }
-  | { kind: "update"; sizeBefore: number; sizeAfter: number; ms: number }
+  // [OPUS-4.8] sq-2mke — `endpoint` marks an update applied to a REMOTE server (no
+  // before/after in-tab count), so the result copy stays honest about which store mutated.
+  | {
+      kind: "update";
+      sizeBefore: number;
+      sizeAfter: number;
+      ms: number;
+      endpoint?: boolean;
+    }
   | { kind: "explain"; plan: string; analyze: boolean; ms: number }
   | { kind: "error"; message: string };
 
@@ -92,6 +104,16 @@ export function Repl() {
     DEFAULT_DATASET.id,
   );
   const storeRef = React.useRef<WasmStore | null>(null);
+
+  // [OPUS-4.8] sq-2mke — endpoint mode. When `endpointActive`, queries route to a running
+  // SPARQL 1.1 Protocol endpoint over the shared `@sparq/client` HTTP client instead of the
+  // in-tab WASM store. The config (URL + optional bearer token) is lifted here so `run()`
+  // can dispatch on it; the Connect panel owns the form + safety UX.
+  const [endpointActive, setEndpointActive] = React.useState(false);
+  const [endpointConfig, setEndpointConfig] = React.useState<EndpointConfig>({
+    url: "http://127.0.0.1:3030/sparql",
+    token: "",
+  });
 
   // Build (or rebuild) the store from RDF text + format. Centralises error handling so
   // every load path (default, picker, upload, URL) reports failures the same way.
@@ -149,12 +171,64 @@ export function Repl() {
     return store;
   }, [buildStore]);
 
+  // [OPUS-4.8] sq-2mke — endpoint-mode execution path. Routes the SAME editor text to the
+  // configured SPARQL 1.1 Protocol endpoint over the shared `@sparq/client` HTTP client.
+  // The form is classified to the four wire shapes (SELECT / ASK / CONSTRUCT-DESCRIBE /
+  // Update) and the response parsed accordingly. EXPLAIN / ANALYZE are NOT routed here —
+  // they are an in-tab planner introspection, so those modes stay WASM-only (the UI grays
+  // them in endpoint mode). The bearer token is sent only in the Authorization header by
+  // the client; it is never logged or echoed by the REPL.
+  const runEndpoint = React.useCallback(async () => {
+    setState({ kind: "running" });
+    const t0 = performance.now();
+    const result = await runEndpointQuery(endpointConfig, sparql);
+    const ms = performance.now() - t0;
+    switch (result.kind) {
+      case "select":
+        setState({ kind: "select", results: result.results, ms });
+        return;
+      case "boolean":
+        setState({ kind: "boolean", value: result.value, ms });
+        return;
+      case "graph": {
+        const trimmed = result.ntriples.trim();
+        const triples = trimmed === "" ? 0 : trimmed.split("\n").length;
+        setState({ kind: "graph", ntriples: trimmed, triples, ms });
+        return;
+      }
+      case "update":
+        // The endpoint owns the dataset; we cannot read a before/after size cheaply, so
+        // surface the server's 204 acknowledgement honestly without inventing a count.
+        setState({
+          kind: "update",
+          sizeBefore: 0,
+          sizeAfter: 0,
+          ms,
+          endpoint: true,
+        });
+        return;
+    }
+  }, [endpointConfig, sparql]);
+
   // [OPUS-4.8] sq-vfbm — dispatch across the whole lean-bundle query surface. EXPLAIN /
   // ANALYZE modes render the planner's plan text (every form for EXPLAIN; SELECT/ASK for
   // ANALYZE). Otherwise we classify the SPARQL form and route to the matching wasm export:
   // SELECT/ASK -> query (JSON), CONSTRUCT/DESCRIBE -> queryQuads (N-Triples), and an Update
   // keyword -> updateInPlace (mutates the in-tab store; we re-count the dataset after).
   const run = React.useCallback(async () => {
+    // [OPUS-4.8] sq-2mke — when endpoint mode is active, the query runs on the remote
+    // server, not the in-tab store. EXPLAIN / ANALYZE remain a WASM-only planner view, so
+    // a "run" in endpoint mode always executes the query (the mode tabs are grayed).
+    if (endpointActive) {
+      try {
+        await runEndpoint();
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        setState({ kind: "error", message });
+        toast.error("Endpoint query failed", { description: message });
+      }
+      return;
+    }
     try {
       const store = await ensureStore();
       const form = classifyQueryForm(sparql);
@@ -206,7 +280,7 @@ export function Repl() {
         description: message,
       });
     }
-  }, [ensureStore, sparql, mode]);
+  }, [ensureStore, sparql, mode, endpointActive, runEndpoint]);
 
   // Switch to a built-in dataset: reload the store, reset the count + active descriptor.
   const selectBuiltin = React.useCallback(
@@ -289,6 +363,13 @@ export function Repl() {
     if (!modeSupportsForm(mode, form)) setMode("run");
   }, [mode, form]);
 
+  // [OPUS-4.8] sq-2mke — EXPLAIN / ANALYZE are an in-tab planner introspection (they call
+  // the WASM `explain`/`explainAnalyze`), so in endpoint mode they are unavailable; snap
+  // back to "run" so the next click executes the query against the endpoint.
+  React.useEffect(() => {
+    if (endpointActive && mode !== "run") setMode("run");
+  }, [endpointActive, mode]);
+
   return (
     <Card>
       <CardHeader className="flex-row items-center justify-between gap-2 space-y-0">
@@ -297,30 +378,56 @@ export function Repl() {
           Live SPARQL REPL
         </CardTitle>
         <div className="flex items-center gap-2">
-          <EngineIndicator engine={engine} />
-          {size !== null && (
-            <button
-              type="button"
-              onClick={() => setViewerOpen(true)}
-              aria-label={`View the ${size} triples in the loaded dataset`}
-              className="rounded-4xl outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
-            >
-              <Badge
-                variant="muted"
-                className="tabular cursor-pointer transition-colors hover:bg-muted-foreground/20"
-              >
-                <Database className="size-3" /> {size} triples
-              </Badge>
-            </button>
+          {endpointActive ? (
+            // [OPUS-4.8] sq-2mke — in endpoint mode the in-tab WASM engine state + triple
+            // count are irrelevant; show that queries route to the remote endpoint.
+            <Badge variant="default" aria-live="polite">
+              <PlugZap className="size-3" /> Endpoint mode
+            </Badge>
+          ) : (
+            <>
+              <EngineIndicator engine={engine} />
+              {size !== null && (
+                <button
+                  type="button"
+                  onClick={() => setViewerOpen(true)}
+                  aria-label={`View the ${size} triples in the loaded dataset`}
+                  className="rounded-4xl outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+                >
+                  <Badge
+                    variant="muted"
+                    className="tabular cursor-pointer transition-colors hover:bg-muted-foreground/20"
+                  >
+                    <Database className="size-3" /> {size} triples
+                  </Badge>
+                </button>
+              )}
+            </>
           )}
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
+        <ConnectPanel
+          config={endpointConfig}
+          onConfigChange={setEndpointConfig}
+          active={endpointActive}
+          onActiveChange={setEndpointActive}
+        />
+
+        {/* The in-tab dataset controls manage the WASM store; in endpoint mode the
+            endpoint owns the data, so they are disabled with an honest note. */}
+        {endpointActive ? (
+          <p className="rounded-lg border bg-muted/30 p-2.5 text-xs text-muted-foreground">
+            Endpoint mode is active — queries run against the configured server, which owns
+            its own dataset. The in-tab dataset picker below is for the WASM engine; switch
+            back to <span className="font-medium">In-tab WASM</span> to use it.
+          </p>
+        ) : null}
         <DatasetControls
           activeBuiltinId={activeBuiltinId}
           onSelectBuiltin={selectBuiltin}
           onLoadText={loadText}
-          disabled={controlsDisabled}
+          disabled={controlsDisabled || endpointActive}
         />
 
         <div className="flex flex-wrap gap-1.5">
@@ -356,7 +463,13 @@ export function Repl() {
             )}
             {mode === "run" ? "Run query" : "Run EXPLAIN"}
           </Button>
-          <ModeTabs mode={mode} onChange={setMode} disabled={busy} form={form} />
+          <ModeTabs
+            mode={mode}
+            onChange={setMode}
+            disabled={busy}
+            form={form}
+            endpointMode={endpointActive}
+          />
           <p aria-live="polite" className="text-xs text-muted-foreground">
             {state.kind === "select" &&
               `${state.results.results.bindings.length} rows · ${state.ms.toFixed(1)} ms`}
@@ -364,14 +477,19 @@ export function Repl() {
             {state.kind === "graph" &&
               `${state.triples} triples · ${state.ms.toFixed(1)} ms`}
             {state.kind === "update" &&
-              `store ${state.sizeBefore} → ${state.sizeAfter} triples · ${state.ms.toFixed(1)} ms`}
+              (state.endpoint
+                ? `endpoint write acknowledged · ${state.ms.toFixed(1)} ms`
+                : `store ${state.sizeBefore} → ${state.sizeAfter} triples · ${state.ms.toFixed(1)} ms`)}
             {state.kind === "explain" &&
               `plan ${state.analyze ? "+ trace " : ""}· ${state.ms.toFixed(1)} ms`}
             {state.kind === "running" &&
-              (mode === "run"
-                ? "Running on the wasm engine…"
-                : "Planning on the wasm engine…")}
+              (endpointActive
+                ? "Running on the endpoint…"
+                : mode === "run"
+                  ? "Running on the wasm engine…"
+                  : "Planning on the wasm engine…")}
             {state.kind === "idle" &&
+              !endpointActive &&
               engine === "warming" &&
               "Pre-warming the wasm engine…"}
           </p>
@@ -424,11 +542,15 @@ function ModeTabs({
   onChange,
   disabled,
   form,
+  endpointMode,
 }: {
   mode: RunMode;
   onChange: (m: RunMode) => void;
   disabled: boolean;
   form: QueryForm;
+  // [OPUS-4.8] sq-2mke — in endpoint mode EXPLAIN / ANALYZE are unavailable (they drive
+  // the in-tab WASM planner, not the remote server), so those tabs are grayed.
+  endpointMode: boolean;
 }) {
   const tabs: { value: RunMode; label: string; title: string }[] = [
     { value: "run", label: "Run", title: "Execute the query / update" },
@@ -452,8 +574,10 @@ function ModeTabs({
       {tabs.map((t) => {
         // Gray out a mode the current query form cannot use (EXPLAIN/ANALYZE on an
         // Update). The engine still validates — this only stops the user picking a
-        // mode that would parse-error.
-        const unsupported = !modeSupportsForm(t.value, form);
+        // mode that would parse-error. EXPLAIN/ANALYZE are also unavailable in endpoint
+        // mode (an in-tab planner introspection, not a protocol operation).
+        const planMode = t.value !== "run";
+        const unsupported = !modeSupportsForm(t.value, form) || (endpointMode && planMode);
         const tabDisabled = disabled || unsupported;
         return (
           <button
@@ -463,9 +587,11 @@ function ModeTabs({
             aria-selected={mode === t.value}
             aria-disabled={unsupported}
             title={
-              unsupported
-                ? `${t.label} is unavailable for SPARQL Update — it plans a query`
-                : t.title
+              endpointMode && planMode
+                ? `${t.label} runs the in-tab WASM planner — switch to In-tab WASM to use it`
+                : unsupported
+                  ? `${t.label} is unavailable for SPARQL Update — it plans a query`
+                  : t.title
             }
             disabled={tabDisabled}
             onClick={() => onChange(t.value)}
@@ -509,6 +635,17 @@ function ResultPanel({ state }: { state: RunState }) {
     );
   }
   if (state.kind === "update") {
+    // [OPUS-4.8] sq-2mke — endpoint updates mutate the REMOTE server (the protocol acks a
+    // 204 with no body), so we cannot show a before/after count without inventing one.
+    if (state.endpoint) {
+      return (
+        <div className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+          <span className="font-medium text-foreground">Update applied</span> on the
+          endpoint — the server acknowledged the write (HTTP 204, no body). Run a SELECT
+          against the same endpoint to see the change.
+        </div>
+      );
+    }
     const delta = state.sizeAfter - state.sizeBefore;
     const sign = delta > 0 ? "+" : "";
     return (

--- a/site/test/endpoint.test.mjs
+++ b/site/test/endpoint.test.mjs
@@ -1,0 +1,273 @@
+// [OPUS-4.8] sq-2mke — unit tests for the SPARQL 1.1 Protocol endpoint client
+// (`@sparq/client` `endpoint.ts`): the honest connection-safety classifier, the query-form
+// classifier, the request builder (auth header + content negotiation), the WS subprotocol
+// derivation, and the `runEndpointQuery` response parsing over an injected `fetch`. These
+// cover the pure, framework-free logic that the Connect panel and the REPL endpoint path
+// rely on. Run via `npm run test:unit`.
+//
+// Imported by RELATIVE path (not the `@sparq/client` alias) so the build-free ts-loader
+// resolves it without a custom alias resolver. In Node there is no `window`, so the
+// browser-only findings (mixed-content / cors-required) do not fire — exactly the headless
+// behaviour the classifier is designed for.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  connectionSafetyWarnings,
+  hasBlockingWarning,
+  isLoopbackHost,
+  parseEndpointUrl,
+  classifyEndpointForm,
+  buildSparqlRequest,
+  wsSubprotocols,
+  runEndpointQuery,
+  EndpointError,
+} from "../../packages/sparq-client/src/endpoint.ts";
+
+// --- isLoopbackHost ---------------------------------------------------------
+
+test("isLoopbackHost recognises localhost, 127.0.0.0/8 and ::1", () => {
+  for (const h of ["localhost", "LOCALHOST", "127.0.0.1", "127.0.0.99", "::1", "[::1]"]) {
+    assert.equal(isLoopbackHost(h), true, `${h} should be loopback`);
+  }
+  for (const h of ["example.org", "10.0.0.1", "192.168.1.5", "0.0.0.0"]) {
+    assert.equal(isLoopbackHost(h), false, `${h} should NOT be loopback`);
+  }
+});
+
+// --- parseEndpointUrl -------------------------------------------------------
+
+test("parseEndpointUrl accepts http/https absolute URLs and rejects junk", () => {
+  assert.ok(parseEndpointUrl("http://127.0.0.1:3030/sparql"));
+  assert.ok(parseEndpointUrl("https://example.org/sparql"));
+  assert.equal(parseEndpointUrl(""), null);
+  assert.equal(parseEndpointUrl("   "), null);
+  assert.equal(parseEndpointUrl("not a url"), null);
+  // A non-http(s) scheme is refused (no ftp:/file:/ws:).
+  assert.equal(parseEndpointUrl("ws://127.0.0.1/subscriptions"), null);
+  assert.equal(parseEndpointUrl("file:///etc/passwd"), null);
+});
+
+// --- connectionSafetyWarnings (the honest classifier) -----------------------
+
+function codes(warnings) {
+  return warnings.map((w) => w.code);
+}
+
+test("an invalid URL yields exactly one blocking error and nothing else", () => {
+  const w = connectionSafetyWarnings({ url: "nope" });
+  assert.deepEqual(codes(w), ["invalid-url"]);
+  assert.equal(w[0].level, "error");
+  assert.equal(hasBlockingWarning(w), true);
+});
+
+test("loopback http with no token: no transport warning, only the SERVICE info note", () => {
+  const w = connectionSafetyWarnings({ url: "http://127.0.0.1:3030/sparql" });
+  // No token, loopback => no token-over-plaintext, no non-loopback warning.
+  assert.equal(codes(w).includes("token-over-plaintext"), false);
+  assert.equal(codes(w).includes("non-loopback-no-tls"), false);
+  // The SERVICE-allowlist reminder is always surfaced (info).
+  assert.equal(codes(w).includes("service-allowlist"), true);
+  assert.equal(hasBlockingWarning(w), false);
+});
+
+test("loopback http WITH a token: token stays on-machine (info, not a warning)", () => {
+  const w = connectionSafetyWarnings({
+    url: "http://localhost:3030/sparql",
+    token: "secret",
+  });
+  const tok = w.find((x) => x.code === "token-over-plaintext");
+  assert.ok(tok, "expected a token-over-plaintext finding");
+  assert.equal(tok.level, "info", "loopback token is an info note, not a transit warning");
+});
+
+test("non-loopback http WITH a token: token-over-plaintext + non-loopback are WARNINGS", () => {
+  const w = connectionSafetyWarnings({
+    url: "http://data.example.org/sparql",
+    token: "secret",
+  });
+  const tok = w.find((x) => x.code === "token-over-plaintext");
+  const non = w.find((x) => x.code === "non-loopback-no-tls");
+  assert.ok(tok && tok.level === "warning", "token over plaintext to a remote host is a warning");
+  assert.ok(non && non.level === "warning", "plaintext to a non-loopback host is a warning");
+  // Honest, not a hard block — the user can proceed (the browser/server decides).
+  assert.equal(hasBlockingWarning(w), false);
+});
+
+test("non-loopback http with NO token still warns about cleartext transport", () => {
+  const w = connectionSafetyWarnings({ url: "http://data.example.org/sparql" });
+  assert.equal(codes(w).includes("non-loopback-no-tls"), true);
+  // No token => no token-specific finding.
+  assert.equal(codes(w).includes("token-over-plaintext"), false);
+});
+
+test("https to a remote host with a token: no transport warnings (TLS protects it)", () => {
+  const w = connectionSafetyWarnings({
+    url: "https://data.example.org/sparql",
+    token: "secret",
+  });
+  assert.equal(codes(w).includes("token-over-plaintext"), false);
+  assert.equal(codes(w).includes("non-loopback-no-tls"), false);
+  assert.equal(hasBlockingWarning(w), false);
+  // The SERVICE reminder is still surfaced.
+  assert.equal(codes(w).includes("service-allowlist"), true);
+});
+
+// --- classifyEndpointForm ---------------------------------------------------
+
+test("classifyEndpointForm folds to the four wire shapes, skipping the prologue", () => {
+  assert.equal(classifyEndpointForm("SELECT * WHERE { ?s ?p ?o }"), "select");
+  assert.equal(classifyEndpointForm("  ASK { ?s ?p ?o }"), "ask");
+  assert.equal(classifyEndpointForm("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }"), "graph");
+  assert.equal(classifyEndpointForm("DESCRIBE <http://example.org/x>"), "graph");
+  assert.equal(classifyEndpointForm("INSERT DATA { <a> <b> <c> }"), "update");
+  assert.equal(classifyEndpointForm("DELETE WHERE { ?s ?p ?o }"), "update");
+  assert.equal(classifyEndpointForm("DROP GRAPH <http://example.org/g>"), "update");
+  // A PREFIX/BASE prologue is skipped so the operative keyword is found.
+  assert.equal(
+    classifyEndpointForm("PREFIX ex: <http://example.org/>\nSELECT * WHERE { ?s ?p ?o }"),
+    "select",
+  );
+  assert.equal(
+    classifyEndpointForm("# a comment\nPREFIX ex: <http://example.org/>\nINSERT DATA { ex:a ex:b ex:c }"),
+    "update",
+  );
+});
+
+// --- buildSparqlRequest (auth + content negotiation) ------------------------
+
+test("buildSparqlRequest uses direct sparql-query POST with the right Accept per form", () => {
+  const cfg = { url: "http://127.0.0.1:3030/sparql" };
+  const sel = buildSparqlRequest(cfg, "SELECT * WHERE {?s ?p ?o}", "select");
+  assert.equal(sel.init.method, "POST");
+  assert.equal(sel.init.headers["Content-Type"], "application/sparql-query");
+  assert.equal(sel.init.headers["Accept"], "application/sparql-results+json");
+  assert.equal(sel.init.body, "SELECT * WHERE {?s ?p ?o}");
+
+  const graph = buildSparqlRequest(cfg, "CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o}", "graph");
+  assert.equal(graph.init.headers["Accept"], "application/n-triples");
+
+  const upd = buildSparqlRequest(cfg, "INSERT DATA { <a> <b> <c> }", "update");
+  assert.equal(upd.init.headers["Content-Type"], "application/sparql-update");
+  // An update body asks for no SPARQL-results Accept (the server acks a 204).
+  assert.equal(upd.init.headers["Accept"], undefined);
+});
+
+test("buildSparqlRequest adds the bearer header iff a non-empty token is set", () => {
+  const sel = buildSparqlRequest(
+    { url: "http://127.0.0.1:3030/sparql", token: "  tok  " },
+    "SELECT * WHERE {?s ?p ?o}",
+    "select",
+  );
+  // The token is trimmed and sent only in the Authorization header.
+  assert.equal(sel.init.headers["Authorization"], "Bearer tok");
+
+  const noTok = buildSparqlRequest(
+    { url: "http://127.0.0.1:3030/sparql", token: "   " },
+    "SELECT * WHERE {?s ?p ?o}",
+    "select",
+  );
+  assert.equal(noTok.init.headers["Authorization"], undefined);
+});
+
+// --- wsSubprotocols ---------------------------------------------------------
+
+test("wsSubprotocols derives the bearer.<token> subprotocol (browser WS auth)", () => {
+  assert.deepEqual(wsSubprotocols("tok"), ["bearer.tok"]);
+  assert.deepEqual(wsSubprotocols(""), []);
+  assert.deepEqual(wsSubprotocols("  "), []);
+  assert.deepEqual(wsSubprotocols(undefined), []);
+});
+
+// --- runEndpointQuery (over an injected fetch) ------------------------------
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/sparql-results+json" },
+  });
+}
+
+test("runEndpointQuery parses a SELECT results document", async () => {
+  const fetchImpl = async () =>
+    jsonResponse({
+      head: { vars: ["s"] },
+      results: { bindings: [{ s: { type: "uri", value: "http://x" } }] },
+    });
+  const r = await runEndpointQuery(
+    { url: "http://127.0.0.1:3030/sparql" },
+    "SELECT * WHERE {?s ?p ?o}",
+    fetchImpl,
+  );
+  assert.equal(r.kind, "select");
+  assert.equal(r.results.results.bindings.length, 1);
+});
+
+test("runEndpointQuery surfaces an ASK boolean", async () => {
+  const fetchImpl = async () => jsonResponse({ head: {}, boolean: true });
+  const r = await runEndpointQuery(
+    { url: "http://127.0.0.1:3030/sparql" },
+    "ASK { ?s ?p ?o }",
+    fetchImpl,
+  );
+  assert.equal(r.kind, "boolean");
+  assert.equal(r.value, true);
+});
+
+test("runEndpointQuery returns the N-Triples body for CONSTRUCT", async () => {
+  const fetchImpl = async () =>
+    new Response("<http://a> <http://b> <http://c> .\n", {
+      status: 200,
+      headers: { "Content-Type": "application/n-triples" },
+    });
+  const r = await runEndpointQuery(
+    { url: "http://127.0.0.1:3030/sparql" },
+    "CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o}",
+    fetchImpl,
+  );
+  assert.equal(r.kind, "graph");
+  assert.match(r.ntriples, /<http:\/\/a>/);
+});
+
+test("runEndpointQuery returns an update ack on a 204", async () => {
+  const fetchImpl = async () => new Response(null, { status: 204 });
+  const r = await runEndpointQuery(
+    { url: "http://127.0.0.1:3030/sparql" },
+    "INSERT DATA { <a> <b> <c> }",
+    fetchImpl,
+  );
+  assert.equal(r.kind, "update");
+  assert.equal(r.status, 204);
+});
+
+test("runEndpointQuery throws a classified EndpointError on a 401", async () => {
+  const fetchImpl = async () =>
+    new Response(JSON.stringify({ error: "authentication required" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  await assert.rejects(
+    () => runEndpointQuery({ url: "http://127.0.0.1:3030/sparql" }, "ASK {}", fetchImpl),
+    (e) => {
+      assert.ok(e instanceof EndpointError);
+      assert.equal(e.status, 401);
+      assert.match(e.message, /Authentication required/);
+      return true;
+    },
+  );
+});
+
+test("runEndpointQuery turns a transport failure into an honest CORS/reachability hint", async () => {
+  const fetchImpl = async () => {
+    throw new TypeError("Failed to fetch");
+  };
+  await assert.rejects(
+    () => runEndpointQuery({ url: "http://data.example.org/sparql" }, "ASK {}", fetchImpl),
+    (e) => {
+      assert.ok(e instanceof EndpointError);
+      assert.equal(e.status, null);
+      assert.match(e.message, /CORS|reach the endpoint/);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-2mke** — *GUI Phase 2: endpoint mode* (`research/gui-design.md` §2, Phase 2 item 6). Wires the `/try` editor to a running `sparq-server` over the **SPARQL 1.1 Protocol** as an alternative to the in-tab WASM store, honouring the server's security posture as connection-safety UX and **never bypassing a gate**. The existing server API is **consumed unchanged** (no `crates/` edits).

## What changed

**`packages/sparq-client` (the shared TS client — extended, not reinvented):**
- **`src/endpoint.ts`** — a framework-agnostic SPARQL 1.1 Protocol HTTP client over `fetch`:
  - `runEndpointQuery(config, sparql)` classifies the form (`classifyEndpointForm`), builds the request (`buildSparqlRequest`: a direct `application/sparql-query` POST for reads with a per-form `Accept`; a direct `application/sparql-update` POST for writes; bearer-auth in the `Authorization` header **only**) and parses the response per form (SELECT/ASK JSON, CONSTRUCT/DESCRIBE N-Triples, a `204` update ack).
  - `connectionSafetyWarnings(config)` — the pure, honest safety classifier (unit-tested).
  - `wsSubprotocols(token)` — derives the `bearer.<token>` subprotocol the server's WS handshake accepts (browsers can't set an `Authorization` header on a WS upgrade; reused by the future live-subscriptions view).
  - `EndpointError` carries the server's status-contract class (401 → auth; 429/503 → transient; 5xx → defect).
- **`src/index.ts`** re-exports the endpoint surface; **`README.md`** documents it + the safety posture.

**`site/`:**
- **`src/components/connect-panel.tsx`** — the **Connect panel**: endpoint URL + optional bearer token, a WASM ⇄ Endpoint switch, a **Test connection** button (a trivial `ASK` over the real request path), and the classified safety warnings rendered honestly.
- **`src/components/repl.tsx`** — routes queries to the endpoint when endpoint mode is active; grays EXPLAIN/ANALYZE (an in-tab planner view, not a protocol op); honest endpoint-update copy (server `204` ack, **no invented before/after count**); an endpoint header indicator; disables the in-tab dataset picker in endpoint mode.
- **`src/app/try/page.tsx`** — copy updated so the "nothing sent to a server" claim is scoped to the default in-tab mode, and the Connect/endpoint path is described honestly.
- **`test/endpoint.test.mjs`** — unit tests for the safety classifier, the form classifier, the request builder (auth + content negotiation), `wsSubprotocols`, and `runEndpointQuery` response parsing over an injected `fetch`.

## How endpoint-mode routes queries

When the **Endpoint** switch is on, `repl.tsx`'s `run()` dispatches to `runEndpointQuery(endpointConfig, sparql)` instead of the WASM store. The client picks the wire shape: SELECT/ASK → SPARQL-results JSON (`/sparql` direct-`application/sparql-query` POST), CONSTRUCT/DESCRIBE → N-Triples, Update → `application/sparql-update` POST (the server's `204`). The bearer token is attached only as `Authorization: Bearer …`, never logged.

## Safety warnings surfaced (mirror `crates/sparq-server/README.md`, never an overclaim)

- **`token-over-plaintext`** (warning) — a token over plaintext `http:` to a **non-loopback** host travels in cleartext (loopback `http:` token → info note: stays on the machine).
- **`non-loopback-no-tls`** (warning) — plaintext `http:` to a non-loopback host: query + results in cleartext; the server refuses a non-loopback bind without `--allow-remote`.
- **`mixed-content`** (error, hard block) — an HTTPS page can't `fetch` a plaintext `http:` endpoint.
- **`cors-required`** (info) — the server emits **no CORS headers** by default, so a cross-origin browser fetch is blocked until an origin is opted in (`--cors-allow-origin`).
- **`service-allowlist`** (info) — `SERVICE` egress is off / default-DENY; a `SERVICE` clause is refused before any socket unless the operator set the allowlist.

No security the server doesn't provide is claimed; the editor never bypasses a server gate.

## Gates

- WASM bundle built first (`cd js && npm run build:wasm`) — build artifact only, no `crates/` changes.
- `cd site && npm run build` — static export **green**, 46 routes, `/try` emitted into `out/`, `basePath` `/sparq` intact on assets.
- `npm run lint` — clean. `tsc --noEmit` — clean (site typechecks the package via the `@sparq/client` alias).
- `npm run test:unit` — **159/159** (incl. the new `endpoint.test.mjs`).
- `check-privacy-claims.sh`, `check-no-perf-numbers.py`, typos gate — all clean.

## Covered vs deferred

- **Covered:** endpoint-mode query routing (SELECT/ASK/CONSTRUCT/DESCRIBE/Update), bearer-auth, the Connect panel + Test-connection, the honest safety classifier.
- **Deferred (already beaded):** the live subscriptions view (`sq-9ij6`, depends on this) and the server-health panel (`sq-he72`). The `wsSubprotocols` helper is in place so the subscriptions view reuses the same auth posture.