### PR TITLE
test(sparq-policy): wire into coverage floor+presence gates + stateless count-default tests (sq-bif.7) [OPUS-4.8]

### DIFF
--- a/bench/coverage-floor.json
+++ b/bench/coverage-floor.json
@@ -56,6 +56,10 @@
     "sparq-parse": {
       "floor": 91
     },
+    "sparq-policy": {
+      "floor": 90,
+      "note": "[OPUS-4.8] sq-bif.7: OPT-IN ODRL usage-control policy. The stateless evaluator (parse/eval/compare/hierarchy) is default-on; measured WITH --features count-enforcement (the stateful odrl:count counter-store modules count/count_file/count_backend + their #![cfg(feature)] integration tests — see scripts/coverage.sh measure() case; a default build compiles that surface out). Measured line% 92.79 (1429/1540); floor = floor(measured) - 2 margin. Conservative work-box seed; CI's --check-robust is the ratchet of record."
+    },
     "sparq-prov": {
       "floor": 94,
       "note": "[OPUS-4.8] sq-bif.1: OPT-IN W3C PROV-O lineage. CONSTRUCT/UPDATE lineage core is default-on; measured WITH --features reason (the sparq-reason proof-tree -> PROV-O bridge module + its tests/reason_prov.rs). Measured line% 96.70 (762/788); floor = floor(measured) - 2 margin. Conservative work-box seed; CI is the ratchet of record."

--- a/bench/coverage-presence.json
+++ b/bench/coverage-presence.json
@@ -61,6 +61,10 @@
       "had_integration_dir": false,
       "min_tests": 13
     },
+    "sparq-policy": {
+      "had_integration_dir": true,
+      "min_tests": 130
+    },
     "sparq-prov": {
       "had_integration_dir": true,
       "min_tests": 30

--- a/crates/sparq-policy/tests/odrl_count_stateless.rs
+++ b/crates/sparq-policy/tests/odrl_count_stateless.rs
@@ -1,0 +1,153 @@
+//! Default-feature (`count-enforcement` OFF) `odrl:count` evaluation tests.
+//! [OPUS-4.8] sq-bif.7.
+//!
+//! `odrl:count` enforcement comes in two layers (see crates/sparq-policy/src/lib.rs):
+//!   - DEFAULT (this file): the *stateless* numeric constraint it always was — the
+//!     caller supplies the actual count in the request context and `evaluate` compares
+//!     it against the constraint's `rightOperand` under `lt`/`lteq`/`eq`/`gt`/`gteq`.
+//!     NO counter store, NO state, NO `count-enforcement` feature.
+//!   - `count-enforcement` (tests/odrl_count*.rs, `#![cfg(feature = "count-enforcement")]`):
+//!     the *stateful* counter-store path (`evaluate_and_exercise`) that increments per
+//!     use and denies once the limit is reached.
+//!
+//! This file is deliberately NOT feature-gated: it is the regression guard for the bead's
+//! "no compile-out regression" requirement — proving the stateless `odrl:count` path keeps
+//! evaluating correctly in the DEFAULT build, where the entire `count`/`count_file`/
+//! `count_backend` surface is compiled out. Every assertion fails if that path regresses.
+//!
+//! It complements `odrl_eval.rs::count_numeric_operators` (which covers `lteq`) by
+//! exercising the FULL operator matrix (`lt`/`lteq`/`eq`/`gt`/`gteq`), the boundary cases,
+//! the missing-count fail-closed default, and the prohibition-side count carve-out.
+
+use sparq_policy::{evaluate, parse_policy_str, Request, Value};
+
+const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
+
+fn left(local: &str) -> String {
+    format!("{ODRL}{local}")
+}
+
+/// A `odrl:Set` permission on `odrl:use`/`urn:asset/x` with one `odrl:count`
+/// constraint under `operator` against the integer `bound`.
+fn count_policy_ttl(operator_local: &str, bound: u32) -> String {
+    format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/c> a odrl:Set ; odrl:permission [
+    odrl:action odrl:use ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:count ;
+                      odrl:operator odrl:{operator_local} ;
+                      odrl:rightOperand "{bound}"^^xsd:integer ] ] .
+"#
+    )
+}
+
+fn req_with_count(n: f64) -> Request {
+    Request::new(left("use"))
+        .on("urn:asset/x")
+        .with(left("count"), Value::Num(n))
+}
+
+/// `odrl:count lteq 5`: counts 0..=5 ALLOW, 6 DENY. (Boundary at the bound itself.)
+#[test]
+fn stateless_lteq_allows_up_to_and_including_bound() {
+    let p = parse_policy_str(&count_policy_ttl("lteq", 5), "turtle").unwrap();
+    assert!(evaluate(&p, &req_with_count(0.0)).allow, "0 lteq 5 must ALLOW");
+    assert!(evaluate(&p, &req_with_count(5.0)).allow, "5 lteq 5 must ALLOW");
+    let d = evaluate(&p, &req_with_count(6.0));
+    assert!(!d.allow, "6 lteq 5 must DENY");
+    assert!(
+        d.unmet_constraints.iter().any(|m| m.contains("count")),
+        "DENY must cite the count constraint: {d:?}"
+    );
+}
+
+/// `odrl:count lt 5`: 4 ALLOW, 5 DENY (strict — the bound itself is excluded).
+#[test]
+fn stateless_lt_excludes_the_bound() {
+    let p = parse_policy_str(&count_policy_ttl("lt", 5), "turtle").unwrap();
+    assert!(evaluate(&p, &req_with_count(4.0)).allow, "4 lt 5 must ALLOW");
+    assert!(!evaluate(&p, &req_with_count(5.0)).allow, "5 lt 5 must DENY");
+    assert!(!evaluate(&p, &req_with_count(6.0)).allow, "6 lt 5 must DENY");
+}
+
+/// `odrl:count eq 3`: only exactly 3 ALLOWs; 2 and 4 DENY.
+#[test]
+fn stateless_eq_matches_only_the_bound() {
+    let p = parse_policy_str(&count_policy_ttl("eq", 3), "turtle").unwrap();
+    assert!(!evaluate(&p, &req_with_count(2.0)).allow, "2 eq 3 must DENY");
+    assert!(evaluate(&p, &req_with_count(3.0)).allow, "3 eq 3 must ALLOW");
+    assert!(!evaluate(&p, &req_with_count(4.0)).allow, "4 eq 3 must DENY");
+}
+
+/// `odrl:count gt 2`: 2 DENY (strict), 3 ALLOW.
+#[test]
+fn stateless_gt_excludes_the_bound() {
+    let p = parse_policy_str(&count_policy_ttl("gt", 2), "turtle").unwrap();
+    assert!(!evaluate(&p, &req_with_count(2.0)).allow, "2 gt 2 must DENY");
+    assert!(evaluate(&p, &req_with_count(3.0)).allow, "3 gt 2 must ALLOW");
+}
+
+/// `odrl:count gteq 2`: 1 DENY, 2 ALLOW (bound included), 3 ALLOW.
+#[test]
+fn stateless_gteq_includes_the_bound() {
+    let p = parse_policy_str(&count_policy_ttl("gteq", 2), "turtle").unwrap();
+    assert!(!evaluate(&p, &req_with_count(1.0)).allow, "1 gteq 2 must DENY");
+    assert!(evaluate(&p, &req_with_count(2.0)).allow, "2 gteq 2 must ALLOW");
+    assert!(evaluate(&p, &req_with_count(3.0)).allow, "3 gteq 2 must ALLOW");
+}
+
+/// FAIL-CLOSED: a `odrl:count` constraint with NO count value in the request context is
+/// unsatisfied (we have no evidence the limit is met), so the permission does NOT grant.
+/// This is the core stateless-default property: without the counter store, the count is
+/// the caller's responsibility, and a missing count cannot widen access.
+#[test]
+fn stateless_missing_count_fails_closed() {
+    let p = parse_policy_str(&count_policy_ttl("lteq", 5), "turtle").unwrap();
+    // Same action/target, but NO `odrl:count` value supplied.
+    let no_count = Request::new(left("use")).on("urn:asset/x");
+    let d = evaluate(&p, &no_count);
+    assert!(
+        !d.allow,
+        "a count constraint with no supplied count must fail closed: {d:?}"
+    );
+    assert!(
+        d.unmet_constraints.iter().any(|m| m.contains("count")),
+        "the unmet count constraint must be reported: {d:?}"
+    );
+}
+
+/// A `odrl:count` carve-out on the PROHIBITION side: the prohibition forbids `use`
+/// once the count exceeds the bound. Under deny-overrides, a request whose count
+/// triggers the prohibition is DENIED even though the permission would otherwise grant;
+/// a request below it is ALLOWED. Proves stateless count drives both rule kinds.
+#[test]
+fn stateless_count_on_prohibition_denies_over_bound() {
+    let ttl = format!(
+        r#"
+@prefix odrl: <{ODRL}> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/p> a odrl:Set ;
+    odrl:permission [ odrl:action odrl:use ; odrl:target <urn:asset/x> ] ;
+    odrl:prohibition [ odrl:action odrl:use ; odrl:target <urn:asset/x> ;
+        odrl:constraint [ odrl:leftOperand odrl:count ;
+                          odrl:operator odrl:gt ;
+                          odrl:rightOperand "10"^^xsd:integer ] ] .
+"#
+    );
+    let p = parse_policy_str(&ttl, "turtle").unwrap();
+    assert_eq!(p.permissions.len(), 1, "expected one permission: {p:?}");
+    assert_eq!(p.prohibitions.len(), 1, "expected one prohibition: {p:?}");
+    // count 5 (not > 10): prohibition does NOT fire → permission stands → ALLOW.
+    assert!(
+        evaluate(&p, &req_with_count(5.0)).allow,
+        "count 5 must not trigger the >10 prohibition"
+    );
+    // count 11 (> 10): prohibition fires → deny-overrides → DENY.
+    let d = evaluate(&p, &req_with_count(11.0));
+    assert!(
+        !d.allow,
+        "count 11 (>10) must trigger the prohibition and DENY: {d:?}"
+    );
+}

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -103,6 +103,13 @@ PER_COMMIT_CRATES=(
   # misleadingly-low artifact (measured 55-79% native; same class as sparq-cli's
   # subprocess artifact) — they are floor-0 + presence-gated in the JSONs instead.
   sparq-fedclient sparq-fedplan sparq-prov
+  # [OPUS-4.8] sq-bif.7: the OPT-IN ODRL usage-control policy crate, untracked by BOTH
+  # gates. The STATELESS evaluator (parse/eval/compare/hierarchy) is default-on, but the
+  # stateful `odrl:count` counter stores (the `count`/`count_file`/`count_backend` modules
+  # + their tests) are `#![cfg(feature = "count-enforcement")]`. So it MUST be measured
+  # WITH --features count-enforcement (the `case` in measure() below names it) — a default
+  # build compiles that whole surface out and reports a non-representative number.
+  sparq-policy
 )
 # Crates whose HEAVY tests are only run in the nightly tier.
 NIGHTLY_ONLY_NOTE="sparq-vectors heavy 50k recall/diskann tests run only in nightly tier"
@@ -329,6 +336,13 @@ measure() {
       # (its integration test, tests/reason_prov.rs, is gated on it). The CONSTRUCT/
       # update lineage core is default-on.
       cargo_args+=(--features reason); features+=("reason") ;;
+    # [OPUS-4.8] sq-bif.7: `count-enforcement` turns on the stateful `odrl:count`
+    # counter-store surface (the `count`/`count_file`/`count_backend` modules + their
+    # `#![cfg(feature = "count-enforcement")]` integration tests). The stateless ODRL
+    # evaluator is default-on; without this feature that whole surface is compiled out
+    # and the number is non-representative. (Mirrors the sparq-prov `reason` quirk above.)
+    sparq-policy)
+      cargo_args+=(--features count-enforcement); features+=("count-enforcement") ;;
   esac
 
   local start end rc=0 json="$WORK/$crate.json"


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-bif.7** (`sparq-policy`: wire into the per-crate coverage gate + verify both feature states).

## What

`sparq-policy` (the ODRL usage-control layer: parse / eval / compare / hierarchy + the opt-in `count-enforcement` counter stores) was **untracked by BOTH coverage gates** — absent from `bench/coverage-floor.json`, `bench/coverage-presence.json`, and the `PER_COMMIT_CRATES` list in `scripts/coverage.sh`. AGENTS.md's "anything merged → coverage ratchet + presence gate" rule was silently un-met for it. This wires it in the same way the sq-bif.1 fedclient/fedplan/prov registration did.

- **`scripts/coverage.sh`** — add `sparq-policy` to `PER_COMMIT_CRATES` + a `measure()` `case` arm measuring **with `--features count-enforcement`**. The opt-in surface (`count`/`count_file`/`count_backend` modules + their `#![cfg(feature = "count-enforcement")]` tests) is feature-gated, so a default-feature run compiles it out and reports a non-representative number (mirrors the `sparq-prov` `reason` quirk).
- **`bench/coverage-floor.json`** — seed `floor = 90` = `floor(measured 92.79%) − 2` margin (measured with the feature on). The floor only ever rises; CI's `--check-robust` is the ratchet of record. (Measured on a non-canonical work box — non-canonical number.)
- **`bench/coverage-presence.json`** — seed `min_tests = 130` (conservative floor; 145 source `#[test]`s measured) + `had_integration_dir: true`.
- **`crates/sparq-policy/tests/odrl_count_stateless.rs`** (NEW, **not** feature-gated → runs in BOTH states) — the regression guard for the bead's "no compile-out regression" requirement: proves the **default** (`count-enforcement` OFF) build still evaluates `odrl:count` statelessly across the full operator matrix (`lt`/`lteq`/`eq`/`gt`/`gteq`), the boundary cases, the missing-count fail-closed default, and a prohibition-side count carve-out. The stateful counter-store path stays gated on `count-enforcement`.

This is a test-coverage bead: **no production `src/` change**.

## Feature states verified (commands)

Default (feature OFF):
- `cargo build -p sparq-policy`
- `cargo clippy -p sparq-policy --all-targets -- -D warnings`
- `cargo test -p sparq-policy`

count-enforcement ON:
- `cargo clippy -p sparq-policy --all-targets --features count-enforcement -- -D warnings`
- `cargo test -p sparq-policy --features count-enforcement`

Both GREEN. Gate self-checks also pass: `coverage-gate.py --check`, `--check-monotonic`, and `coverage-presence.py --check` (sparq-policy: 145 tests ≥ floor 130, +integ; 92.79% ≥ floor 90). Privacy-claims gate: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
