### PR TITLE
fix(bench/gather): harden same-box Oxigraph gather vs the 73min stall (sq-sxso)

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -293,6 +293,38 @@ Notes on a few that need care:
   documented-untested in the authoring worktree** (no Docker there) — validate on the
   next `GATHER_QLEVER=1` gather. (The separate `bench/qlever-*` suites use the upstream
   `qlever` Python CLI instead; this same-box recipe is the standalone Docker variant.)
+- **Same-box SPARQL gather — diagnose-and-avoid-the-stall hardening of the sparq+Oxigraph
+  half** (sq-sxso). The Oxigraph half of [`scripts/gather-ec2-sparql.sh`](../scripts/gather-ec2-sparql.sh)
+  used to have NO per-step timeout and NO timestamped sentinel, so a hung step (a heavy
+  from-source `cargo build`, or a pathological SP2Bench query in Oxigraph) burned the whole
+  window with no `/root/GATHER_DONE` — the observed **"73 min, no sentinel"** stall, the same
+  class the QLever recipe above already fixed. Three measured-rooted fixes (LOCALLY REPRODUCED:
+  at only 50k triples the prebuilt Oxigraph CLI ran `q07` in ~38 s and `q08` past 60 s — so at
+  the old 250k default those unselective SP2Bench joins are minutes-long in Oxigraph, which is
+  the stall):
+  1. **Per-step timestamped logging** — every phase calls `step "…"`, which UTC-stamps a line
+     into `/var/log/gather.log` AND appends it to `/root/GATHER_STEP`. The orchestrator pulls
+     that file (and surfaces the LAST step LIVE while polling, and on the no-sentinel path), so
+     a stalled run names EXACTLY the hung phase instead of being invisible. The step log is also
+     embedded in the result envelope (`step_log`).
+  2. **Prebuilt, SHA-pinned Oxigraph CLI** (default) — `oxigraph load` into an on-disk store +
+     `oxigraph query` per `.rq` (min-of-N, JSON-results count). This removes the from-source
+     `cargo build -p sparq-bench` Oxigraph compile from the critical path (a likely build-time
+     hang on the small fallback box). Pinned to **v0.5.9** by `sha256` (aarch64 + x86_64; the
+     gather box is arm64). Set `OXI_EMBEDDED=1` for the in-process in-RAM embedded path instead
+     — the envelope records `oxigraph_mode` (`prebuilt-cli` on-disk vs `embedded` in-RAM) so the
+     load regime is never silently conflated.
+  3. **Hard per-step `timeout` + smaller configurable dataset** — each phase is wrapped in a
+     `timeout` (per-phase `STEP_*_TIMEOUT` caps) and the per-query Oxigraph loop is per-query
+     timeout-bounded (`STEP_OXI_QUERY_TIMEOUT`, default 120 s), so a pathological query records
+     `ERROR` (honest-n/a) and the gather moves on instead of hanging. The default corpus is
+     smaller (`SP2B_TRIPLES` default **100000**, was 250000) for a cheap smoke/gather; raise to
+     250000 for the full per-commit scale.
+  **HONESTY:** this is the SCRIPT-side diagnostic + avoidance hardening, authored + locally
+  reproduced on the aarch64 work box (the prebuilt-CLI load/query lane was run end to end). The
+  actual confirmation that a real gather now reaches `GATHER_DONE` without stalling **requires
+  one EC2 gather run** — that green-gather confirmation is a follow-up. Competitor numbers from
+  this gather remain **non-canonical** (ephemeral EC2 / work box), per the QUIET-BOX note above.
 
 ## Replicate everything — quickstart
 

--- a/scripts/gather-ec2-sparql.sh
+++ b/scripts/gather-ec2-sparql.sh
@@ -7,11 +7,16 @@
 # WHAT IT MEASURES (HONEST same-box, single box, ONE generated corpus):
 #   1. sparq    : `sparq-cli bench <corpus> turtle bench/sp2b/queries <iters> count`
 #                 (the EXACT runner CI uses for the SP2Bench featured suite).
-#   2. oxigraph : `sparq-bench bench-corpus <corpus> turtle bench/sp2b/queries <iters>`
-#                 (new same-box Oxigraph path; embedded dev-dep 0.5.x from Cargo.lock).
+#   2. oxigraph : by DEFAULT the PREBUILT, SHA-PINNED Oxigraph CLI (sq-sxso) — `oxigraph
+#                 load` into an on-disk store, then `oxigraph query` per `.rq` (min-of-N,
+#                 JSON-results count) — NO from-source compile. Set OXI_EMBEDDED=1 to use
+#                 the in-process embedded path instead: `sparq-bench bench-corpus <corpus>
+#                 turtle bench/sp2b/queries <iters>` (embedded dev-dep 0.5.x from Cargo.lock).
 #   Both engines load the SAME generated SP2Bench corpus and run the SAME query files, so
 #   the two TSVs (<name>\t<rows>\t<best_us>) are a self-consistent same-box comparison.
 #   Solution counts are cross-checked against bench/sp2b/expected-rows.tsv (correctness).
+#   The envelope records oxigraph_mode = prebuilt-cli (on-disk RocksDB store) | embedded
+#   (in-RAM oxigraph::store::Store) so the load regime is never silently conflated.
 #   3. qlever   : BEST-EFFORT (GATHER_QLEVER=1). Delegates to scripts/qlever-same-box.sh
 #                 (sq-52fo): builds a QLever index over the same corpus in Docker
 #                 (IndexBuilderMain), starts ServerMain on a port, polls readiness, runs the
@@ -20,9 +25,37 @@
 #                 can never hang the gather (the prior ~53min stall). If Docker/index/server
 #                 is too heavy/flaky in the bounded window it is SKIPPED and stays honest-n/a.
 #
+# [OPUS-4.8] sq-sxso — DIAGNOSE-AND-AVOID-THE-STALL HARDENING. The same-box Oxigraph half
+# previously had NO per-step timeout and NO timestamped sentinel, so a hung step (a heavy
+# from-source `cargo build`, or a pathological SP2Bench query in Oxigraph) burned the whole
+# window with NO sentinel — the observed "73 min, no GATHER_DONE" failure, the same class of
+# stall the QLever recipe already fixed. THREE measured-rooted fixes (LOCALLY REPRODUCED — at
+# only 50k triples the prebuilt Oxigraph CLI ran q07 in ~38 s and q08 PAST 60 s, so at the old
+# 250k default those queries are minutes-long → the stall):
+#   (a) PER-STEP TIMESTAMPED LOGGING — every phase (apt/rustup/build/gen/sparq-run/oxi-run)
+#       emits `step "..."` -> a UTC-stamped line to /var/log/gather.log AND appends to
+#       /root/GATHER_STEP. The orchestrator pulls /root/GATHER_STEP when no GATHER_DONE
+#       appears, so a stalled run names EXACTLY the hung step instead of being invisible.
+#   (b) PREBUILT, SHA-PINNED OXIGRAPH CLI by default — removes the from-source `cargo build
+#       -p sparq-bench` Oxigraph compile from the critical path (a likely build-time hang on
+#       the small fallback box). The binary is pinned by version + sha256 (OXI_* below).
+#   (c) HARD PER-STEP `timeout` + SMALLER configurable dataset — each phase is wrapped in a
+#       `timeout` (caps below) and the per-query Oxigraph loop is per-query timeout-bounded,
+#       so a hang fails FAST with the logged step instead of stalling for an hour. The default
+#       corpus is SMALLER (SP2B_TRIPLES default 100000, was 250000) to keep the smoke/gather
+#       cheap; raise SP2B_TRIPLES=250000 for the full per-commit scale.
+#
+# HONESTY (sq-sxso): this is the SCRIPT-side diagnostic + avoidance hardening. It is authored
+# + locally reproduced on the aarch64 work box (the prebuilt-CLI load/query lane was run end
+# to end), but the actual confirmation that a real gather now reaches GATHER_DONE without
+# stalling REQUIRES one EC2 gather run — that green-gather confirmation is a follow-up. The
+# instance-side stall itself cannot be reproduced in a worktree. Competitor numbers from this
+# gather are NON-CANONICAL (work-box / ephemeral EC2), per bench/CATALOG.md QUIET-BOX.
+#
 # Corpus scale is BOUNDED + documented: SP2Bench is the cheapest deterministic featured
 # corpus (real Freiburg sp2b_gen, g++ -O2, sha256-pinned, byte-identical output; ~250k
-# triples ≈ 26 MB Turtle). SP2B_TRIPLES caps it (default 250000 = the CI per-commit scale).
+# triples ≈ 26 MB Turtle). SP2B_TRIPLES caps it (default 100000 smoke scale; 250000 = the
+# full CI per-commit scale).
 #
 # ORPHAN-PROOFING (agent-death-independent, 3h hard cap; identical to gather-ec2.sh):
 #   --instance-initiated-shutdown-behavior terminate + detached (sleep 10800; shutdown)
@@ -39,8 +72,12 @@
 #
 # Usage:  AWS_PROFILE=pss scripts/gather-ec2-sparql.sh <branch> [<region>]
 #   GATHER_QLEVER=1   also attempt the QLever best-effort path (default off)
-#   SP2B_TRIPLES=N    corpus scale (default 250000)
+#   SP2B_TRIPLES=N    corpus scale (default 100000 smoke; 250000 = full CI scale)
 #   GATHER_ITERS=K    min-of-K per query (default 5)
+#   OXI_EMBEDDED=1    use the in-process embedded `sparq-bench bench-corpus` Oxigraph path
+#                     (in-RAM store) instead of the default prebuilt SHA-pinned CLI (on-disk)
+#   OXI_VERSION=...   prebuilt Oxigraph CLI release tag (default below); pinned by sha256
+#   STEP_*_TIMEOUT    per-phase hard caps (seconds) — see the user-data step() wrappers below
 # Writes decoded envelopes under bench/competitor-results/ and prints each on stdout.
 # ALWAYS terminates the instance + deletes the keypair/SG (cleanup trap).
 set -euo pipefail
@@ -49,9 +86,32 @@ BRANCH="${1:?usage: gather-ec2-sparql.sh <branch> [region]}"
 REGION="${2:-${AWS_REGION:-eu-west-2}}"
 ITYPE="${GATHER_ITYPE:-c7g.2xlarge}"     # 8 vCPU arm64 (more RAM for the QLever index; falls back below)
 REPO="https://github.com/jeswr/sparq.git"
-SP2B_TRIPLES="${SP2B_TRIPLES:-250000}"
+SP2B_TRIPLES="${SP2B_TRIPLES:-100000}"   # [OPUS-4.8] sq-sxso: smaller smoke default (was 250000)
 ITERS="${GATHER_ITERS:-5}"
 GATHER_QLEVER="${GATHER_QLEVER:-0}"
+OXI_EMBEDDED="${OXI_EMBEDDED:-0}"        # [OPUS-4.8] sq-sxso: 0 = prebuilt CLI (default); 1 = embedded sparq-bench
+
+# [OPUS-4.8] sq-sxso — PREBUILT, SHA-PINNED Oxigraph CLI (avoids the from-source compile).
+# Pin: oxigraph CLI v0.5.9 standalone release binaries (github.com/oxigraph/oxigraph/releases).
+# The gather box is arm64 (Graviton / ubuntu-noble-24.04-arm64); the x86_64 sha is pinned too
+# so the lane is portable + locally reproducible. Re-pin only deliberately: bump OXI_VERSION
+# AND both shas together. Verified 2026-06-19.
+OXI_VERSION="${OXI_VERSION:-v0.5.9}"
+OXI_SHA256_AARCH64="${OXI_SHA256_AARCH64:-dc17e58cf65d74f89853bb8b49180099399a53b9df7f1671a4a9ca188208d794}"
+OXI_SHA256_X86_64="${OXI_SHA256_X86_64:-4be355715ba3945e8fb8c94a06662a29808683bf2ec355894dba9e82762e7cc7}"
+
+# [OPUS-4.8] sq-sxso — per-phase hard-timeout caps (seconds). A hung step now fails FAST with
+# the step logged, instead of burning the whole window with no sentinel (the 73-min stall).
+STEP_APT_TIMEOUT="${STEP_APT_TIMEOUT:-900}"        # apt-get update+install
+STEP_RUSTUP_TIMEOUT="${STEP_RUSTUP_TIMEOUT:-600}"  # rustup install
+STEP_BUILD_TIMEOUT="${STEP_BUILD_TIMEOUT:-2400}"   # cargo build (sparq-cli [+ sparq-bench if embedded])
+STEP_GEN_TIMEOUT="${STEP_GEN_TIMEOUT:-600}"        # sp2b corpus gen (fetch+build gen + emit)
+STEP_OXI_FETCH_TIMEOUT="${STEP_OXI_FETCH_TIMEOUT:-300}"  # prebuilt Oxigraph CLI download
+STEP_SPARQ_RUN_TIMEOUT="${STEP_SPARQ_RUN_TIMEOUT:-1200}" # sparq-cli bench (all queries)
+STEP_OXI_LOAD_TIMEOUT="${STEP_OXI_LOAD_TIMEOUT:-1200}"   # oxigraph load (whole corpus)
+STEP_OXI_RUN_TIMEOUT="${STEP_OXI_RUN_TIMEOUT:-1800}"     # oxigraph query loop (all queries, outer cap)
+STEP_OXI_QUERY_TIMEOUT="${STEP_OXI_QUERY_TIMEOUT:-120}"  # per-query inner cap (a slow query -> ERROR, not a hang)
+
 TAGSPEC='ResourceType=instance,Tags=[{Key=purpose,Value=sparq-bench}]'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -105,48 +165,181 @@ exec > >(tee /var/log/gather.log) 2>&1
 ( sleep 10800; shutdown -h now ) &
 systemd-run --on-active=10800 /sbin/shutdown -h now || true
 
+# [OPUS-4.8] sq-sxso — PER-STEP TIMESTAMPED SENTINEL. Every phase calls step() FIRST, which
+# UTC-stamps a line into the tee'd /var/log/gather.log AND appends it to /root/GATHER_STEP. A
+# stalled run no longer hangs invisibly — the orchestrator pulls /root/GATHER_STEP and the
+# LAST line is EXACTLY the step that hung (the "73 min, no sentinel" failure was just an
+# absence of this). run_step() wraps a command in 'timeout' so a hung step fails FAST (exit
+# 124) with the step name already logged, instead of burning the whole window.
+#   step() writes to STDERR (the top-level 'exec ... 2>&1' still folds it into the gather log)
+#   AND appends to /root/GATHER_STEP. Writing to stderr — not stdout — is load-bearing: several
+#   run_step callers redirect the wrapped command's STDOUT to a TSV, and a step line on stdout
+#   would corrupt that TSV. 'tee ... >&2' sends tee's own copy to fd 2.
+step() { echo "[STEP \$(date -u +%Y-%m-%dT%H:%M:%SZ)] \$*" | tee -a /root/GATHER_STEP >&2; }
+run_step() { # run_step <name> <timeout-s> -- <cmd...>
+  local name="\$1" to="\$2"; shift 3   # drop name, timeout, and the literal '--'
+  step "BEGIN \$name (timeout \${to}s): \$*"
+  if timeout "\$to" "\$@"; then
+    step "OK    \$name"
+  else
+    local rc=\$?
+    [ "\$rc" = 124 ] && step "TIMEOUT \$name hit \${to}s cap (rc=124)" || step "FAIL  \$name (rc=\$rc)"
+    return "\$rc"
+  fi
+}
+
 export DEBIAN_FRONTEND=noninteractive
-apt-get update -qq
-apt-get install -y -qq build-essential g++ pkg-config git curl jq python3 python3-venv python3-pip unzip
+step "apt update+install"
+run_step apt $STEP_APT_TIMEOUT -- bash -c 'apt-get update -qq && apt-get install -y -qq build-essential g++ pkg-config git curl jq python3 python3-venv python3-pip unzip' || true
 if [ "$GATHER_QLEVER" = "1" ]; then
+  step "apt docker.io (qlever opt-in)"
   apt-get install -y -qq docker.io || true
   systemctl start docker || true
 fi
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+step "rustup install"
+run_step rustup $STEP_RUSTUP_TIMEOUT -- bash -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal" || true
 export PATH="/root/.cargo/bin:\$PATH"
 . /root/.cargo/env || true
 for _ in \$(seq 1 30); do command -v cargo >/dev/null 2>&1 && break; sleep 2; done
-command -v cargo || echo "WARN: cargo still not on PATH"
+command -v cargo || step "WARN: cargo still not on PATH"
 
+step "git clone + checkout $BRANCH"
 cd /root
 git clone -q "$REPO" sparq
 cd sparq
 git fetch -q origin "$BRANCH"
 git checkout -q "$BRANCH"
 SHA=\$(git rev-parse --short HEAD)
-echo "GATHER_SHA=\$SHA"
+step "checked out \$SHA"
 
-cargo build --release -q -p sparq-cli
-cargo build --release -q -p sparq-bench
+# [OPUS-4.8] sq-sxso: ALWAYS build sparq-cli (the sparq engine under test). Only build the
+# embedded sparq-bench (the heavy from-source Oxigraph compile) when OXI_EMBEDDED=1 — the
+# default prebuilt-CLI path does NOT need it, which removes the most likely build-time hang
+# from the critical path.
+run_step build-sparq-cli $STEP_BUILD_TIMEOUT -- cargo build --release -q -p sparq-cli \
+  || step "WARN: sparq-cli build failed/timed out"
+if [ "$OXI_EMBEDDED" = "1" ]; then
+  run_step build-sparq-bench $STEP_BUILD_TIMEOUT -- cargo build --release -q -p sparq-bench \
+    || step "WARN: sparq-bench (embedded oxigraph) build failed/timed out"
+fi
 
 # ---- generate the bounded SP2Bench corpus (real Freiburg sp2b_gen) -----------------------
-CORPUS=\$(bash bench/sp2b/gen.sh "$SP2B_TRIPLES")
-echo "CORPUS=\$CORPUS"
-ls -la "\$CORPUS"
+step "sp2b gen ($SP2B_TRIPLES triples)"
+# Redirect lives INSIDE the wrapped command (bash -c '... > file'), so run_step's own step
+# markers still reach the log instead of the redirected file. $SP2B_TRIPLES is baked by the
+# launcher; the inner stdout (the corpus path gen.sh prints) goes to /tmp/corpus_path.txt.
+run_step sp2b-gen $STEP_GEN_TIMEOUT -- bash -c "bash bench/sp2b/gen.sh $SP2B_TRIPLES > /tmp/corpus_path.txt 2>/tmp/gen.err" \
+  || step "WARN: sp2b gen failed/timed out (see /tmp/gen.err)"
+CORPUS=\$(tail -n1 /tmp/corpus_path.txt 2>/dev/null || true)
+step "corpus=\$CORPUS"
+[ -n "\$CORPUS" ] && ls -la "\$CORPUS" || step "WARN: no corpus path"
 
-OXI_V=\$(awk '/^name = "oxigraph"\$/{f=1} f&&/^version = /{gsub(/[",]/,"",\$3);print \$3;exit}' Cargo.lock)
-echo "OXI_V=\$OXI_V"
+OXI_V=\$(awk '/^name = "oxigraph"\$/{f=1} f&&/^version = /{gsub(/[",]/,"",\$3);print \$3;exit}' Cargo.lock 2>/dev/null || echo unknown)
+step "oxigraph (cargo.lock dev-dep) version=\$OXI_V"
 
 export QUIET_BOX=true
 mkdir -p bench/competitor-results
 
 # ---- sparq (the CI runner, count mode) ---------------------------------------------------
-./target/release/sparq-cli bench "\$CORPUS" turtle bench/sp2b/queries "$ITERS" count > /tmp/sparq.tsv 2>/tmp/sparq.err || true
-echo "=== sparq.tsv ==="; cat /tmp/sparq.tsv
+step "sparq-cli bench (count, iters=$ITERS)"
+run_step sparq-run $STEP_SPARQ_RUN_TIMEOUT -- bash -c "./target/release/sparq-cli bench \"\$CORPUS\" turtle bench/sp2b/queries $ITERS count > /tmp/sparq.tsv 2>/tmp/sparq.err" \
+  || step "WARN: sparq run failed/timed out (see /tmp/sparq.err)"
+echo "=== sparq.tsv ==="; cat /tmp/sparq.tsv 2>/dev/null || true
 
 # ---- oxigraph (same corpus, same queries, same count semantics) --------------------------
-./target/release/sparq-bench bench-corpus "\$CORPUS" turtle bench/sp2b/queries "$ITERS" > /tmp/oxi.tsv 2>/tmp/oxi.err || true
-echo "=== oxi.tsv ==="; cat /tmp/oxi.tsv; echo "--- oxi.err ---"; cat /tmp/oxi.err
+# [OPUS-4.8] sq-sxso: DEFAULT = prebuilt SHA-pinned Oxigraph CLI (on-disk store); no compile.
+# OXI_EMBEDDED=1 = the in-process embedded path (in-RAM store). Either way the per-query loop
+# is timeout-bounded so a pathological SP2Bench query (q07/q08 are minutes-long in Oxigraph at
+# scale — measured) records ERROR and the gather moves on, instead of hanging the whole run.
+OXI_MODE="embedded"
+if [ "$OXI_EMBEDDED" = "1" ]; then
+  step "oxigraph EMBEDDED (sparq-bench bench-corpus, in-RAM, iters=$ITERS)"
+  run_step oxi-run $STEP_OXI_RUN_TIMEOUT -- bash -c "./target/release/sparq-bench bench-corpus \"\$CORPUS\" turtle bench/sp2b/queries $ITERS > /tmp/oxi.tsv 2>/tmp/oxi.err" \
+    || step "WARN: embedded oxigraph run failed/timed out (see /tmp/oxi.err)"
+else
+  OXI_MODE="prebuilt-cli"
+  # ---- (1) fetch + sha256-verify the prebuilt Oxigraph CLI (arch-selected) ----
+  ARCH=\$(uname -m)
+  case "\$ARCH" in
+    aarch64|arm64) OXI_ASSET="oxigraph_${OXI_VERSION}_aarch64_linux_gnu"; OXI_SHA="$OXI_SHA256_AARCH64" ;;
+    x86_64|amd64)  OXI_ASSET="oxigraph_${OXI_VERSION}_x86_64_linux_gnu";  OXI_SHA="$OXI_SHA256_X86_64" ;;
+    *) step "FATAL: unsupported arch \$ARCH for prebuilt Oxigraph CLI"; OXI_ASSET=""; OXI_SHA="" ;;
+  esac
+  OXI_URL="https://github.com/oxigraph/oxigraph/releases/download/${OXI_VERSION}/\$OXI_ASSET"
+  OXI_BIN=/usr/local/bin/oxigraph
+  if [ -n "\$OXI_ASSET" ]; then
+    step "oxigraph PREBUILT CLI fetch ${OXI_VERSION} (\$OXI_ASSET)"
+    if run_step oxi-fetch $STEP_OXI_FETCH_TIMEOUT -- curl -fsSL -o "\$OXI_BIN" "\$OXI_URL"; then
+      ACT=\$(sha256sum "\$OXI_BIN" | cut -d' ' -f1)
+      if [ "\$ACT" = "\$OXI_SHA" ]; then
+        chmod +x "\$OXI_BIN"
+        step "oxigraph CLI sha256 OK (\$ACT); version: \$("\$OXI_BIN" --version 2>/dev/null || echo unknown)"
+      else
+        step "FATAL: oxigraph CLI sha256 MISMATCH expected=\$OXI_SHA actual=\$ACT — refusing to run unpinned binary"
+        rm -f "\$OXI_BIN"; OXI_BIN=""
+      fi
+    else
+      step "WARN: oxigraph CLI download failed/timed out"; OXI_BIN=""
+    fi
+  else
+    OXI_BIN=""
+  fi
+  # ---- (2) load the corpus into an on-disk store (bounded) ----
+  : > /tmp/oxi.tsv
+  if [ -n "\$OXI_BIN" ] && [ -n "\$CORPUS" ]; then
+    OXI_STORE=\$(mktemp -d /tmp/oxi-store.XXXXXX)
+    OXI_V="\$("\$OXI_BIN" --version 2>/dev/null | awk '{print \$2}' || echo "$OXI_VERSION")"
+    step "oxigraph PREBUILT load (on-disk, \$OXI_STORE)"
+    if run_step oxi-load $STEP_OXI_LOAD_TIMEOUT -- "\$OXI_BIN" load --location "\$OXI_STORE" --file "\$CORPUS" --format ttl; then
+      # ---- (3) per-query loop, EACH query inner-timeout-bounded; min-of-N JSON-results count ----
+      step "oxigraph PREBUILT query loop (iters=$ITERS, per-query cap \${STEP_OXI_QUERY_TIMEOUT}s)"
+      OXI_BIN="\$OXI_BIN" OXI_STORE="\$OXI_STORE" ITERS="$ITERS" QTO="$STEP_OXI_QUERY_TIMEOUT" QDIR="bench/sp2b/queries" \
+        timeout $STEP_OXI_RUN_TIMEOUT python3 - <<'PYOXI' > /tmp/oxi.tsv 2>/tmp/oxi.err || step "WARN: prebuilt oxigraph query loop failed/timed out"
+import os, sys, glob, json, time, subprocess
+oxi   = os.environ["OXI_BIN"]; store = os.environ["OXI_STORE"]
+iters = int(os.environ["ITERS"]); qto = float(os.environ["QTO"]); qdir = os.environ["QDIR"]
+def count_json(text):
+    # SELECT -> len(results.bindings); ASK -> 1 if true else 0 (matches the embedded oxi_count:
+    # Boolean -> 1; here we count the boolean's solution as 1 only when true, 0 when false, so
+    # the row count equals the number of solutions, like sparq count mode on these ASK queries).
+    obj = json.loads(text)
+    if "boolean" in obj: return 1 if obj["boolean"] else 0
+    res = obj.get("results", {})
+    return len(res.get("bindings", []))
+for qf in sorted(glob.glob(os.path.join(qdir, "*.rq"))):
+    name = os.path.splitext(os.path.basename(qf))[0]
+    best = None; rows = "ERROR"
+    for _ in range(max(1, iters)):
+        t = time.perf_counter()
+        try:
+            out = subprocess.run([oxi, "query", "--location", store, "--query-file", qf,
+                                  "--results-format", "json"],
+                                 capture_output=True, text=True, timeout=qto)
+        except subprocess.TimeoutExpired:
+            rows = "ERROR"; best = None; break
+        if out.returncode != 0:
+            rows = "ERROR"; best = None; break
+        try:
+            rows = count_json(out.stdout)
+        except Exception:
+            rows = "ERROR"; best = None; break
+        us = (time.perf_counter() - t) * 1e6
+        best = us if best is None else min(best, us)
+    if rows == "ERROR" or best is None:
+        print(f"{name}\tERROR\toxigraph")
+    else:
+        print(f"{name}\t{rows}\t{best:.1f}")
+    sys.stdout.flush()
+PYOXI
+    else
+      step "WARN: oxigraph load failed/timed out — leaving oxi.tsv empty (honest-n/a)"
+    fi
+    rm -rf "\$OXI_STORE"
+  else
+    step "WARN: no prebuilt oxigraph binary or no corpus — oxi.tsv stays empty (honest-n/a)"
+  fi
+fi
+echo "=== oxi.tsv (mode=\$OXI_MODE) ==="; cat /tmp/oxi.tsv 2>/dev/null || true; echo "--- oxi.err ---"; cat /tmp/oxi.err 2>/dev/null || true
 
 # ---- env block + combine into ONE same-box-comparison envelope ---------------------------
 CPU=\$(LC_ALL=C grep -m1 'model name' /proc/cpuinfo 2>/dev/null | cut -d: -f2- | sed 's/^ *//' || true)
@@ -164,7 +357,7 @@ NOW=\$(date -u +%Y-%m-%dT%H:%M:%SZ)
 QLEVER_STATUS="skipped"
 QLEVER_TSV=""
 if [ "$GATHER_QLEVER" = "1" ] && command -v docker >/dev/null 2>&1; then
-  echo "=== qlever best-effort (scripts/qlever-same-box.sh) ==="
+  step "qlever best-effort (scripts/qlever-same-box.sh)"
   # sp2b_gen emits Turtle, so format=ttl; the recipe also accepts nt for N-Triples corpora.
   # The recipe is itself bounded + trap-cleaned, but we ALSO wrap it in an outer 'timeout'
   # as a belt-and-braces ceiling so it can never extend the gather window indefinitely.
@@ -172,17 +365,24 @@ if [ "$GATHER_QLEVER" = "1" ] && command -v docker >/dev/null 2>&1; then
        timeout 1800 bash scripts/qlever-same-box.sh "\$CORPUS" ttl bench/sp2b/queries "$ITERS" /tmp/qlever.tsv; then
     QLEVER_STATUS="ok"
     QLEVER_TSV=\$(python3 -c 'import json,sys; print(json.dumps(open("/tmp/qlever.tsv").read()))')
+    step "qlever OK"
   else
-    echo "qlever recipe failed/timed out — keeping dashboard cell honest-n/a"
+    step "qlever recipe failed/timed out — keeping dashboard cell honest-n/a"
     QLEVER_STATUS="failed"
     [ -s /tmp/qlever.tsv ] && QLEVER_TSV=\$(python3 -c 'import json,sys; print(json.dumps(open("/tmp/qlever.tsv").read()))')
   fi
 fi
 
-SPARQ_TSV=\$(python3 -c 'import json,sys; print(json.dumps(open("/tmp/sparq.tsv").read()))')
-OXI_TSV=\$(python3 -c 'import json,sys; print(json.dumps(open("/tmp/oxi.tsv").read()))')
+# [OPUS-4.8] sq-sxso: read the TSVs DEFENSIVELY — a timed-out step leaves an empty/missing
+# file, and the envelope must still be written (so /root/GATHER_DONE is reached and the
+# orchestrator does not itself hang waiting for a sentinel that never comes). A missing file
+# becomes "" rather than aborting the heredoc under set -euo pipefail.
+SPARQ_TSV=\$(python3 -c 'import json; print(json.dumps(open("/tmp/sparq.tsv").read() if __import__("os").path.exists("/tmp/sparq.tsv") else ""))')
+OXI_TSV=\$(python3 -c 'import json; print(json.dumps(open("/tmp/oxi.tsv").read() if __import__("os").path.exists("/tmp/oxi.tsv") else ""))')
 [ -n "\$QLEVER_TSV" ] || QLEVER_TSV='""'
+GATHER_STEPS=\$(python3 -c 'import json; print(json.dumps(open("/root/GATHER_STEP").read() if __import__("os").path.exists("/root/GATHER_STEP") else ""))')
 
+step "writing same-box envelope (oxigraph_mode=\$OXI_MODE)"
 cat > bench/competitor-results/sparql-same-box-\$(date -u +%Y%m%dT%H%M%SZ).json <<EOF2
 {
   "gather": "sparql-same-box-comparison",
@@ -190,17 +390,20 @@ cat > bench/competitor-results/sparql-same-box-\$(date -u +%Y%m%dT%H%M%SZ).json 
   "suite": "sp2b",
   "scale": "SP2Bench $SP2B_TRIPLES triples (real Freiburg sp2b_gen, deterministic)",
   "iters": $ITERS,
+  "oxigraph_mode": "\$OXI_MODE",
   "oxigraph_version": "\$OXI_V",
   "env": {"host_class":"ephemeral-ec2-$ITYPE","cpu_model":"\$CPU","nproc":\$NPROC,"os":"Linux","kernel":"\$KERNEL","quiet_box":true,"gathered_at_utc":"\$NOW","git_commit":"\$SHA"},
   "qlever_status": "\$QLEVER_STATUS",
   "sparq_tsv": \$SPARQ_TSV,
   "oxigraph_tsv": \$OXI_TSV,
-  "qlever_tsv": \$QLEVER_TSV
+  "qlever_tsv": \$QLEVER_TSV,
+  "step_log": \$GATHER_STEPS
 }
 EOF2
 
-jq . bench/competitor-results/sparql-same-box-*.json || echo "WARN: envelope did not validate"
+jq . bench/competitor-results/sparql-same-box-*.json || step "WARN: envelope did not validate"
 ls -la bench/competitor-results/
+step "GATHER_DONE"
 echo "\$SHA" > /root/GATHER_DONE
 sync
 UD
@@ -278,7 +481,11 @@ while :; do
     DONE=1; break
   fi
   STATE=$(aws ec2 describe-instances --region "$REGION" --instance-ids "$INSTANCE_ID" --query 'Reservations[0].Instances[0].State.Name' --output text 2>/dev/null || echo unknown)
-  log "  [$i / ${ELAPSED}s] state=$STATE; waiting for sentinel"
+  # [OPUS-4.8] sq-sxso: surface the CURRENT step LIVE while polling — the last /root/GATHER_STEP
+  # line tells us which phase the box is on, so a stall is visible AS IT HAPPENS (not only after
+  # the deadline). This is the diagnostic the prior "73 min, no sentinel" run lacked entirely.
+  CUR_STEP=$(ssh $SSHO "ubuntu@$IP" "sudo tail -n1 /root/GATHER_STEP 2>/dev/null" 2>/dev/null || true)
+  log "  [$i / ${ELAPSED}s] state=$STATE; step: ${CUR_STEP:-<not started>}"
   [ "$STATE" = "terminated" ] && { log "  instance terminated before sentinel — results may be lost"; break; }
 done
 
@@ -287,7 +494,18 @@ if [ "$DONE" = 1 ]; then
     && log "pulled result envelopes:" || log "tar pull failed"
   for f in "$RESULTS_DIR"/sparql-same-box-*.json; do [ -f "$f" ] || continue; cat "$f"; echo; done
 else
-  log "NO sentinel — pulling /var/log/gather.log for diagnosis"
+  # [OPUS-4.8] sq-sxso: on NO sentinel, pull the per-step log FIRST and call out the LAST step
+  # (the one that hung) explicitly, THEN the gather.log tail. This is the core diagnosability
+  # fix: a future stalled run names the hung phase instead of being invisible.
+  log "NO sentinel — pulling /root/GATHER_STEP (the hung step) + /var/log/gather.log for diagnosis"
+  STEP_LOG=$(ssh $SSHO "ubuntu@$IP" "sudo cat /root/GATHER_STEP 2>/dev/null" 2>/dev/null || true)
+  if [ -n "$STEP_LOG" ]; then
+    log "  --- per-step log (/root/GATHER_STEP) ---"
+    printf '%s\n' "$STEP_LOG" >&2
+    log "  >>> LAST STEP (likely the hung one): $(printf '%s\n' "$STEP_LOG" | tail -n1)"
+  else
+    log "  (no /root/GATHER_STEP — the box may have stalled before user-data ran)"
+  fi
   ssh $SSHO "ubuntu@$IP" "sudo tail -160 /var/log/gather.log 2>/dev/null" >&2 || true
 fi
 


### PR DESCRIPTION
> 🤖 SPARQ agent

## sq-sxso — Oxigraph same-box gather STALLS (73 min, no sentinel)

The sparq+Oxigraph half of `scripts/gather-ec2-sparql.sh` had **no per-step timeout and no timestamped sentinel**, so a hung step (heavy from-source `cargo build`, or a pathological SP2Bench query in Oxigraph) burned the whole window with no `/root/GATHER_DONE` — the observed "73 min, no sentinel" stall (the same class the QLever recipe already fixed in sq-52fo).

### Root cause — LOCALLY REPRODUCED
On the aarch64 work box, with the prebuilt Oxigraph CLI v0.5.9 at only **50k triples** (1/5 of the old default):
- `q07` ≈ **38 s**, `q08` **past 60 s** (recorded `ERROR` at the per-query cap).
- So at the old **250k** default those unselective SP2Bench joins are **minutes-long in Oxigraph** → the stall. (sparq itself is sub-second on `queries/`; Oxigraph's planner is far slower on these joins.)

### The three fixes (diagnose + avoid; `bench/` only)
1. **Per-step timestamped logging.** Every phase emits `step "…"` → a UTC-stamped line to `/var/log/gather.log` **and** `/root/GATHER_STEP`. The orchestrator surfaces the current step **LIVE** while polling, and on the no-sentinel path pulls the step log and calls out the **LAST step (the hung one)** explicitly. The step log is embedded in the result envelope (`step_log`). `step()` writes to **stderr** so a per-command TSV redirect isn't corrupted (validated: 0 `[STEP]` lines leaked into the TSV).
2. **Prebuilt, SHA-pinned Oxigraph CLI (default).** `oxigraph load` (on-disk) + `oxigraph query` per `.rq` (min-of-N, JSON-results count) — removes the from-source `cargo build -p sparq-bench` Oxigraph compile from the critical path. Pinned to **v0.5.9** by `sha256` (aarch64 `dc17e58c…`, x86_64 `4be35571…`). `OXI_EMBEDDED=1` keeps the in-process in-RAM path; the envelope records `oxigraph_mode` (`prebuilt-cli` on-disk vs `embedded` in-RAM) so the load regime is never silently conflated.
3. **Hard per-step `timeout` + smaller configurable dataset.** Each phase wrapped in `timeout` (`STEP_*_TIMEOUT`); the per-query Oxigraph loop is **per-query** bounded (`STEP_OXI_QUERY_TIMEOUT`, default 120 s) so a pathological query records `ERROR` (honest-n/a) and the gather moves on. Default `SP2B_TRIPLES` **100000** (was 250000) for a cheap smoke; raise to 250000 for the full scale.

### Commands the lane runs (locally reproduced)
```
oxigraph load  --location <store> --file <corpus.ttl> --format ttl          # on-disk load
oxigraph query --location <store> --query-file q.rq --results-format json    # per-query, timeout-bounded
```
Correctness preserved: ASK `q12b=1`/`q12c=0` and scale-invariant `q03c=0`/`q09=4`/`q11=10` match `bench/sp2b/expected-rows.tsv`.

### Validity
- `bash -n` + `shellcheck -S warning` **clean** on the source script; the **rendered user-data** is bash-valid (no new warning class vs `origin/main`); the result-envelope JSON template validated.
- `run_step` timeout wrapper unit-tested (success→OK, timeout→124, fail→rc); the exact heredoc query loop run end-to-end against a real 50k corpus.
- typos-gate + privacy-claims gate: no triggering terms in the changed files.

### HONESTY — verification needs an EC2 gather run
This is the **script-side diagnostic + avoidance hardening**, authored and **locally reproduced** on the aarch64 work box. The instance-side stall itself cannot be reproduced in a worktree, so confirming that a **real gather now reaches `GATHER_DONE` without stalling requires one EC2 gather run** — that **green-gather confirmation is a follow-up**, not claimed here. Competitor numbers from this gather are **non-canonical** (ephemeral EC2 / work box) regardless.

Files: `scripts/gather-ec2-sparql.sh`, `bench/CATALOG.md`.