### PR TITLE
ci(release): add UNSIGNED Tauri desktop bundles (.dmg/.msi/.exe/.deb/.AppImage) to release + SLSA subject-path (sq-8n1c)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,187 @@ jobs:
           path: sbom/*.json
           if-no-files-found: error
 
+  # ---- 1c. Tauri desktop GUI bundles (UNSIGNED) ----
+  # [OPUS-4.8] sq-8n1c: build the cross-platform Tauri 2 desktop INSTALLERS — .dmg (+ .app)
+  # on macOS, .msi + NSIS .exe on Windows, .deb + .AppImage on Linux — as ADDITIONAL release
+  # artifacts on the same desktop platforms the `package` matrix already covers, per the GUI
+  # design record (research/gui-design.md §3 "Releases"). They are SLSA build-provenance
+  # attested here (subject-path below), uploaded as `pkg-gui-<label>`, and the `release` job's
+  # `pattern: pkg-*` download then folds them into SHA256SUMS + the GitHub Release for free —
+  # so the existing SBOM/VEX/provenance/checksum estate covers them with no bespoke wiring.
+  #
+  # UNSIGNED — and that is a deliberate, honest limitation, NOT an oversight:
+  #   * macOS bundles are NOT codesigned/notarized (Apple Developer ID cert + notarytool key
+  #     are maintainer-held) -> Gatekeeper will quarantine them on download.
+  #   * Windows .msi/.exe are NOT Authenticode-signed (EV/OV cert is maintainer-held)
+  #     -> SmartScreen will warn on download.
+  # Real OS-level signing is the SEPARATE needs:user bead sq-v286.8 (Apple Developer ID +
+  # Windows Authenticode); this job MUST NOT fabricate signing. The SLSA attestation below
+  # proves WHO BUILT the bundle (build provenance), which is orthogonal to and NOT a substitute
+  # for OS code-signing. Until sq-v286.8 lands, these are test-/developer-install bundles.
+  #
+  # SCOPE — desktop installers only. The matrix covers exactly the desktop (platform, arch)
+  # pairs that produce a native installer, one row per pair (NOT per microarch tier — a .deb is
+  # arch-keyed, not -Ctarget-cpu-keyed, so the x64-linux baseline/v2/v3/v4 split the `package`
+  # matrix carries collapses to ONE Linux-x64 bundle row here). Runner labels are the EXACT set
+  # proven in build-matrix.yml + gui.yml so the GUI and CLI/server matrices cannot drift.
+  #
+  # win-arm64 is DELIBERATELY ABSENT: build-matrix.yml produces the aarch64-pc-windows-msvc
+  # CLI/server binaries by CROSS-LINKING from the x64 Windows runner, but the Tauri bundler runs
+  # the host-arch installer toolchain (NSIS/WiX) and cannot reliably cross-bundle an arm64
+  # Windows installer from an x64 host — so there is no win-arm64 GUI installer this pass (an
+  # honest gap, not a silent drop). Mobile (Android .aab / iOS .ipa) is the separate net-new
+  # bead sq-v286.9 — no rows here.
+  gui-bundle:
+    name: "GUI desktop bundle ${{ matrix.label }} (unsigned)"
+    runs-on: ${{ matrix.os }}
+    # SLSA build-provenance attestation over the produced bundles needs the OIDC token +
+    # attestation write; read-only on the repo otherwise (uploads a workflow artifact, the
+    # `release` job creates the Release).
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    timeout-minutes: 60
+    strategy:
+      # One platform's bundler failure must not cancel the others — each desktop installer is
+      # independent. (A failed row WILL fail the `release` job via `needs`, which is correct:
+      # a release should not silently ship missing a platform's installer.)
+      fail-fast: false
+      matrix:
+        include:
+          - { os: macos-14, label: arm64-darwin }
+          - { os: macos-15-intel, label: x64-darwin }
+          - { os: ubuntu-latest, label: x64-linux }
+          - { os: ubuntu-24.04-arm, label: arm64-linux }
+          - { os: windows-latest, label: win-x64 }
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # The Tauri webview + bundler system libraries are LINUX-ONLY (macOS ships WKWebView,
+      # Windows ships WebView2). This is the SAME apt set gui.yml installs to build the GUI
+      # crate; the bundler additionally needs the deb/appimage tooling, which these packages
+      # (+ patchelf, used by the AppImage bundler) provide.
+      - name: Install Tauri system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      # The Tauri `beforeBuildCommand` (tauri.conf.json) builds the site static export, whose
+      # `prebuild` hook (site/scripts/sync-wasm.mjs) needs the wasm bundle present in js/wasm/.
+      # Mirror gui.yml's site-build job: build the lean shacl,jsonld wasm bundle FIRST, then
+      # `cargo tauri build` drives the site export + the native bundle.
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+
+      - name: Build wasm bundle (shacl,jsonld)
+        working-directory: js
+        run: npm run build:wasm
+
+      - name: Install @sparq/client + site dependencies
+        shell: bash
+        run: |
+          (cd packages/sparq-client && npm install)
+          (cd site && npm install)
+
+      # tauri-cli (the `cargo tauri build` driver). Installed via `cargo install … --locked`,
+      # the SAME pattern gui.yml uses for wasm-pack / tauri-driver (a cargo install is not a
+      # pinned GitHub Action, so no SHA pin applies); `^2` tracks the Tauri 2 line the crate
+      # depends on (gui/src-tauri/Cargo.toml `tauri = { version = "2" }`).
+      - name: Install tauri-cli (v2)
+        run: cargo install tauri-cli --version "^2.0.0" --locked
+
+      # Build the UNSIGNED desktop bundle. `cargo tauri build` runs from gui/src-tauri, drives
+      # the `beforeBuildCommand` (the root-relative site export, NEXT_PUBLIC_BASE_PATH=''),
+      # compiles the native Rust shell, and bundles installers for the host platform into
+      # gui/src-tauri/target/release/bundle/<format>/. `--ci` disables interactive prompts;
+      # no signing env vars are set, so the bundles are produced UNSIGNED (see the job header
+      # — signing is needs:user sq-v286.8). `--verbose` aids first-CI-run diagnosis.
+      #
+      # PROVEN vs DOCUMENTED-UNTESTED (honest status — this workflow is tag-triggered, so it
+      # does NOT run on this PR; validate on the first real `v*` tag):
+      #   * Linux rows (ubuntu-latest, ubuntu-24.04-arm): the GUI crate build + webkit deps are
+      #     already proven green in gui.yml; the .deb/.AppImage bundle step is the new surface.
+      #   * macOS rows: WKWebView ships with the OS; the .dmg/.app bundle is documented-untested.
+      #   * Windows row: WebView2 ships with the OS, BUT tauri.conf.json's beforeBuildCommand
+      #     (`cd ../../site && NEXT_PUBLIC_BASE_PATH='' npm run build`) uses a Unix inline
+      #     env-var prefix that the default Windows shell (cmd) does NOT support. Making that
+      #     command Windows-portable is a gui/ (tauri.conf.json) change OUT OF SCOPE for this
+      #     release-workflow bead and is captured as a follow-up; the Windows row is therefore
+      #     documented-untested and may need that conf fix before its .msi/.exe row goes green.
+      - name: Build Tauri desktop bundle (unsigned)
+        working-directory: gui/src-tauri
+        run: cargo tauri build --ci --verbose
+
+      # Collect every produced installer into a flat staging dir under a stable, tier-keyed
+      # name so the release SHA256SUMS / Release assets are predictable. Tauri names bundles
+      # `<productName>_<version>_<arch>.<ext>` (e.g. `sparq_0.1.0_amd64.deb`), so we glob the
+      # bundle tree (resilient to the exact arch token) and prefix each with the matrix label.
+      # `if-no-files-found: error` on the upload + this `set -e` glob guard mean a bundler that
+      # silently produced nothing FAILS the job rather than shipping an empty release row.
+      - name: Stage GUI bundles
+        shell: bash
+        run: |
+          set -euo pipefail
+          BUNDLE_DIR="gui/src-tauri/target/release/bundle"
+          OUT="gui-bundles"
+          mkdir -p "$OUT"
+          shopt -s nullglob globstar
+          found=0
+          # .dmg/.app (macOS), .deb/.AppImage/.rpm (Linux), .msi/.exe (Windows NSIS+WiX).
+          for f in "$BUNDLE_DIR"/dmg/*.dmg \
+                   "$BUNDLE_DIR"/deb/*.deb \
+                   "$BUNDLE_DIR"/appimage/*.AppImage \
+                   "$BUNDLE_DIR"/rpm/*.rpm \
+                   "$BUNDLE_DIR"/msi/*.msi \
+                   "$BUNDLE_DIR"/nsis/*.exe; do
+            base="$(basename "$f")"
+            cp "$f" "$OUT/sparq-gui-${GITHUB_REF_NAME}-${{ matrix.label }}-${base}"
+            found=$((found + 1))
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "ERROR: tauri build produced no installer bundles under $BUNDLE_DIR" >&2
+            find "$BUNDLE_DIR" -maxdepth 2 -type f 2>/dev/null || true
+            exit 1
+          fi
+          echo "staged $found GUI bundle(s) for ${{ matrix.label }}:"
+          ls -1 "$OUT"
+
+      # SLSA build-provenance over EVERY produced bundle (the subject-path) — this is the
+      # "rides for free" claim made literal: the bundle digests are bound to this workflow run
+      # and verifiable with `gh attestation verify <bundle> --repo <repo>`. (Provenance != OS
+      # code-signing; see the job header.)
+      - name: Attest build provenance (GUI bundles)
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: gui-bundles/*
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pkg-gui-${{ matrix.label }}
+          path: gui-bundles/*
+          if-no-files-found: error
+
   # ---- 2. checksums + GitHub Release ----
   release:
     name: create GitHub Release
-    needs: [package, sbom]
+    needs: [package, sbom, gui-bundle]
     runs-on: ubuntu-latest
     permissions:
       contents: write # create the release + upload assets — the only write this pipeline needs
@@ -118,7 +295,9 @@ jobs:
 
             `SHA256SUMS` covers every attached archive plus the CycloneDX SBOM + VEX: `shasum -a 256 -c SHA256SUMS`.
 
-            **Supply chain:** each release carries a CycloneDX SBOM per binary (`*-${{ github.ref_name }}.sbom.cdx.json`), a CycloneDX SBOM for the published npm/WASM client (`sparq-js-${{ github.ref_name }}.sbom.cdx.json` runtime tree + `sparq-js-dev-${{ github.ref_name }}.sbom.cdx.json` full build tree), and a VEX (`sparq-${{ github.ref_name }}.vex.cdx.json`) stating the exploitability of every advisory the dependency policy ignores. All artifacts (archives, SBOMs, VEX) are SLSA build-provenance attested — verify with `gh attestation verify <file> --repo ${{ github.repository }}`.
+            **Desktop GUI bundles (UNSIGNED).** This release also includes cross-platform [sparq GUI](https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}/gui) desktop installers (`sparq-gui-${{ github.ref_name }}-*`): macOS `.dmg`, Windows `.msi` + NSIS `.exe`, and Linux `.deb` + `.AppImage`. **These bundles are NOT code-signed or notarized.** On macOS, Gatekeeper will quarantine them; on Windows, SmartScreen will warn. OS-level code-signing (Apple Developer ID notarization + Windows Authenticode) requires maintainer-held credentials and is tracked separately — until then, treat the GUI bundles as developer/test installs. The SLSA attestation below proves *who built* each bundle (build provenance); it is not a substitute for OS code-signing. (No `win-arm64` GUI installer yet — the Tauri bundler cannot cross-bundle it from the x64 Windows runner; no mobile app bundles yet.)
+
+            **Supply chain:** each release carries a CycloneDX SBOM per binary (`*-${{ github.ref_name }}.sbom.cdx.json`, including the GUI shell `sparq-gui-${{ github.ref_name }}.sbom.cdx.json`), a CycloneDX SBOM for the published npm/WASM client (`sparq-js-${{ github.ref_name }}.sbom.cdx.json` runtime tree + `sparq-js-dev-${{ github.ref_name }}.sbom.cdx.json` full build tree), and a VEX (`sparq-${{ github.ref_name }}.vex.cdx.json`) stating the exploitability of every advisory the dependency policy ignores. All artifacts (archives, GUI bundles, SBOMs, VEX) are SLSA build-provenance attested — verify with `gh attestation verify <file> --repo ${{ github.repository }}`.
           fail_on_unmatched_files: true
 
   # ---- 3. server container -> ghcr.io ----

--- a/scripts/gen-sbom-vex.sh
+++ b/scripts/gen-sbom-vex.sh
@@ -4,6 +4,8 @@
 # Produces, into $OUT_DIR (default: ./sbom):
 #   - sparq-cli-<version>.sbom.cdx.json     CycloneDX SBOM for the released sparq-cli binary
 #   - sparq-server-<version>.sbom.cdx.json  CycloneDX SBOM for the released sparq-server binary
+#   - sparq-gui-<version>.sbom.cdx.json     CycloneDX SBOM for the Tauri desktop GUI shell
+#                                           (gui/src-tauri; sq-8n1c — the released desktop bundles)
 #   - sparq-<version>.vex.cdx.json          the checked-in VEX (supply-chain/vex.cdx.json) with
 #                                           the released version + a generated timestamp stamped in
 #
@@ -63,6 +65,30 @@ done
 
 # Discard the per-member SBOMs we don't ship (keeps the worktree clean for `git status`).
 find crates -name '*.cdx.json' -delete
+
+# [OPUS-4.8] sq-8n1c: per-release CycloneDX SBOM for the Tauri desktop GUI shell. The release
+# ships UNSIGNED desktop bundles (.dmg/.msi/.exe/.deb/.AppImage) built from gui/src-tauri, so
+# its dependency tree (Tauri + the webview bindings) must be enumerated for "SBOM rides for
+# free" to be literally true. The GUI crate is a STANDALONE crate root (its own empty
+# `[workspace]`, excluded from the main workspace), so the `cargo cyclonedx --all` above does
+# NOT reach it — generate it separately from inside gui/src-tauri. cargo-cyclonedx resolves the
+# dependency graph from Cargo.lock WITHOUT compiling (no webkit/system libs needed), so this
+# runs on the same plain ubuntu runner as the rest of this script. Default feature set, to
+# match the shipped bundle. Then normalize (abs-path scrub) + leak-check identically to the
+# CLI/server SBOMs above.
+if [ -f gui/src-tauri/Cargo.toml ]; then
+  echo "==> generating CycloneDX SBOM (GUI shell, sparq ${VERSION})"
+  ( cd gui/src-tauri && cargo cyclonedx --format json --spec-version 1.5 )
+  gui_src="gui/src-tauri/sparq-gui.cdx.json"
+  gui_dst="$OUT_DIR/sparq-gui-${VERSION}.sbom.cdx.json"
+  jq -f "$NORMALIZE_JQ" "$gui_src" > "$gui_dst"
+  find gui/src-tauri -name '*.cdx.json' -delete
+  if grep -qE 'path\+file://|download_url=file://|/home/' "$gui_dst"; then
+    echo "ERROR: host path leaked into $gui_dst after normalization" >&2
+    exit 1
+  fi
+  echo "    -> $gui_dst (abs-path-normalized)"
+fi
 
 echo "==> stamping VEX (sparq ${VERSION})"
 VEX_OUT="$OUT_DIR/sparq-${VERSION}.vex.cdx.json"


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-8n1c** — add the Tauri 2 desktop installers to the release matrix + the SLSA attestation `subject-path`, so the existing SBOM/VEX/provenance/checksum estate covers them. Scope is `release.yml` + `scripts/gen-sbom-vex.sh` only (no `gui.yml` / `build-matrix.yml` / `crates/` changes).

## What this wires

**`release.yml` — new `gui-bundle` job** (per-platform matrix, exact runner labels from `build-matrix.yml` / `gui.yml`):

| Tier | runner | bundles produced |
|---|---|---|
| arm64-darwin | `macos-14` | `.dmg` (+ `.app`) |
| x64-darwin | `macos-15-intel` | `.dmg` (+ `.app`) |
| x64-linux | `ubuntu-latest` | `.deb` + `.AppImage` |
| arm64-linux | `ubuntu-24.04-arm` | `.deb` + `.AppImage` |
| win-x64 | `windows-latest` | `.msi` + NSIS `.exe` |

One row per **(platform, arch)** — not per microarch tier (a `.deb` is arch-keyed, not `-Ctarget-cpu`-keyed, so the `package` matrix's x64-linux baseline/v2/v3/v4 split collapses to one Linux-x64 GUI row). Each row builds via `cargo tauri build --ci`, stages bundles under a stable `sparq-gui-<tag>-<label>-…` name, SLSA-attests them (`subject-path: gui-bundles/*`), and uploads as `pkg-gui-<label>`.

**How they ride the estate for free:** the existing `release` job already downloads `pattern: pkg-*`, so the GUI bundles fold into `SHA256SUMS` + the GitHub Release with **no change to that job** beyond adding `gui-bundle` to its `needs`. The `gen-sbom-vex.sh` change adds a per-release CycloneDX SBOM for the standalone GUI crate (it's excluded from the main-workspace `--all`), so the SBOM literally covers the bundle's dep tree too.

## UNSIGNED — and honest about it

The bundles are **UNSIGNED**. No signing is fabricated. OS-level code-signing (Apple Developer ID notarization + Windows Authenticode) is the **separate `needs:user` bead sq-v286.8** and needs maintainer-held credentials. The SLSA attestation proves *who built* each bundle (provenance) — orthogonal to, and **not** a substitute for, OS code-signing. The release-notes body documents this (Gatekeeper / SmartScreen warnings). `win-arm64` has **no installer** (Tauri can't cross-bundle arm64 Windows from the x64 runner — flagged honestly); mobile `.aab`/`.ipa` is the separate net-new sq-v286.9.

## Gate / validity

- `release.yml` is **tag-triggered only** (`push: tags: [v*]`), so this job never registers on the PR ref and is correctly **outside** the `ci-summary / gate` aggregator — it does not gate this PR.
- YAML valid (`yaml.safe_load`); `gen-sbom-vex.sh` clean under `bash -n` + `shellcheck`; every external action SHA-pinned to the exact SHAs already used in the file.
- **Locally reproduced:** the new GUI-SBOM block (`cargo cyclonedx` + normalize + leak-check) end-to-end — 325-component CycloneDX 1.5 SBOM, no host-path leak, stray file cleaned. The `cargo tauri build` lane is **documented-untested** (release workflow doesn't run on a PR; needs webview system libs): Linux rows are proven green in `gui.yml`; macOS/Windows bundle rows validate on the first `v*` tag. The Windows `beforeBuildCommand` cmd-shell hazard is flagged inline as a `gui/` follow-up.

Closes the GUI-release artifact gap (`research/gui-design.md` §3); compliance: **SLSA build-provenance (L2 as configured) + CycloneDX SBOM** now cover the desktop bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)