### PR TITLE
ci(publish): npm OIDC trusted publishing (no NPM_TOKEN) + pre-wire crates.io trusted-publishing flip (sq-v286.11) [OPUS-4.8]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,10 +7,14 @@
 #   - the `sparq-rdf` PyPI wheels (crates/sparq-py, maturin-built) — PEP-740 attestations
 #
 # HONEST SCOPE BOUNDARY (see compliance/slsa/):
-#   * npm     — native provenance. `npm publish --provenance` runs in this GitHub Actions
-#               OIDC context (id-token: write); npm's registry records a Sigstore-signed
-#               in-toto SLSA provenance statement bound to this workflow run. A consumer
-#               verifies it with `npm audit signatures`. THIS IS THE PROVENANCE-EMITTING PATH.
+#   * npm     — native provenance via OIDC TRUSTED PUBLISHING. [OPUS-4.8] sq-v286.11: the npm
+#               job authenticates with the GitHub Actions OIDC token (id-token: write) — NO
+#               long-lived NPM_TOKEN — exchanging it for a short-lived publish credential, and
+#               npm's registry records a Sigstore-signed in-toto SLSA provenance statement bound
+#               to this workflow run. A consumer verifies with `npm audit signatures`. THIS IS A
+#               PROVENANCE-EMITTING PATH. ONE-TIME needs:user: register the npm Trusted Publisher
+#               for @jeswr/sparq (owner `jeswr`, repo `sparq`, workflow file `publish.yml`); the
+#               package must already exist, so one bootstrap publish precedes it (see npm job).
 #   * crates.io — crates.io has NO published-package provenance mechanism upstream as of this
 #               writing (no equivalent of npm `--provenance`). The tractable equivalent we CAN
 #               do is attest the packaged `.crate` artifact (the exact bytes `cargo publish`
@@ -68,19 +72,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # ---- npm: @jeswr/sparq with native Sigstore provenance ----
-  # Runs only when a maintainer asks for it (manual input) OR on a published release where the
-  # NPM_TOKEN secret is configured. `npm publish --provenance` requires the OIDC token + a
-  # registry-url; npm then records a signed SLSA provenance statement for the version.
+  # ---- npm: @jeswr/sparq via OIDC TRUSTED PUBLISHING (no NPM_TOKEN) ----
+  # [OPUS-4.8] sq-v286.11 (maintainer #758): switched from a long-lived NPM_TOKEN to npm's
+  # OIDC Trusted Publishing (GA 2025-07-31, github.blog/changelog/2025-07-31). The npm CLI
+  # detects the GitHub Actions OIDC environment (granted by `id-token: write` below), exchanges
+  # the OIDC token with the registry for a short-lived publish credential, and records the
+  # Sigstore-signed SLSA provenance statement automatically — NO static token is read or stored.
+  # Runs only when a maintainer asks for it (manual input) OR on a published release.
+  #
+  # ONE-TIME needs:user step (cannot be a repo file — it is registry-side config): on npmjs.com,
+  # @jeswr/sparq must have a Trusted Publisher registered (npmjs.com/package/@jeswr/sparq/access
+  # -> "Trusted Publisher"): organization/user `jeswr`, repository `sparq`, workflow FILENAME
+  # `publish.yml` (filename only, with extension — NOT a path), environment left blank (this job
+  # uses none). npm trusted publishing requires the package to ALREADY EXIST, so the maintainer
+  # does ONE bootstrap `npm publish` with a granular token, then registers the trusted publisher
+  # and removes the token — every CI publish thereafter is tokenless. See docs/release.md.
   npm:
-    name: npm publish (--provenance)
+    name: npm publish (OIDC trusted publishing)
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && inputs.publish_npm)
     permissions:
       contents: read
-      id-token: write # OIDC token npm uses to mint the provenance attestation
+      id-token: write # OIDC token npm exchanges for a short-lived publish credential + provenance signing
     defaults:
       run:
         working-directory: js
@@ -92,8 +107,19 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-          # registry-url is REQUIRED for provenance + sets up the auth env for NODE_AUTH_TOKEN.
+          # registry-url is still REQUIRED: it writes the .npmrc `//registry.npmjs.org/:...`
+          # line the OIDC flow keys off (and selects the public registry the token is minted
+          # for). Under trusted publishing no NODE_AUTH_TOKEN is read — the npm CLI mints a
+          # short-lived credential from the OIDC token at publish time.
           registry-url: "https://registry.npmjs.org"
+      # [OPUS-4.8] sq-v286.11: OIDC trusted publishing requires npm CLI >= 11.5.1. Node 22's
+      # BUNDLED npm can be older (verified locally: Node 20/22 images have shipped npm 10.x),
+      # so pin an npm that supports trusted publishing rather than relying on the bundled one.
+      # `npm@^11.5.1` is the documented floor (docs.npmjs.com/trusted-publishers).
+      - name: Pin npm CLI >= 11.5.1 (trusted-publishing floor)
+        run: |
+          npm install -g 'npm@^11.5.1'
+          npm --version
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked
       - name: Install npm dependencies
@@ -104,14 +130,16 @@ jobs:
       - name: Package guardrail check
         run: npm run check:package
       # `prepack` (build:wasm + build:ts + bundle skills) runs automatically on `npm publish`,
-      # producing the same tree `npm pack --dry-run` validates in js.yml. We require a modern npm
-      # (>=11.5.1 ships with node 22) so --provenance is supported.
-      - name: Publish to npm with provenance
-        # provenance: emit the Sigstore-signed SLSA build-provenance statement bound to this run.
-        # access public: @jeswr/sparq is a scoped package; scoped packages default to restricted.
+      # producing the same tree `npm pack --dry-run` validates in js.yml.
+      - name: Publish to npm (OIDC trusted publishing + provenance)
+        # NO `env: NODE_AUTH_TOKEN` — trusted publishing authenticates via the GitHub Actions
+        # OIDC token (id-token: write). The npm CLI detects the OIDC environment and exchanges
+        # it for a short-lived publish credential; no long-lived NPM_TOKEN is stored anywhere.
+        # --provenance: provenance is emitted by default under trusted publishing, but the flag
+        #   is kept as an explicit belt-and-suspenders (a practitioner-reported edge case where
+        #   it was not auto-attached); it is a no-op when already on.
+        # --access public: @jeswr/sparq is a scoped package; scoped packages default to restricted.
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       # Verify the just-published version actually carries a registry provenance attestation, so a
       # misconfigured publish (missing OIDC / old npm) fails the job instead of silently shipping an
       # unattested package. `npm view <pkg>@<ver> dist.attestations` returns the registry-recorded

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -104,6 +104,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # create + push the v<version> git tag
+      # [OPUS-4.8] sq-v286.11 — crates.io TRUSTED-PUBLISHING FLIP (step b of release-plz.toml's
+      # `publish` note). UNCOMMENT the next line together with the auth-action step + the
+      # CARGO_REGISTRY_TOKEN env below, and set `publish = true` in release-plz.toml:
+      # id-token: write  # OIDC token crates-io-auth-action exchanges for a short-lived crates.io token
     steps:
       - name: Checkout (full history for tag detection)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -112,16 +116,26 @@ jobs:
           persist-credentials: false
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # [OPUS-4.8] sq-v286.11 — crates.io TRUSTED-PUBLISHING FLIP (continued). When flipping
+      # `publish = true`, release-plz runs `cargo publish` BEFORE tagging and needs a crates.io
+      # credential in CARGO_REGISTRY_TOKEN. crates.io Trusted Publishing (GA 2025-07, RFC 3691)
+      # supplies a SHORT-LIVED token via OIDC — no long-lived secret. UNCOMMENT this step (it
+      # must run BEFORE the release-plz step) and wire its `token` output into the env below:
+      #   - name: Mint short-lived crates.io token (OIDC trusted publishing)
+      #     id: cratesio-auth
+      #     uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
       # [OPUS-4.8] sq-v286.4: `release` command. With `publish = false` +
       # `git_release_enable = false` in release-plz.toml, this creates ONLY the v<version>
-      # git tag — it skips cargo publish (needs:user token, sq-v286.5) and skips its own
-      # GitHub Release (release.yml owns that). The pushed tag then triggers release.yml.
+      # git tag — it skips cargo publish and skips its own GitHub Release (release.yml owns
+      # that). The pushed tag then triggers release.yml.
       - name: Run release-plz (create v<version> tag on version commit)
         uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
         with:
           command: release
         env:
-          # Tagging is a forge operation done with GITHUB_TOKEN. No CARGO_REGISTRY_TOKEN is
-          # passed because crates.io publish is disabled (publish = false) until the
-          # needs:user token lands (sq-v286.5).
+          # Tagging is a forge operation done with GITHUB_TOKEN.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # [OPUS-4.8] sq-v286.11 — crates.io TRUSTED-PUBLISHING FLIP (step b, continued). With
+          # `publish = false`, no crates.io credential is passed (publish is skipped, only the
+          # tag is cut). To flip, UNCOMMENT the auth-action step above + this line:
+          # CARGO_REGISTRY_TOKEN: ${{ steps.cratesio-auth.outputs.token }}

--- a/docs/release.md
+++ b/docs/release.md
@@ -200,10 +200,18 @@ cargo publish -p sparq-server
 >   (external — see `compliance/openssf/gap-register.md` GX-OSSF-2 / `compliance/gap-register.md`
 >   GX-10). Do **not** describe a crates.io publish as "signed".
 > - **npm `@jeswr/sparq` — native Sigstore provenance** via [`publish.yml`](../.github/workflows/publish.yml)'s
->   `npm` job (`npm publish --provenance` in the GitHub OIDC context); consumers verify with
->   `npm audit signatures`.
+>   `npm` job. [OPUS-4.8] sq-v286.11: the job now authenticates with **OIDC trusted publishing**
+>   (no `NPM_TOKEN`) — npm exchanges the GitHub Actions OIDC token for a short-lived publish
+>   credential and records the Sigstore-signed provenance automatically; consumers verify with
+>   `npm audit signatures`. See §8 for the one-time Trusted-Publisher registration.
 > - **PyPI `sparq-rdf` — native PEP-740 attestations** via Trusted Publishing (see the
->   "Python wheels" section below) once the maintainer registers the Trusted Publisher.
+>   "Python wheels" section below + §8) once the maintainer registers the Trusted Publisher.
+>
+> [OPUS-4.8] sq-v286.11: **crates.io Trusted Publishing** (GA 2025-07, RFC 3691) is now available
+> as an *authentication* mechanism (a short-lived OIDC token via `rust-lang/crates-io-auth-action`,
+> in place of a long-lived `CARGO_REGISTRY_TOKEN`). It is **not** a provenance/signing scheme — it
+> does **not** put a provenance link on the crates.io page — so the "do not describe a crates.io
+> publish as signed" caveat above is unchanged. The CI side of the auth flip is pre-wired (§8).
 
 ## 5. Docker (manual / local)
 
@@ -281,3 +289,73 @@ informationally on pushes to main (`.github/workflows/python.yml`); release publ
 > fails to mint an OIDC token (no static API token is stored). Once registered, every published
 > release emits native PyPI provenance (the "Provenance" panel on the release-files page;
 > consumers verify with `pypi-attestations verify` / `gh attestation verify`).
+
+<!-- [OPUS-4.8] sq-v286.11 (maintainer #758): CI publishing via OIDC trusted publishing. -->
+## 8. CI publishing — OIDC trusted publishers (the one-time `needs:user` registry-side steps)
+
+[OPUS-4.8] sq-v286.11 (maintainer #758): "publishing via CI with semantic release, using trusted
+OIDC publishing for npm, and whatever the best practices are for the python ecosystem." The repo
+holds only the **workflows**; each registry's **trust config is a one-time maintainer action** in
+that registry's web UI (it cannot live in a repo file — that is the whole point of OIDC: the
+registry, not a stored secret, decides which workflow it trusts). All three legs use the GitHub
+Actions OIDC token (`id-token: write`); **no long-lived `NPM_TOKEN` / `CARGO_REGISTRY_TOKEN` is
+stored**. Honest bootstrap note: **npm and crates.io require the package/crate to already exist**
+(register the trusted publisher *after* one manual bootstrap publish); **PyPI supports a *pending*
+publisher** so the very first publish can be trusted-publishing too.
+
+### 8a. npm `@jeswr/sparq` — WIRED (`publish.yml` `npm` job)
+
+The `npm` job authenticates entirely via OIDC trusted publishing (no `NODE_AUTH_TOKEN`). It pins
+`npm@^11.5.1` (the trusted-publishing CLI floor — Node 22's bundled npm can be older) and keeps
+`--provenance --access public`.
+
+**needs:user (npmjs.com):** `@jeswr/sparq` must already exist on npm, so:
+1. ONE bootstrap publish with a short-lived **granular** access token (delete the token after).
+2. npmjs.com → `@jeswr/sparq` → **Settings → Trusted Publisher** → *GitHub Actions*:
+   - Organization or user: **`jeswr`**
+   - Repository: **`sparq`**
+   - Workflow filename: **`publish.yml`** (filename only, with extension — **not** a path)
+   - Environment: **leave blank** (the `npm` job uses no GitHub Environment)
+   - Allowed actions: **`npm publish`**
+
+Every subsequent CI publish is tokenless and provenance-bearing (`npm audit signatures`).
+
+### 8b. PyPI `sparq-rdf` — WIRED (`publish.yml` `pypi-publish` job)
+
+Already implemented to current best practice: `pypa/gh-action-pypi-publish` with `attestations: true`
++ OIDC `id-token: write` + GitHub `environment: pypi`, no API token. Emits native PEP-740 provenance.
+
+**needs:user (pypi.org):** PyPI → (project `sparq-rdf` if it exists, else *Your projects → Publishing*
+for a **pending** publisher) → **Add a new publisher** → *GitHub*:
+   - PyPI Project Name: **`sparq-rdf`**
+   - Owner: **`jeswr`**, Repository: **`sparq`**
+   - Workflow name: **`publish.yml`**
+   - Environment: **`pypi`** (matches the `pypi-publish` job's `environment:`)
+
+Because PyPI allows a *pending* publisher, no manual bootstrap upload is required.
+
+### 8c. crates.io (17 crates) — CI side PRE-WIRED, flip is one config change (`release-plz.yml` + `release-plz.toml`)
+
+crates.io Trusted Publishing (GA 2025-07, RFC 3691) supplies a short-lived OIDC token via
+`rust-lang/crates-io-auth-action` — no `CARGO_REGISTRY_TOKEN`. The CI side is pre-wired as a
+commented block on `release-plz.yml`'s `release-plz-release` job; `release-plz.toml` keeps
+`publish = false` until the trust config exists (so a `publish=true` with no credential can't break
+tag-cutting). This is the "config-flip" the design record (§6 item 4) calls "the point of adoption".
+
+**needs:user (crates.io), per the 17 publishable crates (`docs/release.md` §4 DAG), leaf-first:**
+1. ONE bootstrap `cargo publish` per crate (crates.io requires each crate to already exist).
+2. For **each** crate: crates.io → crate → **Settings → Trusted Publishing → Add** → *GitHub*:
+   - Repository owner: **`jeswr`**, Repository name: **`sparq`**
+   - Workflow filename: **`release-plz.yml`**
+   - Environment: **leave blank** (the `release-plz-release` job uses no GitHub Environment)
+
+**Then flip (three coordinated edits):**
+- `release-plz.yml`: uncomment `id-token: write`, the `rust-lang/crates-io-auth-action` step
+  (SHA-pinned `c6f97d4…` # v1.0.5), and the `CARGO_REGISTRY_TOKEN: ${{ steps.cratesio-auth.outputs.token }}` env.
+- `release-plz.toml`: set `publish = true`.
+- `publish.yml`'s `crates` job then reverts to attest-only over the `.crate` bytes (release-plz
+  becomes the publisher; the out-of-band attestation stays as the verifiable-bytes evidence).
+
+> Provenance honesty: crates.io trusted publishing is an **auth** mechanism only — it does **not**
+> put a provenance link on the crates.io page (no upstream scheme exists, unlike npm/PyPI). The
+> "do not describe a crates.io publish as signed" caveat in §4 is unchanged.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -52,12 +52,23 @@ git_tag_name = "v{{ version }}"
 #   the same tag → a collision (duplicate/empty release racing release.yml). Disable it:
 #   release-plz creates the tag, release.yml owns the Release.
 git_release_enable = false
-# publish = false — crates.io publish stays MANUAL for now. The `CARGO_REGISTRY_TOKEN`
-#   secret does not exist yet (needs:user bead sq-v286.5). release-plz runs `cargo publish`
-#   BEFORE creating the tag, so with the default `true` and no token the publish step would
-#   fail and the tag would never be cut. Disabling publish lets `release-plz release`
-#   skip straight to tagging. Flip to `true` (release-plz-driven publish, publish.yml then
-#   only attests .crate bytes) once sq-v286.5 provisions the token — "the point of adoption".
+# publish = false — crates.io publish stays MANUAL for now. release-plz runs `cargo publish`
+#   BEFORE creating the tag, so with the default `true` and no working credential the publish
+#   step would fail and the tag would never be cut. Disabling publish lets `release-plz release`
+#   skip straight to tagging.
+#
+#   [OPUS-4.8] sq-v286.11: the crates.io FLIP is now a coordinated config-flip (no long-lived
+#   token needed — crates.io Trusted Publishing went GA 2025-07, RFC 3691). The CI side is
+#   pre-wired in .github/workflows/release-plz.yml (a commented `crates-io-auth-action` OIDC
+#   block on the `release-plz-release` job). To flip:
+#     (a) needs:user — register the crates.io Trusted Publisher for EACH of the 17 publishable
+#         crates (owner `jeswr`, repo `sparq`, workflow `release-plz.yml`); crates.io requires
+#         each crate to ALREADY EXIST (one bootstrap `cargo publish` per crate, leaf-first per
+#         docs/release.md §4), then enable trusted publishing on each crate's Settings page;
+#     (b) uncomment the auth-action block + its `id-token: write` permission in release-plz.yml;
+#     (c) set this key to `true`.
+#   release-plz then publishes in dep order with the short-lived OIDC token, and publish.yml's
+#   `crates` job reverts to attest-only over the .crate bytes — "the point of adoption".
 publish = false
 
 # --- The locked version_group: all 17 publishable crates ---------------------


### PR DESCRIPTION
> 🤖 **SPARQ agent** (CI/release/supply-chain). Opus-4.8. Bead **sq-v286.11** (child of sq-v286, maintainer #758: *"publishing via CI with semantic release, using trusted OIDC publishing for npm, and whatever the best practices are for the python ecosystem"*). Review-queue PR — **no auto-merge**.

## What this wires

**npm — OIDC trusted publishing (no `NPM_TOKEN`).** `publish.yml`'s `npm` job switches `@jeswr/sparq` from a long-lived `NPM_TOKEN`/`NODE_AUTH_TOKEN` to npm **OIDC Trusted Publishing** (GA 2025-07-31). The `env: NODE_AUTH_TOKEN` block is removed; the npm CLI exchanges the GitHub Actions OIDC token (`id-token: write`) for a short-lived publish credential and records Sigstore SLSA provenance automatically. Adds an explicit **`npm install -g 'npm@^11.5.1'`** step (the trusted-publishing CLI floor — Node 22's *bundled* npm can be older; verified locally: this box ships npm 10.8.2). Keeps `--provenance --access public` and the post-publish `npm audit signatures` verification.

**PyPI — already at best practice (no change).** `publish.yml`'s `pypi-publish` job already uses `pypa/gh-action-pypi-publish` with `attestations: true` + OIDC `id-token: write` + GitHub `environment: pypi`, **no API token** → native PEP-740 attestations. There IS a Python package (`sparq-rdf` via `crates/sparq-py`), so this leg is **not** a no-op/placeholder — it is the strongest of the three and required only the doc consolidation below.

**crates.io — CI side pre-wired; the flip is one config change.** crates.io Trusted Publishing (GA 2025-07, RFC 3691) means **no long-lived `CARGO_REGISTRY_TOKEN`** either. `release-plz.yml`'s `release-plz-release` job carries a commented, ready-to-uncomment block: `id-token: write`, SHA-pinned `rust-lang/crates-io-auth-action@c6f97d4 # v1.0.5`, and `CARGO_REGISTRY_TOKEN: ${{ steps.cratesio-auth.outputs.token }}`. `release-plz.toml` keeps `publish = false` (so a premature `publish=true` with no credential can't break tag-cutting); flipping is: register the trusted publishers → uncomment the block → set `publish = true`.

**docs/release.md §8** documents the exact one-time **needs:user** registry-side trusted-publisher setup for all three registries.

## needs:user — one-time registry-side trusted-publisher config (cannot be a repo file)

- **npm** (npmjs.com → `@jeswr/sparq` → Settings → Trusted Publisher → GitHub Actions): org/user `jeswr`, repo `sparq`, workflow filename `publish.yml` (filename only, with extension), environment **blank**, allowed action `npm publish`. Package must already exist → one bootstrap publish with a granular token first.
- **PyPI** (pypi.org → project `sparq-rdf` or *pending* publisher → Add → GitHub): project `sparq-rdf`, owner `jeswr`, repo `sparq`, workflow `publish.yml`, environment `pypi`. PyPI supports a **pending** publisher → no bootstrap upload needed.
- **crates.io** (per the 17 publishable crates, leaf-first per docs/release.md §4 → crate → Settings → Trusted Publishing → Add → GitHub): owner `jeswr`, repo `sparq`, workflow `release-plz.yml`, environment **blank**. Each crate must already exist → one bootstrap `cargo publish` per crate first.

## Gates (hand-verified — these workflows are tag/release-triggered, never run on a PR)

- **YAML valid** — `yaml.safe_load` OK on both workflows; `release-plz.toml` parses with **17** `[[package]]` entries intact.
- **actionlint 1.7.7** — clean (exit 0) on both workflows.
- **typos** — clean (exit 0) on all four touched files; no banned tokens.
- **SHA-pins** — all `uses:` are full-SHA + `# vX.Y.Z` comment, incl. the new `crates-io-auth-action@c6f97d4` (peeled from the v1.0.5 lightweight tag). `id-token: write` scoped minimally per job.
- **No secrets hardcoded**; the only `NPM_TOKEN`/`NODE_AUTH_TOKEN` strings remaining are in comments explaining the removal.
- **Triggers**: `publish.yml` = `release: published` + `workflow_dispatch`; `release-plz.yml` = `push: main`. Neither registers on a PR ref → **`ci-summary / gate` aggregator unaffected**, no new gating leg.

## Local reproduction
- `npm@^11.5.1` resolves → npm 11.17.0 (> floor) — the pin step works.
- `npm publish --provenance --access public --dry-run` parses the flags and runs `prepack` (wasm-pack builds OK); fails only at `tsc` (no local `npm ci`) — an environment artifact, not a flag/auth defect. CI runs `npm ci` first.
- crates publish itself is **documented-untested** (needs the registry-side trusted publisher + OIDC runner context) — validate on first CI run.

## Compliance gap closed (honest level)
Removes the last long-lived publish secret from the npm path → **tokenless OIDC trusted publishing** on npm (provenance-emitting) and PyPI (PEP-740). crates.io is auth-only via OIDC once flipped — it does **not** put a provenance link on the crates.io page (no upstream scheme); the "do not describe a crates.io publish as signed" caveat is unchanged. Maps to SLSA Build L2 posture as configured + the Scorecard token-permissions / signed-releases controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)