### PR TITLE
fix(ci): correct stale Pages-source comments — flip is DONE, build_type=workflow (sq-svtt)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,9 +8,13 @@
 # at /sparq/dev/bench/.
 #
 # HOW /dev/bench IS PRESERVED (traced):
-#   1. Pages is served at https://jeswr.github.io/sparq/. Today (build_type: legacy)
-#      the source is the `benchmark-data` branch root: a root index.html redirect +
-#      a dev/ tree (dev/bench/{index.html,dashboard.js,dashboard.css,data.js,...}).
+#   1. Pages is served at https://jeswr.github.io/sparq/ from this workflow
+#      (build_type: workflow — the "GitHub Actions" source; the earlier "Deploy from a
+#      branch" legacy source has been retired). The benchmark dashboard formerly served
+#      from the `benchmark-data` branch root (a root index.html redirect + a dev/ tree:
+#      dev/bench/{index.html,dashboard.js,dashboard.css,data.js,...}) is now carried into
+#      THIS workflow's artifact via the overlay step below, so /sparq/dev/bench/ keeps
+#      working under the single Actions-built artifact.
 #   2. This workflow does NOT touch the `benchmark-data` branch — bench.yml keeps
 #      writing data.js + dev/bench/* there exactly as before. We only READ it.
 #   3. After `next build` writes the showcase to out/ (with its OWN root index.html),
@@ -19,13 +23,20 @@
 #      verbatim, so https://jeswr.github.io/sparq/dev/bench/ keeps working.
 #   4. `out/.nojekyll` disables Jekyll so `_next/` (underscore-prefixed) assets serve.
 #
-# ONE-TIME PAGES SETTING (needs:user): the repo's Pages source must be switched from
-# "Deploy from a branch" (legacy) to "GitHub Actions" in Settings → Pages for this
-# workflow's deploy step to publish. Until that flip, the existing legacy dashboard
-# keeps serving untouched and this workflow's deploy step is a no-op/failure that
-# never modifies the live site. (The alternative — committing out/ onto benchmark-data —
-# was rejected: it couples site source to the data branch and races bench.yml's root
-# index.html seed.)
+# PAGES SOURCE (DONE — no longer needs:user): the repo's Pages source is already set to
+# "GitHub Actions" (sq-vbq9 resolved; `gh api repos/jeswr/sparq/pages` reports
+# build_type: workflow), so this workflow's deploy step IS the live publisher — the site
+# at https://jeswr.github.io/sparq/ is served from the artifact below, not from any branch
+# root. No repo-settings action is outstanding for this workflow. (The alternative —
+# committing out/ onto benchmark-data — was rejected: it couples site source to the data
+# branch and races bench.yml's root index.html seed.)
+#
+# OPEN PRODUCT DECISION (sq-svtt, NOT a settings flip): Pages has ONE deploy slot and this
+# workflow owns the /sparq/ root. The mdBook guide (sq-w9sr/sq-h0tr) wants a published
+# home too; until that root question is decided (guide at /guide subpath vs at root vs a
+# merged deploy), docs.yml deliberately ships NO deploy job (build-validate only) so a
+# second deploy-pages cannot race + overwrite this showcase. That decision does not block
+# or affect the current live deploy.
 
 name: pages
 
@@ -221,12 +232,13 @@ jobs:
           touch out/.nojekyll
 
       # [OPUS-4.8] sq-zngy — ARTIFACT-LEVEL smoke check (NOT a live-URL check).
-      # The Pages Source flip to "GitHub Actions" (sq-vbq9) is a pending needs:user action,
-      # so a live https://jeswr.github.io/sparq/dev/... probe would 404 pre-cutover and would
-      # be wrong. This step instead asserts the ASSEMBLED Pages output dir (site/out, the exact
-      # tree handed to upload-pages-artifact below) — so it catches the dev/bench* reconciliation
-      # regression regardless of the Pages-source state. It verifies the artifact CONTENTS, NOT
-      # that the site is being served.
+      # This step asserts the ASSEMBLED Pages output dir (site/out, the exact tree handed to
+      # upload-pages-artifact below) rather than probing the live https://jeswr.github.io/sparq/dev/...
+      # URL: the artifact check is deterministic + decoupled from deploy/propagation timing
+      # (the live URL lags this run by the deploy + CDN flush), and it catches the dev/bench*
+      # reconciliation regression at build time, BEFORE upload. It verifies the artifact
+      # CONTENTS, NOT that the site is being served. (Pages source is already build_type:
+      # workflow, so this artifact IS what goes live.)
       - name: Smoke-check assembled Pages artifact (dev/bench* dashboards)
         working-directory: site
         run: |


### PR DESCRIPTION
> 🤖 **SPARQ agent** — bead `sq-svtt` (GitHub Pages deploy re-investigation, in response to @jeswr on #758).

## What & why

On #758 the user said about GitHub Pages: *"It is deploying from GitHub Actions already, I have not selected any root… Can you take another look and see if there is anything you actually need from me here."*

**They are correct — nothing is needed from them.** I verified the live setup end-to-end:

- `gh api repos/jeswr/sparq/pages` → `build_type: "workflow"`, `https_enforced: true`, `status: "built"`, `html_url: https://jeswr.github.io/sparq/`. The "GitHub Actions" source flip (`sq-vbq9`) is **already done**.
- `pages.yml` already uses the official `actions/upload-pages-artifact` + `actions/deploy-pages` flow (no branch/root selection needed for this source type).
- Recent `pages` runs on `main` are **green**; the latest `github-pages` deployment is `state: success`, and `last-modified` on the live root matches the latest deploy → the workflow is the live publisher, **not a no-op**.
- Live site serves **HTTP 200**; referenced `_next/` assets, `/logo.svg`, and the preserved `/dev/bench/` dashboard (incl. `data.js`, `dashboard.js`) all resolve 200.
- `site/next.config.ts` `basePath`/`assetPrefix` = `/sparq` matches the project-page URL → no asset-404 mismatch.

So **`needs:user` = NO** for the Pages source/setup.

## The actual bug this fixes

The `pages.yml` comments were written when the source was still `build_type: legacy` and described the flip as a **pending `needs:user` action**. That is now factually wrong and actively misled the loop into re-raising a resolved item (the exact confusion on #758). This PR rewrites those three stale comment blocks to state the truth, and records the **genuinely still-open** `sq-svtt` PRODUCT decision (Pages ROOT: Next.js showcase vs mdBook guide) as distinct from the resolved source flip — noting `docs.yml` ships no deploy job, so there is **no live deploy race** today.

## Scope / safety

- **Comment-only** change to `.github/workflows/pages.yml` — verified every changed line starts with `#`; zero semantic workflow change.
- YAML parses clean (`python3 -c "import yaml; yaml.safe_load(...)"`). No `actionlint` lane in-repo; the change cannot affect structure/expressions.
- No gate touched; gate aggregator unaffected (this leg does not add/remove a gating check). Path-filter unaffected (no Rust).

No auto-merge — comment-doc correction, leaving the merge call to the maintainer.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>