### PR TITLE
docs(research): sq-hb75 — projective/extended-TE scalar-mul measured & REJECTED (no-win) [OPUS-4.8]

### DIFF
--- a/research/zk-age-gatecount-reduction.md
+++ b/research/zk-age-gatecount-reduction.md
@@ -215,6 +215,39 @@ Two curve-preserving / curve-changing levers:
   and challenge-reduction binds — A9 in §3.4 — all stay), so it does **not** touch
   the soundness-enforcing equalities, only the coordinate system. Plausibly 3–5× on
   the scalar-mul body — **must be measured**.
+
+  **[OPUS-4.8] sq-hb75 MEASURED RESULT — REJECTED (a no-win, not the projected 3–5×
+  win).** Implemented and measured on this box (`bb gates -s ultra_honk`,
+  `circuit_size`; toolchain `nargo 1.0.0-beta.21` / `bb 5.0.0-nightly.20260324`):
+  rewriting `point_add`/`scalar_mul` into extended twisted-Edwards `(X,Y,T,Z)`
+  coordinates (HWCD-2008 `add-2008-hwcd`, one deferred `1/Z` normalisation per
+  scalar-mul) **REGRESSED** every affected member, it did not reduce them:
+
+  | Member | affine baseline | extended (unified add) | extended (+ dedicated `dbl-2008-hwcd`) |
+  | --- | ---: | ---: | ---: |
+  | `hidden_issuer_d4` | **16,932** | 21,433 (+26.6%) | 20,433 (+20.7%) |
+  | `holder_pok` | **10,334** | 12,582 (+21.8%) | 12,082 (+16.9%) |
+  | `holder_set_d4` | **10,650** | 12,898 (+21.1%) | 12,398 (+16.4%) |
+
+  All 81 `compose_core` in-circuit `nargo test` cases (the REAL-signature
+  `schnorr_verify` / `holder_pok` accept vectors + the tamper/forge/off-curve/
+  identity reject vectors) passed in BOTH the affine and extended forms — so the
+  rewrite was algebraically equivalent and every A9 bind survived; it simply costs
+  MORE gates. **Root cause** (`bb gates --include_gates_per_opcode`, `holder_pok`):
+  the affine form compiles to 6,770 ACIR opcodes of which **1,003 cost ZERO backend
+  gates** — a Field division `q = a/b` on UltraHonk/Barretenberg lowers to a
+  witnessed quotient with a single `q*b == a` constraint that the optimiser fuses
+  into its consumer for free. The extended form replaces those near-free divisions
+  with ~1,750 extra BILLED Field multiplications (the 4th coordinate `T` propagation
+  + the `E·F, G·H, E·H, F·G` products), none of which fold away (7,771 opcodes,
+  7,261 of them one-gate). The textbook "~2000 expensive inversions → 1" premise is
+  **false on this backend**: affine division here is ~1 native gate, so there is no
+  inversion cost to defer. This is the noir-optimisation thesis (PR #37 / the
+  `shr_sticky` spike) recurring — intuition misfires; the measured number governs.
+  Per the bead's gate, the circuit change was reverted (no `.nr` change shipped);
+  the snapshot is unchanged. **Do not re-run this spike.** A future win on these
+  members, if any, would come from lever (b) (the audit-gated Grumpkin re-key to the
+  native `multi_scalar_mul` black-box), not from a coordinate-system change.
 - **(b) Re-key issuer signatures to Grumpkin** so Noir's native
   `multi_scalar_mul`/`embedded_curve_add` black-boxes apply (~10× on the scalar-mul).
   **Blocked as a drop-in**: `sig.rs` signs over **Baby-JubJub**, and those black-boxes
@@ -369,7 +402,14 @@ captured as beads, children of the ZK epic **sq-1s2**, linking this record:
   (sq-qhy4). Expected member ~3,200 gates (estimate; must be measured).
 - **sq-hb75** — rewrite `issuer.nr` `point_add`/`scalar_mul` in projective/extended
   TE coordinates (one normalisation per scalar-mul); re-measure. Curve-preserving
-  (keeps all A9 binds); the issuer/holder members' ~4k path.
+  (keeps all A9 binds). **[OPUS-4.8] DONE / measured / REJECTED:** implemented and
+  measured (see §3.3 lever (a) for the numbers); the extended-coordinate rewrite was
+  algebraically equivalent (all 81 in-circuit oracle tests passed in both forms) but
+  **regressed** every member by +16–27% on `bb gates`, not the projected 3–5× win —
+  affine Field division is ~1 native gate on this UltraHonk backend, so there is no
+  inversion cost to defer. The circuit change was reverted (no `.nr` change shipped,
+  snapshot unchanged). Not the issuer/holder members' path; that is lever (b), the
+  audit-gated Grumpkin re-key.
 
 ## 5. Standing measurement warning
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements bead **sq-hb75** (design: `research/zk-age-gatecount-reduction.md` §3.3 lever (a)): rewrite `zk/compose/compose_core/src/issuer.nr` `point_add`/`scalar_mul` into **projective / extended twisted-Edwards `(X,Y,T,Z)` coordinates** (HWCD-2008 `add-2008-hwcd`) so the per-add Field inversions defer to ONE `1/Z` normalisation per scalar-mul.

## Outcome: measured, algebraically-equivalent, but a NO-WIN — reverted

I implemented the full extended-coordinate rewrite, verified it is algebraically equivalent (all 81 `compose_core` in-circuit `nargo test` cases passed in both the affine and the extended form — the REAL-signature `schnorr_verify` / `holder_pok` accept vectors AND every tamper / forge / wrong-message / off-curve / identity reject vector), then **MEASURED** `bb gates` before/after. It **regressed** every affected member; it did not reduce them. Per the bead's explicit gate ("if the projective rewrite does NOT measurably reduce gates … do NOT force-merge a no-win change") I **reverted the `.nr` change** and this PR ships only the measured negative result, recorded in the design record so the spike is not re-run.

### Measured `bb gates -s ultra_honk` `circuit_size` (nargo 1.0.0-beta.21 / bb 5.0.0-nightly.20260324, this box)

| Member | affine baseline (= snapshot) | extended (unified add) | extended (+ dedicated `dbl-2008-hwcd`) |
| --- | ---: | ---: | ---: |
| `hidden_issuer_d4` | **16,932** | 21,433 (+26.6%) | 20,433 (+20.7%) |
| `holder_pok` | **10,334** | 12,582 (+21.8%) | 12,082 (+16.9%) |
| `holder_set_d4` | **10,650** | 12,898 (+21.1%) | 12,398 (+16.4%) |

(`holder_set_d4` also consumes `scalar_mul`, so it is included.) These are measured numbers, not estimates; the affine baselines reproduce the checked-in snapshot exactly.

### Root cause (`bb gates --include_gates_per_opcode`)

The textbook premise — "~2000 expensive in-loop inversions → 1 deferred inversion" — is **false on this UltraHonk / Barretenberg backend.** A Field division `q = a/b` lowers to a witnessed quotient with a single `q*b == a` constraint that the optimiser fuses into its consumer for free: the affine `holder_pok` compiles to 6,770 opcodes of which **1,003 cost ZERO backend gates**. The extended form trades those near-free divisions for ~1,750 BILLED multiplications (the 4th coordinate `T` propagation + the `E·F, G·H, E·H, F·G` products), none of which fold away. Affine division here is ~1 native gate, so there is no inversion cost to defer. This is the noir-optimisation thesis recurring (PR #37 / the `shr_sticky` spike): intuition misfires on this codebase; the measured number governs.

## A9 binds verified intact (during the equivalent-but-rejected rewrite)

The rewrite touched only the coordinate system; every A9 soundness-enforcing bind was preserved byte-for-meaning and the in-circuit oracle confirmed it: on-curve check (`assert_on_curve`, `:145`), identity-key rejection (`:198`), `s < L` (`assert_lt_l`, `:173-179`), challenge-reduction bind (`:163`), the verify equation `s*G == R + e*pk`, and the key-set Merkle root. None of these is changed by this PR (the `.nr` is reverted to `main`).

## Scope / honesty

- **Diff: `research/zk-age-gatecount-reduction.md` only.** `issuer.nr` is byte-identical to `main`; `gate_count_snapshot.json` is **unchanged** (no circuit change ⇒ deliberately no re-baseline). The host-side `gate_count` regression test passes 4/4.
- The Grumpkin native `multi_scalar_mul` black-box was **NOT** used (out of scope — `sig.rs` signs over Baby-JubJub ≠ Grumpkin; that is the audit-gated lever (b)).
- This is a coordinate-system performance experiment. It preserves the A9 constraint set pending the EXTERNAL accredited-cryptographer audit (sq-qhy4); the v1 ZK verifier is **NOT** externally audited and no soundness property is asserted as achieved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)