### PR TITLE
feat(gui): dataset panel — named-graph list with per-graph triple counts (sq-daru) [OPUS-4.8]

### DIFF
--- a/site/src/components/repl-dataset-panel.tsx
+++ b/site/src/components/repl-dataset-panel.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+// [OPUS-4.8] sq-daru — GUI MVP item 3: the dataset panel.
+//
+// Lists the loaded dataset's graphs — the DEFAULT graph plus every NAMED graph — each
+// with its triple count, so a user can see at a glance how the data is partitioned. This
+// is the live SPARQL REPL's dataset overview; it sits under the dataset-source controls
+// and refreshes whenever the store changes (a new dataset is loaded, or an in-tab Update
+// mutates it — the parent bumps `refreshKey`).
+//
+// HONESTY: every number here is the engine's OWN count, read live from the in-tab WASM
+// store via two queries it already supports (no new Store API, no baked-in figure):
+//   • NAMED_GRAPH_STATS_QUERY  — `GROUP BY ?g` over `GRAPH ?g { ?s ?p ?o }`
+//   • DEFAULT_GRAPH_COUNT_QUERY — `SELECT (COUNT(*) AS ?c) WHERE { ?s ?p ?o }`
+// The pure `parseGraphStats` helper (in `@/lib/repl-dataset`) turns the two SPARQL-JSON
+// documents into the typed rows rendered below, so this component is just the React host.
+// On desktop the Tauri webview renders the SAME component against the SAME query results
+// (its native engine answers `query` identically — see gui/src-tauri/src/engine.rs).
+
+import * as React from "react";
+import { Layers, Globe, FileBox, Loader2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { WasmStore, SparqlResults } from "@/lib/sparq-wasm";
+import {
+  NAMED_GRAPH_STATS_QUERY,
+  DEFAULT_GRAPH_COUNT_QUERY,
+  parseGraphStats,
+  type GraphStat,
+} from "@/lib/repl-dataset";
+
+export interface DatasetPanelProps {
+  /** The live in-tab WASM store, or `null` while the engine is still cold. */
+  store: WasmStore | null;
+  /** Bumped by the parent whenever the dataset changes (load / merge / Update), so the
+   *  panel re-reads the per-graph counts. */
+  refreshKey: number;
+  /** Hide the panel entirely (e.g. endpoint mode owns its own dataset remotely). */
+  hidden?: boolean;
+}
+
+type PanelState =
+  | { kind: "loading" }
+  | { kind: "ready"; stats: GraphStat[] }
+  | { kind: "error"; message: string };
+
+/**
+ * The dataset panel: a labelled list of the loaded dataset's graphs with per-graph
+ * triple counts. The default graph is always shown (even when empty); named graphs
+ * follow in IRI order. Re-queries whenever the store or `refreshKey` changes.
+ */
+export function DatasetPanel({ store, refreshKey, hidden }: DatasetPanelProps) {
+  const [state, setState] = React.useState<PanelState>({ kind: "loading" });
+
+  React.useEffect(() => {
+    if (!store) {
+      setState({ kind: "loading" });
+      return;
+    }
+    try {
+      const namedJson = JSON.parse(
+        store.query(NAMED_GRAPH_STATS_QUERY),
+      ) as SparqlResults;
+      const defaultJson = JSON.parse(
+        store.query(DEFAULT_GRAPH_COUNT_QUERY),
+      ) as SparqlResults;
+      setState({ kind: "ready", stats: parseGraphStats(defaultJson, namedJson) });
+    } catch (e) {
+      setState({ kind: "error", message: e instanceof Error ? e.message : String(e) });
+    }
+  }, [store, refreshKey]);
+
+  if (hidden) return null;
+
+  const namedCount =
+    state.kind === "ready" ? state.stats.filter((s) => !s.isDefault).length : 0;
+
+  return (
+    <section
+      aria-label="Dataset graphs"
+      data-testid="dataset-panel"
+      className="rounded-lg border bg-muted/30 p-2"
+    >
+      <div className="flex items-center gap-1.5 px-1 pb-1.5 text-xs font-medium text-muted-foreground">
+        <Layers className="size-3.5" aria-hidden="true" />
+        Graphs
+        {state.kind === "ready" && (
+          <span className="text-[11px] font-normal">
+            {/* The default graph is always present; show how many NAMED graphs alongside. */}
+            ({namedCount === 0
+              ? "default graph only"
+              : `${namedCount} named ${namedCount === 1 ? "graph" : "graphs"} + default`}
+            )
+          </span>
+        )}
+      </div>
+
+      {state.kind === "loading" ? (
+        <p className="flex items-center gap-1.5 px-1 py-1 text-xs text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" aria-hidden="true" /> Reading graphs…
+        </p>
+      ) : state.kind === "error" ? (
+        <p className="px-1 py-1 text-xs text-destructive">{state.message}</p>
+      ) : (
+        <ul className="space-y-1">
+          {state.stats.map((g) => (
+            <GraphRow key={g.isDefault ? "__default__" : (g.iri as string)} stat={g} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+/** One graph row: an icon + label (the default graph labelled clearly, or the named
+ *  graph's IRI) and a triple-count badge. The IRI truncates with a full-text title so a
+ *  long IRI never breaks the layout but stays inspectable on hover. */
+function GraphRow({ stat }: { stat: GraphStat }) {
+  const label = stat.isDefault ? "Default graph" : stat.iri;
+  const Icon = stat.isDefault ? Globe : FileBox;
+  return (
+    <li className="flex items-center gap-2 rounded-md bg-background/60 px-2 py-1">
+      <Icon
+        className={cn(
+          "size-3.5 shrink-0",
+          stat.isDefault ? "text-primary" : "text-muted-foreground",
+        )}
+        aria-hidden="true"
+      />
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate text-xs",
+          stat.isDefault ? "font-medium" : "font-mono text-[11.5px]",
+        )}
+        title={stat.isDefault ? "The default (unnamed) graph" : (stat.iri as string)}
+      >
+        {label}
+      </span>
+      <Badge variant="muted" className="tabular shrink-0 text-[11px]">
+        {stat.count} {stat.count === 1 ? "triple" : "triples"}
+      </Badge>
+    </li>
+  );
+}

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -50,6 +50,8 @@ import {
   DatasetViewer,
   type ActiveDataset,
 } from "@/components/repl-datasets";
+// [OPUS-4.8] sq-daru — the dataset panel: named-graph list with per-graph triple counts.
+import { DatasetPanel } from "@/components/repl-dataset-panel";
 // [OPUS-4.8] sq-n5aw — the syntax-highlighting SPARQL editor replaces the plain <textarea>.
 import { SparqlEditor } from "@/components/sparql-editor";
 // [OPUS-4.8] sq-2mke — endpoint mode: the Connect panel + the SPARQL 1.1 Protocol client.
@@ -98,6 +100,11 @@ export function Repl() {
   const [size, setSize] = React.useState<number | null>(null);
   const [engine, setEngine] = React.useState<EngineState>("cold");
   const [viewerOpen, setViewerOpen] = React.useState(false);
+  // [OPUS-4.8] sq-daru — monotonic version bumped whenever the in-tab dataset's CONTENT
+  // changes (a new dataset loaded, a merge, or an in-tab Update). The dataset panel keys
+  // its per-graph-count re-read off it, so an Update that leaves the total size unchanged
+  // but moves triples between graphs still refreshes the panel.
+  const [datasetVersion, setDatasetVersion] = React.useState(0);
   const [active, setActive] = React.useState<ActiveDataset>({
     label: DEFAULT_DATASET.label,
     description: DEFAULT_DATASET.description,
@@ -129,6 +136,8 @@ export function Repl() {
       const store = loadIntoStore(Store, text, format);
       storeRef.current = store;
       setSize(datasetSize(store));
+      // [OPUS-4.8] sq-daru — new store content: refresh the dataset panel's per-graph counts.
+      setDatasetVersion((v) => v + 1);
       return store;
     },
     [],
@@ -252,6 +261,9 @@ export function Repl() {
         const ms = performance.now() - t0;
         const sizeAfter = datasetSize(store);
         setSize(sizeAfter);
+        // [OPUS-4.8] sq-daru — an in-tab Update mutated the store (and may have moved
+        // triples between graphs even if the total is unchanged): refresh the panel.
+        setDatasetVersion((v) => v + 1);
         setState({ kind: "update", sizeBefore, sizeAfter, ms });
         return;
       }
@@ -329,6 +341,8 @@ export function Repl() {
         } else {
           storeRef.current = incoming;
           setSize(datasetSize(incoming));
+          // [OPUS-4.8] sq-daru — replaced the store directly (not via buildStore): refresh.
+          setDatasetVersion((v) => v + 1);
           setActive({
             label,
             description: `Custom ${format} dataset loaded in your tab.`,
@@ -430,6 +444,15 @@ export function Repl() {
           onSelectBuiltin={selectBuiltin}
           onLoadText={loadText}
           disabled={controlsDisabled || endpointActive}
+        />
+
+        {/* [OPUS-4.8] sq-daru — the dataset panel: the loaded dataset's graphs (default +
+            named) with per-graph triple counts, refreshed on every content change. Hidden
+            in endpoint mode (the remote server owns its own dataset). */}
+        <DatasetPanel
+          store={storeRef.current}
+          refreshKey={datasetVersion}
+          hidden={endpointActive}
         />
 
         <div className="flex flex-wrap gap-1.5">

--- a/site/src/lib/repl-dataset.ts
+++ b/site/src/lib/repl-dataset.ts
@@ -229,6 +229,88 @@ export function modeSupportsForm(mode: RunMode, form: QueryForm): boolean {
   return form !== "update";
 }
 
+// [OPUS-4.8] sq-daru — dataset panel: per-graph triple counts.
+//
+// The panel enumerates the loaded dataset's graphs with a triple count each, so a user
+// can see at a glance how the data is partitioned (default graph + every named graph).
+// It reuses queries the engine already supports rather than a new Store method:
+//
+//   • NAMED-GRAPH stats — one row per named graph with its triple count. `GROUP BY ?g`
+//     over `GRAPH ?g { ?s ?p ?o }` lists exactly the named graphs (the default graph is
+//     NOT a GRAPH and so is excluded — it is counted separately).
+//   • DEFAULT-GRAPH count — the default graph's triple count on its own.
+//
+// Both are pure strings here (no React/DOM/wasm) so they are unit-testable; the parser
+// `parseGraphStats` turns the two SPARQL-JSON documents into the typed rows the panel
+// renders, and is itself pure + framework-free.
+
+/** The named-graph stats query: one solution per named graph, `?g` = graph IRI,
+ *  `?c` = its triple count. The default graph is not a GRAPH, so it is excluded. */
+export const NAMED_GRAPH_STATS_QUERY =
+  "SELECT ?g (COUNT(*) AS ?c) WHERE { GRAPH ?g { ?s ?p ?o } } GROUP BY ?g ORDER BY ?g";
+
+/** The default-graph triple count (a single solution binding `?c`). */
+export const DEFAULT_GRAPH_COUNT_QUERY =
+  "SELECT (COUNT(*) AS ?c) WHERE { ?s ?p ?o }";
+
+/** One row of the dataset panel: a graph and its triple count. `iri` is `null` for the
+ *  default graph (it has no IRI) and the graph IRI for a named graph. */
+export interface GraphStat {
+  /** The named-graph IRI, or `null` for the default graph. */
+  iri: string | null;
+  /** True for the default graph (always present, even when empty). */
+  isDefault: boolean;
+  /** The triple count in this graph. */
+  count: number;
+}
+
+/** A structural subset of a parsed SPARQL-JSON results document — just what
+ *  {@link parseGraphStats} reads. Lets the parser stay framework-free and avoids a hard
+ *  dependency on the full `SparqlResults` shape for the (pure) unit tests. */
+export interface SparqlResultsLike {
+  results?: {
+    bindings?: Array<Record<string, { value?: string } | undefined>>;
+  };
+}
+
+/** Parses a COUNT solution's `?c` value to a non-negative integer, or `0` if absent /
+ *  unparseable (a robust default so the panel never shows `NaN`). */
+function countFromBinding(value: string | undefined): number {
+  if (value == null) return 0;
+  const n = Number.parseInt(value, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+/**
+ * Turns the two SPARQL-JSON documents — {@link DEFAULT_GRAPH_COUNT_QUERY} and
+ * {@link NAMED_GRAPH_STATS_QUERY} — into the typed {@link GraphStat} rows the dataset
+ * panel renders. The default graph is ALWAYS the first row (even with a count of 0, so
+ * the panel is honest about an empty default graph); the named graphs follow in the
+ * query's order. Malformed/absent counts default to 0 rather than throwing, so a partial
+ * result still renders. Pure + framework-free (takes already-parsed JSON), so it
+ * unit-tests directly.
+ */
+export function parseGraphStats(
+  defaultCount: SparqlResultsLike,
+  namedStats: SparqlResultsLike,
+): GraphStat[] {
+  const defaultBinding = defaultCount.results?.bindings?.[0];
+  const stats: GraphStat[] = [
+    {
+      iri: null,
+      isDefault: true,
+      count: countFromBinding(defaultBinding?.c?.value),
+    },
+  ];
+  for (const row of namedStats.results?.bindings ?? []) {
+    const iri = row.g?.value;
+    // A named-graph row must bind ?g; skip any defensive mis-shape.
+    if (iri == null) continue;
+    stats.push({ iri, isDefault: false, count: countFromBinding(row.c?.value) });
+  }
+  return stats;
+}
+
 /**
  * Serialises {@link ALL_QUADS_QUERY} solution rows to an N-Quads document: a triple
  * line (`s p o .`) when `?g` is unbound (default graph), a quad line

--- a/site/test/repl-dataset.test.mjs
+++ b/site/test/repl-dataset.test.mjs
@@ -16,6 +16,9 @@ import {
   classifyQueryForm,
   isGraphForm,
   modeSupportsForm,
+  NAMED_GRAPH_STATS_QUERY,
+  DEFAULT_GRAPH_COUNT_QUERY,
+  parseGraphStats,
 } from "../src/lib/repl-dataset.ts";
 
 test("isDatasetFormat is true exactly for the quad-bearing formats", () => {
@@ -251,4 +254,94 @@ test("modeSupportsForm: EXPLAIN / ANALYZE are UNavailable for SPARQL Update", ()
   assert.equal(modeSupportsForm("analyze", "update"), false);
   // Run still works — the Update can still be executed.
   assert.equal(modeSupportsForm("run", "update"), true);
+});
+
+// [OPUS-4.8] sq-daru — the dataset panel: named-graph list with per-graph triple counts.
+// The two queries are reused engine-supported SPARQL (no new Store API); `parseGraphStats`
+// is the pure parser that turns their SPARQL-JSON into the panel's typed rows. The
+// SPARQL-JSON fixtures below are the EXACT shape the wasm engine returns (verified live:
+// a GROUP BY ?g list of named graphs, and a standalone default-graph COUNT — each `?c` an
+// xsd:integer literal whose `value` is the integer string).
+
+test("NAMED_GRAPH_STATS_QUERY groups per named graph and excludes the default graph", () => {
+  // GROUP BY over GRAPH ?g lists exactly the named graphs; the default graph is not a
+  // GRAPH, so it is counted separately by DEFAULT_GRAPH_COUNT_QUERY.
+  assert.match(NAMED_GRAPH_STATS_QUERY, /GRAPH \?g/);
+  assert.match(NAMED_GRAPH_STATS_QUERY, /GROUP BY \?g/);
+  assert.match(NAMED_GRAPH_STATS_QUERY, /COUNT\(\*\)/);
+  // The default-graph count uses the unqualified BGP (matches only the default graph).
+  assert.match(DEFAULT_GRAPH_COUNT_QUERY, /WHERE \{ \?s \?p \?o \}/);
+  assert.doesNotMatch(DEFAULT_GRAPH_COUNT_QUERY, /GRAPH/);
+});
+
+const XSD_INT = "http://www.w3.org/2001/XMLSchema#integer";
+const count = (v) => ({ type: "literal", value: v, datatype: XSD_INT });
+const uri = (v) => ({ type: "uri", value: v });
+
+test("parseGraphStats always emits the default graph first, then the named graphs in order", () => {
+  // The exact wasm-engine result shape (verified live).
+  const defaultJson = { head: { vars: ["c"] }, results: { bindings: [{ c: count("2") }] } };
+  const namedJson = {
+    head: { vars: ["g", "c"] },
+    results: {
+      bindings: [
+        { g: uri("http://ex/g1"), c: count("2") },
+        { g: uri("http://ex/g2"), c: count("1") },
+      ],
+    },
+  };
+  const stats = parseGraphStats(defaultJson, namedJson);
+  assert.deepEqual(stats, [
+    { iri: null, isDefault: true, count: 2 },
+    { iri: "http://ex/g1", isDefault: false, count: 2 },
+    { iri: "http://ex/g2", isDefault: false, count: 1 },
+  ]);
+});
+
+test("parseGraphStats shows the default graph alone (count 0) for an empty store", () => {
+  // An empty store: the default-graph COUNT is 0 and there are no named-graph rows. The
+  // default graph is STILL listed (count 0) so the panel is honest about an empty dataset.
+  const defaultJson = { head: { vars: ["c"] }, results: { bindings: [{ c: count("0") }] } };
+  const namedJson = { head: { vars: ["g", "c"] }, results: { bindings: [] } };
+  assert.deepEqual(parseGraphStats(defaultJson, namedJson), [
+    { iri: null, isDefault: true, count: 0 },
+  ]);
+});
+
+test("parseGraphStats handles a triple-only dataset (default graph only, no named graphs)", () => {
+  // The common case: a Turtle dataset has only the default graph.
+  const defaultJson = { results: { bindings: [{ c: count("142") }] } };
+  const namedJson = { results: { bindings: [] } };
+  assert.deepEqual(parseGraphStats(defaultJson, namedJson), [
+    { iri: null, isDefault: true, count: 142 },
+  ]);
+});
+
+test("parseGraphStats defaults a missing/unparseable count to 0 rather than NaN", () => {
+  // A partial / malformed result must still render: an absent default binding -> 0, a
+  // named-graph row with a non-numeric count -> 0 (never NaN in the UI).
+  const defaultJson = { results: { bindings: [] } };
+  const namedJson = {
+    results: { bindings: [{ g: uri("http://ex/g1"), c: { type: "literal", value: "x" } }] },
+  };
+  assert.deepEqual(parseGraphStats(defaultJson, namedJson), [
+    { iri: null, isDefault: true, count: 0 },
+    { iri: "http://ex/g1", isDefault: false, count: 0 },
+  ]);
+});
+
+test("parseGraphStats skips a defensive named-graph row that does not bind ?g", () => {
+  const defaultJson = { results: { bindings: [{ c: count("1") }] } };
+  const namedJson = {
+    results: {
+      bindings: [
+        { c: count("9") }, // no ?g — skipped
+        { g: uri("http://ex/g1"), c: count("3") },
+      ],
+    },
+  };
+  assert.deepEqual(parseGraphStats(defaultJson, namedJson), [
+    { iri: null, isDefault: true, count: 1 },
+    { iri: "http://ex/g1", isDefault: false, count: 3 },
+  ]);
 });


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change for bead `sq-daru` (GUI MVP item 3, parent epic `sq-ixc3`). One of several agents @jeswr runs on this account.

## What the panel shows

A **dataset panel** in the live SPARQL REPL (the `/try` page the Tauri desktop GUI renders in its webview): a labelled list of the loaded dataset's **graphs** — the **default graph** (always shown, labelled clearly, even when empty) plus **every named graph** (its IRI, truncated with a full-text hover title) — each with a **per-graph triple count** badge. A header line summarises the partitioning (`default graph only` vs `N named graphs + default`).

It sits directly under the existing dataset-source controls and **refreshes whenever the in-tab dataset's content changes** — a new dataset loaded (picker / upload / URL), a merge, or an in-tab SPARQL **Update** (so an Update that leaves the total size unchanged but moves triples between graphs still refreshes). It is **hidden in endpoint mode** (the remote server owns its own dataset).

The GUI design (`gui/README.md`, `research/gui-design.md`) reuses the `site/` React frontend in the Tauri webview, so this is the `site/` component the GUI renders; the desktop GUI's **native** engine answers `query` identically (`gui/src-tauri/src/engine.rs`).

## How it queries the engine

No new engine/`Store` API — it reuses **SPARQL the engine already supports**, read live from the in-tab WASM store:

- **named graphs + counts** — `SELECT ?g (COUNT(*) AS ?c) WHERE { GRAPH ?g { ?s ?p ?o } } GROUP BY ?g ORDER BY ?g`
- **default-graph count** — `SELECT (COUNT(*) AS ?c) WHERE { ?s ?p ?o }`

I **verified both live against the WASM engine** on a default-graph + two-named-graph N-Quads dataset: `GROUP BY ?g` yields exactly one row per named graph (`?g` = uri, `?c` = an `xsd:integer` literal) and **excludes** the default graph, which is counted by the standalone query and **always listed first**. The pure, framework-free `parseGraphStats` helper (in `@/lib/repl-dataset`) turns the two SPARQL-JSON documents into the typed rows; the new `repl-dataset-panel.tsx` is just the React host (so the Tauri webview draws the SAME rows from the SAME results). Every number is the engine's own count — no baked-in figure.

## Files

- `site/src/lib/repl-dataset.ts` — `NAMED_GRAPH_STATS_QUERY`, `DEFAULT_GRAPH_COUNT_QUERY`, the `GraphStat` type, and the pure `parseGraphStats` parser.
- `site/src/components/repl-dataset-panel.tsx` — **new** presentational panel.
- `site/src/components/repl.tsx` — wires the panel in + a `datasetVersion` refresh counter bumped on every content change.
- `site/test/repl-dataset.test.mjs` — 6 new pure unit tests.

## Gate results (run on this Linux box)

| Gate | Command | Result |
| --- | --- | --- |
| Unit tests | `npm run test:unit` | ✅ **183/183 pass** (incl. 6 new) |
| Typecheck | `npx tsc --noEmit` | ✅ clean |
| Lint | `npm run lint` (`next lint`) | ✅ no warnings or errors |
| Static export | `npm run build` (`next build`) | ✅ compiled successfully, 46 pages exported |

**Honesty about local vs CI:** these are exactly the load-bearing TS gates of the `gui.yml` "site build + typecheck (consuming @sparq/client)" job, which I ran locally (I supplied the prebuilt git-ignored WASM bundle so the real `next build` ran). The **per-platform Tauri `cargo build`/`clippy` matrix** (macOS/Windows/Linux) needs the webview system libs and is exercised only by release/CI — I did **not** run it; this change touches no Rust. The new pure unit tests cover the parser exhaustively (default-first ordering, empty store, triple-only dataset, malformed-count → 0, missing-`?g` skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)