### PR TITLE
fix(sparq-fedclient): strict exact-token parse_ask_boolean (sq-2gfe) [OPUS-4.8]

### DIFF
--- a/crates/sparq-fedclient/README.md
+++ b/crates/sparq-fedclient/README.md
@@ -22,12 +22,6 @@ Design: [`research/federation-client-design.md`](../../research/federation-clien
 Planner it reuses: [`skills/federated-planning/SKILL.md`](../../skills/federated-planning/SKILL.md).
 Contributing: [`AGENTS.md`](../../AGENTS.md).
 
-Capability discovery prefers a published Service Description and falls back to a FedX-style
-`ASK { ?s ?p ?o }` reachability probe; the probe's SPARQL-Results-JSON answer is parsed
-**strictly** — the `boolean` value must be an exact lowercase JSON `true`/`false` literal at a
-value boundary, so a junk-suffixed token (`trueish` / `falsex`) is rejected, not silently read
-as a boolean (sq-2gfe).
-
 Correctness suite under `tests/` (gated on the `fedclient` feature; the default build compiles it to nothing) — run on the REAL path, with local `sparq-engine` evaluation as the canonical answer: result-equivalence (planner / streaming / multi-source UNION / adaptive vs. static), fail-closed wire & error paths (SRJ decode, brTPF binary codec, interpreter), discovery + source-adapter error paths (incl. the SSRF egress guard), and the one-way `sparq-core`/`sparq-engine` dependency boundary.
 
 ## License

--- a/crates/sparq-fedclient/README.md
+++ b/crates/sparq-fedclient/README.md
@@ -22,6 +22,12 @@ Design: [`research/federation-client-design.md`](../../research/federation-clien
 Planner it reuses: [`skills/federated-planning/SKILL.md`](../../skills/federated-planning/SKILL.md).
 Contributing: [`AGENTS.md`](../../AGENTS.md).
 
+Capability discovery prefers a published Service Description and falls back to a FedX-style
+`ASK { ?s ?p ?o }` reachability probe; the probe's SPARQL-Results-JSON answer is parsed
+**strictly** — the `boolean` value must be an exact lowercase JSON `true`/`false` literal at a
+value boundary, so a junk-suffixed token (`trueish` / `falsex`) is rejected, not silently read
+as a boolean (sq-2gfe).
+
 Correctness suite under `tests/` (gated on the `fedclient` feature; the default build compiles it to nothing) — run on the REAL path, with local `sparq-engine` evaluation as the canonical answer: result-equivalence (planner / streaming / multi-source UNION / adaptive vs. static), fail-closed wire & error paths (SRJ decode, brTPF binary codec, interpreter), discovery + source-adapter error paths (incl. the SSRF egress guard), and the one-way `sparq-core`/`sparq-engine` dependency boundary.
 
 ## License

--- a/crates/sparq-fedclient/src/discovery.rs
+++ b/crates/sparq-fedclient/src/discovery.rs
@@ -690,7 +690,13 @@ fn ask_probe(endpoint: &str, fetcher: &dyn Fetcher) -> Result<bool, String> {
 }
 
 /// Extracts the `boolean` field from a SPARQL-Results-JSON ASK response. Deliberately a tiny
-/// tolerant scan rather than a JSON dependency — the only shape we need is `"boolean": true`.
+/// scan rather than a JSON dependency — the only shape we need is `"boolean": true|false`.
+///
+/// The match is STRICT: the value must be an exact lowercase JSON `true`/`false` literal whose
+/// next character is a value boundary (end-of-input, ASCII whitespace, or a JSON structural
+/// `,` / `}` / `]`). This rejects junk-suffixed tokens like `trueish` / `falsex` / `truex`
+/// that a `starts_with` scan would silently read as a boolean (per the SPARQL 1.1 Query
+/// Results JSON format, the value of `boolean` is a JSON boolean — lowercase, case-sensitive).
 fn parse_ask_boolean(body: &str) -> Result<bool, String> {
     // Find the "boolean" key and read the following true/false token.
     let key = body
@@ -702,12 +708,20 @@ fn parse_ask_boolean(body: &str) -> Result<bool, String> {
         .strip_prefix(':')
         .ok_or_else(|| "discovery: malformed ASK response (no ':' after \"boolean\")".to_string())?
         .trim_start();
-    if after.starts_with("true") {
+    // A literal ends at a JSON value boundary: end-of-input, ASCII whitespace, or a structural
+    // delimiter. `trueish` etc. fail this because the next char (`i`) is none of those.
+    let bounded = |rest: &str| {
+        rest.chars()
+            .next()
+            .map(|c| c.is_ascii_whitespace() || matches!(c, ',' | '}' | ']'))
+            .unwrap_or(true)
+    };
+    if after.strip_prefix("true").is_some_and(bounded) {
         Ok(true)
-    } else if after.starts_with("false") {
+    } else if after.strip_prefix("false").is_some_and(bounded) {
         Ok(false)
     } else {
-        Err("discovery: ASK response \"boolean\" was neither true nor false".to_string())
+        Err("discovery: ASK response \"boolean\" was not an exact JSON true/false".to_string())
     }
 }
 
@@ -927,10 +941,51 @@ _:c1 <http://rdfs.org/ns/void#entities> "100"^^<http://www.w3.org/2001/XMLSchema
 
     #[test]
     fn ask_boolean_parsing() {
+        // Legitimate SPARQL-Results-JSON ASK shapes the function already handled — still parse.
         assert!(parse_ask_boolean(r#"{"boolean": true}"#).unwrap());
         assert!(!parse_ask_boolean(r#"{"boolean":false}"#).unwrap());
         assert!(parse_ask_boolean(r#"{ "head": {}, "boolean" : true }"#).unwrap());
         assert!(parse_ask_boolean(r#"{"results":{}}"#).is_err());
+    }
+
+    #[test]
+    fn ask_boolean_strict_exact_token() {
+        // ACCEPT: every JSON value boundary after the exact literal — `}`, `,`, `]`, whitespace,
+        // and end-of-input — for both true and false.
+        assert!(parse_ask_boolean(r#"{"boolean":true}"#).unwrap());
+        assert!(parse_ask_boolean(r#"{"boolean":true,"x":1}"#).unwrap());
+        assert!(parse_ask_boolean(r#"{"head":{},"boolean":true ,"more":0}"#).unwrap());
+        assert!(parse_ask_boolean("\"boolean\": true").unwrap()); // EOF boundary
+        assert!(parse_ask_boolean("\"boolean\":true\n").unwrap()); // newline boundary
+        assert!(parse_ask_boolean(r#"{"a":["boolean":true]}"#).unwrap()); // `]` boundary
+        assert!(!parse_ask_boolean(r#"{"boolean":false}"#).unwrap());
+        assert!(!parse_ask_boolean(r#"{"boolean": false , "x":1}"#).unwrap());
+        assert!(!parse_ask_boolean("\"boolean\":false").unwrap()); // EOF boundary
+
+        // REJECT: junk-suffixed tokens the old `starts_with` scan silently accepted. THIS is the
+        // sq-2gfe regression guard — `trueish` must NOT be read as `true`.
+        assert!(parse_ask_boolean(r#"{"boolean": trueish}"#).is_err());
+        assert!(parse_ask_boolean(r#"{"boolean": falsey}"#).is_err());
+        assert!(parse_ask_boolean(r#"{"boolean": truex}"#).is_err());
+        assert!(parse_ask_boolean(r#"{"boolean": falsex}"#).is_err());
+        assert!(parse_ask_boolean(r#"{"boolean": true_}"#).is_err()); // `_` is not a boundary
+
+        // REJECT: truncated / empty / malformed values (a prefix that is not the exact literal).
+        assert!(parse_ask_boolean(r#"{"boolean": tr}"#).is_err());
+        assert!(parse_ask_boolean(r#"{"boolean": fal}"#).is_err());
+        assert!(parse_ask_boolean(r#"{"boolean":}"#).is_err());
+        assert!(parse_ask_boolean(r#"{"boolean": }"#).is_err());
+        assert!(parse_ask_boolean(r#"{"boolean"}"#).is_err()); // no ':' after key
+        assert!(parse_ask_boolean("").is_err()); // empty body
+        assert!(parse_ask_boolean("   ").is_err()); // whitespace-only
+
+        // REJECT: wrong case (JSON booleans are lowercase; the SPARQL spec inherits this).
+        assert!(parse_ask_boolean(r#"{"boolean": True}"#).is_err());
+        assert!(parse_ask_boolean(r#"{"boolean": FALSE}"#).is_err());
+
+        // REJECT: wrong JSON type for `boolean` (string / number).
+        assert!(parse_ask_boolean(r#"{"boolean": "true"}"#).is_err());
+        assert!(parse_ask_boolean(r#"{"boolean": 1}"#).is_err());
     }
 
     // ---- well-known VoID URL derivation --------------------------------------------

--- a/crates/sparq-fedclient/tests/discovery_error_paths.rs
+++ b/crates/sparq-fedclient/tests/discovery_error_paths.rs
@@ -16,9 +16,9 @@
 //!  * the VoID best-effort branch: a **malformed VoID** is silently ignored (descriptor stays
 //!    `None`), not fatal;
 //!  * [`well_known_void_url`] over query-string / fragment / IPv6-authority / no-path endpoints;
-//!  * the `parse_ask_boolean` behaviour through `discover` (the tolerant scanner accepts a
-//!    `true`/`false` token), and the [`Capability::ask_fallback`] / [`MediaType`] units the
-//!    round-trip exercises only implicitly.
+//!  * the `parse_ask_boolean` behaviour through `discover` (the strict scanner accepts only an
+//!    exact JSON `true`/`false` literal at a value boundary; sq-2gfe), and the
+//!    [`Capability::ask_fallback`] / [`MediaType`] units the round-trip exercises only implicitly.
 //!
 //! Gated on `fedclient`; the default build compiles this file to nothing.
 //!


### PR DESCRIPTION
> 🤖 SPARQ agent — bead sq-2gfe.

## What

`parse_ask_boolean` in `crates/sparq-fedclient/src/discovery.rs` is the parser for the SPARQL-Results-JSON body returned by the FedX-style `ASK { ?s ?p ?o }` reachability probe — a private helper reached only via `discover()`'s ASK-probe fallback (no Service Description published). It used a **tolerant** `starts_with("true")` / `starts_with("false")` scan that accepted ANY token *starting with* the literal, so a body like `{"boolean": trueish}` was silently read as `true`.

Low risk in practice (private helper; the body comes from an already-reachable server), but a strict exact-token check is more defensive — that is this fix.

## Before / after acceptance

| `boolean` value | before (`starts_with`) | after (strict) |
| --- | --- | --- |
| `true` / `false` (at a `}`/`,`/`]`/ws / EOF boundary) | accept | **accept** |
| `trueish` / `falsey` / `truex` / `falsex` / `true_` | **accepted as bool** ❌ | reject (error) ✅ |
| truncated `tr` / `fal` | reject | reject |
| `True` / `FALSE` (wrong case) | reject | reject |
| `"true"` (string) / `1` (number) | reject | reject |
| empty / whitespace-only / missing `:` / missing key | reject | reject |

After: the value must be an **exact lowercase JSON `true`/`false` literal whose next character is a JSON value boundary** — end-of-input, ASCII whitespace, or a structural `,` / `}` / `]` (per the SPARQL 1.1 Query Results JSON format, the value of `boolean` is a JSON boolean — lowercase, case-sensitive). No new dependencies: still a tiny hand scan, not a JSON crate — core stays lean.

## Test matrix

New inline unit test `discovery::tests::ask_boolean_strict_exact_token` covers, against the REAL `parse_ask_boolean`:

- **ACCEPT** — `true`/`false` at every boundary: `}`, `,`, `]`, whitespace, newline, and end-of-input (both values).
- **REJECT (the sq-2gfe guard)** — `trueish`, `falsey`, `truex`, `falsex`, `true_`.
- **REJECT (truncated / malformed)** — `tr`, `fal`, `{"boolean":}`, `{"boolean": }`, `{"boolean"}` (no `:`), `""` (empty), whitespace-only.
- **REJECT (wrong case)** — `True`, `FALSE`.
- **REJECT (wrong JSON type)** — `"true"` (string), `1` (number).

The pre-existing `ask_boolean_parsing` test plus the discovery orchestration paths (`ask_probe_negative_boolean_still_reachable`, `discover_ask_false_still_proves_reachability`, `discover_ask_response_without_boolean_is_unreachable`) confirm the legitimate ASK-result paths still parse. The stale "tolerant scanner" doc note in `tests/discovery_error_paths.rs` was reworded to "strict scanner".

## Honest scoping

The function is **JSON-only by design** — it locates the `"boolean"` key of the SPARQL 1.1 Query Results JSON format. It does **not** handle the XML or CSV ASK result forms (the bead text mentioned them, but this helper never parsed them — `ask_probe` requests only `application/sparql-results+json`), so no XML/CSV path was touched or left tolerant.

## Gates (both feature states)

- Default (feature OFF): `cargo build` / `cargo clippy --all-targets -D warnings` / `cargo test -p sparq-fedclient` — green (the whole `discovery` module is `#[cfg(feature = "fedclient")]`-gated, so it compiles to nothing here; 0 tests).
- Feature ON (`--features fedclient`, the REAL path): `cargo build` / `cargo clippy --all-targets -D warnings` / `cargo test -p sparq-fedclient --features fedclient` — green (125 lib tests incl. the two ASK-boolean tests, all integration suites pass).
- Also verified `cargo clippy --features fedclient-adaptive --all-targets -D warnings` — green.
- `typos` clean on all three changed files.

Discovered in #785 / sq-bif.2.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>