### PR TITLE
docs(zk): refresh verify+cost report to 28 circuit members (sq-ritq) [OPUS-4.8]

### DIFF
--- a/research/zk-verification-and-costs.md
+++ b/research/zk-verification-and-costs.md
@@ -33,16 +33,24 @@ six-member car-hire flagship has **never been assembled and verified as one unit
 
 | Member (family) | Primitive | Public inputs | Hidden (private) | Status |
 | --- | --- | --- | --- | --- |
-| `filter_int` (`d1..d4`) | range / comparison over a hidden integer | `challenge, operand_enc, op, bound, expected` | the value's decimal digits | **LIVE** (`d2`); `d1/d3/d4` wired (compiled, real prove/verify tests) |
+| `filter_int` (`d1..d4`) | range / comparison over a hidden non-negative integer | `challenge, operand_enc, op, bound, expected` | the value's decimal digits | **LIVE** (`d2`); `d1/d3/d4` wired (compiled, real prove/verify tests) |
+| `filter_signed_int` (`d2`, `d4`) | sign-aware range / comparison over a hidden **signed** `xsd:integer` | `challenge, operand_enc, op, bound_neg, bound, expected` | the value's sign flag + magnitude digits | WIRED (compiled, manifest-composable; extends `filter_int` to negatives) |
+| `filter_decimal` (`i3_f2`) | fixed-point comparison over a hidden `xsd:decimal` (3 int + 2 frac digits) | `challenge, operand_enc, op, bound_neg, bound_scaled, expected` | sign flag + integer-part + fraction digits | WIRED (compiled, manifest-composable; host pre-scales the bound to `FD=2`) |
 | `filter_f64` (raw + `d1..d4`) | comparison over IEEE-754 doubles | `challenge, operand_enc, op, b_bits, expected` | the value's decimal digits | WIRED (composable `d1..d4`); raw `filter_f64` is a non-composable building block |
 | `scan` (`k{1,2}_n{16,64}_r{4,8}`, 8 members) | set-membership **+ completeness** (BGP scan over K committed graphs) | `challenge, commitments[K], pattern, disclosed rows[R], row_count, attribution[K]` | per-graph counts + term encodings | WIRED (all 8 compiled, prove/verify/tamper tests) |
 | `join_eq` (`na{16,64}_nb{16,64}`, 4 members) | equality-join (hidden cross-credential JOIN, single-prover) | `challenge, commit_a, commit_b, join_commitment, slot_a, slot_b` | both graphs' enc/counts, the two joined rows, the join value, a blinder | WIRED (4 compiled; the joined entity never appears in a public input) |
 | `hidden_issuer` (`d4`) | signature-verification + set-membership | `challenge, m, key_set_root` | issuer `pk`, signature `(R,s)`, reduced challenge, membership index+path | WIRED/DESIGNED (gadget + binding complete; inherits the open soundness audit; **additive only**) |
 | `holder_pok` | proof-of-possession / proof-of-knowledge | `challenge, holder_pk_digest` | `hsk`, `hpk_x`, `hpk_y` | WIRED/DESIGNED (compiled; in-circuit hidden-key tier B2 deferred — landed binding is the clear-key B1 tier) |
+| `holder_set` (`d4`) | hidden-holder set-membership PoK (B2 tier) | `challenge, holder_set_root` | `hsk`, `hpk_x`, `hpk_y`, `index`, `siblings` | WIRED/DESIGNED (compiled; the holder-key digest is **not** public here — hides *which* holder; verifier binds only the set root) |
 | `revoke_unset` (`d10`) | non-membership / hidden-index status | `challenge, root, index_commitment` | `index`, `bit(=0)`, blinding, Merkle siblings | WIRED/DESIGNED (compiled; clear-index path still leaks the index unless the committed-index path is used) |
 
-All 24 members compile and have gate-count baselines; the family-completeness gate
-(`every_derivable_id_has_a_compiled_member`) enforces no silent unprovability.
+All 28 members compile and have gate-count baselines; the family-completeness gate
+(`every_derivable_id_has_a_compiled_member`) enforces no silent unprovability, and
+`snapshot_covers_every_member` (tests/gate_count.rs) enforces a baseline for every
+compiled `zk/compose/` member, so a new member cannot ship without a gate-count
+row. (The four members added since the prior revision of this report —
+`filter_signed_int_d2/d4`, `filter_decimal_i3_f2` from `sq-7lrq`/`sq-1q9h`, and
+`holder_set_d4` from `sq-3c00` — are all manifest-composable and covered below.)
 
 ### What the live demo proves today (exactly one statement)
 
@@ -78,9 +86,14 @@ wiring them into the browser as a follow-up.
 Gate counts below are the **deterministic** committed snapshot
 (`bb gates -s ultra_honk` `circuit_size`; bb `5.0.0-nightly.20260324`; nargo
 `1.0.0-beta.21`; 3% regression tolerance absorbs ~0.5–0.75% cross-platform variance).
-Four members were independently re-run on this box and matched the snapshot to the
-gate: `filter_int_d2 = 17416`, `revoke_unset_d10 = 899`, `scan_k1_n16_r4 = 5991`,
-`hidden_issuer_d4 = 16932`.
+Members independently re-run on this box matched the snapshot to the gate:
+`filter_int_d2 = 17416`, `revoke_unset_d10 = 899`, `scan_k1_n16_r4 = 5991`,
+`hidden_issuer_d4 = 16932`, and — for this revision — the four newly-added members
+`filter_signed_int_d2 = 17416`, `filter_signed_int_d4 = 17416`,
+`filter_decimal_i3_f2 = 17416`, and `holder_set_d4 = 10650`. The bench mirror
+`bench/zk-compose/gate_counts_latest.json` is regenerated from the same snapshot
+member list and a CI test (tests/gate_count.rs) fails if the two ever disagree, so
+the catalog and the regression gate cannot drift.
 
 > **All timings below are INDICATIVE / NON-CANONICAL** (native `bb prove` or Node
 > `generateProof` on a shared EC2 work box), not a benchmark of record. Per project
@@ -97,10 +110,13 @@ gate: `filter_int_d2 = 17416`, `revoke_unset_d10 = 899`, `scan_k1_n16_r4 = 5991`
 | `join_eq_na64_nb64` | 18681 | Largest hidden cross-credential join (64×64) |
 | `filter_int_d1..d4` | 17416 | Flat in D — blake3 over the canonical token fits one 64-byte block |
 | `filter_f64_d1..d4` | 17416 | Same token-binding cost as `filter_int` (tie) |
+| `filter_signed_int_d2` / `_d4` | 17416 | Signed `xsd:integer`; same canonical-token blake3 binding — tie, flat in magnitude-digit count |
+| `filter_decimal_i3_f2` | 17416 | `xsd:decimal` (3 int + 2 frac digits); same token binding — tie |
 | `hidden_issuer_d4` | 16932 | In-circuit signature verification — heaviest non-scan / non-filter operator |
 | `scan_k1_n64_r4` | 14923 | |
 | `join_eq_na16_nb64` / `na64_nb16` | 12885 | Equal by bucket-size symmetry |
 | `scan_k2_n16_r8` | 11261 | |
+| `holder_set_d4` | 10650 | Hidden-holder set-membership: `holder_pok`'s scalar-mul + a depth-4 Merkle fold |
 | `holder_pok` | 10334 | One ~251-bit scalar-mul |
 | `scan_k2_n16_r4` | 9254 | |
 | `scan_k1_n16_r8` | 7038 | |
@@ -110,9 +126,15 @@ gate: `filter_int_d2 = 17416`, `revoke_unset_d10 = 899`, `scan_k1_n16_r4 = 5991`
 | `revoke_unset_d10` | 899 | **Cheapest.** Depth-10 Merkle bit-unset |
 
 Scaling: scan members scale ~linearly in `k*n`, with `r` adding a row-soundness pass.
-Filter is **flat in `D`** (the digit count only changes what leaks, not the gate
-count). The signature member is dominated by elliptic-curve scalar multiplication,
-not hashing.
+Every token-bound filter member ties at **17416** — `filter_int`, `filter_f64`
+(composable `d1..d4`), the signed-integer `filter_signed_int_d2/d4`, and the decimal
+`filter_decimal_i3_f2` — because the cost driver is the single-block blake3 over the
+canonical N-Triples token, which is identical regardless of the operand's sign,
+fractional part, or digit count. Filter is therefore **flat in `D`** (the digit
+count only changes what leaks, not the gate count) and flat across the integer →
+signed → decimal extension. The signature member is dominated by elliptic-curve
+scalar multiplication, not hashing; `holder_set_d4` (10650) is `holder_pok`'s
+scalar-mul plus the depth-4 set-membership fold (≈ +316 gates over `holder_pok`).
 
 ### Hotspots
 

--- a/site/src/data/zk-circuit-costs.json
+++ b/site/src/data/zk-circuit-costs.json
@@ -55,6 +55,36 @@
       "source": "snapshot; gate_counts_latest.json=17416; family_cost_curve.json prove ~1.071s (non-canonical). Flat in D."
     },
     {
+      "member": "filter_signed_int_d2",
+      "proves": "The hidden SIGNED xsd:integer behind operand_enc satisfies (value op bound) == expected under signed order, value bound to the committed '[-]?<digits>' token, without disclosing it (2 magnitude digits). Extends filter_int to negatives.",
+      "primitive": "sign-aware range/comparison over a hidden signed xsd:integer (in-circuit blake3 operand-to-commitment binding; sign flag + magnitude digits)",
+      "exercised_live": false,
+      "gate_count": 17416,
+      "prove_ms_t1": null,
+      "prove_ms_tN": null,
+      "source": "snapshot (sq-7lrq/sq-1q9h); RE-RAN bb gates this box = 17416 (match); gate_counts_latest.json=17416. Same single-block blake3 canonical-token binding as filter_int -> same 17416 gates. Flat in magnitude-digit count."
+    },
+    {
+      "member": "filter_signed_int_d4",
+      "proves": "Same as filter_signed_int_d2 for a 4-magnitude-digit hidden signed xsd:integer (choosing this member leaks ceil(log10(|value|)), the documented envelope leak).",
+      "primitive": "sign-aware range/comparison over a hidden signed xsd:integer (in-circuit blake3 operand-to-commitment binding)",
+      "exercised_live": false,
+      "gate_count": 17416,
+      "prove_ms_t1": null,
+      "prove_ms_tN": null,
+      "source": "snapshot (sq-7lrq/sq-1q9h); RE-RAN bb gates this box = 17416 (match); gate_counts_latest.json=17416. Flat in magnitude-digit count."
+    },
+    {
+      "member": "filter_decimal_i3_f2",
+      "proves": "The hidden xsd:decimal behind operand_enc satisfies (value op bound) == expected at FD=2 fixed-point places, value bound to the committed '[-]?<int>.<frac>' token, without disclosing it (3 integer + 2 fraction digits). The host pre-scales the FILTER constant to bound_scaled = round(|bound| * 100).",
+      "primitive": "fixed-point comparison over a hidden xsd:decimal (in-circuit blake3 operand-to-commitment binding; sign flag + integer-part + fraction digits)",
+      "exercised_live": false,
+      "gate_count": 17416,
+      "prove_ms_t1": null,
+      "prove_ms_tN": null,
+      "source": "snapshot (sq-7lrq/sq-1q9h); RE-RAN bb gates this box = 17416 (match); gate_counts_latest.json=17416. Same single-block blake3 canonical-token binding as filter_int -> same 17416 gates."
+    },
+    {
       "member": "filter_f64",
       "proves": "Raw IEEE-754 double comparison building block (free a_bits, NON-composable; no committed-token binding).",
       "primitive": "range/comparison over IEEE-754 doubles (raw bits, building block only)",
@@ -242,7 +272,17 @@
       "gate_count": 10334,
       "prove_ms_t1": null,
       "prove_ms_tN": null,
-      "source": "snapshot (sq-xqfg). One ~251-bit scalar-mul. The in-circuit hidden-key tier (B2) is DEFERRED at the manifest seam; the LANDED holder binding is the clear-key B1 tier that discloses hpk."
+      "source": "snapshot (sq-xqfg). One ~251-bit scalar-mul. holder_pok publishes the issuer-attested holder_pk_digest (clear-digest tier); the hidden-holder tier (does not disclose the digest) is the separate holder_set_d4 circuit below. The manifest verify seam for the hidden-key tier is DEFERRED; the LANDED holder binding wired into verify_manifest is the clear-key B1 tier that discloses hpk."
+    },
+    {
+      "member": "holder_set_d4",
+      "proves": "I am SOME holder in the committed holder set (public holder_set_root): I know a holder secret hsk with hpk = hsk*G on Baby-JubJub (on-curve, non-identity, hsk < L) whose holder-key digest is a member of the set, at a HIDDEN index along a HIDDEN authentication path — disclosing NEITHER the holder key NOR WHICH holder it is. Depth-4 = up to 16 holders. holder_pk_digest is NOT public here (the hidden-holder upgrade over holder_pok).",
+      "primitive": "hidden-holder set-membership proof-of-knowledge (Baby-JubJub key-pair PoK + hidden-key Poseidon2 Merkle membership, hidden-holder tier B2)",
+      "exercised_live": false,
+      "gate_count": 10650,
+      "prove_ms_t1": null,
+      "prove_ms_tN": null,
+      "source": "snapshot (sq-3c00); RE-RAN bb gates this box = 10650 (match); gate_counts_latest.json=10650. holder_pok's scalar-mul/on-curve/<L checks (steps 1-4) plus a depth-4 set-membership Merkle fold replacing the clear-digest binding -> ~+316 gates over holder_pok. ADDITIVE only; the verifier binds only holder_set_root."
     },
     {
       "member": "revoke_unset_d10",


### PR DESCRIPTION
> 🤖 SPARQ agent

Re-run of the ZK verify+cost report workflow (`sq-ritq`). Refreshes the two
maintainer-facing artefacts so they cover the current circuit family:

- `research/zk-verification-and-costs.md` — verify-semantics + per-member gate table
- `site/src/data/zk-circuit-costs.json` — machine-readable per-member cost+semantics the site consumes

## What changed (the drift this corrects)

The regression-gated snapshot (`crates/sparq-zk-compose/tests/gate_count_snapshot.json`)
had grown to **28 members**, but the report doc still claimed "24 members" and the site
JSON carried only 24 entries. This adds the four members landed since the prior revision
(all manifest-composable):

| Member | Gates (`circuit_size`) | Source bead |
| --- | ---: | --- |
| `filter_signed_int_d2` | 17416 | sq-7lrq / sq-1q9h |
| `filter_signed_int_d4` | 17416 | sq-7lrq / sq-1q9h |
| `filter_decimal_i3_f2` | 17416 | sq-7lrq / sq-1q9h |
| `holder_set_d4` | 10650 | sq-3c00 (hidden-holder set-membership) |

The site `zk-circuit-costs.json` now covers all 28 members with gate counts matching
the snapshot 1:1 (verified). No site **code** changed — the accessor
(`site/src/data/zk-circuit-costs.ts`) is fully data-driven and classifies the new
members correctly (`filter*` → filter, `holder*` → holder) with no edit.

## Canonical vs non-canonical labelling

- **Gate counts: CANONICAL** — `bb gates -s ultra_honk` `circuit_size`, bb `5.0.0-nightly.20260324`,
  nargo `1.0.0-beta.21`, driven off the regression-gated snapshot. All four new members were
  **independently re-run live on this box and reproduced the snapshot to the gate**
  (`filter_signed_int_d2/d4 = 17416`, `filter_decimal_i3_f2 = 17416`, `holder_set_d4 = 10650`).
- **Timings: NON-CANONICAL** — the four new members have **no** measured timing; their
  `prove_ms_*` fields are `null` (not fabricated). Existing indicative timings stay labelled
  INDICATIVE / NON-CANONICAL (shared EC2 work box). No timing is baked as canonical.

## Honesty posture (load-bearing)

The ZK estate remains **research-grade and NOT externally audited** (`sq-qhy4`); the
composition verifier is **NOT-yet-sound** (`sq-9hrn` / epic `sq-1s2`); MPC is semi-honest.
This report asserts **no soundness/privacy guarantee** — only measured circuit costs +
documented semantics. Standing caveats are unchanged.

## Gates

- `scripts/check-no-perf-numbers.py` — PASS (0 findings; `research/` + the JSON are out of its prose scan)
- `scripts/check-privacy-claims.sh` — PASS (no unqualified ZK/MPC claim)
- markdownlint-cli2 — 0 errors; `typos` — clean
- JSON validity + snapshot↔costs member/gate cross-check — PASS (28/28, no mismatch)

No auto-merge — opened for the review queue.