### PR TITLE
feat(site): GUI Phase 2 live subscriptions view — stream /subscriptions/sse result deltas (sq-9ij6) [OPUS-4.8]

### DIFF
--- a/packages/sparq-client/README.md
+++ b/packages/sparq-client/README.md
@@ -31,6 +31,19 @@ re-exports the surface from here; the (proposed) Tauri 2 GUI consumes the same p
   `bearer.<token>` subprotocol the server's WS handshake accepts (browsers cannot set an
   `Authorization` header on a WS upgrade). This client **consumes** the existing server API and
   **never bypasses a server gate** — it claims no security the server does not provide.
+- **Live subscriptions** (`src/subscriptions.ts`, `sq-9ij6`): the SSE transport of the server's
+  `/subscriptions` surface — the companion to endpoint mode for the LIVE case.
+  `openSubscription(config, query, handlers)` subscribes a SELECT to `/subscriptions/sse` over
+  `fetch` + a streaming `ReadableStream` reader (NOT native `EventSource`, which cannot set an
+  `Authorization` header — so the SAME bearer token a query uses reaches an authenticated
+  server) and drives `onOpen` / `onEvent` / `onClose(error?)`. `buildSubscriptionUrl` derives the
+  SSE URL from the same `EndpointConfig`; `parseSubscriptionData` parses the SEPA envelopes
+  (`subscribed` / `notification` / `error`); `applyNotification` reduces the streamed
+  added/removed diffs onto a `LiveResultSet` keyed by the server's canonical row key (`rowKey`),
+  and `liveResults` shapes it back into a `SparqlResults` document so the SAME `extractTable`
+  renders a live row exactly like a queried one. It reuses endpoint mode's `EndpointConfig` +
+  bearer posture verbatim, runs the SAME `connectionSafetyWarnings` classifier, and **bypasses no
+  server gate** (the SSE read surface is gated by `--auth-token-read` exactly as `/sparql` GET).
 
 ## Endpoint-mode safety posture (honest, never an overclaim)
 

--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -417,6 +417,33 @@ export {
   wsSubprotocols,
 } from "./endpoint.js";
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-9ij6 — live subscriptions: the SSE transport of the server's
+// `/subscriptions` surface. Subscribe a SELECT and stream the result DELTAS as the dataset
+// mutates, reusing the SAME `EndpointConfig` + bearer posture as the endpoint query client
+// (the token is sent only in the `Authorization: Bearer` header the server's SSE read gate
+// validates). Consumes the existing `sparq-server` subscriptions API; bypasses no gate.
+// ---------------------------------------------------------------------------
+
+export {
+  type SubscribedAck,
+  type SubscriptionNotification,
+  type SubscriptionError,
+  type SubscriptionEvent,
+  type SubscriptionHandlers,
+  type SubscriptionHandle,
+  type LiveResultSet,
+  applyNotification,
+  buildSubscriptionUrl,
+  emptyLiveResultSet,
+  frameData,
+  liveResults,
+  openSubscription,
+  parseSubscriptionData,
+  rowKey,
+  splitSseFrames,
+} from "./subscriptions.js";
+
 /** Renders a term for display, with a compact datatype/lang suffix. */
 export function formatTerm(t: SparqlTerm | undefined): string {
   if (!t) return "";

--- a/packages/sparq-client/src/subscriptions.ts
+++ b/packages/sparq-client/src/subscriptions.ts
@@ -1,0 +1,440 @@
+// [OPUS-4.8] sq-9ij6 — live SPARQL subscriptions client (the SSE transport of the
+// server's `/subscriptions` surface).
+//
+// This is the framework-agnostic companion to the endpoint-mode HTTP client in
+// `./endpoint.ts`. Where that one runs a one-shot query against a SPARQL 1.1 Protocol
+// endpoint, this one SUBSCRIBES a SELECT to the server's SEPA-style subscriptions surface
+// and streams the result DELTAS (added/removed bindings) as the dataset mutates — the one
+// thing a static Pages site fundamentally cannot do on its own.
+//
+// It CONSUMES the existing `sparq-server` subscriptions API
+// (`crates/sparq-server/src/subscriptions.rs`) — it changes nothing server-side and claims
+// no security the server does not provide. It reuses the SAME connection + bearer posture
+// the endpoint client (sq-2mke) established:
+//   * the SAME `EndpointConfig` (endpoint URL + optional bearer token) and the SAME honest
+//     `connectionSafetyWarnings` classifier — a live stream over plaintext to a non-loopback
+//     host, or a token in the clear, is surfaced exactly as for a query, never bypassed;
+//   * the bearer token is sent ONLY in the `Authorization: Bearer <token>` header — the same
+//     channel the server's SSE GET read gate (`--auth-token-read`) validates (see
+//     `crates/sparq-server/src/main.rs`: "The SSE GET takes the `Authorization: Bearer`
+//     header like any GET").
+//
+// WHY THE SSE TRANSPORT (not WebSocket). The server exposes BOTH `/subscriptions` (a
+// multiplexed WS) and `/subscriptions/sse` (a one-subscription-per-stream GET). We use SSE,
+// consumed over `fetch` + a streaming `ReadableStream` reader rather than the browser's
+// native `EventSource`. The reason is auth honesty: native `EventSource` CANNOT set an
+// `Authorization` header, so it could only reach an UNAUTHENTICATED server — but a `fetch`
+// stream sets the exact same `Authorization: Bearer` header a query uses, so the SAME read
+// token works for both. The WS path's `bearer.<token>` subprotocol (`wsSubprotocols`) exists
+// for browsers that cannot header a WS upgrade; the SSE GET has no such limitation, so the
+// header is the honest, single auth channel here.
+//
+// No React, no Next.js, no DOM beyond the `fetch` / `URL` / `TextDecoder` / `AbortController`
+// web-platform globals. No performance claim is made here (this repo's work box is
+// non-canonical).
+
+import type { SparqlResults, SparqlBinding } from "./index.js";
+import { type EndpointConfig, parseEndpointUrl } from "./endpoint.js";
+
+// ---------------------------------------------------------------------------
+// SSE endpoint-URL derivation.
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the `/subscriptions/sse` URL from the configured `/sparql` endpoint URL, carrying
+ * the SELECT (and optional alias) as the query-string parameters the server's
+ * `sse_endpoint` reads (`?query=<SELECT>[&alias=<x>]`).
+ *
+ * The server mounts the SSE route at the path `/subscriptions/sse` on the SAME origin as
+ * `/sparql` (see `crates/sparq-server/src/http.rs` route table). We map the endpoint URL's
+ * path conservatively: a trailing `/sparql` segment is rewritten to `/subscriptions/sse`
+ * (the common `sparq-server` shape), otherwise `/subscriptions/sse` is resolved against the
+ * endpoint's origin. Returns `null` when the endpoint URL is not a valid absolute http(s)
+ * URL (the caller surfaces the same `invalid-url` safety error the query path does).
+ */
+export function buildSubscriptionUrl(
+  config: EndpointConfig,
+  query: string,
+  alias?: string,
+): string | null {
+  const parsed = parseEndpointUrl(config.url);
+  if (!parsed) return null;
+  const sse = new URL(parsed.toString());
+  // Rewrite a trailing `/sparql` to `/subscriptions/sse`; else mount it at the origin root.
+  if (/\/sparql\/?$/.test(sse.pathname)) {
+    sse.pathname = sse.pathname.replace(/\/sparql\/?$/, "/subscriptions/sse");
+  } else {
+    sse.pathname = "/subscriptions/sse";
+  }
+  sse.search = "";
+  sse.searchParams.set("query", query);
+  const a = (alias ?? "").trim();
+  if (a !== "") sse.searchParams.set("alias", a);
+  return sse.toString();
+}
+
+// ---------------------------------------------------------------------------
+// The SEPA notification wire shapes (mirrors subscriptions.rs message builders).
+// ---------------------------------------------------------------------------
+
+/** The `{"subscribed":{"id",…}}` ack the server sends right after a successful subscribe. */
+export interface SubscribedAck {
+  id: number;
+  alias?: string;
+}
+
+/**
+ * One `{"notification":{…}}` frame: the SEPA-shaped diff. `addedResults` / `removedResults`
+ * are both full SPARQL-JSON results objects (`head.vars` + `results.bindings`). `sequence`
+ * is the per-subscription notification counter — 0 is the initial full snapshot (everything
+ * in `addedResults`, `removedResults` empty), then 1, 2, … for each subsequent diff.
+ */
+export interface SubscriptionNotification {
+  id: number;
+  alias?: string;
+  sequence: number;
+  addedResults: SparqlResults;
+  removedResults: SparqlResults;
+}
+
+/** A `{"error":{"message",…}}` frame — a terminating server error on the subscription. */
+export interface SubscriptionError {
+  message: string;
+  id?: number;
+  alias?: string;
+}
+
+/** A parsed subscription event, tagged by which envelope the server sent. */
+export type SubscriptionEvent =
+  | { kind: "subscribed"; ack: SubscribedAck }
+  | { kind: "notification"; notification: SubscriptionNotification }
+  | { kind: "error"; error: SubscriptionError }
+  | { kind: "unknown"; raw: unknown };
+
+/**
+ * Parse one SSE `data:` JSON payload (the server emits one JSON object per `event:`/`data:`
+ * frame) into a tagged {@link SubscriptionEvent}. The SSE `event:` NAME is advisory — the
+ * envelope key (`subscribed` / `notification` / `error`) is the source of truth, exactly as
+ * the WebSocket transport speaks the same JSON. A malformed / unrecognised payload becomes an
+ * `unknown` event (the caller decides whether to surface it), never a throw.
+ */
+export function parseSubscriptionData(data: string): SubscriptionEvent {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(data);
+  } catch {
+    return { kind: "unknown", raw: data };
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return { kind: "unknown", raw: parsed };
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.subscribed && typeof obj.subscribed === "object") {
+    const s = obj.subscribed as Record<string, unknown>;
+    return {
+      kind: "subscribed",
+      ack: { id: Number(s.id), alias: typeof s.alias === "string" ? s.alias : undefined },
+    };
+  }
+  if (obj.notification && typeof obj.notification === "object") {
+    const n = obj.notification as Record<string, unknown>;
+    return {
+      kind: "notification",
+      notification: {
+        id: Number(n.id),
+        sequence: Number(n.sequence),
+        alias: typeof n.alias === "string" ? n.alias : undefined,
+        addedResults: n.addedResults as SparqlResults,
+        removedResults: n.removedResults as SparqlResults,
+      },
+    };
+  }
+  if (obj.error && typeof obj.error === "object") {
+    const e = obj.error as Record<string, unknown>;
+    return {
+      kind: "error",
+      error: {
+        message: typeof e.message === "string" ? e.message : "subscription error",
+        id: typeof e.id === "number" ? e.id : undefined,
+        alias: typeof e.alias === "string" ? e.alias : undefined,
+      },
+    };
+  }
+  return { kind: "unknown", raw: parsed };
+}
+
+// ---------------------------------------------------------------------------
+// The live result set — applying added/removed diffs against a row-keyed map.
+// ---------------------------------------------------------------------------
+
+/**
+ * The canonical identity key of a solution row, matching the server's diff key: the binding
+ * object serialised with its keys in sorted order. The server keys on
+ * `serde_json::Value::to_string()` of the binding object (variables in `serde_json` map
+ * order, which is sorted), so we reproduce that ordering here so a row added in one
+ * notification and removed in a later one collapses to the SAME key.
+ */
+export function rowKey(binding: SparqlBinding): string {
+  const keys = Object.keys(binding).sort();
+  const ordered: Record<string, unknown> = {};
+  for (const k of keys) ordered[k] = binding[k];
+  return JSON.stringify(ordered);
+}
+
+/**
+ * The live, accumulated result set of a subscription: the projected variables plus the
+ * current rows keyed by their canonical {@link rowKey}. The view renders `vars` + the row
+ * VALUES; the map de-duplicates exactly as the server's set-semantics diff does.
+ */
+export interface LiveResultSet {
+  vars: string[];
+  rows: Map<string, SparqlBinding>;
+}
+
+/** An empty live result set (before the sequence-0 snapshot arrives). */
+export function emptyLiveResultSet(): LiveResultSet {
+  return { vars: [], rows: new Map() };
+}
+
+/**
+ * [OPUS-4.8] sq-9ij6 — apply one {@link SubscriptionNotification} diff to a {@link
+ * LiveResultSet}, returning the NEW set (pure — the input is not mutated, so a React state
+ * setter can compare identities). Removed rows are deleted first, then added rows inserted,
+ * keyed by the canonical {@link rowKey} (so a re-added row replaces, and a removed-then-added
+ * row nets correctly). The variable list is refreshed from the notification's `addedResults`
+ * head when it carries one (the head is identical across a subscription's lifetime, but the
+ * sequence-0 snapshot is where it first lands).
+ *
+ * Returns the counts of rows actually added / removed so the diff LOG can report the real
+ * deltas (an added key already present, or a removed key absent, does not double-count).
+ */
+export function applyNotification(
+  set: LiveResultSet,
+  notification: SubscriptionNotification,
+): { next: LiveResultSet; added: number; removed: number } {
+  const rows = new Map(set.rows);
+  let removed = 0;
+  for (const binding of notification.removedResults?.results?.bindings ?? []) {
+    if (rows.delete(rowKey(binding))) removed += 1;
+  }
+  let added = 0;
+  for (const binding of notification.addedResults?.results?.bindings ?? []) {
+    const key = rowKey(binding);
+    if (!rows.has(key)) added += 1;
+    rows.set(key, binding);
+  }
+  const headVars =
+    notification.addedResults?.head?.vars ??
+    notification.removedResults?.head?.vars ??
+    set.vars;
+  return { next: { vars: headVars.length > 0 ? headVars : set.vars, rows }, added, removed };
+}
+
+/** The live rows as a `SparqlResults` document, so the SAME results helpers render them. */
+export function liveResults(set: LiveResultSet): SparqlResults {
+  return {
+    head: { vars: set.vars },
+    results: { bindings: [...set.rows.values()] },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The fetch-based SSE reader (one subscription per stream).
+// ---------------------------------------------------------------------------
+
+/** The callbacks a {@link openSubscription} stream drives. */
+export interface SubscriptionHandlers {
+  /** A parsed event arrived (subscribed ack / notification diff / terminating error). */
+  onEvent: (event: SubscriptionEvent) => void;
+  /** The stream opened (the HTTP response is 200 and the body is flowing). */
+  onOpen?: () => void;
+  /**
+   * The stream closed. `error` is set when it closed because of a transport failure or a
+   * non-2xx response (with an honest, classified message); `undefined` on a clean end (the
+   * caller aborted, or the server ended the stream after a terminating `error` event).
+   */
+  onClose?: (error?: string) => void;
+}
+
+/** A handle to an open subscription stream — call {@link close} to unsubscribe. */
+export interface SubscriptionHandle {
+  /** Abort the stream (drops the server-side subscription, releasing its slot). */
+  close: () => void;
+}
+
+/**
+ * Split a chunk of decoded SSE text into complete frames (separated by a blank line) plus the
+ * trailing partial frame to carry into the next read. Each complete frame is the raw block of
+ * `event:` / `data:` / `id:` lines. Exported for unit testing the framing.
+ */
+export function splitSseFrames(buffer: string): { frames: string[]; rest: string } {
+  // SSE frames are separated by a blank line; tolerate both \n\n and \r\n\r\n.
+  const normalised = buffer.replace(/\r\n/g, "\n");
+  const parts = normalised.split("\n\n");
+  const rest = parts.pop() ?? "";
+  return { frames: parts.filter((p) => p.trim() !== ""), rest };
+}
+
+/**
+ * Extract the `data:` payload from one SSE frame (joining multiple `data:` lines with a
+ * newline, per the SSE spec). A keep-alive comment frame (lines starting with `:`) or a frame
+ * with no `data:` line yields `null` — the caller skips it. Exported for unit testing.
+ */
+export function frameData(frame: string): string | null {
+  const dataLines: string[] = [];
+  for (const line of frame.split("\n")) {
+    if (line.startsWith(":")) continue; // SSE comment / keep-alive ping
+    if (line.startsWith("data:")) {
+      // Per the SSE spec a single leading space after the colon is stripped.
+      dataLines.push(line.slice(5).replace(/^ /, ""));
+    }
+  }
+  return dataLines.length > 0 ? dataLines.join("\n") : null;
+}
+
+/** Add the `Authorization: Bearer <token>` header iff a non-empty token is configured. */
+function authHeaders(token?: string): Record<string, string> {
+  const headers: Record<string, string> = { Accept: "text/event-stream" };
+  const t = (token ?? "").trim();
+  if (t !== "") headers["Authorization"] = `Bearer ${t}`;
+  return headers;
+}
+
+/**
+ * [OPUS-4.8] sq-9ij6 — open a live subscription to the endpoint's `/subscriptions/sse` GET,
+ * over `fetch` + a streaming `ReadableStream` reader, and drive `handlers` as events arrive.
+ *
+ * The bearer token (if any) is sent ONLY in the `Authorization: Bearer` header — the same
+ * channel the server's SSE read gate validates, and the same posture the endpoint query
+ * client uses. `fetch` (not native `EventSource`) is used precisely BECAUSE it can set that
+ * header (native `EventSource` cannot, so it could never reach an authenticated server).
+ *
+ * Lifecycle is reported honestly: `onOpen` once the 200 stream is flowing; `onEvent` per
+ * parsed frame; `onClose(error)` with an HONEST classified message on a non-2xx (401 → auth
+ * required; 413 → result too large; 503 → capacity/timeout, retry; transport failure → the
+ * CORS/reachability hint), or `onClose()` on a clean end (server stream ended, or the caller
+ * aborted). A registration refusal is a non-2xx HTTP status BEFORE the stream opens (the SSE
+ * endpoint sets a real status then, mirroring `/sparql`), so it surfaces as an `onClose`
+ * error, never a silent dead stream.
+ *
+ * Returns a {@link SubscriptionHandle}; `close()` aborts the fetch, which drops the
+ * server-side subscription (its `ConnSlots` `Drop` releases the global slot — no leak).
+ */
+export function openSubscription(
+  config: EndpointConfig,
+  query: string,
+  handlers: SubscriptionHandlers,
+  options: { alias?: string; fetchImpl?: typeof fetch } = {},
+): SubscriptionHandle {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const url = buildSubscriptionUrl(config, query, options.alias);
+
+  if (url === null) {
+    // Invalid endpoint URL — fail closed, consistent with the query path's `invalid-url`.
+    handlers.onClose?.(
+      "Enter a valid absolute endpoint URL (http:// or https://) in the Connect panel before subscribing.",
+    );
+    return { close: () => {} };
+  }
+
+  void (async () => {
+    let resp: Response;
+    try {
+      resp = await fetchImpl(url, {
+        method: "GET",
+        headers: authHeaders(config.token),
+        signal: controller.signal,
+      });
+    } catch (e) {
+      if (controller.signal.aborted) {
+        handlers.onClose?.();
+        return;
+      }
+      const base = e instanceof Error ? e.message : String(e);
+      handlers.onClose?.(
+        `Could not open the subscription stream (${base}). This is usually a CORS block (the server emits no CORS headers by default — opt this origin in with --cors-allow-origin), a refused connection (is the server running and reachable?), or a mixed-content block (HTTPS page → http endpoint).`,
+      );
+      return;
+    }
+
+    if (!resp.ok) {
+      handlers.onClose?.(await subscriptionErrorMessage(resp));
+      return;
+    }
+    if (!resp.body) {
+      handlers.onClose?.("The subscription stream opened but carried no body.");
+      return;
+    }
+
+    handlers.onOpen?.();
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const { frames, rest } = splitSseFrames(buffer);
+        buffer = rest;
+        for (const frame of frames) {
+          const data = frameData(frame);
+          if (data === null) continue; // keep-alive ping / dataless frame
+          handlers.onEvent(parseSubscriptionData(data));
+        }
+      }
+      handlers.onClose?.();
+    } catch (e) {
+      if (controller.signal.aborted) {
+        handlers.onClose?.();
+        return;
+      }
+      const base = e instanceof Error ? e.message : String(e);
+      handlers.onClose?.(`The subscription stream was interrupted (${base}).`);
+    }
+  })();
+
+  return {
+    close: () => controller.abort(),
+  };
+}
+
+/**
+ * Turn a non-2xx subscription-registration response into an honest, classified message that
+ * mirrors the server's SSE refusal contract (`crates/sparq-server/src/subscriptions.rs`
+ * `sse_endpoint`): 401 → auth required; 400 → fix the SELECT (only SELECT is subscribable);
+ * 413 → result too large for the server's row cap; 429/503 → transient capacity/timeout, safe
+ * to retry; 5xx → server defect. The server's JSON error body (`{"error":"…"}`) is surfaced
+ * verbatim when present.
+ */
+async function subscriptionErrorMessage(resp: Response): Promise<string> {
+  let detail = "";
+  try {
+    const text = await resp.text();
+    if (text) {
+      try {
+        const parsed = JSON.parse(text) as { error?: string };
+        detail = parsed?.error ?? text;
+      } catch {
+        detail = text;
+      }
+    }
+  } catch {
+    /* body unreadable — fall through to the status-only message */
+  }
+  const prefix =
+    resp.status === 401
+      ? "Authentication required — the server gates this read surface behind a Bearer token (--auth-token-read). Enter a valid token in the Connect panel."
+      : resp.status === 400
+        ? "The subscription was refused (400) — only a SELECT query can be subscribed; check the query form."
+        : resp.status === 413
+          ? "The subscription was refused (413) — the initial result exceeds the server's max-results row cap."
+          : resp.status === 429 || resp.status === 503
+            ? `Server temporarily unavailable (${resp.status}) — the subscription slot is exhausted or the query timed out; transient, safe to retry.`
+            : resp.status >= 500
+              ? `Server error (${resp.status}).`
+              : `Subscription refused (${resp.status}).`;
+  return detail ? `${prefix} ${detail}` : prefix;
+}

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -54,6 +54,8 @@ import {
 import { SparqlEditor } from "@/components/sparql-editor";
 // [OPUS-4.8] sq-2mke — endpoint mode: the Connect panel + the SPARQL 1.1 Protocol client.
 import { ConnectPanel } from "@/components/connect-panel";
+// [OPUS-4.8] sq-9ij6 — endpoint mode: the live subscriptions view (SSE result deltas).
+import { SubscriptionsView } from "@/components/subscriptions-view";
 import { type EndpointConfig, runEndpointQuery } from "@sparq/client";
 
 // [OPUS-4.8] sq-vfbm — the REPL now dispatches across the whole lean-bundle query
@@ -496,6 +498,12 @@ export function Repl() {
         </div>
 
         <ResultPanel state={state} />
+
+        {/* [OPUS-4.8] sq-9ij6 — the live subscriptions view. Only meaningful in endpoint
+            mode (it streams from a real, mutating server's /subscriptions/sse), so it
+            renders an honest "switch on endpoint mode" hint otherwise. It reuses the SAME
+            endpoint config + bearer/connection-safety posture the Connect panel established. */}
+        <SubscriptionsView config={endpointConfig} active={endpointActive} />
       </CardContent>
 
       <DatasetViewer

--- a/site/src/components/subscriptions-view.tsx
+++ b/site/src/components/subscriptions-view.tsx
@@ -1,0 +1,437 @@
+"use client";
+
+// [OPUS-4.8] sq-9ij6 — GUI Phase 2 item 7: the LIVE subscriptions view.
+//
+// In endpoint mode this view subscribes a SELECT to the connected sparq-server's
+// `/subscriptions/sse` Server-Sent-Events stream and renders the streamed result DELTAS
+// live as the dataset mutates — the standout demo a static Pages site fundamentally cannot
+// do on its own (it needs a real, mutating server to push to it).
+//
+// It REUSES the sq-2mke endpoint-mode connection + bearer posture, never reinventing it:
+//   * the SAME `EndpointConfig` (URL + optional bearer token) the Connect panel owns;
+//   * the SAME honest `connectionSafetyWarnings` classifier — surfaced here too, so a live
+//     stream over plaintext to a non-loopback host, or a token in the clear, is flagged
+//     exactly as for a query (and a hard block, e.g. mixed-content, disables Subscribe);
+//   * the bearer token is sent ONLY in the `Authorization: Bearer` header by the shared
+//     `@sparq/client` `openSubscription` — the same channel the server's SSE read gate
+//     (`--auth-token-read`) validates. This view never logs the token and never bypasses a
+//     server gate.
+//
+// All wire-protocol + safety + diff logic lives in the framework-agnostic `@sparq/client`
+// subscriptions module; this component is just the React host that draws the live table,
+// the diff log, and the honest connect / streaming / disconnected / error lifecycle.
+
+import * as React from "react";
+import { Radio, WifiOff, Plus, Minus, CircleStop, Loader2, Activity } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { SparqlEditor } from "@/components/sparql-editor";
+import {
+  type EndpointConfig,
+  type LiveResultSet,
+  type SubscriptionHandle,
+  applyNotification,
+  connectionSafetyWarnings,
+  emptyLiveResultSet,
+  extractTable,
+  hasBlockingWarning,
+  liveResults,
+  openSubscription,
+} from "@sparq/client";
+
+const DEFAULT_SUBSCRIPTION_QUERY =
+  "SELECT ?s ?age WHERE { ?s <http://ex/age> ?age } ORDER BY ?age";
+
+/** The live stream lifecycle, surfaced honestly in the UI. */
+type StreamStatus =
+  | { kind: "idle" }
+  | { kind: "connecting" }
+  | { kind: "live" }
+  | { kind: "closed"; error?: string };
+
+/** One entry in the diff log — the human-readable delta of a single notification. */
+interface DiffLogEntry {
+  /** The per-subscription SSE sequence (0 = initial snapshot, then 1, 2, …). */
+  sequence: number;
+  added: number;
+  removed: number;
+  /** Local wall-clock time the delta was applied (display only, not a benchmark). */
+  at: string;
+}
+
+export interface SubscriptionsViewProps {
+  /** The endpoint connection (URL + optional bearer token), shared with the REPL. */
+  config: EndpointConfig;
+  /** Whether endpoint mode is active — subscriptions only run against a real server. */
+  active: boolean;
+}
+
+/**
+ * [OPUS-4.8] sq-9ij6 — the live subscriptions view. Renders a SELECT editor, a
+ * Subscribe/Stop control, the honest connection-safety findings (reused from sq-2mke), the
+ * live accumulated result table, and a diff log of each streamed delta.
+ *
+ * The stream is held in a ref so a React re-render never re-opens it; the `useEffect`
+ * cleanup aborts an in-flight stream on unmount or when endpoint mode is switched off, which
+ * drops the server-side subscription (its slot is released on disconnect — no leak).
+ */
+export function SubscriptionsView({ config, active }: SubscriptionsViewProps) {
+  const [query, setQuery] = React.useState(DEFAULT_SUBSCRIPTION_QUERY);
+  const [status, setStatus] = React.useState<StreamStatus>({ kind: "idle" });
+  const [resultSet, setResultSet] = React.useState<LiveResultSet>(emptyLiveResultSet);
+  const [log, setLog] = React.useState<DiffLogEntry[]>([]);
+  const handleRef = React.useRef<SubscriptionHandle | null>(null);
+  // The current live set is mirrored in a ref so each streamed notification diffs against the
+  // latest accumulated set deterministically — computing the diff ONCE per event at the top
+  // level, never inside a state-updater (which React may re-invoke).
+  const setRef = React.useRef<LiveResultSet>(emptyLiveResultSet());
+
+  // Reuse the SAME honest classifier the Connect panel uses; a hard block (invalid URL /
+  // mixed content) disables Subscribe exactly as it disables turning endpoint mode on.
+  const warnings = React.useMemo(() => connectionSafetyWarnings(config), [config]);
+  const blocked = hasBlockingWarning(warnings);
+
+  const streaming = status.kind === "connecting" || status.kind === "live";
+
+  const stop = React.useCallback(() => {
+    handleRef.current?.close();
+    handleRef.current = null;
+  }, []);
+
+  const subscribe = React.useCallback(() => {
+    // Tear down any prior stream first (Subscribe is also "re-subscribe").
+    handleRef.current?.close();
+    setRef.current = emptyLiveResultSet();
+    setResultSet(setRef.current);
+    setLog([]);
+    setStatus({ kind: "connecting" });
+
+    handleRef.current = openSubscription(
+      config,
+      query,
+      {
+        onOpen: () => setStatus({ kind: "live" }),
+        onEvent: (event) => {
+          if (event.kind === "notification") {
+            const note = event.notification;
+            // Diff against the latest accumulated set (held in a ref) ONCE, then commit both
+            // the new set and — when the delta was real — a log entry, at the top level.
+            const { next, added, removed } = applyNotification(setRef.current, note);
+            setRef.current = next;
+            setResultSet(next);
+            // The sequence-0 snapshot always counts; a later no-op diff the server suppresses.
+            if (added > 0 || removed > 0 || note.sequence === 0) {
+              setLog((entries) => [
+                {
+                  sequence: note.sequence,
+                  added,
+                  removed,
+                  at: new Date().toLocaleTimeString(),
+                },
+                ...entries,
+              ]);
+            }
+          } else if (event.kind === "error") {
+            // A terminating server error (re-evaluation failed). The server ends the stream
+            // right after, so onClose fires too; surface the message immediately.
+            setStatus({ kind: "closed", error: event.error.message });
+          }
+          // `subscribed` ack + `unknown` frames need no view change.
+        },
+        onClose: (error) => {
+          handleRef.current = null;
+          // Preserve a server-error message already set by an `error` event.
+          setStatus((prev) =>
+            prev.kind === "closed" && prev.error
+              ? prev
+              : { kind: "closed", error },
+          );
+        },
+      },
+      { alias: "try-live" },
+    );
+  }, [config, query]);
+
+  // Abort an in-flight stream on unmount, or when endpoint mode is switched off (the server
+  // drops the subscription and releases its slot when the fetch is aborted).
+  React.useEffect(() => {
+    if (!active) {
+      handleRef.current?.close();
+      handleRef.current = null;
+      setStatus({ kind: "idle" });
+    }
+    return () => {
+      handleRef.current?.close();
+      handleRef.current = null;
+    };
+  }, [active]);
+
+  if (!active) {
+    return (
+      <div className="space-y-2 rounded-lg border bg-muted/30 p-3">
+        <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+          <Radio className="size-3.5" />
+          Live subscriptions
+          <span className="font-normal text-muted-foreground/80">
+            — stream result deltas from the server as the dataset mutates
+          </span>
+        </div>
+        <p className="text-[11.5px] leading-relaxed text-muted-foreground">
+          Switch on <span className="font-medium">Endpoint mode</span> above and connect to a
+          running sparq-server to subscribe a SELECT to its{" "}
+          <code className="font-mono">/subscriptions/sse</code> stream. The view then renders
+          the live added/removed result deltas each time a SPARQL UPDATE commits — something a
+          static page can only do against a real, mutating server.
+        </p>
+      </div>
+    );
+  }
+
+  const table = extractTable(liveResults(resultSet));
+
+  return (
+    <div className="space-y-3 rounded-lg border bg-muted/30 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+          <Radio
+            className={cn("size-3.5", status.kind === "live" && "text-primary")}
+          />
+          Live subscriptions
+          <span className="font-normal text-muted-foreground/80">
+            — SSE stream of result deltas from <code className="font-mono">/subscriptions/sse</code>
+          </span>
+        </div>
+        <StreamStatusBadge status={status} />
+      </div>
+
+      <div className="space-y-1.5">
+        <label htmlFor="subscription-query" className="text-xs font-medium">
+          Subscribed SELECT
+        </label>
+        <SparqlEditor
+          id="subscription-query"
+          ariaLabel="Subscription SELECT query"
+          value={query}
+          onChange={setQuery}
+          rows={4}
+        />
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          Only a SELECT can be subscribed — the server diffs over solution bindings (a
+          CONSTRUCT / ASK / UPDATE is refused with a 400). To watch it fire, run a SPARQL
+          UPDATE against the same endpoint (the Run button above, in endpoint mode) and the
+          stream pushes the added/removed rows.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        {streaming ? (
+          <Button variant="outline" size="sm" onClick={stop} title="Close the SSE stream (unsubscribe)">
+            <CircleStop className="size-3.5" />
+            Stop
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            onClick={subscribe}
+            disabled={blocked}
+            title={
+              blocked
+                ? "Fix the endpoint URL / transport warning before subscribing"
+                : "Open an SSE subscription to the endpoint and stream result deltas"
+            }
+          >
+            <Radio className="size-3.5" />
+            Subscribe
+          </Button>
+        )}
+        <StreamStatusLine status={status} rows={table.rows.length} />
+      </div>
+
+      <SafetyWarningList warnings={warnings} />
+
+      <LiveTable table={table} status={status} />
+
+      <DiffLog log={log} />
+    </div>
+  );
+}
+
+// [OPUS-4.8] sq-9ij6 — the live-stream status pill, reusing the Badge tokens.
+function StreamStatusBadge({ status }: { status: StreamStatus }) {
+  if (status.kind === "live") {
+    return (
+      <Badge variant="success" aria-live="polite">
+        <Radio className="size-3" /> Streaming
+      </Badge>
+    );
+  }
+  if (status.kind === "connecting") {
+    return (
+      <Badge variant="muted" aria-live="polite">
+        <Loader2 className="size-3 animate-spin" /> Connecting…
+      </Badge>
+    );
+  }
+  if (status.kind === "closed" && status.error) {
+    return (
+      <Badge variant="warning" aria-live="polite">
+        <WifiOff className="size-3" /> Stream error
+      </Badge>
+    );
+  }
+  if (status.kind === "closed") {
+    return (
+      <Badge variant="muted" aria-live="polite">
+        <WifiOff className="size-3" /> Disconnected
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="muted" aria-live="polite">
+      <WifiOff className="size-3" /> Idle
+    </Badge>
+  );
+}
+
+function StreamStatusLine({ status, rows }: { status: StreamStatus; rows: number }) {
+  return (
+    <p aria-live="polite" className="text-xs text-muted-foreground">
+      {status.kind === "connecting" && "Opening the SSE stream…"}
+      {status.kind === "live" && `Live · ${rows} ${rows === 1 ? "row" : "rows"} in the result set`}
+      {status.kind === "closed" && !status.error && "Stream closed."}
+      {status.kind === "closed" && status.error && (
+        <span className="text-destructive">{status.error}</span>
+      )}
+    </p>
+  );
+}
+
+// [OPUS-4.8] sq-9ij6 — render the SAME classified connection-safety findings the Connect
+// panel uses. The subscription stream rides the same transport as a query, so the same
+// posture applies (plaintext to a non-loopback host, token-in-the-clear, CORS, mixed
+// content); we surface them here too so the user is not led to believe a live stream is any
+// more private than a query.
+function SafetyWarningList({
+  warnings,
+}: {
+  warnings: ReturnType<typeof connectionSafetyWarnings>;
+}) {
+  // Only the transport-relevant findings matter for a stream; the SERVICE-allowlist info
+  // note is about federation inside the SELECT, so it is still relevant and kept.
+  if (warnings.length === 0) return null;
+  return (
+    <ul className="space-y-1.5">
+      {warnings.map((w) => (
+        <li
+          key={w.code}
+          data-safety-code={w.code}
+          data-safety-level={w.level}
+          className={cn(
+            "flex items-start gap-2 rounded-md border p-2 text-[11.5px] leading-relaxed",
+            w.level === "error" && "border-destructive/30 bg-destructive/5 text-destructive",
+            w.level === "warning" &&
+              "border-[color-mix(in_oklch,var(--warning)_35%,transparent)] bg-[color-mix(in_oklch,var(--warning)_10%,transparent)] text-[color-mix(in_oklch,var(--warning)_80%,var(--foreground))]",
+            w.level === "info" && "border-border bg-muted/40 text-muted-foreground",
+          )}
+        >
+          <span>{w.message}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// [OPUS-4.8] sq-9ij6 — the live accumulated result set, rendered through the SAME
+// `extractTable` shaping the one-shot SELECT results panel uses, so a live row and a queried
+// row render identically.
+function LiveTable({
+  table,
+  status,
+}: {
+  table: ReturnType<typeof extractTable>;
+  status: StreamStatus;
+}) {
+  if (table.vars.length === 0) {
+    return (
+      <p className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+        {status.kind === "live" || status.kind === "connecting"
+          ? "Waiting for the first snapshot…"
+          : "No live result yet — Subscribe to stream the current result set, then watch it update."}
+      </p>
+    );
+  }
+  return (
+    <div className="max-h-80 overflow-auto rounded-lg border" data-result-kind="live-select">
+      <table className="w-full text-left text-sm">
+        <thead className="sticky top-0 bg-muted/80 backdrop-blur">
+          <tr>
+            {table.vars.map((v) => (
+              <th key={v} className="px-3 py-2 font-medium">
+                ?{v}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {table.rows.length === 0 ? (
+            <tr>
+              <td
+                colSpan={table.vars.length}
+                className="px-3 py-2 text-muted-foreground"
+              >
+                The result set is currently empty.
+              </td>
+            </tr>
+          ) : (
+            table.rows.map((row, i) => (
+              <tr key={i} className="border-t">
+                {row.map((cell, j) => (
+                  <td key={table.vars[j]} className="px-3 py-1.5 font-mono text-[12.5px]">
+                    {cell}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// [OPUS-4.8] sq-9ij6 — the diff log: one line per streamed delta, newest first. Sequence 0 is
+// the initial snapshot (full result as added); each later entry is the net added/removed of
+// one re-evaluation the server pushed when a commit changed the result.
+function DiffLog({ log }: { log: DiffLogEntry[] }) {
+  if (log.length === 0) return null;
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <Activity className="size-3.5" /> Delta log
+      </div>
+      <ul className="max-h-48 space-y-1 overflow-auto" data-testid="subscription-diff-log">
+        {log.map((entry) => (
+          <li
+            key={entry.sequence}
+            className="flex items-center gap-3 rounded-md border bg-background/60 px-2.5 py-1.5 text-[11.5px]"
+          >
+            <span className="tabular text-muted-foreground">
+              {entry.sequence === 0 ? "snapshot" : `seq ${entry.sequence}`}
+            </span>
+            <span className="inline-flex items-center gap-1 text-[var(--success)]">
+              <Plus className="size-3" />
+              {entry.added}
+            </span>
+            <span className="inline-flex items-center gap-1 text-muted-foreground">
+              <Minus className="size-3" />
+              {entry.removed}
+            </span>
+            <span className="ml-auto tabular text-muted-foreground/70">{entry.at}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/site/test/subscriptions.test.mjs
+++ b/site/test/subscriptions.test.mjs
@@ -1,0 +1,317 @@
+// [OPUS-4.8] sq-9ij6 — unit tests for the live SPARQL subscriptions client
+// (`@sparq/client` `subscriptions.ts`): the SSE-URL derivation (reusing the endpoint
+// config + bearer posture), the SEPA notification parser, the SSE frame splitter / data
+// extractor, the row-keyed live-diff reducer (matching the server's set-semantics diff),
+// and the `openSubscription` stream lifecycle (open / notification / error / clean close)
+// driven over an injected `fetch`. These cover the pure, framework-free logic the
+// subscriptions VIEW relies on. Run via `npm run test:unit`.
+//
+// Imported by RELATIVE path (not the `@sparq/client` alias) so the build-free ts-loader
+// resolves it without a custom alias resolver — exactly like endpoint.test.mjs.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildSubscriptionUrl,
+  parseSubscriptionData,
+  splitSseFrames,
+  frameData,
+  rowKey,
+  emptyLiveResultSet,
+  applyNotification,
+  liveResults,
+  openSubscription,
+} from "../../packages/sparq-client/src/subscriptions.ts";
+
+// --- buildSubscriptionUrl ---------------------------------------------------
+
+test("buildSubscriptionUrl rewrites a trailing /sparql to /subscriptions/sse with the query param", () => {
+  const url = buildSubscriptionUrl(
+    { url: "http://127.0.0.1:3030/sparql" },
+    "SELECT ?s WHERE { ?s ?p ?o }",
+  );
+  const u = new URL(url);
+  assert.equal(u.origin, "http://127.0.0.1:3030");
+  assert.equal(u.pathname, "/subscriptions/sse");
+  assert.equal(u.searchParams.get("query"), "SELECT ?s WHERE { ?s ?p ?o }");
+  assert.equal(u.searchParams.get("alias"), null);
+});
+
+test("buildSubscriptionUrl carries a non-empty alias and trims it", () => {
+  const url = buildSubscriptionUrl(
+    { url: "https://data.example.org/sparql" },
+    "SELECT ?s WHERE { ?s ?p ?o }",
+    "  watch  ",
+  );
+  const u = new URL(url);
+  assert.equal(u.searchParams.get("alias"), "watch");
+});
+
+test("buildSubscriptionUrl mounts at the origin root when the path is not /sparql", () => {
+  const url = buildSubscriptionUrl({ url: "http://localhost:3030/" }, "SELECT * WHERE {?s ?p ?o}");
+  const u = new URL(url);
+  assert.equal(u.pathname, "/subscriptions/sse");
+});
+
+test("buildSubscriptionUrl returns null for an invalid endpoint URL", () => {
+  assert.equal(buildSubscriptionUrl({ url: "not a url" }, "SELECT * WHERE {?s ?p ?o}"), null);
+  assert.equal(buildSubscriptionUrl({ url: "" }, "SELECT * WHERE {?s ?p ?o}"), null);
+});
+
+// --- parseSubscriptionData (the SEPA envelope parser) -----------------------
+
+test("parseSubscriptionData tags the subscribed ack", () => {
+  const ev = parseSubscriptionData(`{"subscribed":{"alias":"ages","id":1}}`);
+  assert.equal(ev.kind, "subscribed");
+  assert.equal(ev.ack.id, 1);
+  assert.equal(ev.ack.alias, "ages");
+});
+
+test("parseSubscriptionData tags a notification with its diff results + sequence", () => {
+  // The byte-for-byte sequence-1 frame from the captured server transcript.
+  const data = `{"notification":{"addedResults":{"head":{"vars":["s","age"]},"results":{"bindings":[{"age":{"datatype":"http://www.w3.org/2001/XMLSchema#integer","type":"literal","value":"63"},"s":{"type":"uri","value":"http://ex/frank"}}]}},"alias":"ages","id":1,"removedResults":{"head":{"vars":["s","age"]},"results":{"bindings":[]}},"sequence":1}}`;
+  const ev = parseSubscriptionData(data);
+  assert.equal(ev.kind, "notification");
+  assert.equal(ev.notification.id, 1);
+  assert.equal(ev.notification.sequence, 1);
+  assert.equal(ev.notification.alias, "ages");
+  assert.equal(ev.notification.addedResults.results.bindings.length, 1);
+  assert.equal(ev.notification.removedResults.results.bindings.length, 0);
+});
+
+test("parseSubscriptionData tags a terminating error", () => {
+  const ev = parseSubscriptionData(`{"error":{"message":"re-evaluation failed","id":5}}`);
+  assert.equal(ev.kind, "error");
+  assert.equal(ev.error.message, "re-evaluation failed");
+  assert.equal(ev.error.id, 5);
+});
+
+test("parseSubscriptionData yields 'unknown' for junk, never throws", () => {
+  assert.equal(parseSubscriptionData("not json").kind, "unknown");
+  assert.equal(parseSubscriptionData(`{"surprise":1}`).kind, "unknown");
+  assert.equal(parseSubscriptionData("42").kind, "unknown");
+});
+
+// --- splitSseFrames + frameData (the wire framing) --------------------------
+
+test("splitSseFrames splits on blank lines and keeps a trailing partial frame", () => {
+  const buf = "event: subscribed\ndata: {\"subscribed\":{\"id\":1}}\n\nevent: notification\ndata: {\"x\":1}";
+  const { frames, rest } = splitSseFrames(buf);
+  assert.equal(frames.length, 1);
+  assert.match(frames[0], /subscribed/);
+  // The second (incomplete) frame is carried forward, not parsed.
+  assert.match(rest, /notification/);
+});
+
+test("splitSseFrames tolerates CRLF line endings", () => {
+  const buf = "event: subscribed\r\ndata: {\"subscribed\":{\"id\":1}}\r\n\r\n";
+  const { frames, rest } = splitSseFrames(buf);
+  assert.equal(frames.length, 1);
+  assert.equal(rest, "");
+});
+
+test("frameData extracts the data payload and ignores keep-alive comment frames", () => {
+  // The raw notification frame shape: event:, data: JSON, id: (the id line is not data).
+  const frame = `event: notification\ndata: {"notification":{"sequence":0}}\nid: 0`;
+  assert.equal(frameData(frame), `{"notification":{"sequence":0}}`);
+  // A keep-alive ping (a bare comment line) carries no data.
+  assert.equal(frameData(": ping"), null);
+  // A dataless frame yields null.
+  assert.equal(frameData("event: foo"), null);
+});
+
+// --- rowKey + applyNotification (the live set-semantics diff) ----------------
+
+test("rowKey is order-independent over the binding's variables", () => {
+  const a = { s: { type: "uri", value: "http://x" }, age: { type: "literal", value: "1" } };
+  const b = { age: { type: "literal", value: "1" }, s: { type: "uri", value: "http://x" } };
+  assert.equal(rowKey(a), rowKey(b), "the same row keys identically regardless of var order");
+});
+
+function notification(seq, added, removed = []) {
+  return {
+    id: 1,
+    sequence: seq,
+    addedResults: { head: { vars: ["s"] }, results: { bindings: added } },
+    removedResults: { head: { vars: ["s"] }, results: { bindings: removed } },
+  };
+}
+
+test("applyNotification builds the snapshot then nets added/removed deltas", () => {
+  let set = emptyLiveResultSet();
+
+  // Sequence 0: the full snapshot (two rows added, none removed).
+  const snap = applyNotification(
+    set,
+    notification(0, [
+      { s: { type: "uri", value: "http://a" } },
+      { s: { type: "uri", value: "http://b" } },
+    ]),
+  );
+  assert.equal(snap.added, 2);
+  assert.equal(snap.removed, 0);
+  set = snap.next;
+  assert.deepEqual(set.vars, ["s"]);
+  assert.equal(set.rows.size, 2);
+
+  // Sequence 1: add one, remove one — the live set tracks the net.
+  const diff = applyNotification(
+    set,
+    notification(
+      1,
+      [{ s: { type: "uri", value: "http://c" } }],
+      [{ s: { type: "uri", value: "http://a" } }],
+    ),
+  );
+  assert.equal(diff.added, 1);
+  assert.equal(diff.removed, 1);
+  set = diff.next;
+  assert.equal(set.rows.size, 2);
+
+  const values = liveResults(set).results.bindings.map((r) => r.s.value).sort();
+  assert.deepEqual(values, ["http://b", "http://c"]);
+});
+
+test("applyNotification does not double-count an already-present add or an absent remove", () => {
+  let set = emptyLiveResultSet();
+  set = applyNotification(set, notification(0, [{ s: { type: "uri", value: "http://a" } }])).next;
+
+  // Re-adding the same row + removing a row that was never present nets to nothing.
+  const r = applyNotification(
+    set,
+    notification(
+      1,
+      [{ s: { type: "uri", value: "http://a" } }],
+      [{ s: { type: "uri", value: "http://zzz" } }],
+    ),
+  );
+  assert.equal(r.added, 0, "an already-present row is not counted as added");
+  assert.equal(r.removed, 0, "an absent row is not counted as removed");
+  assert.equal(r.next.rows.size, 1);
+});
+
+// --- openSubscription (the stream lifecycle over an injected fetch) ---------
+
+/** Build a Response whose body streams the given SSE text (one chunk). */
+function sseResponse(text, status = 200) {
+  const body = new ReadableStream({
+    start(ctrl) {
+      ctrl.enqueue(new TextEncoder().encode(text));
+      ctrl.close();
+    },
+  });
+  return new Response(status === 200 ? body : null, {
+    status,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+test("openSubscription opens, parses each frame, and closes cleanly when the stream ends", async () => {
+  const transcript =
+    `event: subscribed\ndata: {"subscribed":{"id":1}}\n\n` +
+    `event: notification\ndata: {"notification":{"id":1,"sequence":0,"addedResults":{"head":{"vars":["s"]},"results":{"bindings":[{"s":{"type":"uri","value":"http://a"}}]}},"removedResults":{"head":{"vars":["s"]},"results":{"bindings":[]}}}}\nid: 0\n\n`;
+  const fetchImpl = async () => sseResponse(transcript);
+
+  const events = [];
+  let opened = false;
+  let closedError;
+  let closed = false;
+  await new Promise((resolve) => {
+    openSubscription(
+      { url: "http://127.0.0.1:3030/sparql" },
+      "SELECT ?s WHERE { ?s ?p ?o }",
+      {
+        onOpen: () => {
+          opened = true;
+        },
+        onEvent: (e) => events.push(e),
+        onClose: (err) => {
+          closed = true;
+          closedError = err;
+          resolve();
+        },
+      },
+      { fetchImpl },
+    );
+  });
+
+  assert.equal(opened, true, "onOpen fired once the 200 body flowed");
+  assert.equal(closed, true);
+  assert.equal(closedError, undefined, "a server stream that ends is a clean close (no error)");
+  assert.equal(events.length, 2);
+  assert.equal(events[0].kind, "subscribed");
+  assert.equal(events[1].kind, "notification");
+  assert.equal(events[1].notification.sequence, 0);
+});
+
+test("openSubscription surfaces a 401 refusal as an honest onClose error, before any event", async () => {
+  const fetchImpl = async () =>
+    new Response(JSON.stringify({ error: "authentication required" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  const events = [];
+  let closedError;
+  await new Promise((resolve) => {
+    openSubscription(
+      { url: "http://127.0.0.1:3030/sparql" },
+      "SELECT ?s WHERE { ?s ?p ?o }",
+      {
+        onOpen: () => events.push("open"),
+        onEvent: (e) => events.push(e),
+        onClose: (err) => {
+          closedError = err;
+          resolve();
+        },
+      },
+      { fetchImpl },
+    );
+  });
+
+  assert.equal(events.length, 0, "no onOpen / onEvent on a refusal");
+  assert.match(closedError, /Authentication required/);
+});
+
+test("openSubscription turns a transport failure into a CORS/reachability hint", async () => {
+  const fetchImpl = async () => {
+    throw new TypeError("Failed to fetch");
+  };
+  let closedError;
+  await new Promise((resolve) => {
+    openSubscription(
+      { url: "http://data.example.org/sparql" },
+      "SELECT ?s WHERE { ?s ?p ?o }",
+      {
+        onEvent: () => {},
+        onClose: (err) => {
+          closedError = err;
+          resolve();
+        },
+      },
+      { fetchImpl },
+    );
+  });
+  assert.match(closedError, /CORS|reachable|subscription stream/);
+});
+
+test("openSubscription fails closed on an invalid endpoint URL", async () => {
+  let closedError;
+  await new Promise((resolve) => {
+    const handle = openSubscription(
+      { url: "nope" },
+      "SELECT ?s WHERE { ?s ?p ?o }",
+      {
+        onEvent: () => {},
+        onClose: (err) => {
+          closedError = err;
+          resolve();
+        },
+      },
+      { fetchImpl: async () => sseResponse("") },
+    );
+    // close() is a no-op on the dead handle — must not throw.
+    handle.close();
+  });
+  assert.match(closedError, /valid absolute endpoint URL/);
+});


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-9ij6** — GUI Phase 2 item 7: the **live subscriptions view**. In endpoint mode, subscribe a SELECT to the connected `sparq-server`'s `/subscriptions/sse` Server-Sent-Events stream and render the streamed result **deltas** live as the dataset mutates — the standout demo a static Pages site fundamentally cannot do on its own (it needs a real, mutating server to push to it). Builds directly on the just-merged endpoint mode (#795, sq-2mke).

## What changed

**Client — `packages/sparq-client/src/subscriptions.ts`** (framework-agnostic, pure + testable):
- `openSubscription(config, query, handlers)` opens the SSE stream over `fetch` + a streaming `ReadableStream` reader (deliberately **not** native `EventSource` — it cannot set an `Authorization` header, so it could never reach an authenticated server; `fetch` sends the **same** bearer header a query uses). Honest `onOpen` / `onEvent` / `onClose(error?)` lifecycle, with classified messages mirroring the server's SSE refusal contract (401 auth / 400 non-SELECT / 413 row-cap / 503 capacity-or-timeout / transport→CORS hint).
- `buildSubscriptionUrl` derives the `/subscriptions/sse?query=…[&alias=…]` URL from the **same** `EndpointConfig`; `parseSubscriptionData` parses the SEPA envelopes (`subscribed` / `notification` / `error`); `applyNotification` reduces the streamed added/removed diffs onto a `LiveResultSet` keyed by the server's canonical row key (`rowKey`); `liveResults` shapes it back into a `SparqlResults` document so the **same** `extractTable` renders a live row exactly like a queried one. `splitSseFrames` / `frameData` handle the SSE wire framing (incl. keep-alive ping frames).

**Site — `site/src/components/subscriptions-view.tsx`** (wired into `repl.tsx`):
- A live SELECT editor + Subscribe/Stop control, the live accumulated result table, and a per-delta diff log (sequence-0 snapshot then each net add/remove). Renders an honest "switch on endpoint mode" hint when not connected.
- The stream is held in a ref and aborted on unmount / when endpoint mode is switched off, which drops the server-side subscription (its slot is released on disconnect — no leak).

## How it reuses the sq-2mke connection / bearer posture
- **Same `EndpointConfig`** (URL + optional bearer token), owned by the Connect panel and shared into the view.
- **Same honest `connectionSafetyWarnings` classifier**, surfaced in the view too — a live stream over plaintext to a non-loopback host, or a token in the clear, is flagged exactly as for a query, and a hard block (invalid URL / mixed content) disables Subscribe.
- The bearer token is sent **only** in the `Authorization: Bearer` header — the channel the server's SSE read gate (`--auth-token-read`) validates (`crates/sparq-server/src/main.rs`: *"The SSE GET takes the `Authorization: Bearer` header like any GET"*). The `bearer.<token>` WS subprotocol path (`wsSubprotocols`) is for the WS upgrade browsers cannot header; the SSE GET has no such limitation. **No server gate is bypassed; no security the server does not provide is claimed.** The safety classifier from sq-2mke applies to this stream too.

## Scope
`site/` + `packages/sparq-client` only. The server `/subscriptions` SSE + WS API already exists (`crates/sparq-server/src/subscriptions.rs`) — this consumes it, **no `crates/` change**.

## Gates
- `cd site && npm run build` (static export) — **green end-to-end**; all routes emitted (`/`, `/try`, `/benchmarks/*`, `/papers`, `/surface/*`, `/showcase/*` intact).
- `npm run lint` — clean. `tsc --noEmit` (site **and** `@sparq/client`, incl. the `sq-06gq` conformance project) — clean.
- Tests: **18 new** `@sparq/client` unit tests (URL derivation, SEPA parser, SSE framing, the row-keyed live diff, the stream lifecycle over an injected `fetch`); full site unit suite **177/177**.
- WASM prereq built (`wasm-pack … --features shacl,jsonld`, the lean bundle) — build artifact only, no `crates/` change.

## Covered vs deferred
- Covered: the SSE transport (one subscription per stream), the live diff + table + delta log, the full connect/stream/error/disconnect lifecycle, the reused bearer + safety posture.
- Deferred → **sq-140b**: the multiplexed `/subscriptions` **WebSocket** transport (many subscriptions per socket, using the `bearer.<token>` subprotocol directly).